### PR TITLE
fix(sync): preserve incomplete durable catchup progress

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -265,7 +265,7 @@ import {
   durableSyncAccumulatorFromResult,
   finalizeDurableSyncCompletion,
   markDurableTerminalBoundary,
-  mergeDurableSyncAccumulators,
+  mergeDurableSyncAccumulatorInto,
   mergeDurableSyncResultIntoAccumulator,
   type DurableSyncAccumulator,
 } from './sync/durable-progress.js';
@@ -4018,10 +4018,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ctx, remotePeerId, legacyContextGraphIds, onPhase, onAccessDenied, sinceBatchIdFor, options,
     );
     if (!changelogResult) return legacyResult;
-    return finalizeDurableSyncCompletion(mergeDurableSyncAccumulators(
-      durableSyncAccumulatorFromResult(changelogResult),
+    const accumulator = durableSyncAccumulatorFromResult(changelogResult);
+    mergeDurableSyncAccumulatorInto(
+      accumulator,
       durableSyncAccumulatorFromResult(legacyResult),
-    ));
+    );
+    return finalizeDurableSyncCompletion(accumulator);
   }
 
   /**
@@ -4083,7 +4085,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           options?.priority,
         ),
       ),
-      merge: mergeDurableSyncAccumulators,
+      merge: mergeDurableSyncAccumulatorInto,
       markDeferred: (summary) => {
         summary.diagnostics.deferredBackpressure += 1;
         return markDurableTerminalBoundary(summary, false);
@@ -4319,7 +4321,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         item.operationId,
         run,
       ),
-      merge: mergeDurableSyncAccumulators,
+      merge: mergeDurableSyncAccumulatorInto,
       markDeferred: (summary) => {
         summary.diagnostics.deferredBackpressure += 1;
         return markDurableTerminalBoundary(summary, false);
@@ -4353,7 +4355,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let insertedDataTriples = 0;
     let insertedMetaTriples = 0;
     const accumulator = createDurableSyncAccumulator();
-    const result = accumulator.diagnostics; // folds every resync's legacy diagnostics
     const acceptUnverified = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId);
     const cgDataUri = contextGraphDataUri(contextGraphId);
     // In-scope iff the graph is this CG's own public data plane. Rejects the reserved
@@ -4472,8 +4473,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const verifiedGraphScopedDataGraphs = new Set(
           processed.verifiedGraphScopedDataGraphs,
         );
-        result.rejectedKcs += processed.rejectedKcs;
-        result.dataRejectedMissingMeta += processed.dataRejectedMissingMeta;
+        accumulator.diagnostics.rejectedKcs += processed.rejectedKcs;
+        accumulator.diagnostics.dataRejectedMissingMeta += processed.dataRejectedMissingMeta;
         const plan = planPageApply({
           records: page.records,
           nextSeq: page.nextSeq,
@@ -4502,20 +4503,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           }
         }
         if (!plan.deferred && processed.rejectedKcs === 0) {
-          result.verifiedPrivateOnlyResponses =
-            result.verifiedPrivateOnlyResponses
+          accumulator.diagnostics.verifiedPrivateOnlyResponses =
+            accumulator.diagnostics.verifiedPrivateOnlyResponses
             + processed.verifiedPrivateOnlyResponses;
         }
         return { advanceTo: plan.advanceTo, applied: plan.applied, deferred: plan.deferred };
       },
     });
-    result.insertedDataTriples += insertedDataTriples;
-    result.insertedMetaTriples += insertedMetaTriples;
-    result.insertedTriples += insertedDataTriples + insertedMetaTriples;
+    accumulator.diagnostics.insertedDataTriples += insertedDataTriples;
+    accumulator.diagnostics.insertedMetaTriples += insertedMetaTriples;
+    accumulator.diagnostics.insertedTriples += insertedDataTriples + insertedMetaTriples;
     const changelogComplete = outcome.kind === 'delta'
       || (outcome.kind === 'resync' && outcome.complete);
-    if (outcome.kind === 'incomplete') result.failedPhases += 1;
-    if (outcome.kind === 'denied') result.deniedPhases += 1;
+    if (outcome.kind === 'incomplete') accumulator.diagnostics.failedPhases += 1;
+    if (outcome.kind === 'denied') accumulator.diagnostics.deniedPhases += 1;
     // A legacy fallback may have completed its own fetch phases while the
     // changelog drop remains unauthoritative. Preserve inserted progress, but
     // do not surface those phase completions as CG readiness evidence.

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -262,7 +262,8 @@ import {
   createCleanEmptyDurableSyncResult,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
-  isDurableSyncComplete,
+  finalizeDurableSyncCompletion,
+  markDurableTerminalBoundary,
 } from './sync/durable-progress.js';
 import {
   getSyncBackpressureSnapshot,
@@ -4530,25 +4531,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const changelogComplete = outcome.kind === 'delta'
       || (outcome.kind === 'resync' && outcome.complete);
     if (outcome.kind === 'incomplete') result.failedPhases += 1;
-    if (!changelogComplete) {
-      // A legacy fallback may have completed its own fetch phases while the
-      // changelog drop remains unauthoritative. Preserve inserted progress,
-      // but do not surface those phase completions as CG readiness evidence.
-      result.completedPhases = 0;
-    }
-    if (
-      changelogComplete
-      && result.timedOutPhases === 0
-      && result.failedPhases === 0
-      && result.failedPeers === 0
-      && result.dataRejectedMissingMeta === 0
-      && result.rejectedKcs === 0
-    ) {
-      result.completedPhases += 1;
-    }
     if (outcome.kind === 'denied') result.deniedPhases += 1;
-    result.complete = isDurableSyncComplete(result, changelogComplete);
-    return result;
+    // A legacy fallback may have completed its own fetch phases while the
+    // changelog drop remains unauthoritative. Preserve inserted progress, but
+    // do not surface those phase completions as CG readiness evidence.
+    markDurableTerminalBoundary(result, changelogComplete, {
+      countCompletedPhase: true,
+      clearCompletedPhasesWhenIncomplete: true,
+    });
+    return finalizeDurableSyncCompletion(result);
   }
 
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -259,11 +259,15 @@ import { mapWithConcurrency } from './map-with-concurrency.js';
 import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
 import {
   classifyDurableProgress,
-  createCleanEmptyDurableSyncResult,
+  createDurableSyncAccumulator,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
+  durableSyncAccumulatorFromResult,
   finalizeDurableSyncCompletion,
   markDurableTerminalBoundary,
+  mergeDurableSyncAccumulators,
+  mergeDurableSyncResultIntoAccumulator,
+  type DurableSyncAccumulator,
 } from './sync/durable-progress.js';
 import {
   getSyncBackpressureSnapshot,
@@ -803,36 +807,6 @@ function durableSyncEnabled(config: DKGAgentConfig): boolean {
 /** OT-RFC-59 responder cap on the peer-controlled raw-scan limit (DoS bound). Honest
  *  requesters send SYNC_PAGE_SIZE (500); the headroom tolerates larger legitimate pages. */
 const CHANGELOG_MAX_SCAN_LIMIT = 2000;
-
-/** Merge same-peer durable results across Context Graphs and requester lanes. */
-function mergeDurableSyncResults(a: DurableSyncResult, b: DurableSyncResult): DurableSyncResult {
-  return {
-    insertedTriples: a.insertedTriples + b.insertedTriples,
-    complete: a.complete === true && b.complete === true,
-    fetchedMetaTriples: a.fetchedMetaTriples + b.fetchedMetaTriples,
-    fetchedDataTriples: a.fetchedDataTriples + b.fetchedDataTriples,
-    insertedMetaTriples: a.insertedMetaTriples + b.insertedMetaTriples,
-    insertedDataTriples: a.insertedDataTriples + b.insertedDataTriples,
-    bytesReceived: a.bytesReceived + b.bytesReceived,
-    resumedPhases: a.resumedPhases + b.resumedPhases,
-    timedOutPhases: a.timedOutPhases + b.timedOutPhases,
-    completedPhases: a.completedPhases + b.completedPhases,
-    checkpointAdvances: a.checkpointAdvances + b.checkpointAdvances,
-    emptyResponses: a.emptyResponses + b.emptyResponses,
-    metaOnlyResponses: a.metaOnlyResponses + b.metaOnlyResponses,
-    verifiedPrivateOnlyResponses:
-      a.verifiedPrivateOnlyResponses + b.verifiedPrivateOnlyResponses,
-    dataRejectedMissingMeta: a.dataRejectedMissingMeta + b.dataRejectedMissingMeta,
-    rejectedKcs: a.rejectedKcs + b.rejectedKcs,
-    // This is peer cardinality, not a per-CG failure count. Both inputs belong
-    // to the same remote peer, so several failed CGs still mean one peer.
-    failedPeers: Math.max(a.failedPeers, b.failedPeers),
-    failedPhases: a.failedPhases + b.failedPhases,
-    deniedPhases: a.deniedPhases + b.deniedPhases,
-    backoffWorthyFailures: (a.backoffWorthyFailures ?? 0) + (b.backoffWorthyFailures ?? 0),
-    deferredBackpressure: (a.deferredBackpressure ?? 0) + (b.deferredBackpressure ?? 0),
-  };
-}
 
 function emptySharedMemorySyncResult(): SharedMemorySyncResult {
   return {
@@ -4028,7 +4002,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const lane = await this.runChangelogLane(ctx, remotePeerId, contextGraphIds, onAccessDenied);
         changelogResult = lane.result;
         legacyContextGraphIds = lane.remainingLegacyCgs;
-        if ((changelogResult.deferredBackpressure ?? 0) > 0) return changelogResult;
+        if (changelogResult && (changelogResult.deferredBackpressure ?? 0) > 0) {
+          return changelogResult;
+        }
       } catch (err) {
         this.log.warn(ctx, `Changelog sync lane failed for ${remotePeerId.slice(-8)}; using legacy sync: ${String(err)}`);
         legacyContextGraphIds = contextGraphIds;
@@ -4036,12 +4012,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
     }
     if (legacyContextGraphIds.length === 0) {
-      return changelogResult ?? createCleanEmptyDurableSyncResult();
+      return changelogResult ?? createIncompleteDurableSyncResult();
     }
     const legacyResult = await this.runLegacyDurableSync(
       ctx, remotePeerId, legacyContextGraphIds, onPhase, onAccessDenied, sinceBatchIdFor, options,
     );
-    return changelogResult ? mergeDurableSyncResults(changelogResult, legacyResult) : legacyResult;
+    if (!changelogResult) return legacyResult;
+    return finalizeDurableSyncCompletion(mergeDurableSyncAccumulators(
+      durableSyncAccumulatorFromResult(changelogResult),
+      durableSyncAccumulatorFromResult(legacyResult),
+    ));
   }
 
   /**
@@ -4066,28 +4046,30 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphIds,
       this.config.syncContextGraphPriorities,
     );
-    const runSync = () => runOrderedContextGraphSyncs({
+    const runSync = async () => finalizeDurableSyncCompletion(await runOrderedContextGraphSyncs<DurableSyncAccumulator>({
       work: orderedContextGraphIds.map((contextGraphId) => ({
         contextGraphId,
         lane: 'durable' as const,
         operationId: `durable:${contextGraphId}:${remotePeerId.slice(-8)}`,
-        run: (remainingContextGraphs) => LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
-          this,
-          ctx,
-          remotePeerId,
-          contextGraphId,
-          remainingContextGraphs,
-          onPhase,
-          onAccessDenied,
-          sinceBatchIdFor,
-          stopOnBackoffWorthyFailure,
-          undefined,
-          totalTimeoutMs,
-          options?.exactAssetUals,
+        run: async (remainingContextGraphs) => durableSyncAccumulatorFromResult(
+          await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
+            this,
+            ctx,
+            remotePeerId,
+            contextGraphId,
+            remainingContextGraphs,
+            onPhase,
+            onAccessDenied,
+            sinceBatchIdFor,
+            stopOnBackoffWorthyFailure,
+            undefined,
+            totalTimeoutMs,
+            options?.exactAssetUals,
+          ),
         ),
       })),
       priorities: this.config.syncContextGraphPriorities,
-      emptyResult: createCleanEmptyDurableSyncResult,
+      emptyResult: createDurableSyncAccumulator,
       runWithAdmission: (item, work) => runSerializedDurableContextGraphSync(
         this,
         remotePeerId,
@@ -4101,20 +4083,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           options?.priority,
         ),
       ),
-      merge: mergeDurableSyncResults,
-      markDeferred: (summary) => ({
-        ...summary,
-        complete: false,
-        deferredBackpressure: (summary.deferredBackpressure ?? 0) + 1,
-      }),
+      merge: mergeDurableSyncAccumulators,
+      markDeferred: (summary) => {
+        summary.diagnostics.deferredBackpressure += 1;
+        return markDurableTerminalBoundary(summary, false);
+      },
       shouldStop: (part) => Boolean(
-        stopOnBackoffWorthyFailure && (part.backoffWorthyFailures ?? 0) > 0,
+        stopOnBackoffWorthyFailure && part.diagnostics.backoffWorthyFailures > 0,
       ),
       onDeferred: (item, error) => this.log.info(
         ctx,
         `Deferring durable sync at CG ${item.contextGraphId} due to local backpressure: ${error.message}`,
       ),
-    });
+    }));
 
     const singleFlightKey = durableSyncSingleFlightKey({
       remotePeerId,
@@ -4297,10 +4278,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeerId: string,
     contextGraphIds: string[],
     onAccessDenied?: (contextGraphId: string) => void,
-  ): Promise<{ result: DurableSyncResult; remainingLegacyCgs: string[] }> {
+  ): Promise<{ result?: DurableSyncResult; remainingLegacyCgs: string[] }> {
     const peerProtocols = await this.getPeerProtocols(remotePeerId);
     if (!peerProtocols.includes(PROTOCOL_SYNC_CHANGELOG)) {
-      return { result: createCleanEmptyDurableSyncResult(), remainingLegacyCgs: contextGraphIds };
+      return { remainingLegacyCgs: contextGraphIds };
     }
     const legacyCgs: string[] = [];
     const work = [];
@@ -4313,24 +4294,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         contextGraphId,
         lane: 'changelog' as const,
         operationId: `changelog:${contextGraphId}:${remotePeerId.slice(-8)}`,
-        run: async (): Promise<DurableSyncResult> => {
+        run: async (): Promise<DurableSyncAccumulator> => {
           try {
             const result = await this.runChangelogSyncForCg(ctx, remotePeerId, contextGraphId);
             if (result.deniedPhases > 0) onAccessDenied?.(contextGraphId);
-            return result;
+            return durableSyncAccumulatorFromResult(result);
           } catch (error) {
             if (getSyncBackpressureBusyError(error)) throw error;
             this.log.warn(ctx, `Changelog sync failed for CG ${contextGraphId} from ${remotePeerId.slice(-8)}; deferring to legacy: ${String(error)}`);
             legacyCgs.push(contextGraphId);
-            return createCleanEmptyDurableSyncResult();
+            return createDurableSyncAccumulator();
           }
         },
       });
     }
-    const result = await runOrderedContextGraphSyncs({
+    const accumulator = await runOrderedContextGraphSyncs<DurableSyncAccumulator>({
       work,
       priorities: this.config.syncContextGraphPriorities,
-      emptyResult: createCleanEmptyDurableSyncResult,
+      emptyResult: createDurableSyncAccumulator,
       runWithAdmission: (item, run) => this.runContextGraphSyncWithBackpressure(
         ctx,
         item.contextGraphId,
@@ -4338,17 +4319,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         item.operationId,
         run,
       ),
-      merge: mergeDurableSyncResults,
-      markDeferred: (summary) => ({
-        ...summary,
-        complete: false,
-        deferredBackpressure: (summary.deferredBackpressure ?? 0) + 1,
-      }),
+      merge: mergeDurableSyncAccumulators,
+      markDeferred: (summary) => {
+        summary.diagnostics.deferredBackpressure += 1;
+        return markDurableTerminalBoundary(summary, false);
+      },
       onDeferred: (item, error) => this.log.info(
         ctx,
         `Deferring changelog sync at CG ${item.contextGraphId} due to local backpressure: ${error.message}`,
       ),
     });
+    const result = accumulator.observedTerminalBoundaries > 0
+      ? finalizeDurableSyncCompletion(accumulator)
+      : undefined;
     return { result, remainingLegacyCgs: legacyCgs };
   }
 
@@ -4369,7 +4352,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<DurableSyncResult> {
     let insertedDataTriples = 0;
     let insertedMetaTriples = 0;
-    let result: DurableSyncResult = createCleanEmptyDurableSyncResult(); // folds every resync's legacy DurableSyncResult
+    const accumulator = createDurableSyncAccumulator();
+    const result = accumulator.diagnostics; // folds every resync's legacy diagnostics
     const acceptUnverified = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId);
     const cgDataUri = contextGraphDataUri(contextGraphId);
     // In-scope iff the graph is this CG's own public data plane. Rejects the reserved
@@ -4443,7 +4427,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             dropsReconciled = reconciled;
           } : undefined,
         );
-        result = mergeDurableSyncResults(result, r);
+        mergeDurableSyncResultIntoAccumulator(accumulator, r);
         const complete = r.complete && dropsReconciled;
         return { complete, insertedTriples: r.insertedTriples };
       },
@@ -4535,11 +4519,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // A legacy fallback may have completed its own fetch phases while the
     // changelog drop remains unauthoritative. Preserve inserted progress, but
     // do not surface those phase completions as CG readiness evidence.
-    markDurableTerminalBoundary(result, changelogComplete, {
+    markDurableTerminalBoundary(accumulator, changelogComplete, {
       countCompletedPhase: true,
       clearCompletedPhasesWhenIncomplete: true,
     });
-    return finalizeDurableSyncCompletion(result);
+    return finalizeDurableSyncCompletion(accumulator);
   }
 
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -257,7 +257,13 @@ import {
 import { runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
 import { mapWithConcurrency } from './map-with-concurrency.js';
 import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
-import { classifyDurableProgress, isDurableSyncComplete } from './sync/durable-progress.js';
+import {
+  classifyDurableProgress,
+  createCleanEmptyDurableSyncResult,
+  createFailedPeerDurableSyncResult,
+  createIncompleteDurableSyncResult,
+  isDurableSyncComplete,
+} from './sync/durable-progress.js';
 import {
   getSyncBackpressureSnapshot,
   getSyncBackpressureBusyError,
@@ -796,32 +802,6 @@ function durableSyncEnabled(config: DKGAgentConfig): boolean {
 /** OT-RFC-59 responder cap on the peer-controlled raw-scan limit (DoS bound). Honest
  *  requesters send SYNC_PAGE_SIZE (500); the headroom tolerates larger legitimate pages. */
 const CHANGELOG_MAX_SCAN_LIMIT = 2000;
-
-function emptyDurableSyncResult(): DurableSyncResult {
-  return {
-    insertedTriples: 0,
-    complete: true,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 0,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 0,
-    bytesReceived: 0,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 0,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    metaOnlyResponses: 0,
-    verifiedPrivateOnlyResponses: 0,
-    dataRejectedMissingMeta: 0,
-    rejectedKcs: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    deniedPhases: 0,
-    backoffWorthyFailures: 0,
-    deferredBackpressure: 0,
-  };
-}
 
 /** Merge same-peer durable results across Context Graphs and requester lanes. */
 function mergeDurableSyncResults(a: DurableSyncResult, b: DurableSyncResult): DurableSyncResult {
@@ -4031,7 +4011,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const ctx = createOperationContext('sync');
     if (!durableSyncEnabled(this.config)) {
       this.log.warn(ctx, `Skipping durable sync from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
-      return { ...emptyDurableSyncResult(), complete: false };
+      return createIncompleteDurableSyncResult();
     }
     // OT-RFC-59 — peel off the public CGs this peer serves via the O(delta) changelog
     // lane; the rest fall through to the legacy full-scan lane below. STRICTLY ADDITIVE:
@@ -4055,7 +4035,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
     }
     if (legacyContextGraphIds.length === 0) {
-      return changelogResult ?? emptyDurableSyncResult();
+      return changelogResult ?? createCleanEmptyDurableSyncResult();
     }
     const legacyResult = await this.runLegacyDurableSync(
       ctx, remotePeerId, legacyContextGraphIds, onPhase, onAccessDenied, sinceBatchIdFor, options,
@@ -4106,7 +4086,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         ),
       })),
       priorities: this.config.syncContextGraphPriorities,
-      emptyResult: emptyDurableSyncResult,
+      emptyResult: createCleanEmptyDurableSyncResult,
       runWithAdmission: (item, work) => runSerializedDurableContextGraphSync(
         this,
         remotePeerId,
@@ -4319,7 +4299,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<{ result: DurableSyncResult; remainingLegacyCgs: string[] }> {
     const peerProtocols = await this.getPeerProtocols(remotePeerId);
     if (!peerProtocols.includes(PROTOCOL_SYNC_CHANGELOG)) {
-      return { result: emptyDurableSyncResult(), remainingLegacyCgs: contextGraphIds };
+      return { result: createCleanEmptyDurableSyncResult(), remainingLegacyCgs: contextGraphIds };
     }
     const legacyCgs: string[] = [];
     const work = [];
@@ -4341,7 +4321,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             if (getSyncBackpressureBusyError(error)) throw error;
             this.log.warn(ctx, `Changelog sync failed for CG ${contextGraphId} from ${remotePeerId.slice(-8)}; deferring to legacy: ${String(error)}`);
             legacyCgs.push(contextGraphId);
-            return emptyDurableSyncResult();
+            return createCleanEmptyDurableSyncResult();
           }
         },
       });
@@ -4349,7 +4329,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const result = await runOrderedContextGraphSyncs({
       work,
       priorities: this.config.syncContextGraphPriorities,
-      emptyResult: emptyDurableSyncResult,
+      emptyResult: createCleanEmptyDurableSyncResult,
       runWithAdmission: (item, run) => this.runContextGraphSyncWithBackpressure(
         ctx,
         item.contextGraphId,
@@ -4388,7 +4368,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<DurableSyncResult> {
     let insertedDataTriples = 0;
     let insertedMetaTriples = 0;
-    let result = emptyDurableSyncResult(); // folds every resync's legacy DurableSyncResult
+    let result: DurableSyncResult = createCleanEmptyDurableSyncResult(); // folds every resync's legacy DurableSyncResult
     const acceptUnverified = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId);
     const cgDataUri = contextGraphDataUri(contextGraphId);
     // In-scope iff the graph is this CG's own public data plane. Rejects the reserved
@@ -5408,27 +5388,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // into HEAD's `accessDeniedPeers` counter so the existing daemon
     // catchup-status endpoint and UI keep working — see
     // `cli/src/daemon.ts` subscribe job and `catchup-runner.ts`.
-    const emptyDurable = (): DurableSyncResult => ({
-      insertedTriples: 0,
-      complete: false,
-      fetchedMetaTriples: 0,
-      fetchedDataTriples: 0,
-      insertedMetaTriples: 0,
-      insertedDataTriples: 0,
-      bytesReceived: 0,
-      resumedPhases: 0,
-      timedOutPhases: 0,
-      completedPhases: 0,
-      checkpointAdvances: 0,
-      emptyResponses: 0,
-      metaOnlyResponses: 0,
-      verifiedPrivateOnlyResponses: 0,
-      dataRejectedMissingMeta: 0,
-      rejectedKcs: 0,
-      failedPeers: 1,
-      failedPhases: 0,
-      deniedPhases: 0,
-    });
     const emptyShared = (): SharedMemorySyncResult => ({
       insertedTriples: 0,
       fetchedMetaTriples: 0,
@@ -5461,7 +5420,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const durable = await this.syncFromPeerDetailed(
           remotePeerId,
           [contextGraphId],
-        ).catch(emptyDurable);
+        ).catch(() => createFailedPeerDurableSyncResult());
         const shared = includeSharedMemory
           ? await this.syncSharedMemoryFromPeerDetailed(remotePeerId, [contextGraphId]).catch(emptyShared)
           : null;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5414,7 +5414,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // or cleanly completed empty. Empty responses still count as a
       // legitimate host response, but a no-progress timeout must not make the
       // subscribe/VM catch-up path report a successful peer.
-      const durableProgress = classifyDurableProgress(r.durable);
+      const durableProgress = classifyDurableProgress(r.durable, {
+        complete: r.durable.complete,
+      });
       const sharedProgress = r.shared ? classifyDurableProgress(r.shared) : null;
       const durableFailed = durableProgress.transportFailed;
       const sharedFailed = Boolean(sharedProgress?.transportFailed);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4190,6 +4190,31 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     exactAssetUals?: string[],
   ): Promise<DurableSyncResult> {
     const syncAgentsMeta = resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META);
+    // The CG name commitment is immutable for an on-chain slot. Prove a
+    // local/on-chain binding once per durable-sync invocation, then reuse the
+    // successful proof for every KA in that batch. Without this operation-
+    // scoped cache, a large CG performs one RPC name-hash read per KA and a
+    // single transient timeout aborts the rest of an otherwise verified page.
+    // Rejections remain fail-closed and are never reused by a later operation.
+    const contextGraphBindingProofs = new Map<string, Promise<boolean>>();
+    const verifyContextGraphBinding = (
+      localContextGraphId: string,
+      onChainContextGraphId: bigint,
+    ): Promise<boolean> => {
+      const onChainId = onChainContextGraphId.toString();
+      const key = `${localContextGraphId}\0${onChainId}`;
+      let proof = contextGraphBindingProofs.get(key);
+      if (!proof) {
+        proof = this.localCgMatchesOnChainSlot(
+          localContextGraphId,
+          onChainId,
+          ctx,
+          { requireCommittedNameHash: true },
+        );
+        contextGraphBindingProofs.set(key, proof);
+      }
+      return proof;
+    };
     return runDurableSync({
       ctx,
       remotePeerId,
@@ -4238,12 +4263,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const authentication = await authenticateVerifiedGraphScopedAsset(
           this.chain,
           asset,
-          (localContextGraphId, onChainContextGraphId) => this.localCgMatchesOnChainSlot(
-            localContextGraphId,
-            onChainContextGraphId.toString(),
-            ctx,
-            { requireCommittedNameHash: true },
-          ),
+          verifyContextGraphBinding,
         );
         const verifiedOnChainId = authentication.onChainContextGraphId;
         const subscription = this.subscribedContextGraphs.get(asset.contextGraphId);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -800,6 +800,7 @@ const CHANGELOG_MAX_SCAN_LIMIT = 2000;
 function emptyDurableSyncResult(): DurableSyncResult {
   return {
     insertedTriples: 0,
+    complete: true,
     fetchedMetaTriples: 0,
     fetchedDataTriples: 0,
     insertedMetaTriples: 0,
@@ -826,6 +827,7 @@ function emptyDurableSyncResult(): DurableSyncResult {
 function mergeDurableSyncResults(a: DurableSyncResult, b: DurableSyncResult): DurableSyncResult {
   return {
     insertedTriples: a.insertedTriples + b.insertedTriples,
+    complete: a.complete === true && b.complete === true,
     fetchedMetaTriples: a.fetchedMetaTriples + b.fetchedMetaTriples,
     fetchedDataTriples: a.fetchedDataTriples + b.fetchedDataTriples,
     insertedMetaTriples: a.insertedMetaTriples + b.insertedMetaTriples,
@@ -4029,7 +4031,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const ctx = createOperationContext('sync');
     if (!durableSyncEnabled(this.config)) {
       this.log.warn(ctx, `Skipping durable sync from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
-      return emptyDurableSyncResult();
+      return { ...emptyDurableSyncResult(), complete: false };
     }
     // OT-RFC-59 — peel off the public CGs this peer serves via the O(delta) changelog
     // lane; the rest fall through to the legacy full-scan lane below. STRICTLY ADDITIVE:
@@ -4121,6 +4123,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       merge: mergeDurableSyncResults,
       markDeferred: (summary) => ({
         ...summary,
+        complete: false,
         deferredBackpressure: (summary.deferredBackpressure ?? 0) + 1,
       }),
       shouldStop: (part) => Boolean(
@@ -4357,6 +4360,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       merge: mergeDurableSyncResults,
       markDeferred: (summary) => ({
         ...summary,
+        complete: false,
         deferredBackpressure: (summary.deferredBackpressure ?? 0) + 1,
       }),
       onDeferred: (item, error) => this.log.info(
@@ -4457,7 +4461,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           } : undefined,
         );
         result = mergeDurableSyncResults(result, r);
-        const complete = dropsReconciled
+        const complete = r.complete === true
+          && dropsReconciled
           && r.timedOutPhases === 0 && r.failedPhases === 0
           && r.failedPeers === 0 && r.dataRejectedMissingMeta === 0
           && r.rejectedKcs === 0;
@@ -4563,6 +4568,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       result.completedPhases += 1;
     }
     if (outcome.kind === 'denied') result.deniedPhases += 1;
+    result.complete = result.complete === true
+      && changelogComplete
+      && result.timedOutPhases === 0
+      && result.failedPhases === 0
+      && result.failedPeers === 0
+      && result.deniedPhases === 0
+      && result.dataRejectedMissingMeta === 0
+      && result.rejectedKcs === 0
+      && (result.deferredBackpressure ?? 0) === 0;
     return result;
   }
 
