### PR TITLE
RFC-64 M1 6/7: expose bounded runtime coverage evidence

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1078,8 +1078,6 @@ export class DKGAgentBase {
     Math.floor(performance.timeOrigin),
     randomUUID(),
   );
-  /** Always-on Edge selections restored during this process's startup wave. */
-  protected readonly rehydratedAlwaysOnSyncContextGraphs = new Set<string>();
   protected started = false;
   /**
    * One OT-RFC-64 persistence owner for the inventory lease and every resource

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -168,6 +168,10 @@ import {
   SyncCapacityRuntime,
   type SyncCapacityStatus,
 } from './sync/capacity-runtime.js';
+import {
+  SyncCoverageEvidenceJournal,
+  type SyncCoverageEvidenceSnapshotV1,
+} from './sync/coverage-evidence-journal.js';
 import { bindRandomSampling, type RandomSamplingDisabledReason, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
@@ -1066,6 +1070,16 @@ export class DKGAgentBase {
   protected readonly corePublicSyncCoverageScheduler: CorePublicSyncCoverageScheduler;
   /** Role-aware requester admission and Core automatic-coverage capacity. */
   protected readonly syncCapacityRuntime: SyncCapacityRuntime;
+  /**
+   * Bounded process-local proof that automatic sync work was actually planned
+   * and reached a terminal result. Exposed only through a node-admin route.
+   */
+  protected readonly syncCoverageEvidenceJournal = new SyncCoverageEvidenceJournal(
+    Math.floor(performance.timeOrigin),
+    randomUUID(),
+  );
+  /** Always-on Edge selections restored during this process's startup wave. */
+  protected readonly rehydratedAlwaysOnSyncContextGraphs = new Set<string>();
   protected started = false;
   /**
    * One OT-RFC-64 persistence owner for the inventory lease and every resource
@@ -1759,6 +1773,10 @@ export class DKGAgentBase {
 
   getSyncCapacityStatus(): SyncCapacityStatus {
     return this.syncCapacityRuntime.getStatus();
+  }
+
+  getSyncCoverageEvidence(afterSequence = 0): SyncCoverageEvidenceSnapshotV1 {
+    return this.syncCoverageEvidenceJournal.snapshot(afterSequence);
   }
 
   /**

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -435,6 +435,7 @@ type ContextGraphDiscoveryDisposition =
 
 /** Internal peer-round policy: initial durable scope is frozen; later explicit intent is live. */
 interface PeerSyncScope {
+  readonly effectiveBatchSize: number;
   readonly automaticContextGraphIds: readonly string[];
   readonly initialDurableContextGraphIds: readonly string[];
   contextGraphIdsAfterDiscovery(): string[];
@@ -1740,13 +1741,14 @@ export class DKGAgentBase {
   /** Build one canonical peer-round scope with named snapshot/live phases. */
   protected planCorePublicSyncPeerRound(remotePeer: string): PeerSyncScope {
     const selected = [...(this.config.syncContextGraphs ?? [])];
+    const effectiveBatchSize = this.syncCapacityRuntime.getEffectiveCoverageBatch();
     let automaticContextGraphIds: string[] = [];
     if ((this.config.nodeRole ?? 'edge') === 'core') {
       automaticContextGraphIds = this.corePublicSyncCoverageScheduler
         .planAutomaticCoverageWithOptions(selected, {
           priorities: this.config.syncContextGraphPriorities,
           planningLane: remotePeer,
-          effectiveBatchSize: this.syncCapacityRuntime.getEffectiveCoverageBatch(),
+          effectiveBatchSize,
         });
     }
     const initialDurableContextGraphIds = [...new Set([
@@ -1754,6 +1756,7 @@ export class DKGAgentBase {
       ...automaticContextGraphIds,
     ])];
     return {
+      effectiveBatchSize,
       automaticContextGraphIds,
       initialDurableContextGraphIds,
       contextGraphIdsAfterDiscovery: () => [...new Set([

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -8,7 +8,8 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -308,6 +309,9 @@ import {
   resolveNonNegativeIntegerSwitch,
   withGlobalSyncBackpressure,
 } from './sync/backpressure.js';
+import type { SyncCoverageEvidenceTrigger } from './sync/coverage-evidence-journal.js';
+import { SyncCoverageEvidenceRecorder } from './sync/coverage-evidence-recorder.js';
+import { DEFAULT_SYNC_CAPACITY_SAMPLE_INTERVAL_MS } from './sync/capacity-runtime.js';
 import {
   contextGraphPriority,
   countSyncPriorityClasses,
@@ -914,6 +918,48 @@ interface RecoverContextGraphSwmFromPeerDependencies {
 }
 
 type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
+
+// Evidence provenance is intentionally module-private and async-context-bound.
+// This preserves the public/internal call shapes while ensuring a direct
+// library call cannot label itself as reconciler-owned automatic work.
+const syncCoverageInvocation = new AsyncLocalStorage<SyncCoverageEvidenceTrigger>();
+
+const UNVERIFIED_SYNC_COVERAGE_PLANES: Readonly<SyncCoverageVerifiedPlanes> = Object.freeze({
+  metadata: false,
+  durable: false,
+  sharedMemory: false,
+});
+
+function sharedMemorySyncCompletedCleanly(
+  result: Readonly<SharedMemorySyncResult>,
+  expectedContextGraphs: number,
+): boolean {
+  return result.failedPhases === 0
+    && result.failedPeers === 0
+    && result.timedOutPhases === 0
+    && result.deniedPhases === 0
+    && result.droppedDataTriples === 0
+    && (result.backoffWorthyFailures ?? 0) === 0
+    && (result.deferredBackpressure ?? 0) === 0
+    && result.completedPhases + result.emptyResponses >= expectedContextGraphs;
+}
+
+function syncCoveragePlanesFor(
+  contextGraphId: string,
+  metadataVerified: ReadonlySet<string>,
+  durableVerified: ReadonlySet<string>,
+  sharedMemoryVerified: ReadonlySet<string>,
+): SyncCoverageVerifiedPlanes {
+  return {
+    metadata: metadataVerified.has(contextGraphId),
+    durable: durableVerified.has(contextGraphId),
+    sharedMemory: sharedMemoryVerified.has(contextGraphId),
+  };
+}
+
+function syncCoveragePlanesComplete(planes: SyncCoverageVerifiedPlanes): boolean {
+  return planes.metadata && planes.durable && planes.sharedMemory;
+}
 
 export interface ContextGraphCatchupOptions {
   includeSharedMemory?: boolean;
@@ -3698,7 +3744,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
     const probe = await this.getSyncReconcilerProbe(remotePeer);
     try {
-      await this.attemptSyncFromPeerWithReconcilerAccounting(remotePeer, probe);
+      await syncCoverageInvocation.run(
+        'connection-open',
+        () => this.attemptSyncFromPeerWithReconcilerAccounting(remotePeer, probe),
+      );
     } catch (err: unknown) {
       handleSyncError(remotePeer, err);
     }
@@ -3765,6 +3814,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeer: string,
     onSyncAccounting?: (outcome: SyncOnConnectPeerOutcome) => void,
     source: SyncAdmissionSource = 'on-connect',
+    invocation?: AutomaticSyncInvocation,
   ): Promise<SyncOnConnectOutcome | 'not-started'> {
     if (!this.started) {
       return 'not-started';
@@ -3775,6 +3825,30 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!this.networkAdmissionCoordinator.isAcceptedPeer(remotePeer)) {
       return 'not-started';
     }
+    const coverageStatus = this.getCorePublicSyncCoverageStatus();
+    const evidence = new SyncCoverageEvidenceRecorder({
+      journal: this.syncCoverageEvidenceJournal,
+      trigger: invocation?.[automaticSyncInvocationBrand] === true
+        ? invocation.trigger
+        : undefined,
+      nodeRole: this.config.nodeRole ?? 'edge',
+      planningLane: remotePeer,
+      configuredBatchSize: coverageStatus.batchSize,
+      effectiveBatchSize: this.syncCapacityRuntime.getEffectiveCoverageBatch(),
+    });
+    const createScopePlan = () => {
+      const scopePlan = this.planCorePublicSyncPeerRound(remotePeer);
+      const selectedContextGraphIds = [...new Set(this.config.syncContextGraphs ?? [])];
+      evidence.beginRound({
+        selectedContextGraphIds,
+        automaticContextGraphIds: scopePlan.automaticContextGraphIds,
+        rehydratedAlwaysOnContextGraphIds: selectedContextGraphIds.filter((contextGraphId) =>
+          this.rehydratedAlwaysOnSyncContextGraphs.has(contextGraphId)
+          && (this.subscribedContextGraphs.get(contextGraphId)?.syncMode ?? 'always-on')
+            === 'always-on'),
+      });
+      return scopePlan;
+    };
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
     const getSharedMemorySyncPlan = (
       peerId: string,
@@ -3791,50 +3865,77 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       return plan;
     };
-    return runSyncOnConnectWithScopePlan({
+    let terminalOutcome: SyncOnConnectOutcome | undefined;
+    try {
+      terminalOutcome = await runSyncOnConnectWithScopePlan({
       remotePeer,
       syncingPeers: this.syncingPeers,
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
       knownCorePeerIds: this.knownCorePeerIds,
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
-      createScopePlan: () => this.planCorePublicSyncPeerRound(remotePeer),
+      createScopePlan,
       getSharedMemorySyncContextGraphs: async (peerId, contextGraphIdsAfterDiscovery) =>
         (await getSharedMemorySyncPlan(peerId, contextGraphIdsAfterDiscovery)).eligibleContextGraphIds,
-      syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
-        peerId,
-        contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
-        undefined,
-        undefined,
-        undefined,
-        { stopOnBackoffWorthyFailure: true, source },
-      ),
-      refreshMetaSyncedFlags: (contextGraphIds) => this.refreshMetaSyncedFlags(contextGraphIds),
-      discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
-      syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, {
-        stopOnBackoffWorthyFailure: true,
-        source,
-        sharedMemorySyncPlan: await getSharedMemorySyncPlan(peerId, contextGraphIds),
-      }),
-      syncSharedMemoryOnConnect: syncOnConnectEnabled(this.config) && (this.config.syncSharedMemoryOnConnect ?? true),
-      logInfo: (ctx, message) => this.log.info(ctx, message),
-      onPeerSkippedNoSync: (peerId) => {
-        this.skippedNoSyncPeers.add(peerId);
-      },
-      onPeerSynced: (peerId, outcome) => {
-        const progressAt = Math.max(Date.now(), (this.lastSyncProgressAt.get(peerId) ?? 0) + 1);
-        if (outcome?.progress) {
-          this.lastSyncProgressAt.set(peerId, progressAt);
-        }
-        if (outcome?.fresh ?? true) {
-          this.lastSuccessfulSyncAt.set(peerId, progressAt);
-        }
-        this.skippedNoSyncPeers.delete(peerId);
-        this.syncReconcilerBackoff.delete(peerId);
-        if (outcome) {
-          onSyncAccounting?.(outcome);
-        }
-      },
-    });
+        syncFromPeer: async (peerId, contextGraphIds) => {
+          const requestedContextGraphIds = contextGraphIds ?? [
+            SYSTEM_CONTEXT_GRAPHS.AGENTS,
+            SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+          ];
+          const result = await this.syncFromPeerDetailed(
+            peerId,
+            requestedContextGraphIds,
+            undefined,
+            undefined,
+            undefined,
+            { stopOnBackoffWorthyFailure: true, source },
+          );
+          evidence.markDurable(requestedContextGraphIds, result.complete);
+          return result;
+        },
+        refreshMetaSyncedFlags: async (contextGraphIds) => {
+          const confirmed = await this.refreshMetaSyncedFlags(contextGraphIds);
+          evidence.markMetadata(confirmed);
+        },
+        discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
+        syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => {
+          const plan = await getSharedMemorySyncPlan(peerId, contextGraphIds);
+          const result = await this.syncSharedMemoryFromPeerDetailed(
+            peerId,
+            contextGraphIds,
+            {
+            stopOnBackoffWorthyFailure: true,
+            source,
+            sharedMemorySyncPlan: plan,
+            },
+          );
+          evidence.markSharedMemory(result.contextGraphTerminals);
+          return result;
+        },
+        syncSharedMemoryOnConnect:
+          syncOnConnectEnabled(this.config) && (this.config.syncSharedMemoryOnConnect ?? true),
+        logInfo: (ctx, message) => this.log.info(ctx, message),
+        onPeerSkippedNoSync: (peerId) => {
+          this.skippedNoSyncPeers.add(peerId);
+        },
+        onPeerSynced: (peerId, outcome) => {
+          const progressAt = Math.max(Date.now(), (this.lastSyncProgressAt.get(peerId) ?? 0) + 1);
+          if (outcome?.progress) {
+            this.lastSyncProgressAt.set(peerId, progressAt);
+          }
+          if (outcome?.fresh ?? true) {
+            this.lastSuccessfulSyncAt.set(peerId, progressAt);
+          }
+          this.skippedNoSyncPeers.delete(peerId);
+          this.syncReconcilerBackoff.delete(peerId);
+          if (outcome) {
+            onSyncAccounting?.(outcome);
+          }
+        },
+      });
+      return terminalOutcome;
+    } finally {
+      evidence.finish(terminalOutcome === 'synced');
+    }
   }
 
   async planSharedMemorySyncContextGraphs(
@@ -4031,7 +4132,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.skippedNoSyncPeers.delete(peerId);
       this.log.info(ctx, `Peer ${shortPeer} now advertises sync protocol — retrying sync-on-connect`);
       setTimeout(() => {
-        this.trySyncFromPeer(peerId).catch((err: unknown) => {
+        syncCoverageInvocation.run('peer-update', () => this.trySyncFromPeer(peerId))
+          .catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
           this.log.warn(ctx, `Sync retry after peer:update failed for ${shortPeer}: ${message}`);
         });
@@ -4090,7 +4192,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       if (!(await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'Sync reconciler'))) continue;
       const shortPeer = peerId.slice(-8);
       this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
-      this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe, 'reconcile')
+      this.attemptSyncFromPeerWithReconcilerAccounting(
+        peerId,
+        probe,
+        'reconcile',
+        'periodic-reconciler',
+      )
         .then(() => undefined)
         .catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
@@ -5395,6 +5502,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
 
     const runSync = async (): Promise<SharedMemorySyncResult> => {
+      const observeContextGraphTerminal = (
+        contextGraphId: string,
+        result: SharedMemorySyncResult,
+      ): SharedMemorySyncResult => {
+        try {
+          options?.onContextGraphTerminal?.(
+            contextGraphId,
+            Object.freeze({ ...result }),
+          );
+        } catch {
+          // Diagnostics must never alter sync decisions or terminal results.
+        }
+        return result;
+      };
       const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
       const getSubGraphAdmission = (contextGraphId: string) => {
         let admission = subGraphAdmissionByContextGraph.get(contextGraphId);
@@ -5485,10 +5606,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             contextGraphId,
             lane: 'shared_memory',
             operationId: `shared-memory:${contextGraphId}:${remotePeerId.slice(-8)}`,
-            run: (remainingContextGraphs: number) => syncPublicContextGraph(
-              contextGraphId,
-              remainingContextGraphs,
-            ),
+            run: async (remainingContextGraphs: number) =>
+              observeContextGraphTerminal(
+                contextGraphId,
+                await syncPublicContextGraph(contextGraphId, remainingContextGraphs),
+              ),
           });
           continue;
         }
@@ -5498,6 +5620,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           lane: 'swm_recovery',
           operationId: `swm-recovery:${contextGraphId}:${remotePeerId.slice(-8)}`,
           run: async (): Promise<SharedMemorySyncResult> => {
+            let result: SharedMemorySyncResult;
             try {
               const recovered = await recoverContextGraphSwmWithProgressRetries({
                 recover: () => recoverPrivateContextGraph(contextGraphId),
@@ -5509,7 +5632,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                   );
                 },
               });
-              const result = emptySharedMemorySyncResult();
+              result = emptySharedMemorySyncResult();
               result.insertedDataTriples = recovered.insertedDataQuads;
               result.insertedMetaTriples = recovered.insertedMetaQuads;
               result.insertedTriples = recovered.insertedDataQuads + recovered.insertedMetaQuads;
@@ -5523,16 +5646,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 result.failedPhases = 1;
                 result.backoffWorthyFailures = 1;
               }
-              return result;
             } catch (error) {
               if (getSyncBackpressureBusyError(error)) throw error;
               this.log.warn(ctx, `Curator-recovery for private CG "${contextGraphId}" from ${remotePeerId} failed: ${error instanceof Error ? error.message : String(error)}`);
-              return {
+              result = {
                 ...emptySharedMemorySyncResult(),
                 failedPeers: 1,
                 backoffWorthyFailures: 1,
               };
             }
+            return observeContextGraphTerminal(contextGraphId, result);
           },
         });
       }
@@ -6430,7 +6553,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     );
   }
 
-  async refreshMetaSyncedFlags(this: DKGAgent, contextGraphIds: Iterable<string>): Promise<void> {
+  async refreshMetaSyncedFlags(
+    this: DKGAgent,
+    contextGraphIds: Iterable<string>,
+  ): Promise<ReadonlySet<string>> {
+    const confirmedContextGraphIds = new Set<string>();
     for (const contextGraphId of contextGraphIds) {
       const sub = this.subscribedContextGraphs.get(contextGraphId);
       if (!sub) continue;
@@ -6520,8 +6647,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           });
         }
         this.queueSharedMemoryGossipSubscription(contextGraphId);
+        confirmedContextGraphIds.add(contextGraphId);
       }
     }
+    return confirmedContextGraphIds;
   }
 
   setContextGraphSubscription(this: DKGAgent,
@@ -7174,6 +7303,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) return;
     const ctx = createOperationContext('init');
+    this.rehydratedAlwaysOnSyncContextGraphs.clear();
     try {
       // System context graphs (AGENTS/ONTOLOGY) are auto-subscribed separately
       // by start(); their persisted rows must NOT be rehydrated here too. Re-
@@ -7376,6 +7506,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           coreHosted: row.coreHosted,
           syncAdmission,
         }, { persist: false });
