### PR TITLE
feat(rfc64): resolve finalized Context Graph policy over RPC

### DIFF
--- a/packages/chain/src/finalized-context-graph-read.ts
+++ b/packages/chain/src/finalized-context-graph-read.ts
@@ -94,7 +94,7 @@ export type FinalizedContextGraphReadV1 = {
 export interface FinalizedContextGraphReadResolverV1 {
   (
     binding: FinalizedContextGraphBindingV1,
-    signal?: AbortSignal,
+    signal: AbortSignal,
   ): Promise<UntrustedFinalizedContextGraphFieldsV1>;
 }
 

--- a/packages/chain/src/finalized-context-graph-read.ts
+++ b/packages/chain/src/finalized-context-graph-read.ts
@@ -92,7 +92,10 @@ export type FinalizedContextGraphReadV1 = {
 };
 
 export interface FinalizedContextGraphReadResolverV1 {
-  (binding: FinalizedContextGraphBindingV1): Promise<UntrustedFinalizedContextGraphFieldsV1>;
+  (
+    binding: FinalizedContextGraphBindingV1,
+    signal?: AbortSignal,
+  ): Promise<UntrustedFinalizedContextGraphFieldsV1>;
 }
 
 function canonicalDecimalU256(
@@ -301,8 +304,9 @@ function composeValidatedFinalizedContextGraphReadV1(
 export async function resolveFinalizedContextGraphReadV1(
   resolver: FinalizedContextGraphReadResolverV1,
   request: FinalizedContextGraphReadRequestV1,
+  signal: AbortSignal = new AbortController().signal,
 ): Promise<FinalizedContextGraphReadV1> {
   const binding = validateFinalizedContextGraphReadRequestV1(request);
-  const raw = await resolver(binding);
+  const raw = await resolver(binding, signal);
   return composeValidatedFinalizedContextGraphReadV1(binding, raw);
 }

--- a/packages/chain/src/finalized-context-graph-read.ts
+++ b/packages/chain/src/finalized-context-graph-read.ts
@@ -92,6 +92,11 @@ export type FinalizedContextGraphReadV1 = {
 };
 
 export interface FinalizedContextGraphReadResolverV1 {
+  (binding: FinalizedContextGraphBindingV1): Promise<UntrustedFinalizedContextGraphFieldsV1>;
+}
+
+/** Signal-aware resolver used by transports that own cancellable I/O. */
+export interface FinalizedContextGraphReadResolverWithSignalV1 {
   (
     binding: FinalizedContextGraphBindingV1,
     signal: AbortSignal,
@@ -304,7 +309,17 @@ function composeValidatedFinalizedContextGraphReadV1(
 export async function resolveFinalizedContextGraphReadV1(
   resolver: FinalizedContextGraphReadResolverV1,
   request: FinalizedContextGraphReadRequestV1,
-  signal: AbortSignal = new AbortController().signal,
+): Promise<FinalizedContextGraphReadV1> {
+  const binding = validateFinalizedContextGraphReadRequestV1(request);
+  const raw = await resolver(binding);
+  return composeValidatedFinalizedContextGraphReadV1(binding, raw);
+}
+
+/** Resolve through a signal-aware transport without manufacturing cancellation ownership. */
+export async function resolveFinalizedContextGraphReadWithSignalV1(
+  resolver: FinalizedContextGraphReadResolverWithSignalV1,
+  request: FinalizedContextGraphReadRequestV1,
+  signal: AbortSignal,
 ): Promise<FinalizedContextGraphReadV1> {
   const binding = validateFinalizedContextGraphReadRequestV1(request);
   const raw = await resolver(binding, signal);

--- a/packages/chain/src/finalized-context-graph-rpc-resolver.ts
+++ b/packages/chain/src/finalized-context-graph-rpc-resolver.ts
@@ -4,7 +4,7 @@ import { CurrentFinalizedEvmCallErrorV1 } from './current-finalized-evm-read-pro
 import {
   FinalizedContextGraphReadErrorV1,
   type FinalizedContextGraphBindingV1,
-  type FinalizedContextGraphReadResolverV1,
+  type FinalizedContextGraphReadResolverWithSignalV1,
   type UntrustedFinalizedContextGraphFieldsV1,
 } from './finalized-context-graph-read.js';
 import {
@@ -32,12 +32,12 @@ const ERC721_FINALIZED_READ_ERROR_INTERFACE = new ethers.Interface([
  */
 export function createFinalizedContextGraphRpcResolverV1(
   read: StrictCurrentFinalizedEvmReadV1,
-): FinalizedContextGraphReadResolverV1 {
+): FinalizedContextGraphReadResolverWithSignalV1 {
   if (typeof read !== 'function') {
     throw new TypeError('Finalized Context Graph RPC resolver requires a read function');
   }
 
-  const resolver: FinalizedContextGraphReadResolverV1 = async (
+  const resolver: FinalizedContextGraphReadResolverWithSignalV1 = async (
     binding,
     signal,
   ) => {

--- a/packages/chain/src/finalized-context-graph-rpc-resolver.ts
+++ b/packages/chain/src/finalized-context-graph-rpc-resolver.ts
@@ -2,11 +2,13 @@ import { ethers } from 'ethers';
 
 import { CurrentFinalizedEvmCallErrorV1 } from './current-finalized-evm-read-profile.js';
 import {
+  FinalizedContextGraphReadErrorV1,
   type FinalizedContextGraphBindingV1,
   type FinalizedContextGraphReadResolverV1,
   type UntrustedFinalizedContextGraphFieldsV1,
 } from './finalized-context-graph-read.js';
 import {
+  readStrictCurrentFinalizedEvmRevertDataV1,
   type StrictCurrentFinalizedEvmReadResultV1,
   type StrictCurrentFinalizedEvmReadV1,
 } from './strict-current-finalized-evm-rpc.js';
@@ -19,6 +21,9 @@ export const FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1 = 32;
 const CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE = new ethers.Interface([
   'function getContextGraph(uint256 contextGraphId) view returns (address owner, address[] participantAgents, uint256 metadataBatchId, bool active, uint256 createdAt, uint8 accessPolicy, uint8 publishPolicy, address publishAuthority, uint256 publishAuthorityAccountId)',
   'function getNameHash(uint256 contextGraphId) view returns (bytes32)',
+]);
+const ERC721_FINALIZED_READ_ERROR_INTERFACE = new ethers.Interface([
+  'error ERC721NonexistentToken(uint256 tokenId)',
 ]);
 
 /**
@@ -37,32 +42,57 @@ export function createFinalizedContextGraphRpcResolverV1(
     signal,
   ) => {
     const contextGraphId = BigInt(binding.contextGraphId);
-    const result = await read({
-      chainId: binding.chainId,
-      calls: Object.freeze([
-        Object.freeze({
-          to: binding.governanceContract,
-          data: CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE.encodeFunctionData(
-            'getContextGraph',
-            [contextGraphId],
-          ),
-          maxReturnBytes: FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1,
-        }),
-        Object.freeze({
-          to: binding.governanceContract,
-          data: CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE.encodeFunctionData(
-            'getNameHash',
-            [contextGraphId],
-          ),
-          maxReturnBytes: FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1,
-        }),
-      ]),
-      signal,
-    });
+    let result: StrictCurrentFinalizedEvmReadResultV1;
+    try {
+      result = await read({
+        chainId: binding.chainId,
+        calls: Object.freeze([
+          Object.freeze({
+            to: binding.governanceContract,
+            data: CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE.encodeFunctionData(
+              'getContextGraph',
+              [contextGraphId],
+            ),
+            maxReturnBytes: FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1,
+          }),
+          Object.freeze({
+            to: binding.governanceContract,
+            data: CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE.encodeFunctionData(
+              'getNameHash',
+              [contextGraphId],
+            ),
+            maxReturnBytes: FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1,
+          }),
+        ]),
+        signal,
+      });
+    } catch (cause) {
+      if (isAuthenticatedMissingContextGraphRevert(cause, contextGraphId)) {
+        throw new FinalizedContextGraphReadErrorV1(
+          'unregistered-context-graph',
+          `Context Graph ${binding.contextGraphId} is not registered at the finalized anchor`,
+        );
+      }
+      throw cause;
+    }
     return decodeFinalizedContextGraphResult(binding, result);
   };
 
   return Object.freeze(resolver);
+}
+
+function isAuthenticatedMissingContextGraphRevert(
+  cause: unknown,
+  contextGraphId: bigint,
+): boolean {
+  if (!(cause instanceof CurrentFinalizedEvmCallErrorV1) || cause.code !== 'revert') {
+    return false;
+  }
+  const authenticatedRevertData = readStrictCurrentFinalizedEvmRevertDataV1(cause);
+  if (authenticatedRevertData === undefined) return false;
+  return authenticatedRevertData === ERC721_FINALIZED_READ_ERROR_INTERFACE
+    .encodeErrorResult('ERC721NonexistentToken', [contextGraphId])
+    .toLowerCase();
 }
 
 function decodeFinalizedContextGraphResult(

--- a/packages/chain/src/finalized-context-graph-rpc-resolver.ts
+++ b/packages/chain/src/finalized-context-graph-rpc-resolver.ts
@@ -1,0 +1,144 @@
+import { type EvmAddressV1 } from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+
+import {
+  CURRENT_FINALIZED_EVM_READ_MAX_RETURN_BYTES_V1,
+  CurrentFinalizedEvmCallErrorV1,
+} from './current-finalized-evm-read-profile.js';
+import {
+  type FinalizedContextGraphBindingV1,
+  type FinalizedContextGraphReadResolverV1,
+  type UntrustedFinalizedContextGraphFieldsV1,
+} from './finalized-context-graph-read.js';
+import {
+  type StrictCurrentFinalizedEvmReadResultV1,
+  type StrictCurrentFinalizedEvmReadV1,
+} from './strict-current-finalized-evm-rpc.js';
+
+export const FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1 =
+  CURRENT_FINALIZED_EVM_READ_MAX_RETURN_BYTES_V1;
+export const FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1 = 32;
+
+const CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE = new ethers.Interface([
+  'function getContextGraph(uint256 contextGraphId) view returns (address owner, address[] participantAgents, uint256 metadataBatchId, bool active, uint256 createdAt, uint8 accessPolicy, uint8 publishPolicy, address publishAuthority, uint256 publishAuthorityAccountId)',
+  'function getNameHash(uint256 contextGraphId) view returns (bytes32)',
+]);
+
+/**
+ * Bind the strict same-anchor transport to the two ContextGraphStorage reads
+ * required by the finalized RFC-64 policy seam.
+ */
+export function createFinalizedContextGraphRpcResolverV1(
+  read: StrictCurrentFinalizedEvmReadV1,
+): FinalizedContextGraphReadResolverV1 {
+  if (typeof read !== 'function') {
+    throw new TypeError('Finalized Context Graph RPC resolver requires a read function');
+  }
+
+  const resolver: FinalizedContextGraphReadResolverV1 = async (
+    binding,
+    signal = new AbortController().signal,
+  ) => {
+    const contextGraphId = BigInt(binding.contextGraphId);
+    const result = await read({
+      chainId: binding.chainId,
+      calls: Object.freeze([
+        Object.freeze({
+          to: binding.governanceContract,
+          data: CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE.encodeFunctionData(
+            'getContextGraph',
+            [contextGraphId],
+          ),
+          maxReturnBytes: FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1,
+        }),
+        Object.freeze({
+          to: binding.governanceContract,
+          data: CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE.encodeFunctionData(
+            'getNameHash',
+            [contextGraphId],
+          ),
+          maxReturnBytes: FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1,
+        }),
+      ]),
+      signal,
+    });
+    return decodeFinalizedContextGraphResult(binding, result);
+  };
+
+  return Object.freeze(resolver);
+}
+
+function decodeFinalizedContextGraphResult(
+  binding: FinalizedContextGraphBindingV1,
+  result: StrictCurrentFinalizedEvmReadResultV1,
+): UntrustedFinalizedContextGraphFieldsV1 {
+  if (result.chainId !== binding.chainId) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'chain-mismatch',
+      `Finalized Context Graph read returned chain ${result.chainId}, expected ${binding.chainId}`,
+    );
+  }
+  if (!Array.isArray(result.returnData) || result.returnData.length !== 2) {
+    throw malformedReturn('Finalized Context Graph read must return exactly two ABI results');
+  }
+
+  try {
+    const contextGraph = CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE.decodeFunctionResult(
+      'getContextGraph',
+      result.returnData[0]!,
+    );
+    const nameHash = CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE.decodeFunctionResult(
+      'getNameHash',
+      result.returnData[1]!,
+    );
+    assertCanonicalAbiResult('getContextGraph', contextGraph, result.returnData[0]!);
+    assertCanonicalAbiResult('getNameHash', nameHash, result.returnData[1]!);
+
+    return Object.freeze({
+      blockNumber: result.blockNumber,
+      blockHash: result.blockHash,
+      owner: lowerAddress(contextGraph[0]),
+      active: contextGraph[3],
+      accessPolicy: Number(contextGraph[5]),
+      publishPolicy: Number(contextGraph[6]),
+      publishAuthority: lowerAddress(contextGraph[7]),
+      publishAuthorityAccountId: decimal(contextGraph[8]),
+      nameHash: String(nameHash[0]).toLowerCase(),
+    });
+  } catch (cause) {
+    if (cause instanceof CurrentFinalizedEvmCallErrorV1) throw cause;
+    throw malformedReturn('Finalized Context Graph ABI result is malformed', cause);
+  }
+}
+
+function assertCanonicalAbiResult(
+  functionName: 'getContextGraph' | 'getNameHash',
+  decoded: ethers.Result,
+  encoded: string,
+): void {
+  const canonical = CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE
+    .encodeFunctionResult(functionName, [...decoded])
+    .toLowerCase();
+  if (canonical !== encoded) {
+    throw malformedReturn(`${functionName} returned a non-canonical ABI encoding`);
+  }
+}
+
+function lowerAddress(value: unknown): EvmAddressV1 {
+  return String(value).toLowerCase() as EvmAddressV1;
+}
+
+function decimal(value: unknown): string {
+  return BigInt(value as bigint).toString(10);
+}
+
+function malformedReturn(
+  message: string,
+  cause?: unknown,
+): CurrentFinalizedEvmCallErrorV1 {
+  return new CurrentFinalizedEvmCallErrorV1(
+    'malformed-return',
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/chain/src/finalized-context-graph-rpc-resolver.ts
+++ b/packages/chain/src/finalized-context-graph-rpc-resolver.ts
@@ -37,7 +37,7 @@ export function createFinalizedContextGraphRpcResolverV1(
 
   const resolver: FinalizedContextGraphReadResolverV1 = async (
     binding,
-    signal = new AbortController().signal,
+    signal,
   ) => {
     const contextGraphId = BigInt(binding.contextGraphId);
     const result = await read({
@@ -94,15 +94,27 @@ function decodeFinalizedContextGraphResult(
     assertCanonicalAbiResult('getContextGraph', contextGraph, result.returnData[0]!);
     assertCanonicalAbiResult('getNameHash', nameHash, result.returnData[1]!);
 
+    const [
+      owner,
+      _participantAgents,
+      _metadataBatchId,
+      active,
+      _createdAt,
+      accessPolicy,
+      publishPolicy,
+      publishAuthority,
+      publishAuthorityAccountId,
+    ] = contextGraph;
+
     return Object.freeze({
       blockNumber: result.blockNumber,
       blockHash: result.blockHash,
-      owner: lowerAddress(contextGraph[0]),
-      active: contextGraph[3],
-      accessPolicy: Number(contextGraph[5]),
-      publishPolicy: Number(contextGraph[6]),
-      publishAuthority: lowerAddress(contextGraph[7]),
-      publishAuthorityAccountId: decimal(contextGraph[8]),
+      owner: lowerAddress(owner),
+      active,
+      accessPolicy: Number(accessPolicy),
+      publishPolicy: Number(publishPolicy),
+      publishAuthority: lowerAddress(publishAuthority),
+      publishAuthorityAccountId: decimal(publishAuthorityAccountId),
       nameHash: String(nameHash[0]).toLowerCase(),
     });
   } catch (cause) {

--- a/packages/chain/src/finalized-context-graph-rpc-resolver.ts
+++ b/packages/chain/src/finalized-context-graph-rpc-resolver.ts
@@ -1,4 +1,3 @@
-import { type EvmAddressV1 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 
 import { CurrentFinalizedEvmCallErrorV1 } from './current-finalized-evm-read-profile.js';
@@ -92,27 +91,15 @@ function decodeFinalizedContextGraphResult(
     assertCanonicalAbiResult('getContextGraph', contextGraph, result.returnData[0]!);
     assertCanonicalAbiResult('getNameHash', nameHash, result.returnData[1]!);
 
-    const [
-      owner,
-      _participantAgents,
-      _metadataBatchId,
-      active,
-      _createdAt,
-      accessPolicy,
-      publishPolicy,
-      publishAuthority,
-      publishAuthorityAccountId,
-    ] = contextGraph;
-
     return Object.freeze({
       blockNumber: result.blockNumber,
       blockHash: result.blockHash,
-      owner: lowerAddress(owner),
-      active,
-      accessPolicy: Number(accessPolicy),
-      publishPolicy: Number(publishPolicy),
-      publishAuthority: lowerAddress(publishAuthority),
-      publishAuthorityAccountId: decimal(publishAuthorityAccountId),
+      owner: lowerAddress(contextGraph.owner),
+      active: contextGraph.active,
+      accessPolicy: Number(contextGraph.accessPolicy),
+      publishPolicy: Number(contextGraph.publishPolicy),
+      publishAuthority: lowerAddress(contextGraph.publishAuthority),
+      publishAuthorityAccountId: decimal(contextGraph.publishAuthorityAccountId),
       nameHash: String(nameHash[0]).toLowerCase(),
     });
   } catch (cause) {
@@ -134,8 +121,8 @@ function assertCanonicalAbiResult(
   }
 }
 
-function lowerAddress(value: unknown): EvmAddressV1 {
-  return String(value).toLowerCase() as EvmAddressV1;
+function lowerAddress(value: unknown): string {
+  return String(value).toLowerCase();
 }
 
 function decimal(value: unknown): string {

--- a/packages/chain/src/finalized-context-graph-rpc-resolver.ts
+++ b/packages/chain/src/finalized-context-graph-rpc-resolver.ts
@@ -1,10 +1,7 @@
 import { type EvmAddressV1 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 
-import {
-  CURRENT_FINALIZED_EVM_READ_MAX_RETURN_BYTES_V1,
-  CurrentFinalizedEvmCallErrorV1,
-} from './current-finalized-evm-read-profile.js';
+import { CurrentFinalizedEvmCallErrorV1 } from './current-finalized-evm-read-profile.js';
 import {
   type FinalizedContextGraphBindingV1,
   type FinalizedContextGraphReadResolverV1,
@@ -15,8 +12,9 @@ import {
   type StrictCurrentFinalizedEvmReadV1,
 } from './strict-current-finalized-evm-rpc.js';
 
-export const FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1 =
-  CURRENT_FINALIZED_EVM_READ_MAX_RETURN_BYTES_V1;
+// getContextGraph has nine fixed words plus a chain-capped 256-address array:
+// its maximal canonical ABI result is 8,512 bytes, below this domain ceiling.
+export const FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1 = 9 * 1024;
 export const FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1 = 32;
 
 const CONTEXT_GRAPH_STORAGE_FINALIZED_READ_INTERFACE = new ethers.Interface([

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -35,6 +35,11 @@ export {
   type CurrentFinalizedEvmChainAdapterV1,
 } from './current-finalized-evm-call.js';
 export {
+  FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1,
+  FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1,
+  createFinalizedContextGraphRpcResolverV1,
+} from './finalized-context-graph-rpc-resolver.js';
+export {
   CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1,
   createStrictCurrentFinalizedEvmChainAdapterV1,
   createStrictCurrentFinalizedEvmReadV1,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -53,12 +53,14 @@ export {
 export {
   FinalizedContextGraphReadErrorV1,
   composeFinalizedContextGraphReadV1,
+  resolveFinalizedContextGraphReadWithSignalV1,
   resolveFinalizedContextGraphReadV1,
   validateFinalizedContextGraphReadRequestV1,
   type FinalizedContextGraphBindingV1,
   type FinalizedContextGraphReadErrorCodeV1,
   type FinalizedContextGraphReadRequestV1,
   type FinalizedContextGraphReadResolverV1,
+  type FinalizedContextGraphReadResolverWithSignalV1,
   type FinalizedContextGraphReadV1,
   type UntrustedFinalizedContextGraphFieldsV1,
 } from './finalized-context-graph-read.js';

--- a/packages/chain/test/finalized-context-graph-read.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-read.unit.test.ts
@@ -91,20 +91,24 @@ describe('RFC-64 finalized Context Graph chain read', () => {
   it('passes one frozen canonical binding through the resolver seam', async () => {
     const request = validRequest();
     const raw = Object.freeze(validRaw());
+    const signal = new AbortController().signal;
     const resolver = vi.fn((received: FinalizedContextGraphBindingV1) => {
       expect(received).not.toBe(request);
       expect(Object.isFrozen(received)).toBe(true);
       expect(received).toEqual(request);
       return Promise.resolve(raw);
     });
-    const viaSeam = await resolveFinalizedContextGraphReadV1(resolver, request);
+    const viaSeam = await resolveFinalizedContextGraphReadV1(resolver, request, signal);
     const direct = composeFinalizedContextGraphReadV1(request, validRaw());
     expect(resolver).toHaveBeenCalledOnce();
-    expect(resolver).toHaveBeenCalledWith(Object.freeze({
-      chainId: CHAIN_ID,
-      contextGraphId: '42',
-      governanceContract: CGS,
-    }));
+    expect(resolver).toHaveBeenCalledWith(
+      Object.freeze({
+        chainId: CHAIN_ID,
+        contextGraphId: '42',
+        governanceContract: CGS,
+      }),
+      signal,
+    );
     expect(viaSeam).toEqual(direct);
   });
 

--- a/packages/chain/test/finalized-context-graph-read.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-read.unit.test.ts
@@ -9,10 +9,13 @@ import type {
 import {
   FinalizedContextGraphReadErrorV1,
   composeFinalizedContextGraphReadV1,
+  resolveFinalizedContextGraphReadWithSignalV1,
   resolveFinalizedContextGraphReadV1,
   type FinalizedContextGraphBindingV1,
   type FinalizedContextGraphReadErrorCodeV1,
   type FinalizedContextGraphReadRequestV1,
+  type FinalizedContextGraphReadResolverV1,
+  type FinalizedContextGraphReadResolverWithSignalV1,
   type UntrustedFinalizedContextGraphFieldsV1,
 } from '../src/finalized-context-graph-read.js';
 
@@ -91,25 +94,44 @@ describe('RFC-64 finalized Context Graph chain read', () => {
   it('passes one frozen canonical binding through the resolver seam', async () => {
     const request = validRequest();
     const raw = Object.freeze(validRaw());
-    const signal = new AbortController().signal;
-    const resolver = vi.fn((received: FinalizedContextGraphBindingV1) => {
+    const resolver: FinalizedContextGraphReadResolverV1 = vi.fn((received) => {
       expect(received).not.toBe(request);
       expect(Object.isFrozen(received)).toBe(true);
       expect(received).toEqual(request);
       return Promise.resolve(raw);
     });
-    const viaSeam = await resolveFinalizedContextGraphReadV1(resolver, request, signal);
+    const viaSeam = await resolveFinalizedContextGraphReadV1(resolver, request);
     const direct = composeFinalizedContextGraphReadV1(request, validRaw());
     expect(resolver).toHaveBeenCalledOnce();
-    expect(resolver).toHaveBeenCalledWith(
-      Object.freeze({
-        chainId: CHAIN_ID,
-        contextGraphId: '42',
-        governanceContract: CGS,
-      }),
+    expect(resolver).toHaveBeenCalledWith(Object.freeze({
+      chainId: CHAIN_ID,
+      contextGraphId: '42',
+      governanceContract: CGS,
+    }));
+    expect(viaSeam).toEqual(direct);
+  });
+
+  it('requires and forwards caller-owned cancellation for signal-aware resolvers', async () => {
+    const request = validRequest();
+    const raw = Object.freeze(validRaw());
+    const signal = new AbortController().signal;
+    const resolver: FinalizedContextGraphReadResolverWithSignalV1 = vi.fn(
+      async () => raw,
+    );
+
+    const result = await resolveFinalizedContextGraphReadWithSignalV1(
+      resolver,
+      request,
       signal,
     );
-    expect(viaSeam).toEqual(direct);
+
+    expect(resolver).toHaveBeenCalledOnce();
+    expect(resolver).toHaveBeenCalledWith(Object.freeze({
+      chainId: CHAIN_ID,
+      contextGraphId: '42',
+      governanceContract: CGS,
+    }), signal);
+    expect(result).toEqual(composeFinalizedContextGraphReadV1(request, raw));
   });
 
   it('rejects malformed identity before invoking the resolver', async () => {

--- a/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../src/finalized-context-graph-rpc-resolver.js';
 import {
   FinalizedContextGraphReadErrorV1,
-  resolveFinalizedContextGraphReadV1,
+  resolveFinalizedContextGraphReadWithSignalV1,
   type FinalizedContextGraphBindingV1,
 } from '../src/finalized-context-graph-read.js';
 import {
@@ -145,7 +145,11 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
   it('feeds the concrete RPC result through the validated finalized read seam', async () => {
     const read = readStub();
     const resolver = createFinalizedContextGraphRpcResolverV1(read);
-    const result = await resolveFinalizedContextGraphReadV1(resolver, binding());
+    const result = await resolveFinalizedContextGraphReadWithSignalV1(
+      resolver,
+      binding(),
+      signal(),
+    );
     const normalizedSignal = read.mock.calls[0]?.[0].signal;
 
     expect(result).toEqual({
@@ -173,7 +177,11 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
       }), nameHashResult(ZERO_HASH)),
     );
 
-    const result = await resolveFinalizedContextGraphReadV1(resolver, binding());
+    const result = await resolveFinalizedContextGraphReadWithSignalV1(
+      resolver,
+      binding(),
+      signal(),
+    );
     expect(result.publishAuthority).toBeNull();
     expect(result.publishAuthorityAccountId).toBe('0');
     expect(result.nameHash).toBeNull();
@@ -224,7 +232,11 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
 
       let caught: unknown;
       try {
-        await resolveFinalizedContextGraphReadV1(resolver, binding());
+        await resolveFinalizedContextGraphReadWithSignalV1(
+          resolver,
+          binding(),
+          signal(),
+        );
       } catch (cause) {
         caught = cause;
       }

--- a/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
@@ -28,7 +28,7 @@ import {
   sendJsonRpcError as sendError,
   sendJsonRpcResult as sendResult,
   type LoopbackJsonRpcServer,
-} from './loopback-json-rpc-test-helpers.js';
+} from './loopback-rpc-harness.js';
 
 const CHAIN_ID = '20430' as ChainIdV1;
 const STORAGE = `0x${'11'.repeat(20)}` as EvmAddressV1;

--- a/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
@@ -1,3 +1,6 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -14,10 +17,15 @@ import {
   createFinalizedContextGraphRpcResolverV1,
 } from '../src/finalized-context-graph-rpc-resolver.js';
 import {
+  FinalizedContextGraphReadErrorV1,
   resolveFinalizedContextGraphReadV1,
   type FinalizedContextGraphBindingV1,
 } from '../src/finalized-context-graph-read.js';
-import { type StrictCurrentFinalizedEvmReadV1 } from '../src/strict-current-finalized-evm-rpc.js';
+import {
+  createStrictCurrentFinalizedEvmReadV1,
+  type StrictCurrentFinalizedEvmReadV1,
+} from '../src/strict-current-finalized-evm-rpc.js';
+import { CurrentFinalizedEvmCallErrorV1 } from '../src/current-finalized-evm-read-profile.js';
 
 const CHAIN_ID = '20430' as ChainIdV1;
 const STORAGE = `0x${'11'.repeat(20)}` as EvmAddressV1;
@@ -32,6 +40,16 @@ const GET_NAME_HASH_SELECTOR = '0x8ce6a5c1';
 const ENCODED_ID_42 = `${'0'.repeat(62)}2a`;
 
 const ABI = ethers.AbiCoder.defaultAbiCoder();
+const ERC721_ERRORS = new ethers.Interface([
+  'error ERC721NonexistentToken(uint256 tokenId)',
+]);
+
+interface JsonRpcRequest {
+  readonly jsonrpc: '2.0';
+  readonly id: number;
+  readonly method: string;
+  readonly params: readonly unknown[];
+}
 
 function binding(): FinalizedContextGraphBindingV1 {
   return Object.freeze({
@@ -194,4 +212,147 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
   it('rejects a non-function transport at construction', () => {
     expect(() => createFinalizedContextGraphRpcResolverV1(null as never)).toThrow(TypeError);
   });
+
+  it('maps an authenticated missing-token revert for the bound ID to unregistered', async () => {
+    const rpc = await startMissingContextGraphRpc(42n);
+    try {
+      const read = createStrictCurrentFinalizedEvmReadV1({
+        chainId: CHAIN_ID,
+        endpoints: [rpc.url],
+      });
+      const resolver = createFinalizedContextGraphRpcResolverV1(read);
+
+      let caught: unknown;
+      try {
+        await resolveFinalizedContextGraphReadV1(resolver, binding());
+      } catch (cause) {
+        caught = cause;
+      }
+      expect(caught).toBeInstanceOf(FinalizedContextGraphReadErrorV1);
+      expect(caught).toMatchObject({ code: 'unregistered-context-graph' });
+    } finally {
+      await rpc.stop();
+    }
+  });
+
+  it('does not map authenticated missing-token evidence for another ID', async () => {
+    const rpc = await startMissingContextGraphRpc(43n);
+    try {
+      const read = createStrictCurrentFinalizedEvmReadV1({
+        chainId: CHAIN_ID,
+        endpoints: [rpc.url],
+      });
+      const resolver = createFinalizedContextGraphRpcResolverV1(read);
+
+      await expect(resolver(binding(), signal())).rejects.toMatchObject({
+        name: 'CurrentFinalizedEvmCallErrorV1',
+        code: 'revert',
+      });
+    } finally {
+      await rpc.stop();
+    }
+  });
+
+  it('does not trust a forgeable public revert error as missing-token evidence', async () => {
+    const forged = new CurrentFinalizedEvmCallErrorV1('revert', 'forged');
+    const read = vi.fn<StrictCurrentFinalizedEvmReadV1>(async () => {
+      throw forged;
+    });
+    const resolver = createFinalizedContextGraphRpcResolverV1(read);
+
+    await expect(resolver(binding(), signal())).rejects.toBe(forged);
+  });
 });
+
+async function startMissingContextGraphRpc(missingId: bigint): Promise<{
+  readonly url: string;
+  readonly stop: () => Promise<void>;
+}> {
+  const missingData = ERC721_ERRORS.encodeErrorResult(
+    'ERC721NonexistentToken',
+    [missingId],
+  ).toLowerCase();
+  const server = createServer(async (request, response) => {
+    try {
+      const call = JSON.parse(await readRequestBody(request)) as JsonRpcRequest;
+      switch (call.method) {
+        case 'eth_chainId':
+          sendResult(response, call, '0x4fce');
+          return;
+        case 'eth_getBlockByNumber':
+          sendResult(response, call, { number: '0x7b', hash: BLOCK_HASH });
+          return;
+        case 'eth_getCode':
+          sendResult(response, call, '0x6000');
+          return;
+        case 'eth_call': {
+          const callObject = call.params[0] as { readonly data?: unknown };
+          if (typeof callObject.data === 'string'
+            && callObject.data.startsWith(GET_CONTEXT_GRAPH_SELECTOR)) {
+            sendError(response, call, 3, 'execution reverted', missingData);
+          } else {
+            sendResult(response, call, nameHashResult());
+          }
+          return;
+        }
+        default:
+          sendError(response, call, -32601, 'method not found');
+      }
+    } catch (cause) {
+      if (!response.headersSent) response.writeHead(500, { 'content-type': 'text/plain' });
+      if (!response.writableEnded) {
+        response.end(cause instanceof Error ? cause.message : 'failure');
+      }
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  let stopped = false;
+  return Object.freeze({
+    url: `http://127.0.0.1:${address.port}`,
+    stop: async () => {
+      if (stopped) return;
+      stopped = true;
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections();
+      });
+    },
+  });
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sendResult(
+  response: ServerResponse,
+  request: JsonRpcRequest,
+  result: unknown,
+): void {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }));
+}
+
+function sendError(
+  response: ServerResponse,
+  request: JsonRpcRequest,
+  code: number,
+  message: string,
+  data?: string,
+): void {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({
+    jsonrpc: '2.0',
+    id: request.id,
+    error: { code, message, ...(data === undefined ? {} : { data }) },
+  }));
+}

--- a/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type BlockNumberV1,
+  type ChainIdV1,
+  type Digest32V1,
+  type EvmAddressV1,
+} from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+
+import {
+  FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1,
+  FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1,
+  createFinalizedContextGraphRpcResolverV1,
+} from '../src/finalized-context-graph-rpc-resolver.js';
+import {
+  resolveFinalizedContextGraphReadV1,
+  type FinalizedContextGraphBindingV1,
+} from '../src/finalized-context-graph-read.js';
+import { type StrictCurrentFinalizedEvmReadV1 } from '../src/strict-current-finalized-evm-rpc.js';
+
+const CHAIN_ID = '20430' as ChainIdV1;
+const STORAGE = `0x${'11'.repeat(20)}` as EvmAddressV1;
+const OWNER = `0x${'22'.repeat(20)}`;
+const AUTHORITY = `0x${'33'.repeat(20)}`;
+const PARTICIPANT = `0x${'44'.repeat(20)}`;
+const BLOCK_HASH = `0x${'55'.repeat(32)}` as Digest32V1;
+const NAME_HASH = `0x${'66'.repeat(32)}`;
+const ZERO_HASH = `0x${'00'.repeat(32)}`;
+const GET_CONTEXT_GRAPH_SELECTOR = '0xca22fff5';
+const GET_NAME_HASH_SELECTOR = '0x8ce6a5c1';
+const ENCODED_ID_42 = `${'0'.repeat(62)}2a`;
+
+const ABI = ethers.AbiCoder.defaultAbiCoder();
+
+function binding(): FinalizedContextGraphBindingV1 {
+  return Object.freeze({
+    chainId: CHAIN_ID,
+    contextGraphId: '42',
+    governanceContract: STORAGE,
+  });
+}
+
+function contextGraphResult(overrides: {
+  owner?: string;
+  active?: boolean;
+  accessPolicy?: number;
+  publishPolicy?: number;
+  publishAuthority?: string;
+  publishAuthorityAccountId?: bigint;
+} = {}): string {
+  return ABI.encode(
+    ['address', 'address[]', 'uint256', 'bool', 'uint256', 'uint8', 'uint8', 'address', 'uint256'],
+    [
+      overrides.owner ?? OWNER,
+      [PARTICIPANT],
+      9n,
+      overrides.active ?? true,
+      123n,
+      overrides.accessPolicy ?? 1,
+      overrides.publishPolicy ?? 0,
+      overrides.publishAuthority ?? AUTHORITY,
+      overrides.publishAuthorityAccountId ?? 7n,
+    ],
+  );
+}
+
+function nameHashResult(value = NAME_HASH): string {
+  return ABI.encode(['bytes32'], [value]);
+}
+
+function readStub(
+  tuple = contextGraphResult(),
+  nameHash = nameHashResult(),
+  resultChainId: ChainIdV1 = CHAIN_ID,
+): ReturnType<typeof vi.fn<StrictCurrentFinalizedEvmReadV1>> {
+  return vi.fn<StrictCurrentFinalizedEvmReadV1>(async () => Object.freeze({
+    chainId: resultChainId,
+    blockNumber: '123' as BlockNumberV1,
+    blockHash: BLOCK_HASH,
+    returnData: Object.freeze([tuple, nameHash]),
+  }));
+}
+
+describe('RFC-64 finalized Context Graph RPC resolver', () => {
+  it('executes the two ABI reads at one transport anchor and decodes the policy tuple', async () => {
+    const read = readStub();
+    const resolver = createFinalizedContextGraphRpcResolverV1(read);
+    const signal = new AbortController().signal;
+
+    const raw = await resolver(binding(), signal);
+
+    expect(Object.isFrozen(resolver)).toBe(true);
+    expect(Object.isFrozen(raw)).toBe(true);
+    expect(read).toHaveBeenCalledOnce();
+    expect(read).toHaveBeenCalledWith({
+      chainId: CHAIN_ID,
+      calls: [
+        {
+          to: STORAGE,
+          data: `${GET_CONTEXT_GRAPH_SELECTOR}${ENCODED_ID_42}`,
+          maxReturnBytes: FINALIZED_CONTEXT_GRAPH_TUPLE_MAX_RETURN_BYTES_V1,
+        },
+        {
+          to: STORAGE,
+          data: `${GET_NAME_HASH_SELECTOR}${ENCODED_ID_42}`,
+          maxReturnBytes: FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1,
+        },
+      ],
+      signal,
+    });
+    expect(raw).toEqual({
+      blockNumber: '123',
+      blockHash: BLOCK_HASH,
+      owner: OWNER,
+      active: true,
+      accessPolicy: 1,
+      publishPolicy: 0,
+      publishAuthority: AUTHORITY,
+      publishAuthorityAccountId: '7',
+      nameHash: NAME_HASH,
+    });
+  });
+
+  it('feeds the concrete RPC result through the validated finalized read seam', async () => {
+    const resolver = createFinalizedContextGraphRpcResolverV1(readStub());
+    const result = await resolveFinalizedContextGraphReadV1(resolver, binding());
+
+    expect(result).toEqual({
+      ...binding(),
+      blockNumber: '123',
+      blockHash: BLOCK_HASH,
+      owner: OWNER,
+      active: true,
+      accessPolicy: 1,
+      publishPolicy: 0,
+      publishAuthority: AUTHORITY,
+      publishAuthorityAccountId: '7',
+      nameHash: NAME_HASH,
+    });
+  });
+
+  it('preserves the chain zero-hash sentinel for canonical null normalization', async () => {
+    const resolver = createFinalizedContextGraphRpcResolverV1(
+      readStub(contextGraphResult({
+        publishPolicy: 1,
+        publishAuthority: ethers.ZeroAddress,
+        publishAuthorityAccountId: 0n,
+      }), nameHashResult(ZERO_HASH)),
+    );
+
+    const result = await resolveFinalizedContextGraphReadV1(resolver, binding());
+    expect(result.publishAuthority).toBeNull();
+    expect(result.publishAuthorityAccountId).toBe('0');
+    expect(result.nameHash).toBeNull();
+  });
+
+  it('rejects a transport result from a different chain', async () => {
+    const resolver = createFinalizedContextGraphRpcResolverV1(
+      readStub(contextGraphResult(), nameHashResult(), '1' as ChainIdV1),
+    );
+    await expect(resolver(binding())).rejects.toMatchObject({ code: 'chain-mismatch' });
+  });
+
+  it('rejects missing, trailing, or non-canonical ABI result bytes', async () => {
+    const cases = [
+      readStub('0x', nameHashResult()),
+      readStub(`${contextGraphResult()}00`, nameHashResult()),
+      readStub(contextGraphResult(), `${nameHashResult()}00`),
+    ];
+    for (const read of cases) {
+      const resolver = createFinalizedContextGraphRpcResolverV1(read);
+      await expect(resolver(binding())).rejects.toMatchObject({ code: 'malformed-return' });
+    }
+  });
+
+  it('rejects any transport shape other than exactly two results', async () => {
+    const read = vi.fn<StrictCurrentFinalizedEvmReadV1>(async () => ({
+      chainId: CHAIN_ID,
+      blockNumber: '123' as BlockNumberV1,
+      blockHash: BLOCK_HASH,
+      returnData: [contextGraphResult()],
+    }));
+    const resolver = createFinalizedContextGraphRpcResolverV1(read);
+    await expect(resolver(binding())).rejects.toMatchObject({ code: 'malformed-return' });
+  });
+
+  it('rejects a non-function transport at construction', () => {
+    expect(() => createFinalizedContextGraphRpcResolverV1(null as never)).toThrow(TypeError);
+  });
+});

--- a/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
@@ -1,7 +1,4 @@
-import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import type { AddressInfo } from 'node:net';
-
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   type BlockNumberV1,
@@ -26,6 +23,12 @@ import {
   type StrictCurrentFinalizedEvmReadV1,
 } from '../src/strict-current-finalized-evm-rpc.js';
 import { CurrentFinalizedEvmCallErrorV1 } from '../src/current-finalized-evm-read-profile.js';
+import {
+  createLoopbackJsonRpcTestHarness,
+  sendJsonRpcError as sendError,
+  sendJsonRpcResult as sendResult,
+  type LoopbackJsonRpcServer,
+} from './loopback-json-rpc-test-helpers.js';
 
 const CHAIN_ID = '20430' as ChainIdV1;
 const STORAGE = `0x${'11'.repeat(20)}` as EvmAddressV1;
@@ -44,12 +47,11 @@ const ERC721_ERRORS = new ethers.Interface([
   'error ERC721NonexistentToken(uint256 tokenId)',
 ]);
 
-interface JsonRpcRequest {
-  readonly jsonrpc: '2.0';
-  readonly id: number;
-  readonly method: string;
-  readonly params: readonly unknown[];
-}
+const rpcHarness = createLoopbackJsonRpcTestHarness();
+
+afterEach(async () => {
+  await rpcHarness.stopAll();
+});
 
 function binding(): FinalizedContextGraphBindingV1 {
   return Object.freeze({
@@ -223,46 +225,38 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
 
   it('maps an authenticated missing-token revert for the bound ID to unregistered', async () => {
     const rpc = await startMissingContextGraphRpc(42n);
-    try {
-      const read = createStrictCurrentFinalizedEvmReadV1({
-        chainId: CHAIN_ID,
-        endpoints: [rpc.url],
-      });
-      const resolver = createFinalizedContextGraphRpcResolverV1(read);
+    const read = createStrictCurrentFinalizedEvmReadV1({
+      chainId: CHAIN_ID,
+      endpoints: [rpc.url],
+    });
+    const resolver = createFinalizedContextGraphRpcResolverV1(read);
 
-      let caught: unknown;
-      try {
-        await resolveFinalizedContextGraphReadWithSignalV1(
-          resolver,
-          binding(),
-          signal(),
-        );
-      } catch (cause) {
-        caught = cause;
-      }
-      expect(caught).toBeInstanceOf(FinalizedContextGraphReadErrorV1);
-      expect(caught).toMatchObject({ code: 'unregistered-context-graph' });
-    } finally {
-      await rpc.stop();
+    let caught: unknown;
+    try {
+      await resolveFinalizedContextGraphReadWithSignalV1(
+        resolver,
+        binding(),
+        signal(),
+      );
+    } catch (cause) {
+      caught = cause;
     }
+    expect(caught).toBeInstanceOf(FinalizedContextGraphReadErrorV1);
+    expect(caught).toMatchObject({ code: 'unregistered-context-graph' });
   });
 
   it('does not map authenticated missing-token evidence for another ID', async () => {
     const rpc = await startMissingContextGraphRpc(43n);
-    try {
-      const read = createStrictCurrentFinalizedEvmReadV1({
-        chainId: CHAIN_ID,
-        endpoints: [rpc.url],
-      });
-      const resolver = createFinalizedContextGraphRpcResolverV1(read);
+    const read = createStrictCurrentFinalizedEvmReadV1({
+      chainId: CHAIN_ID,
+      endpoints: [rpc.url],
+    });
+    const resolver = createFinalizedContextGraphRpcResolverV1(read);
 
-      await expect(resolver(binding(), signal())).rejects.toMatchObject({
-        name: 'CurrentFinalizedEvmCallErrorV1',
-        code: 'revert',
-      });
-    } finally {
-      await rpc.stop();
-    }
+    await expect(resolver(binding(), signal())).rejects.toMatchObject({
+      name: 'CurrentFinalizedEvmCallErrorV1',
+      code: 'revert',
+    });
   });
 
   it('does not trust a forgeable public revert error as missing-token evidence', async () => {
@@ -276,95 +270,34 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
   });
 });
 
-async function startMissingContextGraphRpc(missingId: bigint): Promise<{
-  readonly url: string;
-  readonly stop: () => Promise<void>;
-}> {
+async function startMissingContextGraphRpc(missingId: bigint): Promise<LoopbackJsonRpcServer> {
   const missingData = ERC721_ERRORS.encodeErrorResult(
     'ERC721NonexistentToken',
     [missingId],
   ).toLowerCase();
-  const server = createServer(async (request, response) => {
-    try {
-      const call = JSON.parse(await readRequestBody(request)) as JsonRpcRequest;
-      switch (call.method) {
-        case 'eth_chainId':
-          sendResult(response, call, '0x4fce');
-          return;
-        case 'eth_getBlockByNumber':
-          sendResult(response, call, { number: '0x7b', hash: BLOCK_HASH });
-          return;
-        case 'eth_getCode':
-          sendResult(response, call, '0x6000');
-          return;
-        case 'eth_call': {
-          const callObject = call.params[0] as { readonly data?: unknown };
-          if (typeof callObject.data === 'string'
-            && callObject.data.startsWith(GET_CONTEXT_GRAPH_SELECTOR)) {
-            sendError(response, call, 3, 'execution reverted', missingData);
-          } else {
-            sendResult(response, call, nameHashResult());
-          }
-          return;
+  return rpcHarness.start((call, response) => {
+    switch (call.method) {
+      case 'eth_chainId':
+        sendResult(response, call, '0x4fce');
+        return;
+      case 'eth_getBlockByNumber':
+        sendResult(response, call, { number: '0x7b', hash: BLOCK_HASH });
+        return;
+      case 'eth_getCode':
+        sendResult(response, call, '0x6000');
+        return;
+      case 'eth_call': {
+        const callObject = call.params[0] as { readonly data?: unknown };
+        if (typeof callObject.data === 'string'
+          && callObject.data.startsWith(GET_CONTEXT_GRAPH_SELECTOR)) {
+          sendError(response, call, 3, 'execution reverted', missingData);
+        } else {
+          sendResult(response, call, nameHashResult());
         }
-        default:
-          sendError(response, call, -32601, 'method not found');
+        return;
       }
-    } catch (cause) {
-      if (!response.headersSent) response.writeHead(500, { 'content-type': 'text/plain' });
-      if (!response.writableEnded) {
-        response.end(cause instanceof Error ? cause.message : 'failure');
-      }
+      default:
+        sendError(response, call, -32601, 'method not found');
     }
   });
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      server.off('error', reject);
-      resolve();
-    });
-  });
-  const address = server.address() as AddressInfo;
-  let stopped = false;
-  return Object.freeze({
-    url: `http://127.0.0.1:${address.port}`,
-    stop: async () => {
-      if (stopped) return;
-      stopped = true;
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-        server.closeAllConnections();
-      });
-    },
-  });
-}
-
-async function readRequestBody(request: IncomingMessage): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of request) chunks.push(Buffer.from(chunk));
-  return Buffer.concat(chunks).toString('utf8');
-}
-
-function sendResult(
-  response: ServerResponse,
-  request: JsonRpcRequest,
-  result: unknown,
-): void {
-  response.writeHead(200, { 'content-type': 'application/json' });
-  response.end(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }));
-}
-
-function sendError(
-  response: ServerResponse,
-  request: JsonRpcRequest,
-  code: number,
-  message: string,
-  data?: string,
-): void {
-  response.writeHead(200, { 'content-type': 'application/json' });
-  response.end(JSON.stringify({
-    jsonrpc: '2.0',
-    id: request.id,
-    error: { code, message, ...(data === undefined ? {} : { data }) },
-  }));
 }

--- a/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
@@ -21,8 +21,8 @@ import { type StrictCurrentFinalizedEvmReadV1 } from '../src/strict-current-fina
 
 const CHAIN_ID = '20430' as ChainIdV1;
 const STORAGE = `0x${'11'.repeat(20)}` as EvmAddressV1;
-const OWNER = `0x${'22'.repeat(20)}`;
-const AUTHORITY = `0x${'33'.repeat(20)}`;
+const OWNER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const AUTHORITY = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
 const PARTICIPANT = `0x${'44'.repeat(20)}`;
 const BLOCK_HASH = `0x${'55'.repeat(32)}` as Digest32V1;
 const NAME_HASH = `0x${'66'.repeat(32)}`;

--- a/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
+++ b/packages/chain/test/finalized-context-graph-rpc-resolver.unit.test.ts
@@ -83,12 +83,14 @@ function readStub(
 }
 
 describe('RFC-64 finalized Context Graph RPC resolver', () => {
+  const signal = (): AbortSignal => new AbortController().signal;
+
   it('executes the two ABI reads at one transport anchor and decodes the policy tuple', async () => {
     const read = readStub();
     const resolver = createFinalizedContextGraphRpcResolverV1(read);
-    const signal = new AbortController().signal;
+    const requestSignal = signal();
 
-    const raw = await resolver(binding(), signal);
+    const raw = await resolver(binding(), requestSignal);
 
     expect(Object.isFrozen(resolver)).toBe(true);
     expect(Object.isFrozen(raw)).toBe(true);
@@ -107,7 +109,7 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
           maxReturnBytes: FINALIZED_CONTEXT_GRAPH_NAME_HASH_MAX_RETURN_BYTES_V1,
         },
       ],
-      signal,
+      signal: requestSignal,
     });
     expect(raw).toEqual({
       blockNumber: '123',
@@ -123,8 +125,10 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
   });
 
   it('feeds the concrete RPC result through the validated finalized read seam', async () => {
-    const resolver = createFinalizedContextGraphRpcResolverV1(readStub());
+    const read = readStub();
+    const resolver = createFinalizedContextGraphRpcResolverV1(read);
     const result = await resolveFinalizedContextGraphReadV1(resolver, binding());
+    const normalizedSignal = read.mock.calls[0]?.[0].signal;
 
     expect(result).toEqual({
       ...binding(),
@@ -138,6 +142,8 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
       publishAuthorityAccountId: '7',
       nameHash: NAME_HASH,
     });
+    expect(normalizedSignal?.aborted).toBe(false);
+    expect(typeof normalizedSignal?.addEventListener).toBe('function');
   });
 
   it('preserves the chain zero-hash sentinel for canonical null normalization', async () => {
@@ -159,7 +165,7 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
     const resolver = createFinalizedContextGraphRpcResolverV1(
       readStub(contextGraphResult(), nameHashResult(), '1' as ChainIdV1),
     );
-    await expect(resolver(binding())).rejects.toMatchObject({ code: 'chain-mismatch' });
+    await expect(resolver(binding(), signal())).rejects.toMatchObject({ code: 'chain-mismatch' });
   });
 
   it('rejects missing, trailing, or non-canonical ABI result bytes', async () => {
@@ -170,7 +176,7 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
     ];
     for (const read of cases) {
       const resolver = createFinalizedContextGraphRpcResolverV1(read);
-      await expect(resolver(binding())).rejects.toMatchObject({ code: 'malformed-return' });
+      await expect(resolver(binding(), signal())).rejects.toMatchObject({ code: 'malformed-return' });
     }
   });
 
@@ -182,7 +188,7 @@ describe('RFC-64 finalized Context Graph RPC resolver', () => {
       returnData: [contextGraphResult()],
     }));
     const resolver = createFinalizedContextGraphRpcResolverV1(read);
-    await expect(resolver(binding())).rejects.toMatchObject({ code: 'malformed-return' });
+    await expect(resolver(binding(), signal())).rejects.toMatchObject({ code: 'malformed-return' });
   });
 
   it('rejects a non-function transport at construction', () => {


### PR DESCRIPTION
## Outcome

Connects the reviewed finalized Context Graph policy seam to the strict same-anchor EVM transport.

## Behavior

- Encodes `getContextGraph(uint256)` and `getNameHash(uint256)` for the exact canonical CG ID.
- Executes both reads in one bounded request against one finalized anchor.
- Owns a 9 KiB ContextGraph tuple cap derived from the chain-capped 256-participant ABI; the name hash remains exactly 32 bytes.
- Canonical-round-trips both ABI results so trailing or non-canonical encodings fail closed.
- Keeps decoded fields untrusted, maps the fixed tuple explicitly, and normalizes addresses and uint256 values before the validated chain-read seam.
- Preserves the existing one-argument resolver API and adds an explicit signal-aware resolver type for cancellable transports.
- Requires a caller-owned signal for the strict RPC path; no anonymous unabortable signal is manufactured.
- Maps only transport-authenticated `ERC721NonexistentToken(boundContextGraphId)` evidence to `unregistered-context-graph`.
- Preserves wrong-ID, other-revert, and forged public errors as generic transport failures.
- Reuses the canonical chain loopback RPC harness for real transport regressions.
- Feeds the decoded result through the finalized policy-domain validator.

## Exact-head validation

Head: `8f0690fb263381f33f242d503a1d90d3c3e0c1ac`
Integration base: `3af0ec0fccee58a5864114ec2f4e574c664c9d8c` after #1909 merged.

- rdf-utils build: pass.
- core build: pass.
- chain build: pass.
- focused finalized resolver lane: 3 files / 55 tests passed.
- full chain unit lane: 35 files / 777 passed / 1 skipped / 0 failed.
- diff check and worktree cleanliness: pass.

## Dependency and scope

#1909 is merged. This PR is now directly based on `integration/rfc64-devnet`, and its five-file diff contains only the resolver slice. It does not claim the real two-process finalized VM proof; runtime VM consumption remains the following M2 slice.