### PR TITLE
feat: configure Node UI metrics collection cadence

### DIFF
--- a/docs/use-dkg/node-ui-metrics.md
+++ b/docs/use-dkg/node-ui-metrics.md
@@ -3,34 +3,70 @@
 The daemon writes local Node UI metric snapshots to `node-ui.db`. This local
 collector is separate from OpenTelemetry metric export:
 
-- `telemetry.metrics.collectionEnabled` controls local SQLite snapshots and
-  the store queries used to populate them.
+- `telemetry.metrics.collectionEnabled` and the two `*CollectionIntervalMs`
+  settings control local SQLite snapshots and store scans.
 - `telemetry.metrics.enabled`, `endpoint`, and `exportIntervalMs` control OTLP
-  export. Disabling local collection does not disable OTLP export.
+  export. Changing `exportIntervalMs` does not change local collection.
 
-Local collection remains enabled by default for backward compatibility. To
-disable it, add:
+## Recommended configuration for large stores
+
+Cheap CPU, memory, disk, peer, RPC, and relay snapshots remain useful at
+30-second resolution. Full-store SPARQL cardinality queries are much more
+expensive and default to a separate 12-hour cadence:
 
 ```json
 {
   "telemetry": {
     "metrics": {
-      "collectionEnabled": false
+      "collectionEnabled": true,
+      "collectionIntervalMs": 30000,
+      "storeCollectionIntervalMs": 43200000
     }
   }
 }
 ```
 
-The environment override takes precedence over configuration:
+The collector attempts both lanes immediately at startup. The expensive
+startup attempt only runs when the metrics-presence gate is open. After a
+successful attempt, the next full-store scan is scheduled 12 hours after the
+previous scan finishes, so a slow scan cannot overlap another store scan.
+Cheap snapshots use their own completion-relative scheduler and continue while
+a store scan is active.
+
+To restore the legacy shared 30-second cadence, explicitly set
+`storeCollectionIntervalMs` to `30000`.
+
+## Environment overrides
+
+Environment values take precedence over `config.json` or `config.yaml`:
 
 ```bash
-export DKG_METRICS_COLLECTION_ENABLED=0
+export DKG_METRICS_COLLECTION_ENABLED=1
+export DKG_METRICS_COLLECTION_INTERVAL_MS=30000
+export DKG_STORE_METRICS_COLLECTION_INTERVAL_MS=43200000
 ```
 
-The environment value accepts `1`, `0`, `true`, or `false`. Invalid config or
-environment values fail daemon startup instead of silently enabling the
-collector. Restart the daemon after changing the setting.
+`DKG_METRICS_COLLECTION_ENABLED` accepts `1`, `0`, `true`, or `false`.
+Intervals must be finite integers from `1000` through `2147483647`
+milliseconds. The 1-second minimum prevents accidental busy loops; the maximum
+is Node's safe timer limit. Invalid config or environment values fail daemon
+startup instead of silently falling back. Restart the daemon after changing
+these settings.
 
-Disabling the collector stops new local snapshots and store scans. Existing
-history remains in SQLite. When collection is enabled, the existing metrics
-presence gate and `DKG_METRICS_ALWAYS_COLLECT=1` behavior are unchanged.
+Set `collectionEnabled` to `false` (or the environment toggle to `0`) to stop
+all new local metric snapshots and store scans. Existing history remains in
+SQLite. This toggle is independent of the telemetry master/export toggles.
+
+## Metrics-presence gate
+
+The expensive store getters include total triples, KCs, KAs, confirmed and
+tentative KCs, and context-graph count. They run only when the Node UI has an
+open SSE consumer or `/api/metrics` or `/api/metrics/history` was read
+recently. When the gate is closed, cheap snapshots continue and the expensive
+columns are null; the gate is checked again without querying the store.
+
+`DKG_METRICS_ALWAYS_COLLECT=1` preserves the operator override that keeps the
+presence gate open. It does not bypass `storeCollectionIntervalMs`: with
+`DKG_STORE_METRICS_COLLECTION_INTERVAL_MS=43200000`, the override still permits
+at most one scheduled set of expensive scans per 12 hours, apart from the
+documented immediate startup attempt.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,8 +49,9 @@ dkg query my-project -q "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10"
 
 ## Node UI metrics collection
 
-Operators can disable local dashboard snapshots independently from
-OpenTelemetry metric export; see the
+Local dashboard snapshots use a 30-second system cadence and an independent
+12-hour full-store SPARQL cadence by default. Operators can tune or disable the
+collector without changing OpenTelemetry's `exportIntervalMs`; see the
 [Node UI metrics operator guide](../../docs/use-dkg/node-ui-metrics.md).
 
 ## Running a Core Node (relay operator)

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -726,8 +726,22 @@ export interface DkgConfig {
       token?: string;
       /** PeriodicExportingMetricReader interval. Default 30000ms. */
       exportIntervalMs?: number;
-      /** Enable local Node UI SQLite metric snapshots. Default true. */
+      /**
+       * Local Node UI snapshot collector toggle. Independent of `enabled`,
+       * which controls OTLP metric export. Default true. Environment override:
+       * DKG_METRICS_COLLECTION_ENABLED.
+       */
       collectionEnabled?: boolean;
+      /**
+       * Cheap local system/network snapshot cadence. Default 30000ms.
+       * Environment override: DKG_METRICS_COLLECTION_INTERVAL_MS.
+       */
+      collectionIntervalMs?: number;
+      /**
+       * Full-store SPARQL cardinality cadence. Default 43200000ms (12 hours).
+       * Environment override: DKG_STORE_METRICS_COLLECTION_INTERVAL_MS.
+       */
+      storeCollectionIntervalMs?: number;
     };
   };
   /** Shared memory (workspace) data TTL in milliseconds. Default: 30 days (2592000000). Set to 0 to disable cleanup. */

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1137,8 +1137,9 @@ export async function runDaemonInner(
   startedAt: number,
 ): Promise<void> {
   configureKaPublishLifecycleDebugLogging(config);
-  // Resolve the local collector toggle before constructing daemon resources.
-  // This is independent from OTLP metrics export configuration.
+  // Resolve and validate local metrics collection before constructing the
+  // agent/store or replacing process output. This is independent of OTLP
+  // export config and invalid values fail startup without partial resources.
   const metricsCollectorConfig = resolveMetricsCollectorConfig(config);
   const logFile = logPath();
   // Rotate before installing the in-process stdout/stderr tee so startup does
@@ -2539,17 +2540,14 @@ export async function runDaemonInner(
       }
       return countContextGraphsFromGraphUris(graphUris, knownContextGraphIds, shadowContextGraphIds);
     },
