### PR TITLE
refactor(publisher): promote clearTerminalJob single canonical payload read (#1893)

### DIFF
--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -47,6 +47,7 @@ import {
   PROMOTE_PAYLOAD,
   PROMOTE_STATE,
   PROMOTE_UNIQUENESS_KEY,
+  classifyJobPayload,
   comparePromoteJobs,
   defaultBackoffMs,
   expectBindings,
@@ -55,7 +56,6 @@ import {
   literal,
   normalizePromoteAgentLane,
   parseJobPayload,
-  parseLiteral,
   promoteLaneConflictScope,
   promoteLaneScopesConflict,
   serializeJob,
@@ -615,9 +615,10 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
    * #1837 — atomic by-exact-jobId terminal clear. Runs INSIDE withMutationLock, which
    * already serializes EVERY transition (incl. the only terminal→active path, recover()
    * failed→queued), so a transitioning job cannot be swept and concurrent clears are
-   * deterministic — no new lock needed. Reads the denormalized state triple to split
-   * already_absent / unknown / malformed without a JSON.parse that collapses them. Never
-   * throws / never mutates on a reject.
+   * deterministic — no new lock needed. Classifies from a SINGLE canonical payload read
+   * (matching the lift sibling): `classifyJobPayload` splits already_absent / malformed /
+   * job without the enum drop that collapses them, and the enum + terminal checks run on
+   * the parsed job. Never throws / never mutates on a reject.
    */
   async clearTerminalJob(jobId: string): Promise<TerminalJobClearOutcome> {
     // Reject an empty OR SPARQL-unsafe jobId as malformed before building the jobSubject
@@ -626,28 +627,19 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
     if (!isSafeClearJobId(jobId)) return { outcome: 'rejected', reason: 'malformed' };
     return this.withMutationLock(async () => {
       await this.ensureGraph();
-      const stateRows = expectBindings(
+      const rows = expectBindings(
         await this.store.query(
-          `SELECT ?state WHERE { GRAPH <${this.graphUri}> { <${jobSubject(jobId)}> <${PROMOTE_STATE}> ?state } }`,
+          `SELECT ?payload WHERE { GRAPH <${this.graphUri}> { <${jobSubject(jobId)}> <${PROMOTE_PAYLOAD}> ?payload } }`,
         ),
       );
-      if (stateRows.length === 0) return { outcome: 'already_absent' };
-      const rawState = stateRows[0]?.['state'];
-      // parseLiteral is JSON.parse — a corrupt/non-JSON state literal must become a
-      // bounded reject, never throw out of the method (matches the lift sibling's guard).
-      let state: string | undefined;
-      try {
-        state = rawState === undefined ? undefined : String(parseLiteral(rawState));
-      } catch {
+      const parsed = classifyJobPayload(rows[0]?.['payload']);
+      if (parsed.kind === 'absent') return { outcome: 'already_absent' };
+      if (parsed.kind === 'malformed') return { outcome: 'rejected', reason: 'malformed' };
+      const { job } = parsed;
+      // Structurally-valid job, but its state is not a recognized enum value.
+      if (!(PROMOTE_JOB_STATES as readonly string[]).includes(job.state)) {
         return { outcome: 'rejected', reason: 'unknown' };
       }
-      if (state === undefined || !(PROMOTE_JOB_STATES as readonly string[]).includes(state)) {
-        return { outcome: 'rejected', reason: 'unknown' };
-      }
-      // State literal is a known enum value; the full payload must also parse (a corrupt
-      // payload with a valid state triple is malformed, not unknown).
-      const job = await this.readJob(jobId);
-      if (job === null) return { outcome: 'rejected', reason: 'malformed' };
       if (!isTerminalPromoteJobState(job.state)) return { outcome: 'rejected', reason: 'nonterminal' };
       await this.deleteJob(jobId);
       return { outcome: 'cleared' };

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -636,11 +636,13 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
       if (parsed.kind === 'absent') return { outcome: 'already_absent' };
       if (parsed.kind === 'malformed') return { outcome: 'rejected', reason: 'malformed' };
       const { job } = parsed;
-      // Structurally-valid job, but its state is not a recognized enum value.
+      // Structurally-valid job whose state is a well-formed string but not a recognized enum
+      // value → unknown (a missing/non-string state was already classified `malformed`). Narrow
+      // to PromoteJobState only AFTER the membership check confirms it.
       if (!(PROMOTE_JOB_STATES as readonly string[]).includes(job.state)) {
         return { outcome: 'rejected', reason: 'unknown' };
       }
-      if (!isTerminalPromoteJobState(job.state)) return { outcome: 'rejected', reason: 'nonterminal' };
+      if (!isTerminalPromoteJobState(job.state as PromoteJobState)) return { outcome: 'rejected', reason: 'nonterminal' };
       await this.deleteJob(jobId);
       return { outcome: 'cleared' };
     });

--- a/packages/publisher/src/async-promote-queue-utils.ts
+++ b/packages/publisher/src/async-promote-queue-utils.ts
@@ -251,10 +251,19 @@ function isCommitMarker(value: unknown): value is PromoteCommitMarker {
  * `unknown` from a SINGLE canonical payload read (matching the lift sibling), rather than
  * reading a secondary state-index triple. Never throws.
  */
+/**
+ * A payload that parsed as a structurally complete job whose `state` has been validated only
+ * as a non-empty string — the PROMOTE_JOB_STATES enum-membership check is deliberately deferred
+ * to the caller (so the by-jobId clear can report a well-formed-but-unrecognized state as
+ * `unknown`, distinct from a corrupt payload). Exposing `state: string` keeps the classifier
+ * boundary honest: it never types a value as `PromoteJobState` before that has been checked.
+ */
+export type StructurallyValidPromoteJobPayload = Omit<PromoteJob, 'state'> & { readonly state: string };
+
 export type PromoteJobParseResult =
   | { readonly kind: 'absent' }
   | { readonly kind: 'malformed' }
-  | { readonly kind: 'job'; readonly job: PromoteJob };
+  | { readonly kind: 'job'; readonly job: StructurallyValidPromoteJobPayload };
 
 export function classifyJobPayload(binding: string | undefined): PromoteJobParseResult {
   if (!binding) return { kind: 'absent' };
@@ -264,9 +273,12 @@ export function classifyJobPayload(binding: string | undefined): PromoteJobParse
     const parsed = JSON.parse(payload);
     if (!isRecord(parsed)) return { kind: 'malformed' };
     if (typeof parsed['jobId'] !== 'string' || parsed['jobId'].length === 0) return { kind: 'malformed' };
-    // The PROMOTE_JOB_STATES enum check is intentionally NOT applied here: a structurally
-    // valid job carrying an unrecognized `state` is `kind: 'job'` so the terminal clear can
-    // report it as `unknown`, distinct from a genuinely corrupt payload (`malformed`).
+    // `state` is structurally validated as a non-empty string here, but the PROMOTE_JOB_STATES
+    // enum-membership check is intentionally NOT applied: a well-formed job carrying an
+    // unrecognized state *string* is `kind: 'job'` so the terminal clear can report it as
+    // `unknown`. A missing or non-string `state` is structural corruption (not an unrecognized
+    // state), so — like every other malformed field — it is `malformed`, never `unknown`.
+    if (typeof parsed['state'] !== 'string' || parsed['state'].length === 0) return { kind: 'malformed' };
     if (!isPromoteRequest(parsed['request'])) return { kind: 'malformed' };
     if (!isFiniteNumber(parsed['enqueuedAt']) || !isFiniteNumber(parsed['updatedAt'])) return { kind: 'malformed' };
     if (!isRecord(parsed['attempt'])) return { kind: 'malformed' };
@@ -281,7 +293,7 @@ export function classifyJobPayload(binding: string | undefined): PromoteJobParse
     }
     if (parsed['lease'] !== undefined && !isLease(parsed['lease'])) return { kind: 'malformed' };
     if (parsed['commitMarker'] !== undefined && !isCommitMarker(parsed['commitMarker'])) return { kind: 'malformed' };
-    return { kind: 'job', job: parsed as unknown as PromoteJob };
+    return { kind: 'job', job: parsed as unknown as StructurallyValidPromoteJobPayload };
   } catch {
     return { kind: 'malformed' };
   }
@@ -295,9 +307,11 @@ export function classifyJobPayload(binding: string | undefined): PromoteJobParse
  */
 export function parseJobPayload(binding: string | undefined): PromoteJob | null {
   const result = classifyJobPayload(binding);
-  return result.kind === 'job' && (PROMOTE_JOB_STATES as readonly string[]).includes(String(result.job.state))
-    ? result.job
-    : null;
+  if (result.kind !== 'job') return null;
+  // Re-apply the enum drop classifyJobPayload defers: a well-formed job whose state string is
+  // not a recognized value is skipped by the list/read/conflict paths. The cast is honest only
+  // once the membership check has passed (state is provably a PromoteJobState here).
+  return (PROMOTE_JOB_STATES as readonly string[]).includes(result.job.state) ? (result.job as PromoteJob) : null;
 }
 
 /**

--- a/packages/publisher/src/async-promote-queue-utils.ts
+++ b/packages/publisher/src/async-promote-queue-utils.ts
@@ -244,37 +244,60 @@ function isCommitMarker(value: unknown): value is PromoteCommitMarker {
 }
 
 /**
- * Parse a `payload` binding back into a full `PromoteJob`. Returns null
- * if the literal is malformed (corrupted payload) — the queue logs and
- * skips such rows rather than crashing.
+ * Bounded classification of a `payload` binding. Distinguishes an absent row, a corrupt
+ * payload, and a structurally-valid job whose `state` is not a recognized enum value — a
+ * distinction {@link parseJobPayload} deliberately collapses into `null`. The by-jobId
+ * terminal clear reads through this so it can classify `already_absent` / `malformed` /
+ * `unknown` from a SINGLE canonical payload read (matching the lift sibling), rather than
+ * reading a secondary state-index triple. Never throws.
  */
-export function parseJobPayload(binding: string | undefined): PromoteJob | null {
-  if (!binding) return null;
+export type PromoteJobParseResult =
+  | { readonly kind: 'absent' }
+  | { readonly kind: 'malformed' }
+  | { readonly kind: 'job'; readonly job: PromoteJob };
+
+export function classifyJobPayload(binding: string | undefined): PromoteJobParseResult {
+  if (!binding) return { kind: 'absent' };
   try {
     const payload = parseLiteral(binding);
-    if (typeof payload !== 'string') return null;
+    if (typeof payload !== 'string') return { kind: 'malformed' };
     const parsed = JSON.parse(payload);
-    if (!isRecord(parsed)) return null;
-    if (typeof parsed['jobId'] !== 'string' || parsed['jobId'].length === 0) return null;
-    if (!(PROMOTE_JOB_STATES as readonly string[]).includes(String(parsed['state']))) return null;
-    if (!isPromoteRequest(parsed['request'])) return null;
-    if (!isFiniteNumber(parsed['enqueuedAt']) || !isFiniteNumber(parsed['updatedAt'])) return null;
-    if (!isRecord(parsed['attempt'])) return null;
+    if (!isRecord(parsed)) return { kind: 'malformed' };
+    if (typeof parsed['jobId'] !== 'string' || parsed['jobId'].length === 0) return { kind: 'malformed' };
+    // The PROMOTE_JOB_STATES enum check is intentionally NOT applied here: a structurally
+    // valid job carrying an unrecognized `state` is `kind: 'job'` so the terminal clear can
+    // report it as `unknown`, distinct from a genuinely corrupt payload (`malformed`).
+    if (!isPromoteRequest(parsed['request'])) return { kind: 'malformed' };
+    if (!isFiniteNumber(parsed['enqueuedAt']) || !isFiniteNumber(parsed['updatedAt'])) return { kind: 'malformed' };
+    if (!isRecord(parsed['attempt'])) return { kind: 'malformed' };
     if (!isFiniteNumber(parsed['attempt']['count']) || !isFiniteNumber(parsed['attempt']['maxRetries'])) {
-      return null;
+      return { kind: 'malformed' };
     }
     if (
       parsed['attempt']['nextRetryAt'] !== undefined &&
       !isFiniteNumber(parsed['attempt']['nextRetryAt'])
     ) {
-      return null;
+      return { kind: 'malformed' };
     }
-    if (parsed['lease'] !== undefined && !isLease(parsed['lease'])) return null;
-    if (parsed['commitMarker'] !== undefined && !isCommitMarker(parsed['commitMarker'])) return null;
-    return parsed as unknown as PromoteJob;
+    if (parsed['lease'] !== undefined && !isLease(parsed['lease'])) return { kind: 'malformed' };
+    if (parsed['commitMarker'] !== undefined && !isCommitMarker(parsed['commitMarker'])) return { kind: 'malformed' };
+    return { kind: 'job', job: parsed as unknown as PromoteJob };
   } catch {
-    return null;
+    return { kind: 'malformed' };
   }
+}
+
+/**
+ * Parse a `payload` binding back into a full `PromoteJob`, or null when the payload is
+ * absent, malformed, or carries an unrecognized `state`. A strict view over
+ * {@link classifyJobPayload} (it re-applies the enum drop), so the read/list/conflict paths
+ * skip such rows rather than crashing.
+ */
+export function parseJobPayload(binding: string | undefined): PromoteJob | null {
+  const result = classifyJobPayload(binding);
+  return result.kind === 'job' && (PROMOTE_JOB_STATES as readonly string[]).includes(String(result.job.state))
+    ? result.job
+    : null;
 }
 
 /**

--- a/packages/publisher/test/async-promote-terminal-clear.test.ts
+++ b/packages/publisher/test/async-promote-terminal-clear.test.ts
@@ -55,6 +55,16 @@ describe('#1837 promote queue clearTerminalJob', () => {
     return jobId;
   }
 
+  // Raw stored PROMOTE_PAYLOAD literal for a subject, in the store's own return form. Comparing
+  // the value read before vs after a clear proves a rejected clear neither deleted nor altered
+  // the row (#1893: "never mutates on a reject"), and is immune to insert-vs-return re-escaping.
+  async function rawPayloadOf(jobId: string): Promise<string | undefined> {
+    const result = await store.query(
+      `SELECT ?payload WHERE { GRAPH <${DEFAULT_PROMOTE_CONTROL_GRAPH_URI}> { <${jobSubject(jobId)}> <${PROMOTE_PAYLOAD}> ?payload } }`,
+    );
+    return result.type === 'bindings' ? result.bindings[0]?.['payload'] : undefined;
+  }
+
   it('clears an exact succeeded job (cleared); no other job changes', async () => {
     const queue = createQueue();
     const target = await enqueueSucceeded(queue, { assertionName: 'a' });
@@ -102,9 +112,11 @@ describe('#1837 promote queue clearTerminalJob', () => {
   it('is idempotent: an absent / already-cleared job returns already_absent', async () => {
     const queue = createQueue();
     expect(await queue.clearTerminalJob('never-existed')).toEqual({ outcome: 'already_absent' });
+    expect(await rawPayloadOf('never-existed')).toBeUndefined(); // clearing an absent job creates no row
     const jobId = await enqueueSucceeded(queue);
     expect(await queue.clearTerminalJob(jobId)).toEqual({ outcome: 'cleared' });
     expect(await queue.clearTerminalJob(jobId)).toEqual({ outcome: 'already_absent' }); // repeat
+    expect(await rawPayloadOf(jobId)).toBeUndefined(); // cleared row stays gone
   });
 
   it('rejects an empty or SPARQL-unsafe jobId as malformed without querying/mutating', async () => {
@@ -127,7 +139,10 @@ describe('#1837 promote queue clearTerminalJob', () => {
     await store.insert([
       { subject: jobSubject('bogus-1'), predicate: PROMOTE_PAYLOAD, object: literal(JSON.stringify(bogusJob)), graph: DEFAULT_PROMOTE_CONTROL_GRAPH_URI },
     ]);
+    const before = await rawPayloadOf('bogus-1');
+    expect(before).toBeDefined();
     await expect(queue.clearTerminalJob('bogus-1')).resolves.toEqual({ outcome: 'rejected', reason: 'unknown' });
+    expect(await rawPayloadOf('bogus-1')).toBe(before); // rejected clear must NOT delete or alter the row
   });
 
   // #1893: a payload literal that is present but not a valid job is malformed, not unknown.
@@ -136,7 +151,10 @@ describe('#1837 promote queue clearTerminalJob', () => {
     await store.insert([
       { subject: jobSubject('corrupt-1'), predicate: PROMOTE_PAYLOAD, object: literal('not-a-job-json'), graph: DEFAULT_PROMOTE_CONTROL_GRAPH_URI },
     ]);
+    const before = await rawPayloadOf('corrupt-1');
+    expect(before).toBeDefined();
     await expect(queue.clearTerminalJob('corrupt-1')).resolves.toEqual({ outcome: 'rejected', reason: 'malformed' });
+    expect(await rawPayloadOf('corrupt-1')).toBe(before); // rejected clear must NOT delete or alter the row
   });
 
   // #1893 (review): a payload that is otherwise well-formed but carries no string `state` is
@@ -147,7 +165,10 @@ describe('#1837 promote queue clearTerminalJob', () => {
     await store.insert([
       { subject: jobSubject('nostate-1'), predicate: PROMOTE_PAYLOAD, object: literal(JSON.stringify(noState)), graph: DEFAULT_PROMOTE_CONTROL_GRAPH_URI },
     ]);
+    const before = await rawPayloadOf('nostate-1');
+    expect(before).toBeDefined();
     await expect(queue.clearTerminalJob('nostate-1')).resolves.toEqual({ outcome: 'rejected', reason: 'malformed' });
+    expect(await rawPayloadOf('nostate-1')).toBe(before); // rejected clear must NOT delete or alter the row
   });
 
   it('concurrent clears of one terminal job are deterministic: one cleared, rest already_absent, no other job affected', async () => {

--- a/packages/publisher/test/async-promote-terminal-clear.test.ts
+++ b/packages/publisher/test/async-promote-terminal-clear.test.ts
@@ -7,7 +7,7 @@ import {
   type PromoteTerminalJobClearer,
 } from '../src/async-promote-queue-types.js';
 import { TripleStoreAsyncPromoteQueue } from '../src/async-promote-queue-impl.js';
-import { DEFAULT_PROMOTE_CONTROL_GRAPH_URI, PROMOTE_PAYLOAD, classifyJobPayload, jobSubject, literal } from '../src/async-promote-queue-utils.js';
+import { DEFAULT_PROMOTE_CONTROL_GRAPH_URI, PROMOTE_PAYLOAD, classifyJobPayload, jobSubject, literal, parseJobPayload } from '../src/async-promote-queue-utils.js';
 
 // #1837 — atomic by-exact-jobId TERMINAL clear for the SWM promote queue.
 describe('#1837 promote queue clearTerminalJob', () => {
@@ -199,5 +199,17 @@ describe('classifyJobPayload', () => {
     const result = classifyJobPayload(bind({ ...validJob, state: 'bogus_state' }));
     expect(result.kind).toBe('job');
     if (result.kind === 'job') expect(result.job.state).toBe('bogus_state');
+  });
+
+  // #1893 (review round 2): the classifier deliberately accepts a non-enum state string as
+  // `kind: 'job'` (so the terminal clear can report `unknown`), which makes parseJobPayload the
+  // ONLY runtime guard that keeps ordinary readers (list/getStatus/conflict) from surfacing a
+  // row with an impossible state. Lock that strict enum-drop directly here: were it removed from
+  // parseJobPayload, this asserts red even though the classifier tests above stay green.
+  it('parseJobPayload re-applies the enum drop the classifier defers', () => {
+    const nonEnum = bind({ ...validJob, state: 'bogus_state' });
+    expect(classifyJobPayload(nonEnum).kind).toBe('job'); // classifier accepts it for terminal-clear classification
+    expect(parseJobPayload(nonEnum)).toBeNull();          // strict wrapper rejects it for read/list/conflict callers
+    expect(parseJobPayload(bind(validJob))).not.toBeNull(); // a valid enum state is returned unchanged
   });
 });

--- a/packages/publisher/test/async-promote-terminal-clear.test.ts
+++ b/packages/publisher/test/async-promote-terminal-clear.test.ts
@@ -7,7 +7,7 @@ import {
   type PromoteTerminalJobClearer,
 } from '../src/async-promote-queue-types.js';
 import { TripleStoreAsyncPromoteQueue } from '../src/async-promote-queue-impl.js';
-import { DEFAULT_PROMOTE_CONTROL_GRAPH_URI, PROMOTE_STATE, jobSubject, literal } from '../src/async-promote-queue-utils.js';
+import { DEFAULT_PROMOTE_CONTROL_GRAPH_URI, PROMOTE_PAYLOAD, classifyJobPayload, jobSubject, literal } from '../src/async-promote-queue-utils.js';
 
 // #1837 — atomic by-exact-jobId TERMINAL clear for the SWM promote queue.
 describe('#1837 promote queue clearTerminalJob', () => {
@@ -115,14 +115,28 @@ describe('#1837 promote queue clearTerminalJob', () => {
     expect(await queue.clearTerminalJob('bad>id')).toEqual({ outcome: 'rejected', reason: 'malformed' });
   });
 
-  // #1883 review (🟡): a state triple present but not a recognized enum value must be a
-  // bounded reject (unknown), never throw — and the parse itself is now try/catch-guarded.
-  it('rejects a subject whose state is not a known enum value as unknown, without throwing', async () => {
+  // #1893: a structurally-valid payload whose `state` is not a recognized enum value must be
+  // a bounded reject (unknown) — classified from the single canonical payload read.
+  it('rejects a job whose payload state is not a known enum value as unknown, without throwing', async () => {
     const queue = createQueue();
+    const bogusJob = {
+      jobId: 'bogus-1', state: 'bogus_state',
+      request: makeRequest(), enqueuedAt: now, updatedAt: now,
+      attempt: { count: 0, maxRetries: 3 },
+    };
     await store.insert([
-      { subject: jobSubject('bogus-1'), predicate: PROMOTE_STATE, object: literal('bogus_state'), graph: DEFAULT_PROMOTE_CONTROL_GRAPH_URI },
+      { subject: jobSubject('bogus-1'), predicate: PROMOTE_PAYLOAD, object: literal(JSON.stringify(bogusJob)), graph: DEFAULT_PROMOTE_CONTROL_GRAPH_URI },
     ]);
     await expect(queue.clearTerminalJob('bogus-1')).resolves.toEqual({ outcome: 'rejected', reason: 'unknown' });
+  });
+
+  // #1893: a payload literal that is present but not a valid job is malformed, not unknown.
+  it('rejects a subject with a corrupt payload literal as malformed', async () => {
+    const queue = createQueue();
+    await store.insert([
+      { subject: jobSubject('corrupt-1'), predicate: PROMOTE_PAYLOAD, object: literal('not-a-job-json'), graph: DEFAULT_PROMOTE_CONTROL_GRAPH_URI },
+    ]);
+    await expect(queue.clearTerminalJob('corrupt-1')).resolves.toEqual({ outcome: 'rejected', reason: 'malformed' });
   });
 
   it('concurrent clears of one terminal job are deterministic: one cleared, rest already_absent, no other job affected', async () => {
@@ -135,5 +149,35 @@ describe('#1837 promote queue clearTerminalJob', () => {
     expect(results.filter((r) => r.outcome === 'cleared')).toHaveLength(1);
     expect(results.filter((r) => r.outcome === 'already_absent')).toHaveLength(2);
     expect((await queue.getStatus(other))?.state).toBe('succeeded'); // never affected
+  });
+});
+
+// #1893 — the bounded classifier the single-read clear is built on.
+describe('classifyJobPayload', () => {
+  const validJob = {
+    jobId: 'j1', state: 'queued',
+    request: { contextGraphId: 'g', assertionName: 'a', entities: 'all' },
+    enqueuedAt: 1, updatedAt: 1, attempt: { count: 0, maxRetries: 3 },
+  };
+  // Mirror serializeJob's PROMOTE_PAYLOAD encoding: literal(JSON.stringify(job)).
+  const bind = (v: unknown) => literal(JSON.stringify(v));
+
+  it('absent for an undefined or empty binding', () => {
+    expect(classifyJobPayload(undefined)).toEqual({ kind: 'absent' });
+    expect(classifyJobPayload('')).toEqual({ kind: 'absent' });
+  });
+
+  it('malformed for a non-JSON or structurally-invalid payload', () => {
+    expect(classifyJobPayload(literal('not-json')).kind).toBe('malformed');
+    expect(classifyJobPayload(bind({ ...validJob, jobId: '' })).kind).toBe('malformed');
+    expect(classifyJobPayload(bind({ ...validJob, request: {} })).kind).toBe('malformed');
+    expect(classifyJobPayload(bind({ ...validJob, enqueuedAt: 'x' })).kind).toBe('malformed');
+  });
+
+  it('job for a structurally-valid payload, INCLUDING a non-enum state', () => {
+    expect(classifyJobPayload(bind(validJob))).toMatchObject({ kind: 'job' });
+    const result = classifyJobPayload(bind({ ...validJob, state: 'bogus_state' }));
+    expect(result.kind).toBe('job');
+    if (result.kind === 'job') expect(result.job.state).toBe('bogus_state');
   });
 });

--- a/packages/publisher/test/async-promote-terminal-clear.test.ts
+++ b/packages/publisher/test/async-promote-terminal-clear.test.ts
@@ -139,6 +139,17 @@ describe('#1837 promote queue clearTerminalJob', () => {
     await expect(queue.clearTerminalJob('corrupt-1')).resolves.toEqual({ outcome: 'rejected', reason: 'malformed' });
   });
 
+  // #1893 (review): a payload that is otherwise well-formed but carries no string `state` is
+  // structural corruption → malformed (HTTP 400), NOT the unknown-state path (HTTP 409).
+  it('rejects a payload with a missing/non-string state as malformed, not unknown', async () => {
+    const queue = createQueue();
+    const noState = { jobId: 'nostate-1', request: makeRequest(), enqueuedAt: now, updatedAt: now, attempt: { count: 0, maxRetries: 3 } };
+    await store.insert([
+      { subject: jobSubject('nostate-1'), predicate: PROMOTE_PAYLOAD, object: literal(JSON.stringify(noState)), graph: DEFAULT_PROMOTE_CONTROL_GRAPH_URI },
+    ]);
+    await expect(queue.clearTerminalJob('nostate-1')).resolves.toEqual({ outcome: 'rejected', reason: 'malformed' });
+  });
+
   it('concurrent clears of one terminal job are deterministic: one cleared, rest already_absent, no other job affected', async () => {
     const queue = createQueue();
     const target = await enqueueSucceeded(queue, { assertionName: 'a' });
@@ -174,7 +185,16 @@ describe('classifyJobPayload', () => {
     expect(classifyJobPayload(bind({ ...validJob, enqueuedAt: 'x' })).kind).toBe('malformed');
   });
 
-  it('job for a structurally-valid payload, INCLUDING a non-enum state', () => {
+  // #1893 (review): a missing or non-string `state` is structural corruption — it must be
+  // `malformed`, NOT `unknown` (which is reserved for a well-formed but non-enum state string).
+  it('malformed for a missing or non-string state', () => {
+    expect(classifyJobPayload(bind({ ...validJob, state: undefined })).kind).toBe('malformed'); // JSON.stringify drops the key
+    expect(classifyJobPayload(bind({ ...validJob, state: '' })).kind).toBe('malformed');
+    expect(classifyJobPayload(bind({ ...validJob, state: 42 })).kind).toBe('malformed');
+    expect(classifyJobPayload(bind({ ...validJob, state: null })).kind).toBe('malformed');
+  });
+
+  it('job for a structurally-valid payload, INCLUDING a non-enum state string', () => {
     expect(classifyJobPayload(bind(validJob))).toMatchObject({ kind: 'job' });
     const result = classifyJobPayload(bind({ ...validJob, state: 'bogus_state' }));
     expect(result.kind).toBe('job');


### PR DESCRIPTION
## Summary

- Replaces the **dual read** in `TripleStoreAsyncPromoteQueue.clearTerminalJob` (a bare `PROMOTE_STATE` index probe + `parseLiteral`, then the canonical `readJob`) with a **single canonical payload read**, matching the lift sibling. No behaviour change — verified non-correctness during #1883 review.
- Adds `classifyJobPayload(binding): { kind: 'absent' | 'malformed' } | { kind: 'job'; job }`, which does the same structural validation as `parseJobPayload` **minus the state-enum check**. That lets the clear distinguish, from one read: `already_absent` (no payload), `malformed` (corrupt payload), and a structurally-valid job whose `state` isn't a recognized enum (→ `unknown`).
- `parseJobPayload` is re-implemented as a **strict wrapper** over `classifyJobPayload` (re-applies the enum drop), so `list` / `readJob` / conflict-detection remain byte-identical.

## Related

- Follow-up to #1837 (PR #1883). Resolves #1893.

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/async-promote-queue-utils.ts` | Add `PromoteJobParseResult` + `classifyJobPayload`; `parseJobPayload` becomes a strict wrapper over it. |
| `packages/publisher/src/async-promote-queue-impl.ts` | `clearTerminalJob` classifies from a single `PROMOTE_PAYLOAD` read; drop the `PROMOTE_STATE` probe and the now-dead `parseLiteral` import. |
| `packages/publisher/test/async-promote-terminal-clear.test.ts` | Migrate the `unknown` fixture to a payload with a bogus state; add corrupt-payload → `malformed`; add a focused `classifyJobPayload` unit block. |

## Test plan

- [x] `pnpm -C packages/publisher exec tsc --noEmit` — clean
- [x] `pnpm -C packages/publisher exec vitest run test/async-promote-terminal-clear.test.ts test/async-promote-queue.test.ts` — **80/80** (67 promote-queue regression + 13 terminal-clear)
- [ ] Full CI on `testnet-canary`

## Issue closure

⚠️ Targets `testnet-canary` (non-default base), so merging will **not** auto-close **#1893** — please close it manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
