### PR TITLE
test(publisher): consolidate the async-lift KA VM-publish fixture into _helpers/ (#1862)

### DIFF
--- a/packages/publisher/test/_helpers/ka-vm-publish.ts
+++ b/packages/publisher/test/_helpers/ka-vm-publish.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared fixture for the KA async VM-publish specs.
+ *
+ * The `kaVmPublishRequest` builder, the `storeKnowledgeAssetOperationPublicQuads`
+ * share-snapshot staging, and the repeated validation / broadcast / inclusion
+ * constants were copy-pasted verbatim across six async-lift spec files (see
+ * GH #1862). This module is the single source for that fixture so the specs stay
+ * focused on the behaviour they assert.
+ *
+ * Every value here is byte-identical to the literals it replaced — no scenario
+ * or assertion changed. Cosmetic variations across the original copies (all of
+ * which resolved to the SAME value) were collapsed onto the canonical form:
+ *   - `roots: [] as string[]` / `roots: []`                → `roots: []`
+ *   - `contentScopeVersion: 2 as const`                    → `GRAPH_KA_CONTENT_SCOPE_VERSION` (=== 2)
+ *   - inline `did:dkg:31337/<author>/7` / `ROOTLESS_UAL`   → `KA_VM_KA_UAL`
+ *   - `` `sha256:${'ab'.repeat(32)}` `` / `'sha256:' + …`  → template literal
+ */
+import { GraphManager, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import { GRAPH_KA_CONTENT_SCOPE_VERSION } from '@origintrail-official/dkg-core';
+import {
+  storeKnowledgeAssetOperationPublicQuads,
+  type KnowledgeAssetVmPublishRequest,
+  type LiftJobValidationMetadata,
+} from '../../src/index.js';
+
+/** Fixed KA author address shared by every VM-publish fixture request. */
+export const KA_VM_AUTHOR_ADDRESS = '0x1111111111111111111111111111111111111111';
+/** Fixed KA number shared by every VM-publish fixture request. */
+export const KA_VM_KA_NUMBER = 7n;
+/** Rootless UAL for the one queued KA (`did:dkg:31337/<author>/<kaNumber>`). */
+export const KA_VM_KA_UAL = `did:dkg:31337/${KA_VM_AUTHOR_ADDRESS}/${KA_VM_KA_NUMBER.toString()}`;
+
+/**
+ * Build the canonical KA VM-publish request, overriding any field. The
+ * strongly-typed `Partial<KnowledgeAssetVmPublishRequest>` override subsumes the
+ * loose `Record<string, unknown>` variant some of the original copies used.
+ */
+export function kaVmPublishRequest(
+  overrides: Partial<KnowledgeAssetVmPublishRequest> = {},
+): KnowledgeAssetVmPublishRequest {
+  const base: KnowledgeAssetVmPublishRequest = {
+    contextGraphId: 'music-social',
+    name: 'albums',
+    shareOperationId: 'share-op-1',
+    roots: [],
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: KA_VM_KA_UAL,
+    assertionVersion: '1',
+    publicTripleCount: 2,
+    privateTripleCount: 0,
+    seal: {
+      merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+      authorAddress: KA_VM_AUTHOR_ADDRESS as `0x${string}`,
+      signature: {
+        r: (`0x${'34'.repeat(32)}`) as `0x${string}`,
+        vs: (`0x${'56'.repeat(32)}`) as `0x${string}`,
+      },
+      schemeVersion: 1,
+      reservedKaId: ((BigInt(KA_VM_AUTHOR_ADDRESS) << 96n) | KA_VM_KA_NUMBER).toString() as `${bigint}`,
+    },
+    sealChainId: '31337' as `${bigint}`,
+    sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+    sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+    sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
+    intentKey: `sha256:${'ab'.repeat(32)}`,
+    wmCurrentAssertion: '12'.repeat(32),
+    swmCurrentAssertion: '12'.repeat(32),
+    kaNumber: KA_VM_KA_NUMBER.toString(),
+    reservedUal: KA_VM_KA_UAL,
+  };
+  return { ...base, ...overrides };
+}
+
+/** The two public album triples staged by every share-snapshot fixture. */
+export const KA_VM_ALBUM_QUADS: readonly Quad[] = [
+  { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+  { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+];
+
+export interface StageKnowledgeAssetShareSnapshotParams {
+  store: TripleStore;
+  /** Defaults to a fresh `GraphManager` over `store`. */
+  graphManager?: GraphManager;
+  contextGraphId?: string;
+  shareOperationId?: string;
+  kaUal?: string;
+  /**
+   * Kept as `string | number | bigint` so each call site preserves its exact
+   * value AND type — the two SWM-staging specs pass the string `'1'`, the
+   * rootless-snapshot spec passes the number `1`.
+   */
+  assertionVersion?: string | number | bigint;
+  publisherPeerId?: string;
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  quads?: readonly Quad[];
+}
+
+/**
+ * Stage the KA share snapshot (`storeKnowledgeAssetOperationPublicQuads`) shared
+ * by the SWM-backed VM-publish specs. Every parameter defaults to the canonical
+ * fixture value; genuine per-file variations (store, assertionVersion type,
+ * accessPolicy, shareOperationId) are passed by the caller's thin wrapper.
+ */
+export async function stageKnowledgeAssetShareSnapshot(
+  params: StageKnowledgeAssetShareSnapshotParams,
+): Promise<void> {
+  await storeKnowledgeAssetOperationPublicQuads({
+    store: params.store,
+    graphManager: params.graphManager ?? new GraphManager(params.store),
+    contextGraphId: params.contextGraphId ?? 'music-social',
+    shareOperationId: params.shareOperationId ?? 'share-op-1',
+    kaUal: params.kaUal ?? KA_VM_KA_UAL,
+    assertionVersion: params.assertionVersion ?? '1',
+    publisherPeerId: params.publisherPeerId ?? 'peer-1',
+    quads: params.quads ?? KA_VM_ALBUM_QUADS,
+    ...(params.accessPolicy !== undefined ? { accessPolicy: params.accessPolicy } : {}),
+  });
+}
+
+/** Shared `validated`-transition payload (`authorityProofRef: 'knowledge-asset-lifecycle'`, `swmQuadCount: 2`). */
+export const KA_VM_VALIDATION: LiftJobValidationMetadata = {
+  canonicalRoots: [],
+  canonicalRootMap: {},
+  swmQuadCount: 2,
+  authorityProofRef: 'knowledge-asset-lifecycle',
+  transitionType: 'CREATE',
+};
+
+/** Shared `broadcast` payload (`0xef…` attempted tx hash, `wallet-1`). Untyped so it mirrors the specs' local `bx`. */
+export const KA_VM_BROADCAST_TX = {
+  txHash: (`0x${'ef'.repeat(32)}`) as `0x${string}`,
+  walletId: 'wallet-1',
+};
+
+/** Shared `inclusion` payload (`0xaa…` block hash). Untyped so it mirrors the specs' local `inc` (no txHash). */
+export const KA_VM_INCLUSION = {
+  blockNumber: 10,
+  blockHash: (`0x${'aa'.repeat(32)}`) as `0x${string}`,
+  blockTimestamp: 1,
+};
+
+/** Executor-signed on-chain tx hash (`0xcd…`) driven through the pre-send write-ahead. */
+export const KA_VM_EXECUTOR_TX_HASH = (`0x${'cd'.repeat(32)}`) as `0x${string}`;

--- a/packages/publisher/test/async-lift-broadcast-durability.test.ts
+++ b/packages/publisher/test/async-lift-broadcast-durability.test.ts
@@ -3,12 +3,11 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { NO_FUNDED_PUBLISHER_WALLET_CODE } from '@origintrail-official/dkg-core';
-import { GraphManager, OxigraphStore } from '@origintrail-official/dkg-storage';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   TripleStoreAsyncLiftPublisher,
   type AsyncLiftPublisherConfig,
 } from '../src/index.js';
-import { storeKnowledgeAssetOperationPublicQuads } from '../src/workspace-resolution.js';
 import {
   DEFAULT_JOURNAL_GRAPH_URI,
   JOURNAL_SEQ,
@@ -16,6 +15,11 @@ import {
   parseIntegerLiteral,
   parseLiteral,
 } from '../src/async-lift-control-plane.js';
+import {
+  KA_VM_EXECUTOR_TX_HASH,
+  kaVmPublishRequest,
+  stageKnowledgeAssetShareSnapshot,
+} from './_helpers/ka-vm-publish.js';
 
 // Read the journal kinds (seq-ordered) straight from the node-local journal graph.
 async function journalKinds(store: OxigraphStore): Promise<string[]> {
@@ -70,56 +74,10 @@ describe('async lift publisher broadcast durability', () => {
     });
   }
 
-  function kaVmPublishRequest() {
-    const authorAddress = '0x1111111111111111111111111111111111111111';
-    const kaNumber = 7n;
-    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
-    return {
-      contextGraphId: 'music-social',
-      name: 'albums',
-      shareOperationId: 'share-op-1',
-      roots: [] as string[],
-      contentScopeVersion: 2 as const,
-      kaUal,
-      assertionVersion: '1',
-      publicTripleCount: 2,
-      privateTripleCount: 0,
-      seal: {
-        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-        authorAddress: authorAddress as `0x${string}`,
-        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
-        schemeVersion: 1,
-        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
-      },
-      sealChainId: '31337' as `${bigint}`,
-      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-      intentKey: `sha256:${'ab'.repeat(32)}`,
-      wmCurrentAssertion: '12'.repeat(32),
-      swmCurrentAssertion: '12'.repeat(32),
-      kaNumber: kaNumber.toString(),
-      reservedUal: kaUal,
-    };
-  }
-
-  const TX_HASH = `0x${'cd'.repeat(32)}` as `0x${string}`;
+  const TX_HASH = KA_VM_EXECUTOR_TX_HASH;
 
   async function stageShareSnapshot(targetStore: OxigraphStore): Promise<void> {
-    const request = kaVmPublishRequest();
-    await storeKnowledgeAssetOperationPublicQuads({
-      store: targetStore,
-      graphManager: new GraphManager(targetStore),
-      contextGraphId: 'music-social',
-      shareOperationId: 'share-op-1',
-      kaUal: request.kaUal,
-      assertionVersion: request.assertionVersion,
-      publisherPeerId: 'peer-1',
-      quads: [
-        { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
-        { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-      ],
-    });
+    await stageKnowledgeAssetShareSnapshot({ store: targetStore });
   }
 
   // A VM-publish executor that fires the pre-send write-ahead (onPhase → records

--- a/packages/publisher/test/async-lift-intent-lookup.test.ts
+++ b/packages/publisher/test/async-lift-intent-lookup.test.ts
@@ -12,6 +12,7 @@ import {
   knowledgeAssetVmPublishLifecycleKey,
   serializeJob,
 } from '../src/async-lift-control-plane.js';
+import { KA_VM_BROADCAST_TX, KA_VM_VALIDATION, kaVmPublishRequest } from './_helpers/ka-vm-publish.js';
 
 // #1828 — durable-admission recovery: exact intent lookup keyed on the lifecycle
 // facts a client retains, with a materialized index and deterministic
@@ -37,40 +38,6 @@ describe('#1828 async lift intent lookup', () => {
     });
   }
 
-  function kaVmPublishRequest(overrides: Record<string, unknown> = {}) {
-    const authorAddress = '0x1111111111111111111111111111111111111111';
-    const kaNumber = 7n;
-    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
-    return {
-      contextGraphId: 'music-social',
-      name: 'albums',
-      shareOperationId: 'share-op-1',
-      roots: [] as string[],
-      contentScopeVersion: 2 as const,
-      kaUal,
-      assertionVersion: '1',
-      publicTripleCount: 2,
-      privateTripleCount: 0,
-      seal: {
-        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-        authorAddress: authorAddress as `0x${string}`,
-        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
-        schemeVersion: 1,
-        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
-      },
-      sealChainId: '31337' as `${bigint}`,
-      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-      intentKey: `sha256:${'ab'.repeat(32)}`,
-      wmCurrentAssertion: '12'.repeat(32),
-      swmCurrentAssertion: '12'.repeat(32),
-      kaNumber: kaNumber.toString(),
-      reservedUal: kaUal,
-      ...overrides,
-    };
-  }
-
   // The facts a recovering client retains (never the jobId or intentKey).
   const facts = { contextGraphId: 'music-social', name: 'albums' };
 
@@ -78,18 +45,8 @@ describe('#1828 async lift intent lookup', () => {
     const publisher = createPublisher({ recoveryLookupTimeoutMs: 10 });
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(request);
     await publisher.claimNext('wallet-1');
-    await publisher.update(jobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
-    });
-    await publisher.update(jobId, 'broadcast', {
-      broadcast: { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' },
-    });
+    await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
+    await publisher.update(jobId, 'broadcast', { broadcast: KA_VM_BROADCAST_TX });
     now += 20;
     await publisher.recover();
     const job = await publisher.getStatus(jobId);

--- a/packages/publisher/test/async-lift-journal-append.test.ts
+++ b/packages/publisher/test/async-lift-journal-append.test.ts
@@ -13,6 +13,12 @@ import {
   parseLiteral,
   serializeJob,
 } from '../src/async-lift-control-plane.js';
+import {
+  KA_VM_BROADCAST_TX,
+  KA_VM_INCLUSION,
+  KA_VM_VALIDATION,
+  kaVmPublishRequest,
+} from './_helpers/ka-vm-publish.js';
 
 // #1829 chunk 2-3 — appendJournal hooked into writeJob: per-lineageKey monotonic seq,
 // explicit kinds, daemon-only gating, and #1849 defensiveness (a legacy U+001F job
@@ -37,52 +43,10 @@ describe('#1829 admission journal append (writeJob hook)', () => {
     });
   }
 
-  function kaVmPublishRequest(overrides: Record<string, unknown> = {}) {
-    const authorAddress = '0x1111111111111111111111111111111111111111';
-    const kaNumber = 7n;
-    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
-    return {
-      contextGraphId: 'music-social',
-      name: 'albums',
-      shareOperationId: 'share-op-1',
-      roots: [] as string[],
-      contentScopeVersion: 2 as const,
-      kaUal,
-      assertionVersion: '1',
-      publicTripleCount: 2,
-      privateTripleCount: 0,
-      seal: {
-        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-        authorAddress: authorAddress as `0x${string}`,
-        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
-        schemeVersion: 1,
-        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
-      },
-      sealChainId: '31337' as `${bigint}`,
-      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-      intentKey: `sha256:${'ab'.repeat(32)}`,
-      wmCurrentAssertion: '12'.repeat(32),
-      swmCurrentAssertion: '12'.repeat(32),
-      kaNumber: kaNumber.toString(),
-      reservedUal: kaUal,
-      ...overrides,
-    };
-  }
-
-  async function driveToValidated(publisher: TripleStoreAsyncLiftPublisher, overrides: Record<string, unknown> = {}): Promise<string> {
+  async function driveToValidated(publisher: TripleStoreAsyncLiftPublisher, overrides: Partial<Parameters<typeof kaVmPublishRequest>[0]> = {}): Promise<string> {
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest(overrides));
     await publisher.claimNext('wallet-1');
-    await publisher.update(jobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
-    });
+    await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
     return jobId;
   }
 
@@ -180,15 +144,15 @@ describe('#1829 admission journal append (writeJob hook)', () => {
     const jobId = await driveToValidated(publisher);
     // Force a local no-op finalize so the job reaches 'finalized' without a chain tx.
     await publisher.update(jobId, 'broadcast', {
-      broadcast: { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' },
+      broadcast: KA_VM_BROADCAST_TX,
     });
     await publisher.update(jobId, 'included', {
-      broadcast: { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' },
-      inclusion: { blockNumber: 10, blockHash: `0x${'aa'.repeat(32)}` as `0x${string}`, blockTimestamp: 1 },
+      broadcast: KA_VM_BROADCAST_TX,
+      inclusion: KA_VM_INCLUSION,
     });
     await publisher.update(jobId, 'finalized', {
-      broadcast: { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' },
-      inclusion: { blockNumber: 10, blockHash: `0x${'aa'.repeat(32)}` as `0x${string}`, blockTimestamp: 1 },
+      broadcast: KA_VM_BROADCAST_TX,
+      inclusion: KA_VM_INCLUSION,
       finalization: { mode: 'local' },
     });
     const before = await journalRows();
@@ -205,7 +169,7 @@ describe('#1829 admission journal append (writeJob hook)', () => {
     const publisher = createPublisher();
     const jobId = await driveToValidated(publisher);
     await publisher.update(jobId, 'broadcast', {
-      broadcast: { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' },
+      broadcast: KA_VM_BROADCAST_TX,
     });
     const res = await publisher.readJournalByIntent(facts);
     expect(res.entries.map((e) => e.seq)).toEqual([0, 1, 2, 3]);
@@ -250,8 +214,8 @@ describe('#1829 admission journal append (writeJob hook)', () => {
     // First job driven to a TERMINAL state so it no longer occupies the subject and a
     // fresh enqueue admits a genuine successor (rather than dedup returning the same job).
     const first = await driveToValidated(publisher);
-    const bx = { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' };
-    const inc = { blockNumber: 10, blockHash: `0x${'aa'.repeat(32)}` as `0x${string}`, blockTimestamp: 1 };
+    const bx = KA_VM_BROADCAST_TX;
+    const inc = KA_VM_INCLUSION;
     await publisher.update(first, 'broadcast', { broadcast: bx });
     await publisher.update(first, 'included', { broadcast: bx, inclusion: inc });
     await publisher.update(first, 'finalized', { broadcast: bx, inclusion: inc, finalization: { mode: 'local' } });

--- a/packages/publisher/test/async-lift-ka-broadcast-progress.test.ts
+++ b/packages/publisher/test/async-lift-ka-broadcast-progress.test.ts
@@ -10,7 +10,12 @@ import {
   jobSubject,
   walletLockSubject,
 } from '../src/async-lift-control-plane.js';
-import { storeKnowledgeAssetOperationPublicQuads } from '../src/workspace-resolution.js';
+import {
+  KA_VM_EXECUTOR_TX_HASH,
+  KA_VM_VALIDATION,
+  kaVmPublishRequest,
+  stageKnowledgeAssetShareSnapshot,
+} from './_helpers/ka-vm-publish.js';
 
 describe('KA async VM publish broadcast progress', () => {
   let now = 1_000;
@@ -35,62 +40,12 @@ describe('KA async VM publish broadcast progress', () => {
     });
   }
 
-  function kaVmPublishRequest(overrides: Partial<Parameters<TripleStoreAsyncLiftPublisher['enqueueKnowledgeAssetVmPublish']>[0]> = {}) {
-    const authorAddress = '0x1111111111111111111111111111111111111111';
-    const kaNumber = 7n;
-    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
-    return {
-      contextGraphId: 'music-social',
-      name: 'albums',
-      shareOperationId: 'share-op-1',
-      roots: [],
-      contentScopeVersion: 2 as const,
-      kaUal,
-      assertionVersion: '1',
-      publicTripleCount: 2,
-      privateTripleCount: 0,
-      seal: {
-        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-        authorAddress: authorAddress as `0x${string}`,
-        signature: {
-          r: (`0x${'34'.repeat(32)}`) as `0x${string}`,
-          vs: (`0x${'56'.repeat(32)}`) as `0x${string}`,
-        },
-        schemeVersion: 1,
-        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
-      },
-      sealChainId: '31337' as `${bigint}`,
-      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-      intentKey: `sha256:${'ab'.repeat(32)}`,
-      wmCurrentAssertion: '12'.repeat(32),
-      swmCurrentAssertion: '12'.repeat(32),
-      kaNumber: kaNumber.toString(),
-      reservedUal: kaUal,
-      ...overrides,
-    };
-  }
-
   async function stageShareSnapshot(): Promise<void> {
-    const request = kaVmPublishRequest();
-    await storeKnowledgeAssetOperationPublicQuads({
-      store,
-      graphManager,
-      contextGraphId: 'music-social',
-      shareOperationId: 'share-op-1',
-      kaUal: request.kaUal,
-      assertionVersion: request.assertionVersion,
-      publisherPeerId: 'peer-1',
-      quads: [
-        { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
-        { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-      ],
-    });
+    await stageKnowledgeAssetShareSnapshot({ store, graphManager });
   }
 
   it('persists KA broadcast tx hash when executor write-ahead fires before completion', async () => {
-    const txHash = `0x${'cd'.repeat(32)}` as `0x${string}`;
+    const txHash = KA_VM_EXECUTOR_TX_HASH;
     let jobId = '';
     let statusDuringExecutor: Awaited<ReturnType<TripleStoreAsyncLiftPublisher['getStatus']>> = null;
     const publisher = createPublisher({
@@ -127,13 +82,7 @@ describe('KA async VM publish broadcast progress', () => {
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
+      validation: KA_VM_VALIDATION,
     });
     await publisher.update(jobId, 'broadcast', {
       broadcast: { txHash, walletId: 'wallet-1' },
@@ -195,13 +144,7 @@ describe('KA async VM publish broadcast progress', () => {
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(request);
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
+      validation: KA_VM_VALIDATION,
     });
     await publisher.update(jobId, 'broadcast', {
       broadcast: { txHash, walletId: 'wallet-1', merkleRoot: request.sealMerkleRoot },
@@ -221,13 +164,7 @@ describe('KA async VM publish broadcast progress', () => {
     const includedJobId = await publisher.enqueueKnowledgeAssetVmPublish(request);
     await publisher.claimNext('wallet-1');
     await publisher.update(includedJobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
+      validation: KA_VM_VALIDATION,
     });
     await publisher.update(includedJobId, 'broadcast', {
       broadcast: { txHash, walletId: 'wallet-1', merkleRoot: request.sealMerkleRoot },
@@ -281,13 +218,7 @@ describe('KA async VM publish broadcast progress', () => {
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(request);
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
+      validation: KA_VM_VALIDATION,
     });
     await publisher.update(jobId, 'broadcast', {
       broadcast: { txHash, walletId: 'wallet-1', merkleRoot: request.sealMerkleRoot },

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -17,7 +17,6 @@ import {
   QuorumUnmetError,
   TripleStoreAsyncLiftPublisher,
   createLiftJobFailureMetadata,
-  storeKnowledgeAssetOperationPublicQuads,
   type AsyncLiftPublisherConfig,
   type AsyncLiftPublisherRecoveryResult,
   type LiftRequest,
@@ -51,6 +50,12 @@ import {
   walletLockSubject,
 } from '../src/async-lift-control-plane.js';
 import { withLegacyRawLiftTestSeeder } from './_helpers/legacy-raw-lift.js';
+import {
+  KA_VM_KA_UAL,
+  KA_VM_VALIDATION,
+  kaVmPublishRequest,
+  stageKnowledgeAssetShareSnapshot,
+} from './_helpers/ka-vm-publish.js';
 
 describe('TripleStoreAsyncLiftPublisher', () => {
   let now = 1_000;
@@ -61,7 +66,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
   let _kav10Address: string;
   let _provider: ethers.JsonRpcProvider;
   const _author = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
-  const ROOTLESS_UAL = 'did:dkg:31337/0x1111111111111111111111111111111111111111/7';
+  const ROOTLESS_UAL = KA_VM_KA_UAL;
 
   function makeTestPublisher(opts: ConstructorParameters<typeof DKGPublisher>[0]): DKGPublisher {
     // OT-RFC-43 Option-1: wire a KA-number allocator so the real EVM adapter
@@ -104,55 +109,11 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     authority: { type: 'owner', proofRef: 'proof:owner:1' },
   });
 
-  const kaVmPublishRequest = (overrides: Partial<Parameters<TripleStoreAsyncLiftPublisher['enqueueKnowledgeAssetVmPublish']>[0]> = {}) => {
-    const authorAddress = '0x1111111111111111111111111111111111111111';
-    const kaNumber = 7n;
-    const base = {
-      contextGraphId: 'music-social',
-      name: 'albums',
-      shareOperationId: 'share-op-1',
-      roots: [],
-      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
-      kaUal: ROOTLESS_UAL,
-      assertionVersion: '1',
-      publicTripleCount: 2,
-      privateTripleCount: 0,
-      seal: {
-        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-        authorAddress: authorAddress as `0x${string}`,
-        signature: {
-          r: (`0x${'34'.repeat(32)}`) as `0x${string}`,
-          vs: (`0x${'56'.repeat(32)}`) as `0x${string}`,
-        },
-        schemeVersion: 1,
-        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
-      },
-      sealChainId: '31337' as `${bigint}`,
-      sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-      intentKey: 'sha256:' + 'ab'.repeat(32),
-      wmCurrentAssertion: '12'.repeat(32),
-      swmCurrentAssertion: '12'.repeat(32),
-      kaNumber: kaNumber.toString(),
-      reservedUal: ROOTLESS_UAL,
-    };
-    return { ...base, ...overrides };
-  };
-
   async function stageRootlessSnapshot(shareOperationId: string): Promise<void> {
-    await storeKnowledgeAssetOperationPublicQuads({
+    await stageKnowledgeAssetShareSnapshot({
       store,
-      graphManager: new GraphManager(store),
-      contextGraphId: 'music-social',
       shareOperationId,
-      kaUal: ROOTLESS_UAL,
       assertionVersion: 1,
-      quads: [
-        { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
-        { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-      ],
-      publisherPeerId: 'peer-1',
       accessPolicy: 'public',
     });
   }
@@ -1861,13 +1822,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
+      validation: KA_VM_VALIDATION,
     });
     await publisher.update(jobId, 'broadcast', {
       broadcast: { txHash: '0xkavm', walletId: 'wallet-1' },
@@ -1900,13 +1855,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
-      validation: {
-        canonicalRoots: [],
-        canonicalRootMap: {},
-        swmQuadCount: 2,
-        authorityProofRef: 'knowledge-asset-lifecycle',
-        transitionType: 'CREATE',
-      },
+      validation: KA_VM_VALIDATION,
     });
     await publisher.update(jobId, 'broadcast', {
       broadcast: { txHash: '0xkavm', walletId: 'wallet-1' },

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -2,6 +2,12 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { TripleStoreAsyncLiftPublisher, type AsyncLiftPublisherConfig } from '../src/index.js';
 import { DEFAULT_CONTROL_GRAPH_URI, jobSubject, serializeJob } from '../src/async-lift-control-plane.js';
+import {
+  KA_VM_BROADCAST_TX,
+  KA_VM_INCLUSION,
+  KA_VM_VALIDATION,
+  kaVmPublishRequest,
+} from './_helpers/ka-vm-publish.js';
 
 // #1837 — atomic by-exact-jobId TERMINAL clear for the async publisher (lift) queue.
 describe('#1837 lift publisher clearTerminalJob', () => {
@@ -24,39 +30,16 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     });
   }
 
-  function kaVmPublishRequest(overrides: Record<string, unknown> = {}) {
-    const authorAddress = '0x1111111111111111111111111111111111111111';
-    const kaNumber = 7n;
-    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
-    return {
-      contextGraphId: 'music-social', name: 'albums', shareOperationId: 'share-op-1',
-      roots: [] as string[], contentScopeVersion: 2 as const, kaUal, assertionVersion: '1',
-      publicTripleCount: 2, privateTripleCount: 0,
-      seal: {
-        merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-        authorAddress: authorAddress as `0x${string}`,
-        signature: { r: (`0x${'34'.repeat(32)}`) as `0x${string}`, vs: (`0x${'56'.repeat(32)}`) as `0x${string}` },
-        schemeVersion: 1,
-        reservedKaId: ((BigInt(authorAddress) << 96n) | kaNumber).toString() as `${bigint}`,
-      },
-      sealChainId: '31337' as `${bigint}`, sealKav10Address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z', sealMerkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
-      intentKey: `sha256:${'ab'.repeat(32)}`, wmCurrentAssertion: '12'.repeat(32), swmCurrentAssertion: '12'.repeat(32),
-      kaNumber: kaNumber.toString(), reservedUal: kaUal, ...overrides,
-    };
-  }
-  const bx = { txHash: `0x${'ef'.repeat(32)}` as `0x${string}`, walletId: 'wallet-1' };
-  const inc = { blockNumber: 10, blockHash: `0x${'aa'.repeat(32)}` as `0x${string}`, blockTimestamp: 1 };
+  const bx = KA_VM_BROADCAST_TX;
+  const inc = KA_VM_INCLUSION;
 
-  async function driveToValidated(p: TripleStoreAsyncLiftPublisher, o: Record<string, unknown> = {}): Promise<string> {
+  async function driveToValidated(p: TripleStoreAsyncLiftPublisher, o: Partial<Parameters<typeof kaVmPublishRequest>[0]> = {}): Promise<string> {
     const jobId = await p.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest(o));
     await p.claimNext('wallet-1');
-    await p.update(jobId, 'validated', {
-      validation: { canonicalRoots: [], canonicalRootMap: {}, swmQuadCount: 2, authorityProofRef: 'knowledge-asset-lifecycle', transitionType: 'CREATE' },
-    });
+    await p.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
     return jobId;
   }
-  async function driveToFinalized(p: TripleStoreAsyncLiftPublisher, o: Record<string, unknown> = {}): Promise<string> {
+  async function driveToFinalized(p: TripleStoreAsyncLiftPublisher, o: Partial<Parameters<typeof kaVmPublishRequest>[0]> = {}): Promise<string> {
     const jobId = await driveToValidated(p, o);
     await p.update(jobId, 'broadcast', { broadcast: bx });
     await p.update(jobId, 'included', { broadcast: bx, inclusion: inc });
@@ -64,7 +47,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     return jobId;
   }
   // Terminal, non-retryable (tx_reverted → fail_job): clearable, retry() won't touch it.
-  async function driveToTerminalFailed(p: TripleStoreAsyncLiftPublisher, o: Record<string, unknown> = {}): Promise<string> {
+  async function driveToTerminalFailed(p: TripleStoreAsyncLiftPublisher, o: Partial<Parameters<typeof kaVmPublishRequest>[0]> = {}): Promise<string> {
     const jobId = await driveToValidated(p, o);
     await p.update(jobId, 'broadcast', { broadcast: bx });
     await p.recordPublishFailure(jobId, { error: new Error('tx reverted on chain'), failedFromState: 'broadcast', errorPayloadRef: 'urn:err:1' });


### PR DESCRIPTION
## Summary

- Promotes the copy-pasted async-lift KA VM-publish test fixture — the request builder, the share-snapshot staging, and the repeated tx/validation constants, duplicated across **6** specs — into one helper `packages/publisher/test/_helpers/ka-vm-publish.ts`.
- Exports: `kaVmPublishRequest(overrides?)` (strongly-typed override param) + `KA_VM_AUTHOR_ADDRESS` / `KA_VM_KA_NUMBER` / `KA_VM_KA_UAL`; `stageKnowledgeAssetShareSnapshot(params)` (per-file variations — store, graphManager, shareOperationId, kaUal, `assertionVersion` string-vs-number, accessPolicy — parameterized and defaulted; each spec keeps its thin local wrapper so call sites are unchanged); and `KA_VM_VALIDATION` / `KA_VM_BROADCAST_TX` / `KA_VM_INCLUSION` / `KA_VM_EXECUTOR_TX_HASH`.
- Pure test hygiene — **zero `it()`/`expect()` changes**. The ~20 heterogeneous validation/broadcast blocks in `async-lift-publisher.test.ts` (distinct txHashes / proofRefs) are intentionally left in place. Net **−258 lines**.

## Related

- Follow-up to #1851 review. Resolves #1862. Independent of #1899/#1901/#1902 (test-only; branches off `testnet-canary`).

## Files changed

| File | What |
|------|------|
| `packages/publisher/test/_helpers/ka-vm-publish.ts` | **New** shared fixture (builder + staging + constants). |
| `packages/publisher/test/async-lift-{publisher,broadcast-durability,ka-broadcast-progress,intent-lookup,journal-append,terminal-clear}.test.ts` | Consume the helper; local fixture copies removed. |

## Test plan

- [x] `pnpm -C packages/publisher exec tsc --noEmit` — clean
- [x] `pnpm -C packages/publisher exec vitest run <the 6 async-lift specs>` — **97/97**, all 6 files green
- [x] `it()` counts unchanged per file (47 / 6 / 5 / 16 / 12 / 11) — no scenario dropped
- [ ] Full CI on `testnet-canary`

## Issue closure

⚠️ Targets `testnet-canary` (non-default base) → merging will **not** auto-close **#1862**; close it manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
