### PR TITLE
fix(sync): stop retrying invalid responder sessions

### DIFF
--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { withRetry, withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import { markSyncTransportFailure } from '../sync/error-tags.js';
+import { isSyncResponderSessionInvalidError } from '../sync/durable-session.js';
 import type { Messenger } from './messenger.js';
 
 /**
@@ -129,7 +130,13 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
           params.signal,
         );
       } catch (error) {
-        markSyncTransportFailure(error);
+        // Superseded/expired responder sessions are an application-level
+        // terminal response, not a broken network path. Retrying this exact
+        // token can never succeed and incorrectly charges the peer's transport
+        // health; page-fetch rotates the token after this error escapes.
+        if (!isSyncResponderSessionInvalidError(error)) {
+          markSyncTransportFailure(error);
+        }
         throw error;
       }
       throwIfAborted(params.signal);
@@ -141,7 +148,10 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
       maxAttempts: params.retryAttempts,
       baseDelayMs: 1000,
       signal: params.signal,
-      isRetryable: () => params.signal?.aborted !== true,
+      isRetryable: (error) => (
+        params.signal?.aborted !== true
+        && !isSyncResponderSessionInvalidError(error)
+      ),
       onRetry: params.onRetry,
     },
         );

--- a/packages/agent/src/sync/durable-session.ts
+++ b/packages/agent/src/sync/durable-session.ts
@@ -9,3 +9,17 @@ export function createSyncResponderSessionId(scope = 'sync'): string {
 export function createDurableDataSyncSessionId(): string {
   return createSyncResponderSessionId('durable-data');
 }
+
+/**
+ * A responder-session token is terminal once the responder reports that its
+ * immutable snapshot was superseded or expired. Retrying the same request with
+ * the same token cannot succeed; the requester must rotate the token instead.
+ */
+export function isSyncResponderSessionInvalidError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return message.includes('sync session') && (
+    message.includes('superseded')
+    || message.includes('expired')
+  );
+}

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -13,6 +13,7 @@ import {
   createDurableDataSyncSessionId,
   createSyncResponderSessionId,
   DURABLE_DATA_SYNC_SESSION_TTL_MS,
+  isSyncResponderSessionInvalidError,
 } from '../durable-session.js';
 import {
   createRequesterPhaseTelemetry,
@@ -86,15 +87,6 @@ function forgetUnfinishedSyncResponderSession(
 ): void {
   unfinishedSyncResponderSessions.delete(checkpointKey);
   checkpointStore.clearResponderSession?.(checkpointKey);
-}
-
-function isSyncResponderSessionInvalidError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const message = err.message.toLowerCase();
-  return message.includes('sync session') && (
-    message.includes('superseded')
-    || message.includes('expired')
-  );
 }
 
 function usesResponderSession(includeSharedMemory: boolean, phase: SyncPhase): boolean {

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1013,6 +1013,7 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     );
     const observedSessionIds: Array<string | undefined> = [];
     let expired = true;
+    let expiredSendCalls = 0;
 
     const runFetch = () => runFetchWithFakeTimers(fetchSyncPages({
       ctx: makeCtx(),
@@ -1024,7 +1025,7 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
       deadline: Date.now() + 60_000,
       syncPageTimeoutMs: 5_000,
       syncRouterAttempts: 1,
-      syncPageRetryAttempts: 1,
+      syncPageRetryAttempts: 3,
       syncPageSize: 1,
       syncDeniedResponse: '#DENIED',
       debugSyncProgress: false,
@@ -1046,7 +1047,10 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
       },
       parseAndFilter: singleQuadParser,
       send: async () => {
-        if (expired) throw new Error('Durable data sync session snapshot expired before page completion');
+        if (expired) {
+          expiredSendCalls += 1;
+          throw new Error('Durable data sync session snapshot expired before page completion');
+        }
         return new TextEncoder().encode('');
       },
       logWarn: noopLog,
@@ -1056,6 +1060,7 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
 
     await expect(runFetch()).rejects.toThrow('snapshot expired before page completion');
     expect(observedSessionIds.at(-1)).toBe('expired-responder-token');
+    expect(expiredSendCalls).toBe(1);
     expect(checkpointStore.get(checkpointKey)).toBeUndefined();
 
     expired = false;

--- a/packages/agent/test/sync-transport-metrics.test.ts
+++ b/packages/agent/test/sync-transport-metrics.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { rebuildMetrics } from '@origintrail-official/dkg-core';
 import { sendSyncRequest } from '../src/p2p/sync-transport.js';
+import { isSyncTransportFailure } from '../src/sync/error-tags.js';
 
 const PROTO = '/dkg/10.0.2/sync';
 
@@ -77,6 +78,37 @@ describe('sync transport metrics — real sendSyncRequest emits dkg.sync.request
     await expect(
       sendSyncRequest(baseParams(async () => { throw new Error('transport down'); })),
     ).rejects.toBeTruthy();
+    const pts = await syncReqPoints();
+    expect(pts.some((a) => a.outcome === 'error' && a.protocol_id === PROTO)).toBe(true);
+  });
+
+  it('does not retry or transport-tag a terminal responder-session error', async () => {
+    installMeter();
+    let sends = 0;
+    let retries = 0;
+    const params = {
+      ...baseParams(async () => {
+        sends += 1;
+        throw new Error('Durable data sync session snapshot expired before page completion');
+      }),
+      retryAttempts: 3,
+      onRetry: () => {
+        retries += 1;
+      },
+    };
+
+    let rejected: unknown;
+    try {
+      await sendSyncRequest(params);
+    } catch (error) {
+      rejected = error;
+    }
+
+    expect(rejected).toBeInstanceOf(Error);
+    expect((rejected as Error).message).toContain('snapshot expired before page completion');
+    expect(isSyncTransportFailure(rejected)).toBe(false);
+    expect(sends).toBe(1);
+    expect(retries).toBe(0);
     const pts = await syncReqPoints();
     expect(pts.some((a) => a.outcome === 'error' && a.protocol_id === PROTO)).toBe(true);
   });


### PR DESCRIPTION
## Summary

- classify responder-session `superseded` / `expired` errors as terminal application responses instead of transport failures
- stop the inner page retry loop immediately because the same immutable session token cannot recover
- retain the existing page-fetch cleanup that deletes the invalid token and checkpoint so the next bounded attempt starts at offset zero with a fresh session
- centralize the invalid-session classifier so transport and requester use the same rule

## Why

Live testnet publisher logs showed `Durable data sync session snapshot expired before page completion` entering the normal `1/3`, `2/3` page retry path. Every retry reused the already-terminal responder-session token, reduced page size unnecessarily, occupied scarce global sync slots, and charged the peer as a transport failure before page-fetch finally rotated the token.

This patch makes that terminal condition one attempt. Real dial, stream, timeout, and other transport failures keep the existing retry behavior.

## Validation

- agent dependency/build chain: passed (`tsc`, `test:types`, `test:package-root`)
- focused transport + fresh-session suites: 2 files, 31/31 passed
- regression with `retryAttempts=3`: one send, zero retry callbacks, no transport-failure tag, invalid checkpoint removed
- full agent unit lane: 139 files, 1,788 passed, 5 skipped, 0 failed
- `git diff --check`: passed

## Rollout boundary

Draft PR targeting `testnet-canary`. It has not been merged or deployed. The running publisher and the offline receiver checkpoint were not changed.