### PR TITLE
test(canary): keep incomplete reconnect rounds non-fresh

### DIFF
--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -155,7 +155,14 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     sawBackpressureDeferral = sawBackpressureDeferral || accounting.deferredByBackpressure;
     if (phase === 'durable') {
       sawDurableMetadataOnlyDetailedSync = sawDurableMetadataOnlyDetailedSync || accounting.metadataOnly;
-      cleanDurableDetailedRound = cleanDurableDetailedRound || accounting.cleanNonMetadataResponse;
+      // Safely committed prefixes are useful progress, but an explicit
+      // incomplete durable result must not refresh the peer's successful-sync
+      // timestamp and suppress the next recovery attempt. Legacy counter-only
+      // results keep their existing behaviour when no completion verdict is
+      // available.
+      cleanDurableDetailedRound = cleanDurableDetailedRound || (
+        complete !== false && accounting.cleanNonMetadataResponse
+      );
     }
     return accounting;
   };

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -136,6 +136,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
   let sawBackoffWorthyFailure = false;
   let sawBackpressureDeferral = false;
   let sawDurableMetadataOnlyDetailedSync = false;
+  let sawExplicitIncompleteDurableResult = false;
   let cleanDurableDetailedRound = false;
   const recordSyncAccounting = (
     result: SyncFromPeerResult,
@@ -155,6 +156,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     sawBackpressureDeferral = sawBackpressureDeferral || accounting.deferredByBackpressure;
     if (phase === 'durable') {
       sawDurableMetadataOnlyDetailedSync = sawDurableMetadataOnlyDetailedSync || accounting.metadataOnly;
+      sawExplicitIncompleteDurableResult = sawExplicitIncompleteDurableResult || complete === false;
       // Safely committed prefixes are useful progress, but an explicit
       // incomplete durable result must not refresh the peer's successful-sync
       // timestamp and suppress the next recovery attempt. Legacy counter-only
@@ -167,7 +169,9 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     return accounting;
   };
   const finishSyncAccounting = (): SyncOnConnectOutcome => {
-    const cleanDurableRound = cleanDurableDetailedRound && !sawDurableMetadataOnlyDetailedSync;
+    const cleanDurableRound = cleanDurableDetailedRound
+      && !sawDurableMetadataOnlyDetailedSync
+      && !sawExplicitIncompleteDurableResult;
     if (sawBackpressureDeferral) {
       if (madeProgress) {
         context.onPeerSynced?.(remotePeer, { fresh: false, progress: true });

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -742,6 +742,65 @@ describe('runSyncOnConnect callbacks', () => {
     expect(synced).toEqual([{ peerId: remotePeer, fresh: false, progress: true }]);
   });
 
+  it('keeps an incomplete first durable leg non-fresh after a clean discovered-CG leg', async () => {
+    const remotePeer = freshPeerIdString();
+    let contextGraphs = ['cg-a'];
+    const synced: Array<{
+      peerId: string;
+      fresh: boolean | undefined;
+      progress: boolean | undefined;
+    }> = [];
+    const syncFromPeer = recorder(async (_peerId: string, contextGraphIds?: string[]) => ({
+      complete: contextGraphIds !== undefined,
+      insertedTriples: contextGraphIds === undefined ? 40_000 : 1,
+      insertedDataTriples: contextGraphIds === undefined ? 40_000 : 1,
+      insertedMetaTriples: 0,
+      metaOnlyResponses: 0,
+      verifiedPrivateOnlyResponses: 0,
+      completedPhases: 1,
+      checkpointAdvances: 1,
+      timedOutPhases: 0,
+      failedPeers: 0,
+      failedPhases: 0,
+      deniedPhases: 0,
+      dataRejectedMissingMeta: 0,
+      rejectedKcs: 0,
+    }));
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => contextGraphs,
+      syncFromPeer,
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => {
+        contextGraphs = ['cg-a', 'cg-b'];
+        return 1;
+      },
+      syncSharedMemoryFromPeer: async () => ({
+        insertedTriples: 0,
+        timedOutPhases: 0,
+        failedPeers: 0,
+        deniedPhases: 0,
+      }),
+      logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => synced.push({
+        peerId,
+        fresh: syncOutcome?.fresh,
+        progress: syncOutcome?.progress,
+      }),
+    });
+
+    expect(outcome).toBe('synced');
+    expect(syncFromPeer.calls).toEqual([
+      [remotePeer],
+      [remotePeer, ['cg-b']],
+    ]);
+    expect(synced).toEqual([{ peerId: remotePeer, fresh: false, progress: true }]);
+  });
+
   it.each([
     ['timed out', { timedOutPhases: 1 }],
     ['failed integrity verification', { rejectedKcs: 1 }],

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -692,6 +692,56 @@ describe('runSyncOnConnect callbacks', () => {
     expect(synced).toEqual([{ peerId: remotePeer, fresh: true, progress: true }]);
   });
 
+  it('keeps explicit incomplete durable progress non-fresh and retryable', async () => {
+    const remotePeer = freshPeerIdString();
+    const synced: Array<{
+      peerId: string;
+      fresh: boolean | undefined;
+      progress: boolean | undefined;
+    }> = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => [],
+      syncFromPeer: async () => ({
+        complete: false,
+        insertedTriples: 40_000,
+        insertedDataTriples: 40_000,
+        insertedMetaTriples: 0,
+        metaOnlyResponses: 0,
+        verifiedPrivateOnlyResponses: 0,
+        completedPhases: 1,
+        checkpointAdvances: 1,
+        timedOutPhases: 0,
+        failedPeers: 0,
+        failedPhases: 0,
+        deniedPhases: 0,
+        dataRejectedMissingMeta: 0,
+        rejectedKcs: 0,
+      }),
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async () => ({
+        insertedTriples: 0,
+        timedOutPhases: 0,
+        failedPeers: 0,
+        deniedPhases: 0,
+      }),
+      logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => synced.push({
+        peerId,
+        fresh: syncOutcome?.fresh,
+        progress: syncOutcome?.progress,
+      }),
+    });
+
+    expect(outcome).toBe('synced');
+    expect(synced).toEqual([{ peerId: remotePeer, fresh: false, progress: true }]);
+  });
+
   it.each([
     ['timed out', { timedOutPhases: 1 }],
     ['failed integrity verification', { rejectedKcs: 1 }],


### PR DESCRIPTION
Final-head follow-up for the sealed 10.0.10 Day-One testnet gate.

This carries only the two post-gate reconnect correctness commits from #1898, ending at exact product head 7428b12f10e2c6f3528dfe35da21f62082940912:
- explicit complete:false durable progress remains useful but cannot refresh successful-sync freshness
- incompleteness is sticky across every durable leg, so a later clean discovered-CG leg cannot mask an earlier incomplete scope
- single-leg and two-leg caller regressions are included

Verification:
- delta is byte-identical to c5f5eae..7428b12 from #1898
- independent canary sync-on-connect suite: 52/52
- PR owner churn suite: 16/16
- PR owner CLI catch-up suite: 51/51
- PR owner 17-package build: pass
- diff-check: pass
- all #1898 review threads resolved at creation time

After normal merge, nodes should auto-update. No manual deployment or restart is requested.