### PR TITLE
test(harness): bind RFC-64 recovery evidence to its CG

### DIFF
--- a/scripts/rfc64-matrix-evidence/README.md
+++ b/scripts/rfc64-matrix-evidence/README.md
@@ -1,0 +1,48 @@
+# RFC-64 matrix evidence certification
+
+This tool merges immutable first-attempt matrix evidence with later recovery
+evidence without allowing rows from another run, Context Graph, or asset to
+affect the result.
+
+The previous ad-hoc certifier keyed recovery rows only by `lane:index`. Because
+those ordinals repeat in every test run, passing a recovery JSONL from another
+run could silently change the certified totals.
+
+## Recovery evidence contract
+
+Each recovery JSONL must contain exactly one `recovery_start` record with:
+
+- the source manifest `runId`;
+- the source manifest `datasetDigest`;
+- the exact `contextGraphBindings` map from lane to Context Graph ID.
+
+Every `recovery_result` must repeat:
+
+- `runId` and `datasetDigest`;
+- the exact `contextGraphId` for its lane;
+- the immutable asset identity: `lane`, `index`, `name`, `subject`,
+  `tripleCount`, and `expectedDigest`.
+
+Use `createRecoveryStartEvidence` and `createRecoveryResultEvidence` from
+`certification.mjs` when producing rows. The certifier fails closed on any
+missing or mismatched binding and copies only explicitly allowed recovery
+evidence fields. Recovery JSON cannot replace manifest identity.
+
+## Certify
+
+```bash
+node scripts/rfc64-matrix-evidence/certify.mjs \
+  --manifest runs/example.manifest.json \
+  --recovery runs/example.recovery.jsonl \
+  --output runs/example.certified.json
+```
+
+Multiple `--recovery` arguments are supported. When more than one valid row
+targets the same CG-bound asset, the row with the strongest finalized/readback
+result wins.
+
+## Test
+
+```bash
+node --test scripts/rfc64-matrix-evidence/certification.test.mjs
+```

