### PR TITLE
feat(agent): authorize RFC-64 catalog transports by policy

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -23,6 +23,7 @@
     "./dist/rfc64/control-object-store-v1-internal.js": null,
     "./dist/rfc64/control-object-store-v1.js": null,
     "./dist/rfc64/catalog-access-policy-v1.js": null,
+    "./dist/rfc64/catalog-transport-authorization-v1.js": null,
     "./dist/rfc64/durable-file-store-v1.js": null,
     "./dist/rfc64/ka-bundle-store-v1-internal.js": null,
     "./dist/rfc64/ka-bundle-store-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -66,6 +66,7 @@ const publicRfc64Modules = [
 ];
 const blockedRfc64Modules = [
   'catalog-access-policy-v1.js',
+  'catalog-transport-authorization-v1.js',
   'control-object-store-v1-internal.js',
   'control-object-store-v1.js',
   'durable-file-store-v1.js',

--- a/packages/agent/src/rfc64/catalog-transport-authorization-v1.ts
+++ b/packages/agent/src/rfc64/catalog-transport-authorization-v1.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  Rfc64CatalogAccessAuthorizationInputV1,
+  Rfc64CatalogAccessAuthorizationV1,
+  Rfc64CatalogAccessPolicyRegistryV1,
+} from './catalog-access-policy-v1.js';
+
+export type Rfc64LegacyOpenCatalogAuthorizerV1<
+  Input extends Rfc64CatalogAccessAuthorizationInputV1,
+> = (input: Input) => Promise<Rfc64CatalogAccessAuthorizationV1 | null>;
+
+/**
+ * Collapse the V2 registry and the deprecated open-only callback into one
+ * transport-facing authorizer. The legacy callback is deliberately incapable
+ * of authorizing a private cell: private access requires the current registry's
+ * authenticated peer-to-wallet and member-role checks.
+ */
+export function normalizeRfc64CatalogTransportAuthorizerV1<
+  Input extends Rfc64CatalogAccessAuthorizationInputV1,
+>(options: {
+  readonly current?: Rfc64CatalogAccessPolicyRegistryV1['authorize'];
+  readonly legacyOpen?: Rfc64LegacyOpenCatalogAuthorizerV1<Input>;
+  readonly invalidConfiguration: (message: string) => never;
+}): Rfc64LegacyOpenCatalogAuthorizerV1<Input> {
+  const current = options.current;
+  const legacyOpen = options.legacyOpen;
+  if (
+    (typeof current !== 'function' && typeof legacyOpen !== 'function')
+    || (typeof current === 'function' && typeof legacyOpen === 'function')
+  ) {
+    return options.invalidConfiguration(
+      'exactly one catalog access-policy authorizer must be configured',
+    );
+  }
+  if (typeof current === 'function') {
+    return (input) => current(projectCatalogAccessAuthorizationInput(input));
+  }
+  return async (input) => {
+    const authorization = await legacyOpen!(input);
+    return authorization?.accessPolicy === 0 ? authorization : null;
+  };
+}
+
+/**
+ * Apply the same accepted-current policy before and after an awaited boundary.
+ * This closes policy-generation and membership TOCTOU windows without making
+ * each transport flow reproduce the checkpoint choreography.
+ */
+export async function withCurrentRfc64CatalogPolicyV1<Value>(
+  requireCurrentPolicy: () => Promise<void>,
+  work: () => Value | Promise<Value>,
+): Promise<Value> {
+  await requireCurrentPolicy();
+  const value = await work();
+  await requireCurrentPolicy();
+  return value;
+}
+
+export async function recheckCurrentRfc64CatalogPolicyAfterAwaitV1<Value>(
+  requireCurrentPolicy: () => Promise<void>,
+  work: () => Value | Promise<Value>,
+): Promise<Value> {
+  const value = await work();
+  await requireCurrentPolicy();
+  return value;
+}
+
+export type Rfc64AuthorizedCatalogWorkResultV1<Value> =
+  | { readonly authorized: true; readonly value: Value }
+  | { readonly authorized: false };
+
+export async function withAuthorizedCurrentRfc64CatalogPolicyV1<Value>(
+  isCurrentPolicyAuthorized: () => Promise<boolean>,
+  work: () => Value | Promise<Value>,
+): Promise<Rfc64AuthorizedCatalogWorkResultV1<Value>> {
+  if (!await isCurrentPolicyAuthorized()) return Object.freeze({ authorized: false });
+  const value = await work();
+  if (!await isCurrentPolicyAuthorized()) return Object.freeze({ authorized: false });
+  return Object.freeze({ authorized: true, value });
+}
+
+function projectCatalogAccessAuthorizationInput(
+  input: Rfc64CatalogAccessAuthorizationInputV1,
+): Rfc64CatalogAccessAuthorizationInputV1 {
+  return Object.freeze({
+    operation: input.operation,
+    remotePeerId: input.remotePeerId,
+    networkId: input.networkId,
+    contextGraphId: input.contextGraphId,
+    policyDigest: input.policyDigest,
+  });
+}

--- a/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
@@ -43,10 +43,16 @@ import {
 } from '@origintrail-official/dkg-chain';
 
 import type {
-  Rfc64CatalogAccessAuthorizationInputV1,
   Rfc64CatalogAccessAuthorizationV1,
   Rfc64CatalogAccessPolicyRegistryV1,
 } from './catalog-access-policy-v1.js';
+import {
+  normalizeRfc64CatalogTransportAuthorizerV1,
+  recheckCurrentRfc64CatalogPolicyAfterAwaitV1,
+  withAuthorizedCurrentRfc64CatalogPolicyV1,
+  withCurrentRfc64CatalogPolicyV1,
+} from './catalog-transport-authorization-v1.js';
+import type { Rfc64AuthorizedCatalogWorkResultV1 } from './catalog-transport-authorization-v1.js';
 
 export const RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1 =
   '/dkg/catalog/1/control-object/by-digest' as const;
@@ -239,20 +245,11 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     if (typeof options.readKaBundleByDigest !== 'function') {
       fail('catalog-native-input', 'readKaBundleByDigest must be a function');
     }
-    const currentAuthorizer = options.authorizeCatalogOperation;
-    const legacyAuthorizer = options.authorizeOpenCatalogOperation;
-    if (
-      (typeof currentAuthorizer !== 'function' && typeof legacyAuthorizer !== 'function')
-      || (typeof currentAuthorizer === 'function' && typeof legacyAuthorizer === 'function')
-    ) {
-      fail(
-        'catalog-native-input',
-        'exactly one catalog access-policy authorizer must be configured',
-      );
-    }
-    this.#authorizeCatalogOperation = typeof currentAuthorizer === 'function'
-      ? (input) => currentAuthorizer(toCatalogAccessAuthorizationInput(input))
-      : (input) => legacyAuthorizer!(input);
+    this.#authorizeCatalogOperation = normalizeRfc64CatalogTransportAuthorizerV1({
+      current: options.authorizeCatalogOperation,
+      legacyOpen: options.authorizeOpenCatalogOperation,
+      invalidConfiguration: (message) => fail('catalog-native-input', message),
+    });
     if (typeof options.verifyIssuerSignature !== 'function') {
       fail('catalog-native-input', 'verifyIssuerSignature must be a function');
     }
@@ -299,19 +296,24 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const request = parseCatalogObjectRequest(encodeRequest(requestInput));
-    await this.requireCatalogPolicy('catalog-object-fetch-outbound', remotePeerId, request);
-    const response = await this.router.send(
+    const response = await this.withCurrentCatalogPolicy(
+      'catalog-object-fetch-outbound',
       remotePeerId,
-      RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
-      encodeRequest(request),
-      sendOptions,
+      request,
+      () => this.router.send(
+        remotePeerId,
+        RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
+        encodeRequest(request),
+        sendOptions,
+      ),
     );
     const envelope = parseCatalogObjectResponse(response);
-    await this.requireCatalogPolicy('catalog-object-fetch-outbound', remotePeerId, request);
     if (envelope === null) return null;
     assertCatalogObjectMatchesRequest(envelope, request);
-    const issuerSignature = await this.verifyExactIssuerSignature(envelope);
-    await this.requireCatalogPolicy('catalog-object-fetch-outbound', remotePeerId, request);
+    const issuerSignature = await recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
+      () => this.requireCatalogPolicy('catalog-object-fetch-outbound', remotePeerId, request),
+      () => this.verifyExactIssuerSignature(envelope),
+    );
     return Object.freeze({ envelope: deepFreeze(envelope), issuerSignature });
   }
 
@@ -330,15 +332,18 @@ export class Rfc64PublicCatalogNativeTransportV1 {
         'advertised KA bundle exceeds this receiver transport resource ceiling',
       );
     }
-    await this.requireCatalogPolicy('ka-bundle-fetch-outbound', remotePeerId, request);
-    const response = await this.router.send(
+    const response = await this.withCurrentCatalogPolicy(
+      'ka-bundle-fetch-outbound',
       remotePeerId,
-      RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
-      encodeRequest(request),
-      sendOptions,
+      request,
+      () => this.router.send(
+        remotePeerId,
+        RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
+        encodeRequest(request),
+        sendOptions,
+      ),
     );
     const bundle = parseBundleResponse(response, request);
-    await this.requireCatalogPolicy('ka-bundle-fetch-outbound', remotePeerId, request);
     return bundle;
   }
 
@@ -349,30 +354,26 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const request = parseCatalogObjectRequest(data);
-    if (!await this.isCatalogPolicyAuthorized('catalog-object-fetch-inbound', remotePeerId, request)) {
+    const served = await this.withAuthorizedCurrentCatalogPolicy(
+      'catalog-object-fetch-inbound',
+      remotePeerId,
+      request,
+      async () => {
+        const envelope = await this.options.readCatalogObjectByDigest(request.targetObjectDigest);
+        if (envelope === null) return null;
+        assertCatalogObjectMatchesRequest(envelope, request);
+        await this.verifyExactIssuerSignature(envelope);
+        const bytes = canonicalizeSignedControlEnvelopeBytes(envelope);
+        if (bytes.byteLength + 1 > RFC64_PUBLIC_CATALOG_OBJECT_FETCH_RESPONSE_MAX_BYTES_V1) {
+          fail('catalog-native-resource-refused', 'catalog object exceeds the response ceiling');
+        }
+        return foundResponse(bytes);
+      },
+    );
+    if (!served.authorized) {
       return Uint8Array.of(FETCH_DENIED);
     }
-    const envelope = await this.options.readCatalogObjectByDigest(request.targetObjectDigest);
-    if (envelope === null) {
-      if (!await this.isCatalogPolicyAuthorized(
-        'catalog-object-fetch-inbound',
-        remotePeerId,
-        request,
-      )) {
-        return Uint8Array.of(FETCH_DENIED);
-      }
-      return Uint8Array.of(FETCH_NOT_FOUND);
-    }
-    assertCatalogObjectMatchesRequest(envelope, request);
-    await this.verifyExactIssuerSignature(envelope);
-    if (!await this.isCatalogPolicyAuthorized('catalog-object-fetch-inbound', remotePeerId, request)) {
-      return Uint8Array.of(FETCH_DENIED);
-    }
-    const bytes = canonicalizeSignedControlEnvelopeBytes(envelope);
-    if (bytes.byteLength + 1 > RFC64_PUBLIC_CATALOG_OBJECT_FETCH_RESPONSE_MAX_BYTES_V1) {
-      fail('catalog-native-resource-refused', 'catalog object exceeds the response ceiling');
-    }
-    return foundResponse(bytes);
+    return served.value ?? Uint8Array.of(FETCH_NOT_FOUND);
   }
 
   private async handleBundleFetch(
@@ -386,25 +387,34 @@ export class Rfc64PublicCatalogNativeTransportV1 {
       > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)) {
       fail('catalog-native-resource-refused', 'requested KA bundle exceeds the response ceiling');
     }
