### PR TITLE
fix(publisher): fsync the broadcast record before send to prevent crash-recovery double-submit

### DIFF
--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -14,6 +14,7 @@ import {
   type LiftJob,
   type LiftJobAccepted,
   type LiftJobBroadcast,
+  type LiftJobBroadcastMetadata,
   type LiftJobHex,
   type LiftJobIncluded,
   type LiftJobInclusionMetadata,
@@ -899,18 +900,6 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
   private async writeJob(job: LiftJob): Promise<void> {
     await this.store.deleteByPattern({ subject: jobSubject(job.jobId), graph: this.graphUri });
     await this.store.insert(serializeJob(job, this.graphUri));
-    // Durability before the on-chain send. The 'broadcast' record is written
-    // inside the write-ahead hook (EVMChainAdapterBase.dispatchSerializedV10Write
-    // awaits onBroadcast strictly before the tx is sent). Without an fsync here,
-    // a daemon crash in the flush->send window loses the record: on restart the
-    // job reads back as 'validated', recover() resets it, and it re-broadcasts
-    // with a fresh hash -> a double on-chain submission. Flushing on this
-    // execute-capable transition closes that window. Scoped to 'broadcast' so a
-    // whole-store snapshot is not taken on every state change (matches the
-    // promote queue's per-write flush intent, bounded to where it is load-bearing).
-    if (job.status === 'broadcast') {
-      await this.store.flush?.();
-    }
   }
 
   private async deleteJob(jobId: string): Promise<void> {
@@ -1131,24 +1120,39 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
         `Cannot record knowledge asset VM publish broadcast for job ${params.jobId} from status ${current.status}`,
       );
     }
+    await this.recordDurableBroadcastBeforeSend(current, {
+      txHash: params.txHash,
+      walletId: params.walletId,
+      merkleRoot: params.merkleRoot,
+      publicByteSize: params.publicByteSize,
+    });
+  }
+
+  /**
+   * The single pre-send write-ahead boundary for the KA VM publish path: record
+   * the 'broadcast' transition and make it fsync-durable BEFORE the caller sends
+   * the tx. Runs inside the adapter's `onBroadcast` hook, which is awaited
+   * strictly before `sendSignedTransactionAndWait` (fail-closed).
+   *
+   * Durability is scoped here — not in the generic `writeJob`/`update` — so the
+   * whole-store fsync only happens at this before-send boundary (raw-lift's
+   * post-send 'broadcast' write, and every other state change, stay flush-free).
+   *
+   * On a write-ahead failure (the fsync, or the transition itself) the tx was
+   * never sent, so restore the durable prior job: the store must never report a
+   * 'broadcast' that was not fsync-durable, or recovery would chase a tx that
+   * never landed. The prior job is 'validated' (asserted by the sole caller), so
+   * restoring it takes no fsync and cannot re-fail here. The caller then fails
+   * the job from its pre-broadcast state, off the chain-recovery track.
+   */
+  private async recordDurableBroadcastBeforeSend(
+    current: LiftJob,
+    broadcast: LiftJobBroadcastMetadata,
+  ): Promise<void> {
     try {
-      await this.update(params.jobId, 'broadcast', {
-        broadcast: {
-          txHash: params.txHash,
-          walletId: params.walletId,
-          merkleRoot: params.merkleRoot,
-          publicByteSize: params.publicByteSize,
-        },
-      });
+      await this.update(current.jobId, 'broadcast', { broadcast });
+      await this.store.flush?.();
     } catch (error) {
-      // Write-ahead durability failure BEFORE the on-chain send. `update` mutates
-      // the in-memory row to 'broadcast' and only then fsyncs (writeJob); if that
-      // fsync throws, the store is left showing an un-fsync'd 'broadcast' even
-      // though the adapter fails closed and never sends the tx. Restore the durable
-      // prior 'validated' job so recovery never treats a never-sent tx as on-chain
-      // state — the caller then fails the job from its pre-broadcast state, off the
-      // chain-recovery track. writeJob does not fsync a 'validated' row, so the
-      // rollback itself cannot re-fail here.
       await this.writeJob(current);
       throw error;
     }

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -887,6 +887,18 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
   private async writeJob(job: LiftJob): Promise<void> {
     await this.store.deleteByPattern({ subject: jobSubject(job.jobId), graph: this.graphUri });
     await this.store.insert(serializeJob(job, this.graphUri));
+    // Durability before the on-chain send. The 'broadcast' record is written
+    // inside the write-ahead hook (EVMChainAdapterBase.dispatchSerializedV10Write
+    // awaits onBroadcast strictly before the tx is sent). Without an fsync here,
+    // a daemon crash in the flush->send window loses the record: on restart the
+    // job reads back as 'validated', recover() resets it, and it re-broadcasts
+    // with a fresh hash -> a double on-chain submission. Flushing on this
+    // execute-capable transition closes that window. Scoped to 'broadcast' so a
+    // whole-store snapshot is not taken on every state change (matches the
+    // promote queue's per-write flush intent, bounded to where it is load-bearing).
+    if (job.status === 'broadcast') {
+      await this.store.flush?.();
+    }
   }
 
   private async deleteJob(jobId: string): Promise<void> {

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -529,11 +529,23 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     } catch (error) {
       const current = await this.getStatus(claimed.jobId);
       if (!executorReturned && current?.status === 'broadcast') {
+        // The write-ahead hook durably recorded 'broadcast' (the fsync succeeded)
+        // before the adapter sent the tx, then confirmation was interrupted.
+        // Reconcile on chain — never resend.
         return current;
       }
-      const failedFromState: LiftJobState = this.isKnowledgeAssetPublishPreconditionFailure(error)
+      // The publish tx is sent strictly AFTER the write-ahead record is fsync-durable
+      // (the adapter fails closed on a hook error, evm-adapter-base.dispatchSerializedV10Write).
+      // So if the executor never returned and the durable status is not 'broadcast'
+      // (e.g. the write-ahead fsync failed and rolled the transition back), no tx
+      // reached the wire — fail from the pre-broadcast ('validated') state, off the
+      // chain-recovery track (which chases an on-chain tx that never landed).
+      // Failures after the executor returned keep the precondition heuristic.
+      const failedFromState: LiftJobState = !executorReturned
         ? 'validated'
-        : 'broadcast';
+        : this.isKnowledgeAssetPublishPreconditionFailure(error)
+          ? 'validated'
+          : 'broadcast';
       return await this.recordExecutionFailure(claimed.jobId, failedFromState, error);
     }
   }