--- a/scripts/rfc64-matrix-evidence/certification.mjs
+++ b/scripts/rfc64-matrix-evidence/certification.mjs
@@ -1,0 +1,297 @@
+const IDENTITY_FIELDS = Object.freeze([
+  'lane',
+  'index',
+  'name',
+  'subject',
+  'tripleCount',
+  'expectedDigest',
+]);
+
+const RECOVERY_EVIDENCE_FIELDS = Object.freeze([
+  'sentinel',
+  'swmShared',
+  'swmReadbackPassed',
+  'swmSharedAt',
+  'finalized',
+  'readbackPassed',
+  'actions',
+  'chainAlreadyMinted',
+  'ual',
+  'kaId',
+  'txHash',
+  'blockNumber',
+  'merkleRoot',
+  'storageAckPeerIds',
+  'finalStatus',
+  'finalMemoryLayer',
+  'readback',
+  'startedAt',
+  'completedAt',
+  'shareDurationMs',
+  'publishDurationMs',
+  'vmReadbackDurationMs',
+  'durationMs',
+  'error',
+]);
+
+function fail(message) {
+  throw new Error(`RFC-64 matrix evidence rejected: ${message}`);
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.length === 0) fail(`${label} must be a non-empty string`);
+  return value;
+}
+
+function requireNonNegativeInteger(value, label) {
+  if (!Number.isInteger(value) || value < 0) fail(`${label} must be a non-negative integer`);
+  return value;
+}
+
+function snapshotLaneBindings(manifest) {
+  if (!manifest?.lanes || typeof manifest.lanes !== 'object' || Array.isArray(manifest.lanes)) {
+    fail('manifest lanes must be an object');
+  }
+  return Object.fromEntries(Object.entries(manifest.lanes).map(([lane, config]) => [
+    requireNonEmptyString(lane, 'lane name'),
+    requireNonEmptyString(config?.contextGraphId, `manifest lane ${lane} contextGraphId`),
+  ]));
+}
+
+function evidenceKey(contextGraphId, subject) {
+  return `${contextGraphId}\0${subject}`;
+}
+
+function snapshotManifest(manifest) {
+  const runId = requireNonEmptyString(manifest?.runId, 'manifest runId');
+  const datasetDigest = requireNonEmptyString(manifest?.datasetDigest, 'manifest datasetDigest');
+  if (!Array.isArray(manifest?.assets)) fail('manifest assets must be an array');
+
+  const laneBindings = snapshotLaneBindings(manifest);
+  const byEvidenceKey = new Map();
+  const byLaneIndex = new Map();
+  for (const asset of manifest.assets) {
+    const lane = requireNonEmptyString(asset?.lane, 'asset lane');
+    const contextGraphId = laneBindings[lane];
+    if (!contextGraphId) fail(`asset references unknown lane ${lane}`);
+    const index = requireNonNegativeInteger(asset?.index, `${lane} asset index`);
+    const name = requireNonEmptyString(asset?.name, `${lane}:${index} asset name`);
+    const subject = requireNonEmptyString(asset?.subject, `${lane}:${index} asset subject`);
+    const tripleCount = requireNonNegativeInteger(
+      asset?.tripleCount,
+      `${lane}:${index} asset tripleCount`,
+    );
+    const expectedDigest = requireNonEmptyString(
+      asset?.expectedDigest,
+      `${lane}:${index} asset expectedDigest`,
+    );
+    const snapshot = {
+      ...asset,
+      lane,
+      index,
+      name,
+      subject,
+      tripleCount,
+      expectedDigest,
+      contextGraphId,
+    };
+    const boundKey = evidenceKey(contextGraphId, subject);
+    const ordinalKey = `${lane}\0${index}`;
+    if (byEvidenceKey.has(boundKey)) fail(`duplicate CG-bound asset ${contextGraphId} ${subject}`);
+    if (byLaneIndex.has(ordinalKey)) fail(`duplicate asset ordinal ${lane}:${index}`);
+    byEvidenceKey.set(boundKey, snapshot);
+    byLaneIndex.set(ordinalKey, snapshot);
+  }
+
+  return {
+    runId,
+    datasetDigest,
+    laneBindings,
+    assets: manifest.assets,
+    byEvidenceKey,
+    byLaneIndex,
+  };
+}
+
+function assertSame(value, expected, label, source) {
+  if (value !== expected) {
+    fail(`${source} ${label} differs from the source manifest`);
+  }
+}
+
+function validateRecoveryHeader(header, manifest, source) {
+  assertSame(header?.runId, manifest.runId, 'runId', source);
+  assertSame(header?.datasetDigest, manifest.datasetDigest, 'datasetDigest', source);
+  if (
+    !header?.contextGraphBindings
+    || typeof header.contextGraphBindings !== 'object'
+    || Array.isArray(header.contextGraphBindings)
+  ) {
+    fail(`${source} recovery_start lacks contextGraphBindings`);
+  }
+  const expectedLanes = Object.keys(manifest.laneBindings).sort();
+  const actualLanes = Object.keys(header.contextGraphBindings).sort();
+  assertSame(JSON.stringify(actualLanes), JSON.stringify(expectedLanes), 'lane set', source);
+  for (const lane of expectedLanes) {
+    assertSame(
+      header.contextGraphBindings[lane],
+      manifest.laneBindings[lane],
+      `context graph binding for ${lane}`,
+      source,
+    );
+  }
+}
+
+function validateRecoveryResult(record, manifest, source) {
+  assertSame(record?.runId, manifest.runId, 'runId', source);
+  assertSame(record?.datasetDigest, manifest.datasetDigest, 'datasetDigest', source);
+  const lane = requireNonEmptyString(record?.lane, `${source} recovery lane`);
+  const contextGraphId = requireNonEmptyString(
+    record?.contextGraphId,
+    `${source} recovery contextGraphId`,
+  );
+  assertSame(
+    contextGraphId,
+    manifest.laneBindings[lane],
+    `contextGraphId for ${lane}`,
+    source,
+  );
+
+  const subject = requireNonEmptyString(record?.subject, `${source} recovery subject`);
+  const asset = manifest.byEvidenceKey.get(evidenceKey(contextGraphId, subject));
+  if (!asset) fail(`${source} recovery row does not identify a manifest asset`);
+  for (const field of IDENTITY_FIELDS) {
+    assertSame(record[field], asset[field], `asset ${field}`, source);
+  }
+  const ordinalAsset = manifest.byLaneIndex.get(`${lane}\0${record.index}`);
+  if (ordinalAsset !== asset) fail(`${source} recovery ordinal resolves to a different asset`);
+  return asset;
+}
+
+function recoveryScore(record) {
+  return Number(record.finalized === true) * 2 + Number(record.readbackPassed === true);
+}
+
+function recoveryEvidence(record, source) {
+  const evidence = {};
+  for (const field of RECOVERY_EVIDENCE_FIELDS) {
+    if (record[field] !== undefined) evidence[field] = record[field];
+  }
+  return {
+    ...evidence,
+    evidence: Array.isArray(record.actions) && record.actions.length > 0
+      ? `recovery:${record.actions.join('+')}`
+      : 'recovery:verified-existing',
+    recoveryFile: source,
+  };
+}
+
+export function createRecoveryStartEvidence(manifest, extra = {}) {
+  const snapshot = snapshotManifest(manifest);
+  return {
+    ...extra,
+    type: 'recovery_start',
+    runId: snapshot.runId,
+    datasetDigest: snapshot.datasetDigest,
+    contextGraphBindings: { ...snapshot.laneBindings },
+  };
+}
+
+export function createRecoveryResultEvidence(manifest, asset, evidence = {}) {
+  const snapshot = snapshotManifest(manifest);
+  const sourceAsset = snapshot.byLaneIndex.get(`${asset?.lane}\0${asset?.index}`);
+  if (!sourceAsset) fail('recovery result references an unknown manifest asset');
+  const result = {
+    type: 'recovery_result',
+    runId: snapshot.runId,
+    datasetDigest: snapshot.datasetDigest,
+    contextGraphId: sourceAsset.contextGraphId,
+  };
+  for (const field of IDENTITY_FIELDS) result[field] = sourceAsset[field];
+  for (const field of RECOVERY_EVIDENCE_FIELDS) {
+    if (evidence[field] !== undefined) result[field] = evidence[field];
+  }
+  return result;
+}
+
+export function certifyMatrixEvidence({
+  manifest,
+  recoverySources,
+  certifiedAt = new Date().toISOString(),
+}) {
+  const snapshot = snapshotManifest(manifest);
+  if (!Array.isArray(recoverySources) || recoverySources.length === 0) {
+    fail('at least one recovery source is required');
+  }
+
+  const bestRecovery = new Map();
+  for (const input of recoverySources) {
+    const source = requireNonEmptyString(input?.source, 'recovery source');
+    if (!Array.isArray(input?.records)) fail(`${source} records must be an array`);
+    const headers = input.records.filter((record) => record?.type === 'recovery_start');
+    if (headers.length !== 1) fail(`${source} must contain exactly one recovery_start`);
+    validateRecoveryHeader(headers[0], snapshot, source);
+    for (const record of input.records.filter((row) => row?.type === 'recovery_result')) {
+      const asset = validateRecoveryResult(record, snapshot, source);
+      const key = evidenceKey(asset.contextGraphId, asset.subject);
+      const current = bestRecovery.get(key);
+      if (!current || recoveryScore(record) >= recoveryScore(current.record)) {
+        bestRecovery.set(key, { record, source });
+      }
+    }
+  }
+
+  const assets = snapshot.assets.map((asset) => {
+    const contextGraphId = snapshot.laneBindings[asset.lane];
+    const recovery = bestRecovery.get(evidenceKey(contextGraphId, asset.subject));
+    return recovery
+      ? { ...asset, ...recoveryEvidence(recovery.record, recovery.source) }
+      : { ...asset, evidence: 'first-attempt' };
+  });
+
+  const byLane = Object.fromEntries(Object.keys(snapshot.laneBindings).map((lane) => {
+    const selected = assets.filter((asset) => asset.lane === lane);
+    return [lane, {
+      contextGraphId: snapshot.laneBindings[lane],
+      expectedAssets: selected.length,
+      expectedTriples: selected.reduce((sum, asset) => sum + asset.tripleCount, 0),
+      chainFinalized: selected.filter((asset) => asset.finalized === true).length,
+      publisherExactReadback: selected.filter((asset) => asset.readbackPassed === true).length,
+      unresolvedIndexes: selected
+        .filter((asset) => asset.finalized !== true || asset.readbackPassed !== true)
+        .map((asset) => asset.index),
+    }];
+  }));
+  const unresolved = assets
+    .filter((asset) => asset.finalized !== true || asset.readbackPassed !== true)
+    .map((asset) => ({
+      lane: asset.lane,
+      index: asset.index,
+      name: asset.name,
+      subject: asset.subject,
+      contextGraphId: snapshot.laneBindings[asset.lane],
+      ual: asset.ual,
+      finalized: asset.finalized,
+      readbackPassed: asset.readbackPassed,
+      evidence: asset.evidence,
+      finalStatus: asset.finalStatus,
+      finalMemoryLayer: asset.finalMemoryLayer,
+    }));
+
+  return {
+    ...manifest,
+    schemaVersion: Math.max(Number(manifest.schemaVersion) || 0, 3),
+    certifiedAt,
+    recoveryFiles: recoverySources.map((source) => source.source),
+    firstAttemptPublicationSummary: manifest.publicationSummary,
+    assets,
+    certificationSummary: {
+      expectedAssets: assets.length,
+      expectedTriples: assets.reduce((sum, asset) => sum + asset.tripleCount, 0),
+      chainFinalized: assets.filter((asset) => asset.finalized === true).length,
+      publisherExactReadback: assets.filter((asset) => asset.readbackPassed === true).length,
+      byLane,
+      unresolved,
+    },
+  };
+}

