### PR TITLE
fix(sync): route agents phonebook through paged legacy lane

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4500,6 +4500,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const legacyCgs: string[] = [];
     const work = [];
     for (const contextGraphId of contextGraphIds) {
+      // The agents phonebook is one continually growing data graph. Changelog
+      // upserts are graph-atomic, so once that graph exceeds the router's frame
+      // cap every delta attempt transfers an oversized response and then falls
+      // back to legacy anyway. Route it directly to the row-paged legacy lane.
+      if (contextGraphId === SYSTEM_CONTEXT_GRAPHS.AGENTS) {
+        legacyCgs.push(contextGraphId);
+        continue;
+      }
       if (await this.isPrivateContextGraph(contextGraphId)) {
         legacyCgs.push(contextGraphId);
         continue;

--- a/packages/agent/test/sync-requester-priority.test.ts
+++ b/packages/agent/test/sync-requester-priority.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { createOperationContext, PROTOCOL_SYNC_CHANGELOG } from '@origintrail-official/dkg-core';
+import {
+  createOperationContext,
+  PROTOCOL_SYNC_CHANGELOG,
+  SYSTEM_CONTEXT_GRAPHS,
+} from '@origintrail-official/dkg-core';
 import { runDurableSync } from '../src/sync/requester/durable-sync.js';
 import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
 import { runOrderedContextGraphSyncs } from '../src/sync/requester/ordered-sync.js';
@@ -202,6 +206,67 @@ describe('requester per-CG priority admission', () => {
     expect(lane.result.completedPhases).toBe(1);
     expect(lane.result.deferredBackpressure).toBe(1);
     expect(lane.remainingLegacyCgs).toEqual([]);
+  });
+
+  it('routes the growing agents phonebook directly to row-paged legacy sync', async () => {
+    const admissions: string[] = [];
+    const changelogRuns: string[] = [];
+    const emptyResult = {
+      insertedTriples: 0,
+      fetchedMetaTriples: 0,
+      fetchedDataTriples: 0,
+      insertedMetaTriples: 0,
+      insertedDataTriples: 0,
+      bytesReceived: 0,
+      resumedPhases: 0,
+      timedOutPhases: 0,
+      completedPhases: 1,
+      checkpointAdvances: 0,
+      emptyResponses: 0,
+      metaOnlyResponses: 0,
+      dataRejectedMissingMeta: 0,
+      rejectedKcs: 0,
+      failedPeers: 0,
+      failedPhases: 0,
+      deniedPhases: 0,
+      backoffWorthyFailures: 0,
+      deferredBackpressure: 0,
+    };
+    const agent = {
+      config: { syncContextGraphPriorities: {} },
+      getPeerProtocols: async () => [PROTOCOL_SYNC_CHANGELOG],
+      isPrivateContextGraph: async () => false,
+      runContextGraphSyncWithBackpressure: async (
+        _ctx: unknown,
+        contextGraphId: string,
+        _lane: string,
+        _label: string,
+        work: () => Promise<unknown>,
+      ) => {
+        admissions.push(contextGraphId);
+        return work();
+      },
+      runChangelogSyncForCg: async (
+        _ctx: unknown,
+        _peer: string,
+        contextGraphId: string,
+      ) => {
+        changelogRuns.push(contextGraphId);
+        return emptyResult;
+      },
+      log: { info: noop, warn: noop },
+    };
+
+    const lane = await (LifecycleSyncMethods.prototype.runChangelogLane as any).call(
+      agent,
+      ctx,
+      'peer',
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'public-cg'],
+    );
+
+    expect(admissions).toEqual([SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'public-cg']);
+    expect(changelogRuns).toEqual([SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'public-cg']);
+    expect(lane.remainingLegacyCgs).toEqual([SYSTEM_CONTEXT_GRAPHS.AGENTS]);
   });
 
   it('preserves completed shared-memory progress when a later admission is deferred', async () => {


### PR DESCRIPTION
## Problem

The testnet hotfix soak repeatedly receives an agents changelog response larger than the ProtocolRouter 10 MiB read cap. The agents phonebook is one continually growing graph, while changelog upserts are graph-atomic. Every attempt therefore transfers an oversized response, fails, and falls back to legacy sync, consuming sync admission and contributing to queue bursts.

Live evidence on the local testnet edge node:

- 2 agents changelog read-limit failures in the 20-minute observation window
- 14 bounded sync-backpressure rejections in the same window
- publisher remained healthy at 880 finalized and 0 failed

## Change

Route only SYSTEM_CONTEXT_GRAPHS.AGENTS directly to the existing row-paged legacy lane. Other public CGs, including ontology, continue using changelog sync. Private CG behavior is unchanged.

This does not disable agents phonebook synchronization and does not raise the transport memory limit.

## Verification

- agent dependency build, type tests, and package-root test: pass
- focused sync-requester-priority: 9 passed
- full agent unit lane: 139 files, 1789 passed, 5 skipped, 0 failed

## Rollout boundary

Targets testnet-canary. Draft only. Do not merge until review and canary validation. No core rollout is authorized by this PR.