@@ -5405,6 +5419,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // `cli/src/daemon.ts` subscribe job and `catchup-runner.ts`.
     const emptyDurable = (): DurableSyncResult => ({
       insertedTriples: 0,
+      complete: false,
       fetchedMetaTriples: 0,
       fetchedDataTriples: 0,
       insertedMetaTriples: 0,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -257,7 +257,7 @@ import {
 import { runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
 import { mapWithConcurrency } from './map-with-concurrency.js';
 import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
-import { classifyDurableProgress } from './sync/durable-progress.js';
+import { classifyDurableProgress, isDurableSyncComplete } from './sync/durable-progress.js';
 import {
   getSyncBackpressureSnapshot,
   getSyncBackpressureBusyError,
@@ -4384,6 +4384,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     ctx: OperationContext,
     remotePeerId: string,
     contextGraphId: string,
+    maxRounds?: number,
   ): Promise<DurableSyncResult> {
     let insertedDataTriples = 0;
     let insertedMetaTriples = 0;
@@ -4402,6 +4403,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const outcome = await runChangelogSync({
       contextGraphId,
       limit: SYNC_PAGE_SIZE,
+      maxRounds,
       getCursor: () => {
         const c = this.changelogCursors.get(remotePeerId, contextGraphId);
         return c ? { era: c.era, seq: c.seq } : undefined;
@@ -4461,11 +4463,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           } : undefined,
         );
         result = mergeDurableSyncResults(result, r);
-        const complete = r.complete === true
-          && dropsReconciled
-          && r.timedOutPhases === 0 && r.failedPhases === 0
-          && r.failedPeers === 0 && r.dataRejectedMissingMeta === 0
-          && r.rejectedKcs === 0;
+        const complete = r.complete && dropsReconciled;
         return { complete, insertedTriples: r.insertedTriples };
       },
       logWarn: (m) => this.log.warn(ctx, m),
@@ -4551,6 +4549,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     result.insertedTriples += insertedDataTriples + insertedMetaTriples;
     const changelogComplete = outcome.kind === 'delta'
       || (outcome.kind === 'resync' && outcome.complete);
+    if (outcome.kind === 'incomplete') result.failedPhases += 1;
     if (!changelogComplete) {
       // A legacy fallback may have completed its own fetch phases while the
       // changelog drop remains unauthoritative. Preserve inserted progress,
@@ -4568,15 +4567,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       result.completedPhases += 1;
     }
     if (outcome.kind === 'denied') result.deniedPhases += 1;
-    result.complete = result.complete === true
-      && changelogComplete
-      && result.timedOutPhases === 0
-      && result.failedPhases === 0
-      && result.failedPeers === 0
-      && result.deniedPhases === 0
-      && result.dataRejectedMissingMeta === 0
-      && result.rejectedKcs === 0
-      && (result.deferredBackpressure ?? 0) === 0;
+    result.complete = isDurableSyncComplete(result, changelogComplete);
     return result;
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -262,11 +262,14 @@ import {
   createDurableSyncAccumulator,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
+  durableSyncAccumulatorHasBackoffWorthyFailure,
+  durableSyncAccumulatorHasTerminalBoundary,
   durableSyncAccumulatorFromResult,
   finalizeDurableSyncCompletion,
   markDurableTerminalBoundary,
   mergeDurableSyncAccumulatorInto,
   mergeDurableSyncResultIntoAccumulator,
+  recordDurableSyncDiagnostics,
   type DurableSyncAccumulator,
 } from './sync/durable-progress.js';
 import {
@@ -4087,11 +4090,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ),
       merge: mergeDurableSyncAccumulatorInto,
       markDeferred: (summary) => {
-        summary.diagnostics.deferredBackpressure += 1;
+        recordDurableSyncDiagnostics(summary, { deferredBackpressure: 1 });
         return markDurableTerminalBoundary(summary, false);
       },
       shouldStop: (part) => Boolean(
-        stopOnBackoffWorthyFailure && part.diagnostics.backoffWorthyFailures > 0,
+        stopOnBackoffWorthyFailure
+        && durableSyncAccumulatorHasBackoffWorthyFailure(part),
       ),
       onDeferred: (item, error) => this.log.info(
         ctx,
@@ -4323,7 +4327,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ),
       merge: mergeDurableSyncAccumulatorInto,
       markDeferred: (summary) => {
-        summary.diagnostics.deferredBackpressure += 1;
+        recordDurableSyncDiagnostics(summary, { deferredBackpressure: 1 });
         return markDurableTerminalBoundary(summary, false);
       },
       onDeferred: (item, error) => this.log.info(
@@ -4331,7 +4335,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         `Deferring changelog sync at CG ${item.contextGraphId} due to local backpressure: ${error.message}`,
       ),
     });
-    const result = accumulator.observedTerminalBoundaries > 0
+    const result = durableSyncAccumulatorHasTerminalBoundary(accumulator)
       ? finalizeDurableSyncCompletion(accumulator)
       : undefined;
     return { result, remainingLegacyCgs: legacyCgs };
@@ -4473,8 +4477,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const verifiedGraphScopedDataGraphs = new Set(
           processed.verifiedGraphScopedDataGraphs,
         );
-        accumulator.diagnostics.rejectedKcs += processed.rejectedKcs;
-        accumulator.diagnostics.dataRejectedMissingMeta += processed.dataRejectedMissingMeta;
+        recordDurableSyncDiagnostics(accumulator, {
+          rejectedKcs: processed.rejectedKcs,
+          dataRejectedMissingMeta: processed.dataRejectedMissingMeta,
+        });
         const plan = planPageApply({
           records: page.records,
           nextSeq: page.nextSeq,
@@ -4503,20 +4509,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           }
         }
         if (!plan.deferred && processed.rejectedKcs === 0) {
-          accumulator.diagnostics.verifiedPrivateOnlyResponses =
-            accumulator.diagnostics.verifiedPrivateOnlyResponses
-            + processed.verifiedPrivateOnlyResponses;
+          recordDurableSyncDiagnostics(accumulator, {
+            verifiedPrivateOnlyResponses: processed.verifiedPrivateOnlyResponses,
+          });
         }
         return { advanceTo: plan.advanceTo, applied: plan.applied, deferred: plan.deferred };
       },
     });
-    accumulator.diagnostics.insertedDataTriples += insertedDataTriples;
-    accumulator.diagnostics.insertedMetaTriples += insertedMetaTriples;
-    accumulator.diagnostics.insertedTriples += insertedDataTriples + insertedMetaTriples;
+    recordDurableSyncDiagnostics(accumulator, {
+      insertedDataTriples,
+      insertedMetaTriples,
+      insertedTriples: insertedDataTriples + insertedMetaTriples,
+    });
     const changelogComplete = outcome.kind === 'delta'
       || (outcome.kind === 'resync' && outcome.complete);
