### PR TITLE
feat(agent): cold-start RFC-64 from provider head

### DIFF
--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -44,6 +44,7 @@ const requiredCatalogMethods = [
   'acceptRfc64CatalogAccessSnapshotV1',
   'publishAuthorCatalogGenesisV1',
   'publishAuthorCatalogExactSetSuccessorV1',
+  'synchronizeRfc64PublicCatalogFromProviderV1',
 ];
 for (const method of requiredCatalogMethods) {
   if (

--- a/packages/agent/src/dkg-agent-rfc64-catalog-sync.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-sync.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Focused DKGAgent facade for current-head discovery plus durable receiver
+ * synchronization. Keeping the orchestration here prevents the catalog
+ * lifecycle/authoring mixin from becoming the home for every RFC-64 workflow.
+ */
+
+import {
+  computeAuthorCatalogScopeDigestV1,
+  deriveAuthorCatalogScopeFromHeadV1,
+  type Digest32V1,
+} from '@origintrail-official/dkg-core';
+
+import { DKGAgentBase } from './dkg-agent-base.js';
+import type { DKGAgent } from './dkg-agent.js';
+import type { AppliedCatalogHeadSnapshotV1 } from './rfc64/inventory-v1/index.js';
+import type {
+  Rfc64PublicCatalogCurrentHeadScopeV1,
+} from './rfc64/public-catalog-current-head-discovery-v1.js';
+
+/** Explicit provider + independently accepted public-root scope for a cold pull. */
+export interface SynchronizeRfc64PublicCatalogFromProviderParamsV1 {
+  readonly remotePeerId: string;
+  readonly scope: Rfc64PublicCatalogCurrentHeadScopeV1;
+  readonly signal?: AbortSignal;
+}
+
+/** Exact durable postcondition of a successful provider synchronization. */
+export interface SynchronizeRfc64PublicCatalogFromProviderResultV1
+  extends AppliedCatalogHeadSnapshotV1 {
+  readonly providerPeerId: string;
+  readonly signatureVariantDigest: Digest32V1;
+}
+
+export class Rfc64CatalogSyncMethods extends DKGAgentBase {
+  /**
+   * Pull one provider's authenticated current public-root head and run it
+   * through the ordinary durable receiver. `null` means the provider has no
+   * applied head for the accepted scope. A non-null return proves the exact
+   * discovered head is now the receiver's durable applied-head post-read.
+   */
+  async synchronizeRfc64PublicCatalogFromProviderV1(
+    this: DKGAgent,
+    params: SynchronizeRfc64PublicCatalogFromProviderParamsV1,
+  ): Promise<SynchronizeRfc64PublicCatalogFromProviderResultV1 | null> {
+    const providerPeerId = params.remotePeerId;
+    const scope = params.scope;
+    const signal = params.signal;
+    const service = this.rfc64PublicCatalogServiceV1;
+    if (service === undefined) {
+      throw new Error('RFC-64 public catalog service is not started');
+    }
+    const synchronized = await service.synchronizeCurrentCatalogHead({
+      remotePeerId: providerPeerId,
+      scope,
+      ...(signal === undefined ? {} : { signal }),
+    });
+    if (synchronized === null) return null;
+    const catalogScope = deriveAuthorCatalogScopeFromHeadV1(
+      synchronized.head.envelope.payload,
+    );
+    const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(catalogScope);
+    const applied = this.rfc64PersistenceV1?.inventory.readAppliedCatalogHeadV1(
+      catalogScopeDigest,
+      synchronized.announcement.authorAddress,
+    ) ?? null;
+    if (
+      applied === null
+      || applied.currentCatalogHeadDigest
+        !== synchronized.announcement.catalogHeadObjectDigest
+      || applied.catalogVersion !== synchronized.announcement.catalogVersion
+    ) {
+      const failure = this.readRfc64PublicCatalogReconciliationFailureV1(
+        synchronized.announcement.catalogHeadObjectDigest,
+      );
+      throw new Error(
+        failure === null
+          ? 'RFC-64 current public catalog head did not reach its durable applied postcondition'
+          : `RFC-64 current public catalog head reconciliation failed (${failure.errorCode ?? failure.errorName})`,
+      );
+    }
+    return Object.freeze({
+      ...applied,
+      providerPeerId,
+      signatureVariantDigest: synchronized.announcement.signatureVariantDigest,
+    });
+  }
+}

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -81,6 +81,9 @@ import {
   Rfc64PublicCatalogNativeReceiverV1,
   type Rfc64PublicCatalogNativeSynchronizationEvidenceV1,
 } from './rfc64/public-catalog-native-receiver-v1.js';
+import type {
+  Rfc64PublicCatalogCurrentHeadScopeV1,
+} from './rfc64/public-catalog-current-head-discovery-v1.js';
 import { createRfc64FinalizedVmAgentPrecommitV1 } from './rfc64/finalized-vm-agent-precommit-v1.js';
 import {
   createRfc64BoundedPublicRootCatalogNativeReconcilerV1,
@@ -165,6 +168,20 @@ export interface Rfc64StagedCatalogIssuerDelegationRefV1 {
 export interface Rfc64AppliedCatalogHeadRefV1 {
   readonly catalogScopeDigest: Digest32V1;
   readonly authorAddress: EvmAddressV1;
+}
+
+/** Explicit provider + independently accepted public-root scope for a cold pull. */
+export interface SynchronizeRfc64PublicCatalogFromProviderParamsV1 {
+  readonly remotePeerId: string;
+  readonly scope: Rfc64PublicCatalogCurrentHeadScopeV1;
+  readonly signal?: AbortSignal;
+}
+
+/** Exact durable postcondition of a successful provider synchronization. */
+export interface SynchronizeRfc64PublicCatalogFromProviderResultV1
+  extends AppliedCatalogHeadSnapshotV1 {
+  readonly providerPeerId: string;
+  readonly signatureVariantDigest: Digest32V1;
 }
 
 export {
@@ -280,6 +297,15 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       controlObjects: persistence.controlObjects,
       accessPolicyAuthority: this.config.rfc64CatalogAccessPolicyAuthority,
       native: this.createRfc64PublicCatalogNativeOptionsV1(),
+      currentHeadDiscovery: {
+        readCurrentAppliedCatalogHeadDigest: async (trustedScope) => {
+          const applied = persistence.inventory.readAppliedCatalogHeadV1(
+            computeAuthorCatalogScopeDigestV1(trustedScope),
+            trustedScope.authorAddress,
+          );
+          return applied?.currentCatalogHeadDigest ?? null;
+        },
+      },
       receiver: {
         onError: (announcement, error) => {
           this.rfc64PublicCatalogReconciliationFailuresV1.record(
@@ -404,6 +430,56 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     input: AnnounceRfc64PublicCatalogHeadInputV1,
   ): Promise<AnnounceRfc64PublicCatalogHeadResultV1> {
     return this.requireRfc64PublicCatalogServiceV1().announceCatalogHead(input);
+  }
+
+  /**
+   * Pull one provider's authenticated current public-root head and run it
+   * through the ordinary durable receiver. `null` means the provider has no
+   * applied head for the accepted scope. A non-null return proves the exact
+   * discovered head is now the receiver's durable applied-head post-read.
+   */
+  async synchronizeRfc64PublicCatalogFromProviderV1(
+    this: DKGAgent,
+    params: SynchronizeRfc64PublicCatalogFromProviderParamsV1,
+  ): Promise<SynchronizeRfc64PublicCatalogFromProviderResultV1 | null> {
+    const providerPeerId = params.remotePeerId;
+    const scope = params.scope;
+    const signal = params.signal;
+    const synchronized = await this.requireRfc64PublicCatalogServiceV1()
+      .synchronizeCurrentCatalogHead({
+        remotePeerId: providerPeerId,
+        scope,
+        ...(signal === undefined ? {} : { signal }),
+      });
+    if (synchronized === null) return null;
+    const catalogScope = deriveAuthorCatalogScopeFromHeadV1(
+      synchronized.head.envelope.payload,
+    );
+    const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(catalogScope);
+    const applied = this.rfc64PersistenceV1?.inventory.readAppliedCatalogHeadV1(
+      catalogScopeDigest,
+      synchronized.announcement.authorAddress,
+    ) ?? null;
+    if (
+      applied === null
+      || applied.currentCatalogHeadDigest
+        !== synchronized.announcement.catalogHeadObjectDigest
+      || applied.catalogVersion !== synchronized.announcement.catalogVersion
+    ) {
+      const failure = this.readRfc64PublicCatalogReconciliationFailureV1(
+        synchronized.announcement.catalogHeadObjectDigest,
+      );
+      throw new Error(
+        failure === null
+          ? 'RFC-64 current public catalog head did not reach its durable applied postcondition'
+          : `RFC-64 current public catalog head reconciliation failed (${failure.errorCode ?? failure.errorName})`,
+      );
+    }
+    return Object.freeze({
+      ...applied,
+      providerPeerId,
+      signatureVariantDigest: synchronized.announcement.signatureVariantDigest,
+    });
   }
 
   /**
@@ -779,6 +855,7 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
           contentTransport: clients.contentTransport,
           controlObjects: persistence.controlObjects,
           inventory: persistence.inventory,
+          kaBundles: persistence.kaBundles,
           store: this.store,
           beforeAppliedHeadCommit: finalizedVmPrecommit,
           transportTimeoutMs: clients.transportTimeoutMs,

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -81,9 +81,6 @@ import {
   Rfc64PublicCatalogNativeReceiverV1,
   type Rfc64PublicCatalogNativeSynchronizationEvidenceV1,
 } from './rfc64/public-catalog-native-receiver-v1.js';
-import type {
-  Rfc64PublicCatalogCurrentHeadScopeV1,
-} from './rfc64/public-catalog-current-head-discovery-v1.js';
 import { createRfc64FinalizedVmAgentPrecommitV1 } from './rfc64/finalized-vm-agent-precommit-v1.js';
 import {
   createRfc64BoundedPublicRootCatalogNativeReconcilerV1,
@@ -170,19 +167,10 @@ export interface Rfc64AppliedCatalogHeadRefV1 {
   readonly authorAddress: EvmAddressV1;
 }
 
-/** Explicit provider + independently accepted public-root scope for a cold pull. */
-export interface SynchronizeRfc64PublicCatalogFromProviderParamsV1 {
-  readonly remotePeerId: string;
-  readonly scope: Rfc64PublicCatalogCurrentHeadScopeV1;
-  readonly signal?: AbortSignal;
-}
-
-/** Exact durable postcondition of a successful provider synchronization. */
-export interface SynchronizeRfc64PublicCatalogFromProviderResultV1
-  extends AppliedCatalogHeadSnapshotV1 {
-  readonly providerPeerId: string;
-  readonly signatureVariantDigest: Digest32V1;
-}
+export type {
+  SynchronizeRfc64PublicCatalogFromProviderParamsV1,
+  SynchronizeRfc64PublicCatalogFromProviderResultV1,
+} from './dkg-agent-rfc64-catalog-sync.js';
 
 export {
   RFC64_PUBLIC_CATALOG_RECONCILIATION_FAILURE_MAX_ENTRIES_V1,
@@ -430,56 +418,6 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     input: AnnounceRfc64PublicCatalogHeadInputV1,
   ): Promise<AnnounceRfc64PublicCatalogHeadResultV1> {
     return this.requireRfc64PublicCatalogServiceV1().announceCatalogHead(input);
-  }
-
-  /**
-   * Pull one provider's authenticated current public-root head and run it
-   * through the ordinary durable receiver. `null` means the provider has no
-   * applied head for the accepted scope. A non-null return proves the exact
-   * discovered head is now the receiver's durable applied-head post-read.
-   */
-  async synchronizeRfc64PublicCatalogFromProviderV1(
-    this: DKGAgent,
-    params: SynchronizeRfc64PublicCatalogFromProviderParamsV1,
-  ): Promise<SynchronizeRfc64PublicCatalogFromProviderResultV1 | null> {
-    const providerPeerId = params.remotePeerId;
-    const scope = params.scope;
-    const signal = params.signal;
-    const synchronized = await this.requireRfc64PublicCatalogServiceV1()
-      .synchronizeCurrentCatalogHead({
-        remotePeerId: providerPeerId,
-        scope,
-        ...(signal === undefined ? {} : { signal }),
-      });
-    if (synchronized === null) return null;
-    const catalogScope = deriveAuthorCatalogScopeFromHeadV1(
-      synchronized.head.envelope.payload,
-    );
-    const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(catalogScope);
-    const applied = this.rfc64PersistenceV1?.inventory.readAppliedCatalogHeadV1(
-      catalogScopeDigest,
-      synchronized.announcement.authorAddress,
-    ) ?? null;
-    if (
-      applied === null
-      || applied.currentCatalogHeadDigest
-        !== synchronized.announcement.catalogHeadObjectDigest
-      || applied.catalogVersion !== synchronized.announcement.catalogVersion
-    ) {
-      const failure = this.readRfc64PublicCatalogReconciliationFailureV1(
-        synchronized.announcement.catalogHeadObjectDigest,
-      );
-      throw new Error(
-        failure === null
-          ? 'RFC-64 current public catalog head did not reach its durable applied postcondition'
-          : `RFC-64 current public catalog head reconciliation failed (${failure.errorCode ?? failure.errorName})`,
-      );
-    }
-    return Object.freeze({
-      ...applied,
-      providerPeerId,
-      signatureVariantDigest: synchronized.announcement.signatureVariantDigest,
-    });
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -406,6 +406,7 @@ import {
   snapshotRfc64CatalogAccessPolicyAuthorityV1,
   snapshotRfc64CatalogDeploymentProfileV1,
 } from './dkg-agent-rfc64-catalog.js';
+import { Rfc64CatalogSyncMethods } from './dkg-agent-rfc64-catalog-sync.js';
 import { ContextGraphRegistryMethods } from './dkg-agent-cg-registry.js';
 import { JoinRequestMethods } from './dkg-agent-join.js';
 import { SwmSubstrateMethods } from './dkg-agent-swm-substrate.js';
@@ -3057,5 +3058,5 @@ export class DKGAgent extends DKGAgentBase {
 }
 
 
-export interface DKGAgent extends ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods {}
-applyMixins(DKGAgent, [ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods]);
+export interface DKGAgent extends ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods {}
+applyMixins(DKGAgent, [ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods]);

--- a/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
@@ -159,7 +159,11 @@ export interface Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1 {
     trustedCatalogScope: Readonly<AuthorCatalogScopeV1>,
   ) => Promise<Digest32V1 | null>;
   /** Must consult accepted current policy state, never echo the wire digest. */
-  readonly authorizeCatalogOperation: (
+  readonly authorizeCatalogOperation?: (
+    input: Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
+  ) => Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null>;
+  /** @deprecated Use authorizeCatalogOperation. */
+  readonly authorizeOpenCatalogOperation?: (
     input: Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
   ) => Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null>;
   readonly verifyIssuerSignature: (
@@ -197,6 +201,9 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1 extends Error {
  */
 export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
   #started = false;
+  readonly #authorizeCatalogOperation: (
+    input: Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
+  ) => Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null>;
 
   constructor(
     private readonly router: ProtocolRouter,
@@ -208,9 +215,7 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     if (typeof options.readCurrentAppliedCatalogHeadDigest !== 'function') {
       fail('catalog-discovery-input', 'readCurrentAppliedCatalogHeadDigest must be a function');
     }
-    if (typeof options.authorizeCatalogOperation !== 'function') {
-      fail('catalog-discovery-input', 'authorizeCatalogOperation must be a function');
-    }
+    this.#authorizeCatalogOperation = normalizeCurrentHeadDiscoveryAuthorizerV1(options);
     if (typeof options.verifyIssuerSignature !== 'function') {
       fail('catalog-discovery-input', 'verifyIssuerSignature must be a function');
     }
@@ -412,7 +417,7 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     }) satisfies Rfc64PublicCatalogCurrentHeadAuthorizationInputV1;
     let authorization: Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null;
     try {
-      authorization = await this.options.authorizeCatalogOperation(input);
+      authorization = await this.#authorizeCatalogOperation(input);
     } catch (cause) {
       fail('catalog-discovery-policy-denied', 'public catalog discovery authorization failed', cause);
     }
@@ -435,6 +440,25 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
       fail('catalog-discovery-state', 'RFC-64 current-head discovery transport is not started');
     }
   }
+}
+
+function normalizeCurrentHeadDiscoveryAuthorizerV1(
+  options: Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1,
+): (
+  input: Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
+) => Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null> {
+  const current = options.authorizeCatalogOperation;
+  const legacyOpen = options.authorizeOpenCatalogOperation;
+  if (
+    (typeof current !== 'function' && typeof legacyOpen !== 'function')
+    || (typeof current === 'function' && typeof legacyOpen === 'function')
+  ) {
+    fail(
+      'catalog-discovery-input',
+      'exactly one catalog access-policy authorizer must be configured',
+    );
+  }
+  return typeof current === 'function' ? current : legacyOpen!;
 }
 
 export function encodeRfc64PublicCatalogCurrentHeadQueryV1(

--- a/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * RFC-64 public/open current-head discovery transport.
+ * RFC-64 public-root current-head discovery transport.
  *
  * Discovery is deliberately a narrow hint protocol. A requester names one
- * independently accepted public/open catalog scope and a provider resolves it
+ * independently accepted public-root catalog scope and a provider resolves it
  * through a trusted semantic-current-head reader. Before advertising the
  * result, the provider re-reads and verifies the exact signed head object. The
  * requester must still exact-fetch and verify that object before treating the
@@ -159,7 +159,7 @@ export interface Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1 {
     trustedCatalogScope: Readonly<AuthorCatalogScopeV1>,
   ) => Promise<Digest32V1 | null>;
   /** Must consult accepted current policy state, never echo the wire digest. */
-  readonly authorizeOpenCatalogOperation: (
+  readonly authorizeCatalogOperation: (
     input: Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
   ) => Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null>;
   readonly verifyIssuerSignature: (
@@ -208,8 +208,8 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     if (typeof options.readCurrentAppliedCatalogHeadDigest !== 'function') {
       fail('catalog-discovery-input', 'readCurrentAppliedCatalogHeadDigest must be a function');
     }
-    if (typeof options.authorizeOpenCatalogOperation !== 'function') {
-      fail('catalog-discovery-input', 'authorizeOpenCatalogOperation must be a function');
+    if (typeof options.authorizeCatalogOperation !== 'function') {
+      fail('catalog-discovery-input', 'authorizeCatalogOperation must be a function');
     }
     if (typeof options.verifyIssuerSignature !== 'function') {
       fail('catalog-discovery-input', 'verifyIssuerSignature must be a function');
@@ -412,12 +412,12 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     }) satisfies Rfc64PublicCatalogCurrentHeadAuthorizationInputV1;
     let authorization: Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null;
     try {
-      authorization = await this.options.authorizeOpenCatalogOperation(input);
+      authorization = await this.options.authorizeCatalogOperation(input);
     } catch (cause) {
-      fail('catalog-discovery-policy-denied', 'open catalog discovery authorization failed', cause);
+      fail('catalog-discovery-policy-denied', 'public catalog discovery authorization failed', cause);
     }
     if (authorization === null || authorization.accessPolicy !== 0) {
-      fail('catalog-discovery-policy-denied', 'current-head discovery is not authorized by open policy');
+      fail('catalog-discovery-policy-denied', 'current-head discovery is not authorized by public policy');
     }
     try {
       assertCanonicalDigest(authorization.policyDigest, 'authorized policyDigest');

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -18,6 +18,7 @@ import {
   AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
   AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
   AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+  ASSERTION_SEAL_PREDICATES,
   DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1,
   MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1,
   ZERO_DIGEST32_V1,
@@ -814,6 +815,17 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         head,
         trustedCatalogScope,
       );
+    if (historyDisposition === 'cold-bootstrap') {
+      await assertColdBootstrapHasNoOmittedSemanticStateV1(
+        this.options.store,
+        trustedCatalogScope,
+        preparedRows.map((prepared) => transitionLocationFromTarget(
+          head,
+          prepared.row,
+          prepared.sealBinding,
+        )),
+      );
+    }
     const targetKaIds = new Set(preparedRows.map(({ row }) => row.kaId));
     const plannedRemovals = predecessorRows
       .filter((row) => !targetKaIds.has(row.kaId))
@@ -1565,6 +1577,84 @@ interface Rfc64SemanticTransitionPreimageV1
   extends Rfc64SemanticTransitionLocationV1 {
   readonly graphQuads: readonly Readonly<Quad>[];
   readonly sealQuads: readonly Readonly<Quad>[];
+}
+
+/**
+ * Missing durable history is not proof that the semantic store is empty: a
+ * process may have died after atomic activation and before the applied-head
+ * CAS. Cold bootstrap is therefore allowed only when every materialization
+ * already present for this exact author/root scope belongs to the fetched
+ * target. Matching target rows are safe repair preimages; any omitted graph or
+ * author-seal subject makes the successor fail closed before mutation/CAS.
+ */
+async function assertColdBootstrapHasNoOmittedSemanticStateV1(
+  store: TripleStore,
+  scope: Readonly<AuthorCatalogScopeV1>,
+  targets: readonly Readonly<Rfc64SemanticTransitionLocationV1>[],
+): Promise<void> {
+  const allowedGraphs = new Set(targets.map((target) => target.swmGraph));
+  const allowedSealSubjects = new Set(targets.map((target) => target.sealSubject));
+  const swmPrefix = `${contextGraphWorkspaceGraphUri(scope.contextGraphId)}`
+    + `/${scope.authorAddress}/`;
+  let existingGraphs: string[];
+  try {
+    existingGraphs = store.listGraphsByPrefix === undefined
+      ? (await store.listGraphs({ source: 'rfc64-cold-bootstrap-namespace-proof' }))
+        .filter((graph) => graph.startsWith(swmPrefix))
+      : await store.listGraphsByPrefix(
+        swmPrefix,
+        { source: 'rfc64-cold-bootstrap-namespace-proof' },
+      );
+  } catch (cause) {
+    fail(
+      'catalog-native-receiver-history',
+      'cold bootstrap could not prove the author SWM namespace is exact',
+      cause,
+    );
+  }
+  if (
+    existingGraphs.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1
+    || existingGraphs.some((graph) => !allowedGraphs.has(graph))
+  ) {
+    fail(
+      'catalog-native-receiver-history',
+      'cold bootstrap found author SWM materialization omitted by the fetched exact head',
+    );
+  }
+
+  const metaGraph = targets[0]?.sealMetaGraph;
+  if (metaGraph === undefined) {
+    fail('catalog-native-receiver-history', 'cold successor has no semantic target scope');
+  }
+  let sealSubjects;
+  try {
+    sealSubjects = await store.query(
+      `SELECT DISTINCT ?s WHERE { GRAPH <${metaGraph}> { `
+        + `?s <${ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS}> `
+        + `${JSON.stringify(scope.authorAddress)} } } `
+        + `LIMIT ${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 + 1}`,
+      {
+        source: 'rfc64-cold-bootstrap-namespace-proof',
+        maxResponseBytes: 1024 * 1024,
+      },
+    );
+  } catch (cause) {
+    fail(
+      'catalog-native-receiver-history',
+      'cold bootstrap could not prove the author-seal namespace is exact',
+      cause,
+    );
+  }
+  if (
+    sealSubjects.type !== 'bindings'
+    || sealSubjects.bindings.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1
+    || sealSubjects.bindings.some(({ s }) => typeof s !== 'string' || !allowedSealSubjects.has(s))
+  ) {
+    fail(
+      'catalog-native-receiver-history',
+      'cold bootstrap found author-seal materialization omitted by the fetched exact head',
+    );
+  }
 }
 
 function transitionLocationFromRemoval(

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -83,6 +83,7 @@ import type {
   AppliedCatalogHeadSnapshotV1,
   Rfc64InventoryV1OperationsV1,
 } from './inventory-v1/index.js';
+import type { Rfc64KaBundleOperationsV1 } from './ka-bundle-store-v1.js';
 import { assertRecoverableAuthorAttestationCapabilityV1 } from './recoverable-author-attestation-v1.js';
 import {
   computeRfc64AppliedInventoryDigestV1,
@@ -128,6 +129,8 @@ export interface Rfc64PublicCatalogNativeReceiverOptionsV1 {
     Rfc64InventoryV1OperationsV1,
     'readAppliedCatalogHeadV1' | 'compareAndSwapAppliedCatalogHeadV1'
   >;
+  /** Durable immutable cache that makes every applied receiver a provider. */
+  readonly kaBundles: Pick<Rfc64KaBundleOperationsV1, 'putKaBundle'>;
   readonly store: TripleStore;
   /**
    * Final fail-closed same-process barrier. It runs after the exact SWM
@@ -261,6 +264,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       || typeof options.controlObjects?.getVerifiedObjectByDigest !== 'function'
       || typeof options.inventory?.readAppliedCatalogHeadV1 !== 'function'
       || typeof options.inventory?.compareAndSwapAppliedCatalogHeadV1 !== 'function'
+      || typeof options.kaBundles?.putKaBundle !== 'function'
       || typeof options.store?.query !== 'function'
       || (
         options.beforeAppliedHeadCommit !== undefined
@@ -554,7 +558,11 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       catalogScopeDigest,
       head.payload.authorAddress,
     );
-    const replay = assertMonotonicSuccessorHistory(currentAppliedHead, head, expectedRowCount);
+    const historyDisposition = classifySuccessorHistory(
+      currentAppliedHead,
+      head,
+      expectedRowCount,
+    );
     const scope = nativeScope(announcement, trustedCatalogScope, head);
     const fetchedDelegation = await this.fetchDirectAuthorCatalogIssuerDelegation(
       remotePeerId,
@@ -664,6 +672,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       readonly projectionMetadata: ReturnType<typeof readVerifiedCgSharedProjectionMetadataV1>;
       readonly sealBinding: VerifiedCatalogSealBindingSnapshotV1;
       readonly sealBindingCapability: VerifiedCatalogSealBindingV1;
+      readonly bundleBytes: Uint8Array;
       readonly projectionBytes: Uint8Array;
       readonly expectedEvidence: Rfc64PublicCatalogInventoryEvidenceRowV1;
     }> = [];
@@ -763,6 +772,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         projectionMetadata,
         sealBinding,
         sealBindingCapability,
+        bundleBytes: new Uint8Array(bundle),
         projectionBytes,
         expectedEvidence,
       }));
@@ -792,17 +802,40 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     // predecessor after every target row/bundle has verified, but before the
     // first semantic mutation. This also makes exact-head replay a repair path
     // for a prior indeterminate removal failure.
-    const predecessorRows = await loadExactAppliedPredecessorRows(
-      this.options.controlObjects,
-      head,
-      trustedCatalogScope,
-    );
+    // Every bounded successor is a complete signed exact set. A receiver with
+    // no applied-head record can therefore initialize directly from the
+    // authenticated current snapshot without replaying historical versions.
+    // Existing receivers still reconstruct their exact durable predecessor so
+    // only rows owned by that applied closure may be removed.
+    const predecessorRows = historyDisposition === 'cold-bootstrap'
+      ? Object.freeze([]) as readonly Readonly<AuthorCatalogRowV1>[]
+      : await loadExactAppliedPredecessorRows(
+        this.options.controlObjects,
+        head,
+        trustedCatalogScope,
+      );
     const targetKaIds = new Set(preparedRows.map(({ row }) => row.kaId));
     const plannedRemovals = predecessorRows
       .filter((row) => !targetKaIds.has(row.kaId))
       .map((row) => planOwnedRowRemoval(trustedCatalogScope, row));
 
     try {
+      // An applied-head pointer advertises this node as a current provider, so
+      // every exact bundle must cross its immutable durability barrier before
+      // semantic activation and before that pointer can advance.
+      for (const prepared of preparedRows) {
+        const receipt = await this.options.kaBundles.putKaBundle({
+          blobDigest: prepared.row.transfer.blobDigest,
+          bundleBytes: prepared.bundleBytes,
+        });
+        if (
+          receipt.durable !== true
+          || receipt.blobDigest !== prepared.row.transfer.blobDigest
+          || receipt.byteLength.toString() !== prepared.row.transfer.byteLength
+        ) {
+          throw new Error('KA-bundle store returned a different durable receipt');
+        }
+      }
       await this.options.controlObjects.stageVerifiedObjects([
         fetchedDelegation,
         fetchedHead,
@@ -810,7 +843,11 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         fetchedBucket,
       ]);
     } catch (cause) {
-      fail('catalog-native-receiver-catalog', 'verified catalog objects could not be staged', cause);
+      fail(
+        'catalog-native-receiver-catalog',
+        'verified catalog objects or KA bundles could not be staged',
+        cause,
+      );
     }
 
     const transitionJournal = await snapshotSemanticTransitionV1(
@@ -922,7 +959,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     }
 
     let appliedHeadStatus: 'applied' | 'existing';
-    if (replay) {
+    if (historyDisposition === 'replay') {
       if (currentAppliedHead!.appliedInventoryDigest !== completion.inventoryDigest) {
         fail(
           'catalog-native-receiver-history',
@@ -935,7 +972,9 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         appliedHeadStatus = this.options.inventory.compareAndSwapAppliedCatalogHeadV1({
           catalogScopeDigest,
           authorAddress: head.payload.authorAddress,
-          expectedCurrentCatalogHeadDigest: head.payload.previousHeadDigest,
+          expectedCurrentCatalogHeadDigest: historyDisposition === 'cold-bootstrap'
+            ? null
+            : head.payload.previousHeadDigest,
           currentCatalogHeadDigest: head.objectDigest as Digest32V1,
           appliedInventoryDigest: completion.inventoryDigest,
           catalogVersion: head.payload.version,
@@ -1227,17 +1266,17 @@ function isExactEmptyGenesisSnapshot(
     && current.inventoryRowCount === '0';
 }
 
-function assertMonotonicSuccessorHistory(
+type Rfc64SuccessorHistoryDispositionV1 =
+  | 'cold-bootstrap'
+  | 'monotonic-successor'
+  | 'replay';
+
+function classifySuccessorHistory(
   current: AppliedCatalogHeadSnapshotV1 | null,
   head: SignedAuthorCatalogHeadEnvelopeV1,
   expectedRowCount: number,
-): boolean {
-  if (current === null) {
-    fail(
-      'catalog-native-receiver-history',
-      'successor requires a durable initialized predecessor head',
-    );
-  }
+): Rfc64SuccessorHistoryDispositionV1 {
+  if (current === null) return 'cold-bootstrap';
   if (current.currentCatalogHeadDigest === head.objectDigest) {
     if (
       current.catalogVersion !== head.payload.version
@@ -1245,7 +1284,7 @@ function assertMonotonicSuccessorHistory(
     ) {
       fail('catalog-native-receiver-history', 'replayed head differs from its durable applied state');
     }
-    return true;
+    return 'replay';
   }
   if (
     current.currentCatalogHeadDigest !== head.payload.previousHeadDigest
@@ -1256,7 +1295,7 @@ function assertMonotonicSuccessorHistory(
       'successor does not monotonically extend the durable current head',
     );
   }
-  return false;
+  return 'monotonic-successor';
 }
 
 function assertBoundedSuccessorHead(head: SignedAuthorCatalogHeadEnvelopeV1): number {

--- a/packages/agent/src/rfc64/public-catalog-native-reconciler-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-reconciler-v1.ts
@@ -121,6 +121,40 @@ export function deriveRfc64PublicOpenCatalogScopeV1(
   });
 }
 
+/**
+ * Derive a public root catalog scope for any accepted public policy cell,
+ * including finalized-chain policies and non-owner SWM authors. Principal
+ * authorization remains the accepted-policy registry's responsibility; this
+ * pure helper binds only the graph/governance/lane/era identity.
+ */
+export function deriveRfc64PublicRootCatalogScopeV1(
+  claim: Rfc64PublicOpenCatalogScopeClaimV1,
+  acceptedPolicy: ContextGraphPolicyV1,
+): AuthorCatalogScopeV1 {
+  if (
+    acceptedPolicy.accessPolicy !== 0
+    || acceptedPolicy.networkId !== claim.networkId
+    || acceptedPolicy.contextGraphId !== claim.contextGraphId
+    || acceptedPolicy.era !== claim.catalogEra
+    || claim.subGraphName !== null
+  ) {
+    throw new Error(
+      'RFC-64 public catalog claim is not bound to the accepted public root policy',
+    );
+  }
+  return Object.freeze({
+    networkId: acceptedPolicy.networkId,
+    contextGraphId: acceptedPolicy.contextGraphId,
+    governanceChainId: acceptedPolicy.governanceChainId,
+    governanceContractAddress: acceptedPolicy.governanceContractAddress,
+    ownershipTransitionDigest: acceptedPolicy.ownershipTransitionDigest,
+    subGraphName: null,
+    authorAddress: claim.authorAddress,
+    era: acceptedPolicy.era,
+    bucketCount: '1' as CountV1,
+  });
+}
+
 export class Rfc64BoundedPublicRootCatalogNativeReconcilerV1
   implements Rfc64PublicCatalogReceiverReconcilerV1 {
   constructor(

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -85,7 +85,6 @@ import {
   type Rfc64BoundedPublicRootCatalogTrustedScopeResolverV1,
 } from './public-catalog-native-reconciler-v1.js';
 import {
-  deriveRfc64PublicOpenCatalogScopeV1,
   deriveRfc64PublicRootCatalogScopeV1,
 } from './public-open-catalog-scope-v1.js';
 import type {
@@ -763,13 +762,7 @@ export class Rfc64PublicCatalogServiceV1 {
       })) {
         throw new Error('catalog author is not authorized by the accepted policy');
       }
-      return record.policy.source.kind === 'owner-signed-unregistered'
-        && record.policy.governanceChainId === null
-        && record.policy.governanceContractAddress === null
-        && record.policy.ownershipTransitionDigest === null
-        && record.policy.source.ownerAddress === input.authorAddress
-        ? deriveRfc64PublicOpenCatalogScopeV1(input, record.policy)
-        : deriveRfc64PublicRootCatalogScopeV1(input, record.policy);
+      return deriveRfc64PublicRootCatalogScopeV1(input, record.policy);
     } catch (cause) {
       throw new Error(
         'RFC-64 current-head query is not bound to the accepted public root policy',

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -76,8 +76,6 @@ import {
 } from './public-catalog-current-head-discovery-v1.js';
 import {
   Rfc64PublicCatalogNativeTransportV1,
-  type Rfc64PublicCatalogNativeAuthorizationInputV1,
-  type Rfc64PublicCatalogNativeAuthorizationV1,
   type Rfc64PublicCatalogNativeTransportOptionsV1,
 } from './public-catalog-native-transport-v1.js';
 import {
@@ -164,7 +162,7 @@ export interface Rfc64PublicCatalogServiceNativeOptionsV1 extends Pick<
 export interface Rfc64PublicCatalogServiceCurrentHeadDiscoveryOptionsV1 {
   /**
    * Resolve the durable semantically applied head for one locally trusted
-   * public/open root scope. Staged-only and candidate heads must not be returned.
+   * public-root scope. Staged-only and candidate heads must not be returned.
    */
   readonly readCurrentAppliedCatalogHeadDigest: (
     trustedScope: Readonly<AuthorCatalogScopeV1>,
@@ -269,7 +267,7 @@ export class Rfc64PublicCatalogServiceV1 {
 
     this.#transport = new Rfc64PublicCatalogTransportV1(options.router, {
       controlObjects: this.#controlObjects,
-      authorizeOpenCatalogOperation: this.#policies.authorize,
+      authorizeCatalogOperation: this.#policies.authorize,
       verifyIssuerSignature: this.#verifyIssuerSignature,
       // Non-blocking: schedule() enqueues synchronously so the transport's ACK
       // path (which awaits this callback) is never stalled on a fetch.
@@ -284,7 +282,7 @@ export class Rfc64PublicCatalogServiceV1 {
         controlObjects: this.#controlObjects,
         readCurrentAppliedCatalogHeadDigest:
           options.currentHeadDiscovery.readCurrentAppliedCatalogHeadDigest,
-        authorizeOpenCatalogOperation: (input) =>
+        authorizeCatalogOperation: (input) =>
           this.#authorizeCurrentHeadDiscovery(input),
         verifyIssuerSignature: this.#verifyIssuerSignature,
       });
@@ -294,7 +292,7 @@ export class Rfc64PublicCatalogServiceV1 {
       : new Rfc64PublicCatalogNativeTransportV1(options.router, {
         readCatalogObjectByDigest: options.native.readCatalogObjectByDigest,
         readKaBundleByDigest: options.native.readKaBundleByDigest,
-        authorizeOpenCatalogOperation: (input) => this.#authorizeNativeOperation(input),
+        authorizeCatalogOperation: this.#policies.authorize,
         verifyIssuerSignature: this.#verifyIssuerSignature,
       });
     const reconciler = options.native === undefined
@@ -554,7 +552,7 @@ export class Rfc64PublicCatalogServiceV1 {
   }
 
   /**
-   * Pull and authenticate one provider's semantically current public/open head.
+   * Pull and authenticate one provider's semantically current public-root head.
    * The discovery response is treated as a hint: this method exact-fetches the
    * named signed head, re-verifies it, and binds it to local accepted policy
    * before returning. It intentionally does not stage, schedule, or activate.
@@ -604,7 +602,7 @@ export class Rfc64PublicCatalogServiceV1 {
       assertAuthorCatalogHeadScopeBindingV1(head.envelope.payload, currentTrustedScope);
     } catch (cause) {
       throw new Error(
-        'RFC-64 discovered head differs from the accepted public/open policy scope',
+        'RFC-64 discovered head differs from the accepted public policy scope',
         { cause },
       );
     }
@@ -612,7 +610,7 @@ export class Rfc64PublicCatalogServiceV1 {
   }
 
   /**
-   * Discover one provider's current public/open head, enqueue that exact
+   * Discover one provider's current public-root head, enqueue that exact
    * authenticated head through the ordinary receiver, and wait for all
    * scheduled reconciliation work to drain. A caller must still inspect the
    * durable applied-head record: receiver failures are reported through its
@@ -726,12 +724,6 @@ export class Rfc64PublicCatalogServiceV1 {
     });
   }
 
-  async #authorizeNativeOperation(
-    input: Rfc64PublicCatalogNativeAuthorizationInputV1,
-  ): Promise<Rfc64PublicCatalogNativeAuthorizationV1 | null> {
-    return this.#policies.authorize(input);
-  }
-
   #resolveTrustedCatalogScope(
     announcement: Rfc64PublicCatalogHeadAnnouncementV1,
   ): Readonly<AuthorCatalogScopeV1> {
@@ -759,7 +751,7 @@ export class Rfc64PublicCatalogServiceV1 {
     const record = this.#policies.lookup(input.networkId, input.contextGraphId);
     if (record === null) {
       throw new Error(
-        'RFC-64 current-head query is not bound to the accepted public/open root policy',
+        'RFC-64 current-head query is not bound to the accepted public root policy',
       );
     }
     try {
@@ -807,7 +799,7 @@ export class Rfc64PublicCatalogServiceV1 {
       );
     } catch (cause) {
       throw new Error(
-        'RFC-64 fetched head differs from the accepted public/open policy scope',
+        'RFC-64 fetched head differs from the accepted public policy scope',
         { cause },
       );
     }

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -85,6 +85,7 @@ import {
 } from './public-catalog-issuer-delegation-v1.js';
 import {
   deriveRfc64PublicOpenCatalogScopeV1,
+  deriveRfc64PublicRootCatalogScopeV1,
   type Rfc64BoundedPublicRootCatalogTrustedScopeResolverV1,
 } from './public-catalog-native-reconciler-v1.js';
 import type {
@@ -227,6 +228,14 @@ export interface DiscoveredRfc64PublicCatalogCurrentHeadV1 {
   readonly announcement: Rfc64PublicCatalogHeadAnnouncementV1;
   readonly head: FetchedRfc64PublicCatalogHeadV1;
 }
+
+/**
+ * A current head that was authenticated through discovery and handed to the
+ * receiver scheduler. The receiver remains the only owner of semantic
+ * activation and the durable applied-head commit.
+ */
+export type SynchronizedRfc64PublicCatalogCurrentHeadV1 =
+  DiscoveredRfc64PublicCatalogCurrentHeadV1;
 
 export interface Rfc64PublicCatalogServiceStatsV1 {
   readonly started: boolean;
@@ -602,6 +611,39 @@ export class Rfc64PublicCatalogServiceV1 {
     return Object.freeze({ announcement, head });
   }
 
+  /**
+   * Discover one provider's current public/open head, enqueue that exact
+   * authenticated head through the ordinary receiver, and wait for all
+   * scheduled reconciliation work to drain. A caller must still inspect the
+   * durable applied-head record: receiver failures are reported through its
+   * bounded diagnostic channel rather than thrown from the scheduler.
+   *
+   * Once discovery has completed, reconciliation is deliberately durable work
+   * owned by the receiver lifecycle. Aborting the caller's signal after that
+   * boundary does not cancel a semantic transition already accepted by the
+   * scheduler; service close remains the cancellation authority.
+   */
+  async synchronizeCurrentCatalogHead(
+    input: DiscoverRfc64PublicCatalogCurrentHeadInputV1,
+  ): Promise<SynchronizedRfc64PublicCatalogCurrentHeadV1 | null> {
+    // Snapshot caller-owned values before discovery's first await so a Proxy or
+    // switching accessor cannot redirect the later scheduled fetch to another
+    // provider.
+    const remotePeerId = input.remotePeerId;
+    const scope = input.scope;
+    const signal = input.signal;
+    const discovered = await this.discoverCurrentCatalogHead({
+      remotePeerId,
+      scope,
+      ...(signal === undefined ? {} : { signal }),
+    });
+    if (discovered === null) return null;
+    if (signal?.aborted) throw signal.reason;
+    this.#receiver.schedule(discovered.announcement, remotePeerId);
+    await this.#receiver.whenIdle();
+    return discovered;
+  }
+
   /** Idle-await the receiver (tests / graceful shutdown coordination). */
   whenReceiverIdle(): Promise<void> {
     return this.#receiver.whenIdle();
@@ -719,10 +761,24 @@ export class Rfc64PublicCatalogServiceV1 {
       );
     }
     try {
-      return deriveRfc64PublicOpenCatalogScopeV1(input, record.policy);
+      if (!this.#policies.isSwmAuthorAuthorized({
+        networkId: input.networkId,
+        contextGraphId: input.contextGraphId,
+        policyDigest: record.policyDigest,
+        authorAddress: input.authorAddress,
+      })) {
+        throw new Error('catalog author is not authorized by the accepted policy');
+      }
+      return record.policy.source.kind === 'owner-signed-unregistered'
+        && record.policy.governanceChainId === null
+        && record.policy.governanceContractAddress === null
+        && record.policy.ownershipTransitionDigest === null
+        && record.policy.source.ownerAddress === input.authorAddress
+        ? deriveRfc64PublicOpenCatalogScopeV1(input, record.policy)
+        : deriveRfc64PublicRootCatalogScopeV1(input, record.policy);
     } catch (cause) {
       throw new Error(
-        'RFC-64 current-head query is not bound to the accepted public/open root policy',
+        'RFC-64 current-head query is not bound to the accepted public root policy',
         { cause },
       );
     }

--- a/packages/agent/test/rfc64-current-head-discovery-legacy-authorizer.typecheck.ts
+++ b/packages/agent/test/rfc64-current-head-discovery-legacy-authorizer.typecheck.ts
@@ -1,0 +1,26 @@
+import {
+  type Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1,
+} from '@origintrail-official/dkg-agent';
+
+declare const controlObjects:
+  Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1['controlObjects'];
+declare const readCurrentAppliedCatalogHeadDigest:
+  Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1[
+    'readCurrentAppliedCatalogHeadDigest'
+  ];
+declare const authorizeOpenCatalogOperation: NonNullable<
+  Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1[
+    'authorizeOpenCatalogOperation'
+  ]
+>;
+declare const verifyIssuerSignature:
+  Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1['verifyIssuerSignature'];
+
+const legacyOptions: Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1 = {
+  controlObjects,
+  readCurrentAppliedCatalogHeadDigest,
+  authorizeOpenCatalogOperation,
+  verifyIssuerSignature,
+};
+
+void legacyOptions;

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -545,6 +545,115 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     });
   }, 60_000);
 
+  it('cold-starts after publication from a provider current-head snapshot', async () => {
+    const [author, provider] = await Promise.all([
+      startNativeAgent('cold-author'),
+      startNativeAgent('cold-provider'),
+    ]);
+    provider.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    await connectBothWays(author, provider);
+
+    const genesis = await author.publishOpenAuthorCatalogGenesisV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      author: AUTHOR_WALLET,
+      peers: [provider.peerId],
+      issuedAt: FIXED_HEAD_ISSUED_AT,
+      catalogIssuerDelegationEffectiveAt: DELEGATION_EFFECTIVE_AT,
+      catalogIssuerDelegationExpiresAt: MULTI_DELEGATION_EXPIRES_AT,
+    });
+    await provider.whenRfc64PublicCatalogReceiverIdleV1();
+    const successor = await author.publishOpenAuthorCatalogSuccessorV1({
+      previousHead: {
+        objectDigest: genesis.headObjectDigest,
+        signatureVariantDigest: genesis.signatureVariantDigest,
+      },
+      author: AUTHOR_WALLET,
+      catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
+      assertionCoordinate: 'cold-current-snapshot' as never,
+      projectionBytes: PROJECTION,
+      seal: await authorSeal(7n),
+      deployment: NATIVE_DEPLOYMENT,
+      issuedAt: SUCCESSOR_ISSUED_AT,
+      peers: [provider.peerId],
+    });
+    await provider.whenRfc64PublicCatalogReceiverIdleV1();
+    expect(provider.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })?.currentCatalogHeadDigest).toBe(successor.headObjectDigest);
+
+    // The third agent does not exist until after the successor is durable on
+    // the provider, so it cannot have observed either publication hint.
+    const cold = await startNativeAgent('cold-late-receiver');
+    cold.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    expect(cold.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toBeNull();
+    await connectBothWays(provider, cold);
+
+    const synchronized = await cold.synchronizeRfc64PublicCatalogFromProviderV1({
+      remotePeerId: provider.peerId,
+      scope: {
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        subGraphName: null,
+        authorAddress: AUTHOR,
+        catalogEra: '0',
+      },
+    });
+    expect(synchronized).toMatchObject({
+      providerPeerId: provider.peerId,
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+      currentCatalogHeadDigest: successor.headObjectDigest,
+      signatureVariantDigest: successor.signatureVariantDigest,
+      catalogVersion: '1',
+      inventoryRowCount: '1',
+    });
+    expect(cold.readRfc64PublicCatalogReconciliationFailureV1(
+      successor.headObjectDigest,
+    )).toBeNull();
+    expect(cold.readRfc64PublicCatalogSynchronizationEvidenceV1(
+      successor.headObjectDigest,
+    )).toMatchObject({
+      catalogHeadDigest: successor.headObjectDigest,
+      inventoryRowCount: 1,
+      activatedTripleCount: 2,
+      removedRowCount: 0,
+      appliedHeadStatus: 'applied',
+    });
+    expect(cold.rfc64PublicCatalogStatsV1()?.receiver).toMatchObject({
+      scheduled: 1,
+      applied: 1,
+      failed: 0,
+    });
+
+    const swmGraph = contextGraphLayerUri(
+      CONTEXT_GRAPH_ID,
+      MemoryLayer.SharedWorkingMemory,
+      AUTHOR,
+      7,
+    );
+    await expect((cold as any).store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
+    )).resolves.toMatchObject({
+      type: 'bindings',
+      bindings: expect.arrayContaining([
+        expect.objectContaining({ s: 'https://example.org/alice' }),
+      ]),
+    });
+  }, 60_000);
+
   it('materializes finalized VM through production two-agent wiring before applying the head', async () => {
     const kaNumber = 7n;
     const kaId = ((BigInt(AUTHOR) << 96n) | kaNumber).toString();

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -654,6 +654,79 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     });
   }, 60_000);
 
+  it('rejects the provider-sync API when scheduled semantic activation fails', async () => {
+    const [author, provider] = await Promise.all([
+      startNativeAgent('failure-author'),
+      startNativeAgent('failure-provider'),
+    ]);
+    provider.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    await connectBothWays(author, provider);
+    const genesis = await author.publishOpenAuthorCatalogGenesisV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      author: AUTHOR_WALLET,
+      peers: [provider.peerId],
+      issuedAt: FIXED_HEAD_ISSUED_AT,
+      catalogIssuerDelegationEffectiveAt: DELEGATION_EFFECTIVE_AT,
+      catalogIssuerDelegationExpiresAt: MULTI_DELEGATION_EXPIRES_AT,
+    });
+    await provider.whenRfc64PublicCatalogReceiverIdleV1();
+    const successor = await author.publishOpenAuthorCatalogSuccessorV1({
+      previousHead: {
+        objectDigest: genesis.headObjectDigest,
+        signatureVariantDigest: genesis.signatureVariantDigest,
+      },
+      author: AUTHOR_WALLET,
+      catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
+      assertionCoordinate: 'failure-current-snapshot' as never,
+      projectionBytes: PROJECTION,
+      seal: await authorSeal(7n),
+      deployment: NATIVE_DEPLOYMENT,
+      issuedAt: SUCCESSOR_ISSUED_AT,
+      peers: [provider.peerId],
+    });
+    await provider.whenRfc64PublicCatalogReceiverIdleV1();
+
+    const cold = await startNativeAgent('failure-late-receiver');
+    cold.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    await connectBothWays(provider, cold);
+    const replaceGraphAndSubject = vi.spyOn(
+      (cold as any).store,
+      'replaceGraphAndSubject',
+    ).mockRejectedValue(new Error('simulated receiver semantic-activation failure'));
+
+    await expect(cold.synchronizeRfc64PublicCatalogFromProviderV1({
+      remotePeerId: provider.peerId,
+      scope: {
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        subGraphName: null,
+        authorAddress: AUTHOR,
+        catalogEra: '0',
+      },
+    })).rejects.toThrow(/reconciliation failed \(catalog-native-receiver-activation\)/u);
+    expect(replaceGraphAndSubject).toHaveBeenCalled();
+    expect(cold.readRfc64PublicCatalogReconciliationFailureV1(
+      successor.headObjectDigest,
+    )).toEqual({
+      catalogHeadDigest: successor.headObjectDigest,
+      errorName: 'Rfc64PublicCatalogNativeReceiverErrorV1',
+      errorCode: 'catalog-native-receiver-activation',
+    });
+    expect(cold.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toBeNull();
+  }, 60_000);
+
   it('materializes finalized VM through production two-agent wiring before applying the head', async () => {
     const kaNumber = 7n;
     const kaId = ((BigInt(AUTHOR) << 96n) | kaNumber).toString();

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -599,7 +599,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     await expect(service.discoverCurrentCatalogHead({
       remotePeerId: 'unreachable-peer',
       scope: Object.freeze({ ...discoveryScope(), subGraphName: 'nested' as const }),
-    })).rejects.toThrow(/accepted public\/open root policy/);
+    })).rejects.toThrow(/accepted public root policy/);
   });
 
   it('round-trips only exact canonical query fields', () => {

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -5,9 +5,11 @@ import { join } from 'node:path';
 import { multiaddr } from '@multiformats/multiaddr';
 import {
   DKGNode,
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   ProtocolRouter,
   computeControlSignatureVariantDigestHex,
   type AuthorCatalogScopeV1,
+  type ContextGraphPolicyV1,
   type Digest32V1,
   type EvmAddressV1,
   type TimestampMsV1,
@@ -44,6 +46,8 @@ const AUTHOR_WALLET = new ethers.Wallet(`0x${'64'.repeat(32)}`);
 const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
 const DELEGATION_DIGEST = `0x${'72'.repeat(32)}` as Digest32V1;
 const POLICY_DIGEST = `0x${'71'.repeat(32)}` as Digest32V1;
+const GOVERNANCE_CONTRACT =
+  '0x5555555555555555555555555555555555555555' as EvmAddressV1;
 
 const temporaryDirectories: string[] = [];
 const nodes: DKGNode[] = [];
@@ -105,6 +109,43 @@ function catalogScope(
     era: '0',
     bucketCount: '1',
   }) as AuthorCatalogScopeV1;
+}
+
+function governedCatalogScope(): AuthorCatalogScopeV1 {
+  return Object.freeze({
+    ...catalogScope(),
+    governanceChainId: '20430',
+    governanceContractAddress: GOVERNANCE_CONTRACT,
+    ownershipTransitionDigest: `0x${'57'.repeat(32)}`,
+  }) as AuthorCatalogScopeV1;
+}
+
+function finalizedPublicPolicy(): ContextGraphPolicyV1 {
+  return Object.freeze({
+    networkId: NETWORK_ID,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    governanceChainId: '20430',
+    governanceContractAddress: GOVERNANCE_CONTRACT,
+    ownershipTransitionDigest: `0x${'57'.repeat(32)}`,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy: 0,
+    publishPolicy: 1,
+    publishAuthority: null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'finalized-chain',
+      chainId: '20430',
+      contractAddress: GOVERNANCE_CONTRACT,
+      blockNumber: '123',
+      blockHash: `0x${'77'.repeat(32)}`,
+    },
+    effectiveAt: '1773900000000',
+    issuedAt: '1773900000000',
+  });
 }
 
 async function stageHead(
@@ -179,6 +220,27 @@ function directAuthorization(scope = catalogScope()) {
 }
 
 describe('RFC-64 public catalog current-head discovery v1', () => {
+  it('accepts the deprecated open-authorizer option but rejects ambiguity', () => {
+    const router = {
+      register() {},
+      unregister() {},
+    } as unknown as ProtocolRouter;
+    const legacy = vi.fn(async () => directAuthorization());
+    expect(() => new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
+      readCurrentAppliedCatalogHeadDigest: vi.fn(async () => null),
+      authorizeOpenCatalogOperation: legacy,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    })).not.toThrow();
+    expect(() => new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
+      readCurrentAppliedCatalogHeadDigest: vi.fn(async () => null),
+      authorizeCatalogOperation: legacy,
+      authorizeOpenCatalogOperation: legacy,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    })).toThrow(/exactly one catalog access-policy authorizer/u);
+  });
+
   it('treats an unsorted expected-key declaration as an exact key set', () => {
     expect(snapshotRfc64ExactWireRecordV1(
       { alpha: '1', beta: '2' },
@@ -271,6 +333,53 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       ) as Digest32V1,
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
     })).resolves.toBeNull();
+  }, 30_000);
+
+  it('preserves the finalized public governance scope during current-head discovery', async () => {
+    const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
+      await Promise.all([
+        startNode(),
+        startNode(),
+        openPersistence('governed-provider'),
+        openPersistence('governed-requester'),
+      ]);
+    await connect(requesterNode, providerNode);
+    const expectedScope = governedCatalogScope();
+    const head = await stageHead(providerPersistence, expectedScope);
+    const readCurrentAppliedCatalogHeadDigest = vi.fn(async (
+      trustedScope: Readonly<AuthorCatalogScopeV1>,
+    ) => {
+      expect(trustedScope).toEqual(expectedScope);
+      return head.objectDigest as Digest32V1;
+    });
+    const provider = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(providerNode),
+      controlObjects: providerPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest },
+      transportTimeoutMs: 4_000,
+    });
+    const requester = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(requesterNode),
+      controlObjects: requesterPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
+      transportTimeoutMs: 4_000,
+    });
+    services.push(provider, requester);
+    for (const service of [provider, requester]) {
+      service.acceptPolicySnapshot({
+        policy: finalizedPublicPolicy(),
+        policyDigest: POLICY_DIGEST,
+      });
+      service.start();
+    }
+
+    await expect(requester.discoverCurrentCatalogHead({
+      remotePeerId: providerNode.peerId,
+      scope: discoveryScope(),
+    })).resolves.toMatchObject({
+      head: { envelope: { objectDigest: head.objectDigest } },
+    });
+    expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(2);
   }, 30_000);
 
   it('retries once when the applied ref advances while the old immutable head is read', async () => {

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -519,7 +519,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       },
       readCurrentAppliedCatalogHeadDigest: vi.fn(async () =>
         stored.head.objectDigest as Digest32V1),
-      authorizeOpenCatalogOperation: vi.fn(async () => ({
+      authorizeCatalogOperation: vi.fn(async () => ({
         ...directAuthorization(),
       })),
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
@@ -567,7 +567,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       },
       readCurrentAppliedCatalogHeadDigest: vi.fn(async () =>
         stored.head.objectDigest as Digest32V1),
-      authorizeOpenCatalogOperation: vi.fn(async () => ({
+      authorizeCatalogOperation: vi.fn(async () => ({
         ...directAuthorization(),
       })),
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
@@ -587,7 +587,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
   });
 
   it('rechecks outbound policy after the awaited remote response', async () => {
-    const authorizeOpenCatalogOperation = vi.fn()
+    const authorizeCatalogOperation = vi.fn()
       .mockResolvedValueOnce(directAuthorization())
       .mockResolvedValueOnce(null);
     const send = vi.fn(async () => Uint8Array.of(0));
@@ -599,7 +599,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
       controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
       readCurrentAppliedCatalogHeadDigest: vi.fn(async () => null),
-      authorizeOpenCatalogOperation,
+      authorizeCatalogOperation,
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
     });
     transport.start();
@@ -612,7 +612,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     await expect(transport.discoverCurrentCatalogHead('provider-peer', query))
       .rejects.toMatchObject({ code: 'catalog-discovery-policy-denied' });
     expect(send).toHaveBeenCalledTimes(1);
-    expect(authorizeOpenCatalogOperation).toHaveBeenCalledTimes(2);
+    expect(authorizeCatalogOperation).toHaveBeenCalledTimes(2);
     transport.stop();
   });
 
@@ -622,7 +622,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       peerId: { toString(): string },
       options?: { signal?: AbortSignal },
     ) => Promise<Uint8Array>) | undefined;
