### PR TITLE
RFC-64 M1 3/7: bound Core public CG coverage

### DIFF
--- a/packages/agent/src/context-graph-subscription-policy.ts
+++ b/packages/agent/src/context-graph-subscription-policy.ts
@@ -4,13 +4,14 @@ import type {
   ContextGraphSyncAdmission,
   ContextGraphSubscriptionRecord,
   ContextGraphSyncMode,
+  NormalizedContextGraphSub,
 } from './dkg-agent-types.js';
 
 export function normalizeLegacyContextGraphSubscriptionInput(
   previous: ContextGraphSub | undefined,
   next: ContextGraphSubInput,
   defaultAdmission: ContextGraphSyncAdmission = 'none',
-): ContextGraphSub {
+): NormalizedContextGraphSub {
   return {
     ...next,
     syncMode: next.syncMode ?? previous?.syncMode ?? 'always-on',
@@ -50,7 +51,7 @@ export type ContextGraphSubscriptionPersistenceProjection =
  */
 export function projectContextGraphSubscriptionPersistence(input: {
   contextGraphId: string;
-  subscription: ContextGraphSub | undefined;
+  subscription: NormalizedContextGraphSub | undefined;
   /** Optional legacy-call override; current callers persist the live admission. */
   syncScoped?: boolean;
 }): ContextGraphSubscriptionPersistenceProjection {

--- a/packages/agent/src/context-graph-subscription-policy.ts
+++ b/packages/agent/src/context-graph-subscription-policy.ts
@@ -1,6 +1,7 @@
 import type {
   ContextGraphSub,
   ContextGraphSubInput,
+  ContextGraphSyncAdmission,
   ContextGraphSubscriptionRecord,
   ContextGraphSyncMode,
 } from './dkg-agent-types.js';
@@ -8,10 +9,12 @@ import type {
 export function normalizeLegacyContextGraphSubscriptionInput(
   previous: ContextGraphSub | undefined,
   next: ContextGraphSubInput,
+  defaultAdmission: ContextGraphSyncAdmission = 'none',
 ): ContextGraphSub {
   return {
     ...next,
     syncMode: next.syncMode ?? previous?.syncMode ?? 'always-on',
+    syncAdmission: next.syncAdmission ?? previous?.syncAdmission ?? defaultAdmission,
   };
 }
 
@@ -48,7 +51,8 @@ export type ContextGraphSubscriptionPersistenceProjection =
 export function projectContextGraphSubscriptionPersistence(input: {
   contextGraphId: string;
   subscription: ContextGraphSub | undefined;
-  syncScoped: boolean;
+  /** Optional legacy-call override; current callers persist the live admission. */
+  syncScoped?: boolean;
 }): ContextGraphSubscriptionPersistenceProjection {
   const sub = input.subscription;
   if (sub?.syncMode === 'on-demand' && sub.coreHosted !== true) {
@@ -59,6 +63,11 @@ export function projectContextGraphSubscriptionPersistence(input: {
   }
 
   const persistMemberIntent = sub.syncMode !== 'on-demand';
+  const syncAdmission = persistMemberIntent
+    ? input.syncScoped === undefined
+      ? sub.syncAdmission
+      : input.syncScoped ? 'explicit' : 'none'
+    : 'none';
   return {
     action: 'save',
     persistMemberIntent,
@@ -73,7 +82,9 @@ export function projectContextGraphSubscriptionPersistence(input: {
       onChainHash: sub.onChainHash,
       lastReconciledOrdinal: sub.lastReconciledOrdinal,
       coreHosted: sub.coreHosted,
-      syncScoped: persistMemberIntent && input.syncScoped,
+      syncAdmission,
+      // Keep the legacy compatibility bit derived from the canonical lane.
+      syncScoped: syncAdmission === 'explicit',
     },
   };
 }

--- a/packages/agent/src/context-graph-subscription-policy.ts
+++ b/packages/agent/src/context-graph-subscription-policy.ts
@@ -52,6 +52,8 @@ export type ContextGraphSubscriptionPersistenceProjection =
 export function projectContextGraphSubscriptionPersistence(input: {
   contextGraphId: string;
   subscription: NormalizedContextGraphSub | undefined;
+  /** Durable baseline retained when current config overlays a different live admission. */
+  durableSyncAdmission?: ContextGraphSyncAdmission;
   /** Optional legacy-call override; current callers persist the live admission. */
   syncScoped?: boolean;
 }): ContextGraphSubscriptionPersistenceProjection {
@@ -65,9 +67,10 @@ export function projectContextGraphSubscriptionPersistence(input: {
 
   const persistMemberIntent = sub.syncMode !== 'on-demand';
   const syncAdmission = persistMemberIntent
-    ? input.syncScoped === undefined
-      ? sub.syncAdmission
-      : input.syncScoped ? 'explicit' : 'none'
+    ? input.durableSyncAdmission
+      ?? (input.syncScoped === undefined
+        ? sub.syncAdmission
+        : input.syncScoped ? 'explicit' : 'none')
     : 'none';
   return {
     action: 'save',

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -159,6 +159,11 @@ import {
   type SignedAgentDelegation,
 } from './auth/agent-delegation.js';
 import { SyncVerifyWorker } from './sync-verify-worker.js';
+import {
+  CorePublicSyncCoverageScheduler,
+  resolveCorePublicSyncBatchSize,
+  type CorePublicSyncCoverageStatus,
+} from './sync/core-public-coverage-scheduler.js';
 import { bindRandomSampling, type RandomSamplingDisabledReason, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
@@ -1034,6 +1039,12 @@ export class DKGAgentBase {
   // chain — which would risk a duplicate profile / double-stake.
   protected profileProvisioningInFlight = false;
   protected readonly config: ResolvedDKGAgentConfig;
+  /**
+   * Core-only bounded admission for automatically discovered public CGs.
+   * Explicit user-selected CGs stay in config.syncContextGraphs and are never
+   * capped by this scheduler; Edge nodes never register automatic coverage.
+   */
+  protected readonly corePublicSyncCoverageScheduler: CorePublicSyncCoverageScheduler;
   protected started = false;
   /**
    * One OT-RFC-64 persistence owner for the inventory lease and every resource
@@ -1595,6 +1606,9 @@ export class DKGAgentBase {
     publicSnapshotStore?: WorkspacePublicSnapshotStore,
   ) {
     this.config = config;
+    this.corePublicSyncCoverageScheduler = new CorePublicSyncCoverageScheduler(
+      resolveCorePublicSyncBatchSize(config.syncCorePublicBatchSize),
+    );
     this.wallet = wallet;
     this.node = node;
     this.store = store;
@@ -1625,6 +1639,39 @@ export class DKGAgentBase {
     this.publisher.setWorkspaceSenderKeyEncryptor((input) => (this as unknown as DKGAgent).encryptWorkspacePayloadWithSenderKey(input));
     this.syncCheckpoints = config.syncCheckpointStore ?? this.syncCheckpoints;
     this.changelogCursors = config.changelogCursorStore ?? this.changelogCursors;
+  }
+
+  protected registerCorePublicSyncContextGraph(contextGraphId: string): boolean {
+    if ((this.config.nodeRole ?? 'edge') !== 'core') return false;
+    return this.corePublicSyncCoverageScheduler.register(contextGraphId);
+  }
+
+  protected unregisterCorePublicSyncContextGraph(contextGraphId: string): boolean {
+    return this.corePublicSyncCoverageScheduler.unregister(contextGraphId);
+  }
+
+  protected releaseCorePublicSyncPlanningLane(remotePeer: string): boolean {
+    return this.corePublicSyncCoverageScheduler.releasePlanningLane(remotePeer);
+  }
+
+  /**
+   * Produce the automatic tail for one Core peer round. The caller merges it
+   * with the live explicit scope so newly restored selections stay visible.
+   */
+  protected planAutomaticCorePublicSyncContextGraphsForPeerRound(remotePeer: string): string[] {
+    const selected = this.config.syncContextGraphs ?? [];
+    if ((this.config.nodeRole ?? 'edge') !== 'core') return [];
+    return this.corePublicSyncCoverageScheduler.plan(
+      selected,
+      this.config.syncContextGraphPriorities,
+      remotePeer,
+    ).coverageContextGraphIds;
+  }
+
+  getCorePublicSyncCoverageStatus(): CorePublicSyncCoverageStatus {
+    return this.corePublicSyncCoverageScheduler.getStatus(
+      (this.config.nodeRole ?? 'edge') === 'core',
+    );
   }
 
   /**

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -363,6 +363,7 @@ import {
   type PeerDiagnostics,
   type ChatSendResult,
   type ContextGraphSub,
+  type ContextGraphSyncAdmission,
   type ContextGraphSubscriptionRecord,
   type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
@@ -416,6 +417,19 @@ import { ContextGraphMetaProjection } from './context-graph-meta-projection.js';
 import { ContextGraphJoinAdmissionLockManager } from './context-graph-join-admission-lock.js';
 import { ContextGraphMembershipMutationStore } from './context-graph-membership-mutation.js';
 import type { DKGAgent } from './dkg-agent.js';
+
+type ContextGraphDiscoveryDisposition =
+  | 'catalogue-only'
+  | 'core-hosting-only'
+  | 'explicit-sync-scope'
+  | 'automatic-public-coverage';
+
+/** Internal peer-round policy: initial durable scope is frozen; later explicit intent is live. */
+interface PeerSyncScope {
+  readonly automaticContextGraphIds: readonly string[];
+  readonly initialDurableContextGraphIds: readonly string[];
+  contextGraphIdsAfterDiscovery(): string[];
+}
 
 function readNonNegativeNumberEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -1650,22 +1664,73 @@ export class DKGAgentBase {
     return this.corePublicSyncCoverageScheduler.unregister(contextGraphId);
   }
 
-  protected releaseCorePublicSyncPlanningLane(remotePeer: string): boolean {
-    return this.corePublicSyncCoverageScheduler.releasePlanningLane(remotePeer);
+  protected classifyContextGraphDiscovery(input: {
+    accessPolicy?: 'public' | 'private';
+    legacyPrivate?: boolean;
+    trackSyncScope?: boolean;
+  }): ContextGraphDiscoveryDisposition {
+    if ((this.config.nodeRole ?? 'edge') !== 'core') return 'catalogue-only';
+    if (input.trackSyncScope === false) return 'core-hosting-only';
+    if (input.trackSyncScope === true) return 'explicit-sync-scope';
+    if (input.accessPolicy === 'private' || input.legacyPrivate === true) {
+      return 'explicit-sync-scope';
+    }
+    if (input.accessPolicy === 'public') return 'automatic-public-coverage';
+    return 'core-hosting-only';
   }
 
-  /**
-   * Produce the automatic tail for one Core peer round. The caller merges it
-   * with the live explicit scope so newly restored selections stay visible.
-   */
-  protected planAutomaticCorePublicSyncContextGraphsForPeerRound(remotePeer: string): string[] {
-    const selected = this.config.syncContextGraphs ?? [];
-    if ((this.config.nodeRole ?? 'edge') !== 'core') return [];
-    return this.corePublicSyncCoverageScheduler.plan(
-      selected,
-      this.config.syncContextGraphPriorities,
-      remotePeer,
-    ).coverageContextGraphIds;
+  protected reconcileContextGraphSyncAdmission(
+    contextGraphId: string,
+    input: { subscribed: boolean; admission: ContextGraphSyncAdmission },
+  ): boolean {
+    const admission = input.subscribed ? input.admission : 'none';
+    const explicitScope = new Set(this.config.syncContextGraphs ?? []);
+    const hadExplicitScope = explicitScope.has(contextGraphId);
+    const isSystemContextGraph = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[])
+      .includes(contextGraphId);
+    if (admission === 'explicit' && !isSystemContextGraph) {
+      explicitScope.add(contextGraphId);
+    } else {
+      explicitScope.delete(contextGraphId);
+    }
+    const hasExplicitScope = explicitScope.has(contextGraphId);
+    if (hadExplicitScope !== hasExplicitScope) {
+      this.config.syncContextGraphs = [...explicitScope];
+    }
+
+    const schedulerChanged = admission === 'automatic-public'
+      ? this.registerCorePublicSyncContextGraph(contextGraphId)
+      : this.unregisterCorePublicSyncContextGraph(contextGraphId);
+    const existing = this.subscribedContextGraphs.get(contextGraphId);
+    const stateChanged = !!existing && existing.syncAdmission !== admission;
+    if (stateChanged && existing) {
+      this.subscribedContextGraphs.set(contextGraphId, { ...existing, syncAdmission: admission });
+    }
+    return hadExplicitScope !== hasExplicitScope || schedulerChanged || stateChanged;
+  }
+
+  /** Build one canonical peer-round scope with named snapshot/live phases. */
+  protected planCorePublicSyncPeerRound(remotePeer: string): PeerSyncScope {
+    const selected = [...(this.config.syncContextGraphs ?? [])];
+    const automaticContextGraphIds = (this.config.nodeRole ?? 'edge') === 'core'
+      ? this.corePublicSyncCoverageScheduler.planAutomaticCoverage(
+        selected,
+        this.config.syncContextGraphPriorities,
+        remotePeer,
+      )
+      : [];
+    const initialDurableContextGraphIds = [...new Set([
+      ...selected,
+      ...automaticContextGraphIds,
+    ])];
+    return {
+      automaticContextGraphIds,
+      initialDurableContextGraphIds,
+      contextGraphIdsAfterDiscovery: () => [...new Set([
+        ...(this.config.syncContextGraphs ?? []),
+        ...automaticContextGraphIds,
+      ])],
+    };
   }
 
   getCorePublicSyncCoverageStatus(): CorePublicSyncCoverageStatus {

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1085,6 +1085,9 @@ export class DKGAgentBase {
   protected readonly subscribedContextGraphs = new Map<string, NormalizedContextGraphSub>();
   protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
   protected readonly contextGraphSubscriptionRehydrationAccountedIds = new Set<string>();
+  /** Persisted admission hidden by a live-only configured explicit overlay. */
+  protected readonly contextGraphSubscriptionDurableAdmissionOverrides =
+    new Map<string, ContextGraphSyncAdmission>();
   protected readonly contextGraphSubscriptionPersistRevisions = new Map<string, number>();
   protected readonly contextGraphSubscriptionPersistAppliedRevisions = new Map<string, number>();
   protected readonly contextGraphSubscriptionPersistCanceledRevisions = new Map<string, number>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -363,6 +363,7 @@ import {
   type PeerDiagnostics,
   type ChatSendResult,
   type ContextGraphSub,
+  type NormalizedContextGraphSub,
   type ContextGraphSyncAdmission,
   type ContextGraphSubscriptionRecord,
   type ContextGraphSubscriptionRehydrationStatus,
@@ -1081,7 +1082,7 @@ export class DKGAgentBase {
     new Rfc64PublicCatalogReconciliationFailureRegistryV1();
   /** Serialize local author-head construction/CAS independently per exact scope. */
   protected readonly rfc64AuthorCatalogMutationQueuesV1 = new Map<string, Promise<void>>();
-  protected readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
+  protected readonly subscribedContextGraphs = new Map<string, NormalizedContextGraphSub>();
   protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
   protected readonly contextGraphSubscriptionRehydrationAccountedIds = new Set<string>();
   protected readonly contextGraphSubscriptionPersistRevisions = new Map<string, number>();

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3608,6 +3608,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   clearNetworkRejectedPeerState(this: DKGAgent, remotePeer: string): void {
+    this.releaseCorePublicSyncPlanningLane(remotePeer);
     this.knownCorePeerIds.delete(remotePeer);
     this.knownCorePeerIdsV2.delete(remotePeer);
     this.skippedNoSyncPeers.delete(remotePeer);
@@ -3753,13 +3754,25 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!this.networkAdmissionCoordinator.isAcceptedPeer(remotePeer)) {
       return 'not-started';
     }
+    let plannedAutomaticContextGraphIds: string[] | undefined;
+    const getPlannedContextGraphIds = (): string[] => {
+      plannedAutomaticContextGraphIds ??=
+        this.planAutomaticCorePublicSyncContextGraphsForPeerRound(remotePeer);
+      // Discovery can restore an explicit/private subscription during this
+      // same connect cycle. Keep selected scope live while freezing only the
+      // automatic Core tail so both planes use one bounded coverage batch.
+      return [...new Set([
+        ...(this.config.syncContextGraphs ?? []),
+        ...plannedAutomaticContextGraphIds,
+      ])];
+    };
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
     const getSharedMemorySyncPlan = (peerId: string): Promise<SharedMemorySyncContextGraphPlan> => {
       let plan = sharedMemorySyncPlans.get(peerId);
       if (!plan) {
         plan = this.planSharedMemorySyncContextGraphs(
           peerId,
-          this.config.syncContextGraphs ?? [],
+          getPlannedContextGraphIds(),
           createOperationContext('sync'),
         );
         sharedMemorySyncPlans.set(peerId, plan);
@@ -3772,11 +3785,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
       knownCorePeerIds: this.knownCorePeerIds,
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
-      getSyncContextGraphs: () => this.config.syncContextGraphs ?? [],
+      getSyncContextGraphs: getPlannedContextGraphIds,
       getSharedMemorySyncContextGraphs: async (peerId) => (await getSharedMemorySyncPlan(peerId)).eligibleContextGraphIds,
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
         peerId,
-        contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...(this.config.syncContextGraphs ?? [])],
+        contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...getPlannedContextGraphIds()],
         undefined,
         undefined,
         undefined,
@@ -4089,6 +4102,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     for (const [peerId, ts] of this.lastSyncDisconnectedAt) {
       if (now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
         this.lastSyncDisconnectedAt.delete(peerId);
+        this.releaseCorePublicSyncPlanningLane(peerId);
       }
     }
     for (const [peerId, ts] of this.lastSuccessfulSyncAt) {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -7155,6 +7155,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const systemContextGraphs = new Set<string>(Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]);
       const persistedRows = await store.loadAll();
       const rows = persistedRows.filter((r) => !systemContextGraphs.has(r.id));
+      // Snapshot operator intent before rehydration mutates the live scope.
+      // Legacy rows only persisted `syncScoped`, which cannot distinguish an
+      // explicit selection from a public CG automatically discovered by an
+      // older Core. The configured list is the deterministic explicit source;
+      // persisted-only public rows migrate into bounded automatic coverage.
+      const configuredExplicitSyncContextGraphs = new Set(
+        (this.config.syncContextGraphs ?? []).map((id) => id.trim()).filter(Boolean),
+      );
 
       // `pendingMeta` and the agent chosen for the first authenticated sync
       // are deliberately in-memory state. Recover both from the durable
@@ -7280,13 +7288,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             .some((address) => address.toLowerCase() === approvedAgentAddress)
           : false;
         const restorePendingMeta = hasJoinApproval && !approvedAgentAuthorized;
+        const isLegacySyncAdmission = row.syncAdmission === undefined;
+        const isConfiguredExplicit = configuredExplicitSyncContextGraphs.has(row.id);
         let syncAdmission = row.syncAdmission
-          ?? (row.syncScoped ? 'explicit' : 'none');
+          ?? (isConfiguredExplicit ? 'explicit' : row.syncScoped ? 'explicit' : 'none');
         if (
-          row.syncAdmission === undefined
+          isLegacySyncAdmission
+          && !isConfiguredExplicit
           && (this.config.nodeRole ?? 'edge') === 'core'
           && row.subscribed
-          && !row.syncScoped
           && row.onChainId
         ) {
           const accessPolicy = await this.getExplicitAccessPolicy(row.id);
@@ -7326,6 +7336,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             subscribed: false,
             admission: 'none',
           });
+        }
+        // Complete the V31 -> V32 semantic migration through the existing
+        // nullable schema column. Once written, later restarts use the
+        // canonical admission directly and never reinterpret `syncScoped`.
+        if (isLegacySyncAdmission && row.subscribed) {
+          await this.persistContextGraphSubscriptionStrict(row.id);
         }
         // Upgrade/self-heal path for late private-CG members whose payload and
         // authenticated `_meta` already completed before registration binding

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -280,7 +280,7 @@ import {
   registerSyncHandler,
   resolveSyncResponderSnapshotPolicy,
 } from './sync/responder/sync-handler.js';
-import { runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
+import { runSyncOnConnectWithScopePlan, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
 import { mapWithConcurrency } from './map-with-concurrency.js';
 import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
 import {
@@ -457,6 +457,7 @@ import {
   type PeerDiagnostics,
   type ChatSendResult,
   type ContextGraphSub,
+  type ContextGraphSubInput,
   type ContextGraphSubscriptionRecord,
   type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
@@ -474,7 +475,10 @@ import {
   type SyncReconcilerProbe,
   type SyncReconcilerBackoff,
 } from './dkg-agent-types.js';
-import { projectContextGraphSubscriptionPersistence } from './context-graph-subscription-policy.js';
+import {
+  normalizeLegacyContextGraphSubscriptionInput,
+  projectContextGraphSubscriptionPersistence,
+} from './context-graph-subscription-policy.js';
 import {
   authoritativeSyncPeerId,
   resolveCuratorSyncPeer,
@@ -2677,6 +2681,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             const approvedSubscription: ContextGraphSub = {
               ...this.subscribedContextGraphs.get(contextGraphId),
               syncMode: 'always-on',
+              syncAdmission: 'explicit',
               subscribed: true,
               pendingMeta: true,
               metaSynced: false,
@@ -3608,7 +3613,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   clearNetworkRejectedPeerState(this: DKGAgent, remotePeer: string): void {
-    this.releaseCorePublicSyncPlanningLane(remotePeer);
     this.knownCorePeerIds.delete(remotePeer);
     this.knownCorePeerIdsV2.delete(remotePeer);
     this.skippedNoSyncPeers.delete(remotePeer);
@@ -3754,42 +3758,34 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!this.networkAdmissionCoordinator.isAcceptedPeer(remotePeer)) {
       return 'not-started';
     }
-    let plannedAutomaticContextGraphIds: string[] | undefined;
-    const getPlannedContextGraphIds = (): string[] => {
-      plannedAutomaticContextGraphIds ??=
-        this.planAutomaticCorePublicSyncContextGraphsForPeerRound(remotePeer);
-      // Discovery can restore an explicit/private subscription during this
-      // same connect cycle. Keep selected scope live while freezing only the
-      // automatic Core tail so both planes use one bounded coverage batch.
-      return [...new Set([
-        ...(this.config.syncContextGraphs ?? []),
-        ...plannedAutomaticContextGraphIds,
-      ])];
-    };
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
-    const getSharedMemorySyncPlan = (peerId: string): Promise<SharedMemorySyncContextGraphPlan> => {
+    const getSharedMemorySyncPlan = (
+      peerId: string,
+      contextGraphIdsAfterDiscovery: readonly string[],
+    ): Promise<SharedMemorySyncContextGraphPlan> => {
       let plan = sharedMemorySyncPlans.get(peerId);
       if (!plan) {
         plan = this.planSharedMemorySyncContextGraphs(
           peerId,
-          getPlannedContextGraphIds(),
+          [...contextGraphIdsAfterDiscovery],
           createOperationContext('sync'),
         );
         sharedMemorySyncPlans.set(peerId, plan);
       }
       return plan;
     };
-    return runSyncOnConnect({
+    return runSyncOnConnectWithScopePlan({
       remotePeer,
       syncingPeers: this.syncingPeers,
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
       knownCorePeerIds: this.knownCorePeerIds,
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
-      getSyncContextGraphs: getPlannedContextGraphIds,
-      getSharedMemorySyncContextGraphs: async (peerId) => (await getSharedMemorySyncPlan(peerId)).eligibleContextGraphIds,
+      createScopePlan: () => this.planCorePublicSyncPeerRound(remotePeer),
+      getSharedMemorySyncContextGraphs: async (peerId, contextGraphIdsAfterDiscovery) =>
+        (await getSharedMemorySyncPlan(peerId, contextGraphIdsAfterDiscovery)).eligibleContextGraphIds,
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
         peerId,
-        contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...getPlannedContextGraphIds()],
+        contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
         undefined,
         undefined,
         undefined,
@@ -3800,7 +3796,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, {
         stopOnBackoffWorthyFailure: true,
         source,
-        sharedMemorySyncPlan: await getSharedMemorySyncPlan(peerId),
+        sharedMemorySyncPlan: await getSharedMemorySyncPlan(peerId, contextGraphIds),
       }),
       syncSharedMemoryOnConnect: syncOnConnectEnabled(this.config) && (this.config.syncSharedMemoryOnConnect ?? true),
       logInfo: (ctx, message) => this.log.info(ctx, message),
@@ -4102,7 +4098,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     for (const [peerId, ts] of this.lastSyncDisconnectedAt) {
       if (now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
         this.lastSyncDisconnectedAt.delete(peerId);
-        this.releaseCorePublicSyncPlanningLane(peerId);
       }
     }
     for (const [peerId, ts] of this.lastSuccessfulSyncAt) {
@@ -6514,7 +6509,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
   setContextGraphSubscription(this: DKGAgent,
     contextGraphId: string,
-    next: ContextGraphSub,
+    next: ContextGraphSubInput,
     options?: { persist?: boolean; updateRehydrationStatus?: boolean },
   ): ContextGraphSub {
     this.invalidateListContextGraphsCache();
@@ -6530,8 +6525,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ? this.contextGraphWireId(next.onChainHash)
       : undefined;
     const nextWireId = nextOnChainHash ?? localWireId;
+    const normalizedNext = normalizeLegacyContextGraphSubscriptionInput(
+      previous,
+      next,
+      (this.config.syncContextGraphs ?? []).includes(contextGraphId) ? 'explicit' : 'none',
+    );
     const canonicalNext: ContextGraphSub = {
-      ...next,
+      ...normalizedNext,
       ...(next.onChainHash === nextOnChainHash ? {} : { onChainHash: nextOnChainHash }),
     };
     if (
@@ -6552,7 +6552,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const persistence = projectContextGraphSubscriptionPersistence({
       contextGraphId,
       subscription: canonicalNext,
-      syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
     });
     if (options?.persist !== false && persistence.action !== 'skip') {
       if (this.config.contextGraphSubscriptionStore) {
@@ -6793,7 +6792,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const persistence = projectContextGraphSubscriptionPersistence({
       contextGraphId,
       subscription: sub,
-      syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
     });
     if (persistence.action === 'skip') {
       // Some lifecycle paths persist reconciliation watermarks directly
@@ -6868,7 +6866,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const persistence = projectContextGraphSubscriptionPersistence({
       contextGraphId,
       subscription: sub,
-      syncScoped: syncScoped ?? (this.config.syncContextGraphs ?? []).includes(contextGraphId),
+      syncScoped,
     });
     if (persistence.action !== 'save' || !persistence.persistMemberIntent) {
       throw new Error(
@@ -7282,6 +7280,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             .some((address) => address.toLowerCase() === approvedAgentAddress)
           : false;
         const restorePendingMeta = hasJoinApproval && !approvedAgentAuthorized;
+        let syncAdmission = row.syncAdmission
+          ?? (row.syncScoped ? 'explicit' : 'none');
+        if (
+          row.syncAdmission === undefined
+          && (this.config.nodeRole ?? 'edge') === 'core'
+          && row.subscribed
+          && !row.syncScoped
+          && row.onChainId
+        ) {
+          const accessPolicy = await this.getExplicitAccessPolicy(row.id);
+          if (accessPolicy === 'public') syncAdmission = 'automatic-public';
+        }
         this.setContextGraphSubscription(row.id, {
           name: row.name,
           // Every row in the durable store predates or represents explicit
@@ -7298,17 +7308,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           onChainHash: row.onChainHash,
           lastReconciledOrdinal: row.lastReconciledOrdinal,
           coreHosted: row.coreHosted,
+          syncAdmission,
         }, { persist: false });
-        if (row.syncScoped) {
-          this.trackSyncContextGraph(row.id);
-        }
         if (row.subscribed) {
           this.subscribeToContextGraph(row.id, {
             trackSyncScope: false,
             persist: false,
             syncMode: 'always-on',
           });
+          this.reconcileContextGraphSyncAdmission(row.id, {
+            subscribed: true,
+            admission: syncAdmission,
+          });
           this.persistLocalNodeMembership(row.id, 'rehydrated-subscription');
+        } else {
+          this.reconcileContextGraphSyncAdmission(row.id, {
+            subscribed: false,
+            admission: 'none',
+          });
         }
         // Upgrade/self-heal path for late private-CG members whose payload and
         // authenticated `_meta` already completed before registration binding

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -7291,8 +7291,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const restorePendingMeta = hasJoinApproval && !approvedAgentAuthorized;
         const isLegacySyncAdmission = row.syncAdmission === undefined;
         const isConfiguredExplicit = configuredExplicitSyncContextGraphs.has(row.id);
-        let syncAdmission = row.syncAdmission
-          ?? (isConfiguredExplicit ? 'explicit' : row.syncScoped ? 'explicit' : 'none');
+        // Current operator configuration is the authoritative explicit lane,
+        // even when a prior daemon persisted this public CG as automatic.
+        // Keep that overlay live-only: removing the configured selection on a
+        // later restart should reveal the durable automatic-public baseline.
+        let syncAdmission = isConfiguredExplicit
+          ? 'explicit'
+          : row.syncAdmission ?? (row.syncScoped ? 'explicit' : 'none');
         if (
           isLegacySyncAdmission
           && !isConfiguredExplicit

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -458,6 +458,7 @@ import {
   type ChatSendResult,
   type ContextGraphSub,
   type ContextGraphSubInput,
+  type NormalizedContextGraphSub,
   type ContextGraphSubscriptionRecord,
   type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
@@ -2678,7 +2679,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
               );
               return new TextEncoder().encode(JSON.stringify({ ok: true, skipped: true }));
             }
-            const approvedSubscription: ContextGraphSub = {
+            const approvedSubscription: NormalizedContextGraphSub = {
               ...this.subscribedContextGraphs.get(contextGraphId),
               syncMode: 'always-on',
               syncAdmission: 'explicit',
@@ -6511,7 +6512,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     next: ContextGraphSubInput,
     options?: { persist?: boolean; updateRehydrationStatus?: boolean },
-  ): ContextGraphSub {
+  ): NormalizedContextGraphSub {
     this.invalidateListContextGraphsCache();
     const previous = this.subscribedContextGraphs.get(contextGraphId);
     // A local id is always cleartext unless the subscription explicitly says
@@ -6530,7 +6531,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       next,
       (this.config.syncContextGraphs ?? []).includes(contextGraphId) ? 'explicit' : 'none',
     );
-    const canonicalNext: ContextGraphSub = {
+    const canonicalNext: NormalizedContextGraphSub = {
       ...normalizedNext,
       ...(next.onChainHash === nextOnChainHash ? {} : { onChainHash: nextOnChainHash }),
     };
@@ -6847,7 +6848,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
   async persistContextGraphSubscriptionStrict(this: DKGAgent,
     contextGraphId: string,
-    subscription?: ContextGraphSub,
+    subscription?: NormalizedContextGraphSub,
     syncScoped?: boolean,
   ): Promise<void> {
     const store = this.config.contextGraphSubscriptionStore;
@@ -6894,7 +6895,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async persistJoinApprovalStateStrict(this: DKGAgent,
     contextGraphId: string,
     membership: ContextGraphMembershipRecord,
-    subscription: ContextGraphSub,
+    subscription: NormalizedContextGraphSub,
   ): Promise<void> {
     const membershipStore = this.config.contextGraphMembershipStore;
     const subscriptionStore = this.config.contextGraphSubscriptionStore;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -7299,8 +7299,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           && row.subscribed
           && row.onChainId
         ) {
-          const accessPolicy = await this.getExplicitAccessPolicy(row.id);
-          if (accessPolicy === 'public') syncAdmission = 'automatic-public';
+          try {
+            const accessPolicy = await this.getExplicitAccessPolicy(row.id);
+            if (accessPolicy === 'public') syncAdmission = 'automatic-public';
+          } catch (error) {
+            // One unreadable legacy row must not prevent independent durable
+            // subscriptions from rehydrating. Keep the deterministic V31
+            // fallback, canonicalize that fallback, and continue with later rows.
+            this.log.warn(
+              ctx,
+              `Failed to classify legacy sync admission for "${row.id}"; ` +
+                `preserving fallback "${syncAdmission}" and continuing rehydration: ` +
+                `${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
         }
         this.setContextGraphSubscription(row.id, {
           name: row.name,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -6553,6 +6553,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const persistence = projectContextGraphSubscriptionPersistence({
       contextGraphId,
       subscription: canonicalNext,
+      durableSyncAdmission:
+        this.contextGraphSubscriptionDurableAdmissionOverrides.get(contextGraphId),
     });
     if (options?.persist !== false && persistence.action !== 'skip') {
       if (this.config.contextGraphSubscriptionStore) {
@@ -6762,6 +6764,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   deleteContextGraphSubscription(this: DKGAgent, contextGraphId: string): boolean {
     this.invalidateListContextGraphsCache();
     this.forceClearVmReconcileStateForContextGraph(contextGraphId);
+    this.contextGraphSubscriptionDurableAdmissionOverrides.delete(contextGraphId);
     return this.subscribedContextGraphs.delete(contextGraphId);
   }
 
@@ -6793,6 +6796,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const persistence = projectContextGraphSubscriptionPersistence({
       contextGraphId,
       subscription: sub,
+      durableSyncAdmission:
+        this.contextGraphSubscriptionDurableAdmissionOverrides.get(contextGraphId),
     });
     if (persistence.action === 'skip') {
       // Some lifecycle paths persist reconciliation watermarks directly
@@ -6867,6 +6872,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const persistence = projectContextGraphSubscriptionPersistence({
       contextGraphId,
       subscription: sub,
+      ...(subscription === undefined && syncScoped === undefined
+        ? {
+          durableSyncAdmission:
+            this.contextGraphSubscriptionDurableAdmissionOverrides.get(contextGraphId),
+        }
+        : {}),
       syncScoped,
     });
     if (persistence.action !== 'save' || !persistence.persistMemberIntent) {
@@ -7156,6 +7167,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const systemContextGraphs = new Set<string>(Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]);
       const persistedRows = await store.loadAll();
       const rows = persistedRows.filter((r) => !systemContextGraphs.has(r.id));
+      this.contextGraphSubscriptionDurableAdmissionOverrides.clear();
       // Snapshot operator intent before rehydration mutates the live scope.
       // Legacy rows only persisted `syncScoped`, which cannot distinguish an
       // explicit selection from a public CG automatically discovered by an
@@ -7298,6 +7310,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         let syncAdmission = isConfiguredExplicit
           ? 'explicit'
           : row.syncAdmission ?? (row.syncScoped ? 'explicit' : 'none');
+        if (
+          isConfiguredExplicit
+          && row.syncAdmission !== undefined
+          && row.syncAdmission !== 'explicit'
+        ) {
+          this.contextGraphSubscriptionDurableAdmissionOverrides.set(
+            row.id,
+            row.syncAdmission,
+          );
+        }
         if (
           isLegacySyncAdmission
           && !isConfiguredExplicit

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -352,6 +352,7 @@ import {
   type PeerDiagnostics,
   type ChatSendResult,
   type ContextGraphSub,
+  type ContextGraphSubInput,
   type ContextGraphSubscriptionRecord,
   type ContextGraphSubscriptionStore,
   type ContextGraphMemberPrincipalType,
@@ -2439,7 +2440,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const existing = this.subscribedContextGraphs.get(localCgId);
     if (existing?.coreHosted && existing.onChainId === numericStr) return; // already recorded
 
-    let next: ContextGraphSub;
+    let next: ContextGraphSubInput;
     if (existing) {
       // Rebind through the helper so a CG re-created/rebound under the same
       // local id drops its stale reconcile watermark + in-memory cursor before

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -515,6 +515,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     if (syncSet.delete(contextGraphId)) {
       this.config.syncContextGraphs = [...syncSet];
     }
+    this.unregisterCorePublicSyncContextGraph(contextGraphId);
 
     // Tear down the per-CG gossip topics. These four carry only the member
     // handlers installed by `subscribeToContextGraph`, so a topic-wide

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -392,6 +392,9 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     syncMode?: 'on-demand' | 'always-on';
   }): ContextGraphSub {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
+    const removedConfiguredAdmissionOverlay = options?.trackSyncScope !== false
+      ? this.contextGraphSubscriptionDurableAdmissionOverrides.delete(contextGraphId)
+      : false;
     const syncAdmission = options?.trackSyncScope === false
       ? existing?.syncAdmission ?? 'none'
       : 'explicit';
@@ -433,6 +436,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         !existing?.subscribed
         || existing.syncMode !== syncMode
         || existing.syncAdmission !== syncAdmission
+        || removedConfiguredAdmissionOverlay
       ) {
         return this.setContextGraphSubscription(
           contextGraphId,
@@ -517,6 +521,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
   ): void {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
     if (!existing) return;
+    this.contextGraphSubscriptionDurableAdmissionOverrides.delete(contextGraphId);
 
     // Drop every sync-admission lane through the canonical owner.
     this.reconcileContextGraphSyncAdmission(contextGraphId, {

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -391,11 +391,14 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     deferSharedMemoryGossipSubscribe?: boolean;
     syncMode?: 'on-demand' | 'always-on';
   }): ContextGraphSub {
-    if (options?.trackSyncScope !== false) {
-      this.trackSyncContextGraph(contextGraphId);
-    }
-
     const existing = this.subscribedContextGraphs.get(contextGraphId);
+    const syncAdmission = options?.trackSyncScope === false
+      ? existing?.syncAdmission ?? 'none'
+      : 'explicit';
+    this.reconcileContextGraphSyncAdmission(contextGraphId, {
+      subscribed: true,
+      admission: syncAdmission,
+    });
     // Opening an already durable graph must never silently downgrade it to a
     // process-local subscription. An explicit always-on request may promote an
     // existing on-demand subscription, while an omitted mode preserves the
@@ -426,7 +429,11 @@ export class SwmSubstrateMethods extends DKGAgentBase {
       if (!deferSwmGossip) {
         this.queueSharedMemoryGossipSubscription(contextGraphId);
       }
-      if (!existing?.subscribed || existing.syncMode !== syncMode) {
+      if (
+        !existing?.subscribed
+        || existing.syncMode !== syncMode
+        || existing.syncAdmission !== syncAdmission
+      ) {
         return this.setContextGraphSubscription(
           contextGraphId,
           {
@@ -434,6 +441,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
             subscribed: true,
             synced: existing?.synced ?? false,
             syncMode,
+            syncAdmission,
           },
           { persist },
         );
@@ -455,6 +463,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         subscribed: true,
         synced: existing?.synced ?? false,
         syncMode,
+        syncAdmission,
       },
       { persist },
     );
@@ -509,13 +518,11 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
     if (!existing) return;
 
-    // Drop from the active sync scope so background sweeps no longer treat
-    // this as a subscribed CG to keep current.
-    const syncSet = new Set<string>(this.config.syncContextGraphs ?? []);
-    if (syncSet.delete(contextGraphId)) {
-      this.config.syncContextGraphs = [...syncSet];
-    }
-    this.unregisterCorePublicSyncContextGraph(contextGraphId);
+    // Drop every sync-admission lane through the canonical owner.
+    this.reconcileContextGraphSyncAdmission(contextGraphId, {
+      subscribed: false,
+      admission: 'none',
+    });
 
     // Tear down the per-CG gossip topics. These four carry only the member
     // handlers installed by `subscribeToContextGraph`, so a topic-wide
@@ -553,7 +560,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     // other field) intact. Persisted: the row is kept iff `coreHosted`.
     this.setContextGraphSubscription(
       contextGraphId,
-      { ...existing, subscribed: false },
+      { ...existing, subscribed: false, syncAdmission: 'none' },
       { persist: options?.persist ?? true, updateRehydrationStatus: options?.updateRehydrationStatus },
     );
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -615,11 +615,16 @@ export interface ChatSendResult {
  */
 export type ContextGraphSyncMode = 'on-demand' | 'always-on';
 
+/** Local admission lane for durable and shared-memory synchronization. */
+export type ContextGraphSyncAdmission = 'none' | 'explicit' | 'automatic-public';
+
 /** Tracks the subscription and sync state of a context graph. */
 export interface ContextGraphSub {
   name?: string;
   /** Requested synchronization lifetime, normalized before entering live state. */
   syncMode: ContextGraphSyncMode;
+  /** Canonical local sync admission, independent from gossip subscription. */
+  syncAdmission: ContextGraphSyncAdmission;
   /** GossipSub topics are active for this context graph. */
   subscribed: boolean;
   /** Definition triples exist in the local triple store. */
@@ -704,8 +709,9 @@ export interface ContextGraphSub {
  * values and must choose a synchronization lifetime explicitly. This shape is
  * retained solely for older standalone handler callbacks that predate modes.
  */
-export type ContextGraphSubInput = Omit<ContextGraphSub, 'syncMode'> & {
+export type ContextGraphSubInput = Omit<ContextGraphSub, 'syncMode' | 'syncAdmission'> & {
   syncMode?: ContextGraphSyncMode;
+  syncAdmission?: ContextGraphSyncAdmission;
 };
 
 /**
@@ -722,13 +728,19 @@ export interface ContextGraphDiscoveryMetadata {
   onChainId?: string;
   onChainHash?: string;
   participantAgents?: string[];
+  /**
+   * Authoritative access policy when the discovery source can establish it.
+   * Core automatic public coverage is reconciled only from this explicit
+   * classification; absence keeps a Core in hosting-only compatibility mode.
+   */
+  accessPolicy?: 'public' | 'private';
 }
 
 export interface ContextGraphDiscoveryOptions {
   /**
-   * Whether a newly discovered core subscription joins the ordinary catch-up
-   * scope. Chain registry discovery historically installed gossip handlers
-   * without joining that scope, so its caller passes false.
+   * @deprecated Discovery sources should provide authoritative metadata and
+   * let the agent choose its local sync policy. Retained so existing typed and
+   * precompiled callers can still opt out of the explicit sync scope.
    */
   trackSyncScope?: boolean;
 }
@@ -751,6 +763,8 @@ export interface ContextGraphSubscriptionRecord {
   lastReconciledOrdinal?: number;
   /** Phase D — persisted "this Core hosts a public CG" flag (see ContextGraphSub). */
   coreHosted?: boolean;
+  /** Canonical admission written by current nodes; absent on legacy rows. */
+  syncAdmission?: ContextGraphSyncAdmission;
   syncScoped: boolean;
 }
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -623,8 +623,15 @@ export interface ContextGraphSub {
   name?: string;
   /** Requested synchronization lifetime, normalized before entering live state. */
   syncMode: ContextGraphSyncMode;
-  /** Canonical local sync admission, independent from gossip subscription. */
-  syncAdmission: ContextGraphSyncAdmission;
+  /**
+   * Canonical local sync admission, independent from gossip subscription.
+   *
+   * Optional on this exported compatibility shape so callers that construct
+   * the pre-admission subscription object continue to type-check. Agent-owned
+   * live state crosses a normalization boundary before storage and uses the
+   * required internal shape below.
+   */
+  syncAdmission?: ContextGraphSyncAdmission;
   /** GossipSub topics are active for this context graph. */
   subscribed: boolean;
   /** Definition triples exist in the local triple store. */
@@ -702,10 +709,15 @@ export interface ContextGraphSub {
   pendingMeta?: boolean;
 }
 
+/** Agent-owned live subscription state after the public compatibility boundary. */
+export type NormalizedContextGraphSub = Omit<ContextGraphSub, 'syncAdmission'> & {
+  syncAdmission: ContextGraphSyncAdmission;
+};
+
 /**
  * Legacy compatibility input for the standalone gossip handler only.
  *
- * Agent-owned live-state mutations use normalized {@link ContextGraphSub}
+ * Agent-owned live-state mutations use {@link NormalizedContextGraphSub}
  * values and must choose a synchronization lifetime explicitly. This shape is
  * retained solely for older standalone handler callbacks that predate modes.
  */

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1246,6 +1246,12 @@ export interface DKGAgentConfig {
   syncGlobalLimit?: number;
   /** Max sync jobs waiting behind the global cap. Defaults to 2x the inflight cap. */
   syncGlobalQueueLimit?: number;
+  /**
+   * Maximum automatically discovered public CGs a Core adds to one peer-sync
+   * round. Explicitly selected CGs are not capped. Defaults to 8; 0 disables
+   * automatic Core catch-up while preserving discovery and live hosting.
+   */
+  syncCorePublicBatchSize?: number;
   /** Daemon-local retained responder snapshot row/estimated-byte policy. */
   syncResponderSnapshotLimits?: SyncResponderSnapshotLimitsConfig;
   /** Local requester/responder priority by Context Graph ID. Higher runs first. */

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1374,7 +1374,8 @@ export class DKGAgent extends DKGAgentBase {
         // host-only) private CG here would silently undo that operator choice on
         // every discovery scan. Only re-track CGs the node is still a live
         // subscriber of.
-        if (current.subscribed && await this.isPrivateContextGraph(id) && this.trackSyncContextGraph(id)) {
+        const isPrivate = await this.isPrivateContextGraph(id);
+        if (current.subscribed && isPrivate && this.trackSyncContextGraph(id)) {
           this.log.info(ctx, `Re-tracked already-subscribed private CG "${id.slice(0, 28)}" into the SWM-sync scope on discovery`);
         }
         continue;
@@ -1497,7 +1498,13 @@ export class DKGAgent extends DKGAgentBase {
         if (knownOnChainIds.has(p.contextGraphId)) {
           if (!p.name) continue;
           const durableOnChainId = await readDurableContextGraphOnChainId(p.name);
-          if (durableOnChainId === p.contextGraphId) continue;
+          if (durableOnChainId === p.contextGraphId) {
+            const existing = this.subscribedContextGraphs.get(p.name);
+            if (Number(p.accessPolicy) === 0 && existing?.subscribed === true) {
+              this.registerCorePublicSyncContextGraph(p.name);
+            }
+            continue;
+          }
           knownOnChainIds.delete(p.contextGraphId);
         }
 
@@ -1548,10 +1555,13 @@ export class DKGAgent extends DKGAgentBase {
           graph: ontoGraph,
         }]);
 
-        this.recordDiscoveredContextGraph(p.name, {
+        const recorded = this.recordDiscoveredContextGraph(p.name, {
           name: p.name,
           onChainId: p.contextGraphId,
         }, { trackSyncScope: false });
+        if (Number(p.accessPolicy) === 0 && recorded.subscribed) {
+          this.registerCorePublicSyncContextGraph(p.name);
+        }
         this.contextGraphMetaProjection.markDirty(p.name);
         const roleOutcome = (this.config.nodeRole ?? 'edge') === 'core'
           ? 'auto-subscribed for core ACK hosting'

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -337,6 +337,7 @@ import {
   type PeerDiagnostics,
   type ChatSendResult,
   type ContextGraphSub,
+  type NormalizedContextGraphSub,
   type ContextGraphSyncMode,
   type ContextGraphSyncAdmission,
   type ContextGraphDiscoveryMetadata,
@@ -1238,7 +1239,7 @@ export class DKGAgent extends DKGAgentBase {
     contextGraphId: string,
     metadata: ContextGraphDiscoveryMetadata,
     evidence: { legacyPrivate?: boolean; trackSyncScope?: boolean } = {},
-  ): ContextGraphSub {
+  ): NormalizedContextGraphSub {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
     const disposition = this.classifyContextGraphDiscovery({
       ...(metadata.accessPolicy ? { accessPolicy: metadata.accessPolicy } : {}),
@@ -1247,7 +1248,7 @@ export class DKGAgent extends DKGAgentBase {
         ? { trackSyncScope: evidence.trackSyncScope }
         : {}),
     });
-    const next: ContextGraphSub = {
+    const next: NormalizedContextGraphSub = {
       ...existing,
       syncMode: existing?.syncMode ?? 'always-on',
       syncAdmission: existing?.syncAdmission ?? 'none',

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1283,9 +1283,11 @@ export class DKGAgent extends DKGAgentBase {
     }
 
     const beforeAdmission = this.subscribedContextGraphs.get(contextGraphId) ?? next;
+    const preserveExplicitAdmission = beforeAdmission.syncAdmission === 'explicit'
+      || (this.config.syncContextGraphs ?? []).includes(contextGraphId);
     const admission: ContextGraphSyncAdmission = !beforeAdmission.subscribed
       ? 'none'
-      : disposition === 'explicit-sync-scope'
+      : preserveExplicitAdmission || disposition === 'explicit-sync-scope'
         ? 'explicit'
         : disposition === 'automatic-public-coverage'
           ? 'automatic-public'

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -338,6 +338,7 @@ import {
   type ChatSendResult,
   type ContextGraphSub,
   type ContextGraphSyncMode,
+  type ContextGraphSyncAdmission,
   type ContextGraphDiscoveryMetadata,
   type ContextGraphDiscoveryOptions,
   type ContextGraphSubscriptionRecord,
@@ -451,6 +452,7 @@ export type {
   ChatSendResult,
   ContextGraphSub,
   ContextGraphSyncMode,
+  ContextGraphSyncAdmission,
   ContextGraphDiscoveryMetadata,
   ContextGraphDiscoveryOptions,
   ContextGraphSubscriptionRecord,
@@ -1225,10 +1227,30 @@ export class DKGAgent extends DKGAgentBase {
     metadata: ContextGraphDiscoveryMetadata,
     options: ContextGraphDiscoveryOptions = {},
   ): ContextGraphSub {
+    return this.recordDiscoveredContextGraphWithEvidence(contextGraphId, metadata, {
+      ...(options.trackSyncScope !== undefined
+        ? { trackSyncScope: options.trackSyncScope }
+        : {}),
+    });
+  }
+
+  private recordDiscoveredContextGraphWithEvidence(
+    contextGraphId: string,
+    metadata: ContextGraphDiscoveryMetadata,
+    evidence: { legacyPrivate?: boolean; trackSyncScope?: boolean } = {},
+  ): ContextGraphSub {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
+    const disposition = this.classifyContextGraphDiscovery({
+      ...(metadata.accessPolicy ? { accessPolicy: metadata.accessPolicy } : {}),
+      ...(evidence.legacyPrivate === true ? { legacyPrivate: true } : {}),
+      ...(evidence.trackSyncScope !== undefined
+        ? { trackSyncScope: evidence.trackSyncScope }
+        : {}),
+    });
     const next: ContextGraphSub = {
       ...existing,
       syncMode: existing?.syncMode ?? 'always-on',
+      syncAdmission: existing?.syncAdmission ?? 'none',
       name: metadata.name ?? existing?.name,
       subscribed: existing?.subscribed === true,
       synced: existing?.synced === true,
@@ -1252,14 +1274,36 @@ export class DKGAgent extends DKGAgentBase {
     const persistEnrichment = existing?.subscribed === true || existing?.coreHosted === true;
     this.setContextGraphSubscription(contextGraphId, next, { persist: persistEnrichment });
 
-    if (!existing && (this.config.nodeRole ?? 'edge') === 'core') {
+    if (!existing && disposition !== 'catalogue-only') {
       this.subscribeToContextGraph(contextGraphId, {
-        trackSyncScope: options.trackSyncScope,
+        trackSyncScope: false,
         syncMode: 'always-on',
       });
     }
 
-    return this.subscribedContextGraphs.get(contextGraphId) ?? next;
+    const beforeAdmission = this.subscribedContextGraphs.get(contextGraphId) ?? next;
+    const admission: ContextGraphSyncAdmission = !beforeAdmission.subscribed
+      ? 'none'
+      : disposition === 'explicit-sync-scope'
+        ? 'explicit'
+        : disposition === 'automatic-public-coverage'
+          ? 'automatic-public'
+          : disposition === 'core-hosting-only'
+            ? 'none'
+            : beforeAdmission.syncAdmission;
+    const admissionChanged = this.reconcileContextGraphSyncAdmission(contextGraphId, {
+      subscribed: beforeAdmission.subscribed,
+      admission,
+    });
+    const recorded = this.subscribedContextGraphs.get(contextGraphId) ?? beforeAdmission;
+    if (admissionChanged) {
+      this.setContextGraphSubscription(
+        contextGraphId,
+        { ...recorded, syncAdmission: admission },
+        { persist: persistEnrichment || !existing },
+      );
+    }
+    return this.subscribedContextGraphs.get(contextGraphId) ?? recorded;
   }
 
   async discoverContextGraphsFromStore(): Promise<number> {
@@ -1356,28 +1400,19 @@ export class DKGAgent extends DKGAgentBase {
         // Enrich an existing active/hosted record and persist the binding. The
         // central recorder deliberately does not reactivate an existing
         // unsubscribed row, preserving explicit unsubscribe semantics.
-        this.recordDiscoveredContextGraph(id, { name, onChainId });
-        const current = this.subscribedContextGraphs.get(id) ?? existing;
-        // A restart re-seeds `subscribedContextGraphs` from persisted state but
-        // does NOT re-add the CG to the SWM-sync scope (`config.syncContextGraphs`,
-        // what `getSyncContextGraphs()` and sync-on-connect's shared-memory pass
-        // iterate). For a PRIVATE CG the member is a participant in, that means a
-        // reconnecting member would data-sync the CG but its on-connect SWM pass
-        // would never cover it — the curator-leader REPLACE gate never sees it, so
-        // the member stays stale forever. Re-track the sync scope here for curated
-        // CGs so this same connect cycle's `newlyDiscovered` set picks it up
-        // (refreshing its meta-synced flag) and the shared-memory pass recovers it.
-        // `trackSyncContextGraph` is idempotent, so public/already-scoped CGs are
-        // unaffected. Gate on `existing.subscribed`: `unsubscribeFromContextGraph`
-        // keeps the record but flips `subscribed` to false and drops the CG from
-        // `syncContextGraphs`, so re-tracking an explicitly-unsubscribed (or
-        // host-only) private CG here would silently undo that operator choice on
-        // every discovery scan. Only re-track CGs the node is still a live
-        // subscriber of.
-        const isPrivate = await this.isPrivateContextGraph(id);
-        if (current.subscribed && isPrivate && this.trackSyncContextGraph(id)) {
-          this.log.info(ctx, `Re-tracked already-subscribed private CG "${id.slice(0, 28)}" into the SWM-sync scope on discovery`);
-        }
+        const explicitAccessPolicy = await this.getExplicitAccessPolicy(id);
+        const isPrivate = explicitAccessPolicy === 'private'
+          || (explicitAccessPolicy === null && await this.isPrivateContextGraph(id));
+        this.recordDiscoveredContextGraphWithEvidence(id, {
+          name,
+          onChainId,
+          // A durable on-chain binding is the store-side proof that this is
+          // eligible for automatic public coverage. Unbound local ontology
+          // entries remain catalogue-only for Core scheduling.
+          ...(explicitAccessPolicy ? { accessPolicy: explicitAccessPolicy } : {}),
+        }, {
+          legacyPrivate: explicitAccessPolicy === null && isPrivate,
+        });
         continue;
       }
 
@@ -1399,9 +1434,17 @@ export class DKGAgent extends DKGAgentBase {
       //   `source === 'meta'`, because the ontology-vs-meta
       //   collision resolver above lets an ontology row shadow a
       //   meta row when both exist for the same id.
-      const isCurated = await this.isPrivateContextGraph(id);
+      const explicitAccessPolicy = await this.getExplicitAccessPolicy(id);
+      const isCurated = explicitAccessPolicy === 'private'
+        || (explicitAccessPolicy === null && await this.isPrivateContextGraph(id));
 
-      const recorded = this.recordDiscoveredContextGraph(id, { name, onChainId });
+      const recorded = this.recordDiscoveredContextGraphWithEvidence(id, {
+        name,
+        onChainId,
+        ...(explicitAccessPolicy ? { accessPolicy: explicitAccessPolicy } : {}),
+      }, {
+        legacyPrivate: explicitAccessPolicy === null && isCurated,
+      });
       const roleOutcome = recorded.subscribed ? 'auto-subscribed for core hosting' : 'catalogued for explicit edge opt-in';
       this.log.info(
         ctx,
@@ -1491,6 +1534,42 @@ export class DKGAgent extends DKGAgentBase {
       const value = result.bindings[0]?.['id'];
       return typeof value === 'string' ? value.replace(/^"|"$/g, '') : null;
     };
+    const persistDurableChainClassification = async (
+      contextGraphId: string,
+      onChainId: string,
+      accessPolicy: 'public' | 'private',
+      bindingAlreadyDurable = false,
+    ): Promise<void> => {
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+      if (!bindingAlreadyDurable) {
+        await this.store.deleteByPattern({
+          graph: ontologyGraph,
+          subject: contextGraphUri,
+          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+        });
+      }
+      await this.store.deleteByPattern({
+        graph: ontologyGraph,
+        subject: contextGraphUri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      });
+      await this.store.insert([
+        ...(!bindingAlreadyDurable ? [{
+          subject: contextGraphUri,
+          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+          object: `"${onChainId}"`,
+          graph: ontologyGraph,
+        }] : []),
+        {
+          subject: contextGraphUri,
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: `"${accessPolicy}"`,
+          graph: ontologyGraph,
+        },
+      ]);
+      this.contextGraphMetaProjection.markDirty(contextGraphId);
+    };
 
     let discovered = 0;
     const applyDiscoveredContextGraphs = async (contextGraphs: ContextGraphOnChain[]): Promise<void> => {
@@ -1499,10 +1578,18 @@ export class DKGAgent extends DKGAgentBase {
           if (!p.name) continue;
           const durableOnChainId = await readDurableContextGraphOnChainId(p.name);
           if (durableOnChainId === p.contextGraphId) {
-            const existing = this.subscribedContextGraphs.get(p.name);
-            if (Number(p.accessPolicy) === 0 && existing?.subscribed === true) {
-              this.registerCorePublicSyncContextGraph(p.name);
-            }
+            const accessPolicy = Number(p.accessPolicy) === 0 ? 'public' : 'private';
+            await persistDurableChainClassification(
+              p.name,
+              p.contextGraphId,
+              accessPolicy,
+              true,
+            );
+            this.recordDiscoveredContextGraph(p.name, {
+              name: p.name,
+              onChainId: p.contextGraphId,
+              accessPolicy,
+            });
             continue;
           }
           knownOnChainIds.delete(p.contextGraphId);
@@ -1535,34 +1622,20 @@ export class DKGAgent extends DKGAgentBase {
         // Persist the on-chain ID to the ontology graph so the publisher's
         // VM registration guard can find it via RDF (it has no access to
         // the in-memory subscribedContextGraphs map).
-        const cgUri = contextGraphDataGraphUri(p.name);
-        const ontoGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
         // Single-valued binding guard (RS heal): on-chain id is immutable; clear
         // any prior value so the cgId resolver / heal never read a multi-valued
         // (LIMIT-1-nondeterministic) binding.
         // Keep this durable write before in-memory catalogue mutation: cursor
         // pages are acked after this function returns, and an in-memory onChainId
         // alone must not make a retry skip the RDF binding.
-        await this.store.deleteByPattern({
-          graph: ontoGraph,
-          subject: cgUri,
-          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-        });
-        await this.store.insert([{
-          subject: cgUri,
-          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-          object: `"${p.contextGraphId}"`,
-          graph: ontoGraph,
-        }]);
+        const accessPolicy = Number(p.accessPolicy) === 0 ? 'public' : 'private';
+        await persistDurableChainClassification(p.name, p.contextGraphId, accessPolicy);
 
-        const recorded = this.recordDiscoveredContextGraph(p.name, {
+        this.recordDiscoveredContextGraph(p.name, {
           name: p.name,
           onChainId: p.contextGraphId,
-        }, { trackSyncScope: false });
-        if (Number(p.accessPolicy) === 0 && recorded.subscribed) {
-          this.registerCorePublicSyncContextGraph(p.name);
-        }
-        this.contextGraphMetaProjection.markDirty(p.name);
+          accessPolicy,
+        });
         const roleOutcome = (this.config.nodeRole ?? 'edge') === 'core'
           ? 'auto-subscribed for core ACK hosting'
           : 'catalogued (not subscribed)';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -198,6 +198,7 @@ export {
   type DKGAgentACKTransportOptions,
   type ContextGraphSub,
   type ContextGraphSyncMode,
+  type ContextGraphSyncAdmission,
   type ContextGraphDiscoveryMetadata,
   type ContextGraphDiscoveryOptions,
   type PublishOpts,

--- a/packages/agent/src/sync/core-public-coverage-scheduler.ts
+++ b/packages/agent/src/sync/core-public-coverage-scheduler.ts
@@ -1,0 +1,170 @@
+import {
+  contextGraphPriority,
+  type SyncContextGraphPriorityConfig,
+} from './policy.js';
+
+export const DEFAULT_CORE_PUBLIC_SYNC_BATCH_SIZE = 8;
+
+export interface CorePublicSyncCoverageStatus {
+  enabled: boolean;
+  batchSize: number;
+  trackedContextGraphs: number;
+  planningLanes: number;
+  lastPlanAt?: number;
+  lastPlan?: {
+    selectedContextGraphs: number;
+    coverageContextGraphs: number;
+    totalContextGraphs: number;
+  };
+}
+
+export interface CorePublicSyncPlan {
+  contextGraphIds: string[];
+  selectedContextGraphIds: string[];
+  coverageContextGraphIds: string[];
+}
+
+function normalizeBatchSize(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_CORE_PUBLIC_SYNC_BATCH_SIZE;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new TypeError('syncCorePublicBatchSize must be a non-negative integer');
+  }
+  return value;
+}
+
+function greatestCommonDivisor(a: number, b: number): number {
+  let left = a;
+  let right = b;
+  while (right !== 0) {
+    [left, right] = [right, left % right];
+  }
+  return left;
+}
+
+/** Ensure every CG eventually occupies the fail-fast batch's first slot. */
+function rotationStride(batchSize: number, coverageSize: number): number {
+  if (coverageSize <= 1) return 0;
+  for (let candidate = Math.min(batchSize, coverageSize - 1); candidate >= 1; candidate -= 1) {
+    if (greatestCommonDivisor(candidate, coverageSize) === 1) return candidate;
+  }
+  return 1;
+}
+
+export function resolveCorePublicSyncBatchSize(
+  configured: number | undefined,
+  envValue = process.env['DKG_SYNC_CORE_PUBLIC_BATCH_SIZE'],
+): number {
+  const trimmed = envValue?.trim();
+  if (trimmed) {
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new TypeError(
+        'DKG_SYNC_CORE_PUBLIC_BATCH_SIZE must be a non-negative integer',
+      );
+    }
+    return parsed;
+  }
+  return normalizeBatchSize(configured);
+}
+
+/**
+ * Rotating, bounded admission for automatic Core coverage. Explicitly selected
+ * CGs are always included; only the automatic all-public tail is sliced.
+ */
+export class CorePublicSyncCoverageScheduler {
+  private readonly tracked = new Set<string>();
+  /** Per-peer cursors prevent a stable peer order from pinning each peer to one batch. */
+  private readonly cursors = new Map<string, number>();
+  private lastPlanAt?: number;
+  private lastPlan?: CorePublicSyncCoverageStatus['lastPlan'];
+
+  constructor(
+    private readonly batchSize: number,
+    private readonly now: () => number = Date.now,
+  ) {
+    normalizeBatchSize(batchSize);
+  }
+
+  register(contextGraphId: string): boolean {
+    const normalized = contextGraphId.trim();
+    if (!normalized) return false;
+    const sizeBefore = this.tracked.size;
+    this.tracked.add(normalized);
+    return this.tracked.size !== sizeBefore;
+  }
+
+  unregister(contextGraphId: string): boolean {
+    const removed = this.tracked.delete(contextGraphId);
+    if (this.tracked.size === 0) {
+      this.cursors.clear();
+    } else {
+      for (const [planningLane, cursor] of this.cursors) {
+        this.cursors.set(planningLane, cursor % this.tracked.size);
+      }
+    }
+    return removed;
+  }
+
+  plan(
+    selectedContextGraphIds: readonly string[],
+    priorities?: Readonly<SyncContextGraphPriorityConfig>,
+    planningLane = 'default',
+  ): CorePublicSyncPlan {
+    const selected = [...new Set(
+      selectedContextGraphIds.map((id) => id.trim()).filter(Boolean),
+    )];
+    const selectedSet = new Set(selected);
+    const coverage = [...this.tracked]
+      .map((contextGraphId, index) => ({ contextGraphId, index }))
+      .filter(({ contextGraphId }) => !selectedSet.has(contextGraphId))
+      .sort((a, b) => (
+        contextGraphPriority(priorities, b.contextGraphId)
+        - contextGraphPriority(priorities, a.contextGraphId)
+        || a.index - b.index
+      ))
+      .map(({ contextGraphId }) => contextGraphId);
+
+    const scheduledCoverage: string[] = [];
+    if (this.batchSize > 0 && coverage.length > 0) {
+      const count = Math.min(this.batchSize, coverage.length);
+      const start = (this.cursors.get(planningLane) ?? 0) % coverage.length;
+      for (let offset = 0; offset < count; offset += 1) {
+        scheduledCoverage.push(coverage[(start + offset) % coverage.length]!);
+      }
+      this.cursors.set(
+        planningLane,
+        (start + rotationStride(count, coverage.length)) % coverage.length,
+      );
+    } else {
+      this.cursors.delete(planningLane);
+    }
+
+    const contextGraphIds = [...selected, ...scheduledCoverage];
+    this.lastPlanAt = this.now();
+    this.lastPlan = {
+      selectedContextGraphs: selected.length,
+      coverageContextGraphs: scheduledCoverage.length,
+      totalContextGraphs: contextGraphIds.length,
+    };
+    return {
+      contextGraphIds,
+      selectedContextGraphIds: selected,
+      coverageContextGraphIds: scheduledCoverage,
+    };
+  }
+
+  releasePlanningLane(planningLane: string): boolean {
+    return this.cursors.delete(planningLane);
+  }
+
+  getStatus(enabled: boolean): CorePublicSyncCoverageStatus {
+    return {
+      enabled: enabled && this.batchSize > 0,
+      batchSize: this.batchSize,
+      trackedContextGraphs: this.tracked.size,
+      planningLanes: this.cursors.size,
+      ...(this.lastPlanAt !== undefined ? { lastPlanAt: this.lastPlanAt } : {}),
+      ...(this.lastPlan ? { lastPlan: { ...this.lastPlan } } : {}),
+    };
+  }
+}

--- a/packages/agent/src/sync/core-public-coverage-scheduler.ts
+++ b/packages/agent/src/sync/core-public-coverage-scheduler.ts
@@ -4,6 +4,7 @@ import {
 } from './policy.js';
 
 export const DEFAULT_CORE_PUBLIC_SYNC_BATCH_SIZE = 8;
+export const DEFAULT_CORE_PUBLIC_SYNC_MAX_PLANNING_LANES = 2_048;
 
 export interface CorePublicSyncCoverageStatus {
   enabled: boolean;
@@ -16,12 +17,6 @@ export interface CorePublicSyncCoverageStatus {
     coverageContextGraphs: number;
     totalContextGraphs: number;
   };
-}
-
-export interface CorePublicSyncPlan {
-  contextGraphIds: string[];
-  selectedContextGraphIds: string[];
-  coverageContextGraphIds: string[];
 }
 
 function normalizeBatchSize(value: number | undefined): number {
@@ -67,22 +62,27 @@ export function resolveCorePublicSyncBatchSize(
   return normalizeBatchSize(configured);
 }
 
-/**
- * Rotating, bounded admission for automatic Core coverage. Explicitly selected
- * CGs are always included; only the automatic all-public tail is sliced.
- */
+/** Rotating, bounded admission for the automatic Core-public tail only. */
 export class CorePublicSyncCoverageScheduler {
   private readonly tracked = new Set<string>();
-  /** Per-peer cursors prevent a stable peer order from pinning each peer to one batch. */
-  private readonly cursors = new Map<string, number>();
+  /**
+   * Bounded LRU lane anchors keep active-peer fairness without a lifecycle cleanup contract.
+   * Each value names the graph that most recently occupied the lane's first slot, so the
+   * state remains meaningful when priorities or tracked membership rebuild the ordered list.
+   */
+  private readonly laneAnchors = new Map<string, string>();
   private lastPlanAt?: number;
   private lastPlan?: CorePublicSyncCoverageStatus['lastPlan'];
 
   constructor(
     private readonly batchSize: number,
     private readonly now: () => number = Date.now,
+    private readonly maxPlanningLanes = DEFAULT_CORE_PUBLIC_SYNC_MAX_PLANNING_LANES,
   ) {
     normalizeBatchSize(batchSize);
+    if (!Number.isInteger(maxPlanningLanes) || maxPlanningLanes <= 0) {
+      throw new TypeError('maxPlanningLanes must be a positive integer');
+    }
   }
 
   register(contextGraphId: string): boolean {
@@ -96,20 +96,22 @@ export class CorePublicSyncCoverageScheduler {
   unregister(contextGraphId: string): boolean {
     const removed = this.tracked.delete(contextGraphId);
     if (this.tracked.size === 0) {
-      this.cursors.clear();
-    } else {
-      for (const [planningLane, cursor] of this.cursors) {
-        this.cursors.set(planningLane, cursor % this.tracked.size);
+      this.laneAnchors.clear();
+    } else if (removed) {
+      for (const [planningLane, anchorContextGraphId] of this.laneAnchors) {
+        if (anchorContextGraphId === contextGraphId) {
+          this.laneAnchors.delete(planningLane);
+        }
       }
     }
     return removed;
   }
 
-  plan(
+  planAutomaticCoverage(
     selectedContextGraphIds: readonly string[],
     priorities?: Readonly<SyncContextGraphPriorityConfig>,
     planningLane = 'default',
-  ): CorePublicSyncPlan {
+  ): string[] {
     const selected = [...new Set(
       selectedContextGraphIds.map((id) => id.trim()).filter(Boolean),
     )];
@@ -127,34 +129,35 @@ export class CorePublicSyncCoverageScheduler {
     const scheduledCoverage: string[] = [];
     if (this.batchSize > 0 && coverage.length > 0) {
       const count = Math.min(this.batchSize, coverage.length);
-      const start = (this.cursors.get(planningLane) ?? 0) % coverage.length;
+      const previousAnchor = this.laneAnchors.get(planningLane);
+      const previousAnchorIndex = previousAnchor === undefined
+        ? -1
+        : coverage.indexOf(previousAnchor);
+      const start = previousAnchorIndex < 0
+        ? 0
+        : (previousAnchorIndex + rotationStride(count, coverage.length)) % coverage.length;
       for (let offset = 0; offset < count; offset += 1) {
         scheduledCoverage.push(coverage[(start + offset) % coverage.length]!);
       }
-      this.cursors.set(
-        planningLane,
-        (start + rotationStride(count, coverage.length)) % coverage.length,
-      );
+      // Delete-before-set refreshes LRU order for an existing active lane.
+      if (previousAnchor !== undefined) this.laneAnchors.delete(planningLane);
+      this.laneAnchors.set(planningLane, coverage[start]!);
+      while (this.laneAnchors.size > this.maxPlanningLanes) {
+        const oldestLane = this.laneAnchors.keys().next().value as string | undefined;
+        if (oldestLane === undefined) break;
+        this.laneAnchors.delete(oldestLane);
+      }
     } else {
-      this.cursors.delete(planningLane);
+      this.laneAnchors.delete(planningLane);
     }
 
-    const contextGraphIds = [...selected, ...scheduledCoverage];
     this.lastPlanAt = this.now();
     this.lastPlan = {
       selectedContextGraphs: selected.length,
       coverageContextGraphs: scheduledCoverage.length,
-      totalContextGraphs: contextGraphIds.length,
+      totalContextGraphs: selected.length + scheduledCoverage.length,
     };
-    return {
-      contextGraphIds,
-      selectedContextGraphIds: selected,
-      coverageContextGraphIds: scheduledCoverage,
-    };
-  }
-
-  releasePlanningLane(planningLane: string): boolean {
-    return this.cursors.delete(planningLane);
+    return scheduledCoverage;
   }
 
   getStatus(enabled: boolean): CorePublicSyncCoverageStatus {
@@ -162,7 +165,7 @@ export class CorePublicSyncCoverageScheduler {
       enabled: enabled && this.batchSize > 0,
       batchSize: this.batchSize,
       trackedContextGraphs: this.tracked.size,
-      planningLanes: this.cursors.size,
+      planningLanes: this.laneAnchors.size,
       ...(this.lastPlanAt !== undefined ? { lastPlanAt: this.lastPlanAt } : {}),
       ...(this.lastPlan ? { lastPlan: { ...this.lastPlan } } : {}),
     };

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -8,19 +8,28 @@ type SyncProgressSummary = DurableProgressSummary & { insertedTriples: number };
 
 type SyncFromPeerResult = number | SyncProgressSummary;
 
+export interface SyncOnConnectScopePlan {
+  /** Explicit plus automatic CGs frozen for the first durable request. */
+  initialDurableContextGraphIds: readonly string[];
+  /** Explicit intent re-read after discovery, merged with the frozen automatic tail. */
+  contextGraphIdsAfterDiscovery: () => string[];
+}
+
 export interface SyncOnConnectPeerOutcome {
   fresh: boolean;
   progress?: boolean;
 }
 
-interface SyncOnConnectContext {
+interface SyncOnConnectCommonContext {
   remotePeer: string;
   syncingPeers: Set<string>;
   getPeerProtocols: (peerId: string) => Promise<string[]>;
   knownCorePeerIds: Set<string>;
   knownCorePeerIdsV2?: Set<string>;
-  getSyncContextGraphs: () => string[];
-  getSharedMemorySyncContextGraphs?: (remotePeerId: string) => string[] | Promise<string[]>;
+  getSharedMemorySyncContextGraphs?: (
+    remotePeerId: string,
+    contextGraphIdsAfterDiscovery: readonly string[],
+  ) => string[] | Promise<string[]>;
   syncFromPeer: (peerId: string, contextGraphIds?: string[]) => Promise<SyncFromPeerResult>;
   refreshMetaSyncedFlags: (contextGraphIds: Iterable<string>) => Promise<void>;
   discoverContextGraphsFromStore: () => Promise<number>;
@@ -48,6 +57,18 @@ interface SyncOnConnectContext {
    * controls whether the periodic reconciler may write its long cooldown.
    */
   onPeerSynced?: (peerId: string, outcome?: SyncOnConnectPeerOutcome) => void;
+}
+
+interface SyncOnConnectContext extends SyncOnConnectCommonContext {
+  /** Legacy dynamic scope callback retained at the compatibility boundary. */
+  getSyncContextGraphs?: () => string[];
+  /** Legacy two-phase scope retained at the compatibility boundary. */
+  contextGraphScope?: SyncOnConnectScopePlan;
+}
+
+interface PlannedSyncOnConnectContext extends SyncOnConnectCommonContext {
+  /** Invoked only after the peer passes in-flight and protocol admission. */
+  createScopePlan: () => SyncOnConnectScopePlan;
 }
 
 export type SyncOnConnectOutcome = 'synced' | 'skipped-no-sync' | 'already-syncing' | 'deferred-backpressure';
@@ -106,14 +127,48 @@ function classifySyncResult(
   };
 }
 
-export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<SyncOnConnectOutcome> {
+/** Compatibility adapter for existing direct callers of the generic orchestrator. */
+export function runSyncOnConnect(context: SyncOnConnectContext): Promise<SyncOnConnectOutcome> {
+  const {
+    getSyncContextGraphs = () => [],
+    contextGraphScope,
+    syncFromPeer,
+    ...common
+  } = context;
+  let initialCall = true;
+  return runSyncOnConnectWithScopePlan({
+    ...common,
+    createScopePlan: () => contextGraphScope ?? (() => {
+      const initialDurableContextGraphIds = [...(getSyncContextGraphs() ?? [])];
+      return {
+        initialDurableContextGraphIds,
+        contextGraphIdsAfterDiscovery: () => getSyncContextGraphs() ?? [],
+      };
+    })(),
+    // Preserve the historical one-argument initial call shape for direct
+    // callback-only clients. Legacy two-phase callers already received an
+    // explicit scope, while the normalized orchestrator always supplies one.
+    syncFromPeer: (peerId, contextGraphIds) => {
+      if (initialCall && !contextGraphScope) {
+        initialCall = false;
+        return syncFromPeer(peerId);
+      }
+      initialCall = false;
+      return syncFromPeer(peerId, contextGraphIds);
+    },
+  });
+}
+
+export async function runSyncOnConnectWithScopePlan(
+  context: PlannedSyncOnConnectContext,
+): Promise<SyncOnConnectOutcome> {
   const {
     remotePeer,
     syncingPeers,
     getPeerProtocols,
     knownCorePeerIds,
     knownCorePeerIdsV2 = new Set<string>(),
-    getSyncContextGraphs,
+    createScopePlan,
     getSharedMemorySyncContextGraphs,
     syncFromPeer,
     refreshMetaSyncedFlags,
@@ -221,9 +276,18 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       return 'skipped-no-sync';
     }
 
+    const scopePlan = createScopePlan();
+    const initialDurableContextGraphIds = [...scopePlan.initialDurableContextGraphIds];
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);
-    const knownCgsBefore = new Set(getSyncContextGraphs() ?? []);
-    const synced = await syncFromPeer(remotePeer);
+    const knownCgsBefore = new Set(initialDurableContextGraphIds);
+    const synced = await syncFromPeer(
+      remotePeer,
+      [
+        SYSTEM_CONTEXT_GRAPHS.AGENTS,
+        SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+        ...initialDurableContextGraphIds,
+      ],
+    );
     const syncedAccounting = recordSyncAccounting(synced, 'durable');
     logInfo(ctx, `Synced ${syncedAccounting.insertedTriples} data triples from peer ${shortPeer}`);
     if (syncedAccounting.deferredByBackpressure) {
@@ -238,13 +302,13 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     const syncScope = new Set<string>([
       SYSTEM_CONTEXT_GRAPHS.AGENTS,
       SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
-      ...(getSyncContextGraphs() ?? []),
+      ...initialDurableContextGraphIds,
     ]);
     await runNonTransportStep(() => refreshMetaSyncedFlags(syncScope));
 
     await runNonTransportStep(() => discoverContextGraphsFromStore());
 
-    const allCgsAfter = getSyncContextGraphs() ?? [];
+    const allCgsAfter = scopePlan.contextGraphIdsAfterDiscovery();
     const newlyDiscovered = allCgsAfter.filter((id) => !knownCgsBefore.has(id));
     if (newlyDiscovered.length > 0) {
       logInfo(ctx, `Discovered ${newlyDiscovered.length} new CG(s) — syncing durable data from ${shortPeer}`);
@@ -264,8 +328,10 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
 
     durableSyncCompleted = true;
     const wsContextGraphIds = getSharedMemorySyncContextGraphs
-      ? await runNonTransportStep(() => Promise.resolve(getSharedMemorySyncContextGraphs(remotePeer)))
-      : getSyncContextGraphs() ?? [];
+      ? await runNonTransportStep(() => Promise.resolve(
+        getSharedMemorySyncContextGraphs(remotePeer, allCgsAfter),
+      ))
+      : allCgsAfter;
     if (syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
       const wsSynced = await syncSharedMemoryFromPeer(remotePeer, wsContextGraphIds);
       const sharedAccounting = recordSyncAccounting(wsSynced, 'shared');

--- a/packages/agent/test/context-graph-discovery-public-api.typecheck.ts
+++ b/packages/agent/test/context-graph-discovery-public-api.typecheck.ts
@@ -1,0 +1,16 @@
+import type {
+  ContextGraphDiscoveryOptions,
+} from '../src/index.js';
+
+const compatibilityOptOut = {
+  trackSyncScope: false,
+} satisfies ContextGraphDiscoveryOptions;
+
+void compatibilityOptOut;
+
+// Discovery disposition is node-local scheduling policy, not public API.
+// @ts-expect-error ContextGraphDiscoveryDisposition must remain internal.
+type InternalDisposition = import('../src/index.js').ContextGraphDiscoveryDisposition;
+
+declare const internalDisposition: InternalDisposition;
+void internalDisposition;

--- a/packages/agent/test/context-graph-subscription-public-api.typecheck.ts
+++ b/packages/agent/test/context-graph-subscription-public-api.typecheck.ts
@@ -1,0 +1,18 @@
+import type { ContextGraphSub } from '@origintrail-official/dkg-agent';
+
+// Source-compatibility fixture: this is the exported subscription shape from
+// before sync-admission lanes existed. Runtime normalization supplies the
+// admission before an agent stores the value as live state.
+const legacySubscription: ContextGraphSub = {
+  syncMode: 'always-on',
+  subscribed: true,
+  synced: false,
+};
+
+const currentSubscription: ContextGraphSub = {
+  ...legacySubscription,
+  syncAdmission: 'automatic-public',
+};
+
+void legacySubscription;
+void currentSubscription;

--- a/packages/agent/test/core-public-coverage-scheduler.test.ts
+++ b/packages/agent/test/core-public-coverage-scheduler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CorePublicSyncCoverageScheduler,
   DEFAULT_CORE_PUBLIC_SYNC_BATCH_SIZE,
+  DEFAULT_CORE_PUBLIC_SYNC_MAX_PLANNING_LANES,
   resolveCorePublicSyncBatchSize,
 } from '../src/sync/core-public-coverage-scheduler.js';
 
@@ -12,11 +13,9 @@ describe('Core public Context Graph coverage scheduler', () => {
     scheduler.register('selected');
     scheduler.register('public-b');
 
-    const plan = scheduler.plan(['selected', 'selected']);
+    const automaticCoverage = scheduler.planAutomaticCoverage(['selected', 'selected']);
 
-    expect(plan.selectedContextGraphIds).toEqual(['selected']);
-    expect(plan.coverageContextGraphIds).toHaveLength(1);
-    expect(plan.contextGraphIds).toEqual(['selected', 'public-a']);
+    expect(automaticCoverage).toEqual(['public-a']);
     expect(scheduler.getStatus(true)).toMatchObject({
       enabled: true,
       batchSize: 1,
@@ -36,9 +35,9 @@ describe('Core public Context Graph coverage scheduler', () => {
       scheduler.register(id);
     }
 
-    expect(scheduler.plan([]).coverageContextGraphIds).toEqual(['public-a', 'public-b']);
-    expect(scheduler.plan([]).coverageContextGraphIds).toEqual(['public-c', 'public-d']);
-    expect(scheduler.plan([]).coverageContextGraphIds).toEqual(['public-e', 'public-a']);
+    expect(scheduler.planAutomaticCoverage([])).toEqual(['public-a', 'public-b']);
+    expect(scheduler.planAutomaticCoverage([])).toEqual(['public-c', 'public-d']);
+    expect(scheduler.planAutomaticCoverage([])).toEqual(['public-e', 'public-a']);
   });
 
   it('honors priority ordering without starving lower-priority graphs', () => {
@@ -48,9 +47,32 @@ describe('Core public Context Graph coverage scheduler', () => {
     scheduler.register('high');
     const priorities = { high: 10, low: -10 };
 
-    expect(scheduler.plan([], priorities).coverageContextGraphIds).toEqual(['high']);
-    expect(scheduler.plan([], priorities).coverageContextGraphIds).toEqual(['normal']);
-    expect(scheduler.plan([], priorities).coverageContextGraphIds).toEqual(['low']);
+    expect(scheduler.planAutomaticCoverage([], priorities)).toEqual(['high']);
+    expect(scheduler.planAutomaticCoverage([], priorities)).toEqual(['normal']);
+    expect(scheduler.planAutomaticCoverage([], priorities)).toEqual(['low']);
+  });
+
+  it('anchors each lane to graph identity when priority ordering is rebuilt', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(1);
+    for (const id of ['public-a', 'public-b', 'public-c']) scheduler.register(id);
+
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-a')).toEqual(['public-a']);
+    expect(scheduler.planAutomaticCoverage([], { 'public-c': 10 }, 'peer-a'))
+      .toEqual(['public-b']);
+  });
+
+  it('resets only lanes anchored to an unregistered graph', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(1);
+    for (const id of ['public-a', 'public-b', 'public-c']) scheduler.register(id);
+
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-a')).toEqual(['public-a']);
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-b')).toEqual(['public-a']);
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-b')).toEqual(['public-b']);
+    expect(scheduler.unregister('public-a')).toBe(true);
+
+    expect(scheduler.getStatus(true).planningLanes).toBe(1);
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-a')).toEqual(['public-b']);
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-b')).toEqual(['public-c']);
   });
 
   it('rotates independently per peer so stable peer order cannot pin batches', () => {
@@ -59,13 +81,13 @@ describe('Core public Context Graph coverage scheduler', () => {
       scheduler.register(id);
     }
 
-    expect(scheduler.plan([], undefined, 'peer-a').coverageContextGraphIds)
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-a'))
       .toEqual(['public-a', 'public-b']);
-    expect(scheduler.plan([], undefined, 'peer-b').coverageContextGraphIds)
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-b'))
       .toEqual(['public-a', 'public-b']);
-    expect(scheduler.plan([], undefined, 'peer-a').coverageContextGraphIds)
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-a'))
       .toEqual(['public-b', 'public-c']);
-    expect(scheduler.plan([], undefined, 'peer-b').coverageContextGraphIds)
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-b'))
       .toEqual(['public-b', 'public-c']);
   });
 
@@ -76,41 +98,45 @@ describe('Core public Context Graph coverage scheduler', () => {
 
     const firstAttempted = new Set<string>();
     for (let round = 0; round < contextGraphIds.length; round += 1) {
-      firstAttempted.add(scheduler.plan([], undefined, 'failing-peer').coverageContextGraphIds[0]!);
+      firstAttempted.add(scheduler.planAutomaticCoverage([], undefined, 'failing-peer')[0]!);
     }
 
     expect(firstAttempted).toEqual(new Set(contextGraphIds));
   });
 
-  it('retains fairness across more peer lanes than a Core can normally connect', () => {
+  it('bounds peer-lane state internally while retaining active-lane fairness', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(1, Date.now, 3);
+    scheduler.register('public-a');
+    scheduler.register('public-b');
+    for (const peer of ['peer-a', 'peer-b', 'peer-c', 'peer-d']) {
+      expect(scheduler.planAutomaticCoverage([], undefined, peer)).toEqual(['public-a']);
+    }
+
+    expect(scheduler.getStatus(true).planningLanes).toBe(3);
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-d')).toEqual(['public-b']);
+    expect(scheduler.planAutomaticCoverage([], undefined, 'peer-a')).toEqual(['public-a']);
+    expect(scheduler.getStatus(true).planningLanes).toBe(3);
+    expect(DEFAULT_CORE_PUBLIC_SYNC_MAX_PLANNING_LANES).toBeGreaterThan(3);
+  });
+
+  it('never exceeds the production lane cap under transient peer churn', () => {
     const scheduler = new CorePublicSyncCoverageScheduler(1);
     scheduler.register('public-a');
     scheduler.register('public-b');
-    const peers = Array.from({ length: 2_100 }, (_, index) => `peer-${index}`);
 
-    for (const peer of peers) {
-      expect(scheduler.plan([], undefined, peer).coverageContextGraphIds).toEqual(['public-a']);
+    for (let index = 0; index < DEFAULT_CORE_PUBLIC_SYNC_MAX_PLANNING_LANES + 52; index += 1) {
+      scheduler.planAutomaticCoverage([], undefined, `transient-peer-${index}`);
     }
-    for (const peer of peers) {
-      expect(scheduler.plan([], undefined, peer).coverageContextGraphIds).toEqual(['public-b']);
-    }
+
+    expect(scheduler.getStatus(true).planningLanes)
+      .toBe(DEFAULT_CORE_PUBLIC_SYNC_MAX_PLANNING_LANES);
   });
 
-  it('releases peer-lane cursor state when lifecycle pruning removes a peer', () => {
-    const scheduler = new CorePublicSyncCoverageScheduler(1);
-    scheduler.register('public-a');
-    scheduler.plan([], undefined, 'departed-peer');
-
-    expect(scheduler.getStatus(true).planningLanes).toBe(1);
-    expect(scheduler.releasePlanningLane('departed-peer')).toBe(true);
-    expect(scheduler.getStatus(true).planningLanes).toBe(0);
-  });
-
-  it('keeps explicit selections active when automatic coverage is disabled', () => {
+  it('returns no automatic tail when coverage is disabled', () => {
     const scheduler = new CorePublicSyncCoverageScheduler(0);
     scheduler.register('public-a');
 
-    expect(scheduler.plan(['selected']).contextGraphIds).toEqual(['selected']);
+    expect(scheduler.planAutomaticCoverage(['selected'])).toEqual([]);
     expect(scheduler.getStatus(true)).toMatchObject({
       enabled: false,
       batchSize: 0,

--- a/packages/agent/test/core-public-coverage-scheduler.test.ts
+++ b/packages/agent/test/core-public-coverage-scheduler.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CorePublicSyncCoverageScheduler,
+  DEFAULT_CORE_PUBLIC_SYNC_BATCH_SIZE,
+  resolveCorePublicSyncBatchSize,
+} from '../src/sync/core-public-coverage-scheduler.js';
+
+describe('Core public Context Graph coverage scheduler', () => {
+  it('always admits explicit selections outside the automatic coverage cap', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(1, () => 123);
+    scheduler.register('public-a');
+    scheduler.register('selected');
+    scheduler.register('public-b');
+
+    const plan = scheduler.plan(['selected', 'selected']);
+
+    expect(plan.selectedContextGraphIds).toEqual(['selected']);
+    expect(plan.coverageContextGraphIds).toHaveLength(1);
+    expect(plan.contextGraphIds).toEqual(['selected', 'public-a']);
+    expect(scheduler.getStatus(true)).toMatchObject({
+      enabled: true,
+      batchSize: 1,
+      trackedContextGraphs: 3,
+      lastPlanAt: 123,
+      lastPlan: {
+        selectedContextGraphs: 1,
+        coverageContextGraphs: 1,
+        totalContextGraphs: 2,
+      },
+    });
+  });
+
+  it('rotates bounded batches so every tracked public graph is eventually admitted', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(2);
+    for (const id of ['public-a', 'public-b', 'public-c', 'public-d', 'public-e']) {
+      scheduler.register(id);
+    }
+
+    expect(scheduler.plan([]).coverageContextGraphIds).toEqual(['public-a', 'public-b']);
+    expect(scheduler.plan([]).coverageContextGraphIds).toEqual(['public-c', 'public-d']);
+    expect(scheduler.plan([]).coverageContextGraphIds).toEqual(['public-e', 'public-a']);
+  });
+
+  it('honors priority ordering without starving lower-priority graphs', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(1);
+    scheduler.register('normal');
+    scheduler.register('low');
+    scheduler.register('high');
+    const priorities = { high: 10, low: -10 };
+
+    expect(scheduler.plan([], priorities).coverageContextGraphIds).toEqual(['high']);
+    expect(scheduler.plan([], priorities).coverageContextGraphIds).toEqual(['normal']);
+    expect(scheduler.plan([], priorities).coverageContextGraphIds).toEqual(['low']);
+  });
+
+  it('rotates independently per peer so stable peer order cannot pin batches', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(2);
+    for (const id of ['public-a', 'public-b', 'public-c', 'public-d']) {
+      scheduler.register(id);
+    }
+
+    expect(scheduler.plan([], undefined, 'peer-a').coverageContextGraphIds)
+      .toEqual(['public-a', 'public-b']);
+    expect(scheduler.plan([], undefined, 'peer-b').coverageContextGraphIds)
+      .toEqual(['public-a', 'public-b']);
+    expect(scheduler.plan([], undefined, 'peer-a').coverageContextGraphIds)
+      .toEqual(['public-b', 'public-c']);
+    expect(scheduler.plan([], undefined, 'peer-b').coverageContextGraphIds)
+      .toEqual(['public-b', 'public-c']);
+  });
+
+  it('eventually puts every graph first when each batch fails fast on its first graph', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(4);
+    const contextGraphIds = Array.from({ length: 8 }, (_, index) => `public-${index}`);
+    for (const id of contextGraphIds) scheduler.register(id);
+
+    const firstAttempted = new Set<string>();
+    for (let round = 0; round < contextGraphIds.length; round += 1) {
+      firstAttempted.add(scheduler.plan([], undefined, 'failing-peer').coverageContextGraphIds[0]!);
+    }
+
+    expect(firstAttempted).toEqual(new Set(contextGraphIds));
+  });
+
+  it('retains fairness across more peer lanes than a Core can normally connect', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(1);
+    scheduler.register('public-a');
+    scheduler.register('public-b');
+    const peers = Array.from({ length: 2_100 }, (_, index) => `peer-${index}`);
+
+    for (const peer of peers) {
+      expect(scheduler.plan([], undefined, peer).coverageContextGraphIds).toEqual(['public-a']);
+    }
+    for (const peer of peers) {
+      expect(scheduler.plan([], undefined, peer).coverageContextGraphIds).toEqual(['public-b']);
+    }
+  });
+
+  it('releases peer-lane cursor state when lifecycle pruning removes a peer', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(1);
+    scheduler.register('public-a');
+    scheduler.plan([], undefined, 'departed-peer');
+
+    expect(scheduler.getStatus(true).planningLanes).toBe(1);
+    expect(scheduler.releasePlanningLane('departed-peer')).toBe(true);
+    expect(scheduler.getStatus(true).planningLanes).toBe(0);
+  });
+
+  it('keeps explicit selections active when automatic coverage is disabled', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(0);
+    scheduler.register('public-a');
+
+    expect(scheduler.plan(['selected']).contextGraphIds).toEqual(['selected']);
+    expect(scheduler.getStatus(true)).toMatchObject({
+      enabled: false,
+      batchSize: 0,
+      trackedContextGraphs: 1,
+      planningLanes: 0,
+    });
+  });
+
+  it('resolves the env override and rejects unsafe batch sizes', () => {
+    expect(resolveCorePublicSyncBatchSize(undefined, undefined))
+      .toBe(DEFAULT_CORE_PUBLIC_SYNC_BATCH_SIZE);
+    expect(resolveCorePublicSyncBatchSize(3, '5')).toBe(5);
+    expect(() => resolveCorePublicSyncBatchSize(-1, undefined)).toThrow(/syncCorePublicBatchSize/);
+    expect(() => resolveCorePublicSyncBatchSize(3, '1.5'))
+      .toThrow(/DKG_SYNC_CORE_PUBLIC_BATCH_SIZE/);
+  });
+});

--- a/packages/agent/test/discovery-subscription-boundary.test.ts
+++ b/packages/agent/test/discovery-subscription-boundary.test.ts
@@ -746,6 +746,57 @@ describe('Context Graph discovery/subscription boundary', () => {
     }
   }, 60_000);
 
+  it('keeps configured explicit Core scope authoritative over persisted automatic admission', async () => {
+    const contextGraphId = 'configured-over-persisted-automatic';
+    const persisted = new Map<string, ContextGraphSubscriptionRecord>([[
+      contextGraphId,
+      {
+        id: contextGraphId,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        onChainId: `0x${'9'.repeat(64)}`,
+        syncAdmission: 'automatic-public',
+        syncScoped: false,
+      },
+    ]]);
+    let agent: DKGAgent | undefined;
+
+    try {
+      agent = await DKGAgent.create({
+        name: 'ConfiguredCoreAdmissionOverride',
+        listenHost: '127.0.0.1',
+        nodeRole: 'core',
+        chainAdapter: new MockChainAdapter(),
+        syncContextGraphs: [contextGraphId],
+        contextGraphSubscriptionStore: {
+          loadAll: async () => [...persisted.values()].map((row) => ({ ...row })),
+          save: async (record) => { persisted.set(record.id, { ...record }); },
+          delete: async (id) => { persisted.delete(id); },
+        },
+      });
+
+      await agent.start();
+
+      expect(agent.getSubscribedContextGraphs().get(contextGraphId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'explicit',
+      });
+      expect((agent as any).config.syncContextGraphs).toContain(contextGraphId);
+      expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(0);
+      expect((agent as any).planCorePublicSyncPeerRound('configured-peer')).toMatchObject({
+        initialDurableContextGraphIds: [contextGraphId],
+        automaticContextGraphIds: [],
+      });
+      // The configured override is intentionally an operator overlay; the
+      // durable baseline remains automatic if the selection is later removed.
+      expect(persisted.get(contextGraphId)?.syncAdmission).toBe('automatic-public');
+    } finally {
+      await agent?.stop().catch(() => {});
+    }
+  }, 60_000);
+
   it('continues legacy Core rehydration after one access-policy lookup fails', async () => {
     const failingId = 'legacy-policy-a-fails';
     const validId = 'legacy-policy-b-valid';

--- a/packages/agent/test/discovery-subscription-boundary.test.ts
+++ b/packages/agent/test/discovery-subscription-boundary.test.ts
@@ -412,6 +412,19 @@ describe('Context Graph discovery/subscription boundary', () => {
       expect((agent as any).gossipRegistered.has(localId)).toBe(true);
       expect((agent as any).config.syncContextGraphs ?? []).not.toContain(localId);
       expect(persisted.get(localId)).toMatchObject({ subscribed: true, syncScoped: false });
+      expect(agent.getCorePublicSyncCoverageStatus()).toMatchObject({
+        enabled: true,
+        trackedContextGraphs: 1,
+      });
+      expect((agent as any).planAutomaticCorePublicSyncContextGraphsForPeerRound('peer-a'))
+        .toEqual([localId]);
+
+      agent.unsubscribeFromContextGraph(localId);
+      expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(0);
+      expect((agent as any).planAutomaticCorePublicSyncContextGraphsForPeerRound('peer-a'))
+        .toEqual([]);
+      expect(await agent.discoverContextGraphsFromChain()).toBe(0);
+      expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(0);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/discovery-subscription-boundary.test.ts
+++ b/packages/agent/test/discovery-subscription-boundary.test.ts
@@ -14,11 +14,33 @@ import { MockChainAdapter, type ContextGraphOnChain } from '@origintrail-officia
 import {
   AGENT_REGISTRY_CONTEXT_GRAPH,
   DKGAgent,
+  type ContextGraphSub,
   type ContextGraphMembershipRecord,
   type ContextGraphSubscriptionRecord,
 } from '../src/index.js';
+import { normalizeLegacyContextGraphSubscriptionInput } from '../src/context-graph-subscription-policy.js';
 
 describe('Context Graph discovery/subscription boundary', () => {
+  it('normalizes the legacy public subscription shape before it enters live state', () => {
+    const legacySubscription: ContextGraphSub = {
+      syncMode: 'always-on',
+      subscribed: true,
+      synced: false,
+    };
+
+    const normalized = normalizeLegacyContextGraphSubscriptionInput(
+      undefined,
+      legacySubscription,
+    );
+
+    expect(normalized).toMatchObject({
+      syncMode: 'always-on',
+      syncAdmission: 'none',
+      subscribed: true,
+      synced: false,
+    });
+  });
+
   it('keeps discovery passive, activates explicit intent, and rehydrates only the explicit subscription', async () => {
     expect([...Object.values(SYSTEM_CONTEXT_GRAPHS)].sort()).toEqual(['agents', 'ontology']);
     expect(AGENT_REGISTRY_CONTEXT_GRAPH).toBe(SYSTEM_CONTEXT_GRAPHS.AGENTS);

--- a/packages/agent/test/discovery-subscription-boundary.test.ts
+++ b/packages/agent/test/discovery-subscription-boundary.test.ts
@@ -451,6 +451,61 @@ describe('Context Graph discovery/subscription boundary', () => {
     }
   }, 30_000);
 
+  it('keeps an explicitly selected public Core graph uncapped after rediscovery', async () => {
+    const contextGraphId = 'explicit-public-rediscovery';
+    const persisted = new Map<string, ContextGraphSubscriptionRecord>();
+    const agent = await DKGAgent.create({
+      name: 'ExplicitPublicRediscovery',
+      listenHost: '127.0.0.1',
+      nodeRole: 'core',
+      chainAdapter: new MockChainAdapter(),
+      syncCorePublicBatchSize: 0,
+      contextGraphSubscriptionStore: {
+        loadAll: async () => [...persisted.values()].map((row) => ({ ...row })),
+        save: async (record) => { persisted.set(record.id, { ...record }); },
+        delete: async (id) => { persisted.delete(id); },
+      },
+    });
+
+    try {
+      await agent.start();
+      agent.subscribeToContextGraph(contextGraphId);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(agent.getSubscribedContextGraphs().get(contextGraphId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'explicit',
+      });
+      expect((agent as any).config.syncContextGraphs).toContain(contextGraphId);
+
+      agent.recordDiscoveredContextGraph(contextGraphId, {
+        name: 'Explicit Public Rediscovery',
+        accessPolicy: 'public',
+        onChainId: `0x${'5'.repeat(64)}`,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(agent.getSubscribedContextGraphs().get(contextGraphId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'explicit',
+        onChainId: `0x${'5'.repeat(64)}`,
+      });
+      expect((agent as any).config.syncContextGraphs).toContain(contextGraphId);
+      expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(0);
+      expect((agent as any).planCorePublicSyncPeerRound('explicit-peer')).toMatchObject({
+        initialDurableContextGraphIds: [contextGraphId],
+        automaticContextGraphIds: [],
+      });
+      expect(persisted.get(contextGraphId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'explicit',
+        syncScoped: true,
+      });
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  }, 30_000);
+
   it('catalogues revealed chain entries while retaining their authoritative ID', async () => {
     const onChainId = `0x${'b'.repeat(64)}`;
     let accessPolicy = 0;
@@ -746,7 +801,7 @@ describe('Context Graph discovery/subscription boundary', () => {
     }
   }, 60_000);
 
-  it('keeps configured explicit Core scope authoritative over persisted automatic admission', async () => {
+  it('keeps configured explicit Core scope live-only across an ordinary save and restart', async () => {
     const contextGraphId = 'configured-over-persisted-automatic';
     const persisted = new Map<string, ContextGraphSubscriptionRecord>([[
       contextGraphId,
@@ -761,7 +816,15 @@ describe('Context Graph discovery/subscription boundary', () => {
         syncScoped: false,
       },
     ]]);
+    const subscriptionStore = {
+      loadAll: async () => [...persisted.values()].map((row) => ({ ...row })),
+      save: async (record: ContextGraphSubscriptionRecord) => {
+        persisted.set(record.id, { ...record });
+      },
+      delete: async (id: string) => { persisted.delete(id); },
+    };
     let agent: DKGAgent | undefined;
+    let restarted: DKGAgent | undefined;
 
     try {
       agent = await DKGAgent.create({
@@ -770,11 +833,8 @@ describe('Context Graph discovery/subscription boundary', () => {
         nodeRole: 'core',
         chainAdapter: new MockChainAdapter(),
         syncContextGraphs: [contextGraphId],
-        contextGraphSubscriptionStore: {
-          loadAll: async () => [...persisted.values()].map((row) => ({ ...row })),
-          save: async (record) => { persisted.set(record.id, { ...record }); },
-          delete: async (id) => { persisted.delete(id); },
-        },
+        syncCorePublicBatchSize: 1,
+        contextGraphSubscriptionStore: subscriptionStore,
       });
 
       await agent.start();
@@ -792,8 +852,41 @@ describe('Context Graph discovery/subscription boundary', () => {
       // The configured override is intentionally an operator overlay; the
       // durable baseline remains automatic if the selection is later removed.
       expect(persisted.get(contextGraphId)?.syncAdmission).toBe('automatic-public');
+
+      agent.markContextGraphSubscriptionState(contextGraphId, { metaSynced: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(persisted.get(contextGraphId)).toMatchObject({
+        metaSynced: true,
+        syncAdmission: 'automatic-public',
+        syncScoped: false,
+      });
+
+      await agent.stop();
+      agent = undefined;
+
+      restarted = await DKGAgent.create({
+        name: 'ConfiguredCoreAdmissionRemoved',
+        listenHost: '127.0.0.1',
+        nodeRole: 'core',
+        chainAdapter: new MockChainAdapter(),
+        syncCorePublicBatchSize: 1,
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      await restarted.start();
+
+      expect(restarted.getSubscribedContextGraphs().get(contextGraphId)).toMatchObject({
+        subscribed: true,
+        metaSynced: true,
+        syncAdmission: 'automatic-public',
+      });
+      expect((restarted as any).config.syncContextGraphs ?? []).not.toContain(contextGraphId);
+      expect(restarted.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(1);
+      expect((restarted as any).planCorePublicSyncPeerRound('automatic-peer')).toMatchObject({
+        automaticContextGraphIds: [contextGraphId],
+      });
     } finally {
       await agent?.stop().catch(() => {});
+      await restarted?.stop().catch(() => {});
     }
   }, 60_000);
 

--- a/packages/agent/test/discovery-subscription-boundary.test.ts
+++ b/packages/agent/test/discovery-subscription-boundary.test.ts
@@ -182,8 +182,12 @@ describe('Context Graph discovery/subscription boundary', () => {
           metaSynced: false,
         });
         expect((agent as any).gossipRegistered.has(id)).toBe(role === 'core');
-        expect(((agent as any).config.syncContextGraphs ?? []).includes(id)).toBe(role === 'core');
+        expect((agent as any).config.syncContextGraphs ?? []).not.toContain(id);
         expect(persisted.has(id)).toBe(role === 'core');
+        if (role === 'core') {
+          expect(persisted.get(id)).toMatchObject({ subscribed: true, syncScoped: false });
+          expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(0);
+        }
 
         const inserted = await agent.store.query(`
           ASK WHERE {
@@ -282,13 +286,42 @@ describe('Context Graph discovery/subscription boundary', () => {
 
     try {
       await agent.start();
+      const compatibilityId = 'core-discovery-compat-opt-out';
+      agent.recordDiscoveredContextGraph(compatibilityId, {
+        name: compatibilityId,
+        accessPolicy: 'private',
+      }, { trackSyncScope: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(agent.getSubscribedContextGraphs().get(compatibilityId)?.subscribed).toBe(true);
+      expect((agent as any).gossipRegistered.has(compatibilityId)).toBe(true);
+      expect((agent as any).config.syncContextGraphs ?? []).not.toContain(compatibilityId);
+      expect(persisted.get(compatibilityId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'none',
+        syncScoped: false,
+      });
+      agent.unsubscribeFromContextGraph(compatibilityId);
+
       const publicId = 'core-store-public';
+      const publicOnChainId = `0x${'9'.repeat(64)}`;
       const curatedId = 'core-store-curated';
       await agent.store.insert([
         {
           subject: contextGraphDataGraphUri(publicId),
           predicate: DKG_ONTOLOGY.RDF_TYPE,
           object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+          graph: contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
+        },
+        {
+          subject: contextGraphDataGraphUri(publicId),
+          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+          object: `"${publicOnChainId}"`,
+          graph: contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
+        },
+        {
+          subject: contextGraphDataGraphUri(publicId),
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"public"',
           graph: contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
         },
         {
@@ -308,12 +341,24 @@ describe('Context Graph discovery/subscription boundary', () => {
       expect(await agent.discoverContextGraphsFromStore()).toBe(2);
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      for (const id of [publicId, curatedId]) {
-        expect(agent.getSubscribedContextGraphs().get(id)?.subscribed).toBe(true);
-        expect((agent as any).gossipRegistered.has(id)).toBe(true);
-        expect((agent as any).config.syncContextGraphs ?? []).toContain(id);
-        expect(persisted.get(id)).toMatchObject({ subscribed: true, syncScoped: true });
-      }
+      expect(agent.getSubscribedContextGraphs().get(publicId)?.subscribed).toBe(true);
+      expect((agent as any).gossipRegistered.has(publicId)).toBe(true);
+      expect((agent as any).config.syncContextGraphs ?? []).not.toContain(publicId);
+      expect(persisted.get(publicId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'automatic-public',
+        syncScoped: false,
+      });
+      expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(1);
+
+      expect(agent.getSubscribedContextGraphs().get(curatedId)?.subscribed).toBe(true);
+      expect((agent as any).gossipRegistered.has(curatedId)).toBe(true);
+      expect((agent as any).config.syncContextGraphs ?? []).toContain(curatedId);
+      expect(persisted.get(curatedId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'explicit',
+        syncScoped: true,
+      });
 
       let capturedProfile: Record<string, unknown> | undefined;
       (agent as any).profileManager.publishProfile = async (profile: Record<string, unknown>) => {
@@ -327,7 +372,57 @@ describe('Context Graph discovery/subscription boundary', () => {
       agent.unsubscribeFromContextGraph(publicId);
       expect(await agent.discoverContextGraphsFromStore()).toBe(0);
       expect(agent.getSubscribedContextGraphs().get(publicId)?.subscribed).toBe(false);
+      expect(agent.getSubscribedContextGraphs().get(publicId)?.syncAdmission).toBe('none');
       expect((agent as any).gossipRegistered.has(publicId)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  }, 30_000);
+
+  it('bounds store-discovered public coverage without capping explicit scope', async () => {
+    const publicIds = ['store-public-a', 'store-public-b', 'store-public-c'];
+    const agent = await DKGAgent.create({
+      name: 'BoundedCoreStoreDiscovery',
+      listenHost: '127.0.0.1',
+      nodeRole: 'core',
+      chainAdapter: new MockChainAdapter(),
+      syncContextGraphs: ['explicit-selection'],
+      syncCorePublicBatchSize: 2,
+    });
+
+    try {
+      await agent.start();
+      await agent.store.insert(publicIds.flatMap((id, index) => ([
+        {
+          subject: contextGraphDataGraphUri(id),
+          predicate: DKG_ONTOLOGY.RDF_TYPE,
+          object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+          graph: contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
+        },
+        {
+          subject: contextGraphDataGraphUri(id),
+          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+          object: `"0x${String(index + 1).repeat(64)}"`,
+          graph: contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
+        },
+        {
+          subject: contextGraphDataGraphUri(id),
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"public"',
+          graph: contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
+        },
+      ])));
+
+      expect(await agent.discoverContextGraphsFromStore()).toBe(3);
+      expect((agent as any).config.syncContextGraphs).toEqual(['explicit-selection']);
+      expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(3);
+
+      const scope = (agent as any).planCorePublicSyncPeerRound('store-peer');
+      const planned = scope.initialDurableContextGraphIds;
+      expect(planned[0]).toBe('explicit-selection');
+      expect(planned.slice(1)).toHaveLength(2);
+      expect(new Set(planned.slice(1)).size).toBe(2);
+      expect(planned.slice(1).every((id: string) => publicIds.includes(id))).toBe(true);
     } finally {
       await agent.stop().catch(() => {});
     }
@@ -335,12 +430,13 @@ describe('Context Graph discovery/subscription boundary', () => {
 
   it('catalogues revealed chain entries while retaining their authoritative ID', async () => {
     const onChainId = `0x${'b'.repeat(64)}`;
+    let accessPolicy = 0;
     const chain = new MockChainAdapter();
     (chain as any).listContextGraphsFromChain = async () => ([{
       contextGraphId: onChainId,
       name: 'chain-discovery-only',
       creator: '0x1111111111111111111111111111111111111111',
-      accessPolicy: 0,
+      accessPolicy,
       blockNumber: 100,
       metadataRevealed: true,
     }] satisfies ContextGraphOnChain[]);
@@ -368,24 +464,40 @@ describe('Context Graph discovery/subscription boundary', () => {
       expect((agent as any).config.syncContextGraphs ?? []).not.toContain('chain-discovery-only');
       expect((agent as any).gossipRegistered.has('chain-discovery-only')).toBe(false);
       expect(persisted.has('chain-discovery-only')).toBe(false);
+      expect(await (agent as any).getExplicitAccessPolicy('chain-discovery-only')).toBe('public');
+      accessPolicy = 1;
       expect(await agent.discoverContextGraphsFromChain()).toBe(0);
+      expect(await (agent as any).getExplicitAccessPolicy('chain-discovery-only')).toBe('private');
     } finally {
       await agent.stop().catch(() => {});
     }
   }, 30_000);
 
-  it('auto-subscribes a core to chain discovery while preserving the legacy non-sync-scoped mode', async () => {
+  it('classifies public chain coverage as automatic and curator-private coverage as explicit', async () => {
     const onChainId = `0x${'d'.repeat(64)}`;
+    const privateOnChainId = `0x${'6'.repeat(64)}`;
     const localId = 'core-chain-discovery';
+    const privateId = 'core-chain-private';
+    let curatorAddress = '';
     const chain = new MockChainAdapter();
-    (chain as any).listContextGraphsFromChain = async () => ([{
-      contextGraphId: onChainId,
-      name: localId,
-      creator: '0x1111111111111111111111111111111111111111',
-      accessPolicy: 0,
-      blockNumber: 102,
-      metadataRevealed: true,
-    }] satisfies ContextGraphOnChain[]);
+    (chain as any).listContextGraphsFromChain = async () => ([
+      {
+        contextGraphId: onChainId,
+        name: localId,
+        creator: '0x1111111111111111111111111111111111111111',
+        accessPolicy: 0,
+        blockNumber: 102,
+        metadataRevealed: true,
+      },
+      {
+        contextGraphId: privateOnChainId,
+        name: privateId,
+        creator: curatorAddress,
+        accessPolicy: 1,
+        blockNumber: 103,
+        metadataRevealed: true,
+      },
+    ] satisfies ContextGraphOnChain[]);
     const persisted = new Map<string, ContextGraphSubscriptionRecord>();
     const agent = await DKGAgent.create({
       name: 'CoreChainDiscovery',
@@ -401,7 +513,9 @@ describe('Context Graph discovery/subscription boundary', () => {
 
     try {
       await agent.start();
-      expect(await agent.discoverContextGraphsFromChain()).toBe(1);
+      curatorAddress = '0x1111111111111111111111111111111111111111';
+      (agent as any).defaultAgentAddress = curatorAddress;
+      expect(await agent.discoverContextGraphsFromChain()).toBe(2);
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(agent.getSubscribedContextGraphs().get(localId)).toMatchObject({
@@ -411,24 +525,116 @@ describe('Context Graph discovery/subscription boundary', () => {
       });
       expect((agent as any).gossipRegistered.has(localId)).toBe(true);
       expect((agent as any).config.syncContextGraphs ?? []).not.toContain(localId);
-      expect(persisted.get(localId)).toMatchObject({ subscribed: true, syncScoped: false });
+      expect(persisted.get(localId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'automatic-public',
+        syncScoped: false,
+      });
+      expect(agent.getSubscribedContextGraphs().get(privateId)).toMatchObject({
+        subscribed: true,
+        synced: false,
+        onChainId: privateOnChainId,
+      });
+      expect((agent as any).config.syncContextGraphs ?? []).toContain(privateId);
+      expect(persisted.get(privateId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'explicit',
+        syncScoped: true,
+      });
       expect(agent.getCorePublicSyncCoverageStatus()).toMatchObject({
         enabled: true,
         trackedContextGraphs: 1,
       });
-      expect((agent as any).planAutomaticCorePublicSyncContextGraphsForPeerRound('peer-a'))
+      expect((agent as any).planCorePublicSyncPeerRound('peer-a').automaticContextGraphIds)
         .toEqual([localId]);
 
       agent.unsubscribeFromContextGraph(localId);
       expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(0);
-      expect((agent as any).planAutomaticCorePublicSyncContextGraphsForPeerRound('peer-a'))
+      expect((agent as any).planCorePublicSyncPeerRound('peer-a').automaticContextGraphIds)
         .toEqual([]);
       expect(await agent.discoverContextGraphsFromChain()).toBe(0);
       expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(0);
+      expect((agent as any).config.syncContextGraphs ?? []).toContain(privateId);
     } finally {
       await agent.stop().catch(() => {});
     }
   }, 30_000);
+
+  it('rehydrates automatic public Core coverage before another chain scan succeeds', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-core-coverage-restart-'));
+    const localId = 'core-public-restart';
+    const onChainId = `0x${'7'.repeat(64)}`;
+    const persisted = new Map<string, ContextGraphSubscriptionRecord>();
+    const subscriptionStore = {
+      loadAll: async () => [...persisted.values()],
+      save: async (record: ContextGraphSubscriptionRecord) => {
+        persisted.set(record.id, { ...record });
+      },
+      delete: async (id: string) => { persisted.delete(id); },
+    };
+    const discoveryChain = new MockChainAdapter();
+    (discoveryChain as any).listContextGraphsFromChain = async () => ([{
+      contextGraphId: onChainId,
+      name: localId,
+      creator: '0x1111111111111111111111111111111111111111',
+      accessPolicy: 0,
+      blockNumber: 104,
+      metadataRevealed: true,
+    }] satisfies ContextGraphOnChain[]);
+    let first: DKGAgent | undefined;
+    let restarted: DKGAgent | undefined;
+
+    try {
+      first = await DKGAgent.create({
+        name: 'CoreCoverageRestartFirst',
+        listenHost: '127.0.0.1',
+        nodeRole: 'core',
+        chainAdapter: discoveryChain,
+        contextGraphSubscriptionStore: subscriptionStore,
+        dataDir,
+      });
+      await first.start();
+      expect(await first.discoverContextGraphsFromChain()).toBe(1);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(persisted.get(localId)).toMatchObject({
+        subscribed: true,
+        onChainId,
+        syncAdmission: 'automatic-public',
+        syncScoped: false,
+      });
+      expect(first.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(1);
+      await first.stop();
+      first = undefined;
+
+      const offlineChain = new MockChainAdapter();
+      (offlineChain as any).listContextGraphsFromChain = async () => {
+        throw new Error('chain RPC unavailable');
+      };
+      restarted = await DKGAgent.create({
+        name: 'CoreCoverageRestartOffline',
+        listenHost: '127.0.0.1',
+        nodeRole: 'core',
+        chainAdapter: offlineChain,
+        contextGraphSubscriptionStore: subscriptionStore,
+        dataDir,
+      });
+      await restarted.start();
+
+      expect(restarted.getSubscribedContextGraphs().get(localId)).toMatchObject({
+        subscribed: true,
+        onChainId,
+        syncAdmission: 'automatic-public',
+      });
+      expect((restarted as any).config.syncContextGraphs ?? []).not.toContain(localId);
+      expect(restarted.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(1);
+      expect((restarted as any).planCorePublicSyncPeerRound('restart-peer').automaticContextGraphIds)
+        .toEqual([localId]);
+    } finally {
+      await first?.stop().catch(() => {});
+      await restarted?.stop().catch(() => {});
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  }, 60_000);
 
   it('reconstructs an OnChainId-only edge catalogue entry after restart without chain RPC', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'dkg-discovery-restart-'));

--- a/packages/agent/test/discovery-subscription-boundary.test.ts
+++ b/packages/agent/test/discovery-subscription-boundary.test.ts
@@ -7,6 +7,7 @@ import {
   contextGraphDataGraphUri,
   contextGraphMetaGraphUri,
   DKG_ONTOLOGY,
+  Logger,
   SYSTEM_CONTEXT_GRAPHS,
 } from '@origintrail-official/dkg-core';
 import { MockChainAdapter, type ContextGraphOnChain } from '@origintrail-official/dkg-chain';
@@ -720,6 +721,73 @@ describe('Context Graph discovery/subscription boundary', () => {
     } finally {
       await first?.stop().catch(() => {});
       await restarted?.stop().catch(() => {});
+    }
+  }, 60_000);
+
+  it('continues legacy Core rehydration after one access-policy lookup fails', async () => {
+    const failingId = 'legacy-policy-a-fails';
+    const validId = 'legacy-policy-b-valid';
+    const persisted = new Map<string, ContextGraphSubscriptionRecord>([
+      failingId,
+      validId,
+    ].map((id, index) => [
+      id,
+      {
+        id,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        onChainId: `0x${String(index + 4).repeat(64)}`,
+        syncScoped: true,
+      },
+    ]));
+    const warnings: string[] = [];
+    let agent: DKGAgent | undefined;
+    Logger.setSink((entry) => {
+      if (entry.level === 'warn') warnings.push(entry.message);
+    });
+
+    try {
+      agent = await DKGAgent.create({
+        name: 'LegacyCoreCoveragePolicyFailure',
+        listenHost: '127.0.0.1',
+        nodeRole: 'core',
+        chainAdapter: new MockChainAdapter(),
+        contextGraphSubscriptionStore: {
+          loadAll: async () => [...persisted.values()].map((row) => ({ ...row })),
+          save: async (record) => { persisted.set(record.id, { ...record }); },
+          delete: async (id) => { persisted.delete(id); },
+        },
+      });
+      (agent as any).getExplicitAccessPolicy = async (id: string) => {
+        if (id === failingId) throw new Error('policy projection unavailable');
+        return 'public';
+      };
+
+      await agent.start();
+
+      expect(agent.getSubscribedContextGraphs().get(failingId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'explicit',
+      });
+      expect(agent.getSubscribedContextGraphs().get(validId)).toMatchObject({
+        subscribed: true,
+        syncAdmission: 'automatic-public',
+      });
+      expect(persisted.get(failingId)).toMatchObject({
+        syncAdmission: 'explicit',
+        syncScoped: true,
+      });
+      expect(persisted.get(validId)).toMatchObject({
+        syncAdmission: 'automatic-public',
+        syncScoped: false,
+      });
+      expect(warnings).toContainEqual(expect.stringContaining(failingId));
+      expect(warnings).toContainEqual(expect.stringContaining('policy projection unavailable'));
+    } finally {
+      await agent?.stop().catch(() => {});
+      Logger.setSink(null);
     }
   }, 60_000);
 

--- a/packages/agent/test/discovery-subscription-boundary.test.ts
+++ b/packages/agent/test/discovery-subscription-boundary.test.ts
@@ -636,6 +636,93 @@ describe('Context Graph discovery/subscription boundary', () => {
     }
   }, 60_000);
 
+  it('migrates legacy public Core rows without treating persisted syncScoped as operator intent', async () => {
+    const explicitId = 'legacy-public-configured';
+    const automaticIds = ['legacy-public-automatic-a', 'legacy-public-automatic-b'];
+    const allIds = [explicitId, ...automaticIds];
+    const persisted = new Map<string, ContextGraphSubscriptionRecord>(allIds.map((id, index) => [
+      id,
+      {
+        id,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        onChainId: `0x${String(index + 1).repeat(64)}`,
+        // V31 and older could not distinguish explicit operator intent from
+        // automatic Core discovery: both were written as syncScoped=true.
+        syncScoped: true,
+      },
+    ]));
+    const subscriptionStore = {
+      loadAll: async () => [...persisted.values()].map((row) => ({ ...row })),
+      save: async (record: ContextGraphSubscriptionRecord) => {
+        persisted.set(record.id, { ...record });
+      },
+      delete: async (id: string) => { persisted.delete(id); },
+    };
+    let first: DKGAgent | undefined;
+    let restarted: DKGAgent | undefined;
+
+    try {
+      first = await DKGAgent.create({
+        name: 'LegacyCoreCoverageMigration',
+        listenHost: '127.0.0.1',
+        nodeRole: 'core',
+        chainAdapter: new MockChainAdapter(),
+        contextGraphSubscriptionStore: subscriptionStore,
+        syncContextGraphs: [explicitId],
+        syncCorePublicBatchSize: 1,
+      });
+      (first as any).getExplicitAccessPolicy = async () => 'public';
+      await first.start();
+
+      expect(first.getSubscribedContextGraphs().get(explicitId)?.syncAdmission).toBe('explicit');
+      expect((first as any).config.syncContextGraphs).toEqual([explicitId]);
+      expect(persisted.get(explicitId)).toMatchObject({
+        syncAdmission: 'explicit',
+        syncScoped: true,
+      });
+      for (const id of automaticIds) {
+        expect(first.getSubscribedContextGraphs().get(id)?.syncAdmission).toBe('automatic-public');
+        expect((first as any).config.syncContextGraphs).not.toContain(id);
+        expect(persisted.get(id)).toMatchObject({
+          syncAdmission: 'automatic-public',
+          syncScoped: false,
+        });
+      }
+      expect(first.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(2);
+      const firstRound = (first as any).planCorePublicSyncPeerRound('legacy-migration-peer');
+      expect(firstRound.initialDurableContextGraphIds[0]).toBe(explicitId);
+      expect(firstRound.automaticContextGraphIds).toHaveLength(1);
+      expect(automaticIds).toContain(firstRound.automaticContextGraphIds[0]);
+
+      await first.stop();
+      first = undefined;
+
+      restarted = await DKGAgent.create({
+        name: 'LegacyCoreCoverageMigratedRestart',
+        listenHost: '127.0.0.1',
+        nodeRole: 'core',
+        chainAdapter: new MockChainAdapter(),
+        contextGraphSubscriptionStore: subscriptionStore,
+        syncContextGraphs: [explicitId],
+        syncCorePublicBatchSize: 1,
+      });
+      // Contradict the original migration input. Current-schema canonical
+      // admissions must win directly instead of being reclassified.
+      (restarted as any).getExplicitAccessPolicy = async () => 'private';
+      await restarted.start();
+
+      expect(restarted.getSubscribedContextGraphs().get(explicitId)?.syncAdmission).toBe('explicit');
+      expect(restarted.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(2);
+      expect((restarted as any).config.syncContextGraphs).toEqual([explicitId]);
+    } finally {
+      await first?.stop().catch(() => {});
+      await restarted?.stop().catch(() => {});
+    }
+  }, 60_000);
+
   it('reconstructs an OnChainId-only edge catalogue entry after restart without chain RPC', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'dkg-discovery-restart-'));
     const localId = 'restart-chain-catalogue';

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { createOperationContext, PROTOCOL_SYNC, PROTOCOL_ACCESS, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
+import {
+  createOperationContext,
+  PROTOCOL_SYNC,
+  PROTOCOL_ACCESS,
+  PROTOCOL_STORAGE_ACK,
+  PROTOCOL_STORAGE_ACK_V2,
+  SYSTEM_CONTEXT_GRAPHS,
+} from '@origintrail-official/dkg-core';
 import { peerIdFromString } from '@libp2p/peer-id';
 import {
   runSyncOnConnect,
@@ -1090,13 +1097,22 @@ describe('DKGAgent peer-round scope wiring', () => {
       name: 'DynamicExplicitScope',
       listenHost: '127.0.0.1',
       chainAdapter: new MockChainAdapter(),
-      nodeRole: 'edge',
+      nodeRole: 'core',
       syncContextGraphs: ['initial-selected'],
+      syncCorePublicBatchSize: 1,
     });
     try {
       await agent.start();
+      (agent as any).registerCorePublicSyncContextGraph('automatic-public-a');
+      (agent as any).registerCorePublicSyncContextGraph('automatic-public-b');
+      (agent as any).registerCorePublicSyncContextGraph('automatic-public-c');
       allowAllNetworkAdmission(agent);
       const remotePeer = freshPeerIdString();
+      (agent as any).syncingPeers.add(remotePeer);
+      expect(await (agent as any).trySyncFromPeer(remotePeer)).toBe('already-syncing');
+      (agent as any).syncingPeers.delete(remotePeer);
+      (agent as any).getPeerProtocols = async () => [];
+      expect(await (agent as any).trySyncFromPeer(remotePeer)).toBe('skipped-no-sync');
       (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
       (agent as any).refreshMetaSyncedFlags = async () => {};
       (agent as any).discoverContextGraphsFromStore = async () => {
@@ -1119,9 +1135,23 @@ describe('DKGAgent peer-round scope wiring', () => {
 
       await (agent as any).trySyncFromPeer(remotePeer);
 
+      expect(durable.calls[0]?.[1]).toEqual([
+        SYSTEM_CONTEXT_GRAPHS.AGENTS,
+        SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+        'initial-selected',
+        'automatic-public-a',
+      ]);
       expect(durable.calls[1]?.[1]).toEqual(['restored-private']);
-      expect(planShared.calls[0]?.[1]).toEqual(['initial-selected', 'restored-private']);
-      expect(shared.calls[0]?.[1]).toEqual(['initial-selected', 'restored-private']);
+      expect(planShared.calls[0]?.[1]).toEqual([
+        'initial-selected',
+        'restored-private',
+        'automatic-public-a',
+      ]);
+      expect(shared.calls[0]?.[1]).toEqual([
+        'initial-selected',
+        'restored-private',
+        'automatic-public-a',
+      ]);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1084,6 +1084,50 @@ describe('runSyncOnConnect callbacks', () => {
   });
 });
 
+describe('DKGAgent peer-round scope wiring', () => {
+  it('keeps newly restored explicit CGs live while freezing only the automatic tail', async () => {
+    const agent = await DKGAgent.create({
+      name: 'DynamicExplicitScope',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      nodeRole: 'edge',
+      syncContextGraphs: ['initial-selected'],
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+      const remotePeer = freshPeerIdString();
+      (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+      (agent as any).refreshMetaSyncedFlags = async () => {};
+      (agent as any).discoverContextGraphsFromStore = async () => {
+        (agent as any).config.syncContextGraphs = [
+          ...(agent as any).config.syncContextGraphs,
+          'restored-private',
+        ];
+        return 1;
+      };
+      const durable = recorder(async (..._args: unknown[]) => 1);
+      const planShared = recorder(async (_peerId: string, contextGraphIds: string[]) => ({
+        publicContextGraphIds: contextGraphIds,
+        privateRecoverFromCurator: [],
+        eligibleContextGraphIds: contextGraphIds,
+      }));
+      const shared = recorder(async (..._args: unknown[]) => 1);
+      (agent as any).syncFromPeerDetailed = durable;
+      (agent as any).planSharedMemorySyncContextGraphs = planShared;
+      (agent as any).syncSharedMemoryFromPeerDetailed = shared;
+
+      await (agent as any).trySyncFromPeer(remotePeer);
+
+      expect(durable.calls[1]?.[1]).toEqual(['restored-private']);
+      expect(planShared.calls[0]?.[1]).toEqual(['initial-selected', 'restored-private']);
+      expect(shared.calls[0]?.[1]).toEqual(['initial-selected', 'restored-private']);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+});
+
 describe('DKGAgent sync retry — event-driven via peer:update', () => {
   it('retries trySyncFromPeer when a previously-skipped peer now advertises PROTOCOL_SYNC', async () => {
     const agent = await DKGAgent.create({

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
       "test/map-with-concurrency.test.ts",
       "test/peer-selection.test.ts",
       "test/sync-requester-priority.test.ts",
+      "test/core-public-coverage-scheduler.test.ts",
       "test/sync-requester-progress.test.ts",
       "test/rootless-durable-bounded-progress.test.ts",
       "test/rootless-durable-skips-legacy-partition.test.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "prebuild": "pnpm -r --filter @origintrail-official/dkg-adapter-openclaw... --filter @origintrail-official/dkg-adapter-hermes... --filter @origintrail-official/dkg-mcp... --filter @origintrail-official/dkg-okf... run build",
-    "build": "tsc && node ../../scripts/copy-cli-runtime-assets.mjs",
+    "build": "tsc && pnpm run test:types && node ../../scripts/copy-cli-runtime-assets.mjs",
     "prepack": "node ../../scripts/copy-cli-runtime-assets.mjs",
     "benchmark:catchup-runner": "node scripts/catchup-runner-benchmark.cjs",
     "benchmark:daemon-responsiveness": "node scripts/daemon-responsiveness-benchmark.cjs",
@@ -30,6 +30,7 @@
     "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",
     "test": "vitest run",
     "test:unit": "vitest run --config vitest.unit.config.ts",
+    "test:types": "tsc --project tsconfig.type-tests.json",
     "test:benchmark:publish-async-get": "vitest run --config vitest.benchmark.config.ts",
     "test:coverage": "vitest run --coverage",
     "clean": "node -e \"const fs=require('fs');for(const d of['dist','network']){fs.rmSync(d,{recursive:true,force:true})};fs.rmSync('tsconfig.tsbuildinfo',{force:true})\""

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -15,6 +15,7 @@ import {
 import type { RegisterPcaAgentResult } from './pca-confirmation-wire.js';
 import { parseRegisterPcaAgentResult } from './pca-confirmation-wire.js';
 import type { CatchupStatusResponse } from './catchup-status-wire.js';
+import type { ContextGraphSubscribeResponse } from './context-graph-subscribe-wire.js';
 
 export type { KnowledgeAssetFinalizedPublishOptions } from './finalized-publish-options.js';
 
@@ -1491,79 +1492,14 @@ export class ApiClient {
     return this.post('/api/query-remote', { peerId, ...request });
   }
 
-  async subscribeToContextGraph(contextGraphId: string, options: {
+  async subscribeToContextGraph(contextGraphId: string, options?: {
     includeSharedMemory?: boolean;
-    syncMode: ContextGraphSyncMode;
-  }): Promise<{
-    subscribed: string;
-    syncMode: ContextGraphSyncMode;
-    catchup?:
-      | {
-        connectedPeers: number;
-        totalPeers?: number;
-        selectedPeers?: number;
-        syncCapablePeers: number;
-        peersTried: number;
-        peersResponded: number;
-        peersSucceeded: number;
-        /** Sync-capable peers skipped because an earlier wave already proved every requested plane. */
-        peersNotAttempted?: number;
-        deferredBackpressure: number;
-        dataSynced: number;
-        sharedMemorySynced: number;
-        denied: boolean;
-        deniedPeers: number;
-        diagnostics?: {
-          noProtocolPeers: number;
-          durable: {
-            fetchedMetaTriples: number;
-            fetchedDataTriples: number;
-            insertedMetaTriples: number;
-            insertedDataTriples: number;
-            bytesReceived: number;
-            resumedPhases: number;
-            timedOutPhases: number;
-            completedPhases: number;
-            checkpointAdvances: number;
-            emptyResponses: number;
-            metaOnlyResponses: number;
-            verifiedPrivateOnlyResponses?: number;
-            dataRejectedMissingMeta: number;
-            rejectedKcs: number;
-            failedPeers: number;
-            failedPhases: number;
-            deferredBackpressure: number;
-          };
-          sharedMemory: {
-            fetchedMetaTriples: number;
-            fetchedDataTriples: number;
-            insertedMetaTriples: number;
-            insertedDataTriples: number;
-            bytesReceived: number;
-            resumedPhases: number;
-            timedOutPhases: number;
-            completedPhases: number;
-            checkpointAdvances: number;
-            emptyResponses: number;
-            droppedDataTriples: number;
-            failedPeers: number;
-            failedPhases: number;
-            deferredBackpressure: number;
-          };
-        };
-      }
-      | {
-        status: 'queued';
-        includeSharedMemory: boolean;
-        /** @deprecated Backward-compatible response alias. */
-        includeWorkspace: boolean;
-        jobId: string;
-      };
-  }> {
+    syncMode?: ContextGraphSyncMode;
+  }): Promise<ContextGraphSubscribeResponse> {
     return this.post('/api/context-graph/subscribe', {
       contextGraphId,
-      includeSharedMemory: options.includeSharedMemory,
-      syncMode: options.syncMode,
+      includeSharedMemory: options?.includeSharedMemory,
+      syncMode: options?.syncMode ?? 'always-on',
     });
   }
 
@@ -1576,72 +1512,10 @@ export class ApiClient {
   }
 
   /** @deprecated Use subscribeToContextGraph */
-  async subscribe(contextGraphId: string, options?: { includeWorkspace?: boolean }): Promise<{
-    subscribed: string;
-    syncMode: ContextGraphSyncMode;
-    catchup?:
-      | {
-        connectedPeers: number;
-        totalPeers?: number;
-        selectedPeers?: number;
-        syncCapablePeers: number;
-        peersTried: number;
-        peersResponded: number;
-        peersSucceeded: number;
-        /** Sync-capable peers skipped because an earlier wave already proved every requested plane. */
-        peersNotAttempted?: number;
-        deferredBackpressure: number;
-        dataSynced: number;
-        sharedMemorySynced: number;
-        denied: boolean;
-        deniedPeers: number;
-        diagnostics?: {
-          noProtocolPeers: number;
-          durable: {
-            fetchedMetaTriples: number;
-            fetchedDataTriples: number;
-            insertedMetaTriples: number;
-            insertedDataTriples: number;
-            bytesReceived: number;
-            resumedPhases: number;
-            timedOutPhases: number;
-            completedPhases: number;
-            checkpointAdvances: number;
-            emptyResponses: number;
-            metaOnlyResponses: number;
-            verifiedPrivateOnlyResponses?: number;
-            dataRejectedMissingMeta: number;
-            rejectedKcs: number;
-            failedPeers: number;
-            failedPhases: number;
-            deferredBackpressure: number;
-          };
-          sharedMemory: {
-            fetchedMetaTriples: number;
-            fetchedDataTriples: number;
-            insertedMetaTriples: number;
-            insertedDataTriples: number;
-            bytesReceived: number;
-            resumedPhases: number;
-            timedOutPhases: number;
-            completedPhases: number;
-            checkpointAdvances: number;
-            emptyResponses: number;
-            droppedDataTriples: number;
-            failedPeers: number;
-            failedPhases: number;
-            deferredBackpressure: number;
-          };
-        };
-      }
-      | {
-        status: 'queued';
-        includeSharedMemory: boolean;
-        /** @deprecated Backward-compatible response alias. */
-        includeWorkspace: boolean;
-        jobId: string;
-      };
-  }> {
+  async subscribe(
+    contextGraphId: string,
+    options?: { includeWorkspace?: boolean },
+  ): Promise<ContextGraphSubscribeResponse> {
     return this.subscribeToContextGraph(contextGraphId, {
       includeSharedMemory: options?.includeWorkspace,
       syncMode: 'always-on',

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -628,6 +628,12 @@ export interface DkgConfig {
   syncGlobalLimit?: number;
   /** Max sync jobs waiting behind the global cap. Defaults to 2x the inflight cap. */
   syncGlobalQueueLimit?: number;
+  /**
+   * Public-CG coverage admitted per Core peer-sync round. Explicit Edge/Core
+   * selections are never capped. Default 8; 0 disables automatic Core catch-up.
+   * Env DKG_SYNC_CORE_PUBLIC_BATCH_SIZE wins.
+   */
+  syncCorePublicBatchSize?: number;
   /** Retained sync responder snapshot limits (rows and estimated bytes). */
   syncResponderSnapshotLimits?: SyncResponderSnapshotLimitsConfig;
   /** Local sync scheduling priority by Context Graph ID. */

--- a/packages/cli/src/context-graph-subscribe-wire.ts
+++ b/packages/cli/src/context-graph-subscribe-wire.ts
@@ -1,0 +1,13 @@
+import type { ContextGraphSyncMode } from '@origintrail-official/dkg-agent';
+import type { CatchupJobResult } from './catchup-result-wire.js';
+
+/** Stable response returned by both Context Graph subscription client methods. */
+export interface ContextGraphSubscribeResponse {
+  subscribed: string;
+  syncMode: ContextGraphSyncMode;
+  catchup?: CatchupJobResult | {
+    status: 'queued';
+    includeWorkspace: boolean;
+    jobId: string;
+  };
+}

--- a/packages/cli/src/context-graph-subscribe-wire.ts
+++ b/packages/cli/src/context-graph-subscribe-wire.ts
@@ -7,6 +7,8 @@ export interface ContextGraphSubscribeResponse {
   syncMode: ContextGraphSyncMode;
   catchup?: CatchupJobResult | {
     status: 'queued';
+    includeSharedMemory: boolean;
+    /** @deprecated Backward-compatible response alias for includeSharedMemory. */
     includeWorkspace: boolean;
     jobId: string;
   };

--- a/packages/cli/src/daemon/context-graph-subscription-store.ts
+++ b/packages/cli/src/daemon/context-graph-subscription-store.ts
@@ -1,0 +1,47 @@
+import type { ContextGraphSubscriptionRecord } from '@origintrail-official/dkg-agent';
+import {
+  type ContextGraphSubscriptionRow,
+  type DashboardDB,
+} from '@origintrail-official/dkg-node-ui';
+
+/** Map the daemon SQLite row into the agent persistence contract. */
+export function contextGraphSubscriptionRecordFromRow(
+  row: ContextGraphSubscriptionRow,
+): ContextGraphSubscriptionRecord {
+  return {
+    id: row.context_graph_id,
+    name: row.name ?? undefined,
+    subscribed: row.subscribed === 1,
+    synced: row.synced === 1,
+    sharedMemorySynced: row.shared_memory_synced == null ? undefined : row.shared_memory_synced === 1,
+    metaSynced: row.meta_synced == null ? undefined : row.meta_synced === 1,
+    onChainId: row.on_chain_id ?? undefined,
+    onChainHash: row.on_chain_hash ?? undefined,
+    lastReconciledOrdinal: row.last_reconciled_ordinal ?? undefined,
+    coreHosted: row.core_hosted == null ? undefined : row.core_hosted === 1,
+    syncScoped: row.sync_scoped === 1,
+    syncAdmission: row.sync_admission ?? undefined,
+  };
+}
+
+/** Map the agent persistence contract into the daemon SQLite boundary. */
+export function contextGraphSubscriptionRecordToRow(
+  record: ContextGraphSubscriptionRecord,
+  updatedAt = Date.now(),
+): Parameters<DashboardDB['upsertContextGraphSubscription']>[0] {
+  return {
+    context_graph_id: record.id,
+    name: record.name ?? null,
+    subscribed: record.subscribed ? 1 : 0,
+    synced: record.synced ? 1 : 0,
+    shared_memory_synced: record.sharedMemorySynced == null ? null : record.sharedMemorySynced ? 1 : 0,
+    meta_synced: record.metaSynced == null ? null : record.metaSynced ? 1 : 0,
+    on_chain_id: record.onChainId ?? null,
+    on_chain_hash: record.onChainHash ?? null,
+    last_reconciled_ordinal: record.lastReconciledOrdinal ?? null,
+    core_hosted: record.coreHosted == null ? null : record.coreHosted ? 1 : 0,
+    sync_scoped: record.syncScoped ? 1 : 0,
+    sync_admission: record.syncAdmission ?? null,
+    updated_at: updatedAt,
+  };
+}

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -68,7 +68,12 @@ import {
   MockChainAdapter,
   mergeRpcUsageWindows,
 } from '@origintrail-official/dkg-chain';
-import { DKGAgent, loadOpWallets, KaNumberAllocator, resolveSyncAgentsMeta } from '@origintrail-official/dkg-agent';
+import {
+  DKGAgent,
+  loadOpWallets,
+  KaNumberAllocator,
+  resolveSyncAgentsMeta,
+} from '@origintrail-official/dkg-agent';
 import { isExternalBackend } from '@origintrail-official/dkg-storage';
 import { BackpressureMonitor, computeNetworkId, createOperationContext, createLogRedactor, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables, isKaPublishLifecycleDebugLoggingEnabled, setKaPublishLifecycleDebugLoggingEnabled, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import {
@@ -101,6 +106,10 @@ import {
   SqliteKaNumberStore,
   type MetricsSource,
 } from "@origintrail-official/dkg-node-ui";
+import {
+  contextGraphSubscriptionRecordFromRow,
+  contextGraphSubscriptionRecordToRow,
+} from './context-graph-subscription-store.js';
 import {
   loadConfig,
   saveConfig,
@@ -1801,50 +1810,14 @@ export async function runDaemonInner(
     chainEventCursorStore,
     contextGraphRegistryScanCursorStore,
     contextGraphSubscriptionStore: {
-      loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
-        id: row.context_graph_id,
-        name: row.name ?? undefined,
-        subscribed: row.subscribed === 1,
-        synced: row.synced === 1,
-        sharedMemorySynced: row.shared_memory_synced == null ? undefined : row.shared_memory_synced === 1,
-        metaSynced: row.meta_synced == null ? undefined : row.meta_synced === 1,
-        onChainId: row.on_chain_id ?? undefined,
-        onChainHash: row.on_chain_hash ?? undefined,
-        lastReconciledOrdinal: row.last_reconciled_ordinal ?? undefined,
-        coreHosted: row.core_hosted == null ? undefined : row.core_hosted === 1,
-        syncScoped: row.sync_scoped === 1,
-      })),
+      loadAll: async () => dashDb.listContextGraphSubscriptions()
+        .map(contextGraphSubscriptionRecordFromRow),
       load: async (contextGraphId) => {
         const row = dashDb.getContextGraphSubscription(contextGraphId);
-        return row ? {
-          id: row.context_graph_id,
-          name: row.name ?? undefined,
-          subscribed: row.subscribed === 1,
-          synced: row.synced === 1,
-          sharedMemorySynced: row.shared_memory_synced == null ? undefined : row.shared_memory_synced === 1,
-          metaSynced: row.meta_synced == null ? undefined : row.meta_synced === 1,
-          onChainId: row.on_chain_id ?? undefined,
-          onChainHash: row.on_chain_hash ?? undefined,
-          lastReconciledOrdinal: row.last_reconciled_ordinal ?? undefined,
-          coreHosted: row.core_hosted == null ? undefined : row.core_hosted === 1,
-          syncScoped: row.sync_scoped === 1,
-        } : null;
+        return row ? contextGraphSubscriptionRecordFromRow(row) : null;
       },
       save: async (record) => {
-        dashDb.upsertContextGraphSubscription({
-          context_graph_id: record.id,
-          name: record.name ?? null,
-          subscribed: record.subscribed ? 1 : 0,
-          synced: record.synced ? 1 : 0,
-          shared_memory_synced: record.sharedMemorySynced == null ? null : record.sharedMemorySynced ? 1 : 0,
-          meta_synced: record.metaSynced == null ? null : record.metaSynced ? 1 : 0,
-          on_chain_id: record.onChainId ?? null,
-          on_chain_hash: record.onChainHash ?? null,
-          last_reconciled_ordinal: record.lastReconciledOrdinal ?? null,
-          core_hosted: record.coreHosted == null ? null : record.coreHosted ? 1 : 0,
-          sync_scoped: record.syncScoped ? 1 : 0,
-          updated_at: Date.now(),
-        });
+        dashDb.upsertContextGraphSubscription(contextGraphSubscriptionRecordToRow(record));
       },
       delete: async (contextGraphId) => {
         dashDb.deleteContextGraphSubscription(contextGraphId);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1768,6 +1768,7 @@ export async function runDaemonInner(
     syncGlobalMaxInflight: config.syncGlobalMaxInflight,
     syncGlobalLimit: config.syncGlobalLimit,
     syncGlobalQueueLimit: config.syncGlobalQueueLimit,
+    syncCorePublicBatchSize: config.syncCorePublicBatchSize,
     syncResponderSnapshotLimits: config.syncResponderSnapshotLimits,
     syncContextGraphPriorities: config.syncContextGraphPriorities,
     storageAckHandlerDeadlineMs: config.storageAckHandlerDeadlineMs,

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -710,6 +710,14 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         );
       }
     }
+    const corePublicSyncCoverage = typeof agent.getCorePublicSyncCoverageStatus === 'function'
+      ? agent.getCorePublicSyncCoverageStatus()
+      : {
+          enabled: false,
+          batchSize: config.syncCorePublicBatchSize ?? 8,
+          trackedContextGraphs: 0,
+          planningLanes: 0,
+        };
     return jsonResponse(res, 200, {
       name: config.name,
       version: nodeVersion,
@@ -774,6 +782,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         })),
         diagnosticsAvailable: '/api/diagnostics/backpressure',
       },
+      corePublicSyncCoverage,
       connectedPeers: uniquePeers.size,
       connections: {
         total: allConns.length,

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -480,6 +480,22 @@ describe('ApiClient', () => {
       });
     });
 
+    it('subscribeToContextGraph() preserves omitted-options compatibility', async () => {
+      const { fetch, calls } = createTrackingFetch({
+        ok: true,
+        status: 200,
+        body: { subscribed: 'cg-default', syncMode: 'always-on' },
+      });
+      globalThis.fetch = fetch;
+
+      await client.subscribeToContextGraph('cg-default');
+
+      expect(JSON.parse(calls[0].opts.body as string)).toEqual({
+        contextGraphId: 'cg-default',
+        syncMode: 'always-on',
+      });
+    });
+
     it('subscribe() maps its deprecated workspace option to the canonical request key', async () => {
       const { fetch, calls } = createTrackingFetch({
         ok: true,

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -496,6 +496,41 @@ describe('ApiClient', () => {
       });
     });
 
+    it('subscribeToContextGraph() preserves both queued shared-memory scope fields', async () => {
+      const queuedResponse = {
+        subscribed: 'cg-queued',
+        syncMode: 'always-on' as const,
+        catchup: {
+          status: 'queued' as const,
+          includeSharedMemory: false,
+          includeWorkspace: false,
+          jobId: 'catchup-job-1',
+        },
+      };
+      const { fetch, calls } = createTrackingFetch({
+        ok: true,
+        status: 200,
+        body: queuedResponse,
+      });
+      globalThis.fetch = fetch;
+
+      const response = await client.subscribeToContextGraph('cg-queued', {
+        includeSharedMemory: false,
+      });
+
+      expect(response).toEqual(queuedResponse);
+      if (!response.catchup || !('jobId' in response.catchup)) {
+        throw new Error('Expected queued catch-up response');
+      }
+      expect(response.catchup.includeSharedMemory).toBe(false);
+      expect(response.catchup.includeWorkspace).toBe(false);
+      expect(JSON.parse(calls[0].opts.body as string)).toEqual({
+        contextGraphId: 'cg-queued',
+        includeSharedMemory: false,
+        syncMode: 'always-on',
+      });
+    });
+
     it('subscribe() maps its deprecated workspace option to the canonical request key', async () => {
       const { fetch, calls } = createTrackingFetch({
         ok: true,

--- a/packages/cli/test/context-graph-subscribe-public-api.typecheck.ts
+++ b/packages/cli/test/context-graph-subscribe-public-api.typecheck.ts
@@ -1,0 +1,22 @@
+import type { ApiClient } from '../src/api-client.js';
+
+type SubscribeResponse = Awaited<ReturnType<ApiClient['subscribeToContextGraph']>>;
+type LegacySubscribeResponse = Awaited<ReturnType<ApiClient['subscribe']>>;
+
+function assertQueuedScopeAliases(
+  response: SubscribeResponse | LegacySubscribeResponse,
+): void {
+  if (response.catchup && 'jobId' in response.catchup) {
+    const includeSharedMemory: boolean = response.catchup.includeSharedMemory;
+    const includeWorkspace: boolean = response.catchup.includeWorkspace;
+
+    void includeSharedMemory;
+    void includeWorkspace;
+  }
+}
+
+declare const currentResponse: SubscribeResponse;
+declare const legacyResponse: LegacySubscribeResponse;
+
+assertQueuedScopeAliases(currentResponse);
+assertQueuedScopeAliases(legacyResponse);

--- a/packages/cli/test/context-graph-subscription-store.test.ts
+++ b/packages/cli/test/context-graph-subscription-store.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ContextGraphSubscriptionRecord } from '@origintrail-official/dkg-agent';
+import { DashboardDB } from '@origintrail-official/dkg-node-ui';
+import {
+  contextGraphSubscriptionRecordFromRow,
+  contextGraphSubscriptionRecordToRow,
+} from '../src/daemon/context-graph-subscription-store.js';
+
+describe('daemon context-graph subscription store boundary', () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('round-trips automatic-public admission through SQLite', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'dkg-subscription-admission-'));
+    directories.push(directory);
+    const db = new DashboardDB({ dataDir: directory });
+    const record: ContextGraphSubscriptionRecord = {
+      id: 'public-coverage',
+      subscribed: true,
+      synced: false,
+      sharedMemorySynced: false,
+      metaSynced: true,
+      onChainId: '14',
+      syncAdmission: 'automatic-public',
+      syncScoped: false,
+    };
+
+    try {
+      db.upsertContextGraphSubscription(contextGraphSubscriptionRecordToRow(record, 1234));
+      const persisted = db.getContextGraphSubscription(record.id);
+
+      expect(persisted).toMatchObject({
+        context_graph_id: record.id,
+        sync_admission: 'automatic-public',
+        sync_scoped: 0,
+        updated_at: 1234,
+      });
+      expect(contextGraphSubscriptionRecordFromRow(persisted!)).toEqual(record);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('keeps a legacy sync_scoped row distinguishable from current admission', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'dkg-subscription-legacy-'));
+    directories.push(directory);
+    const db = new DashboardDB({ dataDir: directory });
+
+    try {
+      db.upsertContextGraphSubscription({
+        context_graph_id: 'legacy-explicit',
+        subscribed: 1,
+        synced: 0,
+        sync_scoped: 1,
+        updated_at: 1234,
+      });
+      const loaded = contextGraphSubscriptionRecordFromRow(
+        db.getContextGraphSubscription('legacy-explicit')!,
+      );
+
+      expect(loaded.syncAdmission).toBeUndefined();
+      expect(loaded.syncScoped).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
+++ b/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
@@ -162,6 +162,12 @@ describe('runDaemonInner wires sync options into DKGAgent.create', () => {
     expect(createArg.syncGlobalQueueLimit).toBe(0);
   });
 
+  it('passes the Core public-CG peer-round batch size through unchanged', async () => {
+    const createArg = await captureCreateArg({ syncCorePublicBatchSize: 13 });
+
+    expect(createArg.syncCorePublicBatchSize).toBe(13);
+  });
+
   it('passes snapshot limits and Context Graph priorities through unchanged', async () => {
     const syncResponderSnapshotLimits = {
       global: { rows: 500, bytesEstimate: 600 },

--- a/packages/cli/test/snapshot-page-index-store.test.ts
+++ b/packages/cli/test/snapshot-page-index-store.test.ts
@@ -89,7 +89,7 @@ describe('SqliteSnapshotPageIndexStore', () => {
     await pageIndexes.upsert(record);
 
     expect(await pageIndexes.get(DIGEST)).toEqual(record);
-    expect(dashboard.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(dashboard.db.pragma('user_version', { simple: true })).toBe(32);
   });
 
   it('falls back to the snapshot when the real SQLite connection cannot read or write', async () => {

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -221,6 +221,29 @@ describe('/api/status finalization recovery health', () => {
   });
 });
 
+describe('/api/status Core public synchronization coverage', () => {
+  it('includes the exact bounded scheduler snapshot', async () => {
+    const corePublicSyncCoverage = {
+      enabled: true,
+      batchSize: 8,
+      trackedContextGraphs: 25,
+      planningLanes: 6,
+      lastPlanAt: 123,
+      lastPlan: {
+        selectedContextGraphs: 2,
+        coverageContextGraphs: 8,
+        totalContextGraphs: 10,
+      },
+    };
+    const response = await requestStatusWithAgent({
+      getCorePublicSyncCoverageStatus: () => corePublicSyncCoverage,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.corePublicSyncCoverage).toEqual(corePublicSyncCoverage);
+  });
+});
+
 describe('/api/status selected overlay details', () => {
   it('returns the network id and name for the selected overlay genesis', async () => {
     const network = await loadNetworkConfig('mainnet-gnosis');

--- a/packages/cli/tsconfig.type-tests.json
+++ b/packages/cli/tsconfig.type-tests.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": ".",
+    "sourceMap": false
+  },
+  "include": ["test/**/*.typecheck.ts"]
+}

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -162,6 +162,7 @@ export default defineConfig({
           'test/daemon-hermes.test.ts',
           'test/chain-discovery-scan-mode.test.ts',
           'test/context-graph-subscriptions-route.test.ts',
+          'test/context-graph-subscription-store.test.ts',
           // Daemon call-site wiring guard: runDaemonInner passes the resolved
           // syncAgentsMeta into DKGAgent.create. Fully mocked (network/agent/
           // wallets) — no hardhat.

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -17,7 +17,7 @@ export {
   SqliteContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 
-const SCHEMA_VERSION = 31;
+const SCHEMA_VERSION = 32;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -533,6 +533,8 @@ export class DashboardDB {
           meta_synced INTEGER,
           on_chain_id TEXT,
           sync_scoped INTEGER NOT NULL DEFAULT 1,
+          sync_admission TEXT
+            CHECK (sync_admission IS NULL OR sync_admission IN ('none', 'explicit', 'automatic-public')),
           updated_at INTEGER NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_cg_subs_sync_scoped
@@ -1211,6 +1213,22 @@ export class DashboardDB {
         );
       `);
     }
+    if (version < 32) {
+      // M1 Core public coverage: preserve the canonical admission lane across
+      // daemon restarts. NULL intentionally identifies legacy rows, whose
+      // `sync_scoped` bit is migrated by the agent rehydration boundary.
+      const columns = new Set(
+        (this.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
+          .map((column) => column.name),
+      );
+      if (!columns.has('sync_admission')) {
+        this.db.exec(`
+          ALTER TABLE context_graph_subscriptions
+          ADD COLUMN sync_admission TEXT
+            CHECK (sync_admission IS NULL OR sync_admission IN ('none', 'explicit', 'automatic-public'));
+        `);
+      }
+    }
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
     if (upgradedExistingDb && !this.explicitRetentionDays) {
       this.retentionDays = LEGACY_IMPLICIT_RETENTION_DAYS;
@@ -1508,15 +1526,18 @@ export class DashboardDB {
     last_reconciled_ordinal?: number | null;
     core_hosted?: number | null;
     sync_scoped: number;
+    sync_admission?: 'none' | 'explicit' | 'automatic-public' | null;
     updated_at: number;
   }): void {
     this.stmt('upsertContextGraphSubscription', `
       INSERT INTO context_graph_subscriptions (
         context_graph_id, name, subscribed, synced, shared_memory_synced, meta_synced,
-        on_chain_id, on_chain_hash, last_reconciled_ordinal, core_hosted, sync_scoped, updated_at
+        on_chain_id, on_chain_hash, last_reconciled_ordinal, core_hosted,
+        sync_scoped, sync_admission, updated_at
       ) VALUES (
         @context_graph_id, @name, @subscribed, @synced, @shared_memory_synced, @meta_synced,
-        @on_chain_id, @on_chain_hash, @last_reconciled_ordinal, @core_hosted, @sync_scoped, @updated_at
+        @on_chain_id, @on_chain_hash, @last_reconciled_ordinal, @core_hosted,
+        @sync_scoped, @sync_admission, @updated_at
       )
       ON CONFLICT(context_graph_id) DO UPDATE SET
         name = excluded.name,
@@ -1529,6 +1550,7 @@ export class DashboardDB {
         last_reconciled_ordinal = excluded.last_reconciled_ordinal,
         core_hosted = excluded.core_hosted,
         sync_scoped = excluded.sync_scoped,
+        sync_admission = excluded.sync_admission,
         updated_at = excluded.updated_at
     `).run({
       context_graph_id: record.context_graph_id,
@@ -1542,6 +1564,7 @@ export class DashboardDB {
       last_reconciled_ordinal: record.last_reconciled_ordinal ?? null,
       core_hosted: record.core_hosted ?? null,
       sync_scoped: record.sync_scoped,
+      sync_admission: record.sync_admission ?? null,
       updated_at: record.updated_at,
     });
   }
@@ -4173,6 +4196,7 @@ export interface ContextGraphSubscriptionRow {
   last_reconciled_ordinal: number | null;
   core_hosted: number | null;
   sync_scoped: number;
+  sync_admission: 'none' | 'explicit' | 'automatic-public' | null;
   updated_at: number;
 }
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -86,7 +86,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
 
     const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -142,7 +142,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
 
     const newSnapshotCols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as { name: string }[])
       .map(c => c.name);
@@ -673,7 +673,7 @@ describe('DashboardDB — V15 migration: drop FTS5 logs index', () => {
 
     const upgraded = new DashboardDB({ dataDir: upgradeDir });
     try {
-      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(31);
+      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(32);
 
       const ftsTables = upgraded.db.prepare(
         `SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name LIKE 'logs_fts%'`,
@@ -741,7 +741,7 @@ describe('DashboardDB — V27 join-approval ledger migration', () => {
     db.close();
 
     const raw = new Database(dbPath);
-    expect(raw.pragma('user_version', { simple: true })).toBe(31);
+    expect(raw.pragma('user_version', { simple: true })).toBe(32);
     raw.exec('DROP TRIGGER IF EXISTS cap_cg_join_policy_audit_rows;');
     raw.close();
 
@@ -765,7 +765,7 @@ describe('DashboardDB — V27 join-approval ledger migration', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
     const columns = db.db.pragma(
       'table_info(context_graph_join_approval_ledger)',
     ) as Array<{ name: string }>;
@@ -786,7 +786,7 @@ describe('DashboardDB — V27 join-approval ledger migration', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
     expect(db.db.prepare(`
       SELECT name FROM sqlite_master
       WHERE type = 'table' AND name = 'context_graph_join_policy_audit'
@@ -868,7 +868,7 @@ describe('DashboardDB — V27 join-approval ledger migration', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
     const trigger = db.db.prepare(`
       SELECT sql FROM sqlite_master
       WHERE type = 'trigger' AND name = 'cap_cg_join_policy_audit_rows'
@@ -1273,7 +1273,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1294,7 +1294,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
       .map((c) => c.name);
     expect(cols).toContain('on_chain_hash');
     expect(cols).toContain('last_reconciled_ordinal');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
   });
 });
 
@@ -1378,7 +1378,7 @@ describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1389,6 +1389,70 @@ describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
       on_chain_id: '0xabc',
       core_hosted: null,
     }]);
+  });
+});
+
+describe('DashboardDB — V32 sync_admission column migration', () => {
+  let db: DashboardDB;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dkg-db-v32-test-'));
+    db = new DashboardDB({ dataDir: dir });
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('adds sync_admission to a V31 database without guessing legacy intent', () => {
+    const dbPath = join(dir, 'node-ui.db');
+    db.close();
+
+    const raw = new Database(dbPath);
+    raw.exec('ALTER TABLE context_graph_subscriptions DROP COLUMN sync_admission;');
+    raw.prepare(
+      `INSERT INTO context_graph_subscriptions
+         (context_graph_id, subscribed, synced, sync_scoped, updated_at)
+       VALUES ('legacy-explicit', 1, 0, 1, 1000)`,
+    ).run();
+    raw.pragma('user_version = 31');
+    raw.close();
+
+    db = new DashboardDB({ dataDir: dir });
+
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
+    const columns = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
+      .map((column) => column.name);
+    expect(columns).toContain('sync_admission');
+    expect(db.getContextGraphSubscription('legacy-explicit')).toMatchObject({
+      sync_scoped: 1,
+      sync_admission: null,
+    });
+  });
+
+  it('round-trips every current sync admission independently of sync_scoped', () => {
+    for (const [index, syncAdmission] of ['none', 'explicit', 'automatic-public'].entries()) {
+      db.upsertContextGraphSubscription({
+        context_graph_id: `admission-${syncAdmission}`,
+        subscribed: 1,
+        synced: 0,
+        sync_scoped: syncAdmission === 'explicit' ? 1 : 0,
+        sync_admission: syncAdmission as 'none' | 'explicit' | 'automatic-public',
+        updated_at: 1000 + index,
+      });
+    }
+
+    expect(db.listContextGraphSubscriptions().map((row) => ({
+      id: row.context_graph_id,
+      admission: row.sync_admission,
+      scoped: row.sync_scoped,
+    }))).toEqual([
+      { id: 'admission-automatic-public', admission: 'automatic-public', scoped: 0 },
+      { id: 'admission-explicit', admission: 'explicit', scoped: 1 },
+      { id: 'admission-none', admission: 'none', scoped: 0 },
+    ]);
   });
 });
 
@@ -1407,7 +1471,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
   });
 
   it('fresh install lands at the current schema and already carries the ka_numbers table', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -1444,7 +1508,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -1537,7 +1601,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
   });
 
   it('fresh install carries the sync_checkpoints table and expiry index', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
     const tables = db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all();
@@ -1648,7 +1712,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
     expect(db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all()).toHaveLength(1);
@@ -1677,7 +1741,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
     const columns = new Set(
       (db.db.prepare('PRAGMA table_info(sync_checkpoints)').all() as Array<{ name: string }>)
         .map((column) => column.name),
@@ -2126,7 +2190,7 @@ describe('DashboardDB — V11→V13 chat schema migration chain', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
 
     const cols = (db.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -2192,7 +2256,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
 
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -2221,7 +2285,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
     expect(cols).toContain('context_graph_id');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
   });
 
   it('insertNotification writes context_graph_id to the column; omitted → NULL', () => {
@@ -2464,7 +2528,7 @@ describe('DashboardDB — replication telemetry (Phase F)', () => {
     raw.pragma('user_version = 17');
     raw.close();
     const upgraded = new DashboardDB({ dataDir: dir });
-    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(32);
     // insert works → table exists
     upgraded.insertReplicationEvent({ ts: now, context_graph_id: 'cg', action: 'promote' });
     expect(upgraded.getReplicationSummary(60_000).promotes).toBe(1);
@@ -2519,6 +2583,6 @@ describe('SqliteChangelogEraGuard — OT-RFC-59 §6 P0 durable era guard', () =>
       .map((t) => t.name);
     expect(tables).toContain('changelog_cursors');
     expect(tables).toContain('changelog_era');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
   });
 });

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -46,7 +46,7 @@ describe('V12 migration', () => {
     // DB layer in `db.test.ts`; this assertion just pins that
     // the substrate store fixtures are created against the
     // Current SCHEMA_VERSION includes the durable VM-reconcile negative cache.
-    expect(db.db.pragma('user_version', { simple: true })).toBe(31);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(32);
   });
 });
 


### PR DESCRIPTION
## M1 stack

This is **PR 3 of 7** in the RFC-64 M1 stack.

1. #2011 — explicit Edge synchronization lifetime
2. #2012 — truthful selected-CG VM/SWM convergence
3. **This PR — bounded Core public-CG coverage**
4. Adaptive-capacity primitives
5. Role-aware adaptive Core activation and status
6. Bounded operator-only runtime evidence hooks
7. Fail-closed M1 acceptance verifier and real-runtime release launcher

Stack base: `codex/rfc64-m1-selected-convergence` (PR #2012).

Exact restack coordinates:
- Base: `da58c0c70453b32af4f355b00ca2c7a8fdf78fa9`
- Head: `235c8071a098782d0aa454ec2eededd95280376b`

## User and operator impact

Core nodes maintain a separate bounded automatic-coverage set for revealed, chain-verified public Context Graphs. Edge nodes remain selected-only.

- User-selected CGs remain uncapped and higher priority, including after rediscovery.
- Automatic Core work is capped at 8 CGs per peer-sync round by default.
- `syncCorePublicBatchSize` or `DKG_SYNC_CORE_PUBLIC_BATCH_SIZE` changes that cap; `0` disables automatic coverage without disabling discovery or live hosting.
- The exact same frozen automatic tail drives durable VM and eligible SWM work during one peer round.
- Automatic entries are restored from durable chain-bound records before peer-sync planning after restart.
- A configured explicit overlay cannot silently overwrite a durable automatic baseline during an ordinary persistence pass; removing the overlay on restart restores automatic admission.
- Store-discovered public CGs cannot leak into the uncapped explicit-selection scope.
- Queued CLI subscribe responses expose canonical `includeSharedMemory` while preserving deprecated `includeWorkspace` compatibility.
- `/api/status` exposes configured batch size, tracked coverage, active planning lanes, and bounded last-plan counters.

Hash-only unresolved registrations, private CGs, and public CGs explicitly unsubscribed on that Core remain outside automatic coverage. `coreHosted` remains ACK-derived and is not repurposed.

## Before

```mermaid
sequenceDiagram
    participant Chain
    participant Store as Durable subscription store
    participant Core
    participant Scope as Explicit sync scope
    participant Peer

    Chain->>Core: Discover a public CG
    Core->>Store: Persist registration state
    Note over Core: Automatic scheduler state is memory-only
    Note over Core,Store: Core restarts
    Peer->>Core: Start peer-sync round
    Core->>Scope: Read explicit selections
    Scope-->>Core: Selected CGs only
    Note over Core: Public coverage can be omitted or enter an uncapped path
```

## After

```mermaid
sequenceDiagram
    participant Chain
    participant Store as Durable subscription store
    participant Core
    participant Scheduler as Core coverage scheduler
    participant Peer

    Chain->>Core: Confirm registered public CG
    Core->>Scheduler: Reconcile automatic coverage
    Core->>Store: Persist chain-bound eligibility

    Note over Core,Store: Core restarts
    Core->>Store: Rehydrate durable CG records
    Core->>Scheduler: Restore verified automatic coverage

    Peer->>Core: Start peer-sync round
    Core->>Scheduler: Plan one bounded automatic tail
    Scheduler-->>Core: Explicit selections plus automatic batch
    Core->>Peer: Pull durable VM using frozen round scope
    Core->>Peer: Pull eligible SWM using the same automatic tail
    Note over Core,Scheduler: New explicit selections remain live and uncapped
```

## Scheduling and safety

- Chain discovery, durable rehydration, and unsubscribe are tested against the same explicit-versus-automatic admission invariants. Their remaining mutation and classification helpers are not yet a single canonical boundary.
- Priority configuration determines initial ordering.
- Each peer has an independent cursor; a stable peer order cannot pin it to one batch.
- Rotation uses a stride coprime to coverage size, so every tracked CG eventually becomes first even when work fails fast.
- Peer cursor state survives short reconnects and is pruned with stale/rejected peer state.
- Authoritative chain access policy—not local ontology/store inference—controls automatic-public eligibility.
- The round scope has one owner: explicit selections remain live while only the automatic tail is frozen for VM and SWM parity.
- A regression with more eligible CGs than the batch proves only the bounded automatic tail plus explicit selections is scheduled.

## Non-goals

- Edge nodes do not sync all public CGs; they remain on-demand or explicitly always-on.
- This PR does not adapt concurrency or batch breadth to host pressure; that is split across PRs 4 and 5.
- This PR does not change catalog selection, transport, or authorization policy.

## Validation

- Agent dependency closure plus Agent build, type tests, and package-root test: pass.
- Conflict-sensitive Core scheduler, discovery/restart, and peer-round suite: **83/83 pass**.
- Affected CLI API-client compatibility suite: **86/86 pass**; CLI build and compile-only public API fixture pass.
- Eight-commit `git range-diff`: **8/8 commits preserved**; 6 are exactly patch-equivalent and two have only the expected canonical subscribe request-key/test-context delta from PR #2012.
- `git diff --check`: pass.
- Live GitHub review and CI status remain the merge-readiness source of truth.

## Review focus

1. Edge remains selected-only.
2. Core automatic work stays separate from uncapped explicit selection.
3. Restart restoration occurs before planning from chain-bound durable evidence.
4. VM and SWM consume the same bounded automatic tail.
5. Rotation preserves eventual coverage without widening one round.
