### PR TITLE
fix(agent): autonomously retry durable finalization inbox

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1664,6 +1664,7 @@ export class DKGAgentBase {
 
   /** Drain and checkpoint the inbox before releasing the broader persistence lifetime. */
   protected async closeFinalizationRecoveryStore(): Promise<void> {
+    await this.finalizationHandler?.stopRecoveryWorker();
     const store = this.finalizationRuntime.detachRecoveryStore();
     await store?.close();
   }

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1694,7 +1694,9 @@ export class DKGAgentBase {
         && canonicalReceiptCapability === 'supported',
       canonicalReceiptCapability,
       ...(
-        canonicalReceiptCapability === 'unsupported' && health.available
+        canonicalReceiptCapability === 'unsupported'
+          && health.available
+          && health.degradedReason === undefined
           ? {
               degradedReason: 'canonical-finalization-receipt-unsupported',
             }

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1680,6 +1680,7 @@ export class DKGAgentBase {
         degradedReason: 'not-configured',
         stateCounts: {},
         livePayloadBytes: 0,
+        dueEntries: 0,
       };
     }
     const health = await store.health();

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3273,6 +3273,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }, MESSAGE_OUTBOX_TICK_MS);
     if (this.messengerOutboxTimer.unref) this.messengerOutboxTimer.unref();
 
+    // The durable finalization inbox is an executable retry queue, not only a
+    // write-ahead journal. Its lifecycle is independent of chain-cursor
+    // progress so entries received after a watermark advance are still
+    // reconsidered. The worker batches SQLite reads but serializes graph work.
+    if (this.finalizationRuntime.getRecoveryStore()) {
+      this.getOrCreateFinalizationHandler().startRecoveryWorker();
+    }
+
     // Wire V10 Random Sampling prover. Edge nodes no-op. Core nodes with
     // transient identity/RPC startup failures retry in the background so
     // one flaky `getIdentityId()` call does not disable proving until the

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1754,6 +1754,10 @@ export class DKGAgent extends DKGAgentBase {
         );
       }
     }
+    // Stop admission and await the active finalization recovery batch while
+    // chain and graph-store dependencies are still alive. No new retry may
+    // begin after this boundary.
+    await this.finalizationHandler?.stopRecoveryWorker();
     // OT-RFC-64 Gate 1: unregister the public catalog protocols and drain the
     // receiver scheduler (awaiting in-flight durable stage writes) while the
     // router, node, and control-object store are all still live — before

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -79,6 +79,9 @@ import {
   type FinalizationRecoveryPreparedMaterialization,
   type FinalizationRecoveryReplayOutcome,
 } from './finalization-recovery.js';