-    const authorizeOpenCatalogOperation = vi.fn()
+    const authorizeCatalogOperation = vi.fn()
       .mockResolvedValueOnce(directAuthorization())
       .mockResolvedValueOnce(null);
     const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
@@ -635,7 +635,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
       controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
       readCurrentAppliedCatalogHeadDigest,
-      authorizeOpenCatalogOperation,
+      authorizeCatalogOperation,
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
     });
     transport.start();
@@ -650,7 +650,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       { toString: () => 'requester-peer' },
     )).resolves.toEqual(Uint8Array.of(2));
     expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(2);
-    expect(authorizeOpenCatalogOperation).toHaveBeenCalledTimes(2);
+    expect(authorizeCatalogOperation).toHaveBeenCalledTimes(2);
     transport.stop();
   });
 
@@ -701,7 +701,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
       controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
       readCurrentAppliedCatalogHeadDigest: vi.fn(async () => null),
-      authorizeOpenCatalogOperation: vi.fn(async () => directAuthorization()),
+      authorizeCatalogOperation: vi.fn(async () => directAuthorization()),
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
     });
     transport.start();
@@ -786,7 +786,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       unregister() {},
     } as unknown as ProtocolRouter;
     const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
-    const authorizeOpenCatalogOperation = vi.fn(async () => ({
+    const authorizeCatalogOperation = vi.fn(async () => ({
       ...directAuthorization(),
     }));
     const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
@@ -794,7 +794,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
         getVerifiedObjectByDigest: vi.fn(async () => null),
       },
       readCurrentAppliedCatalogHeadDigest,
-      authorizeOpenCatalogOperation,
+      authorizeCatalogOperation,
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
     });
     transport.start();
