### PR TITLE
feat(agent): advance RFC-64 catalogs after public publish

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -24,6 +24,7 @@
     "./dist/rfc64/control-object-store-v1.js": null,
     "./dist/rfc64/catalog-access-policy-v1.js": null,
     "./dist/rfc64/catalog-authority-config-v1.js": null,
+    "./dist/rfc64/catalog-peers-v1.js": null,
     "./dist/rfc64/catalog-transport-authorization-v1.js": null,
     "./dist/rfc64/catalog-transport-wire-v1-internal.js": null,
     "./dist/rfc64/durable-file-store-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -44,6 +44,7 @@ const requiredCatalogMethods = [
   'acceptRfc64CatalogAccessSnapshotV1',
   'publishAuthorCatalogGenesisV1',
   'publishAuthorCatalogExactSetSuccessorV1',
+  'recordConfirmedRfc64PublicCatalogAssetV1',
 ];
 for (const method of requiredCatalogMethods) {
   if (

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -99,6 +99,7 @@ const publicRfc64Modules = [
 const blockedRfc64Modules = [
   'catalog-access-policy-v1.js',
   'catalog-authority-config-v1.js',
+  'catalog-peers-v1.js',
   'catalog-transport-authorization-v1.js',
   'catalog-transport-wire-v1-internal.js',
   'control-object-store-v1-internal.js',

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1023,6 +1023,8 @@ export class DKGAgentBase {
   /** Bounded process-local terminal receiver failures, keyed by announced head. */
   protected readonly rfc64PublicCatalogReconciliationFailuresV1 =
     new Rfc64PublicCatalogReconciliationFailureRegistryV1();
+  /** Serialize local author-head construction/CAS independently per exact scope. */
+  protected readonly rfc64AuthorCatalogMutationQueuesV1 = new Map<string, Promise<void>>();
   protected readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
   protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
   protected readonly contextGraphSubscriptionRehydrationAccountedIds = new Set<string>();

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -98,6 +98,7 @@ import {
   ciphertextChunkStoreSubject,
   CIPHERTEXT_CHUNK_PREDICATE,
   type SubscriptionSource,
+  type AssertionCoordinateV1,
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
   withSpan,
@@ -5406,6 +5407,24 @@ export class PublishMethods extends DKGAgentBase {
       }
     }
 
+    if (result.status === 'confirmed') {
+      try {
+        await this.recordConfirmedRfc64PublicCatalogAssetV1({
+          contextGraphId: request.contextGraphId as never,
+          subGraphName: request.subGraphName as never,
+          assertionCoordinate: request.name as AssertionCoordinateV1,
+          publicQuads: snapshotQuads,
+          seal,
+        });
+      } catch (err) {
+        this.log.warn(
+          ctx,
+          `Confirmed queued publish for <${assertionUri}> but RFC-64 catalog advancement failed: `
+            + (err instanceof Error ? err.message : String(err)),
+        );
+      }
+    }
+
     return { ...result, assertionUri, seal };
   }
 
@@ -5956,6 +5975,24 @@ export class PublishMethods extends DKGAgentBase {
           opts?.operationCtx ?? createOperationContext('publishFromSWM'),
           `Failed to clear swmShareComplete after confirmed publish of <${lifecycleUri}>: ` +
             (err instanceof Error ? err.message : String(err)),
+        );
+      }
+    }
+
+    if (result.status === 'confirmed') {
+      try {
+        await this.recordConfirmedRfc64PublicCatalogAssetV1({
+          contextGraphId: contextGraphId as never,
+          subGraphName: opts?.subGraphName as never,
+          assertionCoordinate: name as AssertionCoordinateV1,
+          publicQuads: canonicalSwmQuads,
+          seal,
+        });
+      } catch (err) {
+        this.log.warn(
+          opts?.operationCtx ?? createOperationContext('publishFromSWM'),
+          `Confirmed publish for <${assertionUri}> but RFC-64 catalog advancement failed: `
+            + (err instanceof Error ? err.message : String(err)),
         );
       }
     }

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -98,7 +98,9 @@ import {
   ciphertextChunkStoreSubject,
   CIPHERTEXT_CHUNK_PREDICATE,
   type SubscriptionSource,
-  type AssertionCoordinateV1,
+  assertAssertionCoordinateV1,
+  assertContextGraphIdV1,
+  assertSubGraphNameV1,
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
   withSpan,
@@ -5407,23 +5409,17 @@ export class PublishMethods extends DKGAgentBase {
       }
     }
 
-    if (result.status === 'confirmed') {
-      try {
-        await this.recordConfirmedRfc64PublicCatalogAssetV1({
-          contextGraphId: request.contextGraphId as never,
-          subGraphName: request.subGraphName as never,
-          assertionCoordinate: request.name as AssertionCoordinateV1,
-          publicQuads: snapshotQuads,
-          seal,
-        });
-      } catch (err) {
-        this.log.warn(
-          ctx,
-          `Confirmed queued publish for <${assertionUri}> but RFC-64 catalog advancement failed: `
-            + (err instanceof Error ? err.message : String(err)),
-        );
-      }
-    }
+    await this.afterConfirmedGraphScopedVmPublishV1({
+      status: result.status,
+      contextGraphId: request.contextGraphId,
+      subGraphName: request.subGraphName,
+      assertionCoordinate: request.name,
+      publicQuads: snapshotQuads,
+      seal,
+      assertionUri,
+      ctx,
+      publicationLabel: 'queued publish',
+    });
 
     return { ...result, assertionUri, seal };
   }
@@ -5979,25 +5975,63 @@ export class PublishMethods extends DKGAgentBase {
       }
     }
 
-    if (result.status === 'confirmed') {
-      try {
-        await this.recordConfirmedRfc64PublicCatalogAssetV1({
-          contextGraphId: contextGraphId as never,
-          subGraphName: opts?.subGraphName as never,
-          assertionCoordinate: name as AssertionCoordinateV1,
-          publicQuads: canonicalSwmQuads,
-          seal,
-        });
-      } catch (err) {
-        this.log.warn(
-          opts?.operationCtx ?? createOperationContext('publishFromSWM'),
-          `Confirmed publish for <${assertionUri}> but RFC-64 catalog advancement failed: `
-            + (err instanceof Error ? err.message : String(err)),
-        );
-      }
-    }
+    await this.afterConfirmedGraphScopedVmPublishV1({
+      status: result.status,
+      contextGraphId,
+      subGraphName: opts?.subGraphName,
+      assertionCoordinate: name,
+      publicQuads: canonicalSwmQuads,
+      seal,
+      assertionUri,
+      ctx: opts?.operationCtx ?? createOperationContext('publishFromSWM'),
+      publicationLabel: 'publish',
+    });
 
     return { ...result, assertionUri, seal };
+  }
+
+  private async afterConfirmedGraphScopedVmPublishV1(
+    this: DKGAgent,
+    input: Readonly<{
+      status: PublishResult['status'];
+      contextGraphId: string;
+      subGraphName?: string;
+      assertionCoordinate: string;
+      publicQuads: readonly Quad[];
+      seal: AssertionSeal;
+      assertionUri: string;
+      ctx: OperationContext;
+      publicationLabel: 'publish' | 'queued publish';
+    }>,
+  ): Promise<void> {
+    if (input.status !== 'confirmed') return;
+    try {
+      const contextGraphId = input.contextGraphId;
+      const assertionCoordinate = input.assertionCoordinate;
+      const subGraphName = input.subGraphName ?? null;
+      assertContextGraphIdV1(contextGraphId, 'confirmed publish contextGraphId');
+      assertAssertionCoordinateV1(
+        assertionCoordinate,
+        'confirmed publish assertionCoordinate',
+      );
+      if (subGraphName !== null) {
+        assertSubGraphNameV1(subGraphName, 'confirmed publish subGraphName');
+      }
+      await this.recordConfirmedRfc64PublicCatalogAssetV1({
+        contextGraphId,
+        subGraphName,
+        assertionCoordinate,
+        publicQuads: input.publicQuads,
+        seal: input.seal,
+      });
+    } catch (err) {
+      this.log.warn(
+        input.ctx,
+        `Confirmed ${input.publicationLabel} for <${input.assertionUri}> but `
+          + `RFC-64 catalog advancement failed: `
+          + (err instanceof Error ? err.message : String(err)),
+      );
+    }
   }
 
   /**

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -6,12 +6,11 @@
  */
 
 import {
-  GRAPH_KA_CONTENT_SCOPE_VERSION,
-  assertCanonicalGraphScopedAuthorSealV1,
+  canonicalGraphScopedAuthorSealFromAssertionSealV1,
+  encodeCanonicalCgSharedPublicRootProjectionV1,
   type AssertionCoordinateV1,
   type AssertionSeal,
   type AuthorCatalogScopeV1,
-  type CanonicalGraphScopedAuthorSealV1,
   type CatalogSealDeploymentProfileV1,
   type ContextGraphIdV1,
   type CountV1,
@@ -20,7 +19,6 @@ import {
   type SubGraphNameV1,
   type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
-import { serializeWorkspacePublicSnapshotQuads } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
 
@@ -57,7 +55,7 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     const autoPublish = this.config.rfc64PublicCatalogAutoPublish;
     if (autoPublish === undefined) return null;
     if (params.subGraphName !== undefined && params.subGraphName !== null) return null;
-    const seal = canonicalRfc64SealFromAssertionSeal(params.seal);
+    const seal = canonicalGraphScopedAuthorSealFromAssertionSealV1(params.seal);
     // V1 deliberately catalogs public-only KA projections. Private-bearing
     // publishes require the reserved cg-shared-v1 anchor/hash statements to be
     // present in the author-sealed public projection; ordinary publication does
@@ -69,7 +67,7 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
         'RFC-64 auto-publish public projection count differs from the confirmed author seal',
       );
     }
-    const projectionBytes = canonicalPublicProjectionBytes(params.publicQuads);
+    const projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(params.publicQuads);
     const networkId = (this.config.rfc64CatalogDeploymentProfile?.networkId
       ?? this.chain.chainId) as NetworkIdV1;
     if (networkId === 'none') {
@@ -182,59 +180,4 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     return deployment;
   }
 