-    if (!await this.isCatalogPolicyAuthorized('ka-bundle-fetch-inbound', remotePeerId, request)) {
+    const served = await this.withAuthorizedCurrentCatalogPolicy(
+      'ka-bundle-fetch-inbound',
+      remotePeerId,
+      request,
+      async () => {
+        const bundle = await this.options.readKaBundleByDigest(request.blobDigest);
+        if (bundle === null) return null;
+        assertExactBundle(bundle, request);
+        return foundResponse(bundle);
+      },
+    );
+    if (!served.authorized) {
       return Uint8Array.of(FETCH_DENIED);
     }
-    const bundle = await this.options.readKaBundleByDigest(request.blobDigest);
-    if (bundle === null) {
-      if (!await this.isCatalogPolicyAuthorized(
-        'ka-bundle-fetch-inbound',
-        remotePeerId,
-        request,
-      )) {
-        return Uint8Array.of(FETCH_DENIED);
-      }
-      return Uint8Array.of(FETCH_NOT_FOUND);
-    }
-    assertExactBundle(bundle, request);
-    if (!await this.isCatalogPolicyAuthorized('ka-bundle-fetch-inbound', remotePeerId, request)) {
-      return Uint8Array.of(FETCH_DENIED);
-    }
-    return foundResponse(bundle);
+    return served.value ?? Uint8Array.of(FETCH_NOT_FOUND);
+  }
+
+  private async withAuthorizedCurrentCatalogPolicy<Value>(
+    operation: Rfc64PublicCatalogNativeOperationV1,
+    remotePeerId: string,
+    request: Rfc64PublicCatalogObjectFetchRequestV1
+      | Rfc64PublicCatalogBundleFetchRequestV1,
+    work: () => Value | Promise<Value>,
+  ): Promise<Rfc64AuthorizedCatalogWorkResultV1<Value>> {
+    return withAuthorizedCurrentRfc64CatalogPolicyV1(
+      () => this.isCatalogPolicyAuthorized(operation, remotePeerId, request),
+      work,
+    );
   }
 
   private async isCatalogPolicyAuthorized(
@@ -423,6 +433,19 @@ export class Rfc64PublicCatalogNativeTransportV1 {
       ) return false;
       throw cause;
     }
