### PR TITLE
chore(release): bump to 10.0.9 + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [Unreleased]
 
+## [10.0.9] - 2026-07-21
+
+Public Context Graphs work fully: any agent can reliably sync both SWM and VM, including late joiners and Context Graphs whose operation history exceeds the previous snapshot ceiling. This release consolidates the testnet-canary line previously rolled out to nodes by branch ref, plus the fifa-class metadata ceiling fix, validated by a devnet hold-out proof (a node absent during publication reconstructs the full corpus with per-graph digest verification) and by the testnet fleet. **No smart-contract changes — no deployment required** (no Solidity source or ABI changes since 10.0.7).
+
+### Fixed
+
+- **SWM meta sync past the 64,000-row snapshot ceiling** (#1847, #1880): TTL-filtered meta is now served through a bounded session plan instead of a raw snapshot cut off at the store's 64,000-row window, with per-subject count and sha-256 digest verification binding every page. Context Graphs with long operation histories (e.g. `fifa-world-cup-2026`) sync completely instead of silently refusing.
+- **Exact-batch VM reconciliation** (#1871, #1876): chain-driven VM reconciliation fetches exactly the missing assets in bounded batches (wire-capped, with recovery damping) instead of full-graph passes, and three reconcile race/boundary conditions are closed.
+- **Public CG catch-up materializes verified snapshots** (#1842): late-joining subscribers materialize verified public snapshots into the store under the same per-KA write lock live gossip uses, with in-lock version ordering and digest-bound skip guards — content arrives, not just metadata.
+- **Plaintext SWM accepted on public agent-gated CGs** (#1843, #1852, #1853): sender and receiver now agree on the encryption requirement for public/curated Context Graphs (requires-encryption split from supports-encryption), and the on-chain public-access probe is evaluated lazily so ungated receives stay off the chain-RPC hot path.
+- **Curator can VM-publish a member-shared rootless KA** (#1780): author resolution from finalized-assertion seals, fail-closed on conflicting or mismatched seals.
+- **Markdown KA entities preserved across SWM sharing** (#1779).
+- **Public CG metadata projection and subscription catch-up** (#1848, #1866, #1885): member-proof required for private meta refresh, public meta projection corrected, CG-hash fallback fixed.
+- **Broadcast durability** (#1851): the pre-send broadcast record is fsynced before the transaction is sent, preventing crash-recovery double-submit.
+
+### Added
+
+- **Append-only admission & transaction journal** (#1829, #1875): every VM-publish lifecycle transition is journaled node-locally (seq-ordered, gap-detectable) and readable via `GET /api/publisher/journal` by job or by lifecycle facts. Recorded tx hashes are attempted submissions — reconcile against chain.
+- **Durable-admission recovery lookup** (#1828, #1849): `GET /api/publisher/job-by-intent` recovers an admitted async VM-publish job from client-retained facts after a lost 202 response.
+- **Public CG SWM+VM sync proof harness** (#1844): `devnet/public-cg-sync-proof/` — the end-to-end gate (exact content counts, arm's-length receivers, hold-out reconstruction) used to validate this release.
+- **Node UI local metrics collection toggle** (#1892).
+
+### Changed
+
+- **Outbox metadata cleanup** (#1646): metadata capability is explicit and payload-free at the store boundary; diagnostics no longer load payloads.
+
+### Known issues
+
+- Recovery/journal lookups for a curator-published member KA require an explicit `agentAddress=<member>` query parameter (the omitted-parameter default resolves to the caller); fix queued.
+- The chain-reconcile watermark counter can trail the chain head on provenance-fenced entries; cosmetic — durable sync delivers the content and the counter is not a health signal.
+
 ## [10.0.8] - 2026-07-17
 
 Durable-sync materialization hardening for large private Context Graphs. This release makes durable catch-up survive transport drops, responder restarts, and multi-million-quad snapshots without discarding verified work, and fixes the relay and dial paths that stalled fan-out under load. Validated by a 500-Knowledge-Asset private-CG late-join scale test on Gnosis mainnet (5,337,721 unique quads, exact per-graph digest verification). **No smart-contract changes — no deployment required** (no Solidity source, ABI, or deployment-registry changes since 10.0.7).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rdf-utils/package.json
+++ b/packages/rdf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-rdf-utils",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Lockstep version bump 10.0.8 → 10.0.9 (root + all 20 `packages/*`, version-only — lockfile untouched) plus the 10.0.9 CHANGELOG section, per RELEASE_PROCESS.md §3.

This stamps 10.0.9 properly: the earlier "10.0.9" rollout went to nodes by branch ref from testnet-canary and was never tagged, stamped, or published to npm — this release is its consolidated, npm-published form (same line plus the #1880 fifa-class meta ceiling fix and the #1875 journal).

`pnpm release:verify-versions --version 10.0.9`: 21 package.json files at 10.0.9 ✅. Contract surface unchanged since 10.0.7 (no Solidity/ABI changes — the only `evm-module` delta in the promoted line was localhost dev-registry metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)