### PR TITLE
fix(agent): byte-bound public exact sync responses

### DIFF
--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -997,6 +997,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     let sinceBatchId: string | undefined;
     let syncSessionId: string | undefined;
     let assetUals: string[] | undefined;
+    let pageMode: typeof SYNC_BYTE_BUDGET_PAGE_MODE | undefined;
+    let pageRowsHint: number | undefined;
     let tail = parts.length;
     if (tail >= 2 && parts[tail - 2] === 'assets') {
       assetUals = decodeExactAssetUals(parts[tail - 1]);
@@ -1016,7 +1018,30 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       parts[tail - 1].length > 0
     ) {
       syncSessionId = parts[tail - 1];
+      tail -= 2;
     }
+    if (
+      tail >= 2 &&
+      parts[tail - 2] === 'page-rows' &&
+      /^\d+$/.test(parts[tail - 1])
+    ) {
+      const parsedPageRows = Number(parts[tail - 1]);
+      if (Number.isSafeInteger(parsedPageRows) && parsedPageRows > SYNC_PAGE_SIZE) {
+        pageRowsHint = Math.min(parsedPageRows, SYNC_BYTE_BUDGET_MAX_ROWS);
+      }
+      tail -= 2;
+    }
+    if (
+      tail >= 2 &&
+      parts[tail - 2] === 'page-mode' &&
+      parts[tail - 1] === SYNC_BYTE_BUDGET_PAGE_MODE
+    ) {
+      pageMode = SYNC_BYTE_BUDGET_PAGE_MODE;
+    }
+    // A row hint without the matching capability is inert. This mirrors the
+    // authenticated JSON parser and prevents a malformed pipe tail from
+    // accidentally selecting the byte-budget responder path.
+    if (pageMode === undefined) pageRowsHint = undefined;
     return {
       contextGraphId,
       offset: parseInt(parts[1], 10) || 0,
@@ -1027,6 +1052,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       syncSessionId,
       sinceBatchId,
       assetUals,
+      pageMode,
+      pageRowsHint,
     };
   }
 

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -210,10 +210,13 @@ import { runDurableSync } from './sync/requester/durable-sync.js';
 import { runSharedMemorySync } from './sync/requester/shared-memory-sync.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import {
-  decodeExactAssetUals,
   normalizeExactAssetUals,
   requireExactAssetUals,
 } from './sync/exact-assets.js';
+import {
+  decodePipeSyncRequestTail,
+  normalizeByteBudgetPageHint,
+} from './sync/auth/pipe-request-tail.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
 import { runSyncOnConnect } from './sync/on-connect/sync-on-connect.js';
@@ -286,8 +289,6 @@ import {
 } from './dkg-agent-utils.js';
 import {
   PRIVATE_DATA_ANCHOR,
-  SYNC_BYTE_BUDGET_MAX_ROWS,
-  SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_PAGE_SIZE,
   SYNC_PAGE_RETRY_ATTEMPTS,
   SYNC_TOTAL_TIMEOUT_MS,
@@ -948,14 +949,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         snapshotRef: typeof parsed.snapshotRef === 'string' ? parsed.snapshotRef : undefined,
         authPurpose: typeof parsed.authPurpose === 'string' ? parsed.authPurpose : undefined,
         authSelector: typeof parsed.authSelector === 'string' ? parsed.authSelector : undefined,
-        pageMode: parsed.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE
-          ? SYNC_BYTE_BUDGET_PAGE_MODE
-          : undefined,
-        pageRowsHint: parsed.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE &&
-          Number.isSafeInteger(parsed.pageRowsHint) &&
-          Number(parsed.pageRowsHint) > SYNC_PAGE_SIZE
-          ? Math.min(Number(parsed.pageRowsHint), SYNC_BYTE_BUDGET_MAX_ROWS)
-          : undefined,
+        ...normalizeByteBudgetPageHint(parsed.pageMode, parsed.pageRowsHint),
         targetPeerId: parsed.targetPeerId,
         requesterPeerId: parsed.requesterPeerId,
         requestId: parsed.requestId,
@@ -990,58 +984,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const includeSharedMemory = ctxGraphPart.startsWith('workspace:');
     const contextGraphId = includeSharedMemory ? ctxGraphPart.slice('workspace:'.length) : (ctxGraphPart || SYSTEM_CONTEXT_GRAPHS.AGENTS);
     const phase = normalizeSyncPhase(parts[3]);
-    // Phase C: parse only the trailing keyed tokens emitted by
-    // `buildSyncRequestEnvelope` (after the optional phase/snapshot suffix).
-    // Scanning every segment would misparse ordinary values literally equal to
-    // "since" or "session" as control tokens. Old encoders never emit them.
-    let sinceBatchId: string | undefined;
-    let syncSessionId: string | undefined;
-    let assetUals: string[] | undefined;
-    let pageMode: typeof SYNC_BYTE_BUDGET_PAGE_MODE | undefined;
-    let pageRowsHint: number | undefined;
-    let tail = parts.length;
-    if (tail >= 2 && parts[tail - 2] === 'assets') {
-      assetUals = decodeExactAssetUals(parts[tail - 1]);
-      tail -= 2;
-    }
-    if (
-      tail >= 2 &&
-      parts[tail - 2] === 'since' &&
-      /^\d+$/.test(parts[tail - 1])
-    ) {
-      sinceBatchId = parts[tail - 1];
-      tail -= 2;
-    }
-    if (
-      tail >= 2 &&
-      parts[tail - 2] === 'session' &&
-      parts[tail - 1].length > 0
-    ) {
-      syncSessionId = parts[tail - 1];
-      tail -= 2;
-    }
-    if (
-      tail >= 2 &&
-      parts[tail - 2] === 'page-rows' &&
-      /^\d+$/.test(parts[tail - 1])
-    ) {
-      const parsedPageRows = Number(parts[tail - 1]);
-      if (Number.isSafeInteger(parsedPageRows) && parsedPageRows > SYNC_PAGE_SIZE) {
-        pageRowsHint = Math.min(parsedPageRows, SYNC_BYTE_BUDGET_MAX_ROWS);
-      }
-      tail -= 2;
-    }
-    if (
-      tail >= 2 &&
-      parts[tail - 2] === 'page-mode' &&
-      parts[tail - 1] === SYNC_BYTE_BUDGET_PAGE_MODE
-    ) {
-      pageMode = SYNC_BYTE_BUDGET_PAGE_MODE;
-    }
-    // A row hint without the matching capability is inert. This mirrors the
-    // authenticated JSON parser and prevents a malformed pipe tail from
-    // accidentally selecting the byte-budget responder path.
-    if (pageMode === undefined) pageRowsHint = undefined;
+    const tail = decodePipeSyncRequestTail(parts);
     return {
       contextGraphId,
       offset: parseInt(parts[1], 10) || 0,
@@ -1049,11 +992,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       includeSharedMemory,
       phase,
       snapshotRef: phase === 'snapshot' ? parts[4] : undefined,
-      syncSessionId,
-      sinceBatchId,
-      assetUals,
-      pageMode,
-      pageRowsHint,
+      ...tail,
     };
   }
 

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -30,8 +30,9 @@ export const SYNC_PAGE_SIZE = 500;
  * remaining four MiB admits 64 maximum-sized literal rows. That value remains
  * the retry floor for pathological payloads.
  *
- * Upgraded authenticated peers negotiate a byte-budgeted page through
- * additive unsigned hints. The signed `limit` stays capped at the legacy 500,
+ * Upgraded durable-sync peers negotiate a byte-budgeted page through additive
+ * hints. Authenticated JSON requests keep the signed `limit` capped at the
+ * legacy 500,
  * so an old responder authenticates the request and simply returns 500 rows;
  * a new responder may return up to the row hint but serializes only a bounded
  * response body. EOF-only pagination makes both responses unambiguous. A
