### PR TITLE
fix(sync): damp unproductive exact VM reconcile batches

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -990,6 +990,18 @@ export class DKGAgentBase {
   protected readonly vmReconcileNegativeCacheKeysByCg = new Map<string, Set<string>>();
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();
+  /**
+   * Phase D/A4 — bounded retry history for exact batches that reached peers but
+   * made no verified VM progress. Keyed by the requested UAL/reason set so new
+   * work fails open; the recorded peer topology likewise invalidates the delay
+   * when a new source becomes available.
+   */
+  protected readonly vmReconcileExactBatchBackoff = new Map<string, {
+    localCgId: string;
+    failures: number;
+    nextRetryAt: number;
+    peerTopologyKey: string;
+  }>();
   /** Phase D/A4 — round-robin cursor over the already ordered catch-up peer list. */
   protected readonly vmReconcileCatchupPeerCursor = new Map<string, number>();
   protected readonly vmReconcileCatchupPeerOrder = new Map<string, {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3532,9 +3532,51 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this.pruneVmReconcileState();
   }
 
-  shouldRunVmReconcileActiveFetch(this: DKGAgent, localCgId: string): boolean {
+  vmReconcileExactBatchBackoffKey(this: DKGAgent,
+    localCgId: string,
+    targets: readonly OrdinalRecoveryTarget[],
+  ): string {
+    const digest = createHash('sha256');
+    digest.update(localCgId);
+    for (const target of targets) {
+      digest.update('\0');
+      digest.update(target.ual);
+      digest.update('\0');
+      digest.update(target.reason);
+    }
+    return `${localCgId}\0${digest.digest('hex')}`;
+  }
+
+  vmReconcileConnectedPeerTopologyKey(this: DKGAgent): string {
+    try {
+      return [...new Set(
+        this.node.libp2p.getConnections()
+          .map((connection) => connection.remotePeer?.toString())
+          .filter((peerId): peerId is string => typeof peerId === 'string' && peerId.length > 0),
+      )].sort().join(',');
+    } catch {
+      return '';
+    }
+  }
+
+  shouldRunVmReconcileActiveFetch(this: DKGAgent,
+    localCgId: string,
+    exactBatchBackoffKey?: string,
+  ): boolean {
     const now = Date.now();
     this.pruneVmReconcileState(now);
+    if (exactBatchBackoffKey) {
+      const exactBatchBackoff = this.vmReconcileExactBatchBackoff.get(exactBatchBackoffKey);
+      if (exactBatchBackoff && now < exactBatchBackoff.nextRetryAt) {
+        if (exactBatchBackoff.peerTopologyKey === this.vmReconcileConnectedPeerTopologyKey()) {
+          return false;
+        }
+        // A different connected peer set is new recovery evidence. Fail open
+        // immediately instead of waiting for a stale-source retry deadline.
+        this.vmReconcileExactBatchBackoff.delete(exactBatchBackoffKey);
+        this.vmReconcileFetchCooldownAt.delete(localCgId);
+      }
+    }
     const lastFetchAt = this.vmReconcileFetchCooldownAt.get(localCgId);
     if (lastFetchAt !== undefined && now - lastFetchAt < DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS) {
       return false;
@@ -3542,6 +3584,40 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (lastFetchAt !== undefined) this.vmReconcileFetchCooldownAt.delete(localCgId);
     this.vmReconcileFetchCooldownAt.set(localCgId, now);
     return true;
+  }
+
+  recordVmReconcileUnproductiveExactBatch(this: DKGAgent,
+    exactBatchBackoffKey: string,
+    localCgId: string,
+  ): number {
+    const previous = this.vmReconcileExactBatchBackoff.get(exactBatchBackoffKey);
+    const failures = (previous?.failures ?? 0) + 1;
+    const exponentialBackoff = Math.min(
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS * 2 ** Math.max(0, failures - 1),
+    );
+    const jitterSample = createHash('sha256')
+      .update(`${this.node.peerId.toString()}\0${exactBatchBackoffKey}\0${failures}`)
+      .digest()
+      .readUInt32BE(0) / 0x1_0000_0000;
+    const backoff = Math.min(
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+      Math.max(1, Math.round(exponentialBackoff * (0.8 + jitterSample * 0.4))),
+    );
+    if (previous) this.vmReconcileExactBatchBackoff.delete(exactBatchBackoffKey);
+    this.vmReconcileExactBatchBackoff.set(exactBatchBackoffKey, {
+      localCgId,
+      failures,
+      nextRetryAt: Date.now() + backoff,
+      peerTopologyKey: this.vmReconcileConnectedPeerTopologyKey(),
+    });
+    getMetrics().storeRetryAttemptsTotal.add(1, {
+      scope: 'vm_reconcile',
+      reason: 'exact_batch_unproductive',
+      attempt: Math.min(failures, 16),
+    });
+    this.pruneVmReconcileState();
+    return backoff;
   }
 
   vmReconcileActiveFetchHadUsableResponse(this: DKGAgent, result: {
@@ -3575,6 +3651,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const oldestKey = this.vmReconcileFetchCooldownAt.keys().next().value;
       if (oldestKey === undefined) break;
       this.vmReconcileFetchCooldownAt.delete(oldestKey);
+    }
+
+    while (this.vmReconcileExactBatchBackoff.size > DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.vmReconcileExactBatchBackoff.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileExactBatchBackoff.delete(oldestKey);
     }
 
     while (this.vmReconcileCatchupPeerCursor.size > DKGAgentBase.VM_RECONCILE_CG_STATE_MAX_ENTRIES) {
@@ -3611,6 +3693,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
       });
     this.reconcileCursors.delete(localCgId);
     this.vmReconcileFetchCooldownAt.delete(localCgId);
+    for (const [key, record] of this.vmReconcileExactBatchBackoff) {
+      if (record.localCgId === localCgId) this.vmReconcileExactBatchBackoff.delete(key);
+    }
     this.vmReconcileCatchupPeerCursor.delete(localCgId);
     this.vmReconcileCatchupPeerOrder.delete(localCgId);
     this.clearRecentVmReconcileStateForContextGraph(localCgId);
@@ -3674,13 +3759,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     // Damping: the batched path deliberately skips the per-UAL negative cache
     // (consulting it primes connections to every discovered agent — the walk
-    // this path exists to avoid), so the per-CG active-fetch cooldown is the
-    // only damper between this batch and the network. A wholly unproductive
-    // batch (e.g. the curator is offline) therefore costs one bounded exact
-    // fetch per sweep interval, not one per reconcile pass. Progress clears
-    // the cooldown below so a draining backlog proceeds slice after slice.
-    if (!this.shouldRunVmReconcileActiveFetch(localCgId)) {
-      this.log.info(ctx, `VM exact fetch for "${localCgId}" skipped by per-CG cooldown`);
+    // this path exists to avoid). Keep the short per-CG guard, then exponentially
+    // damp only the same wholly-unproductive exact target set. New targets or a
+    // changed connected-peer topology fail open, while verified progress clears
+    // both gates so a draining backlog proceeds slice after slice.
+    const exactBatchBackoffKey = this.vmReconcileExactBatchBackoffKey(localCgId, targets);
+    if (!this.shouldRunVmReconcileActiveFetch(localCgId, exactBatchBackoffKey)) {
+      this.log.info(ctx, `VM exact fetch for "${localCgId}" skipped by per-CG cooldown/backoff`);
       return new Map();
     }
 
@@ -3800,12 +3885,23 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // Mirror the inline path's cooldown policy: an unreachable network must
     // not consume the fetch budget, and completed work resets the damper so
     // the trailing `hasMore` slice of a draining backlog fetches immediately.
-    // Only a batch that reached a peer and recovered nothing leaves the
-    // cooldown standing.
+    // A batch that reached peers but made no verified progress grows a bounded,
+    // target- and topology-scoped delay instead of re-fetching identical VM
+    // content every minute forever.
     const recoveredAny = [...outcomes.values()]
       .some((outcome) => outcome.status === 'reconciled' || outcome.status === 'already');
     if (!attemptedFetch || recoveredAny) {
       this.vmReconcileFetchCooldownAt.delete(localCgId);
+      if (recoveredAny) this.vmReconcileExactBatchBackoff.delete(exactBatchBackoffKey);
+    } else {
+      const backoff = this.recordVmReconcileUnproductiveExactBatch(
+        exactBatchBackoffKey,
+        localCgId,
+      );
+      this.log.info(
+        ctx,
+        `VM exact fetch for "${localCgId}" made no verified progress; retrying this target set in ${backoff}ms`,
+      );
     }
     return outcomes;
   }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3547,12 +3547,25 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return `${localCgId}\0${digest.digest('hex')}`;
   }
 
-  vmReconcileConnectedPeerTopologyKey(this: DKGAgent): string {
+  vmReconcileConnectedPeerTopologyKey(this: DKGAgent, localCgId: string): string {
     try {
+      // Only a newly reachable recovery source is evidence worth bypassing an
+      // exact-batch backoff. Edge peers routinely connect/disconnect through
+      // relays and most cannot serve this CG; including every connection made
+      // that ambient churn clear all per-CG dampers once per sweep. Core peers
+      // and the authenticated curator hint are the stable source candidates
+      // used by the recovery ordering below.
+      const recoverySourcePeerIds = new Set(this.knownCorePeerIds);
+      const preferredPeerId = this.preferredSyncPeers.get(localCgId);
+      if (preferredPeerId) recoverySourcePeerIds.add(preferredPeerId);
       return [...new Set(
         this.node.libp2p.getConnections()
           .map((connection) => connection.remotePeer?.toString())
-          .filter((peerId): peerId is string => typeof peerId === 'string' && peerId.length > 0),
+          .filter((peerId): peerId is string => (
+            typeof peerId === 'string'
+            && peerId.length > 0
+            && recoverySourcePeerIds.has(peerId)
+          )),
       )].sort().join(',');
     } catch {
       return '';
@@ -3568,7 +3581,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (exactBatchBackoffKey) {
       const exactBatchBackoff = this.vmReconcileExactBatchBackoff.get(exactBatchBackoffKey);
       if (exactBatchBackoff && now < exactBatchBackoff.nextRetryAt) {
-        if (exactBatchBackoff.peerTopologyKey === this.vmReconcileConnectedPeerTopologyKey()) {
+        if (exactBatchBackoff.peerTopologyKey === this.vmReconcileConnectedPeerTopologyKey(localCgId)) {
           return false;
         }
         // A different connected peer set is new recovery evidence. Fail open
@@ -3609,7 +3622,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       localCgId,
       failures,
       nextRetryAt: Date.now() + backoff,
-      peerTopologyKey: this.vmReconcileConnectedPeerTopologyKey(),
+      peerTopologyKey: this.vmReconcileConnectedPeerTopologyKey(localCgId),
     });
     getMetrics().storeRetryAttemptsTotal.add(1, {
       scope: 'vm_reconcile',

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2225,6 +2225,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const internals = agent as unknown as AgentInternals;
     const peerA = '12D3KooWExactBackoffPeerA';
     const peerB = '12D3KooWExactBackoffPeerB';
+    const incidentalEdge = '12D3KooWExactBackoffIncidentalEdge';
     const connected = [{ toString: () => peerA }];
     const localCgId = '0x0000000000000000000000000000000000000001/exact-backoff';
     (internals as any).node = {
@@ -2277,13 +2278,20 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(secondRecord.nextRetryAt).toBeGreaterThan(firstRecord.nextRetryAt);
     expect(fetchCount).toBe(2);
 
-    // A newly connected source is fresh recovery evidence and immediately
-    // bypasses both the target-set delay and the short per-CG cooldown.
-    connected.push({ toString: () => peerB });
+    // Ambient edge connection churn is not fresh recovery evidence and must
+    // not clear the target-set backoff.
+    connected.push({ toString: () => incidentalEdge });
     vi.setSystemTime(firstRecord.nextRetryAt + 1);
     expect(Date.now()).toBeLessThan(secondRecord.nextRetryAt);
     await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
-    expect(fetchCount).toBe(4);
+    expect(fetchCount).toBe(2);
+
+    // A newly connected core source is fresh recovery evidence and immediately
+    // bypasses both the target-set delay and the short per-CG cooldown.
+    (internals as any).knownCorePeerIds.add(peerB);
+    connected.push({ toString: () => peerB });
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(fetchCount).toBe(5);
   });
 
   it('clears the fetch cooldown after a productive exact batch so the next slice proceeds', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -736,6 +736,7 @@ describe('Phase D - VM reconcile damping', () => {
   let agent: DKGAgent | null = null;
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (agent) {
       await agent.stop().catch(() => undefined);
       agent = null;
@@ -1771,6 +1772,12 @@ describe('Phase D - VM reconcile damping', () => {
       peerTopologyKey: string;
     }>;
     const fetchCooldown = (internals as any).vmReconcileFetchCooldownAt as Map<string, number>;
+    const exactBatchBackoff = (internals as any).vmReconcileExactBatchBackoff as Map<string, {
+      localCgId: string;
+      failures: number;
+      nextRetryAt: number;
+      peerTopologyKey: string;
+    }>;
     const peerCursor = (internals as any).vmReconcileCatchupPeerCursor as Map<string, number>;
     const peerOrder = (internals as any).vmReconcileCatchupPeerOrder as Map<string, { orderedPeers: string[]; nextPeerId?: string }>;
     const recent = (internals as any).recentReconciledUals as { add(key: string): void; has(key: string): boolean };
@@ -1785,6 +1792,12 @@ describe('Phase D - VM reconcile damping', () => {
         candidateNamespaces: [],
         peerTopologyKey: '',
       });
+      exactBatchBackoff.set(`exact-${i}`, {
+        localCgId: `exact-cg-${i}`,
+        failures: 1,
+        nextRetryAt: now + 60_000,
+        peerTopologyKey: '',
+      });
     }
     fetchCooldown.set('expired-cg', now - DKGAgent.VM_RECONCILE_SWEEP_INTERVAL_MS - 1);
     for (let i = 0; i < DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES + 2; i += 1) {
@@ -1796,6 +1809,7 @@ describe('Phase D - VM reconcile damping', () => {
     (internals as any).pruneVmReconcileState(now);
 
     expect(negativeCache.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES);
+    expect(exactBatchBackoff.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES);
     expect(fetchCooldown.has('expired-cg')).toBe(false);
     expect(fetchCooldown.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES);
     expect(peerCursor.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES);
@@ -1812,12 +1826,19 @@ describe('Phase D - VM reconcile damping', () => {
     });
     (internals as any).indexVmReconcileNegativeCacheEntry('cleanup-cg', 'cleanup-cache');
     fetchCooldown.set('cleanup-cg', now);
+    exactBatchBackoff.set('cleanup-exact', {
+      localCgId: 'cleanup-cg',
+      failures: 1,
+      nextRetryAt: now + 60_000,
+      peerTopologyKey: '',
+    });
     peerCursor.set('cleanup-cg', 7);
     peerOrder.set('cleanup-cg', { orderedPeers: ['peer-a'], nextPeerId: 'peer-a' });
     recent.add('cleanup-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/1#01');
     (agent as any).unsubscribeFromContextGraph('cleanup-cg');
     expect(negativeCache.has('cleanup-cache')).toBe(false);
     expect(fetchCooldown.has('cleanup-cg')).toBe(false);
+    expect(exactBatchBackoff.has('cleanup-exact')).toBe(false);
     expect(peerCursor.has('cleanup-cg')).toBe(false);
     expect(peerOrder.has('cleanup-cg')).toBe(false);
     expect(recent.has('cleanup-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/1#01')).toBe(false);
@@ -1833,12 +1854,19 @@ describe('Phase D - VM reconcile damping', () => {
     });
     (internals as any).indexVmReconcileNegativeCacheEntry('hosted-cg', 'hosted-cache');
     fetchCooldown.set('hosted-cg', now);
+    exactBatchBackoff.set('hosted-exact', {
+      localCgId: 'hosted-cg',
+      failures: 1,
+      nextRetryAt: now + 60_000,
+      peerTopologyKey: '',
+    });
     peerCursor.set('hosted-cg', 3);
     peerOrder.set('hosted-cg', { orderedPeers: ['peer-b'], nextPeerId: 'peer-b' });
     recent.add('hosted-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/2#02');
     (agent as any).unsubscribeFromContextGraph('hosted-cg');
     expect(negativeCache.has('hosted-cache')).toBe(true);
     expect(fetchCooldown.has('hosted-cg')).toBe(true);
+    expect(exactBatchBackoff.has('hosted-exact')).toBe(true);
     expect(peerCursor.has('hosted-cg')).toBe(true);
     expect(peerOrder.has('hosted-cg')).toBe(true);
     expect(recent.has('hosted-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/2#02')).toBe(true);
@@ -1849,6 +1877,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
   let agent: DKGAgent | null = null;
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (agent) {
       await agent.stop().catch(() => undefined);
       agent = null;
@@ -2188,6 +2217,75 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(second.size).toBe(0);
   });
 
+  it('exponentially damps the same unproductive exact batch until topology changes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-23T00:00:00.000Z'));
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmBatchBackoff', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peerA = '12D3KooWExactBackoffPeerA';
+    const peerB = '12D3KooWExactBackoffPeerB';
+    const connected = [{ toString: () => peerA }];
+    const localCgId = '0x0000000000000000000000000000000000000001/exact-backoff';
+    (internals as any).node = {
+      peerId: '12D3KooWExactBackoffLocalPeer',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peerA);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peerA], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    let fetchCount = 0;
+    (internals as any).syncExactKnowledgeAssetsFromPeer = async () => {
+      fetchCount += 1;
+      return {
+        fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+        failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+      };
+    };
+    const target = {
+      ordinal: 0,
+      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
+      kaId: '7',
+      reason: 'verified-vm-metadata-pending' as const,
+    };
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'pending',
+      recovery: target,
+    });
+
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    const exactBackoff = (internals as any).vmReconcileExactBatchBackoff as Map<string, {
+      failures: number;
+      nextRetryAt: number;
+    }>;
+    const firstRecord = [...exactBackoff.values()][0]!;
+    expect(firstRecord.failures).toBe(1);
+    expect(fetchCount).toBe(1);
+
+    vi.setSystemTime(firstRecord.nextRetryAt - 1);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(fetchCount).toBe(1);
+
+    vi.setSystemTime(firstRecord.nextRetryAt);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    const secondRecord = [...exactBackoff.values()][0]!;
+    expect(secondRecord.failures).toBe(2);
+    expect(secondRecord.nextRetryAt).toBeGreaterThan(firstRecord.nextRetryAt);
+    expect(fetchCount).toBe(2);
+
+    // A newly connected source is fresh recovery evidence and immediately
+    // bypasses both the target-set delay and the short per-CG cooldown.
+    connected.push({ toString: () => peerB });
+    vi.setSystemTime(firstRecord.nextRetryAt + 1);
+    expect(Date.now()).toBeLessThan(secondRecord.nextRetryAt);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(fetchCount).toBe(4);
+  });
+
   it('clears the fetch cooldown after a productive exact batch so the next slice proceeds', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmBatchProductive', chainAdapter: chain });
@@ -2227,6 +2325,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
 
     await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
     expect(fetchCount).toBe(1);
+    expect(((internals as any).vmReconcileExactBatchBackoff as Map<string, unknown>).size).toBe(0);
 
     // Progress cleared the cooldown: the trailing hasMore slice fetches now.
     await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);


### PR DESCRIPTION
## Summary

- add bounded, process-local exponential backoff for identical exact VM-reconcile target batches that reached peers but made no verified progress
- scope the delay to the exact target set and connected-peer topology so new work and newly available sources retry immediately
- clear the delay immediately after verified `reconciled` / `already` progress and avoid consuming it when no peer fetch was attempted
- prune and clean up the new state with the existing reconciliation caches

## Why

Testnet publisher evidence showed the same `verified-vm-metadata-pending` or empty private-graph batches being fetched from multiple peers every 60 seconds without any verified state transition. Some cycles inserted thousands of triples but could not repair missing provenance, so they consumed global sync capacity without advancing VM convergence.

This PR does **not** synthesize provenance, relax verification, or mark pending content confirmed. It only spaces repeated network work after a batch has proved unproductive.

## Retry semantics

- first identical unproductive batch: approximately 1 minute (deterministic jitter)
- subsequent failures: exponential delay up to the existing 10-minute cap
- new exact target set: immediate
- connected-peer topology change: immediate
- verified progress: immediate next slice
- no attempted peer fetch: no backoff growth
- process restart: state resets and fails open

## Validation

- agent dependency/build chain: passed (`tsc`, `test:types`, `test:package-root`)
- focused reconciliation suite: 68/68 passed
- full agent unit lane: 139 files, 1,789 passed, 5 skipped, 0 failed
- `git diff --check`: passed

## Rollout boundary

Draft PR targeting `testnet-canary`. It has not been merged or deployed. Distributed completeness validation remains pending until the second edge receiver returns; its last checkpoint is preserved and no manual catch-up was triggered.