### PR TITLE
test(canary): probe explicitly selected sync peer

### DIFF
--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -864,7 +864,14 @@ WHERE {
         continue;
       }
       const baseCandidatePeers = await candidatePeersForContextGraph(cgId);
-      const unsupportedPeers = await unsupportedPeersForContextGraph(cgId, baseCandidatePeers);
+      // An explicit peerId is an operator-directed bounded probe. libp2p's
+      // identify-backed peerStore can lag a live connection, so an absent
+      // protocol advertisement must not suppress the wire negotiation the
+      // operator requested. Default peer enumeration remains conservative and
+      // filters peers that are known not to advertise the current sync wire.
+      const unsupportedPeers = peerIdParam
+        ? new Set<string>()
+        : await unsupportedPeersForContextGraph(cgId, baseCandidatePeers);
       const privateCuratorPeerIds = await privateCuratorPeersForContextGraph(cgId);
       const swmSelectedPeers = canUseSharedMemory
         ? swmCatchupPeerSelector.select({

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -99,6 +99,111 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
     expect(agent.getPeerProtocols).not.toHaveBeenCalled();
   });
 
+  it('probes an explicit durable peer even when its protocol advertisement is absent', async () => {
+    const cgId = 'explicit-durable-probe-cg';
+    const peerId = 'peer-live-with-stale-identify';
+    const syncFromPeerDetailed = vi.fn(async () => detailedDurableResult({
+      insertedTriples: 23,
+      insertedDataTriples: 20,
+      insertedMetaTriples: 3,
+      complete: true,
+    }));
+    const agent = {
+      peerId: 'self-peer',
+      getPeerProtocols: vi.fn(async () => []),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: cgId,
+        peerId,
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(agent.getPeerProtocols).not.toHaveBeenCalled();
+    expect(syncFromPeerDetailed).toHaveBeenCalledWith(
+      peerId,
+      [cgId],
+      undefined,
+      undefined,
+      undefined,
+      { totalTimeoutMs: 109_000 },
+    );
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      durableComplete: true,
+      peersAttempted: 1,
+      totalDurableInsertedTriples: 23,
+      results: [{
+        peerId,
+        durableInsertedTriples: 23,
+        durableComplete: true,
+      }],
+      perContextGraph: [{
+        contextGraphId: cgId,
+        durableComplete: true,
+        perPeer: [{
+          peerId,
+          durableInsertedTriples: 23,
+          durableComplete: true,
+          durableDiagnostics: {
+            insertedDataTriples: 20,
+            insertedMetaTriples: 3,
+          },
+        }],
+      }],
+    });
+  });
+
+  it('still filters an implicitly enumerated durable peer without sync advertisement', async () => {
+    const cgId = 'implicit-unsupported-durable-cg';
+    const peerId = 'peer-legacy';
+    const syncFromPeerDetailed = vi.fn();
+    const agent = {
+      peerId: 'self-peer',
+      node: {
+        libp2p: {
+          getConnections: () => [{
+            remotePeer: { toString: () => peerId },
+          }],
+        },
+      },
+      getPeerProtocols: vi.fn(async () => []),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncFromPeerDetailed,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: cgId,
+        includeSharedMemory: false,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(agent.getPeerProtocols).toHaveBeenCalledWith(peerId);
+    expect(syncFromPeerDetailed).not.toHaveBeenCalled();
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: false,
+      retryable: true,
+      errorCode: 'DURABLE_CATCHUP_NO_ELIGIBLE_PEERS',
+      durableComplete: false,
+      peersAttempted: 0,
+    });
+  });
+
   it('supports durable-only recovery without starting either SWM catchup path', async () => {
     const cgId = 'private-durable-only-cg';
     const peerId = 'peer-curator';


### PR DESCRIPTION
Follow-up to #1903 for the sealed 10.0.10 Day-One testnet gate.

The live candidate correctly rejected false completion but exposed a recovery blocker: the explicitly supplied source peer was connected while the identify-backed peerStore omitted the sync protocol, so the route filtered the operator-selected peer before wire negotiation.

This carries only the reviewed #1898 delta at c5f5eae50418ff376fb231686041555177076617:
- explicit peerId bypasses stale advertised-protocol prefilter and performs one bounded negotiation
- implicit peer enumeration retains the existing protocol filter
- regressions cover both cases

Verification:
- patch is byte-identical to 9e975a3..c5f5eae from #1898
- focused canary route suite: 20/20
- PR owner catch-up suite: 51/51
- PR owner 17-package build: pass
- diff-check: pass

After normal merge, nodes should auto-update. No manual deployment or restart is requested.