### PR TITLE
feat(messaging): agent-addressed direct messages (V1)

### DIFF
--- a/packages/agent/src/agent-message-manifest.ts
+++ b/packages/agent/src/agent-message-manifest.ts
@@ -1,0 +1,162 @@
+import { ethers } from 'ethers';
+
+/**
+ * Agent-addressed direct messaging (V1).
+ *
+ * The existing chat transport is node-addressed: a message is sent to a
+ * libp2p `peerId` and encrypted to that node's key. This module layers an
+ * *agent identity* on top without touching the transport or the encryption:
+ * the sender stamps a small signed manifest — `{ from, to, ts, sig }` — into
+ * the (already encrypted) chat payload, where `from`/`to` are agent EVM
+ * addresses (`0x…`). The receiver verifies the signature to learn *which
+ * agent* sent the message, independently of which node relayed it.
+ *
+ * Confidentiality is unchanged — the manifest rides inside the existing
+ * XChaCha20-Poly1305 payload. What this adds is authenticated agent-level
+ * `from`/`to`. The `sig` is an EIP-191 signature produced by the sender's
+ * agent key via `ChainAdapter.signMessageAs(from, digest)` (the same
+ * primitive the publisher uses to sign author seals), so a hosting/relaying
+ * node cannot forge a `from` it does not control.
+ *
+ * ## Freshness binding
+ *
+ * The signature covers `messageId` and `ts` in addition to `from`/`to`/`text`.
+ * Without this the manifest would be a context-free bearer token: "0xA said
+ * 'hi' to 0xB" could be re-presented by anyone who observed it. Today the
+ * node-keyed ciphertext incidentally blocks cross-node replay, but V2
+ * (agent-keyed end-to-end + store-and-forward mailboxes) removes that
+ * accident — so we anchor the signature to the persistent `messageId` dedup
+ * key and a timestamp skew window *now*, while the wire format is still ours
+ * to define. `recipientPeerId` is deliberately NOT bound: it is a transport
+ * detail that will not survive V2 forwarding, and binding it would re-couple
+ * the agent-level auth token to the node it is meant to be independent of.
+ */
+
+/** Domain-separation tag + wire version for the signed manifest digest. */
+export const AGENT_MESSAGE_MANIFEST_VERSION = 'dkg-agent-msg:v1';
+
+/**
+ * Max clock skew tolerated between the signed `ts` and the receiver's clock.
+ * Combined with the persistent per-node `messageId` dedup, this bounds replay:
+ * a re-presented manifest is either a `messageId` the receiver has already
+ * stored (dropped) or one whose `ts` has aged out of the window (rejected).
+ * 5 minutes is generous for NTP-synced nodes without making the replay window
+ * meaningfully large.
+ */
+export const AGENT_MESSAGE_MAX_SKEW_MS = 5 * 60_000;
+
+export interface AgentMessageManifest {
+  /** Checksummed sender agent EVM address. */
+  from: string;
+  /** Checksummed recipient agent EVM address. */
+  to: string;
+  /** Signed millisecond epoch — freshness bound. */
+  ts: number;
+  /** 65-byte serialized EIP-191 signature over {@link agentManifestDigestBytes}. */
+  sig: string;
+}
+
+/**
+ * The 32-byte digest the sender signs and the receiver recovers. Every field
+ * that must be authenticated is bound here: the domain tag, both agent
+ * addresses (checksum-normalized so both sides hash identical bytes), the
+ * message id, the timestamp, and a hash of the message text. Returns the raw
+ * 32 bytes — callers MUST pass this `Uint8Array` to BOTH `signMessageAs` and
+ * `ethers.verifyMessage`; hexlifying first would make ethers treat it as a
+ * UTF-8 string and every verification would (fail-closed) never match.
+ */
+export function agentManifestDigestBytes(input: {
+  from: string;
+  to: string;
+  messageId: string;
+  ts: number;
+  text: string;
+}): Uint8Array {
+  const canonical = [
+    AGENT_MESSAGE_MANIFEST_VERSION,
+    ethers.getAddress(input.from),
+    ethers.getAddress(input.to),
+    input.messageId,
+    String(input.ts),
+    ethers.id(input.text), // keccak256(utf8(text)) — binds content, bounds length
+  ].join('|');
+  return ethers.getBytes(ethers.id(canonical));
+}
+
+/**
+ * Reassemble the chain adapter's compact `{ r, vs }` (EIP-2098) return shape
+ * into a 65-byte serialized signature that `ethers.verifyMessage` accepts.
+ */
+export function serializeCompactSignature(sig: { r: Uint8Array; vs: Uint8Array }): string {
+  return ethers.Signature.from({
+    r: ethers.hexlify(sig.r),
+    yParityAndS: ethers.hexlify(sig.vs),
+  }).serialized;
+}
+
+export interface VerifiedAgentManifest {
+  from: string;
+  to: string;
+  ts: number;
+}
+
+export type AgentManifestVerification =
+  | { ok: true; manifest: VerifiedAgentManifest }
+  | { ok: false; reason: string };
+
+/**
+ * Verify a manifest carried on an inbound chat. Fail-closed: any missing
+ * field, stale/absent timestamp, malformed signature, or signer≠`from`
+ * mismatch returns `{ ok: false }` with a reason (the caller rejects the
+ * chat). On success the returned `from`/`to` are checksummed and safe to
+ * treat as the authenticated sender / claimed recipient agent identities.
+ *
+ * `messageId` is sourced from the (already-parsed) payload rather than the
+ * manifest itself so that the value the receiver dedups on is the value that
+ * was signed — an attacker cannot change the payload's `messageId` without
+ * invalidating the signature.
+ */
+export function verifyAgentMessageManifest(input: {
+  from?: unknown;
+  to?: unknown;
+  sig?: unknown;
+  ts?: unknown;
+  messageId?: unknown;
+  text: string;
+  nowMs: number;
+  maxSkewMs?: number;
+}): AgentManifestVerification {
+  const { from, to, sig, ts, messageId, text } = input;
+  if (
+    typeof from !== 'string' ||
+    typeof to !== 'string' ||
+    typeof sig !== 'string' ||
+    typeof ts !== 'number' ||
+    typeof messageId !== 'string'
+  ) {
+    return { ok: false, reason: 'incomplete agent manifest' };
+  }
+  const maxSkew = input.maxSkewMs ?? AGENT_MESSAGE_MAX_SKEW_MS;
+  if (!Number.isFinite(ts) || Math.abs(input.nowMs - ts) > maxSkew) {
+    return { ok: false, reason: 'timestamp outside skew window' };
+  }
+  let recovered: string;
+  try {
+    const digest = agentManifestDigestBytes({ from, to, messageId, ts, text });
+    recovered = ethers.verifyMessage(digest, sig);
+  } catch {
+    return { ok: false, reason: 'malformed signature' };
+  }
+  let normalizedFrom: string;
+  let normalizedTo: string;
+  try {
+    normalizedFrom = ethers.getAddress(from);
+    normalizedTo = ethers.getAddress(to);
+  } catch {
+    return { ok: false, reason: 'malformed agent address' };
+  }
+  if (recovered.toLowerCase() !== normalizedFrom.toLowerCase()) {
+    return { ok: false, reason: 'signature does not match sender' };
+  }
+  return { ok: true, manifest: { from: normalizedFrom, to: normalizedTo, ts } };
+}