@@ -812,7 +812,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       { toString: () => 'test-peer' },
       { signal: controller.signal },
     )).rejects.toBe(reason);
-    expect(authorizeOpenCatalogOperation).not.toHaveBeenCalled();
+    expect(authorizeCatalogOperation).not.toHaveBeenCalled();
     expect(readCurrentAppliedCatalogHeadDigest).not.toHaveBeenCalled();
     transport.stop();
   });

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -19,9 +19,12 @@ import {
   computeCanonicalGraphScopedAuthorSealDigestV1,
   computeControlObjectDigestHex,
   computeKaChunkTreeRootV1,
+  decodeOpaqueKaBundleV1,
   deriveCanonicalGraphScopedAuthorSealPlacementV1,
   deriveAuthorCatalogScopeFromHeadV1,
   encodeOpaqueKaBundleV1,
+  parseCanonicalGraphScopedAuthorSealV1,
+  projectCanonicalGraphScopedAuthorSealRowsV1,
   type AuthorCatalogRowV1,
   type AuthorCatalogScopeV1,
   type AuthorCatalogHeadV1,
@@ -152,6 +155,51 @@ async function connect(from: DKGNode, to: DKGNode): Promise<void> {
 }
 
 describe('RFC-64 Gate 1 native successor to public SWM', () => {
+  it('refuses cold bootstrap when an omitted author projection and seal lack durable history', async () => {
+    const fixture = await setupLiveReceiver();
+    const decoded = decodeOpaqueKaBundleV1(fixture.secondRowBundle.bundleBytes);
+    const seal = parseCanonicalGraphScopedAuthorSealV1(decoded.sealBytes);
+    const placement = deriveCanonicalGraphScopedAuthorSealPlacementV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      assertionCoordinate: fixture.secondRowBundle.row.assertionCoordinate,
+    });
+    const staleGraph = `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`
+      + `/_shared_memory/${AUTHOR}/${SECOND_KA_NUMBER}`;
+    await fixture.receiverStore.insert([
+      {
+        subject: 'https://example.org/stale',
+        predicate: 'https://schema.org/name',
+        object: '"omitted"',
+        graph: staleGraph,
+      },
+      ...projectCanonicalGraphScopedAuthorSealRowsV1(seal, {
+        contextGraphId: CONTEXT_GRAPH_ID,
+        subGraphName: null,
+        authorAddress: AUTHOR,
+        assertionCoordinate: fixture.secondRowBundle.row.assertionCoordinate,
+      }),
+    ]);
+
+    await expect(fixture.synchronize()).rejects.toMatchObject({
+      code: 'catalog-native-receiver-history',
+      message: expect.stringContaining('omitted by the fetched exact head'),
+    });
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )).toBeNull();
+    await expect(fixture.receiverStore.hasGraph(staleGraph)).resolves.toBe(true);
+    const sealRead = await fixture.receiverStore.query(
+      `SELECT ?p ?o WHERE { GRAPH <${placement.metaGraph}> { `
+        + `<${placement.subject}> ?p ?o } } LIMIT 1`,
+    );
+    expect(sealRead).toMatchObject({ type: 'bindings' });
+    if (sealRead.type !== 'bindings') throw new Error('stale seal query was not bindings');
+    expect(sealRead.bindings).toHaveLength(1);
+  }, 30_000);
+
   it('bootstraps exact empty genesis then activates one successor without manual seeding', async () => {
     const fixture = await setupLiveReceiver();
     const genesisEvidence = await fixture.bootstrap();

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -845,6 +845,32 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     await expect(fixture.receiverStore.countQuads()).resolves.toBe(0);
   }, 30_000);
 
