### PR TITLE
test(rfc64): bind release CLI into the M1 runtime manifest

### DIFF
--- a/devnet/rfc64-gate2-multi-asset-completeness/runtime-provenance.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/runtime-provenance.ts
@@ -19,6 +19,7 @@ export const GATE2_RUNTIME_PROVENANCE_DIGEST_DOMAIN =
   'dkg-rfc64-gate2-runtime-provenance-v1\n' as const;
 
 export const GATE2_RUNTIME_PACKAGE_CLOSURE = Object.freeze([
+  Object.freeze({ name: '@origintrail-official/dkg', path: 'packages/cli/dist' }),
   Object.freeze({ name: '@origintrail-official/dkg-agent', path: 'packages/agent/dist' }),
   Object.freeze({ name: '@origintrail-official/dkg-chain', path: 'packages/chain/dist' }),
   Object.freeze({ name: '@origintrail-official/dkg-core', path: 'packages/core/dist' }),
@@ -35,7 +36,7 @@ export const GATE2_RUNTIME_PACKAGE_CLOSURE = Object.freeze([
 export const GATE2_RUNTIME_CLEAN_ARGS = Object.freeze([
   '-r',
   '--filter',
-  '@origintrail-official/dkg-agent...',
+  '@origintrail-official/dkg...',
   '--filter',
   '!@origintrail-official/dkg-evm-module',
   'run',
@@ -45,7 +46,7 @@ export const GATE2_RUNTIME_CLEAN_ARGS = Object.freeze([
 export const GATE2_RUNTIME_BUILD_ARGS = Object.freeze([
   '-r',
   '--filter',
-  '@origintrail-official/dkg-agent...',
+  '@origintrail-official/dkg...',
   '--filter',
   '!@origintrail-official/dkg-evm-module',
   'run',

--- a/devnet/rfc64-gate2-multi-asset-completeness/test/runtime-provenance.test.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/test/runtime-provenance.test.ts
@@ -4,6 +4,9 @@ import { resolve } from 'node:path';
 import { test } from 'node:test';
 
 import {
+  GATE2_RUNTIME_BUILD_ARGS,
+  GATE2_RUNTIME_CLEAN_ARGS,
+  GATE2_RUNTIME_PACKAGE_CLOSURE,
   assertGate2ExecutedRuntimeMatchesBuildV1,
   buildGate2ExecutedRuntimeManifestV1,
   buildGate2RuntimeManifestFromEntriesV1,
@@ -17,6 +20,16 @@ const FILES = [
   { path: 'packages/core/dist/index.js', byteLength: 3, sha256: `0x${'3'.repeat(64)}` },
   { path: 'packages/storage/dist/index.js', byteLength: 4, sha256: `0x${'4'.repeat(64)}` },
 ] as const;
+
+test('clean runtime closure includes the release CLI entrypoint', () => {
+  assert.ok(GATE2_RUNTIME_PACKAGE_CLOSURE.some((entry) =>
+    entry.path === 'packages/cli/dist'));
+  for (const args of [GATE2_RUNTIME_CLEAN_ARGS, GATE2_RUNTIME_BUILD_ARGS]) {
+    const values: readonly string[] = args;
+    assert.ok(values.includes('@origintrail-official/dkg...'));
+    assert.equal(values.includes('@origintrail-official/dkg-agent...'), false);
+  }
+});
 
 test('runtime manifests are deterministic and bind exact loaded bytes', () => {
   const build = buildGate2RuntimeManifestFromEntriesV1(SOURCE_COMMIT, FILES);

--- a/devnet/rfc64-m1-selective-coverage/README.md
+++ b/devnet/rfc64-m1-selective-coverage/README.md
@@ -45,7 +45,10 @@ independently requires exact nonzero data, counts, heads, and inventory roots.
 
 ## Runtime sequence
 
-The launcher deliberately starts Core cold, after the second publication wave:
+The launcher deliberately starts Core cold, after the second publication wave.
+Its clean runtime manifest includes the built CLI daemon entrypoint as well as
+the Agent and the M1 synchronization dependency closure, so a release-shaped
+process is cryptographically bound to the reviewed source head:
 
 1. Start Publisher and Edge as distinct OS processes and verify their peer,
    network, commit, and loaded-runtime identities against the trust anchor.

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -39,7 +39,7 @@
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@origintrail-official/dkg-rdf-utils": "workspace:*",


### PR DESCRIPTION
## Impact

This is proof/build hardening for the M1 canary; it does not change synchronization policy or live node behavior.

The M1 launcher starts release-shaped DKG CLI daemons, but the clean runtime manifest previously began at `@origintrail-official/dkg-agent`. That meant the actual `packages/cli/dist/cli.js` entrypoint was outside the hashed evidence closure. This PR makes the CLI package the clean/build root and includes `packages/cli/dist` in the deterministic runtime manifest.

The expanded clean build exposed an existing incremental-build defect in `packages/mcp-dkg`: its clean script removed `dist` but retained `tsconfig.tsbuildinfo`, allowing TypeScript to emit nothing on the next build. The clean script now removes both.

### Before

```mermaid
sequenceDiagram
    participant L as M1 launcher
    participant B as Clean build
    participant D as DKG CLI daemon
    L->>B: clean/build Agent dependencies
    B-->>L: manifest excludes packages/cli/dist
    L->>D: execute packages/cli/dist/cli.js
    D-->>L: process is outside hashed entrypoint closure
```

### After

```mermaid
sequenceDiagram
    participant L as M1 launcher
    participant B as Clean build
    participant M as Runtime manifest
    participant D as DKG CLI daemon
    L->>B: clean/build CLI and M1 sync dependencies
    B->>M: hash packages/cli/dist plus dependency closure
    L->>D: execute packages/cli/dist/cli.js
    D-->>L: release entrypoint is bound to reviewed source
```

### Clean-build repair

```mermaid
sequenceDiagram
    participant C as packages/mcp-dkg clean
    participant T as TypeScript build
    C->>C: remove dist and tsconfig.tsbuildinfo
    C->>T: rebuild from a genuinely clean state
    T-->>C: emit dist deterministically
```

## Validation

- Actual CLI-rooted clean + build from zero — pass
- Runtime manifest: 686 hashed files; `packages/cli/dist/cli.js` present
- Gate 2 runtime/completeness unit lane — 32/32 pass
- Gate 2 TypeScript project — pass
- M1 selective-coverage unit lane — 73/73 pass
- M1 TypeScript project — pass
- `git diff --check` — pass
