### PR TITLE
fix(network): use configured relays for cold-peer first contact

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1142,6 +1142,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const peerResolver = new PeerResolver({
       network,
       registry: new StubNetworkStateRegistry(),
+      configuredRelayPeers: this.config.relayPeers,
       agentDirectory: {
         // Wraps DiscoveryClient.findAgentByPeerId in the resolver's
         // minimal AgentDirectoryLookup shape so packages/core doesn't
@@ -6025,7 +6026,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   async ensurePeerConnected(this: DKGAgent, peerId: string): Promise<void> {
-    await ensurePeerConnectedAtom(this.node.libp2p as any, this.discovery, peerId);
+    await ensurePeerConnectedAtom(
+      this.node.libp2p as any,
+      this.discovery,
+      peerId,
+      this.config.relayPeers,
+    );
     if (await this.networkAdmissionCoordinator.ensureAdmitted(peerId, createOperationContext('connect'))) return;
     throw new NetworkAdmissionRejectedError(peerId);
   }

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -93,6 +93,7 @@ import {
   type SubscriptionSource,
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
+  isPublicLikeAddress,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, PcaUnavailableError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type NodePublishingConvictionAccount, type PcaAccountRelation, type ShardingTableNode, type PcaContracts, type PcaRpcMethod } from '@origintrail-official/dkg-chain';
@@ -153,6 +154,7 @@ import {
 import {
   MultiaddrPeerTargetParseError,
   parseExplicitConnectTarget as parseMultiaddrExplicitConnectTarget,
+  parseMultiaddrConnectTarget,
 } from './p2p/multiaddr-peer-target.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
 import {
@@ -1998,11 +2000,43 @@ export class AgentRegistryMethods extends DKGAgentBase {
     }
     this.log.info(ctx, `Resolved ${peerIdStr} → ${addrs.length} addr(s); dialling...`);
 
-    // peerStore is already primed by the resolver. dial(peerId) finds
-    // the addresses there and goes — same AbortSignal so the overall
-    // budget is honoured end-to-end.
+    // Prefer explicit circuits for a relayed-only target. libp2p's bare
+    // peer-id dial can collapse several circuit candidates to one stale
+    // address; walking the resolver's ordered candidates preserves the
+    // configured-relay fallback proved by the live RFC-64 cold-edge test.
+    const hasPublicDirect = addrs.some(
+      (addr) => !addr.includes('/p2p-circuit') && isPublicLikeAddress(addr),
+    );
+    const circuitAddrs = addrs.filter((addr) => addr.includes('/p2p-circuit'));
+    let connectedViaExplicitCircuit = false;
+    let lastCircuitError: unknown;
+    if (!hasPublicDirect) {
+      for (const circuitAddr of circuitAddrs) {
+        if (signal.aborted) break;
+        try {
+          const target = parseMultiaddrConnectTarget(circuitAddr);
+          if (target.targetPeerId !== peerIdStr) continue;
+          await connectToMultiaddr(
+            this.node.libp2p as any,
+            target,
+            (message) => this.log.info(ctx, message),
+            { signal },
+          );
+          connectedViaExplicitCircuit = true;
+          break;
+        } catch (err) {
+          lastCircuitError = err;
+        }
+      }
+    }
+
+    // peerStore is already primed by the resolver. Keep the legacy bare
+    // peer-id dial for public-direct targets and as a final fallback if every
+    // explicit circuit failed. The same AbortSignal bounds the full attempt.
     try {
-      await this.node.libp2p.dial(peerId, { signal });
+      if (!connectedViaExplicitCircuit) {
+        await this.node.libp2p.dial(peerId, { signal });
+      }
     } catch (err: any) {
       // Codex PR #499 round 5 (dkg-agent.ts:4096): the shared signal
       // covers BOTH resolution and dial. If most of the budget went
@@ -2029,7 +2063,10 @@ export class AgentRegistryMethods extends DKGAgentBase {
         (error as any).code = 'CONNECT_TIMEOUT';
         throw error;
       }
-      const error = new Error(`DIAL_FAILED: ${err?.message ?? String(err)}`);
+      const finalDialError = lastCircuitError ?? err;
+      const error = new Error(
+        `DIAL_FAILED: ${finalDialError instanceof Error ? finalDialError.message : String(finalDialError)}`,
+      );
       (error as any).code = 'DIAL_FAILED';
       throw error;
     }

--- a/packages/agent/src/p2p/peer-connect.ts
+++ b/packages/agent/src/p2p/peer-connect.ts
@@ -5,7 +5,7 @@ import {
 
 interface Libp2pLike {
   getConnections(): Array<{ remotePeer: { toString(): string } }>;
-  dial(peer: unknown): Promise<unknown>;
+  dial(peer: unknown, options?: { signal?: AbortSignal }): Promise<unknown>;
   peerStore: {
     merge(peer: unknown, update: { multiaddrs: unknown[] }): Promise<void>;
   };
@@ -13,15 +13,28 @@ interface Libp2pLike {
 
 const CONNECT_WAIT_TIMEOUT_MS = 5000;
 const CONNECT_WAIT_INTERVAL_MS = 100;
+const MAX_CONFIGURED_RELAY_FALLBACKS = 4;
 const DEBUG_SYNC_TRACE = process.env.DKG_DEBUG_SYNC_PROGRESS === '1' || process.env.DKG_DEBUG_SYNC === '1';
+
+function dialWithOptionalSignal(
+  libp2p: Libp2pLike,
+  target: unknown,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  return signal
+    ? libp2p.dial(target, { signal })
+    : libp2p.dial(target);
+}
 
 async function waitForPeerConnection(
   libp2p: Libp2pLike,
   peerId: string,
   timeoutMs = CONNECT_WAIT_TIMEOUT_MS,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
+    if (signal?.aborted) return false;
     const connected = libp2p.getConnections().some((conn) => conn.remotePeer.toString() === peerId);
     if (connected) {
       return true;
@@ -35,6 +48,7 @@ export async function connectToMultiaddr(
   libp2p: Libp2pLike,
   connectTarget: MultiaddrConnectTarget,
   log?: (message: string) => void,
+  options?: { signal?: AbortSignal },
 ): Promise<void> {
   const debugLog = DEBUG_SYNC_TRACE ? log : undefined;
   const { multiaddr } = await import('@multiformats/multiaddr');
@@ -43,9 +57,18 @@ export async function connectToMultiaddr(
   if (connectTarget.kind === 'direct') {
     debugLog?.(`Dialing direct invite multiaddr: ${multiaddress}`);
     const directTargetPeerId = connectTarget.targetPeerId;
-    await libp2p.dial(multiaddr(multiaddress));
+    await dialWithOptionalSignal(
+      libp2p,
+      multiaddr(multiaddress),
+      options?.signal,
+    );
     if (directTargetPeerId) {
-      const connected = await waitForPeerConnection(libp2p, directTargetPeerId);
+      const connected = await waitForPeerConnection(
+        libp2p,
+        directTargetPeerId,
+        CONNECT_WAIT_TIMEOUT_MS,
+        options?.signal,
+      );
       debugLog?.(`Direct invite connection ${connected ? 'confirmed' : 'not observed before timeout'} for peer ${directTargetPeerId}`);
       if (!connected) {
         throw new Error(`Direct target peer ${directTargetPeerId} not observed before timeout`);
@@ -57,15 +80,24 @@ export async function connectToMultiaddr(
   const { relayMultiaddress, targetPeerId } = connectTarget;
 
   debugLog?.(`Dialing relay from circuit invite: relay=${relayMultiaddress} targetPeer=${targetPeerId}`);
-  await libp2p.dial(multiaddr(relayMultiaddress));
+  await dialWithOptionalSignal(
+    libp2p,
+    multiaddr(relayMultiaddress),
+    options?.signal,
+  );
 
   const { peerIdFromString } = await import('@libp2p/peer-id');
   const targetPid = peerIdFromString(targetPeerId);
   debugLog?.(`Merging circuit target multiaddr into peerStore: targetPeer=${targetPeerId}`);
   await libp2p.peerStore.merge(targetPid, { multiaddrs: [multiaddr(multiaddress)] });
   debugLog?.(`Dialing final circuit target peer: ${targetPeerId}`);
-  await libp2p.dial(targetPid);
-  const connected = await waitForPeerConnection(libp2p, targetPeerId);
+  await dialWithOptionalSignal(libp2p, targetPid, options?.signal);
+  const connected = await waitForPeerConnection(
+    libp2p,
+    targetPeerId,
+    CONNECT_WAIT_TIMEOUT_MS,
+    options?.signal,
+  );
   debugLog?.(`Circuit target connection ${connected ? 'confirmed' : 'not observed before timeout'} for peer ${targetPeerId}`);
   if (!connected) {
     throw new Error(`Circuit target peer ${targetPeerId} not observed before timeout`);
@@ -76,6 +108,7 @@ export async function ensurePeerConnected(
   libp2p: Libp2pLike,
   discovery: DiscoveryClient,
   peerId: string,
+  configuredRelayPeers: readonly string[] = [],
 ): Promise<void> {
   const existingConnections = libp2p.getConnections()
     .filter((conn) => conn.remotePeer.toString() === peerId);
@@ -91,13 +124,43 @@ export async function ensurePeerConnected(
       await libp2p.dial(pid);
       return;
     } catch {
-      const agent = await discovery.findAgentByPeerId(peerId);
-      if (!agent?.relayAddress) return;
-
       const { multiaddr } = await import('@multiformats/multiaddr');
-      const circuitAddr = multiaddr(`${agent.relayAddress}/p2p-circuit/p2p/${peerId}`);
-      await libp2p.peerStore.merge(pid, { multiaddrs: [circuitAddr] });
-      await libp2p.dial(pid);
+      const relayCandidates: string[] = [];
+      relayCandidates.push(
+        ...configuredRelayPeers.slice(0, MAX_CONFIGURED_RELAY_FALLBACKS),
+      );
+      try {
+        const agent = await discovery.findAgentByPeerId(peerId);
+        if (agent?.relayAddress) relayCandidates.push(agent.relayAddress);
+      } catch {
+        // A missing or overloaded agents-CG must not suppress the
+        // operator-configured relay fallback below.
+      }
+      const seen = new Set<string>();
+      for (const rawRelay of relayCandidates) {
+        const relay = rawRelay.replace(/\/+$/, '');
+        if (
+          seen.has(relay) ||
+          relay.includes('/p2p-circuit') ||
+          !/\/p2p\/[^/]+$/.test(relay)
+        ) {
+          continue;
+        }
+        seen.add(relay);
+        try {
+          const circuitAddr = multiaddr(`${relay}/p2p-circuit/p2p/${peerId}`);
+          await libp2p.peerStore.merge(pid, { multiaddrs: [circuitAddr] });
+          await libp2p.dial(multiaddr(relay), {
+            signal: AbortSignal.timeout(CONNECT_WAIT_TIMEOUT_MS),
+          });
+          await libp2p.dial(pid, {
+            signal: AbortSignal.timeout(CONNECT_WAIT_TIMEOUT_MS),
+          });
+          return;
+        } catch {
+          // Try the next bounded operator-configured relay.
+        }
+      }
     }
   } catch {
     // Non-fatal — peer may be unreachable.

--- a/packages/agent/test/explicit-connect-admission.test.ts
+++ b/packages/agent/test/explicit-connect-admission.test.ts
@@ -18,6 +18,9 @@ const PEER_ID_CID = peerIdFromString(PEER_ID).toCID().toString();
 const SELF_PEER_ID = '12D3KooWDCuLesNUYHGEUY5ksEsfJGbShbZ9ep2Pu7uqCNGvgwnb';
 const DIRECT_MULTIADDR = `/ip4/127.0.0.1/tcp/9090/p2p/${PEER_ID}`;
 const DIRECT_MULTIADDR_CID = `/ip4/127.0.0.1/tcp/9090/p2p/${PEER_ID_CID}`;
+const RELAY_MULTIADDR =
+  '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+const CIRCUIT_MULTIADDR = `${RELAY_MULTIADDR}/p2p-circuit/p2p/${PEER_ID}`;
 
 function makeAgent(overrides: Record<string, unknown> = {}): any {
   const agent: any = {
@@ -180,5 +183,33 @@ describe('explicit connect network admission', () => {
       expect.objectContaining({ operationName: 'connect' }),
       expect.stringContaining('Already connected'),
     );
+  });
+
+  it('walks an explicit resolver circuit when the target has no public direct address', async () => {
+    const agent = makeAgent({
+      peerResolver: {
+        resolve: vi.fn(async () => [
+          DIRECT_MULTIADDR,
+          CIRCUIT_MULTIADDR,
+        ]),
+      },
+      networkAdmissionCoordinator: admittedCoordinator(PEER_ID),
+    });
+
+    await expect(
+      AgentRegistryMethods.prototype.connectToPeerId.call(agent, PEER_ID, { timeoutMs: 5_000 }),
+    ).resolves.toBeUndefined();
+
+    expect(peerConnectMocks.connectToMultiaddr).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        kind: 'circuit',
+        multiaddress: CIRCUIT_MULTIADDR,
+        targetPeerId: PEER_ID,
+      }),
+      expect.any(Function),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(agent.node.libp2p.dial).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/test/p2p-peer-connect.test.ts
+++ b/packages/agent/test/p2p-peer-connect.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { parseMultiaddrConnectTarget } from '../src/p2p/multiaddr-peer-target.js';
-import { connectToMultiaddr, primeCatchupConnections } from '../src/p2p/peer-connect.js';
+import {
+  connectToMultiaddr,
+  ensurePeerConnected,
+  primeCatchupConnections,
+} from '../src/p2p/peer-connect.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -126,5 +130,63 @@ describe('primeCatchupConnections', () => {
     expect(merge.calls).toHaveLength(2);
     expect(dial.calls).toHaveLength(2);
     expect(admissionCalls).toEqual([foreignPeer, eligiblePeer]);
+  });
+});
+
+describe('ensurePeerConnected', () => {
+  it('falls back to operator-configured relays when discovery has no target profile', async () => {
+    const relayAddress = '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+    const targetPeerId = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+    const dial = recorder(async (target: any) => {
+      if (target.toString() === targetPeerId && dial.calls.length === 1) {
+        throw new Error('private DHT addresses are unreachable');
+      }
+      return undefined;
+    });
+    const merge = recorder(async () => undefined);
+
+    await ensurePeerConnected({
+      getConnections: () => [],
+      dial,
+      peerStore: { merge },
+    }, {
+      findAgentByPeerId: async () => null,
+    } as any, targetPeerId, [relayAddress]);
+
+    expect(dial.calls.map(([target]) => target.toString())).toEqual([
+      targetPeerId,
+      relayAddress,
+      targetPeerId,
+    ]);
+    expect(merge.calls[0]?.[1].multiaddrs.map((addr) => addr.toString())).toEqual([
+      `${relayAddress}/p2p-circuit/p2p/${targetPeerId}`,
+    ]);
+  });
+
+  it('continues to configured relays when agent-directory lookup throws', async () => {
+    const relayAddress = '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+    const targetPeerId = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+    const dial = recorder(async (target: any) => {
+      if (target.toString() === targetPeerId && dial.calls.length === 1) {
+        throw new Error('no known usable route');
+      }
+      return undefined;
+    });
+
+    await ensurePeerConnected({
+      getConnections: () => [],
+      dial,
+      peerStore: { merge: async () => undefined },
+    }, {
+      findAgentByPeerId: async () => {
+        throw new Error('agents store overloaded');
+      },
+    } as any, targetPeerId, [relayAddress]);
+
+    expect(dial.calls.map(([target]) => target.toString())).toEqual([
+      targetPeerId,
+      relayAddress,
+      targetPeerId,
+    ]);
   });
 });

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -13,6 +13,8 @@
  *      Stub in v1; populated when RFC 04 Phase 2 lands.
  *   4. Agent directory (agents-CG SPARQL) — preserves the chat-only
  *      `Messenger.ensureCircuitRelayAddress` behaviour we're replacing.
+ *   5. Operator-configured relay circuits — only when steps 2-4 yielded
+ *      no remotely viable direct address for the target.
  *
  * Each step that finds addresses calls `network.addKnownAddresses` so
  * a subsequent `dialProtocol(peerId)` hits the transport's address
@@ -32,6 +34,12 @@
  * peerDiscovery in `node.ts`), not a per-peer resolution concern;
  * step 5 has been removed.
  *
+ * The operator-configured relay fallback added later is intentionally
+ * different: `relayPeers` identifies relays on which this local edge already
+ * seeks reservations. Appending `/p2p-circuit/p2p/<target>` constructs a route
+ * to the requested target (when it has a reservation there); it never returns
+ * the relay itself as though it were the target peer.
+ *
  * v1 implements `recordDialSuccess` / `recordDialFailure` /
  * `isHealthy` as stubs; address-health scoring is deferred to a
  * follow-up RFC.
@@ -40,6 +48,7 @@
  */
 import type { Network, NodeIdentity, Address } from './network.js';
 import type { NetworkStateRegistry } from './network-state-registry.js';
+import { isPublicLikeAddress } from '../node.js';
 
 /**
  * Minimal interface PeerResolver needs from the agents-CG. Defined in
@@ -120,6 +129,14 @@ export interface PeerResolverDeps {
   network: Network;
   registry: NetworkStateRegistry;
   agentDirectory: AgentDirectoryLookup;
+  /**
+   * Public relay multiaddrs already trusted by the local operator config.
+   * When every direct address discovered for a target is private/non-routable,
+   * the resolver synthesizes bounded circuit candidates through these relays.
+   * Any agent-directory circuit is retained but does not suppress this
+   * fallback because it can be stale or belong to another network.
+   */
+  configuredRelayPeers?: Address[];
   /** Optional logger; defaults to silent except for serious errors. */
   logger?: PeerResolverLogger;
   /**
@@ -170,6 +187,7 @@ export interface ResolveOpts {
 
 const DEFAULT_PER_STEP_TIMEOUT_MS = 5_000;
 const DEFAULT_AGENT_DIRECTORY_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+const MAX_CONFIGURED_RELAY_FALLBACKS = 4;
 /**
  * Maximum acceptable clock-skew between this node and an agent
  * publishing its `dkg:lastSeen`. Anything more than this far in the
@@ -190,6 +208,7 @@ export class PeerResolver {
   private readonly network: Network;
   private readonly registry: NetworkStateRegistry;
   private readonly agentDirectory: AgentDirectoryLookup;
+  private readonly configuredRelayPeers: Address[];
   private readonly logger: PeerResolverLogger;
   private readonly defaultPerStepTimeoutMs: number;
   private readonly agentDirectoryStaleThresholdMs: number;
@@ -198,6 +217,7 @@ export class PeerResolver {
     this.network = deps.network;
     this.registry = deps.registry;
     this.agentDirectory = deps.agentDirectory;
+    this.configuredRelayPeers = deps.configuredRelayPeers ?? [];
     this.logger = deps.logger ?? SILENT_LOGGER;
     const override = deps.defaultPerStepTimeoutMs;
     this.defaultPerStepTimeoutMs =
@@ -424,6 +444,50 @@ export class PeerResolver {
       }
     } catch (err) {
       this.logger.debug?.(`agents-CG lookup for ${peerId} failed: ${errMsg(err)}`);
+    }
+
+    // Step 5: operator-configured relay fallback. A cold edge can be present
+    // in the DHT while advertising only loopback/LAN/CGNAT addresses, and it
+    // may not yet have a usable agents-CG phonebook row. Returning those
+    // private addresses as "resolved" strands first-contact sync even when
+    // both peers hold reservations on the same public relays. Likewise, an
+    // agents-CG circuit may point at a stale or wrong-network relay, so its
+    // presence alone is not enough to suppress locally trusted fallbacks.
+    //
+    // Only synthesize fallback circuits when no remotely viable DIRECT address
+    // was found above. This keeps the normal public-node path unchanged and
+    // bounds the relayed-target fallback to four operator-trusted relays.
+    if (
+      !aborted() &&
+      !accumulated.some(
+        (addr) => !addr.includes('/p2p-circuit') && isPublicLikeAddress(addr),
+      )
+    ) {
+      const fallbackCircuits: Address[] = [];
+      for (const rawRelay of this.configuredRelayPeers) {
+        if (fallbackCircuits.length >= MAX_CONFIGURED_RELAY_FALLBACKS) break;
+        const relay = rawRelay.replace(/\/+$/, '');
+        if (
+          relay.includes('/p2p-circuit') ||
+          !isPublicLikeAddress(relay)
+        ) {
+          continue;
+        }
+        const relayPeerId = relay.match(/\/p2p\/([^/]+)$/)?.[1];
+        if (!relayPeerId || relayPeerId === peerId) continue;
+        fallbackCircuits.push(`${relay}/p2p-circuit/p2p/${peerId}`);
+      }
+      await primeAndAppend(fallbackCircuits, 'configured-relay fallback');
+      const configuredSet = new Set(fallbackCircuits);
+      const configuredFirst = accumulated.filter((addr) => configuredSet.has(addr));
+      if (configuredFirst.length > 0) {
+        accumulated.splice(
+          0,
+          accumulated.length,
+          ...configuredFirst,
+          ...accumulated.filter((addr) => !configuredSet.has(addr)),
+        );
+      }
     }
 
     return accumulated;

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -200,6 +200,60 @@ describe('PeerResolver', () => {
     expect(out).toEqual([]);
   });
 
+  it('step 5: uses configured relay circuits when DHT only returns private addresses', async () => {
+    net.__findPeerImpl = async () => [
+      `/ip4/127.0.0.1/tcp/9090/p2p/${PEER_B}`,
+      `/ip4/192.168.0.20/tcp/9090/p2p/${PEER_B}`,
+      `/ip4/100.105.212.110/tcp/9090/p2p/${PEER_B}`,
+    ];
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(async () => null),
+      configuredRelayPeers: [RELAY_ADDR],
+    });
+
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toContain(`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`);
+    expect(net.__addedAddresses).toContainEqual({
+      peerId: PEER_B,
+      addrs: [`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`],
+    });
+  });
+
+  it('step 5: does not add configured relay circuits when a public direct route exists', async () => {
+    const publicDirect = `/ip4/178.105.87.39/tcp/9090/p2p/${PEER_B}`;
+    net.__findPeerImpl = async () => [publicDirect];
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(async () => null),
+      configuredRelayPeers: [RELAY_ADDR],
+    });
+
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual([publicDirect]);
+  });
+
+  it('step 5: keeps a directory circuit but also adds configured relays for a relayed-only target', async () => {
+    const staleRelay =
+      '/ip4/178.104.98.10/tcp/9090/p2p/12D3KooWFWm8sg6dkitmdBd5Uxaqp3CDRL27mFcM7vEHK92Xapyy';
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(async () => staleRelay),
+      configuredRelayPeers: [RELAY_ADDR],
+    });
+
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toContain(`${staleRelay}/p2p-circuit/p2p/${PEER_B}`);
+    expect(out).toContain(`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`);
+    expect(out[0]).toBe(`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`);
+  });
+
   it('step 4: agents-CG throwing does not abort resolution', async () => {
     net.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
     const resolver = new PeerResolver({


### PR DESCRIPTION
## Problem

A cold edge can discover a target peer through the DHT but receive only loopback, LAN, or CGNAT addresses. The agents-CG can also advertise a stale relay from another network. In that state, bare peer-id dialing can collapse multiple circuit candidates onto the stale route even though both nodes have reservations on shared public relays.

## Fix

- pass operator-configured relay peers into `PeerResolver` and sync connection helpers
- synthesize at most four target circuits when no public direct route exists
- retain directory routes but prioritize locally configured public relays
- explicitly walk ordered circuit candidates for relayed-only peer-id connects
- preserve the existing network-identity admission boundary after dialing
- preserve legacy one-argument dial call shapes when no abort signal is supplied

## Live testnet evidence

From a fresh isolated testnet edge with no CG subscription or target multiaddress:

- input: publisher peer ID only
- transport: public DKG relay, no Tailscale
- connection: succeeded in 2.224 seconds through configured relay `...Gq6hB57M`
- target: `12D3KooWNBE8KjvhrwgYHqXqoLiSk7cHz2KkhuAyhdHjwCibhzeA`
- network identity admission: passed
- subsequent native catch-up reached the publisher; scheduling/completeness remains independently covered by #1946

## Verification

- core focused resolver tests: 33 passed
- agent focused connection/admission tests: 15 passed
- full core unit lane: 103 files, 1,577 tests passed
- full agent unit lane: 139 files, 1,789 passed, 5 skipped
- agent build: TypeScript, type tests, and package-root test passed
- live fresh-process first-contact gate passed

This PR intentionally does not include the user-first sync scheduling change in #1946 and should be reviewed and promoted independently.