### PR TITLE
Align SWM payload limit with StorageACK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [Unreleased]
 
+### Changed
+
+- **SWM gossip payload ceiling aligned with StorageACK:** one encoded SWM share or promotion is now capped at 4 MiB, matching the untrusted inline StorageACK staging ceiling. GossipSub retains 256 KiB of framing headroom, while the general direct-protocol frame/read limit remains 10 MiB.
+
 ## [10.0.9] - 2026-07-21
 
 Public Context Graphs work fully: any agent can reliably sync both SWM and VM, including late joiners and Context Graphs whose operation history exceeds the previous snapshot ceiling. This release consolidates the testnet-canary line previously rolled out to nodes by branch ref, plus the fifa-class metadata ceiling fix, validated by a devnet hold-out proof (a node absent during publication reconstructs the full corpus with per-graph digest verification) and by the testnet fleet. **No smart-contract changes — no deployment required** (no Solidity source or ABI changes since 10.0.7).

--- a/packages/agent/scripts/ci-shard-agent.mjs
+++ b/packages/agent/scripts/ci-shard-agent.mjs
@@ -64,7 +64,7 @@ const WEIGHTS = {
   'test/v10-ack-provider.test.ts': 1131,
   'test/finalization-promote-extra.test.ts': 1058,
   'test/wm-multi-agent-isolation-extra.test.ts': 1022,
-  'test/swm-10mb-boundary-extra.test.ts': 1000,
+  'test/swm-4mib-boundary-extra.test.ts': 1000,
 };
 const DEFAULT_WEIGHT = 500;
 

