### PR TITLE
refactor(sync): unify durable-_meta IRI term classifier (#1940)

### DIFF
--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -13,6 +13,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { appendInPlace } from './append-in-place.js';
+import { isIriMetaSubject } from './iri-term.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
 const MERKLE_ROOT = `${DKG_NS}merkleRoot`;
@@ -1478,25 +1479,6 @@ function hexToBytes(hex: string): Uint8Array {
 function stripLiteral(raw: string): string {
   const match = raw.match(/^"(.*)"(?:\^\^.*|@.*)?$/);
   return match ? match[1]! : raw;
-}
-
-/**
- * A durable `_meta` subject must be an IRI. Conforming writers only emit IRI
- * subjects (metadata generators build deterministic UALs; the publisher rejects
- * blank nodes; SWM writers skolemize before storage). A blank-node (`_:…`) or
- * literal (`"…"`) subject is only reachable via unverified peer-ingest and has
- * no trustworthy, stable identity, so it is dropped at ingest (#1921) rather
- * than persisted. Mirrors the responder's `isIriTerm` (graph-plan.ts) so ingest
- * and read agree on the contract.
- */
-function isIriMetaSubject(term: string): boolean {
-  // Defensive on `term`: this runs at the verification-input boundary filters
-  // (selectVerifiedDurableSyncQuads and planBoundedGraphScopedDurableBatch, both
-  // on RAW fetched meta) and in the admission selectors. A conforming quad always
-  // carries a non-empty string subject; tolerate a malformed one (treat as
-  // non-IRI → drop) instead of throwing.
-  return typeof term === 'string' && term.length > 0
-    && !term.startsWith('_:') && !term.startsWith('"');
 }
 
 function findLegacyRootOwner(subject: string, roots: ReadonlySet<string>): string | undefined {

--- a/packages/agent/src/sync/iri-term.ts
+++ b/packages/agent/src/sync/iri-term.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared RDF-term IRI classifier for the durable `_meta` sync lane.
+ *
+ * Both the responder read path (graph-plan.ts) and the requester ingest path
+ * (durable-integrity.ts) need to distinguish an IRI term from a blank node
+ * (`_:…`) or a literal (`"…"`). They share ONE core predicate but expose it
+ * under two names with a DELIBERATE, load-bearing divergence on empty/non-string
+ * inputs — hence two exported functions rather than one with a flag. Collapsing
+ * them (or defaulting a flag) would silently flip one side; keep them distinct.
+ *
+ * See {@link isIriTerm} (lenient, responder read) and
+ * {@link isIriMetaSubject} (strict, fail-closed ingest).
+ */
+
+/**
+ * The N-Quads term-kind test both callers agree on: a term is an IRI unless it
+ * is a blank-node label (`_:…`) or a quoted literal (`"…"`). This is the exact
+ * shared core; the divergence between the two exports is ONLY in their handling
+ * of empty-string / non-string inputs, layered on top of this.
+ */
+function isIriTermCore(term: string): boolean {
+  return !term.startsWith('_:') && !term.startsWith('"');
+}
+
+/**
+ * Responder-read IRI test (graph-plan.ts). LENIENT by design: it is the bare
+ * core predicate with no non-string or empty-string guard, so `isIriTerm('')`
+ * is `true`. It runs on the responder's own store-derived rows (a trusted,
+ * always-string source) on the protocol read/paging path, where byte-identical
+ * behavior matters more than defensiveness. Do NOT add a length/`typeof` guard
+ * here — that would change what the responder serves.
+ *
+ * Diverges from {@link isIriMetaSubject} on empty/non-string input: this returns
+ * `true` for `''`, that returns `false`. The divergence is intentional (#1940).
+ */
+export function isIriTerm(term: string): boolean {
+  return isIriTermCore(term);
+}
+
+/**
+ * Requester-ingest `_meta` subject test (durable-integrity.ts). STRICT and
+ * fail-closed: `isIriMetaSubject('')` is `false`, and a non-string subject is
+ * `false` rather than throwing. A durable `_meta` subject must be an IRI —
+ * conforming writers only emit IRI subjects (metadata generators build
+ * deterministic UALs; the publisher rejects blank nodes; SWM writers skolemize
+ * before storage). A blank-node (`_:…`) or literal (`"…"`) subject is only
+ * reachable via unverified peer-ingest and has no trustworthy, stable identity,
+ * so it is dropped at ingest (#1921) rather than persisted.
+ *
+ * The `typeof term === 'string' && term.length > 0` guard is load-bearing: this
+ * runs at the verification-input boundary filters (selectVerifiedDurableSyncQuads
+ * and planBoundedGraphScopedDurableBatch, both on RAW peer-fetched meta) and in
+ * the admission selectors. A conforming quad always carries a non-empty string
+ * subject; tolerate a malformed one (treat as non-IRI → drop) instead of
+ * throwing. This is why it diverges from the lenient {@link isIriTerm}, which
+ * runs on the responder's own trusted rows (#1940).
+ */
+export function isIriMetaSubject(term: string): boolean {
+  return typeof term === 'string' && term.length > 0 && isIriTermCore(term);
+}

--- a/packages/agent/src/sync/iri-term.ts
+++ b/packages/agent/src/sync/iri-term.ts
@@ -54,7 +54,16 @@ export function isIriTerm(term: string): boolean {
  * subject; tolerate a malformed one (treat as non-IRI → drop) instead of
  * throwing. This is why it diverges from the lenient {@link isIriTerm}, which
  * runs on the responder's own trusted rows (#1940).
+ *
+ * The parameter is typed `unknown` on purpose (not `string`): this IS the shared
+ * fail-closed validator for raw peer-ingest values, so a caller holding an
+ * untyped/unknown-valued subject can delegate directly without a cast. The guard
+ * narrows to a non-empty `string` before {@link isIriTermCore}, so tsc stays
+ * clean and the behavior is byte-identical to the previous `string` signature
+ * for the conforming call sites (`quad.subject` is already `string`). The
+ * `string`-vs-`unknown` split across the two exports honestly reflects
+ * trusted-input (responder read) vs fail-closed-untrusted-input (ingest).
  */
-export function isIriMetaSubject(term: string): boolean {
+export function isIriMetaSubject(term: unknown): boolean {
   return typeof term === 'string' && term.length > 0 && isIriTermCore(term);
 }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -34,6 +34,7 @@ import { SYNC_BYTE_BUDGET_RESPONSE_BYTES } from '../../dkg-agent-constants.js';
 import type { ChangelogSyncResponse, ChangelogDeltaRecord } from '../changelog/wire.js';
 import { durableMetaDelegationSubjectAdmissionExpression } from './durable-meta-admission.js';
 import { exactAssetFilterKey } from '../exact-assets.js';
+import { isIriTerm } from '../iri-term.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -3738,10 +3739,6 @@ function filterDurableMetaSnapshotRows(
       !(isIriTerm(row.s) && row.s.startsWith(DKG_JOIN_REQUEST_SUBJECT_PREFIX)),
     )
     .sort(compareRows);
-}
-
-function isIriTerm(term: string): boolean {
-  return !term.startsWith('_:') && !term.startsWith('"');
 }
 
 /**

--- a/packages/agent/test/iri-term.test.ts
+++ b/packages/agent/test/iri-term.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { isIriTerm, isIriMetaSubject } from '../src/sync/iri-term.js';
+
+/**
+ * #1940 — `isIriTerm` (responder read) and `isIriMetaSubject` (requester ingest)
+ * share one core predicate but diverge on empty/non-string input by design. The
+ * divergence is load-bearing (#1921): ingest must fail closed on `''` while the
+ * responder read must preserve its lenient byte-identical behavior. These tests
+ * lock both the shared behavior and the intentional divergence.
+ */
+describe('iri-term classifiers', () => {
+  describe('shared behavior (both exports)', () => {
+    const iris = [
+      'did:dkg:otp:2043/0x1234567890abcdef1234567890abcdef12345678/1',
+      'http://dkg.io/ontology/merkleRoot',
+      'https://example.org/thing#fragment',
+      'urn:uuid:1234',
+    ];
+    for (const iri of iris) {
+      it(`classifies IRI as a term: ${iri}`, () => {
+        expect(isIriTerm(iri)).toBe(true);
+        expect(isIriMetaSubject(iri)).toBe(true);
+      });
+    }
+
+    it('rejects a blank-node label (_:…) in both', () => {
+      expect(isIriTerm('_:b0')).toBe(false);
+      expect(isIriMetaSubject('_:b0')).toBe(false);
+      expect(isIriTerm('_:')).toBe(false);
+      expect(isIriMetaSubject('_:')).toBe(false);
+    });
+
+    it('rejects a quoted literal ("…) in both', () => {
+      expect(isIriTerm('"a literal"')).toBe(false);
+      expect(isIriMetaSubject('"a literal"')).toBe(false);
+      expect(isIriTerm('"42"^^<http://www.w3.org/2001/XMLSchema#integer>')).toBe(false);
+      expect(isIriMetaSubject('"42"^^<http://www.w3.org/2001/XMLSchema#integer>')).toBe(false);
+    });
+  });
+
+  describe('intentional divergence on empty / non-string input (#1940)', () => {
+    it('empty string: isIriTerm is lenient (true), isIriMetaSubject is fail-closed (false)', () => {
+      // Responder read preserves the bare-core semantics: '' starts with
+      // neither '_:' nor '"', so it is an IRI term.
+      expect(isIriTerm('')).toBe(true);
+      // Ingest hardening (#1921): an empty subject is not a trustworthy IRI, so
+      // it is dropped rather than persisted.
+      expect(isIriMetaSubject('')).toBe(false);
+    });
+
+    it('non-string subject: isIriMetaSubject fails closed without throwing', () => {
+      // The verification-input boundary runs on RAW peer-fetched meta; tolerate
+      // a malformed subject (treat as non-IRI → drop) instead of throwing.
+      for (const bad of [undefined, null, 0, {}, []]) {
+        expect(isIriMetaSubject(bad as unknown as string)).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/agent/test/iri-term.test.ts
+++ b/packages/agent/test/iri-term.test.ts
@@ -50,9 +50,12 @@ describe('iri-term classifiers', () => {
 
     it('non-string subject: isIriMetaSubject fails closed without throwing', () => {
       // The verification-input boundary runs on RAW peer-fetched meta; tolerate
-      // a malformed subject (treat as non-IRI → drop) instead of throwing.
-      for (const bad of [undefined, null, 0, {}, []]) {
-        expect(isIriMetaSubject(bad as unknown as string)).toBe(false);
+      // a malformed subject (treat as non-IRI → drop) instead of throwing. The
+      // `unknown` param means these need no cast — an untyped ingest caller can
+      // delegate directly, which is the point of widening the type (#1940 review).
+      const badInputs: unknown[] = [undefined, null, 0, {}, []];
+      for (const bad of badInputs) {
+        expect(isIriMetaSubject(bad)).toBe(false);
       }
     });
   });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       "test/publish-finalized-agent-lane.test.ts",
       "test/publish-foreign-author-resolution.test.ts",
       "test/durable-integrity-seal-assertion-version.test.ts",
+      "test/iri-term.test.ts",
       "test/promote-async-default-agent.test.ts",
       "test/clear-promote-async-facade.test.ts",
       "test/query-min-trust-alias.test.ts",


### PR DESCRIPTION
## Summary

- The durable-`_meta` IRI term classifier existed as two near-identical copies: `isIriMetaSubject` in `packages/agent/src/sync/durable-integrity.ts` (requester ingest) and `isIriTerm` in `packages/agent/src/sync/responder/graph-plan.ts` (responder read). This unifies them into one shared module, `packages/agent/src/sync/iri-term.ts`, imported by both.
- Behavior-preserving refactor. The two predicates share one private core (`!term.startsWith('_:') && !term.startsWith('"')`) but keep a deliberate, load-bearing divergence on empty/non-string input, so they are exported as **two named functions**, not collapsed into one or a defaulted flag:
  - `isIriTerm` (responder read) is the bare core — **lenient**: `isIriTerm('')` stays `true`, and no `typeof`/length guard is added, so the protocol responder read/paging path is byte-identical.
  - `isIriMetaSubject` (requester ingest) is `typeof term === 'string' && term.length > 0 && <core>` — **strict / fail-closed**: `isIriMetaSubject('')` stays `false` and a non-string subject is `false` rather than throwing, preserving the #1921 peer-ingest hardening.
- The shared module carries jsdoc documenting why the divergence is intentional. Both call sites in `durable-integrity.ts` (4) and `graph-plan.ts` (2) are unchanged — only the definition moved.

## Related

- Closes #1940; follow-up to #1936 (#1921).

## Diagrams

- No flow changes

## Files changed

| File | What |
|------|------|
| `packages/agent/src/sync/iri-term.ts` | New shared module: private `isIriTermCore` + two named exports (`isIriTerm` lenient, `isIriMetaSubject` strict), jsdoc documenting the intentional empty/non-string divergence. |
| `packages/agent/src/sync/durable-integrity.ts` | Deleted the local `isIriMetaSubject`; import it from `./iri-term.js`. 4 call sites unchanged. |
| `packages/agent/src/sync/responder/graph-plan.ts` | Deleted the local `isIriTerm`; import it from `../iri-term.js`. 2 call sites unchanged (protocol read path). |
| `packages/agent/test/iri-term.test.ts` | New test: IRI / blank-node (`_:`) / literal (`"`) / empty-string / non-string inputs for both exports; asserts the divergence explicitly (`isIriMetaSubject('') === false`, `isIriTerm('') === true`). |
| `packages/agent/vitest.unit.config.ts` | Register the new test in the explicit unit-config include list (the default `test/**/*.test.ts` glob already auto-discovers it). |

## Test plan

- [x] `tsc --noEmit` clean for `@origintrail-official/dkg-agent`.
- [x] `pnpm exec vitest run --config vitest.unit.config.ts` over durable / sync-responder / sync-verify / sync-control suites + the new `iri-term` test — 24 files, 308 tests green.
- [x] New `test/iri-term.test.ts` — 8 tests green; locks the shared behavior and the intentional empty/non-string divergence.
- [x] Behavior byte-identical: the #1921 durable-integrity suites and the graph-plan responder suites pass unchanged after the import swap.
