### PR TITLE
fix(agent): unify RFC-64 inventory digests

### DIFF
--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -12,11 +12,29 @@ if (
   typeof root.DKGAgent !== 'function'
   || typeof legacyAgent.DKGAgent !== 'function'
   || typeof root.Rfc64PublicCatalogSuccessorProducerV1 !== 'function'
+  || typeof root.computeRfc64AppliedInventoryDigestV1 !== 'function'
 ) {
   throw new Error('published agent entry points did not expose required root APIs');
 }
 if (packageManifest.name !== '@origintrail-official/dkg-agent') {
   throw new Error('historical package.json subpath no longer resolves');
+}
+
+const digestAuthor = '0x1111111111111111111111111111111111111111';
+const digestRows = [10, 2].map((number) => ({
+  kaId: ((BigInt(digestAuthor) << 96n) | BigInt(number)).toString(),
+  catalogRowDigest: `0x${(number * 4).toString(16).padStart(64, '0')}`,
+  contentDigest: `0x${((number * 4) + 1).toString(16).padStart(64, '0')}`,
+  sealDigest: `0x${((number * 4) + 2).toString(16).padStart(64, '0')}`,
+  kaUal: `did:dkg:otp:20430/${digestAuthor}/${number}`,
+  activatedTripleCount: number + 1,
+}));
+const publicDigest = root.computeRfc64AppliedInventoryDigestV1({
+  catalogScopeDigest: '0x6287b105b87dbacce48f7702a54e9410ba4a5d52475b986288042eb75464bbe2',
+  rows: digestRows,
+});
+if (publicDigest !== '0x6d273d5f5fc1acbfe6836168c7159b747fe3df549d2d5bddcd8bf409ff58ea01') {
+  throw new Error('package-root applied-inventory digest did not use numeric KA-ID order');
 }
 const publicRfc64Modules = [
   'author-catalog-producer.js',

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -43,6 +43,11 @@ export * from './rfc64/public-catalog-service-v1.js';
 export * from './rfc64/public-catalog-issuer-delegation-v1.js';
 export * from './rfc64/public-catalog-native-transport-v1.js';
 export * from './rfc64/public-catalog-native-receiver-v1.js';
+export {
+  computeRfc64AppliedInventoryDigestV1,
+  type ComputeRfc64AppliedInventoryDigestInputV1,
+  type Rfc64AppliedInventoryDigestRowV1,
+} from './rfc64/public-catalog-inventory-completeness-v1.js';
 export * from './rfc64/public-catalog-successor-producer-v1.js';
 export * from './rfc64/public-catalog-native-reconciler-v1.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';

--- a/packages/agent/src/rfc64/public-catalog-inventory-completeness-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-inventory-completeness-v1.ts
@@ -65,6 +65,29 @@ export interface Rfc64PublicCatalogInventoryEvidenceRowV1 {
   readonly activatedTripleCount: number;
 }
 
+/**
+ * Exact row fields committed by the durable applied-inventory digest.
+ *
+ * `kaId` is an ordering key and is not itself hashed. It is nevertheless
+ * required so every caller uses the signed catalog's mathematical KA-ID order;
+ * deriving order from lexical UAL text is not equivalent for IDs such as 2 and
+ * 10. `bundleDigest` remains operator evidence outside this legacy commitment,
+ * so callers may pass richer receiver evidence rows without affecting the hash.
+ */
+export interface Rfc64AppliedInventoryDigestRowV1 {
+  readonly kaId: KaIdV1;
+  readonly catalogRowDigest: Digest32V1;
+  readonly contentDigest: Digest32V1;
+  readonly sealDigest: Digest32V1;
+  readonly kaUal: string;
+  readonly activatedTripleCount: number;
+}
+
+export interface ComputeRfc64AppliedInventoryDigestInputV1 {
+  readonly catalogScopeDigest: Digest32V1;
+  readonly rows: readonly Rfc64AppliedInventoryDigestRowV1[];
+}
+
 /** Deterministic evidence for one complete bounded catalog live set. */
 export interface Rfc64PublicCatalogInventoryCompletenessEvidenceV1 {
   readonly catalogScopeDigest: Digest32V1;
@@ -82,6 +105,47 @@ export interface VerifyRfc64PublicCatalogInventoryCompletenessInputV1 {
   readonly expectedRows: readonly Rfc64PublicCatalogInventoryEvidenceRowV1[];
   /** Independently observed exact semantic post-reads; input order is irrelevant. */
   readonly observedRows: readonly Rfc64PublicCatalogInventoryEvidenceRowV1[];
+}
+
+/**
+ * Compute the one canonical applied-inventory commitment for empty, one-row,
+ * and bounded multi-row catalogs.
+ *
+ * Input rows are snapshotted and validated, then sorted by mathematical
+ * `kaId`. Caller order is irrelevant. This preserves the Gate-1 empty/one-row
+ * framing while making the previously unobservable multi-row order explicit.
+ */
+export function computeRfc64AppliedInventoryDigestV1(
+  input: ComputeRfc64AppliedInventoryDigestInputV1,
+): Digest32V1 {
+  const boundary = snapshotExactDataRecord(input, [
+    'catalogScopeDigest',
+    'rows',
+  ], 'applied inventory digest input');
+  try {
+    assertCanonicalDigest(boundary.catalogScopeDigest, 'catalogScopeDigest');
+  } catch (cause) {
+    fail(
+      'catalog-inventory-completeness-input',
+      'catalogScopeDigest is not a canonical digest',
+      cause,
+    );
+  }
+  const rows = snapshotAppliedInventoryDigestRows(boundary.rows);
+  const hasher = sha256.create();
+  hasher.update(UTF8.encode(APPLIED_INVENTORY_DIGEST_DOMAIN_V1));
+  hasher.update(ethers.getBytes(boundary.catalogScopeDigest as Digest32V1));
+  hasher.update(encodeU64(BigInt(rows.length), 'inventory row count'));
+  for (const row of rows) {
+    hasher.update(ethers.getBytes(row.catalogRowDigest));
+    hasher.update(ethers.getBytes(row.contentDigest));
+    hasher.update(ethers.getBytes(row.sealDigest));
+    const ual = UTF8.encode(row.kaUal);
+    hasher.update(encodeU64(BigInt(ual.byteLength), 'KA UAL byte length'));
+    hasher.update(ual);
+    hasher.update(encodeU64(BigInt(row.activatedTripleCount), 'activated triple count'));
+  }
+  return ethers.hexlify(hasher.digest()) as Digest32V1;
 }
 
 /**
@@ -165,7 +229,10 @@ export function verifyRfc64PublicCatalogInventoryCompletenessV1(
   return Object.freeze({
     catalogScopeDigest,
     inventoryRowCount: boundary.expectedTotalRows,
-    inventoryDigest: computeInventoryDigest(catalogScopeDigest, expected),
+    inventoryDigest: computeRfc64AppliedInventoryDigestV1({
+      catalogScopeDigest,
+      rows: expected,
+    }),
     rows: expected,
   });
 }
@@ -326,24 +393,60 @@ function snapshotRow(
   return snapshot;
 }
 
-function computeInventoryDigest(
-  catalogScopeDigest: Digest32V1,
-  rows: readonly Readonly<Rfc64PublicCatalogInventoryEvidenceRowV1>[],
-): Digest32V1 {
-  const hasher = sha256.create();
-  hasher.update(UTF8.encode(APPLIED_INVENTORY_DIGEST_DOMAIN_V1));
-  hasher.update(ethers.getBytes(catalogScopeDigest));
-  hasher.update(encodeU64(BigInt(rows.length), 'inventory row count'));
-  for (const row of rows) {
-    hasher.update(ethers.getBytes(row.catalogRowDigest));
-    hasher.update(ethers.getBytes(row.contentDigest));
-    hasher.update(ethers.getBytes(row.sealDigest));
-    const ual = UTF8.encode(row.kaUal);
-    hasher.update(encodeU64(BigInt(ual.byteLength), 'KA UAL byte length'));
-    hasher.update(ual);
-    hasher.update(encodeU64(BigInt(row.activatedTripleCount), 'activated triple count'));
+function snapshotAppliedInventoryDigestRows(
+  input: unknown,
+): readonly Readonly<Rfc64AppliedInventoryDigestRowV1>[] {
+  const values = snapshotDenseBoundedOrdinaryArray(input, 'applied inventory digest rows');
+  const rows = values.map((value, index) => {
+    const label = `applied inventory digest rows[${index}]`;
+    const fields = snapshotRequiredDataRecord(value, [
+      'activatedTripleCount',
+      'catalogRowDigest',
+      'contentDigest',
+      'kaId',
+      'kaUal',
+      'sealDigest',
+    ], label);
+    const row = Object.freeze({
+      kaId: fields.kaId,
+      catalogRowDigest: fields.catalogRowDigest,
+      contentDigest: fields.contentDigest,
+      sealDigest: fields.sealDigest,
+      kaUal: fields.kaUal,
+      activatedTripleCount: fields.activatedTripleCount,
+    }) as unknown as Rfc64AppliedInventoryDigestRowV1;
+    try {
+      assertCanonicalKaId(row.kaId, `${label}.kaId`);
+      assertCanonicalDigest(row.catalogRowDigest, `${label}.catalogRowDigest`);
+      assertCanonicalDigest(row.contentDigest, `${label}.contentDigest`);
+      assertCanonicalDigest(row.sealDigest, `${label}.sealDigest`);
+      if (!Number.isSafeInteger(row.activatedTripleCount) || row.activatedTripleCount < 1) {
+        throw new Error(`${label}.activatedTripleCount must be a positive safe integer`);
+      }
+      const parsedUal = parseDeterministicKnowledgeAssetUal(row.kaUal);
+      const packedKaId = (BigInt(parsedUal.agentAddress) << 96n) | BigInt(parsedUal.kaNumber);
+      if (parsedUal.ual !== row.kaUal || packedKaId !== BigInt(row.kaId)) {
+        throw new Error(`${label}.kaUal does not canonically encode kaId`);
+      }
+    } catch (cause) {
+      fail(
+        'catalog-inventory-completeness-input',
+        `${label} is not exact canonical digest evidence`,
+        cause,
+      );
+    }
+    return row;
+  });
+  rows.sort((left, right) => compareAuthorCatalogKaIdsV1(left.kaId, right.kaId));
+  for (let index = 1; index < rows.length; index += 1) {
+    if (rows[index - 1]!.kaId === rows[index]!.kaId) {
+      fail(
+        'catalog-inventory-completeness-duplicate',
+        `applied inventory digest rows contain duplicate kaId ${rows[index]!.kaId}`,
+      );
+    }
   }
-  return ethers.hexlify(hasher.digest()) as Digest32V1;
+  return Object.freeze(rows);
 }
 
 function encodeU64(value: bigint, label: string): Uint8Array {
@@ -374,7 +477,7 @@ function sameRow(
 
 function snapshotDenseBoundedOrdinaryArray(
   value: unknown,
-  label: 'expectedRows' | 'observedRows',
+  label: string,
 ): readonly unknown[] {
   try {
     if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) {
@@ -453,6 +556,45 @@ function snapshotExactDataRecord(
     }
     const snapshot: Record<string, unknown> = Object.create(null);
     for (const key of expectedKeys) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (
+        descriptor === undefined
+        || !descriptor.enumerable
+        || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      ) {
+        fail(
+          'catalog-inventory-completeness-input',
+          `${label}.${key} must be an enumerable data property`,
+        );
+      }
+      snapshot[key] = descriptor.value;
+    }
+    return Object.freeze(snapshot);
+  } catch (cause) {
+    if (cause instanceof Rfc64PublicCatalogInventoryCompletenessErrorV1) throw cause;
+    fail(
+      'catalog-inventory-completeness-input',
+      `${label} could not be snapshotted exactly`,
+      cause,
+    );
+  }
+}
+
+/**
+ * Snapshot only the fields committed by a projection. Richer product evidence
+ * may carry additional data, but it is neither enumerated nor read here.
+ */
+function snapshotRequiredDataRecord(
+  value: unknown,
+  requiredKeys: readonly string[],
+  label: string,
+): Readonly<Record<string, unknown>> {
+  try {
+    if (!isPlainRecord(value)) {
+      fail('catalog-inventory-completeness-input', `${label} must be a plain object`);
+    }
+    const snapshot: Record<string, unknown> = Object.create(null);
+    for (const key of requiredKeys) {
       const descriptor = Object.getOwnPropertyDescriptor(value, key);
       if (
         descriptor === undefined

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -53,7 +53,6 @@ import {
   type SignedAuthorCatalogIssuerDelegationEnvelopeV1,
   type VerifiedCatalogSealBindingSnapshotV1,
 } from '@origintrail-official/dkg-core';
-import { sha256 } from '@noble/hashes/sha2.js';
 import {
   quadsToNQuads,
   readExactGraphPaged,
@@ -75,6 +74,7 @@ import type {
   Rfc64InventoryV1OperationsV1,
 } from './inventory-v1/index.js';
 import {
+  computeRfc64AppliedInventoryDigestV1,
   verifyRfc64PublicCatalogInventoryCompletenessV1,
   type Rfc64PublicCatalogInventoryEvidenceRowV1,
 } from './public-catalog-inventory-completeness-v1.js';
@@ -92,8 +92,6 @@ import type {
 } from './public-catalog-transport-v1.js';
 
 const UTF8 = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
-const UTF8_ENCODER = new TextEncoder();
-const APPLIED_INVENTORY_DIGEST_DOMAIN_V1 = 'dkg-rfc64-applied-inventory-v1\n';
 
 export interface Rfc64PublicCatalogNativeReceiverOptionsV1 {
   /** Fetch-only capability; lifecycle ownership remains with the catalog service. */
@@ -1293,48 +1291,6 @@ async function activateExactPublicProjection(
       activatedTripleCount: expectedTripleCount,
     }),
   };
-}
-
-export interface Rfc64AppliedInventoryDigestRowV1 {
-  readonly catalogRowDigest: Digest32V1;
-  readonly contentDigest: Digest32V1;
-  readonly sealDigest: Digest32V1;
-  readonly kaUal: string;
-  readonly activatedTripleCount: number;
-}
-
-/** Compute an applied inventory commitment from exact semantic post-read evidence. */
-export function computeRfc64AppliedInventoryDigestV1(input: {
-  readonly catalogScopeDigest: Digest32V1;
-  readonly rows: readonly Rfc64AppliedInventoryDigestRowV1[];
-}): Digest32V1 {
-  const hasher = sha256.create();
-  hasher.update(UTF8_ENCODER.encode(APPLIED_INVENTORY_DIGEST_DOMAIN_V1));
-  hasher.update(ethers.getBytes(input.catalogScopeDigest));
-  hasher.update(encodeU64(input.rows.length, 'inventory row count'));
-  for (const row of [...input.rows].sort((left, right) => left.kaUal.localeCompare(right.kaUal))) {
-    hasher.update(ethers.getBytes(row.catalogRowDigest));
-    hasher.update(ethers.getBytes(row.contentDigest));
-    hasher.update(ethers.getBytes(row.sealDigest));
-    const ual = UTF8_ENCODER.encode(row.kaUal);
-    hasher.update(encodeU64(ual.byteLength, 'KA UAL byte length'));
-    hasher.update(ual);
-    hasher.update(encodeU64(row.activatedTripleCount, 'activated triple count'));
-  }
-  return ethers.hexlify(hasher.digest()) as Digest32V1;
-}
-
-function encodeU64(value: number, label: string): Uint8Array {
-  if (!Number.isSafeInteger(value) || value < 0) {
-    fail('catalog-native-receiver-activation', `${label} is not a safe unsigned integer`);
-  }
-  const result = new Uint8Array(8);
-  let remaining = BigInt(value);
-  for (let index = result.length - 1; index >= 0; index -= 1) {
-    result[index] = Number(remaining & 0xffn);
-    remaining >>= 8n;
-  }
-  return result;
 }
 
 /**

--- a/packages/agent/test/rfc64-applied-inventory-digest-public-api.typecheck.ts
+++ b/packages/agent/test/rfc64-applied-inventory-digest-public-api.typecheck.ts
@@ -1,0 +1,25 @@
+import {
+  computeRfc64AppliedInventoryDigestV1,
+  type ComputeRfc64AppliedInventoryDigestInputV1,
+  type Rfc64AppliedInventoryDigestRowV1,
+} from '@origintrail-official/dkg-agent';
+import type { Digest32V1, KaIdV1 } from '@origintrail-official/dkg-core';
+
+declare const digest: Digest32V1;
+declare const kaId: KaIdV1;
+
+const row: Rfc64AppliedInventoryDigestRowV1 = {
+  kaId,
+  catalogRowDigest: digest,
+  contentDigest: digest,
+  sealDigest: digest,
+  kaUal: 'did:dkg:otp:20430/0x1111111111111111111111111111111111111111/2',
+  activatedTripleCount: 1,
+};
+const input: ComputeRfc64AppliedInventoryDigestInputV1 = {
+  catalogScopeDigest: digest,
+  rows: [row],
+};
+const result: Digest32V1 = computeRfc64AppliedInventoryDigestV1(input);
+
+void result;

--- a/packages/agent/test/rfc64-public-catalog-inventory-completeness-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-inventory-completeness-v1.test.ts
@@ -9,8 +9,8 @@ import {
   type KaIdV1,
 } from '@origintrail-official/dkg-core';
 
-import { computeRfc64AppliedInventoryDigestV1 } from '../src/rfc64/public-catalog-native-receiver-v1.js';
 import {
+  computeRfc64AppliedInventoryDigestV1,
   Rfc64PublicCatalogInventoryCompletenessErrorV1,
   verifyRfc64PublicCatalogInventoryCompletenessV1,
   type Rfc64PublicCatalogInventoryEvidenceRowV1,
@@ -59,7 +59,13 @@ describe('RFC-64 public catalog bounded inventory completeness', () => {
     expect(repeated).toEqual(evidence);
   });
 
-  it('preserves the exact Gate-1 digest framing for a one-row set', () => {
+  it('preserves the exact Gate-1 empty and one-row digest vectors', () => {
+    const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(SCOPE);
+    expect(computeRfc64AppliedInventoryDigestV1({
+      catalogScopeDigest,
+      rows: [],
+    })).toBe('0xcd36c729c972b50de1b2e562fa7e2200513d8ba282af29ebf4e403a806605aee');
+
     const only = row(7);
     const evidence = verifyRfc64PublicCatalogInventoryCompletenessV1({
       catalogScope: SCOPE,
@@ -67,16 +73,31 @@ describe('RFC-64 public catalog bounded inventory completeness', () => {
       expectedRows: [only],
       observedRows: [only],
     });
-    expect(evidence.inventoryDigest).toBe(computeRfc64AppliedInventoryDigestV1({
+    const recomputed = computeRfc64AppliedInventoryDigestV1({
+      catalogScopeDigest,
+      rows: [only],
+    });
+    expect(recomputed).toBe('0x6b258dc6f104ad042aec38da7837d9ba53f292af96eecd70f4e71dfb9a53e2f2');
+    expect(evidence.inventoryDigest).toBe(recomputed);
+  });
+
+  it('uses numeric KA-ID order for 2 vs 10 and matches the completeness digest', () => {
+    const two = row(2);
+    const ten = row(10);
+    const evidence = verifyRfc64PublicCatalogInventoryCompletenessV1({
+      catalogScope: SCOPE,
+      expectedTotalRows: '2' as CountV1,
+      expectedRows: [two, ten],
+      observedRows: [ten, two],
+    });
+    const recomputed = computeRfc64AppliedInventoryDigestV1({
       catalogScopeDigest: computeAuthorCatalogScopeDigestV1(SCOPE),
-      rows: [{
-        catalogRowDigest: only.catalogRowDigest,
-        contentDigest: only.contentDigest,
-        sealDigest: only.sealDigest,
-        kaUal: only.kaUal,
-        activatedTripleCount: only.activatedTripleCount,
-      }],
-    }));
+      rows: [ten, two],
+    });
+
+    expect(recomputed).toBe('0x6d273d5f5fc1acbfe6836168c7159b747fe3df549d2d5bddcd8bf409ff58ea01');
+    expect(recomputed).not.toBe('0x7fdb1bfd439ccde258f1061d728cc555337ee1764b1188cf36c519ece1d7abb5');
+    expect(recomputed).toBe(evidence.inventoryDigest);
   });
 
   it.each([

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -45,10 +45,10 @@ import {
   produceSparseAuthorCatalogSuccessorV1,
 } from '../src/rfc64/author-catalog-producer.js';
 import {
-  computeRfc64AppliedInventoryDigestV1,
   Rfc64PublicCatalogNativeReceiverV1,
 } from '../src/rfc64/public-catalog-native-receiver-v1.js';
 import {
+  computeRfc64AppliedInventoryDigestV1,
   verifyRfc64PublicCatalogInventoryCompletenessV1,
 } from '../src/rfc64/public-catalog-inventory-completeness-v1.js';
 import {
@@ -171,6 +171,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
           deriveAuthorCatalogScopeFromHeadV1(fixture.successor.head.payload),
         ),
         rows: [{
+          kaId: fixture.rowBundle.row.kaId,
           catalogRowDigest: expectedRowDigest,
           contentDigest: fixture.rowBundle.row.projectionDigest,
           sealDigest: fixture.rowBundle.row.sealDigest,
@@ -279,14 +280,19 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       expectedRows,
       observedRows: expectedRows,
     });
+    const independentlyRecomputedDigest = computeRfc64AppliedInventoryDigestV1({
+      catalogScopeDigest: fixture.scopeDigest,
+      rows: [...evidence.rows].reverse(),
+    });
 
     expect(evidence).toMatchObject({
-      inventoryDigest: expected.inventoryDigest,
+      inventoryDigest: independentlyRecomputedDigest,
       catalogHeadDigest: fixture.multiAssetSuccessor.head.objectDigest,
       inventoryRowCount: 2,
       activatedTripleCount: 4,
       appliedHeadStatus: 'applied',
     });
+    expect(independentlyRecomputedDigest).toBe(expected.inventoryDigest);
     expect(evidence.rows.map((row) => ({
       kaId: row.kaId,
       kaUal: row.kaUal,


### PR DESCRIPTION
Stacked on #1818. This resolves the multi-row digest-ordering feedback without touching integration/rfc64-devnet or main.\n\nChanges:\n- one canonical applied-inventory digest implementation\n- mathematical KA-ID ordering shared by receiver and completeness verification\n- preserve empty and one-row vectors\n- expose and test the package-root API\n- add the /2 versus /10 numeric-order regression\n\nEvidence:\n- completeness: 13/13\n- combined receiver/completeness: 32/32\n- real multi-row receiver regression passed\n- agent build, type tests, and package-root tests passed\n- clean one-commit diff from bffd3d5437200ca3b19c51a3348d14a49fc07b12\n\nGate 2 is not claimed passed by this PR alone.