### PR TITLE
Add opt-in project adoption receipts

### DIFF
--- a/docs/use-dkg/adoption-telemetry.md
+++ b/docs/use-dkg/adoption-telemetry.md
@@ -1,0 +1,98 @@
+# Project adoption telemetry
+
+DKG nodes can optionally report two project-adoption signals to an operator-
+controlled HTTPS endpoint:
+
+- `install_completed` after a project manifest has been written successfully;
+- `context_graph_synced` after a clean Context Graph catch-up emits
+  `PROJECT_SYNCED`.
+
+The feature is disabled unless the daemon-wide telemetry switch, the adoption
+switch, and an endpoint are all configured explicitly:
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "adoption": {
+      "enabled": true,
+      "endpoint": "https://telemetry.example/v1/adoption",
+      "token": "optional-bearer-token",
+      "timeoutMs": 3000,
+      "maxAttempts": 3
+    }
+  }
+}
+```
+
+Environment variables override the adoption block:
+
+```text
+DKG_ADOPTION_TELEMETRY_ENABLED=1
+DKG_ADOPTION_TELEMETRY_ENDPOINT=https://telemetry.example/v1/adoption
+DKG_ADOPTION_TELEMETRY_TOKEN=optional-bearer-token
+DKG_ADOPTION_TELEMETRY_TIMEOUT_MS=3000
+DKG_ADOPTION_TELEMETRY_MAX_ATTEMPTS=3
+```
+
+## Receipt contract
+
+The daemon sends JSON with this shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "receiptId": "sha256:...",
+  "adoptionKey": "sha256:...",
+  "event": "context_graph_synced",
+  "contextGraphId": "example-project",
+  "nodeIdHash": "sha256:...",
+  "nodeVersion": "10.0.7",
+  "network": "mainnet",
+  "occurredAt": "2026-07-22T12:00:00.000Z",
+  "dataSynced": 1200,
+  "sharedMemorySynced": 40
+}
+```
+
+`adoptionKey` is stable for `(event, contextGraphId, nodeIdHash)`. `receiptId`
+identifies one install/sync occurrence and is also sent as the
+`Idempotency-Key` header; retries of that occurrence reuse the same receipt.
+A receiver should deduplicate `receiptId`, then upsert by `adoptionKey`, retaining
+the first timestamp as `firstSeen` and updating `lastSeen` for each new
+occurrence. Therefore recurring sync does not increase the unique installation
+or node count; it refreshes activity without confusing an HTTP retry for a new
+sync.
+
+For example, the receiver's logical record is:
+
+```text
+IF receiptId has not been processed:
+  INSERT receiptId
+  UPSERT adoptionKey
+    firstSeen = existing firstSeen or occurredAt
+    lastSeen = occurredAt
+    syncCount = existing syncCount + 1
+```
+
+Count distinct `nodeIdHash` values for total participating nodes. Filter by
+`lastSeen` for active nodes over a chosen time window. Keep `install_completed`
+and `context_graph_synced` separate: one proves that supported installer code
+wrote the manifest files, while the other proves that the DKG node completed a
+clean catch-up.
+
+## Privacy and delivery
+
+The raw Peer ID, wallet address, workspace path, and daemon authentication token
+are not included. `nodeIdHash` is deterministically derived from the stable Peer
+ID so a receiver can deduplicate a node without receiving the raw identifier.
+Deleting the node's persistent DKG home generates a new Peer ID and therefore a
+new pseudonym.
+
+Delivery is best-effort and fail-open: an unavailable telemetry endpoint never
+turns a successful install or sync into a failure. The daemon retries transient
+HTTP and transport failures within configured bounds and drains outstanding
+deliveries during graceful shutdown. Nodes that do not opt in are not visible,
+so aggregated counts are a lower bound rather than a protocol-wide registry.
+Remote endpoints must use HTTPS; plain HTTP is accepted only for a collector on
+`localhost`, `127.0.0.1`, or `::1`.

