### PR TITLE
fix(swm): evaluate on-chain public probe lazily — restores receive-path latency

### DIFF
--- a/packages/agent/test/swm-plaintext-oracle-wiring.test.ts
+++ b/packages/agent/test/swm-plaintext-oracle-wiring.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Agent -> handler wiring for the public-access-policy on-chain oracle.
+ *
+ * The receiver-side fix for plaintext SWM on public+agent-gated CGs lives in
+ * `SharedMemoryHandler`, but it only takes effect in production if
+ * `getOrCreateSharedMemoryHandler` (dkg-agent-swm-substrate.ts) actually passes
+ * `publicAccessPolicyOnChainOracle` through to the handler. The handler-level
+ * tests inject the oracle themselves and the sender-side tests cover the
+ * predicate, so before this test the wiring line could be deleted and every
+ * suite stayed green while production kept the absent-oracle fail-closed
+ * behavior — rejecting exactly the plaintext writes the fix admits.
+ *
+ * This test builds the handler through the REAL agent accessor, installs a
+ * COUNTING `isContextGraphPublicOnChain` on the agent, and delivers a signed
+ * plaintext write on an agent-gated CG: the write must apply AND the count must
+ * move. Remove the oracle option from `getOrCreateSharedMemoryHandler` and both
+ * assertions fail.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { ethers } from 'ethers';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  computeGossipSigningPayload,
+  contextGraphDataUri,
+  contextGraphMetaUri,
+  DKG_ONTOLOGY,
+  encodeGossipEnvelope,
+  GOSSIP_ENVELOPE_VERSION,
+  GOSSIP_TYPE_WORKSPACE_PUBLISH,
+} from '@origintrail-official/dkg-core';
+import { DKGAgent } from '../src/index.js';
+import { encodeRootlessWorkspaceRequest } from '../../publisher/test/_helpers/rootless-workspace.js';
+
+const CG = 'swm-plaintext-oracle-wiring';
+const DATA = contextGraphDataUri(CG);
+const META = contextGraphMetaUri(CG);
+const PEER = '12D3KooWOracleWiringPeer';
+
+describe('agent wires publicAccessPolicyOnChainOracle into SharedMemoryHandler', () => {
+  let agent: DKGAgent | undefined;
+
+  afterAll(async () => {
+    try { await agent?.stop(); } catch { /* not started */ }
+  });
+
+  it('a signed plaintext write on a public+agent-gated CG applies through the agent-built handler, consulting the agent oracle', async () => {
+    agent = await DKGAgent.create({
+      name: 'PlaintextOracleWiring',
+      chainAdapter: new MockChainAdapter(),
+    });
+
+    // Counting oracle on the AGENT method the substrate closure delegates to.
+    let probeCalls = 0;
+    (agent as unknown as {
+      isContextGraphPublicOnChain: (cgId: string, ctx: unknown) => Promise<boolean>;
+    }).isContextGraphPublicOnChain = async () => {
+      probeCalls += 1;
+      return true;
+    };
+
+    // Agent-gate the CG in the agent's own store: without a live public proof
+    // the handler must demand encryption for it, so a PLAINTEXT apply below is
+    // possible only if the agent handed its oracle to the handler.
+    const writer = ethers.Wallet.createRandom();
+    const internals = agent as unknown as {
+      store: { insert(quads: { subject: string; predicate: string; object: string; graph: string }[]): Promise<void> };
+      localAgents: Map<string, unknown>;
+      getOrCreateSharedMemoryHandler(): {
+        handle(data: Uint8Array, from: string): Promise<{ applied: boolean; reason?: string }>;
+      };
+    };
+    // The receiver applies gated writes only when the local node itself holds
+    // an allowed agent for the CG (the member/curator case the fix restores).
+    internals.localAgents.set(writer.address, {});
+    await internals.store.insert([{
+      subject: DATA,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: `"${writer.address}"`,
+      graph: META,
+    }]);
+
+    const handler = internals.getOrCreateSharedMemoryHandler();
+
+    const payload = encodeRootlessWorkspaceRequest({
+      contextGraphId: CG,
+      nquads: new TextEncoder().encode(
+        `<urn:test:oracle-wiring> <http://schema.org/name> "Oracle Wiring" <${DATA}> .`,
+      ),
+      publisherPeerId: PEER,
+      shareOperationId: 'ws-oracle-wiring',
+      timestampMs: Date.now(),
+    });
+    const timestamp = new Date().toISOString();
+    const signature = await writer.signMessage(
+      computeGossipSigningPayload(GOSSIP_TYPE_WORKSPACE_PUBLISH, CG, timestamp, payload),
+    );
+    const wire = encodeGossipEnvelope({
+      version: GOSSIP_ENVELOPE_VERSION,
+      type: GOSSIP_TYPE_WORKSPACE_PUBLISH,
+      contextGraphId: CG,
+      agentAddress: writer.address,
+      timestamp,
+      signature: ethers.getBytes(signature),
+      payload,
+    });
+
+    const outcome = await handler.handle(wire, PEER);
+
+    expect(outcome.applied, `rejected: ${outcome.reason ?? '<none>'}`).toBe(true);
+    expect(probeCalls).toBeGreaterThan(0);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
       "test/discovery-subscription-boundary.test.ts",
       "test/core-fills-gap.test.ts",
       "test/swm-late-joiner-deferred-gossip.test.ts",
+      "test/swm-plaintext-oracle-wiring.test.ts",
       "test/oversize-filter.test.ts",
       "test/cg-registration-oversize-guard.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",

--- a/packages/publisher/src/workspace-encryption-policy.ts
+++ b/packages/publisher/src/workspace-encryption-policy.ts
@@ -1,0 +1,52 @@
+/**
+ * The SWM encryption policy for one context graph, as a single pure decision.
+ * This module is the CANONICAL home of the must-vs-may rationale; call sites
+ * keep only the sequencing notes that affect their local code.
+ *
+ * Two DIFFERENT questions, and conflating them turns a public+agent-gated CG
+ * into a permanent failure in whichever direction the local chain probe happens
+ * to disagree with the sender's:
+ *
+ *   requiresEncryptedPayload  MUST it be encrypted?  policy, chain-derived
+ *   supportsEncryptedPayload  MAY it be encrypted?   structure, local
+ *
+ * A public CG's allowlist governs PUBLISH AUTHORITY, not READ ACCESS, so a CG
+ * proven public on-chain stops REQUIRING encryption — but an agent-gated CG must
+ * still ACCEPT it, because a sender whose chain probe failed will fail closed
+ * and encrypt. The two probes legitimately diverge during an RPC flake, a stale
+ * mapping, rollout skew, or an older client; admitting both encodings during
+ * any skew window is what makes those survivable instead of silently dropped.
+ * Structural fact (is this CG gated at all?) governs what is ACCEPTABLE;
+ * chain-proven policy governs only what is REQUIRED — hence the invariant that
+ * a CG never REQUIRES encryption without also SUPPORTING it.
+ *
+ * `provenPublicOnChain` must be true ONLY on a live public proof. An absent
+ * oracle, `false`, or a thrown lookup all mean "not proven public" and keep the
+ * encryption requirement — the same fail-closed discipline the sender uses
+ * (`resolveWorkspaceRecipientsGated`), so a stale mapping or an RPC flake can
+ * never become a plaintext-acceptance hole. The field is consumed exclusively
+ * behind `isAgentGated`, so callers may (and the handler does) skip the chain
+ * probe entirely for ungated CGs.
+ */
+
+export interface WorkspaceEncryptionPolicyInput {
+  readonly hasPrivateAccessPolicy: boolean;
+  readonly agentGateAddresses: readonly string[] | null;
+  readonly provenPublicOnChain: boolean;
+}
+
+export interface WorkspaceEncryptionRequirement {
+  requiresEncryptedPayload: boolean;
+  supportsEncryptedPayload: boolean;
+}
+
+export function resolveWorkspaceEncryptionRequirement(
+  params: WorkspaceEncryptionPolicyInput,
+): WorkspaceEncryptionRequirement {
+  const isAgentGated = params.agentGateAddresses !== null;
+  const gateRequiresEncryption = isAgentGated && !params.provenPublicOnChain;
+  return {
+    requiresEncryptedPayload: params.hasPrivateAccessPolicy || gateRequiresEncryption,
+    supportsEncryptedPayload: params.hasPrivateAccessPolicy || isAgentGated,
+  };
+}

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1090,11 +1090,25 @@ export class SharedMemoryHandler {
       // member->curator SWM share on a public/curated CG. Both sides now read
       // the same live on-chain predicate, and both fail closed when it cannot
       // prove public.
+      // LAZY probe — only when the CG is agent-gated. The helper consumes
+      // provenPublicOnChain exclusively behind `isAgentGated`, so for an
+      // ungated CG the probe's answer is irrelevant; awaiting it anyway puts a
+      // live chain RPC (resolveOnChainAccessPolicyState, network + timeout
+      // machinery) on the hot path of EVERY SWM gossip receive. Measured on a
+      // 6-node devnet this took receive-apply from ~3ms to ~33ms and flipped
+      // the public-CG sync gate red: the author's next poll slipped one 3s
+      // cycle, the VM publish then landed AFTER the live receiver's queued
+      // catch-up had already run, and the receiver starved until the periodic
+      // sweep (~5min). The pre-refactor code short-circuited exactly this way
+      // (`agentGateAddresses !== null && !(await probe())`); keep that
+      // evaluation order while preserving the must-vs-may split.
       const { requiresEncryptedPayload, supportsEncryptedPayload } =
         resolveWorkspaceEncryptionRequirement({
           hasPrivateAccessPolicy,
           agentGateAddresses,
-          provenPublicOnChain: await this.isContextGraphProvenPublicOnChain(contextGraphId, ctx),
+          provenPublicOnChain: agentGateAddresses !== null
+            ? await this.isContextGraphProvenPublicOnChain(contextGraphId, ctx)
+            : false,
         });
       // MUST-be-encrypted and MAY-be-encrypted are different questions, and
       // conflating them turns a public+agent-gated CG into a permanent failure

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -36,6 +36,7 @@ import {
 } from './workspace-resolution.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import { workspacePublicQuadsDigest } from './workspace-snapshot-store.js';
+import { resolveWorkspaceEncryptionRequirement } from './workspace-encryption-policy.js';
 
 interface WorkspaceGossipDecodeResult {
   request?: WorkspacePublishRequestMsg;
@@ -275,38 +276,6 @@ function seenShareOpKey(cgId: string, shareOperationId: string): string {
  * Validates the request, stores public triples into SWM graph
  * and metadata into SWM meta graph. No chain, no UAL.
  */
-/**
- * The SWM encryption policy for one context graph, as a single decision.
- *
- * Two DIFFERENT questions, and conflating them turns a public+agent-gated CG
- * into a permanent failure in whichever direction the local chain probe happens
- * to disagree with the sender's:
- *
- *   requiresEncryptedPayload  MUST it be encrypted?  policy, chain-derived
- *   supportsEncryptedPayload  MAY it be encrypted?   structure, local
- *
- * A public CG's allowlist governs PUBLISH AUTHORITY, not READ ACCESS, so a CG
- * proven public on-chain stops REQUIRING encryption — but an agent-gated CG must
- * still ACCEPT it, because a sender whose chain probe failed will fail closed and
- * encrypt. Admitting both encodings is what makes rollout skew, RPC flakes, and
- * older clients survivable instead of silently dropped.
- *
- * Exported so the shipped decision itself is testable: a test that reimplements
- * this expression would keep passing if the handler stopped honouring it.
- */
-export function resolveWorkspaceEncryptionRequirement(params: {
-  readonly hasPrivateAccessPolicy: boolean;
-  readonly agentGateAddresses: readonly string[] | null;
-  readonly provenPublicOnChain: boolean;
-}): { requiresEncryptedPayload: boolean; supportsEncryptedPayload: boolean } {
-  const isAgentGated = params.agentGateAddresses !== null;
-  const gateRequiresEncryption = isAgentGated && !params.provenPublicOnChain;
-  return {
-    requiresEncryptedPayload: params.hasPrivateAccessPolicy || gateRequiresEncryption,
-    supportsEncryptedPayload: params.hasPrivateAccessPolicy || isAgentGated,
-  };
-}
-
 export class SharedMemoryHandler {
   private readonly store: TripleStore;
   private readonly graphManager: GraphManager;
@@ -1082,26 +1051,14 @@ export class SharedMemoryHandler {
         }
       }
 
-      // A PRIVATE CG always requires encryption. An agent gate requires it too,
-      // EXCEPT on a CG proven public on-chain: there the allowlist governs
-      // publish authority, not read access, so the sender deliberately gossips
-      // plaintext (`resolveWorkspaceRecipientsGated`). Deciding here from local
-      // gate triples alone disagreed with that and permanently dropped every
-      // member->curator SWM share on a public/curated CG. Both sides now read
-      // the same live on-chain predicate, and both fail closed when it cannot
-      // prove public.
-      // LAZY probe — only when the CG is agent-gated. The helper consumes
-      // provenPublicOnChain exclusively behind `isAgentGated`, so for an
-      // ungated CG the probe's answer is irrelevant; awaiting it anyway puts a
-      // live chain RPC (resolveOnChainAccessPolicyState, network + timeout
-      // machinery) on the hot path of EVERY SWM gossip receive. Measured on a
-      // 6-node devnet this took receive-apply from ~3ms to ~33ms and flipped
-      // the public-CG sync gate red: the author's next poll slipped one 3s
-      // cycle, the VM publish then landed AFTER the live receiver's queued
-      // catch-up had already run, and the receiver starved until the periodic
-      // sweep (~5min). The pre-refactor code short-circuited exactly this way
-      // (`agentGateAddresses !== null && !(await probe())`); keep that
-      // evaluation order while preserving the must-vs-may split.
+      // Policy rationale lives in `workspace-encryption-policy.ts` (the
+      // must-vs-may split and its fail-closed discipline). Local sequencing
+      // note only: the probe is LAZY — evaluated solely when the CG is
+      // agent-gated, because the policy consumes provenPublicOnChain
+      // exclusively behind `isAgentGated` and awaiting the chain RPC
+      // unconditionally put ~30ms on the hot path of EVERY SWM gossip receive
+      // (measured devnet regression: receive-apply 3ms -> 33ms flipped the
+      // public-CG sync gate red). Keep this evaluation order.
       const { requiresEncryptedPayload, supportsEncryptedPayload } =
         resolveWorkspaceEncryptionRequirement({
           hasPrivateAccessPolicy,
@@ -1110,19 +1067,6 @@ export class SharedMemoryHandler {
             ? await this.isContextGraphProvenPublicOnChain(contextGraphId, ctx)
             : false,
         });
-      // MUST-be-encrypted and MAY-be-encrypted are different questions, and
-      // conflating them turns a public+agent-gated CG into a permanent failure
-      // in whichever direction the local chain probe happens to disagree with
-      // the sender's. The two probes legitimately diverge during an RPC flake,
-      // a stale mapping, rollout skew, or an older client: a sender that cannot
-      // prove public FAILS CLOSED and encrypts, and a receiver that CAN prove
-      // public would then reject that encrypted write below — the mirror image
-      // of the plaintext drop this change exists to fix.
-      //
-      // Structural fact (is this CG gated at all?) governs what is ACCEPTABLE.
-      // Chain-proven policy governs only what is REQUIRED. So an agent-gated CG
-      // always SUPPORTS Sender-Key payloads, and a public one merely stops
-      // demanding them. Both encodings are admitted during any skew window.
       if (requiresEncryptedPayload && !decoded.encryptedPayload && !decoded.senderKeyMessage) {
         const reason = `Sender Key encrypted workspace payload required for private or agent-gated context graph "${contextGraphId}"`;
         this.log.warn(ctx, `SWM write rejected: ${reason}`);

--- a/packages/publisher/test/swm-public-gated-plaintext-accept.test.ts
+++ b/packages/publisher/test/swm-public-gated-plaintext-accept.test.ts
@@ -27,7 +27,21 @@
  * confidence for the exact regression it was meant to pin.
  */
 import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  TypedEventBus,
+  computeGossipSigningPayload,
+  contextGraphDataUri,
+  contextGraphMetaUri,
+  DKG_ONTOLOGY,
+  encodeGossipEnvelope,
+  GOSSIP_ENVELOPE_VERSION,
+  GOSSIP_TYPE_WORKSPACE_PUBLISH,
+} from '@origintrail-official/dkg-core';
+import { SharedMemoryHandler } from '../src/index.js';
 import { resolveWorkspaceEncryptionRequirement } from '../src/workspace-handler.js';
+import { encodeRootlessWorkspaceRequest } from './_helpers/rootless-workspace.js';
 
 const GATE = ['0x1111111111111111111111111111111111111111'];
 
@@ -121,5 +135,91 @@ describe('SWM encryption requirement', () => {
         }
       }
     });
+  });
+});
+
+/**
+ * Probe LAZINESS at the handler boundary.
+ *
+ * The helper only reads `provenPublicOnChain` behind `isAgentGated`, so for an
+ * ungated CG the on-chain probe's answer is irrelevant — but an earlier
+ * revision of the handler awaited `isContextGraphProvenPublicOnChain`
+ * UNCONDITIONALLY before calling the helper. That put a live chain RPC on the
+ * hot path of EVERY SWM gossip receive: measured on a 6-node devnet it took
+ * receive-apply from ~3ms to ~33ms, which slipped the author's next poll by a
+ * full cycle and made the public-CG sync gate's LIVE receiver miss the VM
+ * publish window (devnet gate regression, both public cells).
+ *
+ * These tests drive the REAL handler with a counting oracle:
+ *  - ungated CG  => the write applies and the probe is NEVER invoked
+ *    (mutation check: re-introducing the unconditional await fails this)
+ *  - gated CG    => the probe IS invoked (laziness must not become "never")
+ */
+describe('on-chain probe evaluation at the handler boundary', () => {
+  const CG = 'swm-plaintext-probe-laziness';
+  const DATA = contextGraphDataUri(CG);
+  const META = contextGraphMetaUri(CG);
+  const PEER = '12D3KooWProbeLazinessPeer';
+  const SUBJ = 'urn:test:swm-plaintext-probe';
+
+  const msg = (name: string, op: string): Uint8Array => encodeRootlessWorkspaceRequest({
+    contextGraphId: CG,
+    nquads: new TextEncoder().encode(
+      `<${SUBJ}> <http://schema.org/name> "${name}" <${DATA}> .`,
+    ),
+    publisherPeerId: PEER,
+    shareOperationId: op,
+    timestampMs: Date.now(),
+  });
+
+  it('ungated CG: plaintext applies WITHOUT consulting the on-chain probe', async () => {
+    const store = new OxigraphStore();
+    let probeCalls = 0;
+    const handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: new Map(),
+      publicAccessPolicyOnChainOracle: async () => { probeCalls += 1; return true; },
+    });
+
+    const outcome = await handler.handle(msg('Ungated Fast Path', 'ws-probe-ungated'), PEER);
+
+    expect(outcome.applied).toBe(true);
+    expect(probeCalls).toBe(0);
+  });
+
+  it('agent-gated CG: the probe IS consulted, and a public proof admits the plaintext write', async () => {
+    const store = new OxigraphStore();
+    let probeCalls = 0;
+    const writer = ethers.Wallet.createRandom();
+    await store.insert([{
+      subject: DATA,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: `"${writer.address}"`,
+      graph: META,
+    }]);
+    const handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: new Map(),
+      localAgentAddresses: () => [writer.address],
+      publicAccessPolicyOnChainOracle: async () => { probeCalls += 1; return true; },
+    });
+
+    const payload = msg('Gated Public Plaintext', 'ws-probe-gated');
+    const timestamp = new Date().toISOString();
+    const signature = await writer.signMessage(
+      computeGossipSigningPayload(GOSSIP_TYPE_WORKSPACE_PUBLISH, CG, timestamp, payload),
+    );
+    const wire = encodeGossipEnvelope({
+      version: GOSSIP_ENVELOPE_VERSION,
+      type: GOSSIP_TYPE_WORKSPACE_PUBLISH,
+      contextGraphId: CG,
+      agentAddress: writer.address,
+      timestamp,
+      signature: ethers.getBytes(signature),
+      payload,
+    });
+
+    const outcome = await handler.handle(wire, PEER);
+
+    expect(outcome.applied).toBe(true);
+    expect(probeCalls).toBeGreaterThan(0);
   });
 });

