### PR TITLE
fix(integrations): conform the CLI to the published registry schema

### DIFF
--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -11,10 +11,18 @@
 // install instructions.
 
 import type { Command } from 'commander';
+import { detectInstalled } from './detect-installed.js';
 import { installCli } from './install-cli.js';
 import { installMcp } from './install-mcp.js';
+import { installService } from './install-service.js';
 import { fetchAllEntries, fetchEntry, resolveRegistryConfig } from './registry-client.js';
 import type { IntegrationEntry, TrustTier } from './schema.js';
+
+/** Case-insensitive substring match across the fields a user would search by. */
+function matchesKeyword(e: IntegrationEntry, needle: string): boolean {
+  const haystack = [e.slug, e.name, e.description, ...(e.category ?? [])].join(' ').toLowerCase();
+  return haystack.includes(needle);
+}
 
 const TIER_RANK: Record<TrustTier, number> = { community: 0, verified: 1, featured: 2 };
 
@@ -23,17 +31,23 @@ export function registerIntegrationCommands(program: Command): void {
     .command('integration')
     .description('Install and inspect community DKG integrations from the registry');
 
+  // `search` discovers what EXISTS in the registry; `list` reports what is
+  // installed HERE. That split is what the registry README documents and what
+  // npm/apt users expect. `list` previously did what `search` does now.
   integrationCmd
-    .command('list')
-    .description('List integrations available in the registry')
+    .command('search [keyword]')
+    .description('Search integrations available in the registry')
     .option('--tier <tier>', 'Minimum trust tier: community | verified | featured', 'verified')
     .option('--json', 'Print the raw registry entries as JSON')
-    .action(async (opts: { tier: string; json?: boolean }) => {
+    .action(async (keyword: string | undefined, opts: { tier: string; json?: boolean }) => {
       try {
         const cfg = resolveRegistryConfig();
         const { entries, failures } = await fetchAllEntries(cfg);
         const min = parseTier(opts.tier);
-        const filtered = entries.filter((e) => TIER_RANK[e.trustTier] >= TIER_RANK[min]);
+        const needle = keyword?.trim().toLowerCase();
+        const filtered = entries
+          .filter((e) => TIER_RANK[e.trustTier] >= TIER_RANK[min])
+          .filter((e) => !needle || matchesKeyword(e, needle));
 
         if (opts.json) {
           console.log(JSON.stringify({ entries: filtered, failures }, null, 2));
@@ -41,9 +55,14 @@ export function registerIntegrationCommands(program: Command): void {
         }
 
         if (filtered.length === 0) {
-          console.log(`No integrations at tier "${min}" or above.`);
+          console.log(
+            needle
+              ? `No integrations matching "${keyword}" at tier "${min}" or above.`
+              : `No integrations at tier "${min}" or above.`,
+          );
         } else {
-          console.log(`Showing ${filtered.length} integration(s) at tier ${min}+:\n`);
+          const scope = needle ? ` matching "${keyword}"` : '';
+          console.log(`Showing ${filtered.length} integration(s)${scope} at tier ${min}+:\n`);
           for (const e of filtered) {
             console.log(`  ${e.slug.padEnd(24)}  [${e.trustTier}]  ${e.name}`);
             console.log(`    ${e.description.slice(0, 120)}${e.description.length > 120 ? '…' : ''}`);
@@ -61,7 +80,54 @@ export function registerIntegrationCommands(program: Command): void {
           }
         }
       } catch (err) {
-        console.error(`Failed to list integrations: ${toMessage(err)}`);
+        console.error(`Failed to search integrations: ${toMessage(err)}`);
+        process.exit(1);
+      }
+    });
+
+  integrationCmd
+    .command('list')
+    .description('List which registry integrations are installed on this machine')
+    .option('--tier <tier>', 'Minimum trust tier to consider: community | verified | featured', 'community')
+    .option('--json', 'Print the raw detection result as JSON')
+    .action(async (opts: { tier: string; json?: boolean }) => {
+      try {
+        const cfg = resolveRegistryConfig();
+        const { entries, failures } = await fetchAllEntries(cfg);
+        const min = parseTier(opts.tier);
+        const candidates = entries.filter((e) => TIER_RANK[e.trustTier] >= TIER_RANK[min]);
+        const rows = await detectInstalled(candidates);
+
+        if (opts.json) {
+          console.log(JSON.stringify({ installed: rows, failures }, null, 2));
+          return;
+        }
+
+        const known = rows.filter((r) => r.state !== 'unknown');
+        const installed = rows.filter((r) => r.state === 'installed');
+        if (installed.length === 0) {
+          console.log('No registry integrations detected as installed on this machine.');
+        } else {
+          console.log(`Detected ${installed.length} installed integration(s):\n`);
+          for (const r of installed) {
+            console.log(`  ${r.slug.padEnd(24)}  [${r.kind}]  ${r.detail}`);
+          }
+          console.log('');
+        }
+        const undetectable = rows.filter((r) => r.state === 'unknown');
+        if (undetectable.length > 0) {
+          console.log(
+            `${undetectable.length} entr${undetectable.length === 1 ? 'y' : 'ies'} cannot be detected ` +
+              `(install kinds the CLI does not perform): ${undetectable.map((r) => r.slug).join(', ')}`,
+          );
+        }
+        console.log('');
+        console.log(
+          `Checked ${known.length} detectable entr${known.length === 1 ? 'y' : 'ies'}. ` +
+            `Use \`dkg integration search\` to browse the registry.`,
+        );
+      } catch (err) {
+        console.error(`Failed to list installed integrations: ${toMessage(err)}`);
         process.exit(1);
       }
     });
@@ -155,12 +221,59 @@ export function registerIntegrationCommands(program: Command): void {
             await installMcp({ entry, apiUrl: opts.apiUrl });
             break;
           }
-          case 'service':
+          case 'manual': {
+            // `manual` is not an unimplemented kind — per CONTRIBUTING §2 it
+            // means "the installer links out to your docs". Handing off IS the
+            // success path, so exit 0; the entry's docsUrl is required by the
+            // registry schema precisely so we can print it here.
+            console.log(
+              'This integration installs manually — follow its setup guide:',
+            );
+            console.log('');
+            console.log(`  docs:  ${entry.install.docsUrl}`);
+            if (entry.install.oneLiner) {
+              console.log('');
+              console.log(`  ${entry.install.oneLiner}`);
+            }
+            console.log('');
+            console.log(formatSecurity(entry));
+            console.log('');
+            console.log(`Run \`dkg integration info ${entry.slug}\` for the full entry.`);
+            break;
+          }
+          case 'service': {
+            if (entry.install.runtime !== 'npm-global') {
+              console.error(
+                `Service runtime "${entry.install.runtime}" is declared by this entry but not yet ` +
+                  `automated by the CLI (only "npm-global" is).\n` +
+                  `Follow the integration's own instructions at ${entry.repo} for now.`,
+              );
+              process.exit(2);
+              break;
+            }
+            const result = await installService({
+              entry,
+              dryRun: opts.dryRun,
+              skipProvenance: opts.verifyProvenance === false,
+            });
+            if (opts.dryRun) {
+              console.log('');
+              console.log(`Dry-run: no changes made. Re-run without --dry-run to install.`);
+              console.log(`Note: provenance is only checked on a real install (skipped in dry-run).`);
+            } else {
+              console.log('');
+              console.log(`Installed ${entry.install.npmGlobal?.package}@${entry.install.npmGlobal?.version}.`);
+            }
+            if (result.postInstructions.length > 0) {
+              console.log('');
+              for (const line of result.postInstructions) console.log(line);
+            }
+            break;
+          }
           case 'agent-plugin':
-          case 'manual':
             console.error(
-              `Install kind "${entry.install.kind}" is declared by this entry but not yet supported by the CLI.\n` +
-                `Follow the manual instructions at ${entry.repo} for now. ` +
+              `Install kind "${entry.install.kind}" is declared by this entry but not yet automated by the CLI.\n` +
+                `Follow the integration's own instructions at ${entry.repo} for now. ` +
                 `Automated support is planned for a follow-up release.`,
             );
             process.exit(2);
@@ -206,7 +319,9 @@ function printEntryHuman(e: IntegrationEntry): void {
       console.log(`    binary:     ${e.install.binary}`);
       break;
     case 'mcp':
-      console.log(`    command:    ${e.install.command} ${e.install.args.join(' ')}`);
+      console.log(
+        `    command:    ${e.install.command}${e.install.args?.length ? ` ${e.install.args.join(' ')}` : ' (no args declared)'}`,
+      );
       if (e.install.supportedClients) {
         console.log(`    clients:    ${e.install.supportedClients.join(', ')}`);
       }
@@ -219,6 +334,8 @@ function printEntryHuman(e: IntegrationEntry): void {
         console.log(`    docker:     ${e.install.docker.image}${e.install.docker.digest ? `@${e.install.docker.digest}` : ''}`);
       } else if (e.install.runtime === 'npm-global' && e.install.npmGlobal) {
         console.log(`    npm global: ${e.install.npmGlobal.package}@${e.install.npmGlobal.version}`);
+      } else {
+        console.log(`    runtime:    ${e.install.runtime}`);
       }
       break;
     case 'agent-plugin':
@@ -226,7 +343,8 @@ function printEntryHuman(e: IntegrationEntry): void {
       console.log(`    package:    ${e.install.package}@${e.install.version}`);
       break;
     case 'manual':
-      console.log(`    steps:      ${e.install.steps.length} manual step(s); see registry entry.`);
+      console.log(`    docs:       ${e.install.docsUrl}`);
+      if (e.install.oneLiner) console.log(`    summary:    ${e.install.oneLiner}`);
       break;
   }
   console.log('');

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -1,14 +1,19 @@
 // Wires up the `dkg integration ...` subcommand tree on a Commander program.
 //
 // Exposed:
-//   dkg integration list          - enumerate entries in the registry
-//   dkg integration info <slug>   - show one entry
+//   dkg integration list             - browse the registry
+//   dkg integration search [keyword] - the same view, keyword-filtered
+//   dkg integration installed        - what is present on THIS machine
+//   dkg integration info <slug>      - show one entry
 //   dkg integration install <slug> [--allow-community] [--dry-run]
 //
-// Only install kinds currently in the registry (cli, mcp) are implemented.
-// Other kinds print an explicit "not implemented in this CLI version" error
-// pointing at the entry's repo and registry page so users can follow manual
-// install instructions.
+// Automation by install kind: `cli` and `service` install automatically — the
+// latter only for runtime `npm-global`, and only when the entry carries
+// npmGlobal.package/version, since the schema requires neither. `mcp` renders a
+// config block for the user to paste. `manual` prints the entry's docs link.
+// Everything else, including npm-global services without package metadata,
+// exits cleanly pointing at the integration's own instructions rather than
+// failing generically.
 
 import type { Command } from 'commander';
 import { detectInstalled } from './detect-installed.js';

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -329,6 +329,10 @@ export function registerIntegrationCommands(program: Command): void {
               entry,
               dryRun: opts.dryRun,
               skipProvenance: opts.verifyProvenance === false,
+              // installMcp already honours --api-url; omitting it here made the
+              // same documented flag work for one install kind and silently do
+              // nothing for another.
+              apiUrl: opts.apiUrl,
             });
             if (opts.dryRun) {
               console.log('');
@@ -336,7 +340,11 @@ export function registerIntegrationCommands(program: Command): void {
               console.log(`Note: provenance is only checked on a real install (skipped in dry-run).`);
             } else {
               console.log('');
-              console.log(`Installed ${entry.install.npmGlobal?.package}@${entry.install.npmGlobal?.version}.`);
+              // Report what was actually installed — the resolver's trimmed
+              // values — rather than the raw payload the npm spec was not built
+              // from.
+              const installed = resolveNpmGlobalService(entry.install);
+              console.log(`Installed ${installed?.package}@${installed?.version}.`);
             }
             if (result.postInstructions.length > 0) {
               console.log('');

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -142,12 +142,20 @@ export function registerIntegrationCommands(program: Command): void {
           }
           console.log('');
         }
+        // 'unknown' has more than one cause: an install kind the CLI cannot
+        // detect, or a probe that failed (npm missing from PATH, an unreadable
+        // MCP config). Each row carries its own reason in `detail`, so render
+        // that instead of one blanket explanation — telling someone their cli
+        // entry "is an install kind the CLI does not perform" when npm is
+        // simply absent sends them off to fix the wrong thing.
         const undetectable = rows.filter((r) => r.state === 'unknown');
         if (undetectable.length > 0) {
           console.log(
-            `${undetectable.length} entr${undetectable.length === 1 ? 'y' : 'ies'} cannot be detected ` +
-              `(install kinds the CLI does not perform): ${undetectable.map((r) => r.slug).join(', ')}`,
+            `${undetectable.length} entr${undetectable.length === 1 ? 'y' : 'ies'} could not be determined:\n`,
           );
+          for (const r of undetectable) {
+            console.log(`  ${r.slug.padEnd(24)}  [${r.kind}]  ${r.detail}`);
+          }
         }
         console.log('');
         console.log(

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -19,9 +19,9 @@ import type { Command } from 'commander';
 import { detectInstalled } from './detect-installed.js';
 import { installCli } from './install-cli.js';
 import { installMcp } from './install-mcp.js';
-import { installService, resolveNpmGlobalService } from './install-service.js';
+import { installService } from './install-service.js';
 import { fetchAllEntries, fetchEntry, resolveRegistryConfig } from './registry-client.js';
-import type { IntegrationEntry, TrustTier } from './schema.js';
+import { resolveNpmGlobalService, type IntegrationEntry, type TrustTier } from './schema.js';
 
 /** Case-insensitive substring match across the fields a user would search by. */
 function matchesKeyword(e: IntegrationEntry, needle: string): boolean {

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -19,7 +19,7 @@ import type { Command } from 'commander';
 import { detectInstalled } from './detect-installed.js';
 import { installCli } from './install-cli.js';
 import { installMcp } from './install-mcp.js';
-import { installService } from './install-service.js';
+import { installService, resolveNpmGlobalService } from './install-service.js';
 import { fetchAllEntries, fetchEntry, resolveRegistryConfig } from './registry-client.js';
 import type { IntegrationEntry, TrustTier } from './schema.js';
 
@@ -312,8 +312,11 @@ export function registerIntegrationCommands(program: Command): void {
             // threw and surfaced as a generic "install failed" — a worse
             // experience than the docker/binary case, which exits cleanly with
             // a pointer to the integration's own docs. Same treatment here.
-            const npm = entry.install.npmGlobal;
-            if (!npm?.package || !npm?.version) {
+            // Shares resolveNpmGlobalService with the installer so the two
+            // layers cannot disagree about what "installable" means. They did:
+            // this gate used truthiness while the installer trimmed, so a
+            // whitespace-only package slipped through to a generic failure.
+            if (resolveNpmGlobalService(entry.install) === null) {
               console.error(
                 `This entry declares runtime "npm-global" but carries no npmGlobal.package/version, ` +
                   `so the CLI cannot install it automatically.\n` +

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -287,6 +287,23 @@ export function registerIntegrationCommands(program: Command): void {
               process.exit(2);
               break;
             }
+            // The schema requires only kind + runtime for a service, so
+            // `{ kind: 'service', runtime: 'npm-global' }` with no npmGlobal
+            // block is a READABLE entry that simply cannot be automated.
+            // Dispatching on runtime alone sent it into installService, which
+            // threw and surfaced as a generic "install failed" — a worse
+            // experience than the docker/binary case, which exits cleanly with
+            // a pointer to the integration's own docs. Same treatment here.
+            const npm = entry.install.npmGlobal;
+            if (!npm?.package || !npm?.version) {
+              console.error(
+                `This entry declares runtime "npm-global" but carries no npmGlobal.package/version, ` +
+                  `so the CLI cannot install it automatically.\n` +
+                  `Follow the integration's own instructions at ${entry.repo}.`,
+              );
+              process.exit(2);
+              break;
+            }
             const result = await installService({
               entry,
               dryRun: opts.dryRun,

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -31,15 +31,32 @@ export function registerIntegrationCommands(program: Command): void {
     .command('integration')
     .description('Install and inspect community DKG integrations from the registry');
 
-  // `search` discovers what EXISTS in the registry; `list` reports what is
-  // installed HERE. That split is what the registry README documents and what
-  // npm/apt users expect. `list` previously did what `search` does now.
+  // Three verbs, deliberately: `list` and `search` are siblings over the same
+  // thing (the registry — all entries vs. filtered), and the one that reports
+  // something genuinely different gets a genuinely different word (`installed`).
+  //
+  // An earlier revision of this PR instead repurposed `list` to mean "installed
+  // here". That reads badly: `list` and `search` sound like near-synonyms, so a
+  // user typing `list` and getting local state has nothing in the name to warn
+  // them — and it silently changed the `--json` shape of a shipped command.
+  // `installed` needs no convention knowledge and breaks nothing.
   integrationCmd
     .command('search [keyword]')
-    .description('Search integrations available in the registry')
+    .description('Search registry integrations by keyword')
     .option('--tier <tier>', 'Minimum trust tier: community | verified | featured', 'verified')
     .option('--json', 'Print the raw registry entries as JSON')
     .action(async (keyword: string | undefined, opts: { tier: string; json?: boolean }) => {
+      await runRegistryListing(keyword, opts, 'search');
+    });
+
+  // Shared body for `list` and `search` — same view of the registry, the only
+  // difference being an optional keyword filter. Kept in one place so the two
+  // cannot drift in output or --json shape.
+  async function runRegistryListing(
+    keyword: string | undefined,
+    opts: { tier: string; json?: boolean },
+    verb: 'list' | 'search',
+  ): Promise<void> {
       try {
         const cfg = resolveRegistryConfig();
         const { entries, failures } = await fetchAllEntries(cfg);
@@ -80,14 +97,25 @@ export function registerIntegrationCommands(program: Command): void {
           }
         }
       } catch (err) {
-        console.error(`Failed to search integrations: ${toMessage(err)}`);
+        console.error(`Failed to ${verb} integrations: ${toMessage(err)}`);
         process.exit(1);
       }
+  }
+
+  // Unchanged from before this PR: browse the registry, `{ entries, failures }`
+  // under --json. `search` is the same view with a keyword filter.
+  integrationCmd
+    .command('list')
+    .description('List integrations available in the registry')
+    .option('--tier <tier>', 'Minimum trust tier: community | verified | featured', 'verified')
+    .option('--json', 'Print the raw registry entries as JSON')
+    .action(async (opts: { tier: string; json?: boolean }) => {
+      await runRegistryListing(undefined, opts, 'list');
     });
 
   integrationCmd
-    .command('list')
-    .description('List which registry integrations are installed on this machine')
+    .command('installed')
+    .description('Show which registry integrations are installed on this machine')
     .option('--tier <tier>', 'Minimum trust tier to consider: community | verified | featured', 'community')
     .option('--json', 'Print the raw detection result as JSON')
     .action(async (opts: { tier: string; json?: boolean }) => {
@@ -124,7 +152,7 @@ export function registerIntegrationCommands(program: Command): void {
         console.log('');
         console.log(
           `Checked ${known.length} detectable entr${known.length === 1 ? 'y' : 'ies'}. ` +
-            `Use \`dkg integration search\` to browse the registry.`,
+            `Use \`dkg integration list\` to browse the registry.`,
         );
       } catch (err) {
         console.error(`Failed to list installed integrations: ${toMessage(err)}`);

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -162,6 +162,19 @@ export function registerIntegrationCommands(program: Command): void {
             console.log(`  ${r.slug.padEnd(24)}  [${r.kind}]  ${r.detail}`);
           }
         }
+        // Unreadable registry entries were reported in --json but silently
+        // dropped here, so the human summary counted only what it could parse
+        // and gave no hint that anything was skipped. `list`/`search` already
+        // warn about these; the same evidence belongs in both places.
+        if (failures.length > 0) {
+          console.warn(
+            `Skipped ${failures.length} unreadable registry entr${failures.length === 1 ? 'y' : 'ies'} ` +
+              `(not considered for install detection):`,
+          );
+          for (const f of failures) {
+            console.warn(`  ${f.slug}: ${f.error}`);
+          }
+        }
         console.log('');
         console.log(
           `Checked ${known.length} detectable entr${known.length === 1 ? 'y' : 'ies'}. ` +

--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -13,6 +13,11 @@
 //   mcp                     -> the client configs `dkg mcp setup` knows about,
 //                              via detectClients() + readRegisteredServerKeys()
 //   others                  -> undetectable; 'unknown', never 'not installed'
+//
+// The same rule applies to detection that FAILS rather than comes back empty:
+// if `npm ls -g` cannot run, npm-installable entries report 'unknown', not
+// 'not installed'. "We looked and it is absent" and "we could not look" are
+// different answers and the output must not conflate them.
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -33,15 +38,25 @@ export interface InstalledRow {
 
 /** Injectable so tests spawn no npm and touch no real config files. */
 export interface DetectDeps {
-  listGlobalNpm?: () => Promise<Record<string, string>>;
+  /** Resolves `null` when the probe could not run — NOT an empty map. */
+  listGlobalNpm?: () => Promise<Record<string, string> | null>;
   /** Defaults to the same client targets `dkg mcp setup` registers into. */
   clients?: ClientTarget[];
   /** Defaults to reading each client's registered server keys. */
   readServerKeys?: (target: ClientTarget) => string[];
 }
 
-/** `npm ls -g --json --depth=0` -> { packageName: version }. Empty on failure. */
-async function listGlobalNpmPackages(): Promise<Record<string, string>> {
+/**
+ * `npm ls -g --json --depth=0` -> { packageName: version }.
+ *
+ * Resolves `null` when the probe could not run — npm missing from PATH, a
+ * permissions error, or output we cannot parse. That is DELIBERATELY distinct
+ * from `{}`: an empty map means "npm answered, and nothing is installed
+ * globally", which is a real answer. Collapsing the two would make every
+ * npm-installable entry read as "not installed" on a machine where we simply
+ * failed to look — the exact false negative the three-state model prevents.
+ */
+async function listGlobalNpmPackages(): Promise<Record<string, string> | null> {
   try {
     // npm exits non-zero on extraneous/peer warnings while still emitting valid
     // JSON, so parse stdout regardless of exit code.
@@ -49,7 +64,25 @@ async function listGlobalNpmPackages(): Promise<Record<string, string>> {
       maxBuffer: 8 * 1024 * 1024,
       shell: process.platform === 'win32',
     }).catch((err: { stdout?: string }) => ({ stdout: err?.stdout ?? '' }));
-    if (!stdout.trim()) return {};
+    return parseGlobalNpmList(stdout);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Split out from the spawn so the failure-vs-empty distinction is testable
+ * without mocking a child process. This is where the false negative would come
+ * back if someone "simplified" a `null` return to `{}`, so it is covered
+ * directly rather than only through an injected fake.
+ *
+ * `null` = we have no answer. `{}` = npm answered, nothing is installed.
+ * A machine with no global packages still emits valid JSON (`{"dependencies":{}}`),
+ * so empty stdout genuinely means the probe failed rather than came back empty.
+ */
+export function parseGlobalNpmList(stdout: string): Record<string, string> | null {
+  if (!stdout.trim()) return null;
+  try {
     const parsed = JSON.parse(stdout) as { dependencies?: Record<string, { version?: string }> };
     const out: Record<string, string> = {};
     for (const [name, meta] of Object.entries(parsed.dependencies ?? {})) {
@@ -57,7 +90,7 @@ async function listGlobalNpmPackages(): Promise<Record<string, string>> {
     }
     return out;
   } catch {
-    return {};
+    return null;
   }
 }
 
@@ -106,6 +139,16 @@ export async function detectInstalled(
   return entries.map((e): InstalledRow => {
     const npmPkg = globalNpmPackageFor(e.install);
     if (npmPkg) {
+      // The probe failed, so we know nothing about this entry either way.
+      // Reporting 'not installed' here would be a claim we cannot support.
+      if (globals === null) {
+        return {
+          slug: e.slug,
+          kind: e.install.kind,
+          state: 'unknown',
+          detail: 'could not inspect global npm packages',
+        };
+      }
       const found = globals[npmPkg.package];
       if (found === undefined) {
         return { slug: e.slug, kind: e.install.kind, state: 'not installed', detail: '' };

--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -25,11 +25,25 @@ import {
   detectClients,
   readRegisteredServerKeys,
   type ClientTarget,
+  type RegisteredMcpServer,
   type ServerKeyProbe,
 } from '../mcp-setup.js';
-import type { IntegrationEntry } from './schema.js';
+import type { InstallMcp, IntegrationEntry } from './schema.js';
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Whether a registered block would actually launch what the entry declares.
+ *
+ * The slug alone is not evidence — a user can register anything under that
+ * name. Reporting "installed" for a block that runs a different package would
+ * hide a substituted or stale MCP server behind a reassuring green row.
+ */
+function mcpServerMatches(server: RegisteredMcpServer, install: InstallMcp): boolean {
+  if (server.command !== install.command) return false;
+  const expected = install.args ?? [];
+  return server.args.length === expected.length && expected.every((a, i) => a === server.args[i]);
+}
 
 export type InstalledState = 'installed' | 'not installed' | 'unknown';
 
@@ -131,8 +145,9 @@ export async function detectInstalled(
 
   const globals = needsNpm ? await (deps.listGlobalNpm ?? listGlobalNpmPackages)() : {};
 
-  // slug -> the client(s) whose config registers a server under that name
-  const wiredMcp = new Map<string, string[]>();
+  // slug -> every client registering a server under that name, with the block
+  // itself so the entry's declared command/args can be compared against it.
+  const mcpBlocks = new Map<string, Array<{ client: string; server: RegisteredMcpServer }>>();
   // Configs we could not inspect. A slug absent from every readable config is
   // only genuinely absent if there were no unreadable ones — otherwise the
   // registration could be sitting in a file we failed to parse.
@@ -146,10 +161,10 @@ export async function detectInstalled(
         unreadableClients.push(target.name);
         continue;
       }
-      for (const key of probe.keys) {
-        const list = wiredMcp.get(key) ?? [];
-        if (!list.includes(target.name)) list.push(target.name);
-        wiredMcp.set(key, list);
+      for (const [name, server] of Object.entries(probe.servers)) {
+        const list = mcpBlocks.get(name) ?? [];
+        list.push({ client: target.name, server });
+        mcpBlocks.set(name, list);
       }
     }
   }
@@ -186,26 +201,41 @@ export async function detectInstalled(
       // installMcp keys the server block on the entry slug, so that is what we
       // look for. Note this detects a config the USER pasted — the CLI never
       // writes it — hence "wired into", not "installed by".
-      const clients = wiredMcp.get(e.slug);
-      if (!clients?.length) {
-        // Found in no readable config — but if some config was unreadable the
-        // block could be sitting in it, so we cannot claim absence.
-        if (unreadableClients.length > 0) {
-          return {
-            slug: e.slug,
-            kind: 'mcp',
-            state: 'unknown',
-            detail: `could not inspect ${unreadableClients.join(', ')} config`,
-          };
-        }
-        return { slug: e.slug, kind: 'mcp', state: 'not installed', detail: '' };
+      const found = mcpBlocks.get(e.slug) ?? [];
+      const matching = found.filter((f) => mcpServerMatches(f.server, e.install as InstallMcp));
+      if (matching.length > 0) {
+        return {
+          slug: e.slug,
+          kind: 'mcp',
+          state: 'installed',
+          detail: `wired into ${matching.map((m) => m.client).join(', ')}`,
+        };
       }
-      return {
-        slug: e.slug,
-        kind: 'mcp',
-        state: 'installed',
-        detail: `wired into ${clients.join(', ')}`,
-      };
+      // Something IS registered under this slug, but it launches a different
+      // command. Neither 'installed' (it would start the wrong server) nor
+      // 'not installed' (that hides a name collision the user should know
+      // about) is honest, so say exactly what was found.
+      if (found.length > 0) {
+        return {
+          slug: e.slug,
+          kind: 'mcp',
+          state: 'unknown',
+          detail: `a different server is registered as "${e.slug}" in ${found
+            .map((f) => f.client)
+            .join(', ')}`,
+        };
+      }
+      // Found in no readable config — but if some config was unreadable the
+      // block could be sitting in it, so we cannot claim absence.
+      if (unreadableClients.length > 0) {
+        return {
+          slug: e.slug,
+          kind: 'mcp',
+          state: 'unknown',
+          detail: `could not inspect ${unreadableClients.join(', ')} config`,
+        };
+      }
+      return { slug: e.slug, kind: 'mcp', state: 'not installed', detail: '' };
     }
 
     return {

--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -41,8 +41,23 @@ const execFileAsync = promisify(execFile);
  */
 function mcpServerMatches(server: RegisteredMcpServer, install: InstallMcp): boolean {
   if (server.command !== install.command) return false;
+  // `null` = args were present but are not a string array. That is not the
+  // declared launch block, so it cannot match — including against an args-less
+  // entry, which is what silently dropping the bad elements would have allowed.
+  if (server.args === null) return false;
   const expected = install.args ?? [];
-  return server.args.length === expected.length && expected.every((a, i) => a === server.args[i]);
+  const actual = server.args;
+  return actual.length === expected.length && expected.every((a, i) => a === actual[i]);
+}
+
+/**
+ * Env keys still holding an installMcp placeholder (`<NAME>`). A block carrying
+ * one was pasted but never completed, so it would start unauthenticated.
+ */
+function unfilledPlaceholders(server: RegisteredMcpServer): string[] {
+  return Object.entries(server.env ?? {})
+    .filter(([, v]) => /^<[A-Za-z0-9_]+>$/.test(v))
+    .map(([k]) => k);
 }
 
 export type InstalledState = 'installed' | 'not installed' | 'unknown';
@@ -215,28 +230,32 @@ export async function detectInstalled(
         // clients can supply env from the parent process, so a user who keeps
         // secrets out of the config file is correctly installed. An unfilled
         // placeholder is unambiguous; an absent key is not.
-        const unfilled = [
-          ...new Set(
-            matching.flatMap((m) =>
-              Object.entries(m.server.env ?? {})
-                .filter(([, v]) => /^<[A-Za-z0-9_]+>$/.test(v))
-                .map(([k]) => k),
-            ),
-          ),
-        ];
-        if (unfilled.length > 0) {
+        // Judged PER CLIENT. Aggregating across clients let one stale block
+        // hide a real install: a filled Cursor config plus an old Claude
+        // Desktop block still carrying `<DKG_AUTH_TOKEN>` reported the whole
+        // entry as unknown. One complete registration is enough to be
+        // installed; the incomplete siblings are worth mentioning, not worth
+        // overriding positive evidence with.
+        const complete = matching.filter((m) => unfilledPlaceholders(m.server).length === 0);
+        const incomplete = matching.filter((m) => unfilledPlaceholders(m.server).length > 0);
+        if (complete.length > 0) {
+          const note =
+            incomplete.length > 0
+              ? ` (incomplete block in ${incomplete.map((m) => m.client).join(', ')})`
+              : '';
           return {
             slug: e.slug,
             kind: 'mcp',
-            state: 'unknown',
-            detail: `registered but placeholder values are unfilled: ${unfilled.join(', ')}`,
+            state: 'installed',
+            detail: `wired into ${complete.map((m) => m.client).join(', ')}${note}`,
           };
         }
+        const unfilled = [...new Set(incomplete.flatMap((m) => unfilledPlaceholders(m.server)))];
         return {
           slug: e.slug,
           kind: 'mcp',
-          state: 'installed',
-          detail: `wired into ${matching.map((m) => m.client).join(', ')}`,
+          state: 'unknown',
+          detail: `registered but placeholder values are unfilled: ${unfilled.join(', ')}`,
         };
       }
       // Something IS registered under this slug, but it launches a different

--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -1,0 +1,161 @@
+// Detects which registry integrations are present on this machine.
+//
+// Deliberately DERIVED rather than recorded. A ledger would say what we did;
+// detection says what is true — it cannot go stale when a user upgrades a
+// package by hand, deletes an MCP block, or installs on another machine. It is
+// also the only honest option for `mcp`: installMcp writes nothing, it prints a
+// config block for the user to paste, so a ledger entry would claim an install
+// that may never have happened.
+//
+// Coverage matches what the installers actually do:
+//   cli     -> `npm ls -g` for install.package
+//   mcp     -> the MCP client configs installMcp points users at, keyed on slug
+//   others  -> undetectable; reported as 'unknown', never as 'not installed'
+
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import type { IntegrationEntry } from './schema.js';
+
+const execFileAsync = promisify(execFile);
+
+export type InstalledState = 'installed' | 'not installed' | 'unknown';
+
+export interface InstalledRow {
+  slug: string;
+  kind: string;
+  state: InstalledState;
+  /** Human-readable evidence: version found, or which client it is wired into. */
+  detail: string;
+}
+
+/** Injectable for tests so nothing spawns npm or touches a real home dir. */
+export interface DetectDeps {
+  listGlobalNpm?: () => Promise<Record<string, string>>;
+  readClientConfig?: (path: string) => Promise<string | null>;
+  mcpClientPaths?: Array<{ client: string; path: string }>;
+}
+
+// The same locations install-mcp.ts tells users to paste into. Kept in sync
+// with that list; if one moves, both should move.
+export function defaultMcpClientPaths(): Array<{ client: string; path: string }> {
+  return [
+    { client: 'Cursor', path: join(homedir(), '.cursor', 'mcp.json') },
+    {
+      client: 'Claude Desktop',
+      path: join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
+    },
+    {
+      client: 'Claude Desktop',
+      path: join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json'),
+    },
+  ];
+}
+
+/** `npm ls -g --json --depth=0` -> { packageName: version }. Empty on failure. */
+async function listGlobalNpmPackages(): Promise<Record<string, string>> {
+  try {
+    // npm exits non-zero on extraneous/peer warnings while still emitting valid
+    // JSON, so parse stdout regardless of exit code.
+    const { stdout } = await execFileAsync('npm', ['ls', '--global', '--json', '--depth=0'], {
+      maxBuffer: 8 * 1024 * 1024,
+      shell: process.platform === 'win32',
+    }).catch((err: { stdout?: string }) => ({ stdout: err?.stdout ?? '' }));
+    if (!stdout.trim()) return {};
+    const parsed = JSON.parse(stdout) as { dependencies?: Record<string, { version?: string }> };
+    const out: Record<string, string> = {};
+    for (const [name, meta] of Object.entries(parsed.dependencies ?? {})) {
+      out[name] = meta?.version ?? '';
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+async function readIfPresent(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Which of `entries` are present locally. Never claims 'not installed' for a
+ * kind the CLI cannot detect — that is reported as 'unknown'.
+ */
+export async function detectInstalled(
+  entries: IntegrationEntry[],
+  deps: DetectDeps = {},
+): Promise<InstalledRow[]> {
+  const needsNpm = entries.some((e) => e.install.kind === 'cli');
+  const needsMcp = entries.some((e) => e.install.kind === 'mcp');
+
+  const globals = needsNpm ? await (deps.listGlobalNpm ?? listGlobalNpmPackages)() : {};
+
+  // slug -> the client(s) whose config declares it as an MCP server
+  const wiredMcp = new Map<string, string[]>();
+  if (needsMcp) {
+    const paths = deps.mcpClientPaths ?? defaultMcpClientPaths();
+    const read = deps.readClientConfig ?? readIfPresent;
+    for (const { client, path } of paths) {
+      const raw = await read(path);
+      if (!raw) continue;
+      let servers: Record<string, unknown> = {};
+      try {
+        servers = (JSON.parse(raw) as { mcpServers?: Record<string, unknown> }).mcpServers ?? {};
+      } catch {
+        continue; // a client config we can't parse is not evidence either way
+      }
+      for (const key of Object.keys(servers)) {
+        const list = wiredMcp.get(key) ?? [];
+        if (!list.includes(client)) list.push(client);
+        wiredMcp.set(key, list);
+      }
+    }
+  }
+
+  return entries.map((e): InstalledRow => {
+    switch (e.install.kind) {
+      case 'cli': {
+        const found = globals[e.install.package];
+        if (found === undefined) {
+          return { slug: e.slug, kind: 'cli', state: 'not installed', detail: '' };
+        }
+        const pinned = e.install.version;
+        const drift = found && pinned && found !== pinned ? ` (registry pins ${pinned})` : '';
+        return {
+          slug: e.slug,
+          kind: 'cli',
+          state: 'installed',
+          detail: `${e.install.package}@${found || '?'}${drift}`,
+        };
+      }
+      case 'mcp': {
+        // installMcp keys the server block on the entry slug, so that is what
+        // we look for. Note this detects a config the USER pasted — the CLI
+        // never writes it — so the wording is "wired into", not "installed by".
+        const clients = wiredMcp.get(e.slug);
+        if (!clients?.length) {
+          return { slug: e.slug, kind: 'mcp', state: 'not installed', detail: '' };
+        }
+        return {
+          slug: e.slug,
+          kind: 'mcp',
+          state: 'installed',
+          detail: `wired into ${clients.join(', ')}`,
+        };
+      }
+      default:
+        return {
+          slug: e.slug,
+          kind: e.install.kind,
+          state: 'unknown',
+          detail: 'the CLI does not perform this install kind',
+        };
+    }
+  });
+}

--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -28,7 +28,11 @@ import {
   type RegisteredMcpServer,
   type ServerKeyProbe,
 } from '../mcp-setup.js';
-import type { InstallMcp, IntegrationEntry } from './schema.js';
+import {
+  resolveNpmGlobalService,
+  type InstallMcp,
+  type IntegrationEntry,
+} from './schema.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -132,17 +136,26 @@ export function parseGlobalNpmList(stdout: string): Record<string, string> | nul
   }
 }
 
-/** The npm package an entry installs globally, if any. */
+/**
+ * The npm package an entry installs globally.
+ *
+ * `'unresolvable'` means the entry declares npm-global but carries no usable
+ * package metadata — the installer would refuse it, so detection must not
+ * report a definitive "not installed" as though it had looked. Detection has to
+ * use the SAME resolver the installer and dispatcher use: probing with the raw
+ * payload made a padded `" @acme/svc "` install as `@acme/svc` and then report
+ * itself not installed, because the lookup key kept the spaces.
+ */
 function globalNpmPackageFor(
   install: IntegrationEntry['install'],
-): { package: string; version: string } | null {
+): { package: string; version: string } | 'unresolvable' | null {
   if (install.kind === 'cli') {
     return { package: install.package, version: install.version };
   }
   // A service installed via npm-global lands in exactly the same place as a
   // cli install, so it is detectable the same way.
-  if (install.kind === 'service' && install.runtime === 'npm-global' && install.npmGlobal) {
-    return { package: install.npmGlobal.package, version: install.npmGlobal.version };
+  if (install.kind === 'service' && install.runtime === 'npm-global') {
+    return resolveNpmGlobalService(install) ?? 'unresolvable';
   }
   return null;
 }
@@ -155,7 +168,10 @@ export async function detectInstalled(
   entries: IntegrationEntry[],
   deps: DetectDeps = {},
 ): Promise<InstalledRow[]> {
-  const needsNpm = entries.some((e) => globalNpmPackageFor(e.install) !== null);
+  const needsNpm = entries.some((e) => {
+    const g = globalNpmPackageFor(e.install);
+    return g !== null && g !== 'unresolvable';
+  });
   const needsMcp = entries.some((e) => e.install.kind === 'mcp');
 
   const globals = needsNpm ? await (deps.listGlobalNpm ?? listGlobalNpmPackages)() : {};
@@ -186,6 +202,17 @@ export async function detectInstalled(
 
   return entries.map((e): InstalledRow => {
     const npmPkg = globalNpmPackageFor(e.install);
+    // Declares npm-global but carries no usable package/version. The installer
+    // refuses this entry, so probing npm with the raw payload and reporting
+    // 'not installed' would assert a check we never performed.
+    if (npmPkg === 'unresolvable') {
+      return {
+        slug: e.slug,
+        kind: e.install.kind,
+        state: 'unknown',
+        detail: 'declares npm-global but carries no usable package metadata',
+      };
+    }
     if (npmPkg) {
       // The probe failed, so we know nothing about this entry either way.
       // Reporting 'not installed' here would be a claim we cannot support.

--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -204,6 +204,34 @@ export async function detectInstalled(
       const found = mcpBlocks.get(e.slug) ?? [];
       const matching = found.filter((f) => mcpServerMatches(f.server, e.install as InstallMcp));
       if (matching.length > 0) {
+        // installMcp writes `<NAME>` placeholders for values it cannot supply
+        // (no local auth token, or any env var the entry declares that we do
+        // not fill). A block still carrying one was pasted but never completed,
+        // so the server is registered and will start unauthenticated. That is a
+        // half-install, and calling it "installed" is the same over-claim as
+        // the others fixed on this surface.
+        //
+        // Note we do NOT require every `envRequired` key to be PRESENT: MCP
+        // clients can supply env from the parent process, so a user who keeps
+        // secrets out of the config file is correctly installed. An unfilled
+        // placeholder is unambiguous; an absent key is not.
+        const unfilled = [
+          ...new Set(
+            matching.flatMap((m) =>
+              Object.entries(m.server.env ?? {})
+                .filter(([, v]) => /^<[A-Za-z0-9_]+>$/.test(v))
+                .map(([k]) => k),
+            ),
+          ),
+        ];
+        if (unfilled.length > 0) {
+          return {
+            slug: e.slug,
+            kind: 'mcp',
+            state: 'unknown',
+            detail: `registered but placeholder values are unfilled: ${unfilled.join(', ')}`,
+          };
+        }
         return {
           slug: e.slug,
           kind: 'mcp',

--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -8,15 +8,15 @@
 // that may never have happened.
 //
 // Coverage matches what the installers actually do:
-//   cli     -> `npm ls -g` for install.package
-//   mcp     -> the MCP client configs installMcp points users at, keyed on slug
-//   others  -> undetectable; reported as 'unknown', never as 'not installed'
+//   cli                     -> `npm ls -g` for install.package
+//   service (npm-global)    -> `npm ls -g` for install.npmGlobal.package
+//   mcp                     -> the client configs `dkg mcp setup` knows about,
+//                              via detectClients() + readRegisteredServerKeys()
+//   others                  -> undetectable; 'unknown', never 'not installed'
 
 import { execFile } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { detectClients, readRegisteredServerKeys, type ClientTarget } from '../mcp-setup.js';
 import type { IntegrationEntry } from './schema.js';
 
 const execFileAsync = promisify(execFile);
@@ -31,27 +31,13 @@ export interface InstalledRow {
   detail: string;
 }
 
-/** Injectable for tests so nothing spawns npm or touches a real home dir. */
+/** Injectable so tests spawn no npm and touch no real config files. */
 export interface DetectDeps {
   listGlobalNpm?: () => Promise<Record<string, string>>;
-  readClientConfig?: (path: string) => Promise<string | null>;
-  mcpClientPaths?: Array<{ client: string; path: string }>;
-}
-
-// The same locations install-mcp.ts tells users to paste into. Kept in sync
-// with that list; if one moves, both should move.
-export function defaultMcpClientPaths(): Array<{ client: string; path: string }> {
-  return [
-    { client: 'Cursor', path: join(homedir(), '.cursor', 'mcp.json') },
-    {
-      client: 'Claude Desktop',
-      path: join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
-    },
-    {
-      client: 'Claude Desktop',
-      path: join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json'),
-    },
-  ];
+  /** Defaults to the same client targets `dkg mcp setup` registers into. */
+  clients?: ClientTarget[];
+  /** Defaults to reading each client's registered server keys. */
+  readServerKeys?: (target: ClientTarget) => string[];
 }
 
 /** `npm ls -g --json --depth=0` -> { packageName: version }. Empty on failure. */
@@ -75,12 +61,19 @@ async function listGlobalNpmPackages(): Promise<Record<string, string>> {
   }
 }
 
-async function readIfPresent(path: string): Promise<string | null> {
-  try {
-    return await readFile(path, 'utf8');
-  } catch {
-    return null;
+/** The npm package an entry installs globally, if any. */
+function globalNpmPackageFor(
+  install: IntegrationEntry['install'],
+): { package: string; version: string } | null {
+  if (install.kind === 'cli') {
+    return { package: install.package, version: install.version };
   }
+  // A service installed via npm-global lands in exactly the same place as a
+  // cli install, so it is detectable the same way.
+  if (install.kind === 'service' && install.runtime === 'npm-global' && install.npmGlobal) {
+    return { package: install.npmGlobal.package, version: install.npmGlobal.version };
+  }
+  return null;
 }
 
 /**
@@ -91,71 +84,64 @@ export async function detectInstalled(
   entries: IntegrationEntry[],
   deps: DetectDeps = {},
 ): Promise<InstalledRow[]> {
-  const needsNpm = entries.some((e) => e.install.kind === 'cli');
+  const needsNpm = entries.some((e) => globalNpmPackageFor(e.install) !== null);
   const needsMcp = entries.some((e) => e.install.kind === 'mcp');
 
   const globals = needsNpm ? await (deps.listGlobalNpm ?? listGlobalNpmPackages)() : {};
 
-  // slug -> the client(s) whose config declares it as an MCP server
+  // slug -> the client(s) whose config registers a server under that name
   const wiredMcp = new Map<string, string[]>();
   if (needsMcp) {
-    const paths = deps.mcpClientPaths ?? defaultMcpClientPaths();
-    const read = deps.readClientConfig ?? readIfPresent;
-    for (const { client, path } of paths) {
-      const raw = await read(path);
-      if (!raw) continue;
-      let servers: Record<string, unknown> = {};
-      try {
-        servers = (JSON.parse(raw) as { mcpServers?: Record<string, unknown> }).mcpServers ?? {};
-      } catch {
-        continue; // a client config we can't parse is not evidence either way
-      }
-      for (const key of Object.keys(servers)) {
+    const clients = deps.clients ?? detectClients();
+    const readKeys = deps.readServerKeys ?? readRegisteredServerKeys;
+    for (const target of clients) {
+      for (const key of readKeys(target)) {
         const list = wiredMcp.get(key) ?? [];
-        if (!list.includes(client)) list.push(client);
+        if (!list.includes(target.name)) list.push(target.name);
         wiredMcp.set(key, list);
       }
     }
   }
 
   return entries.map((e): InstalledRow => {
-    switch (e.install.kind) {
-      case 'cli': {
-        const found = globals[e.install.package];
-        if (found === undefined) {
-          return { slug: e.slug, kind: 'cli', state: 'not installed', detail: '' };
-        }
-        const pinned = e.install.version;
-        const drift = found && pinned && found !== pinned ? ` (registry pins ${pinned})` : '';
-        return {
-          slug: e.slug,
-          kind: 'cli',
-          state: 'installed',
-          detail: `${e.install.package}@${found || '?'}${drift}`,
-        };
+    const npmPkg = globalNpmPackageFor(e.install);
+    if (npmPkg) {
+      const found = globals[npmPkg.package];
+      if (found === undefined) {
+        return { slug: e.slug, kind: e.install.kind, state: 'not installed', detail: '' };
       }
-      case 'mcp': {
-        // installMcp keys the server block on the entry slug, so that is what
-        // we look for. Note this detects a config the USER pasted — the CLI
-        // never writes it — so the wording is "wired into", not "installed by".
-        const clients = wiredMcp.get(e.slug);
-        if (!clients?.length) {
-          return { slug: e.slug, kind: 'mcp', state: 'not installed', detail: '' };
-        }
-        return {
-          slug: e.slug,
-          kind: 'mcp',
-          state: 'installed',
-          detail: `wired into ${clients.join(', ')}`,
-        };
-      }
-      default:
-        return {
-          slug: e.slug,
-          kind: e.install.kind,
-          state: 'unknown',
-          detail: 'the CLI does not perform this install kind',
-        };
+      const drift = found && npmPkg.version && found !== npmPkg.version
+        ? ` (registry pins ${npmPkg.version})`
+        : '';
+      return {
+        slug: e.slug,
+        kind: e.install.kind,
+        state: 'installed',
+        detail: `${npmPkg.package}@${found || '?'}${drift}`,
+      };
     }
+
+    if (e.install.kind === 'mcp') {
+      // installMcp keys the server block on the entry slug, so that is what we
+      // look for. Note this detects a config the USER pasted — the CLI never
+      // writes it — hence "wired into", not "installed by".
+      const clients = wiredMcp.get(e.slug);
+      if (!clients?.length) {
+        return { slug: e.slug, kind: 'mcp', state: 'not installed', detail: '' };
+      }
+      return {
+        slug: e.slug,
+        kind: 'mcp',
+        state: 'installed',
+        detail: `wired into ${clients.join(', ')}`,
+      };
+    }
+
+    return {
+      slug: e.slug,
+      kind: e.install.kind,
+      state: 'unknown',
+      detail: 'the CLI does not perform this install kind',
+    };
   });
 }

--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -21,7 +21,12 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { detectClients, readRegisteredServerKeys, type ClientTarget } from '../mcp-setup.js';
+import {
+  detectClients,
+  readRegisteredServerKeys,
+  type ClientTarget,
+  type ServerKeyProbe,
+} from '../mcp-setup.js';
 import type { IntegrationEntry } from './schema.js';
 
 const execFileAsync = promisify(execFile);
@@ -42,8 +47,12 @@ export interface DetectDeps {
   listGlobalNpm?: () => Promise<Record<string, string> | null>;
   /** Defaults to the same client targets `dkg mcp setup` registers into. */
   clients?: ClientTarget[];
-  /** Defaults to reading each client's registered server keys. */
-  readServerKeys?: (target: ClientTarget) => string[];
+  /**
+   * Defaults to probing each client's registered server keys. Returns a
+   * probe result, not a bare list, so "could not read this config" stays
+   * distinguishable from "read it, nothing registered".
+   */
+  readServerKeys?: (target: ClientTarget) => ServerKeyProbe;
 }
 
 /**
@@ -124,11 +133,20 @@ export async function detectInstalled(
 
   // slug -> the client(s) whose config registers a server under that name
   const wiredMcp = new Map<string, string[]>();
+  // Configs we could not inspect. A slug absent from every readable config is
+  // only genuinely absent if there were no unreadable ones — otherwise the
+  // registration could be sitting in a file we failed to parse.
+  const unreadableClients: string[] = [];
   if (needsMcp) {
     const clients = deps.clients ?? detectClients();
     const readKeys = deps.readServerKeys ?? readRegisteredServerKeys;
     for (const target of clients) {
-      for (const key of readKeys(target)) {
+      const probe = readKeys(target);
+      if (!probe.ok) {
+        unreadableClients.push(target.name);
+        continue;
+      }
+      for (const key of probe.keys) {
         const list = wiredMcp.get(key) ?? [];
         if (!list.includes(target.name)) list.push(target.name);
         wiredMcp.set(key, list);
@@ -170,6 +188,16 @@ export async function detectInstalled(
       // writes it — hence "wired into", not "installed by".
       const clients = wiredMcp.get(e.slug);
       if (!clients?.length) {
+        // Found in no readable config — but if some config was unreadable the
+        // block could be sitting in it, so we cannot claim absence.
+        if (unreadableClients.length > 0) {
+          return {
+            slug: e.slug,
+            kind: 'mcp',
+            state: 'unknown',
+            detail: `could not inspect ${unreadableClients.join(', ')} config`,
+          };
+        }
         return { slug: e.slug, kind: 'mcp', state: 'not installed', detail: '' };
       }
       return {

--- a/packages/cli/src/integrations/install-cli.ts
+++ b/packages/cli/src/integrations/install-cli.ts
@@ -6,20 +6,20 @@
 // entry promises a binary and a pinned version; npm -g gives contributors a
 // stable PATH entry and idempotent re-installs.
 
-import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { dkgDir } from '../config.js';
+import {
+  installNpmGlobalPackage,
+  runCommand,
+  type InstallRunner,
+  type ProvenanceVerifier,
+} from './install-npm-global.js';
 import type { InstallCli, IntegrationEntry } from './schema.js';
-import { verifyNpmProvenance, type ProvenanceCheckResult } from './verify-npm-provenance.js';
+import type { ProvenanceCheckResult } from './verify-npm-provenance.js';
 
-export type ProvenanceVerifier = (
-  pkg: string,
-  version: string,
-  expectedRepo: string,
-) => Promise<ProvenanceCheckResult>;
-
-// Injectable so tests can exercise the install flow without spawning npm.
-export type InstallRunner = (cmd: string, args: string[]) => Promise<number>;
+// Re-exported for existing importers; the definitions now live alongside the
+// shared npm-global installer that both `cli` and `service` kinds use.
+export type { InstallRunner, ProvenanceVerifier };
 
 export interface InstallCliOptions {
   entry: IntegrationEntry;
@@ -46,69 +46,25 @@ function assertCli(spec: IntegrationEntry['install']): asserts spec is InstallCl
 }
 
 export async function installCli(options: InstallCliOptions): Promise<InstallCliResult> {
-  const {
-    entry,
-    dryRun = false,
-    skipProvenance = false,
-    verifier = verifyNpmProvenance,
-    runner = runCommand,
-    logger = console.log,
-  } = options;
+  const { entry, dryRun, skipProvenance, verifier, runner = runCommand, logger } = options;
   assertCli(entry.install);
   const { package: pkg, version, binary } = entry.install;
 
-  const command = 'npm';
-  const args = ['install', '--global', `${pkg}@${version}`];
-
-  // Provenance gate: verify BEFORE we touch the user's global npm. We skip
-  // this in dry-run (no side effects to guard) and when the caller passes
-  // --no-verify-provenance (e.g. installing a pre-release dev tarball with
-  // no attestation yet, or an air-gapped registry that doesn't sign).
-  let provenance: ProvenanceCheckResult | undefined;
-  if (!dryRun && !skipProvenance) {
-    logger(`Verifying publish-time provenance for ${pkg}@${version}...`);
-    provenance = await verifier(pkg, version, entry.repo);
-    if (!provenance.ok) {
-      logger('');
-      logger('  Provenance check FAILED:');
-      for (const r of provenance.reasons) logger(`    - ${r}`);
-      logger('');
-      throw new Error(
-        `Refusing to install ${pkg}@${version}: the tarball on npm is not ` +
-          `cryptographically bound to ${entry.repo}. Re-run with --no-verify-provenance ` +
-          `to install anyway.`,
-      );
-    }
-    logger(`  ok — tarball is attested and points at ${entry.repo}.`);
-    logger('');
-  }
-
-  logger(`Installing ${pkg}@${version} globally via npm...`);
-  logger(`  ${command} ${args.join(' ')}`);
-
-  if (dryRun) {
-    return {
-      command,
-      args,
-      exitCode: 0,
-      binary,
-      postInstructions: buildPostInstructions(entry),
-      provenance,
-    };
-  }
-
-  const exitCode = await runner(command, args);
-  if (exitCode !== 0) {
-    throw new Error(`npm install failed with exit code ${exitCode}. See output above for details.`);
-  }
+  const result = await installNpmGlobalPackage({
+    entry,
+    pkg,
+    version,
+    dryRun,
+    skipProvenance,
+    verifier,
+    runner,
+    logger,
+  });
 
   return {
-    command,
-    args,
-    exitCode,
+    ...result,
     binary,
     postInstructions: buildPostInstructions(entry),
-    provenance,
   };
 }
 
@@ -144,10 +100,3 @@ function buildPostInstructions(entry: IntegrationEntry): string[] {
   return lines;
 }
 
-function runCommand(cmd: string, args: string[]): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: 'inherit' });
-    child.on('error', reject);
-    child.on('close', (code) => resolve(code ?? 1));
-  });
-}

--- a/packages/cli/src/integrations/install-mcp.ts
+++ b/packages/cli/src/integrations/install-mcp.ts
@@ -36,6 +36,17 @@ function assertMcp(spec: IntegrationEntry['install']): asserts spec is InstallMc
   if (spec.kind !== 'mcp') {
     throw new Error(`install-mcp received non-mcp install spec (kind=${spec.kind})`);
   }
+  // `args` is optional in the registry schema, so an args-less entry is
+  // READABLE (it lists and inspects fine) but not INSTALLABLE. Refuse here
+  // rather than emitting a config block whose `args` key JSON.stringify would
+  // silently drop — that would leave the client launching a bare `command`
+  // with no package to run, and the failure would surface inside the user's
+  // MCP client rather than here.
+  if (!Array.isArray(spec.args) || spec.args.length === 0) {
+    throw new Error(
+      `Registry entry declares no install.args, so no launch command can be built for "${spec.command}". Report this to the integration maintainer.`,
+    );
+  }
 }
 
 // Best-effort token read from the standard daemon-written path. Matches the

--- a/packages/cli/src/integrations/install-mcp.ts
+++ b/packages/cli/src/integrations/install-mcp.ts
@@ -36,17 +36,6 @@ function assertMcp(spec: IntegrationEntry['install']): asserts spec is InstallMc
   if (spec.kind !== 'mcp') {
     throw new Error(`install-mcp received non-mcp install spec (kind=${spec.kind})`);
   }
-  // `args` is optional in the registry schema, so an args-less entry is
-  // READABLE (it lists and inspects fine) but not INSTALLABLE. Refuse here
-  // rather than emitting a config block whose `args` key JSON.stringify would
-  // silently drop — that would leave the client launching a bare `command`
-  // with no package to run, and the failure would surface inside the user's
-  // MCP client rather than here.
-  if (!Array.isArray(spec.args) || spec.args.length === 0) {
-    throw new Error(
-      `Registry entry declares no install.args, so no launch command can be built for "${spec.command}". Report this to the integration maintainer.`,
-    );
-  }
 }
 
 // Best-effort token read from the standard daemon-written path. Matches the
@@ -110,7 +99,13 @@ export async function installMcp(options: InstallMcpOptions): Promise<InstallMcp
 
   const serverBlock: Record<string, unknown> = {
     command: entry.install.command,
-    args: entry.install.args,
+    // `args` is optional in the registry schema, and legitimately so: a server
+    // launched by a binary already on PATH needs none, whereas an `npx`-style
+    // launcher carries the package here. Normalise to [] rather than letting
+    // JSON.stringify drop an `undefined` key — the emitted block stays
+    // well-formed either way, and judging whether a given command needs args is
+    // the entry author's call, not the installer's.
+    args: entry.install.args ?? [],
     env,
   };
 

--- a/packages/cli/src/integrations/install-npm-global.ts
+++ b/packages/cli/src/integrations/install-npm-global.ts
@@ -1,0 +1,110 @@
+// Shared machinery for the two install kinds that put a package on the user's
+// global npm prefix: `install.kind: "cli"` and `install.kind: "service"` with
+// `runtime: "npm-global"`.
+//
+// The mechanics are identical — same pinned global install, same publish-time
+// provenance gate, same dry-run semantics — and only the post-install guidance
+// differs (a one-shot command vs a daemon to keep running). Keeping the policy
+// here means a change to how integrations reach the global prefix (an npm flag,
+// the provenance message, the failure mode) is made once instead of being kept
+// in sync by memory across two near-identical files.
+
+import { spawn } from 'node:child_process';
+import type { IntegrationEntry } from './schema.js';
+import { verifyNpmProvenance, type ProvenanceCheckResult } from './verify-npm-provenance.js';
+
+export type ProvenanceVerifier = (
+  pkg: string,
+  version: string,
+  expectedRepo: string,
+) => Promise<ProvenanceCheckResult>;
+
+/** Injectable so tests exercise the flow without spawning npm. */
+export type InstallRunner = (cmd: string, args: string[]) => Promise<number>;
+
+export interface NpmGlobalInstallOptions {
+  entry: IntegrationEntry;
+  pkg: string;
+  version: string;
+  dryRun?: boolean;
+  skipProvenance?: boolean;
+  verifier?: ProvenanceVerifier;
+  runner?: InstallRunner;
+  logger?: (msg: string) => void;
+  /** Prefix for the "Installing …" line, e.g. 'service'. */
+  label?: string;
+}
+
+export interface NpmGlobalInstallResult {
+  command: string;
+  args: string[];
+  exitCode: number;
+  provenance?: ProvenanceCheckResult;
+}
+
+export function runCommand(cmd: string, args: string[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+/**
+ * Install one pinned package onto the global npm prefix, gated on publish-time
+ * provenance. Returns without running npm when `dryRun` is set.
+ */
+export async function installNpmGlobalPackage(
+  options: NpmGlobalInstallOptions,
+): Promise<NpmGlobalInstallResult> {
+  const {
+    entry,
+    pkg,
+    version,
+    dryRun = false,
+    skipProvenance = false,
+    verifier = verifyNpmProvenance,
+    runner = runCommand,
+    logger = console.log,
+    label,
+  } = options;
+
+  const command = 'npm';
+  const args = ['install', '--global', `${pkg}@${version}`];
+
+  // Provenance gate: verify BEFORE we touch the user's global npm. Skipped in
+  // dry-run (no side effects to guard) and under --no-verify-provenance (e.g. a
+  // pre-release dev tarball with no attestation yet, or an air-gapped registry).
+  let provenance: ProvenanceCheckResult | undefined;
+  if (!dryRun && !skipProvenance) {
+    logger(`Verifying publish-time provenance for ${pkg}@${version}...`);
+    provenance = await verifier(pkg, version, entry.repo);
+    if (!provenance.ok) {
+      logger('');
+      logger('  Provenance check FAILED:');
+      for (const r of provenance.reasons) logger(`    - ${r}`);
+      logger('');
+      throw new Error(
+        `Refusing to install ${pkg}@${version}: the tarball on npm is not ` +
+          `cryptographically bound to ${entry.repo}. Re-run with --no-verify-provenance ` +
+          `to install anyway.`,
+      );
+    }
+    logger(`  ok — tarball is attested and points at ${entry.repo}.`);
+    logger('');
+  }
+
+  logger(`Installing ${label ? `${label} ` : ''}${pkg}@${version} globally via npm...`);
+  logger(`  ${command} ${args.join(' ')}`);
+
+  if (dryRun) {
+    return { command, args, exitCode: 0, provenance };
+  }
+
+  const exitCode = await runner(command, args);
+  if (exitCode !== 0) {
+    throw new Error(`npm install failed with exit code ${exitCode}. See output above for details.`);
+  }
+
+  return { command, args, exitCode, provenance };
+}

--- a/packages/cli/src/integrations/install-service.ts
+++ b/packages/cli/src/integrations/install-service.ts
@@ -57,8 +57,15 @@ function assertNpmGlobalService(
     );
   }
   // The schema requires package + version; `binary` is optional and defaults to
-  // the package name (see resolveBinary).
-  if (!spec.npmGlobal?.package || !spec.npmGlobal?.version) {
+  // the package name (see resolveBinary). Checked by TYPE, not truthiness: a
+  // non-string `package` is truthy and would reach the npm spec as
+  // `[object Object]@1.0.0` instead of being rejected as malformed.
+  if (
+    typeof spec.npmGlobal?.package !== 'string' ||
+    typeof spec.npmGlobal.version !== 'string' ||
+    !spec.npmGlobal.package.trim() ||
+    !spec.npmGlobal.version.trim()
+  ) {
     throw new Error(
       `Registry entry declares runtime "npm-global" but no npmGlobal.package/version. ` +
         `Report this to the integration maintainer.`,
@@ -71,9 +78,18 @@ function assertNpmGlobalService(
  * OPTIONAL in the registry schema — it is only present "if different from the
  * package name" — so fall back to the package name rather than printing
  * "Start it with: undefined".
+ *
+ * For a SCOPED package the package name is not a runnable command: installing
+ * `@acme/svc` globally puts `svc` on PATH, not `@acme/svc`. Falling back to the
+ * full specifier would print a start command that cannot work, which is the
+ * same class of bad guidance as the `undefined` this fallback was added to fix.
+ * npm's own convention is the unscoped segment, so that is what we print.
  */
 function resolveBinary(npmGlobal: NpmGlobalService['npmGlobal']): string {
-  return npmGlobal.binary?.trim() || npmGlobal.package;
+  const explicit = npmGlobal.binary?.trim();
+  if (explicit) return explicit;
+  const pkg = npmGlobal.package;
+  return pkg.startsWith('@') && pkg.includes('/') ? pkg.slice(pkg.indexOf('/') + 1) : pkg;
 }
 
 function buildPostInstructions(entry: IntegrationEntry, binary: string): string[] {

--- a/packages/cli/src/integrations/install-service.ts
+++ b/packages/cli/src/integrations/install-service.ts
@@ -156,8 +156,12 @@ export async function installService(
 ): Promise<InstallServiceResult> {
   const { entry, dryRun, skipProvenance, verifier, runner = runCommand, logger } = options;
   assertNpmGlobalService(entry.install);
-  const { package: pkg, version } = entry.install.npmGlobal;
-  const binary = resolveBinary(entry.install.npmGlobal);
+  // Use the RESOLVED values, not the raw payload: the resolver trims, and
+  // reading around it would send `"@acme/svc "` to npm with the space intact,
+  // making the trim decorative at the one place it has to hold. The assertion
+  // above guarantees this is non-null.
+  const { package: pkg, version } = resolveNpmGlobalService(entry.install)!;
+  const binary = resolveBinary({ ...entry.install.npmGlobal, package: pkg });
 
   const result = await installNpmGlobalPackage({
     entry,

--- a/packages/cli/src/integrations/install-service.ts
+++ b/packages/cli/src/integrations/install-service.ts
@@ -1,0 +1,153 @@
+// Installer for registry entries with `install.kind === "service"` and
+// `runtime: "npm-global"`.
+//
+// A service is a long-running process rather than a one-shot command, but the
+// npm-global mechanics are identical to `install.kind: "cli"` — same global
+// install, same pinned version, same provenance gate. The difference is the
+// post-install guidance: the operator needs to know how to keep it running and
+// which env vars it requires, not "run --help to get started".
+//
+// `docker` and `binary` runtimes are NOT handled here; commands.ts keeps them
+// on the explicit not-implemented path.
+
+import { spawn } from 'node:child_process';
+import type { InstallService, IntegrationEntry } from './schema.js';
+import { verifyNpmProvenance, type ProvenanceCheckResult } from './verify-npm-provenance.js';
+
+export type ProvenanceVerifier = (
+  pkg: string,
+  version: string,
+  expectedRepo: string,
+) => Promise<ProvenanceCheckResult>;
+
+export type InstallRunner = (cmd: string, args: string[]) => Promise<number>;
+
+export interface InstallServiceOptions {
+  entry: IntegrationEntry;
+  dryRun?: boolean;
+  skipProvenance?: boolean;
+  verifier?: ProvenanceVerifier;
+  runner?: InstallRunner;
+  logger?: (msg: string) => void;
+}
+
+export interface InstallServiceResult {
+  command: string;
+  args: string[];
+  exitCode: number;
+  binary: string;
+  postInstructions: string[];
+  provenance?: ProvenanceCheckResult;
+}
+
+type NpmGlobalService = InstallService & {
+  runtime: 'npm-global';
+  npmGlobal: NonNullable<InstallService['npmGlobal']>;
+};
+
+function assertNpmGlobalService(
+  spec: IntegrationEntry['install'],
+): asserts spec is NpmGlobalService {
+  if (spec.kind !== 'service') {
+    throw new Error(`install-service received non-service install spec (kind=${spec.kind})`);
+  }
+  if (spec.runtime !== 'npm-global') {
+    throw new Error(
+      `install-service only handles runtime "npm-global" (got "${spec.runtime}"). ` +
+        `docker and binary runtimes are not yet automated.`,
+    );
+  }
+  if (!spec.npmGlobal?.package || !spec.npmGlobal?.version) {
+    throw new Error(
+      `Registry entry declares runtime "npm-global" but no npmGlobal.package/version. ` +
+        `Report this to the integration maintainer.`,
+    );
+  }
+}
+
+function runCommand(cmd: string, args: string[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit', shell: process.platform === 'win32' });
+    child.on('error', reject);
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+function buildPostInstructions(entry: IntegrationEntry, binary: string): string[] {
+  const lines: string[] = [];
+  const spec = entry.install as InstallService;
+  lines.push(`This integration is a long-running service. Start it with:`);
+  lines.push(`  ${binary}`);
+  const env = spec.envRequired ?? [];
+  if (env.length > 0) {
+    lines.push('');
+    lines.push('It requires these environment variables:');
+    for (const name of env) lines.push(`  ${name}`);
+  }
+  if (spec.portsOpened?.length) {
+    lines.push('');
+    lines.push(`It listens on: ${spec.portsOpened.join(', ')}`);
+  }
+  lines.push('');
+  lines.push(
+    `Keep it running under your own process manager (systemd, pm2, docker, a terminal multiplexer) — ` +
+      `the DKG CLI does not supervise integrations.`,
+  );
+  lines.push(`Setup details: ${entry.repo}`);
+  return lines;
+}
+
+export async function installService(
+  options: InstallServiceOptions,
+): Promise<InstallServiceResult> {
+  const {
+    entry,
+    dryRun = false,
+    skipProvenance = false,
+    verifier = verifyNpmProvenance,
+    runner = runCommand,
+    logger = console.log,
+  } = options;
+  assertNpmGlobalService(entry.install);
+  const { package: pkg, version, binary } = entry.install.npmGlobal;
+
+  const command = 'npm';
+  const args = ['install', '--global', `${pkg}@${version}`];
+
+  // Same provenance gate as installCli: verify BEFORE touching the user's
+  // global npm, skipped in dry-run and under --no-verify-provenance.
+  let provenance: ProvenanceCheckResult | undefined;
+  if (!dryRun && !skipProvenance) {
+    logger(`Verifying publish-time provenance for ${pkg}@${version}...`);
+    provenance = await verifier(pkg, version, entry.repo);
+    if (!provenance.ok) {
+      logger('');
+      logger('  Provenance check FAILED:');
+      for (const r of provenance.reasons) logger(`    - ${r}`);
+      logger('');
+      throw new Error(
+        `Refusing to install ${pkg}@${version}: the tarball on npm is not ` +
+          `cryptographically bound to ${entry.repo}. Re-run with --no-verify-provenance ` +
+          `to install anyway.`,
+      );
+    }
+    logger(`  ok — tarball is attested and points at ${entry.repo}.`);
+    logger('');
+  }
+
+  logger(`Installing service ${pkg}@${version} globally via npm...`);
+  logger(`  ${command} ${args.join(' ')}`);
+
+  const postInstructions = buildPostInstructions(entry, binary);
+
+  if (dryRun) {
+    return { command, args, exitCode: 0, binary, postInstructions, provenance };
+  }
+
+  const exitCode = await runner(command, args);
+  if (exitCode !== 0) {
+    throw new Error(`npm install failed with exit code ${exitCode}. See output above for details.`);
+  }
+
+  return { command, args, exitCode, binary, postInstructions, provenance };
+}

--- a/packages/cli/src/integrations/install-service.ts
+++ b/packages/cli/src/integrations/install-service.ts
@@ -44,6 +44,33 @@ type NpmGlobalService = InstallService & {
   npmGlobal: NonNullable<InstallService['npmGlobal']>;
 };
 
+/**
+ * THE definition of "an npm-global service this CLI can install", returning the
+ * trimmed payload or null. Exported so the Commander dispatcher and this
+ * installer share one predicate instead of two that agree by coincidence.
+ *
+ * They previously disagreed: the dispatcher gated on truthiness while this file
+ * required non-empty strings after trimming, so a registry-valid
+ * `{ package: '   ', version: '1.0.0' }` passed the dispatcher, threw in here,
+ * and surfaced as a generic "Install failed" instead of the graceful
+ * not-automatable message — the exact failure the dispatcher gate was added to
+ * prevent, reachable through a gap between the two checks.
+ *
+ * Checked by TYPE, not truthiness: a non-string `package` is truthy and would
+ * otherwise reach the npm spec as `[object Object]@1.0.0`.
+ */
+export function resolveNpmGlobalService(
+  install: IntegrationEntry['install'],
+): { package: string; version: string } | null {
+  if (install.kind !== 'service' || install.runtime !== 'npm-global') return null;
+  const n = install.npmGlobal;
+  if (typeof n?.package !== 'string' || typeof n.version !== 'string') return null;
+  const pkg = n.package.trim();
+  const version = n.version.trim();
+  if (!pkg || !version) return null;
+  return { package: pkg, version };
+}
+
 function assertNpmGlobalService(
   spec: IntegrationEntry['install'],
 ): asserts spec is NpmGlobalService {
@@ -56,16 +83,7 @@ function assertNpmGlobalService(
         `docker and binary runtimes are not yet automated.`,
     );
   }
-  // The schema requires package + version; `binary` is optional and defaults to
-  // the package name (see resolveBinary). Checked by TYPE, not truthiness: a
-  // non-string `package` is truthy and would reach the npm spec as
-  // `[object Object]@1.0.0` instead of being rejected as malformed.
-  if (
-    typeof spec.npmGlobal?.package !== 'string' ||
-    typeof spec.npmGlobal.version !== 'string' ||
-    !spec.npmGlobal.package.trim() ||
-    !spec.npmGlobal.version.trim()
-  ) {
+  if (resolveNpmGlobalService(spec) === null) {
     throw new Error(
       `Registry entry declares runtime "npm-global" but no npmGlobal.package/version. ` +
         `Report this to the integration maintainer.`,

--- a/packages/cli/src/integrations/install-service.ts
+++ b/packages/cli/src/integrations/install-service.ts
@@ -18,7 +18,7 @@ import {
   type InstallRunner,
   type ProvenanceVerifier,
 } from './install-npm-global.js';
-import type { InstallService, IntegrationEntry } from './schema.js';
+import { resolveNpmGlobalService, type InstallService, type IntegrationEntry } from './schema.js';
 import type { ProvenanceCheckResult } from './verify-npm-provenance.js';
 
 export interface InstallServiceOptions {
@@ -28,6 +28,13 @@ export interface InstallServiceOptions {
   verifier?: ProvenanceVerifier;
   runner?: InstallRunner;
   logger?: (msg: string) => void;
+  /**
+   * The node the operator selected with `--api-url`. Rendered into the
+   * DKG_API_URL guidance: `installMcp` already honours this flag, so a service
+   * printing the hardcoded default would send an operator who passed
+   * `--api-url` to the wrong node while the same flag worked for mcp entries.
+   */
+  apiUrl?: string;
 }
 
 export interface InstallServiceResult {
@@ -43,33 +50,6 @@ type NpmGlobalService = InstallService & {
   runtime: 'npm-global';
   npmGlobal: NonNullable<InstallService['npmGlobal']>;
 };
-
-/**
- * THE definition of "an npm-global service this CLI can install", returning the
- * trimmed payload or null. Exported so the Commander dispatcher and this
- * installer share one predicate instead of two that agree by coincidence.
- *
- * They previously disagreed: the dispatcher gated on truthiness while this file
- * required non-empty strings after trimming, so a registry-valid
- * `{ package: '   ', version: '1.0.0' }` passed the dispatcher, threw in here,
- * and surfaced as a generic "Install failed" instead of the graceful
- * not-automatable message — the exact failure the dispatcher gate was added to
- * prevent, reachable through a gap between the two checks.
- *
- * Checked by TYPE, not truthiness: a non-string `package` is truthy and would
- * otherwise reach the npm spec as `[object Object]@1.0.0`.
- */
-export function resolveNpmGlobalService(
-  install: IntegrationEntry['install'],
-): { package: string; version: string } | null {
-  if (install.kind !== 'service' || install.runtime !== 'npm-global') return null;
-  const n = install.npmGlobal;
-  if (typeof n?.package !== 'string' || typeof n.version !== 'string') return null;
-  const pkg = n.package.trim();
-  const version = n.version.trim();
-  if (!pkg || !version) return null;
-  return { package: pkg, version };
-}
 
 function assertNpmGlobalService(
   spec: IntegrationEntry['install'],
@@ -110,7 +90,11 @@ function resolveBinary(npmGlobal: NpmGlobalService['npmGlobal']): string {
   return pkg.startsWith('@') && pkg.includes('/') ? pkg.slice(pkg.indexOf('/') + 1) : pkg;
 }
 
-function buildPostInstructions(entry: IntegrationEntry, binary: string): string[] {
+function buildPostInstructions(
+  entry: IntegrationEntry,
+  binary: string,
+  apiUrl: string | undefined,
+): string[] {
   const spec = entry.install as InstallService;
   const lines: string[] = [];
   lines.push(`This integration is a long-running service. Start it with:`);
@@ -124,7 +108,13 @@ function buildPostInstructions(entry: IntegrationEntry, binary: string): string[
       if (name === 'DKG_AUTH_TOKEN') {
         lines.push(`  ${name}  — pull from \`dkg auth show\` or ${join(dkgDir(), 'auth.token')}`);
       } else if (name === 'DKG_API_URL') {
-        lines.push(`  ${name}    — default http://127.0.0.1:9200`);
+        // Echo the node the operator actually selected. Printing the default
+        // when they passed --api-url points the service at the wrong node.
+        lines.push(
+          apiUrl
+            ? `  ${name}    — ${apiUrl}`
+            : `  ${name}    — default http://127.0.0.1:9200`,
+        );
       } else {
         lines.push(`  ${name}`);
       }
@@ -154,7 +144,7 @@ function buildPostInstructions(entry: IntegrationEntry, binary: string): string[
 export async function installService(
   options: InstallServiceOptions,
 ): Promise<InstallServiceResult> {
-  const { entry, dryRun, skipProvenance, verifier, runner = runCommand, logger } = options;
+  const { entry, dryRun, skipProvenance, verifier, runner = runCommand, logger, apiUrl } = options;
   assertNpmGlobalService(entry.install);
   // Use the RESOLVED values, not the raw payload: the resolver trims, and
   // reading around it would send `"@acme/svc "` to npm with the space intact,
@@ -178,6 +168,6 @@ export async function installService(
   return {
     ...result,
     binary,
-    postInstructions: buildPostInstructions(entry, binary),
+    postInstructions: buildPostInstructions(entry, binary, apiUrl),
   };
 }

--- a/packages/cli/src/integrations/install-service.ts
+++ b/packages/cli/src/integrations/install-service.ts
@@ -2,25 +2,24 @@
 // `runtime: "npm-global"`.
 //
 // A service is a long-running process rather than a one-shot command, but the
-// npm-global mechanics are identical to `install.kind: "cli"` — same global
-// install, same pinned version, same provenance gate. The difference is the
-// post-install guidance: the operator needs to know how to keep it running and
-// which env vars it requires, not "run --help to get started".
+// npm-global mechanics are identical to `install.kind: "cli"`, so both share
+// installNpmGlobalPackage(). What differs is the post-install guidance: the
+// operator needs to know how to keep it running and which env vars it requires,
+// not "run --help to get started".
 //
 // `docker` and `binary` runtimes are NOT handled here; commands.ts keeps them
 // on the explicit not-implemented path.
 
-import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { dkgDir } from '../config.js';
+import {
+  installNpmGlobalPackage,
+  runCommand,
+  type InstallRunner,
+  type ProvenanceVerifier,
+} from './install-npm-global.js';
 import type { InstallService, IntegrationEntry } from './schema.js';
-import { verifyNpmProvenance, type ProvenanceCheckResult } from './verify-npm-provenance.js';
-
-export type ProvenanceVerifier = (
-  pkg: string,
-  version: string,
-  expectedRepo: string,
-) => Promise<ProvenanceCheckResult>;
-
-export type InstallRunner = (cmd: string, args: string[]) => Promise<number>;
+import type { ProvenanceCheckResult } from './verify-npm-provenance.js';
 
 export interface InstallServiceOptions {
   entry: IntegrationEntry;
@@ -57,6 +56,8 @@ function assertNpmGlobalService(
         `docker and binary runtimes are not yet automated.`,
     );
   }
+  // The schema requires package + version; `binary` is optional and defaults to
+  // the package name (see resolveBinary).
   if (!spec.npmGlobal?.package || !spec.npmGlobal?.version) {
     throw new Error(
       `Registry entry declares runtime "npm-global" but no npmGlobal.package/version. ` +
@@ -65,33 +66,52 @@ function assertNpmGlobalService(
   }
 }
 
-function runCommand(cmd: string, args: string[]): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: 'inherit', shell: process.platform === 'win32' });
-    child.on('error', reject);
-    child.on('close', (code) => resolve(code ?? 1));
-  });
+/**
+ * The command an operator runs to start the service. `npmGlobal.binary` is
+ * OPTIONAL in the registry schema — it is only present "if different from the
+ * package name" — so fall back to the package name rather than printing
+ * "Start it with: undefined".
+ */
+function resolveBinary(npmGlobal: NpmGlobalService['npmGlobal']): string {
+  return npmGlobal.binary?.trim() || npmGlobal.package;
 }
 
 function buildPostInstructions(entry: IntegrationEntry, binary: string): string[] {
-  const lines: string[] = [];
   const spec = entry.install as InstallService;
+  const lines: string[] = [];
   lines.push(`This integration is a long-running service. Start it with:`);
   lines.push(`  ${binary}`);
+
   const env = spec.envRequired ?? [];
   if (env.length > 0) {
     lines.push('');
-    lines.push('It requires these environment variables:');
-    for (const name of env) lines.push(`  ${name}`);
+    lines.push('Required environment:');
+    for (const name of env) {
+      if (name === 'DKG_AUTH_TOKEN') {
+        lines.push(`  ${name}  — pull from \`dkg auth show\` or ${join(dkgDir(), 'auth.token')}`);
+      } else if (name === 'DKG_API_URL') {
+        lines.push(`  ${name}    — default http://127.0.0.1:9200`);
+      } else {
+        lines.push(`  ${name}`);
+      }
+    }
   }
+
   if (spec.portsOpened?.length) {
     lines.push('');
     lines.push(`It listens on: ${spec.portsOpened.join(', ')}`);
   }
+
+  if (spec.usageHint) {
+    lines.push('');
+    lines.push('Usage:');
+    for (const line of spec.usageHint.split('\n')) lines.push(`  ${line}`);
+  }
+
   lines.push('');
   lines.push(
-    `Keep it running under your own process manager (systemd, pm2, docker, a terminal multiplexer) — ` +
-      `the DKG CLI does not supervise integrations.`,
+    `Keep it running under your own process manager (systemd, pm2, docker, a terminal ` +
+      `multiplexer) — the DKG CLI does not supervise integrations.`,
   );
   lines.push(`Setup details: ${entry.repo}`);
   return lines;
@@ -100,54 +120,26 @@ function buildPostInstructions(entry: IntegrationEntry, binary: string): string[
 export async function installService(
   options: InstallServiceOptions,
 ): Promise<InstallServiceResult> {
-  const {
-    entry,
-    dryRun = false,
-    skipProvenance = false,
-    verifier = verifyNpmProvenance,
-    runner = runCommand,
-    logger = console.log,
-  } = options;
+  const { entry, dryRun, skipProvenance, verifier, runner = runCommand, logger } = options;
   assertNpmGlobalService(entry.install);
-  const { package: pkg, version, binary } = entry.install.npmGlobal;
+  const { package: pkg, version } = entry.install.npmGlobal;
+  const binary = resolveBinary(entry.install.npmGlobal);
 
-  const command = 'npm';
-  const args = ['install', '--global', `${pkg}@${version}`];
+  const result = await installNpmGlobalPackage({
+    entry,
+    pkg,
+    version,
+    dryRun,
+    skipProvenance,
+    verifier,
+    runner,
+    logger,
+    label: 'service',
+  });
 
-  // Same provenance gate as installCli: verify BEFORE touching the user's
-  // global npm, skipped in dry-run and under --no-verify-provenance.
-  let provenance: ProvenanceCheckResult | undefined;
-  if (!dryRun && !skipProvenance) {
-    logger(`Verifying publish-time provenance for ${pkg}@${version}...`);
-    provenance = await verifier(pkg, version, entry.repo);
-    if (!provenance.ok) {
-      logger('');
-      logger('  Provenance check FAILED:');
-      for (const r of provenance.reasons) logger(`    - ${r}`);
-      logger('');
-      throw new Error(
-        `Refusing to install ${pkg}@${version}: the tarball on npm is not ` +
-          `cryptographically bound to ${entry.repo}. Re-run with --no-verify-provenance ` +
-          `to install anyway.`,
-      );
-    }
-    logger(`  ok — tarball is attested and points at ${entry.repo}.`);
-    logger('');
-  }
-
-  logger(`Installing service ${pkg}@${version} globally via npm...`);
-  logger(`  ${command} ${args.join(' ')}`);
-
-  const postInstructions = buildPostInstructions(entry, binary);
-
-  if (dryRun) {
-    return { command, args, exitCode: 0, binary, postInstructions, provenance };
-  }
-
-  const exitCode = await runner(command, args);
-  if (exitCode !== 0) {
-    throw new Error(`npm install failed with exit code ${exitCode}. See output above for details.`);
-  }
-
-  return { command, args, exitCode, binary, postInstructions, provenance };
+  return {
+    ...result,
+    binary,
+    postInstructions: buildPostInstructions(entry, binary),
+  };
 }

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -102,6 +102,33 @@ export interface InstallManual {
   usageHint?: string;
 }
 
+/**
+ * THE definition of "an npm-global service this CLI can act on", returning the
+ * trimmed payload or null.
+ *
+ * Lives here rather than in the installer because three unrelated callers need
+ * it — the Commander dispatcher, the installer, and installed-detection — and
+ * every time it has existed in only one of them the others have drifted:
+ * the dispatcher once gated on truthiness while the installer trimmed (a
+ * whitespace package reached a generic failure), and detection once probed npm
+ * with the raw, untrimmed key (so a padded `" @acme/svc "` installed as
+ * `@acme/svc` and then reported itself not installed).
+ *
+ * Checked by TYPE, not truthiness: a non-string `package` is truthy and would
+ * otherwise reach the npm spec as `[object Object]@1.0.0`.
+ */
+export function resolveNpmGlobalService(
+  install: InstallSpec,
+): { package: string; version: string } | null {
+  if (install.kind !== 'service' || install.runtime !== 'npm-global') return null;
+  const n = install.npmGlobal;
+  if (typeof n?.package !== 'string' || typeof n.version !== 'string') return null;
+  const pkg = n.package.trim();
+  const version = n.version.trim();
+  if (!pkg || !version) return null;
+  return { package: pkg, version };
+}
+
 export interface IntegrationEntry {
   slug: string;
   name: string;

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -28,7 +28,9 @@ export interface InstallCli {
 export interface InstallMcp {
   kind: 'mcp';
   command: string;
-  args: string[];
+  // Optional per the registry schema. An entry without args is readable
+  // (listed, inspectable) but not installable — installMcp refuses it.
+  args?: string[];
   // Env var NAMES the MCP server expects. Per the registry schema,
   // DKG_AUTH_TOKEN and DKG_API_URL are auto-filled by the installer when
   // listed here; other names are rendered as placeholders the user must
@@ -41,7 +43,7 @@ export interface InstallMcp {
 
 export interface InstallService {
   kind: 'service';
-  runtime: 'docker' | 'npm-global';
+  runtime: 'docker' | 'npm-global' | 'binary';
   docker?: {
     image: string;
     digest?: string;
@@ -54,6 +56,13 @@ export interface InstallService {
     binary: string;
     env?: Record<string, string>;
   };
+  binaryDownload?: {
+    url: string;
+    checksumSha256?: string;
+  };
+  // Present in the registry schema; surfaced in post-install guidance.
+  envRequired?: string[];
+  portsOpened?: number[];
   usageHint?: string;
 }
 
@@ -68,7 +77,11 @@ export interface InstallAgentPlugin {
 
 export interface InstallManual {
   kind: 'manual';
-  steps: string[];
+  // The registry schema requires docsUrl and allows only oneLiner beyond it
+  // (additionalProperties: false). `manual` means the installer links out to
+  // the integration's own docs rather than automating anything.
+  docsUrl: string;
+  oneLiner?: string;
   usageHint?: string;
 }
 
@@ -167,6 +180,16 @@ function isStringArray(v: unknown): boolean {
   return Array.isArray(v) && v.every((x) => typeof x === 'string');
 }
 
+// INVARIANT: this must never be STRICTER than the registry's published JSON
+// Schema (https://origintrail.io/schemas/integration/v0.1.0.json, $defs.install*).
+// It may be more lenient — unknown fields and unknown enum values must ride
+// through so an older CLI can still read a newer registry — but every entry the
+// registry can merge has to parse here, or `dkg integration` and the dashboard
+// sidebar silently drop it as "unreadable". Three divergences did exactly that:
+// `manual` required a `steps` field the schema forbids, `mcp` required the
+// schema-optional `args`, and `service` rejected the schema's `binary` runtime.
+// Requirements that make an entry *installable* (rather than readable) belong in
+// the installers, not here — see installMcp's args check.
 function isValidInstallSpec(v: unknown): boolean {
   if (!isPlainObject(v)) return false;
   const kind = v.kind;
@@ -180,14 +203,17 @@ function isValidInstallSpec(v: unknown): boolean {
         (v.usageHint === undefined || typeof v.usageHint === 'string')
       );
     case 'mcp':
+      // `args` is optional per the schema. An entry without it is readable but
+      // not installable; installMcp refuses it rather than emitting a config
+      // with no launch arguments.
       return (
         typeof v.command === 'string' &&
-        isStringArray(v.args) &&
+        (v.args === undefined || isStringArray(v.args)) &&
         (v.envRequired === undefined || isStringArray(v.envRequired)) &&
         (v.supportedClients === undefined || isStringArray(v.supportedClients))
       );
     case 'service':
-      return v.runtime === 'docker' || v.runtime === 'npm-global';
+      return v.runtime === 'docker' || v.runtime === 'npm-global' || v.runtime === 'binary';
     case 'agent-plugin':
       return (
         typeof v.framework === 'string' &&
@@ -195,7 +221,12 @@ function isValidInstallSpec(v: unknown): boolean {
         typeof v.version === 'string'
       );
     case 'manual':
-      return isStringArray(v.steps);
+      // The schema requires docsUrl and forbids anything else beyond oneLiner;
+      // `manual` means "the installer links out to your docs" (CONTRIBUTING §2).
+      return (
+        typeof v.docsUrl === 'string' &&
+        (v.oneLiner === undefined || typeof v.oneLiner === 'string')
+      );
     default:
       return false;
   }

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -222,8 +222,40 @@ function isValidInstallSpec(v: unknown): boolean {
         (v.envRequired === undefined || isStringArray(v.envRequired)) &&
         (v.supportedClients === undefined || isStringArray(v.supportedClients))
       );
-    case 'service':
-      return v.runtime === 'docker' || v.runtime === 'npm-global' || v.runtime === 'binary';
+    case 'service': {
+      if (v.runtime !== 'docker' && v.runtime !== 'npm-global' && v.runtime !== 'binary') {
+        return false;
+      }
+      // Every payload object is OPTIONAL per the schema, so a bare
+      // { kind, runtime } stays readable. But when one IS present the schema
+      // marks its own fields required, and these now drive a global npm
+      // install — so validating them here is schema-CONSISTENT, not stricter.
+      // Without it `npmGlobal: { package: { name: 'x' }, version: '1' }` parses
+      // and the installer builds `[object Object]@1`.
+      if (v.npmGlobal !== undefined) {
+        if (!isPlainObject(v.npmGlobal)) return false;
+        const n = v.npmGlobal;
+        if (typeof n.package !== 'string' || typeof n.version !== 'string') return false;
+        if (n.binary !== undefined && typeof n.binary !== 'string') return false;
+      }
+      if (v.docker !== undefined) {
+        if (!isPlainObject(v.docker)) return false;
+        const d = v.docker;
+        if (typeof d.image !== 'string' || typeof d.version !== 'string') return false;
+      }
+      if (v.binary !== undefined) {
+        if (!isPlainObject(v.binary)) return false;
+        if (typeof (v.binary as Record<string, unknown>).url !== 'string') return false;
+      }
+      if (v.envRequired !== undefined && !isStringArray(v.envRequired)) return false;
+      if (
+        v.portsOpened !== undefined &&
+        (!Array.isArray(v.portsOpened) || !v.portsOpened.every((p) => typeof p === 'number'))
+      ) {
+        return false;
+      }
+      return true;
+    }
     case 'agent-plugin':
       return (
         typeof v.framework === 'string' &&

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -56,7 +56,10 @@ export interface InstallService {
     binary: string;
     env?: Record<string, string>;
   };
-  binaryDownload?: {
+  // Named `binary` to match the registry schema exactly. A maintainer
+  // implementing runtime: 'binary' reads entry.install.binary.url from a real
+  // entry, so the type must not invent a different name for it.
+  binary?: {
     url: string;
     checksumSha256?: string;
   };

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -28,8 +28,10 @@ export interface InstallCli {
 export interface InstallMcp {
   kind: 'mcp';
   command: string;
-  // Optional per the registry schema. An entry without args is readable
-  // (listed, inspectable) but not installable — installMcp refuses it.
+  // Optional per the registry schema, and genuinely optional here: a server
+  // launched by a binary already on PATH needs none, so installMcp normalises
+  // a missing value to `args: []` rather than refusing the entry. Judging
+  // whether a given command needs arguments is the entry author's call.
   args?: string[];
   // Env var NAMES the MCP server expects. Per the registry schema,
   // DKG_AUTH_TOKEN and DKG_API_URL are auto-filled by the installer when

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -46,11 +46,19 @@ export interface InstallMcp {
 export interface InstallService {
   kind: 'service';
   runtime: 'docker' | 'npm-global' | 'binary';
+  // Mirrors the registry schema's installService.docker exactly: it requires
+  // image + version and forbids anything beyond digest/composeUrl
+  // (additionalProperties: false), so no valid entry can carry more than this.
+  // `version` was missing here while the runtime guard validates it — a type
+  // that disagrees with its own validator is worse than either alone, because a
+  // future docker installer would be told the field exists by one and not the
+  // other. `ports` and `env` were invented, had no readers, and could never
+  // appear in a registry entry.
   docker?: {
     image: string;
+    version: string;
     digest?: string;
-    ports?: Array<{ container: number; host?: number }>;
-    env?: Record<string, string>;
+    composeUrl?: string;
   };
   npmGlobal?: {
     package: string;
@@ -61,7 +69,6 @@ export interface InstallService {
     // single normalization point that falls back to the package name — the
     // type must not claim a guarantee the registry does not make.
     binary?: string;
-    env?: Record<string, string>;
   };
   // Named `binary` to match the registry schema exactly. A maintainer
   // implementing runtime: 'binary' reads entry.install.binary.url from a real

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -55,7 +55,12 @@ export interface InstallService {
   npmGlobal?: {
     package: string;
     version: string;
-    binary: string;
+    // Optional in the registry schema (only package + version are required),
+    // and genuinely optional here: an entry whose binary name matches its
+    // package name omits it. `resolveBinary` in install-service.ts is the
+    // single normalization point that falls back to the package name — the
+    // type must not claim a guarantee the registry does not make.
+    binary?: string;
     env?: Record<string, string>;
   };
   // Named `binary` to match the registry schema exactly. A maintainer

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1012,11 +1012,24 @@ function readConfigBody(target: ClientTarget): Record<string, unknown> {
   }
 }
 
+/** The launch shape of one registered MCP server, as the client stores it. */
+export interface RegisteredMcpServer {
+  command: string;
+  args: string[];
+}
+
 /**
  * Outcome of inspecting one client config for registered MCP servers.
  * `ok: false` is "we could not look", never "we looked and found nothing".
+ *
+ * Carries the blocks rather than only their names. A server registered under a
+ * slug is evidence that THAT integration is installed only if it also launches
+ * what the registry entry says it should — the name alone cannot tell a real
+ * installation apart from an unrelated server that happens to share it.
  */
-export type ServerKeyProbe = { ok: true; keys: string[] } | { ok: false; reason: string };
+export type ServerKeyProbe =
+  | { ok: true; servers: Record<string, RegisteredMcpServer> }
+  | { ok: false; reason: string };
 
 /**
  * Names of every MCP server registered in a client's config, whatever container
@@ -1043,31 +1056,40 @@ export function readRegisteredServerKeys(target: ClientTarget): ServerKeyProbe {
   } catch (err) {
     // A config that does not exist IS a real answer: this client has
     // registered nothing. Anything else means the file is there and we failed.
-    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return { ok: true, keys: [] };
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return { ok: true, servers: {} };
     return { ok: false, reason: `could not read ${target.displayPath}` };
   }
   const { head } = splitEntryPath(target.entryPath);
   let cursor: unknown = body;
   for (const segment of head) {
-    if (cursor === null || typeof cursor !== 'object') return { ok: true, keys: [] };
+    if (cursor === null || typeof cursor !== 'object') return { ok: true, servers: {} };
     cursor = (cursor as Record<string, unknown>)[segment];
   }
   // Missing container: readable config, nothing registered.
-  if (cursor === undefined) return { ok: true, keys: [] };
+  if (cursor === undefined) return { ok: true, servers: {} };
   // Present but not an object: malformed exactly where we needed to read.
   if (cursor === null || typeof cursor !== 'object') {
     return { ok: false, reason: `malformed server container in ${target.displayPath}` };
   }
   // Only entries that could actually launch count as registrations. `classify`
   // above already treats `{ dkg: null }` as not-registered (deliberately —
-  // pre-F7 it read as `stale` and claimed there was a value to refresh); a key
-  // whose value is null, scalar, or an array is the same non-registration, and
-  // reporting it as an install would be a false positive in the other
-  // direction from the unreadable-config case.
-  const entries = Object.entries(cursor as Record<string, unknown>).filter(
-    ([, v]) => v !== null && typeof v === 'object' && !Array.isArray(v),
-  );
-  return { ok: true, keys: entries.map(([k]) => k) };
+  // pre-F7 it read as `stale` and claimed there was a value to refresh). A
+  // value that is null, scalar, an array, or an object carrying no `command`
+  // is the same non-registration: nothing there can start. Counting one would
+  // be a false positive, the opposite failure from the unreadable-config case.
+  const servers: Record<string, RegisteredMcpServer> = {};
+  for (const [name, value] of Object.entries(cursor as Record<string, unknown>)) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) continue;
+    const block = value as Record<string, unknown>;
+    if (typeof block.command !== 'string') continue;
+    servers[name] = {
+      command: block.command,
+      args: Array.isArray(block.args)
+        ? block.args.filter((a): a is string => typeof a === 'string')
+        : [],
+    };
+  }
+  return { ok: true, servers };
 }
 
 function serialiseTomlEntryOnly(

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1058,7 +1058,16 @@ export function readRegisteredServerKeys(target: ClientTarget): ServerKeyProbe {
   if (cursor === null || typeof cursor !== 'object') {
     return { ok: false, reason: `malformed server container in ${target.displayPath}` };
   }
-  return { ok: true, keys: Object.keys(cursor as Record<string, unknown>) };
+  // Only entries that could actually launch count as registrations. `classify`
+  // above already treats `{ dkg: null }` as not-registered (deliberately —
+  // pre-F7 it read as `stale` and claimed there was a value to refresh); a key
+  // whose value is null, scalar, or an array is the same non-registration, and
+  // reporting it as an install would be a false positive in the other
+  // direction from the unreadable-config case.
+  const entries = Object.entries(cursor as Record<string, unknown>).filter(
+    ([, v]) => v !== null && typeof v === 'object' && !Array.isArray(v),
+  );
+  return { ok: true, keys: entries.map(([k]) => k) };
 }
 
 function serialiseTomlEntryOnly(

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1013,6 +1013,12 @@ function readConfigBody(target: ClientTarget): Record<string, unknown> {
 }
 
 /**
+ * Outcome of inspecting one client config for registered MCP servers.
+ * `ok: false` is "we could not look", never "we looked and found nothing".
+ */
+export type ServerKeyProbe = { ok: true; keys: string[] } | { ok: false; reason: string };
+
+/**
  * Names of every MCP server registered in a client's config, whatever container
  * that client uses (`mcpServers`, `servers`, `mcp_servers`) and whatever format
  * it is written in (JSON, TOML).
@@ -1023,24 +1029,36 @@ function readConfigBody(target: ClientTarget): Record<string, unknown> {
  * same client targets and container paths that `dkg mcp setup` writes, rather
  * than maintaining a second, narrower list that silently misses clients.
  *
- * Returns [] for a missing, unreadable, or unparseable config — absence of
- * evidence, not evidence of absence.
+ * Absence of evidence is not evidence of absence, so the two are returned as
+ * different values rather than both as []. `ok: false` means we could not look
+ * — the file is present but unreadable, unparseable, or malformed at the
+ * container we needed. A caller that reports install state must not render
+ * that as "not installed": it would tell a user an integration is missing when
+ * the truth is that their config could not be read.
  */
-export function readRegisteredServerKeys(target: ClientTarget): string[] {
+export function readRegisteredServerKeys(target: ClientTarget): ServerKeyProbe {
   let body: Record<string, unknown>;
   try {
     body = readConfigBody(target);
-  } catch {
-    return [];
+  } catch (err) {
+    // A config that does not exist IS a real answer: this client has
+    // registered nothing. Anything else means the file is there and we failed.
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return { ok: true, keys: [] };
+    return { ok: false, reason: `could not read ${target.displayPath}` };
   }
   const { head } = splitEntryPath(target.entryPath);
   let cursor: unknown = body;
   for (const segment of head) {
-    if (cursor === null || typeof cursor !== 'object') return [];
+    if (cursor === null || typeof cursor !== 'object') return { ok: true, keys: [] };
     cursor = (cursor as Record<string, unknown>)[segment];
   }
-  if (cursor === null || typeof cursor !== 'object') return [];
-  return Object.keys(cursor as Record<string, unknown>);
+  // Missing container: readable config, nothing registered.
+  if (cursor === undefined) return { ok: true, keys: [] };
+  // Present but not an object: malformed exactly where we needed to read.
+  if (cursor === null || typeof cursor !== 'object') {
+    return { ok: false, reason: `malformed server container in ${target.displayPath}` };
+  }
+  return { ok: true, keys: Object.keys(cursor as Record<string, unknown>) };
 }
 
 function serialiseTomlEntryOnly(

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1015,7 +1015,14 @@ function readConfigBody(target: ClientTarget): Record<string, unknown> {
 /** The launch shape of one registered MCP server, as the client stores it. */
 export interface RegisteredMcpServer {
   command: string;
-  args: string[];
+  /**
+   * The declared launch arguments. `[]` means the key was absent — a legitimate
+   * args-less server. `null` means the key was PRESENT but is not a string
+   * array, which is not a launch block we can compare. The distinction matters:
+   * quietly dropping a non-string element would rewrite `args: [123]` into `[]`
+   * and let it match an args-less registry entry, manufacturing an install.
+   */
+  args: string[] | null;
   /** String-valued env entries only; non-string values are not represented. */
   env?: Record<string, string>;
 }
@@ -1090,13 +1097,15 @@ export function readRegisteredServerKeys(target: ClientTarget): ServerKeyProbe {
         if (typeof val === 'string') env[k] = val;
       }
     }
-    servers[name] = {
-      command: block.command,
-      args: Array.isArray(block.args)
-        ? block.args.filter((a): a is string => typeof a === 'string')
-        : [],
-      env,
-    };
+    let args: string[] | null;
+    if (block.args === undefined) {
+      args = []; // absent: a legitimate args-less server
+    } else if (Array.isArray(block.args) && block.args.every((a) => typeof a === 'string')) {
+      args = block.args as string[];
+    } else {
+      args = null; // present but not a string array — not comparable
+    }
+    servers[name] = { command: block.command, args, env };
   }
   return { ok: true, servers };
 }

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1076,8 +1076,13 @@ export function readRegisteredServerKeys(target: ClientTarget): ServerKeyProbe {
   }
   // Missing container: readable config, nothing registered.
   if (cursor === undefined) return { ok: true, servers: {} };
-  // Present but not an object: malformed exactly where we needed to read.
-  if (cursor === null || typeof cursor !== 'object') {
+  // Present but not a KEYED object: malformed exactly where we needed to read.
+  // An array counts — `typeof [] === 'object'`, so without the explicit check it
+  // fell through to Object.entries([]) and reported "readable, nothing
+  // registered": a confident claim about a container we cannot interpret. The
+  // entry-level filter below already rejected arrays; the container needed the
+  // same treatment.
+  if (cursor === null || typeof cursor !== 'object' || Array.isArray(cursor)) {
     return { ok: false, reason: `malformed server container in ${target.displayPath}` };
   }
   // Only entries that could actually launch count as registrations. `classify`

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1016,6 +1016,8 @@ function readConfigBody(target: ClientTarget): Record<string, unknown> {
 export interface RegisteredMcpServer {
   command: string;
   args: string[];
+  /** String-valued env entries only; non-string values are not represented. */
+  env?: Record<string, string>;
 }
 
 /**
@@ -1082,11 +1084,18 @@ export function readRegisteredServerKeys(target: ClientTarget): ServerKeyProbe {
     if (value === null || typeof value !== 'object' || Array.isArray(value)) continue;
     const block = value as Record<string, unknown>;
     if (typeof block.command !== 'string') continue;
+    const env: Record<string, string> = {};
+    if (block.env !== null && typeof block.env === 'object' && !Array.isArray(block.env)) {
+      for (const [k, val] of Object.entries(block.env as Record<string, unknown>)) {
+        if (typeof val === 'string') env[k] = val;
+      }
+    }
     servers[name] = {
       command: block.command,
       args: Array.isArray(block.args)
         ? block.args.filter((a): a is string => typeof a === 'string')
         : [],
+      env,
     };
   }
   return { ok: true, servers };

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -491,7 +491,7 @@ function detectContext(
     : { context: 'installed', monorepoRoot: null };
 }
 
-interface ClientTarget {
+export interface ClientTarget {
   name: string;
   configPath: string;
   /** Pretty path for display, with `~` substituted back in. */
@@ -1010,6 +1010,37 @@ function readConfigBody(target: ClientTarget): Record<string, unknown> {
     default:
       throw new Error(`Unknown client config format: ${String(format)}`);
   }
+}
+
+/**
+ * Names of every MCP server registered in a client's config, whatever container
+ * that client uses (`mcpServers`, `servers`, `mcp_servers`) and whatever format
+ * it is written in (JSON, TOML).
+ *
+ * `dkg mcp setup` cares about one fixed leaf (`…dkg`); integration detection
+ * needs the sibling keys instead, because an installed integration registers
+ * itself under its own slug. Exposed here so `dkg integration list` reads the
+ * same client targets and container paths that `dkg mcp setup` writes, rather
+ * than maintaining a second, narrower list that silently misses clients.
+ *
+ * Returns [] for a missing, unreadable, or unparseable config — absence of
+ * evidence, not evidence of absence.
+ */
+export function readRegisteredServerKeys(target: ClientTarget): string[] {
+  let body: Record<string, unknown>;
+  try {
+    body = readConfigBody(target);
+  } catch {
+    return [];
+  }
+  const { head } = splitEntryPath(target.entryPath);
+  let cursor: unknown = body;
+  for (const segment of head) {
+    if (cursor === null || typeof cursor !== 'object') return [];
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  if (cursor === null || typeof cursor !== 'object') return [];
+  return Object.keys(cursor as Record<string, unknown>);
 }
 
 function serialiseTomlEntryOnly(

--- a/packages/cli/test/fixtures/registry/README.md
+++ b/packages/cli/test/fixtures/registry/README.md
@@ -1,0 +1,22 @@
+# Vendored registry fixtures
+
+Verbatim copies of the live entries on `OriginTrail/dkg-integrations@main`, plus
+the published JSON Schema they are validated against.
+
+They exist so `integrations.test.ts` can assert that **every entry the registry
+can merge is readable by this CLI** without making the suite network-dependent.
+That contract had no test, and the CLI's hand-written validator silently drifted
+stricter than the schema in three places — `manual` required a `steps` field the
+schema forbids, `mcp` required the schema-optional `args`, and `service` rejected
+the schema's `binary` runtime. Every `manual` entry was dropped as "unreadable"
+by both `dkg integration` and the node dashboard.
+
+Refresh deliberately (a PR, not a script) when the registry gains an entry shape
+worth pinning:
+
+    curl -s https://raw.githubusercontent.com/OriginTrail/dkg-integrations/main/integrations/<slug>.json \
+      -o packages/cli/test/fixtures/registry/<slug>.json
+
+Staleness here cannot produce a false green: the per-install-kind cases in
+`integrations.test.ts` are derived from the schema itself and are independent of
+these copies.

--- a/packages/cli/test/fixtures/registry/buzz-dkg.json
+++ b/packages/cli/test/fixtures/registry/buzz-dkg.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "../schema/integration.schema.json",
+  "schemaVersion": "0.1.0",
+  "slug": "buzz-dkg",
+  "name": "Buzz DKG Integration",
+  "description": "Joins a Block Buzz channel (Nostr/NIP-29) and turns pinned decision threads into DKG Knowledge Assets across Working, Shared, and Verifiable Memory, with a PROV-O provenance chain back to the signed source events. It also answers in-channel with deterministic, no-model retrieval scoped to that room's Context Graph — claims cited, unsupported questions refused.",
+  "category": ["ingestion", "chat", "nostr", "provenance", "grounded-answering"],
+  "maintainer": {
+    "github": "@OriginTrail/core-developers",
+    "name": "OriginTrail Core Developers"
+  },
+  "repo": "https://github.com/OriginTrail/buzz-dkg-integration",
+  "commit": "806b4e78c5078ed9af8fd33d937743695c345608",
+  "license": "Apache-2.0",
+  "requiresDkgNodeVersion": ">=10.0.8",
+  "memoryLayers": ["WM", "SWM", "VM"],
+  "v10PrimitivesUsed": ["ContextGraph", "KnowledgeAsset", "Assertion", "UAL", "Curator"],
+  "publicInterfacesUsed": ["http-api"],
+  "targetAgents": ["generic-HTTP"],
+  "install": {
+    "kind": "manual",
+    "docsUrl": "https://github.com/OriginTrail/buzz-dkg-integration/blob/main/README.md",
+    "oneLiner": "Run the standalone daemon (Node >=22.13) against a Buzz relay and a DKG v10 edge node, then bind a channel to a Context Graph in bindings.json. Setup and env are in README.md ('Deploy against an existing relay + node'); design and trust boundaries in docs/DESIGN.md. Verifiable Memory publishing is disabled by default and must be explicitly enabled by the operator."
+  },
+  "security": {
+    "networkEgress": [
+      "Buzz relay (BDI_BUZZ_HTTP/BDI_BUZZ_WS): operator-configured Nostr NIP-29 relay, HTTP+WS. No telemetry."
+    ],
+    "writeAuthority": [
+      "POST /api/knowledge-assets (create draft)",
+      "POST /api/knowledge-assets/{name}/wm/write (Working Memory)",
+      "POST /api/knowledge-assets/{name}/wm/finalize",
+      "POST /api/knowledge-assets/{name}/swm/share (Shared Working Memory)",
+      "POST /api/knowledge-assets/{name}/vm/publish (Curator authority: publishes to Verifiable Memory and mints a UAL; disabled by default, gated behind human approval — see notes)"
+    ],
+    "credentialsHandled": [
+      "Buzz service Nostr secret key (BDI_SERVICE_KEY): the bot's member identity"
+    ],
+    "notes": "The daemon talks only to the operator-configured Buzz relay and the local DKG node. It performs Working Memory create/write/finalize and Shared Working Memory share on human signal (a pinned thread or an @-mention), posting a machine-readable receipt back into the channel. Verifiable Memory publish (vm/publish) is a Curator-authority operation and is triple-gated: publishMode is 'disabled' by default (refuses all publication), 'mainnet' requires the node to report chain base:8453 and stays under a rolling-24h publication budget, and each publish additionally requires a per-channel authorized promoter's approval reaction that is consumed exactly once (SQL UNIQUE) and validated against the receipt's KA + source-set digest (re-read from the shared graph at approval time). Trusted-component disclosure: inbound event authenticity is delegated to the relay — the daemon does not itself re-verify Nostr Schnorr signatures on received events (the relay verifies on write); it snapshots the full signed events (NIP-01 preimage + id + sig) into the KA so claims remain independently checkable by any downstream consumer. Reads for the grounded-answering path use POST /api/query scoped to the bound Context Graph only, with no fallback to any other graph; note this scoping guarantees no OTHER graph is read, not that only room-authored content is returned — every member of a bound channel is effectively a reader of that Context Graph. Identity binding across ecosystems is NIP-OA verification only. No postinstall/preinstall scripts."
+  },
+  "trustTier": "verified",
+  "designBrief": "https://github.com/OriginTrail/buzz-dkg-integration/blob/main/docs/DESIGN.md",
+  "demo": "https://github.com/OriginTrail/buzz-dkg-integration/blob/main/docs/acceptance-transcript.md",
+  "promotionPath": "A pinned Buzz decision thread is distilled into a single-root PROV-O DecisionCluster written to Working Memory (create + wm/write), finalized and shared to the room's bound Context Graph as Shared Working Memory (swm/share), with a machine-readable receipt posted back into the channel. On an authorized promoter's approval reaction — enforced by the §6 invariants (promoter allowlist, receipt-target check, KA + source-set-digest match, single consume, publishMode and chain gate) — the asset is published to Verifiable Memory (vm/publish): anchored on-chain on Base and assigned a UAL, with the UAL receipt landing back in the room. Every VM Knowledge Asset preserves an unbroken wasDerivedFrom chain to its signed Nostr source events (Schnorr-verifiable independently of the relay), and outputs are modeled with PROV-O plus a thin Nostr vocabulary so context oracles can consume them downstream. A live example produced by this integration: a signed Buzz decision thread was published to Verifiable Memory at UAL did:dkg:base:8453/0x633e5a7c5e612d9981538f60d824cc03be97e2ab/2201 (tx 0x6daf3e0bad8cba13f7508f69c5550750a30294e997bf5e7fdffe9a24170dbb38, block 49145748) in the FIFA World Cup 2026 Context Graph, with full spend and lifecycle evidence in docs/gates/GATE_D3_REPORT.md and README.md.",
+  "fitNotes": "Advances the LLM-Wiki / autoresearch direction by turning the conclusions of a room of humans and AI agents into cited, ownable Knowledge Assets and answering from them in place, grounded only in the room's Context Graph — with unsupported questions refused rather than hallucinated. The capture-and-receipt floor runs even when no agent is present; the DKG v10 node's MCP surface plus Buzz's buzz-acp (ACP-to-MCP) harness let any agent in the room read and write the same graph directly. The pattern generalizes beyond team chat: any room on the open social protocol can bind to a Context Graph the same way."
+}

--- a/packages/cli/test/fixtures/registry/dkg-hello-world.json
+++ b/packages/cli/test/fixtures/registry/dkg-hello-world.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../schema/integration.schema.json",
+  "schemaVersion": "0.1.0",
+  "slug": "dkg-hello-world",
+  "name": "DKG Hello World",
+  "description": "Minimal reference integration for DKG v10. Writes a greeting into Working Memory and reads it back, to demonstrate the smallest end-to-end round trip an integration can make through the supported public interfaces.",
+  "category": ["template", "example", "working-memory"],
+  "maintainer": {
+    "github": "@OriginTrail/core-developers",
+    "name": "OriginTrail Core Developers"
+  },
+  "repo": "https://github.com/OriginTrail/dkg-hello-world",
+  "commit": "cb6af61a26b31be12ca9ff55a72af7442afe9c6b",
+  "license": "Apache-2.0",
+  "requiresDkgNodeVersion": ">=10.0.0-rc.1",
+  "memoryLayers": ["WM"],
+  "v10PrimitivesUsed": ["ContextGraph", "Assertion"],
+  "publicInterfacesUsed": ["http-api"],
+  "targetAgents": ["generic-CLI", "generic-HTTP"],
+  "install": {
+    "kind": "cli",
+    "package": "@origintrail-official/dkg-hello-world",
+    "version": "0.1.0",
+    "binary": "dkg-hello-world",
+    "envRequired": ["DKG_API_URL", "DKG_AUTH_TOKEN"],
+    "usageHint": "Say hello to the DKG:\n  dkg-hello-world greet \"first post\"\n  dkg-hello-world list\n\nDKG_API_URL defaults to http://127.0.0.1:9200 and DKG_AUTH_TOKEN is auto-filled by `dkg integration install` from your local node."
+  },
+  "security": {
+    "networkEgress": [],
+    "writeAuthority": [
+      "POST /api/context-graph/create",
+      "POST /api/assertion/create",
+      "POST /api/assertion/{name}/write"
+    ],
+    "credentialsHandled": [],
+    "notes": "No third-party credentials handled. Only talks to the local DKG node via its HTTP API. Writes exclusively to Working Memory (private, per-agent); never calls PUBLISH or SHARE and never touches Curator-authority operations. Uses no postinstall/preinstall scripts."
+  },
+  "trustTier": "featured",
+  "designBrief": "https://github.com/OriginTrail/dkg-hello-world/blob/main/DESIGN.md",
+  "demo": "https://github.com/OriginTrail/dkg-hello-world#demo",
+  "promotionPath": "DKG Hello World is a template, not a production integration. It demonstrates the WM leg of the promotion path; a contributor building on this template is expected to extend it to promote matured greetings to Shared Memory (POST /api/assertion/{name}/promote) and, when a greeting has broad relevance, to publish it as a Knowledge Asset for consumption by context oracles. The reference implementation intentionally stops at WM so the template's scope stays minimal.",
+  "fitNotes": "Exists so new contributors have a working, ~150-line starting point for their own integration rather than reverse-engineering the HTTP API from the SKILL.md alone. Not bounty-eligible in its own right (first-party, already maintained)."
+}

--- a/packages/cli/test/fixtures/registry/integration.schema.json
+++ b/packages/cli/test/fixtures/registry/integration.schema.json
@@ -1,0 +1,352 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://origintrail.io/schemas/integration/v0.1.0.json",
+  "title": "DKG Integration Registry Entry",
+  "description": "A single integration listed in the official DKG integrations registry. Entries live in integrations/<slug>.json in this repo and are consumed by `dkg integration` CLI/UI surfaces to discover, install, and manage integrations built on top of DKG v10 public interfaces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "slug",
+    "name",
+    "description",
+    "category",
+    "maintainer",
+    "repo",
+    "commit",
+    "license",
+    "memoryLayers",
+    "v10PrimitivesUsed",
+    "publicInterfacesUsed",
+    "install",
+    "security",
+    "trustTier"
+  ],
+  "properties": {
+    "$schema": {
+      "description": "Editor-tooling hint. Not enforced by the registry; contributors may point it at the local schema file or the canonical URL.",
+      "type": "string"
+    },
+    "schemaVersion": {
+      "description": "Which version of this JSON Schema the entry targets. Semver.",
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "slug": {
+      "description": "URL-safe, globally unique integration identifier. Must match the registry normalization rule: lowercase, ASCII-only, hyphen-separated, stopwords stripped (the/a/an/of/for/and/or/to/in/on/with), length 3-60. The filename must be integrations/<slug>.json.",
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$",
+      "minLength": 3,
+      "maxLength": 60
+    },
+    "name": {
+      "description": "Human-readable integration name shown in `dkg integration search` and the dashboard.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "description": {
+      "description": "One- or two-sentence blurb shown in listings. Plain prose, no marketing.",
+      "type": "string",
+      "minLength": 20,
+      "maxLength": 400
+    },
+    "category": {
+      "description": "Free-text tags for filtering in search. Keep short and lowercase.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 6,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$",
+        "maxLength": 32
+      }
+    },
+    "maintainer": {
+      "description": "Who is responsible for this integration. Required: a GitHub handle or team.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["github"],
+      "properties": {
+        "github": {
+          "type": "string",
+          "pattern": "^@[A-Za-z0-9_-]+(/[A-Za-z0-9_-]+)?$",
+          "description": "GitHub user or team handle, e.g. @brana or @OriginTrail/core-developers."
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 80
+        },
+        "contact": {
+          "type": "string",
+          "description": "Email, Discord handle, or other contact (optional).",
+          "maxLength": 120
+        }
+      }
+    },
+    "repo": {
+      "description": "HTTPS URL of the integration's source repository.",
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    },
+    "commit": {
+      "description": "Full 40-character git SHA the registry entry pins to. Updates require a new registry PR.",
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "license": {
+      "description": "SPDX license identifier (must match the LICENSE file in the pinned commit).",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9.+-]+( WITH [A-Za-z0-9.+-]+)?$"
+    },
+    "requiresDkgNodeVersion": {
+      "description": "Semver range the DKG node must satisfy for this integration. Example: '>=10.0.0'.",
+      "type": "string",
+      "maxLength": 60
+    },
+    "memoryLayers": {
+      "description": "Which memory layers the integration touches.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {
+        "enum": ["WM", "SWM", "VM"]
+      }
+    },
+    "v10PrimitivesUsed": {
+      "description": "Which v10 primitives the integration exercises. Helps the committee assess faithfulness to the model.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "UAL",
+          "KnowledgeAsset",
+          "KnowledgeCollection",
+          "ContextGraph",
+          "SubGraph",
+          "Assertion",
+          "Integration",
+          "Curator",
+          "Entity"
+        ]
+      }
+    },
+    "publicInterfacesUsed": {
+      "description": "Which supported public interfaces the integration CONSUMES from the local DKG node (independent of how the integration itself is distributed). Values: 'http-api' (calls /api/... endpoints), 'cli' (shells out to the `dkg` binary), 'mcp' (consumes the DKG MCP server as a client). An integration that IS an MCP server but talks to the node over HTTP should list only 'http-api' here — what it exposes to its own clients is captured by `install.kind`. Anything outside this list is a scope violation (see bounty doc Section 5).",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {
+        "enum": ["http-api", "cli", "mcp"]
+      }
+    },
+    "targetAgents": {
+      "description": "Which agent frameworks or clients the integration targets.",
+      "type": "array",
+      "items": {
+        "enum": [
+          "OpenClaw",
+          "ElizaOS",
+          "Hermes",
+          "AutoResearch",
+          "Cursor",
+          "Claude Code",
+          "Claude Desktop",
+          "generic-MCP",
+          "generic-HTTP",
+          "generic-CLI"
+        ]
+      }
+    },
+    "install": {
+      "description": "How `dkg integration install <slug>` should materialize this integration. Exactly one kind.",
+      "oneOf": [
+        { "$ref": "#/$defs/installMcp" },
+        { "$ref": "#/$defs/installService" },
+        { "$ref": "#/$defs/installCli" },
+        { "$ref": "#/$defs/installAgentPlugin" },
+        { "$ref": "#/$defs/installManual" }
+      ]
+    },
+    "security": {
+      "description": "Security declarations. CI cross-checks a subset against the published package; the rest is authoritative prose for the review committee.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["networkEgress", "writeAuthority"],
+      "properties": {
+        "networkEgress": {
+          "description": "Every external host (beyond the local DKG node) the integration contacts. Use '*' only with justification in notes.",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 120 }
+        },
+        "writeAuthority": {
+          "description": "Every DKG endpoint or CLI command the integration invokes that mutates state. Curator-authority ops (PUBLISH, SHARE) must appear here if used.",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 200 }
+        },
+        "credentialsHandled": {
+          "description": "Third-party credentials the integration asks the user to provide (e.g. SLACK_BOT_TOKEN). Do NOT list the DKG auth token here; it is handled by the installer.",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 80 }
+        },
+        "notes": {
+          "type": "string",
+          "maxLength": 2000
+        }
+      }
+    },
+    "trustTier": {
+      "description": "Assigned by the review committee. Contributors submit as 'community'; the committee may upgrade.",
+      "enum": ["community", "verified", "featured"]
+    },
+    "designBrief": {
+      "description": "URL of the design brief Markdown document (bounty doc Section 8).",
+      "type": "string",
+      "format": "uri"
+    },
+    "demo": {
+      "description": "URL of a recorded walkthrough or live endpoint (bounty doc Section 8).",
+      "type": "string",
+      "format": "uri"
+    },
+    "promotionPath": {
+      "description": "How Working/Shared artifacts mature toward Verified Memory and downstream oracle consumption (bounty doc Section 9, criterion 4). Prose, 1-4 sentences.",
+      "type": "string",
+      "maxLength": 2000
+    },
+    "fitNotes": {
+      "description": "Optional prose on LLM-Wiki / autoresearch fit.",
+      "type": "string",
+      "maxLength": 2000
+    }
+  },
+
+  "$defs": {
+    "installMcp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "command", "supportedClients"],
+      "properties": {
+        "kind": { "const": "mcp" },
+        "command": { "type": "string", "minLength": 1 },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "envRequired": {
+          "description": "Environment variables the MCP server expects. DKG_AUTH_TOKEN and DKG_API_URL are auto-filled by the installer if listed; others prompt the user.",
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" }
+        },
+        "supportedClients": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["cursor", "claude-code", "claude-desktop", "dkg-node"] }
+        }
+      }
+    },
+
+    "installService": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "runtime"],
+      "properties": {
+        "kind": { "const": "service" },
+        "runtime": { "enum": ["docker", "npm-global", "binary"] },
+        "docker": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["image", "version"],
+          "properties": {
+            "image": { "type": "string", "minLength": 1 },
+            "version": { "type": "string", "minLength": 1 },
+            "digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$",
+              "description": "Optional image digest. Strongly recommended for verified/featured tier."
+            },
+            "composeUrl": { "type": "string", "format": "uri" }
+          }
+        },
+        "npmGlobal": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["package", "version"],
+          "properties": {
+            "package": { "type": "string", "minLength": 1 },
+            "version": { "type": "string", "minLength": 1 },
+            "binary": { "type": "string", "description": "The CLI binary name shipped by this package, if different from the package name." }
+          }
+        },
+        "binary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["url"],
+          "properties": {
+            "url": { "type": "string", "format": "uri" },
+            "checksumSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+          }
+        },
+        "envRequired": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" }
+        },
+        "portsOpened": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+        }
+      }
+    },
+
+    "installCli": {
+      "description": "A CLI tool installed globally and invoked on demand by the operator. Intended for ad-hoc, one-shot integrations (demos, templates, utilities).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "package", "version", "binary"],
+      "properties": {
+        "kind": { "const": "cli" },
+        "package": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "binary": { "type": "string", "minLength": 1 },
+        "envRequired": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" }
+        },
+        "usageHint": {
+          "type": "string",
+          "maxLength": 400,
+          "description": "Short post-install message showing the operator how to invoke the CLI."
+        }
+      }
+    },
+
+    "installAgentPlugin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "framework", "package", "version"],
+      "properties": {
+        "kind": { "const": "agent-plugin" },
+        "framework": { "enum": ["openclaw", "elizaos", "hermes", "autoresearch"] },
+        "package": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "frameworkSetupDocs": { "type": "string", "format": "uri" }
+      }
+    },
+
+    "installManual": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "docsUrl"],
+      "properties": {
+        "kind": { "const": "manual" },
+        "docsUrl": { "type": "string", "format": "uri" },
+        "oneLiner": { "type": "string", "maxLength": 400 }
+      }
+    }
+  }
+}

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -408,6 +408,66 @@ describe('detectInstalled', () => {
     expect(rows[0]!.detail).toContain('DKG_AUTH_TOKEN');
   });
 
+  // One stale block must not hide a real install elsewhere. Judged per client:
+  // a filled Cursor config plus an old Windsurf block still carrying the
+  // placeholder is INSTALLED, with the incomplete sibling noted.
+  it('reports installed when one client is complete and another has placeholders', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        readServerKeys: (t) => ({
+          ok: true as const,
+          servers: {
+            'mcp-slug': {
+              command: 'npx',
+              args: ['-y', 'p'],
+              env:
+                t.name === 'Cursor'
+                  ? { DKG_AUTH_TOKEN: 'dkg_live_abc' }
+                  : { DKG_AUTH_TOKEN: '<DKG_AUTH_TOKEN>' },
+            },
+          },
+        }),
+      },
+    );
+    expect(rows[0]!.state).toBe('installed');
+    expect(rows[0]!.detail).toContain('Cursor');
+    expect(rows[0]!.detail).toContain('incomplete block in Windsurf');
+  });
+
+  // Dropping non-string args would rewrite [123] into [] and let it match an
+  // args-less entry — manufacturing an install from a malformed block.
+  it('does not match an args-less entry when args are present but malformed', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'my-server' })],
+      {
+        clients,
+        readServerKeys: () => ({
+          ok: true as const,
+          servers: { 'mcp-slug': { command: 'my-server', args: null } },
+        }),
+      },
+    );
+    expect(rows[0]!.state).not.toBe('installed');
+  });
+
+  // The control for the case above: an args-less entry DOES match a block whose
+  // args key is genuinely absent (normalized to []).
+  it('matches an args-less entry when the block has no args key', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'my-server' })],
+      {
+        clients,
+        readServerKeys: () => ({
+          ok: true as const,
+          servers: { 'mcp-slug': { command: 'my-server', args: [] } },
+        }),
+      },
+    );
+    expect(rows[0]!.state).toBe('installed');
+  });
+
   // The control: a FILLED env must still read as installed, or the check above
   // would pass simply by never reporting installed for anything with env.
   it('reports installed when env values are real', async () => {

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+
+import { installService } from '../src/integrations/install-service.js';
+import { detectInstalled } from '../src/integrations/detect-installed.js';
+import type { IntegrationEntry } from '../src/integrations/schema.js';
+import type { ProvenanceCheckResult } from '../src/integrations/verify-npm-provenance.js';
+
+const baseEntry = {
+  slug: 'fixture',
+  name: 'Fixture',
+  description: 'Test fixture',
+  maintainer: { github: '@OriginTrail/core-developers' },
+  repo: 'https://github.com/OriginTrail/svc',
+  commit: '0'.repeat(40),
+  license: 'Apache-2.0',
+  memoryLayers: ['WM'],
+  v10PrimitivesUsed: ['UAL'],
+  publicInterfacesUsed: ['http-api'],
+  security: { networkEgress: [], writeAuthority: [] },
+  trustTier: 'community',
+} as unknown as IntegrationEntry;
+
+function recordVerifier(result: ProvenanceCheckResult) {
+  const calls: unknown[][] = [];
+  const fn = async (...args: unknown[]) => {
+    calls.push(args);
+    return result;
+  };
+  return Object.assign(fn, { calls });
+}
+
+function recordRunner(exitCode: number) {
+  const calls: Array<[string, string[]]> = [];
+  const fn = async (cmd: string, args: string[]) => {
+    calls.push([cmd, args]);
+    return exitCode;
+  };
+  return Object.assign(fn, { calls });
+}
+
+const okProv = { ok: true, reasons: [], found: {} } as unknown as ProvenanceCheckResult;
+const badProv = { ok: false, reasons: ['no attestation'], found: {} } as unknown as ProvenanceCheckResult;
+
+const svcEntry = (
+  npmGlobal: Record<string, unknown>,
+  extra: Record<string, unknown> = {},
+): IntegrationEntry =>
+  ({
+    ...baseEntry,
+    slug: 'svc',
+    install: { kind: 'service', runtime: 'npm-global', npmGlobal, ...extra },
+  }) as unknown as IntegrationEntry;
+
+// A service install writes to the user's global npm prefix exactly like a cli
+// install, so it must honour the same provenance contract. These mirror the
+// installCli gate tests rather than trusting that the shared helper stays shared.
+describe('installService (npm-global)', () => {
+  it('refuses to install when provenance fails, before touching npm', async () => {
+    const verifier = recordVerifier(badProv);
+    const runner = recordRunner(0);
+    await expect(
+      installService({
+        entry: svcEntry({ package: '@acme/svc', version: '1.0.0', binary: 'svc' }),
+        verifier,
+        runner,
+        logger: () => {},
+      }),
+    ).rejects.toThrow(/cryptographically bound/i);
+    expect(runner.calls).toHaveLength(0); // the gate runs BEFORE the global write
+  });
+
+  it('installs the pinned version when provenance passes', async () => {
+    const verifier = recordVerifier(okProv);
+    const runner = recordRunner(0);
+    const res = await installService({
+      entry: svcEntry({ package: '@acme/svc', version: '1.0.0', binary: 'svc' }),
+      verifier,
+      runner,
+      logger: () => {},
+    });
+    expect(runner.calls).toEqual([['npm', ['install', '--global', '@acme/svc@1.0.0']]]);
+    expect(res.binary).toBe('svc');
+  });
+
+  it('skips provenance and npm in dry-run', async () => {
+    const verifier = recordVerifier(badProv);
+    const runner = recordRunner(0);
+    const res = await installService({
+      entry: svcEntry({ package: '@acme/svc', version: '1.0.0', binary: 'svc' }),
+      dryRun: true,
+      verifier,
+      runner,
+      logger: () => {},
+    });
+    expect(verifier.calls).toHaveLength(0);
+    expect(runner.calls).toHaveLength(0);
+    expect(res.args).toEqual(['install', '--global', '@acme/svc@1.0.0']);
+  });
+
+  it('runs npm when provenance is explicitly skipped', async () => {
+    const verifier = recordVerifier(badProv);
+    const runner = recordRunner(0);
+    await installService({
+      entry: svcEntry({ package: '@acme/svc', version: '1.0.0' }),
+      skipProvenance: true,
+      verifier,
+      runner,
+      logger: () => {},
+    });
+    expect(verifier.calls).toHaveLength(0);
+    expect(runner.calls).toHaveLength(1);
+  });
+
+  it('surfaces a non-zero npm exit', async () => {
+    const verifier = recordVerifier(okProv);
+    const runner = recordRunner(1);
+    await expect(
+      installService({
+        entry: svcEntry({ package: '@acme/svc', version: '1.0.0' }),
+        verifier,
+        runner,
+        logger: () => {},
+      }),
+    ).rejects.toThrow(/exit code 1/);
+  });
+
+  // npmGlobal.binary is OPTIONAL in the registry schema ("if different from the
+  // package name"), so an entry without it must still print a usable command
+  // rather than "Start it with: undefined".
+  it('falls back to the package name when binary is omitted', async () => {
+    const verifier = recordVerifier(okProv);
+    const runner = recordRunner(0);
+    const res = await installService({
+      entry: svcEntry({ package: '@acme/svc', version: '1.0.0' }),
+      verifier,
+      runner,
+      logger: () => {},
+    });
+    expect(res.binary).toBe('@acme/svc');
+    expect(res.postInstructions.join('\n')).toContain('@acme/svc');
+    expect(res.postInstructions.join('\n')).not.toContain('undefined');
+  });
+
+  it('surfaces envRequired and portsOpened in post-install guidance', async () => {
+    const verifier = recordVerifier(okProv);
+    const runner = recordRunner(0);
+    const res = await installService({
+      entry: svcEntry(
+        { package: '@acme/svc', version: '1.0.0', binary: 'svc' },
+        { envRequired: ['TELEGRAM_BOT_TOKEN', 'DKG_API_URL'], portsOpened: [8080] },
+      ),
+      verifier,
+      runner,
+      logger: () => {},
+    });
+    const text = res.postInstructions.join('\n');
+    expect(text).toContain('TELEGRAM_BOT_TOKEN');
+    expect(text).toContain('DKG_API_URL');
+    expect(text).toContain('8080');
+  });
+
+  it('refuses runtimes it does not handle', async () => {
+    const docker = {
+      ...baseEntry,
+      install: { kind: 'service', runtime: 'docker', docker: { image: 'i' } },
+    } as unknown as IntegrationEntry;
+    await expect(installService({ entry: docker, logger: () => {} })).rejects.toThrow(
+      /only handles runtime "npm-global"/,
+    );
+  });
+});
+
+describe('detectInstalled', () => {
+  const entry = (slug: string, install: Record<string, unknown>): IntegrationEntry =>
+    ({ ...baseEntry, slug, install }) as unknown as IntegrationEntry;
+
+  const clients = [
+    { name: 'Cursor', configPath: '/fake/cursor.json', displayPath: '~/cursor.json' },
+    { name: 'Windsurf', configPath: '/fake/windsurf.json', displayPath: '~/windsurf.json' },
+  ] as never;
+
+  it('reports cli and npm-global service entries from the global npm map', async () => {
+    const rows = await detectInstalled(
+      [
+        entry('a-cli', { kind: 'cli', package: '@acme/cli', version: '1.0.0', binary: 'c' }),
+        entry('a-svc', {
+          kind: 'service',
+          runtime: 'npm-global',
+          npmGlobal: { package: '@acme/svc', version: '1.0.0' },
+        }),
+        entry('missing', { kind: 'cli', package: '@acme/nope', version: '1.0.0', binary: 'n' }),
+      ],
+      { listGlobalNpm: async () => ({ '@acme/cli': '1.0.0', '@acme/svc': '2.0.0' }) },
+    );
+    expect(rows.find((r) => r.slug === 'a-cli')).toMatchObject({ state: 'installed' });
+    // A service installed by installService must not be reported undetectable.
+    expect(rows.find((r) => r.slug === 'a-svc')).toMatchObject({
+      state: 'installed',
+      kind: 'service',
+    });
+    expect(rows.find((r) => r.slug === 'missing')).toMatchObject({ state: 'not installed' });
+  });
+
+  it('surfaces version drift against the registry pin', async () => {
+    const [row] = await detectInstalled(
+      [entry('drift', { kind: 'cli', package: '@acme/cli', version: '1.0.0', binary: 'c' })],
+      { listGlobalNpm: async () => ({ '@acme/cli': '2.5.0' }) },
+    );
+    expect(row!.detail).toContain('2.5.0');
+    expect(row!.detail).toContain('registry pins 1.0.0');
+  });
+
+  it('detects an mcp entry across every client that registers it', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        readServerKeys: (t) => (t.name === 'Cursor' ? ['mcp-slug', 'other'] : ['mcp-slug']),
+      },
+    );
+    expect(rows[0]).toMatchObject({ state: 'installed' });
+    expect(rows[0]!.detail).toContain('Cursor');
+    expect(rows[0]!.detail).toContain('Windsurf');
+  });
+
+  it('reports an mcp entry no client registers as not installed', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      { clients, readServerKeys: () => [] },
+    );
+    expect(rows[0]).toMatchObject({ state: 'not installed' });
+  });
+
+  it('treats an unreadable client config as no evidence, not absence', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        // readRegisteredServerKeys swallows parse errors and returns []
+        readServerKeys: () => [],
+      },
+    );
+    expect(rows[0]!.state).toBe('not installed');
+  });
+
+  it('reports kinds it cannot detect as unknown, never "not installed"', async () => {
+    const rows = await detectInstalled(
+      [
+        entry('m', { kind: 'manual', docsUrl: 'https://x/README.md' }),
+        entry('ap', { kind: 'agent-plugin', framework: 'openclaw', package: 'p', version: '1' }),
+        entry('sb', { kind: 'service', runtime: 'binary' }),
+      ],
+      { listGlobalNpm: async () => ({}) },
+    );
+    for (const r of rows) expect(r.state).toBe('unknown');
+  });
+
+  it('does not consult npm when no entry installs a global package', async () => {
+    let called = false;
+    await detectInstalled([entry('m', { kind: 'manual', docsUrl: 'https://x' })], {
+      listGlobalNpm: async () => {
+        called = true;
+        return {};
+      },
+    });
+    expect(called).toBe(false);
+  });
+});

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import { installService } from '../src/integrations/install-service.js';
-import { detectInstalled } from '../src/integrations/detect-installed.js';
+import { detectInstalled, parseGlobalNpmList } from '../src/integrations/detect-installed.js';
 import type { IntegrationEntry } from '../src/integrations/schema.js';
 import type { ProvenanceCheckResult } from '../src/integrations/verify-npm-provenance.js';
 
@@ -208,6 +208,61 @@ describe('detectInstalled', () => {
     );
     expect(row!.detail).toContain('2.5.0');
     expect(row!.detail).toContain('registry pins 1.0.0');
+  });
+
+  // Covers the real probe's parsing, not just an injected fake — this is where
+  // the false negative originated (returning `{}` for output we could not read).
+  describe('parseGlobalNpmList', () => {
+    it('returns null for output it cannot interpret', () => {
+      // npm absent / spawn failed / permissions error -> nothing on stdout.
+      expect(parseGlobalNpmList('')).toBeNull();
+      expect(parseGlobalNpmList('   \n ')).toBeNull();
+      // A warning banner or truncated output is not an answer either.
+      expect(parseGlobalNpmList('npm ERR! code ENOENT')).toBeNull();
+    });
+
+    it('returns an EMPTY MAP when npm reports no global packages', () => {
+      // Distinct from null: npm answered, and the answer is "nothing".
+      expect(parseGlobalNpmList('{"dependencies":{}}')).toEqual({});
+      expect(parseGlobalNpmList('{}')).toEqual({});
+    });
+
+    it('maps package names to versions', () => {
+      expect(
+        parseGlobalNpmList('{"dependencies":{"@acme/cli":{"version":"1.2.3"}}}'),
+      ).toEqual({ '@acme/cli': '1.2.3' });
+    });
+  });
+
+  // "npm answered, the package is absent" and "we could not ask npm" are
+  // different facts. These two cases must not collapse into one another, so
+  // they are asserted as a pair: the null case pins the fix, and the `{}` case
+  // is the control that stops a regression to "report unknown for everything"
+  // from passing. Break either direction and exactly one of them fails.
+  it('reports npm-installable entries as unknown when the npm probe fails', async () => {
+    const rows = await detectInstalled(
+      [
+        entry('a-cli', { kind: 'cli', package: '@acme/cli', version: '1.0.0', binary: 'c' }),
+        entry('a-svc', {
+          kind: 'service',
+          runtime: 'npm-global',
+          npmGlobal: { package: '@acme/svc', version: '1.0.0' },
+        }),
+      ],
+      { listGlobalNpm: async () => null },
+    );
+    for (const r of rows) {
+      expect(r.state).toBe('unknown');
+      expect(r.detail).toContain('could not inspect');
+    }
+  });
+
+  it('still reports "not installed" when npm answers with no global packages', async () => {
+    const [row] = await detectInstalled(
+      [entry('a-cli', { kind: 'cli', package: '@acme/cli', version: '1.0.0', binary: 'c' })],
+      { listGlobalNpm: async () => ({}) },
+    );
+    expect(row!.state).toBe('not installed');
   });
 
   it('detects an mcp entry across every client that registers it', async () => {

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -270,7 +270,10 @@ describe('detectInstalled', () => {
       [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
       {
         clients,
-        readServerKeys: (t) => (t.name === 'Cursor' ? ['mcp-slug', 'other'] : ['mcp-slug']),
+        readServerKeys: (t) =>
+          t.name === 'Cursor'
+            ? { ok: true as const, keys: ['mcp-slug', 'other'] }
+            : { ok: true as const, keys: ['mcp-slug'] },
       },
     );
     expect(rows[0]).toMatchObject({ state: 'installed' });
@@ -281,9 +284,46 @@ describe('detectInstalled', () => {
   it('reports an mcp entry no client registers as not installed', async () => {
     const rows = await detectInstalled(
       [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
-      { clients, readServerKeys: () => [] },
+      { clients, readServerKeys: () => ({ ok: true as const, keys: [] }) },
     );
     expect(rows[0]).toMatchObject({ state: 'not installed' });
+  });
+
+  // Same pairing as the npm probe: an unreadable client config is not evidence
+  // that the server block is absent — it could be sitting in the file we could
+  // not parse. The `{ ok: true, keys: [] }` case above is the control; without
+  // it, always reporting 'unknown' would pass this test.
+  it('reports mcp as unknown when a client config could not be read', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        readServerKeys: (t) =>
+          t.name === 'Cursor'
+            ? { ok: false as const, reason: 'could not read ~/cursor.json' }
+            : { ok: true as const, keys: [] },
+      },
+    );
+    expect(rows[0]!.state).toBe('unknown');
+    expect(rows[0]!.detail).toContain('Cursor');
+  });
+
+  // A registration found in a READABLE config is still authoritative even when
+  // some other client's config is unreadable — the unknown state must not
+  // swallow positive evidence we actually have.
+  it('still reports installed when one config is unreadable but another registers it', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        readServerKeys: (t) =>
+          t.name === 'Cursor'
+            ? { ok: false as const, reason: 'could not read ~/cursor.json' }
+            : { ok: true as const, keys: ['mcp-slug'] },
+      },
+    );
+    expect(rows[0]!.state).toBe('installed');
+    expect(rows[0]!.detail).toContain('Windsurf');
   });
 
   it('reports kinds it cannot detect as unknown, never "not installed"', async () => {

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -231,18 +231,6 @@ describe('detectInstalled', () => {
     expect(rows[0]).toMatchObject({ state: 'not installed' });
   });
 
-  it('treats an unreadable client config as no evidence, not absence', async () => {
-    const rows = await detectInstalled(
-      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
-      {
-        clients,
-        // readRegisteredServerKeys swallows parse errors and returns []
-        readServerKeys: () => [],
-      },
-    );
-    expect(rows[0]!.state).toBe('not installed');
-  });
-
   it('reports kinds it cannot detect as unknown, never "not installed"', async () => {
     const rows = await detectInstalled(
       [

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -272,8 +272,8 @@ describe('detectInstalled', () => {
         clients,
         readServerKeys: (t) =>
           t.name === 'Cursor'
-            ? { ok: true as const, keys: ['mcp-slug', 'other'] }
-            : { ok: true as const, keys: ['mcp-slug'] },
+            ? { ok: true as const, servers: { 'mcp-slug': { command: 'npx', args: ['-y', 'p'] }, other: { command: 'npx', args: ['-y', 'p'] } } }
+            : { ok: true as const, servers: { 'mcp-slug': { command: 'npx', args: ['-y', 'p'] } } },
       },
     );
     expect(rows[0]).toMatchObject({ state: 'installed' });
@@ -284,14 +284,14 @@ describe('detectInstalled', () => {
   it('reports an mcp entry no client registers as not installed', async () => {
     const rows = await detectInstalled(
       [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
-      { clients, readServerKeys: () => ({ ok: true as const, keys: [] }) },
+      { clients, readServerKeys: () => ({ ok: true as const, servers: {} }) },
     );
     expect(rows[0]).toMatchObject({ state: 'not installed' });
   });
 
   // Same pairing as the npm probe: an unreadable client config is not evidence
   // that the server block is absent — it could be sitting in the file we could
-  // not parse. The `{ ok: true, keys: [] }` case above is the control; without
+  // not parse. The `{ ok: true, servers: {} }` case above is the control; without
   // it, always reporting 'unknown' would pass this test.
   it('reports mcp as unknown when a client config could not be read', async () => {
     const rows = await detectInstalled(
@@ -301,7 +301,7 @@ describe('detectInstalled', () => {
         readServerKeys: (t) =>
           t.name === 'Cursor'
             ? { ok: false as const, reason: 'could not read ~/cursor.json' }
-            : { ok: true as const, keys: [] },
+            : { ok: true as const, servers: {} },
       },
     );
     expect(rows[0]!.state).toBe('unknown');
@@ -319,11 +319,44 @@ describe('detectInstalled', () => {
         readServerKeys: (t) =>
           t.name === 'Cursor'
             ? { ok: false as const, reason: 'could not read ~/cursor.json' }
-            : { ok: true as const, keys: ['mcp-slug'] },
+            : { ok: true as const, servers: { 'mcp-slug': { command: 'npx', args: ['-y', 'p'] } } },
       },
     );
     expect(rows[0]!.state).toBe('installed');
     expect(rows[0]!.detail).toContain('Windsurf');
+  });
+
+  // The slug is a name, not evidence. A block registered under it that launches
+  // a different package must not read as installed — that would hide a
+  // substituted or stale server behind a reassuring row. 'not installed' would
+  // be equally wrong: it hides the name collision the user needs to know about.
+  it('does not report installed when the slug launches a different command', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        readServerKeys: () => ({
+          ok: true as const,
+          servers: { 'mcp-slug': { command: 'npx', args: ['-y', 'other-package'] } },
+        }),
+      },
+    );
+    expect(rows[0]!.state).toBe('unknown');
+    expect(rows[0]!.detail).toContain('different server');
+  });
+
+  it('does not report installed when the slug is registered with a different binary', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        readServerKeys: () => ({
+          ok: true as const,
+          servers: { 'mcp-slug': { command: 'node', args: ['-y', 'p'] } },
+        }),
+      },
+    );
+    expect(rows[0]!.state).toBe('unknown');
   });
 
   it('reports kinds it cannot detect as unknown, never "not installed"', async () => {

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -127,7 +127,10 @@ describe('installService (npm-global)', () => {
   // npmGlobal.binary is OPTIONAL in the registry schema ("if different from the
   // package name"), so an entry without it must still print a usable command
   // rather than "Start it with: undefined".
-  it('falls back to the package name when binary is omitted', async () => {
+  // Installing `@acme/svc` globally puts `svc` on PATH, not `@acme/svc`, so the
+  // fallback must drop the scope — printing the full specifier is the same
+  // class of unusable guidance as the `undefined` this fallback replaced.
+  it('falls back to the UNSCOPED package name when binary is omitted', async () => {
     const verifier = recordVerifier(okProv);
     const runner = recordRunner(0);
     const res = await installService({
@@ -136,9 +139,45 @@ describe('installService (npm-global)', () => {
       runner,
       logger: () => {},
     });
-    expect(res.binary).toBe('@acme/svc');
-    expect(res.postInstructions.join('\n')).toContain('@acme/svc');
-    expect(res.postInstructions.join('\n')).not.toContain('undefined');
+    expect(res.binary).toBe('svc');
+    const text = res.postInstructions.join('\n');
+    expect(text).not.toContain('undefined');
+    // The start command must not be the scoped specifier.
+    expect(text).not.toMatch(/Start it with:.*@acme\/svc/);
+  });
+
+  it('uses an unscoped package name as-is', async () => {
+    const res = await installService({
+      entry: svcEntry({ package: 'plainsvc', version: '1.0.0' }),
+      verifier: recordVerifier(okProv),
+      runner: recordRunner(0),
+      logger: () => {},
+    });
+    expect(res.binary).toBe('plainsvc');
+  });
+
+  // An explicit binary always wins — the scope-stripping is only a fallback.
+  it('prefers an explicit binary over the derived name', async () => {
+    const res = await installService({
+      entry: svcEntry({ package: '@acme/svc', version: '1.0.0', binary: 'custom-bin' }),
+      verifier: recordVerifier(okProv),
+      runner: recordRunner(0),
+      logger: () => {},
+    });
+    expect(res.binary).toBe('custom-bin');
+  });
+
+  // Truthiness is not enough: a non-string package would reach the npm spec and
+  // install `[object Object]@1.0.0`.
+  it('rejects npmGlobal.package that is not a string', async () => {
+    await expect(
+      installService({
+        entry: svcEntry({ package: { name: '@acme/svc' }, version: '1.0.0' }),
+        verifier: recordVerifier(okProv),
+        runner: recordRunner(0),
+        logger: () => {},
+      }),
+    ).rejects.toThrow(/no npmGlobal.package\/version/);
   });
 
   it('surfaces envRequired and portsOpened in post-install guidance', async () => {
@@ -343,6 +382,52 @@ describe('detectInstalled', () => {
     );
     expect(rows[0]!.state).toBe('unknown');
     expect(rows[0]!.detail).toContain('different server');
+  });
+
+  // installMcp emits `<DKG_AUTH_TOKEN>` when it cannot supply a value. A block
+  // still carrying it was pasted but never completed — registered, yet it will
+  // start unauthenticated.
+  it('does not report installed when placeholder env values were never filled', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        readServerKeys: () => ({
+          ok: true as const,
+          servers: {
+            'mcp-slug': {
+              command: 'npx',
+              args: ['-y', 'p'],
+              env: { DKG_API_URL: 'http://127.0.0.1:9200', DKG_AUTH_TOKEN: '<DKG_AUTH_TOKEN>' },
+            },
+          },
+        }),
+      },
+    );
+    expect(rows[0]!.state).toBe('unknown');
+    expect(rows[0]!.detail).toContain('DKG_AUTH_TOKEN');
+  });
+
+  // The control: a FILLED env must still read as installed, or the check above
+  // would pass simply by never reporting installed for anything with env.
+  it('reports installed when env values are real', async () => {
+    const rows = await detectInstalled(
+      [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
+      {
+        clients,
+        readServerKeys: () => ({
+          ok: true as const,
+          servers: {
+            'mcp-slug': {
+              command: 'npx',
+              args: ['-y', 'p'],
+              env: { DKG_AUTH_TOKEN: 'dkg_live_abc123' },
+            },
+          },
+        }),
+      },
+    );
+    expect(rows[0]!.state).toBe('installed');
   });
 
   it('does not report installed when the slug is registered with a different binary', async () => {

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -198,6 +198,53 @@ describe('installService (npm-global)', () => {
     expect(text).toContain('8080');
   });
 
+  // `--api-url` is documented as "wire into integrations" and installMcp honours
+  // it. A service printing the hardcoded default would send an operator who
+  // passed the flag to the wrong node, with the same flag working for mcp.
+  it('echoes the selected --api-url in DKG_API_URL guidance', async () => {
+    const res = await installService({
+      entry: svcEntry(
+        { package: '@acme/svc', version: '1.0.0' },
+        { envRequired: ['DKG_API_URL'] },
+      ),
+      apiUrl: 'http://10.0.0.5:9200',
+      verifier: recordVerifier(okProv),
+      runner: recordRunner(0),
+      logger: () => {},
+    });
+    const text = res.postInstructions.join('\n');
+    expect(text).toContain('http://10.0.0.5:9200');
+    expect(text).not.toContain('default http://127.0.0.1:9200');
+  });
+
+  // Control: with no flag the default guidance is still printed, so the test
+  // above cannot pass by simply never rendering the default.
+  it('falls back to the default node when no --api-url is given', async () => {
+    const res = await installService({
+      entry: svcEntry(
+        { package: '@acme/svc', version: '1.0.0' },
+        { envRequired: ['DKG_API_URL'] },
+      ),
+      verifier: recordVerifier(okProv),
+      runner: recordRunner(0),
+      logger: () => {},
+    });
+    expect(res.postInstructions.join('\n')).toContain('default http://127.0.0.1:9200');
+  });
+
+  // Install trims, so detection must look up the trimmed key. Probing with the
+  // padded value made an installed package report itself missing.
+  it('installs the trimmed spec for a padded package', async () => {
+    const runner = recordRunner(0);
+    await installService({
+      entry: svcEntry({ package: ' @acme/svc ', version: '1.0.0 ' }),
+      verifier: recordVerifier(okProv),
+      runner,
+      logger: () => {},
+    });
+    expect(runner.calls).toEqual([['npm', ['install', '--global', '@acme/svc@1.0.0']]]);
+  });
+
   it('refuses runtimes it does not handle', async () => {
     const docker = {
       ...baseEntry,
@@ -238,6 +285,40 @@ describe('detectInstalled', () => {
       kind: 'service',
     });
     expect(rows.find((r) => r.slug === 'missing')).toMatchObject({ state: 'not installed' });
+  });
+
+  // Detection must use the same resolver the installer does. Probing with the
+  // raw padded key made an entry that installs as `@acme/svc` report itself
+  // not installed, because the lookup string kept its spaces.
+  it('detects a padded npm-global service by its trimmed package name', async () => {
+    const [row] = await detectInstalled(
+      [
+        entry('padded', {
+          kind: 'service',
+          runtime: 'npm-global',
+          npmGlobal: { package: ' @acme/svc ', version: '1.0.0' },
+        }),
+      ],
+      { listGlobalNpm: async () => ({ '@acme/svc': '1.0.0' }) },
+    );
+    expect(row!.state).toBe('installed');
+  });
+
+  // An entry the installer refuses is not something we can report on: claiming
+  // 'not installed' asserts an npm check that could never have matched.
+  it('reports an unresolvable npm-global service as unknown, not "not installed"', async () => {
+    const [row] = await detectInstalled(
+      [
+        entry('blank', {
+          kind: 'service',
+          runtime: 'npm-global',
+          npmGlobal: { package: '   ', version: '1.0.0' },
+        }),
+      ],
+      { listGlobalNpm: async () => ({}) },
+    );
+    expect(row!.state).toBe('unknown');
+    expect(row!.detail).toContain('no usable package metadata');
   });
 
   it('surfaces version drift against the registry pin', async () => {

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -828,6 +828,20 @@ describe('integration commands (Commander layer, real wire)', () => {
     trustTier: 'verified',
   } as unknown as IntegrationEntry;
 
+  // A runtime the CLI does not automate at all. Readable, and this branch is now
+  // its public install behaviour.
+  const svcBinary = {
+    ...baseEntry,
+    slug: 'svc-binary',
+    name: 'Service Binary',
+    install: {
+      kind: 'service',
+      runtime: 'binary',
+      binary: { url: 'https://example.com/svc' },
+    },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
   let savedIndex: string | undefined;
   let savedRaw: string | undefined;
 
@@ -839,7 +853,7 @@ describe('integration commands (Commander layer, real wire)', () => {
     process.env.DKG_REGISTRY_INDEX_URL = `${registryBase}/index`;
     process.env.DKG_REGISTRY_RAW_BASE = `${registryBase}/raw`;
 
-    for (const e of [alpha, beta, communityOnly, svcEntry, svcNoMeta]) {
+    for (const e of [alpha, beta, communityOnly, svcEntry, svcNoMeta, svcBinary]) {
       registryRoutes.set(`/raw/${e.slug}.json`, { status: 200, body: JSON.stringify(e) });
     }
     // Only the manual entries are indexed: `installed` runs detectInstalled over
@@ -989,5 +1003,18 @@ describe('integration commands (Commander layer, real wire)', () => {
     expect(r.exit).toBe(2);
     expect(r.err).toContain('no npmGlobal.package/version');
     expect(r.err).not.toMatch(/undefined/);
+  });
+
+  // Making docker/binary services readable also made this branch their public
+  // install behaviour. A regression routing them into installService would
+  // surface a generic "Install failed" (exit 1) instead of the graceful
+  // runtime-not-automated message — and no helper test would notice.
+  it('`install` gives a non-automated runtime the graceful path, not a generic failure', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-binary']);
+    expect(r.exit).toBe(2);
+    expect(r.err).toContain('binary');
+    expect(r.err).toContain('not yet');
+    // The generic catch-all path would say this instead.
+    expect(r.err).not.toContain('Install failed');
   });
 });

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
 import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -12,6 +13,7 @@ import {
   isGithubHost,
 } from '../src/integrations/registry-client.js';
 import { isIntegrationEntry } from '../src/integrations/schema.js';
+import { registerIntegrationCommands } from '../src/integrations/commands.js';
 import { installCli } from '../src/integrations/install-cli.js';
 import { installMcp } from '../src/integrations/install-mcp.js';
 import { normalizeRepoUrl } from '../src/integrations/verify-npm-provenance.js';
@@ -756,5 +758,129 @@ describe('installMcp with an args-less entry', () => {
       mcpServers: Record<string, { args: string[] }>;
     };
     expect(parsed.mcpServers['with-args']!.args).toEqual(['-y', 'pkg@1.0.0']);
+  });
+});
+
+// ── Commander layer: the public `dkg integration …` contracts ──────────────
+// Everything above tests helpers. The wiring between them — argument parsing,
+// tier defaults, which envelope key each verb prints — lives only in
+// commands.ts, so a regression there (a `search` that ignores its keyword, an
+// `installed` that prints `{ entries }`) would leave every helper test green.
+// These drive the real Commander tree against the real local registry server.
+describe('integration commands (Commander layer, real wire)', () => {
+  const manualEntry = (slug: string, name: string, tier: 'community' | 'verified'): IntegrationEntry =>
+    ({
+      ...baseEntry,
+      slug,
+      name,
+      description: `${name} integration for testing`,
+      install: { kind: 'manual', docsUrl: 'https://example.com/README.md' },
+      trustTier: tier,
+    }) as unknown as IntegrationEntry;
+
+  // `manual` entries keep detectInstalled off the network and off npm: with no
+  // cli/mcp/npm-global candidates it performs no I/O at all, so `installed`
+  // stays deterministic here and still exercises the real command path.
+  const alpha = manualEntry('alpha-chat', 'Alpha Chat', 'verified');
+  const beta = manualEntry('beta-graph', 'Beta Graph', 'verified');
+  const communityOnly = manualEntry('gamma-tool', 'Gamma Tool', 'community');
+
+  let savedIndex: string | undefined;
+  let savedRaw: string | undefined;
+
+  beforeEach(() => {
+    savedIndex = process.env.DKG_REGISTRY_INDEX_URL;
+    savedRaw = process.env.DKG_REGISTRY_RAW_BASE;
+    // commands.ts calls resolveRegistryConfig() with no argument, so the
+    // redirect has to happen through the real environment.
+    process.env.DKG_REGISTRY_INDEX_URL = `${registryBase}/index`;
+    process.env.DKG_REGISTRY_RAW_BASE = `${registryBase}/raw`;
+
+    for (const e of [alpha, beta, communityOnly]) {
+      registryRoutes.set(`/raw/${e.slug}.json`, { status: 200, body: JSON.stringify(e) });
+    }
+    registryRoutes.set('/index', {
+      status: 200,
+      body: JSON.stringify([alpha, beta, communityOnly].map((e) => ({ name: `${e.slug}.json` }))),
+    });
+  });
+
+  afterEach(() => {
+    if (savedIndex === undefined) delete process.env.DKG_REGISTRY_INDEX_URL;
+    else process.env.DKG_REGISTRY_INDEX_URL = savedIndex;
+    if (savedRaw === undefined) delete process.env.DKG_REGISTRY_RAW_BASE;
+    else process.env.DKG_REGISTRY_RAW_BASE = savedRaw;
+  });
+
+  /** Runs the real command tree and returns whatever it printed to stdout. */
+  async function runCli(argv: string[]): Promise<string> {
+    const program = new Command();
+    program.exitOverride(); // never let a parse error kill the test runner
+    registerIntegrationCommands(program);
+    const out: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      out.push(args.map(String).join(' '));
+    });
+    try {
+      await program.parseAsync(['node', 'dkg', ...argv]);
+    } finally {
+      spy.mockRestore();
+    }
+    return out.join('\n');
+  }
+
+  it('`search <keyword> --json` filters by the keyword', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'search', 'alpha', '--json']));
+    expect(parsed.entries.map((e: IntegrationEntry) => e.slug)).toEqual(['alpha-chat']);
+  });
+
+  // The control for the test above: without it, a `search` that dropped its
+  // keyword and returned everything would still need the filtered case to fail,
+  // but a `search` that returned NOTHING would pass it vacuously.
+  it('`search --json` with no keyword returns every entry at the tier', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'search', '--json']));
+    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
+      'alpha-chat',
+      'beta-graph',
+    ]);
+  });
+
+  it('`list --json` keeps its shipped { entries, failures } envelope', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'list', '--json']));
+    expect(Object.keys(parsed).sort()).toEqual(['entries', 'failures']);
+    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
+      'alpha-chat',
+      'beta-graph',
+    ]);
+  });
+
+  // `installed` reports something different from `list`/`search`, so it prints a
+  // different key. Printing `{ entries }` here would silently look like a
+  // registry listing to any script consuming it.
+  it('`installed --json` prints { installed, failures }, never { entries }', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'installed', '--json']));
+    expect(Object.keys(parsed).sort()).toEqual(['failures', 'installed']);
+    expect(parsed.entries).toBeUndefined();
+    expect(Array.isArray(parsed.installed)).toBe(true);
+  });
+
+  // The two verbs deliberately default to different tiers: browsing surfaces
+  // vetted entries, while "what is on my machine" must not hide a
+  // community-tier install the user actually has.
+  it('defaults `search` to verified but `installed` to community', async () => {
+    const searched = JSON.parse(await runCli(['integration', 'search', '--json']));
+    expect(searched.entries.map((e: IntegrationEntry) => e.slug)).not.toContain('gamma-tool');
+
+    const inst = JSON.parse(await runCli(['integration', 'installed', '--json']));
+    expect(inst.installed.map((r: { slug: string }) => r.slug)).toContain('gamma-tool');
+  });
+
+  it('`search --tier community --json` widens to community entries', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'search', '--tier', 'community', '--json']));
+    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
+      'alpha-chat',
+      'beta-graph',
+      'gamma-tool',
+    ]);
   });
 });

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -828,6 +828,21 @@ describe('integration commands (Commander layer, real wire)', () => {
     trustTier: 'verified',
   } as unknown as IntegrationEntry;
 
+  // Registry-valid, but the package is whitespace. The dispatcher used to gate
+  // on truthiness while the installer trimmed, so this passed the gate, threw
+  // inside installService, and surfaced as a generic "Install failed".
+  const svcBlankPkg = {
+    ...baseEntry,
+    slug: 'svc-blank',
+    name: 'Service Blank',
+    install: {
+      kind: 'service',
+      runtime: 'npm-global',
+      npmGlobal: { package: '   ', version: '1.0.0' },
+    },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
   // A runtime the CLI does not automate at all. Readable, and this branch is now
   // its public install behaviour.
   const svcBinary = {
@@ -853,7 +868,7 @@ describe('integration commands (Commander layer, real wire)', () => {
     process.env.DKG_REGISTRY_INDEX_URL = `${registryBase}/index`;
     process.env.DKG_REGISTRY_RAW_BASE = `${registryBase}/raw`;
 
-    for (const e of [alpha, beta, communityOnly, svcEntry, svcNoMeta, svcBinary]) {
+    for (const e of [alpha, beta, communityOnly, svcEntry, svcNoMeta, svcBinary, svcBlankPkg]) {
       registryRoutes.set(`/raw/${e.slug}.json`, { status: 200, body: JSON.stringify(e) });
     }
     // Only the manual entries are indexed: `installed` runs detectInstalled over
@@ -1021,6 +1036,16 @@ describe('integration commands (Commander layer, real wire)', () => {
     // the graceful message and then the generic failure — the regression this
     // test exists to catch.
     expect(r.exits).toEqual([2]);
+    expect(r.err).not.toContain('Install failed');
+  });
+
+  // The gap between the two gates: registry-valid, whitespace package. It must
+  // take the same graceful path as missing metadata, not fall through to the
+  // generic failure because one layer checked truthiness and the other trimmed.
+  it('`install` treats a whitespace-only package as not automatable, not a hard failure', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-blank']);
+    expect(r.exits).toEqual([2]);
+    expect(r.err).toContain('no npmGlobal.package/version');
     expect(r.err).not.toContain('Install failed');
   });
 

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -648,9 +648,17 @@ describe('registry ↔ CLI contract', () => {
   const schemaValidInstalls: Array<[string, Record<string, unknown>]> = [
     ['cli', { kind: 'cli', package: 'p', version: '1.0.0', binary: 'b' }],
     ['mcp (args present)', { kind: 'mcp', command: 'npx', args: ['-y', 'p'], supportedClients: ['cursor'] }],
-    // args is OPTIONAL in the schema — readable here, refused by installMcp.
+    // args is OPTIONAL in the schema; installMcp normalises a missing value to [].
     ['mcp (args absent)', { kind: 'mcp', command: 'npx', supportedClients: ['cursor'] }],
     ['service (npm-global)', { kind: 'service', runtime: 'npm-global', npmGlobal: { package: 'p', version: '1.0.0', binary: 'b' } }],
+    // The schema requires ONLY kind + runtime for a service; every payload
+    // object is optional. These minimal rows are the ones that actually pin
+    // the compatibility boundary — a validator that started demanding
+    // `npmGlobal` or `docker` would still pass the populated rows above and
+    // reject entries the registry considers valid, which is precisely the
+    // stricter-than-schema drift this PR exists to remove.
+    ['service (npm-global, minimal)', { kind: 'service', runtime: 'npm-global' }],
+    ['service (docker, minimal)', { kind: 'service', runtime: 'docker' }],
     ['service (docker)', { kind: 'service', runtime: 'docker', docker: { image: 'i', version: '1' } }],
     // 'binary' is in the schema's runtime enum.
     ['service (binary)', { kind: 'service', runtime: 'binary' }],

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -785,6 +785,29 @@ describe('integration commands (Commander layer, real wire)', () => {
   const beta = manualEntry('beta-graph', 'Beta Graph', 'verified');
   const communityOnly = manualEntry('gamma-tool', 'Gamma Tool', 'community');
 
+  // npm-global service WITHOUT `npmGlobal.binary` — schema-valid, and the shape
+  // resolveBinary's package-name fallback exists for.
+  const svcEntry = {
+    ...baseEntry,
+    slug: 'svc-ok',
+    name: 'Service OK',
+    install: {
+      kind: 'service',
+      runtime: 'npm-global',
+      npmGlobal: { package: '@acme/svc', version: '2.0.0' },
+    },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
+  // Schema-valid (only kind + runtime are required) but NOT automatable.
+  const svcNoMeta = {
+    ...baseEntry,
+    slug: 'svc-bare',
+    name: 'Service Bare',
+    install: { kind: 'service', runtime: 'npm-global' },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
   let savedIndex: string | undefined;
   let savedRaw: string | undefined;
 
@@ -796,9 +819,13 @@ describe('integration commands (Commander layer, real wire)', () => {
     process.env.DKG_REGISTRY_INDEX_URL = `${registryBase}/index`;
     process.env.DKG_REGISTRY_RAW_BASE = `${registryBase}/raw`;
 
-    for (const e of [alpha, beta, communityOnly]) {
+    for (const e of [alpha, beta, communityOnly, svcEntry, svcNoMeta]) {
       registryRoutes.set(`/raw/${e.slug}.json`, { status: 200, body: JSON.stringify(e) });
     }
+    // Only the manual entries are indexed: `installed` runs detectInstalled over
+    // everything the index returns, and keeping npm-backed kinds out of it means
+    // no test here ever shells out to npm. `install <slug>` fetches by slug, so
+    // the service entries are still reachable by the install tests below.
     registryRoutes.set('/index', {
       status: 200,
       body: JSON.stringify([alpha, beta, communityOnly].map((e) => ({ name: `${e.slug}.json` }))),
@@ -882,5 +909,65 @@ describe('integration commands (Commander layer, real wire)', () => {
       'beta-graph',
       'gamma-tool',
     ]);
+  });
+
+  // ── install dispatch ────────────────────────────────────────────────────
+  // The branches below are reachable only through the command; the helpers
+  // cannot tell you whether the dispatcher picked the right one or forwarded
+  // its options. Exit codes are captured rather than allowed to run, or a
+  // process.exit would take the test runner with it.
+  async function runInstall(argv: string[]): Promise<{ out: string; err: string; exit: number | null }> {
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationCommands(program);
+    const out: string[] = [];
+    const err: string[] = [];
+    let exit: number | null = null;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+      out.push(a.map(String).join(' '));
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+      err.push(a.map(String).join(' '));
+    });
+    // Records rather than throws. Throwing would be caught by the command's own
+    // try/catch, which then calls process.exit(1) — turning every asserted exit
+    // code into 1 and hiding which branch actually ran. Only the FIRST code is
+    // kept for the same reason: it is the one the real process would have used.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      if (exit === null) exit = code ?? 0;
+      return undefined;
+    }) as never);
+    try {
+      await program.parseAsync(['node', 'dkg', ...argv]);
+    } finally {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+    return { out: out.join('\n'), err: err.join('\n'), exit };
+  }
+
+  it('`install <manual>` prints the docs link and does not exit non-zero', async () => {
+    const r = await runInstall(['integration', 'install', 'alpha-chat']);
+    expect(r.exit).toBeNull();
+    expect(r.out).toContain('https://example.com/README.md');
+  });
+
+  it('`install <npm-global service> --dry-run` reaches the service installer with the pin', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-ok', '--dry-run']);
+    expect(r.exit).toBeNull();
+    // Proves dispatch reached installService AND that --dry-run was forwarded.
+    expect(r.out).toContain('@acme/svc@2.0.0');
+    expect(r.out).toContain('Dry-run');
+  });
+
+  // A schema-valid npm-global service with no npmGlobal block cannot be
+  // automated. It must take the same graceful path docker/binary take, not
+  // throw out of installService into the generic "install failed".
+  it('`install` falls back gracefully for an npm-global service with no package metadata', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-bare']);
+    expect(r.exit).toBe(2);
+    expect(r.err).toContain('no npmGlobal.package/version');
+    expect(r.err).not.toMatch(/undefined/);
   });
 });

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -950,12 +950,15 @@ describe('integration commands (Commander layer, real wire)', () => {
   // cannot tell you whether the dispatcher picked the right one or forwarded
   // its options. Exit codes are captured rather than allowed to run, or a
   // process.exit would take the test runner with it.
-  async function runInstall(argv: string[]): Promise<{ out: string; err: string; exit: number | null }> {
+  async function runInstall(
+    argv: string[],
+  ): Promise<{ out: string; err: string; exit: number | null; exits: number[] }> {
     const program = new Command();
     program.exitOverride();
     registerIntegrationCommands(program);
     const out: string[] = [];
     const err: string[] = [];
+    const exits: number[] = [];
     let exit: number | null = null;
     const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
       out.push(a.map(String).join(' '));
@@ -967,7 +970,18 @@ describe('integration commands (Commander layer, real wire)', () => {
     // try/catch, which then calls process.exit(1) — turning every asserted exit
     // code into 1 and hiding which branch actually ran. Only the FIRST code is
     // kept for the same reason: it is the one the real process would have used.
+    // The spy RECORDS rather than throws, because throwing is caught by the
+    // command's own try/catch and converted into exit(1) — which collapses
+    // every asserted exit code to 1 and hides which branch ran.
+    //
+    // The cost of not throwing is that execution CONTINUES past a simulated
+    // exit, so a missing `break` would let a branch fall through into the
+    // generic failure path while `exit` still reports the first code. Every
+    // code is therefore recorded: `exits` having more than one entry means the
+    // real process would already have terminated, and the test is observing
+    // code that could never run.
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      exits.push(code ?? 0);
       if (exit === null) exit = code ?? 0;
       return undefined;
     }) as never);
@@ -978,7 +992,7 @@ describe('integration commands (Commander layer, real wire)', () => {
       errSpy.mockRestore();
       exitSpy.mockRestore();
     }
-    return { out: out.join('\n'), err: err.join('\n'), exit };
+    return { out: out.join('\n'), err: err.join('\n'), exit, exits };
   }
 
   it('`install <manual>` prints the docs link and does not exit non-zero', async () => {
@@ -1000,9 +1014,14 @@ describe('integration commands (Commander layer, real wire)', () => {
   // throw out of installService into the generic "install failed".
   it('`install` falls back gracefully for an npm-global service with no package metadata', async () => {
     const r = await runInstall(['integration', 'install', 'svc-bare']);
-    expect(r.exit).toBe(2);
     expect(r.err).toContain('no npmGlobal.package/version');
     expect(r.err).not.toMatch(/undefined/);
+    // Exactly one exit. Asserting only the FIRST code would still pass if the
+    // branch lost its `break` and fell through into installService, printing
+    // the graceful message and then the generic failure — the regression this
+    // test exists to catch.
+    expect(r.exits).toEqual([2]);
+    expect(r.err).not.toContain('Install failed');
   });
 
   // Making docker/binary services readable also made this branch their public
@@ -1011,7 +1030,7 @@ describe('integration commands (Commander layer, real wire)', () => {
   // runtime-not-automated message — and no helper test would notice.
   it('`install` gives a non-automated runtime the graceful path, not a generic failure', async () => {
     const r = await runInstall(['integration', 'install', 'svc-binary']);
-    expect(r.exit).toBe(2);
+    expect(r.exits).toEqual([2]);
     expect(r.err).toContain('binary');
     expect(r.err).toContain('not yet');
     // The generic catch-all path would say this instead.

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -705,26 +705,48 @@ describe('registry ↔ CLI contract', () => {
   });
 });
 
-describe('installMcp args guard', () => {
+describe('installMcp with an args-less entry', () => {
+  // `args` is optional in the registry schema, and legitimately so: a server
+  // launched by a binary already on PATH needs none, while an npx-style
+  // launcher carries the package there. The installer must emit a well-formed
+  // block rather than dropping the key (JSON.stringify discards `undefined`)
+  // or refusing the entry — judging whether a given command needs args is the
+  // entry author's call, not the installer's.
   const mcpNoArgs: IntegrationEntry = {
     ...baseEntry,
     slug: 'no-args',
-    install: { kind: 'mcp', command: 'npx', supportedClients: ['cursor'] },
+    install: { kind: 'mcp', command: 'my-mcp-server', supportedClients: ['cursor'] },
   };
 
-  it('refuses an entry with no args instead of emitting a broken config', async () => {
-    // JSON.stringify drops undefined keys, so without this guard the emitted
-    // block would carry no `args` at all and the client would launch a bare
-    // `npx` with nothing to run.
-    await expect(installMcp({ entry: mcpNoArgs, apiUrl: 'http://127.0.0.1:9200' })).rejects.toThrow(
-      /no install\.args/i,
-    );
+  it('emits args: [] rather than omitting the key', async () => {
+    const res = await installMcp({
+      entry: mcpNoArgs,
+      apiUrl: 'http://127.0.0.1:9200',
+      logger: () => {},
+    });
+    const parsed = JSON.parse(res.mcpJson) as {
+      mcpServers: Record<string, { command: string; args: unknown }>;
+    };
+    const block = parsed.mcpServers['no-args']!;
+    expect(block.command).toBe('my-mcp-server');
+    expect(block.args).toEqual([]);
+    expect(res.mcpJson).toContain('"args"');
   });
 
-  it('refuses an entry with empty args', async () => {
-    const empty: IntegrationEntry = { ...mcpNoArgs, install: { kind: 'mcp', command: 'npx', args: [] } };
-    await expect(installMcp({ entry: empty, apiUrl: 'http://127.0.0.1:9200' })).rejects.toThrow(
-      /no install\.args/i,
-    );
+  it('preserves declared args when present', async () => {
+    const withArgs: IntegrationEntry = {
+      ...mcpNoArgs,
+      slug: 'with-args',
+      install: { kind: 'mcp', command: 'npx', args: ['-y', 'pkg@1.0.0'] },
+    };
+    const res = await installMcp({
+      entry: withArgs,
+      apiUrl: 'http://127.0.0.1:9200',
+      logger: () => {},
+    });
+    const parsed = JSON.parse(res.mcpJson) as {
+      mcpServers: Record<string, { args: string[] }>;
+    };
+    expect(parsed.mcpServers['with-args']!.args).toEqual(['-y', 'pkg@1.0.0']);
   });
 });

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -612,3 +612,119 @@ describe('installMcp', () => {
     expect(res.token).toBeUndefined();
   });
 });
+
+// ── Registry ↔ CLI contract ───────────────────────────────────────────────
+//
+// The CLI's validator is a hand-written re-implementation of the registry's
+// published JSON Schema. It drifted STRICTER than the schema in three places
+// and silently dropped every affected entry as "unreadable" — in `dkg
+// integration` and in the node dashboard sidebar, which share this parser.
+//
+// These tests own that seam. The per-kind cases are derived from the schema's
+// $defs (minimal shapes the registry can merge); the vendored cases are
+// verbatim copies of live entries. The first set is what catches drift.
+
+describe('registry ↔ CLI contract', () => {
+  const contractBase = {
+    schemaVersion: '0.1.0',
+    slug: 'contract-fixture',
+    name: 'Contract Fixture',
+    description: 'x'.repeat(25),
+    category: ['test'],
+    maintainer: { github: '@OriginTrail/core-developers' },
+    repo: 'https://github.com/OriginTrail/dkg',
+    commit: 'a'.repeat(40),
+    license: 'Apache-2.0',
+    memoryLayers: ['WM'],
+    v10PrimitivesUsed: ['UAL'],
+    publicInterfacesUsed: ['http-api'],
+    security: { networkEgress: [], writeAuthority: [] },
+    trustTier: 'community',
+  };
+
+  // One minimal, registry-VALID shape per $defs entry in the published schema.
+  // Every one of these must parse, or the registry can merge something the CLI
+  // cannot read.
+  const schemaValidInstalls: Array<[string, Record<string, unknown>]> = [
+    ['cli', { kind: 'cli', package: 'p', version: '1.0.0', binary: 'b' }],
+    ['mcp (args present)', { kind: 'mcp', command: 'npx', args: ['-y', 'p'], supportedClients: ['cursor'] }],
+    // args is OPTIONAL in the schema — readable here, refused by installMcp.
+    ['mcp (args absent)', { kind: 'mcp', command: 'npx', supportedClients: ['cursor'] }],
+    ['service (npm-global)', { kind: 'service', runtime: 'npm-global', npmGlobal: { package: 'p', version: '1.0.0', binary: 'b' } }],
+    ['service (docker)', { kind: 'service', runtime: 'docker', docker: { image: 'i', version: '1' } }],
+    // 'binary' is in the schema's runtime enum.
+    ['service (binary)', { kind: 'service', runtime: 'binary' }],
+    ['agent-plugin', { kind: 'agent-plugin', framework: 'openclaw', package: 'p', version: '1.0.0' }],
+    // manual requires docsUrl and FORBIDS anything but oneLiner beyond it.
+    ['manual (docsUrl only)', { kind: 'manual', docsUrl: 'https://example.com/README.md' }],
+    ['manual (+ oneLiner)', { kind: 'manual', docsUrl: 'https://example.com/README.md', oneLiner: 'run it' }],
+  ];
+
+  it.each(schemaValidInstalls)('accepts a schema-valid %s entry', (_label, install) => {
+    expect(isIntegrationEntry({ ...contractBase, install })).toBe(true);
+  });
+
+  it('still rejects shapes the schema would also reject', () => {
+    const invalid: Array<Record<string, unknown>> = [
+      { kind: 'manual' }, // docsUrl is required
+      { kind: 'mcp' }, // command is required
+      { kind: 'cli', package: 'p' }, // version + binary required
+      { kind: 'service' }, // runtime required
+      { kind: 'service', runtime: 'kubernetes' }, // not in the enum
+      { kind: 'not-a-kind' },
+    ];
+    for (const install of invalid) {
+      expect(isIntegrationEntry({ ...contractBase, install })).toBe(false);
+    }
+  });
+
+  it('parses every vendored live registry entry', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const dir = join(__dirname, 'fixtures', 'registry');
+    const files = (await readdir(dir)).filter(
+      (f) => f.endsWith('.json') && f !== 'integration.schema.json',
+    );
+    expect(files.length).toBeGreaterThan(0);
+    for (const f of files) {
+      const entry = JSON.parse(await readFile(join(dir, f), 'utf8'));
+      expect(isIntegrationEntry(entry), `${f} must be readable by the CLI`).toBe(true);
+    }
+  });
+
+  it('covers every install kind the published schema defines', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const schema = JSON.parse(
+      await readFile(join(__dirname, 'fixtures', 'registry', 'integration.schema.json'), 'utf8'),
+    );
+    const schemaKinds = Object.values(schema.$defs as Record<string, { properties: { kind: { const: string } } }>)
+      .map((d) => d.properties.kind.const)
+      .sort();
+    const covered = [...new Set(schemaValidInstalls.map(([, i]) => i.kind as string))].sort();
+    // If the registry adds an install kind, this fails until the CLI handles it.
+    expect(covered).toEqual(schemaKinds);
+  });
+});
+
+describe('installMcp args guard', () => {
+  const mcpNoArgs: IntegrationEntry = {
+    ...baseEntry,
+    slug: 'no-args',
+    install: { kind: 'mcp', command: 'npx', supportedClients: ['cursor'] },
+  };
+
+  it('refuses an entry with no args instead of emitting a broken config', async () => {
+    // JSON.stringify drops undefined keys, so without this guard the emitted
+    // block would carry no `args` at all and the client would launch a bare
+    // `npx` with nothing to run.
+    await expect(installMcp({ entry: mcpNoArgs, apiUrl: 'http://127.0.0.1:9200' })).rejects.toThrow(
+      /no install\.args/i,
+    );
+  });
+
+  it('refuses an entry with empty args', async () => {
+    const empty: IntegrationEntry = { ...mcpNoArgs, install: { kind: 'mcp', command: 'npx', args: [] } };
+    await expect(installMcp({ entry: empty, apiUrl: 'http://127.0.0.1:9200' })).rejects.toThrow(
+      /no install\.args/i,
+    );
+  });
+});

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -815,6 +815,9 @@ describe('integration commands (Commander layer, real wire)', () => {
       kind: 'service',
       runtime: 'npm-global',
       npmGlobal: { package: '@acme/svc', version: '2.0.0' },
+      // Declared so the DKG_API_URL guidance renders — that line is where an
+      // ignored --api-url becomes visible to an operator.
+      envRequired: ['DKG_API_URL'],
     },
     trustTier: 'verified',
   } as unknown as IntegrationEntry;
@@ -1037,6 +1040,38 @@ describe('integration commands (Commander layer, real wire)', () => {
     // test exists to catch.
     expect(r.exits).toEqual([2]);
     expect(r.err).not.toContain('Install failed');
+  });
+
+  // Regression guard for a fix that was previously verified only BELOW this
+  // boundary. `installService` accepted and rendered `apiUrl` correctly, and its
+  // unit test passed — while the command never passed the flag through, so the
+  // real CLI still printed the default node. Only a test that drives the actual
+  // command can catch a missing property on the call.
+  it('`install --api-url` reaches the service post-install guidance', async () => {
+    const r = await runInstall([
+      'integration',
+      'install',
+      'svc-ok',
+      '--dry-run',
+      '--api-url',
+      'http://10.0.0.5:9200',
+    ]);
+    expect(r.exits).toEqual([]);
+    expect(r.out).toContain('http://10.0.0.5:9200');
+    expect(r.out).not.toContain('default http://127.0.0.1:9200');
+  });
+
+  // Control: without the flag the guidance still renders, showing the effective
+  // node — so the test above cannot pass by never printing the DKG_API_URL line.
+  // Commander gives --api-url a default, so opts.apiUrl is always populated and
+  // the command path always echoes the URL actually in effect; the literal
+  // "default …" wording only appears for direct installService callers that
+  // pass no apiUrl at all.
+  it('`install --dry-run` shows the effective node when no --api-url is given', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-ok', '--dry-run']);
+    expect(r.out).toContain('DKG_API_URL');
+    expect(r.out).toContain('http://127.0.0.1:9200');
+    expect(r.out).not.toContain('10.0.0.5');
   });
 
   // The gap between the two gates: registry-valid, whitespace package. It must

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -3,7 +3,14 @@ import { Command } from 'commander';
 import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// This package is `"type": "module"`. Vitest's transform happens to supply
+// `__dirname`, so the fixture tests below do run — but relying on that is a
+// latent trap for anyone executing this file outside vitest. Resolve it from
+// import.meta.url instead so the fixture paths do not depend on the runner.
+const testDir = dirname(fileURLToPath(import.meta.url));
 
 import {
   resolveRegistryConfig,
@@ -682,6 +689,19 @@ describe('registry ↔ CLI contract', () => {
       { kind: 'service' }, // runtime required
       { kind: 'service', runtime: 'kubernetes' }, // not in the enum
       { kind: 'not-a-kind' },
+      // Payload objects are optional, but the schema marks THEIR fields
+      // required when present — and these drive a global npm install, so a
+      // non-string package must not reach the installer as `[object Object]`.
+      {
+        kind: 'service',
+        runtime: 'npm-global',
+        npmGlobal: { package: { name: '@acme/svc' }, version: '1.0.0' },
+      },
+      { kind: 'service', runtime: 'npm-global', npmGlobal: { package: '@acme/svc' } },
+      { kind: 'service', runtime: 'npm-global', npmGlobal: 'not-an-object' },
+      { kind: 'service', runtime: 'docker', docker: { image: 'i' } }, // version required
+      { kind: 'service', runtime: 'binary', binary: {} }, // url required
+      { kind: 'service', runtime: 'npm-global', portsOpened: ['8080'] },
     ];
     for (const install of invalid) {
       expect(isIntegrationEntry({ ...contractBase, install })).toBe(false);
@@ -690,7 +710,7 @@ describe('registry ↔ CLI contract', () => {
 
   it('parses every vendored live registry entry', async () => {
     const { readdir, readFile } = await import('node:fs/promises');
-    const dir = join(__dirname, 'fixtures', 'registry');
+    const dir = join(testDir, 'fixtures', 'registry');
     const files = (await readdir(dir)).filter(
       (f) => f.endsWith('.json') && f !== 'integration.schema.json',
     );
@@ -704,7 +724,7 @@ describe('registry ↔ CLI contract', () => {
   it('covers every install kind the published schema defines', async () => {
     const { readFile } = await import('node:fs/promises');
     const schema = JSON.parse(
-      await readFile(join(__dirname, 'fixtures', 'registry', 'integration.schema.json'), 'utf8'),
+      await readFile(join(testDir, 'fixtures', 'registry', 'integration.schema.json'), 'utf8'),
     );
     const schemaKinds = Object.values(schema.$defs as Record<string, { properties: { kind: { const: string } } }>)
       .map((d) => d.properties.kind.const)

--- a/packages/cli/test/mcp-registered-server-keys.test.ts
+++ b/packages/cli/test/mcp-registered-server-keys.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { readRegisteredServerKeys, type ClientTarget } from '../src/mcp-setup.js';
+
+// `dkg integration installed` reads MCP client configs through this helper to
+// decide whether an integration is wired into a client. The detectInstalled
+// tests inject a stub for row-mapping, so the real parsing behaviour — format
+// dispatch, alternate containers, and error swallowing — has to be exercised
+// here against genuine files, or nothing covers it.
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'dkg-mcp-keys-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function target(
+  filename: string,
+  body: string,
+  extra: Partial<ClientTarget> = {},
+): Promise<ClientTarget> {
+  const configPath = join(dir, filename);
+  await writeFile(configPath, body, 'utf8');
+  return { name: 'Test', configPath, displayPath: configPath, ...extra };
+}
+
+describe('readRegisteredServerKeys', () => {
+  it('reads the default mcpServers container', async () => {
+    const t = await target(
+      'cursor.json',
+      JSON.stringify({ mcpServers: { dkg: {}, 'buzz-dkg': {}, other: {} } }),
+    );
+    expect(readRegisteredServerKeys(t).sort()).toEqual(['buzz-dkg', 'dkg', 'other']);
+  });
+
+  // VSCode + Copilot Chat uses `servers.<name>` rather than `mcpServers.<name>`.
+  // A detector hardcoding `mcpServers` would silently report nothing here.
+  it('honours a non-default entryPath container', async () => {
+    const t = await target('vscode.json', JSON.stringify({ servers: { dkg: {}, mine: {} } }), {
+      entryPath: 'servers.dkg',
+    });
+    expect(readRegisteredServerKeys(t).sort()).toEqual(['dkg', 'mine']);
+  });
+
+  // Codex CLI keeps MCP servers in TOML under `mcp_servers`.
+  it('reads a TOML config with its own container', async () => {
+    const t = await target('codex.toml', '[mcp_servers.dkg]\ncommand = "x"\n\n[mcp_servers.mine]\ncommand = "y"\n', {
+      format: 'toml',
+      entryPath: 'mcp_servers.dkg',
+    });
+    expect(readRegisteredServerKeys(t).sort()).toEqual(['dkg', 'mine']);
+  });
+
+  it('returns [] for a malformed config rather than throwing', async () => {
+    const t = await target('broken.json', '{ this is not json');
+    expect(readRegisteredServerKeys(t)).toEqual([]);
+  });
+
+  it('returns [] when the config file does not exist', async () => {
+    const t: ClientTarget = {
+      name: 'Absent',
+      configPath: join(dir, 'nope.json'),
+      displayPath: 'nope.json',
+    };
+    expect(readRegisteredServerKeys(t)).toEqual([]);
+  });
+
+  it('returns [] when the container is missing or not an object', async () => {
+    const missing = await target('a.json', JSON.stringify({ somethingElse: {} }));
+    expect(readRegisteredServerKeys(missing)).toEqual([]);
+
+    const scalar = await target('b.json', JSON.stringify({ mcpServers: 'nope' }));
+    expect(readRegisteredServerKeys(scalar)).toEqual([]);
+  });
+
+  it('returns [] for an empty container without conflating it with a parse error', async () => {
+    const t = await target('empty.json', JSON.stringify({ mcpServers: {} }));
+    expect(readRegisteredServerKeys(t)).toEqual([]);
+  });
+});

--- a/packages/cli/test/mcp-registered-server-keys.test.ts
+++ b/packages/cli/test/mcp-registered-server-keys.test.ts
@@ -84,6 +84,16 @@ describe('readRegisteredServerKeys', () => {
     if (!probe.ok) expect(probe.reason).toContain('could not read');
   });
 
+  // `typeof [] === 'object'`, so an array container slipped past the malformed
+  // check and read as "readable, nothing registered" — a confident claim about
+  // a container we cannot interpret.
+  it('reports an ARRAY server container as a FAILED probe', async () => {
+    const t = await target('arr.json', JSON.stringify({ mcpServers: [] }));
+    const probe = readRegisteredServerKeys(t);
+    expect(probe.ok).toBe(false);
+    if (!probe.ok) expect(probe.reason).toContain('malformed');
+  });
+
   it('reports a malformed server container as a FAILED probe', async () => {
     // Readable JSON, but the container we need is a scalar — we cannot tell
     // what is registered, so this is not evidence of absence.

--- a/packages/cli/test/mcp-registered-server-keys.test.ts
+++ b/packages/cli/test/mcp-registered-server-keys.test.ts
@@ -38,14 +38,17 @@ async function target(
 /** Fails loudly with the probe's own reason instead of a bare undefined. */
 function keysOf(probe: ServerKeyProbe): string[] {
   if (!probe.ok) throw new Error(`expected a readable config, got: ${probe.reason}`);
-  return [...probe.keys].sort();
+  return Object.keys(probe.servers).sort();
 }
+
+/** A minimal launchable block — anything without `command` is not a registration. */
+const blk = (command = 'npx', args: string[] = []) => ({ command, args });
 
 describe('readRegisteredServerKeys', () => {
   it('reads the default mcpServers container', async () => {
     const t = await target(
       'cursor.json',
-      JSON.stringify({ mcpServers: { dkg: {}, 'buzz-dkg': {}, other: {} } }),
+      JSON.stringify({ mcpServers: { dkg: blk(), 'buzz-dkg': blk(), other: blk() } }),
     );
     expect(keysOf(readRegisteredServerKeys(t))).toEqual(['buzz-dkg', 'dkg', 'other']);
   });
@@ -53,7 +56,7 @@ describe('readRegisteredServerKeys', () => {
   // VSCode + Copilot Chat uses `servers.<name>` rather than `mcpServers.<name>`.
   // A detector hardcoding `mcpServers` would silently report nothing here.
   it('honours a non-default entryPath container', async () => {
-    const t = await target('vscode.json', JSON.stringify({ servers: { dkg: {}, mine: {} } }), {
+    const t = await target('vscode.json', JSON.stringify({ servers: { dkg: blk(), mine: blk() } }), {
       entryPath: 'servers.dkg',
     });
     expect(keysOf(readRegisteredServerKeys(t))).toEqual(['dkg', 'mine']);
@@ -90,19 +93,19 @@ describe('readRegisteredServerKeys', () => {
     if (!probe.ok) expect(probe.reason).toContain('malformed');
   });
 
-  it('treats an absent config file as a SUCCESSFUL probe with no keys', async () => {
+  it('treats an absent config file as a SUCCESSFUL probe with no servers', async () => {
     // Nothing to read is a real answer: this client registered nothing.
     const t: ClientTarget = {
       name: 'Absent',
       configPath: join(dir, 'nope.json'),
       displayPath: 'nope.json',
     };
-    expect(readRegisteredServerKeys(t)).toEqual({ ok: true, keys: [] });
+    expect(readRegisteredServerKeys(t)).toEqual({ ok: true, servers: {} });
   });
 
-  it('treats a missing container as a SUCCESSFUL probe with no keys', async () => {
+  it('treats a missing container as a SUCCESSFUL probe with no servers', async () => {
     const t = await target('a.json', JSON.stringify({ somethingElse: {} }));
-    expect(readRegisteredServerKeys(t)).toEqual({ ok: true, keys: [] });
+    expect(readRegisteredServerKeys(t)).toEqual({ ok: true, servers: {} });
   });
 
   // The inverse false report: a key whose value cannot launch anything is not
@@ -118,6 +121,9 @@ describe('readRegisteredServerKeys', () => {
           nulled: null,
           scalar: 'npx -y p',
           listy: [],
+          // An object with no `command` cannot launch either, so it is not a
+          // registration — review flagged `{}` under a slug being counted.
+          noCommand: { env: { A: '1' } },
         },
       }),
     );
@@ -131,7 +137,7 @@ describe('readRegisteredServerKeys', () => {
     // Same "no keys" outcome, DIFFERENT probe status — the previous version of
     // this test compared both to [] and so could not have caught a regression
     // that conflated them.
-    expect(readRegisteredServerKeys(empty)).toEqual({ ok: true, keys: [] });
+    expect(readRegisteredServerKeys(empty)).toEqual({ ok: true, servers: {} });
     expect(readRegisteredServerKeys(broken).ok).toBe(false);
   });
 });

--- a/packages/cli/test/mcp-registered-server-keys.test.ts
+++ b/packages/cli/test/mcp-registered-server-keys.test.ts
@@ -105,6 +105,26 @@ describe('readRegisteredServerKeys', () => {
     expect(readRegisteredServerKeys(t)).toEqual({ ok: true, keys: [] });
   });
 
+  // The inverse false report: a key whose value cannot launch anything is not
+  // a registration. `classify()` in the same module already treats `{ dkg: null }`
+  // as not-registered, so counting it here would have made `installed` claim an
+  // integration was present that no client could start.
+  it('ignores keys whose value is not a usable server block', async () => {
+    const t = await target(
+      'mixed.json',
+      JSON.stringify({
+        mcpServers: {
+          good: { command: 'npx', args: ['-y', 'p'] },
+          nulled: null,
+          scalar: 'npx -y p',
+          listy: [],
+        },
+      }),
+    );
+    // The readable-config status is unchanged — this is a filter, not a failure.
+    expect(keysOf(readRegisteredServerKeys(t))).toEqual(['good']);
+  });
+
   it('distinguishes an empty container from a parse error', async () => {
     const empty = await target('empty.json', JSON.stringify({ mcpServers: {} }));
     const broken = await target('broken2.json', '{ nope');

--- a/packages/cli/test/mcp-registered-server-keys.test.ts
+++ b/packages/cli/test/mcp-registered-server-keys.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { readRegisteredServerKeys, type ClientTarget } from '../src/mcp-setup.js';
+import {
+  readRegisteredServerKeys,
+  type ClientTarget,
+  type ServerKeyProbe,
+} from '../src/mcp-setup.js';
 
 // `dkg integration installed` reads MCP client configs through this helper to
 // decide whether an integration is wired into a client. The detectInstalled
@@ -31,13 +35,19 @@ async function target(
   return { name: 'Test', configPath, displayPath: configPath, ...extra };
 }
 
+/** Fails loudly with the probe's own reason instead of a bare undefined. */
+function keysOf(probe: ServerKeyProbe): string[] {
+  if (!probe.ok) throw new Error(`expected a readable config, got: ${probe.reason}`);
+  return [...probe.keys].sort();
+}
+
 describe('readRegisteredServerKeys', () => {
   it('reads the default mcpServers container', async () => {
     const t = await target(
       'cursor.json',
       JSON.stringify({ mcpServers: { dkg: {}, 'buzz-dkg': {}, other: {} } }),
     );
-    expect(readRegisteredServerKeys(t).sort()).toEqual(['buzz-dkg', 'dkg', 'other']);
+    expect(keysOf(readRegisteredServerKeys(t))).toEqual(['buzz-dkg', 'dkg', 'other']);
   });
 
   // VSCode + Copilot Chat uses `servers.<name>` rather than `mcpServers.<name>`.
@@ -46,7 +56,7 @@ describe('readRegisteredServerKeys', () => {
     const t = await target('vscode.json', JSON.stringify({ servers: { dkg: {}, mine: {} } }), {
       entryPath: 'servers.dkg',
     });
-    expect(readRegisteredServerKeys(t).sort()).toEqual(['dkg', 'mine']);
+    expect(keysOf(readRegisteredServerKeys(t))).toEqual(['dkg', 'mine']);
   });
 
   // Codex CLI keeps MCP servers in TOML under `mcp_servers`.
@@ -55,33 +65,53 @@ describe('readRegisteredServerKeys', () => {
       format: 'toml',
       entryPath: 'mcp_servers.dkg',
     });
-    expect(readRegisteredServerKeys(t).sort()).toEqual(['dkg', 'mine']);
+    expect(keysOf(readRegisteredServerKeys(t))).toEqual(['dkg', 'mine']);
   });
 
-  it('returns [] for a malformed config rather than throwing', async () => {
+  // The cases below are the point of the probe type. "We read it, nothing is
+  // registered" and "we could not read it" must not be the same value, or a
+  // caller reporting install state turns an unreadable config into a confident
+  // "not installed". Each pair is asserted in BOTH directions so a regression
+  // that collapses them fails here rather than surfacing as a false negative.
+
+  it('reports a config it cannot parse as a FAILED probe', async () => {
     const t = await target('broken.json', '{ this is not json');
-    expect(readRegisteredServerKeys(t)).toEqual([]);
+    const probe = readRegisteredServerKeys(t);
+    expect(probe.ok).toBe(false);
+    if (!probe.ok) expect(probe.reason).toContain('could not read');
   });
 
-  it('returns [] when the config file does not exist', async () => {
+  it('reports a malformed server container as a FAILED probe', async () => {
+    // Readable JSON, but the container we need is a scalar — we cannot tell
+    // what is registered, so this is not evidence of absence.
+    const t = await target('b.json', JSON.stringify({ mcpServers: 'nope' }));
+    const probe = readRegisteredServerKeys(t);
+    expect(probe.ok).toBe(false);
+    if (!probe.ok) expect(probe.reason).toContain('malformed');
+  });
+
+  it('treats an absent config file as a SUCCESSFUL probe with no keys', async () => {
+    // Nothing to read is a real answer: this client registered nothing.
     const t: ClientTarget = {
       name: 'Absent',
       configPath: join(dir, 'nope.json'),
       displayPath: 'nope.json',
     };
-    expect(readRegisteredServerKeys(t)).toEqual([]);
+    expect(readRegisteredServerKeys(t)).toEqual({ ok: true, keys: [] });
   });
 
-  it('returns [] when the container is missing or not an object', async () => {
-    const missing = await target('a.json', JSON.stringify({ somethingElse: {} }));
-    expect(readRegisteredServerKeys(missing)).toEqual([]);
-
-    const scalar = await target('b.json', JSON.stringify({ mcpServers: 'nope' }));
-    expect(readRegisteredServerKeys(scalar)).toEqual([]);
+  it('treats a missing container as a SUCCESSFUL probe with no keys', async () => {
+    const t = await target('a.json', JSON.stringify({ somethingElse: {} }));
+    expect(readRegisteredServerKeys(t)).toEqual({ ok: true, keys: [] });
   });
 
-  it('returns [] for an empty container without conflating it with a parse error', async () => {
-    const t = await target('empty.json', JSON.stringify({ mcpServers: {} }));
-    expect(readRegisteredServerKeys(t)).toEqual([]);
+  it('distinguishes an empty container from a parse error', async () => {
+    const empty = await target('empty.json', JSON.stringify({ mcpServers: {} }));
+    const broken = await target('broken2.json', '{ nope');
+    // Same "no keys" outcome, DIFFERENT probe status — the previous version of
+    // this test compared both to [] and so could not have caught a regression
+    // that conflated them.
+    expect(readRegisteredServerKeys(empty)).toEqual({ ok: true, keys: [] });
+    expect(readRegisteredServerKeys(broken).ok).toBe(false);
   });
 });

--- a/packages/cli/test/mcp-registered-server-keys.test.ts
+++ b/packages/cli/test/mcp-registered-server-keys.test.ts
@@ -131,6 +131,27 @@ describe('readRegisteredServerKeys', () => {
     expect(keysOf(readRegisteredServerKeys(t))).toEqual(['good']);
   });
 
+  // Missing args and malformed args are different facts. Normalizing `[123]`
+  // to `[]` would let a malformed block match an args-less registry entry.
+  it('distinguishes an absent args key from a malformed one', async () => {
+    const t = await target(
+      'args.json',
+      JSON.stringify({
+        mcpServers: {
+          absent: { command: 'my-server' },
+          malformed: { command: 'my-server', args: [123] },
+          good: { command: 'npx', args: ['-y', 'p'] },
+        },
+      }),
+    );
+    const probe = readRegisteredServerKeys(t);
+    expect(probe.ok).toBe(true);
+    if (!probe.ok) return;
+    expect(probe.servers.absent!.args).toEqual([]);
+    expect(probe.servers.malformed!.args).toBeNull();
+    expect(probe.servers.good!.args).toEqual(['-y', 'p']);
+  });
+
   it('distinguishes an empty container from a parse error', async () => {
     const empty = await target('empty.json', JSON.stringify({ mcpServers: {} }));
     const broken = await target('broken2.json', '{ nope');


### PR DESCRIPTION
## Summary

- **The CLI's registry parser was stricter than the registry's own published JSON Schema**, so entries that pass `validate.mjs` upstream were silently dropped as "unreadable" — in `dkg integration` *and* in the node dashboard sidebar, which share the parser via `fetchAllEntries()`. `manual` required an `install.steps` field the schema **forbids** (`additionalProperties: false`) while ignoring the required `docsUrl`; `steps` has never existed in the schema, so **no `manual` entry could ever be read**. `mcp` required the schema-optional `args`; `service` rejected the schema's `binary` runtime. Four `manual` entries are affected today, including the merged, `verified`-tier `buzz-dkg`.
- **Nothing tested the seam**, which is why it drifted: the existing fixtures cover only `cli` and `mcp` — precisely the two compatible kinds. This adds a contract test (one schema-valid fixture per install kind + vendored live entries + a check that every schema-defined kind is covered) and records the invariant in-code: *the CLI validator must never be stricter than the published schema.* It may be more lenient, so an older CLI can still read a newer registry.
- **`manual` installs now hand off instead of erroring.** Per CONTRIBUTING §2 `manual` means "the installer links out to your docs" — a success path — so it prints `docsUrl` + `oneLiner` + the security declaration and exits **0**. It was previously grouped with genuinely unimplemented kinds and exited 2. `info` also renders `manual` and the `service` `binary` runtime, both of which printed nothing.
- **`search` / `list` split**, matching the registry README and npm/apt convention: `search` discovers the registry (what `list` used to do, plus a keyword filter); `list` reports what is installed here, **derived** from the install targets rather than a ledger. `installMcp` writes nothing — it prints a block for the user to paste — so a ledger would claim installs that never happened; detection reports what is *true*. Undetectable kinds report `unknown`, never "not installed".
- **`installService` for `runtime: npm-global`**, mirroring `installCli` including the provenance gate, unblocking the one pending `service` entry (dkg-integrations#9). `docker`/`binary` keep the explicit not-implemented message.

> ⚠️ **Behaviour change for release notes:** `dkg integration list` previously listed the registry. Scripts using it for discovery should move to `dkg integration search`. The old meaning contradicted the published registry README.

## Related

- Registry-side companion: **OriginTrail/dkg-integrations#25** — corrects the README to the CLI that exists, adds `publicInterfacesUsed` guidance, drops the redundant `cursor-mcp-dkg` entry. Independent; needs no CLI release.
- Unblocks: **OriginTrail/dkg-integrations#9** (`tracabot`, the only pending `service` entry)
- Plan + full root-cause analysis: `agent-docs/plans/2026-07-28-dkg-integrations-cli-contract.md`

## Diagrams

### Reading a registry entry

Before — a schema-valid `manual` entry never survives the parser:

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Registry
    participant Parser as isIntegrationEntry
    User->>CLI: dkg integration list
    CLI->>Registry: GET integrations/*.json
    Registry-->>CLI: buzz-dkg (kind: manual, docsUrl)
    CLI->>Parser: validate
    Parser-->>CLI: false (no install.steps)
    CLI-->>User: "Skipped 1 unreadable registry entry"
```

After — the parser matches the schema:

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Registry
    participant Parser as isIntegrationEntry
    User->>CLI: dkg integration search
    CLI->>Registry: GET integrations/*.json
    Registry-->>CLI: buzz-dkg (kind: manual, docsUrl)
    CLI->>Parser: validate
    Parser-->>CLI: true
    CLI-->>User: buzz-dkg [verified] Buzz DKG Integration
```

### Installing a `manual` integration

Before — exits 2 pointing at the repo root:

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Entry
    User->>CLI: dkg integration install buzz-dkg
    CLI->>Entry: read install.kind
    Entry-->>CLI: manual
    CLI-->>User: "not yet supported by the CLI" (exit 2)
```

After — hands off to the entry's own docs:

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Entry
    User->>CLI: dkg integration install buzz-dkg
    CLI->>Entry: read install.kind
    Entry-->>CLI: manual + docsUrl + oneLiner
    CLI-->>User: docs URL, one-liner, security declaration (exit 0)
```

## Files changed

| File | What |
|------|------|
| `packages/cli/src/integrations/schema.ts` | Conform `isValidInstallSpec` to the published schema (`manual`→`docsUrl`, `mcp.args` optional, `service` `binary` runtime); fix the matching TS types; record the never-stricter invariant |
| `packages/cli/src/integrations/install-mcp.ts` | Refuse an args-less entry instead of emitting a config whose `args` key `JSON.stringify` drops |
| `packages/cli/src/integrations/install-service.ts` | **New.** `installService` for `runtime: npm-global`, mirroring `installCli` incl. the provenance gate, with daemon-oriented post-install guidance |
| `packages/cli/src/integrations/detect-installed.ts` | **New.** Derive installed state from install targets (`npm ls -g`; MCP client configs keyed on slug); injectable deps so tests spawn nothing |
| `packages/cli/src/integrations/commands.ts` | `search` (registry + keyword) and `list` (installed here); `manual` hand-off exits 0; `info` renders `manual` and `service.binary`; dispatch `service`→`installService` |
| `packages/cli/test/integrations.test.ts` | Contract suite: schema-valid fixture per install kind, vendored live entries, schema-kind coverage check, `installMcp` args guard |
| `packages/cli/test/fixtures/registry/*` | **New.** Vendored live entries + the published schema, with a README explaining why they exist and how to refresh |

## Test plan

- [x] `npx vitest run test/integrations.test.ts` → **54 passed**
- [x] `npx tsc -p tsconfig.json --noEmit` → no errors in `src/integrations/`
- [x] **Mutation check** — revert the `manual` rule to `isStringArray(v.steps)` → 3 contract tests fail (`manual (docsUrl only)`, `manual (+ oneLiner)`, `parses every vendored live registry entry`), mutation confirmed still on disk at exit; restored and re-verified green
- [x] End-to-end against the **live** registry:
  - `dkg integration search` → `buzz-dkg [verified]` now listed (was "Skipped 1 unreadable registry entry")
  - `dkg integration search buzz` → 1 match
  - `dkg integration info buzz-dkg` → renders `docs:` and `summary:` (previously printed nothing for `manual`)
  - `dkg integration install buzz-dkg; echo $?` → docs hand-off, **exit 0**
  - `dkg integration list` → reports `buzz-dkg` as `unknown (install kind the CLI does not perform)`, not "not installed"
- [ ] Reviewer to confirm the dashboard sidebar (`GET /api/integrations/registry`) now returns `buzz-dkg` — same parser, no code change expected on that path

Deferred deliberately: `upgrade`/`uninstall` (must *undo* an install, incl. MCP client configs the CLI never wrote), `agent-plugin` and `service` docker/binary installers, and tightening `mcp.args` to required in schema v0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
