### PR TITLE
fix(agent): accept graph-local receipt UAL in named-KA publish recovery (#1966)

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4833,7 +4833,7 @@ export class PublishMethods extends DKGAgentBase {
       );
       this.log.info(
         ctx,
-        `Recovered confirmed named KA publish ${recovered.publishedUal} from ${job.status} job ${job.jobId}`
+        `Recovered confirmed named KA publish ${recovered.localUal} from ${job.status} job ${job.jobId}`
           + ' (receipt only; current superseding version left unchanged)',
       );
       return;
@@ -4900,7 +4900,7 @@ export class PublishMethods extends DKGAgentBase {
     if (canStampLifecycle) {
       await this._stampQueuedKnowledgeAssetVmPublishedLifecycle(
         request,
-        recovered.publishedUal,
+        recovered.localUal,
         recovered.reservedKaId,
         recovered.materialization.merkleRoot,
       );
@@ -4918,7 +4918,7 @@ export class PublishMethods extends DKGAgentBase {
     // the shared writer-lock cleanup needed to close that wider race.
     this.log.info(
       ctx,
-      `Recovered confirmed named KA publish ${recovered.publishedUal} from ${job.status} job ${job.jobId}`,
+      `Recovered confirmed named KA publish ${recovered.localUal} from ${job.status} job ${job.jobId}`,
     );
   }
 

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4833,7 +4833,7 @@ export class PublishMethods extends DKGAgentBase {
       );
       this.log.info(
         ctx,
-        `Recovered confirmed named KA publish ${recovered.receiptUal} from ${job.status} job ${job.jobId}`
+        `Recovered confirmed named KA publish ${recovered.publishedUal} from ${job.status} job ${job.jobId}`
           + ' (receipt only; current superseding version left unchanged)',
       );
       return;
@@ -4900,7 +4900,7 @@ export class PublishMethods extends DKGAgentBase {
     if (canStampLifecycle) {
       await this._stampQueuedKnowledgeAssetVmPublishedLifecycle(
         request,
-        recovered.receiptUal,
+        recovered.publishedUal,
         recovered.reservedKaId,
         recovered.materialization.merkleRoot,
       );
@@ -4918,7 +4918,7 @@ export class PublishMethods extends DKGAgentBase {
     // the shared writer-lock cleanup needed to close that wider race.
     this.log.info(
       ctx,
-      `Recovered confirmed named KA publish ${recovered.receiptUal} from ${job.status} job ${job.jobId}`,
+      `Recovered confirmed named KA publish ${recovered.publishedUal} from ${job.status} job ${job.jobId}`,
     );
   }
 

--- a/packages/agent/src/named-ka-publish-recovery.ts
+++ b/packages/agent/src/named-ka-publish-recovery.ts
@@ -16,14 +16,11 @@ import { unpackKnowledgeAssetId } from './ka-identity.js';
 export interface RecoveredNamedKaPublish {
   readonly reservedKaId: bigint;
   /**
-   * The recovered published UAL, exactly as returned by the recovery resolver: the graph-local
-   * form (author address + low-96 KA number) for named/graph-scoped KAs — matching what a normal
-   * publish records — or the contract-address + packed-KA-id form for generic recovery. Validated
-   * to be one of those two representations of {@link reservedKaId}, then stamped verbatim as the
-   * asset's `publishedUal`. The immutable identity is `reservedKaId`, not this string.
+   * The single canonical graph-local identity of this named KA (author address + low-96 KA
+   * number), derived from the request — never the raw resolver wire form. This is what a normal
+   * publish records, and it is used both to drive local materialization and to stamp the asset's
+   * `publishedUal`. The immutable identity is `reservedKaId`; this is its graph-local rendering.
    */
-  readonly publishedUal: string;
-  /** Canonical local graph identity: author address + low-96 KA number. Drives local materialization. */
   readonly localUal: string;
   readonly txHash: string;
   readonly receiptBlockNumber: number;
@@ -161,17 +158,17 @@ export async function normalizeRecoveredNamedKaPublish(input: {
       `could not resolve the canonical receipt UAL: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  // The recovery resolver returns the published UAL in one of two proven-equivalent
-  // representations of the SAME reserved packed KA id — both already bound to chain
-  // truth by the batchId/startKAId/endKAId === reservedKaId (above) and author-bit /
-  // localScope checks, all of which run before this point and are independent of `ual`:
-  //   - the canonical chain-receipt form (DKGKnowledgeAssets contract + packed id),
-  //     produced by the generic recovery mapper; or
+  // Cross-check the resolver's returned UAL against the SAME reserved packed KA id in either
+  // of its two proven-equivalent wire representations — both already bound to chain truth by
+  // the batchId/startKAId/endKAId === reservedKaId (above) and the author-bit / localScope
+  // checks, all of which run before this point and are independent of `ual`:
+  //   - the canonical chain-receipt form (DKGKnowledgeAssets contract + packed id), produced
+  //     by the generic recovery mapper; or
   //   - the graph-local form (sealed author + low-96 KA number), which the CLI resolver
-  //     deliberately surfaces for named/graph-scoped KAs so the user-facing UAL stays
-  //     graph-local (also what a normal publish records).
-  // Accept EITHER exact form; every other UAL fails closed. This is a representation
-  // cross-check only — the immutable identity is fixed numerically before this line.
+  //     deliberately surfaces for named/graph-scoped KAs.
+  // Accept EITHER exact form; every other UAL fails closed. `ual` is ONLY validated here — it
+  // is never exported; the normalized identity is the canonical graph-local `localUal`, so
+  // callers never have to reason about which wire shape the resolver happened to send.
   if (!sameHex(ual, expectedReceiptUal) && !sameHex(ual, localUal)) {
     throw inconsistent(
       `published receipt UAL ${ual} does not match the canonical receipt UAL ${expectedReceiptUal} or the graph-local UAL ${localUal}`,
@@ -228,7 +225,6 @@ export async function normalizeRecoveredNamedKaPublish(input: {
 
   return {
     reservedKaId,
-    publishedUal: ual,
     localUal,
     txHash: recovery.inclusion.txHash,
     receiptBlockNumber: recovery.inclusion.blockNumber,

--- a/packages/agent/src/named-ka-publish-recovery.ts
+++ b/packages/agent/src/named-ka-publish-recovery.ts
@@ -61,7 +61,10 @@ export async function normalizeRecoveredNamedKaPublish(input: {
 }): Promise<RecoveredNamedKaPublish> {
   const { request, job, recovery, chain } = input;
   const inconsistent = (message: string): Error => recoveryInconsistent(request.name, message);
+  // Hash equality (merkle roots, tx hashes) vs UAL identity equality are distinct concepts;
+  // give each its own name so the boundary check does not read as a hex-hash comparison.
   const sameHex = (left: string, right: string): boolean => left.toLowerCase() === right.toLowerCase();
+  const sameUal = (left: string, right: string): boolean => left.toLowerCase() === right.toLowerCase();
 
   if (!sameHex(job.broadcast.txHash, recovery.inclusion.txHash)) {
     throw inconsistent(
@@ -142,37 +145,37 @@ export async function normalizeRecoveredNamedKaPublish(input: {
     }
   }
   if (!ual) throw inconsistent('chain recovery did not return the published UAL');
-  let expectedReceiptUal: string;
-  try {
-    if (!chain.getDKGKnowledgeAssetsAddress) {
-      throw new Error('the configured chain adapter cannot resolve the DKGKnowledgeAssets address');
+  // The normalized identity is always the canonical graph-local `localUal`, never the raw
+  // resolver wire form. Cross-check the returned `ual` against the SAME reserved packed KA id
+  // in either proven-equivalent representation — both already bound to chain truth by the
+  // batchId/startKAId/endKAId === reservedKaId (above) and the author-bit / localScope checks,
+  // all independent of `ual`. Match the graph-local form first (the shape the CLI resolver
+  // surfaces for named KAs); only when it does not match do we resolve and compare the
+  // canonical chain-receipt form (DKGKnowledgeAssets contract + packed id) the generic mapper
+  // produces — so the common named-KA path never needs the contract address. Every other UAL
+  // fails closed; `ual` is validated here and never exported.
+  if (!sameUal(ual, localUal)) {
+    let expectedReceiptUal: string;
+    try {
+      if (!chain.getDKGKnowledgeAssetsAddress) {
+        throw new Error('the configured chain adapter cannot resolve the DKGKnowledgeAssets address');
+      }
+      const knowledgeAssetsContract = await chain.getDKGKnowledgeAssetsAddress();
+      expectedReceiptUal = buildKnowledgeAssetUal(
+        chain.chainId,
+        ethers.getAddress(knowledgeAssetsContract),
+        reservedKaId,
+      );
+    } catch (error) {
+      throw inconsistent(
+        `could not resolve the canonical receipt UAL: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
-    const knowledgeAssetsContract = await chain.getDKGKnowledgeAssetsAddress();
-    expectedReceiptUal = buildKnowledgeAssetUal(
-      chain.chainId,
-      ethers.getAddress(knowledgeAssetsContract),
-      reservedKaId,
-    );
-  } catch (error) {
-    throw inconsistent(
-      `could not resolve the canonical receipt UAL: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-  // Cross-check the resolver's returned UAL against the SAME reserved packed KA id in either
-  // of its two proven-equivalent wire representations — both already bound to chain truth by
-  // the batchId/startKAId/endKAId === reservedKaId (above) and the author-bit / localScope
-  // checks, all of which run before this point and are independent of `ual`:
-  //   - the canonical chain-receipt form (DKGKnowledgeAssets contract + packed id), produced
-  //     by the generic recovery mapper; or
-  //   - the graph-local form (sealed author + low-96 KA number), which the CLI resolver
-  //     deliberately surfaces for named/graph-scoped KAs.
-  // Accept EITHER exact form; every other UAL fails closed. `ual` is ONLY validated here — it
-  // is never exported; the normalized identity is the canonical graph-local `localUal`, so
-  // callers never have to reason about which wire shape the resolver happened to send.
-  if (!sameHex(ual, expectedReceiptUal) && !sameHex(ual, localUal)) {
-    throw inconsistent(
-      `published receipt UAL ${ual} does not match the canonical receipt UAL ${expectedReceiptUal} or the graph-local UAL ${localUal}`,
-    );
+    if (!sameUal(ual, expectedReceiptUal)) {
+      throw inconsistent(
+        `published receipt UAL ${ual} does not match the graph-local UAL ${localUal} or the canonical receipt UAL ${expectedReceiptUal}`,
+      );
+    }
   }
   if (!publisherAddress || !ethers.isAddress(publisherAddress)) {
     throw inconsistent('chain recovery did not return a valid publisher address');

--- a/packages/agent/src/named-ka-publish-recovery.ts
+++ b/packages/agent/src/named-ka-publish-recovery.ts
@@ -47,6 +47,17 @@ function recoveryInconsistent(name: string, message: string): Error {
 }
 
 /**
+ * Case-insensitive comparison, named for exactly what it does. It is the right test for both
+ * kinds of evidence compared here: hex evidence (tx hashes, merkle roots) whose casing is not
+ * significant, and the two published-UAL representations, whose only case-variable segment is
+ * the embedded hex address — every other segment is already canonical by construction
+ * (`buildKnowledgeAssetUal` lowercases, `createGraphKnowledgeAssetScope` canonicalizes).
+ */
+function equalsIgnoreCase(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+/**
  * Validate immutable transaction evidence, then separately resolve the chain's
  * current version for local materialization. A later update must never make the
  * original confirmed publish unrecoverable or regress the VM pointer.
@@ -61,20 +72,16 @@ export async function normalizeRecoveredNamedKaPublish(input: {
 }): Promise<RecoveredNamedKaPublish> {
   const { request, job, recovery, chain } = input;
   const inconsistent = (message: string): Error => recoveryInconsistent(request.name, message);
-  // Hash equality (merkle roots, tx hashes) vs UAL identity equality are distinct concepts;
-  // give each its own name so the boundary check does not read as a hex-hash comparison.
-  const sameHex = (left: string, right: string): boolean => left.toLowerCase() === right.toLowerCase();
-  const sameUal = (left: string, right: string): boolean => left.toLowerCase() === right.toLowerCase();
 
-  if (!sameHex(job.broadcast.txHash, recovery.inclusion.txHash)) {
+  if (!equalsIgnoreCase(job.broadcast.txHash, recovery.inclusion.txHash)) {
     throw inconsistent(
       `resolved inclusion tx ${recovery.inclusion.txHash} does not match queued tx ${job.broadcast.txHash}`,
     );
   }
-  if (!recovery.finalization.txHash || !sameHex(job.broadcast.txHash, recovery.finalization.txHash)) {
+  if (!recovery.finalization.txHash || !equalsIgnoreCase(job.broadcast.txHash, recovery.finalization.txHash)) {
     throw inconsistent('resolved finalization is not bound to the queued transaction hash');
   }
-  if (job.broadcast.merkleRoot && !sameHex(job.broadcast.merkleRoot, request.sealMerkleRoot)) {
+  if (job.broadcast.merkleRoot && !equalsIgnoreCase(job.broadcast.merkleRoot, request.sealMerkleRoot)) {
     throw inconsistent(
       `queued broadcast merkle root ${job.broadcast.merkleRoot} does not match seal ${request.sealMerkleRoot}`,
     );
@@ -154,7 +161,7 @@ export async function normalizeRecoveredNamedKaPublish(input: {
   // canonical chain-receipt form (DKGKnowledgeAssets contract + packed id) the generic mapper
   // produces — so the common named-KA path never needs the contract address. Every other UAL
   // fails closed; `ual` is validated here and never exported.
-  if (!sameUal(ual, localUal)) {
+  if (!equalsIgnoreCase(ual, localUal)) {
     let expectedReceiptUal: string;
     try {
       if (!chain.getDKGKnowledgeAssetsAddress) {
@@ -171,7 +178,7 @@ export async function normalizeRecoveredNamedKaPublish(input: {
         `could not resolve the canonical receipt UAL: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    if (!sameUal(ual, expectedReceiptUal)) {
+    if (!equalsIgnoreCase(ual, expectedReceiptUal)) {
       throw inconsistent(
         `published receipt UAL ${ual} does not match the graph-local UAL ${localUal} or the canonical receipt UAL ${expectedReceiptUal}`,
       );
@@ -187,7 +194,7 @@ export async function normalizeRecoveredNamedKaPublish(input: {
   if (!blockHash || !/^0x[0-9a-fA-F]{64}$/.test(blockHash)) {
     throw inconsistent('chain recovery did not return a valid canonical block hash');
   }
-  if (!sameHex(proof.merkleRoot, request.sealMerkleRoot)) {
+  if (!equalsIgnoreCase(proof.merkleRoot, request.sealMerkleRoot)) {
     throw inconsistent(
       `transaction merkle root ${proof.merkleRoot} does not match queued seal ${request.sealMerkleRoot}`,
     );
@@ -209,7 +216,7 @@ export async function normalizeRecoveredNamedKaPublish(input: {
     throw inconsistent('the configured chain adapter cannot resolve the current KA merkle root');
   }
   const latestMerkleRoot = ethers.hexlify(await chain.getLatestMerkleRoot(reservedKaId));
-  const superseded = !sameHex(latestMerkleRoot, proof.merkleRoot);
+  const superseded = !equalsIgnoreCase(latestMerkleRoot, proof.merkleRoot);
   let materializationAuthor = transactionAuthor;
   let materializationPublisher = transactionPublisher;
   let versionBlock = recovery.inclusion.blockNumber;

--- a/packages/agent/src/named-ka-publish-recovery.ts
+++ b/packages/agent/src/named-ka-publish-recovery.ts
@@ -9,8 +9,7 @@ import { createGraphKnowledgeAssetScope } from '@origintrail-official/dkg-core';
 import type {
   AsyncKnowledgeAssetVmPublishRecoveryEvidence,
   KnowledgeAssetVmPublishRequest,
-  LiftJobBroadcast,
-  LiftJobIncluded,
+  LiftJobBroadcastMetadata,
 } from '@origintrail-official/dkg-publisher';
 import { unpackKnowledgeAssetId } from './ka-identity.js';
 
@@ -20,11 +19,11 @@ export interface RecoveredNamedKaPublish {
    * The recovered published UAL, exactly as returned by the recovery resolver: the graph-local
    * form (author address + low-96 KA number) for named/graph-scoped KAs — matching what a normal
    * publish records — or the contract-address + packed-KA-id form for generic recovery. Validated
-   * to be one of those two representations of {@link reservedKaId}; used only as the stamped
-   * `publishedUal`. The immutable identity is `reservedKaId`, not this string.
+   * to be one of those two representations of {@link reservedKaId}, then stamped verbatim as the
+   * asset's `publishedUal`. The immutable identity is `reservedKaId`, not this string.
    */
-  readonly receiptUal: string;
-  /** Canonical local graph identity: author address + low-96 KA number. */
+  readonly publishedUal: string;
+  /** Canonical local graph identity: author address + low-96 KA number. Drives local materialization. */
   readonly localUal: string;
   readonly txHash: string;
   readonly receiptBlockNumber: number;
@@ -57,7 +56,9 @@ function recoveryInconsistent(name: string, message: string): Error {
  */
 export async function normalizeRecoveredNamedKaPublish(input: {
   readonly request: KnowledgeAssetVmPublishRequest;
-  readonly job: LiftJobBroadcast | LiftJobIncluded;
+  // Only the broadcast metadata (queued tx hash + optional merkle root) is read here; a
+  // structural type keeps the boundary honest instead of taking the whole queue-job union.
+  readonly job: { readonly broadcast: LiftJobBroadcastMetadata };
   readonly recovery: AsyncKnowledgeAssetVmPublishRecoveryEvidence;
   readonly chain: ChainAdapter;
 }): Promise<RecoveredNamedKaPublish> {
@@ -227,7 +228,7 @@ export async function normalizeRecoveredNamedKaPublish(input: {
 
   return {
     reservedKaId,
-    receiptUal: ual,
+    publishedUal: ual,
     localUal,
     txHash: recovery.inclusion.txHash,
     receiptBlockNumber: recovery.inclusion.blockNumber,

--- a/packages/agent/src/named-ka-publish-recovery.ts
+++ b/packages/agent/src/named-ka-publish-recovery.ts
@@ -16,7 +16,13 @@ import { unpackKnowledgeAssetId } from './ka-identity.js';
 
 export interface RecoveredNamedKaPublish {
   readonly reservedKaId: bigint;
-  /** Canonical chain receipt identity: contract address + packed KA id. */
+  /**
+   * The recovered published UAL, exactly as returned by the recovery resolver: the graph-local
+   * form (author address + low-96 KA number) for named/graph-scoped KAs — matching what a normal
+   * publish records — or the contract-address + packed-KA-id form for generic recovery. Validated
+   * to be one of those two representations of {@link reservedKaId}; used only as the stamped
+   * `publishedUal`. The immutable identity is `reservedKaId`, not this string.
+   */
   readonly receiptUal: string;
   /** Canonical local graph identity: author address + low-96 KA number. */
   readonly localUal: string;
@@ -154,9 +160,20 @@ export async function normalizeRecoveredNamedKaPublish(input: {
       `could not resolve the canonical receipt UAL: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  if (ual !== expectedReceiptUal) {
+  // The recovery resolver returns the published UAL in one of two proven-equivalent
+  // representations of the SAME reserved packed KA id — both already bound to chain
+  // truth by the batchId/startKAId/endKAId === reservedKaId (above) and author-bit /
+  // localScope checks, all of which run before this point and are independent of `ual`:
+  //   - the canonical chain-receipt form (DKGKnowledgeAssets contract + packed id),
+  //     produced by the generic recovery mapper; or
+  //   - the graph-local form (sealed author + low-96 KA number), which the CLI resolver
+  //     deliberately surfaces for named/graph-scoped KAs so the user-facing UAL stays
+  //     graph-local (also what a normal publish records).
+  // Accept EITHER exact form; every other UAL fails closed. This is a representation
+  // cross-check only — the immutable identity is fixed numerically before this line.
+  if (!sameHex(ual, expectedReceiptUal) && !sameHex(ual, localUal)) {
     throw inconsistent(
-      `published receipt UAL ${ual} does not match ${expectedReceiptUal}`,
+      `published receipt UAL ${ual} does not match the canonical receipt UAL ${expectedReceiptUal} or the graph-local UAL ${localUal}`,
     );
   }
   if (!publisherAddress || !ethers.isAddress(publisherAddress)) {

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -695,9 +695,12 @@ describe('rootless graph-scoped KA lifecycle', () => {
         finalization: {
           mode: 'published',
           txHash,
-          // Production recovery resolver shape: contract + packed KA id. The
-          // finalizer must keep using intent.kaUal for the local exact graph.
-          ual: receiptUal,
+          // GH#1966: for graph-scoped named KAs the production CLI recovery
+          // resolver overrides finalization.ual with the graph-local queued UAL
+          // (author + low-96 KA number) — the same identity a normal publish
+          // records — NOT the contract/packed-id receipt form. Recovery must
+          // accept it; the finalizer keeps using intent.kaUal for the local graph.
+          ual: intent.kaUal,
           batchId: kaId.toString(),
           startKAId: kaId.toString(),
           endKAId: kaId.toString(),
@@ -826,7 +829,9 @@ describe('rootless graph-scoped KA lifecycle', () => {
     expect(history?.memoryLayer).toBe(MemoryLayer.VerifiableMemory);
     expect(history?.status).toBe('vm-confirmed');
     expect(history?.vmCurrentAssertion).toBe(intent.sealMerkleRoot.slice(2));
-    expect(history?.publishedUal).toBe(receiptUal);
+    // GH#1966: recovery stamps the graph-local UAL the resolver returned, matching
+    // what a normal named-KA publish records (not the contract/packed receipt form).
+    expect(history?.publishedUal).toBe(intent.kaUal);
     expect(history?.assertionGraph).toBe(contextGraphLayerUri(
       CG_ID,
       MemoryLayer.VerifiableMemory,

--- a/packages/agent/test/named-ka-publish-recovery.test.ts
+++ b/packages/agent/test/named-ka-publish-recovery.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  MockChainAdapter,
+  buildKnowledgeAssetUal,
+} from '@origintrail-official/dkg-chain';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
+} from '@origintrail-official/dkg-core';
+import type {
+  AsyncKnowledgeAssetVmPublishRecoveryEvidence,
+  KnowledgeAssetVmPublishRequest,
+  LiftJobBroadcast,
+} from '@origintrail-official/dkg-publisher';
+import { normalizeRecoveredNamedKaPublish } from '../src/named-ka-publish-recovery.js';
+
+// Regression suite for GH#1966: a confirmed named-KA publish must recover even
+// when the recovery resolver returns the GRAPH-LOCAL UAL (author + low-96 KA
+// number) instead of the canonical contract/packed-id receipt UAL. For
+// graph-scoped named KAs the production CLI resolver deliberately overrides
+// finalization.ual = request.kaUal (graph-local) — the user-facing identity —
+// so the validator must accept that representation as well as the contract form.
+//
+// The validator only ever runs for graph-scoped requests (kaUal + assertionVersion
+// present), so every case here is graph-scoped. These are the two proven-equivalent
+// representations of the SAME reserved packed KA id; any other UAL must fail closed.
+
+type Hex = `0x${string}`;
+type BigIntString = `${bigint}`;
+
+// `evm:31337` so the mock's chainId equals the kaUal chain segment (the validator
+// rejects at the localScope.chainId check otherwise — a false failure on both commits).
+const CHAIN_ID = 'evm:31337';
+// The GH#1966 incident author — a leading-zero-byte address, which also exercises
+// the unpackKnowledgeAssetId `padStart(40, '0')` path.
+const AUTHOR = '0x00a9d0dcab936a418ffebc734476c91d4027d359' as Hex;
+const KA_NUMBER = 402n;
+const RESERVED_KA_ID = (BigInt(ethers.getAddress(AUTHOR)) << 96n) | KA_NUMBER;
+const GRAPH_LOCAL_UAL = `did:dkg:${CHAIN_ID}/${AUTHOR}/${KA_NUMBER}`;
+const ASSERTION_VERSION = '1';
+const SEAL_MERKLE_ROOT = `0x${'12'.repeat(32)}` as Hex;
+const TX_HASH = `0x${'ab'.repeat(32)}` as Hex;
+const BLOCK_HASH = `0x${'cd'.repeat(32)}` as Hex;
+const PUBLISHER = AUTHOR;
+
+// MockChainAdapter.getDKGKnowledgeAssetsAddress() is a fixed constant.
+const KNOWLEDGE_ASSETS_ADDRESS = ethers.getAddress(
+  '0x000000000000000000000000000000000000c10a',
+);
+const CONTRACT_RECEIPT_UAL = buildKnowledgeAssetUal(
+  CHAIN_ID,
+  KNOWLEDGE_ASSETS_ADDRESS,
+  RESERVED_KA_ID,
+);
+
+/**
+ * A fresh mock whose latest merkle root for the reserved KA equals the seal
+ * root, so the recovered version is NOT superseded. getLatestMerkleRoot() is
+ * called OUTSIDE the validator's try/catch and throws `Mock: unknown kaId`
+ * for an unseeded id, so this seeding is mandatory for the positive cases.
+ */
+function seededChain(): MockChainAdapter {
+  const chain = new MockChainAdapter(CHAIN_ID);
+  chain.__registerKC({
+    kaId: RESERVED_KA_ID,
+    contextGraphId: 1n,
+    merkleRootHex: SEAL_MERKLE_ROOT,
+    chunks: [],
+  });
+  return chain;
+}
+
+function baseRequest(
+  overrides: Partial<KnowledgeAssetVmPublishRequest> = {},
+): KnowledgeAssetVmPublishRequest {
+  return {
+    contextGraphId: '1',
+    name: 'campaign-v2-3p95mib-ka-018',
+    shareOperationId: 'share-op-1966',
+    roots: [],
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: GRAPH_LOCAL_UAL,
+    assertionVersion: ASSERTION_VERSION,
+    publicTripleCount: 1,
+    privateTripleCount: 0,
+    seal: {
+      merkleRoot: SEAL_MERKLE_ROOT,
+      authorAddress: AUTHOR,
+      signature: { r: `0x${'34'.repeat(32)}` as Hex, vs: `0x${'56'.repeat(32)}` as Hex },
+      schemeVersion: 1,
+      reservedKaId: RESERVED_KA_ID.toString() as BigIntString,
+    },
+    sealChainId: '31337',
+    sealKav10Address: `0x${'44'.repeat(20)}` as Hex,
+    sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+    sealMerkleRoot: SEAL_MERKLE_ROOT,
+    intentKey: `sha256:${'ab'.repeat(32)}`,
+    kaNumber: KA_NUMBER.toString(),
+    ...overrides,
+  };
+}
+
+// The validator only reads job.broadcast.{txHash,merkleRoot}; the rest of the
+// LiftJobBroadcast shape is irrelevant to identity normalization.
+function broadcastJob(): LiftJobBroadcast {
+  return {
+    broadcast: { txHash: TX_HASH, walletId: 'wallet-1', merkleRoot: SEAL_MERKLE_ROOT },
+  } as unknown as LiftJobBroadcast;
+}
+
+function recoveryEvidence(
+  ual: string,
+  finalizationOverrides: Partial<AsyncKnowledgeAssetVmPublishRecoveryEvidence['finalization']> = {},
+  overrides: Partial<AsyncKnowledgeAssetVmPublishRecoveryEvidence> = {},
+): AsyncKnowledgeAssetVmPublishRecoveryEvidence {
+  return {
+    inclusion: {
+      txHash: TX_HASH,
+      blockNumber: 77,
+      blockHash: BLOCK_HASH,
+      blockTimestamp: 1_700_000_077,
+    },
+    finalization: {
+      mode: 'published',
+      txHash: TX_HASH,
+      ual,
+      batchId: RESERVED_KA_ID.toString() as BigIntString,
+      startKAId: RESERVED_KA_ID.toString() as BigIntString,
+      endKAId: RESERVED_KA_ID.toString() as BigIntString,
+      publisherAddress: PUBLISHER,
+      ...finalizationOverrides,
+    },
+    publishProof: { merkleRoot: SEAL_MERKLE_ROOT, authorAddress: AUTHOR, txIndex: 4 },
+    ...overrides,
+  } as AsyncKnowledgeAssetVmPublishRecoveryEvidence;
+}
+
+const REJECTS = { code: 'KA_VM_RECOVERY_INCONSISTENT' };
+
+describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966)', () => {
+  it('accepts the graph-local UAL the production resolver returns (regression)', async () => {
+    // On the buggy commit this throws KA_VM_RECOVERY_INCONSISTENT at the
+    // `ual !== expectedReceiptUal` check; with the fix it resolves.
+    const result = await normalizeRecoveredNamedKaPublish({
+      request: baseRequest(),
+      job: broadcastJob(),
+      recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+      chain: seededChain(),
+    });
+
+    expect(result.reservedKaId).toBe(RESERVED_KA_ID);
+    expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
+    // receiptUal carries the resolver-returned form (graph-local here), which is
+    // stamped as publishedUal — matching what a normal named-KA publish records.
+    expect(result.receiptUal).toBe(GRAPH_LOCAL_UAL);
+    expect(result.txHash).toBe(TX_HASH);
+    expect(result.materialization.superseded).toBe(false);
+  });
+
+  it('still accepts the canonical contract/packed-ID receipt UAL', async () => {
+    const result = await normalizeRecoveredNamedKaPublish({
+      request: baseRequest(),
+      job: broadcastJob(),
+      recovery: recoveryEvidence(CONTRACT_RECEIPT_UAL),
+      chain: seededChain(),
+    });
+
+    expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
+    expect(result.receiptUal).toBe(CONTRACT_RECEIPT_UAL);
+  });
+
+  it('accepts a graph-local UAL whose author is checksummed (case-insensitive)', async () => {
+    const checksummedUal = `did:dkg:${CHAIN_ID}/${ethers.getAddress(AUTHOR)}/${KA_NUMBER}`;
+    expect(checksummedUal).not.toBe(GRAPH_LOCAL_UAL); // differs only by case
+    const result = await normalizeRecoveredNamedKaPublish({
+      request: baseRequest(),
+      job: broadcastJob(),
+      recovery: recoveryEvidence(checksummedUal),
+      chain: seededChain(),
+    });
+    expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
+  });
+
+  it('resolver-preserved kaUal canonicalizes to the validator-derived localUal (seam guard)', () => {
+    // The resolver passes finalization.ual = request.kaUal verbatim; the validator
+    // derives localUal = createGraphKnowledgeAssetScope(request.kaUal).ual. This
+    // asserts the two halves agree by construction (the only bridge across the
+    // resolver -> validator seam that no single test exercises end-to-end).
+    const scope = createGraphKnowledgeAssetScope(GRAPH_LOCAL_UAL, ASSERTION_VERSION);
+    expect(scope.ual.toLowerCase()).toBe(GRAPH_LOCAL_UAL.toLowerCase());
+  });
+});
+
+describe('normalizeRecoveredNamedKaPublish — fail-closed boundary (GH#1966)', () => {
+  it('rejects a returned UAL that is neither the receipt nor the graph-local form', async () => {
+    const wrongNumberUal = `did:dkg:${CHAIN_ID}/${AUTHOR}/999`;
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(wrongNumberUal),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects a returned contract-form UAL with the wrong contract address', async () => {
+    const wrongContractUal = buildKnowledgeAssetUal(
+      CHAIN_ID,
+      ethers.getAddress(`0x${'99'.repeat(20)}`),
+      RESERVED_KA_ID,
+    );
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(wrongContractUal),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects a returned UAL on the wrong chain', async () => {
+    const wrongChainUal = `did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}`;
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(wrongChainUal),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects when the queued graph UAL is bound to a different chain', async () => {
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest({ kaUal: `did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}` }),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects when the queued graph UAL author does not match the reserved KA id', async () => {
+    const otherAuthor = `0x${'11'.repeat(20)}` as Hex;
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest({ kaUal: `did:dkg:${CHAIN_ID}/${otherAuthor}/${KA_NUMBER}` }),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects when the queued graph UAL KA number does not match the reserved KA id', async () => {
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest({ kaUal: `did:dkg:${CHAIN_ID}/${AUTHOR}/7` }),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects when the returned singleton range does not equal the reserved KA id', async () => {
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
+          endKAId: (RESERVED_KA_ID + 1n).toString() as BigIntString,
+        }),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects when the inclusion tx hash does not match the queued broadcast tx', async () => {
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {}, {
+          inclusion: {
+            txHash: `0x${'ef'.repeat(32)}` as Hex,
+            blockNumber: 77,
+            blockHash: BLOCK_HASH,
+          },
+        }),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects when the proof merkle root does not match the queued seal', async () => {
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {}, {
+          publishProof: {
+            merkleRoot: `0x${'ba'.repeat(32)}` as Hex,
+            authorAddress: AUTHOR,
+            txIndex: 4,
+          },
+        }),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects when the transaction author does not match the sealed author', async () => {
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {}, {
+          publishProof: {
+            merkleRoot: SEAL_MERKLE_ROOT,
+            authorAddress: `0x${'11'.repeat(20)}` as Hex,
+            txIndex: 4,
+          },
+        }),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+
+  it('rejects when the returned publisher address is missing', async () => {
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, { publisherAddress: undefined }),
+        chain: seededChain(),
+      }),
+    ).rejects.toMatchObject(REJECTS);
+  });
+});
+
+// NOTE: the superseded-version branch (getLatestMerkleRoot != proof root) needs
+// getBlockNumber, which MockChainAdapter does not implement — it is covered by
+// the real-Hardhat e2e (e2e-memory-layers.test.ts). This suite intentionally
+// keeps every KA non-superseded via seededChain().

--- a/packages/agent/test/named-ka-publish-recovery.test.ts
+++ b/packages/agent/test/named-ka-publish-recovery.test.ts
@@ -42,7 +42,9 @@ const ASSERTION_VERSION = '1';
 const SEAL_MERKLE_ROOT = `0x${'12'.repeat(32)}` as Hex;
 const TX_HASH = `0x${'ab'.repeat(32)}` as Hex;
 const BLOCK_HASH = `0x${'cd'.repeat(32)}` as Hex;
-const PUBLISHER = AUTHOR;
+// Deliberately NOT the author: the publisher is a distinct identity in the returned
+// evidence, so reusing the author here would let an author/publisher swap pass unnoticed.
+const PUBLISHER = `0x${'22'.repeat(20)}` as Hex;
 
 // MockChainAdapter.getDKGKnowledgeAssetsAddress() is a fixed constant.
 const KNOWLEDGE_ASSETS_ADDRESS = ethers.getAddress(
@@ -158,7 +160,24 @@ describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966
     // named-KA publish records and what gets stamped as publishedUal / drives materialization.
     expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
     expect(result.txHash).toBe(TX_HASH);
-    expect(result.materialization.superseded).toBe(false);
+    expect(result.receiptBlockNumber).toBe(77);
+    // Author and publisher are distinct identities and must not be transposed.
+    expect(result.transaction).toEqual({
+      merkleRoot: SEAL_MERKLE_ROOT,
+      authorAddress: ethers.getAddress(AUTHOR),
+      publisherAddress: ethers.getAddress(PUBLISHER),
+      blockHash: BLOCK_HASH,
+      txIndex: 4,
+    });
+    // Not superseded (the seeded chain's latest root equals the seal), so the
+    // materialized version is the recovered transaction's own block and identities.
+    expect(result.materialization).toEqual({
+      merkleRoot: SEAL_MERKLE_ROOT,
+      authorAddress: ethers.getAddress(AUTHOR),
+      publisherAddress: ethers.getAddress(PUBLISHER),
+      versionBlock: 77,
+      superseded: false,
+    });
   });
 
   it('still accepts the canonical contract/packed-ID receipt UAL and normalizes to graph-local', async () => {
@@ -197,76 +216,119 @@ describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966
   });
 });
 
-// Declarative boundary matrix: each row names the one invalid condition and supplies the
-// request/recovery it mutates; everything else stays canonical. `job` and a freshly seeded
-// non-superseded `chain` are constant, so a row that reaches the normalizer must be rejected
-// for its named reason alone.
+// Request-side rows mutate `request.kaUal`, from which `localUal` is DERIVED. Feeding the
+// canonical UAL as the resolver's returned value would make such a row fail at the
+// representation cross-check instead of at the guard it is named for — leaving the guard
+// mutation-blind (deletable with the suite green). So each request-side row returns the SAME
+// mutated UAL: the cross-check then agrees, and only the named guard can reject.
+const WRONG_CHAIN_UAL = `did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}`;
+const WRONG_AUTHOR_UAL = `did:dkg:${CHAIN_ID}/0x${'11'.repeat(20)}/${KA_NUMBER}`;
+const WRONG_NUMBER_UAL = `did:dkg:${CHAIN_ID}/${AUTHOR}/7`;
+
+// Declarative boundary matrix: each row names the one invalid condition, supplies only what it
+// mutates, and pins the guard that must reject it via `expected`. `job` and a freshly seeded
+// non-superseded `chain` are constant.
 const REJECT_CASES: ReadonlyArray<{
   readonly name: string;
+  readonly expected: RegExp;
   readonly request?: KnowledgeAssetVmPublishRequest;
   readonly recovery: AsyncKnowledgeAssetVmPublishRecoveryEvidence;
 }> = [
   {
     name: 'returned UAL is neither the receipt nor the graph-local form',
+    expected: /does not match the graph-local UAL/,
     recovery: recoveryEvidence(`did:dkg:${CHAIN_ID}/${AUTHOR}/999`),
   },
   {
     name: 'returned contract-form UAL has the wrong contract address',
+    expected: /does not match the graph-local UAL/,
     recovery: recoveryEvidence(
       buildKnowledgeAssetUal(CHAIN_ID, ethers.getAddress(`0x${'99'.repeat(20)}`), RESERVED_KA_ID),
     ),
   },
   {
     name: 'returned UAL is on the wrong chain',
-    recovery: recoveryEvidence(`did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}`),
+    expected: /does not match the graph-local UAL/,
+    recovery: recoveryEvidence(WRONG_CHAIN_UAL),
   },
   {
     name: 'queued graph UAL is bound to a different chain',
-    request: baseRequest({ kaUal: `did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}` }),
-    recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+    expected: /queued graph UAL is not bound to the recovery chain/,
+    request: baseRequest({ kaUal: WRONG_CHAIN_UAL }),
+    recovery: recoveryEvidence(WRONG_CHAIN_UAL),
   },
   {
     name: 'queued graph UAL author does not match the reserved KA id',
-    request: baseRequest({ kaUal: `did:dkg:${CHAIN_ID}/0x${'11'.repeat(20)}/${KA_NUMBER}` }),
-    recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+    expected: /does not identify reserved KA id/,
+    request: baseRequest({ kaUal: WRONG_AUTHOR_UAL }),
+    recovery: recoveryEvidence(WRONG_AUTHOR_UAL),
   },
   {
     name: 'queued graph UAL KA number does not match the reserved KA id',
-    request: baseRequest({ kaUal: `did:dkg:${CHAIN_ID}/${AUTHOR}/7` }),
+    expected: /does not identify reserved KA id/,
+    request: baseRequest({ kaUal: WRONG_NUMBER_UAL }),
+    recovery: recoveryEvidence(WRONG_NUMBER_UAL),
+  },
+  {
+    name: 'reserved KA id author bits do not match the sealed author',
+    expected: /author bits do not match the signed author address/,
+    // The seal names a different author than the packed reserved id encodes.
+    request: baseRequest({
+      seal: { ...baseRequest().seal, authorAddress: `0x${'33'.repeat(20)}` as Hex },
+    }),
     recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
   },
   {
     name: 'returned singleton range does not equal the reserved KA id',
+    expected: /does not match reserved KA id/,
     recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
       endKAId: (RESERVED_KA_ID + 1n).toString() as BigIntString,
     }),
   },
   {
     name: 'inclusion tx hash does not match the queued broadcast tx',
+    expected: /does not match queued tx/,
     recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
       inclusion: { txHash: `0x${'ef'.repeat(32)}` as Hex, blockNumber: 77, blockHash: BLOCK_HASH },
     }),
   },
   {
+    name: 'canonical block hash is malformed',
+    expected: /did not return a valid canonical block hash/,
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
+      inclusion: { txHash: TX_HASH, blockNumber: 77, blockHash: '0xnotahash' as Hex },
+    }),
+  },
+  {
     name: 'proof merkle root does not match the queued seal',
+    expected: /does not match queued seal/,
     recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
       publishProof: { merkleRoot: `0x${'ba'.repeat(32)}` as Hex, authorAddress: AUTHOR, txIndex: 4 },
     }),
   },
   {
+    name: 'transaction index is not a valid non-negative integer',
+    expected: /did not return a valid transaction index/,
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
+      publishProof: { merkleRoot: SEAL_MERKLE_ROOT, authorAddress: AUTHOR, txIndex: -1 },
+    }),
+  },
+  {
     name: 'transaction author does not match the sealed author',
+    expected: /does not match sealed author/,
     recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
       publishProof: { merkleRoot: SEAL_MERKLE_ROOT, authorAddress: `0x${'11'.repeat(20)}` as Hex, txIndex: 4 },
     }),
   },
   {
     name: 'returned publisher address is missing',
+    expected: /did not return a valid publisher address/,
     recovery: recoveryEvidence(GRAPH_LOCAL_UAL, { omitPublisher: true }),
   },
 ];
 
 describe('normalizeRecoveredNamedKaPublish — fail-closed boundary (GH#1966)', () => {
-  it.each(REJECT_CASES)('rejects when the $name', async ({ request, recovery }) => {
+  it.each(REJECT_CASES)('rejects when the $name', async ({ request, recovery, expected }) => {
     await expect(
       normalizeRecoveredNamedKaPublish({
         request: request ?? baseRequest(),
@@ -274,7 +336,7 @@ describe('normalizeRecoveredNamedKaPublish — fail-closed boundary (GH#1966)', 
         recovery,
         chain: seededChain(),
       }),
-    ).rejects.toMatchObject(REJECTS);
+    ).rejects.toMatchObject({ ...REJECTS, message: expect.stringMatching(expected) });
   });
 });
 

--- a/packages/agent/test/named-ka-publish-recovery.test.ts
+++ b/packages/agent/test/named-ka-publish-recovery.test.ts
@@ -73,6 +73,24 @@ function seededChain(): MockChainAdapter {
   return chain;
 }
 
+/**
+ * `getDKGKnowledgeAssetsAddress` is OPTIONAL on the ChainAdapter contract, and the
+ * graph-local path must neither require nor consult it — the contract address is only
+ * needed to build the canonical receipt form. Returns a seeded chain whose resolver
+ * throws if called, plus the call counter, so a test can prove non-invocation rather
+ * than merely tolerate absence.
+ */
+function chainThatRejectsContractLookup(): { chain: MockChainAdapter; calls: () => number } {
+  const chain = seededChain();
+  let calls = 0;
+  (chain as unknown as { getDKGKnowledgeAssetsAddress: () => Promise<string> })
+    .getDKGKnowledgeAssetsAddress = () => {
+      calls += 1;
+      throw new Error('the graph-local path must not resolve the DKGKnowledgeAssets address');
+    };
+  return { chain, calls: () => calls };
+}
+
 function baseRequest(
   overrides: Partial<KnowledgeAssetVmPublishRequest> = {},
 ): KnowledgeAssetVmPublishRequest {
@@ -204,6 +222,41 @@ describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966
       chain: seededChain(),
     });
     expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
+  });
+
+  it('resolves the graph-local UAL without requiring the optional contract-address resolver', async () => {
+    // The graph-local form is the production shape, and it is self-sufficient: the
+    // DKGKnowledgeAssets address is only needed to build the canonical receipt form.
+    // Pins that contract — a regression hoisting the lookup above the representation
+    // branch would fail here even though every other positive case would still pass.
+    const { chain, calls } = chainThatRejectsContractLookup();
+    const result = await normalizeRecoveredNamedKaPublish({
+      request: baseRequest(),
+      job: broadcastJob(),
+      recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+      chain,
+    });
+
+    expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
+    expect(calls()).toBe(0);
+  });
+
+  it('still requires the contract-address resolver to accept the contract/packed form', async () => {
+    // The mirror of the case above: the receipt form cannot be validated without the
+    // contract address, so it must fail closed rather than be waved through.
+    const { chain, calls } = chainThatRejectsContractLookup();
+    await expect(
+      normalizeRecoveredNamedKaPublish({
+        request: baseRequest(),
+        job: broadcastJob(),
+        recovery: recoveryEvidence(CONTRACT_RECEIPT_UAL),
+        chain,
+      }),
+    ).rejects.toMatchObject({
+      code: 'KA_VM_RECOVERY_INCONSISTENT',
+      message: expect.stringMatching(/could not resolve the canonical receipt UAL/),
+    });
+    expect(calls()).toBe(1);
   });
 
   it('resolver-preserved kaUal canonicalizes to the validator-derived localUal (seam guard)', () => {

--- a/packages/agent/test/named-ka-publish-recovery.test.ts
+++ b/packages/agent/test/named-ka-publish-recovery.test.ts
@@ -154,15 +154,14 @@ describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966
     });
 
     expect(result.reservedKaId).toBe(RESERVED_KA_ID);
+    // The normalized identity is the canonical graph-local UAL — the same value a normal
+    // named-KA publish records and what gets stamped as publishedUal / drives materialization.
     expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
-    // publishedUal carries the resolver-returned form (graph-local here) — the same
-    // identity a normal named-KA publish records.
-    expect(result.publishedUal).toBe(GRAPH_LOCAL_UAL);
     expect(result.txHash).toBe(TX_HASH);
     expect(result.materialization.superseded).toBe(false);
   });
 
-  it('still accepts the canonical contract/packed-ID receipt UAL', async () => {
+  it('still accepts the canonical contract/packed-ID receipt UAL and normalizes to graph-local', async () => {
     const result = await normalizeRecoveredNamedKaPublish({
       request: baseRequest(),
       job: broadcastJob(),
@@ -170,8 +169,10 @@ describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966
       chain: seededChain(),
     });
 
+    // The contract/packed wire form is accepted at the cross-check, but the normalized
+    // identity is still the canonical graph-local UAL — never the raw resolver shape.
+    expect(result.reservedKaId).toBe(RESERVED_KA_ID);
     expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
-    expect(result.publishedUal).toBe(CONTRACT_RECEIPT_UAL);
   });
 
   it('accepts a graph-local UAL whose author is checksummed (case-insensitive)', async () => {

--- a/packages/agent/test/named-ka-publish-recovery.test.ts
+++ b/packages/agent/test/named-ka-publish-recovery.test.ts
@@ -11,7 +11,7 @@ import {
 import type {
   AsyncKnowledgeAssetVmPublishRecoveryEvidence,
   KnowledgeAssetVmPublishRequest,
-  LiftJobBroadcast,
+  LiftJobBroadcastMetadata,
 } from '@origintrail-official/dkg-publisher';
 import { normalizeRecoveredNamedKaPublish } from '../src/named-ka-publish-recovery.js';
 
@@ -101,21 +101,27 @@ function baseRequest(
   };
 }
 
-// The validator only reads job.broadcast.{txHash,merkleRoot}; the rest of the
-// LiftJobBroadcast shape is irrelevant to identity normalization.
-function broadcastJob(): LiftJobBroadcast {
+// The normalizer only reads job.broadcast; its input type is the narrow structural
+// shape, so this fixture is a real contract guard (no cast) rather than a faked job.
+function broadcastJob(): { broadcast: LiftJobBroadcastMetadata } {
   return {
     broadcast: { txHash: TX_HASH, walletId: 'wallet-1', merkleRoot: SEAL_MERKLE_ROOT },
-  } as unknown as LiftJobBroadcast;
+  };
 }
 
+// Typed optional tweaks (no Partial-over-required spread) so the fixture satisfies
+// AsyncKnowledgeAssetVmPublishRecoveryEvidence without a cast.
 function recoveryEvidence(
   ual: string,
-  finalizationOverrides: Partial<AsyncKnowledgeAssetVmPublishRecoveryEvidence['finalization']> = {},
-  overrides: Partial<AsyncKnowledgeAssetVmPublishRecoveryEvidence> = {},
+  opts: {
+    endKAId?: BigIntString;
+    omitPublisher?: boolean;
+    inclusion?: AsyncKnowledgeAssetVmPublishRecoveryEvidence['inclusion'];
+    publishProof?: AsyncKnowledgeAssetVmPublishRecoveryEvidence['publishProof'];
+  } = {},
 ): AsyncKnowledgeAssetVmPublishRecoveryEvidence {
   return {
-    inclusion: {
+    inclusion: opts.inclusion ?? {
       txHash: TX_HASH,
       blockNumber: 77,
       blockHash: BLOCK_HASH,
@@ -127,13 +133,11 @@ function recoveryEvidence(
       ual,
       batchId: RESERVED_KA_ID.toString() as BigIntString,
       startKAId: RESERVED_KA_ID.toString() as BigIntString,
-      endKAId: RESERVED_KA_ID.toString() as BigIntString,
-      publisherAddress: PUBLISHER,
-      ...finalizationOverrides,
+      endKAId: opts.endKAId ?? (RESERVED_KA_ID.toString() as BigIntString),
+      publisherAddress: opts.omitPublisher ? undefined : PUBLISHER,
     },
-    publishProof: { merkleRoot: SEAL_MERKLE_ROOT, authorAddress: AUTHOR, txIndex: 4 },
-    ...overrides,
-  } as AsyncKnowledgeAssetVmPublishRecoveryEvidence;
+    publishProof: opts.publishProof ?? { merkleRoot: SEAL_MERKLE_ROOT, authorAddress: AUTHOR, txIndex: 4 },
+  };
 }
 
 const REJECTS = { code: 'KA_VM_RECOVERY_INCONSISTENT' };
@@ -151,9 +155,9 @@ describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966
 
     expect(result.reservedKaId).toBe(RESERVED_KA_ID);
     expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
-    // receiptUal carries the resolver-returned form (graph-local here), which is
-    // stamped as publishedUal — matching what a normal named-KA publish records.
-    expect(result.receiptUal).toBe(GRAPH_LOCAL_UAL);
+    // publishedUal carries the resolver-returned form (graph-local here) — the same
+    // identity a normal named-KA publish records.
+    expect(result.publishedUal).toBe(GRAPH_LOCAL_UAL);
     expect(result.txHash).toBe(TX_HASH);
     expect(result.materialization.superseded).toBe(false);
   });
@@ -167,7 +171,7 @@ describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966
     });
 
     expect(result.localUal).toBe(GRAPH_LOCAL_UAL);
-    expect(result.receiptUal).toBe(CONTRACT_RECEIPT_UAL);
+    expect(result.publishedUal).toBe(CONTRACT_RECEIPT_UAL);
   });
 
   it('accepts a graph-local UAL whose author is checksummed (case-insensitive)', async () => {
@@ -285,7 +289,7 @@ describe('normalizeRecoveredNamedKaPublish — fail-closed boundary (GH#1966)', 
       normalizeRecoveredNamedKaPublish({
         request: baseRequest(),
         job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {}, {
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
           inclusion: {
             txHash: `0x${'ef'.repeat(32)}` as Hex,
             blockNumber: 77,
@@ -302,7 +306,7 @@ describe('normalizeRecoveredNamedKaPublish — fail-closed boundary (GH#1966)', 
       normalizeRecoveredNamedKaPublish({
         request: baseRequest(),
         job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {}, {
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
           publishProof: {
             merkleRoot: `0x${'ba'.repeat(32)}` as Hex,
             authorAddress: AUTHOR,
@@ -319,7 +323,7 @@ describe('normalizeRecoveredNamedKaPublish — fail-closed boundary (GH#1966)', 
       normalizeRecoveredNamedKaPublish({
         request: baseRequest(),
         job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {}, {
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
           publishProof: {
             merkleRoot: SEAL_MERKLE_ROOT,
             authorAddress: `0x${'11'.repeat(20)}` as Hex,
@@ -336,7 +340,7 @@ describe('normalizeRecoveredNamedKaPublish — fail-closed boundary (GH#1966)', 
       normalizeRecoveredNamedKaPublish({
         request: baseRequest(),
         job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, { publisherAddress: undefined }),
+        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, { omitPublisher: true }),
         chain: seededChain(),
       }),
     ).rejects.toMatchObject(REJECTS);

--- a/packages/agent/test/named-ka-publish-recovery.test.ts
+++ b/packages/agent/test/named-ka-publish-recovery.test.ts
@@ -197,151 +197,81 @@ describe('normalizeRecoveredNamedKaPublish — accepted representations (GH#1966
   });
 });
 
+// Declarative boundary matrix: each row names the one invalid condition and supplies the
+// request/recovery it mutates; everything else stays canonical. `job` and a freshly seeded
+// non-superseded `chain` are constant, so a row that reaches the normalizer must be rejected
+// for its named reason alone.
+const REJECT_CASES: ReadonlyArray<{
+  readonly name: string;
+  readonly request?: KnowledgeAssetVmPublishRequest;
+  readonly recovery: AsyncKnowledgeAssetVmPublishRecoveryEvidence;
+}> = [
+  {
+    name: 'returned UAL is neither the receipt nor the graph-local form',
+    recovery: recoveryEvidence(`did:dkg:${CHAIN_ID}/${AUTHOR}/999`),
+  },
+  {
+    name: 'returned contract-form UAL has the wrong contract address',
+    recovery: recoveryEvidence(
+      buildKnowledgeAssetUal(CHAIN_ID, ethers.getAddress(`0x${'99'.repeat(20)}`), RESERVED_KA_ID),
+    ),
+  },
+  {
+    name: 'returned UAL is on the wrong chain',
+    recovery: recoveryEvidence(`did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}`),
+  },
+  {
+    name: 'queued graph UAL is bound to a different chain',
+    request: baseRequest({ kaUal: `did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}` }),
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+  },
+  {
+    name: 'queued graph UAL author does not match the reserved KA id',
+    request: baseRequest({ kaUal: `did:dkg:${CHAIN_ID}/0x${'11'.repeat(20)}/${KA_NUMBER}` }),
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+  },
+  {
+    name: 'queued graph UAL KA number does not match the reserved KA id',
+    request: baseRequest({ kaUal: `did:dkg:${CHAIN_ID}/${AUTHOR}/7` }),
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
+  },
+  {
+    name: 'returned singleton range does not equal the reserved KA id',
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
+      endKAId: (RESERVED_KA_ID + 1n).toString() as BigIntString,
+    }),
+  },
+  {
+    name: 'inclusion tx hash does not match the queued broadcast tx',
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
+      inclusion: { txHash: `0x${'ef'.repeat(32)}` as Hex, blockNumber: 77, blockHash: BLOCK_HASH },
+    }),
+  },
+  {
+    name: 'proof merkle root does not match the queued seal',
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
+      publishProof: { merkleRoot: `0x${'ba'.repeat(32)}` as Hex, authorAddress: AUTHOR, txIndex: 4 },
+    }),
+  },
+  {
+    name: 'transaction author does not match the sealed author',
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
+      publishProof: { merkleRoot: SEAL_MERKLE_ROOT, authorAddress: `0x${'11'.repeat(20)}` as Hex, txIndex: 4 },
+    }),
+  },
+  {
+    name: 'returned publisher address is missing',
+    recovery: recoveryEvidence(GRAPH_LOCAL_UAL, { omitPublisher: true }),
+  },
+];
+
 describe('normalizeRecoveredNamedKaPublish — fail-closed boundary (GH#1966)', () => {
-  it('rejects a returned UAL that is neither the receipt nor the graph-local form', async () => {
-    const wrongNumberUal = `did:dkg:${CHAIN_ID}/${AUTHOR}/999`;
+  it.each(REJECT_CASES)('rejects when the $name', async ({ request, recovery }) => {
     await expect(
       normalizeRecoveredNamedKaPublish({
-        request: baseRequest(),
+        request: request ?? baseRequest(),
         job: broadcastJob(),
-        recovery: recoveryEvidence(wrongNumberUal),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects a returned contract-form UAL with the wrong contract address', async () => {
-    const wrongContractUal = buildKnowledgeAssetUal(
-      CHAIN_ID,
-      ethers.getAddress(`0x${'99'.repeat(20)}`),
-      RESERVED_KA_ID,
-    );
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest(),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(wrongContractUal),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects a returned UAL on the wrong chain', async () => {
-    const wrongChainUal = `did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}`;
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest(),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(wrongChainUal),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects when the queued graph UAL is bound to a different chain', async () => {
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest({ kaUal: `did:dkg:evm:9999/${AUTHOR}/${KA_NUMBER}` }),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects when the queued graph UAL author does not match the reserved KA id', async () => {
-    const otherAuthor = `0x${'11'.repeat(20)}` as Hex;
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest({ kaUal: `did:dkg:${CHAIN_ID}/${otherAuthor}/${KA_NUMBER}` }),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects when the queued graph UAL KA number does not match the reserved KA id', async () => {
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest({ kaUal: `did:dkg:${CHAIN_ID}/${AUTHOR}/7` }),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects when the returned singleton range does not equal the reserved KA id', async () => {
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest(),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
-          endKAId: (RESERVED_KA_ID + 1n).toString() as BigIntString,
-        }),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects when the inclusion tx hash does not match the queued broadcast tx', async () => {
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest(),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
-          inclusion: {
-            txHash: `0x${'ef'.repeat(32)}` as Hex,
-            blockNumber: 77,
-            blockHash: BLOCK_HASH,
-          },
-        }),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects when the proof merkle root does not match the queued seal', async () => {
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest(),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
-          publishProof: {
-            merkleRoot: `0x${'ba'.repeat(32)}` as Hex,
-            authorAddress: AUTHOR,
-            txIndex: 4,
-          },
-        }),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects when the transaction author does not match the sealed author', async () => {
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest(),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, {
-          publishProof: {
-            merkleRoot: SEAL_MERKLE_ROOT,
-            authorAddress: `0x${'11'.repeat(20)}` as Hex,
-            txIndex: 4,
-          },
-        }),
-        chain: seededChain(),
-      }),
-    ).rejects.toMatchObject(REJECTS);
-  });
-
-  it('rejects when the returned publisher address is missing', async () => {
-    await expect(
-      normalizeRecoveredNamedKaPublish({
-        request: baseRequest(),
-        job: broadcastJob(),
-        recovery: recoveryEvidence(GRAPH_LOCAL_UAL, { omitPublisher: true }),
+        recovery,
         chain: seededChain(),
       }),
     ).rejects.toMatchObject(REJECTS);

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -98,6 +98,7 @@ export default defineConfig({
       "test/finalization-handler-defensive-cg-id.test.ts",
       "test/finalization-recovery.test.ts",
       "test/finalization-recovery-sqlite-store.test.ts",
+      "test/named-ka-publish-recovery.test.ts",
       "test/ka-graph-finalization-handler.test.ts",
       "test/swm-slice-ka-bound.test.ts",
       "test/ka-lifecycle-asset-ual-timeout.test.ts",

--- a/packages/publisher/test/async-lift-ka-broadcast-progress.test.ts
+++ b/packages/publisher/test/async-lift-ka-broadcast-progress.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/async-lift-control-plane.js';
 import {
   KA_VM_EXECUTOR_TX_HASH,
+  KA_VM_KA_UAL,
   KA_VM_VALIDATION,
   kaVmPublishRequest,
   stageKnowledgeAssetShareSnapshot,
@@ -111,7 +112,13 @@ describe('KA async VM publish broadcast progress', () => {
     const txHash = `0x${'aa'.repeat(32)}` as `0x${string}`;
     const request = kaVmPublishRequest();
     const kaId = request.seal.reservedKaId!;
-    const ual = `did:dkg:evm:31337/0x3333333333333333333333333333333333333333/${kaId}`;
+    // GH#1966: the production recovery resolver returns the graph-local queued UAL
+    // (author + low-96 KA number) for named/graph-scoped KAs, not the contract/packed
+    // receipt form. finalizeRecovered is stubbed here, so this proves the durable
+    // recover() cycle finalizes exactly once and passes the resolver's graph-local
+    // UAL through faithfully — validator acceptance of that form is covered by the
+    // agent unit + e2e suites (named-ka-publish-recovery.test.ts, e2e-memory-layers).
+    const ual = KA_VM_KA_UAL;
     const finalized: Array<{ jobId: string; status: string }> = [];
     const publisher = createPublisher({
       knowledgeAssetVmPublishRecoveryResolver: async () => ({
@@ -187,6 +194,11 @@ describe('KA async VM publish broadcast progress', () => {
     ]);
     expect(includedJob?.status).toBe('finalized');
     expect(includedJob?.recovery?.recoveredFromStatus).toBe('included');
+
+    // GH#1966: once finalized from the confirmed transaction, a further recovery
+    // sweep must not re-process either job — no second on-chain submission.
+    expect(await publisher.recover()).toBe(0);
+    expect(finalized).toHaveLength(2);
   });
 
   it('keeps confirmed KA jobs tx-bearing while local lifecycle recovery is blocked', async () => {
@@ -205,7 +217,7 @@ describe('KA async VM publish broadcast progress', () => {
         finalization: {
           mode: 'published',
           txHash,
-          ual: `did:dkg:evm:31337/0x3333333333333333333333333333333333333333/${kaId}`,
+          ual: KA_VM_KA_UAL,
           batchId: kaId,
           startKAId: kaId,
           endKAId: kaId,


### PR DESCRIPTION
## Summary

Fixes #1966. A confirmed named-KA durable async publish could be stranded forever after an ambiguous post-broadcast RPC failure: the transaction was mined, but recovery rejected it with `KA_VM_RECOVERY_INCONSISTENT`, leaving the job in `broadcast` (unsafe to retry — a reset risks a second on-chain mint).

Root cause: for graph-scoped named KAs the CLI recovery resolver **deliberately** returns the graph-local UAL (`did:dkg:<chain>/<author>/<kaNumber>`) as `finalization.ual` — the user-facing identity also surfaced via the kafka event and control-plane `CONTROL_UAL`, and the same form a *normal* publish records. But `normalizeRecoveredNamedKaPublish` compared that returned UAL only against the canonical contract/packed-id receipt form (`ual !== expectedReceiptUal`), so **every** named-KA recovery threw.

The published KA identity is already bound to chain truth *before* that string check — numerically by `batchId/startKAId/endKAId === reservedKaId` and by the sealed-author / graph-scope checks against the reserved packed KA id. The UAL comparison is only a representation cross-check. The fix accepts the returned UAL when it matches **either** proven-equivalent representation of that same reserved id (the canonical contract/packed form **or** the already-validated graph-local form), case-insensitively; every other UAL still fails closed. No other production behavior changes — the resolver override, the numeric/proof validation, and the stored graph-local lifecycle identity are all untouched.

- Per review, the normalizer exposes a **single canonical identity** — `localUal` (graph-local, what a normal publish records) — used for both materialization and the `publishedUal` stamp. The resolver's returned UAL is validated as an accept-either-form cross-check but is never exported, so no downstream code depends on which wire shape the resolver sent. The `job` parameter is also narrowed to the `{ broadcast }` metadata it actually reads.

## Related

- Fixes #1966
- Distinct from #1924 / #1957 (receiver-side sync finalization/provenance recovery); this is publisher-side named-KA recovery.
- Interacts with the deliberate graph-local `finalization.ual` override added in `243371fbf` (kept intentionally).

## Diagrams

### Named-KA durable recovery finalization

Before:

```mermaid
sequenceDiagram
    participant Pub as Publisher.recover()
    participant Res as CLI recovery resolver
    participant Val as normalizeRecoveredNamedKaPublish
    participant Job as Durable job

    Pub->>Res: resolve confirmed tx
    Res-->>Pub: finalization.ual = graph-local (author/kaNumber)
    Pub->>Val: finalizeRecovered(recovery)
    Note over Val: numeric identity checks pass<br/>(batch/start/end === reservedKaId)
    Val->>Val: ual !== expectedReceiptUal (contract/packed)
    Val-->>Pub: throw KA_VM_RECOVERY_INCONSISTENT
    Pub->>Job: keep status = broadcast (STRANDED)
    Note over Job: confirmed tx, never finalized<br/>unsafe to retry (double-mint risk)
```

After:

```mermaid
sequenceDiagram
    participant Pub as Publisher.recover()
    participant Res as CLI recovery resolver
    participant Val as normalizeRecoveredNamedKaPublish
    participant Job as Durable job

    Pub->>Res: resolve confirmed tx
    Res-->>Pub: finalization.ual = graph-local (author/kaNumber)
    Pub->>Val: finalizeRecovered(recovery)
    Note over Val: numeric identity checks pass<br/>(batch/start/end === reservedKaId)
    Val->>Val: equalsIgnoreCase(ual, localUal) matches -> accept
    Note over Val: contract-receipt form is resolved and compared<br/>ONLY if the graph-local form does not match
    Val-->>Pub: RecoveredNamedKaPublish (canonical localUal)
    Pub->>Job: status = finalized (from existing tx)
    Note over Job: no second transaction broadcast
```

In production the CLI resolver always sends the graph-local form for exactly the requests this validator accepts, so that is the live path; the contract/packed comparison is retained for the generic-recovery shape.

## Files changed

| File | What |
|------|------|
| `packages/agent/src/named-ka-publish-recovery.ts` | Accept the returned UAL when it case-insensitively matches the canonical receipt form **or** the already-proven graph-local form (was strict `!==` against the contract form only), matching graph-local first and resolving the contract form only on a miss. Review follow-ups: expose a single canonical `localUal` (the raw resolver UAL is validated but never exported), narrow the `job` param to `{ broadcast: LiftJobBroadcastMetadata }`, and use one accurately-named `equalsIgnoreCase` comparator. |
| `packages/agent/src/dkg-agent-publish.ts` | Point the 3 recovery consumer sites (stamp + logs) at the canonical `localUal`. |
| `packages/agent/test/named-ka-publish-recovery.test.ts` | **New** focused unit suite (MockChainAdapter): accepts graph-local (regression) + contract/packed forms; case-insensitive; resolver→validator seam guard; and a 14-row fail-closed matrix in which every row pins the guard it is named for by asserting that guard's message (mutation-verified: deleting the `localScope` chain or author/KA-number guard now fails the corresponding rows). |
| `packages/agent/test/e2e-memory-layers.test.ts` | Drive the real-Hardhat named-KA recovery with the production graph-local `finalization.ual = intent.kaUal`; assert `publishedUal === intent.kaUal`; fix the factually-wrong "contract + packed KA id" resolver-shape comment. |
| `packages/publisher/test/async-lift-ka-broadcast-progress.test.ts` | Use the real graph-local `KA_VM_KA_UAL` in the durable recover() cycle; add an explicit no-re-broadcast-after-finalized assertion (`recover()===0`, `finalized` length stays 2). |
| `packages/agent/vitest.unit.config.ts` | Register the new unit test in the `test:unit` include list. |

## Test plan

All executed locally (the vitest lanes in `ci.yml` are branch-filtered away from `testnet-canary`, so these runs plus code review are the unit signal at PR time):

- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run test/named-ka-publish-recovery.test.ts` — **18/18 pass**.
- [x] Fail-before proof, re-run against the **final** test state: base source + these tests → the 2 graph-local acceptance tests fail, 13 pass.
- [x] Mutation proof of the fail-closed matrix: deleting the `localScope` chain guard fails its named row; deleting the author/KA-number guard fails both of its rows.
- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run test/e2e-memory-layers.test.ts -t "repairs a named lifecycle"` — passes on real Hardhat.
- [x] `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-ka-broadcast-progress.test.ts` — 5/5 pass; durable recover() finalizes once and never re-broadcasts.
- [x] `pnpm --filter "@origintrail-official/dkg-agent..." run build` — typecheck/build clean across the storage→publisher→agent closure (mirrors the RFC-64 Windows PR gate, which is green on this PR).

### Notes / intentionally deferred

- No single test runs the production resolver output through the real validator end-to-end (the resolver stubs the finalizer). The two halves are bridged by a seam-guard assertion since both key on `request.kaUal`; full wiring deferred (large new harness, low marginal value).
- The superseded-version acceptance branch stays unit-untested (MockChainAdapter has no `getBlockNumber`); it is covered by the real-Hardhat e2e.

