### PR TITLE
feat(agent): bootstrap pinned RFC-64 public catalogs

### DIFF
--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -46,6 +46,8 @@ const requiredCatalogMethods = [
   'publishAuthorCatalogExactSetSuccessorV1',
   'recordConfirmedRfc64PublicCatalogAssetV1',
   'synchronizeRfc64PublicCatalogFromProviderV1',
+  'readRfc64PublicCatalogBootstrapStatusV1',
+  'whenRfc64PublicCatalogBootstrapIdleV1',
 ];
 for (const method of requiredCatalogMethods) {
   if (

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1306,6 +1306,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // production router. Announce/fetch protocols are admission-gated like
     // every other node protocol. Dormant when no dataDir opened persistence.
     this.startRfc64PublicCatalogServiceV1(ctx);
+    this.startRfc64PublicCatalogBootstrapV1(ctx);
 
     const effectiveRole = this.config.nodeRole ?? 'edge';
     const ackSignerCandidates = this.getACKSignerCandidateWallets(ctx);

--- a/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
@@ -3,6 +3,7 @@
 /** Restart-safe, operator-pinned public catalog cold-start supervisor. */
 
 import {
+  computeContextGraphPolicyObjectDigestV1,
   type ContextGraphIdV1,
   type Digest32V1,
   type EvmAddressV1,
@@ -16,6 +17,7 @@ import type {
   Rfc64PublicCatalogBootstrapConfigV1,
   Rfc64PublicCatalogBootstrapScopeV1,
 } from './dkg-agent-types.js';
+import { mapWithConcurrency } from './map-with-concurrency.js';
 
 const MAX_STATUS_ERROR_BYTES_V1 = 1024;
 const MAX_CONCURRENT_TARGETS_V1 = 4;
@@ -89,13 +91,25 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
     }
     for (const accepted of config.acceptedPublicPolicies) {
       service.acceptPolicySnapshot({
-        policy: accepted.policy,
-        policyDigest: accepted.policyDigest,
+        policy: accepted.policyEnvelope.payload,
+        policyDigest: computeContextGraphPolicyObjectDigestV1(accepted.policyEnvelope),
       });
     }
+    const targets = config.acceptedPublicPolicies.flatMap(({ policyEnvelope, targets }) => (
+      targets.map((target) => ({
+        scope: Object.freeze({
+          networkId: policyEnvelope.payload.networkId,
+          contextGraphId: policyEnvelope.payload.contextGraphId,
+          subGraphName: null,
+          authorAddress: target.authorAddress,
+          catalogEra: policyEnvelope.payload.era,
+        }),
+        providers: target.providers,
+      }))
+    ));
     const state: BootstrapStateV1 = {
       config,
-      targets: config.targets.map((target) => ({
+      targets: targets.map((target) => ({
         scope: target.scope,
         providers: target.providers,
         outcome: 'pending',
@@ -197,24 +211,18 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
     state.lastPassStartedAtMs = Date.now();
     const abortController = new AbortController();
     state.abortController = abortController;
-    let cursor = 0;
-    const workers = Array.from(
-      { length: Math.min(MAX_CONCURRENT_TARGETS_V1, state.targets.length) },
-      async () => {
-        while (!state.closed) {
-          const index = cursor;
-          cursor += 1;
-          const target = state.targets[index];
-          if (target === undefined) return;
+    try {
+      await mapWithConcurrency(
+        state.targets,
+        MAX_CONCURRENT_TARGETS_V1,
+        async (target) => {
+          if (state.closed) return;
           await this.synchronizeRfc64PublicCatalogBootstrapTargetV1(
             target,
             abortController.signal,
           );
-        }
-      },
-    );
-    try {
-      await Promise.all(workers);
+        },
+      );
     } finally {
       if (state.abortController === abortController) state.abortController = null;
       state.running = false;
@@ -227,6 +235,13 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
     target: MutableTargetStatusV1,
     signal: AbortSignal,
   ): Promise<void> {
+    target.outcome = 'pending';
+    target.attempts = 0;
+    target.providerPeerId = null;
+    target.appliedHeadDigest = null;
+    target.catalogVersion = null;
+    target.inventoryRowCount = null;
+    target.lastError = null;
     let sawNotFound = false;
     let lastError: string | null = null;
     for (const providerPeerId of target.providers) {
@@ -257,6 +272,9 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
     }
     target.outcome = lastError === null && sawNotFound ? 'not-found' : 'failed';
     target.providerPeerId = null;
+    target.appliedHeadDigest = null;
+    target.catalogVersion = null;
+    target.inventoryRowCount = null;
     target.lastError = lastError;
     target.updatedAtMs = Date.now();
   }

--- a/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** Restart-safe, operator-pinned public catalog cold-start supervisor. */
+
+import {
+  type ContextGraphIdV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
+  type OperationContext,
+} from '@origintrail-official/dkg-core';
+
+import { DKGAgentBase } from './dkg-agent-base.js';
+import type { DKGAgent } from './dkg-agent.js';
+import type {
+  Rfc64PublicCatalogBootstrapConfigV1,
+  Rfc64PublicCatalogBootstrapScopeV1,
+} from './dkg-agent-types.js';
+
+const MAX_STATUS_ERROR_BYTES_V1 = 1024;
+const MAX_CONCURRENT_TARGETS_V1 = 4;
+const UTF8 = new TextEncoder();
+
+export type Rfc64PublicCatalogBootstrapOutcomeV1 =
+  | 'pending'
+  | 'applied'
+  | 'not-found'
+  | 'failed';
+
+export interface Rfc64PublicCatalogBootstrapTargetStatusV1 {
+  readonly scope: Readonly<Rfc64PublicCatalogBootstrapScopeV1>;
+  readonly providers: readonly string[];
+  readonly outcome: Rfc64PublicCatalogBootstrapOutcomeV1;
+  readonly attempts: number;
+  readonly providerPeerId: string | null;
+  readonly appliedHeadDigest: Digest32V1 | null;
+  readonly catalogVersion: string | null;
+  readonly inventoryRowCount: string | null;
+  readonly lastError: string | null;
+  readonly updatedAtMs: number | null;
+}
+
+export interface Rfc64PublicCatalogBootstrapStatusV1 {
+  readonly running: boolean;
+  readonly pass: number;
+  readonly retryIntervalMs: number;
+  readonly lastPassStartedAtMs: number | null;
+  readonly lastPassCompletedAtMs: number | null;
+  readonly targets: readonly Rfc64PublicCatalogBootstrapTargetStatusV1[];
+}
+
+interface MutableTargetStatusV1 {
+  readonly scope: Readonly<Rfc64PublicCatalogBootstrapScopeV1>;
+  readonly providers: readonly string[];
+  outcome: Rfc64PublicCatalogBootstrapOutcomeV1;
+  attempts: number;
+  providerPeerId: string | null;
+  appliedHeadDigest: Digest32V1 | null;
+  catalogVersion: string | null;
+  inventoryRowCount: string | null;
+  lastError: string | null;
+  updatedAtMs: number | null;
+}
+
+interface BootstrapStateV1 {
+  readonly config: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
+  readonly targets: MutableTargetStatusV1[];
+  readonly ctx: OperationContext;
+  closed: boolean;
+  running: boolean;
+  pass: number;
+  lastPassStartedAtMs: number | null;
+  lastPassCompletedAtMs: number | null;
+  timer: ReturnType<typeof setTimeout> | null;
+  abortController: AbortController | null;
+  run: Promise<void> | null;
+}
+
+const STATES = new WeakMap<DKGAgent, BootstrapStateV1>();
+
+export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
+  /** Accept pinned policies and start the first bounded provider pass. */
+  startRfc64PublicCatalogBootstrapV1(this: DKGAgent, ctx: OperationContext): void {
+    const config = this.config.rfc64PublicCatalogBootstrap;
+    if (config === undefined || STATES.has(this)) return;
+    const service = this.rfc64PublicCatalogServiceV1;
+    if (service === undefined) {
+      throw new Error('RFC-64 bootstrap requires the public catalog service');
+    }
+    for (const accepted of config.acceptedPublicPolicies) {
+      service.acceptPolicySnapshot({
+        policy: accepted.policy,
+        policyDigest: accepted.policyDigest,
+      });
+    }
+    const state: BootstrapStateV1 = {
+      config,
+      targets: config.targets.map((target) => ({
+        scope: target.scope,
+        providers: target.providers,
+        outcome: 'pending',
+        attempts: 0,
+        providerPeerId: null,
+        appliedHeadDigest: null,
+        catalogVersion: null,
+        inventoryRowCount: null,
+        lastError: null,
+        updatedAtMs: null,
+      })),
+      ctx,
+      closed: false,
+      running: false,
+      pass: 0,
+      lastPassStartedAtMs: null,
+      lastPassCompletedAtMs: null,
+      timer: null,
+      abortController: null,
+      run: null,
+    };
+    STATES.set(this, state);
+    this.launchRfc64PublicCatalogBootstrapPassV1(state);
+  }
+
+  /** Immutable bounded observability for release harnesses and daemon adapters. */
+  readRfc64PublicCatalogBootstrapStatusV1(
+    this: DKGAgent,
+  ): Readonly<Rfc64PublicCatalogBootstrapStatusV1> | null {
+    const state = STATES.get(this);
+    if (state === undefined) return null;
+    return Object.freeze({
+      running: state.running,
+      pass: state.pass,
+      retryIntervalMs: state.config.retryIntervalMs ?? 0,
+      lastPassStartedAtMs: state.lastPassStartedAtMs,
+      lastPassCompletedAtMs: state.lastPassCompletedAtMs,
+      targets: Object.freeze(state.targets.map(snapshotTargetStatusV1)),
+    });
+  }
+
+  /** Wait for the currently running startup/refresh pass only. */
+  async whenRfc64PublicCatalogBootstrapIdleV1(this: DKGAgent): Promise<void> {
+    const state = STATES.get(this);
+    if (state === undefined) return;
+    while (state.run !== null) {
+      const current = state.run;
+      await current;
+      if (state.run === current) return;
+    }
+  }
+
+  /** Stop future retries and abort/drain the current pass before service close. */
+  async closeRfc64PublicCatalogBootstrapV1(this: DKGAgent): Promise<void> {
+    const state = STATES.get(this);
+    if (state === undefined) return;
+    state.closed = true;
+    if (state.timer !== null) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+    state.abortController?.abort(new Error('RFC-64 public catalog bootstrap closing'));
+    await state.run?.catch(() => undefined);
+    STATES.delete(this);
+  }
+
+  private launchRfc64PublicCatalogBootstrapPassV1(
+    this: DKGAgent,
+    state: BootstrapStateV1,
+  ): void {
+    if (state.closed || state.run !== null) return;
+    const run = this.runRfc64PublicCatalogBootstrapPassV1(state)
+      .catch((error) => {
+        this.log.warn(
+          state.ctx,
+          `RFC-64 public catalog bootstrap pass failed: ${errorMessageV1(error)}`,
+        );
+      })
+      .finally(() => {
+        if (state.run === run) state.run = null;
+        const retryIntervalMs = state.config.retryIntervalMs ?? 0;
+        if (!state.closed && retryIntervalMs > 0) {
+          state.timer = setTimeout(() => {
+            state.timer = null;
+            this.launchRfc64PublicCatalogBootstrapPassV1(state);
+          }, retryIntervalMs);
+          state.timer.unref?.();
+        }
+      });
+    state.run = run;
+  }
+
+  private async runRfc64PublicCatalogBootstrapPassV1(
+    this: DKGAgent,
+    state: BootstrapStateV1,
+  ): Promise<void> {
+    state.running = true;
+    state.pass += 1;
+    state.lastPassStartedAtMs = Date.now();
+    const abortController = new AbortController();
+    state.abortController = abortController;
+    let cursor = 0;
+    const workers = Array.from(
+      { length: Math.min(MAX_CONCURRENT_TARGETS_V1, state.targets.length) },
+      async () => {
+        while (!state.closed) {
+          const index = cursor;
+          cursor += 1;
+          const target = state.targets[index];
+          if (target === undefined) return;
+          await this.synchronizeRfc64PublicCatalogBootstrapTargetV1(
+            target,
+            abortController.signal,
+          );
+        }
+      },
+    );
+    try {
+      await Promise.all(workers);
+    } finally {
+      if (state.abortController === abortController) state.abortController = null;
+      state.running = false;
+      state.lastPassCompletedAtMs = Date.now();
+    }
+  }
+
+  private async synchronizeRfc64PublicCatalogBootstrapTargetV1(
+    this: DKGAgent,
+    target: MutableTargetStatusV1,
+    signal: AbortSignal,
+  ): Promise<void> {
+    let sawNotFound = false;
+    let lastError: string | null = null;
+    for (const providerPeerId of target.providers) {
+      if (signal.aborted) return;
+      target.attempts += 1;
+      try {
+        const applied = await this.synchronizeRfc64PublicCatalogFromProviderV1({
+          remotePeerId: providerPeerId,
+          scope: target.scope,
+          signal,
+        });
+        if (applied === null) {
+          sawNotFound = true;
+          continue;
+        }
+        target.outcome = 'applied';
+        target.providerPeerId = providerPeerId;
+        target.appliedHeadDigest = applied.currentCatalogHeadDigest;
+        target.catalogVersion = applied.catalogVersion;
+        target.inventoryRowCount = applied.inventoryRowCount;
+        target.lastError = null;
+        target.updatedAtMs = Date.now();
+        return;
+      } catch (error) {
+        if (signal.aborted) return;
+        lastError = boundedErrorV1(errorMessageV1(error));
+      }
+    }
+    target.outcome = lastError === null && sawNotFound ? 'not-found' : 'failed';
+    target.providerPeerId = null;
+    target.lastError = lastError;
+    target.updatedAtMs = Date.now();
+  }
+}
+
+function snapshotTargetStatusV1(
+  target: MutableTargetStatusV1,
+): Readonly<Rfc64PublicCatalogBootstrapTargetStatusV1> {
+  return Object.freeze({
+    scope: Object.freeze({
+      networkId: target.scope.networkId as NetworkIdV1,
+      contextGraphId: target.scope.contextGraphId as ContextGraphIdV1,
+      subGraphName: target.scope.subGraphName,
+      authorAddress: target.scope.authorAddress as EvmAddressV1,
+      catalogEra: target.scope.catalogEra,
+    }),
+    providers: Object.freeze([...target.providers]),
+    outcome: target.outcome,
+    attempts: target.attempts,
+    providerPeerId: target.providerPeerId,
+    appliedHeadDigest: target.appliedHeadDigest,
+    catalogVersion: target.catalogVersion,
+    inventoryRowCount: target.inventoryRowCount,
+    lastError: target.lastError,
+    updatedAtMs: target.updatedAtMs,
+  });
+}
+
+function errorMessageV1(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function boundedErrorV1(input: string): string {
+  if (UTF8.encode(input).byteLength <= MAX_STATUS_ERROR_BYTES_V1) return input;
+  let output = '';
+  for (const character of input) {
+    if (UTF8.encode(`${output}${character}`).byteLength > MAX_STATUS_ERROR_BYTES_V1) break;
+    output += character;
+  }
+  return output;
+}

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -181,6 +181,7 @@ export {
   snapshotRfc64CatalogAccessPolicyAuthorityV1,
   snapshotRfc64CatalogDeploymentProfileV1,
   snapshotRfc64PublicCatalogAutoPublishConfigV1,
+  snapshotRfc64PublicCatalogBootstrapConfigV1,
 } from './rfc64/catalog-authority-config-v1.js';
 
 export interface PublishOpenAuthorCatalogSuccessorParamsV1 {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -39,6 +39,7 @@ import type {
   NetworkIdV1,
   SubGraphNameV1,
   TimestampMsV1,
+  UnsignedContextGraphPolicyEnvelopeV1,
 } from '@origintrail-official/dkg-core';
 import type {
   PhaseCallback,
@@ -1086,9 +1087,16 @@ export interface Rfc64PublicCatalogBootstrapScopeV1 {
 }
 
 export interface Rfc64PublicCatalogBootstrapTargetV1 {
-  readonly scope: Rfc64PublicCatalogBootstrapScopeV1;
+  readonly authorAddress: EvmAddressV1;
   /** Ordered provider failover candidates for this exact author catalog. */
   readonly providers: readonly string[];
+}
+
+export interface Rfc64PublicCatalogBootstrapPolicyV1 {
+  /** Exact verified control object; its digest is recomputed during snapshotting. */
+  readonly policyEnvelope: UnsignedContextGraphPolicyEnvelopeV1;
+  /** Author catalogs under the policy graph/era. */
+  readonly targets: readonly Rfc64PublicCatalogBootstrapTargetV1[];
 }
 
 /**
@@ -1098,11 +1106,7 @@ export interface Rfc64PublicCatalogBootstrapTargetV1 {
  * deterministic harnesses. Omission defaults to a 30-second refresh pass.
  */
 export interface Rfc64PublicCatalogBootstrapConfigV1 {
-  readonly acceptedPublicPolicies: readonly Readonly<{
-    readonly policy: ContextGraphPolicyV1;
-    readonly policyDigest: Digest32V1;
-  }>[];
-  readonly targets: readonly Rfc64PublicCatalogBootstrapTargetV1[];
+  readonly acceptedPublicPolicies: readonly Rfc64PublicCatalogBootstrapPolicyV1[];
   readonly retryIntervalMs?: number;
 }
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -31,7 +31,13 @@ import type {
   ContextGraphJoinPolicyMode as CoreContextGraphJoinPolicyMode,
   ContextGraphJoinPolicyRecord as CoreContextGraphJoinPolicyRecord,
   CatalogSealDeploymentProfileV1,
+  ContextGraphIdV1,
+  ContextGraphPolicyV1,
+  DecimalU64V1,
+  Digest32V1,
   EvmAddressV1,
+  NetworkIdV1,
+  SubGraphNameV1,
   TimestampMsV1,
 } from '@origintrail-official/dkg-core';
 import type {
@@ -1071,6 +1077,35 @@ export interface Rfc64PublicCatalogAutoPublishConfigV1 {
   readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;
 }
 
+export interface Rfc64PublicCatalogBootstrapScopeV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly catalogEra: DecimalU64V1;
+}
+
+export interface Rfc64PublicCatalogBootstrapTargetV1 {
+  readonly scope: Rfc64PublicCatalogBootstrapScopeV1;
+  /** Ordered provider failover candidates for this exact author catalog. */
+  readonly providers: readonly string[];
+}
+
+/**
+ * Explicit V1 cold-start manifest. Policies are operator-pinned outputs of an
+ * independent finality/administrative verifier; the catalog lane only consumes
+ * them. A zero retry interval performs one startup pass, which is useful for
+ * deterministic harnesses. Omission defaults to a 30-second refresh pass.
+ */
+export interface Rfc64PublicCatalogBootstrapConfigV1 {
+  readonly acceptedPublicPolicies: readonly Readonly<{
+    readonly policy: ContextGraphPolicyV1;
+    readonly policyDigest: Digest32V1;
+  }>[];
+  readonly targets: readonly Rfc64PublicCatalogBootstrapTargetV1[];
+  readonly retryIntervalMs?: number;
+}
+
 export interface DKGAgentConfig {
   name: string;
   /** Selected genesis document. Defaults to the compatibility Base testnet genesis. */
@@ -1092,6 +1127,8 @@ export interface DKGAgentConfig {
   rfc64CatalogAccessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1;
   /** Omission preserves the existing publication and synchronization behavior. */
   rfc64PublicCatalogAutoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
+  /** Omission preserves manual RFC-64 current-head discovery. */
+  rfc64PublicCatalogBootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
   /**
    * public-projection enable flag. When set, a private CG's confirmed VM
    * publishes emit/refresh a verifiable public projection (the floor: existence,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -407,7 +407,11 @@ import {
   snapshotRfc64CatalogDeploymentProfileV1,
 } from './dkg-agent-rfc64-catalog.js';
 import { Rfc64CatalogAutoPublishMethods } from './dkg-agent-rfc64-catalog-auto-publish.js';
-import { snapshotRfc64PublicCatalogAutoPublishConfigV1 } from './rfc64/catalog-authority-config-v1.js';
+import { Rfc64CatalogBootstrapMethods } from './dkg-agent-rfc64-catalog-bootstrap.js';
+import {
+  snapshotRfc64PublicCatalogAutoPublishConfigV1,
+  snapshotRfc64PublicCatalogBootstrapConfigV1,
+} from './rfc64/catalog-authority-config-v1.js';
 import { Rfc64CatalogSyncMethods } from './dkg-agent-rfc64-catalog-sync.js';
 import { ContextGraphRegistryMethods } from './dkg-agent-cg-registry.js';
 import { JoinRequestMethods } from './dkg-agent-join.js';
@@ -710,6 +714,9 @@ export class DKGAgent extends DKGAgentBase {
     const rfc64PublicCatalogAutoPublish = snapshotRfc64PublicCatalogAutoPublishConfigV1(
       config.rfc64PublicCatalogAutoPublish,
     );
+    const rfc64PublicCatalogBootstrap = snapshotRfc64PublicCatalogBootstrapConfigV1(
+      config.rfc64PublicCatalogBootstrap,
+    );
     let wallet: DKGAgentWallet;
     if (config.dataDir) {
       try {
@@ -817,6 +824,7 @@ export class DKGAgent extends DKGAgentBase {
       rfc64CatalogAccessPolicyAuthority,
       rfc64CatalogDeploymentProfile,
       rfc64PublicCatalogAutoPublish,
+      rfc64PublicCatalogBootstrap,
     };
 
     const port = config.listenPort ?? 0;
@@ -1735,6 +1743,7 @@ export class DKGAgent extends DKGAgentBase {
     // router, node, and control-object store are all still live — before
     // node.stop() below and before closeRfc64PersistenceV1() releases the store.
     try {
+      await this.closeRfc64PublicCatalogBootstrapV1();
       await this.closeRfc64PublicCatalogServiceV1();
     } catch (err) {
       this.log.warn(
@@ -3064,5 +3073,5 @@ export class DKGAgent extends DKGAgentBase {
 }
 
 
-export interface DKGAgent extends ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods, Rfc64CatalogAutoPublishMethods {}
-applyMixins(DKGAgent, [ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods, Rfc64CatalogAutoPublishMethods]);
+export interface DKGAgent extends ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods, Rfc64CatalogAutoPublishMethods, Rfc64CatalogBootstrapMethods {}
+applyMixins(DKGAgent, [ImportedArtifactMethods, ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, Rfc64CatalogMethods, Rfc64CatalogSyncMethods, Rfc64CatalogAutoPublishMethods, Rfc64CatalogBootstrapMethods]);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -699,6 +699,12 @@ export class DKGAgent extends DKGAgentBase {
     | undefined;
 
   static async create(inputConfig: DKGAgentConfig): Promise<DKGAgent> {
+    // RFC-64 bootstrap owns durable catalog and control-object state. Reject
+    // an impossible ephemeral configuration before constructing a store or
+    // node so start() can never fail after leaving libp2p half-running.
+    if (inputConfig.rfc64PublicCatalogBootstrap !== undefined && !inputConfig.dataDir) {
+      throw new TypeError('rfc64PublicCatalogBootstrap requires dataDir');
+    }
     validateSyncResponderSnapshotLimitsConfig(inputConfig.syncResponderSnapshotLimits);
     const config = normalizeStorageAckConfig({
       ...inputConfig,

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -2,7 +2,15 @@
 
 import {
   assertCanonicalChainId,
+  assertCanonicalDecimalU64,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertContextGraphIdV1,
   assertNetworkIdV1,
+  canonicalizeContextGraphPolicyPayloadV1,
+  parseCanonicalContextGraphPolicyPayloadV1,
+  type ContextGraphPolicyV1,
+  type Digest32V1,
   type CatalogSealDeploymentProfileV1,
   type EvmAddressV1,
   type TimestampMsV1,
@@ -12,11 +20,19 @@ import { ethers } from 'ethers';
 import type {
   Rfc64CatalogAccessPolicyAuthorityConfigV1,
   Rfc64PublicCatalogAutoPublishConfigV1,
+  Rfc64PublicCatalogBootstrapConfigV1,
+  Rfc64PublicCatalogBootstrapScopeV1,
+  Rfc64PublicCatalogBootstrapTargetV1,
 } from '../dkg-agent-types.js';
 
 const MAX_RFC64_AUTO_PUBLISH_PEERS_V1 = 64;
 const MAX_RFC64_PEER_ID_BYTES_V1 = 256;
 const UTF8 = new TextEncoder();
+const MAX_RFC64_BOOTSTRAP_POLICIES_V1 = 64;
+const MAX_RFC64_BOOTSTRAP_TARGETS_V1 = 256;
+const MAX_RFC64_BOOTSTRAP_PROVIDERS_V1 = 8;
+const DEFAULT_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1 = 30_000;
+const MAX_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1 = 3_600_000;
 
 /** Detach a locally configured deployment tuple from caller-owned state. */
 export function snapshotRfc64CatalogDeploymentProfileV1(
@@ -166,6 +182,112 @@ export function snapshotRfc64PublicCatalogAutoPublishConfigV1(
   });
 }
 
+/** Detach and validate the explicit public cold-start manifest. */
+export function snapshotRfc64PublicCatalogBootstrapConfigV1(
+  input: Rfc64PublicCatalogBootstrapConfigV1 | undefined,
+): Readonly<Rfc64PublicCatalogBootstrapConfigV1> | undefined {
+  if (input === undefined) return undefined;
+  assertPlainExactObject(
+    input,
+    'rfc64PublicCatalogBootstrap',
+    ['acceptedPublicPolicies', 'retryIntervalMs', 'targets'],
+    ['acceptedPublicPolicies', 'targets'],
+  );
+  if (
+    !Array.isArray(input.acceptedPublicPolicies)
+    || input.acceptedPublicPolicies.length > MAX_RFC64_BOOTSTRAP_POLICIES_V1
+  ) {
+    throw new TypeError(
+      `rfc64PublicCatalogBootstrap.acceptedPublicPolicies must contain at most `
+      + `${MAX_RFC64_BOOTSTRAP_POLICIES_V1} policies`,
+    );
+  }
+  const policies = input.acceptedPublicPolicies.map((entry, index) => {
+    assertPlainExactObject(
+      entry,
+      `rfc64PublicCatalogBootstrap.acceptedPublicPolicies[${index}]`,
+      ['policy', 'policyDigest'],
+      ['policy', 'policyDigest'],
+    );
+    const candidate = entry as {
+      readonly policy: ContextGraphPolicyV1;
+      readonly policyDigest: Digest32V1;
+    };
+    const policy = parseCanonicalContextGraphPolicyPayloadV1(
+      canonicalizeContextGraphPolicyPayloadV1(candidate.policy),
+    );
+    if (policy.accessPolicy !== 0) {
+      throw new TypeError('rfc64PublicCatalogBootstrap accepts public policies only');
+    }
+    assertCanonicalDigest(candidate.policyDigest, `acceptedPublicPolicies[${index}].policyDigest`);
+    return Object.freeze({
+      policy: deepFreezePlain(policy),
+      policyDigest: candidate.policyDigest,
+    });
+  });
+  const policyKeys = new Set<string>();
+  for (const { policy } of policies) {
+    const key = `${policy.networkId}\n${policy.contextGraphId}`;
+    if (policyKeys.has(key)) {
+      throw new TypeError('rfc64PublicCatalogBootstrap policies must be unique by graph');
+    }
+    policyKeys.add(key);
+  }
+
+  if (!Array.isArray(input.targets) || input.targets.length > MAX_RFC64_BOOTSTRAP_TARGETS_V1) {
+    throw new TypeError(
+      `rfc64PublicCatalogBootstrap.targets must contain at most `
+      + `${MAX_RFC64_BOOTSTRAP_TARGETS_V1} catalogs`,
+    );
+  }
+  const targetKeys = new Set<string>();
+  const targets = input.targets.map((target, index) => {
+    assertPlainExactObject(
+      target,
+      `rfc64PublicCatalogBootstrap.targets[${index}]`,
+      ['providers', 'scope'],
+      ['providers', 'scope'],
+    );
+    const candidate = target as unknown as Rfc64PublicCatalogBootstrapTargetV1;
+    const scope = snapshotBootstrapScope(candidate.scope, index);
+    const policy = policies.find((candidate) => (
+      candidate.policy.networkId === scope.networkId
+      && candidate.policy.contextGraphId === scope.contextGraphId
+    ));
+    if (policy === undefined || policy.policy.era !== scope.catalogEra) {
+      throw new TypeError(
+        'rfc64PublicCatalogBootstrap target has no matching accepted policy era',
+      );
+    }
+    const providers = snapshotBootstrapProviders(candidate.providers, index);
+    const key = `${scope.networkId}\n${scope.contextGraphId}\n${scope.authorAddress}`
+      + `\n${scope.catalogEra}`;
+    if (targetKeys.has(key)) {
+      throw new TypeError('rfc64PublicCatalogBootstrap targets must be unique by author scope');
+    }
+    targetKeys.add(key);
+    return Object.freeze({ scope, providers });
+  });
+
+  const retryIntervalMs = input.retryIntervalMs
+    ?? DEFAULT_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1;
+  if (
+    !Number.isSafeInteger(retryIntervalMs)
+    || retryIntervalMs < 0
+    || retryIntervalMs > MAX_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1
+    || (retryIntervalMs > 0 && retryIntervalMs < 1_000)
+  ) {
+    throw new TypeError(
+      'rfc64PublicCatalogBootstrap.retryIntervalMs must be 0 or 1000..3600000',
+    );
+  }
+  return Object.freeze({
+    acceptedPublicPolicies: Object.freeze(policies),
+    targets: Object.freeze(targets),
+    retryIntervalMs,
+  });
+}
+
 function snapshotTimestamp(value: unknown, label: string): TimestampMsV1 {
   if (typeof value !== 'string' || !/^(0|[1-9][0-9]*)$/u.test(value)) {
     throw new TypeError(`rfc64PublicCatalogAutoPublish.${label} must be a canonical timestamp`);
@@ -174,4 +296,93 @@ function snapshotTimestamp(value: unknown, label: string): TimestampMsV1 {
     throw new TypeError(`rfc64PublicCatalogAutoPublish.${label} exceeds uint64`);
   }
   return value as TimestampMsV1;
+}
+
+function snapshotBootstrapScope(
+  input: Rfc64PublicCatalogBootstrapScopeV1,
+  index: number,
+): Readonly<Rfc64PublicCatalogBootstrapScopeV1> {
+  assertPlainExactObject(
+    input,
+    `rfc64PublicCatalogBootstrap.targets[${index}].scope`,
+    ['authorAddress', 'catalogEra', 'contextGraphId', 'networkId', 'subGraphName'],
+    ['authorAddress', 'catalogEra', 'contextGraphId', 'networkId', 'subGraphName'],
+  );
+  assertNetworkIdV1(input.networkId, 'bootstrap scope networkId');
+  assertContextGraphIdV1(input.contextGraphId, 'bootstrap scope contextGraphId');
+  if (input.subGraphName !== null) {
+    throw new TypeError('rfc64PublicCatalogBootstrap V1 targets public root catalogs only');
+  }
+  assertCanonicalEvmAddress(input.authorAddress, 'bootstrap scope authorAddress');
+  if (input.authorAddress === `0x${'0'.repeat(40)}`) {
+    throw new TypeError('rfc64PublicCatalogBootstrap authorAddress must be nonzero');
+  }
+  assertCanonicalDecimalU64(input.catalogEra, 'bootstrap scope catalogEra');
+  return Object.freeze({
+    networkId: input.networkId,
+    contextGraphId: input.contextGraphId,
+    subGraphName: null,
+    authorAddress: input.authorAddress,
+    catalogEra: input.catalogEra,
+  });
+}
+
+function snapshotBootstrapProviders(input: readonly string[], targetIndex: number): readonly string[] {
+  if (
+    !Array.isArray(input)
+    || input.length === 0
+    || input.length > MAX_RFC64_BOOTSTRAP_PROVIDERS_V1
+  ) {
+    throw new TypeError(
+      `rfc64PublicCatalogBootstrap.targets[${targetIndex}].providers must contain 1..`
+      + `${MAX_RFC64_BOOTSTRAP_PROVIDERS_V1} peers`,
+    );
+  }
+  const seen = new Set<string>();
+  const providers = input.map((peerId) => {
+    if (
+      typeof peerId !== 'string'
+      || peerId.length === 0
+      || peerId.trim() !== peerId
+      || UTF8.encode(peerId).byteLength > MAX_RFC64_PEER_ID_BYTES_V1
+      || seen.has(peerId)
+    ) {
+      throw new TypeError('rfc64PublicCatalogBootstrap contains an invalid provider peer ID');
+    }
+    seen.add(peerId);
+    return peerId;
+  });
+  return Object.freeze(providers);
+}
+
+function assertPlainExactObject(
+  input: unknown,
+  label: string,
+  allowed: readonly string[],
+  required: readonly string[],
+): asserts input is Record<string, unknown> {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError(`${label} must be a plain object`);
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(`${label} must be a plain object`);
+  }
+  const keys = Object.keys(input);
+  if (
+    keys.some((key) => !allowed.includes(key))
+    || required.some((key) => !keys.includes(key))
+  ) {
+    throw new TypeError(`${label} has unknown or missing fields`);
+  }
+}
+
+function deepFreezePlain<T>(input: T): Readonly<T> {
+  if (input !== null && typeof input === 'object') {
+    for (const value of Object.values(input as Record<string, unknown>)) {
+      deepFreezePlain(value);
+    }
+    if (!Object.isFrozen(input)) Object.freeze(input);
+  }
+  return input;
 }

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -2,15 +2,10 @@
 
 import {
   assertCanonicalChainId,
-  assertCanonicalDecimalU64,
-  assertCanonicalDigest,
   assertCanonicalEvmAddress,
-  assertContextGraphIdV1,
   assertNetworkIdV1,
-  canonicalizeContextGraphPolicyPayloadV1,
-  parseCanonicalContextGraphPolicyPayloadV1,
-  type ContextGraphPolicyV1,
-  type Digest32V1,
+  canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1,
+  parseCanonicalUnsignedContextGraphPolicyEnvelopeV1,
   type CatalogSealDeploymentProfileV1,
   type EvmAddressV1,
   type TimestampMsV1,
@@ -21,7 +16,6 @@ import type {
   Rfc64CatalogAccessPolicyAuthorityConfigV1,
   Rfc64PublicCatalogAutoPublishConfigV1,
   Rfc64PublicCatalogBootstrapConfigV1,
-  Rfc64PublicCatalogBootstrapScopeV1,
   Rfc64PublicCatalogBootstrapTargetV1,
 } from '../dkg-agent-types.js';
 import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './catalog-peers-v1.js';
@@ -167,8 +161,8 @@ export function snapshotRfc64PublicCatalogBootstrapConfigV1(
   assertPlainExactObject(
     input,
     'rfc64PublicCatalogBootstrap',
-    ['acceptedPublicPolicies', 'retryIntervalMs', 'targets'],
-    ['acceptedPublicPolicies', 'targets'],
+    ['acceptedPublicPolicies', 'retryIntervalMs'],
+    ['acceptedPublicPolicies'],
   );
   if (
     !Array.isArray(input.acceptedPublicPolicies)
@@ -179,71 +173,70 @@ export function snapshotRfc64PublicCatalogBootstrapConfigV1(
       + `${MAX_RFC64_BOOTSTRAP_POLICIES_V1} policies`,
     );
   }
+  const policyKeys = new Set<string>();
+  const targetKeys = new Set<string>();
+  let totalTargets = 0;
   const policies = input.acceptedPublicPolicies.map((entry, index) => {
     assertPlainExactObject(
       entry,
       `rfc64PublicCatalogBootstrap.acceptedPublicPolicies[${index}]`,
-      ['policy', 'policyDigest'],
-      ['policy', 'policyDigest'],
+      ['policyEnvelope', 'targets'],
+      ['policyEnvelope', 'targets'],
     );
-    const candidate = entry as {
-      readonly policy: ContextGraphPolicyV1;
-      readonly policyDigest: Digest32V1;
+    const candidate = entry as unknown as {
+      readonly policyEnvelope: Rfc64PublicCatalogBootstrapConfigV1[
+        'acceptedPublicPolicies'
+      ][number]['policyEnvelope'];
+      readonly targets: readonly Rfc64PublicCatalogBootstrapTargetV1[];
     };
-    const policy = parseCanonicalContextGraphPolicyPayloadV1(
-      canonicalizeContextGraphPolicyPayloadV1(candidate.policy),
+    const policyEnvelope = parseCanonicalUnsignedContextGraphPolicyEnvelopeV1(
+      canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1(candidate.policyEnvelope),
     );
+    const policy = policyEnvelope.payload;
     if (policy.accessPolicy !== 0) {
       throw new TypeError('rfc64PublicCatalogBootstrap accepts public policies only');
     }
-    assertCanonicalDigest(candidate.policyDigest, `acceptedPublicPolicies[${index}].policyDigest`);
-    return Object.freeze({
-      policy: deepFreezePlain(policy),
-      policyDigest: candidate.policyDigest,
-    });
-  });
-  const policyKeys = new Set<string>();
-  for (const { policy } of policies) {
     const key = `${policy.networkId}\n${policy.contextGraphId}`;
     if (policyKeys.has(key)) {
       throw new TypeError('rfc64PublicCatalogBootstrap policies must be unique by graph');
     }
     policyKeys.add(key);
-  }
-
-  if (!Array.isArray(input.targets) || input.targets.length > MAX_RFC64_BOOTSTRAP_TARGETS_V1) {
-    throw new TypeError(
-      `rfc64PublicCatalogBootstrap.targets must contain at most `
-      + `${MAX_RFC64_BOOTSTRAP_TARGETS_V1} catalogs`,
-    );
-  }
-  const targetKeys = new Set<string>();
-  const targets = input.targets.map((target, index) => {
-    assertPlainExactObject(
-      target,
-      `rfc64PublicCatalogBootstrap.targets[${index}]`,
-      ['providers', 'scope'],
-      ['providers', 'scope'],
-    );
-    const candidate = target as unknown as Rfc64PublicCatalogBootstrapTargetV1;
-    const scope = snapshotBootstrapScope(candidate.scope, index);
-    const policy = policies.find((candidate) => (
-      candidate.policy.networkId === scope.networkId
-      && candidate.policy.contextGraphId === scope.contextGraphId
-    ));
-    if (policy === undefined || policy.policy.era !== scope.catalogEra) {
+    if (!Array.isArray(candidate.targets)) {
       throw new TypeError(
-        'rfc64PublicCatalogBootstrap target has no matching accepted policy era',
+        `rfc64PublicCatalogBootstrap.acceptedPublicPolicies[${index}].targets must be an array`,
       );
     }
-    const providers = snapshotBootstrapProviders(candidate.providers, index);
-    const key = `${scope.networkId}\n${scope.contextGraphId}\n${scope.authorAddress}`
-      + `\n${scope.catalogEra}`;
-    if (targetKeys.has(key)) {
-      throw new TypeError('rfc64PublicCatalogBootstrap targets must be unique by author scope');
+    totalTargets += candidate.targets.length;
+    if (totalTargets > MAX_RFC64_BOOTSTRAP_TARGETS_V1) {
+      throw new TypeError(
+        `rfc64PublicCatalogBootstrap targets must contain at most `
+        + `${MAX_RFC64_BOOTSTRAP_TARGETS_V1} catalogs`,
+      );
     }
-    targetKeys.add(key);
-    return Object.freeze({ scope, providers });
+    const targets = candidate.targets.map((target, targetIndex) => {
+      assertPlainExactObject(
+        target,
+        `rfc64PublicCatalogBootstrap.acceptedPublicPolicies[${index}].targets[${targetIndex}]`,
+        ['authorAddress', 'providers'],
+        ['authorAddress', 'providers'],
+      );
+      const targetCandidate = target as unknown as Rfc64PublicCatalogBootstrapTargetV1;
+      assertCanonicalEvmAddress(targetCandidate.authorAddress, 'bootstrap target authorAddress');
+      if (targetCandidate.authorAddress === `0x${'0'.repeat(40)}`) {
+        throw new TypeError('rfc64PublicCatalogBootstrap authorAddress must be nonzero');
+      }
+      const providers = snapshotBootstrapProviders(targetCandidate.providers, targetIndex);
+      const targetKey = `${key}\n${targetCandidate.authorAddress}\n${policy.era}`;
+      if (targetKeys.has(targetKey)) {
+        throw new TypeError('rfc64PublicCatalogBootstrap targets must be unique by author scope');
+      }
+      targetKeys.add(targetKey);
+      return Object.freeze({ authorAddress: targetCandidate.authorAddress, providers });
+    });
+    return Object.freeze({
+      policyEnvelope: deepFreezePlain(policyEnvelope),
+      targets: Object.freeze(targets),
+    });
   });
 
   const retryIntervalMs = input.retryIntervalMs
@@ -260,7 +253,6 @@ export function snapshotRfc64PublicCatalogBootstrapConfigV1(
   }
   return Object.freeze({
     acceptedPublicPolicies: Object.freeze(policies),
-    targets: Object.freeze(targets),
     retryIntervalMs,
   });
 }
@@ -273,35 +265,6 @@ function snapshotTimestamp(value: unknown, label: string): TimestampMsV1 {
     throw new TypeError(`rfc64PublicCatalogAutoPublish.${label} exceeds uint64`);
   }
   return value as TimestampMsV1;
-}
-
-function snapshotBootstrapScope(
-  input: Rfc64PublicCatalogBootstrapScopeV1,
-  index: number,
-): Readonly<Rfc64PublicCatalogBootstrapScopeV1> {
-  assertPlainExactObject(
-    input,
-    `rfc64PublicCatalogBootstrap.targets[${index}].scope`,
-    ['authorAddress', 'catalogEra', 'contextGraphId', 'networkId', 'subGraphName'],
-    ['authorAddress', 'catalogEra', 'contextGraphId', 'networkId', 'subGraphName'],
-  );
-  assertNetworkIdV1(input.networkId, 'bootstrap scope networkId');
-  assertContextGraphIdV1(input.contextGraphId, 'bootstrap scope contextGraphId');
-  if (input.subGraphName !== null) {
-    throw new TypeError('rfc64PublicCatalogBootstrap V1 targets public root catalogs only');
-  }
-  assertCanonicalEvmAddress(input.authorAddress, 'bootstrap scope authorAddress');
-  if (input.authorAddress === `0x${'0'.repeat(40)}`) {
-    throw new TypeError('rfc64PublicCatalogBootstrap authorAddress must be nonzero');
-  }
-  assertCanonicalDecimalU64(input.catalogEra, 'bootstrap scope catalogEra');
-  return Object.freeze({
-    networkId: input.networkId,
-    contextGraphId: input.contextGraphId,
-    subGraphName: null,
-    authorAddress: input.authorAddress,
-    catalogEra: input.catalogEra,
-  });
 }
 
 function snapshotBootstrapProviders(input: readonly string[], targetIndex: number): readonly string[] {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -373,6 +373,23 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     } as unknown as Rfc64PublicCatalogBootstrapConfigV1)).toThrow(/unknown or missing fields/u);
   });
 
+  it('rejects bootstrap without persistence before node startup', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    await expect(DKGAgent.create({
+      name: 'ephemeral-bootstrap-is-invalid',
+      rfc64PublicCatalogBootstrap: {
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [{ authorAddress: AUTHOR, providers: ['12D3KooProvider'] }],
+        }],
+      },
+    })).rejects.toThrow(/rfc64PublicCatalogBootstrap requires dataDir/u);
+  });
+
   it('turns one confirmed public KA into the provider current head and one cold receiver apply', async () => {
     const receiver = await startNativeAgent('auto-publish-receiver');
     const author = await startNativeAgent(

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -30,12 +30,18 @@ import {
   snapshotRfc64CatalogAccessPolicyAuthorityV1,
   snapshotRfc64CatalogDeploymentProfileV1,
   snapshotRfc64PublicCatalogAutoPublishConfigV1,
+  snapshotRfc64PublicCatalogBootstrapConfigV1,
 } from '../src/dkg-agent-rfc64-catalog.js';
+import {
+  buildOpenOwnerContextGraphPolicyV1,
+  computeOpenContextGraphPolicyDigestV1,
+} from '../src/rfc64/open-catalog-policy-v1.js';
 import type {
   ContextGraphSubscriptionRecord,
   ContextGraphSubscriptionStore,
   Rfc64CatalogAccessPolicyAuthorityConfigV1,
   Rfc64PublicCatalogAutoPublishConfigV1,
+  Rfc64PublicCatalogBootstrapConfigV1,
 } from '../src/dkg-agent-types.js';
 import {
   createLoopbackJsonRpcTestHarness,
@@ -101,6 +107,8 @@ async function startNativeAgent(
     initialSubscription?: ContextGraphIdV1;
   }>,
   autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1,
+  bootstrap?: Rfc64PublicCatalogBootstrapConfigV1,
+  persistentStorePath?: string,
 ): Promise<DKGAgent> {
   const dataDir = existingDataDir
     ?? await mkdtemp(join(tmpdir(), `dkg-rfc64-native-${name}-`));
@@ -112,7 +120,7 @@ async function startNativeAgent(
     listenPort: 0,
     bootstrapPeers: [],
     nodeRole: 'edge',
-    store: new OxigraphStore(),
+    store: new OxigraphStore(persistentStorePath),
     syncSharedMemoryOnConnect: false,
     syncReconcilerEnabled: false,
     syncOnConnectEnabled: false,
@@ -121,6 +129,7 @@ async function startNativeAgent(
     rfc64CatalogDeploymentProfile: deployment,
     rfc64CatalogAccessPolicyAuthority: accessPolicyAuthority,
     rfc64PublicCatalogAutoPublish: autoPublish,
+    rfc64PublicCatalogBootstrap: bootstrap,
     ...(finalizedRuntime === undefined ? {} : {
       chainAdapter: finalizedRuntime.chainAdapter,
       chainConfig: {
@@ -294,6 +303,46 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     })).toThrow(/must be unique/u);
   });
 
+  it('snapshots a bounded public-root bootstrap manifest', () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const policyDigest = computeOpenContextGraphPolicyDigestV1(policy);
+    const providers = ['12D3KooPrimary'];
+    const callerOwned: Rfc64PublicCatalogBootstrapConfigV1 = {
+      acceptedPublicPolicies: [{ policy, policyDigest }],
+      targets: [{
+        scope: {
+          networkId: NETWORK_ID,
+          contextGraphId: CONTEXT_GRAPH_ID,
+          subGraphName: null,
+          authorAddress: AUTHOR,
+          catalogEra: policy.era,
+        },
+        providers,
+      }],
+      retryIntervalMs: 1_000,
+    };
+    const snapshot = snapshotRfc64PublicCatalogBootstrapConfigV1(callerOwned)!;
+    providers.push('12D3KooLateMutation');
+
+    expect(snapshot.targets[0]?.providers).toEqual(['12D3KooPrimary']);
+    expect(snapshot.acceptedPublicPolicies[0]).toEqual({ policy, policyDigest });
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.targets)).toBe(true);
+    expect(Object.isFrozen(snapshot.targets[0]?.providers)).toBe(true);
+    expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.policy.source)).toBe(true);
+    expect(() => snapshotRfc64PublicCatalogBootstrapConfigV1({
+      ...callerOwned,
+      targets: [{
+        ...callerOwned.targets[0]!,
+        scope: { ...callerOwned.targets[0]!.scope, subGraphName: 'private' },
+      }],
+    })).toThrow(/public root catalogs only/u);
+  });
+
   it('turns one confirmed public KA into the provider current head and one cold receiver apply', async () => {
     const receiver = await startNativeAgent('auto-publish-receiver');
     const author = await startNativeAgent(
@@ -412,6 +461,130 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     expect(receiver.rfc64PublicCatalogStatsV1()?.receiver).toMatchObject({
       applied: 2,
       failed: 0,
+    });
+  }, 60_000);
+
+  it('automatically cold-joins a published public catalog and recovers it after restart', async () => {
+    const author = await startNativeAgent(
+      'bootstrap-author',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
+    const accepted = author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const publicQuads = [
+      {
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/name',
+        object: '"Alice"',
+        graph: '',
+      },
+      {
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/age',
+        object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: '',
+      },
+    ] as const;
+    await author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'bootstrap-publication-1' as never,
+      publicQuads,
+      seal: assertionSealFromCanonical(await authorSeal(21n)),
+    });
+    const published = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'bootstrap-publication-2' as never,
+      publicQuads,
+      seal: assertionSealFromCanonical(await authorSeal(22n)),
+    });
+    expect(published).toMatchObject({ catalogVersion: '2', inventoryRowCount: '2' });
+
+    const bootstrap: Rfc64PublicCatalogBootstrapConfigV1 = {
+      acceptedPublicPolicies: [accepted],
+      targets: [{
+        scope: {
+          networkId: NETWORK_ID,
+          contextGraphId: CONTEXT_GRAPH_ID,
+          subGraphName: null,
+          authorAddress: AUTHOR,
+          catalogEra: accepted.policy.era,
+        },
+        providers: [author.peerId],
+      }],
+      retryIntervalMs: 1_000,
+    };
+    const receiverDataDir = await mkdtemp(join(tmpdir(), 'dkg-rfc64-native-bootstrap-'));
+    tempDirs.push(receiverDataDir);
+    const persistentStorePath = join(receiverDataDir, 'oxigraph');
+    const receiver = await startNativeAgent(
+      'bootstrap-receiver',
+      NATIVE_DEPLOYMENT,
+      receiverDataDir,
+      undefined,
+      undefined,
+      undefined,
+      bootstrap,
+      persistentStorePath,
+    );
+    await connectBothWays(author, receiver);
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.targets[0]).toMatchObject({
+        outcome: 'applied',
+        providerPeerId: author.peerId,
+        appliedHeadDigest: published?.currentCatalogHeadDigest,
+        catalogVersion: '2',
+        inventoryRowCount: '2',
+      });
+    }, { timeout: 20_000, interval: 100 });
+    expect(receiver.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toMatchObject({
+      currentCatalogHeadDigest: published?.currentCatalogHeadDigest,
+      catalogVersion: '2',
+      inventoryRowCount: '2',
+    });
+
+    await receiver.stop();
+    agents.splice(agents.indexOf(receiver), 1);
+    const restarted = await startNativeAgent(
+      'bootstrap-receiver',
+      NATIVE_DEPLOYMENT,
+      receiverDataDir,
+      undefined,
+      undefined,
+      undefined,
+      bootstrap,
+      persistentStorePath,
+    );
+    await connectBothWays(author, restarted);
+    await vi.waitFor(() => {
+      expect(restarted.readRfc64PublicCatalogBootstrapStatusV1()?.targets[0]).toMatchObject({
+        outcome: 'applied',
+        providerPeerId: author.peerId,
+        appliedHeadDigest: published?.currentCatalogHeadDigest,
+        catalogVersion: '2',
+        inventoryRowCount: '2',
+      });
+    }, { timeout: 20_000, interval: 100 });
+    expect(restarted.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toMatchObject({
+      currentCatalogHeadDigest: published?.currentCatalogHeadDigest,
+      catalogVersion: '2',
+      inventoryRowCount: '2',
     });
   }, 60_000);
 

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -35,7 +35,7 @@ import {
 } from '../src/dkg-agent-rfc64-catalog.js';
 import {
   buildOpenOwnerContextGraphPolicyV1,
-  computeOpenContextGraphPolicyDigestV1,
+  unsignedOpenContextGraphPolicyEnvelopeV1,
 } from '../src/rfc64/open-catalog-policy-v1.js';
 import type {
   ContextGraphSubscriptionRecord,
@@ -108,9 +108,45 @@ async function startNativeAgent(
     initialSubscription?: ContextGraphIdV1;
   }>,
   autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1,
-  bootstrap?: Rfc64PublicCatalogBootstrapConfigV1,
-  persistentStorePath?: string,
 ): Promise<DKGAgent> {
+  return startNativeAgentWithOptions({
+    name,
+    deployment,
+    existingDataDir,
+    accessPolicyAuthority,
+    finalizedRuntime,
+    autoPublish,
+  });
+}
+
+interface NativeAgentStartOptionsV1 {
+  readonly name: string;
+  readonly deployment?: CatalogSealDeploymentProfileV1;
+  readonly existingDataDir?: string;
+  readonly accessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1;
+  readonly finalizedRuntime?: Readonly<{
+    rpcUrl: string;
+    chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
+    initialSubscription?: ContextGraphIdV1;
+  }>;
+  readonly autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
+  readonly bootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
+  readonly persistentStorePath?: string;
+}
+
+async function startNativeAgentWithOptions(
+  options: NativeAgentStartOptionsV1,
+): Promise<DKGAgent> {
+  const {
+    name,
+    deployment = NATIVE_DEPLOYMENT,
+    existingDataDir,
+    accessPolicyAuthority,
+    finalizedRuntime,
+    autoPublish,
+    bootstrap,
+    persistentStorePath,
+  } = options;
   const dataDir = existingDataDir
     ?? await mkdtemp(join(tmpdir(), `dkg-rfc64-native-${name}-`));
   if (existingDataDir === undefined) tempDirs.push(dataDir);
@@ -309,38 +345,32 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
       contextGraphId: CONTEXT_GRAPH_ID,
       ownerAddress: AUTHOR,
     });
-    const policyDigest = computeOpenContextGraphPolicyDigestV1(policy);
+    const policyEnvelope = unsignedOpenContextGraphPolicyEnvelopeV1(policy);
     const providers = ['12D3KooPrimary'];
     const callerOwned: Rfc64PublicCatalogBootstrapConfigV1 = {
-      acceptedPublicPolicies: [{ policy, policyDigest }],
-      targets: [{
-        scope: {
-          networkId: NETWORK_ID,
-          contextGraphId: CONTEXT_GRAPH_ID,
-          subGraphName: null,
-          authorAddress: AUTHOR,
-          catalogEra: policy.era,
-        },
-        providers,
+      acceptedPublicPolicies: [{
+        policyEnvelope,
+        targets: [{ authorAddress: AUTHOR, providers }],
       }],
       retryIntervalMs: 1_000,
     };
     const snapshot = snapshotRfc64PublicCatalogBootstrapConfigV1(callerOwned)!;
     providers.push('12D3KooLateMutation');
 
-    expect(snapshot.targets[0]?.providers).toEqual(['12D3KooPrimary']);
-    expect(snapshot.acceptedPublicPolicies[0]).toEqual({ policy, policyDigest });
+    expect(snapshot.acceptedPublicPolicies[0]?.targets[0]?.providers)
+      .toEqual(['12D3KooPrimary']);
+    expect(snapshot.acceptedPublicPolicies[0]?.policyEnvelope.payload).toEqual(policy);
     expect(Object.isFrozen(snapshot)).toBe(true);
-    expect(Object.isFrozen(snapshot.targets)).toBe(true);
-    expect(Object.isFrozen(snapshot.targets[0]?.providers)).toBe(true);
-    expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.policy.source)).toBe(true);
+    expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.targets)).toBe(true);
+    expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.targets[0]?.providers)).toBe(true);
+    expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.policyEnvelope.payload.source))
+      .toBe(true);
     expect(() => snapshotRfc64PublicCatalogBootstrapConfigV1({
-      ...callerOwned,
-      targets: [{
-        ...callerOwned.targets[0]!,
-        scope: { ...callerOwned.targets[0]!.scope, subGraphName: 'private' },
+      acceptedPublicPolicies: [{
+        ...callerOwned.acceptedPublicPolicies[0]!,
+        policyDigest: `0x${'11'.repeat(32)}`,
       }],
-    })).toThrow(/public root catalogs only/u);
+    } as unknown as Rfc64PublicCatalogBootstrapConfigV1)).toThrow(/unknown or missing fields/u);
   });
 
   it('turns one confirmed public KA into the provider current head and one cold receiver apply', async () => {
@@ -733,32 +763,21 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
     expect(published).toMatchObject({ catalogVersion: '2', inventoryRowCount: '2' });
 
     const bootstrap: Rfc64PublicCatalogBootstrapConfigV1 = {
-      acceptedPublicPolicies: [accepted],
-      targets: [{
-        scope: {
-          networkId: NETWORK_ID,
-          contextGraphId: CONTEXT_GRAPH_ID,
-          subGraphName: null,
-          authorAddress: AUTHOR,
-          catalogEra: accepted.policy.era,
-        },
-        providers: [author.peerId],
+      acceptedPublicPolicies: [{
+        policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(accepted.policy),
+        targets: [{ authorAddress: AUTHOR, providers: [author.peerId] }],
       }],
       retryIntervalMs: 1_000,
     };
     const receiverDataDir = await mkdtemp(join(tmpdir(), 'dkg-rfc64-native-bootstrap-'));
     tempDirs.push(receiverDataDir);
     const persistentStorePath = join(receiverDataDir, 'oxigraph');
-    const receiver = await startNativeAgent(
-      'bootstrap-receiver',
-      NATIVE_DEPLOYMENT,
-      receiverDataDir,
-      undefined,
-      undefined,
-      undefined,
+    const receiver = await startNativeAgentWithOptions({
+      name: 'bootstrap-receiver',
+      existingDataDir: receiverDataDir,
       bootstrap,
       persistentStorePath,
-    );
+    });
     await connectBothWays(author, receiver);
     await vi.waitFor(() => {
       expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.targets[0]).toMatchObject({
@@ -780,16 +799,12 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
 
     await receiver.stop();
     agents.splice(agents.indexOf(receiver), 1);
-    const restarted = await startNativeAgent(
-      'bootstrap-receiver',
-      NATIVE_DEPLOYMENT,
-      receiverDataDir,
-      undefined,
-      undefined,
-      undefined,
+    const restarted = await startNativeAgentWithOptions({
+      name: 'bootstrap-receiver',
+      existingDataDir: receiverDataDir,
       bootstrap,
       persistentStorePath,
-    );
+    });
     await connectBothWays(author, restarted);
     await vi.waitFor(() => {
       expect(restarted.readRfc64PublicCatalogBootstrapStatusV1()?.targets[0]).toMatchObject({
@@ -809,6 +824,146 @@ describe('RFC-64 DKGAgent production native catalog wiring', () => {
       inventoryRowCount: '2',
     });
   }, 60_000);
+
+  it('retries an initial miss and fails over to the later provider', async () => {
+    const emptyProvider = await startNativeAgent('bootstrap-empty-provider');
+    const author = await startNativeAgent(
+      'bootstrap-retry-author',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
+    const accepted = author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    emptyProvider.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const bootstrap: Rfc64PublicCatalogBootstrapConfigV1 = {
+      acceptedPublicPolicies: [{
+        policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(accepted.policy),
+        targets: [{
+          authorAddress: AUTHOR,
+          providers: [emptyProvider.peerId, author.peerId],
+        }],
+      }],
+      retryIntervalMs: 1_000,
+    };
+    const receiver = await startNativeAgentWithOptions({
+      name: 'bootstrap-retry-receiver',
+      bootstrap,
+    });
+    await Promise.all([
+      connectBothWays(emptyProvider, receiver),
+      connectBothWays(author, receiver),
+    ]);
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.targets[0]).toMatchObject({
+        outcome: 'not-found',
+        attempts: 2,
+        providerPeerId: null,
+        appliedHeadDigest: null,
+      });
+    }, { timeout: 20_000, interval: 100 });
+
+    const publicQuads = [
+      {
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/name',
+        object: '"Alice"',
+        graph: '',
+      },
+      {
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/age',
+        object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: '',
+      },
+    ];
+    const published = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'bootstrap-retry-publication' as never,
+      publicQuads,
+      seal: assertionSealFromCanonical(await authorSeal(23n, publicQuads)),
+    });
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()).toMatchObject({
+        pass: expect.any(Number),
+        targets: [expect.objectContaining({
+          outcome: 'applied',
+          attempts: 2,
+          providerPeerId: author.peerId,
+          appliedHeadDigest: published?.currentCatalogHeadDigest,
+          inventoryRowCount: '1',
+        })],
+      });
+    }, { timeout: 20_000, interval: 100 });
+    expect(receiver.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })?.currentCatalogHeadDigest).toBe(published?.currentCatalogHeadDigest);
+  }, 60_000);
+
+  it('clears applied metadata when a later bootstrap refresh misses', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const appliedHeadDigest = `0x${'a1'.repeat(32)}` as Digest32V1;
+    const synchronize = vi.spyOn(
+      DKGAgent.prototype,
+      'synchronizeRfc64PublicCatalogFromProviderV1',
+    ).mockResolvedValueOnce({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+      currentCatalogHeadDigest: appliedHeadDigest,
+      appliedInventoryDigest: `0x${'b2'.repeat(32)}` as Digest32V1,
+      catalogVersion: '2' as never,
+      inventoryRowCount: '3' as never,
+    }).mockResolvedValue(null);
+    const bootstrap: Rfc64PublicCatalogBootstrapConfigV1 = {
+      acceptedPublicPolicies: [{
+        policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+        targets: [{ authorAddress: AUTHOR, providers: ['12D3KooStatusProvider'] }],
+      }],
+      retryIntervalMs: 1_000,
+    };
+    const receiver = await startNativeAgentWithOptions({
+      name: 'bootstrap-status-reset',
+      bootstrap,
+    });
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.targets[0]).toMatchObject({
+        outcome: 'applied',
+        appliedHeadDigest,
+        catalogVersion: '2',
+        inventoryRowCount: '3',
+      });
+    }, { timeout: 10_000, interval: 50 });
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.targets[0]).toMatchObject({
+        outcome: 'not-found',
+        attempts: 1,
+        providerPeerId: null,
+        appliedHeadDigest: null,
+        catalogVersion: null,
+        inventoryRowCount: null,
+      });
+    }, { timeout: 10_000, interval: 50 });
+    expect(synchronize).toHaveBeenCalledTimes(2);
+    synchronize.mockRestore();
+  }, 30_000);
 
 
   it('serializes mixed-case projection terms in raw UTF-8 order', async () => {


### PR DESCRIPTION
## Outcome

Adds the bounded V1 receiver bootstrap path for explicitly pinned public RFC-64 catalog roots.

- snapshots and validates accepted public policies plus ordered provider identities
- automatically accepts pinned policies and synchronizes each target at startup
- retries with bounded target concurrency and ordered provider failover
- exposes typed per-target bootstrap status and drains cleanly on close
- reuses the production catalog transport and durable apply lane

## User-visible proof

The native integration proof publishes a two-asset public catalog before the receiver exists. A newly started receiver uses only its pinned bootstrap manifest to fetch and durably apply the exact head. After the receiver process is closed and restarted over the same persistent Oxigraph and SQLite data directory, it automatically recovers the same exact head again.

## Verification

- agent package build: pass
- native catalog wiring: 15 passed
- encrypt inline policy: 28 passed
- finalized agent lane: 7 passed
- focused total: 50 passed, 0 failed

## Intentionally deferred

- generalized decentralized catalog discovery
- non-root subgraph bootstrap
- private-bearing projection synthesis and private catalog synchronization
- release-scale three-edge harness and canary evidence

Stacked on #1927 until its fresh Windows gate is green; then this PR should be retargeted to integration/rfc64-devnet.