-}
-
-function canonicalRfc64SealFromAssertionSeal(
-  seal: AssertionSeal,
-): Readonly<CanonicalGraphScopedAuthorSealV1> {
-  if (
-    seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
-    || seal.kaUal === undefined
-    || seal.assertionVersion === undefined
-    || seal.publicTripleCount === undefined
-    || seal.privateTripleCount === undefined
-    || seal.reservedKaId === undefined
-    || seal.authorSchemeVersion !== 1
-  ) {
-    throw new Error('RFC-64 auto-publish requires a complete graph-scoped v2 author seal');
-  }
-  const canonical = {
-    assertionMerkleRoot: ethers.hexlify(seal.merkleRoot).toLowerCase(),
-    authorAddress: seal.authorAddress.toLowerCase(),
-    authorAttestationR: ethers.hexlify(seal.authorAttestationR).toLowerCase(),
-    authorAttestationVS: ethers.hexlify(seal.authorAttestationVS).toLowerCase(),
-    authorSchemeVersion: '1',
-    assertedAtChainId: seal.chainId.toString(),
-    assertedAtKav10Address: seal.kav10Address.toLowerCase(),
-    reservedKaId: seal.reservedKaId.toString(),
-    assertionFinalizedAt: seal.finalizedAtIso,
-    contentScopeVersion: '2',
-    kaUal: seal.kaUal,
-    assertionVersion: seal.assertionVersion,
-    publicTripleCount: seal.publicTripleCount.toString(),
-    privateTripleCount: seal.privateTripleCount.toString(),
-    privateMerkleRoot: seal.privateMerkleRoot === undefined
-      ? null
-      : ethers.hexlify(seal.privateMerkleRoot).toLowerCase(),
-  } as unknown as CanonicalGraphScopedAuthorSealV1;
-  assertCanonicalGraphScopedAuthorSealV1(canonical);
-  return Object.freeze(canonical);
-}
-
-function canonicalPublicProjectionBytes(quads: readonly Quad[]): Uint8Array {
-  const encoder = new TextEncoder();
-  const lines = quads.map((quad) => {
-    const line = serializeWorkspacePublicSnapshotQuads([{ ...quad, graph: '' }]);
-    return Object.freeze({ line, bytes: encoder.encode(line) });
-  });
-  lines.sort((left, right) => compareBytes(left.bytes, right.bytes));
-  return encoder.encode(lines.map(({ line }) => line).join(''));
-}
-
-function compareBytes(left: Uint8Array, right: Uint8Array): number {
-  const length = Math.min(left.byteLength, right.byteLength);
-  for (let index = 0; index < length; index += 1) {
-    if (left[index] !== right[index]) return left[index]! - right[index]!;
-  }
-  return left.byteLength - right.byteLength;
 }

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Opt-in RFC-64 producer bridge from an ordinary confirmed public KA publish
+ * to this provider's durable exact author-catalog head.
+ */
+
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  assertCanonicalGraphScopedAuthorSealV1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  assertSignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  canonicalizeCanonicalGraphScopedAuthorSealV1,
+  computeAuthorCatalogScopeDigestV1,
+  computeControlSignatureVariantDigestHex,
+  decodeOpaqueKaBundleV1,
+  parseCanonicalGraphScopedAuthorSealV1,
+  type AssertionCoordinateV1,
+  type AssertionSeal,
+  type AuthorCatalogScopeV1,
+  type CanonicalGraphScopedAuthorSealV1,
+  type CatalogSealDeploymentProfileV1,
+  type ContextGraphIdV1,
+  type CountV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
+  type SubGraphNameV1,
+  type TimestampMsV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+import { serializeWorkspacePublicSnapshotQuads } from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { ethers } from 'ethers';
+
+import { DKGAgentBase } from './dkg-agent-base.js';
+import type { DKGAgent } from './dkg-agent.js';
+import {
+  loadBoundedAuthorCatalogHistoryV1,
+  type BoundedAuthorCatalogHistoryV1,
+  type Rfc64CatalogAuthorSignerV1,
+  type Rfc64CatalogSuccessorAssetInputV1,
+  type Rfc64StagedAuthorCatalogHeadRefV1,
+} from './dkg-agent-rfc64-catalog.js';
+import { snapshotRfc64CatalogDeploymentProfileV1 } from './rfc64/catalog-authority-config-v1.js';
+import type { AppliedCatalogHeadSnapshotV1 } from './rfc64/inventory-v1/index.js';
+import { computeRfc64AppliedInventoryDigestV1 } from './rfc64/public-catalog-inventory-completeness-v1.js';
+import type { Rfc64PersistenceV1 } from './rfc64/persistence-v1.js';
+
+/** Internal normal-publication handoff after VM confirmation is durable locally. */
+export interface RecordConfirmedRfc64PublicCatalogAssetParamsV1 {
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly subGraphName?: SubGraphNameV1 | null;
+  readonly assertionCoordinate: AssertionCoordinateV1;
+  readonly publicQuads: readonly Quad[];
+  readonly seal: AssertionSeal;
+}
+
+export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
+  /**
+   * Advance this provider's exact public-root author catalog after an ordinary
+   * graph-scoped KA publish has confirmed. The hook is dormant unless the
+   * preview config is present. Catalog objects and bundles are staged first,
+   * the provider's applied-head pointer advances second, and peer availability
+   * hints are sent last.
+   */
+  async recordConfirmedRfc64PublicCatalogAssetV1(
+    this: DKGAgent,
+    params: RecordConfirmedRfc64PublicCatalogAssetParamsV1,
+  ): Promise<AppliedCatalogHeadSnapshotV1 | null> {
+    const autoPublish = this.config.rfc64PublicCatalogAutoPublish;
+    if (autoPublish === undefined) return null;
+    if (params.subGraphName !== undefined && params.subGraphName !== null) return null;
+    const persistence = this.rfc64PersistenceV1;
+    if (persistence === undefined) {
+      throw new Error('RFC-64 auto-publish requires durable persistence');
+    }
+
+    const seal = canonicalRfc64SealFromAssertionSeal(params.seal);
+    if (params.publicQuads.length !== Number(seal.publicTripleCount)) {
+      throw new Error(
+        'RFC-64 auto-publish public projection count differs from the confirmed author seal',
+      );
+    }
+    const projectionBytes = canonicalPublicProjectionBytes(params.publicQuads);
+    const networkId = (this.config.rfc64CatalogDeploymentProfile?.networkId
+      ?? this.chain.chainId) as NetworkIdV1;
+    if (networkId === 'none') {
+      throw new Error('RFC-64 auto-publish requires a trusted deployment network');
+    }
+    const service = this.rfc64PublicCatalogServiceV1;
+    if (service === undefined) {
+      throw new Error(
+        'RFC-64 public catalog service is not available (agent not started or no dataDir)',
+      );
+    }
+    const acceptedPolicy = service.acceptedPolicySnapshot(networkId, params.contextGraphId);
+    if (acceptedPolicy === null || acceptedPolicy.policy.accessPolicy !== 0) {
+      throw new Error(
+        'RFC-64 auto-publish requires an independently accepted current public policy',
+      );
+    }
+    const scope: AuthorCatalogScopeV1 = Object.freeze({
+      networkId,
+      contextGraphId: params.contextGraphId,
+      governanceChainId: acceptedPolicy.policy.governanceChainId,
+      governanceContractAddress: acceptedPolicy.policy.governanceContractAddress,
+      ownershipTransitionDigest: acceptedPolicy.policy.ownershipTransitionDigest,
+      subGraphName: null,
+      authorAddress: seal.authorAddress,
+      era: acceptedPolicy.policy.era,
+      bucketCount: '1' as CountV1,
+    });
+    service.acceptedPolicySnapshotForCatalogScope(scope);
+    const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(scope);
+    const queueKey = `${catalogScopeDigest}\n${seal.authorAddress}`;
+
+    return this.runSerializedRfc64AuthorCatalogMutationV1(queueKey, async () => {
+      const signer = this.createRfc64CatalogAuthorSignerV1(seal.authorAddress);
+      let current = persistence.inventory.readAppliedCatalogHeadV1(
+        catalogScopeDigest,
+        seal.authorAddress,
+      );
+      if (current === null) {
+        const genesis = await this.publishAuthorCatalogGenesisV1({
+          scope,
+          author: signer,
+          peers: [],
+          issuedAt: Date.now().toString() as TimestampMsV1,
+          catalogIssuerDelegationEffectiveAt:
+            autoPublish.catalogIssuerDelegationEffectiveAt ?? ('0' as TimestampMsV1),
+          catalogIssuerDelegationExpiresAt:
+            autoPublish.catalogIssuerDelegationExpiresAt,
+        });
+        const emptyInventoryDigest = computeRfc64AppliedInventoryDigestV1({
+          catalogScopeDigest,
+          rows: [],
+        });
+        current = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+          catalogScopeDigest,
+          authorAddress: seal.authorAddress,
+          currentCatalogHeadDigest: genesis.headObjectDigest,
+          appliedInventoryDigest: emptyInventoryDigest,
+          catalogVersion: genesis.announcement.catalogVersion,
+          inventoryRowCount: '0' as CountV1,
+          expectedCurrentCatalogHeadDigest: null,
+        }).snapshot;
+      }
+
+      const storedHead = await persistence.controlObjects.getVerifiedObjectByDigest({
+        objectDigest: current.currentCatalogHeadDigest,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      });
+      if (storedHead === null) {
+        throw new Error('RFC-64 applied author head is not durably staged');
+      }
+      assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
+      const previousHead: Rfc64StagedAuthorCatalogHeadRefV1 = Object.freeze({
+        objectDigest: storedHead.envelope.objectDigest as Digest32V1,
+        signatureVariantDigest: computeControlSignatureVariantDigestHex(
+          storedHead.envelope.objectDigest,
+          storedHead.envelope.signature,
+        ) as Digest32V1,
+      });
+      const history = await loadBoundedAuthorCatalogHistoryV1(persistence, previousHead);
+      const assets = await loadRfc64CatalogSuccessorAssetsV1(persistence, history);
+      const nextAsset: Rfc64CatalogSuccessorAssetInputV1 = Object.freeze({
+        assertionCoordinate: params.assertionCoordinate,
+        projectionBytes,
+        seal,
+      });
+      const existingIndex = assets.findIndex(
+        (asset) => asset.seal.reservedKaId === seal.reservedKaId,
+      );
+      if (existingIndex >= 0 && sameRfc64SuccessorAssetV1(assets[existingIndex]!, nextAsset)) {
+        return current;
+      }
+      if (existingIndex >= 0) assets[existingIndex] = nextAsset;
+      else assets.push(nextAsset);
+
+      const storedDelegation = await persistence.controlObjects.getVerifiedObjectByDigest({
+        objectDigest: history.previousHead.payload.catalogIssuerDelegationDigest,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      });
+      if (storedDelegation === null) {
+        throw new Error('RFC-64 applied author head delegation is not durably staged');
+      }
+      assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
+      const deployment = await this.resolveRfc64AutoPublishDeploymentProfileV1(networkId);
+      const successor = await this.publishAuthorCatalogExactSetSuccessorV1({
+        previousHead,
+        author: signer,
+        catalogIssuerAuthorization: Object.freeze({
+          catalogIssuerDelegation: storedDelegation.envelope,
+          parentAuthorAgentEvidence: null,
+        }),
+        assets,
+        deployment,
+        issuedAt: Date.now().toString() as TimestampMsV1,
+        peers: [],
+      });
+      const appliedInventoryDigest = computeRfc64AppliedInventoryDigestV1({
+        catalogScopeDigest: successor.catalogScopeDigest,
+        rows: successor.assets,
+      });
+      const applied = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+        catalogScopeDigest: successor.catalogScopeDigest,
+        authorAddress: seal.authorAddress,
+        currentCatalogHeadDigest: successor.headObjectDigest,
+        appliedInventoryDigest,
+        catalogVersion: successor.announcement.catalogVersion,
+        inventoryRowCount: successor.signedBucketRowCount,
+        expectedCurrentCatalogHeadDigest: current.currentCatalogHeadDigest,
+      }).snapshot;
+      await this.announceRfc64PublicCatalogHeadV1({
+        announcement: successor.announcement,
+        peers: autoPublish.peers,
+      });
+      return applied;
+    });
+  }
+
+  private createRfc64CatalogAuthorSignerV1(
+    this: DKGAgent,
+    authorAddress: EvmAddressV1,
+  ): Rfc64CatalogAuthorSignerV1 {
+    const custodialKey = this.getCustodialAgentPrivateKey(authorAddress);
+    if (custodialKey !== undefined) {
+      const wallet = new ethers.Wallet(
+        custodialKey.startsWith('0x') ? custodialKey : `0x${custodialKey}`,
+      );
+      if (wallet.address.toLowerCase() !== authorAddress) {
+        throw new Error('RFC-64 custodial author key does not match the confirmed seal');
+      }
+      return Object.freeze({
+        address: authorAddress,
+        signMessage: (message: Uint8Array) => wallet.signMessage(message),
+      });
+    }
+    const signMessageAs = this.chain.signMessageAs?.bind(this.chain);
+    const signMessage = this.chain.signMessage?.bind(this.chain);
+    return Object.freeze({
+      address: authorAddress,
+      signMessage: async (message: Uint8Array) => {
+        const compact = signMessageAs !== undefined
+          ? await signMessageAs(authorAddress, message)
+          : signMessage !== undefined
+            ? await signMessage(message)
+            : (() => { throw new Error('RFC-64 configured chain has no message signer'); })();
+        const signature = ethers.Signature.from({
+          r: ethers.hexlify(compact.r),
+          yParityAndS: ethers.hexlify(compact.vs),
+        }).serialized;
+        if (ethers.verifyMessage(message, signature).toLowerCase() !== authorAddress) {
+          throw new Error('RFC-64 configured publisher cannot sign for the confirmed KA author');
+        }
+        return signature;
+      },
+    });
+  }
+
+  private async resolveRfc64AutoPublishDeploymentProfileV1(
+    this: DKGAgent,
+    networkId: NetworkIdV1,
+  ): Promise<CatalogSealDeploymentProfileV1> {
+    let deployment = this.config.rfc64CatalogDeploymentProfile;
+    const trustedNetworkId = deployment?.networkId ?? this.chain.chainId;
+    if (trustedNetworkId === 'none' || trustedNetworkId !== networkId) {
+      throw new Error('RFC-64 auto-publish network differs from the trusted deployment');
+    }
+    if (deployment === undefined) {
+      const [chainId, kav10Address] = await Promise.all([
+        this.chain.getEvmChainId(),
+        this.chain.getKnowledgeAssetsLifecycleAddress(),
+      ]);
+      deployment = snapshotRfc64CatalogDeploymentProfileV1({
+        networkId,
+        assertedAtChainId: chainId.toString() as never,
+        assertedAtKav10Address: kav10Address as EvmAddressV1,
+      });
+      if (deployment === undefined) {
+        throw new Error('RFC-64 chain deployment profile resolution failed');
+      }
+    }
+    return deployment;
+  }
+
+  private async runSerializedRfc64AuthorCatalogMutationV1<T>(
+    this: DKGAgent,
+    key: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const predecessor = this.rfc64AuthorCatalogMutationQueuesV1.get(key);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const tail = (predecessor ?? Promise.resolve()).catch(() => undefined).then(() => gate);
+    this.rfc64AuthorCatalogMutationQueuesV1.set(key, tail);
+    await predecessor?.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.rfc64AuthorCatalogMutationQueuesV1.get(key) === tail) {
+        this.rfc64AuthorCatalogMutationQueuesV1.delete(key);
+      }
+    }
+  }
+}
+
+function canonicalRfc64SealFromAssertionSeal(
+  seal: AssertionSeal,
+): Readonly<CanonicalGraphScopedAuthorSealV1> {
+  if (
+    seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+    || seal.kaUal === undefined
+    || seal.assertionVersion === undefined
+    || seal.publicTripleCount === undefined
+    || seal.privateTripleCount === undefined
+    || seal.reservedKaId === undefined
+    || seal.authorSchemeVersion !== 1
+  ) {
+    throw new Error('RFC-64 auto-publish requires a complete graph-scoped v2 author seal');
+  }
+  const canonical = {
+    assertionMerkleRoot: ethers.hexlify(seal.merkleRoot).toLowerCase(),
+    authorAddress: seal.authorAddress.toLowerCase(),
+    authorAttestationR: ethers.hexlify(seal.authorAttestationR).toLowerCase(),
+    authorAttestationVS: ethers.hexlify(seal.authorAttestationVS).toLowerCase(),
+    authorSchemeVersion: '1',
+    assertedAtChainId: seal.chainId.toString(),
+    assertedAtKav10Address: seal.kav10Address.toLowerCase(),
+    reservedKaId: seal.reservedKaId.toString(),
+    assertionFinalizedAt: seal.finalizedAtIso,
+    contentScopeVersion: '2',
+    kaUal: seal.kaUal,
+    assertionVersion: seal.assertionVersion,
+    publicTripleCount: seal.publicTripleCount.toString(),
+    privateTripleCount: seal.privateTripleCount.toString(),
+    privateMerkleRoot: seal.privateMerkleRoot === undefined
+      ? null
+      : ethers.hexlify(seal.privateMerkleRoot).toLowerCase(),
+  } as unknown as CanonicalGraphScopedAuthorSealV1;
+  assertCanonicalGraphScopedAuthorSealV1(canonical);
+  return Object.freeze(canonical);
+}
+
+function canonicalPublicProjectionBytes(quads: readonly Quad[]): Uint8Array {
+  const sorted = quads
+    .map((quad) => ({ ...quad, graph: '' }))
+    .sort((left, right) => (
+      left.subject.localeCompare(right.subject)
+      || left.predicate.localeCompare(right.predicate)
+      || left.object.localeCompare(right.object)
+    ));
+  return new TextEncoder().encode(serializeWorkspacePublicSnapshotQuads(sorted));
+}
+
+async function loadRfc64CatalogSuccessorAssetsV1(
+  persistence: Rfc64PersistenceV1,
+  history: BoundedAuthorCatalogHistoryV1,
+): Promise<Rfc64CatalogSuccessorAssetInputV1[]> {
+  const assets: Rfc64CatalogSuccessorAssetInputV1[] = [];
+  for (const row of history.previousBucket?.payload.rows ?? []) {
+    const bundleBytes = await persistence.kaBundles.readKaBundleByDigest(row.transfer.blobDigest);
+    if (bundleBytes === null) {
+      throw new Error(`RFC-64 applied catalog bundle ${row.transfer.blobDigest} is unavailable`);
+    }
+    const decoded = decodeOpaqueKaBundleV1(bundleBytes);
+    if (
+      decoded.blobDigest !== row.transfer.blobDigest
+      || decoded.projectionDigest !== row.projectionDigest
+    ) {
+      throw new Error('RFC-64 applied catalog bundle differs from its signed predecessor row');
+    }
+    assets.push(Object.freeze({
+      assertionCoordinate: row.assertionCoordinate,
+      projectionBytes: new Uint8Array(decoded.projectionBytes),
+      seal: parseCanonicalGraphScopedAuthorSealV1(decoded.sealBytes),
+    }));
+  }
+  return assets;
+}
+
+function sameRfc64SuccessorAssetV1(
+  left: Rfc64CatalogSuccessorAssetInputV1,
+  right: Rfc64CatalogSuccessorAssetInputV1,
+): boolean {
+  return left.assertionCoordinate === right.assertionCoordinate
+    && canonicalizeCanonicalGraphScopedAuthorSealV1(left.seal)
+      === canonicalizeCanonicalGraphScopedAuthorSealV1(right.seal)
+    && equalBytes(left.projectionBytes, right.projectionBytes);
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.byteLength === right.byteLength
+    && left.every((byte, index) => byte === right[index]);
+}

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -8,13 +8,6 @@
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   assertCanonicalGraphScopedAuthorSealV1,
-  assertSignedAuthorCatalogHeadEnvelopeV1,
-  assertSignedAuthorCatalogIssuerDelegationEnvelopeV1,
-  canonicalizeCanonicalGraphScopedAuthorSealV1,
-  computeAuthorCatalogScopeDigestV1,
-  computeControlSignatureVariantDigestHex,
-  decodeOpaqueKaBundleV1,
-  parseCanonicalGraphScopedAuthorSealV1,
   type AssertionCoordinateV1,
   type AssertionSeal,
   type AuthorCatalogScopeV1,