@@ -1119,14 +1131,27 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
         `Cannot record knowledge asset VM publish broadcast for job ${params.jobId} from status ${current.status}`,
       );
     }
-    await this.update(params.jobId, 'broadcast', {
-      broadcast: {
-        txHash: params.txHash,
-        walletId: params.walletId,
-        merkleRoot: params.merkleRoot,
-        publicByteSize: params.publicByteSize,
-      },
-    });
+    try {
+      await this.update(params.jobId, 'broadcast', {
+        broadcast: {
+          txHash: params.txHash,
+          walletId: params.walletId,
+          merkleRoot: params.merkleRoot,
+          publicByteSize: params.publicByteSize,
+        },
+      });
+    } catch (error) {
+      // Write-ahead durability failure BEFORE the on-chain send. `update` mutates
+      // the in-memory row to 'broadcast' and only then fsyncs (writeJob); if that
+      // fsync throws, the store is left showing an un-fsync'd 'broadcast' even
+      // though the adapter fails closed and never sends the tx. Restore the durable
+      // prior 'validated' job so recovery never treats a never-sent tx as on-chain
+      // state — the caller then fails the job from its pre-broadcast state, off the
+      // chain-recovery track. writeJob does not fsync a 'validated' row, so the
+      // rollback itself cannot re-fail here.
+      await this.writeJob(current);
+      throw error;
+    }
   }
 
   private parseJobPayload(binding?: string): LiftJob | null {

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -530,23 +530,21 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     } catch (error) {
       const current = await this.getStatus(claimed.jobId);
       if (!executorReturned && current?.status === 'broadcast') {
-        // The write-ahead hook durably recorded 'broadcast' (the fsync succeeded)
-        // before the adapter sent the tx, then confirmation was interrupted.
-        // Reconcile on chain — never resend.
+        // The tx send happens strictly AFTER the write-ahead durably records
+        // 'broadcast' (fsync inside recordDurableBroadcastBeforeSend, whose
+        // failure rolls the transition back). So a durable 'broadcast' here means
+        // the tx may be on the wire — leave the job in 'broadcast' so recovery's
+        // interrupted-broadcast path reconciles it on chain, never resend. A
+        // pre-send failure (fsync failed → rolled back to 'validated', or an error
+        // before the write-ahead) does NOT reach here and is recorded as 'failed'
+        // below; a failed KA VM job is never chain-recovery-chased
+        // (canRetryFailedRecovery === false), and its code comes from the publish
+        // mapper (e.g. NO_FUNDED_PUBLISHER_WALLET → insufficient_funds).
         return current;
       }
-      // The publish tx is sent strictly AFTER the write-ahead record is fsync-durable
-      // (the adapter fails closed on a hook error, evm-adapter-base.dispatchSerializedV10Write).
-      // So if the executor never returned and the durable status is not 'broadcast'
-      // (e.g. the write-ahead fsync failed and rolled the transition back), no tx
-      // reached the wire — fail from the pre-broadcast ('validated') state, off the
-      // chain-recovery track (which chases an on-chain tx that never landed).
-      // Failures after the executor returned keep the precondition heuristic.
-      const failedFromState: LiftJobState = !executorReturned
+      const failedFromState: LiftJobState = this.isKnowledgeAssetPublishPreconditionFailure(error)
         ? 'validated'
-        : this.isKnowledgeAssetPublishPreconditionFailure(error)
-          ? 'validated'
-          : 'broadcast';
+        : 'broadcast';
       return await this.recordExecutionFailure(claimed.jobId, failedFromState, error);
     }
   }

--- a/packages/publisher/test/async-lift-broadcast-durability.test.ts
+++ b/packages/publisher/test/async-lift-broadcast-durability.test.ts
@@ -1,9 +1,13 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GraphManager, OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   TripleStoreAsyncLiftPublisher,
   type AsyncLiftPublisherConfig,
 } from '../src/index.js';
