### PR TITLE
feat(agent): compose RFC-64 generic catalog authoring service/API (CP1)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -23,6 +23,7 @@
     "./dist/rfc64/control-object-store-v1-internal.js": null,
     "./dist/rfc64/control-object-store-v1.js": null,
     "./dist/rfc64/catalog-access-policy-v1.js": null,
+    "./dist/rfc64/catalog-authority-config-v1.js": null,
     "./dist/rfc64/catalog-transport-authorization-v1.js": null,
     "./dist/rfc64/durable-file-store-v1.js": null,
     "./dist/rfc64/ka-bundle-store-v1-internal.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -79,6 +79,7 @@ const publicRfc64Modules = [
 ];
 const blockedRfc64Modules = [
   'catalog-access-policy-v1.js',
+  'catalog-authority-config-v1.js',
   'catalog-transport-authorization-v1.js',
   'control-object-store-v1-internal.js',
   'control-object-store-v1.js',

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -23,6 +23,19 @@ if (
 ) {
   throw new Error('published agent entry points did not expose required root APIs');
 }
+const requiredCatalogMethods = [
+  'acceptRfc64CatalogAccessSnapshotV1',
+  'publishAuthorCatalogGenesisV1',
+  'publishAuthorCatalogExactSetSuccessorV1',
+];
+for (const method of requiredCatalogMethods) {
+  if (
+    typeof root.DKGAgent.prototype[method] !== 'function'
+    || typeof legacyAgent.DKGAgent.prototype[method] !== 'function'
+  ) {
+    throw new Error(`published DKGAgent entry points did not expose ${method}`);
+  }
+}
 if (
   !Array.isArray(root.RFC64_POLICY_CELLS_V1)
   || !Object.isFrozen(root.RFC64_POLICY_CELLS_V1)

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -43,19 +43,18 @@ import {
   type DecimalU64V1,
   type AuthorCatalogScopeV1,
   type CountV1,
-  assertCanonicalChainId,
-  assertNetworkIdV1,
   type SignedAuthorCatalogBucketEnvelopeV1,
   type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
   type SignedAuthorCatalogHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core';
 import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
-import { ethers } from 'ethers';
-
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
-import type { Rfc64CatalogAccessPolicyAuthorityConfigV1 } from './dkg-agent-types.js';
 import type { Rfc64AuthorCatalogEip191SignerV1 } from './rfc64/author-catalog-producer.js';
+import {
+  snapshotRfc64CatalogAccessPolicyAuthorityV1,
+  snapshotRfc64CatalogDeploymentProfileV1,
+} from './rfc64/catalog-authority-config-v1.js';
 import type { AcceptedOpenCatalogPolicyV1 } from './rfc64/open-catalog-policy-v1.js';
 import type {
   AcceptRfc64CatalogAccessSnapshotInputV1,
@@ -66,6 +65,7 @@ import type { Rfc64PersistenceV1 } from './rfc64/persistence-v1.js';
 import {
   Rfc64PublicCatalogServiceV1,
   snapshotRfc64PublicCatalogAnnouncementPeersV1,
+  type PublishAuthorCatalogGenesisResultV1,
   type PublishOpenAuthorCatalogGenesisResultV1,
   type AnnounceRfc64PublicCatalogHeadInputV1,
   type AnnounceRfc64PublicCatalogHeadResultV1,
@@ -97,16 +97,13 @@ import {
 } from './rfc64/public-catalog-transport-v1.js';
 
 /** Minimal EIP-191 EOA signer (ethers.Wallet-compatible) for author-catalog objects. */
-export interface Rfc64OpenCatalogAuthorSignerV1 {
+export interface Rfc64CatalogAuthorSignerV1 {
   readonly address: string;
   signMessage(message: Uint8Array): Promise<string>;
 }
 
-const LEGACY_OPEN_ONLY_LOCAL_AGENT_ADDRESS =
-  '0x0000000000000000000000000000000000000001' as EvmAddressV1;
-
-/** Policy-neutral catalog author signer; legacy open APIs use the same shape. */
-export type Rfc64CatalogAuthorSignerV1 = Rfc64OpenCatalogAuthorSignerV1;
+/** Compatibility name retained for the legacy public/open authoring surface. */
+export type Rfc64OpenCatalogAuthorSignerV1 = Rfc64CatalogAuthorSignerV1;
 
 export interface AcceptOpenContextGraphPolicyInputV1 {
   readonly networkId: NetworkIdV1;
@@ -171,90 +168,10 @@ export {
   type Rfc64PublicCatalogReconciliationFailureV1,
 } from './rfc64/public-catalog-reconciliation-failure-v1.js';
 
-/**
- * Validate and detach a locally configured deployment tuple from caller-owned
- * state. Exported so `DKGAgent.create()` can snapshot the override before any
- * asynchronous startup work begins.
- */
-export function snapshotRfc64CatalogDeploymentProfileV1(
-  input: CatalogSealDeploymentProfileV1 | undefined,
-): Readonly<CatalogSealDeploymentProfileV1> | undefined {
-  if (input === undefined) return undefined;
-  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
-    throw new TypeError('rfc64CatalogDeploymentProfile must be a plain object');
-  }
-  const prototype = Object.getPrototypeOf(input);
-  if (prototype !== Object.prototype && prototype !== null) {
-    throw new TypeError('rfc64CatalogDeploymentProfile must be a plain object');
-  }
-  const keys = Object.keys(input).sort();
-  const expectedKeys = [
-    'assertedAtChainId',
-    'assertedAtKav10Address',
-    'networkId',
-  ];
-  if (
-    keys.length !== expectedKeys.length
-    || keys.some((key, index) => key !== expectedKeys[index])
-  ) {
-    throw new TypeError(
-      'rfc64CatalogDeploymentProfile must contain exactly networkId, '
-      + 'assertedAtChainId, and assertedAtKav10Address',
-    );
-  }
-  assertNetworkIdV1(input.networkId);
-  assertCanonicalChainId(input.assertedAtChainId, 'assertedAtChainId');
-  if (!ethers.isAddress(input.assertedAtKav10Address)) {
-    throw new TypeError('assertedAtKav10Address must be a non-zero EVM address');
-  }
-  const assertedAtKav10Address = input.assertedAtKav10Address.toLowerCase() as EvmAddressV1;
-  if (assertedAtKav10Address === `0x${'00'.repeat(20)}`) {
-    throw new TypeError('assertedAtKav10Address must be a non-zero EVM address');
-  }
-  return Object.freeze({
-    networkId: input.networkId,
-    assertedAtChainId: input.assertedAtChainId,
-    assertedAtKav10Address,
-  });
-}
-
-/** Snapshot the function-bearing create-time authority without trusting caller mutation. */
-export function snapshotRfc64CatalogAccessPolicyAuthorityV1(
-  input: Rfc64CatalogAccessPolicyAuthorityConfigV1 | undefined,
-): Readonly<Rfc64CatalogAccessPolicyAuthorityConfigV1> | undefined {
-  if (input === undefined) return undefined;
-  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
-    throw new TypeError('rfc64CatalogAccessPolicyAuthority must be a plain object');
-  }
-  const prototype = Object.getPrototypeOf(input);
-  if (prototype !== Object.prototype && prototype !== null) {
-    throw new TypeError('rfc64CatalogAccessPolicyAuthority must be a plain object');
-  }
-  const keys = Object.keys(input).sort();
-  if (
-    keys.length !== 2
-    || keys[0] !== 'localAgentAddress'
-    || keys[1] !== 'resolveRemoteAgentAddress'
-  ) {
-    throw new TypeError('rfc64CatalogAccessPolicyAuthority has unknown or missing fields');
-  }
-  if (
-    typeof input.localAgentAddress !== 'string'
-    || !ethers.isAddress(input.localAgentAddress)
-    || input.localAgentAddress === ethers.ZeroAddress
-  ) {
-    throw new TypeError('rfc64CatalogAccessPolicyAuthority.localAgentAddress is invalid');
-  }
-  if (typeof input.resolveRemoteAgentAddress !== 'function') {
-    throw new TypeError(
-      'rfc64CatalogAccessPolicyAuthority.resolveRemoteAgentAddress must be a function',
-    );
-  }
-  return Object.freeze({
-    localAgentAddress: input.localAgentAddress.toLowerCase() as EvmAddressV1,
-    resolveRemoteAgentAddress: input.resolveRemoteAgentAddress,
-  });
-}
+export {
+  snapshotRfc64CatalogAccessPolicyAuthorityV1,
+  snapshotRfc64CatalogDeploymentProfileV1,
+} from './rfc64/catalog-authority-config-v1.js';
 
 export interface PublishOpenAuthorCatalogSuccessorParamsV1 {
   /** Exact durable predecessor returned by genesis or a prior successor. */
@@ -274,26 +191,25 @@ export interface PublishOpenAuthorCatalogSuccessorParamsV1 {
 }
 
 /** One member of the complete live set supplied to an ordinary successor. */
-export type Rfc64OpenCatalogSuccessorAssetInputV1 =
+export type Rfc64CatalogSuccessorAssetInputV1 =
   Rfc64PublicCatalogSuccessorAssetInputV1;
 
-export interface PublishOpenAuthorCatalogExactSetSuccessorParamsV1 {
+export interface PublishAuthorCatalogExactSetSuccessorParamsV1 {
   /** Exact durable predecessor returned by genesis or a prior successor. */
   readonly previousHead: Rfc64StagedAuthorCatalogHeadRefV1;
-  readonly author: Rfc64OpenCatalogAuthorSignerV1;
+  readonly author: Rfc64CatalogAuthorSignerV1;
   readonly catalogIssuerAuthorization: Rfc64PublicCatalogIssuerAuthorizationV1;
   /** Complete 1..1024-row live set; input order does not affect the signed head. */
-  readonly assets: readonly Rfc64OpenCatalogSuccessorAssetInputV1[];
+  readonly assets: readonly Rfc64CatalogSuccessorAssetInputV1[];
   readonly deployment: CatalogSealDeploymentProfileV1;
   readonly issuedAt?: TimestampMsV1;
   readonly peers: readonly string[];
 }
 
-export type PublishAuthorCatalogExactSetSuccessorParamsV1 =
-  PublishOpenAuthorCatalogExactSetSuccessorParamsV1;
-
-export type PublishAuthorCatalogGenesisResultV1 =
-  PublishOpenAuthorCatalogGenesisResultV1;
+export type Rfc64OpenCatalogSuccessorAssetInputV1 =
+  Rfc64CatalogSuccessorAssetInputV1;
+export type PublishOpenAuthorCatalogExactSetSuccessorParamsV1 =
+  PublishAuthorCatalogExactSetSuccessorParamsV1;
 
 export interface PublishOpenAuthorCatalogSuccessorResultV1 {
   readonly announcement: Rfc64PublicCatalogHeadAnnouncementV1;
@@ -310,7 +226,7 @@ export interface PublishOpenAuthorCatalogSuccessorResultV1 {
   readonly failedPeers: ReadonlyArray<{ readonly peerId: string; readonly error: string }>;
 }
 
-export interface PublishOpenAuthorCatalogSuccessorAssetResultV1 {
+export interface PublishAuthorCatalogSuccessorAssetResultV1 {
   readonly kaId: KaIdV1;
   readonly catalogRowDigest: Digest32V1;
   readonly bundleDigest: Digest32V1;
@@ -324,7 +240,7 @@ export interface PublishOpenAuthorCatalogSuccessorAssetResultV1 {
   readonly kaUal: string;
 }
 
-export interface PublishOpenAuthorCatalogExactSetSuccessorResultV1 {
+export interface PublishAuthorCatalogExactSetSuccessorResultV1 {
   readonly announcement: Rfc64PublicCatalogHeadAnnouncementV1;
   readonly headObjectDigest: Digest32V1;
   readonly signatureVariantDigest: Digest32V1;
@@ -335,14 +251,16 @@ export interface PublishOpenAuthorCatalogExactSetSuccessorResultV1 {
   /** Exact signed bucket row count, sourced independently of head `totalRows`. */
   readonly signedBucketRowCount: CountV1;
   /** Strictly increasing by mathematical KA ID. */
-  readonly assets: readonly Readonly<PublishOpenAuthorCatalogSuccessorAssetResultV1>[];
+  readonly assets: readonly Readonly<PublishAuthorCatalogSuccessorAssetResultV1>[];
   readonly inventoryRowCount: CountV1;
   readonly announcedPeers: readonly string[];
   readonly failedPeers: ReadonlyArray<{ readonly peerId: string; readonly error: string }>;
 }
 
-export type PublishAuthorCatalogExactSetSuccessorResultV1 =
-  PublishOpenAuthorCatalogExactSetSuccessorResultV1;
+export type PublishOpenAuthorCatalogSuccessorAssetResultV1 =
+  PublishAuthorCatalogSuccessorAssetResultV1;
+export type PublishOpenAuthorCatalogExactSetSuccessorResultV1 =
+  PublishAuthorCatalogExactSetSuccessorResultV1;
 
 export class Rfc64CatalogMethods extends DKGAgentBase {
   /**
@@ -353,24 +271,10 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     if (this.rfc64PublicCatalogServiceV1 !== undefined) return;
     const persistence = this.rfc64PersistenceV1;
     if (persistence === undefined) return;
-    const configuredAuthority = this.config.rfc64CatalogAccessPolicyAuthority;
-    const defaultAgentAddress = this.defaultAgentAddress?.toLowerCase();
-    const fallbackLocalAgentAddress = defaultAgentAddress !== undefined
-      && ethers.isAddress(defaultAgentAddress)
-      && defaultAgentAddress !== ethers.ZeroAddress
-      ? defaultAgentAddress as EvmAddressV1
-      : LEGACY_OPEN_ONLY_LOCAL_AGENT_ADDRESS;
-    const accessPolicyAuthority = configuredAuthority ?? Object.freeze({
-      localAgentAddress: fallbackLocalAgentAddress,
-      // Legacy-open compatibility only. Private snapshot acceptance is denied
-      // below unless the caller supplied an explicit authenticated resolver.
-      resolveRemoteAgentAddress: async () => null,
-    });
     const service = new Rfc64PublicCatalogServiceV1({
       router: this.router,
       controlObjects: persistence.controlObjects,
-      accessPolicyAuthority,
-      privatePolicyAuthorityConfigured: configuredAuthority !== undefined,
+      accessPolicyAuthority: this.config.rfc64CatalogAccessPolicyAuthority,
       native: this.createRfc64PublicCatalogNativeOptionsV1(),
       receiver: {
         onError: (announcement, error) => {
@@ -564,7 +468,7 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       throw new Error('RFC-64 public/open compatibility successor requires the root lane');
     }
     service.acceptedOpenPolicyDigestForCatalogScope(scope);
-    return this.publishAuthorCatalogExactSetSuccessorV1(params);
+    return this.publishAuthorCatalogExactSetSuccessorFromHistoryV1(params, history);
   }
 
   /** Exact-set successor path for any locally accepted policy cell. */
@@ -572,15 +476,33 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     this: DKGAgent,
     params: PublishAuthorCatalogExactSetSuccessorParamsV1,
   ): Promise<PublishAuthorCatalogExactSetSuccessorResultV1> {
+    const persistence = this.rfc64PersistenceV1;
+    if (persistence === undefined) {
+      throw new Error('RFC-64 persistence is not available');
+    }
+    const history = await loadBoundedAuthorCatalogHistoryV1(persistence, params.previousHead);
+    return this.publishAuthorCatalogExactSetSuccessorFromHistoryV1(params, history);
+  }
+
+  private async publishAuthorCatalogExactSetSuccessorFromHistoryV1(
+    this: DKGAgent,
+    params: PublishAuthorCatalogExactSetSuccessorParamsV1,
+    history: BoundedAuthorCatalogHistoryV1,
+  ): Promise<PublishAuthorCatalogExactSetSuccessorResultV1> {
     const service = this.requireRfc64PublicCatalogServiceV1();
     const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(params.peers);
     const persistence = this.rfc64PersistenceV1;
     if (persistence === undefined) {
       throw new Error('RFC-64 persistence is not available');
     }
-    const history = await loadBoundedAuthorCatalogHistoryV1(persistence, params.previousHead);
     const scope = deriveAuthorCatalogScopeFromHeadV1(history.previousHead.payload);
-    const policyDigest = service.acceptedPolicyDigestForCatalogScope(scope);
+    const heldPolicy = service.acceptedPolicySnapshotForCatalogScope(scope);
+    const policyDigest = heldPolicy.policyDigest;
+    if (heldPolicy.policy.accessPolicy === 1 && peers.length > 0) {
+      throw new Error(
+        'RFC-64 private catalog peer fan-out requires scope-bound private content transport',
+      );
+    }
     const authorAddress = params.author.address.toLowerCase() as EvmAddressV1;
     if (authorAddress !== scope.authorAddress) {
       throw new Error('RFC-64 successor author must equal the exact predecessor author');

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -54,8 +54,13 @@ import { ethers } from 'ethers';
 
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
+import type { Rfc64CatalogAccessPolicyAuthorityConfigV1 } from './dkg-agent-types.js';
 import type { Rfc64AuthorCatalogEip191SignerV1 } from './rfc64/author-catalog-producer.js';
 import type { AcceptedOpenCatalogPolicyV1 } from './rfc64/open-catalog-policy-v1.js';
+import type {
+  AcceptRfc64CatalogAccessSnapshotInputV1,
+  AcceptedRfc64CatalogAccessSnapshotV1,
+} from './rfc64/catalog-access-policy-v1.js';
 import type { Rfc64PublicCatalogReceiverReconcilerV1 } from './rfc64/public-catalog-receiver-v1.js';
 import type { Rfc64PersistenceV1 } from './rfc64/persistence-v1.js';
 import {
@@ -97,6 +102,12 @@ export interface Rfc64OpenCatalogAuthorSignerV1 {
   signMessage(message: Uint8Array): Promise<string>;
 }
 
+const LEGACY_OPEN_ONLY_LOCAL_AGENT_ADDRESS =
+  '0x0000000000000000000000000000000000000001' as EvmAddressV1;
+
+/** Policy-neutral catalog author signer; legacy open APIs use the same shape. */
+export type Rfc64CatalogAuthorSignerV1 = Rfc64OpenCatalogAuthorSignerV1;
+
 export interface AcceptOpenContextGraphPolicyInputV1 {
   readonly networkId: NetworkIdV1;
   readonly contextGraphId: ContextGraphIdV1;
@@ -105,6 +116,10 @@ export interface AcceptOpenContextGraphPolicyInputV1 {
   readonly issuedAt?: TimestampMsV1;
   readonly effectiveAt?: TimestampMsV1;
 }
+
+/** Already-authoritative current policy snapshot supplied to the catalog plane. */
+export type AcceptRfc64CatalogAccessSnapshotParamsV1 =
+  AcceptRfc64CatalogAccessSnapshotInputV1;
 
 export interface PublishOpenAuthorCatalogGenesisParamsV1 {
   readonly networkId: NetworkIdV1;
@@ -123,6 +138,16 @@ export interface PublishOpenAuthorCatalogGenesisParamsV1 {
   readonly policyIssuedAt?: TimestampMsV1;
   readonly policyEffectiveAt?: TimestampMsV1;
   readonly ownerAuthorityEra?: DecimalU64V1;
+}
+
+export interface PublishAuthorCatalogGenesisParamsV1 {
+  /** Exact accepted policy-bound author catalog scope. */
+  readonly scope: AuthorCatalogScopeV1;
+  readonly author: Rfc64CatalogAuthorSignerV1;
+  readonly peers: readonly string[];
+  readonly issuedAt?: TimestampMsV1;
+  readonly catalogIssuerDelegationEffectiveAt: TimestampMsV1;
+  readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;
 }
 
 export interface Rfc64StagedAuthorCatalogHeadRefV1 {
@@ -193,6 +218,44 @@ export function snapshotRfc64CatalogDeploymentProfileV1(
   });
 }
 
+/** Snapshot the function-bearing create-time authority without trusting caller mutation. */
+export function snapshotRfc64CatalogAccessPolicyAuthorityV1(
+  input: Rfc64CatalogAccessPolicyAuthorityConfigV1 | undefined,
+): Readonly<Rfc64CatalogAccessPolicyAuthorityConfigV1> | undefined {
+  if (input === undefined) return undefined;
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('rfc64CatalogAccessPolicyAuthority must be a plain object');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('rfc64CatalogAccessPolicyAuthority must be a plain object');
+  }
+  const keys = Object.keys(input).sort();
+  if (
+    keys.length !== 2
+    || keys[0] !== 'localAgentAddress'
+    || keys[1] !== 'resolveRemoteAgentAddress'
+  ) {
+    throw new TypeError('rfc64CatalogAccessPolicyAuthority has unknown or missing fields');
+  }
+  if (
+    typeof input.localAgentAddress !== 'string'
+    || !ethers.isAddress(input.localAgentAddress)
+    || input.localAgentAddress === ethers.ZeroAddress
+  ) {
+    throw new TypeError('rfc64CatalogAccessPolicyAuthority.localAgentAddress is invalid');
+  }
+  if (typeof input.resolveRemoteAgentAddress !== 'function') {
+    throw new TypeError(
+      'rfc64CatalogAccessPolicyAuthority.resolveRemoteAgentAddress must be a function',
+    );
+  }
+  return Object.freeze({
+    localAgentAddress: input.localAgentAddress.toLowerCase() as EvmAddressV1,
+    resolveRemoteAgentAddress: input.resolveRemoteAgentAddress,
+  });
+}
+
 export interface PublishOpenAuthorCatalogSuccessorParamsV1 {
   /** Exact durable predecessor returned by genesis or a prior successor. */
   readonly previousHead: Rfc64StagedAuthorCatalogHeadRefV1;
@@ -225,6 +288,12 @@ export interface PublishOpenAuthorCatalogExactSetSuccessorParamsV1 {
   readonly issuedAt?: TimestampMsV1;
   readonly peers: readonly string[];
 }
+
+export type PublishAuthorCatalogExactSetSuccessorParamsV1 =
+  PublishOpenAuthorCatalogExactSetSuccessorParamsV1;
+
+export type PublishAuthorCatalogGenesisResultV1 =
+  PublishOpenAuthorCatalogGenesisResultV1;
 
 export interface PublishOpenAuthorCatalogSuccessorResultV1 {
   readonly announcement: Rfc64PublicCatalogHeadAnnouncementV1;
@@ -272,6 +341,9 @@ export interface PublishOpenAuthorCatalogExactSetSuccessorResultV1 {
   readonly failedPeers: ReadonlyArray<{ readonly peerId: string; readonly error: string }>;
 }
 
+export type PublishAuthorCatalogExactSetSuccessorResultV1 =
+  PublishOpenAuthorCatalogExactSetSuccessorResultV1;
+
 export class Rfc64CatalogMethods extends DKGAgentBase {
   /**
    * Construct + start the public catalog service on the production router.
@@ -281,9 +353,24 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     if (this.rfc64PublicCatalogServiceV1 !== undefined) return;
     const persistence = this.rfc64PersistenceV1;
     if (persistence === undefined) return;
+    const configuredAuthority = this.config.rfc64CatalogAccessPolicyAuthority;
+    const defaultAgentAddress = this.defaultAgentAddress?.toLowerCase();
+    const fallbackLocalAgentAddress = defaultAgentAddress !== undefined
+      && ethers.isAddress(defaultAgentAddress)
+      && defaultAgentAddress !== ethers.ZeroAddress
+      ? defaultAgentAddress as EvmAddressV1
+      : LEGACY_OPEN_ONLY_LOCAL_AGENT_ADDRESS;
+    const accessPolicyAuthority = configuredAuthority ?? Object.freeze({
+      localAgentAddress: fallbackLocalAgentAddress,
+      // Legacy-open compatibility only. Private snapshot acceptance is denied
+      // below unless the caller supplied an explicit authenticated resolver.
+      resolveRemoteAgentAddress: async () => null,
+    });
     const service = new Rfc64PublicCatalogServiceV1({
       router: this.router,
       controlObjects: persistence.controlObjects,
+      accessPolicyAuthority,
+      privatePolicyAuthorityConfigured: configuredAuthority !== undefined,
       native: this.createRfc64PublicCatalogNativeOptionsV1(),
       receiver: {
         onError: (announcement, error) => {
@@ -321,6 +408,40 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     input: AcceptOpenContextGraphPolicyInputV1,
   ): AcceptedOpenCatalogPolicyV1 {
     return this.requireRfc64PublicCatalogServiceV1().acceptOpenPolicy(input);
+  }
+
+  /**
+   * Accept an independently verified current ContextGraphPolicyV1 snapshot and
+   * its conditional MemberRosterV1 into the catalog data-plane authorizer.
+   * This method does not verify administrative/finality authority itself.
+   */
+  acceptRfc64CatalogAccessSnapshotV1(
+    this: DKGAgent,
+    input: AcceptRfc64CatalogAccessSnapshotParamsV1,
+  ): AcceptedRfc64CatalogAccessSnapshotV1 {
+    return this.requireRfc64PublicCatalogServiceV1().acceptPolicySnapshot(input);
+  }
+
+  /** Author path for a previously accepted policy snapshot in any V1 cell. */
+  async publishAuthorCatalogGenesisV1(
+    this: DKGAgent,
+    params: PublishAuthorCatalogGenesisParamsV1,
+  ): Promise<PublishAuthorCatalogGenesisResultV1> {
+    const authorAddress = params.author.address.toLowerCase() as EvmAddressV1;
+    if (authorAddress !== params.scope.authorAddress) {
+      throw new Error('RFC-64 genesis author must equal the exact catalog scope author');
+    }
+    return this.requireRfc64PublicCatalogServiceV1().publishAuthorCatalogGenesis({
+      scope: params.scope,
+      signer: {
+        issuer: authorAddress,
+        signDigest: (objectDigest) => params.author.signMessage(objectDigest),
+      },
+      issuedAt: params.issuedAt ?? (Date.now().toString() as TimestampMsV1),
+      catalogIssuerDelegationEffectiveAt: params.catalogIssuerDelegationEffectiveAt,
+      catalogIssuerDelegationExpiresAt: params.catalogIssuerDelegationExpiresAt,
+      peers: params.peers,
+    });
   }
 
   /**
@@ -430,14 +551,36 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     params: PublishOpenAuthorCatalogExactSetSuccessorParamsV1,
   ): Promise<PublishOpenAuthorCatalogExactSetSuccessorResultV1> {
     const service = this.requireRfc64PublicCatalogServiceV1();
+    const persistence = this.rfc64PersistenceV1;
+    if (persistence === undefined) {
+      throw new Error('RFC-64 persistence is not available');
+    }
+    const history = await loadBoundedAuthorCatalogHistoryV1(
+      persistence,
+      params.previousHead,
+    );
+    const scope = deriveAuthorCatalogScopeFromHeadV1(history.previousHead.payload);
+    if (scope.subGraphName !== null) {
+      throw new Error('RFC-64 public/open compatibility successor requires the root lane');
+    }
+    service.acceptedOpenPolicyDigestForCatalogScope(scope);
+    return this.publishAuthorCatalogExactSetSuccessorV1(params);
+  }
+
+  /** Exact-set successor path for any locally accepted policy cell. */
+  async publishAuthorCatalogExactSetSuccessorV1(
+    this: DKGAgent,
+    params: PublishAuthorCatalogExactSetSuccessorParamsV1,
+  ): Promise<PublishAuthorCatalogExactSetSuccessorResultV1> {
+    const service = this.requireRfc64PublicCatalogServiceV1();
     const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(params.peers);
     const persistence = this.rfc64PersistenceV1;
     if (persistence === undefined) {
       throw new Error('RFC-64 persistence is not available');
     }
-    const history = await loadPublicOpenRootLaneHistoryV1(persistence, params.previousHead);
+    const history = await loadBoundedAuthorCatalogHistoryV1(persistence, params.previousHead);
     const scope = deriveAuthorCatalogScopeFromHeadV1(history.previousHead.payload);
-    const policyDigest = service.acceptedOpenPolicyDigestForCatalogScope(scope);
+    const policyDigest = service.acceptedPolicyDigestForCatalogScope(scope);
     const authorAddress = params.author.address.toLowerCase() as EvmAddressV1;
     if (authorAddress !== scope.authorAddress) {
       throw new Error('RFC-64 successor author must equal the exact predecessor author');
@@ -806,16 +949,16 @@ function countToSafeInteger(value: CountV1, label: string): number {
   return parsed;
 }
 
-interface PublicOpenRootLaneHistoryV1 {
+interface BoundedAuthorCatalogHistoryV1 {
   readonly previousHead: SignedAuthorCatalogHeadEnvelopeV1;
   readonly previousDirectoryPath: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[];
   readonly previousBucket: SignedAuthorCatalogBucketEnvelopeV1 | null;
 }
 
-async function loadPublicOpenRootLaneHistoryV1(
+async function loadBoundedAuthorCatalogHistoryV1(
   persistence: Rfc64PersistenceV1,
   ref: Rfc64StagedAuthorCatalogHeadRefV1,
-): Promise<PublicOpenRootLaneHistoryV1> {
+): Promise<BoundedAuthorCatalogHistoryV1> {
   const storedHead = await persistence.controlObjects.getVerifiedObject({
     objectDigest: ref.objectDigest,
     signatureVariantDigest: ref.signatureVariantDigest,
@@ -825,12 +968,11 @@ async function loadPublicOpenRootLaneHistoryV1(
   assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
   const previousHead = storedHead.envelope;
   if (
-    previousHead.payload.subGraphName !== null
-    || previousHead.payload.bucketCount !== '1'
+    previousHead.payload.bucketCount !== '1'
     || previousHead.payload.directoryHeight !== '0'
     || BigInt(previousHead.payload.totalRows) > BigInt(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1)
   ) {
-    throw new Error('RFC-64 predecessor is outside the public/open root-lane slice');
+    throw new Error('RFC-64 predecessor is outside the bounded one-bucket successor slice');
   }
 
   const storedRoot = await persistence.controlObjects.getVerifiedObjectByDigest({

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -31,6 +31,7 @@ import type {
   ContextGraphJoinPolicyMode as CoreContextGraphJoinPolicyMode,
   ContextGraphJoinPolicyRecord as CoreContextGraphJoinPolicyRecord,
   CatalogSealDeploymentProfileV1,
+  EvmAddressV1,
 } from '@origintrail-official/dkg-core';
 import type {
   PhaseCallback,
@@ -1041,6 +1042,14 @@ export interface ReplicationEvent {
 
 export type ReplicationEventSink = (event: ReplicationEvent) => void;
 
+export interface Rfc64CatalogAccessPolicyAuthorityConfigV1 {
+  readonly localAgentAddress: EvmAddressV1;
+  /** Exact authenticated libp2p-peer to agent-wallet binding. */
+  readonly resolveRemoteAgentAddress: (
+    remotePeerId: string,
+  ) => Promise<EvmAddressV1 | null>;
+}
+
 export interface DKGAgentConfig {
   name: string;
   /** Selected genesis document. Defaults to the compatibility Base testnet genesis. */
@@ -1055,6 +1064,11 @@ export interface DKGAgentConfig {
    * announcement wire data.
    */
   rfc64CatalogDeploymentProfile?: CatalogSealDeploymentProfileV1;
+  /**
+   * Explicit agent-identity authority required before accepting a private
+   * RFC-64 catalog policy. Omission preserves the legacy open-only lane.
+   */
+  rfc64CatalogAccessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1;
   /**
    * public-projection enable flag. When set, a private CG's confirmed VM
    * publishes emit/refresh a verifiable public projection (the floor: existence,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -357,6 +357,7 @@ import {
   type DurableSyncResult,
   type SharedMemorySyncResult,
   type DKGAgentConfig,
+  type Rfc64CatalogAccessPolicyAuthorityConfigV1,
   type DKGAgentACKTransportOptions,
   type ImportedArtifactByteStore,
   type ReplicationEvent,
@@ -402,6 +403,7 @@ import { CclPolicyMethods } from './dkg-agent-ccl.js';
 import { EndorseVerifyMethods } from './dkg-agent-endorse.js';
 import {
   Rfc64CatalogMethods,
+  snapshotRfc64CatalogAccessPolicyAuthorityV1,
   snapshotRfc64CatalogDeploymentProfileV1,
 } from './dkg-agent-rfc64-catalog.js';
 import { ContextGraphRegistryMethods } from './dkg-agent-cg-registry.js';
@@ -457,6 +459,7 @@ export type {
   SharedMemorySyncDiagnostics,
   CatchupSyncDiagnostics,
   DKGAgentConfig,
+  Rfc64CatalogAccessPolicyAuthorityConfigV1,
   DKGAgentACKTransportOptions,
   ImportedArtifactByteStore,
 };
@@ -698,6 +701,9 @@ export class DKGAgent extends DKGAgentBase {
     const rfc64CatalogDeploymentProfile = snapshotRfc64CatalogDeploymentProfileV1(
       config.rfc64CatalogDeploymentProfile,
     );
+    const rfc64CatalogAccessPolicyAuthority = snapshotRfc64CatalogAccessPolicyAuthorityV1(
+      config.rfc64CatalogAccessPolicyAuthority,
+    );
     let wallet: DKGAgentWallet;
     if (config.dataDir) {
       try {
@@ -802,6 +808,7 @@ export class DKGAgent extends DKGAgentBase {
       ...config,
       genesisId,
       networkIdentity,
+      rfc64CatalogAccessPolicyAuthority,
       rfc64CatalogDeploymentProfile,
     };
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -110,6 +110,17 @@ export {
   type PolicyApprovalBinding,
 } from './ccl-policy.js';
 export { DKGAgent } from './dkg-agent.js';
+export type {
+  AcceptRfc64CatalogAccessSnapshotParamsV1,
+  PublishAuthorCatalogExactSetSuccessorParamsV1,
+  PublishAuthorCatalogExactSetSuccessorResultV1,
+  PublishAuthorCatalogGenesisParamsV1,
+  PublishAuthorCatalogGenesisResultV1,
+  Rfc64CatalogAuthorSignerV1,
+} from './dkg-agent-rfc64-catalog.js';
+export type {
+  AcceptedRfc64CatalogAccessSnapshotV1,
+} from './rfc64/catalog-access-policy-v1.js';
 export {
   contextGraphPriority,
   countSyncPriorityClasses,
@@ -175,6 +186,7 @@ export {
   InvalidContentError,
   StaleSenderKeyTargetError,
   type DKGAgentConfig,
+  type Rfc64CatalogAccessPolicyAuthorityConfigV1,
   type DKGAgentACKTransportOptions,
   type ContextGraphSub,
   type ContextGraphDiscoveryMetadata,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -115,7 +115,6 @@ export type {
   PublishAuthorCatalogExactSetSuccessorParamsV1,
   PublishAuthorCatalogExactSetSuccessorResultV1,
   PublishAuthorCatalogGenesisParamsV1,
-  PublishAuthorCatalogGenesisResultV1,
   Rfc64CatalogAuthorSignerV1,
 } from './dkg-agent-rfc64-catalog.js';
 export type {

--- a/packages/agent/src/rfc64/catalog-access-policy-v1.ts
+++ b/packages/agent/src/rfc64/catalog-access-policy-v1.ts
@@ -91,18 +91,23 @@ const UTF8 = new TextEncoder();
  * and opaque-bundle transports.
  */
 export class Rfc64CatalogAccessPolicyRegistryV1 {
-  readonly #localAgentAddress: EvmAddressV1;
-  readonly #resolveRemoteAgentAddress: (
+  readonly #localAgentAddress: EvmAddressV1 | null;
+  readonly #resolveRemoteAgentAddress: ((
     remotePeerId: string,
-  ) => Promise<EvmAddressV1 | null>;
+  ) => Promise<EvmAddressV1 | null>) | null;
   readonly #byKey = new Map<string, HeldCatalogAccessSnapshotV1>();
 
-  constructor(options: Rfc64CatalogAccessPolicyRegistryOptionsV1) {
+  constructor(options?: Rfc64CatalogAccessPolicyRegistryOptionsV1) {
+    if (options === undefined) {
+      this.#localAgentAddress = null;
+      this.#resolveRemoteAgentAddress = null;
+      return;
+    }
     this.#localAgentAddress = snapshotAgentAddress(
-      options?.localAgentAddress,
+      options.localAgentAddress,
       'localAgentAddress',
     );
-    if (typeof options?.resolveRemoteAgentAddress !== 'function') {
+    if (typeof options.resolveRemoteAgentAddress !== 'function') {
       throw new TypeError('resolveRemoteAgentAddress must be a function');
     }
     this.#resolveRemoteAgentAddress = options.resolveRemoteAgentAddress;
@@ -111,6 +116,24 @@ export class Rfc64CatalogAccessPolicyRegistryV1 {
   /** Accept one already-authoritative current snapshot. Exact replay is idempotent. */
   accept(
     input: AcceptRfc64CatalogAccessSnapshotInputV1,
+  ): AcceptedRfc64CatalogAccessSnapshotV1 {
+    return this.#accept(input, false);
+  }
+
+  /**
+   * Advance accepted-current state across one already-verified direct policy
+   * transition. The predecessor digest and monotonic era/version high-water are
+   * rechecked locally before the old authorization snapshot is replaced.
+   */
+  acceptCurrent(
+    input: AcceptRfc64CatalogAccessSnapshotInputV1,
+  ): AcceptedRfc64CatalogAccessSnapshotV1 {
+    return this.#accept(input, true);
+  }
+
+  #accept(
+    input: AcceptRfc64CatalogAccessSnapshotInputV1,
+    allowVerifiedTransition: boolean,
   ): AcceptedRfc64CatalogAccessSnapshotV1 {
     const policy = snapshotPolicy(input?.policy);
     const policyDigest = snapshotDigest(input?.policyDigest, 'policyDigest');
@@ -124,6 +147,11 @@ export class Rfc64CatalogAccessPolicyRegistryV1 {
         throw new Error('open RFC-64 catalog policy forbids an exhaustive member roster');
       }
     } else {
+      if (!this.privatePolicyAuthorityConfigured) {
+        throw new Error(
+          'RFC-64 private catalog policy requires explicit access-policy authority configuration',
+        );
+      }
       if (rosterInput === null) {
         throw new Error('invite-only RFC-64 catalog policy requires a current member roster');
       }
@@ -133,24 +161,28 @@ export class Rfc64CatalogAccessPolicyRegistryV1 {
     }
 
     const key = policyKey(policy.networkId, policy.contextGraphId);
+    const held = Object.freeze({ policy, policyDigest, roster, members });
     const current = this.#byKey.get(key);
     if (current !== undefined) {
-      if (
-        current.policyDigest !== policyDigest
-        || canonicalizeContextGraphPolicyPayloadV1(current.policy)
-          !== canonicalizeContextGraphPolicyPayloadV1(policy)
-        || canonicalRoster(current.roster) !== canonicalRoster(roster)
-      ) {
-        throw new Error(
-          'RFC-64 current policy replacement requires the verified transition/high-water path',
-        );
+      if (!sameSnapshot(current, held)) {
+        if (!allowVerifiedTransition) {
+          throw new Error(
+            'RFC-64 current policy replacement requires the verified transition/high-water path',
+          );
+        }
+        assertDirectMonotonicPolicyTransition(current, held);
+        this.#byKey.set(key, held);
+        return publicSnapshot(held);
       }
       return publicSnapshot(current);
     }
 
-    const held = Object.freeze({ policy, policyDigest, roster, members });
     this.#byKey.set(key, held);
     return publicSnapshot(held);
+  }
+
+  get privatePolicyAuthorityConfigured(): boolean {
+    return this.#localAgentAddress !== null && this.#resolveRemoteAgentAddress !== null;
   }
 
   lookup(
@@ -187,7 +219,11 @@ export class Rfc64CatalogAccessPolicyRegistryV1 {
     if (descriptor.catalogDisclosure === 'open-authenticated') {
       return authorization(held);
     }
-    if (held.members === null) return null;
+    if (
+      held.members === null
+      || this.#localAgentAddress === null
+      || this.#resolveRemoteAgentAddress === null
+    ) return null;
 
     const remoteAgentAddress = await this.#resolveRemoteMemberAddress(boundary.remotePeerId);
     if (remoteAgentAddress === null) return null;
@@ -223,13 +259,17 @@ export class Rfc64CatalogAccessPolicyRegistryV1 {
       const held = this.#byKey.get(policyKey(networkId, contextGraphId));
       if (held === undefined || held.policyDigest !== policyDigest) return false;
       return held.policy.accessPolicy === 0
-        || held.members?.has(authorAddress) === true;
+        || (
+          this.privatePolicyAuthorityConfigured
+          && held.members?.has(authorAddress) === true
+        );
     } catch {
       return false;
     }
   }
 
   async #resolveRemoteMemberAddress(remotePeerId: string): Promise<EvmAddressV1 | null> {
+    if (this.#resolveRemoteAgentAddress === null) return null;
     try {
       const resolved = await this.#resolveRemoteAgentAddress(remotePeerId);
       return resolved === null
@@ -368,6 +408,39 @@ function snapshotPeerId(input: string): string {
 
 function canonicalRoster(roster: Readonly<MemberRosterV1> | null): string | null {
   return roster === null ? null : canonicalizeMemberRosterPayloadV1(roster);
+}
+
+function sameSnapshot(
+  left: HeldCatalogAccessSnapshotV1,
+  right: HeldCatalogAccessSnapshotV1,
+): boolean {
+  return left.policyDigest === right.policyDigest
+    && canonicalizeContextGraphPolicyPayloadV1(left.policy)
+      === canonicalizeContextGraphPolicyPayloadV1(right.policy)
+    && canonicalRoster(left.roster) === canonicalRoster(right.roster);
+}
+
+function assertDirectMonotonicPolicyTransition(
+  current: HeldCatalogAccessSnapshotV1,
+  successor: HeldCatalogAccessSnapshotV1,
+): void {
+  if (successor.policy.previousPolicyDigest !== current.policyDigest) {
+    throw new Error(
+      'RFC-64 accepted-current policy transition is not linked to the exact predecessor digest',
+    );
+  }
+  const currentEra = BigInt(current.policy.era);
+  const successorEra = BigInt(successor.policy.era);
+  const currentVersion = BigInt(current.policy.version);
+  const successorVersion = BigInt(successor.policy.version);
+  if (
+    successorEra < currentEra
+    || (successorEra === currentEra && successorVersion <= currentVersion)
+  ) {
+    throw new Error(
+      'RFC-64 accepted-current policy transition does not advance the era/version high-water',
+    );
+  }
 }
 
 function policyKey(networkId: NetworkIdV1, contextGraphId: ContextGraphIdV1): string {

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  assertCanonicalChainId,
+  assertNetworkIdV1,
+  type CatalogSealDeploymentProfileV1,
+  type EvmAddressV1,
+} from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+
+import type { Rfc64CatalogAccessPolicyAuthorityConfigV1 } from '../dkg-agent-types.js';
+
+/** Detach a locally configured deployment tuple from caller-owned state. */
+export function snapshotRfc64CatalogDeploymentProfileV1(
+  input: CatalogSealDeploymentProfileV1 | undefined,
+): Readonly<CatalogSealDeploymentProfileV1> | undefined {
+  if (input === undefined) return undefined;
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('rfc64CatalogDeploymentProfile must be a plain object');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('rfc64CatalogDeploymentProfile must be a plain object');
+  }
+  const keys = Object.keys(input).sort();
+  const expectedKeys = [
+    'assertedAtChainId',
+    'assertedAtKav10Address',
+    'networkId',
+  ];
+  if (
+    keys.length !== expectedKeys.length
+    || keys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    throw new TypeError(
+      'rfc64CatalogDeploymentProfile must contain exactly networkId, '
+      + 'assertedAtChainId, and assertedAtKav10Address',
+    );
+  }
+  assertNetworkIdV1(input.networkId);
+  assertCanonicalChainId(input.assertedAtChainId, 'assertedAtChainId');
+  if (!ethers.isAddress(input.assertedAtKav10Address)) {
+    throw new TypeError('assertedAtKav10Address must be a non-zero EVM address');
+  }
+  const assertedAtKav10Address = input.assertedAtKav10Address.toLowerCase() as EvmAddressV1;
+  if (assertedAtKav10Address === `0x${'00'.repeat(20)}`) {
+    throw new TypeError('assertedAtKav10Address must be a non-zero EVM address');
+  }
+  return Object.freeze({
+    networkId: input.networkId,
+    assertedAtChainId: input.assertedAtChainId,
+    assertedAtKav10Address,
+  });
+}
+
+/** Snapshot the function-bearing private-policy authority at create time. */
+export function snapshotRfc64CatalogAccessPolicyAuthorityV1(
+  input: Rfc64CatalogAccessPolicyAuthorityConfigV1 | undefined,
+): Readonly<Rfc64CatalogAccessPolicyAuthorityConfigV1> | undefined {
+  if (input === undefined) return undefined;
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('rfc64CatalogAccessPolicyAuthority must be a plain object');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('rfc64CatalogAccessPolicyAuthority must be a plain object');
+  }
+  const keys = Object.keys(input).sort();
+  if (
+    keys.length !== 2
+    || keys[0] !== 'localAgentAddress'
+    || keys[1] !== 'resolveRemoteAgentAddress'
+  ) {
+    throw new TypeError('rfc64CatalogAccessPolicyAuthority has unknown or missing fields');
+  }
+  if (
+    typeof input.localAgentAddress !== 'string'
+    || !ethers.isAddress(input.localAgentAddress)
+    || input.localAgentAddress === ethers.ZeroAddress
+  ) {
+    throw new TypeError('rfc64CatalogAccessPolicyAuthority.localAgentAddress is invalid');
+  }
+  if (typeof input.resolveRemoteAgentAddress !== 'function') {
+    throw new TypeError(
+      'rfc64CatalogAccessPolicyAuthority.resolveRemoteAgentAddress must be a function',
+    );
+  }
+  return Object.freeze({
+    localAgentAddress: input.localAgentAddress.toLowerCase() as EvmAddressV1,
+    resolveRemoteAgentAddress: input.resolveRemoteAgentAddress,
+  });
+}

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -29,7 +29,9 @@ import {
   type SendOptions,
   type SignedControlEnvelopeV1,
   type AuthorCatalogScopeV1,
+  type ContextGraphIdV1,
   type Digest32V1,
+  type NetworkIdV1,
   type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
 import {
@@ -47,12 +49,17 @@ import type {
   StageVerifiedControlObjectsResultV1,
 } from './control-object-store-v1.js';
 import {
-  Rfc64AcceptedOpenCatalogPolicyRegistryV1,
   buildOpenOwnerContextGraphPolicyV1,
   computeOpenContextGraphPolicyDigestV1,
   type AcceptedOpenCatalogPolicyV1,
   type BuildOpenOwnerContextGraphPolicyInputV1,
 } from './open-catalog-policy-v1.js';
+import {
+  Rfc64CatalogAccessPolicyRegistryV1,
+  type AcceptRfc64CatalogAccessSnapshotInputV1,
+  type AcceptedRfc64CatalogAccessSnapshotV1,
+  type Rfc64CatalogAccessPolicyRegistryOptionsV1,
+} from './catalog-access-policy-v1.js';
 import {
   Rfc64PublicCatalogReceiverV1,
   type Rfc64PublicCatalogReceiverReconcilerV1,
@@ -69,7 +76,6 @@ import {
   produceDirectAuthorCatalogIssuerDelegationV1,
 } from './public-catalog-issuer-delegation-v1.js';
 import {
-  deriveRfc64PublicOpenCatalogScopeV1,
   type Rfc64PublicOpenCatalogTrustedScopeResolverV1,
 } from './public-catalog-native-reconciler-v1.js';
 import type {
@@ -93,6 +99,10 @@ const UTF8 = new TextEncoder();
 export interface Rfc64PublicCatalogServiceOptionsV1 {
   readonly router: ProtocolRouter;
   readonly controlObjects: Rfc64ControlObjectOperationsV1;
+  /** Explicit local/remote agent-identity authority for private catalog decisions. */
+  readonly accessPolicyAuthority: Rfc64CatalogAccessPolicyRegistryOptionsV1;
+  /** False only for the DKGAgent legacy-open compatibility authority. */
+  readonly privatePolicyAuthorityConfigured?: boolean;
   readonly receiver?: Rfc64PublicCatalogReceiverOptionsV1;
   /** Full production native content/reconciliation path. Omission is diagnostic-only. */
   readonly native?: Rfc64PublicCatalogServiceNativeOptionsV1;
@@ -150,6 +160,11 @@ export interface PublishOpenAuthorCatalogGenesisInputV1 {
   readonly peers: readonly string[];
 }
 
+export type PublishAuthorCatalogGenesisInputV1 = Omit<
+  PublishOpenAuthorCatalogGenesisInputV1,
+  'policy'
+>;
+
 export interface PublishOpenAuthorCatalogGenesisResultV1 {
   readonly announcement: Rfc64PublicCatalogHeadAnnouncementV1;
   readonly headObjectDigest: Digest32V1;
@@ -190,16 +205,19 @@ export class Rfc64PublicCatalogServiceV1 {
   readonly #verifyIssuerSignature: (
     envelope: SignedControlEnvelopeV1,
   ) => Promise<VerifiedControlEnvelopeIssuerSignatureV1>;
-  readonly #policies = new Rfc64AcceptedOpenCatalogPolicyRegistryV1();
+  readonly #policies: Rfc64CatalogAccessPolicyRegistryV1;
   readonly #receiver: Rfc64PublicCatalogReceiverV1;
   readonly #transport: Rfc64PublicCatalogTransportV1;
   readonly #nativeTransport: Rfc64PublicCatalogNativeTransportV1 | undefined;
   readonly #transportTimeoutMs: number;
+  readonly #privatePolicyAuthorityConfigured: boolean;
   #started = false;
   #closed = false;
 
   constructor(options: Rfc64PublicCatalogServiceOptionsV1) {
     this.#controlObjects = options.controlObjects;
+    this.#policies = new Rfc64CatalogAccessPolicyRegistryV1(options.accessPolicyAuthority);
+    this.#privatePolicyAuthorityConfigured = options.privatePolicyAuthorityConfigured ?? true;
     this.#verifyIssuerSignature =
       options.verifyIssuerSignature ?? verifyControlEnvelopeIssuerSignatureV1;
     this.#transportTimeoutMs = options.transportTimeoutMs ?? DEFAULT_TRANSPORT_TIMEOUT_MS;
@@ -257,10 +275,49 @@ export class Rfc64PublicCatalogServiceV1 {
   acceptOpenPolicy(
     input: BuildOpenOwnerContextGraphPolicyInputV1,
   ): AcceptedOpenCatalogPolicyV1 {
-    return this.#policies.accept(buildOpenOwnerContextGraphPolicyV1(input));
+    const policy = buildOpenOwnerContextGraphPolicyV1(input);
+    const accepted = this.acceptPolicySnapshot({
+      policy,
+      policyDigest: computeOpenContextGraphPolicyDigestV1(policy),
+    });
+    return Object.freeze({ policy: accepted.policy, policyDigest: accepted.policyDigest });
   }
 
-  /** Resolve the locally accepted open-policy digest for one exact catalog scope. */
+  /**
+   * Accept one policy/optional-roster snapshot that already crossed the
+   * administrative/finality authority boundary. All four access/publish cells
+   * are retained; a roster is required exactly when accessPolicy is private.
+   */
+  acceptPolicySnapshot(
+    input: AcceptRfc64CatalogAccessSnapshotInputV1,
+  ): AcceptedRfc64CatalogAccessSnapshotV1 {
+    if (input?.policy?.accessPolicy === 1 && !this.#privatePolicyAuthorityConfigured) {
+      throw new Error(
+        'RFC-64 private catalog policy requires explicit access-policy authority configuration',
+      );
+    }
+    return this.#policies.accept(input);
+  }
+
+  acceptedPolicySnapshot(
+    networkId: NetworkIdV1,
+    contextGraphId: ContextGraphIdV1,
+  ): AcceptedRfc64CatalogAccessSnapshotV1 | null {
+    return this.#policies.lookup(networkId, contextGraphId);
+  }
+
+  /** Resolve the locally accepted policy digest for one exact catalog scope. */
+  acceptedPolicyDigestForCatalogScope(scopeInput: AuthorCatalogScopeV1): Digest32V1 {
+    const scope = snapshotCatalogScope(scopeInput);
+    const held = this.#policies.lookup(scope.networkId, scope.contextGraphId);
+    if (held === null) {
+      throw new Error('RFC-64 catalog scope has no locally accepted policy snapshot');
+    }
+    assertAcceptedPolicyMatchesCatalogScope(this.#policies, held, scope);
+    return held.policyDigest;
+  }
+
+  /** Compatibility alias for the original public/open authoring surface. */
   acceptedOpenPolicyDigestForCatalogScope(scopeInput: AuthorCatalogScopeV1): Digest32V1 {
     const scope = snapshotCatalogScope(scopeInput);
     const held = this.#policies.lookup(scope.networkId, scope.contextGraphId);
@@ -310,6 +367,29 @@ export class Rfc64PublicCatalogServiceV1 {
   async publishOpenAuthorCatalogGenesis(
     input: PublishOpenAuthorCatalogGenesisInputV1,
   ): Promise<PublishOpenAuthorCatalogGenesisResultV1> {
+    const scope = snapshotCatalogScope(input.scope);
+    const heldPolicy = this.#policies.lookup(scope.networkId, scope.contextGraphId);
+    assertOpenPolicyMatchesCatalogScope(input.policy, heldPolicy, scope);
+    return this.#publishAuthorCatalogGenesis(input, heldPolicy!);
+  }
+
+  /** Author path for any already-accepted RFC-64 catalog access-policy cell. */
+  async publishAuthorCatalogGenesis(
+    input: PublishAuthorCatalogGenesisInputV1,
+  ): Promise<PublishOpenAuthorCatalogGenesisResultV1> {
+    const scope = snapshotCatalogScope(input.scope);
+    const heldPolicy = this.#policies.lookup(scope.networkId, scope.contextGraphId);
+    if (heldPolicy === null) {
+      throw new Error('RFC-64 catalog scope has no locally accepted policy snapshot');
+    }
+    assertAcceptedPolicyMatchesCatalogScope(this.#policies, heldPolicy, scope);
+    return this.#publishAuthorCatalogGenesis(input, heldPolicy);
+  }
+
+  async #publishAuthorCatalogGenesis(
+    input: PublishAuthorCatalogGenesisInputV1,
+    heldPolicy: AcceptedRfc64CatalogAccessSnapshotV1,
+  ): Promise<PublishOpenAuthorCatalogGenesisResultV1> {
     this.#requireStarted();
     const scope = snapshotCatalogScope(input.scope);
     const signer = Object.freeze({
@@ -320,9 +400,8 @@ export class Rfc64PublicCatalogServiceV1 {
     const effectiveAt = input.catalogIssuerDelegationEffectiveAt;
     const expiresAt = input.catalogIssuerDelegationExpiresAt;
     const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
-    const heldPolicy = this.#policies.lookup(scope.networkId, scope.contextGraphId);
-    assertOpenPolicyMatchesCatalogScope(input.policy, heldPolicy, scope);
-    const policyDigest = heldPolicy!.policyDigest;
+    assertAcceptedPolicyMatchesCatalogScope(this.#policies, heldPolicy, scope);
+    const policyDigest = heldPolicy.policyDigest;
     const delegation = await produceDirectAuthorCatalogIssuerDelegationV1({
       scope,
       signer,
@@ -406,7 +485,7 @@ export class Rfc64PublicCatalogServiceV1 {
       encodeRfc64PublicCatalogHeadAnnouncementV1(input.announcement),
     );
     const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
-    this.#assertAcceptedOpenAnnouncement(announcement);
+    this.#assertAcceptedCatalogAnnouncement(announcement);
     return this.#announceCatalogHeadSnapshot(announcement, peers);
   }
 
@@ -453,45 +532,50 @@ export class Rfc64PublicCatalogServiceV1 {
     });
   }
 
-  #assertAcceptedOpenAnnouncement(
+  #assertAcceptedCatalogAnnouncement(
     announcement: Rfc64PublicCatalogHeadAnnouncementV1,
   ): void {
     const held = this.#policies.lookup(announcement.networkId, announcement.contextGraphId);
     if (
       held === null
-      || held.policy.accessPolicy !== 0
       || held.policyDigest !== announcement.policyDigest
-      || held.policy.source.kind !== 'owner-signed-unregistered'
-      || held.policy.source.ownerAddress !== announcement.authorAddress
+      || !this.#policies.isSwmAuthorAuthorized({
+        networkId: announcement.networkId,
+        contextGraphId: announcement.contextGraphId,
+        policyDigest: announcement.policyDigest,
+        authorAddress: announcement.authorAddress,
+      })
     ) {
       throw new Error(
-        'RFC-64 catalog announcement is not bound to the locally accepted open policy',
+        'RFC-64 catalog announcement is not bound to the locally accepted policy snapshot',
       );
     }
   }
   async #authorizeNativeOperation(
     input: Rfc64PublicCatalogNativeAuthorizationInputV1,
   ): Promise<Rfc64PublicCatalogNativeAuthorizationV1 | null> {
-    const record = this.#policies.lookup(input.networkId, input.contextGraphId);
-    if (record === null || record.policy.accessPolicy !== 0) return null;
-    return Object.freeze({
-      accessPolicy: 0,
-      policyDigest: record.policyDigest,
-    });
+    return this.#policies.authorize(input);
   }
 
   #resolveTrustedCatalogScope(
     announcement: Rfc64PublicCatalogHeadAnnouncementV1,
   ): Readonly<AuthorCatalogScopeV1> {
     const record = this.#policies.lookup(announcement.networkId, announcement.contextGraphId);
-    if (
-      record === null
-      || record.policyDigest !== announcement.policyDigest
-      || record.policy.accessPolicy !== 0
-    ) {
-      throw new Error('RFC-64 announcement has no matching accepted open policy generation');
+    if (record === null || record.policyDigest !== announcement.policyDigest) {
+      throw new Error('RFC-64 announcement has no matching accepted policy generation');
     }
-    return deriveRfc64PublicOpenCatalogScopeV1(announcement, record.policy);
+    this.#assertAcceptedCatalogAnnouncement(announcement);
+    return Object.freeze({
+      networkId: record.policy.networkId,
+      contextGraphId: record.policy.contextGraphId,
+      governanceChainId: record.policy.governanceChainId,
+      governanceContractAddress: record.policy.governanceContractAddress,
+      ownershipTransitionDigest: record.policy.ownershipTransitionDigest,
+      subGraphName: announcement.subGraphName,
+      authorAddress: announcement.authorAddress,
+      era: announcement.catalogEra,
+      bucketCount: '1',
+    }) as Readonly<AuthorCatalogScopeV1>;
   }
 
   async #stageHeadOnly(
@@ -602,6 +686,31 @@ function assertOpenPolicyMatchesCatalogScope(
   ) {
     throw new Error(
       'RFC-64 open policy is not bound to the exact catalog network, CG, governance scope, era, and author',
+    );
+  }
+}
+
+function assertAcceptedPolicyMatchesCatalogScope(
+  registry: Rfc64CatalogAccessPolicyRegistryV1,
+  held: AcceptedRfc64CatalogAccessSnapshotV1,
+  scope: AuthorCatalogScopeV1,
+): void {
+  const policy = held.policy;
+  if (
+    policy.networkId !== scope.networkId
+    || policy.contextGraphId !== scope.contextGraphId
+    || policy.governanceChainId !== scope.governanceChainId
+    || policy.governanceContractAddress !== scope.governanceContractAddress
+    || policy.ownershipTransitionDigest !== scope.ownershipTransitionDigest
+    || !registry.isSwmAuthorAuthorized({
+      networkId: scope.networkId,
+      contextGraphId: scope.contextGraphId,
+      policyDigest: held.policyDigest,
+      authorAddress: scope.authorAddress,
+    })
+  ) {
+    throw new Error(
+      'RFC-64 policy snapshot is not bound to the exact catalog network, CG, governance scope, and author',
     );
   }
 }

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -99,10 +99,8 @@ const UTF8 = new TextEncoder();
 export interface Rfc64PublicCatalogServiceOptionsV1 {
   readonly router: ProtocolRouter;
   readonly controlObjects: Rfc64ControlObjectOperationsV1;
-  /** Explicit local/remote agent-identity authority for private catalog decisions. */
-  readonly accessPolicyAuthority: Rfc64CatalogAccessPolicyRegistryOptionsV1;
-  /** False only for the DKGAgent legacy-open compatibility authority. */
-  readonly privatePolicyAuthorityConfigured?: boolean;
+  /** Omit for an explicit open-only service; required before accepting private policy. */
+  readonly accessPolicyAuthority?: Rfc64CatalogAccessPolicyRegistryOptionsV1;
   readonly receiver?: Rfc64PublicCatalogReceiverOptionsV1;
   /** Full production native content/reconciliation path. Omission is diagnostic-only. */
   readonly native?: Rfc64PublicCatalogServiceNativeOptionsV1;
@@ -148,24 +146,23 @@ export interface Rfc64PublicCatalogServiceNativeOptionsV1 extends Pick<
   ) => Rfc64PublicCatalogReceiverReconcilerV1;
 }
 
-export interface PublishOpenAuthorCatalogGenesisInputV1 {
+export interface PublishAuthorCatalogGenesisInputV1 {
   readonly scope: AuthorCatalogScopeV1;
   readonly signer: Rfc64AuthorCatalogEip191SignerV1;
   readonly issuedAt: TimestampMsV1;
   readonly catalogIssuerDelegationEffectiveAt: TimestampMsV1;
   readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;
-  /** The accepted open policy for the CG; its digest stamps the announcement. */
-  readonly policy: AcceptedOpenCatalogPolicyV1;
   /** Peers to announce availability to. Announcements are best-effort hints. */
   readonly peers: readonly string[];
 }
 
-export type PublishAuthorCatalogGenesisInputV1 = Omit<
-  PublishOpenAuthorCatalogGenesisInputV1,
-  'policy'
->;
+export interface PublishOpenAuthorCatalogGenesisInputV1
+  extends PublishAuthorCatalogGenesisInputV1 {
+  /** The accepted open policy for the CG; its digest stamps the announcement. */
+  readonly policy: AcceptedOpenCatalogPolicyV1;
+}
 
-export interface PublishOpenAuthorCatalogGenesisResultV1 {
+export interface PublishAuthorCatalogGenesisResultV1 {
   readonly announcement: Rfc64PublicCatalogHeadAnnouncementV1;
   readonly headObjectDigest: Digest32V1;
   readonly signatureVariantDigest: Digest32V1;
@@ -178,6 +175,9 @@ export interface PublishOpenAuthorCatalogGenesisResultV1 {
   /** Peers whose announcement failed (best-effort; correctness comes from pull). */
   readonly failedPeers: ReadonlyArray<{ readonly peerId: string; readonly error: string }>;
 }
+
+export type PublishOpenAuthorCatalogGenesisResultV1 =
+  PublishAuthorCatalogGenesisResultV1;
 
 export interface AnnounceRfc64PublicCatalogHeadInputV1 {
   readonly announcement: Rfc64PublicCatalogHeadAnnouncementV1;
@@ -210,14 +210,12 @@ export class Rfc64PublicCatalogServiceV1 {
   readonly #transport: Rfc64PublicCatalogTransportV1;
   readonly #nativeTransport: Rfc64PublicCatalogNativeTransportV1 | undefined;
   readonly #transportTimeoutMs: number;
-  readonly #privatePolicyAuthorityConfigured: boolean;
   #started = false;
   #closed = false;
 
   constructor(options: Rfc64PublicCatalogServiceOptionsV1) {
     this.#controlObjects = options.controlObjects;
     this.#policies = new Rfc64CatalogAccessPolicyRegistryV1(options.accessPolicyAuthority);
-    this.#privatePolicyAuthorityConfigured = options.privatePolicyAuthorityConfigured ?? true;
     this.#verifyIssuerSignature =
       options.verifyIssuerSignature ?? verifyControlEnvelopeIssuerSignatureV1;
     this.#transportTimeoutMs = options.transportTimeoutMs ?? DEFAULT_TRANSPORT_TIMEOUT_MS;
@@ -291,12 +289,7 @@ export class Rfc64PublicCatalogServiceV1 {
   acceptPolicySnapshot(
     input: AcceptRfc64CatalogAccessSnapshotInputV1,
   ): AcceptedRfc64CatalogAccessSnapshotV1 {
-    if (input?.policy?.accessPolicy === 1 && !this.#privatePolicyAuthorityConfigured) {
-      throw new Error(
-        'RFC-64 private catalog policy requires explicit access-policy authority configuration',
-      );
-    }
-    return this.#policies.accept(input);
+    return this.#policies.acceptCurrent(input);
   }
 
   acceptedPolicySnapshot(
@@ -308,13 +301,19 @@ export class Rfc64PublicCatalogServiceV1 {
 
   /** Resolve the locally accepted policy digest for one exact catalog scope. */
   acceptedPolicyDigestForCatalogScope(scopeInput: AuthorCatalogScopeV1): Digest32V1 {
+    return this.acceptedPolicySnapshotForCatalogScope(scopeInput).policyDigest;
+  }
+
+  acceptedPolicySnapshotForCatalogScope(
+    scopeInput: AuthorCatalogScopeV1,
+  ): AcceptedRfc64CatalogAccessSnapshotV1 {
     const scope = snapshotCatalogScope(scopeInput);
     const held = this.#policies.lookup(scope.networkId, scope.contextGraphId);
     if (held === null) {
       throw new Error('RFC-64 catalog scope has no locally accepted policy snapshot');
     }
     assertAcceptedPolicyMatchesCatalogScope(this.#policies, held, scope);
-    return held.policyDigest;
+    return held;
   }
 
   /** Compatibility alias for the original public/open authoring surface. */
@@ -370,26 +369,30 @@ export class Rfc64PublicCatalogServiceV1 {
     const scope = snapshotCatalogScope(input.scope);
     const heldPolicy = this.#policies.lookup(scope.networkId, scope.contextGraphId);
     assertOpenPolicyMatchesCatalogScope(input.policy, heldPolicy, scope);
-    return this.#publishAuthorCatalogGenesis(input, heldPolicy!);
+    const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
+    return this.#publishAuthorCatalogGenesis(input, heldPolicy!, peers);
   }
 
   /** Author path for any already-accepted RFC-64 catalog access-policy cell. */
   async publishAuthorCatalogGenesis(
     input: PublishAuthorCatalogGenesisInputV1,
-  ): Promise<PublishOpenAuthorCatalogGenesisResultV1> {
+  ): Promise<PublishAuthorCatalogGenesisResultV1> {
     const scope = snapshotCatalogScope(input.scope);
     const heldPolicy = this.#policies.lookup(scope.networkId, scope.contextGraphId);
     if (heldPolicy === null) {
       throw new Error('RFC-64 catalog scope has no locally accepted policy snapshot');
     }
     assertAcceptedPolicyMatchesCatalogScope(this.#policies, heldPolicy, scope);
-    return this.#publishAuthorCatalogGenesis(input, heldPolicy);
+    const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
+    assertSupportedCatalogFanout(heldPolicy, peers);
+    return this.#publishAuthorCatalogGenesis(input, heldPolicy, peers);
   }
 
   async #publishAuthorCatalogGenesis(
     input: PublishAuthorCatalogGenesisInputV1,
     heldPolicy: AcceptedRfc64CatalogAccessSnapshotV1,
-  ): Promise<PublishOpenAuthorCatalogGenesisResultV1> {
+    peers: readonly string[],
+  ): Promise<PublishAuthorCatalogGenesisResultV1> {
     this.#requireStarted();
     const scope = snapshotCatalogScope(input.scope);
     const signer = Object.freeze({
@@ -399,7 +402,6 @@ export class Rfc64PublicCatalogServiceV1 {
     const issuedAt = input.issuedAt;
     const effectiveAt = input.catalogIssuerDelegationEffectiveAt;
     const expiresAt = input.catalogIssuerDelegationExpiresAt;
-    const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
     assertAcceptedPolicyMatchesCatalogScope(this.#policies, heldPolicy, scope);
     const policyDigest = heldPolicy.policyDigest;
     const delegation = await produceDirectAuthorCatalogIssuerDelegationV1({
@@ -485,7 +487,8 @@ export class Rfc64PublicCatalogServiceV1 {
       encodeRfc64PublicCatalogHeadAnnouncementV1(input.announcement),
     );
     const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
-    this.#assertAcceptedCatalogAnnouncement(announcement);
+    const heldPolicy = this.#assertAcceptedCatalogAnnouncement(announcement);
+    assertSupportedCatalogFanout(heldPolicy, peers);
     return this.#announceCatalogHeadSnapshot(announcement, peers);
   }
 
@@ -534,7 +537,7 @@ export class Rfc64PublicCatalogServiceV1 {
 
   #assertAcceptedCatalogAnnouncement(
     announcement: Rfc64PublicCatalogHeadAnnouncementV1,
-  ): void {
+  ): AcceptedRfc64CatalogAccessSnapshotV1 {
     const held = this.#policies.lookup(announcement.networkId, announcement.contextGraphId);
     if (
       held === null
@@ -550,6 +553,7 @@ export class Rfc64PublicCatalogServiceV1 {
         'RFC-64 catalog announcement is not bound to the locally accepted policy snapshot',
       );
     }
+    return held;
   }
   async #authorizeNativeOperation(
     input: Rfc64PublicCatalogNativeAuthorizationInputV1,
@@ -647,6 +651,17 @@ export function snapshotRfc64PublicCatalogAnnouncementPeersV1(
     peers.push(peerId);
   }
   return Object.freeze(peers);
+}
+
+function assertSupportedCatalogFanout(
+  heldPolicy: AcceptedRfc64CatalogAccessSnapshotV1,
+  peers: readonly string[],
+): void {
+  if (heldPolicy.policy.accessPolicy === 1 && peers.length > 0) {
+    throw new Error(
+      'RFC-64 private catalog peer fan-out requires scope-bound private content transport',
+    );
+  }
 }
 
 function snapshotCatalogScope(input: AuthorCatalogScopeV1): Readonly<AuthorCatalogScopeV1> {

--- a/packages/agent/src/rfc64/public-catalog-successor-producer-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-successor-producer-v1.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Production boundary for the bounded public/open successor slice.
+ * Production boundary for the bounded one-bucket catalog successor slice.
  *
  * The adapter deliberately delegates catalog construction and every bundle,
  * seal, and projection codec check to the canonical RFC-64 helpers. Neither
@@ -188,7 +188,7 @@ export interface ProducedAndStagedPublicOpenExactSetSuccessorV1 {
 }
 
 /**
- * Build, authenticate, fully verify, and durably stage one public/open
+ * Build, authenticate, fully verify, and durably stage one
  * root-lane successor. Bundle-first staging prevents a served head from
  * referring to an unavailable bundle; a later control-stage failure can leave
  * only an unreferenced immutable bundle.
@@ -297,8 +297,7 @@ export class Rfc64PublicCatalogSuccessorProducerV1 {
 
     const producedBucket = publication.bucket;
     if (
-      publication.head.payload.subGraphName !== null
-      || publication.head.payload.bucketCount !== '1'
+      publication.head.payload.bucketCount !== '1'
       || publication.head.payload.directoryHeight !== '0'
       || publication.head.payload.totalRows !== String(preparedAssets.length)
       || publication.head.payload.version === '0'
@@ -308,7 +307,7 @@ export class Rfc64PublicCatalogSuccessorProducerV1 {
     ) {
       fail(
         'catalog-successor-producer-verification',
-        'produced catalog is outside the bounded public/open exact-set successor slice',
+        'produced catalog is outside the bounded exact-set successor slice',
       );
     }
 
@@ -686,8 +685,7 @@ function assertSupportedPreviousSlice(
   bucket: SignedAuthorCatalogBucketEnvelopeV1 | null,
 ): void {
   if (
-    head.payload.subGraphName !== null
-    || head.payload.bucketCount !== '1'
+    head.payload.bucketCount !== '1'
     || head.payload.directoryHeight !== '0'
     || BigInt(head.payload.totalRows) > BigInt(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1)
     || (head.payload.totalRows === '0' && bucket !== null)
@@ -697,7 +695,7 @@ function assertSupportedPreviousSlice(
   ) {
     fail(
       'catalog-successor-producer-history',
-      'previous catalog is outside the bounded public/open root-lane slice',
+      'previous catalog is outside the bounded one-bucket successor slice',
     );
   }
 }

--- a/packages/agent/test/rfc64-catalog-access-policy-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-access-policy-v1.test.ts
@@ -119,6 +119,23 @@ function authInput(operation: Rfc64CatalogAccessOperationV1, policyDigest: Diges
 }
 
 describe('RFC-64 D26 catalog access authorization', () => {
+  it('supports an explicit open-only registry without a dummy identity authority', async () => {
+    const subject = new Rfc64CatalogAccessPolicyRegistryV1();
+    const openPolicy = policy(0, 1);
+    const openDigest = digestFor(openPolicy);
+    subject.accept({ policy: openPolicy, policyDigest: openDigest });
+    await expect(subject.authorize(authInput('fetch-inbound', openDigest)))
+      .resolves.toEqual({ accessPolicy: 0, policyDigest: openDigest });
+
+    const privatePolicy = policy(1, 1);
+    const privateDigest = digestFor(privatePolicy);
+    expect(() => subject.accept({
+      policy: privatePolicy,
+      policyDigest: privateDigest,
+      roster: roster(privateDigest),
+    })).toThrow(/requires explicit access-policy authority/u);
+  });
+
   it('keeps both open-sharing cells SWM-equivalent without resolving a roster identity', async () => {
     for (const publishPolicy of [0, 1] as const) {
       let resolverCalls = 0;
@@ -322,5 +339,36 @@ describe('RFC-64 D26 catalog access authorization', () => {
       policy: replacement,
       policyDigest: digestFor(replacement),
     })).toThrow(/verified transition\/high-water path/u);
+  });
+
+  it('advances only across a linked monotonic accepted-current policy transition', async () => {
+    const initial = policy(0, 1);
+    const initialDigest = digestFor(initial);
+    const subject = registry();
+    subject.acceptCurrent({ policy: initial, policyDigest: initialDigest });
+    const successor = {
+      ...policy(0, 0),
+      version: '1',
+      previousPolicyDigest: initialDigest,
+    } satisfies ContextGraphPolicyV1;
+    const successorDigest = digestFor(successor);
+    subject.acceptCurrent({ policy: successor, policyDigest: successorDigest });
+
+    expect(subject.lookup(NETWORK, CG)?.policyDigest).toBe(successorDigest);
+    await expect(subject.authorize(authInput('fetch-inbound', initialDigest)))
+      .resolves.toBeNull();
+    await expect(subject.authorize(authInput('fetch-inbound', successorDigest)))
+      .resolves.toEqual({ accessPolicy: 0, policyDigest: successorDigest });
+
+    const unlinked = {
+      ...policy(0, 1),
+      version: '2',
+      previousPolicyDigest: initialDigest,
+    } satisfies ContextGraphPolicyV1;
+    expect(() => subject.acceptCurrent({
+      policy: unlinked,
+      policyDigest: digestFor(unlinked),
+    })).toThrow(/exact predecessor digest/u);
+    expect(subject.lookup(NETWORK, CG)?.policyDigest).toBe(successorDigest);
   });
 });

--- a/packages/agent/test/rfc64-catalog-policy-api-public.typecheck.ts
+++ b/packages/agent/test/rfc64-catalog-policy-api-public.typecheck.ts
@@ -1,0 +1,93 @@
+import {
+  DKGAgent,
+  type AcceptRfc64CatalogAccessSnapshotParamsV1,
+  type AcceptedRfc64CatalogAccessSnapshotV1,
+  type DKGAgentConfig,
+  type PublishAuthorCatalogExactSetSuccessorParamsV1,
+  type PublishAuthorCatalogExactSetSuccessorResultV1,
+  type PublishAuthorCatalogGenesisParamsV1,
+  type PublishAuthorCatalogGenesisResultV1,
+  type Rfc64CatalogAccessPolicyAuthorityConfigV1,
+} from '@origintrail-official/dkg-agent';
+
+// Every params value below is built as a real object literal rather than passed through as a
+// `declare const params: T`. That distinction is the whole point of this file: `T` assignable to `T`
+// compiles no matter how T's fields are renamed, so it proves only that the export NAME exists.
+// Real literals additionally fail to compile when a published field is renamed, removed, or newly
+// required — which is what an external consumer of this surface would actually hit.
+//
+// Nested/leaf values are pulled through indexed access on the published types themselves, so this
+// file stays free of incidental imports while keeping the field names load-bearing: renaming
+// `scope` breaks both the indexed access and the literal key.
+
+declare const agent: DKGAgent;
+
+declare const policy: AcceptRfc64CatalogAccessSnapshotParamsV1['policy'];
+declare const policyDigest: AcceptRfc64CatalogAccessSnapshotParamsV1['policyDigest'];
+declare const roster: NonNullable<AcceptRfc64CatalogAccessSnapshotParamsV1['roster']>;
+
+const snapshot: AcceptRfc64CatalogAccessSnapshotParamsV1 = {
+  policy,
+  policyDigest,
+  roster,
+};
+const accepted: AcceptedRfc64CatalogAccessSnapshotV1 =
+  agent.acceptRfc64CatalogAccessSnapshotV1(snapshot);
+
+declare const genesisScope: PublishAuthorCatalogGenesisParamsV1['scope'];
+declare const genesisAuthor: PublishAuthorCatalogGenesisParamsV1['author'];
+declare const genesisIssuedAt: NonNullable<PublishAuthorCatalogGenesisParamsV1['issuedAt']>;
+declare const delegationEffectiveAt:
+  PublishAuthorCatalogGenesisParamsV1['catalogIssuerDelegationEffectiveAt'];
+declare const delegationExpiresAt:
+  PublishAuthorCatalogGenesisParamsV1['catalogIssuerDelegationExpiresAt'];
+
+const genesis: PublishAuthorCatalogGenesisParamsV1 = {
+  scope: genesisScope,
+  author: genesisAuthor,
+  peers: ['12D3KooWExamplePeer'],
+  issuedAt: genesisIssuedAt,
+  catalogIssuerDelegationEffectiveAt: delegationEffectiveAt,
+  catalogIssuerDelegationExpiresAt: delegationExpiresAt,
+};
+const genesisResult: Promise<PublishAuthorCatalogGenesisResultV1> =
+  agent.publishAuthorCatalogGenesisV1(genesis);
+
+declare const previousHead: PublishAuthorCatalogExactSetSuccessorParamsV1['previousHead'];
+declare const successorAuthor: PublishAuthorCatalogExactSetSuccessorParamsV1['author'];
+declare const catalogIssuerAuthorization:
+  PublishAuthorCatalogExactSetSuccessorParamsV1['catalogIssuerAuthorization'];
+declare const assets: PublishAuthorCatalogExactSetSuccessorParamsV1['assets'];
+declare const deployment: PublishAuthorCatalogExactSetSuccessorParamsV1['deployment'];
+declare const successorIssuedAt:
+  NonNullable<PublishAuthorCatalogExactSetSuccessorParamsV1['issuedAt']>;
+
+const successor: PublishAuthorCatalogExactSetSuccessorParamsV1 = {
+  previousHead,
+  author: successorAuthor,
+  catalogIssuerAuthorization,
+  assets,
+  deployment,
+  issuedAt: successorIssuedAt,
+  peers: ['12D3KooWExamplePeer'],
+};
+const successorResult: Promise<PublishAuthorCatalogExactSetSuccessorResultV1> =
+  agent.publishAuthorCatalogExactSetSuccessorV1(successor);
+
+declare const localAgentAddress: Rfc64CatalogAccessPolicyAuthorityConfigV1['localAgentAddress'];
+declare const resolveRemoteAgentAddress:
+  Rfc64CatalogAccessPolicyAuthorityConfigV1['resolveRemoteAgentAddress'];
+
+const authority: Rfc64CatalogAccessPolicyAuthorityConfigV1 = {
+  localAgentAddress,
+  resolveRemoteAgentAddress,
+};
+// The authority is create-time configuration, so pin its config field name too.
+const authorityConfig: Pick<DKGAgentConfig, 'rfc64CatalogAccessPolicyAuthority'> = {
+  rfc64CatalogAccessPolicyAuthority: authority,
+};
+
+void accepted;
+void genesisResult;
+void successorResult;
+void authorityConfig;

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -4,14 +4,17 @@ import { join } from 'node:path';
 
 import { multiaddr } from '@multiformats/multiaddr';
 import {
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   assertCanonicalGraphScopedAuthorSealV1,
   buildAuthorAttestationTypedData,
   computeAuthorCatalogScopeDigestV1,
   type CanonicalGraphScopedAuthorSealV1,
   type CatalogSealDeploymentProfileV1,
   type ContextGraphIdV1,
+  type ContextGraphPolicyV1,
   type Digest32V1,
   type EvmAddressV1,
+  type MemberRosterV1,
   type NetworkIdV1,
   type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
@@ -20,7 +23,11 @@ import { ethers } from 'ethers';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { DKGAgent } from '../src/dkg-agent.js';
-import { snapshotRfc64CatalogDeploymentProfileV1 } from '../src/dkg-agent-rfc64-catalog.js';
+import {
+  snapshotRfc64CatalogAccessPolicyAuthorityV1,
+  snapshotRfc64CatalogDeploymentProfileV1,
+} from '../src/dkg-agent-rfc64-catalog.js';
+import type { Rfc64CatalogAccessPolicyAuthorityConfigV1 } from '../src/dkg-agent-types.js';
 
 const AUTHOR_WALLET = new ethers.Wallet(`0x${'64'.repeat(32)}`);
 const NETWORK_ID = 'otp:20430' as NetworkIdV1;
@@ -60,6 +67,7 @@ async function startNativeAgent(
   name: string,
   deployment: CatalogSealDeploymentProfileV1 = NATIVE_DEPLOYMENT,
   existingDataDir?: string,
+  accessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1,
 ): Promise<DKGAgent> {
   const dataDir = existingDataDir
     ?? await mkdtemp(join(tmpdir(), `dkg-rfc64-native-${name}-`));
@@ -78,6 +86,7 @@ async function startNativeAgent(
     durableSyncEnabled: false,
     agentProfileHeartbeatMs: 0,
     rfc64CatalogDeploymentProfile: deployment,
+    rfc64CatalogAccessPolicyAuthority: accessPolicyAuthority,
   });
   agents.push(agent);
   await agent.start();
@@ -109,6 +118,50 @@ function catalogScopeDigest() {
   });
 }
 
+function privateCatalogPolicy(): ContextGraphPolicyV1 {
+  return {
+    networkId: NETWORK_ID,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era: '7',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy: 1,
+    publishPolicy: 1,
+    publishAuthority: null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'owner-signed-unregistered',
+      ownerAddress: AUTHOR,
+      ownerAuthorityEra: '0',
+    },
+    effectiveAt: '0',
+    issuedAt: '0',
+  };
+}
+
+function privateCatalogRoster(
+  policy: ContextGraphPolicyV1,
+  policyDigest: Digest32V1,
+): MemberRosterV1 {
+  return {
+    networkId: policy.networkId,
+    contextGraphId: policy.contextGraphId,
+    ownershipTransitionDigest: policy.ownershipTransitionDigest,
+    era: policy.era,
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest,
+    administrativeDelegationDigest: policy.administrativeDelegationDigest,
+    members: [{ agentAddress: AUTHOR, roles: ['holder', 'provider'] }],
+    issuedAt: '0',
+  };
+}
+
 describe('RFC-64 DKGAgent production native catalog wiring', () => {
   it('snapshots and canonicalizes the deterministic local deployment override', () => {
     const callerOwned = {
@@ -127,6 +180,103 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
       assertedAtKav10Address: `0x${'00'.repeat(20)}` as never,
     })).toThrow(/non-zero EVM address/);
   });
+
+  it('snapshots the explicit access authority and fails closed before private activation', async () => {
+    const resolver = async () => AUTHOR;
+    const callerOwned = {
+      localAgentAddress: ethers.getAddress(AUTHOR) as EvmAddressV1,
+      resolveRemoteAgentAddress: resolver,
+    };
+    const snapshot = snapshotRfc64CatalogAccessPolicyAuthorityV1(callerOwned)!;
+    callerOwned.localAgentAddress = ethers.ZeroAddress as EvmAddressV1;
+    expect(snapshot).toEqual({
+      localAgentAddress: AUTHOR,
+      resolveRemoteAgentAddress: resolver,
+    });
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(() => snapshotRfc64CatalogAccessPolicyAuthorityV1({
+      localAgentAddress: ethers.ZeroAddress as EvmAddressV1,
+      resolveRemoteAgentAddress: resolver,
+    })).toThrow(/localAgentAddress is invalid/);
+
+    const policy = privateCatalogPolicy();
+    const policyDigest = `0x${'ab'.repeat(32)}` as Digest32V1;
+    const roster = privateCatalogRoster(policy, policyDigest);
+    const legacyOpenOnly = await startNativeAgent('private-denied');
+    expect(() => legacyOpenOnly.acceptRfc64CatalogAccessSnapshotV1({
+      policy,
+      policyDigest,
+      roster,
+    })).toThrow(/requires explicit access-policy authority/);
+
+    const configured = await startNativeAgent(
+      'private-configured',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      {
+        localAgentAddress: AUTHOR,
+        resolveRemoteAgentAddress: resolver,
+      },
+    );
+    expect(configured.acceptRfc64CatalogAccessSnapshotV1({
+      policy,
+      policyDigest,
+      roster,
+    })).toMatchObject({ policyDigest, roster: { policyDigest } });
+
+    const published = await configured.publishAuthorCatalogGenesisV1({
+      scope: {
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        governanceChainId: null,
+        governanceContractAddress: null,
+        ownershipTransitionDigest: null,
+        subGraphName: 'service-lane',
+        authorAddress: AUTHOR,
+        era: '0',
+        bucketCount: '1',
+      },
+      author: AUTHOR_WALLET,
+      peers: [],
+      issuedAt: FIXED_HEAD_ISSUED_AT,
+      catalogIssuerDelegationEffectiveAt: DELEGATION_EFFECTIVE_AT,
+      catalogIssuerDelegationExpiresAt: MULTI_DELEGATION_EXPIRES_AT,
+    });
+    expect(published.announcement).toMatchObject({
+      policyDigest,
+      subGraphName: 'service-lane',
+      catalogEra: '0',
+    });
+
+    const successor = await configured.publishAuthorCatalogExactSetSuccessorV1({
+      previousHead: {
+        objectDigest: published.headObjectDigest,
+        signatureVariantDigest: published.signatureVariantDigest,
+      },
+      author: AUTHOR_WALLET,
+      catalogIssuerAuthorization: published.catalogIssuerAuthorization,
+      assets: [{
+        assertionCoordinate: 'private-subgraph-object' as never,
+        projectionBytes: PROJECTION,
+        seal: await authorSeal(7n),
+      }],
+      deployment: NATIVE_DEPLOYMENT,
+      issuedAt: SUCCESSOR_ISSUED_AT,
+      peers: [],
+    });
+    expect(successor).toMatchObject({
+      announcement: {
+        policyDigest,
+        subGraphName: 'service-lane',
+        catalogEra: '0',
+      },
+      catalogScope: {
+        subGraphName: 'service-lane',
+        era: '0',
+      },
+      inventoryRowCount: '1',
+    });
+  }, 60_000);
 
   it('uses the trusted override to fetch provider content and durably apply native genesis', async () => {
     const [author, receiver] = await Promise.all([
@@ -244,7 +394,7 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     });
     await receiver.whenRfc64PublicCatalogReceiverIdleV1();
 
-    const successor = await author.publishOpenAuthorCatalogExactSetSuccessorV1({
+    const successor = await author.publishAuthorCatalogExactSetSuccessorV1({
       previousHead: {
         objectDigest: firstSuccessor.headObjectDigest,
         signatureVariantDigest: firstSuccessor.signatureVariantDigest,

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -224,7 +224,7 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
       roster,
     })).toMatchObject({ policyDigest, roster: { policyDigest } });
 
-    const published = await configured.publishAuthorCatalogGenesisV1({
+    const privateGenesis = {
       scope: {
         networkId: NETWORK_ID,
         contextGraphId: CONTEXT_GRAPH_ID,
@@ -241,14 +241,19 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
       issuedAt: FIXED_HEAD_ISSUED_AT,
       catalogIssuerDelegationEffectiveAt: DELEGATION_EFFECTIVE_AT,
       catalogIssuerDelegationExpiresAt: MULTI_DELEGATION_EXPIRES_AT,
-    });
+    } as const;
+    await expect(configured.publishAuthorCatalogGenesisV1({
+      ...privateGenesis,
+      peers: ['12D3KooPrivateReceiver'],
+    })).rejects.toThrow(/private catalog peer fan-out requires scope-bound/u);
+    const published = await configured.publishAuthorCatalogGenesisV1(privateGenesis);
     expect(published.announcement).toMatchObject({
       policyDigest,
       subGraphName: 'service-lane',
       catalogEra: '0',
     });
 
-    const successor = await configured.publishAuthorCatalogExactSetSuccessorV1({
+    const privateSuccessor = {
       previousHead: {
         objectDigest: published.headObjectDigest,
         signatureVariantDigest: published.signatureVariantDigest,
@@ -263,7 +268,14 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
       deployment: NATIVE_DEPLOYMENT,
       issuedAt: SUCCESSOR_ISSUED_AT,
       peers: [],
-    });
+    } as const;
+    await expect(configured.publishOpenAuthorCatalogExactSetSuccessorV1(privateSuccessor))
+      .rejects.toThrow(/public\/open compatibility successor requires the root lane/u);
+    await expect(configured.publishAuthorCatalogExactSetSuccessorV1({
+      ...privateSuccessor,
+      peers: ['12D3KooPrivateReceiver'],
+    })).rejects.toThrow(/private catalog peer fan-out requires scope-bound/u);
+    const successor = await configured.publishAuthorCatalogExactSetSuccessorV1(privateSuccessor);
     expect(successor).toMatchObject({
       announcement: {
         policyDigest,

--- a/packages/agent/test/rfc64-public-catalog-service-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-service-v1.test.ts
@@ -288,6 +288,57 @@ function countEvent(router: RecordingRouter, event: string): number {
 }
 
 describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
+  it('preserves direct open-only construction and rejects private snapshots', async () => {
+    const service = new Rfc64PublicCatalogServiceV1({
+      router: new RecordingRouter().asProtocolRouter(),
+      controlObjects: controlObjects(),
+    });
+    service.start();
+    const accepted = service.acceptOpenPolicy({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    expect(accepted.policy.accessPolicy).toBe(0);
+
+    const privatePolicy = catalogPolicy(`${CONTEXT_GRAPH_ID}-private`, 1, 1);
+    const privateDigest = `0x${'31'.repeat(32)}` as Digest32V1;
+    expect(() => service.acceptPolicySnapshot({
+      policy: privatePolicy,
+      policyDigest: privateDigest,
+      roster: memberRoster(privatePolicy, privateDigest),
+    })).toThrow(/requires explicit access-policy authority/u);
+    await service.close();
+  });
+
+  it('advances a verified current policy and rejects the old digest immediately', async () => {
+    const service = new Rfc64PublicCatalogServiceV1({
+      router: new RecordingRouter().asProtocolRouter(),
+      controlObjects: controlObjects(),
+    });
+    service.start();
+    const initial = catalogPolicy(CONTEXT_GRAPH_ID, 0, 1);
+    const initialDigest = `0x${'32'.repeat(32)}` as Digest32V1;
+    service.acceptPolicySnapshot({ policy: initial, policyDigest: initialDigest });
+    const successor = {
+      ...catalogPolicy(CONTEXT_GRAPH_ID, 0, 0),
+      version: '1',
+      previousPolicyDigest: initialDigest,
+    } satisfies ContextGraphPolicyV1;
+    const successorDigest = `0x${'33'.repeat(32)}` as Digest32V1;
+    service.acceptPolicySnapshot({ policy: successor, policyDigest: successorDigest });
+
+    await expect(service.announceCatalogHead({
+      announcement: announcement(initialDigest),
+      peers: [],
+    })).rejects.toThrow(/not bound to the locally accepted policy/u);
+    await expect(service.announceCatalogHead({
+      announcement: announcement(successorDigest),
+      peers: [],
+    })).resolves.toMatchObject({ announcedPeers: [], failedPeers: [] });
+    await service.close();
+  });
+
   it('accepts all four policy cells and requires a roster only for private access', async () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: new RecordingRouter().asProtocolRouter(),

--- a/packages/agent/test/rfc64-public-catalog-service-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-service-v1.test.ts
@@ -2,11 +2,14 @@ import {
   AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
   AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
   AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1,
   computeControlSignatureVariantDigestHex,
   type AuthorCatalogScopeV1,
   type Digest32V1,
+  type ContextGraphPolicyV1,
   type EvmAddressV1,
+  type MemberRosterV1,
   type ProtocolRouter,
   type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
@@ -14,6 +17,10 @@ import { ethers } from 'ethers';
 import { describe, expect, it, vi } from 'vitest';
 
 import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
+import {
+  buildOpenOwnerContextGraphPolicyV1,
+  computeOpenContextGraphPolicyDigestV1,
+} from '../src/rfc64/open-catalog-policy-v1.js';
 import type { Rfc64ControlObjectOperationsV1 } from '../src/rfc64/control-object-store-v1.js';
 import {
   RFC64_PUBLIC_CATALOG_ANNOUNCE_MAX_PEERS_V1,
@@ -145,6 +152,79 @@ function nativeOptions(
   } as const;
 }
 
+function accessPolicyAuthority() {
+  return {
+    localAgentAddress: AUTHOR,
+    resolveRemoteAgentAddress: async () => null,
+  } as const;
+}
+
+function catalogPolicy(
+  contextGraphId: string,
+  accessPolicy: 0 | 1,
+  publishPolicy: 0 | 1,
+): ContextGraphPolicyV1 {
+  return {
+    networkId: NETWORK_ID,
+    contextGraphId: contextGraphId as ContextGraphPolicyV1['contextGraphId'],
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy,
+    publishPolicy,
+    publishAuthority: publishPolicy === 0
+      ? OTHER_WALLET.address.toLowerCase() as EvmAddressV1
+      : null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: { kind: 'owner-signed-unregistered', ownerAddress: AUTHOR, ownerAuthorityEra: '0' },
+    effectiveAt: '0',
+    issuedAt: '0',
+  };
+}
+
+function memberRoster(
+  policy: ContextGraphPolicyV1,
+  policyDigest: Digest32V1,
+): MemberRosterV1 {
+  const members = [AUTHOR, OTHER_WALLET.address.toLowerCase() as EvmAddressV1]
+    .sort()
+    .map((agentAddress) => ({ agentAddress, roles: ['holder', 'provider'] as const }));
+  return {
+    networkId: policy.networkId,
+    contextGraphId: policy.contextGraphId,
+    ownershipTransitionDigest: policy.ownershipTransitionDigest,
+    era: policy.era,
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest,
+    administrativeDelegationDigest: policy.administrativeDelegationDigest,
+    members,
+    issuedAt: '0',
+  };
+}
+
+/**
+ * `memberRoster` enrols every wallet these tests author with, which makes the private branch of
+ * `isSwmAuthorAuthorized` unfalsifiable. This builds the same roster minus one address so the
+ * off-roster author case can actually be asserted.
+ */
+function rosterExcluding(
+  policy: ContextGraphPolicyV1,
+  policyDigest: Digest32V1,
+  excluded: EvmAddressV1,
+): MemberRosterV1 {
+  const base = memberRoster(policy, policyDigest);
+  return {
+    ...base,
+    members: base.members.filter((member) => member.agentAddress !== excluded),
+  };
+}
+
 function acceptPolicy(service: Rfc64PublicCatalogServiceV1) {
   return service.acceptOpenPolicy({
     networkId: NETWORK_ID,
@@ -208,6 +288,176 @@ function countEvent(router: RecordingRouter, event: string): number {
 }
 
 describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
+  it('accepts all four policy cells and requires a roster only for private access', async () => {
+    const service = new Rfc64PublicCatalogServiceV1({
+      router: new RecordingRouter().asProtocolRouter(),
+      controlObjects: controlObjects(),
+      accessPolicyAuthority: accessPolicyAuthority(),
+    });
+    let index = 0;
+    for (const accessPolicy of [0, 1] as const) {
+      for (const publishPolicy of [0, 1] as const) {
+        index += 1;
+        const policy = catalogPolicy(
+          `${CONTEXT_GRAPH_ID}-${accessPolicy}-${publishPolicy}`,
+          accessPolicy,
+          publishPolicy,
+        );
+        const policyDigest = `0x${index.toString(16).padStart(64, '0')}` as Digest32V1;
+        const accepted = service.acceptPolicySnapshot({
+          policy,
+          policyDigest,
+          roster: accessPolicy === 1 ? memberRoster(policy, policyDigest) : undefined,
+        });
+        expect(accepted.policy.accessPolicy).toBe(accessPolicy);
+        expect(accepted.policy.publishPolicy).toBe(publishPolicy);
+        expect(accepted.roster === null).toBe(accessPolicy === 0);
+        expect(service.acceptedPolicyDigestForCatalogScope({
+          networkId: policy.networkId,
+          contextGraphId: policy.contextGraphId,
+          governanceChainId: policy.governanceChainId,
+          governanceContractAddress: policy.governanceContractAddress,
+          ownershipTransitionDigest: policy.ownershipTransitionDigest,
+          subGraphName: 'service-lane',
+          authorAddress: OTHER_WALLET.address.toLowerCase() as EvmAddressV1,
+          era: '7',
+          bucketCount: '1',
+        })).toBe(policyDigest);
+      }
+    }
+    expect(service.stats().acceptedPolicies).toBe(4);
+
+    const privatePolicy = catalogPolicy(`${CONTEXT_GRAPH_ID}-missing-roster`, 1, 1);
+    await expect(Promise.resolve().then(() => service.acceptPolicySnapshot({
+      policy: privatePolicy,
+      policyDigest: `0x${'f'.repeat(64)}` as Digest32V1,
+    }))).rejects.toThrow(/requires a current member roster/);
+    await service.close();
+  });
+
+  it('denies a private-cell author that is absent from the current member roster', async () => {
+    const service = new Rfc64PublicCatalogServiceV1({
+      router: new RecordingRouter().asProtocolRouter(),
+      controlObjects: controlObjects(),
+      accessPolicyAuthority: accessPolicyAuthority(),
+    });
+    service.start();
+    const outsider = OTHER_WALLET.address.toLowerCase() as EvmAddressV1;
+
+    const closedPolicy = catalogPolicy(`${CONTEXT_GRAPH_ID}-private-closed`, 1, 1);
+    const closedDigest = `0x${'2c'.repeat(32)}` as Digest32V1;
+    service.acceptPolicySnapshot({
+      policy: closedPolicy,
+      policyDigest: closedDigest,
+      roster: rosterExcluding(closedPolicy, closedDigest, outsider),
+    });
+
+    // Author side (assertAcceptedPolicyMatchesCatalogScope): an accepted private snapshot must not
+    // bind a catalog scope whose author is off-roster.
+    await expect(service.publishAuthorCatalogGenesis({
+      scope: {
+        networkId: closedPolicy.networkId,
+        contextGraphId: closedPolicy.contextGraphId,
+        governanceChainId: closedPolicy.governanceChainId,
+        governanceContractAddress: closedPolicy.governanceContractAddress,
+        ownershipTransitionDigest: closedPolicy.ownershipTransitionDigest,
+        subGraphName: 'service-lane',
+        authorAddress: outsider,
+        era: '0',
+        bucketCount: '1',
+      } as AuthorCatalogScopeV1,
+      signer: {
+        issuer: outsider,
+        signDigest: (digest: Uint8Array) => OTHER_WALLET.signMessage(digest),
+      },
+      issuedAt: HEAD_ISSUED_AT,
+      catalogIssuerDelegationEffectiveAt: DELEGATION_EFFECTIVE_AT,
+      catalogIssuerDelegationExpiresAt: DELEGATION_EXPIRES_AT,
+      peers: [],
+    })).rejects.toThrow(/not bound to the exact catalog network, CG, governance scope, and author/);
+
+    // Receive side (#assertAcceptedCatalogAnnouncement): an announcement naming an off-roster author
+    // must not resolve a trusted catalog scope.
+    await expect(service.announceCatalogHead({
+      announcement: {
+        ...announcement(closedDigest),
+        contextGraphId: closedPolicy.contextGraphId,
+        authorAddress: outsider,
+      } as Rfc64PublicCatalogHeadAnnouncementV1,
+      peers: [],
+    })).rejects.toThrow(/not bound to the locally accepted policy snapshot/);
+
+    // Control: the identical announcement is accepted for a private cell whose roster DOES enrol the
+    // same author, proving both denials above come from the roster check rather than from an
+    // unrelated scope mismatch.
+    const openRosterPolicy = catalogPolicy(`${CONTEXT_GRAPH_ID}-private-enrolled`, 1, 1);
+    const openRosterDigest = `0x${'2d'.repeat(32)}` as Digest32V1;
+    service.acceptPolicySnapshot({
+      policy: openRosterPolicy,
+      policyDigest: openRosterDigest,
+      roster: memberRoster(openRosterPolicy, openRosterDigest),
+    });
+    await expect(service.announceCatalogHead({
+      announcement: {
+        ...announcement(openRosterDigest),
+        contextGraphId: openRosterPolicy.contextGraphId,
+        authorAddress: outsider,
+      } as Rfc64PublicCatalogHeadAnnouncementV1,
+      peers: [],
+    })).resolves.toMatchObject({ announcedPeers: [] });
+
+    await service.close();
+  });
+
+  it('publishes exact subgraph genesis under both public policy cells', async () => {
+    for (const publishPolicy of [0, 1] as const) {
+      const service = new Rfc64PublicCatalogServiceV1({
+        router: new RecordingRouter().asProtocolRouter(),
+        controlObjects: controlObjects(),
+        accessPolicyAuthority: accessPolicyAuthority(),
+      });
+      service.start();
+      const policy = catalogPolicy(
+        `${CONTEXT_GRAPH_ID}-public-${publishPolicy}`,
+        0,
+        publishPolicy,
+      );
+      const policyDigest = (
+        `0x${(10 + publishPolicy).toString(16).padStart(64, '0')}`
+      ) as Digest32V1;
+      service.acceptPolicySnapshot({ policy, policyDigest });
+
+      const authorAddress = OTHER_WALLET.address.toLowerCase() as EvmAddressV1;
+      const result = await service.publishAuthorCatalogGenesis({
+        scope: {
+          networkId: policy.networkId,
+          contextGraphId: policy.contextGraphId,
+          governanceChainId: null,
+          governanceContractAddress: null,
+          ownershipTransitionDigest: null,
+          subGraphName: 'service-lane',
+          authorAddress,
+          era: '0',
+          bucketCount: '1',
+        },
+        signer: {
+          issuer: authorAddress,
+          signDigest: (digest) => OTHER_WALLET.signMessage(digest),
+        },
+        issuedAt: HEAD_ISSUED_AT,
+        catalogIssuerDelegationEffectiveAt: DELEGATION_EFFECTIVE_AT,
+        catalogIssuerDelegationExpiresAt: DELEGATION_EXPIRES_AT,
+        peers: [],
+      });
+      expect(result.announcement).toMatchObject({
+        policyDigest,
+        subGraphName: 'service-lane',
+        authorAddress,
+      });
+      await service.close();
+    }
+  });
+
   it('durably stages the exact signed delegation before genesis and only then announces', async () => {
     const router = new RecordingRouter();
     const store = controlObjects();
@@ -219,6 +469,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: store,
+      accessPolicyAuthority: accessPolicyAuthority(),
     });
     service.start();
 
@@ -259,6 +510,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: store,
+      accessPolicyAuthority: accessPolicyAuthority(),
     });
     service.start();
 
@@ -269,11 +521,15 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
       },
     }) as never)).rejects.toThrow(/signer must equal the exact catalog author/);
 
-    const wrongPolicy = service.acceptOpenPolicy({
+    const wrongPolicyPayload = buildOpenOwnerContextGraphPolicyV1({
       networkId: NETWORK_ID,
       contextGraphId: CONTEXT_GRAPH_ID,
       ownerAddress: OTHER_WALLET.address.toLowerCase() as EvmAddressV1,
     });
+    const wrongPolicy = {
+      policy: wrongPolicyPayload,
+      policyDigest: computeOpenContextGraphPolicyDigestV1(wrongPolicyPayload),
+    };
     await expect(service.publishOpenAuthorCatalogGenesis(genesisInput(service, {
       policy: wrongPolicy,
     }) as never)).rejects.toThrow(/not bound to the exact catalog/);
@@ -289,6 +545,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: store,
+      accessPolicyAuthority: accessPolicyAuthority(),
     });
     service.start();
 
@@ -311,6 +568,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: store,
+      accessPolicyAuthority: accessPolicyAuthority(),
     });
     service.start();
 
@@ -330,6 +588,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: store,
+      accessPolicyAuthority: accessPolicyAuthority(),
     });
     service.start();
 
@@ -345,6 +604,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: controlObjects(),
+      accessPolicyAuthority: accessPolicyAuthority(),
     });
     const policy = acceptPolicy(service);
     const head = announcement(policy.policyDigest);
@@ -405,6 +665,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: controlObjects(),
+      accessPolicyAuthority: accessPolicyAuthority(),
       transportTimeoutMs: 4_321,
       native: nativeOptions(createReconciler),
     });
@@ -445,13 +706,24 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
       era: '0',
       bucketCount: '1',
     });
+    expect(clients!.resolveTrustedCatalogScope({
+      ...announcement(policy.policyDigest),
+      subGraphName: 'service-lane',
+      catalogEra: '7',
+    } as Rfc64PublicCatalogHeadAnnouncementV1)).toMatchObject({
+      subGraphName: 'service-lane',
+      authorAddress: AUTHOR,
+      era: '7',
+    });
     expect(() => clients!.resolveTrustedCatalogScope(announcement(
       `0x${'cc'.repeat(32)}` as Digest32V1,
-    ))).toThrow('no matching accepted open policy generation');
-    expect(() => clients!.resolveTrustedCatalogScope({
+    ))).toThrow('no matching accepted policy generation');
+    expect(clients!.resolveTrustedCatalogScope({
       ...announcement(policy.policyDigest),
       authorAddress: OTHER_WALLET.address.toLowerCase() as EvmAddressV1,
-    })).toThrow('accepted null-governance owner policy');
+    })).toMatchObject({
+      authorAddress: OTHER_WALLET.address.toLowerCase(),
+    });
 
     service.start();
     service.start();
@@ -464,6 +736,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: controlObjects(),
+      accessPolicyAuthority: accessPolicyAuthority(),
       native: nativeOptions(() => inertReconciler()),
     });
 
@@ -483,6 +756,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: controlObjects(),
+      accessPolicyAuthority: accessPolicyAuthority(),
       native: nativeOptions(() => inertReconciler()),
     });
 
@@ -508,6 +782,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: controlObjects(),
+      accessPolicyAuthority: accessPolicyAuthority(),
       receiver: { retryBackoffMs: 0 },
       native: nativeOptions((input) => {
         clients = input;
@@ -582,6 +857,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: store,
+      accessPolicyAuthority: accessPolicyAuthority(),
       onHeadStaged,
     });
     const policy = acceptPolicy(service);
@@ -651,6 +927,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     const service = new Rfc64PublicCatalogServiceV1({
       router: router.asProtocolRouter(),
       controlObjects: store,
+      accessPolicyAuthority: accessPolicyAuthority(),
       receiver: { maxAttempts: 1, retryBackoffMs: 0, onError },
     });
     const policy = acceptPolicy(service);

--- a/packages/agent/test/rfc64-public-catalog-successor-producer-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-successor-producer-v1.test.ts
@@ -131,6 +131,22 @@ describe('RFC-64 public/open one-row successor producer', () => {
     });
   });
 
+  it('preserves an exact non-root subgraph lane across a bounded successor', async () => {
+    const subGraphName = 'service-lane' as AuthorCatalogScopeV1['subGraphName'];
+    const { genesis, authorization } = await producerHistory(subGraphName);
+    const result = await stageOne(
+      { head: genesis.head, directoryPath: genesis.directoryPath, bucket: null },
+      authorization,
+    );
+
+    expect(result.publication.head.payload).toMatchObject({
+      subGraphName,
+      version: '1',
+      previousHeadDigest: genesis.head.objectDigest,
+    });
+    expect(result.publication.bucket?.payload.rows).toHaveLength(1);
+  });
+
   it('canonicalizes an unordered two-row exact set and produces the same signed head', async () => {
     const { genesis, authorization } = await producerHistory();
     const stageKaBundle = vi.fn(durableBundleReceipt);
@@ -622,8 +638,14 @@ type BundleStageInput = {
   readonly bundleBytes: Uint8Array;
 };
 
-async function producerHistory() {
-  const authorization = await directCatalogAuthorization(AUTHOR_WALLET, CONTEXT_GRAPH_ID);
+async function producerHistory(
+  subGraphName: AuthorCatalogScopeV1['subGraphName'] = null,
+) {
+  const authorization = await directCatalogAuthorization(
+    AUTHOR_WALLET,
+    CONTEXT_GRAPH_ID,
+    subGraphName,
+  );
   const genesis = await produceEmptyAuthorCatalogGenesisV1({
     scope: {
       networkId: NETWORK_ID,
@@ -631,7 +653,7 @@ async function producerHistory() {
       governanceChainId: '20430',
       governanceContractAddress: GOVERNANCE,
       ownershipTransitionDigest: null,
-      subGraphName: null,
+      subGraphName,
       authorAddress: AUTHOR,
       era: '0',
       bucketCount: '1',
@@ -685,6 +707,7 @@ async function stageOne(
 async function directCatalogAuthorization(
   wallet: ethers.Wallet,
   contextGraphId: ContextGraphIdV1,
+  subGraphName: AuthorCatalogScopeV1['subGraphName'] = null,
 ) {
   const authorAddress = wallet.address.toLowerCase() as EvmAddressV1;
   const produced = await produceDirectAuthorCatalogIssuerDelegationV1({
@@ -694,7 +717,7 @@ async function directCatalogAuthorization(
       governanceChainId: '20430',
       governanceContractAddress: GOVERNANCE,
       ownershipTransitionDigest: null,
-      subGraphName: null,
+      subGraphName,
       authorAddress,
       era: '0',
       bucketCount: '1',


### PR DESCRIPTION
## What

Composes the RFC-64 **generic catalog authoring** service/API onto the authorized transport stack, completing the CP1 product path. Adds the policy-neutral public authoring surface used by both publicly-readable cells:

- `acceptRfc64CatalogAccessSnapshotV1` — accepts exact **public/open** and **public/curated** policy snapshots with no roster; private access requires a current member roster and **fails closed** without one.
- `publishAuthorCatalogGenesisV1` / `publishAuthorCatalogExactSetSuccessorV1` — generic author / subgraph / catalog-era scope, root **and** named subgraphs, not routed through the legacy open/root-only assertions.
- `rfc64CatalogAccessPolicyAuthority` create-option, plus package-root and type exports.

**Stacked on #1881** (base is that branch, not `integration/rfc64-devnet`) — review/merge #1881 first. Part of the RFC-64 **V2 public-first** milestone. **Not for `main`.**

## Two mutation-dead tests closed

Both of these passed whether or not the product behaved, so they are fixed here rather than left as false signal:

1. **`isSwmAuthorAuthorized`'s private branch was unfalsifiable.** The suite's own `memberRoster()` helper enrols every wallet the tests author with, so deleting the roster clause at *either* call site left the entire 374-test RFC-64 suite green. Adds an off-roster private-cell author negative covering both the author side (`assertAcceptedPolicyMatchesCatalogScope`) and the receive side (`announceCatalogHead` → `resolveTrustedCatalogScope`), with a positive control on an enrolled roster so the denial is attributable to the roster check rather than an unrelated scope mismatch.

2. **The new public-API typecheck had no teeth on parameter shapes.** Every params value was introduced as `declare const x: T` and passed to a method taking exactly `T` — a `T`-assignable-to-`T` no-op that proves only the export *name* exists. A rename or a newly required field on the three published signatures compiled clean. Rebuilt around real object literals (matching the sibling `rfc64-applied-inventory-digest-public-api.typecheck.ts`), so field names are load-bearing.

> Note for reviewers: the negative→positive assertion flip in the service test is **correct, not a regression** — for a public cell `isSwmAuthorAuthorized` rightly short-circuits on `accessPolicy === 0` under the orthogonal model (`accessPolicy` governs read/SWM, `publishPolicy` governs only finalized-VM admission).

## Evidence

- `tsc + test:types + test:package-root` → exit 0, zero errors.
- Full RFC-64 unit regression → **31 files / 374 passed, 5 skipped, 0 failed**.
- **Mutation-verified:**
  - `isSwmAuthorAuthorized` forced to always return `true` → `denies a private-cell author that is absent from the current member roster` **fails** (1 failed / 14 passed).
  - `PublishAuthorCatalogGenesisParamsV1.scope` renamed in the emitted `d.ts` → `test:types` **fails** with TS2339 *and* TS2353 (both the indexed access and the literal key catch it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
