### PR TITLE
feat(agent): authorize RFC-64 catalog policy cells

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -22,6 +22,7 @@
     "./dist/rfc64/inventory-v1/statements.js": "./dist/rfc64/inventory-v1/statements.js",
     "./dist/rfc64/control-object-store-v1-internal.js": null,
     "./dist/rfc64/control-object-store-v1.js": null,
+    "./dist/rfc64/catalog-access-policy-v1.js": null,
     "./dist/rfc64/durable-file-store-v1.js": null,
     "./dist/rfc64/ka-bundle-store-v1-internal.js": null,
     "./dist/rfc64/ka-bundle-store-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -65,6 +65,7 @@ const publicRfc64Modules = [
   'inventory-v1/statements.js',
 ];
 const blockedRfc64Modules = [
+  'catalog-access-policy-v1.js',
   'control-object-store-v1-internal.js',
   'control-object-store-v1.js',
   'durable-file-store-v1.js',

--- a/packages/agent/src/rfc64/catalog-access-policy-v1.ts
+++ b/packages/agent/src/rfc64/catalog-access-policy-v1.ts
@@ -17,6 +17,8 @@
 
 import {
   assertCanonicalDigest,
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
   canonicalizeContextGraphPolicyPayloadV1,
   canonicalizeMemberRosterPayloadV1,
   parseCanonicalContextGraphPolicyPayloadV1,
@@ -171,22 +173,33 @@ export class Rfc64CatalogAccessPolicyRegistryV1 {
   readonly authorize = async (
     input: Rfc64CatalogAccessAuthorizationInputV1,
   ): Promise<Rfc64CatalogAccessAuthorizationV1 | null> => {
-    const held = this.#byKey.get(policyKey(input.networkId, input.contextGraphId));
-    if (held === undefined || held.policyDigest !== input.policyDigest) return null;
+    let boundary: Readonly<Rfc64CatalogAccessAuthorizationInputV1>;
+    try {
+      boundary = snapshotAuthorizationInput(input);
+    } catch {
+      return null;
+    }
+
+    const key = policyKey(boundary.networkId, boundary.contextGraphId);
+    const held = this.#byKey.get(key);
+    if (held === undefined || held.policyDigest !== boundary.policyDigest) return null;
     const descriptor = classifyRfc64PolicyCellV1(held.policy);
     if (descriptor.catalogDisclosure === 'open-authenticated') {
       return authorization(held);
     }
     if (held.members === null) return null;
 
-    const remotePeerId = snapshotPeerId(input.remotePeerId);
-    const remoteAgentAddress = await this.#resolveRemoteMemberAddress(remotePeerId);
+    const remoteAgentAddress = await this.#resolveRemoteMemberAddress(boundary.remotePeerId);
     if (remoteAgentAddress === null) return null;
+    // A future verified transition path may replace the held snapshot while the
+    // authenticated peer binding is being resolved. Never authorize against a
+    // snapshot that stopped being current during that await.
+    if (this.#byKey.get(key) !== held) return null;
     const localMember = held.members.get(this.#localAgentAddress);
     const remoteMember = held.members.get(remoteAgentAddress);
     if (localMember === undefined || remoteMember === undefined) return null;
 
-    const servingMember = servingSide(input.operation) === 'local'
+    const servingMember = servingSide(boundary.operation) === 'local'
       ? localMember
       : remoteMember;
     if (!servingMember.roles.includes('provider')) return null;
@@ -200,16 +213,20 @@ export class Rfc64CatalogAccessPolicyRegistryV1 {
     readonly policyDigest: Digest32V1;
     readonly authorAddress: EvmAddressV1;
   }): boolean {
-    const held = this.#byKey.get(policyKey(input.networkId, input.contextGraphId));
-    if (held === undefined || held.policyDigest !== input.policyDigest) return false;
-    let authorAddress: EvmAddressV1;
     try {
-      authorAddress = snapshotAgentAddress(input.authorAddress, 'authorAddress');
+      const networkId = input.networkId;
+      const contextGraphId = input.contextGraphId;
+      const policyDigest = snapshotDigest(input.policyDigest, 'policyDigest');
+      const authorAddress = snapshotAgentAddress(input.authorAddress, 'authorAddress');
+      assertNetworkIdV1(networkId);
+      assertContextGraphIdV1(contextGraphId);
+      const held = this.#byKey.get(policyKey(networkId, contextGraphId));
+      if (held === undefined || held.policyDigest !== policyDigest) return false;
+      return held.policy.accessPolicy === 0
+        || held.members?.has(authorAddress) === true;
     } catch {
       return false;
     }
-    return held.policy.accessPolicy === 0
-      || held.members?.has(authorAddress) === true;
   }
 
   async #resolveRemoteMemberAddress(remotePeerId: string): Promise<EvmAddressV1 | null> {
@@ -245,6 +262,44 @@ function servingSide(operation: Rfc64CatalogAccessOperationV1): 'local' | 'remot
     case 'catalog-object-fetch-outbound':
     case 'ka-bundle-fetch-outbound':
       return 'remote';
+  }
+}
+
+function snapshotAuthorizationInput(
+  input: Rfc64CatalogAccessAuthorizationInputV1,
+): Readonly<Rfc64CatalogAccessAuthorizationInputV1> {
+  if (input === null || typeof input !== 'object') {
+    throw new TypeError('catalog access authorization input must be an object');
+  }
+  const operation = snapshotOperation(input.operation);
+  const remotePeerId = snapshotPeerId(input.remotePeerId);
+  const networkId = input.networkId;
+  const contextGraphId = input.contextGraphId;
+  assertNetworkIdV1(networkId);
+  assertContextGraphIdV1(contextGraphId);
+  const policyDigest = snapshotDigest(input.policyDigest, 'policyDigest');
+  return Object.freeze({
+    operation,
+    remotePeerId,
+    networkId,
+    contextGraphId,
+    policyDigest,
+  });
+}
+
+function snapshotOperation(input: unknown): Rfc64CatalogAccessOperationV1 {
+  switch (input) {
+    case 'announce-outbound':
+    case 'announce-inbound':
+    case 'fetch-outbound':
+    case 'fetch-inbound':
+    case 'catalog-object-fetch-outbound':
+    case 'catalog-object-fetch-inbound':
+    case 'ka-bundle-fetch-outbound':
+    case 'ka-bundle-fetch-inbound':
+      return input;
+    default:
+      throw new TypeError('operation must be a supported RFC-64 catalog access operation');
   }
 }
 

--- a/packages/agent/src/rfc64/catalog-access-policy-v1.ts
+++ b/packages/agent/src/rfc64/catalog-access-policy-v1.ts
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Accepted-current D26 access decisions for the RFC-64 catalog data plane.
+ *
+ * This registry is deliberately an authorization consumer, not an authority
+ * verifier. Callers may insert only a policy/roster snapshot that has already
+ * passed the RFC-64 administrative/finality boundary. The registry snapshots
+ * those values once, binds a private roster to the exact policy digest, and
+ * refuses in-place policy replacement so a stale caller cannot roll current
+ * authorization backwards.
+ *
+ * SWM read, submission, discovery, and payload transfer follow accessPolicy.
+ * publishPolicy is retained in the accepted policy snapshot but never consulted
+ * here: it governs VM transaction admission, not SWM synchronization.
+ */
+
+import {
+  assertCanonicalDigest,
+  canonicalizeContextGraphPolicyPayloadV1,
+  canonicalizeMemberRosterPayloadV1,
+  parseCanonicalContextGraphPolicyPayloadV1,
+  parseCanonicalMemberRosterPayloadV1,
+  type ContextGraphIdV1,
+  type ContextGraphPolicyV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type MemberRosterEntryV1,
+  type MemberRosterV1,
+  type NetworkIdV1,
+} from '@origintrail-official/dkg-core';
+
+import { classifyRfc64PolicyCellV1 } from './policy-cell-v1.js';
+
+export type Rfc64CatalogAccessOperationV1 =
+  | 'announce-outbound'
+  | 'announce-inbound'
+  | 'fetch-outbound'
+  | 'fetch-inbound'
+  | 'catalog-object-fetch-outbound'
+  | 'catalog-object-fetch-inbound'
+  | 'ka-bundle-fetch-outbound'
+  | 'ka-bundle-fetch-inbound';
+
+export interface Rfc64CatalogAccessAuthorizationInputV1 {
+  readonly operation: Rfc64CatalogAccessOperationV1;
+  readonly remotePeerId: string;
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly policyDigest: Digest32V1;
+}
+
+export interface Rfc64CatalogAccessAuthorizationV1 {
+  readonly accessPolicy: ContextGraphPolicyV1['accessPolicy'];
+  readonly policyDigest: Digest32V1;
+}
+
+export interface AcceptRfc64CatalogAccessSnapshotInputV1 {
+  readonly policy: ContextGraphPolicyV1;
+  readonly policyDigest: Digest32V1;
+  readonly roster?: MemberRosterV1 | null;
+}
+
+export interface AcceptedRfc64CatalogAccessSnapshotV1 {
+  readonly policy: Readonly<ContextGraphPolicyV1>;
+  readonly policyDigest: Digest32V1;
+  readonly roster: Readonly<MemberRosterV1> | null;
+}
+
+export interface Rfc64CatalogAccessPolicyRegistryOptionsV1 {
+  readonly localAgentAddress: EvmAddressV1;
+  /** Exact authenticated libp2p-peer to agent-wallet binding. */
+  readonly resolveRemoteAgentAddress: (
+    remotePeerId: string,
+  ) => Promise<EvmAddressV1 | null>;
+}
+
+interface HeldCatalogAccessSnapshotV1 extends AcceptedRfc64CatalogAccessSnapshotV1 {
+  readonly members: ReadonlyMap<EvmAddressV1, Readonly<MemberRosterEntryV1>> | null;
+}
+
+const EVM_ADDRESS = /^0x[0-9a-f]{40}$/u;
+const ZERO_ADDRESS = `0x${'0'.repeat(40)}`;
+const MAX_PEER_ID_BYTES = 256;
+const UTF8 = new TextEncoder();
+
+/**
+ * Fail-closed current-policy registry shared by announcement, catalog-object,
+ * and opaque-bundle transports.
+ */
+export class Rfc64CatalogAccessPolicyRegistryV1 {
+  readonly #localAgentAddress: EvmAddressV1;
+  readonly #resolveRemoteAgentAddress: (
+    remotePeerId: string,
+  ) => Promise<EvmAddressV1 | null>;
+  readonly #byKey = new Map<string, HeldCatalogAccessSnapshotV1>();
+
+  constructor(options: Rfc64CatalogAccessPolicyRegistryOptionsV1) {
+    this.#localAgentAddress = snapshotAgentAddress(
+      options?.localAgentAddress,
+      'localAgentAddress',
+    );
+    if (typeof options?.resolveRemoteAgentAddress !== 'function') {
+      throw new TypeError('resolveRemoteAgentAddress must be a function');
+    }
+    this.#resolveRemoteAgentAddress = options.resolveRemoteAgentAddress;
+  }
+
+  /** Accept one already-authoritative current snapshot. Exact replay is idempotent. */
+  accept(
+    input: AcceptRfc64CatalogAccessSnapshotInputV1,
+  ): AcceptedRfc64CatalogAccessSnapshotV1 {
+    const policy = snapshotPolicy(input?.policy);
+    const policyDigest = snapshotDigest(input?.policyDigest, 'policyDigest');
+    const descriptor = classifyRfc64PolicyCellV1(policy);
+    const rosterInput = input?.roster ?? null;
+    let roster: Readonly<MemberRosterV1> | null = null;
+    let members: ReadonlyMap<EvmAddressV1, Readonly<MemberRosterEntryV1>> | null = null;
+
+    if (descriptor.rosterMode === 'forbidden') {
+      if (rosterInput !== null) {
+        throw new Error('open RFC-64 catalog policy forbids an exhaustive member roster');
+      }
+    } else {
+      if (rosterInput === null) {
+        throw new Error('invite-only RFC-64 catalog policy requires a current member roster');
+      }
+      roster = snapshotRoster(rosterInput);
+      assertRosterMatchesPolicy(roster, policy, policyDigest);
+      members = new Map(roster.members.map((entry) => [entry.agentAddress, entry]));
+    }
+
+    const key = policyKey(policy.networkId, policy.contextGraphId);
+    const current = this.#byKey.get(key);
+    if (current !== undefined) {
+      if (
+        current.policyDigest !== policyDigest
+        || canonicalizeContextGraphPolicyPayloadV1(current.policy)
+          !== canonicalizeContextGraphPolicyPayloadV1(policy)
+        || canonicalRoster(current.roster) !== canonicalRoster(roster)
+      ) {
+        throw new Error(
+          'RFC-64 current policy replacement requires the verified transition/high-water path',
+        );
+      }
+      return publicSnapshot(current);
+    }
+
+    const held = Object.freeze({ policy, policyDigest, roster, members });
+    this.#byKey.set(key, held);
+    return publicSnapshot(held);
+  }
+
+  lookup(
+    networkId: NetworkIdV1,
+    contextGraphId: ContextGraphIdV1,
+  ): AcceptedRfc64CatalogAccessSnapshotV1 | null {
+    const held = this.#byKey.get(policyKey(networkId, contextGraphId));
+    return held === undefined ? null : publicSnapshot(held);
+  }
+
+  get size(): number {
+    return this.#byKey.size;
+  }
+
+  /**
+   * Authorize one live transport operation from accepted local state only.
+   * Returning null is the sole denial shape; transports still compare the
+   * returned digest with the untrusted wire digest independently.
+   */
+  readonly authorize = async (
+    input: Rfc64CatalogAccessAuthorizationInputV1,
+  ): Promise<Rfc64CatalogAccessAuthorizationV1 | null> => {
+    const held = this.#byKey.get(policyKey(input.networkId, input.contextGraphId));
+    if (held === undefined || held.policyDigest !== input.policyDigest) return null;
+    const descriptor = classifyRfc64PolicyCellV1(held.policy);
+    if (descriptor.catalogDisclosure === 'open-authenticated') {
+      return authorization(held);
+    }
+    if (held.members === null) return null;
+
+    const remotePeerId = snapshotPeerId(input.remotePeerId);
+    const remoteAgentAddress = await this.#resolveRemoteMemberAddress(remotePeerId);
+    if (remoteAgentAddress === null) return null;
+    const localMember = held.members.get(this.#localAgentAddress);
+    const remoteMember = held.members.get(remoteAgentAddress);
+    if (localMember === undefined || remoteMember === undefined) return null;
+
+    const servingMember = servingSide(input.operation) === 'local'
+      ? localMember
+      : remoteMember;
+    if (!servingMember.roles.includes('provider')) return null;
+    return authorization(held);
+  };
+
+  /** SWM authorship follows accessPolicy and is intentionally publishPolicy-neutral. */
+  isSwmAuthorAuthorized(input: {
+    readonly networkId: NetworkIdV1;
+    readonly contextGraphId: ContextGraphIdV1;
+    readonly policyDigest: Digest32V1;
+    readonly authorAddress: EvmAddressV1;
+  }): boolean {
+    const held = this.#byKey.get(policyKey(input.networkId, input.contextGraphId));
+    if (held === undefined || held.policyDigest !== input.policyDigest) return false;
+    let authorAddress: EvmAddressV1;
+    try {
+      authorAddress = snapshotAgentAddress(input.authorAddress, 'authorAddress');
+    } catch {
+      return false;
+    }
+    return held.policy.accessPolicy === 0
+      || held.members?.has(authorAddress) === true;
+  }
+
+  async #resolveRemoteMemberAddress(remotePeerId: string): Promise<EvmAddressV1 | null> {
+    try {
+      const resolved = await this.#resolveRemoteAgentAddress(remotePeerId);
+      return resolved === null
+        ? null
+        : snapshotAgentAddress(resolved, 'resolved remote agent address');
+    } catch {
+      return null;
+    }
+  }
+}
+
+function authorization(
+  held: HeldCatalogAccessSnapshotV1,
+): Rfc64CatalogAccessAuthorizationV1 {
+  return Object.freeze({
+    accessPolicy: held.policy.accessPolicy,
+    policyDigest: held.policyDigest,
+  });
+}
+
+function servingSide(operation: Rfc64CatalogAccessOperationV1): 'local' | 'remote' {
+  switch (operation) {
+    case 'announce-outbound':
+    case 'fetch-inbound':
+    case 'catalog-object-fetch-inbound':
+    case 'ka-bundle-fetch-inbound':
+      return 'local';
+    case 'announce-inbound':
+    case 'fetch-outbound':
+    case 'catalog-object-fetch-outbound':
+    case 'ka-bundle-fetch-outbound':
+      return 'remote';
+  }
+}
+
+function assertRosterMatchesPolicy(
+  roster: Readonly<MemberRosterV1>,
+  policy: Readonly<ContextGraphPolicyV1>,
+  policyDigest: Digest32V1,
+): void {
+  if (
+    roster.networkId !== policy.networkId
+    || roster.contextGraphId !== policy.contextGraphId
+    || roster.ownershipTransitionDigest !== policy.ownershipTransitionDigest
+    || roster.era !== policy.era
+    || roster.policyDigest !== policyDigest
+    || roster.administrativeDelegationDigest !== policy.administrativeDelegationDigest
+  ) {
+    throw new Error('RFC-64 member roster is not bound to the exact accepted policy');
+  }
+}
+
+function publicSnapshot(
+  held: HeldCatalogAccessSnapshotV1,
+): AcceptedRfc64CatalogAccessSnapshotV1 {
+  return Object.freeze({
+    policy: held.policy,
+    policyDigest: held.policyDigest,
+    roster: held.roster,
+  });
+}
+
+function snapshotPolicy(input: ContextGraphPolicyV1): Readonly<ContextGraphPolicyV1> {
+  return deepFreeze(parseCanonicalContextGraphPolicyPayloadV1(
+    canonicalizeContextGraphPolicyPayloadV1(input),
+  ));
+}
+
+function snapshotRoster(input: MemberRosterV1): Readonly<MemberRosterV1> {
+  return deepFreeze(parseCanonicalMemberRosterPayloadV1(
+    canonicalizeMemberRosterPayloadV1(input),
+  ));
+}
+
+function snapshotDigest(input: Digest32V1, label: string): Digest32V1 {
+  assertCanonicalDigest(input, label);
+  return input;
+}
+
+function snapshotAgentAddress(input: EvmAddressV1, label: string): EvmAddressV1 {
+  if (typeof input !== 'string' || !EVM_ADDRESS.test(input) || input === ZERO_ADDRESS) {
+    throw new TypeError(`${label} must be a canonical nonzero EVM address`);
+  }
+  return input;
+}
+
+function snapshotPeerId(input: string): string {
+  if (
+    typeof input !== 'string'
+    || input.length === 0
+    || input.trim() !== input
+    || UTF8.encode(input).byteLength > MAX_PEER_ID_BYTES
+  ) {
+    throw new TypeError('remotePeerId must be a bounded canonical peer identifier');
+  }
+  return input;
+}
+
+function canonicalRoster(roster: Readonly<MemberRosterV1> | null): string | null {
+  return roster === null ? null : canonicalizeMemberRosterPayloadV1(roster);
+}
+
+function policyKey(networkId: NetworkIdV1, contextGraphId: ContextGraphIdV1): string {
+  return `${networkId}\n${contextGraphId}`;
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(child);
+    }
+    Object.freeze(value);
+  }
+  return value as Readonly<T>;
+}