+import { storeKnowledgeAssetOperationPublicQuads } from '../src/workspace-resolution.js';
 
 // Regression: the mutable 'broadcast' record must be fsync-durable BEFORE the
 // on-chain send. It is written inside the write-ahead hook (onBroadcast, awaited
@@ -12,11 +16,14 @@ import {
 // 'validated', recover() resets it, and it re-broadcasts with a fresh hash — a
 // double on-chain submission. writeJob must flush on the execute-capable
 // 'broadcast' transition, and only there (to avoid a whole-store snapshot on
-// every state change).
+// every state change). A flush FAILURE must not leave a phantom 'broadcast'
+// record: the tx was never sent (the adapter fails closed), so the job must
+// stay retryable from its pre-broadcast state, never enter chain recovery.
 describe('async lift publisher broadcast durability', () => {
   let now = 1_000;
   let ids = 0;
   let store: OxigraphStore;
+  const tempDirs: string[] = [];
 
   beforeEach(() => {
     now = 1_000;
@@ -24,10 +31,18 @@ describe('async lift publisher broadcast durability', () => {
     store = new OxigraphStore();
   });
 
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   function createPublisher(
+    targetStore: OxigraphStore = store,
     config: Omit<AsyncLiftPublisherConfig, 'now' | 'idGenerator'> = {},
   ): TripleStoreAsyncLiftPublisher {
-    return new TripleStoreAsyncLiftPublisher(store, {
+    return new TripleStoreAsyncLiftPublisher(targetStore, {
       now: () => ++now,
       idGenerator: () => `job-${++ids}`,
       ...config,
@@ -67,6 +82,44 @@ describe('async lift publisher broadcast durability', () => {
     };
   }
 
+  const VALIDATION_DATA = {
+    validation: {
+      canonicalRoots: [] as string[],
+      canonicalRootMap: {},
+      swmQuadCount: 2,
+      authorityProofRef: 'knowledge-asset-lifecycle',
+      transitionType: 'CREATE' as const,
+    },
+  };
+
+  const TX_HASH = `0x${'cd'.repeat(32)}` as `0x${string}`;
+
+  async function driveToValidated(
+    publisher: TripleStoreAsyncLiftPublisher,
+  ): Promise<string> {
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', VALIDATION_DATA);
+    return jobId;
+  }
+
+  async function stageShareSnapshot(targetStore: OxigraphStore): Promise<void> {
+    const request = kaVmPublishRequest();
+    await storeKnowledgeAssetOperationPublicQuads({
+      store: targetStore,
+      graphManager: new GraphManager(targetStore),
+      contextGraphId: 'music-social',
+      shareOperationId: 'share-op-1',
+      kaUal: request.kaUal,
+      assertionVersion: request.assertionVersion,
+      publisherPeerId: 'peer-1',
+      quads: [
+        { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+        { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+      ],
+    });
+  }
+
   it('fsyncs the store on the broadcast transition, and not on earlier transitions', async () => {
     const publisher = createPublisher();
 
@@ -77,29 +130,141 @@ describe('async lift publisher broadcast durability', () => {
       await orig?.();
     };
 
-    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
-    await publisher.claimNext('wallet-1');
-    await publisher.update(jobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
-    });
+    const jobId = await driveToValidated(publisher);
     // accepted / claimed / validated are not execute-capable — no fsync.
     expect(flushCount).toBe(0);
 
     await publisher.update(jobId, 'broadcast', {
-      broadcast: { txHash: `0x${'cd'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' },
+      broadcast: { txHash: TX_HASH, walletId: 'wallet-1' },
     });
     // broadcast is written inside the pre-send write-ahead hook — must fsync.
     expect(flushCount).toBe(1);
 
-    // The record is durably readable as 'broadcast' (a restart would not reset it).
     const persisted = await publisher.getStatus(jobId);
     expect(persisted?.status).toBe('broadcast');
-    expect(persisted?.broadcast?.txHash).toBe(`0x${'cd'.repeat(32)}`);
+    expect(persisted?.broadcast?.txHash).toBe(TX_HASH);
+  });
+
+  it('awaits the broadcast fsync before the transition resolves', async () => {
+    // Proves the fsync is AWAITED, not fire-and-forget: a regression that dropped
+    // `await` (calling flush without waiting) would let update() resolve before
+    // the record is durable, reopening the flush->send crash window.
+    const publisher = createPublisher();
+
+    const gate: { release: () => void } = { release: () => {} };
+    let flushStarted = false;
+    (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
+      flushStarted = true;
+      await new Promise<void>((resolve) => {
+        gate.release = resolve;
+      });
+    };
+
+    const jobId = await driveToValidated(publisher);
+
+    let settled = false;
+    const transition = publisher
+      .update(jobId, 'broadcast', { broadcast: { txHash: TX_HASH, walletId: 'wallet-1' } })
+      .then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+
+    // Let microtasks + a macrotask drain: the transition must still be pending,
+    // blocked on the in-flight fsync.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(flushStarted).toBe(true);
+    expect(settled).toBe(false);
+
+    gate.release();
+    await transition;
+    expect(settled).toBe(true);
+
+    const persisted = await publisher.getStatus(jobId);
+    expect(persisted?.status).toBe('broadcast');
+  });
+
+  it('persists the broadcast record across a restart (fresh store from disk)', async () => {
+    // Proves durability, not just that flush() was called: drive to broadcast on
+    // a persistent store, then reopen a FRESH store+publisher from the same path
+    // and confirm the record survived. A crash-recovery reads 'broadcast' (the
+    // chain-recovery path) instead of 'validated' (reset-and-resend).
+    const dir = mkdtempSync(join(tmpdir(), 'lift-broadcast-durability-'));
+    tempDirs.push(dir);
+    const persistPath = join(dir, 'store.nq');
+
+    const store1 = new OxigraphStore(persistPath);
+    const publisher1 = createPublisher(store1);
+    const jobId = await driveToValidated(publisher1);
+    await publisher1.update(jobId, 'broadcast', {
+      broadcast: { txHash: TX_HASH, walletId: 'wallet-1', merkleRoot: `0x${'12'.repeat(32)}` as `0x${string}` },
+    });
+
+    const store2 = new OxigraphStore(persistPath);
+    const publisher2 = createPublisher(store2);
+    const recovered = await publisher2.getStatus(jobId);
+
+    expect(recovered?.status).toBe('broadcast');
+    expect(recovered?.broadcast?.txHash).toBe(TX_HASH);
+    expect(recovered?.broadcast?.walletId).toBe('wallet-1');
+  });
+
+  it('does not send or leave a phantom broadcast when the write-ahead fsync fails', async () => {
+    // Regression (#1851 review): the write-ahead fsync runs AFTER the in-memory
+    // 'broadcast' transition. If it throws, the store would show 'broadcast'
+    // although the adapter fails closed and never sends the tx. The job must roll
+    // back to a retryable pre-broadcast state, never be reported/left as
+    // 'broadcast' (which recovery would chase as an on-chain tx that never landed).
+    let sent = false;
+    const publisher = createPublisher(store, {
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          try {
+            // Records 'broadcast' (write-ahead) -> writeJob -> flush (rejects).
+            await input.publishOptions.onPhase?.(`chain:txsigned:tx-${TX_HASH}`, 'start');
+          } catch (hookErr) {
+            // Mirror the adapter's fail-closed rewrap (evm-adapter-base.ts:1609):
+            // a rejected write-ahead hook aborts the broadcast, tx never sent.
+            throw new Error(
+              `chain:writeahead hook failed before publish broadcast: ${(hookErr as Error).message}`,
+            );
+          }
+          sent = true; // real adapter's eth_sendRawTransaction — must NOT run
+          throw new Error('unreachable: send happened after a failed write-ahead flush');
+        },
+      },
+    });
+
+    // fsync is only invoked on the 'broadcast' transition; fault-inject it.
+    (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
+      throw new Error('ENOSPC: no space left on device');
+    };
+
+    await stageShareSnapshot(store);
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const processed = await publisher.processNext('wallet-1');
+
+    // The tx was never sent.
+    expect(sent).toBe(false);
+    // The job is not left or reported as 'broadcast'.
+    expect(processed?.status).toBe('failed');
+    expect(processed?.status).not.toBe('broadcast');
+    expect(processed?.failure?.failedFromState).toBe('validated');
+
+    const persisted = await publisher.getStatus(jobId);
+    expect(persisted?.status).toBe('failed');
+    expect(persisted?.status).not.toBe('broadcast');
+
+    // Recovery must NOT treat it as an on-chain tx: a broadcast/included failure
+    // would be a retry_recovery job that chases a tx hash that never landed. A
+    // pre-broadcast failure is resolved off the chain-recovery track.
+    expect(processed?.failure?.resolution).not.toBe('retry_recovery');
+    const recovered = await publisher.recover();
+    expect(recovered).toBe(0);
+    expect((await publisher.getStatus(jobId))?.status).toBe('failed');
   });
 });

--- a/packages/publisher/test/async-lift-broadcast-durability.test.ts
+++ b/packages/publisher/test/async-lift-broadcast-durability.test.ts
@@ -11,14 +11,15 @@ import { storeKnowledgeAssetOperationPublicQuads } from '../src/workspace-resolu
 
 // Regression: the mutable 'broadcast' record must be fsync-durable BEFORE the
 // on-chain send. It is written inside the write-ahead hook (onBroadcast, awaited
-// strictly before the tx sends). Without a flush there, a daemon crash in the
+// strictly before the tx sends) via recordDurableBroadcastBeforeSend — the sole
+// pre-send durability boundary. Without the flush there, a daemon crash in the
 // flush->send window loses the record; on restart the job reads back as
 // 'validated', recover() resets it, and it re-broadcasts with a fresh hash — a
-// double on-chain submission. writeJob must flush on the execute-capable
-// 'broadcast' transition, and only there (to avoid a whole-store snapshot on
-// every state change). A flush FAILURE must not leave a phantom 'broadcast'
-// record: the tx was never sent (the adapter fails closed), so the job must
-// stay retryable from its pre-broadcast state, never enter chain recovery.
+// double on-chain submission. Durability is scoped to that helper (not the
+// generic update/writeJob), so no other transition takes a whole-store fsync. A
+// flush FAILURE must not leave a phantom 'broadcast': the tx was never sent (the
+// adapter fails closed), so the job rolls back to its pre-broadcast state, off
+// the chain-recovery track.
 describe('async lift publisher broadcast durability', () => {
   let now = 1_000;
   let ids = 0;
@@ -82,26 +83,7 @@ describe('async lift publisher broadcast durability', () => {
     };
   }
 
-  const VALIDATION_DATA = {
-    validation: {
-      canonicalRoots: [] as string[],
-      canonicalRootMap: {},
-      swmQuadCount: 2,
-      authorityProofRef: 'knowledge-asset-lifecycle',
-      transitionType: 'CREATE' as const,
-    },
-  };
-
   const TX_HASH = `0x${'cd'.repeat(32)}` as `0x${string}`;
-
-  async function driveToValidated(
-    publisher: TripleStoreAsyncLiftPublisher,
-  ): Promise<string> {
-    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
-    await publisher.claimNext('wallet-1');
-    await publisher.update(jobId, 'validated', VALIDATION_DATA);
-    return jobId;
-  }
 
   async function stageShareSnapshot(targetStore: OxigraphStore): Promise<void> {
     const request = kaVmPublishRequest();
@@ -120,37 +102,54 @@ describe('async lift publisher broadcast durability', () => {
     });
   }
 
-  it('fsyncs the store on the broadcast transition, and not on earlier transitions', async () => {
-    const publisher = createPublisher();
+  // A VM-publish executor that fires the pre-send write-ahead (onPhase → records
+  // 'broadcast'), then stops before the real send. Drives the exact pre-send
+  // durability boundary through the public processNext() path.
+  function firesBroadcastThenStops(): NonNullable<AsyncLiftPublisherConfig['knowledgeAssetVmPublishHandler']> {
+    return {
+      execute: async (input) => {
+        await input.publishOptions.onPhase?.(`chain:txsigned:tx-${TX_HASH}`, 'start');
+        throw new Error('stop after the durable write-ahead');
+      },
+    };
+  }
 
+  it('fsyncs once on the pre-send broadcast write-ahead, not on the earlier transitions', async () => {
     let flushCount = 0;
+    let flushCountBeforeBroadcast = -1;
     const orig = store.flush?.bind(store);
     (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
       flushCount += 1;
       await orig?.();
     };
 
-    const jobId = await driveToValidated(publisher);
-    // accepted / claimed / validated are not execute-capable — no fsync.
-    expect(flushCount).toBe(0);
-
-    await publisher.update(jobId, 'broadcast', {
-      broadcast: { txHash: TX_HASH, walletId: 'wallet-1' },
+    const publisher = createPublisher(store, {
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          // accepted (enqueue) / claimed (claimNext) / validated (update) have all
+          // run by now and must not have fsync'd.
+          flushCountBeforeBroadcast = flushCount;
+          await input.publishOptions.onPhase?.(`chain:txsigned:tx-${TX_HASH}`, 'start');
+          throw new Error('stop after the durable write-ahead');
+        },
+      },
     });
-    // broadcast is written inside the pre-send write-ahead hook — must fsync.
-    expect(flushCount).toBe(1);
 
-    const persisted = await publisher.getStatus(jobId);
-    expect(persisted?.status).toBe('broadcast');
-    expect(persisted?.broadcast?.txHash).toBe(TX_HASH);
+    await stageShareSnapshot(store);
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const processed = await publisher.processNext('wallet-1');
+
+    expect(flushCountBeforeBroadcast).toBe(0);
+    // Exactly one fsync — the pre-send write-ahead; the post-throw catch path adds none.
+    expect(flushCount).toBe(1);
+    expect(processed?.status).toBe('broadcast');
+    expect(processed?.broadcast?.txHash).toBe(TX_HASH);
   });
 
-  it('awaits the broadcast fsync before the transition resolves', async () => {
+  it('awaits the broadcast fsync before the pre-send write-ahead resolves', async () => {
     // Proves the fsync is AWAITED, not fire-and-forget: a regression that dropped
-    // `await` (calling flush without waiting) would let update() resolve before
-    // the record is durable, reopening the flush->send crash window.
-    const publisher = createPublisher();
-
+    // `await` on store.flush?.() would let the write-ahead resolve before the
+    // record is durable, reopening the flush->send crash window.
     const gate: { release: () => void } = { release: () => {} };
     let flushStarted = false;
     (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
@@ -160,49 +159,51 @@ describe('async lift publisher broadcast durability', () => {
       });
     };
 
-    const jobId = await driveToValidated(publisher);
+    const publisher = createPublisher(store, {
+      knowledgeAssetVmPublishHandler: firesBroadcastThenStops(),
+    });
+
+    await stageShareSnapshot(store);
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
 
     let settled = false;
-    const transition = publisher
-      .update(jobId, 'broadcast', { broadcast: { txHash: TX_HASH, walletId: 'wallet-1' } })
-      .then(
-        () => {
-          settled = true;
-        },
-        () => {
-          settled = true;
-        },
-      );
+    const proc = publisher.processNext('wallet-1').then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
 
-    // Let microtasks + a macrotask drain: the transition must still be pending,
-    // blocked on the in-flight fsync.
+    // Let microtasks + a macrotask drain: processNext must still be pending,
+    // blocked on the in-flight pre-send fsync.
     await new Promise((resolve) => setTimeout(resolve, 10));
     expect(flushStarted).toBe(true);
     expect(settled).toBe(false);
 
     gate.release();
-    await transition;
+    await proc;
     expect(settled).toBe(true);
-
-    const persisted = await publisher.getStatus(jobId);
-    expect(persisted?.status).toBe('broadcast');
   });
 
   it('persists the broadcast record across a restart (fresh store from disk)', async () => {
-    // Proves durability, not just that flush() was called: drive to broadcast on
-    // a persistent store, then reopen a FRESH store+publisher from the same path
-    // and confirm the record survived. A crash-recovery reads 'broadcast' (the
-    // chain-recovery path) instead of 'validated' (reset-and-resend).
+    // Proves durability, not just that flush() was called: drive the pre-send
+    // write-ahead on a persistent store, then reopen a FRESH store+publisher from
+    // the same path and confirm the record survived. A crash-recovery reads
+    // 'broadcast' (chain-recovery path) instead of 'validated' (reset-and-resend).
     const dir = mkdtempSync(join(tmpdir(), 'lift-broadcast-durability-'));
     tempDirs.push(dir);
     const persistPath = join(dir, 'store.nq');
 
     const store1 = new OxigraphStore(persistPath);
-    const publisher1 = createPublisher(store1);
-    const jobId = await driveToValidated(publisher1);
-    await publisher1.update(jobId, 'broadcast', {
-      broadcast: { txHash: TX_HASH, walletId: 'wallet-1', merkleRoot: `0x${'12'.repeat(32)}` as `0x${string}` },
+    const publisher1 = createPublisher(store1, {
+      knowledgeAssetVmPublishHandler: firesBroadcastThenStops(),
     });
+    await stageShareSnapshot(store1);
+    const jobId = await publisher1.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const processed = await publisher1.processNext('wallet-1');
+    expect(processed?.status).toBe('broadcast');
 
     const store2 = new OxigraphStore(persistPath);
     const publisher2 = createPublisher(store2);
@@ -217,14 +218,14 @@ describe('async lift publisher broadcast durability', () => {
     // Regression (#1851 review): the write-ahead fsync runs AFTER the in-memory
     // 'broadcast' transition. If it throws, the store would show 'broadcast'
     // although the adapter fails closed and never sends the tx. The job must roll
-    // back to a retryable pre-broadcast state, never be reported/left as
-    // 'broadcast' (which recovery would chase as an on-chain tx that never landed).
+    // back to a pre-broadcast state, never be reported/left as 'broadcast' (which
+    // recovery would chase as an on-chain tx that never landed).
     let sent = false;
     const publisher = createPublisher(store, {
       knowledgeAssetVmPublishHandler: {
         execute: async (input) => {
           try {
-            // Records 'broadcast' (write-ahead) -> writeJob -> flush (rejects).
+            // Records 'broadcast' (write-ahead) -> flush (rejects) -> rollback.
             await input.publishOptions.onPhase?.(`chain:txsigned:tx-${TX_HASH}`, 'start');
           } catch (hookErr) {
             // Mirror the adapter's fail-closed rewrap (evm-adapter-base.ts:1609):
@@ -239,7 +240,7 @@ describe('async lift publisher broadcast durability', () => {
       },
     });
 
-    // fsync is only invoked on the 'broadcast' transition; fault-inject it.
+    // fsync is only invoked on the pre-send broadcast write-ahead; fault-inject it.
     (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
       throw new Error('ENOSPC: no space left on device');
     };

--- a/packages/publisher/test/async-lift-broadcast-durability.test.ts
+++ b/packages/publisher/test/async-lift-broadcast-durability.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  TripleStoreAsyncLiftPublisher,
+  type AsyncLiftPublisherConfig,
+} from '../src/index.js';
+
+// Regression: the mutable 'broadcast' record must be fsync-durable BEFORE the
+// on-chain send. It is written inside the write-ahead hook (onBroadcast, awaited
+// strictly before the tx sends). Without a flush there, a daemon crash in the
+// flush->send window loses the record; on restart the job reads back as
+// 'validated', recover() resets it, and it re-broadcasts with a fresh hash — a
+// double on-chain submission. writeJob must flush on the execute-capable
+// 'broadcast' transition, and only there (to avoid a whole-store snapshot on
+// every state change).
+describe('async lift publisher broadcast durability', () => {
+  let now = 1_000;
+  let ids = 0;
+  let store: OxigraphStore;
+
+  beforeEach(() => {
+    now = 1_000;
+    ids = 0;
+    store = new OxigraphStore();
+  });
+
+  function createPublisher(
+    config: Omit<AsyncLiftPublisherConfig, 'now' | 'idGenerator'> = {},
+  ): TripleStoreAsyncLiftPublisher {
+    return new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++now,
+      idGenerator: () => `job-${++ids}`,
+      ...config,
+    });
+  }
+
+  function kaVmPublishRequest() {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
+    return {
+      contextGraphId: 'music-social',
+      name: 'albums',
+      shareOperationId: 'share-op-1',
+      roots: [] as string[],
+      contentScopeVersion: 2 as const,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+      seal: {
+        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+        authorAddress: authorAddress as `0x${string}`,
+        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
+        schemeVersion: 1,
+        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
+      },
+      sealChainId: '31337' as `${bigint}`,
+      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      intentKey: `sha256:${'ab'.repeat(32)}`,
+      wmCurrentAssertion: '12'.repeat(32),
+      swmCurrentAssertion: '12'.repeat(32),
+      kaNumber: kaNumber.toString(),
+      reservedUal: kaUal,
+    };
+  }
+
+  it('fsyncs the store on the broadcast transition, and not on earlier transitions', async () => {
+    const publisher = createPublisher();
+
+    let flushCount = 0;
+    const orig = store.flush?.bind(store);
+    (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
+      flushCount += 1;
+      await orig?.();
+    };
+
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', {
+      validation: {
+        canonicalRoots: [],
+        canonicalRootMap: {},
+        swmQuadCount: 2,
+        authorityProofRef: 'knowledge-asset-lifecycle',
+        transitionType: 'CREATE',
+      },
+    });
+    // accepted / claimed / validated are not execute-capable — no fsync.
+    expect(flushCount).toBe(0);
+
+    await publisher.update(jobId, 'broadcast', {
+      broadcast: { txHash: `0x${'cd'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' },
+    });
+    // broadcast is written inside the pre-send write-ahead hook — must fsync.
+    expect(flushCount).toBe(1);
+
+    // The record is durably readable as 'broadcast' (a restart would not reset it).
+    const persisted = await publisher.getStatus(jobId);
+    expect(persisted?.status).toBe('broadcast');
+    expect(persisted?.broadcast?.txHash).toBe(`0x${'cd'.repeat(32)}`);
+  });
+});

--- a/packages/publisher/test/async-lift-broadcast-durability.test.ts
+++ b/packages/publisher/test/async-lift-broadcast-durability.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { NO_FUNDED_PUBLISHER_WALLET_CODE } from '@origintrail-official/dkg-core';
 import { GraphManager, OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   TripleStoreAsyncLiftPublisher,
@@ -251,21 +252,52 @@ describe('async lift publisher broadcast durability', () => {
 
     // The tx was never sent.
     expect(sent).toBe(false);
-    // The job is not left or reported as 'broadcast'.
+    // The job is not left or reported as 'broadcast' (the rollback is what makes
+    // this hold — see the mutation-check below).
     expect(processed?.status).toBe('failed');
     expect(processed?.status).not.toBe('broadcast');
-    expect(processed?.failure?.failedFromState).toBe('validated');
 
     const persisted = await publisher.getStatus(jobId);
     expect(persisted?.status).toBe('failed');
     expect(persisted?.status).not.toBe('broadcast');
 
-    // Recovery must NOT treat it as an on-chain tx: a broadcast/included failure
-    // would be a retry_recovery job that chases a tx hash that never landed. A
-    // pre-broadcast failure is resolved off the chain-recovery track.
+    // Treated as never-sent: retryable and reset to accepted, NOT the
+    // chain-recovery track (retry_recovery / check-chain) that would chase a tx
+    // hash that never landed.
+    expect(processed?.failure?.retryable).toBe(true);
+    expect(processed?.failure?.resolution).toBe('reset_to_accepted');
     expect(processed?.failure?.resolution).not.toBe('retry_recovery');
     const recovered = await publisher.recover();
     expect(recovered).toBe(0);
+    expect((await publisher.getStatus(jobId))?.status).toBe('failed');
+  });
+
+  it('classifies a pre-onPhase funding failure as insufficient_funds, off the recovery track', async () => {
+    // Regression (#1851 review): a NO_FUNDED_PUBLISHER_WALLET thrown by the
+    // executor BEFORE the write-ahead onPhase must keep its structured code
+    // (insufficient_funds via the publish mapper), not be relabelled a generic
+    // validation failure. No tx is ever sent, so it must not enter chain recovery.
+    const publisher = createPublisher(store, {
+      knowledgeAssetVmPublishHandler: {
+        execute: async () => {
+          // Mirrors dkg-chain's funded-wallet selection failing before any send.
+          throw Object.assign(
+            new Error('No operational wallet has enough funds to publish'),
+            { code: NO_FUNDED_PUBLISHER_WALLET_CODE },
+          );
+        },
+      },
+    });
+
+    await stageShareSnapshot(store);
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const processed = await publisher.processNext('wallet-1');
+
+    expect(processed?.status).toBe('failed');
+    expect(processed?.failure?.code).toBe('insufficient_funds');
+    // Terminal funding failure, off the chain-recovery track (no tx was sent).
+    expect(processed?.failure?.resolution).not.toBe('retry_recovery');
+    expect(await publisher.recover()).toBe(0);
     expect((await publisher.getStatus(jobId))?.status).toBe('failed');
   });
 });

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       'test/views-min-trust-extra.test.ts',
       'test/async-lift-validation.test.ts',
       'test/async-lift-ka-broadcast-progress.test.ts',
+      'test/async-lift-broadcast-durability.test.ts',
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
       'test/lift-job-types.test.ts',


### PR DESCRIPTION
## Summary

The async lift publisher can **double-submit a publish transaction on chain** after a crash. The `'broadcast'` job record is written inside the write-ahead hook — `EVMChainAdapterBase.dispatchSerializedV10Write` awaits `onBroadcast({txHash})` **strictly before** `sendSignedTransactionAndWait` (`evm-adapter-base.ts:1608` → `:1615`, fail-closed) — via `recordKnowledgeAssetVmPublishBroadcastProgress` → `update(jobId, 'broadcast', …)`. But `writeJob` inserted without an fsync (unlike the promote queue's `writeJob`).

So if the daemon crashes in the flush→send window (before the store's debounced snapshot lands), on restart the job reads back as `'validated'`, `recover()` resets it and re-claims it, and it **re-broadcasts with a fresh transaction hash** — a second on-chain submission of the same publish. Recovery keys entirely off the mutable `job.status`; nothing durably records "a tx for this job was already put on the wire" before the send.

## Fix

Add one explicit pre-send boundary, `recordDurableBroadcastBeforeSend(current, broadcast)`:

- record the `'broadcast'` transition (`update(...)`), then `await this.store.flush?.()`;
- on any write-ahead failure (the fsync, or the transition), restore the durable prior `'validated'` job (`writeJob(current)`) and rethrow.

Because it runs inside `onBroadcast` — awaited strictly before the send — the record is fsync-durable **before** the tx is sent, so a crash-and-recover reads `'broadcast'` (chain-recovery path, never reset-and-resend) instead of `'validated'`. The rollback closes the phantom-broadcast hole the fsync would otherwise open: a failed fsync must never leave or report a `'broadcast'` that was not fsync-durable, or recovery would chase a tx that never landed. The fsync is scoped to this boundary (a whole-store fsync on the shared agent store), so raw-lift's post-send `'broadcast'` write and every other transition stay flush-free; external backends (`sparql-http`/`blazegraph`) have no `flush` and rely on the synchronous `insert()` round-trip, where `flush?.()` is a safe no-op.

A pre-send failure never reaches the "durable broadcast → reconcile on chain" early-return; it is recorded as `'failed'`, and a failed KA VM job is never chain-recovery-chased (`canRetryFailedRecovery === false`). Its failure code comes from the publish mapper, so the two pre-send cases classify correctly and off the recovery track:

- pre-`onPhase` `NO_FUNDED_PUBLISHER_WALLET` → `insufficient_funds` (terminal);
- pre-send fsync failure → `rpc_unavailable` / `reset_to_accepted` (retryable, treated as never-sent).

The executor-failure classifier is otherwise unchanged (the existing precondition heuristic).

## Review

Adversarial review (otReviewAgent + @zsculac) drove: the phantom-broadcast rollback; extracting the explicit `recordDurableBroadcastBeforeSend` boundary out of generic `writeJob`/`update` plumbing; and keeping `NO_FUNDED_PUBLISHER_WALLET → insufficient_funds` on the pre-broadcast path (an interim blanket `!executorReturned ? 'validated'` rule was tried and reverted — it bypassed the publish mapper). The durability suite proves await-ordering, restart survival, phantom-on-fsync-failure, and the funding-failure classification; all guards are mutation-checked.

## Related

- Publisher durable-admission series: #1836 / #1846, #1828 / #1849.
- Surfaced by the adversarial review of the append-only journal work (#1829).
- Deferred follow-ups from this review: **#1864** (model the pre-send broadcast as a typed, first-class boundary that also owns wallet-lock reconciliation), **#1862** (consolidate the duplicated async-lift KA VM-publish test fixture; spans #1849's in-flight test), **#1867** (pre-existing: a definitive pre-acceptance send failure is left as `broadcast` and chased by recovery — not introduced here).
- **#1861 closed (mooted):** the fsync failure already classifies as the retryable `rpc_unavailable` / `reset_to_accepted` it asked for.

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/async-lift-publisher-impl.ts` | `recordDurableBroadcastBeforeSend` helper: fsync the `'broadcast'` write-ahead before send, and roll back to the durable prior job on failure. `writeJob`/`update` stay generic; the executor-failure classifier is unchanged. |
| `packages/publisher/test/async-lift-broadcast-durability.test.ts` | Durability suite (driven through the real pre-send path): no fsync on `accepted`/`claimed`/`validated`; the fsync is awaited (deferred-gate ordering); the record survives a restart from disk; a rejected write-ahead fsync neither sends the tx nor leaves/reports the job as `'broadcast'`; a pre-`onPhase` `NO_FUNDED_PUBLISHER_WALLET` classifies as `insufficient_funds`, off the recovery track. |
| `packages/publisher/vitest.unit.config.ts` | Add the durability spec to the hardhat-free unit lane (like its sibling `async-lift-ka-broadcast-progress`). |

## Test plan

- [x] `pnpm exec vitest run test/async-lift-broadcast-durability.test.ts` — 5 tests (listed above).
- [x] Regression: `pnpm exec vitest run test/async-lift-ka-broadcast-progress.test.ts test/async-lift-publisher.test.ts` — 5 + 46 pass unchanged.
- [x] Guards mutation-checked (remove the rollback → phantom `'broadcast'` returned; drop the `await` on flush → transition resolves early).
- [x] Publisher `tsc --noEmit` clean.
- [x] Full CI green on `2c13e3a3a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
