### PR TITLE
Fix public Context Graph subscription catch-up

### DIFF
--- a/packages/agent/src/context-graph-public-meta-proof.ts
+++ b/packages/agent/src/context-graph-public-meta-proof.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  DKG_ONTOLOGY,
+  assertSafeIri,
+  contextGraphDataGraphUri,
+  contextGraphMetaGraphUri,
+  sparqlString,
+} from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { stripLiteral } from './dkg-agent-utils.js';
+
+type PublicMetaObjectRequirement =
+  | { kind: 'iri'; value: string }
+  | { kind: 'normalized-literal'; value: string };
+
+interface PublicMetaRequirement {
+  predicate: string;
+  variable: string;
+  object: PublicMetaObjectRequirement;
+}
+
+/**
+ * Canonical facts that prove a root metadata snapshot explicitly declares a
+ * public Context Graph. Snapshot evaluation and store-side ASK queries are
+ * rendered from the same model so public authority cannot drift between sync
+ * admission paths.
+ */
+const PUBLIC_ACCESS_POLICY_REQUIREMENT: PublicMetaRequirement = {
+  predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+  variable: 'accessPolicy',
+  object: { kind: 'normalized-literal', value: 'public' },
+};
+
+const AUTHORITATIVE_PUBLIC_META_REQUIREMENTS: readonly PublicMetaRequirement[] = [
+  {
+    predicate: DKG_ONTOLOGY.RDF_TYPE,
+    variable: 'contextGraphType',
+    object: { kind: 'iri', value: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH },
+  },
+  PUBLIC_ACCESS_POLICY_REQUIREMENT,
+];
+
+function matchesRequirementObject(
+  value: string,
+  requirement: PublicMetaObjectRequirement,
+): boolean {
+  switch (requirement.kind) {
+    case 'iri':
+      return value === requirement.value;
+    case 'normalized-literal':
+      return value.startsWith('"')
+        && stripLiteral(value).trim().toLowerCase() === requirement.value;
+  }
+}
+
+/** Evaluate a fetched root `_meta` snapshot against the canonical public proof. */
+export function hasAuthoritativePublicMetaDefinition(
+  contextGraphId: string,
+  quads: readonly Quad[],
+): boolean {
+  const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+  const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+  const hasRequiredFacts = AUTHORITATIVE_PUBLIC_META_REQUIREMENTS.every((requirement) => quads.some((quad) => (
+    quad.graph === metaGraph
+      && quad.subject === contextGraphUri
+      && quad.predicate === requirement.predicate
+      && matchesRequirementObject(quad.object, requirement.object)
+  )));
+  const hasConflictingPolicy = quads.some((quad) => (
+    quad.graph === metaGraph
+      && quad.subject === contextGraphUri
+      && quad.predicate === PUBLIC_ACCESS_POLICY_REQUIREMENT.predicate
+      && !matchesRequirementObject(quad.object, PUBLIC_ACCESS_POLICY_REQUIREMENT.object)
+  ));
+  return hasRequiredFacts && !hasConflictingPolicy;
+}
+
+function renderRequirement(
+  contextGraphUri: string,
+  requirement: PublicMetaRequirement,
+): string {
+  const subject = `<${assertSafeIri(contextGraphUri)}>`;
+  const predicate = `<${assertSafeIri(requirement.predicate)}>`;
+  if (requirement.object.kind === 'iri') {
+    return `${subject} ${predicate} <${assertSafeIri(requirement.object.value)}> .`;
+  }
+  const variable = `?${requirement.variable}`;
+  return `${subject} ${predicate} ${variable} .\n` +
+    `      FILTER(isLiteral(${variable}) && LCASE(REPLACE(STR(${variable}), "^\\\\s+|\\\\s+$", "")) = ${sparqlString(requirement.object.value)})`;
+}
+
+/** Build the store-side ASK query from the canonical public proof model. */
+export function buildAuthoritativePublicMetaAskQuery(contextGraphId: string): string {
+  const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+  const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+  const requirements = AUTHORITATIVE_PUBLIC_META_REQUIREMENTS
+    .map((requirement) => `      ${renderRequirement(contextGraphUri, requirement)}`)
+    .join('\n');
+  const accessPolicyPredicate = assertSafeIri(PUBLIC_ACCESS_POLICY_REQUIREMENT.predicate);
+  const publicPolicy = PUBLIC_ACCESS_POLICY_REQUIREMENT.object;
+  if (publicPolicy.kind !== 'normalized-literal') {
+    throw new Error('Public access policy proof must use a normalized literal');
+  }
+  return `ASK WHERE {
+    GRAPH <${assertSafeIri(metaGraph)}> {
+${requirements}
+      FILTER NOT EXISTS {
+        <${assertSafeIri(contextGraphUri)}> <${accessPolicyPredicate}> ?conflictingAccessPolicy .
+        FILTER(
+          !isLiteral(?conflictingAccessPolicy) ||
+          LCASE(REPLACE(STR(?conflictingAccessPolicy), "^\\\\s+|\\\\s+$", "")) != ${sparqlString(publicPolicy.value)}
+        )
+      }
+    }
+  }`;
+}

--- a/packages/agent/src/curator-meta-refresh.ts
+++ b/packages/agent/src/curator-meta-refresh.ts
@@ -23,6 +23,7 @@ import {
   hasAuthoritativePrivateMetaDefinition,
   type AuthoritativePrivateMetaMemberProof,
 } from './context-graph-private-meta-proof.js';
+import { hasAuthoritativePublicMetaDefinition } from './context-graph-public-meta-proof.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from './sync/checkpoint/state.js';
 import { insertWithOversizeGuard, type OversizeDrop } from './sync/oversize-filter.js';
 import type { SyncPageResult } from './sync/requester/page-fetch.js';
@@ -354,16 +355,21 @@ async function fetchAuthoritativeMetaSnapshot(
     agent.syncCheckpoints.delete(result.checkpointKey);
     return undefined;
   }
