### PR TITLE
refactor(publisher): extract shared atomic replace/fallback writer across async-lift and async-promote queues

### DIFF
--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -1,5 +1,5 @@
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
-import { GraphManager, PrivateContentStore, tryReplaceSubjectAtomically } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   LegacyKnowledgeAssetReadOnlyError,
@@ -45,6 +45,7 @@ import type {
 import { AsyncLiftJobConflictError } from './async-lift-publisher-types.js';
 import { type TerminalJobClearOutcome } from './terminal-job-clear.js';
 import { isSafeJobId } from './job-id.js';
+import { replaceSubjectAtomicallyOrFallback } from './subject-atomic-write.js';
 import {
   isDefinitivePreAcceptanceSendFailure,
   mapPublishExceptionToLiftJobFailure,
@@ -1120,7 +1121,8 @@ export class TripleStoreAsyncLiftPublisher
    * false `kind:'none'` intent-lookup miss / dedup gap that hinges on that index
    * row disappearing mid-write cannot occur.
    *
-   * Routed through the storage capability `tryReplaceSubjectAtomically` (a
+   * Routed through the shared writer `replaceSubjectAtomicallyOrFallback` (#1938),
+   * which uses the storage capability `tryReplaceSubjectAtomically` (a
    * sibling of `replaceGraph` / `replaceGraphAndSubject`) rather than a raw
    * `update()` string: the storage layer owns the transaction boundary, literal
    * externalization, graph-set-index and changelog bookkeeping, and — crucially —
@@ -1153,17 +1155,15 @@ export class TripleStoreAsyncLiftPublisher
     const { jobRef, jobQuads, requestQuads } = serializeJobRecord(job, this.graphUri);
     // (1) Request present BEFORE the job subject is observable — ordering matters.
     await this.store.insert(requestQuads);
-    // (2) Atomically replace the mutable job subject.
-    const replaced = await tryReplaceSubjectAtomically(
+    // (2) Atomically replace the mutable job subject via the shared writer (#1938),
+    //     which owns the atomic-capable-vs-bounded-fallback policy for both queues.
+    await replaceSubjectAtomicallyOrFallback(
       this.store,
       this.graphUri,
       jobRef,
       jobQuads,
-      { source: 'publisher.asyncLift.writeJob' },
+      'publisher.asyncLift.writeJob',
     );
-    if (replaced) return;
-    await this.store.deleteByPattern({ subject: jobRef, graph: this.graphUri });
-    await this.store.insert(jobQuads);
   }
 
   /**

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -17,9 +17,10 @@
  * `docs/specs/SPEC_ASYNC_PROMOTE_QUEUE_IMPLEMENTATION_PLAN.md` (plan).
  */
 
-import { tryReplaceSubjectAtomically, type TripleStore } from '@origintrail-official/dkg-storage';
+import { type TripleStore } from '@origintrail-official/dkg-storage';
 import { type TerminalJobClearOutcome } from './terminal-job-clear.js';
 import { isSafeJobId } from './job-id.js';
+import { replaceSubjectAtomicallyOrFallback } from './subject-atomic-write.js';
 import {
   ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
   ASYNC_PROMOTE_QUEUE_MIN_AUTO_RECOVERABLE_FORMAT_VERSION,
@@ -48,7 +49,6 @@ import {
   PROMOTE_PAYLOAD,
   PROMOTE_STATE,
   PROMOTE_UNIQUENESS_KEY,
-  assertPromoteJobRecordSingleSubject,
   classifyJobPayload,
   comparePromoteJobs,
   defaultBackoffMs,
@@ -60,7 +60,7 @@ import {
   parseJobPayload,
   promoteLaneConflictScope,
   promoteLaneScopesConflict,
-  serializeJob,
+  serializeJobRecord,
   uniquenessKey,
   uniquenessLookupKeys,
   type PromoteUniquenessInput,
@@ -608,7 +608,8 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
    * #1933 — persist a job transition as a single-subject atomic replace so a crash between
    * the delete and the insert can never lose the job row (delete-then-insert is two separate
    * commits; a crash after the delete commits but before the insert commits permanently
-   * strands the subject empty). Routed through the storage capability
+   * strands the subject empty). Routed through the shared writer
+   * `replaceSubjectAtomicallyOrFallback` (#1938), which uses the storage capability
    * `tryReplaceSubjectAtomically` (one commit boundary — the storage layer owns literal
    * externalization, graph-set-index, changelog, and reserved-plane bookkeeping structurally,
    * rather than a raw `update()` string that ChangelogStore would scan and false-reject).
@@ -617,28 +618,26 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
    * the lift sibling needs is N/A.
    *
    * A store that cannot guarantee one commit boundary (no `replaceSubject`, or a
-   * non-transactional endpoint that refuses it) takes the BOUNDED pre-#1933 delete-then-insert
-   * fallback — still safe here because every same-process transition and read serializes under
-   * `withMutationLock`, so the transient window is masked in-process. `cancel` routes through
-   * this path (it retains the row as a `failed`/`cancelled` replace, never a delete), so the
-   * atomic replace preserves its retain semantics by construction.
+   * non-transactional endpoint that refuses it) takes the shared writer's BOUNDED pre-#1933
+   * delete-then-insert fallback — still safe here because every same-process transition and
+   * read serializes under `withMutationLock`, so the transient window is masked in-process.
+   * `cancel` routes through this path (it retains the row as a `failed`/`cancelled` replace,
+   * never a delete), so the atomic replace preserves its retain semantics by construction.
    */
   private async persistJobRecord(job: PromoteJob): Promise<void> {
-    const jobRef = jobSubject(job.jobId);
-    const jobQuads = serializeJob(job, this.graphUri);
-    // Fail loud if the record is ever not EXACTLY the job subject (see the guard) before it
-    // reaches the STRICT single-subject replace / the jobRef-only fallback delete.
-    assertPromoteJobRecordSingleSubject(job.jobId, jobRef, jobQuads);
-    const replaced = await tryReplaceSubjectAtomically(
+    // The serializer owns record shaping AND the fail-loud single-subject guard (it throws if
+    // the record is ever not EXACTLY the job subject, before it reaches the STRICT
+    // single-subject replace / the jobRef-only fallback delete).
+    const { jobRef, jobQuads } = serializeJobRecord(job, this.graphUri);
+    // Persist via the shared writer (#1938), which owns the atomic-capable-vs-bounded-fallback
+    // policy for both queues (fallback delete scoped to EXACTLY jobRef).
+    await replaceSubjectAtomicallyOrFallback(
       this.store,
       this.graphUri,
       jobRef,
       jobQuads,
-      { source: 'publisher.asyncPromote.writeJob' },
+      'publisher.asyncPromote.writeJob',
     );
-    if (replaced) return;
-    await this.store.deleteByPattern({ subject: jobRef, graph: this.graphUri });
-    await this.store.insert(jobQuads);
   }
 
   // #1837 — subject-scoped record removal (the delete half of writeJob, no re-insert).

--- a/packages/publisher/src/async-promote-queue-utils.ts
+++ b/packages/publisher/src/async-promote-queue-utils.ts
@@ -207,14 +207,15 @@ export function serializeJob(job: PromoteJob, graphUri: string): Quad[] {
 }
 
 /**
- * #1933 — fail-loud guard that a promote-job record is EXACTLY one subject. Called by the
- * writer (`persistJobRecord`) on `serializeJob`'s output before the atomic replace. Unlike the
- * lift publisher, a promote job has NO immutable request subject to partition, so there is no
- * `serializeJobRecord`-style wrapper — just this focused assertion. `serializeJob` emits rows
- * for only the job subject today, so this never fires in prod; it is a future-proofing tripwire
- * (and a unit-testable seam): if a new field ever emits a second subject it throws HERE rather
- * than being rejected by the STRICT single-subject `replaceSubject` in prod, or silently leaked
- * by the delete-then-insert fallback (which deletes only `jobRef`).
+ * #1933 — fail-loud guard that a promote-job record is EXACTLY one subject. Run by
+ * {@link serializeJobRecord} on `serializeJob`'s output before the atomic replace. Unlike the
+ * lift publisher, a promote job has NO immutable request subject to partition, so
+ * `serializeJobRecord` is a thin single-subject wrapper around this focused assertion (rather
+ * than a two-subject split). `serializeJob` emits rows for only the job subject today, so this
+ * never fires in prod; it is a future-proofing tripwire (and a unit-testable seam): if a new
+ * field ever emits a second subject it throws HERE rather than being rejected by the STRICT
+ * single-subject `replaceSubject` in prod, or silently leaked by the delete-then-insert
+ * fallback (which deletes only `jobRef`).
  */
 export function assertPromoteJobRecordSingleSubject(jobId: string, jobRef: string, jobQuads: Quad[]): void {
   const stray = jobQuads.find((q) => q.subject !== jobRef);
@@ -224,6 +225,28 @@ export function assertPromoteJobRecordSingleSubject(jobId: string, jobRef: strin
         `— it would be rejected by the atomic replace / leaked by the fallback`,
     );
   }
+}
+
+/** The single subject group a promote-job record serializes into. */
+export interface SerializedPromoteJobRecord {
+  readonly jobRef: string;
+  readonly jobQuads: Quad[];
+}
+
+/**
+ * #1938 — the grouping the atomic write path needs, owned by the serializer rather than
+ * re-derived at the write site. Mirrors the async-lift sibling's `serializeJobRecord`, adapted
+ * to the promote job's SINGLE subject: there is no immutable request subject to partition, so
+ * the record is just the job subject and its quads. Runs
+ * {@link assertPromoteJobRecordSingleSubject} internally, so the fail-loud single-subject guard
+ * still fires on the write path (before the STRICT single-subject atomic replace / the
+ * jobRef-only fallback delete) without the writer re-asserting it.
+ */
+export function serializeJobRecord(job: PromoteJob, graphUri: string): SerializedPromoteJobRecord {
+  const jobRef = jobSubject(job.jobId);
+  const jobQuads = serializeJob(job, graphUri);
+  assertPromoteJobRecordSingleSubject(job.jobId, jobRef, jobQuads);
+  return { jobRef, jobQuads };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/publisher/src/subject-atomic-write.ts
+++ b/packages/publisher/src/subject-atomic-write.ts
@@ -6,11 +6,26 @@
 // pre-insert ordering; promote's single-subject guard) and calls this for the mutable
 // subject write.
 
-import { tryReplaceSubjectAtomically, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  assertSubjectReplacementPayload,
+  tryReplaceSubjectAtomically,
+  type Quad,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 
 /**
  * Persist a single mutable subject as one atomic replace when the store can guarantee one
  * commit boundary, else fall through to the BOUNDED delete-then-insert.
+ *
+ * The single-subject invariant is enforced UP FRONT via the storage layer's own
+ * `assertSubjectReplacementPayload` — the SAME assertion the atomic path runs inside
+ * `buildAtomicSubjectReplaceUpdate` — so BOTH paths reject an out-of-contract payload
+ * identically (subject is a canonical skolem IRI; every quad targets exactly `subject` in
+ * `graphUri`; blank-node free). Without this, only the atomic path validated: the bounded
+ * fallback deletes only `subject`'s rows in `graphUri` and then inserts whatever it is
+ * given, so a co-located or blank-node quad would be silently leaked on the fallback path
+ * while the atomic path rejected it (#1938 — close the asymmetry rather than leave the
+ * invariant to caller discipline). The queue serializers still own record shaping.
  *
  * The atomic path routes through the storage capability `tryReplaceSubjectAtomically` (a
  * sibling of `replaceGraph` / `replaceGraphAndSubject`): the storage layer owns the
@@ -32,6 +47,8 @@ export async function replaceSubjectAtomicallyOrFallback(
   quads: Quad[],
   source: string,
 ): Promise<void> {
+  // Enforce the atomic path's single-subject contract on BOTH paths, before either runs.
+  assertSubjectReplacementPayload(graphUri, subject, quads);
   const replaced = await tryReplaceSubjectAtomically(store, graphUri, subject, quads, { source });
   if (replaced) return;
   await store.deleteByPattern({ subject, graph: graphUri });

--- a/packages/publisher/src/subject-atomic-write.ts
+++ b/packages/publisher/src/subject-atomic-write.ts
@@ -1,0 +1,39 @@
+// #1938 — the single shared atomic-replace/fallback writer for the two persistent
+// publisher control-plane queues (async-lift #1863/#1919 and async-promote #1933).
+// The atomic-capable-vs-fallback policy is a publisher/storage concern, NOT a per-queue
+// one; keeping it in one place stops the queues drifting on fallback behavior or `source`
+// tagging. Each queue keeps only its own record-shaping concern (lift's request-first
+// pre-insert ordering; promote's single-subject guard) and calls this for the mutable
+// subject write.
+
+import { tryReplaceSubjectAtomically, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
+
+/**
+ * Persist a single mutable subject as one atomic replace when the store can guarantee one
+ * commit boundary, else fall through to the BOUNDED delete-then-insert.
+ *
+ * The atomic path routes through the storage capability `tryReplaceSubjectAtomically` (a
+ * sibling of `replaceGraph` / `replaceGraphAndSubject`): the storage layer owns the
+ * transaction boundary, literal externalization, and graph-set-index / changelog /
+ * reserved-plane bookkeeping structurally — a raw `update()` string would be scanned and
+ * false-rejected by ChangelogStore. On a store with no `replaceSubject`, or a
+ * non-transactional endpoint that refuses it, the fallback delete is scoped to EXACTLY
+ * `subject` in `graphUri`, so it never widens to touch a co-located subject (e.g. the lift
+ * queue's immutable request row).
+ *
+ * `source` is passed through per-queue (`publisher.asyncLift.writeJob` /
+ * `publisher.asyncPromote.writeJob`) so storage-side instrumentation still attributes the
+ * write to its originating queue.
+ */
+export async function replaceSubjectAtomicallyOrFallback(
+  store: TripleStore,
+  graphUri: string,
+  subject: string,
+  quads: Quad[],
+  source: string,
+): Promise<void> {
+  const replaced = await tryReplaceSubjectAtomically(store, graphUri, subject, quads, { source });
+  if (replaced) return;
+  await store.deleteByPattern({ subject, graph: graphUri });
+  await store.insert(quads);
+}

--- a/packages/publisher/test/subject-atomic-write.test.ts
+++ b/packages/publisher/test/subject-atomic-write.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #1938 — the shared atomic-replace/fallback writer both persistent publisher control-plane
+ * queues (async-lift #1863/#1919 and async-promote #1933) route their mutable-subject writes
+ * through. These tests pin the helper's ORCHESTRATION directly (independent of either queue):
+ *  - an atomic-capable store routes through `replaceSubject` (never a control-graph delete);
+ *  - a store with no `replaceSubject`, or one that refuses it, takes the BOUNDED
+ *    delete-then-insert fallback;
+ *  - the fallback delete is scoped to EXACTLY the target subject (never widens to a
+ *    co-located subject in the same graph — the invariant the lift queue's immutable request
+ *    row and the promote queue's single-subject write both depend on).
+ * Internal commit atomicity of `replaceSubject` is a storage-layer concern, proven there.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  OxigraphStore,
+  UnsupportedTripleStoreCapabilityError,
+  type Quad,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import { replaceSubjectAtomicallyOrFallback } from '../src/subject-atomic-write.js';
+
+const GRAPH = 'urn:test:subject-atomic-write';
+const SUBJECT = 'urn:test:subject-atomic-write:subject';
+const PRED = 'urn:test:subject-atomic-write:pred';
+
+function quad(subject: string, object: string, graph = GRAPH): Quad {
+  return { subject, predicate: PRED, object, graph };
+}
+
+async function objectsFor(store: OxigraphStore, subject: string): Promise<string[]> {
+  const result = await store.query(`SELECT ?o WHERE { GRAPH <${GRAPH}> { <${subject}> <${PRED}> ?o } }`);
+  return result.type === 'bindings' ? result.bindings.map((b) => b['o']!).sort() : [];
+}
+
+/**
+ * Wrap a real OxigraphStore, counting `replaceSubject` calls and control-graph
+ * `deleteByPattern` calls. `mode` selects the capability behaviour (mirrors the per-queue
+ * atomicity suites): `real` delegates to the real atomic replace; `absent` exposes no
+ * capability; `refuse` raises a clean capability refusal (SparqlHttpStore atomicUpdates:false).
+ */
+function countingStore(
+  inner: OxigraphStore,
+  mode: 'real' | 'absent' | 'refuse',
+): { store: TripleStore; counts: { replaceSubject: number; graphDeletes: number } } {
+  const counts = { replaceSubject: 0, graphDeletes: 0 };
+  type RealStore = {
+    replaceSubject: (g: string, s: string, q: unknown, o?: unknown) => Promise<void>;
+    deleteByPattern: (p: unknown, o?: unknown) => Promise<unknown>;
+  };
+  const store = new Proxy(inner, {
+    get(target, prop) {
+      if (prop === 'replaceSubject') {
+        if (mode === 'absent') return undefined;
+        return async (g: string, s: string, q: unknown, o?: unknown) => {
+          counts.replaceSubject++;
+          if (mode === 'refuse') {
+            throw new UnsupportedTripleStoreCapabilityError('replaceSubject', 'SparqlHttpStore');
+          }
+          return (target as unknown as RealStore).replaceSubject(g, s, q, o);
+        };
+      }
+      if (prop === 'deleteByPattern') {
+        return async (pattern: { graph?: string }, o?: unknown) => {
+          if (pattern?.graph === GRAPH) counts.graphDeletes++;
+          return (target as unknown as RealStore).deleteByPattern(pattern, o);
+        };
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  }) as unknown as TripleStore;
+  return { store, counts };
+}
+
+describe('#1938 replaceSubjectAtomicallyOrFallback', () => {
+  it('routes an atomic-capable store through replaceSubject, never a delete', async () => {
+    const inner = new OxigraphStore();
+    await inner.createGraph(GRAPH);
+    await inner.insert([quad(SUBJECT, '"old"')]);
+    const { store, counts } = countingStore(inner, 'real');
+
+    await replaceSubjectAtomicallyOrFallback(store, GRAPH, SUBJECT, [quad(SUBJECT, '"new"')], 'test.source');
+
+    expect(counts.replaceSubject).toBe(1);
+    expect(counts.graphDeletes).toBe(0);
+    // replaceSubject fully replaces the subject: the prior value is gone, the new one present.
+    expect(await objectsFor(inner, SUBJECT)).toEqual(['"new"']);
+  });
+
+  it('falls back to delete-then-insert when the store has no replaceSubject capability', async () => {
+    const inner = new OxigraphStore();
+    await inner.createGraph(GRAPH);
+    await inner.insert([quad(SUBJECT, '"old"')]);
+    const { store, counts } = countingStore(inner, 'absent');
+
+    await replaceSubjectAtomicallyOrFallback(store, GRAPH, SUBJECT, [quad(SUBJECT, '"new"')], 'test.source');
+
+    expect(counts.replaceSubject).toBe(0);
+    expect(counts.graphDeletes).toBeGreaterThan(0);
+    // The fallback still replaces: delete removes the old value, insert writes the new.
+    expect(await objectsFor(inner, SUBJECT)).toEqual(['"new"']);
+  });
+
+  it('falls back when the store implements replaceSubject but refuses it (non-atomic backend)', async () => {
+    const inner = new OxigraphStore();
+    await inner.createGraph(GRAPH);
+    const { store, counts } = countingStore(inner, 'refuse');
+
+    await replaceSubjectAtomicallyOrFallback(store, GRAPH, SUBJECT, [quad(SUBJECT, '"new"')], 'test.source');
+
+    // The capability was attempted (and refused), then the bounded fallback ran.
+    expect(counts.replaceSubject).toBe(1);
+    expect(counts.graphDeletes).toBeGreaterThan(0);
+    expect(await objectsFor(inner, SUBJECT)).toEqual(['"new"']);
+  });
+
+  it('the fallback delete is scoped to EXACTLY the target subject (a co-located subject survives)', async () => {
+    const sibling = 'urn:test:subject-atomic-write:sibling';
+    const inner = new OxigraphStore();
+    await inner.createGraph(GRAPH);
+    await inner.insert([quad(sibling, '"keep"'), quad(SUBJECT, '"old"')]);
+    const { store } = countingStore(inner, 'absent'); // force the fallback delete path
+
+    await replaceSubjectAtomicallyOrFallback(store, GRAPH, SUBJECT, [quad(SUBJECT, '"new"')], 'test.source');
+
+    expect(await objectsFor(inner, SUBJECT)).toEqual(['"new"']);
+    // The bounded fallback never widened to the sibling row.
+    expect(await objectsFor(inner, sibling)).toEqual(['"keep"']);
+  });
+});

--- a/packages/publisher/test/subject-atomic-write.test.ts
+++ b/packages/publisher/test/subject-atomic-write.test.ts
@@ -128,4 +128,52 @@ describe('#1938 replaceSubjectAtomicallyOrFallback', () => {
     // The bounded fallback never widened to the sibling row.
     expect(await objectsFor(inner, sibling)).toEqual(['"keep"']);
   });
+
+  // #1938 — the helper enforces the atomic path's single-subject contract on BOTH paths
+  // (assertSubjectReplacementPayload), so an out-of-contract payload throws BEFORE any
+  // deleteByPattern/insert — the fallback can never silently leak what the atomic path
+  // would reject. Each case runs in 'absent' mode (the fallback path): without the guard
+  // the delete+insert would run; with it, the throw pre-empts all store interaction.
+  it('rejects a multi-subject payload before any delete/insert (fallback path)', async () => {
+    const other = 'urn:test:subject-atomic-write:other';
+    const inner = new OxigraphStore();
+    await inner.createGraph(GRAPH);
+    const { store, counts } = countingStore(inner, 'absent');
+
+    await expect(
+      replaceSubjectAtomicallyOrFallback(store, GRAPH, SUBJECT, [quad(SUBJECT, '"a"'), quad(other, '"b"')], 'test.source'),
+    ).rejects.toThrow(/must target subject/);
+
+    expect(counts.graphDeletes).toBe(0);
+    expect(await objectsFor(inner, SUBJECT)).toEqual([]);
+    expect(await objectsFor(inner, other)).toEqual([]);
+  });
+
+  it('rejects a wrong-graph payload before any delete/insert (fallback path)', async () => {
+    const inner = new OxigraphStore();
+    await inner.createGraph(GRAPH);
+    const { store, counts } = countingStore(inner, 'absent');
+
+    await expect(
+      replaceSubjectAtomicallyOrFallback(store, GRAPH, SUBJECT, [quad(SUBJECT, '"a"', 'urn:test:other-graph')], 'test.source'),
+    ).rejects.toThrow(/must target subject/);
+
+    expect(counts.graphDeletes).toBe(0);
+    expect(await objectsFor(inner, SUBJECT)).toEqual([]);
+  });
+
+  it('rejects a blank-node payload before any delete/insert (parity with the atomic path)', async () => {
+    const inner = new OxigraphStore();
+    await inner.createGraph(GRAPH);
+    const { store, counts } = countingStore(inner, 'absent');
+
+    // subject/graph match, but a blank-node object — the atomic path rejects this, so the
+    // fallback must too (the asymmetry a subject/graph-only re-check would have left open).
+    await expect(
+      replaceSubjectAtomicallyOrFallback(store, GRAPH, SUBJECT, [{ subject: SUBJECT, predicate: PRED, object: '_:b0', graph: GRAPH }], 'test.source'),
+    ).rejects.toThrow(/blank node/);
+
+    expect(counts.graphDeletes).toBe(0);
+    expect(await objectsFor(inner, SUBJECT)).toEqual([]);
+  });
 });

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
       'test/async-promote-writejob-atomicity.test.ts',
+      'test/subject-atomic-write.test.ts',
       'test/async-lift-terminal-clear.test.ts',
       'test/async-promote-terminal-clear.test.ts',
       'test/lift-job-types.test.ts',

--- a/packages/storage/src/atomic-graph-replace.ts
+++ b/packages/storage/src/atomic-graph-replace.ts
@@ -173,7 +173,19 @@ function assertReplacementPayload(graphUri: string, quads: readonly Quad[]): voi
   }
 }
 
-function assertSubjectReplacementPayload(
+/**
+ * The strict single-subject payload contract shared by the atomic subject-replace
+ * primitive (`buildAtomicSubjectReplaceUpdate` → `tryReplaceSubjectAtomically` →
+ * `replaceSubject`) and `buildAtomicGraphAndSubjectReplaceUpdate`: `subject` must be a
+ * canonical skolem IRI (never a blank node), and every quad must target exactly that
+ * `subject` in `graphUri` and be blank-node free. Exported so a caller that reproduces
+ * the atomic-replace orchestration WITH a non-atomic fallback (the publisher's
+ * `replaceSubjectAtomicallyOrFallback`, #1938) can enforce the IDENTICAL contract on
+ * BOTH paths — a subject/graph-only re-check would leave the fallback laxer than the
+ * atomic path on blank nodes, the exact asymmetry that guard closes. Throws on the
+ * first violation; never mutates.
+ */
+export function assertSubjectReplacementPayload(
   graphUri: string,
   subject: string,
   quads: readonly Quad[],

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -25,6 +25,7 @@ export {
 } from './triple-store.js';
 export {
   ATOMIC_GRAPH_REPLACE_STAGING_PREFIX,
+  assertSubjectReplacementPayload,
   buildAtomicGraphAndSubjectReplaceUpdate,
   buildAtomicGraphReplaceUpdate,
   buildAtomicSubjectReplaceUpdate,


### PR DESCRIPTION
## Summary

- Both persistent publisher control-plane queues persisted a mutable job subject through the **same** orchestration: `tryReplaceSubjectAtomically(store, graphUri, subject, quads, { source })`, and — when the store has no `replaceSubject` or refuses it — a bounded, `subject`-scoped `deleteByPattern` + `insert` fallback. This is a shared publisher concern, not a per-queue one; duplicating it invited the two queues to drift on fallback behavior, `source` tagging, or instrumentation.
- Extract that block into one focused helper `replaceSubjectAtomicallyOrFallback(store, graphUri, subject, quads, source)` in a new shared module `packages/publisher/src/subject-atomic-write.ts` (owned by neither queue, mirroring the existing `terminal-job-clear.ts` / `job-id.ts` shared modules). Each queue keeps only its own record-shaping concern.
- **async-lift** `persistJobRecord`: the request-first pre-insert ordering is preserved verbatim (the immutable request rows are inserted *before* the helper replaces the mutable job subject); the helper covers only the job subject.
- **async-promote** `persistJobRecord`: a new `serializeJobRecord(job, graphUri)` wrapper (in `async-promote-queue-utils.ts`) runs the existing `assertPromoteJobRecordSingleSubject` fail-loud guard internally and returns `{ jobRef, jobQuads }`, then calls the shared helper — so the single-subject tripwire still fires on the write path.
- **Single-subject invariant now lives in the abstraction** (addressing review): the helper enforces the contract on **both** paths by calling the storage layer's own `assertSubjectReplacementPayload` up front — the exact assertion the atomic path already runs inside `buildAtomicSubjectReplaceUpdate`. Previously only the atomic path validated, so a co-located or blank-node quad would be rejected atomically but silently leaked by the fallback. To reuse the *identical* contract with zero drift (a subject/graph-only re-check would stay laxer than the atomic path on blank nodes), `assertSubjectReplacementPayload` is now exported from `@origintrail-official/dkg-storage`.
- **Scope:** this PR spans two packages — `dkg-storage` (one additive export of an existing validator) and `dkg-publisher` (the refactor). Behavior-preserving for both queues' current callers; no change to fallback scope, ordering, `source` values, journal append, or `flush`.

## Related

- Closes #1938.
- Follow-up to #1935 (#1933, async-promote `writeJob` atomicity) and #1919 (#1863, async-lift `writeJob` atomicity + the `tryReplaceSubjectAtomically` capability). Raised by otReviewAgent on #1935, which intentionally mirrored the proven #1919 pattern rather than refactoring both queues at once.

## Diagrams

- No flow changes (behavior-preserving refactor: the identical atomic-replace/fallback block is moved into one shared helper; call order, fallback scope, and `source` tags are unchanged. The added up-front assert only rejects payloads the atomic path already rejected — current callers are unaffected).

## Files changed

| File | What |
|------|------|
| `packages/storage/src/atomic-graph-replace.ts` | Export `assertSubjectReplacementPayload` (the shared single-subject-payload contract already backing `buildAtomicSubjectReplaceUpdate` / the graph+subject builder); added a docstring. Additive — no behavior change for existing consumers. |
| `packages/storage/src/index.ts` | Surface `assertSubjectReplacementPayload` from the package barrel. |
| `packages/publisher/src/subject-atomic-write.ts` | New shared helper `replaceSubjectAtomicallyOrFallback`; enforces the single-subject contract on both paths via `assertSubjectReplacementPayload`, then atomic-replace-or-bounded-fallback. |
| `packages/publisher/src/async-lift-publisher-impl.ts` | `persistJobRecord` calls the shared helper for the mutable job subject (request-first pre-insert ordering preserved); dropped the now-unused `tryReplaceSubjectAtomically` import; docblock updated. |
| `packages/publisher/src/async-promote-queue-impl.ts` | `persistJobRecord` uses the new `serializeJobRecord` wrapper + the shared helper; dropped the now-unused `tryReplaceSubjectAtomically` / `serializeJob` / `assertPromoteJobRecordSingleSubject` direct imports; docblock updated. |
| `packages/publisher/src/async-promote-queue-utils.ts` | Added `serializeJobRecord` (single-subject wrapper that runs `assertPromoteJobRecordSingleSubject` internally) + `SerializedPromoteJobRecord` type; guard docblock refreshed. |
| `packages/publisher/test/subject-atomic-write.test.ts` | New focused unit test for the helper: atomic-capable / no-capability / refused paths, bounded-delete-scope, plus multi-subject / wrong-graph / blank-node payloads each rejected before any delete/insert. |
| `packages/publisher/vitest.unit.config.ts` | Registered the new test file in the fixed unit include list. |

## Test plan

- [x] `pnpm exec vitest run --config vitest.unit.config.ts` from `packages/publisher` — **47 files / 554 tests passed**.
- [x] Both pinned atomicity suites green **unchanged**: `async-lift-writejob-atomicity.test.ts` (5) + `async-promote-writejob-atomicity.test.ts` (7), including the promote single-subject fail-loud guard test.
- [x] New `subject-atomic-write.test.ts` (7): routes atomic-capable through `replaceSubject` with no control-graph delete; falls back on absent capability; falls back on a refused capability; fallback delete scoped to EXACTLY the target subject (co-located sibling survives); and multi-subject / wrong-graph / blank-node payloads each throw **before** any `deleteByPattern`/`insert`.
- [x] `tsc --noEmit` clean for the publisher package; `dkg-storage` rebuilt via turbo (tsc clean, additive export only).