+import {
+  FinalizationRecoveryWorker,
+} from './finalization-recovery-worker.js';
 import type {
   FinalizationRecoveryEntry,
   FinalizationRecoveryStore,
@@ -381,6 +384,7 @@ export class FinalizationHandler {
   private readonly negativeSnapshotMemo = new Map<string, NegativeSnapshotMemoEntry>();
   /** Equivalent finalization/reconcile reads share one promise until it settles. */
   private readonly scanSingleFlights = new Map<string, Promise<unknown>>();
+  private readonly recoveryWorker: FinalizationRecoveryWorker;
 
   constructor(
     store: TripleStore,
@@ -448,6 +452,21 @@ export class FinalizationHandler {
       },
       materializer,
     );
+    this.recoveryWorker = new FinalizationRecoveryWorker(
+      (limit) => this.recovery.processDueBatch(limit),
+      {
+        info: (message) => this.log.info(createOperationContext('system'), message),
+        warn: (message) => this.log.warn(createOperationContext('system'), message),
+      },
+    );
+  }
+
+  startRecoveryWorker(): void {
+    this.recoveryWorker.start();
+  }
+
+  stopRecoveryWorker(): Promise<void> {
+    return this.recoveryWorker.stop();
   }
 
   async handleFinalizationMessage(

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -422,6 +422,32 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     return entry.nextAttemptAt === undefined || entry.nextAttemptAt <= this.#policy.now();
   }
 
+  async listDue(limit: number): Promise<FinalizationRecoveryEntry[]> {
+    if (this.#closed || this.#closing) return [];
+    if (!Number.isFinite(limit)) return [];
+    const boundedLimit = Math.min(
+      this.#policy.maxEntries,
+      Math.max(0, Math.trunc(limit)),
+    );
+    if (boundedLimit === 0) return [];
+    await this.#mutationTail;
+    if (this.#closed) return [];
+    const now = this.#policy.now();
+    return this.database.prepare(`
+      SELECT * FROM finalization_inbox_v1
+      WHERE (
+          state IN ('RECEIVED','VERIFIED','REORGED')
+          OR (
+            state = 'SETTLED'
+            AND (publisher_upgrade_pending = 1 OR next_attempt_at IS NOT NULL)
+          )
+        )
+        AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+      ORDER BY COALESCE(next_attempt_at, updated_at), updated_at, key
+      LIMIT ?
+    `).all(now, boundedLimit).map(finalizationRecoveryRowToEntry);
+  }
+
   async listForKnowledgeAsset(input: {
     chainId: string;
     contextGraphId: string;

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -34,6 +34,17 @@ export type {
   SqliteFinalizationRecoveryStoreOptions,
 } from './finalization-recovery-sqlite-policy.js';
 
+const DUE_FINALIZATION_SQL_PREDICATE = `
+  (
+    state IN ('RECEIVED','VERIFIED','REORGED')
+    OR (
+      state = 'SETTLED'
+      AND (publisher_upgrade_pending = 1 OR next_attempt_at IS NOT NULL)
+    )
+  )
+  AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+`;
+
 function sameFinalizationRecoveryIdentity(
   existing: FinalizationRecoveryEntry,
   input: FinalizationRecoveryReceiveInput,
@@ -78,6 +89,16 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
 
   get closed(): boolean {
     return this.#closed;
+  }
+
+  async get(key: string): Promise<FinalizationRecoveryEntry | undefined> {
+    if (this.#closed || this.#closing) return undefined;
+    await this.#mutationTail;
+    if (this.#closed) return undefined;
+    const row = this.database.prepare(
+      'SELECT * FROM finalization_inbox_v1 WHERE key = ?',
+    ).get(key);
+    return row ? finalizationRecoveryRowToEntry(row) : undefined;
   }
 
   receive(input: FinalizationRecoveryReceiveInput): Promise<FinalizationRecoveryReceiveResult> {
@@ -435,14 +456,7 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     const now = this.#policy.now();
     return this.database.prepare(`
       SELECT * FROM finalization_inbox_v1
-      WHERE (
-          state IN ('RECEIVED','VERIFIED','REORGED')
-          OR (
-            state = 'SETTLED'
-            AND (publisher_upgrade_pending = 1 OR next_attempt_at IS NOT NULL)
-          )
-        )
-        AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+      WHERE ${DUE_FINALIZATION_SQL_PREDICATE}
       ORDER BY COALESCE(next_attempt_at, updated_at), updated_at, key
       LIMIT ?
     `).all(now, boundedLimit).map(finalizationRecoveryRowToEntry);
@@ -523,17 +537,24 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     return this.mutate(() => {
       if (this.#closed) return;
       const now = this.#policy.now();
+      const nextAttemptAt = retryDelayMs === undefined ? null : now + retryDelayMs;
       this.database.prepare(`
         UPDATE finalization_inbox_v1
         SET attempt_count = attempt_count + 1,
             last_error = ?,
-            next_attempt_at = ?,
+            next_attempt_at = CASE
+              WHEN ? IS NULL THEN next_attempt_at
+              WHEN next_attempt_at IS NULL THEN ?
+              ELSE MAX(next_attempt_at, ?)
+            END,
             updated_at = ?
         WHERE key = ? AND generation = ?
           AND state IN ('RECEIVED','VERIFIED','REORGED','SETTLED')
       `).run(
         lastError ?? null,
-        retryDelayMs === undefined ? null : now + retryDelayMs,
+        nextAttemptAt,
+        nextAttemptAt,
+        nextAttemptAt,
         now,
         key,
         generation,
@@ -549,17 +570,31 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
         degradedReason: 'closing',
         stateCounts: {},
         livePayloadBytes: 0,
+        dueEntries: 0,
       };
     }
     await this.#mutationTail;
     if (this.#closed) {
-      return { available: false, closed: true, degradedReason: 'closed', stateCounts: {}, livePayloadBytes: 0 };
+      return {
+        available: false,
+        closed: true,
+        degradedReason: 'closed',
+        stateCounts: {},
+        livePayloadBytes: 0,
+        dueEntries: 0,
+      };
     }
     const counts = this.database.prepare(
       'SELECT state, COUNT(*) AS count FROM finalization_inbox_v1 GROUP BY state',
     ).all();
     const stateCounts: Partial<Record<FinalizationRecoveryState, number>> = {};
     for (const row of counts) stateCounts[String(row.state) as FinalizationRecoveryState] = Number(row.count);
+    const now = this.#policy.now();
+    const due = this.database.prepare(`
+      SELECT COUNT(*) AS count, MIN(created_at) AS oldest
+      FROM finalization_inbox_v1
+      WHERE ${DUE_FINALIZATION_SQL_PREDICATE}
+    `).get(now) as { count: number | bigint; oldest: number | bigint | null };
     const capacity = readFinalizationRecoveryCapacity(this.database, this.#policy);
     return {
       available: true,
@@ -568,9 +603,13 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
       ...(capacity.capacityExhausted ? { degradedReason: 'capacity-exhausted' } : {}),
       stateCounts,
       livePayloadBytes: capacity.livePayloadBytes,
+      dueEntries: Number(due.count),
+      ...(due.oldest === null
+        ? {}
+        : { oldestDueAgeMs: Math.max(0, now - Number(due.oldest)) }),
       ...(capacity.oldest === undefined
         ? {}
-        : { oldestPendingAgeMs: Math.max(0, this.#policy.now() - capacity.oldest) }),
+        : { oldestPendingAgeMs: Math.max(0, now - capacity.oldest) }),
     };
   }
 

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -80,11 +80,15 @@ export interface FinalizationRecoveryHealth {
   degradedReason?: string;
   stateCounts: Partial<Record<FinalizationRecoveryState, number>>;
   livePayloadBytes: number;
+  dueEntries: number;
+  oldestDueAgeMs?: number;
   oldestPendingAgeMs?: number;
 }
 
 export interface FinalizationRecoveryStore {
   readonly closed: boolean;
+  /** Reloads one entry after waiting on an in-process serialization boundary. */
+  get(key: string): Promise<FinalizationRecoveryEntry | undefined>;
   receive(input: FinalizationRecoveryReceiveInput): Promise<FinalizationRecoveryReceiveResult>;
   recordTrustedPublisher(
     key: string,

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -113,6 +113,12 @@ export interface FinalizationRecoveryStore {
   clearSettledRetry(key: string, generation: number): Promise<void>;
   rejectSettled(key: string, generation: number, lastError: string): Promise<boolean>;
   isAttemptDue(entry: FinalizationRecoveryEntry): boolean;
+  /**
+   * Returns a bounded, oldest-first snapshot of entries whose persisted retry
+   * gate is open. Callers must still rely on generation-checked transitions:
+   * live gossip or reconciliation may update an entry after this read.
+   */
+  listDue(limit: number): Promise<FinalizationRecoveryEntry[]>;
   listForKnowledgeAsset(input: {
     chainId: string;
     contextGraphId: string;

--- a/packages/agent/src/finalization-recovery-worker.ts
+++ b/packages/agent/src/finalization-recovery-worker.ts
@@ -1,0 +1,100 @@
+export const FINALIZATION_RECOVERY_WORKER_BATCH_SIZE = 16;
+export const FINALIZATION_RECOVERY_WORKER_POLL_INTERVAL_MS = 5_000;
+
+interface FinalizationRecoveryWorkerLog {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+interface FinalizationRecoveryWorkerOptions {
+  batchSize?: number;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Lifecycle-owned asynchronous retry loop for the durable finalization inbox.
+ *
+ * SQLite reads are batched, while graph materialization remains serial inside
+ * `processDueBatch`. This is an I/O scheduler on the Node.js event loop, not a
+ * worker thread: it never blocks startup and never introduces concurrent
+ * Blazegraph finalization writes.
+ */
+export class FinalizationRecoveryWorker {
+  readonly #batchSize: number;
+  readonly #pollIntervalMs: number;
+  #running = false;
+  #timer: ReturnType<typeof setTimeout> | undefined;
+  #inFlight: Promise<void> | undefined;
+
+  constructor(
+    private readonly processDueBatch: (limit: number) => Promise<number>,
+    private readonly log: FinalizationRecoveryWorkerLog,
+    options: FinalizationRecoveryWorkerOptions = {},
+  ) {
+    this.#batchSize = Math.max(
+      1,
+      Math.trunc(options.batchSize ?? FINALIZATION_RECOVERY_WORKER_BATCH_SIZE),
+    );
+    this.#pollIntervalMs = Math.max(
+      1,
+      Math.trunc(
+        options.pollIntervalMs ?? FINALIZATION_RECOVERY_WORKER_POLL_INTERVAL_MS,
+      ),
+    );
+  }
+
+  get running(): boolean {
+    return this.#running;
+  }
+
+  start(): void {
+    if (this.#running) return;
+    this.#running = true;
+    this.schedule(0);
+  }
+
+  async stop(): Promise<void> {
+    this.#running = false;
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = undefined;
+    }
+    await this.#inFlight?.catch(() => undefined);
+  }
+
+  private schedule(delayMs: number): void {
+    if (!this.#running || this.#timer) return;
+    this.#timer = setTimeout(() => {
+      this.#timer = undefined;
+      if (!this.#running) return;
+      const run = this.runBatch();
+      this.#inFlight = run;
+      void run.finally(() => {
+        if (this.#inFlight === run) this.#inFlight = undefined;
+      });
+    }, delayMs);
+    this.#timer.unref?.();
+  }
+
+  private async runBatch(): Promise<void> {
+    let selected = 0;
+    try {
+      selected = await this.processDueBatch(this.#batchSize);
+      if (selected > 0) {
+        this.log.info(
+          `Finalization recovery worker inspected ${selected} due inbox entr`
+            + `${selected === 1 ? 'y' : 'ies'}`,
+        );
+      }
+    } catch (error) {
+      this.log.warn(
+        `Finalization recovery worker batch failed: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      if (this.#running) {
+        this.schedule(selected >= this.#batchSize ? 0 : this.#pollIntervalMs);
+      }
+    }
+  }
+}

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -157,13 +157,17 @@ const SETTLED_NOT_FOUND_RETRY_LIMIT = 5;
 const DEFERRED_RETRY_BASE_MS = 1_000;
 const DEFERRED_RETRY_MAX_MS = 60_000;
 /**
- * At the maximum retry delay this preserves approximately seven days of
- * autonomous recovery before a poison entry becomes an audited terminal row.
+ * At the maximum retry delay this is approximately seven days of autonomous
+ * worker attempts. The wall-clock window below must also elapse so duplicate
+ * gossip and reconciliation cannot burn the budget early.
  */
 export const FINALIZATION_RECOVERY_LIVE_RETRY_LIMIT = 7 * 24 * 60;
+export const FINALIZATION_RECOVERY_LIVE_RETRY_WINDOW_MS = 7 * 24 * 60 * 60 * 1_000;
 
 export interface FinalizationRecoveryOptions {
   liveRetryLimit?: number;
+  liveRetryWindowMs?: number;
+  now?: () => number;
 }
 
 function deferredRetryDelayMs(attemptCount: number): number {
@@ -200,6 +204,8 @@ export class FinalizationRecovery<
   private readonly store: FinalizationRecoveryStore | undefined;
   private readonly storeSource: FinalizationRecoveryStoreSource | undefined;
   private readonly liveRetryLimit: number;
+  private readonly liveRetryWindowMs: number;
+  private readonly now: () => number;
 
   constructor(
     store: FinalizationRecoveryStore | FinalizationRecoveryStoreSource | undefined,
@@ -219,6 +225,13 @@ export class FinalizationRecovery<
       1,
       Math.trunc(options.liveRetryLimit ?? FINALIZATION_RECOVERY_LIVE_RETRY_LIMIT),
     );
+    this.liveRetryWindowMs = Math.max(
+      1,
+      Math.trunc(
+        options.liveRetryWindowMs ?? FINALIZATION_RECOVERY_LIVE_RETRY_WINDOW_MS,
+      ),
+    );
+    this.now = options.now ?? Date.now;
   }
 
   private getStore(): FinalizationRecoveryStore | undefined {
@@ -338,23 +351,27 @@ export class FinalizationRecovery<
    */
   async processDueBatch(limit: number): Promise<number> {
     const store = this.getStore();
-    if (!store || !this.chain || this.chain.chainId === 'none') return 0;
-    let entries: FinalizationRecoveryEntry[];
+    if (!store) return 0;
     try {
-      entries = await store.listDue(limit);
-    } catch (error) {
-      this.log.warn(
-        `Finalization recovery due-inbox read failed: `
-          + `${error instanceof Error ? error.message : String(error)}`,
-      );
-      return 0;
+      if (!this.chain || this.chain.chainId === 'none') return 0;
+      let entries: FinalizationRecoveryEntry[];
+      try {
+        entries = await store.listDue(limit);
+      } catch (error) {
+        this.log.warn(
+          `Finalization recovery due-inbox read failed: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+        );
+        return 0;
+      }
+      for (const entry of entries) {
+        const outcome = await this.replayDueEntry(entry);
+        getMetrics().finalizationRecoveryAttemptsTotal?.add(1, { outcome });
+      }
+      return entries.length;
+    } finally {
+      await this.recordDueMetrics(store);
     }
-    for (const entry of entries) {
-      const outcome = await this.replayDueEntry(entry);
-      getMetrics().finalizationRecoveryAttemptsTotal?.add(1, { outcome });
-    }
-    await this.recordDueMetrics(store);
-    return entries.length;
   }
 
   private async recordDueMetrics(store: FinalizationRecoveryStore): Promise<void> {
@@ -388,11 +405,14 @@ export class FinalizationRecovery<
     const entry = await store.get(snapshot.key);
     if (!entry) return 'none';
     if (!store.isAttemptDue(entry)) return 'retry-pending';
+    const liveRetryAgeMs = Math.max(0, this.now() - entry.createdAt);
     if (
       this.isLiveEntry(entry)
       && entry.attemptCount >= this.liveRetryLimit
+      && liveRetryAgeMs >= this.liveRetryWindowMs
     ) {
-      const reason = `autonomous retry limit exhausted after ${entry.attemptCount} attempts`;
+      const reason = 'autonomous retry budget exhausted after '
+        + `${entry.attemptCount} attempts over ${liveRetryAgeMs}ms`;
       const rejected = await this.transition(entry, 'REJECTED', reason);
       if (rejected) {
         this.log.warn(

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -6,6 +6,7 @@ import type {
 } from '@origintrail-official/dkg-chain';
 import {
   decodeFinalizationMessage,
+  getMetrics,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
@@ -155,6 +156,15 @@ const SETTLED_RECEIPT_RETRY_MAX_MS = 60_000;
 const SETTLED_NOT_FOUND_RETRY_LIMIT = 5;
 const DEFERRED_RETRY_BASE_MS = 1_000;
 const DEFERRED_RETRY_MAX_MS = 60_000;
+/**
+ * At the maximum retry delay this preserves approximately seven days of
+ * autonomous recovery before a poison entry becomes an audited terminal row.
+ */
+export const FINALIZATION_RECOVERY_LIVE_RETRY_LIMIT = 7 * 24 * 60;
+
+export interface FinalizationRecoveryOptions {
+  liveRetryLimit?: number;
+}
 
 function deferredRetryDelayMs(attemptCount: number): number {
   const exponent = Math.min(30, Math.max(0, attemptCount));
@@ -186,14 +196,17 @@ export class FinalizationRecovery<
     string,
     Promise<FinalizationRecoveryReplayOutcome>
   >();
+  private readonly entryLockTails = new Map<string, Promise<void>>();
   private readonly store: FinalizationRecoveryStore | undefined;
   private readonly storeSource: FinalizationRecoveryStoreSource | undefined;
+  private readonly liveRetryLimit: number;
 
   constructor(
     store: FinalizationRecoveryStore | FinalizationRecoveryStoreSource | undefined,
     private readonly chain: ChainAdapter | undefined,
     private readonly log: FinalizationRecoveryLog,
     private readonly materializer: FinalizationRecoveryMaterializer<Prepared>,
+    options: FinalizationRecoveryOptions = {},
   ) {
     if (store && 'getRecoveryStore' in store) {
       this.storeSource = store;
@@ -202,6 +215,10 @@ export class FinalizationRecovery<
       this.store = store;
       this.storeSource = undefined;
     }
+    this.liveRetryLimit = Math.max(
+      1,
+      Math.trunc(options.liveRetryLimit ?? FINALIZATION_RECOVERY_LIVE_RETRY_LIMIT),
+    );
   }
 
   private getStore(): FinalizationRecoveryStore | undefined {
@@ -261,39 +278,57 @@ export class FinalizationRecovery<
       || this.chain.chainId === 'none'
       || !this.chain.resolveCanonicalFinalizationReceipt
     ) return false;
-    let entry = await this.receive(input);
-    // A configured inbox fails closed: capacity, conflict, corruption, and
-    // write failures leave Oxigraph untouched.
-    if (!entry) return true;
-    if (entry.state === 'SETTLED') {
-      entry = await this.revalidateSettled(input, entry);
+    const key = finalizationRecoveryEntryKey({
+      chainId: this.chain.chainId,
+      contextGraphId: input.contextGraphId,
+      ual: input.candidate.scope.ual,
+      txHash: input.candidate.msg.txHash,
+    });
+    return this.withEntryLock(key, async () => {
+      let entry = await this.receive(input);
+      // A configured inbox fails closed: capacity, conflict, corruption, and
+      // write failures leave Oxigraph untouched.
       if (!entry) return true;
-    }
-
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      try {
-        const outcome = await this.materialize(input, { kind: 'recovery', entry });
-        if (outcome === 'deferred') {
-          await this.recordDeferred(entry, 'finalization processing deferred');
-        } else {
-          await this.settleEntry(entry, outcome);
-        }
-        return true;
-      } catch (error) {
-        if (!this.materializer.isRetryableError(error)) throw error;
-        if (attempt === 0) {
-          await new Promise((resolve) => setTimeout(resolve, 50));
-          continue;
-        }
-        this.log.warn(
-          `Finalization recovery materialization remained busy for ${entry.ual}; `
-            + 'keeping inbox entry',
-        );
-        await this.recordDeferred(entry, 'store scheduler remained busy');
-        return true;
+      if (entry.state === 'SETTLED') {
+        entry = await this.revalidateSettled(input, entry);
+        if (!entry) return true;
       }
-    }
-    return true;
+      // Terminal rows remain audited and inert until retention removes them.
+      // In particular, duplicate gossip must not revive an entry that exhausted
+      // the autonomous retry budget.
+      if (!this.isLiveEntry(entry)) return true;
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          const outcome = await this.materialize(input, { kind: 'recovery', entry });
+          if (outcome === 'deferred') {
+            await this.recordDeferred(
+              entry,
+              'finalization processing deferred',
+            );
+          } else {
+            await this.settleEntry(entry, outcome);
+          }
+          return true;
+        } catch (error) {
+          if (!this.materializer.isRetryableError(error)) throw error;
+          if (attempt === 0) {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            continue;
+          }
+          this.log.warn(
+            `Finalization recovery materialization remained busy for ${entry.ual}; `
+              + 'keeping inbox entry',
+          );
+          await this.recordDeferred(
+            entry,
+            'store scheduler remained busy',
+          );
+          return true;
+        }
+      }
+      return true;
+    });
   }
 
   /**
@@ -315,16 +350,57 @@ export class FinalizationRecovery<
       return 0;
     }
     for (const entry of entries) {
-      await this.replayDueEntry(entry);
+      const outcome = await this.replayDueEntry(entry);
+      getMetrics().finalizationRecoveryAttemptsTotal?.add(1, { outcome });
     }
+    await this.recordDueMetrics(store);
     return entries.length;
   }
 
+  private async recordDueMetrics(store: FinalizationRecoveryStore): Promise<void> {
+    try {
+      const health = await store.health();
+      const metrics = getMetrics();
+      metrics.finalizationRecoveryDueEntries?.record(health.dueEntries);
+      metrics.finalizationRecoveryOldestDueAgeMs?.record(health.oldestDueAgeMs ?? 0);
+    } catch (error) {
+      this.log.warn(
+        `Finalization recovery metrics snapshot failed: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
   async replayDueEntry(
-    entry: FinalizationRecoveryEntry,
+    snapshot: FinalizationRecoveryEntry,
+  ): Promise<FinalizationRecoveryReplayOutcome> {
+    return this.withEntryLock(
+      snapshot.key,
+      () => this.replayDueEntryLocked(snapshot),
+    );
+  }
+
+  private async replayDueEntryLocked(
+    snapshot: FinalizationRecoveryEntry,
   ): Promise<FinalizationRecoveryReplayOutcome> {
     const store = this.getStore();
-    if (!store || !store.isAttemptDue(entry)) return 'retry-pending';
+    if (!store) return 'none';
+    const entry = await store.get(snapshot.key);
+    if (!entry) return 'none';
+    if (!store.isAttemptDue(entry)) return 'retry-pending';
+    if (
+      this.isLiveEntry(entry)
+      && entry.attemptCount >= this.liveRetryLimit
+    ) {
+      const reason = `autonomous retry limit exhausted after ${entry.attemptCount} attempts`;
+      const rejected = await this.transition(entry, 'REJECTED', reason);
+      if (rejected) {
+        this.log.warn(
+          `Finalization recovery rejected exhausted inbox entry for ${entry.ual}: ${reason}`,
+        );
+      }
+      return 'invalidated';
+    }
     if (
       !this.chain
       || this.chain.chainId === 'none'
@@ -355,14 +431,23 @@ export class FinalizationRecovery<
         );
         return 'retry-pending';
       }
-      const outcome = await this.replayMatching({
+      const replayInput: FinalizationRecoveryReplayInput = {
         chainId: entry.chainId,
         contextGraphId: entry.contextGraphId,
         onChainCgId: BigInt(boundContextGraphId).toString(),
         ual: entry.ual,
         merkleRoot: entry.merkleRoot,
         kaId: entry.kaId,
-      }, { persistDeferredBackoff: true });
+      };
+      const matches = await this.matchingEntries(replayInput);
+      const matchingEntry = matches.find((candidate) => candidate.key === entry.key);
+      const outcome = matchingEntry
+        ? await this.replayEntry(
+            matchingEntry,
+            replayInput,
+            deferredRetryDelayMs(matchingEntry.attemptCount),
+          )
+        : 'none';
       if (outcome !== 'none') return outcome;
       await this.recordDeferred(
         entry,
@@ -381,6 +466,33 @@ export class FinalizationRecovery<
         deferredRetryDelayMs(entry.attemptCount),
       );
       return 'retry-pending';
+    }
+  }
+
+  private isLiveEntry(entry: FinalizationRecoveryEntry): boolean {
+    return entry.state === 'RECEIVED'
+      || entry.state === 'VERIFIED'
+      || entry.state === 'REORGED';
+  }
+
+  private async withEntryLock<T>(
+    key: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.entryLockTails.get(key) ?? Promise.resolve();
+    let release: (() => void) | undefined;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.entryLockTails.set(key, current);
+    await previous.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release?.();
+      if (this.entryLockTails.get(key) === current) {
+        this.entryLockTails.delete(key);
+      }
     }
   }
 
@@ -1170,14 +1282,20 @@ export class FinalizationRecovery<
     for (const entry of entries) {
       const replayKey = this.replaySingleFlightKey(entry, input);
       const existing = this.replaySingleFlights.get(replayKey);
-      const replay = existing ?? this.replayEntry(
-        entry,
-        input,
-        replayKey,
-        options.persistDeferredBackoff
-          ? deferredRetryDelayMs(entry.attemptCount)
-          : undefined,
-      );
+      const replay = existing ?? this.withEntryLock(
+        entry.key,
+        () => this.replayEntry(
+          entry,
+          input,
+          options.persistDeferredBackoff
+            ? deferredRetryDelayMs(entry.attemptCount)
+            : undefined,
+        ),
+      ).finally(() => {
+        if (this.replaySingleFlights.get(replayKey) === replay) {
+          this.replaySingleFlights.delete(replayKey);
+        }
+      });
       if (!existing) this.replaySingleFlights.set(replayKey, replay);
       const entryOutcome = await replay;
       if (entryOutcome === 'recovered') outcome = 'recovered';
@@ -1214,6 +1332,7 @@ export class FinalizationRecovery<
         degradedReason: 'not-configured',
         stateCounts: {},
         livePayloadBytes: 0,
+        dueEntries: 0,
       };
     }
     return store.health();
@@ -1460,140 +1579,141 @@ export class FinalizationRecovery<
     return this.settleEntry(reorged, outcome);
   }
 
-  private replayEntry(
-    entry: FinalizationRecoveryEntry,
+  private async replayEntry(
+    snapshot: FinalizationRecoveryEntry,
     input: FinalizationRecoveryReplayInput,
-    replayKey: string,
     deferredRetryDelay?: number,
   ): Promise<FinalizationRecoveryReplayOutcome> {
-    const replay = (async () => {
-      try {
-        if (
-          entry.state !== 'SETTLED'
-          && !this.getStore()?.isAttemptDue(entry)
-        ) return 'none' as const;
-        const candidate = this.decodeEntry(entry);
-        if (!candidate) return 'none' as const;
-        if (entry.state === 'SETTLED') {
-          return this.replaySettled(
-            entry,
-            candidate,
-            input,
-            deferredRetryDelay,
-          );
-        }
-
-        let outcome: FinalizationRecoveryApplyOutcome;
-        if (entry.state === 'VERIFIED' && entry.verifiedEvidence) {
-          const evidence = entry.verifiedEvidence;
-          const evidenceMatchesEnvelope = entry.generation > 0
-            ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
-                evidence,
-                candidate,
-                entry,
-              )
-            : VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
-                evidence,
-                candidate,
-                entry,
-              );
-          if (!evidenceMatchesEnvelope) {
-            this.log.warn(
-              `Finalization recovery evidence does not match its envelope for ${entry.ual}`,
-            );
-            await this.rejectEntry(entry, 'verified evidence does not match immutable envelope');
-            return 'none' as const;
-          }
-          const receiptStatus = await this.verifyPersistedReceipt(
-            candidate,
-            evidence,
-            entry.generation > 0,
-          );
-          if (receiptStatus !== 'confirmed') {
-            if (receiptStatus === 'reorged') {
-              await this.markReorged(
-                entry,
-                'persisted receipt disagrees with canonical chain truth',
-              );
-            } else if (receiptStatus === 'rejected') {
-              await this.rejectEntry(
-                entry,
-                'persisted transaction failed or contains no finalization event',
-              );
-            } else if (receiptStatus === 'unsupported') {
-              await this.markUnsupported(entry);
-            } else {
-              await this.recordDeferred(
-                entry,
-                `persisted receipt is ${receiptStatus}`,
-                deferredRetryDelay,
-              );
-            }
-            this.log.info(
-              `Finalization recovery receipt is ${receiptStatus} for ${entry.ual}`,
-            );
-            return deferredRetryDelay !== undefined
-              && (receiptStatus === 'pending' || receiptStatus === 'not-found')
-              ? 'retry-pending' as const
-              : 'none' as const;
-          }
-          const replayOutcome = await this.materializer.replayVerified({
-            replay: input,
-            entry,
-            candidate,
-            evidence,
-          });
-          outcome = replayOutcome === 'promoted'
-            ? 'applied'
-            : replayOutcome === 'already-confirmed' || replayOutcome === 'stale-target'
-              ? 'already-confirmed'
-              : 'deferred';
-        } else {
-          const recoverySourcePeerId = entry.trustedPublisherPeerId ?? entry.sourcePeerId;
-          outcome = await this.materialize(
-            {
-              rawMessage: entry.rawMessage,
-              contextGraphId: entry.contextGraphId,
-              ...(recoverySourcePeerId ? { sourcePeerId: recoverySourcePeerId } : {}),
-              candidate,
-            },
-            { kind: 'recovery', entry },
-          );
-        }
-
-        if (outcome === 'deferred') {
-          await this.recordDeferred(
-            entry,
-            'replay processing deferred',
-            deferredRetryDelay,
-          );
-          return deferredRetryDelay === undefined
-            ? 'none' as const
-            : 'retry-pending' as const;
-        }
-        const settled = await this.settleEntry(entry, outcome);
-        return settled ? 'recovered' as const : 'none' as const;
-      } catch (error) {
-        if (!this.materializer.isRetryableError(error)) throw error;
-        this.log.info(
-          `Finalization recovery materialization remains busy for ${entry.ual}; `
-            + 'keeping inbox entry',
+    const store = this.getStore();
+    if (!store) return 'none';
+    const entry = await store.get(snapshot.key);
+    if (!entry || (!this.isLiveEntry(entry) && entry.state !== 'SETTLED')) {
+      return 'none';
+    }
+    try {
+      // Only autonomous replay observes its persisted deadline. Chain
+      // reconciliation remains an immediate, authoritative recovery trigger.
+      if (
+        deferredRetryDelay !== undefined
+        && entry.state !== 'SETTLED'
+        && !store.isAttemptDue(entry)
+      ) return 'retry-pending' as const;
+      const candidate = this.decodeEntry(entry);
+      if (!candidate) return 'none' as const;
+      if (entry.state === 'SETTLED') {
+        return this.replaySettled(
+          entry,
+          candidate,
+          input,
+          deferredRetryDelay,
         );
+      }
+
+      let outcome: FinalizationRecoveryApplyOutcome;
+      if (entry.state === 'VERIFIED' && entry.verifiedEvidence) {
+        const evidence = entry.verifiedEvidence;
+        const evidenceMatchesEnvelope = entry.generation > 0
+          ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
+              evidence,
+              candidate,
+              entry,
+            )
+          : VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
+              evidence,
+              candidate,
+              entry,
+            );
+        if (!evidenceMatchesEnvelope) {
+          this.log.warn(
+            `Finalization recovery evidence does not match its envelope for ${entry.ual}`,
+          );
+          await this.rejectEntry(entry, 'verified evidence does not match immutable envelope');
+          return 'none' as const;
+        }
+        const receiptStatus = await this.verifyPersistedReceipt(
+          candidate,
+          evidence,
+          entry.generation > 0,
+        );
+        if (receiptStatus !== 'confirmed') {
+          if (receiptStatus === 'reorged') {
+            await this.markReorged(
+              entry,
+              'persisted receipt disagrees with canonical chain truth',
+            );
+          } else if (receiptStatus === 'rejected') {
+            await this.rejectEntry(
+              entry,
+              'persisted transaction failed or contains no finalization event',
+            );
+          } else if (receiptStatus === 'unsupported') {
+            await this.markUnsupported(entry);
+          } else {
+            await this.recordDeferred(
+              entry,
+              `persisted receipt is ${receiptStatus}`,
+              deferredRetryDelay,
+            );
+          }
+          this.log.info(
+            `Finalization recovery receipt is ${receiptStatus} for ${entry.ual}`,
+          );
+          return deferredRetryDelay !== undefined
+            && (receiptStatus === 'pending' || receiptStatus === 'not-found')
+            ? 'retry-pending' as const
+            : 'none' as const;
+        }
+        const replayOutcome = await this.materializer.replayVerified({
+          replay: input,
+          entry,
+          candidate,
+          evidence,
+        });
+        outcome = replayOutcome === 'promoted'
+          ? 'applied'
+          : replayOutcome === 'already-confirmed' || replayOutcome === 'stale-target'
+            ? 'already-confirmed'
+            : 'deferred';
+      } else {
+        const recoverySourcePeerId = entry.trustedPublisherPeerId ?? entry.sourcePeerId;
+        outcome = await this.materialize(
+          {
+            rawMessage: entry.rawMessage,
+            contextGraphId: entry.contextGraphId,
+            ...(recoverySourcePeerId ? { sourcePeerId: recoverySourcePeerId } : {}),
+            candidate,
+          },
+          { kind: 'recovery', entry },
+        );
+      }
+
+      if (outcome === 'deferred') {
         await this.recordDeferred(
           entry,
-          'replay store scheduler remained busy',
+          'replay processing deferred',
           deferredRetryDelay,
         );
         return deferredRetryDelay === undefined
           ? 'none' as const
           : 'retry-pending' as const;
       }
-    })().finally(() => {
-      if (this.replaySingleFlights.get(replayKey) === replay) {
-        this.replaySingleFlights.delete(replayKey);
-      }
-    });
-    return replay;
+      const settled = await this.settleEntry(entry, outcome);
+      return settled ? 'recovered' as const : 'none' as const;
+    } catch (error) {
+      if (!this.materializer.isRetryableError(error)) throw error;
+      this.log.info(
+        `Finalization recovery materialization remains busy for ${entry.ual}; `
+          + 'keeping inbox entry',
+      );
+      await this.recordDeferred(
+        entry,
+        'replay store scheduler remained busy',
+        deferredRetryDelay,
+      );
+      return deferredRetryDelay === undefined
+        ? 'none' as const
+        : 'retry-pending' as const;
+    }
   }
 
   private decodeEntry(

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -365,7 +365,21 @@ export class FinalizationRecovery<
         return 0;
       }
       for (const entry of entries) {
-        const outcome = await this.replayDueEntry(entry);
+        let outcome: FinalizationRecoveryReplayOutcome;
+        try {
+          outcome = await this.replayDueEntry(entry);
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          this.log.warn(
+            `Finalization recovery due-entry replay failed for ${entry.ual}: ${reason}`,
+          );
+          await this.recordDeferred(
+            entry,
+            `background replay failed: ${reason}`,
+            deferredRetryDelayMs(entry.attemptCount),
+          );
+          outcome = 'retry-pending';
+        }
         getMetrics().finalizationRecoveryAttemptsTotal?.add(1, { outcome });
       }
       return entries.length;

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -153,6 +153,16 @@ interface ResolveCanonicalReceiptOptions {
 const SETTLED_RECEIPT_RETRY_BASE_MS = 1_000;
 const SETTLED_RECEIPT_RETRY_MAX_MS = 60_000;
 const SETTLED_NOT_FOUND_RETRY_LIMIT = 5;
+const DEFERRED_RETRY_BASE_MS = 1_000;
+const DEFERRED_RETRY_MAX_MS = 60_000;
+
+function deferredRetryDelayMs(attemptCount: number): number {
+  const exponent = Math.min(30, Math.max(0, attemptCount));
+  return Math.min(
+    DEFERRED_RETRY_MAX_MS,
+    DEFERRED_RETRY_BASE_MS * (2 ** exponent),
+  );
+}
 
 export function finalizationRecoveryEntryKey(input: {
   chainId: string;
@@ -284,6 +294,94 @@ export class FinalizationRecovery<
       }
     }
     return true;
+  }
+
+  /**
+   * Replays a bounded due snapshot independently of chain-cursor progress.
+   * Entries are processed serially so a recovered backlog cannot recreate the
+   * store pressure that caused it.
+   */
+  async processDueBatch(limit: number): Promise<number> {
+    const store = this.getStore();
+    if (!store || !this.chain || this.chain.chainId === 'none') return 0;
+    let entries: FinalizationRecoveryEntry[];
+    try {
+      entries = await store.listDue(limit);
+    } catch (error) {
+      this.log.warn(
+        `Finalization recovery due-inbox read failed: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+      return 0;
+    }
+    for (const entry of entries) {
+      await this.replayDueEntry(entry);
+    }
+    return entries.length;
+  }
+
+  async replayDueEntry(
+    entry: FinalizationRecoveryEntry,
+  ): Promise<FinalizationRecoveryReplayOutcome> {
+    const store = this.getStore();
+    if (!store || !store.isAttemptDue(entry)) return 'retry-pending';
+    if (
+      !this.chain
+      || this.chain.chainId === 'none'
+      || this.chain.chainId !== entry.chainId
+      || !this.chain.getKAContextGraphId
+    ) {
+      await this.recordDeferred(
+        entry,
+        'background replay lacks the matching chain binding capability',
+        deferredRetryDelayMs(entry.attemptCount),
+      );
+      return 'retry-pending';
+    }
+
+    try {
+      const boundContextGraphId = await this.chain.getKAContextGraphId(
+        BigInt(entry.kaId),
+      );
+      if (
+        boundContextGraphId === null
+        || boundContextGraphId === undefined
+        || BigInt(boundContextGraphId) <= 0n
+      ) {
+        await this.recordDeferred(
+          entry,
+          'background replay chain binding is not available yet',
+          deferredRetryDelayMs(entry.attemptCount),
+        );
+        return 'retry-pending';
+      }
+      const outcome = await this.replayMatching({
+        chainId: entry.chainId,
+        contextGraphId: entry.contextGraphId,
+        onChainCgId: BigInt(boundContextGraphId).toString(),
+        ual: entry.ual,
+        merkleRoot: entry.merkleRoot,
+        kaId: entry.kaId,
+      }, { persistDeferredBackoff: true });
+      if (outcome !== 'none') return outcome;
+      await this.recordDeferred(
+        entry,
+        'background replay found no canonical finalization match',
+        deferredRetryDelayMs(entry.attemptCount),
+      );
+      return 'retry-pending';
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      this.log.warn(
+        `Finalization recovery background replay failed for ${entry.ual}: ${reason}`,
+      );
+      await this.recordDeferred(
+        entry,
+        `background replay failed: ${reason}`,
+        deferredRetryDelayMs(entry.attemptCount),
+      );
+      return 'retry-pending';
+    }
   }
 
   /** Processes the compatibility path when no durable inbox can be used. */
@@ -603,11 +701,20 @@ export class FinalizationRecovery<
     return this.transition(entry, 'SETTLED');
   }
 
-  async recordDeferred(entry: FinalizationRecoveryEntry, reason: string): Promise<void> {
+  async recordDeferred(
+    entry: FinalizationRecoveryEntry,
+    reason: string,
+    retryDelayMs?: number,
+  ): Promise<void> {
     const store = this.getStore();
     if (!store) return;
     try {
-      await store.recordAttempt(entry.key, entry.generation, reason);
+      await store.recordAttempt(
+        entry.key,
+        entry.generation,
+        reason,
+        retryDelayMs,
+      );
     } catch (error) {
       this.log.warn(
         `Finalization recovery attempt update failed for ${entry.ual}: `
@@ -1056,13 +1163,21 @@ export class FinalizationRecovery<
 
   async replayMatching(
     input: FinalizationRecoveryReplayInput,
+    options: { persistDeferredBackoff?: boolean } = {},
   ): Promise<FinalizationRecoveryReplayOutcome> {
     const entries = await this.matchingEntries(input);
     let outcome: FinalizationRecoveryReplayOutcome = 'none';
     for (const entry of entries) {
       const replayKey = this.replaySingleFlightKey(entry, input);
       const existing = this.replaySingleFlights.get(replayKey);
-      const replay = existing ?? this.replayEntry(entry, input, replayKey);
+      const replay = existing ?? this.replayEntry(
+        entry,
+        input,
+        replayKey,
+        options.persistDeferredBackoff
+          ? deferredRetryDelayMs(entry.attemptCount)
+          : undefined,
+      );
       if (!existing) this.replaySingleFlights.set(replayKey, replay);
       const entryOutcome = await replay;
       if (entryOutcome === 'recovered') outcome = 'recovered';
@@ -1126,6 +1241,7 @@ export class FinalizationRecovery<
     entry: FinalizationRecoveryEntry,
     candidate: ParsedGraphScopedFinalization,
     input: FinalizationRecoveryReplayInput,
+    deferredRetryDelay?: number,
   ): Promise<FinalizationRecoveryReplayOutcome> {
     const evidence = entry.verifiedEvidence;
     if (
@@ -1159,12 +1275,17 @@ export class FinalizationRecovery<
           sameCanonicalFinalizationPlacement(canonical.receipt, evidence)
             ? 'trusted publisher access semantics arrived after settlement'
             : 'trusted publisher access semantics and canonical placement changed after settlement',
+          deferredRetryDelay,
         );
         if (!matchesReplayTarget) return 'none';
         return recovered ? 'recovered' : 'retry-pending';
       }
       if (!sameCanonicalFinalizationPlacement(canonical.receipt, evidence)) {
-        const recovered = await this.recoverSettledReorg(entry, candidate);
+        const recovered = await this.recoverSettledReorg(
+          entry,
+          candidate,
+          deferredRetryDelay,
+        );
         if (!matchesReplayTarget) return 'none';
         return recovered ? 'recovered' : 'retry-pending';
       }
@@ -1188,11 +1309,16 @@ export class FinalizationRecovery<
           entry,
           candidate,
           'trusted publisher access semantics and canonical placement changed after settlement',
+          deferredRetryDelay,
         );
         if (!matchesReplayTarget) return 'none';
         return recovered ? 'recovered' : 'retry-pending';
       }
-      const recovered = await this.recoverSettledReorg(entry, candidate);
+      const recovered = await this.recoverSettledReorg(
+        entry,
+        candidate,
+        deferredRetryDelay,
+      );
       if (!matchesReplayTarget) return 'none';
       return recovered ? 'recovered' : 'retry-pending';
     }
@@ -1237,6 +1363,7 @@ export class FinalizationRecovery<
     entry: FinalizationRecoveryEntry,
     candidate: ParsedGraphScopedFinalization,
     reason: string,
+    deferredRetryDelay?: number,
   ): Promise<boolean> {
     const publisherPeerId = entry.trustedPublisherPeerId;
     if (
@@ -1265,7 +1392,11 @@ export class FinalizationRecovery<
       { kind: 'recovery', entry: rearmed },
     );
     if (outcome === 'deferred') {
-      await this.recordDeferred(rearmed, 'settled publisher upgrade recovery deferred');
+      await this.recordDeferred(
+        rearmed,
+        'settled publisher upgrade recovery deferred',
+        deferredRetryDelay,
+      );
       return false;
     }
     return this.settleEntry(rearmed, outcome);
@@ -1295,6 +1426,7 @@ export class FinalizationRecovery<
   private async recoverSettledReorg(
     entry: FinalizationRecoveryEntry,
     candidate: ParsedGraphScopedFinalization,
+    deferredRetryDelay?: number,
   ): Promise<boolean> {
     if (!await this.markReorged(
       entry,
@@ -1318,7 +1450,11 @@ export class FinalizationRecovery<
       { kind: 'recovery', entry: reorged },
     );
     if (outcome === 'deferred') {
-      await this.recordDeferred(reorged, 'settled reorg recovery deferred');
+      await this.recordDeferred(
+        reorged,
+        'settled reorg recovery deferred',
+        deferredRetryDelay,
+      );
       return false;
     }
     return this.settleEntry(reorged, outcome);
@@ -1328,13 +1464,23 @@ export class FinalizationRecovery<
     entry: FinalizationRecoveryEntry,
     input: FinalizationRecoveryReplayInput,
     replayKey: string,
+    deferredRetryDelay?: number,
   ): Promise<FinalizationRecoveryReplayOutcome> {
     const replay = (async () => {
       try {
+        if (
+          entry.state !== 'SETTLED'
+          && !this.getStore()?.isAttemptDue(entry)
+        ) return 'none' as const;
         const candidate = this.decodeEntry(entry);
         if (!candidate) return 'none' as const;
         if (entry.state === 'SETTLED') {
-          return this.replaySettled(entry, candidate, input);
+          return this.replaySettled(
+            entry,
+            candidate,
+            input,
+            deferredRetryDelay,
+          );
         }
 
         let outcome: FinalizationRecoveryApplyOutcome;
@@ -1377,12 +1523,19 @@ export class FinalizationRecovery<
             } else if (receiptStatus === 'unsupported') {
               await this.markUnsupported(entry);
             } else {
-              await this.recordDeferred(entry, `persisted receipt is ${receiptStatus}`);
+              await this.recordDeferred(
+                entry,
+                `persisted receipt is ${receiptStatus}`,
+                deferredRetryDelay,
+              );
             }
             this.log.info(
               `Finalization recovery receipt is ${receiptStatus} for ${entry.ual}`,
             );
-            return 'none' as const;
+            return deferredRetryDelay !== undefined
+              && (receiptStatus === 'pending' || receiptStatus === 'not-found')
+              ? 'retry-pending' as const
+              : 'none' as const;
           }
           const replayOutcome = await this.materializer.replayVerified({
             replay: input,
@@ -1409,8 +1562,14 @@ export class FinalizationRecovery<
         }
 
         if (outcome === 'deferred') {
-          await this.recordDeferred(entry, 'replay processing deferred');
-          return 'none' as const;
+          await this.recordDeferred(
+            entry,
+            'replay processing deferred',
+            deferredRetryDelay,
+          );
+          return deferredRetryDelay === undefined
+            ? 'none' as const
+            : 'retry-pending' as const;
         }
         const settled = await this.settleEntry(entry, outcome);
         return settled ? 'recovered' as const : 'none' as const;
@@ -1420,8 +1579,14 @@ export class FinalizationRecovery<
           `Finalization recovery materialization remains busy for ${entry.ual}; `
             + 'keeping inbox entry',
         );
-        await this.recordDeferred(entry, 'replay store scheduler remained busy');
-        return 'none' as const;
+        await this.recordDeferred(
+          entry,
+          'replay store scheduler remained busy',
+          deferredRetryDelay,
+        );
+        return deferredRetryDelay === undefined
+          ? 'none' as const
+          : 'retry-pending' as const;
       }
     })().finally(() => {
       if (this.replaySingleFlights.get(replayKey) === replay) {

--- a/packages/agent/test/finalization-recovery-sqlite-store.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-store.test.ts
@@ -173,6 +173,47 @@ describe('SQLite finalization recovery store', () => {
     }
   });
 
+  it('never narrows a persisted retry deadline and reports due backlog health', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      let now = 1_000;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        now: () => now,
+      });
+      await store.receive(received());
+      await expect(store.health()).resolves.toMatchObject({
+        dueEntries: 1,
+        oldestDueAgeMs: 0,
+      });
+
+      await store.recordAttempt('entry-1', 0, 'long backoff', 10_000);
+      expect(await store.get('entry-1')).toMatchObject({
+        nextAttemptAt: 11_000,
+      });
+      await expect(store.health()).resolves.toMatchObject({ dueEntries: 0 });
+
+      now = 1_500;
+      await store.recordAttempt('entry-1', 0, 'duplicate without delay');
+      await store.recordAttempt('entry-1', 0, 'shorter backoff', 100);
+      expect(await store.get('entry-1')).toMatchObject({
+        nextAttemptAt: 11_000,
+      });
+
+      await store.recordAttempt('entry-1', 0, 'longer backoff', 20_000);
+      expect(await store.get('entry-1')).toMatchObject({
+        nextAttemptAt: 21_500,
+      });
+      now = 21_500;
+      await expect(store.health()).resolves.toMatchObject({
+        dueEntries: 1,
+        oldestDueAgeMs: 20_500,
+      });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('durably transitions RECEIVED to VERIFIED to SETTLED across reopen', async () => {
     const directory = await temporaryDirectory();
     try {

--- a/packages/agent/test/finalization-recovery-sqlite-store.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-store.test.ts
@@ -120,6 +120,59 @@ setInterval(() => {}, 60_000);
 }
 
 describe('SQLite finalization recovery store', () => {
+  it('lists only due live work in bounded oldest-first batches', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      let now = 1_000;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        now: () => now,
+      });
+      await store.receive(received({ key: 'entry-1' }));
+      await store.receive(received({ key: 'entry-2' }));
+      await store.receive(received({ key: 'entry-3' }));
+      await store.recordAttempt('entry-1', 0, 'busy', 1_000);
+      await store.markVerified('entry-3', 0, evidence());
+      await store.transition('entry-3', 0, 'SETTLED');
+
+      await expect(store.listDue(16)).resolves.toMatchObject([
+        { key: 'entry-2', state: 'RECEIVED' },
+      ]);
+
+      now = 2_000;
+      await expect(store.listDue(16)).resolves.toMatchObject([
+        { key: 'entry-2', state: 'RECEIVED', attemptCount: 0 },
+        { key: 'entry-1', state: 'RECEIVED', attemptCount: 1 },
+      ]);
+      await expect(store.listDue(0)).resolves.toEqual([]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('lists a SETTLED receipt retry only after its persisted deadline', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      let now = 1_000;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        now: () => now,
+      });
+      await store.receive(received());
+      await store.markVerified('entry-1', 0, evidence());
+      await store.transition('entry-1', 0, 'SETTLED');
+      await store.recordAttempt('entry-1', 0, 'receipt pending', 1_000);
+
+      await expect(store.listDue(16)).resolves.toEqual([]);
+      now = 2_000;
+      await expect(store.listDue(16)).resolves.toMatchObject([
+        { key: 'entry-1', state: 'SETTLED', lastError: 'receipt pending' },
+      ]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('durably transitions RECEIVED to VERIFIED to SETTLED across reopen', async () => {
     const directory = await temporaryDirectory();
     try {

--- a/packages/agent/test/finalization-recovery-worker.test.ts
+++ b/packages/agent/test/finalization-recovery-worker.test.ts
@@ -60,4 +60,33 @@ describe('FinalizationRecoveryWorker', () => {
     expect(worker.running).toBe(false);
     expect(processDueBatch).toHaveBeenCalledOnce();
   });
+
+  it('logs a transient batch failure and continues polling', async () => {
+    vi.useFakeTimers();
+    const processDueBatch = vi.fn()
+      .mockRejectedValueOnce(new Error('busy'))
+      .mockResolvedValueOnce(0);
+    const warn = vi.fn();
+    const worker = new FinalizationRecoveryWorker(
+      processDueBatch,
+      { info: () => {}, warn },
+      { pollIntervalMs: 25 },
+    );
+    try {
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(processDueBatch).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        'Finalization recovery worker batch failed: busy',
+      );
+      expect(worker.running).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(processDueBatch).toHaveBeenCalledTimes(2);
+    } finally {
+      await worker.stop();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/agent/test/finalization-recovery-worker.test.ts
+++ b/packages/agent/test/finalization-recovery-worker.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  FINALIZATION_RECOVERY_WORKER_BATCH_SIZE,
+  FinalizationRecoveryWorker,
+} from '../src/finalization-recovery-worker.js';
+
+describe('FinalizationRecoveryWorker', () => {
+  it('continues full batches immediately and uses the configured SQLite batch size', async () => {
+    const processDueBatch = vi.fn()
+      .mockResolvedValueOnce(FINALIZATION_RECOVERY_WORKER_BATCH_SIZE)
+      .mockResolvedValueOnce(0);
+    const worker = new FinalizationRecoveryWorker(
+      processDueBatch,
+      { info: () => {}, warn: () => {} },
+      { pollIntervalMs: 60_000 },
+    );
+    try {
+      worker.start();
+      await vi.waitFor(() => expect(processDueBatch).toHaveBeenCalledTimes(2));
+      expect(processDueBatch).toHaveBeenNthCalledWith(
+        1,
+        FINALIZATION_RECOVERY_WORKER_BATCH_SIZE,
+      );
+      expect(processDueBatch).toHaveBeenNthCalledWith(
+        2,
+        FINALIZATION_RECOVERY_WORKER_BATCH_SIZE,
+      );
+    } finally {
+      await worker.stop();
+    }
+  });
+
+  it('never overlaps batches and waits for the active batch during shutdown', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const processDueBatch = vi.fn(async () => {
+      await gate;
+      return FINALIZATION_RECOVERY_WORKER_BATCH_SIZE;
+    });
+    const worker = new FinalizationRecoveryWorker(
+      processDueBatch,
+      { info: () => {}, warn: () => {} },
+      { pollIntervalMs: 1 },
+    );
+    worker.start();
+    await vi.waitFor(() => expect(processDueBatch).toHaveBeenCalledOnce());
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(processDueBatch).toHaveBeenCalledOnce();
+
+    let stopped = false;
+    const stopping = worker.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    release();
+    await stopping;
+    expect(worker.running).toBe(false);
+    expect(processDueBatch).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -112,6 +112,99 @@ function recoveryMaterializer() {
 }
 
 describe('graph-scoped finalization recovery admission', () => {
+  it('autonomously settles a durable RECEIVED entry without a chain-cursor replay', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-worker-'));
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      let applyCalls = 0;
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain(),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          apply: async () => {
+            applyCalls += 1;
+            return 'applied' as const;
+          },
+        },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+      expect(await store.list()).toMatchObject([{
+        state: 'RECEIVED',
+        attemptCount: 0,
+      }]);
+
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      expect(applyCalls).toBe(1);
+      expect(await store.list()).toMatchObject([{
+        state: 'SETTLED',
+        attemptCount: 0,
+      }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('backs off a busy due entry before the autonomous worker retries it', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-backoff-'));
+    try {
+      let now = 1_000;
+      let busy = true;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        now: () => now,
+      });
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain(),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          apply: async () => {
+            if (busy) {
+              throw new StoreSchedulerBusyError(
+                'queue_wait_timeout',
+                'normal',
+                'finalization-recovery-worker',
+              );
+            }
+            return 'applied' as const;
+          },
+        },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      const [deferred] = await store.list();
+      expect(deferred).toMatchObject({
+        state: 'VERIFIED',
+        attemptCount: 1,
+        lastError: 'replay store scheduler remained busy',
+      });
+      expect(deferred.nextAttemptAt).toBe(2_000);
+      await expect(recovery.processDueBatch(16)).resolves.toBe(0);
+
+      busy = false;
+      now = deferred.nextAttemptAt!;
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('returns a typed parsed envelope for a valid singleton finalization', () => {
     expect(parseGraphScopedFinalization(message(), CONTEXT_GRAPH)).toMatchObject({
       ok: true,

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -3,10 +3,18 @@ import { createHash } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { metrics } from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
 import {
   decodeFinalizationMessage,
   encodeFinalizationMessage,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
+  rebuildMetrics,
   type FinalizationMessageMsg,
 } from '@origintrail-official/dkg-core';
 import {
@@ -205,14 +213,89 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
-  it('refreshes due metrics even when the due-inbox read fails', async () => {
+  it('continues a due batch after one entry throws and backs off the failed row', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-poison-'));
+    try {
+      let now = 1_000;
+      const secondTxHash = `0x${'bc'.repeat(32)}`;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        now: () => now,
+      });
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain({
+          resolveCanonicalFinalizationReceipt: async (txHash) => ({
+            status: 'confirmed',
+            receipt: confirmedReceipt({ txHash }),
+          }),
+        }),
+        { info: () => {}, warn: () => {} },
+        recoveryMaterializer(),
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message({ txHash: secondTxHash })),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage({ txHash: secondTxHash }),
+      });
+      const originalReplayDueEntry = recovery.replayDueEntry.bind(recovery);
+      const replayDueEntry = vi.spyOn(recovery, 'replayDueEntry');
+      replayDueEntry
+        .mockRejectedValueOnce(new Error('poison replay'))
+        .mockImplementation(originalReplayDueEntry);
+
+      await expect(recovery.processDueBatch(16)).resolves.toBe(2);
+      expect(replayDueEntry).toHaveBeenCalledTimes(2);
+      expect(await store.list()).toMatchObject([
+        {
+          state: 'RECEIVED',
+          attemptCount: 1,
+          lastError: 'background replay failed: poison replay',
+          nextAttemptAt: 2_000,
+        },
+        {
+          state: 'SETTLED',
+          txHash: secondTxHash,
+        },
+      ]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('emits due metrics even when the due-inbox read fails', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-metrics-'));
+    const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+    const meterProvider = new MeterProvider({
+      readers: [
+        new PeriodicExportingMetricReader({
+          exporter,
+          exportIntervalMillis: 60_000,
+        }),
+      ],
+    });
+    metrics.setGlobalMeterProvider(meterProvider);
+    rebuildMetrics();
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
-      const health = vi.spyOn(store, 'health');
       vi.spyOn(store, 'listDue').mockRejectedValueOnce(
         new Error('sqlite due read unavailable'),
       );
+      vi.spyOn(store, 'health').mockResolvedValueOnce({
+        available: true,
+        closed: false,
+        stateCounts: { RECEIVED: 7 },
+        livePayloadBytes: 123,
+        dueEntries: 7,
+        oldestDueAgeMs: 4_321,
+      });
       const recovery = new FinalizationRecovery(
         store,
         recoveryChain(),
@@ -221,9 +304,25 @@ describe('graph-scoped finalization recovery admission', () => {
       );
 
       await expect(recovery.processDueBatch(16)).resolves.toBe(0);
-      expect(health).toHaveBeenCalledTimes(1);
+      await meterProvider.forceFlush();
+      const datapoints = new Map<string, number>();
+      for (const resourceMetrics of exporter.getMetrics()) {
+        for (const scopeMetrics of resourceMetrics.scopeMetrics) {
+          for (const metric of scopeMetrics.metrics) {
+            const [point] = metric.dataPoints;
+            if (point && typeof point.value === 'number') {
+              datapoints.set(metric.descriptor.name, point.value);
+            }
+          }
+        }
+      }
+      expect(datapoints.get('dkg.finalization_recovery.due_entries')).toBe(7);
+      expect(datapoints.get('dkg.finalization_recovery.oldest_due_age_ms')).toBe(4_321);
       await store.close();
     } finally {
+      await meterProvider.shutdown().catch(() => {});
+      metrics.disable();
+      rebuildMetrics();
       await rm(directory, { recursive: true, force: true });
     }
   });
@@ -616,6 +715,7 @@ describe('graph-scoped finalization recovery admission', () => {
   it('persists RECEIVED before a store-heavy operation can fail', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recovery-wiring-'));
     let agent: DKGAgent | undefined;
+    let releaseWorkerStop: (() => void) | undefined;
     try {
       agent = await DKGAgent.create({
         name: 'FinalizationRecoveryWiringBot',
@@ -650,8 +750,22 @@ describe('graph-scoped finalization recovery admission', () => {
         available: true,
         stateCounts: { RECEIVED: 1 },
       });
-      await agent.stop();
-      expect(stopWorker).toHaveBeenCalled();
+      const workerStopGate = new Promise<void>((resolve) => {
+        releaseWorkerStop = resolve;
+      });
+      stopWorker.mockImplementationOnce(() => workerStopGate);
+      const nextTeardown = vi.spyOn(
+        agent as unknown as {
+          closeRfc64PublicCatalogBootstrapV1(): Promise<void>;
+        },
+        'closeRfc64PublicCatalogBootstrapV1',
+      );
+      const stopping = agent.stop();
+      await vi.waitFor(() => expect(stopWorker).toHaveBeenCalledTimes(1));
+      expect(nextTeardown).not.toHaveBeenCalled();
+      releaseWorkerStop();
+      await stopping;
+      expect(nextTeardown).toHaveBeenCalled();
       expect(agent.getOrCreateFinalizationHandler()).toBe(preStartHandler);
       expect(await agent.getFinalizationRecoveryHealth()).toMatchObject({
         available: false,
@@ -659,6 +773,7 @@ describe('graph-scoped finalization recovery admission', () => {
         degradedReason: 'not-configured',
       });
     } finally {
+      releaseWorkerStop?.();
       await agent?.stop().catch(() => {});
       await agent?.store.close().catch(() => {});
       await rm(directory, { recursive: true, force: true });

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -327,6 +327,77 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
+  it('autonomously applies a pending SETTLED publisher upgrade after restart', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-settled-upgrade-'));
+    let store: Awaited<ReturnType<typeof openSqliteFinalizationRecoveryStore>> | undefined;
+    try {
+      const chain = recoveryChain();
+      store = await openSqliteFinalizationRecoveryStore(directory);
+      const initialRecovery = new FinalizationRecovery(
+        store,
+        chain,
+        { info: () => {}, warn: () => {} },
+        recoveryMaterializer(),
+      );
+      await initialRecovery.processLive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWRelay',
+        candidate: parsedMessage(),
+      });
+      const [settled] = await store.list();
+      expect(settled).toMatchObject({
+        state: 'SETTLED',
+        generation: 0,
+        publisherUpgradePending: false,
+      });
+      await expect(store.recordSettledPublisherUpgrade(
+        settled!.key,
+        settled!.generation,
+        '12D3KooWPublisher',
+      )).resolves.toMatchObject({ status: 'recorded' });
+      expect(await store.listDue(16)).toMatchObject([{
+        state: 'SETTLED',
+        publisherUpgradePending: true,
+      }]);
+
+      await store.close();
+      store = await openSqliteFinalizationRecoveryStore(directory);
+      let upgradeApplyCalls = 0;
+      const restartedRecovery = new FinalizationRecovery(
+        store,
+        chain,
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          prepare: async () => ({
+            onChainContextGraphId: '42',
+            localTopicOnChainContextGraphId: '42',
+            publisherPeerId: '12D3KooWPublisher',
+            accessPolicy: 'allowList' as const,
+            allowedPeers: ['12D3KooWReader'],
+          }),
+          apply: async () => {
+            upgradeApplyCalls += 1;
+            return 'applied' as const;
+          },
+        },
+      );
+
+      await expect(restartedRecovery.processDueBatch(16)).resolves.toBe(1);
+      expect(upgradeApplyCalls).toBe(1);
+      expect(await store.list()).toMatchObject([{
+        state: 'SETTLED',
+        generation: 1,
+        publisherUpgradePending: false,
+        trustedPublisherPeerId: '12D3KooWPublisher',
+      }]);
+    } finally {
+      await store?.close().catch(() => {});
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('rejects a VERIFIED poison entry only after count and age budgets expire', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-exhausted-'));
     try {

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -205,6 +205,232 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
+  it('rejects an exhausted VERIFIED poison entry and frees live capacity', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-exhausted-'));
+    try {
+      let now = 1_000;
+      let applyCalls = 0;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 1,
+        now: () => now,
+      });
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain(),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          apply: async () => {
+            applyCalls += 1;
+            throw new StoreSchedulerBusyError(
+              'queue_wait_timeout',
+              'normal',
+              'finalization-recovery-worker',
+            );
+          },
+          replayVerified: async () => {
+            throw new StoreSchedulerBusyError(
+              'queue_wait_timeout',
+              'normal',
+              'finalization-recovery-worker',
+            );
+          },
+        },
+        { liveRetryLimit: 2 },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+
+      await recovery.processDueBatch(16);
+      let [entry] = await store.list();
+      expect(entry).toMatchObject({ state: 'VERIFIED', attemptCount: 1 });
+      now = entry!.nextAttemptAt!;
+      await recovery.processDueBatch(16);
+      [entry] = await store.list();
+      expect(entry).toMatchObject({ state: 'VERIFIED', attemptCount: 2 });
+      now = entry!.nextAttemptAt!;
+
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      expect(await store.list()).toMatchObject([{
+        state: 'REJECTED',
+        attemptCount: 2,
+        lastError: 'autonomous retry limit exhausted after 2 attempts',
+      }]);
+      await expect(recovery.processLive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      })).resolves.toBe(true);
+      expect(applyCalls).toBe(1);
+      expect(await store.list()).toMatchObject([{
+        state: 'REJECTED',
+        attemptCount: 2,
+      }]);
+      await expect(store.receive({
+        key: 'replacement',
+        chainId: 'base:84532',
+        contextGraphId: CONTEXT_GRAPH,
+        ual: UAL,
+        txHash: `0x${'ef'.repeat(32)}`,
+        assertionVersion: '1',
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: PACKED_KA_ID.toString(),
+        batchId: PACKED_KA_ID.toString(),
+        rawMessage: encodeFinalizationMessage(message({
+          txHash: `0x${'ef'.repeat(32)}`,
+        })),
+      })).resolves.toMatchObject({ status: 'inserted' });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes live and autonomous materialization for the same inbox key', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-entry-lock-'));
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      let releaseApply: (() => void) | undefined;
+      const applyGate = new Promise<void>((resolve) => {
+        releaseApply = resolve;
+      });
+      let applyCalls = 0;
+      let concurrentApplies = 0;
+      let maximumConcurrentApplies = 0;
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain(),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          apply: async () => {
+            applyCalls += 1;
+            concurrentApplies += 1;
+            maximumConcurrentApplies = Math.max(
+              maximumConcurrentApplies,
+              concurrentApplies,
+            );
+            await applyGate;
+            concurrentApplies -= 1;
+            return 'applied' as const;
+          },
+        },
+      );
+      const input = {
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      };
+      await recovery.receive(input);
+
+      const live = recovery.processLive(input);
+      const worker = recovery.processDueBatch(16);
+      await vi.waitFor(() => expect(applyCalls).toBe(1));
+      releaseApply?.();
+      await Promise.all([live, worker]);
+
+      expect(maximumConcurrentApplies).toBe(1);
+      expect(applyCalls).toBe(1);
+      expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('does not let duplicate live gossip erase a live-entry retry deadline', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-live-backoff-'));
+    try {
+      let now = 1_000;
+      let receiptCalls = 0;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        now: () => now,
+      });
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain({
+          resolveCanonicalFinalizationReceipt: async () => {
+            receiptCalls += 1;
+            return { status: 'pending' };
+          },
+        }),
+        { info: () => {}, warn: () => {} },
+        recoveryMaterializer(),
+      );
+      const input = {
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      };
+
+      await recovery.receive(input);
+      await recovery.processDueBatch(16);
+      const [deferred] = await store.list();
+      expect(deferred).toMatchObject({
+        state: 'RECEIVED',
+        attemptCount: 1,
+        nextAttemptAt: 2_000,
+      });
+      await recovery.processLive(input);
+      expect(receiptCalls).toBe(2);
+      expect(await store.list()).toMatchObject([{
+        attemptCount: 2,
+        nextAttemptAt: 2_000,
+      }]);
+
+      now = 2_000;
+      await recovery.processDueBatch(16);
+      expect(receiptCalls).toBe(3);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('lets chain reconciliation recover an entry before its worker deadline', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-reconcile-deadline-'));
+    try {
+      let now = 1_000;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        now: () => now,
+      });
+      const chain = recoveryChain();
+      const recovery = new FinalizationRecovery(
+        store,
+        chain,
+        { info: () => {}, warn: () => {} },
+        recoveryMaterializer(),
+      );
+      const entry = await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+      await store.recordAttempt(entry!.key, entry!.generation, 'worker busy', 60_000);
+
+      await expect(recovery.replayMatching({
+        chainId: chain.chainId,
+        contextGraphId: CONTEXT_GRAPH,
+        onChainCgId: '42',
+        ual: UAL,
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: PACKED_KA_ID.toString(),
+      })).resolves.toBe('recovered');
+      expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('returns a typed parsed envelope for a valid singleton finalization', () => {
     expect(parseGraphScopedFinalization(message(), CONTEXT_GRAPH)).toMatchObject({
       ok: true,
@@ -347,7 +573,10 @@ describe('graph-scoped finalization recovery admission', () => {
         chainAdapter: new MockChainAdapter(),
       });
       const preStartHandler = agent.getOrCreateFinalizationHandler();
+      const startWorker = vi.spyOn(preStartHandler, 'startRecoveryWorker');
+      const stopWorker = vi.spyOn(preStartHandler, 'stopRecoveryWorker');
       await agent.start();
+      expect(startWorker).toHaveBeenCalledTimes(1);
       expect(agent.getOrCreateFinalizationHandler()).toBe(preStartHandler);
       const originalQuery = agent.store.query.bind(agent.store);
       agent.store.query = async () => {
@@ -371,6 +600,7 @@ describe('graph-scoped finalization recovery admission', () => {
         stateCounts: { RECEIVED: 1 },
       });
       await agent.stop();
+      expect(stopWorker).toHaveBeenCalled();
       expect(agent.getOrCreateFinalizationHandler()).toBe(preStartHandler);
       expect(await agent.getFinalizationRecoveryHealth()).toMatchObject({
         available: false,
@@ -738,11 +968,11 @@ describe('graph-scoped finalization recovery admission', () => {
         ...replay,
         merkleRoot: `0x${'ff'.repeat(32)}`,
       });
-      await vi.waitFor(() => expect(replayReceiptCalls).toBe(2));
       releaseReceipts();
 
       await expect(Promise.all([currentRootReplay, newerRootReplay]))
         .resolves.toEqual(['recovered', 'none']);
+      expect(replayReceiptCalls).toBe(2);
     } finally {
       releaseReceipts();
       await store?.close().catch(() => {});

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -281,14 +281,16 @@ describe('graph-scoped finalization recovery admission', () => {
         }),
       ],
     });
-    metrics.setGlobalMeterProvider(meterProvider);
+    let store: Awaited<ReturnType<typeof openSqliteFinalizationRecoveryStore>> | undefined;
+    metrics.disable();
+    expect(metrics.setGlobalMeterProvider(meterProvider)).toBe(true);
     rebuildMetrics();
     try {
-      const store = await openSqliteFinalizationRecoveryStore(directory);
+      store = await openSqliteFinalizationRecoveryStore(directory);
       vi.spyOn(store, 'listDue').mockRejectedValueOnce(
         new Error('sqlite due read unavailable'),
       );
-      vi.spyOn(store, 'health').mockResolvedValueOnce({
+      vi.spyOn(store, 'health').mockResolvedValue({
         available: true,
         closed: false,
         stateCounts: { RECEIVED: 7 },
@@ -296,30 +298,38 @@ describe('graph-scoped finalization recovery admission', () => {
         dueEntries: 7,
         oldestDueAgeMs: 4_321,
       });
+      const warn = vi.fn();
       const recovery = new FinalizationRecovery(
         store,
         recoveryChain(),
-        { info: () => {}, warn: () => {} },
+        { info: () => {}, warn },
         recoveryMaterializer(),
       );
 
       await expect(recovery.processDueBatch(16)).resolves.toBe(0);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('due-inbox read failed'),
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('metrics snapshot failed'),
+      );
       await meterProvider.forceFlush();
       const datapoints = new Map<string, number>();
       for (const resourceMetrics of exporter.getMetrics()) {
         for (const scopeMetrics of resourceMetrics.scopeMetrics) {
           for (const metric of scopeMetrics.metrics) {
-            const [point] = metric.dataPoints;
-            if (point && typeof point.value === 'number') {
-              datapoints.set(metric.descriptor.name, point.value);
+            for (const point of metric.dataPoints) {
+              if (typeof point.value === 'number') {
+                datapoints.set(metric.descriptor.name, point.value);
+              }
             }
           }
         }
       }
       expect(datapoints.get('dkg.finalization_recovery.due_entries')).toBe(7);
       expect(datapoints.get('dkg.finalization_recovery.oldest_due_age_ms')).toBe(4_321);
-      await store.close();
     } finally {
+      await store?.close().catch(() => {});
       await meterProvider.shutdown().catch(() => {});
       metrics.disable();
       rebuildMetrics();

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -205,7 +205,30 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
-  it('rejects an exhausted VERIFIED poison entry and frees live capacity', async () => {
+  it('refreshes due metrics even when the due-inbox read fails', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-metrics-'));
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      const health = vi.spyOn(store, 'health');
+      vi.spyOn(store, 'listDue').mockRejectedValueOnce(
+        new Error('sqlite due read unavailable'),
+      );
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain(),
+        { info: () => {}, warn: () => {} },
+        recoveryMaterializer(),
+      );
+
+      await expect(recovery.processDueBatch(16)).resolves.toBe(0);
+      expect(health).toHaveBeenCalledTimes(1);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a VERIFIED poison entry only after count and age budgets expire', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-exhausted-'));
     try {
       let now = 1_000;
@@ -236,7 +259,11 @@ describe('graph-scoped finalization recovery admission', () => {
             );
           },
         },
-        { liveRetryLimit: 2 },
+        {
+          liveRetryLimit: 2,
+          liveRetryWindowMs: 10_000,
+          now: () => now,
+        },
       );
       await recovery.receive({
         rawMessage: encodeFinalizationMessage(message()),
@@ -255,10 +282,15 @@ describe('graph-scoped finalization recovery admission', () => {
       now = entry!.nextAttemptAt!;
 
       await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      [entry] = await store.list();
+      expect(entry).toMatchObject({ state: 'VERIFIED', attemptCount: 3 });
+
+      now = entry!.createdAt + 10_000;
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
       expect(await store.list()).toMatchObject([{
         state: 'REJECTED',
-        attemptCount: 2,
-        lastError: 'autonomous retry limit exhausted after 2 attempts',
+        attemptCount: 3,
+        lastError: 'autonomous retry budget exhausted after 3 attempts over 10000ms',
       }]);
       await expect(recovery.processLive({
         rawMessage: encodeFinalizationMessage(message()),
@@ -269,7 +301,7 @@ describe('graph-scoped finalization recovery admission', () => {
       expect(applyCalls).toBe(1);
       expect(await store.list()).toMatchObject([{
         state: 'REJECTED',
-        attemptCount: 2,
+        attemptCount: 3,
       }]);
       await expect(store.receive({
         key: 'replacement',
@@ -300,8 +332,18 @@ describe('graph-scoped finalization recovery admission', () => {
         releaseApply = resolve;
       });
       let applyCalls = 0;
-      let concurrentApplies = 0;
-      let maximumConcurrentApplies = 0;
+      let replayVerifiedCalls = 0;
+      let concurrentMaterializations = 0;
+      let maximumConcurrentMaterializations = 0;
+      const enterMaterializationSection = async (): Promise<void> => {
+        concurrentMaterializations += 1;
+        maximumConcurrentMaterializations = Math.max(
+          maximumConcurrentMaterializations,
+          concurrentMaterializations,
+        );
+        await applyGate;
+        concurrentMaterializations -= 1;
+      };
       const recovery = new FinalizationRecovery(
         store,
         recoveryChain(),
@@ -310,14 +352,13 @@ describe('graph-scoped finalization recovery admission', () => {
           ...recoveryMaterializer(),
           apply: async () => {
             applyCalls += 1;
-            concurrentApplies += 1;
-            maximumConcurrentApplies = Math.max(
-              maximumConcurrentApplies,
-              concurrentApplies,
-            );
-            await applyGate;
-            concurrentApplies -= 1;
+            await enterMaterializationSection();
             return 'applied' as const;
+          },
+          replayVerified: async () => {
+            replayVerifiedCalls += 1;
+            await enterMaterializationSection();
+            return 'promoted' as const;
           },
         },
       );
@@ -335,8 +376,9 @@ describe('graph-scoped finalization recovery admission', () => {
       releaseApply?.();
       await Promise.all([live, worker]);
 
-      expect(maximumConcurrentApplies).toBe(1);
+      expect(maximumConcurrentMaterializations).toBe(1);
       expect(applyCalls).toBe(1);
+      expect(replayVerifiedCalls).toBe(1);
       expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
       await store.close();
     } finally {
@@ -362,6 +404,11 @@ describe('graph-scoped finalization recovery admission', () => {
         }),
         { info: () => {}, warn: () => {} },
         recoveryMaterializer(),
+        {
+          liveRetryLimit: 1,
+          liveRetryWindowMs: 10_000,
+          now: () => now,
+        },
       );
       const input = {
         rawMessage: encodeFinalizationMessage(message()),
@@ -388,6 +435,10 @@ describe('graph-scoped finalization recovery admission', () => {
       now = 2_000;
       await recovery.processDueBatch(16);
       expect(receiptCalls).toBe(3);
+      expect(await store.list()).toMatchObject([{
+        state: 'RECEIVED',
+        attemptCount: 3,
+      }]);
       await store.close();
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1209,6 +1209,83 @@ describe('graph-scoped finalization handler', () => {
     }
   });
 
+  it('autonomously drains a persisted busy finalization after restart', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-worker-restart-'));
+    let inbox: SqliteFinalizationRecoveryStore | undefined;
+    let restarted: FinalizationHandler | undefined;
+    const query = store.query.bind(store);
+    try {
+      const { message, vmGraph } = await stageGraph();
+      const chain = {
+        chainId: 'base:84532',
+        getLatestMerkleRoot: async () => message.kcMerkleRoot,
+        getMerkleRootCount: async () => 1n,
+        getKAContextGraphId: async () => 42n,
+        resolveCanonicalFinalizationReceipt: async () => canonicalReceipt(message),
+      } as ChainAdapter;
+      inbox = await openSqliteFinalizationRecoveryStore(directory, {
+        maxPerContextGraph: 1,
+      });
+      const pressured = new FinalizationHandler(
+        store,
+        chain,
+        recoveryOptions(inbox),
+      );
+      let busyReads = 2;
+      store.query = async (sparql, options) => {
+        if (busyReads > 0) {
+          busyReads -= 1;
+          throw new StoreSchedulerBusyError(
+            'queue_wait_timeout',
+            'normal',
+            'autonomous-finalization-recovery.query',
+          );
+        }
+        return query(sparql, options);
+      };
+
+      await pressured.handleFinalizationMessage(
+        encodeFinalizationMessage(message),
+        CG,
+        '12D3KooWPublisher',
+      );
+      expect(await inbox.list()).toMatchObject([{
+        state: 'RECEIVED',
+        attemptCount: 1,
+        lastError: 'store scheduler remained busy',
+      }]);
+      expect(await inbox.health()).toMatchObject({
+        ready: false,
+        degradedReason: 'capacity-exhausted',
+      });
+
+      store.query = query;
+      await inbox.close();
+      inbox = await openSqliteFinalizationRecoveryStore(directory, {
+        maxPerContextGraph: 1,
+      });
+      restarted = new FinalizationHandler(
+        store,
+        chain,
+        recoveryOptions(inbox),
+      );
+      restarted.startRecoveryWorker();
+
+      await vi.waitFor(async () => {
+        expect(await inbox!.list()).toMatchObject([{ state: 'SETTLED' }]);
+      });
+      expect(await store.countQuads(vmGraph)).toBe(2);
+      const health = await inbox.health();
+      expect(health.ready).toBe(true);
+      expect(health).not.toHaveProperty('degradedReason');
+    } finally {
+      store.query = query;
+      await restarted?.stopRecoveryWorker();
+      await closeInbox(inbox);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('does not mutate Oxigraph when the VERIFIED transaction cannot commit', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recovery-'));
     let inbox: SqliteFinalizationRecoveryStore | undefined;
@@ -1233,6 +1310,7 @@ describe('graph-scoped finalization handler', () => {
         clearSettledRetry: inbox.clearSettledRetry.bind(inbox),
         rejectSettled: inbox.rejectSettled.bind(inbox),
         isAttemptDue: inbox.isAttemptDue.bind(inbox),
+        listDue: inbox.listDue.bind(inbox),
         listForKnowledgeAsset: inbox.listForKnowledgeAsset.bind(inbox),
         transition: inbox.transition.bind(inbox),
         recordAttempt: inbox.recordAttempt.bind(inbox),
@@ -1314,6 +1392,7 @@ describe('graph-scoped finalization handler', () => {
         clearSettledRetry: async () => {},
         rejectSettled: async () => false,
         isAttemptDue: () => true,
+        listDue: async () => [],
         listForKnowledgeAsset: async () => [],
         transition: async () => false,
         recordAttempt: async () => {},

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1299,6 +1299,7 @@ describe('graph-scoped finalization handler', () => {
       inbox = await openSqliteFinalizationRecoveryStore(directory);
       const failingVerifiedStore: FinalizationRecoveryStore = {
         get closed() { return inbox!.closed; },
+        get: inbox.get.bind(inbox),
         receive: inbox.receive.bind(inbox),
         recordTrustedPublisher: inbox.recordTrustedPublisher.bind(inbox),
         recordSettledPublisherUpgrade:
@@ -1372,6 +1373,7 @@ describe('graph-scoped finalization handler', () => {
       } as ChainAdapter;
       const rejectedStore: FinalizationRecoveryStore = {
         closed: false,
+        get: async () => undefined,
         receive: async () => {
           if (failureMode === 'write-failure') throw new Error('disk full');
           return { status: 'capacity' };
@@ -1401,6 +1403,7 @@ describe('graph-scoped finalization handler', () => {
           closed: false,
           stateCounts: {},
           livePayloadBytes: 0,
+          dueEntries: 0,
         }),
         close: async () => {},
       };

--- a/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
@@ -263,6 +263,28 @@ describe('DKGAgent RFC-64 inventory lifecycle', () => {
     await expect(agent.closeRfc64PersistenceV1()).resolves.toBeUndefined();
   });
 
+  it('preserves capacity exhaustion when canonical receipt support is unavailable', async () => {
+    const agent = syntheticAgent();
+    agent.chain = { chainId: 'none' };
+    agent.finalizationRuntime.attachRecoveryStore({
+      health: async () => ({
+        available: true,
+        closed: false,
+        ready: false,
+        degradedReason: 'capacity-exhausted',
+        stateCounts: { RECEIVED: 64 },
+        livePayloadBytes: 1,
+        dueEntries: 64,
+      }),
+    } as any);
+
+    await expect(agent.getFinalizationRecoveryHealth()).resolves.toMatchObject({
+      ready: false,
+      canonicalReceiptCapability: 'unsupported',
+      degradedReason: 'capacity-exhausted',
+    });
+  });
+
   it('owns one persistent foundation and purges every stale candidate in bounded yielding batches', async () => {
     const dataDirectory = temporaryDataDirectory();
     await seedStaleCandidateLoads(dataDirectory, 17);

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -99,6 +99,7 @@ export default defineConfig({
       "test/finalization-handler-chain-truth.test.ts",
       "test/finalization-handler-defensive-cg-id.test.ts",
       "test/finalization-recovery.test.ts",
+      "test/finalization-recovery-worker.test.ts",
       "test/finalization-recovery-sqlite-store.test.ts",
       "test/named-ka-publish-recovery.test.ts",
       "test/ka-graph-finalization-handler.test.ts",

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -247,6 +247,7 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
     // Distinct target probes run in parallel, so their server arrival order is
     // intentionally unspecified. The contract is that every target is checked
     // before the eth_call phase begins.
+    expect(server.calls.slice(2)).toHaveLength(2);
     expect(new Set(server.calls.slice(2).map(({ params }) => params[0])))
       .toEqual(new Set([TO, OTHER_TO]));
   });

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -244,8 +244,11 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
       'eth_getCode',
       'eth_getCode',
     ]);
-    expect(server.calls[2]!.params[0]).toBe(TO);
-    expect(server.calls[3]!.params[0]).toBe(OTHER_TO);
+    // Distinct target probes run in parallel, so their server arrival order is
+    // intentionally unspecified. The contract is that every target is checked
+    // before the eth_call phase begins.
+    expect(new Set(server.calls.slice(2).map(({ params }) => params[0])))
+      .toEqual(new Set([TO, OTHER_TO]));
   });
 
   it('rejects an oversized generic return only after a stable fallback sandwich', async () => {

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -696,6 +696,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       degradedReason: reason,
       stateCounts: {},
       livePayloadBytes: 0,
+      dueEntries: 0,
     });
     let finalizationRecovery: Awaited<
       ReturnType<DKGAgent['getFinalizationRecoveryHealth']>

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -189,6 +189,7 @@ describe('/api/status finalization recovery health', () => {
       stateCounts: { RECEIVED: 1 },
       liveEntries: 1,
       livePayloadBytes: 4,
+      dueEntries: 1,
     };
 
     const response = await requestStatusWithAgent({
@@ -215,6 +216,7 @@ describe('/api/status finalization recovery health', () => {
       degradedReason: 'finalization inbox health read failed',
       stateCounts: {},
       livePayloadBytes: 0,
+      dueEntries: 0,
     });
   });
 });

--- a/packages/core/src/telemetry-api.ts
+++ b/packages/core/src/telemetry-api.ts
@@ -195,6 +195,12 @@ export interface DkgMetrics {
   storeCancellationCompletedTotal: Counter;
   /** scope and reason identify the bounded retry loop; attempt is capped */
   storeRetryAttemptsTotal: Counter;
+  /** current durable finalization entries whose retry gate is open */
+  finalizationRecoveryDueEntries: Gauge;
+  /** milliseconds since the oldest currently due finalization was received */
+  finalizationRecoveryOldestDueAgeMs: Gauge;
+  /** outcome={recovered|invalidated|retry-pending|none} */
+  finalizationRecoveryAttemptsTotal: Counter;
   /** process-local sync inflight sample */
   syncGlobalInflight: Histogram;
   /** ms; lane and priority_class are bounded sync scheduler enums */
@@ -328,6 +334,21 @@ function buildMetrics(): DkgMetrics {
     storeRetryAttemptsTotal: meter.createCounter('dkg.store.retry_attempts_total', {
       description: 'Bounded expensive-work retry attempts',
     }),
+    finalizationRecoveryDueEntries: meter.createGauge(
+      'dkg.finalization_recovery.due_entries',
+      { description: 'Durable finalization inbox entries currently eligible for retry' },
+    ),
+    finalizationRecoveryOldestDueAgeMs: meter.createGauge(
+      'dkg.finalization_recovery.oldest_due_age_ms',
+      {
+        unit: 'ms',
+        description: 'Age of the oldest durable finalization inbox entry eligible for retry',
+      },
+    ),
+    finalizationRecoveryAttemptsTotal: meter.createCounter(
+      'dkg.finalization_recovery.attempts_total',
+      { description: 'Autonomous finalization replay attempts by bounded outcome' },
+    ),
     syncGlobalInflight: meter.createHistogram('dkg.sync.global_inflight', {
       description: 'Sampled process-local sync inflight count',
     }),


### PR DESCRIPTION
## Summary

This PR turns the durable SQLite finalization inbox into an executable retry queue.

It follows the crash-safe admission and guarded replay foundation introduced in [#1939](https://github.com/OriginTrail/dkg/pull/1939). That work persists the raw finalization message as `RECEIVED` before store-heavy processing and requires canonical chain evidence before promotion. The missing piece was autonomous progress: a durable row was reconsidered only if chain reconciliation happened to revisit the same graph, UAL, and KA.

This PR adds a lifecycle-owned asynchronous recovery worker that:

- reads due SQLite rows in bounded batches of 16;
- processes worker rows serially, contributing at most one recovery graph operation at a time;
- reuses the existing #1939 receipt-validation, authority, placement, and generation-CAS path;
- persists exponential retry deadlines for busy or deferred attempts;
- starts independently of chain-cursor progress and drains cleanly during shutdown;
- serializes live gossip, worker replay, and reconciliation replay for the same durable entry;
- bounds poison-row lifetime and exposes due depth, age, and retry outcomes.

The worker is an asynchronous Node.js event-loop task, not an OS worker thread. It does not block startup. The per-entry mutex is intentionally not a global mutex: independent live finalizations remain governed by the existing store scheduler.

## Problem

The inbox already prevented finalization messages from being lost under store pressure, but persistence alone did not guarantee progress:

1. Finalization gossip was durably inserted as `RECEIVED`.
2. Immediate processing encountered store-scheduler pressure or was interrupted before recording an outcome.
3. The row remained live with `next_attempt_at = NULL` or an expired deadline.
4. No autonomous consumer scanned due rows.
5. Replay depended on reconciliation revisiting the exact graph, UAL, and KA.
6. If the reconciliation watermark already covered that ordinal, the sweep could return `current` without revisiting it.
7. Old live rows kept consuming the per-context-graph capacity of 64 and global capacity of 128.
8. New finalizations were rejected as `capacity-exhausted` even after Blazegraph and the normal store queue recovered.

`next_attempt_at` was an eligibility gate, not a schedule.

## Failure sequence before this PR

```mermaid
sequenceDiagram
    participant G as Finalization gossip
    participant H as Finalization handler
    participant I as SQLite inbox
    participant S as Store scheduler
    participant R as Chain reconciler

    G->>H: finalization message
    H->>I: persist RECEIVED
    I-->>H: durable admission succeeds
    H->>S: immediate verification and materialization
    S-->>H: busy, deferred, or interrupted
    opt outcome is recorded
        H->>I: record attempt and optional deadline
    end

    R->>R: watermark already covers ordinal
    R-->>R: return current without exact replay
    Note over I,R: No autonomous due-row consumer
    Note over I: RECEIVED or VERIFIED remains live
    G->>I: later finalizations consume the graph quota
    I-->>G: capacity-exhausted at 64 live graph rows
```

## Base implementation

| Finding | Consequence | Fix |
|---|---|---|
| No bounded global due-work query existed. | A scheduler had no safe way to discover retryable rows. | Add oldest-first `listDue(limit)` using the existing retention bound. |
| Due rows were reconsidered only by another explicit replay path. | Eligible rows could remain untouched forever. | Start a lifecycle-owned worker independent of cursor movement. |
| Concurrent backlog drain could recreate store pressure. | Recovery itself could overload Blazegraph. | Fetch 16 SQLite rows but process the worker snapshot serially. |
| Busy/deferred retries could hot-loop. | Recovery could continuously contend with normal work. | Persist 1s, 2s, 4s, 8s, 16s, 32s, then 60s maximum backoff. |
| Shutdown could race an active timer. | Dependencies could close under recovery. | Stop new batches, cancel the timer, and await the active batch before teardown. |

## Review findings addressed

Commit `5c1d430ea` addresses every actionable finding from the post-implementation review.

| Severity | Finding | Fix | Regression proof |
|---|---|---|---|
| HIGH | Retrying a permanently failing row updated `updated_at` every minute, preventing raw TTL eviction and making the capacity leak immortal. | Autonomous live retries require both the default 10,080-attempt ceiling and a seven-day minimum wall-clock age. Duplicate live gossip or reconciliation may increase the attempt count, but cannot accelerate terminal rejection before the age window. Once both bounds expire, recovery generation-CASes `RECEIVED`, `VERIFIED`, or `REORGED` to audited terminal `REJECTED`, immediately releasing live capacity. Terminal retention still bounds disk use. | A real SQLite test proves the count ceiling alone does not reject, then advances the clock to the age boundary, proves `REJECTED`, proves a replacement is admitted at `maxEntries: 1`, and proves duplicate gossip cannot revive materialization. |
| HIGH | Worker replay and duplicate live gossip could both enter the graph write before either generation CAS settled the row. | A FIFO async mutex keyed by the durable entry key wraps live processing, autonomous replay, and reconciliation replay. Every lane reloads the row after acquiring the lock. | A gated concurrency test starts live and worker paths together and shares one concurrency counter across both `apply` and `replayVerified`; maximum same-key materialization concurrency is 1. |
| MEDIUM | `VERIFIED` had no age-eviction path and could permanently consume capacity. | The bounded live-retry terminalization covers `VERIFIED` as well as `RECEIVED` and `REORGED`; it does not silently delete live evidence by `created_at`. | The poison-row test reaches the ceiling specifically from `VERIFIED`. |
| MEDIUM | Duplicate live gossip could clear a worker deadline and make a backed-off row due immediately. | SQLite attempt recording is monotonic: no delay preserves the deadline, a shorter deadline cannot narrow it, and only a later deadline extends it. | Store tests cover omitted, shorter, and longer delays; integration proves gossip preserves the worker deadline. |
| MEDIUM | Worker lifecycle wiring was not pinned through the real handler. | A lifecycle test attaches the real handler, spies `startRecoveryWorker` and `stopRecoveryWorker`, and drives actual agent `start()` and `stop()`. | Removing either lifecycle call now fails the test. |
| LOW | The worker due gate accidentally delayed authoritative chain reconciliation. | Only autonomous replay observes `next_attempt_at`; reconciliation remains immediate while sharing the entry lock. | A row with a future worker deadline is recovered by reconciliation before the deadline. |
| LOW | Queue depth, oldest due age, and outcomes were invisible. | Health reports `dueEntries` and `oldestDueAgeMs`. OpenTelemetry exports `dkg.finalization_recovery.due_entries`, `dkg.finalization_recovery.oldest_due_age_ms`, and `dkg.finalization_recovery.attempts_total{outcome}`. | Health tests prove due count and age use the same predicate as `listDue`; builds type-check the metric surface. |

## Round 2 review findings addressed

Commits `c98c796a5` and `5f23ae4e1` address the new review findings against `92e0efeca`.

| Severity | Finding | Disposition | Regression proof |
|---|---|---|---|
| HIGH | The 10,080-attempt budget was incremented by live gossip and reconciliation as well as the one-minute worker, so duplicate traffic could consume a nominal seven-day budget immediately and irreversibly reject the row. | Terminal rejection now requires **both** the attempt ceiling and a seven-day wall-clock window measured from durable receipt. This preserves the count safety bound without allowing traffic frequency to shorten evidence lifetime. No schema migration is required. | A duplicate-gossip test crosses the count ceiling before the age window and proves the row remains live. Removing the age predicate makes the test fail because canonical receipt calls stop early. |
| MEDIUM | The same-entry lock test counted only `apply`; if the live lane promoted the row to `VERIFIED`, the worker could enter `replayVerified` concurrently without the test noticing. | The test now uses one shared active/max counter across `apply` and `replayVerified`. | Replacing the awaited lock predecessor with a non-awaited promise makes the test fail with maximum concurrency 2 instead of 1. |
| MEDIUM | Canonical-receipt capability reporting overwrote the more actionable store reason `capacity-exhausted`. | `canonical-finalization-receipt-unsupported` is now a fallback only when the store has no degraded reason. | A lifecycle health test supplies both conditions and proves `capacity-exhausted` wins. |
| LOW | Due gauges could freeze when the chain was unavailable or `listDue` failed because metric refresh occurred only on the success path. | Due-depth and age gauges are refreshed in `finally` whenever a store exists. Metric snapshot failures remain contained and logged. | A real SQLite test forces `listDue` to reject and proves the health snapshot still runs. |
| NIT | A `Set` equality assertion verified distinct chain targets but not the number of calls. | The test now asserts exactly two calls before comparing the target set. | A duplicate target call can no longer satisfy the test. |
| MEDIUM | A transient `processDueBatch` exception was handled in production but the worker reschedule path was not regression-tested. | Added deterministic fake-timer coverage proving the worker logs the failure, remains running, and invokes the next poll without overlap. | The focused worker suite now fails if `catch`/`finally` stops scheduling after one rejection. |
| MEDIUM, reported follow-up | Autonomous replay routes an already-selected due row through the KA-wide reconciliation selector, adding a repeated query/filter and orchestration coupling. | Intentionally not refactored here. A direct-entry canonical snapshot helper changes the central replay decomposition and should be reviewed separately; the current bounded serial worker remains correct. | Follow-up should share the canonical chain checks between exact due replay and cursor replay without routing either orchestration mode through the other. |
| MEDIUM, reported follow-up | Optional `deferredRetryDelay` also acts as an implicit autonomous-vs-reconciliation mode flag. | Intentionally not refactored here. Replacing it with a typed replay-policy union spans live, settled upgrade, reorg, deadline, and outcome behavior and is broader than a minor review correction. | Follow-up should introduce an explicit reconciliation/autonomous policy object with characterization tests before changing signatures. |
| MEDIUM, reported follow-up | `oldestDueAgeMs` is based on `created_at`, so it reports age since receipt rather than age since the last retry/progress. | Intentionally not expanded in this patch. Adding a separate progress-age field is an additive health/telemetry/status/alerting contract change, not a local minor correction. The existing metric keeps its documented receipt-age semantics. | Follow-up should add a separately named metric based on `MIN(updated_at)` rather than silently changing the meaning of the existing series. |

### Retry-budget sequence after Round 2

```mermaid
sequenceDiagram
    participant G as Duplicate live gossip
    participant I as Durable inbox
    participant W as Recovery worker
    participant C as Live capacity

    loop duplicate or reconciliation traffic
        G->>I: serialize by entry key
        G->>I: record outcome and monotonic deadline
        Note over I: attempt count may cross 10,080
    end

    W->>I: reload due row under the same entry lock
    alt attempt ceiling reached but age is under seven days
        I-->>W: keep row live
        W->>I: guarded replay and backoff
    else attempt ceiling and age window both expired
        W->>I: generation-CAS live row to REJECTED
        I-->>C: release live quota
    end
```

### Round 2 validation

- Changed agent tests: **42/42 passed**.
- Strict current/finalized chain transport tests: **30/30 passed**.
- Full chain unit suite: **829 passed; 1 skipped**.
- Agent build: passed TypeScript, type tests, and package-root validation.
- Full agent suite: **1,988 passed; 5 skipped** with the one unrelated loaded-run SIGKILL fixture mismatch described below; isolated rerun passed **3/3**.
- Mutation proof: removing the wall-clock predicate fails the duplicate-gossip test; bypassing the awaited entry lock fails the cross-branch concurrency test.

## Round 3 review findings addressed

Commit `697c7308a` addresses the standalone findings added against `5f23ae4e1`.

| Severity | Finding | Disposition | Regression proof |
|---|---|---|---|
| HIGH | One due entry throwing outside its internal retryable-error path could abort the serial batch before later independent entries were processed. If the failed row stayed oldest and due, it could repeatedly starve the queue. | Each due entry now has its own error boundary. An escaped failure is logged, best-effort generation-CASed into the normal monotonic backoff, reported as `retry-pending`, and the worker continues with the remaining snapshot. | A real SQLite test admits two due rows, forces the first replay to throw, proves the first row gains a one-second retry deadline, and proves the second row still reaches `SETTLED`. Removing the boundary makes the batch reject immediately. |
| HIGH | The due-metrics failure-path test observed only `store.health()`, so deleting or corrupting the actual gauge writes would not fail the test. | The test installs an in-memory OpenTelemetry meter, rebuilds the real metric facade, forces a failed `listDue` path with known health values, flushes, and asserts both exported gauge datapoints. | Replacing the due-depth recording with zero fails with expected 7 / received 0. |
| MEDIUM | The lifecycle test proved `stopRecoveryWorker()` was called, but not that `DKGAgent.stop()` awaited it before dependent teardown. | The test now returns a deferred worker-stop promise and proves the next catalog teardown method is not invoked until the gate is released. | Replacing the production `await` with `void` makes teardown advance and the test fail before the gate is released. |
| MEDIUM, repeated follow-up | Extract autonomous orchestration from the already large recovery state machine. | Still a valid maintainability follow-up, but not a contained correctness fix. It overlaps the previously documented direct-entry/canonical-snapshot refactor and should be reviewed as a separate structural PR. | Existing behavior remains pinned by autonomous drain, backoff, lock, reconciliation, and lifecycle tests. |
| MEDIUM, repeated follow-up | Replace optional retry-delay plumbing with an explicit replay mode or policy. | Still intentionally deferred to a characterization-first refactor because it spans reconciliation, live recovery, settled upgrades, reorgs, deadlines, and outcome mapping. | The current distinct deadline semantics remain covered; the follow-up can change the representation without changing behavior. |

### Per-entry failure isolation

```mermaid
sequenceDiagram
    participant W as Recovery worker
    participant I as Durable inbox
    participant P as Poison entry
    participant V as Later valid entry

    W->>I: listDue limit 16
    I-->>W: poison entry, then valid entry
    W->>P: guarded replay
    P-->>W: escaped error
    W->>I: best-effort record failure and backoff
    Note over W: keep processing this bounded snapshot
    W->>V: guarded replay
    V-->>W: recovered
    W->>I: generation-CAS to SETTLED
```

### Round 3 validation

- Focused recovery, SQLite store, worker, and lifecycle suites: **67/67 passed**.
- Agent build: passed TypeScript, type tests, and package-root validation.
- Mutation proof: escaping the poison error fails the two-row test; zeroing the due gauge fails the telemetry assertion; removing the shutdown `await` fails the lifecycle gate.
- `git diff --check`: passed.

## Round 5 small review fix

The Round 4 review found one blocking defect in the new metrics regression test. The production recovery path already refreshes due-inbox metrics from a `finally` block, but the test could both hide its real assertion and bind its instruments to the wrong OpenTelemetry provider.

| Finding | Why it mattered | Fix |
|---|---|---|
| SQLite was closed only at the end of the successful `try` path | If an assertion failed, the database stayed open. On Windows, recursive cleanup then raised `EBUSY` and replaced the useful assertion failure. | Keep the store reference outside the `try` and close it first in `finally`, before removing the temporary directory. |
| Global meter registration was not verified | OpenTelemetry can reject a second global provider registration. The test would then rebuild instruments against a previously registered provider and the local exporter could contain no datapoint. | Disable any prior provider, assert that registration succeeds, and only then rebuild the metric instruments. |
| The health mock was one-shot and metric warnings were discarded | An unexpected extra health read could consume the only mocked result, while the no-op logger hid a metrics-snapshot failure. | Make the health result stable for the test and assert that no `metrics snapshot failed` warning occurs. |
| Export inspection read only the first point | This was unnecessarily coupled to exporter point ordering. | Inspect every point exported for each metric descriptor. |

No production behavior changed in this round. The test now proves the intended failure-path sequence without allowing cleanup or global telemetry state to obscure the result:

```mermaid
sequenceDiagram
    participant Test
    participant Recovery as FinalizationRecovery
    participant Store as SQLite inbox
    participant Meter as OTel meter provider
    participant Exporter

    Test->>Meter: disable prior provider
    Test->>Meter: register provider and assert success
    Test->>Recovery: processDueBatch(16)
    Recovery->>Store: listDue(16)
    Store-->>Recovery: throw due-read error
    Recovery->>Store: health() from finally
    Store-->>Recovery: dueEntries=7, oldestDueAgeMs=4321
    Recovery->>Meter: record both gauges
    Recovery-->>Test: return 0
    Test->>Meter: forceFlush()
    Meter->>Exporter: export datapoints
    Test->>Exporter: assert both gauge values
    Test->>Store: close() in finally
    Test->>Test: remove temporary directory
```

Validation on `6d20e82d1`:

- `finalization-recovery.test.ts`: 25/25 passed.
- Focused recovery and lifecycle set: 68/68 passed across four files.
- `git diff --check`: passed.


## Round 4 medium review

Commit `9622adc28` addresses the contained test gap added after Round 3.

| Finding | Disposition | Evidence |
|---|---|---|
| Autonomous `SETTLED` recovery lacked direct coverage. | **Fixed.** A real SQLite row is first settled without publisher authority, marked with a pending trusted-publisher upgrade, closed, reopened, and processed only through `processDueBatch(16)`. | The test proves the worker selects the due `SETTLED` row, applies upgraded access semantics once, advances generation 0 to 1, and clears `publisherUpgradePending`. |
| Due-queue semantics are split between the store and recovery layers. | **Reported follow-up.** A higher-level due-work repository is a cross-layer ownership refactor, not a local correctness patch. The current generation reload, due gate, and transition behavior remain explicitly tested. | Follow-up should consolidate the SQL predicate, freshness reload, and retry clock without weakening generation-CAS behavior. |
| Recovery-worker lifecycle knowledge is distributed across handler, lifecycle, agent stop, and persistence cleanup. | **Reported follow-up.** Consolidating ownership behind a handler/runtime lifecycle API is reasonable but changes startup, stop, and fail-safe teardown boundaries. | Current shutdown ordering is now pinned by a deferred-gate test proving the worker is awaited before dependent teardown. |

### Round 4 validation

- Focused recovery, SQLite store, worker, and lifecycle suites: **68/68 passed**.
- The new `SETTLED` case uses a real close/reopen boundary and autonomous `processDueBatch`; it does not call `replayMatching`.
- `git diff --check`: passed.

## Recovery sequence

```mermaid
sequenceDiagram
    participant L as Agent lifecycle
    participant W as Recovery worker
    participant I as SQLite inbox
    participant C as Chain adapter
    participant R as Guarded recovery path
    participant S as Graph store

    L->>W: start after inbox and runtime are ready

    loop while agent is running
        W->>I: listDue limit 16
        I-->>W: oldest due snapshot

        loop each row, strictly serial
            W->>C: resolve KA context-graph binding
            C-->>W: current on-chain graph id
            W->>R: replay persisted raw finalization
            R->>C: resolve canonical receipt
            R->>R: validate placement, authority, and target
            R->>S: existing verified materialization

            alt applied or already applied
                R->>I: generation-CAS to SETTLED
            else busy, deferred, or chain evidence pending
                R->>I: record outcome and monotonic backoff
            end
        end

        alt batch contained 16 rows
            W->>W: schedule next batch immediately
        else partial or empty batch
            W->>W: poll after 5 seconds
        end
    end

    L->>W: stop
    W->>W: cancel timer and await active batch
    W-->>L: drained
    L->>S: continue graph-store shutdown
```

## Same-entry serialization

```mermaid
sequenceDiagram
    participant L as Live gossip
    participant W as Recovery worker
    participant M as Per-entry FIFO mutex
    participant I as SQLite inbox
    participant S as Graph store

    L->>M: acquire entry key
    W->>M: wait for same entry key
    L->>I: receive or reload durable row
    L->>S: verify and materialize
    L->>I: generation-CAS to SETTLED
    L-->>M: release
    M-->>W: acquire
    W->>I: reload after lock
    I-->>W: state is SETTLED
    W-->>M: no duplicate graph write; release
```

The reverse ordering has the same result: whichever lane acquires the key first may materialize; the second reloads current durable state rather than trusting a stale snapshot.

## Bounded poison-row lifecycle

```mermaid
sequenceDiagram
    participant W as Recovery worker
    participant I as SQLite inbox
    participant C as Live capacity

    loop due while count or age budget remains
        W->>I: reload due live row
        W->>W: canonical validation or materialization
        W->>I: record failure and monotonic backoff
    end
    W->>I: reload after count ceiling and age window
    W->>I: generation-CAS live state to REJECTED
    I-->>C: row no longer counts against live quota
    Note over I: Terminal row remains auditable and is bounded by terminal retention
    C-->>W: new finalizations can be admitted
```

This deliberately avoids changing raw pruning to `created_at`: a long but legitimate RPC or reorg outage retains durable evidence, duplicate traffic cannot burn the lifetime early, and a poison row still has a finite autonomous lifecycle once both the count and wall-clock bounds expire. Identical gossip for a terminal row is handled without graph work until retention removes that row.

## Batching and load bounds

| Control | Value | Purpose |
|---|---:|---|
| SQLite due-query batch | 16 rows | Avoid one SQL round trip per row while keeping snapshots bounded. |
| Worker recovery operations | 1 at a time | Prevent backlog recovery from multiplying store pressure. |
| Same-entry concurrency | 1 across live, worker, and reconciliation | Prevent duplicate writes before state CAS. |
| Idle/partial poll | 5 seconds | Bound retry latency without polling an empty database continuously. |
| Full-batch continuation | immediate | Drain a real backlog without a 5-second gap per 16 rows. |
| Deferred retry | 1s exponential to 60s | Move pressured rows out of the hot set. |
| Live retry budget | 10,080 attempts **and** a seven-day minimum wall-clock age | Duplicate traffic cannot accelerate audited terminalization; both bounds must expire. |

At the existing global cap of 128, a fully due inbox needs at most eight 16-row selections to inspect every row. A graph at its 64-row cap spans at most four full selections. Completion time remains dominated by serial chain and graph work.

## Measured recovery and concurrency evidence

| Scenario | Result | What it proves |
|---|---:|---|
| Incident-shaped backlog: 64 `RECEIVED` rows with `attempt_count=0`, `last_error=NULL`, and `next_attempt_at=NULL` | 64 rows reached `SETTLED` in 416 ms; health changed from `capacity-exhausted` to ready; the 65th row changed from rejected to admitted | The worker drains the exact reported inbox shape and releases capacity. |
| Fail-before control with due discovery disabled | All 64 rows remained `RECEIVED` with zero attempts after 20 seconds | The recovery genuinely depends on autonomous due scanning. |
| Pre-hardening same-key live/worker probe | 2 concurrent `apply` entries in 3 of 5 runs | Reproduces the review's graph-write race. |
| Post-hardening gated test | max active same-key materializations = 1 across `apply` and `replayVerified` | The entry mutex removes the race, and the test observes both materialization branches. |
| Focused recovery run | 93/93 passed in 25.01 seconds | Pins selection, bounds, backoff, reconciliation, lifecycle, concurrency, and terminal duplicates. |

The 416 ms result is an in-process real-SQLite review benchmark, not a production Blazegraph latency claim.

## Consistency and security invariants

This does not create an alternate or weaker finalization path. The worker calls the #1939 recovery machinery:

- persisted raw bytes remain the replay source;
- chain ID, graph, UAL, KA ID, Merkle root, and transaction identity must match the durable entry;
- the KA-to-graph binding is resolved from the active chain before autonomous replay;
- canonical receipt placement and publisher/author evidence are revalidated before materialization;
- trusted-publisher upgrade and settled-reorg handling keep their existing guarded paths;
- state transitions remain generation-checked;
- live, worker, and reconciliation paths share per-entry FIFO serialization;
- raw envelopes are not exposed through status or metric surfaces.

## Lifecycle and SQLite compatibility

- Startup schedules the first pass asynchronously, so backlog size does not block agent startup.
- Only one worker batch can be active; timer ticks do not overlap.
- `stop()` cancels the timer and awaits the active batch.
- Shutdown stops the worker while chain and graph dependencies are still available.
- Recovery-store close retains an idempotent fail-safe stop.
- No schema migration is required.
- Existing inbox databases created by #1939 are consumed directly.
- Due selection includes live `RECEIVED`, `VERIFIED`, and `REORGED`, plus eligible `SETTLED` publisher-upgrade or receipt-retry work.
- Ordinary terminal rows are not replayed.

## Validation

### New coverage

- bounded oldest-first due selection and exact NULL-due incident shape;
- future-due and ordinary terminal exclusion;
- autonomous restart recovery and capacity release;
- poison-row terminalization and terminal duplicate inertness;
- same-key live/worker serialization;
- monotonic retry deadlines;
- immediate chain reconciliation despite worker backoff;
- real lifecycle start/stop wiring;
- due depth and oldest-age health;
- immediate full-batch continuation, non-overlapping batches, and shutdown drain.

### Commands and results

- Focused finalization recovery suite: **3 files, 93 tests passed; 0 failed**.
- Previous full agent unit suite: **148 files passed; 1,987 tests passed; 5 skipped; 0 failed**.
- Round 2 full agent run: **147 files and 1,988 tests passed; 5 skipped**. One unrelated child-process fault-injection test expected `SIGKILL` but observed exit code 13 under the loaded full run; its immediate isolated rerun passed **3/3**.
- Full core suite: **103 files and 1,580 tests completed successfully**; after completion the runner reported one unrelated existing `StreamStateError` unhandled rejection from `test/libp2p-network.test.ts` and exited non-zero.
- `pnpm --filter @origintrail-official/dkg-core build`: passed.
- `pnpm --filter @origintrail-official/dkg-agent build`: passed (`tsc`, type tests, package-root test).
- `git diff --check`: passed.

## Risk and rollout

The worker uses conservative fixed bounds. It does not raise inbox capacity, silently delete live evidence, or bypass chain evidence. It contributes at most one serial recovery operation; same-entry live/replay work is mutexed, while independent live operations remain under the existing store scheduler.

After deployment, old eligible rows will begin moving through attempts. Rows whose chain evidence or store capacity remains unavailable keep durable evidence with monotonic deadlines. A row that exhausts both the default attempt ceiling and wall-clock window becomes audited terminal `REJECTED` and releases live capacity.

Operators can alert on:

- `dkg.finalization_recovery.due_entries`;
- `dkg.finalization_recovery.oldest_due_age_ms`;
- `dkg.finalization_recovery.attempts_total{outcome}`;
- inbox state counts and capacity health.

## Scope boundary

This PR fixes autonomous progress for the durable finalization inbox. It does not change Blazegraph atomic graph replacement, store-scheduler admission, reconciliation watermark semantics, or inbox capacity limits. It does not claim that every atomic graph-replace 500/deadline has this root cause; it removes the code-level condition that can leave safely persisted finalizations permanently unconsumed after transient pressure.

## Related

- Durable finalization inbox and guarded replay foundation: [#1939](https://github.com/OriginTrail/dkg/pull/1939)