@@ -45,7 +46,7 @@ export const SYNC_REQUEST_SAFE_PAGE_SIZE = Math.max(
     JAVA_WRITE_UTF_MAX_BYTES,
   ),
 );
-/** Additive wire capability understood by upgraded authenticated responders. */
+/** Additive wire capability understood by upgraded durable-sync responders. */
 export const SYNC_BYTE_BUDGET_PAGE_MODE = 'byte-budget-v1' as const;
 /** Maximum rows a responder may materialize for one byte-budgeted durable page. */
 export const SYNC_BYTE_BUDGET_MAX_ROWS = 8_192;

--- a/packages/agent/src/sync/auth/pipe-request-tail.ts
+++ b/packages/agent/src/sync/auth/pipe-request-tail.ts
@@ -1,0 +1,119 @@
+import {
+  SYNC_BYTE_BUDGET_MAX_ROWS,
+  SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_PAGE_SIZE,
+} from '../../dkg-agent-constants.js';
+import {
+  decodeExactAssetUals,
+  encodeExactAssetUals,
+} from '../exact-assets.js';
+
+export interface ByteBudgetPageHint {
+  pageMode?: typeof SYNC_BYTE_BUDGET_PAGE_MODE;
+  pageRowsHint?: number;
+}
+
+export interface PipeSyncRequestTail extends ByteBudgetPageHint {
+  syncSessionId?: string;
+  sinceBatchId?: string;
+  assetUals?: string[];
+}
+
+/**
+ * Normalize the additive byte-budget hint identically for authenticated JSON
+ * envelopes and public pipe requests. A row hint without the matching
+ * capability is intentionally inert.
+ */
+export function normalizeByteBudgetPageHint(
+  pageMode: unknown,
+  pageRowsHint: unknown,
+): ByteBudgetPageHint {
+  const normalizedMode = pageMode === SYNC_BYTE_BUDGET_PAGE_MODE
+    ? SYNC_BYTE_BUDGET_PAGE_MODE
+    : undefined;
+  const rows = typeof pageRowsHint === 'number' ? pageRowsHint : Number.NaN;
+  return {
+    pageMode: normalizedMode,
+    pageRowsHint: normalizedMode !== undefined &&
+      Number.isSafeInteger(rows) &&
+      rows > SYNC_PAGE_SIZE
+      ? Math.min(rows, SYNC_BYTE_BUDGET_MAX_ROWS)
+      : undefined,
+  };
+}
+
+/**
+ * Encode the ordered additive tail shared by public sync request builders.
+ *
+ * Byte-budget tokens deliberately precede the legacy session/since/assets
+ * suffix. Old responders parse those narrowing fields from the end and ignore
+ * the unknown capability tokens, preserving rolling wire compatibility.
+ */
+export function encodePipeSyncRequestTail(tail: PipeSyncRequestTail): string {
+  const parts: string[] = [];
+  const page = normalizeByteBudgetPageHint(tail.pageMode, tail.pageRowsHint);
+  if (page.pageMode && page.pageRowsHint !== undefined) {
+    parts.push('page-mode', page.pageMode, 'page-rows', String(page.pageRowsHint));
+  }
+  if (tail.syncSessionId) parts.push('session', tail.syncSessionId);
+  if (tail.sinceBatchId) parts.push('since', tail.sinceBatchId);
+  if (tail.assetUals) parts.push('assets', encodeExactAssetUals(tail.assetUals));
+  return parts.length > 0 ? `|${parts.join('|')}` : '';
+}
+
+/**
+ * Decode only the ordered keyed suffix emitted by
+ * {@link encodePipeSyncRequestTail}. Walking backwards avoids interpreting
+ * ordinary phase values as control tokens.
+ */
+export function decodePipeSyncRequestTail(parts: readonly string[]): PipeSyncRequestTail {
+  let tail = parts.length;
+  let sinceBatchId: string | undefined;
+  let syncSessionId: string | undefined;
+  let assetUals: string[] | undefined;
+  let rawPageMode: unknown;
+  let rawPageRowsHint: unknown;
+
+  if (tail >= 2 && parts[tail - 2] === 'assets') {
+    assetUals = decodeExactAssetUals(parts[tail - 1]);
+    tail -= 2;
+  }
+  if (
+    tail >= 2 &&
+    parts[tail - 2] === 'since' &&
+    /^\d+$/.test(parts[tail - 1])
+  ) {
+    sinceBatchId = parts[tail - 1];
+    tail -= 2;
+  }
+  if (
+    tail >= 2 &&
+    parts[tail - 2] === 'session' &&
+    parts[tail - 1].length > 0
+  ) {
+    syncSessionId = parts[tail - 1];
+    tail -= 2;
+  }
+  if (
+    tail >= 2 &&
+    parts[tail - 2] === 'page-rows'
+  ) {
+    rawPageRowsHint = /^\d+$/.test(parts[tail - 1])
+      ? Number(parts[tail - 1])
+      : undefined;
+    tail -= 2;
+  }
+  if (
+    tail >= 2 &&
+    parts[tail - 2] === 'page-mode'
+  ) {
+    rawPageMode = parts[tail - 1];
+  }
+
+  return {
+    ...normalizeByteBudgetPageHint(rawPageMode, rawPageRowsHint),
+    syncSessionId,
+    sinceBatchId,
+    assetUals,
+  };
+}

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -4,7 +4,8 @@ import {
   SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_PAGE_SIZE,
 } from '../../dkg-agent-constants.js';
-import { encodeExactAssetUals, requireExactAssetUals } from '../exact-assets.js';
+import { requireExactAssetUals } from '../exact-assets.js';
+import { encodePipeSyncRequestTail } from './pipe-request-tail.js';
 
 // 'catalog' (§7) — the public facet open-serve: served to ANYONE
 // without the allowlist gate, bounded to exactly the `_catalog` named graph.
@@ -211,18 +212,15 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
           : useByteBudgetPage
             ? '|data'
             : '';
-    // Trailing keyed tokens are additive; old responders ignore the extra parts.
-    // Keep the byte-budget tokens BEFORE the legacy session/since/assets tail:
-    // old exact-fetch responders can still recover those narrowing tokens from
-    // the end even though they do not understand byte-budget pagination.
-    const byteBudgetSuffix = useByteBudgetPage
-      ? `|page-mode|${SYNC_BYTE_BUDGET_PAGE_MODE}|page-rows|${requestedLimit}`
-      : '';
-    const sessionSuffix = syncSessionId ? `|session|${syncSessionId}` : '';
-    const sinceSuffix = sinceBatchId ? `|since|${sinceBatchId}` : '';
-    const assetsSuffix = assetUals ? `|assets|${encodeExactAssetUals(assetUals)}` : '';
+    const tail = encodePipeSyncRequestTail({
+      pageMode: useByteBudgetPage ? SYNC_BYTE_BUDGET_PAGE_MODE : undefined,
+      pageRowsHint: useByteBudgetPage ? requestedLimit : undefined,
+      syncSessionId,
+      sinceBatchId,
+      assetUals,
+    });
     return new TextEncoder().encode(
-      `${prefix}|${offset}|${requestedLimit}${phaseSuffix}${byteBudgetSuffix}${sessionSuffix}${sinceSuffix}${assetsSuffix}`,
+      `${prefix}|${offset}|${requestedLimit}${phaseSuffix}${tail}`,
     );
   }
 

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -206,12 +206,24 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
           // wire and the responder routes to readCatalogPage instead of falling
           // back to the DEFAULT data phase (which is gated and serves nothing).
           ? '|catalog'
-          : '';
+          // Byte-budget tokens make the otherwise implicit DATA phase explicit,
+          // so upgraded parsers have an unambiguous start for the keyed tail.
+          : useByteBudgetPage
+            ? '|data'
+            : '';
     // Trailing keyed tokens are additive; old responders ignore the extra parts.