@@ -22,30 +15,23 @@ import {
   type CatalogSealDeploymentProfileV1,
   type ContextGraphIdV1,
   type CountV1,
-  type Digest32V1,
   type EvmAddressV1,
   type NetworkIdV1,
   type SubGraphNameV1,
   type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
-import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
 import { serializeWorkspacePublicSnapshotQuads } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
 
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
-import {
-  loadBoundedAuthorCatalogHistoryV1,
-  type BoundedAuthorCatalogHistoryV1,
-  type Rfc64CatalogAuthorSignerV1,
-  type Rfc64CatalogSuccessorAssetInputV1,
-  type Rfc64StagedAuthorCatalogHeadRefV1,
+import type {
+  Rfc64CatalogAuthorSignerV1,
+  Rfc64CatalogSuccessorAssetInputV1,
 } from './dkg-agent-rfc64-catalog.js';
 import { snapshotRfc64CatalogDeploymentProfileV1 } from './rfc64/catalog-authority-config-v1.js';
 import type { AppliedCatalogHeadSnapshotV1 } from './rfc64/inventory-v1/index.js';
-import { computeRfc64AppliedInventoryDigestV1 } from './rfc64/public-catalog-inventory-completeness-v1.js';
-import type { Rfc64PersistenceV1 } from './rfc64/persistence-v1.js';
 
 /** Internal normal-publication handoff after VM confirmation is durable locally. */
 export interface RecordConfirmedRfc64PublicCatalogAssetParamsV1 {
@@ -71,12 +57,13 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     const autoPublish = this.config.rfc64PublicCatalogAutoPublish;
     if (autoPublish === undefined) return null;
     if (params.subGraphName !== undefined && params.subGraphName !== null) return null;
-    const persistence = this.rfc64PersistenceV1;
-    if (persistence === undefined) {
-      throw new Error('RFC-64 auto-publish requires durable persistence');
-    }
-
     const seal = canonicalRfc64SealFromAssertionSeal(params.seal);
+    // V1 deliberately catalogs public-only KA projections. Private-bearing
+    // publishes require the reserved cg-shared-v1 anchor/hash statements to be
+    // present in the author-sealed public projection; ordinary publication does
+    // not synthesize those statements yet, so attempting an upsert would always
+    // fail projection verification after chain confirmation.
+    if (BigInt(seal.privateTripleCount) > 0n) return null;
     if (params.publicQuads.length !== Number(seal.publicTripleCount)) {
       throw new Error(
         'RFC-64 auto-publish public projection count differs from the confirmed author seal',
@@ -112,111 +99,21 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       bucketCount: '1' as CountV1,
     });
     service.acceptedPolicySnapshotForCatalogScope(scope);
-    const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(scope);
-    const queueKey = `${catalogScopeDigest}\n${seal.authorAddress}`;
-
-    return this.runSerializedRfc64AuthorCatalogMutationV1(queueKey, async () => {
-      const signer = this.createRfc64CatalogAuthorSignerV1(seal.authorAddress);
-      let current = persistence.inventory.readAppliedCatalogHeadV1(
-        catalogScopeDigest,
-        seal.authorAddress,
-      );
-      if (current === null) {
-        const genesis = await this.publishAuthorCatalogGenesisV1({
-          scope,
-          author: signer,
-          peers: [],
-          issuedAt: Date.now().toString() as TimestampMsV1,
-          catalogIssuerDelegationEffectiveAt:
-            autoPublish.catalogIssuerDelegationEffectiveAt ?? ('0' as TimestampMsV1),
-          catalogIssuerDelegationExpiresAt:
-            autoPublish.catalogIssuerDelegationExpiresAt,
-        });
-        const emptyInventoryDigest = computeRfc64AppliedInventoryDigestV1({
-          catalogScopeDigest,
-          rows: [],
-        });
-        current = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-          catalogScopeDigest,
-          authorAddress: seal.authorAddress,
-          currentCatalogHeadDigest: genesis.headObjectDigest,
-          appliedInventoryDigest: emptyInventoryDigest,
-          catalogVersion: genesis.announcement.catalogVersion,
-          inventoryRowCount: '0' as CountV1,
-          expectedCurrentCatalogHeadDigest: null,
-        }).snapshot;
-      }
-
-      const storedHead = await persistence.controlObjects.getVerifiedObjectByDigest({
-        objectDigest: current.currentCatalogHeadDigest,
-        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
-      });
-      if (storedHead === null) {
-        throw new Error('RFC-64 applied author head is not durably staged');
-      }
-      assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
-      const previousHead: Rfc64StagedAuthorCatalogHeadRefV1 = Object.freeze({
-        objectDigest: storedHead.envelope.objectDigest as Digest32V1,
-        signatureVariantDigest: computeControlSignatureVariantDigestHex(
-          storedHead.envelope.objectDigest,
-          storedHead.envelope.signature,
-        ) as Digest32V1,
-      });
-      const history = await loadBoundedAuthorCatalogHistoryV1(persistence, previousHead);
-      const assets = await loadRfc64CatalogSuccessorAssetsV1(persistence, history);
-      const nextAsset: Rfc64CatalogSuccessorAssetInputV1 = Object.freeze({
-        assertionCoordinate: params.assertionCoordinate,
-        projectionBytes,
-        seal,
-      });
-      const existingIndex = assets.findIndex(
-        (asset) => asset.seal.reservedKaId === seal.reservedKaId,
-      );
-      if (existingIndex >= 0 && sameRfc64SuccessorAssetV1(assets[existingIndex]!, nextAsset)) {
-        return current;
-      }
-      if (existingIndex >= 0) assets[existingIndex] = nextAsset;
-      else assets.push(nextAsset);
-
-      const storedDelegation = await persistence.controlObjects.getVerifiedObjectByDigest({
-        objectDigest: history.previousHead.payload.catalogIssuerDelegationDigest,
-        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
-      });
-      if (storedDelegation === null) {
-        throw new Error('RFC-64 applied author head delegation is not durably staged');
-      }
-      assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
-      const deployment = await this.resolveRfc64AutoPublishDeploymentProfileV1(networkId);
-      const successor = await this.publishAuthorCatalogExactSetSuccessorV1({
-        previousHead,
-        author: signer,
-        catalogIssuerAuthorization: Object.freeze({
-          catalogIssuerDelegation: storedDelegation.envelope,
-          parentAuthorAgentEvidence: null,
-        }),
-        assets,
-        deployment,
-        issuedAt: Date.now().toString() as TimestampMsV1,
-        peers: [],
-      });
-      const appliedInventoryDigest = computeRfc64AppliedInventoryDigestV1({
-        catalogScopeDigest: successor.catalogScopeDigest,
-        rows: successor.assets,
-      });
-      const applied = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-        catalogScopeDigest: successor.catalogScopeDigest,
-        authorAddress: seal.authorAddress,
-        currentCatalogHeadDigest: successor.headObjectDigest,
-        appliedInventoryDigest,
-        catalogVersion: successor.announcement.catalogVersion,
-        inventoryRowCount: successor.signedBucketRowCount,
-        expectedCurrentCatalogHeadDigest: current.currentCatalogHeadDigest,
-      }).snapshot;
-      await this.announceRfc64PublicCatalogHeadV1({
-        announcement: successor.announcement,
-        peers: autoPublish.peers,
-      });
-      return applied;
+    const asset: Rfc64CatalogSuccessorAssetInputV1 = Object.freeze({
+      assertionCoordinate: params.assertionCoordinate,
+      projectionBytes,
+      seal,
+    });
+    return this.upsertConfirmedRfc64PublicRootCatalogAssetV1({
+      scope,
+      author: this.createRfc64CatalogAuthorSignerV1(seal.authorAddress),
+      asset,
+      deployment: await this.resolveRfc64AutoPublishDeploymentProfileV1(networkId),
+      peers: autoPublish.peers,
+      catalogIssuerDelegationEffectiveAt:
+        autoPublish.catalogIssuerDelegationEffectiveAt ?? ('0' as TimestampMsV1),
+      catalogIssuerDelegationExpiresAt:
+        autoPublish.catalogIssuerDelegationExpiresAt,
     });
   }
 
@@ -285,26 +182,6 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     return deployment;
   }
 
