### PR TITLE
fix(sync): prioritize user graphs over system discovery

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3536,21 +3536,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
       getSyncContextGraphs: () => this.config.syncContextGraphs ?? [],
       getSharedMemorySyncContextGraphs: async (peerId) => (await getSharedMemorySyncPlan(peerId)).eligibleContextGraphIds,
-      syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
+      syncFromPeer: (peerId, contextGraphIds, options) => this.syncFromPeerDetailed(
         peerId,
         contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...(this.config.syncContextGraphs ?? [])],
         undefined,
         undefined,
         undefined,
-        { stopOnBackoffWorthyFailure: true },
+        {
+          stopOnBackoffWorthyFailure: true,
+          priority: options?.priority,
+        },
       ),
       refreshMetaSyncedFlags: (contextGraphIds) => this.refreshMetaSyncedFlags(contextGraphIds),
       discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
-      syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, {
+      syncSharedMemoryFromPeer: async (peerId, contextGraphIds, options) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, {
         stopOnBackoffWorthyFailure: true,
         sharedMemorySyncPlan: await getSharedMemorySyncPlan(peerId),
+        priority: options?.priority,
       }),
       syncSharedMemoryOnConnect: syncOnConnectEnabled(this.config) && (this.config.syncSharedMemoryOnConnect ?? true),