-  if (!hasAuthoritativePrivateMetaDefinition(
+  const hasAuthoritativePublicDefinition = hasAuthoritativePublicMetaDefinition(
+    contextGraphId,
+    controlMetaQuads,
+  );
+  const hasAuthoritativePrivateDefinition = hasAuthoritativePrivateMetaDefinition(
     contextGraphId,
     controlMetaQuads,
     options.memberProof,
-  )) {
+  );
+  if (!hasAuthoritativePublicDefinition && !hasAuthoritativePrivateDefinition) {
     agent.syncCheckpoints.delete(snapshotCheckpointKey);
     agent.syncCheckpoints.delete(result.checkpointKey);
     agent.log.warn(
       ctx,
-      `Rejected curator metadata snapshot for "${contextGraphId}": missing the complete private definition or approved-member delegation proof`,
+      `Rejected curator metadata snapshot for "${contextGraphId}": missing an unambiguous public definition or the complete private definition and approved-member delegation proof`,
     );
     return undefined;
   }

--- a/packages/agent/src/curator-meta-refresh.ts
+++ b/packages/agent/src/curator-meta-refresh.ts
@@ -359,12 +359,17 @@ async function fetchAuthoritativeMetaSnapshot(
     contextGraphId,
     controlMetaQuads,
   );
+  // Supplying memberProof selects the fail-closed private post-approval
+  // contract. A public-only snapshot must not satisfy that request: public
+  // subscriptions reach this refresh without a member proof.
+  const acceptsAuthoritativePublicDefinition = options.memberProof === undefined
+    && hasAuthoritativePublicDefinition;
   const hasAuthoritativePrivateDefinition = hasAuthoritativePrivateMetaDefinition(
     contextGraphId,
     controlMetaQuads,
     options.memberProof,
   );
-  if (!hasAuthoritativePublicDefinition && !hasAuthoritativePrivateDefinition) {
+  if (!acceptsAuthoritativePublicDefinition && !hasAuthoritativePrivateDefinition) {
     agent.syncCheckpoints.delete(snapshotCheckpointKey);
     agent.syncCheckpoints.delete(result.checkpointKey);
     agent.log.warn(

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -6857,7 +6857,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     );
     const hasUnregisteredPlaceholder = unregisteredPlaceholderResult.type === 'boolean' &&
       unregisteredPlaceholderResult.value === true;
-    let hasActivePublicOnChainProof = false;
+    let hasActivePublicOnChainProof: boolean | undefined;
     if (hasUnregisteredPlaceholder && options?.rejectUnregisteredPlaceholder === true) {
       // Replicas do not rewrite the creator's local registrationStatus marker,
       // so a legitimately registered public CG can still say "unregistered".
@@ -6865,8 +6865,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // non-zero id, active slot, accessPolicy=public); a legacy local shadow
       // has no such proof, and a private slot cannot borrow its public ontology
       // fallback.
-      hasActivePublicOnChainProof = await this.contextGraphActivePublicOnChainFromRegistry(
+      hasActivePublicOnChainProof = await this.isContextGraphPublicOnChain(
         contextGraphId,
+        createOperationContext('sync'),
       ).catch(() => false);
     }
     // Curated/private CG creation in 10.0.6 emits this complete definition in
@@ -6900,6 +6901,45 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     ) {
       return true;
     }
+
+    // Public subscriptions have no member credential to prove. A complete
+    // root definition that explicitly says `accessPolicy="public"` is the
+    // corresponding authoritative metadata gate; publisher allowlists do not
+    // alter that read/subscription policy. Keep this separate from the private
+    // definition above so private bootstrap still requires the current local
+    // member delegation.
+    const authoritativePublicDefinitionResult = await this.store.query(
+      `ASK WHERE {
+        GRAPH <${metaGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> ;
+            <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?accessPolicy .
+          FILTER(isLiteral(?accessPolicy) && LCASE(REPLACE(STR(?accessPolicy), "^\\\\s+|\\\\s+$", "")) = "public")
+        }
+      }`,
+    );
+    if (
+      authoritativePublicDefinitionResult.type === 'boolean' &&
+      authoritativePublicDefinitionResult.value === true &&
+      // A replica may retain the creator's local-only placeholder. When the
+      // caller explicitly rejects that shape, preserve the existing fresh
+      // active-public chain requirement instead of trusting the shadow alone.
+      (!hasUnregisteredPlaceholder || options?.rejectUnregisteredPlaceholder !== true || hasActivePublicOnChainProof)
+    ) {
+      return true;
+    }
+
+    // A tracked, active registration with live accessPolicy=public is an
+    // independent authority. This covers chain-discovered subscriptions whose
+    // local ontology/control projection has not landed yet. The registry
+    // resolver is fail-closed: it requires an identity-bound on-chain id,
+    // liveness, and policy=public, so a private or stale slot cannot pass.
+    if (hasActivePublicOnChainProof === undefined) {
+      hasActivePublicOnChainProof = await this.isContextGraphPublicOnChain(
+        contextGraphId,
+        createOperationContext('sync'),
+      ).catch(() => false);
+    }
+    if (hasActivePublicOnChainProof) return true;
 
     // `ensureContextGraphLocal` remains authoritative for explicit public
     // network defaults, including namespaced defaults. Reject that otherwise-

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -143,6 +143,7 @@ import {
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
 import { buildAuthoritativePrivateMetaAskQuery } from './context-graph-private-meta-proof.js';
+import { buildAuthoritativePublicMetaAskQuery } from './context-graph-public-meta-proof.js';
 
 import { ProfileManager } from './profile-manager.js';
 import { DiscoveryClient, type SkillSearchOptions, type DiscoveredAgent, type DiscoveredOffering } from './discovery.js';
@@ -6909,13 +6910,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // definition above so private bootstrap still requires the current local
     // member delegation.
     const authoritativePublicDefinitionResult = await this.store.query(
-      `ASK WHERE {
-        GRAPH <${metaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> ;
-            <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?accessPolicy .
-          FILTER(isLiteral(?accessPolicy) && LCASE(REPLACE(STR(?accessPolicy), "^\\\\s+|\\\\s+$", "")) = "public")
-        }
-      }`,
+      buildAuthoritativePublicMetaAskQuery(contextGraphId),
     );
     if (
       authoritativePublicDefinitionResult.type === 'boolean' &&

--- a/packages/agent/test/cg-resolve-refresh.test.ts
+++ b/packages/agent/test/cg-resolve-refresh.test.ts
@@ -391,6 +391,66 @@ describe('refreshMetaFromCurator', () => {
     expect(staged).toHaveLength(2);
   });
 
+  it('rejects a public-only snapshot when private member proof was required', async () => {
+    const contextGraphId = 'private/member-proof-cannot-use-public-snapshot';
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+    const snapshot: Quad[] = [{
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: metaGraph,
+    }, {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      object: '"public"',
+      graph: metaGraph,
+    }];
+    let targetMutated = false;
+    const agent = {
+      metaRefreshTimestamps: new Map<string, number>(),
+      peerId: 'local-peer',
+      node: {
+        libp2p: {
+          getConnections: () => [{ remotePeer: { toString: () => CURATOR_PEER_ID } }],
+        },
+      },
+      discovery: {},
+      fetchSyncPages: async () => ({
+        quads: snapshot,
+        checkpointKey: 'member-proof-public-snapshot',
+        resumedFromOffset: 0,
+        completed: true,
+      }),
+      store: {
+        insert: async () => { targetMutated = true; },
+        update: async () => { targetMutated = true; },
+        dropGraph: async () => { targetMutated = true; },
+      },
+      oversizeTombstoneLog: { record: noop },
+      invalidateListContextGraphsCache: noop,
+      contextGraphMetaProjection: { markDirty: noop },
+      syncCheckpoints: new Map<string, number>(),
+      log: { warn: noop, info: noop },
+    };
+
+    const refreshed = await ContextGraphResolveMethods.prototype.refreshMetaFromCurator.call(
+      agent as never,
+      contextGraphId,
+      {
+        trustedCuratorPeerId: CURATOR_PEER_ID,
+        force: true,
+        memberProof: {
+          approvedAgentAddress: '0x00000000000000000000000000000000000000A1',
+          expectedDelegateePeerId: 'local-peer',
+        },
+      },
+    );
+
+    expect(refreshed).toBe(false);
+    expect(targetMutated).toBe(false);
+  });
+
   it('uses a trusted join-approved curator directly and bypasses the auth-probe cooldown', async () => {
     const contextGraphId = 'private/trusted-curator-bootstrap';
     const metaGraph = contextGraphMetaGraphUri(contextGraphId);

--- a/packages/agent/test/cg-resolve-refresh.test.ts
+++ b/packages/agent/test/cg-resolve-refresh.test.ts
@@ -338,6 +338,59 @@ describe('refreshMetaFromCurator', () => {
     expect(dialSignals).toEqual([controller.signal, controller.signal]);
   });
 
+  it('accepts an authoritative public snapshot without a private member proof', async () => {
+    const contextGraphId = 'public/authoritative-curator-snapshot';
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+    const snapshot: Quad[] = [{
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: metaGraph,
+    }, {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      object: '"public"',
+      graph: metaGraph,
+    }];
+    let staged: Quad[] = [];
+    const agent = {
+      metaRefreshTimestamps: new Map<string, number>(),
+      peerId: 'local-peer',
+      node: {
+        libp2p: {
+          getConnections: () => [{ remotePeer: { toString: () => CURATOR_PEER_ID } }],
+        },
+      },
+      discovery: {},
+      fetchSyncPages: async () => ({
+        quads: snapshot,
+        checkpointKey: 'public-authoritative-snapshot',
+        resumedFromOffset: 0,
+        completed: true,
+      }),
+      store: {
+        insert: async (quads: Quad[]) => { staged = quads; },
+        update: async () => undefined,
+        dropGraph: async () => undefined,
+      },
+      oversizeTombstoneLog: { record: noop },
+      invalidateListContextGraphsCache: noop,
+      contextGraphMetaProjection: { markDirty: noop },
+      syncCheckpoints: new Map<string, number>(),
+      log: { warn: noop, info: noop },
+    };
+
+    const refreshed = await ContextGraphResolveMethods.prototype.refreshMetaFromCurator.call(
+      agent as never,
+      contextGraphId,
+      { trustedCuratorPeerId: CURATOR_PEER_ID, force: true },
+    );
+
+    expect(refreshed).toBe(true);
+    expect(staged).toHaveLength(2);
+  });
+
   it('uses a trusted join-approved curator directly and bypasses the auth-probe cooldown', async () => {
     const contextGraphId = 'private/trusted-curator-bootstrap';
     const metaGraph = contextGraphMetaGraphUri(contextGraphId);

--- a/packages/agent/test/context-graph-public-meta-proof.test.ts
+++ b/packages/agent/test/context-graph-public-meta-proof.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DKG_ONTOLOGY,
+  contextGraphDataGraphUri,
+  contextGraphMetaGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  buildAuthoritativePublicMetaAskQuery,
+  hasAuthoritativePublicMetaDefinition,
+} from '../src/context-graph-public-meta-proof.js';
+
+function authoritativePublicMetaQuads(contextGraphId: string): Quad[] {
+  const graph = contextGraphMetaGraphUri(contextGraphId);
+  const subject = contextGraphDataGraphUri(contextGraphId);
+  return [
+    {
+      subject,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph,
+    },
+    {
+      subject,
+      predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      object: '"public"',
+      graph,
+    },
+  ];
+}
+
+describe('authoritative public metadata proof', () => {
+  it('keeps fetched-snapshot evaluation and the generated store query in lockstep', async () => {
+    const cases = [
+      {
+        name: 'complete public definition',
+        mutate: (quads: Quad[]) => quads,
+        expected: true,
+      },
+      {
+        name: 'normalized public policy whitespace',
+        mutate: (quads: Quad[]) => quads.map((quad) => (
+          quad.predicate === DKG_ONTOLOGY.DKG_ACCESS_POLICY
+            ? { ...quad, object: '"  PuBlIc  "' }
+            : quad
+        )),
+        expected: true,
+      },
+      {
+        name: 'private policy',
+        mutate: (quads: Quad[]) => quads.map((quad) => (
+          quad.predicate === DKG_ONTOLOGY.DKG_ACCESS_POLICY
+            ? { ...quad, object: '"private"' }
+            : quad
+        )),
+        expected: false,
+      },
+      {
+        name: 'contradictory public and private policies',
+        mutate: (quads: Quad[]) => [
+          ...quads,
+          {
+            ...quads.find(
+              (quad) => quad.predicate === DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+            )!,
+            object: '"private"',
+          },
+        ],
+        expected: false,
+      },
+      {
+        name: 'missing context graph type',
+        mutate: (quads: Quad[]) => quads.filter(
+          (quad) => quad.predicate !== DKG_ONTOLOGY.RDF_TYPE,
+        ),
+        expected: false,
+      },
+      {
+        name: 'definition attached to a different root',
+        mutate: (quads: Quad[]) => quads.map((quad) => ({
+          ...quad,
+          subject: `${quad.subject}/forged`,
+        })),
+        expected: false,
+      },
+    ];
+
+    for (const [index, proofCase] of cases.entries()) {
+      const contextGraphId = `public/proof-parity-${index}`;
+      const quads = proofCase.mutate(authoritativePublicMetaQuads(contextGraphId));
+      const store = new OxigraphStore();
+      try {
+        await store.insert(quads);
+        const queryResult = await store.query(
+          buildAuthoritativePublicMetaAskQuery(contextGraphId),
+        );
+        expect(queryResult.type, proofCase.name).toBe('boolean');
+        if (queryResult.type !== 'boolean') throw new Error('expected boolean ASK result');
+        expect(
+          hasAuthoritativePublicMetaDefinition(contextGraphId, quads),
+          proofCase.name,
+        ).toBe(proofCase.expected);
+        expect(queryResult.value, proofCase.name).toBe(proofCase.expected);
+      } finally {
+        await store.close();
+      }
+    }
+  });
+});

--- a/packages/agent/test/private-cg-membership-bootstrap.test.ts
+++ b/packages/agent/test/private-cg-membership-bootstrap.test.ts
@@ -195,6 +195,32 @@ describe('private CG membership bootstrap recovery', () => {
     expect(await (agent as any).hasConfirmedMetaState(contextGraphId)).toBe(false);
   });
 
+  it('accepts an explicit public root definition without a member delegation even when publishers are allowlisted', async () => {
+    ({ agent } = await createAgent('PublicBootstrapAuthoritativeMeta'));
+    const contextGraphId = '0x00a9D0dcab936a418ffEbc734476C91D4027d359/balkan-places-to-visit';
+    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+    await (agent as any).store.insert([{
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: contextGraphMetaGraphUri(contextGraphId),
+    }, {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      object: '"public"',
+      graph: contextGraphMetaGraphUri(contextGraphId),
+    }, {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: '"0x1111111111111111111111111111111111111111"',
+      graph: contextGraphMetaGraphUri(contextGraphId),
+    }]);
+
+    expect(await (agent as any).hasConfirmedMetaState(contextGraphId)).toBe(true);
+    expect(await agent.isPrivateContextGraph(contextGraphId)).toBe(false);
+    expect(await (agent as any).canUseSharedMemoryForContextGraph(contextGraphId)).toBe(true);
+  });
+
   it('requires the full identity-bearing private definition before metadata is authoritative', async () => {
     ({ agent } = await createAgent('PrivateBootstrapAuthoritativeMeta'));
     const contextGraphId = 'private/bootstrap/authoritative-meta';
@@ -292,6 +318,23 @@ describe('private CG membership bootstrap recovery', () => {
     }
   });
 
+  it('accepts active public on-chain registration as authoritative without local metadata', async () => {
+    ({ agent } = await createAgent('PublicBootstrapOnChainOnly'));
+    const contextGraphId = 'public/bootstrap/on-chain-only';
+    (agent as any).subscribedContextGraphs.set(contextGraphId, {
+      id: contextGraphId,
+      onChainId: '8',
+      subscribed: true,
+      synced: false,
+      metaSynced: false,
+    });
+    const publicOnChainProof = vi.fn(async () => true);
+    (agent as any).isContextGraphPublicOnChain = publicOnChainProof;
+
+    expect(await (agent as any).hasConfirmedMetaState(contextGraphId)).toBe(true);
+    expect(publicOnChainProof).toHaveBeenCalledWith(contextGraphId, expect.any(Object));
+  });
+
   it('accepts an unregistered public replica only with active public on-chain proof', async () => {
     ({ agent } = await createAgent('PrivateBootstrapPublicReplica'));
     const contextGraphId = 'public/bootstrap/on-chain-replica';
@@ -304,13 +347,13 @@ describe('private CG membership bootstrap recovery', () => {
       pendingMeta: true,
     });
     const publicOnChainProof = vi.fn(async () => true);
-    (agent as any).contextGraphActivePublicOnChainFromRegistry = publicOnChainProof;
+    (agent as any).isContextGraphPublicOnChain = publicOnChainProof;
 
     expect(await (agent as any).hasConfirmedMetaState(
       contextGraphId,
       { rejectUnregisteredPlaceholder: true },
     )).toBe(true);
-    expect(publicOnChainProof).toHaveBeenCalledWith(contextGraphId);
+    expect(publicOnChainProof).toHaveBeenCalledWith(contextGraphId, expect.any(Object));
   });
 
   it('keeps requester decisions local, preserves queued generations, and drops stale decisions', async () => {
@@ -418,6 +461,7 @@ describe('private CG membership bootstrap recovery', () => {
     )));
     expect(oldCuratorForgery).toEqual({ ok: true, skipped: true });
     expect(await agent.getJoinRequestStatus(contextGraphId, agentAddress)).toBe('pending');
+    expect(agent.getSubscribedContextGraphs().has(contextGraphId)).toBe(false);
 
     const nextCuratorDecision = JSON.parse(decoder.decode(await handler(
       encoder.encode(JSON.stringify({

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import type { CatchupJobResult } from '../src/catchup-runner.js';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import { handleQueryRoutes } from '../src/daemon/routes/query.js';
 import { daemonState } from '../src/daemon/state.js';
 
 function cleanEmptyResult(): CatchupJobResult {
@@ -103,6 +104,25 @@ function privateSharedMemoryOnlyResult(): CatchupJobResult {
   return result;
 }
 
+function publicDurableAndSharedMemoryResult(): CatchupJobResult {
+  const result = cleanEmptyResult();
+  if (!result.diagnostics?.durable || !result.diagnostics.sharedMemory) {
+    throw new Error('catch-up diagnostics missing');
+  }
+  if (!result.cleanPlaneCompletions) throw new Error('clean completion proof missing');
+  result.dataSynced = 3;
+  result.sharedMemorySynced = 4;
+  result.diagnostics.durable.emptyResponses = 0;
+  result.diagnostics.durable.fetchedDataTriples = 3;
+  result.diagnostics.durable.insertedDataTriples = 3;
+  result.diagnostics.sharedMemory.emptyResponses = 0;
+  result.diagnostics.sharedMemory.fetchedDataTriples = 4;
+  result.diagnostics.sharedMemory.insertedDataTriples = 4;
+  result.cleanPlaneCompletions.durable = { verifiedDataPeers: 1, emptyPeers: 0 };
+  result.cleanPlaneCompletions.sharedMemory = { verifiedDataPeers: 1, emptyPeers: 0 };
+  return result;
+}
+
 describe('context graph subscribe readiness requires authoritative metadata', () => {
   const previousCatchupRunner = daemonState.catchupRunner;
   let server: Server | undefined;
@@ -121,6 +141,8 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     hasConfirmedMeta: boolean;
     hasConfirmedMetaAfterCatchup?: boolean;
     isPrivate?: boolean;
+    allowedAgents?: string[];
+    callerAddress?: string;
     result?: CatchupJobResult;
     includeSharedMemory?: boolean;
     readiness?: {
@@ -136,6 +158,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     state: Record<string, any>;
     patches: Array<Record<string, unknown>>;
     readiness: Record<string, unknown> | undefined;
+    statusResponse: any;
   }> {
     const contextGraphId = `readiness-${Math.random().toString(36).slice(2, 8)}`;
     const state = new Map<string, Record<string, any>>();
@@ -159,7 +182,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     };
 
     const agent = {
-      getContextGraphAllowedAgents: async () => [],
+      getContextGraphAllowedAgents: async () => opts.allowedAgents ?? [],
       getSubscribedContextGraphs: () => state,
       subscribeToContextGraph: (id: string) => {
         state.set(id, {
@@ -178,12 +201,12 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
       },
       isPrivateContextGraph: async () => opts.isPrivate ?? false,
       resolveAgentByToken: () => undefined,
-      getDefaultAgentAddress: () => '0x0000000000000000000000000000000000000001',
+      getDefaultAgentAddress: () => opts.callerAddress ?? '0x0000000000000000000000000000000000000001',
     };
 
     server = createServer(async (req, res) => {
       const url = new URL(req.url ?? '/', 'http://127.0.0.1');
-      await handleContextGraphRoutes({
+      const routeContext = {
         req,
         res,
         agent,
@@ -219,7 +242,9 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
         path: url.pathname,
         requestToken: undefined,
         requestAgentAddress: undefined,
-      } as any);
+      } as any;
+      await handleContextGraphRoutes(routeContext);
+      if (!res.writableEnded) await handleQueryRoutes(routeContext);
       if (!res.writableEnded) {
         res.statusCode = 404;
         res.end();
@@ -245,6 +270,11 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
 
+    const statusHttpResponse = await fetch(
+      `http://127.0.0.1:${address.port}/api/sync/catchup-status?jobId=${encodeURIComponent(jobId)}`,
+    );
+    const statusResponse = await statusHttpResponse.json() as any;
+
     return {
       response,
       job: catchupTracker.jobs.get(jobId),
@@ -252,6 +282,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
       state: state.get(contextGraphId) ?? {},
       patches,
       readiness,
+      statusResponse,
     };
   }
 
@@ -433,6 +464,48 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     expect(result.runCalls).toBe(1);
     expect(result.job.status).toBe('done');
     expect(result.job.error).toBeUndefined();
+    expect(result.state).toMatchObject({
+      subscribed: true,
+      synced: true,
+      sharedMemorySynced: true,
+      metaSynced: true,
+      pendingMeta: false,
+    });
+    expect(result.readiness).toMatchObject({
+      version: 1,
+      durableVerified: true,
+      sharedMemoryVerified: true,
+    });
+  });
+
+  it('backfills both public planes and exposes the completed subscription job through catchup status', async () => {
+    const result = await subscribe({
+      hasConfirmedMeta: true,
+      // Publishing is allowlisted to a different wallet. Explicit public read
+      // policy must still bypass the private membership gate.
+      allowedAgents: ['0x1111111111111111111111111111111111111111'],
+      callerAddress: '0x2222222222222222222222222222222222222222',
+      result: publicDurableAndSharedMemoryResult(),
+      initial: {
+        subscribed: false,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: true,
+      },
+    });
+
+    expect(result.response.catchup).toMatchObject({
+      status: 'queued',
+      jobId: expect.any(String),
+    });
+    expect(result.statusResponse).toMatchObject({
+      jobId: result.response.catchup.jobId,
+      status: 'done',
+      result: {
+        dataSynced: 3,
+        sharedMemorySynced: 4,
+      },
+    });
     expect(result.state).toMatchObject({
       subscribed: true,
       synced: true,

--- a/packages/node-ui/e2e/specs/left-navigation.spec.ts
+++ b/packages/node-ui/e2e/specs/left-navigation.spec.ts
@@ -44,7 +44,7 @@ test.describe('Left Panel Navigation (rc.12)', () => {
     expect((await leftPanel.getActiveMode())?.trim()).toContain('Context Oracle');
     // The catalogue renders EITHER discovered public CGs OR the empty-state
     // hint — both are valid on a real node depending on what's been synced.
-    const emptyState = page.getByText(/No public catalogue entries yet/i);
+    const emptyState = page.getByText(/No discovered public Context Graphs yet/i);
     const catalogueRows = leftPanel.root.locator('.v10-tree-section');
     await expect
       .poll(async () => (await emptyState.isVisible().catch(() => false)) || (await catalogueRows.count()) > 0)

--- a/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
@@ -122,13 +122,61 @@ export function parseInviteCode(raw: string): ParsedInvite {
   return { cgId, curatorPeerId, legacyMultiaddr, hasUnparsedExtra };
 }
 
-export function shouldSubscribePublicGraph(
+function shouldSubscribePublicGraph(
   invite: ParsedInvite,
   contextGraphs: readonly Pick<ContextGraph, 'id' | 'accessPolicy'>[],
 ): boolean {
   return !invite.hasUnparsedExtra && contextGraphs.some((graph) => (
     graph.id === invite.cgId && normalizeAccessPolicy(graph.accessPolicy) === 'public'
   ));
+}
+
+interface JoinIntentBase {
+  invite: ParsedInvite;
+  validationError: string | null;
+  idleLabel: string;
+  sendingLabel: string;
+}
+
+export type JoinIntent =
+  | (JoinIntentBase & { kind: 'publicSubscribe' })
+  | (JoinIntentBase & { kind: 'privateJoin' });
+
+/** Resolve the modal's two user intents once, including validation and copy. */
+export function resolveJoinIntent(
+  rawInvite: string,
+  contextGraphs: readonly Pick<ContextGraph, 'id' | 'accessPolicy'>[],
+): JoinIntent {
+  const invite = parseInviteCode(rawInvite);
+  if (shouldSubscribePublicGraph(invite, contextGraphs)) {
+    return {
+      kind: 'publicSubscribe',
+      invite,
+      validationError: validateInvite(invite, { allowBareContextGraphId: true }),
+      idleLabel: 'Subscribe',
+      sendingLabel: 'Subscribing…',
+    };
+  }
+  return {
+    kind: 'privateJoin',
+    invite,
+    validationError: validateInvite(invite),
+    idleLabel: 'Request to Join',
+    sendingLabel: 'Sending request…',
+  };
+}
+
+async function warmInviteCuratorConnection(invite: ParsedInvite): Promise<void> {
+  if (invite.curatorPeerId) {
+    await connectToPeerIdWithTimeout(invite.curatorPeerId).catch(() => {});
+    return;
+  }
+  if (invite.legacyMultiaddr) {
+    console.warn(
+      '[DKG] This invite uses a legacy multiaddr (deprecated). Ask the curator to regenerate using the current Share Context Graph modal — V10 invites carry a peer id and resolve via DHT, so they survive relay rotations.',
+    );
+    await connectToPeerWithTimeout(invite.legacyMultiaddr).catch(() => {});
+  }
 }
 
 export function validateInvite(
@@ -300,6 +348,23 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
     }
   }, [open, initialContextGraphId]);
 
+  const activateContextGraph = useCallback((graph: ContextGraph) => {
+    setActiveProject(graph.id);
+    openTab({ id: `project:${graph.id}`, label: graph.name || graph.id, closable: true });
+  }, [setActiveProject, openTab]);
+
+  const refreshAndOpenContextGraph = useCallback(async (
+    cgId: string,
+    fallback?: ContextGraph,
+  ): Promise<ContextGraph | undefined> => {
+    const { contextGraphs: freshList } = await fetchContextGraphs();
+    const freshContextGraphs: ContextGraph[] = freshList ?? [];
+    setContextGraphs(freshContextGraphs);
+    const graph = freshContextGraphs.find((candidate) => candidate.id === cgId) ?? fallback;
+    if (graph) activateContextGraph(graph);
+    return graph;
+  }, [setContextGraphs, activateContextGraph]);
+
   // Drive the post-approval flow: refresh the sidebar, focus the new
   // CG's tab, and hand off to the wire-workspace step. Idempotent —
   // safe to call from both the SSE join_approved handler and the
@@ -310,12 +375,8 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
   const transitionToApproved = useCallback(async (cgId: string) => {
     setPhase('approved');
     try {
-      const { contextGraphs: freshList } = await fetchContextGraphs();
-      setContextGraphs(freshList ?? []);
-      const joined = freshList?.find((cg: any) => cg.id === cgId);
+      const joined = await refreshAndOpenContextGraph(cgId);
       if (joined) {
-        setActiveProject(joined.id);
-        openTab({ id: `project:${joined.id}`, label: joined.name || joined.id, closable: true });
         setWiredProjectName(joined.name ?? cgId);
         setWiredCgId(cgId);
       }
@@ -324,7 +385,7 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
       // modal and re-open the project from the (eventually-refreshed)
       // sidebar.
     }
-  }, [setContextGraphs, setActiveProject, openTab]);
+  }, [refreshAndOpenContextGraph]);
 
   // Auto-transition to wire-workspace when the curator approves a
   // pending request. The SSE event arrives when the daemon's
@@ -354,40 +415,29 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
   if (!open) return null;
 
   const handleRequestJoin = async () => {
-    const invite = parseInviteCode(inviteCode);
-    const publicSubscription = shouldSubscribePublicGraph(invite, contextGraphs);
-    const inviteError = validateInvite(invite, {
-      allowBareContextGraphId: publicSubscription,
-    });
-    if (inviteError) {
-      setError(inviteError);
+    const intent = resolveJoinIntent(inviteCode, contextGraphs);
+    if (intent.validationError) {
+      setError(intent.validationError);
       return;
     }
-    const { cgId, curatorPeerId, legacyMultiaddr } = invite;
+    const { cgId, curatorPeerId } = intent.invite;
 
     setError(null);
 
-    if (publicSubscription) {
+    if (intent.kind === 'publicSubscribe') {
       setPhase('sending');
       try {
-        const existing = contextGraphs.find((cg: any) => cg.id === cgId);
-        if (!existing?.subscribed) {
-          // Public read/subscription is an explicit local opt-in. The daemon
-          // queues the same tracked durable+SWM catch-up job used by the CLI;
-          // no curator approval or member delegation participates.
-          await subscribeToContextGraph(cgId);
-        }
-        const { contextGraphs: freshList } = await fetchContextGraphs();
-        setContextGraphs(freshList ?? []);
-        const subscribed = freshList?.find((cg: any) => cg.id === cgId) ?? existing;
-        if (subscribed) {
-          setActiveProject(subscribed.id);
-          openTab({
-            id: `project:${subscribed.id}`,
-            label: subscribed.name || subscribed.id,
-            closable: true,
-          });
-        }
+        const existing = contextGraphs.find((graph) => graph.id === cgId);
+        // Public read/subscription is an explicit local opt-in. Always hand the
+        // intent to the daemon: `subscribed=true` is not readiness proof, and
+        // the idempotent route either reuses an active/done job or queues the
+        // durable+SWM catch-up needed by a subscribed-but-unsynced graph.
+        // A pasted invite may be the only fresh source hint, so warm that
+        // connection before the daemon snapshots its preferred/fallback peer
+        // cohort for the catch-up job. Dial failure remains best-effort.
+        await warmInviteCuratorConnection(intent.invite);
+        await subscribeToContextGraph(cgId);
+        await refreshAndOpenContextGraph(cgId, existing);
         onClose();
       } catch (err: unknown) {
         setError(err instanceof Error ? err.message : 'Could not subscribe to this public context graph.');
@@ -399,10 +449,9 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
     // Pre-check: if we already have this CG locally (previous join, or
     // curator added us via add-agent), just open it. No need to re-sign
     // a delegation we don't need.
-    const existing = contextGraphs.find((cg: any) => cg.id === cgId);
+    const existing = contextGraphs.find((graph) => graph.id === cgId);
     if (existing) {
-      setActiveProject(existing.id);
-      openTab({ id: `project:${existing.id}`, label: existing.name || existing.id, closable: true });
+      activateContextGraph(existing);
       onClose();
       return;
     }
@@ -413,14 +462,7 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
       // Warm the curator path so the daemon's targeted `forwardJoinRequest`
       // dial doesn't pay the full DHT-walk + relay-handshake cost. Best-
       // effort — the daemon will retry via DHT internally.
-      if (curatorPeerId) {
-        await connectToPeerIdWithTimeout(curatorPeerId).catch(() => {});
-      } else if (legacyMultiaddr) {
-        console.warn(
-          '[DKG] This invite uses a legacy multiaddr (deprecated). Ask the curator to regenerate using the current Share Context Graph modal — V10 invites carry a peer id and resolve via DHT, so they survive relay rotations.',
-        );
-        await connectToPeerWithTimeout(legacyMultiaddr).catch(() => {});
-      }
+      await warmInviteCuratorConnection(intent.invite);
 
       const signed = await signJoinRequest(cgId);
       const agentName = await fetchCurrentAgent().then((i) => i.name).catch(() => undefined);
@@ -510,10 +552,7 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
   const pending = phase === 'pending';
   const approved = phase === 'approved';
   const rejected = phase === 'rejected';
-  const publicSubscription = shouldSubscribePublicGraph(
-    parseInviteCode(inviteCode),
-    contextGraphs,
-  );
+  const intent = resolveJoinIntent(inviteCode, contextGraphs);
 
   return (
     <div
@@ -607,14 +646,12 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
             disabled={!inviteCode.trim() || sending || pending || approved}
           >
             {sending
-              ? (publicSubscription ? 'Subscribing…' : 'Sending request…')
+              ? intent.sendingLabel
               : pending
                 ? 'Awaiting approval…'
                 : approved
                   ? 'Approved'
-                  : publicSubscription
-                    ? 'Subscribe'
-                    : 'Request to Join'}
+                  : intent.idleLabel}
           </button>
         </div>
       </div>

--- a/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
@@ -3,11 +3,13 @@ import {
   fetchContextGraphs,
   signJoinRequest, submitJoinRequest, fetchCurrentAgent,
   connectToPeerWithTimeout, connectToPeerIdWithTimeout,
+  subscribeToContextGraph,
   HttpError,
 } from '../../api.js';
-import { useProjectsStore } from '../../stores/projects.js';
+import { useProjectsStore, type ContextGraph } from '../../stores/projects.js';
 import { useTabsStore } from '../../stores/tabs.js';
 import { useNodeEvents } from '../../hooks/useNodeEvents.js';
+import { normalizeAccessPolicy } from '../../lib/contextGraphSidebar.js';
 import { WireWorkspacePanel } from '../Workspace/WireWorkspacePanel.js';
 import { useModalDismiss } from './useModalDismiss.js';
 
@@ -120,18 +122,28 @@ export function parseInviteCode(raw: string): ParsedInvite {
   return { cgId, curatorPeerId, legacyMultiaddr, hasUnparsedExtra };
 }
 
-export function validateInvite(invite: ParsedInvite): string | null {
+export function shouldSubscribePublicGraph(
+  invite: ParsedInvite,
+  contextGraphs: readonly Pick<ContextGraph, 'id' | 'accessPolicy'>[],
+): boolean {
+  return !invite.hasUnparsedExtra && contextGraphs.some((graph) => (
+    graph.id === invite.cgId && normalizeAccessPolicy(graph.accessPolicy) === 'public'
+  ));
+}
+
+export function validateInvite(
+  invite: ParsedInvite,
+  options: { allowBareContextGraphId?: boolean } = {},
+): string | null {
   if (!invite.cgId) return 'Missing context graph ID';
   if (invite.hasUnparsedExtra) {
     return 'Invite contains a second line that is not a valid peer ID (12D3Koo…) or multiaddr (/ip4/…). Check for typos.';
   }
-  // V10: every join requires a curator peer id (the daemon's
+  // V10 private joins require a curator peer id (the daemon's
   // `/request-join` returns 400 when curatorPeerId is absent — see
-  // `forwardJoinRequest`). A bare cgId would silently 400 here, so
-  // reject it loudly with actionable copy. The old subscribe-to-public-CG
-  // paste flow has been removed; users who want a public CG that hasn't
-  // surfaced in the Oracle yet need to ask the creator for an invite.
-  if (!invite.curatorPeerId && !invite.legacyMultiaddr) {
+  // `forwardJoinRequest`). A discovered graph whose explicit access policy is
+  // public uses `/api/subscribe` instead and deliberately needs no invite.
+  if (!invite.curatorPeerId && !invite.legacyMultiaddr && !options.allowBareContextGraphId) {
     return 'This invite is missing the curator peer id. Ask the curator to regenerate the invite from the Share Context Graph dialog.';
   }
   if (invite.legacyMultiaddr) {
@@ -343,7 +355,10 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
 
   const handleRequestJoin = async () => {
     const invite = parseInviteCode(inviteCode);
-    const inviteError = validateInvite(invite);
+    const publicSubscription = shouldSubscribePublicGraph(invite, contextGraphs);
+    const inviteError = validateInvite(invite, {
+      allowBareContextGraphId: publicSubscription,
+    });
     if (inviteError) {
       setError(inviteError);
       return;
@@ -351,6 +366,35 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
     const { cgId, curatorPeerId, legacyMultiaddr } = invite;
 
     setError(null);
+
+    if (publicSubscription) {
+      setPhase('sending');
+      try {
+        const existing = contextGraphs.find((cg: any) => cg.id === cgId);
+        if (!existing?.subscribed) {
+          // Public read/subscription is an explicit local opt-in. The daemon
+          // queues the same tracked durable+SWM catch-up job used by the CLI;
+          // no curator approval or member delegation participates.
+          await subscribeToContextGraph(cgId);
+        }
+        const { contextGraphs: freshList } = await fetchContextGraphs();
+        setContextGraphs(freshList ?? []);
+        const subscribed = freshList?.find((cg: any) => cg.id === cgId) ?? existing;
+        if (subscribed) {
+          setActiveProject(subscribed.id);
+          openTab({
+            id: `project:${subscribed.id}`,
+            label: subscribed.name || subscribed.id,
+            closable: true,
+          });
+        }
+        onClose();
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Could not subscribe to this public context graph.');
+        setPhase('idle');
+      }
+      return;
+    }
 
     // Pre-check: if we already have this CG locally (previous join, or
     // curator added us via add-agent), just open it. No need to re-sign
@@ -466,6 +510,10 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
   const pending = phase === 'pending';
   const approved = phase === 'approved';
   const rejected = phase === 'rejected';
+  const publicSubscription = shouldSubscribePublicGraph(
+    parseInviteCode(inviteCode),
+    contextGraphs,
+  );
 
   return (
     <div
@@ -494,7 +542,7 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
         <div className="v10-modal-header">
           <div id="dkg-join-cg-title" className="v10-modal-title">Join a Context Graph</div>
           <div id="dkg-join-cg-subtitle" className="v10-modal-subtitle">
-            Paste the invite from the curator. Your node will send a signed join request and wait for approval.
+            Enter a discovered public Context Graph ID to subscribe, or paste a curator invite for a private graph.
           </div>
         </div>
 
@@ -532,12 +580,12 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
           )}
 
           <div className="v10-form-group">
-            <label className="v10-form-label" htmlFor="dkg-cg-invite">Invite Code</label>
+            <label className="v10-form-label" htmlFor="dkg-cg-invite">Context Graph ID or Invite Code</label>
             <textarea
               id="dkg-cg-invite"
               name="dkg-cg-invite"
               className="v10-form-textarea"
-              placeholder={"Paste the invite code from the context graph curator.\n\ne.g.\nmy-context-graph-abc123\n12D3KooW..."}
+              placeholder={"Public: paste a Context Graph ID\n\nPrivate: paste the curator invite\nmy-context-graph-abc123\n12D3KooW..."}
               value={inviteCode}
               onChange={(e) => setInviteCode(e.target.value)}
               autoFocus
@@ -558,7 +606,15 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
             onClick={handleRequestJoin}
             disabled={!inviteCode.trim() || sending || pending || approved}
           >
-            {sending ? 'Sending request…' : pending ? 'Awaiting approval…' : approved ? 'Approved' : 'Request to Join'}
+            {sending
+              ? (publicSubscription ? 'Subscribing…' : 'Sending request…')
+              : pending
+                ? 'Awaiting approval…'
+                : approved
+                  ? 'Approved'
+                  : publicSubscription
+                    ? 'Subscribe'
+                    : 'Request to Join'}
           </button>
         </div>
       </div>

--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -18,6 +18,7 @@ import {
 import {
   belongsInContextOracleSidebar,
   belongsInMyProjectsSidebar,
+  classifyContextOracleEntry,
   toSidebarIdentity,
   type AgentSidebarIdentity,
 } from '../../lib/contextGraphSidebar.js';
@@ -59,6 +60,56 @@ function ProjectTreeItem({
           className="v10-tree-hide-btn"
           title="Hide this context graph from the sidebar (reversible)"
           onClick={(e) => { e.stopPropagation(); onHide(); }}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface OracleCatalogueItemProps {
+  cg: ContextGraph;
+  isBrowsing: boolean;
+  onBrowse: () => void;
+  onSubscribe: () => void;
+  onHide: () => void;
+}
+
+function OracleCatalogueItem({
+  cg,
+  isBrowsing,
+  onBrowse,
+  onSubscribe,
+  onHide,
+}: OracleCatalogueItemProps) {
+  const label = cg.name || cg.id.slice(0, 16);
+  return (
+    <div className="v10-tree-section">
+      <div className={`v10-tree-section-header catalogue ${isBrowsing ? 'active' : ''}`}>
+        <span className="v10-tree-project-dot" />
+        <span className="v10-tree-section-label">{label}</span>
+        <button
+          type="button"
+          className="v10-tree-catalogue-btn"
+          aria-label={`Browse ${label}`}
+          onClick={onBrowse}
+        >
+          Browse
+        </button>
+        <button
+          type="button"
+          className="v10-tree-catalogue-btn primary"
+          aria-label={`Subscribe to ${label}`}
+          onClick={onSubscribe}
+        >
+          Subscribe
+        </button>
+        <button
+          type="button"
+          className="v10-tree-hide-btn"
+          title="Hide this context graph from the sidebar (reversible)"
+          onClick={onHide}
         >
           ×
         </button>
@@ -176,6 +227,17 @@ export function PanelLeft() {
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showJoinModal, setShowJoinModal] = useState(false);
+  const [joinContextGraphId, setJoinContextGraphId] = useState<string | undefined>();
+
+  const openJoinModal = useCallback((contextGraphId?: string) => {
+    setJoinContextGraphId(contextGraphId);
+    setShowJoinModal(true);
+  }, []);
+
+  const closeJoinModal = useCallback(() => {
+    setShowJoinModal(false);
+    setJoinContextGraphId(undefined);
+  }, []);
 
   const loadCGs = useCallback(() => {
     setLoading(true);
@@ -202,7 +264,7 @@ export function PanelLeft() {
     <div className="v10-panel-left">
       <div style={{ display: 'flex', gap: 4, padding: '8px 8px 4px' }}>
         <button className="v10-new-project-btn" onClick={() => setShowCreateModal(true)}>+ New Context Graph</button>
-        <button className="v10-new-project-btn" onClick={() => setShowJoinModal(true)}>↗ Join Context Graph</button>
+        <button className="v10-new-project-btn" onClick={() => openJoinModal()}>↗ Join Context Graph</button>
       </div>
 
       <div className="v10-tree-header">
@@ -347,21 +409,42 @@ export function PanelLeft() {
           {contextOracleProjects.length > 0 && (
             <>
               <div className="v10-tree-group-label">Context Oracle</div>
-              {contextOracleProjects.map((cg) => (
-                <ProjectTreeItem
-                  key={cg.id}
-                  cg={cg}
-                  isActive={activeProjectId === cg.id}
-                  onSelect={() => {
-                    setActiveProject(cg.id);
-                    openTab({ id: `project:${cg.id}`, label: cg.name || cg.id.slice(0, 16), closable: true });
-                  }}
-                  onHide={() => {
-                    hideProject(cg.id);
-                    if (activeProjectId === cg.id) setActiveProject(null);
-                  }}
-                />
-              ))}
+              {contextOracleProjects.map((cg) => {
+                const onHide = () => {
+                  hideProject(cg.id);
+                  if (activeProjectId === cg.id) setActiveProject(null);
+                };
+                if (classifyContextOracleEntry(cg) === 'catalogue') {
+                  return (
+                    <OracleCatalogueItem
+                      key={cg.id}
+                      cg={cg}
+                      isBrowsing={activeTabId === `project:${cg.id}`}
+                      onBrowse={() => {
+                        openTab({
+                          id: `project:${cg.id}`,
+                          label: cg.name || cg.id.slice(0, 16),
+                          closable: true,
+                        });
+                      }}
+                      onSubscribe={() => openJoinModal(cg.id)}
+                      onHide={onHide}
+                    />
+                  );
+                }
+                return (
+                  <ProjectTreeItem
+                    key={cg.id}
+                    cg={cg}
+                    isActive={activeProjectId === cg.id}
+                    onSelect={() => {
+                      setActiveProject(cg.id);
+                      openTab({ id: `project:${cg.id}`, label: cg.name || cg.id.slice(0, 16), closable: true });
+                    }}
+                    onHide={onHide}
+                  />
+                );
+              })}
             </>
           )}
           {contextOracleProjects.length === 0 && (
@@ -383,7 +466,11 @@ export function PanelLeft() {
       )}
 
       <CreateProjectModal open={showCreateModal} onClose={() => setShowCreateModal(false)} />
-      <JoinProjectModal open={showJoinModal} onClose={() => setShowJoinModal(false)} />
+      <JoinProjectModal
+        open={showJoinModal}
+        onClose={closeJoinModal}
+        initialContextGraphId={joinContextGraphId}
+      />
     </div>
   );
 }

--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -366,7 +366,7 @@ export function PanelLeft() {
           )}
           {contextOracleProjects.length === 0 && (
             <p style={{ fontSize: 12, color: 'var(--text-tertiary)', padding: '20px 12px', textAlign: 'center', lineHeight: 1.5 }}>
-              No public catalogue entries yet. Context graphs you sync or curate appear under <strong>Context Graphs</strong>; non-private graphs you discover but haven&apos;t joined list here — use <strong>Join Context Graph</strong> to subscribe.
+              No discovered public Context Graphs yet. Public graphs appear here as soon as your node discovers them; use <strong>Join Context Graph</strong> to subscribe by ID.
             </p>
           )}
           {hiddenCount > 0 && (

--- a/packages/node-ui/src/ui/lib/contextGraphSidebar.ts
+++ b/packages/node-ui/src/ui/lib/contextGraphSidebar.ts
@@ -104,3 +104,10 @@ export function belongsInContextOracleSidebar(cg: ContextGraph, identity: AgentS
   if (normalizeAccessPolicy(cg.accessPolicy) !== 'public') return false;
   return true;
 }
+
+export type ContextOracleEntryKind = 'catalogue' | 'project';
+
+/** Passive discoveries need explicit Browse/Subscribe actions, not project-row semantics. */
+export function classifyContextOracleEntry(cg: ContextGraph): ContextOracleEntryKind {
+  return cg.subscribed === true || cg.synced === true ? 'project' : 'catalogue';
+}

--- a/packages/node-ui/src/ui/lib/contextGraphSidebar.ts
+++ b/packages/node-ui/src/ui/lib/contextGraphSidebar.ts
@@ -95,29 +95,12 @@ export function computeSelectableProjects(
  *     they ended up in the local list (chain auto-subscribe, manual subscribe,
  *     dev script).
  *
- *  2. ONLY graphs the daemon has actually interacted with (`subscribed` OR
- *     `synced`). Without this filter the Oracle becomes a dumping ground for
- *     every CG the node has ever heard about via gossip — on a long-running
- *     testnet node that's hundreds of stale `*-smoke`, `*-test`, etc. entries
- *     whose curators are long gone. The filter narrows to entries where the
- *     daemon either holds an active subscription (so future gossip lands)
- *     or has at least one successful catchup on file (so the CG is known
- *     to actually exist on a reachable peer).
- *
- *     The Join Project modal does NOT compensate for an Oracle miss: it
- *     now requires a curator-supplied invite (cgId + curator peer id) so
- *     `/request-join` has somewhere to forward the signed delegation.
- *     Bare-cgId paste is rejected client-side (see `validateInvite`).
- *     A user who wants to join a public CG that hasn't surfaced here yet
- *     either waits for it to gossip from a subscribed peer, or asks the
- *     creator for an invite.
- *
- *  Older daemons that don't populate `synced` continue to work — `subscribed`
- *  alone gates the result, and brand-new nodes with no subscriptions just see
- *  an empty Oracle (rather than wading through historical noise from peers).
+ *  2. Discovery is catalogue state, not membership. An explicitly-public
+ *     graph belongs here before subscription or catch-up so users can browse
+ *     it and opt in without asking a curator for an unnecessary invitation.
  */
 export function belongsInContextOracleSidebar(cg: ContextGraph, identity: AgentSidebarIdentity | null): boolean {
   if (belongsInMyProjectsSidebar(cg, identity)) return false;
   if (normalizeAccessPolicy(cg.accessPolicy) !== 'public') return false;
-  return cg.subscribed === true || cg.synced === true;
+  return true;
 }

--- a/packages/node-ui/src/ui/stores/projects.ts
+++ b/packages/node-ui/src/ui/stores/projects.ts
@@ -16,7 +16,7 @@ export interface ContextGraph {
    * the local store for this CG. Distinct from `subscribed`: a CG can be
    * subscribed but never synced (no peer holds the data), and conversely a CG
    * can be synced but no longer subscribed (we caught up once and unsubscribed).
-   * Used by the Context Oracle sidebar to hide stale entries the daemon learned
+   * Used to distinguish active subscriptions from catalogue-only graphs learned
    * about via gossip but never actually interacted with.
    */
   synced?: boolean;

--- a/packages/node-ui/src/ui/styles/03-left-center.css
+++ b/packages/node-ui/src/ui/styles/03-left-center.css
@@ -61,6 +61,7 @@
 }
 .v10-tree-section-header:hover { background: var(--bg-hover); }
 .v10-tree-section-header.active { background: var(--bg-active); }
+.v10-tree-section-header.catalogue { cursor: default; gap: 6px; }
 .v10-tree-chevron {
   color: var(--text-tertiary);
   transition: transform 0.15s;
@@ -98,6 +99,25 @@
 .v10-tree-hide-btn:hover {
   background: rgba(239, 68, 68, 0.12);
   color: var(--accent-red, #ef4444);
+}
+.v10-tree-catalogue-btn {
+  flex-shrink: 0;
+  border: 1px solid var(--border-primary);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-tertiary);
+  padding: 2px 5px;
+  font-size: 10px;
+  line-height: 1.3;
+  cursor: pointer;
+}
+.v10-tree-catalogue-btn:hover {
+  border-color: var(--text-tertiary);
+  color: var(--text-primary);
+}
+.v10-tree-catalogue-btn.primary {
+  border-color: color-mix(in srgb, var(--accent-primary) 55%, transparent);
+  color: var(--accent-primary);
 }
 
 /* "My Projects" / "Participating Projects" group dividers. Token

--- a/packages/node-ui/test/contextGraphSidebar.test.ts
+++ b/packages/node-ui/test/contextGraphSidebar.test.ts
@@ -3,6 +3,7 @@ import {
   belongsInContextOracleSidebar,
   belongsInMyProjectsSidebar,
   canonicalAgentDid,
+  classifyContextOracleEntry,
   computeSelectableProjects,
 } from '../src/ui/lib/contextGraphSidebar.js';
 import type { ContextGraph } from '../src/ui/stores/projects.js';
@@ -102,6 +103,20 @@ describe('contextGraphSidebar', () => {
       creator: 'did:dkg:agent:0x1000000000000000000000000000000000000000',
     } as ContextGraph;
     expect(belongsInContextOracleSidebar(cg, id)).toBe(true);
+    expect(classifyContextOracleEntry(cg)).toBe('catalogue');
+  });
+
+  it('classifies an explicitly subscribed or synced Oracle entry as a project', () => {
+    expect(classifyContextOracleEntry({
+      id: 'subscribed',
+      name: 'Subscribed',
+      subscribed: true,
+    })).toBe('project');
+    expect(classifyContextOracleEntry({
+      id: 'synced',
+      name: 'Synced',
+      synced: true,
+    })).toBe('project');
   });
 
   it('neither oracle: private unsolicited', () => {

--- a/packages/node-ui/test/contextGraphSidebar.test.ts
+++ b/packages/node-ui/test/contextGraphSidebar.test.ts
@@ -93,12 +93,7 @@ describe('contextGraphSidebar', () => {
     expect(belongsInContextOracleSidebar(cg, id)).toBe(true);
   });
 
-  it('oracle: public, not mine, NEITHER subscribed nor synced — excluded as stale', () => {
-    // The Oracle should NOT show graphs the daemon has only ever heard about
-    // via gossip without any actual interaction. On a long-running testnet
-    // node those stale entries dominate the list (hundreds of one-off
-    // smoke/test CGs whose curators are long gone). A user who wants to join
-    // such a CG can still paste its ID into "Join Project" directly.
+  it('oracle: discovered public graph is browseable before subscription or sync', () => {
     const cg = {
       id: 'x',
       name: 'n',
@@ -106,7 +101,7 @@ describe('contextGraphSidebar', () => {
       accessPolicy: 'public',
       creator: 'did:dkg:agent:0x1000000000000000000000000000000000000000',
     } as ContextGraph;
-    expect(belongsInContextOracleSidebar(cg, id)).toBe(false);
+    expect(belongsInContextOracleSidebar(cg, id)).toBe(true);
   });
 
   it('neither oracle: private unsolicited', () => {

--- a/packages/node-ui/test/join-project-modal.interaction.test.ts
+++ b/packages/node-ui/test/join-project-modal.interaction.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+const {
+  fetchContextGraphsMock,
+  subscribeToContextGraphMock,
+  signJoinRequestMock,
+  submitJoinRequestMock,
+  fetchCurrentAgentMock,
+  connectToPeerWithTimeoutMock,
+  connectToPeerIdWithTimeoutMock,
+} = vi.hoisted(() => ({
+  fetchContextGraphsMock: vi.fn(),
+  subscribeToContextGraphMock: vi.fn(),
+  signJoinRequestMock: vi.fn(),
+  submitJoinRequestMock: vi.fn(),
+  fetchCurrentAgentMock: vi.fn(),
+  connectToPeerWithTimeoutMock: vi.fn(),
+  connectToPeerIdWithTimeoutMock: vi.fn(),
+}));
+
+vi.mock('../src/ui/api.js', async () => {
+  const actual = await vi.importActual<any>('../src/ui/api.js');
+  return {
+    ...actual,
+    fetchContextGraphs: fetchContextGraphsMock,
+    subscribeToContextGraph: subscribeToContextGraphMock,
+    signJoinRequest: signJoinRequestMock,
+    submitJoinRequest: submitJoinRequestMock,
+    fetchCurrentAgent: fetchCurrentAgentMock,
+    connectToPeerWithTimeout: connectToPeerWithTimeoutMock,
+    connectToPeerIdWithTimeout: connectToPeerIdWithTimeoutMock,
+  };
+});
+
+vi.mock('../src/ui/components/Workspace/WireWorkspacePanel.js', () => ({
+  WireWorkspacePanel: ({ contextGraphId }: { contextGraphId: string }) =>
+    React.createElement('div', { 'data-testid': 'wire-workspace' }, contextGraphId),
+}));
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function flush(): Promise<void> {
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+}
+
+describe('JoinProjectModal public subscription interaction', () => {
+  beforeEach(async () => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+    (globalThis as any).EventSource = class {
+      constructor(_url: string) {}
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+      onopen = null;
+      onmessage = null;
+      onerror = null;
+    };
+
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+    const { useTabsStore } = await import('../src/ui/stores/tabs.js');
+    useProjectsStore.setState({
+      contextGraphs: [{
+        id: 'open-project',
+        name: 'Open Project',
+        accessPolicy: 'public',
+        subscribed: true,
+        synced: false,
+      }],
+      loading: false,
+      activeProjectId: null,
+    });
+    useTabsStore.setState({
+      tabs: [{ id: 'dashboard', label: 'Dashboard', closable: false }],
+      activeTabId: 'dashboard',
+    });
+
+    subscribeToContextGraphMock.mockResolvedValue({
+      subscribed: 'open-project',
+      catchup: { status: 'queued', jobId: 'catchup-1' },
+    });
+    fetchContextGraphsMock.mockResolvedValue({
+      contextGraphs: [{
+        id: 'open-project',
+        name: 'Open Project',
+        accessPolicy: 'public',
+        subscribed: true,
+        synced: false,
+      }],
+    });
+  });
+
+  afterEach(() => {
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+  });
+
+  async function renderModal(initialContextGraphId: string) {
+    const { JoinProjectModal } = await import('../src/ui/components/Modals/JoinProjectModal.js');
+    const onClose = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mountedRoots.push(root);
+    mountedContainers.push(container);
+
+    await act(async () => {
+      root.render(React.createElement(JoinProjectModal, {
+        open: true,
+        onClose,
+        initialContextGraphId,
+      }));
+    });
+    await flush();
+    return { container, onClose };
+  }
+
+  it.each([
+    { subscribed: false, caseName: 'starts a first subscription' },
+    { subscribed: true, caseName: 'retries catch-up for a subscribed-but-unsynced graph' },
+  ])('$caseName through the rendered public modal path', async ({ subscribed }) => {
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+    const { useTabsStore } = await import('../src/ui/stores/tabs.js');
+    const publicGraph = {
+      id: 'open-project',
+      name: 'Open Project',
+      accessPolicy: 'public',
+      subscribed,
+      synced: false,
+    };
+    useProjectsStore.setState({ contextGraphs: [publicGraph] });
+    fetchContextGraphsMock.mockResolvedValue({ contextGraphs: [publicGraph] });
+    const { container, onClose } = await renderModal('open-project');
+
+    const primary = container.querySelector('.v10-modal-btn.primary') as HTMLButtonElement;
+    expect(primary.textContent).toBe('Subscribe');
+
+    await act(async () => { primary.click(); });
+    await flush();
+
+    expect(subscribeToContextGraphMock).toHaveBeenCalledWith('open-project');
+    expect(fetchContextGraphsMock).toHaveBeenCalled();
+    expect(signJoinRequestMock).not.toHaveBeenCalled();
+    expect(submitJoinRequestMock).not.toHaveBeenCalled();
+    expect(useProjectsStore.getState().activeProjectId).toBe('open-project');
+    expect(useTabsStore.getState()).toMatchObject({ activeTabId: 'project:open-project' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('dials a curator supplied with a public invite before queuing subscription catch-up', async () => {
+    const curatorPeerId = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+    connectToPeerIdWithTimeoutMock.mockResolvedValue(undefined);
+    const { container } = await renderModal(`open-project\n${curatorPeerId}`);
+
+    const primary = container.querySelector('.v10-modal-btn.primary') as HTMLButtonElement;
+    await act(async () => { primary.click(); });
+    await flush();
+
+    expect(connectToPeerIdWithTimeoutMock).toHaveBeenCalledWith(curatorPeerId);
+    expect(subscribeToContextGraphMock).toHaveBeenCalledWith('open-project');
+    expect(connectToPeerIdWithTimeoutMock.mock.invocationCallOrder[0]).toBeLessThan(
+      subscribeToContextGraphMock.mock.invocationCallOrder[0],
+    );
+    expect(signJoinRequestMock).not.toHaveBeenCalled();
+    expect(submitJoinRequestMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node-ui/test/join-project-modal.test.ts
+++ b/packages/node-ui/test/join-project-modal.test.ts
@@ -4,7 +4,7 @@ import {
   validateInvite,
   formatJoinRequestError,
   joinRequestWasApproved,
-  shouldSubscribePublicGraph,
+  resolveJoinIntent,
 } from '../src/ui/components/Modals/JoinProjectModal.js';
 import { HttpError } from '../src/ui/api.js';
 
@@ -47,27 +47,32 @@ describe('JoinProjectModal invite parsing', () => {
         subscribed: false,
         synced: false,
       }];
-      expect(shouldSubscribePublicGraph(parsed, publicGraphs)).toBe(true);
+      expect(resolveJoinIntent('open-project', publicGraphs)).toMatchObject({
+        kind: 'publicSubscribe',
+        validationError: null,
+        idleLabel: 'Subscribe',
+      });
       expect(validateInvite(parsed, { allowBareContextGraphId: true })).toBeNull();
     });
 
     it('keeps an explicitly public graph on the subscribe path when an old curator invite is pasted', () => {
-      const parsed = parseInviteCode('open-project\n12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6');
-
-      expect(shouldSubscribePublicGraph(parsed, [{
+      expect(resolveJoinIntent('open-project\n12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6', [{
         id: 'open-project',
         accessPolicy: 'public',
-      }])).toBe(true);
+      }]).kind).toBe('publicSubscribe');
     });
 
     it('still requires a curator invite for a private or unknown bare context graph id', () => {
       const parsed = parseInviteCode('private-project');
-      expect(shouldSubscribePublicGraph(parsed, [{
+      expect(resolveJoinIntent('private-project', [{
         id: 'private-project',
         name: 'Private Project',
         accessPolicy: 'private',
-      }])).toBe(false);
-      expect(shouldSubscribePublicGraph(parsed, [])).toBe(false);
+      }])).toMatchObject({
+        kind: 'privateJoin',
+        validationError: expect.stringContaining('curator peer id'),
+      });
+      expect(resolveJoinIntent('private-project', []).kind).toBe('privateJoin');
       expect(validateInvite(parsed)).toContain('curator peer id');
     });
 

--- a/packages/node-ui/test/join-project-modal.test.ts
+++ b/packages/node-ui/test/join-project-modal.test.ts
@@ -4,6 +4,7 @@ import {
   validateInvite,
   formatJoinRequestError,
   joinRequestWasApproved,
+  shouldSubscribePublicGraph,
 } from '../src/ui/components/Modals/JoinProjectModal.js';
 import { HttpError } from '../src/ui/api.js';
 
@@ -33,20 +34,41 @@ describe('JoinProjectModal invite parsing', () => {
       expect(parsed.legacyMultiaddr).toBeNull();
     });
 
-    // PR #448 review: V10 `/request-join` requires a curator peer id, so
-    // a bare cgId now 400s on the daemon. validateInvite rejects it
-    // client-side instead, with actionable copy. The old subscribe-to-public
-    // paste flow has been removed; users who want a public CG that
-    // hasn't surfaced in the Oracle have to ask the curator for an invite.
-    it('rejects invite with only a cgId (no curator peer id)', () => {
+    it('uses the public subscribe path for a discovered public graph with no curator invite', () => {
       const parsed = parseInviteCode('open-project');
       expect(parsed.cgId).toBe('open-project');
       expect(parsed.curatorPeerId).toBeNull();
       expect(parsed.legacyMultiaddr).toBeNull();
       expect(parsed.hasUnparsedExtra).toBe(false);
-      const err = validateInvite(parsed);
-      expect(err).not.toBeNull();
-      expect(err).toContain('curator peer id');
+      const publicGraphs = [{
+        id: 'open-project',
+        name: 'Open Project',
+        accessPolicy: 'public',
+        subscribed: false,
+        synced: false,
+      }];
+      expect(shouldSubscribePublicGraph(parsed, publicGraphs)).toBe(true);
+      expect(validateInvite(parsed, { allowBareContextGraphId: true })).toBeNull();
+    });
+
+    it('keeps an explicitly public graph on the subscribe path when an old curator invite is pasted', () => {
+      const parsed = parseInviteCode('open-project\n12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6');
+
+      expect(shouldSubscribePublicGraph(parsed, [{
+        id: 'open-project',
+        accessPolicy: 'public',
+      }])).toBe(true);
+    });
+
+    it('still requires a curator invite for a private or unknown bare context graph id', () => {
+      const parsed = parseInviteCode('private-project');
+      expect(shouldSubscribePublicGraph(parsed, [{
+        id: 'private-project',
+        name: 'Private Project',
+        accessPolicy: 'private',
+      }])).toBe(false);
+      expect(shouldSubscribePublicGraph(parsed, [])).toBe(false);
+      expect(validateInvite(parsed)).toContain('curator peer id');
     });
 
     it('validates a peer-id invite as ok', () => {

--- a/packages/node-ui/test/panel-left.test.ts
+++ b/packages/node-ui/test/panel-left.test.ts
@@ -240,6 +240,44 @@ describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
     expect(container.textContent).not.toContain('Catalog Only CG');
   });
 
+  it('explains that discovered public graphs are browseable before subscription', async () => {
+    const { container } = await renderPanel();
+    const modeButtons = container.querySelectorAll('.v10-tree-mode-btn');
+
+    await act(async () => {
+      (modeButtons[1] as HTMLButtonElement).click();
+    });
+
+    expect(container.textContent).toContain('Public graphs appear here as soon as your node discovers them');
+    expect(container.textContent).toContain('subscribe by ID');
+  });
+
+  it('renders a successfully synchronized public graph in the Context Oracle', async () => {
+    const { container } = await renderPanel();
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+    act(() => {
+      useProjectsStore.setState({
+        contextGraphs: [{
+          id: 'public-ready',
+          name: 'Public Ready Graph',
+          accessPolicy: 'public',
+          callerInvolved: false,
+          subscribed: true,
+          synced: true,
+          sharedMemorySynced: true,
+          metaSynced: true,
+        } as any],
+      });
+    });
+
+    const modeButtons = container.querySelectorAll('.v10-tree-mode-btn');
+    await act(async () => {
+      (modeButtons[1] as HTMLButtonElement).click();
+    });
+
+    expect(container.textContent).toContain('Public Ready Graph');
+  });
+
   it('section headers point at their body containers via aria-controls', async () => {
     const { container } = await renderPanel();
     const headers = container.querySelectorAll('.v10-peer-group-header');

--- a/packages/node-ui/test/panel-left.test.ts
+++ b/packages/node-ui/test/panel-left.test.ts
@@ -278,6 +278,54 @@ describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
     expect(container.textContent).toContain('Public Ready Graph');
   });
 
+  it('keeps a passive public catalogue result separate from project activation', async () => {
+    const { container } = await renderPanel();
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+    const { useTabsStore } = await import('../src/ui/stores/tabs.js');
+    act(() => {
+      useProjectsStore.setState({
+        contextGraphs: [{
+          id: 'public-passive',
+          name: 'Passive Public Graph',
+          accessPolicy: 'public',
+          callerInvolved: false,
+          subscribed: false,
+          synced: false,
+        } as any],
+        activeProjectId: null,
+      });
+      useTabsStore.setState({
+        tabs: [{ id: 'dashboard', label: 'Dashboard', closable: false }],
+        activeTabId: 'dashboard',
+      });
+    });
+
+    const modeButtons = container.querySelectorAll('.v10-tree-mode-btn');
+    await act(async () => {
+      (modeButtons[1] as HTMLButtonElement).click();
+    });
+
+    const browseButton = container.querySelector(
+      'button[aria-label="Browse Passive Public Graph"]',
+    ) as HTMLButtonElement | null;
+    const subscribeButton = container.querySelector(
+      'button[aria-label="Subscribe to Passive Public Graph"]',
+    ) as HTMLButtonElement | null;
+    expect(browseButton).toBeTruthy();
+    expect(subscribeButton).toBeTruthy();
+
+    await act(async () => { browseButton!.click(); });
+    expect(useTabsStore.getState().activeTabId).toBe('project:public-passive');
+    expect(useProjectsStore.getState().activeProjectId).toBeNull();
+
+    await act(async () => { subscribeButton!.click(); });
+    expect(container.querySelector('[role="dialog"]')).toBeTruthy();
+    expect(
+      (container.querySelector('#dkg-cg-invite') as HTMLTextAreaElement).value,
+    ).toBe('public-passive');
+    expect(container.querySelector('.v10-modal-btn.primary')?.textContent).toBe('Subscribe');
+  });
+
   it('section headers point at their body containers via aria-controls', async () => {
     const { container } = await renderPanel();
     const headers = container.querySelectorAll('.v10-peer-group-header');


### PR DESCRIPTION
## Summary

- expose passively discovered public Context Graphs in the Context Oracle
- route explicitly public graphs through the public `/api/subscribe` path, including when an older curator invite is pasted
- recognize authoritative public metadata from an explicit public root definition or identity-bound active public on-chain registration
- preserve existing tracked durable + SWM catch-up, preferred-peer ordering, fallback peers, and readiness protections
- keep private/curated metadata and join approval fail-closed

## Root cause

The UI hid a discovered public graph until it was subscribed or synced, then forced it through the curator-invite flow. After approval, `runImmediatePostApprovalSync()` correctly used the private metadata refresh path, whose proof correctly rejected the public snapshot because it had neither a private definition nor an approved-member delegation. `hasConfirmedMetaState()` also did not recognize the graph's exact root `accessPolicy="public"` definition, so SWM catch-up remained unauthorized.

The daemon's public subscribe route and catch-up tracker were already correct; the UI simply never reached that path for this graph.

Reproduction graph:

`0x00a9D0dcab936a418ffEbc734476C91D4027d359/balkan-places-to-visit`

## Security boundary

- publisher allowlists on explicit-public graphs do not restrict reading, subscription, or catch-up
- private metadata still requires the complete private definition and a current member delegation bound to the local peer or operational key
- forged/stale join approval remains unable to create a private subscription
- empty responses alone cannot mark a graph synced; authoritative metadata and clean plane completion remain required

## Verification

- `pnpm --dir packages/agent exec vitest run --config vitest.unit.config.ts test/private-cg-membership-bootstrap.test.ts` — 27 passed
- relevant agent discovery/peer-selection/SWM suites — 59 passed
- `pnpm --dir packages/agent exec vitest run test/cg-resolve-refresh.test.ts -t "requires a current approved member delegation" --reporter=verbose` — 1 passed, 13 skipped
- `pnpm --dir packages/cli exec vitest run --config vitest.unit.config.ts test/context-graph-subscribe-readiness.test.ts` — 17 passed
- `pnpm --dir packages/node-ui exec vitest run test/contextGraphSidebar.test.ts test/join-project-modal.test.ts test/panel-left.test.ts` — 50 passed
- `pnpm --dir packages/query exec vitest run test/query-handler.test.ts` — 35 passed
- agent, node-ui, CLI TypeScript builds passed
- node-ui production Vite build passed
- `git diff --check` passed

## Remote query note

The separate `ACCESS_DENIED: Context graph is not queryable` response remains unchanged. Remote query access is controlled by `queryAccess`; the current testnet chain did not contain a committed registration for the exact graph hash, so denial under the default policy is expected unless the curator explicitly enables per-graph query access.
