### PR TITLE
fix(agent): roll back failed RFC-64 transitions

### DIFF
--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -17,6 +17,7 @@ import {
   AUTHOR_SCHEME_VERSION_V1,
   AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
   AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+  DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1,
   MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1,
   ZERO_DIGEST32_V1,
   assertAuthorCatalogHeadScopeBindingV1,
@@ -62,7 +63,9 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import {
   quadsToNQuads,
   readExactGraphPaged,
+  readExactGraphPagedWithDiscoveredCount,
   tryReplaceGraphAndSubjectAtomically,
+  type Quad,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
@@ -99,6 +102,13 @@ import type {
 const UTF8 = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
 const UTF8_ENCODER = new TextEncoder();
 const APPLIED_INVENTORY_DIGEST_DOMAIN_V1 = 'dkg-rfc64-applied-inventory-v1\n';
+const MAX_TRANSITION_JOURNAL_ENTRIES_V1 = MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 * 2;
+const MAX_TRANSITION_GRAPH_QUADS_V1 =
+  DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1.maxPublicTriples;
+// Includes the graph IRI repeated on every materialized N-Quad, so it must be
+// wider than the verified projection-byte ceiling while remaining finite.
+const MAX_TRANSITION_GRAPH_NQUADS_BYTES_V1 = 256 * 1024 * 1024;
+const MAX_TRANSITION_SEAL_SUBJECT_ROWS_V1 = 15;
 
 export interface Rfc64PublicCatalogNativeReceiverOptionsV1 {
   /** Fetch-only capability; lifecycle ownership remains with the catalog service. */
@@ -750,33 +760,47 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       fail('catalog-native-receiver-catalog', 'verified catalog objects could not be staged', cause);
     }
 
+    const transitionJournal = await snapshotSemanticTransitionV1(
+      this.options.store,
+      [
+        ...plannedRemovals.map((removal) => transitionLocationFromRemoval(removal)),
+        ...preparedRows.map((prepared) => transitionLocationFromTarget(
+          head,
+          prepared.row,
+          prepared.sealBinding,
+        )),
+      ],
+    );
     const removedRows: Rfc64PublicCatalogNativeRemovedRowEvidenceV1[] = [];
-    for (const removal of plannedRemovals) {
-      throwIfAborted(signal);
-      await deactivateExactOwnedPublicProjection(this.options.store, removal);
-      removedRows.push(removal);
-    }
-
     const activatedRows: Rfc64PublicCatalogNativeActivatedRowEvidenceV1[] = [];
-    for (const prepared of preparedRows) {
-      throwIfAborted(signal);
-      const activation = await activateExactPublicProjection(
-        this.options.store,
-        head,
-        prepared.row,
-        prepared.projectionMetadata.kaUal,
-        prepared.projectionBytes,
-        Number(prepared.projectionMetadata.publicTripleCount),
-        prepared.sealBinding,
-      );
-      activatedRows.push(Object.freeze({
-        ...activation.evidence,
-        swmGraph: activation.swmGraph,
-        authorship: prepared.authorship,
-      }));
-    }
-    let completion: ReturnType<typeof verifyRfc64PublicCatalogInventoryCompletenessV1>;
+    let completion!: ReturnType<typeof verifyRfc64PublicCatalogInventoryCompletenessV1>;
+    let activatedTripleCount = 0;
+    let semanticMutationAttempted = false;
     try {
+      for (const removal of plannedRemovals) {
+        throwIfAborted(signal);
+        semanticMutationAttempted = true;
+        await deactivateExactOwnedPublicProjection(this.options.store, removal);
+        removedRows.push(removal);
+      }
+      for (const prepared of preparedRows) {
+        throwIfAborted(signal);
+        semanticMutationAttempted = true;
+        const activation = await activateExactPublicProjection(
+          this.options.store,
+          head,
+          prepared.row,
+          prepared.projectionMetadata.kaUal,
+          prepared.projectionBytes,
+          Number(prepared.projectionMetadata.publicTripleCount),
+          prepared.sealBinding,
+        );
+        activatedRows.push(Object.freeze({
+          ...activation.evidence,
+          swmGraph: activation.swmGraph,
+          authorship: prepared.authorship,
+        }));
+      }
       completion = verifyRfc64PublicCatalogInventoryCompletenessV1({
         catalogScope: trustedCatalogScope,
         expectedTotalRows: head.payload.totalRows as CountV1,
@@ -791,19 +815,35 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
           activatedTripleCount: row.activatedTripleCount,
         })),
       });
+      activatedTripleCount = activatedRows.reduce(
+        (total, row) => total + row.activatedTripleCount,
+        0,
+      );
+      if (!Number.isSafeInteger(activatedTripleCount)) {
+        fail(
+          'catalog-native-receiver-activation',
+          'total activated triple count is not a safe integer',
+        );
+      }
     } catch (cause) {
+      if (semanticMutationAttempted) {
+        try {
+          await restoreSemanticTransitionV1(this.options.store, transitionJournal);
+        } catch (rollbackCause) {
+          fail(
+            'catalog-native-receiver-activation',
+            'semantic transition failed and its exact predecessor rollback also failed',
+            new AggregateError([cause, rollbackCause]),
+          );
+        }
+      }
+      if (signal?.aborted && cause === signal.reason) throw cause;
+      if (cause instanceof Rfc64PublicCatalogNativeReceiverErrorV1) throw cause;
       fail(
         'catalog-native-receiver-activation',
-        'semantic post-reads do not equal the exact signed inventory',
+        'semantic transition failed after mutation began',
         cause,
       );
-    }
-    const activatedTripleCount = activatedRows.reduce(
-      (total, row) => total + row.activatedTripleCount,
-      0,
-    );
-    if (!Number.isSafeInteger(activatedTripleCount)) {
-      fail('catalog-native-receiver-activation', 'total activated triple count is not a safe integer');
     }
 
     let appliedHeadStatus: 'applied' | 'existing';
