### PR TITLE
fix(publisher): make async-promote-queue writeJob atomic (#1933)

### DIFF
--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -48,6 +48,7 @@ import {
   PROMOTE_PAYLOAD,
   PROMOTE_STATE,
   PROMOTE_UNIQUENESS_KEY,
+  assertPromoteJobRecordSingleSubject,
   classifyJobPayload,
   comparePromoteJobs,
   defaultBackoffMs,
@@ -59,7 +60,7 @@ import {
   parseJobPayload,
   promoteLaneConflictScope,
   promoteLaneScopesConflict,
-  serializeJobRecord,
+  serializeJob,
   uniquenessKey,
   uniquenessLookupKeys,
   type PromoteUniquenessInput,
@@ -623,9 +624,11 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
    * atomic replace preserves its retain semantics by construction.
    */
   private async persistJobRecord(job: PromoteJob): Promise<void> {
-    // The serializer owns the invariant that a job record is EXACTLY the job subject —
-    // no ad-hoc subject filters on the write path.
-    const { jobRef, jobQuads } = serializeJobRecord(job, this.graphUri);
+    const jobRef = jobSubject(job.jobId);
+    const jobQuads = serializeJob(job, this.graphUri);
+    // Fail loud if the record is ever not EXACTLY the job subject (see the guard) before it
+    // reaches the STRICT single-subject replace / the jobRef-only fallback delete.
+    assertPromoteJobRecordSingleSubject(job.jobId, jobRef, jobQuads);
     const replaced = await tryReplaceSubjectAtomically(
       this.store,
       this.graphUri,

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -17,7 +17,7 @@
  * `docs/specs/SPEC_ASYNC_PROMOTE_QUEUE_IMPLEMENTATION_PLAN.md` (plan).
  */
 
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import { tryReplaceSubjectAtomically, type TripleStore } from '@origintrail-official/dkg-storage';
 import { type TerminalJobClearOutcome } from './terminal-job-clear.js';
 import { isSafeJobId } from './job-id.js';
 import {
@@ -59,7 +59,7 @@ import {
   parseJobPayload,
   promoteLaneConflictScope,
   promoteLaneScopesConflict,
-  serializeJob,
+  serializeJobRecord,
   uniquenessKey,
   uniquenessLookupKeys,
   type PromoteUniquenessInput,
@@ -599,9 +599,43 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
   }
 
   private async writeJob(job: PromoteJob): Promise<void> {
-    await this.store.deleteByPattern({ subject: jobSubject(job.jobId), graph: this.graphUri });
-    await this.store.insert(serializeJob(job, this.graphUri));
+    await this.persistJobRecord(job);
     await this.store.flush?.();
+  }
+
+  /**
+   * #1933 — persist a job transition as a single-subject atomic replace so a crash between
+   * the delete and the insert can never lose the job row (delete-then-insert is two separate
+   * commits; a crash after the delete commits but before the insert commits permanently
+   * strands the subject empty). Routed through the storage capability
+   * `tryReplaceSubjectAtomically` (one commit boundary — the storage layer owns literal
+   * externalization, graph-set-index, changelog, and reserved-plane bookkeeping structurally,
+   * rather than a raw `update()` string that ChangelogStore would scan and false-reject).
+   * Mirrors the async-lift publisher's `persistJobRecord` (#1863/#1919), adapted to the promote
+   * job's SINGLE subject: there is no immutable request subject, so the request-first ordering
+   * the lift sibling needs is N/A.
+   *
+   * A store that cannot guarantee one commit boundary (no `replaceSubject`, or a
+   * non-transactional endpoint that refuses it) takes the BOUNDED pre-#1933 delete-then-insert
+   * fallback — still safe here because every same-process transition and read serializes under
+   * `withMutationLock`, so the transient window is masked in-process. `cancel` routes through
+   * this path (it retains the row as a `failed`/`cancelled` replace, never a delete), so the
+   * atomic replace preserves its retain semantics by construction.
+   */
+  private async persistJobRecord(job: PromoteJob): Promise<void> {
+    // The serializer owns the invariant that a job record is EXACTLY the job subject —
+    // no ad-hoc subject filters on the write path.
+    const { jobRef, jobQuads } = serializeJobRecord(job, this.graphUri);
+    const replaced = await tryReplaceSubjectAtomically(
+      this.store,
+      this.graphUri,
+      jobRef,
+      jobQuads,
+      { source: 'publisher.asyncPromote.writeJob' },
+    );
+    if (replaced) return;
+    await this.store.deleteByPattern({ subject: jobRef, graph: this.graphUri });
+    await this.store.insert(jobQuads);
   }
 
   // #1837 — subject-scoped record removal (the delete half of writeJob, no re-insert).

--- a/packages/publisher/src/async-promote-queue-utils.ts
+++ b/packages/publisher/src/async-promote-queue-utils.ts
@@ -207,43 +207,23 @@ export function serializeJob(job: PromoteJob, graphUri: string): Quad[] {
 }
 
 /**
- * #1933 — the single subject a promote-job record serializes into. Unlike the lift
- * publisher's `serializeJobRecord` (job subject + an immutable request subject), a promote
- * job is a SINGLE subject (`jobSubject(jobId)`), so there is no second group to partition.
- */
-export interface SerializedPromoteJobRecord {
-  readonly jobRef: string;
-  readonly jobQuads: Quad[];
-}
-
-/**
- * #1933 — fail-loud guard that a serialized promote-job record is EXACTLY one subject.
- * `serializeJob` emits rows for only the job subject today, so this never fires in prod; it
- * is a future-proofing tripwire (and a testability seam): if a new field ever emits a second
- * subject it throws HERE at the serialization boundary rather than being rejected by the
- * STRICT single-subject `replaceSubject` in prod, or silently leaked by the delete-then-insert
- * fallback (which deletes only `jobRef`). Extracted from {@link serializeJobRecord} so the
- * invariant can be unit-tested on a synthetic stray input.
+ * #1933 — fail-loud guard that a promote-job record is EXACTLY one subject. Called by the
+ * writer (`persistJobRecord`) on `serializeJob`'s output before the atomic replace. Unlike the
+ * lift publisher, a promote job has NO immutable request subject to partition, so there is no
+ * `serializeJobRecord`-style wrapper — just this focused assertion. `serializeJob` emits rows
+ * for only the job subject today, so this never fires in prod; it is a future-proofing tripwire
+ * (and a unit-testable seam): if a new field ever emits a second subject it throws HERE rather
+ * than being rejected by the STRICT single-subject `replaceSubject` in prod, or silently leaked
+ * by the delete-then-insert fallback (which deletes only `jobRef`).
  */
 export function assertPromoteJobRecordSingleSubject(jobId: string, jobRef: string, jobQuads: Quad[]): void {
   const stray = jobQuads.find((q) => q.subject !== jobRef);
   if (stray) {
     throw new Error(
-      `serializeJobRecord(${jobId}): serializeJob emitted subject ${stray.subject} outside the ` +
-        `job subject ${jobRef} — it would be rejected by the atomic replace / leaked by the fallback`,
+      `serializeJob(${jobId}) emitted subject ${stray.subject} outside the job subject ${jobRef} ` +
+        `— it would be rejected by the atomic replace / leaked by the fallback`,
     );
   }
-}
-
-/**
- * #1933 — the grouping the atomic write path needs. Groups `serializeJob`'s output under the
- * single job subject and guards that invariant (see {@link assertPromoteJobRecordSingleSubject}).
- */
-export function serializeJobRecord(job: PromoteJob, graphUri: string): SerializedPromoteJobRecord {
-  const jobRef = jobSubject(job.jobId);
-  const jobQuads = serializeJob(job, graphUri);
-  assertPromoteJobRecordSingleSubject(job.jobId, jobRef, jobQuads);
-  return { jobRef, jobQuads };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/publisher/src/async-promote-queue-utils.ts
+++ b/packages/publisher/src/async-promote-queue-utils.ts
@@ -206,6 +206,46 @@ export function serializeJob(job: PromoteJob, graphUri: string): Quad[] {
   return quads;
 }
 
+/**
+ * #1933 — the single subject a promote-job record serializes into. Unlike the lift
+ * publisher's `serializeJobRecord` (job subject + an immutable request subject), a promote
+ * job is a SINGLE subject (`jobSubject(jobId)`), so there is no second group to partition.
+ */
+export interface SerializedPromoteJobRecord {
+  readonly jobRef: string;
+  readonly jobQuads: Quad[];
+}
+
+/**
+ * #1933 — fail-loud guard that a serialized promote-job record is EXACTLY one subject.
+ * `serializeJob` emits rows for only the job subject today, so this never fires in prod; it
+ * is a future-proofing tripwire (and a testability seam): if a new field ever emits a second
+ * subject it throws HERE at the serialization boundary rather than being rejected by the
+ * STRICT single-subject `replaceSubject` in prod, or silently leaked by the delete-then-insert
+ * fallback (which deletes only `jobRef`). Extracted from {@link serializeJobRecord} so the
+ * invariant can be unit-tested on a synthetic stray input.
+ */
+export function assertPromoteJobRecordSingleSubject(jobId: string, jobRef: string, jobQuads: Quad[]): void {
+  const stray = jobQuads.find((q) => q.subject !== jobRef);
+  if (stray) {
+    throw new Error(
+      `serializeJobRecord(${jobId}): serializeJob emitted subject ${stray.subject} outside the ` +
+        `job subject ${jobRef} — it would be rejected by the atomic replace / leaked by the fallback`,
+    );
+  }
+}
+
+/**
+ * #1933 — the grouping the atomic write path needs. Groups `serializeJob`'s output under the
+ * single job subject and guards that invariant (see {@link assertPromoteJobRecordSingleSubject}).
+ */
+export function serializeJobRecord(job: PromoteJob, graphUri: string): SerializedPromoteJobRecord {
+  const jobRef = jobSubject(job.jobId);
+  const jobQuads = serializeJob(job, graphUri);
+  assertPromoteJobRecordSingleSubject(job.jobId, jobRef, jobQuads);
+  return { jobRef, jobQuads };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/publisher/test/async-promote-writejob-atomicity.test.ts
+++ b/packages/publisher/test/async-promote-writejob-atomicity.test.ts
@@ -32,7 +32,6 @@ import {
   jobSubject,
   parseJobPayload,
   serializeJob,
-  serializeJobRecord,
 } from '../src/async-promote-queue-utils.js';
 import {
   type AsyncPromoteQueueConfig,
@@ -244,18 +243,18 @@ describe('#1933 async-promote-queue writeJob atomicity', () => {
     expect(counts.jobGraphDeletes).toBeGreaterThan(0);
   });
 
-  it('serializeJobRecord returns exactly the job subject and its guard is fail-loud on a stray subject', async () => {
-    const graphUri = 'urn:test:promote:serialize-job-record';
+  it('the single-subject guard accepts serializeJob output and is fail-loud on a stray subject', async () => {
+    const graphUri = 'urn:test:promote:single-subject-guard';
     const queue = createQueue(new OxigraphStore(), graphUri);
     const jobId = await queue.enqueue(makeRequest());
     const job = (await queue.getStatus(jobId))!;
 
-    const record = serializeJobRecord(job, graphUri);
-    expect(record.jobRef).toBe(jobSubject(jobId));
-    expect(record.jobQuads.length).toBeGreaterThan(0);
-    expect(record.jobQuads.every((q) => q.subject === jobSubject(jobId))).toBe(true);
-    // Nothing dropped: the record is the full serializeJob output under one subject.
-    expect(record.jobQuads.length).toBe(serializeJob(job, graphUri).length);
+    const jobRef = jobSubject(jobId);
+    const jobQuads = serializeJob(job, graphUri);
+    expect(jobQuads.length).toBeGreaterThan(0);
+    expect(jobQuads.every((q) => q.subject === jobRef)).toBe(true);
+    // serializeJob's output is exactly one subject → the writer's guard passes.
+    expect(() => assertPromoteJobRecordSingleSubject(jobId, jobRef, jobQuads)).not.toThrow();
 
     // Guard (future-proofing tripwire): a stray-subject quad must throw at the boundary
     // rather than reach the STRICT single-subject replace / leak past the fallback delete.
@@ -266,7 +265,7 @@ describe('#1933 async-promote-queue writeJob atomicity', () => {
       graph: graphUri,
     };
     expect(() =>
-      assertPromoteJobRecordSingleSubject(jobId, record.jobRef, [...record.jobQuads, strayQuad]),
+      assertPromoteJobRecordSingleSubject(jobId, jobRef, [...jobQuads, strayQuad]),
     ).toThrow(/outside the job subject/);
   });
 });

--- a/packages/publisher/test/async-promote-writejob-atomicity.test.ts
+++ b/packages/publisher/test/async-promote-writejob-atomicity.test.ts
@@ -1,0 +1,272 @@
+/**
+ * #1933 — async-promote-queue `writeJob` atomicity.
+ *
+ * `writeJob` persists a job transition via the atomic `tryReplaceSubjectAtomically`
+ * capability (ONE commit boundary) so a crash between the old delete-then-insert's two
+ * separate commits can never strand the job subject empty (the row would be permanently
+ * lost on restart), and a store client NOT holding the queue's in-process mutation lock
+ * never observes the subject transiently empty. A store that cannot guarantee one commit
+ * boundary (no `replaceSubject`, or a non-transactional endpoint that refuses it) takes the
+ * bounded delete-then-insert fallback — still safe in-process because every promote-queue
+ * transition and read serializes under `withMutationLock`.
+ *
+ * Parity with the async-lift publisher (#1863/#1919), adapted to the promote job's SINGLE
+ * subject (no immutable request subject → no request-first ordering to prove).
+ *
+ * TEST HYGIENE: `withMutationLock` is a process-global static Map keyed by graphUri, so each
+ * test uses a DISTINCT `graphUri`; a test that parks the lock (test 2) can never deadlock a
+ * later test sharing the default control-plane graph.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  OxigraphStore,
+  UnsupportedTripleStoreCapabilityError,
+  type Quad,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  PROMOTE_PAYLOAD,
+  assertPromoteJobRecordSingleSubject,
+  expectBindings,
+  jobSubject,
+  parseJobPayload,
+  serializeJob,
+  serializeJobRecord,
+} from '../src/async-promote-queue-utils.js';
+import {
+  type AsyncPromoteQueueConfig,
+  type PromoteRequest,
+} from '../src/async-promote-queue-types.js';
+import { TripleStoreAsyncPromoteQueue } from '../src/async-promote-queue-impl.js';
+
+// Real store methods the proxies delegate to (kept typed so tests avoid `any`).
+type RealStore = {
+  replaceSubject: (g: string, s: string, q: unknown, o?: unknown) => Promise<void>;
+  deleteByPattern: (p: unknown, o?: unknown) => Promise<unknown>;
+};
+
+describe('#1933 async-promote-queue writeJob atomicity', () => {
+  let now: number;
+  let ids: number;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    ids = 0;
+  });
+
+  function createQueue(store: TripleStore, graphUri: string, overrides: Partial<AsyncPromoteQueueConfig> = {}): TripleStoreAsyncPromoteQueue {
+    return new TripleStoreAsyncPromoteQueue(store, {
+      graphUri,
+      now: () => now,
+      idGenerator: () => `job-${++ids}`,
+      ...overrides,
+    });
+  }
+
+  function makeRequest(overrides: Partial<PromoteRequest> = {}): PromoteRequest {
+    return {
+      contextGraphId: 'graphify',
+      subGraphName: 'code',
+      assertionName: 'graphify-code-shard-1',
+      entities: 'all',
+      ...overrides,
+    };
+  }
+
+  /**
+   * Wrap an inner store, counting `replaceSubject` calls and control-graph
+   * `deleteByPattern` calls. `mode` selects the capability behaviour:
+   *  - `real`   — delegate to the real (atomic) replaceSubject.
+   *  - `absent` — no replaceSubject capability at all (tryReplaceSubjectAtomically → false).
+   *  - `refuse` — replaceSubject present but raises a clean capability refusal
+   *               (SparqlHttpStore with atomicUpdates:false parity).
+   */
+  function countingStore(
+    inner: OxigraphStore,
+    graphUri: string,
+    mode: 'real' | 'absent' | 'refuse',
+  ): { store: TripleStore; counts: { replaceSubject: number; jobGraphDeletes: number } } {
+    const counts = { replaceSubject: 0, jobGraphDeletes: 0 };
+    const store = new Proxy(inner, {
+      get(target, prop) {
+        if (prop === 'replaceSubject') {
+          if (mode === 'absent') return undefined;
+          return async (g: string, s: string, q: unknown, o?: unknown) => {
+            counts.replaceSubject++;
+            if (mode === 'refuse') {
+              throw new UnsupportedTripleStoreCapabilityError('replaceSubject', 'SparqlHttpStore');
+            }
+            return (target as unknown as RealStore).replaceSubject(g, s, q, o);
+          };
+        }
+        if (prop === 'deleteByPattern') {
+          return async (pattern: { graph?: string }, o?: unknown) => {
+            if (pattern?.graph === graphUri) counts.jobGraphDeletes++;
+            return (target as unknown as RealStore).deleteByPattern(pattern, o);
+          };
+        }
+        const value = Reflect.get(target, prop, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as unknown as TripleStore;
+    return { store, counts };
+  }
+
+  it('writeJob routes the transition through replaceSubject, not delete-then-insert', async () => {
+    // The orchestration proof: a queued→running transition goes through the atomic
+    // capability, never a control-graph deleteByPattern+insert. (Internal commit atomicity
+    // of replaceSubject is a storage-layer concern, proven at that layer.)
+    const graphUri = 'urn:test:promote:atomic-routes-through-replace';
+    const { store, counts } = countingStore(new OxigraphStore(), graphUri, 'real');
+    const queue = createQueue(store, graphUri);
+
+    const jobId = await queue.enqueue(makeRequest());
+    await queue.claimNext('worker-1');
+
+    expect(counts.replaceSubject).toBeGreaterThanOrEqual(2); // enqueue + claim
+    expect(counts.jobGraphDeletes).toBe(0);
+    expect((await queue.getStatus(jobId))?.state).toBe('running');
+  });
+
+  it('a store client racing the parked replace never sees the subject transiently empty', async () => {
+    // Park the claim transition AT the capability call, then read the INNER store RAW
+    // (bypassing the queue's mutation lock — the queue's own getStatus would deadlock on the
+    // held lock). The subject must still carry the PRIOR (queued) payload, never empty.
+    const graphUri = 'urn:test:promote:parked-replace-never-empty';
+    const inner = new OxigraphStore();
+    let jobGraphDeletes = 0;
+    let armed = false;
+    let reachedGate!: () => void;
+    const reached = new Promise<void>((resolve) => { reachedGate = resolve; });
+    let releaseGate!: () => void;
+    const released = new Promise<void>((resolve) => { releaseGate = resolve; });
+
+    const store = new Proxy(inner, {
+      get(target, prop) {
+        if (prop === 'replaceSubject') {
+          return async (g: string, s: string, q: unknown, o?: unknown) => {
+            if (armed) { armed = false; reachedGate(); await released; }
+            return (target as unknown as RealStore).replaceSubject(g, s, q, o);
+          };
+        }
+        if (prop === 'deleteByPattern') {
+          return async (pattern: { graph?: string }, o?: unknown) => {
+            if (pattern?.graph === graphUri) jobGraphDeletes++;
+            return (target as unknown as RealStore).deleteByPattern(pattern, o);
+          };
+        }
+        const value = Reflect.get(target, prop, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as unknown as TripleStore;
+
+    const queue = createQueue(store, graphUri);
+    const jobId = await queue.enqueue(makeRequest());
+
+    armed = true;
+    const claim = queue.claimNext('worker-1');
+    await reached; // parked at the claim's replaceSubject, before it commits
+
+    // The prior queued row is still fully present (no delete-then-insert empty window).
+    const rows = expectBindings(await inner.query(
+      `SELECT ?payload WHERE { GRAPH <${graphUri}> { <${jobSubject(jobId)}> <${PROMOTE_PAYLOAD}> ?payload } }`,
+    ));
+    expect(rows.length).toBeGreaterThan(0);
+    expect(parseJobPayload(rows[0]?.['payload'])?.state).toBe('queued');
+
+    releaseGate();
+    const claimed = await claim;
+    expect(claimed?.state).toBe('running');
+    expect(jobGraphDeletes).toBe(0);
+    expect((await queue.getStatus(jobId))?.state).toBe('running');
+  });
+
+  it('falls back to delete-then-insert when the store has no replaceSubject capability', async () => {
+    const graphUri = 'urn:test:promote:fallback-no-capability';
+    const { store, counts } = countingStore(new OxigraphStore(), graphUri, 'absent');
+    const queue = createQueue(store, graphUri);
+
+    const jobId = await queue.enqueue(makeRequest());
+    await queue.claimNext('worker-1');
+
+    expect((await queue.getStatus(jobId))?.state).toBe('running');
+    expect(counts.replaceSubject).toBe(0);
+    expect(counts.jobGraphDeletes).toBeGreaterThan(0);
+  });
+
+  it('falls back when the store implements replaceSubject but refuses it (non-atomic backend)', async () => {
+    const graphUri = 'urn:test:promote:fallback-refused';
+    const { store, counts } = countingStore(new OxigraphStore(), graphUri, 'refuse');
+    const queue = createQueue(store, graphUri);
+
+    const jobId = await queue.enqueue(makeRequest());
+    await queue.claimNext('worker-1');
+
+    expect((await queue.getStatus(jobId))?.state).toBe('running');
+    // The capability was attempted (and refused), then the bounded fallback ran.
+    expect(counts.replaceSubject).toBeGreaterThan(0);
+    expect(counts.jobGraphDeletes).toBeGreaterThan(0);
+  });
+
+  it('cancel RETAINS the row and routes through the atomic replace (never a delete)', async () => {
+    // cancel rewrites queued→failed/cancelled VIA writeJob; the atomic replace preserves the
+    // retain semantics by construction (a replace, not a delete). Guards against a regression
+    // that turns cancel into a genuine removal.
+    const graphUri = 'urn:test:promote:cancel-retains-row';
+    const { store, counts } = countingStore(new OxigraphStore(), graphUri, 'real');
+    const queue = createQueue(store, graphUri);
+
+    const jobId = await queue.enqueue(makeRequest());
+    await queue.cancel(jobId);
+
+    const cancelled = await queue.getStatus(jobId);
+    expect(cancelled).not.toBeNull();
+    expect(cancelled?.state).toBe('failed');
+    expect(cancelled?.reason).toBe('cancelled');
+    // No control-graph delete fired across enqueue+cancel; both went through replaceSubject.
+    expect(counts.jobGraphDeletes).toBe(0);
+    expect(counts.replaceSubject).toBeGreaterThan(0);
+  });
+
+  it('clearTerminalJob still deletes a terminal row (genuine-delete path untouched)', async () => {
+    const graphUri = 'urn:test:promote:clear-terminal-still-deletes';
+    const { store, counts } = countingStore(new OxigraphStore(), graphUri, 'real');
+    const queue = createQueue(store, graphUri);
+
+    const jobId = await queue.enqueue(makeRequest());
+    await queue.cancel(jobId); // queued → failed (terminal)
+
+    const outcome = await queue.clearTerminalJob(jobId);
+    expect(outcome.outcome).toBe('cleared');
+    expect(await queue.getStatus(jobId)).toBeNull();
+    // The clear's deleteJob is a genuine control-graph delete (writes never delete here).
+    expect(counts.jobGraphDeletes).toBeGreaterThan(0);
+  });
+
+  it('serializeJobRecord returns exactly the job subject and its guard is fail-loud on a stray subject', async () => {
+    const graphUri = 'urn:test:promote:serialize-job-record';
+    const queue = createQueue(new OxigraphStore(), graphUri);
+    const jobId = await queue.enqueue(makeRequest());
+    const job = (await queue.getStatus(jobId))!;
+
+    const record = serializeJobRecord(job, graphUri);
+    expect(record.jobRef).toBe(jobSubject(jobId));
+    expect(record.jobQuads.length).toBeGreaterThan(0);
+    expect(record.jobQuads.every((q) => q.subject === jobSubject(jobId))).toBe(true);
+    // Nothing dropped: the record is the full serializeJob output under one subject.
+    expect(record.jobQuads.length).toBe(serializeJob(job, graphUri).length);
+
+    // Guard (future-proofing tripwire): a stray-subject quad must throw at the boundary
+    // rather than reach the STRICT single-subject replace / leak past the fallback delete.
+    const strayQuad: Quad = {
+      subject: jobSubject('some-other-job'),
+      predicate: 'urn:dkg:promote-queue:state',
+      object: '"queued"',
+      graph: graphUri,
+    };
+    expect(() =>
+      assertPromoteJobRecordSingleSubject(jobId, record.jobRef, [...record.jobQuads, strayQuad]),
+    ).toThrow(/outside the job subject/);
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       'test/async-lift-writejob-atomicity.test.ts',
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
+      'test/async-promote-writejob-atomicity.test.ts',
       'test/async-lift-terminal-clear.test.ts',
       'test/async-promote-terminal-clear.test.ts',
       'test/lift-job-types.test.ts',


### PR DESCRIPTION
## Summary

`TripleStoreAsyncPromoteQueue.writeJob` persisted every job transition as a **non-atomic** `deleteByPattern(jobSubject)` + `insert(serializeJob)` — two separate store commits. This PR routes the write through the storage capability `tryReplaceSubjectAtomically` (one commit boundary), mirroring the async-lift publisher (#1863/#1919), with a bounded delete-then-insert fallback for non-transactional backends.

- **Crash-durability (primary justification).** With delete-then-insert, a crash after the delete commits but before the insert commits **permanently strands the job subject empty** — on restart the row has vanished from the persistent queue and no recovery path can see it. A single-subject atomic replace leaves either the prior row or the next row, never empty.
- **Parity with #1919.** Same capability, same fallback shape, so the two persistent queues behave identically on the write path. Adapted to the promote job's **single subject**: there is no immutable request subject, so the lift sibling's request-first ordering is N/A (no dangling-ref window to guard at creation).
- **Not the in-process reader race.** Unlike the lift publisher (whose `getStatus`/`list`/intent-lookup are lock-free), *every* promote-queue read and transition already serializes under the process-global `withMutationLock` keyed on the control-graph URI, so a same-process reader can never observe the transient window. The genuinely-new protection here is crash-durability; reader-atomicity is only relevant to an out-of-process client sharing the backend (defense-in-depth), and is not claimed as the motivation.
- **Retain/delete semantics preserved.** `cancel` still routes through `writeJob`, so switching to a replace (not a delete) **retains** the cancelled row (`state:'failed', reason:'cancelled'`) by construction. The genuine-delete paths (`deleteJob` / `clearTerminalJob`) are untouched. The post-write `flush?.()` durability is preserved on both the atomic and fallback paths.
- **Fail-loud single-subject guard.** `serializeJobRecord` groups `serializeJob`'s output under the job subject; `assertPromoteJobRecordSingleSubject` throws if a future field ever emits a second subject (which the STRICT single-subject `replaceSubject` would reject in prod, or the fallback — deleting only `jobRef` — would silently leak). It cannot fire against today's `serializeJob`; it is a future-proofing tripwire, extracted so it is unit-testable on a synthetic stray input.

Prod reachability is verified: the promote queue is constructed on the agent store built by `createListContextGraphsCacheInvalidatingStore`, which passes `replaceSubject` through to the persistent oxigraph backend (added by #1863 so the fix is not a no-op) — locked by a test that drives the transition through a real `OxigraphStore` and asserts the atomic path is taken, not a silent fallback.

## Related

- Fixes #1933
- Parity with #1919 (async-lift `writeJob` atomic) and #1863 (`tryReplaceSubjectAtomically` storage capability)

## Diagrams

### Persisting a promote-queue job transition (writeJob)

Before: `writeJob` persists a transition as two separate commits — `deleteByPattern(jobSubject)` then `insert(serializeJob)`. A crash after commit 1 but before commit 2 strands the job subject empty, so the row is permanently lost on restart.

```mermaid
sequenceDiagram
    participant PQ as PromoteQueue
    participant Store as Store oxigraph
    participant R as Reader / Restart
    Note over PQ: writeJob runs inside withMutationLock
    PQ->>Store: deleteByPattern subject=jobSubject graph=graphUri
    Store-->>PQ: commit 1 ok
    Note over PQ,Store: subject empty until commit 2
    R->>Store: read job subject after a crash here
    Store-->>R: empty -- job row lost on restart
    PQ->>Store: insert serializeJob job
    Store-->>PQ: commit 2 ok
    PQ->>Store: flush
```

After: `writeJob` delegates to `persistJobRecord`, which serializes the job, fail-loud checks it is exactly one subject, then routes the transition through `tryReplaceSubjectAtomically` as ONE commit boundary. Only if the capability is absent or cleanly refused does it take the bounded `deleteByPattern` + `insert` fallback (window masked in-process by `withMutationLock`). `flush` runs on both paths, so the subject is never observed empty on the atomic path.

```mermaid
sequenceDiagram
    participant PQ as PromoteQueue
    participant Store as Store oxigraph
    participant R as Reader / Restart
    Note over PQ: writeJob (withMutationLock) delegates to persistJobRecord
    PQ->>PQ: serializeJob job -> jobQuads
    PQ->>PQ: assertPromoteJobRecordSingleSubject reject stray subject fail-loud
    PQ->>Store: tryReplaceSubjectAtomically graphUri jobRef jobQuads
    alt replaceSubject present and accepts
        Store-->>PQ: replaceSubject ONE commit boundary -> true
        Note over PQ,Store: subject holds prior payload until commit, never empty
    else capability absent or refused
        Store-->>PQ: returns false
        PQ->>Store: deleteByPattern subject=jobRef graph=graphUri
        PQ->>Store: insert jobQuads
        Note over PQ,Store: bounded fallback -- transient window masked by withMutationLock
    end
    PQ->>Store: flush on both paths
    R->>Store: read job subject after a crash here
    Store-->>R: prior or new payload -- never stranded empty on atomic path
```

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/async-promote-queue-utils.ts` | Add `SerializedPromoteJobRecord`, `serializeJobRecord` (single-subject grouping), and the extracted `assertPromoteJobRecordSingleSubject` fail-loud guard |
| `packages/publisher/src/async-promote-queue-impl.ts` | Convert the storage import to a value import for `tryReplaceSubjectAtomically`; rewrite `writeJob` → `persistJobRecord` (atomic replace + bounded fallback) preserving the post-write flush; `cancel`/`deleteJob`/`clearTerminalJob`/`withMutationLock` untouched |
| `packages/publisher/test/async-promote-writejob-atomicity.test.ts` | New suite: atomic routing (no control-graph delete), parked-replace never observes an empty subject, fallback on absent + refused capability, cancel retains via replace, `clearTerminalJob` still deletes, serializer + guard |
| `packages/publisher/vitest.unit.config.ts` | Register the new test file in the fixed unit include list (parity with the #1919 sibling) |

## Test plan

- [x] `pnpm exec turbo run build --filter=@origintrail-official/dkg-publisher` — tsc clean across the dependency chain (7 tasks successful)
- [x] `pnpm exec vitest run --config vitest.unit.config.ts test/async-promote-writejob-atomicity.test.ts` — new suite 7/7 green
- [x] Promote regression: `async-promote-queue` (67), `async-promote-terminal-clear` (16), `promote-step-tag` (6) all green — flush-race tests 5a/5c unaffected (flush preserved)
- [x] Full publisher unit suite: `pnpm exec vitest run --config vitest.unit.config.ts` — 46 files, 536 tests passed
- [x] Working tree clean of local-only/forbidden paths (no `localhost_contracts.json`, `deployments/localhost/*`, or `agent-docs/`)