--- a/packages/agent/test/swm-4mib-boundary-extra.test.ts
+++ b/packages/agent/test/swm-4mib-boundary-extra.test.ts
@@ -1,5 +1,5 @@
 /**
- * SHARE / SWM 10 MB gossip-size boundary, exercised from the agent layer.
+ * SHARE / SWM 4 MiB gossip-size boundary, exercised from the agent layer.
  *
  * Audit findings covered:
  *   A-2 (CRITICAL) — `DKGPublisher#_shareImpl` rejects encoded SWM messages
@@ -13,7 +13,7 @@
  *             split-into-smaller-share() batches.
  *          3. Boundary: callers that hit the limit see a *clear* error, not
  *             a silent libp2p-level drop. Error message contains both the
- *             observed KB and the 10 MB limit so operators can react.
+ *             observed KB and the 4 MiB limit so operators can react.
  *
  * No mocks — real `DKGAgent` + real libp2p + real chain (only used to boot
  * the agent; share() never submits a tx).
@@ -87,12 +87,12 @@ afterAll(async () => {
   await revertSnapshot(_fileSnapshot);
 });
 
-describe('A-2: SHARE 10 MB gossip-size boundary', () => {
-  it('share() with a payload well below 10 MB succeeds and lands in SWM', async () => {
+describe('A-2: SHARE 4 MiB gossip-size boundary', () => {
+  it('share() with a payload well below 4 MiB succeeds and lands in SWM', async () => {
     const cgId = freshCgId('bnd-lo');
     await nodeA!.createContextGraph({ id: cgId, name: 'Boundary Lo', description: '' });
 
-    // Target ~100 KB of literal payload — well under the 10 MB cap.
+    // Target ~100 KB of literal payload — well under the 4 MiB cap.
     // Split across multiple literals to mimic realistic agent output.
     const chunkCount = 10;
     const chunkLen = 10 * 1024; // 10 KB per chunk
@@ -118,7 +118,7 @@ describe('A-2: SHARE 10 MB gossip-size boundary', () => {
     }
   });
 
-  it('share() with a payload well above 10 MB is rejected with the expected error message', async () => {
+  it('share() with a payload well above 4 MiB is rejected with the expected error message', async () => {
     const cgId = freshCgId('bnd-hi');
     await nodeA!.createContextGraph({ id: cgId, name: 'Boundary Hi', description: '' });
 
@@ -133,9 +133,9 @@ describe('A-2: SHARE 10 MB gossip-size boundary', () => {
       caught = e as Error;
     }
     expect(caught, 'share() should reject an oversized payload with a size-limit error').not.toBeNull();
-    // Spec text from dkg-publisher.ts: "SWM message too large (<KB> KB, limit 10 MB)."
+    // Spec text from dkg-publisher.ts: "SWM message too large (<KB> KB, limit 4 MB)."
     expect(caught!.message).toMatch(/SWM message too large/);
-    expect(caught!.message).toMatch(/limit\s+10\s*MB/);
+    expect(caught!.message).toMatch(/limit\s+4\s*MB/);
     // Operator-actionable guidance: split into multiple share() calls.
     expect(caught!.message.toLowerCase()).toMatch(/split|multiple share/);
   });

--- a/packages/cli/skills/dkg-importer/SKILL.md
+++ b/packages/cli/skills/dkg-importer/SKILL.md
@@ -29,7 +29,7 @@ many times, with each call staying under fixed budgets.
 | Constant | Value | Where it lands |
 |---|---|---|
 | `CHUNK` | **5,000 quads** | Per `POST /api/knowledge-assets/<name>/wm/write` call |
-| `ROOT_CHUNK` | **1,000 URIs** | Per `POST /api/knowledge-assets/<name>/swm/share` `entities` array |
+| `ROOT_CHUNK` | **400 URIs** | Initial per-call batch for `POST /api/knowledge-assets/<name>/swm/share`; halve on the 4 MiB encoded-payload cap |
 | Max concurrent writes within one assertion | **1** (sequential) | The daemon does not parallelise intra-assertion writes; the manifest in §3 tracks per-assertion state anyway |
 | Max concurrent assertions | **4** | Safe across assertions; keeps memory bounded for laptop-class nodes |
 
@@ -41,27 +41,29 @@ heavy end.
 ### 1.1 Known daemon caps and the exact error strings they produce
 
 These are the three hard caps you will hit if you push past the constants
-above, with the verbatim error text the daemon emits. The cap source lives in
-[`packages/cli/src/daemon/http-utils.ts`](../../../../packages/cli/src/daemon/http-utils.ts).
+above, with the verbatim error text the daemon emits. The HTTP body caps live
+in [`packages/cli/src/daemon/http-utils.ts`](../../../../packages/cli/src/daemon/http-utils.ts);
+the gossip cap lives in
+[`packages/core/src/constants.ts`](../../../../packages/core/src/constants.ts).
 
 | Endpoint | Cap | Constant | Trigger | Error response |
 |---|---|---|---|---|
 | `POST /api/knowledge-assets/<name>/wm/write` | **10 MB** request body | `MAX_BODY_BYTES` | N-Quads payload too large | `HTTP 413` "Request body too large (>10485760 bytes)" |
 | `POST /api/knowledge-assets/<name>/swm/share` | **256 KB** request body | `SMALL_BODY_BYTES` | `entities` array too long (~4,000+ URIs at 60-char average) | `HTTP 413` "Request body too large (>262144 bytes)" |
-| `POST /api/knowledge-assets/<name>/swm/share` | **10 MB** gossip message | hard-coded in gossipsub publish | Promoted assertion's N-Quads serialisation exceeds 10 MB | `HTTP 500` "Promoted assertion too large for gossip (XXXX KB, limit 10 MB). Promote fewer entities per call." |
+| `POST /api/knowledge-assets/<name>/swm/share` | **4 MiB** gossip message | `DKG_GOSSIP_MAX_MESSAGE_BYTES` | Promoted assertion's encoded payload exceeds 4 MiB | `HTTP 500` "Promoted assertion too large for gossip (XXXX KB, limit 4 MB). Promote fewer entities per call." |
 
 The two `/swm/share` caps are independent: the 256 KB body cap is on the
-**request** you send (URI count × URI length); the 10 MB gossip cap is on the
+**request** you send (URI count × URI length); the 4 MiB gossip cap is on the
 **assertion** that ends up in SWM (triples × N-Quads length). It is possible
 to hit the gossip cap with a single-URI `entities` array, if the assertion
 under that root is large enough. `entities: "all"` triggers it most often
 because it asks the daemon to gossip every root in one message; for any
-assertion above ~30k triples, expect to split.
+assertion above ~12k typical-sized triples, expect to split.
 
 In practice this means a robust importer needs **two independent halve-and-
 retry paths on `/swm/share`**: one for 413 (shrink the `entities` array) and
 one for 500 (shrink the per-root scope or switch from `"all"` to explicit
-batches of N ≤ 1000 root URIs). See [§5 Error handling](#5-error-handling)
+batches of N ≤ 400 root URIs). See [§5 Error handling](#5-error-handling)
 for the recipes.
 
 **Self-tune from `/api/status`.** Future versions of the daemon advertise their
@@ -120,12 +122,12 @@ for (const partition of partitions) {                       // one source artefa
     triples,
   }, { batchSize: 5000 });                                  // bump if your triples are small
   const entities = rootUrisFor(partition);
-  for (let i = 0; i < entities.length; i += 1000) {         // chunk promote ourselves
+  for (let i = 0; i < entities.length; i += 400) {          // chunk promote ourselves
     await client.promote({
       contextGraphId: client.cgId,
       assertionName,
       subGraphName: 'code',
-      entities: entities.slice(i, i + 1000),
+      entities: entities.slice(i, i + 400),
     });
   }
 }
@@ -144,7 +146,7 @@ with open(TOKEN_PATH) as f:
 H = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
 BASE = f'http://localhost:{PORT}/api'
 CHUNK = 5000
-ROOT_CHUNK = 1000
+ROOT_CHUNK = 400
 
 def ensure_assertion(cg, name, sg):
     res = requests.post(f'{BASE}/knowledge-assets',
@@ -188,7 +190,7 @@ await createImportManifest({
 `createImportManifest` writes a single `urn:dkg:import:<id>` assertion to the
 `meta` sub-graph listing every partition with `initialStatus = "pending"`.
 Manifests follow the chunking contract automatically: the import root **and**
-every partition URI are promoted to SWM in chunks of `ROOT_CHUNK ≤ 1000` so a
+every partition URI are promoted to SWM in chunks of `ROOT_CHUNK ≤ 400` so a
 peer node (or this node after a restart) can read the manifest back from SWM
 to resume — promoting only the root would leave partition triples in WM only.
 
@@ -294,7 +296,7 @@ typical lengths. Recovery is to shrink the `entities` array, not the
 underlying assertion:
 
 ```ts
-async function promoteRoots(assertion, roots, batchSize = 1000) {
+async function promoteRoots(assertion, roots, batchSize = 400) {
   for (let i = 0; i < roots.length; i += batchSize) {
     const batch = roots.slice(i, i + batchSize);
     try {
@@ -313,25 +315,25 @@ async function promoteRoots(assertion, roots, batchSize = 1000) {
 
 ### HTTP 500 on `/swm/share` with "too large for gossip"
 
-The assertion you're promoting serialises to more than 10 MB of N-Quads.
+The assertion you're promoting serialises to an encoded payload above 4 MiB.
 This is independent of how many root URIs you pass — even
 `entities: ["<one-uri>"]` can trip this if that one root's transitive
-triple set is bigger than 10 MB. The error message is verbatim:
+triple set is bigger than 4 MiB. The error message is verbatim:
 
 ```
 HTTP 500 "Promoted assertion too large for gossip
-(XXXX KB, limit 10 MB). Promote fewer entities per call."
+(XXXX KB, limit 4 MB). Promote fewer entities per call."
 ```
 
 Recovery is to **shrink the per-promote scope**, which means: if you were
 promoting with `entities: "all"`, switch to an explicit URI batch sized so
-its transitive triples land under 10 MB. There is no formula because triple
-fan-out varies; in practice 500-1000 roots per call works for code graphs
-and 100-200 for prose corpora with long string literals.
+its transitive triples land under 4 MiB. There is no formula because triple
+fan-out varies; start around 200-400 roots per call for code graphs and
+50-100 for prose corpora with long string literals, then halve on the cap.
 
 ```ts
 async function promoteAllInBatches(assertion, allRoots) {
-  let batch = 1000;
+  let batch = 400;
   for (let i = 0; i < allRoots.length; i += batch) {
     try {
       await promoteRoots(assertion, allRoots.slice(i, i + batch));
@@ -552,7 +554,7 @@ The worker classifies every failure into one of three buckets. Read it from
 | Classification | Retry? | Typical cause | Importer action |
 |---|---|---|---|
 | `transient` | yes (until `maxRetries=5` reached) | `fetch failed` / `ECONNRESET` / `timeout` | Wait — the worker auto-retries with backoff. No-op for the importer until the job leaves `failed_retrying`. |
-| `cap_exceeded` | no | `Promoted assertion too large for gossip` (10 MB) or `Request body too large` (256 KB) | Re-enqueue with a smaller `entities` slice (the queue can't subdivide on its own — that's a future enhancement). Same halve-and-retry shape as the synchronous recipe, just applied at the queue layer. |
+| `cap_exceeded` | no | `Promoted assertion too large for gossip` (4 MiB) or `Request body too large` (256 KB) | Re-enqueue with a smaller `entities` slice (the queue can't subdivide on its own — that's a future enhancement). Same halve-and-retry shape as the synchronous recipe, just applied at the queue layer. |
 | `fatal` | no | Bad request, missing assertion, etc. | Inspect the error message, fix the cause, then `POST /api/knowledge-assets/swm/share-jobs/<jobId>/recover` to re-queue. |
 
 Note that `cap_exceeded` jobs reach `state: "failed"`, not `failed_retrying`,
@@ -634,7 +636,7 @@ promote job is queued / running.
    a. markPartitionStatus(..., 'in_progress')
    b. POST /api/knowledge-assets   { name, subGraphName, contextGraphId }
    c. POST /api/knowledge-assets/<name>/wm/write   { quads }      // chunks of ≤ 5000
-   d. POST /api/knowledge-assets/<name>/swm/share { entities }   // chunks of ≤ 1000 URIs
+   d. POST /api/knowledge-assets/<name>/swm/share { entities }   // chunks of ≤ 400 URIs
    e. markPartitionStatus(..., 'done')
 4. On 413: halve chunk + retry.
 5. On crash: loadImportManifest → pendingPartitions → resume from step 3.

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -240,7 +240,7 @@ lifecycle (`finalize` = seal; a full `share` seals by default, so the explicit f
 knowledge into Shared Working Memory, author it as a **named knowledge asset** (`dkg_knowledge_asset_create`
 → `dkg_knowledge_asset_share`); there is no separate loose-write or direct-bridge publish tool.
 
-**Bulk imports (>5,000 quads in one logical operation):** the per-call `dkg_knowledge_asset_*` loop IS the chunked-write API; there is no `/api/import/bulk`. Keep `/api/knowledge-assets/<name>/wm/write` payloads under the 10 MB body cap, keep `/api/knowledge-assets/<name>/swm/share` payloads under the 256 KB body cap, and remember that promotion can still fail at the 10 MB gossip-message cap even when the HTTP body is small. For multi-part imports, write a resumable manifest in the `meta` sub-graph (`scripts/lib/manifest.mjs` is the canonical helper), promote import roots in size-aware batches, and halve/retry on 413 rather than restarting the whole import. The expanded contract — chunking budgets, manifest pattern, HTTP 413 recipes, async-promote queue (`/api/knowledge-assets/<name>/swm/share-async`) — is served at `GET /.well-known/skill-importer.md` (the daemon's second canonical skill endpoint, same auth-public + ETag-cacheable shape as `/.well-known/skill.md`). Source checkouts also have the same file at `packages/cli/skills/dkg-importer/SKILL.md`.
+**Bulk imports (>5,000 quads in one logical operation):** the per-call `dkg_knowledge_asset_*` loop IS the chunked-write API; there is no `/api/import/bulk`. Keep `/api/knowledge-assets/<name>/wm/write` payloads under the 10 MB body cap, keep `/api/knowledge-assets/<name>/swm/share` payloads under the 256 KB body cap, and remember that promotion can still fail at the 4 MiB gossip-message cap even when the HTTP body is small. For multi-part imports, write a resumable manifest in the `meta` sub-graph (`scripts/lib/manifest.mjs` is the canonical helper), promote import roots in size-aware batches, and halve/retry on 413 rather than restarting the whole import. The expanded contract — chunking budgets, manifest pattern, HTTP 413 recipes, async-promote queue (`/api/knowledge-assets/<name>/swm/share-async`) — is served at `GET /.well-known/skill-importer.md` (the daemon's second canonical skill endpoint, same auth-public + ETag-cacheable shape as `/.well-known/skill.md`). Source checkouts also have the same file at `packages/cli/skills/dkg-importer/SKILL.md`.
 
 ### HTTP-only operations (no tool wrapper)
 
@@ -527,7 +527,7 @@ Respect these when producing writes — they're enforced at the node and produce
 
 - **Reorganizing assertions.** There is no rename-assertion or move-between-sub-graphs endpoint. To reorganize, create a new assertion (with `subGraphName?` for a different partition), copy the triples over via `/wm/write`, then `/wm/discard` the original. A new assertion starts a fresh lifecycle record in `_meta`.
 - **Reserved subject IRIs.** Subjects matching `urn:dkg:file:*` or `urn:dkg:extraction:*` are reserved for internal file/extraction metadata and are rejected at write time. Use a different subject IRI.
-- **SWM gossip size cap (10 MB).** A single share (`/swm/share`) must fit in one 10 MB gossip message. Split larger assertions by root entity before sharing — use the `entities` parameter on `/swm/share` to share subsets.
+- **SWM gossip size cap (4 MiB).** A single share (`/swm/share`) must fit in one 4 MiB gossip message. Split larger assertions by root entity before sharing — use the `entities` parameter on `/swm/share` to share subsets.
 - **SWM entity ownership (first-writer-wins).** The first peer to write a root entity in SWM becomes its owner; other peers' promotes or writes against that same root entity are rejected with an ownership error. Partition work by agent-owned root entities to avoid conflicts.
 - **Blank nodes are auto-skolemized.** Any `_:b0`-style blank nodes you submit are deterministically rewritten to UUID-backed URIs before storage, so IDs stay stable across sync and on-chain anchoring. Prefer explicit IRIs in production data.
 
@@ -830,7 +830,7 @@ Failure classifications you'll see in `attempt.lastError.classification`:
 | Classification | Retry? | Typical cause | Operator action |
 |---|---|---|---|
 | `transient` | yes (until `maxRetries=5` reached) | `fetch failed` / `ECONNRESET` / `timeout` | Wait — the worker will pick it up after backoff. |
-| `cap_exceeded` | no | `Promoted assertion too large for gossip` (10 MB) or `Request body too large` (256 KB) | Re-enqueue with a smaller `entities` slice — the queue can't subdivide on its own. |
+| `cap_exceeded` | no | `Promoted assertion too large for gossip` (4 MiB) or `Request body too large` (256 KB) | Re-enqueue with a smaller `entities` slice — the queue can't subdivide on its own. |
 | `fatal` | no | Bad request, missing assertion, etc. | Inspect the error message, fix the cause, then `POST /api/knowledge-assets/swm/share-jobs/{jobId}/recover`. |
 
 ### TRAC auto-approve policy (V10 publish + update)

--- a/packages/cli/src/daemon/worker/async-promote-worker.ts
+++ b/packages/cli/src/daemon/worker/async-promote-worker.ts
@@ -156,8 +156,8 @@ export function classifyPromoteError(err: unknown): ClassifiedPromoteError {
       ? String((err as { code?: unknown }).code ?? '').toLowerCase()
       : '';
 
-  // 1. 10 MB gossip cap — surfaced as
-  //    "Promoted assertion too large for gossip (XXXX KB, limit 10 MB)"
+  // 1. 4 MiB gossip cap — surfaced as
+  //    "Promoted assertion too large for gossip (XXXX KB, limit 4 MB)"
   //    by the daemon's promote pipeline.
   if (
     code === 'swm_gossip_payload_too_large' ||

--- a/packages/cli/test/async-promote-queue-e2e.test.ts
+++ b/packages/cli/test/async-promote-queue-e2e.test.ts
@@ -365,7 +365,7 @@ describe('async-promote queue — end-to-end (routes + worker + queue)', () => {
 
   it('cap_exceeded: gossip-too-large error settles immediately in terminal failed (no retries)', async () => {
     promoteHandler = async () => {
-      throw new Error('Promoted assertion too large for gossip (12000 KB, limit 10 MB)');
+      throw new Error('Promoted assertion too large for gossip (6000 KB, limit 4 MB)');
     };
     await startServerAndSupervisor();
     const { body } = await post('/api/knowledge-assets/giant/swm/share-async', {

--- a/packages/cli/test/async-promote-worker.test.ts
+++ b/packages/cli/test/async-promote-worker.test.ts
@@ -47,7 +47,7 @@ describe('classifyPromoteError', () => {
 
   it('classifies gossip-cap errors as cap_exceeded (non-retryable)', () => {
     const verdict = classifyPromoteError(
-      new Error('Promoted assertion too large for gossip (10240 KB, limit 10 MB). Promote fewer entities per call.'),
+      new Error('Promoted assertion too large for gossip (5120 KB, limit 4 MB). Promote fewer entities per call.'),
     );
     expect(verdict).toEqual({ classification: 'cap_exceeded', retryable: false });
   });
@@ -101,7 +101,7 @@ describe('classifyPromoteError', () => {
       .toEqual({ classification: 'transient', retryable: true });
     // A GENUINE gossip-cap error (token in the ORIGINAL message) still classifies cap_exceeded even
     // when tagged — stripping removes only the injected prefix, never real tokens.
-    expect(classifyPromoteError(new Error('[promote:assertionScopedQuads] Promoted assertion too large for gossip (limit 10 MB)')))
+    expect(classifyPromoteError(new Error('[promote:assertionScopedQuads] Promoted assertion too large for gossip (limit 4 MB)')))
       .toEqual({ classification: 'cap_exceeded', retryable: false });
   });
 
@@ -328,7 +328,7 @@ describe('runPromoteJob', () => {
       queue,
       workerId: 'worker-test',
       runPromote: async () => {
-        throw new Error('Promoted assertion too large for gossip (12000 KB, limit 10 MB)');
+        throw new Error('Promoted assertion too large for gossip (6000 KB, limit 4 MB)');
       },
       now: () => now,
       heartbeatIntervalMs: 0,

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,4 +1,5 @@
 import { MemoryLayer, memoryLayerSlug } from './memory-model.js';
+import { STORAGE_ACK_MAX_STAGING_BYTES } from './protocol-limits.js';
 import { assertSafeIri } from './sparql-safe.js';
 
 // ── V10 Protocol Stream IDs ─────────────────────────────────────────────
@@ -226,8 +227,12 @@ export function logicalTopicFromWireTopic(networkId: string | undefined, wireTop
   return `dkg/${suffix}`;
 }
 
-/** Maximum application payload size allowed for one DKG GossipSub message (10 MB). */
-export const DKG_GOSSIP_MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
+/**
+ * Maximum application payload size allowed for one DKG GossipSub message.
+ * Kept equal to the 4 MiB inline StorageACK staging ceiling so one Knowledge
+ * Asset has one consistent application-payload limit across SWM and ACK paths.
+ */
+export const DKG_GOSSIP_MAX_MESSAGE_BYTES = STORAGE_ACK_MAX_STAGING_BYTES;
 
 /** Allows GossipSub RPC framing around one max-sized application payload. */
 export const DKG_GOSSIP_MAX_RPC_BYTES = DKG_GOSSIP_MAX_MESSAGE_BYTES + 256 * 1024;

