### PR TITLE
Fix public context graph metadata projection

### DIFF
--- a/packages/agent/src/context-graph-public-meta-proof.ts
+++ b/packages/agent/src/context-graph-public-meta-proof.ts
@@ -41,6 +41,29 @@ const AUTHORITATIVE_PUBLIC_META_REQUIREMENTS: readonly PublicMetaRequirement[] =
   PUBLIC_ACCESS_POLICY_REQUIREMENT,
 ];
 
+/**
+ * Materialize the canonical root `_meta` facts required to prove that a
+ * Context Graph is publicly readable.
+ *
+ * Keep writers on the same requirement model as snapshot and store-side
+ * validators. Public graph definitions remain in ONTOLOGY for discovery, but
+ * these two facts are duplicated into the graph's own `_meta` partition so a
+ * late subscriber can authenticate the control snapshot before admitting SWM
+ * data.
+ */
+export function buildAuthoritativePublicMetaQuads(contextGraphId: string): Quad[] {
+  const graph = contextGraphMetaGraphUri(contextGraphId);
+  const subject = contextGraphDataGraphUri(contextGraphId);
+  return AUTHORITATIVE_PUBLIC_META_REQUIREMENTS.map((requirement) => ({
+    subject,
+    predicate: requirement.predicate,
+    object: requirement.object.kind === 'iri'
+      ? requirement.object.value
+      : `"${requirement.object.value}"`,
+    graph,
+  }));
+}
+
 function matchesRequirementObject(
   value: string,
   requirement: PublicMetaObjectRequirement,

--- a/packages/agent/src/context-graph-public-meta-repair.ts
+++ b/packages/agent/src/context-graph-public-meta-repair.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  assertSafeIri,
+  contextGraphDataGraphUri,
+  contextGraphMetaGraphUri,
+} from '@origintrail-official/dkg-core';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import { buildAuthoritativePublicMetaQuads } from './context-graph-public-meta-proof.js';
+import { stripLiteral } from './dkg-agent-utils.js';
+
+const CONTEXT_GRAPH_URI_PREFIX = 'did:dkg:context-graph:';
+
+export interface PublicMetaRepairResult {
+  candidates: number;
+  repairedGraphs: number;
+  insertedTriples: number;
+  conflictingGraphs: string[];
+}
+
+/**
+ * Backfill the canonical public proof for graphs created by this exact peer.
+ *
+ * Older builds wrote public definitions only to ONTOLOGY even though the sync
+ * admission contract requires `rdf:type` and `accessPolicy="public"` in the
+ * root `_meta` graph. Only creator-owned ontology rows are eligible: a
+ * subscriber must never promote a network-discovered definition into an
+ * authoritative control snapshot. Existing non-public `_meta` policy is a
+ * hard conflict and is left untouched.
+ */
+export async function repairCreatorPublicMetaProjections(
+  store: TripleStore,
+  peerId: string,
+): Promise<PublicMetaRepairResult> {
+  const ontologyGraph = assertSafeIri(
+    contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
+  );
+  const creatorDid = assertSafeIri(`did:dkg:agent:${peerId}`);
+  const candidatesResult = await store.query(`
+    SELECT DISTINCT ?contextGraph WHERE {
+      GRAPH <${ontologyGraph}> {
+        ?contextGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> ;
+          <${DKG_ONTOLOGY.DKG_CREATOR}> <${creatorDid}> ;
+          <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?accessPolicy .
+        FILTER(
+          isLiteral(?accessPolicy) &&
+          LCASE(REPLACE(STR(?accessPolicy), "^\\\\s+|\\\\s+$", "")) = "public"
+        )
+        FILTER NOT EXISTS {
+          ?contextGraph <${DKG_ONTOLOGY.DKG_CREATOR}> ?conflictingCreator .
+          FILTER(?conflictingCreator != <${creatorDid}>)
+        }
+        FILTER NOT EXISTS {
+          ?contextGraph <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?conflictingAccessPolicy .
+          FILTER(
+            !isLiteral(?conflictingAccessPolicy) ||
+            LCASE(REPLACE(STR(?conflictingAccessPolicy), "^\\\\s+|\\\\s+$", "")) != "public"
+          )
+        }
+      }
+    }
+  `);
+  const candidateSubjects = candidatesResult.type === 'bindings'
+    ? [...new Set(candidatesResult.bindings
+        .map((row) => row['contextGraph'])
+        .filter((value): value is string => Boolean(value)))]
+    : [];
+
+  const inserts: Quad[] = [];
+  const conflictingGraphs: string[] = [];
+  let repairedGraphs = 0;
+
+  for (const subject of candidateSubjects) {
+    if (!subject.startsWith(CONTEXT_GRAPH_URI_PREFIX)) continue;
+    const contextGraphId = subject.slice(CONTEXT_GRAPH_URI_PREFIX.length);
+    if (!contextGraphId || contextGraphDataGraphUri(contextGraphId) !== subject) continue;
+    const metaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
+    const existingResult = await store.query(`
+      SELECT ?predicate ?object WHERE {
+        GRAPH <${metaGraph}> {
+          <${assertSafeIri(subject)}> ?predicate ?object .
+          FILTER(?predicate IN (
+            <${DKG_ONTOLOGY.RDF_TYPE}>,
+            <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}>
+          ))
+        }
+      }
+    `);
+    const existing = existingResult.type === 'bindings'
+      ? existingResult.bindings
+      : [];
+    const policies = existing
+      .filter((row) => row['predicate'] === DKG_ONTOLOGY.DKG_ACCESS_POLICY)
+      .map((row) => row['object']);
+    const hasConflictingPolicy = policies.some((value) => (
+      !value?.startsWith('"') || stripLiteral(value).trim().toLowerCase() !== 'public'
+    ));
+    if (hasConflictingPolicy) {
+      conflictingGraphs.push(contextGraphId);
+      continue;
+    }
+
+    const hasType = existing.some((row) => (
+      row['predicate'] === DKG_ONTOLOGY.RDF_TYPE &&
+      row['object'] === DKG_ONTOLOGY.DKG_CONTEXT_GRAPH
+    ));
+    const hasPublicPolicy = policies.some((value) => (
+      value?.startsWith('"') && stripLiteral(value).trim().toLowerCase() === 'public'
+    ));
+    const missing = buildAuthoritativePublicMetaQuads(contextGraphId).filter((quad) => (
+      quad.predicate === DKG_ONTOLOGY.RDF_TYPE ? !hasType : !hasPublicPolicy
+    ));
+    if (missing.length === 0) continue;
+    inserts.push(...missing);
+    repairedGraphs += 1;
+  }
+
+  if (inserts.length > 0) {
+    await store.insert(inserts, { source: 'agent.publicMetaRepair' });
+    await store.flush?.();
+  }
+
+  return {
+    candidates: candidateSubjects.length,
+    repairedGraphs,
+    insertedTriples: inserts.length,
+    conflictingGraphs,
+  };
+}

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -130,6 +130,7 @@ import {
   type QueryRequest, type QueryResponse, type QueryAccessConfig, type LookupType,
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
+import { buildAuthoritativePublicMetaQuads } from './context-graph-public-meta-proof.js';
 
 import { ProfileManager } from './profile-manager.js';
 import { DiscoveryClient, type SkillSearchOptions, type DiscoveredAgent, type DiscoveredOffering } from './discovery.js';
@@ -553,6 +554,9 @@ export class ContextGraphMethods extends DKGAgentBase {
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"unregistered"`, graph: cgMetaGraph },
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
     );
+    if (!isCurated && !opts.private) {
+      quads.push(...buildAuthoritativePublicMetaQuads(opts.id));
+    }
     if (opts.publishPolicy !== undefined) {
       quads.push({
         subject: contextGraphUri,
@@ -938,10 +942,14 @@ export class ContextGraphMethods extends DKGAgentBase {
       await this.store.deleteByPattern({ graph: defGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
       await this.store.deleteByPattern({ graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
       await this.store.deleteByPattern({ graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR });
-      await this.store.insert([
+      const authorityQuads: Quad[] = [
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorPeerDid, graph: defGraph },
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
-      ]);
+      ];
+      if (!isCurated) {
+        authorityQuads.push(...buildAuthoritativePublicMetaQuads(id));
+      }
+      await this.store.insert(authorityQuads);
       this.invalidateListContextGraphsCache();
       this.contextGraphMetaProjection.markDirty(id);
       this.log.info(ctx, `Stamped local node as creator contact and address curator for "${id}" (registration-time lazy stamp)`);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -144,6 +144,7 @@ import {
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
 import { buildAuthoritativePrivateMetaAskQuery } from './context-graph-private-meta-proof.js';
 import { buildAuthoritativePublicMetaAskQuery } from './context-graph-public-meta-proof.js';
+import { repairCreatorPublicMetaProjections } from './context-graph-public-meta-repair.js';
 
 import { ProfileManager } from './profile-manager.js';
 import { DiscoveryClient, type SkillSearchOptions, type DiscoveredAgent, type DiscoveredOffering } from './discovery.js';
@@ -949,6 +950,36 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     await this.node.start();
     this.started = true;
     this.log.info(ctx, `Node started, peer ID: ${this.node.peerId.toString()}`);
+
+    // Public definitions were historically written only to ONTOLOGY while
+    // late-subscriber admission requires the canonical proof in root `_meta`.
+    // Repair only graphs whose ontology creator is this exact peer. This runs
+    // after libp2p has exposed the stable peer ID but before protocol handlers
+    // and sync serving are registered. Foreign/discovered graphs remain
+    // ineligible; conflicting local policy remains fail-closed.
+    try {
+      const repaired = await repairCreatorPublicMetaProjections(
+        this.store,
+        this.node.peerId.toString(),
+      );
+      if (repaired.repairedGraphs > 0) {
+        this.log.info(
+          ctx,
+          `Repaired authoritative public metadata for ${repaired.repairedGraphs} creator-owned context graph(s) (${repaired.insertedTriples} triples)`,
+        );
+      }
+      if (repaired.conflictingGraphs.length > 0) {
+        this.log.warn(
+          ctx,
+          `Skipped authoritative public metadata repair for ${repaired.conflictingGraphs.length} context graph(s) with conflicting root policy: ${repaired.conflictingGraphs.join(', ')}`,
+        );
+      }
+    } catch (err) {
+      this.log.warn(
+        ctx,
+        `Failed to repair creator-owned public metadata projections; continuing fail-closed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
 
     // Load registered agents from triple store; auto-register default if none exist.
     // loadAgentsFromStore restores defaultAgentAddress from the persisted

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -179,6 +179,7 @@ import {
   type QueryRequest, type QueryResponse, type QueryAccessConfig, type LookupType,
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
+import { buildAuthoritativePublicMetaQuads } from './context-graph-public-meta-proof.js';
 import { sharedMemoryScopeForFinalizedLifecycle } from './finalized-lifecycle-scope.js';
 import { resolveFinalizedAssertionAuthor } from './finalized-assertion-author.js';
 import { RootlessUpdateError, type RootlessUpdateErrorCode } from './rootless-update-error.js';
@@ -2436,6 +2437,7 @@ export class PublishMethods extends DKGAgentBase {
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: '"unregistered"', graph: cgMetaGraph },
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${curatorAgentAddress}`, graph: cgMetaGraph },
+      ...buildAuthoritativePublicMetaQuads(contextGraphId),
     ];
 
     await this.store.insert(quads);

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -44,6 +44,25 @@ describe('Genesis Knowledge', () => {
       await expect(agent.registerContextGraph('register-owner-agent', { callerAgentAddress: nonDefaultAddr }))
         .resolves.toMatchObject({ onChainId: expect.any(String) });
 
+      const bootstrapId = 'register-bootstrap-public';
+      const bootstrapUri = `did:dkg:context-graph:${bootstrapId}`;
+      const bootstrapMetaGraph = contextGraphMetaUri(bootstrapId);
+      const hasBootstrapPublicProof = async () => {
+        const result = await store.query(`ASK WHERE {
+          GRAPH <${bootstrapMetaGraph}> {
+            <${bootstrapUri}>
+              <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> ;
+              <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> "public" .
+          }
+        }`);
+        return result.type === 'boolean' && result.value;
+      };
+      await agent.ensureContextGraphLocal({ id: bootstrapId, name: 'Bootstrap Public' });
+      expect(await hasBootstrapPublicProof()).toBe(false);
+      await expect(agent.registerContextGraph(bootstrapId, { callerAgentAddress: nonDefaultAddr }))
+        .resolves.toMatchObject({ onChainId: expect.any(String) });
+      expect(await hasBootstrapPublicProof()).toBe(true);
+
       await agent.createContextGraph({ id: 'register-legacy-peer-curator', name: 'Legacy Peer Curator' });
       const legacyMetaGraph = contextGraphMetaUri('register-legacy-peer-curator');
       const legacyUri = 'did:dkg:context-graph:register-legacy-peer-curator';

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -299,6 +299,14 @@ describe('implicit SWM context graph metadata', () => {
       synced: true,
       metaSynced: true,
     });
+    const publicMetaProof = await result.store.query(`ASK WHERE {
+      GRAPH <${contextGraphMetaGraphUri(contextGraphId)}> {
+        <${contextGraphDataGraphUri(contextGraphId)}>
+          <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> ;
+          <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> "public" .
+      }
+    }`);
+    expect(publicMetaProof).toEqual({ type: 'boolean', value: true });
   }, 15000);
 
   it('does not overwrite an explicitly created context graph on later SWM writes', async () => {

--- a/packages/agent/test/context-graph-public-meta-repair-http.test.ts
+++ b/packages/agent/test/context-graph-public-meta-repair-http.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  contextGraphDataGraphUri,
+} from '@origintrail-official/dkg-core';
+import {
+  BlazegraphStore,
+  SparqlHttpStore,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  startOxigraphSparqlEndpoint,
+  type OxigraphSparqlEndpoint,
+} from '../../storage/test/helpers/oxigraph-sparql-endpoint.js';
+import { buildAuthoritativePublicMetaAskQuery } from '../src/context-graph-public-meta-proof.js';
+import { repairCreatorPublicMetaProjections } from '../src/context-graph-public-meta-repair.js';
+
+describe('creator-owned public metadata repair over SPARQL HTTP', () => {
+  let endpoint: OxigraphSparqlEndpoint | undefined;
+
+  afterEach(async () => {
+    await endpoint?.close();
+    endpoint = undefined;
+  });
+
+  it.each([
+    ['SPARQL HTTP / oxigraph-server', (target: OxigraphSparqlEndpoint) => new SparqlHttpStore({
+      queryEndpoint: target.queryEndpoint,
+      updateEndpoint: target.updateEndpoint,
+    })],
+    ['Blazegraph', (target: OxigraphSparqlEndpoint) => new BlazegraphStore(target.queryEndpoint)],
+  ] satisfies Array<[string, (target: OxigraphSparqlEndpoint) => TripleStore]>)('%s uses only the portable TripleStore query/insert contract', async (_name, createStore) => {
+    endpoint = await startOxigraphSparqlEndpoint();
+    const store = createStore(endpoint);
+    const contextGraphId = 'legacy-public-sparql-http';
+    const peerId = '12D3KooWSparqlHttpPublicMetaRepair111111111111111111111';
+    const subject = contextGraphDataGraphUri(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    try {
+      await store.insert([
+        {
+          subject,
+          predicate: DKG_ONTOLOGY.RDF_TYPE,
+          object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+          graph: ontologyGraph,
+        },
+        {
+          subject,
+          predicate: DKG_ONTOLOGY.DKG_CREATOR,
+          object: `did:dkg:agent:${peerId}`,
+          graph: ontologyGraph,
+        },
+        {
+          subject,
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"public"',
+          graph: ontologyGraph,
+        },
+      ]);
+
+      const repaired = await repairCreatorPublicMetaProjections(store, peerId);
+      const proof = await store.query(buildAuthoritativePublicMetaAskQuery(contextGraphId));
+
+      expect(repaired.repairedGraphs).toBe(1);
+      expect(repaired.insertedTriples).toBe(2);
+      expect(proof).toEqual({ type: 'boolean', value: true });
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/agent/test/context-graph-public-meta-repair.test.ts
+++ b/packages/agent/test/context-graph-public-meta-repair.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  contextGraphDataGraphUri,
+  contextGraphMetaGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { buildAuthoritativePublicMetaAskQuery } from '../src/context-graph-public-meta-proof.js';
+import { repairCreatorPublicMetaProjections } from '../src/context-graph-public-meta-repair.js';
+
+const CREATOR_PEER = '12D3KooWCreatorPublicMetaRepair111111111111111111111111';
+const FOREIGN_PEER = '12D3KooWForeignPublicMetaRepair111111111111111111111111';
+
+function publicOntologyDefinition(contextGraphId: string, creatorPeerId: string): Quad[] {
+  const subject = contextGraphDataGraphUri(contextGraphId);
+  const graph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+  return [
+    {
+      subject,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph,
+    },
+    {
+      subject,
+      predicate: DKG_ONTOLOGY.DKG_CREATOR,
+      object: `did:dkg:agent:${creatorPeerId}`,
+      graph,
+    },
+    {
+      subject,
+      predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      object: '"public"',
+      graph,
+    },
+  ];
+}
+
+async function hasPublicProof(store: OxigraphStore, contextGraphId: string): Promise<boolean> {
+  const result = await store.query(buildAuthoritativePublicMetaAskQuery(contextGraphId));
+  expect(result.type).toBe('boolean');
+  return result.type === 'boolean' && result.value;
+}
+
+describe('creator-owned public metadata projection repair', () => {
+  it('backfills the complete root proof for a creator-owned legacy public graph', async () => {
+    const store = new OxigraphStore();
+    const contextGraphId = 'legacy-public-missing-meta-proof';
+    try {
+      await store.insert(publicOntologyDefinition(contextGraphId, CREATOR_PEER));
+
+      const repaired = await repairCreatorPublicMetaProjections(store, CREATOR_PEER);
+
+      expect(repaired).toEqual({
+        candidates: 1,
+        repairedGraphs: 1,
+        insertedTriples: 2,
+        conflictingGraphs: [],
+      });
+      expect(await hasPublicProof(store, contextGraphId)).toBe(true);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('repairs only the missing fact and is idempotent', async () => {
+    const store = new OxigraphStore();
+    const contextGraphId = 'legacy-public-partial-meta-proof';
+    try {
+      await store.insert([
+        ...publicOntologyDefinition(contextGraphId, CREATOR_PEER),
+        {
+          subject: contextGraphDataGraphUri(contextGraphId),
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '" PuBlIc "',
+          graph: contextGraphMetaGraphUri(contextGraphId),
+        },
+      ]);
+
+      const first = await repairCreatorPublicMetaProjections(store, CREATOR_PEER);
+      const second = await repairCreatorPublicMetaProjections(store, CREATOR_PEER);
+
+      expect(first.repairedGraphs).toBe(1);
+      expect(first.insertedTriples).toBe(1);
+      expect(second.repairedGraphs).toBe(0);
+      expect(second.insertedTriples).toBe(0);
+      expect(await hasPublicProof(store, contextGraphId)).toBe(true);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('does not make a foreign network-discovered graph authoritative locally', async () => {
+    const store = new OxigraphStore();
+    const contextGraphId = 'foreign-public-missing-meta-proof';
+    try {
+      await store.insert(publicOntologyDefinition(contextGraphId, FOREIGN_PEER));
+
+      const repaired = await repairCreatorPublicMetaProjections(store, CREATOR_PEER);
+
+      expect(repaired.candidates).toBe(0);
+      expect(repaired.insertedTriples).toBe(0);
+      expect(await hasPublicProof(store, contextGraphId)).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('fails closed when creator-owned root metadata has a conflicting policy', async () => {
+    const store = new OxigraphStore();
+    const contextGraphId = 'legacy-public-conflicting-meta-policy';
+    try {
+      await store.insert([
+        ...publicOntologyDefinition(contextGraphId, CREATOR_PEER),
+        {
+          subject: contextGraphDataGraphUri(contextGraphId),
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"private"',
+          graph: contextGraphMetaGraphUri(contextGraphId),
+        },
+      ]);
+
+      const repaired = await repairCreatorPublicMetaProjections(store, CREATOR_PEER);
+
+      expect(repaired.repairedGraphs).toBe(0);
+      expect(repaired.insertedTriples).toBe(0);
+      expect(repaired.conflictingGraphs).toEqual([contextGraphId]);
+      expect(await hasPublicProof(store, contextGraphId)).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('fails closed when the ontology has conflicting creator or policy claims', async () => {
+    const store = new OxigraphStore();
+    const contextGraphId = 'legacy-public-conflicting-ontology';
+    const subject = contextGraphDataGraphUri(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    try {
+      await store.insert([
+        ...publicOntologyDefinition(contextGraphId, CREATOR_PEER),
+        {
+          subject,
+          predicate: DKG_ONTOLOGY.DKG_CREATOR,
+          object: `did:dkg:agent:${FOREIGN_PEER}`,
+          graph: ontologyGraph,
+        },
+        {
+          subject,
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"private"',
+          graph: ontologyGraph,
+        },
+      ]);
+
+      const repaired = await repairCreatorPublicMetaProjections(store, CREATOR_PEER);
+
+      expect(repaired.candidates).toBe(0);
+      expect(repaired.insertedTriples).toBe(0);
+      expect(await hasPublicProof(store, contextGraphId)).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/agent/test/issue-865-public-cg-allowlist.test.ts
+++ b/packages/agent/test/issue-865-public-cg-allowlist.test.ts
@@ -30,6 +30,7 @@ import {
   contextGraphMetaUri,
 } from '@origintrail-official/dkg-core';
 import { DKGAgent } from '../src/index.js';
+import { buildAuthoritativePublicMetaAskQuery } from '../src/context-graph-public-meta-proof.js';
 import { createEVMAdapter, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 
 const CG_ID = 'issue-865-public-cg';
@@ -86,6 +87,14 @@ describe('Issue #865 — public CG + allowlist must not be classified as private
       if (policyResult.type === 'bindings') {
         expect(policyResult.bindings[0]?.['policy']).toBe('"public"');
       }
+
+      // Late subscribers validate the curator's root `_meta` snapshot before
+      // admitting SWM. Creation must materialize the same canonical proof
+      // there instead of relying on the discoverability copy in ONTOLOGY.
+      const publicMetaProof = await store.query(
+        buildAuthoritativePublicMetaAskQuery(CG_ID),
+      );
+      expect(publicMetaProof).toEqual({ type: 'boolean', value: true });
 
       await agent.inviteAgentToContextGraph(CG_ID, INVITEE_AGENT, owner);
 

--- a/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
+++ b/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
@@ -11,6 +11,8 @@
  *   - POST /update                                  → store.update(), 204 / 400
  *   - POST /query  Accept: sparql-results+json      → SELECT (W3C JSON) / ASK
  *   - POST /query  Accept: n-quads | n-triples      → CONSTRUCT (N-Quads text)
+ * It also accepts BlazegraphStore's N-Quads bulk-insert request on /query,
+ * allowing backend-portability tests to exercise that adapter hermetically.
  */
 import { createServer, type Server } from 'node:http';
 import oxigraph from 'oxigraph';
@@ -76,6 +78,13 @@ export async function startOxigraphSparqlEndpoint(): Promise<OxigraphSparqlEndpo
     req.on('data', (c) => { body += c; });
     req.on('end', () => {
       try {
+        const contentType = String(req.headers['content-type'] ?? '');
+        if (contentType.includes('text/x-nquads') || contentType.includes('application/n-quads')) {
+          store.load(body, { format: 'application/n-quads' });
+          res.writeHead(200);
+          res.end();
+          return;
+        }
         if (req.url?.includes('/update')) {
           store.update(body);
           res.writeHead(204);


### PR DESCRIPTION
## Summary

- materialize the canonical public Context Graph proof in the root `_meta` graph for explicit creation, implicit first-write creation, and registration-time ownership stamping
- repair legacy public graphs at startup only when the ontology has an unambiguous creator claim for the local peer
- fail closed on conflicting creator or access-policy declarations
- keep bootstrap/subscriber paths non-authoritative
- implement the repair through the generic `TripleStore` query/insert/optional-flush contract

## Root cause

Public Context Graph definitions were written to `ONTOLOGY`, but late-subscriber catchup validates `rdf:type dkg:ContextGraph` and `dkg:accessPolicy "public"` in the graph's own root `_meta` snapshot. As a result, a genuinely public graph could be discovered and subscribed to while its SWM catchup was rejected as unconfirmed.

An allowlist on a public graph remains a publishing/membership hint and does not convert the graph to private.

## Impact

New public graphs immediately serve a valid authoritative metadata snapshot. Creator nodes repair eligible legacy graphs on startup, allowing public subscribers to admit the SWM backfill without an invite or private membership proof.

The implementation is backend-neutral and covers embedded Oxigraph, SPARQL HTTP / oxigraph-server, and Blazegraph.

## Validation

- `pnpm build`
- `pnpm --filter @origintrail-official/dkg-agent build`
- public proof, allowlist, creator migration, and conflict/idempotency tests
- embedded Oxigraph repair test
- `SparqlHttpStore` repair test against an Oxigraph SPARQL endpoint
- `BlazegraphStore` transport/serialization repair test
- implicit creation, registration-time stamping, and bootstrap trust-boundary regressions
