### PR TITLE
feat(publisher): job-scoped terminal cleanup for publisher + SWM share queues (#1837)

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -115,6 +115,7 @@ import {
   FileWorkspacePublicSnapshotStore,
   parseWorkspacePublicSnapshotNQuads,
   type AsyncPromoteQueue, type AsyncPromoteQueueConfig,
+  type PromoteTerminalJobClearer,
   type PromoteJob, type PromoteListFilter,
   wrapAsRpcPreconditionIfApplicable,
   type PublishOptions, type PublishResult, type PhaseCallback, type KAMetadata, type CASCondition,
@@ -554,7 +555,10 @@ export class DKGAgentBase {
    * getter so the worker (a daemon-side concern) and tests can drive
    * the queue directly without going through the assertion subsurface.
    */
-  protected _promoteQueue?: AsyncPromoteQueue;
+  // Typed with the terminal-clear capability at the ownership boundary (not cast at the
+  // getter): the only assigned value is `TripleStoreAsyncPromoteQueue`, which implements it,
+  // and any test/subclass substituting a queue must now satisfy the clearer at compile time.
+  protected _promoteQueue?: AsyncPromoteQueue & PromoteTerminalJobClearer;
   /**
    * Override for tests / future operator config. When set before
    * `promoteQueue` is first accessed, the queue is constructed with

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -107,6 +107,7 @@ import {
   FileWorkspacePublicSnapshotStore,
   parseWorkspacePublicSnapshotNQuads,
   type AsyncPromoteQueue, type AsyncPromoteQueueConfig,
+  type PromoteTerminalJobClearer, type TerminalJobClearOutcome,
   type PromoteJob, type PromoteListFilter,
   wrapAsRpcPreconditionIfApplicable,
   resolveStorageAckTiming,
@@ -2968,6 +2969,11 @@ export class DKGAgent extends DKGAgentBase {
       async recoverPromoteAsync(jobId: string): Promise<void> {
         return agent.promoteQueue.recover(jobId);
       },
+      // #1837 — atomic by-jobId terminal clear (record removal). Distinct from
+      // cancelPromoteAsync (queued abort, retains the row).
+      async clearPromoteAsync(jobId: string): Promise<TerminalJobClearOutcome> {
+        return agent.promoteQueue.clearTerminalJob(jobId);
+      },
     };
   }
 
@@ -2983,11 +2989,13 @@ export class DKGAgent extends DKGAgentBase {
    * `recordCommitMarker` / `recoverOnStartup`) without the assertion
    * subsurface having to leak those methods to user-facing callers.
    */
-  get promoteQueue(): AsyncPromoteQueue {
+  get promoteQueue(): AsyncPromoteQueue & PromoteTerminalJobClearer {
     if (!this._promoteQueue) {
       this._promoteQueue = new TripleStoreAsyncPromoteQueue(this.store, this._promoteQueueConfig ?? {});
     }
-    return this._promoteQueue;
+    // The instance is always a TripleStoreAsyncPromoteQueue, which implements both the
+    // base queue and the #1837 terminal-clear capability.
+    return this._promoteQueue as AsyncPromoteQueue & PromoteTerminalJobClearer;
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2993,9 +2993,7 @@ export class DKGAgent extends DKGAgentBase {
     if (!this._promoteQueue) {
       this._promoteQueue = new TripleStoreAsyncPromoteQueue(this.store, this._promoteQueueConfig ?? {});
     }
-    // The instance is always a TripleStoreAsyncPromoteQueue, which implements both the
-    // base queue and the #1837 terminal-clear capability.
-    return this._promoteQueue as AsyncPromoteQueue & PromoteTerminalJobClearer;
+    return this._promoteQueue;
   }
 
   /**

--- a/packages/agent/test/clear-promote-async-facade.test.ts
+++ b/packages/agent/test/clear-promote-async-facade.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  TripleStoreAsyncPromoteQueue,
+  type PromoteRequest,
+} from '@origintrail-official/dkg-publisher';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+// #1837 — verifies the PRODUCTION DKGAgent facade wiring between
+// `agent.assertion.clearPromoteAsync` and `promoteQueue.clearTerminalJob`, driving a REAL
+// promote queue. The SWM route tests stub `clearPromoteAsync` onto a fake agent, so they
+// cover the route + queue contract but NOT this delegation: a regression that pointed the
+// facade at `cancel()` (which retains the row) or any other queue method would leave those
+// route tests green yet be caught here.
+describe('DKGAgent assertion.clearPromoteAsync facade wiring (#1837)', () => {
+  const stores: OxigraphStore[] = [];
+  afterEach(async () => {
+    await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {})));
+  });
+
+  function makeRequest(overrides: Partial<PromoteRequest> = {}): PromoteRequest {
+    return { contextGraphId: 'graphify', subGraphName: 'code', assertionName: 'shard-1', entities: 'all', ...overrides };
+  }
+
+  function newQueue(): TripleStoreAsyncPromoteQueue {
+    const store = new OxigraphStore();
+    stores.push(store);
+    let id = 0;
+    return new TripleStoreAsyncPromoteQueue(store, { now: () => 1_000_000, idGenerator: () => `job-${++id}` });
+  }
+
+  // Real DKGAgent facade over an injected real queue — `agent.assertion.clearPromoteAsync`
+  // routes through the public `promoteQueue` getter, exactly as production does.
+  // `defaultAgentAddress` is set so the `assertion` getter's `this.defaultAgentAddress ??
+  // this.peerId` resolves without touching the unbuilt libp2p `node` (mirrors the sibling
+  // promote-async-default-agent facade test).
+  function agentFor(queue: TripleStoreAsyncPromoteQueue): { assertion: { clearPromoteAsync(jobId: string): Promise<unknown> } } {
+    const agent = Object.create(DKGAgent.prototype) as {
+      _promoteQueue: TripleStoreAsyncPromoteQueue;
+      defaultAgentAddress: string;
+    };
+    agent.defaultAgentAddress = `0x${'11'.repeat(20)}`;
+    agent._promoteQueue = queue;
+    return agent as unknown as { assertion: { clearPromoteAsync(jobId: string): Promise<unknown> } };
+  }
+
+  async function driveToSucceeded(queue: TripleStoreAsyncPromoteQueue): Promise<string> {
+    const jobId = await queue.enqueue(makeRequest());
+    const claimed = await queue.claimNext('worker-1');
+    const token = claimed!.lease!.claimToken;
+    for (const marker of ['swmInserted', 'wmCleaned', 'lifecycleStamped', 'gossiped'] as const) {
+      await queue.recordCommitMarker(jobId, token, marker);
+    }
+    await queue.succeed(jobId, token, { promotedCount: 1, succeededAt: 1_000_000 });
+    return jobId;
+  }
+
+  it('clears a terminal job through the real facade, removes only that row, and is idempotent', async () => {
+    const queue = newQueue();
+    const target = await driveToSucceeded(queue);
+    const other = await driveToSucceeded(queue);
+    const agent = agentFor(queue);
+
+    // cleared — and the row is actually gone (a mis-delegation to cancel() would retain it).
+    expect(await agent.assertion.clearPromoteAsync(target)).toEqual({ outcome: 'cleared' });
+    expect(await queue.getStatus(target)).toBeNull();
+    expect((await queue.getStatus(other))?.state).toBe('succeeded'); // only the exact row cleared
+
+    // Idempotent repeat via the facade.
+    expect(await agent.assertion.clearPromoteAsync(target)).toEqual({ outcome: 'already_absent' });
+  });
+
+  it('rejects a nonterminal (queued) job through the facade without mutation', async () => {
+    const queue = newQueue();
+    const queued = await queue.enqueue(makeRequest());
+    const agent = agentFor(queue);
+
+    expect(await agent.assertion.clearPromoteAsync(queued)).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await queue.getStatus(queued))?.state).toBe('queued'); // untouched
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       "test/publish-foreign-author-resolution.test.ts",
       "test/durable-integrity-seal-assertion-version.test.ts",
       "test/promote-async-default-agent.test.ts",
+      "test/clear-promote-async-facade.test.ts",
       "test/query-min-trust-alias.test.ts",
       "test/sync-envelope-cursor.test.ts",
       "test/exact-assets.test.ts",

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -798,6 +798,13 @@ export class ApiClient {
     return this.post(`/api/knowledge-assets/swm/share-jobs/${encodeURIComponent(jobId)}/recover`, {});
   }
 
+  // #1837 — atomic by-exact-jobId TERMINAL record removal (idempotent). Distinct from
+  // knowledgeAssetCancelShareJob (DELETE = queued cancellation that retains the row).
+  // cleared / already_absent resolve normally (200); rejected throws via post().
+  async knowledgeAssetClearShareJob(jobId: string): Promise<{ outcome: 'cleared' | 'already_absent'; jobId: string }> {
+    return this.post(`/api/knowledge-assets/swm/share-jobs/${encodeURIComponent(jobId)}/clear`, {});
+  }
+
   /** Publish to VM (mint or update on chain; git push origin main). */
   async knowledgeAssetPublish(
     contextGraphId: string,
@@ -1277,6 +1284,14 @@ export class ApiClient {
 
   async publisherClear(status: 'failed' | 'finalized'): Promise<{ cleared: number; status: 'failed' | 'finalized' }> {
     return this.post('/api/publisher/clear', { status });
+  }
+
+  // #1837 — atomic by-exact-jobId TERMINAL clear (distinct from publisherCancel and the
+  // status-scoped publisherClear). cleared / already_absent resolve normally (200);
+  // rejected (nonterminal/unknown → 409, malformed → 400) throws via the post() helper
+  // carrying { outcome:'rejected', reason } in the response body.
+  async publisherClearJob(jobId: string): Promise<{ outcome: 'cleared' | 'already_absent'; jobId: string }> {
+    return this.post('/api/publisher/clear-job', { jobId });
   }
 
   // ------------------------- EPCIS -------------------------------------

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -5,7 +5,6 @@
 // is instantiated per-daemon-boot by `runDaemonInner`.
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { TerminalJobClearOutcome } from '@origintrail-official/dkg-publisher';
 import {
   PayloadTooLargeError,
   assertQuadLiteralsMutf8Safe,
@@ -526,22 +525,6 @@ export function jsonResponse(
     ...(extraHeaders ?? {}),
   });
   res.end(body);
-}
-
-// #1837 — single source for the TerminalJobClearOutcome → HTTP projection, shared by the
-// publisher and SWM share-job clear routes so the response contract cannot drift. cleared /
-// already_absent are SUCCESS (200, idempotent — NOT 404); rejected(malformed) is a client
-// input error (400); rejected(nonterminal|unknown) is a server-side state condition (409).
-export function respondTerminalClearOutcome(
-  res: ServerResponse,
-  outcome: TerminalJobClearOutcome,
-  jobId: string,
-): void {
-  if (outcome.outcome === "cleared" || outcome.outcome === "already_absent") {
-    jsonResponse(res, 200, { ...outcome, jobId });
-    return;
-  }
-  jsonResponse(res, outcome.reason === "malformed" ? 400 : 409, { ...outcome, jobId });
 }
 
 export function safeDecodeURIComponent(

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -5,6 +5,7 @@
 // is instantiated per-daemon-boot by `runDaemonInner`.
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { TerminalJobClearOutcome } from '@origintrail-official/dkg-publisher';
 import {
   PayloadTooLargeError,
   assertQuadLiteralsMutf8Safe,
@@ -525,6 +526,22 @@ export function jsonResponse(
     ...(extraHeaders ?? {}),
   });
   res.end(body);
+}
+
+// #1837 — single source for the TerminalJobClearOutcome → HTTP projection, shared by the
+// publisher and SWM share-job clear routes so the response contract cannot drift. cleared /
+// already_absent are SUCCESS (200, idempotent — NOT 404); rejected(malformed) is a client
+// input error (400); rejected(nonterminal|unknown) is a server-side state condition (409).
+export function respondTerminalClearOutcome(
+  res: ServerResponse,
+  outcome: TerminalJobClearOutcome,
+  jobId: string,
+): void {
+  if (outcome.outcome === "cleared" || outcome.outcome === "already_absent") {
+    jsonResponse(res, 200, { ...outcome, jobId });
+    return;
+  }
+  jsonResponse(res, outcome.reason === "malformed" ? 400 : 409, { ...outcome, jobId });
 }
 
 export function safeDecodeURIComponent(

--- a/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
@@ -25,6 +25,7 @@
 import type { RequestContext } from "./context.js";
 import {
   jsonResponse,
+  respondTerminalClearOutcome,
   readBody,
   safeParseJson,
   validateEntities,
@@ -247,10 +248,5 @@ export async function handleKaShareJobRecover(ctx: RequestContext, jobId: string
 // (already_absent = 200, not 404). The caller passes the already url-decoded jobId.
 export async function handleKaShareJobClear(ctx: RequestContext, jobId: string): Promise<void> {
   const { res, agent } = ctx;
-  const outcome = await agent.assertion.clearPromoteAsync(jobId);
-  if (outcome.outcome === "cleared" || outcome.outcome === "already_absent") {
-    return jsonResponse(res, 200, { ...outcome, jobId });
-  }
-  const status = outcome.reason === "malformed" ? 400 : 409;
-  return jsonResponse(res, status, { ...outcome, jobId });
+  return respondTerminalClearOutcome(res, await agent.assertion.clearPromoteAsync(jobId), jobId);
 }

--- a/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
@@ -238,3 +238,19 @@ export async function handleKaShareJobRecover(ctx: RequestContext, jobId: string
     throw err;
   }
 }
+
+// ── POST /api/knowledge-assets/swm/share-jobs/:jobId/clear ────────────────────
+//
+// #1837 — atomic by-exact-jobId TERMINAL record removal. DISTINCT from the DELETE
+// cancellation above (which rewrites a queued job to failed+cancelled and RETAINS the
+// row): this REMOVES a native-terminal (succeeded|failed) job record and is idempotent
+// (already_absent = 200, not 404). The caller passes the already url-decoded jobId.
+export async function handleKaShareJobClear(ctx: RequestContext, jobId: string): Promise<void> {
+  const { res, agent } = ctx;
+  const outcome = await agent.assertion.clearPromoteAsync(jobId);
+  if (outcome.outcome === "cleared" || outcome.outcome === "already_absent") {
+    return jsonResponse(res, 200, { ...outcome, jobId });
+  }
+  const status = outcome.reason === "malformed" ? 400 : 409;
+  return jsonResponse(res, status, { ...outcome, jobId });
+}

--- a/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
@@ -23,9 +23,9 @@
 // Shared logic lives in `./shared-assertion-helpers.js`.
 
 import type { RequestContext } from "./context.js";
+import { respondTerminalClearOutcome } from "./terminal-clear-response.js";
 import {
   jsonResponse,
-  respondTerminalClearOutcome,
   readBody,
   safeParseJson,
   validateEntities,

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -62,6 +62,7 @@ import {
   handleKaShareJobsList,
   handleKaShareJobStatus,
   handleKaShareJobCancel,
+  handleKaShareJobClear,
   handleKaShareJobRecover,
 } from "./knowledge-assets-async-share.js";
 import {
@@ -666,6 +667,21 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       );
       if (jobId === null) return;
       return handleKaShareJobRecover(ctx, jobId);
+    }
+    // POST /api/knowledge-assets/swm/share-jobs/:jobId/clear — #1837 atomic terminal
+    // record removal (idempotent). DISTINCT from the DELETE cancellation below (which
+    // rewrites a queued job to failed+cancelled and RETAINS the row).
+    if (
+      method === "POST" &&
+      path.startsWith(`${SHARE_JOBS_PREFIX}/`) &&
+      path.endsWith("/clear")
+    ) {
+      const jobId = decodePromoteJobId(
+        path.slice(`${SHARE_JOBS_PREFIX}/`.length, -"/clear".length),
+        res,
+      );
+      if (jobId === null) return;
+      return handleKaShareJobClear(ctx, jobId);
     }
     // GET /api/knowledge-assets/swm/share-jobs/:jobId — status (#3)
     if (

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -189,6 +189,7 @@ import {
 import {
   resolveNameToPeerId,
   jsonResponse,
+  respondTerminalClearOutcome,
   safeDecodeURIComponent,
   safeParseJson,
   validateOptionalSubGraphName,
@@ -559,16 +560,13 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     } catch {
       return jsonResponse(res, 400, { error: "Invalid JSON body" });
     }
-    const { jobId } = clearJobParsed;
+    // `JSON.parse("null")` etc. succeeds but yields a non-object; optional-chain so a
+    // `null`/primitive body falls through to the malformed guard (400), never a
+    // destructure TypeError → 500.
+    const jobId = clearJobParsed && typeof clearJobParsed === "object" ? clearJobParsed.jobId : undefined;
     if (typeof jobId !== "string" || jobId.trim().length === 0) {
       return jsonResponse(res, 400, { outcome: "rejected", reason: "malformed", error: "Missing jobId" });
     }
-    const outcome = await publisherControl.clearTerminalJob(jobId);
-    if (outcome.outcome === "cleared" || outcome.outcome === "already_absent") {
-      return jsonResponse(res, 200, { ...outcome, jobId });
-    }
-    // rejected: malformed → 400 (bad input); nonterminal/unknown → 409 (server-side state)
-    const status = outcome.reason === "malformed" ? 400 : 409;
-    return jsonResponse(res, status, { ...outcome, jobId });
+    return respondTerminalClearOutcome(res, await publisherControl.clearTerminalJob(jobId), jobId);
   }
 }

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -545,4 +545,30 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     const count = await publisherControl.clear(status);
     return jsonResponse(res, 200, { cleared: count, status });
   }
+
+  // POST /api/publisher/clear-job  { jobId }
+  // #1837 — atomic by-exact-jobId TERMINAL clear. DISTINCT from cancel (which aborts an
+  // ACCEPTED job) and from bulk /clear (status-scoped): clears exactly one job iff it is
+  // in a native terminal state, is idempotent for an absent job (already_absent = 200,
+  // NOT 404), and never touches another job. Preserves the #1829 journal (subject-scoped).
+  if (req.method === "POST" && path === "/api/publisher/clear-job") {
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    let clearJobParsed: any;
+    try {
+      clearJobParsed = JSON.parse(body || "{}");
+    } catch {
+      return jsonResponse(res, 400, { error: "Invalid JSON body" });
+    }
+    const { jobId } = clearJobParsed;
+    if (typeof jobId !== "string" || jobId.trim().length === 0) {
+      return jsonResponse(res, 400, { outcome: "rejected", reason: "malformed", error: "Missing jobId" });
+    }
+    const outcome = await publisherControl.clearTerminalJob(jobId);
+    if (outcome.outcome === "cleared" || outcome.outcome === "already_absent") {
+      return jsonResponse(res, 200, { ...outcome, jobId });
+    }
+    // rejected: malformed → 400 (bad input); nonterminal/unknown → 409 (server-side state)
+    const status = outcome.reason === "malformed" ? 400 : 409;
+    return jsonResponse(res, status, { ...outcome, jobId });
+  }
 }

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -186,10 +186,10 @@ import {
   bindingValue,
   carryForwardBundledMarkItDownBinary,
 } from '../manifest.js';
+import { respondTerminalClearOutcome } from './terminal-clear-response.js';
 import {
   resolveNameToPeerId,
   jsonResponse,
-  respondTerminalClearOutcome,
   safeDecodeURIComponent,
   safeParseJson,
   validateOptionalSubGraphName,

--- a/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
+++ b/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
@@ -20,7 +20,12 @@ import {
   resolveImportedArtifactMetadata,
   assertRdfLiteralMutf8Safe,
 } from '@origintrail-official/dkg-core';
-import { type PromoteJob, type PromoteJobState } from '@origintrail-official/dkg-publisher';
+import {
+  type PromoteJob,
+  type PromoteJobState,
+  SAFE_CLEAR_JOB_ID_PATTERN,
+  SAFE_CLEAR_JOB_ID_MAX_LENGTH,
+} from '@origintrail-official/dkg-publisher';
 import { daemonState } from '../state.js';
 import {
   jsonResponse,
@@ -116,9 +121,12 @@ export class ImportArtifactRouteError extends Error {
 }
 
 export function validatePromoteJobId(jobId: string): { valid: true } | { valid: false; reason: string } {
+  // Grammar + length bound are imported from the publisher (the single authoritative
+  // job-id contract, also enforced control-plane-side by `isSafeClearJobId`) so route
+  // acceptance and control-plane acceptance cannot drift.
   if (!jobId) return { valid: false, reason: "jobId is required" };
-  if (jobId.length > 256) return { valid: false, reason: "jobId is too long" };
-  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(jobId)) {
+  if (jobId.length > SAFE_CLEAR_JOB_ID_MAX_LENGTH) return { valid: false, reason: "jobId is too long" };
+  if (!SAFE_CLEAR_JOB_ID_PATTERN.test(jobId)) {
     return {
       valid: false,
       reason: "jobId may only contain letters, numbers, '.', '_', ':', and '-'",

--- a/packages/cli/src/daemon/routes/terminal-clear-response.ts
+++ b/packages/cli/src/daemon/routes/terminal-clear-response.ts
@@ -1,0 +1,28 @@
+// daemon/routes/terminal-clear-response.ts
+//
+// #1837 — single source for the TerminalJobClearOutcome → HTTP projection, shared by the
+// publisher (`POST /api/publisher/clear-job`) and SWM share-job
+// (`POST /api/knowledge-assets/swm/share-jobs/:jobId/clear`) clear routes so the response
+// contract cannot drift. This is route-owned policy (both clear routes are the only
+// callers), so it lives beside the routes rather than in the generic `http-utils.ts`
+// bucket, which stays focused on protocol-level helpers (JSON responses, body parsing).
+//
+// Mapping: `cleared` / `already_absent` are SUCCESS (200, idempotent — NOT 404);
+// `rejected(malformed)` is a client input error (400); `rejected(nonterminal|unknown)` is a
+// server-side state condition (409).
+
+import type { ServerResponse } from "node:http";
+import type { TerminalJobClearOutcome } from "@origintrail-official/dkg-publisher";
+import { jsonResponse } from "../http-utils.js";
+
+export function respondTerminalClearOutcome(
+  res: ServerResponse,
+  outcome: TerminalJobClearOutcome,
+  jobId: string,
+): void {
+  if (outcome.outcome === "cleared" || outcome.outcome === "already_absent") {
+    jsonResponse(res, 200, { ...outcome, jobId });
+    return;
+  }
+  jsonResponse(res, outcome.reason === "malformed" ? 400 : 409, { ...outcome, jobId });
+}

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -33,6 +33,7 @@ import {
   type VmPublishIntentRecoveryPublisher,
   type VmPublishIntentIndexBackfiller,
   type VmPublishAdmissionJournalReader,
+  type VmPublishTerminalJobClearer,
   type LiftJobBroadcast,
   type LiftJobHex,
   type LiftJobIncluded,
@@ -374,7 +375,7 @@ export function createPublisherInspectorFromStore(
 export function createPublisherControlFromStore(
   store: TripleStore,
   options: { publicSnapshotStore?: WorkspacePublicSnapshotStore; maxRetries?: number } = {},
-): VmPublishIntentRecoveryPublisher & VmPublishIntentIndexBackfiller & VmPublishAdmissionJournalReader {
+): VmPublishIntentRecoveryPublisher & VmPublishIntentIndexBackfiller & VmPublishAdmissionJournalReader & VmPublishTerminalJobClearer {
   // The daemon admission instance also serves the #1828 recovery lookup (route)
   // and the boot index backfill — segregated capabilities the base
   // AsyncLiftPublisher runtime contract intentionally does NOT carry.

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1120,6 +1120,22 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(calls[0].opts.method).toBe('POST');
   });
 
+  it('#1837 clear-job helpers POST the terminal-clear routes with correct encoding and body', async () => {
+    // SWM share-job clear: jobId is percent-encoded in the path, empty JSON body.
+    let calls = track({ outcome: 'cleared', jobId: 'share/job 1' });
+    await client.knowledgeAssetClearShareJob('share/job 1');
+    expect(calls[0].url).toBe(`${base}/api/knowledge-assets/swm/share-jobs/share%2Fjob%201/clear`);
+    expect(calls[0].opts.method).toBe('POST');
+    expect(JSON.parse(calls[0].opts.body as string)).toEqual({});
+
+    // Publisher clear-job: jobId travels in the body, not the path.
+    calls = track({ outcome: 'already_absent', jobId: 'lift job 7' });
+    await client.publisherClearJob('lift job 7');
+    expect(calls[0].url).toBe(`${base}/api/publisher/clear-job`);
+    expect(calls[0].opts.method).toBe('POST');
+    expect(JSON.parse(calls[0].opts.body as string)).toEqual({ jobId: 'lift job 7' });
+  });
+
   it('knowledgeAssetShareAsync rejects unsupported sync-only options before HTTP serialization', async () => {
     const calls = track({ jobId: 'should-not-reach', state: 'queued' });
     await expect(client.knowledgeAssetShareAsync('cg', 'f', {

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -118,6 +118,9 @@ describe('async SWM-share queue daemon routes', () => {
         async recoverPromoteAsync(jobId: string): Promise<void> {
           return queue.recover(jobId);
         },
+        async clearPromoteAsync(jobId: string) {
+          return (queue as TripleStoreAsyncPromoteQueue).clearTerminalJob(jobId);
+        },
       },
     };
   }
@@ -557,6 +560,51 @@ describe('async SWM-share queue daemon routes', () => {
   it('POST /swm/share-jobs/:jobId/recover rejects unsafe path values before queue lookup', async () => {
     await startRoutes(makeAgent());
     const r = await post('/api/knowledge-assets/swm/share-jobs/job%3Ebad/recover', {});
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/Invalid promote jobId/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /api/knowledge-assets/swm/share-jobs/:jobId/clear  (#1837)
+  // Atomic terminal record removal — DISTINCT from DELETE (cancel). Idempotent:
+  // already_absent is 200, not 404.
+  // ---------------------------------------------------------------------------
+
+  it('POST /swm/share-jobs/:jobId/clear clears a terminal job → 200 cleared; repeat → 200 already_absent', async () => {
+    await startRoutes(makeAgent());
+    const enq = await post('/api/knowledge-assets/clearable/swm/share-async', { contextGraphId: 'cg' });
+    await del(`/api/knowledge-assets/swm/share-jobs/${enq.body.jobId}`); // cancel → terminal 'failed'
+    expect((await queue.getStatus(enq.body.jobId))?.state).toBe('failed');
+
+    const r = await post(`/api/knowledge-assets/swm/share-jobs/${enq.body.jobId}/clear`, {});
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ outcome: 'cleared' });
+    expect(await queue.getStatus(enq.body.jobId)).toBeNull();
+
+    const again = await post(`/api/knowledge-assets/swm/share-jobs/${enq.body.jobId}/clear`, {});
+    expect(again.status).toBe(200);
+    expect(again.body).toMatchObject({ outcome: 'already_absent' });
+  });
+
+  it('POST /swm/share-jobs/:jobId/clear returns 409 for a nonterminal (queued) job, without mutation', async () => {
+    await startRoutes(makeAgent());
+    const enq = await post('/api/knowledge-assets/queued2/swm/share-async', { contextGraphId: 'cg' });
+    const r = await post(`/api/knowledge-assets/swm/share-jobs/${enq.body.jobId}/clear`, {});
+    expect(r.status).toBe(409);
+    expect(r.body).toMatchObject({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await queue.getStatus(enq.body.jobId))?.state).toBe('queued');
+  });
+
+  it('POST /swm/share-jobs/:jobId/clear returns 200 already_absent for an unknown job (idempotent)', async () => {
+    await startRoutes(makeAgent());
+    const r = await post('/api/knowledge-assets/swm/share-jobs/non-existent/clear', {});
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ outcome: 'already_absent' });
+  });
+
+  it('POST /swm/share-jobs/:jobId/clear rejects an unsafe path value before queue lookup (400)', async () => {
+    await startRoutes(makeAgent());
+    const r = await post('/api/knowledge-assets/swm/share-jobs/job%3Ebad/clear', {});
     expect(r.status).toBe(400);
     expect(r.body.error).toMatch(/Invalid promote jobId/);
   });

--- a/packages/cli/test/publisher-clear-job-route.test.ts
+++ b/packages/cli/test/publisher-clear-job-route.test.ts
@@ -93,6 +93,17 @@ describe('#1837 POST /api/publisher/clear-job', () => {
     expect(responseBody(ctx)).toMatchObject({ outcome: 'rejected', reason: 'malformed' });
   });
 
+  // #1883 review (🔴): a SPARQL-unsafe jobId must be a bounded 400, never a query-error 500.
+  it('rejects a SPARQL-unsafe jobId → 400 malformed (no 500)', async () => {
+    const control = newControl();
+    for (const jobId of ['bad id', 'bad>id']) {
+      const ctx = postClearJob(control, { jobId });
+      await handlePublisherRoutes(ctx);
+      expect(responseStatus(ctx)).toBe(400);
+      expect(responseBody(ctx)).toMatchObject({ outcome: 'rejected', reason: 'malformed' });
+    }
+  });
+
   function postClearJob(publisherControl: RequestContext['publisherControl'], body: Record<string, unknown>): RequestContext {
     return postClearJobRaw(publisherControl, JSON.stringify(body));
   }

--- a/packages/cli/test/publisher-clear-job-route.test.ts
+++ b/packages/cli/test/publisher-clear-job-route.test.ts
@@ -1,0 +1,138 @@
+import type { ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import { afterEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { createPublisherControlFromStore } from '../src/publisher-runner.js';
+import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+// #1837 — POST /api/publisher/clear-job outcome → HTTP mapping.
+describe('#1837 POST /api/publisher/clear-job', () => {
+  const stores: OxigraphStore[] = [];
+  let ids = 0;
+  let now = 1_000;
+  afterEach(async () => {
+    await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {})));
+  });
+
+  function kaVmPublishRequest() {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
+    return {
+      contextGraphId: 'music-social', name: 'albums', agentAddress: '0x0', shareOperationId: 'share-op-1',
+      roots: [] as string[], contentScopeVersion: 2 as const, kaUal, assertionVersion: '1',
+      publicTripleCount: 2, privateTripleCount: 0,
+      seal: {
+        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`, authorAddress: authorAddress as `0x${string}`,
+        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
+        schemeVersion: 1, reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
+      },
+      sealChainId: '31337' as `${bigint}`, sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z', sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      intentKey: `sha256:${'ab'.repeat(32)}`, wmCurrentAssertion: '12'.repeat(32), swmCurrentAssertion: '12'.repeat(32),
+      kaNumber: kaNumber.toString(), reservedUal: kaUal,
+    };
+  }
+
+  function newControl() {
+    const store = new OxigraphStore();
+    stores.push(store);
+    return createPublisherControlFromStore(store, {});
+  }
+
+  async function finalizedJob(control: ReturnType<typeof createPublisherControlFromStore>): Promise<string> {
+    const bx = { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' };
+    const inc = { blockNumber: 10, blockHash: `0x${'aa'.repeat(32)}` as `0x${string}`, blockTimestamp: 1 };
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    await control.claimNext('wallet-1');
+    await control.update(jobId, 'validated', { validation: { canonicalRoots: [], canonicalRootMap: {}, swmQuadCount: 2, authorityProofRef: 'knowledge-asset-lifecycle', transitionType: 'CREATE' } });
+    await control.update(jobId, 'broadcast', { broadcast: bx });
+    await control.update(jobId, 'included', { broadcast: bx, inclusion: inc });
+    await control.update(jobId, 'finalized', { broadcast: bx, inclusion: inc, finalization: { mode: 'local' } });
+    return jobId;
+  }
+
+  it('clears a terminal job → 200 cleared; repeat → 200 already_absent', async () => {
+    const control = newControl();
+    const jobId = await finalizedJob(control);
+    const ctx1 = postClearJob(control, { jobId });
+    await handlePublisherRoutes(ctx1);
+    expect(responseStatus(ctx1)).toBe(200);
+    expect(responseBody(ctx1)).toMatchObject({ outcome: 'cleared', jobId });
+
+    const ctx2 = postClearJob(control, { jobId });
+    await handlePublisherRoutes(ctx2);
+    expect(responseStatus(ctx2)).toBe(200);
+    expect(responseBody(ctx2)).toMatchObject({ outcome: 'already_absent', jobId });
+  });
+
+  it('rejects a nonterminal (accepted) job → 409 nonterminal', async () => {
+    const control = newControl();
+    const jobId = await control.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    const ctx = postClearJob(control, { jobId });
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(409);
+    expect(responseBody(ctx)).toMatchObject({ outcome: 'rejected', reason: 'nonterminal' });
+  });
+
+  it('rejects a missing/empty jobId → 400 malformed', async () => {
+    const control = newControl();
+    const ctx = postClearJob(control, {});
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(400);
+  });
+
+  function postClearJob(publisherControl: RequestContext['publisherControl'], body: Record<string, unknown>): RequestContext {
+    const path = '/api/publisher/clear-job';
+    const url = new URL(`http://127.0.0.1${path}`);
+    const req = Readable.from([]);
+    // readBody() resolves synchronously from a prebuffered body (as httpAuthGuard's
+    // eager drain leaves it) — avoids driving a mock stream in the unit harness.
+    Object.assign(req, {
+      method: 'POST', url: path, headers: { host: '127.0.0.1' },
+      __dkgPrebufferedBody: Buffer.from(JSON.stringify(body), 'utf8'),
+    });
+    return {
+      req: req as RequestContext['req'],
+      res: createResponse() as unknown as ServerResponse,
+      agent: {} as RequestContext['agent'],
+      publisherControl,
+      publisherState: { runtime: null, availability: { available: false, reason: 'publisher_disabled', retryable: false, operatorActionRequired: true } },
+      config: {} as RequestContext['config'],
+      startedAt: 0,
+      dashDb: {} as RequestContext['dashDb'],
+      opWallets: { adminWallet: { address: '0x0', privateKey: '0x0' }, wallets: [] } as RequestContext['opWallets'],
+      network: null as RequestContext['network'],
+      tracker: {} as RequestContext['tracker'],
+      memoryManager: {} as RequestContext['memoryManager'],
+      bridgeAuthToken: undefined,
+      nodeVersion: 'test',
+      nodeCommit: 'test',
+      catchupTracker: {} as RequestContext['catchupTracker'],
+      extractionRegistry: {} as RequestContext['extractionRegistry'],
+      fileStore: {} as RequestContext['fileStore'],
+      extractionStatus: new Map(),
+      assertionImportLocks: new Map(),
+      vectorStore: {} as RequestContext['vectorStore'],
+      embeddingProvider: null,
+      validTokens: new Set(),
+      apiHost: '127.0.0.1',
+      apiPortRef: { value: 0 },
+      url,
+      path: url.pathname,
+      requestToken: undefined,
+      requestAgentAddress: '0x0',
+    };
+  }
+
+  function createResponse() {
+    return {
+      statusCode: 0, headers: undefined as Record<string, string> | undefined, body: '', writableEnded: false,
+      writeHead(status: number, headers: Record<string, string>) { this.statusCode = status; this.headers = headers; return this; },
+      end(body?: string) { this.body = body ?? ''; this.writableEnded = true; return this; },
+    };
+  }
+  function responseStatus(ctx: RequestContext): number { return (ctx.res as unknown as { statusCode: number }).statusCode; }
+  function responseBody(ctx: RequestContext): Record<string, unknown> { return JSON.parse((ctx.res as unknown as { body: string }).body) as Record<string, unknown>; }
+});

--- a/packages/cli/test/publisher-clear-job-route.test.ts
+++ b/packages/cli/test/publisher-clear-job-route.test.ts
@@ -83,7 +83,21 @@ describe('#1837 POST /api/publisher/clear-job', () => {
     expect(responseStatus(ctx)).toBe(400);
   });
 
+  // #1883 review (🔴): a literal `null` body parses fine but must not TypeError on
+  // destructure (→ 500). It falls through to the malformed guard as a bounded 400.
+  it('rejects a literal null body → 400 malformed (no 500)', async () => {
+    const control = newControl();
+    const ctx = postClearJobRaw(control, 'null');
+    await handlePublisherRoutes(ctx);
+    expect(responseStatus(ctx)).toBe(400);
+    expect(responseBody(ctx)).toMatchObject({ outcome: 'rejected', reason: 'malformed' });
+  });
+
   function postClearJob(publisherControl: RequestContext['publisherControl'], body: Record<string, unknown>): RequestContext {
+    return postClearJobRaw(publisherControl, JSON.stringify(body));
+  }
+
+  function postClearJobRaw(publisherControl: RequestContext['publisherControl'], rawBody: string): RequestContext {
     const path = '/api/publisher/clear-job';
     const url = new URL(`http://127.0.0.1${path}`);
     const req = Readable.from([]);
@@ -91,7 +105,7 @@ describe('#1837 POST /api/publisher/clear-job', () => {
     // eager drain leaves it) — avoids driving a mock stream in the unit harness.
     Object.assign(req, {
       method: 'POST', url: path, headers: { host: '127.0.0.1' },
-      __dkgPrebufferedBody: Buffer.from(JSON.stringify(body), 'utf8'),
+      __dkgPrebufferedBody: Buffer.from(rawBody, 'utf8'),
     });
     return {
       req: req as RequestContext['req'],

--- a/packages/cli/test/terminal-clear-response.test.ts
+++ b/packages/cli/test/terminal-clear-response.test.ts
@@ -1,0 +1,55 @@
+import type { ServerResponse } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import type { TerminalJobClearOutcome } from '@origintrail-official/dkg-publisher';
+import { respondTerminalClearOutcome } from '../src/daemon/routes/terminal-clear-response.js';
+
+// #1837 — locks the shared TerminalJobClearOutcome → HTTP contract that BOTH the publisher
+// (/api/publisher/clear-job) and SWM (/api/knowledge-assets/swm/share-jobs/:id/clear) clear
+// routes project through, so a future mapping change (wrong status, dropped jobId, or the
+// `unknown` branch diverging) cannot silently alter the clear-route contract.
+describe('respondTerminalClearOutcome mapping', () => {
+  function fakeRes() {
+    return {
+      statusCode: 0,
+      body: '',
+      headers: undefined as Record<string, string> | undefined,
+      writableEnded: false,
+      writeHead(status: number, headers: Record<string, string>) {
+        this.statusCode = status;
+        this.headers = headers;
+        return this;
+      },
+      end(body?: string) {
+        this.body = body ?? '';
+        this.writableEnded = true;
+        return this;
+      },
+    };
+  }
+
+  function run(outcome: TerminalJobClearOutcome, jobId: string) {
+    const res = fakeRes();
+    respondTerminalClearOutcome(res as unknown as ServerResponse, outcome, jobId);
+    return { status: res.statusCode, body: JSON.parse(res.body) as Record<string, unknown> };
+  }
+
+  it('cleared → 200 with echoed jobId', () => {
+    expect(run({ outcome: 'cleared' }, 'job-1')).toEqual({ status: 200, body: { outcome: 'cleared', jobId: 'job-1' } });
+  });
+
+  it('already_absent → 200 (idempotent success, NOT 404)', () => {
+    expect(run({ outcome: 'already_absent' }, 'job-2')).toEqual({ status: 200, body: { outcome: 'already_absent', jobId: 'job-2' } });
+  });
+
+  it('rejected malformed → 400 (client input error)', () => {
+    expect(run({ outcome: 'rejected', reason: 'malformed' }, 'bad id')).toEqual({ status: 400, body: { outcome: 'rejected', reason: 'malformed', jobId: 'bad id' } });
+  });
+
+  it('rejected nonterminal → 409 (server-side state condition)', () => {
+    expect(run({ outcome: 'rejected', reason: 'nonterminal' }, 'job-3')).toEqual({ status: 409, body: { outcome: 'rejected', reason: 'nonterminal', jobId: 'job-3' } });
+  });
+
+  it('rejected unknown → 409 with echoed jobId', () => {
+    expect(run({ outcome: 'rejected', reason: 'unknown' }, 'bogus-1')).toEqual({ status: 409, body: { outcome: 'rejected', reason: 'unknown', jobId: 'bogus-1' } });
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
           // #1828 — durable-admission recovery lookup route (pure handler, no hardhat).
           'test/publisher-job-by-intent-route.test.ts',
           'test/publisher-journal-route.test.ts',
+          'test/publisher-clear-job-route.test.ts',
           // #1828 — daemon-boot intent-index backfill wiring (fail-open contract).
           'test/vm-publish-intent-backfill.test.ts',
           'test/agent-connect-routes.test.ts',

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -37,9 +37,11 @@ import type {
   IntentLookupResult,
   JournalReadInput,
   JournalReadResult,
+  TerminalJobClearOutcome,
   VmPublishIntentRecoveryPublisher,
   VmPublishIntentIndexBackfiller,
   VmPublishAdmissionJournalReader,
+  VmPublishTerminalJobClearer,
 } from './async-lift-publisher-types.js';
 import { AsyncLiftJobConflictError } from './async-lift-publisher-types.js';
 import {
@@ -80,6 +82,7 @@ import {
   getRecoveryTxHash,
   isKnowledgeAssetVmPublishJobRequest,
   isFailedJob,
+  isClearableTerminalLiftJob,
   isOccupyingLifecycleJob,
   normalizePersistedLiftJobRequest,
   rawLiftRequestFromJobRequest,
@@ -192,7 +195,7 @@ function resolveKnowledgeAssetVmPublishHandler(
 }
 
 export class TripleStoreAsyncLiftPublisher
-  implements VmPublishIntentRecoveryPublisher, VmPublishIntentIndexBackfiller, VmPublishAdmissionJournalReader {
+  implements VmPublishIntentRecoveryPublisher, VmPublishIntentIndexBackfiller, VmPublishAdmissionJournalReader, VmPublishTerminalJobClearer {
   private static readonly claimQueues = new Map<string, Promise<void>>();
   // #1829 — dedicated per-lineageKey journal mutex, SEPARATE from claimQueues, so the
   // read-modify-write seq allocation is atomic without touching the claim lock (lock
@@ -992,17 +995,24 @@ export class TripleStoreAsyncLiftPublisher
     await this.ensureGraph();
     if (filter.status && filter.status !== 'failed') return 0;
 
-    let retried = 0;
-    for (const job of (await this.list({ status: 'failed' })).filter(isFailedJob)) {
-      if (!job.failure.retryable || job.retries.retryCount >= job.retries.maxRetries) continue;
-      // Jobs that failed with a recovery-phase resolution must go through recover(),
-      // not retry(), to avoid double-publishing if the original tx eventually lands.
-      if (job.failure.resolution === 'retry_recovery') continue;
+    // #1837 — reaccept (failed→accepted) is a terminal→active transition; it MUST be
+    // serialized with claimNext/enqueue AND with clearTerminalJob (which also runs under
+    // withClaimLock) so a by-id clear that read a job as clearable-failed cannot be swept
+    // after retry() flips it active. Without this lock the "a transitioning job cannot be
+    // swept" guarantee does not hold.
+    return this.withClaimLock(async () => {
+      let retried = 0;
+      for (const job of (await this.list({ status: 'failed' })).filter(isFailedJob)) {
+        if (!job.failure.retryable || job.retries.retryCount >= job.retries.maxRetries) continue;
+        // Jobs that failed with a recovery-phase resolution must go through recover(),
+        // not retry(), to avoid double-publishing if the original tx eventually lands.
+        if (job.failure.resolution === 'retry_recovery') continue;
 
-      await this.reacceptFailedJob(job);
-      retried += 1;
-    }
-    return retried;
+        await this.reacceptFailedJob(job);
+        retried += 1;
+      }
+      return retried;
+    });
   }
 
   async clear(status: 'finalized' | 'failed'): Promise<number> {
@@ -1010,14 +1020,50 @@ export class TripleStoreAsyncLiftPublisher
     const jobs = await this.list({ status });
     let cleared = 0;
     for (const job of jobs) {
-      // Protect retry_recovery jobs — they may still have a pending on-chain tx
-      // that periodic recovery will finalize. Only explicit cancel can remove them.
-      if (status === 'failed' && isFailedJob(job) && job.failure.resolution === 'retry_recovery') continue;
+      // #1837 — single terminal-clear authority shared with clearTerminalJob: skips
+      // retry_recovery-failed jobs (a pending on-chain tx may still land). Behavior is
+      // identical to the prior inline `resolution === 'retry_recovery'` guard.
+      if (!isClearableTerminalLiftJob(job)) continue;
       await this.releaseWalletLockForJob(job);
       await this.deleteJob(job.jobId);
       cleared += 1;
     }
     return cleared;
+  }
+
+  /**
+   * #1837 — atomic by-exact-jobId terminal clear. Runs INSIDE withClaimLock so it is
+   * serialized against claimNext/enqueue/reaccept and retry() (the only terminal→active
+   * transitions) — a job transitioning cannot be swept, and concurrent clears are
+   * deterministic (exactly one 'cleared', the rest 'already_absent'). deleteJob is
+   * subject-scoped to the control-plane graph, so it never touches another job or the
+   * #1829 journal. Never throws / never mutates on a reject.
+   */
+  async clearTerminalJob(jobId: string): Promise<TerminalJobClearOutcome> {
+    if (!jobId || jobId.trim().length === 0) return { outcome: 'rejected', reason: 'malformed' };
+    return this.withClaimLock(async () => {
+      await this.ensureGraph();
+      const rows = expectBindings(
+        await this.store.query(
+          `SELECT ?payload WHERE { GRAPH <${this.graphUri}> { <${jobSubject(jobId)}> <${PAYLOAD_PREDICATE}> ?payload } }`,
+        ),
+      );
+      if (rows.length === 0) return { outcome: 'already_absent' };
+      // Parse defensively — a corrupt persisted payload must surface as rejected(malformed),
+      // never throw (parseJobPayload does an unguarded JSON.parse).
+      let job: LiftJob | null;
+      try {
+        job = this.parseJobPayload(rows[0]?.['payload']);
+      } catch {
+        return { outcome: 'rejected', reason: 'malformed' };
+      }
+      if (job === null) return { outcome: 'rejected', reason: 'malformed' };
+      if (!LIFT_JOB_STATES.includes(job.status)) return { outcome: 'rejected', reason: 'unknown' };
+      if (!isClearableTerminalLiftJob(job)) return { outcome: 'rejected', reason: 'nonterminal' };
+      await this.releaseWalletLockForJob(job);
+      await this.deleteJob(jobId);
+      return { outcome: 'cleared' };
+    });
   }
 
   private async ensureGraph(): Promise<void> {

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -37,13 +37,13 @@ import type {
   IntentLookupResult,
   JournalReadInput,
   JournalReadResult,
-  TerminalJobClearOutcome,
   VmPublishIntentRecoveryPublisher,
   VmPublishIntentIndexBackfiller,
   VmPublishAdmissionJournalReader,
   VmPublishTerminalJobClearer,
 } from './async-lift-publisher-types.js';
 import { AsyncLiftJobConflictError } from './async-lift-publisher-types.js';
+import { isSafeClearJobId, type TerminalJobClearOutcome } from './terminal-job-clear.js';
 import {
   mapPublishExceptionToLiftJobFailure,
   mapPublishResultToLiftJobSuccess,
@@ -1040,7 +1040,11 @@ export class TripleStoreAsyncLiftPublisher
    * #1829 journal. Never throws / never mutates on a reject.
    */
   async clearTerminalJob(jobId: string): Promise<TerminalJobClearOutcome> {
-    if (!jobId || jobId.trim().length === 0) return { outcome: 'rejected', reason: 'malformed' };
+    // Reject an empty OR SPARQL-unsafe jobId as malformed BEFORE building the jobSubject
+    // IRI — otherwise an attacker-controlled jobId (from the clear-job HTTP body) with a
+    // space/'>'/'{' could break the query out of `<…>` and surface as a 500/injection
+    // instead of the bounded outcome.
+    if (!isSafeClearJobId(jobId)) return { outcome: 'rejected', reason: 'malformed' };
     return this.withClaimLock(async () => {
       await this.ensureGraph();
       const rows = expectBindings(

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -125,6 +125,30 @@ export interface VmPublishAdmissionJournalReader {
 }
 
 /**
+ * #1837 — bounded outcome of an atomic by-exact-jobId TERMINAL clear, shared by BOTH
+ * the lift publisher and the SWM promote queue for symmetry. The control method owns
+ * every reason INCLUDING `malformed` (a corrupt persisted payload is only detectable
+ * inside the method, never at the HTTP route). Never throws and never mutates on a
+ * reject. `already_absent` is a SUCCESS (idempotent repeat), distinct from a rejection.
+ */
+export type TerminalJobClearOutcome =
+  | { readonly outcome: 'cleared' }
+  | { readonly outcome: 'already_absent' }
+  | { readonly outcome: 'rejected'; readonly reason: 'nonterminal' | 'unknown' | 'malformed' };
+
+/**
+ * #1837 — atomic by-jobId terminal cleanup. Segregated off the base contract (like the
+ * #1828/#1829 capabilities); a MUTATION/admin capability, not a query. Clears the exact
+ * job ONLY when it is in a native terminal state, rejects otherwise without mutation,
+ * and is idempotent for an absent job. Never broadens to other jobs. On the lift side
+ * this preserves the #1829 append-only journal by construction (subject-scoped delete
+ * in the control-plane graph only).
+ */
+export interface VmPublishTerminalJobClearer {
+  clearTerminalJob(jobId: string): Promise<TerminalJobClearOutcome>;
+}
+
+/**
  * #1828 — one-shot storage maintenance: (re)build the ephemeral intent index for
  * VM-publish jobs admitted before it existed. This is a boot-time repair, not a
  * runtime publisher behaviour, so it lives on its OWN narrow interface — the

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -17,6 +17,7 @@ import type { PublishOptions, PublishResult } from './publisher.js';
 import type { AsyncLiftPublishFailureInput } from './async-lift-publish-result.js';
 import type { AsyncPreparedPublishPayload, LiftResolvedPublishSlice } from './async-lift-publish-options.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
+import type { TerminalJobClearOutcome } from './terminal-job-clear.js';
 
 export class AsyncLiftJobConflictError extends Error {
   readonly code = 'ASYNC_LIFT_JOB_CONFLICT';
@@ -123,18 +124,6 @@ export interface VmPublishAdmissionJournalReader {
   /** All journal entries bearing this jobId (a successor job continues the lineage seq). */
   readJournalByJob(jobId: string): Promise<JournalReadResult>;
 }
-
-/**
- * #1837 — bounded outcome of an atomic by-exact-jobId TERMINAL clear, shared by BOTH
- * the lift publisher and the SWM promote queue for symmetry. The control method owns
- * every reason INCLUDING `malformed` (a corrupt persisted payload is only detectable
- * inside the method, never at the HTTP route). Never throws and never mutates on a
- * reject. `already_absent` is a SUCCESS (idempotent repeat), distinct from a rejection.
- */
-export type TerminalJobClearOutcome =
-  | { readonly outcome: 'cleared' }
-  | { readonly outcome: 'already_absent' }
-  | { readonly outcome: 'rejected'; readonly reason: 'nonterminal' | 'unknown' | 'malformed' };
 
 /**
  * #1837 — atomic by-jobId terminal cleanup. Segregated off the base contract (like the

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -72,6 +72,19 @@ export function isFailedJob(job: LiftJob): job is PersistedFailedJob {
 }
 
 /**
+ * #1837 — the single terminal-clear authority, reused by both `clear(status)` (bulk) and
+ * `clearTerminalJob(jobId)` so they cannot drift. A job is clearable iff it is in a native
+ * terminal state (finalized|failed) AND is not a `retry_recovery`-failed job — those may
+ * still carry a pending on-chain tx that periodic recovery will finalize, so only explicit
+ * cancel removes them. A `retry_recovery`-failed job is therefore treated as
+ * NONTERMINAL-for-cleanup.
+ */
+export function isClearableTerminalLiftJob(job: LiftJob): boolean {
+  return isTerminalLiftJobState(job.status)
+    && !(isFailedJob(job) && job.failure.resolution === 'retry_recovery');
+}
+
+/**
  * #1828 — whether a job still OCCUPIES its lifecycle subject: any non-terminal
  * state, or a failed job admission would still reaccept (retryable with retries
  * remaining). Admission dedup (findActiveKnowledgeAssetVmPublishJob) and the

--- a/packages/publisher/src/async-lift-publisher.ts
+++ b/packages/publisher/src/async-lift-publisher.ts
@@ -15,11 +15,11 @@ export type {
   VmPublishIntentIndexBackfiller,
   VmPublishAdmissionJournalReader,
   VmPublishTerminalJobClearer,
-  TerminalJobClearOutcome,
   IntentLookupInput,
   IntentLookupResult,
   JournalReadInput,
   JournalReadResult,
 } from './async-lift-publisher-types.js';
 export { AsyncLiftJobConflictError } from './async-lift-publisher-types.js';
+export type { TerminalJobClearOutcome } from './terminal-job-clear.js';
 export { TripleStoreAsyncLiftPublisher } from './async-lift-publisher-impl.js';

--- a/packages/publisher/src/async-lift-publisher.ts
+++ b/packages/publisher/src/async-lift-publisher.ts
@@ -14,6 +14,8 @@ export type {
   VmPublishIntentRecoveryPublisher,
   VmPublishIntentIndexBackfiller,
   VmPublishAdmissionJournalReader,
+  VmPublishTerminalJobClearer,
+  TerminalJobClearOutcome,
   IntentLookupInput,
   IntentLookupResult,
   JournalReadInput,

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -18,6 +18,7 @@
  */
 
 import type { TripleStore } from '@origintrail-official/dkg-storage';
+import type { TerminalJobClearOutcome } from './async-lift-publisher-types.js';
 import {
   ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
   ASYNC_PROMOTE_QUEUE_MIN_AUTO_RECOVERABLE_FORMAT_VERSION,
@@ -26,6 +27,7 @@ import {
   PROMOTE_JOB_STATES,
   type AsyncPromoteQueue,
   type AsyncPromoteQueueConfig,
+  type PromoteTerminalJobClearer,
   type PromoteAttemptError,
   type PromoteCommitMarker,
   type PromoteCommitMarkerStep,
@@ -48,10 +50,12 @@ import {
   comparePromoteJobs,
   defaultBackoffMs,
   expectBindings,
+  isTerminalPromoteJobState,
   jobSubject,
   literal,
   normalizePromoteAgentLane,
   parseJobPayload,
+  parseLiteral,
   promoteLaneConflictScope,
   promoteLaneScopesConflict,
   serializeJob,
@@ -68,7 +72,7 @@ type PromoteConflictLookup = {
   laneScope: ReturnType<typeof promoteLaneConflictScope>;
 };
 
-export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
+export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteTerminalJobClearer {
   /**
    * Per-graph-URI mutex map. Serialises uniqueness-affecting mutations
    * callers can't both observe stale state and then persist conflicting
@@ -597,6 +601,47 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
     await this.store.deleteByPattern({ subject: jobSubject(job.jobId), graph: this.graphUri });
     await this.store.insert(serializeJob(job, this.graphUri));
     await this.store.flush?.();
+  }
+
+  // #1837 — subject-scoped record removal (the delete half of writeJob, no re-insert).
+  // All of a job's triples live under jobSubject(jobId) in the single control-plane
+  // graph, so this provably cannot touch another job or another graph.
+  private async deleteJob(jobId: string): Promise<void> {
+    await this.store.deleteByPattern({ subject: jobSubject(jobId), graph: this.graphUri });
+    await this.store.flush?.();
+  }
+
+  /**
+   * #1837 — atomic by-exact-jobId terminal clear. Runs INSIDE withMutationLock, which
+   * already serializes EVERY transition (incl. the only terminal→active path, recover()
+   * failed→queued), so a transitioning job cannot be swept and concurrent clears are
+   * deterministic — no new lock needed. Reads the denormalized state triple to split
+   * already_absent / unknown / malformed without a JSON.parse that collapses them. Never
+   * throws / never mutates on a reject.
+   */
+  async clearTerminalJob(jobId: string): Promise<TerminalJobClearOutcome> {
+    if (!jobId || jobId.trim().length === 0) return { outcome: 'rejected', reason: 'malformed' };
+    return this.withMutationLock(async () => {
+      await this.ensureGraph();
+      const stateRows = expectBindings(
+        await this.store.query(
+          `SELECT ?state WHERE { GRAPH <${this.graphUri}> { <${jobSubject(jobId)}> <${PROMOTE_STATE}> ?state } }`,
+        ),
+      );
+      if (stateRows.length === 0) return { outcome: 'already_absent' };
+      const rawState = stateRows[0]?.['state'];
+      const state = rawState === undefined ? undefined : String(parseLiteral(rawState));
+      if (state === undefined || !(PROMOTE_JOB_STATES as readonly string[]).includes(state)) {
+        return { outcome: 'rejected', reason: 'unknown' };
+      }
+      // State literal is a known enum value; the full payload must also parse (a corrupt
+      // payload with a valid state triple is malformed, not unknown).
+      const job = await this.readJob(jobId);
+      if (job === null) return { outcome: 'rejected', reason: 'malformed' };
+      if (!isTerminalPromoteJobState(job.state)) return { outcome: 'rejected', reason: 'nonterminal' };
+      await this.deleteJob(jobId);
+      return { outcome: 'cleared' };
+    });
   }
 
   private assertLeaseHeld(job: PromoteJob, claimToken: string): void {

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -18,7 +18,7 @@
  */
 
 import type { TripleStore } from '@origintrail-official/dkg-storage';
-import type { TerminalJobClearOutcome } from './async-lift-publisher-types.js';
+import { isSafeClearJobId, type TerminalJobClearOutcome } from './terminal-job-clear.js';
 import {
   ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
   ASYNC_PROMOTE_QUEUE_MIN_AUTO_RECOVERABLE_FORMAT_VERSION,
@@ -620,7 +620,10 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
    * throws / never mutates on a reject.
    */
   async clearTerminalJob(jobId: string): Promise<TerminalJobClearOutcome> {
-    if (!jobId || jobId.trim().length === 0) return { outcome: 'rejected', reason: 'malformed' };
+    // Reject an empty OR SPARQL-unsafe jobId as malformed before building the jobSubject
+    // IRI (defense-in-depth; the SWM route already pre-validates via decodePromoteJobId,
+    // but a direct agent.assertion.clearPromoteAsync caller must be bounded too).
+    if (!isSafeClearJobId(jobId)) return { outcome: 'rejected', reason: 'malformed' };
     return this.withMutationLock(async () => {
       await this.ensureGraph();
       const stateRows = expectBindings(

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -630,7 +630,14 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
       );
       if (stateRows.length === 0) return { outcome: 'already_absent' };
       const rawState = stateRows[0]?.['state'];
-      const state = rawState === undefined ? undefined : String(parseLiteral(rawState));
+      // parseLiteral is JSON.parse — a corrupt/non-JSON state literal must become a
+      // bounded reject, never throw out of the method (matches the lift sibling's guard).
+      let state: string | undefined;
+      try {
+        state = rawState === undefined ? undefined : String(parseLiteral(rawState));
+      } catch {
+        return { outcome: 'rejected', reason: 'unknown' };
+      }
       if (state === undefined || !(PROMOTE_JOB_STATES as readonly string[]).includes(state)) {
         return { outcome: 'rejected', reason: 'unknown' };
       }

--- a/packages/publisher/src/async-promote-queue-types.ts
+++ b/packages/publisher/src/async-promote-queue-types.ts
@@ -14,7 +14,7 @@
  * differences from `AsyncLiftPublisher`.
  */
 
-import type { TerminalJobClearOutcome } from './async-lift-publisher-types.js';
+import type { TerminalJobClearOutcome } from './terminal-job-clear.js';
 
 export const PROMOTE_JOB_STATES = [
   'queued',

--- a/packages/publisher/src/async-promote-queue-types.ts
+++ b/packages/publisher/src/async-promote-queue-types.ts
@@ -14,6 +14,8 @@
  * differences from `AsyncLiftPublisher`.
  */
 
+import type { TerminalJobClearOutcome } from './async-lift-publisher-types.js';
+
 export const PROMOTE_JOB_STATES = [
   'queued',
   'running',
@@ -217,6 +219,18 @@ export interface AsyncPromoteQueue {
   pause(): Promise<void>;
   resume(): Promise<void>;
   getStats(): Promise<PromoteStats>;
+}
+
+/**
+ * #1837 — atomic by-exact-jobId terminal cleanup for the SWM share (promote) queue.
+ * Segregated off the base contract (mirrors the publisher-side VmPublishTerminalJobClearer);
+ * a mutation/admin capability. Clears the exact job ONLY when in a native terminal state
+ * ({succeeded, failed}, no carve-out — nothing background re-drives a terminal promote row),
+ * rejects otherwise without mutation, idempotent for an absent job, never broadens to other
+ * jobs. Reuses the shared TerminalJobClearOutcome for symmetry with the lift clearer.
+ */
+export interface PromoteTerminalJobClearer {
+  clearTerminalJob(jobId: string): Promise<TerminalJobClearOutcome>;
 }
 
 export interface AsyncPromoteQueueConfig {

--- a/packages/publisher/src/async-promote-queue-utils.ts
+++ b/packages/publisher/src/async-promote-queue-utils.ts
@@ -69,7 +69,7 @@ export const ACTIVE_PROMOTE_STATES: readonly PromoteJobState[] = [
 export const TERMINAL_PROMOTE_JOB_STATES: readonly PromoteJobState[] = ['succeeded', 'failed'];
 
 export function isTerminalPromoteJobState(state: PromoteJobState): boolean {
-  return state === 'succeeded' || state === 'failed';
+  return TERMINAL_PROMOTE_JOB_STATES.includes(state);
 }
 
 export function jobSubject(jobId: string): string {

--- a/packages/publisher/src/async-promote-queue-utils.ts
+++ b/packages/publisher/src/async-promote-queue-utils.ts
@@ -58,6 +58,20 @@ export const ACTIVE_PROMOTE_STATES: readonly PromoteJobState[] = [
   'failed_retrying',
 ];
 
+/**
+ * #1837 — native terminal states for a by-jobId terminal clear. Unlike the lift queue
+ * there is NO carve-out: nothing background re-drives a terminal promote row (no on-chain
+ * tx; recover() failed→queued is manual-only + locked; reconcileExpiredRunning touches
+ * only 'running'; conflict detection gates on ACTIVE states), so both terminal states are
+ * uniformly clearable — a `requiresManualInspection` (partial-ambiguity) failed row
+ * included (data-safe: nothing reads a removed row).
+ */
+export const TERMINAL_PROMOTE_JOB_STATES: readonly PromoteJobState[] = ['succeeded', 'failed'];
+
+export function isTerminalPromoteJobState(state: PromoteJobState): boolean {
+  return state === 'succeeded' || state === 'failed';
+}
+
 export function jobSubject(jobId: string): string {
   return `urn:dkg:promote-queue:job:${jobId}`;
 }

--- a/packages/publisher/src/async-promote-queue.ts
+++ b/packages/publisher/src/async-promote-queue.ts
@@ -14,6 +14,7 @@ export type {
   PromoteRequest,
   PromoteResult,
   PromoteStats,
+  PromoteTerminalJobClearer,
 } from './async-promote-queue-types.js';
 export {
   ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -267,6 +267,8 @@ export {
   type VmPublishIntentRecoveryPublisher,
   type VmPublishIntentIndexBackfiller,
   type VmPublishAdmissionJournalReader,
+  type VmPublishTerminalJobClearer,
+  type TerminalJobClearOutcome,
   type IntentLookupInput,
   type IntentLookupResult,
   type JournalReadInput,
@@ -294,6 +296,7 @@ export {
   type PromoteRequest,
   type PromoteResult,
   type PromoteStats,
+  type PromoteTerminalJobClearer,
 } from './async-promote-queue.js';
 export {
   AsyncLiftRunner,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -275,6 +275,10 @@ export {
   type JournalReadResult,
 } from './async-lift-publisher.js';
 export {
+  SAFE_CLEAR_JOB_ID_PATTERN,
+  SAFE_CLEAR_JOB_ID_MAX_LENGTH,
+} from './terminal-job-clear.js';
+export {
   TripleStoreAsyncPromoteQueue,
   ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
   PROMOTE_COMMIT_MARKER_STEPS,

--- a/packages/publisher/src/terminal-job-clear.ts
+++ b/packages/publisher/src/terminal-job-clear.ts
@@ -1,0 +1,31 @@
+// #1837 — shared contract for the atomic by-exact-jobId TERMINAL clear, owned by NEITHER
+// queue (lift nor promote) so a generic admin-clear result is not coupled to one
+// implementation family's type module.
+
+/**
+ * Bounded outcome of a terminal clear, shared by the lift publisher and the SWM promote
+ * queue. The control method owns every reason INCLUDING `malformed` (a corrupt persisted
+ * payload — or an unsafe jobId — is only detectable inside the method, never at the HTTP
+ * route). Never throws and never mutates on a reject. `already_absent` is a SUCCESS
+ * (idempotent repeat), distinct from a rejection.
+ */
+export type TerminalJobClearOutcome =
+  | { readonly outcome: 'cleared' }
+  | { readonly outcome: 'already_absent' }
+  | { readonly outcome: 'rejected'; readonly reason: 'nonterminal' | 'unknown' | 'malformed' };
+
+// Producer grammar for a queue jobId (crypto.randomUUID(), or test 'job-N'): starts
+// alphanumeric, then alnum/'.'/'_'/':'/'-', max 256. This is IRI-safe — it excludes every
+// character that could break out of the `<…>` IRI in a control-plane SPARQL query (spaces,
+// '<' '>' '"' '{' '}' '|' '^' '`', control chars). Mirrors the CLI's validatePromoteJobId.
+const SAFE_CLEAR_JOB_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+
+/**
+ * True iff `jobId` is safe to interpolate into a control-plane SPARQL IRI. A by-id clear
+ * MUST reject an unsafe jobId as `malformed` BEFORE building the query, so an
+ * attacker-controlled jobId (from the clear-job HTTP body) yields a bounded reject rather
+ * than a query syntax error / injection / 500.
+ */
+export function isSafeClearJobId(jobId: string): boolean {
+  return jobId.length > 0 && jobId.length <= 256 && SAFE_CLEAR_JOB_ID.test(jobId);
+}

--- a/packages/publisher/src/terminal-job-clear.ts
+++ b/packages/publisher/src/terminal-job-clear.ts
@@ -15,10 +15,13 @@ export type TerminalJobClearOutcome =
   | { readonly outcome: 'rejected'; readonly reason: 'nonterminal' | 'unknown' | 'malformed' };
 
 // Producer grammar for a queue jobId (crypto.randomUUID(), or test 'job-N'): starts
-// alphanumeric, then alnum/'.'/'_'/':'/'-', max 256. This is IRI-safe — it excludes every
-// character that could break out of the `<…>` IRI in a control-plane SPARQL query (spaces,
-// '<' '>' '"' '{' '}' '|' '^' '`', control chars). Mirrors the CLI's validatePromoteJobId.
-const SAFE_CLEAR_JOB_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+// alphanumeric, then alnum/'.'/'_'/':'/'-'. This is IRI-safe — it excludes every character
+// that could break out of the `<…>` IRI in a control-plane SPARQL query (spaces, '<' '>'
+// '"' '{' '}' '|' '^' '`', control chars). This is the SINGLE authoritative job-id grammar:
+// the CLI route validator (`validatePromoteJobId`) imports it rather than re-declaring the
+// regex, so route-level and control-plane job-id acceptance cannot drift.
+export const SAFE_CLEAR_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+export const SAFE_CLEAR_JOB_ID_MAX_LENGTH = 256;
 
 /**
  * True iff `jobId` is safe to interpolate into a control-plane SPARQL IRI. A by-id clear
@@ -27,5 +30,7 @@ const SAFE_CLEAR_JOB_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
  * than a query syntax error / injection / 500.
  */
 export function isSafeClearJobId(jobId: string): boolean {
-  return jobId.length > 0 && jobId.length <= 256 && SAFE_CLEAR_JOB_ID.test(jobId);
+  return (
+    jobId.length > 0 && jobId.length <= SAFE_CLEAR_JOB_ID_MAX_LENGTH && SAFE_CLEAR_JOB_ID_PATTERN.test(jobId)
+  );
 }

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -133,10 +133,15 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     expect(await p.clearTerminalJob(jobId)).toEqual({ outcome: 'already_absent' });
   });
 
-  it('rejects a malformed (empty) jobId without mutation', async () => {
+  it('rejects an empty or SPARQL-unsafe jobId as malformed without querying/mutating', async () => {
     const p = createPublisher();
     expect(await p.clearTerminalJob('')).toEqual({ outcome: 'rejected', reason: 'malformed' });
     expect(await p.clearTerminalJob('  ')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+    // #1883 review (🔴): a jobId that would break out of the <…> SPARQL IRI must be a
+    // bounded malformed reject, never a query error / injection.
+    expect(await p.clearTerminalJob('bad id')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+    expect(await p.clearTerminalJob('bad>id')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+    expect(await p.clearTerminalJob('a{ b')).toEqual({ outcome: 'rejected', reason: 'malformed' });
   });
 
   it('preserves the #1829 journal: clearing a terminal job leaves its journal lineage readable', async () => {

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { TripleStoreAsyncLiftPublisher, type AsyncLiftPublisherConfig } from '../src/index.js';
+import { DEFAULT_CONTROL_GRAPH_URI, jobSubject, serializeJob } from '../src/async-lift-control-plane.js';
+
+// #1837 — atomic by-exact-jobId TERMINAL clear for the async publisher (lift) queue.
+describe('#1837 lift publisher clearTerminalJob', () => {
+  let now = 1_000;
+  let ids = 0;
+  let store: OxigraphStore;
+
+  beforeEach(() => {
+    now = 1_000;
+    ids = 0;
+    store = new OxigraphStore();
+  });
+
+  function createPublisher(config: Omit<AsyncLiftPublisherConfig, 'now' | 'idGenerator'> = {}): TripleStoreAsyncLiftPublisher {
+    return new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++now,
+      idGenerator: () => `job-${++ids}`,
+      journalWrites: true,
+      ...config,
+    });
+  }
+
+  function kaVmPublishRequest(overrides: Record<string, unknown> = {}) {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
+    return {
+      contextGraphId: 'music-social', name: 'albums', shareOperationId: 'share-op-1',
+      roots: [] as string[], contentScopeVersion: 2 as const, kaUal, assertionVersion: '1',
+      publicTripleCount: 2, privateTripleCount: 0,
+      seal: {
+        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+        authorAddress: authorAddress as `0x${string}`,
+        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
+        schemeVersion: 1,
+        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
+      },
+      sealChainId: '31337' as `${bigint}`, sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z', sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      intentKey: `sha256:${'ab'.repeat(32)}`, wmCurrentAssertion: '12'.repeat(32), swmCurrentAssertion: '12'.repeat(32),
+      kaNumber: kaNumber.toString(), reservedUal: kaUal, ...overrides,
+    };
+  }
+  const bx = { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' };
+  const inc = { blockNumber: 10, blockHash: `0x${'aa'.repeat(32)}` as `0x${string}`, blockTimestamp: 1 };
+
+  async function driveToValidated(p: TripleStoreAsyncLiftPublisher, o: Record<string, unknown> = {}): Promise<string> {
+    const jobId = await p.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest(o));
+    await p.claimNext('wallet-1');
+    await p.update(jobId, 'validated', {
+      validation: { canonicalRoots: [], canonicalRootMap: {}, swmQuadCount: 2, authorityProofRef: 'knowledge-asset-lifecycle', transitionType: 'CREATE' },
+    });
+    return jobId;
+  }
+  async function driveToFinalized(p: TripleStoreAsyncLiftPublisher, o: Record<string, unknown> = {}): Promise<string> {
+    const jobId = await driveToValidated(p, o);
+    await p.update(jobId, 'broadcast', { broadcast: bx });
+    await p.update(jobId, 'included', { broadcast: bx, inclusion: inc });
+    await p.update(jobId, 'finalized', { broadcast: bx, inclusion: inc, finalization: { mode: 'local' } });
+    return jobId;
+  }
+  // Terminal, non-retryable (tx_reverted → fail_job): clearable, retry() won't touch it.
+  async function driveToTerminalFailed(p: TripleStoreAsyncLiftPublisher, o: Record<string, unknown> = {}): Promise<string> {
+    const jobId = await driveToValidated(p, o);
+    await p.update(jobId, 'broadcast', { broadcast: bx });
+    await p.recordPublishFailure(jobId, { error: new Error('tx reverted on chain'), failedFromState: 'broadcast', errorPayloadRef: 'urn:err:1' });
+    return jobId;
+  }
+  it('clears an exact finalized job (cleared); no other job changes', async () => {
+    const p = createPublisher();
+    const target = await driveToFinalized(p, { name: 'a' });
+    const other = await driveToFinalized(p, { name: 'b' });
+    expect(await p.clearTerminalJob(target)).toEqual({ outcome: 'cleared' });
+    expect(await p.getStatus(target)).toBeNull();
+    expect((await p.getStatus(other))?.status).toBe('finalized'); // untouched
+  });
+
+  it('clears an exact terminal (non-retryable) failed job', async () => {
+    const p = createPublisher();
+    const jobId = await driveToTerminalFailed(p);
+    expect((await p.getStatus(jobId))?.status).toBe('failed');
+    expect(await p.clearTerminalJob(jobId)).toEqual({ outcome: 'cleared' });
+    expect(await p.getStatus(jobId)).toBeNull();
+  });
+
+  it('rejects an accepted (queued) job as nonterminal without mutation', async () => {
+    const p = createPublisher();
+    const accepted = await p.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    expect(await p.clearTerminalJob(accepted)).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await p.getStatus(accepted))?.status).toBe('accepted');
+  });
+
+  it('rejects a validated job as nonterminal without mutation', async () => {
+    const p = createPublisher();
+    const validated = await driveToValidated(p);
+    expect(await p.clearTerminalJob(validated)).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await p.getStatus(validated))?.status).toBe('validated');
+  });
+
+  it('rejects a broadcast job as nonterminal without mutation', async () => {
+    const p = createPublisher();
+    const broadcast = await driveToValidated(p);
+    await p.update(broadcast, 'broadcast', { broadcast: bx });
+    expect(await p.clearTerminalJob(broadcast)).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await p.getStatus(broadcast))?.status).toBe('broadcast');
+  });
+
+  it('rejects a retry_recovery-protected failed job as nonterminal (a pending tx may still land)', async () => {
+    // retry_recovery is a raw-lift-only recovery resolution (KA-VM canRetryFailedRecovery
+    // is false), so inject a synthetic retry_recovery-failed job to exercise the guard the
+    // clearer shares with bulk clear(). Start from a real terminal-failed job and rewrite
+    // its persisted resolution.
+    const p = createPublisher();
+    const jobId = await driveToTerminalFailed(p);
+    const job = await p.getStatus(jobId);
+    if (!job || !('failure' in job)) throw new Error('expected a failed job');
+    const mutated = { ...job, failure: { ...job.failure, resolution: 'retry_recovery' } };
+    await store.deleteByPattern({ subject: jobSubject(jobId), graph: DEFAULT_CONTROL_GRAPH_URI });
+    await store.insert(serializeJob(mutated as typeof job, DEFAULT_CONTROL_GRAPH_URI));
+    expect(await p.clearTerminalJob(jobId)).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await p.getStatus(jobId))?.status).toBe('failed'); // unchanged
+  });
+
+  it('is idempotent: absent / already-cleared → already_absent', async () => {
+    const p = createPublisher();
+    expect(await p.clearTerminalJob('never-existed')).toEqual({ outcome: 'already_absent' });
+    const jobId = await driveToFinalized(p);
+    expect(await p.clearTerminalJob(jobId)).toEqual({ outcome: 'cleared' });
+    expect(await p.clearTerminalJob(jobId)).toEqual({ outcome: 'already_absent' });
+  });
+
+  it('rejects a malformed (empty) jobId without mutation', async () => {
+    const p = createPublisher();
+    expect(await p.clearTerminalJob('')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+    expect(await p.clearTerminalJob('  ')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+  });
+
+  it('preserves the #1829 journal: clearing a terminal job leaves its journal lineage readable', async () => {
+    const p = createPublisher();
+    const jobId = await driveToFinalized(p);
+    expect((await p.readJournalByJob(jobId)).entries.length).toBeGreaterThan(0);
+    expect(await p.clearTerminalJob(jobId)).toEqual({ outcome: 'cleared' });
+    expect(await p.getStatus(jobId)).toBeNull(); // gone from control plane
+    const journal = await p.readJournalByJob(jobId);
+    expect(journal.entries.length).toBeGreaterThan(0); // lineage survives the clear
+    expect(journal.entries.some((e) => e.kind === 'finalized')).toBe(true);
+  });
+
+  it('no-sweep: a clearable-failed job reaccepted by concurrent retry() is never deleted while active', async () => {
+    // maxRetries:1 + a retryable failure (rpc_unavailable/reset_to_accepted) → the job is
+    // BOTH clearable (terminal failed, not retry_recovery) AND reacceptable by retry().
+    // clearTerminalJob and retry() both run under withClaimLock, so they serialize:
+    // whichever wins, an ACTIVE job is never swept.
+    const p = createPublisher({ maxRetries: 1 });
+    const jobId = await driveToValidated(p, { name: 'race' });
+    await p.update(jobId, 'broadcast', { broadcast: bx });
+    await p.recordPublishFailure(jobId, { error: new Error('rpc temporarily down'), failedFromState: 'broadcast', errorPayloadRef: 'urn:err:2' });
+    const failed = await p.getStatus(jobId);
+    expect(failed?.status).toBe('failed');
+    expect(failed && 'failure' in failed && failed.failure.retryable).toBe(true);
+
+    const [clearOutcome, retried] = await Promise.all([p.clearTerminalJob(jobId), p.retry({ status: 'failed' })]);
+    const after = await p.getStatus(jobId);
+    if (clearOutcome.outcome === 'cleared') {
+      // clear won: job gone, retry could not have reaccepted it.
+      expect(after).toBeNull();
+      expect(retried).toBe(0);
+    } else {
+      // retry won: job is active ('accepted'); clear must have rejected it, NOT deleted it.
+      expect(clearOutcome).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+      expect(after?.status).toBe('accepted');
+      expect(retried).toBe(1);
+    }
+  });
+
+  it('concurrent clears of one terminal job are deterministic: one cleared, rest already_absent', async () => {
+    const p = createPublisher();
+    const target = await driveToFinalized(p, { name: 'a' });
+    const other = await driveToFinalized(p, { name: 'b' });
+    const results = await Promise.all([p.clearTerminalJob(target), p.clearTerminalJob(target), p.clearTerminalJob(target)]);
+    expect(results.filter((r) => r.outcome === 'cleared')).toHaveLength(1);
+    expect(results.filter((r) => r.outcome === 'already_absent')).toHaveLength(2);
+    expect((await p.getStatus(other))?.status).toBe('finalized'); // never affected
+  });
+});

--- a/packages/publisher/test/async-promote-terminal-clear.test.ts
+++ b/packages/publisher/test/async-promote-terminal-clear.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  type AsyncPromoteQueue,
+  type AsyncPromoteQueueConfig,
+  type PromoteRequest,
+  type PromoteTerminalJobClearer,
+} from '../src/async-promote-queue-types.js';
+import { TripleStoreAsyncPromoteQueue } from '../src/async-promote-queue-impl.js';
+
+// #1837 — atomic by-exact-jobId TERMINAL clear for the SWM promote queue.
+describe('#1837 promote queue clearTerminalJob', () => {
+  let store: OxigraphStore;
+  let now: number;
+  let idCounter: number;
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    now = 1_000_000;
+    idCounter = 0;
+  });
+
+  function createQueue(overrides: Partial<AsyncPromoteQueueConfig> = {}): AsyncPromoteQueue & PromoteTerminalJobClearer {
+    return new TripleStoreAsyncPromoteQueue(store, {
+      now: () => now,
+      idGenerator: () => `job-${++idCounter}`,
+      ...overrides,
+    }) as TripleStoreAsyncPromoteQueue;
+  }
+
+  function makeRequest(overrides: Partial<PromoteRequest> = {}): PromoteRequest {
+    return { contextGraphId: 'graphify', subGraphName: 'code', assertionName: 'shard-1', entities: 'all', ...overrides };
+  }
+
+  async function enqueueSucceeded(queue: AsyncPromoteQueue, req?: Partial<PromoteRequest>): Promise<string> {
+    const jobId = await queue.enqueue(makeRequest(req));
+    const claimed = await queue.claimNext('worker-1');
+    const token = claimed!.lease!.claimToken;
+    // Worker records commit progress — required before succeed().
+    await queue.recordCommitMarker(jobId, token, 'swmInserted');
+    await queue.recordCommitMarker(jobId, token, 'wmCleaned');
+    await queue.recordCommitMarker(jobId, token, 'lifecycleStamped');
+    await queue.recordCommitMarker(jobId, token, 'gossiped');
+    await queue.succeed(jobId, token, { promotedCount: 1, succeededAt: now });
+    return jobId;
+  }
+
+  async function enqueueTerminalFailed(queue: AsyncPromoteQueue, req?: Partial<PromoteRequest>): Promise<string> {
+    const jobId = await queue.enqueue(makeRequest(req));
+    const claimed = await queue.claimNext('worker-1');
+    await queue.fail(jobId, claimed!.lease!.claimToken, {
+      message: 'permanent', retryable: false, classification: 'permanent', recordedAt: now,
+    });
+    return jobId;
+  }
+
+  it('clears an exact succeeded job (cleared); no other job changes', async () => {
+    const queue = createQueue();
+    const target = await enqueueSucceeded(queue, { assertionName: 'a' });
+    const other = await enqueueSucceeded(queue, { assertionName: 'b' });
+    expect(await queue.clearTerminalJob(target)).toEqual({ outcome: 'cleared' });
+    expect(await queue.getStatus(target)).toBeNull();
+    expect((await queue.getStatus(other))?.state).toBe('succeeded'); // untouched
+  });
+
+  it('clears an exact terminal-failed job (incl. no retry_recovery carve-out)', async () => {
+    const queue = createQueue();
+    const jobId = await enqueueTerminalFailed(queue);
+    expect(await queue.clearTerminalJob(jobId)).toEqual({ outcome: 'cleared' });
+    expect(await queue.getStatus(jobId)).toBeNull();
+  });
+
+  it('rejects a queued job as nonterminal without mutation', async () => {
+    const queue = createQueue();
+    const queued = await queue.enqueue(makeRequest());
+    expect(await queue.clearTerminalJob(queued)).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await queue.getStatus(queued))?.state).toBe('queued');
+  });
+
+  it('rejects a running job as nonterminal without mutation', async () => {
+    const queue = createQueue();
+    const runningId = await queue.enqueue(makeRequest());
+    await queue.claimNext('worker-1');
+    expect((await queue.getStatus(runningId))?.state).toBe('running');
+    expect(await queue.clearTerminalJob(runningId)).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await queue.getStatus(runningId))?.state).toBe('running');
+  });
+
+  it('rejects a failed_retrying job as nonterminal without mutation', async () => {
+    const queue = createQueue({ backoff: () => 10_000 });
+    const retryingId = await queue.enqueue(makeRequest());
+    const claimed = await queue.claimNext('worker-1');
+    await queue.fail(retryingId, claimed!.lease!.claimToken, {
+      message: 'transient', retryable: true, classification: 'transient', recordedAt: now,
+    });
+    expect((await queue.getStatus(retryingId))?.state).toBe('failed_retrying');
+    expect(await queue.clearTerminalJob(retryingId)).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await queue.getStatus(retryingId))?.state).toBe('failed_retrying');
+  });
+
+  it('is idempotent: an absent / already-cleared job returns already_absent', async () => {
+    const queue = createQueue();
+    expect(await queue.clearTerminalJob('never-existed')).toEqual({ outcome: 'already_absent' });
+    const jobId = await enqueueSucceeded(queue);
+    expect(await queue.clearTerminalJob(jobId)).toEqual({ outcome: 'cleared' });
+    expect(await queue.clearTerminalJob(jobId)).toEqual({ outcome: 'already_absent' }); // repeat
+  });
+
+  it('rejects a malformed (empty) jobId without mutation', async () => {
+    const queue = createQueue();
+    expect(await queue.clearTerminalJob('')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+    expect(await queue.clearTerminalJob('   ')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+  });
+
+  it('concurrent clears of one terminal job are deterministic: one cleared, rest already_absent, no other job affected', async () => {
+    const queue = createQueue();
+    const target = await enqueueSucceeded(queue, { assertionName: 'a' });
+    const other = await enqueueSucceeded(queue, { assertionName: 'b' });
+    const results = await Promise.all([
+      queue.clearTerminalJob(target), queue.clearTerminalJob(target), queue.clearTerminalJob(target),
+    ]);
+    expect(results.filter((r) => r.outcome === 'cleared')).toHaveLength(1);
+    expect(results.filter((r) => r.outcome === 'already_absent')).toHaveLength(2);
+    expect((await queue.getStatus(other))?.state).toBe('succeeded'); // never affected
+  });
+});

--- a/packages/publisher/test/async-promote-terminal-clear.test.ts
+++ b/packages/publisher/test/async-promote-terminal-clear.test.ts
@@ -7,6 +7,7 @@ import {
   type PromoteTerminalJobClearer,
 } from '../src/async-promote-queue-types.js';
 import { TripleStoreAsyncPromoteQueue } from '../src/async-promote-queue-impl.js';
+import { DEFAULT_PROMOTE_CONTROL_GRAPH_URI, PROMOTE_STATE, jobSubject, literal } from '../src/async-promote-queue-utils.js';
 
 // #1837 — atomic by-exact-jobId TERMINAL clear for the SWM promote queue.
 describe('#1837 promote queue clearTerminalJob', () => {
@@ -110,6 +111,16 @@ describe('#1837 promote queue clearTerminalJob', () => {
     const queue = createQueue();
     expect(await queue.clearTerminalJob('')).toEqual({ outcome: 'rejected', reason: 'malformed' });
     expect(await queue.clearTerminalJob('   ')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+  });
+
+  // #1883 review (🟡): a state triple present but not a recognized enum value must be a
+  // bounded reject (unknown), never throw — and the parse itself is now try/catch-guarded.
+  it('rejects a subject whose state is not a known enum value as unknown, without throwing', async () => {
+    const queue = createQueue();
+    await store.insert([
+      { subject: jobSubject('bogus-1'), predicate: PROMOTE_STATE, object: literal('bogus_state'), graph: DEFAULT_PROMOTE_CONTROL_GRAPH_URI },
+    ]);
+    await expect(queue.clearTerminalJob('bogus-1')).resolves.toEqual({ outcome: 'rejected', reason: 'unknown' });
   });
 
   it('concurrent clears of one terminal job are deterministic: one cleared, rest already_absent, no other job affected', async () => {

--- a/packages/publisher/test/async-promote-terminal-clear.test.ts
+++ b/packages/publisher/test/async-promote-terminal-clear.test.ts
@@ -107,10 +107,12 @@ describe('#1837 promote queue clearTerminalJob', () => {
     expect(await queue.clearTerminalJob(jobId)).toEqual({ outcome: 'already_absent' }); // repeat
   });
 
-  it('rejects a malformed (empty) jobId without mutation', async () => {
+  it('rejects an empty or SPARQL-unsafe jobId as malformed without querying/mutating', async () => {
     const queue = createQueue();
     expect(await queue.clearTerminalJob('')).toEqual({ outcome: 'rejected', reason: 'malformed' });
     expect(await queue.clearTerminalJob('   ')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+    expect(await queue.clearTerminalJob('bad id')).toEqual({ outcome: 'rejected', reason: 'malformed' });
+    expect(await queue.clearTerminalJob('bad>id')).toEqual({ outcome: 'rejected', reason: 'malformed' });
   });
 
   // #1883 review (🟡): a state triple present but not a recognized enum value must be a

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
       'test/async-lift-intent-lookup.test.ts',
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
+      'test/async-lift-terminal-clear.test.ts',
+      'test/async-promote-terminal-clear.test.ts',
       'test/lift-job-types.test.ts',
       'test/multi-root-token-rows.test.ts',
       'test/access-verification.test.ts',


### PR DESCRIPTION
## Summary

Adds two explicit, atomic, by-exact-jobId **terminal-clear** operations (Publisher epic PR4, issue #1837) — one for the async publisher (lift) queue, one for the SWM share (promote) queue. Each uses the node's **native terminal state as the sole cleanup authority**: it clears exactly one job only when that job is in a native terminal state, rejects active/queued/retrying/recovering/unknown/malformed **without mutation**, never broadens to other jobs or a status class, is **idempotent** for an already-absent job, and returns a bounded machine-readable outcome. Receipt/reconciliation/retry-authority/hold checks remain the caller's responsibility.

Shared bounded outcome (both queues, for symmetry):
```ts
type TerminalJobClearOutcome =
  | { outcome: 'cleared' } | { outcome: 'already_absent' }
  | { outcome: 'rejected'; reason: 'nonterminal' | 'unknown' | 'malformed' };
```
The control method owns every reason **including `malformed`** — a corrupt persisted payload is only detectable inside the method, never at the HTTP route.

### Publisher (lift)
- `clearTerminalJob(jobId)` on a segregated `VmPublishTerminalJobClearer` interface. Runs **inside `withClaimLock`**, and — the load-bearing anti-sweep fix — **`retry()` is now also wrapped in `withClaimLock`** (it is the only lock-free terminal→active transition; without this a concurrent by-id clear could sweep a just-reaccepted active job). Terminal authority = new shared `isClearableTerminalLiftJob` (`finalized|failed`, excluding `retry_recovery`-failed jobs that may still land an on-chain tx); bulk `clear()` was refactored to reuse it (behavior identical). An ordered defensive read splits `already_absent`/`malformed`/`unknown`/`nonterminal` without ever throwing.
- **Preserves the #1829 append-only journal by construction:** `deleteJob` is subject-scoped to the control-plane graph and never touches `urn:dkg:publisher:journal`; a regression test asserts the lineage is still readable after a clear.

### Promote (SWM share)
- `clearTerminalJob(jobId)` on a segregated `PromoteTerminalJobClearer`, inside the existing `withMutationLock` (which already serializes **every** transition incl. `recover()`), so it is race-safe with **no new locking**. New subject-scoped `deleteJob` primitive. Terminal = `{succeeded, failed}` with **no carve-out** (nothing background re-drives a terminal promote row — a genuine simplification vs the lift side). A bare denormalized-state probe splits `already_absent`/`unknown`/`malformed`.

### Surface
`POST /api/publisher/clear-job` and `POST /api/knowledge-assets/swm/share-jobs/:jobId/clear` — both **distinct** from the existing cancel/cancellation routes (which are left untouched), with `already_absent` → **200** (idempotency), `nonterminal`/`unknown` → 409, `malformed` → 400. `agent.assertion.clearPromoteAsync` pass-through; api-client `publisherClearJob` + `knowledgeAssetClearShareJob`. Base contracts stay frozen (capabilities on segregated interfaces per the #1828/#1829 convention); the factory/getter intersections are widened.

## Related
- Publisher durable-admission epic: #1846 (#1836), #1851, #1849 (#1828), #1829 — this is PR4, the final one.
- Depends on / preserves #1829's append-only journal (AC4: the journal is the only survivor of a clear).
- Plan: `agent-docs/plans/2026-07-21-1837-terminal-clear.md` (local-only, not committed).

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/async-lift-publisher-types.ts` | shared `TerminalJobClearOutcome` + `VmPublishTerminalJobClearer` interface. |
| `packages/publisher/src/async-lift-publisher-utils.ts` | shared `isClearableTerminalLiftJob` authority. |
| `packages/publisher/src/async-lift-publisher-impl.ts` | lift `clearTerminalJob`; `retry()` wrapped in `withClaimLock`; `clear()` refactored to the shared authority. |
| `packages/publisher/src/async-promote-queue-{types,utils,impl}.ts` | `PromoteTerminalJobClearer`; `TERMINAL_PROMOTE_JOB_STATES`/`isTerminalPromoteJobState`; promote `clearTerminalJob` + subject-scoped `deleteJob`. |
| `packages/publisher/src/{async-lift-publisher,async-promote-queue,index}.ts` | export the new types. |
| `packages/cli/src/daemon/routes/publisher.ts`, `knowledge-assets{,-async-share}.ts` | the two clear routes + handler. |
| `packages/cli/src/publisher-runner.ts` | widen the control factory return type. |
| `packages/cli/src/api-client.ts` | `publisherClearJob` + `knowledgeAssetClearShareJob`. |
| `packages/agent/src/dkg-agent.ts` | `clearPromoteAsync` pass-through + widened `promoteQueue` getter. |
| `packages/{publisher,cli}/test/*` | 19 unit + 3 route tests. |

## Test plan
- [x] `pnpm --filter @origintrail-official/dkg-publisher exec vitest run --config vitest.unit.config.ts` — 19 new clear tests (lift 11: all outcomes, synthetic retry_recovery rejection, no-sweep vs concurrent `retry()`, journal preservation, concurrent-clear determinism; promote 8) + existing lift/promote regression (67) unchanged.
- [x] `pnpm --filter @origintrail-official/dkg-cli exec vitest run --config vitest.unit.config.ts test/publisher-clear-job-route.test.ts` — outcome→HTTP mapping (200 cleared/already_absent, 409 nonterminal, 400 malformed).
- [x] Publisher / agent / cli `tsc --noEmit` clean.
- [ ] Full CI on testnet-canary.

## Issue closure

⚠️ This PR targets `testnet-canary`, so merging it will **not** auto-close the linked issue **#1837** — GitHub auto-close only fires on merges into the default branch `main`. **Please close #1837 manually on merge**, referencing this PR. (The sibling issue #1829 for PR #1875 was closed manually for the same reason.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

