### PR TITLE
test(rfc64): bind M1 process identity across hosts

### DIFF
--- a/devnet/rfc64-m1-selective-coverage/README.md
+++ b/devnet/rfc64-m1-selective-coverage/README.md
@@ -100,7 +100,7 @@ Commands are:
 
 | Command | Required runtime action/evidence |
 | --- | --- |
-| `start` | Start the named role; independently return PID, process instance/wave IDs, `processStartedAt` as integer epoch milliseconds sourced from `Math.floor(performance.timeOrigin)`, durable-directory identity, peer ID, network, commit, and loaded-runtime digest. The command contains only the role, never the trust anchor. |
+| `start` | Start the named role; independently return host identity, PID, process instance/wave IDs, `processStartedAt` as integer epoch milliseconds sourced from `Math.floor(performance.timeOrigin)`, durable-directory identity, peer ID, network, commit, and loaded-runtime digest. OS-process uniqueness is evaluated as `(hostIdentity, pid)`, so valid processes on different hosts may reuse a numeric PID. The command contains only the role, never the trust anchor. |
 | `publish-wave` | Publish the named anchored wave; return exact Publisher VM/SWM observations for every graph. |
 | `observe-edge` | Return exact Edge VM/SWM observations, effective runtime mode, and the actual producing job ID. |
 | `synchronize-edge` | Issue only the named explicit user selection; return its real job ID and terminal exact snapshot. |

--- a/devnet/rfc64-m1-selective-coverage/process-runtime-fixture.mjs
+++ b/devnet/rfc64-m1-selective-coverage/process-runtime-fixture.mjs
@@ -2,7 +2,7 @@ import { createInterface } from 'node:readline';
 
 const commandSchema = 'dkg-rfc64-m1-selective-coverage-runtime-command-v1';
 const resultSchema = 'dkg-rfc64-m1-selective-coverage-runtime-result-v1';
-const protocol = 'dkg-rfc64-m1-selective-coverage-runtime-v1';
+const protocol = 'dkg-rfc64-m1-selective-coverage-runtime-v2';
 const prefix = 'DKG_RFC64_M1_RESULT ';
 const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
 