--- a/packages/publisher/test/swm-public-gated-plaintext-accept.test.ts
+++ b/packages/publisher/test/swm-public-gated-plaintext-accept.test.ts
@@ -40,7 +40,7 @@ import {
   GOSSIP_TYPE_WORKSPACE_PUBLISH,
 } from '@origintrail-official/dkg-core';
 import { SharedMemoryHandler } from '../src/index.js';
-import { resolveWorkspaceEncryptionRequirement } from '../src/workspace-handler.js';
+import { resolveWorkspaceEncryptionRequirement } from '../src/workspace-encryption-policy.js';
 import { encodeRootlessWorkspaceRequest } from './_helpers/rootless-workspace.js';
 
 const GATE = ['0x1111111111111111111111111111111111111111'];


### PR DESCRIPTION
## Symptom (on this canary)

Devnet sync gate regression in BOTH public cells: LIVE receivers timing out on VM content (previously ~3s), and markdown KAs reported EMPTY on peers within the 90s window. Testers may have seen slow SWM/VM arrival on receiving nodes — **not data loss**; content still converges via the durable lane.

## Root cause

The #1843 review fix routed the receiver's SWM encryption decision through `resolveWorkspaceEncryptionRequirement`, but the handler integration awaited `isContextGraphProvenPublicOnChain` **unconditionally** — putting a live chain RPC on the hot path of **every** SWM gossip receive, including plain ungated public CGs where its answer is irrelevant (the helper only reads it behind `isAgentGated`).

Measured on a 6-node devnet: receive-apply went **~3ms → ~33ms**, slipping receiver polling by a full cycle so LIVE receivers missed the VM/markdown windows.

## Fix

Evaluate the probe **lazily** — only when the CG is actually agent-gated. The ungated fast path never touches the chain.

Handler-boundary tests with a counting oracle (in the vitest include list):
- ungated CG → write applies and the probe is **never invoked** — mutation-checked: re-introducing the unconditional await fails this test
- gated CG → the probe **is** invoked (laziness must not become "never")

## Validation status

Unit + mutation coverage attached and green. The full devnet gate re-run is in progress in parallel (environment flakiness, not red results, has delayed it) — pushed now at operator request because the team is actively testing on the regressed canary. Gate numbers will be posted here when the run completes; hold merge for them if you prefer.

Cherry-picked cleanly onto current `testnet-canary` head (includes #1848).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