@@ -1402,6 +1442,175 @@ function planOwnedRowRemoval(
     sealMetaGraph: placement.metaGraph,
     sealSubject: placement.subject,
   });
+}
+
+interface Rfc64SemanticTransitionLocationV1 {
+  readonly swmGraph: string;
+  readonly sealMetaGraph: string;
+  readonly sealSubject: string;
+}
+
+interface Rfc64SemanticTransitionPreimageV1
+  extends Rfc64SemanticTransitionLocationV1 {
+  readonly graphQuads: readonly Readonly<Quad>[];
+  readonly sealQuads: readonly Readonly<Quad>[];
+}
+
+function transitionLocationFromRemoval(
+  removal: Readonly<Rfc64PublicCatalogNativeRemovedRowEvidenceV1>,
+): Readonly<Rfc64SemanticTransitionLocationV1> {
+  return Object.freeze({
+    swmGraph: removal.swmGraph,
+    sealMetaGraph: removal.sealMetaGraph,
+    sealSubject: removal.sealSubject,
+  });
+}
+
+function transitionLocationFromTarget(
+  head: SignedAuthorCatalogHeadEnvelopeV1,
+  row: Readonly<AuthorCatalogRowV1>,
+  binding: VerifiedCatalogSealBindingSnapshotV1,
+): Readonly<Rfc64SemanticTransitionLocationV1> {
+  return Object.freeze({
+    swmGraph: derivePublicSwmGraph(head.payload.contextGraphId, row.kaId),
+    sealMetaGraph: binding.placement.metaGraph,
+    sealSubject: binding.placement.subject,
+  });
+}
+
+/**
+ * Capture only the exact graph/subject pairs this verified transition may
+ * mutate. The journal is deliberately in-memory: it closes returned-failure
+ * consistency, while process-death recovery remains a Gate-4 durable protocol.
+ */
+async function snapshotSemanticTransitionV1(
+  store: TripleStore,
+  locations: readonly Readonly<Rfc64SemanticTransitionLocationV1>[],
+): Promise<readonly Readonly<Rfc64SemanticTransitionPreimageV1>[]> {
+  if (locations.length > MAX_TRANSITION_JOURNAL_ENTRIES_V1) {
+    fail(
+      'catalog-native-receiver-activation',
+      `semantic transition exceeds ${MAX_TRANSITION_JOURNAL_ENTRIES_V1} exact preimages`,
+    );
+  }
+  const journal: Rfc64SemanticTransitionPreimageV1[] = [];
+  try {
+    for (const location of locations) {
+      const graphQuads = await readExactGraphPagedWithDiscoveredCount(
+        store,
+        location.swmGraph,
+        {
+          maxQuadCount: MAX_TRANSITION_GRAPH_QUADS_V1,
+          maxNQuadsBytes: MAX_TRANSITION_GRAPH_NQUADS_BYTES_V1,
+          outputGraph: location.swmGraph,
+          queryOptions: { source: 'rfc64-public-catalog-transition-snapshot' },
+        },
+      );
+      const sealQuads = await readExactSealSubjectRowsV1(
+        store,
+        location.sealMetaGraph,
+        location.sealSubject,
+        'rfc64-public-catalog-transition-snapshot',
+      );
+      journal.push(Object.freeze({
+        ...location,
+        graphQuads: Object.freeze(graphQuads.map((quad) => Object.freeze({ ...quad }))),
+        sealQuads,
+      }));
+    }
+  } catch (cause) {
+    fail(
+      'catalog-native-receiver-activation',
+      'bounded exact semantic transition snapshot failed before mutation',
+      cause,
+    );
+  }
+  return Object.freeze(journal);
+}
+
+async function restoreSemanticTransitionV1(
+  store: TripleStore,
+  journal: readonly Readonly<Rfc64SemanticTransitionPreimageV1>[],
+): Promise<void> {
+  for (let index = journal.length - 1; index >= 0; index -= 1) {
+    const preimage = journal[index];
+    if (preimage === undefined) continue;
+    const restored = await tryReplaceGraphAndSubjectAtomically(
+      store,
+      preimage.swmGraph,
+      preimage.graphQuads.map((quad) => ({ ...quad })),
+      preimage.sealMetaGraph,
+      preimage.sealSubject,
+      preimage.sealQuads.map((quad) => ({ ...quad })),
+      { source: 'rfc64-public-catalog-transition-rollback' },
+    );
+    if (!restored) {
+      throw new Error('store lacks atomic graph/subject replacement during semantic rollback');
+    }
+    await assertExactSemanticTransitionPreimageV1(store, preimage);
+  }
+}
+
+async function assertExactSemanticTransitionPreimageV1(
+  store: TripleStore,
+  preimage: Readonly<Rfc64SemanticTransitionPreimageV1>,
+): Promise<void> {
+  const [graphQuads, sealQuads] = await Promise.all([
+    readExactGraphPaged(store, preimage.swmGraph, {
+      expectedQuadCount: preimage.graphQuads.length,
+      maxQuadCount: MAX_TRANSITION_GRAPH_QUADS_V1,
+      maxNQuadsBytes: MAX_TRANSITION_GRAPH_NQUADS_BYTES_V1,
+      outputGraph: preimage.swmGraph,
+      queryOptions: { source: 'rfc64-public-catalog-transition-rollback-post-read' },
+    }),
+    readExactSealSubjectRowsV1(
+      store,
+      preimage.sealMetaGraph,
+      preimage.sealSubject,
+      'rfc64-public-catalog-transition-rollback-post-read',
+    ),
+  ]);
+  if (
+    canonicalQuadSetV1(graphQuads) !== canonicalQuadSetV1(preimage.graphQuads)
+    || canonicalQuadSetV1(sealQuads) !== canonicalQuadSetV1(preimage.sealQuads)
+  ) {
+    throw new Error('semantic transition rollback post-read differs from its exact preimage');
+  }
+}
+
+async function readExactSealSubjectRowsV1(
+  store: TripleStore,
+  metaGraph: string,
+  subject: string,
+  source: string,
+): Promise<readonly Readonly<Quad>[]> {
+  const result = await store.query(
+    `SELECT ?p ?o WHERE { GRAPH <${metaGraph}> { <${subject}> ?p ?o } } `
+      + `ORDER BY ?p ?o LIMIT ${MAX_TRANSITION_SEAL_SUBJECT_ROWS_V1 + 1}`,
+    { source, maxResponseBytes: 64 * 1024 },
+  );
+  if (
+    result.type !== 'bindings'
+    || result.bindings.length > MAX_TRANSITION_SEAL_SUBJECT_ROWS_V1
+  ) {
+    throw new Error('exact transition seal subject exceeds its bounded row contract');
+  }
+  const quads = result.bindings.map((row) => {
+    if (typeof row.p !== 'string' || typeof row.o !== 'string') {
+      throw new Error('exact transition seal subject row is incomplete');
+    }
+    return Object.freeze({
+      subject,
+      predicate: row.p,
+      object: row.o,
+      graph: metaGraph,
+    });
+  });
+  return Object.freeze(quads);
+}
+
+function canonicalQuadSetV1(quads: readonly Readonly<Quad>[]): string {
+  return quadsToNQuads([...quads].sort(compareQuads));
 }
 
 async function deactivateExactOwnedPublicProjection(

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -81,6 +81,7 @@ const UAL = `did:dkg:${NETWORK_ID}/${AUTHOR}/${KA_NUMBER}`;
 const SECOND_KA_NUMBER = 8n;
 const SECOND_KA_ID = ((BigInt(AUTHOR) << 96n) | SECOND_KA_NUMBER).toString();
 const SECOND_UAL = `did:dkg:${NETWORK_ID}/${AUTHOR}/${SECOND_KA_NUMBER}`;
+const THIRD_KA_NUMBER = 9n;
 const PROJECTION =
   '<https://example.org/alice> <https://schema.org/age> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
   + '<https://example.org/alice> <https://schema.org/name> "Alice" .\n';
@@ -491,7 +492,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       fixture.scopeDigest,
       AUTHOR,
     )?.currentCatalogHeadDigest).toBe(fixture.multiAssetSuccessor.head.objectDigest);