--- a/packages/core/src/protocol-limits.ts
+++ b/packages/core/src/protocol-limits.ts
@@ -1,6 +1,7 @@
 export const MAX_UINT72 = (1n << 72n) - 1n;
 export const MAX_UINT72_DECIMAL = MAX_UINT72.toString();
 
+/** Maximum untrusted inline N-Quads payload accepted by a StorageACK handler (4 MiB). */
 export const STORAGE_ACK_MAX_STAGING_BYTES = 4 * 1024 * 1024;
 
 export type Uint72DecimalParseResult =

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -54,6 +54,7 @@ import {
   contextGraphSessionTopic,
 } from '../src/constants.js';
 import { MemoryLayer } from '../src/memory-model.js';
+import { STORAGE_ACK_MAX_STAGING_BYTES } from '../src/protocol-limits.js';
 
 describe('V10 protocol stream IDs', () => {
   // rc.9 plan: protocols on /dkg/10.0.1/* are migrated onto the
@@ -127,9 +128,10 @@ describe('V10 GossipSub topics', () => {
     expect(networkPeersTopic()).toBe('dkg/network/peers');
   });
 
-  it('allows one 10 MB DKG gossip application payload', () => {
-    expect(DKG_GOSSIP_MAX_MESSAGE_BYTES).toBe(10 * 1024 * 1024);
-    expect(DKG_GOSSIP_MAX_RPC_BYTES).toBeGreaterThan(DKG_GOSSIP_MAX_MESSAGE_BYTES);
+  it('limits one DKG gossip application payload to the 4 MiB StorageACK ceiling', () => {
+    expect(DKG_GOSSIP_MAX_MESSAGE_BYTES).toBe(4 * 1024 * 1024);
+    expect(DKG_GOSSIP_MAX_MESSAGE_BYTES).toBe(STORAGE_ACK_MAX_STAGING_BYTES);
+    expect(DKG_GOSSIP_MAX_RPC_BYTES).toBe(DKG_GOSSIP_MAX_MESSAGE_BYTES + 256 * 1024);
   });
 });
 

--- a/packages/publisher/src/async-promote-queue-types.ts
+++ b/packages/publisher/src/async-promote-queue-types.ts
@@ -57,7 +57,7 @@ export const ASYNC_PROMOTE_QUEUE_MIN_AUTO_RECOVERABLE_FORMAT_VERSION = 2;
  * the error message.
  *
  * - `transient`  — network blip, daemon overload, retry with backoff.
- * - `cap_exceeded` — 256 KB body cap or 10 MB gossip cap. The worker may
+ * - `cap_exceeded` — 256 KB body cap or 4 MiB gossip cap. The worker may
  *                   shrink the entity batch and retry, OR mark the whole
  *                   job failed if it can't subdivide further.
  * - `fatal`      — validation failure, unknown assertion, etc.; no retry.

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -1921,7 +1921,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     }
   });
 