--- a/scripts/rfc64-matrix-evidence/certification.test.mjs
+++ b/scripts/rfc64-matrix-evidence/certification.test.mjs
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  certifyMatrixEvidence,
+  createRecoveryResultEvidence,
+  createRecoveryStartEvidence,
+} from './certification.mjs';
+
+function fixtureManifest() {
+  return {
+    schemaVersion: 1,
+    runId: 'run-a',
+    datasetDigest: 'dataset-a',
+    lanes: {
+      'public-open': {
+        contextGraphId: '0xabc/run-a-public-open',
+      },
+      'private-curated': {
+        contextGraphId: '0xabc/run-a-private-curated',
+      },
+    },
+    assets: [
+      {
+        lane: 'public-open',
+        index: 0,
+        name: 'run-a-public-open-0',
+        subject: 'urn:run-a:public-open:0',
+        tripleCount: 101,
+        expectedDigest: 'digest-public',
+        finalized: false,
+        readbackPassed: false,
+      },
+      {
+        lane: 'private-curated',
+        index: 0,
+        name: 'run-a-private-curated-0',
+        subject: 'urn:run-a:private-curated:0',
+        tripleCount: 202,
+        expectedDigest: 'digest-private',
+        finalized: true,
+        readbackPassed: true,
+      },
+    ],
+    publicationSummary: {
+      expectedAssets: 2,
+    },
+  };
+}
+
+function source(manifest, asset = manifest.assets[0], evidence = {}) {
+  return {
+    source: 'recovery.jsonl',
+    records: [
+      createRecoveryStartEvidence(manifest),
+      createRecoveryResultEvidence(manifest, asset, evidence),
+    ],
+  };
+}
+
+test('merges only CG-bound recovery evidence and preserves manifest identity', () => {
+  const manifest = fixtureManifest();
+  const certified = certifyMatrixEvidence({
+    manifest,
+    recoverySources: [source(manifest, manifest.assets[0], {
+      finalized: true,
+      readbackPassed: true,
+      actions: ['publish'],
+      txHash: '0x1234',
+    })],
+    certifiedAt: '2026-07-24T00:00:00.000Z',
+  });
+
+  assert.equal(certified.schemaVersion, 3);
+  assert.equal(certified.assets[0].name, manifest.assets[0].name);
+  assert.equal(certified.assets[0].subject, manifest.assets[0].subject);
+  assert.equal(certified.assets[0].finalized, true);
+  assert.equal(certified.assets[0].readbackPassed, true);
+  assert.equal(certified.assets[0].evidence, 'recovery:publish');
+  assert.equal(certified.certificationSummary.chainFinalized, 2);
+  assert.equal(certified.certificationSummary.publisherExactReadback, 2);
+  assert.equal(
+    certified.certificationSummary.byLane['public-open'].contextGraphId,
+    manifest.lanes['public-open'].contextGraphId,
+  );
+});
+
+test('rejects a recovery file from another run even when lane and index collide', () => {
+  const manifest = fixtureManifest();
+  const recovery = source(manifest);
+  recovery.records[0].runId = 'run-b';
+  recovery.records[1].runId = 'run-b';
+
+  assert.throws(
+    () => certifyMatrixEvidence({ manifest, recoverySources: [recovery] }),
+    /runId differs from the source manifest/,
+  );
+});
+
+test('rejects a recovery file with a different dataset digest', () => {
+  const manifest = fixtureManifest();
+  const recovery = source(manifest);
+  recovery.records[0].datasetDigest = 'dataset-b';
+
+  assert.throws(
+    () => certifyMatrixEvidence({ manifest, recoverySources: [recovery] }),
+    /datasetDigest differs from the source manifest/,
+  );
+});
+
+test('rejects a recovery header whose lane points at another context graph', () => {
+  const manifest = fixtureManifest();
+  const recovery = source(manifest);
+  recovery.records[0].contextGraphBindings['public-open'] = '0xabc/other-public-open';
+
+  assert.throws(
+    () => certifyMatrixEvidence({ manifest, recoverySources: [recovery] }),
+    /context graph binding for public-open differs/,
+  );
+});
+
+test('rejects a recovery row whose context graph differs from its manifest lane', () => {
+  const manifest = fixtureManifest();
+  const recovery = source(manifest);
+  recovery.records[1].contextGraphId = manifest.lanes['private-curated'].contextGraphId;
+
+  assert.throws(
+    () => certifyMatrixEvidence({ manifest, recoverySources: [recovery] }),
+    /contextGraphId for public-open differs/,
+  );
+});
+
+test('rejects cross-asset evidence even within the same run and context graph', () => {
+  const manifest = fixtureManifest();
+  const recovery = source(manifest);
+  recovery.records[1].subject = 'urn:run-a:public-open:attacker';
+
+  assert.throws(
+    () => certifyMatrixEvidence({ manifest, recoverySources: [recovery] }),
+    /does not identify a manifest asset/,
+  );
+});
+
+test('rejects recovery JSON that tries to replace immutable identity', () => {
+  const manifest = fixtureManifest();
+  const recovery = source(manifest);
+  recovery.records[1].expectedDigest = 'attacker-digest';
+
+  assert.throws(
+    () => certifyMatrixEvidence({ manifest, recoverySources: [recovery] }),
+    /asset expectedDigest differs/,
+  );
+});
+
+test('requires one CG-bound recovery_start per recovery file', () => {
+  const manifest = fixtureManifest();
+  const recovery = source(manifest);
+  recovery.records.shift();
+
+  assert.throws(
+    () => certifyMatrixEvidence({ manifest, recoverySources: [recovery] }),
+    /must contain exactly one recovery_start/,
+  );
+});
+
+test('selects the strongest valid recovery without mixing asset identities', () => {
+  const manifest = fixtureManifest();
+  const first = source(manifest, manifest.assets[0], {
+    finalized: true,
+    readbackPassed: false,
+    actions: ['chain-already-minted'],
+  });
+  first.source = 'first.jsonl';
+  const second = source(manifest, manifest.assets[0], {
+    finalized: true,
+    readbackPassed: true,
+    actions: ['verified-readback'],
+  });
+  second.source = 'second.jsonl';
+
+  const certified = certifyMatrixEvidence({
+    manifest,
+    recoverySources: [first, second],
+  });
+  assert.equal(certified.assets[0].recoveryFile, 'second.jsonl');
+  assert.equal(certified.assets[0].evidence, 'recovery:verified-readback');
+});