+        if (
+          (this.config.nodeRole ?? 'edge') === 'edge'
+          && row.subscribed
+          && syncAdmission === 'explicit'
+        ) {
+          this.rehydratedAlwaysOnSyncContextGraphs.add(row.id);
+        }
         if (row.subscribed) {
           this.subscribeToContextGraph(row.id, {
             trackSyncScope: false,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3750,6 +3750,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       await this.attemptSyncFromPeerWithReconcilerAccounting(
         remotePeer,
         probe,
+        'on-connect',
         'connection-open',
       );
     } catch (err: unknown) {
@@ -4148,6 +4149,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         this.trySyncFromPeer(
           peerId,
           undefined,
+          'on-connect',
           automaticSyncInvocation('peer-update'),
         )
           .catch((err: unknown) => {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -9,7 +9,6 @@
  */
 
 import { createHash } from 'node:crypto';
-import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -475,6 +474,7 @@ import {
   type DurableSyncResult,
   type SharedMemoryContextGraphResult,
   type SharedMemoryContextGraphTerminal,
+  type SharedMemorySyncDetailedResult,
   type SharedMemorySyncResult,
   type DKGAgentConfig,
   type ReplicationEvent,
@@ -905,6 +905,8 @@ type SharedMemorySyncDetailedOptions = {
   sharedMemorySyncPlan?: SharedMemorySyncContextGraphPlan;
   /** Admission override for foreground catch-up. */
   priority?: number;
+  /** Bounded admission origin for node-wide scheduler diagnostics. */
+  source?: SyncAdmissionSource;
 };
 
 type RecoverContextGraphSwmOptions = Parameters<typeof recoverContextGraphSwm>[0];
@@ -929,10 +931,21 @@ interface RecoverContextGraphSwmFromPeerDependencies {
 
 type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
 
-// Evidence provenance is intentionally module-private and async-context-bound.
-// This preserves the public/internal call shapes while ensuring a direct
-// library call cannot label itself as reconciler-owned automatic work.
-const syncCoverageInvocation = new AsyncLocalStorage<SyncCoverageEvidenceTrigger>();
+const automaticSyncInvocationBrand: unique symbol = Symbol('automatic-sync-invocation');
+
+interface AutomaticSyncInvocation {
+  readonly [automaticSyncInvocationBrand]: true;
+  readonly trigger: SyncCoverageEvidenceTrigger;
+}
+
+function automaticSyncInvocation(
+  trigger: SyncCoverageEvidenceTrigger,
+): AutomaticSyncInvocation {
+  return Object.freeze({
+    [automaticSyncInvocationBrand]: true as const,
+    trigger,
+  });
+}
 
 export interface ContextGraphCatchupOptions {
   includeSharedMemory?: boolean;
@@ -1178,7 +1191,7 @@ function mergeSharedMemorySyncResults(
 function withSharedMemoryContextGraphTerminals(
   summary: SharedMemoryContextGraphResult,
   terminals: readonly SharedMemoryContextGraphTerminal[],
-): SharedMemorySyncResult {
+): SharedMemorySyncDetailedResult {
   const immutableTerminals = Object.freeze(
     terminals.map((terminal) => Object.freeze(terminal)),
   );
@@ -3734,28 +3747,35 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
     const probe = await this.getSyncReconcilerProbe(remotePeer);
     try {
-      await syncCoverageInvocation.run(
+      await this.attemptSyncFromPeerWithReconcilerAccounting(
+        remotePeer,
+        probe,
         'connection-open',
-        () => this.attemptSyncFromPeerWithReconcilerAccounting(remotePeer, probe),
       );
     } catch (err: unknown) {
       handleSyncError(remotePeer, err);
     }
   }
 
-  async attemptSyncFromPeerWithReconcilerAccounting(
+  protected async attemptSyncFromPeerWithReconcilerAccounting(
     this: DKGAgent,
     remotePeer: string,
     probe: SyncReconcilerProbe,
     source: SyncAdmissionSource = 'on-connect',
+    trigger?: SyncCoverageEvidenceTrigger,
   ): Promise<SyncReconcilerAttemptOutcome> {
     const lastOk = this.lastSuccessfulSyncAt.get(remotePeer);
     const lastProgress = this.lastSyncProgressAt.get(remotePeer);
     let syncAccountingClearedBackoff = false;
     try {
-      const outcome = await this.trySyncFromPeer(remotePeer, () => {
-        syncAccountingClearedBackoff = true;
-      }, source);
+      const outcome = await this.trySyncFromPeer(
+        remotePeer,
+        () => {
+          syncAccountingClearedBackoff = true;
+        },
+        source,
+        trigger ? automaticSyncInvocation(trigger) : undefined,
+      );
       if (outcome === 'deferred-backpressure') {
         this.log.info(
           createOperationContext('sync'),
@@ -3818,6 +3838,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const coverageStatus = this.getCorePublicSyncCoverageStatus();
     const evidence = new SyncCoverageEvidenceRecorder({
       journal: this.syncCoverageEvidenceJournal,
+      // Runtime-check the module-private brand as well as relying on the type:
+      // plain JavaScript callers cannot forge automatic provenance by passing
+      // an object with a trigger-shaped public property.
       trigger: invocation?.[automaticSyncInvocationBrand] === true
         ? invocation.trigger
         : undefined,
@@ -4122,7 +4145,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.skippedNoSyncPeers.delete(peerId);
       this.log.info(ctx, `Peer ${shortPeer} now advertises sync protocol — retrying sync-on-connect`);
       setTimeout(() => {
-        syncCoverageInvocation.run('peer-update', () => this.trySyncFromPeer(peerId))
+        this.trySyncFromPeer(
+          peerId,
+          undefined,
+          automaticSyncInvocation('peer-update'),
+        )
           .catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
           this.log.warn(ctx, `Sync retry after peer:update failed for ${shortPeer}: ${message}`);
@@ -5411,7 +5438,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeerId: string,
     contextGraphIds: string[],
     options?: SharedMemorySyncDetailedOptions,
-  ): Promise<SharedMemorySyncResult> {
+  ): Promise<SharedMemorySyncDetailedResult> {
     const ctx = createOperationContext('sync');
     if (!durableSyncEnabled(this.config)) {
       this.log.warn(ctx, `Skipping shared-memory sync from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
@@ -5489,7 +5516,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       priority: options?.priority,
     });
 
-    const runSync = async (): Promise<SharedMemorySyncResult> => {
+    const runSync = async (): Promise<SharedMemorySyncDetailedResult> => {
       const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
       const getSubGraphAdmission = (contextGraphId: string) => {
         let admission = subGraphAdmissionByContextGraph.get(contextGraphId);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3988,12 +3988,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             },
           );
           // Existing JavaScript embedders can override the detailed method with
-          // the legacy aggregate-only shape. Missing or malformed terminals
-          // make evidence unverifiable, but must not turn successful sync into
-          // a runtime failure.
-          if (Array.isArray(result.contextGraphTerminals)) {
-            evidence.markSharedMemory(result.contextGraphTerminals);
-          }
+          // legacy or malformed runtime values. The recorder owns that untrusted
+          // observer boundary so evidence can fail closed without changing sync.
+          evidence.markSharedMemoryResult(result);
           return result;
         },
         syncSharedMemoryOnConnect:

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3769,14 +3769,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const lastProgress = this.lastSyncProgressAt.get(remotePeer);
     let syncAccountingClearedBackoff = false;
     try {
-      const outcome = await this.trySyncFromPeer(
-        remotePeer,
-        () => {
-          syncAccountingClearedBackoff = true;
-        },
-        source,
-        trigger ? automaticSyncInvocation(trigger) : undefined,
-      );
+      const onSyncAccounting = () => {
+        syncAccountingClearedBackoff = true;
+      };
+      // Keep the established three-argument call shape when no internal
+      // automatic trigger exists. Some embedders replace this method with a
+      // strict-arity seam, and a trailing `undefined` is still observable.
+      const outcome = trigger
+        ? await this.trySyncFromPeer(
+          remotePeer,
+          onSyncAccounting,
+          source,
+          automaticSyncInvocation(trigger),
+        )
+        : await this.trySyncFromPeer(remotePeer, onSyncAccounting, source);
       if (outcome === 'deferred-backpressure') {
         this.log.info(
           createOperationContext('sync'),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -269,6 +269,7 @@ import {
   runOrderedContextGraphSyncs,
   runOrderedContextGraphSyncsWithOutcomes,
   type ContextGraphSyncWork,
+  type OrderedContextGraphSyncExecution,
 } from './sync/requester/ordered-sync.js';
 import {
   recoverContextGraphSwm,
@@ -1196,6 +1197,49 @@ function withSharedMemoryContextGraphTerminals(
     terminals.map((terminal) => Object.freeze(terminal)),
   );
   return { ...summary, contextGraphTerminals: immutableTerminals };
+}
+
+function asSharedMemorySyncDetailedResult(
+  execution: OrderedContextGraphSyncExecution<SharedMemorySyncResult>,
+  requestedContextGraphIds: readonly string[],
+): SharedMemorySyncDetailedResult {
+  const terminalContextGraphIds = new Set(
+    execution.outcomes.map((outcome) => outcome.contextGraphId),
+  );
+  const terminals: SharedMemoryContextGraphTerminal[] = execution.outcomes.map((outcome) => {
+    if (outcome.disposition === 'settled') {
+      return {
+        contextGraphId: outcome.contextGraphId,
+        lane: asSharedMemoryTerminalLane(outcome.lane),
+        disposition: 'settled',
+        result: Object.freeze({ ...outcome.result } satisfies SharedMemoryContextGraphResult),
+      };
+    }
+    if (outcome.disposition === 'deferred') {
+      return {
+        contextGraphId: outcome.contextGraphId,
+        lane: asSharedMemoryTerminalLane(outcome.lane),
+        disposition: 'deferred',
+      };
+    }
+    return {
+      contextGraphId: outcome.contextGraphId,
+      lane: asSharedMemoryTerminalLane(outcome.lane),
+      disposition: 'skipped',
+      reason: outcome.reason,
+    };
+  });
+  for (const contextGraphId of [...new Set(requestedContextGraphIds)]) {
+    if (!terminalContextGraphIds.has(contextGraphId)) {
+      terminals.push({
+        contextGraphId,
+        lane: null,
+        disposition: 'skipped',
+        reason: 'not-eligible',
+      });
+    }
+  }
+  return withSharedMemoryContextGraphTerminals(execution.summary, terminals);
 }
 
 function asSharedMemoryTerminalLane(
@@ -3928,7 +3972,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             sharedMemorySyncPlan: plan,
             },
           );
-          evidence.markSharedMemory(result.contextGraphTerminals);
+          // Existing JavaScript embedders can override the detailed method with
+          // the legacy aggregate-only shape. Missing or malformed terminals
+          // make evidence unverifiable, but must not turn successful sync into
+          // a runtime failure.
+          if (Array.isArray(result.contextGraphTerminals)) {
+            evidence.markSharedMemory(result.contextGraphTerminals);
+          }
           return result;
         },
         syncSharedMemoryOnConnect:
@@ -5691,43 +5741,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           `Deferring ${item.lane} at CG ${item.contextGraphId} due to local backpressure: ${error.message}`,
         ),
       });
-      const terminalContextGraphIds = new Set(
-        execution.outcomes.map((outcome) => outcome.contextGraphId),
-      );
-      const terminals: SharedMemoryContextGraphTerminal[] = execution.outcomes.map((outcome) => {
-        if (outcome.disposition === 'settled') {
-          return {
-            contextGraphId: outcome.contextGraphId,
-            lane: asSharedMemoryTerminalLane(outcome.lane),
-            disposition: 'settled',
-            result: Object.freeze({ ...outcome.result } satisfies SharedMemoryContextGraphResult),
-          };
-        }
-        if (outcome.disposition === 'deferred') {
-          return {
-            contextGraphId: outcome.contextGraphId,
-            lane: asSharedMemoryTerminalLane(outcome.lane),
-            disposition: 'deferred',
-          };
-        }
-        return {
-          contextGraphId: outcome.contextGraphId,
-          lane: asSharedMemoryTerminalLane(outcome.lane),
-          disposition: 'skipped',
-          reason: outcome.reason,
-        };
-      });
-      for (const contextGraphId of [...new Set(contextGraphIds)]) {
-        if (!terminalContextGraphIds.has(contextGraphId)) {
-          terminals.push({
-            contextGraphId,
-            lane: null,
-            disposition: 'skipped',
-            reason: 'not-eligible',
-          });
-        }
-      }
-      return withSharedMemoryContextGraphTerminals(execution.summary, terminals);
+      return asSharedMemorySyncDetailedResult(execution, contextGraphIds);
     };
 
     return runSyncSingleFlight(this, singleFlightKey, runSync);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3865,6 +3865,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
   }
 
+  /** Canonical live subset of this process's startup-rehydrated Edge intent. */
+  protected getRehydratedAlwaysOnEvidenceContextGraphIds(
+    this: DKGAgent,
+    selectedContextGraphIds: readonly string[],
+  ): string[] {
+    const startupRehydrated = new Set(
+      this.contextGraphSubscriptionRehydrationStatus?.rehydratedAlwaysOnIds ?? [],
+    );
+    return [...new Set(selectedContextGraphIds)].filter((contextGraphId) => {
+      const subscription = this.subscribedContextGraphs.get(contextGraphId);
+      return startupRehydrated.has(contextGraphId)
+        && subscription?.subscribed === true
+        && subscription.syncAdmission === 'explicit'
+        && subscription.syncMode === 'always-on';
+    });
+  }
+
   /**
    * Pull all triples for the given context graphs from a remote peer and merge
    * them into our local store. Used on peer:connect for initial catch-up,
@@ -3906,10 +3923,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       evidence.beginRound({
         selectedContextGraphIds,
         automaticContextGraphIds: scopePlan.automaticContextGraphIds,
-        rehydratedAlwaysOnContextGraphIds: selectedContextGraphIds.filter((contextGraphId) =>
-          this.rehydratedAlwaysOnSyncContextGraphs.has(contextGraphId)
-          && (this.subscribedContextGraphs.get(contextGraphId)?.syncMode ?? 'always-on')
-            === 'always-on'),
+        rehydratedAlwaysOnContextGraphIds:
+          this.getRehydratedAlwaysOnEvidenceContextGraphIds(selectedContextGraphIds),
       });
       return scopePlan;
     };
@@ -7352,6 +7367,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return {
       ...status,
       hostedActivatedIds: [...(status.hostedActivatedIds ?? [])],
+      rehydratedAlwaysOnIds: [...(status.rehydratedAlwaysOnIds ?? [])],
       dormantIds: [...status.dormantIds],
     };
   }
@@ -7360,7 +7376,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) return;
     const ctx = createOperationContext('init');
-    this.rehydratedAlwaysOnSyncContextGraphs.clear();
     try {
       // System context graphs (AGENTS/ONTOLOGY) are auto-subscribed separately
       // by start(); their persisted rows must NOT be rehydrated here too. Re-
@@ -7484,6 +7499,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const cappedUserRows = cap > 0 ? userRows.slice(0, cap) : userRows;
       const toActivate = [...hostedRows, ...cappedUserRows];
       const dormantRows = cap > 0 ? userRows.slice(cap) : [];
+      const rehydratedAlwaysOnIds: string[] = [];
       for (let i = 0; i < toActivate.length; i++) {
         const row = toActivate[i];
         const approvedAgentAddress = row.subscribed
@@ -7568,7 +7584,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           && row.subscribed
           && syncAdmission === 'explicit'
         ) {
-          this.rehydratedAlwaysOnSyncContextGraphs.add(row.id);
+          rehydratedAlwaysOnIds.push(row.id);
         }
         if (row.subscribed) {
           this.subscribeToContextGraph(row.id, {
@@ -7623,6 +7639,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         systemExcluded: persistedRows.length - rows.length,
         hostedActivated: hostedRows.length,
         hostedActivatedIds: hostedRows.map((r) => r.id),
+        rehydratedAlwaysOnIds,
         activated: toActivate.length,
         dormant: skipped,
         activationCap: cap,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3915,12 +3915,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       nodeRole: this.config.nodeRole ?? 'edge',
       planningLane: remotePeer,
       configuredBatchSize: coverageStatus.batchSize,
-      effectiveBatchSize: this.syncCapacityRuntime.getEffectiveCoverageBatch(),
     });
     const createScopePlan = () => {
       const scopePlan = this.planCorePublicSyncPeerRound(remotePeer);
       const selectedContextGraphIds = [...new Set(this.config.syncContextGraphs ?? [])];
       evidence.beginRound({
+        effectiveBatchSize: scopePlan.effectiveBatchSize,
         selectedContextGraphIds,
         automaticContextGraphIds: scopePlan.automaticContextGraphIds,
         rehydratedAlwaysOnContextGraphIds:

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -8,7 +8,7 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
@@ -268,6 +268,7 @@ import { runSharedMemorySync, sharedMemoryOwnershipKeyFromGraph } from './sync/r
 import { createSharedMemorySnapshotMaterializer } from './sync/requester/swm-snapshot-materializer.js';
 import {
   runOrderedContextGraphSyncs,
+  runOrderedContextGraphSyncsWithOutcomes,
   type ContextGraphSyncWork,
 } from './sync/requester/ordered-sync.js';
 import {
@@ -472,6 +473,8 @@ import {
   type SharedMemorySyncDiagnostics,
   type CatchupSyncDiagnostics,
   type DurableSyncResult,
+  type SharedMemoryContextGraphResult,
+  type SharedMemoryContextGraphTerminal,
   type SharedMemorySyncResult,
   type DKGAgentConfig,
   type ReplicationEvent,
@@ -897,6 +900,13 @@ type SharedMemorySyncContextGraphPlan = {
   eligibleContextGraphIds: string[];
 };
 
+type SharedMemorySyncDetailedOptions = {
+  stopOnBackoffWorthyFailure?: boolean;
+  sharedMemorySyncPlan?: SharedMemorySyncContextGraphPlan;
+  /** Admission override for foreground catch-up. */
+  priority?: number;
+};
+
 type RecoverContextGraphSwmOptions = Parameters<typeof recoverContextGraphSwm>[0];
 
 interface RecoverContextGraphSwmFromPeerDependencies {
@@ -923,43 +933,6 @@ type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'defe
 // This preserves the public/internal call shapes while ensuring a direct
 // library call cannot label itself as reconciler-owned automatic work.
 const syncCoverageInvocation = new AsyncLocalStorage<SyncCoverageEvidenceTrigger>();
-
-const UNVERIFIED_SYNC_COVERAGE_PLANES: Readonly<SyncCoverageVerifiedPlanes> = Object.freeze({
-  metadata: false,
-  durable: false,
-  sharedMemory: false,
-});
-
-function sharedMemorySyncCompletedCleanly(
-  result: Readonly<SharedMemorySyncResult>,
-  expectedContextGraphs: number,
-): boolean {
-  return result.failedPhases === 0
-    && result.failedPeers === 0
-    && result.timedOutPhases === 0
-    && result.deniedPhases === 0
-    && result.droppedDataTriples === 0
-    && (result.backoffWorthyFailures ?? 0) === 0
-    && (result.deferredBackpressure ?? 0) === 0
-    && result.completedPhases + result.emptyResponses >= expectedContextGraphs;
-}
-
-function syncCoveragePlanesFor(
-  contextGraphId: string,
-  metadataVerified: ReadonlySet<string>,
-  durableVerified: ReadonlySet<string>,
-  sharedMemoryVerified: ReadonlySet<string>,
-): SyncCoverageVerifiedPlanes {
-  return {
-    metadata: metadataVerified.has(contextGraphId),
-    durable: durableVerified.has(contextGraphId),
-    sharedMemory: sharedMemoryVerified.has(contextGraphId),
-  };
-}
-
-function syncCoveragePlanesComplete(planes: SyncCoverageVerifiedPlanes): boolean {
-  return planes.metadata && planes.durable && planes.sharedMemory;
-}
 
 export interface ContextGraphCatchupOptions {
   includeSharedMemory?: boolean;
@@ -1200,6 +1173,23 @@ function mergeSharedMemorySyncResults(
     backoffWorthyFailures: (a.backoffWorthyFailures ?? 0) + (b.backoffWorthyFailures ?? 0),
     deferredBackpressure: (a.deferredBackpressure ?? 0) + (b.deferredBackpressure ?? 0),
   };
+}
+
+function withSharedMemoryContextGraphTerminals(
+  summary: SharedMemoryContextGraphResult,
+  terminals: readonly SharedMemoryContextGraphTerminal[],
+): SharedMemorySyncResult {
+  const immutableTerminals = Object.freeze(
+    terminals.map((terminal) => Object.freeze(terminal)),
+  );
+  return { ...summary, contextGraphTerminals: immutableTerminals };
+}
+
+function asSharedMemoryTerminalLane(
+  lane: SyncSchedulerLane,
+): 'shared_memory' | 'swm_recovery' {
+  if (lane === 'shared_memory' || lane === 'swm_recovery') return lane;
+  throw new TypeError(`Unexpected shared-memory terminal lane: ${lane}`);
 }
 
 function emptySwmRecoveryResult(): RecoverContextGraphSwmResult {
@@ -5416,26 +5406,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return { peerIds: [curatorPeerId], curatorIsLocal: false, legacyTripleResolved: true };
   }
 
-  async syncSharedMemoryFromPeerDetailed(this: DKGAgent,
+  async syncSharedMemoryFromPeerDetailed(
+    this: DKGAgent,
     remotePeerId: string,
     contextGraphIds: string[],
-    options?: {
-      stopOnBackoffWorthyFailure?: boolean;
-      sharedMemorySyncPlan?: SharedMemorySyncContextGraphPlan;
-      /** Admission override for foreground catch-up. */
-      priority?: number;
-      /**
-       * Bounded admission origin for node-wide scheduler diagnostics. The
-       * closed union: the catch-up Worker RPC is the only untrusted producer
-       * and it clamps in the CLI bridge, while `acquire` re-clamps regardless.
-       */
-      source?: SyncAdmissionSource;
-    },
+    options?: SharedMemorySyncDetailedOptions,
   ): Promise<SharedMemorySyncResult> {
     const ctx = createOperationContext('sync');
     if (!durableSyncEnabled(this.config)) {
       this.log.warn(ctx, `Skipping shared-memory sync from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
-      return emptySharedMemorySyncResult();
+      return withSharedMemoryContextGraphTerminals(
+        emptySharedMemorySyncResult(),
+        [...new Set(contextGraphIds)].map((contextGraphId) => ({
+          contextGraphId,
+          lane: null,
+          disposition: 'skipped',
+          reason: 'disabled',
+        })),
+      );
     }
     const recoverPrivateContextGraph = (contextGraphId: string) => runRecoverContextGraphSwmFromPeer(
       {
@@ -5502,20 +5490,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
 
     const runSync = async (): Promise<SharedMemorySyncResult> => {
-      const observeContextGraphTerminal = (
-        contextGraphId: string,
-        result: SharedMemorySyncResult,
-      ): SharedMemorySyncResult => {
-        try {
-          options?.onContextGraphTerminal?.(
-            contextGraphId,
-            Object.freeze({ ...result }),
-          );
-        } catch {
-          // Diagnostics must never alter sync decisions or terminal results.
-        }
-        return result;
-      };
       const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
       const getSubGraphAdmission = (contextGraphId: string) => {
         let admission = subGraphAdmissionByContextGraph.get(contextGraphId);
@@ -5607,10 +5581,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             lane: 'shared_memory',
             operationId: `shared-memory:${contextGraphId}:${remotePeerId.slice(-8)}`,
             run: async (remainingContextGraphs: number) =>
-              observeContextGraphTerminal(
-                contextGraphId,
-                await syncPublicContextGraph(contextGraphId, remainingContextGraphs),
-              ),
+              syncPublicContextGraph(contextGraphId, remainingContextGraphs),
           });
           continue;
         }
@@ -5655,12 +5626,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 backoffWorthyFailures: 1,
               };
             }
-            return observeContextGraphTerminal(contextGraphId, result);
+            return result;
           },
         });
       }
 
-      return runOrderedContextGraphSyncs({
+      const execution = await runOrderedContextGraphSyncsWithOutcomes({
         work,
         priorities: this.config.syncContextGraphPriorities,
         emptyResult: emptySharedMemorySyncResult,
@@ -5685,6 +5656,43 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           `Deferring ${item.lane} at CG ${item.contextGraphId} due to local backpressure: ${error.message}`,
         ),
       });
+      const terminalContextGraphIds = new Set(
+        execution.outcomes.map((outcome) => outcome.contextGraphId),
+      );
+      const terminals: SharedMemoryContextGraphTerminal[] = execution.outcomes.map((outcome) => {
+        if (outcome.disposition === 'settled') {
+          return {
+            contextGraphId: outcome.contextGraphId,
+            lane: asSharedMemoryTerminalLane(outcome.lane),
+            disposition: 'settled',
+            result: Object.freeze({ ...outcome.result } satisfies SharedMemoryContextGraphResult),
+          };
+        }
+        if (outcome.disposition === 'deferred') {
+          return {
+            contextGraphId: outcome.contextGraphId,
+            lane: asSharedMemoryTerminalLane(outcome.lane),
+            disposition: 'deferred',
+          };
+        }
+        return {
+          contextGraphId: outcome.contextGraphId,
+          lane: asSharedMemoryTerminalLane(outcome.lane),
+          disposition: 'skipped',
+          reason: outcome.reason,
+        };
+      });
+      for (const contextGraphId of [...new Set(contextGraphIds)]) {
+        if (!terminalContextGraphIds.has(contextGraphId)) {
+          terminals.push({
+            contextGraphId,
+            lane: null,
+            disposition: 'skipped',
+            reason: 'not-eligible',
+          });
+        }
+      }
+      return withSharedMemoryContextGraphTerminals(execution.summary, terminals);
     };
 
     return runSyncSingleFlight(this, singleFlightKey, runSync);

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1100,6 +1100,15 @@ export interface SharedMemorySyncResult extends SharedMemoryContextGraphResult {
   contextGraphTerminals?: readonly SharedMemoryContextGraphTerminal[];
 }
 
+/**
+ * Exact production result of the detailed shared-memory sync path. Aggregate
+ * compatibility callers may continue to use SharedMemorySyncResult, while
+ * automatic coverage evidence requires the per-CG terminal contract.
+ */
+export interface SharedMemorySyncDetailedResult extends SharedMemorySyncResult {
+  contextGraphTerminals: readonly SharedMemoryContextGraphTerminal[];
+}
+
 // ── DKGAgent configuration ──────────────────────────────────────────
 
 /**

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1091,19 +1091,13 @@ export type SharedMemoryContextGraphTerminal =
       | 'not-eligible';
   };
 
-export interface SharedMemorySyncResult extends SharedMemoryContextGraphResult {
-  /**
-   * Exact terminal outcome for each requested Context Graph. Production sync
-   * always populates this field. It remains optional so existing structural
-   * mocks and external implementations stay source-compatible.
-   */
-  contextGraphTerminals?: readonly SharedMemoryContextGraphTerminal[];
-}
+/** Aggregate-only compatibility result for shared-memory synchronization. */
+export interface SharedMemorySyncResult extends SharedMemoryContextGraphResult {}
 
 /**
  * Exact production result of the detailed shared-memory sync path. Aggregate
- * compatibility callers may continue to use SharedMemorySyncResult, while
- * automatic coverage evidence requires the per-CG terminal contract.
+ * compatibility callers continue to use SharedMemorySyncResult without
+ * terminal state, while this boundary requires the per-CG terminal contract.
  */
 export interface SharedMemorySyncDetailedResult extends SharedMemorySyncResult {
   contextGraphTerminals: readonly SharedMemoryContextGraphTerminal[];

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -809,6 +809,8 @@ export interface ContextGraphSubscriptionRehydrationStatus {
   systemExcluded: number;
   hostedActivated: number;
   hostedActivatedIds: string[];
+  /** Edge always-on selections restored during this process's startup wave. */
+  rehydratedAlwaysOnIds?: string[];
   activated: number;
   dormant: number;
   activationCap: number;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1062,9 +1062,42 @@ export interface DurableSyncResult extends DurableSyncDiagnostics {
   complete: boolean;
 }
 
-export interface SharedMemorySyncResult extends SharedMemorySyncDiagnostics {
+export interface SharedMemoryContextGraphResult extends SharedMemorySyncDiagnostics {
   insertedTriples: number;
   deniedPhases: number;
+}
+
+export type SharedMemoryContextGraphTerminal =
+  | {
+    readonly contextGraphId: string;
+    readonly lane: 'shared_memory' | 'swm_recovery';
+    readonly disposition: 'settled';
+    readonly result: Readonly<SharedMemoryContextGraphResult>;
+  }
+  | {
+    readonly contextGraphId: string;
+    readonly lane: 'shared_memory' | 'swm_recovery' | null;
+    readonly disposition: 'deferred';
+  }
+  | {
+    readonly contextGraphId: string;
+    readonly lane: 'shared_memory' | 'swm_recovery' | null;
+    readonly disposition: 'skipped';
+    readonly reason:
+      | 'continuation-stopped'
+      | 'stop-policy'
+      | 'prior-deferral'
+      | 'disabled'
+      | 'not-eligible';
+  };
+
+export interface SharedMemorySyncResult extends SharedMemoryContextGraphResult {
+  /**
+   * Exact terminal outcome for each requested Context Graph. Production sync
+   * always populates this field. It remains optional so existing structural
+   * mocks and external implementations stay source-compatible.
+   */
+  contextGraphTerminals?: readonly SharedMemoryContextGraphTerminal[];
 }
 
 // ── DKGAgent configuration ──────────────────────────────────────────

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -229,6 +229,8 @@ export {
   type DurableSyncDiagnostics,
   type DurableSyncResult,
   type SharedMemorySyncDiagnostics,
+  type SharedMemoryContextGraphResult,
+  type SharedMemoryContextGraphTerminal,
   type SharedMemorySyncResult,
 } from './dkg-agent-types.js';
 export {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -231,14 +231,11 @@ export {
   type SharedMemorySyncDiagnostics,
   type SharedMemoryContextGraphResult,
   type SharedMemoryContextGraphTerminal,
+  type SharedMemorySyncDetailedResult,
   type SharedMemorySyncResult,
 } from './dkg-agent-types.js';
 export {
   SYNC_COVERAGE_EVIDENCE_SCHEMA_VERSION,
-  DEFAULT_SYNC_COVERAGE_EVIDENCE_CAPACITY,
-  MAX_SYNC_COVERAGE_EVIDENCE_CONTEXT_GRAPHS,
-  SyncCoverageEvidenceJournal,
-  boundedSyncCoverageContextGraphIds,
   type SyncCoverageEvidenceState,
   type SyncCoverageEvidenceTrigger,
   type SyncCoverageVerifiedPlanes,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -232,6 +232,21 @@ export {
   type SharedMemorySyncResult,
 } from './dkg-agent-types.js';
 export {
+  SYNC_COVERAGE_EVIDENCE_SCHEMA_VERSION,
+  DEFAULT_SYNC_COVERAGE_EVIDENCE_CAPACITY,
+  MAX_SYNC_COVERAGE_EVIDENCE_CONTEXT_GRAPHS,
+  SyncCoverageEvidenceJournal,
+  boundedSyncCoverageContextGraphIds,
+  type SyncCoverageEvidenceState,
+  type SyncCoverageEvidenceTrigger,
+  type SyncCoverageVerifiedPlanes,
+  type EdgeReconcilerSyncCoverageEvidence,
+  type CoreAutomaticSyncCoverageCompletion,
+  type CoreAutomaticSyncCoverageEvidence,
+  type SyncCoverageEvidenceEntry,
+  type SyncCoverageEvidenceSnapshotV1,
+} from './sync/coverage-evidence-journal.js';
+export {
   computeImportedArtifactSelector,
   IMPORTED_ARTIFACT_AUTH_PURPOSE,
   IMPORTED_ARTIFACT_MAX_PAGE_BYTES,

--- a/packages/agent/src/sync/coverage-evidence-journal.ts
+++ b/packages/agent/src/sync/coverage-evidence-journal.ts
@@ -93,7 +93,7 @@ export interface FinishSyncCoverageEvidenceInput {
   finishedAt: number;
 }
 
-declare const syncCoverageEvidenceHandleBrand: unique symbol;
+const syncCoverageEvidenceHandleBrand = Symbol('syncCoverageEvidenceHandle');
 
 export interface CoreAutomaticRoundHandle {
   readonly [syncCoverageEvidenceHandleBrand]: true;
@@ -213,7 +213,11 @@ export class SyncCoverageEvidenceJournal {
       })),
     });
     this.runningByJobId.set(jobId, cloneEntry(running));
-    return Object.freeze({ kind: 'core-automatic-round', jobId }) as CoreAutomaticRoundHandle;
+    return Object.freeze({
+      [syncCoverageEvidenceHandleBrand]: true as const,
+      kind: 'core-automatic-round',
+      jobId,
+    });
   }
 
   finishCoreAutomaticRound(
@@ -284,10 +288,11 @@ export class SyncCoverageEvidenceJournal {
       });
       this.runningByJobId.set(jobId, cloneEntry(running));
       return Object.freeze({
+        [syncCoverageEvidenceHandleBrand]: true as const,
         kind: 'edge-reconciler-job',
         jobId,
         contextGraphId,
-      }) as EdgeReconcilerJobHandle;
+      });
     });
   }
 
@@ -341,6 +346,9 @@ export class SyncCoverageEvidenceJournal {
   private takeRunning(
     handle: CoreAutomaticRoundHandle | EdgeReconcilerJobHandle,
   ): SyncCoverageEvidenceEntry {
+    if (handle[syncCoverageEvidenceHandleBrand] !== true) {
+      throw new TypeError('sync coverage evidence handle was not issued by this module');
+    }
     const running = this.runningByJobId.get(handle.jobId);
     if (!running || running.kind !== handle.kind) {
       throw new TypeError('sync coverage evidence handle is unknown or already finished');

--- a/packages/agent/src/sync/coverage-evidence-journal.ts
+++ b/packages/agent/src/sync/coverage-evidence-journal.ts
@@ -1,0 +1,169 @@
+export const SYNC_COVERAGE_EVIDENCE_SCHEMA_VERSION = 1 as const;
+export const DEFAULT_SYNC_COVERAGE_EVIDENCE_CAPACITY = 256;
+export const MAX_SYNC_COVERAGE_EVIDENCE_CONTEXT_GRAPHS = 32;
+const MAX_SYNC_COVERAGE_EVIDENCE_CONTEXT_GRAPH_ID_LENGTH = 256;
+
+export type SyncCoverageEvidenceState = 'running' | 'complete' | 'failed';
+export type SyncCoverageEvidenceTrigger =
+  | 'connection-open'
+  | 'peer-update'
+  | 'periodic-reconciler';
+
+export interface SyncCoverageVerifiedPlanes {
+  metadata: boolean;
+  durable: boolean;
+  sharedMemory: boolean;
+}
+
+interface SyncCoverageEvidenceBase {
+  sequence: number;
+  waveId: string;
+  jobId: string;
+  state: SyncCoverageEvidenceState;
+  startedAt: number;
+  finishedAt?: number;
+}
+
+export interface EdgeReconcilerSyncCoverageEvidence extends SyncCoverageEvidenceBase {
+  kind: 'edge-reconciler-job';
+  contextGraphId: string;
+  source: 'reconciler';
+  trigger: 'periodic-reconciler';
+  syncMode: 'always-on';
+  rehydratedSelectionCount: number;
+  evidenceTruncated: boolean;
+  verified: SyncCoverageVerifiedPlanes;
+}
+
+export interface CoreAutomaticSyncCoverageCompletion {
+  jobId: string;
+  contextGraphId: string;
+  state: SyncCoverageEvidenceState;
+  verified: SyncCoverageVerifiedPlanes;
+  finishedAt?: number;
+}
+
+export interface CoreAutomaticSyncCoverageEvidence extends SyncCoverageEvidenceBase {
+  kind: 'core-automatic-round';
+  planningLane: string;
+  source: 'automatic-core-public';
+  trigger: SyncCoverageEvidenceTrigger;
+  configuredBatchSize: number;
+  effectiveBatchSize: number;
+  explicitSelectedContextGraphIds: string[];
+  explicitSelectedContextGraphCount: number;
+  automaticContextGraphIds: string[];
+  automaticContextGraphCount: number;
+  evidenceTruncated: boolean;
+  completions: CoreAutomaticSyncCoverageCompletion[];
+}
+
+export type SyncCoverageEvidenceEntry =
+  | EdgeReconcilerSyncCoverageEvidence
+  | CoreAutomaticSyncCoverageEvidence;
+
+export type SyncCoverageEvidenceDraft =
+  | Omit<EdgeReconcilerSyncCoverageEvidence, 'sequence' | 'waveId'>
+  | Omit<CoreAutomaticSyncCoverageEvidence, 'sequence' | 'waveId'>;
+
+export interface SyncCoverageEvidenceSnapshotV1 {
+  schemaVersion: typeof SYNC_COVERAGE_EVIDENCE_SCHEMA_VERSION;
+  processStartedAt: number;
+  waveId: string;
+  capacity: number;
+  nextSequence: number;
+  droppedBeforeSequence: number;
+  entries: SyncCoverageEvidenceEntry[];
+}
+
+function cloneVerified(verified: SyncCoverageVerifiedPlanes): SyncCoverageVerifiedPlanes {
+  return { ...verified };
+}
+
+function cloneEntry(entry: SyncCoverageEvidenceEntry): SyncCoverageEvidenceEntry {
+  if (entry.kind === 'edge-reconciler-job') {
+    return { ...entry, verified: cloneVerified(entry.verified) };
+  }
+  return {
+    ...entry,
+    explicitSelectedContextGraphIds: [...entry.explicitSelectedContextGraphIds],
+    automaticContextGraphIds: [...entry.automaticContextGraphIds],
+    completions: entry.completions.map((completion) => ({
+      ...completion,
+      verified: cloneVerified(completion.verified),
+    })),
+  };
+}
+
+/**
+ * Process-local, append-only operator evidence. State transitions append a new
+ * immutable row so polling with afterSequence never misses a terminal update.
+ */
+export class SyncCoverageEvidenceJournal {
+  private readonly entries: SyncCoverageEvidenceEntry[] = [];
+  private nextSequence = 1;
+  private droppedBeforeSequence = 0;
+
+  constructor(
+    readonly processStartedAt: number,
+    readonly waveId: string,
+    private readonly capacity = DEFAULT_SYNC_COVERAGE_EVIDENCE_CAPACITY,
+  ) {
+    if (!Number.isSafeInteger(processStartedAt) || processStartedAt < 0) {
+      throw new TypeError('sync coverage evidence processStartedAt must be a non-negative safe integer');
+    }
+    if (!waveId.trim()) {
+      throw new TypeError('sync coverage evidence waveId must be non-empty');
+    }
+    if (!Number.isSafeInteger(capacity) || capacity < 1) {
+      throw new TypeError('sync coverage evidence capacity must be a positive safe integer');
+    }
+  }
+
+  append(draft: SyncCoverageEvidenceDraft): SyncCoverageEvidenceEntry {
+    const entry = cloneEntry({
+      ...draft,
+      sequence: this.nextSequence,
+      waveId: this.waveId,
+    } as SyncCoverageEvidenceEntry);
+    this.nextSequence += 1;
+    this.entries.push(entry);
+    while (this.entries.length > this.capacity) {
+      const dropped = this.entries.shift();
+      if (dropped) this.droppedBeforeSequence = dropped.sequence;
+    }
+    return cloneEntry(entry);
+  }
+
+  snapshot(afterSequence = 0): SyncCoverageEvidenceSnapshotV1 {
+    if (!Number.isSafeInteger(afterSequence) || afterSequence < 0) {
+      throw new TypeError('afterSequence must be a non-negative safe integer');
+    }
+    return {
+      schemaVersion: SYNC_COVERAGE_EVIDENCE_SCHEMA_VERSION,
+      processStartedAt: this.processStartedAt,
+      waveId: this.waveId,
+      capacity: this.capacity,
+      nextSequence: this.nextSequence,
+      droppedBeforeSequence: this.droppedBeforeSequence,
+      entries: this.entries
+        .filter((entry) => entry.sequence > afterSequence)
+        .map(cloneEntry),
+    };
+  }
+}
+
+export function boundedSyncCoverageContextGraphIds(
+  contextGraphIds: readonly string[],
+): { ids: string[]; count: number; truncated: boolean } {
+  const unique = [...new Set(contextGraphIds)];
+  const boundedIds = unique
+    .filter((contextGraphId) =>
+      contextGraphId.length <= MAX_SYNC_COVERAGE_EVIDENCE_CONTEXT_GRAPH_ID_LENGTH)
+    .slice(0, MAX_SYNC_COVERAGE_EVIDENCE_CONTEXT_GRAPHS);
+  return {
+    ids: boundedIds,
+    count: unique.length,
+    truncated: boundedIds.length !== unique.length,
+  };
+}

--- a/packages/agent/src/sync/coverage-evidence-journal.ts
+++ b/packages/agent/src/sync/coverage-evidence-journal.ts
@@ -224,6 +224,9 @@ export class SyncCoverageEvidenceJournal {
     handle: CoreAutomaticRoundHandle,
     input: FinishSyncCoverageEvidenceInput,
   ): CoreAutomaticSyncCoverageEvidence {
+    if (handle.kind !== 'core-automatic-round') {
+      throw new TypeError('sync coverage evidence handle kind does not match Core round');
+    }
     const running = this.takeRunning(handle);
     if (running.kind !== 'core-automatic-round') {
       throw new TypeError('sync coverage evidence handle kind does not match Core round');
@@ -300,6 +303,9 @@ export class SyncCoverageEvidenceJournal {
     handle: EdgeReconcilerJobHandle,
     input: FinishSyncCoverageEvidenceInput,
   ): EdgeReconcilerSyncCoverageEvidence {
+    if (handle.kind !== 'edge-reconciler-job') {
+      throw new TypeError('sync coverage evidence handle kind does not match Edge job');
+    }
     const running = this.takeRunning(handle);
     if (running.kind !== 'edge-reconciler-job') {
       throw new TypeError('sync coverage evidence handle kind does not match Edge job');

--- a/packages/agent/src/sync/coverage-evidence-journal.ts
+++ b/packages/agent/src/sync/coverage-evidence-journal.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 export const SYNC_COVERAGE_EVIDENCE_SCHEMA_VERSION = 1 as const;
 export const DEFAULT_SYNC_COVERAGE_EVIDENCE_CAPACITY = 256;
 export const MAX_SYNC_COVERAGE_EVIDENCE_CONTEXT_GRAPHS = 32;
@@ -61,10 +63,50 @@ export interface CoreAutomaticSyncCoverageEvidence extends SyncCoverageEvidenceB
 export type SyncCoverageEvidenceEntry =
   | EdgeReconcilerSyncCoverageEvidence
   | CoreAutomaticSyncCoverageEvidence;
+type EdgeReconcilerSyncCoverageDraft = Omit<
+  EdgeReconcilerSyncCoverageEvidence,
+  'sequence' | 'waveId'
+>;
+type CoreAutomaticSyncCoverageDraft = Omit<
+  CoreAutomaticSyncCoverageEvidence,
+  'sequence' | 'waveId'
+>;
 
-export type SyncCoverageEvidenceDraft =
-  | Omit<EdgeReconcilerSyncCoverageEvidence, 'sequence' | 'waveId'>
-  | Omit<CoreAutomaticSyncCoverageEvidence, 'sequence' | 'waveId'>;
+export interface StartCoreAutomaticRoundInput {
+  planningLane: string;
+  trigger: SyncCoverageEvidenceTrigger;
+  configuredBatchSize: number;
+  effectiveBatchSize: number;
+  explicitSelectedContextGraphIds: readonly string[];
+  automaticContextGraphIds: readonly string[];
+  startedAt: number;
+}
+
+export interface StartEdgeReconcilerJobsInput {
+  contextGraphIds: readonly string[];
+  startedAt: number;
+}
+
+export interface FinishSyncCoverageEvidenceInput {
+  operationCompleted: boolean;
+  verifiedByContextGraph: ReadonlyMap<string, SyncCoverageVerifiedPlanes>;
+  finishedAt: number;
+}
+
+declare const syncCoverageEvidenceHandleBrand: unique symbol;
+
+export interface CoreAutomaticRoundHandle {
+  readonly [syncCoverageEvidenceHandleBrand]: true;
+  readonly kind: 'core-automatic-round';
+  readonly jobId: string;
+}
+
+export interface EdgeReconcilerJobHandle {
+  readonly [syncCoverageEvidenceHandleBrand]: true;
+  readonly kind: 'edge-reconciler-job';
+  readonly jobId: string;
+  readonly contextGraphId: string;
+}
 
 export interface SyncCoverageEvidenceSnapshotV1 {
   schemaVersion: typeof SYNC_COVERAGE_EVIDENCE_SCHEMA_VERSION;
@@ -101,6 +143,7 @@ function cloneEntry(entry: SyncCoverageEvidenceEntry): SyncCoverageEvidenceEntry
  */
 export class SyncCoverageEvidenceJournal {
   private readonly entries: SyncCoverageEvidenceEntry[] = [];
+  private readonly runningByJobId = new Map<string, SyncCoverageEvidenceEntry>();
   private nextSequence = 1;
   private droppedBeforeSequence = 0;
 
@@ -120,7 +163,11 @@ export class SyncCoverageEvidenceJournal {
     }
   }
 
-  append(draft: SyncCoverageEvidenceDraft): SyncCoverageEvidenceEntry {
+  private append(draft: EdgeReconcilerSyncCoverageDraft): EdgeReconcilerSyncCoverageEvidence;
+  private append(draft: CoreAutomaticSyncCoverageDraft): CoreAutomaticSyncCoverageEvidence;
+  private append(
+    draft: EdgeReconcilerSyncCoverageDraft | CoreAutomaticSyncCoverageDraft,
+  ): SyncCoverageEvidenceEntry {
     const entry = cloneEntry({
       ...draft,
       sequence: this.nextSequence,
@@ -133,6 +180,145 @@ export class SyncCoverageEvidenceJournal {
       if (dropped) this.droppedBeforeSequence = dropped.sequence;
     }
     return cloneEntry(entry);
+  }
+
+  startCoreAutomaticRound(
+    input: StartCoreAutomaticRoundInput,
+  ): CoreAutomaticRoundHandle {
+    const explicitSelected = boundedSyncCoverageContextGraphIds(
+      input.explicitSelectedContextGraphIds,
+    );
+    const automatic = boundedSyncCoverageContextGraphIds(input.automaticContextGraphIds);
+    const jobId = randomUUID();
+    const running = this.append({
+      kind: 'core-automatic-round',
+      jobId,
+      planningLane: input.planningLane,
+      source: 'automatic-core-public',
+      trigger: input.trigger,
+      configuredBatchSize: input.configuredBatchSize,
+      effectiveBatchSize: input.effectiveBatchSize,
+      explicitSelectedContextGraphIds: explicitSelected.ids,
+      explicitSelectedContextGraphCount: explicitSelected.count,
+      automaticContextGraphIds: automatic.ids,
+      automaticContextGraphCount: automatic.count,
+      evidenceTruncated: explicitSelected.truncated || automatic.truncated,
+      state: 'running',
+      startedAt: input.startedAt,
+      completions: automatic.ids.map((contextGraphId) => ({
+        jobId,
+        contextGraphId,
+        state: 'running' as const,
+        verified: { metadata: false, durable: false, sharedMemory: false },
+      })),
+    });
+    this.runningByJobId.set(jobId, cloneEntry(running));
+    return Object.freeze({ kind: 'core-automatic-round', jobId }) as CoreAutomaticRoundHandle;
+  }
+
+  finishCoreAutomaticRound(
+    handle: CoreAutomaticRoundHandle,
+    input: FinishSyncCoverageEvidenceInput,
+  ): CoreAutomaticSyncCoverageEvidence {
+    const running = this.takeRunning(handle);
+    if (running.kind !== 'core-automatic-round') {
+      throw new TypeError('sync coverage evidence handle kind does not match Core round');
+    }
+    const completions: CoreAutomaticSyncCoverageCompletion[] = running.completions.map(
+      (completion) => {
+        const verified = input.verifiedByContextGraph.get(completion.contextGraphId)
+          ?? { metadata: false, durable: false, sharedMemory: false };
+        return {
+          ...completion,
+          state: input.operationCompleted && verifiedPlanesComplete(verified)
+            ? 'complete'
+            : 'failed',
+          verified,
+          finishedAt: input.finishedAt,
+        };
+      },
+    );
+    return this.append({
+      kind: 'core-automatic-round',
+      jobId: running.jobId,
+      planningLane: running.planningLane,
+      source: 'automatic-core-public',
+      trigger: running.trigger,
+      configuredBatchSize: running.configuredBatchSize,
+      effectiveBatchSize: running.effectiveBatchSize,
+      explicitSelectedContextGraphIds: running.explicitSelectedContextGraphIds,
+      explicitSelectedContextGraphCount: running.explicitSelectedContextGraphCount,
+      automaticContextGraphIds: running.automaticContextGraphIds,
+      automaticContextGraphCount: running.automaticContextGraphCount,
+      evidenceTruncated: running.evidenceTruncated,
+      state: input.operationCompleted
+        && !running.evidenceTruncated
+        && completions.length === running.automaticContextGraphCount
+        && completions.every((completion) => completion.state === 'complete')
+          ? 'complete'
+          : 'failed',
+      startedAt: running.startedAt,
+      finishedAt: input.finishedAt,
+      completions,
+    });
+  }
+
+  startEdgeReconcilerJobs(
+    input: StartEdgeReconcilerJobsInput,
+  ): EdgeReconcilerJobHandle[] {
+    const bounded = boundedSyncCoverageContextGraphIds(input.contextGraphIds);
+    return bounded.ids.map((contextGraphId) => {
+      const jobId = randomUUID();
+      const running = this.append({
+        kind: 'edge-reconciler-job',
+        jobId,
+        contextGraphId,
+        source: 'reconciler',
+        trigger: 'periodic-reconciler',
+        syncMode: 'always-on',
+        rehydratedSelectionCount: bounded.count,
+        evidenceTruncated: bounded.truncated,
+        state: 'running',
+        verified: { metadata: false, durable: false, sharedMemory: false },
+        startedAt: input.startedAt,
+      });
+      this.runningByJobId.set(jobId, cloneEntry(running));
+      return Object.freeze({
+        kind: 'edge-reconciler-job',
+        jobId,
+        contextGraphId,
+      }) as EdgeReconcilerJobHandle;
+    });
+  }
+
+  finishEdgeReconcilerJob(
+    handle: EdgeReconcilerJobHandle,
+    input: FinishSyncCoverageEvidenceInput,
+  ): EdgeReconcilerSyncCoverageEvidence {
+    const running = this.takeRunning(handle);
+    if (running.kind !== 'edge-reconciler-job') {
+      throw new TypeError('sync coverage evidence handle kind does not match Edge job');
+    }
+    const verified = input.verifiedByContextGraph.get(running.contextGraphId)
+      ?? { metadata: false, durable: false, sharedMemory: false };
+    return this.append({
+      kind: 'edge-reconciler-job',
+      jobId: running.jobId,
+      contextGraphId: running.contextGraphId,
+      source: 'reconciler',
+      trigger: 'periodic-reconciler',
+      syncMode: 'always-on',
+      rehydratedSelectionCount: running.rehydratedSelectionCount,
+      evidenceTruncated: running.evidenceTruncated,
+      state: input.operationCompleted
+        && !running.evidenceTruncated
+        && verifiedPlanesComplete(verified)
+          ? 'complete'
+          : 'failed',
+      verified,
+      startedAt: running.startedAt,
+      finishedAt: input.finishedAt,
+    });
   }
 
   snapshot(afterSequence = 0): SyncCoverageEvidenceSnapshotV1 {
@@ -151,6 +337,21 @@ export class SyncCoverageEvidenceJournal {
         .map(cloneEntry),
     };
   }
+
+  private takeRunning(
+    handle: CoreAutomaticRoundHandle | EdgeReconcilerJobHandle,
+  ): SyncCoverageEvidenceEntry {
+    const running = this.runningByJobId.get(handle.jobId);
+    if (!running || running.kind !== handle.kind) {
+      throw new TypeError('sync coverage evidence handle is unknown or already finished');
+    }
+    this.runningByJobId.delete(handle.jobId);
+    return cloneEntry(running);
+  }
+}
+
+function verifiedPlanesComplete(verified: SyncCoverageVerifiedPlanes): boolean {
+  return verified.metadata && verified.durable && verified.sharedMemory;
 }
 
 export function boundedSyncCoverageContextGraphIds(

--- a/packages/agent/src/sync/coverage-evidence-recorder.ts
+++ b/packages/agent/src/sync/coverage-evidence-recorder.ts
@@ -1,0 +1,148 @@
+import {
+  SyncCoverageEvidenceJournal,
+  type CoreAutomaticRoundHandle,
+  type EdgeReconcilerJobHandle,
+  type SyncCoverageEvidenceTrigger,
+  type SyncCoverageVerifiedPlanes,
+} from './coverage-evidence-journal.js';
+import type {
+  SharedMemoryContextGraphResult,
+  SharedMemoryContextGraphTerminal,
+} from '../dkg-agent-types.js';
+
+export interface SyncCoverageEvidenceRecorderOptions {
+  journal: SyncCoverageEvidenceJournal;
+  trigger: SyncCoverageEvidenceTrigger | undefined;
+  nodeRole: 'edge' | 'core';
+  planningLane: string;
+  configuredBatchSize: number;
+  effectiveBatchSize: number;
+}
+
+export interface SyncCoverageEvidenceRoundInput {
+  selectedContextGraphIds: readonly string[];
+  automaticContextGraphIds: readonly string[];
+  rehydratedAlwaysOnContextGraphIds: readonly string[];
+  startedAt?: number;
+}
+
+/**
+ * Per-peer automatic-sync evidence state. Lifecycle code only reports phase
+ * terminals; this recorder owns journal shapes, transitions, and fail-closed
+ * completion rules.
+ */
+export class SyncCoverageEvidenceRecorder {
+  private initialized = false;
+  private finished = false;
+  private coreRunning: CoreAutomaticRoundHandle | undefined;
+  private edgeRunning: EdgeReconcilerJobHandle[] = [];
+  private readonly evidenceContextGraphs = new Set<string>();
+  private readonly metadataVerified = new Set<string>();
+  private readonly durableVerified = new Set<string>();
+  private readonly sharedMemoryVerified = new Set<string>();
+
+  constructor(private readonly options: SyncCoverageEvidenceRecorderOptions) {}
+
+  beginRound(input: SyncCoverageEvidenceRoundInput): void {
+    if (this.initialized) return;
+    this.initialized = true;
+    const trigger = this.options.trigger;
+    if (!trigger) return;
+    const startedAt = input.startedAt ?? Date.now();
+    if (this.options.nodeRole === 'core' && input.automaticContextGraphIds.length > 0) {
+      for (const contextGraphId of input.automaticContextGraphIds) {
+        this.evidenceContextGraphs.add(contextGraphId);
+      }
+      this.coreRunning = this.options.journal.startCoreAutomaticRound({
+        planningLane: this.options.planningLane,
+        trigger,
+        configuredBatchSize: this.options.configuredBatchSize,
+        effectiveBatchSize: this.options.effectiveBatchSize,
+        explicitSelectedContextGraphIds: input.selectedContextGraphIds,
+        automaticContextGraphIds: input.automaticContextGraphIds,
+        startedAt,
+      });
+    }
+    if (this.options.nodeRole === 'edge' && trigger === 'periodic-reconciler') {
+      for (const contextGraphId of input.rehydratedAlwaysOnContextGraphIds) {
+        this.evidenceContextGraphs.add(contextGraphId);
+      }
+      this.edgeRunning = this.options.journal.startEdgeReconcilerJobs({
+        contextGraphIds: input.rehydratedAlwaysOnContextGraphIds,
+        startedAt,
+      });
+    }
+  }
+
+  hasActiveEvidence(): boolean {
+    return this.coreRunning !== undefined || this.edgeRunning.length > 0;
+  }
+
+  markMetadata(contextGraphIds: Iterable<string>): void {
+    if (!this.hasActiveEvidence()) return;
+    for (const contextGraphId of contextGraphIds) {
+      this.metadataVerified.add(contextGraphId);
+    }
+  }
+
+  markDurable(contextGraphIds: Iterable<string>, complete: boolean): void {
+    if (!complete || !this.hasActiveEvidence()) return;
+    for (const contextGraphId of contextGraphIds) {
+      this.durableVerified.add(contextGraphId);
+    }
+  }
+
+  markSharedMemory(
+    outcomes: readonly SharedMemoryContextGraphTerminal[],
+  ): void {
+    if (!this.hasActiveEvidence()) return;
+    for (const outcome of outcomes) {
+      if (
+        outcome.disposition === 'settled'
+        && sharedMemoryTerminalCompletedCleanly(outcome.result)
+      ) {
+        this.sharedMemoryVerified.add(outcome.contextGraphId);
+      }
+    }
+  }
+
+  finish(operationCompleted: boolean, finishedAt = Date.now()): void {
+    if (this.finished) return;
+    this.finished = true;
+    const verifiedByContextGraph = new Map<string, SyncCoverageVerifiedPlanes>();
+    for (const contextGraphId of this.evidenceContextGraphs) {
+      verifiedByContextGraph.set(contextGraphId, {
+        metadata: this.metadataVerified.has(contextGraphId),
+        durable: this.durableVerified.has(contextGraphId),
+        sharedMemory: this.sharedMemoryVerified.has(contextGraphId),
+      });
+    }
+    if (this.coreRunning) {
+      this.options.journal.finishCoreAutomaticRound(this.coreRunning, {
+        operationCompleted,
+        verifiedByContextGraph,
+        finishedAt,
+      });
+    }
+    for (const running of this.edgeRunning) {
+      this.options.journal.finishEdgeReconcilerJob(running, {
+        operationCompleted,
+        verifiedByContextGraph,
+        finishedAt,
+      });
+    }
+  }
+}
+
+function sharedMemoryTerminalCompletedCleanly(
+  result: Readonly<SharedMemoryContextGraphResult>,
+): boolean {
+  return result.failedPhases === 0
+    && result.failedPeers === 0
+    && result.timedOutPhases === 0
+    && result.deniedPhases === 0
+    && result.droppedDataTriples === 0
+    && (result.backoffWorthyFailures ?? 0) === 0
+    && (result.deferredBackpressure ?? 0) === 0
+    && result.completedPhases + result.emptyResponses >= 1;
+}

--- a/packages/agent/src/sync/coverage-evidence-recorder.ts
+++ b/packages/agent/src/sync/coverage-evidence-recorder.ts
@@ -78,9 +78,11 @@ export class SyncCoverageEvidenceRecorder {
     return this.coreRunning !== undefined || this.edgeRunning.length > 0;
   }
 
-  markMetadata(contextGraphIds: Iterable<string>): void {
+  markMetadata(contextGraphIds: unknown): void {
     if (!this.hasActiveEvidence()) return;
-    for (const contextGraphId of contextGraphIds) {
+    const verifiedContextGraphIds = iterableStringValues(contextGraphIds);
+    if (!verifiedContextGraphIds) return;
+    for (const contextGraphId of verifiedContextGraphIds) {
       this.metadataVerified.add(contextGraphId);
     }
   }
@@ -138,6 +140,28 @@ export class SyncCoverageEvidenceRecorder {
         finishedAt,
       });
     }
+  }
+}
+
+function iterableStringValues(value: unknown): string[] | undefined {
+  try {
+    if (
+      (typeof value !== 'object' && typeof value !== 'function')
+      || value === null
+      || typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] !== 'function'
+    ) {
+      return undefined;
+    }
+    const strings: string[] = [];
+    for (const candidate of value as Iterable<unknown>) {
+      if (typeof candidate !== 'string') return undefined;
+      strings.push(candidate);
+    }
+    return strings;
+  } catch {
+    // Legacy JavaScript overrides may return void or hostile iterables. Evidence
+    // remains unverified, but observer parsing must never alter sync control flow.
+    return undefined;
   }
 }
 

--- a/packages/agent/src/sync/coverage-evidence-recorder.ts
+++ b/packages/agent/src/sync/coverage-evidence-recorder.ts
@@ -16,10 +16,10 @@ export interface SyncCoverageEvidenceRecorderOptions {
   nodeRole: 'edge' | 'core';
   planningLane: string;
   configuredBatchSize: number;
-  effectiveBatchSize: number;
 }
 
 export interface SyncCoverageEvidenceRoundInput {
+  effectiveBatchSize: number;
   selectedContextGraphIds: readonly string[];
   automaticContextGraphIds: readonly string[];
   rehydratedAlwaysOnContextGraphIds: readonly string[];
@@ -57,7 +57,7 @@ export class SyncCoverageEvidenceRecorder {
         planningLane: this.options.planningLane,
         trigger,
         configuredBatchSize: this.options.configuredBatchSize,
-        effectiveBatchSize: this.options.effectiveBatchSize,
+        effectiveBatchSize: input.effectiveBatchSize,
         explicitSelectedContextGraphIds: input.selectedContextGraphIds,
         automaticContextGraphIds: input.automaticContextGraphIds,
         startedAt,

--- a/packages/agent/src/sync/coverage-evidence-recorder.ts
+++ b/packages/agent/src/sync/coverage-evidence-recorder.ts
@@ -92,17 +92,24 @@ export class SyncCoverageEvidenceRecorder {
     }
   }
 
-  markSharedMemory(
-    outcomes: readonly SharedMemoryContextGraphTerminal[],
-  ): void {
+  markSharedMemoryResult(result: unknown): void {
     if (!this.hasActiveEvidence()) return;
-    for (const outcome of outcomes) {
-      if (
-        outcome.disposition === 'settled'
-        && sharedMemoryTerminalCompletedCleanly(outcome.result)
-      ) {
-        this.sharedMemoryVerified.add(outcome.contextGraphId);
-      }
+    let outcomes: unknown;
+    try {
+      if (typeof result !== 'object' || result === null) return;
+      outcomes = (result as Record<string, unknown>).contextGraphTerminals;
+    } catch {
+      return;
+    }
+    this.markSharedMemory(outcomes);
+  }
+
+  markSharedMemory(outcomes: unknown): void {
+    if (!this.hasActiveEvidence()) return;
+    const verifiedContextGraphIds = verifiedSharedMemoryContextGraphIds(outcomes);
+    if (!verifiedContextGraphIds) return;
+    for (const contextGraphId of verifiedContextGraphIds) {
+      this.sharedMemoryVerified.add(contextGraphId);
     }
   }
 
@@ -132,6 +139,40 @@ export class SyncCoverageEvidenceRecorder {
       });
     }
   }
+}
+
+function verifiedSharedMemoryContextGraphIds(outcomes: unknown): string[] | undefined {
+  try {
+    if (!Array.isArray(outcomes)) return undefined;
+    const verifiedContextGraphIds: string[] = [];
+    for (const outcome of outcomes) {
+      const verifiedContextGraphId = verifiedSharedMemoryContextGraphId(outcome);
+      if (verifiedContextGraphId !== undefined) {
+        verifiedContextGraphIds.push(verifiedContextGraphId);
+      }
+    }
+    return verifiedContextGraphIds;
+  } catch {
+    // Evidence is an observer. Host-defined arrays/proxies that throw during
+    // inspection make the plane unverifiable, but never alter sync control flow.
+    return undefined;
+  }
+}
+
+function verifiedSharedMemoryContextGraphId(outcome: unknown): string | undefined {
+  if (typeof outcome !== 'object' || outcome === null) return undefined;
+  const terminal = outcome as Partial<SharedMemoryContextGraphTerminal>;
+  if (
+    terminal.disposition !== 'settled'
+    || typeof terminal.contextGraphId !== 'string'
+    || typeof terminal.result !== 'object'
+    || terminal.result === null
+  ) {
+    return undefined;
+  }
+  return sharedMemoryTerminalCompletedCleanly(terminal.result)
+    ? terminal.contextGraphId
+    : undefined;
 }
 
 function sharedMemoryTerminalCompletedCleanly(

--- a/packages/agent/src/sync/requester/ordered-sync.ts
+++ b/packages/agent/src/sync/requester/ordered-sync.ts
@@ -55,6 +55,10 @@ export interface OrderedContextGraphSyncExecution<Result> {
   outcomes: readonly OrderedContextGraphSyncOutcome<Result>[];
 }
 
+type OrderedContextGraphSyncOutcomeCollector<Result> = (
+  outcome: OrderedContextGraphSyncOutcome<Result>,
+) => void;
+
 function orderWork<Result>(
   work: readonly ContextGraphSyncWork<Result>[],
   priorities: Readonly<SyncContextGraphPriorityConfig> | undefined,
@@ -83,26 +87,39 @@ function orderWork<Result>(
 export async function runOrderedContextGraphSyncs<Result>(
   options: OrderedContextGraphSyncOptions<Result>,
 ): Promise<Result> {
-  return (await runOrderedContextGraphSyncsWithOutcomes(options)).summary;
+  return runOrderedContextGraphSyncsInternal(options);
 }
 
 /** Same scheduler contract with an exact outcome for every planned work item. */
 export async function runOrderedContextGraphSyncsWithOutcomes<Result>(
   options: OrderedContextGraphSyncOptions<Result>,
 ): Promise<OrderedContextGraphSyncExecution<Result>> {
+  const outcomes: OrderedContextGraphSyncOutcome<Result>[] = [];
+  const summary = await runOrderedContextGraphSyncsInternal(
+    options,
+    (outcome) => outcomes.push(outcome),
+  );
+  return { summary, outcomes: Object.freeze(outcomes.map((outcome) => Object.freeze(outcome))) };
+}
+
+async function runOrderedContextGraphSyncsInternal<Result>(
+  options: OrderedContextGraphSyncOptions<Result>,
+  collectOutcome?: OrderedContextGraphSyncOutcomeCollector<Result>,
+): Promise<Result> {
   let summary = options.emptyResult();
   const orderedWork = orderWork(options.work, options.priorities);
-  const outcomes: OrderedContextGraphSyncOutcome<Result>[] = [];
   for (const [index, item] of orderedWork.entries()) {
     if (options.shouldContinue && !options.shouldContinue()) {
       const skipped = orderedWork.slice(index);
       summary = options.markSkipped?.(summary, skipped) ?? summary;
-      outcomes.push(...skipped.map((candidate) => ({
-        contextGraphId: candidate.contextGraphId,
-        lane: candidate.lane,
-        disposition: 'skipped' as const,
-        reason: 'continuation-stopped' as const,
-      })));
+      for (const candidate of skipped) {
+        collectOutcome?.({
+          contextGraphId: candidate.contextGraphId,
+          lane: candidate.lane,
+          disposition: 'skipped',
+          reason: 'continuation-stopped',
+        });
+      }
       break;
     }
     const remaining = orderedWork.length - index;
@@ -111,7 +128,7 @@ export async function runOrderedContextGraphSyncsWithOutcomes<Result>(
         item,
         () => item.run(remaining),
       );
-      outcomes.push({
+      collectOutcome?.({
         contextGraphId: item.contextGraphId,
         lane: item.lane,
         disposition: 'settled',
@@ -119,32 +136,36 @@ export async function runOrderedContextGraphSyncsWithOutcomes<Result>(
       });
       summary = options.merge(summary, part);
       if (options.shouldStop?.(part)) {
-        outcomes.push(...orderedWork.slice(index + 1).map((candidate) => ({
-          contextGraphId: candidate.contextGraphId,
-          lane: candidate.lane,
-          disposition: 'skipped' as const,
-          reason: 'stop-policy' as const,
-        })));
+        for (const candidate of orderedWork.slice(index + 1)) {
+          collectOutcome?.({
+            contextGraphId: candidate.contextGraphId,
+            lane: candidate.lane,
+            disposition: 'skipped',
+            reason: 'stop-policy',
+          });
+        }
         break;
       }
     } catch (error) {
       const backpressureError = getSyncBackpressureBusyError(error);
       if (!backpressureError) throw error;
-      outcomes.push({
+      collectOutcome?.({
         contextGraphId: item.contextGraphId,
         lane: item.lane,
         disposition: 'deferred',
       });
-      outcomes.push(...orderedWork.slice(index + 1).map((candidate) => ({
-        contextGraphId: candidate.contextGraphId,
-        lane: candidate.lane,
-        disposition: 'skipped' as const,
-        reason: 'prior-deferral' as const,
-      })));
+      for (const candidate of orderedWork.slice(index + 1)) {
+        collectOutcome?.({
+          contextGraphId: candidate.contextGraphId,
+          lane: candidate.lane,
+          disposition: 'skipped',
+          reason: 'prior-deferral',
+        });
+      }
       summary = options.markDeferred(summary);
       options.onDeferred?.(item, backpressureError);
       break;
     }
   }
-  return { summary, outcomes: Object.freeze(outcomes.map((outcome) => Object.freeze(outcome))) };
+  return summary;
 }

--- a/packages/agent/src/sync/requester/ordered-sync.ts
+++ b/packages/agent/src/sync/requester/ordered-sync.ts
@@ -31,6 +31,30 @@ export interface OrderedContextGraphSyncOptions<Result> {
   onDeferred?: (item: ContextGraphSyncWork<Result>, error: Error) => void;
 }
 
+export type OrderedContextGraphSyncOutcome<Result> =
+  | {
+    readonly contextGraphId: string;
+    readonly lane: SyncSchedulerLane;
+    readonly disposition: 'settled';
+    readonly result: Result;
+  }
+  | {
+    readonly contextGraphId: string;
+    readonly lane: SyncSchedulerLane;
+    readonly disposition: 'deferred';
+  }
+  | {
+    readonly contextGraphId: string;
+    readonly lane: SyncSchedulerLane;
+    readonly disposition: 'skipped';
+    readonly reason: 'continuation-stopped' | 'stop-policy' | 'prior-deferral';
+  };
+
+export interface OrderedContextGraphSyncExecution<Result> {
+  summary: Result;
+  outcomes: readonly OrderedContextGraphSyncOutcome<Result>[];
+}
+
 function orderWork<Result>(
   work: readonly ContextGraphSyncWork<Result>[],
   priorities: Readonly<SyncContextGraphPriorityConfig> | undefined,
@@ -59,11 +83,26 @@ function orderWork<Result>(
 export async function runOrderedContextGraphSyncs<Result>(
   options: OrderedContextGraphSyncOptions<Result>,
 ): Promise<Result> {
+  return (await runOrderedContextGraphSyncsWithOutcomes(options)).summary;
+}
+
+/** Same scheduler contract with an exact outcome for every planned work item. */
+export async function runOrderedContextGraphSyncsWithOutcomes<Result>(
+  options: OrderedContextGraphSyncOptions<Result>,
+): Promise<OrderedContextGraphSyncExecution<Result>> {
   let summary = options.emptyResult();
   const orderedWork = orderWork(options.work, options.priorities);
+  const outcomes: OrderedContextGraphSyncOutcome<Result>[] = [];
   for (const [index, item] of orderedWork.entries()) {
     if (options.shouldContinue && !options.shouldContinue()) {
-      summary = options.markSkipped?.(summary, orderedWork.slice(index)) ?? summary;
+      const skipped = orderedWork.slice(index);
+      summary = options.markSkipped?.(summary, skipped) ?? summary;
+      outcomes.push(...skipped.map((candidate) => ({
+        contextGraphId: candidate.contextGraphId,
+        lane: candidate.lane,
+        disposition: 'skipped' as const,
+        reason: 'continuation-stopped' as const,
+      })));
       break;
     }
     const remaining = orderedWork.length - index;
@@ -72,15 +111,40 @@ export async function runOrderedContextGraphSyncs<Result>(
         item,
         () => item.run(remaining),
       );
+      outcomes.push({
+        contextGraphId: item.contextGraphId,
+        lane: item.lane,
+        disposition: 'settled',
+        result: part,
+      });
       summary = options.merge(summary, part);
-      if (options.shouldStop?.(part)) break;
+      if (options.shouldStop?.(part)) {
+        outcomes.push(...orderedWork.slice(index + 1).map((candidate) => ({
+          contextGraphId: candidate.contextGraphId,
+          lane: candidate.lane,
+          disposition: 'skipped' as const,
+          reason: 'stop-policy' as const,
+        })));
+        break;
+      }
     } catch (error) {
       const backpressureError = getSyncBackpressureBusyError(error);
       if (!backpressureError) throw error;
+      outcomes.push({
+        contextGraphId: item.contextGraphId,
+        lane: item.lane,
+        disposition: 'deferred',
+      });
+      outcomes.push(...orderedWork.slice(index + 1).map((candidate) => ({
+        contextGraphId: candidate.contextGraphId,
+        lane: candidate.lane,
+        disposition: 'skipped' as const,
+        reason: 'prior-deferral' as const,
+      })));
       summary = options.markDeferred(summary);
       options.onDeferred?.(item, backpressureError);
       break;
     }
   }
-  return summary;
+  return { summary, outcomes: Object.freeze(outcomes.map((outcome) => Object.freeze(outcome))) };
 }

--- a/packages/agent/test/sync-coverage-evidence-journal.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-journal.test.ts
@@ -4,26 +4,19 @@ import {
   boundedSyncCoverageContextGraphIds,
 } from '../src/sync/coverage-evidence-journal.js';
 
-const verified = { metadata: false, durable: false, sharedMemory: false };
-
 describe('SyncCoverageEvidenceJournal', () => {
   it('appends immutable transitions and filters by sequence', () => {
     const journal = new SyncCoverageEvidenceJournal(100, 'wave-1', 4);
-    const running = journal.append({
-      kind: 'edge-reconciler-job',
-      jobId: 'job-1',
-      contextGraphId: 'cg-1',
-      source: 'reconciler',
-      trigger: 'periodic-reconciler',
-      syncMode: 'always-on',
-      state: 'running',
-      verified,
+    const [handle] = journal.startEdgeReconcilerJobs({
+      contextGraphIds: ['cg-1'],
       startedAt: 101,
     });
-    journal.append({
-      ...running,
-      state: 'complete',
-      verified: { metadata: true, durable: true, sharedMemory: true },
+    journal.finishEdgeReconcilerJob(handle!, {
+      operationCompleted: true,
+      verifiedByContextGraph: new Map([[
+        'cg-1',
+        { metadata: true, durable: true, sharedMemory: true },
+      ]]),
       finishedAt: 102,
     });
 
@@ -36,7 +29,7 @@ describe('SyncCoverageEvidenceJournal', () => {
       droppedBeforeSequence: 0,
     });
     expect(snapshot.entries).toEqual([
-      expect.objectContaining({ sequence: 2, state: 'complete', jobId: 'job-1' }),
+      expect.objectContaining({ sequence: 2, state: 'complete', jobId: handle!.jobId }),
     ]);
 
     snapshot.entries[0]!.verified.metadata = false;
@@ -46,15 +39,8 @@ describe('SyncCoverageEvidenceJournal', () => {
   it('reports the exact overwrite boundary for fail-closed collectors', () => {
     const journal = new SyncCoverageEvidenceJournal(100, 'wave-1', 2);
     for (let index = 1; index <= 3; index += 1) {
-      journal.append({
-        kind: 'edge-reconciler-job',
-        jobId: `job-${index}`,
-        contextGraphId: `cg-${index}`,
-        source: 'reconciler',
-        trigger: 'periodic-reconciler',
-        syncMode: 'always-on',
-        state: 'running',
-        verified,
+      journal.startEdgeReconcilerJobs({
+        contextGraphIds: [`cg-${index}`],
         startedAt: 100 + index,
       });
     }
@@ -88,5 +74,48 @@ describe('SyncCoverageEvidenceJournal', () => {
     expect(() => new SyncCoverageEvidenceJournal(100, 'wave', 0)).toThrow(/capacity/);
     const journal = new SyncCoverageEvidenceJournal(100, 'wave');
     expect(() => journal.snapshot(-1)).toThrow(/afterSequence/);
+  });
+
+  it('owns job identity and transition state behind immutable handles', () => {
+    const journal = new SyncCoverageEvidenceJournal(100, 'wave-1');
+    const selected = ['selected-cg'];
+    const automatic = ['automatic-cg'];
+    const handle = journal.startCoreAutomaticRound({
+      planningLane: 'peer-a',
+      trigger: 'connection-open',
+      configuredBatchSize: 8,
+      effectiveBatchSize: 4,
+      explicitSelectedContextGraphIds: selected,
+      automaticContextGraphIds: automatic,
+      startedAt: 101,
+    });
+
+    selected[0] = 'mutated-selected';
+    automatic[0] = 'mutated-automatic';
+    expect(Object.isFrozen(handle)).toBe(true);
+    expect(() => {
+      (handle as { jobId: string }).jobId = 'forged';
+    }).toThrow(TypeError);
+
+    const terminal = journal.finishCoreAutomaticRound(handle, {
+      operationCompleted: true,
+      verifiedByContextGraph: new Map([[
+        'automatic-cg',
+        { metadata: true, durable: true, sharedMemory: true },
+      ]]),
+      finishedAt: 102,
+    });
+
+    expect(terminal).toMatchObject({
+      jobId: handle.jobId,
+      explicitSelectedContextGraphIds: ['selected-cg'],
+      automaticContextGraphIds: ['automatic-cg'],
+      state: 'complete',
+    });
+    expect(() => journal.finishCoreAutomaticRound(handle, {
+      operationCompleted: true,
+      verifiedByContextGraph: new Map(),
+      finishedAt: 103,
+    })).toThrow(/unknown or already finished/);
   });
 });

--- a/packages/agent/test/sync-coverage-evidence-journal.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-journal.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   SyncCoverageEvidenceJournal,
   boundedSyncCoverageContextGraphIds,
+  type EdgeReconcilerJobHandle,
 } from '../src/sync/coverage-evidence-journal.js';
 
 describe('SyncCoverageEvidenceJournal', () => {
@@ -104,6 +105,14 @@ describe('SyncCoverageEvidenceJournal', () => {
       verifiedByContextGraph: new Map(),
       finishedAt: 102,
     })).toThrow(/not issued by this module/);
+    expect(() => journal.finishEdgeReconcilerJob(
+      handle as unknown as EdgeReconcilerJobHandle,
+      {
+        operationCompleted: true,
+        verifiedByContextGraph: new Map(),
+        finishedAt: 102,
+      },
+    )).toThrow(/kind does not match Edge job/);
 
     const terminal = journal.finishCoreAutomaticRound(handle, {
       operationCompleted: true,

--- a/packages/agent/test/sync-coverage-evidence-journal.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-journal.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SyncCoverageEvidenceJournal,
+  boundedSyncCoverageContextGraphIds,
+} from '../src/sync/coverage-evidence-journal.js';
+
+const verified = { metadata: false, durable: false, sharedMemory: false };
+
+describe('SyncCoverageEvidenceJournal', () => {
+  it('appends immutable transitions and filters by sequence', () => {
+    const journal = new SyncCoverageEvidenceJournal(100, 'wave-1', 4);
+    const running = journal.append({
+      kind: 'edge-reconciler-job',
+      jobId: 'job-1',
+      contextGraphId: 'cg-1',
+      source: 'reconciler',
+      trigger: 'periodic-reconciler',
+      syncMode: 'always-on',
+      state: 'running',
+      verified,
+      startedAt: 101,
+    });
+    journal.append({
+      ...running,
+      state: 'complete',
+      verified: { metadata: true, durable: true, sharedMemory: true },
+      finishedAt: 102,
+    });
+
+    const snapshot = journal.snapshot(1);
+    expect(snapshot).toMatchObject({
+      schemaVersion: 1,
+      processStartedAt: 100,
+      waveId: 'wave-1',
+      nextSequence: 3,
+      droppedBeforeSequence: 0,
+    });
+    expect(snapshot.entries).toEqual([
+      expect.objectContaining({ sequence: 2, state: 'complete', jobId: 'job-1' }),
+    ]);
+
+    snapshot.entries[0]!.verified.metadata = false;
+    expect(journal.snapshot(1).entries[0]!.verified.metadata).toBe(true);
+  });
+
+  it('reports the exact overwrite boundary for fail-closed collectors', () => {
+    const journal = new SyncCoverageEvidenceJournal(100, 'wave-1', 2);
+    for (let index = 1; index <= 3; index += 1) {
+      journal.append({
+        kind: 'edge-reconciler-job',
+        jobId: `job-${index}`,
+        contextGraphId: `cg-${index}`,
+        source: 'reconciler',
+        trigger: 'periodic-reconciler',
+        syncMode: 'always-on',
+        state: 'running',
+        verified,
+        startedAt: 100 + index,
+      });
+    }
+
+    expect(journal.snapshot()).toMatchObject({
+      capacity: 2,
+      nextSequence: 4,
+      droppedBeforeSequence: 1,
+      entries: [
+        expect.objectContaining({ sequence: 2 }),
+        expect.objectContaining({ sequence: 3 }),
+      ],
+    });
+  });
+
+  it('bounds planned context graph identifiers while retaining exact counts', () => {
+    const bounded = boundedSyncCoverageContextGraphIds(
+      Array.from({ length: 300 }, (_, index) => `cg-${index}`),
+    );
+    expect(bounded.ids).toHaveLength(32);
+    expect(bounded.count).toBe(300);
+    expect(bounded.truncated).toBe(true);
+  });
+
+  it('omits oversized identifiers and marks the evidence truncated', () => {
+    const bounded = boundedSyncCoverageContextGraphIds(['cg-ok', 'x'.repeat(257)]);
+    expect(bounded).toEqual({ ids: ['cg-ok'], count: 2, truncated: true });
+  });
+
+  it('rejects invalid cursors and capacities', () => {
+    expect(() => new SyncCoverageEvidenceJournal(100, 'wave', 0)).toThrow(/capacity/);
+    const journal = new SyncCoverageEvidenceJournal(100, 'wave');
+    expect(() => journal.snapshot(-1)).toThrow(/afterSequence/);
+  });
+});

--- a/packages/agent/test/sync-coverage-evidence-journal.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-journal.test.ts
@@ -96,6 +96,14 @@ describe('SyncCoverageEvidenceJournal', () => {
     expect(() => {
       (handle as { jobId: string }).jobId = 'forged';
     }).toThrow(TypeError);
+    expect(() => journal.finishCoreAutomaticRound({
+      kind: 'core-automatic-round',
+      jobId: handle.jobId,
+    } as typeof handle, {
+      operationCompleted: true,
+      verifiedByContextGraph: new Map(),
+      finishedAt: 102,
+    })).toThrow(/not issued by this module/);
 
     const terminal = journal.finishCoreAutomaticRound(handle, {
       operationCompleted: true,

--- a/packages/agent/test/sync-coverage-evidence-journal.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-journal.test.ts
@@ -71,6 +71,43 @@ describe('SyncCoverageEvidenceJournal', () => {
     expect(bounded).toEqual({ ids: ['cg-ok'], count: 2, truncated: true });
   });
 
+  it('cannot finish truncated Core evidence as complete', () => {
+    const journal = new SyncCoverageEvidenceJournal(100, 'wave-1');
+    const automaticContextGraphIds = Array.from(
+      { length: 33 },
+      (_, index) => `automatic-cg-${index}`,
+    );
+    const handle = journal.startCoreAutomaticRound({
+      planningLane: 'peer-a',
+      trigger: 'connection-open',
+      configuredBatchSize: 33,
+      effectiveBatchSize: 33,
+      explicitSelectedContextGraphIds: [],
+      automaticContextGraphIds,
+      startedAt: 101,
+    });
+    const verifiedByContextGraph = new Map(
+      automaticContextGraphIds.slice(0, 32).map((contextGraphId) => [
+        contextGraphId,
+        { metadata: true, durable: true, sharedMemory: true },
+      ] as const),
+    );
+
+    const terminal = journal.finishCoreAutomaticRound(handle, {
+      operationCompleted: true,
+      verifiedByContextGraph,
+      finishedAt: 102,
+    });
+
+    expect(terminal).toMatchObject({
+      state: 'failed',
+      evidenceTruncated: true,
+      automaticContextGraphCount: 33,
+    });
+    expect(terminal.completions).toHaveLength(32);
+    expect(terminal.completions.every((completion) => completion.state === 'complete')).toBe(true);
+  });
+
   it('rejects invalid cursors and capacities', () => {
     expect(() => new SyncCoverageEvidenceJournal(100, 'wave', 0)).toThrow(/capacity/);
     const journal = new SyncCoverageEvidenceJournal(100, 'wave');

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -236,6 +236,35 @@ describe('automatic sync coverage runtime evidence', () => {
     });
   });
 
+  it('records the exact adaptive batch snapshot used by Core planning', async () => {
+    const automatic = ['cg-adaptive-a', 'cg-adaptive-b'];
+    const agent = await createEvidenceAgent('core', []);
+    for (const contextGraphId of automatic) {
+      (agent as any).subscribedContextGraphs.set(contextGraphId, {
+        subscribed: false,
+        metaSynced: false,
+      });
+      (agent as any).registerCorePublicSyncContextGraph(contextGraphId);
+    }
+    let effectiveBatchSize = 2;
+    (agent as any).syncCapacityRuntime.getEffectiveCoverageBatch = () => effectiveBatchSize;
+    (agent as any).getPeerProtocols = async () => {
+      effectiveBatchSize = 1;
+      return [PROTOCOL_SYNC];
+    };
+
+    await runConnectionOpenSync(agent);
+    const running = agent.getSyncCoverageEvidence().entries[0];
+
+    expect(running).toMatchObject({
+      kind: 'core-automatic-round',
+      state: 'running',
+      effectiveBatchSize: 1,
+      automaticContextGraphCount: 1,
+    });
+    expect(running?.automaticContextGraphIds).toHaveLength(1);
+  });
+
   it('closes an admitted automatic evidence job when a sync phase throws', async () => {
     const automatic = 'cg-automatic-throw';
     const agent = await createEvidenceAgent('core', []);

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -236,6 +236,44 @@ describe('automatic sync coverage runtime evidence', () => {
     });
   });
 
+  it.each([
+    ['a null terminal', [null]],
+    ['a settled terminal without a result', [{
+      contextGraphId: 'cg-automatic-malformed-result',
+      lane: 'shared_memory',
+      disposition: 'settled',
+    }]],
+  ])('keeps Core automatic sync successful with %s', async (_label, contextGraphTerminals) => {
+    const automatic = 'cg-automatic-malformed-result';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    (agent as any).syncSharedMemoryFromPeerDetailed = async () => ({
+      ...cleanSharedMemorySyncResult(),
+      contextGraphTerminals,
+    });
+
+    const errors = await runConnectionOpenSyncWithErrors(agent);
+    const entries = agent.getSyncCoverageEvidence().entries;
+
+    expect(errors).toEqual([]);
+    expect((agent as any).lastSuccessfulSyncAt.get(PEER)).toEqual(expect.any(Number));
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({
+      kind: 'core-automatic-round',
+      jobId: entries[0]!.jobId,
+      state: 'failed',
+      completions: [{
+        contextGraphId: automatic,
+        state: 'failed',
+        verified: { metadata: true, durable: true, sharedMemory: false },
+      }],
+    });
+  });
+
   it('records the exact adaptive batch snapshot used by Core planning', async () => {
     const automatic = ['cg-adaptive-a', 'cg-adaptive-b'];
     const agent = await createEvidenceAgent('core', []);
@@ -388,7 +426,7 @@ describe('automatic sync coverage runtime evidence', () => {
     });
   });
 
-  it('keeps Edge reconciler sync successful when terminals are malformed', async () => {
+  it('keeps Edge reconciler sync successful when terminal normalization throws', async () => {
     const rehydrated = 'cg-rehydrated-legacy-result';
     const persisted = new Map<string, ContextGraphSubscriptionRecord>([[rehydrated, {
       id: rehydrated,
@@ -419,9 +457,19 @@ describe('automatic sync coverage runtime evidence', () => {
       peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
     };
     await (agent as any).rehydrateContextGraphSubscriptions();
+    const terminalWithThrowingResult = {
+      contextGraphId: rehydrated,
+      lane: 'shared_memory',
+      disposition: 'settled',
+    };
+    Object.defineProperty(terminalWithThrowingResult, 'result', {
+      get: () => {
+        throw new Error('malformed terminal result getter');
+      },
+    });
     (agent as any).syncSharedMemoryFromPeerDetailed = async () => ({
       ...cleanSharedMemorySyncResult(),
-      contextGraphTerminals: null,
+      contextGraphTerminals: [terminalWithThrowingResult],
     });
     (agent.node as any).node = {
       getPeers: () => [{ toString: () => PEER }],

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -208,6 +208,87 @@ describe('automatic sync coverage runtime evidence', () => {
     expect(complete!.sequence).toBe(running!.sequence + 1);
   });
 
+  it('fails durable evidence closed on non-throwing incomplete sync progress', async () => {
+    const automatic = 'cg-automatic-incomplete-durable';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    (agent as any).syncFromPeerDetailed = async () => ({
+      ...cleanDurableSyncResult(),
+      insertedTriples: 1,
+      insertedDataTriples: 1,
+      fetchedDataTriples: 1,
+      checkpointAdvances: 1,
+      complete: false,
+    });
+
+    const errors = await runConnectionOpenSyncWithErrors(agent);
+    const entries = agent.getSyncCoverageEvidence().entries;
+
+    expect(errors).toEqual([]);
+    expect((agent as any).lastSyncProgressAt.get(PEER)).toEqual(expect.any(Number));
+    expect((agent as any).lastSuccessfulSyncAt.has(PEER)).toBe(false);
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({
+      kind: 'core-automatic-round',
+      jobId: entries[0]!.jobId,
+      state: 'failed',
+      completions: [{
+        contextGraphId: automatic,
+        state: 'failed',
+        verified: { metadata: true, durable: false, sharedMemory: true },
+      }],
+    });
+  });
+
+  it.each([
+    {
+      label: 'an empty confirmation set',
+      automatic: ['cg-metadata-empty'],
+      confirmed: [],
+    },
+    {
+      label: 'a subset confirmation set',
+      automatic: ['cg-metadata-confirmed', 'cg-metadata-unconfirmed'],
+      confirmed: ['cg-metadata-confirmed'],
+    },
+  ])('fails metadata evidence closed with $label', async ({ automatic, confirmed }) => {
+    const agent = await createEvidenceAgent('core', []);
+    for (const contextGraphId of automatic) {
+      (agent as any).subscribedContextGraphs.set(contextGraphId, {
+        subscribed: false,
+        metaSynced: false,
+      });
+      (agent as any).registerCorePublicSyncContextGraph(contextGraphId);
+    }
+    (agent as any).refreshMetaSyncedFlags = async () => new Set(confirmed);
+
+    const errors = await runConnectionOpenSyncWithErrors(agent);
+    const entries = agent.getSyncCoverageEvidence().entries;
+    const terminal = entries[1] as any;
+
+    expect(errors).toEqual([]);
+    expect((agent as any).lastSuccessfulSyncAt.get(PEER)).toEqual(expect.any(Number));
+    expect(entries).toHaveLength(2);
+    expect(terminal).toMatchObject({
+      kind: 'core-automatic-round',
+      jobId: entries[0]!.jobId,
+      state: 'failed',
+    });
+    expect(terminal.completions).toHaveLength(automatic.length);
+    for (const contextGraphId of automatic) {
+      const metadata = confirmed.includes(contextGraphId);
+      expect(terminal.completions).toContainEqual(expect.objectContaining({
+        contextGraphId,
+        state: metadata ? 'complete' : 'failed',
+        verified: { metadata, durable: true, sharedMemory: true },
+      }));
+    }
+  });
+
   it('keeps Core automatic sync successful when a legacy result omits terminals', async () => {
     const automatic = 'cg-automatic-legacy-result';
     const agent = await createEvidenceAgent('core', []);

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -306,11 +306,14 @@ describe('automatic sync coverage runtime evidence', () => {
     (agent as any).subscribedContextGraphs.set(runtimeSelected, {
       subscribed: true,
       syncMode: 'always-on',
+      syncAdmission: 'explicit',
       metaSynced: false,
     });
     expect((agent as any).config.syncContextGraphs).toEqual(
       expect.arrayContaining([rehydrated, runtimeSelected]),
     );
+    expect(agent.getContextGraphSubscriptionRehydrationStatus()?.rehydratedAlwaysOnIds)
+      .toEqual([rehydrated]);
 
     (agent.node as any).node = {
       getPeers: () => [{ toString: () => PEER }],
@@ -320,6 +323,17 @@ describe('automatic sync coverage runtime evidence', () => {
       protocolsKey: PROTOCOL_SYNC,
       connectionKey: PEER,
     });
+    (agent as any).subscribedContextGraphs.get(rehydrated).syncMode = 'on-demand';
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if ((agent as any).lastSuccessfulSyncAt.has(PEER)) break;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(agent.getSyncCoverageEvidence().entries).toEqual([]);
+
+    (agent as any).lastSuccessfulSyncAt.delete(PEER);
+    (agent as any).lastSyncProgressAt.delete(PEER);
+    (agent as any).subscribedContextGraphs.get(rehydrated).syncMode = 'always-on';
     await (agent as any).reconcileSyncFromConnectedPeers();
     for (let attempt = 0; attempt < 20; attempt += 1) {
       if (agent.getSyncCoverageEvidence().entries.length >= 2) break;

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { performance } from 'node:perf_hooks';
 import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { DKGAgent } from '../src/index.js';
+import {
+  DKGAgent,
+  type ContextGraphSubscriptionRecord,
+  type ContextGraphSubscriptionStore,
+} from '../src/index.js';
 
 const PEER = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
 
@@ -72,6 +76,7 @@ function withSettledSharedMemoryTerminals(
 async function createEvidenceAgent(
   nodeRole: 'edge' | 'core',
   selected: string[],
+  contextGraphSubscriptionStore?: ContextGraphSubscriptionStore,
 ): Promise<DKGAgent> {
   const agent = await DKGAgent.create({
     name: `SyncEvidence${nodeRole}`,
@@ -79,6 +84,7 @@ async function createEvidenceAgent(
     nodeRole,
     syncContextGraphs: selected,
     chainAdapter: new MockChainAdapter(),
+    contextGraphSubscriptionStore,
   });
   (agent as any).started = true;
   (agent as any).networkAdmissionCoordinator.isAcceptedPeer = () => true;
@@ -138,6 +144,11 @@ describe('automatic sync coverage runtime evidence', () => {
     (agent as any).registerCorePublicSyncContextGraph('cg-automatic');
 
     await (agent as any).trySyncFromPeer(PEER);
+    await (agent as any).trySyncFromPeer(
+      PEER,
+      undefined,
+      { trigger: 'connection-open' },
+    );
 
     expect(agent.getSyncCoverageEvidence().entries).toEqual([]);
   });
@@ -186,15 +197,34 @@ describe('automatic sync coverage runtime evidence', () => {
   it('records only startup-rehydrated always-on Edge selections on periodic work', async () => {
     const rehydrated = 'cg-rehydrated';
     const runtimeSelected = 'cg-runtime-selected';
-    const agent = await createEvidenceAgent('edge', [rehydrated, runtimeSelected]);
-    for (const contextGraphId of [rehydrated, runtimeSelected]) {
-      (agent as any).subscribedContextGraphs.set(contextGraphId, {
-        subscribed: true,
-        syncMode: 'always-on',
-        metaSynced: false,
-      });
-    }
-    (agent as any).rehydratedAlwaysOnSyncContextGraphs.add(rehydrated);
+    const persisted = new Map<string, ContextGraphSubscriptionRecord>([[rehydrated, {
+      id: rehydrated,
+      subscribed: false,
+      synced: false,
+      sharedMemorySynced: false,
+      metaSynced: false,
+      syncScoped: true,
+    }]]);
+    const subscriptionStore: ContextGraphSubscriptionStore = {
+      loadAll: async () => [...persisted.values()],
+      save: async (record) => {
+        persisted.set(record.id, { ...record });
+      },
+      delete: async (contextGraphId) => {
+        persisted.delete(contextGraphId);
+      },
+    };
+    const agent = await createEvidenceAgent('edge', [runtimeSelected], subscriptionStore);
+
+    await (agent as any).rehydrateContextGraphSubscriptions();
+    (agent as any).subscribedContextGraphs.set(runtimeSelected, {
+      subscribed: true,
+      syncMode: 'always-on',
+      metaSynced: false,
+    });
+    expect((agent as any).config.syncContextGraphs).toEqual(
+      expect.arrayContaining([rehydrated, runtimeSelected]),
+    );
 
     (agent.node as any).node = {
       getPeers: () => [{ toString: () => PEER }],
@@ -226,6 +256,44 @@ describe('automatic sync coverage runtime evidence', () => {
       jobId: entries[0]!.jobId,
       state: 'complete',
       verified: { metadata: true, durable: true, sharedMemory: true },
+    });
+  });
+
+  it('records peer-update automatic work through the real retry boundary', async () => {
+    const automatic = 'cg-peer-update';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    (agent as any).skippedNoSyncPeers.add(PEER);
+    (agent.node as any).node = {
+      peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
+    };
+
+    (agent as any).handlePeerUpdateForSyncRetry(PEER, [PROTOCOL_SYNC]);
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (agent.getSyncCoverageEvidence().entries.length >= 2) break;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    const entries = agent.getSyncCoverageEvidence().entries;
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      kind: 'core-automatic-round',
+      trigger: 'peer-update',
+      state: 'running',
+      automaticContextGraphIds: [automatic],
+    });
+    expect(entries[1]).toMatchObject({
+      jobId: entries[0]!.jobId,
+      state: 'complete',
+      completions: [{
+        contextGraphId: automatic,
+        state: 'complete',
+        verified: { metadata: true, durable: true, sharedMemory: true },
+      }],
     });
   });
 

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from 'vitest';
+import { performance } from 'node:perf_hooks';
+import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+
+const PEER = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+
+function cleanDurableSyncResult() {
+  return {
+    insertedTriples: 0,
+    insertedDataTriples: 0,
+    insertedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    fetchedMetaTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 10,
+    checkpointAdvances: 0,
+    emptyResponses: 1,
+    metaOnlyResponses: 0,
+    verifiedPrivateOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    backoffWorthyFailures: 0,
+    deferredBackpressure: 0,
+    complete: true,
+  };
+}
+
+function cleanSharedMemorySyncResult() {
+  return {
+    insertedTriples: 0,
+    insertedDataTriples: 0,
+    insertedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    fetchedMetaTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 1,
+    droppedDataTriples: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    backoffWorthyFailures: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+async function createEvidenceAgent(
+  nodeRole: 'edge' | 'core',
+  selected: string[],
+): Promise<DKGAgent> {
+  const agent = await DKGAgent.create({
+    name: `SyncEvidence${nodeRole}`,
+    listenHost: '127.0.0.1',
+    nodeRole,
+    syncContextGraphs: selected,
+    chainAdapter: new MockChainAdapter(),
+  });
+  (agent as any).started = true;
+  (agent as any).networkAdmissionCoordinator.isAcceptedPeer = () => true;
+  (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+  (agent as any).syncFromPeerDetailed = async () => cleanDurableSyncResult();
+  (agent as any).syncSharedMemoryFromPeerDetailed = async (
+    _peerId: string,
+    contextGraphIds: string[],
+    options?: { onContextGraphTerminal?: (id: string, result: unknown) => void },
+  ) => {
+    for (const contextGraphId of contextGraphIds) {
+      options?.onContextGraphTerminal?.(contextGraphId, cleanSharedMemorySyncResult());
+    }
+    return cleanSharedMemorySyncResult();
+  };
+  (agent as any).discoverContextGraphsFromStore = async () => 0;
+  (agent as any).planSharedMemorySyncContextGraphs = async (
+    _peerId: string,
+    contextGraphIds: string[],
+  ) => ({
+    publicContextGraphIds: [...contextGraphIds],
+    privateRecoverFromCurator: [],
+    eligibleContextGraphIds: [...contextGraphIds],
+  });
+  (agent as any).refreshMetaSyncedFlags = async (contextGraphIds: string[]) => {
+    const confirmed = new Set<string>();
+    for (const contextGraphId of contextGraphIds) {
+      const existing = (agent as any).subscribedContextGraphs.get(contextGraphId);
+      if (existing) {
+        existing.metaSynced = true;
+        confirmed.add(contextGraphId);
+      }
+    }
+    return confirmed;
+  };
+  (agent as any).hasConfirmedMetaState = async () => true;
+  return agent;
+}
+
+async function runConnectionOpenSync(agent: DKGAgent): Promise<void> {
+  (agent as any).getSyncReconcilerProbe = async () => ({
+    protocolsKey: PROTOCOL_SYNC,
+    connectionKey: PEER,
+  });
+  const errors: unknown[] = [];
+  await (agent as any).runSyncFromPeerOnConnect(
+    PEER,
+    (_peerId: string, error: unknown) => errors.push(error),
+  );
+  expect(errors).toEqual([]);
+}
+
+describe('automatic sync coverage runtime evidence', () => {
+  it('does not let direct library calls manufacture an internal trigger source', async () => {
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set('cg-automatic', {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph('cg-automatic');
+
+    await (agent as any).trySyncFromPeer(PEER);
+
+    expect(agent.getSyncCoverageEvidence().entries).toEqual([]);
+  });
+
+  it('records actual terminal Core automatic-round work with per-CG job evidence', async () => {
+    const selected = 'cg-selected';
+    const automatic = 'cg-automatic';
+    const agent = await createEvidenceAgent('core', [selected]);
+    (agent as any).subscribedContextGraphs.set(selected, { subscribed: true, metaSynced: false });
+    (agent as any).subscribedContextGraphs.set(automatic, { subscribed: false, metaSynced: false });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+
+    await runConnectionOpenSync(agent);
+    const snapshot = agent.getSyncCoverageEvidence();
+
+    expect(snapshot.processStartedAt).toBe(Math.floor(performance.timeOrigin));
+    expect(snapshot.entries).toHaveLength(2);
+    const [running, complete] = snapshot.entries;
+    expect(running).toMatchObject({
+      kind: 'core-automatic-round',
+      source: 'automatic-core-public',
+      trigger: 'connection-open',
+      planningLane: PEER,
+      explicitSelectedContextGraphIds: [selected],
+      automaticContextGraphIds: [automatic],
+      automaticContextGraphCount: 1,
+      evidenceTruncated: false,
+      state: 'running',
+      completions: [{ contextGraphId: automatic, state: 'running' }],
+    });
+    expect((running as any).completions[0].jobId).toBe(running!.jobId);
+    expect(complete).toMatchObject({
+      kind: 'core-automatic-round',
+      jobId: running!.jobId,
+      state: 'complete',
+      completions: [{
+        jobId: (running as any).completions[0].jobId,
+        contextGraphId: automatic,
+        state: 'complete',
+        verified: { metadata: true, durable: true, sharedMemory: true },
+      }],
+    });
+    expect(complete!.sequence).toBe(running!.sequence + 1);
+  });
+
+  it('records only startup-rehydrated always-on Edge selections on periodic work', async () => {
+    const rehydrated = 'cg-rehydrated';
+    const runtimeSelected = 'cg-runtime-selected';
+    const agent = await createEvidenceAgent('edge', [rehydrated, runtimeSelected]);
+    for (const contextGraphId of [rehydrated, runtimeSelected]) {
+      (agent as any).subscribedContextGraphs.set(contextGraphId, {
+        subscribed: true,
+        syncMode: 'always-on',
+        metaSynced: false,
+      });
+    }
+    (agent as any).rehydratedAlwaysOnSyncContextGraphs.add(rehydrated);
+
+    (agent.node as any).node = {
+      getPeers: () => [{ toString: () => PEER }],
+      getConnections: () => [],
+    };
+    (agent as any).getSyncReconcilerProbe = async () => ({
+      protocolsKey: PROTOCOL_SYNC,
+      connectionKey: PEER,
+    });
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (agent.getSyncCoverageEvidence().entries.length >= 2) break;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    const entries = agent.getSyncCoverageEvidence().entries;
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.contextGraphId)).toEqual([rehydrated, rehydrated]);
+    expect(entries[0]).toMatchObject({
+      kind: 'edge-reconciler-job',
+      source: 'reconciler',
+      trigger: 'periodic-reconciler',
+      syncMode: 'always-on',
+      rehydratedSelectionCount: 1,
+      evidenceTruncated: false,
+      state: 'running',
+    });
+    expect(entries[1]).toMatchObject({
+      jobId: entries[0]!.jobId,
+      state: 'complete',
+      verified: { metadata: true, durable: true, sharedMemory: true },
+    });
+  });
+
+  it('fails closed when an observed plane does not reach a clean terminal result', async () => {
+    const automatic = 'cg-automatic';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, { subscribed: false, metaSynced: false });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+      options?: { onContextGraphTerminal?: (id: string, result: unknown) => void },
+    ) => {
+      const failed = {
+        ...cleanSharedMemorySyncResult(),
+        failedPhases: 1,
+        backoffWorthyFailures: 1,
+      };
+      for (const contextGraphId of contextGraphIds) {
+        options?.onContextGraphTerminal?.(contextGraphId, failed);
+      }
+      return failed;
+    };
+
+    await runConnectionOpenSync(agent);
+    const terminal = agent.getSyncCoverageEvidence().entries.at(-1);
+
+    expect(terminal).toMatchObject({
+      kind: 'core-automatic-round',
+      state: 'failed',
+      completions: [{
+        contextGraphId: automatic,
+        state: 'failed',
+        verified: { metadata: true, durable: true, sharedMemory: false },
+      }],
+    });
+  });
+
+  it('does not verify shared memory when received triples were dropped', async () => {
+    const automatic = 'cg-automatic';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, { subscribed: false, metaSynced: false });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+      options?: { onContextGraphTerminal?: (id: string, result: unknown) => void },
+    ) => {
+      const incomplete = {
+        ...cleanSharedMemorySyncResult(),
+        droppedDataTriples: 1,
+      };
+      for (const contextGraphId of contextGraphIds) {
+        options?.onContextGraphTerminal?.(contextGraphId, incomplete);
+      }
+      return incomplete;
+    };
+
+    await runConnectionOpenSync(agent);
+    const terminal = agent.getSyncCoverageEvidence().entries.at(-1);
+
+    expect(terminal).toMatchObject({
+      kind: 'core-automatic-round',
+      state: 'failed',
+      completions: [{
+        contextGraphId: automatic,
+        state: 'failed',
+        verified: { metadata: true, durable: true, sharedMemory: false },
+      }],
+    });
+  });
+});

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -134,6 +134,19 @@ async function runConnectionOpenSync(agent: DKGAgent): Promise<void> {
   expect(errors).toEqual([]);
 }
 
+async function runConnectionOpenSyncWithErrors(agent: DKGAgent): Promise<unknown[]> {
+  (agent as any).getSyncReconcilerProbe = async () => ({
+    protocolsKey: PROTOCOL_SYNC,
+    connectionKey: PEER,
+  });
+  const errors: unknown[] = [];
+  await (agent as any).runSyncFromPeerOnConnect(
+    PEER,
+    (_peerId: string, error: unknown) => errors.push(error),
+  );
+  return errors;
+}
+
 describe('automatic sync coverage runtime evidence', () => {
   it('does not let direct library calls manufacture an internal trigger source', async () => {
     const agent = await createEvidenceAgent('core', []);
@@ -147,6 +160,7 @@ describe('automatic sync coverage runtime evidence', () => {
     await (agent as any).trySyncFromPeer(
       PEER,
       undefined,
+      'on-connect',
       { trigger: 'connection-open' },
     );
 
@@ -194,15 +208,50 @@ describe('automatic sync coverage runtime evidence', () => {
     expect(complete!.sequence).toBe(running!.sequence + 1);
   });
 
+  it('closes an admitted automatic evidence job when a sync phase throws', async () => {
+    const automatic = 'cg-automatic-throw';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    const failure = new Error('durable sync failed after admission');
+    (agent as any).syncFromPeerDetailed = async () => {
+      throw failure;
+    };
+
+    const errors = await runConnectionOpenSyncWithErrors(agent);
+    const entries = agent.getSyncCoverageEvidence().entries;
+
+    expect(errors).toEqual([failure]);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      kind: 'core-automatic-round',
+      trigger: 'connection-open',
+      state: 'running',
+    });
+    expect(entries[1]).toMatchObject({
+      jobId: entries[0]!.jobId,
+      state: 'failed',
+      completions: [{
+        contextGraphId: automatic,
+        state: 'failed',
+        verified: { metadata: false, durable: false, sharedMemory: false },
+      }],
+    });
+  });
+
   it('records only startup-rehydrated always-on Edge selections on periodic work', async () => {
     const rehydrated = 'cg-rehydrated';
     const runtimeSelected = 'cg-runtime-selected';
     const persisted = new Map<string, ContextGraphSubscriptionRecord>([[rehydrated, {
       id: rehydrated,
-      subscribed: false,
+      subscribed: true,
       synced: false,
       sharedMemorySynced: false,
       metaSynced: false,
+      syncAdmission: 'explicit',
       syncScoped: true,
     }]]);
     const subscriptionStore: ContextGraphSubscriptionStore = {
@@ -215,6 +264,15 @@ describe('automatic sync coverage runtime evidence', () => {
       },
     };
     const agent = await createEvidenceAgent('edge', [runtimeSelected], subscriptionStore);
+    (agent as any).gossip = {
+      subscribe: () => undefined,
+      unsubscribe: () => undefined,
+      onMessage: () => undefined,
+      offMessage: () => undefined,
+    };
+    (agent.node as any).node = {
+      peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
+    };
 
     await (agent as any).rehydrateContextGraphSubscriptions();
     (agent as any).subscribedContextGraphs.set(runtimeSelected, {

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -167,6 +167,23 @@ describe('automatic sync coverage runtime evidence', () => {
     expect(agent.getSyncCoverageEvidence().entries).toEqual([]);
   });
 
+  it('does not record an automatic job when peer admission reports already syncing', async () => {
+    const automatic = 'cg-automatic-already-syncing';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    (agent as any).syncingPeers.add(PEER);
+
+    const errors = await runConnectionOpenSyncWithErrors(agent);
+
+    expect(errors).toEqual([]);
+    expect(agent.getSyncCoverageEvidence().entries).toEqual([]);
+    expect((agent as any).lastSuccessfulSyncAt.has(PEER)).toBe(false);
+  });
+
   it('records actual terminal Core automatic-round work with per-CG job evidence', async () => {
     const selected = 'cg-selected';
     const automatic = 'cg-automatic';
@@ -288,6 +305,73 @@ describe('automatic sync coverage runtime evidence', () => {
       }));
     }
   });
+
+  it('keeps automatic sync successful when legacy metadata refresh returns void', async () => {
+    const automatic = 'cg-automatic-legacy-metadata';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    (agent as any).refreshMetaSyncedFlags = async () => undefined;
+
+    const errors = await runConnectionOpenSyncWithErrors(agent);
+    const entries = agent.getSyncCoverageEvidence().entries;
+
+    expect(errors).toEqual([]);
+    expect((agent as any).lastSuccessfulSyncAt.get(PEER)).toEqual(expect.any(Number));
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({
+      kind: 'core-automatic-round',
+      jobId: entries[0]!.jobId,
+      state: 'failed',
+      completions: [{
+        contextGraphId: automatic,
+        state: 'failed',
+        verified: { metadata: false, durable: true, sharedMemory: true },
+      }],
+    });
+  });
+
+  it.each(['stop-policy', 'continuation-stopped'] as const)(
+    'fails shared-memory evidence closed for a %s terminal',
+    async (reason) => {
+      const automatic = `cg-automatic-${reason}`;
+      const agent = await createEvidenceAgent('core', []);
+      (agent as any).subscribedContextGraphs.set(automatic, {
+        subscribed: false,
+        metaSynced: false,
+      });
+      (agent as any).registerCorePublicSyncContextGraph(automatic);
+      (agent as any).syncSharedMemoryFromPeerDetailed = async () => ({
+        ...cleanSharedMemorySyncResult(),
+        contextGraphTerminals: [{
+          contextGraphId: automatic,
+          lane: 'shared_memory',
+          disposition: 'skipped',
+          reason,
+        }],
+      });
+
+      const errors = await runConnectionOpenSyncWithErrors(agent);
+      const entries = agent.getSyncCoverageEvidence().entries;
+
+      expect(errors).toEqual([]);
+      expect((agent as any).lastSuccessfulSyncAt.get(PEER)).toEqual(expect.any(Number));
+      expect(entries).toHaveLength(2);
+      expect(entries[1]).toMatchObject({
+        kind: 'core-automatic-round',
+        jobId: entries[0]!.jobId,
+        state: 'failed',
+        completions: [{
+          contextGraphId: automatic,
+          state: 'failed',
+          verified: { metadata: true, durable: true, sharedMemory: false },
+        }],
+      });
+    },
+  );
 
   it('keeps Core automatic sync successful when a legacy result omits terminals', async () => {
     const automatic = 'cg-automatic-legacy-result';

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -208,6 +208,34 @@ describe('automatic sync coverage runtime evidence', () => {
     expect(complete!.sequence).toBe(running!.sequence + 1);
   });
 
+  it('keeps Core automatic sync successful when a legacy result omits terminals', async () => {
+    const automatic = 'cg-automatic-legacy-result';
+    const agent = await createEvidenceAgent('core', []);
+    (agent as any).subscribedContextGraphs.set(automatic, {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph(automatic);
+    (agent as any).syncSharedMemoryFromPeerDetailed = async () =>
+      cleanSharedMemorySyncResult();
+
+    await runConnectionOpenSync(agent);
+    const entries = agent.getSyncCoverageEvidence().entries;
+
+    expect((agent as any).lastSuccessfulSyncAt.get(PEER)).toEqual(expect.any(Number));
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({
+      kind: 'core-automatic-round',
+      jobId: entries[0]!.jobId,
+      state: 'failed',
+      completions: [{
+        contextGraphId: automatic,
+        state: 'failed',
+        verified: { metadata: true, durable: true, sharedMemory: false },
+      }],
+    });
+  });
+
   it('closes an admitted automatic evidence job when a sync phase throws', async () => {
     const automatic = 'cg-automatic-throw';
     const agent = await createEvidenceAgent('core', []);
@@ -314,6 +342,67 @@ describe('automatic sync coverage runtime evidence', () => {
       jobId: entries[0]!.jobId,
       state: 'complete',
       verified: { metadata: true, durable: true, sharedMemory: true },
+    });
+  });
+
+  it('keeps Edge reconciler sync successful when terminals are malformed', async () => {
+    const rehydrated = 'cg-rehydrated-legacy-result';
+    const persisted = new Map<string, ContextGraphSubscriptionRecord>([[rehydrated, {
+      id: rehydrated,
+      subscribed: true,
+      synced: false,
+      sharedMemorySynced: false,
+      metaSynced: false,
+      syncAdmission: 'explicit',
+      syncScoped: true,
+    }]]);
+    const subscriptionStore: ContextGraphSubscriptionStore = {
+      loadAll: async () => [...persisted.values()],
+      save: async (record) => {
+        persisted.set(record.id, { ...record });
+      },
+      delete: async (contextGraphId) => {
+        persisted.delete(contextGraphId);
+      },
+    };
+    const agent = await createEvidenceAgent('edge', [], subscriptionStore);
+    (agent as any).gossip = {
+      subscribe: () => undefined,
+      unsubscribe: () => undefined,
+      onMessage: () => undefined,
+      offMessage: () => undefined,
+    };
+    (agent.node as any).node = {
+      peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
+    };
+    await (agent as any).rehydrateContextGraphSubscriptions();
+    (agent as any).syncSharedMemoryFromPeerDetailed = async () => ({
+      ...cleanSharedMemorySyncResult(),
+      contextGraphTerminals: null,
+    });
+    (agent.node as any).node = {
+      getPeers: () => [{ toString: () => PEER }],
+      getConnections: () => [],
+    };
+    (agent as any).getSyncReconcilerProbe = async () => ({
+      protocolsKey: PROTOCOL_SYNC,
+      connectionKey: PEER,
+    });
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (agent.getSyncCoverageEvidence().entries.length >= 2) break;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    const entries = agent.getSyncCoverageEvidence().entries;
+
+    expect((agent as any).lastSuccessfulSyncAt.get(PEER)).toEqual(expect.any(Number));
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({
+      kind: 'edge-reconciler-job',
+      jobId: entries[0]!.jobId,
+      state: 'failed',
+      verified: { metadata: true, durable: true, sharedMemory: false },
     });
   });
 

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -54,6 +54,21 @@ function cleanSharedMemorySyncResult() {
   };
 }
 
+function withSettledSharedMemoryTerminals(
+  summary: ReturnType<typeof cleanSharedMemorySyncResult>,
+  contextGraphIds: readonly string[],
+) {
+  return {
+    ...summary,
+    contextGraphTerminals: Object.freeze(contextGraphIds.map((contextGraphId) => Object.freeze({
+      contextGraphId,
+      lane: 'shared_memory' as const,
+      disposition: 'settled' as const,
+      result: Object.freeze({ ...summary }),
+    }))),
+  };
+}
+
 async function createEvidenceAgent(
   nodeRole: 'edge' | 'core',
   selected: string[],
@@ -72,12 +87,9 @@ async function createEvidenceAgent(
   (agent as any).syncSharedMemoryFromPeerDetailed = async (
     _peerId: string,
     contextGraphIds: string[],
-    options?: { onContextGraphTerminal?: (id: string, result: unknown) => void },
   ) => {
-    for (const contextGraphId of contextGraphIds) {
-      options?.onContextGraphTerminal?.(contextGraphId, cleanSharedMemorySyncResult());
-    }
-    return cleanSharedMemorySyncResult();
+    const summary = cleanSharedMemorySyncResult();
+    return withSettledSharedMemoryTerminals(summary, contextGraphIds);
   };
   (agent as any).discoverContextGraphsFromStore = async () => 0;
   (agent as any).planSharedMemorySyncContextGraphs = async (
@@ -225,17 +237,13 @@ describe('automatic sync coverage runtime evidence', () => {
     (agent as any).syncSharedMemoryFromPeerDetailed = async (
       _peerId: string,
       contextGraphIds: string[],
-      options?: { onContextGraphTerminal?: (id: string, result: unknown) => void },
     ) => {
       const failed = {
         ...cleanSharedMemorySyncResult(),
         failedPhases: 1,
         backoffWorthyFailures: 1,
       };
-      for (const contextGraphId of contextGraphIds) {
-        options?.onContextGraphTerminal?.(contextGraphId, failed);
-      }
-      return failed;
+      return withSettledSharedMemoryTerminals(failed, contextGraphIds);
     };
 
     await runConnectionOpenSync(agent);
@@ -260,16 +268,12 @@ describe('automatic sync coverage runtime evidence', () => {
     (agent as any).syncSharedMemoryFromPeerDetailed = async (
       _peerId: string,
       contextGraphIds: string[],
-      options?: { onContextGraphTerminal?: (id: string, result: unknown) => void },
     ) => {
       const incomplete = {
         ...cleanSharedMemorySyncResult(),
         droppedDataTriples: 1,
       };
-      for (const contextGraphId of contextGraphIds) {
-        options?.onContextGraphTerminal?.(contextGraphId, incomplete);
-      }
-      return incomplete;
+      return withSettledSharedMemoryTerminals(incomplete, contextGraphIds);
     };
 
     await runConnectionOpenSync(agent);

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -597,6 +597,61 @@ describe('DKGAgent sync fetch coalescing', () => {
     }
   });
 
+  it('isolates shared-memory terminal observers from sync results and fanout', async () => {
+    let fetchCalls = 0;
+    let observerCalls = 0;
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const contextGraphIds = ['observer-cg-a', 'observer-cg-b'];
+    const sharedMemorySyncPlan = {
+      eligibleContextGraphIds: contextGraphIds,
+      publicContextGraphIds: contextGraphIds,
+      privateRecoverFromCurator: [],
+    };
+    (agent as any).listSubGraphs = async () => [];
+    stubLifecycleFetch(agent, async ({ phase }) => {
+      fetchCalls += 1;
+      return emptySyncPage(phase);
+    });
+    (agent as any).getOrCreateSyncVerifyWorker = () => ({
+      processSharedMemoryBatch: async () => ({
+        verifiedData: [],
+        verifiedMeta: [],
+        totalFetchedDataQuads: 0,
+        totalFetchedMetaQuads: 0,
+        droppedDataTriples: 0,
+        emptyResponses: 1,
+        entityCreators: [],
+      }),
+    });
+
+    try {
+      const result = await (agent as any).syncSharedMemoryFromPeerDetailed(
+        PEER_A,
+        contextGraphIds,
+        {
+          sharedMemorySyncPlan,
+          stopOnBackoffWorthyFailure: true,
+          onContextGraphTerminal: (_contextGraphId: string, terminal: object) => {
+            observerCalls += 1;
+            expect(Object.isFrozen(terminal)).toBe(true);
+            (terminal as { failedPhases: number }).failedPhases = 99;
+            throw new Error('observer failure must remain diagnostic-only');
+          },
+        },
+      );
+
+      expect(observerCalls).toBe(2);
+      expect(fetchCalls).toBe(4);
+      expect(result).toMatchObject({
+        failedPhases: 0,
+        failedPeers: 0,
+        backoffWorthyFailures: 0,
+      });
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('does not join direct shared-memory syncs with different admission priorities', async () => {
     let fetchCalls = 0;
     const agent = await createAgentWithSend(async () => new Uint8Array(0));

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -118,6 +118,7 @@ async function createAgentWithSend(
     syncGlobalMaxInflight: number;
     syncGlobalQueueLimit: number;
     syncContextGraphPriorities?: Record<string, number>;
+    nodeRole?: 'edge' | 'core';
   },
 ): Promise<DKGAgent> {
   const agent = await DKGAgent.create({
@@ -597,16 +598,16 @@ describe('DKGAgent sync fetch coalescing', () => {
     }
   });
 
-  it('isolates shared-memory terminal observers from sync results and fanout', async () => {
+  it('returns immutable per-CG shared-memory terminals without changing aggregate fanout', async () => {
     let fetchCalls = 0;
-    let observerCalls = 0;
     const agent = await createAgentWithSend(async () => new Uint8Array(0));
-    const contextGraphIds = ['observer-cg-a', 'observer-cg-b'];
+    const contextGraphIds = ['observer-cg-a', 'observer-cg-b', 'observer-cg-ineligible'];
     const sharedMemorySyncPlan = {
-      eligibleContextGraphIds: contextGraphIds,
-      publicContextGraphIds: contextGraphIds,
+      eligibleContextGraphIds: contextGraphIds.slice(0, 2),
+      publicContextGraphIds: contextGraphIds.slice(0, 2),
       privateRecoverFromCurator: [],
     };
+    (agent as any).planSharedMemorySyncContextGraphs = async () => sharedMemorySyncPlan;
     (agent as any).listSubGraphs = async () => [];
     stubLifecycleFetch(agent, async ({ phase }) => {
       fetchCalls += 1;
@@ -631,21 +632,117 @@ describe('DKGAgent sync fetch coalescing', () => {
         {
           sharedMemorySyncPlan,
           stopOnBackoffWorthyFailure: true,
-          onContextGraphTerminal: (_contextGraphId: string, terminal: object) => {
-            observerCalls += 1;
-            expect(Object.isFrozen(terminal)).toBe(true);
-            (terminal as { failedPhases: number }).failedPhases = 99;
-            throw new Error('observer failure must remain diagnostic-only');
-          },
         },
       );
 
-      expect(observerCalls).toBe(2);
       expect(fetchCalls).toBe(4);
+      expect(result.contextGraphTerminals.map((terminal: any) => terminal.contextGraphId))
+        .toEqual(contextGraphIds);
+      expect(Object.isFrozen(result.contextGraphTerminals)).toBe(true);
+      for (const terminal of result.contextGraphTerminals.slice(0, 2)) {
+        expect(Object.isFrozen(terminal)).toBe(true);
+        expect(terminal.disposition).toBe('settled');
+        expect(Object.isFrozen(terminal.result)).toBe(true);
+        expect(() => {
+          (terminal.result as { failedPhases: number }).failedPhases = 99;
+        }).toThrow(TypeError);
+      }
+      expect(result.contextGraphTerminals[2]).toEqual({
+        contextGraphId: 'observer-cg-ineligible',
+        lane: null,
+        disposition: 'skipped',
+        reason: 'not-eligible',
+      });
+      expect(Object.isFrozen(result.contextGraphTerminals[2])).toBe(true);
       expect(result).toMatchObject({
         failedPhases: 0,
         failedPeers: 0,
         backoffWorthyFailures: 0,
+      });
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('records complete automatic evidence when it joins an existing manual SWM flight', async () => {
+    const contextGraphId = 'coalesced-evidence-cg';
+    const firstMetaFetch = deferred<SyncPageResult>();
+    let fetchCalls = 0;
+    const agent = await createAgentWithSend(
+      async () => new Uint8Array(0),
+      { syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 0, nodeRole: 'core' },
+    );
+    const sharedMemorySyncPlan = {
+      eligibleContextGraphIds: [contextGraphId],
+      publicContextGraphIds: [contextGraphId],
+      privateRecoverFromCurator: [],
+    };
+    (agent as any).started = true;
+    (agent as any).networkAdmissionCoordinator.isAcceptedPeer = () => true;
+    (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+    (agent as any).getSyncReconcilerProbe = async () => ({
+      protocolsKey: PROTOCOL_SYNC,
+      connectionKey: PEER_A,
+    });
+    (agent as any).syncFromPeerDetailed = async () => ({
+      ...cleanDurableSyncResult(),
+      complete: true,
+    });
+    (agent as any).refreshMetaSyncedFlags = async () => new Set([contextGraphId]);
+    (agent as any).discoverContextGraphsFromStore = async () => 0;
+    (agent as any).planSharedMemorySyncContextGraphs = async () => sharedMemorySyncPlan;
+    (agent as any).subscribedContextGraphs.set(contextGraphId, {
+      subscribed: false,
+      metaSynced: false,
+    });
+    (agent as any).registerCorePublicSyncContextGraph(contextGraphId);
+    (agent as any).listSubGraphs = async () => [];
+    stubLifecycleFetch(agent, async ({ phase }) => {
+      fetchCalls += 1;
+      if (fetchCalls === 1) return firstMetaFetch.promise;
+      return emptySyncPage(phase);
+    });
+    (agent as any).getOrCreateSyncVerifyWorker = () => ({
+      processSharedMemoryBatch: async () => ({
+        verifiedData: [],
+        verifiedMeta: [],
+        totalFetchedDataQuads: 0,
+        totalFetchedMetaQuads: 0,
+        droppedDataTriples: 0,
+        emptyResponses: 1,
+        entityCreators: [],
+      }),
+    });
+
+    try {
+      const manual = (agent as any).syncSharedMemoryFromPeerDetailed(
+        PEER_A,
+        [contextGraphId],
+        { sharedMemorySyncPlan, stopOnBackoffWorthyFailure: true },
+      );
+      await waitFor(() => fetchCalls === 1);
+
+      const errors: unknown[] = [];
+      const automatic = (agent as any).runSyncFromPeerOnConnect(
+        PEER_A,
+        (_peerId: string, error: unknown) => errors.push(error),
+      );
+      await flushMicrotasks();
+      expect(fetchCalls).toBe(1);
+
+      firstMetaFetch.resolve(emptySyncPage('meta'));
+      await Promise.all([manual, automatic]);
+
+      expect(errors).toEqual([]);
+      expect(fetchCalls).toBe(2);
+      expect(agent.getSyncCoverageEvidence().entries.at(-1)).toMatchObject({
+        kind: 'core-automatic-round',
+        state: 'complete',
+        completions: [{
+          contextGraphId,
+          state: 'complete',
+          verified: { metadata: true, durable: true, sharedMemory: true },
+        }],
       });
     } finally {
       await agent.stop().catch(() => {});

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -125,22 +125,20 @@ describe('sync-on-connect churn gates', () => {
     // relabel most sync-global pressure on the operator dashboards.
     const agent = await createUnstartedAgent('SyncOnConnectSourceLabel');
     (agent as any).started = true;
-    const sources: unknown[] = [];
-    (agent as any).trySyncFromPeer = async (
-      _peer: string,
-      _onAccounting: unknown,
-      source: unknown,
-    ) => {
-      sources.push(source);
-      return undefined;
-    };
+    const trySyncFromPeer = recorder(async () => undefined);
+    (agent as any).trySyncFromPeer = trySyncFromPeer;
 
     await (agent as any).attemptSyncFromPeerWithReconcilerAccounting(PEER_A, {
       connected: true,
       hasSyncProtocol: true,
     });
 
-    expect(sources).toEqual(['on-connect']);
+    // An untriggered compatibility call must not gain a trailing `undefined`.
+    expect(trySyncFromPeer.calls).toEqual([[
+      PEER_A,
+      expect.any(Function),
+      'on-connect',
+    ]]);
   });
 
   it('reconciler still retries stale connected peers', async () => {
@@ -157,10 +155,15 @@ describe('sync-on-connect churn gates', () => {
     await (agent as any).reconcileSyncFromConnectedPeers();
     await flushTimers();
 
-    // The third argument is the bounded admission origin (issue #2006): the
-    // reconciler's queue pressure must be attributable to `reconcile`, not
-    // indistinguishable from sync-on-connect.
-    expect(trySyncFromPeer.calls).toEqual([[PEER_A, expect.any(Function), 'reconcile']]);
+    // The third argument is the bounded admission origin (issue #2006), while
+    // the fourth is the opaque module-private provenance token used only by
+    // automatic paths. Direct callers cannot manufacture its symbol brand.
+    expect(trySyncFromPeer.calls).toEqual([[
+      PEER_A,
+      expect.any(Function),
+      'reconcile',
+      expect.objectContaining({ trigger: 'periodic-reconciler' }),
+    ]]);
   });
 
   it('records backoff after a failed sync round and blocks connection-open rescheduling', async () => {

--- a/packages/agent/test/sync-requester-priority.test.ts
+++ b/packages/agent/test/sync-requester-priority.test.ts
@@ -400,6 +400,79 @@ describe('requester per-CG priority admission', () => {
     expect(summary.backoffWorthyFailures).toBe(0);
   });
 
+  it('emits a stop-policy terminal for the untouched shared-memory tail', async () => {
+    const admissions: string[] = [];
+    const contextGraphIds = ['stop', 'tail'];
+    const stopResult = {
+      insertedTriples: 0,
+      fetchedMetaTriples: 0,
+      fetchedDataTriples: 0,
+      insertedMetaTriples: 0,
+      insertedDataTriples: 0,
+      bytesReceived: 0,
+      resumedPhases: 0,
+      timedOutPhases: 0,
+      completedPhases: 0,
+      checkpointAdvances: 0,
+      emptyResponses: 0,
+      droppedDataTriples: 0,
+      failedPeers: 1,
+      failedPhases: 1,
+      deniedPhases: 0,
+      backoffWorthyFailures: 1,
+      deferredBackpressure: 0,
+    };
+    const agent = {
+      config: { syncContextGraphPriorities: {} },
+      store: {},
+      listSubGraphs: async () => [],
+      createContextGraphSyncDeadline: () => Date.now() + 1_000,
+      runContextGraphSyncWithBackpressure: async (
+        _ctx: unknown,
+        contextGraphId: string,
+        _lane: string,
+        _label: string,
+        work: () => Promise<unknown>,
+      ) => {
+        admissions.push(contextGraphId);
+        if (contextGraphId === 'stop') return stopResult;
+        return work();
+      },
+      syncCheckpoints: new Map(),
+      workspaceOwnedEntities: new Map(),
+      log: { info: noop, warn: noop, debug: noop },
+    };
+
+    const result = await (
+      LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailed as any
+    ).call(agent, 'peer', contextGraphIds, {
+      stopOnBackoffWorthyFailure: true,
+      sharedMemorySyncPlan: {
+        publicContextGraphIds: contextGraphIds,
+        privateRecoverFromCurator: [],
+        eligibleContextGraphIds: contextGraphIds,
+      },
+    });
+
+    expect(admissions).toEqual(['stop']);
+    expect(result.contextGraphTerminals).toEqual([
+      {
+        contextGraphId: 'stop',
+        lane: 'shared_memory',
+        disposition: 'settled',
+        result: stopResult,
+      },
+      {
+        contextGraphId: 'tail',
+        lane: 'shared_memory',
+        disposition: 'skipped',
+        reason: 'stop-policy',
+      },
+    ]);
+    expect(Object.isFrozen(result.contextGraphTerminals)).toBe(true);
+    expect(result.contextGraphTerminals.every(Object.isFrozen)).toBe(true);
+  });
+
   it('counts several failed Context Graphs from one remote as one failed peer', async () => {
     const contextGraphIds = ['private-a', 'private-b'];
     const agent = {
@@ -431,6 +504,20 @@ describe('requester per-CG priority admission', () => {
 
     expect(summary.failedPeers).toBe(1);
     expect(summary.backoffWorthyFailures).toBe(2);
+    expect(summary.contextGraphTerminals).toHaveLength(2);
+    for (const [index, terminal] of summary.contextGraphTerminals.entries()) {
+      expect(terminal).toMatchObject({
+        contextGraphId: contextGraphIds[index],
+        lane: 'swm_recovery',
+        disposition: 'settled',
+        result: {
+          failedPeers: 1,
+          backoffWorthyFailures: 1,
+        },
+      });
+      expect(Object.isFrozen(terminal)).toBe(true);
+      expect(Object.isFrozen(terminal.result)).toBe(true);
+    }
   });
 
   it('runs a mixed durable list in the supplied stable priority order', async () => {

--- a/packages/agent/test/sync-requester-priority.test.ts
+++ b/packages/agent/test/sync-requester-priority.test.ts
@@ -6,7 +6,10 @@ import {
 } from '../src/sync/requester/durable-sync.js';
 import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
 import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
-import { runOrderedContextGraphSyncs } from '../src/sync/requester/ordered-sync.js';
+import {
+  runOrderedContextGraphSyncs,
+  runOrderedContextGraphSyncsWithOutcomes,
+} from '../src/sync/requester/ordered-sync.js';
 import {
   resolveSyncGlobalBackpressure,
   SyncBackpressureBusyError,
@@ -103,6 +106,49 @@ function lifecycleAgent(
 }
 
 describe('requester per-CG priority admission', () => {
+  it('returns an immutable terminal outcome for every planned ordered item', async () => {
+    const execution = await runOrderedContextGraphSyncsWithOutcomes({
+      work: ['settled', 'deferred', 'tail'].map((contextGraphId) => ({
+        contextGraphId,
+        lane: 'shared_memory' as const,
+        operationId: contextGraphId,
+        run: async () => 1,
+      })),
+      emptyResult: () => 0,
+      runWithAdmission: async (item, work) => {
+        if (item.contextGraphId === 'deferred') {
+          throw new SyncBackpressureBusyError('queue full');
+        }
+        return work();
+      },
+      merge: (summary, part) => summary + part,
+      markDeferred: (summary) => summary,
+    });
+
+    expect(execution.summary).toBe(1);
+    expect(execution.outcomes).toEqual([
+      {
+        contextGraphId: 'settled',
+        lane: 'shared_memory',
+        disposition: 'settled',
+        result: 1,
+      },
+      {
+        contextGraphId: 'deferred',
+        lane: 'shared_memory',
+        disposition: 'deferred',
+      },
+      {
+        contextGraphId: 'tail',
+        lane: 'shared_memory',
+        disposition: 'skipped',
+        reason: 'prior-deferral',
+      },
+    ]);
+    expect(Object.isFrozen(execution.outcomes)).toBe(true);
+    expect(execution.outcomes.every(Object.isFrozen)).toBe(true);
+  });
+
   it('wires configured priority order through the durable lifecycle admission boundary', async () => {
     const admissions: string[] = [];
     const agent = lifecycleAgent(

--- a/packages/agent/test/sync-requester-priority.test.ts
+++ b/packages/agent/test/sync-requester-priority.test.ts
@@ -149,6 +149,83 @@ describe('requester per-CG priority admission', () => {
     expect(execution.outcomes.every(Object.isFrozen)).toBe(true);
   });
 
+  it('records stop-policy outcomes for every item after the terminating result', async () => {
+    const executed: string[] = [];
+    const execution = await runOrderedContextGraphSyncsWithOutcomes({
+      work: ['first', 'stop', 'tail'].map((contextGraphId) => ({
+        contextGraphId,
+        lane: 'shared_memory' as const,
+        operationId: contextGraphId,
+        run: async () => {
+          executed.push(contextGraphId);
+          return contextGraphId;
+        },
+      })),
+      emptyResult: () => [] as string[],
+      runWithAdmission: async (_item, work) => work(),
+      merge: (summary, part) => [...summary, part],
+      markDeferred: (summary) => summary,
+      shouldStop: (part) => part === 'stop',
+    });
+
+    expect(executed).toEqual(['first', 'stop']);
+    expect(execution.summary).toEqual(['first', 'stop']);
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({ contextGraphId: 'first', disposition: 'settled' }),
+      expect.objectContaining({ contextGraphId: 'stop', disposition: 'settled' }),
+      {
+        contextGraphId: 'tail',
+        lane: 'shared_memory',
+        disposition: 'skipped',
+        reason: 'stop-policy',
+      },
+    ]);
+    expect(Object.isFrozen(execution.outcomes)).toBe(true);
+    expect(execution.outcomes.every(Object.isFrozen)).toBe(true);
+  });
+
+  it('records continuation-stopped outcomes for the entire remaining tail', async () => {
+    let shouldContinue = true;
+    const executed: string[] = [];
+    const execution = await runOrderedContextGraphSyncsWithOutcomes({
+      work: ['first', 'second', 'third'].map((contextGraphId) => ({
+        contextGraphId,
+        lane: 'shared_memory' as const,
+        operationId: contextGraphId,
+        run: async () => {
+          executed.push(contextGraphId);
+          shouldContinue = false;
+          return contextGraphId;
+        },
+      })),
+      emptyResult: () => [] as string[],
+      runWithAdmission: async (_item, work) => work(),
+      merge: (summary, part) => [...summary, part],
+      markDeferred: (summary) => summary,
+      shouldContinue: () => shouldContinue,
+    });
+
+    expect(executed).toEqual(['first']);
+    expect(execution.summary).toEqual(['first']);
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({ contextGraphId: 'first', disposition: 'settled' }),
+      {
+        contextGraphId: 'second',
+        lane: 'shared_memory',
+        disposition: 'skipped',
+        reason: 'continuation-stopped',
+      },
+      {
+        contextGraphId: 'third',
+        lane: 'shared_memory',
+        disposition: 'skipped',
+        reason: 'continuation-stopped',
+      },
+    ]);
+    expect(Object.isFrozen(execution.outcomes)).toBe(true);
+    expect(execution.outcomes.every(Object.isFrozen)).toBe(true);
+  });
+
   it('wires configured priority order through the durable lifecycle admission boundary', async () => {
     const admissions: string[] = [];
     const agent = lifecycleAgent(

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -78,6 +78,8 @@ export default defineConfig({
       "test/sync-responder-metrics.test.ts",
       "test/sync-fetch-coalescing.test.ts",
       "test/sync-fetch-coalescing-durable.test.ts",
+      "test/sync-coverage-evidence-journal.test.ts",
+      "test/sync-coverage-evidence-runtime.test.ts",
       "test/sync-backpressure.test.ts",
       "test/sync-policy.test.ts",
       "test/catchup-policy.test.ts",

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -312,6 +312,7 @@ import {
 import type { MemoryGraphChangedEvent, NotificationSseEvent, RequestContext } from './routes/context.js';
 import { handleStatusRoutes } from './routes/status.js';
 import { handleBackpressureRoutes } from './routes/backpressure.js';
+import { handleSyncCoverageEvidenceRoutes } from './routes/sync-coverage-evidence.js';
 import { handleAgentChatRoutes } from './routes/agent-chat.js';
 import { handleOpenclawRoutes } from './routes/openclaw.js';
 import { handleHermesRoutes } from './routes/hermes.js';
@@ -362,6 +363,9 @@ export async function handleRequest(input: HandleRequestInput): Promise<void> {
   if (res.writableEnded) return;
 
   await handleBackpressureRoutes(ctx);
+  if (res.writableEnded) return;
+
+  await handleSyncCoverageEvidenceRoutes(ctx);
   if (res.writableEnded) return;
 
   await handleAgentChatRoutes(ctx);

--- a/packages/cli/src/daemon/routes/backpressure.ts
+++ b/packages/cli/src/daemon/routes/backpressure.ts
@@ -1,6 +1,7 @@
 import { backpressureRegistry } from '@origintrail-official/dkg-core';
 import { jsonResponse } from '../http-utils.js';
 import type { RequestContext } from './context.js';
+import { isNodeAdminCaller } from './node-admin-auth.js';
 
 /**
  * Node-admin diagnostics for every registered scheduler/backlog source.
@@ -13,24 +14,12 @@ export async function handleBackpressureRoutes(ctx: RequestContext): Promise<voi
   const {
     req,
     res,
-    agent,
-    config,
-    validTokens,
     path,
-    requestToken,
   } = ctx;
 
   if (req.method !== 'GET' || path !== '/api/diagnostics/backpressure') return;
 
-  const authEnabled = config.auth?.enabled !== false;
-  const isNodeAdminCaller =
-    !authEnabled
-    || (
-      !!requestToken
-      && validTokens.has(requestToken)
-      && !agent.resolveAgentByToken(requestToken)
-    );
-  if (!isNodeAdminCaller) {
+  if (!isNodeAdminCaller(ctx)) {
     return jsonResponse(res, 403, {
       error:
         'GET /api/diagnostics/backpressure requires a node-level admin token '

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1901,6 +1901,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
             subscribed: s?.subscribed === true,
             synced: s?.synced === true,
             coreHosted: s?.coreHosted === true,
+            syncMode: s?.syncMode ?? 'always-on',
           }))
       : [];
     return jsonResponse(res, 200, {

--- a/packages/cli/src/daemon/routes/node-admin-auth.ts
+++ b/packages/cli/src/daemon/routes/node-admin-auth.ts
@@ -1,0 +1,23 @@
+import type { RequestContext } from './context.js';
+
+type NodeAdminAuthContext = Pick<
+  RequestContext,
+  'agent' | 'config' | 'requestToken' | 'validTokens'
+>;
+
+/**
+ * Exact daemon node-admin boundary for node-wide diagnostics.
+ *
+ * Auth-disabled daemons retain their trusted-local behavior. With auth
+ * enabled, the caller must present a recognized token that is not bound to an
+ * agent identity; missing, unknown, and agent-scoped tokens all fail closed.
+ */
+export function isNodeAdminCaller(ctx: NodeAdminAuthContext): boolean {
+  if (ctx.config.auth?.enabled === false) return true;
+  const { requestToken } = ctx;
+  return Boolean(
+    requestToken
+    && ctx.validTokens.has(requestToken)
+    && !ctx.agent.resolveAgentByToken(requestToken),
+  );
+}

--- a/packages/cli/src/daemon/routes/sync-coverage-evidence.ts
+++ b/packages/cli/src/daemon/routes/sync-coverage-evidence.ts
@@ -1,0 +1,48 @@
+import { jsonResponse } from '../http-utils.js';
+import type { RequestContext } from './context.js';
+
+function parseAfterSequence(value: string | null): number | null {
+  if (value === null || value === '') return 0;
+  if (!/^(0|[1-9]\d*)$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+/** Bounded node-admin evidence for actual Edge/Core automatic sync work. */
+export async function handleSyncCoverageEvidenceRoutes(ctx: RequestContext): Promise<void> {
+  const {
+    req,
+    res,
+    agent,
+    config,
+    validTokens,
+    path,
+    requestToken,
+    url,
+  } = ctx;
+
+  if (req.method !== 'GET' || path !== '/api/diagnostics/sync-coverage-evidence') return;
+
+  const authEnabled = config.auth?.enabled !== false;
+  const isNodeAdminCaller = !authEnabled || (
+    !!requestToken
+    && validTokens.has(requestToken)
+    && !agent.resolveAgentByToken(requestToken)
+  );
+  if (!isNodeAdminCaller) {
+    return jsonResponse(res, 403, {
+      error:
+        'GET /api/diagnostics/sync-coverage-evidence requires a node-level admin token '
+        + '(~/.dkg/auth.token); agent-scoped tokens cannot inspect node-wide sync work.',
+    });
+  }
+
+  const afterSequence = parseAfterSequence(url.searchParams.get('afterSequence'));
+  if (afterSequence === null) {
+    return jsonResponse(res, 400, {
+      error: 'afterSequence must be a non-negative safe integer',
+    });
+  }
+
+  return jsonResponse(res, 200, agent.getSyncCoverageEvidence(afterSequence));
+}

--- a/packages/cli/src/daemon/routes/sync-coverage-evidence.ts
+++ b/packages/cli/src/daemon/routes/sync-coverage-evidence.ts
@@ -1,5 +1,6 @@
 import { jsonResponse } from '../http-utils.js';
 import type { RequestContext } from './context.js';
+import { isNodeAdminCaller } from './node-admin-auth.js';
 
 function parseAfterSequence(value: string | null): number | null {
   if (value === null || value === '') return 0;
@@ -14,22 +15,13 @@ export async function handleSyncCoverageEvidenceRoutes(ctx: RequestContext): Pro
     req,
     res,
     agent,
-    config,
-    validTokens,
     path,
-    requestToken,
     url,
   } = ctx;
 
   if (req.method !== 'GET' || path !== '/api/diagnostics/sync-coverage-evidence') return;
 
-  const authEnabled = config.auth?.enabled !== false;
-  const isNodeAdminCaller = !authEnabled || (
-    !!requestToken
-    && validTokens.has(requestToken)
-    && !agent.resolveAgentByToken(requestToken)
-  );
-  if (!isNodeAdminCaller) {
+  if (!isNodeAdminCaller(ctx)) {
     return jsonResponse(res, 403, {
       error:
         'GET /api/diagnostics/sync-coverage-evidence requires a node-level admin token '

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -25,7 +25,7 @@ describe('context graph subscription diagnostics route', () => {
   beforeEach(async () => {
     rehydrationStatus = rehydration;
     subscriptions = new Map<string, any>([
-      ['cg-000', { subscribed: true, synced: true, coreHosted: false }],
+      ['cg-000', { subscribed: true, synced: true, coreHosted: false, syncMode: 'on-demand' }],
       ['cg-hosted', { subscribed: true, synced: false, coreHosted: true }],
       ['cg-host-only', { subscribed: false, synced: false, coreHosted: true }],
       ['cg-discoverable', { subscribed: false, synced: false, coreHosted: false }],
@@ -126,8 +126,8 @@ describe('context graph subscription diagnostics route', () => {
     expect(response.status).toBe(200);
     expect(body.count).toBe(2);
     expect(body.subscriptions).toEqual([
-      { contextGraphId: 'cg-000', subscribed: true, synced: true, coreHosted: false },
-      { contextGraphId: 'cg-hosted', subscribed: true, synced: false, coreHosted: true },
+      { contextGraphId: 'cg-000', subscribed: true, synced: true, coreHosted: false, syncMode: 'on-demand' },
+      { contextGraphId: 'cg-hosted', subscribed: true, synced: false, coreHosted: true, syncMode: 'always-on' },
     ]);
     expect(body.rehydration).toEqual(rehydration);
   });
@@ -158,7 +158,7 @@ describe('context graph subscription diagnostics route', () => {
     expect(response.status).toBe(200);
     expect(body.count).toBe(1);
     expect(body.subscriptions).toEqual([
-      { contextGraphId: 'cg-hosted', subscribed: true, synced: false, coreHosted: true },
+      { contextGraphId: 'cg-hosted', subscribed: true, synced: false, coreHosted: true, syncMode: 'always-on' },
     ]);
     expect(body.rehydration).toEqual({
       ...rehydration,

--- a/packages/cli/test/sync-coverage-evidence-route.test.ts
+++ b/packages/cli/test/sync-coverage-evidence-route.test.ts
@@ -89,4 +89,15 @@ describe('sync coverage evidence diagnostics route', () => {
     expect(malformed.status).toBe(400);
     expect(getSyncCoverageEvidence).not.toHaveBeenCalled();
   });
+
+  it('rejects missing and unknown credentials without reading node evidence', async () => {
+    const missing = await fetch(`${baseUrl}/api/diagnostics/sync-coverage-evidence`);
+    expect(missing.status).toBe(403);
+
+    const unknown = await fetch(`${baseUrl}/api/diagnostics/sync-coverage-evidence`, {
+      headers: { authorization: 'Bearer unknown-token' },
+    });
+    expect(unknown.status).toBe(403);
+    expect(getSyncCoverageEvidence).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/test/sync-coverage-evidence-route.test.ts
+++ b/packages/cli/test/sync-coverage-evidence-route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createServer, type Server } from 'node:http';
+import { handleRequest } from '../src/daemon/handle-request.js';
 import { handleSyncCoverageEvidenceRoutes } from '../src/daemon/routes/sync-coverage-evidence.js';
 
 describe('sync coverage evidence diagnostics route', () => {
@@ -75,6 +76,55 @@ describe('sync coverage evidence diagnostics route', () => {
       entries: [{ sequence: 7, afterSequence: 6 }],
     });
     expect(getSyncCoverageEvidence).toHaveBeenCalledWith(6);
+  });
+
+  it('is reachable through the top-level daemon dispatcher only for node admins', async () => {
+    getSyncCoverageEvidence.mockClear();
+    const dispatcherAgent = {
+      getSyncCoverageEvidence,
+      resolveAgentAddress: () => undefined,
+      resolveAgentByToken: (token?: string) => token === 'agent-token'
+        ? '0x1111111111111111111111111111111111111111'
+        : undefined,
+    };
+    const dispatcher = createServer(async (req, res) => {
+      await handleRequest({
+        req,
+        res,
+        agent: dispatcherAgent,
+        config: { auth: { enabled: true } },
+        validTokens: new Set(['admin-token', 'agent-token']),
+      } as any);
+    });
+    await new Promise<void>((resolve) => {
+      dispatcher.listen(0, '127.0.0.1', resolve);
+    });
+
+    try {
+      const address = dispatcher.address();
+      expect(typeof address).toBe('object');
+      const dispatcherBaseUrl = `http://127.0.0.1:${(address as { port: number }).port}`;
+      const accepted = await fetch(
+        `${dispatcherBaseUrl}/api/diagnostics/sync-coverage-evidence?afterSequence=6`,
+        { headers: { authorization: 'Bearer admin-token' } },
+      );
+      expect(accepted.status).toBe(200);
+      expect(await accepted.json()).toMatchObject({
+        waveId: 'wave-1',
+        entries: [{ sequence: 7, afterSequence: 6 }],
+      });
+
+      const denied = await fetch(
+        `${dispatcherBaseUrl}/api/diagnostics/sync-coverage-evidence`,
+        { headers: { authorization: 'Bearer agent-token' } },
+      );
+      expect(denied.status).toBe(403);
+      expect(getSyncCoverageEvidence).toHaveBeenCalledTimes(1);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        dispatcher.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it('rejects agent-scoped access and malformed cursors', async () => {

--- a/packages/cli/test/sync-coverage-evidence-route.test.ts
+++ b/packages/cli/test/sync-coverage-evidence-route.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { handleSyncCoverageEvidenceRoutes } from '../src/daemon/routes/sync-coverage-evidence.js';
+
+describe('sync coverage evidence diagnostics route', () => {
+  let server: Server | undefined;
+  let baseUrl = '';
+  const getSyncCoverageEvidence = vi.fn((afterSequence: number) => ({
+    schemaVersion: 1,
+    processStartedAt: 100,
+    waveId: 'wave-1',
+    capacity: 256,
+    nextSequence: 8,
+    droppedBeforeSequence: 0,
+    entries: [{ sequence: 7, afterSequence }],
+  }));
+
+  beforeEach(async () => {
+    getSyncCoverageEvidence.mockClear();
+    const agent = {
+      getSyncCoverageEvidence,
+      resolveAgentByToken: (token?: string) => token === 'agent-token'
+        ? '0x1111111111111111111111111111111111111111'
+        : undefined,
+    };
+    const validTokens = new Set(['admin-token', 'agent-token']);
+
+    server = createServer(async (req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      const auth = req.headers.authorization;
+      const requestToken = typeof auth === 'string'
+        ? auth.replace(/^Bearer\s+/i, '')
+        : undefined;
+      await handleSyncCoverageEvidenceRoutes({
+        req,
+        res,
+        agent,
+        config: { auth: { enabled: true } },
+        validTokens,
+        url,
+        path: url.pathname,
+        requestToken,
+      } as any);
+      if (!res.writableEnded) {
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+      }
+    });
+    await new Promise<void>((resolve) => {
+      server!.listen(0, '127.0.0.1', () => {
+        const address = server!.address();
+        if (typeof address === 'object' && address) {
+          baseUrl = `http://127.0.0.1:${address.port}`;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    if (!server) return;
+    await new Promise<void>((resolve, reject) => {
+      server!.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it('returns bounded journal entries after the requested cursor to node admins', async () => {
+    const response = await fetch(`${baseUrl}/api/diagnostics/sync-coverage-evidence?afterSequence=6`, {
+      headers: { authorization: 'Bearer admin-token' },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      schemaVersion: 1,
+      waveId: 'wave-1',
+      entries: [{ sequence: 7, afterSequence: 6 }],
+    });
+    expect(getSyncCoverageEvidence).toHaveBeenCalledWith(6);
+  });
+
+  it('rejects agent-scoped access and malformed cursors', async () => {
+    const denied = await fetch(`${baseUrl}/api/diagnostics/sync-coverage-evidence`, {
+      headers: { authorization: 'Bearer agent-token' },
+    });
+    expect(denied.status).toBe(403);
+
+    const malformed = await fetch(`${baseUrl}/api/diagnostics/sync-coverage-evidence?afterSequence=-1`, {
+      headers: { authorization: 'Bearer admin-token' },
+    });
+    expect(malformed.status).toBe(400);
+    expect(getSyncCoverageEvidence).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -162,6 +162,7 @@ export default defineConfig({
           'test/daemon-hermes.test.ts',
           'test/chain-discovery-scan-mode.test.ts',
           'test/context-graph-subscriptions-route.test.ts',
+          'test/sync-coverage-evidence-route.test.ts',
           'test/context-graph-subscription-store.test.ts',
           // Daemon call-site wiring guard: runDaemonInner passes the resolved
           // syncAgentsMeta into DKGAgent.create. Fully mocked (network/agent/


### PR DESCRIPTION
## M1 stack

This is **PR 6 of 7** in the RFC-64 M1 stack. It is stacked on exact adaptive-capacity head `6992dd36ec23bf298e039ad5fd7a9b517b7a855d` and supplies the runtime evidence contract consumed by PR 7. The validated review head is `f123856165e168f7d15664d7e07d26badcf9ad81`.

## Summary

This PR adds bounded, node-admin-only evidence for automatic RFC-64 synchronization work.

It records immutable `running` and terminal `complete` or `failed` entries for:

- Core automatic public-CG rounds: the explicit-selection snapshot used for evidence, the frozen automatic tail, configured/effective batch sizes, planning lane, one real round job ID, and per-CG completions;
- Edge periodic reconciler work for startup-rehydrated `always-on` selections;
- observed metadata, durable, and shared-memory completion signals.

Operators can poll:

```text
GET /api/diagnostics/sync-coverage-evidence?afterSequence=N
```

The endpoint requires the node-admin token. Agent-scoped tokens cannot inspect node-wide synchronization work. The exact authorization predicate is shared with the existing node-wide backpressure diagnostics route, while each route retains its own 403 response.

This is observability only. It does not change CG selection, scheduler priority, admission, retry, persistence, single-flight, or sync completion decisions.

## User and operator impact

Before this PR, aggregate status and final store state could not prove which CGs a Core scheduler actually admitted, whether work was automatic or explicit, or whether an Edge refresh came from its post-restart `always-on` reconciler.

After this PR, operators and the release harness can bind exact observations to actual automatic runtime work. The journal is not itself a convergence verdict: PR 7 independently verifies exact VM/SWM heads, inventories, assets, and triples.

Edge behavior is unchanged:

- `on-demand` CGs move only after explicit requests;
- `always-on` CGs reconcile automatically;
- unselected CGs are not activated.

## Bounds and fail-closed behavior

- 256 retained entries;
- at most 32 CG identifiers per entry;
- at most 256 characters per identifier;
- actual Node process start from `performance.timeOrigin` plus a distinct wave ID;
- `nextSequence` and `droppedBeforeSequence` expose overwritten evidence.

Evidence fails closed when IDs are truncated, metadata/durable/SWM is incomplete, SWM reports failure/timeout/denial/backpressure/dropped triples, or the overall operation does not cleanly terminate.

The aggregate compatibility result carries no terminal field, while the production detailed SWM boundary requires the canonical per-CG terminal list. A legacy JavaScript override returning only the aggregate result, malformed terminal entries, or throwing terminal getters leaves automatic evidence unverifiable and failed closed without changing successful sync accounting or retry behavior.

The negative runtime coverage explicitly proves:

- a non-throwing durable result with `complete: false` records progress but cannot produce a successful evidence terminal;
- an empty metadata confirmation set fails only the metadata plane;
- a partial metadata confirmation set completes only the confirmed CG and fails the unconfirmed CG;
- a legacy metadata observer returning `void`, a non-iterable, or a hostile iterable cannot abort synchronization and leaves the metadata plane unverified;
- stop-policy and continuation-stopped SWM terminals leave the affected CG evidence unverified;
- an already-syncing automatic admission no-op creates no synthetic journal row;
- public stop-policy and private `swm_recovery` detailed terminals retain their exact lane and disposition, and their frozen results cannot be mutated by callers.

Every Core per-CG completion carries the scheduler round's actual job ID, preventing detached or synthetic completion claims.

## Before

```mermaid
sequenceDiagram
    participant T as Internal sync trigger
    participant A as DKGAgent
    participant P as Existing planner
    participant S as Existing sync runtime
    participant D as Triple store
    participant O as Node operator

    T->>A: Connection or reconciler event
    A->>P: Plan synchronization work
    P-->>A: Selected and automatic CGs
    A->>S: Execute existing work
    S->>D: Persist verified results
    S-->>A: Aggregate result
    O->>A: Read aggregate status
    Note over O,A: No immutable per-round provenance
```

## After

```mermaid
sequenceDiagram
    participant T as Internal sync trigger
    participant A as DKGAgent
    participant P as Existing planner
    participant J as Bounded evidence journal
    participant S as Existing sync runtime
    participant D as Triple store
    participant O as Node operator

    T->>A: Explicit module-private automatic command
    A->>P: Plan automatic round
    P-->>A: Evidence snapshot and frozen automatic tail
    A->>J: Start journal-owned running entry
    A->>S: Execute or join existing single-flight
    Note over A,S: Explicit selections remain live during later phases
    S->>D: Persist verified results once
    S-->>A: Aggregate plus mandatory per-CG SWM terminals
    A->>J: Finish through opaque journal handle
    O->>A: GET evidence after sequence N
    A->>J: Read bounded snapshot
    J-->>A: Entries and overwrite boundary
    A-->>O: Node-admin evidence
    Note over A,S: Every joiner receives the same canonical terminals
```

## Compatibility and risk

- The existing `syncSharedMemoryFromPeerDetailed(peer, ids, options)` call shape is unchanged.
- The broad aggregate `SharedMemorySyncResult` remains aggregate-only for structural compatibility. The production detailed method returns `SharedMemorySyncDetailedResult` with mandatory terminals, and one detailed-boundary translator maps canonical scheduler executions to those terminals.
- Exact settled, deferred, skipped, disabled, and ineligible outcomes are frozen before single-flight fanout, so a reconciler joining a manual call receives the same evidence without duplicate fetching.
- Runtime terminal and metadata-observer normalization is isolated inside the evidence recorder; malformed host values cannot escape into sync control flow.
- Untriggered compatibility paths retain the exact established three-argument call shape. Connection-open, peer-update, and periodic automatic paths alone pass the module-private branded fourth token.
- Planning and evidence transitions are explicit: plan the round, start the recorder once, run sync, then finish. Wrong-finisher calls fail before consuming the live journal entry.
- Evidence bookkeeping lives in a focused recorder; UUID creation, canonical running state, transitions, and wire rows live in the journal behind opaque frozen handles.
- Only stable evidence schema, entry, and snapshot types remain in the package root; journal construction, capacity constants, and bounding helpers stay internal.
- Metadata evidence reuses the existing confirmed set without duplicate store reads.
- Edge startup provenance is owned by canonical rehydration state and intersects with current selected, subscribed, explicit, `always-on` state.
- `/api/context-graph/subscriptions` gains additive effective `syncMode`.
- The journal is intentionally process-local; consumers bind evidence to process start and wave IDs.
- The shared `isNodeAdminCaller` helper preserves auth-disabled behavior and fails closed for missing, unknown, and agent-scoped tokens when authentication is enabled.

## Validation

- Exact base: `6992dd36ec23bf298e039ad5fd7a9b517b7a855d`.
- Exact validated head: `f123856165e168f7d15664d7e07d26badcf9ad81`.
- Full review-focused Agent lane: **7 files / 149 tests passed**.
- Evidence runtime plus journal subset: **2 files / 26 tests passed** (`19 + 7`).
- Focused observer and scheduler terminal lane: **3 files / 38 tests passed**.
- CLI evidence plus backpressure authorization: **2 files / 7 tests passed** (`4 + 3`).
- Agent build passed: TypeScript, public type-contract tests, and package-root validation.
- CLI build passed: dependency prebuild, TypeScript, public CLI type-contract tests, and runtime-asset assembly.
- Full CLI dependency closure: **17 workspace packages built successfully**, including the EVM no-op compile check, Agent build, and CLI build.
- Full diff: **21 files, +2,581/-104**; no generated or untracked artifacts.
- Rebase range-diff: **14/14 commits patch-equivalent**. The 13 previously published commits moved unchanged onto the corrected parent, and the held hidden-review fix remains the distinct 14th commit.
- `git diff --check`: pass.
- Live GitHub checks and review state remain the merge-readiness source of truth.

## Review focus

1. Evidence is bounded, authorized, truthful, and overwrite-detectable.
2. Every single-flight joiner receives exact immutable per-CG outcomes.
3. Automatic provenance remains explicit and module-private inside the trusted process; the node-admin endpoint remains the external authorization boundary.
4. Journal shapes match the downstream fail-closed verifier contract.
