### PR TITLE
Merge main into testnet-canary

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1489,6 +1489,10 @@ export class PublishMethods extends DKGAgentBase {
     );
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(this.store, {
       publicSnapshotStore: this.publicSnapshotStore,
+      // #1836 — honor the operator's publisher.maxRetries on this admission path
+      // too (EPCIS / Kafka plugins publish through the agent, not the daemon
+      // control instance). Nullish → the publisher's built-in default.
+      maxRetries: this.config.publisherMaxRetries,
     });
     const captureID = await asyncPublisher.enqueueKnowledgeAssetVmPublish(intent);
     return { captureID };

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1108,6 +1108,13 @@ export interface DKGAgentConfig {
   largeLiteralStorage?: LargeLiteralStorageConfig;
   /** Out-of-Oxigraph immutable public SWM operation snapshots. Defaults on when dataDir is set. */
   sharedMemoryPublicSnapshotStorage?: SharedMemoryPublicSnapshotStorageConfig;
+  /**
+   * Max automatic-retry budget stamped onto async VM-publish jobs admitted
+   * through this agent's `publishAsync` (EPCIS / Kafka plugin paths). Mirrors
+   * the daemon's `publisher.maxRetries`. Nullish → the publisher's built-in
+   * default; `0` disables auto-retry. (#1836)
+   */
+  publisherMaxRetries?: number;
   importedArtifactByteStore?: ImportedArtifactByteStore;
   /** When false, peer-connect sync skips SWM catch-up and relies on gossip for new SWM writes. */
   syncSharedMemoryOnConnect?: boolean;

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -289,6 +289,33 @@ describe('publishJsonLd', () => {
     expect(result.status).toBe('confirmed');
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
+  it('stamps configured publisher.maxRetries onto agent publishAsync jobs (EPCIS/Kafka path, #1836)', async () => {
+    // #1836 — the agent's own publishAsync (used by the EPCIS/Kafka plugins) must
+    // stamp the operator-configured retry budget onto the queued job, not fall
+    // back to the publisher default. Reverting publishAsync to construct
+    // TripleStoreAsyncLiftPublisher without maxRetries makes this assert 10.
+    const { agent, store } = await createAgent('AsyncMaxRetriesBot', { publisherMaxRetries: 0 });
+    await agent.createContextGraph({ id: 'async-maxretries', name: 'AsyncMaxRetries', description: '' });
+    await agent.registerContextGraph('async-maxretries');
+
+    const { captureID } = await agent.publishAsync(
+      'did:dkg:context-graph:async-maxretries',
+      {
+        private: {
+          '@context': 'http://schema.org/',
+          '@id': 'http://example.org/AsyncMaxRetries',
+          '@type': 'Thing',
+          'name': 'Async MaxRetries',
+        },
+      },
+      { localOnly: true },
+    );
+
+    const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
+    const job = await asyncPublisher.getStatus(captureID);
+    expect(job?.retries.maxRetries).toBe(0);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
+
   it('async private-only JSON-LD enqueues one rootless KA with one non-root challenge anchor', async () => {
     const { agent, store } = await createAgent('AsyncPrivateOnlyBot');
     await agent.createContextGraph({ id: 'async-priv-only', name: 'AsyncPrivateOnly', description: '' });
@@ -320,6 +347,8 @@ describe('publishJsonLd', () => {
     expect(request.kaUal).toMatch(/^did:dkg:[^/]+\/0x[0-9a-f]{40}\/\d+$/);
     expect(request.accessPolicy).toBe('allowList');
     expect(request.allowedPeers).toEqual(['peer-a', 'peer-b']);
+    // #1836 — with publisherMaxRetries unset the agent path keeps the publisher default.
+    expect(job?.retries.maxRetries).toBe(10);
     // With a positive public challenge leaf the local queue may complete and
     // clean its mutable assertion lifecycle immediately. The immutable queued
     // request above is the durable contract; do not race cleanup by resolving

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1219,6 +1219,28 @@ export class ApiClient {
     return this.get(`/api/publisher/job-payload?id=${encodeURIComponent(jobId)}`);
   }
 
+  // #1828 — durable-admission recovery: look a VM-publish job up by the lifecycle
+  // facts the client retains (contextGraphId + name required). Read-only.
+  async publisherJobByIntent(facts: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+    agentAddress?: string;
+    intentKey?: string;
+  }): Promise<{
+    result: 'none' | 'active' | 'superseded' | 'conflict';
+    job?: any;
+    superseded?: any[];
+    jobs?: any[];
+    exactIntentMatch?: boolean;
+  }> {
+    const qs = new URLSearchParams({ contextGraphId: facts.contextGraphId, name: facts.name });
+    if (facts.subGraphName !== undefined) qs.set('subGraphName', facts.subGraphName);
+    if (facts.agentAddress !== undefined) qs.set('agentAddress', facts.agentAddress);
+    if (facts.intentKey !== undefined) qs.set('intentKey', facts.intentKey);
+    return this.get(`/api/publisher/job-by-intent?${qs.toString()}`);
+  }
+
   async publisherStats(): Promise<Record<string, number>> {
     return this.get('/api/publisher/stats');
   }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -149,6 +149,7 @@ import { createDaemonLogSink } from './log-sink.js';
 import { startRpcUsageTelemetry } from './rpc-usage-log.js';
 import { startDashboardLogVolumePruner } from './dashboard-log-volume-pruner.js';
 import { createInitialPublisherState, createPublicSnapshotStore, createPublisherControlFromStore, startPublisherRuntimeWithOutcome, type PublisherState } from '../publisher-runner.js';
+import { backfillVmPublishIntentIndexOnBoot } from './vm-publish-intent-backfill.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
 import {
   migrateLegacyContextGraphReadiness,
@@ -1964,6 +1965,12 @@ export async function runDaemonInner(
     // built-in default (10) even when publisher.maxRetries was configured (incl. 0).
     maxRetries: config.publisher?.maxRetries,
   });
+  // #1828 — one-time idempotent backfill of the durable-admission intent index
+  // for VM-publish jobs admitted before it existed. Additive-only (RDF set
+  // semantics), so it is safe here — before the runner starts — and fail-open so
+  // a backfill hiccup never blocks boot. Contract unit-tested in
+  // vm-publish-intent-backfill.test.ts.
+  await backfillVmPublishIntentIndexOnBoot(publisherControl, log);
   log(`Network: ${networkId.slice(0, 16)}...`);
   if (network) {
     log(

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1736,6 +1736,9 @@ export async function runDaemonInner(
     syncContextGraphPriorities: config.syncContextGraphPriorities,
     storageAckHandlerDeadlineMs: config.storageAckHandlerDeadlineMs,
     swmAwaitCuratorAck: config.swmAwaitCuratorAck,
+    // #1836 — forward the operator retry budget to the agent so its own
+    // publishAsync enqueue (EPCIS / Kafka) stamps publisher.maxRetries too.
+    publisherMaxRetries: config.publisher?.maxRetries,
     syncAgentsMeta: resolveSyncAgentsMeta(config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META),
     queryAccess: config.queryAccess,
     chainAdapter: mockChainAdapter,
@@ -1954,10 +1957,13 @@ export async function runDaemonInner(
   let promoteWorkerLifecycle: PromoteWorkerDaemonLifecycle | null = null;
   let shuttingDown = false;
 
-  const publisherControl = createPublisherControlFromStore(
-    agent.store,
-    createPublicSnapshotStore(dkgDir(), config),
-  );
+  const publisherControl = createPublisherControlFromStore(agent.store, {
+    publicSnapshotStore: createPublicSnapshotStore(dkgDir(), config),
+    // #1836 — the daemon admission instance MUST carry the operator's retry
+    // budget; without it every API-admitted VM-publish job was stamped with the
+    // built-in default (10) even when publisher.maxRetries was configured (incl. 0).
+    maxRetries: config.publisher?.maxRetries,
+  });
   log(`Network: ${networkId.slice(0, 16)}...`);
   if (network) {
     log(

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -193,6 +193,7 @@ import {
   safeParseJson,
   validateOptionalSubGraphName,
   validateRequiredContextGraphId,
+  normalizeContextGraphIdOrUri,
   validateEntities,
   validateConditions,
   MAX_BODY_BYTES,
@@ -389,6 +390,63 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
       });
     const payload = await publisherControl.inspectPreparedPayload(jobId);
     return jsonResponse(res, 200, { job, payload });
+  }
+
+  // GET /api/publisher/job-by-intent?contextGraphId=&name=&subGraphName=&agentAddress=&intentKey=
+  // #1828 — read-only durable-admission recovery, keyed on the lifecycle facts a
+  // client always retains (the lost 202 also loses jobId + intentKey). intentKey,
+  // when supplied, only qualifies exactIntentMatch. Never mutates.
+  if (req.method === "GET" && path === "/api/publisher/job-by-intent") {
+    const rawContextGraphId = url.searchParams.get("contextGraphId");
+    const name = url.searchParams.get("name") ?? undefined;
+    if (!rawContextGraphId || !name) {
+      return jsonResponse(res, 400, { error: "Missing required contextGraphId and name" });
+    }
+    const intentKey = url.searchParams.get("intentKey") ?? undefined;
+    if (intentKey !== undefined && !/^sha256:[0-9a-f]{64}$/.test(intentKey)) {
+      return jsonResponse(res, 400, { error: "Malformed intentKey" });
+    }
+    // Derive the lifecycle key from the SAME normalization admission persisted, or
+    // a client that retries with the exact facts it originally submitted gets a
+    // false result=none (#1828):
+    //  - contextGraphId: admission runs resolveRequiredWriteContextGraphId, which
+    //    trims and strips the did:dkg:context-graph: prefix before persisting.
+    //  - agentAddress: admission always persists a non-empty lane
+    //    (agentAddress ?? defaultAgentAddress ?? peerId); a recovering client rarely
+    //    retains it, so default to the caller's authenticated lane — resolved by the
+    //    identical chain (resolveAgentAddress) admission used — instead of the empty
+    //    lane, which would never match. An explicit query param still wins.
+    const contextGraphId = normalizeContextGraphIdOrUri(rawContextGraphId.trim());
+    // Admission rejects an empty subGraphName (validateOptionalSubGraphName): the
+    // root lane is addressed by OMITTING the param, not by an empty value. Reuse the
+    // same validator so an explicit `subGraphName=` is a 400 rather than silently
+    // aliasing the root job — knowledgeAssetVmPublishLifecycleKey collapses '' and
+    // undefined to the same lane (`subGraphName ?? ''`). #1828 review.
+    const rawSubGraphName = url.searchParams.get("subGraphName");
+    if (!validateOptionalSubGraphName(rawSubGraphName, res)) return;
+    const subGraphName = rawSubGraphName ?? undefined;
+    const explicitAgentAddress = url.searchParams.get("agentAddress")?.trim() || undefined;
+    const agentAddress = explicitAgentAddress ?? requestAgentAddress;
+    // The lifecycle key joins these facts with a U+001F control char (matching the
+    // promote-queue uniquenessKey), whose safety depends on no component carrying
+    // that delimiter. Reject C0 control chars on this public route so a crafted
+    // param cannot forge a colliding key. #1828.
+    const hasControlChar = (value: string | undefined): boolean =>
+      value !== undefined && /[\u0000-\u001F\u007F]/.test(value);
+    if ([contextGraphId, name, subGraphName, agentAddress].some(hasControlChar)) {
+      return jsonResponse(res, 400, {
+        error: "contextGraphId, name, subGraphName and agentAddress must not contain control characters",
+      });
+    }
+    const lookup = await publisherControl.lookupKnowledgeAssetVmPublishJobByIntent({
+      contextGraphId,
+      name,
+      subGraphName,
+      agentAddress,
+      intentKey,
+    });
+    const { kind, ...rest } = lookup;
+    return jsonResponse(res, 200, { result: kind, ...rest });
   }
 
   // Legacy: GET /api/publisher/jobs/:id and /api/publisher/jobs/:id/payload (bare response)

--- a/packages/cli/src/daemon/vm-publish-intent-backfill.ts
+++ b/packages/cli/src/daemon/vm-publish-intent-backfill.ts
@@ -1,0 +1,27 @@
+// #1828 — daemon-boot backfill of the durable-admission intent-recovery index.
+//
+// Extracted from `runDaemonInner` so the fail-open contract (a backfill error
+// must NEVER abort boot) and the count-logging behaviour are unit-testable
+// without driving the whole daemon-start path. Depends only on the narrow
+// VmPublishIntentIndexBackfiller maintenance interface (exported by the publisher
+// package), never on the runtime publisher contract.
+
+import type { VmPublishIntentIndexBackfiller } from '@origintrail-official/dkg-publisher';
+
+/**
+ * Run the one-time, additive intent-index backfill for VM-publish jobs admitted
+ * before the index existed. Additive insert (RDF set-semantics) means it is safe
+ * to run before the runner starts and cannot race in-flight writes. Fail-open:
+ * a backfill error is logged and swallowed so a hiccup never blocks boot.
+ */
+export async function backfillVmPublishIntentIndexOnBoot(
+  publisherControl: VmPublishIntentIndexBackfiller,
+  log: (message: string) => void,
+): Promise<void> {
+  try {
+    const indexed = await publisherControl.ensureVmPublishIntentIndex();
+    if (indexed > 0) log(`Publisher: backfilled intent-recovery index for ${indexed} job(s)`);
+  } catch (err) {
+    log(`Publisher: intent-index backfill skipped (${(err as Error)?.message ?? String(err)})`);
+  }
+}

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -30,6 +30,8 @@ import {
   type AsyncLiftPublisher,
   type AsyncLiftPublisherConfig,
   type AsyncLiftPublisherRecoveryResult,
+  type VmPublishIntentRecoveryPublisher,
+  type VmPublishIntentIndexBackfiller,
   type LiftJobBroadcast,
   type LiftJobHex,
   type LiftJobIncluded,
@@ -369,7 +371,10 @@ export function createPublisherInspectorFromStore(
 export function createPublisherControlFromStore(
   store: TripleStore,
   options: { publicSnapshotStore?: WorkspacePublicSnapshotStore; maxRetries?: number } = {},
-): AsyncLiftPublisher {
+): VmPublishIntentRecoveryPublisher & VmPublishIntentIndexBackfiller {
+  // The daemon admission instance also serves the #1828 recovery lookup (route)
+  // and the boot index backfill — segregated capabilities the base
+  // AsyncLiftPublisher runtime contract intentionally does NOT carry.
   return new TripleStoreAsyncLiftPublisher(store, {
     publicSnapshotStore: options.publicSnapshotStore,
     maxRetries: options.maxRetries,

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -368,9 +368,12 @@ export function createPublisherInspectorFromStore(
 
 export function createPublisherControlFromStore(
   store: TripleStore,
-  publicSnapshotStore?: WorkspacePublicSnapshotStore,
+  options: { publicSnapshotStore?: WorkspacePublicSnapshotStore; maxRetries?: number } = {},
 ): AsyncLiftPublisher {
-  return new TripleStoreAsyncLiftPublisher(store, { publicSnapshotStore });
+  return new TripleStoreAsyncLiftPublisher(store, {
+    publicSnapshotStore: options.publicSnapshotStore,
+    maxRetries: options.maxRetries,
+  });
 }
 
 export async function createPublisherRuntimeFromAgent(args: {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -370,6 +370,46 @@ describe('ApiClient', () => {
       expect(url).toContain('contextType=review');
       expect(url).toContain('includeBody=true');
     });
+
+    // #1828 (otReviewAgent): the recovery-lookup client wrapper is the public
+    // surface callers use — assert endpoint spelling, param encoding, optional
+    // forwarding, and response passthrough at the client boundary.
+    it('publisherJobByIntent() GETs /api/publisher/job-by-intent with all facts encoded', async () => {
+      const body = { result: 'active', job: { jobId: 'job-1' }, superseded: [] };
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
+      globalThis.fetch = fetch;
+
+      const result = await client.publisherJobByIntent({
+        contextGraphId: 'music social',
+        name: 'albums/2026',
+        subGraphName: 'research',
+        agentAddress: '0x1111111111111111111111111111111111111111',
+        intentKey: `sha256:${'ab'.repeat(32)}`,
+      });
+
+      expect(result).toEqual(body);
+      expect(calls).toHaveLength(1);
+      const url = calls[0].url;
+      expect(url.startsWith(`http://127.0.0.1:${PORT}/api/publisher/job-by-intent?`)).toBe(true);
+      expect(url).toContain('contextGraphId=music+social');
+      expect(url).toContain('name=albums%2F2026');
+      expect(url).toContain('subGraphName=research');
+      expect(url).toContain('agentAddress=0x1111111111111111111111111111111111111111');
+      expect(url).toContain(`intentKey=sha256%3A${'ab'.repeat(32)}`);
+    });
+
+    it('publisherJobByIntent() omits optional facts when not provided', async () => {
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body: { result: 'none' } });
+      globalThis.fetch = fetch;
+      await client.publisherJobByIntent({ contextGraphId: 'cg', name: 'albums' });
+
+      const url = calls[0].url;
+      expect(url).toContain('contextGraphId=cg');
+      expect(url).toContain('name=albums');
+      expect(url).not.toContain('subGraphName=');
+      expect(url).not.toContain('agentAddress=');
+      expect(url).not.toContain('intentKey=');
+    });
   });
 
   describe('PUT endpoints', () => {

--- a/packages/cli/test/publisher-backfill-wiring-1828.test.ts
+++ b/packages/cli/test/publisher-backfill-wiring-1828.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// GH #1828 — regression at the daemon-boot WIRING point. The durable-admission
+// intent index only repairs pre-index jobs if runDaemonInner actually calls the
+// backfill on boot. The helper's own contract is unit-tested in
+// vm-publish-intent-backfill.test.ts, but a helper-only test stays green if the
+// boot call (lifecycle.ts) is deleted or moved out of the boot path. This drives
+// runDaemonInner and proves backfillVmPublishIntentIndexOnBoot is invoked with the
+// admission publisher control that createPublisherControlFromStore returns.
+// (Mirrors the #1836 config→construction wiring test.)
+const mocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  chainResetWipe: vi.fn(),
+  createServer: vi.fn(),
+  loadOpWallets: vi.fn(),
+  loadNetworkConfig: vi.fn(),
+  startPublisherRuntimeWithOutcome: vi.fn(),
+  createPublisherControlFromStore: vi.fn(),
+  backfillOnBoot: vi.fn(),
+}));
+
+vi.mock('node:http', () => ({ createServer: mocks.createServer }));
+
+vi.mock('@origintrail-official/dkg-agent', async importOriginal => {
+  const actual = await importOriginal<typeof import('@origintrail-official/dkg-agent')>();
+  return {
+    ...actual,
+    DKGAgent: { create: mocks.agentCreate },
+    loadOpWallets: mocks.loadOpWallets,
+    KaNumberAllocator: class KaNumberAllocator {},
+  };
+});
+
+vi.mock('../src/config.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/config.js')>();
+  return { ...actual, loadNetworkConfig: mocks.loadNetworkConfig };
+});
+
+vi.mock('../src/daemon/chain-reset-wipe.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/daemon/chain-reset-wipe.js')>();
+  return { ...actual, chainResetWipe: mocks.chainResetWipe };
+});
+
+vi.mock('../src/publisher-runner.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/publisher-runner.js')>();
+  return {
+    ...actual,
+    startPublisherRuntimeWithOutcome: mocks.startPublisherRuntimeWithOutcome,
+    createPublisherControlFromStore: mocks.createPublisherControlFromStore,
+  };
+});
+
+vi.mock('../src/daemon/vm-publish-intent-backfill.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/daemon/vm-publish-intent-backfill.js')>();
+  return { ...actual, backfillVmPublishIntentIndexOnBoot: mocks.backfillOnBoot };
+});
+
+const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
+
+function createFakeServer() {
+  const server = {
+    listen: vi.fn((_port: number, _host: string, cb?: () => void) => { cb?.(); return server; }),
+    address: vi.fn(() => ({ port: 43123 })),
+    close: vi.fn((cb?: () => void) => { cb?.(); return server; }),
+    on: vi.fn(() => server),
+    once: vi.fn(() => server),
+  };
+  return server;
+}
+
+function closeDashboardDbFromAgentCreateArg(createArg: any): void {
+  const db =
+    createArg?.chainEventCursorStore?.cursors?.db ??
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+  db?.close?.();
+}
+
+describe('runDaemonInner VM-publish intent backfill wiring (#1828)', () => {
+  let tempHome: string | undefined;
+  let originalDkgHome: string | undefined;
+  let uncaughtExceptionListeners: NodeJS.UncaughtExceptionListener[] = [];
+  let unhandledRejectionListeners: NodeJS.UnhandledRejectionListener[] = [];
+  let sigintListeners: NodeJS.SignalsListener[] = [];
+  let sigtermListeners: NodeJS.SignalsListener[] = [];
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-backfill-wiring-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+    sigintListeners = process.listeners('SIGINT') as NodeJS.SignalsListener[];
+    sigtermListeners = process.listeners('SIGTERM') as NodeJS.SignalsListener[];
+
+    mocks.createServer.mockImplementation(createFakeServer);
+    mocks.startPublisherRuntimeWithOutcome.mockResolvedValue({
+      runtime: null,
+      availability: { available: false, reason: 'no_publisher_wallets', retryable: false, operatorActionRequired: true },
+    });
+    mocks.loadNetworkConfig.mockResolvedValue({
+      networkName: 'DKG V10 Gnosis Mainnet',
+      genesisId: 'gnosis-mainnet',
+      genesisVersion: 1,
+      relays: ['/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M'],
+      defaultNodeRole: 'core',
+    });
+    mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
+    mocks.chainResetWipe.mockResolvedValue({
+      wiped: false, skipped: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [],
+    });
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    process.removeAllListeners('uncaughtException');
+    for (const l of uncaughtExceptionListeners) process.on('uncaughtException', l);
+    process.removeAllListeners('unhandledRejection');
+    for (const l of unhandledRejectionListeners) process.on('unhandledRejection', l);
+    process.removeAllListeners('SIGINT');
+    for (const l of sigintListeners) process.on('SIGINT', l);
+    process.removeAllListeners('SIGTERM');
+    for (const l of sigtermListeners) process.on('SIGTERM', l);
+    if (originalDkgHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = originalDkgHome;
+    if (tempHome) await rm(tempHome, { recursive: true, force: true });
+    tempHome = undefined;
+  });
+
+  it('invokes backfillVmPublishIntentIndexOnBoot with the admission publisher control on boot', async () => {
+    const fakeAgent = {
+      peerId: 'self-peer',
+      multiaddrs: [],
+      wallet: { keypair: { publicKey: new Uint8Array([1]), secretKey: new Uint8Array([2]) } },
+      store: {},
+      node: { libp2p: { getMultiaddrs: vi.fn(() => []) } },
+      eventBus: { on: vi.fn() },
+      assertion: { create: vi.fn(), write: vi.fn() },
+      setChatAcl: vi.fn(),
+      setSkillAcl: vi.fn(),
+      onChat: vi.fn(),
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      publishProfile: vi.fn(async () => undefined),
+      publishRelayRegistry: vi.fn(async () => undefined),
+      ensureContextGraphLocal: vi.fn(async () => undefined),
+      getSubscribedContextGraphs: vi.fn(() => new Map()),
+      subscribeToContextGraph: vi.fn(),
+      pingPeers: vi.fn(async () => undefined),
+      listLocalAgents: vi.fn(() => []),
+      registerImportedArtifactByteStore: vi.fn(),
+      getDefaultAgentAddress: vi.fn(() => undefined),
+      query: vi.fn(async () => ({ type: 'bindings', bindings: [] })),
+      createContextGraph: vi.fn(),
+      listContextGraphs: vi.fn(async () => []),
+      drainRpcUsage: vi.fn(() => ({ calls: 0, errors: 0, throttledMs: 0, byEndpoint: {} })),
+    };
+    mocks.agentCreate.mockResolvedValue(fakeAgent);
+    // createPublisherControlFromStore returns the admission control; boot then reaches
+    // the backfill call on the very next statement (lifecycle.ts). Make the backfill
+    // reject to stop boot cleanly right there so the rest of startup isn't faked.
+    const fakeControl = { __brand: 'publisher-control' };
+    mocks.createPublisherControlFromStore.mockReturnValue(fakeControl as never);
+    mocks.backfillOnBoot.mockRejectedValue(new Error('after-backfill'));
+
+    await expect(runDaemonInner(true, {
+      name: 'backfill-wiring-test',
+      networkConfig: 'mainnet-gnosis',
+      listenPort: 0,
+      apiPort: 0,
+      nodeRole: 'edge',
+      auth: { enabled: false },
+      promoteQueue: { enabled: false },
+      source: 'monorepo',
+      publisher: { enabled: true },
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
+    } as any, Date.now())).rejects.toThrow('after-backfill');
+
+    closeDashboardDbFromAgentCreateArg(mocks.agentCreate.mock.calls[0]?.[0]);
+    // The boot path actually called the backfill (delete the call → this fails)...
+    expect(mocks.backfillOnBoot).toHaveBeenCalledTimes(1);
+    // ...with the SAME control createPublisherControlFromStore built (the wiring).
+    const [controlArg] = mocks.backfillOnBoot.mock.calls[0] as [unknown, unknown];
+    expect(controlArg).toBe(fakeControl);
+  });
+});

--- a/packages/cli/test/publisher-job-by-intent-route.test.ts
+++ b/packages/cli/test/publisher-job-by-intent-route.test.ts
@@ -1,0 +1,260 @@
+import type { ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import { afterEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { createPublisherControlFromStore } from '../src/publisher-runner.js';
+import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+// #1828 — GET /api/publisher/job-by-intent route: read-only durable-admission
+// recovery keyed on the lifecycle facts the client retains.
+describe('#1828 GET /api/publisher/job-by-intent', () => {
+  const stores: OxigraphStore[] = [];
+  afterEach(async () => {
+    await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {})));
+  });
+
+  function kaVmPublishRequest(overrides: Record<string, unknown> = {}) {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
+    return {
+      contextGraphId: 'music-social',
+      name: 'albums',
+      // Admission always persists a non-empty agent lane; the default here mirrors
+      // the ctx.requestAgentAddress the route falls back to, so the lifecycle key
+      // matches on both write and lookup (as it does in production).
+      agentAddress: '0x0',
+      shareOperationId: 'share-op-1',
+      roots: [] as string[],
+      contentScopeVersion: 2 as const,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+      seal: {
+        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+        authorAddress: authorAddress as `0x${string}`,
+        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
+        schemeVersion: 1,
+        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
+      },
+      sealChainId: '31337' as `${bigint}`,
+      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      intentKey: `sha256:${'ab'.repeat(32)}`,
+      wmCurrentAssertion: '12'.repeat(32),
+      swmCurrentAssertion: '12'.repeat(32),
+      kaNumber: kaNumber.toString(),
+      reservedUal: kaUal,
+      ...overrides,
+    };
+  }
+
+  async function newControlWithJob(
+    overrides: Record<string, unknown> = {},
+  ): Promise<{ control: ReturnType<typeof createPublisherControlFromStore>; jobId: string }> {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const control = createPublisherControlFromStore(store);
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest(overrides));
+    return { control, jobId };
+  }
+
+  it('recovers the active job by lifecycle facts (200 result=active)', async () => {
+    const { control, jobId } = await newControlWithJob();
+    const ctx = createContext('/api/publisher/job-by-intent?contextGraphId=music-social&name=albums', control);
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(200);
+    const body = responseBody(ctx) as { result: string; job?: { jobId: string }; superseded?: unknown[] };
+    expect(body.result).toBe('active');
+    expect(body.job?.jobId).toBe(jobId);
+    expect(body.superseded).toEqual([]);
+  });
+
+  it('returns result=none for unknown facts', async () => {
+    const { control } = await newControlWithJob();
+    const ctx = createContext('/api/publisher/job-by-intent?contextGraphId=music-social&name=missing', control);
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(200);
+    expect((responseBody(ctx) as { result: string }).result).toBe('none');
+  });
+
+  it('400s when required facts are missing', async () => {
+    const { control } = await newControlWithJob();
+    const ctx = createContext('/api/publisher/job-by-intent?contextGraphId=music-social', control);
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(400);
+  });
+
+  it('400s on a malformed intentKey', async () => {
+    const { control } = await newControlWithJob();
+    const ctx = createContext('/api/publisher/job-by-intent?contextGraphId=music-social&name=albums&intentKey=not-a-hash', control);
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(400);
+  });
+
+  // #1828 (otReviewAgent): the lifecycle key joins facts with U+001F, so a fact
+  // carrying that delimiter could forge a colliding key on this public route.
+  it('400s when a fact carries a control character (U+001F key-delimiter)', async () => {
+    const { control } = await newControlWithJob();
+    const ctx = createContext(
+      '/api/publisher/job-by-intent?contextGraphId=music-social&name=al%1Fbums',
+      control,
+    );
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(400);
+  });
+
+  // #1828 (otReviewAgent): admission indexes under a non-empty agent lane, and a
+  // recovering client rarely retains agentAddress. The route must default the
+  // omitted lane to the caller's authenticated agent (the same resolver admission
+  // used), not the empty lane, or the job is invisible.
+  it('defaults an omitted agentAddress to the caller lane so an agent-scoped job is still found', async () => {
+    const agentLane = `0x${'ab'.repeat(20)}`;
+    const { control, jobId } = await newControlWithJob({ agentAddress: agentLane });
+
+    // Same lane, agentAddress omitted -> recovered via the caller-lane default.
+    const ctx = createContext('/api/publisher/job-by-intent?contextGraphId=music-social&name=albums', control, agentLane);
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(200);
+    const body = responseBody(ctx) as { result: string; job?: { jobId: string } };
+    expect(body.result).toBe('active');
+    expect(body.job?.jobId).toBe(jobId);
+
+    // A different caller lane (still omitting agentAddress) must NOT see it —
+    // proves the defaulted lane is actually applied to the lookup key.
+    const otherCtx = createContext('/api/publisher/job-by-intent?contextGraphId=music-social&name=albums', control, `0x${'cd'.repeat(20)}`);
+    await handlePublisherRoutes(otherCtx);
+    expect((responseBody(otherCtx) as { result: string }).result).toBe('none');
+  });
+
+  // #1828 (zsculac): admission normalizes contextGraphId (trim + strip the
+  // did:dkg:context-graph: prefix) before persisting, so recovery must apply the
+  // same normalization or the URI form the client submitted returns a false none.
+  it('normalizes a did:dkg:context-graph URI contextGraphId to the persisted bare id', async () => {
+    const { control, jobId } = await newControlWithJob();
+    const ctx = createContext(
+      '/api/publisher/job-by-intent?contextGraphId=did%3Adkg%3Acontext-graph%3Amusic-social&name=albums',
+      control,
+    );
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(200);
+    const body = responseBody(ctx) as { result: string; job?: { jobId: string } };
+    expect(body.result).toBe('active');
+    expect(body.job?.jobId).toBe(jobId);
+  });
+
+  // #1828 (otReviewAgent): subGraphName is part of the recovery identity, so the
+  // route must forward it and recover only the matching lane.
+  it('respects subGraphName as part of the recovery identity', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const control = createPublisherControlFromStore(store);
+    const research = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ subGraphName: 'research' }));
+    await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ subGraphName: 'production' }));
+
+    const ctx = createContext(
+      '/api/publisher/job-by-intent?contextGraphId=music-social&name=albums&subGraphName=research',
+      control,
+    );
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(200);
+    const body = responseBody(ctx) as { result: string; job?: { jobId: string } };
+    expect(body.result).toBe('active');
+    expect(body.job?.jobId).toBe(research);
+  });
+
+  // #1828 (otReviewAgent + branarakic): admission rejects an empty subGraphName
+  // (validateOptionalSubGraphName), and the lifecycle key collapses '' and undefined
+  // to the same root lane (`subGraphName ?? ''`). An explicit `subGraphName=` must be
+  // a 400 — not silently alias and recover the root job.
+  it('400s on an explicit empty subGraphName (does not alias the root job)', async () => {
+    const { control, jobId } = await newControlWithJob(); // root-lane job (no subGraphName)
+    const ctx = createContext(
+      '/api/publisher/job-by-intent?contextGraphId=music-social&name=albums&subGraphName=',
+      control,
+    );
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(400);
+
+    // Sanity: the same facts WITHOUT the empty param recover the root job, proving
+    // the 400 is specifically the empty-string guard, not a facts mismatch.
+    const ok = createContext('/api/publisher/job-by-intent?contextGraphId=music-social&name=albums', control);
+    await handlePublisherRoutes(ok);
+    expect(responseStatus(ok)).toBe(200);
+    expect((responseBody(ok) as { result: string; job?: { jobId: string } }).job?.jobId).toBe(jobId);
+  });
+});
+
+function createContext(
+  path: string,
+  publisherControl: RequestContext['publisherControl'],
+  requestAgentAddress = '0x0',
+): RequestContext {
+  const url = new URL(`http://127.0.0.1${path}`);
+  const req = Readable.from([]);
+  Object.assign(req, { method: 'GET', url: path, headers: { host: '127.0.0.1' } });
+  return {
+    req: req as RequestContext['req'],
+    res: createResponse() as unknown as ServerResponse,
+    agent: {} as RequestContext['agent'],
+    publisherControl,
+    publisherState: {
+      runtime: null,
+      availability: { available: false, reason: 'publisher_disabled', retryable: false, operatorActionRequired: true },
+    },
+    config: {} as RequestContext['config'],
+    startedAt: 0,
+    dashDb: {} as RequestContext['dashDb'],
+    opWallets: { adminWallet: { address: '0x0', privateKey: '0x0' }, wallets: [] } as RequestContext['opWallets'],
+    network: null as RequestContext['network'],
+    tracker: {} as RequestContext['tracker'],
+    memoryManager: {} as RequestContext['memoryManager'],
+    bridgeAuthToken: undefined,
+    nodeVersion: 'test',
+    nodeCommit: 'test',
+    catchupTracker: {} as RequestContext['catchupTracker'],
+    extractionRegistry: {} as RequestContext['extractionRegistry'],
+    fileStore: {} as RequestContext['fileStore'],
+    extractionStatus: new Map(),
+    assertionImportLocks: new Map(),
+    vectorStore: {} as RequestContext['vectorStore'],
+    embeddingProvider: null,
+    validTokens: new Set(),
+    apiHost: '127.0.0.1',
+    apiPortRef: { value: 0 },
+    url,
+    path: url.pathname,
+    requestToken: undefined,
+    requestAgentAddress,
+  };
+}
+
+function createResponse() {
+  return {
+    statusCode: 0,
+    headers: undefined as Record<string, string> | undefined,
+    body: '',
+    writableEnded: false,
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+      return this;
+    },
+    end(body?: string) {
+      this.body = body ?? '';
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+function responseStatus(ctx: RequestContext): number {
+  return (ctx.res as unknown as { statusCode: number }).statusCode;
+}
+
+function responseBody(ctx: RequestContext): Record<string, unknown> {
+  return JSON.parse((ctx.res as unknown as { body: string }).body) as Record<string, unknown>;
+}

--- a/packages/cli/test/publisher-maxretries-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-1836.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { createPublisherControlFromStore } from '../src/publisher-runner.js';
+
+// GH #1836 — this suite proves the DESERIALIZATION half of the fix: a configured
+// maxRetries (including a literal 0) that reaches createPublisherControlFromStore
+// is stamped onto the admitted job and survives the constructor's
+// `?? DEFAULT_MAX_RETRIES` guard + the JSON serialize→readJob round-trip.
+// The CONFIG→CONSTRUCTION wiring (that runDaemonInner actually forwards
+// config.publisher.maxRetries into this helper and into DKGAgent.create) is
+// covered separately in publisher-maxretries-wiring-1836.test.ts, so neither
+// half can regress silently.
+
+describe('#1836 publisher.maxRetries round-trips through createPublisherControlFromStore', () => {
+  const stores: OxigraphStore[] = [];
+
+  afterEach(async () => {
+    await Promise.all(stores.splice(0).map((store) => store.close().catch(() => {})));
+  });
+
+  function newStore(): OxigraphStore {
+    const store = new OxigraphStore();
+    stores.push(store);
+    return store;
+  }
+
+  // Minimal, well-formed graph-scoped VM-publish intent (mirrors the shape used
+  // by the publisher package's broadcast-progress suite).
+  function kaVmPublishRequest() {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
+    return {
+      contextGraphId: 'music-social',
+      name: 'albums',
+      shareOperationId: 'share-op-1',
+      roots: [] as string[],
+      contentScopeVersion: 2 as const,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+      seal: {
+        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+        authorAddress: authorAddress as `0x${string}`,
+        signature: {
+          r: (`0x${'34'.repeat(32)}`) as `0x${string}`,
+          vs: (`0x${'56'.repeat(32)}`) as `0x${string}`,
+        },
+        schemeVersion: 1,
+        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
+      },
+      sealChainId: '31337' as `${bigint}`,
+      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      intentKey: `sha256:${'ab'.repeat(32)}`,
+      wmCurrentAssertion: '12'.repeat(32),
+      swmCurrentAssertion: '12'.repeat(32),
+      kaNumber: kaNumber.toString(),
+      reservedUal: kaUal,
+    };
+  }
+
+  it('stamps a configured literal 0 (never the default) onto admitted jobs', async () => {
+    const control = createPublisherControlFromStore(newStore(), { maxRetries: 0 });
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const job = await control.getStatus(jobId);
+    expect(job?.retries.maxRetries).toBe(0);
+  });
+
+  it('preserves the built-in default (10) when maxRetries is omitted', async () => {
+    const control = createPublisherControlFromStore(newStore());
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const job = await control.getStatus(jobId);
+    expect(job?.retries.maxRetries).toBe(10);
+  });
+
+  it('propagates an arbitrary configured budget', async () => {
+    const control = createPublisherControlFromStore(newStore(), { maxRetries: 3 });
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const job = await control.getStatus(jobId);
+    expect(job?.retries.maxRetries).toBe(3);
+  });
+});

--- a/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// GH #1836 — regression at the CONFIG→CONSTRUCTION seam. The original bug was
+// that daemon config was not forwarded into the admission-time publisher, so a
+// helper-only test cannot protect it. These tests drive runDaemonInner and prove
+// config.publisher.maxRetries reaches BOTH admission constructors:
+//   • DKGAgent.create (publisherMaxRetries → agent publishAsync: EPCIS/Kafka), and
+//   • createPublisherControlFromStore (daemon HTTP admission — the reported bug).
+// Removing either forwarding makes one of these fail.
+const mocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  chainResetWipe: vi.fn(),
+  createServer: vi.fn(),
+  loadOpWallets: vi.fn(),
+  loadNetworkConfig: vi.fn(),
+  startPublisherRuntimeWithOutcome: vi.fn(),
+  createPublisherControlFromStore: vi.fn(),
+}));
+
+vi.mock('node:http', () => ({ createServer: mocks.createServer }));
+
+vi.mock('@origintrail-official/dkg-agent', async importOriginal => {
+  const actual = await importOriginal<typeof import('@origintrail-official/dkg-agent')>();
+  return {
+    ...actual,
+    DKGAgent: { create: mocks.agentCreate },
+    loadOpWallets: mocks.loadOpWallets,
+    KaNumberAllocator: class KaNumberAllocator {},
+  };
+});
+
+vi.mock('../src/config.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/config.js')>();
+  return { ...actual, loadNetworkConfig: mocks.loadNetworkConfig };
+});
+
+vi.mock('../src/daemon/chain-reset-wipe.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/daemon/chain-reset-wipe.js')>();
+  return { ...actual, chainResetWipe: mocks.chainResetWipe };
+});
+
+vi.mock('../src/publisher-runner.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/publisher-runner.js')>();
+  return {
+    ...actual,
+    startPublisherRuntimeWithOutcome: mocks.startPublisherRuntimeWithOutcome,
+    createPublisherControlFromStore: mocks.createPublisherControlFromStore,
+  };
+});
+
+const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
+
+function createFakeServer() {
+  const server = {
+    listen: vi.fn((_port: number, _host: string, cb?: () => void) => { cb?.(); return server; }),
+    address: vi.fn(() => ({ port: 43123 })),
+    close: vi.fn((cb?: () => void) => { cb?.(); return server; }),
+    on: vi.fn(() => server),
+    once: vi.fn(() => server),
+  };
+  return server;
+}
+
+function closeDashboardDbFromAgentCreateArg(createArg: any): void {
+  const db =
+    createArg?.chainEventCursorStore?.cursors?.db ??
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+  db?.close?.();
+}
+
+describe('runDaemonInner publisher.maxRetries wiring (#1836)', () => {
+  let tempHome: string | undefined;
+  let originalDkgHome: string | undefined;
+  let uncaughtExceptionListeners: NodeJS.UncaughtExceptionListener[] = [];
+  let unhandledRejectionListeners: NodeJS.UnhandledRejectionListener[] = [];
+  let sigintListeners: NodeJS.SignalsListener[] = [];
+  let sigtermListeners: NodeJS.SignalsListener[] = [];
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-maxretries-wiring-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+    sigintListeners = process.listeners('SIGINT') as NodeJS.SignalsListener[];
+    sigtermListeners = process.listeners('SIGTERM') as NodeJS.SignalsListener[];
+
+    mocks.createServer.mockImplementation(createFakeServer);
+    mocks.startPublisherRuntimeWithOutcome.mockResolvedValue({
+      runtime: null,
+      availability: { available: false, reason: 'no_publisher_wallets', retryable: false, operatorActionRequired: true },
+    });
+    mocks.loadNetworkConfig.mockResolvedValue({
+      networkName: 'DKG V10 Gnosis Mainnet',
+      genesisId: 'gnosis-mainnet',
+      genesisVersion: 1,
+      relays: ['/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M'],
+      defaultNodeRole: 'core',
+    });
+    mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
+    mocks.chainResetWipe.mockResolvedValue({
+      wiped: false, skipped: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [],
+    });
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    process.removeAllListeners('uncaughtException');
+    for (const l of uncaughtExceptionListeners) process.on('uncaughtException', l);
+    process.removeAllListeners('unhandledRejection');
+    for (const l of unhandledRejectionListeners) process.on('unhandledRejection', l);
+    process.removeAllListeners('SIGINT');
+    for (const l of sigintListeners) process.on('SIGINT', l);
+    process.removeAllListeners('SIGTERM');
+    for (const l of sigtermListeners) process.on('SIGTERM', l);
+    if (originalDkgHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = originalDkgHome;
+    if (tempHome) await rm(tempHome, { recursive: true, force: true });
+    tempHome = undefined;
+  });
+
+  // agentCreate rejects → runDaemonInner throws right after DKGAgent.create, so we
+  // capture the exact create arg (the DKGAgent.create forwarding).
+  async function captureCreateArg(configOverrides: Record<string, unknown> = {}): Promise<any> {
+    mocks.agentCreate.mockRejectedValue(new Error('after-agent-create'));
+    await expect(runDaemonInner(true, {
+      name: 'maxretries-wiring-core-test',
+      networkConfig: 'mainnet-gnosis',
+      listenPort: 0,
+      nodeRole: 'core',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
+      ...configOverrides,
+    } as any, Date.now())).rejects.toThrow('after-agent-create');
+    expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
+    const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
+    closeDashboardDbFromAgentCreateArg(createArg);
+    return createArg;
+  }
+
+  it('forwards config.publisher.maxRetries (incl. 0) into DKGAgent.create as publisherMaxRetries', async () => {
+    const createArg = await captureCreateArg({ publisher: { enabled: true, maxRetries: 0 } });
+    expect(createArg.publisherMaxRetries).toBe(0);
+  });
+
+  it('leaves publisherMaxRetries undefined when unconfigured (publisher default preserved)', async () => {
+    const createArg = await captureCreateArg();
+    expect(createArg.publisherMaxRetries).toBeUndefined();
+  });
+
+  it('forwards config.publisher.maxRetries into createPublisherControlFromStore (daemon HTTP admission)', async () => {
+    const fakeAgent = {
+      peerId: 'self-peer',
+      multiaddrs: [],
+      wallet: { keypair: { publicKey: new Uint8Array([1]), secretKey: new Uint8Array([2]) } },
+      store: {},
+      node: { libp2p: { getMultiaddrs: vi.fn(() => []) } },
+      eventBus: { on: vi.fn() },
+      assertion: { create: vi.fn(), write: vi.fn() },
+      setChatAcl: vi.fn(),
+      setSkillAcl: vi.fn(),
+      onChat: vi.fn(),
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      publishProfile: vi.fn(async () => undefined),
+      publishRelayRegistry: vi.fn(async () => undefined),
+      ensureContextGraphLocal: vi.fn(async () => undefined),
+      getSubscribedContextGraphs: vi.fn(() => new Map()),
+      subscribeToContextGraph: vi.fn(),
+      pingPeers: vi.fn(async () => undefined),
+      listLocalAgents: vi.fn(() => []),
+      registerImportedArtifactByteStore: vi.fn(),
+      getDefaultAgentAddress: vi.fn(() => undefined),
+      query: vi.fn(async () => ({ type: 'bindings', bindings: [] })),
+      createContextGraph: vi.fn(),
+      listContextGraphs: vi.fn(async () => []),
+      drainRpcUsage: vi.fn(() => ({ calls: 0, errors: 0, throttledMs: 0, byEndpoint: {} })),
+    };
+    mocks.agentCreate.mockResolvedValue(fakeAgent);
+    // Record the admission-construction args, then stop the boot cleanly right at
+    // that call so the rest of daemon startup does not need to be faked.
+    mocks.createPublisherControlFromStore.mockImplementation(() => {
+      throw new Error('after-publisher-control');
+    });
+
+    await expect(runDaemonInner(true, {
+      name: 'maxretries-wiring-admission-test',
+      networkConfig: 'mainnet-gnosis',
+      listenPort: 0,
+      apiPort: 0,
+      nodeRole: 'edge',
+      auth: { enabled: false },
+      promoteQueue: { enabled: false },
+      source: 'monorepo',
+      publisher: { enabled: true, maxRetries: 0 },
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
+    } as any, Date.now())).rejects.toThrow('after-publisher-control');
+
+    closeDashboardDbFromAgentCreateArg(mocks.agentCreate.mock.calls[0]?.[0]);
+    expect(mocks.createPublisherControlFromStore).toHaveBeenCalledTimes(1);
+    const [store, options] = mocks.createPublisherControlFromStore.mock.calls[0] as [unknown, { maxRetries?: number }];
+    expect(store).toBe(fakeAgent.store);
+    expect(options.maxRetries).toBe(0);
+  });
+});