--- a/packages/cli/src/adoption-telemetry.ts
+++ b/packages/cli/src/adoption-telemetry.ts
@@ -1,0 +1,326 @@
+import { createHash, randomUUID } from 'node:crypto';
+import type { DkgConfig } from './config.js';
+
+export type AdoptionTelemetryEventType =
+  | 'install_completed'
+  | 'context_graph_synced';
+
+export interface AdoptionTelemetryEvent {
+  type: AdoptionTelemetryEventType;
+  contextGraphId: string;
+  dataSynced?: number;
+  sharedMemorySynced?: number;
+}
+
+export interface AdoptionTelemetryReceipt {
+  schemaVersion: 1;
+  /** Unique sync/install occurrence. Retries of this occurrence reuse it. */
+  receiptId: string;
+  /** Stable key for (event, Context Graph, node); receivers UPSERT this key. */
+  adoptionKey: string;
+  event: AdoptionTelemetryEventType;
+  contextGraphId: string;
+  /** Stable pseudonymous node identity. The raw libp2p Peer ID never leaves the node. */
+  nodeIdHash: string;
+  nodeVersion?: string;
+  network?: string;
+  occurredAt: string;
+  dataSynced?: number;
+  sharedMemorySynced?: number;
+}
+
+export interface ResolvedAdoptionTelemetryConfig {
+  enabled: boolean;
+  endpoint?: string;
+  token?: string;
+  timeoutMs: number;
+  maxAttempts: number;
+  warning?: string;
+}
+
+export interface AdoptionTelemetrySink {
+  readonly enabled: boolean;
+  enqueue(event: AdoptionTelemetryEvent): boolean;
+}
+
+interface AdoptionTelemetryReporterOptions {
+  config: ResolvedAdoptionTelemetryConfig;
+  peerId: string;
+  nodeVersion?: string;
+  network?: string;
+  fetcher?: typeof fetch;
+  now?: () => number;
+  delay?: (ms: number) => Promise<void>;
+  log?: (message: string) => void;
+  maxPending?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 3_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_MAX_PENDING = 128;
+const MAX_TIMEOUT_MS = 30_000;
+const MAX_ATTEMPTS = 5;
+
+function parseExplicitBoolean(raw: string | undefined): boolean | undefined {
+  if (raw == null || raw.trim() === '') return undefined;
+  const value = raw.trim().toLowerCase();
+  if (value === '1' || value === 'true') return true;
+  if (value === '0' || value === 'false') return false;
+  return undefined;
+}
+
+function positiveInteger(
+  envValue: string | undefined,
+  configValue: number | undefined,
+  fallback: number,
+  max: number,
+): number {
+  const candidate = envValue == null || envValue.trim() === ''
+    ? configValue
+    : Number(envValue);
+  if (!Number.isSafeInteger(candidate) || Number(candidate) <= 0) return fallback;
+  return Math.min(Number(candidate), max);
+}
+
+function validateEndpoint(raw: string | undefined): { endpoint?: string; warning?: string } {
+  const endpoint = raw?.trim();
+  if (!endpoint) return {};
+  try {
+    const parsed = new URL(endpoint);
+    const loopback = parsed.hostname === 'localhost'
+      || parsed.hostname === '127.0.0.1'
+      || parsed.hostname === '[::1]';
+    if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && loopback)) {
+      return { warning: 'adoption telemetry endpoint must use https (http is allowed only on loopback)' };
+    }
+    if (parsed.username || parsed.password) {
+      return { warning: 'adoption telemetry endpoint must not contain credentials' };
+    }
+    return { endpoint: parsed.toString() };
+  } catch {
+    return { warning: 'adoption telemetry endpoint is not a valid URL' };
+  }
+}
+
+/**
+ * Resolve adoption telemetry independently from OTLP signals, but keep the
+ * daemon-wide telemetry master switch authoritative. Both gates must be
+ * explicit and an endpoint must resolve; otherwise no adoption data leaves
+ * the node.
+ */
+export function resolveAdoptionTelemetryConfig(
+  telemetry: DkgConfig['telemetry'],
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): ResolvedAdoptionTelemetryConfig {
+  const adoption = telemetry?.adoption;
+  const envEnabledRaw = env.DKG_ADOPTION_TELEMETRY_ENABLED;
+  const envEnabled = parseExplicitBoolean(envEnabledRaw);
+  const invalidEnvEnabled = envEnabledRaw != null && envEnabledRaw.trim() !== '' && envEnabled === undefined;
+  const explicitlyEnabled = envEnabled ?? adoption?.enabled === true;
+  const { endpoint, warning } = validateEndpoint(
+    env.DKG_ADOPTION_TELEMETRY_ENDPOINT ?? adoption?.endpoint,
+  );
+  const timeoutMs = positiveInteger(
+    env.DKG_ADOPTION_TELEMETRY_TIMEOUT_MS,
+    adoption?.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    MAX_TIMEOUT_MS,
+  );
+  const maxAttempts = positiveInteger(
+    env.DKG_ADOPTION_TELEMETRY_MAX_ATTEMPTS,
+    adoption?.maxAttempts,
+    DEFAULT_MAX_ATTEMPTS,
+    MAX_ATTEMPTS,
+  );
+
+  if (telemetry?.enabled !== true) {
+    return { enabled: false, timeoutMs, maxAttempts };
+  }
+  if (invalidEnvEnabled) {
+    return {
+      enabled: false,
+      timeoutMs,
+      maxAttempts,
+      warning: 'DKG_ADOPTION_TELEMETRY_ENABLED must be true/false or 1/0',
+    };
+  }
+  if (!explicitlyEnabled) {
+    return { enabled: false, timeoutMs, maxAttempts };
+  }
+  if (warning) {
+    return { enabled: false, timeoutMs, maxAttempts, warning };
+  }
+  if (!endpoint) {
+    return {
+      enabled: false,
+      timeoutMs,
+      maxAttempts,
+      warning: 'adoption telemetry is enabled but no endpoint is configured',
+    };
+  }
+  return {
+    enabled: true,
+    endpoint,
+    token: env.DKG_ADOPTION_TELEMETRY_TOKEN ?? adoption?.token,
+    timeoutMs,
+    maxAttempts,
+  };
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function adoptionNodeIdHash(peerId: string): string {
+  return `sha256:${sha256(`dkg-adoption-node-v1\0${peerId}`)}`;
+}
+
+export function buildAdoptionTelemetryReceipt(
+  event: AdoptionTelemetryEvent,
+  identity: { peerId: string; nodeVersion?: string; network?: string },
+  occurredAtMs = Date.now(),
+  occurrenceId = randomUUID(),
+): AdoptionTelemetryReceipt {
+  const contextGraphId = event.contextGraphId.trim();
+  if (!contextGraphId) throw new Error('adoption telemetry requires a contextGraphId');
+  const nodeIdHash = adoptionNodeIdHash(identity.peerId);
+  const adoptionKey = `sha256:${sha256(
+    `dkg-adoption-receipt-v1\0${event.type}\0${contextGraphId}\0${nodeIdHash}`,
+  )}`;
+  const receiptId = `sha256:${sha256(
+    `dkg-adoption-occurrence-v1\0${adoptionKey}\0${occurrenceId}`,
+  )}`;
+  const receipt: AdoptionTelemetryReceipt = {
+    schemaVersion: 1,
+    receiptId,
+    adoptionKey,
+    event: event.type,
+    contextGraphId,
+    nodeIdHash,
+    nodeVersion: identity.nodeVersion,
+    network: identity.network,
+    occurredAt: new Date(occurredAtMs).toISOString(),
+  };
+  if (Number.isFinite(event.dataSynced)) receipt.dataSynced = event.dataSynced;
+  if (Number.isFinite(event.sharedMemorySynced)) {
+    receipt.sharedMemorySynced = event.sharedMemorySynced;
+  }
+  return receipt;
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+/**
+ * Best-effort, bounded adoption-receipt delivery. Callers enqueue after their
+ * primary operation has succeeded; delivery never changes install/sync
+ * success. Concurrent duplicates share one in-flight request, while later
+ * repeats send a new receipt ID with the same adoption key so the receiver can
+ * UPSERT lastSeen without counting a second node.
+ */
+export class AdoptionTelemetryReporter implements AdoptionTelemetrySink {
+  readonly enabled: boolean;
+  private readonly config: ResolvedAdoptionTelemetryConfig;
+  private readonly identity: { peerId: string; nodeVersion?: string; network?: string };
+  private readonly fetcher: typeof fetch;
+  private readonly now: () => number;
+  private readonly delay: (ms: number) => Promise<void>;
+  private readonly log: (message: string) => void;
+  private readonly maxPending: number;
+  private readonly pending = new Map<string, Promise<void>>();
+  private accepting = true;
+  private warnedQueueFull = false;
+
+  constructor(options: AdoptionTelemetryReporterOptions) {
+    this.config = options.config;
+    this.enabled = options.config.enabled;
+    this.identity = {
+      peerId: options.peerId,
+      nodeVersion: options.nodeVersion,
+      network: options.network,
+    };
+    this.fetcher = options.fetcher ?? globalThis.fetch;
+    this.now = options.now ?? Date.now;
+    this.delay = options.delay ?? defaultDelay;
+    this.log = options.log ?? (() => {});
+    this.maxPending = options.maxPending ?? DEFAULT_MAX_PENDING;
+  }
+
+  enqueue(event: AdoptionTelemetryEvent): boolean {
+    if (!this.accepting || !this.enabled || !this.config.endpoint) return false;
+    let receipt: AdoptionTelemetryReceipt;
+    try {
+      receipt = buildAdoptionTelemetryReceipt(event, this.identity, this.now());
+    } catch (error) {
+      this.log(`Adoption telemetry ignored invalid event: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    }
+    // A repeated sync arriving while the same adoption key is still being
+    // delivered is redundant. A later repeat gets a new per-occurrence receipt
+    // ID and refreshes lastSeen for the same adoption key.
+    if (this.pending.has(receipt.adoptionKey)) return true;
+    if (this.pending.size >= this.maxPending) {
+      if (!this.warnedQueueFull) {
+        this.warnedQueueFull = true;
+        this.log(`Adoption telemetry queue full (${this.maxPending}); dropping new receipts`);
+      }
+      return false;
+    }
+
+    const task = this.deliver(receipt).finally(() => {
+      this.pending.delete(receipt.adoptionKey);
+      if (this.pending.size < this.maxPending) this.warnedQueueFull = false;
+    });
+    this.pending.set(receipt.adoptionKey, task);
+    return true;
+  }
+
+  async flush(): Promise<void> {
+    await Promise.allSettled([...this.pending.values()]);
+  }
+
+  async shutdown(): Promise<void> {
+    this.accepting = false;
+    await this.flush();
+  }
+
+  private async deliver(receipt: AdoptionTelemetryReceipt): Promise<void> {
+    const endpoint = this.config.endpoint!;
+    let lastError = 'unknown error';
+    for (let attempt = 1; attempt <= this.config.maxAttempts; attempt += 1) {
+      const abort = new AbortController();
+      const timeout = setTimeout(() => abort.abort(), this.config.timeoutMs);
+      try {
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          'Idempotency-Key': receipt.receiptId,
+        };
+        if (this.config.token) headers.Authorization = `Bearer ${this.config.token}`;
+        const response = await this.fetcher(endpoint, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(receipt),
+          signal: abort.signal,
+        });
+        if (response.ok) return;
+        lastError = `HTTP ${response.status}`;
+        if (!isRetryableStatus(response.status)) break;
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      } finally {
+        clearTimeout(timeout);
+      }
+      if (attempt < this.config.maxAttempts) {
+        await this.delay(Math.min(250 * 2 ** (attempt - 1), 2_000));
+      }
+    }
+    this.log(
+      `Adoption telemetry delivery failed for ${receipt.event}/${receipt.contextGraphId}: ${lastError}`,
+    );
+  }
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -729,6 +729,23 @@ export interface DkgConfig {
       /** Enable local Node UI SQLite metric snapshots. Default true. */
       collectionEnabled?: boolean;
     };
+    /**
+     * Opt-in project adoption receipts. The node sends only a SHA-256-derived
+     * pseudonym of its Peer ID; the raw Peer ID, wallet, workspace path, and
+     * daemon token are never included. Requires both `telemetry.enabled=true`
+     * and `adoption.enabled=true` plus an explicit endpoint.
+     */
+    adoption?: {
+      enabled?: boolean;
+      /** HTTPS endpoint accepting idempotent receipt POSTs; HTTP is loopback-only. */
+      endpoint?: string;
+      /** Optional Bearer credential for the receipt endpoint. */
+      token?: string;
+      /** Per-attempt request deadline. Default 3000ms, capped at 30000ms. */
+      timeoutMs?: number;
+      /** Total delivery attempts. Default 3, capped at 5. */
+      maxAttempts?: number;
+    };
   };
   /** Shared memory (workspace) data TTL in milliseconds. Default: 30 days (2592000000). Set to 0 to disable cleanup. */
   sharedMemoryTtlMs?: number;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -146,6 +146,10 @@ import {
 import { projectRuntimeEvmChainConfig } from '../runtime-chain-config.js';
 import { resolveOtelSignals, resolveLogExporterMode, isUnknownLogExporter } from '../telemetry-config.js';
 import {
+  AdoptionTelemetryReporter,
+  resolveAdoptionTelemetryConfig,
+} from '../adoption-telemetry.js';
+import {
   formatMetricsCollectorStartupLog,
   resolveMetricsCollectorConfig,
 } from '../metrics-collector-config.js';
@@ -2665,6 +2669,20 @@ export async function runDaemonInner(
   const networkKey = network?.networkName?.toLowerCase().includes("testnet")
     ? "testnet"
     : "mainnet";
+  const adoptionTelemetryConfig = resolveAdoptionTelemetryConfig(config.telemetry);
+  if (adoptionTelemetryConfig.warning) {
+    log(`Telemetry(adoption): ${adoptionTelemetryConfig.warning}; disabled`);
+  }
+  const adoptionTelemetry = new AdoptionTelemetryReporter({
+    config: adoptionTelemetryConfig,
+    peerId: agent.peerId,
+    nodeVersion,
+    network: network?.networkName ?? networkKey,
+    log: (message) => log(`Telemetry(adoption): ${message}`),
+  });
+  if (adoptionTelemetry.enabled) {
+    log('Telemetry: adoption receipts enabled');
+  }
   const syslogEndpoint = TELEMETRY_ENDPOINTS[networkKey]?.syslog;
   let logPusher: LogPushWorker | null = null;
   let otlpExporter: OtlpLogWorker | null = null;
@@ -3101,6 +3119,12 @@ export async function runDaemonInner(
 
   agent.eventBus.on(DKGEvent.PROJECT_SYNCED, (data: any) => {
     try {
+      adoptionTelemetry.enqueue({
+        type: 'context_graph_synced',
+        contextGraphId: data.contextGraphId,
+        dataSynced: data.dataSynced,
+        sharedMemorySynced: data.sharedMemorySynced,
+      });
       sseBroadcast("project_synced", {
         contextGraphId: data.contextGraphId,
         dataSynced: data.dataSynced,
@@ -3637,6 +3661,7 @@ export async function runDaemonInner(
         apiPortRef,
         routePlugins,
         admission: admissionStats,
+        adoptionTelemetry,
         emitMemoryGraphChanged,
         emitNotification,
       });
@@ -3740,6 +3765,7 @@ export async function runDaemonInner(
         rpcUsageTelemetry.stop();
         rateLimiter.destroy();
         metricsCollector?.stop();
+        await adoptionTelemetry.shutdown();
         // Stops log exporters AND flushes + shuts down the OTel SDK.
         await stopTelemetry();
         natStatusWatcherStop?.();

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -496,6 +496,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     requestToken,
     requestAgentAddress,
     emitMemoryGraphChanged,
+    adoptionTelemetry,
   } = ctx;
   // Operator gate for the node-wide subscription endpoints. When auth is ENABLED,
   // require a node-level admin token — a recognised token (in validTokens) that
@@ -1611,6 +1612,10 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       };
       const plan = planInstallImpl({ ...ctx.context, manifest });
       const written = await writeInstallImpl(plan);
+      const trackingQueued = written.length > 0 && (adoptionTelemetry?.enqueue({
+        type: 'install_completed',
+        contextGraphId: manifest.contextGraphId,
+      }) ?? false);
       const skipped: string[] = [];
       if (!(ctx.context.tools as readonly string[]).includes('claude-code')) {
         skipped.push('claudeHooksTemplate (claude-code not selected)');
@@ -1628,11 +1633,32 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         })),
         warnings: plan.warnings,
         skipped,
+        adoptionTracking: trackingQueued ? 'queued' : 'disabled',
       });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       return jsonResponse(res, 500, { error: `manifest install failed: ${msg}` });
     }
+  }
+
+  // Used by the standalone `dkg-mcp join` path after its local file writes
+  // succeed. The daemon owns the stable Peer ID and telemetry configuration,
+  // so the CLI never needs to read or transmit node identity itself.
+  const manifestInstallReceiptMatch = path.match(/^\/api\/context-graph\/([^/]+)\/manifest\/install-receipt$/);
+  if (req.method === 'POST' && manifestInstallReceiptMatch) {
+    const contextGraphId = safeDecodeURIComponent(manifestInstallReceiptMatch[1], res);
+    if (contextGraphId === null) return;
+    if (!isValidContextGraphId(contextGraphId)) {
+      return jsonResponse(res, 400, { error: 'Invalid context graph id' });
+    }
+    const queued = adoptionTelemetry?.enqueue({
+      type: 'install_completed',
+      contextGraphId,
+    }) ?? false;
+    return jsonResponse(res, 202, {
+      ok: true,
+      adoptionTracking: queued ? 'queued' : 'disabled',
+    });
   }
 
   // POST /api/context-graph/reconcile

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -26,6 +26,7 @@ import type { VectorStore, EmbeddingProvider } from '../../vector-store.js';
 import type { CatchupTracker } from '../types.js';
 import type { RoutePlugin } from '../plugin-api.js';
 import type { AdmissionStatsView } from '../http-utils.js';
+import type { AdoptionTelemetrySink } from '../../adoption-telemetry.js';
 
 export type MemoryGraphLayer = 'wm' | 'swm' | 'vm';
 
@@ -93,6 +94,8 @@ export interface RequestContext {
   // shedding load. Deliberately the read-only `AdmissionStatsView`, not the
   // concrete limiter — plugin-facing routes must not reach tryAcquire()/release().
   admission: AdmissionStatsView;
+  /** Optional, fail-open central adoption receipt reporter. */
+  adoptionTelemetry?: AdoptionTelemetrySink;
   // Derived per-request (from req.url + headers + token). Routes read
   // `path`, `url`, `requestAgentAddress` extensively; pre-computing
   // here keeps every group on the same fast path.

--- a/packages/cli/test/adoption-telemetry-route.test.ts
+++ b/packages/cli/test/adoption-telemetry-route.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+
+describe('manifest install adoption receipt route', () => {
+  it('queues the graph-scoped install signal without accepting identity input', async () => {
+    const events: unknown[] = [];
+    let status = 0;
+    let responseBody = '';
+    const req = { method: 'POST' } as any;
+    const res = {
+      writableEnded: false,
+      writeHead(nextStatus: number) {
+        status = nextStatus;
+      },
+      end(body?: string) {
+        responseBody = body ?? '';
+        this.writableEnded = true;
+      },
+    } as any;
+    const url = new URL(
+      'http://127.0.0.1/api/context-graph/project%2Falpha/manifest/install-receipt',
+    );
+    await handleContextGraphRoutes({
+        req,
+        res,
+        agent: { resolveAgentByToken: () => undefined },
+        publisherControl: {},
+        config: {},
+        startedAt: Date.now(),
+        dashDb: {},
+        opWallets: {},
+        network: {},
+        tracker: {},
+        memoryManager: {},
+        bridgeAuthToken: undefined,
+        nodeVersion: 'test',
+        nodeCommit: 'test',
+        catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
+        extractionRegistry: {},
+        fileStore: {},
+        extractionStatus: new Map(),
+        assertionImportLocks: new Map(),
+        vectorStore: {},
+        embeddingProvider: null,
+        validTokens: new Set(),
+        apiHost: '127.0.0.1',
+        apiPortRef: { value: 0 },
+        routePlugins: [],
+        admission: { inFlight: 0, max: 1, rejectedTotal: 0 },
+        url,
+        path: url.pathname,
+        requestToken: undefined,
+        requestAgentAddress: '',
+        adoptionTelemetry: {
+          enabled: true,
+          enqueue: (event) => {
+            events.push(event);
+            return true;
+          },
+        },
+      } as any);
+
+    expect(status).toBe(202);
+    expect(JSON.parse(responseBody)).toEqual({ ok: true, adoptionTracking: 'queued' });
+    expect(events).toEqual([{
+      type: 'install_completed',
+      contextGraphId: 'project/alpha',
+    }]);
+  });
+});

--- a/packages/cli/test/adoption-telemetry.test.ts
+++ b/packages/cli/test/adoption-telemetry.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AdoptionTelemetryReporter,
+  adoptionNodeIdHash,
+  buildAdoptionTelemetryReceipt,
+  resolveAdoptionTelemetryConfig,
+} from '../src/adoption-telemetry.js';
+
+describe('resolveAdoptionTelemetryConfig', () => {
+  it('requires the telemetry master gate, explicit adoption opt-in, and an endpoint', () => {
+    expect(resolveAdoptionTelemetryConfig(undefined, {}).enabled).toBe(false);
+    expect(resolveAdoptionTelemetryConfig({
+      enabled: true,
+      adoption: { endpoint: 'https://telemetry.example/adoption' },
+    }, {}).enabled).toBe(false);
+    const missingEndpoint = resolveAdoptionTelemetryConfig({
+      enabled: true,
+      adoption: { enabled: true },
+    }, {});
+    expect(missingEndpoint.enabled).toBe(false);
+    expect(missingEndpoint.warning).toMatch(/no endpoint/);
+  });
+
+  it('supports env overrides and fails closed for an unsafe endpoint', () => {
+    const resolved = resolveAdoptionTelemetryConfig(
+      { enabled: true, adoption: { enabled: false } },
+      {
+        DKG_ADOPTION_TELEMETRY_ENABLED: '1',
+        DKG_ADOPTION_TELEMETRY_ENDPOINT: 'https://collector.example/v1/adoption',
+        DKG_ADOPTION_TELEMETRY_TOKEN: 'secret',
+        DKG_ADOPTION_TELEMETRY_TIMEOUT_MS: '4500',
+        DKG_ADOPTION_TELEMETRY_MAX_ATTEMPTS: '2',
+      },
+    );
+    expect(resolved).toMatchObject({
+      enabled: true,
+      endpoint: 'https://collector.example/v1/adoption',
+      token: 'secret',
+      timeoutMs: 4_500,
+      maxAttempts: 2,
+    });
+
+    const unsafe = resolveAdoptionTelemetryConfig({
+      enabled: true,
+      adoption: { enabled: true, endpoint: 'file:///tmp/receipts' },
+    }, {});
+    expect(unsafe.enabled).toBe(false);
+    expect(unsafe.warning).toMatch(/must use https/);
+
+    const insecureRemote = resolveAdoptionTelemetryConfig({
+      enabled: true,
+      adoption: { enabled: true, endpoint: 'http://collector.example/adoption' },
+    }, {});
+    expect(insecureRemote.enabled).toBe(false);
+    expect(insecureRemote.warning).toMatch(/loopback/);
+
+    const localCollector = resolveAdoptionTelemetryConfig({
+      enabled: true,
+      adoption: { enabled: true, endpoint: 'http://127.0.0.1:4319/adoption' },
+    }, {});
+    expect(localCollector.enabled).toBe(true);
+
+    const invalidToggle = resolveAdoptionTelemetryConfig({
+      enabled: true,
+      adoption: { enabled: true, endpoint: 'https://collector.example/adoption' },
+    }, { DKG_ADOPTION_TELEMETRY_ENABLED: 'perhaps' });
+    expect(invalidToggle.enabled).toBe(false);
+    expect(invalidToggle.warning).toMatch(/true\/false/);
+  });
+});
+
+describe('adoption receipts', () => {
+  it('uses stable event/node ids without exposing the raw Peer ID', () => {
+    const peerId = '12D3KooWExamplePeer';
+    const first = buildAdoptionTelemetryReceipt({
+      type: 'context_graph_synced',
+      contextGraphId: 'project-a',
+      dataSynced: 42,
+    }, { peerId, nodeVersion: '10.0.7', network: 'testnet' }, 1_000, 'occurrence-1');
+    const later = buildAdoptionTelemetryReceipt({
+      type: 'context_graph_synced',
+      contextGraphId: 'project-a',
+      dataSynced: 7,
+    }, { peerId, nodeVersion: '10.0.7', network: 'testnet' }, 2_000, 'occurrence-2');
+    const install = buildAdoptionTelemetryReceipt({
+      type: 'install_completed',
+      contextGraphId: 'project-a',
+    }, { peerId }, 2_000, 'occurrence-3');
+
+    expect(first.adoptionKey).toBe(later.adoptionKey);
+    expect(first.receiptId).not.toBe(later.receiptId);
+    expect(first.adoptionKey).not.toBe(install.adoptionKey);
+    expect(first.nodeIdHash).toBe(adoptionNodeIdHash(peerId));
+    expect(JSON.stringify(first)).not.toContain(peerId);
+    expect(first).toMatchObject({
+      event: 'context_graph_synced',
+      contextGraphId: 'project-a',
+      dataSynced: 42,
+      occurredAt: new Date(1_000).toISOString(),
+    });
+  });
+});
+
+describe('AdoptionTelemetryReporter', () => {
+  const enabledConfig = {
+    enabled: true,
+    endpoint: 'https://collector.example/v1/adoption',
+    timeoutMs: 1_000,
+    maxAttempts: 3,
+  } as const;
+
+  it('suppresses concurrent duplicates and sends idempotent receipts', async () => {
+    let release!: (response: Response) => void;
+    const pendingResponse = new Promise<Response>((resolve) => { release = resolve; });
+    const calls: Array<{ headers: Headers; body: string }> = [];
+    const reporter = new AdoptionTelemetryReporter({
+      config: enabledConfig,
+      peerId: 'peer-a',
+      fetcher: (async (_url, init) => {
+        calls.push({
+          headers: new Headers(init?.headers),
+          body: String(init?.body),
+        });
+        return pendingResponse;
+      }) as typeof fetch,
+      delay: async () => {},
+    });
+
+    expect(reporter.enqueue({ type: 'context_graph_synced', contextGraphId: 'cg-a' })).toBe(true);
+    expect(reporter.enqueue({ type: 'context_graph_synced', contextGraphId: 'cg-a' })).toBe(true);
+    expect(calls).toHaveLength(1);
+    release(new Response(null, { status: 204 }));
+    await reporter.flush();
+
+    const body = JSON.parse(calls[0].body);
+    expect(calls[0].headers.get('Idempotency-Key')).toBe(body.receiptId);
+  });
+
+  it('retries transient failures but not successful delivery', async () => {
+    let calls = 0;
+    const warnings: string[] = [];
+    const reporter = new AdoptionTelemetryReporter({
+      config: enabledConfig,
+      peerId: 'peer-a',
+      fetcher: (async () => {
+        calls += 1;
+        return new Response(calls === 1 ? '' : null, { status: calls === 1 ? 503 : 204 });
+      }) as typeof fetch,
+      delay: async () => {},
+      log: (message) => warnings.push(message),
+    });
+
+    reporter.enqueue({ type: 'install_completed', contextGraphId: 'cg-a' });
+    await reporter.flush();
+    expect(calls).toBe(2);
+    expect(warnings).toEqual([]);
+  });
+
+  it('does nothing when disabled', async () => {
+    let calls = 0;
+    const reporter = new AdoptionTelemetryReporter({
+      config: { enabled: false, timeoutMs: 1_000, maxAttempts: 1 },
+      peerId: 'peer-a',
+      fetcher: (async () => {
+        calls += 1;
+        return new Response(null, { status: 204 });
+      }) as typeof fetch,
+    });
+    expect(reporter.enqueue({ type: 'install_completed', contextGraphId: 'cg-a' })).toBe(false);
+    await reporter.flush();
+    expect(calls).toBe(0);
+  });
+
+  it('stops accepting new receipts during shutdown', async () => {
+    let calls = 0;
+    const reporter = new AdoptionTelemetryReporter({
+      config: enabledConfig,
+      peerId: 'peer-a',
+      fetcher: (async () => {
+        calls += 1;
+        return new Response(null, { status: 204 });
+      }) as typeof fetch,
+    });
+    reporter.enqueue({ type: 'install_completed', contextGraphId: 'cg-a' });
+    await reporter.shutdown();
+    expect(reporter.enqueue({ type: 'install_completed', contextGraphId: 'cg-b' })).toBe(false);
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -75,6 +75,9 @@ export default defineConfig({
           'test/metrics-queries.test.ts',
           // #1066 Item 1 — metrics presence gate. Pure logic (injected clock).
           'test/metrics-presence.test.ts',
+          // Opt-in install/sync adoption receipts. Pure config + mocked HTTP.
+          'test/adoption-telemetry.test.ts',
+          'test/adoption-telemetry-route.test.ts',
           'test/rpc-usage-log.test.ts',
           'test/dashboard-log-volume-pruner.test.ts',
           // RFC 120 / plan PR 1 + 2 — Blazegraph support. Pure logic

--- a/packages/mcp-dkg/src/cli/index.ts
+++ b/packages/mcp-dkg/src/cli/index.ts
@@ -508,6 +508,18 @@ async function cmdJoin(args: string[]): Promise<number> {
     console.log(`[join]   ${r.action.padEnd(10)} ${r.absPath} (${r.bytesWritten.toLocaleString()} bytes)`);
   }
 
+  // File installation is already complete, so adoption delivery is strictly
+  // best-effort and must never turn a successful local install into a failure.
+  // The daemon owns the stable Peer ID and opt-in policy; this client sends only
+  // the Context Graph identifier.
+  if (results.length > 0) {
+    try {
+      await client.recordProjectInstall(invite.contextGraphId);
+    } catch (err) {
+      console.warn(`[join] install tracking was not recorded: ${(err as Error).message.slice(0, 160)}`);
+    }
+  }
+
   console.log(`\n[join] ✔ Installed ${results.length} file${results.length === 1 ? '' : 's'} for project ${invite.contextGraphId}.`);
   // Mirror what planInstall actually templated in — agentUri wins when
   // we successfully resolved a wallet from /api/agent/identity; fall

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -944,6 +944,23 @@ export class DkgClient {
   }
 
   /**
+   * Best-effort notification that this client successfully materialised a
+   * project manifest. The daemon applies the operator's opt-in telemetry policy
+   * and derives the pseudonymous node identity; callers send no identity data.
+   */
+  async recordProjectInstall(contextGraphId: string): Promise<{
+    ok: boolean;
+    adoptionTracking: 'queued' | 'disabled';
+  }> {
+    const id = normalizeContextGraphId(contextGraphId);
+    return this.request(
+      'POST',
+      `/api/context-graph/${encodeURIComponent(id)}/manifest/install-receipt`,
+      {},
+    );
+  }
+
+  /**
    * OT-RFC-38 / LU-6 Phase B path 4 — operator-driven host-mode
    * subscribe. Asks the connected daemon (must be a core with
    * `swmHostMode` enabled) to start hosting the curated CG's opaque

--- a/packages/mcp-dkg/test/context-graph-client.test.ts
+++ b/packages/mcp-dkg/test/context-graph-client.test.ts
@@ -48,4 +48,14 @@ describe('DkgClient context-graph registration', () => {
     })).rejects.toThrow(/positive decimal integer/);
     expect(calls).toHaveLength(0);
   });
+
+  it('records a completed local install through the daemon without identity data', async () => {
+    const { client, calls } = makeClient();
+    await client.recordProjectInstall('did:dkg:context-graph:project/alpha');
+
+    expect(calls[0].url).toContain(
+      '/api/context-graph/project%2Falpha/manifest/install-receipt',
+    );
+    expect(calls[0].body).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary

Add an opt-in, fail-open adoption receipt pipeline for project manifest installs and verified Context Graph sync completions.

## Why

A plain request counter cannot distinguish a new installation from a retry or a recurring sync. Nodes already have a persistent libp2p Peer ID, so this change derives a stable pseudonymous node key locally and gives the collector enough information to deduplicate nodes while retaining activity history.

## What changed

- add `install_completed` and `context_graph_synced` receipt types
- derive `nodeIdHash` from the persistent Peer ID without transmitting the raw ID
- use a stable `adoptionKey` for each event/Context Graph/node tuple
- use a per-occurrence `receiptId` as the HTTP idempotency key
- report successful manifest writes from both daemon and standalone `dkg-mcp join` paths
- report syncs only after the existing `PROJECT_SYNCED` completion signal
- add bounded retries, request deadlines, queue limits, graceful shutdown draining, and HTTPS validation
- keep delivery disabled unless telemetry, adoption tracking, and an endpoint are all explicitly configured
- document the receipt and receiver-side upsert contract

## Impact

Repeated syncs refresh `lastSeen` and may increment a sync occurrence counter without inflating the distinct participating-node count. Delivery failures never change install or sync success.

This PR implements the node-side producer and wire contract. A central collector still needs to deploy the documented idempotent upsert endpoint and opt-in nodes must configure it.

## Privacy and security

Receipts exclude the raw Peer ID, wallet address, workspace path, and daemon token. Remote collectors must use HTTPS; HTTP is accepted only for loopback development endpoints.

## Validation

- `pnpm --filter @origintrail-official/dkg build`
- CLI adoption tests: 8 passed
- MCP suite: 340 passed
- `git diff --check`