-    await expect(fixture.receiverStore.hasGraph(omittedSwmGraph)).resolves.toBe(false);
+    await expect(fixture.receiverStore.hasGraph(omittedSwmGraph)).resolves.toBe(true);
 
     const restartedReceiver = fixture.createReceiver(fixture.receiverPersistence.inventory);
     const repaired = await fixture.synchronizeAny(
@@ -511,6 +512,186 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     )).toMatchObject({
       currentCatalogHeadDigest: fixture.removalSuccessor.head.objectDigest,
       inventoryRowCount: '1',
+    });
+  }, 30_000);
+
+  it('rolls back an omitted row and earlier target activations when a later target post-read fails', async () => {
+    const fixture = await setupLiveReceiver();
+    await fixture.bootstrap();
+    await fixture.synchronize();
+    await fixture.synchronizeAny(fixture.multiAssetAnnouncement);
+    await fixture.synchronizeAny(fixture.threeAssetAnnouncement);
+    const firstGraph =
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${AUTHOR}/${KA_NUMBER}`;
+    const omittedGraph =
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${AUTHOR}/${SECOND_KA_NUMBER}`;
+    const laterGraph =
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${AUTHOR}/${THIRD_KA_NUMBER}`;
+    const firstSeal = deriveCanonicalGraphScopedAuthorSealPlacementV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      assertionCoordinate: 'gate-1-object' as never,
+    });
+    const omittedSeal = deriveCanonicalGraphScopedAuthorSealPlacementV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      assertionCoordinate: 'gate-2-object' as never,
+    });
+    const laterSeal = deriveCanonicalGraphScopedAuthorSealPlacementV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      assertionCoordinate: 'gate-2-replacement-object' as never,
+    });
+    const foreignAuthor = '0x9999999999999999999999999999999999999999' as EvmAddressV1;
+    const foreignGraph =
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${foreignAuthor}/77`;
+    const foreignSeal = deriveCanonicalGraphScopedAuthorSealPlacementV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: foreignAuthor,
+      assertionCoordinate: 'transition-foreign-object' as never,
+    });
+    await fixture.receiverStore.insert([
+      {
+        subject: 'https://example.org/predecessor-only',
+        predicate: 'https://schema.org/name',
+        object: '"Exact predecessor sentinel"',
+        graph: firstGraph,
+      },
+      {
+        subject: 'https://example.org/transition-foreign',
+        predicate: 'https://schema.org/name',
+        object: '"Foreign transition sentinel"',
+        graph: foreignGraph,
+      },
+      {
+        subject: foreignSeal.subject,
+        predicate: 'https://example.org/foreignTransitionSeal',
+        object: '"owned elsewhere"',
+        graph: foreignSeal.metaGraph,
+      },
+    ]);
+    const predecessorFirst = await readExactSemanticPairForTest(
+      fixture.receiverStore,
+      firstGraph,
+      firstSeal.metaGraph,
+      firstSeal.subject,
+    );
+    const predecessorOmitted = await readExactSemanticPairForTest(
+      fixture.receiverStore,
+      omittedGraph,
+      omittedSeal.metaGraph,
+      omittedSeal.subject,
+    );
+    const predecessorLater = await readExactSemanticPairForTest(
+      fixture.receiverStore,
+      laterGraph,
+      laterSeal.metaGraph,
+      laterSeal.subject,
+    );
+    const foreignBefore = await readExactSemanticPairForTest(
+      fixture.receiverStore,
+      foreignGraph,
+      foreignSeal.metaGraph,
+      foreignSeal.subject,
+    );
+    expect(predecessorFirst.graph).toHaveLength(3);
+    const activatedGraphs: string[] = [];
+    let failLaterPostRead = true;
+    const faultStore = new Proxy(fixture.receiverStore, {
+      get(target, property) {
+        if (property === 'replaceGraphAndSubject') {
+          return async (...args: Parameters<NonNullable<TripleStore['replaceGraphAndSubject']>>) => {
+            await target.replaceGraphAndSubject!(...args);
+            if (args[1].length > 0) activatedGraphs.push(args[0]);
+          };
+        }
+        if (property === 'query') {
+          return async (...args: Parameters<TripleStore['query']>) => {
+            if (
+              failLaterPostRead
+              && args[1]?.source === 'rfc64-public-catalog-native-post-read'
+              && args[0].includes(`<${laterGraph}>`)
+            ) {
+              failLaterPostRead = false;
+              throw new Error('injected later-row exact post-read failure');
+            }
+            return target.query(...args);
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    const failed = fixture.createCasObservedReceiver(undefined, faultStore);
+
+    await expect(fixture.synchronizeAny(
+      fixture.replacementAnnouncement,
+      failed.receiver,
+    )).rejects.toMatchObject({ code: 'catalog-native-receiver-activation' });
+
+    expect(activatedGraphs.slice(0, 2)).toEqual([firstGraph, laterGraph]);
+    expect(failed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )?.currentCatalogHeadDigest).toBe(fixture.threeAssetSuccessor.head.objectDigest);
+    await expect(readExactSemanticPairForTest(
+      fixture.receiverStore,
+      firstGraph,
+      firstSeal.metaGraph,
+      firstSeal.subject,
+    )).resolves.toEqual(predecessorFirst);
+    await expect(readExactSemanticPairForTest(
+      fixture.receiverStore,
+      omittedGraph,
+      omittedSeal.metaGraph,
+      omittedSeal.subject,
+    )).resolves.toEqual(predecessorOmitted);
+    await expect(readExactSemanticPairForTest(
+      fixture.receiverStore,
+      laterGraph,
+      laterSeal.metaGraph,
+      laterSeal.subject,
+    )).resolves.toEqual(predecessorLater);
+    await expect(readExactSemanticPairForTest(
+      fixture.receiverStore,
+      foreignGraph,
+      foreignSeal.metaGraph,
+      foreignSeal.subject,
+    )).resolves.toEqual(foreignBefore);
+
+    const retried = await fixture.synchronizeAny(fixture.replacementAnnouncement);
+    expect(retried).toMatchObject({
+      catalogHeadDigest: fixture.replacementSuccessor.head.objectDigest,
+      inventoryRowCount: 2,
+      removedRowCount: 1,
+      appliedHeadStatus: 'applied',
+    });
+    await expect(fixture.receiverStore.hasGraph(firstGraph)).resolves.toBe(true);
+    await expect(fixture.receiverStore.hasGraph(omittedGraph)).resolves.toBe(false);
+    await expect(fixture.receiverStore.hasGraph(laterGraph)).resolves.toBe(true);
+    await expect(readExactSemanticPairForTest(
+      fixture.receiverStore,
+      firstGraph,
+      firstSeal.metaGraph,
+      firstSeal.subject,
+    )).resolves.not.toEqual(predecessorFirst);
+    await expect(readExactSemanticPairForTest(
+      fixture.receiverStore,
+      foreignGraph,
+      foreignSeal.metaGraph,
+      foreignSeal.subject,
+    )).resolves.toEqual(foreignBefore);
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )).toMatchObject({
+      currentCatalogHeadDigest: fixture.replacementSuccessor.head.objectDigest,
+      inventoryRowCount: '2',
     });
   }, 30_000);
 