+    // Keep the byte-budget tokens BEFORE the legacy session/since/assets tail:
+    // old exact-fetch responders can still recover those narrowing tokens from
+    // the end even though they do not understand byte-budget pagination.
+    const byteBudgetSuffix = useByteBudgetPage
+      ? `|page-mode|${SYNC_BYTE_BUDGET_PAGE_MODE}|page-rows|${requestedLimit}`
+      : '';
     const sessionSuffix = syncSessionId ? `|session|${syncSessionId}` : '';
     const sinceSuffix = sinceBatchId ? `|since|${sinceBatchId}` : '';
     const assetsSuffix = assetUals ? `|assets|${encodeExactAssetUals(assetUals)}` : '';
-    return new TextEncoder().encode(`${prefix}|${offset}|${requestedLimit}${phaseSuffix}${sessionSuffix}${sinceSuffix}${assetsSuffix}`);
+    return new TextEncoder().encode(
+      `${prefix}|${offset}|${requestedLimit}${phaseSuffix}${byteBudgetSuffix}${sessionSuffix}${sinceSuffix}${assetsSuffix}`,
+    );
   }
 
   const request: SyncRequestEnvelope = {

--- a/packages/agent/src/sync/responder/durable-data-request-policy.ts
+++ b/packages/agent/src/sync/responder/durable-data-request-policy.ts
@@ -1,0 +1,56 @@
+import {
+  SYNC_BYTE_BUDGET_MAX_ROWS,
+  SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_REQUEST_SAFE_PAGE_SIZE,
+} from '../../dkg-agent-constants.js';
+
+export type DurableDataCacheMode = 'session-snapshot' | 'page-only';
+export type ExactGraphReadMode = 'snapshot-or-page' | 'page-only';
+
+export interface DurableDataRequestPolicy {
+  usesByteBudgetPage: boolean;
+  limit: number;
+  cacheMode: DurableDataCacheMode;
+  exactGraphReadMode: ExactGraphReadMode;
+}
+
+/**
+ * Resolve responder resource policy from authenticated request semantics only.
+ *
+ * Signature fields are deliberately absent: public-graph authorization may
+ * accept a request before validating them, so their presence is not proof that
+ * a caller is authenticated. Every negotiated exact-asset read therefore uses
+ * the conservative store-page path and 64-row floor.
+ */
+export function resolveDurableDataRequestPolicy(params: {
+  legacyLimit: number;
+  includeSharedMemory: boolean;
+  phase: string;
+  pageMode?: string;
+  pageRowsHint?: number;
+  hasExactAssetFilter: boolean;
+}): DurableDataRequestPolicy {
+  const hintedPageRows = typeof params.pageRowsHint === 'number' &&
+    Number.isSafeInteger(params.pageRowsHint)
+    ? Math.max(1, Math.min(params.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))
+    : 0;
+  const usesByteBudgetPage = !params.includeSharedMemory &&
+    params.phase === 'data' &&
+    params.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE &&
+    hintedPageRows > params.legacyLimit;
+  const pageOnlyExactFetch = usesByteBudgetPage && params.hasExactAssetFilter;
+
+  return {
+    usesByteBudgetPage,
+    limit: usesByteBudgetPage
+      ? Math.min(
+        hintedPageRows,
+        pageOnlyExactFetch
+          ? SYNC_REQUEST_SAFE_PAGE_SIZE
+          : SYNC_BYTE_BUDGET_MAX_ROWS,
+      )
+      : params.legacyLimit,
+    cacheMode: pageOnlyExactFetch ? 'page-only' : 'session-snapshot',
+    exactGraphReadMode: pageOnlyExactFetch ? 'page-only' : 'snapshot-or-page',
+  };
+}

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -1574,6 +1574,13 @@ export async function readDurableDataPage(params: {
   /** Keep the immutable row snapshot until an explicit empty-page EOF. */
   releaseCacheOnShortPage?: boolean;
   assetUals?: readonly string[];
+  /**
+   * Force exact-graph payloads through OFFSET/LIMIT reads instead of loading a
+   * whole graph snapshot. Public exact fetches use this with a conservative
+   * row cap so unauthenticated callers cannot amplify one response into a
+   * multi-megabyte pre-serialization materialization.
+   */
+  forcePagedGraphs?: boolean;
 }): Promise<SyncRow[]> {
   const cache = params.rowListMemo
     ? {
@@ -1613,6 +1620,7 @@ export async function readDurableDataPage(params: {
           () => Promise.resolve(true),
           planSignal,
           new Map(entries.map((entry) => [entry.graph, entry.rowCount])),
+          params.forcePagedGraphs,
         );
       },
     );
@@ -1666,6 +1674,7 @@ export async function readDurableDataPage(params: {
           isAdmitted(params.rowListMemo ? undefined : planSignal),
           planSignal,
           knownRowCounts,
+          params.forcePagedGraphs,
         );
       },
     );
@@ -1824,6 +1833,7 @@ async function buildExactGraphPagePlan(
   isAdmitted: (graph: string) => Promise<boolean>,
   signal?: AbortSignal,
   knownRowCounts?: ReadonlyMap<string, number>,
+  forcePagedGraphs = false,
 ): Promise<ExactGraphPagePlan> {
   const entries: ExactGraphPagePlanEntry[] = [];
   for (const graph of dedupeStrings(graphs).sort(compareCodePoint)) {
@@ -1838,7 +1848,7 @@ async function buildExactGraphPagePlan(
   return {
     entries,
     totalRows: entries.reduce((sum, entry) => sum + entry.rowCount, 0),
-    pagedGraphs: new Set<string>(),
+    pagedGraphs: new Set(forcePagedGraphs ? entries.map((entry) => entry.graph) : []),
   };
 }
 

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -35,6 +35,7 @@ import type { ChangelogSyncResponse, ChangelogDeltaRecord } from '../changelog/w
 import { durableMetaDelegationSubjectAdmissionExpression } from './durable-meta-admission.js';
 import { exactAssetFilterKey } from '../exact-assets.js';
 import { isIriTerm } from '../iri-term.js';
+import type { ExactGraphReadMode } from './durable-data-request-policy.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -1575,12 +1576,11 @@ export async function readDurableDataPage(params: {
   releaseCacheOnShortPage?: boolean;
   assetUals?: readonly string[];
   /**
-   * Force exact-graph payloads through OFFSET/LIMIT reads instead of loading a
-   * whole graph snapshot. Public exact fetches use this with a conservative
-   * row cap so unauthenticated callers cannot amplify one response into a
-   * multi-megabyte pre-serialization materialization.
+   * Select whether exact-graph payloads may use a bounded graph snapshot or
+   * must use OFFSET/LIMIT reads. Resource policy is resolved by the handler;
+   * this planner only consumes the neutral read strategy.
    */
-  forcePagedGraphs?: boolean;
+  exactGraphReadMode?: ExactGraphReadMode;
 }): Promise<SyncRow[]> {
   const cache = params.rowListMemo
     ? {
@@ -1620,7 +1620,7 @@ export async function readDurableDataPage(params: {
           () => Promise.resolve(true),
           planSignal,
           new Map(entries.map((entry) => [entry.graph, entry.rowCount])),
-          params.forcePagedGraphs,
+          params.exactGraphReadMode,
         );
       },
     );
@@ -1674,7 +1674,7 @@ export async function readDurableDataPage(params: {
           isAdmitted(params.rowListMemo ? undefined : planSignal),
           planSignal,
           knownRowCounts,
-          params.forcePagedGraphs,
+          params.exactGraphReadMode,
         );
       },
     );
@@ -1833,7 +1833,7 @@ async function buildExactGraphPagePlan(
   isAdmitted: (graph: string) => Promise<boolean>,
   signal?: AbortSignal,
   knownRowCounts?: ReadonlyMap<string, number>,
-  forcePagedGraphs = false,
+  exactGraphReadMode: ExactGraphReadMode = 'snapshot-or-page',
 ): Promise<ExactGraphPagePlan> {
   const entries: ExactGraphPagePlanEntry[] = [];
   for (const graph of dedupeStrings(graphs).sort(compareCodePoint)) {
@@ -1848,7 +1848,11 @@ async function buildExactGraphPagePlan(
   return {
     entries,
     totalRows: entries.reduce((sum, entry) => sum + entry.rowCount, 0),
-    pagedGraphs: new Set(forcePagedGraphs ? entries.map((entry) => entry.graph) : []),
+    pagedGraphs: new Set(
+      exactGraphReadMode === 'page-only'
+        ? entries.map((entry) => entry.graph)
+        : [],
+    ),
   };
 }
 

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -11,6 +11,7 @@ import {
   SYNC_BYTE_BUDGET_MAX_ROWS,
   SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_BYTE_BUDGET_RESPONSE_BYTES,
+  SYNC_REQUEST_SAFE_PAGE_SIZE,
 } from '../../dkg-agent-constants.js';
 import {
   serializeWorkspacePublicSnapshotQuads,
@@ -563,7 +564,22 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       phase === 'data' &&
       request.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE &&
       hintedPageRows > limit;
-    const durableDataLimit = usesByteBudgetPage ? hintedPageRows : limit;
+    const unauthenticatedPublicExactFetch = usesByteBudgetPage &&
+      assetUals !== undefined &&
+      (!request.requesterSignatureR || !request.requesterSignatureVS);
+    // Public exact-fetch pipe requests are intentionally unsigned. Keep their
+    // pre-serialization store read at the conservative 64-row floor instead of
+    // materializing the full 8,192-row hint and discarding everything beyond
+    // the 4 MiB response budget. Authenticated and non-exact durable sync keeps
+    // the throughput-oriented hint.
+    const durableDataLimit = usesByteBudgetPage
+      ? Math.min(
+        hintedPageRows,
+        unauthenticatedPublicExactFetch
+          ? SYNC_REQUEST_SAFE_PAGE_SIZE
+          : SYNC_BYTE_BUDGET_MAX_ROWS,
+      )
+      : limit;
     // Durable meta negotiated its byte-budget page mode on the wire (#1916 /
     // #1923). The subject-atomic byte-fit in readDurableMetaPage already bounds
     // the page ≤ budget for BOTH modes, so this only selects the belt-and-
@@ -842,8 +858,14 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           offset,
           limit: durableDataLimit,
           signal,
-          rowListMemo: session ? durableDataRowsMemo : undefined,
-          rowListCacheScope: session ? peerId : undefined,
+          // A row-list snapshot would eagerly materialize every selected KA,
+          // defeating the public exact-fetch read cap before serialization.
+          rowListMemo: session && !unauthenticatedPublicExactFetch
+            ? durableDataRowsMemo
+            : undefined,
+          rowListCacheScope: session && !unauthenticatedPublicExactFetch
+            ? peerId
+            : undefined,
           refreshRowList: session?.refreshRowList,
           refreshGeneration: session?.refreshGeneration,
           exactGraphPlanMemo: durableDataExactGraphPlanMemo,
@@ -852,6 +874,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           // because that slice was short; the explicit empty request is EOF.
           releaseCacheOnShortPage: !usesByteBudgetPage,
           assetUals,
+          // Prevent the exact-graph planner from loading an entire KA graph
+          // when this unauthenticated response is allowed to read only 64 rows.
+          forcePagedGraphs: unauthenticatedPublicExactFetch,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();
@@ -867,15 +892,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (totalDurationMs > 100) {
         logDebug(createOperationContext('sync'), `Sync responder total for "${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): ${totalDurationMs}ms`);
       }
-      const responseBytes = new TextEncoder().encode(nquads.join('\n'));
-      if (responseBytes.byteLength > DEFAULT_MAX_READ_BYTES) {
-        const message = `Sync responder refused ${responseBytes.byteLength}-byte response for `
-          + `"${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): exceeds `
-          + `${DEFAULT_MAX_READ_BYTES}-byte transport frame cap; requester must negotiate byte-budget paging`;
-        logWarn(createOperationContext('sync'), message);
-        throw new Error(message);
-      }
-      return responseBytes;
+      return new TextEncoder().encode(nquads.join('\n'));
     };
 
     const preAuthorizationScheduling: SyncResponderScheduling = {
@@ -919,9 +936,19 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           },
         );
 
+    const guardSyncResponseBytes = (bytes: Uint8Array): Uint8Array => {
+      if (bytes.byteLength <= DEFAULT_MAX_READ_BYTES) return bytes;
+      const message = `Sync responder refused ${bytes.byteLength}-byte response for `
+        + `"${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): exceeds `
+        + `${DEFAULT_MAX_READ_BYTES}-byte transport frame cap; response must be paginated below the transport ceiling`;
+      logWarn(createOperationContext('sync'), message);
+      throw new Error(message);
+    };
+
     return response.then((res) => {
+      const guarded = guardSyncResponseBytes(res);
       getMetrics().syncResponseTotal.add(1, { outcome: 'ok' });
-      return res;
+      return guarded;
     }).catch((err) => {
       if (err instanceof SyncResponderBusyError) {
         getMetrics().syncResponseTotal.add(1, { outcome: 'busy' });

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -1,5 +1,6 @@
 import {
   createOperationContext,
+  DEFAULT_MAX_READ_BYTES,
   QuietRetryableHandlerError,
   withSpan,
   getMetrics,
@@ -866,7 +867,15 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (totalDurationMs > 100) {
         logDebug(createOperationContext('sync'), `Sync responder total for "${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): ${totalDurationMs}ms`);
       }
-      return new TextEncoder().encode(nquads.join('\n'));
+      const responseBytes = new TextEncoder().encode(nquads.join('\n'));
+      if (responseBytes.byteLength > DEFAULT_MAX_READ_BYTES) {
+        const message = `Sync responder refused ${responseBytes.byteLength}-byte response for `
+          + `"${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): exceeds `
+          + `${DEFAULT_MAX_READ_BYTES}-byte transport frame cap; requester must negotiate byte-budget paging`;
+        logWarn(createOperationContext('sync'), message);
+        throw new Error(message);
+      }
+      return responseBytes;
     };
 
     const preAuthorizationScheduling: SyncResponderScheduling = {

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -8,10 +8,8 @@ import {
 } from '@origintrail-official/dkg-core';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import {
-  SYNC_BYTE_BUDGET_MAX_ROWS,
   SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_BYTE_BUDGET_RESPONSE_BYTES,
-  SYNC_REQUEST_SAFE_PAGE_SIZE,
 } from '../../dkg-agent-constants.js';
 import {
   serializeWorkspacePublicSnapshotQuads,
@@ -56,6 +54,7 @@ import {
   PriorityAdmissionQueue,
   type PriorityAdmission,
 } from '../priority-admission-queue.js';
+import { resolveDurableDataRequestPolicy } from './durable-data-request-policy.js';
 
 const MAX_SYNC_SESSION_TOKENS = 256;
 
@@ -556,30 +555,15 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     const assetSelectionKey = assetUals === undefined
       ? 'full'
       : exactAssetFilterKey(assetUals);
-    const hintedPageRows = typeof request.pageRowsHint === 'number' &&
-      Number.isSafeInteger(request.pageRowsHint)
-      ? Math.max(1, Math.min(request.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))
-      : 0;
-    const usesByteBudgetPage = !isWorkspace &&
-      phase === 'data' &&
-      request.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE &&
-      hintedPageRows > limit;
-    const unauthenticatedPublicExactFetch = usesByteBudgetPage &&
-      assetUals !== undefined &&
-      (!request.requesterSignatureR || !request.requesterSignatureVS);
-    // Public exact-fetch pipe requests are intentionally unsigned. Keep their
-    // pre-serialization store read at the conservative 64-row floor instead of
-    // materializing the full 8,192-row hint and discarding everything beyond
-    // the 4 MiB response budget. Authenticated and non-exact durable sync keeps
-    // the throughput-oriented hint.
-    const durableDataLimit = usesByteBudgetPage
-      ? Math.min(
-        hintedPageRows,
-        unauthenticatedPublicExactFetch
-          ? SYNC_REQUEST_SAFE_PAGE_SIZE
-          : SYNC_BYTE_BUDGET_MAX_ROWS,
-      )
-      : limit;
+    const durableDataPolicy = resolveDurableDataRequestPolicy({
+      legacyLimit: limit,
+      includeSharedMemory: isWorkspace,
+      phase,
+      pageMode: request.pageMode,
+      pageRowsHint: request.pageRowsHint,
+      hasExactAssetFilter: assetUals !== undefined,
+    });
+    const usesByteBudgetPage = durableDataPolicy.usesByteBudgetPage;
     // Durable meta negotiated its byte-budget page mode on the wire (#1916 /
     // #1923). The subject-atomic byte-fit in readDurableMetaPage already bounds
     // the page ≤ budget for BOTH modes, so this only selects the belt-and-
@@ -856,14 +840,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           contextGraphId,
           sinceBatchId,
           offset,
-          limit: durableDataLimit,
+          limit: durableDataPolicy.limit,
           signal,
-          // A row-list snapshot would eagerly materialize every selected KA,
-          // defeating the public exact-fetch read cap before serialization.
-          rowListMemo: session && !unauthenticatedPublicExactFetch
+          rowListMemo: session && durableDataPolicy.cacheMode === 'session-snapshot'
             ? durableDataRowsMemo
             : undefined,
-          rowListCacheScope: session && !unauthenticatedPublicExactFetch
+          rowListCacheScope: session && durableDataPolicy.cacheMode === 'session-snapshot'
             ? peerId
             : undefined,
           refreshRowList: session?.refreshRowList,
@@ -874,9 +856,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           // because that slice was short; the explicit empty request is EOF.
           releaseCacheOnShortPage: !usesByteBudgetPage,
           assetUals,
-          // Prevent the exact-graph planner from loading an entire KA graph
-          // when this unauthenticated response is allowed to read only 64 rows.
-          forcePagedGraphs: unauthenticatedPublicExactFetch,
+          exactGraphReadMode: durableDataPolicy.exactGraphReadMode,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();

--- a/packages/agent/test/_helpers/sync-responder.ts
+++ b/packages/agent/test/_helpers/sync-responder.ts
@@ -20,6 +20,7 @@ export interface CapturedSyncHandler {
     handler: (data: Uint8Array, peerId: string) => Promise<Uint8Array>,
   ) => void;
   invoke: (envelope: SyncRequestEnvelope, remotePeerId?: string) => Promise<string>;
+  invokeBytes: (request: Uint8Array, remotePeerId?: string) => Promise<string>;
 }
 
 export function captureSyncHandler(): CapturedSyncHandler {
@@ -34,6 +35,11 @@ export function captureSyncHandler(): CapturedSyncHandler {
       const out = await captured(bytes, remotePeerId);
       return new TextDecoder().decode(out);
     },
+    invokeBytes: async (request, remotePeerId = TEST_REMOTE_PEER) => {
+      if (!captured) throw new Error('handler not registered');
+      const out = await captured(request, remotePeerId);
+      return new TextDecoder().decode(out);
+    },
   };
 }
 
@@ -44,6 +50,7 @@ export function registerTestSyncHandler(
     syncPageSize?: number;
     snapshotBudget?: SyncResponderSnapshotBudgetOptions;
     authorize?: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
+    parseSyncRequest?: (data: Uint8Array) => SyncRequestEnvelope;
     logDebug?: (ctx: OperationContext, message: string) => void;
     publicSnapshotStore?: WorkspacePublicSnapshotStore;
   } = {},
@@ -58,7 +65,8 @@ export function registerTestSyncHandler(
     store,
     publicSnapshotStore: options.publicSnapshotStore,
     peerId: 'self-peer',
-    parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+    parseSyncRequest: options.parseSyncRequest ??
+      ((data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope),
     authorizeSyncRequest: options.authorize ?? (async () => true),
     logWarn: noopLog,
     logDebug: options.logDebug ?? noopLog,

--- a/packages/agent/test/exact-asset-wire-parse.test.ts
+++ b/packages/agent/test/exact-asset-wire-parse.test.ts
@@ -293,4 +293,84 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
 
     await store.close();
   }, 60_000);
+
+  it('keeps fake signature fields on the 64-row page-only exact-fetch policy', async () => {
+    const contextGraphId = 'fake-signature-public-exact';
+    const store = new OxigraphStore();
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const ual = `did:dkg:base:84532/${AUTHOR}/99`;
+    const graph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(ual, 1),
+    );
+    const rowCount = 200;
+    await store.insert([
+      { graph: metaGraph, subject: ual, predicate: `${DKG}contentScopeVersion`, object: integer(GRAPH_KA_CONTENT_SCOPE_VERSION) },
+      { graph: metaGraph, subject: ual, predicate: `${DKG}kaUal`, object: ual },
+      { graph: metaGraph, subject: ual, predicate: `${DKG}assertionVersion`, object: integer(1) },
+      { graph: metaGraph, subject: ual, predicate: `${DKG}assertionGraph`, object: graph },
+      { graph: metaGraph, subject: ual, predicate: `${DKG}contextGraph`, object: contextGraphDataGraphUri(contextGraphId) },
+      { graph: metaGraph, subject: ual, predicate: `${DKG}publicTripleCount`, object: integer(rowCount) },
+      { graph: metaGraph, subject: ual, predicate: `${DKG}privateTripleCount`, object: integer(0) },
+      { graph: metaGraph, subject: ual, predicate: `${DKG}status`, object: '"confirmed"' },
+      ...Array.from({ length: rowCount }, (_, i) => ({
+        graph,
+        subject: `urn:fake-signature-entity:${i.toString().padStart(3, '0')}`,
+        predicate: 'urn:predicate',
+        object: `"value-${i}"`,
+      })),
+    ]);
+
+    const originalQuery = store.query.bind(store);
+    const payloadReadLimits: number[] = [];
+    let maxPayloadBindings = 0;
+    let payloadSnapshotQueries = 0;
+    store.query = (async (
+      sparql: string,
+      options?: Parameters<OxigraphStore['query']>[1],
+    ) => {
+      const result = await originalQuery(sparql, options);
+      const isPayloadRead = sparql.includes(`GRAPH <${graph}> { ?s ?p ?o }`);
+      if (isPayloadRead && sparql.includes('ORDER BY ?s ?p ?o')) {
+        const limit = /\bLIMIT\s+(\d+)/i.exec(sparql);
+        if (limit) payloadReadLimits.push(Number(limit[1]));
+        if (result.type === 'bindings') {
+          maxPayloadBindings = Math.max(maxPayloadBindings, result.bindings.length);
+        }
+      } else if (isPayloadRead) {
+        payloadSnapshotQueries += 1;
+      }
+      return result;
+    }) as OxigraphStore['query'];
+
+    const agent = await getAgent();
+    const cap = registerTestSyncHandler(store, {
+      syncPageSize: SYNC_PAGE_SIZE,
+      parseSyncRequest: (data) => (agent as any).parseSyncRequest(data),
+    });
+    const response = await cap.invokeBytes(encode({
+      contextGraphId,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: false,
+      phase: 'data',
+      syncSessionId: 'fake-signature-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+      assetUals: [ual],
+      requesterSignatureR: 'attacker-controlled-r',
+      requesterSignatureVS: 'attacker-controlled-vs',
+    }));
+
+    expect(linesFromNquads(response)).toHaveLength(SYNC_REQUEST_SAFE_PAGE_SIZE);
+    expect(new TextEncoder().encode(response).byteLength)
+      .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+    expect(payloadReadLimits.length).toBeGreaterThan(0);
+    expect(Math.max(...payloadReadLimits)).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+    expect(maxPayloadBindings).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+    expect(payloadSnapshotQueries).toBe(0);
+
+    await store.close();
+  });
 });

--- a/packages/agent/test/exact-asset-wire-parse.test.ts
+++ b/packages/agent/test/exact-asset-wire-parse.test.ts
@@ -1,13 +1,29 @@
 import { afterAll, describe, expect, it } from 'vitest';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  contextGraphDataGraphUri,
+  contextGraphMetaGraphUri,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { DKGAgent } from '../src/index.js';
 import {
   SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_BYTE_BUDGET_RESPONSE_BYTES,
   SYNC_PAGE_SIZE,
   SYNC_REQUEST_PAGE_SIZE,
+  SYNC_REQUEST_SAFE_PAGE_SIZE,
 } from '../src/dkg-agent-constants.js';
 import { buildSyncRequestEnvelope } from '../src/sync/auth/request-build.js';
 import { encodeExactAssetUals, MAX_EXACT_SYNC_ASSETS } from '../src/sync/exact-assets.js';
+import { serializeResponderRows } from '../src/sync/responder/graph-plan.js';
+import {
+  linesFromNquads,
+  registerTestSyncHandler,
+} from './_helpers/sync-responder.js';
 
 // #1871 — the exact-KA filter is only as safe as the production wire parsing
 // that feeds registerSyncHandler. These tests pin ContextGraphResolveMethods.
@@ -16,6 +32,10 @@ import { encodeExactAssetUals, MAX_EXACT_SYNC_ASSETS } from '../src/sync/exact-a
 // serves nothing), and absent filters stay undefined (full sync).
 const UAL_7 = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7';
 const UAL_8 = 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/8';
+const DKG = 'http://dkg.io/ontology/';
+const AUTHOR = '0x00000000000000000000000000000000000000ab';
+const integer = (value: number) =>
+  `"${value}"^^<http://www.w3.org/2001/XMLSchema#integer>`;
 
 const encode = (value: unknown): Uint8Array =>
   new TextEncoder().encode(typeof value === 'string' ? value : JSON.stringify(value));
@@ -85,6 +105,11 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
       computeSyncDigest: () => new Uint8Array(32),
       getIdentityId: async () => 0n,
     });