--- a/scripts/rfc64-matrix-evidence/certify.mjs
+++ b/scripts/rfc64-matrix-evidence/certify.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { certifyMatrixEvidence } from './certification.mjs';
+
+const arg = (name) => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+
+const manifestArgument = arg('--manifest');
+const outputArgument = arg('--output');
+const recoveryArguments = process.argv.flatMap((value, index, values) => (
+  value === '--recovery' && values[index + 1] ? [values[index + 1]] : []
+));
+if (!manifestArgument) throw new Error('--manifest is required');
+if (!outputArgument) throw new Error('--output is required');
+if (recoveryArguments.length === 0) throw new Error('at least one --recovery is required');
+
+const manifestFile = resolve(manifestArgument);
+const outputFile = resolve(outputArgument);
+const manifest = JSON.parse(readFileSync(manifestFile, 'utf8'));
+const recoverySources = recoveryArguments.map((argument) => {
+  const source = resolve(argument);
+  const records = readFileSync(source, 'utf8')
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  return { source, records };
+});
+
+const certified = certifyMatrixEvidence({ manifest, recoverySources });
+writeFileSync(outputFile, `${JSON.stringify(certified, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify({
+  outputFile,
+  datasetDigest: certified.datasetDigest,
+  summary: certified.certificationSummary,
+}, null, 2)}\n`);


### PR DESCRIPTION
## Summary

- add a fail-closed RFC-64 matrix evidence certifier for first-attempt plus recovery results
- bind every recovery file to the manifest run ID, dataset digest, and exact lane-to-Context-Graph mapping
- bind every recovery row to its Context Graph, subject, lane/index, name, triple count, and content digest
- whitelist recovery evidence fields so recovery JSON cannot replace immutable manifest identity

## Problem

The ad-hoc testnet certifier keyed recovery rows only by lane:index. Those ordinals repeat across runs, so supplying a recovery JSONL from another run could silently change the certified totals. This is a harness accounting false-positive, not a DKG runtime failure.

## Validation

- node --test scripts/rfc64-matrix-evidence/certification.test.mjs: 9 passed, 0 failed
- adversarial coverage rejects cross-run lane/index collisions, dataset mismatch, CG mismatch, cross-asset rows, identity replacement, and unbound recovery files
- synthetic active-harness check: correctly bound evidence certifies; historical unbound recovery evidence fails closed
- node syntax checks and git diff check passed

## Operational scope

Harness-only change based directly on testnet-canary at 1dba8f5e7b12680a267356dae9e5eb944248436a. No node code, configuration, deployment, restart, or branch merge is included.