-  private async runSerializedRfc64AuthorCatalogMutationV1<T>(
-    this: DKGAgent,
-    key: string,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    const predecessor = this.rfc64AuthorCatalogMutationQueuesV1.get(key);
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => { release = resolve; });
-    const tail = (predecessor ?? Promise.resolve()).catch(() => undefined).then(() => gate);
-    this.rfc64AuthorCatalogMutationQueuesV1.set(key, tail);
-    await predecessor?.catch(() => undefined);
-    try {
-      return await operation();
-    } finally {
-      release();
-      if (this.rfc64AuthorCatalogMutationQueuesV1.get(key) === tail) {
-        this.rfc64AuthorCatalogMutationQueuesV1.delete(key);
-      }
-    }
-  }
 }
 
 function canonicalRfc64SealFromAssertionSeal(
@@ -345,53 +222,19 @@ function canonicalRfc64SealFromAssertionSeal(
 }
 
 function canonicalPublicProjectionBytes(quads: readonly Quad[]): Uint8Array {
-  const sorted = quads
-    .map((quad) => ({ ...quad, graph: '' }))
-    .sort((left, right) => (
-      left.subject.localeCompare(right.subject)
-      || left.predicate.localeCompare(right.predicate)
-      || left.object.localeCompare(right.object)
-    ));
-  return new TextEncoder().encode(serializeWorkspacePublicSnapshotQuads(sorted));
+  const encoder = new TextEncoder();
+  const lines = quads.map((quad) => {
+    const line = serializeWorkspacePublicSnapshotQuads([{ ...quad, graph: '' }]);
+    return Object.freeze({ line, bytes: encoder.encode(line) });
+  });
+  lines.sort((left, right) => compareBytes(left.bytes, right.bytes));
+  return encoder.encode(lines.map(({ line }) => line).join(''));
 }
 
-async function loadRfc64CatalogSuccessorAssetsV1(
-  persistence: Rfc64PersistenceV1,
-  history: BoundedAuthorCatalogHistoryV1,
-): Promise<Rfc64CatalogSuccessorAssetInputV1[]> {
-  const assets: Rfc64CatalogSuccessorAssetInputV1[] = [];
-  for (const row of history.previousBucket?.payload.rows ?? []) {
-    const bundleBytes = await persistence.kaBundles.readKaBundleByDigest(row.transfer.blobDigest);
-    if (bundleBytes === null) {
-      throw new Error(`RFC-64 applied catalog bundle ${row.transfer.blobDigest} is unavailable`);
-    }
-    const decoded = decodeOpaqueKaBundleV1(bundleBytes);
-    if (
-      decoded.blobDigest !== row.transfer.blobDigest
-      || decoded.projectionDigest !== row.projectionDigest
-    ) {
-      throw new Error('RFC-64 applied catalog bundle differs from its signed predecessor row');
-    }
-    assets.push(Object.freeze({
-      assertionCoordinate: row.assertionCoordinate,
-      projectionBytes: new Uint8Array(decoded.projectionBytes),
-      seal: parseCanonicalGraphScopedAuthorSealV1(decoded.sealBytes),
-    }));
+function compareBytes(left: Uint8Array, right: Uint8Array): number {
+  const length = Math.min(left.byteLength, right.byteLength);
+  for (let index = 0; index < length; index += 1) {
+    if (left[index] !== right[index]) return left[index]! - right[index]!;
   }
-  return assets;
-}
-
-function sameRfc64SuccessorAssetV1(
-  left: Rfc64CatalogSuccessorAssetInputV1,
-  right: Rfc64CatalogSuccessorAssetInputV1,
-): boolean {
-  return left.assertionCoordinate === right.assertionCoordinate
-    && canonicalizeCanonicalGraphScopedAuthorSealV1(left.seal)
-      === canonicalizeCanonicalGraphScopedAuthorSealV1(right.seal)
-    && equalBytes(left.projectionBytes, right.projectionBytes);
-}
-
-function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
-  return left.byteLength === right.byteLength
-    && left.every((byte, index) => byte === right[index]);
+  return left.byteLength - right.byteLength;
 }

--- a/packages/agent/src/dkg-agent-rfc64-catalog-upsert.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-upsert.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** Catalog-owned, serialized exact-set mutation for one confirmed public asset. */
+
+import {
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  assertSignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  canonicalizeCanonicalGraphScopedAuthorSealV1,
+  computeAuthorCatalogScopeDigestV1,
+  computeControlSignatureVariantDigestHex,
+  decodeOpaqueKaBundleV1,
+  parseCanonicalGraphScopedAuthorSealV1,
+  type AuthorCatalogScopeV1,
+  type CatalogSealDeploymentProfileV1,
+  type CountV1,
+  type Digest32V1,
+  type TimestampMsV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+
+import { DKGAgentBase } from './dkg-agent-base.js';
+import type { DKGAgent } from './dkg-agent.js';
+import {
+  loadBoundedAuthorCatalogHistoryV1,
+  type BoundedAuthorCatalogHistoryV1,
+  type Rfc64CatalogAuthorSignerV1,
+  type Rfc64CatalogSuccessorAssetInputV1,
+  type Rfc64StagedAuthorCatalogHeadRefV1,
+} from './dkg-agent-rfc64-catalog.js';
+import type { AppliedCatalogHeadSnapshotV1 } from './rfc64/inventory-v1/index.js';
+import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './rfc64/catalog-peers-v1.js';
+import { computeRfc64AppliedInventoryDigestV1 } from './rfc64/public-catalog-inventory-completeness-v1.js';
+import type { Rfc64PersistenceV1 } from './rfc64/persistence-v1.js';
+
+export interface UpsertConfirmedRfc64PublicRootCatalogAssetParamsV1 {
+  readonly scope: AuthorCatalogScopeV1;
+  readonly author: Rfc64CatalogAuthorSignerV1;
+  readonly asset: Rfc64CatalogSuccessorAssetInputV1;
+  readonly deployment: CatalogSealDeploymentProfileV1;
+  readonly peers: readonly string[];
+  readonly catalogIssuerDelegationEffectiveAt: TimestampMsV1;
+  readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;
+}
+
+export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
+  /**
+   * Own genesis creation, predecessor reconstruction, exact-set successor,
+   * applied-head CAS, and best-effort availability announcement as one
+   * serialized catalog mutation.
+   */
+  async upsertConfirmedRfc64PublicRootCatalogAssetV1(
+    this: DKGAgent,
+    params: UpsertConfirmedRfc64PublicRootCatalogAssetParamsV1,
+  ): Promise<AppliedCatalogHeadSnapshotV1> {
+    if (params.scope.subGraphName !== null) {
+      throw new Error('RFC-64 confirmed public asset upsert requires the root catalog lane');
+    }
+    if (params.scope.authorAddress !== params.asset.seal.authorAddress) {
+      throw new Error('RFC-64 confirmed public asset author differs from the catalog scope');
+    }
+    const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(params.peers);
+    const persistence = this.rfc64PersistenceV1;
+    if (persistence === undefined) {
+      throw new Error('RFC-64 catalog upsert requires durable persistence');
+    }
+    const service = this.rfc64PublicCatalogServiceV1;
+    if (service === undefined) {
+      throw new Error('RFC-64 catalog upsert requires the public catalog service');
+    }
+    service.acceptedPolicySnapshotForCatalogScope(params.scope);
+    const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(params.scope);
+    const queueKey = `${catalogScopeDigest}\n${params.scope.authorAddress}`;
+
+    return this.runSerializedRfc64AuthorCatalogMutationV1(queueKey, async () => {
+      let current = persistence.inventory.readAppliedCatalogHeadV1(
+        catalogScopeDigest,
+        params.scope.authorAddress,
+      );
+      if (current === null) {
+        const genesis = await this.publishAuthorCatalogGenesisV1({
+          scope: params.scope,
+          author: params.author,
+          peers: [],
+          issuedAt: Date.now().toString() as TimestampMsV1,
+          catalogIssuerDelegationEffectiveAt:
+            params.catalogIssuerDelegationEffectiveAt,
+          catalogIssuerDelegationExpiresAt:
+            params.catalogIssuerDelegationExpiresAt,
+        });
+        const emptyInventoryDigest = computeRfc64AppliedInventoryDigestV1({
+          catalogScopeDigest,
+          rows: [],
+        });
+        current = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+          catalogScopeDigest,
+          authorAddress: params.scope.authorAddress,
+          currentCatalogHeadDigest: genesis.headObjectDigest,
+          appliedInventoryDigest: emptyInventoryDigest,
+          catalogVersion: genesis.announcement.catalogVersion,
+          inventoryRowCount: '0' as CountV1,
+          expectedCurrentCatalogHeadDigest: null,
+        }).snapshot;
+      }
+
+      const storedHead = await persistence.controlObjects.getVerifiedObjectByDigest({
+        objectDigest: current.currentCatalogHeadDigest,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      });
+      if (storedHead === null) {
+        throw new Error('RFC-64 applied author head is not durably staged');
+      }
+      assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
+      const previousHead: Rfc64StagedAuthorCatalogHeadRefV1 = Object.freeze({
+        objectDigest: storedHead.envelope.objectDigest as Digest32V1,
+        signatureVariantDigest: computeControlSignatureVariantDigestHex(
+          storedHead.envelope.objectDigest,
+          storedHead.envelope.signature,
+        ) as Digest32V1,
+      });
+      const history = await loadBoundedAuthorCatalogHistoryV1(persistence, previousHead);
+      const assets = await loadRfc64CatalogSuccessorAssetsV1(persistence, history);
+      const existingIndex = assets.findIndex(
+        (asset) => asset.seal.reservedKaId === params.asset.seal.reservedKaId,
+      );
+      if (
+        existingIndex >= 0
+        && sameRfc64SuccessorAssetV1(assets[existingIndex]!, params.asset)
+      ) return current;
+      if (existingIndex >= 0) assets[existingIndex] = params.asset;
+      else assets.push(params.asset);
+
+      const storedDelegation = await persistence.controlObjects.getVerifiedObjectByDigest({
+        objectDigest: history.previousHead.payload.catalogIssuerDelegationDigest,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      });
+      if (storedDelegation === null) {
+        throw new Error('RFC-64 applied author head delegation is not durably staged');
+      }
+      assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
+      const successor = await this.publishAuthorCatalogExactSetSuccessorV1({
+        previousHead,
+        author: params.author,
+        catalogIssuerAuthorization: Object.freeze({
+          catalogIssuerDelegation: storedDelegation.envelope,
+          parentAuthorAgentEvidence: null,
+        }),
+        assets,
+        deployment: params.deployment,
+        issuedAt: Date.now().toString() as TimestampMsV1,
+        peers: [],
+      });
+      const appliedInventoryDigest = computeRfc64AppliedInventoryDigestV1({
+        catalogScopeDigest: successor.catalogScopeDigest,
+        rows: successor.assets,
+      });
+      const applied = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+        catalogScopeDigest: successor.catalogScopeDigest,
+        authorAddress: params.scope.authorAddress,
+        currentCatalogHeadDigest: successor.headObjectDigest,
+        appliedInventoryDigest,
+        catalogVersion: successor.announcement.catalogVersion,
+        inventoryRowCount: successor.signedBucketRowCount,
+        expectedCurrentCatalogHeadDigest: current.currentCatalogHeadDigest,
+      }).snapshot;
+      await this.announceRfc64PublicCatalogHeadV1({
+        announcement: successor.announcement,
+        peers,
+      });
+      return applied;
+    });
+  }
+
+  private async runSerializedRfc64AuthorCatalogMutationV1<T>(
+    this: DKGAgent,
+    key: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const predecessor = this.rfc64AuthorCatalogMutationQueuesV1.get(key);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const tail = (predecessor ?? Promise.resolve()).catch(() => undefined).then(() => gate);
+    this.rfc64AuthorCatalogMutationQueuesV1.set(key, tail);
+    await predecessor?.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.rfc64AuthorCatalogMutationQueuesV1.get(key) === tail) {
+        this.rfc64AuthorCatalogMutationQueuesV1.delete(key);
+      }
+    }
+  }
+}
+
+async function loadRfc64CatalogSuccessorAssetsV1(
+  persistence: Rfc64PersistenceV1,
+  history: BoundedAuthorCatalogHistoryV1,
+): Promise<Rfc64CatalogSuccessorAssetInputV1[]> {
+  const assets: Rfc64CatalogSuccessorAssetInputV1[] = [];
+  for (const row of history.previousBucket?.payload.rows ?? []) {
+    const bundleBytes = await persistence.kaBundles.readKaBundleByDigest(row.transfer.blobDigest);
+    if (bundleBytes === null) {
+      throw new Error(`RFC-64 applied catalog bundle ${row.transfer.blobDigest} is unavailable`);
+    }
+    const decoded = decodeOpaqueKaBundleV1(bundleBytes);
+    if (
+      decoded.blobDigest !== row.transfer.blobDigest
+      || decoded.projectionDigest !== row.projectionDigest
+    ) {
+      throw new Error('RFC-64 applied catalog bundle differs from its signed predecessor row');
+    }
+    assets.push(Object.freeze({
+      assertionCoordinate: row.assertionCoordinate,
+      projectionBytes: new Uint8Array(decoded.projectionBytes),
+      seal: parseCanonicalGraphScopedAuthorSealV1(decoded.sealBytes),
+    }));
+  }
+  return assets;
+}
+
+function sameRfc64SuccessorAssetV1(
+  left: Rfc64CatalogSuccessorAssetInputV1,
+  right: Rfc64CatalogSuccessorAssetInputV1,
+): boolean {
+  return left.assertionCoordinate === right.assertionCoordinate
+    && canonicalizeCanonicalGraphScopedAuthorSealV1(left.seal)
+      === canonicalizeCanonicalGraphScopedAuthorSealV1(right.seal)
+    && equalBytes(left.projectionBytes, right.projectionBytes);
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.byteLength === right.byteLength
+    && left.every((byte, index) => byte === right[index]);
+}