+    expect(new TextDecoder().decode(encoded)).toBe(
+      `mfacts|0|${SYNC_REQUEST_PAGE_SIZE}|data`
+      + `|page-mode|${SYNC_BYTE_BUDGET_PAGE_MODE}|page-rows|${SYNC_REQUEST_PAGE_SIZE}`
+      + `|session|s-1|since|42|assets|${encodeExactAssetUals([UAL_7, UAL_8])}`,
+    );
     const parsed = await parseBytes(encoded);
 
     expect(parsed.phase).toBe('data');
@@ -94,6 +119,43 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
     expect(parsed.syncSessionId).toBe('s-1');
     expect(parsed.sinceBatchId).toBe('42');
     expect(parsed.assetUals).toEqual([UAL_7, UAL_8]);
+  });
+
+  it('keeps malformed or unnegotiated pipe page hints inert without losing legacy tail fields', async () => {
+    const missingMode = await parse(
+      `mfacts|0|${SYNC_REQUEST_PAGE_SIZE}|data|page-rows|${SYNC_REQUEST_PAGE_SIZE}`
+      + `|session|s-1|since|42|assets|${encodeExactAssetUals([UAL_7])}`,
+    );
+    expect(missingMode.pageMode).toBeUndefined();
+    expect(missingMode.pageRowsHint).toBeUndefined();
+    expect(missingMode.syncSessionId).toBe('s-1');
+    expect(missingMode.sinceBatchId).toBe('42');
+    expect(missingMode.assetUals).toEqual([UAL_7]);
+
+    const malformedRows = await parse(
+      `mfacts|0|${SYNC_REQUEST_PAGE_SIZE}|data`
+      + `|page-mode|${SYNC_BYTE_BUDGET_PAGE_MODE}|page-rows|not-a-number`
+      + `|session|s-1|since|42|assets|${encodeExactAssetUals([UAL_7])}`,
+    );
+    expect(malformedRows.pageMode).toBe(SYNC_BYTE_BUDGET_PAGE_MODE);
+    expect(malformedRows.pageRowsHint).toBeUndefined();
+    expect(malformedRows.syncSessionId).toBe('s-1');
+    expect(malformedRows.assetUals).toEqual([UAL_7]);
+
+    const wrongMode = await parse(
+      `mfacts|0|${SYNC_REQUEST_PAGE_SIZE}|data`
+      + `|page-mode|unknown-v2|page-rows|${SYNC_REQUEST_PAGE_SIZE}`,
+    );
+    expect(wrongMode.pageMode).toBeUndefined();
+    expect(wrongMode.pageRowsHint).toBeUndefined();
+
+    const stringJsonRows = await parse({
+      contextGraphId: 'mfacts',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: String(SYNC_REQUEST_PAGE_SIZE),
+    });
+    expect(stringJsonRows.pageMode).toBe(SYNC_BYTE_BUDGET_PAGE_MODE);
+    expect(stringJsonRows.pageRowsHint).toBeUndefined();
   });
 
   it('parses the |assets| token without session/since tokens', async () => {
@@ -115,4 +177,120 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
     expect(parsed.assetUals).toBeUndefined();
     expect(parsed.sinceBatchId).toBe('42');
   });
