### PR TITLE
feat(observability): track verified VM and SWM sync outcomes

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -97,6 +97,9 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
   withRetry,
+  SyncAttemptObserver,
+  classifySyncPlaneOutcome,
+  type SyncTrigger,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, asChangelogReader, tryReplaceGraphAtomically, type ChangelogReader, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { readChangelogDeltaPage } from './sync/responder/graph-plan.js';
@@ -5571,6 +5574,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
      * during this context-graph catch-up run.
      */
     deniedPeers: number;
+    cleanPlaneCompletions: {
+      durable: {
+        verifiedDataPeers: number;
+        verifiedPrivateOnlyPeers: number;
+        emptyPeers: number;
+      };
+      sharedMemory: {
+        verifiedDataPeers: number;
+        emptyPeers: number;
+      };
+    };
     diagnostics: CatchupSyncDiagnostics;
   }> {
     const ctx = createOperationContext('sync');
@@ -5588,6 +5602,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
 
     return runSyncSingleFlight(this, singleFlightKey, async (): Promise<ContextGraphCatchupResult> => {
+      const trigger: SyncTrigger = mode === 'foreground' ? 'foreground' : 'background';
+      const syncAttempt = new SyncAttemptObserver({
+        logger: this.log,
+        context: ctx,
+        contextGraphId,
+        trigger,
+        planes: includeSharedMemory ? ['vm', 'swm'] : ['vm'],
+      });
+      try {
       const isPrivateContextGraph = await this.isPrivateContextGraph(contextGraphId);
 
       const preferredPeerId = await this.resolvePreferredSyncPeerId(contextGraphId);
@@ -5635,7 +5658,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers, {
         totalPeers: orderedPeers.length,
         mode,
+        trigger,
+        observer: syncAttempt,
       });
+      } catch (error) {
+        const message = error instanceof Error
+          ? `${error.name}: ${error.message}`
+          : String(error);
+        syncAttempt.finishRemaining(
+          /timed?\s*out|timeout|aborterror/i.test(message) ? 'timeout' : 'failed',
+          { errorCode: 'SYNC_JOB_EXCEPTION' },
+        );
+        throw error;
+      }
     });
   }
 
@@ -5725,7 +5760,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     includeSharedMemory: boolean,
     peers: Array<{ toString(): string }>,
-    stats?: { totalPeers?: number; mode?: CatchupMode },
+    stats?: {
+      totalPeers?: number;
+      mode?: CatchupMode;
+      trigger?: SyncTrigger;
+      observer?: SyncAttemptObserver;
+    },
   ): Promise<{
     /** Ordered connected peers before optional caller windowing. */
     connectedPeers: number;
@@ -5744,9 +5784,31 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     sharedMemoryCompletedCleanly: boolean;
     denied: boolean;
     deniedPeers: number;
+    cleanPlaneCompletions: {
+      durable: {
+        verifiedDataPeers: number;
+        verifiedPrivateOnlyPeers: number;
+        emptyPeers: number;
+      };
+      sharedMemory: {
+        verifiedDataPeers: number;
+        emptyPeers: number;
+      };
+    };
     diagnostics: CatchupSyncDiagnostics;
   }> {
     const ctx = createOperationContext('sync');
+    const trigger = stats?.trigger ?? (
+      stats?.mode === 'foreground' ? 'foreground' : 'background'
+    );
+    const syncAttempt = stats?.observer ?? new SyncAttemptObserver({
+        logger: this.log,
+        context: ctx,
+        contextGraphId,
+        trigger,
+        planes: includeSharedMemory ? ['vm', 'swm'] : ['vm'],
+      });
+    try {
     let syncCapablePeers = 0;
     let peersTried = 0;
     let peersResponded = 0;
@@ -5754,6 +5816,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let dataSynced = 0;
     let sharedMemorySynced = 0;
     let noProtocolPeers = 0;
+    let durableDeniedPhases = 0;
+    let sharedMemoryDeniedPhases = 0;
+    const cleanPlaneCompletions = {
+      durable: { verifiedDataPeers: 0, verifiedPrivateOnlyPeers: 0, emptyPeers: 0 },
+      sharedMemory: { verifiedDataPeers: 0, emptyPeers: 0 },
+    };
     const diagnostics: CatchupSyncDiagnostics = {
       noProtocolPeers: 0,
       durable: {
@@ -5940,9 +6008,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         cleanDurableDataSynced += r.durable.insertedDataTriples;
         cleanDurablePrivateOnlyCompletions +=
           durableProgress.hasVerifiedPrivateOnlyResponse ? 1 : 0;
+        if (r.durable.insertedDataTriples > 0) {
+          cleanPlaneCompletions.durable.verifiedDataPeers += 1;
+        }
+        if (durableProgress.hasVerifiedPrivateOnlyResponse) {
+          cleanPlaneCompletions.durable.verifiedPrivateOnlyPeers += 1;
+        }
+        if (r.durable.emptyResponses > 0) {
+          cleanPlaneCompletions.durable.emptyPeers += 1;
+        }
       }
       if (sharedMemoryCompletedCleanly) {
         cleanSharedMemoryDataSynced += r.shared!.insertedDataTriples;
+        cleanPlaneCompletions.sharedMemory.verifiedDataPeers += 1;
+      }
+      if (
+        r.shared
+        && sharedProgress?.completedWithoutFailure
+        && r.shared.emptyResponses > 0
+      ) {
+        cleanPlaneCompletions.sharedMemory.emptyPeers += 1;
       }
       if (durableResponded || sharedResponded) {
         peersResponded++;
@@ -5963,6 +6048,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         peersSucceeded++;
       }
       dataSynced += r.durable.insertedDataTriples;
+      durableDeniedPhases += r.durable.deniedPhases ?? 0;
       diagnostics.durable.fetchedMetaTriples += r.durable.fetchedMetaTriples;
       diagnostics.durable.fetchedDataTriples += r.durable.fetchedDataTriples;
       diagnostics.durable.insertedMetaTriples += r.durable.insertedMetaTriples;
@@ -5986,6 +6072,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       let peerDenied = durableProgress.denied;
       if (r.shared) {
         sharedMemorySynced += r.shared.insertedDataTriples;
+        sharedMemoryDeniedPhases += r.shared.deniedPhases ?? 0;
         diagnostics.sharedMemory.fetchedMetaTriples += r.shared.fetchedMetaTriples;
         diagnostics.sharedMemory.fetchedDataTriples += r.shared.fetchedDataTriples;
         diagnostics.sharedMemory.insertedMetaTriples += r.shared.insertedMetaTriples;
@@ -6042,6 +6129,48 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       });
     }
 
+    const hasConfirmedMeta = await this.hasConfirmedMetaState(contextGraphId)
+      .catch(() => false);
+    const isPrivate = hasConfirmedMeta
+      ? await this.isPrivateContextGraph(contextGraphId).catch(() => true)
+      : true;
+    const commonEvidence = {
+      authoritativeScopeConfirmed: hasConfirmedMeta,
+      connectedPeers: stats?.totalPeers ?? peers.length,
+      syncCapablePeers,
+      peersTried,
+      peersResponded,
+    };
+    const vmOutcome = classifySyncPlaneOutcome({
+      ...commonEvidence,
+      verified: hasConfirmedMeta && (
+        cleanPlaneCompletions.durable.verifiedDataPeers > 0
+        || cleanPlaneCompletions.durable.verifiedPrivateOnlyPeers > 0
+        || (!isPrivate && cleanPlaneCompletions.durable.emptyPeers > 0)
+      ),
+      deferredBackpressure: diagnostics.durable.deferredBackpressure,
+      deniedPhases: durableDeniedPhases,
+      timedOutPhases: diagnostics.durable.timedOutPhases,
+    });
+    syncAttempt.finish('vm', vmOutcome, {
+      triplesSynced: vmOutcome === 'success' ? cleanDurableDataSynced : 0,
+    });
+    if (includeSharedMemory) {
+      const swmOutcome = classifySyncPlaneOutcome({
+        ...commonEvidence,
+        verified: hasConfirmedMeta && (
+          cleanPlaneCompletions.sharedMemory.verifiedDataPeers > 0
+          || (!isPrivate && cleanPlaneCompletions.sharedMemory.emptyPeers > 0)
+        ),
+        deferredBackpressure: diagnostics.sharedMemory.deferredBackpressure,
+        deniedPhases: sharedMemoryDeniedPhases,
+        timedOutPhases: diagnostics.sharedMemory.timedOutPhases,
+      });
+      syncAttempt.finish('swm', swmOutcome, {
+        triplesSynced: swmOutcome === 'success' ? cleanSharedMemoryDataSynced : 0,
+      });
+    }
+
     return {
       connectedPeers: stats?.totalPeers ?? peers.length,
       totalPeers: stats?.totalPeers ?? peers.length,
@@ -6056,8 +6185,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       sharedMemoryCompletedCleanly,
       denied: accessDeniedPeers > 0,
       deniedPeers: accessDeniedPeers,
+      cleanPlaneCompletions,
       diagnostics,
     };
+    } catch (error) {
+      const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+      syncAttempt.finishRemaining(
+        /timed?\s*out|timeout|aborterror/i.test(message) ? 'timeout' : 'failed',
+        { errorCode: 'SYNC_JOB_EXCEPTION' },
+      );
+      throw error;
+    }
   }
 
   async primeCatchupConnections(this: DKGAgent): Promise<void> {
@@ -6162,6 +6300,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
               contextGraphId,
               includeSharedMemory,
               [curatorRemote],
+              { trigger: 'post-approval' },
             );
             totalDataSynced += result.dataSynced;
             totalSharedMemorySynced += result.sharedMemorySynced;

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -1,5 +1,10 @@
 import type { DKGAgent } from '@origintrail-official/dkg-agent';