--- a/packages/agent/src/dkg-agent-rfc64-catalog-upsert.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-upsert.ts
@@ -12,7 +12,6 @@ import {
   parseCanonicalGraphScopedAuthorSealV1,
   type AuthorCatalogScopeV1,
   type CatalogSealDeploymentProfileV1,
-  type CountV1,
   type Digest32V1,
   type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
@@ -30,6 +29,7 @@ import {
 import type { AppliedCatalogHeadSnapshotV1 } from './rfc64/inventory-v1/index.js';
 import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './rfc64/catalog-peers-v1.js';
 import { computeRfc64AppliedInventoryDigestV1 } from './rfc64/public-catalog-inventory-completeness-v1.js';
+import type { Rfc64PublicCatalogIssuerAuthorizationV1 } from './rfc64/public-catalog-successor-producer-v1.js';
 import type { Rfc64PersistenceV1 } from './rfc64/persistence-v1.js';
 
 export interface UpsertConfirmedRfc64PublicRootCatalogAssetParamsV1 {
@@ -72,10 +72,14 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
     const queueKey = `${catalogScopeDigest}\n${params.scope.authorAddress}`;
 
     return this.runSerializedRfc64AuthorCatalogMutationV1(queueKey, async () => {
-      let current = persistence.inventory.readAppliedCatalogHeadV1(
+      const current = persistence.inventory.readAppliedCatalogHeadV1(
         catalogScopeDigest,
         params.scope.authorAddress,
       );
+      let previousHead: Rfc64StagedAuthorCatalogHeadRefV1;
+      let catalogIssuerAuthorization: Rfc64PublicCatalogIssuerAuthorizationV1;
+      let assets: Rfc64CatalogSuccessorAssetInputV1[];
+      let expectedCurrentCatalogHeadDigest: Digest32V1 | null;
       if (current === null) {
         const genesis = await this.publishAuthorCatalogGenesisV1({
           scope: params.scope,
@@ -87,63 +91,64 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
           catalogIssuerDelegationExpiresAt:
             params.catalogIssuerDelegationExpiresAt,
         });
-        const emptyInventoryDigest = computeRfc64AppliedInventoryDigestV1({
-          catalogScopeDigest,
-          rows: [],
+        previousHead = Object.freeze({
+          objectDigest: genesis.headObjectDigest,
+          signatureVariantDigest: genesis.signatureVariantDigest,
         });
-        current = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-          catalogScopeDigest,
-          authorAddress: params.scope.authorAddress,
-          currentCatalogHeadDigest: genesis.headObjectDigest,
-          appliedInventoryDigest: emptyInventoryDigest,
-          catalogVersion: genesis.announcement.catalogVersion,
-          inventoryRowCount: '0' as CountV1,
-          expectedCurrentCatalogHeadDigest: null,
-        }).snapshot;
+        catalogIssuerAuthorization = genesis.catalogIssuerAuthorization;
+        assets = [];
+        expectedCurrentCatalogHeadDigest = null;
+      } else {
+        const storedHead = await persistence.controlObjects.getVerifiedObjectByDigest({
+          objectDigest: current.currentCatalogHeadDigest,
+          verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+        });
+        if (storedHead === null) {
+          throw new Error('RFC-64 applied author head is not durably staged');
+        }
+        assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
+        previousHead = Object.freeze({
+          objectDigest: storedHead.envelope.objectDigest as Digest32V1,
+          signatureVariantDigest: computeControlSignatureVariantDigestHex(
+            storedHead.envelope.objectDigest,
+            storedHead.envelope.signature,
+          ) as Digest32V1,
+        });
+        const history = await loadBoundedAuthorCatalogHistoryV1(persistence, previousHead);
+        assets = await loadRfc64CatalogSuccessorAssetsV1(persistence, history);
+        const storedDelegation = await persistence.controlObjects.getVerifiedObjectByDigest({
+          objectDigest: history.previousHead.payload.catalogIssuerDelegationDigest,
+          verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+        });
+        if (storedDelegation === null) {
+          throw new Error('RFC-64 applied author head delegation is not durably staged');
+        }
+        assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
+        catalogIssuerAuthorization = Object.freeze({
+          catalogIssuerDelegation: storedDelegation.envelope,
+          parentAuthorAgentEvidence: null,
+        });
+        expectedCurrentCatalogHeadDigest = current.currentCatalogHeadDigest;
       }
-
-      const storedHead = await persistence.controlObjects.getVerifiedObjectByDigest({
-        objectDigest: current.currentCatalogHeadDigest,
-        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
-      });
-      if (storedHead === null) {
-        throw new Error('RFC-64 applied author head is not durably staged');
-      }
-      assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
-      const previousHead: Rfc64StagedAuthorCatalogHeadRefV1 = Object.freeze({
-        objectDigest: storedHead.envelope.objectDigest as Digest32V1,
-        signatureVariantDigest: computeControlSignatureVariantDigestHex(
-          storedHead.envelope.objectDigest,
-          storedHead.envelope.signature,
-        ) as Digest32V1,
-      });
-      const history = await loadBoundedAuthorCatalogHistoryV1(persistence, previousHead);
-      const assets = await loadRfc64CatalogSuccessorAssetsV1(persistence, history);
       const existingIndex = assets.findIndex(
         (asset) => asset.seal.reservedKaId === params.asset.seal.reservedKaId,
       );
       if (
         existingIndex >= 0
         && sameRfc64SuccessorAssetV1(assets[existingIndex]!, params.asset)
-      ) return current;
+      ) {
+        if (current === null) {
+          throw new Error('RFC-64 staged genesis unexpectedly contains an ordinary asset');
+        }
+        return current;
+      }
       if (existingIndex >= 0) assets[existingIndex] = params.asset;
       else assets.push(params.asset);
 
-      const storedDelegation = await persistence.controlObjects.getVerifiedObjectByDigest({
-        objectDigest: history.previousHead.payload.catalogIssuerDelegationDigest,
-        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
-      });
-      if (storedDelegation === null) {
-        throw new Error('RFC-64 applied author head delegation is not durably staged');
-      }
-      assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
       const successor = await this.publishAuthorCatalogExactSetSuccessorV1({
         previousHead,
         author: params.author,
-        catalogIssuerAuthorization: Object.freeze({
-          catalogIssuerDelegation: storedDelegation.envelope,
-          parentAuthorAgentEvidence: null,
-        }),
+        catalogIssuerAuthorization,
         assets,
         deployment: params.deployment,
         issuedAt: Date.now().toString() as TimestampMsV1,
@@ -160,7 +165,7 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
         appliedInventoryDigest,
         catalogVersion: successor.announcement.catalogVersion,
         inventoryRowCount: successor.signedBucketRowCount,
-        expectedCurrentCatalogHeadDigest: current.currentCatalogHeadDigest,
+        expectedCurrentCatalogHeadDigest,
       }).snapshot;
       await this.announceRfc64PublicCatalogHeadV1({
         announcement: successor.announcement,

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -192,6 +192,7 @@ export {
 export {
   snapshotRfc64CatalogAccessPolicyAuthorityV1,
   snapshotRfc64CatalogDeploymentProfileV1,
+  snapshotRfc64PublicCatalogAutoPublishConfigV1,
 } from './rfc64/catalog-authority-config-v1.js';
 
 export interface PublishOpenAuthorCatalogSuccessorParamsV1 {
@@ -976,13 +977,13 @@ function countToSafeInteger(value: CountV1, label: string): number {
   return parsed;
 }
 
-interface BoundedAuthorCatalogHistoryV1 {
+export interface BoundedAuthorCatalogHistoryV1 {
   readonly previousHead: SignedAuthorCatalogHeadEnvelopeV1;
   readonly previousDirectoryPath: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[];
   readonly previousBucket: SignedAuthorCatalogBucketEnvelopeV1 | null;
 }
 
-async function loadBoundedAuthorCatalogHistoryV1(
+export async function loadBoundedAuthorCatalogHistoryV1(
   persistence: Rfc64PersistenceV1,
   ref: Rfc64StagedAuthorCatalogHeadRefV1,
 ): Promise<BoundedAuthorCatalogHistoryV1> {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -32,6 +32,7 @@ import type {
   ContextGraphJoinPolicyRecord as CoreContextGraphJoinPolicyRecord,
   CatalogSealDeploymentProfileV1,
   EvmAddressV1,
+  TimestampMsV1,
 } from '@origintrail-official/dkg-core';
 import type {
   PhaseCallback,
@@ -1059,6 +1060,17 @@ export interface Rfc64CatalogAccessPolicyAuthorityConfigV1 {
   ) => Promise<EvmAddressV1 | null>;
 }
 
+/**
+ * Opt-in RFC-64 author-catalog production for ordinary confirmed public KA
+ * publishes. Peer fan-out is an availability hint; the durable applied-head
+ * pointer remains the correctness source for pull discovery.
+ */
+export interface Rfc64PublicCatalogAutoPublishConfigV1 {
+  readonly peers: readonly string[];
+  readonly catalogIssuerDelegationEffectiveAt?: TimestampMsV1;
+  readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;
+}
+
 export interface DKGAgentConfig {
   name: string;
   /** Selected genesis document. Defaults to the compatibility Base testnet genesis. */
@@ -1078,6 +1090,8 @@ export interface DKGAgentConfig {
    * RFC-64 catalog policy. Omission preserves the legacy open-only lane.
    */
   rfc64CatalogAccessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1;
+  /** Omission preserves the existing publication and synchronization behavior. */
+  rfc64PublicCatalogAutoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
   /**
    * public-projection enable flag. When set, a private CG's confirmed VM
    * publishes emit/refresh a verifiable public projection (the floor: existence,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -406,6 +406,8 @@ import {
   snapshotRfc64CatalogAccessPolicyAuthorityV1,
   snapshotRfc64CatalogDeploymentProfileV1,
 } from './dkg-agent-rfc64-catalog.js';
+import { Rfc64CatalogAutoPublishMethods } from './dkg-agent-rfc64-catalog-auto-publish.js';
+import { snapshotRfc64PublicCatalogAutoPublishConfigV1 } from './rfc64/catalog-authority-config-v1.js';
 import { ContextGraphRegistryMethods } from './dkg-agent-cg-registry.js';
 import { JoinRequestMethods } from './dkg-agent-join.js';
 import { SwmSubstrateMethods } from './dkg-agent-swm-substrate.js';
@@ -704,6 +706,9 @@ export class DKGAgent extends DKGAgentBase {
     const rfc64CatalogAccessPolicyAuthority = snapshotRfc64CatalogAccessPolicyAuthorityV1(
       config.rfc64CatalogAccessPolicyAuthority,
     );
+    const rfc64PublicCatalogAutoPublish = snapshotRfc64PublicCatalogAutoPublishConfigV1(
+      config.rfc64PublicCatalogAutoPublish,
+    );
     let wallet: DKGAgentWallet;
     if (config.dataDir) {
       try {
@@ -810,6 +815,7 @@ export class DKGAgent extends DKGAgentBase {
       networkIdentity,
       rfc64CatalogAccessPolicyAuthority,
       rfc64CatalogDeploymentProfile,
+      rfc64PublicCatalogAutoPublish,
     };
 
     const port = config.listenPort ?? 0;
@@ -3057,5 +3063,5 @@ export class DKGAgent extends DKGAgentBase {
 }
 
 
-export interface DKGAgent extends ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods {}
-applyMixins(DKGAgent, [ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods]);
+export interface DKGAgent extends ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogAutoPublishMethods {}
+applyMixins(DKGAgent, [ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogAutoPublishMethods]);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -407,6 +407,7 @@ import {
   snapshotRfc64CatalogDeploymentProfileV1,
 } from './dkg-agent-rfc64-catalog.js';
 import { Rfc64CatalogAutoPublishMethods } from './dkg-agent-rfc64-catalog-auto-publish.js';
+import { Rfc64CatalogUpsertMethods } from './dkg-agent-rfc64-catalog-upsert.js';
 import { snapshotRfc64PublicCatalogAutoPublishConfigV1 } from './rfc64/catalog-authority-config-v1.js';
 import { Rfc64CatalogSyncMethods } from './dkg-agent-rfc64-catalog-sync.js';
 import { ContextGraphRegistryMethods } from './dkg-agent-cg-registry.js';
@@ -3064,5 +3065,5 @@ export class DKGAgent extends DKGAgentBase {
 }
 
 
-export interface DKGAgent extends ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods, Rfc64CatalogAutoPublishMethods {}
-applyMixins(DKGAgent, [ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods, Rfc64CatalogAutoPublishMethods]);
+export interface DKGAgent extends ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods, Rfc64CatalogUpsertMethods, Rfc64CatalogAutoPublishMethods {}
+applyMixins(DKGAgent, [ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods, Rfc64CatalogUpsertMethods, Rfc64CatalogAutoPublishMethods]);

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -13,10 +13,8 @@ import type {
   Rfc64CatalogAccessPolicyAuthorityConfigV1,
   Rfc64PublicCatalogAutoPublishConfigV1,
 } from '../dkg-agent-types.js';
+import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './catalog-peers-v1.js';
 
-const MAX_RFC64_AUTO_PUBLISH_PEERS_V1 = 64;
-const MAX_RFC64_PEER_ID_BYTES_V1 = 256;
-const UTF8 = new TextEncoder();
 
 /** Detach a locally configured deployment tuple from caller-owned state. */
 export function snapshotRfc64CatalogDeploymentProfileV1(
@@ -124,28 +122,7 @@ export function snapshotRfc64PublicCatalogAutoPublishConfigV1(
   ) {
     throw new TypeError('rfc64PublicCatalogAutoPublish has unknown or missing fields');
   }
-  if (!Array.isArray(input.peers) || input.peers.length > MAX_RFC64_AUTO_PUBLISH_PEERS_V1) {
-    throw new TypeError(
-      `rfc64PublicCatalogAutoPublish.peers must contain at most ${MAX_RFC64_AUTO_PUBLISH_PEERS_V1} peer IDs`,
-    );
-  }
-  const peers: string[] = [];
-  const seen = new Set<string>();
-  for (const peerId of input.peers) {
-    if (
-      typeof peerId !== 'string'
-      || peerId.length === 0
-      || peerId.trim() !== peerId
-      || UTF8.encode(peerId).byteLength > MAX_RFC64_PEER_ID_BYTES_V1
-    ) {
-      throw new TypeError('rfc64PublicCatalogAutoPublish.peers contains an invalid peer ID');
-    }
-    if (seen.has(peerId)) {
-      throw new TypeError('rfc64PublicCatalogAutoPublish.peers must be unique');
-    }
-    seen.add(peerId);
-    peers.push(peerId);
-  }
+  const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
   const effectiveAt = snapshotTimestamp(
     input.catalogIssuerDelegationEffectiveAt ?? ('0' as TimestampMsV1),
     'catalogIssuerDelegationEffectiveAt',
@@ -160,7 +137,7 @@ export function snapshotRfc64PublicCatalogAutoPublishConfigV1(
     );
   }
   return Object.freeze({
-    peers: Object.freeze(peers),
+    peers,
     catalogIssuerDelegationEffectiveAt: effectiveAt,
     catalogIssuerDelegationExpiresAt: expiresAt,
   });

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -5,10 +5,18 @@ import {
   assertNetworkIdV1,
   type CatalogSealDeploymentProfileV1,
   type EvmAddressV1,
+  type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 
-import type { Rfc64CatalogAccessPolicyAuthorityConfigV1 } from '../dkg-agent-types.js';
+import type {
+  Rfc64CatalogAccessPolicyAuthorityConfigV1,
+  Rfc64PublicCatalogAutoPublishConfigV1,
+} from '../dkg-agent-types.js';
+
+const MAX_RFC64_AUTO_PUBLISH_PEERS_V1 = 64;
+const MAX_RFC64_PEER_ID_BYTES_V1 = 256;
+const UTF8 = new TextEncoder();
 
 /** Detach a locally configured deployment tuple from caller-owned state. */
 export function snapshotRfc64CatalogDeploymentProfileV1(
@@ -89,4 +97,81 @@ export function snapshotRfc64CatalogAccessPolicyAuthorityV1(
     localAgentAddress: input.localAgentAddress.toLowerCase() as EvmAddressV1,
     resolveRemoteAgentAddress: input.resolveRemoteAgentAddress,
   });
+}
+
+/** Detach and validate the preview authoring configuration at create time. */
+export function snapshotRfc64PublicCatalogAutoPublishConfigV1(
+  input: Rfc64PublicCatalogAutoPublishConfigV1 | undefined,
+): Readonly<Rfc64PublicCatalogAutoPublishConfigV1> | undefined {
+  if (input === undefined) return undefined;
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('rfc64PublicCatalogAutoPublish must be a plain object');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('rfc64PublicCatalogAutoPublish must be a plain object');
+  }
+  const keys = Object.keys(input).sort();
+  const allowed = new Set([
+    'catalogIssuerDelegationEffectiveAt',
+    'catalogIssuerDelegationExpiresAt',
+    'peers',
+  ]);
+  if (
+    keys.some((key) => !allowed.has(key))
+    || !keys.includes('peers')
+    || !keys.includes('catalogIssuerDelegationExpiresAt')
+  ) {
+    throw new TypeError('rfc64PublicCatalogAutoPublish has unknown or missing fields');
+  }
+  if (!Array.isArray(input.peers) || input.peers.length > MAX_RFC64_AUTO_PUBLISH_PEERS_V1) {
+    throw new TypeError(
+      `rfc64PublicCatalogAutoPublish.peers must contain at most ${MAX_RFC64_AUTO_PUBLISH_PEERS_V1} peer IDs`,
+    );
+  }
+  const peers: string[] = [];
+  const seen = new Set<string>();
+  for (const peerId of input.peers) {
+    if (
+      typeof peerId !== 'string'
+      || peerId.length === 0
+      || peerId.trim() !== peerId
+      || UTF8.encode(peerId).byteLength > MAX_RFC64_PEER_ID_BYTES_V1
+    ) {
+      throw new TypeError('rfc64PublicCatalogAutoPublish.peers contains an invalid peer ID');
+    }
+    if (seen.has(peerId)) {
+      throw new TypeError('rfc64PublicCatalogAutoPublish.peers must be unique');
+    }
+    seen.add(peerId);
+    peers.push(peerId);
+  }
+  const effectiveAt = snapshotTimestamp(
+    input.catalogIssuerDelegationEffectiveAt ?? ('0' as TimestampMsV1),
+    'catalogIssuerDelegationEffectiveAt',
+  );
+  const expiresAt = snapshotTimestamp(
+    input.catalogIssuerDelegationExpiresAt,
+    'catalogIssuerDelegationExpiresAt',
+  );
+  if (BigInt(expiresAt) <= BigInt(effectiveAt)) {
+    throw new TypeError(
+      'rfc64PublicCatalogAutoPublish delegation expiry must be after its effective time',
+    );
+  }
+  return Object.freeze({
+    peers: Object.freeze(peers),
+    catalogIssuerDelegationEffectiveAt: effectiveAt,
+    catalogIssuerDelegationExpiresAt: expiresAt,
+  });
+}
+
+function snapshotTimestamp(value: unknown, label: string): TimestampMsV1 {
+  if (typeof value !== 'string' || !/^(0|[1-9][0-9]*)$/u.test(value)) {
+    throw new TypeError(`rfc64PublicCatalogAutoPublish.${label} must be a canonical timestamp`);
+  }
+  if (BigInt(value) > 18_446_744_073_709_551_615n) {
+    throw new TypeError(`rfc64PublicCatalogAutoPublish.${label} exceeds uint64`);
+  }
+  return value as TimestampMsV1;
 }

--- a/packages/agent/src/rfc64/catalog-peers-v1.ts
+++ b/packages/agent/src/rfc64/catalog-peers-v1.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** Canonical bounded peer-list snapshot shared by catalog config and fan-out. */
+
+export const RFC64_PUBLIC_CATALOG_ANNOUNCE_MAX_PEERS_V1 = 64;
+const RFC64_PUBLIC_CATALOG_PEER_ID_MAX_BYTES_V1 = 256;
+const UTF8 = new TextEncoder();
+
+export function snapshotRfc64PublicCatalogAnnouncementPeersV1(
+  input: readonly string[],
+): readonly string[] {
+  if (!Array.isArray(input)) {
+    throw new TypeError('RFC-64 catalog announcement peers must be an array');
+  }
+  if (input.length > RFC64_PUBLIC_CATALOG_ANNOUNCE_MAX_PEERS_V1) {
+    throw new RangeError(
+      `RFC-64 catalog announcement accepts at most `
+      + `${RFC64_PUBLIC_CATALOG_ANNOUNCE_MAX_PEERS_V1} peers`,
+    );
+  }
+  const seen = new Set<string>();
+  const peers: string[] = [];
+  for (let index = 0; index < input.length; index += 1) {
+    const peerId = input[index];
+    const byteLength = typeof peerId === 'string' ? UTF8.encode(peerId).byteLength : 0;
+    if (
+      typeof peerId !== 'string'
+      || byteLength === 0
+      || byteLength > RFC64_PUBLIC_CATALOG_PEER_ID_MAX_BYTES_V1
+      || peerId.trim() !== peerId
+    ) {
+      throw new TypeError(`RFC-64 catalog announcement peer ${index} is invalid`);
+    }
+    if (seen.has(peerId)) {
+      throw new TypeError(`RFC-64 catalog announcement peer ${index} is duplicated`);
+    }
+    seen.add(peerId);
+    peers.push(peerId);
+  }
+  return Object.freeze(peers);
+}

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -98,13 +98,15 @@ import {
   type FetchedRfc64PublicCatalogHeadV1,
   type Rfc64PublicCatalogHeadAnnouncementV1,
 } from './public-catalog-transport-v1.js';
+import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './catalog-peers-v1.js';
+
+export {
+  RFC64_PUBLIC_CATALOG_ANNOUNCE_MAX_PEERS_V1,
+  snapshotRfc64PublicCatalogAnnouncementPeersV1,
+} from './catalog-peers-v1.js';
 
 /** Default per-peer announce/fetch deadline (ms). */
 const DEFAULT_TRANSPORT_TIMEOUT_MS = 10_000;
-/** Hard fan-out bound for one explicit best-effort announcement call. */
-export const RFC64_PUBLIC_CATALOG_ANNOUNCE_MAX_PEERS_V1 = 64;
-const RFC64_PUBLIC_CATALOG_PEER_ID_MAX_BYTES_V1 = 256;
-const UTF8 = new TextEncoder();
 
 export interface Rfc64PublicCatalogServiceOptionsV1 {
   readonly router: ProtocolRouter;
@@ -806,40 +808,6 @@ export class Rfc64PublicCatalogServiceV1 {
       throw new Error('RFC-64 public catalog service is not started');
     }
   }
-}
-
-export function snapshotRfc64PublicCatalogAnnouncementPeersV1(
-  input: readonly string[],
-): readonly string[] {
-  if (!Array.isArray(input)) {
-    throw new TypeError('RFC-64 catalog announcement peers must be an array');
-  }
-  if (input.length > RFC64_PUBLIC_CATALOG_ANNOUNCE_MAX_PEERS_V1) {
-    throw new RangeError(
-      `RFC-64 catalog announcement accepts at most `
-      + `${RFC64_PUBLIC_CATALOG_ANNOUNCE_MAX_PEERS_V1} peers`,
-    );
-  }
-  const seen = new Set<string>();
-  const peers: string[] = [];
-  for (let index = 0; index < input.length; index += 1) {
-    const peerId = input[index];
-    const byteLength = typeof peerId === 'string' ? UTF8.encode(peerId).byteLength : 0;
-    if (
-      typeof peerId !== 'string'
-      || byteLength === 0
-      || byteLength > RFC64_PUBLIC_CATALOG_PEER_ID_MAX_BYTES_V1
-      || peerId.trim() !== peerId
-    ) {
-      throw new TypeError(`RFC-64 catalog announcement peer ${index} is invalid`);
-    }
-    if (seen.has(peerId)) {
-      throw new TypeError(`RFC-64 catalog announcement peer ${index} is duplicated`);
-    }
-    seen.add(peerId);
-    peers.push(peerId);
-  }
-  return Object.freeze(peers);
 }
 
 function assertSupportedCatalogFanout(

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -798,6 +798,8 @@ function makeQueuedAgentHarness(options: {
     _resolveEncryptInlineChunked: recorder(async () => options.encryptInlineChunked),
     _stampPointer: recorder(async () => undefined),
   };
+  agentLike.afterConfirmedGraphScopedVmPublishV1 =
+    (DKGAgent.prototype as any).afterConfirmedGraphScopedVmPublishV1;
   if (options.onChainContextGraphId !== undefined) {
     agentLike.getContextGraphOnChainId = recorder(
       async () => options.onChainContextGraphId,
@@ -892,6 +894,42 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
         contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
       },
     });
+  });
+
+  it('keeps a confirmed queued publish successful when catalog advancement fails', async () => {
+    const { agentLike } = makeQueuedAgentHarness({
+      peerId: 'did:dkg:agent:queued-catalog-failure',
+      ual: 'did:dkg:local/queued-catalog-failure',
+      publishStatus: 'confirmed',
+    });
+    agentLike.recordConfirmedRfc64PublicCatalogAssetV1 = recorder(async () => {
+      throw new Error('simulated RFC-64 catalog failure');
+    });
+    const snapshotQuads = [{
+      subject: 'urn:test:queued-public-failure',
+      predicate: 'http://schema.org/name',
+      object: '"Queued Public"',
+      graph: '',
+    }];
+    const request = await makeQueuedPublishRequest({
+      contextGraphId: 'public-cg',
+      name: 'queued-public-ka-failure',
+      shareOperationId: 'share-op-catalog-failure',
+      intentByte: 'ae',
+      quads: snapshotQuads,
+    });
+
+    const result = await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(
+      agentLike,
+      request,
+      { contextGraphId: request.contextGraphId, quads: snapshotQuads },
+    );
+
+    expect(result).toMatchObject({ status: 'confirmed' });
+    expect(agentLike.log.warn.calls.some((call: unknown[]) => (
+      String(call[1]).includes('RFC-64 catalog advancement failed')
+      && String(call[1]).includes('simulated RFC-64 catalog failure')
+    ))).toBe(true);
   });
 
   it('keeps the V2 snapshot exact while passing a detached catalog capability', async () => {

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -764,13 +764,14 @@ const QUEUED_TEST_LIFECYCLE = '0x2222222222222222222222222222222222222222';
 function makeQueuedAgentHarness(options: {
   peerId: string;
   ual: string;
+  publishStatus?: 'tentative' | 'confirmed';
   chain?: Record<string, unknown>;
   onChainContextGraphId?: string | null;
   encryptInlinePayload?: unknown;
   encryptInlineChunked?: unknown;
 }) {
   const publisherPublish = recorder(async (_opts: any) => ({
-    status: 'tentative' as const,
+    status: options.publishStatus ?? 'tentative',
     ual: options.ual,
   }));
   const agentLike: any = {
@@ -853,6 +854,46 @@ async function makeQueuedPublishRequest(options: {
 }
 
 describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routing', () => {
+  it('hands one confirmed queued public publish to the RFC-64 catalog bridge', async () => {
+    const { agentLike } = makeQueuedAgentHarness({
+      peerId: 'did:dkg:agent:queued-catalog',
+      ual: 'did:dkg:local/queued-catalog',
+      publishStatus: 'confirmed',
+    });
+    const catalogAdvance = recorder(async () => null);
+    agentLike.recordConfirmedRfc64PublicCatalogAssetV1 = catalogAdvance;
+    const snapshotQuads = [{
+      subject: 'urn:test:queued-public',
+      predicate: 'http://schema.org/name',
+      object: '"Queued Public"',
+      graph: '',
+    }];
+    const request = await makeQueuedPublishRequest({
+      contextGraphId: 'public-cg',
+      name: 'queued-public-ka',
+      shareOperationId: 'share-op-catalog',
+      intentByte: 'ad',
+      quads: snapshotQuads,
+    });
+
+    await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(
+      agentLike,
+      request,
+      { contextGraphId: request.contextGraphId, quads: snapshotQuads },
+    );
+
+    expect(catalogAdvance.calls).toHaveLength(1);
+    expect(catalogAdvance.calls[0]?.[0]).toMatchObject({
+      contextGraphId: 'public-cg',
+      assertionCoordinate: 'queued-public-ka',
+      publicQuads: snapshotQuads,
+      seal: {
+        authorAddress: QUEUED_TEST_AUTHOR,
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      },
+    });
+  });
+
   it('keeps the V2 snapshot exact while passing a detached catalog capability', async () => {
     const realInline = recorder(async (plaintext: Uint8Array) => new Uint8Array([...plaintext, 0xaa]));
     const realChunked = recorder(async () => ({

--- a/packages/agent/test/publish-finalized-agent-lane.test.ts
+++ b/packages/agent/test/publish-finalized-agent-lane.test.ts
@@ -140,6 +140,7 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
     }> = [];
     const publishCalls: Array<{ contextGraphId: string; selection: any; opts: any }> = [];
     const remainingClearCalls: any[][] = [];
+    const rfc64CatalogCalls: any[] = [];
 
     const agent = Object.create(DKGAgent.prototype) as any;
     agent.store = store;
@@ -173,6 +174,10 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
         status: 'confirmed',
         publicQuads: [],
       };
+    };
+    agent.recordConfirmedRfc64PublicCatalogAssetV1 = async (input: any) => {
+      rfc64CatalogCalls.push(input);
+      return null;
     };
 
     // GH#1778 — a genuinely absent name still yields "is not finalized":
@@ -221,6 +226,17 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
     expect(remainingClearCalls).toHaveLength(1);
     expect(remainingClearCalls[0].slice(0, 2)).toEqual([CG, undefined]);
     expect(result.status).toBe('confirmed');
+    expect(rfc64CatalogCalls).toHaveLength(1);
+    expect(rfc64CatalogCalls[0]).toMatchObject({
+      contextGraphId: CG,
+      assertionCoordinate: NAME,
+      publicQuads: [PUBLIC_QUAD],
+    });
+    expect(rfc64CatalogCalls[0].seal).toMatchObject({
+      authorAddress: AGENT_B,
+      reservedKaId: RESERVED_KA_ID,
+      kaUal: KA_UAL,
+    });
   });
 
   it('maps an empty exact KA graph to the mint no-data precondition', async () => {

--- a/packages/agent/test/publish-finalized-agent-lane.test.ts
+++ b/packages/agent/test/publish-finalized-agent-lane.test.ts
@@ -141,6 +141,7 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
     const publishCalls: Array<{ contextGraphId: string; selection: any; opts: any }> = [];
     const remainingClearCalls: any[][] = [];
     const rfc64CatalogCalls: any[] = [];
+    const warnings: string[] = [];
 
     const agent = Object.create(DKGAgent.prototype) as any;
     agent.store = store;
@@ -150,7 +151,10 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
       value: '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6',
       configurable: true,
     });
-    agent.log = makeLog();
+    agent.log = {
+      ...makeLog(),
+      warn: (_ctx: unknown, message: string) => { warnings.push(message); },
+    };
     agent.publisher = {
       hasSwmShareComplete: async (
         contextGraphId: string,
@@ -177,7 +181,7 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
     };
     agent.recordConfirmedRfc64PublicCatalogAssetV1 = async (input: any) => {
       rfc64CatalogCalls.push(input);
-      return null;
+      throw new Error('simulated finalized RFC-64 catalog failure');
     };
 
     // GH#1778 — a genuinely absent name still yields "is not finalized":
@@ -237,6 +241,9 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
       reservedKaId: RESERVED_KA_ID,
       kaUal: KA_UAL,
     });
+    expect(warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('simulated finalized RFC-64 catalog failure'),
+    ]));
   });
 
   it('maps an empty exact KA graph to the mint no-data precondition', async () => {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -416,6 +416,137 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     });
   }, 60_000);
 
+  it('does not expose an empty applied head when first-asset successor staging fails', async () => {
+    const author = await startNativeAgent(
+      'auto-publish-first-asset-retry',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
+    author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const publicQuads = [
+      {
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/age',
+        object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: '',
+      },
+      {
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/name',
+        object: '"Alice"',
+        graph: '',
+      },
+    ];
+    const params = {
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'first-asset-retry' as never,
+      publicQuads,
+      seal: assertionSealFromCanonical(await authorSeal(60n, publicQuads)),
+    };
+    const publishSuccessor = vi.spyOn(author, 'publishAuthorCatalogExactSetSuccessorV1')
+      .mockRejectedValueOnce(new Error('simulated successor staging failure'));
+    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1(params))
+      .rejects.toThrow('simulated successor staging failure');
+    expect(author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toBeNull();
+
+    publishSuccessor.mockRestore();
+    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1(params)).resolves.toMatchObject({
+      catalogVersion: '1',
+      inventoryRowCount: '1',
+    });
+  }, 60_000);
+
+  it('atomically serializes concurrent first-asset catalog upserts without losing a row', async () => {
+    const receiver = await startNativeAgent('auto-publish-concurrent-receiver');
+    const author = await startNativeAgent(
+      'auto-publish-concurrent-author',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [receiver.peerId],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
+    for (const agent of [author, receiver]) {
+      agent.acceptOpenContextGraphPolicyV1({
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        ownerAddress: AUTHOR,
+      });
+    }
+    await connectBothWays(author, receiver);
+
+    const publicQuads = [
+      {
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/age',
+        object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: '',
+      },
+      {
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/name',
+        object: '"Alice"',
+        graph: '',
+      },
+    ];
+    const kaNumbers = [61n, 62n] as const;
+    const results = await Promise.all(kaNumbers.map(async (kaNumber, index) => (
+      author.recordConfirmedRfc64PublicCatalogAssetV1({
+        contextGraphId: CONTEXT_GRAPH_ID,
+        assertionCoordinate: `concurrent-confirmed-${index + 1}` as never,
+        publicQuads,
+        seal: assertionSealFromCanonical(await authorSeal(kaNumber, publicQuads)),
+      })
+    )));
+    expect(results).not.toContain(null);
+    const first = results.find((result) => result?.catalogVersion === '1');
+    const final = results.find((result) => result?.catalogVersion === '2');
+    expect(final).toMatchObject({ catalogVersion: '2', inventoryRowCount: '2' });
+    if (first === undefined || first === null || final === undefined || final === null) {
+      throw new Error('concurrent catalog upserts did not produce both successors');
+    }
+
+    const scopeDigest = catalogScopeDigest();
+    expect(author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: scopeDigest,
+      authorAddress: AUTHOR,
+    })).toEqual(final);
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64AppliedCatalogHeadV1({
+        catalogScopeDigest: scopeDigest,
+        authorAddress: AUTHOR,
+      })?.currentCatalogHeadDigest).toBe(final.currentCatalogHeadDigest);
+    }, { timeout: 20_000, interval: 100 });
+    const evidence = receiver.readRfc64PublicCatalogSynchronizationEvidenceV1(
+      final.currentCatalogHeadDigest,
+    );
+    expect(evidence).toMatchObject({
+      inventoryRowCount: 2,
+      appliedHeadStatus: 'applied',
+    });
+    expect(new Set(evidence?.rows.map(({ kaId }) => kaId))).toEqual(new Set(
+      kaNumbers.map((kaNumber) => ((BigInt(AUTHOR) << 96n) | kaNumber).toString()),
+    ));
+  }, 60_000);
+
   it('serializes mixed-case projection terms in raw UTF-8 order', async () => {
     const author = await startNativeAgent(
       'auto-publish-byte-order',

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -12,6 +12,7 @@ import {
   contextGraphLayerUri,
   type CanonicalGraphScopedAuthorSealV1,
   type CatalogSealDeploymentProfileV1,
+  type AssertionSeal,
   type ContextGraphIdV1,
   type ContextGraphPolicyV1,
   type Digest32V1,
@@ -28,11 +29,13 @@ import { DKGAgent } from '../src/dkg-agent.js';
 import {
   snapshotRfc64CatalogAccessPolicyAuthorityV1,
   snapshotRfc64CatalogDeploymentProfileV1,
+  snapshotRfc64PublicCatalogAutoPublishConfigV1,
 } from '../src/dkg-agent-rfc64-catalog.js';
 import type {
   ContextGraphSubscriptionRecord,
   ContextGraphSubscriptionStore,
   Rfc64CatalogAccessPolicyAuthorityConfigV1,
+  Rfc64PublicCatalogAutoPublishConfigV1,
 } from '../src/dkg-agent-types.js';
 import {
   createLoopbackJsonRpcTestHarness,
@@ -97,6 +100,7 @@ async function startNativeAgent(
     chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
     initialSubscription?: ContextGraphIdV1;
   }>,
+  autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1,
 ): Promise<DKGAgent> {
   const dataDir = existingDataDir
     ?? await mkdtemp(join(tmpdir(), `dkg-rfc64-native-${name}-`));
@@ -116,6 +120,7 @@ async function startNativeAgent(
     agentProfileHeartbeatMs: 0,
     rfc64CatalogDeploymentProfile: deployment,
     rfc64CatalogAccessPolicyAuthority: accessPolicyAuthority,
+    rfc64PublicCatalogAutoPublish: autoPublish,
     ...(finalizedRuntime === undefined ? {} : {
       chainAdapter: finalizedRuntime.chainAdapter,
       chainConfig: {
@@ -268,6 +273,147 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
       assertedAtKav10Address: `0x${'00'.repeat(20)}` as never,
     })).toThrow(/non-zero EVM address/);
   });
+
+  it('snapshots the opt-in normal-publication catalog producer configuration', () => {
+    const callerOwned = {
+      peers: ['12D3KooReceiver'],
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    };
+    const snapshot = snapshotRfc64PublicCatalogAutoPublishConfigV1(callerOwned)!;
+    callerOwned.peers.push('hostile-late-mutation');
+    expect(snapshot).toEqual({
+      peers: ['12D3KooReceiver'],
+      catalogIssuerDelegationEffectiveAt: '0',
+      catalogIssuerDelegationExpiresAt: '1893456000000',
+    });
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.peers)).toBe(true);
+    expect(() => snapshotRfc64PublicCatalogAutoPublishConfigV1({
+      peers: ['duplicate', 'duplicate'],
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    })).toThrow(/must be unique/u);
+  });
+
+  it('turns one confirmed public KA into the provider current head and one cold receiver apply', async () => {
+    const receiver = await startNativeAgent('auto-publish-receiver');
+    const author = await startNativeAgent(
+      'auto-publish-author',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [receiver.peerId],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
+    for (const agent of [author, receiver]) {
+      agent.acceptOpenContextGraphPolicyV1({
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        ownerAddress: AUTHOR,
+      });
+    }
+    await connectBothWays(author, receiver);
+
+    const seal = assertionSealFromCanonical(await authorSeal(11n));
+    const first = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'ordinary-confirmed-publication' as never,
+      publicQuads: [
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/name',
+          object: '"Alice"',
+          graph: 'urn:ignored-local-graph',
+        },
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/age',
+          object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          graph: 'urn:ignored-local-graph',
+        },
+      ],
+      seal,
+    });
+    expect(first).toMatchObject({ catalogVersion: '1', inventoryRowCount: '1' });
+    await receiver.whenRfc64PublicCatalogReceiverIdleV1();
+
+    const scopeDigest = catalogScopeDigest();
+    expect(author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: scopeDigest,
+      authorAddress: AUTHOR,
+    })).toEqual(first);
+    expect(receiver.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: scopeDigest,
+      authorAddress: AUTHOR,
+    })).toMatchObject({
+      currentCatalogHeadDigest: first?.currentCatalogHeadDigest,
+      catalogVersion: '1',
+      inventoryRowCount: '1',
+    });
+    expect(receiver.rfc64PublicCatalogStatsV1()?.receiver).toMatchObject({
+      applied: 1,
+      failed: 0,
+    });
+
+    const replay = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'ordinary-confirmed-publication' as never,
+      publicQuads: [
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/name',
+          object: '"Alice"',
+          graph: '',
+        },
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/age',
+          object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          graph: '',
+        },
+      ],
+      seal,
+    });
+    expect(replay).toEqual(first);
+    expect(receiver.rfc64PublicCatalogStatsV1()?.receiver.applied).toBe(1);
+
+    const second = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'second-ordinary-confirmed-publication' as never,
+      publicQuads: [
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/name',
+          object: '"Alice"',
+          graph: '',
+        },
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/age',
+          object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          graph: '',
+        },
+      ],
+      seal: assertionSealFromCanonical(await authorSeal(12n)),
+    });
+    expect(second).toMatchObject({ catalogVersion: '2', inventoryRowCount: '2' });
+    await receiver.whenRfc64PublicCatalogReceiverIdleV1();
+    expect(receiver.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: scopeDigest,
+      authorAddress: AUTHOR,
+    })).toMatchObject({
+      currentCatalogHeadDigest: second?.currentCatalogHeadDigest,
+      catalogVersion: '2',
+      inventoryRowCount: '2',
+    });
+    expect(receiver.rfc64PublicCatalogStatsV1()?.receiver).toMatchObject({
+      applied: 2,
+      failed: 0,
+    });
+  }, 60_000);
 
   it('snapshots the explicit access authority and fails closed before private activation', async () => {
     const resolver = async () => AUTHOR;
@@ -975,4 +1121,27 @@ async function authorSeal(kaNumber: bigint): Promise<CanonicalGraphScopedAuthorS
   } as unknown as CanonicalGraphScopedAuthorSealV1;
   assertCanonicalGraphScopedAuthorSealV1(seal);
   return seal;
+}
+
+function assertionSealFromCanonical(seal: CanonicalGraphScopedAuthorSealV1): AssertionSeal {
+  return {
+    merkleRoot: ethers.getBytes(seal.assertionMerkleRoot),
+    authorAddress: seal.authorAddress,
+    authorAttestationR: ethers.getBytes(seal.authorAttestationR),
+    authorAttestationVS: ethers.getBytes(seal.authorAttestationVS),
+    authorSchemeVersion: 1,
+    chainId: BigInt(seal.assertedAtChainId),
+    kav10Address: seal.assertedAtKav10Address,
+    reservedKaId: BigInt(seal.reservedKaId),
+    finalizedAtIso: seal.assertionFinalizedAt,
+    contentScopeVersion: 2,
+    kaUal: seal.kaUal,
+    assertionVersion: seal.assertionVersion,
+    publicTripleCount: Number(seal.publicTripleCount),
+    ...(seal.privateMerkleRoot === null
+      ? {}
+      : { privateMerkleRoot: ethers.getBytes(seal.privateMerkleRoot) }),
+    privateTripleCount: Number(seal.privateTripleCount),
+    rootEntities: [],
+  };
 }

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -21,7 +21,8 @@ import {
   type NetworkIdV1,
   type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
-import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -291,7 +292,7 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     expect(() => snapshotRfc64PublicCatalogAutoPublishConfigV1({
       peers: ['duplicate', 'duplicate'],
       catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
-    })).toThrow(/must be unique/u);
+    })).toThrow(/duplicated/u);
   });
 
   it('turns one confirmed public KA into the provider current head and one cold receiver apply', async () => {
@@ -413,6 +414,95 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
       applied: 2,
       failed: 0,
     });
