### PR TITLE
feat(chain): scan finalized VM ordinals at one anchor

### DIFF
--- a/packages/chain/src/finalized-vm-chain-scanner.ts
+++ b/packages/chain/src/finalized-vm-chain-scanner.ts
@@ -1,0 +1,407 @@
+import {
+  assertCanonicalChainId,
+  assertCanonicalDecimalU256,
+  assertCanonicalDecimalU64,
+  assertCanonicalDigest,
+  assertNetworkIdV1,
+  type BlockNumberV1,
+  type ChainIdV1,
+  type DecimalU256V1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
+} from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+
+import { loadAbi } from './evm-adapter-abi.js';
+import {
+  CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1,
+  CurrentFinalizedEvmCallErrorV1,
+} from './current-finalized-evm-read-profile.js';
+import {
+  CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1,
+  CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1,
+  type StrictCurrentFinalizedEvmSnapshotScopeV1,
+  type StrictCurrentFinalizedEvmSnapshotSessionV1,
+} from './current-finalized-evm-snapshot.js';
+import type { StrictCurrentFinalizedEvmReadCallV1 } from './current-finalized-evm-read-model.js';
+import {
+  assertCanonicalNonzeroEvmAddress,
+  isAbortSignal,
+  snapshotExactDataRecord,
+} from './strict-local-data.js';
+
+const CONTEXT_GRAPH_STORAGE_INTERFACE = new ethers.Interface(loadAbi('ContextGraphStorage'));
+const KNOWLEDGE_ASSET_STORAGE_INTERFACE = new ethers.Interface(loadAbi('DKGKnowledgeAssets'));
+
+const CONFIG_KEYS = Object.freeze([
+  'chainId',
+  'contextGraphStorageAddress',
+  'knowledgeAssetStorageAddress',
+  'networkId',
+  'snapshot',
+] as const);
+const REQUEST_KEYS = Object.freeze(['contextGraphId', 'signal'] as const);
+const UINT256_RETURN_BYTES = 32;
+const UPDATE_CONTEXT_RETURN_BYTES = 7 * 32;
+const PACKED_KA_NUMBER_BITS = 96n;
+const PACKED_KA_NUMBER_MASK = (1n << PACKED_KA_NUMBER_BITS) - 1n;
+
+/**
+ * One count read plus one indexed-ID read and two assertion reads per row.
+ * The exact grouping below consumes one count batch, ceil(N/4) ID batches,
+ * and ceil(2N/4) assertion batches. 1,364 is the largest N that stays inside
+ * both the pinned-snapshot batch and call budgets.
+ */
+export const FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 = Math.min(
+  Math.floor((CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1 - 1) / 3),
+  1_364,
+);
+
+export interface FinalizedVmChainScannerConfigV1 {
+  readonly networkId: NetworkIdV1;
+  readonly chainId: ChainIdV1;
+  readonly contextGraphStorageAddress: EvmAddressV1;
+  readonly knowledgeAssetStorageAddress: EvmAddressV1;
+  readonly snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1;
+}
+
+export interface FinalizedVmChainScanRequestV1 {
+  readonly contextGraphId: DecimalU256V1;
+  readonly signal: AbortSignal;
+}
+
+/** Chain-authenticated assertion identity before subgraph placement is joined. */
+export interface FinalizedVmChainCandidateV1 {
+  readonly chainId: ChainIdV1;
+  readonly contractAddress: EvmAddressV1;
+  readonly ordinal: DecimalU64V1;
+  readonly kaId: string;
+  readonly ual: string;
+  readonly authorAddress: EvmAddressV1;
+  readonly assertionVersion: DecimalU64V1;
+  readonly assertionRoot: Digest32V1;
+  readonly finalizedBlockNumber: BlockNumberV1;
+  readonly finalizedBlockHash: Digest32V1;
+}
+
+export interface FinalizedVmChainInventoryV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: DecimalU256V1;
+  readonly chainId: ChainIdV1;
+  readonly contractAddress: EvmAddressV1;
+  readonly finalizedBlockNumber: BlockNumberV1;
+  readonly finalizedBlockHash: Digest32V1;
+  readonly highestFinalizedOrdinal: DecimalU64V1 | null;
+  readonly rows: readonly Readonly<FinalizedVmChainCandidateV1>[];
+}
+
+export interface FinalizedVmChainScannerV1 {
+  (request: FinalizedVmChainScanRequestV1): Promise<Readonly<FinalizedVmChainInventoryV1>>;
+}
+
+interface ScannerConfigSnapshotV1 {
+  readonly networkId: NetworkIdV1;
+  readonly chainId: ChainIdV1;
+  readonly contextGraphStorageAddress: EvmAddressV1;
+  readonly knowledgeAssetStorageAddress: EvmAddressV1;
+  readonly snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1;
+}
+
+/**
+ * Build one bounded finalized-chain ordinal scanner.
+ *
+ * The scanner deliberately stops at chain-authenticated candidates. It does
+ * not guess a subgraph or manufacture placementEvidenceDigest; the RFC-64
+ * placement layer must join author-authorized catalog/placement evidence later.
+ */
+export function createFinalizedVmChainScannerV1(
+  input: FinalizedVmChainScannerConfigV1,
+): FinalizedVmChainScannerV1 {
+  const config = snapshotConfig(input);
+  const scan: FinalizedVmChainScannerV1 = async (inputRequest) => {
+    const request = snapshotRequest(inputRequest);
+    return config.snapshot({ chainId: config.chainId, signal: request.signal }, async (session) =>
+      scanPinnedInventory(config, request.contextGraphId, session));
+  };
+  return Object.freeze(scan);
+}
+
+async function scanPinnedInventory(
+  config: ScannerConfigSnapshotV1,
+  contextGraphId: DecimalU256V1,
+  session: StrictCurrentFinalizedEvmSnapshotSessionV1,
+): Promise<Readonly<FinalizedVmChainInventoryV1>> {
+  if (session.chainId !== config.chainId) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'chain-mismatch',
+      `Finalized VM snapshot returned chain ${session.chainId}, expected ${config.chainId}`,
+    );
+  }
+  try {
+    assertCanonicalDecimalU64(session.blockNumber, 'finalized VM snapshot block number');
+    assertCanonicalDigest(session.blockHash, 'finalized VM snapshot block hash');
+    if (typeof session.read !== 'function') throw new Error('snapshot read is not callable');
+  } catch (cause) {
+    throw malformedReturn('Finalized VM snapshot returned a malformed anchor capability', cause);
+  }
+  const contextGraphIdValue = BigInt(contextGraphId);
+  const [encodedCount] = await session.read(Object.freeze([Object.freeze({
+    to: config.contextGraphStorageAddress,
+    data: CONTEXT_GRAPH_STORAGE_INTERFACE.encodeFunctionData(
+      'getContextGraphKaCount',
+      [contextGraphIdValue],
+    ),
+    maxReturnBytes: UINT256_RETURN_BYTES,
+  })]));
+  if (encodedCount === undefined) {
+    throw malformedReturn('Finalized VM count read returned no result');
+  }
+  const rowCount = decodeUint256(
+    CONTEXT_GRAPH_STORAGE_INTERFACE,
+    'getContextGraphKaCount',
+    encodedCount,
+  );
+  if (rowCount > BigInt(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1)) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'resource-limit',
+      `Finalized VM inventory has ${rowCount} rows, above the v1 pinned-scan limit ${FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1}`,
+    );
+  }
+
+  const rowCountNumber = Number(rowCount);
+  const idCalls: StrictCurrentFinalizedEvmReadCallV1[] = [];
+  for (let ordinal = 0; ordinal < rowCountNumber; ordinal += 1) {
+    idCalls.push(Object.freeze({
+      to: config.contextGraphStorageAddress,
+      data: CONTEXT_GRAPH_STORAGE_INTERFACE.encodeFunctionData(
+        'getContextGraphKaAt',
+        [contextGraphIdValue, BigInt(ordinal)],
+      ),
+      maxReturnBytes: UINT256_RETURN_BYTES,
+    }));
+  }
+  const encodedIds = await readBatches(session, idCalls);
+  const kaIds = encodedIds.map((encoded) => decodeUint256(
+    CONTEXT_GRAPH_STORAGE_INTERFACE,
+    'getContextGraphKaAt',
+    encoded,
+  ));
+
+  const assertionCalls: StrictCurrentFinalizedEvmReadCallV1[] = [];
+  for (const kaId of kaIds) {
+    assertionCalls.push(
+      Object.freeze({
+        to: config.knowledgeAssetStorageAddress,
+        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
+          'getKnowledgeAssetUpdateContext',
+          [kaId],
+        ),
+        maxReturnBytes: UPDATE_CONTEXT_RETURN_BYTES,
+      }),
+      Object.freeze({
+        to: config.knowledgeAssetStorageAddress,
+        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
+          'getLatestMerkleRoot',
+          [kaId],
+        ),
+        maxReturnBytes: UINT256_RETURN_BYTES,
+      }),
+    );
+  }
+  const encodedAssertions = await readBatches(session, assertionCalls);
+  const rows = kaIds.map((kaId, ordinal) => {
+    const encodedContext = encodedAssertions[ordinal * 2];
+    const encodedRoot = encodedAssertions[(ordinal * 2) + 1];
+    if (encodedContext === undefined || encodedRoot === undefined) {
+      throw malformedReturn(`Finalized VM ordinal ${ordinal} is missing assertion results`);
+    }
+    const assertionVersion = decodeAssertionVersion(encodedContext);
+    const assertionRoot = decodeBytes32(
+      KNOWLEDGE_ASSET_STORAGE_INTERFACE,
+      'getLatestMerkleRoot',
+      encodedRoot,
+    );
+    const identity = unpackRootlessKaIdentity(kaId);
+    return Object.freeze({
+      chainId: config.chainId,
+      contractAddress: config.contextGraphStorageAddress,
+      ordinal: String(ordinal) as DecimalU64V1,
+      kaId: kaId.toString(10),
+      ual: `did:dkg:${config.networkId}/${identity.authorAddress}/${identity.kaNumber}`,
+      authorAddress: identity.authorAddress,
+      assertionVersion,
+      assertionRoot,
+      finalizedBlockNumber: session.blockNumber,
+      finalizedBlockHash: session.blockHash,
+    } satisfies FinalizedVmChainCandidateV1);
+  });
+
+  const highestFinalizedOrdinal = rowCount === 0n
+    ? null
+    : (rowCount - 1n).toString(10) as DecimalU64V1;
+  return Object.freeze({
+    networkId: config.networkId,
+    contextGraphId,
+    chainId: config.chainId,
+    contractAddress: config.contextGraphStorageAddress,
+    finalizedBlockNumber: session.blockNumber,
+    finalizedBlockHash: session.blockHash,
+    highestFinalizedOrdinal,
+    rows: Object.freeze(rows),
+  });
+}
+
+async function readBatches(
+  session: StrictCurrentFinalizedEvmSnapshotSessionV1,
+  calls: readonly StrictCurrentFinalizedEvmReadCallV1[],
+): Promise<readonly string[]> {
+  const results: string[] = [];
+  for (let offset = 0; offset < calls.length; offset += CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1) {
+    const batch = Object.freeze(calls.slice(
+      offset,
+      offset + CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1,
+    ));
+    const batchResults = await session.read(batch);
+    if (!Array.isArray(batchResults) || batchResults.length !== batch.length) {
+      throw malformedReturn('Finalized VM batch result count differs from its request count');
+    }
+    results.push(...batchResults);
+  }
+  return Object.freeze(results);
+}
+
+function decodeAssertionVersion(encoded: string): DecimalU64V1 {
+  const decoded = decodeCanonicalResult(
+    KNOWLEDGE_ASSET_STORAGE_INTERFACE,
+    'getKnowledgeAssetUpdateContext',
+    encoded,
+  );
+  const version = BigInt(decoded[0] as bigint).toString(10);
+  try {
+    assertCanonicalDecimalU64(version, 'finalized VM assertion version');
+  } catch (cause) {
+    throw malformedReturn('Finalized VM assertion version is outside the canonical u64 domain', cause);
+  }
+  if (version === '0') {
+    throw malformedReturn('Finalized VM assertion version must be positive');
+  }
+  return version;
+}
+
+function decodeUint256(
+  abi: ethers.Interface,
+  functionName: 'getContextGraphKaCount' | 'getContextGraphKaAt',
+  encoded: string,
+): bigint {
+  const decoded = decodeCanonicalResult(abi, functionName, encoded);
+  return BigInt(decoded[0] as bigint);
+}
+
+function decodeBytes32(
+  abi: ethers.Interface,
+  functionName: 'getLatestMerkleRoot',
+  encoded: string,
+): Digest32V1 {
+  const decoded = decodeCanonicalResult(abi, functionName, encoded);
+  const value = String(decoded[0]).toLowerCase();
+  if (!/^0x[0-9a-f]{64}$/.test(value) || value === `0x${'00'.repeat(32)}`) {
+    throw malformedReturn('Finalized VM assertion root must be a nonzero bytes32 value');
+  }
+  return value as Digest32V1;
+}
+
+function decodeCanonicalResult(
+  abi: ethers.Interface,
+  functionName: string,
+  encoded: string,
+): ethers.Result {
+  try {
+    const decoded = abi.decodeFunctionResult(functionName, encoded);
+    const canonical = abi.encodeFunctionResult(functionName, [...decoded]).toLowerCase();
+    if (canonical !== encoded) {
+      throw new Error(`${functionName} returned a non-canonical ABI encoding`);
+    }
+    return decoded;
+  } catch (cause) {
+    if (cause instanceof CurrentFinalizedEvmCallErrorV1) throw cause;
+    throw malformedReturn(`Finalized VM ${functionName} result is malformed`, cause);
+  }
+}
+
+function unpackRootlessKaIdentity(kaId: bigint): Readonly<{
+  authorAddress: EvmAddressV1;
+  kaNumber: string;
+}> {
+  const authorValue = kaId >> PACKED_KA_NUMBER_BITS;
+  if (authorValue === 0n || authorValue >= (1n << 160n)) {
+    throw malformedReturn('Finalized VM row does not use the rootless packed KA identity');
+  }
+  const authorAddress = `0x${authorValue.toString(16).padStart(40, '0')}` as EvmAddressV1;
+  const kaNumber = (kaId & PACKED_KA_NUMBER_MASK).toString(10);
+  return Object.freeze({ authorAddress, kaNumber });
+}
+
+function snapshotConfig(input: unknown): ScannerConfigSnapshotV1 {
+  try {
+    const record = snapshotExactDataRecord(input, CONFIG_KEYS);
+    assertNetworkIdV1(record.networkId, 'finalized VM scanner networkId');
+    assertCanonicalChainId(record.chainId, 'finalized VM scanner chainId');
+    assertCanonicalNonzeroEvmAddress(
+      record.contextGraphStorageAddress,
+      'finalized VM scanner ContextGraphStorage address',
+    );
+    assertCanonicalNonzeroEvmAddress(
+      record.knowledgeAssetStorageAddress,
+      'finalized VM scanner DKGKnowledgeAssets address',
+    );
+    if (typeof record.snapshot !== 'function') throw new Error('snapshot is not callable');
+    const snapshot = record.snapshot as StrictCurrentFinalizedEvmSnapshotScopeV1;
+    return Object.freeze({
+      networkId: record.networkId,
+      chainId: record.chainId,
+      contextGraphStorageAddress: record.contextGraphStorageAddress,
+      knowledgeAssetStorageAddress: record.knowledgeAssetStorageAddress,
+      snapshot,
+    });
+  } catch (cause) {
+    throw new TypeError('Finalized VM scanner configuration is invalid', { cause });
+  }
+}
+
+function snapshotRequest(input: unknown): Readonly<FinalizedVmChainScanRequestV1> {
+  try {
+    const record = snapshotExactDataRecord(input, REQUEST_KEYS);
+    assertCanonicalDecimalU256(record.contextGraphId, 'finalized VM contextGraphId');
+    if (!isAbortSignal(record.signal)) throw new Error('signal is not an AbortSignal');
+    return Object.freeze({ contextGraphId: record.contextGraphId, signal: record.signal });
+  } catch (cause) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'rpc-unavailable',
+      'Finalized VM scan request failed the fixed local profile',
+      { cause },
+    );
+  }
+}
+
+function malformedReturn(
+  message: string,
+  cause?: unknown,
+): CurrentFinalizedEvmCallErrorV1 {
+  return new CurrentFinalizedEvmCallErrorV1(
+    'malformed-return',
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}
+
+// Keep the derived public bound tied to the two snapshot budgets if either is
+// tightened later; this assertion is module-load local and performs no I/O.
+if (
+  1 + Math.ceil(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
+    + Math.ceil((FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 * 2) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
+  > CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1
+) {
+  throw new Error('Finalized VM scan row bound exceeds the pinned-snapshot batch budget');
+}

--- a/packages/chain/src/finalized-vm-chain-scanner.ts
+++ b/packages/chain/src/finalized-vm-chain-scanner.ts
@@ -42,6 +42,12 @@ const CONFIG_KEYS = Object.freeze([
   'networkId',
   'snapshot',
 ] as const);
+const SESSION_CONFIG_KEYS = Object.freeze([
+  'chainId',
+  'contextGraphStorageAddress',
+  'knowledgeAssetStorageAddress',
+  'networkId',
+] as const);
 const REQUEST_KEYS = Object.freeze(['contextGraphId', 'signal'] as const);
 const UINT256_RETURN_BYTES = 32;
 const UPDATE_CONTEXT_RETURN_BYTES = 7 * 32;
@@ -49,21 +55,28 @@ const PACKED_KA_NUMBER_BITS = 96n;
 const PACKED_KA_NUMBER_MASK = (1n << PACKED_KA_NUMBER_BITS) - 1n;
 
 /**
- * One count read plus one indexed-ID read and two assertion reads per row.
+ * One count read plus one indexed-ID read and four assertion reads per row.
  * The exact grouping below consumes one count batch, ceil(N/4) ID batches,
- * and ceil(2N/4) assertion batches. 1,364 is the largest N that stays inside
- * both the pinned-snapshot batch and call budgets.
+ * and N assertion batches. The exported ceiling is derived from both the
+ * pinned-snapshot batch and call budgets rather than copied as a magic limit.
  */
 export const FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 = Math.min(
-  Math.floor((CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1 - 1) / 3),
-  1_364,
+  Math.floor((CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1 - 1) / 5),
+  Math.floor(
+    ((CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1 - 1)
+      * CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1) / 5,
+  ),
 );
 
-export interface FinalizedVmChainScannerConfigV1 {
+export interface FinalizedVmChainSessionScannerConfigV1 {
   readonly networkId: NetworkIdV1;
   readonly chainId: ChainIdV1;
   readonly contextGraphStorageAddress: EvmAddressV1;
   readonly knowledgeAssetStorageAddress: EvmAddressV1;
+}
+
+export interface FinalizedVmChainScannerConfigV1
+  extends FinalizedVmChainSessionScannerConfigV1 {
   readonly snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1;
 }
 
@@ -76,10 +89,15 @@ export interface FinalizedVmChainScanRequestV1 {
 export interface FinalizedVmChainCandidateV1 {
   readonly chainId: ChainIdV1;
   readonly contractAddress: EvmAddressV1;
+  readonly knowledgeAssetStorageAddress: EvmAddressV1;
   readonly ordinal: DecimalU64V1;
   readonly kaId: string;
   readonly ual: string;
   readonly authorAddress: EvmAddressV1;
+  /** Latest chain-verified author attestation; null is explicit legacy/incomplete state. */
+  readonly attestedAuthorAddress: EvmAddressV1 | null;
+  /** EOA that submitted the latest root; curated admission consumes this chain truth. */
+  readonly publisherAddress: EvmAddressV1 | null;
   readonly assertionVersion: DecimalU64V1;
   readonly assertionRoot: Digest32V1;
   readonly finalizedBlockNumber: BlockNumberV1;
@@ -91,6 +109,7 @@ export interface FinalizedVmChainInventoryV1 {
   readonly contextGraphId: DecimalU256V1;
   readonly chainId: ChainIdV1;
   readonly contractAddress: EvmAddressV1;
+  readonly knowledgeAssetStorageAddress: EvmAddressV1;
   readonly finalizedBlockNumber: BlockNumberV1;
   readonly finalizedBlockHash: Digest32V1;
   readonly highestFinalizedOrdinal: DecimalU64V1 | null;
@@ -101,11 +120,14 @@ export interface FinalizedVmChainScannerV1 {
   (request: FinalizedVmChainScanRequestV1): Promise<Readonly<FinalizedVmChainInventoryV1>>;
 }
 
-interface ScannerConfigSnapshotV1 {
+interface ScannerSessionConfigSnapshotV1 {
   readonly networkId: NetworkIdV1;
   readonly chainId: ChainIdV1;
   readonly contextGraphStorageAddress: EvmAddressV1;
   readonly knowledgeAssetStorageAddress: EvmAddressV1;
+}
+
+interface ScannerConfigSnapshotV1 extends ScannerSessionConfigSnapshotV1 {
   readonly snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1;
 }
 
@@ -128,8 +150,23 @@ export function createFinalizedVmChainScannerV1(
   return Object.freeze(scan);
 }
 
+/**
+ * Scan inside a caller-owned snapshot session. Runtime composition uses this
+ * seam to read the CG policy/name binding and VM inventory at one exact anchor
+ * instead of opening a second independently finalized view.
+ */
+export function scanFinalizedVmChainInventoryInSnapshotV1(
+  input: FinalizedVmChainSessionScannerConfigV1,
+  inputRequest: FinalizedVmChainScanRequestV1,
+  session: StrictCurrentFinalizedEvmSnapshotSessionV1,
+): Promise<Readonly<FinalizedVmChainInventoryV1>> {
+  const config = snapshotSessionConfig(input);
+  const request = snapshotRequest(inputRequest);
+  return scanPinnedInventory(config, request.contextGraphId, session);
+}
+
 async function scanPinnedInventory(
-  config: ScannerConfigSnapshotV1,
+  config: ScannerSessionConfigSnapshotV1,
   contextGraphId: DecimalU256V1,
   session: StrictCurrentFinalizedEvmSnapshotSessionV1,
 ): Promise<Readonly<FinalizedVmChainInventoryV1>> {
@@ -208,13 +245,37 @@ async function scanPinnedInventory(
         ),
         maxReturnBytes: UINT256_RETURN_BYTES,
       }),
+      Object.freeze({
+        to: config.knowledgeAssetStorageAddress,
+        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
+          'getLatestMerkleRootAuthor',
+          [kaId],
+        ),
+        maxReturnBytes: UINT256_RETURN_BYTES,
+      }),
+      Object.freeze({
+        to: config.knowledgeAssetStorageAddress,
+        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
+          'getLatestMerkleRootPublisher',
+          [kaId],
+        ),
+        maxReturnBytes: UINT256_RETURN_BYTES,
+      }),
     );
   }
   const encodedAssertions = await readBatches(session, assertionCalls);
   const rows = kaIds.map((kaId, ordinal) => {
-    const encodedContext = encodedAssertions[ordinal * 2];
-    const encodedRoot = encodedAssertions[(ordinal * 2) + 1];
-    if (encodedContext === undefined || encodedRoot === undefined) {
+    const offset = ordinal * 4;
+    const encodedContext = encodedAssertions[offset];
+    const encodedRoot = encodedAssertions[offset + 1];
+    const encodedAuthor = encodedAssertions[offset + 2];
+    const encodedPublisher = encodedAssertions[offset + 3];
+    if (
+      encodedContext === undefined
+      || encodedRoot === undefined
+      || encodedAuthor === undefined
+      || encodedPublisher === undefined
+    ) {
       throw malformedReturn(`Finalized VM ordinal ${ordinal} is missing assertion results`);
     }
     const assertionVersion = decodeAssertionVersion(encodedContext);
@@ -224,13 +285,34 @@ async function scanPinnedInventory(
       encodedRoot,
     );
     const identity = unpackRootlessKaIdentity(kaId);
+    const attestedAuthorAddress = decodeNullableAddress(
+      KNOWLEDGE_ASSET_STORAGE_INTERFACE,
+      'getLatestMerkleRootAuthor',
+      encodedAuthor,
+    );
+    const publisherAddress = decodeNullableAddress(
+      KNOWLEDGE_ASSET_STORAGE_INTERFACE,
+      'getLatestMerkleRootPublisher',
+      encodedPublisher,
+    );
+    if (
+      attestedAuthorAddress !== null
+      && attestedAuthorAddress !== identity.authorAddress
+    ) {
+      throw malformedReturn(
+        `Finalized VM ordinal ${ordinal} author attestation differs from its packed KA identity`,
+      );
+    }
     return Object.freeze({
       chainId: config.chainId,
       contractAddress: config.contextGraphStorageAddress,
+      knowledgeAssetStorageAddress: config.knowledgeAssetStorageAddress,
       ordinal: String(ordinal) as DecimalU64V1,
       kaId: kaId.toString(10),
       ual: `did:dkg:${config.networkId}/${identity.authorAddress}/${identity.kaNumber}`,
       authorAddress: identity.authorAddress,
+      attestedAuthorAddress,
+      publisherAddress,
       assertionVersion,
       assertionRoot,
       finalizedBlockNumber: session.blockNumber,
@@ -246,6 +328,7 @@ async function scanPinnedInventory(
     contextGraphId,
     chainId: config.chainId,
     contractAddress: config.contextGraphStorageAddress,
+    knowledgeAssetStorageAddress: config.knowledgeAssetStorageAddress,
     finalizedBlockNumber: session.blockNumber,
     finalizedBlockHash: session.blockHash,
     highestFinalizedOrdinal,
@@ -312,6 +395,22 @@ function decodeBytes32(
   return value as Digest32V1;
 }
 
+function decodeNullableAddress(
+  abi: ethers.Interface,
+  functionName: 'getLatestMerkleRootAuthor' | 'getLatestMerkleRootPublisher',
+  encoded: string,
+): EvmAddressV1 | null {
+  const decoded = decodeCanonicalResult(abi, functionName, encoded);
+  const value = String(decoded[0]).toLowerCase();
+  if (value === ethers.ZeroAddress) return null;
+  try {
+    assertCanonicalNonzeroEvmAddress(value, `finalized VM ${functionName} address`);
+  } catch (cause) {
+    throw malformedReturn(`Finalized VM ${functionName} address is malformed`, cause);
+  }
+  return value;
+}
+
 function decodeCanonicalResult(
   abi: ethers.Interface,
   functionName: string,
@@ -370,6 +469,30 @@ function snapshotConfig(input: unknown): ScannerConfigSnapshotV1 {
   }
 }
 
+function snapshotSessionConfig(input: unknown): ScannerSessionConfigSnapshotV1 {
+  try {
+    const record = snapshotExactDataRecord(input, SESSION_CONFIG_KEYS);
+    assertNetworkIdV1(record.networkId, 'finalized VM scanner networkId');
+    assertCanonicalChainId(record.chainId, 'finalized VM scanner chainId');
+    assertCanonicalNonzeroEvmAddress(
+      record.contextGraphStorageAddress,
+      'finalized VM scanner ContextGraphStorage address',
+    );
+    assertCanonicalNonzeroEvmAddress(
+      record.knowledgeAssetStorageAddress,
+      'finalized VM scanner DKGKnowledgeAssets address',
+    );
+    return Object.freeze({
+      networkId: record.networkId,
+      chainId: record.chainId,
+      contextGraphStorageAddress: record.contextGraphStorageAddress,
+      knowledgeAssetStorageAddress: record.knowledgeAssetStorageAddress,
+    });
+  } catch (cause) {
+    throw new TypeError('Finalized VM session scanner configuration is invalid', { cause });
+  }
+}
+
 function snapshotRequest(input: unknown): Readonly<FinalizedVmChainScanRequestV1> {
   try {
     const record = snapshotExactDataRecord(input, REQUEST_KEYS);
@@ -400,7 +523,7 @@ function malformedReturn(
 // tightened later; this assertion is module-load local and performs no I/O.
 if (
   1 + Math.ceil(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
-    + Math.ceil((FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 * 2) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
+    + Math.ceil((FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 * 4) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
   > CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1
 ) {
   throw new Error('Finalized VM scan row bound exceeds the pinned-snapshot batch budget');

--- a/packages/chain/src/finalized-vm-chain-scanner.ts
+++ b/packages/chain/src/finalized-vm-chain-scanner.ts
@@ -493,23 +493,11 @@ function decodeCanonicalResult(
 function snapshotConfig(input: unknown): ScannerConfigSnapshotV1 {
   try {
     const record = snapshotExactDataRecord(input, CONFIG_KEYS);
-    assertNetworkIdV1(record.networkId, 'finalized VM scanner networkId');
-    assertCanonicalChainId(record.chainId, 'finalized VM scanner chainId');
-    assertCanonicalNonzeroEvmAddress(
-      record.contextGraphStorageAddress,
-      'finalized VM scanner ContextGraphStorage address',
-    );
-    assertCanonicalNonzeroEvmAddress(
-      record.knowledgeAssetStorageAddress,
-      'finalized VM scanner DKGKnowledgeAssets address',
-    );
+    const sessionConfig = snapshotSessionConfigFields(record);
     if (typeof record.snapshot !== 'function') throw new Error('snapshot is not callable');
     const snapshot = record.snapshot as StrictCurrentFinalizedEvmSnapshotScopeV1;
     return Object.freeze({
-      networkId: record.networkId,
-      chainId: record.chainId,
-      contextGraphStorageAddress: record.contextGraphStorageAddress,
-      knowledgeAssetStorageAddress: record.knowledgeAssetStorageAddress,
+      ...sessionConfig,
       snapshot,
     });
   } catch (cause) {
@@ -520,25 +508,31 @@ function snapshotConfig(input: unknown): ScannerConfigSnapshotV1 {
 function snapshotSessionConfig(input: unknown): ScannerSessionConfigSnapshotV1 {
   try {
     const record = snapshotExactDataRecord(input, SESSION_CONFIG_KEYS);
-    assertNetworkIdV1(record.networkId, 'finalized VM scanner networkId');
-    assertCanonicalChainId(record.chainId, 'finalized VM scanner chainId');
-    assertCanonicalNonzeroEvmAddress(
-      record.contextGraphStorageAddress,
-      'finalized VM scanner ContextGraphStorage address',
-    );
-    assertCanonicalNonzeroEvmAddress(
-      record.knowledgeAssetStorageAddress,
-      'finalized VM scanner DKGKnowledgeAssets address',
-    );
-    return Object.freeze({
-      networkId: record.networkId,
-      chainId: record.chainId,
-      contextGraphStorageAddress: record.contextGraphStorageAddress,
-      knowledgeAssetStorageAddress: record.knowledgeAssetStorageAddress,
-    });
+    return snapshotSessionConfigFields(record);
   } catch (cause) {
     throw new TypeError('Finalized VM session scanner configuration is invalid', { cause });
   }
+}
+
+function snapshotSessionConfigFields(
+  record: Record<string, unknown>,
+): ScannerSessionConfigSnapshotV1 {
+  assertNetworkIdV1(record.networkId, 'finalized VM scanner networkId');
+  assertCanonicalChainId(record.chainId, 'finalized VM scanner chainId');
+  assertCanonicalNonzeroEvmAddress(
+    record.contextGraphStorageAddress,
+    'finalized VM scanner ContextGraphStorage address',
+  );
+  assertCanonicalNonzeroEvmAddress(
+    record.knowledgeAssetStorageAddress,
+    'finalized VM scanner DKGKnowledgeAssets address',
+  );
+  return Object.freeze({
+    networkId: record.networkId,
+    chainId: record.chainId,
+    contextGraphStorageAddress: record.contextGraphStorageAddress,
+    knowledgeAssetStorageAddress: record.knowledgeAssetStorageAddress,
+  });
 }
 
 function snapshotRequest(input: unknown): Readonly<FinalizedVmChainScanRequestV1> {

--- a/packages/chain/src/finalized-vm-chain-scanner.ts
+++ b/packages/chain/src/finalized-vm-chain-scanner.ts
@@ -4,6 +4,7 @@ import {
   assertCanonicalDecimalU64,
   assertCanonicalDigest,
   assertNetworkIdV1,
+  unpackDeterministicRootlessKnowledgeAssetId,
   type BlockNumberV1,
   type ChainIdV1,
   type DecimalU256V1,
@@ -51,21 +52,20 @@ const SESSION_CONFIG_KEYS = Object.freeze([
 const REQUEST_KEYS = Object.freeze(['contextGraphId', 'signal'] as const);
 const UINT256_RETURN_BYTES = 32;
 const UPDATE_CONTEXT_RETURN_BYTES = 7 * 32;
-const PACKED_KA_NUMBER_BITS = 96n;
-const PACKED_KA_NUMBER_MASK = (1n << PACKED_KA_NUMBER_BITS) - 1n;
+const FIXED_SCAN_CALLS = 2;
+const ID_CALLS_PER_ROW = 1;
+const ASSERTION_CALLS_PER_ROW = 4;
+const TOTAL_CALLS_PER_ROW = ID_CALLS_PER_ROW + ASSERTION_CALLS_PER_ROW;
 
 /**
- * One count read plus one indexed-ID read and four assertion reads per row.
- * The exact grouping below consumes one count batch, ceil(N/4) ID batches,
- * and N assertion batches. The exported ceiling is derived from both the
- * pinned-snapshot batch and call budgets rather than copied as a magic limit.
+ * One active/count header plus one indexed-ID read and four assertion reads
+ * per row. The exported ceiling is derived from the exact call and batching
+ * equations so transport-budget changes cannot silently invalidate it.
  */
-export const FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 = Math.min(
-  Math.floor((CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1 - 1) / 5),
-  Math.floor(
-    ((CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1 - 1)
-      * CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1) / 5,
-  ),
+export const FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 = deriveFinalizedVmScanMaxRows(
+  CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1,
+  CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1,
+  CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1,
 );
 
 export interface FinalizedVmChainSessionScannerConfigV1 {
@@ -131,6 +131,13 @@ interface ScannerConfigSnapshotV1 extends ScannerSessionConfigSnapshotV1 {
   readonly snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1;
 }
 
+interface FinalizedVmAssertionReadV1 {
+  readonly assertionVersion: DecimalU64V1;
+  readonly assertionRoot: Digest32V1;
+  readonly attestedAuthorAddress: EvmAddressV1 | null;
+  readonly publisherAddress: EvmAddressV1 | null;
+}
+
 /**
  * Build one bounded finalized-chain ordinal scanner.
  *
@@ -184,16 +191,35 @@ async function scanPinnedInventory(
     throw malformedReturn('Finalized VM snapshot returned a malformed anchor capability', cause);
   }
   const contextGraphIdValue = BigInt(contextGraphId);
-  const [encodedCount] = await session.read(Object.freeze([Object.freeze({
-    to: config.contextGraphStorageAddress,
-    data: CONTEXT_GRAPH_STORAGE_INTERFACE.encodeFunctionData(
-      'getContextGraphKaCount',
-      [contextGraphIdValue],
-    ),
-    maxReturnBytes: UINT256_RETURN_BYTES,
-  })]));
-  if (encodedCount === undefined) {
-    throw malformedReturn('Finalized VM count read returned no result');
+  const encodedHeader = await session.read(Object.freeze([
+    Object.freeze({
+      to: config.contextGraphStorageAddress,
+      data: CONTEXT_GRAPH_STORAGE_INTERFACE.encodeFunctionData(
+        'isContextGraphActive',
+        [contextGraphIdValue],
+      ),
+      maxReturnBytes: UINT256_RETURN_BYTES,
+    }),
+    Object.freeze({
+      to: config.contextGraphStorageAddress,
+      data: CONTEXT_GRAPH_STORAGE_INTERFACE.encodeFunctionData(
+        'getContextGraphKaCount',
+        [contextGraphIdValue],
+      ),
+      maxReturnBytes: UINT256_RETURN_BYTES,
+    }),
+  ]));
+  if (!Array.isArray(encodedHeader) || encodedHeader.length !== FIXED_SCAN_CALLS) {
+    throw malformedReturn('Finalized VM context-graph header result count is invalid');
+  }
+  const [encodedActive, encodedCount] = encodedHeader;
+  if (encodedActive === undefined || encodedCount === undefined) {
+    throw malformedReturn('Finalized VM context-graph header read returned incomplete results');
+  }
+  if (!decodeBoolean(CONTEXT_GRAPH_STORAGE_INTERFACE, 'isContextGraphActive', encodedActive)) {
+    throw malformedReturn(
+      `Finalized VM context graph ${contextGraphId} is not active at the pinned anchor`,
+    );
   }
   const rowCount = decodeUint256(
     CONTEXT_GRAPH_STORAGE_INTERFACE,
@@ -226,78 +252,28 @@ async function scanPinnedInventory(
     encoded,
   ));
 
-  const assertionCalls: StrictCurrentFinalizedEvmReadCallV1[] = [];
-  for (const kaId of kaIds) {
-    assertionCalls.push(
-      Object.freeze({
-        to: config.knowledgeAssetStorageAddress,
-        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
-          'getKnowledgeAssetUpdateContext',
-          [kaId],
-        ),
-        maxReturnBytes: UPDATE_CONTEXT_RETURN_BYTES,
-      }),
-      Object.freeze({
-        to: config.knowledgeAssetStorageAddress,
-        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
-          'getLatestMerkleRoot',
-          [kaId],
-        ),
-        maxReturnBytes: UINT256_RETURN_BYTES,
-      }),
-      Object.freeze({
-        to: config.knowledgeAssetStorageAddress,
-        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
-          'getLatestMerkleRootAuthor',
-          [kaId],
-        ),
-        maxReturnBytes: UINT256_RETURN_BYTES,
-      }),
-      Object.freeze({
-        to: config.knowledgeAssetStorageAddress,
-        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
-          'getLatestMerkleRootPublisher',
-          [kaId],
-        ),
-        maxReturnBytes: UINT256_RETURN_BYTES,
-      }),
-    );
-  }
-  const encodedAssertions = await readBatches(session, assertionCalls);
+  const assertions = await readFinalizedVmAssertions(
+    session,
+    config.knowledgeAssetStorageAddress,
+    kaIds,
+  );
   const rows = kaIds.map((kaId, ordinal) => {
-    const offset = ordinal * 4;
-    const encodedContext = encodedAssertions[offset];
-    const encodedRoot = encodedAssertions[offset + 1];
-    const encodedAuthor = encodedAssertions[offset + 2];
-    const encodedPublisher = encodedAssertions[offset + 3];
-    if (
-      encodedContext === undefined
-      || encodedRoot === undefined
-      || encodedAuthor === undefined
-      || encodedPublisher === undefined
-    ) {
+    const assertion = assertions[ordinal];
+    if (assertion === undefined) {
       throw malformedReturn(`Finalized VM ordinal ${ordinal} is missing assertion results`);
     }
-    const assertionVersion = decodeAssertionVersion(encodedContext);
-    const assertionRoot = decodeBytes32(
-      KNOWLEDGE_ASSET_STORAGE_INTERFACE,
-      'getLatestMerkleRoot',
-      encodedRoot,
-    );
-    const identity = unpackRootlessKaIdentity(kaId);
-    const attestedAuthorAddress = decodeNullableAddress(
-      KNOWLEDGE_ASSET_STORAGE_INTERFACE,
-      'getLatestMerkleRootAuthor',
-      encodedAuthor,
-    );
-    const publisherAddress = decodeNullableAddress(
-      KNOWLEDGE_ASSET_STORAGE_INTERFACE,
-      'getLatestMerkleRootPublisher',
-      encodedPublisher,
-    );
+    let identity: ReturnType<typeof unpackDeterministicRootlessKnowledgeAssetId>;
+    try {
+      identity = unpackDeterministicRootlessKnowledgeAssetId(config.networkId, kaId);
+    } catch (cause) {
+      throw malformedReturn(
+        `Finalized VM ordinal ${ordinal} does not use the canonical rootless KA identity`,
+        cause,
+      );
+    }
     if (
-      attestedAuthorAddress !== null
-      && attestedAuthorAddress !== identity.authorAddress
+      assertion.attestedAuthorAddress !== null
+      && assertion.attestedAuthorAddress !== identity.agentAddress
     ) {
       throw malformedReturn(
         `Finalized VM ordinal ${ordinal} author attestation differs from its packed KA identity`,
@@ -308,13 +284,13 @@ async function scanPinnedInventory(
       contractAddress: config.contextGraphStorageAddress,
       knowledgeAssetStorageAddress: config.knowledgeAssetStorageAddress,
       ordinal: String(ordinal) as DecimalU64V1,
-      kaId: kaId.toString(10),
-      ual: `did:dkg:${config.networkId}/${identity.authorAddress}/${identity.kaNumber}`,
-      authorAddress: identity.authorAddress,
-      attestedAuthorAddress,
-      publisherAddress,
-      assertionVersion,
-      assertionRoot,
+      kaId: identity.kaId,
+      ual: identity.ual,
+      authorAddress: identity.agentAddress as EvmAddressV1,
+      attestedAuthorAddress: assertion.attestedAuthorAddress,
+      publisherAddress: assertion.publisherAddress,
+      assertionVersion: assertion.assertionVersion,
+      assertionRoot: assertion.assertionRoot,
       finalizedBlockNumber: session.blockNumber,
       finalizedBlockHash: session.blockHash,
     } satisfies FinalizedVmChainCandidateV1);
@@ -334,6 +310,79 @@ async function scanPinnedInventory(
     highestFinalizedOrdinal,
     rows: Object.freeze(rows),
   });
+}
+
+async function readFinalizedVmAssertions(
+  session: StrictCurrentFinalizedEvmSnapshotSessionV1,
+  knowledgeAssetStorageAddress: EvmAddressV1,
+  kaIds: readonly bigint[],
+): Promise<readonly Readonly<FinalizedVmAssertionReadV1>[]> {
+  const rows: Readonly<FinalizedVmAssertionReadV1>[] = [];
+  for (const [ordinal, kaId] of kaIds.entries()) {
+    const calls = Object.freeze([
+      Object.freeze({
+        to: knowledgeAssetStorageAddress,
+        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
+          'getKnowledgeAssetUpdateContext',
+          [kaId],
+        ),
+        maxReturnBytes: UPDATE_CONTEXT_RETURN_BYTES,
+      }),
+      Object.freeze({
+        to: knowledgeAssetStorageAddress,
+        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData('getLatestMerkleRoot', [kaId]),
+        maxReturnBytes: UINT256_RETURN_BYTES,
+      }),
+      Object.freeze({
+        to: knowledgeAssetStorageAddress,
+        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
+          'getLatestMerkleRootAuthor',
+          [kaId],
+        ),
+        maxReturnBytes: UINT256_RETURN_BYTES,
+      }),
+      Object.freeze({
+        to: knowledgeAssetStorageAddress,
+        data: KNOWLEDGE_ASSET_STORAGE_INTERFACE.encodeFunctionData(
+          'getLatestMerkleRootPublisher',
+          [kaId],
+        ),
+        maxReturnBytes: UINT256_RETURN_BYTES,
+      }),
+    ] as const);
+    const encoded = await session.read(calls);
+    if (!Array.isArray(encoded) || encoded.length !== calls.length) {
+      throw malformedReturn(`Finalized VM ordinal ${ordinal} assertion batch is incomplete`);
+    }
+    const [encodedContext, encodedRoot, encodedAuthor, encodedPublisher] = encoded;
+    if (
+      encodedContext === undefined
+      || encodedRoot === undefined
+      || encodedAuthor === undefined
+      || encodedPublisher === undefined
+    ) {
+      throw malformedReturn(`Finalized VM ordinal ${ordinal} is missing assertion results`);
+    }
+    rows.push(Object.freeze({
+      assertionVersion: decodeAssertionVersion(encodedContext),
+      assertionRoot: decodeBytes32(
+        KNOWLEDGE_ASSET_STORAGE_INTERFACE,
+        'getLatestMerkleRoot',
+        encodedRoot,
+      ),
+      attestedAuthorAddress: decodeNullableAddress(
+        KNOWLEDGE_ASSET_STORAGE_INTERFACE,
+        'getLatestMerkleRootAuthor',
+        encodedAuthor,
+      ),
+      publisherAddress: decodeNullableAddress(
+        KNOWLEDGE_ASSET_STORAGE_INTERFACE,
+        'getLatestMerkleRootPublisher',
+        encodedPublisher,
+      ),
+    } satisfies FinalizedVmAssertionReadV1));
+  }
+  return Object.freeze(rows);
 }
 
 async function readBatches(
@@ -382,6 +431,18 @@ function decodeUint256(
   return BigInt(decoded[0] as bigint);
 }
 
+function decodeBoolean(
+  abi: ethers.Interface,
+  functionName: 'isContextGraphActive',
+  encoded: string,
+): boolean {
+  const decoded = decodeCanonicalResult(abi, functionName, encoded);
+  if (typeof decoded[0] !== 'boolean') {
+    throw malformedReturn(`Finalized VM ${functionName} result is not boolean`);
+  }
+  return decoded[0];
+}
+
 function decodeBytes32(
   abi: ethers.Interface,
   functionName: 'getLatestMerkleRoot',
@@ -427,19 +488,6 @@ function decodeCanonicalResult(
     if (cause instanceof CurrentFinalizedEvmCallErrorV1) throw cause;
     throw malformedReturn(`Finalized VM ${functionName} result is malformed`, cause);
   }
-}
-
-function unpackRootlessKaIdentity(kaId: bigint): Readonly<{
-  authorAddress: EvmAddressV1;
-  kaNumber: string;
-}> {
-  const authorValue = kaId >> PACKED_KA_NUMBER_BITS;
-  if (authorValue === 0n || authorValue >= (1n << 160n)) {
-    throw malformedReturn('Finalized VM row does not use the rootless packed KA identity');
-  }
-  const authorAddress = `0x${authorValue.toString(16).padStart(40, '0')}` as EvmAddressV1;
-  const kaNumber = (kaId & PACKED_KA_NUMBER_MASK).toString(10);
-  return Object.freeze({ authorAddress, kaNumber });
 }
 
 function snapshotConfig(input: unknown): ScannerConfigSnapshotV1 {
@@ -497,6 +545,7 @@ function snapshotRequest(input: unknown): Readonly<FinalizedVmChainScanRequestV1
   try {
     const record = snapshotExactDataRecord(input, REQUEST_KEYS);
     assertCanonicalDecimalU256(record.contextGraphId, 'finalized VM contextGraphId');
+    if (record.contextGraphId === '0') throw new Error('contextGraphId must be nonzero');
     if (!isAbortSignal(record.signal)) throw new Error('signal is not an AbortSignal');
     return Object.freeze({ contextGraphId: record.contextGraphId, signal: record.signal });
   } catch (cause) {
@@ -506,6 +555,28 @@ function snapshotRequest(input: unknown): Readonly<FinalizedVmChainScanRequestV1
       { cause },
     );
   }
+}
+
+function deriveFinalizedVmScanMaxRows(
+  maxCalls: number,
+  maxBatches: number,
+  maxCallsPerBatch: number,
+): number {
+  const fits = (rows: number): boolean => (
+    FIXED_SCAN_CALLS + (rows * TOTAL_CALLS_PER_ROW) <= maxCalls
+    && 1
+      + Math.ceil((rows * ID_CALLS_PER_ROW) / maxCallsPerBatch)
+      + Math.ceil((rows * ASSERTION_CALLS_PER_ROW) / maxCallsPerBatch)
+      <= maxBatches
+  );
+  let lower = 0;
+  let upper = Math.max(0, Math.floor((maxCalls - FIXED_SCAN_CALLS) / TOTAL_CALLS_PER_ROW));
+  while (lower < upper) {
+    const candidate = Math.ceil((lower + upper) / 2);
+    if (fits(candidate)) lower = candidate;
+    else upper = candidate - 1;
+  }
+  return lower;
 }
 
 function malformedReturn(
@@ -522,9 +593,18 @@ function malformedReturn(
 // Keep the derived public bound tied to the two snapshot budgets if either is
 // tightened later; this assertion is module-load local and performs no I/O.
 if (
-  1 + Math.ceil(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
-    + Math.ceil((FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 * 4) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
+  1
+    + Math.ceil(
+      (FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 * ID_CALLS_PER_ROW)
+      / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1,
+    )
+    + Math.ceil(
+      (FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 * ASSERTION_CALLS_PER_ROW)
+      / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1,
+    )
   > CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1
+  || FIXED_SCAN_CALLS + (FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 * TOTAL_CALLS_PER_ROW)
+    > CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1
 ) {
-  throw new Error('Finalized VM scan row bound exceeds the pinned-snapshot batch budget');
+  throw new Error('Finalized VM scan row bound exceeds a pinned-snapshot resource budget');
 }

--- a/packages/chain/src/finalized-vm-chain-scanner.ts
+++ b/packages/chain/src/finalized-vm-chain-scanner.ts
@@ -271,14 +271,6 @@ async function scanPinnedInventory(
         cause,
       );
     }
-    if (
-      assertion.attestedAuthorAddress !== null
-      && assertion.attestedAuthorAddress !== identity.agentAddress
-    ) {
-      throw malformedReturn(
-        `Finalized VM ordinal ${ordinal} author attestation differs from its packed KA identity`,
-      );
-    }
     return Object.freeze({
       chainId: config.chainId,
       contractAddress: config.contextGraphStorageAddress,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -47,10 +47,12 @@ export {
 export {
   FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1,
   createFinalizedVmChainScannerV1,
+  scanFinalizedVmChainInventoryInSnapshotV1,
   type FinalizedVmChainCandidateV1,
   type FinalizedVmChainInventoryV1,
   type FinalizedVmChainScanRequestV1,
   type FinalizedVmChainScannerConfigV1,
+  type FinalizedVmChainSessionScannerConfigV1,
   type FinalizedVmChainScannerV1,
 } from './finalized-vm-chain-scanner.js';
 export {

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -45,6 +45,15 @@ export {
   createFinalizedContextGraphRpcResolverV1,
 } from './finalized-context-graph-rpc-resolver.js';
 export {
+  FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1,
+  createFinalizedVmChainScannerV1,
+  type FinalizedVmChainCandidateV1,
+  type FinalizedVmChainInventoryV1,
+  type FinalizedVmChainScanRequestV1,
+  type FinalizedVmChainScannerConfigV1,
+  type FinalizedVmChainScannerV1,
+} from './finalized-vm-chain-scanner.js';
+export {
   CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1,
   createStrictCurrentFinalizedEvmChainAdapterV1,
   createStrictCurrentFinalizedEvmReadV1,

--- a/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
+++ b/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
@@ -293,7 +293,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
     }
   });
 
-  it('keeps absent chain author/publisher evidence explicit and rejects identity drift', async () => {
+  it('keeps absent evidence explicit and preserves transferred KA namespace separately', async () => {
     const noEvidence = createFinalizedVmChainScannerV1(config(scriptedSnapshot([
       activeCountResults(1n),
       [uintResult(KA_A)],
@@ -306,15 +306,22 @@ describe('RFC-64 finalized VM chain scanner', () => {
       rows: [{ attestedAuthorAddress: null, publisherAddress: null }],
     });
 
-    const wrongAuthor = createFinalizedVmChainScannerV1(config(scriptedSnapshot([
+    const transferredUpdate = createFinalizedVmChainScannerV1(config(scriptedSnapshot([
       activeCountResults(1n),
       [uintResult(KA_A)],
       assertionResults(1n, ROOT_A, AUTHOR_B, PUBLISHER_A),
     ])));
-    await expect(wrongAuthor({
+    await expect(transferredUpdate({
       contextGraphId: CG_ID,
       signal: new AbortController().signal,
-    })).rejects.toMatchObject({ code: 'malformed-return' });
+    })).resolves.toMatchObject({
+      rows: [{
+        kaId: KA_A.toString(),
+        ual: `did:dkg:${NETWORK_ID}/${AUTHOR_A}/7`,
+        authorAddress: AUTHOR_A,
+        attestedAuthorAddress: AUTHOR_B,
+      }],
+    });
   });
 
   it('scans inside a caller-owned snapshot session for same-anchor runtime composition', async () => {

--- a/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
+++ b/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
@@ -55,7 +55,7 @@ afterEach(async () => {
 
 describe('RFC-64 finalized VM chain scanner', () => {
   it('pins its complete-row ceiling to both snapshot resource budgets', () => {
-    const calls = (rows: number) => 1 + (rows * 5);
+    const calls = (rows: number) => 2 + (rows * 5);
     const batches = (rows: number) => 1
       + Math.ceil(rows / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
       + Math.ceil((rows * 4) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1);
@@ -72,7 +72,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
     const calls: Array<readonly { readonly to: string; readonly data: string }[]> = [];
     const snapshot = snapshotStub(async (batch) => {
       calls.push(batch);
-      if (calls.length === 1) return [uintResult(2n)];
+      if (calls.length === 1) return [boolResult(true), uintResult(2n)];
       if (calls.length === 2) return [uintResult(KA_A), uintResult(KA_B)];
       if (calls.length === 3) return [
         updateContextResult(2n),
@@ -137,7 +137,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
         },
       ],
     });
-    expect(calls.map((batch) => batch.length)).toEqual([1, 2, 4, 4]);
+    expect(calls.map((batch) => batch.length)).toEqual([2, 2, 4, 4]);
     expect(calls[0]![0]!.to).toBe(CG_STORAGE);
     expect(calls[1]!.every(({ to }) => to === CG_STORAGE)).toBe(true);
     expect(calls.slice(2).flat().every(({ to }) => to === KA_STORAGE)).toBe(true);
@@ -145,14 +145,15 @@ describe('RFC-64 finalized VM chain scanner', () => {
 
   it('returns a canonical empty inventory without issuing ordinal reads', async () => {
     let batches = 0;
+    const requestSignal = new AbortController().signal;
     const scanner = createFinalizedVmChainScannerV1(config(snapshotStub(async () => {
       batches += 1;
-      return [uintResult(0n)];
-    })));
+      return [boolResult(true), uintResult(0n)];
+    }, requestSignal)));
 
     await expect(scanner({
       contextGraphId: CG_ID,
-      signal: new AbortController().signal,
+      signal: requestSignal,
     })).resolves.toMatchObject({
       highestFinalizedOrdinal: null,
       rows: [],
@@ -160,11 +161,74 @@ describe('RFC-64 finalized VM chain scanner', () => {
     expect(batches).toBe(1);
   });
 
+  it('fails closed when the pinned context graph is inactive', async () => {
+    const scanner = createFinalizedVmChainScannerV1(config(scriptedSnapshot([
+      [boolResult(false), uintResult(0n)],
+    ])));
+    await expect(scanner({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ code: 'malformed-return' });
+  });
+
+  it('splits five rows into bounded ordered ID and assertion batches', async () => {
+    const batchSizes: number[] = [];
+    const kaIds = Array.from({ length: 5 }, (_, index) => pack(AUTHOR_A, BigInt(index + 1)));
+    const snapshot = snapshotStub(async (batch) => {
+      batchSizes.push(batch.length);
+      return batch.map(({ data }) => {
+        const selector = data.slice(0, 10);
+        if (selector === CG_ABI.getFunction('isContextGraphActive')!.selector) {
+          return boolResult(true);
+        }
+        if (selector === CG_ABI.getFunction('getContextGraphKaCount')!.selector) {
+          return uintResult(5n);
+        }
+        if (selector === CG_ABI.getFunction('getContextGraphKaAt')!.selector) {
+          const [, ordinal] = CG_ABI.decodeFunctionData('getContextGraphKaAt', data);
+          return uintResult(kaIds[Number(ordinal)]!);
+        }
+        if (selector === KA_ABI.getFunction('getKnowledgeAssetUpdateContext')!.selector) {
+          return updateContextResult(1n);
+        }
+        if (selector === KA_ABI.getFunction('getLatestMerkleRoot')!.selector) {
+          return bytes32Result(ROOT_A);
+        }
+        if (selector === KA_ABI.getFunction('getLatestMerkleRootAuthor')!.selector) {
+          return addressResult(AUTHOR_A);
+        }
+        if (selector === KA_ABI.getFunction('getLatestMerkleRootPublisher')!.selector) {
+          return addressResult(PUBLISHER_A);
+        }
+        throw new Error(`Unexpected selector ${selector}`);
+      });
+    });
+    const scanner = createFinalizedVmChainScannerV1(config(snapshot));
+
+    const inventory = await scanner({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    });
+
+    expect(batchSizes).toEqual([2, 4, 1, 4, 4, 4, 4, 4]);
+    expect(batchSizes.every((size) => size <= CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1))
+      .toBe(true);
+    expect(inventory.rows.map(({ kaId, ual }) => ({ kaId, ual }))).toEqual(
+      kaIds.map((kaId, index) => ({
+        kaId: kaId.toString(),
+        ual: `did:dkg:${NETWORK_ID}/${AUTHOR_A}/${index + 1}`,
+      })),
+    );
+  });
+
   it('fails before ordinal reads when the finalized inventory exceeds the v1 scope', async () => {
     let batches = 0;
     const scanner = createFinalizedVmChainScannerV1(config(snapshotStub(async () => {
       batches += 1;
-      return [uintResult(BigInt(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 + 1))];
+      return [
+        boolResult(true),
+        uintResult(BigInt(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 + 1)),
+      ];
     })));
 
     await expect(scanner({
@@ -176,10 +240,10 @@ describe('RFC-64 finalized VM chain scanner', () => {
 
   it('rejects legacy sequential ids, zero versions, zero roots, and batch shape drift', async () => {
     const cases: StrictCurrentFinalizedEvmSnapshotScopeV1[] = [
-      scriptedSnapshot([[uintResult(1n)], [uintResult(7n)], assertionResults(1n, ROOT_A, AUTHOR_A, PUBLISHER_A)]),
-      scriptedSnapshot([[uintResult(1n)], [uintResult(KA_A)], assertionResults(0n, ROOT_A, AUTHOR_A, PUBLISHER_A)]),
-      scriptedSnapshot([[uintResult(1n)], [uintResult(KA_A)], assertionResults(1n, ethers.ZeroHash, AUTHOR_A, PUBLISHER_A)]),
-      scriptedSnapshot([[uintResult(1n)], []]),
+      scriptedSnapshot([activeCountResults(1n), [uintResult(7n)], assertionResults(1n, ROOT_A, AUTHOR_A, PUBLISHER_A)]),
+      scriptedSnapshot([activeCountResults(1n), [uintResult(KA_A)], assertionResults(0n, ROOT_A, AUTHOR_A, PUBLISHER_A)]),
+      scriptedSnapshot([activeCountResults(1n), [uintResult(KA_A)], assertionResults(1n, ethers.ZeroHash, AUTHOR_A, PUBLISHER_A)]),
+      scriptedSnapshot([activeCountResults(1n), []]),
     ];
     for (const snapshot of cases) {
       const scanner = createFinalizedVmChainScannerV1(config(snapshot));
@@ -192,7 +256,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
 
   it('keeps absent chain author/publisher evidence explicit and rejects identity drift', async () => {
     const noEvidence = createFinalizedVmChainScannerV1(config(scriptedSnapshot([
-      [uintResult(1n)],
+      activeCountResults(1n),
       [uintResult(KA_A)],
       assertionResults(1n, ROOT_A, ethers.ZeroAddress, ethers.ZeroAddress),
     ])));
@@ -204,7 +268,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
     });
 
     const wrongAuthor = createFinalizedVmChainScannerV1(config(scriptedSnapshot([
-      [uintResult(1n)],
+      activeCountResults(1n),
       [uintResult(KA_A)],
       assertionResults(1n, ROOT_A, AUTHOR_B, PUBLISHER_A),
     ])));
@@ -220,7 +284,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
       blockNumber: BLOCK_NUMBER,
       blockHash: BLOCK_HASH,
       read: scriptedRead([
-        [uintResult(1n)],
+        activeCountResults(1n),
         [uintResult(KA_A)],
         assertionResults(2n, ROOT_A, AUTHOR_A, PUBLISHER_A),
       ]),
@@ -254,6 +318,10 @@ describe('RFC-64 finalized VM chain scanner', () => {
       contextGraphStorageAddress: CG_STORAGE.toUpperCase() as EvmAddressV1,
     })).toThrow(TypeError);
     await expect(malformed({
+      contextGraphId: '0' as never,
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ code: 'rpc-unavailable' });
+    await expect(malformed({
       contextGraphId: '014' as never,
       signal: new AbortController().signal,
     })).rejects.toMatchObject({ code: 'rpc-unavailable' });
@@ -279,7 +347,9 @@ describe('RFC-64 finalized VM chain scanner', () => {
           const request = call.params[0] as { readonly data?: string };
           const data = request.data ?? '';
           const selector = data.slice(0, 10);
-          if (selector === CG_ABI.getFunction('getContextGraphKaCount')!.selector) {
+          if (selector === CG_ABI.getFunction('isContextGraphActive')!.selector) {
+            sendResult(response, call, boolResult(true));
+          } else if (selector === CG_ABI.getFunction('getContextGraphKaCount')!.selector) {
             sendResult(response, call, uintResult(2n));
           } else if (selector === CG_ABI.getFunction('getContextGraphKaAt')!.selector) {
             const [, ordinal] = CG_ABI.decodeFunctionData('getContextGraphKaAt', data);
@@ -325,7 +395,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
       { ual: `did:dkg:${NETWORK_ID}/${AUTHOR_B}/9`, assertionVersion: '3', assertionRoot: ROOT_B },
     ]);
     const ethCalls = rpc.calls.filter(({ method }) => method === 'eth_call');
-    expect(ethCalls).toHaveLength(11);
+    expect(ethCalls).toHaveLength(12);
     expect(ethCalls.every(({ params }) => {
       const block = params[1] as { readonly blockHash?: unknown; readonly requireCanonical?: unknown };
       return block.blockHash === BLOCK_HASH && block.requireCanonical === true;
@@ -351,11 +421,16 @@ function sessionConfig() {
 
 function snapshotStub(
   read: StrictCurrentFinalizedEvmSnapshotSessionV1['read'],
+  expectedSignal?: AbortSignal,
 ): StrictCurrentFinalizedEvmSnapshotScopeV1 {
-  return Object.freeze(async <T>(request: { readonly chainId: ChainIdV1 }, consume: (
+  return Object.freeze(async <T>(request: {
+    readonly chainId: ChainIdV1;
+    readonly signal: AbortSignal;
+  }, consume: (
     session: StrictCurrentFinalizedEvmSnapshotSessionV1,
   ) => Promise<T>): Promise<T> => {
     expect(request.chainId).toBe(CHAIN_ID);
+    if (expectedSignal !== undefined) expect(request.signal).toBe(expectedSignal);
     return consume(Object.freeze({
       chainId: CHAIN_ID,
       blockNumber: BLOCK_NUMBER,
@@ -384,6 +459,14 @@ function pack(author: EvmAddressV1, number: bigint): bigint {
 
 function uintResult(value: bigint): string {
   return ABI.encode(['uint256'], [value]);
+}
+
+function boolResult(value: boolean): string {
+  return ABI.encode(['bool'], [value]);
+}
+
+function activeCountResults(count: bigint): readonly string[] {
+  return [boolResult(true), uintResult(count)];
 }
 
 function bytes32Result(value: string): string {

--- a/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
+++ b/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
@@ -21,7 +21,7 @@ import {
   type StrictCurrentFinalizedEvmSnapshotSessionV1,
 } from '../src/current-finalized-evm-snapshot.js';
 import { CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1 } from '../src/current-finalized-evm-read-profile.js';
-import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '../src/strict-current-finalized-evm-rpc.js';
+import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '../src/strict-current-finalized-evm-snapshot-factory.js';
 import {
   createLoopbackJsonRpcTestHarness,
   sendJsonRpcError as sendError,
@@ -304,9 +304,31 @@ describe('RFC-64 finalized VM chain scanner', () => {
     });
   });
 
-  it('rejects non-canonical ABI bytes and hostile local shapes', async () => {
+  it('rejects a decodable non-canonical ABI result at the assertion decoder', async () => {
+    let batches = 0;
+    const nonCanonicalRoot = `${bytes32Result(ROOT_A).slice(0, 2)}${bytes32Result(ROOT_A).slice(2).toUpperCase()}`;
+    const scanner = createFinalizedVmChainScannerV1(config(snapshotStub(async () => {
+      batches += 1;
+      if (batches === 1) return activeCountResults(1n);
+      if (batches === 2) return [uintResult(KA_A)];
+      return [
+        updateContextResult(2n),
+        nonCanonicalRoot,
+        addressResult(AUTHOR_A),
+        addressResult(PUBLISHER_A),
+      ];
+    })));
+
+    await expect(scanner({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ code: 'malformed-return' });
+    expect(batches).toBe(3);
+  });
+
+  it('rejects incomplete batch shapes and hostile local inputs', async () => {
     const malformed = createFinalizedVmChainScannerV1(config(snapshotStub(async () => [
-      `${uintResult(0n)}00`,
+      uintResult(0n),
     ])));
     await expect(malformed({
       contextGraphId: CG_ID,

--- a/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
+++ b/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
@@ -1,0 +1,314 @@
+import {
+  type BlockNumberV1,
+  type ChainIdV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
+} from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { loadAbi } from '../src/evm-adapter-abi.js';
+import {
+  FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1,
+  createFinalizedVmChainScannerV1,
+} from '../src/finalized-vm-chain-scanner.js';
+import {
+  CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1,
+  CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1,
+  type StrictCurrentFinalizedEvmSnapshotScopeV1,
+  type StrictCurrentFinalizedEvmSnapshotSessionV1,
+} from '../src/current-finalized-evm-snapshot.js';
+import { CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1 } from '../src/current-finalized-evm-read-profile.js';
+import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '../src/strict-current-finalized-evm-rpc.js';
+import {
+  createLoopbackJsonRpcTestHarness,
+  sendJsonRpcError as sendError,
+  sendJsonRpcResult as sendResult,
+} from './loopback-rpc-harness.js';
+
+const NETWORK_ID = 'otp:20430' as NetworkIdV1;
+const CHAIN_ID = '20430' as ChainIdV1;
+const CG_STORAGE = `0x${'11'.repeat(20)}` as EvmAddressV1;
+const KA_STORAGE = `0x${'22'.repeat(20)}` as EvmAddressV1;
+const AUTHOR_A = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as EvmAddressV1;
+const AUTHOR_B = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as EvmAddressV1;
+const ROOT_A = `0x${'aa'.repeat(32)}` as Digest32V1;
+const ROOT_B = `0x${'bb'.repeat(32)}` as Digest32V1;
+const BLOCK_HASH = `0x${'44'.repeat(32)}` as Digest32V1;
+const BLOCK_NUMBER = '123' as BlockNumberV1;
+const CG_ID = '14' as const;
+const CG_ABI = new ethers.Interface(loadAbi('ContextGraphStorage'));
+const KA_ABI = new ethers.Interface(loadAbi('DKGKnowledgeAssets'));
+const ABI = ethers.AbiCoder.defaultAbiCoder();
+const KA_A = pack(AUTHOR_A, 7n);
+const KA_B = pack(AUTHOR_B, 9n);
+
+const rpcHarness = createLoopbackJsonRpcTestHarness();
+
+afterEach(async () => {
+  await rpcHarness.stopAll();
+});
+
+describe('RFC-64 finalized VM chain scanner', () => {
+  it('pins its complete-row ceiling to both snapshot resource budgets', () => {
+    const calls = (rows: number) => 1 + (rows * 3);
+    const batches = (rows: number) => 1
+      + Math.ceil(rows / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
+      + Math.ceil((rows * 2) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1);
+
+    expect(calls(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1))
+      .toBeLessThanOrEqual(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1);
+    expect(batches(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1))
+      .toBeLessThanOrEqual(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1);
+    expect(batches(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 + 1))
+      .toBeGreaterThan(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1);
+  });
+
+  it('derives ordered rootless VM candidates from one pinned snapshot', async () => {
+    const calls: Array<readonly { readonly to: string; readonly data: string }[]> = [];
+    const snapshot = snapshotStub(async (batch) => {
+      calls.push(batch);
+      if (calls.length === 1) return [uintResult(2n)];
+      if (calls.length === 2) return [uintResult(KA_A), uintResult(KA_B)];
+      return [
+        updateContextResult(2n),
+        bytes32Result(ROOT_A),
+        updateContextResult(3n),
+        bytes32Result(ROOT_B),
+      ];
+    });
+    const scanner = createFinalizedVmChainScannerV1(config(snapshot));
+    const requestSignal = new AbortController().signal;
+
+    const inventory = await scanner({ contextGraphId: CG_ID, signal: requestSignal });
+
+    expect(Object.isFrozen(scanner)).toBe(true);
+    expect(Object.isFrozen(inventory)).toBe(true);
+    expect(Object.isFrozen(inventory.rows)).toBe(true);
+    expect(inventory).toEqual({
+      networkId: NETWORK_ID,
+      contextGraphId: CG_ID,
+      chainId: CHAIN_ID,
+      contractAddress: CG_STORAGE,
+      finalizedBlockNumber: BLOCK_NUMBER,
+      finalizedBlockHash: BLOCK_HASH,
+      highestFinalizedOrdinal: '1',
+      rows: [
+        {
+          chainId: CHAIN_ID,
+          contractAddress: CG_STORAGE,
+          ordinal: '0',
+          kaId: KA_A.toString(),
+          ual: `did:dkg:${NETWORK_ID}/${AUTHOR_A}/7`,
+          authorAddress: AUTHOR_A,
+          assertionVersion: '2',
+          assertionRoot: ROOT_A,
+          finalizedBlockNumber: BLOCK_NUMBER,
+          finalizedBlockHash: BLOCK_HASH,
+        },
+        {
+          chainId: CHAIN_ID,
+          contractAddress: CG_STORAGE,
+          ordinal: '1',
+          kaId: KA_B.toString(),
+          ual: `did:dkg:${NETWORK_ID}/${AUTHOR_B}/9`,
+          authorAddress: AUTHOR_B,
+          assertionVersion: '3',
+          assertionRoot: ROOT_B,
+          finalizedBlockNumber: BLOCK_NUMBER,
+          finalizedBlockHash: BLOCK_HASH,
+        },
+      ],
+    });
+    expect(calls.map((batch) => batch.length)).toEqual([1, 2, 4]);
+    expect(calls[0]![0]!.to).toBe(CG_STORAGE);
+    expect(calls[1]!.every(({ to }) => to === CG_STORAGE)).toBe(true);
+    expect(calls[2]!.every(({ to }) => to === KA_STORAGE)).toBe(true);
+  });
+
+  it('returns a canonical empty inventory without issuing ordinal reads', async () => {
+    let batches = 0;
+    const scanner = createFinalizedVmChainScannerV1(config(snapshotStub(async () => {
+      batches += 1;
+      return [uintResult(0n)];
+    })));
+
+    await expect(scanner({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    })).resolves.toMatchObject({
+      highestFinalizedOrdinal: null,
+      rows: [],
+    });
+    expect(batches).toBe(1);
+  });
+
+  it('fails before ordinal reads when the finalized inventory exceeds the v1 scope', async () => {
+    let batches = 0;
+    const scanner = createFinalizedVmChainScannerV1(config(snapshotStub(async () => {
+      batches += 1;
+      return [uintResult(BigInt(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 + 1))];
+    })));
+
+    await expect(scanner({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ code: 'resource-limit' });
+    expect(batches).toBe(1);
+  });
+
+  it('rejects legacy sequential ids, zero versions, zero roots, and batch shape drift', async () => {
+    const cases: StrictCurrentFinalizedEvmSnapshotScopeV1[] = [
+      scriptedSnapshot([[uintResult(1n)], [uintResult(7n)], [updateContextResult(1n), bytes32Result(ROOT_A)]]),
+      scriptedSnapshot([[uintResult(1n)], [uintResult(KA_A)], [updateContextResult(0n), bytes32Result(ROOT_A)]]),
+      scriptedSnapshot([[uintResult(1n)], [uintResult(KA_A)], [updateContextResult(1n), bytes32Result(ethers.ZeroHash)]]),
+      scriptedSnapshot([[uintResult(1n)], []]),
+    ];
+    for (const snapshot of cases) {
+      const scanner = createFinalizedVmChainScannerV1(config(snapshot));
+      await expect(scanner({
+        contextGraphId: CG_ID,
+        signal: new AbortController().signal,
+      })).rejects.toMatchObject({ code: 'malformed-return' });
+    }
+  });
+
+  it('rejects non-canonical ABI bytes and hostile local shapes', async () => {
+    const malformed = createFinalizedVmChainScannerV1(config(snapshotStub(async () => [
+      `${uintResult(0n)}00`,
+    ])));
+    await expect(malformed({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ code: 'malformed-return' });
+
+    expect(() => createFinalizedVmChainScannerV1({
+      ...config(snapshotStub(async () => [uintResult(0n)])),
+      contextGraphStorageAddress: CG_STORAGE.toUpperCase() as EvmAddressV1,
+    })).toThrow(TypeError);
+    await expect(malformed({
+      contextGraphId: '014' as never,
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ code: 'rpc-unavailable' });
+    await expect(malformed({
+      contextGraphId: CG_ID,
+      signal: {} as never,
+    })).rejects.toMatchObject({ code: 'rpc-unavailable' });
+  });
+
+  it('executes the complete scan over the real strict loopback transport', async () => {
+    const rpc = await rpcHarness.start((call, response) => {
+      switch (call.method) {
+        case 'eth_chainId':
+          sendResult(response, call, '0x4fce');
+          return;
+        case 'eth_getBlockByNumber':
+          sendResult(response, call, { number: '0x7b', hash: BLOCK_HASH });
+          return;
+        case 'eth_getCode':
+          sendResult(response, call, '0x6000');
+          return;
+        case 'eth_call': {
+          const request = call.params[0] as { readonly data?: string };
+          const data = request.data ?? '';
+          const selector = data.slice(0, 10);
+          if (selector === CG_ABI.getFunction('getContextGraphKaCount')!.selector) {
+            sendResult(response, call, uintResult(2n));
+          } else if (selector === CG_ABI.getFunction('getContextGraphKaAt')!.selector) {
+            const [, ordinal] = CG_ABI.decodeFunctionData('getContextGraphKaAt', data);
+            sendResult(response, call, uintResult(BigInt(ordinal) === 0n ? KA_A : KA_B));
+          } else if (selector === KA_ABI.getFunction('getKnowledgeAssetUpdateContext')!.selector) {
+            const [kaId] = KA_ABI.decodeFunctionData('getKnowledgeAssetUpdateContext', data);
+            sendResult(response, call, updateContextResult(BigInt(kaId) === KA_A ? 2n : 3n));
+          } else if (selector === KA_ABI.getFunction('getLatestMerkleRoot')!.selector) {
+            const [kaId] = KA_ABI.decodeFunctionData('getLatestMerkleRoot', data);
+            sendResult(response, call, bytes32Result(BigInt(kaId) === KA_A ? ROOT_A : ROOT_B));
+          } else {
+            sendError(response, call, -32601, 'unexpected eth_call selector');
+          }
+          return;
+        }
+        default:
+          sendError(response, call, -32601, 'method not found');
+      }
+    });
+    const snapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      chainId: CHAIN_ID,
+      endpoints: [rpc.url],
+    });
+    const scanner = createFinalizedVmChainScannerV1(config(snapshot));
+
+    const inventory = await scanner({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    });
+
+    expect(inventory.rows.map(({ ual, assertionVersion, assertionRoot }) => ({
+      ual,
+      assertionVersion,
+      assertionRoot,
+    }))).toEqual([
+      { ual: `did:dkg:${NETWORK_ID}/${AUTHOR_A}/7`, assertionVersion: '2', assertionRoot: ROOT_A },
+      { ual: `did:dkg:${NETWORK_ID}/${AUTHOR_B}/9`, assertionVersion: '3', assertionRoot: ROOT_B },
+    ]);
+    const ethCalls = rpc.calls.filter(({ method }) => method === 'eth_call');
+    expect(ethCalls).toHaveLength(7);
+    expect(ethCalls.every(({ params }) => {
+      const block = params[1] as { readonly blockHash?: unknown; readonly requireCanonical?: unknown };
+      return block.blockHash === BLOCK_HASH && block.requireCanonical === true;
+    })).toBe(true);
+  });
+});
+
+function config(snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1) {
+  return Object.freeze({
+    networkId: NETWORK_ID,
+    chainId: CHAIN_ID,
+    contextGraphStorageAddress: CG_STORAGE,
+    knowledgeAssetStorageAddress: KA_STORAGE,
+    snapshot,
+  });
+}
+
+function snapshotStub(
+  read: StrictCurrentFinalizedEvmSnapshotSessionV1['read'],
+): StrictCurrentFinalizedEvmSnapshotScopeV1 {
+  return Object.freeze(async <T>(request: { readonly chainId: ChainIdV1 }, consume: (
+    session: StrictCurrentFinalizedEvmSnapshotSessionV1,
+  ) => Promise<T>): Promise<T> => {
+    expect(request.chainId).toBe(CHAIN_ID);
+    return consume(Object.freeze({
+      chainId: CHAIN_ID,
+      blockNumber: BLOCK_NUMBER,
+      blockHash: BLOCK_HASH,
+      read,
+    }));
+  });
+}
+
+function scriptedSnapshot(
+  responses: readonly (readonly string[])[],
+): StrictCurrentFinalizedEvmSnapshotScopeV1 {
+  let index = 0;
+  return snapshotStub(async () => responses[index++] ?? []);
+}
+
+function pack(author: EvmAddressV1, number: bigint): bigint {
+  return (BigInt(author) << 96n) | number;
+}
+
+function uintResult(value: bigint): string {
+  return ABI.encode(['uint256'], [value]);
+}
+
+function bytes32Result(value: string): string {
+  return ABI.encode(['bytes32'], [value]);
+}
+
+function updateContextResult(version: bigint): string {
+  return ABI.encode(
+    ['uint256', 'uint256', 'uint88', 'uint40', 'uint96', 'bool', 'uint32'],
+    [version, 1n, 100n, 999n, 1n, false, 3n],
+  );
+}

--- a/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
+++ b/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
@@ -415,7 +415,9 @@ describe('RFC-64 finalized VM chain scanner', () => {
           const request = call.params[0] as { readonly data?: string };
           const data = request.data ?? '';
           const selector = data.slice(0, 10);
-          if (selector === CG_ABI.getFunction('isContextGraphActive')!.selector) {
+          if (data === '0x') {
+            sendResult(response, call, '0x');
+          } else if (selector === CG_ABI.getFunction('isContextGraphActive')!.selector) {
             sendResult(response, call, boolResult(true));
           } else if (selector === CG_ABI.getFunction('getContextGraphKaCount')!.selector) {
             sendResult(response, call, uintResult(2n));
@@ -463,7 +465,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
       { ual: `did:dkg:${NETWORK_ID}/${AUTHOR_B}/9`, assertionVersion: '3', assertionRoot: ROOT_B },
     ]);
     const ethCalls = rpc.calls.filter(({ method }) => method === 'eth_call');
-    expect(ethCalls).toHaveLength(12);
+    expect(ethCalls).toHaveLength(13);
     expect(ethCalls.every(({ params }) => {
       const block = params[1] as { readonly blockHash?: unknown; readonly requireCanonical?: unknown };
       return block.blockHash === BLOCK_HASH && block.requireCanonical === true;

--- a/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
+++ b/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
@@ -54,18 +54,57 @@ afterEach(async () => {
 });
 
 describe('RFC-64 finalized VM chain scanner', () => {
-  it('pins its complete-row ceiling to both snapshot resource budgets', () => {
-    const calls = (rows: number) => 2 + (rows * 5);
-    const batches = (rows: number) => 1
-      + Math.ceil(rows / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
-      + Math.ceil((rows * 4) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1);
+  it('executes its exported row ceiling within both snapshot resource budgets', async () => {
+    let batches = 0;
+    let calls = 0;
+    const snapshot = snapshotStub(async (batch) => {
+      batches += 1;
+      calls += batch.length;
+      return batch.map(({ data }) => {
+        const selector = data.slice(0, 10);
+        if (selector === CG_ABI.getFunction('isContextGraphActive')!.selector) {
+          return boolResult(true);
+        }
+        if (selector === CG_ABI.getFunction('getContextGraphKaCount')!.selector) {
+          return uintResult(BigInt(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1));
+        }
+        if (selector === CG_ABI.getFunction('getContextGraphKaAt')!.selector) {
+          const [, ordinal] = CG_ABI.decodeFunctionData('getContextGraphKaAt', data);
+          return uintResult(pack(AUTHOR_A, BigInt(ordinal) + 1n));
+        }
+        if (selector === KA_ABI.getFunction('getKnowledgeAssetUpdateContext')!.selector) {
+          return updateContextResult(1n);
+        }
+        if (selector === KA_ABI.getFunction('getLatestMerkleRoot')!.selector) {
+          return bytes32Result(ROOT_A);
+        }
+        if (selector === KA_ABI.getFunction('getLatestMerkleRootAuthor')!.selector) {
+          return addressResult(AUTHOR_A);
+        }
+        if (selector === KA_ABI.getFunction('getLatestMerkleRootPublisher')!.selector) {
+          return addressResult(PUBLISHER_A);
+        }
+        throw new Error(`Unexpected selector ${selector}`);
+      });
+    });
+    const scanner = createFinalizedVmChainScannerV1(config(snapshot));
 
-    expect(calls(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1))
-      .toBeLessThanOrEqual(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1);
-    expect(batches(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1))
-      .toBeLessThanOrEqual(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1);
-    expect(batches(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 + 1))
-      .toBeGreaterThan(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1);
+    const inventory = await scanner({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    });
+
+    expect(inventory.rows).toHaveLength(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1);
+    expect(inventory.rows.at(-1)?.ordinal)
+      .toBe(String(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 - 1));
+    expect(calls).toBe(2 + (FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 * 5));
+    expect(batches).toBe(
+      1
+      + Math.ceil(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
+      + FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1,
+    );
+    expect(calls).toBeLessThanOrEqual(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1);
+    expect(batches).toBeLessThanOrEqual(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1);
   });
 
   it('derives ordered rootless VM candidates from one pinned snapshot', async () => {

--- a/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
+++ b/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
@@ -12,6 +12,7 @@ import { loadAbi } from '../src/evm-adapter-abi.js';
 import {
   FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1,
   createFinalizedVmChainScannerV1,
+  scanFinalizedVmChainInventoryInSnapshotV1,
 } from '../src/finalized-vm-chain-scanner.js';
 import {
   CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_BATCHES_V1,
@@ -33,6 +34,8 @@ const CG_STORAGE = `0x${'11'.repeat(20)}` as EvmAddressV1;
 const KA_STORAGE = `0x${'22'.repeat(20)}` as EvmAddressV1;
 const AUTHOR_A = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as EvmAddressV1;
 const AUTHOR_B = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as EvmAddressV1;
+const PUBLISHER_A = '0x1111111111111111111111111111111111111111' as EvmAddressV1;
+const PUBLISHER_B = '0x3333333333333333333333333333333333333333' as EvmAddressV1;
 const ROOT_A = `0x${'aa'.repeat(32)}` as Digest32V1;
 const ROOT_B = `0x${'bb'.repeat(32)}` as Digest32V1;
 const BLOCK_HASH = `0x${'44'.repeat(32)}` as Digest32V1;
@@ -52,10 +55,10 @@ afterEach(async () => {
 
 describe('RFC-64 finalized VM chain scanner', () => {
   it('pins its complete-row ceiling to both snapshot resource budgets', () => {
-    const calls = (rows: number) => 1 + (rows * 3);
+    const calls = (rows: number) => 1 + (rows * 5);
     const batches = (rows: number) => 1
       + Math.ceil(rows / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1)
-      + Math.ceil((rows * 2) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1);
+      + Math.ceil((rows * 4) / CURRENT_FINALIZED_EVM_READ_MAX_CALLS_V1);
 
     expect(calls(FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1))
       .toBeLessThanOrEqual(CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CALLS_V1);
@@ -71,11 +74,17 @@ describe('RFC-64 finalized VM chain scanner', () => {
       calls.push(batch);
       if (calls.length === 1) return [uintResult(2n)];
       if (calls.length === 2) return [uintResult(KA_A), uintResult(KA_B)];
-      return [
+      if (calls.length === 3) return [
         updateContextResult(2n),
         bytes32Result(ROOT_A),
+        addressResult(AUTHOR_A),
+        addressResult(PUBLISHER_A),
+      ];
+      return [
         updateContextResult(3n),
         bytes32Result(ROOT_B),
+        addressResult(AUTHOR_B),
+        addressResult(PUBLISHER_B),
       ];
     });
     const scanner = createFinalizedVmChainScannerV1(config(snapshot));
@@ -91,6 +100,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
       contextGraphId: CG_ID,
       chainId: CHAIN_ID,
       contractAddress: CG_STORAGE,
+      knowledgeAssetStorageAddress: KA_STORAGE,
       finalizedBlockNumber: BLOCK_NUMBER,
       finalizedBlockHash: BLOCK_HASH,
       highestFinalizedOrdinal: '1',
@@ -98,10 +108,13 @@ describe('RFC-64 finalized VM chain scanner', () => {
         {
           chainId: CHAIN_ID,
           contractAddress: CG_STORAGE,
+          knowledgeAssetStorageAddress: KA_STORAGE,
           ordinal: '0',
           kaId: KA_A.toString(),
           ual: `did:dkg:${NETWORK_ID}/${AUTHOR_A}/7`,
           authorAddress: AUTHOR_A,
+          attestedAuthorAddress: AUTHOR_A,
+          publisherAddress: PUBLISHER_A,
           assertionVersion: '2',
           assertionRoot: ROOT_A,
           finalizedBlockNumber: BLOCK_NUMBER,
@@ -110,10 +123,13 @@ describe('RFC-64 finalized VM chain scanner', () => {
         {
           chainId: CHAIN_ID,
           contractAddress: CG_STORAGE,
+          knowledgeAssetStorageAddress: KA_STORAGE,
           ordinal: '1',
           kaId: KA_B.toString(),
           ual: `did:dkg:${NETWORK_ID}/${AUTHOR_B}/9`,
           authorAddress: AUTHOR_B,
+          attestedAuthorAddress: AUTHOR_B,
+          publisherAddress: PUBLISHER_B,
           assertionVersion: '3',
           assertionRoot: ROOT_B,
           finalizedBlockNumber: BLOCK_NUMBER,
@@ -121,10 +137,10 @@ describe('RFC-64 finalized VM chain scanner', () => {
         },
       ],
     });
-    expect(calls.map((batch) => batch.length)).toEqual([1, 2, 4]);
+    expect(calls.map((batch) => batch.length)).toEqual([1, 2, 4, 4]);
     expect(calls[0]![0]!.to).toBe(CG_STORAGE);
     expect(calls[1]!.every(({ to }) => to === CG_STORAGE)).toBe(true);
-    expect(calls[2]!.every(({ to }) => to === KA_STORAGE)).toBe(true);
+    expect(calls.slice(2).flat().every(({ to }) => to === KA_STORAGE)).toBe(true);
   });
 
   it('returns a canonical empty inventory without issuing ordinal reads', async () => {
@@ -160,9 +176,9 @@ describe('RFC-64 finalized VM chain scanner', () => {
 
   it('rejects legacy sequential ids, zero versions, zero roots, and batch shape drift', async () => {
     const cases: StrictCurrentFinalizedEvmSnapshotScopeV1[] = [
-      scriptedSnapshot([[uintResult(1n)], [uintResult(7n)], [updateContextResult(1n), bytes32Result(ROOT_A)]]),
-      scriptedSnapshot([[uintResult(1n)], [uintResult(KA_A)], [updateContextResult(0n), bytes32Result(ROOT_A)]]),
-      scriptedSnapshot([[uintResult(1n)], [uintResult(KA_A)], [updateContextResult(1n), bytes32Result(ethers.ZeroHash)]]),
+      scriptedSnapshot([[uintResult(1n)], [uintResult(7n)], assertionResults(1n, ROOT_A, AUTHOR_A, PUBLISHER_A)]),
+      scriptedSnapshot([[uintResult(1n)], [uintResult(KA_A)], assertionResults(0n, ROOT_A, AUTHOR_A, PUBLISHER_A)]),
+      scriptedSnapshot([[uintResult(1n)], [uintResult(KA_A)], assertionResults(1n, ethers.ZeroHash, AUTHOR_A, PUBLISHER_A)]),
       scriptedSnapshot([[uintResult(1n)], []]),
     ];
     for (const snapshot of cases) {
@@ -172,6 +188,56 @@ describe('RFC-64 finalized VM chain scanner', () => {
         signal: new AbortController().signal,
       })).rejects.toMatchObject({ code: 'malformed-return' });
     }
+  });
+
+  it('keeps absent chain author/publisher evidence explicit and rejects identity drift', async () => {
+    const noEvidence = createFinalizedVmChainScannerV1(config(scriptedSnapshot([
+      [uintResult(1n)],
+      [uintResult(KA_A)],
+      assertionResults(1n, ROOT_A, ethers.ZeroAddress, ethers.ZeroAddress),
+    ])));
+    await expect(noEvidence({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    })).resolves.toMatchObject({
+      rows: [{ attestedAuthorAddress: null, publisherAddress: null }],
+    });
+
+    const wrongAuthor = createFinalizedVmChainScannerV1(config(scriptedSnapshot([
+      [uintResult(1n)],
+      [uintResult(KA_A)],
+      assertionResults(1n, ROOT_A, AUTHOR_B, PUBLISHER_A),
+    ])));
+    await expect(wrongAuthor({
+      contextGraphId: CG_ID,
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ code: 'malformed-return' });
+  });
+
+  it('scans inside a caller-owned snapshot session for same-anchor runtime composition', async () => {
+    const session = Object.freeze({
+      chainId: CHAIN_ID,
+      blockNumber: BLOCK_NUMBER,
+      blockHash: BLOCK_HASH,
+      read: scriptedRead([
+        [uintResult(1n)],
+        [uintResult(KA_A)],
+        assertionResults(2n, ROOT_A, AUTHOR_A, PUBLISHER_A),
+      ]),
+    }) satisfies StrictCurrentFinalizedEvmSnapshotSessionV1;
+
+    const inventory = await scanFinalizedVmChainInventoryInSnapshotV1(
+      sessionConfig(),
+      { contextGraphId: CG_ID, signal: new AbortController().signal },
+      session,
+    );
+
+    expect(inventory.rows).toHaveLength(1);
+    expect(inventory.rows[0]).toMatchObject({
+      attestedAuthorAddress: AUTHOR_A,
+      publisherAddress: PUBLISHER_A,
+      finalizedBlockHash: BLOCK_HASH,
+    });
   });
 
   it('rejects non-canonical ABI bytes and hostile local shapes', async () => {
@@ -224,6 +290,12 @@ describe('RFC-64 finalized VM chain scanner', () => {
           } else if (selector === KA_ABI.getFunction('getLatestMerkleRoot')!.selector) {
             const [kaId] = KA_ABI.decodeFunctionData('getLatestMerkleRoot', data);
             sendResult(response, call, bytes32Result(BigInt(kaId) === KA_A ? ROOT_A : ROOT_B));
+          } else if (selector === KA_ABI.getFunction('getLatestMerkleRootAuthor')!.selector) {
+            const [kaId] = KA_ABI.decodeFunctionData('getLatestMerkleRootAuthor', data);
+            sendResult(response, call, addressResult(BigInt(kaId) === KA_A ? AUTHOR_A : AUTHOR_B));
+          } else if (selector === KA_ABI.getFunction('getLatestMerkleRootPublisher')!.selector) {
+            const [kaId] = KA_ABI.decodeFunctionData('getLatestMerkleRootPublisher', data);
+            sendResult(response, call, addressResult(BigInt(kaId) === KA_A ? PUBLISHER_A : PUBLISHER_B));
           } else {
             sendError(response, call, -32601, 'unexpected eth_call selector');
           }
@@ -253,7 +325,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
       { ual: `did:dkg:${NETWORK_ID}/${AUTHOR_B}/9`, assertionVersion: '3', assertionRoot: ROOT_B },
     ]);
     const ethCalls = rpc.calls.filter(({ method }) => method === 'eth_call');
-    expect(ethCalls).toHaveLength(7);
+    expect(ethCalls).toHaveLength(11);
     expect(ethCalls.every(({ params }) => {
       const block = params[1] as { readonly blockHash?: unknown; readonly requireCanonical?: unknown };
       return block.blockHash === BLOCK_HASH && block.requireCanonical === true;
@@ -263,11 +335,17 @@ describe('RFC-64 finalized VM chain scanner', () => {
 
 function config(snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1) {
   return Object.freeze({
+    ...sessionConfig(),
+    snapshot,
+  });
+}
+
+function sessionConfig() {
+  return Object.freeze({
     networkId: NETWORK_ID,
     chainId: CHAIN_ID,
     contextGraphStorageAddress: CG_STORAGE,
     knowledgeAssetStorageAddress: KA_STORAGE,
-    snapshot,
   });
 }
 
@@ -290,8 +368,14 @@ function snapshotStub(
 function scriptedSnapshot(
   responses: readonly (readonly string[])[],
 ): StrictCurrentFinalizedEvmSnapshotScopeV1 {
+  return snapshotStub(scriptedRead(responses));
+}
+
+function scriptedRead(
+  responses: readonly (readonly string[])[],
+): StrictCurrentFinalizedEvmSnapshotSessionV1['read'] {
   let index = 0;
-  return snapshotStub(async () => responses[index++] ?? []);
+  return async () => responses[index++] ?? [];
 }
 
 function pack(author: EvmAddressV1, number: bigint): bigint {
@@ -304,6 +388,24 @@ function uintResult(value: bigint): string {
 
 function bytes32Result(value: string): string {
   return ABI.encode(['bytes32'], [value]);
+}
+
+function addressResult(value: string): string {
+  return ABI.encode(['address'], [value]);
+}
+
+function assertionResults(
+  version: bigint,
+  root: string,
+  author: string,
+  publisher: string,
+): readonly string[] {
+  return [
+    updateContextResult(version),
+    bytes32Result(root),
+    addressResult(author),
+    addressResult(publisher),
+  ];
 }
 
 function updateContextResult(version: bigint): string {

--- a/packages/core/src/ka-content-scope.ts
+++ b/packages/core/src/ka-content-scope.ts
@@ -4,6 +4,10 @@ import {
 } from './constants.js';
 import type { MemoryLayer } from './memory-model.js';
 import { assertSafeIri, isSafeIri } from './sparql-safe.js';
+import {
+  assertNetworkIdV1,
+  type NetworkIdV1,
+} from './sync-wire-identifiers.js';
 
 /** Existing V10 KAs may be resolved through the quarantined read-only path. */
 export const LEGACY_ROOT_CONTENT_SCOPE_VERSION = 1 as const;
@@ -129,9 +133,10 @@ export function parseDeterministicKnowledgeAssetUal(
  * bits and therefore fail closed instead of aliasing a graph identity.
  */
 export function unpackDeterministicRootlessKnowledgeAssetId(
-  chainId: string,
+  networkId: NetworkIdV1,
   kaId: bigint,
 ): Readonly<DeterministicRootlessKnowledgeAssetIdentity> {
+  assertNetworkIdV1(networkId, 'rootless Knowledge Asset networkId');
   if (typeof kaId !== 'bigint' || kaId < 1n || kaId > MAX_PACKED_ROOTLESS_KNOWLEDGE_ASSET_ID) {
     throw new Error('Rootless Knowledge Asset id must be a nonzero uint256');
   }
@@ -142,7 +147,7 @@ export function unpackDeterministicRootlessKnowledgeAssetId(
   const agentAddress = `0x${authorValue.toString(16).padStart(40, '0')}`;
   const kaNumber = (kaId & MAX_KNOWLEDGE_ASSET_NUMBER).toString(10);
   const parsed = parseDeterministicKnowledgeAssetUal(
-    `did:dkg:${chainId}/${agentAddress}/${kaNumber}`,
+    `did:dkg:${networkId}/${agentAddress}/${kaNumber}`,
   );
   return Object.freeze({ ...parsed, kaId: kaId.toString(10) });
 }

--- a/packages/core/src/ka-content-scope.ts
+++ b/packages/core/src/ka-content-scope.ts
@@ -60,6 +60,12 @@ export interface DeterministicKnowledgeAssetUalParts {
   readonly kaNumber: string;
 }
 
+export interface DeterministicRootlessKnowledgeAssetIdentity
+  extends DeterministicKnowledgeAssetUalParts {
+  /** Canonical base-10 packed `(uint160(author) << 96) | uint96(number)` id. */
+  readonly kaId: string;
+}
+
 export class LegacyKnowledgeAssetReadOnlyError extends Error {
   readonly code = 'LEGACY_KA_READ_ONLY';
 
@@ -77,6 +83,8 @@ const DETERMINISTIC_KA_UAL_RE = /^did:dkg:([^/]+)\/(0x[0-9a-fA-F]{40})\/([0-9]+)
  * through the packed identity are valid graph identities.
  */
 export const MAX_KNOWLEDGE_ASSET_NUMBER = (1n << 96n) - 1n;
+const MAX_PACKED_ROOTLESS_KNOWLEDGE_ASSET_ID = (1n << 256n) - 1n;
+const PACKED_ROOTLESS_KNOWLEDGE_ASSET_NUMBER_BITS = 96n;
 
 /**
  * Parse and canonicalize the deterministic Option-1 UAL used as graph identity.
@@ -113,6 +121,30 @@ export function parseDeterministicKnowledgeAssetUal(
     agentAddress,
     kaNumber,
   };
+}
+
+/**
+ * Unpack the canonical rootless on-chain KA id into the same deterministic
+ * identity used by graph-scoped content. Legacy sequential ids have no author
+ * bits and therefore fail closed instead of aliasing a graph identity.
+ */
+export function unpackDeterministicRootlessKnowledgeAssetId(
+  chainId: string,
+  kaId: bigint,
+): Readonly<DeterministicRootlessKnowledgeAssetIdentity> {
+  if (typeof kaId !== 'bigint' || kaId < 1n || kaId > MAX_PACKED_ROOTLESS_KNOWLEDGE_ASSET_ID) {
+    throw new Error('Rootless Knowledge Asset id must be a nonzero uint256');
+  }
+  const authorValue = kaId >> PACKED_ROOTLESS_KNOWLEDGE_ASSET_NUMBER_BITS;
+  if (authorValue === 0n) {
+    throw new Error('Rootless Knowledge Asset id does not contain a packed author');
+  }
+  const agentAddress = `0x${authorValue.toString(16).padStart(40, '0')}`;
+  const kaNumber = (kaId & MAX_KNOWLEDGE_ASSET_NUMBER).toString(10);
+  const parsed = parseDeterministicKnowledgeAssetUal(
+    `did:dkg:${chainId}/${agentAddress}/${kaNumber}`,
+  );
+  return Object.freeze({ ...parsed, kaId: kaId.toString(10) });
 }
 
 export function canonicalAssertionVersion(

--- a/packages/core/test/ka-content-scope.test.ts
+++ b/packages/core/test/ka-content-scope.test.ts
@@ -10,6 +10,7 @@ import {
   parseDeterministicKnowledgeAssetUal,
   resolveKnowledgeAssetReadScope,
   resolveKnowledgeAssetWriteScope,
+  unpackDeterministicRootlessKnowledgeAssetId,
 } from '../src/index.js';
 
 const UAL = 'did:dkg:base:8453/0x70997970C51812dc3A010C7d01b50e0d17dc79C8/0007';
@@ -37,6 +38,24 @@ describe('KA content scope', () => {
 
     expect(() => parseDeterministicKnowledgeAssetUal(ual))
       .toThrow(/packed uint96 identity domain/);
+  });
+
+  it('canonically unpacks rootless ids and rejects legacy or out-of-range ids', () => {
+    const author = 0x70997970c51812dc3a010c7d01b50e0d17dc79c8n;
+    const packed = (author << 96n) | 7n;
+    expect(unpackDeterministicRootlessKnowledgeAssetId('base:8453', packed)).toEqual({
+      kaId: packed.toString(),
+      ual: CANONICAL_UAL,
+      chainId: 'base:8453',
+      agentAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      kaNumber: '7',
+    });
+    expect(() => unpackDeterministicRootlessKnowledgeAssetId('base:8453', 7n))
+      .toThrow(/packed author/);
+    expect(() => unpackDeterministicRootlessKnowledgeAssetId('base:8453', 0n))
+      .toThrow(/nonzero uint256/);
+    expect(() => unpackDeterministicRootlessKnowledgeAssetId('base:8453', 1n << 256n))
+      .toThrow(/nonzero uint256/);
   });
 
   it('derives one stable per-KA graph while assertion version remains explicit', () => {

--- a/packages/core/test/ka-content-scope.test.ts
+++ b/packages/core/test/ka-content-scope.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { NetworkIdV1 } from '../src/index.js';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   LEGACY_ROOT_CONTENT_SCOPE_VERSION,
@@ -15,6 +16,7 @@ import {
 
 const UAL = 'did:dkg:base:8453/0x70997970C51812dc3A010C7d01b50e0d17dc79C8/0007';
 const CANONICAL_UAL = 'did:dkg:base:8453/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/7';
+const NETWORK_ID = 'base:8453' as NetworkIdV1;
 
 describe('KA content scope', () => {
   it('canonicalizes a deterministic UAL and assertion version', () => {
@@ -43,19 +45,21 @@ describe('KA content scope', () => {
   it('canonically unpacks rootless ids and rejects legacy or out-of-range ids', () => {
     const author = 0x70997970c51812dc3a010c7d01b50e0d17dc79c8n;
     const packed = (author << 96n) | 7n;
-    expect(unpackDeterministicRootlessKnowledgeAssetId('base:8453', packed)).toEqual({
+    expect(unpackDeterministicRootlessKnowledgeAssetId(NETWORK_ID, packed)).toEqual({
       kaId: packed.toString(),
       ual: CANONICAL_UAL,
       chainId: 'base:8453',
       agentAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
       kaNumber: '7',
     });
-    expect(() => unpackDeterministicRootlessKnowledgeAssetId('base:8453', 7n))
+    expect(() => unpackDeterministicRootlessKnowledgeAssetId(NETWORK_ID, 7n))
       .toThrow(/packed author/);
-    expect(() => unpackDeterministicRootlessKnowledgeAssetId('base:8453', 0n))
+    expect(() => unpackDeterministicRootlessKnowledgeAssetId(NETWORK_ID, 0n))
       .toThrow(/nonzero uint256/);
-    expect(() => unpackDeterministicRootlessKnowledgeAssetId('base:8453', 1n << 256n))
+    expect(() => unpackDeterministicRootlessKnowledgeAssetId(NETWORK_ID, 1n << 256n))
       .toThrow(/nonzero uint256/);
+    expect(() => unpackDeterministicRootlessKnowledgeAssetId('base/8453' as never, packed))
+      .toThrow(/networkId grammar/);
   });
 
   it('derives one stable per-KA graph while assertion version remains explicit', () => {


### PR DESCRIPTION
## M2b — finalized VM chain scanner

Exact head: `7d44080c318a1c41e1fa944024c4f217e93423fc`

This stacked PR scans one active ContextGraphStorage inventory at the caller-owned finalized snapshot anchor, reconstructs canonical rootless KA identities, and reads each latest assertion root/version plus author/publisher chain evidence from DKGKnowledgeAssets. It deliberately stops before off-chain subgraph placement composition.

Review hardening on the exact head:
- zero/inactive graphs, row ceilings, packed-identity drift, author drift, malformed/non-canonical ABI, and cross-anchor/lane state fail closed
- scan ceiling is derived from exact call and batch equations
- decodable uppercase ABI bytes now reach and prove the canonical re-encode guard; incomplete batch shape is a separate test
- shared scanner config validation removes duplicate field checks
- same caller-owned snapshot seam keeps policy/name resolution and VM inventory composable at one anchor

Validation:
- scanner + snapshot focused: 2 files / 26 passed
- full chain unit lane: pass (37 files; 803 passed, 1 skipped)
- rdf-utils, core, and chain builds: pass
- `git diff --check`: pass

Base: `codex/rfc64-m2-pinned-finalized-snapshot`. This PR must merge only after its parent and must never target `main`.
