### PR TITLE
fix(publisher): honor publisher.maxRetries for API- and agent-admitted lift jobs (#1836)

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1489,6 +1489,10 @@ export class PublishMethods extends DKGAgentBase {
     );
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(this.store, {
       publicSnapshotStore: this.publicSnapshotStore,
+      // #1836 — honor the operator's publisher.maxRetries on this admission path
+      // too (EPCIS / Kafka plugins publish through the agent, not the daemon
+      // control instance). Nullish → the publisher's built-in default.
+      maxRetries: this.config.publisherMaxRetries,
     });
     const captureID = await asyncPublisher.enqueueKnowledgeAssetVmPublish(intent);
     return { captureID };

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1108,6 +1108,13 @@ export interface DKGAgentConfig {
   largeLiteralStorage?: LargeLiteralStorageConfig;
   /** Out-of-Oxigraph immutable public SWM operation snapshots. Defaults on when dataDir is set. */
   sharedMemoryPublicSnapshotStorage?: SharedMemoryPublicSnapshotStorageConfig;
+  /**
+   * Max automatic-retry budget stamped onto async VM-publish jobs admitted
+   * through this agent's `publishAsync` (EPCIS / Kafka plugin paths). Mirrors
+   * the daemon's `publisher.maxRetries`. Nullish → the publisher's built-in
+   * default; `0` disables auto-retry. (#1836)
+   */
+  publisherMaxRetries?: number;
   importedArtifactByteStore?: ImportedArtifactByteStore;
   /** When false, peer-connect sync skips SWM catch-up and relies on gossip for new SWM writes. */
   syncSharedMemoryOnConnect?: boolean;

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -289,6 +289,33 @@ describe('publishJsonLd', () => {
     expect(result.status).toBe('confirmed');
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
+  it('stamps configured publisher.maxRetries onto agent publishAsync jobs (EPCIS/Kafka path, #1836)', async () => {
+    // #1836 — the agent's own publishAsync (used by the EPCIS/Kafka plugins) must
+    // stamp the operator-configured retry budget onto the queued job, not fall
+    // back to the publisher default. Reverting publishAsync to construct
+    // TripleStoreAsyncLiftPublisher without maxRetries makes this assert 10.
+    const { agent, store } = await createAgent('AsyncMaxRetriesBot', { publisherMaxRetries: 0 });
+    await agent.createContextGraph({ id: 'async-maxretries', name: 'AsyncMaxRetries', description: '' });
+    await agent.registerContextGraph('async-maxretries');
+
+    const { captureID } = await agent.publishAsync(
+      'did:dkg:context-graph:async-maxretries',
+      {
+        private: {
+          '@context': 'http://schema.org/',
+          '@id': 'http://example.org/AsyncMaxRetries',
+          '@type': 'Thing',
+          'name': 'Async MaxRetries',
+        },
+      },
+      { localOnly: true },
+    );
+
+    const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
+    const job = await asyncPublisher.getStatus(captureID);
+    expect(job?.retries.maxRetries).toBe(0);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
+
   it('async private-only JSON-LD enqueues one rootless KA with one non-root challenge anchor', async () => {
     const { agent, store } = await createAgent('AsyncPrivateOnlyBot');
     await agent.createContextGraph({ id: 'async-priv-only', name: 'AsyncPrivateOnly', description: '' });
@@ -320,6 +347,8 @@ describe('publishJsonLd', () => {
     expect(request.kaUal).toMatch(/^did:dkg:[^/]+\/0x[0-9a-f]{40}\/\d+$/);
     expect(request.accessPolicy).toBe('allowList');
     expect(request.allowedPeers).toEqual(['peer-a', 'peer-b']);
+    // #1836 — with publisherMaxRetries unset the agent path keeps the publisher default.
+    expect(job?.retries.maxRetries).toBe(10);
     // With a positive public challenge leaf the local queue may complete and
     // clean its mutable assertion lifecycle immediately. The immutable queued
     // request above is the durable contract; do not race cleanup by resolving

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1957,14 +1957,13 @@ export async function runDaemonInner(
   let promoteWorkerLifecycle: PromoteWorkerDaemonLifecycle | null = null;
   let shuttingDown = false;
 
-  const publisherControl = createPublisherControlFromStore(
-    agent.store,
-    createPublicSnapshotStore(dkgDir(), config),
+  const publisherControl = createPublisherControlFromStore(agent.store, {
+    publicSnapshotStore: createPublicSnapshotStore(dkgDir(), config),
     // #1836 — the daemon admission instance MUST carry the operator's retry
     // budget; without it every API-admitted VM-publish job was stamped with the
     // built-in default (10) even when publisher.maxRetries was configured (incl. 0).
-    config.publisher?.maxRetries,
-  );
+    maxRetries: config.publisher?.maxRetries,
+  });
   log(`Network: ${networkId.slice(0, 16)}...`);
   if (network) {
     log(

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1736,6 +1736,9 @@ export async function runDaemonInner(
     syncContextGraphPriorities: config.syncContextGraphPriorities,
     storageAckHandlerDeadlineMs: config.storageAckHandlerDeadlineMs,
     swmAwaitCuratorAck: config.swmAwaitCuratorAck,
+    // #1836 — forward the operator retry budget to the agent so its own
+    // publishAsync enqueue (EPCIS / Kafka) stamps publisher.maxRetries too.
+    publisherMaxRetries: config.publisher?.maxRetries,
     syncAgentsMeta: resolveSyncAgentsMeta(config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META),
     queryAccess: config.queryAccess,
     chainAdapter: mockChainAdapter,
@@ -1957,6 +1960,10 @@ export async function runDaemonInner(
   const publisherControl = createPublisherControlFromStore(
     agent.store,
     createPublicSnapshotStore(dkgDir(), config),
+    // #1836 — the daemon admission instance MUST carry the operator's retry
+    // budget; without it every API-admitted VM-publish job was stamped with the
+    // built-in default (10) even when publisher.maxRetries was configured (incl. 0).
+    config.publisher?.maxRetries,
   );
   log(`Network: ${networkId.slice(0, 16)}...`);
   if (network) {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -368,10 +368,12 @@ export function createPublisherInspectorFromStore(
 
 export function createPublisherControlFromStore(
   store: TripleStore,
-  publicSnapshotStore?: WorkspacePublicSnapshotStore,
-  maxRetries?: number,
+  options: { publicSnapshotStore?: WorkspacePublicSnapshotStore; maxRetries?: number } = {},
 ): AsyncLiftPublisher {
-  return new TripleStoreAsyncLiftPublisher(store, { publicSnapshotStore, maxRetries });
+  return new TripleStoreAsyncLiftPublisher(store, {
+    publicSnapshotStore: options.publicSnapshotStore,
+    maxRetries: options.maxRetries,
+  });
 }
 
 export async function createPublisherRuntimeFromAgent(args: {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -369,8 +369,9 @@ export function createPublisherInspectorFromStore(
 export function createPublisherControlFromStore(
   store: TripleStore,
   publicSnapshotStore?: WorkspacePublicSnapshotStore,
+  maxRetries?: number,
 ): AsyncLiftPublisher {
-  return new TripleStoreAsyncLiftPublisher(store, { publicSnapshotStore });
+  return new TripleStoreAsyncLiftPublisher(store, { publicSnapshotStore, maxRetries });
 }
 
 export async function createPublisherRuntimeFromAgent(args: {

--- a/packages/cli/test/publisher-maxretries-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-1836.test.ts
@@ -2,16 +2,16 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { createPublisherControlFromStore } from '../src/publisher-runner.js';
 
-// GH #1836 — the daemon HTTP admission path builds its async-lift publisher via
-// createPublisherControlFromStore(). That constructor used to drop maxRetries,
-// so a node configured `publisher.maxRetries: 0` still stamped the built-in
-// default (10) onto every API-admitted VM-publish job. These regressions pin
-// the value end to end: enqueue admits through the fixed function and the
-// assertion reads the value back off the PERSISTED job (serialize → readJob),
-// so a literal 0 must survive the constructor's `?? DEFAULT_MAX_RETRIES` guard
-// and the JSON round-trip.
+// GH #1836 — this suite proves the DESERIALIZATION half of the fix: a configured
+// maxRetries (including a literal 0) that reaches createPublisherControlFromStore
+// is stamped onto the admitted job and survives the constructor's
+// `?? DEFAULT_MAX_RETRIES` guard + the JSON serialize→readJob round-trip.
+// The CONFIG→CONSTRUCTION wiring (that runDaemonInner actually forwards
+// config.publisher.maxRetries into this helper and into DKGAgent.create) is
+// covered separately in publisher-maxretries-wiring-1836.test.ts, so neither
+// half can regress silently.
 
-describe('#1836 publisher.maxRetries propagation through createPublisherControlFromStore', () => {
+describe('#1836 publisher.maxRetries round-trips through createPublisherControlFromStore', () => {
   const stores: OxigraphStore[] = [];
 
   afterEach(async () => {
@@ -63,21 +63,21 @@ describe('#1836 publisher.maxRetries propagation through createPublisherControlF
   }
 
   it('stamps a configured literal 0 (never the default) onto admitted jobs', async () => {
-    const control = createPublisherControlFromStore(newStore(), undefined, 0);
+    const control = createPublisherControlFromStore(newStore(), { maxRetries: 0 });
     const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
     const job = await control.getStatus(jobId);
     expect(job?.retries.maxRetries).toBe(0);
   });
 
   it('preserves the built-in default (10) when maxRetries is omitted', async () => {
-    const control = createPublisherControlFromStore(newStore(), undefined);
+    const control = createPublisherControlFromStore(newStore());
     const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
     const job = await control.getStatus(jobId);
     expect(job?.retries.maxRetries).toBe(10);
   });
 
   it('propagates an arbitrary configured budget', async () => {
-    const control = createPublisherControlFromStore(newStore(), undefined, 3);
+    const control = createPublisherControlFromStore(newStore(), { maxRetries: 3 });
     const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
     const job = await control.getStatus(jobId);
     expect(job?.retries.maxRetries).toBe(3);

--- a/packages/cli/test/publisher-maxretries-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-1836.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { createPublisherControlFromStore } from '../src/publisher-runner.js';
+
+// GH #1836 — the daemon HTTP admission path builds its async-lift publisher via
+// createPublisherControlFromStore(). That constructor used to drop maxRetries,
+// so a node configured `publisher.maxRetries: 0` still stamped the built-in
+// default (10) onto every API-admitted VM-publish job. These regressions pin
+// the value end to end: enqueue admits through the fixed function and the
+// assertion reads the value back off the PERSISTED job (serialize → readJob),
+// so a literal 0 must survive the constructor's `?? DEFAULT_MAX_RETRIES` guard
+// and the JSON round-trip.
+
+describe('#1836 publisher.maxRetries propagation through createPublisherControlFromStore', () => {
+  const stores: OxigraphStore[] = [];
+
+  afterEach(async () => {
+    await Promise.all(stores.splice(0).map((store) => store.close().catch(() => {})));
+  });
+
+  function newStore(): OxigraphStore {
+    const store = new OxigraphStore();
+    stores.push(store);
+    return store;
+  }
+
+  // Minimal, well-formed graph-scoped VM-publish intent (mirrors the shape used
+  // by the publisher package's broadcast-progress suite).
+  function kaVmPublishRequest() {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
+    return {
+      contextGraphId: 'music-social',
+      name: 'albums',
+      shareOperationId: 'share-op-1',
+      roots: [] as string[],
+      contentScopeVersion: 2 as const,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+      seal: {
+        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+        authorAddress: authorAddress as `0x${string}`,
+        signature: {
+          r: (`0x${'34'.repeat(32)}`) as `0x${string}`,
+          vs: (`0x${'56'.repeat(32)}`) as `0x${string}`,
+        },
+        schemeVersion: 1,
+        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
+      },
+      sealChainId: '31337' as `${bigint}`,
+      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      intentKey: `sha256:${'ab'.repeat(32)}`,
+      wmCurrentAssertion: '12'.repeat(32),
+      swmCurrentAssertion: '12'.repeat(32),
+      kaNumber: kaNumber.toString(),
+      reservedUal: kaUal,
+    };
+  }
+
+  it('stamps a configured literal 0 (never the default) onto admitted jobs', async () => {
+    const control = createPublisherControlFromStore(newStore(), undefined, 0);
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const job = await control.getStatus(jobId);
+    expect(job?.retries.maxRetries).toBe(0);
+  });
+
+  it('preserves the built-in default (10) when maxRetries is omitted', async () => {
+    const control = createPublisherControlFromStore(newStore(), undefined);
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const job = await control.getStatus(jobId);
+    expect(job?.retries.maxRetries).toBe(10);
+  });
+
+  it('propagates an arbitrary configured budget', async () => {
+    const control = createPublisherControlFromStore(newStore(), undefined, 3);
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const job = await control.getStatus(jobId);
+    expect(job?.retries.maxRetries).toBe(3);
+  });
+});

--- a/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// GH #1836 — regression at the CONFIG→CONSTRUCTION seam. The original bug was
+// that daemon config was not forwarded into the admission-time publisher, so a
+// helper-only test cannot protect it. These tests drive runDaemonInner and prove
+// config.publisher.maxRetries reaches BOTH admission constructors:
+//   • DKGAgent.create (publisherMaxRetries → agent publishAsync: EPCIS/Kafka), and
+//   • createPublisherControlFromStore (daemon HTTP admission — the reported bug).
+// Removing either forwarding makes one of these fail.
+const mocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  chainResetWipe: vi.fn(),
+  createServer: vi.fn(),
+  loadOpWallets: vi.fn(),
+  loadNetworkConfig: vi.fn(),
+  startPublisherRuntimeWithOutcome: vi.fn(),
+  createPublisherControlFromStore: vi.fn(),
+}));
+
+vi.mock('node:http', () => ({ createServer: mocks.createServer }));
+
+vi.mock('@origintrail-official/dkg-agent', async importOriginal => {
+  const actual = await importOriginal<typeof import('@origintrail-official/dkg-agent')>();
+  return {
+    ...actual,
+    DKGAgent: { create: mocks.agentCreate },
+    loadOpWallets: mocks.loadOpWallets,
+    KaNumberAllocator: class KaNumberAllocator {},
+  };
+});
+
+vi.mock('../src/config.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/config.js')>();
+  return { ...actual, loadNetworkConfig: mocks.loadNetworkConfig };
+});
+
+vi.mock('../src/daemon/chain-reset-wipe.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/daemon/chain-reset-wipe.js')>();
+  return { ...actual, chainResetWipe: mocks.chainResetWipe };
+});
+
+vi.mock('../src/publisher-runner.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/publisher-runner.js')>();
+  return {
+    ...actual,
+    startPublisherRuntimeWithOutcome: mocks.startPublisherRuntimeWithOutcome,
+    createPublisherControlFromStore: mocks.createPublisherControlFromStore,
+  };
+});
+
+const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
+
+function createFakeServer() {
+  const server = {
+    listen: vi.fn((_port: number, _host: string, cb?: () => void) => { cb?.(); return server; }),
+    address: vi.fn(() => ({ port: 43123 })),
+    close: vi.fn((cb?: () => void) => { cb?.(); return server; }),
+    on: vi.fn(() => server),
+    once: vi.fn(() => server),
+  };
+  return server;
+}
+
+function closeDashboardDbFromAgentCreateArg(createArg: any): void {
+  const db =
+    createArg?.chainEventCursorStore?.cursors?.db ??
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+  db?.close?.();
+}
+
+describe('runDaemonInner publisher.maxRetries wiring (#1836)', () => {
+  let tempHome: string | undefined;
+  let originalDkgHome: string | undefined;
+  let uncaughtExceptionListeners: NodeJS.UncaughtExceptionListener[] = [];
+  let unhandledRejectionListeners: NodeJS.UnhandledRejectionListener[] = [];
+  let sigintListeners: NodeJS.SignalsListener[] = [];
+  let sigtermListeners: NodeJS.SignalsListener[] = [];
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-maxretries-wiring-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+    sigintListeners = process.listeners('SIGINT') as NodeJS.SignalsListener[];
+    sigtermListeners = process.listeners('SIGTERM') as NodeJS.SignalsListener[];
+
+    mocks.createServer.mockImplementation(createFakeServer);
+    mocks.startPublisherRuntimeWithOutcome.mockResolvedValue({
+      runtime: null,
+      availability: { available: false, reason: 'no_publisher_wallets', retryable: false, operatorActionRequired: true },
+    });
+    mocks.loadNetworkConfig.mockResolvedValue({
+      networkName: 'DKG V10 Gnosis Mainnet',
+      genesisId: 'gnosis-mainnet',
+      genesisVersion: 1,
+      relays: ['/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M'],
+      defaultNodeRole: 'core',
+    });
+    mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
+    mocks.chainResetWipe.mockResolvedValue({
+      wiped: false, skipped: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [],
+    });
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    process.removeAllListeners('uncaughtException');
+    for (const l of uncaughtExceptionListeners) process.on('uncaughtException', l);
+    process.removeAllListeners('unhandledRejection');
+    for (const l of unhandledRejectionListeners) process.on('unhandledRejection', l);
+    process.removeAllListeners('SIGINT');
+    for (const l of sigintListeners) process.on('SIGINT', l);
+    process.removeAllListeners('SIGTERM');
+    for (const l of sigtermListeners) process.on('SIGTERM', l);
+    if (originalDkgHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = originalDkgHome;
+    if (tempHome) await rm(tempHome, { recursive: true, force: true });
+    tempHome = undefined;
+  });
+
+  // agentCreate rejects → runDaemonInner throws right after DKGAgent.create, so we
+  // capture the exact create arg (the DKGAgent.create forwarding).
+  async function captureCreateArg(configOverrides: Record<string, unknown> = {}): Promise<any> {
+    mocks.agentCreate.mockRejectedValue(new Error('after-agent-create'));
+    await expect(runDaemonInner(true, {
+      name: 'maxretries-wiring-core-test',
+      networkConfig: 'mainnet-gnosis',
+      listenPort: 0,
+      nodeRole: 'core',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
+      ...configOverrides,
+    } as any, Date.now())).rejects.toThrow('after-agent-create');
+    expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
+    const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
+    closeDashboardDbFromAgentCreateArg(createArg);
+    return createArg;
+  }
+
+  it('forwards config.publisher.maxRetries (incl. 0) into DKGAgent.create as publisherMaxRetries', async () => {
+    const createArg = await captureCreateArg({ publisher: { enabled: true, maxRetries: 0 } });
+    expect(createArg.publisherMaxRetries).toBe(0);
+  });
+
+  it('leaves publisherMaxRetries undefined when unconfigured (publisher default preserved)', async () => {
+    const createArg = await captureCreateArg();
+    expect(createArg.publisherMaxRetries).toBeUndefined();
+  });
+
+  it('forwards config.publisher.maxRetries into createPublisherControlFromStore (daemon HTTP admission)', async () => {
+    const fakeAgent = {
+      peerId: 'self-peer',
+      multiaddrs: [],
+      wallet: { keypair: { publicKey: new Uint8Array([1]), secretKey: new Uint8Array([2]) } },
+      store: {},
+      node: { libp2p: { getMultiaddrs: vi.fn(() => []) } },
+      eventBus: { on: vi.fn() },
+      assertion: { create: vi.fn(), write: vi.fn() },
+      setChatAcl: vi.fn(),
+      setSkillAcl: vi.fn(),
+      onChat: vi.fn(),
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      publishProfile: vi.fn(async () => undefined),
+      publishRelayRegistry: vi.fn(async () => undefined),
+      ensureContextGraphLocal: vi.fn(async () => undefined),
+      getSubscribedContextGraphs: vi.fn(() => new Map()),
+      subscribeToContextGraph: vi.fn(),
+      pingPeers: vi.fn(async () => undefined),
+      listLocalAgents: vi.fn(() => []),
+      registerImportedArtifactByteStore: vi.fn(),
+      getDefaultAgentAddress: vi.fn(() => undefined),
+      query: vi.fn(async () => ({ type: 'bindings', bindings: [] })),
+      createContextGraph: vi.fn(),
+      listContextGraphs: vi.fn(async () => []),
+      drainRpcUsage: vi.fn(() => ({ calls: 0, errors: 0, throttledMs: 0, byEndpoint: {} })),
+    };
+    mocks.agentCreate.mockResolvedValue(fakeAgent);
+    // Record the admission-construction args, then stop the boot cleanly right at
+    // that call so the rest of daemon startup does not need to be faked.
+    mocks.createPublisherControlFromStore.mockImplementation(() => {
+      throw new Error('after-publisher-control');
+    });
+
+    await expect(runDaemonInner(true, {
+      name: 'maxretries-wiring-admission-test',
+      networkConfig: 'mainnet-gnosis',
+      listenPort: 0,
+      apiPort: 0,
+      nodeRole: 'edge',
+      auth: { enabled: false },
+      promoteQueue: { enabled: false },
+      source: 'monorepo',
+      publisher: { enabled: true, maxRetries: 0 },
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
+    } as any, Date.now())).rejects.toThrow('after-publisher-control');
+
+    closeDashboardDbFromAgentCreateArg(mocks.agentCreate.mock.calls[0]?.[0]);
+    expect(mocks.createPublisherControlFromStore).toHaveBeenCalledTimes(1);
+    const [store, options] = mocks.createPublisherControlFromStore.mock.calls[0] as [unknown, { maxRetries?: number }];
+    expect(store).toBe(fakeAgent.store);
+    expect(options.maxRetries).toBe(0);
+  });
+});

--- a/packages/cli/test/publisher-route-snapshot.test.ts
+++ b/packages/cli/test/publisher-route-snapshot.test.ts
@@ -45,7 +45,7 @@ describe('publisher routes with disk public snapshot refs', () => {
       { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Route Snapshot"', graph: '' },
     ], { publisherPeerId: 'peer-route' });
 
-    const publisherControl = createPublisherControlFromStore(store, publicSnapshotStore);
+    const publisherControl = createPublisherControlFromStore(store, { publicSnapshotStore });
     const jobId = await seedLegacyRawLiftTestJob(store, {
       contextGraphId: CONTEXT_GRAPH,
       swmId: write.shareOperationId,

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -86,6 +86,9 @@ export default defineConfig({
           // #1836 — publisher.maxRetries must propagate through
           // createPublisherControlFromStore (incl. a literal 0). Pure logic.
           'test/publisher-maxretries-1836.test.ts',
+          // #1836 — config→construction wiring seam (runDaemonInner forwards
+          // config.publisher.maxRetries into both admission constructors).
+          'test/publisher-maxretries-wiring-1836.test.ts',
           // SQLite-backed vector store. Pure local DB coverage; no hardhat.
           'test/vector-store-extra.test.ts',
           // Release 2 — managed local Oxigraph server (opt-in). Pure logic

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -83,6 +83,9 @@ export default defineConfig({
           'test/publisher-runner-lu11.test.ts',
           'test/publisher-runner-ack-transport.test.ts',
           'test/publisher-ka-recovery.test.ts',
+          // #1836 — publisher.maxRetries must propagate through
+          // createPublisherControlFromStore (incl. a literal 0). Pure logic.
+          'test/publisher-maxretries-1836.test.ts',
           // SQLite-backed vector store. Pure local DB coverage; no hardhat.
           'test/vector-store-extra.test.ts',
           // Release 2 — managed local Oxigraph server (opt-in). Pure logic


### PR DESCRIPTION
## Summary

`publisher.maxRetries` was ignored for async VM-publish jobs admitted through the daemon API. A node configured `publisher.maxRetries: 0` still returned newly admitted jobs with `retries.maxRetries: 10`.

**Root cause.** The daemon HTTP admission path uses the control-plane publisher built by `createPublisherControlFromStore()` (`lifecycle.ts`), and that factory constructed `TripleStoreAsyncLiftPublisher` **without** `maxRetries`. The constructor default is nullish-coalesced (`config.maxRetries ?? DEFAULT_MAX_RETRIES`, `= 10`), so the omitted argument resolved to `10`; that value is stamped onto the job at admission and every retry gate reads the *persisted* budget thereafter. The runtime/runner instance *did* thread `config.publisher.maxRetries`, but it never enqueues VM-publish jobs, so that value was dead for this path.

A **second admission path** had the same defect: the agent's `publishAsync` (reached in production via the EPCIS and Kafka plugins) built its own `TripleStoreAsyncLiftPublisher` without `maxRetries`.

## Changes

- `createPublisherControlFromStore(store, publicSnapshotStore?, **maxRetries?**)` now forwards the argument to the publisher; the daemon passes `config.publisher?.maxRetries` at the call site.
- `DKGAgentConfig` gains a flat `publisherMaxRetries?: number`; `publishAsync` stamps it, wired from the daemon's `DKGAgent.create`.
- Because the constructor default uses `??` (not `||`), a configured literal `0` now survives end to end (`0 ?? 10 === 0`) and cleanly means "never auto-retry".

Scope notes: the read-only `createPublisherInspectorFromStore` is intentionally left unchanged (it never enqueues, so `maxRetries` has no effect there). The daemon config value is a plain number, so this fix deliberately does **not** route through the CLI `--max-retries` parser, which rejects a literal `0`.

## Files changed

| File | Change |
|---|---|
| `packages/cli/src/publisher-runner.ts` | `createPublisherControlFromStore` accepts + forwards `maxRetries` |
| `packages/cli/src/daemon/lifecycle.ts` | daemon control instance gets `config.publisher?.maxRetries`; agent gets `publisherMaxRetries` |
| `packages/agent/src/dkg-agent-types.ts` | new `publisherMaxRetries?: number` on `DKGAgentConfig` |
| `packages/agent/src/dkg-agent-publish.ts` | `publishAsync` stamps `this.config.publisherMaxRetries` |
| `packages/cli/test/publisher-maxretries-1836.test.ts` | new regression (added to the fast unit lane) |

## Test plan

- New `publisher-maxretries-1836.test.ts` admits a VM-publish through the fixed `createPublisherControlFromStore` and reads the value back off the **persisted** job (serialize → read), asserting:
  - configured `0` → persisted `retries.maxRetries === 0` (the reported failure),
  - omitted → default `10` preserved,
  - configured `3` → `3`.
- `pnpm --filter "@origintrail-official/dkg^..." run build` green (includes `agent` `tsc` + `test:types`).
- `pnpm -C packages/cli exec tsc --noEmit` clean.
- Adjacent publisher unit tests green (`publisher-ka-recovery`, `publisher-runner-lu11`, `publisher-runner-ack-transport`).

Note: jobs admitted **before** this fix keep their persisted `maxRetries: 10` (that field is immutable per job); the fix applies to newly admitted jobs.

Closes #1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)