+  }, 60_000);
+
+  it('serializes mixed-case projection terms in raw UTF-8 order', async () => {
+    const author = await startNativeAgent(
+      'auto-publish-byte-order',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
+    author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const publicQuads = [
+      {
+        subject: 'urn:a',
+        predicate: 'https://schema.org/name',
+        object: '"lowercase"',
+        graph: '',
+      },
+      {
+        subject: 'urn:Z',
+        predicate: 'https://schema.org/name',
+        object: '"uppercase"',
+        graph: '',
+      },
+    ];
+    const applied = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'mixed-case-byte-order' as never,
+      publicQuads,
+      seal: assertionSealFromCanonical(await authorSeal(31n, publicQuads)),
+    });
+    expect(applied).toMatchObject({ catalogVersion: '1', inventoryRowCount: '1' });
+  }, 60_000);
+
+  it('explicitly skips private-bearing ordinary publishes in the public-only V1 bridge', async () => {
+    const author = await startNativeAgent(
+      'auto-publish-private-skip',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
+    author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const privateBearingSeal: AssertionSeal = {
+      ...assertionSealFromCanonical(await authorSeal(32n)),
+      privateTripleCount: 1,
+      privateMerkleRoot: ethers.getBytes(`0x${'99'.repeat(32)}`),
+    };
+    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'private-bearing-skip' as never,
+      publicQuads: [
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/name',
+          object: '"Alice"',
+          graph: '',
+        },
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/age',
+          object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          graph: '',
+        },
+      ],
+      seal: privateBearingSeal,
+    })).resolves.toBeNull();
+    expect(author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toBeNull();
   }, 60_000);
 
   it('snapshots the explicit access authority and fails closed before private activation', async () => {
@@ -1160,13 +1250,19 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
   }, 60_000);
 });
 