--- a/packages/agent/src/agent-message-manifest.ts
+++ b/packages/agent/src/agent-message-manifest.ts
@@ -36,14 +36,28 @@ import { ethers } from 'ethers';
 export const AGENT_MESSAGE_MANIFEST_VERSION = 'dkg-agent-msg:v1';
 
 /**
- * Max clock skew tolerated between the signed `ts` and the receiver's clock.
- * Combined with the persistent per-node `messageId` dedup, this bounds replay:
- * a re-presented manifest is either a `messageId` the receiver has already
- * stored (dropped) or one whose `ts` has aged out of the window (rejected).
- * 5 minutes is generous for NTP-synced nodes without making the replay window
- * meaningfully large.
+ * Age bound on the signed `ts`, deliberately set to **24h** so it composes
+ * exactly with the two existing substrate windows:
+ *
+ *   * the durable outbox drops undelivered entries at `maxAgeMs` (24h), so a
+ *     legitimately retried message is ALWAYS delivered less than 24h after it
+ *     was signed; and
+ *   * `message_idempotency` retains dedup rows for 24h
+ *     (`DashboardDB` prune, `Date.now() - 24h`).
+ *
+ * The persistent `messageId` dedup — not this timestamp — is the primary
+ * anti-replay guard. Within 24h a re-presented manifest is dropped as a
+ * duplicate `messageId`; beyond 24h the dedup row has been pruned, and that is
+ * exactly where this bound takes over and rejects it. No gap, and no false
+ * rejection of a legitimate delayed retry.
+ *
+ * Do NOT tighten this to "a few minutes": the outbox backoff ladder runs
+ * 5s → 15s → 30s → 60s → 5m → 30m → 2h, so a recipient that was briefly
+ * offline routinely receives a message whose `ts` is hours old. A short window
+ * would make the durable outbox faithfully redeliver messages that can never
+ * verify — defeating at-least-once delivery.
  */