-    // The count getters below each issue a data-proportional full-scan COUNT,
-    // but the only caller is the 30 s metrics tick (metricsSource is consumed
-    // solely by MetricsCollector — no on-demand /api/status path), so each tick
-    // already re-reads the store fresh and there is nothing concurrent to
-    // coalesce. They are intentionally left uncached so a snapshot never serves
-    // a stale count and can't mask a store outage. The context-graph count
+    // The count getters below each issue a data-proportional full-scan COUNT.
+    // MetricsCollector owns their configured store cadence and serializes calls
+    // (including its cold-start API fallback), so the source deliberately adds
+    // no second cache or timer. The context-graph count
     // avoids the composite context-graph listing enrichment path. It uses the
     // cached store graph inventory plus backed subscription/declaration evidence,
     // then dedupes local layer graphs. It intentionally includes private CG graphs
     // that are backed by local subscription/declaration state.
-    // These COUNTs are cheap (~0.015 CPU-s/tick on a 75k-triple store).
     getTotalTriples: async () => {
       const r = await agent.query(GET_TOTAL_TRIPLES_SPARQL);
       return parseRdfInt(r?.bindings?.[0]?.c);
@@ -2656,6 +2654,10 @@ export async function runDaemonInner(
       metricsSource,
       dkgDir(),
       () => metricsPresence.hasRecentConsumer(),
+      {
+        collectionIntervalMs: metricsCollectorConfig.collectionIntervalMs,
+        storeCollectionIntervalMs: metricsCollectorConfig.storeCollectionIntervalMs,
+      },
     );
     metricsCollector.start();
   }

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -24,10 +24,10 @@ const CONTEXT_GRAPH_RESERVED_SUFFIXES = [
 const WALLET_SCOPED_CONTEXT_GRAPH_RE = /^0x[a-fA-F0-9]{40}\/.+$/;
 
 /**
- * Total triples across the default graph and all named graphs. Run on the 30s
- * metrics-collector cadence via `getTotalTriples` (see the metrics source in
- * `lifecycle.ts`). It is the heaviest read the collector issues and the one the
- * store-read-latency benchmark tracks.
+ * Total triples across the default graph and all named graphs. Run on the
+ * independently configured store-metrics cadence via `getTotalTriples` (see
+ * the metrics source in `lifecycle.ts`). It is the heaviest read the collector
+ * issues and the one the store-read-latency benchmark tracks.
  */
 export const GET_TOTAL_TRIPLES_SPARQL =
   'SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }';

--- a/packages/cli/src/doctor/checks/config-sanity.ts
+++ b/packages/cli/src/doctor/checks/config-sanity.ts
@@ -20,11 +20,11 @@ import {
   parseAutoUpdateVerifyTagSignature,
   type DkgConfig,
 } from '../../config.js';
-import { resolveMetricsCollectorConfig } from '../../metrics-collector-config.js';
 import {
   formatAutoUpdateTagVerificationWarning,
   resolveAutoUpdateGitRefPlan,
 } from '../../auto-update-ref.js';
+import { resolveMetricsCollectorConfig } from '../../metrics-collector-config.js';
 import type { DoctorDeps, Finding } from '../types.js';
 
 export async function runConfigSanityCheck(deps: DoctorDeps): Promise<Finding[]> {
@@ -99,23 +99,34 @@ export async function runConfigSanityCheck(deps: DoctorDeps): Promise<Finding[]>
     }
   }
 
