### PR TITLE
feat(agent): batch exact missing VM asset reconciliation

### DIFF
--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -48,8 +48,15 @@ import {
 export type OrdinalOutcome =
   | { status: 'reconciled'; blockNumber: number }
   | { status: 'already'; blockNumber: number }
-  | { status: 'pending' }
+  | { status: 'pending'; recovery?: OrdinalRecoveryTarget }
   | { status: 'skip' };
+
+export interface OrdinalRecoveryTarget {
+  ordinal: number;
+  ual: string;
+  kaId: string;
+  reason: 'no-swm' | 'verified-vm-metadata-pending';
+}
 
 export interface ChainReconcilerDeps {
   /** Chain-head ordinal for the CG (`getContextGraphKCCount`). */
@@ -78,6 +85,17 @@ export interface ChainReconcilerDeps {
   maxOrdinalsPerPass?: number;
   /** Maximum ordinal reconciliations allowed to run concurrently in one pass. */
   maxOrdinalConcurrency?: number;
+  /**
+   * Fetch one exact batch containing only locally-missing KAs, then re-run
+   * local verification for those ordinals. Undefined preserves scan-only
+   * behavior for callers/tests that do not provide network recovery.
+   */
+  recoverPendingOrdinals?: (
+    localCgId: string,
+    onChainCgId: bigint,
+    targets: readonly OrdinalRecoveryTarget[],
+    headBlock: number | undefined,
+  ) => Promise<ReadonlyMap<number, OrdinalOutcome>>;
   /**
    * Revalidate the local-CG -> on-chain-CG binding between ordinals. An active
    * pass must stop when discovery repairs a stale/reused chain id.
@@ -204,6 +222,22 @@ export async function reconcileContextGraph(
 
     const workerCount = Math.min(ordinalConcurrency, ordinals.length);
     await Promise.all(Array.from({ length: workerCount }, () => runOrdinalWorker()));
+
+    const recoveryTargets = ordinals
+      .map((ordinal) => outcomes.get(ordinal))
+      .filter((outcome): outcome is Extract<OrdinalOutcome, { status: 'pending' }> =>
+        outcome?.status === 'pending' && outcome.recovery !== undefined,
+      )
+      .map((outcome) => outcome.recovery!);
+    if (!staleTarget && recoveryTargets.length > 0 && deps.recoverPendingOrdinals) {
+      const recovered = await deps.recoverPendingOrdinals(
+        localCgId,
+        onChainCgId,
+        recoveryTargets,
+        headBlock,
+      );
+      for (const [ordinal, outcome] of recovered) outcomes.set(ordinal, outcome);
+    }
 
     // Cursor state is deliberately updated in ordinal order even though chain
     // reads, store verification, and independent per-KA materializations ran in

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -74,6 +74,13 @@ export interface ChainReconcilerDeps {
     ordinal: number,
     headBlock: number | undefined,
   ) => Promise<OrdinalOutcome>;
+  /** Maximum ordinals attempted before yielding the global VM worker. */
+  maxOrdinalsPerPass?: number;
+  /**
+   * Revalidate the local-CG -> on-chain-CG binding between ordinals. An active
+   * pass must stop when discovery repairs a stale/reused chain id.
+   */
+  isTargetCurrent?: (localCgId: string, onChainCgId: bigint) => boolean | Promise<boolean>;
   /** Persist the watermark. Called ONLY when it actually moves. */
   persistWatermark: (localCgId: string, watermark: number) => void;
   /** Confirmation depth (blocks) before a completed ordinal advances the watermark. */
@@ -86,13 +93,19 @@ export interface ReconcileResult {
   watermark: number;
   reconciled: number;
   pending: number;
+  processed: number;
+  /** True when another bounded slice should be queued immediately. */
+  hasMore: boolean;
+  /** True when this pass stopped because its captured chain binding changed. */
+  staleTarget: boolean;
 }
 
 /**
- * One sweep pass for a single CG: reconcile every ordinal in `[watermark, head)`
- * (skipping ones already completed and held in the cursor), then advance the
- * contiguous, confirmation-depth-buried watermark. Persists the watermark only
- * if it moved. Mutates `state` in place (the agent owns one `CursorState` per CG).
+ * One bounded sweep slice for a single CG: reconcile up to
+ * `maxOrdinalsPerPass` ordinals in `[watermark, head)` (skipping ones already
+ * completed and held in the cursor), then advance the contiguous,
+ * confirmation-depth-buried watermark. Persists the watermark only if it
+ * moved. Mutates `state` in place (the agent owns one `CursorState` per CG).
  */
 export async function reconcileContextGraph(
   deps: ChainReconcilerDeps,
@@ -108,7 +121,16 @@ export async function reconcileContextGraph(
   // work. A watermark ahead of the observed head is surfaced by the caller as
   // an evidence mismatch, but is equally non-actionable in this pass.
   if (before >= head) {
-    return { head, watermark: before, reconciled: 0, pending: 0 };
+    state.scanOrdinal = before;
+    return {
+      head,
+      watermark: before,
+      reconciled: 0,
+      pending: 0,
+      processed: 0,
+      hasMore: false,
+      staleTarget: false,
+    };
   }
 
   // Keep transient head-fetch failures distinct from truly head-less chains.
@@ -130,13 +152,37 @@ export async function reconcileContextGraph(
   if (headBlock !== undefined) absorbConfirmed(state, headBlock, deps.confirmationDepth);
 
   let reconciled = 0;
-  let pending = 0;
-  const ordinals = ordinalsToReconcile(state, head);
+  let processed = 0;
+  let staleTarget = false;
+  const outstandingBefore = ordinalsToReconcile(state, head);
+  const configuredLimit = deps.maxOrdinalsPerPass;
+  const passLimit = configuredLimit === undefined
+    ? Number.POSITIVE_INFINITY
+    : Math.max(1, Math.floor(configuredLimit));
+  const scanStart = Math.max(state.watermark, state.scanOrdinal);
+  let candidates = outstandingBefore.filter((ordinal) => ordinal >= scanStart);
+  if (candidates.length === 0 && outstandingBefore.length > 0) {
+    // A prior slice reached the observed head. A later periodic pass starts a
+    // fresh cycle from the first still-missing contiguous gap.
+    state.scanOrdinal = state.watermark;
+    candidates = outstandingBefore;
+  }
+  const ordinals = candidates.slice(0, passLimit);
+  const hasUnvisitedCandidates = candidates.length > ordinals.length;
   if (headUnavailable) {
-    pending = ordinals.length;
+    state.scanOrdinal = state.watermark;
   } else {
     for (const ordinal of ordinals) {
+      if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
+        staleTarget = true;
+        break;
+      }
       const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
+      processed += 1;
+      if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
+        staleTarget = true;
+        break;
+      }
       if (outcome.status === 'reconciled' || outcome.status === 'already') {
         reconciled += 1;
         // With a known head, apply the reorg-depth gate; otherwise (no chain
@@ -148,20 +194,35 @@ export async function reconcileContextGraph(
           headBlock ?? outcome.blockNumber,
           headBlock !== undefined ? deps.confirmationDepth : 0,
         );
-      } else {
-        pending += 1;
       }
     }
   }
 
-  if (state.watermark !== before) {
-    deps.persistWatermark(localCgId, state.watermark);
-    deps.log(`reconcile ${localCgId}: watermark ${before} -> ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending})`);
-  } else if (reconciled > 0 || pending > 0) {
-    deps.log(`reconcile ${localCgId}: watermark held at ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending}${headUnavailable ? ', headUnavailable' : ''})`);
+  if (staleTarget || headUnavailable || !hasUnvisitedCandidates) {
+    state.scanOrdinal = state.watermark;
+  } else if (ordinals.length > 0) {
+    state.scanOrdinal = ordinals[ordinals.length - 1]! + 1;
   }
 
-  return { head, watermark: state.watermark, reconciled, pending };
+  const pending = ordinalsToReconcile(state, head).length;
+  const hasMore = !headUnavailable && !staleTarget && hasUnvisitedCandidates;
+
+  if (state.watermark !== before) {
+    deps.persistWatermark(localCgId, state.watermark);
+    deps.log(`reconcile ${localCgId}: watermark ${before} -> ${state.watermark} (head=${head}, processed=${processed}, reconciled=${reconciled}, pending=${pending})`);
+  } else if (reconciled > 0 || pending > 0) {
+    deps.log(`reconcile ${localCgId}: watermark held at ${state.watermark} (head=${head}, processed=${processed}, reconciled=${reconciled}, pending=${pending}${headUnavailable ? ', headUnavailable' : ''})`);
+  }
+
+  return {
+    head,
+    watermark: state.watermark,
+    reconciled,
+    pending,
+    processed,
+    hasMore,
+    staleTarget,
+  };
 }
 
 /**

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -198,30 +198,45 @@ export async function reconcileContextGraph(
       : Math.max(1, Math.floor(configuredConcurrency));
     const outcomes = new Map<number, OrdinalOutcome>();
     let nextOrdinalIndex = 0;
+    let workerFailed = false;
+    let workerError: unknown;
 
     const runOrdinalWorker = async (): Promise<void> => {
-      while (!staleTarget) {
-        const index = nextOrdinalIndex;
-        nextOrdinalIndex += 1;
-        if (index >= ordinals.length) return;
+      // Contain failures instead of racing them: a thrown ordinal must not
+      // leave sibling workers running past this pass's lifetime (their network
+      // and store side effects would overlap the caller's retry). The first
+      // error stops dispatch across all workers, every in-flight ordinal is
+      // drained, and only then does the pass reject with that error.
+      try {
+        while (!staleTarget && !workerFailed) {
+          const index = nextOrdinalIndex;
+          nextOrdinalIndex += 1;
+          if (index >= ordinals.length) return;
 
-        if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
-          staleTarget = true;
-          return;
+          if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
+            staleTarget = true;
+            return;
+          }
+          const ordinal = ordinals[index]!;
+          const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
+          processed += 1;
+          if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
+            staleTarget = true;
+            return;
+          }
+          outcomes.set(ordinal, outcome);
         }
-        const ordinal = ordinals[index]!;
-        const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
-        processed += 1;
-        if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
-          staleTarget = true;
-          return;
+      } catch (error) {
+        if (!workerFailed) {
+          workerFailed = true;
+          workerError = error;
         }
-        outcomes.set(ordinal, outcome);
       }
     };
 
     const workerCount = Math.min(ordinalConcurrency, ordinals.length);
     await Promise.all(Array.from({ length: workerCount }, () => runOrdinalWorker()));
+    if (workerFailed) throw workerError;
 
     const recoveryTargets = ordinals
       .map((ordinal) => outcomes.get(ordinal))
@@ -236,7 +251,15 @@ export async function reconcileContextGraph(
         recoveryTargets,
         headBlock,
       );
-      for (const [ordinal, outcome] of recovered) outcomes.set(ordinal, outcome);
+      // Recovery is the longest await in the pass; the binding can be repaired
+      // while it runs. Outcomes recovered under the old binding must never
+      // advance or persist cursor state for the rebound CG, so re-check before
+      // merging and treat staleness exactly like staleness during ordinal work.
+      if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
+        staleTarget = true;
+      } else {
+        for (const [ordinal, outcome] of recovered) outcomes.set(ordinal, outcome);
+      }
     }
 
     // Cursor state is deliberately updated in ordinal order even though chain

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -76,6 +76,8 @@ export interface ChainReconcilerDeps {
   ) => Promise<OrdinalOutcome>;
   /** Maximum ordinals attempted before yielding the global VM worker. */
   maxOrdinalsPerPass?: number;
+  /** Maximum ordinal reconciliations allowed to run concurrently in one pass. */
+  maxOrdinalConcurrency?: number;
   /**
    * Revalidate the local-CG -> on-chain-CG binding between ordinals. An active
    * pass must stop when discovery repairs a stale/reused chain id.
@@ -172,17 +174,44 @@ export async function reconcileContextGraph(
   if (headUnavailable) {
     state.scanOrdinal = state.watermark;
   } else {
-    for (const ordinal of ordinals) {
-      if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
-        staleTarget = true;
-        break;
+    const configuredConcurrency = deps.maxOrdinalConcurrency;
+    const ordinalConcurrency = configuredConcurrency === undefined
+      ? 1
+      : Math.max(1, Math.floor(configuredConcurrency));
+    const outcomes = new Map<number, OrdinalOutcome>();
+    let nextOrdinalIndex = 0;
+
+    const runOrdinalWorker = async (): Promise<void> => {
+      while (!staleTarget) {
+        const index = nextOrdinalIndex;
+        nextOrdinalIndex += 1;
+        if (index >= ordinals.length) return;
+
+        if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
+          staleTarget = true;
+          return;
+        }
+        const ordinal = ordinals[index]!;
+        const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
+        processed += 1;
+        if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
+          staleTarget = true;
+          return;
+        }
+        outcomes.set(ordinal, outcome);
       }
-      const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
-      processed += 1;
-      if (deps.isTargetCurrent && !(await deps.isTargetCurrent(localCgId, onChainCgId))) {
-        staleTarget = true;
-        break;
-      }
+    };
+
+    const workerCount = Math.min(ordinalConcurrency, ordinals.length);
+    await Promise.all(Array.from({ length: workerCount }, () => runOrdinalWorker()));
+
+    // Cursor state is deliberately updated in ordinal order even though chain
+    // reads, store verification, and independent per-KA materializations ran in
+    // parallel. This preserves the contiguous-watermark contract and makes the
+    // observable result deterministic.
+    if (!staleTarget) for (const ordinal of ordinals) {
+      const outcome = outcomes.get(ordinal);
+      if (!outcome) continue;
       if (outcome.status === 'reconciled' || outcome.status === 'already') {
         reconciled += 1;
         // With a known head, apply the reorg-depth gate; otherwise (no chain

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -872,6 +872,16 @@ export class DKGAgentBase {
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES']) || 1_000);
   static readonly VM_RECONCILE_QUEUE_MAX_PENDING =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_QUEUE_MAX_PENDING']) || 256);
+  /**
+   * Maximum chain ordinals one CG may process before yielding the single VM
+   * worker. Ten amortizes one authenticated payload fetch across a useful
+   * batch while bounding cross-CG latency.
+   */
+  static readonly VM_RECONCILE_BATCH_SIZE =
+    Math.max(1, Number(process.env['DKG_VM_RECONCILE_BATCH_SIZE']) || 10);
+  /** At most one authenticated peer pull per batch; later batches rotate peers. */
+  static readonly VM_RECONCILE_FETCHES_PER_BATCH =
+    Math.max(1, Number(process.env['DKG_VM_RECONCILE_FETCHES_PER_BATCH']) || 1);
   static readonly VM_RECONCILE_MAX_FOREGROUND_BURST =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_MAX_FOREGROUND_BURST']) || 8);
   static readonly VM_RECONCILE_SHUTDOWN_TIMEOUT_MS =

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -874,8 +874,8 @@ export class DKGAgentBase {
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_QUEUE_MAX_PENDING']) || 256);
   /**
    * Maximum chain ordinals one CG may process before yielding the single VM
-   * worker. Ten amortizes one authenticated payload fetch across a useful
-   * batch while bounding cross-CG latency.
+   * worker. Ten keeps exact missing-KA pulls useful while bounding cross-CG
+   * latency and the per-request UAL filter.
    */
   static readonly VM_RECONCILE_BATCH_SIZE =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_BATCH_SIZE']) || 10);
@@ -888,9 +888,6 @@ export class DKGAgentBase {
   /** Keep a slow peer recovery for one CG from blocking every other CG. */
   static readonly VM_RECONCILE_CONCURRENCY =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CONCURRENCY']) || 2);
-  /** At most one authenticated peer pull per batch; later batches rotate peers. */
-  static readonly VM_RECONCILE_FETCHES_PER_BATCH =
-    Math.max(1, Number(process.env['DKG_VM_RECONCILE_FETCHES_PER_BATCH']) || 1);
   static readonly VM_RECONCILE_MAX_FOREGROUND_BURST =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_MAX_FOREGROUND_BURST']) || 8);
   static readonly VM_RECONCILE_SHUTDOWN_TIMEOUT_MS =

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -879,6 +879,15 @@ export class DKGAgentBase {
    */
   static readonly VM_RECONCILE_BATCH_SIZE =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_BATCH_SIZE']) || 10);
+  /**
+   * Parallel ordinal work per CG. Combined with the default two-CG dispatcher
+   * concurrency this caps chain/store pressure at ten in-flight ordinals.
+   */
+  static readonly VM_RECONCILE_ORDINAL_CONCURRENCY =
+    Math.max(1, Number(process.env['DKG_VM_RECONCILE_ORDINAL_CONCURRENCY']) || 5);
+  /** Keep a slow peer recovery for one CG from blocking every other CG. */
+  static readonly VM_RECONCILE_CONCURRENCY =
+    Math.max(1, Number(process.env['DKG_VM_RECONCILE_CONCURRENCY']) || 2);
   /** At most one authenticated peer pull per batch; later batches rotate peers. */
   static readonly VM_RECONCILE_FETCHES_PER_BATCH =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_FETCHES_PER_BATCH']) || 1);

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -209,6 +209,11 @@ import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch
 import { runDurableSync } from './sync/requester/durable-sync.js';
 import { runSharedMemorySync } from './sync/requester/shared-memory-sync.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
+import {
+  decodeExactAssetUals,
+  normalizeExactAssetUals,
+  requireExactAssetUals,
+} from './sync/exact-assets.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
 import { runSyncOnConnect } from './sync/on-connect/sync-on-connect.js';
@@ -962,6 +967,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         syncSessionId: typeof parsed.syncSessionId === 'string' ? parsed.syncSessionId : undefined,
         // Phase C: unsigned delta hint. Validated/normalised in the responder.
         sinceBatchId: typeof parsed.sinceBatchId === 'string' ? parsed.sinceBatchId : undefined,
+        // Exact-asset filter is narrowing-only. Present-but-invalid must remain
+        // an empty filter so the responder serves nothing instead of silently
+        // expanding the request into a full Context Graph scan.
+        assetUals: normalizeExactAssetUals(parsed.assetUals),
         // R9 (SECURITY): the unsigned member-recovery marker. This is a STRICT
         // FIELD ALLOWLIST — anything not copied here is dropped. If `recovery`
         // were omitted, the responder would never see it, silently fall through
@@ -987,7 +996,12 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     // "since" or "session" as control tokens. Old encoders never emit them.
     let sinceBatchId: string | undefined;
     let syncSessionId: string | undefined;
+    let assetUals: string[] | undefined;
     let tail = parts.length;
+    if (tail >= 2 && parts[tail - 2] === 'assets') {
+      assetUals = decodeExactAssetUals(parts[tail - 1]);
+      tail -= 2;
+    }
     if (
       tail >= 2 &&
       parts[tail - 2] === 'since' &&
@@ -1012,6 +1026,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       snapshotRef: phase === 'snapshot' ? parts[4] : undefined,
       syncSessionId,
       sinceBatchId,
+      assetUals,
     };
   }
 
@@ -1089,6 +1104,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     sinceBatchId?: string,
     syncSessionId?: string,
     recovery?: boolean,
+    assetUals?: string[],
   ): Promise<Uint8Array> {
     // Policy-read uncertainty must not abort bootstrap or downgrade it to the
     // public pipe encoding. Treat an unreadable policy as private; catalog is
@@ -1124,6 +1140,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     );
     const claimedAgentAddress = await this.findLocalAgentForContextGraph(contextGraphId);
     const claimedAgent = claimedAgentAddress ? this.localAgents.get(claimedAgentAddress) : undefined;
+    const exactAssetUals = assetUals === undefined ? undefined : requireExactAssetUals(assetUals);
     return buildSyncRequestEnvelope({
       contextGraphId,
       offset,
@@ -1138,6 +1155,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       // is gap-safe only when it comes from a CONTIGUOUS watermark, so it is
       // supplied explicitly by callers, never auto-derived from local MAX().
       sinceBatchId: phase === 'data' && !includeSharedMemory ? sinceBatchId : undefined,
+      assetUals: !includeSharedMemory && phase !== 'catalog' ? exactAssetUals : undefined,
       syncSessionId: phase === 'snapshot' ? undefined : syncSessionId,
       needsAuth,
       // R9: forces the EDGE (member-agent-key) signing path so the responder

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -232,6 +232,7 @@ import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-core-connections.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
+import { requireExactAssetUals } from './sync/exact-assets.js';
 import { insertWithOversizeGuard, type OversizeGuardHooks } from './sync/oversize-filter.js';
 import { runOversizeSweep } from './sync/oversize-sweep.js';
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
@@ -543,6 +544,7 @@ function syncPageFetchCoalescingKey(params: {
   sinceBatchId?: string;
   recovery?: boolean;
   forceFreshSession?: boolean;
+  assetUals?: readonly string[];
 }): string {
   return JSON.stringify([
     params.remotePeerId,
@@ -554,6 +556,7 @@ function syncPageFetchCoalescingKey(params: {
     params.sinceBatchId ?? null,
     params.recovery === true,
     params.forceFreshSession === true,
+    params.assetUals ?? null,
   ]);
 }
 
@@ -622,6 +625,7 @@ function durableSyncSingleFlightKey(params: {
   hasPhaseCallback: boolean;
   hasAccessDeniedCallback: boolean;
   hasSinceBatchIdResolver: boolean;
+  exactAssetUals?: readonly string[];
 }): string | null {
   if (params.hasPhaseCallback || params.hasAccessDeniedCallback || params.hasSinceBatchIdResolver) {
     return null;
@@ -632,6 +636,7 @@ function durableSyncSingleFlightKey(params: {
     stopOnBackoffWorthyFailure: params.stopOnBackoffWorthyFailure === true,
     totalTimeoutMs: params.totalTimeoutMs,
     syncAgentsMeta: params.syncAgentsMeta,
+    exactAssetUals: params.exactAssetUals ?? null,
   });
 }
 
@@ -756,6 +761,10 @@ export type DurableSyncOptions = {
    * independently so an API caller cannot create an unbounded sync operation.
    */
   totalTimeoutMs?: number;
+  /** Internal VM-recovery filter; only these locally-missing KAs are stored. */
+  exactAssetUals?: string[];
+  /** Admission override for foreground VM recovery. */
+  priority?: number;
 };
 
 const MAX_DURABLE_SYNC_TOTAL_TIMEOUT_MS = 300_000;
@@ -910,8 +919,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     lane: SyncSchedulerLane,
     label: string,
     work: () => Promise<T>,
+    priorityOverride?: number,
   ): Promise<T> {
-    const priority = contextGraphPriority(this.config.syncContextGraphPriorities, contextGraphId);
+    const priority = priorityOverride
+      ?? contextGraphPriority(this.config.syncContextGraphPriorities, contextGraphId);
     return withGlobalSyncBackpressure(
       {
         policy: resolveSyncGlobalBackpressure(this.config),
@@ -4089,6 +4100,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           stopOnBackoffWorthyFailure,
           undefined,
           totalTimeoutMs,
+          options?.exactAssetUals,
         ),
       })),
       priorities: this.config.syncContextGraphPriorities,
@@ -4103,6 +4115,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           item.lane,
           item.operationId,
           work,
+          options?.priority,
         ),
       ),
       merge: mergeDurableSyncResults,
@@ -4128,8 +4141,38 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       hasPhaseCallback: Boolean(onPhase),
       hasAccessDeniedCallback: Boolean(onAccessDenied),
       hasSinceBatchIdResolver: Boolean(sinceBatchIdFor),
+      exactAssetUals: options?.exactAssetUals,
     });
     return singleFlightKey ? runSyncSingleFlight(this, singleFlightKey, runSync) : runSync();
+  }
+
+  /**
+   * Foreground VM repair for one bounded set of locally-missing KAs.
+   * Upgraded peers serve only these descriptors/payload graphs. Responses from
+   * older peers are accepted for rolling compatibility, but runDurableSync
+   * filters them back to this exact set before verification or storage.
+   */
+  async syncExactKnowledgeAssetsFromPeer(this: DKGAgent,
+    remotePeerId: string,
+    contextGraphId: string,
+    requestedAssetUals: string[],
+  ): Promise<DurableSyncResult> {
+    const assetUals = requireExactAssetUals(requestedAssetUals);
+    const ctx = createOperationContext('sync');
+    return this.runLegacyDurableSync(
+      ctx,
+      remotePeerId,
+      [contextGraphId],
+      undefined,
+      undefined,
+      undefined,
+      {
+        exactAssetUals: assetUals,
+        stopOnBackoffWorthyFailure: true,
+        totalTimeoutMs: 60_000,
+        priority: 1_000,
+      },
+    );
   }
 
   /** Execute one legacy durable Context Graph after its caller owns admission. */
@@ -4144,6 +4187,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     stopOnBackoffWorthyFailure?: boolean,
     onVerifiedFullSnapshot?: (snapshot: VerifiedFullSnapshot) => Promise<void>,
     totalTimeoutMs: number = SYNC_TOTAL_TIMEOUT_MS,
+    exactAssetUals?: string[],
   ): Promise<DurableSyncResult> {
     const syncAgentsMeta = resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META);
     return runDurableSync({
@@ -4180,8 +4224,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         undefined,
         undefined,
         onVerifiedFullSnapshot !== undefined,
+        exactAssetUals,
       ),
       sinceBatchIdFor,
+      exactAssetUalsFor: exactAssetUals ? () => exactAssetUals : undefined,
       stopOnBackoffWorthyFailure,
       processDurableBatchInWorker: this.processDurableBatchInWorker.bind(this),
       storeInsert: (quads) => this.insertSyncedQuadsAndInvalidateListCache(quads, {
@@ -4506,6 +4552,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // Authoritative snapshot callers must rotate the responder session even
     // when an unfinished offset-zero requester session is still cached.
     forceFreshSession?: boolean,
+    // Exact VM recovery filter. Kept in the checkpoint, coalescing, wire, and
+    // responder-session identities so offsets can never cross asset batches.
+    assetUals?: string[],
   ): Promise<SyncPageResult> {
     const coalescingKey = syncPageFetchCoalescingKey({
       remotePeerId,
@@ -4517,6 +4566,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       sinceBatchId,
       recovery,
       forceFreshSession,
+      assetUals,
     });
     const inFlight = inFlightSyncPageFetchesFor(this);
     const existing = inFlight.get(coalescingKey);
@@ -4552,6 +4602,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       graphUri,
       snapshotRef,
       sinceBatchId,
+      assetUals,
       deadline,
       recovery,
       syncPageTimeoutMs: SYNC_PAGE_TIMEOUT_MS,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -238,6 +238,7 @@ import {
   VmReconcileDispatcher,
   type ChainReconcilerDeps,
   type OrdinalOutcome,
+  type OrdinalRecoveryTarget,
 } from './chain-reconciler.js';
 import {
   ContextGraphOnChainIdUnresolvedError,
@@ -416,6 +417,8 @@ type VmReconcileOrdinalOptions = {
   maxPeerAttempts?: number;
   /** Re-check a captured local/on-chain binding around slow fetch work. */
   isTargetCurrent?: () => boolean;
+  /** Collect the missing KA for one batch fetch instead of fetching inline. */
+  deferActiveFetch?: boolean;
 };
 
 /**
@@ -2791,7 +2794,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const capturedSub = this.subscribedContextGraphs.get(localCgId);
     const capturedOnChainId = capturedSub?.onChainId;
     const capturedCursor = this.reconcileCursors.get(localCgId);
-    let remainingFetches = DKGAgentBase.VM_RECONCILE_FETCHES_PER_BATCH;
     const isTargetCurrent = (): boolean => {
       const current = this.subscribedContextGraphs.get(localCgId);
       return current === capturedSub
@@ -2814,14 +2816,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
       },
       reconcileOrdinal: (lcg, ocg, ordinal, headBlock) =>
         this.reconcileChainOrdinal(lcg, ocg, ordinal, headBlock, {
-          acquireActiveFetchPermit: () => {
-            if (remainingFetches <= 0) return false;
-            remainingFetches -= 1;
-            return true;
-          },
-          maxPeerAttempts: 1,
           isTargetCurrent,
+          deferActiveFetch: true,
         }),
+      recoverPendingOrdinals: (lcg, ocg, targets, headBlock) =>
+        this.recoverVmReconcileBatch(lcg, ocg, targets, headBlock, isTargetCurrent),
       maxOrdinalsPerPass: DKGAgentBase.VM_RECONCILE_BATCH_SIZE,
       maxOrdinalConcurrency: DKGAgentBase.VM_RECONCILE_ORDINAL_CONCURRENCY,
       isTargetCurrent: () => isTargetCurrent(),
@@ -3652,6 +3651,122 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   /**
+   * Drain one exact missing-KA batch. The initial ordinal scan has already
+   * proven these UALs are not locally materialized, so no already-confirmed KA
+   * enters the wire request. After every peer response we re-run local chain
+   * verification and remove completed KAs before considering another peer.
+   */
+  async recoverVmReconcileBatch(this: DKGAgent,
+    localCgId: string,
+    onChainCgId: bigint,
+    targets: readonly OrdinalRecoveryTarget[],
+    headBlock: number | undefined,
+    isTargetCurrent: () => boolean,
+  ): Promise<ReadonlyMap<number, OrdinalOutcome>> {
+    const ctx = createOperationContext('system');
+    if (!isTargetCurrent() || targets.length === 0) return new Map();
+
+    // Capture the authenticated join-approval hint before consulting metadata:
+    // older member snapshots can contain a legacy creator self-stamp that is
+    // unrelated to a wallet-scoped CG's structural curator. The structural
+    // registry resolver is authoritative for `0x…/slug` graphs and can return
+    // every node registered to that curator wallet.
+    const approvedCuratorPeerId = this.preferredSyncPeers.get(localCgId);
+    const curatorResolution = await this.resolveCuratorPeerIdsForCg(localCgId)
+      .catch(() => ({ peerIds: [] as string[], curatorIsLocal: false, legacyTripleResolved: false }));
+    let legacyPreferredPeerId: string | undefined;
+    if (curatorResolution.peerIds.length === 0) {
+      legacyPreferredPeerId = await this.resolvePreferredSyncPeerId(localCgId);
+    }
+    const curatorPeerIds = [...new Set([
+      approvedCuratorPeerId,
+      ...curatorResolution.peerIds,
+      legacyPreferredPeerId,
+    ].filter((peerId): peerId is string => Boolean(peerId && peerId !== this.peerId)))]
+      .slice(0, 3);
+    for (const peerId of curatorPeerIds) {
+      await this.ensurePeerConnected(peerId).catch((error) => {
+        this.log.info(
+          ctx,
+          `VM exact fetch could not connect curator peer ${peerId.slice(-8)}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    }
+
+    const connectedByPeerId = new Map(
+      this.node.libp2p.getConnections()
+        .map((connection) => [connection.remotePeer.toString(), connection.remotePeer]),
+    );
+    const connected = [...connectedByPeerId.values()];
+    const connectedPeerIds = new Set(connectedByPeerId.keys());
+    const orderedConnectedPeerIds = this.selectCatchupPeers(
+      connected,
+      approvedCuratorPeerId ?? curatorPeerIds[0],
+      false,
+    ).map((peer) => peer.toString());
+    const peerIds = [...new Set([
+      ...curatorPeerIds.filter((peerId) => connectedPeerIds.has(peerId)),
+      ...orderedConnectedPeerIds,
+    ])].slice(0, 3);
+    const outcomes = new Map<number, OrdinalOutcome>();
+    let remaining = [...targets];
+
+    for (const peerId of peerIds) {
+      if (!isTargetCurrent() || remaining.length === 0) break;
+      const connectedPeer = connectedByPeerId.get(peerId);
+      if (!connectedPeer || !(await this.waitForSyncProtocol(connectedPeer))) continue;
+
+      const requestedUals = [...new Set(remaining.map((target) => target.ual))];
+      for (const target of remaining) {
+        this.emitReplication({
+          contextGraphId: localCgId,
+          onChainCgId: onChainCgId.toString(),
+          action: 'fetch',
+          ordinal: target.ordinal,
+          kaId: target.kaId,
+          ual: target.ual,
+          detail: `exact-batch:${requestedUals.length}`,
+        });
+      }
+
+      try {
+        const result = await this.syncExactKnowledgeAssetsFromPeer(
+          peerId,
+          localCgId,
+          requestedUals,
+        );
+        this.log.info(
+          ctx,
+          `VM exact fetch for "${localCgId}" from ${peerId.slice(-8)}: requested=${requestedUals.length} fetched=${result.fetchedDataTriples + result.fetchedMetaTriples} inserted=${result.insertedTriples} failed=${result.failedPeers + result.failedPhases} deferred=${result.deferredBackpressure}`,
+        );
+      } catch (error) {
+        this.log.info(
+          ctx,
+          `VM exact fetch for "${localCgId}" from ${peerId.slice(-8)} failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      const stillMissing: OrdinalRecoveryTarget[] = [];
+      for (const target of remaining) {
+        if (!isTargetCurrent()) break;
+        const outcome = await this.reconcileChainOrdinal(
+          localCgId,
+          onChainCgId,
+          target.ordinal,
+          headBlock,
+          { isTargetCurrent, deferActiveFetch: true },
+        );
+        outcomes.set(target.ordinal, outcome);
+        if (outcome.status === 'pending' && outcome.recovery) {
+          stillMissing.push(outcome.recovery);
+        }
+      }
+      remaining = stillMissing;
+    }
+    return outcomes;
+  }
+
+  /**
    * Reconcile a single per-CG registration ordinal: resolve the kaId + its
    * latest on-chain merkle root + publisher, build the UAL, and ask the
    * finalization handler to promote the matching local SWM snapshot to VM
@@ -3694,7 +3809,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // cursor advances without redoing chain reads + an SWM scan.
       if (this.recentReconciledUals.has(cacheKey)) return { status: 'already', blockNumber: versionBlock };
 
-      if (await this.shouldDeferVmReconcileByNegativeCache(cacheKey, localCgId)) {
+      if (!options.deferActiveFetch && await this.shouldDeferVmReconcileByNegativeCache(cacheKey, localCgId)) {
         this.emitReplication({
           contextGraphId: localCgId,
           onChainCgId: onChainCgId.toString(),
@@ -3735,6 +3850,26 @@ export class SwmHostModeMethods extends DKGAgentBase {
     let activeFetchHadUsableResponse = false;
     let outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
     if (outcome === 'no-swm' || outcome === 'verified-vm-metadata-pending') {
+      if (options.deferActiveFetch) {
+        this.emitReplication({
+          contextGraphId: localCgId,
+          onChainCgId: onChainCgId.toString(),
+          action: 'defer',
+          ordinal,
+          kaId: kaId.toString(),
+          ual,
+          detail: outcome,
+        });
+        return {
+          status: 'pending',
+          recovery: {
+            ordinal,
+            ual,
+            kaId: kaId.toString(),
+            reason: outcome,
+          },
+        };
+      }
       if (outcome === 'no-swm') {
         swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
       }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -240,6 +240,7 @@ import {
   type OrdinalOutcome,
   type OrdinalRecoveryTarget,
 } from './chain-reconciler.js';
+import { MAX_EXACT_SYNC_ASSETS } from './sync/exact-assets.js';
 import {
   ContextGraphOnChainIdUnresolvedError,
   VmReconcileUnavailableError,
@@ -3666,6 +3667,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const ctx = createOperationContext('system');
     if (!isTargetCurrent() || targets.length === 0) return new Map();
 
+    // Damping: the batched path deliberately skips the per-UAL negative cache
+    // (consulting it primes connections to every discovered agent — the walk
+    // this path exists to avoid), so the per-CG active-fetch cooldown is the
+    // only damper between this batch and the network. A wholly unproductive
+    // batch (e.g. the curator is offline) therefore costs one bounded exact
+    // fetch per sweep interval, not one per reconcile pass. Progress clears
+    // the cooldown below so a draining backlog proceeds slice after slice.
+    if (!this.shouldRunVmReconcileActiveFetch(localCgId)) {
+      this.log.info(ctx, `VM exact fetch for "${localCgId}" skipped by per-CG cooldown`);
+      return new Map();
+    }
+
     // Capture the authenticated join-approval hint before consulting metadata:
     // older member snapshots can contain a legacy creator self-stamp that is
     // unrelated to a wallet-scoped CG's structural curator. The structural
@@ -3710,14 +3723,23 @@ export class SwmHostModeMethods extends DKGAgentBase {
     ])].slice(0, 3);
     const outcomes = new Map<number, OrdinalOutcome>();
     let remaining = [...targets];
+    let attemptedFetch = false;
 
     for (const peerId of peerIds) {
       if (!isTargetCurrent() || remaining.length === 0) break;
       const connectedPeer = connectedByPeerId.get(peerId);
       if (!connectedPeer || !(await this.waitForSyncProtocol(connectedPeer))) continue;
 
-      const requestedUals = [...new Set(remaining.map((target) => target.ual))];
-      for (const target of remaining) {
+      // The wire protocol rejects filters above MAX_EXACT_SYNC_ASSETS, so a
+      // scan batch configured larger than the protocol cap is requested in
+      // protocol-sized slices; targets past the cap stay in `remaining` for a
+      // later peer or pass. Revalidation is likewise restricted to the
+      // requested slice — each revalidated ordinal costs chain reads, and an
+      // unrequested target cannot have changed state.
+      const requestedTargets = remaining.slice(0, MAX_EXACT_SYNC_ASSETS);
+      const deferredTargets = remaining.slice(MAX_EXACT_SYNC_ASSETS);
+      const requestedUals = [...new Set(requestedTargets.map((target) => target.ual))];
+      for (const target of requestedTargets) {
         this.emitReplication({
           contextGraphId: localCgId,
           onChainCgId: onChainCgId.toString(),
@@ -3730,6 +3752,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       }
 
       try {
+        attemptedFetch = true;
         const result = await this.syncExactKnowledgeAssetsFromPeer(
           peerId,
           localCgId,
@@ -3747,7 +3770,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       }
 
       const stillMissing: OrdinalRecoveryTarget[] = [];
-      for (const target of remaining) {
+      for (const target of requestedTargets) {
         if (!isTargetCurrent()) break;
         const outcome = await this.reconcileChainOrdinal(
           localCgId,
@@ -3761,7 +3784,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
           stillMissing.push(outcome.recovery);
         }
       }
-      remaining = stillMissing;
+      remaining = [...stillMissing, ...deferredTargets];
+    }
+
+    // Mirror the inline path's cooldown policy: an unreachable network must
+    // not consume the fetch budget, and completed work resets the damper so
+    // the trailing `hasMore` slice of a draining backlog fetches immediately.
+    // Only a batch that reached a peer and recovered nothing leaves the
+    // cooldown standing.
+    const recoveredAny = [...outcomes.values()]
+      .some((outcome) => outcome.status === 'reconciled' || outcome.status === 'already');
+    if (!attemptedFetch || recoveredAny) {
+      this.vmReconcileFetchCooldownAt.delete(localCgId);
     }
     return outcomes;
   }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2717,7 +2717,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           );
         },
         {
-          concurrency: 1,
+          concurrency: DKGAgentBase.VM_RECONCILE_CONCURRENCY,
           maxPending: DKGAgentBase.VM_RECONCILE_QUEUE_MAX_PENDING,
           maxForegroundBurst: DKGAgentBase.VM_RECONCILE_MAX_FOREGROUND_BURST,
         },
@@ -2823,6 +2823,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           isTargetCurrent,
         }),
       maxOrdinalsPerPass: DKGAgentBase.VM_RECONCILE_BATCH_SIZE,
+      maxOrdinalConcurrency: DKGAgentBase.VM_RECONCILE_ORDINAL_CONCURRENCY,
       isTargetCurrent: () => isTargetCurrent(),
       persistWatermark: (lcg, watermark) => {
         const sub = this.subscribedContextGraphs.get(lcg);
@@ -3733,10 +3734,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
     let activeFetchRan = false;
     let activeFetchHadUsableResponse = false;
     let outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
-    if (outcome === 'no-swm') {
-      swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
+    if (outcome === 'no-swm' || outcome === 'verified-vm-metadata-pending') {
+      if (outcome === 'no-swm') {
+        swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
+      }
       // Active fetch: pull the missing snapshot core-first (selectCatchupPeers
       // already prioritises known cores + the preferred sync peer), then retry.
+      // Metadata-pending exact VM content needs the same recovery: a durable
+      // sync can supply the missing provenance-bearing assertion metadata even
+      // when no content triples need to move.
       const batchAllowsFetch = options.acquireActiveFetchPermit?.() ?? true;
       const cooldownAllowsFetch = batchAllowsFetch
         && this.shouldRunVmReconcileActiveFetch(localCgId);
@@ -3751,7 +3757,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
           ? undefined
           : Math.max(1, Math.floor(options.maxPeerAttempts));
         if (fixedMaxAttempts !== undefined) maxAttempts = fixedMaxAttempts;
-        for (let attempt = 0; attempt < maxAttempts && outcome === 'no-swm'; attempt += 1) {
+        for (
+          let attempt = 0;
+          attempt < maxAttempts
+            && (outcome === 'no-swm' || outcome === 'verified-vm-metadata-pending');
+          attempt += 1
+        ) {
           if (options.isTargetCurrent && !options.isTargetCurrent()) {
             break;
           }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3729,6 +3729,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
       if (!isTargetCurrent() || remaining.length === 0) break;
       const connectedPeer = connectedByPeerId.get(peerId);
       if (!connectedPeer || !(await this.waitForSyncProtocol(connectedPeer))) continue;
+      // Network boundary: a merely-connected peer is not necessarily admitted
+      // to this DKG network (curator hints and getConnections() both predate
+      // the identity probe). Never send an authenticated exact request to an
+      // unverified or rejected peer.
+      if (!(await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'VM exact fetch'))) continue;
 
       // The wire protocol rejects filters above MAX_EXACT_SYNC_ASSETS, so a
       // scan batch configured larger than the protocol cap is requested in

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -409,6 +409,15 @@ type VmReconcileTarget = {
   watermarkBefore: number;
 };
 
+type VmReconcileOrdinalOptions = {
+  /** Shared by every ordinal in one bounded pass. */
+  acquireActiveFetchPermit?: () => boolean;
+  /** Cap peer rotations for the one batch fetch; omitted preserves legacy behavior. */
+  maxPeerAttempts?: number;
+  /** Re-check a captured local/on-chain binding around slow fetch work. */
+  isTargetCurrent?: () => boolean;
+};
+
 /**
  * Max age (ms) of a cached `publishPolicy` value the host-mode self-signed
  * admission gate (`isConfirmedPublicForHostMode`) will trust. Deliberately
@@ -2736,6 +2745,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     );
     const response = this.toContextGraphReconcileResult(localCgId, source, target, result);
     this.emitVmReconcileTelemetry(localCgId, target, result, response.status);
+    // Queue one trailing slice while this key is still active. The dispatcher
+    // places it behind already-waiting live CGs, so a large graph makes steady
+    // progress without monopolising the only VM worker.
+    if (result.hasMore || result.staleTarget) {
+      this.vmReconcileDispatcher?.triggerLive(localCgId);
+    }
     return response;
   }
 
@@ -2773,6 +2788,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   createVmReconcileDeps(this: DKGAgent, localCgId: string): ChainReconcilerDeps {
+    const capturedSub = this.subscribedContextGraphs.get(localCgId);
+    const capturedOnChainId = capturedSub?.onChainId;
+    const capturedCursor = this.reconcileCursors.get(localCgId);
+    let remainingFetches = DKGAgentBase.VM_RECONCILE_FETCHES_PER_BATCH;
+    const isTargetCurrent = (): boolean => {
+      const current = this.subscribedContextGraphs.get(localCgId);
+      return current === capturedSub
+        && current?.onChainId === capturedOnChainId
+        && this.reconcileCursors.get(localCgId) === capturedCursor;
+    };
     return {
       getKCCount: async (cg) => {
         const head = Number(await this.chain.getContextGraphKCCount!(cg));
@@ -2788,7 +2813,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
         return await this.chain.getBlockNumber();
       },
       reconcileOrdinal: (lcg, ocg, ordinal, headBlock) =>
-        this.reconcileChainOrdinal(lcg, ocg, ordinal, headBlock),
+        this.reconcileChainOrdinal(lcg, ocg, ordinal, headBlock, {
+          acquireActiveFetchPermit: () => {
+            if (remainingFetches <= 0) return false;
+            remainingFetches -= 1;
+            return true;
+          },
+          maxPeerAttempts: 1,
+          isTargetCurrent,
+        }),
+      maxOrdinalsPerPass: DKGAgentBase.VM_RECONCILE_BATCH_SIZE,
+      isTargetCurrent: () => isTargetCurrent(),
       persistWatermark: (lcg, watermark) => {
         const sub = this.subscribedContextGraphs.get(lcg);
         if (!sub) return;
@@ -3629,10 +3664,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
     onChainCgId: bigint,
     ordinal: number,
     headBlock: number | undefined,
+    options: VmReconcileOrdinalOptions = {},
   ): Promise<OrdinalOutcome> {
     const ctx = createOperationContext('system');
     const versionBlock = headBlock ?? 0;
     this.pruneVmReconcileState();
+
+    if (options.isTargetCurrent && !options.isTargetCurrent()) {
+      return { status: 'skip' };
+    }
 
     let kaId: bigint;
     let merkleRoot: Uint8Array;
@@ -3675,6 +3715,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
       return { status: 'pending' };
     }
 
+    if (options.isTargetCurrent && !options.isTargetCurrent()) {
+      return { status: 'skip' };
+    }
     const fh = this.getOrCreateFinalizationHandler();
     const reconcileInput = {
       contextGraphId: localCgId,
@@ -3694,25 +3737,37 @@ export class SwmHostModeMethods extends DKGAgentBase {
       swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
       // Active fetch: pull the missing snapshot core-first (selectCatchupPeers
       // already prioritises known cores + the preferred sync peer), then retry.
-      if (this.shouldRunVmReconcileActiveFetch(localCgId)) {
+      const batchAllowsFetch = options.acquireActiveFetchPermit?.() ?? true;
+      const cooldownAllowsFetch = batchAllowsFetch
+        && this.shouldRunVmReconcileActiveFetch(localCgId);
+      if (batchAllowsFetch && cooldownAllowsFetch) {
         activeFetchRan = true;
         this.emitReplication({
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'fetch', ordinal, kaId: kaId.toString(), ual,
         });
         let maxAttempts = 1;
+        const fixedMaxAttempts = options.maxPeerAttempts === undefined
+          ? undefined
+          : Math.max(1, Math.floor(options.maxPeerAttempts));
+        if (fixedMaxAttempts !== undefined) maxAttempts = fixedMaxAttempts;
         for (let attempt = 0; attempt < maxAttempts && outcome === 'no-swm'; attempt += 1) {
+          if (options.isTargetCurrent && !options.isTargetCurrent()) {
+            break;
+          }
           try {
             const fetchResult = await this.syncContextGraphFromConnectedPeers(localCgId, {
               includeSharedMemory: true,
               maxPeers: 1,
               peerRotationKey: localCgId,
             });
-            maxAttempts = Math.max(
-              maxAttempts,
-              fetchResult.totalPeers ?? fetchResult.connectedPeers ?? 0,
-              this.vmReconcileConnectedPeerCount(),
-            );
+            if (fixedMaxAttempts === undefined) {
+              maxAttempts = Math.max(
+                maxAttempts,
+                fetchResult.totalPeers ?? fetchResult.connectedPeers ?? 0,
+                this.vmReconcileConnectedPeerCount(),
+              );
+            }
             if ((fetchResult.peersTried ?? 0) === 0 && (fetchResult.syncCapablePeers ?? 0) === 0) {
               continue;
             }
@@ -3722,8 +3777,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
             activeFetchHadUsableResponse = true;
           } catch (err) {
             this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
-            maxAttempts = Math.max(maxAttempts, this.vmReconcileConnectedPeerCount());
+            if (fixedMaxAttempts === undefined) {
+              maxAttempts = Math.max(maxAttempts, this.vmReconcileConnectedPeerCount());
+            }
             continue;
+          }
+          if (options.isTargetCurrent && !options.isTargetCurrent()) {
+            break;
           }
           outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
         }
@@ -3731,8 +3791,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
           swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
         }
       } else {
-        this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) skipped by per-CG cooldown`);
+        const reason = batchAllowsFetch ? 'per-CG cooldown' : 'per-batch fetch budget';
+        this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) skipped by ${reason}`);
       }
+    }
+
+    if (options.isTargetCurrent && !options.isTargetCurrent()) {
+      return { status: 'skip' };
     }
 
     switch (outcome) {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -179,6 +179,8 @@ export interface SyncRequestEnvelope {
    * like `phase`/`snapshotRef`), so it's additive and backward-compatible.
    */
   sinceBatchId?: string;
+  /** Additive exact-KA response filter; present-but-invalid parses fail closed. */
+  assetUals?: string[];
   /**
    * R9 (SECURITY) — UNSIGNED member-recovery marker. When set, the responder
    * authorizes via the strict members-only `isMemberRecoveryAuthorized`

--- a/packages/agent/src/reconcile-cursor.ts
+++ b/packages/agent/src/reconcile-cursor.ts
@@ -46,6 +46,14 @@ export interface CursorState {
    * sweep re-derives everything from chain + the persisted watermark.
    */
   ahead: Map<number, number>;
+  /**
+   * In-memory fair-scan cursor for bounded reconcile slices. A pass starts at
+   * this ordinal and advances toward the observed chain head; after reaching
+   * the head it resets to the contiguous watermark so a later periodic sweep
+   * retries any gaps. This is deliberately not persisted: completed ordinals
+   * remain protected by `ahead`, and replay after restart is safe.
+   */
+  scanOrdinal: number;
 }
 
 /** A reconciled ordinal plus the chain block its registration was observed at. */
@@ -55,7 +63,12 @@ export interface CompletedOrdinal {
 }
 
 export function createCursorState(watermark = 0): CursorState {
-  return { watermark: Math.max(0, watermark), ahead: new Map() };
+  const normalizedWatermark = Math.max(0, watermark);
+  return {
+    watermark: normalizedWatermark,
+    ahead: new Map(),
+    scanOrdinal: normalizedWatermark,
+  };
 }
 
 /**

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -4,6 +4,7 @@ import {
   SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_PAGE_SIZE,
 } from '../../dkg-agent-constants.js';
+import { encodeExactAssetUals, requireExactAssetUals } from '../exact-assets.js';
 
 // 'catalog' (§7) — the public facet open-serve: served to ANYONE
 // without the allowlist gate, bounded to exactly the `_catalog` named graph.
@@ -57,6 +58,13 @@ export interface SyncRequestEnvelope {
    */
   sinceBatchId?: string;
   /**
+   * Additive, UNSIGNED exact-KA response filter. It can only narrow an already
+   * authorized Context Graph read. Upgraded responders serve metadata and data
+   * for these UALs only; old responders ignore it, while the upgraded requester
+   * still filters their full response before verification/storage.
+   */
+  assetUals?: string[];
+  /**
    * R9 (SECURITY) — member SWM recovery marker. When set, the recovery path
    * serves PLAINTEXT member-to-member, so the responder MUST authorize it via
    * the strict members-only `isMemberRecoveryAuthorized` hard-deny gate (a
@@ -88,6 +96,7 @@ interface BuildSyncRequestParams {
   authPurpose?: string;
   authSelector?: string;
   sinceBatchId?: string;
+  assetUals?: string[];
   syncSessionId?: string;
   needsAuth: boolean;
   /**
@@ -147,6 +156,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     authPurpose,
     authSelector,
     sinceBatchId,
+    assetUals: rawAssetUals,
     syncSessionId,
     needsAuth,
     recovery,
@@ -173,6 +183,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     ? Math.max(1, Math.min(limit, SYNC_BYTE_BUDGET_MAX_ROWS))
     : SYNC_PAGE_SIZE;
   const useByteBudgetPage = !includeSharedMemory && phase === 'data' && requestedLimit > SYNC_PAGE_SIZE;
+  const assetUals = rawAssetUals === undefined ? undefined : requireExactAssetUals(rawAssetUals);
 
   if (!needsAuth) {
     const prefix = includeSharedMemory ? `workspace:${contextGraphId}` : contextGraphId;
@@ -191,7 +202,8 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     // Trailing keyed tokens are additive; old responders ignore the extra parts.
     const sessionSuffix = syncSessionId ? `|session|${syncSessionId}` : '';
     const sinceSuffix = sinceBatchId ? `|since|${sinceBatchId}` : '';
-    return new TextEncoder().encode(`${prefix}|${offset}|${requestedLimit}${phaseSuffix}${sessionSuffix}${sinceSuffix}`);
+    const assetsSuffix = assetUals ? `|assets|${encodeExactAssetUals(assetUals)}` : '';
+    return new TextEncoder().encode(`${prefix}|${offset}|${requestedLimit}${phaseSuffix}${sessionSuffix}${sinceSuffix}${assetsSuffix}`);
   }
 
   const request: SyncRequestEnvelope = {
@@ -241,6 +253,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
   // authorization; only narrows the responder's result set).
   if (syncSessionId) request.syncSessionId = syncSessionId;
   if (sinceBatchId) request.sinceBatchId = sinceBatchId;
+  if (assetUals) request.assetUals = assetUals;
   if (useByteBudgetPage) {
     request.pageMode = SYNC_BYTE_BUDGET_PAGE_MODE;
     request.pageRowsHint = requestedLimit;

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -185,6 +185,7 @@ export function getSyncCheckpointKey(
   snapshotRef?: string,
   sinceBatchId?: string,
   recovery?: boolean,
+  assetFilterKey?: string,
 ): string {
   const refSuffix = phase === 'snapshot' && snapshotRef ? `|${snapshotRef}` : '';
   // Phase C: `sinceBatchId` changes the responder's result set, so a delta
@@ -201,5 +202,6 @@ export function getSyncCheckpointKey(
   // shared incremental-sync cursor. The flag is additive (only set on the
   // recovery path), so normal sync keeps its unscoped key.
   const recoverySuffix = recovery ? '|recovery' : '';
-  return `${remotePeerId}|${contextGraphId}|${includeSharedMemory ? 'swm' : 'durable'}|${phase}${refSuffix}${sinceSuffix}${recoverySuffix}`;
+  const assetsSuffix = assetFilterKey ? `|assets:${encodeURIComponent(assetFilterKey)}` : '';
+  return `${remotePeerId}|${contextGraphId}|${includeSharedMemory ? 'swm' : 'durable'}|${phase}${refSuffix}${sinceSuffix}${recoverySuffix}${assetsSuffix}`;
 }

--- a/packages/agent/src/sync/exact-assets.ts
+++ b/packages/agent/src/sync/exact-assets.ts
@@ -1,0 +1,59 @@
+import { parseDeterministicKnowledgeAssetUal } from '@origintrail-official/dkg-core';
+
+/** One VM reconciliation slice deliberately fetches at most this many KAs. */
+export const MAX_EXACT_SYNC_ASSETS = 10;
+
+/**
+ * Normalize the additive exact-asset sync filter.
+ *
+ * `undefined` means the caller did not request filtering. Any present but
+ * malformed value becomes an empty filter, which is fail-closed: a bad
+ * narrowing hint must never silently expand into a full-CG response.
+ */
+export function normalizeExactAssetUals(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_EXACT_SYNC_ASSETS) {
+    return [];
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of value) {
+    if (typeof candidate !== 'string') return [];
+    try {
+      const ual = parseDeterministicKnowledgeAssetUal(candidate).ual;
+      if (!seen.has(ual)) {
+        seen.add(ual);
+        normalized.push(ual);
+      }
+    } catch {
+      return [];
+    }
+  }
+  return normalized;
+}
+
+export function requireExactAssetUals(value: unknown): string[] {
+  const normalized = normalizeExactAssetUals(value);
+  if (!normalized || normalized.length === 0) {
+    throw new Error(`Exact VM sync requires 1-${MAX_EXACT_SYNC_ASSETS} valid KA UALs`);
+  }
+  return normalized;
+}
+
+/** Stable identity for checkpoints, single-flight keys, and responder plans. */
+export function exactAssetFilterKey(assetUals: readonly string[] | undefined): string {
+  return assetUals === undefined ? 'full' : `exact:${assetUals.join('\u001f')}`;
+}
+
+export function encodeExactAssetUals(assetUals: readonly string[]): string {
+  return encodeURIComponent(JSON.stringify(assetUals));
+}
+
+export function decodeExactAssetUals(encoded: string): string[] {
+  try {
+    return normalizeExactAssetUals(JSON.parse(decodeURIComponent(encoded))) ?? [];
+  } catch {
+    return [];
+  }
+}

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -107,6 +107,7 @@ interface DurableSyncContext {
     deadline: number,
     snapshotRef?: string,
     sinceBatchId?: string,
+    assetUals?: string[],
   ) => Promise<SyncPageResult>;
   /**
    * Phase C — optional, gap-safe per-CG delta high-water mark resolver. When it
@@ -115,6 +116,8 @@ interface DurableSyncContext {
    * backed by a CONTIGUOUS watermark. Undefined ⇒ full scan (default today).
    */
   sinceBatchIdFor?: (contextGraphId: string) => string | undefined;
+  /** Exact missing KAs for VM recovery; undefined retains normal full/delta sync. */
+  exactAssetUalsFor?: (contextGraphId: string) => string[] | undefined;
   stopOnBackoffWorthyFailure?: boolean;
   processDurableBatchInWorker: (
     dataQuads: Quad[],
@@ -149,6 +152,29 @@ interface DurableSyncContext {
   logDebug: (ctx: OperationContext, message: string) => void;
 }
 
+/**
+ * Rolling-upgrade guard: an old responder may ignore the additive exact-asset
+ * filter and return the whole CG. Keep only requested descriptor subjects and
+ * their declared assertion graphs before any verification or store write.
+ */
+export function filterExactAssetDurablePayload(
+  dataQuads: readonly Quad[],
+  metaQuads: readonly Quad[],
+  assetUals: readonly string[],
+): { dataQuads: Quad[]; metaQuads: Quad[] } {
+  const exactUals = new Set(assetUals);
+  const exactMeta = metaQuads.filter((quad) => exactUals.has(quad.subject));
+  const exactGraphs = new Set(
+    exactMeta
+      .filter((quad) => quad.predicate === ASSERTION_GRAPH)
+      .map((quad) => quad.object),
+  );
+  return {
+    metaQuads: exactMeta,
+    dataQuads: dataQuads.filter((quad) => exactGraphs.has(quad.graph)),
+  };
+}
+
 export async function runDurableSync(context: DurableSyncContext): Promise<DurableSyncSummary> {
   const {
     ctx,
@@ -160,6 +186,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     createContextGraphSyncDeadline,
     fetchSyncPages,
     sinceBatchIdFor,
+    exactAssetUalsFor,
     stopOnBackoffWorthyFailure = false,
     processDurableBatchInWorker,
     storeInsert,
@@ -252,6 +279,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       const dataGraph = contextGraphDataGraphUri(pid);
       const metaGraph = contextGraphMetaGraphUri(pid);
       const deadline = createContextGraphSyncDeadline(contextGraphIds.length - index);
+      const exactAssetUals = exactAssetUalsFor?.(pid);
 
       logInfo(ctx, `Syncing context graph "${pid}" from ${remotePeerId}`);
 
@@ -271,7 +299,20 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
             completed: true,
             timedOut: false,
           }
-        : await fetchSyncPages(ctx, remotePeerId, pid, false, 'meta', metaGraph, deadline);
+        : exactAssetUals === undefined
+          ? await fetchSyncPages(ctx, remotePeerId, pid, false, 'meta', metaGraph, deadline)
+          : await fetchSyncPages(
+              ctx,
+              remotePeerId,
+              pid,
+              false,
+              'meta',
+              metaGraph,
+              deadline,
+              undefined,
+              undefined,
+              exactAssetUals,
+            );
       if (!skipAgentsMeta) peerRespondedForContextGraph = true;
       if (metaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
         recordPhaseOutcome(metaResult, { updateCheckpoint: false });
@@ -279,11 +320,49 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         break;
       }
       const sinceBatchId = sinceBatchIdFor?.(pid);
-      const dataResult = await fetchSyncPages(ctx, remotePeerId, pid, false, 'data', dataGraph, deadline, undefined, sinceBatchId);
+      const rawDataResult = exactAssetUals === undefined
+        ? await fetchSyncPages(
+            ctx,
+            remotePeerId,
+            pid,
+            false,
+            'data',
+            dataGraph,
+            deadline,
+            undefined,
+            sinceBatchId,
+          )
+        : await fetchSyncPages(
+            ctx,
+            remotePeerId,
+            pid,
+            false,
+            'data',
+            dataGraph,
+            deadline,
+            undefined,
+            sinceBatchId,
+            exactAssetUals,
+          );
       peerRespondedForContextGraph = true;
       endPhase();
       const fetchDurationMs = Date.now() - fetchStartedAt;
       const isSystemContextGraph = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(pid);
+
+      let effectiveMetaResult = metaResult;
+      let dataResult = rawDataResult;
+      if (exactAssetUals !== undefined) {
+        const exact = filterExactAssetDurablePayload(
+          rawDataResult.quads,
+          metaResult.quads,
+          exactAssetUals,
+        );
+        effectiveMetaResult = { ...metaResult, quads: exact.metaQuads };
+        dataResult = {
+          ...rawDataResult,
+          quads: exact.dataQuads,
+        };
+      }
 
       let effectiveDataResult = dataResult;
       let dataForVerification = dataResult.quads;
@@ -306,7 +385,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       ) {
         const bounded = planBoundedGraphScopedDurableBatch(
           dataResult.quads,
-          metaResult.quads,
+          effectiveMetaResult.quads,
           dataResult.resumedFromOffset,
           dataResult.nextOffset,
           dataResult.completed,
@@ -338,7 +417,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       const verifyStartedAt = Date.now();
       const processed = await processDurableBatchInWorker(
         dataForVerification,
-        metaResult.quads,
+        effectiveMetaResult.quads,
         ctx,
         isSystemContextGraph,
         verificationMode,
@@ -348,7 +427,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
 
       logInfo(ctx, `  meta: ${processed.totalFetchedMetaQuads} triples fetched`);
       logInfo(ctx, `  data: ${processed.totalFetchedDataQuads} triples fetched`);
-      summary.bytesReceived += metaResult.bytesReceived + dataResult.bytesReceived;
+      summary.bytesReceived += metaResult.bytesReceived + rawDataResult.bytesReceived;
       summary.fetchedMetaTriples += processed.totalFetchedMetaQuads;
       summary.fetchedDataTriples += processed.totalFetchedDataQuads;
       summary.emptyResponses += processed.emptyResponses;
@@ -372,6 +451,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       const notifyVerifiedFullSnapshot = async (): Promise<void> => {
         if (
           !onVerifiedFullSnapshot
+          || exactAssetUals !== undefined
           || sinceBatchId !== undefined
           || !batchVerifiedCleanly
           || processed.dataRejectedMissingMeta !== 0

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -7,6 +7,7 @@ import {
 import { isSyncBackoffWorthyError, markSyncPeerResponded } from '../error-tags.js';
 import { appendInPlace } from '../append-in-place.js';
 import type { SyncPhase } from '../auth/request-build.js';
+import { exactAssetFilterKey } from '../exact-assets.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
 import {
   createDurableDataSyncSessionId,
@@ -161,7 +162,7 @@ interface FetchSyncPagesParams {
    * members-only `isMemberRecoveryAuthorized`). Default false ⇒ normal sync.
    */
   recovery?: boolean;
-  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string, sinceBatchId?: string, syncSessionId?: string, recovery?: boolean) => Promise<Uint8Array>;
+  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string, sinceBatchId?: string, syncSessionId?: string, recovery?: boolean, assetUals?: string[]) => Promise<Uint8Array>;
   /**
    * Phase C — optional, gap-safe delta-sync high-water mark. Forwarded to the
    * responder for the durable DATA phase so it returns only KAs with
@@ -169,6 +170,8 @@ interface FetchSyncPagesParams {
    * (never local MAX, which would skip gaps). Omitted ⇒ full scan.
    */
   sinceBatchId?: string;
+  /** Exact KAs requested by VM recovery. Undefined retains ordinary full sync. */
+  assetUals?: string[];
   parseAndFilter: (nquadsText: string, graphUri: string, contextGraphId: string) => Promise<{ quads: Quad[]; totalQuads: number }>;
   /**
    * Per-attempt send hook. `DKGAgent`'s production adapter sends raw
@@ -246,6 +249,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     recovery,
     buildSyncRequest,
     sinceBatchId,
+    assetUals,
     parseAndFilter,
     send,
     logWarn,
@@ -259,7 +263,8 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   // terminal outcome. Every started phase is guaranteed a finish() below.
   throwIfAborted(signal);
   const phaseTelemetry = createRequesterPhaseTelemetry({ includeSharedMemory, phase });
-  const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId, recovery);
+  const assetKey = assetUals ? exactAssetFilterKey(assetUals) : undefined;
+  const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId, recovery, assetKey);
   if (forceFreshSession) {
     checkpointStore.delete(checkpointKey);
     unfinishedSyncResponderSessions.delete(checkpointKey);
@@ -343,7 +348,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         requestFactory: async () => {
           throwIfAborted(signal);
           successfulPageSize = activePageSize;
-          const request = await buildSyncRequest(contextGraphId, curOffset, activePageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId, recovery);
+          const request = await buildSyncRequest(contextGraphId, curOffset, activePageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId, recovery, assetUals);
           throwIfAborted(signal);
           return request;
         },

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -2804,9 +2804,9 @@ async function readDurableMetaRowsPage(
 /**
  * Serve only the immutable V2 descriptors for an explicitly requested KA set.
  * The caller intersects the request with the confirmed manifest first, so this
- * query cannot expose tentative workspace descriptors. Ten descriptors fit in
- * one ordinary sync page, but OFFSET/LIMIT remains deterministic for protocol
- * compatibility and future descriptor growth.
+ * query cannot expose tentative workspace descriptors. The protocol caps the
+ * VALUES list at ten UALs, so read that bounded descriptor set once, sort it,
+ * and take the requested page in memory instead of OFFSET-scanning `_meta`.
  */
 async function readExactDurableMetaRowsPage(
   store: TripleStore,
@@ -2821,19 +2821,19 @@ async function readExactDurableMetaRowsPage(
   if (safeLimit === 0 || assetUals.length === 0) return [];
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const values = assetUals.map((ual) => `<${assertSafeIri(ual)}>`).join(' ');
+  // sparql-scan-allow: R4 -- ?s is bound to at most ten exact, confirmed KA UALs by the protocol filter
   const result = await store.query(`
     SELECT ?s ?p ?o WHERE {
       VALUES ?s { ${values} }
       GRAPH <${assertSafeIri(metaGraph)}> { ?s ?p ?o }
     }
-    ORDER BY ?s ?p ?o
-    OFFSET ${safeOffset}
-    LIMIT ${safeLimit}
   `, syncResponderStoreOptions(signal, 'sync.responder.readExactDurableMetaRowsPage'));
   if (result.type !== 'bindings') return [];
   return result.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: metaGraph }))
-    .filter((row): row is SyncRow => Boolean(row.s && row.p && row.o));
+    .filter((row): row is SyncRow => Boolean(row.s && row.p && row.o))
+    .sort(compareRows)
+    .slice(safeOffset, safeOffset + safeLimit);
 }
 
 async function readDurableDeltaRowsPageAcrossGraphs(

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -27,6 +27,7 @@ import { SyncRowSnapshotBudgetError } from './snapshot-budget.js';
 import { estimateStringRowHeapBytes } from '../memory-telemetry.js';
 import type { ChangelogSyncResponse, ChangelogDeltaRecord } from '../changelog/wire.js';
 import { durableMetaDelegationSubjectAdmissionExpression } from './durable-meta-admission.js';
+import { exactAssetFilterKey } from '../exact-assets.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -599,7 +600,28 @@ export async function readDurableMetaPage(params: {
   rowListCacheKey?: string;
   refreshRowList?: boolean;
   refreshGeneration?: string;
+  assetUals?: readonly string[];
 }): Promise<SyncRow[]> {
+  if (params.assetUals !== undefined) {
+    if (params.assetUals.length === 0) return [];
+    const manifest = await readGraphScopedVmManifest(
+      params.store,
+      params.contextGraphId,
+      params.signal,
+    );
+    const requested = new Set(params.assetUals);
+    const confirmedUals = manifest.confirmedEntries
+      .map((entry) => entry.ual)
+      .filter((ual) => requested.has(ual));
+    return readExactDurableMetaRowsPage(
+      params.store,
+      params.contextGraphId,
+      confirmedUals,
+      params.offset,
+      params.limit,
+      params.signal,
+    );
+  }
   const cache = params.rowListMemo && params.rowListCacheKey
     ? {
       memo: params.rowListMemo,
@@ -1104,6 +1126,7 @@ export async function readDurableDataPage(params: {
   exactGraphPlanMemo?: ExactGraphPagePlanMemo;
   /** Keep the immutable row snapshot until an explicit empty-page EOF. */
   releaseCacheOnShortPage?: boolean;
+  assetUals?: readonly string[];
 }): Promise<SyncRow[]> {
   const cache = params.rowListMemo
     ? {
@@ -1112,12 +1135,41 @@ export async function readDurableDataPage(params: {
         params.rowListCacheScope ?? 'default',
         params.contextGraphId,
         params.sinceBatchId,
+        params.assetUals,
       ),
       refresh: params.refreshRowList,
       refreshGeneration: params.refreshGeneration,
       releaseOnShortPage: params.releaseCacheOnShortPage,
     }
     : undefined;
+
+  if (params.assetUals !== undefined) {
+    if (params.assetUals.length === 0) return [];
+    const requested = new Set(params.assetUals);
+    return readPagedRowsFromExactGraphPlanLoader(
+      params.store,
+      params.offset,
+      params.limit,
+      cache,
+      params.signal,
+      params.exactGraphPlanMemo,
+      async (planSignal) => {
+        const manifest = await readGraphScopedVmManifest(
+          params.store,
+          params.contextGraphId,
+          planSignal,
+        );
+        const entries = manifest.confirmedEntries.filter((entry) => requested.has(entry.ual));
+        return buildExactGraphPagePlan(
+          params.store,
+          entries.map((entry) => entry.graph),
+          () => Promise.resolve(true),
+          planSignal,
+          new Map(entries.map((entry) => [entry.graph, entry.rowCount])),
+        );
+      },
+    );
+  }
 
   if (params.sinceBatchId == null) {
     return readPagedRowsFromExactGraphPlanLoader(
@@ -2749,6 +2801,41 @@ async function readDurableMetaRowsPage(
   );
 }
 
+/**
+ * Serve only the immutable V2 descriptors for an explicitly requested KA set.
+ * The caller intersects the request with the confirmed manifest first, so this
+ * query cannot expose tentative workspace descriptors. Ten descriptors fit in
+ * one ordinary sync page, but OFFSET/LIMIT remains deterministic for protocol
+ * compatibility and future descriptor growth.
+ */
+async function readExactDurableMetaRowsPage(
+  store: TripleStore,
+  contextGraphId: string,
+  assetUals: readonly string[],
+  offset: number,
+  limit: number,
+  signal?: AbortSignal,
+): Promise<SyncRow[]> {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0 || assetUals.length === 0) return [];
+  const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+  const values = assetUals.map((ual) => `<${assertSafeIri(ual)}>`).join(' ');
+  const result = await store.query(`
+    SELECT ?s ?p ?o WHERE {
+      VALUES ?s { ${values} }
+      GRAPH <${assertSafeIri(metaGraph)}> { ?s ?p ?o }
+    }
+    ORDER BY ?s ?p ?o
+    OFFSET ${safeOffset}
+    LIMIT ${safeLimit}
+  `, syncResponderStoreOptions(signal, 'sync.responder.readExactDurableMetaRowsPage'));
+  if (result.type !== 'bindings') return [];
+  return result.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: metaGraph }))
+    .filter((row): row is SyncRow => Boolean(row.s && row.p && row.o));
+}
+
 async function readDurableDeltaRowsPageAcrossGraphs(
   store: TripleStore,
   graphs: readonly string[],
@@ -2870,8 +2957,16 @@ function graphValues(graphs: readonly string[]): string {
   return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
 }
 
-function durableDataRowListCacheKey(scope: string, contextGraphId: string, sinceBatchId: bigint | null): string {
-  return `durable-data:${scope}:${contextGraphId}:${sinceBatchId == null ? 'full' : `since:${sinceBatchId.toString()}`}`;
+function durableDataRowListCacheKey(
+  scope: string,
+  contextGraphId: string,
+  sinceBatchId: bigint | null,
+  assetUals?: readonly string[],
+): string {
+  const selection = assetUals === undefined
+    ? (sinceBatchId == null ? 'full' : `since:${sinceBatchId.toString()}`)
+    : exactAssetFilterKey(assetUals);
+  return `durable-data:${scope}:${contextGraphId}:${selection}`;
 }
 
 function dedupeStrings(values: readonly string[]): string[] {

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -33,6 +33,7 @@ import {
   serializeResponderRowsWithinByteBudget,
   SyncRowSnapshotLimitError,
 } from './graph-plan.js';
+import { exactAssetFilterKey } from '../exact-assets.js';
 import {
   createSyncResponderSnapshotBudget,
   SyncRowSnapshotBudgetError,
@@ -539,6 +540,10 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     const phase = request.phase ?? 'data';
     const isWorkspace = request.includeSharedMemory;
     const contextGraphId = request.contextGraphId;
+    const assetUals = request.assetUals;
+    const assetSelectionKey = assetUals === undefined
+      ? 'full'
+      : exactAssetFilterKey(assetUals);
     const hintedPageRows = typeof request.pageRowsHint === 'number' &&
       Number.isSafeInteger(request.pageRowsHint)
       ? Math.max(1, Math.min(request.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))
@@ -740,7 +745,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           const queryStartedAt = Date.now();
           const session = prepareResponderSession(
             'Durable meta',
-            `${peerId}:durable-meta:${contextGraphId}`,
+            `${peerId}:durable-meta:${contextGraphId}:${assetSelectionKey}`,
             request.syncSessionId,
             offset,
           );
@@ -762,6 +767,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             rowListCacheKey: session?.rowListCacheKey,
             refreshRowList: session?.refreshRowList,
             refreshGeneration: session?.refreshGeneration,
+            assetUals,
           });
           const queryDurationMs = Date.now() - queryStartedAt;
           const serializeStartedAt = Date.now();
@@ -774,7 +780,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const queryStartedAt = Date.now();
         const session = prepareResponderSession(
           'Durable data',
-          `${peerId}:durable-data:${contextGraphId}:${sinceBatchId == null ? 'full' : sinceBatchId.toString()}`,
+          `${peerId}:durable-data:${contextGraphId}:${assetUals === undefined
+            ? (sinceBatchId == null ? 'full' : sinceBatchId.toString())
+            : assetSelectionKey}`,
           request.syncSessionId,
           offset,
         );
@@ -799,6 +807,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           // loaded above. Do not release the immutable session snapshot merely
           // because that slice was short; the explicit empty request is EOF.
           releaseCacheOnShortPage: !usesByteBudgetPage,
+          assetUals,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -312,6 +312,83 @@ describe('reconcileContextGraph — sweep', () => {
     expect(state.watermark).toBe(0);
     expect(state.scanOrdinal).toBe(0);
   });
+
+  it('discards recovered outcomes when the binding flips during batch recovery', async () => {
+    let current = true;
+    const { deps, persisted } = makeDeps({
+      getKCCount: async () => 2,
+      maxOrdinalsPerPass: 10,
+      isTargetCurrent: async () => current,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => ({
+        status: 'pending',
+        recovery: {
+          ordinal,
+          ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
+          kaId: String(ordinal),
+          reason: 'no-swm',
+        },
+      }),
+      recoverPendingOrdinals: async (_cg, _onchain, targets) => {
+        // The rebind lands while the long recovery await is in flight. The
+        // recovered outcomes belong to the OLD binding and must be discarded.
+        current = false;
+        return new Map(targets.map((target) => [
+          target.ordinal,
+          { status: 'reconciled', blockNumber: 100 } as OrdinalOutcome,
+        ]));
+      },
+    });
+    const state = createCursorState(0);
+
+    const result = await reconcileContextGraph(deps, state, 'cg', 5n);
+
+    expect(result.staleTarget).toBe(true);
+    expect(result.reconciled).toBe(0);
+    expect(result.hasMore).toBe(false);
+    expect(state.watermark).toBe(0);
+    expect(state.scanOrdinal).toBe(0);
+    expect(persisted).toEqual([]);
+  });
+
+  it('contains a worker failure: siblings drain, no new ordinals start, then the pass rejects', async () => {
+    const attempted: number[] = [];
+    const completed: number[] = [];
+    let releaseSlow!: () => void;
+    const slowGate = new Promise<void>((resolve) => { releaseSlow = resolve; });
+    const { deps } = makeDeps({
+      getKCCount: async () => 6,
+      maxOrdinalsPerPass: 6,
+      maxOrdinalConcurrency: 2,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => {
+        attempted.push(ordinal);
+        if (ordinal === 0) {
+          throw new Error('ordinal 0 exploded');
+        }
+        if (ordinal === 1) {
+          await slowGate;
+        }
+        completed.push(ordinal);
+        return { status: 'reconciled', blockNumber: 0 };
+      },
+    });
+    const state = createCursorState(0);
+
+    const pass = reconcileContextGraph(deps, state, 'cg', 1n);
+    let settled = false;
+    void pass.catch(() => undefined).then(() => { settled = true; });
+
+    // Let the failing worker reject and the dispatch loops observe it.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    // The pass must still be waiting on the in-flight sibling ordinal…
+    expect(settled).toBe(false);
+    releaseSlow();
+    await expect(pass).rejects.toThrow('ordinal 0 exploded');
+
+    // …and after the failure no NEW ordinal may have been dispatched.
+    expect(attempted).toEqual([0, 1]);
+    expect(completed).toEqual([1]);
+    expect(state.watermark).toBe(0);
+  });
 });
 
 describe('VmReconcileDispatcher scheduling', () => {

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -63,7 +63,15 @@ describe('reconcileContextGraph — sweep', () => {
     const state = createCursorState(3); // already at head
     const result = await reconcileContextGraph(deps, state, 'cg', 1n);
 
-    expect(result).toEqual({ head: 3, watermark: 3, reconciled: 0, pending: 0 });
+    expect(result).toEqual({
+      head: 3,
+      watermark: 3,
+      reconciled: 0,
+      pending: 0,
+      processed: 0,
+      hasMore: false,
+      staleTarget: false,
+    });
     expect(headBlockReads).toBe(0);
     expect(attempted).toEqual([]);
     expect(persisted).toEqual([]);
@@ -165,9 +173,112 @@ describe('reconcileContextGraph — sweep', () => {
     expect(attempted).toEqual([0, 1]);
     expect(persisted).toEqual([{ cg: 'cg', watermark: 2 }]);
   });
+
+  it('processes a large head in bounded slices and yields between them', async () => {
+    const attempts: number[][] = [[], [], []];
+    let pass = 0;
+    const { deps } = makeDeps({
+      getKCCount: async () => 25,
+      maxOrdinalsPerPass: 10,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => {
+        attempts[pass]!.push(ordinal);
+        return { status: 'pending' };
+      },
+    });
+    const state = createCursorState(0);
+
+    const r1 = await reconcileContextGraph(deps, state, 'cg', 1n);
+    pass += 1;
+    const r2 = await reconcileContextGraph(deps, state, 'cg', 1n);
+    pass += 1;
+    const r3 = await reconcileContextGraph(deps, state, 'cg', 1n);
+
+    expect(attempts).toEqual([
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+      [20, 21, 22, 23, 24],
+    ]);
+    expect([r1.processed, r2.processed, r3.processed]).toEqual([10, 10, 5]);
+    expect([r1.hasMore, r2.hasMore, r3.hasMore]).toEqual([true, true, false]);
+    expect(state.scanOrdinal).toBe(0);
+  });
+
+  it('keeps scanning later slices when an early ordinal remains pending', async () => {
+    const attempts: number[][] = [[], [], []];
+    let pass = 0;
+    const { deps } = makeDeps({
+      getKCCount: async () => 6,
+      maxOrdinalsPerPass: 2,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => {
+        attempts[pass]!.push(ordinal);
+        if (ordinal === 0) return { status: 'pending' };
+        return { status: 'reconciled', blockNumber: 0 };
+      },
+    });
+    const state = createCursorState(0);
+
+    await reconcileContextGraph(deps, state, 'cg', 1n);
+    pass += 1;
+    await reconcileContextGraph(deps, state, 'cg', 1n);
+    pass += 1;
+    const result = await reconcileContextGraph(deps, state, 'cg', 1n);
+
+    expect(attempts).toEqual([[0, 1], [2, 3], [4, 5]]);
+    expect(result.watermark).toBe(0);
+    expect(result.pending).toBe(1);
+    expect(result.hasMore).toBe(false);
+    expect(state.ahead.size).toBe(5);
+  });
+
+  it('stops a slice when its captured context-graph binding becomes stale', async () => {
+    let current = true;
+    const { deps, attempted } = makeDeps({
+      getKCCount: async () => 5,
+      maxOrdinalsPerPass: 5,
+      isTargetCurrent: async () => current,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => {
+        attempted.push(ordinal);
+        current = false;
+        return { status: 'reconciled', blockNumber: 0 };
+      },
+    });
+    const state = createCursorState(0);
+
+    const result = await reconcileContextGraph(deps, state, 'cg', 66n);
+
+    expect(attempted).toEqual([0]);
+    expect(result).toMatchObject({
+      processed: 1,
+      reconciled: 0,
+      staleTarget: true,
+      hasMore: false,
+    });
+    expect(state.watermark).toBe(0);
+    expect(state.scanOrdinal).toBe(0);
+  });
 });
 
 describe('VmReconcileDispatcher scheduling', () => {
+  it('places a self-scheduled next slice behind context graphs already waiting', async () => {
+    const observed: string[] = [];
+    let scheduler!: VmReconcileDispatcher<void>;
+    scheduler = new VmReconcileDispatcher(
+      async (key) => {
+        observed.push(key);
+        if (key === 'large-cg' && observed.filter((seen) => seen === key).length === 1) {
+          scheduler.triggerLive(key);
+        }
+      },
+      () => undefined,
+    );
+
+    scheduler.triggerLive('large-cg');
+    scheduler.triggerLive('waiting-cg');
+    await scheduler.waitForIdle();
+
+    expect(observed).toEqual(['large-cg', 'waiting-cg', 'large-cg']);
+  });
+
   it('passes the trigger source to the scheduled run', async () => {
     const observed: string[] = [];
     const scheduler = new VmReconcileDispatcher(

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -226,6 +226,39 @@ describe('reconcileContextGraph — sweep', () => {
     expect(result).toMatchObject({ processed: 10, reconciled: 10, watermark: 10 });
   });
 
+  it('batch-recovers only locally-missing ordinals and reuses their outcomes', async () => {
+    const recoveryCalls: number[][] = [];
+    const { deps } = makeDeps({
+      getKCCount: async () => 3,
+      maxOrdinalsPerPass: 10,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => {
+        if (ordinal === 0) return { status: 'already', blockNumber: 100 };
+        return {
+          status: 'pending',
+          recovery: {
+            ordinal,
+            ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
+            kaId: String(ordinal),
+            reason: 'no-swm',
+          },
+        };
+      },
+      recoverPendingOrdinals: async (_cg, _onchain, targets) => {
+        recoveryCalls.push(targets.map((target) => target.ordinal));
+        return new Map(targets.map((target) => [
+          target.ordinal,
+          { status: 'reconciled', blockNumber: 100 } as OrdinalOutcome,
+        ]));
+      },
+    });
+    const state = createCursorState(0);
+
+    const result = await reconcileContextGraph(deps, state, 'cg', 1n);
+
+    expect(recoveryCalls).toEqual([[1, 2]]);
+    expect(result).toMatchObject({ processed: 3, reconciled: 3, watermark: 3 });
+  });
+
   it('keeps scanning later slices when an early ordinal remains pending', async () => {
     const attempts: number[][] = [[], [], []];
     let pass = 0;

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -203,6 +203,29 @@ describe('reconcileContextGraph — sweep', () => {
     expect(state.scanOrdinal).toBe(0);
   });
 
+  it('runs each bounded slice with capped ordinal concurrency', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const { deps } = makeDeps({
+      getKCCount: async () => 10,
+      maxOrdinalsPerPass: 10,
+      maxOrdinalConcurrency: 3,
+      reconcileOrdinal: async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        active -= 1;
+        return { status: 'reconciled', blockNumber: 0 };
+      },
+    });
+    const state = createCursorState(0);
+
+    const result = await reconcileContextGraph(deps, state, 'cg', 1n);
+
+    expect(maxActive).toBe(3);
+    expect(result).toMatchObject({ processed: 10, reconciled: 10, watermark: 10 });
+  });
+
   it('keeps scanning later slices when an early ordinal remains pending', async () => {
     const attempts: number[][] = [[], [], []];
     let pass = 0;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2233,6 +2233,57 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(fetchCount).toBe(2);
   });
 
+  it('never sends an exact request to a peer the network-admission boundary rejects', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmAdmissionGate', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const rejectedPeer = '12D3KooWExactRejectedPeer';
+    const admittedPeer = '12D3KooWExactAdmittedPeer';
+    const localCgId = '0x0000000000000000000000000000000000000001/exact-admission';
+    const connected = [rejectedPeer, admittedPeer].map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWExactAdmissionLocalPeer',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    // The curator hint points at the peer the admission boundary rejects — a
+    // hint must never bypass the identity gate.
+    (internals as any).preferredSyncPeers.set(localCgId, rejectedPeer);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [rejectedPeer], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).networkAdmissionCoordinator = {
+      isAcceptedPeer: (peerId: string) => peerId === admittedPeer,
+      isRejectedPeer: (peerId: string) => peerId === rejectedPeer,
+      ensureAdmitted: async () => false,
+    };
+    const fetches: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeer = async (peerId: string) => {
+      fetches.push(peerId);
+      return {
+        fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+        failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+      };
+    };
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled',
+      blockNumber: 100,
+    });
+    const target = {
+      ordinal: 0,
+      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
+      kaId: '7',
+      reason: 'no-swm' as const,
+    };
+
+    const result = await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+
+    expect(fetches).toEqual([admittedPeer]);
+    expect(result.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+  });
+
   it('reports a durable watermark ahead of the chain head without ordinal work', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'CoreFillWatermarkAhead', chainAdapter: chain });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -57,7 +57,17 @@ interface AgentInternals {
   createContextGraph(opts: { id: string; name: string; description?: string; private?: boolean; callerAgentAddress?: string }): Promise<void>;
   registerContextGraph(id: string, opts?: { callerAgentAddress?: string }): Promise<{ onChainId: string; txHash?: string }>;
   recordCoreHostedPublicCg(cgId: string, swmGraphId?: string): Promise<void>;
-  reconcileChainOrdinal(localCgId: string, onChainCgId: bigint, ordinal: number, headBlock: number | undefined): Promise<{ status: string }>;
+  reconcileChainOrdinal(
+    localCgId: string,
+    onChainCgId: bigint,
+    ordinal: number,
+    headBlock: number | undefined,
+    options?: {
+      acquireActiveFetchPermit?: () => boolean;
+      maxPeerAttempts?: number;
+      isTargetCurrent?: () => boolean;
+    },
+  ): Promise<{ status: string }>;
   syncContextGraphFromConnectedPeers(contextGraphId: string, options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string }): Promise<unknown>;
   runVmReconcileForCg(localCgId: string, source?: 'live' | 'periodic' | 'manual'): Promise<{
     status: string;
@@ -1897,6 +1907,46 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       watermarkAfter: 2,
     });
     expect(reconcileOrdinal.calls).toEqual([]);
+  });
+
+  it('shares one active payload-fetch permit across a bounded ordinal batch', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillBatchFetchBudget', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'batch-fetch-budget';
+    internals.subscribedContextGraphs.set(localCgId, {
+      subscribed: false,
+      coreHosted: true,
+      onChainId: '324',
+      lastReconciledOrdinal: 0,
+    });
+    chain.getContextGraphKCCount = async () => 3n;
+
+    const permits: boolean[] = [];
+    const peerAttemptCaps: Array<number | undefined> = [];
+    (internals as any).reconcileChainOrdinal = async (
+      _lcg: string,
+      _ocg: bigint,
+      _ordinal: number,
+      _headBlock: number | undefined,
+      options: {
+        acquireActiveFetchPermit?: () => boolean;
+        maxPeerAttempts?: number;
+        isTargetCurrent?: () => boolean;
+      },
+    ) => {
+      permits.push(options.acquireActiveFetchPermit?.() ?? true);
+      peerAttemptCaps.push(options.maxPeerAttempts);
+      expect(options.isTargetCurrent?.()).toBe(true);
+      return { status: 'reconciled', blockNumber: 0 };
+    };
+
+    const result = await internals.runVmReconcileForCg(localCgId, 'manual');
+
+    expect(result.watermarkAfter).toBe(3);
+    expect(permits).toEqual([true, false, false]);
+    expect(peerAttemptCaps).toEqual([1, 1, 1]);
   });
 
   it('reports a durable watermark ahead of the chain head without ordinal work', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -66,8 +66,21 @@ interface AgentInternals {
       acquireActiveFetchPermit?: () => boolean;
       maxPeerAttempts?: number;
       isTargetCurrent?: () => boolean;
+      deferActiveFetch?: boolean;
     },
   ): Promise<{ status: string }>;
+  recoverVmReconcileBatch(
+    localCgId: string,
+    onChainCgId: bigint,
+    targets: readonly Array<{
+      ordinal: number;
+      ual: string;
+      kaId: string;
+      reason: 'no-swm' | 'verified-vm-metadata-pending';
+    }>,
+    headBlock: number | undefined,
+    isTargetCurrent: () => boolean,
+  ): Promise<ReadonlyMap<number, { status: 'reconciled'; blockNumber: number }>>;
   syncContextGraphFromConnectedPeers(contextGraphId: string, options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string }): Promise<unknown>;
   runVmReconcileForCg(localCgId: string, source?: 'live' | 'periodic' | 'manual'): Promise<{
     status: string;
@@ -1936,7 +1949,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(reconcileOrdinal.calls).toEqual([]);
   });
 
-  it('shares one active payload-fetch permit across a bounded ordinal batch', async () => {
+  it('defers payload fetch during the parallel scan and recovers only missing ordinals as one batch', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'CoreFillBatchFetchBudget', chainAdapter: chain });
     stubNode(agent);
@@ -1950,30 +1963,122 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     });
     chain.getContextGraphKCCount = async () => 3n;
 
-    const permits: boolean[] = [];
-    const peerAttemptCaps: Array<number | undefined> = [];
+    const scannedOrdinals: number[] = [];
+    const deferredFetches: boolean[] = [];
     (internals as any).reconcileChainOrdinal = async (
       _lcg: string,
       _ocg: bigint,
-      _ordinal: number,
+      ordinal: number,
       _headBlock: number | undefined,
       options: {
-        acquireActiveFetchPermit?: () => boolean;
-        maxPeerAttempts?: number;
         isTargetCurrent?: () => boolean;
+        deferActiveFetch?: boolean;
       },
     ) => {
-      permits.push(options.acquireActiveFetchPermit?.() ?? true);
-      peerAttemptCaps.push(options.maxPeerAttempts);
+      scannedOrdinals.push(ordinal);
+      deferredFetches.push(options.deferActiveFetch ?? false);
       expect(options.isTargetCurrent?.()).toBe(true);
-      return { status: 'reconciled', blockNumber: 0 };
+      if (ordinal === 0) return { status: 'already', blockNumber: 0 };
+      return {
+        status: 'pending',
+        recovery: {
+          ordinal,
+          ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
+          kaId: String(ordinal),
+          reason: 'no-swm',
+        },
+      };
+    };
+    const recoveryBatches: number[][] = [];
+    (internals as any).recoverVmReconcileBatch = async (
+      _lcg: string,
+      _ocg: bigint,
+      targets: readonly Array<{ ordinal: number }>,
+    ) => {
+      recoveryBatches.push(targets.map((target) => target.ordinal));
+      return new Map(targets.map((target) => [
+        target.ordinal,
+        { status: 'reconciled', blockNumber: 0 } as const,
+      ]));
     };
 
     const result = await internals.runVmReconcileForCg(localCgId, 'manual');
 
     expect(result.watermarkAfter).toBe(3);
-    expect(permits).toEqual([true, false, false]);
-    expect(peerAttemptCaps).toEqual([1, 1, 1]);
+    expect(scannedOrdinals).toEqual([0, 1, 2]);
+    expect(deferredFetches).toEqual([true, true, true]);
+    expect(recoveryBatches).toEqual([[1, 2]]);
+  });
+
+  it('targets the authenticated curator without running the global connection-prime walk', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmCuratorTarget', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const approvedPeer = '12D3KooWApprovedCuratorPeer';
+    const registryPeer = '12D3KooWRegistryCuratorPeer';
+    const localCgId = '0x0000000000000000000000000000000000000001/exact-target';
+    const connected = [approvedPeer, registryPeer].map((peerId) => ({
+      toString: () => peerId,
+    }));
+    (internals as any).node = {
+      peerId: '12D3KooWExactVmLocalPeer',
+      libp2p: {
+        getConnections: () => connected.map((remotePeer) => ({ remotePeer })),
+      },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, approvedPeer);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [registryPeer],
+      curatorIsLocal: false,
+      legacyTripleResolved: false,
+    });
+    (internals as any).primeCatchupConnections = async () => {
+      throw new Error('exact recovery must not walk every discovered agent');
+    };
+    const connectionAttempts: string[] = [];
+    (internals as any).ensurePeerConnected = async (peerId: string) => {
+      connectionAttempts.push(peerId);
+    };
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    const protocolPeers: Array<{ toString(): string }> = [];
+    (internals as any).waitForSyncProtocol = async (peer: { toString(): string }) => {
+      protocolPeers.push(peer);
+      return true;
+    };
+    const fetches: Array<{ peerId: string; uals: string[] }> = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeer = async (
+      peerId: string,
+      _cg: string,
+      uals: string[],
+    ) => {
+      fetches.push({ peerId, uals });
+      return {
+        fetchedDataTriples: 1,
+        fetchedMetaTriples: 8,
+        insertedTriples: 9,
+        failedPeers: 0,
+        failedPhases: 0,
+        deferredBackpressure: 0,
+      };
+    };
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled',
+      blockNumber: 100,
+    });
+    const ual = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7';
+
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId,
+      1n,
+      [{ ordinal: 0, ual, kaId: '7', reason: 'no-swm' }],
+      100,
+      () => true,
+    );
+
+    expect(connectionAttempts).toEqual([approvedPeer, registryPeer]);
+    expect(protocolPeers[0]).toBe(connected[0]);
+    expect(fetches).toEqual([{ peerId: approvedPeer, uals: [ual] }]);
+    expect(result.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
   });
 
   it('reports a durable watermark ahead of the chain head without ordinal work', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -21,6 +21,7 @@
  */
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { MockChainAdapter, buildKnowledgeAssetUal } from '@origintrail-official/dkg-chain';
+import { MAX_EXACT_SYNC_ASSETS } from '../src/sync/exact-assets.js';
 
 // Hand-rolled call recorder (replaces vitest spy factories): wraps an
 // implementation, records every argument tuple on `.calls`, and returns the
@@ -2079,6 +2080,157 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(protocolPeers[0]).toBe(connected[0]);
     expect(fetches).toEqual([{ peerId: approvedPeer, uals: [ual] }]);
     expect(result.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+  });
