### PR TITLE
fix(ui): prevent large context graph query storms

### DIFF
--- a/packages/cli/src/daemon/context-graph-read-model.ts
+++ b/packages/cli/src/daemon/context-graph-read-model.ts
@@ -1,0 +1,286 @@
+import {
+  assertSafeIri,
+} from '@origintrail-official/dkg-core';
+import type {
+  QueryOptions,
+  TripleStore,
+} from '@origintrail-official/dkg-storage';
+
+export type MemoryLayerKey = 'wm' | 'swm' | 'vm';
+
+export interface MemoryLayerBinding {
+  s: string;
+  p: string;
+  o: string;
+  g: string;
+}
+
+export interface MemoryLayerReadResult {
+  bindings: MemoryLayerBinding[];
+  ok: boolean;
+  truncated: boolean;
+}
+
+export interface MemoryLayersSnapshot {
+  layers: Record<MemoryLayerKey, MemoryLayerReadResult>;
+}
+
+export interface ContextGraphNamedGraphStats {
+  graph: string;
+  entityCount: number;
+  tripleCount: number;
+}
+
+export const MEMORY_LAYER_LIMITS: Record<MemoryLayerKey, number> = {
+  wm: 50_000,
+  swm: 20_000,
+  vm: 20_000,
+};
+
+// Keep each query-plan branch set deliberately small. Large VALUES lists bound
+// to GRAPH variables make Oxigraph choose a CartesianProductJoinIterator and
+// were the source of the multi-core query storm fixed by this module.
+export const EXACT_GRAPH_QUERY_BATCH_SIZE = 8;
+
+const LAYER_KEYS: readonly MemoryLayerKey[] = ['wm', 'swm', 'vm'];
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
+  }
+}
+
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
+function isScopedGraph(graph: string, root: string): boolean {
+  return graph === root || graph.startsWith(`${root}/`);
+}
+
+/**
+ * Classify one concrete named graph using the same layer rules previously
+ * embedded in useMemoryEntities' three GRAPH-variable SPARQL queries.
+ */
+export function classifyMemoryGraph(
+  graph: string,
+  contextGraphId: string,
+): MemoryLayerKey | undefined {
+  const root = `did:dkg:context-graph:${contextGraphId}`;
+  if (!isScopedGraph(graph, root)) return undefined;
+
+  const isMeta = graph === `${root}/meta` || graph.includes('/meta/');
+  if (
+    graph.startsWith(`${root}/`)
+    && (graph.includes('/assertion/') || graph.includes('/_working_memory/'))
+    && !isMeta
+    && !graph.endsWith('/_meta')
+  ) {
+    return 'wm';
+  }
+
+  if (
+    (graph.endsWith('/_shared_memory') || graph.includes('/_shared_memory/'))
+    && graph !== `${root}/meta/_shared_memory`
+    && !isMeta
+    && !graph.includes('/_shared_memory/staging/')
+  ) {
+    return 'swm';
+  }
+
+  if (
+    !graph.includes('/assertion/')
+    && !graph.includes('/_working_memory')
+    && !graph.includes('/_shared_memory')
+    && !graph.includes('_verifiable_memory_meta')
+    && !graph.endsWith('/_meta')
+    && !isMeta
+    && !graph.includes('/_private')
+    && !graph.includes('/_rules')
+  ) {
+    return 'vm';
+  }
+
+  return undefined;
+}
+
+async function listContextGraphNamedGraphs(
+  store: TripleStore,
+  contextGraphId: string,
+  options?: QueryOptions,
+): Promise<string[]> {
+  const root = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
+  const graphs = store.listGraphsByPrefix
+    ? await store.listGraphsByPrefix(root, options)
+    : await store.listGraphs(options);
+  return graphs
+    .filter((graph) => isScopedGraph(graph, root))
+    .map((graph) => assertSafeIri(graph))
+    .sort();
+}
+
+function exactGraphUnion(graphs: readonly string[]): string {
+  return graphs
+    .map((graph) =>
+      `{ GRAPH <${graph}> { ?s ?p ?o } BIND(<${graph}> AS ?g) }`)
+    .join('\nUNION\n');
+}
+
+function buildLayerQuery(
+  graphs: readonly string[],
+  limit: number,
+  layer: MemoryLayerKey,
+): string {
+  const predicateFilter = layer === 'swm'
+    ? '\nFILTER(?p != <http://dkg.io/ontology/workspaceOwner>)'
+    : '';
+  return `SELECT ?s ?p ?o ?g WHERE {
+${exactGraphUnion(graphs)}${predicateFilter}
+}
+LIMIT ${limit}`;
+}
+
+function buildStatsQuery(graphs: readonly string[]): string {
+  return `SELECT ?g (COUNT(DISTINCT ?s) AS ?entities) (COUNT(*) AS ?triples)
+WHERE {
+${exactGraphUnion(graphs)}
+}
+GROUP BY ?g`;
+}
+
+function parseCount(value: unknown): number {
+  const raw = typeof value === 'string'
+    ? value
+    : value && typeof value === 'object' && 'value' in value
+      ? String((value as { value?: unknown }).value ?? '')
+      : '';
+  const match = raw.match(/^"?(\d+)/);
+  return match ? Number(match[1]) : 0;
+}
+
+async function readLayer(
+  store: TripleStore,
+  graphs: readonly string[],
+  limit: number,
+  layer: MemoryLayerKey,
+  options: QueryOptions,
+): Promise<MemoryLayerReadResult> {
+  const bindings: MemoryLayerBinding[] = [];
+
+  for (let offset = 0; offset < graphs.length; offset += EXACT_GRAPH_QUERY_BATCH_SIZE) {
+    throwIfAborted(options.signal);
+    const batch = graphs.slice(offset, offset + EXACT_GRAPH_QUERY_BATCH_SIZE);
+    const remaining = limit - bindings.length;
+    const result = await store.query(
+      buildLayerQuery(batch, remaining + 1, layer),
+      options,
+    );
+    if (result.type !== 'bindings') {
+      throw new Error('Memory-layer read expected SELECT bindings');
+    }
+
+    for (const row of result.bindings) {
+      if (
+        typeof row.s !== 'string'
+        || typeof row.p !== 'string'
+        || typeof row.o !== 'string'
+        || typeof row.g !== 'string'
+      ) {
+        throw new Error('Memory-layer read received an incomplete binding');
+      }
+      if (bindings.length === limit) {
+        return { bindings, ok: true, truncated: true };
+      }
+      bindings.push({ s: row.s, p: row.p, o: row.o, g: row.g });
+    }
+
+    // Preserve the previous UI contract: reaching the fixed limit is a lower
+    // bound even when the result happens to contain exactly that many rows.
+    if (bindings.length === limit) {
+      return { bindings, ok: true, truncated: true };
+    }
+  }
+
+  return { bindings, ok: true, truncated: false };
+}
+
+/**
+ * Read all three UI memory layers without ever binding a GRAPH variable.
+ * Graph discovery is served by GraphSetIndexStore, then small UNION batches
+ * target exact named graphs. Layers run serially so a single dashboard card
+ * cannot occupy three external-store scheduler slots at once.
+ */
+export async function readMemoryLayers(
+  store: TripleStore,
+  contextGraphId: string,
+  options: QueryOptions = {},
+): Promise<MemoryLayersSnapshot> {
+  const queryOptions: QueryOptions = {
+    ...options,
+    priority: options.priority ?? 'normal',
+    source: options.source ?? 'node-ui.memory-layers',
+  };
+  const graphs = await listContextGraphNamedGraphs(store, contextGraphId, queryOptions);
+  const byLayer: Record<MemoryLayerKey, string[]> = { wm: [], swm: [], vm: [] };
+  for (const graph of graphs) {
+    const layer = classifyMemoryGraph(graph, contextGraphId);
+    if (layer) byLayer[layer].push(graph);
+  }
+
+  const layers = {} as Record<MemoryLayerKey, MemoryLayerReadResult>;
+  for (const layer of LAYER_KEYS) {
+    try {
+      layers[layer] = await readLayer(
+        store,
+        byLayer[layer],
+        MEMORY_LAYER_LIMITS[layer],
+        layer,
+        { ...queryOptions, source: `node-ui.memory-layers.${layer}` },
+      );
+    } catch (error) {
+      if (isAborted(options.signal)) throw error;
+      layers[layer] = { bindings: [], ok: false, truncated: false };
+    }
+  }
+  return { layers };
+}
+
+/**
+ * Compute the legacy per-named-graph subgraph counts with exact GRAPH IRIs.
+ * This preserves the response semantics while avoiding one context-wide
+ * GRAPH-variable aggregate and its giant query-engine VALUES allow-list.
+ */
+export async function readContextGraphNamedGraphStats(
+  store: TripleStore,
+  contextGraphId: string,
+  options: QueryOptions = {},
+): Promise<ContextGraphNamedGraphStats[]> {
+  const queryOptions: QueryOptions = {
+    ...options,
+    priority: options.priority ?? 'normal',
+    source: options.source ?? 'node-ui.sub-graph-stats',
+  };
+  const graphs = await listContextGraphNamedGraphs(store, contextGraphId, queryOptions);
+  const stats: ContextGraphNamedGraphStats[] = [];
+
+  for (let offset = 0; offset < graphs.length; offset += EXACT_GRAPH_QUERY_BATCH_SIZE) {
+    throwIfAborted(queryOptions.signal);
+    const batch = graphs.slice(offset, offset + EXACT_GRAPH_QUERY_BATCH_SIZE);
+    const result = await store.query(buildStatsQuery(batch), queryOptions);
+    if (result.type !== 'bindings') {
+      throw new Error('Context-graph stats read expected SELECT bindings');
+    }
+    for (const row of result.bindings) {
+      if (typeof row.g !== 'string' || !isScopedGraph(row.g, `did:dkg:context-graph:${contextGraphId}`)) {
+        continue;
+      }
+      stats.push({
+        graph: row.g,
+        entityCount: parseCount(row.entities),
+        tripleCount: parseCount(row.triples),
+      });
+    }
+  }
+
+  return stats;
+}

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -40,6 +40,9 @@ export const MANAGED_OXIGRAPH_BACKEND = 'oxigraph-server';
 /** Default loopback bind port. Override via `store.options.port`. */
 export const DEFAULT_OXIGRAPH_PORT = 7878;
 
+/** Mirrors SparqlHttpStore's default while making the managed launch invariant explicit. */
+export const DEFAULT_MANAGED_OXIGRAPH_CLIENT_TIMEOUT_MS = 30_000;
+
 const MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS = 5_000;
 // Node timers (and AbortSignal.timeout) coerce any delay above 2^31-1 ms to 1ms
 // with a TimeoutOverflowWarning — aborting the request almost immediately, the
@@ -75,10 +78,29 @@ function resolveManagedQueryClientTimeoutMs(
   clientTimeoutMs: number | undefined,
   queryTimeoutS: number | undefined,
 ): number | undefined {
-  if (clientTimeoutMs !== undefined) return clampNodeTimerMs(clientTimeoutMs);
+  if (clientTimeoutMs !== undefined) {
+    const configured = clampNodeTimerMs(clientTimeoutMs);
+    return queryTimeoutS === undefined
+      ? configured
+      : Math.max(
+          configured,
+          clampNodeTimerMs(queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS),
+        );
+  }
   return queryTimeoutS === undefined
     ? undefined
     : clampNodeTimerMs(queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS);
+}
+
+function deriveManagedQueryTimeoutS(clientTimeoutMs: number | undefined): number | undefined {
+  if (clientTimeoutMs === undefined) return undefined;
+  const clampedClientTimeoutMs = clampNodeTimerMs(clientTimeoutMs);
+  if (clampedClientTimeoutMs <= MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS + 1_000) {
+    return undefined;
+  }
+  return Math.floor(
+    (clampedClientTimeoutMs - MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS) / 1_000,
+  );
 }
 
 interface StoreConfigLike {
@@ -131,7 +153,7 @@ export interface ManagedOxigraphPlan {
   readyTimeoutMs?: number;
   /** Native Oxigraph query timeout, passed as `oxigraph serve --timeout-s`. */
   queryTimeoutS?: number;
-  /** SPARQL HTTP client deadline, independent from Oxigraph's native timeout. */
+  /** SPARQL HTTP client deadline; kept after Oxigraph's native timeout when both exist. */
   clientTimeoutMs?: number;
   /** Finite limits applied to an isolated systemd user scope. */
   memoryLimits?: OxigraphMemoryLimits;
@@ -159,9 +181,16 @@ export function planManagedOxigraph(
   const options = config.store.options ?? {};
   const port = resolveManagedOxigraphPort(options);
   const readyTimeoutMs = resolvePositiveIntegerOption(options, 'readyTimeoutMs');
-  const queryTimeoutS = resolvePositiveIntegerOption(options, 'queryTimeoutS');
+  const configuredClientTimeoutMs = resolvePositiveIntegerOption(options, 'clientTimeoutMs')
+    ?? DEFAULT_MANAGED_OXIGRAPH_CLIENT_TIMEOUT_MS;
+  // A client-only deadline closes the HTTP socket but cannot cancel an
+  // evaluation already running inside the Oxigraph server. Derive a native
+  // deadline with five seconds of client grace so timed-out queries are
+  // actually interrupted server-side instead of accumulating as zombies.
+  const queryTimeoutS = resolvePositiveIntegerOption(options, 'queryTimeoutS')
+    ?? deriveManagedQueryTimeoutS(configuredClientTimeoutMs);
   const clientTimeoutMs = resolveManagedQueryClientTimeoutMs(
-    resolvePositiveIntegerOption(options, 'clientTimeoutMs'),
+    configuredClientTimeoutMs,
     queryTimeoutS,
   );
   const memoryLimits = normalizeOxigraphMemoryLimits({

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -333,6 +333,10 @@ import {
   reverseLocalAgentSetupForUi,
   refreshLocalAgentIntegrationFromUi,
 } from '../local-agents.js';
+import {
+  readContextGraphNamedGraphStats,
+  readMemoryLayers,
+} from '../context-graph-read-model.js';
 
 import type { RequestContext } from './context.js';
 
@@ -877,6 +881,48 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     }
   }
 
+  // POST /api/context-graph/memory-layers  { contextGraphId }
+  //
+  // Purpose-built read model for the node UI. The old UI issued three broad
+  // GRAPH ?g queries and opted into every context-graph partition; the scoped
+  // query engine then injected a potentially enormous VALUES allow-list. On a
+  // large, actively publishing CG, Oxigraph planned those as Cartesian joins
+  // and client-side HTTP timeouts left the server evaluations running. This
+  // endpoint discovers graph names through GraphSetIndexStore and reads small
+  // batches of concrete GRAPH IRIs serially.
+  if (req.method === 'POST' && path === '/api/context-graph/memory-layers') {
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    const parsed = safeParseJson(body, res);
+    if (!parsed) return;
+    const contextGraphId = parsed.contextGraphId;
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
+
+    const disconnected = new AbortController();
+    const abortRead = () => disconnected.abort(new Error('Memory-layer client disconnected'));
+    const abortIfUnfinished = () => {
+      if (!res.writableEnded) abortRead();
+    };
+    req.once('aborted', abortRead);
+    res.once('close', abortIfUnfinished);
+    try {
+      const snapshot = await readMemoryLayers(agent.store, contextGraphId, {
+        signal: disconnected.signal,
+      });
+      if (!res.writableEnded && !res.destroyed) {
+        return jsonResponse(res, 200, { contextGraphId, ...snapshot });
+      }
+      return;
+    } catch (err: any) {
+      if (disconnected.signal.aborted || res.destroyed) return;
+      return jsonResponse(res, 500, {
+        error: err?.message ?? 'Failed to read context-graph memory layers',
+      });
+    } finally {
+      req.removeListener('aborted', abortRead);
+      res.removeListener('close', abortIfUnfinished);
+    }
+  }
+
   // GET /api/sub-graph/list?contextGraphId=...
   // Returns per-sub-graph metadata + entity/triple counts so UIs can render a
   // SubGraphBar without a second round-trip per sub-graph.
@@ -886,45 +932,28 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     try {
       const registered = await agent.listSubGraphs(contextGraphId!);
-      // One pass enumerates *all* named graphs in the project + their
-      // distinct-subject and triple counts. Sub-graph ownership is inferred
-      // from the named-graph path segment after the context-graph id:
+      // Enumerate named graphs through the graph-set index, then aggregate
+      // exact-IRI query batches. Sub-graph ownership is inferred from the
+      // named-graph path segment after the context-graph id:
       //   did:dkg:context-graph:<cg>/<subGraph>/assertion/<author>/<name>
       //   did:dkg:context-graph:<cg>/<subGraph>   (committed sub-graph view)
-      // This is one SPARQL round-trip regardless of how many sub-graphs exist.
+      // Unlike the old GRAPH ?g aggregate, this never creates a giant VALUES
+      // allow-list or an unbounded CartesianProductJoinIterator in Oxigraph.
       const counts = new Map<string, { entityCount: number; tripleCount: number }>();
       try {
         const prefix = `did:dkg:context-graph:${contextGraphId}/`;
-        const sparql = `
-          SELECT ?g (COUNT(DISTINCT ?s) AS ?entities) (COUNT(*) AS ?triples)
-          WHERE {
-            GRAPH ?g { ?s ?p ?o }
-            FILTER(STRSTARTS(STR(?g), ${JSON.stringify(prefix)}))
-          }
-          GROUP BY ?g
-        `;
-        const result = await agent.query(sparql, {
-          contextGraphId: contextGraphId!,
-          includeContextGraphPartitions: true,
-        });
-        const parseCount = (v: any) => {
-          if (v === undefined || v === null) return 0;
-          const s = typeof v === 'string' ? v : (v && typeof v === 'object' && 'value' in v ? (v as any).value : '');
-          const m = String(s).match(/^"?(\d+)/);
-          return m ? Number(m[1]) : 0;
-        };
-        for (const row of (result?.bindings ?? []) as Array<Record<string, any>>) {
-          const g = typeof row.g === 'string' ? row.g : (row.g && typeof row.g === 'object' && 'value' in row.g ? row.g.value : undefined);
-          if (!g || !g.startsWith(prefix)) continue;
-          const tail = g.slice(prefix.length);
+        const graphStats = await readContextGraphNamedGraphStats(agent.store, contextGraphId!);
+        for (const row of graphStats) {
+          if (!row.graph.startsWith(prefix)) continue;
+          const tail = row.graph.slice(prefix.length);
           // tail starts with either "<subGraphName>/..." or "_meta" or "_shared_memory".
           // Only care about the first segment, but skip daemon-internal graphs.
           const firstSlash = tail.indexOf('/');
           const seg = firstSlash >= 0 ? tail.slice(0, firstSlash) : tail;
           if (!seg || seg.startsWith('_')) continue;
           const entry = counts.get(seg) ?? { entityCount: 0, tripleCount: 0 };
-          entry.entityCount += parseCount(row.entities);
-          entry.tripleCount += parseCount(row.triples);
+          entry.entityCount += row.entityCount;
+          entry.tripleCount += row.tripleCount;
           counts.set(seg, entry);
         }
       } catch {

--- a/packages/cli/test/context-graph-read-model.test.ts
+++ b/packages/cli/test/context-graph-read-model.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  QueryOptions,
+  QueryResult,
+  TripleStore,
+} from '@origintrail-official/dkg-storage';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  EXACT_GRAPH_QUERY_BATCH_SIZE,
+  classifyMemoryGraph,
+  readContextGraphNamedGraphStats,
+  readMemoryLayers,
+} from '../src/daemon/context-graph-read-model.js';
+
+const CG = 'large-cg';
+const ROOT = `did:dkg:context-graph:${CG}`;
+
+function exactGraphs(sparql: string): string[] {
+  return [...sparql.matchAll(/GRAPH <([^>]+)>/g)].map((match) => match[1]);
+}
+
+function mockStore(
+  graphs: string[],
+  queryImpl: (sparql: string, options?: QueryOptions) => Promise<QueryResult>,
+): TripleStore {
+  return {
+    listGraphsByPrefix: vi.fn(async () => graphs),
+    query: vi.fn(queryImpl),
+  } as unknown as TripleStore;
+}
+
+describe('context-graph read model', () => {
+  it('classifies the existing WM, SWM, and VM graph families without prefix collisions', () => {
+    expect(classifyMemoryGraph(`${ROOT}/notes/assertion/0xabc/a`, CG)).toBe('wm');
+    expect(classifyMemoryGraph(`${ROOT}/notes/_working_memory/a`, CG)).toBe('wm');
+    expect(classifyMemoryGraph(`${ROOT}/notes/_shared_memory`, CG)).toBe('swm');
+    expect(classifyMemoryGraph(`${ROOT}/notes/_shared_memory/ka-1`, CG)).toBe('swm');
+    expect(classifyMemoryGraph(ROOT, CG)).toBe('vm');
+    expect(classifyMemoryGraph(`${ROOT}/notes`, CG)).toBe('vm');
+    expect(classifyMemoryGraph(`${ROOT}/notes/_verifiable_memory/ka-1`, CG)).toBe('vm');
+
+    expect(classifyMemoryGraph(`${ROOT}/meta/assertion/0xabc/profile`, CG)).toBeUndefined();
+    expect(classifyMemoryGraph(`${ROOT}/notes/_shared_memory/staging/ka-1`, CG)).toBeUndefined();
+    expect(classifyMemoryGraph(`${ROOT}-other/notes`, CG)).toBeUndefined();
+  });
+
+  it('uses graph-index discovery and small exact-IRI batches instead of GRAPH variables or VALUES', async () => {
+    const wmGraphs = Array.from(
+      { length: EXACT_GRAPH_QUERY_BATCH_SIZE + 3 },
+      (_, index) => `${ROOT}/notes/assertion/0xabc/a-${index}`,
+    );
+    const graphs = [
+      ...wmGraphs,
+      `${ROOT}/notes/_shared_memory`,
+      `${ROOT}/notes`,
+      `${ROOT}/meta/assertion/0xabc/profile`,
+    ];
+    const queries: Array<{ sparql: string; source?: string }> = [];
+    const store = mockStore(graphs, async (sparql, options) => {
+      queries.push({ sparql, source: options?.source });
+      return {
+        type: 'bindings',
+        bindings: exactGraphs(sparql).map((graph) => ({
+          s: `urn:entity:${graph.slice(-3)}`,
+          p: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+          o: 'http://schema.org/Thing',
+          g: graph,
+        })),
+      };
+    });
+
+    const snapshot = await readMemoryLayers(store, CG);
+
+    expect(store.listGraphsByPrefix).toHaveBeenCalledTimes(1);
+    expect(snapshot.layers.wm.bindings).toHaveLength(wmGraphs.length);
+    expect(snapshot.layers.swm.bindings).toHaveLength(1);
+    expect(snapshot.layers.vm.bindings).toHaveLength(1);
+    expect(queries.map((query) => query.source)).toEqual([
+      'node-ui.memory-layers.wm',
+      'node-ui.memory-layers.wm',
+      'node-ui.memory-layers.swm',
+      'node-ui.memory-layers.vm',
+    ]);
+    for (const { sparql } of queries) {
+      expect(sparql).not.toMatch(/GRAPH\s+\?g/i);
+      expect(sparql).not.toMatch(/\bVALUES\b/i);
+      expect(exactGraphs(sparql).length).toBeLessThanOrEqual(EXACT_GRAPH_QUERY_BATCH_SIZE);
+    }
+    expect(queries.find((query) => query.source?.endsWith('.swm'))?.sparql)
+      .toContain('FILTER(?p != <http://dkg.io/ontology/workspaceOwner>)');
+  });
+
+  it('contains a layer failure and continues with the remaining serial reads', async () => {
+    const store = mockStore([
+      `${ROOT}/notes/assertion/0xabc/a`,
+      `${ROOT}/notes/_shared_memory`,
+      `${ROOT}/notes`,
+    ], async (sparql, options) => {
+      if (options?.source === 'node-ui.memory-layers.swm') throw new Error('slow SWM read');
+      const graph = exactGraphs(sparql)[0];
+      return {
+        type: 'bindings',
+        bindings: [{ s: 'urn:s', p: 'urn:p', o: 'urn:o', g: graph }],
+      };
+    });
+
+    const snapshot = await readMemoryLayers(store, CG);
+
+    expect(snapshot.layers.wm.ok).toBe(true);
+    expect(snapshot.layers.swm).toEqual({ bindings: [], ok: false, truncated: false });
+    expect(snapshot.layers.vm.ok).toBe(true);
+  });
+
+  it('computes subgraph stats in exact-IRI batches', async () => {
+    const graphs = Array.from(
+      { length: EXACT_GRAPH_QUERY_BATCH_SIZE + 1 },
+      (_, index) => `${ROOT}/sg-${index}`,
+    );
+    const queries: string[] = [];
+    const store = mockStore(graphs, async (sparql) => {
+      queries.push(sparql);
+      return {
+        type: 'bindings',
+        bindings: exactGraphs(sparql).map((graph) => ({
+          g: graph,
+          entities: '"2"^^http://www.w3.org/2001/XMLSchema#integer',
+          triples: '"3"^^http://www.w3.org/2001/XMLSchema#integer',
+        })),
+      };
+    });
+
+    const stats = await readContextGraphNamedGraphStats(store, CG);
+
+    expect(stats).toHaveLength(graphs.length);
+    expect(stats[0]).toEqual({ graph: graphs[0], entityCount: 2, tripleCount: 3 });
+    expect(queries).toHaveLength(2);
+    for (const query of queries) {
+      expect(query).not.toMatch(/GRAPH\s+\?g/i);
+      expect(query).not.toMatch(/\bVALUES\b/i);
+      expect(exactGraphs(query).length).toBeLessThanOrEqual(EXACT_GRAPH_QUERY_BATCH_SIZE);
+    }
+  });
+
+  it('executes the exact-graph UNION reads against real Oxigraph', async () => {
+    const store = new OxigraphStore();
+    try {
+      await store.insert([
+        { subject: 'urn:wm', predicate: 'urn:type', object: 'urn:Thing', graph: `${ROOT}/notes/assertion/0xabc/a` },
+        { subject: 'urn:swm', predicate: 'urn:type', object: 'urn:Thing', graph: `${ROOT}/notes/_shared_memory` },
+        { subject: 'urn:swm', predicate: 'http://dkg.io/ontology/workspaceOwner', object: 'urn:owner', graph: `${ROOT}/notes/_shared_memory` },
+        { subject: 'urn:vm', predicate: 'urn:type', object: 'urn:Thing', graph: `${ROOT}/notes` },
+      ]);
+
+      const snapshot = await readMemoryLayers(store, CG);
+      expect(snapshot.layers.wm.bindings.map((row) => row.s)).toEqual(['urn:wm']);
+      expect(snapshot.layers.swm.bindings.map((row) => row.p)).toEqual(['urn:type']);
+      expect(snapshot.layers.vm.bindings.map((row) => row.s)).toEqual(['urn:vm']);
+
+      const stats = await readContextGraphNamedGraphStats(store, CG);
+      expect(stats.find((row) => row.graph === `${ROOT}/notes/_shared_memory`))
+        .toMatchObject({ entityCount: 1, tripleCount: 2 });
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -104,8 +104,10 @@ describe('planManagedOxigraph', () => {
     });
     expect(plan!.storeConfigTemplate).toEqual({
       backend: 'sparql-http',
-      options: { managedByDkg: true },
+      options: { managedByDkg: true, timeout: 30_000 },
     });
+    expect(plan!.queryTimeoutS).toBe(25);
+    expect(plan!.clientTimeoutMs).toBe(30_000);
   });
 
   it('honours operator overrides for port, location and cacheDir', () => {
@@ -139,7 +141,7 @@ describe('planManagedOxigraph', () => {
     expect(plan!.storeConfigTemplate.options.timeout).toBe(40_000);
   });
 
-  it('honours an independent HTTP client timeout without enabling the native Oxigraph timeout', () => {
+  it('derives a native Oxigraph deadline before a configured HTTP client timeout', () => {
     const plan = planManagedOxigraph(
       {
         store: {
@@ -149,7 +151,7 @@ describe('planManagedOxigraph', () => {
       },
       '/data',
     );
-    expect(plan!.queryTimeoutS).toBeUndefined();
+    expect(plan!.queryTimeoutS).toBe(175);
     expect(plan!.clientTimeoutMs).toBe(180_000);
     expect(plan!.storeConfigTemplate.options.timeout).toBe(180_000);
   });
@@ -167,6 +169,21 @@ describe('planManagedOxigraph', () => {
     expect(plan!.queryTimeoutS).toBe(35);
     expect(plan!.clientTimeoutMs).toBe(120_000);
     expect(plan!.storeConfigTemplate.options.timeout).toBe(120_000);
+  });
+
+  it('extends an unsafe client deadline so the native timeout fires first', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { queryTimeoutS: 35, clientTimeoutMs: 30_000 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.queryTimeoutS).toBe(35);
+    expect(plan!.clientTimeoutMs).toBe(40_000);
+    expect(plan!.storeConfigTemplate.options.timeout).toBe(40_000);
   });
 
   it('plans finite managed Oxigraph memory limits independently of the daemon service', () => {
@@ -231,11 +248,12 @@ describe('planManagedOxigraph', () => {
       },
       '/data',
     );
+    expect(plan!.queryTimeoutS).toBe(2_147_478);
     expect(plan!.clientTimeoutMs).toBe(2_147_483_647);
     expect(plan!.storeConfigTemplate.options.timeout).toBe(2_147_483_647);
   });
 
-  it('ignores invalid managed Oxigraph timeout options', () => {
+  it('falls back to safe managed Oxigraph deadlines for invalid timeout options', () => {
     const plan = planManagedOxigraph(
       {
         store: {
@@ -246,9 +264,9 @@ describe('planManagedOxigraph', () => {
       '/data',
     );
     expect(plan!.readyTimeoutMs).toBeUndefined();
-    expect(plan!.queryTimeoutS).toBeUndefined();
-    expect(plan!.clientTimeoutMs).toBeUndefined();
-    expect(plan!.storeConfigTemplate.options).toEqual({ managedByDkg: true });
+    expect(plan!.queryTimeoutS).toBe(25);
+    expect(plan!.clientTimeoutMs).toBe(30_000);
+    expect(plan!.storeConfigTemplate.options).toEqual({ managedByDkg: true, timeout: 30_000 });
   });
 
   it('resolveManagedOxigraphPort rejects out-of-range values', () => {
@@ -408,7 +426,7 @@ describe('startManagedOxigraph (real download + real server)', () => {
     }
   });
 
-  it('forwards an independent client timeout without passing --timeout-s to Oxigraph', async () => {
+  it('forwards the native deadline derived from a configured client timeout', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'oxi-managed-'));
     const port = await freePort();
 
@@ -427,7 +445,9 @@ describe('startManagedOxigraph (real download + real server)', () => {
       expect(result).not.toBeNull();
       expect(result!.storeConfig.options.timeout).toBe(180_000);
       const args = await fetchManagedArgs(port);
-      expect(args).not.toContain('--timeout-s');
+      const timeoutIndex = args.indexOf('--timeout-s');
+      expect(timeoutIndex).toBeGreaterThanOrEqual(0);
+      expect(args[timeoutIndex + 1]).toBe('175');
     } finally {
       await result?.handle.stop();
       await rm(dataDir, { recursive: true, force: true });
@@ -503,6 +523,7 @@ describe('startManagedOxigraph (real download + real server)', () => {
           backend: 'sparql-http',
           options: {
             managedByDkg: true,
+            timeout: 30_000,
             queryEndpoint: `http://127.0.0.1:${port}/query`,
             updateEndpoint: `http://127.0.0.1:${port}/update`,
           },

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
           'test/status-route-store-quads.test.ts',
           'test/status-command-store.test.ts',
           'test/memory-graph-events.test.ts',
+          'test/context-graph-read-model.test.ts',
           'test/memory-turn-route.test.ts',
           'test/trust-endpoint-validation.test.ts',
           'test/daemon/plugin-loader.test.ts',

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -577,6 +577,53 @@ export async function importFile(
 
 // --- Query ---
 
+export type MemoryLayerApiKey = 'wm' | 'swm' | 'vm';
+
+export interface MemoryLayerApiBinding {
+  s: string;
+  p: string;
+  o: string;
+  g: string;
+}
+
+export interface MemoryLayerApiResult {
+  bindings: MemoryLayerApiBinding[];
+  ok: boolean;
+  truncated: boolean;
+}
+
+export interface MemoryLayersApiResponse {
+  contextGraphId: string;
+  layers: Record<MemoryLayerApiKey, MemoryLayerApiResult>;
+}
+
+// Every mounted view of the same CG consumes the same read model. Keep one
+// browser request in flight per CG so DashboardView, ProjectView, strict-mode
+// mounts, and SSE refreshes cannot multiply storage work.
+const inflightMemoryLayers = new Map<string, Promise<MemoryLayersApiResponse>>();
+
+export function fetchMemoryLayersDeduped(contextGraphId: string): Promise<MemoryLayersApiResponse> {
+  const existing = inflightMemoryLayers.get(contextGraphId);
+  if (existing) return existing;
+  const promise = (async () => {
+    const res = await fetch(`${BASE}/api/context-graph/memory-layers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({ contextGraphId }),
+    });
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      const msg = (errBody as { error?: string })?.error ?? `HTTP ${res.status}`;
+      throw new HttpError(res.status, msg, errBody);
+    }
+    return res.json() as Promise<MemoryLayersApiResponse>;
+  })().finally(() => {
+    inflightMemoryLayers.delete(contextGraphId);
+  });
+  inflightMemoryLayers.set(contextGraphId, promise);
+  return promise;
+}
+
 // In-flight POST /api/query dedup. Coalesces concurrent identical
 // requests so React strict-mode double-mounts and sibling views asking
 // the same SPARQL against the same CG share one underlying fetch.

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -1,5 +1,8 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { postQueryDeduped } from '../api.js';
+import {
+  fetchMemoryLayersDeduped,
+  type MemoryLayerApiResult,
+} from '../api.js';
 import { useMemoryGraphEvents } from './useNodeEvents.js';
 import { MEMORY_LABEL_PREDICATES } from '../lib/memoryLabels.js';
 import { decodeRdfStringLiteral } from '../../rdf-literal.js';
@@ -185,123 +188,9 @@ function deriveEntityLabel(entity: MemoryEntity): string {
   return readableFallbackLabel(entity);
 }
 
-// All three layer queries walk the named-graph space directly with a
-// FILTER on the graph URI, rather than going through the daemon's
-// built-in `view` helpers. Two wins from this:
-//   1. Coverage of per-sub-graph SWM/VM partitions (the built-in views
-//      only resolve to top-level graphs).
-//   2. `?g` projection — every triple comes back tagged with its
-//      source graph so we can assign the sub-graph slug, which drives
-//      SubGraphBar filtering and the Graph Overview grid across all
-//      three layers.
-//
-// The V10 named-graph layout we rely on (see `resolveViewGraphs`
-// in `@origintrail-official/dkg-query` and named KA lifecycle publish):
-//
-//   WM  (drafts)    : did:dkg:context-graph:<cg>/<sg>/assertion/<addr>/<name>
-//   SWM (proposed)  : did:dkg:context-graph:<cg>/<sg>/_shared_memory
-//                     did:dkg:context-graph:<cg>/_shared_memory     (default)
-//   VM  (committed) : did:dkg:context-graph:<cg>/<sg>              (per-sg)
-//                     did:dkg:context-graph:<cg>                   (root)
-//                     did:dkg:context-graph:<cg>/_verifiable_memory/*
-//
-// Key insight: in V10 the plain `<cg>/<sg>` graph IS the committed
-// (chain-attested) view of a sub-graph — that's where
-// publishing to VM (`POST /api/knowledge-assets/:name/vm/publish`) deposits
-// KAs after on-chain registration.
-// We treat it as VM, not WM. Pre-publish writes only exist in
-// `assertion/<addr>/<name>` graphs.
-//
-// 50k triples comfortably fits realistic PoC projects in full (our
-// seeded `dkg-code-project` WM has ~28k); SWM/VM stay smaller by
-// design (hundreds of triples each).
-const WM_LIMIT = 50_000;
-const SWM_LIMIT = 20_000;
-const VM_LIMIT = 20_000;
-
-function wmSparql(cgId: string) {
-  const cgUri = `did:dkg:context-graph:${cgId}`;
-  // WM = every per-agent assertion under the project, regardless of
-  // sub-graph. We match any graph whose path contains `/assertion/`.
-  //
-  // PR #818 Codex sweep 3 (ux-lead Finding 1 verdict) — exclude the
-  // `meta` namespace. Profile artifacts (prof:Profile,
-  // prof:SubGraphBinding, prof:FilterChip, prof:QueryCatalog,
-  // prof:SavedQuery) are published as assertions under
-  // `<cg>/meta/assertion/<addr>/<name>`, so the pre-fix
-  // `CONTAINS(/assertion/)` filter scooped them into `memory.entityList`
-  // alongside real user knowledge. Those entities are UI configuration,
-  // not user knowledge — they have their own surfaces via
-  // `useProjectProfile` (which queries the meta graphs directly via
-  // its own SPARQL, not via this hook). Mirrors the meta-exclusion
-  // policy that `vmSparql` already enforces (`:262-269`); GH #806's
-  // `subGraphOf` `meta` filter handles the chip-row side and this
-  // upstream filter handles the entity-list side — same family.
-  return `SELECT ?s ?p ?o ?g WHERE {
-    GRAPH ?g { ?s ?p ?o }
-    FILTER(
-      STRSTARTS(STR(?g), "${cgUri}/") &&
-      (CONTAINS(STR(?g), "/assertion/") || CONTAINS(STR(?g), "/_working_memory/")) &&
-      STR(?g) != "${cgUri}/meta" &&
-      !CONTAINS(STR(?g), "/meta/") &&
-      !STRENDS(STR(?g), "/_meta")
-    )
-  } LIMIT ${WM_LIMIT}`;
-}
-
-function swmSparql(cgId: string) {
-  const cgUri = `did:dkg:context-graph:${cgId}`;
-  // Any graph whose tail ends in `_shared_memory` (excluding the sibling
-  // `_shared_memory_meta` bookkeeping graphs which carry lifecycle
-  // provenance rather than user data).
-  //
-  // PR #818 Codex sweep 3 (ux-lead Finding 1 verdict) — exclude
-  // `<cg>/meta/_shared_memory` so SWM-promoted profile artifacts don't
-  // surface in the user-facing entityList. Mirrors `vmSparql`'s
-  // existing meta-exclusion policy (`:262-269`). Without this,
-  // `STRENDS(/_shared_memory)` admits `<cg>/meta/_shared_memory` —
-  // a profile-namespace graph — and the entity becomes a "root SWM
-  // entity" in every consumer downstream.
-  return `SELECT ?s ?p ?o ?g WHERE {
-    GRAPH ?g { ?s ?p ?o }
-    FILTER(
-      STRSTARTS(STR(?g), "${cgUri}") &&
-      (STRENDS(STR(?g), "/_shared_memory") || CONTAINS(STR(?g), "/_shared_memory/")) &&
-      STR(?g) != "${cgUri}/meta/_shared_memory" &&
-      !CONTAINS(STR(?g), "/meta/") &&
-      !CONTAINS(STR(?g), "/_shared_memory/staging/") &&
-      ?p != <http://dkg.io/ontology/workspaceOwner>
-    )
-  } LIMIT ${SWM_LIMIT}`;
-}
-
-function vmSparql(cgId: string) {
-  const cgUri = `did:dkg:context-graph:${cgId}`;
-  // VM covers three named-graph shapes:
-  //   • Root content graph       `<cgUri>`        — finalised VM
-  //   • Per-sub-graph data graph `<cgUri>/<sg>`   — post-publish VM view
-  //   • Per-sub-graph VM bucket  `<cgUri>/<sg>/_verifiable_memory(/*)`
-  // We exclude:
-  //   • `_shared_memory*`        — belongs to SWM
-  //   • `assertion/*`            — belongs to WM
-  //   • `_meta`, `/meta`, `/meta/*`, `_private`, `_rules`, any `_verifiable_memory_meta`
-  //     — bookkeeping graphs, not user data.
-  return `SELECT ?s ?p ?o ?g WHERE {
-    GRAPH ?g { ?s ?p ?o }
-    FILTER(
-      STRSTARTS(STR(?g), "${cgUri}") &&
-      !CONTAINS(STR(?g), "/assertion/") &&
-      !CONTAINS(STR(?g), "/_working_memory") &&
-      !CONTAINS(STR(?g), "/_shared_memory") &&
-      !CONTAINS(STR(?g), "_verifiable_memory_meta") &&
-      !STRENDS(STR(?g), "/_meta") &&
-      STR(?g) != "${cgUri}/meta" &&
-      !CONTAINS(STR(?g), "/meta/") &&
-      !CONTAINS(STR(?g), "/_private") &&
-      !CONTAINS(STR(?g), "/_rules")
-    )
-  } LIMIT ${VM_LIMIT}`;
-}
+// The daemon owns graph discovery and layer classification. It uses the
+// graph-set index followed by concrete GRAPH IRIs, preserving source-graph
+// attribution without exposing a broad GRAPH-variable query to Oxigraph.
 
 /**
  * Extract the sub-graph slug from a named-graph URI of the shape
@@ -332,15 +221,6 @@ export function subGraphOf(gUri: string, cgId: string): string | undefined {
 
 interface LayerResult { triples: Triple[]; ok: boolean; truncated: boolean }
 
-interface QueryLayerOptions {
-  view?: string;
-  includeSharedMemory?: boolean;
-  graphSuffix?: string;
-  includeContextGraphPartitions?: boolean;
-  /** Local-only result limit used to detect lower-bound totals; never sent to /api/query. */
-  layerLimit?: number;
-}
-
 const LOADING_LAYER_STATUS: Record<MemoryLayerKey, MemoryLayerStatus> = {
   wm: 'loading',
   swm: 'loading',
@@ -353,44 +233,23 @@ const ERROR_LAYER_STATUS: Record<MemoryLayerKey, MemoryLayerStatus> = {
   vm: 'error',
 };
 
-async function queryLayer(
-  sparql: string,
+function normalizeLayer(
+  result: MemoryLayerApiResult | undefined,
   contextGraphId: string,
-  opts?: QueryLayerOptions,
-): Promise<LayerResult> {
-  // Never throws and never loses the failed-vs-empty distinction: it
-  // returns `{ triples, ok, truncated }`. A failed/unreachable `/api/query` yields
-  // `{ triples: [], ok: false }` so triple data still degrades to
-  // "empty" for every consumer (unchanged behavior), while `ok=false`
-  // lets the hook compute `partial` UNCONDITIONALLY — previously it was
-  // dead for non-opt-in callers, making truncated counts look exact
-  // (Codex). Whether a total failure escalates to a hard `error` stays
-  // the configurable part (see `signalErrors`).
-  try {
-    // Routed through `postQueryDeduped` so the 3-way WM/SWM/VM fan-out
-    // here coalesces with any other concurrently-mounted instance of
-    // this hook (e.g. Dashboard card + ProjectView both subscribed to
-    // the same CG). One underlying fetch instead of N for each layer.
-    const { layerLimit, ...requestOpts } = opts ?? {};
-    const body: any = { sparql, contextGraphId, ...requestOpts };
-    const data: any = await postQueryDeduped(body);
-    const bindings = data?.result?.bindings ?? data?.results?.bindings ?? [];
-    const truncated = typeof layerLimit === 'number' && bindings.length >= layerLimit;
-    const triples = bindings
-      .map((row: any) => {
-        const g = bv(row.g);
-        return {
-          subject: bv(row.s) ?? '',
-          predicate: bv(row.p) ?? '',
-          object: bv(row.o) ?? '',
-          subGraph: g ? subGraphOf(g, contextGraphId) : undefined,
-        };
-      })
-      .filter((t: Triple) => t.subject && t.predicate && t.object);
-    return { triples, ok: true, truncated };
-  } catch {
-    return { triples: [], ok: false, truncated: false };
-  }
+): LayerResult {
+  if (!result?.ok) return { triples: [], ok: false, truncated: false };
+  const triples = result.bindings
+    .map((row) => {
+      const graph = bv(row.g);
+      return {
+        subject: bv(row.s) ?? '',
+        predicate: bv(row.p) ?? '',
+        object: bv(row.o) ?? '',
+        subGraph: graph ? subGraphOf(graph, contextGraphId) : undefined,
+      };
+    })
+    .filter((triple: Triple) => triple.subject && triple.predicate && triple.object);
+  return { triples, ok: true, truncated: result.truncated };
 }
 
 export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntity> {
@@ -630,9 +489,15 @@ export function useMemoryEntities(
     LOADING_LAYER_STATUS,
   );
   const versionRef = useRef(0);
+  const activeContextGraphRef = useRef(contextGraphId);
+  const signalErrorsRef = useRef(signalErrors);
+  const refreshRunningRef = useRef(false);
+  const refreshPendingRef = useRef(false);
+  activeContextGraphRef.current = contextGraphId;
+  signalErrorsRef.current = signalErrors;
 
-  const fetchAll = useCallback(async () => {
-    if (!contextGraphId) return;
+  const fetchOnce = useCallback(async (requestedContextGraphId: string) => {
+    if (!requestedContextGraphId) return;
     const version = ++versionRef.current;
     setLoading(true);
     setError(null);
@@ -640,17 +505,15 @@ export function useMemoryEntities(
     setLayerStatus(LOADING_LAYER_STATUS);
 
     try {
-      // queryLayer never throws — it returns { triples, ok }. We keep
-      // whatever layers succeeded (failed layers contribute []), so a
-      // single-layer 500 never blanks the others for any consumer.
-      const countScope = { includeContextGraphPartitions: true };
-      const [wmR, swmR, vmR] = await Promise.all([
-        queryLayer(wmSparql(contextGraphId), contextGraphId, { ...countScope, layerLimit: WM_LIMIT }),
-        queryLayer(swmSparql(contextGraphId), contextGraphId, { ...countScope, layerLimit: SWM_LIMIT }),
-        queryLayer(vmSparql(contextGraphId), contextGraphId, { ...countScope, layerLimit: VM_LIMIT }),
-      ]);
+      const snapshot = await fetchMemoryLayersDeduped(requestedContextGraphId);
+      const wmR = normalizeLayer(snapshot.layers.wm, requestedContextGraphId);
+      const swmR = normalizeLayer(snapshot.layers.swm, requestedContextGraphId);
+      const vmR = normalizeLayer(snapshot.layers.vm, requestedContextGraphId);
 
-      if (version !== versionRef.current) return;
+      if (
+        version !== versionRef.current
+        || requestedContextGraphId !== activeContextGraphRef.current
+      ) return;
 
       const all: LayeredTriple[] = [
         ...wmR.triples.map(t => ({ ...t, layer: 'working' as const })),
@@ -676,20 +539,53 @@ export function useMemoryEntities(
       // (dashboard assetCount fallback / views' error screen) stays the
       // configurable part via `signalErrors`.
       setPartial((failed > 0 && failed < 3) || clipped);
-      setError(signalErrors && failed === 3 ? 'Failed to load memory data' : null);
+      setError(signalErrorsRef.current && failed === 3 ? 'Failed to load memory data' : null);
     } catch (err: any) {
-      if (version === versionRef.current) {
-        setError(err.message ?? 'Failed to load memory data');
+      if (
+        version === versionRef.current
+        && requestedContextGraphId === activeContextGraphRef.current
+      ) {
+        setError(signalErrorsRef.current ? (err.message ?? 'Failed to load memory data') : null);
+        setPartial(false);
         setLayerStatus(ERROR_LAYER_STATUS);
       }
     } finally {
-      if (version === versionRef.current) setLoading(false);
+      if (
+        version === versionRef.current
+        && requestedContextGraphId === activeContextGraphRef.current
+      ) setLoading(false);
     }
-  }, [contextGraphId, signalErrors]);
+  }, []);
+
+  // Serialize refreshes per hook instance. Any number of SSE events received
+  // during a read collapses to one trailing refresh, while the API-level
+  // singleflight coalesces sibling views of the same CG. This keeps live data
+  // fresh without allowing refresh storms to overlap storage work.
+  const fetchAll = useCallback(async () => {
+    if (!activeContextGraphRef.current) return;
+    if (refreshRunningRef.current) {
+      refreshPendingRef.current = true;
+      return;
+    }
+    refreshRunningRef.current = true;
+    try {
+      do {
+        refreshPendingRef.current = false;
+        await fetchOnce(activeContextGraphRef.current);
+      } while (refreshPendingRef.current);
+    } finally {
+      refreshRunningRef.current = false;
+    }
+  }, [fetchOnce]);
 
   useMemoryGraphEvents(contextGraphId, fetchAll);
 
-  useEffect(() => { fetchAll(); }, [fetchAll]);
+  useEffect(() => {
+    fetchAll();
+    return () => {
+      versionRef.current++;
+    };
+  }, [contextGraphId, fetchAll]);
 
   const entities = useMemo(() => buildMemoryEntities(layeredTriples), [layeredTriples]);
 

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -433,17 +433,11 @@ describe('useMemoryEntities hook', () => {
     expect(hook).toContain("type TrustLevel = 'working' | 'shared' | 'verified'");
   });
 
-  it('queries WM, SWM, and VM in parallel', () => {
-    // Hook was refactored from `view: 'shared-working-memory' | 'verifiable-memory'`
-    // to per-layer SPARQL builders that walk the named-graph space directly
-    // (see the rationale comment in useMemoryEntities.ts) so per-sub-graph
-    // SWM/VM partitions are covered and each triple carries its source `?g`.
-    // The original intent of this test — that all three layers are fetched
-    // in parallel — is still asserted, just against the new shape.
-    expect(hook).toContain('Promise.all');
-    expect(hook).toContain('wmSparql');
-    expect(hook).toContain('swmSparql');
-    expect(hook).toContain('vmSparql');
+  it('loads one daemon-owned memory-layer snapshot instead of broad layer SPARQL fan-out', () => {
+    expect(hook).toContain('fetchMemoryLayersDeduped');
+    expect(hook).not.toContain('GRAPH ?g');
+    expect(hook).not.toContain('wmSparql');
+    expect(hook).not.toContain('Promise.all');
   });
 
   it('builds entity map grouped by subject URI', () => {

--- a/packages/node-ui/test/use-memory-entities-counts.test.ts
+++ b/packages/node-ui/test/use-memory-entities-counts.test.ts
@@ -71,35 +71,28 @@ describe('useMemoryEntities canonical layer counts', () => {
     root = createRoot(container);
 
     vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
-      const { sparql = '', contextGraphId = 'cg' } =
-        JSON.parse(String(init?.body ?? '{}')) as { sparql?: string; contextGraphId?: string };
-      const isVm = sparql.includes('_verifiable_memory_meta');
-      // PR #818 sweep 3 — WM SPARQL now contains `STRENDS(...,
-      // "/_meta")` for the meta-exclusion filter, so the SWM
-      // detection needs the discriminating clause that's still
-      // SWM-exclusive: the `/_shared_memory` tail check.
-      const isSwm = !isVm && sparql.includes('STRENDS(STR(?g), "/_shared_memory")');
+      const { contextGraphId = 'cg' } =
+        JSON.parse(String(init?.body ?? '{}')) as { contextGraphId?: string };
       const graphBase = `did:dkg:context-graph:${contextGraphId}`;
-      const bindings = isVm
-        ? [
-            typeBinding('urn:test:verified', graphBase),
-            typeBinding('urn:test:full-pipeline', graphBase),
-          ]
-        : isSwm
-          ? [
-              typeBinding('urn:test:promoted', `${graphBase}/notes/_shared_memory`),
-              typeBinding('urn:test:full-pipeline', `${graphBase}/notes/_shared_memory`),
-            ]
-          : [
-              typeBinding('urn:test:promoted', `${graphBase}/notes/assertion/agent/a-1`),
-              typeBinding('urn:test:full-pipeline', `${graphBase}/notes/assertion/agent/a-1`),
-              typeBinding('urn:test:draft', `${graphBase}/notes/assertion/agent/a-2`),
-              typeBinding('urn:test:draft', `${graphBase}/docs/assertion/agent/a-3`),
-              uriBinding('urn:test:draft', MENTIONS, 'urn:test:object-only', `${graphBase}/docs/assertion/agent/a-3`),
-            ];
       return {
         ok: true,
-        json: async () => ({ result: { bindings } }),
+        json: async () => ({ contextGraphId, layers: {
+          wm: { ok: true, truncated: false, bindings: [
+            typeBinding('urn:test:promoted', `${graphBase}/notes/assertion/agent/a-1`),
+            typeBinding('urn:test:full-pipeline', `${graphBase}/notes/assertion/agent/a-1`),
+            typeBinding('urn:test:draft', `${graphBase}/notes/assertion/agent/a-2`),
+            typeBinding('urn:test:draft', `${graphBase}/docs/assertion/agent/a-3`),
+            uriBinding('urn:test:draft', MENTIONS, 'urn:test:object-only', `${graphBase}/docs/assertion/agent/a-3`),
+          ] },
+          swm: { ok: true, truncated: false, bindings: [
+            typeBinding('urn:test:promoted', `${graphBase}/notes/_shared_memory`),
+            typeBinding('urn:test:full-pipeline', `${graphBase}/notes/_shared_memory`),
+          ] },
+          vm: { ok: true, truncated: false, bindings: [
+            typeBinding('urn:test:verified', graphBase),
+            typeBinding('urn:test:full-pipeline', graphBase),
+          ] },
+        } }),
       } as Response;
     }));
   });
@@ -126,36 +119,9 @@ describe('useMemoryEntities canonical layer counts', () => {
     expect(el.getAttribute('data-current-layers')).toContain('urn:test:full-pipeline:verified');
     expect(el.getAttribute('data-current-layers')).not.toContain('urn:test:object-only');
 
-    const queryBodies = vi.mocked(fetch).mock.calls
-      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string; includeContextGraphPartitions?: boolean });
-    expect(queryBodies).toHaveLength(3);
-    expect(queryBodies.every(body => body.includeContextGraphPartitions === true)).toBe(true);
-
-    const vmRequest = vi.mocked(fetch).mock.calls
-      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string })
-      .find(body => body.sparql?.includes('_verifiable_memory_meta'));
-    expect(vmRequest?.sparql).toContain('STR(?g) != "did:dkg:context-graph:cg-counts/meta"');
-    expect(vmRequest?.sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
-
-    // PR #818 Codex sweep 3 (ux-lead Finding 1 verdict) — WM and
-    // SWM SPARQL queries gain the same meta-namespace exclusions VM
-    // already enforces. Profile artifacts (prof:* — project profile
-    // configuration) live under `<cg>/meta/...` and are loaded by
-    // `useProjectProfile` directly via its own SPARQL; without the
-    // upstream filter here they also leak into `memory.entityList`,
-    // becoming "root entities" in every consumer downstream (the
-    // GH #806 family root cause).
-    const wmRequest = vi.mocked(fetch).mock.calls
-      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string })
-      .find(body => body.sparql?.includes('CONTAINS(STR(?g), "/assertion/")'));
-    expect(wmRequest?.sparql).toContain('STR(?g) != "did:dkg:context-graph:cg-counts/meta"');
-    expect(wmRequest?.sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
-    expect(wmRequest?.sparql).toContain('!STRENDS(STR(?g), "/_meta")');
-
-    const swmRequest = vi.mocked(fetch).mock.calls
-      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string })
-      .find(body => body.sparql?.includes('STRENDS(STR(?g), "/_shared_memory")'));
-    expect(swmRequest?.sparql).toContain('STR(?g) != "did:dkg:context-graph:cg-counts/meta/_shared_memory"');
-    expect(swmRequest?.sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(String(url)).toContain('/api/context-graph/memory-layers');
+    expect(JSON.parse(String(init?.body ?? '{}'))).toEqual({ contextGraphId: 'cg-counts' });
   });
 });

--- a/packages/node-ui/test/use-memory-entities-live-updates.test.ts
+++ b/packages/node-ui/test/use-memory-entities-live-updates.test.ts
@@ -42,13 +42,7 @@ function tripleBinding(subject: string, graph: string) {
   };
 }
 
-function bindingsForLayer(sparql: string, contextGraphId: string, revision: number) {
-  const isVm = sparql.includes('_verifiable_memory_meta');
-  // PR #818 sweep 3 — WM SPARQL also contains STRENDS (for the
-  // `/_meta` exclusion); discriminate by the SWM-exclusive
-  // `/_shared_memory` tail check.
-  const isSwm = !isVm && sparql.includes('STRENDS(STR(?g), "/_shared_memory")');
-  if (isVm || isSwm) return [];
+function wmBindings(contextGraphId: string, revision: number) {
   return Array.from({ length: revision }, (_, i) =>
     tripleBinding(
       `urn:test:${contextGraphId}:wm-${i + 1}`,
@@ -92,11 +86,15 @@ describe('useMemoryEntities live updates', () => {
     root = createRoot(container);
 
     vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
-      const body = JSON.parse(String(init?.body ?? '{}')) as { sparql?: string; contextGraphId?: string };
-      const bindings = bindingsForLayer(body.sparql ?? '', body.contextGraphId ?? 'unknown', revision);
+      const body = JSON.parse(String(init?.body ?? '{}')) as { contextGraphId?: string };
+      const contextGraphId = body.contextGraphId ?? 'unknown';
       return {
         ok: true,
-        json: async () => ({ result: { bindings } }),
+        json: async () => ({ contextGraphId, layers: {
+          wm: { ok: true, truncated: false, bindings: wmBindings(contextGraphId, revision) },
+          swm: { ok: true, truncated: false, bindings: [] },
+          vm: { ok: true, truncated: false, bindings: [] },
+        } }),
       } as Response;
     }));
   });
@@ -114,7 +112,7 @@ describe('useMemoryEntities live updates', () => {
     });
     await flush();
 
-    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenCalledTimes(1);
     expect(container.querySelector('#probe')?.getAttribute('data-wm')).toBe('1');
 
     revision = 2;
@@ -127,14 +125,14 @@ describe('useMemoryEntities live updates', () => {
       });
       vi.advanceTimersByTime(349);
     });
-    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       vi.advanceTimersByTime(1);
     });
     await flush();
 
-    expect(fetch).toHaveBeenCalledTimes(6);
+    expect(fetch).toHaveBeenCalledTimes(2);
     expect(container.querySelector('#probe')?.getAttribute('data-wm')).toBe('2');
   });
 
@@ -155,7 +153,64 @@ describe('useMemoryEntities live updates', () => {
     });
     await flush();
 
-    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenCalledTimes(1);
     expect(container.querySelector('#probe')?.getAttribute('data-wm')).toBe('1');
+  });
+
+  it('collapses events during an active read to one trailing refresh', async () => {
+    let resolveFirst!: (response: Response) => void;
+    let calls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+      calls++;
+      const { contextGraphId = 'unknown' } = JSON.parse(String(init?.body ?? '{}')) as {
+        contextGraphId?: string;
+      };
+      const response = () => ({
+        ok: true,
+        json: async () => ({ contextGraphId, layers: {
+          wm: { ok: true, truncated: false, bindings: wmBindings(contextGraphId, calls) },
+          swm: { ok: true, truncated: false, bindings: [] },
+          vm: { ok: true, truncated: false, bindings: [] },
+        } }),
+      } as Response);
+      if (calls === 1) {
+        return new Promise<Response>((resolve) => { resolveFirst = resolve; });
+      }
+      return response();
+    }));
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { contextGraphId: 'project-a' }));
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      MockEventSource.instances[0].emit('memory_graph_changed', {
+        contextGraphId: 'project-a', layers: ['wm'], operation: 'write-1',
+      });
+      vi.advanceTimersByTime(350);
+      MockEventSource.instances[0].emit('memory_graph_changed', {
+        contextGraphId: 'project-a', layers: ['wm'], operation: 'write-2',
+      });
+      vi.advanceTimersByTime(350);
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst({
+        ok: true,
+        json: async () => ({ contextGraphId: 'project-a', layers: {
+          wm: { ok: true, truncated: false, bindings: wmBindings('project-a', 1) },
+          swm: { ok: true, truncated: false, bindings: [] },
+          vm: { ok: true, truncated: false, bindings: [] },
+        } }),
+      } as Response);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('#probe')?.getAttribute('data-wm')).toBe('2');
   });
 });

--- a/packages/node-ui/test/use-memory-entities-partial.test.ts
+++ b/packages/node-ui/test/use-memory-entities-partial.test.ts
@@ -26,10 +26,6 @@ function triple(subject: string, graph: string) {
   return { s: { value: subject }, p: { value: RDF_TYPE }, o: { value: 'http://schema.org/Thing' }, g: { value: graph } };
 }
 
-function sparqlLimit(sparql: string): number {
-  return Number(sparql.match(/\bLIMIT\s+(\d+)/i)?.[1] ?? 0);
-}
-
 function Probe({ id }: { id: string }) {
   // Dashboard-style consumer: opts into failed-vs-empty signalling.
   const m = useMemoryEntities(id, { signalErrors: true });
@@ -64,41 +60,23 @@ describe('useMemoryEntities — partial layer failure', () => {
     document.body.appendChild(container);
     root = createRoot(container);
 
-    // WM (/assertion/) and VM (the exclusion query) succeed; the SWM
-    // query (ends in /_shared_memory) returns a 500.
     vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
-      const { sparql = '', contextGraphId = 'cg' } =
-        JSON.parse(String(init?.body ?? '{}')) as { sparql?: string; contextGraphId?: string };
-      // Robust layer discriminators: every query references both
-      // "/assertion/" and "/_shared_memory" (inside FILTER negations),
-      // so match on tokens unique to each — `_verifiable_memory_meta`
-      // only appears in the VM query, the `/_shared_memory` tail
-      // check only in the SWM query (PR #818 sweep 3: WM also has
-      // `STRENDS(..., "/_meta")` now so the bare `STRENDS` token
-      // no longer discriminates).
-      const isVm = sparql.includes('_verifiable_memory_meta');
-      const isSwm = !isVm && sparql.includes('STRENDS(STR(?g), "/_shared_memory")');
-      const isWm = !isVm && !isSwm;
-      if (isSwm && scenario === 'swm-error') {
-        return { ok: false, status: 500, json: async () => ({}) } as Response;
-      }
-      if (isSwm && scenario === 'swm-limit') {
-        const limit = sparqlLimit(sparql);
-        return { ok: true, json: async () => ({ result: { bindings: Array.from(
-          { length: limit },
-          () => triple(`urn:${contextGraphId}:swm-limited`, `did:dkg:context-graph:${contextGraphId}/n/_shared_memory`),
-        ) } }) } as Response;
-      }
-      if (isWm) {
-        return { ok: true, json: async () => ({ result: { bindings: [
+      const { contextGraphId = 'cg' } =
+        JSON.parse(String(init?.body ?? '{}')) as { contextGraphId?: string };
+      return { ok: true, json: async () => ({ contextGraphId, layers: {
+        wm: { ok: true, truncated: false, bindings: [
           triple(`urn:${contextGraphId}:wm-1`, `did:dkg:context-graph:${contextGraphId}/n/assertion/a/x-1`),
           triple(`urn:${contextGraphId}:wm-2`, `did:dkg:context-graph:${contextGraphId}/n/assertion/a/x-2`),
-        ] } }) } as Response;
-      }
-      // VM
-      return { ok: true, json: async () => ({ result: { bindings: [
-        triple(`urn:${contextGraphId}:vm-1`, `did:dkg:context-graph:${contextGraphId}`),
-      ] } }) } as Response;
+        ] },
+        swm: scenario === 'swm-error'
+          ? { ok: false, truncated: false, bindings: [] }
+          : { ok: true, truncated: true, bindings: [
+              triple(`urn:${contextGraphId}:swm-limited`, `did:dkg:context-graph:${contextGraphId}/n/_shared_memory`),
+            ] },
+        vm: { ok: true, truncated: false, bindings: [
+          triple(`urn:${contextGraphId}:vm-1`, `did:dkg:context-graph:${contextGraphId}`),
+        ] },
+      } }) } as Response;
     }));
   });
 
@@ -141,8 +119,6 @@ describe('useMemoryEntities — partial layer failure', () => {
     expect(el.getAttribute('data-vm-status')).toBe('ok');
     expect(el.getAttribute('data-swm')).toBe('1');
 
-    const queryBodies = vi.mocked(fetch).mock.calls
-      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { layerLimit?: number });
-    expect(queryBodies.every(body => body.layerLimit === undefined)).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Problem

Opening a UI surface backed by `useMemoryEntities` launched three concurrent whole-layer SPARQL reads. Each used `GRAPH ?g` plus URI filters and opted into every context-graph partition. The scoped query engine then injected the complete graph allow-list as `VALUES ?g`, producing very large queries and an Oxigraph `CartesianProductJoinIterator` plan.

On an actively publishing large context graph, `memory_graph_changed` SSE traffic retriggered those reads. Browser-side in-flight deduplication only lasted until the request settled, so a storage HTTP timeout allowed another refresh to start. The HTTP abort closed the client socket but did not interrupt the evaluation inside managed Oxigraph because `--timeout-s` was not set. The result was an accumulating server-side query storm and sustained multi-core CPU usage.

The subgraph-count route used the same broad `GRAPH ?g` shape, so it had the same scaling risk.

## Fix

- Add a daemon-owned memory-layer read model that discovers graph names through the graph-set index.
- Classify WM, SWM, and VM graph families in the daemon and read concrete graph IRIs in serial batches of at most eight UNION branches.
- Replace the three-query UI fan-out with one deduplicated endpoint request per context graph.
- Serialize hook refreshes and collapse any number of SSE events during an active read to one trailing refresh.
- Abort remaining server batches when the HTTP client disconnects.
- Replace the subgraph aggregate scan with exact-graph count batches.
- Ensure managed Oxigraph always receives a native query deadline before the HTTP client deadline. Defaults are now 25s native / 30s client; a 180s client configuration derives a 175s native deadline.

## Verification

- `pnpm exec vitest run --config vitest.unit.config.ts test/oxigraph-managed.test.ts test/context-graph-read-model.test.ts`
- `pnpm exec vitest run test/use-memory-entities-counts.test.ts test/use-memory-entities-partial.test.ts test/use-memory-entities-live-updates.test.ts test/ui-compat.test.ts`
- `pnpm --filter @origintrail-official/dkg-node-ui run build`
- `pnpm --filter @origintrail-official/dkg exec tsc --noEmit`
- The read-model regression suite executes the generated exact-graph UNION queries against a real in-memory Oxigraph store and asserts that no query contains `GRAPH ?g` or `VALUES`.

## Operational note

Existing managed nodes need a daemon restart after upgrading so Oxigraph is relaunched with the native timeout argument.