+  // Local Node UI metrics collector config. Validate each leaf separately so
+  // one typo does not hide another in `dkg doctor` output. Daemon startup uses
+  // the same resolver (with the real environment) and fails fast as well.
   const telemetry = parsed.telemetry;
   if (telemetry && typeof telemetry === 'object' && !Array.isArray(telemetry)) {
     const metrics = (telemetry as Record<string, unknown>).metrics;
     if (metrics && typeof metrics === 'object' && !Array.isArray(metrics)) {
-      const collectionEnabled = (metrics as Record<string, unknown>).collectionEnabled;
-      if (collectionEnabled !== undefined) {
+      const metricConfig = metrics as Record<string, unknown>;
+      for (const field of [
+        'collectionEnabled',
+        'collectionIntervalMs',
+        'storeCollectionIntervalMs',
+      ] as const) {
+        if (metricConfig[field] === undefined) continue;
         try {
           resolveMetricsCollectorConfig({
-            telemetry: { metrics: { collectionEnabled } },
+            telemetry: { metrics: { [field]: metricConfig[field] } },
           } as unknown as Pick<DkgConfig, 'telemetry'>, {});
         } catch (err) {
           findings.push({
             check: 'config-sanity',
             severity: 'error',
             message: err instanceof Error ? err.message : String(err),
-            advisory: 'Set telemetry.metrics.collectionEnabled to true or false.',
-            subject: 'telemetry.metrics.collectionEnabled',
+            advisory:
+              field === 'collectionEnabled'
+                ? 'Set telemetry.metrics.collectionEnabled to true or false.'
+                : 'Use an integer from 1000 through 2147483647 milliseconds.',
+            subject: `telemetry.metrics.${field}`,
           });
         }
       }

--- a/packages/cli/src/metrics-collector-config.ts
+++ b/packages/cli/src/metrics-collector-config.ts
@@ -1,7 +1,17 @@
 import type { DkgConfig } from './config.js';
 
+// Kept in sync with @origintrail-official/dkg-node-ui's constructor guard.
+// This resolver lives in the CLI package so config errors are reported before
+// daemon lifecycle constructs the collector.
+export const DEFAULT_METRICS_COLLECTION_INTERVAL_MS = 30_000;
+export const DEFAULT_STORE_METRICS_COLLECTION_INTERVAL_MS = 43_200_000;
+export const MIN_METRICS_COLLECTION_INTERVAL_MS = 1_000;
+export const MAX_METRICS_COLLECTION_INTERVAL_MS = 2_147_483_647;
+
 export interface ResolvedMetricsCollectorConfig {
   enabled: boolean;
+  collectionIntervalMs: number;
+  storeCollectionIntervalMs: number;
 }
 
 function resolveEnabled(configValue: unknown, envValue: string | undefined): boolean {
@@ -24,27 +34,71 @@ function resolveEnabled(configValue: unknown, envValue: string | undefined): boo
   return configValue;
 }
 
+function resolveInterval(
+  field: string,
+  envName: string,
+  envValue: string | undefined,
+  configValue: unknown,
+  defaultValue: number,
+): number {
+  const candidate = envValue !== undefined ? Number(envValue) : (configValue ?? defaultValue);
+  if (
+    typeof candidate !== 'number' ||
+    !Number.isFinite(candidate) ||
+    !Number.isInteger(candidate) ||
+    candidate < MIN_METRICS_COLLECTION_INTERVAL_MS ||
+    candidate > MAX_METRICS_COLLECTION_INTERVAL_MS
+  ) {
+    const source = envValue !== undefined ? envName : field;
+    throw new Error(
+      `${source}: ${field} must be a finite integer between ` +
+      `${MIN_METRICS_COLLECTION_INTERVAL_MS} and ${MAX_METRICS_COLLECTION_INTERVAL_MS} ms ` +
+      `(received ${String(candidate)})`,
+    );
+  }
+  return candidate;
+}
+
 /**
  * Resolve local Node UI snapshot collection independently from OTLP export.
- * The dedicated environment variable wins over config; invalid values fail
- * startup rather than silently enabling collection.
+ * Dedicated DKG_* environment variables win over config values; invalid env
+ * values fail startup rather than silently falling back to config.
  */
 export function resolveMetricsCollectorConfig(
   config: Pick<DkgConfig, 'telemetry'> | null | undefined,
   env: Record<string, string | undefined> = process.env,
 ): ResolvedMetricsCollectorConfig {
+  const metrics = config?.telemetry?.metrics;
   return {
     enabled: resolveEnabled(
-      config?.telemetry?.metrics?.collectionEnabled,
+      metrics?.collectionEnabled,
       env.DKG_METRICS_COLLECTION_ENABLED,
+    ),
+    collectionIntervalMs: resolveInterval(
+      'telemetry.metrics.collectionIntervalMs',
+      'DKG_METRICS_COLLECTION_INTERVAL_MS',
+      env.DKG_METRICS_COLLECTION_INTERVAL_MS,
+      metrics?.collectionIntervalMs,
+      DEFAULT_METRICS_COLLECTION_INTERVAL_MS,
+    ),
+    storeCollectionIntervalMs: resolveInterval(
+      'telemetry.metrics.storeCollectionIntervalMs',
+      'DKG_STORE_METRICS_COLLECTION_INTERVAL_MS',
+      env.DKG_STORE_METRICS_COLLECTION_INTERVAL_MS,
+      metrics?.storeCollectionIntervalMs,
+      DEFAULT_STORE_METRICS_COLLECTION_INTERVAL_MS,
     ),
   };
 }
 
+/** Startup line used by daemon lifecycle and pinned by unit tests. */
 export function formatMetricsCollectorStartupLog(
   resolved: ResolvedMetricsCollectorConfig,
 ): string {
-  return resolved.enabled
-    ? 'Metrics collector started (30s interval)'
-    : 'Metrics collector disabled';
+  if (!resolved.enabled) return 'Metrics collector disabled';
+  return (
+    'Metrics collector started ' +
+    `(systemIntervalMs=${resolved.collectionIntervalMs}, ` +
+    `storeIntervalMs=${resolved.storeCollectionIntervalMs}, immediateInitialCollection=true)`
+  );
 }

--- a/packages/cli/test/dkg-doctor.test.ts
+++ b/packages/cli/test/dkg-doctor.test.ts
@@ -400,11 +400,17 @@ describe('config-sanity check (§4.7.2)', () => {
     expect(findings.find((f) => f.subject === 'apiPort' && f.severity === 'error')).toBeDefined();
   });
 
-  it('rejects invalid local metrics collector toggle types', async () => {
+  it('rejects invalid local metrics collector intervals and toggle types', async () => {
     const deps = makeDeps({
       fs: {
         '/test/.dkg/config.json': JSON.stringify({
-          telemetry: { metrics: { collectionEnabled: 'yes' } },
+          telemetry: {
+            metrics: {
+              collectionEnabled: 'yes',
+              collectionIntervalMs: 0,
+              storeCollectionIntervalMs: 2_147_483_648,
+            },
+          },
         }),
       },
     });
@@ -412,20 +418,30 @@ describe('config-sanity check (§4.7.2)', () => {
     expect(findings.find((f) =>
       f.subject === 'telemetry.metrics.collectionEnabled' && f.severity === 'error',
     )).toBeDefined();
+    expect(findings.find((f) =>
+      f.subject === 'telemetry.metrics.collectionIntervalMs' && f.severity === 'error',
+    )).toBeDefined();
+    expect(findings.find((f) =>
+      f.subject === 'telemetry.metrics.storeCollectionIntervalMs' && f.severity === 'error',
+    )).toBeDefined();
   });
 
-  it('accepts a boolean local metrics collector toggle', async () => {
+  it('accepts the documented 30-second and 12-hour collector cadences', async () => {
     const deps = makeDeps({
       fs: {
         '/test/.dkg/config.json': JSON.stringify({
-          telemetry: { metrics: { collectionEnabled: false } },
+          telemetry: {
+            metrics: {
+              collectionEnabled: true,
+              collectionIntervalMs: 30_000,
+              storeCollectionIntervalMs: 43_200_000,
+            },
+          },
         }),
       },
     });
     const findings = await runConfigSanityCheck(deps);
-    expect(findings.find((f) =>
-      f.subject === 'telemetry.metrics.collectionEnabled',
-    )).toBeUndefined();
+    expect(findings.filter((f) => f.subject?.startsWith('telemetry.metrics.'))).toEqual([]);
   });
 
   it('warns on deprecated autoUpdate fields set to non-empty values', async () => {

--- a/packages/cli/test/metrics-collector-config.test.ts
+++ b/packages/cli/test/metrics-collector-config.test.ts
@@ -5,54 +5,94 @@ import {
 } from '../src/metrics-collector-config.js';
 
 describe('resolveMetricsCollectorConfig', () => {
-  it('keeps local metric collection enabled by default', () => {
-    expect(resolveMetricsCollectorConfig(undefined, {})).toEqual({ enabled: true });
+  it('keeps the 30-second cheap default and uses the conservative 12-hour store default', () => {
+    expect(resolveMetricsCollectorConfig(undefined, {})).toEqual({
+      enabled: true,
+      collectionIntervalMs: 30_000,
+      storeCollectionIntervalMs: 43_200_000,
+    });
   });
 
-  it('disables local collection without changing OTLP metrics.enabled', () => {
+  it('accepts a configured 12-hour collection interval', () => {
     expect(resolveMetricsCollectorConfig({
-      telemetry: { metrics: { enabled: true, collectionEnabled: false } },
-    }, {})).toEqual({ enabled: false });
+      telemetry: { metrics: { collectionIntervalMs: 43_200_000 } },
+    }, {}).collectionIntervalMs).toBe(43_200_000);
+  });
+
+  it('environment overrides take precedence over config', () => {
+    const resolved = resolveMetricsCollectorConfig({
+      telemetry: {
+        metrics: {
+          collectionEnabled: false,
+          collectionIntervalMs: 60_000,
+          storeCollectionIntervalMs: 120_000,
+        },
+      },
+    }, {
+      DKG_METRICS_COLLECTION_ENABLED: '1',
+      DKG_METRICS_COLLECTION_INTERVAL_MS: '43200000',
+      DKG_STORE_METRICS_COLLECTION_INTERVAL_MS: '86400000',
+    });
+    expect(resolved).toEqual({
+      enabled: true,
+      collectionIntervalMs: 43_200_000,
+      storeCollectionIntervalMs: 86_400_000,
+    });
   });
 
   it.each([
-    ['1', true],
-    ['true', true],
-    ['0', false],
-    ['false', false],
-  ])('accepts environment toggle %j', (value, enabled) => {
-    expect(resolveMetricsCollectorConfig(undefined, {
-      DKG_METRICS_COLLECTION_ENABLED: value,
-    })).toEqual({ enabled });
-  });
-
-  it('gives the environment override precedence over config', () => {
-    expect(resolveMetricsCollectorConfig({
-      telemetry: { metrics: { collectionEnabled: false } },
-    }, { DKG_METRICS_COLLECTION_ENABLED: '1' })).toEqual({ enabled: true });
-  });
-
-  it('rejects invalid environment values', () => {
-    expect(() => resolveMetricsCollectorConfig(undefined, {
-      DKG_METRICS_COLLECTION_ENABLED: 'yes',
-    })).toThrow(/DKG_METRICS_COLLECTION_ENABLED/);
-  });
-
-  it('rejects non-boolean config values', () => {
+    ['zero', 0],
+    ['negative', -1],
+    ['fractional', 30_000.5],
+    ['NaN', Number.NaN],
+    ['infinite', Number.POSITIVE_INFINITY],
+    ['below the safe minimum', 999],
+    ['above the Node timer maximum', 2_147_483_648],
+  ])('rejects %s config intervals', (_label, value) => {
     expect(() => resolveMetricsCollectorConfig({
-      telemetry: { metrics: { collectionEnabled: 'yes' } },
-    } as never, {})).toThrow(/telemetry\.metrics\.collectionEnabled/);
+      telemetry: { metrics: { collectionIntervalMs: value } },
+    }, {})).toThrow(/telemetry\.metrics\.collectionIntervalMs/);
+  });
+
+  it.each(['0', '-1', '1.5', 'NaN', 'Infinity', '999', '2147483648', ''])
+    ('rejects invalid environment interval %j without falling back to config', value => {
+      expect(() => resolveMetricsCollectorConfig({
+        telemetry: { metrics: { collectionIntervalMs: 60_000 } },
+      }, { DKG_METRICS_COLLECTION_INTERVAL_MS: value })).toThrow(
+        /DKG_METRICS_COLLECTION_INTERVAL_MS/,
+      );
+    });
+
+  it('validates the independently configured store interval', () => {
+    expect(() => resolveMetricsCollectorConfig({
+      telemetry: { metrics: { storeCollectionIntervalMs: Number.NaN } },
+    }, {})).toThrow(/telemetry\.metrics\.storeCollectionIntervalMs/);
+  });
+
+  it('supports the local collection toggle without changing OTLP metrics.enabled', () => {
+    expect(resolveMetricsCollectorConfig({
+      telemetry: { metrics: { enabled: true, collectionEnabled: false } },
+    }, {}).enabled).toBe(false);
   });
 });
 
 describe('formatMetricsCollectorStartupLog', () => {
-  it('preserves the enabled startup log', () => {
-    expect(formatMetricsCollectorStartupLog({ enabled: true }))
-      .toBe('Metrics collector started (30s interval)');
+  it('reports the actual resolved system and store intervals', () => {
+    expect(formatMetricsCollectorStartupLog({
+      enabled: true,
+      collectionIntervalMs: 60_000,
+      storeCollectionIntervalMs: 43_200_000,
+    })).toBe(
+      'Metrics collector started ' +
+      '(systemIntervalMs=60000, storeIntervalMs=43200000, immediateInitialCollection=true)',
+    );
   });
 
   it('reports when local collection is disabled', () => {
-    expect(formatMetricsCollectorStartupLog({ enabled: false }))
-      .toBe('Metrics collector disabled');
+    expect(formatMetricsCollectorStartupLog({
+      enabled: false,
+      collectionIntervalMs: 30_000,
+      storeCollectionIntervalMs: 43_200_000,
+    })).toBe('Metrics collector disabled');
   });
 });

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -11,8 +11,8 @@ import {
 } from '../src/daemon/metrics-queries.js';
 
 // Guards the shared COUNT parser the daemon's metric getters depend on. The
-// getters themselves are intentionally uncached (metricsSource is consumed only
-// by the 30s MetricsCollector tick, so each snapshot re-reads the store fresh).
+// getters themselves are intentionally uncached: MetricsCollector owns the
+// independently configured store cadence and serializes each actual scan.
 describe('parseRdfInt', () => {
   it('parses RDF typed-integer literals and bare numbers, defaulting to 0', () => {
     expect(parseRdfInt('"1000"^^<http://www.w3.org/2001/XMLSchema#integer>')).toBe(1000);

--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -116,9 +116,10 @@ export async function handleNodeUIRequest(
     // Serve the latest tick-written snapshot rather than live-collecting.
     // A live collect() re-runs the full-store COUNT scans on every request, so
     // an external poller (Grafana / health probe) could hammer a saturated
-    // store. The periodic collector already refreshes the snapshot (effective
-    // 30s TTL) and a store outage still surfaces as null columns rather than
-    // being masked. (#1066 Item 1)
+    // store. The periodic collector refreshes cheap fields on its configured
+    // system cadence and cardinality fields on the separate store cadence; a
+    // failed scheduled scan replaces cached cardinalities with null columns.
+    // (#1066 Item 1)
     const snap = db.getLatestSnapshot();
     if (snap) return json(res, 200, snap);
     // Cold start only: no snapshot yet (before the first tick). Fall back to a

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -50,8 +50,15 @@ export type {
 
 export { StructuredLogger } from './structured-logger.js';
 export { OperationTracker } from './operation-tracker.js';
-export { MetricsCollector } from './metrics-collector.js';
-export type { MetricsSource } from './metrics-collector.js';
+export {
+  MetricsCollector,
+  DEFAULT_METRICS_COLLECTION_INTERVAL_MS,
+  DEFAULT_STORE_METRICS_COLLECTION_INTERVAL_MS,
+  MIN_METRICS_COLLECTION_INTERVAL_MS,
+  MAX_METRICS_COLLECTION_INTERVAL_MS,
+  assertMetricsCollectionIntervalMs,
+} from './metrics-collector.js';
+export type { MetricsSource, MetricsCollectorOptions } from './metrics-collector.js';
 export { handleNodeUIRequest } from './api.js';
 export { scopeNotifications, PCA_COST_COVERED_TYPE } from './notifications-scope.js';
 export type {

--- a/packages/node-ui/src/metrics-collector.ts
+++ b/packages/node-ui/src/metrics-collector.ts
@@ -50,7 +50,50 @@ export interface MetricsSource {
   getRelayStats?(): RelayStatsSnapshot | null;
 }
 
-const SNAPSHOT_INTERVAL_MS = 30_000; // 30 seconds
+/** Default cadence for cheap system/network snapshots (30 seconds). */
+export const DEFAULT_METRICS_COLLECTION_INTERVAL_MS = 30_000;
+/**
+ * Default cadence for full-store cardinality scans (12 hours). These queries
+ * can saturate large remote SPARQL stores, so they deliberately do not inherit
+ * the cheap snapshot cadence.
+ */
+export const DEFAULT_STORE_METRICS_COLLECTION_INTERVAL_MS = 43_200_000;
+/** Prevent an accidentally configured tight loop from pegging the daemon. */
+export const MIN_METRICS_COLLECTION_INTERVAL_MS = 1_000;
+/** Largest delay Node timers represent without overflowing to a ~1 ms delay. */
+export const MAX_METRICS_COLLECTION_INTERVAL_MS = 2_147_483_647;
+
+export interface MetricsCollectorOptions {
+  /** Cheap system/network snapshot cadence. Default: 30 seconds. */
+  collectionIntervalMs?: number;
+  /** Expensive full-store cardinality cadence. Default: 12 hours. */
+  storeCollectionIntervalMs?: number;
+}
+
+interface StoreMetricsSnapshot {
+  totalTriples: number | null;
+  totalKCs: number | null;
+  totalKAs: number | null;
+  confirmedKCs: number | null;
+  tentativeKCs: number | null;
+  contextGraphCount: number | null;
+}
+
+export function assertMetricsCollectionIntervalMs(value: number, field: string): number {
+  if (
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < MIN_METRICS_COLLECTION_INTERVAL_MS ||
+    value > MAX_METRICS_COLLECTION_INTERVAL_MS
+  ) {
+    throw new Error(
+      `${field} must be a finite integer between ` +
+      `${MIN_METRICS_COLLECTION_INTERVAL_MS} and ${MAX_METRICS_COLLECTION_INTERVAL_MS} ms ` +
+      `(received ${String(value)})`,
+    );
+  }
+  return value;
+}
 
 /**
  * Clamp a bigint relay byte count to a safe JS Number for SQLite storage.
@@ -70,9 +113,16 @@ function bigintToSafeNumber(v: bigint): number {
  * and stores them as snapshots in SQLite.
  */
 export class MetricsCollector {
-  private timer: ReturnType<typeof setInterval> | null = null;
+  private systemTimer: ReturnType<typeof setTimeout> | null = null;
+  private storeTimer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+  private activeStoreCollection: Promise<StoreMetricsSnapshot> | null = null;
+  private latestStoreMetrics: StoreMetricsSnapshot | null = null;
+  private initialSnapshotHandled = false;
   private prevCpuTimes: { idle: number; total: number } | null = null;
   private readonly startTime = Date.now();
+  readonly collectionIntervalMs: number;
+  readonly storeCollectionIntervalMs: number;
 
   constructor(
     private readonly db: DashboardDB,
@@ -84,16 +134,91 @@ export class MetricsCollector {
      * null. Defaults to always-collect so existing callers/tests are unchanged.
      */
     private readonly shouldCollectStoreMetrics: () => boolean = () => true,
-  ) {}
+    options: MetricsCollectorOptions = {},
+  ) {
+    this.collectionIntervalMs = assertMetricsCollectionIntervalMs(
+      options.collectionIntervalMs ?? DEFAULT_METRICS_COLLECTION_INTERVAL_MS,
+      'collectionIntervalMs',
+    );
+    this.storeCollectionIntervalMs = assertMetricsCollectionIntervalMs(
+      options.storeCollectionIntervalMs ?? DEFAULT_STORE_METRICS_COLLECTION_INTERVAL_MS,
+      'storeCollectionIntervalMs',
+    );
+  }
 
   start(): void {
-    if (this.timer) return;
-    this.collectAndStore().then(snap => {
-      this.backfillNulls(snap);
-    }).catch(() => {});
-    this.timer = setInterval(() => {
-      this.collectAndStore().catch(() => {});
-    }, SNAPSHOT_INTERVAL_MS);
+    if (this.running) return;
+    this.running = true;
+    // Start both lanes immediately. Each lane schedules its next run only
+    // after its current work settles, so neither cheap snapshots nor expensive
+    // scans can overlap with themselves. Keeping the lanes independent lets
+    // 30-second CPU/memory snapshots continue during a slow store scan.
+    void this.runSystemCollection();
+    void this.runStoreCollection();
+  }
+
+  private shouldCollectStoreMetricsSafely(): boolean {
+    try {
+      return this.shouldCollectStoreMetrics();
+    } catch {
+      return false;
+    }
+  }
+
+  private scheduleSystemCollection(): void {
+    if (!this.running) return;
+    this.systemTimer = setTimeout(() => {
+      this.systemTimer = null;
+      void this.runSystemCollection();
+    }, this.collectionIntervalMs);
+  }
+
+  private async runSystemCollection(): Promise<void> {
+    if (!this.running) return;
+    try {
+      const cachedStoreMetrics = this.shouldCollectStoreMetricsSafely()
+        ? this.latestStoreMetrics
+        : null;
+      const snap = await this.collectAndStoreInternal(false, cachedStoreMetrics);
+      if (cachedStoreMetrics && !this.initialSnapshotHandled) {
+        this.initialSnapshotHandled = true;
+        this.backfillNulls(snap);
+      }
+    } catch {
+      // Metrics are best-effort and must never stop the daemon.
+    } finally {
+      this.scheduleSystemCollection();
+    }
+  }
+
+  private scheduleStoreCollection(delayMs: number): void {
+    if (!this.running) return;
+    this.storeTimer = setTimeout(() => {
+      this.storeTimer = null;
+      void this.runStoreCollection();
+    }, delayMs);
+  }
+
+  private async runStoreCollection(): Promise<void> {
+    if (!this.running) return;
+    if (!this.shouldCollectStoreMetricsSafely()) {
+      // Keep re-evaluating the presence gate at the cheaper of the two
+      // cadences. This does not query the store, and prevents a consumer that
+      // appears just after startup from waiting 12 hours for its first scan.
+      this.scheduleStoreCollection(
+        Math.min(this.collectionIntervalMs, this.storeCollectionIntervalMs),
+      );
+      return;
+    }
+
+    try {
+      this.latestStoreMetrics = await this.collectStoreMetricsSerialized();
+    } catch {
+      // Individual source errors are already converted to null below. This is
+      // defence in depth for an unexpected collector-level failure.
+    } finally {
+      this.scheduleStoreCollection(this.storeCollectionIntervalMs);
+    }
   }
 
   private backfillNulls(snap: MetricSnapshotRow): void {
@@ -107,19 +232,38 @@ export class MetricsCollector {
   }
 
   stop(): void {
-    if (this.timer) {
-      clearInterval(this.timer);
-      this.timer = null;
+    this.running = false;
+    if (this.systemTimer) {
+      clearTimeout(this.systemTimer);
+      this.systemTimer = null;
+    }
+    if (this.storeTimer) {
+      clearTimeout(this.storeTimer);
+      this.storeTimer = null;
     }
   }
 
   async collectAndStore(): Promise<MetricSnapshotRow> {
-    const snap = await this.collect();
+    return this.collectAndStoreInternal(this.shouldCollectStoreMetricsSafely());
+  }
+
+  private async collectAndStoreInternal(
+    includeStoreMetrics: boolean,
+    cachedStoreMetrics: StoreMetricsSnapshot | null = null,
+  ): Promise<MetricSnapshotRow> {
+    const snap = await this.collectInternal(includeStoreMetrics, cachedStoreMetrics);
     this.db.insertSnapshot(snap);
     return snap;
   }
 
   async collect(): Promise<MetricSnapshotRow> {
+    return this.collectInternal(this.shouldCollectStoreMetricsSafely());
+  }
+
+  private async collectInternal(
+    includeStoreMetrics: boolean,
+    cachedStoreMetrics: StoreMetricsSnapshot | null = null,
+  ): Promise<MetricSnapshotRow> {
     const cpuPercent = this.measureCpu();
     const mem = memoryUsage();
     const heap = mem.heapUsed;
@@ -147,12 +291,14 @@ export class MetricsCollector {
       rpcHealthy = (await this.source.isRpcHealthy()) ? 1 : 0;
     } catch { /* ignore */ }
 
-    let totalTriples: number | null = null;
-    let totalKCs: number | null = null;
-    let totalKAs: number | null = null;
-    let confirmedKCs: number | null = null;
-    let tentativeKCs: number | null = null;
-    let contextGraphCount: number | null = null;
+    let storeMetrics = cachedStoreMetrics ?? {
+      totalTriples: null,
+      totalKCs: null,
+      totalKAs: null,
+      confirmedKCs: null,
+      tentativeKCs: null,
+      contextGraphCount: null,
+    };
 
     // These six getters are full-store SPARQL scans (COUNT / COUNT(DISTINCT)
     // across every graph, plus the context-graph inventory) — the expensive
@@ -160,13 +306,8 @@ export class MetricsCollector {
     // columns null (already nullable; charts render the gap). The cheap
     // system/network metrics above always collect, so a CPU peg is still
     // recorded even while no dashboard is open. (#1066 Item 1)
-    if (this.shouldCollectStoreMetrics()) {
-      try { totalTriples = await this.source.getTotalTriples(); } catch { /* ignore */ }
-      try { totalKCs = await this.source.getTotalKCs(); } catch { /* ignore */ }
-      try { totalKAs = await this.source.getTotalKAs(); } catch { /* ignore */ }
-      try { confirmedKCs = await this.source.getConfirmedKCs(); } catch { /* ignore */ }
-      try { tentativeKCs = await this.source.getTentativeKCs(); } catch { /* ignore */ }
-      try { contextGraphCount = await this.source.getContextGraphCount(); } catch { /* ignore */ }
+    if (includeStoreMetrics) {
+      storeMetrics = await this.collectStoreMetricsSerialized();
     }
 
     let relayCapacity: number | null = null;
@@ -206,13 +347,13 @@ export class MetricsCollector {
       direct_peers: this.source.getDirectPeerCount(),
       relayed_peers: this.source.getRelayedPeerCount(),
       mesh_peers: this.source.getMeshPeerCount(),
-      contextGraph_count: contextGraphCount,
-      total_triples: totalTriples,
-      total_kcs: totalKCs,
-      total_kas: totalKAs,
+      contextGraph_count: storeMetrics.contextGraphCount,
+      total_triples: storeMetrics.totalTriples,
+      total_kcs: storeMetrics.totalKCs,
+      total_kas: storeMetrics.totalKAs,
       store_bytes: storeBytes,
-      confirmed_kcs: confirmedKCs,
-      tentative_kcs: tentativeKCs,
+      confirmed_kcs: storeMetrics.confirmedKCs,
+      tentative_kcs: storeMetrics.tentativeKCs,
       rpc_latency_ms: rpcLatency,
       rpc_healthy: rpcHealthy,
       relay_capacity: relayCapacity,
@@ -220,6 +361,39 @@ export class MetricsCollector {
       relay_active_circuits: relayActiveCircuits,
       relay_bytes_in: relayBytesIn,
       relay_bytes_out: relayBytesOut,
+    };
+  }
+
+  private collectStoreMetricsSerialized(): Promise<StoreMetricsSnapshot> {
+    if (this.activeStoreCollection) return this.activeStoreCollection;
+    const collection = this.collectStoreMetrics();
+    this.activeStoreCollection = collection;
+    void collection.finally(() => {
+      if (this.activeStoreCollection === collection) this.activeStoreCollection = null;
+    });
+    return collection;
+  }
+
+  private async collectStoreMetrics(): Promise<StoreMetricsSnapshot> {
+    let totalTriples: number | null = null;
+    let totalKCs: number | null = null;
+    let totalKAs: number | null = null;
+    let confirmedKCs: number | null = null;
+    let tentativeKCs: number | null = null;
+    let contextGraphCount: number | null = null;
+    try { totalTriples = await this.source.getTotalTriples(); } catch { /* ignore */ }
+    try { totalKCs = await this.source.getTotalKCs(); } catch { /* ignore */ }
+    try { totalKAs = await this.source.getTotalKAs(); } catch { /* ignore */ }
+    try { confirmedKCs = await this.source.getConfirmedKCs(); } catch { /* ignore */ }
+    try { tentativeKCs = await this.source.getTentativeKCs(); } catch { /* ignore */ }
+    try { contextGraphCount = await this.source.getContextGraphCount(); } catch { /* ignore */ }
+    return {
+      totalTriples,
+      totalKCs,
+      totalKAs,
+      confirmedKCs,
+      tentativeKCs,
+      contextGraphCount,
     };
   }
 

--- a/packages/node-ui/test/metrics-collector.test.ts
+++ b/packages/node-ui/test/metrics-collector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -38,6 +38,12 @@ afterEach(() => {
 });
 
 describe('MetricsCollector', () => {
+  it('uses the supported 30-second system and 12-hour store defaults', () => {
+    const collector = new MetricsCollector(db, mockSource(), dir);
+    expect(collector.collectionIntervalMs).toBe(30_000);
+    expect(collector.storeCollectionIntervalMs).toBe(43_200_000);
+  });
+
   it('collects a snapshot with all metrics', async () => {
     const collector = new MetricsCollector(db, mockSource(), dir);
     const snap = await collector.collect();
@@ -114,25 +120,17 @@ describe('MetricsCollector', () => {
     collector.stop();
   });
 
-  it('start is idempotent — a second start() does not allocate a second interval', () => {
-    const collector = new MetricsCollector(db, mockSource(), dir);
-
-    // Peek at the private timer handle through a narrow cast. Re-entrant
-    // start() calls previously had no observable check; a regression that
-    // fires `setInterval` twice would leak the first handle and silently
-    // double the DB write rate. Comparing the timer reference before and
-    // after the second start() locks in the "no second interval" contract.
-    const internal = collector as unknown as { timer: ReturnType<typeof setInterval> | null };
-
+  it('start is idempotent — a second start() does not launch another initial collection', async () => {
+    let calls = 0;
+    const collector = new MetricsCollector(db, mockSource({
+      getStoreBytes: async () => { calls++; return 65_536; },
+    }), dir);
     collector.start();
-    const firstTimer = internal.timer;
-    expect(firstTimer).not.toBeNull();
-
     collector.start();
-    expect(internal.timer).toBe(firstTimer);
+    await new Promise(r => setTimeout(r, 100));
+    expect(calls).toBe(1);
 
     collector.stop();
-    expect(internal.timer).toBeNull();
   });
 
   it('cpu measurement returns 0 on first call (no baseline)', async () => {
@@ -269,6 +267,230 @@ describe('MetricsCollector', () => {
       expect(snap.relay_capacity).toBeNull();
       expect(snap.relay_bytes_in).toBeNull();
     });
+  });
+});
+
+describe('MetricsCollector scheduling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs the initial collection immediately, before an interval elapses', async () => {
+    let calls = 0;
+    const collector = new MetricsCollector(
+      db,
+      mockSource({ getStoreBytes: async () => { calls++; return 65_536; } }),
+      undefined,
+      () => true,
+      { collectionIntervalMs: 1_000, storeCollectionIntervalMs: 5_000 },
+    );
+
+    collector.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(calls).toBe(1);
+    expect(db.getLatestSnapshot()).toBeDefined();
+    collector.stop();
+  });
+
+  it('keeps cheap snapshots frequent while store scans use their slower cadence', async () => {
+    let cheapCalls = 0;
+    let storeCalls = 0;
+    const collector = new MetricsCollector(
+      db,
+      mockSource({
+        getPeerCount: () => { cheapCalls++; return 5; },
+        getTotalTriples: async () => { storeCalls++; return 1_000; },
+      }),
+      undefined,
+      () => true,
+      { collectionIntervalMs: 1_000, storeCollectionIntervalMs: 5_000 },
+    );
+
+    collector.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(storeCalls).toBe(1); // documented immediate startup attempt
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(cheapCalls).toBe(5);
+    expect(storeCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(cheapCalls).toBe(6);
+    expect(storeCalls).toBe(2);
+    collector.stop();
+  });
+
+  it('honors a 12-hour store interval after the documented initial scan', async () => {
+    let storeCalls = 0;
+    const twelveHours = 43_200_000;
+    const collector = new MetricsCollector(
+      db,
+      mockSource({
+        getTotalTriples: async () => { storeCalls++; return 1_000; },
+      }),
+      undefined,
+      () => true,
+      { collectionIntervalMs: twelveHours, storeCollectionIntervalMs: twelveHours },
+    );
+
+    collector.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(storeCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(twelveHours - 1);
+    expect(storeCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(storeCalls).toBe(2);
+    collector.stop();
+  });
+
+  it('never overlaps collection when a tick takes longer than its interval', async () => {
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    const releases: Array<() => void> = [];
+    const collector = new MetricsCollector(
+      db,
+      mockSource({
+        getStoreBytes: async () => {
+          calls++;
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise<void>(resolve => releases.push(resolve));
+          active--;
+          return 65_536;
+        },
+      }),
+      undefined,
+      () => true,
+      { collectionIntervalMs: 1_000, storeCollectionIntervalMs: 1_000 },
+    );
+
+    collector.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls).toBe(1);
+    expect(maxActive).toBe(1);
+
+    releases.shift()?.();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(calls).toBe(2);
+    expect(maxActive).toBe(1);
+
+    collector.stop();
+    releases.shift()?.();
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it('continues cheap snapshots while a slow store scan remains serialized', async () => {
+    let cheapCalls = 0;
+    let storeCalls = 0;
+    let activeStoreCalls = 0;
+    let maxActiveStoreCalls = 0;
+    const releases: Array<() => void> = [];
+    const collector = new MetricsCollector(
+      db,
+      mockSource({
+        getPeerCount: () => { cheapCalls++; return 5; },
+        getTotalTriples: async () => {
+          storeCalls++;
+          activeStoreCalls++;
+          maxActiveStoreCalls = Math.max(maxActiveStoreCalls, activeStoreCalls);
+          await new Promise<void>(resolve => releases.push(resolve));
+          activeStoreCalls--;
+          return 1_000;
+        },
+      }),
+      undefined,
+      () => true,
+      { collectionIntervalMs: 1_000, storeCollectionIntervalMs: 1_000 },
+    );
+
+    collector.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(storeCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(cheapCalls).toBe(6); // immediate + five one-second system ticks
+    expect(storeCalls).toBe(1);
+    expect(maxActiveStoreCalls).toBe(1);
+
+    releases.shift()?.();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(storeCalls).toBe(2);
+    expect(maxActiveStoreCalls).toBe(1);
+
+    collector.stop();
+    releases.shift()?.();
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it('stop during an active collection prevents every future tick', async () => {
+    let calls = 0;
+    let release!: () => void;
+    const collector = new MetricsCollector(
+      db,
+      mockSource({
+        getStoreBytes: async () => {
+          calls++;
+          await new Promise<void>(resolve => { release = resolve; });
+          return 65_536;
+        },
+      }),
+      undefined,
+      () => true,
+      { collectionIntervalMs: 1_000, storeCollectionIntervalMs: 1_000 },
+    );
+
+    collector.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toBe(1);
+
+    collector.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    release();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(calls).toBe(1);
+    const internal = collector as unknown as {
+      systemTimer: ReturnType<typeof setTimeout> | null;
+      storeTimer: ReturnType<typeof setTimeout> | null;
+    };
+    expect(internal.systemTimer).toBeNull();
+    expect(internal.storeTimer).toBeNull();
+  });
+
+  it('keeps probing the presence gate cheaply and scans when a consumer appears', async () => {
+    let watching = false;
+    let storeCalls = 0;
+    const collector = new MetricsCollector(
+      db,
+      mockSource({
+        getTotalTriples: async () => { storeCalls++; return 1_000; },
+      }),
+      undefined,
+      () => watching,
+      { collectionIntervalMs: 1_000, storeCollectionIntervalMs: 5_000 },
+    );
+
+    collector.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(storeCalls).toBe(0);
+
+    watching = true;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(storeCalls).toBe(1);
+    collector.stop();
   });
 });
 

--- a/tools/observability/RUNBOOK.md
+++ b/tools/observability/RUNBOOK.md
@@ -116,10 +116,11 @@ Restart the node. Local logging (SQLite + daemon.log) is unaffected; this only a
 
 **Logs vs traces/metrics (different transports, same endpoint host):** logs ship via a hand-rolled **OTLP/HTTP JSON** exporter (the OTel Logs SDK is still "Development"), while **traces and metrics use the stable OTel SDK** OTLP/protobuf exporters. The polaris setup today only has a **logs** backend (Loki via Alloy), so leave `telemetry.traces`/`telemetry.metrics` out (or set `enabled: false`) until a traces backend (Tempo) and metrics backend (Mimir/Prometheus) are provisioned — the `node-config.example.json` shows the full three-signal shape and `config.alloy` has the matching commented routing.
 
-The local Node UI metrics collector is independent of OTLP export. Set
-`telemetry.metrics.collectionEnabled` to `false` to disable local SQLite
-snapshots and store scans without changing OTLP settings. See the
-[Node UI metrics operator guide](../../docs/use-dkg/node-ui-metrics.md).
+The local Node UI metrics collector is independent of OTLP export. Its
+`collectionEnabled`, `collectionIntervalMs`, and `storeCollectionIntervalMs`
+settings still apply when `telemetry.metrics.enabled` is false. See the
+[Node UI metrics operator guide](../../docs/use-dkg/node-ui-metrics.md) before
+changing full-store scan cadence on Blazegraph nodes.
 
 ## Step 4 — view in Grafana
 - **Per-node:** `https://polaris.xtrmstrngth.com/d/dkg-node-logs` → pick a **Node** → set the time range (top-right) → logs appear. `Level` and `Filter (regex)` narrow further; the bottom panel is volume-by-level.

--- a/tools/observability/node-config.example.json
+++ b/tools/observability/node-config.example.json
@@ -3,7 +3,7 @@
 
   "_comment_signals": "Three independent signals. LOGS use a hand-rolled OTLP/HTTP JSON exporter (the OTel Logs SDK is still 'Development'); set logs.exporter to 'otlp' — if you leave it unset on a hosted node it defaults to legacy syslog/Graylog, NOT OTLP. TRACES and METRICS use the stable OTel SDK exporters (OTLP/protobuf). IMPORTANT: the polaris backend today is LOGS-ONLY (Alloy → Loki; no Tempo for traces, no Prometheus/Mimir for metrics). So traces/metrics are shown here with enabled:false — they will NOT export until you (a) stand up a traces/metrics backend, (b) point config.alloy at it (see its FULL-SIGNAL section), and (c) flip enabled:true. Pointing them at the logs-only ingest host while enabled would just send spans/metrics into a void.",
 
-  "_comment_local_metrics": "metrics.enabled/exportIntervalMs control OTLP export. collectionEnabled independently controls local Node UI SQLite snapshots and store scans.",
+  "_comment_local_metrics": "metrics.enabled/exportIntervalMs control OTLP export. collectionEnabled/collectionIntervalMs/storeCollectionIntervalMs independently control local Node UI SQLite snapshots. Keep cheap system metrics at 30s and full-store SPARQL scans at 12h on large stores.",
 
   "name": "testnet-core-01",
 
@@ -26,7 +26,9 @@
       "endpoint": "https://metrics-ingest.example.com/v1/metrics",
       "token": "<INGEST_TOKEN>",
       "exportIntervalMs": 30000,
-      "collectionEnabled": true
+      "collectionEnabled": true,
+      "collectionIntervalMs": 30000,
+      "storeCollectionIntervalMs": 43200000
     }
   }
 }


### PR DESCRIPTION
## Depends on

- #1892 — adds the minimal local collector enable/disable toggle

This PR is stacked on #1892. Its review diff contains only interval configuration and the cheap-system versus expensive-store scheduling split.

## Summary

- add `telemetry.metrics.collectionIntervalMs` for cheap CPU, memory, process, peer, RPC, and relay snapshots
- add `telemetry.metrics.storeCollectionIntervalMs` for expensive full-store SPARQL cardinality scans
- add environment overrides with environment-over-config precedence
- retain a 30-second default for cheap snapshots and use a conservative 12-hour default for store scans
- replace interval scheduling with completion-relative `setTimeout` loops so a collection never overlaps with itself
- keep cheap snapshots running while a slow store scan is active
- preserve the immediate gated startup attempt, metrics-presence gate, and `DKG_METRICS_ALWAYS_COLLECT=1`
- report the resolved system and store intervals in startup logs

## Configuration

| Setting | Environment override | Default |
| --- | --- | --- |
| `telemetry.metrics.collectionIntervalMs` | `DKG_METRICS_COLLECTION_INTERVAL_MS` | `30000` |
| `telemetry.metrics.storeCollectionIntervalMs` | `DKG_STORE_METRICS_COLLECTION_INTERVAL_MS` | `43200000` |

Intervals must be finite positive integers between 1,000ms and Node's maximum safe timer delay of 2,147,483,647ms. These local collector settings remain independent of OpenTelemetry `exportIntervalMs`.

## Why

The existing 30-second collector tick includes several global SPARQL `COUNT` scans. On large Blazegraph stores, those scans can consume most available CPU, outlive the interval, congest the query queue, and cause store-scheduler timeouts.

The independent store cadence preserves useful 30-second operational dashboards without repeatedly scanning the full RDF store.

## Compatibility

Cheap metrics retain their 30-second default cadence. The intentional behavior change is that expensive store scans default to 12 hours. Operators that require the legacy store cadence can set `telemetry.metrics.storeCollectionIntervalMs` to `30000`.

With `DKG_STORE_METRICS_COLLECTION_INTERVAL_MS=43200000`, the collector makes one gated startup attempt and schedules no subsequent expensive scan until at least 12 hours after that scan finishes.

## Validation

- MetricsCollector scheduling and presence tests: 25 passed
- focused CLI configuration, doctor, presence, and query tests: 90 passed
- Node UI package build passed
- CLI TypeScript `tsc --noEmit` passed
- `git diff --check` passed