+  it('withholds staging, semantic mutation, and head CAS when verified bundle retention fails', async () => {
+    const fixture = await setupLiveReceiver();
+    await fixture.bootstrap();
+    const putKaBundle = vi.fn(async () => {
+      throw new Error('simulated durable bundle-store failure');
+    });
+    const observed = fixture.createCasObservedReceiver(
+      undefined,
+      fixture.receiverStore,
+      { putKaBundle },
+    );
+
+    await expect(fixture.synchronize(
+      fixture.announcement,
+      observed.receiver,
+    )).rejects.toMatchObject({ code: 'catalog-native-receiver-catalog' });
+    expect(putKaBundle).toHaveBeenCalledTimes(1);
+    expect(observed.stageVerifiedObjects).not.toHaveBeenCalled();
+    expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )?.currentCatalogHeadDigest).toBe(fixture.genesis.head.objectDigest);
+    await expect(fixture.receiverStore.countQuads()).resolves.toBe(0);
+  }, 30_000);
+
   it('rejects a governed-scope genesis under the trusted null-governance policy before any mutation', async () => {
     const fixture = await setupLiveReceiver();
     const observed = fixture.createCasObservedReceiver();
@@ -987,6 +1013,10 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     const restartedReceiver = fixture.createReceiver(
       reopened.inventory,
       reopened.controlObjects,
+      undefined,
+      undefined,
+      undefined,
+      reopened.kaBundles,
     );
 
     await expect(fixture.bootstrap(
@@ -1807,18 +1837,24 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     },
     store: TripleStore = receiverStore,
     beforeAppliedHeadCommit?: Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1,
+    kaBundles: Pick<Rfc64PersistenceV1['kaBundles'], 'putKaBundle'> =
+      receiverPersistence.kaBundles,
   ) => new Rfc64PublicCatalogNativeReceiverV1({
     headTransport: { fetchCatalogHead: receiverHeadFetch },
     contentTransport,
     controlObjects,
     inventory,
+    kaBundles,
     store,
     beforeAppliedHeadCommit,
   });
   const createCasObservedReceiver = (contentTransport?: Pick<
     Rfc64PublicCatalogNativeTransportV1,
     'fetchCatalogObject' | 'fetchKaBundle'
-  >, store: TripleStore = receiverStore) => {
+  >, store: TripleStore = receiverStore, kaBundles: Pick<
+    Rfc64PersistenceV1['kaBundles'],
+    'putKaBundle'
+  > = receiverPersistence.kaBundles) => {
     const compareAndSwapAppliedCatalogHeadV1 = vi.fn(
       receiverPersistence.inventory.compareAndSwapAppliedCatalogHeadV1.bind(
         receiverPersistence.inventory,
@@ -1842,7 +1878,10 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
             receiverPersistence.inventory,
           ),
         compareAndSwapAppliedCatalogHeadV1,
-      }, { stageVerifiedObjects, getVerifiedObjectByDigest }, contentTransport, store),
+      }, {
+        stageVerifiedObjects,
+        getVerifiedObjectByDigest,
+      }, contentTransport, store, undefined, kaBundles),
     });
   };
   const receiver = createReceiver(receiverPersistence.inventory);


### PR DESCRIPTION
## Outcome

Closes the RFC-64 M3b cold-join slice: a public edge receiver that did not exist during publication can discover one provider's authenticated current head, fetch the complete exact snapshot, durably materialize it, and advance its applied-head pointer without replaying historical catalog versions.

## What changed

- exposes explicit provider current-head synchronization through DKGAgent
- allows a cold receiver to initialize directly from a complete authenticated successor snapshot
- durably retains every verified KA bundle before staging, semantic mutation, or head CAS, so an applied receiver can serve the next cold node
- resolves public-root scopes for both public/open and public/curated policy cells
- migrates service transports to the generic accepted-policy authorization boundary
- adds a real three-edge proof where the late receiver starts only after publication
- fails closed when durable bundle retention does not succeed

## Evidence

- focused RFC-64 lane: 5 files, 74 tests passed
- agent package build: TypeScript, type tests, and package-root test passed
- git diff check passed
- real three-agent proof checks discovery, exact fetch, durable applied-head equality, SWM materialization, and zero reconciliation failures

## Release boundary

This PR provides the authenticated cold-pull primitive. Automatic normal-publication catalog updates, automatic startup subscription, and the combined finalized-VM cold-join release proof remain follow-up slices before the preview release.
