### PR TITLE
fix(sync): damp metadata-pending VM reconcile scans

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -900,6 +900,17 @@ export class DKGAgentBase {
     Math.max(5_000, DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS);
   static readonly VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS =
     Number(process.env['DKG_VM_RECONCILE_BACKOFF_MAX_MS']) || 10 * 60_000;
+  // Metadata-pending assets already have exact VM content; only transaction
+  // provenance is missing. Keep their retry history on a longer bounded curve
+  // so a loaded node can finish a full subscribed-CG traversal before retrying
+  // unchanged historical gaps. New local evidence, chain roots, and recovery
+  // topology still invalidate these entries immediately.
+  static readonly VM_RECONCILE_METADATA_PENDING_BACKOFF_MAX_MS =
+    Math.max(
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+      Number(process.env['DKG_VM_RECONCILE_METADATA_PENDING_BACKOFF_MAX_MS'])
+        || 60 * 60_000,
+    );
   static readonly VM_RECONCILE_CACHE_MAX_ENTRIES =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CACHE_MAX_ENTRIES']) || 1_000);
   static readonly VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS =

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3491,16 +3491,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const failures = (previous?.failures ?? 0) + 1;
     // Metadata-pending means the exact VM payload is already present but its
     // transaction provenance is not. On a loaded node, a full subscribed-CG
-    // traversal can exceed the one-minute sweep cadence, so a cadence-sized
-    // first backoff expires before the cursor wraps and provides no damping.
-    // New local evidence and connected-peer topology changes already invalidate
-    // this cache immediately; use the bounded ceiling for the timer-only
-    // fallback so unchanged historical gaps are not re-scanned every traversal.
+    // traversal can exceed the ordinary ten-minute negative-cache ceiling.
+    // Start metadata-pending retries at that ceiling, but let their retained
+    // retry history grow toward a separate one-hour bound. New local evidence,
+    // chain roots, and connected-peer topology changes still invalidate the
+    // entry immediately, so this only damps unchanged historical gaps.
     const backoffBase = reason === 'metadata_pending'
       ? DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS
       : DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS;
+    const backoffMax = reason === 'metadata_pending'
+      ? DKGAgentBase.VM_RECONCILE_METADATA_PENDING_BACKOFF_MAX_MS
+      : DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
     const exponentialBackoff = Math.min(
-      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+      backoffMax,
       backoffBase * 2 ** Math.max(0, failures - 1),
     );
     const jitterSample = createHash('sha256')
@@ -3508,7 +3511,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       .digest()
       .readUInt32BE(0) / 0x1_0000_0000;
     const backoff = Math.min(
-      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+      backoffMax,
       Math.max(1, Math.round(exponentialBackoff * (0.8 + jitterSample * 0.4))),
     );
     getMetrics().storeRetryAttemptsTotal.add(1, {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -420,6 +420,11 @@ type VmReconcileOrdinalOptions = {
   isTargetCurrent?: () => boolean;
   /** Collect the missing KA for one batch fetch instead of fetching inline. */
   deferActiveFetch?: boolean;
+  /**
+   * Revalidate immediately after an exact batch fetch even when the initial
+   * scan recorded a generation-gated miss for this UAL.
+   */
+  bypassNegativeCache?: boolean;
 };
 
 /**
@@ -3377,6 +3382,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
   async shouldDeferVmReconcileByNegativeCache(this: DKGAgent,
     cacheKey: string,
     localCgId: string,
+    options: { primeConnections?: boolean } = {},
   ): Promise<boolean> {
     let cached = this.vmReconcileNegativeCache.get(cacheKey);
     if (!cached && !this.vmReconcileNegativeCacheHydrated.has(cacheKey)) {
@@ -3420,11 +3426,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (Date.now() >= cached.nextRetryAt) return false;
 
     try {
-      try {
-        await this.primeCatchupConnections();
-      } catch {
-        // Best effort only; an unchanged connection view can still honor the
-        // cached miss until the backoff expires.
+      if (options.primeConnections !== false) {
+        try {
+          await this.primeCatchupConnections();
+        } catch {
+          // Best effort only; an unchanged connection view can still honor the
+          // cached miss until the backoff expires.
+        }
       }
       if (await this.vmReconcilePeerTopologyKey(localCgId) !== cached.peerTopologyKey) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
@@ -3472,6 +3480,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     cacheKey: string,
     localCgId: string,
     state: VmReconcileSwmCandidateState,
+    reason: 'no_swm' | 'metadata_pending' = 'no_swm',
   ): void {
     if (state.swmGen === null) {
       this.deleteVmReconcileNegativeCacheEntry(cacheKey);
@@ -3494,7 +3503,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     );
     getMetrics().storeRetryAttemptsTotal.add(1, {
       scope: 'vm_reconcile',
-      reason: 'no_swm',
+      reason,
       attempt: Math.min(failures, 16),
     });
     if (previous) {
@@ -3672,13 +3681,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const ctx = createOperationContext('system');
     if (!isTargetCurrent() || targets.length === 0) return new Map();
 
-    // Damping: the batched path deliberately skips the per-UAL negative cache
-    // (consulting it primes connections to every discovered agent — the walk
-    // this path exists to avoid), so the per-CG active-fetch cooldown is the
-    // only damper between this batch and the network. A wholly unproductive
-    // batch (e.g. the curator is offline) therefore costs one bounded exact
-    // fetch per sweep interval, not one per reconcile pass. Progress clears
-    // the cooldown below so a draining backlog proceeds slice after slice.
+    // Damping: the initial scan records and consults per-UAL generation-gated
+    // misses without priming connections. This per-CG active-fetch cooldown is
+    // a second network-side guard within the current sweep. A wholly
+    // unproductive batch (e.g. the curator is offline) therefore costs one
+    // bounded exact fetch per sweep interval, not one per reconcile pass.
+    // Progress clears the cooldown below so a draining backlog proceeds slice
+    // after slice.
     if (!this.shouldRunVmReconcileActiveFetch(localCgId)) {
       this.log.info(ctx, `VM exact fetch for "${localCgId}" skipped by per-CG cooldown`);
       return new Map();
@@ -3787,7 +3796,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
           onChainCgId,
           target.ordinal,
           headBlock,
-          { isTargetCurrent, deferActiveFetch: true },
+          {
+            isTargetCurrent,
+            deferActiveFetch: true,
+            // The initial scan records a generation-gated miss before the
+            // network request. A response may have supplied the missing
+            // provenance, so this one same-pass verification must bypass it.
+            bypassNegativeCache: true,
+          },
         );
         outcomes.set(target.ordinal, outcome);
         if (outcome.status === 'pending' && outcome.recovery) {
@@ -3853,7 +3869,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // cursor advances without redoing chain reads + an SWM scan.
       if (this.recentReconciledUals.has(cacheKey)) return { status: 'already', blockNumber: versionBlock };
 
-      if (!options.deferActiveFetch && await this.shouldDeferVmReconcileByNegativeCache(cacheKey, localCgId)) {
+      if (
+        !options.bypassNegativeCache
+        && await this.shouldDeferVmReconcileByNegativeCache(
+          cacheKey,
+          localCgId,
+          // Batched exact recovery deliberately avoids a DHT-wide connection
+          // prime. The cache still fails open when the already-connected
+          // recovery topology or local generation changes, and on expiry.
+          { primeConnections: !options.deferActiveFetch },
+        )
+      ) {
         this.emitReplication({
           contextGraphId: localCgId,
           onChainCgId: onChainCgId.toString(),
@@ -3895,6 +3921,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
     let outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
     if (outcome === 'no-swm' || outcome === 'verified-vm-metadata-pending') {
       if (options.deferActiveFetch) {
+        if (!options.bypassNegativeCache) {
+          this.recordVmReconcileNegativeCache(
+            cacheKey,
+            localCgId,
+            await this.collectVmReconcileSwmCandidateState(localCgId),
+            outcome === 'verified-vm-metadata-pending' ? 'metadata_pending' : 'no_swm',
+          );
+        }
         this.emitReplication({
           contextGraphId: localCgId,
           onChainCgId: onChainCgId.toString(),
@@ -4019,6 +4053,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return { status: 'already', blockNumber: versionBlock };
       case 'no-swm':
+      case 'verified-vm-metadata-pending':
         if (activeFetchRan && !activeFetchHadUsableResponse) {
           this.vmReconcileFetchCooldownAt.delete(localCgId);
         } else {
@@ -4026,6 +4061,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
             cacheKey,
             localCgId,
             swmState ?? await this.collectVmReconcileSwmCandidateState(localCgId),
+            outcome === 'verified-vm-metadata-pending' ? 'metadata_pending' : 'no_swm',
           );
         }
         this.emitReplication({

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3328,7 +3328,34 @@ export class SwmHostModeMethods extends DKGAgentBase {
     });
   }
 
+  vmReconcileLocalWriteGen(this: DKGAgent,
+    candidateNamespaces: VmReconcileSwmNamespace[],
+  ): string | null {
+    const rootDataGraph = candidateNamespaces[0]?.dataGraph;
+    if (!rootDataGraph) return null;
+    const swmSuffix = rootDataGraph.indexOf('/_shared_memory');
+    const graphPrefix = swmSuffix >= 0
+      ? `${rootDataGraph.slice(0, swmSuffix)}/`
+      : rootDataGraph;
+    const writeGen = asGraphWriteGenSource(this.store)?.getWriteGen(graphPrefix);
+    return writeGen === undefined ? null : `local-write-gen:${writeGen}`;
+  }
+
+  async readVmReconcileSwmGenForCachedMode(this: DKGAgent,
+    cachedSwmGen: string,
+    candidateNamespaces: VmReconcileSwmNamespace[],
+  ): Promise<string | null> {
+    if (cachedSwmGen.startsWith('local-write-gen:')) {
+      return this.vmReconcileLocalWriteGen(candidateNamespaces);
+    }
+    return this.readVmReconcileSwmGen(candidateNamespaces);
+  }
+
   vmReconcileSwmGenSupportsDurableNegative(this: DKGAgent, swmGen: string): boolean {
+    // The per-CG write generation is deliberately process-local: it prevents
+    // unrelated CG writes from invalidating a metadata-pending backoff, while a
+    // daemon restart drops the accelerator and performs an authoritative scan.
+    if (swmGen.startsWith('local-write-gen:')) return false;
     // A changelog cursor covers every descendant graph mutation. The fallback
     // fingerprint covers only the bare SWM bucket, so an operation whose data
     // later lands in a per-KA child graph must fail open after restart.
@@ -3444,7 +3471,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const cachedNamespaceKey = this.vmReconcileSwmNamespaceKey(cached.candidateNamespaces);
       if (currentNamespaceKey !== cachedNamespaceKey) {
         if (!currentNamespaces.complete) {
-          const currentSwmGen = await this.readVmReconcileSwmGen(currentNamespaces.namespaces);
+          const currentSwmGen = await this.readVmReconcileSwmGenForCachedMode(
+            cached.swmGen,
+            currentNamespaces.namespaces,
+          );
           if (currentSwmGen === null) {
             this.deleteVmReconcileNegativeCacheEntry(cacheKey);
             return false;
@@ -3460,7 +3490,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
       }
       const pattern = this.vmReconcileWorkspaceOperationPattern(currentNamespaces.namespaces.map((namespace) => namespace.metaGraph));
       if (!pattern) return true;
-      const currentSwmGen = await this.readVmReconcileSwmGen(currentNamespaces.namespaces);
+      const currentSwmGen = await this.readVmReconcileSwmGenForCachedMode(
+        cached.swmGen,
+        currentNamespaces.namespaces,
+      );
       if (currentSwmGen === null) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return false;
@@ -3531,7 +3564,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
       localCgId,
       failures,
       nextRetryAt: Date.now() + backoff,
-      swmGen: state.swmGen,
+      // The node-global changelog head advances for every CG and made a loaded
+      // node invalidate all metadata-pending misses continuously. Prefer the
+      // adapter's per-CG write generation for this process-local accelerator;
+      // target-CG writes still invalidate immediately, while unrelated writes
+      // no longer trigger repeated exact fetches.
+      swmGen: reason === 'metadata_pending'
+        ? this.vmReconcileLocalWriteGen(state.candidateNamespaces) ?? state.swmGen
+        : state.swmGen,
       candidateNamespaces: state.candidateNamespaces,
       peerTopologyKey: state.peerTopologyKey,
     };

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3489,9 +3489,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this.pruneVmReconcileState();
     const previous = this.vmReconcileNegativeCache.get(cacheKey);
     const failures = (previous?.failures ?? 0) + 1;
+    // Metadata-pending means the exact VM payload is already present but its
+    // transaction provenance is not. On a loaded node, a full subscribed-CG
+    // traversal can exceed the one-minute sweep cadence, so a cadence-sized
+    // first backoff expires before the cursor wraps and provides no damping.
+    // New local evidence and connected-peer topology changes already invalidate
+    // this cache immediately; use the bounded ceiling for the timer-only
+    // fallback so unchanged historical gaps are not re-scanned every traversal.
+    const backoffBase = reason === 'metadata_pending'
+      ? DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS
+      : DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS;
     const exponentialBackoff = Math.min(
       DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
-      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS * 2 ** Math.max(0, failures - 1),
+      backoffBase * 2 ** Math.max(0, failures - 1),
     );
     const jitterSample = createHash('sha256')
       .update(`${this.node.peerId.toString()}\0${cacheKey}\0${failures}`)

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -1249,7 +1249,15 @@ describe('Phase D - VM reconcile damping', () => {
       recovery: { reason: 'verified-vm-metadata-pending' },
     });
     expect(handleChainReconciledKC.calls).toHaveLength(1);
-    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+    const metadataPendingCache =
+      (internals as any).vmReconcileNegativeCache as Map<string, { nextRetryAt: number }>;
+    expect(metadataPendingCache.size).toBe(1);
+    const metadataPendingRetryDelay =
+      [...metadataPendingCache.values()][0]!.nextRetryAt - Date.now();
+    // A loaded node can take several minutes to traverse all subscribed CGs.
+    // Pin a first retry horizon that survives that traversal; local generation
+    // or connected-peer topology changes still invalidate it immediately.
+    expect(metadataPendingRetryDelay).toBeGreaterThan(4 * 60_000);
 
     await expect(internals.reconcileChainOrdinal(
       '68',

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -1250,14 +1250,41 @@ describe('Phase D - VM reconcile damping', () => {
     });
     expect(handleChainReconciledKC.calls).toHaveLength(1);
     const metadataPendingCache =
-      (internals as any).vmReconcileNegativeCache as Map<string, { nextRetryAt: number }>;
+      (internals as any).vmReconcileNegativeCache as Map<string, {
+        failures: number;
+        nextRetryAt: number;
+        swmGen: string;
+        candidateNamespaces: Array<{ metaGraph: string; dataGraph: string }>;
+        peerTopologyKey: string;
+      }>;
     expect(metadataPendingCache.size).toBe(1);
+    const [metadataPendingKey, firstMetadataPending] =
+      [...metadataPendingCache.entries()][0]!;
     const metadataPendingRetryDelay =
-      [...metadataPendingCache.values()][0]!.nextRetryAt - Date.now();
+      firstMetadataPending.nextRetryAt - Date.now();
     // A loaded node can take several minutes to traverse all subscribed CGs.
     // Pin a first retry horizon that survives that traversal; local generation
     // or connected-peer topology changes still invalidate it immediately.
     expect(metadataPendingRetryDelay).toBeGreaterThan(4 * 60_000);
+
+    // Retained retry history must actually grow beyond the ordinary ten-minute
+    // ceiling. Otherwise a traversal longer than that ceiling re-runs the same
+    // unchanged historical gaps forever without ever reaching a cache hit.
+    firstMetadataPending.nextRetryAt = Date.now() - 1;
+    (internals as any).recordVmReconcileNegativeCache(
+      metadataPendingKey,
+      '68',
+      {
+        swmGen: firstMetadataPending.swmGen,
+        candidateNamespaces: firstMetadataPending.candidateNamespaces,
+        peerTopologyKey: firstMetadataPending.peerTopologyKey,
+      },
+      'metadata_pending',
+    );
+    const secondMetadataPending = metadataPendingCache.get(metadataPendingKey)!;
+    expect(secondMetadataPending.failures).toBe(2);
+    expect(secondMetadataPending.nextRetryAt - Date.now())
+      .toBeGreaterThan(metadataPendingRetryDelay);
 
     await expect(internals.reconcileChainOrdinal(
       '68',

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -1260,6 +1260,7 @@ describe('Phase D - VM reconcile damping', () => {
     expect(metadataPendingCache.size).toBe(1);
     const [metadataPendingKey, firstMetadataPending] =
       [...metadataPendingCache.entries()][0]!;
+    expect(firstMetadataPending.swmGen).toMatch(/^local-write-gen:\d+$/);
     const metadataPendingRetryDelay =
       firstMetadataPending.nextRetryAt - Date.now();
     // A loaded node can take several minutes to traverse all subscribed CGs.
@@ -1285,6 +1286,15 @@ describe('Phase D - VM reconcile damping', () => {
     expect(secondMetadataPending.failures).toBe(2);
     expect(secondMetadataPending.nextRetryAt - Date.now())
       .toBeGreaterThan(metadataPendingRetryDelay);
+
+    // Activity in another CG advances the node-global changelog but must not
+    // invalidate a miss whose target CG has not changed.
+    await internals.store.insert([{
+      subject: 'urn:test:unrelated-activity',
+      predicate: 'http://schema.org/name',
+      object: '"unrelated local evidence"',
+      graph: contextGraphWorkspaceMetaGraphUri('unrelated-cg'),
+    }]);
 
     await expect(internals.reconcileChainOrdinal(
       '68',

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -68,6 +68,7 @@ interface AgentInternals {
       maxPeerAttempts?: number;
       isTargetCurrent?: () => boolean;
       deferActiveFetch?: boolean;
+      bypassNegativeCache?: boolean;
     },
   ): Promise<{ status: string }>;
   recoverVmReconcileBatch(
@@ -1217,6 +1218,109 @@ describe('Phase D - VM reconcile damping', () => {
 
     expect(fetch.calls).toHaveLength(1);
     expect(handleChainReconciledKC.calls).toHaveLength(2);
+  });
+
+  it('generation-gates unchanged metadata-pending batch scans without priming connections', async () => {
+    const internals = await boot();
+    const onChainCgId = 68n;
+    const root = new Uint8Array(32);
+    root[31] = 68;
+    registerUnmatchedKC(internals.chain, 9068n, onChainCgId, bytesToHex(root));
+
+    const handleChainReconciledKC = recorder(async () =>
+      'verified-vm-metadata-pending' as const);
+    (internals as any).getOrCreateFinalizationHandler = recorder(() => ({
+      handleChainReconciledKC,
+    }));
+    const primeCatchupConnections = recorder(async () => {
+      throw new Error('batched negative-cache checks must not dial discovered agents');
+    });
+    (internals as any).primeCatchupConnections = primeCatchupConnections;
+
+    const first = await internals.reconcileChainOrdinal(
+      '68',
+      onChainCgId,
+      0,
+      undefined,
+      { deferActiveFetch: true },
+    );
+    expect(first).toMatchObject({
+      status: 'pending',
+      recovery: { reason: 'verified-vm-metadata-pending' },
+    });
+    expect(handleChainReconciledKC.calls).toHaveLength(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    await expect(internals.reconcileChainOrdinal(
+      '68',
+      onChainCgId,
+      0,
+      undefined,
+      { deferActiveFetch: true },
+    )).resolves.toEqual({ status: 'pending' });
+    expect(handleChainReconciledKC.calls).toHaveLength(1);
+    expect(primeCatchupConnections.calls).toHaveLength(0);
+
+    await internals.store.insert([{
+      subject: 'urn:test:metadata-arrived',
+      predicate: 'http://schema.org/name',
+      object: '"new local evidence"',
+      graph: contextGraphWorkspaceMetaGraphUri('68'),
+    }]);
+
+    const afterWrite = await internals.reconcileChainOrdinal(
+      '68',
+      onChainCgId,
+      0,
+      undefined,
+      { deferActiveFetch: true },
+    );
+    expect(afterWrite).toMatchObject({
+      status: 'pending',
+      recovery: { reason: 'verified-vm-metadata-pending' },
+    });
+    expect(handleChainReconciledKC.calls).toHaveLength(2);
+    expect(primeCatchupConnections.calls).toHaveLength(0);
+  });
+
+  it('bypasses a metadata-pending miss for same-pass exact-fetch revalidation', async () => {
+    const internals = await boot();
+    const onChainCgId = 69n;
+    const root = new Uint8Array(32);
+    root[31] = 69;
+    registerUnmatchedKC(internals.chain, 9069n, onChainCgId, bytesToHex(root));
+
+    let attempts = 0;
+    const handleChainReconciledKC = recorder(async () => {
+      attempts += 1;
+      return attempts === 1
+        ? 'verified-vm-metadata-pending' as const
+        : 'already-confirmed' as const;
+    });
+    (internals as any).getOrCreateFinalizationHandler = recorder(() => ({
+      handleChainReconciledKC,
+    }));
+
+    await expect(internals.reconcileChainOrdinal(
+      '69',
+      onChainCgId,
+      0,
+      undefined,
+      { deferActiveFetch: true },
+    )).resolves.toMatchObject({
+      status: 'pending',
+      recovery: { reason: 'verified-vm-metadata-pending' },
+    });
+
+    await expect(internals.reconcileChainOrdinal(
+      '69',
+      onChainCgId,
+      0,
+      undefined,
+      { deferActiveFetch: true, bypassNegativeCache: true },
+    )).resolves.toEqual({ status: 'already', blockNumber: 0 });
+    expect(handleChainReconciledKC.calls).toHaveLength(2);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
   it('retries an incomplete SWM operation when data changes without triple-count changes', async () => {


### PR DESCRIPTION
## What

- apply the existing generation/topology-gated negative cache to batched VM reconciliation misses
- avoid DHT-wide connection priming while scanning batched exact-recovery targets
- revalidate once immediately after an exact fetch, then clear or refresh the cache from the authoritative result
- distinguish no-SWM and metadata-pending retry metrics

## Why

A node with historical VM content but missing transaction provenance repeatedly re-ran the same expensive metadata verification for every sweep slice. On the local testnet edge this produced hundreds of identical cannot-repair-without-provenance attempts even though neither local evidence nor connected recovery peers had changed.

The cache remains fail-open: a local graph generation change, recovery-peer topology change, or bounded expiry causes an authoritative retry. It never synthesizes provenance and never promotes unverifiable VM state.

## Validation

- `pnpm --filter @origintrail-official/dkg-agent build`
- agent unit lane: 144 files passed; 1,888 tests passed; 5 skipped; 0 failed
- focused VM reconcile lane: 69 tests passed

Live local-node validation will be added before this draft is marked ready. No core rollout is authorized by this PR.