### PR TITLE
fix: address query scheduler follow-up review feedback

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,8 +58,10 @@ OpenTelemetry metric export; see the
 `POST /api/query` reads use the store scheduler's `background` lane by default
 so slow external reads cannot consume the capacity reserved for normal node
 work. Set `DKG_API_QUERY_PRIORITY=normal` before starting the daemon to restore
-the previous admission behavior during a canary rollback. A background query
-that is shed before execution returns HTTP 503 with `Retry-After: 1` and
+the previous admission behavior during a canary rollback. Invalid non-empty
+values fail safe to `background` with a startup warning, and the daemon logs
+the effective lane once at boot. A background query that is shed before
+execution returns HTTP 503 with `Retry-After: 1` and
 `code: "STORE_SCHEDULER_BUSY"`.
 
 ## Running a Core Node (relay operator)

--- a/packages/cli/src/daemon/api-query-priority.ts
+++ b/packages/cli/src/daemon/api-query-priority.ts
@@ -1,0 +1,45 @@
+export type ApiQueryPriority = 'normal' | 'background';
+
+export interface ApiQueryPriorityLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+let effectiveApiQueryPriority: ApiQueryPriority = 'background';
+
+/** Resolve the reversible API-read lane, defaulting fail-safe to background. */
+export function resolveApiQueryPriority(raw: string | undefined): ApiQueryPriority {
+  return raw?.trim().toLowerCase() === 'normal' ? 'normal' : 'background';
+}
+
+/**
+ * Resolve and log the API-query lane once during daemon startup.
+ *
+ * Empty/unset values intentionally select the protective background lane.
+ * Non-empty typos also fail safe, but are warned so an operator cannot believe
+ * an incident override took effect when it did not.
+ */
+export function configureApiQueryPriority(
+  raw: string | undefined,
+  logger: ApiQueryPriorityLogger,
+): ApiQueryPriority {
+  const normalized = raw?.trim().toLowerCase();
+  if (normalized && normalized !== 'normal' && normalized !== 'background') {
+    const printable = JSON.stringify(raw?.trim().slice(0, 64));
+    logger.warn(
+      `Invalid DKG_API_QUERY_PRIORITY=${printable}; expected "background" or "normal". ` +
+      'Falling back to "background".',
+    );
+  }
+
+  effectiveApiQueryPriority = resolveApiQueryPriority(raw);
+  logger.info(
+    `API query store priority: ${effectiveApiQueryPriority} ` +
+    '(DKG_API_QUERY_PRIORITY; effective until daemon restart)',
+  );
+  return effectiveApiQueryPriority;
+}
+
+export function getApiQueryPriority(): ApiQueryPriority {
+  return effectiveApiQueryPriority;
+}

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -403,6 +403,7 @@ import {
 } from './local-agents.js';
 
 import { handleRequest } from './handle-request.js';