-import { DKGEvent, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import {
+  DKGEvent,
+  SYSTEM_CONTEXT_GRAPHS,
+  classifySyncPlaneOutcome,
+  type SyncPlaneOutcome,
+} from '@origintrail-official/dkg-core';
 import type {
   ContextGraphReadinessProvenance,
   DashboardDB,
@@ -200,6 +205,56 @@ function catchupPlaneReadyThisRun(input: {
     : input.result.sharedMemorySynced > 0;
   return catchupPlaneCompletedWithoutFailure(diagnostics) &&
     (dataProgress || (!input.isPrivate && (diagnostics?.emptyResponses ?? 0) > 0));
+}
+
+export interface CatchupPlaneOutcomes {
+  vm: SyncPlaneOutcome;
+  swm?: SyncPlaneOutcome;
+}
+
+/**
+ * Derive current-attempt outcomes from verified per-plane evidence. Persisted
+ * readiness from an older run is intentionally ignored: it must not turn a
+ * failed retry into a successful current attempt.
+ */
+export function classifyCatchupPlaneOutcomes(input: {
+  result: CatchupJobResult;
+  includeSharedMemory: boolean;
+  hasConfirmedMeta: boolean;
+  isPrivate: boolean;
+}): CatchupPlaneOutcomes {
+  const connectedPeers = input.result.totalPeers ?? input.result.connectedPeers;
+  const peersResponded = input.result.peersResponded ?? input.result.peersSucceeded;
+  const classify = (plane: 'durable' | 'sharedMemory'): SyncPlaneOutcome => {
+    const diagnostics = input.result.diagnostics?.[plane];
+    return classifySyncPlaneOutcome({
+      verified: input.hasConfirmedMeta && catchupPlaneReadyThisRun({
+        result: input.result,
+        plane,
+        isPrivate: input.isPrivate,
+      }),
+      authoritativeScopeConfirmed: input.hasConfirmedMeta,
+      connectedPeers,
+      syncCapablePeers: input.result.syncCapablePeers,
+      peersTried: input.result.peersTried,
+      peersResponded,
+      // New workers report pressure per plane. During rolling upgrades an
+      // older runner can only return the aggregate counter; treat that as a
+      // deferral for every unverified requested plane rather than fabricating
+      // a failure.
+      deferredBackpressure:
+        diagnostics?.deferredBackpressure ?? input.result.deferredBackpressure,
+      deniedPhases: diagnostics?.deniedPhases ?? (
+        input.result.denied ? input.result.deniedPeers : 0
+      ),
+      timedOutPhases: diagnostics?.timedOutPhases,
+    });
+  };
+
+  return {
+    vm: classify('durable'),
+    ...(input.includeSharedMemory ? { swm: classify('sharedMemory') } : {}),
+  };
 }
 
 export interface ContextGraphCatchupReadinessClassification {

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -65,7 +65,7 @@ import {
   VmReconcileQueueFullError,
   VmReconcileUnavailableError,
 } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, SyncAttemptObserver } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -115,6 +115,7 @@ import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type P
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
 import {
   catchupResultHasCleanResponse,
+  classifyCatchupPlaneOutcomes,
   classifyContextGraphCatchupReadiness,
   classifyExistingContextGraphReadiness,
   readContextGraphReadiness,
@@ -464,6 +465,8 @@ async function handleReconcileContextGraphRoute(
     return respondReconcileError(res, err);
   }
 }
+
+const syncOutcomeLogger = new Logger('daemon-catchup');
 
 export async function handleContextGraphRoutes(ctx: RequestContext): Promise<void> {
   const {
@@ -1835,6 +1838,13 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     void (async () => {
       job.status = "running";
       job.startedAt = Date.now();
+      const syncAttempt = new SyncAttemptObserver({
+        logger: syncOutcomeLogger,
+        context: createOperationContext('sync'),
+        contextGraphId,
+        trigger: 'subscription',
+        planes: shouldSyncSharedMemory ? ['vm', 'swm'] : ['vm'],
+      });
       if (DEBUG_SYNC_TRACE) console.log(`[catchup] job=${jobId} contextGraph=${contextGraphId} started`);
       try {
         const result = await daemonState.catchupRunner!.run({
@@ -1850,6 +1860,32 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         if (result.deferredBackpressure > 0 && !result.denied) {
           job.status = "deferred";
           job.error = "Sync deferred by local scheduler backpressure; retry when capacity is available.";
+          // The job remains globally deferred and does not mutate readiness,
+          // but one requested plane may still have completed cleanly before a
+          // different plane hit pressure. Classify each plane independently
+          // so a SWM deferral cannot erase a verified VM result (or vice versa).
+          const hasConfirmedMeta = typeof agent.hasConfirmedMetaState === 'function'
+            ? await agent.hasConfirmedMetaState(contextGraphId).catch(() => false)
+            : false;
+          const isPrivate = hasConfirmedMeta
+            ? await agent.isPrivateContextGraph(contextGraphId).catch(() => true)
+            : true;
+          const planeOutcomes = classifyCatchupPlaneOutcomes({
+            result,
+            includeSharedMemory: shouldSyncSharedMemory,
+            hasConfirmedMeta,
+            isPrivate,
+          });
+          syncAttempt.finish('vm', planeOutcomes.vm, {
+            triplesSynced: planeOutcomes.vm === 'success' ? result.dataSynced : 0,
+          });
+          if (shouldSyncSharedMemory && planeOutcomes.swm) {
+            syncAttempt.finish('swm', planeOutcomes.swm, {
+              triplesSynced: planeOutcomes.swm === 'success'
+                ? result.sharedMemorySynced
+                : 0,
+            });
+          }
           if (DEBUG_SYNC_TRACE) console.log(`[catchup] job=${jobId} contextGraph=${contextGraphId} deferred by local scheduler: ${result.deferredBackpressure}`);
         } else {
           const inspectReadiness = catchupResultHasCleanResponse(result);
@@ -1865,6 +1901,12 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
             hasConfirmedMeta,
             isPrivate,
             readinessBeforeCatchup,
+          });
+          const planeOutcomes = classifyCatchupPlaneOutcomes({
+            result,
+            includeSharedMemory: shouldSyncSharedMemory,
+            hasConfirmedMeta,
+            isPrivate,
           });
 
           job.status = classification.jobStatus;
@@ -1895,6 +1937,17 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
             job.status = "deferred";
             job.error = "Sync deferred by local scheduler backpressure; retry when capacity is available.";
           }
+
+          syncAttempt.finish('vm', planeOutcomes.vm, {
+            triplesSynced: planeOutcomes.vm === 'success' ? result.dataSynced : 0,
+          });
+          if (shouldSyncSharedMemory && planeOutcomes.swm) {
+            syncAttempt.finish('swm', planeOutcomes.swm, {
+              triplesSynced: planeOutcomes.swm === 'success'
+                ? result.sharedMemorySynced
+                : 0,
+            });
+          }
         }
 
         if (DEBUG_SYNC_TRACE) {
@@ -1911,6 +1964,10 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       } catch (err) {
         job.error = err instanceof Error ? err.message : String(err);
         job.status = "failed";
+        const terminalOutcome = /timed?\s*out|timeout|aborterror/i.test(job.error)
+          ? 'timeout'
+          : 'failed';
+        syncAttempt.finishRemaining(terminalOutcome, { errorCode: 'SYNC_JOB_EXCEPTION' });
         if (DEBUG_SYNC_TRACE) console.log(`[catchup] job=${jobId} contextGraph=${contextGraphId} threw: ${job.error}`);
       } finally {
         job.finishedAt = Date.now();

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { CatchupJobResult } from '../src/catchup-runner.js';
-import { classifyContextGraphCatchupReadiness } from '../src/context-graph-readiness.js';
+import {
+  classifyCatchupPlaneOutcomes,
+  classifyContextGraphCatchupReadiness,
+} from '../src/context-graph-readiness.js';
 
 function mixedPeerResult(verifiedDataPeers: number): CatchupJobResult {
   return {
@@ -11,6 +14,7 @@ function mixedPeerResult(verifiedDataPeers: number): CatchupJobResult {
     peersTried: 2,
     peersResponded: 2,
     peersSucceeded: verifiedDataPeers > 0 ? 1 : 0,
+    deferredBackpressure: 0,
     dataSynced: 5,
     sharedMemorySynced: 0,
     denied: true,
@@ -217,5 +221,54 @@ describe('context graph catch-up readiness classification', () => {
         sharedMemoryVerified: false,
       },
     });
+  });
+
+  it('classifies VM and SWM from their own verified terminal evidence', () => {
+    const result = mixedPeerResult(1);
+    if (!result.diagnostics?.sharedMemory) throw new Error('SWM diagnostics missing');
+    result.diagnostics.sharedMemory.timedOutPhases = 1;
+
+    expect(classifyCatchupPlaneOutcomes({
+      result,
+      includeSharedMemory: true,
+      hasConfirmedMeta: true,
+      isPrivate: true,
+    })).toEqual({ vm: 'success', swm: 'timeout' });
+  });
+
+  it('keeps a verified VM success when only SWM is deferred', () => {
+    const result = mixedPeerResult(1);
+    result.denied = false;
+    result.deniedPeers = 0;
+    result.deferredBackpressure = 1;
+    if (!result.diagnostics?.durable || !result.diagnostics.sharedMemory) {
+      throw new Error('plane diagnostics missing');
+    }
+    result.diagnostics.durable.deniedPhases = 0;
+    result.diagnostics.durable.timedOutPhases = 0;
+    result.diagnostics.sharedMemory.deferredBackpressure = 1;
+
+    expect(classifyCatchupPlaneOutcomes({
+      result,
+      includeSharedMemory: true,
+      hasConfirmedMeta: true,
+      isPrivate: true,
+    })).toEqual({ vm: 'success', swm: 'deferred' });
+  });
+
+  it('does not report clean payload data as success without authoritative metadata', () => {
+    const result = mixedPeerResult(1);
+    result.denied = false;
+    result.deniedPeers = 0;
+    if (!result.diagnostics?.durable) throw new Error('durable diagnostics missing');
+    result.diagnostics.durable.deniedPhases = 0;
+    result.diagnostics.durable.timedOutPhases = 0;
+
+    expect(classifyCatchupPlaneOutcomes({
+      result,
+      includeSharedMemory: false,
+      hasConfirmedMeta: false,
+      isPrivate: true,
+    })).toEqual({ vm: 'unreachable' });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,7 +76,9 @@ export {
   type OperationName,
   type LogSink,
   type LogRecord,
+  type LogSemanticAttributes,
 } from './logger.js';
+export * from './sync-outcome-observability.js';
 export {
   KA_LIFECYCLE_ROLES,
   KA_LIFECYCLE_STAGES,

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -11,6 +11,23 @@ export interface OperationContext {
 }
 
 /**
+ * Bounded operational fields used by Loki/Grafana without parsing the human
+ * message. Never put peer IDs, context-graph IDs, UALs, or error messages in
+ * these fields.
+ */
+export interface LogSemanticAttributes {
+  eventCode?: string;
+  component?: string;
+  outcome?: string;
+  retryable?: boolean;
+  errorCode?: string;
+  syncPlane?: 'vm' | 'swm';
+  syncTrigger?: 'foreground' | 'background' | 'subscription' | 'post-approval';
+  durationMs?: number;
+  triplesSynced?: number;
+}
+
+/**
  * The canonical structured log record emitted on every Logger call. This is
  * the single shape that flows to the local dashboard DB and to any remote
  * shipper (syslog, OTLP). Keep it stable — redaction and the OTLP exporter
@@ -23,6 +40,15 @@ export interface LogRecord {
   sourceOperationId?: string;
   module: string;
   message: string;
+  eventCode?: string;
+  component?: string;
+  outcome?: string;
+  retryable?: boolean;
+  errorCode?: string;
+  syncPlane?: 'vm' | 'swm';
+  syncTrigger?: 'foreground' | 'background' | 'subscription' | 'post-approval';
+  durationMs?: number;
+  triplesSynced?: number;
   /** Hex W3C trace/span id of the active span when logged (when a span is recording), for trace↔log correlation. */
   traceId?: string;
   spanId?: string;
@@ -53,7 +79,12 @@ export class Logger {
    * span's trace/span id when one is recording (no-op/empty otherwise), so logs
    * emitted inside an instrumented boundary correlate to its trace.
    */
-  private emit(level: string, ctx: OperationContext, message: string): void {
+  private emit(
+    level: string,
+    ctx: OperationContext,
+    message: string,
+    semantic: LogSemanticAttributes = {},
+  ): void {
     if (!Logger.sink) return;
     Logger.sink({
       level,
@@ -62,27 +93,28 @@ export class Logger {
       sourceOperationId: ctx.sourceOperationId,
       module: this.moduleName,
       message,
+      ...semantic,
       ...currentTraceIds(),
     });
   }
 
-  debug(ctx: OperationContext, message: string): void {
-    this.emit('debug', ctx, message);
+  debug(ctx: OperationContext, message: string, semantic?: LogSemanticAttributes): void {
+    this.emit('debug', ctx, message, semantic);
   }
 
-  info(ctx: OperationContext, message: string): void {
+  info(ctx: OperationContext, message: string, semantic?: LogSemanticAttributes): void {
     process.stdout.write(`${this.format(ctx, message)}\n`);
-    this.emit('info', ctx, message);
+    this.emit('info', ctx, message, semantic);
   }
 
-  warn(ctx: OperationContext, message: string): void {
+  warn(ctx: OperationContext, message: string, semantic?: LogSemanticAttributes): void {
     process.stderr.write(`${this.format(ctx, message)} [WARN]\n`);
-    this.emit('warn', ctx, message);
+    this.emit('warn', ctx, message, semantic);
   }
 
-  error(ctx: OperationContext, message: string): void {
+  error(ctx: OperationContext, message: string, semantic?: LogSemanticAttributes): void {
     process.stderr.write(`${this.format(ctx, message)} [ERROR]\n`);
-    this.emit('error', ctx, message);
+    this.emit('error', ctx, message, semantic);
   }
 
   private format(ctx: OperationContext, message: string): string {

--- a/packages/core/src/sync-outcome-observability.ts
+++ b/packages/core/src/sync-outcome-observability.ts
@@ -1,0 +1,152 @@
+import {
+  Logger,
+  type OperationContext,
+} from './logger.js';
+import { getMetrics } from './telemetry-api.js';
+
+export type SyncPlane = 'vm' | 'swm';
+export type SyncTrigger = 'foreground' | 'background' | 'subscription' | 'post-approval';
+export type SyncPlaneOutcome =
+  | 'success'
+  | 'failed'
+  | 'timeout'
+  | 'deferred'
+  | 'denied'
+  | 'unreachable';
+
+export interface SyncPlaneEvidence {
+  verified: boolean;
+  /** Whether the graph's authoritative scope/metadata was verified this run. */
+  authoritativeScopeConfirmed?: boolean;
+  connectedPeers: number;
+  syncCapablePeers: number;
+  peersTried: number;
+  peersResponded: number;
+  deferredBackpressure?: number;
+  deniedPhases?: number;
+  timedOutPhases?: number;
+}
+
+/**
+ * Convert final plane evidence into one bounded operator outcome. Success is
+ * deliberately only reachable through a caller-provided verification proof;
+ * fetched/inserted triple counts alone never count as success.
+ */
+export function classifySyncPlaneOutcome(
+  evidence: SyncPlaneEvidence,
+): SyncPlaneOutcome {
+  if (evidence.verified) return 'success';
+  if ((evidence.deniedPhases ?? 0) > 0) return 'denied';
+  if ((evidence.deferredBackpressure ?? 0) > 0) return 'deferred';
+  if ((evidence.timedOutPhases ?? 0) > 0) return 'timeout';
+  if (
+    evidence.authoritativeScopeConfirmed === false
+    ||
+    evidence.connectedPeers === 0
+    || evidence.syncCapablePeers === 0
+    || evidence.peersTried === 0
+    || evidence.peersResponded === 0
+  ) return 'unreachable';
+  return 'failed';
+}
+
+export interface SyncPlaneTerminalDetails {
+  triplesSynced?: number;
+  errorCode?: string;
+}
+
+export interface SyncAttemptObserverOptions {
+  logger: Logger;
+  context: OperationContext;
+  contextGraphId: string;
+  trigger: SyncTrigger;
+  planes: readonly SyncPlane[];
+  now?: () => number;
+}
+
+const DEFAULT_ERROR_CODE: Record<Exclude<SyncPlaneOutcome, 'success'>, string> = {
+  failed: 'SYNC_PLANE_FAILED',
+  timeout: 'SYNC_PLANE_TIMEOUT',
+  deferred: 'SYNC_PLANE_DEFERRED',
+  denied: 'SYNC_PLANE_DENIED',
+  unreachable: 'SYNC_PLANE_UNREACHABLE',
+};
+
+const RETRYABLE: Record<SyncPlaneOutcome, boolean> = {
+  success: false,
+  failed: true,
+  timeout: true,
+  deferred: true,
+  denied: false,
+  unreachable: true,
+};
+
+/**
+ * Process-local exactly-once recorder for one logical sync job. Each requested
+ * plane gets one start and at most one terminal event, regardless of peers or
+ * pages involved in the transfer.
+ */
+export class SyncAttemptObserver {
+  private readonly startedAt: number;
+  private readonly pending: Set<SyncPlane>;
+  private readonly now: () => number;
+
+  constructor(private readonly options: SyncAttemptObserverOptions) {
+    this.now = options.now ?? Date.now;
+    this.startedAt = this.now();
+    this.pending = new Set(options.planes);
+    for (const plane of this.pending) {
+      const attrs = { plane, trigger: options.trigger };
+      getMetrics().syncPlaneStartedTotal.add(1, attrs);
+      getMetrics().syncPlaneActive.add(1, attrs);
+    }
+  }
+
+  finish(
+    plane: SyncPlane,
+    outcome: SyncPlaneOutcome,
+    details: SyncPlaneTerminalDetails = {},
+  ): boolean {
+    if (!this.pending.delete(plane)) return false;
+
+    const durationMs = Math.max(0, this.now() - this.startedAt);
+    const metricAttrs = { plane, trigger: this.options.trigger, outcome };
+    getMetrics().syncPlaneTerminalTotal.add(1, metricAttrs);
+    getMetrics().syncPlaneDurationMs.record(durationMs, metricAttrs);
+    getMetrics().syncPlaneActive.add(-1, {
+      plane,
+      trigger: this.options.trigger,
+    });
+
+    const semantic = {
+      eventCode: 'sync.plane.terminal',
+      component: 'sync',
+      outcome,
+      retryable: RETRYABLE[outcome],
+      ...(outcome === 'success'
+        ? {}
+        : { errorCode: details.errorCode ?? DEFAULT_ERROR_CODE[outcome] }),
+      syncPlane: plane,
+      syncTrigger: this.options.trigger,
+      durationMs,
+      triplesSynced: Math.max(0, details.triplesSynced ?? 0),
+    } as const;
+    const message = `Sync plane ${plane.toUpperCase()} for "${this.options.contextGraphId}" reached terminal outcome=${outcome} durationMs=${durationMs} triplesSynced=${semantic.triplesSynced}`;
+
+    if (outcome === 'success') {
+      this.options.logger.info(this.options.context, message, semantic);
+    } else if (outcome === 'failed') {
+      this.options.logger.error(this.options.context, message, semantic);
+    } else {
+      this.options.logger.warn(this.options.context, message, semantic);
+    }
+    return true;
+  }
+
+  finishRemaining(
+    outcome: Exclude<SyncPlaneOutcome, 'success'>,
+    details: SyncPlaneTerminalDetails = {},
+  ): void {
+    for (const plane of [...this.pending]) this.finish(plane, outcome, details);
+  }
+}

--- a/packages/core/src/telemetry-api.ts
+++ b/packages/core/src/telemetry-api.ts
@@ -260,6 +260,14 @@ export interface DkgMetrics {
   /** outcome={ok|busy|limit|error|invalid} — `invalid` = malformed request
    *  (e.g. missing contextGraphId) short-circuited before serving. */
   syncResponseTotal: Counter;
+  /** plane={vm|swm}, trigger={foreground|background|subscription|post-approval} */
+  syncPlaneStartedTotal: Counter;
+  /** plane, trigger, outcome={success|failed|timeout|deferred|denied|unreachable} */
+  syncPlaneTerminalTotal: Counter;
+  /** ms; plane, trigger, outcome are bounded sync lifecycle enums */
+  syncPlaneDurationMs: Histogram;
+  /** process-local logical plane attempts currently awaiting a terminal result */
+  syncPlaneActive: UpDownCounter;
   /** outcome={ok|error}, protocol_id — outbound P2P protocol send */
   protocolSendTotal: Counter;
   /** ms; protocol_id — P2P protocol send duration */
@@ -455,6 +463,20 @@ function buildMetrics(): DkgMetrics {
     chainRpcFailoverTotal: meter.createCounter('dkg.chain.rpc.failover.total', { description: 'Chain RPC endpoint failover events' }),
     syncRequestTotal: meter.createCounter('dkg.sync.request.total', { description: 'Outbound sync requests' }),
     syncResponseTotal: meter.createCounter('dkg.sync.response.total', { description: 'Inbound sync responses' }),
+    syncPlaneStartedTotal: meter.createCounter('dkg.sync.plane.started.total', {
+      description: 'Logical VM/SWM sync plane attempts started',
+    }),
+    syncPlaneTerminalTotal: meter.createCounter('dkg.sync.plane.terminal.total', {
+      description: 'Terminal verified VM/SWM sync plane outcomes',
+    }),
+    syncPlaneDurationMs: meter.createHistogram('dkg.sync.plane.duration', {
+      unit: 'ms',
+      description: 'Logical VM/SWM sync plane wall-time to a terminal verified outcome',
+      advice: { explicitBucketBoundaries: OP_DURATION_BUCKETS },
+    }),
+    syncPlaneActive: meter.createUpDownCounter('dkg.sync.plane.active', {
+      description: 'Logical VM/SWM sync plane attempts currently awaiting a terminal result',
+    }),
     protocolSendTotal: meter.createCounter('dkg.protocol_router.send.total', { description: 'Outbound P2P protocol sends' }),
     oversizeTombstonesTotal: meter.createCounter('dkg.sync.oversize_tombstones.total', {
       description: 'Synced quads refused for exceeding the RDF-literal size invariant (OT-RFC-56)',

--- a/packages/core/test/sync-outcome-observability.test.ts
+++ b/packages/core/test/sync-outcome-observability.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { classifySyncPlaneOutcome } from '../src/index.js';
+
+describe('verified sync plane outcome classification', () => {
+  const base = {
+    verified: false,
+    authoritativeScopeConfirmed: true,
+    connectedPeers: 2,
+    syncCapablePeers: 2,
+    peersTried: 2,
+    peersResponded: 2,
+  };
+
+  it('only reports success from explicit verification evidence', () => {
+    expect(classifySyncPlaneOutcome({ ...base, verified: true })).toBe('success');
+    expect(classifySyncPlaneOutcome(base)).toBe('failed');
+  });
+
+  it('keeps terminal failure classes distinct and ordered', () => {
+    expect(classifySyncPlaneOutcome({ ...base, deniedPhases: 1 })).toBe('denied');
+    expect(classifySyncPlaneOutcome({ ...base, deferredBackpressure: 1 })).toBe('deferred');
+    expect(classifySyncPlaneOutcome({ ...base, timedOutPhases: 1 })).toBe('timeout');
+    expect(classifySyncPlaneOutcome({ ...base, authoritativeScopeConfirmed: false })).toBe('unreachable');
+    expect(classifySyncPlaneOutcome({ ...base, peersResponded: 0 })).toBe('unreachable');
+  });
+});

--- a/packages/node-ui/src/otlp-log-worker.ts
+++ b/packages/node-ui/src/otlp-log-worker.ts
@@ -98,7 +98,7 @@ interface OtlpAttribute {
   value: { stringValue: string };
 }
 
-function attr(key: string, value: string | undefined): OtlpAttribute | null {
+function attr(key: string, value: string | number | boolean | undefined): OtlpAttribute | null {
   if (value == null || value === '') return null;
   return { key, value: { stringValue: String(value) } };
 }
@@ -317,6 +317,15 @@ export function encodeOtlpLogPayload(
         attr('dkg.operation_name', r.operationName),
         attr('dkg.source_operation_id', r.sourceOperationId),
         attr('dkg.module', r.module),
+        attr('dkg.event_code', r.eventCode),
+        attr('dkg.component', r.component),
+        attr('dkg.outcome', r.outcome),
+        attr('dkg.retryable', r.retryable),
+        attr('dkg.error_code', r.errorCode),
+        attr('dkg.sync_plane', r.syncPlane),
+        attr('dkg.sync_trigger', r.syncTrigger),
+        attr('dkg.duration_ms', r.durationMs),
+        attr('dkg.triples_synced', r.triplesSynced),
       ].filter((a): a is OtlpAttribute => a !== null),
     };
   });

--- a/packages/node-ui/test/otlp-log-worker.test.ts
+++ b/packages/node-ui/test/otlp-log-worker.test.ts
@@ -102,7 +102,21 @@ describe('OtlpLogWorker — OTLP/HTTP log export', () => {
     workers.push(w);
     w.start();
 
-    w.push(rec({ level: 'error', message: 'boom', operationId: 'op-1', sourceOperationId: 'op-src' }));
+    w.push(rec({
+      level: 'error',
+      message: 'boom',
+      operationId: 'op-1',
+      sourceOperationId: 'op-src',
+      eventCode: 'sync.plane.terminal',
+      component: 'sync',
+      outcome: 'timeout',
+      retryable: true,
+      errorCode: 'SYNC_PLANE_TIMEOUT',
+      syncPlane: 'vm',
+      syncTrigger: 'subscription',
+      durationMs: 12_345,
+      triplesSynced: 0,
+    }));
     await waitFor(() => srv.received.length >= 1);
 
     const { body, headers } = srv.received[0];
@@ -132,6 +146,15 @@ describe('OtlpLogWorker — OTLP/HTTP log export', () => {
     expect(recAttrs['dkg.operation_id']).toBe('op-1');
     expect(recAttrs['dkg.source_operation_id']).toBe('op-src');
     expect(recAttrs['dkg.module']).toBe('publisher');
+    expect(recAttrs['dkg.event_code']).toBe('sync.plane.terminal');
+    expect(recAttrs['dkg.component']).toBe('sync');
+    expect(recAttrs['dkg.outcome']).toBe('timeout');
+    expect(recAttrs['dkg.retryable']).toBe('true');
+    expect(recAttrs['dkg.error_code']).toBe('SYNC_PLANE_TIMEOUT');
+    expect(recAttrs['dkg.sync_plane']).toBe('vm');
+    expect(recAttrs['dkg.sync_trigger']).toBe('subscription');
+    expect(recAttrs['dkg.duration_ms']).toBe('12345');
+    expect(recAttrs['dkg.triples_synced']).toBe('0');
   });
 
   it('batches multiple records into a single request', async () => {

--- a/packages/node-ui/test/sync-outcome-observer.test.ts
+++ b/packages/node-ui/test/sync-outcome-observer.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { metrics } from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import {
+  Logger,
+  SyncAttemptObserver,
+  rebuildMetrics,
+  type LogRecord,
+} from '@origintrail-official/dkg-core';
+
+describe('SyncAttemptObserver', () => {
+  let meterProvider: MeterProvider | undefined;
+
+  afterEach(async () => {
+    Logger.setSink(null);
+    if (meterProvider) await meterProvider.shutdown().catch(() => undefined);
+    meterProvider = undefined;
+    metrics.disable();
+    rebuildMetrics();
+  });
+
+  it('records one start and one terminal result per requested plane', async () => {
+    const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+    meterProvider = new MeterProvider({
+      readers: [new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: 60_000,
+      })],
+    });
+    metrics.setGlobalMeterProvider(meterProvider);
+    rebuildMetrics();
+
+    const logs: LogRecord[] = [];
+    Logger.setSink((record) => logs.push(record));
+    const times = [1_000, 16_000];
+    const observer = new SyncAttemptObserver({
+      logger: new Logger('sync-test'),
+      context: { operationId: 'sync-op', operationName: 'sync' },
+      contextGraphId: 'cg-test',
+      trigger: 'subscription',
+      planes: ['vm', 'swm'],
+      now: () => times.shift() ?? 16_000,
+    });
+
+    expect(observer.finish('vm', 'success', { triplesSynced: 42 })).toBe(true);
+    expect(observer.finish('vm', 'failed')).toBe(false);
+    observer.finishRemaining('timeout');
+    await meterProvider.forceFlush();
+
+    const points = (metricName: string) => exporter.getMetrics()
+      .flatMap((resource) => resource.scopeMetrics)
+      .flatMap((scope) => scope.metrics)
+      .filter((metric) => metric.descriptor.name === metricName)
+      .flatMap((metric) => metric.dataPoints as Array<{
+        attributes: Record<string, unknown>;
+        value: number;
+      }>);
+
+    expect(points('dkg.sync.plane.started.total')).toHaveLength(2);
+    expect(points('dkg.sync.plane.terminal.total')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ attributes: expect.objectContaining({ plane: 'vm', outcome: 'success' }), value: 1 }),
+      expect.objectContaining({ attributes: expect.objectContaining({ plane: 'swm', outcome: 'timeout' }), value: 1 }),
+    ]));
+    expect(points('dkg.sync.plane.active').map((point) => point.value)).toEqual([0, 0]);
+    expect(logs).toHaveLength(2);
+    expect(logs[0]).toMatchObject({
+      eventCode: 'sync.plane.terminal',
+      syncPlane: 'vm',
+      outcome: 'success',
+      durationMs: 15_000,
+      triplesSynced: 42,
+    });
+    expect(logs[1]).toMatchObject({
+      syncPlane: 'swm',
+      outcome: 'timeout',
+      retryable: true,
+      errorCode: 'SYNC_PLANE_TIMEOUT',
+    });
+  });
+});

--- a/packages/node-ui/test/telemetry.test.ts
+++ b/packages/node-ui/test/telemetry.test.ts
@@ -227,6 +227,10 @@ describe('metrics — bounded, low-cardinality attributes only', () => {
     m.ackPeerTotal.add(1, { result: 'decline', decline_code: 'NO_DATA_IN_SWM' });
     m.ackQuorumTotal.add(1, { outcome: 'timeout', chain_id: 'base:8453' });
     m.syncRequestTotal.add(1, { outcome: 'ok', protocol_id: '/dkg/10.0.2/sync' });
+    m.syncPlaneStartedTotal.add(1, { plane: 'vm', trigger: 'subscription' });
+    m.syncPlaneTerminalTotal.add(1, { plane: 'vm', trigger: 'subscription', outcome: 'success' });
+    m.syncPlaneDurationMs.record(15_000, { plane: 'vm', trigger: 'subscription', outcome: 'success' });
+    m.syncPlaneActive.add(1, { plane: 'vm', trigger: 'subscription' });
     m.protocolSendTotal.add(1, { outcome: 'ok', protocol_id: '/dkg/10.0.2/sync' });
     m.protocolSendDuration.record(5, { protocol_id: '/dkg/10.0.2/sync' });
     m.processHeapUsedBytes.record(1024, { phase: 'durable_data', boundary: 'requester_phase_start' });
@@ -256,7 +260,7 @@ describe('metrics — bounded, low-cardinality attributes only', () => {
     const ALLOWED = new Set([
       'outcome', 'source', 'chain_id', 'rpc_method', 'retryable', 'result',
       'decline_code', 'protocol_id', 'method', 'module', 'role', 'reason', 'error_type',
-      'phase', 'boundary',
+      'phase', 'boundary', 'plane', 'trigger',
     ]);
     expect([...keys].filter((k) => !ALLOWED.has(k))).toEqual([]);
     // high-cardinality keys must never be metric labels

--- a/tools/observability/RUNBOOK.md
+++ b/tools/observability/RUNBOOK.md
@@ -27,7 +27,9 @@ channels): `example-alerts.md` (importable payloads: `alert-rules.provisioning.j
 - Severity is **structured metadata**: filter with `| severity_text=`ERROR``
   (values DEBUG/INFO/WARN/ERROR) or `detected_level`. There is no `level` label.
 - Other metadata available per line: `dkg_module`, `dkg_operation_id`,
-  `dkg_peer_id`, `dkg_chain`, `dkg_node_role` — filter the same way.
+  `dkg_peer_id`, `dkg_chain`, `dkg_node_role`, `dkg_event_code`,
+  `dkg_sync_plane`, `dkg_sync_trigger`, `dkg_outcome`, `dkg_duration_ms`, and
+  `dkg_triples_synced` — filter the same way.
 - `rpc_usage` accounting lines parse directly:
   `|= `rpc_usage` | logfmt | method != `` | unwrap count`.
 - **Loki 3 gotcha:** *instant* metric queries over ranges ≥ a few hours are
@@ -53,6 +55,32 @@ silent no-ops.
 > and metrics have no such mode switch and follow the resolved endpoint
 > directly. (The fleet's current nodes already ship logs, so they have this
 > set; this matters when provisioning new nodes from a template.)
+
+### Verified VM / SWM sync success contract
+
+Sync success is measured once per requested logical plane, after final
+verification. A transport response or a non-zero inserted-triple count does
+not count as success: partial progress followed by a timeout remains
+`timeout`, local admission pressure is `deferred`, ACL rejection is `denied`,
+and missing peers or authoritative graph metadata is `unreachable`. A clean
+empty response is successful only when the graph is public and authoritative
+metadata is present.
+
+The metrics dashboard uses:
+
+- `dkg_sync_plane_started_total{plane,trigger}` — accepted logical attempts;
+- `dkg_sync_plane_terminal_total{plane,trigger,outcome}` — exactly one final
+  outcome per started plane;
+- `dkg_sync_plane_duration_milliseconds` — start-to-terminal duration;
+- `dkg_sync_plane_active{plane,trigger}` — process-local in-flight attempts.
+
+The fleet/node log dashboards use terminal events with
+`dkg_event_code="sync.plane.terminal"` for outcome rates and drill-down. Do
+not alert on a bare success percentage until the fleet has a representative
+baseline. Any future rule must use a window longer than the configured sync
+timeout and require a minimum number of terminal samples; separately alert on
+a sustained started-vs-terminal gap or active attempts to expose abandoned
+work without treating an in-progress transfer as a failure.
 
 ---
 

--- a/tools/observability/grafana-dashboard-dkg-fleet-logs.json
+++ b/tools/observability/grafana-dashboard-dkg-fleet-logs.json
@@ -182,12 +182,124 @@
       ]
     },
     {
+      "title": "Verified VM / SWM sync",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "type": "row",
+      "collapsed": false
+    },
+    {
+      "title": "Verified sync success rate (terminal logs)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${loki}"
+      },
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${loki}"
+          },
+          "refId": "A",
+          "expr": "100 * sum(count_over_time({service_name=\"dkg-node\", deployment_environment=~\"${env:regex}\"} | dkg_event_code = `sync.plane.terminal` | dkg_sync_plane = `vm` | dkg_outcome = `success` [$__auto])) / sum(count_over_time({service_name=\"dkg-node\", deployment_environment=~\"${env:regex}\"} | dkg_event_code = `sync.plane.terminal` | dkg_sync_plane = `vm` [$__auto]))",
+          "legendFormat": "VM"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${loki}"
+          },
+          "refId": "B",
+          "expr": "100 * sum(count_over_time({service_name=\"dkg-node\", deployment_environment=~\"${env:regex}\"} | dkg_event_code = `sync.plane.terminal` | dkg_sync_plane = `swm` | dkg_outcome = `success` [$__auto])) / sum(count_over_time({service_name=\"dkg-node\", deployment_environment=~\"${env:regex}\"} | dkg_event_code = `sync.plane.terminal` | dkg_sync_plane = `swm` [$__auto]))",
+          "legendFormat": "SWM"
+        }
+      ]
+    },
+    {
+      "title": "Verified sync terminal outcomes (logs)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${loki}"
+      },
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${loki}"
+          },
+          "refId": "A",
+          "expr": "sum by (dkg_sync_plane, dkg_outcome) (count_over_time({service_name=\"dkg-node\", deployment_environment=~\"${env:regex}\"} | dkg_event_code = `sync.plane.terminal` [$__auto]))",
+          "legendFormat": "{{dkg_sync_plane}} {{dkg_outcome}}"
+        }
+      ]
+    },
+    {
+      "title": "Recent verified sync failures",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${loki}"
+      },
+      "type": "logs",
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true,
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${loki}"
+          },
+          "refId": "A",
+          "expr": "{service_name=\"dkg-node\", deployment_environment=~\"${env:regex}\"} | dkg_event_code = `sync.plane.terminal` | dkg_outcome != `success`"
+        }
+      ]
+    },
+    {
       "title": "RPC requests per node",
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 46
       },
       "datasource": {
         "type": "loki",
@@ -218,7 +330,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 46
       },
       "datasource": {
         "type": "loki",
@@ -249,7 +361,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 36
+        "y": 55
       },
       "datasource": {
         "type": "loki",
@@ -288,7 +400,7 @@
         "h": 7,
         "w": 18,
         "x": 6,
-        "y": 36
+        "y": 55
       },
       "datasource": {
         "type": "loki",

--- a/tools/observability/grafana-dashboard-dkg-node-logs.json
+++ b/tools/observability/grafana-dashboard-dkg-node-logs.json
@@ -204,6 +204,47 @@
           "expr": "sum(sum_over_time({service_name=\"dkg-node\", service_instance_id=\"$node\"} |= `rpc_usage` | logfmt | method != `` | unwrap count [$__auto]))"
         }
       ]
+    },
+    {
+      "title": "Verified VM / SWM sync",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "type": "row",
+      "collapsed": false
+    },
+    {
+      "title": "Sync terminal failures — $node",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${loki}"
+      },
+      "type": "logs",
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true,
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${loki}"
+          },
+          "refId": "A",
+          "expr": "{service_name=\"dkg-node\", service_instance_id=\"$node\"} | dkg_event_code = `sync.plane.terminal` | dkg_outcome != `success`"
+        }
+      ]
     }
   ]
 }

--- a/tools/observability/grafana-dashboard-dkg-node-metrics.json
+++ b/tools/observability/grafana-dashboard-dkg-node-metrics.json
@@ -517,7 +517,7 @@
       ]
     },
     {
-      "title": "Pipeline health (collector — live now)",
+      "title": "Verified VM / SWM sync lifecycle",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -528,12 +528,196 @@
       "collapsed": false
     },
     {
-      "title": "Collector log records/s: accepted vs exported",
+      "title": "Verified sync success rate",
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
         "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${vm}"
+      },
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${vm}"
+          },
+          "refId": "A",
+          "expr": "100 * sum by (plane) (rate(dkg_sync_plane_terminal_total{outcome=\"success\", instance=~\"${node:regex}\"}[$__rate_interval])) / sum by (plane) (rate(dkg_sync_plane_terminal_total{instance=~\"${node:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{plane}}"
+        }
+      ]
+    },
+    {
+      "title": "Sync attempts: started vs terminal",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${vm}"
+      },
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${vm}"
+          },
+          "refId": "A",
+          "expr": "sum by (plane) (rate(dkg_sync_plane_started_total{instance=~\"${node:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{plane}} started"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${vm}"
+          },
+          "refId": "B",
+          "expr": "sum by (plane) (rate(dkg_sync_plane_terminal_total{instance=~\"${node:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{plane}} terminal"
+        }
+      ]
+    },
+    {
+      "title": "Active logical sync planes",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${vm}"
+      },
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${vm}"
+          },
+          "refId": "A",
+          "expr": "sum by (plane) (dkg_sync_plane_active{instance=~\"${node:regex}\"})",
+          "legendFormat": "{{plane}}"
+        }
+      ]
+    },
+    {
+      "title": "Sync terminal outcomes by plane",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${vm}"
+      },
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${vm}"
+          },
+          "refId": "A",
+          "expr": "sum by (plane, outcome) (rate(dkg_sync_plane_terminal_total{instance=~\"${node:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{plane}} {{outcome}}"
+        }
+      ]
+    },
+    {
+      "title": "Sync duration p50/p95 by plane",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${vm}"
+      },
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${vm}"
+          },
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, plane) (rate({__name__=~\"dkg_sync_plane_duration(_milliseconds)?_bucket\", outcome=\"success\", instance=~\"${node:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{plane}} p95 success"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${vm}"
+          },
+          "refId": "B",
+          "expr": "histogram_quantile(0.50, sum by (le, plane) (rate({__name__=~\"dkg_sync_plane_duration(_milliseconds)?_bucket\", outcome=\"success\", instance=~\"${node:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{plane}} p50 success"
+        }
+      ]
+    },
+    {
+      "title": "Pipeline health (collector — live now)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "type": "row",
+      "collapsed": false
+    },
+    {
+      "title": "Collector log records/s: accepted vs exported",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 64
       },
       "datasource": {
         "type": "prometheus",
@@ -582,7 +766,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 47
+        "y": 64
       },
       "datasource": {
         "type": "prometheus",
@@ -622,7 +806,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 47
+        "y": 64
       },
       "datasource": {
         "type": "prometheus",

--- a/tools/observability/lib/dashboards.mjs
+++ b/tools/observability/lib/dashboards.mjs
@@ -69,6 +69,8 @@ const LOGSP = (w, h, title, expr) => ({ w, h, def: { datasource: LOKI, type: 'lo
 const TEXT = (content) => ({ w: 24, h: 3, def: { type: 'text', title: '', options: { mode: 'markdown', content }, transparent: true } });
 const ROW = (title) => ({ w: 24, h: 1, def: { type: 'row', title, collapsed: false } });
 
+const SYNC_TERMINAL = ' | dkg_event_code = `sync.plane.terminal`';
+
 // Loki query building blocks come from the shared contract (lib/queries.mjs)
 // — the same module alerts.mjs composes from, so the stream selector,
 // severity filter shape and rpc_usage pipeline cannot drift between the
@@ -92,6 +94,24 @@ const buildFleetLogsDashboard = () => ({
     ],
     [ TS(24, 8, LOKI, 'Errors per node', [{ expr: `sum by (service_instance_id) (count_over_time(${FE}${severityIs('ERROR')} [$__auto]))`, legend: '{{service_instance_id}}' }]) ],
     [ LOGSP(24, 10, 'Recent errors (all nodes)', `${FE}${severityIs('ERROR')}`) ],
+    [ ROW('Verified VM / SWM sync') ],
+    [
+      TS(12, 8, LOKI, 'Verified sync success rate (terminal logs)', [
+        {
+          expr: `100 * sum(count_over_time(${FE}${SYNC_TERMINAL} | dkg_sync_plane = \`vm\` | dkg_outcome = \`success\` [$__auto])) / sum(count_over_time(${FE}${SYNC_TERMINAL} | dkg_sync_plane = \`vm\` [$__auto]))`,
+          legend: 'VM',
+        },
+        {
+          expr: `100 * sum(count_over_time(${FE}${SYNC_TERMINAL} | dkg_sync_plane = \`swm\` | dkg_outcome = \`success\` [$__auto])) / sum(count_over_time(${FE}${SYNC_TERMINAL} | dkg_sync_plane = \`swm\` [$__auto]))`,
+          legend: 'SWM',
+        },
+      ], 'percent'),
+      TS(12, 8, LOKI, 'Verified sync terminal outcomes (logs)', [{
+        expr: `sum by (dkg_sync_plane, dkg_outcome) (count_over_time(${FE}${SYNC_TERMINAL} [$__auto]))`,
+        legend: '{{dkg_sync_plane}} {{dkg_outcome}}',
+      }], 'short'),
+    ],
+    [ LOGSP(24, 10, 'Recent verified sync failures', `${FE}${SYNC_TERMINAL} | dkg_outcome != \`success\``) ],
     [
       TS(12, 9, LOKI, 'RPC requests per node', [{ expr: `sum by (service_instance_id) (sum_over_time(${FE}${RPCPIPE}[$__auto]))`, legend: '{{service_instance_id}}' }]),
       TS(12, 9, LOKI, 'RPC requests by method (fleet)', [{ expr: `sum by (method) (sum_over_time(${FE}${RPCPIPE}[$__auto]))`, legend: '{{method}}' }]),
@@ -131,6 +151,8 @@ const buildNodeLogsDashboard = (NODE_IDENTITY) => ({
         options: { reduceOptions: { calcs: ['sum'], fields: '', values: false } },
         targets: [{ datasource: LOKI, refId: 'A', expr: `sum(sum_over_time(${NB}${RPCPIPE}[$__auto]))` }] } },
     ],
+    [ ROW('Verified VM / SWM sync') ],
+    [ LOGSP(24, 10, 'Sync terminal failures — $node', `${NB}${SYNC_TERMINAL} | dkg_outcome != \`success\``) ],
   ]),
 });
 
@@ -185,6 +207,31 @@ const buildMetricsDashboard = (nodeProfile, NODE_IDENTITY) => {
         { expr: `sum by (outcome) (rate(dkg_protocol_router_send_total{${SEL}}${R}))`, legend: 'send: {{outcome}}' },
         { expr: `histogram_quantile(0.95, sum by (le, protocol_id) (rate({__name__=~"dkg_protocol_router_send_duration(_milliseconds)?_bucket", ${SEL}}${R})))`, legend: 'p95 {{protocol_id}}' },
       ]),
+    ],
+    [ ROW('Verified VM / SWM sync lifecycle') ],
+    [
+      TS(8, 8, VM, 'Verified sync success rate', [{
+        expr: `100 * sum by (plane) (rate(dkg_sync_plane_terminal_total{outcome="success", ${SEL}}${R})) / sum by (plane) (rate(dkg_sync_plane_terminal_total{${SEL}}${R}))`,
+        legend: '{{plane}}',
+      }], 'percent'),
+      TS(8, 8, VM, 'Sync attempts: started vs terminal', [
+        { expr: `sum by (plane) (rate(dkg_sync_plane_started_total{${SEL}}${R}))`, legend: '{{plane}} started' },
+        { expr: `sum by (plane) (rate(dkg_sync_plane_terminal_total{${SEL}}${R}))`, legend: '{{plane}} terminal' },
+      ], 'ops'),
+      TS(8, 8, VM, 'Active logical sync planes', [{
+        expr: `sum by (plane) (dkg_sync_plane_active{${SEL}})`,
+        legend: '{{plane}}',
+      }], 'short'),
+    ],
+    [
+      TS(12, 8, VM, 'Sync terminal outcomes by plane', [{
+        expr: `sum by (plane, outcome) (rate(dkg_sync_plane_terminal_total{${SEL}}${R}))`,
+        legend: '{{plane}} {{outcome}}',
+      }], 'ops'),
+      TS(12, 8, VM, 'Sync duration p50/p95 by plane', [
+        { expr: `histogram_quantile(0.95, sum by (le, plane) (rate({__name__=~"dkg_sync_plane_duration(_milliseconds)?_bucket", outcome="success", ${SEL}}${R})))`, legend: '{{plane}} p95 success' },
+        { expr: `histogram_quantile(0.50, sum by (le, plane) (rate({__name__=~"dkg_sync_plane_duration(_milliseconds)?_bucket", outcome="success", ${SEL}}${R})))`, legend: '{{plane}} p50 success' },
+      ], 'ms'),
     ],
     [ ROW('Pipeline health (collector — live now)') ],
     [


### PR DESCRIPTION
## What changed

- add a shared per-plane VM/SWM sync attempt observer with exactly-once terminal outcomes
- classify successful syncs only from authoritative, current-run verification evidence
- emit structured terminal logs and native counters, duration histograms, and active-attempt metrics
- instrument daemon subscription catch-up, agent background catch-up, and post-approval catch-up
- add fleet, node, and metrics dashboard panels for success rate, outcomes, durations, active attempts, and failure drilldowns
- document the verified sync outcome contract and safe alerting requirements

## Why

Publish telemetry does not show whether a receiver actually completed VM or SWM synchronization. This adds an explicit lifecycle for each logical sync plane so queued, deferred, failed, or stale results cannot be counted as successful synchronization.

## Impact

After deployment, Grafana can show verified VM and SWM success rates independently, including mixed outcomes such as VM success with SWM deferred. Existing sync behavior is unchanged; this PR adds observation and classification around the current flows.

No alert rule is enabled yet. A reliable alert requires real post-deployment samples, a minimum terminal sample count, and an evaluation window longer than the configured sync timeout.

## Validation

- 129 focused sync-observability tests passed
- core full suite: 1,587 passed
- node-ui full suite: 2,182 passed, 38 skipped
- full workspace build passed
- generated dashboard consistency check passed
- git diff whitespace check passed