### PR TITLE
fix(sync): preserve VM miss cache across peer loss

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -28,6 +28,7 @@ import { ContextGraphMembershipPersistScheduler } from './context-graph-membersh
 import { ContextGraphBindingState } from './context-graph-binding-state.js';
 import { SelectedSwmBootstrapAdmission } from './sync/selected-swm-bootstrap-admission.js';
 import { SyncOnConnectPeerScheduler } from './sync/on-connect/peer-scheduler.js';
+import type { VmReconcilePeerTopology } from './vm-reconcile-peer-topology.js';
 import type {
   Rfc64AuthorizedSwmRecoveryPlanV1,
   Rfc64SwmRecoveryCoordinatorV1,
@@ -1064,7 +1065,11 @@ export class DKGAgentBase {
   /** Monotonic guard: continuations from abandoned drain generations must not persist after restart. */
   protected coreHostRecordingGeneration = 0;
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
-  protected readonly vmReconcileNegativeCache = new Map<string, Omit<VmReconcileNegativeRecord, 'cacheKey'>>();
+  protected readonly vmReconcileNegativeCache = new Map<string,
+    Omit<VmReconcileNegativeRecord, 'cacheKey' | 'peerTopologyKey'> & {
+      peerTopology: VmReconcilePeerTopology;
+    }
+  >();
   /** Bounded access-ordered keys already consulted in the durable store. */
   protected readonly vmReconcileNegativeCacheHydrated = new Map<string, string>();
   protected readonly vmReconcileNegativeCacheKeysByCg = new Map<string, Set<string>>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -372,6 +372,7 @@ import {
   type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
   type VmReconcileNegativeRecord,
+  type VmReconcilePeerTopology,
   type SelectedVmReconcileCursorRecord,
   type VmReconcileRotationRecord,
   type ContextGraphMemberPrincipalType,
@@ -1066,7 +1067,13 @@ export class DKGAgentBase {
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
   protected readonly vmReconcileNegativeCache = new Map<
     string,
-    Omit<VmReconcileNegativeRecord, 'cacheKey'>
+    Omit<
+      VmReconcileNegativeRecord,
+      'cacheKey' | 'peerTopologyKey' | 'peerTopology' | 'cleanMissPeerIds'
+    > & {
+      peerTopology: VmReconcilePeerTopology;
+      cleanMissPeerIds: string[];
+    }
   >();
   /** Bounded access-ordered keys already consulted in the durable store. */
   protected readonly vmReconcileNegativeCacheHydrated = new Map<string, string>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -28,7 +28,6 @@ import { ContextGraphMembershipPersistScheduler } from './context-graph-membersh
 import { ContextGraphBindingState } from './context-graph-binding-state.js';
 import { SelectedSwmBootstrapAdmission } from './sync/selected-swm-bootstrap-admission.js';
 import { SyncOnConnectPeerScheduler } from './sync/on-connect/peer-scheduler.js';
-import type { VmReconcilePeerTopology } from './vm-reconcile-peer-topology.js';
 import type {
   Rfc64AuthorizedSwmRecoveryPlanV1,
   Rfc64SwmRecoveryCoordinatorV1,
@@ -1065,10 +1064,9 @@ export class DKGAgentBase {
   /** Monotonic guard: continuations from abandoned drain generations must not persist after restart. */
   protected coreHostRecordingGeneration = 0;
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
-  protected readonly vmReconcileNegativeCache = new Map<string,
-    Omit<VmReconcileNegativeRecord, 'cacheKey' | 'peerTopologyKey'> & {
-      peerTopology: VmReconcilePeerTopology;
-    }
+  protected readonly vmReconcileNegativeCache = new Map<
+    string,
+    Omit<VmReconcileNegativeRecord, 'cacheKey'>
   >();
   /** Bounded access-ordered keys already consulted in the durable store. */
   protected readonly vmReconcileNegativeCacheHydrated = new Map<string, string>();

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -811,10 +811,47 @@ type ContextGraphCatchupResult = Awaited<ReturnType<DKGAgent['runCatchupOverPeer
 
 const inFlightSyncPageFetchesByAgent = new WeakMap<DKGAgent, Map<string, InFlightSyncPageFetch>>();
 const inFlightSyncSingleFlightsByAgent = new WeakMap<DKGAgent, Map<string, InFlightSyncSingleFlight>>();
+const vmRecoveryEvidenceSinksByAgent = new WeakMap<
+  DKGAgent,
+  Map<string, Set<(peerId: string) => void>>
+>();
 const syncPageSizeProfilesByAgent = new WeakMap<DKGAgent, SyncPageSizeProfileCache>();
 const alreadyMemberDelegationRefreshChains = new WeakMap<DKGAgent, Map<string, Promise<void>>>();
 const durableContextGraphSyncChains = new WeakMap<DKGAgent, Map<string, Promise<void>>>();
 const durableRecoveryRunnersByAgent = new WeakMap<DKGAgent, DurableRecoveryRunner>();
+
+function registerVmRecoveryEvidenceSink(
+  agent: DKGAgent,
+  contextGraphId: string,
+  sink: (peerId: string) => void,
+): () => void {
+  let byGraph = vmRecoveryEvidenceSinksByAgent.get(agent);
+  if (!byGraph) {
+    byGraph = new Map();
+    vmRecoveryEvidenceSinksByAgent.set(agent, byGraph);
+  }
+  let sinks = byGraph.get(contextGraphId);
+  if (!sinks) {
+    sinks = new Set();
+    byGraph.set(contextGraphId, sinks);
+  }
+  sinks.add(sink);
+  return () => {
+    sinks?.delete(sink);
+    if (sinks?.size === 0) byGraph?.delete(contextGraphId);
+    if (byGraph?.size === 0) vmRecoveryEvidenceSinksByAgent.delete(agent);
+  };
+}
+
+function recordVmRecoveryCleanPeer(
+  agent: DKGAgent,
+  contextGraphId: string,
+  peerId: string,
+): void {
+  for (const sink of vmRecoveryEvidenceSinksByAgent.get(agent)?.get(contextGraphId) ?? []) {
+    sink(peerId);
+  }
+}
 
 function durableRecoveryRunnerFor(agent: DKGAgent): DurableRecoveryRunner {
   let runner = durableRecoveryRunnersByAgent.get(agent);
@@ -8076,50 +8113,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async syncContextGraphFromConnectedPeers(this: DKGAgent,
     contextGraphId: string,
     options?: ContextGraphCatchupOptions,
-  ): Promise<{
-    /** Ordered connected peers before optional maxPeers windowing. */
-    connectedPeers: number;
-    /** Ordered connected peers before optional maxPeers windowing. */
-    totalPeers: number;
-    /** Peers selected and evaluated after optional maxPeers windowing. */
-    selectedPeers: number;
-    syncCapablePeers: number;
-    peersTried: number;
-    /**
-     * Subset of `peersTried` whose sync-capable peer produced a non-transport-
-     * failed round. Denials, metadata-only rows, and timeout-after-response
-     * still count as responses; daemon status mapping uses this to avoid
-     * reporting reachable-but-failed peers as curator-offline.
-     */
-    peersResponded: number;
-    /**
-     * Subset of `peersTried` whose sync round finished without a transport
-     * failure, without an explicit ACL denial, and with either real progress
-     * or a clean non-metadata-only empty completion.
-     */
-    peersSucceeded: number;
-    /** Peers whose shared-memory plane completed without failure in this run. */
-    sharedMemoryCleanPeerIds: string[];
-    /** Context Graph admissions deferred by local scheduler pressure. */
-    deferredBackpressure: number;
-    dataSynced: number;
-    sharedMemorySynced: number;
-    /** A selected peer completed a non-empty SWM snapshot without failure. */
-    sharedMemoryCompletedCleanly: boolean;
-    /**
-     * `true` iff at least one peer in this run explicitly denied the sync
-     * by emitting a denial sentinel (`syncDenied` marker raised from
-     * `sync/requester/page-fetch.ts`, rolled up via `deniedPhases`). Kept
-     * as a boolean for the subscribe job's terminal status mapping.
-     */
-    denied: boolean;
-    /**
-     * Number of peers that explicitly denied at least one durable/SWM phase
-     * during this context-graph catch-up run.
-     */
-    deniedPeers: number;
-    diagnostics: CatchupSyncDiagnostics;
-  }> {
+  ): Promise<ContextGraphCatchupResult> {
     const ctx = createOperationContext('sync');
     const includeSharedMemory = options?.includeSharedMemory ?? false;
     const mode = options?.mode ?? 'background';
@@ -8193,11 +8187,33 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         totalPeers: orderedPeers.length,
         mode,
         sourceOverride,
+        recordSharedMemoryCleanPeer: (peerId) =>
+          recordVmRecoveryCleanPeer(this, contextGraphId, peerId),
       });
     }, {
       scope: 'context-graph',
       source: catchupAdmissionSource(mode, sourceOverride),
     });
+  }
+
+  /** Focused VM-recovery operation that returns clean per-peer miss evidence. */
+  async syncVmRecoveryFromConnectedPeers(
+    this: DKGAgent,
+    contextGraphId: string,
+    options?: ContextGraphCatchupOptions,
+  ): Promise<{ catchup: ContextGraphCatchupResult; cleanMissPeerIds: string[] }> {
+    const cleanMissPeerIds = new Set<string>();
+    const unregister = registerVmRecoveryEvidenceSink(
+      this,
+      contextGraphId,
+      (peerId) => cleanMissPeerIds.add(peerId),
+    );
+    try {
+      const catchup = await this.syncContextGraphFromConnectedPeers(contextGraphId, options);
+      return { catchup, cleanMissPeerIds: [...cleanMissPeerIds] };
+    } finally {
+      unregister();
+    }
   }
 
   selectCatchupPeerWindow(this: DKGAgent,
@@ -8292,6 +8308,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       sourceOverride?: SyncAdmissionSource;
       /** Explicit test/embedding override; production resolves the operator env per job. */
       swmCatchupPassConfig?: CatchupPassConfig;
+      /** Internal evidence sink used only by the focused VM-recovery wrapper. */
+      recordSharedMemoryCleanPeer?: (peerId: string) => void;
     },
   ): Promise<{
     /** Ordered connected peers before optional caller windowing. */
@@ -8304,8 +8322,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     peersTried: number;
     peersResponded: number;
     peersSucceeded: number;
-    /** Peers whose shared-memory plane completed without failure in this run. */
-    sharedMemoryCleanPeerIds: string[];
     deferredBackpressure: number;
     dataSynced: number;
     sharedMemorySynced: number;
@@ -8507,7 +8523,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let cleanDurablePrivateOnlyCompletions = 0;
     let cleanSharedMemoryDataSynced = 0;
     const peersSucceeded = new Set<string>();
-    const sharedMemoryCleanPeerIds = new Set<string>();
     for (const [resultIndex, r] of results.entries()) {
       const remotePeerId = catchupPeers[resultIndex]!;
       // A peer "succeeded" when its sync round finished without a transport
@@ -8520,7 +8535,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       });
       const sharedProgress = r.shared ? classifyDurableProgress(r.shared) : null;
       if (sharedProgress?.completedWithoutFailure) {
-        sharedMemoryCleanPeerIds.add(remotePeerId);
+        stats?.recordSharedMemoryCleanPeer?.(remotePeerId);
       }
       if (r.shared) {
         passTracker.recordPeerRound(
@@ -8668,7 +8683,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     ): void => {
       const progress = classifyDurableProgress(shared);
       if (progress.completedWithoutFailure) {
-        sharedMemoryCleanPeerIds.add(remotePeerId);
+        stats?.recordSharedMemoryCleanPeer?.(remotePeerId);
       }
       passTracker.recordPeerRound(
         remotePeerId,
@@ -8836,7 +8851,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       peersTried,
       peersResponded: peersResponded.size,
       peersSucceeded: peersSucceeded.size,
-      sharedMemoryCleanPeerIds: [...sharedMemoryCleanPeerIds],
       deferredBackpressure,
       dataSynced,
       sharedMemorySynced,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -811,47 +811,10 @@ type ContextGraphCatchupResult = Awaited<ReturnType<DKGAgent['runCatchupOverPeer
 
 const inFlightSyncPageFetchesByAgent = new WeakMap<DKGAgent, Map<string, InFlightSyncPageFetch>>();
 const inFlightSyncSingleFlightsByAgent = new WeakMap<DKGAgent, Map<string, InFlightSyncSingleFlight>>();
-const vmRecoveryEvidenceSinksByAgent = new WeakMap<
-  DKGAgent,
-  Map<string, Set<(peerId: string) => void>>
->();
 const syncPageSizeProfilesByAgent = new WeakMap<DKGAgent, SyncPageSizeProfileCache>();
 const alreadyMemberDelegationRefreshChains = new WeakMap<DKGAgent, Map<string, Promise<void>>>();
 const durableContextGraphSyncChains = new WeakMap<DKGAgent, Map<string, Promise<void>>>();
 const durableRecoveryRunnersByAgent = new WeakMap<DKGAgent, DurableRecoveryRunner>();
-
-function registerVmRecoveryEvidenceSink(
-  agent: DKGAgent,
-  contextGraphId: string,
-  sink: (peerId: string) => void,
-): () => void {
-  let byGraph = vmRecoveryEvidenceSinksByAgent.get(agent);
-  if (!byGraph) {
-    byGraph = new Map();
-    vmRecoveryEvidenceSinksByAgent.set(agent, byGraph);
-  }
-  let sinks = byGraph.get(contextGraphId);
-  if (!sinks) {
-    sinks = new Set();
-    byGraph.set(contextGraphId, sinks);
-  }
-  sinks.add(sink);
-  return () => {
-    sinks?.delete(sink);
-    if (sinks?.size === 0) byGraph?.delete(contextGraphId);
-    if (byGraph?.size === 0) vmRecoveryEvidenceSinksByAgent.delete(agent);
-  };
-}
-
-function recordVmRecoveryCleanPeer(
-  agent: DKGAgent,
-  contextGraphId: string,
-  peerId: string,
-): void {
-  for (const sink of vmRecoveryEvidenceSinksByAgent.get(agent)?.get(contextGraphId) ?? []) {
-    sink(peerId);
-  }
-}
 
 function durableRecoveryRunnerFor(agent: DKGAgent): DurableRecoveryRunner {
   let runner = durableRecoveryRunnersByAgent.get(agent);
@@ -8187,8 +8150,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         totalPeers: orderedPeers.length,
         mode,
         sourceOverride,
-        recordSharedMemoryCleanPeer: (peerId) =>
-          recordVmRecoveryCleanPeer(this, contextGraphId, peerId),
       });
     }, {
       scope: 'context-graph',
@@ -8202,18 +8163,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     options?: ContextGraphCatchupOptions,
   ): Promise<{ catchup: ContextGraphCatchupResult; cleanMissPeerIds: string[] }> {
-    const cleanMissPeerIds = new Set<string>();
-    const unregister = registerVmRecoveryEvidenceSink(
-      this,
-      contextGraphId,
-      (peerId) => cleanMissPeerIds.add(peerId),
-    );
-    try {
-      const catchup = await this.syncContextGraphFromConnectedPeers(contextGraphId, options);
-      return { catchup, cleanMissPeerIds: [...cleanMissPeerIds] };
-    } finally {
-      unregister();
-    }
+    const catchup = await this.syncContextGraphFromConnectedPeers(contextGraphId, options);
+    return {
+      catchup,
+      // Embedders may still override the catch-up method with the pre-evidence
+      // result shape. Treat that legacy shape as no proof; production results
+      // always carry the immutable field below.
+      cleanMissPeerIds: [...(catchup.cleanSharedMemoryPeerIds ?? [])],
+    };
   }
 
   selectCatchupPeerWindow(this: DKGAgent,
@@ -8308,8 +8265,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       sourceOverride?: SyncAdmissionSource;
       /** Explicit test/embedding override; production resolves the operator env per job. */
       swmCatchupPassConfig?: CatchupPassConfig;
-      /** Internal evidence sink used only by the focused VM-recovery wrapper. */
-      recordSharedMemoryCleanPeer?: (peerId: string) => void;
     },
   ): Promise<{
     /** Ordered connected peers before optional caller windowing. */
@@ -8327,6 +8282,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     sharedMemorySynced: number;
     /** A selected peer completed a non-empty SWM snapshot without failure. */
     sharedMemoryCompletedCleanly: boolean;
+    /** Immutable evidence owned by this catch-up operation and its single-flight result. */
+    cleanSharedMemoryPeerIds: readonly string[];
     denied: boolean;
     deniedPeers: number;
     diagnostics: CatchupSyncDiagnostics;
@@ -8340,6 +8297,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let dataSynced = 0;
     let sharedMemorySynced = 0;
     let noProtocolPeers = 0;
+    const cleanSharedMemoryPeerIds = new Set<string>();
     const diagnostics: CatchupSyncDiagnostics = {
       noProtocolPeers: 0,
       durable: {
@@ -8535,7 +8493,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       });
       const sharedProgress = r.shared ? classifyDurableProgress(r.shared) : null;
       if (sharedProgress?.completedWithoutFailure) {
-        stats?.recordSharedMemoryCleanPeer?.(remotePeerId);
+        cleanSharedMemoryPeerIds.add(remotePeerId);
       }
       if (r.shared) {
         passTracker.recordPeerRound(
@@ -8683,7 +8641,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     ): void => {
       const progress = classifyDurableProgress(shared);
       if (progress.completedWithoutFailure) {
-        stats?.recordSharedMemoryCleanPeer?.(remotePeerId);
+        cleanSharedMemoryPeerIds.add(remotePeerId);
       }
       passTracker.recordPeerRound(
         remotePeerId,
@@ -8855,6 +8813,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       dataSynced,
       sharedMemorySynced,
       sharedMemoryCompletedCleanly,
+      cleanSharedMemoryPeerIds: Object.freeze([...cleanSharedMemoryPeerIds]),
       denied: accessDeniedPeers.size > 0,
       deniedPeers: accessDeniedPeers.size,
       diagnostics,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -8098,6 +8098,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
      * or a clean non-metadata-only empty completion.
      */
     peersSucceeded: number;
+    /** Peers whose shared-memory plane completed without failure in this run. */
+    sharedMemoryCleanPeerIds: string[];
     /** Context Graph admissions deferred by local scheduler pressure. */
     deferredBackpressure: number;
     dataSynced: number;
@@ -8302,6 +8304,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     peersTried: number;
     peersResponded: number;
     peersSucceeded: number;
+    /** Peers whose shared-memory plane completed without failure in this run. */
+    sharedMemoryCleanPeerIds: string[];
     deferredBackpressure: number;
     dataSynced: number;
     sharedMemorySynced: number;
@@ -8503,6 +8507,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let cleanDurablePrivateOnlyCompletions = 0;
     let cleanSharedMemoryDataSynced = 0;
     const peersSucceeded = new Set<string>();
+    const sharedMemoryCleanPeerIds = new Set<string>();
     for (const [resultIndex, r] of results.entries()) {
       const remotePeerId = catchupPeers[resultIndex]!;
       // A peer "succeeded" when its sync round finished without a transport
@@ -8514,6 +8519,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         complete: r.durable.complete,
       });
       const sharedProgress = r.shared ? classifyDurableProgress(r.shared) : null;
+      if (sharedProgress?.completedWithoutFailure) {
+        sharedMemoryCleanPeerIds.add(remotePeerId);
+      }
       if (r.shared) {
         passTracker.recordPeerRound(
           remotePeerId,
@@ -8659,6 +8667,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       shared: SharedMemorySyncResult,
     ): void => {
       const progress = classifyDurableProgress(shared);
+      if (progress.completedWithoutFailure) {
+        sharedMemoryCleanPeerIds.add(remotePeerId);
+      }
       passTracker.recordPeerRound(
         remotePeerId,
         shared.swmCoverage,
@@ -8825,6 +8836,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       peersTried,
       peersResponded: peersResponded.size,
       peersSucceeded: peersSucceeded.size,
+      sharedMemoryCleanPeerIds: [...sharedMemoryCleanPeerIds],
       deferredBackpressure,
       dataSynced,
       sharedMemorySynced,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -377,10 +377,9 @@ import { buildCclEvaluationQuads } from './ccl-evaluation-publish.js';
 import { buildManualCclFacts, resolveFactsFromSnapshot, type CclFactResolutionMode } from './ccl-fact-resolution.js';
 import {
   canReuseVmReconcilePeerTopology,
-  decodeVmReconcilePeerTopology,
-  encodeVmReconcilePeerTopology,
+  createVmReconcilePeerTopology,
+  isVmReconcilePeerTopology,
   UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
-  type VmReconcilePeerTopology,
 } from './vm-reconcile-peer-topology.js';
 import {
   stripLiteral, jsonLdToQuads,
@@ -462,6 +461,7 @@ import {
   type ContextGraphSub,
   type ContextGraphSubscriptionRecord,
   type ContextGraphSubscriptionStore,
+  type VmReconcilePeerTopology,
   type SelectedVmReconcileCursorRecord,
   type VmReconcileRotationRecord,
   type ContextGraphMemberPrincipalType,
@@ -4254,12 +4254,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
   }
 
-  async collectVmReconcileSwmCandidateState(this: DKGAgent, localCgId: string): Promise<VmReconcileSwmCandidateState> {
+  async collectVmReconcileSwmCandidateState(
+    this: DKGAgent,
+    localCgId: string,
+    cleanMissPeerIds: readonly string[] = [],
+  ): Promise<VmReconcileSwmCandidateState> {
     const candidateNamespaces = await this.collectVmReconcileSwmCandidateNamespacesBestEffort(localCgId);
     return {
       candidateNamespaces: candidateNamespaces.namespaces,
       swmGen: await this.readVmReconcileSwmGen(candidateNamespaces.namespaces),
-      peerTopology: await this.vmReconcilePeerTopology(localCgId),
+      peerTopology: await this.vmReconcilePeerTopology(localCgId, cleanMissPeerIds),
     };
   }
 
@@ -4302,6 +4306,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
   async vmReconcilePeerTopology(
     this: DKGAgent,
     localCgId: string,
+    cleanMissPeerIds: readonly string[] = [],
   ): Promise<VmReconcilePeerTopology> {
     try {
       const preferredPeerId = await this.resolvePreferredSyncPeerId(localCgId);
@@ -4321,19 +4326,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
         preferredPeerId,
         isPrivateContextGraph,
       );
-      return {
-        kind: 'readable',
+      return createVmReconcilePeerTopology({
         preferredPeerId: preferredPeerId ?? null,
         privateOnly: isPrivateContextGraph,
         peers: orderedPeers.map((peer) => {
           const peerId = peer.toString();
           return {
             peerId,
-            preferred: peerId === preferredPeerId,
             core: this.knownCorePeerIds.has(peerId),
           };
         }),
-      };
+        cleanMissPeerIds,
+      });
     } catch {
       return UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY;
     }
@@ -4545,28 +4549,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
           Array.isArray(durable.candidateNamespaces) &&
           durable.candidateNamespaces.every((item) =>
             typeof item?.metaGraph === 'string' && typeof item?.dataGraph === 'string') &&
-          typeof durable.peerTopologyKey === 'string'
+          isVmReconcilePeerTopology(durable.peerTopology)
         ) {
           if (!this.vmReconcileSwmGenSupportsDurableNegative(durable.swmGen)) {
             await this.config.contextGraphSubscriptionStore
               ?.deleteVmReconcileNegative?.(cacheKey);
           } else {
-            const peerTopology = decodeVmReconcilePeerTopology(durable.peerTopologyKey);
-            if (!peerTopology) {
-              await this.config.contextGraphSubscriptionStore
-                ?.deleteVmReconcileNegative?.(cacheKey);
-            } else {
-              cached = {
-                localCgId: durable.localCgId,
-                failures: durable.failures,
-                nextRetryAt: durable.nextRetryAt,
-                swmGen: durable.swmGen,
-                candidateNamespaces: durable.candidateNamespaces,
-                peerTopology,
-              };
-              this.vmReconcileNegativeCache.set(cacheKey, cached);
-              this.indexVmReconcileNegativeCacheEntry(localCgId, cacheKey);
-            }
+            cached = {
+              localCgId: durable.localCgId,
+              failures: durable.failures,
+              nextRetryAt: durable.nextRetryAt,
+              swmGen: durable.swmGen,
+              candidateNamespaces: durable.candidateNamespaces,
+              peerTopology: durable.peerTopology,
+            };
+            this.vmReconcileNegativeCache.set(cacheKey, cached);
+            this.indexVmReconcileNegativeCacheEntry(localCgId, cacheKey);
           }
         }
       } catch {
@@ -4683,7 +4681,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         nextRetryAt: record.nextRetryAt,
         swmGen: record.swmGen,
         candidateNamespaces: record.candidateNamespaces,
-        peerTopologyKey: encodeVmReconcilePeerTopology(record.peerTopology),
+        peerTopology: record.peerTopology,
       }).catch(() => {
         // Persistence is an accelerator only; the process-local gate still works.
       });
@@ -6267,6 +6265,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     let swmState: VmReconcileSwmCandidateState | undefined;
     let activeFetchRan = false;
     let activeFetchHadUsableResponse = false;
+    const cleanMissPeerIds = new Set<string>();
     if (!(await targetMayMaterialize())) return { status: 'skip' };
     let outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
     if (outcome === 'no-swm' || outcome === 'verified-vm-metadata-pending') {
@@ -6353,6 +6352,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
               continue;
             }
             activeFetchHadUsableResponse = true;
+            for (const peerId of fetchResult.sharedMemoryCleanPeerIds ?? []) {
+              cleanMissPeerIds.add(peerId);
+            }
           } catch (err) {
             this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
             if (fixedMaxAttempts === undefined) {
@@ -6367,7 +6369,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
           outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
         }
         if (outcome === 'no-swm') {
-          swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
+          swmState = await this.collectVmReconcileSwmCandidateState(
+            localCgId,
+            [...cleanMissPeerIds],
+          );
         }
       } else {
         const reason = batchAllowsFetch ? 'per-CG cooldown' : 'per-batch fetch budget';

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -380,7 +380,9 @@ import {
   canReuseVmReconcilePeerTopology,
   createVmReconcileCleanMissPeerIds,
   createVmReconcilePeerTopology,
+  encodeLegacyVmReconcilePeerTopologyKey,
   isVmReconcilePeerTopology,
+  parseLegacyVmReconcilePeerTopologyKey,
   parseVmReconcileCleanMissPeerIds,
   UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
 } from './vm-reconcile-peer-topology.js';
@@ -4540,10 +4542,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
       try {
         const durable = await this.config.contextGraphSubscriptionStore
           ?.loadVmReconcileNegative?.(cacheKey);
-        const durableCleanMissPeerIds = durable && isVmReconcilePeerTopology(durable.peerTopology)
+        const durablePeerTopology = durable
+          ? isVmReconcilePeerTopology(durable.peerTopology)
+            ? durable.peerTopology
+            : parseLegacyVmReconcilePeerTopologyKey(durable.peerTopologyKey)
+          : null;
+        const durableCleanMissPeerIds = durablePeerTopology
           ? parseVmReconcileCleanMissPeerIds(
-            durable.cleanMissPeerIds ?? [],
-            durable.peerTopology,
+            durable?.cleanMissPeerIds ?? [],
+            durablePeerTopology,
           )
           : null;
         if (
@@ -4556,7 +4563,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           Array.isArray(durable.candidateNamespaces) &&
           durable.candidateNamespaces.every((item) =>
             typeof item?.metaGraph === 'string' && typeof item?.dataGraph === 'string') &&
-          isVmReconcilePeerTopology(durable.peerTopology) &&
+          durablePeerTopology !== null &&
           durableCleanMissPeerIds !== null
         ) {
           if (!this.vmReconcileSwmGenSupportsDurableNegative(durable.swmGen)) {
@@ -4569,7 +4576,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
               nextRetryAt: durable.nextRetryAt,
               swmGen: durable.swmGen,
               candidateNamespaces: durable.candidateNamespaces,
-              peerTopology: durable.peerTopology,
+              peerTopology: durablePeerTopology,
               cleanMissPeerIds: durableCleanMissPeerIds,
             };
             this.vmReconcileNegativeCache.set(cacheKey, cached);
@@ -4694,6 +4701,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         nextRetryAt: record.nextRetryAt,
         swmGen: record.swmGen,
         candidateNamespaces: record.candidateNamespaces,
+        peerTopologyKey: encodeLegacyVmReconcilePeerTopologyKey(record.peerTopology),
         peerTopology: record.peerTopology,
         cleanMissPeerIds: record.cleanMissPeerIds,
       }).catch(() => {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -4329,6 +4329,63 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
   }
 
+  vmReconcilePeerTopologyCanReuse(this: DKGAgent,
+    cachedKey: string,
+    currentKey: string,
+  ): boolean {
+    if (cachedKey === currentKey) return true;
+    if (cachedKey === 'unreadable' || currentKey === 'unreadable') return false;
+    try {
+      type TopologyPeer = {
+        peerId: string;
+        preferred: boolean;
+        core: boolean;
+      };
+      type Topology = {
+        preferredPeerId: string | null;
+        privateOnly: boolean;
+        peers: TopologyPeer[];
+      };
+      const cached = JSON.parse(cachedKey) as Topology;
+      const current = JSON.parse(currentKey) as Topology;
+      if (
+        cached.preferredPeerId !== current.preferredPeerId
+        || cached.privateOnly !== current.privateOnly
+        || !Array.isArray(cached.peers)
+        || !Array.isArray(current.peers)
+      ) {
+        return false;
+      }
+
+      // A provider disappearing cannot make an unchanged historical miss
+      // fetchable. Preserve the backoff when the current ranked providers are
+      // only a capability-preserving subsequence of those already checked.
+      // Additions, reclassification, or ranking changes still fail open to a
+      // fresh fetch so newly useful evidence is never hidden by this cache.
+      let cachedIndex = 0;
+      for (const peer of current.peers) {
+        while (
+          cachedIndex < cached.peers.length
+          && cached.peers[cachedIndex]?.peerId !== peer.peerId
+        ) {
+          cachedIndex++;
+        }
+        const cachedPeer = cached.peers[cachedIndex];
+        if (
+          !cachedPeer
+          || cachedPeer.preferred !== peer.preferred
+          || cachedPeer.core !== peer.core
+        ) {
+          return false;
+        }
+        cachedIndex++;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async readVmReconcileSwmGen(this: DKGAgent, candidateNamespaces: VmReconcileSwmNamespace[]): Promise<string | null> {
     if (candidateNamespaces.length === 0) return 'empty:0';
     try {
@@ -4567,7 +4624,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Best effort only; an unchanged connection view can still honor the
         // cached miss until the backoff expires.
       }
-      if (await this.vmReconcilePeerTopologyKey(localCgId) !== cached.peerTopologyKey) {
+      const currentPeerTopologyKey = await this.vmReconcilePeerTopologyKey(localCgId);
+      if (!this.vmReconcilePeerTopologyCanReuse(cached.peerTopologyKey, currentPeerTopologyKey)) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         this.clearVmReconcileActiveFetchCooldown(localCgId);
         return false;

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -368,13 +368,20 @@ type VmReconcileSwmCandidateNamespaces = { namespaces: VmReconcileSwmNamespace[]
 type VmReconcileSwmCandidateState = {
   swmGen: string | null;
   candidateNamespaces: VmReconcileSwmNamespace[];
-  peerTopologyKey: string;
+  peerTopology: VmReconcilePeerTopology;
 };
 import { multiaddr } from '@multiformats/multiaddr';
 import { buildCclPolicyQuads, buildPolicyApprovalQuads, buildPolicyRevocationQuads, hashCclPolicy, type CclPolicyRecord, type PolicyApprovalBinding } from './ccl-policy.js';
 import { CclEvaluator, parseCclPolicy, validateCclPolicy, type CclEvaluationResult, type CclFactTuple } from './ccl-evaluator.js';
 import { buildCclEvaluationQuads } from './ccl-evaluation-publish.js';
 import { buildManualCclFacts, resolveFactsFromSnapshot, type CclFactResolutionMode } from './ccl-fact-resolution.js';
+import {
+  canReuseVmReconcilePeerTopology,
+  decodeVmReconcilePeerTopology,
+  encodeVmReconcilePeerTopology,
+  UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
+  type VmReconcilePeerTopology,
+} from './vm-reconcile-peer-topology.js';
 import {
   stripLiteral, jsonLdToQuads,
   type JsonLdContent,
@@ -4252,7 +4259,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return {
       candidateNamespaces: candidateNamespaces.namespaces,
       swmGen: await this.readVmReconcileSwmGen(candidateNamespaces.namespaces),
-      peerTopologyKey: await this.vmReconcilePeerTopologyKey(localCgId),
+      peerTopology: await this.vmReconcilePeerTopology(localCgId),
     };
   }
 
@@ -4292,13 +4299,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
       .join('\n');
   }
 
-  async vmReconcilePeerTopologyKey(this: DKGAgent, localCgId: string): Promise<string> {
+  async vmReconcilePeerTopology(
+    this: DKGAgent,
+    localCgId: string,
+  ): Promise<VmReconcilePeerTopology> {
     try {
       const preferredPeerId = await this.resolvePreferredSyncPeerId(localCgId);
       const isPrivateContextGraph = await this.isPrivateContextGraph(localCgId);
       const libp2p = (this.node as any)?.libp2p;
       const getConnections = libp2p?.getConnections;
-      if (typeof getConnections !== 'function') return 'unreadable';
+      if (typeof getConnections !== 'function') return UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY;
       const peerIds = [...new Map(
         (getConnections.call(libp2p) as Array<{ remotePeer?: { toString(): string } }>)
           .map((connection) => [connection.remotePeer?.toString(), connection.remotePeer] as const)
@@ -4311,78 +4321,21 @@ export class SwmHostModeMethods extends DKGAgentBase {
         preferredPeerId,
         isPrivateContextGraph,
       );
-      return JSON.stringify({
+      return {
+        kind: 'readable',
         preferredPeerId: preferredPeerId ?? null,
         privateOnly: isPrivateContextGraph,
-        peers: orderedPeers.map((peer, rank) => {
+        peers: orderedPeers.map((peer) => {
           const peerId = peer.toString();
           return {
-            rank,
             peerId,
             preferred: peerId === preferredPeerId,
             core: this.knownCorePeerIds.has(peerId),
           };
         }),
-      });
-    } catch {
-      return 'unreadable';
-    }
-  }
-
-  vmReconcilePeerTopologyCanReuse(this: DKGAgent,
-    cachedKey: string,
-    currentKey: string,
-  ): boolean {
-    if (cachedKey === currentKey) return true;
-    if (cachedKey === 'unreadable' || currentKey === 'unreadable') return false;
-    try {
-      type TopologyPeer = {
-        peerId: string;
-        preferred: boolean;
-        core: boolean;
       };
-      type Topology = {
-        preferredPeerId: string | null;
-        privateOnly: boolean;
-        peers: TopologyPeer[];
-      };
-      const cached = JSON.parse(cachedKey) as Topology;
-      const current = JSON.parse(currentKey) as Topology;
-      if (
-        cached.preferredPeerId !== current.preferredPeerId
-        || cached.privateOnly !== current.privateOnly
-        || !Array.isArray(cached.peers)
-        || !Array.isArray(current.peers)
-      ) {
-        return false;
-      }
-
-      // A provider disappearing cannot make an unchanged historical miss
-      // fetchable. Preserve the backoff when the current ranked providers are
-      // only a capability-preserving subsequence of those already checked.
-      // Additions, reclassification, or ranking changes still fail open to a
-      // fresh fetch so newly useful evidence is never hidden by this cache.
-      let cachedIndex = 0;
-      for (const peer of current.peers) {
-        while (
-          cachedIndex < cached.peers.length
-          && cached.peers[cachedIndex]?.peerId !== peer.peerId
-        ) {
-          cachedIndex++;
-        }
-        const cachedPeer = cached.peers[cachedIndex];
-        if (
-          !cachedPeer
-          || cachedPeer.preferred !== peer.preferred
-          || cachedPeer.core !== peer.core
-        ) {
-          return false;
-        }
-        cachedIndex++;
-      }
-      return true;
     } catch {
-      return false;
+      return UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY;
     }
   }
 
@@ -4598,16 +4551,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
             await this.config.contextGraphSubscriptionStore
               ?.deleteVmReconcileNegative?.(cacheKey);
           } else {
-            cached = {
-              localCgId: durable.localCgId,
-              failures: durable.failures,
-              nextRetryAt: durable.nextRetryAt,
-              swmGen: durable.swmGen,
-              candidateNamespaces: durable.candidateNamespaces,
-              peerTopologyKey: durable.peerTopologyKey,
-            };
-            this.vmReconcileNegativeCache.set(cacheKey, cached);
-            this.indexVmReconcileNegativeCacheEntry(localCgId, cacheKey);
+            const peerTopology = decodeVmReconcilePeerTopology(durable.peerTopologyKey);
+            if (!peerTopology) {
+              await this.config.contextGraphSubscriptionStore
+                ?.deleteVmReconcileNegative?.(cacheKey);
+            } else {
+              cached = {
+                localCgId: durable.localCgId,
+                failures: durable.failures,
+                nextRetryAt: durable.nextRetryAt,
+                swmGen: durable.swmGen,
+                candidateNamespaces: durable.candidateNamespaces,
+                peerTopology,
+              };
+              this.vmReconcileNegativeCache.set(cacheKey, cached);
+              this.indexVmReconcileNegativeCacheEntry(localCgId, cacheKey);
+            }
           }
         }
       } catch {
@@ -4624,8 +4583,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Best effort only; an unchanged connection view can still honor the
         // cached miss until the backoff expires.
       }
-      const currentPeerTopologyKey = await this.vmReconcilePeerTopologyKey(localCgId);
-      if (!this.vmReconcilePeerTopologyCanReuse(cached.peerTopologyKey, currentPeerTopologyKey)) {
+      const currentPeerTopology = await this.vmReconcilePeerTopology(localCgId);
+      if (!canReuseVmReconcilePeerTopology(cached.peerTopology, currentPeerTopology)) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         this.clearVmReconcileActiveFetchCooldown(localCgId);
         return false;
@@ -4710,7 +4669,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       nextRetryAt: Date.now() + backoff,
       swmGen: state.swmGen,
       candidateNamespaces: state.candidateNamespaces,
-      peerTopologyKey: state.peerTopologyKey,
+      peerTopology: state.peerTopology,
     };
     this.vmReconcileNegativeCache.set(cacheKey, record);
     this.markVmReconcileNegativeCacheHydrated(cacheKey, localCgId);
@@ -4719,7 +4678,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (this.vmReconcileSwmGenSupportsDurableNegative(record.swmGen)) {
       void durableStore?.saveVmReconcileNegative?.({
         cacheKey,
-        ...record,
+        localCgId: record.localCgId,
+        failures: record.failures,
+        nextRetryAt: record.nextRetryAt,
+        swmGen: record.swmGen,
+        candidateNamespaces: record.candidateNamespaces,
+        peerTopologyKey: encodeVmReconcilePeerTopology(record.peerTopology),
       }).catch(() => {
         // Persistence is an accelerator only; the process-local gate still works.
       });

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -369,6 +369,7 @@ type VmReconcileSwmCandidateState = {
   swmGen: string | null;
   candidateNamespaces: VmReconcileSwmNamespace[];
   peerTopology: VmReconcilePeerTopology;
+  cleanMissPeerIds: string[];
 };
 import { multiaddr } from '@multiformats/multiaddr';
 import { buildCclPolicyQuads, buildPolicyApprovalQuads, buildPolicyRevocationQuads, hashCclPolicy, type CclPolicyRecord, type PolicyApprovalBinding } from './ccl-policy.js';
@@ -377,8 +378,10 @@ import { buildCclEvaluationQuads } from './ccl-evaluation-publish.js';
 import { buildManualCclFacts, resolveFactsFromSnapshot, type CclFactResolutionMode } from './ccl-fact-resolution.js';
 import {
   canReuseVmReconcilePeerTopology,
+  createVmReconcileCleanMissPeerIds,
   createVmReconcilePeerTopology,
   isVmReconcilePeerTopology,
+  parseVmReconcileCleanMissPeerIds,
   UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
 } from './vm-reconcile-peer-topology.js';
 import {
@@ -4257,13 +4260,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
   async collectVmReconcileSwmCandidateState(
     this: DKGAgent,
     localCgId: string,
-    cleanMissPeerIds: readonly string[] = [],
   ): Promise<VmReconcileSwmCandidateState> {
     const candidateNamespaces = await this.collectVmReconcileSwmCandidateNamespacesBestEffort(localCgId);
     return {
       candidateNamespaces: candidateNamespaces.namespaces,
       swmGen: await this.readVmReconcileSwmGen(candidateNamespaces.namespaces),
-      peerTopology: await this.vmReconcilePeerTopology(localCgId, cleanMissPeerIds),
+      peerTopology: await this.vmReconcilePeerTopology(localCgId),
+      cleanMissPeerIds: [],
     };
   }
 
@@ -4306,7 +4309,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
   async vmReconcilePeerTopology(
     this: DKGAgent,
     localCgId: string,
-    cleanMissPeerIds: readonly string[] = [],
   ): Promise<VmReconcilePeerTopology> {
     try {
       const preferredPeerId = await this.resolvePreferredSyncPeerId(localCgId);
@@ -4336,7 +4338,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
             core: this.knownCorePeerIds.has(peerId),
           };
         }),
-        cleanMissPeerIds,
       });
     } catch {
       return UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY;
@@ -4539,6 +4540,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
       try {
         const durable = await this.config.contextGraphSubscriptionStore
           ?.loadVmReconcileNegative?.(cacheKey);
+        const durableCleanMissPeerIds = durable && isVmReconcilePeerTopology(durable.peerTopology)
+          ? parseVmReconcileCleanMissPeerIds(
+            durable.cleanMissPeerIds ?? [],
+            durable.peerTopology,
+          )
+          : null;
         if (
           durable &&
           durable.cacheKey === cacheKey &&
@@ -4549,7 +4556,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
           Array.isArray(durable.candidateNamespaces) &&
           durable.candidateNamespaces.every((item) =>
             typeof item?.metaGraph === 'string' && typeof item?.dataGraph === 'string') &&
-          isVmReconcilePeerTopology(durable.peerTopology)
+          isVmReconcilePeerTopology(durable.peerTopology) &&
+          durableCleanMissPeerIds !== null
         ) {
           if (!this.vmReconcileSwmGenSupportsDurableNegative(durable.swmGen)) {
             await this.config.contextGraphSubscriptionStore
@@ -4562,6 +4570,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
               swmGen: durable.swmGen,
               candidateNamespaces: durable.candidateNamespaces,
               peerTopology: durable.peerTopology,
+              cleanMissPeerIds: durableCleanMissPeerIds,
             };
             this.vmReconcileNegativeCache.set(cacheKey, cached);
             this.indexVmReconcileNegativeCacheEntry(localCgId, cacheKey);
@@ -4582,7 +4591,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // cached miss until the backoff expires.
       }
       const currentPeerTopology = await this.vmReconcilePeerTopology(localCgId);
-      if (!canReuseVmReconcilePeerTopology(cached.peerTopology, currentPeerTopology)) {
+      if (!canReuseVmReconcilePeerTopology({
+        topology: cached.peerTopology,
+        cleanMissPeerIds: cached.cleanMissPeerIds,
+      }, currentPeerTopology)) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         this.clearVmReconcileActiveFetchCooldown(localCgId);
         return false;
@@ -4668,6 +4680,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       swmGen: state.swmGen,
       candidateNamespaces: state.candidateNamespaces,
       peerTopology: state.peerTopology,
+      cleanMissPeerIds: state.cleanMissPeerIds,
     };
     this.vmReconcileNegativeCache.set(cacheKey, record);
     this.markVmReconcileNegativeCacheHydrated(cacheKey, localCgId);
@@ -4682,6 +4695,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         swmGen: record.swmGen,
         candidateNamespaces: record.candidateNamespaces,
         peerTopology: record.peerTopology,
+        cleanMissPeerIds: record.cleanMissPeerIds,
       }).catch(() => {
         // Persistence is an accelerator only; the process-local gate still works.
       });
@@ -6327,7 +6341,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
             break;
           }
           try {
-            const fetchResult = await this.syncContextGraphFromConnectedPeers(localCgId, {
+            const recovery = await this.syncVmRecoveryFromConnectedPeers(localCgId, {
               includeSharedMemory: true,
               maxPeers: 1,
               peerRotationKey: localCgId,
@@ -6338,6 +6352,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
               // selection and the coalescing key are all unchanged.
               sourceOverride: 'vm-recovery',
             });
+            const fetchResult = recovery.catchup;
             if (fixedMaxAttempts === undefined) {
               maxAttempts = Math.max(
                 maxAttempts,
@@ -6352,7 +6367,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
               continue;
             }
             activeFetchHadUsableResponse = true;
-            for (const peerId of fetchResult.sharedMemoryCleanPeerIds ?? []) {
+            for (const peerId of recovery.cleanMissPeerIds) {
               cleanMissPeerIds.add(peerId);
             }
           } catch (err) {
@@ -6369,8 +6384,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
           outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
         }
         if (outcome === 'no-swm') {
-          swmState = await this.collectVmReconcileSwmCandidateState(
-            localCgId,
+          swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
+          swmState.cleanMissPeerIds = createVmReconcileCleanMissPeerIds(
+            swmState.peerTopology,
             [...cleanMissPeerIds],
           );
         }

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -778,6 +778,23 @@ export interface ContextGraphSubscriptionRecord {
   syncScoped: boolean;
 }
 
+export interface VmReconcilePeerTopologyPeer {
+  peerId: string;
+  core: boolean;
+}
+
+export type VmReconcilePeerTopology =
+  | { kind: 'unreadable' }
+  | {
+    kind: 'readable';
+    preferredPeerId: string | null;
+    privateOnly: boolean;
+    /** Ranked provider order; array position is the rank. */
+    peers: VmReconcilePeerTopologyPeer[];
+    /** Peers that completed a clean SWM round while the cached miss was recorded. */
+    cleanMissPeerIds: string[];
+  };
+
 export interface ContextGraphSubscriptionStore {
   loadAll(): Promise<ContextGraphSubscriptionRecord[]>;
   load?(contextGraphId: string): Promise<ContextGraphSubscriptionRecord | null>;
@@ -829,7 +846,7 @@ export interface VmReconcileNegativeRecord {
   nextRetryAt: number;
   swmGen: string;
   candidateNamespaces: Array<{ metaGraph: string; dataGraph: string }>;
-  peerTopologyKey: string;
+  peerTopology: VmReconcilePeerTopology;
 }
 
 /** Process-local evidence for one chain-ordinal exact-recovery rotation. */

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -850,9 +850,16 @@ export interface VmReconcileNegativeRecord {
   nextRetryAt: number;
   swmGen: string;
   candidateNamespaces: Array<{ metaGraph: string; dataGraph: string }>;
-  peerTopology: VmReconcilePeerTopology;
-  /** Peers that completed a clean SWM round while this miss was recorded. */
-  cleanMissPeerIds: string[];
+  /**
+   * Legacy serialized topology contract. Required during the v1-to-v2
+   * migration so existing custom stores can keep reading and persisting the
+   * field they were compiled against.
+   */
+  peerTopologyKey: string;
+  /** Typed topology used by v2-aware stores; absent when loading a legacy row. */
+  peerTopology?: VmReconcilePeerTopology;
+  /** V2 clean-miss evidence; absent legacy records conservatively imply none. */
+  cleanMissPeerIds?: string[];
 }
 
 /** Process-local evidence for one chain-ordinal exact-recovery rotation. */

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -791,9 +791,13 @@ export type VmReconcilePeerTopology =
     privateOnly: boolean;
     /** Ranked provider order; array position is the rank. */
     peers: VmReconcilePeerTopologyPeer[];
-    /** Peers that completed a clean SWM round while the cached miss was recorded. */
-    cleanMissPeerIds: string[];
   };
+
+/** Historical proof attached to a cached miss, separate from live topology. */
+export interface VmReconcilePeerTopologyEvidence {
+  topology: VmReconcilePeerTopology;
+  cleanMissPeerIds: string[];
+}
 
 export interface ContextGraphSubscriptionStore {
   loadAll(): Promise<ContextGraphSubscriptionRecord[]>;
@@ -847,6 +851,8 @@ export interface VmReconcileNegativeRecord {
   swmGen: string;
   candidateNamespaces: Array<{ metaGraph: string; dataGraph: string }>;
   peerTopology: VmReconcilePeerTopology;
+  /** Peers that completed a clean SWM round while this miss was recorded. */
+  cleanMissPeerIds: string[];
 }
 
 /** Process-local evidence for one chain-ordinal exact-recovery rotation. */

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -406,7 +406,9 @@ export { mapWithConcurrency } from './map-with-concurrency.js';
 export {
   createVmReconcilePeerTopology,
   createVmReconcileCleanMissPeerIds,
+  encodeLegacyVmReconcilePeerTopologyKey,
   isVmReconcilePeerTopology,
+  parseLegacyVmReconcilePeerTopologyKey,
   parseVmReconcileCleanMissPeerIds,
   parseVmReconcilePeerTopology,
 } from './vm-reconcile-peer-topology.js';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -300,6 +300,9 @@ export {
   type ContextGraphSubscriptionRecord,
   type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
+  type VmReconcileNegativeRecord,
+  type VmReconcilePeerTopology,
+  type VmReconcilePeerTopologyPeer,
   type SelectedVmReconcileCursorStore,
   type SelectedVmReconcileCursorRecord,
   type ContextGraphWritePreflightProbe,
@@ -399,6 +402,10 @@ export {
 // registry-scale per-peer fan-out and must be bounded by the SAME knob, without
 // deep-importing the compiled `dist/` module.
 export { mapWithConcurrency } from './map-with-concurrency.js';
+export {
+  createVmReconcilePeerTopology,
+  isVmReconcilePeerTopology,
+} from './vm-reconcile-peer-topology.js';
 export {
   CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
   CATCHUP_STOP_ON_PROOF,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -302,6 +302,7 @@ export {
   type ContextGraphSubscriptionStore,
   type VmReconcileNegativeRecord,
   type VmReconcilePeerTopology,
+  type VmReconcilePeerTopologyEvidence,
   type VmReconcilePeerTopologyPeer,
   type SelectedVmReconcileCursorStore,
   type SelectedVmReconcileCursorRecord,
@@ -404,7 +405,10 @@ export {
 export { mapWithConcurrency } from './map-with-concurrency.js';
 export {
   createVmReconcilePeerTopology,
+  createVmReconcileCleanMissPeerIds,
   isVmReconcilePeerTopology,
+  parseVmReconcileCleanMissPeerIds,
+  parseVmReconcilePeerTopology,
 } from './vm-reconcile-peer-topology.js';
 export {
   CATCHUP_MAX_CONCURRENT_PEER_SYNCS,

--- a/packages/agent/src/vm-reconcile-peer-topology.ts
+++ b/packages/agent/src/vm-reconcile-peer-topology.ts
@@ -1,5 +1,6 @@
 import type {
   VmReconcilePeerTopology,
+  VmReconcilePeerTopologyEvidence,
   VmReconcilePeerTopologyPeer,
 } from './dkg-agent-types.js';
 
@@ -10,7 +11,6 @@ export function createVmReconcilePeerTopology(input: {
   preferredPeerId: string | null;
   privateOnly: boolean;
   peers: readonly VmReconcilePeerTopologyPeer[];
-  cleanMissPeerIds?: readonly string[];
 }): VmReconcilePeerTopology {
   const seenPeerIds = new Set<string>();
   const peers = input.peers.filter((peer) => {
@@ -18,51 +18,74 @@ export function createVmReconcilePeerTopology(input: {
     seenPeerIds.add(peer.peerId);
     return true;
   }).map((peer) => ({ peerId: peer.peerId, core: peer.core }));
-  const cleanMissPeerIds = [...new Set(input.cleanMissPeerIds ?? [])]
-    .filter((peerId) => seenPeerIds.has(peerId));
   return {
     kind: 'readable',
     preferredPeerId: input.preferredPeerId,
     privateOnly: input.privateOnly,
     peers,
-    cleanMissPeerIds,
   };
 }
 
-/** Defensive guard for custom ContextGraphSubscriptionStore implementations. */
-export function isVmReconcilePeerTopology(value: unknown): value is VmReconcilePeerTopology {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+/** One agent-owned parser for live and persistence-adapter topology input. */
+export function parseVmReconcilePeerTopology(value: unknown): VmReconcilePeerTopology | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const topology = value as Record<string, unknown>;
-  if (topology.kind === 'unreadable') return true;
+  if (topology.kind === 'unreadable') return UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY;
   if (
     topology.kind !== 'readable'
     || !(topology.preferredPeerId === null || typeof topology.preferredPeerId === 'string')
     || typeof topology.privateOnly !== 'boolean'
     || !Array.isArray(topology.peers)
-    || !Array.isArray(topology.cleanMissPeerIds)
-  ) return false;
+  ) return null;
   const peerIds = new Set<string>();
   for (const candidate of topology.peers) {
-    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return false;
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
     const peer = candidate as Record<string, unknown>;
     if (
       typeof peer.peerId !== 'string'
       || peer.peerId.length === 0
       || typeof peer.core !== 'boolean'
       || peerIds.has(peer.peerId)
-    ) return false;
+    ) return null;
     peerIds.add(peer.peerId);
   }
-  const cleanMisses = new Set<string>();
-  for (const peerId of topology.cleanMissPeerIds) {
-    if (
-      typeof peerId !== 'string'
-      || !peerIds.has(peerId)
-      || cleanMisses.has(peerId)
-    ) return false;
-    cleanMisses.add(peerId);
+  return createVmReconcilePeerTopology({
+    preferredPeerId: topology.preferredPeerId,
+    privateOnly: topology.privateOnly,
+    peers: topology.peers as VmReconcilePeerTopologyPeer[],
+  });
+}
+
+/** Defensive guard for custom ContextGraphSubscriptionStore implementations. */
+export function isVmReconcilePeerTopology(value: unknown): value is VmReconcilePeerTopology {
+  return parseVmReconcilePeerTopology(value) !== null;
+}
+
+export function parseVmReconcileCleanMissPeerIds(
+  value: unknown,
+  topology: VmReconcilePeerTopology,
+): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const peers = topology.kind === 'readable'
+    ? new Set(topology.peers.map((peer) => peer.peerId))
+    : new Set<string>();
+  const seen = new Set<string>();
+  const cleanMissPeerIds: string[] = [];
+  for (const peerId of value) {
+    if (typeof peerId !== 'string' || !peers.has(peerId) || seen.has(peerId)) return null;
+    seen.add(peerId);
+    cleanMissPeerIds.push(peerId);
   }
-  return true;
+  return cleanMissPeerIds;
+}
+
+export function createVmReconcileCleanMissPeerIds(
+  topology: VmReconcilePeerTopology,
+  peerIds: readonly string[],
+): string[] {
+  if (topology.kind === 'unreadable') return [];
+  const topologyPeers = new Set(topology.peers.map((peer) => peer.peerId));
+  return [...new Set(peerIds)].filter((peerId) => topologyPeers.has(peerId));
 }
 
 /**
@@ -72,15 +95,16 @@ export function isVmReconcilePeerTopology(value: unknown): value is VmReconcileP
  * absence evidence.
  */
 export function canReuseVmReconcilePeerTopology(
-  cached: VmReconcilePeerTopology,
+  cached: VmReconcilePeerTopologyEvidence,
   current: VmReconcilePeerTopology,
 ): boolean {
-  if (cached.kind === 'unreadable' || current.kind === 'unreadable') {
-    return cached.kind === current.kind;
+  const cachedTopology = cached.topology;
+  if (cachedTopology.kind === 'unreadable' || current.kind === 'unreadable') {
+    return cachedTopology.kind === current.kind;
   }
   if (
-    cached.preferredPeerId !== current.preferredPeerId
-    || cached.privateOnly !== current.privateOnly
+    cachedTopology.preferredPeerId !== current.preferredPeerId
+    || cachedTopology.privateOnly !== current.privateOnly
   ) {
     return false;
   }
@@ -90,8 +114,8 @@ export function canReuseVmReconcilePeerTopology(
     right: VmReconcilePeerTopologyPeer,
   ): boolean => left.peerId === right.peerId && left.core === right.core;
   if (
-    cached.peers.length === current.peers.length
-    && current.peers.every((peer, index) => peersMatch(cached.peers[index]!, peer))
+    cachedTopology.peers.length === current.peers.length
+    && current.peers.every((peer, index) => peersMatch(cachedTopology.peers[index]!, peer))
   ) {
     return true;
   }
@@ -99,12 +123,12 @@ export function canReuseVmReconcilePeerTopology(
   let cachedIndex = 0;
   for (const peer of current.peers) {
     while (
-      cachedIndex < cached.peers.length
-      && cached.peers[cachedIndex]?.peerId !== peer.peerId
+      cachedIndex < cachedTopology.peers.length
+      && cachedTopology.peers[cachedIndex]?.peerId !== peer.peerId
     ) {
       cachedIndex += 1;
     }
-    const cachedPeer = cached.peers[cachedIndex];
+    const cachedPeer = cachedTopology.peers[cachedIndex];
     if (
       !cachedPeer
       || !peersMatch(cachedPeer, peer)

--- a/packages/agent/src/vm-reconcile-peer-topology.ts
+++ b/packages/agent/src/vm-reconcile-peer-topology.ts
@@ -61,6 +61,62 @@ export function isVmReconcilePeerTopology(value: unknown): value is VmReconcileP
   return parseVmReconcilePeerTopology(value) !== null;
 }
 
+/** Exact pre-v2 encoding retained for third-party subscription-store adapters. */
+export function encodeLegacyVmReconcilePeerTopologyKey(
+  topology: VmReconcilePeerTopology,
+): string {
+  if (topology.kind === 'unreadable') return 'unreadable';
+  return JSON.stringify({
+    preferredPeerId: topology.preferredPeerId,
+    privateOnly: topology.privateOnly,
+    peers: topology.peers.map((peer, rank) => ({
+      rank,
+      peerId: peer.peerId,
+      preferred: peer.peerId === topology.preferredPeerId,
+      core: peer.core,
+    })),
+  });
+}
+
+/** Decode the public store's pre-v2 peerTopologyKey representation. */
+export function parseLegacyVmReconcilePeerTopologyKey(
+  value: unknown,
+): VmReconcilePeerTopology | null {
+  if (value === 'unreadable') return UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY;
+  if (typeof value !== 'string') return null;
+  try {
+    const decoded: unknown = JSON.parse(value);
+    if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) return null;
+    const raw = decoded as Record<string, unknown>;
+    if (
+      !(raw.preferredPeerId === null || typeof raw.preferredPeerId === 'string')
+      || typeof raw.privateOnly !== 'boolean'
+      || !Array.isArray(raw.peers)
+    ) return null;
+    const peers: unknown[] = [];
+    for (const [rank, candidate] of raw.peers.entries()) {
+      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
+      const peer = candidate as Record<string, unknown>;
+      if (
+        peer.rank !== rank
+        || typeof peer.peerId !== 'string'
+        || typeof peer.preferred !== 'boolean'
+        || peer.preferred !== (peer.peerId === raw.preferredPeerId)
+        || typeof peer.core !== 'boolean'
+      ) return null;
+      peers.push({ peerId: peer.peerId, core: peer.core });
+    }
+    return parseVmReconcilePeerTopology({
+      kind: 'readable',
+      preferredPeerId: raw.preferredPeerId,
+      privateOnly: raw.privateOnly,
+      peers,
+    });
+  } catch {
+    return null;
+  }
+}
+
 export function parseVmReconcileCleanMissPeerIds(
   value: unknown,
   topology: VmReconcilePeerTopology,

--- a/packages/agent/src/vm-reconcile-peer-topology.ts
+++ b/packages/agent/src/vm-reconcile-peer-topology.ts
@@ -1,0 +1,127 @@
+export type VmReconcilePeerTopologyPeer = {
+  peerId: string;
+  preferred: boolean;
+  core: boolean;
+};
+
+export type VmReconcilePeerTopology =
+  | { kind: 'unreadable' }
+  | {
+    kind: 'readable';
+    preferredPeerId: string | null;
+    privateOnly: boolean;
+    peers: VmReconcilePeerTopologyPeer[];
+  };
+
+export const UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY: VmReconcilePeerTopology = {
+  kind: 'unreadable',
+};
+const VM_RECONCILE_PEER_TOPOLOGY_VERSION = 1;
+
+/** Serialize the typed process-local topology only when crossing the durable-store boundary. */
+export function encodeVmReconcilePeerTopology(topology: VmReconcilePeerTopology): string {
+  if (topology.kind === 'unreadable') return 'unreadable';
+  return JSON.stringify({
+    version: VM_RECONCILE_PEER_TOPOLOGY_VERSION,
+    preferredPeerId: topology.preferredPeerId,
+    privateOnly: topology.privateOnly,
+    peers: topology.peers.map((peer, rank) => ({ rank, ...peer })),
+  });
+}
+
+/**
+ * Decode and validate the legacy string persistence contract. The explicit unreadable
+ * sentinel preserves exact-match behavior; malformed or unknown versions fail open.
+ */
+export function decodeVmReconcilePeerTopology(encoded: string): VmReconcilePeerTopology | null {
+  if (encoded === 'unreadable') return UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY;
+  try {
+    const value: unknown = JSON.parse(encoded);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return null;
+    }
+    const record = value as Record<string, unknown>;
+    if (
+      record.version !== VM_RECONCILE_PEER_TOPOLOGY_VERSION
+      || !(record.preferredPeerId === null || typeof record.preferredPeerId === 'string')
+      || typeof record.privateOnly !== 'boolean'
+      || !Array.isArray(record.peers)
+    ) {
+      return null;
+    }
+
+    const peers: VmReconcilePeerTopologyPeer[] = [];
+    const seenPeerIds = new Set<string>();
+    for (const [rank, candidate] of record.peers.entries()) {
+      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+        return null;
+      }
+      const peer = candidate as Record<string, unknown>;
+      if (
+        peer.rank !== rank
+        || typeof peer.peerId !== 'string'
+        || peer.peerId.length === 0
+        || typeof peer.preferred !== 'boolean'
+        || typeof peer.core !== 'boolean'
+        || peer.preferred !== (peer.peerId === record.preferredPeerId)
+        || seenPeerIds.has(peer.peerId)
+      ) {
+        return null;
+      }
+      seenPeerIds.add(peer.peerId);
+      peers.push({
+        peerId: peer.peerId,
+        preferred: peer.preferred,
+        core: peer.core,
+      });
+    }
+
+    return {
+      kind: 'readable',
+      preferredPeerId: record.preferredPeerId,
+      privateOnly: record.privateOnly,
+      peers,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A missing provider cannot make a prior clean miss fetchable. Reuse is therefore safe only
+ * when the current ranked providers are a capability-preserving subsequence of those checked.
+ */
+export function canReuseVmReconcilePeerTopology(
+  cached: VmReconcilePeerTopology,
+  current: VmReconcilePeerTopology,
+): boolean {
+  if (cached.kind === 'unreadable' || current.kind === 'unreadable') {
+    return cached.kind === current.kind;
+  }
+  if (
+    cached.preferredPeerId !== current.preferredPeerId
+    || cached.privateOnly !== current.privateOnly
+  ) {
+    return false;
+  }
+
+  let cachedIndex = 0;
+  for (const peer of current.peers) {
+    while (
+      cachedIndex < cached.peers.length
+      && cached.peers[cachedIndex]?.peerId !== peer.peerId
+    ) {
+      cachedIndex += 1;
+    }
+    const cachedPeer = cached.peers[cachedIndex];
+    if (
+      !cachedPeer
+      || cachedPeer.preferred !== peer.preferred
+      || cachedPeer.core !== peer.core
+    ) {
+      return false;
+    }
+    cachedIndex += 1;
+  }
+  return true;
+}

--- a/packages/agent/src/vm-reconcile-peer-topology.ts
+++ b/packages/agent/src/vm-reconcile-peer-topology.ts
@@ -1,95 +1,75 @@
-export type VmReconcilePeerTopologyPeer = {
-  peerId: string;
-  preferred: boolean;
-  core: boolean;
-};
-
-export type VmReconcilePeerTopology =
-  | { kind: 'unreadable' }
-  | {
-    kind: 'readable';
-    preferredPeerId: string | null;
-    privateOnly: boolean;
-    peers: VmReconcilePeerTopologyPeer[];
-  };
+import type {
+  VmReconcilePeerTopology,
+  VmReconcilePeerTopologyPeer,
+} from './dkg-agent-types.js';
 
 export const UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY: VmReconcilePeerTopology = {
   kind: 'unreadable',
 };
-const VM_RECONCILE_PEER_TOPOLOGY_VERSION = 1;
-
-/** Serialize the typed process-local topology only when crossing the durable-store boundary. */
-export function encodeVmReconcilePeerTopology(topology: VmReconcilePeerTopology): string {
-  if (topology.kind === 'unreadable') return 'unreadable';
-  return JSON.stringify({
-    version: VM_RECONCILE_PEER_TOPOLOGY_VERSION,
-    preferredPeerId: topology.preferredPeerId,
-    privateOnly: topology.privateOnly,
-    peers: topology.peers.map((peer, rank) => ({ rank, ...peer })),
-  });
+export function createVmReconcilePeerTopology(input: {
+  preferredPeerId: string | null;
+  privateOnly: boolean;
+  peers: readonly VmReconcilePeerTopologyPeer[];
+  cleanMissPeerIds?: readonly string[];
+}): VmReconcilePeerTopology {
+  const seenPeerIds = new Set<string>();
+  const peers = input.peers.filter((peer) => {
+    if (!peer.peerId || seenPeerIds.has(peer.peerId)) return false;
+    seenPeerIds.add(peer.peerId);
+    return true;
+  }).map((peer) => ({ peerId: peer.peerId, core: peer.core }));
+  const cleanMissPeerIds = [...new Set(input.cleanMissPeerIds ?? [])]
+    .filter((peerId) => seenPeerIds.has(peerId));
+  return {
+    kind: 'readable',
+    preferredPeerId: input.preferredPeerId,
+    privateOnly: input.privateOnly,
+    peers,
+    cleanMissPeerIds,
+  };
 }
 
-/**
- * Decode and validate the legacy string persistence contract. The explicit unreadable
- * sentinel preserves exact-match behavior; malformed or unknown versions fail open.
- */
-export function decodeVmReconcilePeerTopology(encoded: string): VmReconcilePeerTopology | null {
-  if (encoded === 'unreadable') return UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY;
-  try {
-    const value: unknown = JSON.parse(encoded);
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return null;
-    }
-    const record = value as Record<string, unknown>;
+/** Defensive guard for custom ContextGraphSubscriptionStore implementations. */
+export function isVmReconcilePeerTopology(value: unknown): value is VmReconcilePeerTopology {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const topology = value as Record<string, unknown>;
+  if (topology.kind === 'unreadable') return true;
+  if (
+    topology.kind !== 'readable'
+    || !(topology.preferredPeerId === null || typeof topology.preferredPeerId === 'string')
+    || typeof topology.privateOnly !== 'boolean'
+    || !Array.isArray(topology.peers)
+    || !Array.isArray(topology.cleanMissPeerIds)
+  ) return false;
+  const peerIds = new Set<string>();
+  for (const candidate of topology.peers) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return false;
+    const peer = candidate as Record<string, unknown>;
     if (
-      record.version !== VM_RECONCILE_PEER_TOPOLOGY_VERSION
-      || !(record.preferredPeerId === null || typeof record.preferredPeerId === 'string')
-      || typeof record.privateOnly !== 'boolean'
-      || !Array.isArray(record.peers)
-    ) {
-      return null;
-    }
-
-    const peers: VmReconcilePeerTopologyPeer[] = [];
-    const seenPeerIds = new Set<string>();
-    for (const [rank, candidate] of record.peers.entries()) {
-      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
-        return null;
-      }
-      const peer = candidate as Record<string, unknown>;
-      if (
-        peer.rank !== rank
-        || typeof peer.peerId !== 'string'
-        || peer.peerId.length === 0
-        || typeof peer.preferred !== 'boolean'
-        || typeof peer.core !== 'boolean'
-        || peer.preferred !== (peer.peerId === record.preferredPeerId)
-        || seenPeerIds.has(peer.peerId)
-      ) {
-        return null;
-      }
-      seenPeerIds.add(peer.peerId);
-      peers.push({
-        peerId: peer.peerId,
-        preferred: peer.preferred,
-        core: peer.core,
-      });
-    }
-
-    return {
-      kind: 'readable',
-      preferredPeerId: record.preferredPeerId,
-      privateOnly: record.privateOnly,
-      peers,
-    };
-  } catch {
-    return null;
+      typeof peer.peerId !== 'string'
+      || peer.peerId.length === 0
+      || typeof peer.core !== 'boolean'
+      || peerIds.has(peer.peerId)
+    ) return false;
+    peerIds.add(peer.peerId);
   }
+  const cleanMisses = new Set<string>();
+  for (const peerId of topology.cleanMissPeerIds) {
+    if (
+      typeof peerId !== 'string'
+      || !peerIds.has(peerId)
+      || cleanMisses.has(peerId)
+    ) return false;
+    cleanMisses.add(peerId);
+  }
+  return true;
 }
 
 /**
- * A missing provider cannot make a prior clean miss fetchable. Reuse is therefore safe only
- * when the current ranked providers are a capability-preserving subsequence of those checked.
+ * Exact topology preserves the existing local-generation backoff. A smaller
+ * topology is reusable only when every remaining peer produced a clean SWM
+ * completion while the miss was recorded; a connected-but-skipped peer is not
+ * absence evidence.
  */
 export function canReuseVmReconcilePeerTopology(
   cached: VmReconcilePeerTopology,
@@ -105,6 +85,17 @@ export function canReuseVmReconcilePeerTopology(
     return false;
   }
 
+  const peersMatch = (
+    left: VmReconcilePeerTopologyPeer,
+    right: VmReconcilePeerTopologyPeer,
+  ): boolean => left.peerId === right.peerId && left.core === right.core;
+  if (
+    cached.peers.length === current.peers.length
+    && current.peers.every((peer, index) => peersMatch(cached.peers[index]!, peer))
+  ) {
+    return true;
+  }
+
   let cachedIndex = 0;
   for (const peer of current.peers) {
     while (
@@ -116,12 +107,12 @@ export function canReuseVmReconcilePeerTopology(
     const cachedPeer = cached.peers[cachedIndex];
     if (
       !cachedPeer
-      || cachedPeer.preferred !== peer.preferred
-      || cachedPeer.core !== peer.core
+      || !peersMatch(cachedPeer, peer)
     ) {
       return false;
     }
     cachedIndex += 1;
   }
-  return true;
+  const provenCleanMisses = new Set(cached.cleanMissPeerIds);
+  return current.peers.every((peer) => provenCleanMisses.has(peer.peerId));
 }

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -161,9 +161,10 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         }));
         (agent as any).syncSharedMemoryFromPeerDetailed = syncSharedMemoryFromPeerDetailed;
 
-        const result = await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
+        const recovery = await agent.syncVmRecoveryFromConnectedPeers('runtime-contextGraph', {
           includeSharedMemory: true,
         });
+        const result = recovery.catchup;
 
         expect(peerStoreReads).toBe(3);
         // Background catch-up carries no admission priority override, but it
@@ -193,7 +194,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         expect(result.peersTried).toBe(1);
         expect(result.dataSynced).toBe(5);
         expect(result.sharedMemorySynced).toBe(2);
-        expect(result.sharedMemoryCleanPeerIds).toEqual([remotePeer.toString()]);
+        expect(recovery.cleanMissPeerIds).toEqual([remotePeer.toString()]);
         expect(result.diagnostics.noProtocolPeers).toBe(0);
         expect(result.diagnostics.durable.failedPeers).toBe(0);
         expect(result.diagnostics.sharedMemory.failedPeers).toBe(0);
@@ -201,6 +202,47 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           synced: true,
           sharedMemorySynced: true,
         });
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+
+    it('records clean empty SWM completion as VM-recovery miss evidence', async () => {
+      const agent = await DKGAgent.create({
+        name: 'RuntimeVmRecoveryCleanEmptyEvidence',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+
+      try {
+        await agent.start();
+        allowAllNetworkAdmission(agent);
+        agent.subscribeToContextGraph('runtime-contextGraph');
+
+        const remotePeer = agent.node.peerId;
+        (agent.node.libp2p as any).getConnections = () => [{ remotePeer } as any];
+        (agent.node.libp2p.peerStore as any).get = async () => ({
+          protocols: [PROTOCOL_SYNC],
+        } as any);
+        (agent as any).syncFromPeerDetailed = async () => ({
+          ...cleanDurableSyncResult(),
+          completedPhases: 1,
+          emptyResponses: 1,
+        });
+        (agent as any).syncSharedMemoryFromPeerDetailed = async () => ({
+          ...cleanSharedMemorySyncResult(),
+          completedPhases: 1,
+          emptyResponses: 1,
+        });
+
+        const recovery = await agent.syncVmRecoveryFromConnectedPeers(
+          'runtime-contextGraph',
+          { includeSharedMemory: true },
+        );
+
+        expect(recovery.catchup.sharedMemorySynced).toBe(0);
+        expect(recovery.cleanMissPeerIds).toEqual([remotePeer.toString()]);
       } finally {
         await agent.stop().catch(() => {});
       }
@@ -361,7 +403,6 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         expect(durableOnlyResponse.peersSucceeded).toBe(0);
         expect(durableOnlyResponse.diagnostics.durable.failedPeers).toBe(0);
         expect(durableOnlyResponse.diagnostics.sharedMemory.failedPeers).toBe(1);
-        expect(durableOnlyResponse.sharedMemoryCleanPeerIds).toEqual([]);
         expect(durableOnlyResponse.sharedMemorySynced).toBe(1);
         expect(agent.getSubscribedContextGraphs().get('runtime-contextGraph')?.sharedMemorySynced)
           .not.toBe(true);
@@ -836,7 +877,6 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         expect(result.connectedPeers).toBe(1);
         expect(result.syncCapablePeers).toBe(0);
         expect(result.peersTried).toBe(0);
-        expect(result.sharedMemoryCleanPeerIds).toEqual([]);
         expect(result.diagnostics.noProtocolPeers).toBe(1);
       } finally {
         await agent.stop().catch(() => {});

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -248,6 +248,54 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it.each([
+      ['timeout', { timedOutPhases: 1 }],
+      ['phase failure', { failedPhases: 1 }],
+      ['denial', { deniedPhases: 1 }],
+      ['backpressure deferral', { deferredBackpressure: 1 }],
+    ] as const)('does not record a failed-only SWM %s as VM-recovery miss evidence', async (
+      failureKind,
+      failure,
+    ) => {
+      const agent = await DKGAgent.create({
+        name: `RuntimeVmRecoveryNo${failureKind.replace(/\s/g, '')}Evidence`,
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+
+      try {
+        await agent.start();
+        allowAllNetworkAdmission(agent);
+        agent.subscribeToContextGraph('runtime-contextGraph');
+
+        const remotePeer = agent.node.peerId;
+        (agent.node.libp2p as any).getConnections = () => [{ remotePeer } as any];
+        (agent.node.libp2p.peerStore as any).get = async () => ({
+          protocols: [PROTOCOL_SYNC],
+        } as any);
+        (agent as any).syncFromPeerDetailed = async () => ({
+          ...cleanDurableSyncResult(),
+          completedPhases: 1,
+          emptyResponses: 1,
+        });
+        (agent as any).syncSharedMemoryFromPeerDetailed = async () => ({
+          ...cleanSharedMemorySyncResult(),
+          completedPhases: 1,
+          emptyResponses: 1,
+          ...failure,
+        });
+
+        const recovery = await agent.syncVmRecoveryFromConnectedPeers(
+          'runtime-contextGraph',
+          { includeSharedMemory: true },
+        );
+
+        expect(recovery.cleanMissPeerIds).toEqual([]);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
 
     it('does not count timed-out catchup rounds as peer success', async () => {
       const agent = await DKGAgent.create({

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -296,6 +296,56 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('attributes VM-recovery miss evidence only to the clean peer in a mixed fan-out', async () => {
+      const agent = await DKGAgent.create({
+        name: 'RuntimeVmRecoveryMixedPeerEvidence',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+
+      try {
+        await agent.start();
+        allowAllNetworkAdmission(agent);
+        agent.subscribeToContextGraph('runtime-contextGraph');
+
+        const cleanPeer = { toString: () => 'peer-clean-miss' };
+        const timedOutPeer = { toString: () => 'peer-timed-out' };
+        (agent.node.libp2p as any).getConnections = () => [
+          { remotePeer: cleanPeer } as any,
+          { remotePeer: timedOutPeer } as any,
+        ];
+        (agent.node.libp2p.peerStore as any).get = async () => ({
+          protocols: [PROTOCOL_SYNC],
+        } as any);
+        (agent as any).syncFromPeerDetailed = async () => ({
+          ...cleanDurableSyncResult(),
+          completedPhases: 1,
+          emptyResponses: 1,
+        });
+        const syncSharedMemoryFromPeerDetailed = recorder(async (peerId: string) => ({
+          ...cleanSharedMemorySyncResult(),
+          completedPhases: 1,
+          emptyResponses: 1,
+          ...(peerId === timedOutPeer.toString() ? { timedOutPhases: 1 } : {}),
+        }));
+        (agent as any).syncSharedMemoryFromPeerDetailed = syncSharedMemoryFromPeerDetailed;
+
+        const recovery = await agent.syncVmRecoveryFromConnectedPeers(
+          'runtime-contextGraph',
+          { includeSharedMemory: true },
+        );
+
+        expect(syncSharedMemoryFromPeerDetailed.calls.map(([peerId]) => peerId).sort()).toEqual([
+          cleanPeer.toString(),
+          timedOutPeer.toString(),
+        ]);
+        expect(recovery.cleanMissPeerIds).toEqual([cleanPeer.toString()]);
+        expect(recovery.catchup.diagnostics.sharedMemory.timedOutPhases).toBe(1);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
 
     it('does not count timed-out catchup rounds as peer success', async () => {
       const agent = await DKGAgent.create({

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -193,6 +193,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         expect(result.peersTried).toBe(1);
         expect(result.dataSynced).toBe(5);
         expect(result.sharedMemorySynced).toBe(2);
+        expect(result.sharedMemoryCleanPeerIds).toEqual([remotePeer.toString()]);
         expect(result.diagnostics.noProtocolPeers).toBe(0);
         expect(result.diagnostics.durable.failedPeers).toBe(0);
         expect(result.diagnostics.sharedMemory.failedPeers).toBe(0);
@@ -360,6 +361,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         expect(durableOnlyResponse.peersSucceeded).toBe(0);
         expect(durableOnlyResponse.diagnostics.durable.failedPeers).toBe(0);
         expect(durableOnlyResponse.diagnostics.sharedMemory.failedPeers).toBe(1);
+        expect(durableOnlyResponse.sharedMemoryCleanPeerIds).toEqual([]);
         expect(durableOnlyResponse.sharedMemorySynced).toBe(1);
         expect(agent.getSubscribedContextGraphs().get('runtime-contextGraph')?.sharedMemorySynced)
           .not.toBe(true);
@@ -834,6 +836,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         expect(result.connectedPeers).toBe(1);
         expect(result.syncCapablePeers).toBe(0);
         expect(result.peersTried).toBe(0);
+        expect(result.sharedMemoryCleanPeerIds).toEqual([]);
         expect(result.diagnostics.noProtocolPeers).toBe(1);
       } finally {
         await agent.stop().catch(() => {});

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -993,13 +993,27 @@ describe('Phase D - VM reconcile damping', () => {
   });
 
   it('rehydrates a generation-gated miss after restart without repeating the scan', async () => {
-    const durable = new Map<string, VmReconcileNegativeRecord>();
+    type LegacyVmReconcileNegativeRecord = Omit<
+      VmReconcileNegativeRecord,
+      'peerTopology' | 'cleanMissPeerIds'
+    >;
+    const durable = new Map<string, LegacyVmReconcileNegativeRecord>();
     const subscriptionStore: ContextGraphSubscriptionStore = {
       loadAll: async () => [],
       save: async () => undefined,
       delete: async () => undefined,
       loadVmReconcileNegative: async (key) => durable.get(key) ?? null,
-      saveVmReconcileNegative: async (record) => { durable.set(record.cacheKey, record); },
+      saveVmReconcileNegative: async (record) => {
+        durable.set(record.cacheKey, {
+          cacheKey: record.cacheKey,
+          localCgId: record.localCgId,
+          failures: record.failures,
+          nextRetryAt: record.nextRetryAt,
+          swmGen: record.swmGen,
+          candidateNamespaces: record.candidateNamespaces,
+          peerTopologyKey: record.peerTopologyKey,
+        });
+      },
       deleteVmReconcileNegative: async (key) => { durable.delete(key); },
       deleteVmReconcileNegativesForContextGraph: async (cg) => {
         for (const [key, record] of durable) if (record.localCgId === cg) durable.delete(key);
@@ -1011,6 +1025,10 @@ describe('Phase D - VM reconcile damping', () => {
     (internals as any).syncContextGraphFromConnectedPeers = recorder(async () => emptyCatchupStats());
     await internals.reconcileChainOrdinal('52', onChainCgId, 0, undefined);
     expect(durable.size).toBe(1);
+    const savedLegacyRecord = [...durable.values()][0]!;
+    expect(savedLegacyRecord.peerTopologyKey).toEqual(expect.any(String));
+    expect('peerTopology' in savedLegacyRecord).toBe(false);
+    expect('cleanMissPeerIds' in savedLegacyRecord).toBe(false);
 
     await agent!.stop();
     agent = null;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -754,7 +754,7 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
       nextRetryAt: Date.now() + 60_000,
       swmGen: 'empty:0',
       candidateNamespaces: [],
-      peerTopologyKey: '',
+      peerTopology: { kind: 'unreadable' },
     });
     negativeKeysByCg.set(localCgId, new Set([recentKey]));
     fetchCooldown.set(localCgId, { startedAt: Date.now(), owner: Symbol(localCgId) });
@@ -1629,7 +1629,7 @@ describe('Phase D - VM reconcile damping', () => {
     (internals as any).recordVmReconcileNegativeCache(keyA, '61', {
       swmGen: 'empty:0',
       candidateNamespaces: [],
-      peerTopologyKey: 'unreadable',
+      peerTopology: { kind: 'unreadable' },
     });
 
     await expect((internals as any).shouldDeferVmReconcileByNegativeCache(keyB, '62')).resolves.toBe(false);
@@ -1637,7 +1637,7 @@ describe('Phase D - VM reconcile damping', () => {
     (internals as any).recordVmReconcileNegativeCache(keyB, '62', {
       swmGen: 'empty:0',
       candidateNamespaces: [],
-      peerTopologyKey: 'unreadable',
+      peerTopology: { kind: 'unreadable' },
     });
 
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(2);
@@ -1911,7 +1911,7 @@ describe('Phase D - VM reconcile damping', () => {
       nextRetryAt: Date.now() + 60_000,
       swmGen: 'empty:0',
       candidateNamespaces: [],
-      peerTopologyKey: '',
+      peerTopology: { kind: 'unreadable' },
     });
     (internals as any).getOrCreateFinalizationHandler = recorder(() => ({
       handleChainReconciledKC: recorder(async () => 'stale-target'),
@@ -1931,7 +1931,7 @@ describe('Phase D - VM reconcile damping', () => {
       nextRetryAt: number;
       swmGen: string;
       candidateNamespaces: unknown[];
-      peerTopologyKey: string;
+      peerTopology: { kind: 'unreadable' };
     }>;
     const now = Date.now();
     const cacheKey = 'retry-history-key';
@@ -1942,7 +1942,7 @@ describe('Phase D - VM reconcile damping', () => {
       nextRetryAt: now - 1,
       swmGen: 'empty:0',
       candidateNamespaces: [],
-      peerTopologyKey: '',
+      peerTopology: { kind: 'unreadable' },
     } as any);
 
     (internals as any).pruneVmReconcileState(now);
@@ -1952,7 +1952,7 @@ describe('Phase D - VM reconcile damping', () => {
     (internals as any).recordVmReconcileNegativeCache(cacheKey, 'retry-cg', {
       swmGen: 'empty:0',
       candidateNamespaces: [],
-      peerTopologyKey: '',
+      peerTopology: { kind: 'unreadable' },
     });
 
     expect(negativeCache.get(cacheKey)?.failures).toBe(2);
@@ -1997,7 +1997,7 @@ describe('Phase D - VM reconcile damping', () => {
       nextRetryAt: number;
       swmGen: string;
       candidateNamespaces: unknown[];
-      peerTopologyKey: string;
+      peerTopology: { kind: 'unreadable' };
     }>;
     const fetchCooldown = (internals as any).vmReconcileFetchCooldowns as Map<
       string,
@@ -2017,7 +2017,7 @@ describe('Phase D - VM reconcile damping', () => {
         nextRetryAt: now + 60_000,
         swmGen: 'empty:0',
         candidateNamespaces: [],
-        peerTopologyKey: '',
+        peerTopology: { kind: 'unreadable' },
       });
     }
     fetchCooldown.set('expired-cg', {
@@ -2045,7 +2045,7 @@ describe('Phase D - VM reconcile damping', () => {
       nextRetryAt: now + 60_000,
       swmGen: 'empty:0',
       candidateNamespaces: [],
-      peerTopologyKey: '',
+      peerTopology: { kind: 'unreadable' },
     });
     (internals as any).indexVmReconcileNegativeCacheEntry('cleanup-cg', 'cleanup-cache');
     (internals as any).markVmReconcileNegativeCacheHydrated('cleanup-hydrated', 'cleanup-cg');
@@ -2073,7 +2073,7 @@ describe('Phase D - VM reconcile damping', () => {
       nextRetryAt: now + 60_000,
       swmGen: 'empty:0',
       candidateNamespaces: [],
-      peerTopologyKey: '',
+      peerTopology: { kind: 'unreadable' },
     });
     (internals as any).indexVmReconcileNegativeCacheEntry('hosted-cg', 'hosted-cache');
     (internals as any).markVmReconcileNegativeCacheHydrated('hosted-hydrated', 'hosted-cg');

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -59,6 +59,7 @@ import {
 } from '../src/chain-reconciler.js';
 import { packKnowledgeAssetIdFromIdentity } from '../src/ka-identity.js';
 import type { ContextGraphReconcileResult } from '../src/vm-reconcile-service.js';
+import { createVmReconcilePeerTopology } from '../src/vm-reconcile-peer-topology.js';
 
 interface AgentInternals {
   createContextGraph(opts: { id: string; name: string; description?: string; private?: boolean; callerAgentAddress?: string }): Promise<void>;
@@ -1240,6 +1241,40 @@ describe('Phase D - VM reconcile damping', () => {
     expect(fetch.calls).toHaveLength(3);
     expect(expensiveScans).toBe(0);
   });
+
+  it.each([
+    ['preferred peer', 154n, 'peer-new', false],
+    ['privacy mode', 155n, 'peer-stable', true],
+  ] as const)(
+    'refetches after a cached miss when the %s changes',
+    async (_field, onChainCgId, preferredPeerId, privateOnly) => {
+      const internals = await boot();
+      const localCgId = onChainCgId.toString();
+      registerUnmatchedKC(internals.chain, 9_000n + onChainCgId, onChainCgId);
+      let peerTopology = createVmReconcilePeerTopology({
+        preferredPeerId: 'peer-stable',
+        privateOnly: false,
+        peers: [{ peerId: 'peer-stable', core: false }],
+      });
+      (internals as any).vmReconcilePeerTopology = async () => peerTopology;
+      const fetch = recorder(async () => emptyCatchupStats());
+      (internals as any).syncContextGraphFromConnectedPeers = fetch;
+
+      await expect(internals.reconcileChainOrdinal(localCgId, onChainCgId, 0, undefined))
+        .resolves.toEqual({ status: 'pending' });
+      const initialFetches = fetch.calls.length;
+      expect(initialFetches).toBeGreaterThan(0);
+
+      peerTopology = createVmReconcilePeerTopology({
+        preferredPeerId,
+        privateOnly,
+        peers: [{ peerId: 'peer-stable', core: false }],
+      });
+      await expect(internals.reconcileChainOrdinal(localCgId, onChainCgId, 0, undefined))
+        .resolves.toEqual({ status: 'pending' });
+      expect(fetch.calls.length).toBeGreaterThan(initialFetches);
+    },
+  );
 
   it('reuses a negative cache entry when a previously checked peer disappears', async () => {
     const internals = await boot();

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -1048,6 +1048,85 @@ describe('Phase D - VM reconcile damping', () => {
     expect(fetch.calls).toHaveLength(0);
   });
 
+  it('rehydrates clean-miss evidence and reuses it after a peer disappears', async () => {
+    const durable = new Map<string, VmReconcileNegativeRecord>();
+    let durableLoads = 0;
+    let durableSaves = 0;
+    const subscriptionStore: ContextGraphSubscriptionStore = {
+      loadAll: async () => [],
+      save: async () => undefined,
+      delete: async () => undefined,
+      loadVmReconcileNegative: async (key) => {
+        durableLoads += 1;
+        const record = durable.get(key);
+        return record ? structuredClone(record) : null;
+      },
+      saveVmReconcileNegative: async (record) => {
+        durableSaves += 1;
+        durable.set(record.cacheKey, structuredClone(record));
+      },
+      deleteVmReconcileNegative: async (key) => { durable.delete(key); },
+      deleteVmReconcileNegativesForContextGraph: async (cg) => {
+        for (const [key, record] of durable) if (record.localCgId === cg) durable.delete(key);
+      },
+    };
+    const localCgId = '59';
+    const onChainCgId = 59n;
+    const kaId = 9059n;
+    let connectedPeers = ['peer-stable', 'peer-flaky'];
+    let internals = await boot(subscriptionStore);
+    registerUnmatchedKC(internals.chain, kaId, onChainCgId);
+    (agent as any).node.libp2p.getConnections = () =>
+      connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
+    const provenPeers = ['peer-stable', 'peer-flaky'];
+    const initialFetch = recorder(async () => ({
+      catchup: emptyCatchupStats(),
+      cleanMissPeerIds: [provenPeers.shift()!],
+    }));
+    (internals as any).syncVmRecoveryFromConnectedPeers = initialFetch;
+
+    await expect(internals.reconcileChainOrdinal(localCgId, onChainCgId, 0, undefined))
+      .resolves.toEqual({ status: 'pending' });
+    expect(initialFetch.calls).toHaveLength(2);
+    expect(durableSaves).toBe(1);
+    expect(durable.size).toBe(1);
+    const savedRecord = [...durable.values()][0]!;
+    expect(savedRecord.peerTopology).toMatchObject({
+      kind: 'readable',
+      peers: expect.arrayContaining([
+        { peerId: 'peer-stable', core: false },
+        { peerId: 'peer-flaky', core: false },
+      ]),
+    });
+    expect(savedRecord.cleanMissPeerIds).toEqual(['peer-stable', 'peer-flaky']);
+
+    const loadsBeforeRestart = durableLoads;
+    await agent!.stop();
+    agent = null;
+    connectedPeers = ['peer-stable'];
+    internals = await boot(subscriptionStore);
+    registerUnmatchedKC(internals.chain, kaId, onChainCgId);
+    (agent as any).node.libp2p.getConnections = () =>
+      connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
+    const restartedFetch = recorder(async () => ({
+      catchup: emptyCatchupStats(),
+      cleanMissPeerIds: ['peer-stable'],
+    }));
+    (internals as any).syncVmRecoveryFromConnectedPeers = restartedFetch;
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    (internals.store as any).query = recorder(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans += 1;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal(localCgId, onChainCgId, 0, undefined))
+      .resolves.toEqual({ status: 'pending' });
+    expect(durableLoads).toBeGreaterThan(loadsBeforeRestart);
+    expect(restartedFetch.calls).toHaveLength(0);
+    expect(expensiveScans).toBe(0);
+  });
+
   it('rescans after restart when an incomplete operation payload appears only in a per-KA child graph', async () => {
     const durable = new Map<string, VmReconcileNegativeRecord>();
     const subscriptionStore: ContextGraphSubscriptionStore = {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -1144,6 +1144,37 @@ describe('Phase D - VM reconcile damping', () => {
     expect(expensiveScans).toBe(0);
   });
 
+  it('reuses a negative cache entry when a previously checked peer disappears', async () => {
+    const internals = await boot();
+    const onChainCgId = 58n;
+    registerUnmatchedKC(internals.chain, 9018n, onChainCgId);
+
+    let connectedPeers = ['peer-stable', 'peer-flaky'];
+    (agent as any).node.libp2p.getConnections = () =>
+      connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
+
+    const fetch = recorder(async () => emptyCatchupStats());
+    (internals as any).syncContextGraphFromConnectedPeers = fetch;
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    (internals.store as any).query = recorder(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('58', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    const fetchesAfterFirstMiss = fetch.calls.length;
+    expect(fetchesAfterFirstMiss).toBeGreaterThan(0);
+    expect(expensiveScans).toBeGreaterThan(0);
+
+    expensiveScans = 0;
+    connectedPeers = ['peer-stable'];
+
+    await expect(internals.reconcileChainOrdinal('58', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch.calls).toHaveLength(fetchesAfterFirstMiss);
+    expect(expensiveScans).toBe(0);
+  });
+
   it('reuses a negative cache entry when connected peers only reorder', async () => {
     const internals = await boot();
     const onChainCgId = 55n;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -122,14 +122,13 @@ function stubNode(agent: DKGAgent): void {
   };
 }
 
-function emptyCatchupStats(sharedMemoryCleanPeerIds: string[] = []) {
+function emptyCatchupStats() {
   return {
     connectedPeers: 1,
     totalPeers: 1,
     syncCapablePeers: 1,
     peersTried: 1,
     peersSucceeded: 1,
-    sharedMemoryCleanPeerIds,
     dataSynced: 0,
     sharedMemorySynced: 0,
     denied: false,
@@ -1155,10 +1154,11 @@ describe('Phase D - VM reconcile damping', () => {
       connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
 
     const provenPeers = ['peer-stable', 'peer-flaky'];
-    const fetch = recorder(async () => emptyCatchupStats([
-      provenPeers.shift() ?? 'peer-stable',
-    ]));
-    (internals as any).syncContextGraphFromConnectedPeers = fetch;
+    const fetch = recorder(async () => ({
+      catchup: emptyCatchupStats(),
+      cleanMissPeerIds: [provenPeers.shift() ?? 'peer-stable'],
+    }));
+    (internals as any).syncVmRecoveryFromConnectedPeers = fetch;
     const originalQuery = internals.store.query.bind(internals.store);
     let expensiveScans = 0;
     (internals.store as any).query = recorder(async (sparql: string) => {
@@ -1191,12 +1191,16 @@ describe('Phase D - VM reconcile damping', () => {
     let snapshotAvailable = false;
     const fetch = recorder(async () => {
       fetchCalls += 1;
-      if (fetchCalls === 1) return noProtocolCatchupStats();
-      if (fetchCalls === 2) return emptyCatchupStats(['peer-clean']);
+      if (fetchCalls === 1) {
+        return { catchup: noProtocolCatchupStats(), cleanMissPeerIds: [] };
+      }
+      if (fetchCalls === 2) {
+        return { catchup: emptyCatchupStats(), cleanMissPeerIds: ['peer-clean'] };
+      }
       snapshotAvailable = true;
-      return emptyCatchupStats(['peer-skipped']);
+      return { catchup: emptyCatchupStats(), cleanMissPeerIds: ['peer-skipped'] };
     });
-    (internals as any).syncContextGraphFromConnectedPeers = fetch;
+    (internals as any).syncVmRecoveryFromConnectedPeers = fetch;
     (internals as any).getOrCreateFinalizationHandler = () => ({
       handleChainReconciledKC: async () => snapshotAvailable ? 'promoted' : 'no-swm',
     });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -122,13 +122,14 @@ function stubNode(agent: DKGAgent): void {
   };
 }
 
-function emptyCatchupStats() {
+function emptyCatchupStats(sharedMemoryCleanPeerIds: string[] = []) {
   return {
     connectedPeers: 1,
     totalPeers: 1,
     syncCapablePeers: 1,
     peersTried: 1,
     peersSucceeded: 1,
+    sharedMemoryCleanPeerIds,
     dataSynced: 0,
     sharedMemorySynced: 0,
     denied: false,
@@ -1153,7 +1154,10 @@ describe('Phase D - VM reconcile damping', () => {
     (agent as any).node.libp2p.getConnections = () =>
       connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
 
-    const fetch = recorder(async () => emptyCatchupStats());
+    const provenPeers = ['peer-stable', 'peer-flaky'];
+    const fetch = recorder(async () => emptyCatchupStats([
+      provenPeers.shift() ?? 'peer-stable',
+    ]));
     (internals as any).syncContextGraphFromConnectedPeers = fetch;
     const originalQuery = internals.store.query.bind(internals.store);
     let expensiveScans = 0;
@@ -1173,6 +1177,38 @@ describe('Phase D - VM reconcile damping', () => {
     await expect(internals.reconcileChainOrdinal('58', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
     expect(fetch.calls).toHaveLength(fetchesAfterFirstMiss);
     expect(expensiveScans).toBe(0);
+  });
+
+  it('rechecks a remaining peer that was skipped before another clean peer disappeared', async () => {
+    const internals = await boot();
+    const onChainCgId = 60n;
+    registerUnmatchedKC(internals.chain, 9020n, onChainCgId);
+
+    let connectedPeers = ['peer-skipped', 'peer-clean'];
+    (agent as any).node.libp2p.getConnections = () =>
+      connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
+    let fetchCalls = 0;
+    let snapshotAvailable = false;
+    const fetch = recorder(async () => {
+      fetchCalls += 1;
+      if (fetchCalls === 1) return noProtocolCatchupStats();
+      if (fetchCalls === 2) return emptyCatchupStats(['peer-clean']);
+      snapshotAvailable = true;
+      return emptyCatchupStats(['peer-skipped']);
+    });
+    (internals as any).syncContextGraphFromConnectedPeers = fetch;
+    (internals as any).getOrCreateFinalizationHandler = () => ({
+      handleChainReconciledKC: async () => snapshotAvailable ? 'promoted' : 'no-swm',
+    });
+
+    await expect(internals.reconcileChainOrdinal('60', onChainCgId, 0, undefined))
+      .resolves.toEqual({ status: 'pending' });
+    expect(fetch.calls).toHaveLength(2);
+
+    connectedPeers = ['peer-skipped'];
+    await expect(internals.reconcileChainOrdinal('60', onChainCgId, 0, undefined))
+      .resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(fetch.calls).toHaveLength(3);
   });
 
   it('reuses a negative cache entry when connected peers only reorder', async () => {

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -1672,20 +1672,23 @@ describe('DKGAgent sync fetch coalescing', () => {
         const resolved = sharedCalls.length === 1 ? 2 : 3;
         return {
           ...cleanSharedMemorySyncResult(),
+          completedPhases: 1,
           ...(resolved < 3 ? { failedPhases: 1, snapshotPlaneIncomplete: 1 } : {}),
           swmCoverage: coverage(resolved),
         };
       };
 
-      const result = await agent.syncContextGraphFromConnectedPeers('coalesced-cg', {
+      const recovery = await agent.syncVmRecoveryFromConnectedPeers('coalesced-cg', {
         includeSharedMemory: true,
       });
+      const result = recovery.catchup;
 
       expect(durableCalls).toEqual([PEER_A]);
       expect(sharedCalls).toEqual([PEER_A, PEER_A]);
       expect(result.diagnostics.sharedMemory.swmCoverage).toEqual(coverage(3));
       expect(result.diagnostics.sharedMemory.continuationPasses).toBe(1);
       expect(result.diagnostics.sharedMemory.continuationStopReason).toBe('no-capable-peers');
+      expect(recovery.cleanMissPeerIds).toEqual([PEER_A]);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -1447,6 +1447,103 @@ describe('DKGAgent sync fetch coalescing', () => {
     }
   });
 
+  it('keeps clean-peer evidence scoped to overlapping catch-up windows', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const peerA = { toString: () => PEER_A };
+    const peerB = { toString: () => PEER_B };
+
+    try {
+      await agent.start();
+      (agent as any).isPrivateContextGraph = async () => false;
+      (agent as any).resolvePreferredSyncPeerId = async () => undefined;
+      (agent as any).primeCatchupConnections = async () => undefined;
+      (agent as any).ensurePeerAdmittedForRecovery = async () => true;
+      (agent as any).waitForSyncProtocol = async () => true;
+      (agent as any).refreshMetaSyncedFlags = async () => undefined;
+      (agent.node.libp2p as any).getConnections = () => [
+        { remotePeer: peerA },
+        { remotePeer: peerB },
+      ];
+      (agent.node.libp2p.peerStore as any).get = async () => ({ protocols: [PROTOCOL_SYNC] });
+      (agent as any).selectCatchupPeerWindow = (
+        peers: Array<{ toString(): string }>,
+        options: { peerRotationKey?: string },
+      ) => options.peerRotationKey === 'window-a' ? [peers[0]] : [peers[1]];
+      (agent as any).syncFromPeerDetailed = async () => cleanDurableSyncResult();
+      (agent as any).syncSharedMemoryFromPeerDetailed = async () =>
+        cleanSharedMemorySyncResult();
+
+      const [windowA, windowB] = await Promise.all([
+        agent.syncVmRecoveryFromConnectedPeers('coalesced-cg', {
+          includeSharedMemory: true,
+          maxPeers: 1,
+          peerRotationKey: 'window-a',
+        }),
+        agent.syncVmRecoveryFromConnectedPeers('coalesced-cg', {
+          includeSharedMemory: true,
+          maxPeers: 1,
+          peerRotationKey: 'window-b',
+        }),
+      ]);
+
+      expect(windowA.cleanMissPeerIds).toEqual([PEER_A]);
+      expect(windowB.cleanMissPeerIds).toEqual([PEER_B]);
+      expect(windowA.catchup.cleanSharedMemoryPeerIds).toEqual([PEER_A]);
+      expect(windowB.catchup.cleanSharedMemoryPeerIds).toEqual([PEER_B]);
+      expect(Object.isFrozen(windowA.catchup.cleanSharedMemoryPeerIds)).toBe(true);
+      expect(Object.isFrozen(windowB.catchup.cleanSharedMemoryPeerIds)).toBe(true);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('replays completed clean-peer evidence to a late single-flight joiner', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const remotePeer = { toString: () => PEER_A };
+    const refreshEntered = deferred<void>();
+    const releaseRefresh = deferred<void>();
+    let sharedSyncs = 0;
+
+    try {
+      await agent.start();
+      (agent as any).isPrivateContextGraph = async () => false;
+      (agent as any).resolvePreferredSyncPeerId = async () => undefined;
+      (agent as any).primeCatchupConnections = async () => undefined;
+      (agent as any).ensurePeerAdmittedForRecovery = async () => true;
+      (agent as any).waitForSyncProtocol = async () => true;
+      (agent.node.libp2p as any).getConnections = () => [{ remotePeer }];
+      (agent.node.libp2p.peerStore as any).get = async () => ({ protocols: [PROTOCOL_SYNC] });
+      (agent as any).syncFromPeerDetailed = async () => cleanDurableSyncResult();
+      (agent as any).syncSharedMemoryFromPeerDetailed = async () => {
+        sharedSyncs += 1;
+        return cleanSharedMemorySyncResult();
+      };
+      (agent as any).refreshMetaSyncedFlags = async () => {
+        refreshEntered.resolve();
+        await releaseRefresh.promise;
+      };
+
+      const first = agent.syncVmRecoveryFromConnectedPeers('coalesced-cg', {
+        includeSharedMemory: true,
+      });
+      await refreshEntered.promise;
+      const lateJoiner = agent.syncVmRecoveryFromConnectedPeers('coalesced-cg', {
+        includeSharedMemory: true,
+      });
+      await flushMicrotasks();
+      releaseRefresh.resolve();
+
+      const [firstResult, lateResult] = await Promise.all([first, lateJoiner]);
+      expect(sharedSyncs).toBe(1);
+      expect(firstResult.cleanMissPeerIds).toEqual([PEER_A]);
+      expect(lateResult.cleanMissPeerIds).toEqual([PEER_A]);
+      expect(lateResult.catchup).toBe(firstResult.catchup);
+    } finally {
+      releaseRefresh.resolve();
+      await agent.stop().catch(() => {});
+    }
+  });
+
   // #2050. The IN-AGENT catch-up walk (`runCatchupOverPeers`) has to publish the
   // same SWM diagnostics the worker-backed CLI runner does, or a job that happens
   // to take the inline path reports a shortfall it cannot name while an identical
@@ -1705,7 +1802,6 @@ describe('DKGAgent sync fetch coalescing', () => {
   ) => {
     const agent = await createAgentWithSend(async () => new Uint8Array(0));
     const remotePeer = { toString: () => PEER_A };
-    const cleanMissPeerIds = new Set<string>();
     let sharedCalls = 0;
     const incompleteCoverage: SwmSnapshotCoverage = {
       contextGraphId: 'coalesced-cg',
@@ -1739,14 +1835,13 @@ describe('DKGAgent sync fetch coalescing', () => {
         true,
         [remotePeer],
         {
-          recordSharedMemoryCleanPeer: (peerId: string) => cleanMissPeerIds.add(peerId),
           swmCatchupPassConfig: { budgetMs: 60_000, maxPasses: 2 },
         },
       );
 
       expect(sharedCalls).toBe(2);
       expect(result.diagnostics.sharedMemory.continuationPasses).toBe(1);
-      expect([...cleanMissPeerIds]).toEqual([]);
+      expect(result.cleanSharedMemoryPeerIds).toEqual([]);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -1693,4 +1693,62 @@ describe('DKGAgent sync fetch coalescing', () => {
       await agent.stop().catch(() => {});
     }
   });
+
+  it.each([
+    ['timeout', { timedOutPhases: 1 }],
+    ['phase failure', { failedPhases: 1 }],
+    ['denial', { deniedPhases: 1 }],
+    ['backpressure deferral', { deferredBackpressure: 1 }],
+  ] as const)('does not record a failed-only SWM %s continuation as miss evidence', async (
+    _failureKind,
+    continuationFailure,
+  ) => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const remotePeer = { toString: () => PEER_A };
+    const cleanMissPeerIds = new Set<string>();
+    let sharedCalls = 0;
+    const incompleteCoverage: SwmSnapshotCoverage = {
+      contextGraphId: 'coalesced-cg',
+      peerIdSuffix: PEER_A.slice(-8),
+      snapshotsResolved: 2,
+      snapshotsTotal: 3,
+      manifestComplete: true,
+      missingCount: 1,
+      missingSample: ['sha256:remaining'],
+      materializationFailures: 0,
+    };
+
+    try {
+      await agent.start();
+      (agent as any).waitForSyncProtocol = async () => true;
+      (agent as any).refreshMetaSyncedFlags = async () => undefined;
+      (agent as any).syncFromPeerDetailed = async () => cleanDurableSyncResult();
+      (agent as any).syncSharedMemoryFromPeerDetailed = async () => {
+        sharedCalls += 1;
+        return {
+          ...cleanSharedMemorySyncResult(),
+          completedPhases: 1,
+          emptyResponses: 1,
+          swmCoverage: { ...incompleteCoverage },
+          ...(sharedCalls === 1 ? { failedPhases: 1 } : continuationFailure),
+        };
+      };
+
+      const result = await (agent as any).runCatchupOverPeers(
+        'coalesced-cg',
+        true,
+        [remotePeer],
+        {
+          recordSharedMemoryCleanPeer: (peerId: string) => cleanMissPeerIds.add(peerId),
+          swmCatchupPassConfig: { budgetMs: 60_000, maxPasses: 2 },
+        },
+      );
+
+      expect(sharedCalls).toBe(2);
+      expect(result.diagnostics.sharedMemory.continuationPasses).toBe(1);
+      expect([...cleanMissPeerIds]).toEqual([]);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
 });

--- a/packages/agent/test/vm-reconcile-peer-topology.test.ts
+++ b/packages/agent/test/vm-reconcile-peer-topology.test.ts
@@ -3,7 +3,9 @@ import {
   canReuseVmReconcilePeerTopology,
   createVmReconcileCleanMissPeerIds,
   createVmReconcilePeerTopology,
+  encodeLegacyVmReconcilePeerTopologyKey,
   isVmReconcilePeerTopology,
+  parseLegacyVmReconcilePeerTopologyKey,
   parseVmReconcileCleanMissPeerIds,
   UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
 } from '../src/vm-reconcile-peer-topology.js';
@@ -56,6 +58,26 @@ describe('VM reconcile peer-topology compatibility', () => {
     expect(isVmReconcilePeerTopology(value)).toBe(true);
     expect(createVmReconcileCleanMissPeerIds(value, ['core', 'missing', 'core']))
       .toEqual(['core']);
+  });
+
+  it('round-trips the exact legacy topology-key representation', () => {
+    const value = topology(
+      [{ peerId: 'preferred', core: true }, { peerId: 'other' }],
+      'preferred',
+    );
+    const encoded = encodeLegacyVmReconcilePeerTopologyKey(value);
+
+    expect(JSON.parse(encoded)).toEqual({
+      preferredPeerId: 'preferred',
+      privateOnly: false,
+      peers: [
+        { rank: 0, peerId: 'preferred', preferred: true, core: true },
+        { rank: 1, peerId: 'other', preferred: false, core: false },
+      ],
+    });
+    expect(parseLegacyVmReconcilePeerTopologyKey(encoded)).toEqual(value);
+    expect(parseLegacyVmReconcilePeerTopologyKey('unreadable'))
+      .toEqual(UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY);
   });
 
   it('reuses exact topology and removal of peers with clean-miss evidence', () => {

--- a/packages/agent/test/vm-reconcile-peer-topology.test.ts
+++ b/packages/agent/test/vm-reconcile-peer-topology.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   canReuseVmReconcilePeerTopology,
+  createVmReconcileCleanMissPeerIds,
   createVmReconcilePeerTopology,
   isVmReconcilePeerTopology,
+  parseVmReconcileCleanMissPeerIds,
   UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
 } from '../src/vm-reconcile-peer-topology.js';
 import type { VmReconcilePeerTopology } from '../src/dkg-agent-types.js';
@@ -10,7 +12,6 @@ import type { VmReconcilePeerTopology } from '../src/dkg-agent-types.js';
 function topology(
   peers: Array<{ peerId: string; core?: boolean }>,
   preferredPeerId: string | null = null,
-  cleanMissPeerIds: string[] = [],
 ): VmReconcilePeerTopology {
   return createVmReconcilePeerTopology({
     preferredPeerId,
@@ -19,8 +20,17 @@ function topology(
       peerId: peer.peerId,
       core: peer.core ?? false,
     })),
-    cleanMissPeerIds,
   });
+}
+
+function evidence(
+  value: VmReconcilePeerTopology,
+  cleanMissPeerIds: string[],
+) {
+  return {
+    topology: value,
+    cleanMissPeerIds: createVmReconcileCleanMissPeerIds(value, cleanMissPeerIds),
+  };
 }
 
 describe('VM reconcile peer-topology compatibility', () => {
@@ -33,7 +43,6 @@ describe('VM reconcile peer-topology compatibility', () => {
         { peerId: 'preferred', core: true },
         { peerId: 'core', core: true },
       ],
-      cleanMissPeerIds: ['core', 'missing', 'core'],
     });
     expect(value).toEqual({
       kind: 'readable',
@@ -43,18 +52,18 @@ describe('VM reconcile peer-topology compatibility', () => {
         { peerId: 'preferred', core: false },
         { peerId: 'core', core: true },
       ],
-      cleanMissPeerIds: ['core'],
     });
     expect(isVmReconcilePeerTopology(value)).toBe(true);
+    expect(createVmReconcileCleanMissPeerIds(value, ['core', 'missing', 'core']))
+      .toEqual(['core']);
   });
 
   it('reuses exact topology and removal of peers with clean-miss evidence', () => {
-    const cached = topology(
+    const cachedTopology = topology(
       [{ peerId: 'a' }, { peerId: 'b', core: true }, { peerId: 'c' }],
-      null,
-      ['a', 'b', 'c'],
     );
-    expect(canReuseVmReconcilePeerTopology(cached, cached)).toBe(true);
+    const cached = evidence(cachedTopology, ['a', 'b', 'c']);
+    expect(canReuseVmReconcilePeerTopology(cached, cachedTopology)).toBe(true);
     expect(canReuseVmReconcilePeerTopology(
       cached,
       topology([{ peerId: 'a' }, { peerId: 'c' }]),
@@ -62,11 +71,9 @@ describe('VM reconcile peer-topology compatibility', () => {
   });
 
   it('rejects removal that exposes a previously unproven peer', () => {
-    const cached = topology(
+    const cached = evidence(topology(
       [{ peerId: 'skipped' }, { peerId: 'clean' }],
-      null,
-      ['clean'],
-    );
+    ), ['clean']);
     expect(canReuseVmReconcilePeerTopology(
       cached,
       topology([{ peerId: 'skipped' }]),
@@ -74,7 +81,7 @@ describe('VM reconcile peer-topology compatibility', () => {
   });
 
   it('rejects peer additions, capability reclassification, and ordering changes', () => {
-    const cached = topology([{ peerId: 'a' }, { peerId: 'b' }]);
+    const cached = evidence(topology([{ peerId: 'a' }, { peerId: 'b' }]), []);
     expect(canReuseVmReconcilePeerTopology(
       cached,
       topology([{ peerId: 'a' }, { peerId: 'b' }, { peerId: 'c' }]),
@@ -92,16 +99,13 @@ describe('VM reconcile peer-topology compatibility', () => {
   it('preserves explicit unreadable equality and rejects malformed domain records', () => {
     const readable = topology([{ peerId: 'a' }]);
     expect(canReuseVmReconcilePeerTopology(
-      UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
+      evidence(UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY, []),
       UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
     )).toBe(true);
     expect(canReuseVmReconcilePeerTopology(
-      UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
+      evidence(UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY, []),
       readable,
     )).toBe(false);
-    expect(isVmReconcilePeerTopology({
-      ...readable,
-      cleanMissPeerIds: ['unknown'],
-    })).toBe(false);
+    expect(parseVmReconcileCleanMissPeerIds(['unknown'], readable)).toBeNull();
   });
 });

--- a/packages/agent/test/vm-reconcile-peer-topology.test.ts
+++ b/packages/agent/test/vm-reconcile-peer-topology.test.ts
@@ -1,47 +1,76 @@
 import { describe, expect, it } from 'vitest';
 import {
   canReuseVmReconcilePeerTopology,
-  decodeVmReconcilePeerTopology,
-  encodeVmReconcilePeerTopology,
-  type VmReconcilePeerTopology,
+  createVmReconcilePeerTopology,
+  isVmReconcilePeerTopology,
+  UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
 } from '../src/vm-reconcile-peer-topology.js';
+import type { VmReconcilePeerTopology } from '../src/dkg-agent-types.js';
 
 function topology(
-  peers: Array<{ peerId: string; preferred?: boolean; core?: boolean }>,
+  peers: Array<{ peerId: string; core?: boolean }>,
   preferredPeerId: string | null = null,
+  cleanMissPeerIds: string[] = [],
 ): VmReconcilePeerTopology {
-  return {
-    kind: 'readable',
+  return createVmReconcilePeerTopology({
     preferredPeerId,
     privateOnly: false,
     peers: peers.map((peer) => ({
       peerId: peer.peerId,
-      preferred: peer.preferred ?? false,
       core: peer.core ?? false,
     })),
-  };
+    cleanMissPeerIds,
+  });
 }
 
 describe('VM reconcile peer-topology compatibility', () => {
-  it('round-trips a validated readable topology at the durable boundary', () => {
-    const value = topology([
-      { peerId: 'preferred', preferred: true },
-      { peerId: 'core', core: true },
-    ], 'preferred');
-    expect(decodeVmReconcilePeerTopology(encodeVmReconcilePeerTopology(value))).toEqual(value);
+  it('constructs a canonical topology without redundant rank or preferred fields', () => {
+    const value = createVmReconcilePeerTopology({
+      preferredPeerId: 'preferred',
+      privateOnly: false,
+      peers: [
+        { peerId: 'preferred', core: false },
+        { peerId: 'preferred', core: true },
+        { peerId: 'core', core: true },
+      ],
+      cleanMissPeerIds: ['core', 'missing', 'core'],
+    });
+    expect(value).toEqual({
+      kind: 'readable',
+      preferredPeerId: 'preferred',
+      privateOnly: false,
+      peers: [
+        { peerId: 'preferred', core: false },
+        { peerId: 'core', core: true },
+      ],
+      cleanMissPeerIds: ['core'],
+    });
+    expect(isVmReconcilePeerTopology(value)).toBe(true);
   });
 
-  it('reuses exact topology and capability-preserving peer removal', () => {
-    const cached = topology([
-      { peerId: 'a' },
-      { peerId: 'b', core: true },
-      { peerId: 'c' },
-    ]);
+  it('reuses exact topology and removal of peers with clean-miss evidence', () => {
+    const cached = topology(
+      [{ peerId: 'a' }, { peerId: 'b', core: true }, { peerId: 'c' }],
+      null,
+      ['a', 'b', 'c'],
+    );
     expect(canReuseVmReconcilePeerTopology(cached, cached)).toBe(true);
-    expect(canReuseVmReconcilePeerTopology(cached, topology([
-      { peerId: 'a' },
-      { peerId: 'c' },
-    ]))).toBe(true);
+    expect(canReuseVmReconcilePeerTopology(
+      cached,
+      topology([{ peerId: 'a' }, { peerId: 'c' }]),
+    )).toBe(true);
+  });
+
+  it('rejects removal that exposes a previously unproven peer', () => {
+    const cached = topology(
+      [{ peerId: 'skipped' }, { peerId: 'clean' }],
+      null,
+      ['clean'],
+    );
+    expect(canReuseVmReconcilePeerTopology(
+      cached,
+      topology([{ peerId: 'skipped' }]),
+    )).toBe(false);
   });
 
   it('rejects peer additions, capability reclassification, and ordering changes', () => {
@@ -60,33 +89,19 @@ describe('VM reconcile peer-topology compatibility', () => {
     )).toBe(false);
   });
 
-  it('preserves explicit unreadable equality but rejects malformed durable state', () => {
+  it('preserves explicit unreadable equality and rejects malformed domain records', () => {
     const readable = topology([{ peerId: 'a' }]);
-    const unreadable = decodeVmReconcilePeerTopology('unreadable');
-    expect(unreadable).toEqual({ kind: 'unreadable' });
-    expect(canReuseVmReconcilePeerTopology(unreadable!, unreadable!)).toBe(true);
-    expect(canReuseVmReconcilePeerTopology(unreadable!, readable)).toBe(false);
-    expect(canReuseVmReconcilePeerTopology(readable, unreadable!)).toBe(false);
-
-    const invalidPayloads = [
-      '{',
-      JSON.stringify({ version: 2, preferredPeerId: null, privateOnly: false, peers: [] }),
-      JSON.stringify({ version: 1, preferredPeerId: null, privateOnly: false, peers: [{
-        rank: 1,
-        peerId: 'a',
-        preferred: false,
-        core: false,
-      }] }),
-      JSON.stringify({ version: 1, preferredPeerId: null, privateOnly: false, peers: [{
-        rank: 0,
-        peerId: 'a',
-        preferred: true,
-        core: false,
-      }] }),
-    ];
-    for (const payload of invalidPayloads) {
-      const decoded = decodeVmReconcilePeerTopology(payload);
-      expect(decoded).toBeNull();
-    }
+    expect(canReuseVmReconcilePeerTopology(
+      UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
+      UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
+    )).toBe(true);
+    expect(canReuseVmReconcilePeerTopology(
+      UNREADABLE_VM_RECONCILE_PEER_TOPOLOGY,
+      readable,
+    )).toBe(false);
+    expect(isVmReconcilePeerTopology({
+      ...readable,
+      cleanMissPeerIds: ['unknown'],
+    })).toBe(false);
   });
 });

--- a/packages/agent/test/vm-reconcile-peer-topology.test.ts
+++ b/packages/agent/test/vm-reconcile-peer-topology.test.ts
@@ -118,6 +118,27 @@ describe('VM reconcile peer-topology compatibility', () => {
     )).toBe(false);
   });
 
+  it.each([
+    ['preferred peer', 'b', false],
+    ['privacy mode', 'a', true],
+  ] as const)('rejects reuse when the %s changes', (_field, preferredPeerId, privateOnly) => {
+    const cachedTopology = createVmReconcilePeerTopology({
+      preferredPeerId: 'a',
+      privateOnly: false,
+      peers: [{ peerId: 'a', core: false }],
+    });
+    const currentTopology = createVmReconcilePeerTopology({
+      preferredPeerId,
+      privateOnly,
+      peers: [{ peerId: 'a', core: false }],
+    });
+
+    expect(canReuseVmReconcilePeerTopology(
+      evidence(cachedTopology, ['a']),
+      currentTopology,
+    )).toBe(false);
+  });
+
   it('preserves explicit unreadable equality and rejects malformed domain records', () => {
     const readable = topology([{ peerId: 'a' }]);
     expect(canReuseVmReconcilePeerTopology(

--- a/packages/agent/test/vm-reconcile-peer-topology.test.ts
+++ b/packages/agent/test/vm-reconcile-peer-topology.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canReuseVmReconcilePeerTopology,
+  decodeVmReconcilePeerTopology,
+  encodeVmReconcilePeerTopology,
+  type VmReconcilePeerTopology,
+} from '../src/vm-reconcile-peer-topology.js';
+
+function topology(
+  peers: Array<{ peerId: string; preferred?: boolean; core?: boolean }>,
+  preferredPeerId: string | null = null,
+): VmReconcilePeerTopology {
+  return {
+    kind: 'readable',
+    preferredPeerId,
+    privateOnly: false,
+    peers: peers.map((peer) => ({
+      peerId: peer.peerId,
+      preferred: peer.preferred ?? false,
+      core: peer.core ?? false,
+    })),
+  };
+}
+
+describe('VM reconcile peer-topology compatibility', () => {
+  it('round-trips a validated readable topology at the durable boundary', () => {
+    const value = topology([
+      { peerId: 'preferred', preferred: true },
+      { peerId: 'core', core: true },
+    ], 'preferred');
+    expect(decodeVmReconcilePeerTopology(encodeVmReconcilePeerTopology(value))).toEqual(value);
+  });
+
+  it('reuses exact topology and capability-preserving peer removal', () => {
+    const cached = topology([
+      { peerId: 'a' },
+      { peerId: 'b', core: true },
+      { peerId: 'c' },
+    ]);
+    expect(canReuseVmReconcilePeerTopology(cached, cached)).toBe(true);
+    expect(canReuseVmReconcilePeerTopology(cached, topology([
+      { peerId: 'a' },
+      { peerId: 'c' },
+    ]))).toBe(true);
+  });
+
+  it('rejects peer additions, capability reclassification, and ordering changes', () => {
+    const cached = topology([{ peerId: 'a' }, { peerId: 'b' }]);
+    expect(canReuseVmReconcilePeerTopology(
+      cached,
+      topology([{ peerId: 'a' }, { peerId: 'b' }, { peerId: 'c' }]),
+    )).toBe(false);
+    expect(canReuseVmReconcilePeerTopology(
+      cached,
+      topology([{ peerId: 'a', core: true }, { peerId: 'b' }]),
+    )).toBe(false);
+    expect(canReuseVmReconcilePeerTopology(
+      cached,
+      topology([{ peerId: 'b' }, { peerId: 'a' }]),
+    )).toBe(false);
+  });
+
+  it('preserves explicit unreadable equality but rejects malformed durable state', () => {
+    const readable = topology([{ peerId: 'a' }]);
+    const unreadable = decodeVmReconcilePeerTopology('unreadable');
+    expect(unreadable).toEqual({ kind: 'unreadable' });
+    expect(canReuseVmReconcilePeerTopology(unreadable!, unreadable!)).toBe(true);
+    expect(canReuseVmReconcilePeerTopology(unreadable!, readable)).toBe(false);
+    expect(canReuseVmReconcilePeerTopology(readable, unreadable!)).toBe(false);
+
+    const invalidPayloads = [
+      '{',
+      JSON.stringify({ version: 2, preferredPeerId: null, privateOnly: false, peers: [] }),
+      JSON.stringify({ version: 1, preferredPeerId: null, privateOnly: false, peers: [{
+        rank: 1,
+        peerId: 'a',
+        preferred: false,
+        core: false,
+      }] }),
+      JSON.stringify({ version: 1, preferredPeerId: null, privateOnly: false, peers: [{
+        rank: 0,
+        peerId: 'a',
+        preferred: true,
+        core: false,
+      }] }),
+    ];
+    for (const payload of invalidPayloads) {
+      const decoded = decodeVmReconcilePeerTopology(payload);
+      expect(decoded).toBeNull();
+    }
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -71,6 +71,7 @@ export default defineConfig({
       "test/gossip-publish-handler.test.ts",
       "test/discovery-subscription-boundary.test.ts",
       "test/core-fills-gap.test.ts",
+      "test/vm-reconcile-peer-topology.test.ts",
       "test/swm-late-joiner-deferred-gossip.test.ts",
       "test/swm-plaintext-oracle-wiring.test.ts",
       "test/oversize-filter.test.ts",

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -173,6 +173,10 @@ import {
 import { createDaemonTelemetryLifecycle } from './telemetry-lifecycle.js';
 import { startRpcUsageTelemetry } from './rpc-usage-log.js';
 import { SqliteSnapshotPageIndexStore } from './snapshot-page-index-store.js';
+import {
+  decodeVmReconcileNegativeRow,
+  encodeVmReconcileNegativeRow,
+} from './vm-reconcile-negative-store-adapter.js';
 import { createAdmissionRecoveryCapabilityProbe, createInitialPublisherState, createPublicSnapshotStore, createPublisherControlFromStore, startPublisherRuntimeWithOutcome, type PublisherState } from '../publisher-runner.js';
 import { backfillVmPublishIntentIndexOnBoot } from './vm-publish-intent-backfill.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
@@ -1973,37 +1977,15 @@ async function runDaemonInnerWithStartupOwnership(
       loadVmReconcileNegative: async (cacheKey) => {
         const row = dashDb.getVmReconcileNegative(cacheKey);
         if (!row) return null;
-        try {
-          const candidateNamespaces = JSON.parse(row.candidate_namespaces) as Array<{
-            metaGraph: string;
-            dataGraph: string;
-          }>;
-          if (!Array.isArray(candidateNamespaces)) return null;
-          return {
-            cacheKey: row.cache_key,
-            localCgId: row.context_graph_id,
-            failures: row.failures,
-            nextRetryAt: row.next_retry_at,
-            swmGen: row.swm_gen,
-            candidateNamespaces,
-            peerTopologyKey: row.peer_topology_key,
-          };
-        } catch {
+        const decoded = decodeVmReconcileNegativeRow(row);
+        if (!decoded) {
           dashDb.deleteVmReconcileNegative(cacheKey);
           return null;
         }
+        return decoded;
       },
       saveVmReconcileNegative: async (record) => {
-        dashDb.upsertVmReconcileNegative({
-          cache_key: record.cacheKey,
-          context_graph_id: record.localCgId,
-          failures: record.failures,
-          next_retry_at: record.nextRetryAt,
-          swm_gen: record.swmGen,
-          candidate_namespaces: JSON.stringify(record.candidateNamespaces),
-          peer_topology_key: record.peerTopologyKey,
-          updated_at: Date.now(),
-        });
+        dashDb.upsertVmReconcileNegative(encodeVmReconcileNegativeRow(record, Date.now()));
       },
       deleteVmReconcileNegative: async (cacheKey) => {
         dashDb.deleteVmReconcileNegative(cacheKey);

--- a/packages/cli/src/daemon/vm-reconcile-negative-store-adapter.ts
+++ b/packages/cli/src/daemon/vm-reconcile-negative-store-adapter.ts
@@ -1,0 +1,140 @@
+import {
+  createVmReconcilePeerTopology,
+  type VmReconcileNegativeRecord,
+  type VmReconcilePeerTopology,
+  type VmReconcilePeerTopologyPeer,
+} from '@origintrail-official/dkg-agent';
+
+/** Raw SQLite-facing DTO. Encoding is intentionally confined to this adapter. */
+export interface VmReconcileNegativePersistenceRow {
+  cache_key: string;
+  context_graph_id: string;
+  failures: number;
+  next_retry_at: number;
+  swm_gen: string;
+  candidate_namespaces: string;
+  peer_topology_key: string;
+  updated_at: number;
+}
+
+const TOPOLOGY_VERSION = 2;
+
+function decodeTopology(encoded: string): VmReconcilePeerTopology | null {
+  if (encoded === 'unreadable') return { kind: 'unreadable' };
+  try {
+    const value: unknown = JSON.parse(encoded);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const raw = value as Record<string, unknown>;
+    if (
+      !(raw.preferredPeerId === null || typeof raw.preferredPeerId === 'string')
+      || typeof raw.privateOnly !== 'boolean'
+      || !Array.isArray(raw.peers)
+      || (raw.version !== 1 && raw.version !== TOPOLOGY_VERSION)
+    ) return null;
+
+    const peers: VmReconcilePeerTopologyPeer[] = [];
+    const peerIds = new Set<string>();
+    for (const [rank, candidate] of raw.peers.entries()) {
+      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
+      const peer = candidate as Record<string, unknown>;
+      if (
+        typeof peer.peerId !== 'string'
+        || peer.peerId.length === 0
+        || typeof peer.core !== 'boolean'
+        || peerIds.has(peer.peerId)
+      ) return null;
+      if (
+        raw.version === 1
+        && (
+          peer.rank !== rank
+          || typeof peer.preferred !== 'boolean'
+          || peer.preferred !== (peer.peerId === raw.preferredPeerId)
+        )
+      ) return null;
+      peerIds.add(peer.peerId);
+      peers.push({ peerId: peer.peerId, core: peer.core });
+    }
+
+    const rawCleanMissPeerIds = raw.version === 1 ? [] : raw.cleanMissPeerIds;
+    if (!Array.isArray(rawCleanMissPeerIds)) return null;
+    const cleanMissPeerIds: string[] = [];
+    const cleanMisses = new Set<string>();
+    for (const peerId of rawCleanMissPeerIds) {
+      if (
+        typeof peerId !== 'string'
+        || !peerIds.has(peerId)
+        || cleanMisses.has(peerId)
+      ) return null;
+      cleanMisses.add(peerId);
+      cleanMissPeerIds.push(peerId);
+    }
+    return createVmReconcilePeerTopology({
+      preferredPeerId: raw.preferredPeerId,
+      privateOnly: raw.privateOnly,
+      peers,
+      cleanMissPeerIds,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function encodeTopology(topology: VmReconcilePeerTopology): string {
+  if (topology.kind === 'unreadable') return 'unreadable';
+  return JSON.stringify({
+    version: TOPOLOGY_VERSION,
+    preferredPeerId: topology.preferredPeerId,
+    privateOnly: topology.privateOnly,
+    peers: topology.peers,
+    cleanMissPeerIds: topology.cleanMissPeerIds,
+  });
+}
+
+export function decodeVmReconcileNegativeRow(
+  row: VmReconcileNegativePersistenceRow,
+): VmReconcileNegativeRecord | null {
+  try {
+    const candidateNamespaces: unknown = JSON.parse(row.candidate_namespaces);
+    const peerTopology = decodeTopology(row.peer_topology_key);
+    if (
+      !Number.isInteger(row.failures)
+      || row.failures <= 0
+      || !Number.isFinite(row.next_retry_at)
+      || !Array.isArray(candidateNamespaces)
+      || !candidateNamespaces.every((item) =>
+        item
+        && typeof item === 'object'
+        && !Array.isArray(item)
+        && typeof (item as Record<string, unknown>).metaGraph === 'string'
+        && typeof (item as Record<string, unknown>).dataGraph === 'string')
+      || !peerTopology
+    ) return null;
+    return {
+      cacheKey: row.cache_key,
+      localCgId: row.context_graph_id,
+      failures: row.failures,
+      nextRetryAt: row.next_retry_at,
+      swmGen: row.swm_gen,
+      candidateNamespaces: candidateNamespaces as Array<{ metaGraph: string; dataGraph: string }>,
+      peerTopology,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function encodeVmReconcileNegativeRow(
+  record: VmReconcileNegativeRecord,
+  updatedAt: number,
+): VmReconcileNegativePersistenceRow {
+  return {
+    cache_key: record.cacheKey,
+    context_graph_id: record.localCgId,
+    failures: record.failures,
+    next_retry_at: record.nextRetryAt,
+    swm_gen: record.swmGen,
+    candidate_namespaces: JSON.stringify(record.candidateNamespaces),
+    peer_topology_key: encodeTopology(record.peerTopology),
+    updated_at: updatedAt,
+  };
+}

--- a/packages/cli/src/daemon/vm-reconcile-negative-store-adapter.ts
+++ b/packages/cli/src/daemon/vm-reconcile-negative-store-adapter.ts
@@ -1,4 +1,7 @@
 import {
+  encodeLegacyVmReconcilePeerTopologyKey,
+  isVmReconcilePeerTopology,
+  parseLegacyVmReconcilePeerTopologyKey,
   parseVmReconcileCleanMissPeerIds,
   parseVmReconcilePeerTopology,
   type VmReconcileNegativeRecord,
@@ -19,10 +22,10 @@ export interface VmReconcileNegativePersistenceRow {
 
 const TOPOLOGY_VERSION = 2;
 
-type DecodedTopology = Pick<
-  VmReconcileNegativeRecord,
-  'peerTopology' | 'cleanMissPeerIds'
->;
+type DecodedTopology = {
+  peerTopology: VmReconcilePeerTopology;
+  cleanMissPeerIds: string[];
+};
 
 function decodeTopology(encoded: string): DecodedTopology | null {
   if (encoded === 'unreadable') {
@@ -40,21 +43,12 @@ function decodeTopology(encoded: string): DecodedTopology | null {
     ) return null;
 
     const isLegacy = raw.version === undefined;
-    const peers: unknown[] = [];
     if (isLegacy) {
-      for (const [rank, candidate] of raw.peers.entries()) {
-        if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
-        const peer = candidate as Record<string, unknown>;
-        if (
-          peer.rank !== rank
-          || typeof peer.preferred !== 'boolean'
-          || peer.preferred !== (peer.peerId === raw.preferredPeerId)
-        ) return null;
-        peers.push({ peerId: peer.peerId, core: peer.core });
-      }
-    } else {
-      peers.push(...raw.peers);
+      const peerTopology = parseLegacyVmReconcilePeerTopologyKey(encoded);
+      return peerTopology ? { peerTopology, cleanMissPeerIds: [] } : null;
     }
+    const peers: unknown[] = [];
+    peers.push(...raw.peers);
 
     const peerTopology = parseVmReconcilePeerTopology({
       kind: 'readable',
@@ -63,9 +57,10 @@ function decodeTopology(encoded: string): DecodedTopology | null {
       peers,
     });
     if (!peerTopology) return null;
-    const cleanMissPeerIds = isLegacy
-      ? []
-      : parseVmReconcileCleanMissPeerIds(raw.cleanMissPeerIds, peerTopology);
+    const cleanMissPeerIds = parseVmReconcileCleanMissPeerIds(
+      raw.cleanMissPeerIds,
+      peerTopology,
+    );
     return cleanMissPeerIds === null ? null : { peerTopology, cleanMissPeerIds };
   } catch {
     return null;
@@ -112,6 +107,7 @@ export function decodeVmReconcileNegativeRow(
       nextRetryAt: row.next_retry_at,
       swmGen: row.swm_gen,
       candidateNamespaces: candidateNamespaces as Array<{ metaGraph: string; dataGraph: string }>,
+      peerTopologyKey: encodeLegacyVmReconcilePeerTopologyKey(topology.peerTopology),
       peerTopology: topology.peerTopology,
       cleanMissPeerIds: topology.cleanMissPeerIds,
     };
@@ -124,6 +120,15 @@ export function encodeVmReconcileNegativeRow(
   record: VmReconcileNegativeRecord,
   updatedAt: number,
 ): VmReconcileNegativePersistenceRow {
+  const peerTopology = isVmReconcilePeerTopology(record.peerTopology)
+    ? record.peerTopology
+    : parseLegacyVmReconcilePeerTopologyKey(record.peerTopologyKey);
+  if (!peerTopology) throw new TypeError('Invalid VM reconcile peer topology');
+  const cleanMissPeerIds = parseVmReconcileCleanMissPeerIds(
+    record.cleanMissPeerIds ?? [],
+    peerTopology,
+  );
+  if (!cleanMissPeerIds) throw new TypeError('Invalid VM reconcile clean-miss evidence');
   return {
     cache_key: record.cacheKey,
     context_graph_id: record.localCgId,
@@ -131,7 +136,7 @@ export function encodeVmReconcileNegativeRow(
     next_retry_at: record.nextRetryAt,
     swm_gen: record.swmGen,
     candidate_namespaces: JSON.stringify(record.candidateNamespaces),
-    peer_topology_key: encodeTopology(record.peerTopology, record.cleanMissPeerIds),
+    peer_topology_key: encodeTopology(peerTopology, cleanMissPeerIds),
     updated_at: updatedAt,
   };
 }

--- a/packages/cli/src/daemon/vm-reconcile-negative-store-adapter.ts
+++ b/packages/cli/src/daemon/vm-reconcile-negative-store-adapter.ts
@@ -1,8 +1,8 @@
 import {
-  createVmReconcilePeerTopology,
+  parseVmReconcileCleanMissPeerIds,
+  parseVmReconcilePeerTopology,
   type VmReconcileNegativeRecord,
   type VmReconcilePeerTopology,
-  type VmReconcilePeerTopologyPeer,
 } from '@origintrail-official/dkg-agent';
 
 /** Raw SQLite-facing DTO. Encoding is intentionally confined to this adapter. */
@@ -19,8 +19,15 @@ export interface VmReconcileNegativePersistenceRow {
 
 const TOPOLOGY_VERSION = 2;
 
-function decodeTopology(encoded: string): VmReconcilePeerTopology | null {
-  if (encoded === 'unreadable') return { kind: 'unreadable' };
+type DecodedTopology = Pick<
+  VmReconcileNegativeRecord,
+  'peerTopology' | 'cleanMissPeerIds'
+>;
+
+function decodeTopology(encoded: string): DecodedTopology | null {
+  if (encoded === 'unreadable') {
+    return { peerTopology: { kind: 'unreadable' }, cleanMissPeerIds: [] };
+  }
   try {
     const value: unknown = JSON.parse(encoded);
     if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
@@ -29,64 +36,53 @@ function decodeTopology(encoded: string): VmReconcilePeerTopology | null {
       !(raw.preferredPeerId === null || typeof raw.preferredPeerId === 'string')
       || typeof raw.privateOnly !== 'boolean'
       || !Array.isArray(raw.peers)
-      || (raw.version !== 1 && raw.version !== TOPOLOGY_VERSION)
+      || !(raw.version === undefined || raw.version === 1 || raw.version === TOPOLOGY_VERSION)
     ) return null;
 
-    const peers: VmReconcilePeerTopologyPeer[] = [];
-    const peerIds = new Set<string>();
-    for (const [rank, candidate] of raw.peers.entries()) {
-      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
-      const peer = candidate as Record<string, unknown>;
-      if (
-        typeof peer.peerId !== 'string'
-        || peer.peerId.length === 0
-        || typeof peer.core !== 'boolean'
-        || peerIds.has(peer.peerId)
-      ) return null;
-      if (
-        raw.version === 1
-        && (
+    const isLegacy = raw.version === undefined || raw.version === 1;
+    const peers: unknown[] = [];
+    if (isLegacy) {
+      for (const [rank, candidate] of raw.peers.entries()) {
+        if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
+        const peer = candidate as Record<string, unknown>;
+        if (
           peer.rank !== rank
           || typeof peer.preferred !== 'boolean'
           || peer.preferred !== (peer.peerId === raw.preferredPeerId)
-        )
-      ) return null;
-      peerIds.add(peer.peerId);
-      peers.push({ peerId: peer.peerId, core: peer.core });
+        ) return null;
+        peers.push({ peerId: peer.peerId, core: peer.core });
+      }
+    } else {
+      peers.push(...raw.peers);
     }
 
-    const rawCleanMissPeerIds = raw.version === 1 ? [] : raw.cleanMissPeerIds;
-    if (!Array.isArray(rawCleanMissPeerIds)) return null;
-    const cleanMissPeerIds: string[] = [];
-    const cleanMisses = new Set<string>();
-    for (const peerId of rawCleanMissPeerIds) {
-      if (
-        typeof peerId !== 'string'
-        || !peerIds.has(peerId)
-        || cleanMisses.has(peerId)
-      ) return null;
-      cleanMisses.add(peerId);
-      cleanMissPeerIds.push(peerId);
-    }
-    return createVmReconcilePeerTopology({
+    const peerTopology = parseVmReconcilePeerTopology({
+      kind: 'readable',
       preferredPeerId: raw.preferredPeerId,
       privateOnly: raw.privateOnly,
       peers,
-      cleanMissPeerIds,
     });
+    if (!peerTopology) return null;
+    const cleanMissPeerIds = isLegacy
+      ? []
+      : parseVmReconcileCleanMissPeerIds(raw.cleanMissPeerIds, peerTopology);
+    return cleanMissPeerIds === null ? null : { peerTopology, cleanMissPeerIds };
   } catch {
     return null;
   }
 }
 
-function encodeTopology(topology: VmReconcilePeerTopology): string {
+function encodeTopology(
+  topology: VmReconcilePeerTopology,
+  cleanMissPeerIds: readonly string[],
+): string {
   if (topology.kind === 'unreadable') return 'unreadable';
   return JSON.stringify({
     version: TOPOLOGY_VERSION,
     preferredPeerId: topology.preferredPeerId,
     privateOnly: topology.privateOnly,
     peers: topology.peers,
-    cleanMissPeerIds: topology.cleanMissPeerIds,
+    cleanMissPeerIds,
   });
 }
 
@@ -95,7 +91,7 @@ export function decodeVmReconcileNegativeRow(
 ): VmReconcileNegativeRecord | null {
   try {
     const candidateNamespaces: unknown = JSON.parse(row.candidate_namespaces);
-    const peerTopology = decodeTopology(row.peer_topology_key);
+    const topology = decodeTopology(row.peer_topology_key);
     if (
       !Number.isInteger(row.failures)
       || row.failures <= 0
@@ -107,7 +103,7 @@ export function decodeVmReconcileNegativeRow(
         && !Array.isArray(item)
         && typeof (item as Record<string, unknown>).metaGraph === 'string'
         && typeof (item as Record<string, unknown>).dataGraph === 'string')
-      || !peerTopology
+      || !topology
     ) return null;
     return {
       cacheKey: row.cache_key,
@@ -116,7 +112,8 @@ export function decodeVmReconcileNegativeRow(
       nextRetryAt: row.next_retry_at,
       swmGen: row.swm_gen,
       candidateNamespaces: candidateNamespaces as Array<{ metaGraph: string; dataGraph: string }>,
-      peerTopology,
+      peerTopology: topology.peerTopology,
+      cleanMissPeerIds: topology.cleanMissPeerIds,
     };
   } catch {
     return null;
@@ -134,7 +131,7 @@ export function encodeVmReconcileNegativeRow(
     next_retry_at: record.nextRetryAt,
     swm_gen: record.swmGen,
     candidate_namespaces: JSON.stringify(record.candidateNamespaces),
-    peer_topology_key: encodeTopology(record.peerTopology),
+    peer_topology_key: encodeTopology(record.peerTopology, record.cleanMissPeerIds),
     updated_at: updatedAt,
   };
 }

--- a/packages/cli/src/daemon/vm-reconcile-negative-store-adapter.ts
+++ b/packages/cli/src/daemon/vm-reconcile-negative-store-adapter.ts
@@ -36,10 +36,10 @@ function decodeTopology(encoded: string): DecodedTopology | null {
       !(raw.preferredPeerId === null || typeof raw.preferredPeerId === 'string')
       || typeof raw.privateOnly !== 'boolean'
       || !Array.isArray(raw.peers)
-      || !(raw.version === undefined || raw.version === 1 || raw.version === TOPOLOGY_VERSION)
+      || !(raw.version === undefined || raw.version === TOPOLOGY_VERSION)
     ) return null;
 
-    const isLegacy = raw.version === undefined || raw.version === 1;
+    const isLegacy = raw.version === undefined;
     const peers: unknown[] = [];
     if (isLegacy) {
       for (const [rank, candidate] of raw.peers.entries()) {

--- a/packages/cli/test/vm-reconcile-negative-store-adapter.test.ts
+++ b/packages/cli/test/vm-reconcile-negative-store-adapter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createVmReconcilePeerTopology,
+  type VmReconcileNegativeRecord,
+} from '@origintrail-official/dkg-agent';
+import {
+  decodeVmReconcileNegativeRow,
+  encodeVmReconcileNegativeRow,
+} from '../src/daemon/vm-reconcile-negative-store-adapter.js';
+
+function record(): VmReconcileNegativeRecord {
+  return {
+    cacheKey: 'cg\0ual#root',
+    localCgId: 'cg',
+    failures: 2,
+    nextRetryAt: 1234,
+    swmGen: 'changelog:1:2',
+    candidateNamespaces: [{ metaGraph: 'urn:meta', dataGraph: 'urn:data' }],
+    peerTopology: createVmReconcilePeerTopology({
+      preferredPeerId: 'peer-a',
+      privateOnly: false,
+      peers: [
+        { peerId: 'peer-a', core: true },
+        { peerId: 'peer-b', core: false },
+      ],
+      cleanMissPeerIds: ['peer-b'],
+    }),
+  };
+}
+
+describe('VM reconcile negative SQLite adapter', () => {
+  it('round-trips the typed domain record through the existing text columns', () => {
+    const value = record();
+    const row = encodeVmReconcileNegativeRow(value, 999);
+
+    expect(row.updated_at).toBe(999);
+    expect(JSON.parse(row.peer_topology_key)).toEqual({
+      version: 2,
+      preferredPeerId: 'peer-a',
+      privateOnly: false,
+      peers: [
+        { peerId: 'peer-a', core: true },
+        { peerId: 'peer-b', core: false },
+      ],
+      cleanMissPeerIds: ['peer-b'],
+    });
+    expect(decodeVmReconcileNegativeRow(row)).toEqual(value);
+  });
+
+  it('round-trips the unreadable topology sentinel without JSON encoding', () => {
+    const value = record();
+    value.peerTopology = { kind: 'unreadable' };
+    const row = encodeVmReconcileNegativeRow(value, 999);
+
+    expect(row.peer_topology_key).toBe('unreadable');
+    expect(decodeVmReconcileNegativeRow(row)).toEqual(value);
+  });
+
+  it('migrates the previous redundant topology encoding without granting miss evidence', () => {
+    const row = encodeVmReconcileNegativeRow(record(), 999);
+    row.peer_topology_key = JSON.stringify({
+      version: 1,
+      preferredPeerId: 'peer-a',
+      privateOnly: false,
+      peers: [
+        { rank: 0, peerId: 'peer-a', preferred: true, core: true },
+        { rank: 1, peerId: 'peer-b', preferred: false, core: false },
+      ],
+    });
+
+    expect(decodeVmReconcileNegativeRow(row)?.peerTopology).toEqual({
+      kind: 'readable',
+      preferredPeerId: 'peer-a',
+      privateOnly: false,
+      peers: [
+        { peerId: 'peer-a', core: true },
+        { peerId: 'peer-b', core: false },
+      ],
+      cleanMissPeerIds: [],
+    });
+  });
+
+  it('fails open on malformed topology state', () => {
+    const row = encodeVmReconcileNegativeRow(record(), 999);
+    row.peer_topology_key = JSON.stringify({
+      version: 2,
+      preferredPeerId: null,
+      privateOnly: false,
+      peers: [{ peerId: 'peer-a', core: false }],
+      cleanMissPeerIds: ['unknown-peer'],
+    });
+
+    expect(decodeVmReconcileNegativeRow(row)).toBeNull();
+  });
+});

--- a/packages/cli/test/vm-reconcile-negative-store-adapter.test.ts
+++ b/packages/cli/test/vm-reconcile-negative-store-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   createVmReconcilePeerTopology,
+  encodeLegacyVmReconcilePeerTopologyKey,
   type VmReconcileNegativeRecord,
 } from '@origintrail-official/dkg-agent';
 import {
@@ -9,6 +10,14 @@ import {
 } from '../src/daemon/vm-reconcile-negative-store-adapter.js';
 
 function record(): VmReconcileNegativeRecord {
+  const peerTopology = createVmReconcilePeerTopology({
+    preferredPeerId: 'peer-a',
+    privateOnly: false,
+    peers: [
+      { peerId: 'peer-a', core: true },
+      { peerId: 'peer-b', core: false },
+    ],
+  });
   return {
     cacheKey: 'cg\0ual#root',
     localCgId: 'cg',
@@ -16,14 +25,8 @@ function record(): VmReconcileNegativeRecord {
     nextRetryAt: 1234,
     swmGen: 'changelog:1:2',
     candidateNamespaces: [{ metaGraph: 'urn:meta', dataGraph: 'urn:data' }],
-    peerTopology: createVmReconcilePeerTopology({
-      preferredPeerId: 'peer-a',
-      privateOnly: false,
-      peers: [
-        { peerId: 'peer-a', core: true },
-        { peerId: 'peer-b', core: false },
-      ],
-    }),
+    peerTopologyKey: encodeLegacyVmReconcilePeerTopologyKey(peerTopology),
+    peerTopology,
     cleanMissPeerIds: ['peer-b'],
   };
 }
@@ -50,6 +53,7 @@ describe('VM reconcile negative SQLite adapter', () => {
   it('round-trips the unreadable topology sentinel without JSON encoding', () => {
     const value = record();
     value.peerTopology = { kind: 'unreadable' };
+    value.peerTopologyKey = 'unreadable';
     value.cleanMissPeerIds = [];
     const row = encodeVmReconcileNegativeRow(value, 999);
 

--- a/packages/cli/test/vm-reconcile-negative-store-adapter.test.ts
+++ b/packages/cli/test/vm-reconcile-negative-store-adapter.test.ts
@@ -82,6 +82,21 @@ describe('VM reconcile negative SQLite adapter', () => {
     });
   });
 
+  it('rejects the unshipped intermediate version-1 topology encoding', () => {
+    const row = encodeVmReconcileNegativeRow(record(), 999);
+    row.peer_topology_key = JSON.stringify({
+      version: 1,
+      preferredPeerId: 'peer-a',
+      privateOnly: false,
+      peers: [
+        { rank: 0, peerId: 'peer-a', preferred: true, core: true },
+        { rank: 1, peerId: 'peer-b', preferred: false, core: false },
+      ],
+    });
+
+    expect(decodeVmReconcileNegativeRow(row)).toBeNull();
+  });
+
   it('fails open on malformed topology state', () => {
     const row = encodeVmReconcileNegativeRow(record(), 999);
     row.peer_topology_key = JSON.stringify({

--- a/packages/cli/test/vm-reconcile-negative-store-adapter.test.ts
+++ b/packages/cli/test/vm-reconcile-negative-store-adapter.test.ts
@@ -23,8 +23,8 @@ function record(): VmReconcileNegativeRecord {
         { peerId: 'peer-a', core: true },
         { peerId: 'peer-b', core: false },
       ],
-      cleanMissPeerIds: ['peer-b'],
     }),
+    cleanMissPeerIds: ['peer-b'],
   };
 }
 
@@ -50,16 +50,16 @@ describe('VM reconcile negative SQLite adapter', () => {
   it('round-trips the unreadable topology sentinel without JSON encoding', () => {
     const value = record();
     value.peerTopology = { kind: 'unreadable' };
+    value.cleanMissPeerIds = [];
     const row = encodeVmReconcileNegativeRow(value, 999);
 
     expect(row.peer_topology_key).toBe('unreadable');
     expect(decodeVmReconcileNegativeRow(row)).toEqual(value);
   });
 
-  it('migrates the previous redundant topology encoding without granting miss evidence', () => {
+  it('migrates the exact unversioned legacy encoding without granting miss evidence', () => {
     const row = encodeVmReconcileNegativeRow(record(), 999);
     row.peer_topology_key = JSON.stringify({
-      version: 1,
       preferredPeerId: 'peer-a',
       privateOnly: false,
       peers: [
@@ -68,14 +68,16 @@ describe('VM reconcile negative SQLite adapter', () => {
       ],
     });
 
-    expect(decodeVmReconcileNegativeRow(row)?.peerTopology).toEqual({
-      kind: 'readable',
-      preferredPeerId: 'peer-a',
-      privateOnly: false,
-      peers: [
-        { peerId: 'peer-a', core: true },
-        { peerId: 'peer-b', core: false },
-      ],
+    expect(decodeVmReconcileNegativeRow(row)).toMatchObject({
+      peerTopology: {
+        kind: 'readable',
+        preferredPeerId: 'peer-a',
+        privateOnly: false,
+        peers: [
+          { peerId: 'peer-a', core: true },
+          { peerId: 'peer-b', core: false },
+        ],
+      },
       cleanMissPeerIds: [],
     });
   });


### PR DESCRIPTION
## Summary

- retain a verified VM negative-cache entry when the current provider topology is a capability-preserving subsequence of the topology already checked
- invalidate immediately when providers are added, reclassified, reranked, or otherwise change capability
- cover peer disappearance and unsafe topology changes in focused tests

## Why

An intermittently reachable core peer caused the connected provider set to oscillate between 10 and 9 peers. Exact-topology equality invalidated hundreds of otherwise valid VM miss-cache entries and restarted exact fetches, even though losing a provider cannot reveal data that the larger already-checked set did not have.

## Current validation

- rebased directly onto current `testnet-canary` (`b6c9e5f467d4f5f256aa75443b809f982b2a3c70`)
- focused VM reconcile suite: 126/126 passed
- runtime package build, agent build, type tests, and package-root tests: passed
- diff hygiene check: passed
- earlier one-hour local edge soak: cache reuse continued after the provider set contracted 10 to 9, with zero sync-backpressure rejections in the observation window

This remains a draft. It must not be merged until exact-head CI/review and a fresh distributed receiver completeness gate are satisfied.
