### PR TITLE
chore: sync main into testnet-canary after CI parity (#1992)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # CODEOWNERS — required reviewer routing for security-sensitive paths.
 #
-# Branch protection on `main` / `v10-rc` should have "Require review from
+# Branch protection on `main` / `testnet-canary` should have "Require review from
 # Code Owners" enabled (admin task — see
 # docs/security/SUPPLY_CHAIN_HARDENING.md §C). With that toggle on, any
 # PR that touches a path listed below requires an approving review from

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,7 +1022,7 @@ jobs:
   #                                parallel; previously ~20 min single).
   #   - merge queue candidate    : same sharded suite against the exact
   #                                combined commit that is about to land.
-  #   - push (main / v10-rc / …) : full coverage + ratchet safety net,
+  #   - push (trigger branches)  : full coverage + ratchet safety net,
   #                                single job (coverage reports don't
   #                                compose across shards, so we keep
   #                                the safety-net job unsharded).
@@ -1203,7 +1203,7 @@ jobs:
   #   * pull_request : runs only when the `changes` filter detects
   #                    contract-touching paths (mirrors the existing
   #                    Tornado: Solidity lane).
-  #   * push (main / v10-rc / …) : ALWAYS runs so the Security tab
+  #   * push (trigger branches) : ALWAYS runs so the Security tab
   #                    baseline refreshes after every merge. Without
   #                    this, post-merge findings would never bubble
   #                    up to Code Scanning even though they apply to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ name: CI
 #     or trigger the workflow manually via `workflow_dispatch`.
 on:
   push:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
   pull_request:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   # When merge queue is enabled, this is the pre-merge full-CI safety net.
   # It validates the exact candidate that will land, without introducing a
@@ -231,7 +231,7 @@ jobs:
           key: turbo-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-${{ github.ref }}-
-            turbo-${{ runner.os }}-refs/heads/v10-rc-
+            turbo-${{ runner.os }}-refs/heads/main-
             turbo-${{ runner.os }}-
 
       - name: Build all Node packages (evm-module hardhat compile short-circuits)

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -2,9 +2,9 @@ name: EVM Integration Tests
 
 on:
   push:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
   pull_request:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -13,9 +13,9 @@ name: Knip (dead-code baseline)
 
 on:
   push:
-    branches: [main, v10-rc, rc17-vm-wip]
+    branches: [main, testnet-canary, rc17-vm-wip]
   pull_request:
-    branches: [main, v10-rc, rc17-vm-wip]
+    branches: [main, testnet-canary, rc17-vm-wip]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -26,7 +26,7 @@ name: Supply chain scan
 
 on:
   pull_request:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
@@ -53,7 +53,7 @@ on:
       - '.cursorrules'
       - '**/.cursorrules'
   push:
-    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge this with a merge commit — do not squash.**
> Squash-merging the previous sync (#1986) is what silently diverged the two
> branches: it collapsed the merge into a single-parent commit, so the content
> matched byte-for-byte while the ancestry did not. That had to be repaired by
> hand in `eb1cc7946`. A real merge commit keeps the histories joined.

## Summary

- Syncs `main` into `testnet-canary` after #1992 merged, so canary carries the CI trigger parity it was created to receive.
- The only delta is #1992's workflow/CODEOWNERS change — canary carries **no** content outside `.github/` that `main` lacks, so this sync has no behavioural surface beyond CI triggering.
- After this lands, canary PRs stop silently skipping the main test suite. Today a canary-targeted PR dispatches only the RFC-64 Windows gate and the SPARQL lint; the vitest shards, EVM integration, Knip, and the supply-chain scan never fire, because canary's own `ci.yml` is the file GitHub consults and it does not list `testnet-canary` in `on.pull_request.branches`.

### Divergence state going in

| | |
|---|---|
| `main` | `b67656772` |
| `testnet-canary` | `eb1cc7946` |
| canary behind main | 3 commits (#1992 and its two commits) |
| canary ahead of main | 2 commits — `aab9ec94d` (squash artifact) + `eb1cc7946` (the repair merge) |
| content canary has that main lacks | none |

## Related

- Follows #1992 (`ci: run the full gates on testnet-canary PRs`) — this PR is what actually delivers that config to canary.
- Repairs the pattern from #1986, whose squash-merge caused the ancestry split fixed in `eb1cc7946`.
- Blocks the follow-up `protect-testnet-canary` ruleset: it requires the `CI gate` and `EVM integration gate` checks, which cannot dispatch on canary PRs until this merges. Creating that ruleset first would leave every canary PR blocked on checks that never arrive.

## Diagrams

### Which workflows dispatch on a `testnet-canary` PR

Before (canary's `ci.yml` omits `testnet-canary`, so the trigger filter rejects it):

```mermaid
sequenceDiagram
    participant Dev
    participant GitHub
    participant Workflows
    Dev->>GitHub: open PR, base=testnet-canary
    GitHub->>GitHub: read ci.yml from merge commit
    Note over GitHub: on.pull_request.branches =<br/>[main, v10-rc, release/rc.12, rc17-vm-wip]<br/>base not in list
    GitHub--xWorkflows: CI, EVM, Knip, supply-chain NOT dispatched
    GitHub->>Workflows: RFC-64 Windows gate, SPARQL lint (unfiltered)
    Workflows-->>Dev: 2 checks — looks green, suite never ran
```

After (canary inherits the widened filter):

```mermaid
sequenceDiagram
    participant Dev
    participant GitHub
    participant Workflows
    Dev->>GitHub: open PR, base=testnet-canary
    GitHub->>GitHub: read ci.yml from merge commit
    Note over GitHub: on.pull_request.branches =<br/>[main, testnet-canary, release/rc.12, rc17-vm-wip]<br/>base matches
    GitHub->>Workflows: CI (4 vitest shards), EVM integration, Knip, supply-chain
    GitHub->>Workflows: RFC-64 Windows gate, SPARQL lint
    Workflows-->>Dev: full gate set — green means tested
```

## Files changed

| File | What |
|------|------|
| `.github/workflows/ci.yml` | `v10-rc` → `testnet-canary` in the push/PR trigger lists; turbo cache restore-key repointed from the deleted `refs/heads/v10-rc-` to `refs/heads/main-`; two branch-policy comments made generic |
| `.github/workflows/evm-integration.yml` | Same trigger-list rotation |
| `.github/workflows/knip.yml` | Same trigger-list rotation |
| `.github/workflows/supply-chain-scan.yml` | Same trigger-list rotation |
| `.github/CODEOWNERS` | Header comment now names `testnet-canary` as a protected branch instead of the deleted `v10-rc` |

## Test plan

- [x] `git diff origin/main origin/testnet-canary -- . ':(exclude).github'` is empty — canary carries no unique content, so this sync cannot revert work.
- [x] All four workflows parse, with the intended filters: `ci`/`evm-integration`/`supply-chain-scan` → `[main, testnet-canary, release/rc.12, rc17-vm-wip]`, `knip` → `[main, testnet-canary, rc17-vm-wip]`.
- [x] `grep -rn v10-rc .github/` on `main` returns nothing.
- [ ] **Merge with a merge commit.** Afterwards verify `git rev-list --count origin/testnet-canary..origin/main` is `0` and the tree hashes match.
- [ ] Push an empty commit to an open canary PR (or reopen one) and confirm `CI`, `EVM Integration Tests`, `Knip`, and `Supply chain scan` now dispatch with `base=testnet-canary`. Read the run's `created_at` against the PR timeline rather than trusting the API's `pull_requests[0].base.ref`, which reports the *current* base and mislabels runs on retargeted PRs.
- [ ] Only then create the `protect-testnet-canary` ruleset mirroring `protect-main` (id `14325863`).