--- a/packages/cli/test/publisher-route-snapshot.test.ts
+++ b/packages/cli/test/publisher-route-snapshot.test.ts
@@ -45,7 +45,7 @@ describe('publisher routes with disk public snapshot refs', () => {
       { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Route Snapshot"', graph: '' },
     ], { publisherPeerId: 'peer-route' });
 
-    const publisherControl = createPublisherControlFromStore(store, publicSnapshotStore);
+    const publisherControl = createPublisherControlFromStore(store, { publicSnapshotStore });
     const jobId = await seedLegacyRawLiftTestJob(store, {
       contextGraphId: CONTEXT_GRAPH,
       swmId: write.shareOperationId,

--- a/packages/cli/test/vm-publish-intent-backfill.test.ts
+++ b/packages/cli/test/vm-publish-intent-backfill.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { backfillVmPublishIntentIndexOnBoot } from '../src/daemon/vm-publish-intent-backfill.js';
+
+// #1828 — daemon-boot wiring for the intent-index backfill. The engine test
+// (packages/publisher) covers ensureVmPublishIntentIndex itself; this locks the
+// boot-side contract that runDaemonInner depends on: the backfill is invoked,
+// its count is surfaced, and — critically — a thrown error is swallowed so a
+// backfill hiccup can never abort daemon boot.
+describe('#1828 backfillVmPublishIntentIndexOnBoot', () => {
+  it('invokes ensureVmPublishIntentIndex once and logs the count when > 0', async () => {
+    const ensureVmPublishIntentIndex = vi.fn().mockResolvedValue(3);
+    const logs: string[] = [];
+    await backfillVmPublishIntentIndexOnBoot({ ensureVmPublishIntentIndex }, (m) => logs.push(m));
+    expect(ensureVmPublishIntentIndex).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual(['Publisher: backfilled intent-recovery index for 3 job(s)']);
+  });
+
+  it('invokes the backfill but stays quiet when there is nothing to index', async () => {
+    const ensureVmPublishIntentIndex = vi.fn().mockResolvedValue(0);
+    const logs: string[] = [];
+    await backfillVmPublishIntentIndexOnBoot({ ensureVmPublishIntentIndex }, (m) => logs.push(m));
+    expect(ensureVmPublishIntentIndex).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual([]);
+  });
+
+  it('is fail-open: a backfill error is logged and swallowed, never thrown', async () => {
+    const ensureVmPublishIntentIndex = vi.fn().mockRejectedValue(new Error('store offline'));
+    const logs: string[] = [];
+    await expect(
+      backfillVmPublishIntentIndexOnBoot({ ensureVmPublishIntentIndex }, (m) => logs.push(m)),
+    ).resolves.toBeUndefined();
+    expect(ensureVmPublishIntentIndex).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual(['Publisher: intent-index backfill skipped (store offline)']);
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       ? ['test/daemon-http-behavior-extra.test.ts']
       : [
           'test/api-client.test.ts',
+          // #1828 — durable-admission recovery lookup route (pure handler, no hardhat).
+          'test/publisher-job-by-intent-route.test.ts',
+          // #1828 — daemon-boot intent-index backfill wiring (fail-open contract).
+          'test/vm-publish-intent-backfill.test.ts',
           'test/agent-connect-routes.test.ts',
           'test/preferred-relays.test.ts',
           'test/reconcile-503-mapping.test.ts',
@@ -89,6 +93,9 @@ export default defineConfig({
           // #1836 — config→construction wiring seam (runDaemonInner forwards
           // config.publisher.maxRetries into both admission constructors).
           'test/publisher-maxretries-wiring-1836.test.ts',
+          // #1828 — daemon-boot wiring seam (runDaemonInner invokes the VM-publish
+          // intent-index backfill with the admission publisher control).
+          'test/publisher-backfill-wiring-1828.test.ts',
           // SQLite-backed vector store. Pure local DB coverage; no hardhat.
           'test/vector-store-extra.test.ts',
           // Release 2 — managed local Oxigraph server (opt-in). Pure logic

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -83,6 +83,12 @@ export default defineConfig({
           'test/publisher-runner-lu11.test.ts',
           'test/publisher-runner-ack-transport.test.ts',
           'test/publisher-ka-recovery.test.ts',
+          // #1836 — publisher.maxRetries must propagate through
+          // createPublisherControlFromStore (incl. a literal 0). Pure logic.
+          'test/publisher-maxretries-1836.test.ts',
+          // #1836 — config→construction wiring seam (runDaemonInner forwards
+          // config.publisher.maxRetries into both admission constructors).
+          'test/publisher-maxretries-wiring-1836.test.ts',
           // SQLite-backed vector store. Pure local DB coverage; no hardhat.
           'test/vector-store-extra.test.ts',
           // Release 2 — managed local Oxigraph server (opt-in). Pure logic

--- a/packages/publisher/src/async-lift-control-plane.ts
+++ b/packages/publisher/src/async-lift-control-plane.ts
@@ -41,6 +41,14 @@ export const CONTROL_UPDATED_AT = 'urn:dkg:publisher:updatedAt';
 export const CONTROL_RETRY_COUNT = 'urn:dkg:publisher:retryCount';
 export const CONTROL_MAX_RETRIES = 'urn:dkg:publisher:maxRetries';
 export const CONTROL_LAST_RETRY_REASON = 'urn:dkg:publisher:lastRetryReason';
+// #1828 — ephemeral secondary index on the (mutable) job subject enabling O(1)
+// intent recovery. This triple lives on jobRef, so clear/cancel/deleteJob remove
+// it with the job. PR3 (#1829) append-only journal MUST key intent on its OWN
+// journal subjects — never rely on the job-subject index for durability.
+// `lifecycleKey` mirrors the promote queue's uniquenessKey (the dedup subject).
+// Intent exactness is derived from the parsed payload at lookup time, so no
+// separate intentKey triple is materialized.
+export const CONTROL_LIFECYCLE_KEY = 'urn:dkg:publisher:lifecycleKey';
 export const CONTROL_WALLET_ID = 'urn:dkg:publisher:walletId';
 export const CONTROL_CLAIMED_BY = 'urn:dkg:publisher:claimedBy';
 export const CONTROL_CLAIM_TOKEN = 'urn:dkg:publisher:claimToken';
@@ -204,7 +212,74 @@ export function serializeJob(job: LiftJob, graphUri: string): Quad[] {
     pushOptional(quads, jobRef, CONTROL_TX_HASH_CHECKED, job.recovery.txHashChecked, graphUri, literal);
   }
 
+  // #1828 — materialize the ephemeral recovery index on the job subject.
+  quads.push(...serializeVmPublishIntentIndex(job, graphUri));
+
   return quads;
+}
+
+/** Canonical agent lane for a VM-publish lifecycle subject (case-insensitive, trimmed). */
+function agentAddressScopeKey(agentAddress?: string): string {
+  return agentAddress?.trim().toLowerCase() ?? '';
+}
+
+/**
+ * #1828 — the lifecycle subject a VM-publish job dedups on
+ * (contextGraphId, name, subGraphName, agent lane), joined by U+001F (a control
+ * char absent from every component) into one literal for indexed equality
+ * lookup, mirroring the promote queue's uniquenessKey. MUST stay identical to
+ * findActiveKnowledgeAssetVmPublishJob's tuple — both derive it from here.
+ */
+export function knowledgeAssetVmPublishLifecycleKey(publish: {
+  contextGraphId: string;
+  name: string;
+  subGraphName?: string;
+  agentAddress?: string;
+}): string {
+  const separator = String.fromCharCode(0x1f);
+  const components = [
+    publish.contextGraphId,
+    publish.name,
+    publish.subGraphName ?? '',
+    agentAddressScopeKey(publish.agentAddress),
+  ];
+  // The components are joined with U+001F, so a component that itself contains the
+  // delimiter would shift the boundaries and collide two distinct intents onto one
+  // lifecycle subject. The recovery route rejects control chars, but the admission
+  // validators (validateAssertionName/validateSubGraphName) do NOT exclude U+001F —
+  // so fail closed HERE, the single point every path (admission dedup, index, and
+  // lookup) funnels through, rather than silently alias. #1828 review.
+  if (components.some((component) => component.includes(separator))) {
+    throw new Error(
+      'knowledgeAssetVmPublishLifecycleKey: components must not contain the U+001F delimiter',
+    );
+  }
+  return components.join(separator);
+}
+
+/**
+ * #1828 — the ephemeral lifecycle-key index triple on the job subject, for
+ * VM-publish jobs only. Single source used by both serializeJob and the boot
+ * backfill so the index is built identically everywhere. Intent exactness is
+ * derived from the parsed payload at lookup time (no separate intentKey triple).
+ */
+export function serializeVmPublishIntentIndex(job: LiftJob, graphUri: string): Quad[] {
+  if (job.request.jobType !== 'knowledge-asset-vm-publish') return [];
+  const jobRef = jobSubject(job.jobId);
+  const publish = job.request.knowledgeAssetVmPublish;
+  let lifecycleKey: string;
+  try {
+    lifecycleKey = knowledgeAssetVmPublishLifecycleKey(publish);
+  } catch {
+    // A malformed legacy job (a component carrying the U+001F delimiter, admitted
+    // before the key guard existed) is left un-indexed rather than throwing — never
+    // let one bad persisted job abort a writeJob or the whole boot backfill. New
+    // writes are still rejected upstream (the incoming key is built fail-closed).
+    return [];
+  }
+  return [
+    quad(jobRef, CONTROL_LIFECYCLE_KEY, literal(lifecycleKey), graphUri),
+  ];
 }
 
 export function serializeRequest(request: LiftJobRequest, subject: string, graphUri: string): Quad[] {

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -29,9 +29,12 @@ import {
 import type {
   AsyncKnowledgeAssetVmPublishJobHandler,
   AsyncKnowledgeAssetVmPublishRecoveryResolver,
-  AsyncLiftPublisher,
   AsyncLiftPublisherConfig,
   AsyncLiftPublisherRecoveryResolver,
+  IntentLookupInput,
+  IntentLookupResult,
+  VmPublishIntentRecoveryPublisher,
+  VmPublishIntentIndexBackfiller,
 } from './async-lift-publisher-types.js';
 import { AsyncLiftJobConflictError } from './async-lift-publisher-types.js';
 import {
@@ -54,6 +57,9 @@ import {
   DEFAULT_GRAPH_URI,
   PAYLOAD_PREDICATE,
   STATUS_PREDICATE,
+  CONTROL_LIFECYCLE_KEY,
+  knowledgeAssetVmPublishLifecycleKey,
+  serializeVmPublishIntentIndex,
   compareAcceptedJobs,
   createKnowledgeAssetVmPublishSnapshotMetadata,
   createKnowledgeAssetVmPublishSnapshotRequest,
@@ -63,6 +69,7 @@ import {
   getRecoveryTxHash,
   isKnowledgeAssetVmPublishJobRequest,
   isFailedJob,
+  isOccupyingLifecycleJob,
   normalizePersistedLiftJobRequest,
   rawLiftRequestFromJobRequest,
   jobSubject,
@@ -150,7 +157,8 @@ function resolveKnowledgeAssetVmPublishHandler(
   };
 }
 
-export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
+export class TripleStoreAsyncLiftPublisher
+  implements VmPublishIntentRecoveryPublisher, VmPublishIntentIndexBackfiller {
   private static readonly claimQueues = new Map<string, Promise<void>>();
   private static readonly DEFAULT_RECOVERY_LOOKUP_TIMEOUT_MS = 15 * 60 * 1000;
   private static readonly DEFAULT_MAX_RETRIES = 10;
@@ -315,6 +323,80 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     const rows = expectBindings(result);
     if (rows.length === 0) return null;
     return this.parseJobPayload(rows[0]?.['payload']);
+  }
+
+  async lookupKnowledgeAssetVmPublishJobByIntent(facts: IntentLookupInput): Promise<IntentLookupResult> {
+    await this.ensureGraph();
+    const key = knowledgeAssetVmPublishLifecycleKey(facts);
+    // Object-bound triple pattern (not a FILTER) so the store resolves it via the
+    // index instead of scanning every job. Read-only: no lock, no write, no reaccept.
+    //
+    // Best-effort during a concurrent in-flight rewrite: writeJob replaces the job
+    // subject as delete-then-insert, so a lookup that races a state transition can
+    // transiently miss the index and return `none`. This window is pre-existing
+    // (getStatus/list/findActive all share it) and NOT introduced here; admission's
+    // claim-locked findActive remains the authoritative dedup guard, so a transient
+    // false `none` cannot by itself create a duplicate active job. Making writeJob
+    // atomic (single transactional store.update) is a dedicated follow-up (#1863)
+    // so this PR does not put raw-SPARQL payload-literal escaping on the hot path.
+    const result = await this.store.query(
+      `SELECT ?payload WHERE { GRAPH <${this.graphUri}> { ?job <${CONTROL_LIFECYCLE_KEY}> ${literal(key)} ; <${PAYLOAD_PREDICATE}> ?payload } }`,
+    );
+    const jobs = expectBindings(result)
+      .map((row) => this.parseJobPayload(row['payload']))
+      .filter((job): job is LiftJob => job !== null);
+    if (jobs.length === 0) return { kind: 'none' };
+    // Partition on lifecycle-subject occupancy via the SHARED predicate that
+    // admission dedup (findActiveKnowledgeAssetVmPublishJob) also uses, so the two
+    // partitions are identical by construction: an occupying job (non-terminal, or
+    // a retryable failed job with retries remaining that admission would reaccept)
+    // is the live job to bind; everything else is superseded.
+    const active = jobs.filter(isOccupyingLifecycleJob);
+    const superseded = jobs.filter((job) => !isOccupyingLifecycleJob(job));
+    const intentKeyOf = (job: LiftJob): string | undefined =>
+      isKnowledgeAssetVmPublishJobRequest(job.request)
+        ? job.request.knowledgeAssetVmPublish.intentKey
+        : undefined;
+    const exact = (candidates: LiftJob[]): { exactIntentMatch?: boolean } =>
+      facts.intentKey === undefined
+        ? {}
+        : { exactIntentMatch: candidates.some((job) => intentKeyOf(job) === facts.intentKey) };
+    if (active.length > 1) return { kind: 'conflict', jobs: active };
+    if (active.length === 1) {
+      return { kind: 'active', job: active[0]!, superseded, ...exact(active) };
+    }
+    return { kind: 'superseded', jobs: superseded, ...exact(superseded) };
+  }
+
+  /**
+   * #1828 — idempotently backfill the ephemeral lifecycle index for VM-publish
+   * jobs admitted before the index existed. Reads the subjects already carrying
+   * the index and inserts ONLY the missing ones (additive insert; never
+   * deletes/rewrites, so it cannot race the runner), returning the real number
+   * of jobs repaired rather than a full-reindex count. Run once at boot.
+   */
+  async ensureVmPublishIntentIndex(): Promise<number> {
+    await this.ensureGraph();
+    const vmPublishJobs = (await this.list()).filter((job) =>
+      isKnowledgeAssetVmPublishJobRequest(job.request),
+    );
+    if (vmPublishJobs.length === 0) return 0;
+    // Subjects that already carry the lifecycle index. Object-unbound read of the
+    // one predicate — no job-payload scan — so we diff in JS and insert only the
+    // jobs missing it (VM-publish filtered above, never via a SPARQL MINUS, which
+    // would over-select raw-lift jobs).
+    const indexed = await this.store.query(
+      `SELECT ?job WHERE { GRAPH <${this.graphUri}> { ?job <${CONTROL_LIFECYCLE_KEY}> ?lifecycleKey } }`,
+    );
+    const alreadyIndexed = new Set(
+      expectBindings(indexed)
+        .map((row) => row['job'])
+        .filter((subject): subject is string => typeof subject === 'string'),
+    );
+    const missing = vmPublishJobs.filter((job) => !alreadyIndexed.has(jobSubject(job.jobId)));
+    const quads = missing.flatMap((job) => serializeVmPublishIntentIndex(job, this.graphUri));
+    if (quads.length > 0) await this.store.insert(quads);
+    return missing.length;
   }
 
   async list(filter: { status?: LiftJobState } = {}): Promise<LiftJob[]> {
@@ -639,19 +721,27 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
   private async findActiveKnowledgeAssetVmPublishJob(
     request: KnowledgeAssetVmPublishRequest,
   ): Promise<{ job: LiftJob; compatible: boolean } | null> {
+    // Build the INCOMING key up front so a delimiter in the incoming facts fails the
+    // admission closed. A malformed PERSISTED job (e.g. a legacy pre-guard admission
+    // whose name carries U+001F) must NOT abort this scan and block an unrelated
+    // admission, so each persisted job's key is built defensively.
+    const requestKey = knowledgeAssetVmPublishLifecycleKey(request);
     const jobs = await this.list();
     for (const job of jobs) {
-      if (job.status === 'finalized') continue;
-      if (isFailedJob(job)) {
-        if (!job.failure.retryable || job.retries.retryCount >= job.retries.maxRetries) continue;
-      }
       if (!isKnowledgeAssetVmPublishJobRequest(job.request)) continue;
+      // #1828 — occupancy + lifecycle subject via the SHARED helpers so admission
+      // dedup and the intent-recovery lookup partition jobs identically (a job that
+      // still occupies the subject is the live one; finalized/exhausted/non-retryable
+      // are superseded).
+      if (!isOccupyingLifecycleJob(job)) continue;
       const publish = job.request.knowledgeAssetVmPublish;
-      const sameLifecycleSubject = publish.contextGraphId === request.contextGraphId
-        && publish.name === request.name
-        && (publish.subGraphName ?? '') === (request.subGraphName ?? '')
-        && agentAddressScopeKey(publish.agentAddress) === agentAddressScopeKey(request.agentAddress);
-      if (!sameLifecycleSubject) continue;
+      let jobKey: string;
+      try {
+        jobKey = knowledgeAssetVmPublishLifecycleKey(publish);
+      } catch {
+        continue; // skip a malformed legacy job rather than failing this admission
+      }
+      if (jobKey !== requestKey) continue;
       return { job, compatible: publish.intentKey === request.intentKey };
     }
     return null;
@@ -1617,8 +1707,4 @@ function canonicalizeTerm(term: string, canonicalRootMap: Readonly<Record<string
 function txHashFromSignedPhase(phase: string): LiftJobHex | null {
   const match = phase.match(/^chain:txsigned:tx-(0x[0-9a-fA-F]+)$/);
   return match ? (match[1] as LiftJobHex) : null;
-}
-
-function agentAddressScopeKey(agentAddress?: string): string {
-  return agentAddress?.trim().toLowerCase() ?? '';
 }

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -14,6 +14,7 @@ import {
   type LiftJob,
   type LiftJobAccepted,
   type LiftJobBroadcast,
+  type LiftJobBroadcastMetadata,
   type LiftJobHex,
   type LiftJobIncluded,
   type LiftJobInclusionMetadata,
@@ -529,6 +530,16 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     } catch (error) {
       const current = await this.getStatus(claimed.jobId);
       if (!executorReturned && current?.status === 'broadcast') {
+        // The tx send happens strictly AFTER the write-ahead durably records
+        // 'broadcast' (fsync inside recordDurableBroadcastBeforeSend, whose
+        // failure rolls the transition back). So a durable 'broadcast' here means
+        // the tx may be on the wire — leave the job in 'broadcast' so recovery's
+        // interrupted-broadcast path reconciles it on chain, never resend. A
+        // pre-send failure (fsync failed → rolled back to 'validated', or an error
+        // before the write-ahead) does NOT reach here and is recorded as 'failed'
+        // below; a failed KA VM job is never chain-recovery-chased
+        // (canRetryFailedRecovery === false), and its code comes from the publish
+        // mapper (e.g. NO_FUNDED_PUBLISHER_WALLET → insufficient_funds).
         return current;
       }
       const failedFromState: LiftJobState = this.isKnowledgeAssetPublishPreconditionFailure(error)
@@ -1107,14 +1118,42 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
         `Cannot record knowledge asset VM publish broadcast for job ${params.jobId} from status ${current.status}`,
       );
     }
-    await this.update(params.jobId, 'broadcast', {
-      broadcast: {
-        txHash: params.txHash,
-        walletId: params.walletId,
-        merkleRoot: params.merkleRoot,
-        publicByteSize: params.publicByteSize,
-      },
+    await this.recordDurableBroadcastBeforeSend(current, {
+      txHash: params.txHash,
+      walletId: params.walletId,
+      merkleRoot: params.merkleRoot,
+      publicByteSize: params.publicByteSize,
     });
+  }
+
+  /**
+   * The single pre-send write-ahead boundary for the KA VM publish path: record
+   * the 'broadcast' transition and make it fsync-durable BEFORE the caller sends
+   * the tx. Runs inside the adapter's `onBroadcast` hook, which is awaited
+   * strictly before `sendSignedTransactionAndWait` (fail-closed).
+   *
+   * Durability is scoped here — not in the generic `writeJob`/`update` — so the
+   * whole-store fsync only happens at this before-send boundary (raw-lift's
+   * post-send 'broadcast' write, and every other state change, stay flush-free).
+   *
+   * On a write-ahead failure (the fsync, or the transition itself) the tx was
+   * never sent, so restore the durable prior job: the store must never report a
+   * 'broadcast' that was not fsync-durable, or recovery would chase a tx that
+   * never landed. The prior job is 'validated' (asserted by the sole caller), so
+   * restoring it takes no fsync and cannot re-fail here. The caller then fails
+   * the job from its pre-broadcast state, off the chain-recovery track.
+   */
+  private async recordDurableBroadcastBeforeSend(
+    current: LiftJob,
+    broadcast: LiftJobBroadcastMetadata,
+  ): Promise<void> {
+    try {
+      await this.update(current.jobId, 'broadcast', { broadcast });
+      await this.store.flush?.();
+    } catch (error) {
+      await this.writeJob(current);
+      throw error;
+    }
   }
 
   private parseJobPayload(binding?: string): LiftJob | null {

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -29,6 +29,30 @@ export class AsyncLiftJobConflictError extends Error {
   }
 }
 
+/** #1828 — the immutable facts a client retains to recover a lost VM-publish admission. */
+export interface IntentLookupInput {
+  readonly contextGraphId: string;
+  readonly name: string;
+  readonly subGraphName?: string;
+  readonly agentAddress?: string;
+  /** Optional exactness qualifier; sets `exactIntentMatch` on the result. */
+  readonly intentKey?: string;
+}
+
+/**
+ * #1828 — deterministic result of an intent lookup. At most one ACTIVE job can
+ * exist per lifecycle subject (admission dedup invariant), so `active` is the
+ * live job to bind; `superseded` carries terminal jobs sharing the subject;
+ * `conflict` (>1 active) signals a broken invariant. `exactIntentMatch` (only
+ * when the caller passed `intentKey`) reports whether the returned job's stored
+ * intent equals it.
+ */
+export type IntentLookupResult =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'active'; readonly job: LiftJob; readonly superseded: LiftJob[]; readonly exactIntentMatch?: boolean }
+  | { readonly kind: 'superseded'; readonly jobs: LiftJob[]; readonly exactIntentMatch?: boolean }
+  | { readonly kind: 'conflict'; readonly jobs: LiftJob[] };
+
 export interface AsyncLiftPublisher {
   enqueueKnowledgeAssetVmPublish(request: KnowledgeAssetVmPublishRequest): Promise<string>;
   claimNext(walletId: string): Promise<LiftJob | null>;
@@ -46,6 +70,31 @@ export interface AsyncLiftPublisher {
   cancel(jobId: string): Promise<void>;
   retry(filter?: { status?: 'failed' }): Promise<number>;
   clear(status: 'finalized' | 'failed'): Promise<number>;
+}
+
+/**
+ * #1828 — a publisher that also exposes the read-only durable-admission intent
+ * recovery lookup. Kept OFF the base {@link AsyncLiftPublisher} runtime queue
+ * contract so runner/adapter implementations that never serve recovery are not
+ * forced to implement it (the exported contract stays minimal). The daemon's
+ * `createPublisherControlFromStore` returns this; the recovery route depends on
+ * it. PR3/PR4 add their own feature reads on their own extended interfaces —
+ * the base contract does not grow.
+ */
+export interface VmPublishIntentRecoveryPublisher extends AsyncLiftPublisher {
+  /** #1828 — read-only recovery lookup by lifecycle facts (+ optional intentKey). */
+  lookupKnowledgeAssetVmPublishJobByIntent(facts: IntentLookupInput): Promise<IntentLookupResult>;
+}
+
+/**
+ * #1828 — one-shot storage maintenance: (re)build the ephemeral intent index for
+ * VM-publish jobs admitted before it existed. This is a boot-time repair, not a
+ * runtime publisher behaviour, so it lives on its OWN narrow interface — the
+ * daemon boot backfill depends only on this, never on the publisher contract.
+ */
+export interface VmPublishIntentIndexBackfiller {
+  /** Idempotent additive backfill; returns the number of jobs (re)indexed. */
+  ensureVmPublishIntentIndex(): Promise<number>;
 }
 
 export interface AsyncLiftPublisherRecoveryResult {

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -2,6 +2,7 @@ import type { QueryResult } from '@origintrail-official/dkg-storage';
 import {
   LIFT_AUTHORITY_TYPES,
   LIFT_TRANSITION_TYPES,
+  isTerminalLiftJobState,
 } from './lift-job.js';
 import type {
   KnowledgeAssetVmPublishJobRequest,
@@ -24,6 +25,9 @@ export {
   DEFAULT_CONTROL_GRAPH_URI as DEFAULT_GRAPH_URI,
   CONTROL_PAYLOAD as PAYLOAD_PREDICATE,
   CONTROL_STATUS as STATUS_PREDICATE,
+  CONTROL_LIFECYCLE_KEY,
+  knowledgeAssetVmPublishLifecycleKey,
+  serializeVmPublishIntentIndex,
   createJobSlug,
   jobSubject,
   parseIntegerLiteral,
@@ -59,6 +63,19 @@ export function getRecoveryTxHash(job: LiftJob): LiftJobHex | undefined {
 
 export function isFailedJob(job: LiftJob): job is PersistedFailedJob {
   return job.status === 'failed' && 'failure' in job;
+}
+
+/**
+ * #1828 — whether a job still OCCUPIES its lifecycle subject: any non-terminal
+ * state, or a failed job admission would still reaccept (retryable with retries
+ * remaining). Admission dedup (findActiveKnowledgeAssetVmPublishJob) and the
+ * intent-recovery lookup MUST both partition on this so they cannot drift — an
+ * occupying job is the live one to bind; everything else (finalized, exhausted
+ * or non-retryable failed) is superseded.
+ */
+export function isOccupyingLifecycleJob(job: LiftJob): boolean {
+  if (!isTerminalLiftJobState(job.status)) return true;
+  return isFailedJob(job) && job.failure.retryable && job.retries.retryCount < job.retries.maxRetries;
 }
 
 export function createKnowledgeAssetVmPublishSnapshotRequest(

--- a/packages/publisher/src/async-lift-publisher.ts
+++ b/packages/publisher/src/async-lift-publisher.ts
@@ -11,6 +11,10 @@ export type {
   AsyncLiftPublishExecutionInput,
   AsyncLiftPublisherRecoveryResolver,
   AsyncLiftPublisherRecoveryResult,
+  VmPublishIntentRecoveryPublisher,
+  VmPublishIntentIndexBackfiller,
+  IntentLookupInput,
+  IntentLookupResult,
 } from './async-lift-publisher-types.js';
 export { AsyncLiftJobConflictError } from './async-lift-publisher-types.js';
 export { TripleStoreAsyncLiftPublisher } from './async-lift-publisher-impl.js';

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -256,6 +256,10 @@ export {
   type AsyncLiftPublishExecutionInput,
   type AsyncLiftPublisherRecoveryResult,
   type AsyncLiftPublisherRecoveryResolver,
+  type VmPublishIntentRecoveryPublisher,
+  type VmPublishIntentIndexBackfiller,
+  type IntentLookupInput,
+  type IntentLookupResult,
 } from './async-lift-publisher.js';
 export {
   TripleStoreAsyncPromoteQueue,

--- a/packages/publisher/test/async-lift-broadcast-durability.test.ts
+++ b/packages/publisher/test/async-lift-broadcast-durability.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { NO_FUNDED_PUBLISHER_WALLET_CODE } from '@origintrail-official/dkg-core';
+import { GraphManager, OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  TripleStoreAsyncLiftPublisher,
+  type AsyncLiftPublisherConfig,
+} from '../src/index.js';
+import { storeKnowledgeAssetOperationPublicQuads } from '../src/workspace-resolution.js';
+
+// Regression: the mutable 'broadcast' record must be fsync-durable BEFORE the
+// on-chain send. It is written inside the write-ahead hook (onBroadcast, awaited
+// strictly before the tx sends) via recordDurableBroadcastBeforeSend — the sole
+// pre-send durability boundary. Without the flush there, a daemon crash in the
+// flush->send window loses the record; on restart the job reads back as
+// 'validated', recover() resets it, and it re-broadcasts with a fresh hash — a
+// double on-chain submission. Durability is scoped to that helper (not the
+// generic update/writeJob), so no other transition takes a whole-store fsync. A
+// flush FAILURE must not leave a phantom 'broadcast': the tx was never sent (the
+// adapter fails closed), so the job rolls back to its pre-broadcast state, off
+// the chain-recovery track.
+describe('async lift publisher broadcast durability', () => {
+  let now = 1_000;
+  let ids = 0;
+  let store: OxigraphStore;
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    now = 1_000;
+    ids = 0;
+    store = new OxigraphStore();
+  });
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function createPublisher(
+    targetStore: OxigraphStore = store,
+    config: Omit<AsyncLiftPublisherConfig, 'now' | 'idGenerator'> = {},
+  ): TripleStoreAsyncLiftPublisher {
+    return new TripleStoreAsyncLiftPublisher(targetStore, {
+      now: () => ++now,
+      idGenerator: () => `job-${++ids}`,
+      ...config,
+    });
+  }
+
+  function kaVmPublishRequest() {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
+    return {
+      contextGraphId: 'music-social',
+      name: 'albums',
+      shareOperationId: 'share-op-1',
+      roots: [] as string[],
+      contentScopeVersion: 2 as const,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+      seal: {
+        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+        authorAddress: authorAddress as `0x${string}`,
+        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
+        schemeVersion: 1,
+        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
+      },
+      sealChainId: '31337' as `${bigint}`,
+      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      intentKey: `sha256:${'ab'.repeat(32)}`,
+      wmCurrentAssertion: '12'.repeat(32),
+      swmCurrentAssertion: '12'.repeat(32),
+      kaNumber: kaNumber.toString(),
+      reservedUal: kaUal,
+    };
+  }
+
+  const TX_HASH = `0x${'cd'.repeat(32)}` as `0x${string}`;
+
+  async function stageShareSnapshot(targetStore: OxigraphStore): Promise<void> {
+    const request = kaVmPublishRequest();
+    await storeKnowledgeAssetOperationPublicQuads({
+      store: targetStore,
+      graphManager: new GraphManager(targetStore),
+      contextGraphId: 'music-social',
+      shareOperationId: 'share-op-1',
+      kaUal: request.kaUal,
+      assertionVersion: request.assertionVersion,
+      publisherPeerId: 'peer-1',
+      quads: [
+        { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+        { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+      ],
+    });
+  }
+
+  // A VM-publish executor that fires the pre-send write-ahead (onPhase → records
+  // 'broadcast'), then stops before the real send. Drives the exact pre-send
+  // durability boundary through the public processNext() path.
+  function firesBroadcastThenStops(): NonNullable<AsyncLiftPublisherConfig['knowledgeAssetVmPublishHandler']> {
+    return {
+      execute: async (input) => {
+        await input.publishOptions.onPhase?.(`chain:txsigned:tx-${TX_HASH}`, 'start');
+        throw new Error('stop after the durable write-ahead');
+      },
+    };
+  }
+
+  it('fsyncs once on the pre-send broadcast write-ahead, not on the earlier transitions', async () => {
+    let flushCount = 0;
+    let flushCountBeforeBroadcast = -1;
+    const orig = store.flush?.bind(store);
+    (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
+      flushCount += 1;
+      await orig?.();
+    };
+
+    const publisher = createPublisher(store, {
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          // accepted (enqueue) / claimed (claimNext) / validated (update) have all
+          // run by now and must not have fsync'd.
+          flushCountBeforeBroadcast = flushCount;
+          await input.publishOptions.onPhase?.(`chain:txsigned:tx-${TX_HASH}`, 'start');
+          throw new Error('stop after the durable write-ahead');
+        },
+      },
+    });
+
+    await stageShareSnapshot(store);
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const processed = await publisher.processNext('wallet-1');
+
+    expect(flushCountBeforeBroadcast).toBe(0);
+    // Exactly one fsync — the pre-send write-ahead; the post-throw catch path adds none.
+    expect(flushCount).toBe(1);
+    expect(processed?.status).toBe('broadcast');
+    expect(processed?.broadcast?.txHash).toBe(TX_HASH);
+  });
+
+  it('awaits the broadcast fsync before the pre-send write-ahead resolves', async () => {
+    // Proves the fsync is AWAITED, not fire-and-forget: a regression that dropped
+    // `await` on store.flush?.() would let the write-ahead resolve before the
+    // record is durable, reopening the flush->send crash window.
+    const gate: { release: () => void } = { release: () => {} };
+    let flushStarted = false;
+    (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
+      flushStarted = true;
+      await new Promise<void>((resolve) => {
+        gate.release = resolve;
+      });
+    };
+
+    const publisher = createPublisher(store, {
+      knowledgeAssetVmPublishHandler: firesBroadcastThenStops(),
+    });
+
+    await stageShareSnapshot(store);
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+
+    let settled = false;
+    const proc = publisher.processNext('wallet-1').then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    // Let microtasks + a macrotask drain: processNext must still be pending,
+    // blocked on the in-flight pre-send fsync.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(flushStarted).toBe(true);
+    expect(settled).toBe(false);
+
+    gate.release();
+    await proc;
+    expect(settled).toBe(true);
+  });
+
+  it('persists the broadcast record across a restart (fresh store from disk)', async () => {
+    // Proves durability, not just that flush() was called: drive the pre-send
+    // write-ahead on a persistent store, then reopen a FRESH store+publisher from
+    // the same path and confirm the record survived. A crash-recovery reads
+    // 'broadcast' (chain-recovery path) instead of 'validated' (reset-and-resend).
+    const dir = mkdtempSync(join(tmpdir(), 'lift-broadcast-durability-'));
+    tempDirs.push(dir);
+    const persistPath = join(dir, 'store.nq');
+
+    const store1 = new OxigraphStore(persistPath);
+    const publisher1 = createPublisher(store1, {
+      knowledgeAssetVmPublishHandler: firesBroadcastThenStops(),
+    });
+    await stageShareSnapshot(store1);
+    const jobId = await publisher1.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const processed = await publisher1.processNext('wallet-1');
+    expect(processed?.status).toBe('broadcast');
+
+    const store2 = new OxigraphStore(persistPath);
+    const publisher2 = createPublisher(store2);
+    const recovered = await publisher2.getStatus(jobId);
+
+    expect(recovered?.status).toBe('broadcast');
+    expect(recovered?.broadcast?.txHash).toBe(TX_HASH);
+    expect(recovered?.broadcast?.walletId).toBe('wallet-1');
+  });
+
+  it('does not send or leave a phantom broadcast when the write-ahead fsync fails', async () => {
+    // Regression (#1851 review): the write-ahead fsync runs AFTER the in-memory
+    // 'broadcast' transition. If it throws, the store would show 'broadcast'
+    // although the adapter fails closed and never sends the tx. The job must roll
+    // back to a pre-broadcast state, never be reported/left as 'broadcast' (which
+    // recovery would chase as an on-chain tx that never landed).
+    let sent = false;
+    const publisher = createPublisher(store, {
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          try {
+            // Records 'broadcast' (write-ahead) -> flush (rejects) -> rollback.
+            await input.publishOptions.onPhase?.(`chain:txsigned:tx-${TX_HASH}`, 'start');
+          } catch (hookErr) {
+            // Mirror the adapter's fail-closed rewrap (evm-adapter-base.ts:1609):
+            // a rejected write-ahead hook aborts the broadcast, tx never sent.
+            throw new Error(
+              `chain:writeahead hook failed before publish broadcast: ${(hookErr as Error).message}`,
+            );
+          }
+          sent = true; // real adapter's eth_sendRawTransaction — must NOT run
+          throw new Error('unreachable: send happened after a failed write-ahead flush');
+        },
+      },
+    });
+
+    // fsync is only invoked on the pre-send broadcast write-ahead; fault-inject it.
+    (store as unknown as { flush?: () => Promise<void> }).flush = async () => {
+      throw new Error('ENOSPC: no space left on device');
+    };
+
+    await stageShareSnapshot(store);
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const processed = await publisher.processNext('wallet-1');
+
+    // The tx was never sent.
+    expect(sent).toBe(false);
+    // The job is not left or reported as 'broadcast' (the rollback is what makes
+    // this hold — see the mutation-check below).
+    expect(processed?.status).toBe('failed');
+    expect(processed?.status).not.toBe('broadcast');
+
+    const persisted = await publisher.getStatus(jobId);
+    expect(persisted?.status).toBe('failed');
+    expect(persisted?.status).not.toBe('broadcast');
+
+    // Treated as never-sent: retryable and reset to accepted, NOT the
+    // chain-recovery track (retry_recovery / check-chain) that would chase a tx
+    // hash that never landed.
+    expect(processed?.failure?.retryable).toBe(true);
+    expect(processed?.failure?.resolution).toBe('reset_to_accepted');
+    expect(processed?.failure?.resolution).not.toBe('retry_recovery');
+    const recovered = await publisher.recover();
+    expect(recovered).toBe(0);
+    expect((await publisher.getStatus(jobId))?.status).toBe('failed');
+  });
+
+  it('classifies a pre-onPhase funding failure as insufficient_funds, off the recovery track', async () => {
+    // Regression (#1851 review): a NO_FUNDED_PUBLISHER_WALLET thrown by the
+    // executor BEFORE the write-ahead onPhase must keep its structured code
+    // (insufficient_funds via the publish mapper), not be relabelled a generic
+    // validation failure. No tx is ever sent, so it must not enter chain recovery.
+    const publisher = createPublisher(store, {
+      knowledgeAssetVmPublishHandler: {
+        execute: async () => {
+          // Mirrors dkg-chain's funded-wallet selection failing before any send.
+          throw Object.assign(
+            new Error('No operational wallet has enough funds to publish'),
+            { code: NO_FUNDED_PUBLISHER_WALLET_CODE },
+          );
+        },
+      },
+    });
+
+    await stageShareSnapshot(store);
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const processed = await publisher.processNext('wallet-1');
+
+    expect(processed?.status).toBe('failed');
+    expect(processed?.failure?.code).toBe('insufficient_funds');
+    // Terminal funding failure, off the chain-recovery track (no tx was sent).
+    expect(processed?.failure?.resolution).not.toBe('retry_recovery');
+    expect(await publisher.recover()).toBe(0);
+    expect((await publisher.getStatus(jobId))?.status).toBe('failed');
+  });
+});

--- a/packages/publisher/test/async-lift-intent-lookup.test.ts
+++ b/packages/publisher/test/async-lift-intent-lookup.test.ts
@@ -1,0 +1,386 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  TripleStoreAsyncLiftPublisher,
+  type AsyncLiftPublisherConfig,
+} from '../src/index.js';
+import type { LiftJob } from '../src/lift-job.js';
+import {
+  CONTROL_LIFECYCLE_KEY,
+  DEFAULT_CONTROL_GRAPH_URI,
+  jobSubject,
+  knowledgeAssetVmPublishLifecycleKey,
+  serializeJob,
+} from '../src/async-lift-control-plane.js';
+
+// #1828 — durable-admission recovery: exact intent lookup keyed on the lifecycle
+// facts a client retains, with a materialized index and deterministic
+// none/active/superseded/conflict classification.
+describe('#1828 async lift intent lookup', () => {
+  let now = 1_000;
+  let ids = 0;
+  let store: OxigraphStore;
+
+  beforeEach(() => {
+    now = 1_000;
+    ids = 0;
+    store = new OxigraphStore();
+  });
+
+  function createPublisher(
+    config: Omit<AsyncLiftPublisherConfig, 'now' | 'idGenerator'> = {},
+  ): TripleStoreAsyncLiftPublisher {
+    return new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++now,
+      idGenerator: () => `job-${++ids}`,
+      ...config,
+    });
+  }
+
+  function kaVmPublishRequest(overrides: Record<string, unknown> = {}) {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
+    return {
+      contextGraphId: 'music-social',
+      name: 'albums',
+      shareOperationId: 'share-op-1',
+      roots: [] as string[],
+      contentScopeVersion: 2 as const,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+      seal: {
+        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+        authorAddress: authorAddress as `0x${string}`,
+        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
+        schemeVersion: 1,
+        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
+      },
+      sealChainId: '31337' as `${bigint}`,
+      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      intentKey: `sha256:${'ab'.repeat(32)}`,
+      wmCurrentAssertion: '12'.repeat(32),
+      swmCurrentAssertion: '12'.repeat(32),
+      kaNumber: kaNumber.toString(),
+      reservedUal: kaUal,
+      ...overrides,
+    };
+  }
+
+  // The facts a recovering client retains (never the jobId or intentKey).
+  const facts = { contextGraphId: 'music-social', name: 'albums' };
+
+  async function driveToFailed(request: ReturnType<typeof kaVmPublishRequest>): Promise<string> {
+    const publisher = createPublisher({ recoveryLookupTimeoutMs: 10 });
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(request);
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', {
+      validation: {
+        canonicalRoots: [],
+        canonicalRootMap: {},
+        swmQuadCount: 2,
+        authorityProofRef: 'knowledge-asset-lifecycle',
+        transitionType: 'CREATE',
+      },
+    });
+    await publisher.update(jobId, 'broadcast', {
+      broadcast: { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' },
+    });
+    now += 20;
+    await publisher.recover();
+    const job = await publisher.getStatus(jobId);
+    expect(job?.status).toBe('failed');
+    return jobId;
+  }
+
+  it('materializes only the lifecycleKey index triple on admission (Chunk 1)', async () => {
+    const publisher = createPublisher();
+    const request = kaVmPublishRequest();
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(request);
+    const lifecycle = await store.query(
+      `SELECT ?lk WHERE { GRAPH <${DEFAULT_CONTROL_GRAPH_URI}> { <${jobSubject(jobId)}> <${CONTROL_LIFECYCLE_KEY}> ?lk } }`,
+    );
+    expect(lifecycle.type).toBe('bindings');
+    if (lifecycle.type !== 'bindings') return;
+    expect(lifecycle.bindings).toHaveLength(1);
+    // No separate intentKey triple is materialized — exactness is payload-derived,
+    // so the index carries only the lookup key (guards against re-adding the triple).
+    const intent = await store.query(
+      `SELECT ?ik WHERE { GRAPH <${DEFAULT_CONTROL_GRAPH_URI}> { <${jobSubject(jobId)}> <urn:dkg:publisher:intentKey> ?ik } }`,
+    );
+    expect(intent.type).toBe('bindings');
+    if (intent.type !== 'bindings') return;
+    expect(intent.bindings).toHaveLength(0);
+  });
+
+  // #1828 review (otReviewAgent + branarakic): components are joined with U+001F, so
+  // a component carrying that delimiter would shift boundaries and collide two
+  // distinct intents onto one lifecycle subject. The key builder is the single choke
+  // point (admission dedup, index, lookup), so it fails closed there.
+  it('rejects a lifecycle-key component that contains the U+001F delimiter', () => {
+    expect(() =>
+      knowledgeAssetVmPublishLifecycleKey({ contextGraphId: 'music-social', name: 'al' + String.fromCharCode(0x1f) + 'bums' }),
+    ).toThrow(/U\+001F delimiter/);
+    expect(() =>
+      knowledgeAssetVmPublishLifecycleKey({ contextGraphId: 'music-social', name: 'albums' }),
+    ).not.toThrow();
+  });
+
+  it('admission rejects a name carrying the U+001F delimiter (no silent collision)', async () => {
+    const publisher = createPublisher();
+    await expect(
+      publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ name: 'al' + String.fromCharCode(0x1f) + 'bums' })),
+    ).rejects.toThrow(/U\+001F delimiter/);
+  });
+
+  // #1828 review (otReviewAgent): the fail-closed key guard must reject bad INCOMING
+  // requests without letting one malformed PERSISTED job (a legacy pre-guard
+  // admission whose name carries U+001F) poison unrelated admissions or abort the
+  // boot backfill.
+  it('a legacy delimiter-bearing job does not poison an unrelated admission or the backfill', async () => {
+    const publisher = createPublisher();
+    const sep = String.fromCharCode(0x1f);
+
+    // Persist a pre-guard legacy job directly (bypassing the now-guarded enqueue),
+    // built from a real accepted job's shape so it is well-formed apart from the
+    // delimiter. serializeJob leaves it un-indexed (the defensive index skip).
+    const seedId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ name: 'seed' }));
+    const seed = await publisher.getStatus(seedId);
+    if (!seed || seed.request.jobType !== 'knowledge-asset-vm-publish') throw new Error('seed missing');
+    const legacyBad: LiftJob = {
+      ...seed,
+      jobId: 'legacy-bad',
+      request: {
+        ...seed.request,
+        knowledgeAssetVmPublish: { ...seed.request.knowledgeAssetVmPublish, name: `bad${sep}name` },
+      },
+    };
+    await store.insert(serializeJob(legacyBad, DEFAULT_CONTROL_GRAPH_URI));
+
+    // Unrelated valid admission still succeeds (the malformed legacy job is skipped
+    // in the dedup scan, not thrown on).
+    const okId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ name: 'albums' }));
+    expect(typeof okId).toBe('string');
+
+    // Boot backfill does not abort on the malformed job.
+    const indexed = await publisher.ensureVmPublishIntentIndex();
+    expect(indexed).toBeGreaterThanOrEqual(0);
+  });
+
+  // #1828 review (otReviewAgent): writeJob deletes the job subject BEFORE serializing
+  // the replacement, so if the key guard threw inside serializeJob a legacy
+  // delimiter-bearing job would be ERASED on its next transition (data loss). The
+  // defensive index skip keeps serializeJob total, so writeJob's re-insert restores it.
+  it('claiming a legacy delimiter-bearing job does not erase it (writeJob delete-then-insert)', async () => {
+    const publisher = createPublisher();
+    const sep = String.fromCharCode(0x1f);
+    const seedId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ name: 'seed' }));
+    const seed = await publisher.getStatus(seedId);
+    if (!seed || seed.request.jobType !== 'knowledge-asset-vm-publish') throw new Error('seed missing');
+    // Make the injected legacy job the only claimable one, then inject it directly.
+    await publisher.cancel(seedId);
+    const legacyBad: LiftJob = {
+      ...seed,
+      jobId: 'legacy-bad',
+      request: {
+        ...seed.request,
+        knowledgeAssetVmPublish: { ...seed.request.knowledgeAssetVmPublish, name: `bad${sep}name` },
+      },
+    };
+    await store.insert(serializeJob(legacyBad, DEFAULT_CONTROL_GRAPH_URI));
+
+    // claimNext runs writeJob (delete subject, then serialize + insert) on it.
+    const claimed = await publisher.claimNext('wallet-1');
+    expect(claimed?.jobId).toBe('legacy-bad');
+    // The record survived the delete-then-insert (not erased by a mid-serialize throw).
+    expect(await publisher.getStatus('legacy-bad')).not.toBeNull();
+  });
+
+  it('recovers the live in-flight job from facts alone (AC1)', async () => {
+    const publisher = createPublisher();
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const result = await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts);
+    expect(result.kind).toBe('active');
+    if (result.kind !== 'active') return;
+    expect(result.job.jobId).toBe(jobId);
+    expect(result.superseded).toEqual([]);
+  });
+
+  it('returns none for unknown facts (AC2)', async () => {
+    const publisher = createPublisher();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const result = await publisher.lookupKnowledgeAssetVmPublishJobByIntent({
+      contextGraphId: 'music-social',
+      name: 'does-not-exist',
+    });
+    expect(result.kind).toBe('none');
+  });
+
+  it('reports exactIntentMatch only when the caller passes an intentKey (AC3)', async () => {
+    const publisher = createPublisher();
+    const request = kaVmPublishRequest();
+    await publisher.enqueueKnowledgeAssetVmPublish(request);
+    const noKey = await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts);
+    expect(noKey.kind === 'active' && noKey.exactIntentMatch).toBeUndefined();
+    const match = await publisher.lookupKnowledgeAssetVmPublishJobByIntent({ ...facts, intentKey: request.intentKey });
+    expect(match.kind === 'active' && match.exactIntentMatch).toBe(true);
+    const wrong = await publisher.lookupKnowledgeAssetVmPublishJobByIntent({ ...facts, intentKey: `sha256:${'ff'.repeat(32)}` });
+    expect(wrong.kind === 'active' && wrong.exactIntentMatch).toBe(false);
+  });
+
+  it('finds the job after a restart and for terminal jobs (AC4)', async () => {
+    const jobId = await driveToFailed(kaVmPublishRequest());
+    // Fresh instance over the same durable store — models a daemon restart.
+    const restarted = createPublisher();
+    const result = await restarted.lookupKnowledgeAssetVmPublishJobByIntent(facts);
+    expect(result.kind).toBe('superseded');
+    if (result.kind !== 'superseded') return;
+    expect(result.jobs.map((j) => j.jobId)).toEqual([jobId]);
+  });
+
+  it('returns the active job with terminal siblings as superseded', async () => {
+    const request = kaVmPublishRequest();
+    const failedId = await driveToFailed(request);
+    // Add an active job under the same lifecycle subject (a real re-admission
+    // scenario after a terminal failure). Built from the stored request wrapper.
+    const failed = (await createPublisher().getStatus(failedId))!;
+    const activeClone: LiftJob = {
+      jobId: 'active-1',
+      jobSlug: 'active-1',
+      request: failed.request,
+      status: 'accepted',
+      timestamps: { acceptedAt: 5, updatedAt: 5 },
+      retries: { retryCount: 0, maxRetries: 10 },
+      controlPlane: { jobRef: jobSubject('active-1') },
+    };
+    await store.insert(serializeJob(activeClone, DEFAULT_CONTROL_GRAPH_URI));
+
+    const result = await createPublisher().lookupKnowledgeAssetVmPublishJobByIntent(facts);
+    expect(result.kind).toBe('active');
+    if (result.kind !== 'active') return;
+    expect(result.job.jobId).toBe('active-1');
+    expect(result.superseded.map((j) => j.jobId)).toEqual([failedId]);
+  });
+
+  it('classifies a retryable failed job as active (admission still owns the subject)', async () => {
+    const publisher = createPublisher();
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const accepted = (await publisher.getStatus(jobId))!;
+    // A failed-but-retryable job (retries remaining) is exactly what admission's
+    // findActive would reaccept, so recovery must surface it as the live job.
+    const failureBase = {
+      code: 'workspace_unavailable',
+      phase: 'validation',
+      mode: 'retryable',
+      resolution: 'reset_to_accepted',
+      message: 'transient store outage',
+      errorPayloadRef: `urn:dkg:publisher:error:${jobId}`,
+      failedFromState: 'validated',
+    };
+    const insertFailed = async (retryable: boolean, retryCount: number): Promise<void> => {
+      await store.deleteByPattern({ subject: jobSubject(jobId), graph: DEFAULT_CONTROL_GRAPH_URI });
+      const failed = {
+        ...accepted,
+        status: 'failed',
+        failure: { ...failureBase, retryable },
+        retries: { retryCount, maxRetries: 10 },
+      } as unknown as LiftJob;
+      await store.insert(serializeJob(failed, DEFAULT_CONTROL_GRAPH_URI));
+    };
+
+    await insertFailed(true, 0);
+    const recoverable = await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts);
+    expect(recoverable.kind).toBe('active');
+    if (recoverable.kind === 'active') expect(recoverable.job.jobId).toBe(jobId);
+
+    // Exhausted retries → genuinely superseded (admission would not reaccept it).
+    await insertFailed(true, 10);
+    expect((await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts)).kind).toBe('superseded');
+
+    // Non-retryable failure → superseded even with retries nominally remaining.
+    await insertFailed(false, 0);
+    expect((await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts)).kind).toBe('superseded');
+  });
+
+  it('partitions the recovery identity by subGraphName (Chunk 1)', async () => {
+    const publisher = createPublisher();
+    const research = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ subGraphName: 'research' }));
+    const production = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ subGraphName: 'production' }));
+
+    const r = await publisher.lookupKnowledgeAssetVmPublishJobByIntent({ ...facts, subGraphName: 'research' });
+    expect(r.kind).toBe('active');
+    if (r.kind === 'active') expect(r.job.jobId).toBe(research);
+
+    const p = await publisher.lookupKnowledgeAssetVmPublishJobByIntent({ ...facts, subGraphName: 'production' });
+    expect(p.kind).toBe('active');
+    if (p.kind === 'active') expect(p.job.jobId).toBe(production);
+
+    // The no-subGraphName lane is a distinct lifecycle subject from both.
+    expect((await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts)).kind).toBe('none');
+  });
+
+  it('classifies more than one active job as a conflict (broken invariant, AC2)', async () => {
+    const publisher = createPublisher();
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const original = (await publisher.getStatus(jobId))!;
+    const dup: LiftJob = { ...original, jobId: 'dup-1', jobSlug: 'dup-1', controlPlane: { jobRef: jobSubject('dup-1') } };
+    await store.insert(serializeJob(dup, DEFAULT_CONTROL_GRAPH_URI));
+
+    const result = await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts);
+    expect(result.kind).toBe('conflict');
+    if (result.kind !== 'conflict') return;
+    expect(result.jobs).toHaveLength(2);
+  });
+
+  it('is read-only: a lookup performs no enqueue/retry/repair (AC6)', async () => {
+    const publisher = createPublisher();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const before = await publisher.getStats();
+    await publisher.lookupKnowledgeAssetVmPublishJobByIntent({ ...facts, intentKey: `sha256:${'ab'.repeat(32)}` });
+    const after = await publisher.getStats();
+    expect(after).toEqual(before);
+  });
+
+  it('boot backfill inserts only missing index rows and reports the real count (Chunk 3)', async () => {
+    const publisher = createPublisher();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    // Simulate a pre-index job by stripping the lifecycle index triple.
+    await store.deleteByPattern({ predicate: CONTROL_LIFECYCLE_KEY, graph: DEFAULT_CONTROL_GRAPH_URI });
+    expect((await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts)).kind).toBe('none');
+
+    // First run repairs the one missing job and reports exactly it.
+    expect(await publisher.ensureVmPublishIntentIndex()).toBe(1);
+    expect((await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts)).kind).toBe('active');
+
+    // Second run finds nothing missing → repairs 0 (not a full reindex) and does
+    // not duplicate the index (still 'active', never 'conflict').
+    expect(await publisher.ensureVmPublishIntentIndex()).toBe(0);
+    expect((await publisher.lookupKnowledgeAssetVmPublishJobByIntent(facts)).kind).toBe('active');
+  });
+
+  it('is indexed: a lookup issues a single object-bound query, not a full scan (AC5)', async () => {
+    const publisher = createPublisher();
+    for (let i = 0; i < 200; i++) {
+      await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ name: `album-${i}` }));
+    }
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ name: 'target' }));
+
+    let queryCount = 0;
+    let lastSql = '';
+    const origQuery = store.query.bind(store);
+    (store as unknown as { query: (q: string) => unknown }).query = (q: string) => {
+      queryCount += 1;
+      lastSql = q;
+      return origQuery(q);
+    };
+    const result = await publisher.lookupKnowledgeAssetVmPublishJobByIntent({ ...facts, name: 'target' });
+    expect(result.kind).toBe('active');
+    expect(queryCount).toBe(1);
+    expect(lastSql).toContain(CONTROL_LIFECYCLE_KEY);
+    expect(lastSql).not.toContain('?status');
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       'test/views-min-trust-extra.test.ts',
       'test/async-lift-validation.test.ts',
       'test/async-lift-ka-broadcast-progress.test.ts',
+      'test/async-lift-broadcast-durability.test.ts',
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
       'test/lift-job-types.test.ts',

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       'test/async-lift-validation.test.ts',
       'test/async-lift-ka-broadcast-progress.test.ts',
       'test/async-lift-broadcast-durability.test.ts',
+      'test/async-lift-intent-lookup.test.ts',
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
       'test/lift-job-types.test.ts',


### PR DESCRIPTION
## Summary
- Merge latest `main` (`bb4c21015`) into `testnet-canary` (`f11bb1203`).
- Preserve all canary-specific changes while bringing in the three main-only PRs.
- Resolve the single additive Vitest configuration conflict by keeping both branches’ test entries.

## Conflict resolution
- `packages/cli/vitest.unit.config.ts`: retained canary’s async VM publish registration test and main’s publisher recovery/control-plane tests.

## Verification
- `pnpm run build:runtime:packages`
- CLI focused suite: 99 tests passed
- Publisher focused suite: 21 tests passed
- Agent/Hardhat focused suite: 37 tests passed