### PR TITLE
fix(sync): retain backoff after partial progress failures

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3453,10 +3453,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<SyncReconcilerAttemptOutcome> {
     const lastOk = this.lastSuccessfulSyncAt.get(remotePeer);
     const lastProgress = this.lastSyncProgressAt.get(remotePeer);
-    let syncAccountingClearedBackoff = false;
+    let syncAccounting: SyncOnConnectPeerOutcome | undefined;
     try {
-      const outcome = await this.trySyncFromPeer(remotePeer, () => {
-        syncAccountingClearedBackoff = true;
+      const outcome = await this.trySyncFromPeer(remotePeer, (peerOutcome) => {
+        syncAccounting = peerOutcome;
       });
       if (outcome === 'deferred-backpressure') {
         this.log.info(
@@ -3465,11 +3465,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         );
         return outcome;
       }
-      if (
+      if (syncAccounting?.retryBackoff) {
+        this.recordSyncReconcilerFailure(remotePeer, probe);
+      } else if (
         outcome !== 'skipped-no-sync' &&
         outcome !== 'already-syncing' &&
         outcome !== 'not-started' &&
-        !syncAccountingClearedBackoff &&
+        !syncAccounting &&
         this.lastSuccessfulSyncAt.get(remotePeer) === lastOk &&
         this.lastSyncProgressAt.get(remotePeer) === lastProgress
       ) {
@@ -3564,7 +3566,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           this.lastSuccessfulSyncAt.set(peerId, progressAt);
         }
         this.skippedNoSyncPeers.delete(peerId);
-        this.syncReconcilerBackoff.delete(peerId);
+        if (!outcome?.retryBackoff) {
+          this.syncReconcilerBackoff.delete(peerId);
+        }
         if (outcome) {
           onSyncAccounting?.(outcome);
         }

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -11,6 +11,13 @@ type SyncFromPeerResult = number | SyncProgressSummary;
 export interface SyncOnConnectPeerOutcome {
   fresh: boolean;
   progress?: boolean;
+  /**
+   * The round committed useful progress but also hit a transport/integrity
+   * failure that should retain the ordinary per-peer retry backoff. Without
+   * this signal, every transient connection:open clears the failure history
+   * and immediately replays the full sync scope.
+   */
+  retryBackoff?: boolean;
 }
 
 interface SyncOnConnectContext {
@@ -178,11 +185,12 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       }
       return 'deferred-backpressure';
     }
-    const clearsPeerBackoff = madeProgress || (!sawBackoffWorthyFailure && (cleanDurableRound || sawDeniedPhase));
-    if (clearsPeerBackoff) {
+    const recordsPeerAccounting = madeProgress || (!sawBackoffWorthyFailure && (cleanDurableRound || sawDeniedPhase));
+    if (recordsPeerAccounting) {
       context.onPeerSynced?.(remotePeer, {
         fresh: !sawBackoffWorthyFailure && !sawDeniedPhase && !sawFailedPhase && cleanDurableRound,
         progress: madeProgress,
+        retryBackoff: sawBackoffWorthyFailure,
       });
     }
     return 'synced';

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -157,6 +157,43 @@ describe('sync-on-connect churn gates', () => {
     expect((agent as any).catchupOnConnectAt.get(PEER_A)).toBe(staleQueuedAt);
   });
 
+  it('retains progress while backing off a mixed progress-and-failure round', async () => {
+    const agent = await createUnstartedAgent('SyncReconnectPartialProgressBackoff');
+    (agent as any).started = true;
+    (agent.node as any).node = {
+      getPeers: () => [{ toString: () => PEER_A }],
+      getConnections: () => [{
+        remotePeer: { toString: () => PEER_A },
+        direction: 'outbound',
+        timeline: { open: 123 },
+        remoteAddr: { toString: () => '/ip4/127.0.0.1/tcp/9090' },
+      }],
+    };
+    (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+    (agent as any).syncFromPeerDetailed = async () => emptyDetailedSync({
+      insertedTriples: 3,
+      insertedDataTriples: 3,
+      completedPhases: 1,
+      checkpointAdvances: 1,
+      timedOutPhases: 1,
+      backoffWorthyFailures: 1,
+    });
+
+    await (agent as any).runSyncFromPeerOnConnect(PEER_A, () => undefined);
+
+    expect((agent as any).lastSyncProgressAt.get(PEER_A)).toBeGreaterThan(0);
+    expect((agent as any).lastSuccessfulSyncAt.has(PEER_A)).toBe(false);
+    const backoff = (agent as any).syncReconcilerBackoff.get(PEER_A);
+    expect(backoff?.failures).toBe(1);
+    expect(backoff?.nextRetryAt).toBeGreaterThan(Date.now());
+
+    (agent as any).catchupOnConnectAt.set(
+      PEER_A,
+      Date.now() - CATCHUP_ON_CONNECT_COOLDOWN_MS - 1,
+    );
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(false);
+  });
+
   it('does not let one peer backoff suppress connection-open sync for another peer', async () => {
     const agent = await createUnstartedAgent('SyncReconnectBackoffPeerScoped');
     const calls: string[] = [];
@@ -310,7 +347,12 @@ describe('sync-on-connect churn gates', () => {
     const refreshMetaSyncedFlags = recorder(async () => undefined);
     const discoverContextGraphsFromStore = recorder(async () => 0);
     const syncSharedMemoryFromPeer = recorder(async () => 0);
-    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
+    const syncedPeers: Array<{
+      peerId: string;
+      fresh: boolean;
+      progress?: boolean;
+      retryBackoff?: boolean;
+    }> = [];
 
     const outcome = await runSyncOnConnect({
       remotePeer: PEER_A,
@@ -331,7 +373,12 @@ describe('sync-on-connect churn gates', () => {
       syncSharedMemoryFromPeer,
       logInfo: noopLog,
       onPeerSynced: (peerId, syncOutcome) => {
-        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+        syncedPeers.push({
+          peerId,
+          fresh: syncOutcome?.fresh ?? false,
+          progress: syncOutcome?.progress,
+          retryBackoff: syncOutcome?.retryBackoff,
+        });
       },
     });
 
@@ -339,7 +386,12 @@ describe('sync-on-connect churn gates', () => {
     expect(refreshMetaSyncedFlags.calls).toEqual([]);
     expect(discoverContextGraphsFromStore.calls).toEqual([]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([]);
-    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+    expect(syncedPeers).toEqual([{
+      peerId: PEER_A,
+      fresh: false,
+      progress: true,
+      retryBackoff: true,
+    }]);
   });
 
   it('records progress before stopping newly discovered CG fanout after durable pressure', async () => {
@@ -350,7 +402,12 @@ describe('sync-on-connect churn gates', () => {
       return 1;
     });
     const syncSharedMemoryFromPeer = recorder(async () => 0);
-    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
+    const syncedPeers: Array<{
+      peerId: string;
+      fresh: boolean;
+      progress?: boolean;
+      retryBackoff?: boolean;
+    }> = [];
     const syncFromPeer = recorder(async (_peerId: string, contextGraphIds?: string[]) => {
       if (contextGraphIds?.includes('cg-b')) {
         return emptyDetailedSync({
@@ -377,7 +434,12 @@ describe('sync-on-connect churn gates', () => {
       syncSharedMemoryFromPeer,
       logInfo: noopLog,
       onPeerSynced: (peerId, syncOutcome) => {
-        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+        syncedPeers.push({
+          peerId,
+          fresh: syncOutcome?.fresh ?? false,
+          progress: syncOutcome?.progress,
+          retryBackoff: syncOutcome?.retryBackoff,
+        });
       },
     });
 
@@ -386,7 +448,12 @@ describe('sync-on-connect churn gates', () => {
     expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
     expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([]);
-    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+    expect(syncedPeers).toEqual([{
+      peerId: PEER_A,
+      fresh: false,
+      progress: true,
+      retryBackoff: true,
+    }]);
   });
 
   it('skips SWM sync-on-connect fanout when no CG is locally eligible', async () => {


### PR DESCRIPTION
## Summary

- preserve useful sync progress from mixed progress-and-failure rounds
- retain and grow the ordinary per-peer retry backoff when that same round hits transport or integrity pressure
- prevent transient connection-open events from replaying the full subscribed graph scope after only the base catch-up cooldown

## Live evidence

A testnet edge peer repeatedly replayed its full subscribed-user graph fanout every 1-3 minutes. The round successfully integrated verified triples, then hit a graph-scoped durable authorization deadline. Progress accounting cleared the peer failure history, so the next transient connection-open bypassed exponential retry damping and repeated the full scan.

## Correctness boundaries

- clean progress still clears backoff
- pure local backpressure behavior is unchanged
- mixed progress plus a real failure records progress without marking the peer fresh and grows peer-scoped backoff
- topology or protocol probe changes can still bypass stale backoff
- no timing constants or deployment configuration change

## Validation

- `git diff --check`
- focused sync-on-connect churn and retry tests: 2 files, 69 passed
- agent build: TypeScript, type tests, package-root tests passed
- full agent unit lane: 139 files, 1,789 passed, 5 skipped, 0 failed

## Integration note

This is a standalone patch based on exact `testnet-canary` commit `1dba8f5e7b12680a267356dae9e5eb944248436a`. Draft only; no node was restarted or deployed.