### PR TITLE
ci: run the full gates on testnet-canary PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # CODEOWNERS — required reviewer routing for security-sensitive paths.
 #
-# Branch protection on `main` / `v10-rc` should have "Require review from
+# Branch protection on `main` / `testnet-canary` should have "Require review from
 # Code Owners" enabled (admin task — see
 # docs/security/SUPPLY_CHAIN_HARDENING.md §C). With that toggle on, any
 # PR that touches a path listed below requires an approving review from

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,7 +1022,7 @@ jobs:
   #                                parallel; previously ~20 min single).
   #   - merge queue candidate    : same sharded suite against the exact
   #                                combined commit that is about to land.
-  #   - push (main / v10-rc / …) : full coverage + ratchet safety net,
+  #   - push (trigger branches)  : full coverage + ratchet safety net,
   #                                single job (coverage reports don't
   #                                compose across shards, so we keep
   #                                the safety-net job unsharded).
@@ -1203,7 +1203,7 @@ jobs:
   #   * pull_request : runs only when the `changes` filter detects
   #                    contract-touching paths (mirrors the existing
   #                    Tornado: Solidity lane).
-  #   * push (main / v10-rc / …) : ALWAYS runs so the Security tab
+  #   * push (trigger branches) : ALWAYS runs so the Security tab
   #                    baseline refreshes after every merge. Without
   #                    this, post-merge findings would never bubble
   #                    up to Code Scanning even though they apply to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ name: CI
 #     or trigger the workflow manually via `workflow_dispatch`.
 on:
   push:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
   pull_request:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   # When merge queue is enabled, this is the pre-merge full-CI safety net.
   # It validates the exact candidate that will land, without introducing a
@@ -231,7 +231,7 @@ jobs:
           key: turbo-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-${{ github.ref }}-
-            turbo-${{ runner.os }}-refs/heads/v10-rc-
+            turbo-${{ runner.os }}-refs/heads/main-
             turbo-${{ runner.os }}-
 
       - name: Build all Node packages (evm-module hardhat compile short-circuits)

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -2,9 +2,9 @@ name: EVM Integration Tests
 
 on:
   push:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
   pull_request:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -13,9 +13,9 @@ name: Knip (dead-code baseline)
 
 on:
   push:
-    branches: [main, v10-rc, rc17-vm-wip]
+    branches: [main, testnet-canary, rc17-vm-wip]
   pull_request:
-    branches: [main, v10-rc, rc17-vm-wip]
+    branches: [main, testnet-canary, rc17-vm-wip]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -26,7 +26,7 @@ name: Supply chain scan
 
 on:
   pull_request:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
@@ -53,7 +53,7 @@ on:
       - '.cursorrules'
       - '**/.cursorrules'
   push:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'


### PR DESCRIPTION
## Summary

- **`testnet-canary` PRs currently run almost no CI.** The vitest lanes, EVM integration, knip and the supply-chain scan are all branch-filtered to `[main, v10-rc, release/rc.12, rc17-vm-wip]`, so a PR targeting canary gets only SPARQL-lint and the path-filtered gates. A change can land on canary with no unit signal at all.
- **This was an omission, not a decision.** `git log -S'testnet-canary' -- .github/workflows/ci.yml` returns nothing — the branch was never in the filters. They were last touched on 2026-04-03 to add `v10-rc`, and `testnet-canary` postdates that.
- **Also drops `v10-rc`**, which no longer resolves (`git rev-parse origin/v10-rc` → gone). A deleted branch in a filter is dead weight, and it was also used as a turbo `restore-key` fallback, so that cache tier could never hit; repointed at `main`.

## Related

- Surfaced while retargeting **#1988** at `testnet-canary` and noticing the CLI vitest lanes stopped running.
- Ordering note for whoever lands this: see **Follow-up** below — the `protect-main` ruleset requires `CI gate` and `EVM integration gate`, so a canary ruleset must come *after* this merges, not before.

## Diagrams

- No flow changes — CI trigger configuration only.

## Files changed

| File | What |
|------|------|
| `.github/workflows/ci.yml` | Add `testnet-canary` to push + PR filters; drop dead `v10-rc`; repoint the `v10-rc` turbo restore-key at `main` |
| `.github/workflows/evm-integration.yml` | Same filter update |
| `.github/workflows/knip.yml` | Same filter update |
| `.github/workflows/supply-chain-scan.yml` | Same filter update |

## Test plan

- [x] All four workflows parse: `npx js-yaml <file>` → OK for each
- [x] `grep -rn v10-rc .github/workflows/` → only two explanatory comments remain, no live references
- [ ] After merge: open or re-push a PR targeting `testnet-canary` and confirm `CI gate`, `EVM integration gate`, `Knip dead-code report` and the supply-chain scan all appear
- [ ] After merge: confirm a push to `testnet-canary` triggers the same lanes

## Follow-up (deliberately not in this PR)

Branch **rules** are a settings change, not a file change, so they can't ride along here. `main` is governed by the `protect-main` ruleset (id `14325863`), which targets `~DEFAULT_BRANCH` only:

| rule | value |
|---|---|
| pull_request | 1 approving review, code-owner review required |
| required_status_checks | `CI gate`, `EVM integration gate` (non-strict) |
| merge_queue | MERGE, ALLGREEN, up to 5 entries |
| deletion / non_fast_forward | blocked |

**These must be applied to `testnet-canary` only after this PR merges.** The required checks are exactly the ones this PR enables — turning them on first would leave every canary PR blocked forever on checks that never run.

Worth a separate decision: whether canary wants the **merge queue** at all. It adds latency, and a canary branch is usually optimising for iteration speed. The protection rules (no deletion, no force-push, review required) are the parts that matter most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