-async function authorSeal(kaNumber: bigint): Promise<CanonicalGraphScopedAuthorSealV1> {
+async function authorSeal(
+  kaNumber: bigint,
+  publicQuads?: readonly Quad[],
+): Promise<CanonicalGraphScopedAuthorSealV1> {
   const kaId = ((BigInt(AUTHOR) << 96n) | kaNumber).toString();
   const kaUal = `did:dkg:${NETWORK_ID}/${AUTHOR}/${kaNumber}`;
+  const assertionMerkleRoot = publicQuads === undefined
+    ? ASSERTION_ROOT
+    : ethers.hexlify(computeFlatKCRootV10([...publicQuads], [])) as Digest32V1;
   const typedData = buildAuthorAttestationTypedData({
     chainId: BigInt(NATIVE_DEPLOYMENT.assertedAtChainId),
     kav10Address: NATIVE_DEPLOYMENT.assertedAtKav10Address,
-    merkleRoot: ethers.getBytes(ASSERTION_ROOT),
+    merkleRoot: ethers.getBytes(assertionMerkleRoot),
     authorAddress: AUTHOR,
     reservedKaId: BigInt(kaId),
   });
@@ -1176,7 +1272,7 @@ async function authorSeal(kaNumber: bigint): Promise<CanonicalGraphScopedAuthorS
     typedData.message,
   ));
   const seal = {
-    assertionMerkleRoot: ASSERTION_ROOT,
+    assertionMerkleRoot,
     authorAddress: AUTHOR,
     authorAttestationR: signature.r,
     authorAttestationVS: signature.yParityAndS,
@@ -1188,7 +1284,7 @@ async function authorSeal(kaNumber: bigint): Promise<CanonicalGraphScopedAuthorS
     contentScopeVersion: '2',
     kaUal,
     assertionVersion: '1',
-    publicTripleCount: '2',
+    publicTripleCount: String(publicQuads?.length ?? 2),
     privateTripleCount: '0',
     privateMerkleRoot: null,
   } as unknown as CanonicalGraphScopedAuthorSealV1;

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -416,6 +416,97 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     });
   }, 60_000);
 