+import { configureApiQueryPriority } from './api-query-priority.js';
 import { loadRoutePlugins, countConfiguredPluginSpecs } from './plugin-loader.js';
 import type { MemoryGraphChangedEvent, MemoryGraphLayer } from './routes/context.js';
 import {
@@ -1170,6 +1171,11 @@ export async function runDaemonInner(
     if (foreground) origStdoutWrite(line + "\n");
     appendFile(logFile, line + "\n").catch(() => {});
   }
+
+  configureApiQueryPriority(process.env.DKG_API_QUERY_PRIORITY, {
+    info: log,
+    warn: log,
+  });
 
   if (startupLogRotation?.rotated) {
     log(

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -107,6 +107,15 @@ import {
   slotEntryPoint,
   CLI_NPM_PACKAGE,
 } from '../../config.js';
+import {
+  getApiQueryPriority,
+  type ApiQueryPriority,
+} from '../api-query-priority.js';
+export {
+  configureApiQueryPriority,
+  resolveApiQueryPriority,
+} from '../api-query-priority.js';
+export type { ApiQueryPriority } from '../api-query-priority.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
 import { loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
@@ -333,8 +342,6 @@ const VERIFY_COLLECTION_TIMEOUT_MIN_MS = 1_000;
 const VERIFY_COLLECTION_TIMEOUT_MAX_MS = 30 * 60 * 1000;
 const API_QUERY_CALLER_DISCONNECTED = 'API_QUERY_CALLER_DISCONNECTED';
 
-export type ApiQueryPriority = 'normal' | 'background';
-
 export interface ApiQueryRequestLifecycle {
   readonly signal: AbortSignal;
   readonly priority: ApiQueryPriority;
@@ -349,13 +356,6 @@ class ApiQueryCallerDisconnectedError extends Error {
     super('API query caller disconnected');
     this.name = 'ApiQueryCallerDisconnectedError';
   }
-}
-
-/** Resolve the reversible API-read lane, defaulting to the protective setting. */
-export function resolveApiQueryPriority(
-  raw = process.env.DKG_API_QUERY_PRIORITY,
-): ApiQueryPriority {
-  return raw?.trim().toLowerCase() === 'normal' ? 'normal' : 'background';
 }
 
 /**
@@ -379,7 +379,7 @@ export function createApiQueryRequestLifecycle(
 
   return {
     signal: controller.signal,
-    priority: resolveApiQueryPriority(),
+    priority: getApiQueryPriority(),
     source: 'api.query',
     dispose() {
       req.removeListener('aborted', abortDisconnectedQuery);
@@ -704,10 +704,17 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
     } catch (err: any) {
       if (err?.code === API_QUERY_CALLER_DISCONNECTED) {
         tracker.cancel(ctx, err);
+        if (!res.writableEnded) res.end();
+        return;
+      }
+      if (respondIfApiQueryStoreBusy(res, err)) {
+        // Admission shedding means the operation never reached the store. Keep
+        // it visible with the scheduler reason, but do not count it as an
+        // execution failure in dashboard health rates.
+        tracker.cancel(ctx, err);
         return;
       }
       tracker.fail(ctx, err);
-      if (respondIfApiQueryStoreBusy(res, err)) return;
       const msg = err?.message ?? "";
       if (
         msg.startsWith("SPARQL rejected:") ||

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -72,6 +72,7 @@ import {
   LlmClient,
   type MetricsSource,
 } from "@origintrail-official/dkg-node-ui";
+import { StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
 import {
   loadConfig,
   saveConfig,
@@ -331,7 +332,6 @@ import type { RequestContext } from './context.js';
 const VERIFY_COLLECTION_TIMEOUT_MIN_MS = 1_000;
 const VERIFY_COLLECTION_TIMEOUT_MAX_MS = 30 * 60 * 1000;
 const API_QUERY_CALLER_DISCONNECTED = 'API_QUERY_CALLER_DISCONNECTED';
-const STORE_SCHEDULER_BUSY = 'STORE_SCHEDULER_BUSY';
 
 export type ApiQueryPriority = 'normal' | 'background';
 
@@ -390,19 +390,16 @@ export function createApiQueryRequestLifecycle(
 
 /** Map retryable, pre-dispatch read shedding without changing write routes. */
 export function respondIfApiQueryStoreBusy(res: ServerResponse, err: unknown): boolean {
-  const shaped = err && typeof err === 'object'
-    ? err as Record<string, unknown>
-    : {};
-  if (shaped.code !== STORE_SCHEDULER_BUSY) return false;
+  if (!(err instanceof StoreSchedulerBusyError)) return false;
 
   jsonResponse(
     res,
     503,
     {
-      error: err instanceof Error ? err.message : 'Store scheduler busy',
-      code: STORE_SCHEDULER_BUSY,
-      reason: shaped.reason,
-      priority: shaped.priority,
+      error: err.message,
+      code: err.code,
+      reason: err.reason,
+      priority: err.priority,
       retryable: true,
     },
     undefined,

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -1,15 +1,21 @@
 import { EventEmitter } from 'node:events';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
 import {
   createApiQueryRequestLifecycle,
+  handleQueryRoutes,
   resolveApiQueryPriority,
   respondIfApiQueryStoreBusy,
 } from '../src/daemon/routes/query.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
 
 class RequestStub extends EventEmitter {
   aborted = false;
+  method = 'POST';
+  __dkgPrebufferedBody = Buffer.from(JSON.stringify({
+    sparql: 'SELECT ?s WHERE { ?s ?p ?o }',
+  }));
 }
 
 class ResponseStub extends EventEmitter {
@@ -32,6 +38,25 @@ class ResponseStub extends EventEmitter {
     this.writableEnded = true;
     return this;
   }
+}
+
+function queryRouteContext(
+  req: RequestStub,
+  res: ResponseStub,
+  agent: Record<string, unknown>,
+  tracker: Record<string, unknown>,
+): RequestContext {
+  return {
+    req,
+    res,
+    agent,
+    tracker,
+    validTokens: new Set<string>(),
+    url: new URL('http://127.0.0.1/api/query'),
+    path: '/api/query',
+    requestToken: undefined,
+    requestAgentAddress: '',
+  } as unknown as RequestContext;
 }
 
 describe('/api/query request lifecycle', () => {
@@ -103,6 +128,133 @@ describe('/api/query request lifecycle', () => {
       res as unknown as ServerResponse,
       new Error('parse failed'),
     )).toBe(false);
+    expect(respondIfApiQueryStoreBusy(
+      res as unknown as ServerResponse,
+      {
+        code: 'STORE_SCHEDULER_BUSY',
+        reason: 'queue_full',
+        priority: 'background',
+      },
+    )).toBe(false);
     expect(res.writableEnded).toBe(false);
+  });
+
+  it('passes the lifecycle admission options through the actual route handoff', async () => {
+    const req = new RequestStub();
+    const res = new ResponseStub();
+    let receivedOptions: Record<string, unknown> | undefined;
+    const agent = {
+      query: vi.fn(async (_sparql: string, options: Record<string, unknown>) => {
+        receivedOptions = options;
+        return { type: 'bindings', bindings: [] };
+      }),
+    };
+    const tracker = {
+      start: vi.fn(),
+      startPhase: vi.fn(),
+      completePhase: vi.fn(),
+      complete: vi.fn(),
+      fail: vi.fn(),
+      cancel: vi.fn(),
+    };
+
+    await handleQueryRoutes(queryRouteContext(req, res, agent, tracker));
+
+    expect(agent.query).toHaveBeenCalledTimes(1);
+    expect(receivedOptions).toMatchObject({
+      priority: 'background',
+      source: 'api.query',
+    });
+    expect(receivedOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect((receivedOptions?.signal as AbortSignal).aborted).toBe(false);
+    expect(res.statusCode).toBe(200);
+    expect(tracker.complete).toHaveBeenCalledTimes(1);
+    expect(tracker.fail).not.toHaveBeenCalled();
+  });
+
+  it('aborts the route signal on disconnect and maps canonical shedding to 503', async () => {
+    const disconnectReq = new RequestStub();
+    const disconnectRes = new ResponseStub();
+    let receivedSignal: AbortSignal | undefined;
+    let queryStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      queryStarted = resolve;
+    });
+    const disconnectTracker = {
+      start: vi.fn(),
+      startPhase: vi.fn(),
+      completePhase: vi.fn(),
+      complete: vi.fn(),
+      fail: vi.fn(),
+      cancel: vi.fn(),
+    };
+    const disconnectRoute = handleQueryRoutes(queryRouteContext(
+      disconnectReq,
+      disconnectRes,
+      {
+        query: vi.fn(async (_sparql: string, options: Record<string, unknown>) => {
+          receivedSignal = options.signal as AbortSignal;
+          queryStarted();
+          return new Promise((_resolve, reject) => {
+            receivedSignal?.addEventListener(
+              'abort',
+              () => reject(receivedSignal?.reason),
+              { once: true },
+            );
+          });
+        }),
+      },
+      disconnectTracker,
+    ));
+    await started;
+
+    disconnectReq.aborted = true;
+    disconnectReq.emit('aborted');
+    await disconnectRoute;
+
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(disconnectTracker.cancel).toHaveBeenCalledTimes(1);
+    expect(disconnectTracker.fail).not.toHaveBeenCalled();
+    expect(disconnectRes.writableEnded).toBe(false);
+
+    const busyReq = new RequestStub();
+    const busyRes = new ResponseStub();
+    let busyOptions: Record<string, unknown> | undefined;
+    const busyTracker = {
+      start: vi.fn(),
+      startPhase: vi.fn(),
+      completePhase: vi.fn(),
+      complete: vi.fn(),
+      fail: vi.fn(),
+      cancel: vi.fn(),
+    };
+    await handleQueryRoutes(queryRouteContext(
+      busyReq,
+      busyRes,
+      {
+        query: vi.fn(async (_sparql: string, options: Record<string, unknown>) => {
+          busyOptions = options;
+          throw new StoreSchedulerBusyError(
+            'queue_wait_timeout',
+            'background',
+            'api.query',
+          );
+        }),
+      },
+      busyTracker,
+    ));
+
+    expect(busyOptions).toMatchObject({
+      priority: 'background',
+      source: 'api.query',
+    });
+    expect(busyOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(busyRes.statusCode).toBe(503);
+    expect(busyRes.headers['Retry-After']).toBe('1');
+    expect(JSON.parse(busyRes.body)).toMatchObject({
+      code: 'STORE_SCHEDULER_BUSY',
+      retryable: true,
+    });
+    expect(busyTracker.fail).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
 import {
+  configureApiQueryPriority,
   createApiQueryRequestLifecycle,
   handleQueryRoutes,
   resolveApiQueryPriority,
@@ -65,18 +66,40 @@ describe('/api/query request lifecycle', () => {
   afterEach(() => {
     if (originalPriority === undefined) delete process.env.DKG_API_QUERY_PRIORITY;
     else process.env.DKG_API_QUERY_PRIORITY = originalPriority;
+    configureApiQueryPriority(originalPriority, {
+      info: () => {},
+      warn: () => {},
+    });
   });
 
-  it('defaults API reads to background and allows a reversible normal-lane override', () => {
+  it('resolves the lane once, logs it, and warns when an incident override is invalid', () => {
     expect(resolveApiQueryPriority(undefined)).toBe('background');
     expect(resolveApiQueryPriority('background')).toBe('background');
     expect(resolveApiQueryPriority('normal')).toBe('normal');
     expect(resolveApiQueryPriority(' NORMAL ')).toBe('normal');
     expect(resolveApiQueryPriority('ack')).toBe('background');
+
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    expect(configureApiQueryPriority('normal', logger)).toBe('normal');
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('priority: normal'));
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    expect(configureApiQueryPriority('noraml', logger)).toBe('background');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid DKG_API_QUERY_PRIORITY="noraml"'),
+    );
+    expect(logger.info).toHaveBeenLastCalledWith(expect.stringContaining('priority: background'));
   });
 
   it('forwards the exact lane/source and aborts the signal on request disconnect', () => {
     process.env.DKG_API_QUERY_PRIORITY = 'normal';
+    configureApiQueryPriority(process.env.DKG_API_QUERY_PRIORITY, {
+      info: () => {},
+      warn: () => {},
+    });
     const req = new RequestStub();
     const res = new ResponseStub();
     const lifecycle = createApiQueryRequestLifecycle(
@@ -215,7 +238,7 @@ describe('/api/query request lifecycle', () => {
     expect(receivedSignal?.aborted).toBe(true);
     expect(disconnectTracker.cancel).toHaveBeenCalledTimes(1);
     expect(disconnectTracker.fail).not.toHaveBeenCalled();
-    expect(disconnectRes.writableEnded).toBe(false);
+    expect(disconnectRes.writableEnded).toBe(true);
 
     const busyReq = new RequestStub();
     const busyRes = new ResponseStub();
@@ -255,6 +278,7 @@ describe('/api/query request lifecycle', () => {
       code: 'STORE_SCHEDULER_BUSY',
       retryable: true,
     });
-    expect(busyTracker.fail).toHaveBeenCalledTimes(1);
+    expect(busyTracker.cancel).toHaveBeenCalledTimes(1);
+    expect(busyTracker.fail).not.toHaveBeenCalled();
   });
 });

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -2278,11 +2278,7 @@ export class DashboardDB {
     duration_ms: number;
     error_message: string;
   }): void {
-    this.stmt('failOp', `
-      UPDATE operations SET status = 'error', duration_ms = @duration_ms,
-        error_message = @error_message
-      WHERE operation_id = @operation_id AND status = 'in_progress'
-    `).run(op);
+    this.finishOperation({ ...op, status: 'error' });
   }
 
   cancelOperation(op: {
@@ -2290,8 +2286,17 @@ export class DashboardDB {
     duration_ms: number;
     error_message: string;
   }): void {
-    this.stmt('cancelOp', `
-      UPDATE operations SET status = 'cancelled', duration_ms = @duration_ms,
+    this.finishOperation({ ...op, status: 'cancelled' });
+  }
+
+  finishOperation(op: {
+    operation_id: string;
+    duration_ms: number;
+    error_message: string;
+    status: 'error' | 'cancelled';
+  }): void {
+    this.stmt('finishOperation', `
+      UPDATE operations SET status = @status, duration_ms = @duration_ms,
         error_message = @error_message
       WHERE operation_id = @operation_id AND status = 'in_progress'
     `).run(op);
@@ -2467,16 +2472,22 @@ export class DashboardDB {
   }
 
   failPhase(op: { operation_id: string; phase: string; duration_ms: number; error_message: string }): void {
-    this.stmt('failPhase', `
-      UPDATE operation_phases SET status = 'error', duration_ms = @duration_ms,
-        details = @error_message
-      WHERE operation_id = @operation_id AND phase = @phase AND status = 'in_progress'
-    `).run(op);
+    this.finishPhase({ ...op, status: 'error' });
   }
 
   cancelPhase(op: { operation_id: string; phase: string; duration_ms: number; error_message: string }): void {
-    this.stmt('cancelPhase', `
-      UPDATE operation_phases SET status = 'cancelled', duration_ms = @duration_ms,
+    this.finishPhase({ ...op, status: 'cancelled' });
+  }
+
+  finishPhase(op: {
+    operation_id: string;
+    phase: string;
+    duration_ms: number;
+    error_message: string;
+    status: 'error' | 'cancelled';
+  }): void {
+    this.stmt('finishPhase', `
+      UPDATE operation_phases SET status = @status, duration_ms = @duration_ms,
         details = @error_message
       WHERE operation_id = @operation_id AND phase = @phase AND status = 'in_progress'
     `).run(op);
@@ -2538,6 +2549,7 @@ export class DashboardDB {
         COUNT(*) as totalCount,
         SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as successCount,
         SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as errorCount,
+        SUM(CASE WHEN status IN ('success', 'error') THEN 1 ELSE 0 END) as healthCount,
         AVG(CASE WHEN status = 'success' THEN duration_ms END) as avgDurationMs,
         AVG(gas_cost_eth) as avgGasCostEth,
         SUM(gas_cost_eth) as totalGasCostEth,
@@ -2550,7 +2562,9 @@ export class DashboardDB {
       totalCount: summaryRow.totalCount ?? 0,
       successCount: summaryRow.successCount ?? 0,
       errorCount: summaryRow.errorCount ?? 0,
-      successRate: summaryRow.totalCount > 0 ? (summaryRow.successCount ?? 0) / summaryRow.totalCount : 0,
+      successRate: summaryRow.healthCount > 0
+        ? (summaryRow.successCount ?? 0) / summaryRow.healthCount
+        : 0,
       avgDurationMs: summaryRow.avgDurationMs ?? 0,
       avgGasCostEth: summaryRow.avgGasCostEth ?? 0,
       totalGasCostEth: summaryRow.totalGasCostEth ?? 0,
@@ -2567,6 +2581,7 @@ export class DashboardDB {
         (CAST(started_at / ? AS INTEGER) * ?) as bucket,
         COUNT(*) as count,
         SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as successCount,
+        SUM(CASE WHEN status IN ('success', 'error') THEN 1 ELSE 0 END) as healthCount,
         AVG(CASE WHEN status = 'success' THEN duration_ms END) as avgDurationMs,
         AVG(gas_cost_eth) as avgGasCostEth,
         SUM(gas_cost_eth) as totalGasCostEth
@@ -2580,7 +2595,7 @@ export class DashboardDB {
       timeSeries: timeSeries.map((r: any) => ({
         bucket: r.bucket,
         count: r.count,
-        successRate: r.count > 0 ? r.successCount / r.count : 0,
+        successRate: r.healthCount > 0 ? r.successCount / r.healthCount : 0,
         avgDurationMs: r.avgDurationMs ?? 0,
         avgGasCostEth: r.avgGasCostEth ?? 0,
         totalGasCostEth: r.totalGasCostEth ?? 0,
@@ -2603,6 +2618,7 @@ export class DashboardDB {
         COUNT(*) as count,
         AVG(CASE WHEN status = 'success' THEN duration_ms END) as avgMs,
         SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as successCount,
+        SUM(CASE WHEN status IN ('success', 'error') THEN 1 ELSE 0 END) as healthCount,
         SUM(gas_cost_eth) as gasCostEth
       FROM operations WHERE started_at >= ?
       GROUP BY bucket, operation_name ORDER BY bucket
@@ -2625,7 +2641,7 @@ export class DashboardDB {
         return {
           count: r?.count ?? 0,
           avgMs: r?.avgMs ?? 0,
-          successRate: r ? (r.count > 0 ? r.successCount / r.count : 0) : 0,
+          successRate: r ? (r.healthCount > 0 ? r.successCount / r.healthCount : 0) : 0,
           gasCostEth: r?.gasCostEth ?? 0,
         };
       });
@@ -2649,7 +2665,7 @@ export class DashboardDB {
       GROUP BY operation_name ORDER BY total DESC
     `).all(cutoff) as any[]).map(r => ({
       ...r,
-      rate: r.total > 0 ? r.success / r.total : 0,
+      rate: r.success + r.error > 0 ? r.success / (r.success + r.error) : 0,
       avgMs: r.avgMs ?? 0,
     }));
   }

--- a/packages/node-ui/src/operation-tracker.ts
+++ b/packages/node-ui/src/operation-tracker.ts
@@ -54,36 +54,18 @@ export class OperationTracker {
   }
 
   fail(ctx: OperationContext, err: unknown): void {
-    if (!this.db) return;
-    const now = Date.now();
-    const startedAt = this.starts.get(ctx.operationId);
-    this.starts.delete(ctx.operationId);
-    const message = err instanceof Error ? err.message : String(err);
-    try {
-      const prefix = ctx.operationId + ':';
-      const activeKeys = [...this.phaseStarts.keys()].filter(k => k.startsWith(prefix));
-      for (const key of activeKeys) {
-        const phase = key.slice(prefix.length);
-        const phaseStartedAt = this.phaseStarts.get(key);
-        this.phaseStarts.delete(key);
-        this.db.failPhase({
-          operation_id: ctx.operationId,
-          phase,
-          duration_ms: phaseStartedAt ? now - phaseStartedAt : 0,
-          error_message: message,
-        });
-      }
-      this.db.failOperation({
-        operation_id: ctx.operationId,
-        duration_ms: startedAt ? now - startedAt : 0,
-        error_message: message,
-      });
-    } catch {
-      // Must never break the node
-    }
+    this.finish(ctx, 'error', err);
   }
 
   cancel(ctx: OperationContext, reason: unknown): void {
+    this.finish(ctx, 'cancelled', reason);
+  }
+
+  private finish(
+    ctx: OperationContext,
+    status: 'error' | 'cancelled',
+    reason: unknown,
+  ): void {
     if (!this.db) return;
     const now = Date.now();
     const startedAt = this.starts.get(ctx.operationId);
@@ -96,17 +78,19 @@ export class OperationTracker {
         const phase = key.slice(prefix.length);
         const phaseStartedAt = this.phaseStarts.get(key);
         this.phaseStarts.delete(key);
-        this.db.cancelPhase({
+        this.db.finishPhase({
           operation_id: ctx.operationId,
           phase,
           duration_ms: phaseStartedAt ? now - phaseStartedAt : 0,
           error_message: message,
+          status,
         });
       }
-      this.db.cancelOperation({
+      this.db.finishOperation({
         operation_id: ctx.operationId,
         duration_ms: startedAt ? now - startedAt : 0,
         error_message: message,
+        status,
       });
     } catch {
       // Must never break the node

--- a/packages/node-ui/src/ui/pages/Operations.tsx
+++ b/packages/node-ui/src/ui/pages/Operations.tsx
@@ -21,12 +21,7 @@ import {
   PHASE_LEGEND_ENTRIES,
 } from '../phase-colors.js';
 
-const STATUS_COLORS: Record<string, string> = {
-  success: '#22c55e',
-  error: '#ef4444',
-  cancelled: '#94a3b8',
-  in_progress: '#f59e0b',
-};
+const CANCELLED_COLOR = '#94a3b8';
 
 const PHASE_DESCRIPTIONS: Record<string, string> = {
   prepare: 'Partitioning triples, computing Merkle hashes, validating & signing.',
@@ -893,7 +888,11 @@ function MiniGantt({ phases, totalMs }: { phases: any[]; totalMs: number }) {
       {/* Phase label pills */}
       <div style={{ display: 'flex', gap: 4, marginBottom: 3, flexWrap: 'wrap' }}>
         {phases.map((p: any, i: number) => {
-          const color = p.status === 'error' ? '#ef4444' : PHASE_COLORS[p.phase] ?? PHASE_FALLBACK_COLOR;
+          const color = p.status === 'error'
+            ? '#ef4444'
+            : p.status === 'cancelled'
+              ? CANCELLED_COLOR
+              : PHASE_COLORS[p.phase] ?? PHASE_FALLBACK_COLOR;
           return (
             <span key={`label-${p.phase}-${i}`} style={{
               fontSize: 9, fontWeight: 600, color, letterSpacing: '.02em',
@@ -912,7 +911,11 @@ function MiniGantt({ phases, totalMs }: { phases: any[]; totalMs: number }) {
       <div style={{ display: 'flex', height: 10, borderRadius: 3, overflow: 'hidden', background: 'rgba(255,255,255,.04)' }}>
         {phases.map((p: any, i: number) => {
           const pct = Math.max(((p.duration_ms ?? 0) / phaseTotal) * 100, 3);
-          const color = p.status === 'error' ? '#ef4444' : PHASE_COLORS[p.phase] ?? PHASE_FALLBACK_COLOR;
+          const color = p.status === 'error'
+            ? '#ef4444'
+            : p.status === 'cancelled'
+              ? CANCELLED_COLOR
+              : PHASE_COLORS[p.phase] ?? PHASE_FALLBACK_COLOR;
           const isHovered = hover === i;
           return (
             <div
@@ -955,6 +958,9 @@ function MiniGantt({ phases, totalMs }: { phases: any[]; totalMs: number }) {
               </span>
               {phases[hover].status === 'error' && (
                 <span style={{ color: 'var(--red)', marginLeft: 6, fontWeight: 600 }}>FAILED</span>
+              )}
+              {phases[hover].status === 'cancelled' && (
+                <span style={{ color: CANCELLED_COLOR, marginLeft: 6, fontWeight: 600 }}>CANCELLED</span>
               )}
             </div>
             {desc && (
@@ -1220,8 +1226,15 @@ function PhaseTimeline({ phases, op }: { phases: any[]; op: any }) {
           const left = Math.max(0, ((phaseStart - opStart) / opDuration) * 100);
           const width = Math.max(1.5, (phaseDuration / opDuration) * 100);
           const isError = p.status === 'error';
+          const isCancelled = p.status === 'cancelled';
           const isInProgress = p.status === 'in_progress';
-          const color = isError ? '#ef4444' : isInProgress ? '#f59e0b' : PHASE_COLORS[p.phase] ?? PHASE_FALLBACK_COLOR;
+          const color = isError
+            ? '#ef4444'
+            : isCancelled
+              ? CANCELLED_COLOR
+              : isInProgress
+                ? '#f59e0b'
+                : PHASE_COLORS[p.phase] ?? PHASE_FALLBACK_COLOR;
 
           return (
             <div key={`${p.phase}-${i}`} style={{ display: 'flex', alignItems: 'center', height: 22, padding: '0 8px', position: 'relative' }}>
@@ -1229,7 +1242,13 @@ function PhaseTimeline({ phases, op }: { phases: any[]; op: any }) {
                 title={p.phase}>{p.phase}</div>
               <div style={{ flex: 1, position: 'relative', height: 12 }}>
                 <div
-                  title={`${p.phase}: ${formatDuration(phaseDuration)}${isError ? ' — FAILED: ' + (p.details ?? '') : ''}`}
+                  title={`${p.phase}: ${formatDuration(phaseDuration)}${
+                    isError
+                      ? ` — FAILED: ${p.details ?? ''}`
+                      : isCancelled
+                        ? ` — CANCELLED: ${p.details ?? ''}`
+                        : ''
+                  }`}
                   style={{
                     position: 'absolute', left: `${left}%`, width: `${Math.min(width, 100 - left)}%`,
                     height: '100%', borderRadius: 3, opacity: isInProgress ? 0.7 : 1, transition: 'width .3s ease',
@@ -1254,6 +1273,11 @@ function PhaseTimeline({ phases, op }: { phases: any[]; op: any }) {
         {phases.some((p: any) => p.status === 'error') && (
           <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
             <span style={{ width: 8, height: 8, borderRadius: 2, background: 'var(--red)', display: 'inline-block' }} /> Failed
+          </span>
+        )}
+        {phases.some((p: any) => p.status === 'cancelled') && (
+          <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: CANCELLED_COLOR, display: 'inline-block' }} /> Cancelled
           </span>
         )}
         {phases.some((p: any) => p.status === 'in_progress') && (
@@ -1326,6 +1350,11 @@ function OperationDetail({ op, logs, phases, explorerUrl, onBack }: {
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
               {phases.map((p: any, i: number) => {
                 const color = PHASE_COLORS[p.phase] ?? PHASE_FALLBACK_COLOR;
+                const terminalColor = p.status === 'error'
+                  ? 'var(--red)'
+                  : p.status === 'cancelled'
+                    ? CANCELLED_COLOR
+                    : color;
                 const topLevel = p.phase.includes(':') ? p.phase.split(':')[0] : p.phase;
                 // Codex PR #241 iter-6: exact-match first, then fall back
                 // to the top-level phase. Same rationale as the bar-hover
@@ -1334,7 +1363,7 @@ function OperationDetail({ op, logs, phases, explorerUrl, onBack }: {
                 // to the umbrella `chain` entry.
                 const desc = PHASE_DESCRIPTIONS[p.phase] ?? PHASE_DESCRIPTIONS[topLevel];
                 return (
-                  <div key={`${p.phase}-${i}`} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 10px', background: 'rgba(255,255,255,.02)', borderRadius: 6, borderLeft: `3px solid ${p.status === 'error' ? 'var(--red)' : color}` }}>
+                  <div key={`${p.phase}-${i}`} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 10px', background: 'rgba(255,255,255,.02)', borderRadius: 6, borderLeft: `3px solid ${terminalColor}` }}>
                     <span style={{ fontWeight: 600, fontSize: 12, color, minWidth: 65 }} title={desc ?? ''}>{p.phase}</span>
                     <StatusBadge status={p.status} />
                     <span style={{ fontSize: 11, color: 'var(--text-dim)', fontFamily: "'JetBrains Mono', monospace" }}>{formatDuration(p.duration_ms)}</span>
@@ -1345,8 +1374,8 @@ function OperationDetail({ op, logs, phases, explorerUrl, onBack }: {
                     >
                       {p.started_at ? formatTime(p.started_at) : ''}
                     </span>
-                    {p.status === 'error' && p.details && (
-                      <span style={{ fontSize: 10, color: 'var(--red)', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={p.details}>
+                    {(p.status === 'error' || p.status === 'cancelled') && p.details && (
+                      <span style={{ fontSize: 10, color: terminalColor, maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={p.details}>
                         {p.details}
                       </span>
                     )}
@@ -1650,8 +1679,15 @@ function StyledDaemonLine({ line, lineNum, highlight }: { line: string; lineNum:
   );
 }
 
-function StatusBadge({ status }: { status: string }) {
-  const cls = status === 'success' ? 'badge-success' : status === 'error' ? 'badge-error' : 'badge-warning';
+export function operationStatusBadgeClass(status: string): string {
+  if (status === 'success') return 'badge-success';
+  if (status === 'error') return 'badge-error';
+  if (status === 'cancelled') return 'badge-cancelled';
+  return 'badge-warn';
+}
+
+export function StatusBadge({ status }: { status: string }) {
+  const cls = operationStatusBadgeClass(status);
   return <span className={`badge ${cls}`}>{status}</span>;
 }
 

--- a/packages/node-ui/src/ui/styles/12-observability.css
+++ b/packages/node-ui/src/ui/styles/12-observability.css
@@ -136,6 +136,7 @@ select.input {
    `.badge-warn` below. */
 .badge-success { background: rgba(34,197,94,.12); color: var(--text-success); }
 .badge-error   { background: rgba(239,68,68,.12);  color: var(--text-danger); }
+.badge-cancelled { background: rgba(148,163,184,.14); color: var(--text-muted); }
 /* Warning semantics resolve to the theme-aware `--text-warning` token
    (#fbbf24 dark / #92400e light) on `--amber-dim`, matching
    `.v10-modal-warning` and the EmptyState `warning` tone so the whole

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -554,6 +554,47 @@ describe('DashboardDB — operation stats', () => {
     expect(summary.totalTracCost).toBeCloseTo(0.5);
   });
 
+  it('keeps cancelled operations visible without depressing health success rates', () => {
+    db.insertOperation({
+      operation_id: 'st-cancelled',
+      operation_name: 'query',
+      started_at: Date.now(),
+    });
+    db.cancelOperation({
+      operation_id: 'st-cancelled',
+      duration_ms: 25,
+      error_message: 'API query caller disconnected',
+    });
+
+    const { summary, timeSeries } = db.getOperationStats({
+      periodMs: 86_400_000,
+      bucketMs: 1_000_000_000_000,
+    });
+    expect(summary.totalCount).toBe(11);
+    expect(summary.successCount).toBe(8);
+    expect(summary.errorCount).toBe(2);
+    expect(summary.successRate).toBeCloseTo(0.8);
+    expect(timeSeries).toHaveLength(1);
+    expect(timeSeries[0].count).toBe(11);
+    expect(timeSeries[0].successRate).toBeCloseTo(0.8);
+
+    const perType = db.getPerTypeTimeSeries({
+      periodMs: 86_400_000,
+      bucketMs: 1_000_000_000_000,
+    });
+    expect(perType.series.query[0].count).toBe(4);
+    expect(perType.series.query[0].successRate).toBeCloseTo(1 / 3);
+
+    const queryRate = db.getSuccessRatesByType(86_400_000)
+      .find((row) => row.type === 'query');
+    expect(queryRate).toMatchObject({
+      total: 4,
+      success: 1,
+      error: 2,
+    });
+    expect(queryRate!.rate).toBeCloseTo(1 / 3);
+  });
+
   it('filters stats by operation name', () => {
     const { summary } = db.getOperationStats({ name: 'publish', periodMs: 86_400_000, bucketMs: 3_600_000 });
     expect(summary.totalCount).toBe(7);

--- a/packages/node-ui/test/operations-status-badge.test.ts
+++ b/packages/node-ui/test/operations-status-badge.test.ts
@@ -1,0 +1,22 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  StatusBadge,
+  operationStatusBadgeClass,
+} from '../src/ui/pages/Operations.js';
+
+describe('operation status badges', () => {
+  it('renders cancellation distinctly from failure and warning states', () => {
+    expect(operationStatusBadgeClass('success')).toBe('badge-success');
+    expect(operationStatusBadgeClass('error')).toBe('badge-error');
+    expect(operationStatusBadgeClass('cancelled')).toBe('badge-cancelled');
+    expect(operationStatusBadgeClass('in_progress')).toBe('badge-warn');
+
+    const html = renderToStaticMarkup(
+      React.createElement(StatusBadge, { status: 'cancelled' }),
+    );
+    expect(html).toContain('badge-cancelled');
+    expect(html).toContain('cancelled');
+  });
+});

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -886,9 +886,17 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
 
   private async discoverGraphsByPrefix(
     prefix: string,
-    reads: StoreReadLane,
+    reads: QueryStoreReadContext | StoreReadLane,
   ): Promise<string[]> {
-    const allGraphs = await reads.listGraphsByPrefix(prefix);
+    // GraphSetIndexStore coalesces refreshes by priority. Never let that shared
+    // upstream flight capture one HTTP caller's disconnect signal; race the
+    // individual caller locally while priority/source stay on the shared lane.
+    const sharedReads = 'shared' in reads ? reads.shared : reads;
+    const callerSignal = 'shared' in reads ? reads.signal : undefined;
+    const allGraphs = await raceAgainstCallerAbort(
+      sharedReads.listGraphsByPrefix(prefix),
+      callerSignal,
+    );
     return allGraphs.filter(
       (g) => g.startsWith(prefix) && !g.includes('/_meta') && !g.includes('/staging/'),
     );

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -42,7 +42,14 @@ import {
   detectSparqlQueryForm,
 } from './sparql-guard.js';
 import {
+  findMatchingSparqlCloseBrace as findMatchingCloseBrace,
+  isSparqlKeyword,
+  isSparqlKeywordStart as isKeywordStart,
+  isSparqlWordContinuation as isWordContinuation,
+  readSparqlVariable,
   skipSparqlStringLiteral as scanSparqlStringLiteral,
+  skipSparqlIriRef,
+  skipSparqlSpaceAndLineComments,
   stripLiteralsAndComments,
 } from './sparql-utils.js';
 import {
@@ -90,6 +97,48 @@ function sharedDiscoveryStoreOptions(
   return {
     priority: options.priority,
     source: options.source,
+  };
+}
+
+interface StoreReadLane {
+  query(sparql: string): Promise<StoreQueryResult>;
+  listGraphsByPrefix(prefix: string): Promise<string[]>;
+  listGraphFamily(rootGraph: string): Promise<string[]>;
+}
+
+interface QueryStoreReadContext extends StoreReadLane {
+  readonly signal: AbortSignal | undefined;
+  readonly shared: StoreReadLane & { readonly cacheKey: string };
+}
+
+function createStoreReadLane(
+  store: TripleStore,
+  options: StoreQueryOptions | undefined,
+): StoreReadLane {
+  return {
+    query: (sparql) => store.query(sparql, options),
+    listGraphsByPrefix: (prefix) => listGraphsByPrefix(store, prefix, options),
+    listGraphFamily: (rootGraph) => listGraphFamily(store, rootGraph, options),
+  };
+}
+
+function createQueryStoreReadContext(
+  store: TripleStore,
+  queryOptions: QueryOptions | undefined,
+): QueryStoreReadContext {
+  const options = storeOptions(queryOptions);
+  const lane = createStoreReadLane(store, options);
+  const sharedOptions = sharedDiscoveryStoreOptions(options);
+  return {
+    ...lane,
+    signal: options?.signal,
+    shared: {
+      ...createStoreReadLane(store, sharedOptions),
+      cacheKey: JSON.stringify([
+        sharedOptions?.priority ?? 'normal',
+        sharedOptions?.source ?? null,
+      ]),
+    },
   };
 }
 
@@ -327,6 +376,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
   }
 
   async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    const reads = createQueryStoreReadContext(this.store, options);
     const guard = validateReadOnlySparql(sparql);
     if (!guard.safe) {
       throw new Error(`SPARQL rejected: ${guard.reason}`);
@@ -352,7 +402,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
       // …/_shared_memory/{addr}/{number} graphs so GRAPH-variable scans bind them.
       const swmRouted = (options?.includeSharedMemory ?? options?.includeWorkspace) || options?.graphSuffix === '_shared_memory';
       const swmPerKaGraphs = swmRouted
-        ? await this.discoverGraphsByPrefix(`${sharedMemoryGraph}/`, storeOptions(options))
+        ? await this.discoverGraphsByPrefix(`${sharedMemoryGraph}/`, reads)
         : [];
       // Per-KA VM: published data is in …/_verifiable_memory/{addr}/{number}; bind those too
       // for GRAPH-variable scans on any route that reads the data graph.
@@ -360,7 +410,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
       const vmPerKaGraphs = dataRouted
         ? await this.discoverGraphsByPrefix(
             `${dataGraph}/_verifiable_memory/`,
-            storeOptions(options),
+            reads,
           )
         : [];
       const allowedGraphs = options?.includeSharedMemory ?? options?.includeWorkspace
@@ -435,8 +485,8 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
               : contextGraphPrivateUri(effectiveContextGraphId),
             ...(await this.discoverGraphScopedPrivateGraphs(
               effectiveContextGraphId,
+              reads,
               subGraphName,
-              storeOptions(options),
             )),
           ]
         : [];
@@ -448,7 +498,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
             effectiveContextGraphId,
             explicitAllowedGraphs,
             { subGraphName, isSwmOnlyRoute },
-            storeOptions(options),
+            reads,
           )
         : explicitAllowedGraphs;
       // Explicit GRAPH IRIs remain limited to the static route-specific
@@ -472,7 +522,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         const v = validateSubGraphName(options.subGraphName);
         if (!v.valid) throw new Error(v.reason);
       }
-      return this.queryWithView(sparql, options.view, effectiveContextGraphId, options);
+      return this.queryWithView(sparql, options.view, effectiveContextGraphId, options, reads);
     }
 
     // ── Legacy routing (V9 compat) ────────────────────────────────────
@@ -487,7 +537,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         // Per-KA VM: read-both the published per-KA …/_verifiable_memory/{addr}/{number} + root.
         const vmGraphsInc = await this.discoverGraphsByPrefix(
           `${dataGraph}/_verifiable_memory/`,
-          storeOptions(options),
+          reads,
         );
         const dataSparql = vmGraphsInc.length > 0
           ? (this.wrapVerifiableMemoryGraphSet(sparql, [dataGraph, ...vmGraphsInc])
@@ -496,13 +546,13 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         // Per-KA SWM: union the discovered …/_shared_memory/{addr}/{number} graphs.
         const swmGraphs = await this.discoverGraphsByPrefix(
           `${sharedMemoryGraph}/`,
-          storeOptions(options),
+          reads,
         );
         const sharedMemorySparql = swmGraphs.length > 0
           ? (wrapWithGraphUnion(sparql, swmGraphs) ?? wrapWithGraph(sparql, sharedMemoryGraph))
           : wrapWithGraph(sparql, sharedMemoryGraph);
-        const dataResult = await this.store.query(dataSparql, storeOptions(options));
-        const smResult = await this.store.query(sharedMemorySparql, storeOptions(options));
+        const dataResult = await reads.query(dataSparql);
+        const smResult = await reads.query(sharedMemorySparql);
         return mergeSharedMemoryAndDataResults(dataResult, smResult);
       }
       if (options?.graphSuffix === '_shared_memory') {
@@ -510,7 +560,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         // per-KA graphs under the prefix and union them (the legacy bucket is now empty).
         const swmGraphs = await this.discoverGraphsByPrefix(
           `${sharedMemoryGraph}/`,
-          storeOptions(options),
+          reads,
         );
         effectiveSparql = swmGraphs.length > 0
           ? (wrapWithGraphUnion(sparql, swmGraphs) ?? wrapWithGraph(sparql, sharedMemoryGraph))
@@ -519,7 +569,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         // Per-KA VM: read-both the published per-KA …/_verifiable_memory/{addr}/{number} + root.
         const vmGraphs = await this.discoverGraphsByPrefix(
           `${dataGraph}/_verifiable_memory/`,
-          storeOptions(options),
+          reads,
         );
         effectiveSparql = vmGraphs.length > 0
           ? (this.wrapVerifiableMemoryGraphSet(sparql, [dataGraph, ...vmGraphs])
@@ -528,7 +578,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
       }
     }
 
-    const result = await this.execAndNormalize(effectiveSparql, storeOptions(options));
+    const result = await this.execAndNormalize(effectiveSparql, reads);
 
     // Strip results originating from excluded graphs (e.g. private CGs).
     if (options?.excludeGraphPrefixes?.length && result.bindings.length > 0) {
@@ -565,6 +615,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     view: GetView,
     contextGraphId: string,
     options: QueryOptions,
+    reads: QueryStoreReadContext,
   ): Promise<QueryResult> {
     // Uniform layout (rc.17): a by-name working-memory read must target the per-KA
     // graph `…/_working_memory/{addr}/{number}` the data was written to. Resolve the
@@ -577,8 +628,8 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         contextGraphId,
         options.agentAddress,
         options.assertionName,
+        reads,
         options.subGraphName,
-        storeOptions(options),
       );
     }
 
@@ -598,7 +649,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     const allGraphs = [...resolution.graphs];
 
     for (const prefix of resolution.graphPrefixes) {
-      const discovered = await this.discoverGraphsByPrefix(prefix, storeOptions(options));
+      const discovered = await this.discoverGraphsByPrefix(prefix, reads);
       allGraphs.push(...discovered);
     }
 
@@ -609,7 +660,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
       for (const rootGraph of resolution.graphs) {
         allGraphs.push(...(await this.discoverGraphsByPrefix(
           `${rootGraph}${ASSERTION_NAMED_GRAPH_PREFIX}`,
-          storeOptions(options),
+          reads,
         )));
       }
     }
@@ -627,7 +678,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     if (!options.subGraphName && !options.verifiedGraph && !(view === 'working-memory' && options.assertionName)) {
       const subNames = await this.discoverRegisteredSubGraphNames(
         contextGraphId,
-        storeOptions(options),
+        reads,
       );
       for (const sub of subNames) {
         const subResolution = resolveViewGraphs(view, contextGraphId, {
@@ -636,7 +687,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         });
         allGraphs.push(...subResolution.graphs);
         for (const prefix of subResolution.graphPrefixes) {
-          allGraphs.push(...(await this.discoverGraphsByPrefix(prefix, storeOptions(options))));
+          allGraphs.push(...(await this.discoverGraphsByPrefix(prefix, reads)));
         }
       }
     }
@@ -655,7 +706,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     if (view === 'verifiable-memory' && !options.verifiedGraph && !options.subGraphName) {
       allGraphs.push(...(await this.discoverContextGraphPerCgIdDataGraphs(
         contextGraphId,
-        storeOptions(options),
+        reads,
       )));
     }
 
@@ -720,18 +771,18 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     if (allGraphs.length === 1) {
       return this.execAndNormalize(
         wrapWithGraph(effectiveSparql, allGraphs[0]),
-        storeOptions(options),
+        reads,
       );
     }
 
     if (view === 'verifiable-memory') {
       const rewritten = this.wrapVerifiableMemoryGraphSet(effectiveSparql, allGraphs);
       if (rewritten !== null) {
-        return this.execAndNormalize(rewritten, storeOptions(options));
+        return this.execAndNormalize(rewritten, reads);
       }
     }
 
-    return this.queryMultipleGraphs(effectiveSparql, allGraphs, storeOptions(options));
+    return this.queryMultipleGraphs(effectiveSparql, allGraphs, reads);
   }
 
   /** Canonical graph rewrite for root + per-KA/per-cgId verifiable-memory reads. */
@@ -746,11 +797,11 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
   private async queryMultipleGraphs(
     sparql: string,
     graphs: string[],
-    options?: StoreQueryOptions,
+    reads: StoreReadLane,
   ): Promise<QueryResult> {
     if (graphs.length === 0) return { bindings: [] };
     if (graphs.length === 1) {
-      return this.execAndNormalize(wrapWithGraph(sparql, graphs[0]), options);
+      return this.execAndNormalize(wrapWithGraph(sparql, graphs[0]), reads);
     }
     // Prefer a single `VALUES ?g { … } GRAPH ?g { … }` query: it scopes the
     // read to the named-graph set as ONE basic graph pattern iterated over a
@@ -763,7 +814,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     // around the injected block.
     const valuesSparql = wrapWithGraphValues(sparql, graphs);
     if (valuesSparql !== null) {
-      return this.execAndNormalize(valuesSparql, options);
+      return this.execAndNormalize(valuesSparql, reads);
     }
     // Residual shapes `wrapWithGraphValues` declines (an inner top-level
     // UNION, no locatable WHERE block, or a sentinel-variable collision) keep
@@ -771,7 +822,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     // cross-graph merge below is preserved unchanged.
     const unionSparql = wrapWithGraphUnion(sparql, graphs);
     if (unionSparql !== null) {
-      return this.execAndNormalize(unionSparql, options);
+      return this.execAndNormalize(unionSparql, reads);
     }
     // Fallback: the inner body contains a UNION so we cannot safely wrap
     // in a single query without either crashing Blazegraph (nested
@@ -790,7 +841,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
       // constructed from multiple source graphs).
       const merged: Quad[] = [];
       for (const g of graphs) {
-        const r = await this.execAndNormalize(wrapWithGraph(sparql, g), options);
+        const r = await this.execAndNormalize(wrapWithGraph(sparql, g), reads);
         if (r.quads) merged.push(...r.quads);
       }
       return { bindings: [], quads: dedupeQuads(merged) };
@@ -800,7 +851,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
       // Boolean result: true iff the pattern matches in ANY graph.
       // Short-circuit on the first positive graph.
       for (const g of graphs) {
-        const r = await this.execAndNormalize(wrapWithGraph(sparql, g), options);
+        const r = await this.execAndNormalize(wrapWithGraph(sparql, g), reads);
         if (r.bindings[0]?.result === 'true') {
           return { bindings: [{ result: 'true' }] };
         }
@@ -827,7 +878,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     }
     const all: Record<string, string>[] = [];
     for (const g of graphs) {
-      const r = await this.execAndNormalize(wrapWithGraph(sparql, g), options);
+      const r = await this.execAndNormalize(wrapWithGraph(sparql, g), reads);
       all.push(...r.bindings);
     }
     return { bindings: all };
@@ -835,9 +886,9 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
 
   private async discoverGraphsByPrefix(
     prefix: string,
-    options?: StoreQueryOptions,
+    reads: StoreReadLane,
   ): Promise<string[]> {
-    const allGraphs = await listGraphsByPrefix(this.store, prefix, options);
+    const allGraphs = await reads.listGraphsByPrefix(prefix);
     return allGraphs.filter(
       (g) => g.startsWith(prefix) && !g.includes('/_meta') && !g.includes('/staging/'),
     );
@@ -855,10 +906,10 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
    */
   private async discoverContextGraphPerCgIdDataGraphs(
     contextGraphId: string,
-    options?: StoreQueryOptions,
+    reads: StoreReadLane,
   ): Promise<string[]> {
     const base = `did:dkg:context-graph:${contextGraphId}/context/`;
-    const discovered = await this.discoverGraphsByPrefix(base, options);
+    const discovered = await this.discoverGraphsByPrefix(base, reads);
     return discovered.filter((g) => {
       const rest = g.slice(base.length);
       return rest.length > 0 && !rest.includes('/');
@@ -875,14 +926,14 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
    */
   private async discoverGraphScopedPrivateGraphs(
     contextGraphId: string,
+    reads: StoreReadLane,
     subGraphName?: string,
-    options?: StoreQueryOptions,
   ): Promise<string[]> {
     const metaGraph = contextGraphMetaUri(contextGraphId);
     const subGraphClause = subGraphName
       ? `?ual <http://dkg.io/ontology/subGraphName> "${escapeSparqlLiteral(subGraphName)}" .`
       : `FILTER NOT EXISTS { ?ual <http://dkg.io/ontology/subGraphName> ?_subGraphName . }`;
-    const result = await this.store.query(
+    const result = await reads.query(
       `SELECT DISTINCT ?ual ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph ?privateCount WHERE {
         GRAPH <${assertSafeIri(metaGraph)}> {
           ?ual <http://dkg.io/ontology/contentScopeVersion> ?scopeVersion ;
@@ -895,7 +946,6 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
           ${subGraphClause}
         }
       }`,
-      options,
     );
     if (result.type !== 'bindings') return [];
 
@@ -951,8 +1001,8 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     contextGraphId: string,
     agentAddress: string,
     assertionName: string,
+    reads: StoreReadLane,
     subGraphName?: string,
-    options?: StoreQueryOptions,
   ): Promise<bigint | undefined> {
     // Mirror the writer (`assertionFinalize`): the `dkg:kaId` stamp lives in the
     // ROOT `_meta` graph, but keyed by the SUB-GRAPH-AWARE lifecycle URN
@@ -960,9 +1010,8 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     // segment here made every sub-graph by-name lookup miss (Codex on PR #1132).
     const urn = assertionLifecycleUri(contextGraphId, agentAddress, assertionName, subGraphName);
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    const res = await this.store.query(
+    const res = await reads.query(
       `SELECT ?n WHERE { GRAPH <${metaGraph}> { <${urn}> <http://dkg.io/ontology/kaId> ?n } } LIMIT 1`,
-      options,
     );
     if (res.type === 'bindings' && res.bindings.length > 0) {
       const m = res.bindings[0]['n']?.match(/(\d+)/);
@@ -975,7 +1024,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     contextGraphId: string,
     staticAllowedGraphs: string[],
     opts: { subGraphName?: string; isSwmOnlyRoute: boolean },
-    options?: StoreQueryOptions,
+    reads: QueryStoreReadContext,
   ): Promise<string[]> {
     if (opts.isSwmOnlyRoute) {
       return staticAllowedGraphs;
@@ -984,8 +1033,8 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     const allowed = new Set(staticAllowedGraphs);
     const scopedContentGraphs = await this.resolveScopedContentGraphAllowList(
       contextGraphId,
+      reads,
       opts.subGraphName,
-      options,
     );
     for (const graph of scopedContentGraphs) {
       allowed.add(graph);
@@ -996,25 +1045,23 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
 
   private async resolveScopedContentGraphAllowList(
     contextGraphId: string,
+    reads: QueryStoreReadContext,
     subGraphName?: string,
-    options?: StoreQueryOptions,
   ): Promise<string[]> {
-    const sharedOptions = sharedDiscoveryStoreOptions(options);
     const key = JSON.stringify([
       contextGraphId,
       subGraphName ?? null,
-      sharedOptions?.priority ?? 'normal',
-      sharedOptions?.source ?? null,
+      reads.shared.cacheKey,
     ]);
     const cached = this.scopedContentGraphAllowListInFlight.get(key);
     if (cached) {
-      return raceAgainstCallerAbort(cached, options?.signal);
+      return raceAgainstCallerAbort(cached, reads.signal);
     }
 
     const promise = this.discoverScopedContentGraphAllowList(
       contextGraphId,
+      reads.shared,
       subGraphName,
-      sharedOptions,
     );
     this.scopedContentGraphAllowListInFlight.set(key, promise);
     void promise.finally(() => {
@@ -1022,30 +1069,28 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         this.scopedContentGraphAllowListInFlight.delete(key);
       }
     }).catch(() => undefined);
-    return raceAgainstCallerAbort(promise, options?.signal);
+    return raceAgainstCallerAbort(promise, reads.signal);
   }
 
   private async discoverScopedContentGraphAllowList(
     contextGraphId: string,
+    reads: StoreReadLane,
     subGraphName?: string,
-    options?: StoreQueryOptions,
   ): Promise<string[]> {
     const allowed = new Set<string>();
     const registeredSubGraphs = subGraphName
       ? new Set([subGraphName])
-      : await this.discoverRegisteredSubGraphNames(contextGraphId, options);
+      : await this.discoverRegisteredSubGraphNames(contextGraphId, reads);
     const registeredAssertionGraphs = await this.discoverRegisteredAssertionGraphs(
       contextGraphId,
-      options,
+      reads,
     );
     const knownChildContextGraphs = await this.discoverKnownChildContextGraphUris(
       contextGraphId,
-      options,
+      reads,
     );
-    const allGraphs = await listGraphFamily(
-      this.store,
+    const allGraphs = await reads.listGraphFamily(
       `did:dkg:context-graph:${contextGraphId}`,
-      options,
     );
 
     for (const graph of allGraphs) {
@@ -1068,18 +1113,17 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
 
   private async discoverRegisteredSubGraphNames(
     contextGraphId: string,
-    options?: StoreQueryOptions,
+    reads: StoreReadLane,
   ): Promise<Set<string>> {
     const names = new Set<string>();
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    const result = await this.store.query(
+    const result = await reads.query(
       `SELECT ?name WHERE {
         GRAPH <${assertSafeIri(metaGraph)}> {
           ?subGraph a <http://dkg.io/ontology/SubGraph> ;
                     <http://schema.org/name> ?name .
         }
       }`,
-      options,
     );
     if (result.type !== 'bindings') return names;
 
@@ -1094,17 +1138,16 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
 
   private async discoverRegisteredAssertionGraphs(
     contextGraphId: string,
-    options?: StoreQueryOptions,
+    reads: StoreReadLane,
   ): Promise<Set<string>> {
     const graphs = new Set<string>();
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    const result = await this.store.query(
+    const result = await reads.query(
       `SELECT ?graph WHERE {
         GRAPH <${assertSafeIri(metaGraph)}> {
           ?assertion <http://dkg.io/ontology/assertionGraph> ?graph .
         }
       }`,
-      options,
     );
     if (result.type !== 'bindings') return graphs;
 
@@ -1119,10 +1162,10 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
 
   private async discoverKnownChildContextGraphUris(
     contextGraphId: string,
-    options?: StoreQueryOptions,
+    reads: StoreReadLane,
   ): Promise<Set<string>> {
     const rootPrefix = `${contextGraphDataUri(contextGraphId)}/`;
-    const result = await this.store.query(
+    const result = await reads.query(
       `SELECT DISTINCT ?ctxGraph WHERE {
         GRAPH ?g {
           {
@@ -1134,7 +1177,6 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
         FILTER(STRSTARTS(STR(?ctxGraph), "${escapeSparqlLiteral(rootPrefix)}"))
       }`,
-      options,
     );
     const uris = new Set<string>();
     if (result.type !== 'bindings') return uris;
@@ -1150,9 +1192,9 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
 
   private async execAndNormalize(
     sparql: string,
-    options?: StoreQueryOptions,
+    reads: StoreReadLane,
   ): Promise<QueryResult> {
-    const result = await this.store.query(sparql, options);
+    const result = await reads.query(sparql);
 
     if (result.type === 'bindings') {
       if (result.bindings.length === 0) {
@@ -1990,127 +2032,6 @@ function collectGraphVariables(sparql: string): string[] {
   return variables;
 }
 
-function skipSparqlIriRef(sparql: string, start: number): number | null {
-  if (sparql[start] !== '<') return null;
-  const next = sparql[start + 1];
-  if (!isLikelyIriRefStart(next)) return null;
-
-  for (let i = start + 1; i < sparql.length; i++) {
-    const ch = sparql[i];
-    if (ch === '>') return i + 1;
-    if (
-      ch === '<' ||
-      ch === '"' ||
-      ch === '{' ||
-      ch === '}' ||
-      ch === '|' ||
-      ch === '\\' ||
-      ch === '^' ||
-      ch === '`' ||
-      /\s/.test(ch)
-    ) {
-      return null;
-    }
-  }
-
-  return null;
-}
-
-function isLikelyIriRefStart(ch: string | undefined): boolean {
-  return !!ch && (
-    (ch >= 'A' && ch <= 'Z') ||
-    (ch >= 'a' && ch <= 'z') ||
-    ch === '#' ||
-    ch === '_' ||
-    ch === '/' ||
-    ch === '.'
-  );
-}
-
-function readSparqlVariable(sparql: string, start: number): string | null {
-  const sigil = sparql[start];
-  if (sigil !== '?' && sigil !== '$') return null;
-  let end = start + 1;
-  const first = readCodePoint(sparql, end);
-  if (!first || !isSparqlVariableInitialCodePoint(first.codePoint)) return null;
-  end += first.width;
-
-  while (end < sparql.length) {
-    const next = readCodePoint(sparql, end);
-    if (!next || !isSparqlVariableContinuationCodePoint(next.codePoint)) break;
-    end += next.width;
-  }
-
-  return end > start + 1 ? sparql.slice(start, end) : null;
-}
-
-function readCodePoint(src: string, index: number): { codePoint: number; width: number } | null {
-  if (index >= src.length) return null;
-  const codePoint = src.codePointAt(index);
-  if (codePoint === undefined) return null;
-  return { codePoint, width: codePoint > 0xffff ? 2 : 1 };
-}
-
-function isSparqlVariableInitialCodePoint(codePoint: number): boolean {
-  return isSparqlPnCharsUCodePoint(codePoint) || isAsciiDigitCodePoint(codePoint);
-}
-
-function isSparqlVariableContinuationCodePoint(codePoint: number): boolean {
-  return (
-    isSparqlPnCharsUCodePoint(codePoint) ||
-    isAsciiDigitCodePoint(codePoint) ||
-    codePoint === 0x00b7 ||
-    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
-    (codePoint >= 0x203f && codePoint <= 0x2040)
-  );
-}
-
-function isSparqlPnCharsUCodePoint(codePoint: number): boolean {
-  return (
-    codePoint === 0x5f ||
-    isAsciiAlphaCodePoint(codePoint) ||
-    (codePoint >= 0x00c0 && codePoint <= 0x00d6) ||
-    (codePoint >= 0x00d8 && codePoint <= 0x00f6) ||
-    (codePoint >= 0x00f8 && codePoint <= 0x02ff) ||
-    (codePoint >= 0x0370 && codePoint <= 0x037d) ||
-    (codePoint >= 0x037f && codePoint <= 0x1fff) ||
-    (codePoint >= 0x200c && codePoint <= 0x200d) ||
-    (codePoint >= 0x2070 && codePoint <= 0x218f) ||
-    (codePoint >= 0x2c00 && codePoint <= 0x2fef) ||
-    (codePoint >= 0x3001 && codePoint <= 0xd7ff) ||
-    (codePoint >= 0xf900 && codePoint <= 0xfdcf) ||
-    (codePoint >= 0xfdf0 && codePoint <= 0xfffd) ||
-    (codePoint >= 0x10000 && codePoint <= 0xeffff)
-  );
-}
-
-function isAsciiAlphaCodePoint(codePoint: number): boolean {
-  return (
-    (codePoint >= 0x41 && codePoint <= 0x5a) ||
-    (codePoint >= 0x61 && codePoint <= 0x7a)
-  );
-}
-
-function isAsciiDigitCodePoint(codePoint: number): boolean {
-  return codePoint >= 0x30 && codePoint <= 0x39;
-}
-
-function skipSparqlSpaceAndLineComments(sparql: string, start: number): number {
-  let i = start;
-  while (i < sparql.length) {
-    if (/\s/.test(sparql[i])) {
-      i++;
-      continue;
-    }
-    if (sparql[i] === '#') {
-      while (i < sparql.length && sparql[i] !== '\n') i++;
-      continue;
-    }
-    break;
-  }
-  return i;
-}
-
 function skipBalancedParentheses(sparql: string, start: number, limit = sparql.length): number | null {
   if (sparql[start] !== '(') return null;
   let depth = 1;
@@ -2162,37 +2083,6 @@ function skipValuesClause(sparql: string, start: number, limit: number): number 
     i++;
   }
   return i;
-}
-
-function isKeywordStart(src: string, idx: number): boolean {
-  const ch = src[idx];
-  if (!isWordStart(ch)) return false;
-  const prev = idx > 0 ? src[idx - 1] : '';
-  return !prev || (!isWordContinuation(prev) && prev !== '?' && prev !== '$' && prev !== ':' && prev !== '#');
-}
-
-function isSparqlKeyword(src: string, start: number, end: number, keyword: string): boolean {
-  const next = src[end];
-  return src.slice(start, end).toUpperCase() === keyword
-    && next !== ':'
-    && next !== '-'
-    && next !== '.';
-}
-
-function isWordStart(ch: string | undefined): ch is string {
-  return !!ch && (
-    (ch >= 'A' && ch <= 'Z') ||
-    (ch >= 'a' && ch <= 'z') ||
-    ch === '_'
-  );
-}
-
-function isWordContinuation(ch: string | undefined): ch is string {
-  return isWordStart(ch) || isAsciiDigitChar(ch);
-}
-
-function isAsciiDigitChar(ch: string | undefined): ch is string {
-  return !!ch && ch >= '0' && ch <= '9';
 }
 
 /**
@@ -2529,79 +2419,6 @@ function findWhereBraceStart(sparql: string): number {
   }
   if (depth !== 0 || opens.length === 0) return -1;
   return opens[opens.length - 1];
-}
-
-/**
- * Locate the matching `}` for the `{` at `openIdx`, while skipping over
- * `{` / `}` chars that appear inside SPARQL string literals, line
- * comments, or IRIREFs.
- *
- * — dkg-query-engine.ts:939). The naive
- * brace-balance loop in `injectMinTrustFilter`, `wrapWithGraph`, and
- * `wrapWithGraphUnion` counted `{`/`}` blindly. A query like
- *
- *     SELECT ?t WHERE { ... FILTER(STR(?t) = "{") }
- *
- * has a literal `{` inside a string literal and a single closing `}`
- * for the WHERE block, so the naive counter ended at depth 1 and
- * returned `-1`. Every caller treated `-1` as "refuse to rewrite" and
- * (for `injectMinTrustFilter`) silently fail-closed `minTrust >
- * Endorsed` queries to an empty result — exactly the literal-heavy
- * shape the surrounding scrubbing was supposed to enable.
- *
- * Returns `-1` if `sparql[openIdx]` is not `{` or no matching close
- * exists at depth zero.
- */
-function findMatchingCloseBrace(sparql: string, openIdx: number): number {
-  if (sparql[openIdx] !== '{') return -1;
-  const n = sparql.length;
-  let depth = 0;
-  let i = openIdx;
-  while (i < n) {
-    const ch = sparql[i];
-    if (ch === '#') {
-      // Line comment — skip to newline.
-      while (i < n && sparql[i] !== '\n') i++;
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      // Centralised triple-quoted-aware skip.
-      i = skipSparqlStringLiteral(sparql, i);
-      continue;
-    }
-    if (ch === '<') {
-      // Look ahead for a balanced `>` that delimits an IRIREF body.
-      // IRIREFs cannot contain whitespace or any of `<{}|"^\``, so a
-      // candidate range that contains those chars is treated as a
-      // comparison operator and we fall through to a single-byte
-      // advance. (Mirror of the IRI/comparison disambiguation in
-      // `findWhereBraceStart`.)
-      let foundIri = false;
-      for (let j = i + 1; j < n; j++) {
-        const c = sparql[j];
-        if (c === '>') { foundIri = true; i = j + 1; break; }
-        if (
-          c === '<' || c === '"' || c === '{' || c === '}' ||
-          c === '|' || c === '\\' || c === '^' || c === '`' ||
-          /\s/.test(c)
-        ) {
-          break;
-        }
-      }
-      if (foundIri) continue;
-      // Comparison operator — advance one byte.
-      i++;
-      continue;
-    }
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) return i;
-      if (depth < 0) return -1;
-    }
-    i++;
-  }
-  return -1;
 }
 
 /**

--- a/packages/query/src/sparql-graph-scope.ts
+++ b/packages/query/src/sparql-graph-scope.ts
@@ -1,4 +1,13 @@
-import { skipSparqlStringLiteral } from './sparql-utils.js';
+import {
+  findMatchingSparqlCloseBrace as findMatchingCloseBrace,
+  isSparqlKeyword,
+  isSparqlKeywordStart as isKeywordStart,
+  isSparqlWordContinuation as isWordContinuation,
+  readSparqlVariable,
+  skipSparqlIriRef,
+  skipSparqlSpaceAndLineComments,
+  skipSparqlStringLiteral,
+} from './sparql-utils.js';
 
 export interface SparqlPrefixName {
   prefix: string;
@@ -192,129 +201,6 @@ function parseStaticGraphValues(
     i += prefixedName.length;
   }
   return values;
-}
-
-function findMatchingCloseBrace(sparql: string, openIdx: number): number {
-  if (sparql[openIdx] !== '{') return -1;
-  let depth = 0;
-  let i = openIdx;
-  while (i < sparql.length) {
-    const ch = sparql[i];
-    if (ch === '#') {
-      while (i < sparql.length && sparql[i] !== '\n') i++;
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      i = skipSparqlStringLiteral(sparql, i);
-      continue;
-    }
-    if (ch === '<') {
-      const iriEnd = skipSparqlIriRef(sparql, i);
-      if (iriEnd) {
-        i = iriEnd;
-        continue;
-      }
-    }
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) return i;
-      if (depth < 0) return -1;
-    }
-    i++;
-  }
-  return -1;
-}
-
-function skipSparqlIriRef(sparql: string, start: number): number | null {
-  if (sparql[start] !== '<') return null;
-  const next = sparql[start + 1];
-  if (!next || !(/[A-Za-z]/.test(next) || '#_/.'.includes(next))) return null;
-  for (let i = start + 1; i < sparql.length; i++) {
-    const ch = sparql[i];
-    if (ch === '>') return i + 1;
-    if (
-      ch === '<' ||
-      ch === '"' ||
-      ch === '{' ||
-      ch === '}' ||
-      ch === '|' ||
-      ch === '\\' ||
-      ch === '^' ||
-      ch === '`' ||
-      /\s/.test(ch)
-    ) {
-      return null;
-    }
-  }
-  return null;
-}
-
-function readSparqlVariable(sparql: string, start: number): string | null {
-  const sigil = sparql[start];
-  if (sigil !== '?' && sigil !== '$') return null;
-  let end = start + 1;
-  if (!isVariableChar(sparql[end])) return null;
-  while (isVariableChar(sparql[end])) end++;
-  return sparql.slice(start, end);
-}
-
-function isVariableChar(ch: string | undefined): ch is string {
-  return !!ch && /[\p{L}\p{N}_\u00B7\u0300-\u036F\u203F-\u2040]/u.test(ch);
-}
-
-function skipSparqlSpaceAndLineComments(sparql: string, start: number): number {
-  let i = start;
-  while (i < sparql.length) {
-    if (/\s/.test(sparql[i])) {
-      i++;
-      continue;
-    }
-    if (sparql[i] === '#') {
-      while (i < sparql.length && sparql[i] !== '\n') i++;
-      continue;
-    }
-    break;
-  }
-  return i;
-}
-
-function isKeywordStart(src: string, idx: number): boolean {
-  const ch = src[idx];
-  if (!isWordStart(ch)) return false;
-  const prev = idx > 0 ? src[idx - 1] : '';
-  return !prev || (
-    !isWordContinuation(prev) &&
-    prev !== '?' &&
-    prev !== '$' &&
-    prev !== ':' &&
-    prev !== '#'
-  );
-}
-
-function isSparqlKeyword(
-  src: string,
-  start: number,
-  end: number,
-  keyword: string,
-): boolean {
-  const next = src[end];
-  return src.slice(start, end).toUpperCase() === keyword
-    && next !== ':'
-    && next !== '-'
-    && next !== '.';
-}
-
-function isWordStart(ch: string | undefined): boolean {
-  return !!ch && (
-    (ch >= 'A' && ch <= 'Z') ||
-    (ch >= 'a' && ch <= 'z') ||
-    ch === '_'
-  );
-}
-
-function isWordContinuation(ch: string | undefined): boolean {
-  return isWordStart(ch) || (!!ch && ch >= '0' && ch <= '9');
 }
 
 function isSparqlPrefixLabelChar(ch: string | undefined): ch is string {

--- a/packages/query/src/sparql-utils.ts
+++ b/packages/query/src/sparql-utils.ts
@@ -41,3 +41,198 @@ export function skipSparqlStringLiteral(src: string, i: number): number {
   }
   return j;
 }
+
+/** Skip a syntactically valid SPARQL IRIREF, or return null for `<` comparisons. */
+export function skipSparqlIriRef(sparql: string, start: number): number | null {
+  if (sparql[start] !== '<') return null;
+  const next = sparql[start + 1];
+  if (!isLikelyIriRefStart(next)) return null;
+
+  for (let i = start + 1; i < sparql.length; i++) {
+    const ch = sparql[i];
+    if (ch === '>') return i + 1;
+    if (
+      ch === '<' ||
+      ch === '"' ||
+      ch === '{' ||
+      ch === '}' ||
+      ch === '|' ||
+      ch === '\\' ||
+      ch === '^' ||
+      ch === '`' ||
+      /\s/.test(ch)
+    ) {
+      return null;
+    }
+  }
+  return null;
+}
+
+function isLikelyIriRefStart(ch: string | undefined): boolean {
+  return !!ch && (
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= 'a' && ch <= 'z') ||
+    ch === '#' ||
+    ch === '_' ||
+    ch === '/' ||
+    ch === '.'
+  );
+}
+
+/** Read a SPARQL variable using the full Unicode variable-name grammar. */
+export function readSparqlVariable(sparql: string, start: number): string | null {
+  const sigil = sparql[start];
+  if (sigil !== '?' && sigil !== '$') return null;
+  let end = start + 1;
+  const first = readCodePoint(sparql, end);
+  if (!first || !isSparqlVariableInitialCodePoint(first.codePoint)) return null;
+  end += first.width;
+
+  while (end < sparql.length) {
+    const next = readCodePoint(sparql, end);
+    if (!next || !isSparqlVariableContinuationCodePoint(next.codePoint)) break;
+    end += next.width;
+  }
+  return sparql.slice(start, end);
+}
+
+function readCodePoint(src: string, index: number): { codePoint: number; width: number } | null {
+  if (index >= src.length) return null;
+  const codePoint = src.codePointAt(index);
+  if (codePoint === undefined) return null;
+  return { codePoint, width: codePoint > 0xffff ? 2 : 1 };
+}
+
+function isSparqlVariableInitialCodePoint(codePoint: number): boolean {
+  return isSparqlPnCharsUCodePoint(codePoint) || isAsciiDigitCodePoint(codePoint);
+}
+
+function isSparqlVariableContinuationCodePoint(codePoint: number): boolean {
+  return (
+    isSparqlPnCharsUCodePoint(codePoint) ||
+    isAsciiDigitCodePoint(codePoint) ||
+    codePoint === 0x00b7 ||
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x203f && codePoint <= 0x2040)
+  );
+}
+
+function isSparqlPnCharsUCodePoint(codePoint: number): boolean {
+  return (
+    codePoint === 0x5f ||
+    isAsciiAlphaCodePoint(codePoint) ||
+    (codePoint >= 0x00c0 && codePoint <= 0x00d6) ||
+    (codePoint >= 0x00d8 && codePoint <= 0x00f6) ||
+    (codePoint >= 0x00f8 && codePoint <= 0x02ff) ||
+    (codePoint >= 0x0370 && codePoint <= 0x037d) ||
+    (codePoint >= 0x037f && codePoint <= 0x1fff) ||
+    (codePoint >= 0x200c && codePoint <= 0x200d) ||
+    (codePoint >= 0x2070 && codePoint <= 0x218f) ||
+    (codePoint >= 0x2c00 && codePoint <= 0x2fef) ||
+    (codePoint >= 0x3001 && codePoint <= 0xd7ff) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfdcf) ||
+    (codePoint >= 0xfdf0 && codePoint <= 0xfffd) ||
+    (codePoint >= 0x10000 && codePoint <= 0xeffff)
+  );
+}
+
+function isAsciiAlphaCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x41 && codePoint <= 0x5a) ||
+    (codePoint >= 0x61 && codePoint <= 0x7a)
+  );
+}
+
+function isAsciiDigitCodePoint(codePoint: number): boolean {
+  return codePoint >= 0x30 && codePoint <= 0x39;
+}
+
+/** Skip whitespace and `#` line comments between SPARQL tokens. */
+export function skipSparqlSpaceAndLineComments(sparql: string, start: number): number {
+  let i = start;
+  while (i < sparql.length) {
+    if (/\s/.test(sparql[i])) {
+      i++;
+      continue;
+    }
+    if (sparql[i] === '#') {
+      while (i < sparql.length && sparql[i] !== '\n') i++;
+      continue;
+    }
+    break;
+  }
+  return i;
+}
+
+export function isSparqlKeywordStart(src: string, idx: number): boolean {
+  const ch = src[idx];
+  if (!isWordStart(ch)) return false;
+  const prev = idx > 0 ? src[idx - 1] : '';
+  return !prev || (
+    !isSparqlWordContinuation(prev) &&
+    prev !== '?' &&
+    prev !== '$' &&
+    prev !== ':' &&
+    prev !== '#'
+  );
+}
+
+export function isSparqlKeyword(
+  src: string,
+  start: number,
+  end: number,
+  keyword: string,
+): boolean {
+  const next = src[end];
+  return src.slice(start, end).toUpperCase() === keyword
+    && next !== ':'
+    && next !== '-'
+    && next !== '.';
+}
+
+function isWordStart(ch: string | undefined): boolean {
+  return !!ch && (
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= 'a' && ch <= 'z') ||
+    ch === '_'
+  );
+}
+
+export function isSparqlWordContinuation(ch: string | undefined): ch is string {
+  return isWordStart(ch) || (!!ch && ch >= '0' && ch <= '9');
+}
+
+/** Find the closing brace while treating strings, comments, and IRIREFs as opaque. */
+export function findMatchingSparqlCloseBrace(sparql: string, openIdx: number): number {
+  if (sparql[openIdx] !== '{') return -1;
+  let depth = 0;
+  let i = openIdx;
+  while (i < sparql.length) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < sparql.length && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const iriEnd = skipSparqlIriRef(sparql, i);
+      if (iriEnd) {
+        i = iriEnd;
+        continue;
+      }
+      i++;
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return i;
+      if (depth < 0) return -1;
+    }
+    i++;
+  }
+  return -1;
+}

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, expectTypeOf } from 'vitest';
 import {
+  GraphSetIndexStore,
   OxigraphStore,
   type Quad,
   type QueryOptions as StoreQueryOptions,
@@ -118,18 +119,19 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings[0]['name']).toBe('"ImageBot"');
   });
 
-  it('propagates cancellation, priority, and source to every unshared store read', async () => {
+  it('keeps caller cancellation on execution reads but out of shareable graph discovery', async () => {
     class OptionsRecordingStore extends OxigraphStore {
-      readOptions: Array<Parameters<OxigraphStore['query']>[1]> = [];
+      queryOptions: Array<Parameters<OxigraphStore['query']>[1]> = [];
+      discoveryOptions: StoreQueryOptions[] = [];
       async query(sparql: string, options?: Parameters<OxigraphStore['query']>[1]) {
-        this.readOptions.push(options);
+        this.queryOptions.push(options);
         return super.query(sparql, options);
       }
       async listGraphsByPrefix(
         prefix: string,
         options?: StoreQueryOptions,
       ) {
-        this.readOptions.push(options);
+        this.discoveryOptions.push(options ?? {});
         return (await super.listGraphs(options)).filter((graph) => graph.startsWith(prefix));
       }
     }
@@ -152,13 +154,19 @@ describe('DKGQueryEngine', () => {
       },
     );
 
-    expect(recordingStore.readOptions.length).toBeGreaterThanOrEqual(4);
-    for (const options of recordingStore.readOptions) {
+    expect(recordingStore.queryOptions).not.toHaveLength(0);
+    expect(recordingStore.queryOptions).toContainEqual(expect.objectContaining({
+      signal: controller.signal,
+      priority: 'background',
+      source: 'api.query',
+    }));
+    expect(recordingStore.discoveryOptions).not.toHaveLength(0);
+    for (const options of recordingStore.discoveryOptions) {
       expect(options).toMatchObject({
-        signal: controller.signal,
         priority: 'background',
         source: 'api.query',
       });
+      expect(options.signal).toBeUndefined();
     }
   });
 
@@ -228,6 +236,77 @@ describe('DKGQueryEngine', () => {
       source: 'api.query',
     });
     expect(sharedStore.sharedOptions[0]?.signal).toBeUndefined();
+    expect(secondController.signal.aborted).toBe(false);
+  });
+
+  it('keeps caller cancellation out of GraphSetIndexStore refresh flights', async () => {
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    let refreshStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      refreshStarted = resolve;
+    });
+
+    class AbortAwareGraphListStore extends OxigraphStore {
+      readonly listGraphOptions: StoreQueryOptions[] = [];
+      private held = false;
+
+      override async listGraphs(options?: StoreQueryOptions): Promise<string[]> {
+        this.listGraphOptions.push(options ?? {});
+        if (!this.held) {
+          this.held = true;
+          refreshStarted();
+          await new Promise<void>((resolve, reject) => {
+            const onAbort = () => reject(options?.signal?.reason);
+            options?.signal?.addEventListener('abort', onAbort, { once: true });
+            void refreshGate.then(() => {
+              options?.signal?.removeEventListener('abort', onAbort);
+              resolve();
+            }, reject);
+          });
+        }
+        return super.listGraphs(options);
+      }
+    }
+
+    const inner = new AbortAwareGraphListStore();
+    await inner.insert([
+      q('urn:indexed:s', 'http://schema.org/name', '"Indexed"', GRAPH),
+    ]);
+    const indexedEngine = new DKGQueryEngine(new GraphSetIndexStore(inner));
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const common = {
+      contextGraphId: CONTEXT_GRAPH,
+      includeSharedMemory: true,
+      priority: 'background' as const,
+      source: 'api.query',
+    };
+
+    const first = indexedEngine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { ...common, signal: firstController.signal },
+    );
+    const firstRejected = expect(first).rejects.toThrow('first caller disconnected');
+    await started;
+    const second = indexedEngine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { ...common, signal: secondController.signal },
+    );
+
+    firstController.abort(new Error('first caller disconnected'));
+    await firstRejected;
+    releaseRefresh();
+
+    await expect(second).resolves.toBeDefined();
+    expect(inner.listGraphOptions).toHaveLength(1);
+    expect(inner.listGraphOptions[0]).toMatchObject({
+      priority: 'background',
+      source: 'api.query',
+    });
+    expect(inner.listGraphOptions[0].signal).toBeUndefined();
     expect(secondController.signal.aborted).toBe(false);
   });
 
@@ -1689,6 +1768,44 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings).toEqual([{ sourceGraph: vm, name: '"allowed"' }]);
     const executed = recordingStore.queries.at(-1) ?? '';
     expect(executed.match(/VALUES\s+\?sourceGraph/gi)).toHaveLength(2);
+  });
+
+  it('rejects a default-graph pattern even when authorized VALUES makes graph injection redundant', async () => {
+    const vm = `${GRAPH}/_verifiable_memory/0xagent/guard-order-default`;
+    await store.insert([
+      q('urn:guard:default', 'http://schema.org/name', '"guard"', vm),
+    ]);
+
+    await expect(engine.query(
+      `SELECT ?sourceGraph ?name ?description WHERE {
+        VALUES ?sourceGraph { <${vm}> }
+        GRAPH ?sourceGraph { ?s <http://schema.org/name> ?name }
+        ?s <http://schema.org/description> ?description
+      }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    )).rejects.toThrow(
+      /Scoped query violation: GRAPH variables cannot be mixed with default-graph triple patterns/i,
+    );
+  });
+
+  it('rejects nested GRAPH use even when authorized VALUES makes graph injection redundant', async () => {
+    const vm = `${GRAPH}/_verifiable_memory/0xagent/guard-order-optional`;
+    await store.insert([
+      q('urn:guard:optional', 'http://schema.org/name', '"guard"', vm),
+    ]);
+
+    await expect(engine.query(
+      `SELECT ?sourceGraph ?name ?description WHERE {
+        VALUES ?sourceGraph { <${vm}> }
+        GRAPH ?sourceGraph { ?s <http://schema.org/name> ?name }
+        OPTIONAL {
+          GRAPH ?sourceGraph { ?s <http://schema.org/description> ?description }
+        }
+      }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    )).rejects.toThrow(
+      /Scoped query violation: GRAPH variables must appear at the top level/i,
+    );
   });
 
   it('rejects mixed GRAPH-variable and default-graph triple patterns', async () => {

--- a/packages/storage/src/abortable-store-work-lifecycle.ts
+++ b/packages/storage/src/abortable-store-work-lifecycle.ts
@@ -4,34 +4,37 @@
  * Kept here instead of in an HTTP adapter so every scheduled operation in one
  * lifecycle generation observes the same close boundary.
  */
+export interface AbortSignalScope {
+  readonly signal: AbortSignal | undefined;
+  dispose(): void;
+}
+
+const NOOP_DISPOSE = () => {};
+
 export function composeAbortSignals(
   primary: AbortSignal | undefined,
   secondary: AbortSignal | undefined,
-): AbortSignal | undefined {
-  if (!primary) return secondary;
-  if (!secondary) return primary;
-  const AnyImpl = (AbortSignal as unknown as {
-    any?: (signals: AbortSignal[]) => AbortSignal;
-  }).any;
-  if (AnyImpl) return AnyImpl([primary, secondary]);
+): AbortSignalScope {
+  if (!primary) return { signal: secondary, dispose: NOOP_DISPOSE };
+  if (!secondary) return { signal: primary, dispose: NOOP_DISPOSE };
 
   const combined = new AbortController();
-  let settled = false;
-  const cleanup = () => {
+  let disposed = false;
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
     primary.removeEventListener('abort', forwardPrimary);
     secondary.removeEventListener('abort', forwardSecondary);
   };
   const forwardPrimary = () => {
-    if (settled) return;
-    settled = true;
-    cleanup();
+    if (disposed || combined.signal.aborted) return;
     combined.abort(primary.reason);
+    dispose();
   };
   const forwardSecondary = () => {
-    if (settled) return;
-    settled = true;
-    cleanup();
+    if (disposed || combined.signal.aborted) return;
     combined.abort(secondary.reason);
+    dispose();
   };
 
   if (primary.aborted) combined.abort(primary.reason);
@@ -40,7 +43,7 @@ export function composeAbortSignals(
     primary.addEventListener('abort', forwardPrimary, { once: true });
     secondary.addEventListener('abort', forwardSecondary, { once: true });
   }
-  return combined.signal;
+  return { signal: combined.signal, dispose };
 }
 
 interface StoreWorkGeneration {
@@ -82,11 +85,18 @@ export class AbortableStoreWorkLifecycle {
       );
     }
 
-    const signal = composeAbortSignals(callerSignal, generation.controller.signal);
-    const task = start(signal);
+    const signalScope = composeAbortSignals(callerSignal, generation.controller.signal);
+    let task: Promise<T>;
+    try {
+      task = start(signalScope.signal);
+    } catch (error) {
+      signalScope.dispose();
+      throw error;
+    }
     generation.inFlight.add(task);
     void task.finally(() => {
       generation.inFlight.delete(task);
+      signalScope.dispose();
     }).catch(() => undefined);
     return task;
   }

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -223,7 +223,12 @@ export class SparqlHttpStore implements TripleStore {
     return this.writeGen.getWriteGen(graphPrefix);
   }
 
-  private async postQuery(sparql: string, accept: string, options?: SparqlHttpQueryOptions): Promise<Response> {
+  private async postQuery<T>(
+    sparql: string,
+    accept: string,
+    options: SparqlHttpQueryOptions | undefined,
+    consume: (response: Response) => Promise<T>,
+  ): Promise<T> {
     // Direct POST (W3C SPARQL 1.1 Protocol §2.1.3): the query is the raw
     // request body with `application/sparql-query`, not URL-encoded form
     // data. Form-encoded bodies (`query=...`) are parsed by the server's
@@ -236,14 +241,19 @@ export class SparqlHttpStore implements TripleStore {
     // mojibake-ing any non-ASCII character in the query. UTF-8 is what the
     // SPARQL protocol prescribes.
     const timeoutSignal = AbortSignal.timeout(this.timeout);
-    const signal = composeAbortSignals(options?.signal, timeoutSignal) ?? timeoutSignal;
+    const signalScope = composeAbortSignals(options?.signal, timeoutSignal);
+    const signal = signalScope.signal ?? timeoutSignal;
     try {
-      return await fetch(this.queryEndpoint, {
+      const response = await fetch(this.queryEndpoint, {
         method: 'POST',
         headers: { ...this.headers, 'Content-Type': SPARQL_QUERY_CONTENT_TYPE, Accept: accept },
         body: sparql,
         signal,
       });
+      // Keep the composed caller/deadline signal linked until the response body
+      // has settled. A fetch promise may resolve as soon as headers arrive,
+      // while JSON/N-Quads parsing is still holding the scheduler admission.
+      return await consume(response);
     } catch (error) {
       if (signal.aborted) {
         getMetrics().storeCancellationCompletedTotal.add(1, {
@@ -252,6 +262,8 @@ export class SparqlHttpStore implements TripleStore {
         });
       }
       throw error;
+    } finally {
+      signalScope.dispose();
     }
   }
 
@@ -265,7 +277,8 @@ export class SparqlHttpStore implements TripleStore {
     // data. See postQuery for why form encoding breaks large payloads.
     return this.runStoreWork(operation, options, async (lifecycleSignal) => {
       const timeoutSignal = AbortSignal.timeout(this.timeout);
-      const signal = composeAbortSignals(lifecycleSignal, timeoutSignal) ?? timeoutSignal;
+      const signalScope = composeAbortSignals(lifecycleSignal, timeoutSignal);
+      const signal = signalScope.signal ?? timeoutSignal;
       // charset=utf-8: same ISO-8859-1 default-decode hazard as postQuery —
       // without it a Jetty-backed store corrupts non-ASCII INSERT DATA
       // literals and DELETE DATA patterns silently stop matching.
@@ -290,6 +303,8 @@ export class SparqlHttpStore implements TripleStore {
           });
         }
         throw error;
+      } finally {
+        signalScope.dispose();
       }
     });
   }
@@ -531,43 +546,46 @@ export class SparqlHttpStore implements TripleStore {
       const upper = trimmed.toUpperCase();
       const isAsk = upper.startsWith('ASK');
       const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
-      const operation = inferQueryOperation(trimmed);
 
       try {
         if (isConstruct) {
           return await this.queryConstruct(trimmed, effectiveOptions);
         }
 
-        const res = await this.postQuery(
+        return await this.postQuery(
           trimmed,
           'application/sparql-results+json',
           effectiveOptions,
+          async (res) => {
+            if (!res.ok) {
+              const text = await (effectiveOptions.maxResponseBytes === undefined
+                ? res.text()
+                : readResponseTextBounded(res, effectiveOptions.maxResponseBytes)
+              ).catch(() => '');
+              throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
+            }
+
+            const json = effectiveOptions.maxResponseBytes === undefined
+              ? await res.json() as AdapterSparqlJsonSelectResponse | W3CAskResponse
+              : JSON.parse(
+                  await readResponseTextBounded(res, effectiveOptions.maxResponseBytes),
+                ) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
+
+            if (isAsk || 'boolean' in json) {
+              return {
+                type: 'boolean',
+                value: (json as W3CAskResponse).boolean,
+              } satisfies AskResult;
+            }
+
+            const bindings = formatSparqlJsonBindings(json as AdapterSparqlJsonSelectResponse);
+            return { type: 'bindings', bindings } satisfies SelectResult;
+          },
         );
-        if (!res.ok) {
-          const text = await (effectiveOptions.maxResponseBytes === undefined
-            ? res.text()
-            : readResponseTextBounded(res, effectiveOptions.maxResponseBytes)
-          ).catch(() => '');
-          throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
-        }
-
-        const json = effectiveOptions.maxResponseBytes === undefined
-          ? await res.json() as AdapterSparqlJsonSelectResponse | W3CAskResponse
-          : JSON.parse(
-              await readResponseTextBounded(res, effectiveOptions.maxResponseBytes),
-            ) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
-
-        if (isAsk || 'boolean' in json) {
-          return { type: 'boolean', value: (json as W3CAskResponse).boolean } satisfies AskResult;
-        }
-
-        const bindings = formatSparqlJsonBindings(json as AdapterSparqlJsonSelectResponse);
-        return { type: 'bindings', bindings } satisfies SelectResult;
       } finally {
         this.maybeEmitSlowQuery({
           sparql: trimmed,
           source: options?.source,
-          operation,
           startedAt,
         });
       }
@@ -575,19 +593,25 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   private async queryConstruct(sparql: string, options?: SparqlHttpQueryOptions): Promise<ConstructResult> {
-    const res = await this.postQuery(sparql, 'application/n-quads, text/n-quads', options);
-    if (!res.ok) {
-      const text = await (options?.maxResponseBytes === undefined
-        ? res.text()
-        : readResponseTextBounded(res, options.maxResponseBytes)
-      ).catch(() => '');
-      throw new Error(`SPARQL HTTP construct failed (${res.status}): ${text.slice(0, 300)}`);
-    }
-    const text = options?.maxResponseBytes === undefined
-      ? await res.text()
-      : await readResponseTextBounded(res, options.maxResponseBytes);
-    const quads = parseNQuadsText(text);
-    return { type: 'quads', quads };
+    return this.postQuery(
+      sparql,
+      'application/n-quads, text/n-quads',
+      options,
+      async (res) => {
+        if (!res.ok) {
+          const text = await (options?.maxResponseBytes === undefined
+            ? res.text()
+            : readResponseTextBounded(res, options.maxResponseBytes)
+          ).catch(() => '');
+          throw new Error(`SPARQL HTTP construct failed (${res.status}): ${text.slice(0, 300)}`);
+        }
+        const text = options?.maxResponseBytes === undefined
+          ? await res.text()
+          : await readResponseTextBounded(res, options.maxResponseBytes);
+        const quads = parseNQuadsText(text);
+        return { type: 'quads', quads };
+      },
+    );
   }
 
   async hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean> {
@@ -691,7 +715,6 @@ export class SparqlHttpStore implements TripleStore {
   private maybeEmitSlowQuery(input: {
     sparql: string;
     source?: string;
-    operation: SparqlHttpSlowQueryEvent['operation'];
     startedAt: number;
   }): void {
     if (this.slowQueryThresholdMs <= 0 || this.slowQuerySampleRate <= 0) return;
@@ -701,7 +724,9 @@ export class SparqlHttpStore implements TripleStore {
 
     const event: SparqlHttpSlowQueryEvent = {
       source: normalizeQuerySource(input.source),
-      operation: input.operation,
+      // Classification scans the complete query. Keep it behind the same
+      // threshold/sample gates as hashing so normal reads pay no telemetry cost.
+      operation: inferQueryOperation(input.sparql),
       elapsedMs,
       thresholdMs: this.slowQueryThresholdMs,
       endpoint: sanitizeEndpointForTelemetry(this.queryEndpoint),

--- a/packages/storage/test/abortable-store-work-lifecycle.test.ts
+++ b/packages/storage/test/abortable-store-work-lifecycle.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AbortableStoreWorkLifecycle,
+  composeAbortSignals,
+} from '../src/abortable-store-work-lifecycle.js';
+
+function abortCalls(spy: ReturnType<typeof vi.spyOn>): number {
+  return spy.mock.calls.filter(([type]) => type === 'abort').length;
+}
+
+describe('AbortableStoreWorkLifecycle signal ownership', () => {
+  it('forwards the first abort reason and unlinks both source signals', () => {
+    const caller = new AbortController();
+    const generation = new AbortController();
+    const callerRemove = vi.spyOn(caller.signal, 'removeEventListener');
+    const generationRemove = vi.spyOn(generation.signal, 'removeEventListener');
+    const scope = composeAbortSignals(caller.signal, generation.signal);
+    const reason = new Error('caller disconnected');
+
+    caller.abort(reason);
+
+    expect(scope.signal?.aborted).toBe(true);
+    expect(scope.signal?.reason).toBe(reason);
+    expect(abortCalls(callerRemove)).toBe(1);
+    expect(abortCalls(generationRemove)).toBe(1);
+    scope.dispose();
+    expect(abortCalls(callerRemove)).toBe(1);
+    expect(abortCalls(generationRemove)).toBe(1);
+  });
+
+  it('balances listeners when completed operations dispose against a long-lived signal', () => {
+    const generation = new AbortController();
+    const generationAdd = vi.spyOn(generation.signal, 'addEventListener');
+    const generationRemove = vi.spyOn(generation.signal, 'removeEventListener');
+
+    for (let index = 0; index < 1_000; index++) {
+      const caller = new AbortController();
+      const scope = composeAbortSignals(caller.signal, generation.signal);
+      expect(scope.signal?.aborted).toBe(false);
+      scope.dispose();
+    }
+
+    expect(abortCalls(generationAdd)).toBe(1_000);
+    expect(abortCalls(generationRemove)).toBe(1_000);
+  });
+
+  it('disposes the composed scope when tracked work settles', async () => {
+    const caller = new AbortController();
+    const callerRemove = vi.spyOn(caller.signal, 'removeEventListener');
+    const lifecycle = new AbortableStoreWorkLifecycle();
+
+    await expect(lifecycle.run(caller.signal, async () => 'done')).resolves.toBe('done');
+    await Promise.resolve();
+
+    expect(abortCalls(callerRemove)).toBe(1);
+  });
+});

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -515,6 +515,52 @@ describe('SparqlHttpStore (test server)', () => {
     }
   });
 
+  it('close aborts and drains an in-flight update request', async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      fetchStarted = resolve;
+    });
+    let observedSignal: AbortSignal | undefined;
+    let cancellationSettled = false;
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      observedSignal = init?.signal ?? undefined;
+      fetchStarted();
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          setTimeout(() => {
+            cancellationSettled = true;
+            reject(init.signal?.reason);
+          }, 10);
+        }, { once: true });
+      });
+    }) as typeof fetch;
+
+    try {
+      const store = new SparqlHttpStore({
+        queryEndpoint: 'http://write-close.test/query',
+        updateEndpoint: 'http://write-close.test/update',
+        timeout: 30_000,
+      });
+      const update = store.insert([{
+        subject: 'http://ex.org/s',
+        predicate: 'http://ex.org/p',
+        object: '"value"',
+        graph: 'http://ex.org/g',
+      }]);
+      const updateRejected = expect(update).rejects.toThrow(/SparqlHttpStore closed/);
+      await started;
+
+      await store.close();
+
+      expect(observedSignal?.aborted).toBe(true);
+      expect(cancellationSettled).toBe(true);
+      await updateRejected;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('rejects work admitted during close and reopens only after the drain', async () => {
     const originalFetch = globalThis.fetch;
     let fetchStarted!: () => void;

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -297,29 +297,33 @@ describe('SparqlHttpStore (test server)', () => {
     const seenSignals: AbortSignal[] = [];
     globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
       if (init?.signal instanceof AbortSignal) seenSignals.push(init.signal);
-      const accept = String((init?.headers as Record<string, string> | undefined)?.Accept ?? '');
-      if (accept.includes('n-quads')) {
-        return new Response('', { status: 200 });
-      }
-      return new Response(JSON.stringify({
-        head: { vars: [] },
-        results: { bindings: [] },
-      }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/sparql-results+json' },
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {
+          once: true,
+        });
       });
     }) as typeof fetch;
     try {
       const signalController = new AbortController();
       const signalStore = new SparqlHttpStore({ queryEndpoint: 'http://example.test/query', timeout: 30_000 });
 
-      await signalStore.query('SELECT ?s WHERE { ?s ?p ?o }', { signal: signalController.signal });
-      await signalStore.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }', { signal: signalController.signal });
+      const select = signalStore.query(
+        'SELECT ?s WHERE { ?s ?p ?o }',
+        { signal: signalController.signal },
+      );
+      const construct = signalStore.query(
+        'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }',
+        { signal: signalController.signal },
+      );
+      const selectRejected = expect(select).rejects.toThrow('caller aborted');
+      const constructRejected = expect(construct).rejects.toThrow('caller aborted');
 
+      await waitForCondition(() => seenSignals.length === 2, 'both fetches should start');
       expect(seenSignals).toHaveLength(2);
       expect(seenSignals.every((signal) => !signal.aborted)).toBe(true);
       signalController.abort(new Error('caller aborted'));
       expect(seenSignals.every((signal) => signal.aborted)).toBe(true);
+      await Promise.all([selectRejected, constructRejected]);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Context and scope

Follow-up to the review feedback on merged PR #1991. The original change prevents scoped API reads from starving higher-priority store work; this PR tightens the cancellation, shared-flight, telemetry, route, and UI invariants identified in two review rounds.

Related to [#1989](https://github.com/OriginTrail/dkg/issues/1989) and the SWM symptom evidence in [#1990](https://github.com/OriginTrail/dkg/issues/1990).

This PR **does not claim** that the separate mainnet Blazegraph atomic graph-replace HTTP 500/deadline failures have the same upstream query. The `urn:dkg:internal:atomic-graph-replace:*` names are transactional staging graphs. Recovering the Blazegraph/Jetty exception and correlating JVM, disk, lock, and scheduler telemetry remain separate evidence requirements.

## What this fixes

The proven code-level failure was a cross-workflow store-pressure cascade:

1. an untrusted `/api/query` read could enter the normal store lane;
2. disconnect cancellation and read options were not carried consistently through every planning/execution read;
3. shared graph-discovery flights could accidentally inherit one caller's abort signal;
4. completed signal compositions could retain listeners and object graphs;
5. route and dashboard terminal states did not consistently distinguish cancellation, admission shedding, and execution failure.

The branch keeps API reads in the `background` lane by default, threads cancellation to interruptible stores, preserves shared-flight safety, and makes cancellation a first-class terminal outcome.

## Finding-by-finding resolution

### First review round

| Finding | Why it mattered | Fix | Regression proof |
|---|---|---|---|
| Store-read options were manually threaded through the query engine | Planning or execution helpers could silently lose `signal`, `priority`, or `source` | Build one `QueryStoreReadContext` at query entry and expose bound execution and shared-discovery lanes | Query-engine option propagation tests |
| Cancelled operations lowered dashboard success rates | Client disconnects looked like service failures | Preserve cancelled rows/counts, but compute health as `success / (success + error)` | Node UI DB and tracker tests |
| Scheduler-busy mapping was stringly typed | Message changes could turn a retryable 503 into a 500 | Match the canonical `StoreSchedulerBusyError` class | Real route 503 test |
| Query engine and graph guard duplicated SPARQL scanner logic | Lexer behavior could drift between security and planning paths | Move scanner primitives into shared `sparql-utils.ts` | Query and graph-scope guard suites |
| Cancellation duplicated failure terminal flow | Operation/phase bookkeeping could diverge | Use shared status-parameterized terminal transitions | Operation tracker tests |
| Route handoff was only indirectly covered | Correct lower-layer behavior did not prove `/api/query` passed the values | Exercise `handleQueryRoutes` directly and assert signal, priority, source, disconnect, and 503 behavior | CLI route lifecycle suite |
| Write-side close cancellation was missing | A store could report closed while an update still unwound | Track, abort, and drain both reads and writes through one lifecycle generation | In-flight update close/drain test |

### Second review round

| Finding | Severity | Why it mattered | How it was fixed | Regression proof |
|---|---:|---|---|---|
| A shared `GraphSetIndexStore` refresh could capture the first caller's signal | High | Caller A disconnecting could reject the coalesced upstream refresh used by caller B | Shared discovery retains priority/source but omits caller cancellation upstream; each caller races the shared promise against its own signal locally | Real `GraphSetIndexStore` two-caller test: A aborts, B completes, one upstream scan |
| Slow-query operation classification scanned every query eagerly | High | Normal successful reads paid an O(query bytes) telemetry cost even when no slow event could be emitted | Move full classification behind threshold and sampling gates, alongside hashing | Slow-query tests plus the benchmark below |
| `AbortSignal.any` compositions retained source-signal graphs | High | A long-lived generation signal accumulated completed per-request graph references | Replace `AbortSignal.any` with an explicit disposable scope; dispose on synchronous start failure, task settlement, adapter completion, and abort | Listener-balance soak test, reason-forwarding test, lifecycle-settlement test |
| HTTP signal disposal happened at fetch-header completion | High, found during parity validation | Delayed JSON/N-Quads bodies stopped observing caller aborts, and a retry could wait forever | Keep the composed caller/deadline signal linked through response-body consumption and dispose only after the body settles | Cross-adapter delayed body cancellation/admission parity tests |
| A disconnected `/api/query` response was never ended | Medium | The route cancelled store work but could leave the HTTP response open | Call `res.end()` when the disconnect error reaches the route and the response is not already ended | Route test asserts `writableEnded === true` |
| Real route handoff coverage was requested | Medium | Unit-level option tests alone would not prove production wiring | Retain direct `handleQueryRoutes` coverage for exact option handoff, disconnect cancellation, and typed 503 shedding | CLI route lifecycle suite, 6/6 |
| Cancelled operations were not visually distinct | Low | The UI could render cancellation as warning/failure-like state | Add a dedicated cancelled badge/color and apply it to badges, mini-Gantt, phase timeline, legend, and detail rows | Static rendered badge test plus DB tests |
| Admission shedding was recorded as execution failure | Low | Work that never entered the store polluted failure health | Record `StoreSchedulerBusyError` as `cancelled` before returning retryable 503 | Route test asserts cancel once and fail never |
| `DKG_API_QUERY_PRIORITY` had no boot-time validation or effective-value log | Low | A typo could silently defeat an incident rollback expectation | Resolve once at daemon boot, warn on invalid non-empty values, fail safe to `background`, and log the effective lane | Resolver/configuration logger test |
| The duplicate lexer concern needed explicit closure | Low | It was unclear whether both parsing paths really shared one implementation | Keep the first-round shared scanner refactor; no second scanner was reintroduced | Existing query/guard suites |
| Guard-order regressions around authorized `VALUES` were missing | Low | Early graph injection could bypass later default-graph or nested-`GRAPH` validation | Add tests proving authorized top-level `VALUES` does not bypass either guard | Two new query-engine guard tests |

## Sequence: shared discovery is caller-safe

```mermaid
sequenceDiagram
    autonumber
    participant A as API caller A
    participant B as API caller B
    participant R as Query route
    participant Q as Query engine
    participant I as GraphSetIndexStore
    participant S as Store backend

    A->>R: POST /api/query
    R->>Q: signal A, background, api.query
    Q->>I: listGraphsByPrefix with shared lane
    Note over Q,I: priority and source retained; caller signal omitted
    I->>S: start one refresh

    B->>R: POST /api/query
    R->>Q: signal B, background, api.query
    Q->>I: join the same refresh

    A--xR: client disconnects
    R->>Q: abort signal A
    Q--xR: caller A local race rejects
    R->>R: tracker.cancel and response.end

    S-->>I: graph list
    I-->>Q: shared refresh resolves
    Q-->>R: caller B continues
    R-->>B: 200 response
```

## Sequence: cancellation ownership lasts through body cleanup

```mermaid
sequenceDiagram
    autonumber
    participant R as Route caller signal
    participant L as Store work lifecycle
    participant P as Priority scheduler
    participant H as SPARQL HTTP adapter
    participant B as Response body

    R->>L: run caller work
    L->>L: compose caller plus generation scope
    L->>P: admit tracked task
    P->>H: execute with lifecycle signal
    H->>H: compose lifecycle plus deadline scope
    H-->>B: fetch resolves headers
    Note over H,B: signal scope remains linked

    alt caller disconnects during body decode
        R->>L: abort caller
        L->>H: propagate abort
        H->>B: abort delayed json, text, or N-Quads read
        B--xH: body cleanup rejects
    else body completes normally
        B-->>H: parsed response
    end

    H->>H: dispose HTTP scope
    H-->>P: operation settles
    P-->>L: release admission
    L->>L: dispose lifecycle scope
    Note over P,L: retry can enter only after prior cleanup settles
```

## Sequence: normal reads skip full telemetry parsing

```mermaid
sequenceDiagram
    autonumber
    participant Q as Completed SPARQL query
    participant T as Slow-query telemetry
    participant C as SPARQL classifier
    participant E as Event sink

    Q->>T: sparql, source, start time
    T->>T: threshold enabled?
    alt below threshold or telemetry disabled
        T-->>Q: return without scanning query
    else threshold exceeded
        T->>T: sampling gate
        alt not sampled
            T-->>Q: return without scanning query
        else sampled
            T->>C: classify complete query
            C-->>T: operation form
            T->>T: hash and size query
            T->>E: emit bounded slow-query event
        end
    end
```

## Benchmarks

Environment: Node `v25.2.1`, macOS arm64. These are isolated microbenchmarks for the reviewed hot paths, not end-to-end HTTP latency.

### Slow-query telemetry gate

Nine-run median. The eager column runs the full canonical SPARQL classifier, matching the old placement. The gated column runs the current below-threshold fast path.

| Query bytes | Eager classifier | Gated normal path | Avoided work |
|---:|---:|---:|---:|
| 2,704 | 101.13 us/op | 0.0102 us/op | 99.99% |
| 13,000 | 455.89 us/op | 0.0042 us/op | >99.99% |
| 26,501 | 538.38 us/op | 0.0042 us/op | >99.99% |
| 53,006 | 1,047.20 us/op | 0.0050 us/op | >99.99% |

The important result is asymptotic: ordinary queries no longer scan their full SPARQL text for telemetry. Classification still runs for sampled slow events.

### Abort-signal composition retention

Forced-GC soak over 200,000 completed compositions sharing one long-lived generation signal:

| Implementation | Retained heap | Retained/op | Composition time |
|---|---:|---:|---:|
| `AbortSignal.any` | 351,796,136 B | 1,758.98 B/op | 5,250 ns/op |
| Disposable scope + `dispose()` | 98,600 B | 0.493 B/op | 1,530 ns/op |

On this runtime, explicit disposal reduced retained heap by more than 99.97% and composition time by about 70.9%. Absolute retained bytes vary by Node/V8 version; the invariant enforced by tests is balanced listener ownership after every settled operation.

## End-to-end terminal behavior

| Outcome | Store execution | HTTP result | Tracker status | Health denominator |
|---|---|---|---|---|
| Success | Completed | 200 | `success` | Included |
| Query/input failure | Started and failed | 4xx/5xx as applicable | `error` | Included |
| Scheduler shedding | Never admitted | 503 + `Retry-After: 1` | `cancelled` | Excluded |
| Caller disconnect | Queued/in-flight work aborted and drained | Socket ended | `cancelled` | Excluded |

## Validation

- `@origintrail-official/dkg-storage`
  - build
  - full package: **471 passed**, **26 skipped**
  - focused cancellation parity: **44/44**
- `@origintrail-official/dkg-query`
  - build
  - full package: **330/330**
  - query engine: **121/121**
- `@origintrail-official/dkg-node-ui`
  - build
  - operations status + DB: **104/104**
- `@origintrail-official/dkg` CLI
  - build
  - route lifecycle: **6/6**
- `git diff --check`

## Base proof

Current head: `be2e59b1366d9985f77639279b413d7a4416203f`.

At the time of this update:

- live `main`: `b676567723d038649690681375a0fbf1142915db`
- live `testnet-canary`: `736d6c28e3508998d60cf175ebab4eb890f3a7fe`
- both are ancestors of this PR head

## Review focus

1. Shared-flight cancellation ownership: caller aborts must never poison a coalesced upstream graph refresh.
2. Signal-scope lifetime: disposal must happen after response-body cleanup, not after headers.
3. Terminal classification: scheduler shedding and disconnects remain observable without being counted as execution failures.
4. Scope boundary: this removes a proven source of store pressure but leaves the mainnet Blazegraph atomic-replace root cause explicitly unproven.