+      isolateSystemContextGraphs: true,
       logInfo: (ctx, message) => this.log.info(ctx, message),
       onPeerSkippedNoSync: (peerId) => {
         this.skippedNoSyncPeers.add(peerId);

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -3,6 +3,7 @@ import {
   classifyDurableProgress,
   type DurableProgressSummary,
 } from '../durable-progress.js';
+import { FOREGROUND_CATCHUP_SYNC_PRIORITY } from '../catchup-policy.js';
 
 type SyncProgressSummary = DurableProgressSummary & { insertedTriples: number };
 
@@ -21,11 +22,26 @@ interface SyncOnConnectContext {
   knownCorePeerIdsV2?: Set<string>;
   getSyncContextGraphs: () => string[];
   getSharedMemorySyncContextGraphs?: (remotePeerId: string) => string[] | Promise<string[]>;
-  syncFromPeer: (peerId: string, contextGraphIds?: string[]) => Promise<SyncFromPeerResult>;
+  syncFromPeer: (
+    peerId: string,
+    contextGraphIds?: string[],
+    options?: { priority?: number },
+  ) => Promise<SyncFromPeerResult>;
   refreshMetaSyncedFlags: (contextGraphIds: Iterable<string>) => Promise<void>;
   discoverContextGraphsFromStore: () => Promise<number>;
-  syncSharedMemoryFromPeer: (peerId: string, contextGraphIds: string[]) => Promise<SyncFromPeerResult>;
+  syncSharedMemoryFromPeer: (
+    peerId: string,
+    contextGraphIds: string[],
+    options?: { priority?: number },
+  ) => Promise<SyncFromPeerResult>;
   syncSharedMemoryOnConnect?: boolean;
+  /**
+   * Run already-subscribed user graphs as foreground work before the large
+   * discovery/system graphs. System-graph pressure remains observable and is
+   * retried on the ordinary freshness interval, but cannot invalidate a clean
+   * user-graph round or block its shared-memory catch-up.
+   */
+  isolateSystemContextGraphs?: boolean;
   logInfo: (ctx: OperationContext, message: string) => void;
   /**
    * Optional. Called when the peer is reachable but does not currently
@@ -120,6 +136,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     discoverContextGraphsFromStore,
     syncSharedMemoryFromPeer,
     syncSharedMemoryOnConnect = true,
+    isolateSystemContextGraphs = false,
     logInfo,
   } = context;
 
@@ -219,6 +236,126 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       logInfo(ctx, `Peer ${shortPeer} does not support sync protocol (protocols: ${protocols.join(', ')})`);
       context.onPeerSkippedNoSync?.(remotePeer, protocols);
       return 'skipped-no-sync';
+    }
+
+    const configuredContextGraphIds = [...new Set(getSyncContextGraphs() ?? [])];
+    if (isolateSystemContextGraphs && configuredContextGraphIds.length > 0) {
+      logInfo(
+        ctx,
+        `Syncing ${configuredContextGraphIds.length} subscribed user CG(s) from ${shortPeer} before background system discovery`,
+      );
+      const userSynced = await syncFromPeer(
+        remotePeer,
+        configuredContextGraphIds,
+        { priority: FOREGROUND_CATCHUP_SYNC_PRIORITY },
+      );
+      const userAccounting = recordSyncAccounting(userSynced, 'durable');
+      logInfo(
+        ctx,
+        `Synced ${userAccounting.insertedTriples} subscribed-user data triples from peer ${shortPeer}`,
+      );
+      if (userAccounting.deferredByBackpressure) {
+        logInfo(ctx, `Stopping sync-on-connect user fanout for peer ${shortPeer} after local admission deferral`);
+        return finishSyncAccounting();
+      }
+      if (userAccounting.backoffWorthyFailure) {
+        logInfo(ctx, `Stopping sync-on-connect user fanout for peer ${shortPeer} after durable sync hit backoff-worthy pressure`);
+        return finishSyncAccounting();
+      }
+
+      await runNonTransportStep(() => refreshMetaSyncedFlags(configuredContextGraphIds));
+      durableSyncCompleted = true;
+
+      const wsContextGraphIds = getSharedMemorySyncContextGraphs
+        ? await runNonTransportStep(() => Promise.resolve(getSharedMemorySyncContextGraphs(remotePeer)))
+        : configuredContextGraphIds;
+      if (syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
+        const wsSynced = await syncSharedMemoryFromPeer(
+          remotePeer,
+          wsContextGraphIds,
+          { priority: FOREGROUND_CATCHUP_SYNC_PRIORITY },
+        );
+        const sharedAccounting = recordSyncAccounting(wsSynced, 'shared');
+        logInfo(ctx, `Synced ${sharedAccounting.insertedTriples} foreground shared memory triples from peer ${shortPeer}`);
+        if (sharedAccounting.deferredByBackpressure) {
+          logInfo(ctx, `Foreground shared-memory sync from peer ${shortPeer} deferred by local admission pressure`);
+          return finishSyncAccounting();
+        }
+        if (sharedAccounting.backoffWorthyFailure) {
+          logInfo(ctx, `Stopping sync-on-connect after foreground shared-memory pressure from peer ${shortPeer}`);
+          return finishSyncAccounting();
+        }
+      } else if (!syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
+        logInfo(ctx, `Skipping shared memory sync from peer ${shortPeer} (syncSharedMemoryOnConnect=false)`);
+      }
+
+      // System graphs are still maintained: they simply leave the critical
+      // user-CG path. Their failure is intentionally scope-local. A clean user
+      // round writes the ordinary peer freshness marker, so relay churn cannot
+      // immediately re-enqueue the same large AGENTS/ONTOLOGY work; the
+      // periodic reconciler retries it after the normal staleness interval.
+      const systemContextGraphIds = [
+        SYSTEM_CONTEXT_GRAPHS.AGENTS,
+        SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      ];
+      try {
+        logInfo(ctx, `Syncing system discovery graphs from peer ${shortPeer} in the background lane`);
+        const systemSynced = await syncFromPeer(remotePeer, systemContextGraphIds);
+        const systemComplete = typeof systemSynced !== 'number'
+          && 'complete' in systemSynced
+          && typeof systemSynced.complete === 'boolean'
+            ? systemSynced.complete
+            : undefined;
+        const systemAccounting = classifySyncResult(systemSynced, systemComplete);
+        logInfo(ctx, `Synced ${systemAccounting.insertedTriples} background system triples from peer ${shortPeer}`);
+        if (
+          systemComplete === false
+          || systemAccounting.failed
+          || systemAccounting.deferredByBackpressure
+          || systemAccounting.backoffWorthyFailure
+        ) {
+          logInfo(
+            ctx,
+            `Deferring system discovery from peer ${shortPeer} without invalidating the clean user-CG round`,
+          );
+          return finishSyncAccounting();
+        }
+
+        await refreshMetaSyncedFlags(systemContextGraphIds);
+        const knownCgsBeforeDiscovery = new Set(configuredContextGraphIds);
+        await discoverContextGraphsFromStore();
+        const newlyDiscovered = (getSyncContextGraphs() ?? [])
+          .filter((id) => !knownCgsBeforeDiscovery.has(id));
+        if (newlyDiscovered.length > 0) {
+          logInfo(ctx, `Discovered ${newlyDiscovered.length} new CG(s) — scheduling one background durable pass from ${shortPeer}`);
+          const discoveredSynced = await syncFromPeer(remotePeer, newlyDiscovered);
+          const discoveredComplete = typeof discoveredSynced !== 'number'
+            && 'complete' in discoveredSynced
+            && typeof discoveredSynced.complete === 'boolean'
+              ? discoveredSynced.complete
+              : undefined;
+          const discoveredAccounting = classifySyncResult(discoveredSynced, discoveredComplete);
+          logInfo(
+            ctx,
+            `Synced ${discoveredAccounting.insertedTriples} background triples for newly discovered CG(s) from ${shortPeer}`,
+          );
+          if (
+            discoveredComplete !== false
+            && !discoveredAccounting.failed
+            && !discoveredAccounting.deferredByBackpressure
+            && !discoveredAccounting.backoffWorthyFailure
+          ) {
+            await refreshMetaSyncedFlags(newlyDiscovered);
+          }
+        }
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        logInfo(
+          ctx,
+          `Background system discovery from peer ${shortPeer} failed without blocking subscribed user CGs: ${detail}`,
+        );
+      }
+      return finishSyncAccounting();
     }
 
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -140,7 +140,8 @@ describe('sync-on-connect churn gates', () => {
         priority: undefined,
       },
     ]);
-    expect(syncedPeers).toEqual([{ fresh: true, progress: true }]);
+    expect(syncedPeers).toHaveLength(1);
+    expect(syncedPeers[0]).toMatchObject({ fresh: true, progress: true });
   });
 
   it('does not let a system-graph transport failure invalidate a clean user-CG round', async () => {
@@ -174,7 +175,8 @@ describe('sync-on-connect churn gates', () => {
 
     expect(outcome).toBe('synced');
     expect(sharedRuns).toEqual([['current-user-cg']]);
-    expect(syncedPeers).toEqual([{ fresh: true, progress: true }]);
+    expect(syncedPeers).toHaveLength(1);
+    expect(syncedPeers[0]).toMatchObject({ fresh: true, progress: true });
   });
 
   it('dedupes repeated reconnect scheduling across a short relay flap', async () => {

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -3,7 +3,10 @@ import { PROTOCOL_SYNC, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent } from '../src/index.js';
 import { CATCHUP_ON_CONNECT_COOLDOWN_MS, SYNC_RECONNECT_FLAP_GRACE_MS } from '../src/dkg-agent-constants.js';
-import { runSyncOnConnect } from '../src/sync/on-connect/sync-on-connect.js';
+import {
+  runSyncOnConnect,
+  type SyncOnConnectPeerOutcome,
+} from '../src/sync/on-connect/sync-on-connect.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 
 const PEER_A = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
@@ -76,6 +79,102 @@ describe('sync-on-connect churn gates', () => {
       SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
       configuredGraph,
     ]);
+  });
+
+  it('finishes foreground user durable and shared sync before a pressured system-graph lane', async () => {
+    const calls: Array<{
+      lane: 'durable' | 'shared';
+      contextGraphIds: string[];
+      priority?: number;
+    }> = [];
+    const syncedPeers: SyncOnConnectPeerOutcome[] = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['current-user-cg'],
+      getSharedMemorySyncContextGraphs: () => ['current-user-cg'],
+      syncFromPeer: async (_peerId, contextGraphIds = [], options) => {
+        calls.push({ lane: 'durable', contextGraphIds, priority: options?.priority });
+        if (contextGraphIds.includes(SYSTEM_CONTEXT_GRAPHS.AGENTS)) {
+          return emptyDetailedSync({
+            timedOutPhases: 1,
+            backoffWorthyFailures: 1,
+          });
+        }
+        return emptyDetailedSync({ completedPhases: 1, checkpointAdvances: 1 });
+      },
+      refreshMetaSyncedFlags: async () => undefined,
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async (_peerId, contextGraphIds, options) => {
+        calls.push({ lane: 'shared', contextGraphIds, priority: options?.priority });
+        return emptyDetailedSync({ completedPhases: 1, checkpointAdvances: 1 });
+      },
+      isolateSystemContextGraphs: true,
+      logInfo: noopLog,
+      onPeerSynced: (_peerId, syncOutcome) => {
+        if (syncOutcome) syncedPeers.push(syncOutcome);
+      },
+    });
+
+    expect(outcome).toBe('synced');
+    expect(calls).toEqual([
+      {
+        lane: 'durable',
+        contextGraphIds: ['current-user-cg'],
+        priority: 2_000,
+      },
+      {
+        lane: 'shared',
+        contextGraphIds: ['current-user-cg'],
+        priority: 2_000,
+      },
+      {
+        lane: 'durable',
+        contextGraphIds: [
+          SYSTEM_CONTEXT_GRAPHS.AGENTS,
+          SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+        ],
+        priority: undefined,
+      },
+    ]);
+    expect(syncedPeers).toEqual([{ fresh: true, progress: true }]);
+  });
+
+  it('does not let a system-graph transport failure invalidate a clean user-CG round', async () => {
+    const sharedRuns: string[][] = [];
+    const syncedPeers: SyncOnConnectPeerOutcome[] = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['current-user-cg'],
+      syncFromPeer: async (_peerId, contextGraphIds = []) => {
+        if (contextGraphIds.includes(SYSTEM_CONTEXT_GRAPHS.AGENTS)) {
+          throw new Error('system responder timed out');
+        }
+        return emptyDetailedSync({ completedPhases: 1, checkpointAdvances: 1 });
+      },
+      refreshMetaSyncedFlags: async () => undefined,
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async (_peerId, contextGraphIds) => {
+        sharedRuns.push(contextGraphIds);
+        return emptyDetailedSync({ completedPhases: 1, checkpointAdvances: 1 });
+      },
+      isolateSystemContextGraphs: true,
+      logInfo: noopLog,
+      onPeerSynced: (_peerId, syncOutcome) => {
+        if (syncOutcome) syncedPeers.push(syncOutcome);
+      },
+    });
+
+    expect(outcome).toBe('synced');
+    expect(sharedRuns).toEqual([['current-user-cg']]);
+    expect(syncedPeers).toEqual([{ fresh: true, progress: true }]);
   });
 
   it('dedupes repeated reconnect scheduling across a short relay flap', async () => {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -1,6 +1,7 @@
 import type { Stream } from '@libp2p/interface';
 import type { StreamHandler as DKGStreamHandler } from './types.js';
 import type { DKGNode } from './node.js';
+import { isPublicLikeAddress } from './node.js';
 import type { PeerResolver } from './network/peer-resolver.js';
 import {
   MessageStreamPool,
@@ -908,19 +909,28 @@ export class ProtocolRouter {
           protocolId,
           attemptSignal,
           {
-            // Probe peerStore for non-circuit (direct) addresses; the
+            // Probe peerStore for remotely usable non-circuit (direct)
+            // addresses; the
             // fast path uses this to gate whether reusing a LIMITED
             // (circuit-relay-v2) connection is safe or whether
             // libp2p's CM is about to auto-upgrade and prune it
             // mid-stream. See the JSDoc inside
             // `tryReuseExistingConnection` + the PR #537 CI
             // postmortem for the DCUtR upgrade race detail.
+            //
+            // A peerStore record can also contain the remote peer's
+            // loopback/LAN/CGNAT listen addresses. Those are not viable
+            // upgrade targets from this node and must not suppress reuse of
+            // the only healthy relay circuit. The profile publisher already
+            // uses the same public-address classifier to avoid advertising
+            // these addresses in the first place; applying it here also
+            // handles stale and identify-learned peerStore records.
             peerHasDirectAddrs: async (): Promise<boolean> => {
               const peer = await libp2p.peerStore.get(peerId);
               const addrs = peer.addresses ?? [];
               for (const a of addrs) {
                 const ma = a.multiaddr?.toString?.() ?? '';
-                if (ma && !ma.includes('/p2p-circuit')) return true;
+                if (ma && !ma.includes('/p2p-circuit') && isPublicLikeAddress(ma)) return true;
               }
               return false;
             },

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -1502,6 +1502,40 @@ describe('ProtocolRouter', () => {
       expect(dialCalls).toBe(0);
     });
 
+    it('uses a limited candidate when peerStore direct addresses are loopback or private', async () => {
+      let limitedUsed = 0;
+      let dialCalls = 0;
+      const router = makeRouterWithFastPath({
+        connections: [
+          {
+            status: 'open',
+            limits: { bytes: 1024 * 1024 },
+            newStream: async () => {
+              limitedUsed += 1;
+              return makeStubStream(new Uint8Array([0x89])) as any;
+            },
+          },
+        ],
+        peerStoreGet: async () => ({
+          addresses: [
+            { multiaddr: { toString: () => '/ip4/127.0.0.1/tcp/4001' } },
+            { multiaddr: { toString: () => '/ip4/192.168.1.60/tcp/4001' } },
+            { multiaddr: { toString: () => '/ip4/100.99.142.87/tcp/4001' } },
+            { multiaddr: { toString: () => '/ip6/fd00::1/tcp/4001' } },
+          ],
+        }),
+        dialBehavior: async () => {
+          dialCalls += 1;
+          throw new Error('dialProtocol must not be called for unusable direct addresses');
+        },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, '/dkg/test/1.0.0', new Uint8Array([1]));
+      expect(out).toEqual(new Uint8Array([0x89]));
+      expect(limitedUsed).toBe(1);
+      expect(dialCalls).toBe(0);
+    });
+
     it('skips connections whose status is not "open"', async () => {
       let openCalls = 0;
       let closedCalls = 0;


### PR DESCRIPTION
## Summary
- reuse healthy relay circuits when peerStore only contains loopback, LAN, CGNAT, or ULA direct addresses
- run subscribed user durable and SWM catch-up at foreground priority before agents/ontology discovery
- keep agents and ontology maintained in a background lane without letting their pressure invalidate a clean user-CG round

## Evidence
- `@origintrail-official/dkg-agent` build, type tests, and package-root checks pass
- full agent unit lane: 139 files, 1790 passed, 5 skipped
- sync-on-connect focused lane: 70 passed
- protocol-router focused lane: 65 passed

## Live gate
Draft until the same commit passes the two-node dirty-receiver canary with preserved stores and subscriptions.