-  it('promote accepts a payload above the old 512 KB cap and below 10 MB', async () => {
+  it('promote accepts a payload above the old 512 KB cap and below 4 MiB', async () => {
     await publisher.assertionCreate(CG_ID, 'large-promote', AGENT);
     const quads = largePayloadQuads('large-promote', 2 * 1024 * 1024);
     await publisher.assertionWrite(CG_ID, 'large-promote', AGENT, quads);
@@ -1937,7 +1937,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(result.gossipMessage!.length).toBeLessThan(DKG_GOSSIP_MAX_MESSAGE_BYTES);
   });
 
-  it('promote rejects payloads above 10 MB before mutating WM or SWM', async () => {
+  it('promote rejects payloads above 4 MiB before mutating WM or SWM', async () => {
     await publisher.assertionCreate(CG_ID, 'too-large-promote', AGENT);
     const quads = largePayloadQuads('too-large-promote', DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
     await publisher.assertionWrite(CG_ID, 'too-large-promote', AGENT, quads);
@@ -1945,7 +1945,7 @@ describe('Working Memory Assertion Lifecycle', () => {
 
     await expect(
       publisher.assertionPromote(CG_ID, 'too-large-promote', AGENT, { publisherPeerId: PEER }),
-    ).rejects.toThrow(/Promoted assertion too large for gossip.*10\s*MB/i);
+    ).rejects.toThrow(/Promoted assertion too large for gossip.*4\s*MB/i);
 
     const assertionQuads = await publisher.assertionQuery(CG_ID, 'too-large-promote', AGENT);
     expect(assertionQuads.length).toBe(quads.length);

--- a/packages/publisher/test/share-size-boundary-extra.test.ts
+++ b/packages/publisher/test/share-size-boundary-extra.test.ts
@@ -3,19 +3,19 @@
  *
  * Audit findings covered:
  *
- *   P-4 (HIGH) — 10 MB SHARE gossip boundary.
+ *   P-4 (HIGH) — 4 MiB SHARE gossip boundary.
  *                `packages/publisher/src/dkg-publisher.ts` enforces
  *                `DKG_GOSSIP_MAX_MESSAGE_BYTES`. The existing
  *                suite never sends a payload near that limit, so a
  *                silent change to the cap (or a regression that stops
  *                measuring the encoded protobuf length) would not be
  *                detected. These tests pin both sides of the boundary:
- *                  • a multi-MB payload below 10 MB must succeed; and
- *                  • a payload just over 10 MB must fail with a clear,
+ *                  • a multi-MB payload below 4 MiB must succeed; and
+ *                  • a payload just over 4 MiB must fail with a clear,
  *                    caller-actionable error that mentions the limit.
  *
- * Per QA policy: do NOT modify production code or spec docs. If the
- * boundary ever drifts, the failing assertion IS the bug evidence.
+ * Keep these assertions and the operator guidance aligned whenever the shared
+ * protocol limit changes.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
@@ -56,7 +56,7 @@ function makePublisher(store: OxigraphStore, eventBus: TypedEventBus): Promise<D
   })();
 }
 
-describe('P-4: SWM share() 10 MB gossip-message boundary', () => {
+describe('P-4: SWM share() 4 MiB gossip-message boundary', () => {
   let store: OxigraphStore;
   let eventBus: TypedEventBus;
   let publisher: DKGPublisher;
@@ -67,7 +67,7 @@ describe('P-4: SWM share() 10 MB gossip-message boundary', () => {
     publisher = await makePublisher(store, eventBus);
   });
 
-  it('accepts a multi-MB payload below the 10 MB cap and returns an encoded message', async () => {
+  it('accepts a multi-MB payload below the 4 MiB cap and returns an encoded message', async () => {
     // Many modest literals match the large-context-graph shape without
     // stressing storage's single-literal formatter.
     const under = buildQuadsWithTotalPayload(2 * 1024 * 1024);
@@ -84,8 +84,8 @@ describe('P-4: SWM share() 10 MB gossip-message boundary', () => {
     expect(result.message.length).toBeGreaterThan(1024 * 1024); // sanity: did we actually build big
   });
 
-  it('rejects a payload just over the 10 MB cap with a clear, actionable error', async () => {
-    // Well over the 10 MB cap so there is no ambiguity about the exit path.
+  it('rejects a payload just over the 4 MiB cap with a clear, actionable error', async () => {
+    // Well over the 4 MiB cap so there is no ambiguity about the exit path.
     // Use many Blazegraph-safe literals so this exercises the aggregate
     // gossip-message boundary rather than the per-literal safety guard.
     const over = buildQuadsWithTotalPayload(DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
@@ -104,11 +104,11 @@ describe('P-4: SWM share() 10 MB gossip-message boundary', () => {
     // without attaching a debugger. We also assert the remediation
     // guidance (split by root entity) per spec §04.
     expect(msg).toMatch(/too large/i);
-    expect(msg).toMatch(/10\s*MB/);
+    expect(msg).toMatch(/4\s*MB/);
     expect(msg).toMatch(/split/i);
   });
 
-  it('the cap is 10 MB — an oversized payload fails, a multi-MB payload passes', async () => {
+  it('the cap is 4 MiB — an oversized payload fails, a multi-MB payload passes', async () => {
     // Pin the constant. If someone reduces the cap without updating
     // the guidance in the error or the spec, BOTH
     // halves of this test flip status and the regression is noisy.
@@ -121,6 +121,6 @@ describe('P-4: SWM share() 10 MB gossip-message boundary', () => {
 
     await expect(
       publisher.share(CG, justOver, { publisherPeerId: PEER }),
-    ).rejects.toThrow(/too large.*10\s*MB/i);
+    ).rejects.toThrow(/too large.*4\s*MB/i);
   });
 });

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -11,6 +11,7 @@ import {
   encryptWorkspacePayload,
   generateWorkspaceRecipientEncryptionKey,
   computeGossipSigningPayload,
+  DKG_GOSSIP_MAX_MESSAGE_BYTES,
   GOSSIP_ENVELOPE_VERSION,
   GOSSIP_TYPE_WORKSPACE_PUBLISH,
   STORAGE_ACK_MAX_STAGING_BYTES,
@@ -503,7 +504,7 @@ describe('Workspace: publishFromSharedMemory', () => {
     expect(decoded).toContain(`<${ENTITY}> <http://schema.org/name> "Inline From SWM"`);
   });
 
-  it('omits staging quads for over-limit internal public SWM first ACK attempts', async () => {
+  it('omits staging quads for over-limit aggregate public SWM first ACK attempts', async () => {
     const targetBytes = STORAGE_ACK_MAX_STAGING_BYTES + 1;
     // The publisher prices/ACKs the canonical data-graph N-Quads, not the
     // caller's graphless SWM input. Build the boundary fixture with that exact
@@ -511,11 +512,24 @@ describe('Workspace: publishFromSharedMemory', () => {
     const selectedQuads = buildPublicQuadsWithByteSize(targetBytes, DATA_GRAPH);
     expect(encodedPublicByteLength(selectedQuads)).toBe(targetBytes);
 
-    await publisher.share(
+    // An aggregate SWM selection can exceed the 4 MiB ACK-inline ceiling even
+    // though every individual gossip operation respects the same 4 MiB limit.
+    // Seed that reachable state through two valid shares instead of one
+    // oversized share that must now fail at the producing boundary.
+    const graphlessQuads = selectedQuads.map((quad) => ({ ...quad, graph: '' }));
+    const splitAt = Math.ceil(graphlessQuads.length / 2);
+    const firstShare = await publisher.share(
       CONTEXT_GRAPH,
-      selectedQuads.map((quad) => ({ ...quad, graph: '' })),
-      { publisherPeerId: 'peer-oversized-inline' },
+      graphlessQuads.slice(0, splitAt),
+      { publisherPeerId: 'peer-aggregate-first' },
     );
+    const secondShare = await publisher.share(
+      CONTEXT_GRAPH,
+      graphlessQuads.slice(splitAt),
+      { publisherPeerId: 'peer-aggregate-second' },
+    );
+    expect(firstShare.message.length).toBeLessThanOrEqual(DKG_GOSSIP_MAX_MESSAGE_BYTES);
+    expect(secondShare.message.length).toBeLessThanOrEqual(DKG_GOSSIP_MAX_MESSAGE_BYTES);
 
     let receivedParams: V10ACKProviderParams | undefined;
     const stopAfterCapture = new Error('stop after over-limit ACK capture');


### PR DESCRIPTION
## Summary

- cap DKG GossipSub application payloads at 4 MiB by sourcing `DKG_GOSSIP_MAX_MESSAGE_BYTES` from `STORAGE_ACK_MAX_STAGING_BYTES`
- retain 256 KiB of GossipSub RPC framing headroom while leaving the generic 10 MiB direct-protocol frame/read ceiling unchanged
- update SWM boundary tests, CI sharding, async-promote examples, importer/operator guidance, and the changelog

## Why

SWM previously admitted Knowledge Asset payloads up to 10 MiB, while inline StorageACK staging rejected payloads above 4 MiB. That created a 4–10 MiB range which could pass the SWM transport boundary but then depended on a healthy SWM-backed ACK path. Using one 4 MiB application ceiling makes the behavior predictable and rejects oversized shares at the producing boundary.

## Impact

A single SWM share or promotion must now encode to at most 4 MiB. Larger assertions need to be split by root entity. Importer guidance now starts promotion batches at 400 roots and halves on the encoded-payload cap. HTTP write bodies and generic direct protocol frames retain their existing 10 MiB limits.

No smart-contract changes are included.

## Validation

- core constants: 44 tests passed
- CLI async-promote classification and queue: 34 tests passed
- CLI skill endpoint: 21 tests passed
- publisher boundary and lifecycle: 88 tests passed
- agent SWM boundary: 3 tests passed
- affected packages and their workspace prerequisites built successfully
- `git diff --check`
