### PR TITLE
refactor(publisher): named VmPublisherControl contract + neutral job-id grammar (#1889)

### DIFF
--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -16,10 +16,8 @@ import type {
   OperationTracker,
 } from '@origintrail-official/dkg-node-ui';
 import type { DkgConfig, loadNetworkConfig } from '../../config.js';
-import type {
-  createPublisherControlFromStore,
-  PublisherState,
-} from '../../publisher-runner.js';
+import type { VmPublisherControl } from '@origintrail-official/dkg-publisher';
+import type { PublisherState } from '../../publisher-runner.js';
 import type { ExtractionStatusRecord } from '../../extraction-status.js';
 import type { FileStore } from '../../file-store.js';
 import type { VectorStore, EmbeddingProvider } from '../../vector-store.js';
@@ -61,7 +59,7 @@ export interface RequestContext {
   req: IncomingMessage;
   res: ServerResponse;
   agent: DKGAgent;
-  publisherControl: ReturnType<typeof createPublisherControlFromStore>;
+  publisherControl: VmPublisherControl;
   /** Lifecycle-owned runtime and readiness as one correlated state. */
   publisherState: PublisherState;
   config: DkgConfig;

--- a/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
+++ b/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
@@ -23,8 +23,8 @@ import {
 import {
   type PromoteJob,
   type PromoteJobState,
-  SAFE_CLEAR_JOB_ID_PATTERN,
-  SAFE_CLEAR_JOB_ID_MAX_LENGTH,
+  SAFE_JOB_ID_PATTERN,
+  SAFE_JOB_ID_MAX_LENGTH,
 } from '@origintrail-official/dkg-publisher';
 import { daemonState } from '../state.js';
 import {
@@ -122,11 +122,11 @@ export class ImportArtifactRouteError extends Error {
 
 export function validatePromoteJobId(jobId: string): { valid: true } | { valid: false; reason: string } {
   // Grammar + length bound are imported from the publisher (the single authoritative
-  // job-id contract, also enforced control-plane-side by `isSafeClearJobId`) so route
+  // job-id contract, also enforced control-plane-side by `isSafeJobId`) so route
   // acceptance and control-plane acceptance cannot drift.
   if (!jobId) return { valid: false, reason: "jobId is required" };
-  if (jobId.length > SAFE_CLEAR_JOB_ID_MAX_LENGTH) return { valid: false, reason: "jobId is too long" };
-  if (!SAFE_CLEAR_JOB_ID_PATTERN.test(jobId)) {
+  if (jobId.length > SAFE_JOB_ID_MAX_LENGTH) return { valid: false, reason: "jobId is too long" };
+  if (!SAFE_JOB_ID_PATTERN.test(jobId)) {
     return {
       valid: false,
       reason: "jobId may only contain letters, numbers, '.', '_', ':', and '-'",

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -30,10 +30,7 @@ import {
   type AsyncLiftPublisher,
   type AsyncLiftPublisherConfig,
   type AsyncLiftPublisherRecoveryResult,
-  type VmPublishIntentRecoveryPublisher,
-  type VmPublishIntentIndexBackfiller,
-  type VmPublishAdmissionJournalReader,
-  type VmPublishTerminalJobClearer,
+  type VmPublisherControl,
   type LiftJobBroadcast,
   type LiftJobHex,
   type LiftJobIncluded,
@@ -375,7 +372,7 @@ export function createPublisherInspectorFromStore(
 export function createPublisherControlFromStore(
   store: TripleStore,
   options: { publicSnapshotStore?: WorkspacePublicSnapshotStore; maxRetries?: number } = {},
-): VmPublishIntentRecoveryPublisher & VmPublishIntentIndexBackfiller & VmPublishAdmissionJournalReader & VmPublishTerminalJobClearer {
+): VmPublisherControl {
   // The daemon admission instance also serves the #1828 recovery lookup (route)
   // and the boot index backfill — segregated capabilities the base
   // AsyncLiftPublisher runtime contract intentionally does NOT carry.

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -43,7 +43,8 @@ import type {
   VmPublishTerminalJobClearer,
 } from './async-lift-publisher-types.js';
 import { AsyncLiftJobConflictError } from './async-lift-publisher-types.js';
-import { isSafeClearJobId, type TerminalJobClearOutcome } from './terminal-job-clear.js';
+import { type TerminalJobClearOutcome } from './terminal-job-clear.js';
+import { isSafeJobId } from './job-id.js';
 import {
   mapPublishExceptionToLiftJobFailure,
   mapPublishResultToLiftJobSuccess,
@@ -1044,7 +1045,7 @@ export class TripleStoreAsyncLiftPublisher
     // IRI — otherwise an attacker-controlled jobId (from the clear-job HTTP body) with a
     // space/'>'/'{' could break the query out of `<…>` and surface as a 500/injection
     // instead of the bounded outcome.
-    if (!isSafeClearJobId(jobId)) return { outcome: 'rejected', reason: 'malformed' };
+    if (!isSafeJobId(jobId)) return { outcome: 'rejected', reason: 'malformed' };
     return this.withClaimLock(async () => {
       await this.ensureGraph();
       const rows = expectBindings(

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -148,6 +148,20 @@ export interface VmPublishIntentIndexBackfiller {
   ensureVmPublishIntentIndex(): Promise<number>;
 }
 
+/**
+ * #1889 — the composite VM-publisher control surface returned by the daemon factory
+ * (`createPublisherControlFromStore`) and held by `RequestContext.publisherControl`. Names
+ * the capability set the daemon depends on, so the factory return type and the context field
+ * are a single named contract instead of an ad-hoc intersection. The four base interfaces
+ * remain the narrow contracts for callers that need a smaller surface (e.g. the boot
+ * backfill depends only on `VmPublishIntentIndexBackfiller`).
+ */
+export interface VmPublisherControl
+  extends VmPublishIntentRecoveryPublisher,
+    VmPublishIntentIndexBackfiller,
+    VmPublishAdmissionJournalReader,
+    VmPublishTerminalJobClearer {}
+
 export interface AsyncLiftPublisherRecoveryResult {
   inclusion: LiftJobInclusionMetadata;
   finalization: LiftJobFinalizationMetadata;

--- a/packages/publisher/src/async-lift-publisher.ts
+++ b/packages/publisher/src/async-lift-publisher.ts
@@ -15,6 +15,7 @@ export type {
   VmPublishIntentIndexBackfiller,
   VmPublishAdmissionJournalReader,
   VmPublishTerminalJobClearer,
+  VmPublisherControl,
   IntentLookupInput,
   IntentLookupResult,
   JournalReadInput,

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -18,7 +18,8 @@
  */
 
 import type { TripleStore } from '@origintrail-official/dkg-storage';
-import { isSafeClearJobId, type TerminalJobClearOutcome } from './terminal-job-clear.js';
+import { type TerminalJobClearOutcome } from './terminal-job-clear.js';
+import { isSafeJobId } from './job-id.js';
 import {
   ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
   ASYNC_PROMOTE_QUEUE_MIN_AUTO_RECOVERABLE_FORMAT_VERSION,
@@ -624,7 +625,7 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
     // Reject an empty OR SPARQL-unsafe jobId as malformed before building the jobSubject
     // IRI (defense-in-depth; the SWM route already pre-validates via decodePromoteJobId,
     // but a direct agent.assertion.clearPromoteAsync caller must be bounded too).
-    if (!isSafeClearJobId(jobId)) return { outcome: 'rejected', reason: 'malformed' };
+    if (!isSafeJobId(jobId)) return { outcome: 'rejected', reason: 'malformed' };
     return this.withMutationLock(async () => {
       await this.ensureGraph();
       const rows = expectBindings(

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -268,6 +268,7 @@ export {
   type VmPublishIntentIndexBackfiller,
   type VmPublishAdmissionJournalReader,
   type VmPublishTerminalJobClearer,
+  type VmPublisherControl,
   type TerminalJobClearOutcome,
   type IntentLookupInput,
   type IntentLookupResult,
@@ -275,9 +276,10 @@ export {
   type JournalReadResult,
 } from './async-lift-publisher.js';
 export {
-  SAFE_CLEAR_JOB_ID_PATTERN,
-  SAFE_CLEAR_JOB_ID_MAX_LENGTH,
-} from './terminal-job-clear.js';
+  SAFE_JOB_ID_PATTERN,
+  SAFE_JOB_ID_MAX_LENGTH,
+  isSafeJobId,
+} from './job-id.js';
 export {
   TripleStoreAsyncPromoteQueue,
   ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,

--- a/packages/publisher/src/job-id.ts
+++ b/packages/publisher/src/job-id.ts
@@ -1,0 +1,23 @@
+// Neutral job-id grammar contract, shared by BOTH the by-jobId terminal-clear guard
+// (`isSafeJobId`, used by the lift publisher and the promote queue) AND the CLI promote
+// route validator (`validatePromoteJobId`). It is NOT clear-specific — status / cancel /
+// recover / clear all accept the same job-id shape — so it lives in its own module rather
+// than being named as terminal-clear policy, and a change here provably applies to every
+// promote route + control-plane operation at once.
+
+// Producer grammar for a queue jobId (crypto.randomUUID(), or test 'job-N'): starts
+// alphanumeric, then alnum / '.' / '_' / ':' / '-'. IRI-safe — it excludes every character
+// that could break out of the `<…>` IRI in a control-plane SPARQL query (spaces, '<' '>'
+// '"' '{' '}' '|' '^' '`', control chars).
+export const SAFE_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+export const SAFE_JOB_ID_MAX_LENGTH = 256;
+
+/**
+ * True iff `jobId` is safe to interpolate into a control-plane SPARQL IRI. A by-jobId
+ * operation MUST reject an unsafe jobId BEFORE building the query, so an attacker-controlled
+ * jobId (e.g. from an HTTP body) yields a bounded reject rather than a query syntax error /
+ * injection / 500.
+ */
+export function isSafeJobId(jobId: string): boolean {
+  return jobId.length > 0 && jobId.length <= SAFE_JOB_ID_MAX_LENGTH && SAFE_JOB_ID_PATTERN.test(jobId);
+}

--- a/packages/publisher/src/terminal-job-clear.ts
+++ b/packages/publisher/src/terminal-job-clear.ts
@@ -1,6 +1,6 @@
-// #1837 — shared contract for the atomic by-exact-jobId TERMINAL clear, owned by NEITHER
-// queue (lift nor promote) so a generic admin-clear result is not coupled to one
-// implementation family's type module.
+// #1837 — shared contract for the atomic by-exact-jobId TERMINAL clear OUTCOME, owned by
+// NEITHER queue (lift nor promote) so a generic admin-clear result is not coupled to one
+// implementation family's type module. (The job-id grammar guard lives in `./job-id.ts`.)
 
 /**
  * Bounded outcome of a terminal clear, shared by the lift publisher and the SWM promote
@@ -13,24 +13,3 @@ export type TerminalJobClearOutcome =
   | { readonly outcome: 'cleared' }
   | { readonly outcome: 'already_absent' }
   | { readonly outcome: 'rejected'; readonly reason: 'nonterminal' | 'unknown' | 'malformed' };
-
-// Producer grammar for a queue jobId (crypto.randomUUID(), or test 'job-N'): starts
-// alphanumeric, then alnum/'.'/'_'/':'/'-'. This is IRI-safe — it excludes every character
-// that could break out of the `<…>` IRI in a control-plane SPARQL query (spaces, '<' '>'
-// '"' '{' '}' '|' '^' '`', control chars). This is the SINGLE authoritative job-id grammar:
-// the CLI route validator (`validatePromoteJobId`) imports it rather than re-declaring the
-// regex, so route-level and control-plane job-id acceptance cannot drift.
-export const SAFE_CLEAR_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
-export const SAFE_CLEAR_JOB_ID_MAX_LENGTH = 256;
-
-/**
- * True iff `jobId` is safe to interpolate into a control-plane SPARQL IRI. A by-id clear
- * MUST reject an unsafe jobId as `malformed` BEFORE building the query, so an
- * attacker-controlled jobId (from the clear-job HTTP body) yields a bounded reject rather
- * than a query syntax error / injection / 500.
- */
-export function isSafeClearJobId(jobId: string): boolean {
-  return (
-    jobId.length > 0 && jobId.length <= SAFE_CLEAR_JOB_ID_MAX_LENGTH && SAFE_CLEAR_JOB_ID_PATTERN.test(jobId)
-  );
-}


### PR DESCRIPTION
## Summary

- **Named control contract (Part A):** introduces `VmPublisherControl` — a composite of the four `VmPublish*` capability interfaces. `createPublisherControlFromStore` now returns `VmPublisherControl`, and `RequestContext.publisherControl` is typed with it instead of `ReturnType<typeof createPublisherControlFromStore>`, removing the factory-indirection leak. The four base interfaces stay as narrow contracts for smaller-surface callers (e.g. the boot backfill).
- **Neutral job-id grammar (Part B):** moves the shared job-id grammar out of `terminal-job-clear.ts` (where it was named as clear policy despite governing **all** promote routes via `validatePromoteJobId`) into a neutral `job-id.ts` — `SAFE_JOB_ID_PATTERN` / `SAFE_JOB_ID_MAX_LENGTH` / `isSafeJobId`. The lift + promote clear guards and the CLI route validator all delegate to it, so route-level and control-plane acceptance provably cannot drift. `terminal-job-clear.ts` is now the clear-**outcome** module only.
- No runtime behaviour change. Clean rename (`SAFE_CLEAR_JOB_ID_*` → `SAFE_JOB_ID_*`, no back-compat shim per repo policy); the accepted grammar is byte-identical.
- Part C (naming the promote-queue intersection) intentionally **skipped** — the `agent.promoteQueue` cast it targeted was already removed in #1883, so it carried no value.

## Related

- Follow-up to #1837 (PR #1883). Resolves #1889.
- **Stacked on #1899** (`fix/1893-promote-single-read`) — both edit `async-promote-queue-impl.ts` at the terminal-clear guard, so this branches off #1899 to avoid a merge conflict. Until #1899 merges, this PR's diff includes it; it narrows to just this change once #1899 lands. **Merge #1899 first.**

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/job-id.ts` | **New** neutral grammar module (`SAFE_JOB_ID_PATTERN` / `SAFE_JOB_ID_MAX_LENGTH` / `isSafeJobId`). |
| `packages/publisher/src/terminal-job-clear.ts` | Grammar removed; now the clear-outcome type only. |
| `packages/publisher/src/async-lift-publisher-types.ts` | Add `VmPublisherControl` composite. |
| `packages/publisher/src/async-lift-publisher.ts`, `index.ts` | Re-export `VmPublisherControl`; grammar re-export now from `job-id.js`. |
| `packages/publisher/src/async-lift-publisher-impl.ts`, `async-promote-queue-impl.ts` | Import `isSafeJobId` from `job-id.js`; guard call sites renamed. |
| `packages/cli/src/publisher-runner.ts` | Return type → `VmPublisherControl`. |
| `packages/cli/src/daemon/routes/context.ts` | `publisherControl: VmPublisherControl` (drops the `ReturnType` indirection). |
| `packages/cli/src/daemon/routes/shared-assertion-helpers.ts` | `validatePromoteJobId` uses the renamed grammar symbols. |

## Test plan

- [x] `pnpm -C packages/publisher build` (tsc) — clean
- [x] `pnpm -C packages/publisher exec vitest run test/async-lift-terminal-clear.test.ts test/async-promote-terminal-clear.test.ts` — **24/24** (isSafeJobId guard)
- [x] cli `tsc --noEmit` — clean (after `pnpm build:packages`); agent `tsc --noEmit` — clean
- [x] `pnpm -C packages/cli exec vitest run test/promote-async-routes.test.ts test/publisher-clear-job-route.test.ts` — green
- [ ] Full CI on `testnet-canary`

## Issue closure

⚠️ Targets `testnet-canary` (non-default base) → merging will **not** auto-close **#1889**; close it manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