+  it('canonicalizes ordinary literal lexical forms before catalog projection verification', async () => {
+    const author = await startNativeAgent(
+      'auto-publish-canonical-literal',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
+    author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const publicQuads = [{
+      subject: 'https://example.org/alice',
+      predicate: 'https://schema.org/age',
+      object: '"042"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      graph: 'urn:ignored-local-graph',
+    }];
+
+    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'ordinary-noncanonical-literal' as never,
+      publicQuads,
+      seal: assertionSealFromCanonical(await authorSeal(13n, publicQuads)),
+    })).resolves.toMatchObject({ catalogVersion: '1', inventoryRowCount: '1' });
+  }, 60_000);
+
+  it('uses the chain signer for a confirmed author when no custodial key is available', async () => {
+    const author = await startNativeAgent(
+      'auto-publish-chain-signer',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(undefined);
+    const chain = (author as unknown as {
+      chain: {
+        signMessageAs?: (
+          address: string,
+          message: Uint8Array,
+        ) => Promise<{ r: Uint8Array; vs: Uint8Array }>;
+      };
+    }).chain;
+    const signMessageAs = vi.fn(async (address: string, message: Uint8Array) => {
+      expect(address).toBe(AUTHOR);
+      const signature = ethers.Signature.from(await AUTHOR_WALLET.signMessage(message));
+      return {
+        r: ethers.getBytes(signature.r),
+        vs: ethers.getBytes(signature.yParityAndS),
+      };
+    });
+    chain.signMessageAs = signMessageAs;
+    author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+
+    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'ordinary-chain-signed-publication' as never,
+      publicQuads: [
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/name',
+          object: '"Alice"',
+          graph: '',
+        },
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/age',
+          object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          graph: '',
+        },
+      ],
+      seal: assertionSealFromCanonical(await authorSeal(14n)),
+    })).resolves.toMatchObject({ catalogVersion: '1', inventoryRowCount: '1' });
+    expect(signMessageAs).toHaveBeenCalled();
+  }, 60_000);
+
   it('does not expose an empty applied head when first-asset successor staging fails', async () => {
     const author = await startNativeAgent(
       'auto-publish-first-asset-retry',

--- a/packages/core/src/canonical-graph-scoped-author-seal.ts
+++ b/packages/core/src/canonical-graph-scoped-author-seal.ts
@@ -4,6 +4,7 @@ import {
   ASSERTION_SEAL_PREDICATES,
   buildAssertionSealQuads,
   parseGraphScopedAssertionSealCandidate,
+  type AssertionSeal,
   type GraphScopedAssertionSealCandidate,
 } from './assertion-seal.js';
 import {
@@ -119,6 +120,48 @@ export interface CanonicalGraphScopedAuthorSealV1 {
   readonly publicTripleCount: SealTripleCountV1;
   readonly privateTripleCount: SealTripleCountV1;
   readonly privateMerkleRoot: Digest32V1 | null;
+}
+
+/**
+ * Convert the normal publication seal into the exact RFC-64 wire payload.
+ * Keeping this at the protocol boundary prevents catalog bridges from owning
+ * a second, cast-heavy encoding of the signed graph-scoped seal.
+ */
+export function canonicalGraphScopedAuthorSealFromAssertionSealV1(
+  seal: AssertionSeal,
+): Readonly<CanonicalGraphScopedAuthorSealV1> {
+  if (
+    seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+    || seal.kaUal === undefined
+    || seal.assertionVersion === undefined
+    || seal.publicTripleCount === undefined
+    || seal.privateTripleCount === undefined
+    || seal.reservedKaId === undefined
+    || seal.authorSchemeVersion !== 1
+  ) {
+    fail('canonical-seal-schema', 'conversion requires a complete graph-scoped v2 author seal');
+  }
+  const canonical: unknown = {
+    assertionMerkleRoot: bytesToLowerHex32(seal.merkleRoot, 'assertionMerkleRoot'),
+    authorAddress: seal.authorAddress.toLowerCase(),
+    authorAttestationR: bytesToLowerHex32(seal.authorAttestationR, 'authorAttestationR'),
+    authorAttestationVS: bytesToLowerHex32(seal.authorAttestationVS, 'authorAttestationVS'),
+    authorSchemeVersion: '1',
+    assertedAtChainId: seal.chainId.toString(),
+    assertedAtKav10Address: seal.kav10Address.toLowerCase(),
+    reservedKaId: seal.reservedKaId.toString(),
+    assertionFinalizedAt: seal.finalizedAtIso,
+    contentScopeVersion: '2',
+    kaUal: seal.kaUal,
+    assertionVersion: seal.assertionVersion,
+    publicTripleCount: seal.publicTripleCount.toString(),
+    privateTripleCount: seal.privateTripleCount.toString(),
+    privateMerkleRoot: seal.privateMerkleRoot === undefined
+      ? null
+      : bytesToLowerHex32(seal.privateMerkleRoot, 'privateMerkleRoot'),
+  };
+  assertCanonicalGraphScopedAuthorSealV1(canonical);
+  return Object.freeze(canonical);
 }
 
 /** Authenticated catalog coordinate used to derive subject and physical metadata graph. */
@@ -963,6 +1006,15 @@ function hex32ToBytes(value: string): Uint8Array {
     bytes[index] = Number.parseInt(value.slice(2 + (index * 2), 4 + (index * 2)), 16);
   }
   return bytes;
+}
+
+function bytesToLowerHex32(bytes: Uint8Array, label: string): string {
+  if (bytes.byteLength !== 32) {
+    fail('canonical-seal-scalar', `${label} must contain exactly 32 bytes`);
+  }
+  let result = '0x';
+  for (const byte of bytes) result += byte.toString(16).padStart(2, '0');
+  return result;
 }
 
 function bytesToDigest(bytes: Uint8Array): Digest32V1 {

--- a/packages/core/src/cg-shared-projection.ts
+++ b/packages/core/src/cg-shared-projection.ts
@@ -77,6 +77,38 @@ export interface CgSharedProjectionVerificationLimitsV1 {
   readonly maxLineBytes: number;
 }
 
+export interface CgSharedPublicRootProjectionTripleV1 {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+}
+
+/**
+ * Encode public-root triples into the exact canonical bytes consumed by the
+ * cg-shared-v1 verifier: V10-canonical terms, one LF per line, and raw UTF-8
+ * byte ordering. Graph placement is deliberately absent from this wire view.
+ */
+export function encodeCanonicalCgSharedPublicRootProjectionV1(
+  triples: readonly CgSharedPublicRootProjectionTripleV1[],
+): Uint8Array {
+  const lines = triples.map(({ subject, predicate, object }) => {
+    const content = tripleContentV10(subject, predicate, object);
+    const line = new Uint8Array(content.byteLength + 1);
+    line.set(content);
+    line[line.byteLength - 1] = 0x0a;
+    return line;
+  });
+  lines.sort(compareBytes);
+  const byteLength = lines.reduce((sum, line) => sum + line.byteLength, 0);
+  const projection = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const line of lines) {
+    projection.set(line, offset);
+    offset += line.byteLength;
+  }
+  return projection;
+}
+
 /**
  * Process-local proof that one structurally verified transferred bundle carries
  * the exact canonical `cg-shared-v1` projection committed by its author seal.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -361,6 +361,7 @@ export {
   MAX_SEAL_TRIPLE_COUNT_V1,
   CanonicalGraphScopedAuthorSealError,
   assertCanonicalGraphScopedAuthorSealV1,
+  canonicalGraphScopedAuthorSealFromAssertionSealV1,
   canonicalizeCanonicalGraphScopedAuthorSealV1,
   canonicalizeCanonicalGraphScopedAuthorSealBytesV1,
   parseCanonicalGraphScopedAuthorSealV1,


### PR DESCRIPTION
## Summary
- add an opt-in RFC-64 producer bridge for ordinary confirmed root/public KA publishes
- durably advance exact author-catalog heads, preserve existing rows, dedupe replay, and best-effort announce configured peers
- wire both direct finalized and queued publication paths while leaving legacy behavior unchanged when disabled
- isolate authoring orchestration in a focused mixin and validate/snapshot configuration at agent creation

Stacked on #1926; retarget to `integration/rfc64-devnet` after that PR merges.

## Evidence
- `pnpm --filter @origintrail-official/dkg-agent build`
- native production wiring: 11/11 passed after stack merge
- publication hook suites: 34/34 passed
- real two-agent proof advances two confirmed KAs through catalog versions 1 -> 2 and receiver row counts 1 -> 2; exact replay is deduped