+  }
+
+  private withCurrentCatalogPolicy<Value>(
+    operation: Rfc64PublicCatalogNativeOperationV1,
+    remotePeerId: string,
+    request: Rfc64PublicCatalogObjectFetchRequestV1
+      | Rfc64PublicCatalogBundleFetchRequestV1,
+    work: () => Value | Promise<Value>,
+  ): Promise<Value> {
+    return withCurrentRfc64CatalogPolicyV1(
+      () => this.requireCatalogPolicy(operation, remotePeerId, request),
+      work,
+    );
   }
 
   private async requireCatalogPolicy(
@@ -494,18 +517,6 @@ export class Rfc64PublicCatalogNativeTransportV1 {
   private requireStarted(): void {
     if (!this.#started) fail('catalog-native-state', 'catalog native transport is not started');
   }
-}
-
-function toCatalogAccessAuthorizationInput(
-  input: Rfc64PublicCatalogNativeAuthorizationInputV1,
-): Rfc64CatalogAccessAuthorizationInputV1 {
-  return Object.freeze({
-    operation: input.operation,
-    remotePeerId: input.remotePeerId,
-    networkId: input.networkId,
-    contextGraphId: input.contextGraphId,
-    policyDigest: input.policyDigest,
-  });
 }
 
 export function encodeRfc64PublicCatalogObjectFetchRequestV1(

--- a/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * RFC-64 public/open catalog content transport.
+ * RFC-64 catalog content transport.
  *
  * This is the digest-following half of the Gate-1 transport. A catalog-head
  * announcement still travels through `Rfc64PublicCatalogTransportV1`; after the
@@ -28,7 +28,6 @@ import {
   decodeOpaqueKaBundleV1,
   parseCanonicalDecimalU64,
   parseCanonicalSignedControlEnvelope,
-  type ContextGraphAccessPolicyV1,
   type ContextGraphIdV1,
   type DecimalU64V1,
   type Digest32V1,
@@ -42,6 +41,12 @@ import {
   readVerifiedControlEnvelopeIssuerSignatureV1,
   type VerifiedControlEnvelopeIssuerSignatureV1,
 } from '@origintrail-official/dkg-chain';
+
+import type {
+  Rfc64CatalogAccessAuthorizationInputV1,
+  Rfc64CatalogAccessAuthorizationV1,
+  Rfc64CatalogAccessPolicyRegistryV1,
+} from './catalog-access-policy-v1.js';
 
 export const RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1 =
   '/dkg/catalog/1/control-object/by-digest' as const;
@@ -170,10 +175,8 @@ export interface Rfc64PublicCatalogNativeAuthorizationInputV1 {
   readonly catalogHeadObjectDigest: Digest32V1;
 }
 
-export interface Rfc64PublicCatalogNativeAuthorizationV1 {
-  readonly accessPolicy: ContextGraphAccessPolicyV1;
-  readonly policyDigest: Digest32V1;
-}
+export type Rfc64PublicCatalogNativeAuthorizationV1 =
+  Rfc64CatalogAccessAuthorizationV1;
 
 export interface FetchedRfc64PublicCatalogObjectV1 {
   readonly envelope: SignedControlEnvelopeV1;
@@ -189,8 +192,10 @@ export interface Rfc64PublicCatalogNativeTransportOptionsV1 {
   readonly readKaBundleByDigest: (
     blobDigest: Digest32V1,
   ) => Promise<Uint8Array | null>;
-  /** Must consult accepted current policy state, never the untrusted request. */
-  readonly authorizeOpenCatalogOperation: (
+  /** Preferred V2 contract: the accepted-current access-policy registry. */
+  readonly authorizeCatalogOperation?: Rfc64CatalogAccessPolicyRegistryV1['authorize'];
+  /** @deprecated Gate-1 compatibility until the service wiring migrates. */
+  readonly authorizeOpenCatalogOperation?: (
     input: Rfc64PublicCatalogNativeAuthorizationInputV1,
   ) => Promise<Rfc64PublicCatalogNativeAuthorizationV1 | null>;
   readonly verifyIssuerSignature: (
@@ -220,6 +225,9 @@ export class Rfc64PublicCatalogNativeTransportErrorV1 extends Error {
 
 export class Rfc64PublicCatalogNativeTransportV1 {
   #started = false;
+  readonly #authorizeCatalogOperation: (
+    input: Rfc64PublicCatalogNativeAuthorizationInputV1,
+  ) => Promise<Rfc64PublicCatalogNativeAuthorizationV1 | null>;
 
   constructor(
     private readonly router: ProtocolRouter,
@@ -231,9 +239,20 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     if (typeof options.readKaBundleByDigest !== 'function') {
       fail('catalog-native-input', 'readKaBundleByDigest must be a function');
     }
-    if (typeof options.authorizeOpenCatalogOperation !== 'function') {
-      fail('catalog-native-input', 'authorizeOpenCatalogOperation must be a function');
+    const currentAuthorizer = options.authorizeCatalogOperation;
+    const legacyAuthorizer = options.authorizeOpenCatalogOperation;
+    if (
+      (typeof currentAuthorizer !== 'function' && typeof legacyAuthorizer !== 'function')
+      || (typeof currentAuthorizer === 'function' && typeof legacyAuthorizer === 'function')
+    ) {
+      fail(
+        'catalog-native-input',
+        'exactly one catalog access-policy authorizer must be configured',
+      );
     }
+    this.#authorizeCatalogOperation = typeof currentAuthorizer === 'function'
+      ? (input) => currentAuthorizer(toCatalogAccessAuthorizationInput(input))
+      : (input) => legacyAuthorizer!(input);
     if (typeof options.verifyIssuerSignature !== 'function') {
       fail('catalog-native-input', 'verifyIssuerSignature must be a function');
     }
@@ -280,7 +299,7 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const request = parseCatalogObjectRequest(encodeRequest(requestInput));
-    await this.requireOpenPolicy('catalog-object-fetch-outbound', remotePeerId, request);
+    await this.requireCatalogPolicy('catalog-object-fetch-outbound', remotePeerId, request);
     const response = await this.router.send(
       remotePeerId,
       RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
@@ -288,10 +307,11 @@ export class Rfc64PublicCatalogNativeTransportV1 {
       sendOptions,
     );
     const envelope = parseCatalogObjectResponse(response);
-    await this.requireOpenPolicy('catalog-object-fetch-outbound', remotePeerId, request);
+    await this.requireCatalogPolicy('catalog-object-fetch-outbound', remotePeerId, request);
     if (envelope === null) return null;
     assertCatalogObjectMatchesRequest(envelope, request);
     const issuerSignature = await this.verifyExactIssuerSignature(envelope);
+    await this.requireCatalogPolicy('catalog-object-fetch-outbound', remotePeerId, request);
     return Object.freeze({ envelope: deepFreeze(envelope), issuerSignature });
   }
 
@@ -310,7 +330,7 @@ export class Rfc64PublicCatalogNativeTransportV1 {
         'advertised KA bundle exceeds this receiver transport resource ceiling',
       );
     }
-    await this.requireOpenPolicy('ka-bundle-fetch-outbound', remotePeerId, request);
+    await this.requireCatalogPolicy('ka-bundle-fetch-outbound', remotePeerId, request);
     const response = await this.router.send(
       remotePeerId,
       RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
@@ -318,7 +338,7 @@ export class Rfc64PublicCatalogNativeTransportV1 {
       sendOptions,
     );
     const bundle = parseBundleResponse(response, request);
-    await this.requireOpenPolicy('ka-bundle-fetch-outbound', remotePeerId, request);
+    await this.requireCatalogPolicy('ka-bundle-fetch-outbound', remotePeerId, request);
     return bundle;
   }
 
@@ -329,14 +349,23 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const request = parseCatalogObjectRequest(data);
-    if (!await this.isOpenPolicy('catalog-object-fetch-inbound', remotePeerId, request)) {
+    if (!await this.isCatalogPolicyAuthorized('catalog-object-fetch-inbound', remotePeerId, request)) {
       return Uint8Array.of(FETCH_DENIED);
     }
     const envelope = await this.options.readCatalogObjectByDigest(request.targetObjectDigest);
-    if (envelope === null) return Uint8Array.of(FETCH_NOT_FOUND);
+    if (envelope === null) {
+      if (!await this.isCatalogPolicyAuthorized(
+        'catalog-object-fetch-inbound',
+        remotePeerId,
+        request,
+      )) {
+        return Uint8Array.of(FETCH_DENIED);
+      }
+      return Uint8Array.of(FETCH_NOT_FOUND);
+    }
     assertCatalogObjectMatchesRequest(envelope, request);
     await this.verifyExactIssuerSignature(envelope);
-    if (!await this.isOpenPolicy('catalog-object-fetch-inbound', remotePeerId, request)) {
+    if (!await this.isCatalogPolicyAuthorized('catalog-object-fetch-inbound', remotePeerId, request)) {
       return Uint8Array.of(FETCH_DENIED);
     }
     const bytes = canonicalizeSignedControlEnvelopeBytes(envelope);
@@ -357,26 +386,35 @@ export class Rfc64PublicCatalogNativeTransportV1 {
       > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)) {
       fail('catalog-native-resource-refused', 'requested KA bundle exceeds the response ceiling');
     }
-    if (!await this.isOpenPolicy('ka-bundle-fetch-inbound', remotePeerId, request)) {
+    if (!await this.isCatalogPolicyAuthorized('ka-bundle-fetch-inbound', remotePeerId, request)) {
       return Uint8Array.of(FETCH_DENIED);
     }
     const bundle = await this.options.readKaBundleByDigest(request.blobDigest);
-    if (bundle === null) return Uint8Array.of(FETCH_NOT_FOUND);
+    if (bundle === null) {
+      if (!await this.isCatalogPolicyAuthorized(
+        'ka-bundle-fetch-inbound',
+        remotePeerId,
+        request,
+      )) {
+        return Uint8Array.of(FETCH_DENIED);
+      }
+      return Uint8Array.of(FETCH_NOT_FOUND);
+    }
     assertExactBundle(bundle, request);
-    if (!await this.isOpenPolicy('ka-bundle-fetch-inbound', remotePeerId, request)) {
+    if (!await this.isCatalogPolicyAuthorized('ka-bundle-fetch-inbound', remotePeerId, request)) {
       return Uint8Array.of(FETCH_DENIED);
     }
     return foundResponse(bundle);
   }
 
-  private async isOpenPolicy(
+  private async isCatalogPolicyAuthorized(
     operation: Rfc64PublicCatalogNativeOperationV1,
     remotePeerId: string,
     request: Rfc64PublicCatalogObjectFetchRequestV1
       | Rfc64PublicCatalogBundleFetchRequestV1,
   ): Promise<boolean> {
     try {
-      await this.requireOpenPolicy(operation, remotePeerId, request);
+      await this.requireCatalogPolicy(operation, remotePeerId, request);
       return true;
     } catch (cause) {
       if (
@@ -387,7 +425,7 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     }
   }
 
-  private async requireOpenPolicy(
+  private async requireCatalogPolicy(
     operation: Rfc64PublicCatalogNativeOperationV1,
     remotePeerId: string,
     request: Rfc64PublicCatalogObjectFetchRequestV1
@@ -395,7 +433,7 @@ export class Rfc64PublicCatalogNativeTransportV1 {
   ): Promise<void> {
     let authorization: Rfc64PublicCatalogNativeAuthorizationV1 | null;
     try {
-      authorization = await this.options.authorizeOpenCatalogOperation(Object.freeze({
+      authorization = await this.#authorizeCatalogOperation(Object.freeze({
         operation,
         remotePeerId,
         networkId: request.networkId,
@@ -405,10 +443,20 @@ export class Rfc64PublicCatalogNativeTransportV1 {
         catalogHeadObjectDigest: request.catalogHeadObjectDigest,
       }));
     } catch (cause) {
-      fail('catalog-native-policy-denied', 'open catalog policy authorization failed', cause);
+      fail('catalog-native-policy-denied', 'catalog access-policy authorization failed', cause);
     }
+    // The native content protocols resolve objects and bundles purely by the digest carried in the
+    // request, out of a store that is shared by every context graph on this node, and nothing on the
+    // serve path binds what is served back to the context graph that authorized the request. Admitting
+    // a private cell (accessPolicy === 1) here would therefore let any peer authorized under ANY public
+    // cell this node happens to hold read another graph's control objects and KA bundles by digest
+    // alone, and would leave a removed member's remembered digests a permanent read capability.
+    // Public cells are safe because their content is open by definition. Serving private content needs
+    // the serve path to be scope-bound first (heads carry networkId/contextGraphId, buckets carry
+    // catalogScopeDigest, bundles bind only via row membership in the announced head) — that is a
+    // design slice for the private-CG milestone, not a widening of this gate.
     if (authorization === null || authorization.accessPolicy !== 0) {
-      fail('catalog-native-policy-denied', 'catalog content fetch is not open-policy authorized');
+      fail('catalog-native-policy-denied', 'catalog content fetch is not access-policy authorized');
     }
     try {
       assertCanonicalDigest(authorization.policyDigest, 'authorized policyDigest');
@@ -446,6 +494,18 @@ export class Rfc64PublicCatalogNativeTransportV1 {
   private requireStarted(): void {
     if (!this.#started) fail('catalog-native-state', 'catalog native transport is not started');
   }
+}
+
+function toCatalogAccessAuthorizationInput(
+  input: Rfc64PublicCatalogNativeAuthorizationInputV1,
+): Rfc64CatalogAccessAuthorizationInputV1 {
+  return Object.freeze({
+    operation: input.operation,
+    remotePeerId: input.remotePeerId,
+    networkId: input.networkId,
+    contextGraphId: input.contextGraphId,
+    policyDigest: input.policyDigest,
+  });
 }
 
 export function encodeRfc64PublicCatalogObjectFetchRequestV1(

--- a/packages/agent/src/rfc64/public-catalog-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-transport-v1.ts
@@ -26,10 +26,16 @@ import {
 } from '@origintrail-official/dkg-chain';
 
 import type {
-  Rfc64CatalogAccessAuthorizationInputV1,
   Rfc64CatalogAccessAuthorizationV1,
   Rfc64CatalogAccessPolicyRegistryV1,
 } from './catalog-access-policy-v1.js';
+import {
+  normalizeRfc64CatalogTransportAuthorizerV1,
+  recheckCurrentRfc64CatalogPolicyAfterAwaitV1,
+  withAuthorizedCurrentRfc64CatalogPolicyV1,
+  withCurrentRfc64CatalogPolicyV1,
+} from './catalog-transport-authorization-v1.js';
+import type { Rfc64AuthorizedCatalogWorkResultV1 } from './catalog-transport-authorization-v1.js';
 
 /**
  * Additive RFC-64 protocol IDs. Their `/catalog/1` component is the wire
@@ -205,20 +211,11 @@ export class Rfc64PublicCatalogTransportV1 {
     if (typeof options?.controlObjects?.getVerifiedObject !== 'function') {
       fail('catalog-transport-input', 'controlObjects.getVerifiedObject must be a function');
     }
-    const currentAuthorizer = options.authorizeCatalogOperation;
-    const legacyAuthorizer = options.authorizeOpenCatalogOperation;
-    if (
-      (typeof currentAuthorizer !== 'function' && typeof legacyAuthorizer !== 'function')
-      || (typeof currentAuthorizer === 'function' && typeof legacyAuthorizer === 'function')
-    ) {
-      fail(
-        'catalog-transport-input',
-        'exactly one catalog access-policy authorizer must be configured',
-      );
-    }
-    this.#authorizeCatalogOperation = typeof currentAuthorizer === 'function'
-      ? (input) => currentAuthorizer(toCatalogAccessAuthorizationInput(input))
-      : (input) => legacyAuthorizer!(input);
+    this.#authorizeCatalogOperation = normalizeRfc64CatalogTransportAuthorizerV1({
+      current: options.authorizeCatalogOperation,
+      legacyOpen: options.authorizeOpenCatalogOperation,
+      invalidConfiguration: (message) => fail('catalog-transport-input', message),
+    });
     if (typeof options.verifyIssuerSignature !== 'function') {
       fail('catalog-transport-input', 'verifyIssuerSignature must be a function');
     }
@@ -268,12 +265,16 @@ export class Rfc64PublicCatalogTransportV1 {
     this.requireStarted();
     const peerId = snapshotPeerId(remotePeerId);
     const announcement = parseAnnouncement(encodeAnnouncement(announcementInput));
-    await this.requireCatalogPolicy('announce-outbound', peerId, announcement);
-    const response = await this.router.send(
+    const response = await this.withCurrentCatalogPolicy(
+      'announce-outbound',
       peerId,
-      RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_PROTOCOL_V1,
-      encodeAnnouncement(announcement),
-      sendOptions,
+      announcement,
+      () => this.router.send(
+        peerId,
+        RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_PROTOCOL_V1,
+        encodeAnnouncement(announcement),
+        sendOptions,
+      ),
     );
     if (response.byteLength === 1 && response[0] === ANNOUNCEMENT_DENIED) {
       fail('catalog-transport-policy-denied', 'remote peer denied the catalog-head announcement');
@@ -281,7 +282,6 @@ export class Rfc64PublicCatalogTransportV1 {
     if (response.byteLength !== 1 || response[0] !== ACK[0]) {
       fail('catalog-transport-wire', 'catalog-head announcement returned an invalid acknowledgement');
     }
-    await this.requireCatalogPolicy('announce-outbound', peerId, announcement);
   }
 
   async fetchCatalogHead(
@@ -292,20 +292,25 @@ export class Rfc64PublicCatalogTransportV1 {
     this.requireStarted();
     const peerId = snapshotPeerId(remotePeerId);
     const announcement = parseAnnouncement(encodeAnnouncement(announcementInput));
-    await this.requireCatalogPolicy('fetch-outbound', peerId, announcement);
     const request = requestFromAnnouncement(announcement);
-    const response = await this.router.send(
+    const response = await this.withCurrentCatalogPolicy(
+      'fetch-outbound',
       peerId,
-      RFC64_PUBLIC_CATALOG_HEAD_FETCH_PROTOCOL_V1,
-      encodeFetchRequest(request),
-      sendOptions,
+      announcement,
+      () => this.router.send(
+        peerId,
+        RFC64_PUBLIC_CATALOG_HEAD_FETCH_PROTOCOL_V1,
+        encodeFetchRequest(request),
+        sendOptions,
+      ),
     );
     const envelope = parseFetchResponse(response);
-    await this.requireCatalogPolicy('fetch-outbound', peerId, announcement);
     if (envelope === null) return null;
     assertHeadMatchesAnnouncement(envelope, announcement);
-    const issuerSignature = await this.verifyExactIssuerSignature(envelope);
-    await this.requireCatalogPolicy('fetch-outbound', peerId, announcement);
+    const issuerSignature = await recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
+      () => this.requireCatalogPolicy('fetch-outbound', peerId, announcement),
+      () => this.verifyExactIssuerSignature(envelope),
+    );
     return Object.freeze({
       envelope: deepFreeze(envelope),
       issuerSignature,
@@ -319,11 +324,13 @@ export class Rfc64PublicCatalogTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const announcement = parseAnnouncement(data);
-    if (!await this.isCatalogPolicyAuthorized('announce-inbound', remotePeerId, announcement)) {
-      return Uint8Array.of(ANNOUNCEMENT_DENIED);
-    }
-    await this.options.onCatalogHeadAvailable(announcement, remotePeerId);
-    if (!await this.isCatalogPolicyAuthorized('announce-inbound', remotePeerId, announcement)) {
+    const admitted = await this.withAuthorizedCurrentCatalogPolicy(
+      'announce-inbound',
+      remotePeerId,
+      announcement,
+      () => this.options.onCatalogHeadAvailable(announcement, remotePeerId),
+    );
+    if (!admitted.authorized) {
       return Uint8Array.of(ANNOUNCEMENT_DENIED);
     }
     return ACK;
@@ -336,44 +343,56 @@ export class Rfc64PublicCatalogTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const request = parseFetchRequest(data);
-    if (!await this.isCatalogPolicyAuthorized('fetch-inbound', remotePeerId, request)) {
+    const served = await this.withAuthorizedCurrentCatalogPolicy(
+      'fetch-inbound',
+      remotePeerId,
+      request,
+      async () => {
+        const stored = await this.options.controlObjects.getVerifiedObject({
+          objectDigest: request.catalogHeadObjectDigest,
+          signatureVariantDigest: request.signatureVariantDigest,
+          verifyIssuerSignature: this.options.verifyIssuerSignature,
+        });
+        if (stored === null) return null;
+        let envelope: SignedAuthorCatalogHeadEnvelopeV1;
+        try {
+          assertSignedAuthorCatalogHeadEnvelopeV1(stored.envelope);
+          envelope = stored.envelope;
+          assertHeadMatchesRequest(envelope, request);
+          assertExactIssuerSignatureProof(envelope, stored.issuerSignature);
+        } catch (cause) {
+          fail(
+            'catalog-transport-object-mismatch',
+            'stored object is not the exact requested author-catalog head',
+            cause,
+          );
+        }
+        const envelopeBytes = canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(envelope);
+        const response = new Uint8Array(1 + envelopeBytes.byteLength);
+        response[0] = FETCH_FOUND;
+        response.set(envelopeBytes, 1);
+        if (response.byteLength > RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1) {
+          fail('catalog-transport-wire', 'author-catalog head exceeds the v1 fetch response cap');
+        }
+        return response;
+      },
+    );
+    if (!served.authorized) {
       return Uint8Array.of(FETCH_DENIED);
     }
-    const stored = await this.options.controlObjects.getVerifiedObject({
-      objectDigest: request.catalogHeadObjectDigest,
-      signatureVariantDigest: request.signatureVariantDigest,
-      verifyIssuerSignature: this.options.verifyIssuerSignature,
-    });
-    if (stored === null) {
-      if (!await this.isCatalogPolicyAuthorized('fetch-inbound', remotePeerId, request)) {
-        return Uint8Array.of(FETCH_DENIED);
-      }
-      return Uint8Array.of(FETCH_NOT_FOUND);
-    }
-    let envelope: SignedAuthorCatalogHeadEnvelopeV1;
-    try {
-      assertSignedAuthorCatalogHeadEnvelopeV1(stored.envelope);
-      envelope = stored.envelope;
-      assertHeadMatchesRequest(envelope, request);
-      assertExactIssuerSignatureProof(envelope, stored.issuerSignature);
-    } catch (cause) {
-      fail(
-        'catalog-transport-object-mismatch',
-        'stored object is not the exact requested author-catalog head',
-        cause,
-      );
-    }
-    const envelopeBytes = canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(envelope);
-    const response = new Uint8Array(1 + envelopeBytes.byteLength);
-    response[0] = FETCH_FOUND;
-    response.set(envelopeBytes, 1);
-    if (response.byteLength > RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1) {
-      fail('catalog-transport-wire', 'author-catalog head exceeds the v1 fetch response cap');
-    }
-    if (!await this.isCatalogPolicyAuthorized('fetch-inbound', remotePeerId, request)) {
-      return Uint8Array.of(FETCH_DENIED);
-    }
-    return response;
+    return served.value ?? Uint8Array.of(FETCH_NOT_FOUND);
+  }
+
+  private async withAuthorizedCurrentCatalogPolicy<Value>(
+    operation: Rfc64PublicCatalogOperationV1,
+    remotePeerId: string,
+    scope: Rfc64PublicCatalogHeadAnnouncementV1 | Rfc64PublicCatalogHeadFetchRequestV1,
+    work: () => Value | Promise<Value>,
+  ): Promise<Rfc64AuthorizedCatalogWorkResultV1<Value>> {
+    return withAuthorizedCurrentRfc64CatalogPolicyV1(
+      () => this.isCatalogPolicyAuthorized(operation, remotePeerId, scope),
+      work,
+    );
   }
 
   private async isCatalogPolicyAuthorized(
@@ -391,6 +410,18 @@ export class Rfc64PublicCatalogTransportV1 {
       ) return false;
       throw cause;
     }
+  }
+
+  private withCurrentCatalogPolicy<Value>(
+    operation: Rfc64PublicCatalogOperationV1,
+    remotePeerId: string,
+    scope: Rfc64PublicCatalogHeadAnnouncementV1 | Rfc64PublicCatalogHeadFetchRequestV1,
+    work: () => Value | Promise<Value>,
+  ): Promise<Value> {
+    return withCurrentRfc64CatalogPolicyV1(
+      () => this.requireCatalogPolicy(operation, remotePeerId, scope),
+      work,
+    );
   }
 
   private async requireCatalogPolicy(
@@ -658,18 +689,6 @@ function assertExactIssuerSignatureProof(
   ) {
     fail('catalog-transport-signature', 'issuer signature proof is not bound to the exact envelope');
   }
-}
-
-function toCatalogAccessAuthorizationInput(
-  input: Rfc64PublicCatalogAuthorizationInputV1,
-): Rfc64CatalogAccessAuthorizationInputV1 {
-  return Object.freeze({
-    operation: input.operation,
-    remotePeerId: input.remotePeerId,
-    networkId: input.networkId,
-    contextGraphId: input.contextGraphId,
-    policyDigest: input.policyDigest,
-  });
 }
 
 function encodeFlatCanonicalJson(

--- a/packages/agent/src/rfc64/public-catalog-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-transport-v1.ts
@@ -10,7 +10,6 @@ import {
   canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1,
   computeControlSignatureVariantDigestHex,
   parseCanonicalSignedAuthorCatalogHeadEnvelopeV1,
-  type ContextGraphAccessPolicyV1,
   type ContextGraphIdV1,
   type DecimalU64V1,
   type Digest32V1,
@@ -25,6 +24,12 @@ import {
   readVerifiedControlEnvelopeIssuerSignatureV1,
   type VerifiedControlEnvelopeIssuerSignatureV1,
 } from '@origintrail-official/dkg-chain';
+
+import type {
+  Rfc64CatalogAccessAuthorizationInputV1,
+  Rfc64CatalogAccessAuthorizationV1,
+  Rfc64CatalogAccessPolicyRegistryV1,
+} from './catalog-access-policy-v1.js';
 
 /**
  * Additive RFC-64 protocol IDs. Their `/catalog/1` component is the wire
@@ -113,14 +118,11 @@ export interface Rfc64PublicCatalogAuthorizationInputV1 {
 }
 
 /**
- * A caller-minted current-policy decision. The transport independently requires
- * `accessPolicy === 0` and an exact digest match, so returning a private policy or
- * a different policy generation always fails closed.
+ * A caller-minted current-policy decision. The transport independently validates
+ * the access-policy cell and exact digest match; the registry decides whether
+ * the authenticated remote is authorized for an open or invite-only cell.
  */
-export interface Rfc64PublicCatalogAuthorizationV1 {
-  readonly accessPolicy: ContextGraphAccessPolicyV1;
-  readonly policyDigest: Digest32V1;
-}
+export type Rfc64PublicCatalogAuthorizationV1 = Rfc64CatalogAccessAuthorizationV1;
 
 export interface Rfc64PublicCatalogControlObjectReaderV1 {
   getVerifiedObject(input: {
@@ -142,8 +144,10 @@ export interface FetchedRfc64PublicCatalogHeadV1 {
 
 export interface Rfc64PublicCatalogTransportOptionsV1 {
   readonly controlObjects: Rfc64PublicCatalogControlObjectReaderV1;
-  /** Must consult accepted current policy state, not the untrusted wire hint. */
-  readonly authorizeOpenCatalogOperation: (
+  /** Preferred V2 contract: the accepted-current access-policy registry. */
+  readonly authorizeCatalogOperation?: Rfc64CatalogAccessPolicyRegistryV1['authorize'];
+  /** @deprecated Gate-1 compatibility until the service wiring migrates. */
+  readonly authorizeOpenCatalogOperation?: (
     input: Rfc64PublicCatalogAuthorizationInputV1,
   ) => Promise<Rfc64PublicCatalogAuthorizationV1 | null>;
   /** Generic envelope cryptography only; object-specific head/scope binding is local. */
@@ -181,15 +185,18 @@ export class Rfc64PublicCatalogTransportErrorV1 extends Error {
 }
 
 /**
- * Small public/open RFC-64 transport slice.
+ * Small RFC-64 author-catalog transport slice.
  *
  * It deliberately does not select peers, activate catalog state, admit candidate
- * rows, or support invite-only policy. Announcements are only untrusted hints;
+ * rows. Announcements are only untrusted hints;
  * every served and received head is fetched by both exact digests, structurally
  * bound to the hint, and reverified with the generic signature verifier.
  */
 export class Rfc64PublicCatalogTransportV1 {
   #started = false;
+  readonly #authorizeCatalogOperation: (
+    input: Rfc64PublicCatalogAuthorizationInputV1,
+  ) => Promise<Rfc64PublicCatalogAuthorizationV1 | null>;
 
   constructor(
     private readonly router: ProtocolRouter,
@@ -198,9 +205,20 @@ export class Rfc64PublicCatalogTransportV1 {
     if (typeof options?.controlObjects?.getVerifiedObject !== 'function') {
       fail('catalog-transport-input', 'controlObjects.getVerifiedObject must be a function');
     }
-    if (typeof options.authorizeOpenCatalogOperation !== 'function') {
-      fail('catalog-transport-input', 'authorizeOpenCatalogOperation must be a function');
+    const currentAuthorizer = options.authorizeCatalogOperation;
+    const legacyAuthorizer = options.authorizeOpenCatalogOperation;
+    if (
+      (typeof currentAuthorizer !== 'function' && typeof legacyAuthorizer !== 'function')
+      || (typeof currentAuthorizer === 'function' && typeof legacyAuthorizer === 'function')
+    ) {
+      fail(
+        'catalog-transport-input',
+        'exactly one catalog access-policy authorizer must be configured',
+      );
     }
+    this.#authorizeCatalogOperation = typeof currentAuthorizer === 'function'
+      ? (input) => currentAuthorizer(toCatalogAccessAuthorizationInput(input))
+      : (input) => legacyAuthorizer!(input);
     if (typeof options.verifyIssuerSignature !== 'function') {
       fail('catalog-transport-input', 'verifyIssuerSignature must be a function');
     }
@@ -250,7 +268,7 @@ export class Rfc64PublicCatalogTransportV1 {
     this.requireStarted();
     const peerId = snapshotPeerId(remotePeerId);
     const announcement = parseAnnouncement(encodeAnnouncement(announcementInput));
-    await this.requireOpenPolicy('announce-outbound', peerId, announcement);
+    await this.requireCatalogPolicy('announce-outbound', peerId, announcement);
     const response = await this.router.send(
       peerId,
       RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_PROTOCOL_V1,
@@ -263,7 +281,7 @@ export class Rfc64PublicCatalogTransportV1 {
     if (response.byteLength !== 1 || response[0] !== ACK[0]) {
       fail('catalog-transport-wire', 'catalog-head announcement returned an invalid acknowledgement');
     }
-    await this.requireOpenPolicy('announce-outbound', peerId, announcement);
+    await this.requireCatalogPolicy('announce-outbound', peerId, announcement);
   }
 
   async fetchCatalogHead(
@@ -274,7 +292,7 @@ export class Rfc64PublicCatalogTransportV1 {
     this.requireStarted();
     const peerId = snapshotPeerId(remotePeerId);
     const announcement = parseAnnouncement(encodeAnnouncement(announcementInput));
-    await this.requireOpenPolicy('fetch-outbound', peerId, announcement);
+    await this.requireCatalogPolicy('fetch-outbound', peerId, announcement);
     const request = requestFromAnnouncement(announcement);
     const response = await this.router.send(
       peerId,
@@ -283,10 +301,11 @@ export class Rfc64PublicCatalogTransportV1 {
       sendOptions,
     );
     const envelope = parseFetchResponse(response);
-    await this.requireOpenPolicy('fetch-outbound', peerId, announcement);
+    await this.requireCatalogPolicy('fetch-outbound', peerId, announcement);
     if (envelope === null) return null;
     assertHeadMatchesAnnouncement(envelope, announcement);
     const issuerSignature = await this.verifyExactIssuerSignature(envelope);
+    await this.requireCatalogPolicy('fetch-outbound', peerId, announcement);
     return Object.freeze({
       envelope: deepFreeze(envelope),
       issuerSignature,
@@ -300,11 +319,11 @@ export class Rfc64PublicCatalogTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const announcement = parseAnnouncement(data);
-    if (!await this.isOpenPolicy('announce-inbound', remotePeerId, announcement)) {
+    if (!await this.isCatalogPolicyAuthorized('announce-inbound', remotePeerId, announcement)) {
       return Uint8Array.of(ANNOUNCEMENT_DENIED);
     }
     await this.options.onCatalogHeadAvailable(announcement, remotePeerId);
-    if (!await this.isOpenPolicy('announce-inbound', remotePeerId, announcement)) {
+    if (!await this.isCatalogPolicyAuthorized('announce-inbound', remotePeerId, announcement)) {
       return Uint8Array.of(ANNOUNCEMENT_DENIED);
     }
     return ACK;
@@ -317,7 +336,7 @@ export class Rfc64PublicCatalogTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const request = parseFetchRequest(data);
-    if (!await this.isOpenPolicy('fetch-inbound', remotePeerId, request)) {
+    if (!await this.isCatalogPolicyAuthorized('fetch-inbound', remotePeerId, request)) {
       return Uint8Array.of(FETCH_DENIED);
     }
     const stored = await this.options.controlObjects.getVerifiedObject({
@@ -326,7 +345,7 @@ export class Rfc64PublicCatalogTransportV1 {
       verifyIssuerSignature: this.options.verifyIssuerSignature,
     });
     if (stored === null) {
-      if (!await this.isOpenPolicy('fetch-inbound', remotePeerId, request)) {
+      if (!await this.isCatalogPolicyAuthorized('fetch-inbound', remotePeerId, request)) {
         return Uint8Array.of(FETCH_DENIED);
       }
       return Uint8Array.of(FETCH_NOT_FOUND);
@@ -351,19 +370,19 @@ export class Rfc64PublicCatalogTransportV1 {
     if (response.byteLength > RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1) {
       fail('catalog-transport-wire', 'author-catalog head exceeds the v1 fetch response cap');
     }
-    if (!await this.isOpenPolicy('fetch-inbound', remotePeerId, request)) {
+    if (!await this.isCatalogPolicyAuthorized('fetch-inbound', remotePeerId, request)) {
       return Uint8Array.of(FETCH_DENIED);
     }
     return response;
   }
 
-  private async isOpenPolicy(
+  private async isCatalogPolicyAuthorized(
     operation: Rfc64PublicCatalogOperationV1,
     remotePeerId: string,
     scope: Rfc64PublicCatalogHeadAnnouncementV1 | Rfc64PublicCatalogHeadFetchRequestV1,
   ): Promise<boolean> {
     try {
-      await this.requireOpenPolicy(operation, remotePeerId, scope);
+      await this.requireCatalogPolicy(operation, remotePeerId, scope);
       return true;
     } catch (cause) {
       if (
@@ -374,7 +393,7 @@ export class Rfc64PublicCatalogTransportV1 {
     }
   }
 
-  private async requireOpenPolicy(
+  private async requireCatalogPolicy(
     operation: Rfc64PublicCatalogOperationV1,
     remotePeerId: string,
     scope: Rfc64PublicCatalogHeadAnnouncementV1 | Rfc64PublicCatalogHeadFetchRequestV1,
@@ -390,12 +409,15 @@ export class Rfc64PublicCatalogTransportV1 {
     }) satisfies Rfc64PublicCatalogAuthorizationInputV1;
     let authorization: Rfc64PublicCatalogAuthorizationV1 | null;
     try {
-      authorization = await this.options.authorizeOpenCatalogOperation(input);
+      authorization = await this.#authorizeCatalogOperation(input);
     } catch (cause) {
-      fail('catalog-transport-policy-denied', 'open catalog policy authorization failed', cause);
+      fail('catalog-transport-policy-denied', 'catalog access-policy authorization failed', cause);
     }
-    if (authorization === null || authorization.accessPolicy !== 0) {
-      fail('catalog-transport-policy-denied', 'catalog operation is not authorized by open access policy');
+    if (
+      authorization === null
+      || (authorization.accessPolicy !== 0 && authorization.accessPolicy !== 1)
+    ) {
+      fail('catalog-transport-policy-denied', 'catalog operation is not access-policy authorized');
     }
     try {
       assertCanonicalDigest(authorization.policyDigest, 'authorized policyDigest');
@@ -636,6 +658,18 @@ function assertExactIssuerSignatureProof(
   ) {
     fail('catalog-transport-signature', 'issuer signature proof is not bound to the exact envelope');
   }
+}
+
+function toCatalogAccessAuthorizationInput(
+  input: Rfc64PublicCatalogAuthorizationInputV1,
+): Rfc64CatalogAccessAuthorizationInputV1 {
+  return Object.freeze({
+    operation: input.operation,
+    remotePeerId: input.remotePeerId,
+    networkId: input.networkId,
+    contextGraphId: input.contextGraphId,
+    policyDigest: input.policyDigest,
+  });
 }
 
 function encodeFlatCanonicalJson(

--- a/packages/agent/test/rfc64-public-catalog-native-transport-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-transport-v1.test.ts
@@ -1,14 +1,18 @@
 import { multiaddr } from '@multiformats/multiaddr';
 import {
   AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   DKGNode,
   ProtocolRouter,
   canonicalizeSignedControlEnvelopeBytes,
   computeControlSignatureVariantDigestHex,
   encodeOpaqueKaBundleV1,
   type AuthorCatalogScopeV1,
+  type ContextGraphIdV1,
+  type ContextGraphPolicyV1,
   type Digest32V1,
   type EvmAddressV1,
+  type MemberRosterV1,
   type SignedControlEnvelopeV1,
 } from '@origintrail-official/dkg-core';
 import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
@@ -16,6 +20,7 @@ import { ethers } from 'ethers';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
+import { Rfc64CatalogAccessPolicyRegistryV1 } from '../src/rfc64/catalog-access-policy-v1.js';
 import {
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
@@ -32,6 +37,9 @@ const AUTHOR_WALLET = new ethers.Wallet(`0x${'65'.repeat(32)}`);
 const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
 const POLICY_DIGEST = `0x${'73'.repeat(32)}` as Digest32V1;
 const DELEGATION_DIGEST = `0x${'74'.repeat(32)}` as Digest32V1;
+const LOCAL_MEMBER = '0x3333333333333333333333333333333333333333' as EvmAddressV1;
+const REMOTE_MEMBER = '0x4444444444444444444444444444444444444444' as EvmAddressV1;
+const CURATOR = '0x5555555555555555555555555555555555555555' as EvmAddressV1;
 const UTF8 = new TextEncoder();
 
 const nodes: DKGNode[] = [];
@@ -60,6 +68,59 @@ async function connect(from: DKGNode, to: DKGNode): Promise<void> {
   await from.libp2p.dial(multiaddr(address));
 }
 
+function policyRegistry(
+  localAgentAddress: EvmAddressV1,
+  remoteAgentAddress: EvmAddressV1,
+  contextGraphId: ContextGraphIdV1,
+  accessPolicy: 0 | 1,
+  publishPolicy: 0 | 1,
+): Rfc64CatalogAccessPolicyRegistryV1 {
+  const registry = new Rfc64CatalogAccessPolicyRegistryV1({
+    localAgentAddress,
+    resolveRemoteAgentAddress: async () => remoteAgentAddress,
+  });
+  const policy = {
+    networkId: 'otp:20430',
+    contextGraphId,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy,
+    publishPolicy,
+    publishAuthority: publishPolicy === 0 ? CURATOR : null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'owner-signed-unregistered',
+      ownerAddress: AUTHOR,
+      ownerAuthorityEra: '0',
+    },
+    effectiveAt: '0',
+    issuedAt: '0',
+  } satisfies ContextGraphPolicyV1;
+  const roster = accessPolicy === 0 ? null : {
+    networkId: policy.networkId,
+    contextGraphId: policy.contextGraphId,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest: POLICY_DIGEST,
+    administrativeDelegationDigest: null,
+    members: [
+      { agentAddress: LOCAL_MEMBER, roles: ['holder', 'provider'] },
+      { agentAddress: REMOTE_MEMBER, roles: ['holder', 'provider'] },
+    ],
+    issuedAt: '0',
+  } satisfies MemberRosterV1;
+  registry.accept({ policy, policyDigest: POLICY_DIGEST, roster });
+  return registry;
+}
+
 describe('RFC-64 public catalog native content transport v1', () => {
   it('accepts the exact-set bundle-byte ceiling and rejects one byte over it', () => {
     const ceiling = BigInt(RFC64_PUBLIC_CATALOG_EXACT_SET_BUNDLE_BYTES_MAX_V1);
@@ -73,7 +134,16 @@ describe('RFC-64 public catalog native content transport v1', () => {
     ])).toThrow(/exceed.*ceiling/);
   });
 
-  it('fetches exact directory and bundle digests across two live libp2p nodes', async () => {
+  // Only the publicly-readable cells are servable over the native content protocols: the serve path
+  // resolves by digest out of an agent-wide store and is not bound back to the authorizing graph, so
+  // private content stays denied (see requireCatalogPolicy). publishPolicy must not affect this —
+  // it governs finalized-VM admission only, never read/SWM authorization.
+  it.each([
+    { accessPolicy: 0 as const, publishPolicy: 0 as const },
+    { accessPolicy: 0 as const, publishPolicy: 1 as const },
+  ])(
+    'fetches exact directory and bundle digests for accessPolicy=$accessPolicy publishPolicy=$publishPolicy',
+    async ({ accessPolicy, publishPolicy }) => {
     const [authorNode, receiverNode] = await Promise.all([startNode(), startNode()]);
     await connect(receiverNode, authorNode);
 
@@ -108,16 +178,29 @@ describe('RFC-64 public catalog native content transport v1', () => {
     const authorBundleReads = vi.fn(async (digest: Digest32V1) => bundles.get(digest) ?? null);
     const authorAuthorizations: string[] = [];
     const receiverAuthorizations: string[] = [];
-    const openPolicy = () => Object.freeze({ accessPolicy: 0 as const, policyDigest: POLICY_DIGEST });
+    const authorPolicy = policyRegistry(
+      LOCAL_MEMBER,
+      REMOTE_MEMBER,
+      produced.head.payload.contextGraphId,
+      accessPolicy,
+      publishPolicy,
+    );
+    const receiverPolicy = policyRegistry(
+      REMOTE_MEMBER,
+      LOCAL_MEMBER,
+      produced.head.payload.contextGraphId,
+      accessPolicy,
+      publishPolicy,
+    );
 
     const authorTransport = new Rfc64PublicCatalogNativeTransportV1(
       new ProtocolRouter(authorNode),
       {
         readCatalogObjectByDigest: authorCatalogReads,
         readKaBundleByDigest: authorBundleReads,
-        authorizeOpenCatalogOperation: async (input) => {
+        authorizeCatalogOperation: async (input) => {
           authorAuthorizations.push(input.operation);
-          return openPolicy();
+          return authorPolicy.authorize(input);
         },
         verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
       },
@@ -127,9 +210,9 @@ describe('RFC-64 public catalog native content transport v1', () => {
       {
         readCatalogObjectByDigest: async () => null,
         readKaBundleByDigest: async () => null,
-        authorizeOpenCatalogOperation: async (input) => {
+        authorizeCatalogOperation: async (input) => {
           receiverAuthorizations.push(input.operation);
-          return openPolicy();
+          return receiverPolicy.authorize(input);
         },
         verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
       },
@@ -181,12 +264,15 @@ describe('RFC-64 public catalog native content transport v1', () => {
     expect(receiverAuthorizations).toEqual([
       'catalog-object-fetch-outbound',
       'catalog-object-fetch-outbound',
+      'catalog-object-fetch-outbound',
       'ka-bundle-fetch-outbound',
       'ka-bundle-fetch-outbound',
     ]);
-  }, 30_000);
+    },
+    30_000,
+  );
 
-  it('denies a private-policy request before provider lookup', async () => {
+  it('denies an unauthorized request before provider lookup', async () => {
     const [authorNode, receiverNode] = await Promise.all([startNode(), startNode()]);
     await connect(receiverNode, authorNode);
     const providerRead = vi.fn(async () => null);
@@ -195,10 +281,7 @@ describe('RFC-64 public catalog native content transport v1', () => {
       {
         readCatalogObjectByDigest: providerRead,
         readKaBundleByDigest: async () => null,
-        authorizeOpenCatalogOperation: async () => ({
-          accessPolicy: 1,
-          policyDigest: POLICY_DIGEST,
-        }),
+        authorizeCatalogOperation: async () => null,
         verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
       },
     );
@@ -207,7 +290,7 @@ describe('RFC-64 public catalog native content transport v1', () => {
       {
         readCatalogObjectByDigest: async () => null,
         readKaBundleByDigest: async () => null,
-        authorizeOpenCatalogOperation: async () => ({
+        authorizeCatalogOperation: async () => ({
           accessPolicy: 0,
           policyDigest: POLICY_DIGEST,
         }),
@@ -233,6 +316,204 @@ describe('RFC-64 public catalog native content transport v1', () => {
     }, { timeoutMs: 4_000 })).rejects.toThrow(/policy/);
     expect(providerRead).not.toHaveBeenCalled();
   }, 15_000);
+
+  it('denies a private-policy request before provider lookup on both content protocols', async () => {
+    const [authorNode, receiverNode] = await Promise.all([startNode(), startNode()]);
+    await connect(receiverNode, authorNode);
+    const providerObjectRead = vi.fn(async () => null);
+    const providerBundleRead = vi.fn(async () => null);
+    const authorTransport = new Rfc64PublicCatalogNativeTransportV1(
+      new ProtocolRouter(authorNode),
+      {
+        readCatalogObjectByDigest: providerObjectRead,
+        readKaBundleByDigest: providerBundleRead,
+        // A provider that has itself accepted a private cell must STILL refuse to serve that cell's
+        // content over the native protocols. The serve path resolves purely by the digest in the
+        // request, out of a store shared by every graph on the node, so serving private content here
+        // would hand it to anyone authorized under any public cell the node happens to hold.
+        authorizeCatalogOperation: async () => ({
+          accessPolicy: 1,
+          policyDigest: POLICY_DIGEST,
+        }),
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    const receiverTransport = new Rfc64PublicCatalogNativeTransportV1(
+      new ProtocolRouter(receiverNode),
+      {
+        readCatalogObjectByDigest: async () => null,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: async () => ({
+          accessPolicy: 0,
+          policyDigest: POLICY_DIGEST,
+        }),
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    transports.push(authorTransport, receiverTransport);
+    authorTransport.start();
+    receiverTransport.start();
+
+    const scope = {
+      networkId: 'otp:20430' as never,
+      contextGraphId: '0x1111111111111111111111111111111111111111/private-denied' as never,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      catalogEra: '0' as never,
+      catalogVersion: '1' as never,
+      policyDigest: POLICY_DIGEST,
+      catalogHeadObjectDigest: `0x${'81'.repeat(32)}` as Digest32V1,
+    };
+
+    await expect(receiverTransport.fetchCatalogObject(authorNode.peerId, {
+      kind: RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+      ...scope,
+      targetObjectType: AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+      targetObjectDigest: `0x${'82'.repeat(32)}` as Digest32V1,
+    }, { timeoutMs: 4_000 })).rejects.toThrow(/policy/);
+    expect(providerObjectRead).not.toHaveBeenCalled();
+
+    const encoded = encodeOpaqueKaBundleV1(UTF8.encode('private'), new Uint8Array());
+    await expect(receiverTransport.fetchKaBundle(authorNode.peerId, {
+      kind: RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
+      ...scope,
+      blobDigest: encoded.blobDigest,
+      byteLength: encoded.bundleBytes.byteLength.toString() as never,
+    }, { timeoutMs: 4_000 })).rejects.toThrow(/policy/);
+    expect(providerBundleRead).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it('rechecks provider authorization after an awaited catalog-object miss', async () => {
+    const [authorNode, receiverNode] = await Promise.all([startNode(), startNode()]);
+    await connect(receiverNode, authorNode);
+    const providerRead = vi.fn(async () => null);
+    let providerAuthorizationChecks = 0;
+    const authorTransport = new Rfc64PublicCatalogNativeTransportV1(
+      new ProtocolRouter(authorNode),
+      {
+        readCatalogObjectByDigest: providerRead,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: async () => {
+          providerAuthorizationChecks += 1;
+          return providerAuthorizationChecks === 1 ? {
+            accessPolicy: 0,
+            policyDigest: POLICY_DIGEST,
+          } : null;
+        },
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    const receiverTransport = new Rfc64PublicCatalogNativeTransportV1(
+      new ProtocolRouter(receiverNode),
+      {
+        readCatalogObjectByDigest: async () => null,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: async () => ({
+          accessPolicy: 0,
+          policyDigest: POLICY_DIGEST,
+        }),
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    transports.push(authorTransport, receiverTransport);
+    authorTransport.start();
+    receiverTransport.start();
+
+    await expect(receiverTransport.fetchCatalogObject(authorNode.peerId, {
+      kind: RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+      networkId: 'otp:20430' as never,
+      contextGraphId: '0x1111111111111111111111111111111111111111/revoked' as never,
+      subGraphName: 'member-subgraph' as never,
+      authorAddress: AUTHOR,
+      catalogEra: '0' as never,
+      catalogVersion: '1' as never,
+      policyDigest: POLICY_DIGEST,
+      catalogHeadObjectDigest: `0x${'81'.repeat(32)}` as Digest32V1,
+      targetObjectType: AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+      targetObjectDigest: `0x${'82'.repeat(32)}` as Digest32V1,
+    }, { timeoutMs: 4_000 })).rejects.toMatchObject({
+      code: 'catalog-native-policy-denied',
+    });
+    expect(providerRead).toHaveBeenCalledOnce();
+    expect(providerAuthorizationChecks).toBe(2);
+  }, 15_000);
+
+  it('rechecks current authorization after the outbound bundle-fetch await', async () => {
+    const bundle = encodeOpaqueKaBundleV1(UTF8.encode('x'), new Uint8Array()).bundleBytes;
+    const response = new Uint8Array(bundle.byteLength + 1);
+    response[0] = 1;
+    response.set(bundle, 1);
+    const send = vi.fn(async () => response);
+    let authorizationChecks = 0;
+    const transport = new Rfc64PublicCatalogNativeTransportV1({
+      register: () => {},
+      unregister: () => {},
+      send,
+    } as unknown as ProtocolRouter, {
+      readCatalogObjectByDigest: async () => null,
+      readKaBundleByDigest: async () => null,
+      authorizeCatalogOperation: async () => {
+        authorizationChecks += 1;
+        return authorizationChecks === 1 ? {
+          accessPolicy: 0,
+          policyDigest: POLICY_DIGEST,
+        } : null;
+      },
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transports.push(transport);
+    transport.start();
+
+    await expect(transport.fetchKaBundle('remote-peer', {
+      kind: RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
+      networkId: 'otp:20430' as never,
+      contextGraphId: '0x1111111111111111111111111111111111111111/recheck' as never,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      catalogEra: '0' as never,
+      catalogVersion: '1' as never,
+      policyDigest: POLICY_DIGEST,
+      catalogHeadObjectDigest: `0x${'81'.repeat(32)}` as Digest32V1,
+      blobDigest: encodeOpaqueKaBundleV1(UTF8.encode('x'), new Uint8Array()).blobDigest,
+      byteLength: bundle.byteLength.toString() as never,
+    })).rejects.toMatchObject({ code: 'catalog-native-policy-denied' });
+    expect(send).toHaveBeenCalledOnce();
+    expect(authorizationChecks).toBe(2);
+  });
+
+  it('rejects a stale registry digest before sending a native fetch request', async () => {
+    const send = vi.fn(async () => Uint8Array.of(0));
+    const transport = new Rfc64PublicCatalogNativeTransportV1({
+      register: () => {},
+      unregister: () => {},
+      send,
+    } as unknown as ProtocolRouter, {
+      readCatalogObjectByDigest: async () => null,
+      readKaBundleByDigest: async () => null,
+      authorizeCatalogOperation: async () => ({
+        accessPolicy: 0,
+        policyDigest: `0x${'99'.repeat(32)}` as Digest32V1,
+      }),
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transports.push(transport);
+    transport.start();
+
+    await expect(transport.fetchCatalogObject('remote-peer', {
+      kind: RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+      networkId: 'otp:20430' as never,
+      contextGraphId: '0x1111111111111111111111111111111111111111/stale' as never,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      catalogEra: '0' as never,
+      catalogVersion: '1' as never,
+      policyDigest: POLICY_DIGEST,
+      catalogHeadObjectDigest: `0x${'81'.repeat(32)}` as Digest32V1,
+      targetObjectType: AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+      targetObjectDigest: `0x${'82'.repeat(32)}` as Digest32V1,
+    })).rejects.toMatchObject({ code: 'catalog-native-policy-denied' });
+    expect(send).not.toHaveBeenCalled();
+  });
 
   it('rejects a generic signature proof minted for another exact signature variant', async () => {
     const produced = await produceEmptyAuthorCatalogGenesisV1({
@@ -285,7 +566,7 @@ describe('RFC-64 public catalog native content transport v1', () => {
     const transport = new Rfc64PublicCatalogNativeTransportV1(router, {
       readCatalogObjectByDigest: async () => null,
       readKaBundleByDigest: async () => null,
-      authorizeOpenCatalogOperation: async () => ({
+      authorizeCatalogOperation: async () => ({
         accessPolicy: 0,
         policyDigest: POLICY_DIGEST,
       }),

--- a/packages/agent/test/rfc64-public-catalog-native-transport-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-transport-v1.test.ts
@@ -1,7 +1,6 @@
 import { multiaddr } from '@multiformats/multiaddr';
 import {
   AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
-  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   DKGNode,
   ProtocolRouter,
   canonicalizeSignedControlEnvelopeBytes,
@@ -9,10 +8,8 @@ import {
   encodeOpaqueKaBundleV1,
   type AuthorCatalogScopeV1,
   type ContextGraphIdV1,
-  type ContextGraphPolicyV1,
   type Digest32V1,
   type EvmAddressV1,
-  type MemberRosterV1,
   type SignedControlEnvelopeV1,
 } from '@origintrail-official/dkg-core';
 import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
@@ -20,7 +17,6 @@ import { ethers } from 'ethers';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
-import { Rfc64CatalogAccessPolicyRegistryV1 } from '../src/rfc64/catalog-access-policy-v1.js';
 import {
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
@@ -32,6 +28,7 @@ import {
   type Rfc64PublicCatalogNativeFetchScopeV1,
   Rfc64PublicCatalogNativeTransportErrorV1,
 } from '../src/rfc64/public-catalog-native-transport-v1.js';
+import { createRfc64CatalogAccessPolicyRegistryFixture } from './support/rfc64-catalog-access-policy-fixture.js';
 
 const AUTHOR_WALLET = new ethers.Wallet(`0x${'65'.repeat(32)}`);
 const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
@@ -74,51 +71,17 @@ function policyRegistry(
   contextGraphId: ContextGraphIdV1,
   accessPolicy: 0 | 1,
   publishPolicy: 0 | 1,
-): Rfc64CatalogAccessPolicyRegistryV1 {
-  const registry = new Rfc64CatalogAccessPolicyRegistryV1({
+) {
+  return createRfc64CatalogAccessPolicyRegistryFixture({
     localAgentAddress,
-    resolveRemoteAgentAddress: async () => remoteAgentAddress,
-  });
-  const policy = {
-    networkId: 'otp:20430',
+    remoteAgentAddress,
     contextGraphId,
-    governanceChainId: null,
-    governanceContractAddress: null,
-    ownershipTransitionDigest: null,
-    era: '0',
-    version: '0',
-    previousPolicyDigest: null,
     accessPolicy,
     publishPolicy,
-    publishAuthority: publishPolicy === 0 ? CURATOR : null,
-    publishAuthorityAccountId: '0',
-    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
-    administrativeDelegationDigest: null,
-    source: {
-      kind: 'owner-signed-unregistered',
-      ownerAddress: AUTHOR,
-      ownerAuthorityEra: '0',
-    },
-    effectiveAt: '0',
-    issuedAt: '0',
-  } satisfies ContextGraphPolicyV1;
-  const roster = accessPolicy === 0 ? null : {
-    networkId: policy.networkId,
-    contextGraphId: policy.contextGraphId,
-    ownershipTransitionDigest: null,
-    era: '0',
-    version: '0',
-    previousRosterDigest: null,
     policyDigest: POLICY_DIGEST,
-    administrativeDelegationDigest: null,
-    members: [
-      { agentAddress: LOCAL_MEMBER, roles: ['holder', 'provider'] },
-      { agentAddress: REMOTE_MEMBER, roles: ['holder', 'provider'] },
-    ],
-    issuedAt: '0',
-  } satisfies MemberRosterV1;
-  registry.accept({ policy, policyDigest: POLICY_DIGEST, roster });
-  return registry;
+    ownerAddress: AUTHOR,
+    curatorAddress: CURATOR,
+  });
 }
 
 describe('RFC-64 public catalog native content transport v1', () => {

--- a/packages/agent/test/rfc64-public-catalog-transport-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-transport-v1.test.ts
@@ -4,17 +4,24 @@ import { join } from 'node:path';
 
 import { multiaddr } from '@multiformats/multiaddr';
 import {
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   DKGNode,
   ProtocolRouter,
   type AuthorCatalogScopeV1,
+  type ContextGraphPolicyV1,
   type Digest32V1,
   type EvmAddressV1,
+  type MemberRosterV1,
 } from '@origintrail-official/dkg-core';
 import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
 import { ethers } from 'ethers';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
+import {
+  Rfc64CatalogAccessPolicyRegistryV1,
+  type Rfc64CatalogAccessAuthorizationInputV1,
+} from '../src/rfc64/catalog-access-policy-v1.js';
 import { openRfc64PersistenceV1, type Rfc64PersistenceV1 } from '../src/rfc64/persistence-v1.js';
 import {
   RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
@@ -23,7 +30,6 @@ import {
   Rfc64PublicCatalogTransportV1,
   encodeRfc64PublicCatalogHeadAnnouncementV1,
   parseRfc64PublicCatalogHeadAnnouncementV1,
-  type Rfc64PublicCatalogAuthorizationInputV1,
   type Rfc64PublicCatalogHeadAnnouncementV1,
 } from '../src/rfc64/public-catalog-transport-v1.js';
 
@@ -31,6 +37,11 @@ const AUTHOR_WALLET = new ethers.Wallet(`0x${'64'.repeat(32)}`);
 const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
 const POLICY_DIGEST = `0x${'71'.repeat(32)}` as Digest32V1;
 const DELEGATION_DIGEST = `0x${'72'.repeat(32)}` as Digest32V1;
+const CONTEXT_GRAPH_ID =
+  '0x1111111111111111111111111111111111111111/gate-1' as const;
+const LOCAL_MEMBER = '0x3333333333333333333333333333333333333333' as EvmAddressV1;
+const REMOTE_MEMBER = '0x4444444444444444444444444444444444444444' as EvmAddressV1;
+const CURATOR = '0x5555555555555555555555555555555555555555' as EvmAddressV1;
 
 const temporaryDirectories: string[] = [];
 const nodes: DKGNode[] = [];
@@ -86,7 +97,7 @@ async function stageOpenCatalogHead(
 ): Promise<Rfc64PublicCatalogHeadAnnouncementV1> {
   const scope = {
     networkId: 'otp:20430',
-    contextGraphId: '0x1111111111111111111111111111111111111111/gate-1',
+    contextGraphId: CONTEXT_GRAPH_ID,
     governanceChainId: '20430',
     governanceContractAddress: '0x2222222222222222222222222222222222222222',
     ownershipTransitionDigest: null,
@@ -130,8 +141,67 @@ const OPEN_POLICY = async () => Object.freeze({
   policyDigest: POLICY_DIGEST,
 });
 
-describe('RFC-64 public/open author catalog transport v1', () => {
-  it('announces and fetches one exact signed head across two live libp2p nodes', async () => {
+function policyRegistry(
+  localAgentAddress: EvmAddressV1,
+  remoteAgentAddress: EvmAddressV1,
+  accessPolicy: 0 | 1,
+  publishPolicy: 0 | 1,
+): Rfc64CatalogAccessPolicyRegistryV1 {
+  const registry = new Rfc64CatalogAccessPolicyRegistryV1({
+    localAgentAddress,
+    resolveRemoteAgentAddress: async () => remoteAgentAddress,
+  });
+  const policy = {
+    networkId: 'otp:20430',
+    contextGraphId: CONTEXT_GRAPH_ID,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy,
+    publishPolicy,
+    publishAuthority: publishPolicy === 0 ? CURATOR : null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'owner-signed-unregistered',
+      ownerAddress: AUTHOR,
+      ownerAuthorityEra: '0',
+    },
+    effectiveAt: '0',
+    issuedAt: '0',
+  } satisfies ContextGraphPolicyV1;
+  const roster = accessPolicy === 0 ? null : {
+    networkId: policy.networkId,
+    contextGraphId: policy.contextGraphId,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest: POLICY_DIGEST,
+    administrativeDelegationDigest: null,
+    members: [
+      { agentAddress: LOCAL_MEMBER, roles: ['holder', 'provider'] },
+      { agentAddress: REMOTE_MEMBER, roles: ['holder', 'provider'] },
+    ],
+    issuedAt: '0',
+  } satisfies MemberRosterV1;
+  registry.accept({ policy, policyDigest: POLICY_DIGEST, roster });
+  return registry;
+}
+
+describe('RFC-64 author catalog transport v1', () => {
+  it.each([
+    { accessPolicy: 0 as const, publishPolicy: 0 as const },
+    { accessPolicy: 0 as const, publishPolicy: 1 as const },
+    { accessPolicy: 1 as const, publishPolicy: 0 as const },
+    { accessPolicy: 1 as const, publishPolicy: 1 as const },
+  ])(
+    'announces and fetches one exact signed head for accessPolicy=$accessPolicy publishPolicy=$publishPolicy',
+    async ({ accessPolicy, publishPolicy }) => {
     const [authorNode, receiverNode, authorPersistence, receiverPersistence] = await Promise.all([
       startNode(),
       startNode(),
@@ -145,16 +215,28 @@ describe('RFC-64 public/open author catalog transport v1', () => {
       announcement: Rfc64PublicCatalogHeadAnnouncementV1;
       remotePeerId: string;
     }> = [];
-    const authorAuthorizations: Rfc64PublicCatalogAuthorizationInputV1[] = [];
-    const receiverAuthorizations: Rfc64PublicCatalogAuthorizationInputV1[] = [];
+    const authorAuthorizations: Rfc64CatalogAccessAuthorizationInputV1[] = [];
+    const receiverAuthorizations: Rfc64CatalogAccessAuthorizationInputV1[] = [];
+    const authorPolicy = policyRegistry(
+      LOCAL_MEMBER,
+      REMOTE_MEMBER,
+      accessPolicy,
+      publishPolicy,
+    );
+    const receiverPolicy = policyRegistry(
+      REMOTE_MEMBER,
+      LOCAL_MEMBER,
+      accessPolicy,
+      publishPolicy,
+    );
 
     const authorTransport = new Rfc64PublicCatalogTransportV1(
       new ProtocolRouter(authorNode),
       {
         controlObjects: authorPersistence.controlObjects,
-        authorizeOpenCatalogOperation: async (input) => {
+        authorizeCatalogOperation: async (input) => {
           authorAuthorizations.push(input);
-          return OPEN_POLICY();
+          return authorPolicy.authorize(input);
         },
         verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
         onCatalogHeadAvailable: async () => {},
@@ -164,9 +246,9 @@ describe('RFC-64 public/open author catalog transport v1', () => {
       new ProtocolRouter(receiverNode),
       {
         controlObjects: receiverPersistence.controlObjects,
-        authorizeOpenCatalogOperation: async (input) => {
+        authorizeCatalogOperation: async (input) => {
           receiverAuthorizations.push(input);
-          return OPEN_POLICY();
+          return receiverPolicy.authorize(input);
         },
         verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
         onCatalogHeadAvailable: async (received, remotePeerId) => {
@@ -221,10 +303,13 @@ describe('RFC-64 public/open author catalog transport v1', () => {
       'announce-inbound',
       'fetch-outbound',
       'fetch-outbound',
+      'fetch-outbound',
     ]);
-  }, 30_000);
+    },
+    30_000,
+  );
 
-  it('denies private-policy fetch before revealing cache hit or miss state', async () => {
+  it('denies an unauthorized fetch before revealing cache hit or miss state', async () => {
     const [providerNode, requesterNode] = await Promise.all([startNode(), startNode()]);
     await connect(requesterNode, providerNode);
     const getVerifiedObject = vi.fn(async () => null);
@@ -245,10 +330,7 @@ describe('RFC-64 public/open author catalog transport v1', () => {
       new ProtocolRouter(providerNode),
       {
         controlObjects: { getVerifiedObject },
-        authorizeOpenCatalogOperation: async () => ({
-          accessPolicy: 1,
-          policyDigest: POLICY_DIGEST,
-        }),
+        authorizeCatalogOperation: async () => null,
         verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
         onCatalogHeadAvailable: async () => {},
       },
@@ -257,7 +339,7 @@ describe('RFC-64 public/open author catalog transport v1', () => {
       new ProtocolRouter(requesterNode),
       {
         controlObjects: { getVerifiedObject: vi.fn(async () => null) },
-        authorizeOpenCatalogOperation: OPEN_POLICY,
+        authorizeCatalogOperation: OPEN_POLICY,
         verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
         onCatalogHeadAvailable: async () => {},
       },
@@ -273,6 +355,82 @@ describe('RFC-64 public/open author catalog transport v1', () => {
     )).rejects.toThrow();
     expect(getVerifiedObject).not.toHaveBeenCalled();
   }, 15_000);
+
+  it('rechecks current authorization after the outbound fetch await', async () => {
+    const send = vi.fn(async () => Uint8Array.of(0));
+    const router = {
+      register: () => {},
+      unregister: () => {},
+      send,
+    } as unknown as ProtocolRouter;
+    let authorizationChecks = 0;
+    const transport = new Rfc64PublicCatalogTransportV1(router, {
+      controlObjects: { getVerifiedObject: async () => null },
+      authorizeCatalogOperation: async () => {
+        authorizationChecks += 1;
+        return authorizationChecks === 1 ? {
+          accessPolicy: 1,
+          policyDigest: POLICY_DIGEST,
+        } : null;
+      },
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      onCatalogHeadAvailable: async () => {},
+    });
+    transports.push(transport);
+    transport.start();
+    const announcement = {
+      kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+      networkId: 'otp:20430',
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      catalogEra: '0',
+      catalogVersion: '0',
+      policyDigest: POLICY_DIGEST,
+      catalogHeadObjectDigest: `0x${'81'.repeat(32)}`,
+      signatureVariantDigest: `0x${'82'.repeat(32)}`,
+    } as Rfc64PublicCatalogHeadAnnouncementV1;
+
+    await expect(transport.fetchCatalogHead('remote-peer', announcement))
+      .rejects.toMatchObject({ code: 'catalog-transport-policy-denied' });
+    expect(send).toHaveBeenCalledOnce();
+    expect(authorizationChecks).toBe(2);
+  });
+
+  it('rejects a stale registry digest before sending any wire request', async () => {
+    const send = vi.fn(async () => Uint8Array.of(0));
+    const transport = new Rfc64PublicCatalogTransportV1({
+      register: () => {},
+      unregister: () => {},
+      send,
+    } as unknown as ProtocolRouter, {
+      controlObjects: { getVerifiedObject: async () => null },
+      authorizeCatalogOperation: async () => ({
+        accessPolicy: 1,
+        policyDigest: `0x${'99'.repeat(32)}` as Digest32V1,
+      }),
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      onCatalogHeadAvailable: async () => {},
+    });
+    transports.push(transport);
+    transport.start();
+    const announcement = {
+      kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+      networkId: 'otp:20430',
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      catalogEra: '0',
+      catalogVersion: '0',
+      policyDigest: POLICY_DIGEST,
+      catalogHeadObjectDigest: `0x${'81'.repeat(32)}`,
+      signatureVariantDigest: `0x${'82'.repeat(32)}`,
+    } as Rfc64PublicCatalogHeadAnnouncementV1;
+
+    await expect(transport.fetchCatalogHead('remote-peer', announcement))
+      .rejects.toMatchObject({ code: 'catalog-transport-policy-denied' });
+    expect(send).not.toHaveBeenCalled();
+  });
 
   it('round-trips only exact canonical announcement fields', () => {
     const announcement = Object.freeze({

--- a/packages/agent/test/rfc64-public-catalog-transport-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-transport-v1.test.ts
@@ -4,14 +4,11 @@ import { join } from 'node:path';
 
 import { multiaddr } from '@multiformats/multiaddr';
 import {
-  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   DKGNode,
   ProtocolRouter,
   type AuthorCatalogScopeV1,
-  type ContextGraphPolicyV1,
   type Digest32V1,
   type EvmAddressV1,
-  type MemberRosterV1,
 } from '@origintrail-official/dkg-core';
 import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
 import { ethers } from 'ethers';
@@ -19,7 +16,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
 import {
-  Rfc64CatalogAccessPolicyRegistryV1,
   type Rfc64CatalogAccessAuthorizationInputV1,
 } from '../src/rfc64/catalog-access-policy-v1.js';
 import { openRfc64PersistenceV1, type Rfc64PersistenceV1 } from '../src/rfc64/persistence-v1.js';
@@ -32,6 +28,7 @@ import {
   parseRfc64PublicCatalogHeadAnnouncementV1,
   type Rfc64PublicCatalogHeadAnnouncementV1,
 } from '../src/rfc64/public-catalog-transport-v1.js';
+import { createRfc64CatalogAccessPolicyRegistryFixture } from './support/rfc64-catalog-access-policy-fixture.js';
 
 const AUTHOR_WALLET = new ethers.Wallet(`0x${'64'.repeat(32)}`);
 const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
@@ -146,51 +143,17 @@ function policyRegistry(
   remoteAgentAddress: EvmAddressV1,
   accessPolicy: 0 | 1,
   publishPolicy: 0 | 1,
-): Rfc64CatalogAccessPolicyRegistryV1 {
-  const registry = new Rfc64CatalogAccessPolicyRegistryV1({
+) {
+  return createRfc64CatalogAccessPolicyRegistryFixture({
     localAgentAddress,
-    resolveRemoteAgentAddress: async () => remoteAgentAddress,
-  });
-  const policy = {
-    networkId: 'otp:20430',
+    remoteAgentAddress,
     contextGraphId: CONTEXT_GRAPH_ID,
-    governanceChainId: null,
-    governanceContractAddress: null,
-    ownershipTransitionDigest: null,
-    era: '0',
-    version: '0',
-    previousPolicyDigest: null,
     accessPolicy,
     publishPolicy,
-    publishAuthority: publishPolicy === 0 ? CURATOR : null,
-    publishAuthorityAccountId: '0',
-    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
-    administrativeDelegationDigest: null,
-    source: {
-      kind: 'owner-signed-unregistered',
-      ownerAddress: AUTHOR,
-      ownerAuthorityEra: '0',
-    },
-    effectiveAt: '0',
-    issuedAt: '0',
-  } satisfies ContextGraphPolicyV1;
-  const roster = accessPolicy === 0 ? null : {
-    networkId: policy.networkId,
-    contextGraphId: policy.contextGraphId,
-    ownershipTransitionDigest: null,
-    era: '0',
-    version: '0',
-    previousRosterDigest: null,
     policyDigest: POLICY_DIGEST,
-    administrativeDelegationDigest: null,
-    members: [
-      { agentAddress: LOCAL_MEMBER, roles: ['holder', 'provider'] },
-      { agentAddress: REMOTE_MEMBER, roles: ['holder', 'provider'] },
-    ],
-    issuedAt: '0',
-  } satisfies MemberRosterV1;
-  registry.accept({ policy, policyDigest: POLICY_DIGEST, roster });
-  return registry;
+    ownerAddress: AUTHOR,
+    curatorAddress: CURATOR,
+  });
 }
 
 describe('RFC-64 author catalog transport v1', () => {
@@ -353,6 +316,55 @@ describe('RFC-64 author catalog transport v1', () => {
       announcement,
       { timeoutMs: 4_000 },
     )).rejects.toThrow();
+    expect(getVerifiedObject).not.toHaveBeenCalled();
+  }, 15_000);
+
+  it('keeps the deprecated open authorizer fail-closed for private policy', async () => {
+    const [providerNode, requesterNode] = await Promise.all([startNode(), startNode()]);
+    await connect(requesterNode, providerNode);
+    const getVerifiedObject = vi.fn(async () => null);
+    const announcement = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+      networkId: 'otp:20430',
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      catalogEra: '0',
+      catalogVersion: '0',
+      policyDigest: POLICY_DIGEST,
+      catalogHeadObjectDigest: `0x${'81'.repeat(32)}`,
+      signatureVariantDigest: `0x${'82'.repeat(32)}`,
+    }) as Rfc64PublicCatalogHeadAnnouncementV1;
+    const providerTransport = new Rfc64PublicCatalogTransportV1(
+      new ProtocolRouter(providerNode),
+      {
+        controlObjects: { getVerifiedObject },
+        authorizeOpenCatalogOperation: async () => ({
+          accessPolicy: 1,
+          policyDigest: POLICY_DIGEST,
+        }),
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+        onCatalogHeadAvailable: async () => {},
+      },
+    );
+    const requesterTransport = new Rfc64PublicCatalogTransportV1(
+      new ProtocolRouter(requesterNode),
+      {
+        controlObjects: { getVerifiedObject: async () => null },
+        authorizeCatalogOperation: OPEN_POLICY,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+        onCatalogHeadAvailable: async () => {},
+      },
+    );
+    transports.push(providerTransport, requesterTransport);
+    providerTransport.start();
+    requesterTransport.start();
+
+    await expect(requesterTransport.fetchCatalogHead(
+      providerNode.peerId,
+      announcement,
+      { timeoutMs: 4_000 },
+    )).rejects.toMatchObject({ code: 'catalog-transport-policy-denied' });
     expect(getVerifiedObject).not.toHaveBeenCalled();
   }, 15_000);
 

--- a/packages/agent/test/support/rfc64-catalog-access-policy-fixture.ts
+++ b/packages/agent/test/support/rfc64-catalog-access-policy-fixture.ts
@@ -1,0 +1,69 @@
+import {
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+  type ContextGraphIdV1,
+  type ContextGraphPolicyV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type MemberRosterV1,
+  type NetworkIdV1,
+} from '@origintrail-official/dkg-core';
+
+import { Rfc64CatalogAccessPolicyRegistryV1 } from '../../src/rfc64/catalog-access-policy-v1.js';
+
+export function createRfc64CatalogAccessPolicyRegistryFixture(options: {
+  readonly localAgentAddress: EvmAddressV1;
+  readonly remoteAgentAddress: EvmAddressV1;
+  readonly networkId?: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly accessPolicy: 0 | 1;
+  readonly publishPolicy: 0 | 1;
+  readonly policyDigest: Digest32V1;
+  readonly ownerAddress: EvmAddressV1;
+  readonly curatorAddress: EvmAddressV1;
+}): Rfc64CatalogAccessPolicyRegistryV1 {
+  const networkId = options.networkId ?? 'otp:20430';
+  const registry = new Rfc64CatalogAccessPolicyRegistryV1({
+    localAgentAddress: options.localAgentAddress,
+    resolveRemoteAgentAddress: async () => options.remoteAgentAddress,
+  });
+  const policy = {
+    networkId,
+    contextGraphId: options.contextGraphId,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy: options.accessPolicy,
+    publishPolicy: options.publishPolicy,
+    publishAuthority: options.publishPolicy === 0 ? options.curatorAddress : null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'owner-signed-unregistered',
+      ownerAddress: options.ownerAddress,
+      ownerAuthorityEra: '0',
+    },
+    effectiveAt: '0',
+    issuedAt: '0',
+  } satisfies ContextGraphPolicyV1;
+  const roster = options.accessPolicy === 0 ? null : {
+    networkId: policy.networkId,
+    contextGraphId: policy.contextGraphId,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest: options.policyDigest,
+    administrativeDelegationDigest: null,
+    members: [
+      { agentAddress: options.localAgentAddress, roles: ['holder', 'provider'] },
+      { agentAddress: options.remoteAgentAddress, roles: ['holder', 'provider'] },
+    ].sort((left, right) => left.agentAddress.localeCompare(right.agentAddress)),
+    issuedAt: '0',
+  } satisfies MemberRosterV1;
+  registry.accept({ policy, policyDigest: options.policyDigest, roster });
+  return registry;
+}


### PR DESCRIPTION
## What

Replaces the ad-hoc open-policy check on the RFC-64 catalog transports with the registry-backed access-policy authorizer landed in #1835:

- exactly one authorizer must be configured (current or legacy compatibility path),
- authorization is re-checked after each `await` on the inbound and outbound paths, so a policy revoked mid-operation cannot be raced,
- head requests remain bound to the authorized scope.

Stacked on `integration/rfc64-devnet` @ `3089e573e` (the #1835 merge). Part of the RFC-64 **V2 public-first** milestone. **Not for `main`.**

## Security decision: the native *content* protocols stay public-only

The two native content protocols (`/dkg/catalog/1/control-object/by-digest`, `/dkg/catalog/1/ka-bundle/by-digest`) keep the `accessPolicy === 0` gate.

An earlier revision of this branch widened that gate to admit private cells (`accessPolicy 0 || 1`). That is **unsound today**, and an adversarial review reproduced it at runtime against the built dist:

- both handlers resolve the object/bundle **purely by the digest carried in the request**, out of a store that is **shared by every context graph on the node**;
- authorization is decided from the requester's **claimed** `networkId`/`contextGraphId`/`policyDigest`, and a public cell allows any authenticated peer;
- nothing on the serve path binds what is served back to the graph that authorized the request (`assertCatalogObjectMatchesRequest` compares only `objectType`/`objectDigest`/`issuer` — all supplied by the same request).

Net effect: the ACL over every control object and KA bundle on the node collapses to *"possession of a digest"*. A peer authorized under public CG `A` could read private CG `B`'s signed head/directory objects and full KA payloads, and a removed member's remembered digests would remain a permanent read capability. The **head** transport in this same commit *does* scope-bind (`assertHeadMatchesScope`), so this was an asymmetry rather than a design choice — and the object protocol would have served the very head envelope the head transport protects.

Serving private content needs the serve path scope-bound first: heads carry `networkId`/`contextGraphId`; buckets carry `catalogScopeDigest`, which the authorizer's `{accessPolicy, policyDigest}` return cannot reconstruct; directory nodes carry no scope; opaque bundles can bind only via row membership in the announced-and-verified `catalogHeadObjectDigest` that the request already carries but never uses. That is a **design slice for the private-CG milestone**, not a widening of this gate.

### Follow-up to schedule (private-CG milestone)

The RFC-64 control-object and KA-bundle stores are agent-wide and digest-keyed. This is benign while only publicly-readable cells are servable (their content is open by definition), but it is the **structural blocker for the private cell and for roster revocation**. The sound binding: authorization returns the accepted scope, objects bind to it, and bundles are proven committed by a row of the announced-and-verified head.

## Tests pin the boundary, not the hole

- The live two-node fetch runs across **both public cells** — `publishPolicy` governs finalized-VM admission only and must not affect read authorization.
- Restored (and strengthened) negative: a private-policy provider denies **before provider lookup on both content protocols**, asserting the provider store is never consulted.

## Evidence

- `tsc + test:types + test:package-root` → exit 0, zero errors.
- Full RFC-64 unit regression → **31 files / 374 passed, 5 skipped, 0 failed**.
- **Mutation-verified:** re-widening the gate to admit `accessPolicy 1` makes `denies a private-policy request before provider lookup on both content protocols` **fail**. The test has teeth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