--- a/devnet/rfc64-m1-selective-coverage/process-runtime-fixture.mjs
+++ b/devnet/rfc64-m1-selective-coverage/process-runtime-fixture.mjs
@@ -16,6 +16,7 @@ lines.on('line', (line) => {
     value = {
       protocol,
       role,
+      hostIdentity: 'fixture-host',
       pid: process.pid,
       peerId: `${role}-peer`,
       networkId: process.env.FIXTURE_NETWORK_ID,

--- a/devnet/rfc64-m1-selective-coverage/process-runtime.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/process-runtime.test.ts
@@ -54,6 +54,7 @@ test('exchanges sequence-bound JSON without sending the trust anchor to the adap
     const ready = await runtime.start('publisher');
     assert.equal(ready.protocol, SELECTIVE_COVERAGE_RUNTIME_PROTOCOL);
     assert.equal(ready.role, 'publisher');
+    assert.equal(ready.hostIdentity, 'fixture-host');
     assert.equal(ready.peerId, 'publisher-peer');
     assert.ok(ready.pid > 0);
     await runtime.stop('publisher');

--- a/devnet/rfc64-m1-selective-coverage/runtime-wire.ts
+++ b/devnet/rfc64-m1-selective-coverage/runtime-wire.ts
@@ -50,6 +50,7 @@ type OptionalPropertyKeys<T> = {
 const RUNTIME_READY_KEYS = defineRecordKeys<SelectiveCoverageRuntimeReadyV1>()(
   'protocol',
   'role',
+  'hostIdentity',
   'pid',
   'peerId',
   'networkId',
@@ -65,6 +66,7 @@ const EDGE_RESTART_RECEIPT_KEYS = defineRecordKeys<SelectiveCoverageEdgeRestartR
   'current',
 );
 const EDGE_RESTART_PREVIOUS_KEYS = defineRecordKeys<EdgeRestartPreviousV1>()(
+  'hostIdentity',
   'pid',
   'processInstanceId',
   'exitedAt',
@@ -89,6 +91,7 @@ export function decodeRuntimeReady(input: unknown): SelectiveCoverageRuntimeRead
   return {
     protocol: SELECTIVE_COVERAGE_RUNTIME_PROTOCOL,
     role,
+    hostIdentity: text(row.hostIdentity, 'hostIdentity'),
     pid: row.pid as number,
     peerId: text(row.peerId, 'peerId'),
     networkId: text(row.networkId, 'networkId'),
@@ -109,6 +112,7 @@ export function decodeRestartReceipt(input: unknown): SelectiveCoverageEdgeResta
   }
   return {
     previous: {
+      hostIdentity: text(previous.hostIdentity, 'hostIdentity'),
       pid: previous.pid as number,
       processInstanceId: text(previous.processInstanceId, 'processInstanceId'),
       exitedAt: previous.exitedAt as number,

--- a/devnet/rfc64-m1-selective-coverage/runtime.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/runtime.test.ts
@@ -162,6 +162,7 @@ class ScriptedRuntime implements SelectiveCoverageRuntimeV1 {
     const ready: SelectiveCoverageRuntimeReadyV1 = {
       protocol: SELECTIVE_COVERAGE_RUNTIME_PROTOCOL,
       role,
+      hostIdentity: role === 'core' ? 'core-host' : 'local-host',
       pid,
       peerId,
       networkId: expected.networkId,
@@ -259,6 +260,7 @@ class ScriptedRuntime implements SelectiveCoverageRuntimeV1 {
     const ready: SelectiveCoverageRuntimeReadyV1 = {
       protocol: SELECTIVE_COVERAGE_RUNTIME_PROTOCOL,
       role: 'edge',
+      hostIdentity: 'local-host',
       pid: 103,
       peerId: expected.edgePeerId,
       networkId: expected.networkId,
@@ -271,6 +273,7 @@ class ScriptedRuntime implements SelectiveCoverageRuntimeV1 {
     };
     const receipt: SelectiveCoverageEdgeRestartReceiptV1 = {
       previous: {
+        hostIdentity: 'local-host',
         pid: 102,
         processInstanceId: 'edge-instance-before',
         exitedAt: 1,
@@ -463,6 +466,38 @@ test('collects the anchored three-process Edge/Core sequence and cleans up', asy
   );
 });
 
+test('allows different hosts to reuse the same numeric PID', async () => {
+  const runtime = new ScriptedRuntime();
+  runtime.readyMutation = (ready) => ready.role === 'core'
+    ? { ...ready, pid: 101 }
+    : ready;
+  await assert.doesNotReject(
+    collectSelectiveCoverageEvidenceV1({ corpus, expectedProvenance: expected, runtime }),
+  );
+});
+
+test('rejects the same host and PID reused by two roles', async () => {
+  const runtime = new ScriptedRuntime();
+  runtime.readyMutation = (ready) => ready.role === 'core'
+    ? { ...ready, hostIdentity: 'local-host', pid: 101 }
+    : ready;
+  await assert.rejects(
+    collectSelectiveCoverageEvidenceV1({ corpus, expectedProvenance: expected, runtime }),
+    /distinct OS process boundaries/,
+  );
+});
+
+test('rejects duplicate process-instance evidence across hosts', async () => {
+  const runtime = new ScriptedRuntime();
+  runtime.readyMutation = (ready) => ready.role === 'core'
+    ? { ...ready, processInstanceId: 'publisher-instance-before' }
+    : ready;
+  await assert.rejects(
+    collectSelectiveCoverageEvidenceV1({ corpus, expectedProvenance: expected, runtime }),
+    /distinct OS process boundaries/,
+  );
+});
+
 test('rejects metadata-only runtime output and does not skip cleanup', async () => {
   const runtime = new ScriptedRuntime();
   runtime.selectedPublisherMutation = (rows) => {
@@ -591,6 +626,17 @@ test('requires restart to cross an OS process boundary', async () => {
   const runtime = new ScriptedRuntime();
   runtime.readyMutation = (ready) => ready.role === 'edge' && ready.pid === 103
     ? { ...ready, pid: 102 }
+    : ready;
+  await assert.rejects(
+    collectSelectiveCoverageEvidenceV1({ corpus, expectedProvenance: expected, runtime }),
+    /does not prove old-process exit/,
+  );
+});
+
+test('requires an Edge restart to stay on the anchored host', async () => {
+  const runtime = new ScriptedRuntime();
+  runtime.readyMutation = (ready) => ready.role === 'edge' && ready.pid === 103
+    ? { ...ready, hostIdentity: 'replacement-host' }
     : ready;
   await assert.rejects(
     collectSelectiveCoverageEvidenceV1({ corpus, expectedProvenance: expected, runtime }),

--- a/devnet/rfc64-m1-selective-coverage/runtime.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/runtime.test.ts
@@ -23,7 +23,7 @@ import {
   type SelectiveCoverageRuntimeV1,
 } from './runtime.ts';
 import { decodeEdgeSyncOperationPayload } from './evidence-codec.ts';
-import { decodeEdgeSyncResult } from './runtime-wire.ts';
+import { decodeEdgeSyncResult, decodeRuntimeReady } from './runtime-wire.ts';
 import type { SyncCoverageJournalReferenceV1 } from './sync-coverage-journal.ts';
 import { runSelectiveCoverageLiveV1 } from './live-runner.ts';
 
@@ -642,6 +642,34 @@ test('requires an Edge restart to stay on the anchored host', async () => {
     collectSelectiveCoverageEvidenceV1({ corpus, expectedProvenance: expected, runtime }),
     /does not prove old-process exit/,
   );
+});
+
+test('requires the restart receipt to identify the previous Edge host', async () => {
+  const runtime = new ScriptedRuntime();
+  runtime.restartReceiptMutation = (receipt) => ({
+    ...receipt,
+    previous: { ...receipt.previous, hostIdentity: 'wrong-previous-host' },
+  });
+  await assert.rejects(
+    collectSelectiveCoverageEvidenceV1({ corpus, expectedProvenance: expected, runtime }),
+    /does not prove old-process exit/,
+  );
+});
+
+test('rejects the pre-host-identity v1 runtime wire shape under protocol v2', () => {
+  assert.throws(() => decodeRuntimeReady({
+    protocol: 'dkg-rfc64-m1-selective-coverage-runtime-v1',
+    role: 'edge',
+    pid: 102,
+    peerId: expected.edgePeerId,
+    networkId: expected.networkId,
+    testedHeadCommit: expected.testedHeadCommit,
+    runtimeManifestDigest: expected.runtimeManifestDigest,
+    processStartedAt: 0,
+    processInstanceId: 'edge-instance-before',
+    dataDirectoryIdentity: 'edge-data',
+    evidenceWaveId: 'edge-wave-before',
+  }), /runtime adapter record/);
 });
 
 test('requires positive proof that the previous Edge process exited', async () => {

--- a/devnet/rfc64-m1-selective-coverage/runtime.ts
+++ b/devnet/rfc64-m1-selective-coverage/runtime.ts
@@ -20,7 +20,7 @@ import {
 } from './sync-coverage-journal.ts';
 
 export const SELECTIVE_COVERAGE_RUNTIME_PROTOCOL =
-  'dkg-rfc64-m1-selective-coverage-runtime-v1' as const;
+  'dkg-rfc64-m1-selective-coverage-runtime-v2' as const;
 
 export type SelectiveCoverageRuntimeRole = 'publisher' | 'edge' | 'core';
 
@@ -52,6 +52,15 @@ export interface SelectiveCoverageEdgeRestartReceiptV1 {
     readonly exitedAt: number;
   };
   readonly current: SelectiveCoverageRuntimeReadyV1;
+}
+
+interface OsProcessIdentity {
+  readonly hostIdentity: string;
+  readonly pid: number;
+}
+
+interface ProcessInstanceIdentity extends OsProcessIdentity {
+  readonly processInstanceId: string;
 }
 
 export interface SelectiveCoverageRuntimeV1 {
@@ -285,15 +294,14 @@ function assertEdgeRestartReceipt(
   receipt: SelectiveCoverageEdgeRestartReceiptV1,
   previous: SelectiveCoverageRuntimeReadyV1,
 ): void {
-  if (receipt.previous.pid !== previous.pid
-    || receipt.previous.hostIdentity !== previous.hostIdentity
-    || receipt.previous.processInstanceId !== previous.processInstanceId
+  if (!sameOsProcess(receipt.previous, previous)
+    || !sameProcessInstance(receipt.previous, previous)
     || !Number.isSafeInteger(receipt.previous.exitedAt)
     || receipt.previous.exitedAt < previous.processStartedAt
     || receipt.current.processStartedAt < receipt.previous.exitedAt
     || receipt.current.hostIdentity !== previous.hostIdentity
-    || receipt.current.pid === previous.pid
-    || receipt.current.processInstanceId === previous.processInstanceId
+    || sameOsProcess(receipt.current, previous)
+    || sameProcessInstance(receipt.current, previous)
     || receipt.current.dataDirectoryIdentity !== previous.dataDirectoryIdentity) {
     throw new Error('Edge restart receipt does not prove old-process exit and durable reuse');
   }
@@ -380,16 +388,30 @@ function assertReady(
 function assertDistinctProcesses(
   processes: readonly SelectiveCoverageRuntimeReadyV1[],
 ): void {
-  const osProcessIdentities = processes.map((entry) => `${entry.hostIdentity}\0${entry.pid}`);
-  if (new Set(osProcessIdentities).size !== processes.length
-    || new Set(processes.map((entry) => entry.processInstanceId)).size !== processes.length) {
-    throw new Error('M1 roles did not cross distinct OS process boundaries');
+  for (let left = 0; left < processes.length; left += 1) {
+    for (let right = left + 1; right < processes.length; right += 1) {
+      if (sameOsProcess(processes[left]!, processes[right]!)
+        || sameProcessInstance(processes[left]!, processes[right]!)) {
+        throw new Error('M1 roles did not cross distinct OS process boundaries');
+      }
+    }
   }
   const peerByRole = new Map<SelectiveCoverageRuntimeRole, string>();
   for (const process of processes) peerByRole.set(process.role, process.peerId);
   if (new Set(peerByRole.values()).size !== peerByRole.size) {
     throw new Error('M1 roles did not use distinct DKG peer identities');
   }
+}
+
+function sameOsProcess(left: OsProcessIdentity, right: OsProcessIdentity): boolean {
+  return left.hostIdentity === right.hostIdentity && left.pid === right.pid;
+}
+
+function sameProcessInstance(
+  left: ProcessInstanceIdentity,
+  right: ProcessInstanceIdentity,
+): boolean {
+  return left.processInstanceId === right.processInstanceId;
 }
 
 function canonicalGraphObservations<T extends GraphObservationV1>(

--- a/devnet/rfc64-m1-selective-coverage/runtime.ts
+++ b/devnet/rfc64-m1-selective-coverage/runtime.ts
@@ -27,6 +27,8 @@ export type SelectiveCoverageRuntimeRole = 'publisher' | 'edge' | 'core';
 export interface SelectiveCoverageRuntimeReadyV1 {
   readonly protocol: typeof SELECTIVE_COVERAGE_RUNTIME_PROTOCOL;
   readonly role: SelectiveCoverageRuntimeRole;
+  /** Stable identity for the OS host that owns this process namespace. */
+  readonly hostIdentity: string;
   readonly pid: number;
   readonly peerId: string;
   readonly networkId: string;
@@ -44,6 +46,7 @@ export interface SelectiveCoverageRuntimeReadyV1 {
 
 export interface SelectiveCoverageEdgeRestartReceiptV1 {
   readonly previous: {
+    readonly hostIdentity: string;
     readonly pid: number;
     readonly processInstanceId: string;
     readonly exitedAt: number;
@@ -283,10 +286,12 @@ function assertEdgeRestartReceipt(
   previous: SelectiveCoverageRuntimeReadyV1,
 ): void {
   if (receipt.previous.pid !== previous.pid
+    || receipt.previous.hostIdentity !== previous.hostIdentity
     || receipt.previous.processInstanceId !== previous.processInstanceId
     || !Number.isSafeInteger(receipt.previous.exitedAt)
     || receipt.previous.exitedAt < previous.processStartedAt
     || receipt.current.processStartedAt < receipt.previous.exitedAt
+    || receipt.current.hostIdentity !== previous.hostIdentity
     || receipt.current.pid === previous.pid
     || receipt.current.processInstanceId === previous.processInstanceId
     || receipt.current.dataDirectoryIdentity !== previous.dataDirectoryIdentity) {
@@ -358,6 +363,7 @@ function assertReady(
     throw new Error(`${role} runtime identity differs from the external trust anchor`);
   }
   for (const [label, value] of [
+    ['hostIdentity', actual.hostIdentity],
     ['processInstanceId', actual.processInstanceId],
     ['dataDirectoryIdentity', actual.dataDirectoryIdentity],
     ['evidenceWaveId', actual.evidenceWaveId],
@@ -374,7 +380,9 @@ function assertReady(
 function assertDistinctProcesses(
   processes: readonly SelectiveCoverageRuntimeReadyV1[],
 ): void {
-  if (new Set(processes.map((entry) => entry.pid)).size !== processes.length) {
+  const osProcessIdentities = processes.map((entry) => `${entry.hostIdentity}\0${entry.pid}`);
+  if (new Set(osProcessIdentities).size !== processes.length
+    || new Set(processes.map((entry) => entry.processInstanceId)).size !== processes.length) {
     throw new Error('M1 roles did not cross distinct OS process boundaries');
   }
   const peerByRole = new Map<SelectiveCoverageRuntimeRole, string>();


### PR DESCRIPTION
## Impact

This is a proof-only M1 harness change; it does not change DKG runtime behavior.

The three-node canary spans multiple machines. Linux PIDs are unique only inside one host, so comparing bare PIDs can reject a valid Publisher/Core pair that happens to reuse the same number. The adapter now reports a stable `hostIdentity`, and the harness defines an OS process as `(hostIdentity, pid)`.

Because `hostIdentity` is a required wire field, the adapter protocol is explicitly bumped from runtime v1 to runtime v2. Old v1 adapter payloads fail closed instead of being misidentified as compatible.

The gate also rejects duplicated process-instance evidence and requires an Edge restart receipt to remain bound to the original host and durable directory. A single process-identity abstraction now governs both role distinctness and restart proof.

### Before

```mermaid
sequenceDiagram
    participant P as Publisher host A
    participant C as Core host B
    participant H as M1 collector
    P->>H: ready(pid=101)
    C->>H: ready(pid=101)
    H-->>H: bare PID collision
    H-->>P: reject valid cross-host run
```

### After

```mermaid
sequenceDiagram
    participant P as Publisher host A
    participant C as Core host B
    participant H as M1 collector
    P->>H: runtime-v2 ready(host=A, pid=101, instance=P1)
    C->>H: runtime-v2 ready(host=B, pid=101, instance=C1)
    H-->>H: compare (hostIdentity, pid)
    H-->>H: require unique processInstanceId
    H-->>P: accept distinct OS processes
```

### Edge restart binding

```mermaid
sequenceDiagram
    participant E1 as Edge process 1
    participant H as M1 collector
    participant E2 as Edge process 2
    E1->>H: ready(host=A, pid=102, durable=D)
    E1->>H: exited(host=A, pid=102, instance=E1)
    E2->>H: ready(host=A, pid=103, durable=D, instance=E2)
    H-->>H: require same host and durable directory
```

## Validation

- M1 focused tests — 75/75 pass
- Process/runtime boundary subset — 46/46 pass
- M1 TypeScript project — pass
- `git diff --check` — pass