-    if (outcome.kind === 'incomplete') accumulator.diagnostics.failedPhases += 1;
-    if (outcome.kind === 'denied') accumulator.diagnostics.deniedPhases += 1;
+    if (outcome.kind === 'incomplete') {
+      recordDurableSyncDiagnostics(accumulator, { failedPhases: 1 });
+    }
+    if (outcome.kind === 'denied') {
+      recordDurableSyncDiagnostics(accumulator, { deniedPhases: 1 });
+    }
     // A legacy fallback may have completed its own fetch phases while the
     // changelog drop remains unauthoritative. Preserve inserted progress, but
     // do not surface those phase completions as CG readiness evidence.

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -993,6 +993,13 @@ export interface CatchupSyncDiagnostics {
 export interface DurableSyncResult extends DurableSyncDiagnostics {
   insertedTriples: number;
   deniedPhases: number;
+  /**
+   * True only when every requested Context Graph reached a verified terminal
+   * state in this invocation. Committed prefixes remain observable through the
+   * counters while this stays false, so callers never have to infer whole-run
+   * completeness from per-phase progress.
+   */
+  complete: boolean;
 }
 
 export interface SharedMemorySyncResult extends SharedMemorySyncDiagnostics {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -273,7 +273,10 @@ export { mapWithConcurrency } from './map-with-concurrency.js';
 export { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
 export {
   classifyDurableProgress,
+  DURABLE_SYNC_COUNTER_REDUCERS,
   isDurableSyncComplete,
+  type DurableSyncCounterKey,
+  type DurableSyncCounterReducer,
   type DurableProgressClassification,
   type DurableProgressSummary,
 } from './sync/durable-progress.js';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -274,10 +274,8 @@ export { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js
 export {
   classifyDurableProgress,
   createFailedPeerDurableSyncResult,
-  DURABLE_SYNC_COUNTER_REDUCERS,
   isDurableSyncComplete,
-  type DurableSyncCounterKey,
-  type DurableSyncCounterReducer,
+  normalizeDurableSyncResult,
   type DurableProgressClassification,
   type DurableProgressClassificationOptions,
   type DurableProgressSummary,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -186,6 +186,8 @@ export {
   type PendingSenderKeyEntry,
   type AssertionArtifactKind,
   type ImportedArtifactByteStore,
+  type DurableSyncDiagnostics,
+  type DurableSyncResult,
 } from './dkg-agent-types.js';
 export {
   computeImportedArtifactSelector,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -273,11 +273,13 @@ export { mapWithConcurrency } from './map-with-concurrency.js';
 export { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
 export {
   classifyDurableProgress,
+  createFailedPeerDurableSyncResult,
   DURABLE_SYNC_COUNTER_REDUCERS,
   isDurableSyncComplete,
   type DurableSyncCounterKey,
   type DurableSyncCounterReducer,
   type DurableProgressClassification,
+  type DurableProgressClassificationOptions,
   type DurableProgressSummary,
 } from './sync/durable-progress.js';
 // 2026-07-08 sync-storm mitigation (#1233) — resolve the opt-in `agents/_meta`

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -273,6 +273,7 @@ export { mapWithConcurrency } from './map-with-concurrency.js';
 export { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
 export {
   classifyDurableProgress,
+  isDurableSyncComplete,
   type DurableProgressClassification,
   type DurableProgressSummary,
 } from './sync/durable-progress.js';

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -6,8 +6,6 @@ import type { DurableSyncResult } from '../dkg-agent-types.js';
  * classified without first manufacturing a full requester result.
  */
 export interface DurableProgressSummary {
-  /** Finalized whole-run verdict when the caller has a public durable result. */
-  readonly complete?: boolean;
   readonly insertedTriples?: number;
   readonly insertedDataTriples?: number;
   readonly insertedMetaTriples?: number;
@@ -24,6 +22,11 @@ export interface DurableProgressSummary {
   readonly deniedPhases?: number;
   readonly backoffWorthyFailures?: number;
   readonly deferredBackpressure?: number;
+}
+
+/** Explicit durable-only lifecycle state; generic/shared-memory callers omit it. */
+export interface DurableProgressClassificationOptions {
+  readonly complete?: boolean;
 }
 
 /** Typed policy decisions shared by reconnect and explicit catch-up paths. */
@@ -56,6 +59,7 @@ export interface DurableProgressClassification {
  */
 export function classifyDurableProgress(
   progress: DurableProgressSummary | null | undefined,
+  options: DurableProgressClassificationOptions = {},
 ): DurableProgressClassification {
   const insertedTriples = progress?.insertedTriples ?? 0;
   const insertedMetaTriples = progress?.insertedMetaTriples ?? 0;
@@ -86,7 +90,7 @@ export function classifyDurableProgress(
   // handled separately by reconnect accounting, matching the pre-classifier
   // policy while keeping partial-deferral progress observable.
   const hasCleanVerifiedPrivateOnlyCompletion = hasVerifiedPrivateOnlyResponse
-    && progress?.complete !== false
+    && options.complete !== false
     && metaOnlyResponses === 0
     && completedPhases > 0
     && !timedOut
@@ -120,7 +124,7 @@ export function classifyDurableProgress(
     || (completedPhases > 0 && resumedPhases > 0);
 
   const completedWithoutFailure = progress != null
-    && progress.complete !== false
+    && options.complete !== false
     && completedPhases > 0
     && !hasBlockingFailure;
 

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -179,7 +179,7 @@ export interface DurableTerminalBoundaryOptions {
   readonly clearCompletedPhasesWhenIncomplete?: boolean;
 }
 
-export type DurableSyncCounterReducer = 'sum' | 'max';
+type DurableSyncCounterReducer = 'sum' | 'max';
 
 /**
  * Canonical runtime metadata for every numeric field in DurableSyncResult.
@@ -187,7 +187,7 @@ export type DurableSyncCounterReducer = 'sum' | 'max';
  * aggregation policy is declared here. Consumers can also reuse this table for
  * zero construction and normalized projections instead of duplicating fields.
  */
-export const DURABLE_SYNC_COUNTER_REDUCERS = {
+const DURABLE_SYNC_COUNTER_REDUCERS = {
   insertedTriples: 'sum',
   fetchedMetaTriples: 'sum',
   fetchedDataTriples: 'sum',
@@ -213,7 +213,7 @@ export const DURABLE_SYNC_COUNTER_REDUCERS = {
   DurableSyncCounterReducer
 >>;
 
-export type DurableSyncCounterKey = keyof typeof DURABLE_SYNC_COUNTER_REDUCERS;
+type DurableSyncCounterKey = keyof typeof DURABLE_SYNC_COUNTER_REDUCERS;
 
 /**
  * Internal durable aggregation state. The public `complete` verdict is absent
@@ -344,6 +344,25 @@ function createDurableSyncDiagnosticsBase(): InitializedDurableSyncDiagnostics {
   return Object.fromEntries(
     Object.keys(DURABLE_SYNC_COUNTER_REDUCERS).map((key) => [key, 0]),
   ) as InitializedDurableSyncDiagnostics;
+}
+
+/**
+ * Project an externally supplied public result onto the canonical initialized
+ * result contract without exposing internal reducer metadata. Consumers get a
+ * stable typed boundary; aggregation policy remains private to this module.
+ */
+export function normalizeDurableSyncResult(
+  result: DurableSyncResult,
+): InitializedDurableSyncResult {
+  const diagnostics = createDurableSyncDiagnosticsBase();
+  const normalized = diagnostics as Record<DurableSyncCounterKey, number>;
+  for (const key of Object.keys(DURABLE_SYNC_COUNTER_REDUCERS) as DurableSyncCounterKey[]) {
+    const value = result[key];
+    normalized[key] = typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? value
+      : 0;
+  }
+  return { ...diagnostics, complete: result.complete === true };
 }
 
 /** No work completed, but the caller must keep retrying. */

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -175,6 +175,42 @@ export interface DurableTerminalBoundaryOptions {
   readonly clearCompletedPhasesWhenIncomplete?: boolean;
 }
 
+export type DurableSyncCounterReducer = 'sum' | 'max';
+
+/**
+ * Canonical runtime metadata for every numeric field in DurableSyncResult.
+ * The satisfies clause makes a newly added counter a compile error until its
+ * aggregation policy is declared here. Consumers can also reuse this table for
+ * zero construction and normalized projections instead of duplicating fields.
+ */
+export const DURABLE_SYNC_COUNTER_REDUCERS = {
+  insertedTriples: 'sum',
+  fetchedMetaTriples: 'sum',
+  fetchedDataTriples: 'sum',
+  insertedMetaTriples: 'sum',
+  insertedDataTriples: 'sum',
+  bytesReceived: 'sum',
+  resumedPhases: 'sum',
+  timedOutPhases: 'sum',
+  completedPhases: 'sum',
+  checkpointAdvances: 'sum',
+  emptyResponses: 'sum',
+  metaOnlyResponses: 'sum',
+  verifiedPrivateOnlyResponses: 'sum',
+  dataRejectedMissingMeta: 'sum',
+  rejectedKcs: 'sum',
+  failedPeers: 'max',
+  failedPhases: 'sum',
+  deniedPhases: 'sum',
+  backoffWorthyFailures: 'sum',
+  deferredBackpressure: 'sum',
+} as const satisfies Readonly<Record<
+  Exclude<keyof DurableSyncResult, 'complete'>,
+  DurableSyncCounterReducer
+>>;
+
+export type DurableSyncCounterKey = keyof typeof DURABLE_SYNC_COUNTER_REDUCERS;
+
 /**
  * Internal durable aggregation state. The public `complete` verdict is absent
  * here by design: boundary aggregation and a finalized result must not share
@@ -214,45 +250,29 @@ function mergeDurableSyncDiagnostics(
   a: InitializedDurableSyncDiagnostics,
   b: InitializedDurableSyncDiagnostics,
 ): InitializedDurableSyncDiagnostics {
-  return {
-    insertedTriples: a.insertedTriples + b.insertedTriples,
-    fetchedMetaTriples: a.fetchedMetaTriples + b.fetchedMetaTriples,
-    fetchedDataTriples: a.fetchedDataTriples + b.fetchedDataTriples,
-    insertedMetaTriples: a.insertedMetaTriples + b.insertedMetaTriples,
-    insertedDataTriples: a.insertedDataTriples + b.insertedDataTriples,
-    bytesReceived: a.bytesReceived + b.bytesReceived,
-    resumedPhases: a.resumedPhases + b.resumedPhases,
-    timedOutPhases: a.timedOutPhases + b.timedOutPhases,
-    completedPhases: a.completedPhases + b.completedPhases,
-    checkpointAdvances: a.checkpointAdvances + b.checkpointAdvances,
-    emptyResponses: a.emptyResponses + b.emptyResponses,
-    metaOnlyResponses: a.metaOnlyResponses + b.metaOnlyResponses,
-    verifiedPrivateOnlyResponses:
-      a.verifiedPrivateOnlyResponses + b.verifiedPrivateOnlyResponses,
-    dataRejectedMissingMeta: a.dataRejectedMissingMeta + b.dataRejectedMissingMeta,
-    rejectedKcs: a.rejectedKcs + b.rejectedKcs,
-    // This is peer cardinality, not a per-CG failure count. All folded inputs
-    // belong to one remote peer, so several failed CGs still mean one peer.
-    failedPeers: Math.max(a.failedPeers, b.failedPeers),
-    failedPhases: a.failedPhases + b.failedPhases,
-    deniedPhases: a.deniedPhases + b.deniedPhases,
-    backoffWorthyFailures: a.backoffWorthyFailures + b.backoffWorthyFailures,
-    deferredBackpressure: a.deferredBackpressure + b.deferredBackpressure,
-  };
+  const merged = createDurableSyncDiagnosticsBase();
+  const counters = merged as Record<DurableSyncCounterKey, number>;
+  for (const key of Object.keys(DURABLE_SYNC_COUNTER_REDUCERS) as DurableSyncCounterKey[]) {
+    counters[key] = DURABLE_SYNC_COUNTER_REDUCERS[key] === 'max'
+      ? Math.max(a[key], b[key])
+      : a[key] + b[key];
+  }
+  return merged;
 }
 
-/** Fold two internal durable aggregates without manufacturing a public verdict. */
-export function mergeDurableSyncAccumulators(
-  a: DurableSyncAccumulator,
-  b: DurableSyncAccumulator,
+/** Mutate one internal aggregate with another; no public verdict is manufactured. */
+export function mergeDurableSyncAccumulatorInto(
+  target: DurableSyncAccumulator,
+  part: DurableSyncAccumulator,
 ): DurableSyncAccumulator {
-  return {
-    diagnostics: mergeDurableSyncDiagnostics(a.diagnostics, b.diagnostics),
-    allTerminalBoundariesReached:
-      a.allTerminalBoundariesReached && b.allTerminalBoundariesReached,
-    observedTerminalBoundaries:
-      a.observedTerminalBoundaries + b.observedTerminalBoundaries,
-  };
+  Object.assign(
+    target.diagnostics,
+    mergeDurableSyncDiagnostics(target.diagnostics, part.diagnostics),
+  );
+  target.allTerminalBoundariesReached =
+    target.allTerminalBoundariesReached && part.allTerminalBoundariesReached;
+  target.observedTerminalBoundaries += part.observedTerminalBoundaries;
+  return target;
 }
 
 /** Fold a finalized lane result into an existing internal aggregate. */
@@ -260,14 +280,10 @@ export function mergeDurableSyncResultIntoAccumulator(
   accumulator: DurableSyncAccumulator,
   result: DurableSyncResult,
 ): DurableSyncAccumulator {
-  const merged = mergeDurableSyncAccumulators(
+  return mergeDurableSyncAccumulatorInto(
     accumulator,
     durableSyncAccumulatorFromResult(result),
   );
-  Object.assign(accumulator.diagnostics, merged.diagnostics);
-  accumulator.allTerminalBoundariesReached = merged.allTerminalBoundariesReached;
-  accumulator.observedTerminalBoundaries = merged.observedTerminalBoundaries;
-  return accumulator;
 }
 
 /**
@@ -321,28 +337,9 @@ export type InitializedDurableSyncResult = DurableSyncResult & Required<Pick<
 export type InitializedDurableSyncDiagnostics = Omit<InitializedDurableSyncResult, 'complete'>;
 
 function createDurableSyncDiagnosticsBase(): InitializedDurableSyncDiagnostics {
-  return {
-    insertedTriples: 0,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 0,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 0,
-    bytesReceived: 0,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 0,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    metaOnlyResponses: 0,
-    verifiedPrivateOnlyResponses: 0,
-    dataRejectedMissingMeta: 0,
-    rejectedKcs: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    deniedPhases: 0,
-    backoffWorthyFailures: 0,
-    deferredBackpressure: 0,
-  };
+  return Object.fromEntries(
+    Object.keys(DURABLE_SYNC_COUNTER_REDUCERS).map((key) => [key, 0]),
+  ) as InitializedDurableSyncDiagnostics;
 }
 
 /** No work completed, but the caller must keep retrying. */

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -38,6 +38,7 @@ export interface DurableProgressClassification {
   readonly phaseFailed: boolean;
   readonly denied: boolean;
   readonly deferredByBackpressure: boolean;
+  readonly hasBlockingFailure: boolean;
   readonly backoffWorthyFailure: boolean;
   readonly madeReconnectProgress: boolean;
   readonly madeReadinessProgress: boolean;
@@ -71,6 +72,12 @@ export function classifyDurableProgress(
     || (progress?.rejectedKcs ?? 0) > 0;
   const hasVerifiedPrivateOnlyResponse = verifiedPrivateOnlyResponses > 0;
   const hasMetadataEvidence = insertedMetaTriples > 0 || metaOnlyResponses > 0;
+  const hasBlockingFailure = timedOut
+    || transportFailed
+    || phaseFailed
+    || denied
+    || integrityRejected
+    || deferredByBackpressure;
 
   // Reconnect freshness treats the private-only signal as authoritative only
   // when the durable phase that produced it is itself clean. Backpressure is
@@ -111,12 +118,7 @@ export function classifyDurableProgress(
 
   const completedWithoutFailure = progress != null
     && completedPhases > 0
-    && !timedOut
-    && !transportFailed
-    && !phaseFailed
-    && !integrityRejected
-    && !deferredByBackpressure
-    && !denied;
+    && !hasBlockingFailure;
 
   return {
     insertedDataTriples,
@@ -131,6 +133,7 @@ export function classifyDurableProgress(
     phaseFailed,
     denied,
     deferredByBackpressure,
+    hasBlockingFailure,
     backoffWorthyFailure: (progress?.backoffWorthyFailures ?? 0) > 0
       || transportFailed
       || timedOut,
@@ -159,6 +162,46 @@ export function isDurableSyncComplete(
 ): boolean {
   return reachedTerminalBoundary
     && classifyDurableProgress(progress).completedWithoutFailure;
+}
+
+export interface DurableTerminalBoundaryOptions {
+  /** Count this clean lane boundary as a completed diagnostic phase. */
+  readonly countCompletedPhase?: boolean;
+  /** Hide fallback phase completions when the authoritative lane is incomplete. */
+  readonly clearCompletedPhasesWhenIncomplete?: boolean;
+}
+
+/**
+ * Record one lane's terminal boundary on the result itself. `complete` acts as
+ * a sticky boundary accumulator: once any requested lane is incomplete, later
+ * clean lanes cannot accidentally make the whole run complete again.
+ *
+ * Diagnostic phase synthesis also lives here so lanes never duplicate the
+ * blocking-counter policy when reporting an authoritative completion.
+ */
+export function markDurableTerminalBoundary<T extends DurableSyncResult>(
+  result: T,
+  reachedTerminalBoundary: boolean,
+  options: DurableTerminalBoundaryOptions = {},
+): T {
+  if (!reachedTerminalBoundary && options.clearCompletedPhasesWhenIncomplete) {
+    result.completedPhases = 0;
+  }
+  if (
+    reachedTerminalBoundary
+    && options.countCompletedPhase
+    && !classifyDurableProgress(result).hasBlockingFailure
+  ) {
+    result.completedPhases += 1;
+  }
+  result.complete = result.complete && reachedTerminalBoundary;
+  return result;
+}
+
+/** Apply the shared counter policy to a result after all lanes are marked. */
+export function finalizeDurableSyncCompletion<T extends DurableSyncResult>(result: T): T {
+  result.complete = isDurableSyncComplete(result, result.complete);
+  return result;
 }
 
 type InitializedDurableSyncResult = DurableSyncResult & Required<Pick<

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -145,3 +145,16 @@ export function classifyDurableProgress(
       && !metadataOnly,
   };
 }
+
+/**
+ * Canonical whole-run completion policy for durable requester lanes.
+ * Callers provide only whether their lane reached its own terminal boundary;
+ * the shared classifier owns every diagnostic counter that can invalidate it.
+ */
+export function isDurableSyncComplete(
+  progress: DurableProgressSummary | null | undefined,
+  reachedTerminalBoundary: boolean,
+): boolean {
+  return reachedTerminalBoundary
+    && classifyDurableProgress(progress).completedWithoutFailure;
+}

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -6,6 +6,8 @@ import type { DurableSyncResult } from '../dkg-agent-types.js';
  * classified without first manufacturing a full requester result.
  */
 export interface DurableProgressSummary {
+  /** Finalized whole-run verdict when the caller has a public durable result. */
+  readonly complete?: boolean;
   readonly insertedTriples?: number;
   readonly insertedDataTriples?: number;
   readonly insertedMetaTriples?: number;
@@ -84,6 +86,7 @@ export function classifyDurableProgress(
   // handled separately by reconnect accounting, matching the pre-classifier
   // policy while keeping partial-deferral progress observable.
   const hasCleanVerifiedPrivateOnlyCompletion = hasVerifiedPrivateOnlyResponse
+    && progress?.complete !== false
     && metaOnlyResponses === 0
     && completedPhases > 0
     && !timedOut
@@ -117,6 +120,7 @@ export function classifyDurableProgress(
     || (completedPhases > 0 && resumedPhases > 0);
 
   const completedWithoutFailure = progress != null
+    && progress.complete !== false
     && completedPhases > 0
     && !hasBlockingFailure;
 
@@ -172,18 +176,113 @@ export interface DurableTerminalBoundaryOptions {
 }
 
 /**
- * Record one lane's terminal boundary on the result itself. `complete` acts as
- * a sticky boundary accumulator: once any requested lane is incomplete, later
- * clean lanes cannot accidentally make the whole run complete again.
+ * Internal durable aggregation state. The public `complete` verdict is absent
+ * here by design: boundary aggregation and a finalized result must not share
+ * one boolean whose meaning changes midway through a run.
+ */
+export interface DurableSyncAccumulator {
+  diagnostics: InitializedDurableSyncDiagnostics;
+  allTerminalBoundariesReached: boolean;
+  observedTerminalBoundaries: number;
+}
+
+/** Start a neutral internal fold. It is never exposed as a public result. */
+export function createDurableSyncAccumulator(): DurableSyncAccumulator {
+  return {
+    diagnostics: createDurableSyncDiagnosticsBase(),
+    allTerminalBoundariesReached: true,
+    observedTerminalBoundaries: 0,
+  };
+}
+
+/** Convert one finalized public result into an internal fold contribution. */
+export function durableSyncAccumulatorFromResult(
+  result: DurableSyncResult,
+): DurableSyncAccumulator {
+  const { complete, ...diagnostics } = result;
+  return {
+    diagnostics: {
+      ...createDurableSyncDiagnosticsBase(),
+      ...diagnostics,
+    },
+    allTerminalBoundariesReached: complete === true,
+    observedTerminalBoundaries: 1,
+  };
+}
+
+function mergeDurableSyncDiagnostics(
+  a: InitializedDurableSyncDiagnostics,
+  b: InitializedDurableSyncDiagnostics,
+): InitializedDurableSyncDiagnostics {
+  return {
+    insertedTriples: a.insertedTriples + b.insertedTriples,
+    fetchedMetaTriples: a.fetchedMetaTriples + b.fetchedMetaTriples,
+    fetchedDataTriples: a.fetchedDataTriples + b.fetchedDataTriples,
+    insertedMetaTriples: a.insertedMetaTriples + b.insertedMetaTriples,
+    insertedDataTriples: a.insertedDataTriples + b.insertedDataTriples,
+    bytesReceived: a.bytesReceived + b.bytesReceived,
+    resumedPhases: a.resumedPhases + b.resumedPhases,
+    timedOutPhases: a.timedOutPhases + b.timedOutPhases,
+    completedPhases: a.completedPhases + b.completedPhases,
+    checkpointAdvances: a.checkpointAdvances + b.checkpointAdvances,
+    emptyResponses: a.emptyResponses + b.emptyResponses,
+    metaOnlyResponses: a.metaOnlyResponses + b.metaOnlyResponses,
+    verifiedPrivateOnlyResponses:
+      a.verifiedPrivateOnlyResponses + b.verifiedPrivateOnlyResponses,
+    dataRejectedMissingMeta: a.dataRejectedMissingMeta + b.dataRejectedMissingMeta,
+    rejectedKcs: a.rejectedKcs + b.rejectedKcs,
+    // This is peer cardinality, not a per-CG failure count. All folded inputs
+    // belong to one remote peer, so several failed CGs still mean one peer.
+    failedPeers: Math.max(a.failedPeers, b.failedPeers),
+    failedPhases: a.failedPhases + b.failedPhases,
+    deniedPhases: a.deniedPhases + b.deniedPhases,
+    backoffWorthyFailures: a.backoffWorthyFailures + b.backoffWorthyFailures,
+    deferredBackpressure: a.deferredBackpressure + b.deferredBackpressure,
+  };
+}
+
+/** Fold two internal durable aggregates without manufacturing a public verdict. */
+export function mergeDurableSyncAccumulators(
+  a: DurableSyncAccumulator,
+  b: DurableSyncAccumulator,
+): DurableSyncAccumulator {
+  return {
+    diagnostics: mergeDurableSyncDiagnostics(a.diagnostics, b.diagnostics),
+    allTerminalBoundariesReached:
+      a.allTerminalBoundariesReached && b.allTerminalBoundariesReached,
+    observedTerminalBoundaries:
+      a.observedTerminalBoundaries + b.observedTerminalBoundaries,
+  };
+}
+
+/** Fold a finalized lane result into an existing internal aggregate. */
+export function mergeDurableSyncResultIntoAccumulator(
+  accumulator: DurableSyncAccumulator,
+  result: DurableSyncResult,
+): DurableSyncAccumulator {
+  const merged = mergeDurableSyncAccumulators(
+    accumulator,
+    durableSyncAccumulatorFromResult(result),
+  );
+  Object.assign(accumulator.diagnostics, merged.diagnostics);
+  accumulator.allTerminalBoundariesReached = merged.allTerminalBoundariesReached;
+  accumulator.observedTerminalBoundaries = merged.observedTerminalBoundaries;
+  return accumulator;
+}
+
+/**
+ * Record one lane's terminal boundary in internal state. Once any requested
+ * lane is incomplete, later clean lanes cannot make the whole run complete.
  *
  * Diagnostic phase synthesis also lives here so lanes never duplicate the
  * blocking-counter policy when reporting an authoritative completion.
  */
-export function markDurableTerminalBoundary<T extends DurableSyncResult>(
-  result: T,
+export function markDurableTerminalBoundary(
+  accumulator: DurableSyncAccumulator,
   reachedTerminalBoundary: boolean,
   options: DurableTerminalBoundaryOptions = {},
-): T {
+): DurableSyncAccumulator {
+  const result = accumulator.diagnostics;
   if (!reachedTerminalBoundary && options.clearCompletedPhasesWhenIncomplete) {
     result.completedPhases = 0;
   }
@@ -194,25 +293,36 @@ export function markDurableTerminalBoundary<T extends DurableSyncResult>(
   ) {
     result.completedPhases += 1;
   }
-  result.complete = result.complete && reachedTerminalBoundary;
-  return result;
+  accumulator.allTerminalBoundariesReached =
+    accumulator.allTerminalBoundariesReached && reachedTerminalBoundary;
+  accumulator.observedTerminalBoundaries += 1;
+  return accumulator;
 }
 
-/** Apply the shared counter policy to a result after all lanes are marked. */
-export function finalizeDurableSyncCompletion<T extends DurableSyncResult>(result: T): T {
-  result.complete = isDurableSyncComplete(result, result.complete);
-  return result;
+/** Assign the public completion verdict once, after every lane is folded. */
+export function finalizeDurableSyncCompletion(
+  accumulator: DurableSyncAccumulator,
+): InitializedDurableSyncResult {
+  return {
+    ...accumulator.diagnostics,
+    complete: accumulator.observedTerminalBoundaries > 0
+      && isDurableSyncComplete(
+        accumulator.diagnostics,
+        accumulator.allTerminalBoundariesReached,
+      ),
+  };
 }
 
-type InitializedDurableSyncResult = DurableSyncResult & Required<Pick<
+export type InitializedDurableSyncResult = DurableSyncResult & Required<Pick<
   DurableSyncResult,
   'backoffWorthyFailures' | 'deferredBackpressure'
 >>;
 
-function createDurableSyncResultBase(): InitializedDurableSyncResult {
+export type InitializedDurableSyncDiagnostics = Omit<InitializedDurableSyncResult, 'complete'>;
+
+function createDurableSyncDiagnosticsBase(): InitializedDurableSyncDiagnostics {
   return {
     insertedTriples: 0,
-    complete: false,
     fetchedMetaTriples: 0,
     fetchedDataTriples: 0,
     insertedMetaTriples: 0,
@@ -235,17 +345,12 @@ function createDurableSyncResultBase(): InitializedDurableSyncResult {
   };
 }
 
-/** Neutral merge identity: no work was needed and no failure occurred. */
-export function createCleanEmptyDurableSyncResult(): InitializedDurableSyncResult {
-  return { ...createDurableSyncResultBase(), complete: true };
-}
-
 /** No work completed, but the caller must keep retrying. */
 export function createIncompleteDurableSyncResult(): InitializedDurableSyncResult {
-  return createDurableSyncResultBase();
+  return { ...createDurableSyncDiagnosticsBase(), complete: false };
 }
 
 /** A peer attempt failed before producing a usable durable result. */
 export function createFailedPeerDurableSyncResult(): InitializedDurableSyncResult {
-  return { ...createDurableSyncResultBase(), failedPeers: 1 };
+  return { ...createIncompleteDurableSyncResult(), failedPeers: 1 };
 }

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -1,3 +1,5 @@
+import type { DurableSyncResult } from '../dkg-agent-types.js';
+
 /**
  * The common progress counters emitted by durable and shared-memory sync.
  * Fields are optional so older callers and diagnostic projections can be
@@ -157,4 +159,50 @@ export function isDurableSyncComplete(
 ): boolean {
   return reachedTerminalBoundary
     && classifyDurableProgress(progress).completedWithoutFailure;
+}
+
+type InitializedDurableSyncResult = DurableSyncResult & Required<Pick<
+  DurableSyncResult,
+  'backoffWorthyFailures' | 'deferredBackpressure'
+>>;
+
+function createDurableSyncResultBase(): InitializedDurableSyncResult {
+  return {
+    insertedTriples: 0,
+    complete: false,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 0,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    metaOnlyResponses: 0,
+    verifiedPrivateOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    backoffWorthyFailures: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+/** Neutral merge identity: no work was needed and no failure occurred. */
+export function createCleanEmptyDurableSyncResult(): InitializedDurableSyncResult {
+  return { ...createDurableSyncResultBase(), complete: true };
+}
+
+/** No work completed, but the caller must keep retrying. */
+export function createIncompleteDurableSyncResult(): InitializedDurableSyncResult {
+  return createDurableSyncResultBase();
+}
+
+/** A peer attempt failed before producing a usable durable result. */
+export function createFailedPeerDurableSyncResult(): InitializedDurableSyncResult {
+  return { ...createDurableSyncResultBase(), failedPeers: 1 };
 }

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -184,8 +184,8 @@ type DurableSyncCounterReducer = 'sum' | 'max';
 /**
  * Canonical runtime metadata for every numeric field in DurableSyncResult.
  * The satisfies clause makes a newly added counter a compile error until its
- * aggregation policy is declared here. Consumers can also reuse this table for
- * zero construction and normalized projections instead of duplicating fields.
+ * aggregation policy is declared here. The table stays module-private; public
+ * consumers use typed factories and normalization helpers.
  */
 const DURABLE_SYNC_COUNTER_REDUCERS = {
   insertedTriples: 'sum',
@@ -220,34 +220,92 @@ type DurableSyncCounterKey = keyof typeof DURABLE_SYNC_COUNTER_REDUCERS;
  * here by design: boundary aggregation and a finalized result must not share
  * one boolean whose meaning changes midway through a run.
  */
-export interface DurableSyncAccumulator {
-  diagnostics: InitializedDurableSyncDiagnostics;
-  allTerminalBoundariesReached: boolean;
-  observedTerminalBoundaries: number;
+export class DurableSyncAccumulator {
+  private diagnostics: InitializedDurableSyncDiagnostics;
+
+  private allTerminalBoundariesReached: boolean;
+
+  private observedTerminalBoundaries: number;
+
+  constructor(result?: DurableSyncResult) {
+    if (result) {
+      const { complete, ...diagnostics } = normalizeDurableSyncResult(result);
+      this.diagnostics = diagnostics;
+      this.allTerminalBoundariesReached = complete;
+      this.observedTerminalBoundaries = 1;
+      return;
+    }
+    this.diagnostics = createDurableSyncDiagnosticsBase();
+    this.allTerminalBoundariesReached = true;
+    this.observedTerminalBoundaries = 0;
+  }
+
+  recordDiagnostics(partial: Partial<InitializedDurableSyncDiagnostics>): this {
+    this.diagnostics = mergeDurableSyncDiagnostics(
+      this.diagnostics,
+      normalizeDurableSyncDiagnostics(partial),
+    );
+    return this;
+  }
+
+  merge(part: DurableSyncAccumulator): this {
+    this.diagnostics = mergeDurableSyncDiagnostics(this.diagnostics, part.diagnostics);
+    this.allTerminalBoundariesReached =
+      this.allTerminalBoundariesReached && part.allTerminalBoundariesReached;
+    this.observedTerminalBoundaries += part.observedTerminalBoundaries;
+    return this;
+  }
+
+  recordTerminalBoundary(
+    reachedTerminalBoundary: boolean,
+    options: DurableTerminalBoundaryOptions = {},
+  ): this {
+    if (!reachedTerminalBoundary && options.clearCompletedPhasesWhenIncomplete) {
+      this.diagnostics.completedPhases = 0;
+    }
+    if (
+      reachedTerminalBoundary
+      && options.countCompletedPhase
+      && !classifyDurableProgress(this.diagnostics).hasBlockingFailure
+    ) {
+      this.diagnostics.completedPhases += 1;
+    }
+    this.allTerminalBoundariesReached =
+      this.allTerminalBoundariesReached && reachedTerminalBoundary;
+    this.observedTerminalBoundaries += 1;
+    return this;
+  }
+
+  hasBackoffWorthyFailure(): boolean {
+    return this.diagnostics.backoffWorthyFailures > 0;
+  }
+
+  hasTerminalBoundary(): boolean {
+    return this.observedTerminalBoundaries > 0;
+  }
+
+  finalize(): InitializedDurableSyncResult {
+    return {
+      ...this.diagnostics,
+      complete: this.observedTerminalBoundaries > 0
+        && isDurableSyncComplete(
+          this.diagnostics,
+          this.allTerminalBoundariesReached,
+        ),
+    };
+  }
 }
 
 /** Start a neutral internal fold. It is never exposed as a public result. */
 export function createDurableSyncAccumulator(): DurableSyncAccumulator {
-  return {
-    diagnostics: createDurableSyncDiagnosticsBase(),
-    allTerminalBoundariesReached: true,
-    observedTerminalBoundaries: 0,
-  };
+  return new DurableSyncAccumulator();
 }
 
 /** Convert one finalized public result into an internal fold contribution. */
 export function durableSyncAccumulatorFromResult(
   result: DurableSyncResult,
 ): DurableSyncAccumulator {
-  const { complete, ...diagnostics } = result;
-  return {
-    diagnostics: {
-      ...createDurableSyncDiagnosticsBase(),
-      ...diagnostics,
-    },
-    allTerminalBoundariesReached: complete === true,
-    observedTerminalBoundaries: 1,
-  };
+  return new DurableSyncAccumulator(result);
 }
 
 function mergeDurableSyncDiagnostics(
@@ -269,14 +327,7 @@ export function mergeDurableSyncAccumulatorInto(
   target: DurableSyncAccumulator,
   part: DurableSyncAccumulator,
 ): DurableSyncAccumulator {
-  Object.assign(
-    target.diagnostics,
-    mergeDurableSyncDiagnostics(target.diagnostics, part.diagnostics),
-  );
-  target.allTerminalBoundariesReached =
-    target.allTerminalBoundariesReached && part.allTerminalBoundariesReached;
-  target.observedTerminalBoundaries += part.observedTerminalBoundaries;
-  return target;
+  return target.merge(part);
 }
 
 /** Fold a finalized lane result into an existing internal aggregate. */
@@ -284,10 +335,27 @@ export function mergeDurableSyncResultIntoAccumulator(
   accumulator: DurableSyncAccumulator,
   result: DurableSyncResult,
 ): DurableSyncAccumulator {
-  return mergeDurableSyncAccumulatorInto(
-    accumulator,
-    durableSyncAccumulatorFromResult(result),
-  );
+  return accumulator.merge(durableSyncAccumulatorFromResult(result));
+}
+
+/** Record typed counter deltas without exposing the accumulator's mutable state. */
+export function recordDurableSyncDiagnostics(
+  accumulator: DurableSyncAccumulator,
+  diagnostics: Partial<InitializedDurableSyncDiagnostics>,
+): DurableSyncAccumulator {
+  return accumulator.recordDiagnostics(diagnostics);
+}
+
+export function durableSyncAccumulatorHasBackoffWorthyFailure(
+  accumulator: DurableSyncAccumulator,
+): boolean {
+  return accumulator.hasBackoffWorthyFailure();
+}
+
+export function durableSyncAccumulatorHasTerminalBoundary(
+  accumulator: DurableSyncAccumulator,
+): boolean {
+  return accumulator.hasTerminalBoundary();
 }
 
 /**
@@ -302,35 +370,14 @@ export function markDurableTerminalBoundary(
   reachedTerminalBoundary: boolean,
   options: DurableTerminalBoundaryOptions = {},
 ): DurableSyncAccumulator {
-  const result = accumulator.diagnostics;
-  if (!reachedTerminalBoundary && options.clearCompletedPhasesWhenIncomplete) {
-    result.completedPhases = 0;
-  }
-  if (
-    reachedTerminalBoundary
-    && options.countCompletedPhase
-    && !classifyDurableProgress(result).hasBlockingFailure
-  ) {
-    result.completedPhases += 1;
-  }
-  accumulator.allTerminalBoundariesReached =
-    accumulator.allTerminalBoundariesReached && reachedTerminalBoundary;
-  accumulator.observedTerminalBoundaries += 1;
-  return accumulator;
+  return accumulator.recordTerminalBoundary(reachedTerminalBoundary, options);
 }
 
 /** Assign the public completion verdict once, after every lane is folded. */
 export function finalizeDurableSyncCompletion(
   accumulator: DurableSyncAccumulator,
 ): InitializedDurableSyncResult {
-  return {
-    ...accumulator.diagnostics,
-    complete: accumulator.observedTerminalBoundaries > 0
-      && isDurableSyncComplete(
-        accumulator.diagnostics,
-        accumulator.allTerminalBoundariesReached,
-      ),
-  };
+  return accumulator.finalize();
 }
 
 export type InitializedDurableSyncResult = DurableSyncResult & Required<Pick<
@@ -351,18 +398,25 @@ function createDurableSyncDiagnosticsBase(): InitializedDurableSyncDiagnostics {
  * result contract without exposing internal reducer metadata. Consumers get a
  * stable typed boundary; aggregation policy remains private to this module.
  */
+function normalizeDurableSyncDiagnostics(
+  diagnostics: Partial<InitializedDurableSyncDiagnostics>,
+): InitializedDurableSyncDiagnostics {
+  const normalized = createDurableSyncDiagnosticsBase();
+  for (const key of Object.keys(DURABLE_SYNC_COUNTER_REDUCERS) as DurableSyncCounterKey[]) {
+    const value = diagnostics[key];
+    normalized[key] = value !== undefined && Number.isFinite(value) && value > 0 ? value : 0;
+  }
+  return normalized;
+}
+
+/** Stable public adapter for consumers that need a fully initialized result. */
 export function normalizeDurableSyncResult(
   result: DurableSyncResult,
 ): InitializedDurableSyncResult {
-  const diagnostics = createDurableSyncDiagnosticsBase();
-  const normalized = diagnostics as Record<DurableSyncCounterKey, number>;
-  for (const key of Object.keys(DURABLE_SYNC_COUNTER_REDUCERS) as DurableSyncCounterKey[]) {
-    const value = result[key];
-    normalized[key] = typeof value === 'number' && Number.isFinite(value) && value > 0
-      ? value
-      : 0;
-  }
-  return { ...diagnostics, complete: result.complete === true };
+  return {
+    ...normalizeDurableSyncDiagnostics(result),
+    complete: result.complete === true,
+  };
 }
 
 /** No work completed, but the caller must keep retrying. */

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -155,7 +155,14 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     sawBackpressureDeferral = sawBackpressureDeferral || accounting.deferredByBackpressure;
     if (phase === 'durable') {
       sawDurableMetadataOnlyDetailedSync = sawDurableMetadataOnlyDetailedSync || accounting.metadataOnly;
-      cleanDurableDetailedRound = cleanDurableDetailedRound || accounting.cleanNonMetadataResponse;
+      // Safely committed prefixes are useful progress, but an explicit
+      // incomplete durable result must not refresh the peer's successful-sync
+      // timestamp and suppress the next recovery attempt. Legacy counter-only
+      // results keep their existing behaviour when no completion verdict is
+      // available.
+      cleanDurableDetailedRound = cleanDurableDetailedRound || (
+        complete !== false && accounting.cleanNonMetadataResponse
+      );
     }
     return accounting;
   };

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -136,6 +136,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
   let sawBackoffWorthyFailure = false;
   let sawBackpressureDeferral = false;
   let sawDurableMetadataOnlyDetailedSync = false;
+  let sawExplicitIncompleteDurableResult = false;
   let cleanDurableDetailedRound = false;
   const recordSyncAccounting = (
     result: SyncFromPeerResult,
@@ -155,6 +156,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     sawBackpressureDeferral = sawBackpressureDeferral || accounting.deferredByBackpressure;
     if (phase === 'durable') {
       sawDurableMetadataOnlyDetailedSync = sawDurableMetadataOnlyDetailedSync || accounting.metadataOnly;
+      sawExplicitIncompleteDurableResult = sawExplicitIncompleteDurableResult || complete === false;
       // Safely committed prefixes are useful progress, but an explicit
       // incomplete durable result must not refresh the peer's successful-sync
       // timestamp and suppress the next recovery attempt. Legacy counter-only
@@ -167,7 +169,9 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     return accounting;
   };
   const finishSyncAccounting = (): SyncOnConnectOutcome => {
-    const cleanDurableRound = cleanDurableDetailedRound && !sawDurableMetadataOnlyDetailedSync;
+    const cleanDurableRound = cleanDurableDetailedRound
+      && !sawDurableMetadataOnlyDetailedSync
+      && !sawExplicitIncompleteDurableResult;
     if (sawBackpressureDeferral) {
       if (madeProgress) {
         context.onPeerSynced?.(remotePeer, { fresh: false, progress: true });

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -76,7 +76,10 @@ interface SyncResultAccounting {
   cleanNonMetadataResponse: boolean;
 }
 
-function classifySyncResult(result: SyncFromPeerResult): SyncResultAccounting {
+function classifySyncResult(
+  result: SyncFromPeerResult,
+  complete?: boolean,
+): SyncResultAccounting {
   if (typeof result === 'number') {
     return {
       insertedTriples: result,
@@ -90,7 +93,7 @@ function classifySyncResult(result: SyncFromPeerResult): SyncResultAccounting {
     };
   }
 
-  const progress = classifyDurableProgress(result);
+  const progress = classifyDurableProgress(result, { complete });
   return {
     insertedTriples: result.insertedTriples,
     madeProgress: progress.madeReconnectProgress,
@@ -138,7 +141,13 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     result: SyncFromPeerResult,
     phase: 'durable' | 'shared',
   ): SyncResultAccounting => {
-    const accounting = classifySyncResult(result);
+    const complete = phase === 'durable'
+      && typeof result !== 'number'
+      && 'complete' in result
+      && typeof result.complete === 'boolean'
+        ? result.complete
+        : undefined;
+    const accounting = classifySyncResult(result, complete);
     madeProgress = madeProgress || accounting.madeProgress;
     sawDeniedPhase = sawDeniedPhase || accounting.denied;
     sawFailedPhase = sawFailedPhase || accounting.failed;

--- a/packages/agent/src/sync/requester/changelog-sync.ts
+++ b/packages/agent/src/sync/requester/changelog-sync.ts
@@ -198,11 +198,14 @@ export interface ChangelogSyncDeps {
    */
   runResync(dropCandidates: readonly string[]): Promise<ResyncOutcome>;
   logWarn?(message: string): void;
+  /** Test/containment override; production uses the defensive 100,000-round bound. */
+  maxRounds?: number;
 }
 
 export type ChangelogSyncOutcome =
   | { kind: 'delta' | 'denied'; applied: number }
-  | { kind: 'resync'; applied: number; complete: boolean };
+  | { kind: 'resync'; applied: number; complete: boolean }
+  | { kind: 'incomplete'; applied: number; reason: 'round-limit' };
 
 /** After this many consecutive no-forward-progress rounds, fall back to a full resync. */
 const RESYNC_AFTER_STALLED_ROUNDS = 3;
@@ -222,7 +225,8 @@ const RESYNC_AFTER_STALLED_ROUNDS = 3;
 export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<ChangelogSyncOutcome> {
   let applied = 0;
   let stalledRounds = 0;
-  for (let round = 0; round < 100_000; round++) {
+  const maxRounds = deps.maxRounds ?? 100_000;
+  for (let round = 0; round < maxRounds; round++) {
     const cursor = deps.getCursor();
     const priorSeq = cursor?.seq ?? 0;
     const requestBytes = encodeChangelogRequest({
@@ -270,5 +274,5 @@ export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<Changel
     if (!deferred && advanceTo >= resp.headSeq) return { kind: 'delta', applied };
   }
   deps.logWarn?.('changelog sync exceeded the round bound; stopping (misbehaving peer?)');
-  return { kind: 'delta', applied };
+  return { kind: 'incomplete', applied, reason: 'round-limit' };
 }

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -143,9 +143,17 @@ export function filterExactAssetDurablePayload(
   dataQuads: readonly Quad[],
   metaQuads: readonly Quad[],
   assetUals: readonly string[],
-): { dataQuads: Quad[]; metaQuads: Quad[] } {
+): { dataQuads: Quad[]; metaQuads: Quad[]; descriptorCoverageComplete: boolean } {
   const exactUals = new Set(assetUals);
   const exactMeta = metaQuads.filter((quad) => exactUals.has(quad.subject));
+  const returnedDescriptors = new Set(
+    exactMeta
+      .filter((quad) => (
+        quad.predicate === KA_UAL
+        && quad.subject === stripLiteral(quad.object)
+      ))
+      .map((quad) => quad.subject),
+  );
   const exactGraphs = new Set(
     exactMeta
       .filter((quad) => quad.predicate === ASSERTION_GRAPH)
@@ -154,31 +162,9 @@ export function filterExactAssetDurablePayload(
   return {
     metaQuads: exactMeta,
     dataQuads: dataQuads.filter((quad) => exactGraphs.has(quad.graph)),
+    descriptorCoverageComplete: returnedDescriptors.size === exactUals.size
+      && [...exactUals].every((ual) => returnedDescriptors.has(ual)),
   };
-}
-
-/**
- * An exact VM request has a closed caller-owned inventory. A responder's
- * completed page is not request completion unless it returned one self-bound
- * descriptor for every requested UAL. Descriptor coverage, rather than data
- * graph coverage, deliberately includes private-only/zero-public assets.
- */
-function hasExactAssetDescriptorCoverage(
-  metaQuads: readonly Quad[],
-  assetUals: readonly string[],
-): boolean {
-  const requested = new Set(assetUals);
-  const returned = new Set(
-    metaQuads
-      .filter((quad) => (
-        quad.predicate === KA_UAL
-        && quad.subject === stripLiteral(quad.object)
-        && requested.has(quad.subject)
-      ))
-      .map((quad) => quad.subject),
-  );
-  return returned.size === requested.size
-    && [...requested].every((ual) => returned.has(ual));
 }
 
 export async function runDurableSync(
@@ -352,10 +338,7 @@ export async function runDurableSync(
           ...rawDataResult,
           quads: exact.dataQuads,
         };
-        exactAssetDescriptorCoverageComplete = hasExactAssetDescriptorCoverage(
-          exact.metaQuads,
-          exactAssetUals,
-        );
+        exactAssetDescriptorCoverageComplete = exact.descriptorCoverageComplete;
         if (!exactAssetDescriptorCoverageComplete) {
           logWarn(
             ctx,

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -10,6 +10,7 @@ import type { DurableBatchVerificationMode } from '../../sync-verify-worker.js';
 import { packKnowledgeAssetIdFromIdentity } from '../../ka-identity.js';
 import { planBoundedGraphScopedDurableBatch } from '../durable-integrity.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
+import { isDurableSyncComplete } from '../durable-progress.js';
 import { getSyncCheckpointKey } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
 import type {
@@ -203,7 +204,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
 
   const summary: DurableSyncSummary = {
     insertedTriples: 0,
-    complete: true,
+    complete: false,
     fetchedMetaTriples: 0,
     fetchedDataTriples: 0,
     insertedMetaTriples: 0,
@@ -224,6 +225,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     backoffWorthyFailures: 0,
     deferredBackpressure: 0,
   };
+  let reachedEveryContextGraphTerminalBoundary = contextGraphIds.length > 0;
 
   const recordPhaseOutcome = (
     result: SyncPageResult,
@@ -318,7 +320,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
             );
       if (!skipAgentsMeta) peerRespondedForContextGraph = true;
       if (metaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
-        summary.complete = false;
+        reachedEveryContextGraphTerminalBoundary = false;
         recordPhaseOutcome(metaResult, { updateCheckpoint: false });
         endPhase();
         break;
@@ -495,7 +497,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       const updateDataCheckpoint = batchVerifiedCleanly
         && processed.dataRejectedMissingMeta === 0
         && !metadataOnlyResponse;
-      const contextGraphComplete = batchVerifiedCleanly
+      const reachedContextGraphTerminalBoundary = batchVerifiedCleanly
         && processed.dataRejectedMissingMeta === 0
         && updateMetaCheckpoint
         && updateDataCheckpoint
@@ -503,7 +505,9 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         && !metaResult.timedOut
         && effectiveDataResult.completed
         && !effectiveDataResult.timedOut;
-      if (!contextGraphComplete) summary.complete = false;
+      if (!reachedContextGraphTerminalBoundary) {
+        reachedEveryContextGraphTerminalBoundary = false;
+      }
       // Metadata-only pages may move the meta cursor after storage, but they
       // still are not usable data progress for freshness/backoff accounting.
       if (
@@ -590,7 +594,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       }
 
     } catch (pidErr) {
-      summary.complete = false;
+      reachedEveryContextGraphTerminalBoundary = false;
       endPhase();
       logWarn(ctx, `Sync for context graph "${pid}" from ${remotePeerId} failed: ${pidErr instanceof Error ? pidErr.message : String(pidErr)}`);
       if (isSyncPermanentRejection(pidErr)) {
@@ -627,6 +631,11 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
   if (summary.insertedTriples > 0) {
     logInfo(ctx, `Sync complete: ${summary.insertedTriples} verified triples from ${remotePeerId}`);
   }
+
+  summary.complete = isDurableSyncComplete(
+    summary,
+    reachedEveryContextGraphTerminalBoundary,
+  );
 
   return summary;
 }

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -11,8 +11,10 @@ import { packKnowledgeAssetIdFromIdentity } from '../../ka-identity.js';
 import { planBoundedGraphScopedDurableBatch } from '../durable-integrity.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import {
+  createCleanEmptyDurableSyncResult,
   createIncompleteDurableSyncResult,
-  isDurableSyncComplete,
+  finalizeDurableSyncCompletion,
+  markDurableTerminalBoundary,
 } from '../durable-progress.js';
 import { getSyncCheckpointKey } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
@@ -205,8 +207,9 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     logDebug,
   } = context;
 
-  const summary: DurableSyncSummary = createIncompleteDurableSyncResult();
-  let reachedEveryContextGraphTerminalBoundary = contextGraphIds.length > 0;
+  const summary: DurableSyncSummary = contextGraphIds.length > 0
+    ? createCleanEmptyDurableSyncResult()
+    : createIncompleteDurableSyncResult();
 
   const recordPhaseOutcome = (
     result: SyncPageResult,
@@ -301,7 +304,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
             );
       if (!skipAgentsMeta) peerRespondedForContextGraph = true;
       if (metaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
-        reachedEveryContextGraphTerminalBoundary = false;
+        markDurableTerminalBoundary(summary, false);
         recordPhaseOutcome(metaResult, { updateCheckpoint: false });
         endPhase();
         break;
@@ -486,9 +489,6 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         && !metaResult.timedOut
         && effectiveDataResult.completed
         && !effectiveDataResult.timedOut;
-      if (!reachedContextGraphTerminalBoundary) {
-        reachedEveryContextGraphTerminalBoundary = false;
-      }
       // Metadata-only pages may move the meta cursor after storage, but they
       // still are not usable data progress for freshness/backoff accounting.
       if (
@@ -511,6 +511,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
           updateCheckpoint: updateDataCheckpoint,
           emptyPhase,
         });
+        markDurableTerminalBoundary(summary, reachedContextGraphTerminalBoundary);
         if ((metaResult.timedOut || effectiveDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
           break;
         }
@@ -561,6 +562,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       await notifyVerifiedFullSnapshot();
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
       recordPhaseOutcome(effectiveDataResult, { updateCheckpoint: updateDataCheckpoint });
+      markDurableTerminalBoundary(summary, reachedContextGraphTerminalBoundary);
       endPhase();
       if ((metaResult.timedOut || effectiveDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
         break;
@@ -575,7 +577,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       }
 
     } catch (pidErr) {
-      reachedEveryContextGraphTerminalBoundary = false;
+      markDurableTerminalBoundary(summary, false);
       endPhase();
       logWarn(ctx, `Sync for context graph "${pid}" from ${remotePeerId} failed: ${pidErr instanceof Error ? pidErr.message : String(pidErr)}`);
       if (isSyncPermanentRejection(pidErr)) {
@@ -613,12 +615,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     logInfo(ctx, `Sync complete: ${summary.insertedTriples} verified triples from ${remotePeerId}`);
   }
 
-  summary.complete = isDurableSyncComplete(
-    summary,
-    reachedEveryContextGraphTerminalBoundary,
-  );
-
-  return summary;
+  return finalizeDurableSyncCompletion(summary);
 }
 
 function partitionVerifiedGraphScopedAssets(

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -533,11 +533,18 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
           { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
         );
       }
-      const appliedGraphScopedAssets: VerifiedGraphScopedAsset[] = [];
       for (const asset of partitioned.assets) {
         const outcome = await storeGraphScopedAsset!(asset);
-        if (outcome === 'applied') appliedGraphScopedAssets.push(asset);
-        else if (outcome === 'stale') {
+        if (outcome === 'applied') {
+          // Materialization is atomic per asset, not per fetched page. Account
+          // for each committed asset immediately so a later asset failure does
+          // not erase truthful progress from the returned summary. The phase
+          // checkpoint still advances only after the whole verified page
+          // settles, preserving safe replay semantics.
+          summary.insertedDataTriples += asset.dataQuads.length;
+          summary.insertedMetaTriples += asset.metadataQuads.length;
+          summary.insertedTriples += asset.dataQuads.length + asset.metadataQuads.length;
+        } else if (outcome === 'stale') {
           logDebug(ctx, `Skipped stale graph-scoped durable assertion ${asset.ual} v${asset.assertionVersion}`);
         } else {
           logWarn(ctx, `Quarantined oversized graph-scoped durable assertion ${asset.ual} v${asset.assertionVersion}`);
@@ -552,19 +559,6 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         await storeInsert(partitioned.remainingMeta);
         summary.insertedTriples += partitioned.remainingMeta.length;
         summary.insertedMetaTriples += partitioned.remainingMeta.length;
-      }
-      if (appliedGraphScopedAssets.length > 0) {
-        const graphScopedDataCount = appliedGraphScopedAssets.reduce(
-          (total, asset) => total + asset.dataQuads.length,
-          0,
-        );
-        const graphScopedMetaCount = appliedGraphScopedAssets.reduce(
-          (total, asset) => total + asset.metadataQuads.length,
-          0,
-        );
-        summary.insertedTriples += graphScopedDataCount + graphScopedMetaCount;
-        summary.insertedDataTriples += graphScopedDataCount;
-        summary.insertedMetaTriples += graphScopedMetaCount;
       }
       await notifyVerifiedFullSnapshot();
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -10,7 +10,10 @@ import type { DurableBatchVerificationMode } from '../../sync-verify-worker.js';
 import { packKnowledgeAssetIdFromIdentity } from '../../ka-identity.js';
 import { planBoundedGraphScopedDurableBatch } from '../durable-integrity.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
-import { isDurableSyncComplete } from '../durable-progress.js';
+import {
+  createIncompleteDurableSyncResult,
+  isDurableSyncComplete,
+} from '../durable-progress.js';
 import { getSyncCheckpointKey } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
 import type {
@@ -202,29 +205,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     logDebug,
   } = context;
 
-  const summary: DurableSyncSummary = {
-    insertedTriples: 0,
-    complete: false,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 0,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 0,
-    bytesReceived: 0,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 0,
-    checkpointAdvances: 0,
-    deniedPhases: 0,
-    emptyResponses: 0,
-    metaOnlyResponses: 0,
-    verifiedPrivateOnlyResponses: 0,
-    dataRejectedMissingMeta: 0,
-    rejectedKcs: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    backoffWorthyFailures: 0,
-    deferredBackpressure: 0,
-  };
+  const summary: DurableSyncSummary = createIncompleteDurableSyncResult();
   let reachedEveryContextGraphTerminalBoundary = contextGraphIds.length > 0;
 
   const recordPhaseOutcome = (

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -14,6 +14,7 @@ import {
   createDurableSyncAccumulator,
   finalizeDurableSyncCompletion,
   markDurableTerminalBoundary,
+  type InitializedDurableSyncResult,
 } from '../durable-progress.js';
 import { getSyncCheckpointKey } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
@@ -52,32 +53,6 @@ const GRAPH_SCOPED_SYNC_METADATA_PREDICATES = new Set([
   `${DKG_NS}subGraphName`,
   TRANSACTION_HASH,
 ]);
-
-export interface DurableSyncSummary {
-  insertedTriples: number;
-  /** True only when every requested Context Graph completed cleanly. */
-  complete: boolean;
-  fetchedMetaTriples: number;
-  fetchedDataTriples: number;
-  insertedMetaTriples: number;
-  insertedDataTriples: number;
-  bytesReceived: number;
-  resumedPhases: number;
-  timedOutPhases: number;
-  completedPhases: number;
-  checkpointAdvances: number;
-  deniedPhases: number;
-  emptyResponses: number;
-  metaOnlyResponses: number;
-  verifiedPrivateOnlyResponses: number;
-  dataRejectedMissingMeta: number;
-  rejectedKcs: number;
-  failedPeers: number;
-  failedPhases: number;
-  backoffWorthyFailures: number;
-  /** Context Graph admissions deferred by local scheduler pressure. */
-  deferredBackpressure: number;
-}
 
 /** Graph inventory from one clean, complete legacy full snapshot. */
 export interface VerifiedFullSnapshot {
@@ -182,7 +157,33 @@ export function filterExactAssetDurablePayload(
   };
 }
 
-export async function runDurableSync(context: DurableSyncContext): Promise<DurableSyncSummary> {
+/**
+ * An exact VM request has a closed caller-owned inventory. A responder's
+ * completed page is not request completion unless it returned one self-bound
+ * descriptor for every requested UAL. Descriptor coverage, rather than data
+ * graph coverage, deliberately includes private-only/zero-public assets.
+ */
+function hasExactAssetDescriptorCoverage(
+  metaQuads: readonly Quad[],
+  assetUals: readonly string[],
+): boolean {
+  const requested = new Set(assetUals);
+  const returned = new Set(
+    metaQuads
+      .filter((quad) => (
+        quad.predicate === KA_UAL
+        && quad.subject === stripLiteral(quad.object)
+        && requested.has(quad.subject)
+      ))
+      .map((quad) => quad.subject),
+  );
+  return returned.size === requested.size
+    && [...requested].every((ual) => returned.has(ual));
+}
+
+export async function runDurableSync(
+  context: DurableSyncContext,
+): Promise<InitializedDurableSyncResult> {
   const {
     ctx,
     remotePeerId,
@@ -339,6 +340,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
 
       let effectiveMetaResult = metaResult;
       let dataResult = rawDataResult;
+      let exactAssetDescriptorCoverageComplete = true;
       if (exactAssetUals !== undefined) {
         const exact = filterExactAssetDurablePayload(
           rawDataResult.quads,
@@ -350,6 +352,16 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
           ...rawDataResult,
           quads: exact.dataQuads,
         };
+        exactAssetDescriptorCoverageComplete = hasExactAssetDescriptorCoverage(
+          exact.metaQuads,
+          exactAssetUals,
+        );
+        if (!exactAssetDescriptorCoverageComplete) {
+          logWarn(
+            ctx,
+            `Exact durable response for "${pid}" did not cover every requested asset descriptor`,
+          );
+        }
       }
 
       let effectiveDataResult = dataResult;
@@ -481,6 +493,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         && !metadataOnlyResponse;
       const reachedContextGraphTerminalBoundary = batchVerifiedCleanly
         && processed.dataRejectedMissingMeta === 0
+        && exactAssetDescriptorCoverageComplete
         && updateMetaCheckpoint
         && updateDataCheckpoint
         && metaResult.completed

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -14,6 +14,7 @@ import {
   createDurableSyncAccumulator,
   finalizeDurableSyncCompletion,
   markDurableTerminalBoundary,
+  recordDurableSyncDiagnostics,
   type InitializedDurableSyncResult,
 } from '../durable-progress.js';
 import { getSyncCheckpointKey } from '../checkpoint/state.js';
@@ -194,7 +195,6 @@ export async function runDurableSync(
   } = context;
 
   const accumulator = createDurableSyncAccumulator();
-  const summary = accumulator.diagnostics;
 
   const recordPhaseOutcome = (
     result: SyncPageResult,
@@ -205,8 +205,8 @@ export async function runDurableSync(
     },
   ) => {
     const countProgress = options.countProgress ?? true;
-    summary.resumedPhases += result.resumedFromOffset > 0 ? 1 : 0;
-    summary.timedOutPhases += result.timedOut ? 1 : 0;
+    let completedPhases = 0;
+    let checkpointAdvances = 0;
     if (options.updateCheckpoint && countProgress) {
       if (
         result.completed &&
@@ -217,12 +217,18 @@ export async function runDurableSync(
           result.nextOffset > result.resumedFromOffset
         )
       ) {
-        summary.completedPhases += 1;
+        completedPhases = 1;
       }
       if (result.nextOffset > result.resumedFromOffset) {
-        summary.checkpointAdvances += 1;
+        checkpointAdvances = 1;
       }
     }
+    recordDurableSyncDiagnostics(accumulator, {
+      resumedPhases: result.resumedFromOffset > 0 ? 1 : 0,
+      timedOutPhases: result.timedOut ? 1 : 0,
+      completedPhases,
+      checkpointAdvances,
+    });
     if (!options.updateCheckpoint) return;
     if (result.completed) deleteCheckpoint(result.checkpointKey);
     else if (result.nextOffset > 0 || result.resumedFromOffset > 0) {
@@ -410,13 +416,15 @@ export async function runDurableSync(
 
       logInfo(ctx, `  meta: ${processed.totalFetchedMetaQuads} triples fetched`);
       logInfo(ctx, `  data: ${processed.totalFetchedDataQuads} triples fetched`);
-      summary.bytesReceived += metaResult.bytesReceived + rawDataResult.bytesReceived;
-      summary.fetchedMetaTriples += processed.totalFetchedMetaQuads;
-      summary.fetchedDataTriples += processed.totalFetchedDataQuads;
-      summary.emptyResponses += processed.emptyResponses;
-      summary.metaOnlyResponses += processed.metaOnlyResponses;
-      summary.verifiedPrivateOnlyResponses += processed.verifiedPrivateOnlyResponses;
-      summary.dataRejectedMissingMeta += processed.dataRejectedMissingMeta;
+      recordDurableSyncDiagnostics(accumulator, {
+        bytesReceived: metaResult.bytesReceived + rawDataResult.bytesReceived,
+        fetchedMetaTriples: processed.totalFetchedMetaQuads,
+        fetchedDataTriples: processed.totalFetchedDataQuads,
+        emptyResponses: processed.emptyResponses,
+        metaOnlyResponses: processed.metaOnlyResponses,
+        verifiedPrivateOnlyResponses: processed.verifiedPrivateOnlyResponses,
+        dataRejectedMissingMeta: processed.dataRejectedMissingMeta,
+      });
 
       // A rejected KA means this page cannot be acknowledged safely. We may
       // still persist independently verified KAs from the page, but keeping
@@ -428,7 +436,7 @@ export async function runDurableSync(
           ctx,
           `Rejected ${processed.rejectedKcs} KCs that failed durable integrity verification from ${remotePeerId}`,
         );
-        summary.rejectedKcs += processed.rejectedKcs;
+        recordDurableSyncDiagnostics(accumulator, { rejectedKcs: processed.rejectedKcs });
       }
 
       const notifyVerifiedFullSnapshot = async (): Promise<void> => {
@@ -534,9 +542,11 @@ export async function runDurableSync(
           // not erase truthful progress from the returned summary. The phase
           // checkpoint still advances only after the whole verified page
           // settles, preserving safe replay semantics.
-          summary.insertedDataTriples += asset.dataQuads.length;
-          summary.insertedMetaTriples += asset.metadataQuads.length;
-          summary.insertedTriples += asset.dataQuads.length + asset.metadataQuads.length;
+          recordDurableSyncDiagnostics(accumulator, {
+            insertedDataTriples: asset.dataQuads.length,
+            insertedMetaTriples: asset.metadataQuads.length,
+            insertedTriples: asset.dataQuads.length + asset.metadataQuads.length,
+          });
         } else if (outcome === 'stale') {
           logDebug(ctx, `Skipped stale graph-scoped durable assertion ${asset.ual} v${asset.assertionVersion}`);
         } else {
@@ -545,13 +555,17 @@ export async function runDurableSync(
       }
       if (partitioned.remainingData.length > 0) {
         await storeInsert(partitioned.remainingData);
-        summary.insertedTriples += partitioned.remainingData.length;
-        summary.insertedDataTriples += partitioned.remainingData.length;
+        recordDurableSyncDiagnostics(accumulator, {
+          insertedTriples: partitioned.remainingData.length,
+          insertedDataTriples: partitioned.remainingData.length,
+        });
       }
       if (partitioned.remainingMeta.length > 0) {
         await storeInsert(partitioned.remainingMeta);
-        summary.insertedTriples += partitioned.remainingMeta.length;
-        summary.insertedMetaTriples += partitioned.remainingMeta.length;
+        recordDurableSyncDiagnostics(accumulator, {
+          insertedTriples: partitioned.remainingMeta.length,
+          insertedMetaTriples: partitioned.remainingMeta.length,
+        });
       }
       await notifyVerifiedFullSnapshot();
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
@@ -583,17 +597,17 @@ export async function runDurableSync(
       }
       const backoffWorthy = isSyncBackoffWorthyError(pidErr);
       if (backoffWorthy) {
-        summary.backoffWorthyFailures += 1;
+        recordDurableSyncDiagnostics(accumulator, { backoffWorthyFailures: 1 });
       }
       if ((pidErr as Error & { syncDenied?: boolean }).syncDenied) {
         onAccessDenied?.(pid);
-        summary.deniedPhases += 1;
+        recordDurableSyncDiagnostics(accumulator, { deniedPhases: 1 });
       } else if (
         peerRespondedForContextGraph ||
         didSyncPeerRespond(pidErr) ||
         !isSyncTransportFailure(pidErr)
       ) {
-        summary.failedPhases += 1;
+        recordDurableSyncDiagnostics(accumulator, { failedPhases: 1 });
       } else {
         peerFailed = true;
       }
@@ -603,13 +617,14 @@ export async function runDurableSync(
     }
   }
   if (peerFailed) {
-    summary.failedPeers = 1;
+    recordDurableSyncDiagnostics(accumulator, { failedPeers: 1 });
   }
-  if (summary.insertedTriples > 0) {
-    logInfo(ctx, `Sync complete: ${summary.insertedTriples} verified triples from ${remotePeerId}`);
+  const result = finalizeDurableSyncCompletion(accumulator);
+  if (result.insertedTriples > 0) {
+    logInfo(ctx, `Sync complete: ${result.insertedTriples} verified triples from ${remotePeerId}`);
   }
 
-  return finalizeDurableSyncCompletion(accumulator);
+  return result;
 }
 
 function partitionVerifiedGraphScopedAssets(

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -50,6 +50,8 @@ const GRAPH_SCOPED_SYNC_METADATA_PREDICATES = new Set([
 
 export interface DurableSyncSummary {
   insertedTriples: number;
+  /** True only when every requested Context Graph completed cleanly. */
+  complete: boolean;
   fetchedMetaTriples: number;
   fetchedDataTriples: number;
   insertedMetaTriples: number;
@@ -201,6 +203,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
 
   const summary: DurableSyncSummary = {
     insertedTriples: 0,
+    complete: true,
     fetchedMetaTriples: 0,
     fetchedDataTriples: 0,
     insertedMetaTriples: 0,
@@ -315,6 +318,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
             );
       if (!skipAgentsMeta) peerRespondedForContextGraph = true;
       if (metaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
+        summary.complete = false;
         recordPhaseOutcome(metaResult, { updateCheckpoint: false });
         endPhase();
         break;
@@ -491,6 +495,15 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       const updateDataCheckpoint = batchVerifiedCleanly
         && processed.dataRejectedMissingMeta === 0
         && !metadataOnlyResponse;
+      const contextGraphComplete = batchVerifiedCleanly
+        && processed.dataRejectedMissingMeta === 0
+        && updateMetaCheckpoint
+        && updateDataCheckpoint
+        && metaResult.completed
+        && !metaResult.timedOut
+        && effectiveDataResult.completed
+        && !effectiveDataResult.timedOut;
+      if (!contextGraphComplete) summary.complete = false;
       // Metadata-only pages may move the meta cursor after storage, but they
       // still are not usable data progress for freshness/backoff accounting.
       if (
@@ -577,6 +590,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       }
 
     } catch (pidErr) {
+      summary.complete = false;
       endPhase();
       logWarn(ctx, `Sync for context graph "${pid}" from ${remotePeerId} failed: ${pidErr instanceof Error ? pidErr.message : String(pidErr)}`);
       if (isSyncPermanentRejection(pidErr)) {

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -11,8 +11,7 @@ import { packKnowledgeAssetIdFromIdentity } from '../../ka-identity.js';
 import { planBoundedGraphScopedDurableBatch } from '../durable-integrity.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import {
-  createCleanEmptyDurableSyncResult,
-  createIncompleteDurableSyncResult,
+  createDurableSyncAccumulator,
   finalizeDurableSyncCompletion,
   markDurableTerminalBoundary,
 } from '../durable-progress.js';
@@ -207,9 +206,8 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     logDebug,
   } = context;
 
-  const summary: DurableSyncSummary = contextGraphIds.length > 0
-    ? createCleanEmptyDurableSyncResult()
-    : createIncompleteDurableSyncResult();
+  const accumulator = createDurableSyncAccumulator();
+  const summary = accumulator.diagnostics;
 
   const recordPhaseOutcome = (
     result: SyncPageResult,
@@ -304,7 +302,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
             );
       if (!skipAgentsMeta) peerRespondedForContextGraph = true;
       if (metaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
-        markDurableTerminalBoundary(summary, false);
+        markDurableTerminalBoundary(accumulator, false);
         recordPhaseOutcome(metaResult, { updateCheckpoint: false });
         endPhase();
         break;
@@ -511,7 +509,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
           updateCheckpoint: updateDataCheckpoint,
           emptyPhase,
         });
-        markDurableTerminalBoundary(summary, reachedContextGraphTerminalBoundary);
+        markDurableTerminalBoundary(accumulator, reachedContextGraphTerminalBoundary);
         if ((metaResult.timedOut || effectiveDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
           break;
         }
@@ -562,7 +560,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       await notifyVerifiedFullSnapshot();
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
       recordPhaseOutcome(effectiveDataResult, { updateCheckpoint: updateDataCheckpoint });
-      markDurableTerminalBoundary(summary, reachedContextGraphTerminalBoundary);
+      markDurableTerminalBoundary(accumulator, reachedContextGraphTerminalBoundary);
       endPhase();
       if ((metaResult.timedOut || effectiveDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
         break;
@@ -577,7 +575,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       }
 
     } catch (pidErr) {
-      markDurableTerminalBoundary(summary, false);
+      markDurableTerminalBoundary(accumulator, false);
       endPhase();
       logWarn(ctx, `Sync for context graph "${pid}" from ${remotePeerId} failed: ${pidErr instanceof Error ? pidErr.message : String(pidErr)}`);
       if (isSyncPermanentRejection(pidErr)) {
@@ -615,7 +613,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     logInfo(ctx, `Sync complete: ${summary.insertedTriples} verified triples from ${remotePeerId}`);
   }
 
-  return finalizeDurableSyncCompletion(summary);
+  return finalizeDurableSyncCompletion(accumulator);
 }
 
 function partitionVerifiedGraphScopedAssets(

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -405,9 +405,68 @@ describe('runChangelogSync — driver loop', () => {
     expect(h.resyncs()).toBe(0);
     expect(h.cursor()).toEqual({ era: 'e1', seq: 4 });
   });
+
+  it('returns an explicit incomplete outcome when forward progress never reaches head before the round bound', async () => {
+    const h = loopHarness(
+      [delta(10, 1), delta(10, 2)],
+      async (p) => ({ advanceTo: p.nextSeq, applied: 1, deferred: false }),
+    );
+    h.deps.maxRounds = 2;
+
+    const out = await runChangelogSync(h.deps);
+
+    expect(out).toEqual({ kind: 'incomplete', applied: 2, reason: 'round-limit' });
+    expect(h.cursor()).toEqual({ era: 'e1', seq: 2 });
+  });
 });
 
 describe('changelog drop resync reconciliation', () => {
+  it('surfaces a round-bound stop as an incomplete durable result', async () => {
+    const responses = [
+      encodeChangelogResponse(delta(10, 1)),
+      encodeChangelogResponse(delta(10, 2)),
+    ];
+    let responseIndex = 0;
+    let cursor: { era: string; seq: number } | undefined;
+    const agent = {
+      changelogCursors: {
+        get: () => cursor,
+        set: (_peer: string, _cg: string, era: string, seq: number) => {
+          cursor = { era, seq };
+        },
+      },
+      messenger: { sendToPeer: async () => responses[responseIndex++]! },
+      node: { stopSignal: null },
+      getOrCreateSyncVerifyWorker: () => ({ parseAndFilter: async () => ({ quads: [] }) }),
+      processDurableBatchInWorker: async () => ({
+        verifiedData: [],
+        verifiedMeta: [],
+        verifiedGraphScopedDataGraphs: [],
+        totalFetchedDataQuads: 0,
+        totalFetchedMetaQuads: 0,
+        rejectedKcs: 0,
+        emptyResponses: 1,
+        metaOnlyResponses: 0,
+        verifiedPrivateOnlyResponses: 0,
+        dataRejectedMissingMeta: 0,
+      }),
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+
+    const result = await (LifecycleSyncMethods.prototype.runChangelogSyncForCg as any).call(
+      agent,
+      { kind: 'system', id: 'test', startedAt: 0 },
+      'peer',
+      'cg',
+      2,
+    );
+
+    expect(result.complete).toBe(false);
+    expect(result.failedPhases).toBe(1);
+    expect(result.completedPhases).toBe(0);
+    expect(cursor).toEqual({ era: 'e1', seq: 2 });
+  });
+
   it('removes only graphs absent from the complete verified snapshot before advancing the cursor', async () => {
     const presentGraph = 'did:dkg:context-graph:cg/_verifiable_memory/0xabc/8';
     const staleGraph = 'did:dkg:context-graph:cg/_verifiable_memory/0xabc/9';
@@ -442,8 +501,9 @@ describe('changelog drop resync reconciliation', () => {
         forceFreshSession?: boolean,
       ) => {
         forceFreshSessionFlags.push(forceFreshSession === true);
+        const quads = phase === 'data' ? [qd(presentGraph, 1)] : [];
         return {
-          quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 0,
+          quads, bytesReceived: 0, resumedFromOffset: 0, nextOffset: quads.length,
           checkpointKey: `${contextGraphId}:${phase}`, completed: true, timedOut: false,
         };
       },

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -4,7 +4,9 @@ import {
   createCleanEmptyDurableSyncResult,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
+  finalizeDurableSyncCompletion,
   isDurableSyncComplete,
+  markDurableTerminalBoundary,
 } from '../src/sync/durable-progress.js';
 
 describe('classifyDurableProgress', () => {
@@ -143,6 +145,50 @@ describe('isDurableSyncComplete', () => {
     ['missing metadata', { dataRejectedMissingMeta: 1 }],
   ])('centralizes %s as a non-complete durable result', (_label, failure) => {
     expect(isDurableSyncComplete({ completedPhases: 1, ...failure }, true)).toBe(false);
+  });
+});
+
+describe('durable terminal boundary model', () => {
+  it('keeps an incomplete lane sticky across later clean boundaries', () => {
+    const result = createCleanEmptyDurableSyncResult();
+    result.completedPhases = 1;
+
+    markDurableTerminalBoundary(result, false);
+    markDurableTerminalBoundary(result, true);
+
+    expect(finalizeDurableSyncCompletion(result).complete).toBe(false);
+  });
+
+  it('owns clean phase synthesis and authoritative incomplete cleanup', () => {
+    const complete = createCleanEmptyDurableSyncResult();
+    markDurableTerminalBoundary(complete, true, { countCompletedPhase: true });
+    expect(finalizeDurableSyncCompletion(complete)).toMatchObject({
+      complete: true,
+      completedPhases: 1,
+    });
+
+    const incomplete = createCleanEmptyDurableSyncResult();
+    incomplete.completedPhases = 2;
+    markDurableTerminalBoundary(incomplete, false, {
+      countCompletedPhase: true,
+      clearCompletedPhasesWhenIncomplete: true,
+    });
+    expect(finalizeDurableSyncCompletion(incomplete)).toMatchObject({
+      complete: false,
+      completedPhases: 0,
+    });
+  });
+
+  it('does not synthesize a completed phase when a blocking counter is present', () => {
+    const result = createCleanEmptyDurableSyncResult();
+    result.rejectedKcs = 1;
+
+    markDurableTerminalBoundary(result, true, { countCompletedPhase: true });
+
+    expect(finalizeDurableSyncCompletion(result)).toMatchObject({
+      complete: false,
+      completedPhases: 0,
+    });
   });
 });
 

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -10,6 +10,7 @@ import {
   markDurableTerminalBoundary,
   mergeDurableSyncAccumulatorInto,
   normalizeDurableSyncResult,
+  recordDurableSyncDiagnostics,
 } from '../src/sync/durable-progress.js';
 
 describe('classifyDurableProgress', () => {
@@ -142,6 +143,21 @@ describe('classifyDurableProgress', () => {
     expect(progress.completedReadinessCleanly).toBe(false);
   });
 
+  it('does not classify an explicitly incomplete private-only result as clean progress', () => {
+    const progress = classifyDurableProgress({
+      insertedTriples: 8,
+      insertedDataTriples: 0,
+      insertedMetaTriples: 8,
+      verifiedPrivateOnlyResponses: 1,
+      completedPhases: 1,
+    }, { complete: false });
+
+    expect(progress.hasVerifiedPrivateOnlyResponse).toBe(true);
+    expect(progress.hasCleanVerifiedPrivateOnlyCompletion).toBe(false);
+    expect(progress.madeReconnectProgress).toBe(false);
+    expect(progress.completedWithoutFailure).toBe(false);
+  });
+
   it('keeps the generic classifier counters-only and accepts an explicit durable verdict', () => {
     const counters = { completedPhases: 1 };
 
@@ -175,7 +191,7 @@ describe('isDurableSyncComplete', () => {
 describe('durable terminal boundary model', () => {
   it('keeps an incomplete lane sticky across later clean boundaries', () => {
     const accumulator = createDurableSyncAccumulator();
-    accumulator.diagnostics.completedPhases = 1;
+    recordDurableSyncDiagnostics(accumulator, { completedPhases: 1 });
 
     markDurableTerminalBoundary(accumulator, false);
     markDurableTerminalBoundary(accumulator, true);
@@ -192,7 +208,7 @@ describe('durable terminal boundary model', () => {
     });
 
     const incomplete = createDurableSyncAccumulator();
-    incomplete.diagnostics.completedPhases = 2;
+    recordDurableSyncDiagnostics(incomplete, { completedPhases: 2 });
     markDurableTerminalBoundary(incomplete, false, {
       countCompletedPhase: true,
       clearCompletedPhasesWhenIncomplete: true,
@@ -205,7 +221,7 @@ describe('durable terminal boundary model', () => {
 
   it('does not synthesize a completed phase when a blocking counter is present', () => {
     const accumulator = createDurableSyncAccumulator();
-    accumulator.diagnostics.rejectedKcs = 1;
+    recordDurableSyncDiagnostics(accumulator, { rejectedKcs: 1 });
 
     markDurableTerminalBoundary(accumulator, true, { countCompletedPhase: true });
 
@@ -221,16 +237,16 @@ describe('durable terminal boundary model', () => {
     const publicLane = finalizeDurableSyncCompletion(completedLane);
     const neutral = createDurableSyncAccumulator();
 
-    expect('complete' in neutral.diagnostics).toBe(false);
+    expect('complete' in neutral).toBe(false);
     const merged = mergeDurableSyncAccumulatorInto(
       neutral,
       durableSyncAccumulatorFromResult(publicLane),
     );
-    expect('complete' in merged.diagnostics).toBe(false);
+    expect('complete' in merged).toBe(false);
     expect(finalizeDurableSyncCompletion(merged).complete).toBe(true);
   });
 
-  it('uses canonical counter policies when folding same-peer failures', () => {
+  it('keeps peer failure idempotent while summing phase failures', () => {
     const first = createFailedPeerDurableSyncResult();
     first.failedPhases = 1;
     const second = createFailedPeerDurableSyncResult();
@@ -242,8 +258,10 @@ describe('durable terminal boundary model', () => {
       durableSyncAccumulatorFromResult(second),
     );
 
-    expect(accumulator.diagnostics.failedPeers).toBe(1);
-    expect(accumulator.diagnostics.failedPhases).toBe(3);
+    expect(finalizeDurableSyncCompletion(accumulator)).toMatchObject({
+      failedPeers: 1,
+      failedPhases: 3,
+    });
   });
 });
 

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { classifyDurableProgress } from '../src/sync/durable-progress.js';
+import {
+  classifyDurableProgress,
+  isDurableSyncComplete,
+} from '../src/sync/durable-progress.js';
 
 describe('classifyDurableProgress', () => {
   it('classifies inserted durable data as reconnect and readiness progress', () => {
@@ -116,5 +119,26 @@ describe('classifyDurableProgress', () => {
 
     expect(progress.madeReconnectProgress).toBe(true);
     expect(progress.madeReadinessProgress).toBe(true);
+  });
+});
+
+describe('isDurableSyncComplete', () => {
+  it('requires both a lane terminal boundary and a clean completed phase', () => {
+    const progress = { completedPhases: 1 };
+
+    expect(isDurableSyncComplete(progress, true)).toBe(true);
+    expect(isDurableSyncComplete(progress, false)).toBe(false);
+  });
+
+  it.each([
+    ['timeout', { timedOutPhases: 1 }],
+    ['transport failure', { failedPeers: 1 }],
+    ['phase failure', { failedPhases: 1 }],
+    ['denial', { deniedPhases: 1 }],
+    ['backpressure', { deferredBackpressure: 1 }],
+    ['rejected KC', { rejectedKcs: 1 }],
+    ['missing metadata', { dataRejectedMissingMeta: 1 }],
+  ])('centralizes %s as a non-complete durable result', (_label, failure) => {
+    expect(isDurableSyncComplete({ completedPhases: 1, ...failure }, true)).toBe(false);
   });
 });

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   classifyDurableProgress,
+  createCleanEmptyDurableSyncResult,
+  createFailedPeerDurableSyncResult,
+  createIncompleteDurableSyncResult,
   isDurableSyncComplete,
 } from '../src/sync/durable-progress.js';
 
@@ -140,5 +143,25 @@ describe('isDurableSyncComplete', () => {
     ['missing metadata', { dataRejectedMissingMeta: 1 }],
   ])('centralizes %s as a non-complete durable result', (_label, failure) => {
     expect(isDurableSyncComplete({ completedPhases: 1, ...failure }, true)).toBe(false);
+  });
+});
+
+describe('durable result factories', () => {
+  it('makes clean, incomplete, and failed-peer intent explicit', () => {
+    expect(createCleanEmptyDurableSyncResult()).toMatchObject({
+      complete: true,
+      insertedTriples: 0,
+      failedPeers: 0,
+    });
+    expect(createIncompleteDurableSyncResult()).toMatchObject({
+      complete: false,
+      insertedTriples: 0,
+      failedPeers: 0,
+    });
+    expect(createFailedPeerDurableSyncResult()).toMatchObject({
+      complete: false,
+      insertedTriples: 0,
+      failedPeers: 1,
+    });
   });
 });

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
   classifyDurableProgress,
-  createCleanEmptyDurableSyncResult,
+  createDurableSyncAccumulator,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
+  durableSyncAccumulatorFromResult,
   finalizeDurableSyncCompletion,
   isDurableSyncComplete,
   markDurableTerminalBoundary,
+  mergeDurableSyncAccumulators,
 } from '../src/sync/durable-progress.js';
 
 describe('classifyDurableProgress', () => {
@@ -125,6 +127,20 @@ describe('classifyDurableProgress', () => {
     expect(progress.madeReconnectProgress).toBe(true);
     expect(progress.madeReadinessProgress).toBe(true);
   });
+
+  it('does not classify an explicitly incomplete durable result as readiness complete', () => {
+    const progress = classifyDurableProgress({
+      complete: false,
+      insertedTriples: 40_000,
+      insertedDataTriples: 40_000,
+      completedPhases: 1,
+      checkpointAdvances: 1,
+    });
+
+    expect(progress.madeReadinessProgress).toBe(true);
+    expect(progress.completedWithoutFailure).toBe(false);
+    expect(progress.completedReadinessCleanly).toBe(false);
+  });
 });
 
 describe('isDurableSyncComplete', () => {
@@ -133,6 +149,7 @@ describe('isDurableSyncComplete', () => {
 
     expect(isDurableSyncComplete(progress, true)).toBe(true);
     expect(isDurableSyncComplete(progress, false)).toBe(false);
+    expect(isDurableSyncComplete({ ...progress, complete: false }, true)).toBe(false);
   });
 
   it.each([
@@ -150,25 +167,25 @@ describe('isDurableSyncComplete', () => {
 
 describe('durable terminal boundary model', () => {
   it('keeps an incomplete lane sticky across later clean boundaries', () => {
-    const result = createCleanEmptyDurableSyncResult();
-    result.completedPhases = 1;
+    const accumulator = createDurableSyncAccumulator();
+    accumulator.diagnostics.completedPhases = 1;
 
-    markDurableTerminalBoundary(result, false);
-    markDurableTerminalBoundary(result, true);
+    markDurableTerminalBoundary(accumulator, false);
+    markDurableTerminalBoundary(accumulator, true);
 
-    expect(finalizeDurableSyncCompletion(result).complete).toBe(false);
+    expect(finalizeDurableSyncCompletion(accumulator).complete).toBe(false);
   });
 
   it('owns clean phase synthesis and authoritative incomplete cleanup', () => {
-    const complete = createCleanEmptyDurableSyncResult();
+    const complete = createDurableSyncAccumulator();
     markDurableTerminalBoundary(complete, true, { countCompletedPhase: true });
     expect(finalizeDurableSyncCompletion(complete)).toMatchObject({
       complete: true,
       completedPhases: 1,
     });
 
-    const incomplete = createCleanEmptyDurableSyncResult();
-    incomplete.completedPhases = 2;
+    const incomplete = createDurableSyncAccumulator();
+    incomplete.diagnostics.completedPhases = 2;
     markDurableTerminalBoundary(incomplete, false, {
       countCompletedPhase: true,
       clearCompletedPhasesWhenIncomplete: true,
@@ -180,25 +197,35 @@ describe('durable terminal boundary model', () => {
   });
 
   it('does not synthesize a completed phase when a blocking counter is present', () => {
-    const result = createCleanEmptyDurableSyncResult();
-    result.rejectedKcs = 1;
+    const accumulator = createDurableSyncAccumulator();
+    accumulator.diagnostics.rejectedKcs = 1;
 
-    markDurableTerminalBoundary(result, true, { countCompletedPhase: true });
+    markDurableTerminalBoundary(accumulator, true, { countCompletedPhase: true });
 
-    expect(finalizeDurableSyncCompletion(result)).toMatchObject({
+    expect(finalizeDurableSyncCompletion(accumulator)).toMatchObject({
       complete: false,
       completedPhases: 0,
     });
   });
+
+  it('keeps the neutral merge identity internal and assigns complete only on finalization', () => {
+    const completedLane = createDurableSyncAccumulator();
+    markDurableTerminalBoundary(completedLane, true, { countCompletedPhase: true });
+    const publicLane = finalizeDurableSyncCompletion(completedLane);
+    const neutral = createDurableSyncAccumulator();
+
+    expect('complete' in neutral.diagnostics).toBe(false);
+    const merged = mergeDurableSyncAccumulators(
+      neutral,
+      durableSyncAccumulatorFromResult(publicLane),
+    );
+    expect('complete' in merged.diagnostics).toBe(false);
+    expect(finalizeDurableSyncCompletion(merged).complete).toBe(true);
+  });
 });
 
 describe('durable result factories', () => {
-  it('makes clean, incomplete, and failed-peer intent explicit', () => {
-    expect(createCleanEmptyDurableSyncResult()).toMatchObject({
-      complete: true,
-      insertedTriples: 0,
-      failedPeers: 0,
-    });
+  it('makes incomplete and failed-peer public results self-consistent', () => {
     expect(createIncompleteDurableSyncResult()).toMatchObject({
       complete: false,
       insertedTriples: 0,

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -4,12 +4,12 @@ import {
   createDurableSyncAccumulator,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
-  DURABLE_SYNC_COUNTER_REDUCERS,
   durableSyncAccumulatorFromResult,
   finalizeDurableSyncCompletion,
   isDurableSyncComplete,
   markDurableTerminalBoundary,
   mergeDurableSyncAccumulatorInto,
+  normalizeDurableSyncResult,
 } from '../src/sync/durable-progress.js';
 
 describe('classifyDurableProgress', () => {
@@ -230,7 +230,7 @@ describe('durable terminal boundary model', () => {
     expect(finalizeDurableSyncCompletion(merged).complete).toBe(true);
   });
 
-  it('uses the canonical reducer metadata when folding same-peer failures', () => {
+  it('uses canonical counter policies when folding same-peer failures', () => {
     const first = createFailedPeerDurableSyncResult();
     first.failedPhases = 1;
     const second = createFailedPeerDurableSyncResult();
@@ -242,7 +242,6 @@ describe('durable terminal boundary model', () => {
       durableSyncAccumulatorFromResult(second),
     );
 
-    expect(DURABLE_SYNC_COUNTER_REDUCERS.failedPeers).toBe('max');
     expect(accumulator.diagnostics.failedPeers).toBe(1);
     expect(accumulator.diagnostics.failedPhases).toBe(3);
   });
@@ -259,6 +258,22 @@ describe('durable result factories', () => {
       complete: false,
       insertedTriples: 0,
       failedPeers: 1,
+    });
+  });
+
+  it('normalizes public results without exposing reducer metadata', () => {
+    const result = createIncompleteDurableSyncResult();
+    result.insertedTriples = Number.NaN;
+    result.insertedDataTriples = 7;
+    result.failedPhases = -1;
+    result.backoffWorthyFailures = undefined;
+
+    expect(normalizeDurableSyncResult(result)).toMatchObject({
+      complete: false,
+      insertedTriples: 0,
+      insertedDataTriples: 7,
+      failedPhases: 0,
+      backoffWorthyFailures: 0,
     });
   });
 });

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -4,11 +4,12 @@ import {
   createDurableSyncAccumulator,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
+  DURABLE_SYNC_COUNTER_REDUCERS,
   durableSyncAccumulatorFromResult,
   finalizeDurableSyncCompletion,
   isDurableSyncComplete,
   markDurableTerminalBoundary,
-  mergeDurableSyncAccumulators,
+  mergeDurableSyncAccumulatorInto,
 } from '../src/sync/durable-progress.js';
 
 describe('classifyDurableProgress', () => {
@@ -215,12 +216,29 @@ describe('durable terminal boundary model', () => {
     const neutral = createDurableSyncAccumulator();
 
     expect('complete' in neutral.diagnostics).toBe(false);
-    const merged = mergeDurableSyncAccumulators(
+    const merged = mergeDurableSyncAccumulatorInto(
       neutral,
       durableSyncAccumulatorFromResult(publicLane),
     );
     expect('complete' in merged.diagnostics).toBe(false);
     expect(finalizeDurableSyncCompletion(merged).complete).toBe(true);
+  });
+
+  it('uses the canonical reducer metadata when folding same-peer failures', () => {
+    const first = createFailedPeerDurableSyncResult();
+    first.failedPhases = 1;
+    const second = createFailedPeerDurableSyncResult();
+    second.failedPhases = 2;
+    const accumulator = durableSyncAccumulatorFromResult(first);
+
+    mergeDurableSyncAccumulatorInto(
+      accumulator,
+      durableSyncAccumulatorFromResult(second),
+    );
+
+    expect(DURABLE_SYNC_COUNTER_REDUCERS.failedPeers).toBe('max');
+    expect(accumulator.diagnostics.failedPeers).toBe(1);
+    expect(accumulator.diagnostics.failedPhases).toBe(3);
   });
 });
 

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -263,6 +263,28 @@ describe('durable terminal boundary model', () => {
       failedPhases: 3,
     });
   });
+
+  it('records diagnostic deltas additively while keeping peer failure idempotent', () => {
+    const accumulator = createDurableSyncAccumulator();
+    recordDurableSyncDiagnostics(accumulator, {
+      insertedTriples: 7,
+      failedPeers: 1,
+      failedPhases: 1,
+    });
+    recordDurableSyncDiagnostics(accumulator, {
+      insertedTriples: 5,
+      failedPeers: 1,
+      failedPhases: 2,
+    });
+    markDurableTerminalBoundary(accumulator, false);
+
+    expect(finalizeDurableSyncCompletion(accumulator)).toMatchObject({
+      complete: false,
+      insertedTriples: 12,
+      failedPeers: 1,
+      failedPhases: 3,
+    });
+  });
 });
 
 describe('durable result factories', () => {

--- a/packages/agent/test/durable-progress.test.ts
+++ b/packages/agent/test/durable-progress.test.ts
@@ -131,16 +131,23 @@ describe('classifyDurableProgress', () => {
 
   it('does not classify an explicitly incomplete durable result as readiness complete', () => {
     const progress = classifyDurableProgress({
-      complete: false,
       insertedTriples: 40_000,
       insertedDataTriples: 40_000,
       completedPhases: 1,
       checkpointAdvances: 1,
-    });
+    }, { complete: false });
 
     expect(progress.madeReadinessProgress).toBe(true);
     expect(progress.completedWithoutFailure).toBe(false);
     expect(progress.completedReadinessCleanly).toBe(false);
+  });
+
+  it('keeps the generic classifier counters-only and accepts an explicit durable verdict', () => {
+    const counters = { completedPhases: 1 };
+
+    expect(classifyDurableProgress(counters).completedWithoutFailure).toBe(true);
+    expect(classifyDurableProgress(counters, { complete: true }).completedWithoutFailure).toBe(true);
+    expect(classifyDurableProgress(counters, { complete: false }).completedWithoutFailure).toBe(false);
   });
 });
 
@@ -150,7 +157,6 @@ describe('isDurableSyncComplete', () => {
 
     expect(isDurableSyncComplete(progress, true)).toBe(true);
     expect(isDurableSyncComplete(progress, false)).toBe(false);
-    expect(isDurableSyncComplete({ ...progress, complete: false }, true)).toBe(false);
   });
 
   it.each([

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -46,14 +46,15 @@ describe('durable sync lifecycle chain binding', () => {
     const root = new Uint8Array(32);
     root[31] = 2;
     const rootHex = Array.from(root, (byte) => byte.toString(16).padStart(2, '0')).join('');
+    const getContextGraphNameHash = vi.fn(async () => ethers.keccak256(
+      ethers.toUtf8Bytes(contextGraphId),
+    ));
     const chain = {
       chainId: 'otp:2043',
       getLatestMerkleRoot: async () => root,
       getMerkleRootCount: async () => 2n,
       getKAContextGraphId: async () => 14n,
-      getContextGraphNameHash: async () => ethers.keccak256(
-        ethers.toUtf8Bytes(contextGraphId),
-      ),
+      getContextGraphNameHash,
       getLatestMerkleRootPublisher: async () => '0x2222222222222222222222222222222222222222',
       verifyKAUpdate: async () => ({
         verified: true,
@@ -124,6 +125,9 @@ describe('durable sync lifecycle chain binding', () => {
       ],
     };
     await expect(storeGraphScopedAsset!(asset)).resolves.toBe('applied');
+    await expect(storeGraphScopedAsset!(asset)).resolves.toBe('applied');
+
+    expect(getContextGraphNameHash).toHaveBeenCalledTimes(1);
 
     expect(bindSubscriptionOnChainId).toHaveBeenCalledWith(
       contextGraphId,

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -148,4 +148,101 @@ describe('durable sync lifecycle chain binding', () => {
     >;
     expect('verifiedOnChainContextGraphId' in materializedAsset).toBe(false);
   });
+
+  it('does not reuse a binding proof across different on-chain CG slots', async () => {
+    const root = new Uint8Array(32);
+    root[31] = 2;
+    const rootHex = Array.from(root, (byte) => byte.toString(16).padStart(2, '0')).join('');
+    const expectedNameHash = ethers.keccak256(ethers.toUtf8Bytes(contextGraphId));
+    const getContextGraphNameHash = vi.fn(async (onChainId: bigint) => (
+      onChainId === 14n
+        ? expectedNameHash
+        : ethers.keccak256(ethers.toUtf8Bytes('different-context-graph'))
+    ));
+    const kaNumberMask = (1n << 96n) - 1n;
+    const chain = {
+      chainId: 'otp:2043',
+      getLatestMerkleRoot: async () => root,
+      getMerkleRootCount: async () => 2n,
+      getKAContextGraphId: async (kaId: bigint) => (
+        (kaId & kaNumberMask) === 1n ? 14n : 15n
+      ),
+      getContextGraphNameHash,
+      getLatestMerkleRootPublisher: async () => '0x2222222222222222222222222222222222222222',
+      verifyKAUpdate: async () => ({
+        verified: true,
+        onChainMerkleRoot: root,
+        blockNumber: 123,
+        txIndex: 4,
+        merkleRootCount: 2n,
+      }),
+    } as ChainAdapter;
+    const subscription: { onChainId?: string; subscribed: boolean } = { subscribed: true };
+    const agentLike: any = {
+      config: {},
+      chain,
+      store: {},
+      subscribedContextGraphs: new Map([[contextGraphId, subscription]]),
+      wireIdToLocalCgId: new Map(),
+      bindSubscriptionOnChainId: vi.fn(
+        (_localId: string, sub: typeof subscription, onChainId: string) => {
+          sub.onChainId = onChainId;
+        },
+      ),
+      persistContextGraphSubscriptionState: vi.fn(),
+      processDurableBatchInWorker: async () => ({}),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      syncCheckpoints: new Map(),
+      oversizeTombstoneLog: { record: () => {} },
+      invalidateListContextGraphsCache: vi.fn(),
+      contextGraphMetaProjection: { markDirtyFromQuads: vi.fn() },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+    agentLike.localCgMatchesOnChainSlot = (DKGAgent.prototype as any).localCgMatchesOnChainSlot;
+    agentLike.isWireIdKeyedSubscription = (DKGAgent.prototype as any).isWireIdKeyedSubscription;
+    agentLike.raceChainPolicyRead = (DKGAgent.prototype as any).raceChainPolicyRead;
+
+    await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
+      agentLike,
+      ctx,
+      'peer-remote',
+      contextGraphId,
+      1,
+    );
+    const storeGraphScopedAsset = mockedRunDurableSync.mock.calls[0]![0].storeGraphScopedAsset;
+    const asset = (kaNumber: number): VerifiedGraphScopedAsset => {
+      const assetUal = `did:dkg:otp:2043/0x1111111111111111111111111111111111111111/${kaNumber}`;
+      return {
+        contextGraphId,
+        ual: assetUal,
+        assertionVersion: 2n,
+        assertionGraph: `${assertionGraph}-${kaNumber}`,
+        metaGraph,
+        dataQuads: [],
+        metadataQuads: [
+          {
+            subject: assetUal,
+            predicate: `${DKG}merkleRoot`,
+            object: `"${rootHex}"`,
+            graph: metaGraph,
+          },
+          {
+            subject: assetUal,
+            predicate: `${DKG}transactionHash`,
+            object: `"0x${'02'.padStart(64, '0')}"`,
+            graph: metaGraph,
+          },
+        ],
+      };
+    };
+
+    await expect(storeGraphScopedAsset!(asset(1))).resolves.toBe('applied');
+    await expect(storeGraphScopedAsset!(asset(2))).rejects.toMatchObject({
+      code: 'VM_CHAIN_CONTEXT_GRAPH_MISMATCH',
+    });
+
+    expect(getContextGraphNameHash).toHaveBeenCalledTimes(2);
+    expect(getContextGraphNameHash.mock.calls.map(([id]) => id)).toEqual([14n, 15n]);
+    expect(mockedMaterialize).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/agent/test/durable-sync-since-threading.test.ts
+++ b/packages/agent/test/durable-sync-since-threading.test.ts
@@ -37,6 +37,21 @@ describe('exact-asset rolling-upgrade filter', () => {
 
     expect(filtered.metaQuads.map((quad) => quad.subject)).toEqual([wanted, wanted]);
     expect(filtered.dataQuads.map((quad) => quad.graph)).toEqual([wantedGraph]);
+    expect(filtered.descriptorCoverageComplete).toBe(true);
+  });
+
+  it('reports incomplete descriptor coverage from the same exact projection', () => {
+    const wanted = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7';
+    const missing = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/8';
+    const graph = 'did:dkg:context-graph:cg/_verifiable_memory/0x0000000000000000000000000000000000000001/7';
+    const meta = [
+      { subject: wanted, predicate: 'http://dkg.io/ontology/assertionGraph', object: graph, graph: 'did:dkg:context-graph:cg/_meta' },
+      { subject: wanted, predicate: 'http://dkg.io/ontology/kaUal', object: wanted, graph: 'did:dkg:context-graph:cg/_meta' },
+    ] as Quad[];
+
+    expect(filterExactAssetDurablePayload([], meta, [wanted, missing])).toMatchObject({
+      descriptorCoverageComplete: false,
+    });
   });
 
   it('threads exactAssetUalsFor into both fetch phases and filters an old-responder payload before verification', async () => {

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -216,6 +216,51 @@ describe('bounded rootless durable progress', () => {
     expect(inserted.flat().some((quad) => fixtures.some((entry) => entry.graph === quad.graph))).toBe(false);
   });
 
+  it('reports assets committed before a later materialization failure without advancing the page checkpoint', async () => {
+    const fixtures = orderedAssets();
+    const selected = fixtures.slice(0, 2);
+    const meta = selected.flatMap((entry) => entry.meta);
+    const data = selected.flatMap((entry) => entry.payload);
+    const materialized: Array<{ dataQuads: Quad[]; metadataQuads: Quad[] }> = [];
+    const checkpoints: Array<[string, number]> = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx,
+        _peer,
+        _contextGraphId,
+        _includeSharedMemory,
+        phase,
+      ) => phase === 'meta'
+        ? pageResult('meta', { quads: meta, nextOffset: meta.length })
+        : pageResult('data', { quads: data, nextOffset: data.length }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async (entry) => {
+        if (materialized.length === 1) throw new Error('transient chain lookup timeout');
+        materialized.push(entry);
+        return 'applied';
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: (key, offset) => { checkpoints.push([key, offset]); },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.failedPhases).toBe(1);
+    expect(summary.insertedDataTriples).toBe(materialized[0]!.dataQuads.length);
+    expect(summary.insertedMetaTriples).toBe(materialized[0]!.metadataQuads.length);
+    expect(summary.insertedTriples).toBe(
+      materialized[0]!.dataQuads.length + materialized[0]!.metadataQuads.length,
+    );
+    expect(checkpoints).toEqual([]);
+  });
+
   it('checkpoints a cleanly-closed rootless prefix instead of replaying it from zero', async () => {
     const fixtures = orderedAssets();
     const meta = fixtures.flatMap((entry) => entry.meta);

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -204,6 +204,7 @@ describe('bounded rootless durable progress', () => {
     });
 
     expect(summary.rejectedKcs).toBe(0);
+    expect(summary.complete).toBe(false);
     expect(summary.timedOutPhases).toBe(1);
     expect(summary.insertedDataTriples).toBe(8);
     expect(checkpoints).toContainEqual([`${CONTEXT_GRAPH_ID}:data`, 8]);
@@ -253,6 +254,7 @@ describe('bounded rootless durable progress', () => {
     });
 
     expect(summary.failedPhases).toBe(1);
+    expect(summary.complete).toBe(false);
     expect(summary.insertedDataTriples).toBe(materialized[0]!.dataQuads.length);
     expect(summary.insertedMetaTriples).toBe(materialized[0]!.metadataQuads.length);
     expect(summary.insertedTriples).toBe(
@@ -305,6 +307,7 @@ describe('bounded rootless durable progress', () => {
     });
 
     expect(summary.rejectedKcs).toBe(0);
+    expect(summary.complete).toBe(false);
     expect(summary.timedOutPhases).toBe(0);
     expect(summary.insertedDataTriples).toBe(cleanPrefix.length);
     expect(summary.completedPhases).toBe(1);
@@ -358,6 +361,7 @@ describe('bounded rootless durable progress', () => {
     });
 
     expect(summary.rejectedKcs).toBe(0);
+    expect(summary.complete).toBe(true);
     expect(summary.timedOutPhases).toBe(0);
     expect(summary.insertedDataTriples).toBe(4);
     expect(summary.completedPhases).toBe(2);

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   computeFlatKCRootV10,
+  computePrivateRootV10,
   generateGraphKnowledgeAssetMetadata,
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
@@ -25,6 +26,7 @@ const CONTEXT_GRAPH_URI = `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`;
 const ctx = { operationId: 'bounded-rootless', operationName: 'sync' } as OperationContext;
 
 interface AssetFixture {
+  ual: string;
   graph: string;
   payload: Quad[];
   meta: Quad[];
@@ -44,19 +46,30 @@ function asset(kaNumber: number, tripleCount = 4): AssetFixture {
     object: `"${index}"`,
     graph,
   }));
+  const privateQuads: Quad[] = tripleCount === 0 ? [{
+    subject: `urn:bounded:${kaNumber}:private`,
+    predicate: 'urn:bounded:value',
+    object: '"private"',
+    graph: '',
+  }] : [];
+  const privateMerkleRoot = computePrivateRootV10(privateQuads);
   const meta = generateGraphKnowledgeAssetMetadata({
     ual,
     contextGraphId: CONTEXT_GRAPH_ID,
-    merkleRoot: computeFlatKCRootV10(payload, []),
+    merkleRoot: computeFlatKCRootV10(
+      payload,
+      privateMerkleRoot ? [privateMerkleRoot] : [],
+    ),
     publisherPeerId: 'publisher-peer',
     accessPolicy: 'public',
     timestamp: new Date(0),
     assertionVersion: '1',
     publicTripleCount: payload.length,
-    privateTripleCount: 0,
+    privateTripleCount: privateQuads.length,
+    ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
     assertionGraph: graph,
   }, 'tentative');
-  return { graph, payload, meta };
+  return { ual, graph, payload, meta };
 }
 
 function orderedAssets(): AssetFixture[] {
@@ -261,6 +274,89 @@ describe('bounded rootless durable progress', () => {
       materialized[0]!.dataQuads.length + materialized[0]!.metadataQuads.length,
     );
     expect(checkpoints).toEqual([]);
+  });
+
+  it('keeps a 20-asset exact request incomplete when the responder returns only 6 descriptors', async () => {
+    const requested = Array.from({ length: 20 }, (_, index) => asset(index + 1))
+      .sort((left, right) => left.graph.localeCompare(right.graph));
+    const returned = requested.slice(0, 6);
+    const meta = returned.flatMap((entry) => entry.meta);
+    const data = returned.flatMap((entry) => entry.payload);
+    const materialized: string[] = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-partial-host',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      exactAssetUalsFor: () => requested.map((entry) => entry.ual),
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx,
+        _peer,
+        _contextGraphId,
+        _includeSharedMemory,
+        phase,
+      ) => phase === 'meta'
+        ? pageResult('meta', { quads: meta, nextOffset: meta.length })
+        : pageResult('data', { quads: data, nextOffset: data.length }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async (entry) => {
+        materialized.push(entry.ual);
+        return 'applied';
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(materialized).toEqual(returned.map((entry) => entry.ual));
+    expect(summary.insertedDataTriples).toBe(data.length);
+    expect(summary.complete).toBe(false);
+  });
+
+  it('counts a verified zero-public descriptor toward exact-request coverage', async () => {
+    const requested = [asset(1, 4), asset(2, 0)]
+      .sort((left, right) => left.graph.localeCompare(right.graph));
+    const meta = requested.flatMap((entry) => entry.meta);
+    const data = requested.flatMap((entry) => entry.payload);
+    const materialized: Array<{ ual: string; dataCount: number }> = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-complete-host',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      exactAssetUalsFor: () => requested.map((entry) => entry.ual),
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx,
+        _peer,
+        _contextGraphId,
+        _includeSharedMemory,
+        phase,
+      ) => phase === 'meta'
+        ? pageResult('meta', { quads: meta, nextOffset: meta.length })
+        : pageResult('data', { quads: data, nextOffset: data.length }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async (entry) => {
+        materialized.push({ ual: entry.ual, dataCount: entry.dataQuads.length });
+        return 'applied';
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(materialized).toEqual(requested.map((entry) => ({
+      ual: entry.ual,
+      dataCount: entry.payload.length,
+    })));
+    expect(summary.complete).toBe(true);
   });
 
   it('checkpoints a cleanly-closed rootless prefix instead of replaying it from zero', async () => {

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -720,6 +720,40 @@ describe('DKGAgent sync fetch coalescing', () => {
     }
   });
 
+  it('does not promote subscription readiness from an explicitly incomplete durable result', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const remotePeer = { toString: () => PEER_A };
+
+    try {
+      await agent.start();
+      agent.subscribeToContextGraph('coalesced-cg');
+      (agent as any).isPrivateContextGraph = async () => false;
+      (agent as any).resolvePreferredSyncPeerId = async () => undefined;
+      (agent as any).primeCatchupConnections = async () => undefined;
+      (agent as any).ensurePeerAdmittedForRecovery = async () => true;
+      (agent as any).waitForSyncProtocol = async () => true;
+      (agent as any).refreshMetaSyncedFlags = async () => undefined;
+      (agent.node.libp2p as any).getConnections = () => [{ remotePeer }];
+      (agent.node.libp2p.peerStore as any).get = async () => ({ protocols: [PROTOCOL_SYNC] });
+      (agent as any).syncFromPeerDetailed = async () => ({
+        ...cleanDurableSyncResult(),
+        complete: false,
+        insertedTriples: 40_000,
+        fetchedDataTriples: 40_000,
+        insertedDataTriples: 40_000,
+        checkpointAdvances: 1,
+      });
+
+      const result = await agent.syncContextGraphFromConnectedPeers('coalesced-cg');
+
+      expect(result.peersResponded).toBe(1);
+      expect(result.dataSynced).toBe(40_000);
+      expect(agent.getSubscribedContextGraphs().get('coalesced-cg')?.synced).not.toBe(true);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('does not join catch-up rounds with different shareable identity fields', async () => {
     const cases: Array<{
       name: string;

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -742,6 +742,65 @@ describe('runSyncOnConnect callbacks', () => {
     expect(synced).toEqual([{ peerId: remotePeer, fresh: false, progress: true }]);
   });
 
+  it('keeps an incomplete first durable leg non-fresh after a clean discovered-CG leg', async () => {
+    const remotePeer = freshPeerIdString();
+    let contextGraphs = ['cg-a'];
+    const synced: Array<{
+      peerId: string;
+      fresh: boolean | undefined;
+      progress: boolean | undefined;
+    }> = [];
+    const syncFromPeer = recorder(async (_peerId: string, contextGraphIds?: string[]) => ({
+      complete: contextGraphIds !== undefined,
+      insertedTriples: contextGraphIds === undefined ? 40_000 : 1,
+      insertedDataTriples: contextGraphIds === undefined ? 40_000 : 1,
+      insertedMetaTriples: 0,
+      metaOnlyResponses: 0,
+      verifiedPrivateOnlyResponses: 0,
+      completedPhases: 1,
+      checkpointAdvances: 1,
+      timedOutPhases: 0,
+      failedPeers: 0,
+      failedPhases: 0,
+      deniedPhases: 0,
+      dataRejectedMissingMeta: 0,
+      rejectedKcs: 0,
+    }));
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => contextGraphs,
+      syncFromPeer,
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => {
+        contextGraphs = ['cg-a', 'cg-b'];
+        return 1;
+      },
+      syncSharedMemoryFromPeer: async () => ({
+        insertedTriples: 0,
+        timedOutPhases: 0,
+        failedPeers: 0,
+        deniedPhases: 0,
+      }),
+      logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => synced.push({
+        peerId,
+        fresh: syncOutcome?.fresh,
+        progress: syncOutcome?.progress,
+      }),
+    });
+
+    expect(outcome).toBe('synced');
+    expect(syncFromPeer.calls).toEqual([
+      [remotePeer],
+      [remotePeer, ['cg-b']],
+    ]);
+    expect(synced).toEqual([{ peerId: remotePeer, fresh: false, progress: true }]);
+  });
+
   it.each([
     ['timed out', { timedOutPhases: 1 }],
     ['failed integrity verification', { rejectedKcs: 1 }],

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -692,6 +692,56 @@ describe('runSyncOnConnect callbacks', () => {
     expect(synced).toEqual([{ peerId: remotePeer, fresh: true, progress: true }]);
   });
 
+  it('keeps explicit incomplete durable progress non-fresh and retryable', async () => {
+    const remotePeer = freshPeerIdString();
+    const synced: Array<{
+      peerId: string;
+      fresh: boolean | undefined;
+      progress: boolean | undefined;
+    }> = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => [],
+      syncFromPeer: async () => ({
+        complete: false,
+        insertedTriples: 40_000,
+        insertedDataTriples: 40_000,
+        insertedMetaTriples: 0,
+        metaOnlyResponses: 0,
+        verifiedPrivateOnlyResponses: 0,
+        completedPhases: 1,
+        checkpointAdvances: 1,
+        timedOutPhases: 0,
+        failedPeers: 0,
+        failedPhases: 0,
+        deniedPhases: 0,
+        dataRejectedMissingMeta: 0,
+        rejectedKcs: 0,
+      }),
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async () => ({
+        insertedTriples: 0,
+        timedOutPhases: 0,
+        failedPeers: 0,
+        deniedPhases: 0,
+      }),
+      logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => synced.push({
+        peerId,
+        fresh: syncOutcome?.fresh,
+        progress: syncOutcome?.progress,
+      }),
+    });
+
+    expect(outcome).toBe('synced');
+    expect(synced).toEqual([{ peerId: remotePeer, fresh: false, progress: true }]);
+  });
+
   it.each([
     ['timed out', { timedOutPhases: 1 }],
     ['failed integrity verification', { rejectedKcs: 1 }],

--- a/packages/agent/test/sync-requester-priority.test.ts
+++ b/packages/agent/test/sync-requester-priority.test.ts
@@ -144,6 +144,7 @@ describe('requester per-CG priority admission', () => {
     expect(summary.deferredBackpressure).toBe(1);
     expect(summary.failedPeers).toBe(0);
     expect(summary.backoffWorthyFailures).toBe(0);
+    expect(summary.complete).toBe(false);
   });
 
   it('marks changelog admission pressure deferred without routing that graph to legacy', async () => {

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -146,6 +146,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   // from the other peers instead of failing the entire subscribe/catch-up immediately.
   const emptyDurable = () => ({
     insertedTriples: 0,
+    complete: false,
     fetchedMetaTriples: 0,
     fetchedDataTriples: 0,
     insertedMetaTriples: 0,

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -1,5 +1,9 @@
 import { parentPort } from 'node:worker_threads';
-import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS, mapWithConcurrency } from '@origintrail-official/dkg-agent';
+import {
+  CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
+  createFailedPeerDurableSyncResult,
+  mapWithConcurrency,
+} from '@origintrail-official/dkg-agent';
 import {
   catchupPeerResponded,
   catchupPeerSucceeded,
@@ -144,28 +148,6 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
 
   // Isolate per-peer failures: if one peer's sync steps throw, aggregate what we can
   // from the other peers instead of failing the entire subscribe/catch-up immediately.
-  const emptyDurable = () => ({
-    insertedTriples: 0,
-    complete: false,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 0,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 0,
-    bytesReceived: 0,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 0,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    metaOnlyResponses: 0,
-    verifiedPrivateOnlyResponses: 0,
-    dataRejectedMissingMeta: 0,
-    rejectedKcs: 0,
-    failedPeers: 1,
-    failedPhases: 0,
-    deniedPhases: 0,
-    deferredBackpressure: 0,
-  });
   const emptyShared = () => ({
     insertedTriples: 0,
     fetchedMetaTriples: 0,
@@ -193,7 +175,8 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     syncCapable,
     CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
     async (peerId) => {
-      const rawDurable = await invoke<any>('syncDurable', peerId, request.contextGraphId).catch(() => emptyDurable());
+      const rawDurable = await invoke<any>('syncDurable', peerId, request.contextGraphId)
+        .catch(() => createFailedPeerDurableSyncResult());
       const durable = {
         ...rawDurable,
         verifiedPrivateOnlyResponses: rawDurable.verifiedPrivateOnlyResponses ?? 0,
@@ -230,7 +213,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       (diagnostics.durable.deniedPhases ?? 0) + (durable.deniedPhases ?? 0);
     peerDenied = peerDenied || durable.deniedPhases > 0;
 
-    if (catchupPlaneCompletedWithoutFailure(durable)) {
+    if (catchupPlaneCompletedWithoutFailure(durable, durable.complete)) {
       if ((durable.insertedDataTriples ?? 0) > 0) {
         cleanPlaneCompletions.durable.verifiedDataPeers += 1;
       }
@@ -286,7 +269,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     // completed with no timeout. Mirrors the inline
     // `syncContextGraphFromConnectedPeers` path so both runners report the
     // same shape.
-    if (catchupPeerSucceeded(durable, shared, peerDenied)) {
+    if (catchupPeerSucceeded(durable, shared, peerDenied, durable.complete)) {
       peersSucceeded += 1;
     }
   }

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -3,8 +3,10 @@ import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
   classifyDurableProgress,
+  DURABLE_SYNC_COUNTER_REDUCERS,
   type DKGAgent,
   type DurableProgressSummary,
+  type DurableSyncCounterKey,
   type DurableSyncDiagnostics,
   type DurableSyncResult,
 } from '@origintrail-official/dkg-agent';
@@ -120,6 +122,39 @@ export interface DurableLegSummary {
   hardFailureDetails: string[];
 }
 
+/** The only agent capabilities required by the route-level durable leg. */
+export interface DurableCatchupAgent {
+  syncFromPeerDetailed?: OmitThisParameter<DKGAgent['syncFromPeerDetailed']>;
+  syncFromPeer?: OmitThisParameter<DKGAgent['syncFromPeer']>;
+}
+
+export interface DurableCatchupLegResult {
+  insertedTriples: number;
+  complete?: boolean;
+  diagnostics?: DurableLegDiagnostics;
+  error?: string;
+}
+
+export interface DurableCatchupAttempt {
+  durableComplete?: boolean;
+  durableError?: string;
+  error?: string;
+}
+
+export interface DurableCatchupRequestOutcome {
+  attempts: DurableCatchupAttempt[];
+  perContextGraphCompletion: Array<boolean | undefined>;
+  complete?: boolean;
+  allPeersFailed: boolean;
+  incomplete: boolean;
+  responseStatus: 200 | 503;
+  errorBody: {
+    errorCode: 'DURABLE_CATCHUP_ALL_PEERS_FAILED' | 'DURABLE_CATCHUP_INCOMPLETE';
+    error: string;
+    retryable: true;
+  } | undefined;
+}
+
 /**
  * Adapt the agent's typed durable result for operator-facing catch-up APIs.
  * Whole-leg completion comes only from the explicit agent contract; phase
@@ -130,28 +165,11 @@ export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummar
     if (value === undefined || !Number.isFinite(value) || value <= 0) return 0;
     return value;
   };
-  const diagnostics: DurableLegDiagnostics = {
-    fetchedMetaTriples: count(result.fetchedMetaTriples),
-    fetchedDataTriples: count(result.fetchedDataTriples),
-    insertedMetaTriples: count(result.insertedMetaTriples),
-    insertedDataTriples: count(result.insertedDataTriples),
-    bytesReceived: count(result.bytesReceived),
-    resumedPhases: count(result.resumedPhases),
-    timedOutPhases: count(result.timedOutPhases),
-    completedPhases: count(result.completedPhases),
-    checkpointAdvances: count(result.checkpointAdvances),
-    deniedPhases: count(result.deniedPhases),
-    emptyResponses: count(result.emptyResponses),
-    metaOnlyResponses: count(result.metaOnlyResponses),
-    verifiedPrivateOnlyResponses: count(result.verifiedPrivateOnlyResponses),
-    dataRejectedMissingMeta: count(result.dataRejectedMissingMeta),
-    rejectedKcs: count(result.rejectedKcs),
-    failedPeers: count(result.failedPeers),
-    failedPhases: count(result.failedPhases),
-    backoffWorthyFailures: count(result.backoffWorthyFailures),
-    deferredBackpressure: count(result.deferredBackpressure),
-  };
-  const insertedTriples = count(result.insertedTriples);
+  const normalizedCounters = Object.fromEntries(
+    (Object.keys(DURABLE_SYNC_COUNTER_REDUCERS) as DurableSyncCounterKey[])
+      .map((key) => [key, count(result[key])]),
+  ) as Record<DurableSyncCounterKey, number>;
+  const { insertedTriples, ...diagnostics } = normalizedCounters;
   const hardFailureDetails = [
     ['failedPeers', diagnostics.failedPeers],
     ['failedPhases', diagnostics.failedPhases],
@@ -176,6 +194,113 @@ export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummar
     diagnostics,
     complete: result.complete,
     hardFailureDetails,
+  };
+}
+
+/**
+ * Execute one durable route leg behind a typed capability boundary. Detailed
+ * agents expose completion/diagnostics; older agents retain the legacy count.
+ */
+export async function runDurableCatchupLeg(
+  agent: DurableCatchupAgent,
+  peerId: string,
+  contextGraphId: string,
+  totalTimeoutMs: number,
+): Promise<DurableCatchupLegResult> {
+  try {
+    if (typeof agent.syncFromPeerDetailed === 'function') {
+      const detailed = await agent.syncFromPeerDetailed(
+        peerId,
+        [contextGraphId],
+        undefined,
+        undefined,
+        undefined,
+        { totalTimeoutMs },
+      );
+      const summary = summarizeDurableLeg(detailed);
+      return {
+        insertedTriples: summary.insertedTriples,
+        complete: summary.complete,
+        diagnostics: summary.diagnostics,
+        ...(summary.hardFailureDetails.length > 0 ? {
+          error: `Durable sync did not complete (${summary.hardFailureDetails.join(', ')})`,
+        } : {}),
+      };
+    }
+
+    return {
+      insertedTriples: typeof agent.syncFromPeer === 'function'
+        ? await agent.syncFromPeer(
+          peerId,
+          [contextGraphId],
+          undefined,
+          undefined,
+          { totalTimeoutMs },
+        )
+        : 0,
+    };
+  } catch (error) {
+    return {
+      insertedTriples: 0,
+      complete: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function durableCatchupCompletionFor(
+  attempts: readonly DurableCatchupAttempt[],
+): boolean | undefined {
+  return attempts.length > 0 && attempts.every((attempt) => attempt.durableComplete !== undefined)
+    ? attempts.every((attempt) => attempt.durableComplete === true)
+    : undefined;
+}
+
+/**
+ * Aggregate completion across every requested CG. A complete subset must not
+ * manufacture a complete whole-request verdict when another CG had no result.
+ */
+export function classifyDurableCatchupRequest(
+  perContextGraphAttempts: ReadonlyArray<readonly DurableCatchupAttempt[]>,
+  includeDurable: boolean,
+  includeSharedMemory: boolean,
+): DurableCatchupRequestOutcome {
+  const attempts = includeDurable ? perContextGraphAttempts.flatMap((parts) => [...parts]) : [];
+  const perContextGraphCompletion = perContextGraphAttempts.map(durableCatchupCompletionFor);
+  const complete = includeDurable
+    && perContextGraphCompletion.length > 0
+    && perContextGraphCompletion.every((value) => value !== undefined)
+      ? perContextGraphCompletion.every((value) => value === true)
+      : undefined;
+  const allPeersFailed = includeDurable
+    && !includeSharedMemory
+    && attempts.length > 0
+    && attempts.every((attempt) => Boolean(attempt.durableError || attempt.error));
+  const incomplete = includeDurable
+    && !includeSharedMemory
+    && complete === false
+    && !allPeersFailed;
+
+  return {
+    attempts,
+    perContextGraphCompletion,
+    complete,
+    allPeersFailed,
+    incomplete,
+    responseStatus: allPeersFailed ? 503 : 200,
+    errorBody: allPeersFailed
+      ? {
+        errorCode: 'DURABLE_CATCHUP_ALL_PEERS_FAILED',
+        error: 'Durable catchup failed for every selected peer',
+        retryable: true,
+      }
+      : incomplete
+        ? {
+          errorCode: 'DURABLE_CATCHUP_INCOMPLETE',
+          error: 'Durable catchup committed partial progress but did not reach the terminal boundary',
+          retryable: true,
+        }
+        : undefined,
   };
 }
 

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -5,6 +5,7 @@ import {
   classifyDurableProgress,
   type DKGAgent,
   type DurableProgressSummary,
+  type DurableSyncDiagnostics,
   type DurableSyncResult,
 } from '@origintrail-official/dkg-agent';
 import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
@@ -109,10 +110,8 @@ export interface CatchupPhaseProgress extends DurableProgressSummary {
   emptyResponses?: number;
 }
 
-export type DurableLegDiagnostics = Omit<
-  Required<DurableSyncResult>,
-  'insertedTriples' | 'complete'
->;
+export type DurableLegDiagnostics = DurableSyncDiagnostics
+  & Pick<DurableSyncResult, 'deniedPhases'>;
 
 export interface DurableLegSummary {
   insertedTriples: number;
@@ -159,14 +158,10 @@ export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummar
     ['rejectedKcs', diagnostics.rejectedKcs],
     ['dataRejectedMissingMeta', diagnostics.dataRejectedMissingMeta],
   ].flatMap(([name, value]) => Number(value) > 0 ? [`${name}=${value}`] : []);
-  const progress = classifyDurableProgress(result);
-
   return {
     insertedTriples: count(result.insertedTriples),
     diagnostics,
-    complete: result.complete === true
-      && progress.completedWithoutFailure
-      && hardFailureDetails.length === 0,
+    complete: result.complete,
     hardFailureDetails,
   };
 }

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -146,10 +146,14 @@ export interface DurableCatchupRequestOutcome {
   perContextGraphCompletion: Array<boolean | undefined>;
   complete?: boolean;
   allPeersFailed: boolean;
+  noEligibleAttempts: boolean;
   incomplete: boolean;
   responseStatus: 200 | 503;
   errorBody: {
-    errorCode: 'DURABLE_CATCHUP_ALL_PEERS_FAILED' | 'DURABLE_CATCHUP_INCOMPLETE';
+    errorCode:
+      | 'DURABLE_CATCHUP_ALL_PEERS_FAILED'
+      | 'DURABLE_CATCHUP_NO_ELIGIBLE_PEERS'
+      | 'DURABLE_CATCHUP_INCOMPLETE';
     error: string;
     retryable: true;
   } | undefined;
@@ -268,15 +272,22 @@ export function classifyDurableCatchupRequest(
 ): DurableCatchupRequestOutcome {
   const attempts = includeDurable ? perContextGraphAttempts.flatMap((parts) => [...parts]) : [];
   const perContextGraphCompletion = perContextGraphAttempts.map(durableCatchupCompletionFor);
-  const complete = includeDurable
-    && perContextGraphCompletion.length > 0
-    && perContextGraphCompletion.every((value) => value !== undefined)
+  const missingContextGraphAttempt = includeDurable
+    && !includeSharedMemory
+    && perContextGraphAttempts.length > 0
+    && perContextGraphAttempts.some((parts) => parts.length === 0);
+  const everyContextGraphCompletionKnown = perContextGraphCompletion.length > 0
+    && perContextGraphCompletion.every((value) => value !== undefined);
+  const complete = missingContextGraphAttempt
+    ? false
+    : includeDurable && everyContextGraphCompletionKnown
       ? perContextGraphCompletion.every((value) => value === true)
       : undefined;
   const allPeersFailed = includeDurable
     && !includeSharedMemory
     && attempts.length > 0
     && attempts.every((attempt) => Boolean(attempt.durableError || attempt.error));
+  const noEligibleAttempts = missingContextGraphAttempt && attempts.length === 0;
   const incomplete = includeDurable
     && !includeSharedMemory
     && complete === false
@@ -287,14 +298,21 @@ export function classifyDurableCatchupRequest(
     perContextGraphCompletion,
     complete,
     allPeersFailed,
+    noEligibleAttempts,
     incomplete,
-    responseStatus: allPeersFailed ? 503 : 200,
+    responseStatus: allPeersFailed || noEligibleAttempts ? 503 : 200,
     errorBody: allPeersFailed
       ? {
         errorCode: 'DURABLE_CATCHUP_ALL_PEERS_FAILED',
         error: 'Durable catchup failed for every selected peer',
         retryable: true,
       }
+      : noEligibleAttempts
+        ? {
+          errorCode: 'DURABLE_CATCHUP_NO_ELIGIBLE_PEERS',
+          error: 'Durable catchup had no eligible peer for any requested context graph',
+          retryable: true,
+        }
       : incomplete
         ? {
           errorCode: 'DURABLE_CATCHUP_INCOMPLETE',

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -151,6 +151,7 @@ export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummar
     backoffWorthyFailures: count(result.backoffWorthyFailures),
     deferredBackpressure: count(result.deferredBackpressure),
   };
+  const insertedTriples = count(result.insertedTriples);
   const hardFailureDetails = [
     ['failedPeers', diagnostics.failedPeers],
     ['failedPhases', diagnostics.failedPhases],
@@ -158,8 +159,20 @@ export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummar
     ['rejectedKcs', diagnostics.rejectedKcs],
     ['dataRejectedMissingMeta', diagnostics.dataRejectedMissingMeta],
   ].flatMap(([name, value]) => Number(value) > 0 ? [`${name}=${value}`] : []);
+  const committedProgress = insertedTriples > 0
+    || diagnostics.insertedDataTriples > 0
+    || diagnostics.insertedMetaTriples > 0
+    || diagnostics.checkpointAdvances > 0;
+  if (!result.complete && !committedProgress && hardFailureDetails.length === 0) {
+    // A timeout/backpressure stop before the first durable boundary is not a
+    // successful no-op. Give the HTTP adapter a typed failure reason so
+    // durable-only automation keeps retrying instead of treating 200/ok as an
+    // already-synchronized graph. Safely committed prefixes remain observable
+    // as retryable progress and intentionally do not enter this branch.
+    hardFailureDetails.push('incompleteWithoutProgress=1');
+  }
   return {
-    insertedTriples: count(result.insertedTriples),
+    insertedTriples,
     diagnostics,
     complete: result.complete,
     hardFailureDetails,

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -251,8 +251,9 @@ export async function runDurableCatchupLeg(
 export function durableCatchupCompletionFor(
   attempts: readonly DurableCatchupAttempt[],
 ): boolean | undefined {
+  if (attempts.some((attempt) => attempt.durableComplete === true)) return true;
   return attempts.length > 0 && attempts.every((attempt) => attempt.durableComplete !== undefined)
-    ? attempts.every((attempt) => attempt.durableComplete === true)
+    ? false
     : undefined;
 }
 
@@ -306,16 +307,18 @@ export function classifyDurableCatchupRequest(
 
 export function catchupPlaneCompletedWithoutFailure(
   progress: CatchupPhaseProgress | null | undefined,
+  complete?: boolean,
 ): boolean {
-  return classifyDurableProgress(progress).completedWithoutFailure;
+  return classifyDurableProgress(progress, { complete }).completedWithoutFailure;
 }
 
 export function catchupPeerSucceeded(
   durable: CatchupPhaseProgress,
   shared: CatchupPhaseProgress | null | undefined,
   peerDenied: boolean,
+  durableComplete?: boolean,
 ): boolean {
-  const durableProgress = classifyDurableProgress(durable);
+  const durableProgress = classifyDurableProgress(durable, { complete: durableComplete });
   const sharedProgress = shared ? classifyDurableProgress(shared) : null;
   if (
     !catchupPeerResponded(durable, shared)

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -118,8 +118,23 @@ export interface DurableLegSummary {
   insertedTriples: number;
   diagnostics: DurableLegDiagnostics;
   complete: boolean;
-  hardFailureDetails: string[];
+  state: DurableCatchupLegState;
+  failureReasons: DurableCatchupFailureReason[];
 }
+
+export type DurableCatchupLegState = 'complete' | 'incomplete-progress' | 'failed' | 'legacy';
+
+export type DurableCatchupFailureCode =
+  | 'failedPeers'
+  | 'failedPhases'
+  | 'deniedPhases'
+  | 'rejectedKcs'
+  | 'dataRejectedMissingMeta'
+  | 'incompleteWithoutProgress';
+
+export type DurableCatchupFailureReason =
+  | { code: DurableCatchupFailureCode; count: number }
+  | { code: 'exception'; message: string };
 
 /** The only agent capabilities required by the route-level durable leg. */
 export interface DurableCatchupAgent {
@@ -129,12 +144,14 @@ export interface DurableCatchupAgent {
 
 export interface DurableCatchupLegResult {
   insertedTriples: number;
+  state: DurableCatchupLegState;
   complete?: boolean;
   diagnostics?: DurableLegDiagnostics;
-  error?: string;
+  failureReasons?: DurableCatchupFailureReason[];
 }
 
 export interface DurableCatchupAttempt {
+  durableState?: DurableCatchupLegState;
   durableComplete?: boolean;
   durableError?: string;
   error?: string;
@@ -164,36 +181,60 @@ export interface DurableCatchupRequestOutcome {
  * counters remain diagnostics and can describe safely committed prefixes.
  */
 export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummary {
-  const {
-    insertedTriples,
-    complete,
-    ...diagnostics
-  } = normalizeDurableSyncResult(result);
-  const hardFailureDetails = [
+  const normalized = normalizeDurableSyncResult(result);
+  const { insertedTriples, complete, ...diagnostics } = normalized;
+  const failureReasons = [
     ['failedPeers', diagnostics.failedPeers],
     ['failedPhases', diagnostics.failedPhases],
     ['deniedPhases', diagnostics.deniedPhases],
     ['rejectedKcs', diagnostics.rejectedKcs],
     ['dataRejectedMissingMeta', diagnostics.dataRejectedMissingMeta],
-  ].flatMap(([name, value]) => Number(value) > 0 ? [`${name}=${value}`] : []);
+  ].flatMap(([code, count]) => Number(count) > 0 ? [{
+      code: code as DurableCatchupFailureCode,
+      count: Number(count),
+    }] : []);
   const committedProgress = insertedTriples > 0
     || diagnostics.insertedDataTriples > 0
     || diagnostics.insertedMetaTriples > 0
     || diagnostics.checkpointAdvances > 0;
-  if (!complete && !committedProgress && hardFailureDetails.length === 0) {
+  if (!complete && !committedProgress && failureReasons.length === 0) {
     // A timeout/backpressure stop before the first durable boundary is not a
     // successful no-op. Give the HTTP adapter a typed failure reason so
     // durable-only automation keeps retrying instead of treating 200/ok as an
     // already-synchronized graph. Safely committed prefixes remain observable
     // as retryable progress and intentionally do not enter this branch.
-    hardFailureDetails.push('incompleteWithoutProgress=1');
+    failureReasons.push({ code: 'incompleteWithoutProgress', count: 1 });
   }
+  const state: DurableCatchupLegState = complete && failureReasons.length === 0
+    ? 'complete'
+    : failureReasons.length > 0
+      ? 'failed'
+      : 'incomplete-progress';
   return {
     insertedTriples,
     diagnostics,
-    complete,
-    hardFailureDetails,
+    complete: state === 'complete',
+    state,
+    failureReasons,
   };
+}
+
+/** Convert typed leg failures to the legacy operator-facing message at the HTTP boundary. */
+export function formatDurableCatchupFailure(
+  reasons: readonly DurableCatchupFailureReason[] | undefined,
+): string | undefined {
+  if (!reasons || reasons.length === 0) return undefined;
+  const exception = reasons.find(
+    (reason): reason is Extract<DurableCatchupFailureReason, { code: 'exception' }> => (
+      reason.code === 'exception'
+    ),
+  );
+  if (exception) return exception.message;
+  return `Durable sync did not complete (${reasons
+    .map((reason) => reason.code === 'exception'
+      ? reason.message
+      : `${reason.code}=${reason.count}`)
+    .join(', ')})`;
 }
 
 /**
@@ -219,11 +260,10 @@ export async function runDurableCatchupLeg(
       const summary = summarizeDurableLeg(detailed);
       return {
         insertedTriples: summary.insertedTriples,
+        state: summary.state,
         complete: summary.complete,
         diagnostics: summary.diagnostics,
-        ...(summary.hardFailureDetails.length > 0 ? {
-          error: `Durable sync did not complete (${summary.hardFailureDetails.join(', ')})`,
-        } : {}),
+        ...(summary.failureReasons.length > 0 ? { failureReasons: summary.failureReasons } : {}),
       };
     }
 
@@ -237,12 +277,17 @@ export async function runDurableCatchupLeg(
           { totalTimeoutMs },
         )
         : 0,
+      state: 'legacy',
     };
   } catch (error) {
     return {
       insertedTriples: 0,
+      state: 'failed',
       complete: false,
-      error: error instanceof Error ? error.message : String(error),
+      failureReasons: [{
+        code: 'exception',
+        message: error instanceof Error ? error.message : String(error),
+      }],
     };
   }
 }
@@ -281,7 +326,10 @@ export function classifyDurableCatchupRequest(
   const allPeersFailed = includeDurable
     && !includeSharedMemory
     && attempts.length > 0
-    && attempts.every((attempt) => Boolean(attempt.durableError || attempt.error));
+    && attempts.every((attempt) => (
+      attempt.durableState === 'failed'
+      || (attempt.durableState === undefined && Boolean(attempt.error))
+    ));
   const noEligibleAttempts = missingContextGraphAttempt && attempts.length === 0;
   const incomplete = includeDurable
     && !includeSharedMemory

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -5,6 +5,7 @@ import {
   classifyDurableProgress,
   type DKGAgent,
   type DurableProgressSummary,
+  type DurableSyncResult,
 } from '@origintrail-official/dkg-agent';
 import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
 
@@ -106,6 +107,68 @@ export interface CatchupRunRequest {
 export interface CatchupPhaseProgress extends DurableProgressSummary {
   bytesReceived?: number;
   emptyResponses?: number;
+}
+
+export type DurableLegDiagnostics = Omit<
+  Required<DurableSyncResult>,
+  'insertedTriples' | 'complete'
+>;
+
+export interface DurableLegSummary {
+  insertedTriples: number;
+  diagnostics: DurableLegDiagnostics;
+  complete: boolean;
+  hardFailureDetails: string[];
+}
+
+/**
+ * Adapt the agent's typed durable result for operator-facing catch-up APIs.
+ * Whole-leg completion comes only from the explicit agent contract; phase
+ * counters remain diagnostics and can describe safely committed prefixes.
+ */
+export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummary {
+  const count = (value: number | undefined): number => {
+    if (value === undefined || !Number.isFinite(value) || value <= 0) return 0;
+    return value;
+  };
+  const diagnostics: DurableLegDiagnostics = {
+    fetchedMetaTriples: count(result.fetchedMetaTriples),
+    fetchedDataTriples: count(result.fetchedDataTriples),
+    insertedMetaTriples: count(result.insertedMetaTriples),
+    insertedDataTriples: count(result.insertedDataTriples),
+    bytesReceived: count(result.bytesReceived),
+    resumedPhases: count(result.resumedPhases),
+    timedOutPhases: count(result.timedOutPhases),
+    completedPhases: count(result.completedPhases),
+    checkpointAdvances: count(result.checkpointAdvances),
+    deniedPhases: count(result.deniedPhases),
+    emptyResponses: count(result.emptyResponses),
+    metaOnlyResponses: count(result.metaOnlyResponses),
+    verifiedPrivateOnlyResponses: count(result.verifiedPrivateOnlyResponses),
+    dataRejectedMissingMeta: count(result.dataRejectedMissingMeta),
+    rejectedKcs: count(result.rejectedKcs),
+    failedPeers: count(result.failedPeers),
+    failedPhases: count(result.failedPhases),
+    backoffWorthyFailures: count(result.backoffWorthyFailures),
+    deferredBackpressure: count(result.deferredBackpressure),
+  };
+  const hardFailureDetails = [
+    ['failedPeers', diagnostics.failedPeers],
+    ['failedPhases', diagnostics.failedPhases],
+    ['deniedPhases', diagnostics.deniedPhases],
+    ['rejectedKcs', diagnostics.rejectedKcs],
+    ['dataRejectedMissingMeta', diagnostics.dataRejectedMissingMeta],
+  ].flatMap(([name, value]) => Number(value) > 0 ? [`${name}=${value}`] : []);
+  const progress = classifyDurableProgress(result);
+
+  return {
+    insertedTriples: count(result.insertedTriples),
+    diagnostics,
+    complete: result.complete === true
+      && progress.completedWithoutFailure
+      && hardFailureDetails.length === 0,
+    hardFailureDetails,
+  };
 }
 
 export function catchupPlaneCompletedWithoutFailure(

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -3,10 +3,9 @@ import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
   classifyDurableProgress,
-  DURABLE_SYNC_COUNTER_REDUCERS,
+  normalizeDurableSyncResult,
   type DKGAgent,
   type DurableProgressSummary,
-  type DurableSyncCounterKey,
   type DurableSyncDiagnostics,
   type DurableSyncResult,
 } from '@origintrail-official/dkg-agent';
@@ -165,15 +164,11 @@ export interface DurableCatchupRequestOutcome {
  * counters remain diagnostics and can describe safely committed prefixes.
  */
 export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummary {
-  const count = (value: number | undefined): number => {
-    if (value === undefined || !Number.isFinite(value) || value <= 0) return 0;
-    return value;
-  };
-  const normalizedCounters = Object.fromEntries(
-    (Object.keys(DURABLE_SYNC_COUNTER_REDUCERS) as DurableSyncCounterKey[])
-      .map((key) => [key, count(result[key])]),
-  ) as Record<DurableSyncCounterKey, number>;
-  const { insertedTriples, ...diagnostics } = normalizedCounters;
+  const {
+    insertedTriples,
+    complete,
+    ...diagnostics
+  } = normalizeDurableSyncResult(result);
   const hardFailureDetails = [
     ['failedPeers', diagnostics.failedPeers],
     ['failedPhases', diagnostics.failedPhases],
@@ -185,7 +180,7 @@ export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummar
     || diagnostics.insertedDataTriples > 0
     || diagnostics.insertedMetaTriples > 0
     || diagnostics.checkpointAdvances > 0;
-  if (!result.complete && !committedProgress && hardFailureDetails.length === 0) {
+  if (!complete && !committedProgress && hardFailureDetails.length === 0) {
     // A timeout/backpressure stop before the first durable boundary is not a
     // successful no-op. Give the HTTP adapter a typed failure reason so
     // durable-only automation keeps retrying instead of treating 200/ok as an
@@ -196,7 +191,7 @@ export function summarizeDurableLeg(result: DurableSyncResult): DurableLegSummar
   return {
     insertedTriples,
     diagnostics,
-    complete: result.complete,
+    complete,
     hardFailureDetails,
   };
 }

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -1113,7 +1113,16 @@ WHERE {
       attempts.length > 0 && attempts.every((attempt) => attempt.durableComplete !== undefined)
         ? attempts.every((attempt) => attempt.durableComplete === true)
         : undefined;
-    const durableComplete = completionFor(durableAttempts);
+    // Whole-request completion is an AND over every requested CG. Flattening
+    // attempts alone can accidentally hide a CG that had no eligible peer and
+    // report the other CGs as a complete request. Preserve `undefined` for
+    // legacy/unknown result shapes, but never manufacture `true` from a strict
+    // subset of the requested graphs.
+    const perContextGraphCompletion = perCgLegs.map((cg) => completionFor(cg.perPeer));
+    const durableComplete = perContextGraphCompletion.length > 0
+      && perContextGraphCompletion.every((complete) => complete !== undefined)
+      ? perContextGraphCompletion.every((complete) => complete === true)
+      : undefined;
     const durableOnlyAllPeersFailed = includeDurable
       && !includeSharedMemory
       && durableAttempts.length > 0

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -817,10 +817,34 @@ WHERE {
     // peers Ã— many CGs), select a narrowed per-CG peer set, and parallelize
     // only that set. Per-peer dial+request is 5-20s on devnet; serialising
     // the selected peers would compound to NÃ—20s.
+    type DurableLegDiagnostics = {
+      fetchedMetaTriples: number;
+      fetchedDataTriples: number;
+      insertedMetaTriples: number;
+      insertedDataTriples: number;
+      bytesReceived: number;
+      resumedPhases: number;
+      timedOutPhases: number;
+      completedPhases: number;
+      checkpointAdvances: number;
+      deniedPhases: number;
+      emptyResponses: number;
+      metaOnlyResponses: number;
+      verifiedPrivateOnlyResponses: number;
+      dataRejectedMissingMeta: number;
+      rejectedKcs: number;
+      failedPeers: number;
+      failedPhases: number;
+      backoffWorthyFailures: number;
+      deferredBackpressure: number;
+    };
     type PerPeerLeg = {
       peerId: string;
       insertedTriples: number;
       durableInsertedTriples: number;
+      /** Present when the agent supports detailed durable-sync outcomes. */
+      durableComplete?: boolean;
+      durableDiagnostics?: DurableLegDiagnostics;
       swmError?: string;
       durableError?: string;
       error?: string;
@@ -831,6 +855,45 @@ WHERE {
       insertedTriples: number;
       durableInsertedTriples: number;
     };
+    const durableDiagnosticsFrom = (result: Record<string, unknown>): DurableLegDiagnostics => {
+      const count = (key: string): number => {
+        const value = Number(result[key] ?? 0);
+        return Number.isFinite(value) && value > 0 ? value : 0;
+      };
+      return {
+        fetchedMetaTriples: count('fetchedMetaTriples'),
+        fetchedDataTriples: count('fetchedDataTriples'),
+        insertedMetaTriples: count('insertedMetaTriples'),
+        insertedDataTriples: count('insertedDataTriples'),
+        bytesReceived: count('bytesReceived'),
+        resumedPhases: count('resumedPhases'),
+        timedOutPhases: count('timedOutPhases'),
+        completedPhases: count('completedPhases'),
+        checkpointAdvances: count('checkpointAdvances'),
+        deniedPhases: count('deniedPhases'),
+        emptyResponses: count('emptyResponses'),
+        metaOnlyResponses: count('metaOnlyResponses'),
+        verifiedPrivateOnlyResponses: count('verifiedPrivateOnlyResponses'),
+        dataRejectedMissingMeta: count('dataRejectedMissingMeta'),
+        rejectedKcs: count('rejectedKcs'),
+        failedPeers: count('failedPeers'),
+        failedPhases: count('failedPhases'),
+        backoffWorthyFailures: count('backoffWorthyFailures'),
+        deferredBackpressure: count('deferredBackpressure'),
+      };
+    };
+    const durableHardFailureDetails = (diagnostics: DurableLegDiagnostics): string[] => [
+      ['failedPeers', diagnostics.failedPeers],
+      ['failedPhases', diagnostics.failedPhases],
+      ['deniedPhases', diagnostics.deniedPhases],
+      ['rejectedKcs', diagnostics.rejectedKcs],
+      ['dataRejectedMissingMeta', diagnostics.dataRejectedMissingMeta],
+    ].flatMap(([name, value]) => Number(value) > 0 ? [`${name}=${value}`] : []);
+    const durableLegComplete = (diagnostics: DurableLegDiagnostics): boolean =>
+      diagnostics.completedPhases > 0
+      && diagnostics.timedOutPhases === 0
+      && diagnostics.deferredBackpressure === 0
+      && durableHardFailureDetails(diagnostics).length === 0;
     const perCgLegs: PerCgLeg[] = [];
     for (const cgId of cgIds) {
       const canUseSharedMemory = includeSharedMemory
@@ -865,6 +928,8 @@ WHERE {
         selectedPeers.map(async (candidate) => {
           let swm = 0;
           let durable = 0;
+          let durableComplete: boolean | undefined;
+          let durableDiagnostics: DurableLegDiagnostics | undefined;
           let swmError: string | undefined;
           let durableError: string | undefined;
           if (swmSelected.has(candidate)) {
@@ -902,20 +967,47 @@ WHERE {
               // settlement and report its real inserted count. The serialized
               // peer+CG durable lane prevents automatic recovery from racing
               // this tail.
-              durable = await (
-                (agent as any).syncFromPeer?.(
+              if (typeof (agent as any).syncFromPeerDetailed === 'function') {
+                const detailed = await (agent as any).syncFromPeerDetailed(
                   candidate,
                   [cgId],
                   undefined,
                   undefined,
+                  undefined,
                   { totalTimeoutMs: INTERNAL_DURABLE_BUDGET_MS },
-                ) ?? Promise.resolve(0)
-              );
+                ) as Record<string, unknown>;
+                durable = Number(detailed.insertedTriples ?? 0);
+                durableDiagnostics = durableDiagnosticsFrom(detailed);
+                durableComplete = durableLegComplete(durableDiagnostics);
+                const hardFailures = durableHardFailureDetails(durableDiagnostics);
+                if (hardFailures.length > 0) {
+                  durableError = `Durable sync did not complete (${hardFailures.join(', ')})`;
+                }
+              } else {
+                durable = await (
+                  (agent as any).syncFromPeer?.(
+                    candidate,
+                    [cgId],
+                    undefined,
+                    undefined,
+                    { totalTimeoutMs: INTERNAL_DURABLE_BUDGET_MS },
+                  ) ?? Promise.resolve(0)
+                );
+              }
             } catch (err: any) {
+              durableComplete = false;
               durableError = err?.message ?? String(err);
             }
           }
-          return { peerId: candidate, insertedTriples: swm, durableInsertedTriples: durable, swmError, durableError } as PerPeerLeg;
+          return {
+            peerId: candidate,
+            insertedTriples: swm,
+            durableInsertedTriples: durable,
+            durableComplete,
+            durableDiagnostics,
+            swmError,
+            durableError,
+          } as PerPeerLeg;
         }),
       );
       const perPeer: PerPeerLeg[] = settled.map((s, idx) => {
@@ -924,6 +1016,8 @@ WHERE {
             peerId: selectedPeers[idx],
             insertedTriples: s.value.insertedTriples,
             durableInsertedTriples: s.value.durableInsertedTriples,
+            ...(s.value.durableComplete !== undefined ? { durableComplete: s.value.durableComplete } : {}),
+            ...(s.value.durableDiagnostics ? { durableDiagnostics: s.value.durableDiagnostics } : {}),
             ...(s.value.swmError ? { swmError: s.value.swmError } : {}),
             ...(s.value.durableError ? { durableError: s.value.durableError } : {}),
           };
@@ -1028,6 +1122,7 @@ WHERE {
       peerId: string;
       insertedTriples: number;
       durableInsertedTriples: number;
+      durableComplete?: boolean;
       swmError?: string;
       durableError?: string;
       otherErrors?: string[];
@@ -1037,6 +1132,11 @@ WHERE {
         const entry = perPeerAggregate.get(p.peerId) ?? { peerId: p.peerId, insertedTriples: 0, durableInsertedTriples: 0 };
         entry.insertedTriples += p.insertedTriples;
         entry.durableInsertedTriples += p.durableInsertedTriples;
+        if (p.durableComplete !== undefined) {
+          entry.durableComplete = entry.durableComplete === undefined
+            ? p.durableComplete
+            : entry.durableComplete && p.durableComplete;
+        }
         if (p.swmError && !entry.swmError) entry.swmError = p.swmError;
         if (p.durableError && !entry.durableError) entry.durableError = p.durableError;
         if (p.error) entry.otherErrors = [...(entry.otherErrors ?? []), p.error];
@@ -1047,6 +1147,7 @@ WHERE {
       peerId: r.peerId,
       insertedTriples: r.insertedTriples,
       durableInsertedTriples: r.durableInsertedTriples,
+      ...(r.durableComplete !== undefined ? { durableComplete: r.durableComplete } : {}),
       ...(r.swmError ? { swmError: r.swmError } : {}),
       ...(r.durableError ? { durableError: r.durableError } : {}),
       ...(r.otherErrors && r.otherErrors.length > 0 ? { errors: r.otherErrors } : {}),
@@ -1062,6 +1163,11 @@ WHERE {
     const durableAttempts = includeDurable
       ? perCgLegs.flatMap((cg) => cg.perPeer)
       : [];
+    const completionFor = (attempts: PerPeerLeg[]): boolean | undefined =>
+      attempts.length > 0 && attempts.every((attempt) => attempt.durableComplete !== undefined)
+        ? attempts.every((attempt) => attempt.durableComplete === true)
+        : undefined;
+    const durableComplete = completionFor(durableAttempts);
     const durableOnlyAllPeersFailed = includeDurable
       && !includeSharedMemory
       && durableAttempts.length > 0
@@ -1079,6 +1185,7 @@ WHERE {
       peersAttempted: perPeerAggregate.size,
       includeSharedMemory,
       includeDurable,
+      ...(durableComplete !== undefined ? { durableComplete } : {}),
       totalInsertedTriples: totalInserted,
       totalDurableInsertedTriples: totalDurable,
       standardInsertedTriples: standardInserted,
@@ -1087,6 +1194,7 @@ WHERE {
         contextGraphId: cg.contextGraphId,
         insertedTriples: cg.insertedTriples,
         durableInsertedTriples: cg.durableInsertedTriples,
+        ...(completionFor(cg.perPeer) !== undefined ? { durableComplete: completionFor(cg.perPeer) } : {}),
         perPeer: cg.perPeer,
       })),
       hostCatchup: hostCatchupOpted ? {

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -111,7 +111,13 @@ import {
   CLI_NPM_PACKAGE,
 } from '../../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
-import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
+import {
+  createCatchupRunner,
+  summarizeDurableLeg,
+  type CatchupJobResult,
+  type CatchupRunner,
+  type DurableLegDiagnostics,
+} from '../../catchup-runner.js';
 import { loadTokens, httpAuthGuard } from '../../auth.js';
 import { recordAssertionActivity } from '../activity-notification.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
@@ -817,27 +823,6 @@ WHERE {
     // peers Ã— many CGs), select a narrowed per-CG peer set, and parallelize
     // only that set. Per-peer dial+request is 5-20s on devnet; serialising
     // the selected peers would compound to NÃ—20s.
-    type DurableLegDiagnostics = {
-      fetchedMetaTriples: number;
-      fetchedDataTriples: number;
-      insertedMetaTriples: number;
-      insertedDataTriples: number;
-      bytesReceived: number;
-      resumedPhases: number;
-      timedOutPhases: number;
-      completedPhases: number;
-      checkpointAdvances: number;
-      deniedPhases: number;
-      emptyResponses: number;
-      metaOnlyResponses: number;
-      verifiedPrivateOnlyResponses: number;
-      dataRejectedMissingMeta: number;
-      rejectedKcs: number;
-      failedPeers: number;
-      failedPhases: number;
-      backoffWorthyFailures: number;
-      deferredBackpressure: number;
-    };
     type PerPeerLeg = {
       peerId: string;
       insertedTriples: number;
@@ -855,45 +840,6 @@ WHERE {
       insertedTriples: number;
       durableInsertedTriples: number;
     };
-    const durableDiagnosticsFrom = (result: Record<string, unknown>): DurableLegDiagnostics => {
-      const count = (key: string): number => {
-        const value = Number(result[key] ?? 0);
-        return Number.isFinite(value) && value > 0 ? value : 0;
-      };
-      return {
-        fetchedMetaTriples: count('fetchedMetaTriples'),
-        fetchedDataTriples: count('fetchedDataTriples'),
-        insertedMetaTriples: count('insertedMetaTriples'),
-        insertedDataTriples: count('insertedDataTriples'),
-        bytesReceived: count('bytesReceived'),
-        resumedPhases: count('resumedPhases'),
-        timedOutPhases: count('timedOutPhases'),
-        completedPhases: count('completedPhases'),
-        checkpointAdvances: count('checkpointAdvances'),
-        deniedPhases: count('deniedPhases'),
-        emptyResponses: count('emptyResponses'),
-        metaOnlyResponses: count('metaOnlyResponses'),
-        verifiedPrivateOnlyResponses: count('verifiedPrivateOnlyResponses'),
-        dataRejectedMissingMeta: count('dataRejectedMissingMeta'),
-        rejectedKcs: count('rejectedKcs'),
-        failedPeers: count('failedPeers'),
-        failedPhases: count('failedPhases'),
-        backoffWorthyFailures: count('backoffWorthyFailures'),
-        deferredBackpressure: count('deferredBackpressure'),
-      };
-    };
-    const durableHardFailureDetails = (diagnostics: DurableLegDiagnostics): string[] => [
-      ['failedPeers', diagnostics.failedPeers],
-      ['failedPhases', diagnostics.failedPhases],
-      ['deniedPhases', diagnostics.deniedPhases],
-      ['rejectedKcs', diagnostics.rejectedKcs],
-      ['dataRejectedMissingMeta', diagnostics.dataRejectedMissingMeta],
-    ].flatMap(([name, value]) => Number(value) > 0 ? [`${name}=${value}`] : []);
-    const durableLegComplete = (diagnostics: DurableLegDiagnostics): boolean =>
-      diagnostics.completedPhases > 0
-      && diagnostics.timedOutPhases === 0
-      && diagnostics.deferredBackpressure === 0
-      && durableHardFailureDetails(diagnostics).length === 0;
     const perCgLegs: PerCgLeg[] = [];
     for (const cgId of cgIds) {
       const canUseSharedMemory = includeSharedMemory
@@ -975,13 +921,13 @@ WHERE {
                   undefined,
                   undefined,
                   { totalTimeoutMs: INTERNAL_DURABLE_BUDGET_MS },
-                ) as Record<string, unknown>;
-                durable = Number(detailed.insertedTriples ?? 0);
-                durableDiagnostics = durableDiagnosticsFrom(detailed);
-                durableComplete = durableLegComplete(durableDiagnostics);
-                const hardFailures = durableHardFailureDetails(durableDiagnostics);
-                if (hardFailures.length > 0) {
-                  durableError = `Durable sync did not complete (${hardFailures.join(', ')})`;
+                );
+                const durableSummary = summarizeDurableLeg(detailed);
+                durable = durableSummary.insertedTriples;
+                durableDiagnostics = durableSummary.diagnostics;
+                durableComplete = durableSummary.complete;
+                if (durableSummary.hardFailureDetails.length > 0) {
+                  durableError = `Durable sync did not complete (${durableSummary.hardFailureDetails.join(', ')})`;
                 }
               } else {
                 durable = await (

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -114,9 +114,12 @@ import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type P
 import {
   classifyDurableCatchupRequest,
   createCatchupRunner,
+  formatDurableCatchupFailure,
   runDurableCatchupLeg,
   type CatchupJobResult,
   type CatchupRunner,
+  type DurableCatchupFailureReason,
+  type DurableCatchupLegState,
   type DurableLegDiagnostics,
 } from '../../catchup-runner.js';
 import { loadTokens, httpAuthGuard } from '../../auth.js';
@@ -832,6 +835,8 @@ WHERE {
       peerId: string;
       insertedTriples: number;
       durableInsertedTriples: number;
+      /** Typed internal outcome; omitted from the legacy HTTP response shape. */
+      durableState?: DurableCatchupLegState;
       /** Present when the agent supports detailed durable-sync outcomes. */
       durableComplete?: boolean;
       durableDiagnostics?: DurableLegDiagnostics;
@@ -879,8 +884,10 @@ WHERE {
         selectedPeers.map(async (candidate) => {
           let swm = 0;
           let durable = 0;
+          let durableState: DurableCatchupLegState | undefined;
           let durableComplete: boolean | undefined;
           let durableDiagnostics: DurableLegDiagnostics | undefined;
+          let durableFailureReasons: DurableCatchupFailureReason[] | undefined;
           let swmError: string | undefined;
           let durableError: string | undefined;
           if (swmSelected.has(candidate)) {
@@ -919,14 +926,17 @@ WHERE {
               INTERNAL_DURABLE_BUDGET_MS,
             );
             durable = durableLeg.insertedTriples;
+            durableState = durableLeg.state;
             durableDiagnostics = durableLeg.diagnostics;
             durableComplete = durableLeg.complete;
-            durableError = durableLeg.error;
+            durableFailureReasons = durableLeg.failureReasons;
+            durableError = formatDurableCatchupFailure(durableFailureReasons);
           }
           return {
             peerId: candidate,
             insertedTriples: swm,
             durableInsertedTriples: durable,
+            durableState,
             durableComplete,
             durableDiagnostics,
             swmError,
@@ -940,6 +950,7 @@ WHERE {
             peerId: selectedPeers[idx],
             insertedTriples: s.value.insertedTriples,
             durableInsertedTriples: s.value.durableInsertedTriples,
+            ...(s.value.durableState ? { durableState: s.value.durableState } : {}),
             ...(s.value.durableComplete !== undefined ? { durableComplete: s.value.durableComplete } : {}),
             ...(s.value.durableDiagnostics ? { durableDiagnostics: s.value.durableDiagnostics } : {}),
             ...(s.value.swmError ? { swmError: s.value.swmError } : {}),
@@ -1109,7 +1120,7 @@ WHERE {
           insertedTriples: cg.insertedTriples,
           durableInsertedTriples: cg.durableInsertedTriples,
           ...(durableComplete !== undefined ? { durableComplete } : {}),
-          perPeer: cg.perPeer,
+          perPeer: cg.perPeer.map(({ durableState: _durableState, ...peer }) => peer),
         };
       }),
       hostCatchup: hostCatchupOpted ? {

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -864,7 +864,14 @@ WHERE {
         continue;
       }
       const baseCandidatePeers = await candidatePeersForContextGraph(cgId);
-      const unsupportedPeers = await unsupportedPeersForContextGraph(cgId, baseCandidatePeers);
+      // An explicit peerId is an operator-directed bounded probe. libp2p's
+      // identify-backed peerStore can lag a live connection, so an absent
+      // protocol advertisement must not suppress the wire negotiation the
+      // operator requested. Default peer enumeration remains conservative and
+      // filters peers that are known not to advertise the current sync wire.
+      const unsupportedPeers = peerIdParam
+        ? new Set<string>()
+        : await unsupportedPeersForContextGraph(cgId, baseCandidatePeers);
       const privateCuratorPeerIds = await privateCuratorPeersForContextGraph(cgId);
       const swmSelectedPeers = canUseSharedMemory
         ? swmCatchupPeerSelector.select({

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -804,7 +804,11 @@ WHERE {
       }
     };
 
-    if (!peerIdParam && connectedPeerIds().length === 0) {
+    if (
+      !peerIdParam
+      && connectedPeerIds().length === 0
+      && !(includeDurable && !includeSharedMemory)
+    ) {
       return jsonResponse(res, 200, {
         contextGraphIds: cgIds,
         peersAttempted: 0,

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -114,7 +114,6 @@ import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type P
 import {
   classifyDurableCatchupRequest,
   createCatchupRunner,
-  durableCatchupCompletionFor,
   runDurableCatchupLeg,
   type CatchupJobResult,
   type CatchupRunner,
@@ -1099,15 +1098,16 @@ WHERE {
       totalDurableInsertedTriples: totalDurable,
       standardInsertedTriples: standardInserted,
       results,
-      perContextGraph: perCgLegs.map((cg) => ({
-        contextGraphId: cg.contextGraphId,
-        insertedTriples: cg.insertedTriples,
-        durableInsertedTriples: cg.durableInsertedTriples,
-        ...(durableCatchupCompletionFor(cg.perPeer) !== undefined
-          ? { durableComplete: durableCatchupCompletionFor(cg.perPeer) }
-          : {}),
-        perPeer: cg.perPeer,
-      })),
+      perContextGraph: perCgLegs.map((cg, index) => {
+        const durableComplete = durableOutcome.perContextGraphCompletion[index];
+        return {
+          contextGraphId: cg.contextGraphId,
+          insertedTriples: cg.insertedTriples,
+          durableInsertedTriples: cg.durableInsertedTriples,
+          ...(durableComplete !== undefined ? { durableComplete } : {}),
+          perPeer: cg.perPeer,
+        };
+      }),
       hostCatchup: hostCatchupOpted ? {
         ranFallback: hostCatchup.length > 0,
         triggeredForContextGraphIds: hostCatchup.map((h) => h.contextGraphId),

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -112,8 +112,10 @@ import {
 } from '../../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
 import {
+  classifyDurableCatchupRequest,
   createCatchupRunner,
-  summarizeDurableLeg,
+  durableCatchupCompletionFor,
+  runDurableCatchupLeg,
   type CatchupJobResult,
   type CatchupRunner,
   type DurableLegDiagnostics,
@@ -903,47 +905,20 @@ WHERE {
             }
           }
           if (durableSelected.has(candidate)) {
-            try {
-              // The agent deadline bounds network fetching, but exact graph
-              // verification and atomic store materialization must settle
-              // afterward. Racing that promise against an HTTP timer does not
-              // cancel it; it only returns a false terminal response while the
-              // write continues invisibly and lets another recovery overlap
-              // the same responder session. Await the correctness-critical
-              // settlement and report its real inserted count. The serialized
-              // peer+CG durable lane prevents automatic recovery from racing
-              // this tail.
-              if (typeof (agent as any).syncFromPeerDetailed === 'function') {
-                const detailed = await (agent as any).syncFromPeerDetailed(
-                  candidate,
-                  [cgId],
-                  undefined,
-                  undefined,
-                  undefined,
-                  { totalTimeoutMs: INTERNAL_DURABLE_BUDGET_MS },
-                );
-                const durableSummary = summarizeDurableLeg(detailed);
-                durable = durableSummary.insertedTriples;
-                durableDiagnostics = durableSummary.diagnostics;
-                durableComplete = durableSummary.complete;
-                if (durableSummary.hardFailureDetails.length > 0) {
-                  durableError = `Durable sync did not complete (${durableSummary.hardFailureDetails.join(', ')})`;
-                }
-              } else {
-                durable = await (
-                  (agent as any).syncFromPeer?.(
-                    candidate,
-                    [cgId],
-                    undefined,
-                    undefined,
-                    { totalTimeoutMs: INTERNAL_DURABLE_BUDGET_MS },
-                  ) ?? Promise.resolve(0)
-                );
-              }
-            } catch (err: any) {
-              durableComplete = false;
-              durableError = err?.message ?? String(err);
-            }
+            // The agent deadline bounds network fetching, but exact graph
+            // verification and atomic store materialization must settle
+            // afterward. The helper owns capability probing, typed invocation,
+            // completion classification, and legacy-agent adaptation.
+            const durableLeg = await runDurableCatchupLeg(
+              agent,
+              candidate,
+              cgId,
+              INTERNAL_DURABLE_BUDGET_MS,
+            );
+            durable = durableLeg.insertedTriples;
+            durableDiagnostics = durableLeg.diagnostics;
+            durableComplete = durableLeg.complete;
+            durableError = durableLeg.error;
           }
           return {
             peerId: candidate,
@@ -1099,48 +1074,27 @@ WHERE {
       ...(r.otherErrors && r.otherErrors.length > 0 ? { errors: r.otherErrors } : {}),
     }));
 
-    // A durable-only operator request must not look successful when every
-    // selected peer failed before producing a terminal sync result. The
-    // detailed `durableError` fields have always been preserved below, but an
-    // HTTP 200 + zero aggregate is easy for scripts and dashboards to mistake
-    // for an already-synchronized no-op. Keep successful zero-insert no-ops at
-    // 200, and keep mixed SWM+durable responses backward-compatible; only the
-    // unambiguous all-peer durable-only failure is a retryable 503.
-    const durableAttempts = includeDurable
-      ? perCgLegs.flatMap((cg) => cg.perPeer)
-      : [];
-    const completionFor = (attempts: PerPeerLeg[]): boolean | undefined =>
-      attempts.length > 0 && attempts.every((attempt) => attempt.durableComplete !== undefined)
-        ? attempts.every((attempt) => attempt.durableComplete === true)
-        : undefined;
-    // Whole-request completion is an AND over every requested CG. Flattening
-    // attempts alone can accidentally hide a CG that had no eligible peer and
-    // report the other CGs as a complete request. Preserve `undefined` for
-    // legacy/unknown result shapes, but never manufacture `true` from a strict
-    // subset of the requested graphs.
-    const perContextGraphCompletion = perCgLegs.map((cg) => completionFor(cg.perPeer));
-    const durableComplete = perContextGraphCompletion.length > 0
-      && perContextGraphCompletion.every((complete) => complete !== undefined)
-      ? perContextGraphCompletion.every((complete) => complete === true)
-      : undefined;
-    const durableOnlyAllPeersFailed = includeDurable
-      && !includeSharedMemory
-      && durableAttempts.length > 0
-      && durableAttempts.every((attempt) => Boolean(attempt.durableError || attempt.error));
-    const responseStatus = durableOnlyAllPeersFailed ? 503 : 200;
+    // A durable-only operator request must not look successful until every
+    // detailed attempt reaches a terminal sync result. Preserve HTTP 200 for
+    // safely committed/checkpointed prefixes, but make the body explicitly
+    // retryable and `ok:false`; callers that only inspect `ok` must not confuse
+    // useful partial progress with completed catch-up. Keep mixed SWM+durable
+    // responses backward-compatible, and reserve 503 for the unambiguous case
+    // where every durable-only attempt failed without a usable result.
+    const durableOutcome = classifyDurableCatchupRequest(
+      perCgLegs.map((cg) => cg.perPeer),
+      includeDurable,
+      includeSharedMemory,
+    );
 
-    return jsonResponse(res, responseStatus, {
-      ok: !durableOnlyAllPeersFailed,
-      ...(durableOnlyAllPeersFailed ? {
-        errorCode: 'DURABLE_CATCHUP_ALL_PEERS_FAILED',
-        error: 'Durable catchup failed for every selected peer',
-        retryable: true,
-      } : {}),
+    return jsonResponse(res, durableOutcome.responseStatus, {
+      ok: !durableOutcome.allPeersFailed && !durableOutcome.incomplete,
+      ...(durableOutcome.errorBody ?? {}),
       contextGraphIds: cgIds,
       peersAttempted: perPeerAggregate.size,
       includeSharedMemory,
       includeDurable,
-      ...(durableComplete !== undefined ? { durableComplete } : {}),
+      ...(durableOutcome.complete !== undefined ? { durableComplete: durableOutcome.complete } : {}),
       totalInsertedTriples: totalInserted,
       totalDurableInsertedTriples: totalDurable,
       standardInsertedTriples: standardInserted,
@@ -1149,7 +1103,9 @@ WHERE {
         contextGraphId: cg.contextGraphId,
         insertedTriples: cg.insertedTriples,
         durableInsertedTriples: cg.durableInsertedTriples,
-        ...(completionFor(cg.perPeer) !== undefined ? { durableComplete: completionFor(cg.perPeer) } : {}),
+        ...(durableCatchupCompletionFor(cg.perPeer) !== undefined
+          ? { durableComplete: durableCatchupCompletionFor(cg.perPeer) }
+          : {}),
         perPeer: cg.perPeer,
       })),
       hostCatchup: hostCatchupOpted ? {

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -43,6 +43,7 @@ const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 function durableResult() {
   return {
     insertedTriples: 1,
+    complete: true,
     fetchedMetaTriples: 0,
     fetchedDataTriples: 1,
     insertedMetaTriples: 0,
@@ -350,6 +351,44 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
     });
     expect(result.cleanPlaneCompletions?.durable).toEqual({
       verifiedDataPeers: 1,
+      verifiedPrivateOnlyPeers: 0,
+      emptyPeers: 0,
+    });
+  });
+
+  it('keeps explicit incomplete progress out of clean completion evidence', async () => {
+    const result = await runWorkerCatchup(
+      { contextGraphId: 'cg-incomplete', includeSharedMemory: false },
+      async (method) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return {
+              preferredPeerId: undefined,
+              isPrivateContextGraph: true,
+              peerIds: ['peer-partial'],
+              connectedPeers: 1,
+            };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return { ...durableResult(), complete: false };
+          case 'finalizeCatchup':
+            return null;
+          default:
+            throw new Error(`unexpected invoke: ${method}`);
+        }
+      },
+    );
+
+    // peersSucceeded is liveness/progress accounting only. Readiness consumes
+    // the separate cleanPlaneCompletions proof, which must remain empty.
+    expect(result).toMatchObject({
+      peersResponded: 1,
+      peersSucceeded: 1,
+      dataSynced: 1,
+    });
+    expect(result.cleanPlaneCompletions?.durable).toEqual({
+      verifiedDataPeers: 0,
       verifiedPrivateOnlyPeers: 0,
       emptyPeers: 0,
     });

--- a/packages/cli/test/catchup-runner.test.ts
+++ b/packages/cli/test/catchup-runner.test.ts
@@ -320,4 +320,49 @@ describe('route-level durable catchup orchestration', () => {
     });
     expect(outcome.errorBody).toBeUndefined();
   });
+
+  it('fails retryably when a durable-only request has no eligible attempt', () => {
+    const outcome = classifyDurableCatchupRequest([[]], true, false);
+
+    expect(outcome).toMatchObject({
+      perContextGraphCompletion: [undefined],
+      complete: false,
+      allPeersFailed: false,
+      noEligibleAttempts: true,
+      incomplete: true,
+      responseStatus: 503,
+      errorBody: { errorCode: 'DURABLE_CATCHUP_NO_ELIGIBLE_PEERS', retryable: true },
+    });
+  });
+
+  it('keeps a complete subset retryable when another requested CG has no attempt', () => {
+    const outcome = classifyDurableCatchupRequest([
+      [{ durableComplete: true }],
+      [],
+    ], true, false);
+
+    expect(outcome).toMatchObject({
+      perContextGraphCompletion: [true, undefined],
+      complete: false,
+      allPeersFailed: false,
+      noEligibleAttempts: false,
+      incomplete: true,
+      responseStatus: 200,
+      errorBody: { errorCode: 'DURABLE_CATCHUP_INCOMPLETE', retryable: true },
+    });
+  });
+
+  it('preserves unknown completion for a real legacy durable attempt', () => {
+    const outcome = classifyDurableCatchupRequest([[{}]], true, false);
+
+    expect(outcome).toMatchObject({
+      perContextGraphCompletion: [undefined],
+      allPeersFailed: false,
+      noEligibleAttempts: false,
+      incomplete: false,
+      responseStatus: 200,
+    });
+    expect(outcome.complete).toBeUndefined();
+    expect(outcome.errorBody).toBeUndefined();
+  });
 });

--- a/packages/cli/test/catchup-runner.test.ts
+++ b/packages/cli/test/catchup-runner.test.ts
@@ -274,8 +274,9 @@ describe('route-level durable catchup orchestration', () => {
 
     expect(result).toMatchObject({
       insertedTriples: 0,
+      state: 'failed',
       complete: false,
-      error: 'Durable sync did not complete (incompleteWithoutProgress=1)',
+      failureReasons: [{ code: 'incompleteWithoutProgress', count: 1 }],
     });
     expect(syncFromPeerDetailed).toHaveBeenCalledWith(
       'peer-a',
@@ -306,8 +307,12 @@ describe('route-level durable catchup orchestration', () => {
   it('keeps a CG complete when any redundant peer completed cleanly', () => {
     const outcome = classifyDurableCatchupRequest([
       [
-        { durableComplete: true },
-        { durableComplete: false },
+        { durableState: 'complete', durableComplete: true },
+        {
+          durableState: 'failed',
+          durableComplete: false,
+          durableError: 'Durable sync did not complete (failedPhases=1)',
+        },
       ],
     ], true, false);
 
@@ -364,5 +369,19 @@ describe('route-level durable catchup orchestration', () => {
     });
     expect(outcome.complete).toBeUndefined();
     expect(outcome.errorBody).toBeUndefined();
+  });
+
+  it('classifies all-peer failure from typed state without parsing display text', () => {
+    const outcome = classifyDurableCatchupRequest([
+      [{ durableState: 'failed', durableComplete: false }],
+    ], true, false);
+
+    expect(outcome).toMatchObject({
+      complete: false,
+      allPeersFailed: true,
+      incomplete: false,
+      responseStatus: 503,
+      errorBody: { errorCode: 'DURABLE_CATCHUP_ALL_PEERS_FAILED' },
+    });
   });
 });

--- a/packages/cli/test/catchup-runner.test.ts
+++ b/packages/cli/test/catchup-runner.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   catchupPeerResponded,
   catchupPeerSucceeded,
   catchupPlaneCompletedWithoutFailure,
+  classifyDurableCatchupRequest,
+  runDurableCatchupLeg,
 } from '../src/catchup-runner.js';
 
 describe('catchup runner progress accounting', () => {
@@ -234,5 +236,70 @@ describe('catchup runner progress accounting', () => {
     };
     expect(catchupPeerResponded(partialThenDeferred, null)).toBe(true);
     expect(catchupPeerSucceeded(partialThenDeferred, null, false)).toBe(false);
+  });
+});
+
+describe('route-level durable catchup orchestration', () => {
+  it('adapts a detailed incomplete result and preserves its retry reason', async () => {
+    const syncFromPeerDetailed = vi.fn(async () => ({
+      insertedTriples: 0,
+      complete: false,
+      fetchedMetaTriples: 0,
+      fetchedDataTriples: 0,
+      insertedMetaTriples: 0,
+      insertedDataTriples: 0,
+      bytesReceived: 0,
+      resumedPhases: 0,
+      timedOutPhases: 0,
+      completedPhases: 0,
+      checkpointAdvances: 0,
+      emptyResponses: 0,
+      metaOnlyResponses: 0,
+      verifiedPrivateOnlyResponses: 0,
+      dataRejectedMissingMeta: 0,
+      rejectedKcs: 0,
+      failedPeers: 0,
+      failedPhases: 0,
+      deniedPhases: 0,
+      backoffWorthyFailures: 0,
+      deferredBackpressure: 0,
+    }));
+
+    const result = await runDurableCatchupLeg(
+      { syncFromPeerDetailed },
+      'peer-a',
+      'cg-a',
+      1234,
+    );
+
+    expect(result).toMatchObject({
+      insertedTriples: 0,
+      complete: false,
+      error: 'Durable sync did not complete (incompleteWithoutProgress=1)',
+    });
+    expect(syncFromPeerDetailed).toHaveBeenCalledWith(
+      'peer-a',
+      ['cg-a'],
+      undefined,
+      undefined,
+      undefined,
+      { totalTimeoutMs: 1234 },
+    );
+  });
+
+  it('ANDs completion across requested CGs and classifies partial progress', () => {
+    const outcome = classifyDurableCatchupRequest([
+      [{ durableComplete: true }],
+      [{ durableComplete: false }],
+    ], true, false);
+
+    expect(outcome).toMatchObject({
+      perContextGraphCompletion: [true, false],
+      complete: false,
+      allPeersFailed: false,
+      incomplete: true,
+      responseStatus: 200,
+      errorBody: { errorCode: 'DURABLE_CATCHUP_INCOMPLETE', retryable: true },
+    });
   });
 });

--- a/packages/cli/test/catchup-runner.test.ts
+++ b/packages/cli/test/catchup-runner.test.ts
@@ -302,4 +302,22 @@ describe('route-level durable catchup orchestration', () => {
       errorBody: { errorCode: 'DURABLE_CATCHUP_INCOMPLETE', retryable: true },
     });
   });
+
+  it('keeps a CG complete when any redundant peer completed cleanly', () => {
+    const outcome = classifyDurableCatchupRequest([
+      [
+        { durableComplete: true },
+        { durableComplete: false },
+      ],
+    ], true, false);
+
+    expect(outcome).toMatchObject({
+      perContextGraphCompletion: [true],
+      complete: true,
+      allPeersFailed: false,
+      incomplete: false,
+      responseStatus: 200,
+    });
+    expect(outcome.errorBody).toBeUndefined();
+  });
 });

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -164,8 +164,12 @@ describe('context graph catch-up readiness classification', () => {
   });
 
   it('keeps same-peer partial progress unready when no peer completed cleanly', () => {
+    const result = mixedPeerResult(0);
+    // The worker may count a peer that committed useful partial progress as a
+    // liveness success. That counter is deliberately not readiness evidence.
+    result.peersSucceeded = 1;
     const classification = classifyContextGraphCatchupReadiness({
-      result: mixedPeerResult(0),
+      result,
       includeSharedMemory: false,
       hasConfirmedMeta: true,
       isPrivate: true,
@@ -179,6 +183,7 @@ describe('context graph catch-up readiness classification', () => {
         sharedMemoryVerified: false,
       },
     });
+    expect(classification.eventPayload).toBeUndefined();
   });
 
   it('accepts a public clean-empty peer when another peer denies', () => {

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -99,6 +99,111 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     expect(agent.getPeerProtocols).not.toHaveBeenCalled();
   });
 
+  it('probes an explicit durable peer even when its protocol advertisement is absent', async () => {
+    const cgId = 'explicit-durable-probe-cg';
+    const peerId = 'peer-live-with-stale-identify';
+    const syncFromPeerDetailed = vi.fn(async () => detailedDurableResult({
+      insertedTriples: 23,
+      insertedDataTriples: 20,
+      insertedMetaTriples: 3,
+      complete: true,
+    }));
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => []),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: cgId,
+        peerId,
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(agent.getPeerProtocols).not.toHaveBeenCalled();
+    expect(syncFromPeerDetailed).toHaveBeenCalledWith(
+      peerId,
+      [cgId],
+      undefined,
+      undefined,
+      undefined,
+      { totalTimeoutMs: 109_000 },
+    );
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      durableComplete: true,
+      peersAttempted: 1,
+      totalDurableInsertedTriples: 23,
+      results: [{
+        peerId,
+        durableInsertedTriples: 23,
+        durableComplete: true,
+      }],
+      perContextGraph: [{
+        contextGraphId: cgId,
+        durableComplete: true,
+        perPeer: [{
+          peerId,
+          durableInsertedTriples: 23,
+          durableComplete: true,
+          durableDiagnostics: {
+            insertedDataTriples: 20,
+            insertedMetaTriples: 3,
+          },
+        }],
+      }],
+    });
+  });
+
+  it('still filters an implicitly enumerated durable peer without sync advertisement', async () => {
+    const cgId = 'implicit-unsupported-durable-cg';
+    const peerId = 'peer-legacy';
+    const syncFromPeerDetailed = vi.fn();
+    const agent = {
+      peerId: 'self-peer',
+      node: {
+        libp2p: {
+          getConnections: () => [{
+            remotePeer: { toString: () => peerId },
+          }],
+        },
+      },
+      getPeerProtocols: vi.fn(async () => []),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: cgId,
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(agent.getPeerProtocols).toHaveBeenCalledWith(peerId);
+    expect(syncFromPeerDetailed).not.toHaveBeenCalled();
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: false,
+      retryable: true,
+      errorCode: 'DURABLE_CATCHUP_NO_ELIGIBLE_PEERS',
+      durableComplete: false,
+      peersAttempted: 0,
+    });
+  });
+
   it('supports durable-only recovery without starting either SWM catchup path', async () => {
     const cgId = 'private-durable-only-cg';
     const peerId = 'peer-curator';

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -38,6 +38,32 @@ function buildCatchupCtx(body: unknown, agent: Record<string, any>) {
   return { ctx, res };
 }
 
+function detailedDurableResult(overrides: Record<string, number> = {}) {
+  return {
+    insertedTriples: 0,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 2,
+    checkpointAdvances: 0,
+    deniedPhases: 0,
+    emptyResponses: 0,
+    metaOnlyResponses: 0,
+    verifiedPrivateOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    backoffWorthyFailures: 0,
+    deferredBackpressure: 0,
+    ...overrides,
+  };
+}
+
 describe('POST /api/shared-memory/catchup durable leg', () => {
   it('supports durable-only recovery without starting either SWM catchup path', async () => {
     const cgId = 'private-durable-only-cg';
@@ -99,6 +125,114 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
       appliedEnvelopes: 0,
       perContextGraph: [],
     });
+  });
+
+  it('preserves committed progress and returns 503 when a detailed durable phase fails', async () => {
+    const syncFromPeer = vi.fn();
+    const syncFromPeerDetailed = vi.fn(async () => detailedDurableResult({
+      insertedTriples: 77_767,
+      insertedMetaTriples: 570,
+      insertedDataTriples: 77_197,
+      fetchedMetaTriples: 1_200,
+      fetchedDataTriples: 159_744,
+      completedPhases: 0,
+      failedPhases: 1,
+      backoffWorthyFailures: 1,
+    }));
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeer,
+      syncFromPeerDetailed,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'agent-blackbox-vm',
+        peerId: 'peer-core',
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(syncFromPeer).not.toHaveBeenCalled();
+    expect(syncFromPeerDetailed).toHaveBeenCalledWith(
+      'peer-core',
+      ['agent-blackbox-vm'],
+      undefined,
+      undefined,
+      undefined,
+      { totalTimeoutMs: 109_000 },
+    );
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: false,
+      durableComplete: false,
+      totalDurableInsertedTriples: 77_767,
+      results: [{
+        peerId: 'peer-core',
+        durableInsertedTriples: 77_767,
+        durableComplete: false,
+        durableError: 'Durable sync did not complete (failedPhases=1)',
+      }],
+      perContextGraph: [{
+        contextGraphId: 'agent-blackbox-vm',
+        durableComplete: false,
+        perPeer: [{
+          durableComplete: false,
+          durableDiagnostics: {
+            insertedDataTriples: 77_197,
+            insertedMetaTriples: 570,
+            failedPhases: 1,
+          },
+        }],
+      }],
+    });
+  });
+
+  it('reports a safely checkpointed timeout as retryable incomplete progress', async () => {
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed: vi.fn(async () => detailedDurableResult({
+        insertedTriples: 155_858,
+        insertedDataTriples: 155_000,
+        insertedMetaTriples: 858,
+        timedOutPhases: 1,
+        completedPhases: 1,
+        checkpointAdvances: 1,
+      })),
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'agent-blackbox-vm',
+        peerId: 'peer-core',
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      durableComplete: false,
+      totalDurableInsertedTriples: 155_858,
+      results: [{
+        peerId: 'peer-core',
+        durableInsertedTriples: 155_858,
+        durableComplete: false,
+      }],
+    });
+    expect(JSON.parse(res.body).results[0].durableError).toBeUndefined();
   });
 
   it('awaits durable verification and store settlement after the fetch budget', async () => {

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -272,7 +272,9 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
 
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toMatchObject({
-      ok: true,
+      ok: false,
+      retryable: true,
+      errorCode: 'DURABLE_CATCHUP_INCOMPLETE',
       durableComplete: false,
       totalDurableInsertedTriples: 155_858,
       results: [{
@@ -356,7 +358,9 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
 
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toMatchObject({
-      ok: true,
+      ok: false,
+      retryable: true,
+      errorCode: 'DURABLE_CATCHUP_INCOMPLETE',
       durableComplete: false,
       totalDurableInsertedTriples: 40_000,
       results: [{
@@ -465,7 +469,9 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     expect(res.statusCode).toBe(200);
     expect(syncFromPeerDetailed).toHaveBeenCalledTimes(2);
     expect(JSON.parse(res.body)).toMatchObject({
-      ok: true,
+      ok: false,
+      retryable: true,
+      errorCode: 'DURABLE_CATCHUP_INCOMPLETE',
       durableComplete: false,
       results: [{ peerId, durableComplete: false }],
       perContextGraph: [

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -161,7 +161,7 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     });
   });
 
-  it('preserves committed progress and returns 503 when a detailed durable phase fails', async () => {
+  it('preserves committed progress and returns 503 when a timed-out durable phase hard-fails', async () => {
     const syncFromPeer = vi.fn();
     const syncFromPeerDetailed = vi.fn(async () => detailedDurableResult({
       insertedTriples: 77_767,
@@ -170,6 +170,7 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
       fetchedMetaTriples: 1_200,
       fetchedDataTriples: 159_744,
       completedPhases: 0,
+      timedOutPhases: 1,
       failedPhases: 1,
       backoffWorthyFailures: 1,
       complete: false,
@@ -222,6 +223,7 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
           durableDiagnostics: {
             insertedDataTriples: 77_197,
             insertedMetaTriples: 570,
+            timedOutPhases: 1,
             failedPhases: 1,
           },
         }],

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
 import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import type { DurableSyncResult } from '@origintrail-official/dkg-agent';
 
 function fakeRes() {
   const res: any = { statusCode: 0, body: '', headers: {} as Record<string, string>, writableEnded: false };
@@ -38,9 +39,10 @@ function buildCatchupCtx(body: unknown, agent: Record<string, any>) {
   return { ctx, res };
 }
 
-function detailedDurableResult(overrides: Record<string, number> = {}) {
+function detailedDurableResult(overrides: Partial<DurableSyncResult> = {}): DurableSyncResult {
   return {
     insertedTriples: 0,
+    complete: true,
     fetchedMetaTriples: 0,
     fetchedDataTriples: 0,
     insertedMetaTriples: 0,
@@ -138,6 +140,7 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
       completedPhases: 0,
       failedPhases: 1,
       backoffWorthyFailures: 1,
+      complete: false,
     }));
     const agent = {
       peerId: 'self-peer',
@@ -206,6 +209,7 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
         timedOutPhases: 1,
         completedPhases: 1,
         checkpointAdvances: 1,
+        complete: false,
       })),
     };
     const { ctx, res } = buildCatchupCtx(
@@ -233,6 +237,102 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
       }],
     });
     expect(JSON.parse(res.body).results[0].durableError).toBeUndefined();
+  });
+
+  it('keeps a clean bounded prefix incomplete until the explicit durable contract is terminal', async () => {
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed: vi.fn(async () => detailedDurableResult({
+        insertedTriples: 40_000,
+        insertedDataTriples: 39_500,
+        insertedMetaTriples: 500,
+        completedPhases: 1,
+        checkpointAdvances: 1,
+        complete: false,
+      })),
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'agent-blackbox-vm',
+        peerId: 'peer-core',
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      durableComplete: false,
+      totalDurableInsertedTriples: 40_000,
+      results: [{
+        peerId: 'peer-core',
+        durableComplete: false,
+      }],
+      perContextGraph: [{
+        contextGraphId: 'agent-blackbox-vm',
+        durableComplete: false,
+      }],
+    });
+  });
+
+  it('reports a clean detailed durable result as complete at every response level', async () => {
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed: vi.fn(async () => detailedDurableResult({
+        insertedTriples: 42,
+        insertedDataTriples: 40,
+        insertedMetaTriples: 2,
+        completedPhases: 2,
+        checkpointAdvances: 2,
+        complete: true,
+      })),
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'agent-blackbox-vm',
+        peerId: 'peer-core',
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      durableComplete: true,
+      totalDurableInsertedTriples: 42,
+      results: [{
+        peerId: 'peer-core',
+        durableInsertedTriples: 42,
+        durableComplete: true,
+      }],
+      perContextGraph: [{
+        contextGraphId: 'agent-blackbox-vm',
+        durableComplete: true,
+        perPeer: [{
+          durableComplete: true,
+          durableDiagnostics: {
+            insertedDataTriples: 40,
+            insertedMetaTriples: 2,
+            completedPhases: 2,
+            checkpointAdvances: 2,
+          },
+        }],
+      }],
+    });
   });
 
   it('awaits durable verification and store settlement after the fetch budget', async () => {

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -197,6 +197,51 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     });
   });
 
+  it.each([
+    ['rejectedKcs', { rejectedKcs: 1 }],
+    ['dataRejectedMissingMeta', { dataRejectedMissingMeta: 1 }],
+    ['deniedPhases', { deniedPhases: 1 }],
+  ] as const)('returns 503 and preserves progress for a %s hard failure', async (counter, failure) => {
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed: vi.fn(async () => detailedDurableResult({
+        insertedTriples: 12,
+        insertedDataTriples: 10,
+        insertedMetaTriples: 2,
+        completedPhases: 1,
+        complete: false,
+        ...failure,
+      })),
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'agent-blackbox-vm',
+        peerId: 'peer-core',
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: false,
+      durableComplete: false,
+      totalDurableInsertedTriples: 12,
+      results: [{
+        peerId: 'peer-core',
+        durableInsertedTriples: 12,
+        durableComplete: false,
+        durableError: `Durable sync did not complete (${counter}=1)`,
+      }],
+    });
+  });
+
   it('reports a safely checkpointed timeout as retryable incomplete progress', async () => {
     const agent = {
       peerId: 'self-peer',

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -481,6 +481,62 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     });
   });
 
+  it('keeps one CG complete when a redundant peer returns an incomplete prefix', async () => {
+    const peers = ['peer-complete', 'peer-incomplete'];
+    const syncFromPeerDetailed = vi.fn(async (candidate: string) => (
+      candidate === 'peer-complete'
+        ? detailedDurableResult({
+            insertedTriples: 10,
+            insertedDataTriples: 8,
+            insertedMetaTriples: 2,
+            complete: true,
+          })
+        : detailedDurableResult({
+            insertedTriples: 5,
+            insertedDataTriples: 4,
+            insertedMetaTriples: 1,
+            completedPhases: 1,
+            checkpointAdvances: 1,
+            complete: false,
+          })
+    ));
+    const agent = {
+      peerId: 'self-peer',
+      node: {
+        libp2p: {
+          getConnections: () => peers.map((peerId) => ({
+            remotePeer: { toString: () => peerId },
+          })),
+        },
+      },
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'cg-redundant-peers',
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(syncFromPeerDetailed).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      durableComplete: true,
+      perContextGraph: [{
+        contextGraphId: 'cg-redundant-peers',
+        durableComplete: true,
+      }],
+    });
+  });
+
   it('awaits durable verification and store settlement after the fetch budget', async () => {
     vi.useFakeTimers();
     let resolveDurable!: (inserted: number) => void;

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -284,6 +284,49 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     expect(JSON.parse(res.body).results[0].durableError).toBeUndefined();
   });
 
+  it('returns a retryable 503 for a zero-progress incomplete durable attempt', async () => {
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed: vi.fn(async () => detailedDurableResult({
+        insertedTriples: 0,
+        insertedDataTriples: 0,
+        insertedMetaTriples: 0,
+        timedOutPhases: 1,
+        completedPhases: 0,
+        checkpointAdvances: 0,
+        complete: false,
+      })),
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'agent-blackbox-vm',
+        peerId: 'peer-core',
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: false,
+      retryable: true,
+      errorCode: 'DURABLE_CATCHUP_ALL_PEERS_FAILED',
+      durableComplete: false,
+      totalDurableInsertedTriples: 0,
+      results: [{
+        peerId: 'peer-core',
+        durableComplete: false,
+        durableError: 'Durable sync did not complete (incompleteWithoutProgress=1)',
+      }],
+    });
+  });
+
   it('keeps a clean bounded prefix incomplete until the explicit durable contract is terminal', async () => {
     const agent = {
       peerId: 'self-peer',
@@ -377,6 +420,58 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
           },
         }],
       }],
+    });
+  });
+
+  it('uses all-requested-CG AND semantics for durable completion', async () => {
+    const peerId = 'peer-core';
+    const syncFromPeerDetailed = vi.fn(async (
+      _candidate: string,
+      contextGraphIds: string[],
+    ) => contextGraphIds[0] === 'cg-a'
+      ? detailedDurableResult({
+          insertedTriples: 10,
+          insertedDataTriples: 8,
+          insertedMetaTriples: 2,
+          complete: true,
+        })
+      : detailedDurableResult({
+          insertedTriples: 5,
+          insertedDataTriples: 4,
+          insertedMetaTriples: 1,
+          completedPhases: 1,
+          checkpointAdvances: 1,
+          complete: false,
+        }));
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: ['cg-a', 'cg-b'],
+        peerId,
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(syncFromPeerDetailed).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      durableComplete: false,
+      results: [{ peerId, durableComplete: false }],
+      perContextGraph: [
+        { contextGraphId: 'cg-a', durableComplete: true },
+        { contextGraphId: 'cg-b', durableComplete: false },
+      ],
     });
   });
 

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -513,8 +513,8 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     });
   });
 
-  it('keeps one CG complete when a redundant peer returns an incomplete prefix', async () => {
-    const peers = ['peer-complete', 'peer-incomplete'];
+  it('keeps one CG complete when a redundant peer fails', async () => {
+    const peers = ['peer-complete', 'peer-failed'];
     const syncFromPeerDetailed = vi.fn(async (candidate: string) => (
       candidate === 'peer-complete'
         ? detailedDurableResult({
@@ -529,6 +529,7 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
             insertedMetaTriples: 1,
             completedPhases: 1,
             checkpointAdvances: 1,
+            failedPhases: 1,
             complete: false,
           })
     ));
@@ -562,9 +563,31 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     expect(JSON.parse(res.body)).toMatchObject({
       ok: true,
       durableComplete: true,
+      results: [
+        {
+          peerId: 'peer-complete',
+          durableComplete: true,
+        },
+        {
+          peerId: 'peer-failed',
+          durableComplete: false,
+          durableError: 'Durable sync did not complete (failedPhases=1)',
+        },
+      ],
       perContextGraph: [{
         contextGraphId: 'cg-redundant-peers',
         durableComplete: true,
+        perPeer: [
+          {
+            peerId: 'peer-complete',
+            durableComplete: true,
+          },
+          {
+            peerId: 'peer-failed',
+            durableComplete: false,
+            durableError: 'Durable sync did not complete (failedPhases=1)',
+          },
+        ],
       }],
     });
   });

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -67,6 +67,38 @@ function detailedDurableResult(overrides: Partial<DurableSyncResult> = {}): Dura
 }
 
 describe('POST /api/shared-memory/catchup durable leg', () => {
+  it('returns a retryable 503 when no connected peer can attempt durable catchup', async () => {
+    const agent = {
+      peerId: 'self-peer',
+      node: { libp2p: { getConnections: vi.fn(() => []) } },
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'durable-no-peer-cg',
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: false,
+      retryable: true,
+      errorCode: 'DURABLE_CATCHUP_NO_ELIGIBLE_PEERS',
+      durableComplete: false,
+      peersAttempted: 0,
+      totalDurableInsertedTriples: 0,
+      results: [],
+    });
+    expect(agent.getPeerProtocols).not.toHaveBeenCalled();
+  });
+
   it('supports durable-only recovery without starting either SWM catchup path', async () => {
     const cgId = 'private-durable-only-cg';
     const peerId = 'peer-curator';


### PR DESCRIPTION
## Summary

A bounded durable-sync pass could commit an exact graph-scoped prefix, fail on a later KA, and then report the whole pass as a successful zero-insert no-op. This made a large cold-join look settled while most of the manifest remained absent.

The live reproduction was the public `agent-blackbox-vm` graph:

- authoritative manifest: 5,337,721 triples
- bounded fetch: 159,744 raw triples, 155,858 at the last complete graph boundary
- KAs 212-217 committed successfully
- KA 218 hit a transient `getContextGraphNameHash(14)` timeout
- the requester returned `failedPhases=1`, but the CLI route discarded the detailed result and returned HTTP 200 with `totalDurableInsertedTriples=0`

## Changes

- Cache the immutable local-CG/on-chain-slot name-hash proof for one durable-sync invocation, instead of repeating the same RPC read for every KA. The first proof remains strict and fail-closed.
- Account for each atomically materialized graph-scoped asset immediately, so a later asset failure does not erase already-committed progress. Page checkpoints still advance only after the full verified page settles.
- Make `/api/shared-memory/catchup` use `syncFromPeerDetailed` when available and return:
  - the real committed triple count
  - `durableComplete`
  - per-peer phase diagnostics
  - a retryable 503 when every durable-only peer has a hard failed phase
  - HTTP 200 with `durableComplete=false` for safe bounded/checkpointed timeout progress

Legacy agents exposing only `syncFromPeer` retain the previous fallback path.

## Verification

- `pnpm --filter @origintrail-official/dkg-agent... build`
- `pnpm --filter @origintrail-official/dkg... build`
- agent focused regressions: 2 files, 8 tests passed
- CLI focused regression: 1 file, 9 tests passed
- full agent unit lane: 99 files, 1,257 tests passed
- broader CLI unit lane: 102 files / 1,709 tests passed; 5 existing live-daemon suites could not start because `vitest.unit.config.ts` did not create the required `dkg-hardhat-ctx-9545.json`. The affected catch-up suite and CLI build pass independently.

## Scope note

This fixes DKG pass resilience and truthful completion reporting. A consumer that explicitly disables DKG sync-on-connect and the periodic reconciler still needs to enable those settings if it expects background synchronization after its own bounded command exits.