-export const AGENT_MESSAGE_MAX_SKEW_MS = 5 * 60_000;
+export const AGENT_MESSAGE_MAX_SKEW_MS = 24 * 60 * 60_000;
 
 export interface AgentMessageManifest {
   /** Checksummed sender agent EVM address. */

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -123,6 +123,11 @@ import {
   type SharedMemoryPublicSnapshotStorageConfig, type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
+import {
+  agentManifestDigestBytes,
+  serializeCompactSignature,
+  type AgentMessageManifest,
+} from './agent-message-manifest.js';
 import { join } from 'node:path';
 import {
   DKGQueryEngine, QueryHandler,
@@ -1746,13 +1751,56 @@ export class AgentRegistryMethods extends DKGAgentBase {
   async sendChat(this: DKGAgent,
     recipientPeerId: string,
     text: string,
-    options: { contextGraphId?: string; messageId?: string } = {},
+    options: {
+      contextGraphId?: string;
+      messageId?: string;
+      // Agent-addressed messaging (V1): the recipient agent's `0x…` identity.
+      // When set, the outgoing chat carries a signed manifest binding THIS
+      // agent's identity as `from` and this address as `to`, so the receiver
+      // can authenticate the sending agent independently of the relaying node.
+      // Requires the agent to hold a signing key for its own identity address;
+      // if it cannot sign, the send fails rather than silently downgrading to
+      // an unauthenticated node-only message the caller did not ask for.
+      recipientAgentAddress?: string;
+    } = {},
   ): Promise<ChatSendResult> {
     if (!this.messageHandler) throw new Error('Agent not started');
     const messageId = options.messageId ?? crypto.randomUUID();
+
+    let agentManifest: AgentMessageManifest | undefined;
+    if (options.recipientAgentAddress) {
+      const from = this.defaultAgentAddress;
+      if (!from) {
+        throw new Error(
+          'Cannot send agent-addressed message: this node has no agent identity ' +
+            'address (defaultAgentAddress).',
+        );
+      }
+      const signAs = this.chain.signMessageAs?.bind(this.chain);
+      if (!signAs) {
+        throw new Error(
+          'Cannot send agent-addressed message: chain adapter does not support ' +
+            'signMessageAs (no agent signing key available).',
+        );
+      }
+      // `ethers.getAddress` validates + checksum-normalizes both ends (throws
+      // on a malformed recipient address — a clean 4xx-able error for callers).
+      const fromAddr = ethers.getAddress(from);
+      const toAddr = ethers.getAddress(options.recipientAgentAddress);
+      const ts = Date.now();
+      const digest = agentManifestDigestBytes({ from: fromAddr, to: toAddr, messageId, ts, text });
+      // Sign as the agent's OWN identity address (not the node operational
+      // key) — mirrors the publisher author-seal path (dkg-publisher.ts). Throws
+      // if `fromAddr` is absent from the adapter's signer pool, which correctly
+      // fails the send instead of shipping an unauthenticated message.
+      const sig = await signAs(fromAddr, digest);
+      agentManifest = { from: fromAddr, to: toAddr, ts, sig: serializeCompactSignature(sig) };
+    }
+
     const result = await this.messageHandler.sendChat(recipientPeerId, text, {
-      ...options,
+      contextGraphId: options.contextGraphId,
       messageId,
+      agentManifest,
     });
 
     if (result.delivered) {

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1776,25 +1776,41 @@ export class AgentRegistryMethods extends DKGAgentBase {
             'address (defaultAgentAddress).',
         );
       }
-      const signAs = this.chain.signMessageAs?.bind(this.chain);
-      if (!signAs) {
-        throw new Error(
-          'Cannot send agent-addressed message: chain adapter does not support ' +
-            'signMessageAs (no agent signing key available).',
-        );
-      }
       // `ethers.getAddress` validates + checksum-normalizes both ends (throws
       // on a malformed recipient address — a clean 4xx-able error for callers).
       const fromAddr = ethers.getAddress(from);
       const toAddr = ethers.getAddress(options.recipientAgentAddress);
       const ts = Date.now();
       const digest = agentManifestDigestBytes({ from: fromAddr, to: toAddr, messageId, ts, text });
-      // Sign as the agent's OWN identity address (not the node operational
-      // key) — mirrors the publisher author-seal path (dkg-publisher.ts). Throws
-      // if `fromAddr` is absent from the adapter's signer pool, which correctly
-      // fails the send instead of shipping an unauthenticated message.
-      const sig = await signAs(fromAddr, digest);
-      agentManifest = { from: fromAddr, to: toAddr, ts, sig: serializeCompactSignature(sig) };
+
+      // Sign the digest AS the sender's agent identity — never the node's
+      // operational key. Custodial agents (the common case: the daemon
+      // generated and persisted their keypair at registration) hold a random
+      // keystore wallet that is NOT in the EVM adapter's signer pool, so
+      // `signMessageAs` would throw for them and hard-fail every send. Sign
+      // with the keystore key directly, mirroring the SWM-host / gossip
+      // author-signing paths. Self-sovereign or pool-backed identities fall
+      // through to the adapter. Both `ethers.Wallet.signMessage` and
+      // `ChainAdapter.signMessageAs` apply the EIP-191 framing that
+      // `verifyAgentMessageManifest` recovers.
+      let sig: string;
+      const custodialKey = this.getCustodialAgentPrivateKey(
+        this.resolveLocalAgentAddress(fromAddr),
+      );
+      if (custodialKey) {
+        sig = await new ethers.Wallet(custodialKey).signMessage(digest);
+      } else {
+        const signAs = this.chain.signMessageAs?.bind(this.chain);
+        if (!signAs) {
+          throw new Error(
+            `Cannot send agent-addressed message: no signing key for agent ${fromAddr} ` +
+              '(not a local custodial agent, and the chain adapter does not ' +
+              'support signMessageAs).',
+          );
+        }
+        sig = serializeCompactSignature(await signAs(fromAddr, digest));
+      }
+      agentManifest = { from: fromAddr, to: toAddr, ts, sig };
     }
 
     const result = await this.messageHandler.sendChat(recipientPeerId, text, {

--- a/packages/agent/src/messaging.ts
+++ b/packages/agent/src/messaging.ts
@@ -11,6 +11,10 @@ import {
 } from '@origintrail-official/dkg-core';
 import type { Messenger } from './p2p/messenger.js';
 import { encrypt, decrypt, x25519SharedSecret, ed25519ToX25519Public } from './encryption.js';
+import {
+  verifyAgentMessageManifest,
+  type AgentMessageManifest,
+} from './agent-message-manifest.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 
@@ -71,6 +75,15 @@ export type ChatHandler = (
   // layer treats it as "no dedup possible" and inserts the row
   // unconditionally — i.e. legacy on-the-wire behaviour is preserved.
   messageId?: string,
+  // Agent-addressed messaging (V1). Set ONLY when the inbound chat carried
+  // a signed agent manifest that `handleIncoming` cryptographically verified
+  // (see agent-message-manifest.ts). `senderAgentAddress` is the authenticated
+  // `0x…` identity of the sending agent (independent of which node relayed it);
+  // `recipientAgentAddress` is the agent this message was addressed to. Both
+  // are undefined for legacy node-addressed chats, so existing handlers that
+  // don't take these args keep working unchanged.
+  senderAgentAddress?: string,
+  recipientAgentAddress?: string,
 ) => void | Promise<void>;
 
 /**
@@ -228,7 +241,15 @@ export class MessageHandler {
   async sendChat(
     recipientPeerId: string,
     text: string,
-    options: { contextGraphId?: string; messageId?: string } = {},
+    options: {
+      contextGraphId?: string;
+      messageId?: string;
+      // Agent-addressed messaging (V1). When present, the signed manifest is
+      // stamped into the (already encrypted) chat payload so the receiver can
+      // authenticate which agent sent the message. Built + signed one layer up
+      // in `DKGAgent.sendChat`, which owns the agent's signing key.
+      agentManifest?: AgentMessageManifest;
+    } = {},
   ): Promise<{
     delivered: boolean;
     error?: string;
@@ -253,6 +274,17 @@ export class MessageHandler {
         text,
         ...(options.contextGraphId ? { contextGraphId: options.contextGraphId } : {}),
         ...(options.messageId ? { messageId: options.messageId } : {}),
+        // Agent manifest fields ride inside the encrypted payload — the
+        // signature authenticates `from`/`to` at the agent (0x) level while
+        // the transport stays node-addressed. Absent ⇒ legacy node-only chat.
+        ...(options.agentManifest
+          ? {
+              from: options.agentManifest.from,
+              to: options.agentManifest.to,
+              ts: options.agentManifest.ts,
+              sig: options.agentManifest.sig,
+            }
+          : {}),
       }));
 
       const nonce = buildNonce(conversationId, 1);
@@ -542,6 +574,33 @@ export class MessageHandler {
       const senderMessageId =
         typeof parsed.messageId === 'string' ? parsed.messageId : undefined;
 
+      // Agent-addressed messaging (V1): if the payload carries any agent
+      // manifest field, it MUST verify — fail closed. Verifying binds the
+      // sender's `0x` identity to this exact message (id + ts + text), so a
+      // relaying/hosting node cannot forge `from` or replay a stale token.
+      // No manifest ⇒ legacy node-addressed chat, both stay undefined.
+      let senderAgentAddress: string | undefined;
+      let recipientAgentAddress: string | undefined;
+      if (parsed.from !== undefined || parsed.to !== undefined || parsed.sig !== undefined) {
+        const verified = verifyAgentMessageManifest({
+          from: parsed.from,
+          to: parsed.to,
+          sig: parsed.sig,
+          ts: parsed.ts,
+          messageId: senderMessageId,
+          text,
+          nowMs: Date.now(),
+        });
+        if (!verified.ok) {
+          return this.encryptAndSign(conv.sharedSecret, convId, seq + 1, {
+            success: false,
+            error: `Invalid agent manifest: ${verified.reason}`,
+          });
+        }
+        senderAgentAddress = verified.manifest.from;
+        recipientAgentAddress = verified.manifest.to;
+      }
+
       // Authorisation check (layered on top of the existing Ed25519
       // signature check above). When unset, all authenticated senders are
       // accepted — this preserves the legacy behaviour for nodes that
@@ -596,6 +655,8 @@ export class MessageHandler {
             senderContextGraphId,
             verifiedContextGraphId,
             senderMessageId,
+            senderAgentAddress,
+            recipientAgentAddress,
           );
         } catch (err) {
           console.error(`[Messaging] chat handler error:`, err instanceof Error ? err.message : err);

--- a/packages/agent/test/agent-message-manifest.test.ts
+++ b/packages/agent/test/agent-message-manifest.test.ts
@@ -1,0 +1,162 @@
+// agent-message-manifest.test.ts
+//
+// Unit tests for the V1 agent-addressed messaging manifest
+// (packages/agent/src/agent-message-manifest.ts).
+//
+// The highest-risk surface is `serializeCompactSignature`: the chain
+// adapter returns a compact EIP-2098 `{ r, vs }` pair, and we reassemble
+// it into a 65-byte signature for `ethers.verifyMessage`. A byte-order or
+// yParity bug there would fail-closed (never authenticate) rather than
+// crash — so every round-trip test below deliberately produces the SAME
+// `{ r: Uint8Array, vs: Uint8Array }` shape the adapter emits and runs it
+// through the real serialize→verify path, not `wallet.signMessage` +
+// `ethers.verifyMessage` directly (which would skip the reserialization).
+
+import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  agentManifestDigestBytes,
+  serializeCompactSignature,
+  verifyAgentMessageManifest,
+  AGENT_MESSAGE_MAX_SKEW_MS,
+} from '../src/agent-message-manifest.js';
+
+const SENDER = new ethers.Wallet(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+);
+const OTHER = new ethers.Wallet(
+  '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba',
+);
+const RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+
+/**
+ * Sign a manifest the way `EvmAdapter.signMessageAs` does: EIP-191 over the
+ * 32-byte digest, decomposed into the compact `{ r, vs }` return shape, then
+ * reassembled via the code under test.
+ */
+async function signManifest(
+  wallet: ethers.Wallet,
+  input: { from: string; to: string; messageId: string; ts: number; text: string },
+): Promise<string> {
+  const digest = agentManifestDigestBytes(input);
+  const flat = await wallet.signMessage(digest);
+  const s = ethers.Signature.from(flat);
+  const compact = { r: ethers.getBytes(s.r), vs: ethers.getBytes(s.yParityAndS) };
+  return serializeCompactSignature(compact);
+}
+
+describe('agent-message-manifest', () => {
+  const base = {
+    from: SENDER.address,
+    to: RECIPIENT,
+    messageId: '11111111-1111-4111-8111-111111111111',
+    ts: 1_700_000_000_000,
+    text: 'hello 0x123',
+  };
+
+  it('round-trips a valid manifest through the compact→serialized path', async () => {
+    const sig = await signManifest(SENDER, base);
+    const result = verifyAgentMessageManifest({
+      from: base.from,
+      to: base.to,
+      sig,
+      ts: base.ts,
+      messageId: base.messageId,
+      text: base.text,
+      nowMs: base.ts + 1_000,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // checksummed + authenticated identities
+      expect(result.manifest.from).toBe(ethers.getAddress(SENDER.address));
+      expect(result.manifest.to).toBe(ethers.getAddress(RECIPIENT));
+      expect(result.manifest.ts).toBe(base.ts);
+    }
+  });
+
+  it('rejects a tampered message text (content is bound)', async () => {
+    const sig = await signManifest(SENDER, base);
+    const result = verifyAgentMessageManifest({
+      from: base.from,
+      to: base.to,
+      sig,
+      ts: base.ts,
+      messageId: base.messageId,
+      text: 'hello 0xEVIL', // changed after signing
+      nowMs: base.ts,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a swapped messageId (dedup key is bound)', async () => {
+    const sig = await signManifest(SENDER, base);
+    const result = verifyAgentMessageManifest({
+      from: base.from,
+      to: base.to,
+      sig,
+      ts: base.ts,
+      messageId: '22222222-2222-4222-8222-222222222222', // not the signed id
+      text: base.text,
+      nowMs: base.ts,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a spoofed `from` — signer must equal claimed sender', async () => {
+    // OTHER signs, but the manifest claims it is from SENDER.
+    const sig = await signManifest(OTHER, base);
+    const result = verifyAgentMessageManifest({
+      from: base.from, // SENDER — a lie
+      to: base.to,
+      sig,
+      ts: base.ts,
+      messageId: base.messageId,
+      text: base.text,
+      nowMs: base.ts,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain('does not match sender');
+  });
+
+  it('rejects a stale timestamp outside the skew window', async () => {
+    const sig = await signManifest(SENDER, base);
+    const result = verifyAgentMessageManifest({
+      from: base.from,
+      to: base.to,
+      sig,
+      ts: base.ts,
+      messageId: base.messageId,
+      text: base.text,
+      nowMs: base.ts + AGENT_MESSAGE_MAX_SKEW_MS + 1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain('skew');
+  });
+
+  it('rejects a malformed / truncated signature', () => {
+    const result = verifyAgentMessageManifest({
+      from: base.from,
+      to: base.to,
+      sig: '0xdeadbeef',
+      ts: base.ts,
+      messageId: base.messageId,
+      text: base.text,
+      nowMs: base.ts,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects an incomplete manifest (missing fields)', () => {
+    const result = verifyAgentMessageManifest({
+      from: base.from,
+      to: undefined,
+      sig: undefined,
+      ts: base.ts,
+      messageId: base.messageId,
+      text: base.text,
+      nowMs: base.ts,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain('incomplete');
+  });
+});

--- a/packages/agent/test/agent-message-manifest.test.ts
+++ b/packages/agent/test/agent-message-manifest.test.ts
@@ -118,6 +118,32 @@ describe('agent-message-manifest', () => {
     if (!result.ok) expect(result.reason).toContain('does not match sender');
   });
 
+  it('accepts a signature from the custodial keystore path (direct Wallet.signMessage)', async () => {
+    // Custodial agents sign with their own keystore wallet, which returns an
+    // already-serialized 65-byte signature — no compact {r,vs} reassembly.
+    // This is the DEFAULT production path (see DKGAgent.sendChat), so it must
+    // verify identically to the adapter's compact path exercised above.
+    const digest = agentManifestDigestBytes(base);
+    const sig = await SENDER.signMessage(digest);
+    const result = verifyAgentMessageManifest({ ...base, sig, nowMs: base.ts });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.manifest.from).toBe(ethers.getAddress(SENDER.address));
+  });
+
+  it('accepts a delayed outbox retry whose ts is hours old', async () => {
+    // The durable outbox retries with the ORIGINAL signed `ts` on a ladder that
+    // reaches 2h and keeps entries for 24h. Rejecting these would make the
+    // outbox faithfully redeliver messages that can never verify — defeating
+    // at-least-once delivery. Guards the regression a short window would cause.
+    const sig = await signManifest(SENDER, base);
+    const result = verifyAgentMessageManifest({
+      ...base,
+      sig,
+      nowMs: base.ts + 6 * 60 * 60_000, // 6h later, still inside the bound
+    });
+    expect(result.ok).toBe(true);
+  });
+
   it('rejects a stale timestamp outside the skew window', async () => {
     const sig = await signManifest(SENDER, base);
     const result = verifyAgentMessageManifest({

--- a/packages/agent/test/messaging-chat-acl.test.ts
+++ b/packages/agent/test/messaging-chat-acl.test.ts
@@ -31,6 +31,11 @@ import {
 } from '@origintrail-official/dkg-core';
 import { MessageHandler, ed25519ToX25519Private, type ChatHandler, type ChatAclCheck } from '../src/index.js';
 import { Messenger } from '../src/p2p/messenger.js';
+import { ethers } from 'ethers';
+import {
+  agentManifestDigestBytes,
+  serializeCompactSignature,
+} from '../src/agent-message-manifest.js';
 
 // Hand-rolled recorder: a plain function that records every call's
 // arguments and delegates to `impl`. Replaces the vitest spy seams used
@@ -394,5 +399,97 @@ describe('MessageHandler — skill_request ACL (GH #462)', () => {
     const res = await a.sendSkillRequest(PEER_B, { skillUri: SKILL, inputData: new Uint8Array([4]) });
     expect(res.success).toBe(true);
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Agent-addressed messaging (V1): the signed manifest rides the existing
+// encrypted chat payload; `handleIncoming` verifies it end-to-end and hands
+// the AUTHENTICATED agent identities to the chat handler. These cases exercise
+// the real send-payload → receive-parse field plumbing (the `from`/`to`/`ts`/
+// `sig` JSON keys are dynamic and not covered by tsc), plus the fail-closed path.
+describe('MessageHandler — agent-addressed messaging (V1)', () => {
+  // Deterministic sender agent wallet (hardhat account #0) + a recipient addr.
+  const AGENT = new ethers.Wallet(
+    '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+  );
+  const RECIP_AGENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+
+  async function signManifest(messageId: string, ts: number, text: string): Promise<string> {
+    const digest = agentManifestDigestBytes({
+      from: AGENT.address,
+      to: RECIP_AGENT,
+      messageId,
+      ts,
+      text,
+    });
+    const s = ethers.Signature.from(await AGENT.signMessage(digest));
+    return serializeCompactSignature({ r: ethers.getBytes(s.r), vs: ethers.getBytes(s.yParityAndS) });
+  }
+
+  it('verified manifest reaches the chat handler as sender/recipient agent addresses', async () => {
+    const { a, b } = await buildPair();
+    const chatHandler = recorder<Parameters<ChatHandler>, void>(() => undefined);
+    b.onChat(chatHandler);
+
+    const messageId = 'rt-agent-1';
+    const ts = Date.now();
+    const text = 'hi from agent';
+    const sig = await signManifest(messageId, ts, text);
+
+    const result = await a.sendChat(PEER_B, text, {
+      messageId,
+      agentManifest: {
+        from: ethers.getAddress(AGENT.address),
+        to: ethers.getAddress(RECIP_AGENT),
+        ts,
+        sig,
+      },
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(chatHandler.calls).toHaveLength(1);
+    // positional: [text, sender, convId, senderCg, verifiedCg, messageId,
+    //              senderAgentAddress, recipientAgentAddress]
+    const [callText, , , , , , senderAgent, recipientAgent] = chatHandler.calls[0];
+    expect(callText).toBe(text);
+    expect(senderAgent).toBe(ethers.getAddress(AGENT.address));
+    expect(recipientAgent).toBe(ethers.getAddress(RECIP_AGENT));
+  });
+
+  it('tampered text (sig over a different message) → rejected, handler NOT invoked', async () => {
+    const { a, b } = await buildPair();
+    const chatHandler = recorder<Parameters<ChatHandler>, void>(() => undefined);
+    b.onChat(chatHandler);
+
+    const messageId = 'rt-agent-2';
+    const ts = Date.now();
+    // Sign over the original text, then send DIFFERENT text with that manifest.
+    const sig = await signManifest(messageId, ts, 'original text');
+
+    const result = await a.sendChat(PEER_B, 'DIFFERENT text', {
+      messageId,
+      agentManifest: {
+        from: ethers.getAddress(AGENT.address),
+        to: ethers.getAddress(RECIP_AGENT),
+        ts,
+        sig,
+      },
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toContain('Invalid agent manifest');
+    expect(chatHandler.calls).toEqual([]);
+  });
+
+  it('legacy chat without a manifest leaves the agent addresses undefined', async () => {
+    const { a, b } = await buildPair();
+    const chatHandler = recorder<Parameters<ChatHandler>, void>(() => undefined);
+    b.onChat(chatHandler);
+
+    await a.sendChat(PEER_B, 'plain node chat');
+
+    const [, , , , , , senderAgent, recipientAgent] = chatHandler.calls[0];
+    expect(senderAgent).toBeUndefined();
+    expect(recipientAgent).toBeUndefined();
   });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -13,6 +13,7 @@ const SQLITE_EXEC_ARGV = [
 export default defineConfig({
   test: {
     include: [
+      "test/agent-message-manifest.test.ts",
       "test/endorse.test.ts",
       "test/ack-candidate-pool.test.ts",
       "test/e2e-dht-dial.test.ts",

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1999,7 +1999,34 @@ export async function runDaemonInner(
   }
 
   let chatDb: DashboardDB | null = null;
-  agent.onChat((text, senderPeerId, _convId, senderContextGraphId, verifiedContextGraphId, messageId) => {
+  agent.onChat((
+    text,
+    senderPeerId,
+    _convId,
+    senderContextGraphId,
+    verifiedContextGraphId,
+    messageId,
+    senderAgentAddress,
+    recipientAgentAddress,
+  ) => {
+    // Agent-addressed messaging (V1): when the sender addressed a specific
+    // agent (`to`), only accept the message if THIS node actually hosts that
+    // agent. The manifest signature was already verified in `messaging.ts`;
+    // this is the routing check that keeps a message meant for 0xB out of
+    // 0xC's inbox (the `to` binding would otherwise be decorative).
+    if (
+      recipientAgentAddress &&
+      !agent
+        .listLocalAgents()
+        .some((a) => a.agentAddress.toLowerCase() === recipientAgentAddress.toLowerCase())
+    ) {
+      log(
+        `CHAT IN  [${shortId(senderPeerId)}] dropped: addressed to agent ` +
+          `${recipientAgentAddress} which this node does not host`,
+      );
+      return;
+    }
+    const fromTag = senderAgentAddress ? ` from=${shortId(senderAgentAddress)}` : '';
     if (chatDb) {
       // `messageId` is forwarded from the encrypted payload (V11+
       // senders). `insertChatMessage` uses it as the dedup key
@@ -2026,6 +2053,8 @@ export async function runDaemonInner(
           peer: senderPeerId,
           text,
           messageId,
+          senderAgent: senderAgentAddress,
+          recipientAgent: recipientAgentAddress,
         });
         writeOutcome = inserted ? 'stored' : 'deduped';
       } catch (err) {
@@ -2037,7 +2066,7 @@ export async function runDaemonInner(
       }
       if (writeOutcome === 'deduped') {
         const cgTag = verifiedContextGraphId ? ` cg=${shortId(verifiedContextGraphId)}` : '';
-        log(`CHAT IN  [${shortId(senderPeerId)}]${cgTag} (deduped): ${text}`);
+        log(`CHAT IN  [${shortId(senderPeerId)}]${cgTag}${fromTag} (deduped): ${text}`);
         return;
       }
       // ADR-001: inbound peer chat no longer produces a bell notification —
@@ -2047,7 +2076,7 @@ export async function runDaemonInner(
       // bell-pane `chat_message` notification.
     }
     const cgTag = verifiedContextGraphId ? ` cg=${shortId(verifiedContextGraphId)}` : '';
-    log(`CHAT IN  [${shortId(senderPeerId)}]${cgTag}: ${text}`);
+    log(`CHAT IN  [${shortId(senderPeerId)}]${cgTag}${fromTag}: ${text}`);
   });
 
   // Register before network startup. A queued join approval can arrive as

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -825,6 +825,10 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       peerId?: string;
       message?: string;
       contextGraphId?: string;
+      // Agent-addressed messaging (V1): the recipient agent's `0x…` identity.
+      // The caller supplies BOTH the transport `to`/`peerId` (which node to
+      // dial) and this (which agent it is for) — no directory lookup in V1.
+      recipientAgentAddress?: string;
     };
     // #1106 (1): accept the intuitive `peerId`/`message` aliases for
     // `to`/`text` — callers integrating from the tool tables repeatedly
@@ -832,6 +836,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     const to = chatParsed.to ?? chatParsed.peerId;
     const text = chatParsed.text ?? chatParsed.message;
     const contextGraphId = chatParsed.contextGraphId;
+    const recipientAgentAddress = chatParsed.recipientAgentAddress;
     if (!to || !text)
       return jsonResponse(res, 400, { error: 'Missing "to" or "text" (aliases: "peerId" / "message")' });
 
@@ -842,8 +847,14 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       return jsonResponse(res, 404, { error: `Agent "${to}" not found` });
 
     const sendT0 = Date.now();
+    const sendOptions: {
+      contextGraphId?: string;
+      recipientAgentAddress?: string;
+    } = {};
+    if (contextGraphId) sendOptions.contextGraphId = contextGraphId;
+    if (recipientAgentAddress) sendOptions.recipientAgentAddress = recipientAgentAddress;
     const result = await Promise.race([
-      agent.sendChat(peerId, text, contextGraphId ? { contextGraphId } : {}),
+      agent.sendChat(peerId, text, sendOptions),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error("sendChat timeout (30s)")), 30_000),
       ),
@@ -936,6 +947,10 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       peerName: r.peer_name ?? undefined,
       text: r.text,
       delivered: r.delivered == null ? undefined : r.delivered === 1,
+      // Agent-addressed messaging (V1): authenticated sender / addressed-to
+      // agent identities. Undefined for legacy node-addressed chats.
+      senderAgent: r.sender_agent ?? undefined,
+      recipientAgent: r.recipient_agent ?? undefined,
     }));
     return jsonResponse(res, 200, { messages: msgs });
   }

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -491,6 +491,10 @@ export class DkgClient {
     to: string;
     text: string;
     contextGraphId?: string;
+    // Agent-addressed messaging (V1): the recipient agent's `0x…` identity.
+    // Sent alongside the transport `to` so the message is signed by this
+    // agent and addressed to that agent, verifiable independently of the node.
+    recipientAgentAddress?: string;
   }): Promise<{
     delivered: boolean;
     /**
@@ -512,6 +516,7 @@ export class DkgClient {
     const body: Record<string, unknown> = { to: args.to, text: args.text };
     const contextGraphId = optionalContextGraphId(args.contextGraphId);
     if (contextGraphId) body.contextGraphId = contextGraphId;
+    if (args.recipientAgentAddress) body.recipientAgentAddress = args.recipientAgentAddress;
     return this.request('POST', '/api/chat', body);
   }
 
@@ -560,6 +565,10 @@ export class DkgClient {
       peerName?: string;
       text: string;
       delivered?: boolean;
+      // Agent-addressed messaging (V1): authenticated sender / addressed-to
+      // agent `0x…` identities. Undefined for legacy node-addressed chats.
+      senderAgent?: string;
+      recipientAgent?: string;
     }>;
   }> {
     const params = new URLSearchParams();

--- a/packages/mcp-dkg/src/tools/chat.ts
+++ b/packages/mcp-dkg/src/tools/chat.ts
@@ -156,14 +156,27 @@ export function registerChatTools(
               "distinct concerns (the local node's chosen scope " +
               'should not silently appear on every outgoing chat).',
           ),
+        recipientAgentAddress: z
+          .string()
+          .optional()
+          .describe(
+            "Optional recipient AGENT identity — its 0x EVM address. When " +
+              'set, the message is cryptographically signed by THIS agent and ' +
+              'addressed to that specific agent, so the receiver can ' +
+              'authenticate the sender (and route to the right local agent) ' +
+              'independently of which node relayed it. Supply it ALONGSIDE ' +
+              '`to` (the node/peer to dial); in V1 you provide both. Requires ' +
+              'this agent to hold its own identity signing key.',
+          ),
       },
     },
-    async ({ to, text, contextGraphId }): Promise<ToolResult> => {
+    async ({ to, text, contextGraphId, recipientAgentAddress }): Promise<ToolResult> => {
       try {
         const result = await client.sendChat({
           to,
           text,
           ...(contextGraphId ? { contextGraphId } : {}),
+          ...(recipientAgentAddress ? { recipientAgentAddress } : {}),
         });
         if (result.delivered) {
           return ok(`Delivered to ${to}.`);
@@ -354,9 +367,13 @@ export function registerChatTools(
         const lines = filtered.map((m) => {
           const arrow = m.direction === 'in' ? '←' : '→';
           const who = formatPeer(m.peer, names);
+          // Agent-addressed messaging (V1): when the message carried a verified
+          // agent identity, surface the authenticated `0x…` sender so the
+          // operator/agent sees who it is really from (not just the node).
+          const agentTag = m.senderAgent ? ` [agent ${m.senderAgent}]` : '';
           const undeliveredTag =
             m.direction === 'out' && m.delivered === false ? ' [UNDELIVERED]' : '';
-          return `- ${arrow} ${who} · ${formatTs(m.ts)}${undeliveredTag}\n    ${m.text.replace(/\n/g, '\n    ')}`;
+          return `- ${arrow} ${who}${agentTag} · ${formatTs(m.ts)}${undeliveredTag}\n    ${m.text.replace(/\n/g, '\n    ')}`;
         });
         const header =
           dir === 'in'

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -316,12 +316,34 @@ export class DashboardDB {
         this.db.exec(`ALTER TABLE sync_checkpoints ADD COLUMN responder_session_expires_at INTEGER;`);
       }
     };
+    // Agent-addressed messaging (V1): add the sender/recipient agent identity
+    // columns to an existing chat_messages table. Idempotent + version-
+    // independent (mirrors the responder-session adjunct above) so it lands on
+    // any pre-existing DB regardless of which schema version it was created at.
+    const ensureChatMessageAgentColumns = () => {
+      const table = this.db.prepare(`
+        SELECT 1 AS found FROM sqlite_master
+        WHERE type = 'table' AND name = 'chat_messages'
+      `).get() as { found: number } | undefined;
+      if (!table) return;
+      const columns = new Set(
+        (this.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
+          .map((column) => column.name),
+      );
+      if (!columns.has('sender_agent')) {
+        this.db.exec(`ALTER TABLE chat_messages ADD COLUMN sender_agent TEXT;`);
+      }
+      if (!columns.has('recipient_agent')) {
+        this.db.exec(`ALTER TABLE chat_messages ADD COLUMN recipient_agent TEXT;`);
+      }
+    };
     if (version > SCHEMA_VERSION) return;
     if (version === SCHEMA_VERSION) {
       // Repair restored/development databases that carry the current version
       // but lost an idempotent schema adjunct.
       ensureJoinApprovalRepairMarker();
       ensureSyncCheckpointResponderSessionColumns();
+      ensureChatMessageAgentColumns();
       ensureJoinPolicyAuditCapTrigger();
       return;
     }
@@ -458,7 +480,9 @@ export class DashboardDB {
           peer_name TEXT,
           text TEXT NOT NULL,
           delivered INTEGER,
-          message_id TEXT
+          message_id TEXT,
+          sender_agent TEXT,
+          recipient_agent TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_chat_ts ON chat_messages(ts);
         CREATE INDEX IF NOT EXISTS idx_chat_peer ON chat_messages(peer);
@@ -1193,6 +1217,10 @@ export class DashboardDB {
       // restart can resume that same list instead of discarding durable work.
       ensureSyncCheckpointResponderSessionColumns();
     }
+    // Agent-addressed messaging (V1): idempotent, version-independent — lands
+    // the sender/recipient agent columns on any upgrading DB whose
+    // chat_messages predates them.
+    ensureChatMessageAgentColumns();
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
     if (upgradedExistingDb && !this.explicitRetentionDays) {
       this.retentionDays = LEGACY_IMPLICIT_RETENTION_DAYS;
@@ -2690,10 +2718,16 @@ export class DashboardDB {
     text: string;
     delivered?: boolean | null;
     messageId?: string | null;
+    // Agent-addressed messaging (V1) — the authenticated sending agent and the
+    // local agent it was addressed to. Null/omitted for legacy node chats.
+    senderAgent?: string | null;
+    recipientAgent?: string | null;
   }): boolean {
     const info = this.stmt('insertChat', `
-      INSERT INTO chat_messages (ts, direction, peer, peer_name, text, delivered, message_id)
-      VALUES (@ts, @direction, @peer, @peer_name, @text, @delivered, @message_id)
+      INSERT INTO chat_messages
+        (ts, direction, peer, peer_name, text, delivered, message_id, sender_agent, recipient_agent)
+      VALUES
+        (@ts, @direction, @peer, @peer_name, @text, @delivered, @message_id, @sender_agent, @recipient_agent)
     `).run({
       ts: msg.ts,
       direction: msg.direction,
@@ -2702,6 +2736,8 @@ export class DashboardDB {
       text: msg.text,
       delivered: msg.delivered == null ? null : msg.delivered ? 1 : 0,
       message_id: msg.messageId ?? null,
+      sender_agent: msg.senderAgent ?? null,
+      recipient_agent: msg.recipientAgent ?? null,
     });
     return info.changes > 0;
   }
@@ -4078,6 +4114,14 @@ export interface ChatMessageRow {
    * readers + rollback safety.
    */
   message_id: string | null;
+  /**
+   * Agent-addressed messaging (V1). `sender_agent` is the authenticated `0x…`
+   * identity of the sending agent (from the verified manifest); `recipient_agent`
+   * is the local agent it was addressed to. Both null for legacy node-addressed
+   * chats and for outbound rows that predate agent addressing.
+   */
+  sender_agent: string | null;
+  recipient_agent: string | null;
 }
 
 export type ChatPersistenceStatus = 'pending' | 'in_progress' | 'stored' | 'failed';


### PR DESCRIPTION
## Agent-addressed direct messages (V1)

Today the chat protocol is **node-addressed**: you send to a libp2p `peerId` and the message is signed by that node's Ed25519 key. "Agent" and "node" are effectively the same thing — the agent DID is derived from the peerId. This PR adds a thin **agent-identity layer on top of the existing transport**, so you can send to `agent 0x123` and the receiver can cryptographically verify *which agent* sent it, independently of which node relayed it.

The transport, the X25519 encryption, and the reliable-delivery substrate are **completely unchanged**. All this adds is a small signed manifest carried *inside* the already-encrypted chat payload.

### How it works

A sender that supplies a `recipientAgentAddress` stamps a manifest into the payload:

```
{ from: 0x<sender agent>, to: 0x<recipient agent>, ts, sig }
```

- **`sig`** is an EIP-191 signature produced by the sender's *agent identity key* — never the node's operational key. Custodial agents (the common case) sign with their keystore key via `getCustodialAgentPrivateKey`, mirroring the SWM-host / gossip author-signing paths; self-sovereign / pool-backed identities fall back to `ChainAdapter.signMessageAs`. A relaying/hosting node cannot forge a `from` it does not control.
- The digest binds `from | to | messageId | ts | keccak256(text)`. On receive, `messaging.ts` recovers the signer and (fail-closed) rejects the chat unless it equals `from`.
- The verified `senderAgentAddress` / `recipientAgentAddress` are handed to the chat handler, persisted, and surfaced in the inbox.

Confidentiality is unchanged (the manifest rides inside the existing XChaCha20-Poly1305 payload). What's new is authenticated agent-level `from`/`to`.

> **Note on the signer** — an earlier revision of this branch used `signMessageAs(defaultAgentAddress)` throughout (mirroring the publisher's author-seal path). That is wrong for agent identities: the publisher signs as the node's *pool-backed operational* key, whereas a custodial agent's wallet is a random keystore key that `findSignerByAddress` never sees, so the call throws. Combined with the deliberate hard-fail, every agent-addressed send would have errored. Fixed in the second commit.

### Why `ts` + `messageId` are signed (freshness)

Without binding them, the manifest would be a **context-free bearer token** — "0xA said 'hi' to 0xB" could be re-presented by anyone who observed it. Today the node-keyed ciphertext incidentally blocks cross-node replay, but the planned V2 (agent-keyed end-to-end + store-and-forward mailboxes) removes that accident. So we anchor the signature to the persistent per-node `messageId` dedup key and a timestamp bound **now**, while the wire format is still ours to define. `recipientPeerId` is deliberately **not** bound — it's a transport detail that won't survive V2 forwarding.

The `ts` bound is **24h**, chosen to compose exactly with the two existing substrate windows rather than as an arbitrary freshness figure:

- the durable outbox drops undelivered entries at `maxAgeMs` (24h), so a legitimately retried message is *always* delivered less than 24h after signing; and
- `message_idempotency` retains dedup rows for 24h.

Within 24h the persistent `messageId` dedup — the **primary** anti-replay guard — drops duplicates; beyond 24h that row is pruned and the `ts` bound takes over. No gap, and no false rejection.

⚠️ Do **not** tighten this to "a few minutes". The outbox backoff ladder runs `5s → 15s → 30s → 60s → 5m → 30m → 2h`, so a briefly-offline recipient routinely receives a message whose `ts` is hours old. A short window makes the durable outbox faithfully redeliver messages that can never verify, defeating at-least-once delivery. (The first commit had exactly this bug at ±5 min; fixed in the second.)

### Scope (V1)

- The sender provides **both** the transport target (`to`/`peerId`) **and** `recipientAgentAddress` — no directory lookup yet (that's a fast-follow; the agents-CG already publishes the `0x → peerId` map).
- `to == self` is enforced on receive: a node only accepts an agent-addressed message for an agent it actually hosts (`listLocalAgents()`).
- Legacy node-addressed chats are 100% unaffected — no manifest ⇒ identical behavior.

### Security notes for review

- **Fail-closed**: any manifest field present but signature invalid / stale / signer≠`from` ⇒ the chat is rejected (sender gets an error), never delivered with an unverified identity.
- **Hard-fail on send**: if `recipientAgentAddress` is requested but the agent can't sign as its own identity (`signMessageAs` unavailable / address not in the signer pool), the send throws rather than silently downgrading to an unauthenticated message.
- No new crypto primitive — reuses `signMessageAs` + `ethers.verifyMessage` + the existing `agent-message-manifest` digest.

### Testing

- New unit test `agent-message-manifest.test.ts` (added to the `test:unit` include list) — **9/9**. Drives *both* real signing paths: the custodial direct `Wallet.signMessage` path (the production default) and the adapter's compact-`{r,vs}` → serialized reassembly (EIP-2098, the riskiest line). Tamper cases: modified text, swapped `messageId`, spoofed `from`, stale `ts`, malformed sig, incomplete manifest. Plus a regression guard that a **6h-delayed outbox retry is accepted**.
- `messaging-chat-acl.test.ts` — **18/18** (15 pre-existing, no regression + 3 new): manifest round-trip reaching the chat handler as verified agent addresses, tampered-text fail-closed, and legacy-chat backward compat (agent fields stay `undefined`). These cover the send-payload → receive-parse field plumbing, which tsc cannot check (dynamic JSON keys).
- `turbo build` (tsc across all 22 packages) green.

**Not yet exercised:** a real two-daemon end-to-end run against live custodial agents. The signer fix above is verified by code path + unit test, not by a live send — worth a devnet smoke before merge.

### Migration

`chat_messages` gains two nullable columns (`sender_agent`, `recipient_agent`) via an idempotent, version-independent `ensureChatMessageAgentColumns()` — lands on any existing DB regardless of schema version.

### Follow-ups (V2, not in this PR)

- `0x → peerId` directory resolution so the caller only needs the agent address.
- Agent-keyed end-to-end encryption (encrypt to the agent's published X25519 key) so a hosting/relay node can't read the plaintext.
- Multiple agents per node process + receive-side demux.
- A receiver policy to *require* signed messages (reject unsigned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
