### PR TITLE
fix(node-ui): collect metrics daily by default

### DIFF
--- a/packages/node-ui/src/metrics-collector.ts
+++ b/packages/node-ui/src/metrics-collector.ts
@@ -50,7 +50,7 @@ export interface MetricsSource {
   getRelayStats?(): RelayStatsSnapshot | null;
 }
 
-const SNAPSHOT_INTERVAL_MS = 30_000; // 30 seconds
+const SNAPSHOT_INTERVAL_MS = 86_400_000; // 24 hours
 
 /**
  * Clamp a bigint relay byte count to a safe JS Number for SQLite storage.


### PR DESCRIPTION
## Title

fix(node-ui): collect metrics daily by default

## Description

Changes the local Node UI metrics snapshot interval from 30 seconds to 24 hours.

On large Blazegraph-backed nodes, the 30-second store-wide metric count scans can accumulate in the normal store-query lane and block unrelated work, including Blackbox deduplication checks. A daily cadence preserves periodic snapshots while avoiding sustained query pressure by default.

## Validation

- One-line change in `packages/node-ui/src/metrics-collector.ts`
- Focused test was not run because the isolated worktree does not have test dependencies installed.