+
+  it('paginates nine public exact KAs through the production pipe builder and parser with exact parity', async () => {
+    const contextGraphId = 'nine-ka-public-exact';
+    const rowsPerKa = 77;
+    const store = new OxigraphStore();
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const payload = `"${'x'.repeat(40_000)}"`;
+    const assetUals: string[] = [];
+    const payloadGraphs: string[] = [];
+    const manifestQuads: Quad[] = [];
+    const expectedRows: Array<{ s: string; p: string; o: string; g: string }> = [];
+
+    for (let assetIndex = 0; assetIndex < 9; assetIndex += 1) {
+      const ual = `did:dkg:base:84532/${AUTHOR}/${assetIndex + 1}`;
+      const graph = knowledgeAssetLayerGraphUri(
+        contextGraphId,
+        MemoryLayer.VerifiableMemory,
+        createGraphKnowledgeAssetScope(ual, 1),
+      );
+      assetUals.push(ual);
+      payloadGraphs.push(graph);
+      manifestQuads.push(
+        { graph: metaGraph, subject: ual, predicate: `${DKG}contentScopeVersion`, object: integer(GRAPH_KA_CONTENT_SCOPE_VERSION) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}kaUal`, object: ual },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}assertionVersion`, object: integer(1) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}assertionGraph`, object: graph },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}contextGraph`, object: contextGraphDataGraphUri(contextGraphId) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}publicTripleCount`, object: integer(rowsPerKa) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}privateTripleCount`, object: integer(0) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}status`, object: '"confirmed"' },
+      );
+      for (let rowIndex = 0; rowIndex < rowsPerKa; rowIndex += 1) {
+        expectedRows.push({
+          g: graph,
+          s: `urn:entity:${String(assetIndex * rowsPerKa + rowIndex).padStart(4, '0')}`,
+          p: 'urn:predicate',
+          o: payload,
+        });
+      }
+    }
+    await store.insert([
+      ...manifestQuads,
+      ...expectedRows.map((row) => ({
+        graph: row.g,
+        subject: row.s,
+        predicate: row.p,
+        object: row.o,
+      })),
+    ]);
+
+    const originalQuery = store.query.bind(store);
+    const payloadReadLimits: number[] = [];
+    let maxPayloadBindings = 0;
+    store.query = (async (
+      sparql: string,
+      options?: Parameters<OxigraphStore['query']>[1],
+    ) => {
+      const result = await originalQuery(sparql, options);
+      const isPagedPayloadRead = sparql.includes('ORDER BY ?s ?p ?o') &&
+        payloadGraphs.some((graph) => sparql.includes(`<${graph}>`));
+      if (isPagedPayloadRead) {
+        const limit = /\bLIMIT\s+(\d+)/i.exec(sparql);
+        if (limit) payloadReadLimits.push(Number(limit[1]));
+        if (result.type === 'bindings') {
+          maxPayloadBindings = Math.max(maxPayloadBindings, result.bindings.length);
+        }
+      }
+      return result;
+    }) as OxigraphStore['query'];
+
+    const agent = await getAgent();
+    const cap = registerTestSyncHandler(store, {
+      syncPageSize: SYNC_PAGE_SIZE,
+      parseSyncRequest: (data) => (agent as any).parseSyncRequest(data),
+    });
+    const received: string[] = [];
+    const requestedOffsets: number[] = [];
+    let offset = 0;
+    for (let page = 0; page < 20; page += 1) {
+      requestedOffsets.push(offset);
+      const request = await buildSyncRequestEnvelope({
+        contextGraphId,
+        offset,
+        limit: SYNC_REQUEST_PAGE_SIZE,
+        includeSharedMemory: false,
+        targetPeerId: 'peer-responder',
+        requesterPeerId: 'peer-requester',
+        phase: 'data',
+        syncSessionId: 'nine-ka-session',
+        assetUals,
+        needsAuth: false,
+        computeSyncDigest: () => new Uint8Array(32),
+        getIdentityId: async () => 0n,
+      });
+      const response = await cap.invokeBytes(request);
+      const lines = linesFromNquads(response);
+      expect(new TextEncoder().encode(response).byteLength)
+        .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+      expect(lines.length).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+      if (lines.length === 0) break;
+      received.push(...lines);
+      offset += lines.length;
+    }
+
+    const expected = linesFromNquads(serializeResponderRows(expectedRows));
+    expect(received).toHaveLength(9 * rowsPerKa);
+    expect(new Set(received)).toEqual(new Set(expected));
+    expect(requestedOffsets).toEqual([
+      0, 64, 128, 192, 256, 320, 384, 448, 512, 576, 640, 693,
+    ]);
+    expect(payloadReadLimits.length).toBeGreaterThan(0);
+    expect(Math.max(...payloadReadLimits)).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+    expect(maxPayloadBindings).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+
+    await store.close();
+  }, 60_000);
 });

--- a/packages/agent/test/exact-asset-wire-parse.test.ts
+++ b/packages/agent/test/exact-asset-wire-parse.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, describe, expect, it } from 'vitest';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent } from '../src/index.js';
+import {
+  SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_PAGE_SIZE,
+  SYNC_REQUEST_PAGE_SIZE,
+} from '../src/dkg-agent-constants.js';
+import { buildSyncRequestEnvelope } from '../src/sync/auth/request-build.js';
 import { encodeExactAssetUals, MAX_EXACT_SYNC_ASSETS } from '../src/sync/exact-assets.js';
 
 // #1871 — the exact-KA filter is only as safe as the production wire parsing
@@ -26,6 +32,8 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
 
   const parse = async (value: unknown) =>
     (await getAgent() as any).parseSyncRequest(encode(value));
+  const parseBytes = async (value: Uint8Array) =>
+    (await getAgent() as any).parseSyncRequest(value);
 
   it('preserves a valid assetUals filter from a JSON envelope', async () => {
     const parsed = await parse({ contextGraphId: 'cg', phase: 'data', assetUals: [UAL_7, UAL_8] });
@@ -59,6 +67,33 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
     expect(parsed.syncSessionId).toBe('s-1');
     expect(parsed.sinceBatchId).toBe('42');
     expect(parsed.assetUals).toEqual([UAL_7]);
+  });
+
+  it('round-trips public exact-fetch byte-budget negotiation through the pipe wire form', async () => {
+    const encoded = await buildSyncRequestEnvelope({
+      contextGraphId: 'mfacts',
+      offset: 0,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      includeSharedMemory: false,
+      targetPeerId: 'peer-responder',
+      requesterPeerId: 'peer-requester',
+      phase: 'data',
+      syncSessionId: 's-1',
+      sinceBatchId: '42',
+      assetUals: [UAL_7, UAL_8],
+      needsAuth: false,
+      computeSyncDigest: () => new Uint8Array(32),
+      getIdentityId: async () => 0n,
+    });
+    const parsed = await parseBytes(encoded);
+
+    expect(parsed.phase).toBe('data');
+    expect(parsed.limit).toBe(SYNC_PAGE_SIZE);
+    expect(parsed.pageMode).toBe(SYNC_BYTE_BUDGET_PAGE_MODE);
+    expect(parsed.pageRowsHint).toBe(SYNC_REQUEST_PAGE_SIZE);
+    expect(parsed.syncSessionId).toBe('s-1');
+    expect(parsed.sinceBatchId).toBe('42');
+    expect(parsed.assetUals).toEqual([UAL_7, UAL_8]);
   });
 
   it('parses the |assets| token without session/since tokens', async () => {

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -20,6 +20,7 @@ import {
   serializeResponderRowsWithinByteBudget,
   type SyncRow,
 } from '../src/sync/responder/graph-plan.js';
+import { resolveDurableDataRequestPolicy } from '../src/sync/responder/durable-data-request-policy.js';
 import {
   linesFromNquads,
   registerTestSyncHandler,
@@ -353,5 +354,35 @@ describe('byte-budget sync pagination', () => {
 
   it('retains the 64-row transport fallback floor', () => {
     expect(SYNC_REQUEST_SAFE_PAGE_SIZE).toBe(64);
+  });
+
+  it('derives exact-fetch resource policy without trusting signature fields', () => {
+    expect(resolveDurableDataRequestPolicy({
+      legacyLimit: SYNC_PAGE_SIZE,
+      includeSharedMemory: false,
+      phase: 'data',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+      hasExactAssetFilter: true,
+    })).toEqual({
+      usesByteBudgetPage: true,
+      limit: SYNC_REQUEST_SAFE_PAGE_SIZE,
+      cacheMode: 'page-only',
+      exactGraphReadMode: 'page-only',
+    });
+
+    expect(resolveDurableDataRequestPolicy({
+      legacyLimit: SYNC_PAGE_SIZE,
+      includeSharedMemory: false,
+      phase: 'data',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+      hasExactAssetFilter: false,
+    })).toEqual({
+      usesByteBudgetPage: true,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      cacheMode: 'session-snapshot',
+      exactGraphReadMode: 'snapshot-or-page',
+    });
   });
 });

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ethers } from 'ethers';
 import {
+  contextGraphCatalogUri,
   DEFAULT_MAX_READ_BYTES,
   type OperationContext,
 } from '@origintrail-official/dkg-core';
@@ -321,6 +322,31 @@ describe('byte-budget sync pagination', () => {
     expect(negotiatedBytes).toBeGreaterThan(0);
     expect(negotiatedBytes).toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
     expect(linesFromNquads(negotiated).length).toBeLessThan(SYNC_PAGE_SIZE);
+
+    await store.close();
+  });
+
+  it('guards an oversized prepared catalog response at the common protocol boundary', async () => {
+    const store = new OxigraphStore();
+    const graph = contextGraphCatalogUri(CG_ID);
+    const largeObject = `"${'c'.repeat(22_000)}"`;
+    await store.insert(Array.from({ length: SYNC_PAGE_SIZE }, (_, i) => ({
+      graph,
+      subject: `urn:catalog-subject:${i.toString().padStart(4, '0')}`,
+      predicate: 'urn:predicate',
+      object: largeObject,
+    })));
+    const cap = registerTestSyncHandler(store, { syncPageSize: SYNC_PAGE_SIZE });
+
+    await expect(cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: false,
+      phase: 'catalog',
+    })).rejects.toThrow(
+      new RegExp(`exceeds ${DEFAULT_MAX_READ_BYTES}-byte transport frame cap`),
+    );
 
     await store.close();
   });

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { ethers } from 'ethers';
-import type { OperationContext } from '@origintrail-official/dkg-core';
+import {
+  DEFAULT_MAX_READ_BYTES,
+  type OperationContext,
+} from '@origintrail-official/dkg-core';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_BYTE_BUDGET_RESPONSE_BYTES,
   SYNC_PAGE_SIZE,
   SYNC_REQUEST_PAGE_SIZE,
   SYNC_REQUEST_SAFE_PAGE_SIZE,
@@ -31,6 +35,26 @@ function makeCtx(): OperationContext {
 function noopLog(): void {}
 
 describe('byte-budget sync pagination', () => {
+  it('advertises byte-budget paging in an unauthenticated public request', async () => {
+    const encoded = await buildSyncRequestEnvelope({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      includeSharedMemory: false,
+      targetPeerId: REMOTE_PEER_ID,
+      requesterPeerId: LOCAL_PEER_ID,
+      phase: 'data',
+      needsAuth: false,
+      computeSyncDigest: () => new Uint8Array(32),
+      getIdentityId: async () => 0n,
+    });
+
+    expect(new TextDecoder().decode(encoded)).toBe(
+      `${CG_ID}|0|${SYNC_REQUEST_PAGE_SIZE}|data`
+      + `|page-mode|${SYNC_BYTE_BUDGET_PAGE_MODE}|page-rows|${SYNC_REQUEST_PAGE_SIZE}`,
+    );
+  });
+
   it('keeps the authenticated legacy limit signed while adding the larger hint', async () => {
     const wallet = ethers.Wallet.createRandom();
     const signedLimits: number[] = [];
@@ -256,6 +280,47 @@ describe('byte-budget sync pagination', () => {
       pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
     });
     expect(linesFromNquads(upgraded)).toHaveLength(1_200);
+
+    await store.close();
+  });
+
+  it('never emits an oversized legacy response frame and keeps negotiated data under 4 MiB', async () => {
+    const store = new OxigraphStore();
+    const graph = `did:dkg:context-graph:${CG_ID}/context/oversized`;
+    const largeObject = `"${'x'.repeat(22_000)}"`;
+    await store.insert(Array.from({ length: SYNC_PAGE_SIZE }, (_, i) => ({
+      graph,
+      subject: `urn:large-subject:${i.toString().padStart(4, '0')}`,
+      predicate: 'urn:predicate',
+      object: largeObject,
+    })));
+    const cap = registerTestSyncHandler(store, { syncPageSize: SYNC_PAGE_SIZE });
+
+    await expect(cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: false,
+      phase: 'data',
+      syncSessionId: 'oversized-legacy-session',
+    })).rejects.toThrow(
+      new RegExp(`exceeds ${DEFAULT_MAX_READ_BYTES}-byte transport frame cap`),
+    );
+
+    const negotiated = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: false,
+      phase: 'data',
+      syncSessionId: 'oversized-negotiated-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+    });
+    const negotiatedBytes = new TextEncoder().encode(negotiated).byteLength;
+    expect(negotiatedBytes).toBeGreaterThan(0);
+    expect(negotiatedBytes).toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+    expect(linesFromNquads(negotiated).length).toBeLessThan(SYNC_PAGE_SIZE);
 
     await store.close();
   });


### PR DESCRIPTION
## Summary

Fix public Context Graph exact-fetch responses that could exceed the ProtocolRouter frame ceiling when several large Knowledge Assets were requested together.

Public unauthenticated sync requests now carry the byte-budget page capability and row hint. A shared pipe-tail codec owns the compatibility-sensitive `page-mode/page-rows/session/since/assets` order, and one normalizer validates byte-budget hints for both JSON and pipe requests.

The responder selects the existing 4 MiB serializer. One durable-data request policy applies a conservative 64-row, page-only strategy to every negotiated exact-asset fetch, regardless of requester-supplied signature fields; non-exact sync retains the throughput-oriented page hint and session snapshots. A final response-boundary guard rejects every oversized non-empty sync response—including prepared catalog and denied-response exits—before transport framing.

## Root cause

The requester already computed `pageMode=byte-budget-v1` and `pageRowsHint=8192`, but the unauthenticated pipe-delimited request builder did not encode them. The pipe parser consequently could not restore them.

The responder enables `serializeResponderRowsWithinByteBudget` only when those fields are present. Public exact-fetch therefore fell back to the legacy 500-row unbounded serializer.

Observed testnet failure:

- requested exact assets: 9
- aggregate response frame: 26,036,015 bytes (24.83 MiB)
- receiver frame ceiling: 10,485,760 bytes
- intended sync response target: 4 MiB
- retries: 3 identical oversized responses
- result: `requested=9 fetched=0 inserted=0 failed=1`

For the affected dataset, 9 KAs contained 693 triples. A legacy 500-row slice of the roughly 34.2 MiB aggregate is approximately 24.7 MiB, matching the rejected frame.

## Changes

- Encode `page-mode` and `page-rows` in public pipe-delimited durable data/meta requests.
- Make the data phase explicit when byte-budget tokens are present.
- Centralize ordered pipe-tail encoding/decoding and byte-budget hint normalization.
- Preserve the legacy `session`/`since`/`assets` suffix order for old exact-fetch responders.
- Extract durable-data resource policy as `{ limit, cacheMode, exactGraphReadMode }`.
- Apply the 64-row/page-only policy to every negotiated exact-asset request; never infer trust from signature-field presence.
- Keep non-exact negotiated data on the 8,192-row/session-snapshot throughput path.
- Replace the feature-named graph-planner boolean with the neutral `snapshot-or-page | page-only` read strategy.
- Apply the 10 MiB frame guard once at the common protocol response boundary.
- Add golden wire, malformed-hint, oversized prepared-catalog, store-read-bound, fake-signature, and nine-KA multi-page regressions.

## Compatibility

- New requester -> new responder: byte-budget pagination is negotiated; exact-fetch payload reads are capped at 64 rows and responses remain at or below the 4 MiB target.
- New requester -> old responder: the additive tokens remain wire-decodable and legacy narrowing fields still parse, but an old responder does not implement byte-budget serialization. Large exact sync can therefore still reproduce the original oversized frame failure. The responder hosting the large KAs must be upgraded for this incident to be fixed.
- Old requester -> new responder: absence of the capability retains legacy paging semantics, with the final 10 MiB boundary guard failing loudly rather than emitting an unreadable frame.
- The generic 10 MiB transport limit is unchanged.

## Validation

- Agent build, TypeScript/type tests, and package-root checks passed.
- Seven focused/adjacent suites passed: 75/75 tests.
- The production-wire regression creates 9 confirmed KAs × 77 triples = 693 triples with a >10 MiB aggregate payload.
- It completes in 11 data pages plus explicit empty-page EOF, advances offsets by the parsed row count, reproduces exact triple parity with no duplicates/skips, and keeps every response at or below 4 MiB.
- Instrumented payload reads prove every store query and returned binding page is capped at 64 rows.
- An adversarial public JSON request with fake non-empty signature fields still returns exactly 64 rows, performs no payload snapshot query, and remains on bounded `OFFSET/LIMIT` reads.
- Oversized durable and prepared catalog responses are rejected at the common response boundary.
- `sync-handler.ts` is back below 1,000 lines after policy extraction.
- `git diff --check` passed.
