### PR TITLE
fix(agent): bound RFC-64 exact-set bundle memory

### DIFF
--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -81,6 +81,7 @@ import {
 import {
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
   RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+  assertRfc64PublicCatalogExactSetBundleBytesV1,
   type FetchedRfc64PublicCatalogObjectV1,
   type Rfc64PublicCatalogNativeFetchScopeV1,
   type Rfc64PublicCatalogNativeTransportV1,
@@ -578,6 +579,17 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       }
     } catch (cause) {
       fail('catalog-native-receiver-catalog', 'catalog bucket is not bound to its directory', cause);
+    }
+    try {
+      assertRfc64PublicCatalogExactSetBundleBytesV1(
+        bucket.payload.rows.map((row) => row.transfer.byteLength),
+      );
+    } catch (cause) {
+      fail(
+        'catalog-native-receiver-slice',
+        'signed catalog exact set exceeds the V1 aggregate bundle-byte ceiling',
+        cause,
+      );
     }
     const preparedRows: Array<{
       readonly row: AuthorCatalogRowV1;

--- a/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
@@ -26,6 +26,7 @@ import {
   canonicalizeSignedControlEnvelopeBytes,
   computeControlSignatureVariantDigestHex,
   decodeOpaqueKaBundleV1,
+  parseCanonicalDecimalU64,
   parseCanonicalSignedControlEnvelope,
   type ContextGraphAccessPolicyV1,
   type ContextGraphIdV1,
@@ -58,6 +59,46 @@ export const RFC64_PUBLIC_CATALOG_OBJECT_FETCH_RESPONSE_MAX_BYTES_V1 =
 /** First vertical slice resource ceiling; protocol descriptors may advertise more. */
 export const RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1 =
   8 * 1024 * 1024;
+/**
+ * Maximum logical bytes in every complete bundle committed by one exact-set
+ * successor. This keeps the 1..1,024-row slice useful for small assets while
+ * bounding a producer/receiver batch to 64 MiB (eight maximum-size bundles,
+ * or 1,024 bundles averaging 64 KiB).
+ */
+export const RFC64_PUBLIC_CATALOG_EXACT_SET_BUNDLE_BYTES_MAX_V1 =
+  64 * 1024 * 1024;
+
+/** Add one canonical signed-row byte length to the shared V1 exact-set budget. */
+export function addRfc64PublicCatalogExactSetBundleBytesV1(
+  currentTotal: bigint,
+  byteLength: DecimalU64V1,
+): bigint {
+  const ceiling = BigInt(RFC64_PUBLIC_CATALOG_EXACT_SET_BUNDLE_BYTES_MAX_V1);
+  if (typeof currentTotal !== 'bigint' || currentTotal < 0n || currentTotal > ceiling) {
+    throw new RangeError('current exact-set bundle-byte total is outside the V1 ceiling');
+  }
+  const nextTotal = currentTotal + parseCanonicalDecimalU64(
+    byteLength,
+    'exact-set bundle byteLength',
+  );
+  if (nextTotal > ceiling) {
+    throw new RangeError(
+      `exact-set bundle bytes exceed the V1 ${RFC64_PUBLIC_CATALOG_EXACT_SET_BUNDLE_BYTES_MAX_V1}-byte ceiling`,
+    );
+  }
+  return nextTotal;
+}
+
+/** Validate canonical row byte lengths before a receiver fetches any bundle. */
+export function assertRfc64PublicCatalogExactSetBundleBytesV1(
+  byteLengths: readonly DecimalU64V1[],
+): bigint {
+  let total = 0n;
+  for (const byteLength of byteLengths) {
+    total = addRfc64PublicCatalogExactSetBundleBytesV1(total, byteLength);
+  }
+  return total;
+}
 
 const FETCH_NOT_FOUND = 0;
 const FETCH_FOUND = 1;

--- a/packages/agent/src/rfc64/public-catalog-successor-producer-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-successor-producer-v1.ts
@@ -68,7 +68,10 @@ import type {
   StageVerifiedControlObjectsResultV1,
 } from './control-object-store-v1.js';
 import { assertRecoverableAuthorAttestationV1 } from './public-catalog-native-receiver-v1.js';
-import { RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1 } from './public-catalog-native-transport-v1.js';
+import {
+  RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1,
+  addRfc64PublicCatalogExactSetBundleBytesV1,
+} from './public-catalog-native-transport-v1.js';
 
 export type Rfc64PublicCatalogSuccessorProducerErrorCodeV1 =
   | 'catalog-successor-producer-input'
@@ -494,6 +497,8 @@ function prepareExactSet(input: ProduceAndStagePublicOpenExactSetSuccessorInputV
       `assets must contain 1..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} entries`,
     );
   }
+  const snapshots: PreparedRfc64PublicCatalogSuccessorAssetSnapshotV1[] = [];
+  let aggregateBundleBytes = 0n;
   for (let index = 0; index < assets.length; index += 1) {
     const descriptor = Object.getOwnPropertyDescriptor(assets, String(index));
     if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
@@ -502,9 +507,57 @@ function prepareExactSet(input: ProduceAndStagePublicOpenExactSetSuccessorInputV
         'assets must contain only enumerable data elements',
       );
     }
+    const asset = descriptor.value as Rfc64PublicCatalogSuccessorAssetInputV1;
+    try {
+      // Snapshot each caller-owned field exactly once. In particular, no
+      // stateful projectionBytes getter can change validation vs encoding.
+      const assertionCoordinate = asset?.assertionCoordinate;
+      const projectionInput = asset?.projectionBytes;
+      const sealInput = asset?.seal;
+      if (!(projectionInput instanceof Uint8Array)) {
+        throw new TypeError('projectionBytes must be a Uint8Array');
+      }
+      // Reject a projection that cannot possibly fit the Gate-1 transport
+      // before allocating its detached snapshot.
+      if (
+        BigInt(projectionInput.byteLength)
+        > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)
+          - MIN_KA_BUNDLE_BYTES_V1
+      ) {
+        throw new RangeError('projection exceeds the Gate-1 complete-bundle ceiling');
+      }
+      const projectionBytes = new Uint8Array(projectionInput);
+      const sealBytes = canonicalizeCanonicalGraphScopedAuthorSealBytesV1(sealInput);
+      const seal = parseCanonicalGraphScopedAuthorSealV1(sealBytes);
+      const bundleByteLength = calculateOpaqueKaBundleByteLengthV1(
+        BigInt(projectionBytes.byteLength),
+        BigInt(sealBytes.byteLength),
+      );
+      if (bundleByteLength > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)) {
+        throw new RangeError('bundle exceeds the Gate-1 complete-bundle ceiling');
+      }
+      const canonicalBundleByteLength = bundleByteLength.toString() as ByteLengthV1;
+      aggregateBundleBytes = addRfc64PublicCatalogExactSetBundleBytesV1(
+        aggregateBundleBytes,
+        canonicalBundleByteLength,
+      );
+      snapshots.push(Object.freeze({
+        assertionCoordinate,
+        projectionBytes,
+        seal,
+        sealBytes,
+        bundleByteLength,
+      }));
+    } catch (cause) {
+      fail(
+        'catalog-successor-producer-input',
+        'projection, seal, or exact-set bundle-byte budget is not canonical',
+        cause,
+      );
+    }
   }