+
+  it('slices an over-cap recovery batch to the wire protocol limit and defers the rest', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmBatchCap', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peerA = '12D3KooWExactCapPeerA';
+    const peerB = '12D3KooWExactCapPeerB';
+    const localCgId = '0x0000000000000000000000000000000000000001/exact-cap';
+    const connected = [peerA, peerB].map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWExactCapLocalPeer',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peerA);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peerA, peerB],
+      curatorIsLocal: false,
+      legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    const fetches: Array<{ peerId: string; uals: string[] }> = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeer = async (
+      peerId: string,
+      _cg: string,
+      uals: string[],
+    ) => {
+      fetches.push({ peerId, uals });
+      return {
+        fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+        failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+      };
+    };
+    const revalidated: number[] = [];
+    (internals as any).reconcileChainOrdinal = async (
+      _lcg: string, _ocg: bigint, ordinal: number,
+    ) => {
+      revalidated.push(ordinal);
+      return { status: 'reconciled', blockNumber: 100 };
+    };
+    const targets = Array.from({ length: MAX_EXACT_SYNC_ASSETS + 2 }, (_, ordinal) => ({
+      ordinal,
+      ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
+      kaId: String(ordinal),
+      reason: 'no-swm' as const,
+    }));
+
+    const result = await internals.recoverVmReconcileBatch(localCgId, 1n, targets, 100, () => true);
+
+    // Peer 1 gets exactly the protocol cap; the deferred tail goes to peer 2.
+    expect(fetches).toHaveLength(2);
+    expect(fetches[0]!.uals).toHaveLength(MAX_EXACT_SYNC_ASSETS);
+    expect(fetches[1]!.uals).toEqual(targets.slice(MAX_EXACT_SYNC_ASSETS).map((t) => t.ual));
+    // Revalidation runs only for requested targets, in request order.
+    expect(revalidated).toEqual(targets.map((t) => t.ordinal));
+    expect(result.size).toBe(targets.length);
+  });
+
+  it('damps an unproductive exact batch with the per-CG fetch cooldown', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmBatchCooldown', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peer = '12D3KooWExactCooldownPeer';
+    const localCgId = '0x0000000000000000000000000000000000000001/exact-cooldown';
+    const connected = [{ toString: () => peer }];
+    (internals as any).node = {
+      peerId: '12D3KooWExactCooldownLocalPeer',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peer);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peer], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    let fetchCount = 0;
+    (internals as any).syncExactKnowledgeAssetsFromPeer = async () => {
+      fetchCount += 1;
+      return {
+        fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+        failedPeers: 1, failedPhases: 0, deferredBackpressure: 0,
+      };
+    };
+    const target = {
+      ordinal: 0,
+      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
+      kaId: '7',
+      reason: 'no-swm' as const,
+    };
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'pending',
+      recovery: target,
+    });
+
+    const first = await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(fetchCount).toBe(1);
+    expect(first.get(0)).toMatchObject({ status: 'pending' });
+
+    // Nothing recovered: the cooldown stamped on entry stands, so an immediate
+    // next pass performs no network fetch for this CG.
+    const second = await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(fetchCount).toBe(1);
+    expect(second.size).toBe(0);
+  });
+
+  it('clears the fetch cooldown after a productive exact batch so the next slice proceeds', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmBatchProductive', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peer = '12D3KooWExactProductivePeer';
+    const localCgId = '0x0000000000000000000000000000000000000001/exact-productive';
+    const connected = [{ toString: () => peer }];
+    (internals as any).node = {
+      peerId: '12D3KooWExactProductiveLocalPeer',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peer);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peer], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    let fetchCount = 0;
+    (internals as any).syncExactKnowledgeAssetsFromPeer = async () => {
+      fetchCount += 1;
+      return {
+        fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+        failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+      };
+    };
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled',
+      blockNumber: 100,
+    });
+    const target = {
+      ordinal: 0,
+      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
+      kaId: '7',
+      reason: 'no-swm' as const,
+    };
+
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(fetchCount).toBe(1);
+
+    // Progress cleared the cooldown: the trailing hasMore slice fetches now.
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(fetchCount).toBe(2);
   });
 
   it('reports a durable watermark ahead of the chain head without ordinal work', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -1178,6 +1178,33 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
+  it('actively fetches provenance metadata when exact VM content is metadata-pending', async () => {
+    const internals = await boot();
+    const onChainCgId = 62n;
+    const root = new Uint8Array(32);
+    root[31] = 62;
+    registerUnmatchedKC(internals.chain, 9062n, onChainCgId, bytesToHex(root));
+
+    let finalizationAttempt = 0;
+    const handleChainReconciledKC = recorder(async () => {
+      finalizationAttempt += 1;
+      return finalizationAttempt === 1
+        ? 'verified-vm-metadata-pending'
+        : 'already-confirmed';
+    });
+    (internals as any).getOrCreateFinalizationHandler = recorder(() => ({
+      handleChainReconciledKC,
+    }));
+    const fetch = recorder(async () => emptyCatchupStats());
+    (internals as any).syncContextGraphFromConnectedPeers = fetch;
+
+    await expect(internals.reconcileChainOrdinal('62', onChainCgId, 0, undefined))
+      .resolves.toEqual({ status: 'already', blockNumber: 0 });
+
+    expect(fetch.calls).toHaveLength(1);
+    expect(handleChainReconciledKC.calls).toHaveLength(2);
+  });
+
   it('retries an incomplete SWM operation when data changes without triple-count changes', async () => {
     const internals = await boot();
     const onChainCgId = 52n;

--- a/packages/agent/test/durable-sync-since-threading.test.ts
+++ b/packages/agent/test/durable-sync-since-threading.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { createOperationContext, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
-import { runDurableSync } from '../src/sync/requester/durable-sync.js';
+import {
+  filterExactAssetDurablePayload,
+  runDurableSync,
+} from '../src/sync/requester/durable-sync.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { DurableBatchVerificationMode } from '../src/sync-verify-worker.js';
@@ -12,6 +15,29 @@ interface FetchCall {
   snapshotRef: string | undefined;
   sinceBatchId: string | undefined;
 }
+
+describe('exact-asset rolling-upgrade filter', () => {
+  it('drops already-present KAs from an old responder full-CG response', () => {
+    const wanted = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7';
+    const existing = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/8';
+    const wantedGraph = 'did:dkg:context-graph:cg/_verifiable_memory/0x0000000000000000000000000000000000000001/7';
+    const existingGraph = 'did:dkg:context-graph:cg/_verifiable_memory/0x0000000000000000000000000000000000000001/8';
+    const meta = [
+      { subject: wanted, predicate: 'http://dkg.io/ontology/assertionGraph', object: wantedGraph, graph: 'did:dkg:context-graph:cg/_meta' },
+      { subject: wanted, predicate: 'http://dkg.io/ontology/kaUal', object: wanted, graph: 'did:dkg:context-graph:cg/_meta' },
+      { subject: existing, predicate: 'http://dkg.io/ontology/assertionGraph', object: existingGraph, graph: 'did:dkg:context-graph:cg/_meta' },
+    ] as Quad[];
+    const data = [
+      { subject: 'urn:wanted', predicate: 'urn:p', object: '"wanted"', graph: wantedGraph },
+      { subject: 'urn:existing', predicate: 'urn:p', object: '"existing"', graph: existingGraph },
+    ] as Quad[];
+
+    const filtered = filterExactAssetDurablePayload(data, meta, [wanted]);
+
+    expect(filtered.metaQuads.map((quad) => quad.subject)).toEqual([wanted, wanted]);
+    expect(filtered.dataQuads.map((quad) => quad.graph)).toEqual([wantedGraph]);
+  });
+});
 
 function makeContext(options: {
   sinceBatchIdFor?: (cg: string) => string | undefined;

--- a/packages/agent/test/durable-sync-since-threading.test.ts
+++ b/packages/agent/test/durable-sync-since-threading.test.ts
@@ -14,6 +14,7 @@ interface FetchCall {
   graphUri: string;
   snapshotRef: string | undefined;
   sinceBatchId: string | undefined;
+  assetUals: string[] | undefined;
 }
 
 describe('exact-asset rolling-upgrade filter', () => {
@@ -37,10 +38,54 @@ describe('exact-asset rolling-upgrade filter', () => {
     expect(filtered.metaQuads.map((quad) => quad.subject)).toEqual([wanted, wanted]);
     expect(filtered.dataQuads.map((quad) => quad.graph)).toEqual([wantedGraph]);
   });
+
+  it('threads exactAssetUalsFor into both fetch phases and filters an old-responder payload before verification', async () => {
+    const wanted = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7';
+    const extra = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/8';
+    const wantedGraph = 'did:dkg:context-graph:mfacts/_verifiable_memory/0x0000000000000000000000000000000000000001/7';
+    const extraGraph = 'did:dkg:context-graph:mfacts/_verifiable_memory/0x0000000000000000000000000000000000000001/8';
+    const metaGraph = 'did:dkg:context-graph:mfacts/_meta';
+    // An OLD responder ignores the filter and returns the whole CG: both KAs.
+    const meta = [
+      { subject: wanted, predicate: 'http://dkg.io/ontology/assertionGraph', object: wantedGraph, graph: metaGraph },
+      { subject: wanted, predicate: 'http://dkg.io/ontology/kaUal', object: wanted, graph: metaGraph },
+      { subject: extra, predicate: 'http://dkg.io/ontology/assertionGraph', object: extraGraph, graph: metaGraph },
+      { subject: extra, predicate: 'http://dkg.io/ontology/kaUal', object: extra, graph: metaGraph },
+    ] as Quad[];
+    const data = [
+      { subject: 'urn:wanted', predicate: 'urn:p', object: '"wanted"', graph: wantedGraph },
+      { subject: 'urn:extra', predicate: 'urn:p', object: '"extra"', graph: extraGraph },
+    ] as Quad[];
+    const { calls, context, processCalls } = makeContext({
+      exactAssetUalsFor: () => [wanted],
+      pageQuads: { data, meta },
+    });
+
+    await runDurableSync(context);
+
+    // Both phases must carry the exact filter on the wire…
+    const metaCall = calls.find((c) => c.phase === 'meta')!;
+    const dataCall = calls.find((c) => c.phase === 'data')!;
+    expect(metaCall.assetUals).toEqual([wanted]);
+    expect(dataCall.assetUals).toEqual([wanted]);
+    // …and the worker must only ever see the requested KA's quads, even though
+    // the (old) responder returned the extra KA too.
+    expect(processCalls).toHaveLength(1);
+    expect(processCalls[0]!.metaCount).toBe(2);
+    expect(processCalls[0]!.dataCount).toBe(1);
+  });
+
+  it('does not thread a filter when exactAssetUalsFor is not wired', async () => {
+    const { calls, context } = makeContext();
+    await runDurableSync(context);
+    expect(calls.every((c) => c.assetUals === undefined)).toBe(true);
+  });
 });
 
 function makeContext(options: {
   sinceBatchIdFor?: (cg: string) => string | undefined;
+  exactAssetUalsFor?: (cg: string) => string[] | undefined;
+  pageQuads?: { data: Quad[]; meta: Quad[] };
   contextGraphIds?: string[];
   syncAgentsMeta?: boolean;
   processResult?: {
@@ -60,7 +105,9 @@ function makeContext(options: {
   const insertedBatches: Quad[][] = [];
   const deletedCheckpoints: string[] = [];
   const page = (phase: 'data' | 'meta'): SyncPageResult => ({
-    quads: phase === 'data' ? ([{ id: 'data' }] as never[]) : ([{ id: 'meta' }] as never[]),
+    quads: options.pageQuads
+      ? (options.pageQuads[phase] as never[])
+      : phase === 'data' ? ([{ id: 'data' }] as never[]) : ([{ id: 'meta' }] as never[]),
     bytesReceived: phase === 'data' ? 20 : 10,
     resumedFromOffset: 0,
     nextOffset: phase === 'data' ? 1 : 2,
@@ -91,11 +138,13 @@ function makeContext(options: {
         _deadline: number,
         snapshotRef?: string,
         sinceBatchId?: string,
+        assetUals?: string[],
       ) => {
-        calls.push({ contextGraphId, phase, graphUri, snapshotRef, sinceBatchId });
+        calls.push({ contextGraphId, phase, graphUri, snapshotRef, sinceBatchId, assetUals });
         return page(phase);
       },
       sinceBatchIdFor: options.sinceBatchIdFor,
+      exactAssetUalsFor: options.exactAssetUalsFor,
       processDurableBatchInWorker: async (
         dataQuads: Quad[],
         metaQuads: Quad[],

--- a/packages/agent/test/exact-asset-responder.test.ts
+++ b/packages/agent/test/exact-asset-responder.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  contextGraphDataGraphUri,
+  contextGraphMetaGraphUri,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  readDurableDataPage,
+  readDurableMetaPage,
+} from '../src/sync/responder/graph-plan.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const CG_ID = 'exact-asset-responder';
+const AUTHOR = '0x00000000000000000000000000000000000000ab';
+const integer = (value: number) =>
+  `"${value}"^^<http://www.w3.org/2001/XMLSchema#integer>`;
+
+function asset(index: number): { ual: string; graph: string; quads: Quad[] } {
+  const ual = `did:dkg:base:84532/${AUTHOR}/${index}`;
+  const graph = knowledgeAssetLayerGraphUri(
+    CG_ID,
+    MemoryLayer.VerifiableMemory,
+    createGraphKnowledgeAssetScope(ual, 1),
+  );
+  const meta = contextGraphMetaGraphUri(CG_ID);
+  return {
+    ual,
+    graph,
+    quads: [
+      { graph: meta, subject: ual, predicate: `${DKG}contentScopeVersion`, object: integer(GRAPH_KA_CONTENT_SCOPE_VERSION) },
+      { graph: meta, subject: ual, predicate: `${DKG}kaUal`, object: ual },
+      { graph: meta, subject: ual, predicate: `${DKG}assertionVersion`, object: integer(1) },
+      { graph: meta, subject: ual, predicate: `${DKG}assertionGraph`, object: graph },
+      { graph: meta, subject: ual, predicate: `${DKG}contextGraph`, object: contextGraphDataGraphUri(CG_ID) },
+      { graph: meta, subject: ual, predicate: `${DKG}publicTripleCount`, object: integer(1) },
+      { graph: meta, subject: ual, predicate: `${DKG}privateTripleCount`, object: integer(0) },
+      { graph: meta, subject: ual, predicate: `${DKG}status`, object: '"confirmed"' },
+      { graph, subject: `urn:entity:${index}`, predicate: 'http://schema.org/name', object: `"asset-${index}"` },
+    ],
+  };
+}
+
+describe('exact asset responder', () => {
+  it('serves only the requested confirmed descriptor and immutable data graph', async () => {
+    const store = new OxigraphStore();
+    const requested = asset(1);
+    const alreadyPresent = asset(2);
+    await store.insert([...requested.quads, ...alreadyPresent.quads]);
+
+    const meta = await readDurableMetaPage({
+      store,
+      contextGraphId: CG_ID,
+      registeredSubGraphNames: [],
+      offset: 0,
+      limit: 100,
+      assetUals: [requested.ual],
+    });
+    const data = await readDurableDataPage({
+      store,
+      graphList: [requested.graph, alreadyPresent.graph],
+      contextGraphId: CG_ID,
+      sinceBatchId: null,
+      offset: 0,
+      limit: 100,
+      assetUals: [requested.ual],
+    });
+
+    expect(new Set(meta.map((row) => row.s))).toEqual(new Set([requested.ual]));
+    expect(meta).toHaveLength(8);
+    expect(data).toEqual([{
+      g: requested.graph,
+      s: 'urn:entity:1',
+      p: 'http://schema.org/name',
+      o: '"asset-1"',
+    }]);
+  });
+});

--- a/packages/agent/test/exact-asset-wire-parse.test.ts
+++ b/packages/agent/test/exact-asset-wire-parse.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+import { encodeExactAssetUals, MAX_EXACT_SYNC_ASSETS } from '../src/sync/exact-assets.js';
+
+// #1871 — the exact-KA filter is only as safe as the production wire parsing
+// that feeds registerSyncHandler. These tests pin ContextGraphResolveMethods.
+// parseSyncRequest end to end for both wire formats: valid filters survive
+// normalization, present-but-invalid filters fail closed to [] (responder
+// serves nothing), and absent filters stay undefined (full sync).
+const UAL_7 = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7';
+const UAL_8 = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/8';
+
+const encode = (value: unknown): Uint8Array =>
+  new TextEncoder().encode(typeof value === 'string' ? value : JSON.stringify(value));
+
+describe('exact-asset wire parsing (parseSyncRequest)', () => {
+  let agentPromise: Promise<DKGAgent> | undefined;
+  const getAgent = async (): Promise<DKGAgent> => {
+    agentPromise ??= DKGAgent.create({ name: 'ExactAssetWireParse', chainAdapter: new MockChainAdapter() });
+    return agentPromise;
+  };
+  afterAll(async () => {
+    await (await getAgent()).stop().catch(() => {});
+  });
+
+  const parse = async (value: unknown) =>
+    (await getAgent() as any).parseSyncRequest(encode(value));
+
+  it('preserves a valid assetUals filter from a JSON envelope', async () => {
+    const parsed = await parse({ contextGraphId: 'cg', phase: 'data', assetUals: [UAL_7, UAL_8] });
+    expect(parsed.assetUals).toEqual([UAL_7, UAL_8]);
+  });
+
+  it('fail-closes present-but-invalid JSON filters to an empty filter, never undefined', async () => {
+    for (const bad of [
+      ['not-a-ual'],
+      [UAL_7, 'not-a-ual'],
+      [],
+      'not-an-array',
+      Array.from({ length: MAX_EXACT_SYNC_ASSETS + 1 }, (_, i) =>
+        `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${i}`),
+    ]) {
+      const parsed = await parse({ contextGraphId: 'cg', phase: 'data', assetUals: bad });
+      expect(parsed.assetUals, JSON.stringify(bad)).toEqual([]);
+    }
+  });
+
+  it('leaves assetUals undefined when a JSON envelope omits it', async () => {
+    const parsed = await parse({ contextGraphId: 'cg', phase: 'data' });
+    expect(parsed.assetUals).toBeUndefined();
+  });
+
+  it('parses the |assets| tail token after legacy session/since tokens', async () => {
+    const parsed = await parse(
+      `mfacts|0|100|data|session|s-1|since|42|assets|${encodeExactAssetUals([UAL_7])}`,
+    );
+    expect(parsed.contextGraphId).toBe('mfacts');
+    expect(parsed.syncSessionId).toBe('s-1');
+    expect(parsed.sinceBatchId).toBe('42');
+    expect(parsed.assetUals).toEqual([UAL_7]);
+  });
+
+  it('parses the |assets| token without session/since tokens', async () => {
+    const parsed = await parse(`mfacts|0|100|data|assets|${encodeExactAssetUals([UAL_7, UAL_8])}`);
+    expect(parsed.assetUals).toEqual([UAL_7, UAL_8]);
+    expect(parsed.sinceBatchId).toBeUndefined();
+    expect(parsed.syncSessionId).toBeUndefined();
+  });
+
+  it('fail-closes a malformed pipe assets token to an empty filter', async () => {
+    for (const badToken of ['%%%not-json', encodeURIComponent(JSON.stringify(['not-a-ual']))]) {
+      const parsed = await parse(`mfacts|0|100|data|assets|${badToken}`);
+      expect(parsed.assetUals, badToken).toEqual([]);
+    }
+  });
+
+  it('leaves assetUals undefined for a legacy pipe request without the token', async () => {
+    const parsed = await parse('mfacts|0|100|data|session|s-1|since|42');
+    expect(parsed.assetUals).toBeUndefined();
+    expect(parsed.sinceBatchId).toBe('42');
+  });
+});

--- a/packages/agent/test/exact-assets.test.ts
+++ b/packages/agent/test/exact-assets.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_EXACT_SYNC_ASSETS,
+  decodeExactAssetUals,
+  encodeExactAssetUals,
+  normalizeExactAssetUals,
+} from '../src/sync/exact-assets.js';
+
+const ual = (number: number) =>
+  `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${number}`;
+
+describe('exact VM sync asset filter', () => {
+  it('canonicalizes, deduplicates, and round-trips a bounded KA batch', () => {
+    const normalized = normalizeExactAssetUals([ual(1), ual(1), ual(2)]);
+    expect(normalized).toEqual([ual(1), ual(2)]);
+    expect(decodeExactAssetUals(encodeExactAssetUals(normalized!))).toEqual(normalized);
+  });
+
+  it('fails closed for malformed or oversized present filters', () => {
+    expect(normalizeExactAssetUals(['not-a-ual'])).toEqual([]);
+    expect(normalizeExactAssetUals(Array.from(
+      { length: MAX_EXACT_SYNC_ASSETS + 1 },
+      (_, index) => ual(index),
+    ))).toEqual([]);
+  });
+});

--- a/packages/agent/test/sync-checkpoint-key.test.ts
+++ b/packages/agent/test/sync-checkpoint-key.test.ts
@@ -33,6 +33,20 @@ describe('getSyncCheckpointKey', () => {
     expect(delta7).not.toBe(delta9);
   });
 
+  it('isolates exact VM batches from full sync and from each other', () => {
+    const full = getSyncCheckpointKey('peerA', 'mfacts', false, 'data');
+    const exactA = getSyncCheckpointKey(
+      'peerA', 'mfacts', false, 'data', undefined, undefined, undefined, 'exact:a',
+    );
+    const exactB = getSyncCheckpointKey(
+      'peerA', 'mfacts', false, 'data', undefined, undefined, undefined, 'exact:b',
+    );
+
+    expect(exactA).not.toBe(full);
+    expect(exactB).not.toBe(full);
+    expect(exactA).not.toBe(exactB);
+  });
+
   // R10 — member SWM recovery must get its OWN cursor namespace so it never
   // overwrites or deletes the shared incremental-sync cursor.
   it('scopes the key with a |recovery segment distinct from the normal SWM key', () => {

--- a/packages/agent/test/sync-envelope-cursor.test.ts
+++ b/packages/agent/test/sync-envelope-cursor.test.ts
@@ -36,6 +36,8 @@ const baseParams = (sinceBatchId?: string, syncSessionId?: string) => {
   };
 };
 
+const EXACT_UAL = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7';
+
 describe('Phase C sync envelope — sinceBatchId is unsigned', () => {
   it('does not feed sinceBatchId or syncSessionId into the signed digest', async () => {
     const without = baseParams(undefined);
@@ -81,6 +83,16 @@ describe('Phase C sync envelope — sinceBatchId is unsigned', () => {
     expect(parsed.requesterSignatureR).toBeTruthy();
   });
 
+  it('carries an exact-KA filter outside the authenticated digest', async () => {
+    const { params, digestCalls } = baseParams(undefined);
+    const bytes = await buildSyncRequestEnvelope({ ...params, assetUals: [EXACT_UAL] });
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as SyncRequestEnvelope;
+
+    expect(parsed.assetUals).toEqual([EXACT_UAL]);
+    expect(digestCalls).toHaveLength(1);
+    expect(digestCalls[0]).not.toContain(EXACT_UAL);
+  });
+
   it('omits sinceBatchId from the envelope when unset (no key leakage)', async () => {
     const { params } = baseParams(undefined);
     const bytes = await buildSyncRequestEnvelope(params);
@@ -117,6 +129,18 @@ describe('Phase C sync envelope — sinceBatchId is unsigned', () => {
     const bytes = await buildSyncRequestEnvelope({ ...params, needsAuth: false });
     const text = new TextDecoder().decode(bytes);
     expect(text).toBe('mfacts|0|100|session|session-1|since|42');
+  });
+
+  it('appends the exact-KA token after legacy session/delta tokens', async () => {
+    const { params } = baseParams('42', 'session-1');
+    const bytes = await buildSyncRequestEnvelope({
+      ...params,
+      needsAuth: false,
+      assetUals: [EXACT_UAL],
+    });
+    const text = new TextDecoder().decode(bytes);
+    expect(text).toContain('mfacts|0|100|session|session-1|since|42|assets|');
+    expect(decodeURIComponent(text.split('|assets|')[1]!)).toBe(JSON.stringify([EXACT_UAL]));
   });
 
   it('omits the pipe |since| token when the hint is unset', async () => {

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -21,7 +21,11 @@ type FetchArgs = {
   sinceBatchId?: string;
   signal?: AbortSignal;
   recovery?: boolean;
+  assetUals?: string[];
 };
+
+const EXACT_UAL_7 = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7';
+const EXACT_UAL_8 = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/8';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -133,6 +137,8 @@ function fetchPages(agent: DKGAgent, args: FetchArgs = {}): Promise<SyncPageResu
     args.sinceBatchId,
     args.signal,
     args.recovery,
+    undefined,
+    args.assetUals,
   );
 }
 
@@ -175,6 +181,10 @@ describe('DKGAgent sync fetch coalescing', () => {
       },
       { name: 'sinceBatchId', base: { sinceBatchId: '10' }, variant: { sinceBatchId: '11' } },
       { name: 'recovery', base: { includeSharedMemory: true, recovery: false }, variant: { includeSharedMemory: true, recovery: true } },
+      // Exact VM batches: different asset filters must never share a page
+      // sequence, and an exact batch must never join a full sync.
+      { name: 'assetUals', base: { assetUals: [EXACT_UAL_7] }, variant: { assetUals: [EXACT_UAL_8] } },
+      { name: 'assetUals-vs-full', base: {}, variant: { assetUals: [EXACT_UAL_7] } },
     ];
 
     for (const testCase of cases) {
@@ -356,6 +366,44 @@ describe('DKGAgent sync fetch coalescing', () => {
       const third = (agent as any).syncFromPeerDetailed(PEER_A, ['coalesced-cg']);
       await expect(third).resolves.toMatchObject({ failedPeers: 0 });
       expect(fetchCalls).toBe(4);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not single-flight exact VM syncs with different asset batches', async () => {
+    let fetchCalls = 0;
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    (agent as any).fetchSyncPages = async (...args: unknown[]) => {
+      fetchCalls++;
+      return emptySyncPage(String(args[4]));
+    };
+    (agent as any).processDurableBatchInWorker = async () => ({
+      verifiedData: [],
+      verifiedMeta: [],
+      totalFetchedDataQuads: 0,
+      totalFetchedMetaQuads: 0,
+      rejectedKcs: 0,
+      emptyResponses: 1,
+      metaOnlyResponses: 0,
+      dataRejectedMissingMeta: 0,
+    });
+
+    try {
+      // Different exact batches: two separate runs (2 phases each).
+      const first = (agent as any).syncExactKnowledgeAssetsFromPeer(PEER_A, 'coalesced-cg', [EXACT_UAL_7]);
+      const second = (agent as any).syncExactKnowledgeAssetsFromPeer(PEER_A, 'coalesced-cg', [EXACT_UAL_8]);
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+      expect(firstResult).not.toBe(secondResult);
+      expect(fetchCalls).toBe(4);
+
+      // The identical exact batch single-flights onto one run.
+      fetchCalls = 0;
+      const third = (agent as any).syncExactKnowledgeAssetsFromPeer(PEER_A, 'coalesced-cg', [EXACT_UAL_7]);
+      const fourth = (agent as any).syncExactKnowledgeAssetsFromPeer(PEER_A, 'coalesced-cg', [EXACT_UAL_7]);
+      const [thirdResult, fourthResult] = await Promise.all([third, fourth]);
+      expect(thirdResult).toBe(fourthResult);
+      expect(fetchCalls).toBe(2);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       "test/sync-envelope-cursor.test.ts",
       "test/exact-assets.test.ts",
       "test/exact-asset-responder.test.ts",
+      "test/exact-asset-wire-parse.test.ts",
       "test/swm/host-catchup-sign.test.ts",
       "test/swm/host-catchup-wire.test.ts",
       "test/swm/host-mode-store.test.ts",

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
       "test/promote-async-default-agent.test.ts",
       "test/query-min-trust-alias.test.ts",
       "test/sync-envelope-cursor.test.ts",
+      "test/exact-assets.test.ts",
+      "test/exact-asset-responder.test.ts",
       "test/swm/host-catchup-sign.test.ts",
       "test/swm/host-catchup-wire.test.ts",
       "test/swm/host-mode-store.test.ts",


### PR DESCRIPTION
## Summary

- scan up to 10 on-chain registration ordinals in parallel and build one recovery batch from only the KAs that are not locally complete
- request those exact UALs through the authenticated sync protocol instead of refreshing the whole context graph
- revalidate every requested KA against its on-chain root after each peer response and narrow any fallback request to the still-missing remainder
- prioritize exact VM recovery over generic background sync and contact the authenticated/structural curator without walking every discovered agent first
- serve only the requested confirmed KA descriptors and immutable data graphs when the remote node also runs this code
- keep rolling-upgrade safety: if an older responder ignores the filter and returns the whole CG, filter it to the requested UALs before verification or storage

## Safety invariant

Already-complete KAs never enter the exact request. Exact filters have isolated checkpoint, session, and singleflight keys. Malformed filters fail closed, and all returned data still passes the existing authorization and Merkle verification path.

## Why

VM reconciliation previously waited on SWM-oriented recovery and could refresh a whole CG once per ordinal. It also primed connections by dialing every discovered agent. A CG with an on-chain VM gap could therefore make little visible progress despite the missing UALs being known.

## Configuration

- `DKG_VM_RECONCILE_BATCH_SIZE` (default 10)
- `DKG_VM_RECONCILE_ORDINAL_CONCURRENCY` (default 5)
- `DKG_VM_RECONCILE_CONCURRENCY` (default 2)

## Validation

- full monorepo `pnpm build`
- agent unit suite: 94 files, 1,194 tests passed
- live testnet member: ordinals 10-19 produced `exact-batch:9`; ordinal 15 was already complete and was excluded
- live request targeted curator `12D3KooWENez...9cxFnZh9` and displaced a generic background sync after about four seconds
- upgraded-responder integration test proves a one-UAL request returns only that KA descriptor and data graph

## Rolling upgrade note

The requester-side correctness and store filter work immediately. The network-size and latency improvement requires the serving curator/host to run this PR; an older responder can still do an expensive whole-CG read before the requester narrows its response.