@@ -1003,6 +1184,10 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     kaNumber: SECOND_KA_NUMBER,
     assertionCoordinate: 'gate-2-object',
   });
+  const thirdRowBundle = await buildRowBundle(signingWallet, {
+    kaNumber: THIRD_KA_NUMBER,
+    assertionCoordinate: 'gate-2-replacement-object',
+  });
   const genesis = await produceEmptyAuthorCatalogGenesisV1({
     scope,
     catalogIssuerDelegationDigest: catalogIssuerDelegation.objectDigest,
@@ -1041,6 +1226,24 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     selectedBucketId: '0' as never,
     nextRows: [rowBundle.row],
     issuedAt: '1773900001003' as never,
+    signer,
+  });
+  const threeAssetSuccessor = await produceSparseAuthorCatalogSuccessorV1({
+    previousHead: multiAssetSuccessor.head,
+    previousDirectoryPath: multiAssetSuccessor.directoryPath,
+    previousBucket: multiAssetSuccessor.bucket,
+    selectedBucketId: '0' as never,
+    nextRows: [rowBundle.row, secondRowBundle.row, thirdRowBundle.row],
+    issuedAt: '1773900001004' as never,
+    signer,
+  });
+  const replacementSuccessor = await produceSparseAuthorCatalogSuccessorV1({
+    previousHead: threeAssetSuccessor.head,
+    previousDirectoryPath: threeAssetSuccessor.directoryPath,
+    previousBucket: threeAssetSuccessor.bucket,
+    selectedBucketId: '0' as never,
+    nextRows: [rowBundle.row, thirdRowBundle.row],
+    issuedAt: '1773900001005' as never,
     signer,
   });
   const governedSuccessor = await produceSparseAuthorCatalogSuccessorV1({
@@ -1089,6 +1292,8 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       ...successor.stagedObjects,
       ...multiAssetSuccessor.stagedObjects,
       ...removalSuccessor.stagedObjects,
+      ...threeAssetSuccessor.stagedObjects,
+      ...replacementSuccessor.stagedObjects,
       ...governedSuccessor.stagedObjects,
       ...competingSuccessor.stagedObjects,
       crossLaneHead,
@@ -1102,6 +1307,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   const bundleBytesByDigest = new Map<string, Uint8Array>([
     [rowBundle.row.transfer.blobDigest, rowBundle.bundleBytes],
     [secondRowBundle.row.transfer.blobDigest, secondRowBundle.bundleBytes],
+    [thirdRowBundle.row.transfer.blobDigest, thirdRowBundle.bundleBytes],
   ]);
   const authorBundleRead = vi.fn(async (digest: Digest32V1) =>
     bundleBytesByDigest.get(digest) ?? null);
@@ -1117,6 +1323,8 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       ...successor.stagedObjects,
       ...multiAssetSuccessor.stagedObjects,
       ...removalSuccessor.stagedObjects,
+      ...threeAssetSuccessor.stagedObjects,
+      ...replacementSuccessor.stagedObjects,
       ...governedSuccessor.stagedObjects,
       ...competingSuccessor.stagedObjects,
       crossLaneHead,
@@ -1151,6 +1359,12 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   const removalHeadKeys = staged.objects.find(
     (keys) => keys.objectDigest === removalSuccessor.head.objectDigest,
   );
+  const replacementHeadKeys = staged.objects.find(
+    (keys) => keys.objectDigest === replacementSuccessor.head.objectDigest,
+  );
+  const threeAssetHeadKeys = staged.objects.find(
+    (keys) => keys.objectDigest === threeAssetSuccessor.head.objectDigest,
+  );
   const governedGenesisHeadKeys = staged.objects.find(
     (keys) => keys.objectDigest === governedGenesis.head.objectDigest,
   );
@@ -1176,6 +1390,8 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   if (genesisHeadKeys === undefined) throw new Error('genesis head was not staged');
   if (multiAssetHeadKeys === undefined) throw new Error('multi-asset successor head was not staged');
   if (removalHeadKeys === undefined) throw new Error('removal successor head was not staged');
+  if (replacementHeadKeys === undefined) throw new Error('replacement successor head was not staged');
+  if (threeAssetHeadKeys === undefined) throw new Error('three-asset successor head was not staged');
   if (governedGenesisHeadKeys === undefined) throw new Error('governed genesis head was not staged');
   if (governedSuccessorHeadKeys === undefined) throw new Error('governed successor head was not staged');
   if (invalidGenesisHeadKeys === undefined) throw new Error('invalid genesis head was not staged');
@@ -1261,6 +1477,18 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     catalogVersion: removalSuccessor.head.payload.version,
     catalogHeadObjectDigest: removalHeadKeys.objectDigest,
     signatureVariantDigest: removalHeadKeys.signatureVariantDigest,
+  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
+  const replacementAnnouncement = Object.freeze({
+    ...announcement,
+    catalogVersion: replacementSuccessor.head.payload.version,
+    catalogHeadObjectDigest: replacementHeadKeys.objectDigest,
+    signatureVariantDigest: replacementHeadKeys.signatureVariantDigest,
+  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
+  const threeAssetAnnouncement = Object.freeze({
+    ...announcement,
+    catalogVersion: threeAssetSuccessor.head.payload.version,
+    catalogHeadObjectDigest: threeAssetHeadKeys.objectDigest,
+    signatureVariantDigest: threeAssetHeadKeys.signatureVariantDigest,
   }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
   const competingAnnouncement = Object.freeze({
     ...announcement,
@@ -1390,6 +1618,8 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     multiAssetSuccessor,
     removalAnnouncement,
     removalSuccessor,
+    replacementAnnouncement,
+    replacementSuccessor,
     receiverDirectory: receiverOpened.directory,
     receiverHeadFetch,
     receiverObjectFetch,
@@ -1397,6 +1627,9 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     receiverStore,
     rowBundle,
     secondRowBundle,
+    thirdRowBundle,
+    threeAssetAnnouncement,
+    threeAssetSuccessor,
     scope,
     scopeDigest,
     successor,
@@ -1434,6 +1667,33 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       signal,
     ),
   };
+}
+
+async function readExactSemanticPairForTest(
+  store: TripleStore,
+  graph: string,
+  sealMetaGraph: string,
+  sealSubject: string,
+): Promise<{
+  readonly graph: readonly Readonly<Record<string, string>>[];
+  readonly seal: readonly Readonly<Record<string, string>>[];
+}> {
+  const [graphResult, sealResult] = await Promise.all([
+    store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${graph}> { ?s ?p ?o } } ORDER BY ?s ?p ?o`,
+    ),
+    store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${sealMetaGraph}> { `
+        + `<${sealSubject}> ?p ?o } } ORDER BY ?p ?o`,
+    ),
+  ]);
+  if (graphResult.type !== 'bindings' || sealResult.type !== 'bindings') {
+    throw new Error('exact semantic pair test read did not return bindings');
+  }
+  return Object.freeze({
+    graph: Object.freeze(graphResult.bindings.map((row) => Object.freeze({ ...row }))),
+    seal: Object.freeze(sealResult.bindings.map((row) => Object.freeze({ ...row }))),
+  });
 }
 
 async function buildDirectCatalogIssuerDelegation(options: {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -86,6 +86,7 @@ export {
   quadToNQuad,
   quadsToNQuads,
   readExactGraphPaged,
+  readExactGraphPagedWithDiscoveredCount,
   type ExactGraphReadErrorCode,
   type ExactGraphReadErrorKind,
   type ReadExactGraphPagedOptions,


### PR DESCRIPTION
Stacked on #1825. This resolves PR #1818s synchronous multi-row partial-activation blocker without touching integration/rfc64-devnet or main.\n\nChanges:\n- capture bounded preimages only for the exact SWM graphs and exact author-seal subjects touched by a transition\n- restore mutations in reverse order on synchronous removal, activation, post-read, completeness, or count failure\n- verify each restored preimage exactly before propagating failure\n- preserve typed errors and abort behavior; applied-head CAS remains withheld\n\nRegression proof:\n- construct a three-row predecessor and two-row successor with one omitted asset\n- inject a row-two post-read failure after row one mutates\n- prove no CAS and exact restoration of row-one, omitted, and later graph plus seal state\n- prove foreign scope remains unchanged\n- clean retry converges\n\nEvidence:\n- focused native: 24/24\n- adjacent RFC-64: 36/36\n- storage and agent builds passed\n- type and package-root checks passed\n- clean two-commit diff\n\nBoundary: this closes returned-failure consistency. Durable SIGKILL recovery remains Gate 4 and is not claimed here.