--- a/packages/agent/test/rfc64-catalog-access-policy-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-access-policy-v1.test.ts
@@ -229,6 +229,54 @@ describe('RFC-64 D26 catalog access authorization', () => {
       .resolves.toBeNull();
   });
 
+  it('fails closed for malformed runtime operations and peer identifiers', async () => {
+    for (const accessPolicy of [0, 1] as const) {
+      const acceptedPolicy = policy(accessPolicy, 1);
+      const policyDigest = digestFor(acceptedPolicy);
+      const subject = registry();
+      subject.accept({
+        policy: acceptedPolicy,
+        policyDigest,
+        roster: accessPolicy === 1 ? roster(policyDigest) : null,
+      });
+
+      await expect(subject.authorize({
+        ...authInput('fetch-inbound', policyDigest),
+        operation: 'not-a-catalog-operation',
+      } as never)).resolves.toBeNull();
+      await expect(subject.authorize({
+        ...authInput('fetch-inbound', policyDigest),
+        remotePeerId: '',
+      })).resolves.toBeNull();
+      await expect(subject.authorize(null as never)).resolves.toBeNull();
+      expect(subject.isSwmAuthorAuthorized(null as never)).toBe(false);
+    }
+  });
+
+  it('snapshots the operation before awaiting peer-to-agent resolution', async () => {
+    let finishResolution: ((address: EvmAddressV1) => void) | undefined;
+    const acceptedPolicy = policy(1, 1);
+    const policyDigest = digestFor(acceptedPolicy);
+    const subject = new Rfc64CatalogAccessPolicyRegistryV1({
+      localAgentAddress: LOCAL,
+      resolveRemoteAgentAddress: async () => new Promise<EvmAddressV1>((resolve) => {
+        finishResolution = resolve;
+      }),
+    });
+    subject.accept({
+      policy: acceptedPolicy,
+      policyDigest,
+      roster: roster(policyDigest, { remoteProvider: false }),
+    });
+
+    const input = { ...authInput('fetch-outbound', policyDigest) };
+    const authorization = subject.authorize(input);
+    input.operation = 'fetch-inbound';
+    expect(finishResolution).toBeTypeOf('function');
+    finishResolution!(REMOTE);
+    await expect(authorization).resolves.toBeNull();
+  });
+
   it('binds the conditional roster exactly and snapshots mutable caller input', async () => {
     const acceptedPolicy = policy(1, 1);
     const policyDigest = digestFor(acceptedPolicy);

--- a/packages/agent/test/rfc64-catalog-access-policy-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-access-policy-v1.test.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import {
+  CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+  computeContextGraphPolicyObjectDigestV1,
+  type ContextGraphPolicyV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type MemberRosterV1,
+  type UnsignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+
+import {
+  Rfc64CatalogAccessPolicyRegistryV1,
+  type Rfc64CatalogAccessOperationV1,
+} from '../src/rfc64/catalog-access-policy-v1.js';
+
+const OWNER = '0x1111111111111111111111111111111111111111' as EvmAddressV1;
+const LOCAL = '0x2222222222222222222222222222222222222222' as EvmAddressV1;
+const REMOTE = '0x3333333333333333333333333333333333333333' as EvmAddressV1;
+const OUTSIDER = '0x4444444444444444444444444444444444444444' as EvmAddressV1;
+const CURATOR = '0x5555555555555555555555555555555555555555' as EvmAddressV1;
+const NETWORK = 'otp:20430' as const;
+const CG = '0x1111111111111111111111111111111111111111/v2-policy' as const;
+
+const OPERATIONS: readonly Rfc64CatalogAccessOperationV1[] = Object.freeze([
+  'announce-outbound',
+  'announce-inbound',
+  'fetch-outbound',
+  'fetch-inbound',
+  'catalog-object-fetch-outbound',
+  'catalog-object-fetch-inbound',
+  'ka-bundle-fetch-outbound',
+  'ka-bundle-fetch-inbound',
+]);
+
+function policy(accessPolicy: 0 | 1, publishPolicy: 0 | 1): ContextGraphPolicyV1 {
+  return {
+    networkId: NETWORK,
+    contextGraphId: CG,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy,
+    publishPolicy,
+    publishAuthority: publishPolicy === 0 ? CURATOR : null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'owner-signed-unregistered',
+      ownerAddress: OWNER,
+      ownerAuthorityEra: '0',
+    },
+    effectiveAt: '0',
+    issuedAt: '0',
+  };
+}
+
+function digestFor(input: ContextGraphPolicyV1): Digest32V1 {
+  return computeContextGraphPolicyObjectDigestV1({
+    issuer: OWNER,
+    objectType: CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+    payload: input,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  } as unknown as UnsignedControlEnvelopeV1);
+}
+
+function roster(
+  policyDigest: Digest32V1,
+  options: { localProvider?: boolean; remoteProvider?: boolean } = {},
+): MemberRosterV1 {
+  return {
+    networkId: NETWORK,
+    contextGraphId: CG,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest,
+    administrativeDelegationDigest: null,
+    members: [
+      {
+        agentAddress: LOCAL,
+        roles: options.localProvider === false ? ['holder'] : ['holder', 'provider'],
+      },
+      {
+        agentAddress: REMOTE,
+        roles: options.remoteProvider === false ? ['holder'] : ['holder', 'provider'],
+      },
+    ],
+    issuedAt: '0',
+  };
+}
+
+function registry(
+  remoteAddress: EvmAddressV1 | null = REMOTE,
+): Rfc64CatalogAccessPolicyRegistryV1 {
+  return new Rfc64CatalogAccessPolicyRegistryV1({
+    localAgentAddress: LOCAL,
+    resolveRemoteAgentAddress: async () => remoteAddress,
+  });
+}
+
+function authInput(operation: Rfc64CatalogAccessOperationV1, policyDigest: Digest32V1) {
+  return {
+    operation,
+    remotePeerId: '12D3KooRemote',
+    networkId: NETWORK,
+    contextGraphId: CG,
+    policyDigest,
+  } as const;
+}
+
+describe('RFC-64 D26 catalog access authorization', () => {
+  it('keeps both open-sharing cells SWM-equivalent without resolving a roster identity', async () => {
+    for (const publishPolicy of [0, 1] as const) {
+      let resolverCalls = 0;
+      const acceptedPolicy = policy(0, publishPolicy);
+      const policyDigest = digestFor(acceptedPolicy);
+      const subject = new Rfc64CatalogAccessPolicyRegistryV1({
+        localAgentAddress: LOCAL,
+        resolveRemoteAgentAddress: async () => {
+          resolverCalls += 1;
+          return null;
+        },
+      });
+      subject.accept({ policy: acceptedPolicy, policyDigest });
+      for (const operation of OPERATIONS) {
+        await expect(subject.authorize(authInput(operation, policyDigest))).resolves.toEqual({
+          accessPolicy: 0,
+          policyDigest,
+        });
+      }
+      expect(subject.isSwmAuthorAuthorized({
+        networkId: NETWORK,
+        contextGraphId: CG,
+        policyDigest,
+        authorAddress: OUTSIDER,
+      })).toBe(true);
+      expect(resolverCalls).toBe(0);
+    }
+  });
+
+  it('keeps both invite-only cells SWM-equivalent and requires current members', async () => {
+    for (const publishPolicy of [0, 1] as const) {
+      const acceptedPolicy = policy(1, publishPolicy);
+      const policyDigest = digestFor(acceptedPolicy);
+      const subject = registry();
+      subject.accept({ policy: acceptedPolicy, policyDigest, roster: roster(policyDigest) });
+      for (const operation of OPERATIONS) {
+        await expect(subject.authorize(authInput(operation, policyDigest))).resolves.toEqual({
+          accessPolicy: 1,
+          policyDigest,
+        });
+      }
+      expect(subject.isSwmAuthorAuthorized({
+        networkId: NETWORK,
+        contextGraphId: CG,
+        policyDigest,
+        authorAddress: REMOTE,
+      })).toBe(true);
+      expect(subject.isSwmAuthorAuthorized({
+        networkId: NETWORK,
+        contextGraphId: CG,
+        policyDigest,
+        authorAddress: OUTSIDER,
+      })).toBe(false);
+    }
+  });
+
+  it('requires the serving side to hold the provider role', async () => {
+    const acceptedPolicy = policy(1, 1);
+    const policyDigest = digestFor(acceptedPolicy);
+
+    const localNotProvider = registry();
+    localNotProvider.accept({
+      policy: acceptedPolicy,
+      policyDigest,
+      roster: roster(policyDigest, { localProvider: false }),
+    });
+    for (const operation of [
+      'announce-outbound',
+      'fetch-inbound',
+      'catalog-object-fetch-inbound',
+      'ka-bundle-fetch-inbound',
+    ] as const) {
+      await expect(localNotProvider.authorize(authInput(operation, policyDigest)))
+        .resolves.toBeNull();
+    }
+
+    const remoteNotProvider = registry();
+    remoteNotProvider.accept({
+      policy: acceptedPolicy,
+      policyDigest,
+      roster: roster(policyDigest, { remoteProvider: false }),
+    });
+    for (const operation of [
+      'announce-inbound',
+      'fetch-outbound',
+      'catalog-object-fetch-outbound',
+      'ka-bundle-fetch-outbound',
+    ] as const) {
+      await expect(remoteNotProvider.authorize(authInput(operation, policyDigest)))
+        .resolves.toBeNull();
+    }
+  });
+
+  it('denies unknown peers, stale digests, and missing private membership', async () => {
+    const acceptedPolicy = policy(1, 0);
+    const policyDigest = digestFor(acceptedPolicy);
+    const outsider = registry(OUTSIDER);
+    outsider.accept({ policy: acceptedPolicy, policyDigest, roster: roster(policyDigest) });
+    await expect(outsider.authorize(authInput('fetch-inbound', policyDigest)))
+      .resolves.toBeNull();
+    await expect(outsider.authorize(authInput(
+      'fetch-inbound',
+      `0x${'ab'.repeat(32)}` as Digest32V1,
+    ))).resolves.toBeNull();
+    const unresolved = registry(null);
+    unresolved.accept({ policy: acceptedPolicy, policyDigest, roster: roster(policyDigest) });
+    await expect(unresolved.authorize(authInput('fetch-inbound', policyDigest)))
+      .resolves.toBeNull();
+  });
+
+  it('binds the conditional roster exactly and snapshots mutable caller input', async () => {
+    const acceptedPolicy = policy(1, 1);
+    const policyDigest = digestFor(acceptedPolicy);
+    const acceptedRoster = roster(policyDigest);
+    const subject = registry();
+    const accepted = subject.accept({
+      policy: acceptedPolicy,
+      policyDigest,
+      roster: acceptedRoster,
+    });
+    acceptedPolicy.accessPolicy = 0;
+    acceptedRoster.members.splice(0, acceptedRoster.members.length);
+    expect(accepted.policy.accessPolicy).toBe(1);
+    expect(accepted.roster?.members).toHaveLength(2);
+    await expect(subject.authorize(authInput('fetch-outbound', policyDigest)))
+      .resolves.toEqual({ accessPolicy: 1, policyDigest });
+
+    expect(() => registry().accept({
+      policy: policy(1, 1),
+      policyDigest,
+    })).toThrow(/requires a current member roster/u);
+    expect(() => registry().accept({
+      policy: policy(0, 1),
+      policyDigest: digestFor(policy(0, 1)),
+      roster: roster(policyDigest),
+    })).toThrow(/forbids an exhaustive member roster/u);
+    expect(() => registry().accept({
+      policy: policy(1, 1),
+      policyDigest,
+      roster: { ...roster(policyDigest), policyDigest: `0x${'cd'.repeat(32)}` as Digest32V1 },
+    })).toThrow(/not bound to the exact accepted policy/u);
+  });
+
+  it('allows exact replay but refuses unverified current-policy replacement', () => {
+    const initial = policy(0, 1);
+    const initialDigest = digestFor(initial);
+    const subject = registry();
+    subject.accept({ policy: initial, policyDigest: initialDigest });
+    expect(subject.accept({ policy: initial, policyDigest: initialDigest }).policyDigest)
+      .toBe(initialDigest);
+    const replacement = { ...policy(0, 0), version: '1', previousPolicyDigest: initialDigest };
+    expect(() => subject.accept({
+      policy: replacement,
+      policyDigest: digestFor(replacement),
+    })).toThrow(/verified transition\/high-water path/u);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -134,6 +134,7 @@ export default defineConfig({
       "test/rfc64-persistent-catalog-provider-v1.test.ts",
       "test/rfc64-public-catalog-successor-producer-v1.test.ts",
       "test/rfc64-dkg-agent-successor-publication.integration.test.ts",
+      "test/rfc64-catalog-access-policy-v1.test.ts",
       "test/rfc64-policy-cell-v1.test.ts",
     ],
     testTimeout: 60_000,


### PR DESCRIPTION
V2 authorization contract for the RFC-64 catalog data plane.

- models announcement, head fetch, catalog-object fetch, and KA-bundle fetch in both directions
- treats public/open and public/curated as the same open SWM authorization behavior
- requires exact current roster membership and the serving-side provider role for both private cells
- binds private rosters to the exact accepted policy digest and authority coordinates
- denies stale digests, unresolved peers, outsiders, and unverified policy replacement
- keeps SWM authorization independent of publishPolicy

This is intentionally an authorization consumer: an upstream authority must provide an already-verified current policy and optional roster. Transport/service wiring and the real four-cell process demonstration remain follow-up V2 PRs.

Verification:
- policy-cell and catalog-access focused tests: 11 passed
- exact dependency build closure: passed
- agent TypeScript, type tests, and package-root checks: passed