### PR TITLE
fix(chain): preserve confirmed publishes when timestamp RPCs exhaust

### DIFF
--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -28,7 +28,7 @@ import { loadAbi } from './evm-adapter-abi.js';
 import { errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, getPcaLogicInterface, HUB_STALE_ERROR_MARKERS, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
 import { resolveRpcUrls, boundedRetryFetchRequest, withTimeout, isRetryableRpcError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
 import { rpcHost } from './rpc-failover-log.js';
-import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
+import { ChainRpcTransportError, isChainRpcTransportError } from './chain-rpc-transport-error.js';
 import { RpcFailoverClient, type ReadOpts, type ReceiptLookupOptions } from './rpc-failover-client.js';
 import { waitForReceiptWithDeadline } from './receipt-wait.js';
 import { RpcUsageTracker, createCountingJsonRpcProvider, type RpcUsageWindow } from './rpc-usage.js';
@@ -53,6 +53,37 @@ type ContractWriteSender = (
 type SerializedSignerWriteContext = {
   sendContractTransaction: ContractWriteSender;
 };
+
+/**
+ * A successful receipt is authoritative for transaction inclusion. Fetching
+ * its block timestamp is enrichment only and must not turn an already-mined
+ * write into a failed publish when every RPC endpoint is temporarily
+ * throttled or unavailable.
+ *
+ * Deterministic and non-transport failures still propagate so malformed block
+ * references and programmer errors are never hidden.
+ */
+export async function resolveConfirmedReceiptBlockTimestamp(
+  receipt: Pick<ethers.TransactionReceipt, 'hash' | 'blockNumber'>,
+  readTimestamp: () => Promise<number>,
+): Promise<number> {
+  try {
+    return await readTimestamp();
+  } catch (error) {
+    if (
+      !isChainRpcTransportError(error)
+      || error.code !== 'RPC_ENDPOINTS_EXHAUSTED'
+    ) {
+      throw error;
+    }
+    console.warn(
+      `[chain] Transaction ${receipt.hash} is confirmed in block ${receipt.blockNumber}, ` +
+      `but its timestamp is temporarily unavailable (${error.code}); ` +
+      'continuing with blockTimestamp=0.',
+    );
+    return 0;
+  }
+}
 
 /**
  * Maps a Hub-registered contract name to its local binding invalidation policy.
@@ -3692,7 +3723,10 @@ export class EVMChainAdapterBase {
     // estimate). Absent for a non-PCA publish → the UI badge degrades hidden.
     const convictionCostCovered = decodeConvictionCostCovered(receipt.logs);
 
-    const blockTimestamp = await this.getBlockTimestamp(receipt.blockNumber);
+    const blockTimestamp = await resolveConfirmedReceiptBlockTimestamp(
+      receipt,
+      () => this.getBlockTimestamp(receipt.blockNumber),
+    );
 
     return {
       batchId: kaId,

--- a/packages/chain/src/evm-adapter-publish.ts
+++ b/packages/chain/src/evm-adapter-publish.ts
@@ -9,7 +9,11 @@
  * via applyMixins(); see evm-adapter.ts for the assembly.
  */
 
-import { EVMChainAdapterBase, decodeConvictionCostCovered } from './evm-adapter-base.js';
+import {
+  EVMChainAdapterBase,
+  decodeConvictionCostCovered,
+  resolveConfirmedReceiptBlockTimestamp,
+} from './evm-adapter-base.js';
 import { ethers, Wallet, Contract } from 'ethers';
 import type { ChainReadOptions, ReservedRange, BatchMintParams, BatchMintResult, KAUpdateVerification, OnChainPublishResult, V10UpdateKAParams, TxResult, PublisherPublishPlan, PublisherPublishPlanRequest } from './chain-adapter.js';
 import { floorPublishTokenAmount, computeUpdateACKDigest, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
@@ -513,7 +517,10 @@ export class PublishMethods extends EVMChainAdapterBase {
       publisherAddress = receipt.from ?? authorAddress ?? '';
     }
 
-    const blockTimestamp = await this.getBlockTimestamp(receipt.blockNumber, options);
+    const blockTimestamp = await resolveConfirmedReceiptBlockTimestamp(
+      receipt,
+      () => this.getBlockTimestamp(receipt.blockNumber, options),
+    );
     const convictionCostCovered = decodeConvictionCostCovered(receipt.logs);
 
     return {

--- a/packages/chain/test/chain-lifecycle-extra.test.ts
+++ b/packages/chain/test/chain-lifecycle-extra.test.ts
@@ -43,6 +43,7 @@ import {
   HARDHAT_KEYS,
 } from './evm-test-context.js';
 import { mintTokens } from './hardhat-harness.js';
+import { ChainRpcTransportError } from '../src/chain-rpc-transport-error.js';
 import {
   buildAuthorAttestationTypedData,
   buildUpdateAuthorAttestationTypedData,
@@ -92,10 +93,26 @@ async function publishOneKCV10(opts: {
   // OT-RFC-43 Option-1: explicit packed reservedKaId. When omitted the helper
   // allocates a fresh `(author<<96)|number` for the CORE_OP author.
   reservedKaId?: bigint;
-} = {}): Promise<{ kaId: bigint; txHash: string; contextGraphId: bigint; merkleRoot: Uint8Array; reservedKaId: bigint }> {
+  timestampTransportFailure?: boolean;
+} = {}): Promise<{
+  kaId: bigint;
+  txHash: string;
+  contextGraphId: bigint;
+  merkleRoot: Uint8Array;
+  reservedKaId: bigint;
+  blockTimestamp: number;
+}> {
   const provider = createProvider();
   const { hubAddress, coreProfileId } = getSharedContext();
   const adapter = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+  if (opts.timestampTransportFailure) {
+    (adapter as unknown as { getBlockTimestamp: () => Promise<number> }).getBlockTimestamp = async () => {
+      throw new ChainRpcTransportError(
+        'RPC_ENDPOINTS_EXHAUSTED',
+        'getBlock read failed on all configured RPC endpoints: 429 Too Many Requests',
+      );
+    };
+  }
   await mintTokens(
     provider,
     hubAddress,
@@ -202,6 +219,7 @@ async function publishOneKCV10(opts: {
     contextGraphId,
     merkleRoot,
     reservedKaId,
+    blockTimestamp: result.blockTimestamp,
   };
 }
 
@@ -227,6 +245,19 @@ describe('chain-lifecycle-extra — V10 lifecycle + adapter invariants', () => {
   // --------------------------------------------------------------------
 
   describe('V10 lifecycle: createKnowledgeAssets + updateKnowledgeCollectionV10 + verifyKAUpdate + resolvePublishByTxHash [CH-3]', () => {
+    it('keeps a mined publish confirmed when every RPC rejects timestamp enrichment', async () => {
+      const result = await publishOneKCV10({
+        kaCount: 1,
+        byteSize: 256n,
+        epochs: 2,
+        timestampTransportFailure: true,
+      });
+
+      expect(result.txHash).toMatch(/^0x[0-9a-f]{64}$/);
+      expect(result.kaId).toBe(result.reservedKaId);
+      expect(result.blockTimestamp).toBe(0);
+    });
+
     it('publishes, updates, verifies the update, and round-trips the publish receipt', async () => {
       const adapter = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
 

--- a/packages/chain/test/conviction-cost-covered-decode.test.ts
+++ b/packages/chain/test/conviction-cost-covered-decode.test.ts
@@ -8,11 +8,12 @@
  * exercised on the CI devnet @mutating lane; here we pin the decode itself by
  * round-tripping a synthesized log through the same interface.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Interface } from 'ethers';
 import { decodeConvictionCostCovered } from '../src/evm-adapter-base.js';
 import { PublishMethods } from '../src/evm-adapter-publish.js';
 import { getPcaLogicInterface } from '../src/evm-adapter-errors.js';
+import { ChainRpcTransportError } from '../src/chain-rpc-transport-error.js';
 
 function costCoveredLog(values: bigint[]): { topics: string[]; data: string } {
   const iface = getPcaLogicInterface();
@@ -98,5 +99,75 @@ describe('decodeConvictionCostCovered (B8)', () => {
       drawnFromEpoch: 500n,
       drawnFromTopUp: 200n,
     });
+  });
+
+  it('keeps a confirmed V10 publish when timestamp enrichment exhausts every RPC', async () => {
+    const parser = Object.create(PublishMethods.prototype) as PublishMethods & {
+      contracts: Record<string, unknown>;
+      getBlockTimestamp: () => Promise<number>;
+    };
+    parser.contracts = {
+      knowledgeAssetStorage: {
+        target: KAS,
+        interface: new Interface([
+          'event KnowledgeAssetCreated(uint256 id, address author)',
+        ]),
+      },
+    };
+    parser.getBlockTimestamp = async () => {
+      throw new ChainRpcTransportError(
+        'RPC_ENDPOINTS_EXHAUSTED',
+        'getBlock read failed on all configured RPC endpoints: 429 Too Many Requests',
+      );
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const out = await parser.parseV10PublishReceipt({
+        hash: '0xconfirmed',
+        blockNumber: 12,
+        index: 3,
+        from: '0x3333333333333333333333333333333333333333',
+        logs: [kaCreatedLog()],
+      } as any);
+
+      expect(out).toMatchObject({
+        txHash: '0xconfirmed',
+        blockNumber: 12,
+        blockTimestamp: 0,
+        kaId: 55n,
+      });
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('continuing with blockTimestamp=0'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('still rejects deterministic timestamp parsing failures', async () => {
+    const parser = Object.create(PublishMethods.prototype) as PublishMethods & {
+      contracts: Record<string, unknown>;
+      getBlockTimestamp: () => Promise<number>;
+    };
+    parser.contracts = {
+      knowledgeAssetStorage: {
+        target: KAS,
+        interface: new Interface([
+          'event KnowledgeAssetCreated(uint256 id, address author)',
+        ]),
+      },
+    };
+    parser.getBlockTimestamp = async () => {
+      throw Object.assign(new Error('invalid block tag'), { code: 'INVALID_ARGUMENT' });
+    };
+
+    await expect(parser.parseV10PublishReceipt({
+      hash: '0xinvalid',
+      blockNumber: 12,
+      index: 3,
+      from: '0x3333333333333333333333333333333333333333',
+      logs: [kaCreatedLog()],
+    } as any)).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 });


### PR DESCRIPTION
## What changed

A successful publish receipt is now authoritative even if the subsequent block-timestamp enrichment read exhausts every configured RPC endpoint. In that narrow case the adapter returns the exact confirmed transaction hash, block number, and KA id with `blockTimestamp: 0` instead of misclassifying the mined publish as failed.

The same handling applies to transaction-hash recovery. Explicit caller timeouts/aborts and deterministic parsing errors still propagate unchanged.

## Testnet evidence behind the fix

In the R2 smoke run, four V10 publishes were mined but their client operations failed after the receipt because `eth_getBlockByNumber` received 429 responses from every RPC endpoint. The retained SWM entries were then retried and rejected on-chain as `KaIdAlreadyMinted`. This change preserves the original confirmed result and transaction provenance.

## Validation

- Real Hardhat V10 mint with injected typed all-endpoint 429 exhaustion: passed; returned tx hash and reserved/minted KA id remain exact, timestamp falls back to zero.
- Receipt-recovery parser coverage for all-endpoint exhaustion: passed.
- Deterministic timestamp error remains fail-loud: passed.
- Existing explicit cancellation coverage remains green.
- `pnpm --filter @origintrail-official/dkg-chain build`: passed.
- Full chain suite: 67 files passed; 1,214 tests passed, 1 skipped, 0 failed.

This is a draft hotfix PR targeting `testnet-canary`. No deployment or merge is included.