-  const prepared = assets.map((asset) => prepareRowAndBundle(
-    asset,
+  const prepared = snapshots.map((snapshot) => prepareRowAndBundle(
+    snapshot,
     input.previousHead,
     input.deployment,
   ));
@@ -525,48 +578,35 @@ function prepareExactSet(input: ProduceAndStagePublicOpenExactSetSuccessorInputV
   return Object.freeze(prepared);
 }
 
+interface PreparedRfc64PublicCatalogSuccessorAssetSnapshotV1 {
+  readonly assertionCoordinate: AssertionCoordinateV1;
+  readonly projectionBytes: Uint8Array;
+  readonly seal: CanonicalGraphScopedAuthorSealV1;
+  readonly sealBytes: Uint8Array;
+  readonly bundleByteLength: bigint;
+}
+
 function prepareRowAndBundle(
-  asset: Rfc64PublicCatalogSuccessorAssetInputV1,
+  asset: PreparedRfc64PublicCatalogSuccessorAssetSnapshotV1,
   previousHead: SignedAuthorCatalogHeadEnvelopeV1,
   deploymentInput: CatalogSealDeploymentProfileV1,
 ) {
-  let sealBytes: Uint8Array;
-  let seal: CanonicalGraphScopedAuthorSealV1;
   let encoded: ReturnType<typeof encodeOpaqueKaBundleV1>;
   let row: AuthorCatalogRowV1;
   try {
-    if (!(asset?.projectionBytes instanceof Uint8Array)) {
-      throw new TypeError('projectionBytes must be a Uint8Array');
-    }
-    // Reject a projection that cannot possibly fit the Gate-1 transport before
-    // canonicalizing the seal or allocating/copying a complete bundle.
-    if (
-      BigInt(asset.projectionBytes.byteLength)
-      > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)
-        - MIN_KA_BUNDLE_BYTES_V1
-    ) {
-      throw new RangeError('projection exceeds the Gate-1 complete-bundle ceiling');
-    }
-    const assertionCoordinate = asset?.assertionCoordinate;
-    sealBytes = canonicalizeCanonicalGraphScopedAuthorSealBytesV1(asset.seal);
-    seal = parseCanonicalGraphScopedAuthorSealV1(sealBytes);
-    const bundleByteLength = calculateOpaqueKaBundleByteLengthV1(
-      BigInt(asset.projectionBytes.byteLength),
-      BigInt(sealBytes.byteLength),
-    );
-    if (bundleByteLength > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)) {
-      throw new RangeError('bundle exceeds the Gate-1 complete-bundle ceiling');
-    }
-    encoded = encodeOpaqueKaBundleV1(asset.projectionBytes, sealBytes);
+    encoded = encodeOpaqueKaBundleV1(asset.projectionBytes, asset.sealBytes);
     const byteLength = BigInt(encoded.bundleBytes.byteLength);
+    if (byteLength !== asset.bundleByteLength) {
+      throw new Error('encoded bundle length differs from its exact-set budget snapshot');
+    }
     const chunkCount = ((byteLength - 1n) / KA_TRANSFER_CHUNK_SIZE_BYTES_V1) + 1n;
     row = parseCanonicalAuthorCatalogRowV1(canonicalizeAuthorCatalogRowV1({
-      kaId: seal.reservedKaId,
-      assertionCoordinate,
-      assertionVersion: seal.assertionVersion,
+      kaId: asset.seal.reservedKaId,
+      assertionCoordinate: asset.assertionCoordinate,
+      assertionVersion: asset.seal.assertionVersion,
       projectionId: KA_TRANSFER_PROJECTION_V1,
       projectionDigest: encoded.projectionDigest,
-      sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(seal),
+      sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(asset.seal),
       transfer: {
         codec: KA_TRANSFER_CODEC_V1,
         projectionId: KA_TRANSFER_PROJECTION_V1,
@@ -598,7 +638,7 @@ function prepareRowAndBundle(
       deployment,
       scope,
       row: Object.freeze(row),
-      sealBytes,
+      sealBytes: asset.sealBytes,
       encoded,
       bundleBytes: new Uint8Array(encoded.bundleBytes),
     });

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -47,11 +47,13 @@ import {
 import {
   computeRfc64AppliedInventoryDigestV1,
   Rfc64PublicCatalogNativeReceiverV1,
+  rfc64CatalogSignatureVariantDigestV1,
 } from '../src/rfc64/public-catalog-native-receiver-v1.js';
 import {
   verifyRfc64PublicCatalogInventoryCompletenessV1,
 } from '../src/rfc64/public-catalog-inventory-completeness-v1.js';
 import {
+  RFC64_PUBLIC_CATALOG_EXACT_SET_BUNDLE_BYTES_MAX_V1,
   Rfc64PublicCatalogNativeTransportV1,
 } from '../src/rfc64/public-catalog-native-transport-v1.js';
 import {
@@ -350,6 +352,70 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       observed.receiver,
     )).rejects.toMatchObject({ code: 'catalog-native-receiver-transfer' });
     expect(fixture.receiverBundleFetch).toHaveBeenCalledTimes(2);
+    expect(observed.stageVerifiedObjects).not.toHaveBeenCalled();
+    expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )?.currentCatalogHeadDigest).toBe(fixture.successor.head.objectDigest);
+    await expect(fixture.receiverStore.countQuads()).resolves.toBe(16);
+  }, 30_000);
+
+  it('rejects an over-budget signed exact set before fetching its first bundle', async () => {
+    const fixture = await setupLiveReceiver();
+    await fixture.bootstrap();
+    await fixture.synchronize();
+    const declaredBundleByteLength =
+      BigInt(RFC64_PUBLIC_CATALOG_EXACT_SET_BUNDLE_BYTES_MAX_V1);
+    const built = await buildRowBundle(AUTHOR_WALLET, {
+      kaNumber: 100n,
+      assertionCoordinate: 'budget-row',
+    });
+    const row = {
+      ...built.row,
+      transfer: {
+        ...built.row.transfer,
+        byteLength: declaredBundleByteLength.toString(),
+        chunkCount: (
+          ((declaredBundleByteLength - 1n) / 262_144n) + 1n
+        ).toString(),
+      },
+    } as AuthorCatalogRowV1;
+    assertAuthorCatalogRowV1(row);
+    const successor = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: fixture.successor.head,
+      previousDirectoryPath: fixture.successor.directoryPath,
+      previousBucket: fixture.successor.bucket,
+      selectedBucketId: '0' as never,
+      nextRows: [fixture.rowBundle.row, row],
+      issuedAt: '1773900001003' as never,
+      signer: {
+        issuer: AUTHOR,
+        signDigest: async (digest) => AUTHOR_WALLET.signMessage(digest),
+      },
+    });
+    for (const envelope of successor.stagedObjects) {
+      fixture.authorObjects.set(envelope.objectDigest, envelope);
+    }
+    const headSignature = await verifyControlEnvelopeIssuerSignatureV1(successor.head);
+    fixture.receiverHeadFetch.mockImplementationOnce(async () => Object.freeze({
+      envelope: successor.head,
+      issuerSignature: headSignature,
+    }));
+    const announcement = Object.freeze({
+      ...fixture.announcement,
+      catalogVersion: successor.head.payload.version,
+      catalogHeadObjectDigest: successor.head.objectDigest,
+      signatureVariantDigest: rfc64CatalogSignatureVariantDigestV1(successor.head),
+    }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
+    fixture.receiverBundleFetch.mockClear();
+    const observed = fixture.createCasObservedReceiver();
+
+    await expect(fixture.synchronizeAny(
+      announcement,
+      observed.receiver,
+    )).rejects.toMatchObject({ code: 'catalog-native-receiver-slice' });
+    expect(fixture.receiverBundleFetch).not.toHaveBeenCalled();
     expect(observed.stageVerifiedObjects).not.toHaveBeenCalled();
     expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
     expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(

--- a/packages/agent/test/rfc64-public-catalog-native-transport-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-transport-v1.test.ts
@@ -19,9 +19,11 @@ import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-
 import {
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
+  RFC64_PUBLIC_CATALOG_EXACT_SET_BUNDLE_BYTES_MAX_V1,
   RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
   RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
   Rfc64PublicCatalogNativeTransportV1,
+  assertRfc64PublicCatalogExactSetBundleBytesV1,
   type Rfc64PublicCatalogNativeFetchScopeV1,
   Rfc64PublicCatalogNativeTransportErrorV1,
 } from '../src/rfc64/public-catalog-native-transport-v1.js';
@@ -59,6 +61,18 @@ async function connect(from: DKGNode, to: DKGNode): Promise<void> {
 }
 
 describe('RFC-64 public catalog native content transport v1', () => {
+  it('accepts the exact-set bundle-byte ceiling and rejects one byte over it', () => {
+    const ceiling = BigInt(RFC64_PUBLIC_CATALOG_EXACT_SET_BUNDLE_BYTES_MAX_V1);
+    expect(assertRfc64PublicCatalogExactSetBundleBytesV1([
+      (ceiling - 1n).toString() as never,
+      '1' as never,
+    ])).toBe(ceiling);
+    expect(() => assertRfc64PublicCatalogExactSetBundleBytesV1([
+      ceiling.toString() as never,
+      '1' as never,
+    ])).toThrow(/exceed.*ceiling/);
+  });
+
   it('fetches exact directory and bundle digests across two live libp2p nodes', async () => {
     const [authorNode, receiverNode] = await Promise.all([startNode(), startNode()]);
     await connect(receiverNode, authorNode);

--- a/packages/agent/test/rfc64-public-catalog-successor-producer-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-successor-producer-v1.test.ts
@@ -245,6 +245,39 @@ describe('RFC-64 public/open one-row successor producer', () => {
     expect(stageVerifiedObjects).not.toHaveBeenCalled();
   });
 
+  it('rejects an aggregate over-budget exact set before signing or staging', async () => {
+    const { genesis, authorization } = await producerHistory();
+    const signDigest = vi.fn(async (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest));
+    const stageKaBundle = vi.fn(durableBundleReceipt);
+    const stageVerifiedObjects = vi.fn(async () => undefined as never);
+    const producer = new Rfc64PublicCatalogSuccessorProducerV1({
+      controlObjects: { stageVerifiedObjects } as never,
+      stageKaBundle,
+    });
+    const asset = {
+      assertionCoordinate: 'gate-1-object' as never,
+      projectionBytes: new Uint8Array(
+        RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1 - 4_096,
+      ),
+      seal: await authorSeal(AUTHOR_WALLET),
+    };
+
+    await expect(producer.produceAndStageExactSet({
+      previousHead: genesis.head,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      assets: Array.from({ length: 9 }, () => asset),
+      deployment: DEPLOYMENT,
+      issuedAt: '1773900001000' as never,
+      catalogSigner: { issuer: AUTHOR, signDigest },
+      catalogIssuerAuthorization: authorization,
+    })).rejects.toMatchObject({ code: 'catalog-successor-producer-input' });
+
+    expect(signDigest).not.toHaveBeenCalled();
+    expect(stageKaBundle).not.toHaveBeenCalled();
+    expect(stageVerifiedObjects).not.toHaveBeenCalled();
+  });
+
   it('rejects a non-author attestation before either durable staging callback', async () => {
     const { genesis, authorization } = await producerHistory();
     const stageKaBundle = vi.fn(durableBundleReceipt);
@@ -434,6 +467,49 @@ describe('RFC-64 public/open one-row successor producer', () => {
     expect(signDigest).not.toHaveBeenCalled();
     expect(stageKaBundle).not.toHaveBeenCalled();
     expect(stageVerifiedObjects).not.toHaveBeenCalled();
+  });
+
+  it('snapshots a stateful projection getter once before validation and encoding', async () => {
+    const { genesis, authorization } = await producerHistory();
+    const stageKaBundle = vi.fn(durableBundleReceipt);
+    const stageVerifiedObjects = vi.fn(async () => Object.freeze({
+      durable: true as const,
+      namespaceDurability: 'test-exact-durable' as never,
+      objects: Object.freeze([]),
+    }));
+    const producer = new Rfc64PublicCatalogSuccessorProducerV1({
+      controlObjects: { stageVerifiedObjects } as never,
+      stageKaBundle,
+    });
+    let projectionReads = 0;
+    const asset = {
+      assertionCoordinate: 'gate-1-object' as never,
+      get projectionBytes() {
+        projectionReads += 1;
+        return projectionReads === 1
+          ? PROJECTION
+          : new Uint8Array(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1);
+      },
+      seal: await authorSeal(AUTHOR_WALLET),
+    };
+
+    const result = await producer.produceAndStageExactSet({
+      previousHead: genesis.head,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      assets: [asset],
+      deployment: DEPLOYMENT,
+      issuedAt: '1773900001000' as never,
+      catalogSigner: catalogSigner(),
+      catalogIssuerAuthorization: authorization,
+    });
+
+    expect(projectionReads).toBe(1);
+    expect(decodeOpaqueKaBundleV1(result.assets[0]!.bundleBytes).projectionBytes).toEqual(
+      PROJECTION,
+    );
+    expect(stageKaBundle).toHaveBeenCalledOnce();
+    expect(stageVerifiedObjects).toHaveBeenCalledOnce();
   });
 
   it('fails control-object staging only after the bundle is durably staged first', async () => {


### PR DESCRIPTION
Stacked on #1818. This resolves the Gate 2 bounded-memory feedback without touching integration/rfc64-devnet or main.\n\nChanges:\n- snapshot each asset and projection exactly once\n- enforce one shared 64 MiB whole-set bundle ceiling in producer and receiver before fetch\n- cover exact boundary, boundary-plus-one, switching getters, and aggregate overflow\n\nEvidence:\n- focused RFC-64 lane: 65 tests passed\n- full agent unit lane: 1,472 passed, 5 skipped\n- agent build, type tests, and package-root tests passed\n- clean one-commit diff from bffd3d5437200ca3b19c51a3348d14a49fc07b12\n\nGate 2 is not claimed passed by this PR alone.