### PR TITLE
test(rfc64): add release-shaped M1 testnet adapter

### DIFF
--- a/devnet/rfc64-m1-selective-coverage/README.md
+++ b/devnet/rfc64-m1-selective-coverage/README.md
@@ -149,12 +149,61 @@ malformed command values all fail closed. The launcher also has a direct
 regression test proving that corpus, trust-anchor, and artifact paths are absent
 from the spawned adapter environment.
 
-This repository supplies the fail-closed orchestrator and framed adapter
-protocol, not a deployment-specific adapter executable. The live command is
-therefore intentionally blocked unless `DKG_RFC64_M1_ADAPTER_COMMAND` names an
-operator-reviewed implementation. The launcher removes corpus, trust-anchor,
-and output paths from the adapter environment; the adapter must report runtime
-identity from the processes it launched, not echo expected values.
+This repository also supplies `testnet-operator-adapter.ts`, a configuration-
+driven implementation for isolated local or SSH-controlled testnet processes.
+SSH is used only for deployment control; every publication, catalog exchange,
+selection, catch-up, and automatic Core round still travels through the DKG and
+chain paths. The adapter starts the configured release CLI, reads runtime
+identity from the live node, checks its short reported commit against the full
+tested head, and derives exact VM/SWM evidence through scoped node queries. It
+fails immediately on a terminal catch-up result instead of hiding it behind the
+general transient retry window.
+
+The launcher removes corpus, trust-anchor, and output paths from the adapter
+environment, so the adapter cannot echo expected values. Operator configuration
+is closed-schema and contains only process-control inputs plus the pre-created
+five-graph observation plan.
+
+### User-visible impact
+
+Before this adapter, the checked M1 contract stopped at an implementation-
+neutral process protocol: an operator could unit-test the gate but could not run
+the exact gate against release-shaped nodes without writing a separate bridge.
+After this adapter, the same gate can create a reproducible five-CG testnet
+corpus and drive a local Publisher, a local Edge, and an isolated remote Core,
+while preserving all process, peer, repository, runtime-manifest, journal, and
+exact-payload evidence required by the verifier.
+
+```mermaid
+sequenceDiagram
+  participant O as Operator
+  participant G as M1 gate
+  participant X as Missing deployment adapter
+  O->>G: Start live test
+  G->>X: Framed runtime command
+  X--xG: No implementation supplied
+  G-->>O: No testnet evidence
+```
+
+```mermaid
+sequenceDiagram
+  participant O as Operator
+  participant G as M1 gate
+  participant A as Testnet operator adapter
+  participant P as Isolated Publisher
+  participant E as Isolated Edge
+  participant C as Isolated Core
+  O->>G: Start anchored live test
+  G->>A: Sequenced runtime commands
+  A->>P: Start and publish two VM and SWM waves
+  A->>E: Select, sync, restart, and observe
+  A->>C: Start cold and observe automatic public coverage
+  P-->>A: Live identity and exact snapshots
+  E-->>A: Job and reconciler journal evidence
+  C-->>A: Bounded scheduler journal evidence
+  A-->>G: Closed decoded observations
+  G-->>O: Verified canonical PASS artifact
+```
 
 ## Running the live gate
 
@@ -169,6 +218,15 @@ export DKG_RFC64_M1_ADAPTER_COMMAND=/secure/operator/dkg-m1-adapter
 export DKG_RFC64_M1_ADAPTER_ARGS_JSON='[]'
 pnpm test:m1:rfc64-selective-coverage
 ```
+
+For the shipped TypeScript adapter, set the command to `node`, pass
+`["--import","tsx","devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts"]`
+as `DKG_RFC64_M1_ADAPTER_ARGS_JSON`, and provide the closed operator file via
+`DKG_RFC64_M1_OPERATOR_CONFIG`. `prepare-testnet-corpus.ts` creates and seals
+exactly two KAs in each of the five policy/selection cells, then writes both the
+immutable corpus and the adapter graph plan. After probing stable identities for
+the three isolated data directories, `create-testnet-trust-anchor.ts` binds
+those peer IDs to the clean source/runtime manifest and corpus digest.
 
 The trust anchor contains `networkId`, exact `testedHeadCommit`, computed
 `runtimeManifestDigest`, `corpusManifestDigest`, and the three expected peer

--- a/devnet/rfc64-m1-selective-coverage/create-testnet-trust-anchor.ts
+++ b/devnet/rfc64-m1-selective-coverage/create-testnet-trust-anchor.ts
@@ -1,0 +1,48 @@
+import { resolve } from 'node:path';
+
+import {
+  atomicWriteExactBytes,
+  readCleanRepositoryHead,
+} from '../rfc64-persistence-lifecycle/evidence.ts';
+import { buildGate2RuntimeManifestV1 } from
+  '../rfc64-gate2-multi-asset-completeness/runtime-provenance.ts';
+import { canonicalJson, type ExpectedSelectiveCoverageProvenanceV1 } from './manifest.ts';
+import { readSelectiveCoverageCorpus } from './operator-input.ts';
+
+const repoRoot = resolve(import.meta.dirname, '../..');
+const corpusPath = resolve(requiredEnvironment('DKG_RFC64_M1_CORPUS_FILE'));
+const outputPath = resolve(requiredEnvironment('DKG_RFC64_M1_TRUST_ANCHOR_FILE'));
+const corpus = readSelectiveCoverageCorpus(corpusPath);
+const sourceCommit = readCleanRepositoryHead(repoRoot);
+const runtimeManifest = buildGate2RuntimeManifestV1(repoRoot, sourceCommit);
+const trustAnchor: ExpectedSelectiveCoverageProvenanceV1 = {
+  networkId: corpus.networkId,
+  testedHeadCommit: sourceCommit,
+  runtimeManifestDigest: runtimeManifest.manifestDigest,
+  corpusManifestDigest: corpus.manifestDigest,
+  publisherPeerId: peerId('DKG_RFC64_M1_PUBLISHER_PEER_ID'),
+  edgePeerId: peerId('DKG_RFC64_M1_EDGE_PEER_ID'),
+  corePeerId: peerId('DKG_RFC64_M1_CORE_PEER_ID'),
+};
+const published = atomicWriteExactBytes(
+  outputPath,
+  Buffer.from(`${canonicalJson(trustAnchor)}\n`, 'utf8'),
+);
+process.stdout.write(
+  `[rfc64-m1] wrote externally anchored runtime/peer provenance to ${outputPath} `
+    + `sha256:${published.sha256}\n`,
+);
+
+function peerId(name: string): string {
+  const value = requiredEnvironment(name);
+  if (!/^12D3KooW[1-9A-HJ-NP-Za-km-z]{40,60}$/u.test(value)) {
+    throw new TypeError(`${name} is not a bounded libp2p Ed25519 peer ID`);
+  }
+  return value;
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/devnet/rfc64-m1-selective-coverage/package.json
+++ b/devnet/rfc64-m1-selective-coverage/package.json
@@ -6,7 +6,9 @@
   "description": "Fail-closed evidence contract for RFC-64 M1 Edge selection and bounded Core public coverage.",
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node --experimental-strip-types --test verifier.test.ts runtime.test.ts process-runtime.test.ts adapter-environment.test.ts operator-input.test.ts boundary-codec.test.ts",
+    "test": "node --experimental-strip-types --test verifier.test.ts runtime.test.ts process-runtime.test.ts adapter-environment.test.ts operator-input.test.ts boundary-codec.test.ts && node --import tsx --test testnet-operator-common.test.ts",
+    "prepare-testnet": "node --import tsx prepare-testnet-corpus.ts",
+    "anchor-testnet": "node --import tsx create-testnet-trust-anchor.ts",
     "live": "node --import tsx launch-live.ts",
     "verify-live": "node --import tsx verify-live.ts"
   }

--- a/devnet/rfc64-m1-selective-coverage/prepare-testnet-corpus.ts
+++ b/devnet/rfc64-m1-selective-coverage/prepare-testnet-corpus.ts
@@ -1,0 +1,173 @@
+import { mkdirSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import {
+  atomicWriteExactBytes,
+} from '../rfc64-persistence-lifecycle/evidence.ts';
+import {
+  createRfc64SemanticSnapshot,
+  type Rfc64KnowledgeAssetObservation,
+} from '../_bootstrap/rfc64-evidence.ts';
+import {
+  canonicalJson,
+  createSelectiveCoverageCorpus,
+  type GraphSnapshotExpectationV1,
+  type SelectiveCoverageGraphV1,
+} from './manifest.ts';
+import {
+  TESTNET_OPERATOR_CONFIG_SCHEMA,
+  requireJson,
+  type TestnetOperatorAssetV1,
+  type TestnetOperatorGraphV1,
+  type TestnetOperatorRoleV1,
+} from './testnet-operator-common.ts';
+
+const apiUrl = requiredEnvironment('DKG_RFC64_M1_PREPUBLISHER_API');
+const corpusPath = resolve(requiredEnvironment('DKG_RFC64_M1_CORPUS_FILE'));
+const configPath = resolve(requiredEnvironment('DKG_RFC64_M1_OPERATOR_CONFIG'));
+const rolesPath = resolve(requiredEnvironment('DKG_RFC64_M1_OPERATOR_ROLES_FILE'));
+const runId = (process.env['DKG_RFC64_M1_RUN_ID'] ?? Date.now().toString(36))
+  .toLowerCase().replace(/[^a-z0-9-]/gu, '-').slice(0, 24);
+if (!runId) throw new Error('DKG_RFC64_M1_RUN_ID normalized to an empty value');
+
+const publisher: TestnetOperatorRoleV1 = {
+  transport: 'local',
+  apiUrl,
+  repoRoot: process.cwd(),
+  dataDir: '.',
+  command: ['unused'],
+  environment: {},
+};
+const roleConfig = JSON.parse(await readFile(rolesPath, 'utf8')) as Record<string, unknown>;
+const identity = await requireJson(publisher, '/api/agent/identity');
+const agentAddress = requiredText(identity['agentAddress'], 'publisher agent address');
+const status = await requireJson(publisher, '/api/status');
+const networkId = requiredText(status['networkId'], 'publisher network ID');
+
+const policyCells = [
+  { suffix: 'public-open-ondemand', accessPolicy: 0 as const, publishPolicy: 1 as const, edgePolicy: 'on-demand' as const },
+  { suffix: 'public-curated-always', accessPolicy: 0 as const, publishPolicy: 0 as const, edgePolicy: 'always-on' as const },
+  { suffix: 'public-open-unselected', accessPolicy: 0 as const, publishPolicy: 1 as const, edgePolicy: 'unselected' as const },
+  { suffix: 'private-open-unselected', accessPolicy: 1 as const, publishPolicy: 1 as const, edgePolicy: 'unselected' as const },
+  { suffix: 'private-curated-unselected', accessPolicy: 1 as const, publishPolicy: 0 as const, edgePolicy: 'unselected' as const },
+];
+
+const operatorGraphs: TestnetOperatorGraphV1[] = [];
+const corpusGraphs: SelectiveCoverageGraphV1[] = [];
+for (const [graphIndex, policy] of policyCells.entries()) {
+  const contextGraphId = `m1-${runId}-${graphIndex + 1}`;
+  const create = await requireJson(publisher, '/api/context-graph/create', {
+    method: 'POST',
+    body: JSON.stringify({
+      id: contextGraphId,
+      name: `RFC64 M1 ${runId} ${policy.suffix}`,
+      accessPolicy: policy.accessPolicy,
+      publishPolicy: policy.publishPolicy,
+      allowedAgents: [agentAddress],
+      register: true,
+    }),
+  });
+  if (create['registered'] !== true || create['onChainId'] === undefined) {
+    throw new Error(`context graph ${contextGraphId} did not register: ${JSON.stringify(create)}`);
+  }
+
+  const assets: TestnetOperatorAssetV1[] = [];
+  const semantic: Rfc64KnowledgeAssetObservation[] = [];
+  let selectedSnapshot: GraphSnapshotExpectationV1 | undefined;
+  for (const wave of ['selected', 'final'] as const) {
+    const name = `${wave}-${graphIndex + 1}`;
+    const subject = `urn:dkg:rfc64:m1:${runId}:g${graphIndex + 1}:${wave}`;
+    const lines = Array.from({ length: 24 }, (_, tripleIndex) => {
+      const predicate = `urn:dkg:rfc64:m1:predicate:${tripleIndex.toString().padStart(2, '0')}`;
+      const object = JSON.stringify(`${runId}|g${graphIndex + 1}|${wave}|${tripleIndex}`);
+      return `<${subject}> <${predicate}> ${object} .`;
+    });
+    const quads = lines.map((line) => {
+      const match = /^<([^>]+)> <([^>]+)> (.+) \.$/u.exec(line);
+      if (!match) throw new Error('generated M1 N-Quad is malformed');
+      return { subject: match[1], predicate: match[2], object: match[3] };
+    });
+    await requireJson(publisher, '/api/knowledge-assets', {
+      method: 'POST',
+      body: JSON.stringify({ contextGraphId, name, quads, finalize: true }),
+    }, [201]);
+    const descriptor = await requireJson(
+      publisher,
+      `/api/knowledge-assets/${encodeURIComponent(name)}?contextGraphId=${encodeURIComponent(contextGraphId)}`,
+    );
+    const ual = requiredText(descriptor['reservedUal'], `${contextGraphId}/${name} reserved UAL`);
+    assets.push({ name, subject, ual, wave });
+    semantic.push({ ual, semanticNQuads: lines });
+    const snapshot = await createRfc64SemanticSnapshot(semantic);
+    const expectation = {
+      vm: {
+        headDigest: snapshot.ualsSha256,
+        inventoryDigest: snapshot.semanticNQuadsSha256,
+        assetCount: snapshot.kaCount,
+        dataTripleCount: snapshot.quadCount,
+      },
+      swm: {
+        headDigest: snapshot.ualsSha256,
+        inventoryDigest: snapshot.semanticNQuadsSha256,
+        assetCount: snapshot.kaCount,
+        dataTripleCount: snapshot.quadCount,
+      },
+    } satisfies GraphSnapshotExpectationV1;
+    if (wave === 'selected') selectedSnapshot = expectation;
+    else {
+      if (!selectedSnapshot) throw new Error('selected snapshot was not constructed');
+      corpusGraphs.push({
+        contextGraphId,
+        accessPolicy: policy.accessPolicy,
+        publishPolicy: policy.publishPolicy,
+        edgePolicy: policy.edgePolicy,
+        selectedSnapshot,
+        finalSnapshot: expectation,
+      });
+    }
+  }
+  operatorGraphs.push({
+    contextGraphId,
+    accessPolicy: policy.accessPolicy,
+    publishPolicy: policy.publishPolicy,
+    edgePolicy: policy.edgePolicy,
+    assets,
+  });
+}
+
+const corpus = createSelectiveCoverageCorpus({
+  networkId,
+  coreAutomaticBatchSize: 3,
+  coreCoverageRoundLimit: 2,
+  graphs: corpusGraphs,
+});
+const operatorConfig = {
+  schema: TESTNET_OPERATOR_CONFIG_SCHEMA,
+  roles: roleConfig,
+  graphs: operatorGraphs,
+  pollIntervalMs: 2_000,
+  operationTimeoutMs: 20 * 60_000,
+};
+writeJson(corpusPath, corpus);
+writeJson(configPath, operatorConfig);
+process.stdout.write(
+  `[rfc64-m1] prepared ${operatorGraphs.length} registered CGs and 10 sealed KAs; `
+    + `corpus=${corpusPath} operatorConfig=${configPath}\n`,
+);
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  atomicWriteExactBytes(path, Buffer.from(`${canonicalJson(value)}\n`, 'utf8'));
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredText(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !value.trim()) throw new TypeError(`${label} is missing`);
+  return value;
+}

--- a/devnet/rfc64-m1-selective-coverage/prepare-testnet-corpus.ts
+++ b/devnet/rfc64-m1-selective-coverage/prepare-testnet-corpus.ts
@@ -17,6 +17,7 @@ import {
 } from './manifest.ts';
 import {
   TESTNET_OPERATOR_CONFIG_SCHEMA,
+  buildTestnetContextGraphCreateRequest,
   requireJson,
   type TestnetOperatorAssetV1,
   type TestnetOperatorGraphV1,
@@ -59,14 +60,13 @@ for (const [graphIndex, policy] of policyCells.entries()) {
   const contextGraphId = `m1-${runId}-${graphIndex + 1}`;
   const create = await requireJson(publisher, '/api/context-graph/create', {
     method: 'POST',
-    body: JSON.stringify({
-      id: contextGraphId,
+    body: JSON.stringify(buildTestnetContextGraphCreateRequest({
+      contextGraphId,
       name: `RFC64 M1 ${runId} ${policy.suffix}`,
       accessPolicy: policy.accessPolicy,
       publishPolicy: policy.publishPolicy,
-      allowedAgents: [agentAddress],
-      register: true,
-    }),
+      agentAddress,
+    })),
   });
   if (create['registered'] !== true || create['onChainId'] === undefined) {
     throw new Error(`context graph ${contextGraphId} did not register: ${JSON.stringify(create)}`);

--- a/devnet/rfc64-m1-selective-coverage/print-runtime-provenance.ts
+++ b/devnet/rfc64-m1-selective-coverage/print-runtime-provenance.ts
@@ -1,0 +1,17 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { buildGate2RuntimeManifestV1 } from
+  '../rfc64-gate2-multi-asset-completeness/runtime-provenance.ts';
+
+const repoRoot = resolve(process.argv[2] ?? '.');
+const sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+  cwd: repoRoot,
+  encoding: 'utf8',
+}).trim();
+const manifest = buildGate2RuntimeManifestV1(repoRoot, sourceCommit);
+process.stdout.write(`${JSON.stringify({
+  sourceCommit,
+  runtimeManifestDigest: manifest.manifestDigest,
+})}\n`);
+

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts
@@ -1,0 +1,771 @@
+import { spawn, execFileSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { hostname } from 'node:os';
+import { realpathSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createInterface } from 'node:readline';
+
+import { buildGate2RuntimeManifestV1 } from
+  '../rfc64-gate2-multi-asset-completeness/runtime-provenance.ts';
+import {
+  SELECTIVE_COVERAGE_RUNTIME_PROTOCOL,
+  type SelectiveCoverageEdgeRestartReceiptV1,
+  type SelectiveCoverageRuntimeReadyV1,
+  type SelectiveCoverageRuntimeRole,
+} from './runtime.ts';
+import type {
+  CoreAutomaticRoundV1,
+  CoreFinalObservationV1,
+  EdgeGraphObservationV1,
+  EdgeSyncOperationV1,
+  GraphObservationV1,
+  SyncCoverageJournalReferenceV1,
+} from './manifest.ts';
+import {
+  observeGraph,
+  readTestnetOperatorConfig,
+  requestJson,
+  requireJson,
+  type TestnetOperatorConfigV1,
+  type TestnetOperatorGraphV1,
+  type TestnetOperatorRoleV1,
+} from './testnet-operator-common.ts';
+
+const COMMAND_SCHEMA = 'dkg-rfc64-m1-selective-coverage-runtime-command-v1';
+const RESULT_SCHEMA = 'dkg-rfc64-m1-selective-coverage-runtime-result-v1';
+const RESULT_PREFIX = 'DKG_RFC64_M1_RESULT ';
+const REMOTE_PID_PREFIX = 'DKG_RFC64_M1_REMOTE_PID=';
+const configPath = requiredEnvironment('DKG_RFC64_M1_OPERATOR_CONFIG');
+const config = readTestnetOperatorConfig(resolve(configPath));
+
+interface RuntimeCommand {
+  readonly schema: typeof COMMAND_SCHEMA;
+  readonly protocol: typeof SELECTIVE_COVERAGE_RUNTIME_PROTOCOL;
+  readonly sessionNonce: string;
+  readonly sequence: number;
+  readonly command: string;
+  readonly payload: Record<string, unknown>;
+}
+
+interface RuntimeProcess {
+  readonly role: SelectiveCoverageRuntimeRole;
+  readonly child: ChildProcessWithoutNullStreams;
+  readonly ready: SelectiveCoverageRuntimeReadyV1;
+  readonly exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+}
+
+class TestnetOperatorController {
+  private readonly processes = new Map<SelectiveCoverageRuntimeRole, RuntimeProcess>();
+  private readonly edgeProducingJobIds = new Map<string, string>();
+  private readonly coreJobIds = new Map<string, Set<string>>();
+  private lastCoreSequence = 0;
+
+  constructor(private readonly cfg: TestnetOperatorConfigV1) {}
+
+  async handle(command: string, payload: Record<string, unknown>): Promise<unknown> {
+    switch (command) {
+      case 'start':
+        return await this.start(role(payload['role']));
+      case 'stop':
+        await this.stop(role(payload['role']));
+        return null;
+      case 'publish-wave':
+        return await this.publishWave(wave(payload['wave']));
+      case 'observe-edge':
+        return await this.observeEdge();
+      case 'synchronize-edge':
+        return await this.synchronizeEdge(payload);
+      case 'restart-edge':
+        return await this.restartEdge();
+      case 'wait-edge-reconciler':
+        return await this.waitEdgeReconciler(requiredText(payload['contextGraphId'], 'contextGraphId'));
+      case 'core-automatic-round':
+        return await this.coreAutomaticRound(nonNegativeInteger(payload['round'], 'round'));
+      case 'observe-core-final':
+        return await this.observeCoreFinal();
+      case 'shutdown':
+        await this.stopAll();
+        return null;
+      default:
+        throw new Error(`unsupported M1 operator command: ${command}`);
+    }
+  }
+
+  async start(roleName: SelectiveCoverageRuntimeRole): Promise<SelectiveCoverageRuntimeReadyV1> {
+    if (this.processes.has(roleName)) throw new Error(`${roleName} is already running`);
+    const roleConfig = this.cfg.roles[roleName];
+    const provenance = await runtimeProvenance(roleConfig);
+    const hostIdentity = await roleCapture(roleConfig, ['hostname']);
+    const durableDirectoryIdentity = await dataDirectoryIdentity(roleConfig);
+    const launched = launchRole(roleName, roleConfig);
+    const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((done) => {
+      launched.child.once('exit', (code, signal) => done({ code, signal }));
+    });
+    launched.child.stdout.on('data', (chunk: Buffer) => {
+      process.stderr.write(`[${roleName}] ${chunk.toString('utf8')}`);
+    });
+    launched.child.stderr.on('data', (chunk: Buffer) => {
+      process.stderr.write(`[${roleName}] ${chunk.toString('utf8')}`);
+    });
+    try {
+      const [status, journal, pid] = await Promise.race([
+        Promise.all([
+          waitForStatus(roleConfig, this.cfg),
+          waitForJournal(roleConfig, this.cfg),
+          launched.pid,
+        ]),
+        exit.then(({ code, signal }) => {
+          throw new FatalPollError(
+            `${roleName} exited before readiness (code=${String(code)} signal=${String(signal)})`,
+          );
+        }),
+      ]);
+      const peerId = requiredText(status['peerId'], `${roleName} peerId`);
+      const networkId = requiredText(status['networkId'], `${roleName} networkId`);
+      const reportedCommit = requiredText(status['commit'], `${roleName} reported commit`);
+      if (!provenance.sourceCommit.startsWith(reportedCommit)
+        || reportedCommit.length < 7) {
+        throw new Error(
+          `${roleName} running commit ${reportedCommit} does not match tested head ${provenance.sourceCommit}`,
+        );
+      }
+      const nodeRole = status['nodeRole'];
+      if ((roleName === 'core' && nodeRole !== 'core')
+        || (roleName !== 'core' && nodeRole !== 'edge')) {
+        throw new Error(`${roleName} started with unexpected nodeRole=${String(nodeRole)}`);
+      }
+      const processStartedAt = nonNegativeInteger(journal['processStartedAt'], 'processStartedAt');
+      const evidenceWaveId = requiredText(journal['waveId'], 'evidence waveId');
+      const ready: SelectiveCoverageRuntimeReadyV1 = {
+        protocol: SELECTIVE_COVERAGE_RUNTIME_PROTOCOL,
+        role: roleName,
+        hostIdentity: hostIdentity.trim(),
+        pid,
+        peerId,
+        networkId,
+        testedHeadCommit: provenance.sourceCommit,
+        runtimeManifestDigest: provenance.runtimeManifestDigest,
+        processStartedAt,
+        processInstanceId: evidenceWaveId,
+        dataDirectoryIdentity: durableDirectoryIdentity,
+        evidenceWaveId,
+      };
+      this.processes.set(roleName, { role: roleName, child: launched.child, ready, exited: exit });
+      return ready;
+    } catch (error) {
+      launched.child.kill('SIGTERM');
+      throw error;
+    }
+  }
+
+  async stop(roleName: SelectiveCoverageRuntimeRole): Promise<void> {
+    const running = this.processes.get(roleName);
+    if (!running) return;
+    const roleConfig = this.cfg.roles[roleName];
+    let outcome: { code: number | null; signal: NodeJS.Signals | null };
+    try {
+      const shutdown = await requestJson(roleConfig, '/api/shutdown', { method: 'POST' });
+      if (shutdown.status !== 200) {
+        throw new Error(`${roleName} shutdown request failed (${shutdown.status})`);
+      }
+      outcome = await withTimeout(
+        running.exited,
+        30_000,
+        `${roleName} process exit after shutdown`,
+      );
+    } finally {
+      this.processes.delete(roleName);
+    }
+    if (outcome.code !== 0 || outcome.signal !== null) {
+      throw new Error(
+        `${roleName} exited abnormally (code=${String(outcome.code)} signal=${String(outcome.signal)})`,
+      );
+    }
+  }
+
+  async stopAll(): Promise<void> {
+    const failures: unknown[] = [];
+    for (const roleName of ['core', 'edge', 'publisher'] as const) {
+      try { await this.stop(roleName); } catch (error) { failures.push(error); }
+    }
+    if (failures.length) throw new AggregateError(failures, 'M1 operator node shutdown failed');
+  }
+
+  async publishWave(selectedWave: 'selected' | 'final'): Promise<readonly GraphObservationV1[]> {
+    this.requireRunning('publisher');
+    const publisher = this.cfg.roles.publisher;
+    for (const graph of this.cfg.graphs) {
+      for (const asset of graph.assets.filter((candidate) => candidate.wave === selectedWave)) {
+        await requireJson(
+          publisher,
+          `/api/knowledge-assets/${encodeURIComponent(asset.name)}/swm/share`,
+          { method: 'POST', body: JSON.stringify({ contextGraphId: graph.contextGraphId }) },
+        );
+        const published = await requireJson(
+          publisher,
+          `/api/knowledge-assets/${encodeURIComponent(asset.name)}/vm/publish`,
+          { method: 'POST', body: JSON.stringify({ contextGraphId: graph.contextGraphId }) },
+        );
+        const returnedUal = published['ual'];
+        if (typeof returnedUal === 'string' && returnedUal.toLowerCase() !== asset.ual.toLowerCase()) {
+          throw new Error(`${graph.contextGraphId}/${asset.name} published an unexpected UAL`);
+        }
+      }
+    }
+    const expectedAssets = selectedWave === 'selected' ? 1 : 2;
+    return await this.waitForObservations('publisher', (rows) =>
+      rows.every((row) => row.vm.assetCount === expectedAssets && row.swm.assetCount === expectedAssets));
+  }
+
+  async observeEdge(): Promise<readonly EdgeGraphObservationV1[]> {
+    this.requireRunning('edge');
+    const rows = await this.observeAll('edge');
+    const subscriptions = await requireJson(
+      this.cfg.roles.edge,
+      '/api/context-graph/subscriptions',
+    );
+    const subscriptionRows = Array.isArray(subscriptions['subscriptions'])
+      ? subscriptions['subscriptions']
+      : [];
+    const modeById = new Map<string, 'always-on' | 'on-demand'>();
+    for (const value of subscriptionRows) {
+      const item = looseRecord(value);
+      if (!item) continue;
+      const id = item['contextGraphId'];
+      const mode = item['syncMode'];
+      if (typeof id === 'string' && (mode === 'always-on' || mode === 'on-demand')) {
+        modeById.set(id, mode);
+      }
+    }
+    return rows.map((row): EdgeGraphObservationV1 => {
+      const payloadPresent = row.vm.assetCount > 0 || row.swm.assetCount > 0;
+      return {
+        ...row,
+        runtimeSyncMode: modeById.get(row.contextGraphId) ?? null,
+        producingJobId: payloadPresent
+          ? this.edgeProducingJobIds.get(row.contextGraphId) ?? null
+          : null,
+      };
+    });
+  }
+
+  async synchronizeEdge(payload: Record<string, unknown>): Promise<{
+    operation: Omit<EdgeSyncOperationV1, 'sequence'>;
+  }> {
+    this.requireRunning('edge');
+    const contextGraphId = requiredText(payload['contextGraphId'], 'contextGraphId');
+    const phase = payload['phase'];
+    const syncMode = payload['syncMode'];
+    const completedWave = payload['wave'];
+    if ((phase !== 'selection' && phase !== 'post-restart-explicit')
+      || (syncMode !== 'always-on' && syncMode !== 'on-demand')
+      || (completedWave !== 'selected' && completedWave !== 'final')) {
+      throw new TypeError('synchronize-edge payload is malformed');
+    }
+    const graph = this.graph(contextGraphId);
+    const response = await requireJson(this.cfg.roles.edge, '/api/context-graph/subscribe', {
+      method: 'POST',
+      body: JSON.stringify({ contextGraphId, includeSharedMemory: true, syncMode }),
+    });
+    const catchup = requiredRecord(response['catchup'], 'catchup response');
+    const jobId = requiredText(catchup['jobId'], 'catchup jobId');
+    await this.waitForCatchup(jobId);
+    const snapshot = await this.waitForGraphSnapshot('edge', graph, completedWave === 'selected' ? 1 : 2);
+    this.edgeProducingJobIds.set(contextGraphId, jobId);
+    return {
+      operation: {
+        phase,
+        source: 'user',
+        syncMode,
+        contextGraphId,
+        jobId,
+        completedWave,
+        completedSnapshot: snapshot,
+      },
+    };
+  }
+
+  async restartEdge(): Promise<SelectiveCoverageEdgeRestartReceiptV1> {
+    const previous = this.requireRunning('edge').ready;
+    await this.stop('edge');
+    const exitedAt = Date.now();
+    const current = await this.start('edge');
+    return {
+      previous: {
+        hostIdentity: previous.hostIdentity,
+        pid: previous.pid,
+        processInstanceId: previous.processInstanceId,
+        exitedAt,
+      },
+      current,
+    };
+  }
+
+  async waitEdgeReconciler(contextGraphId: string): Promise<{
+    operation: Omit<EdgeSyncOperationV1, 'sequence'>;
+    journal: SyncCoverageJournalReferenceV1;
+  }> {
+    this.requireRunning('edge');
+    const journal = await this.waitForJournalEntry('edge', 0, (entry) =>
+      entry['kind'] === 'edge-reconciler-job'
+        && entry['contextGraphId'] === contextGraphId
+        && entry['state'] === 'complete');
+    const entry = journal.entry;
+    const jobId = requiredText(entry['jobId'], 'Edge reconciler jobId');
+    const graph = this.graph(contextGraphId);
+    const snapshot = await this.waitForGraphSnapshot('edge', graph, 2);
+    this.edgeProducingJobIds.set(contextGraphId, jobId);
+    return {
+      operation: {
+        phase: 'post-restart-auto',
+        source: 'reconciler',
+        syncMode: 'always-on',
+        contextGraphId,
+        jobId,
+        completedWave: 'final',
+        completedSnapshot: snapshot,
+      },
+      journal: { snapshot: journal.snapshot, sequence: journal.sequence },
+    };
+  }
+
+  async coreAutomaticRound(round: number): Promise<{
+    round: CoreAutomaticRoundV1;
+    journal: SyncCoverageJournalReferenceV1;
+  }> {
+    this.requireRunning('core');
+    const journal = await this.waitForJournalEntry('core', this.lastCoreSequence, (entry) =>
+      entry['kind'] === 'core-automatic-round' && entry['state'] === 'complete');
+    this.lastCoreSequence = journal.sequence;
+    const entry = journal.entry;
+    const contextGraphIds = stringArray(entry['automaticContextGraphIds'], 'automatic CG IDs');
+    const explicit = stringArray(entry['explicitSelectedContextGraphIds'], 'explicit CG IDs');
+    const jobId = requiredText(entry['jobId'], 'Core round jobId');
+    const completions = [];
+    for (const contextGraphId of contextGraphIds) {
+      const graph = this.graph(contextGraphId);
+      const completedSnapshot = await this.waitForGraphSnapshot('core', graph, 2);
+      completions.push({ contextGraphId, completedWave: 'final' as const, completedSnapshot });
+      const jobs = this.coreJobIds.get(contextGraphId) ?? new Set<string>();
+      jobs.add(jobId);
+      this.coreJobIds.set(contextGraphId, jobs);
+    }
+    return {
+      round: {
+        round,
+        jobId,
+        planningLane: requiredText(entry['planningLane'], 'Core planning lane'),
+        source: 'automatic-core-public',
+        configuredBatchSize: nonNegativeInteger(entry['configuredBatchSize'], 'configuredBatchSize'),
+        explicitSelectedContextGraphIds: explicit,
+        contextGraphIds,
+        completions,
+      },
+      journal: { snapshot: journal.snapshot, sequence: journal.sequence },
+    };
+  }
+
+  async observeCoreFinal(): Promise<readonly CoreFinalObservationV1[]> {
+    this.requireRunning('core');
+    const observations = await this.observeAll('core');
+    return observations.map((observation): CoreFinalObservationV1 => ({
+      ...observation,
+      automaticJobIds: [...(this.coreJobIds.get(observation.contextGraphId) ?? [])],
+    }));
+  }
+
+  private async observeAll(
+    roleName: 'publisher' | 'edge' | 'core',
+  ): Promise<readonly GraphObservationV1[]> {
+    const roleConfig = this.cfg.roles[roleName];
+    return await Promise.all(this.cfg.graphs.map((graph) => observeGraph(roleConfig, graph)));
+  }
+
+  private async waitForObservations(
+    roleName: 'publisher' | 'edge' | 'core',
+    accept: (observations: readonly GraphObservationV1[]) => boolean,
+  ): Promise<readonly GraphObservationV1[]> {
+    return await poll(
+      `${roleName} exact graph observations`,
+      this.cfg,
+      async () => {
+        const observations = await this.observeAll(roleName);
+        return accept(observations) ? observations : undefined;
+      },
+    );
+  }
+
+  private async waitForGraphSnapshot(
+    roleName: 'edge' | 'core',
+    graph: TestnetOperatorGraphV1,
+    expectedAssets: number,
+  ) {
+    const observation = await poll(
+      `${roleName} ${graph.contextGraphId} ${expectedAssets}-asset snapshot`,
+      this.cfg,
+      async () => {
+        const row = await observeGraph(this.cfg.roles[roleName], graph);
+        return row.vm.assetCount === expectedAssets && row.swm.assetCount === expectedAssets
+          ? row
+          : undefined;
+      },
+    );
+    if (!observation.vm.reportedComplete || !observation.swm.reportedComplete
+      || observation.vm.headDigest === null || observation.vm.inventoryDigest === null
+      || observation.swm.headDigest === null || observation.swm.inventoryDigest === null) {
+      throw new Error(`${roleName} ${graph.contextGraphId} snapshot is incomplete`);
+    }
+    return {
+      vm: {
+        headDigest: observation.vm.headDigest,
+        inventoryDigest: observation.vm.inventoryDigest,
+        assetCount: observation.vm.assetCount,
+        dataTripleCount: observation.vm.dataTripleCount,
+      },
+      swm: {
+        headDigest: observation.swm.headDigest,
+        inventoryDigest: observation.swm.inventoryDigest,
+        assetCount: observation.swm.assetCount,
+        dataTripleCount: observation.swm.dataTripleCount,
+      },
+    };
+  }
+
+  private async waitForCatchup(jobId: string): Promise<void> {
+    await poll(`Edge catch-up ${jobId}`, this.cfg, async () => {
+      const status = await requireJson(
+        this.cfg.roles.edge,
+        `/api/sync/catchup-status?jobId=${encodeURIComponent(jobId)}`,
+      );
+      if (status['status'] === 'failed' || status['status'] === 'denied'
+        || status['status'] === 'unreachable') {
+        throw new FatalPollError(
+          `Edge catch-up ${jobId} failed: ${JSON.stringify(status).slice(0, 1_000)}`,
+        );
+      }
+      const convergence = looseRecord(status['convergence']);
+      return status['status'] === 'done' && convergence?.['state'] === 'complete'
+        ? true
+        : undefined;
+    });
+  }
+
+  private async waitForJournalEntry(
+    roleName: 'edge' | 'core',
+    afterSequence: number,
+    accept: (entry: Record<string, unknown>) => boolean,
+  ): Promise<{ snapshot: Record<string, unknown>; entry: Record<string, unknown>; sequence: number }> {
+    return await poll(`${roleName} automatic journal entry`, this.cfg, async () => {
+      const snapshot = await requireJson(
+        this.cfg.roles[roleName],
+        `/api/diagnostics/sync-coverage-evidence?afterSequence=${afterSequence}`,
+      );
+      const entries = Array.isArray(snapshot['entries']) ? snapshot['entries'] : [];
+      for (const value of entries) {
+        const entry = looseRecord(value);
+        if (!entry || !accept(entry)) continue;
+        const sequence = nonNegativeInteger(entry['sequence'], 'journal sequence');
+        return { snapshot, entry, sequence };
+      }
+      return undefined;
+    });
+  }
+
+  private requireRunning(roleName: SelectiveCoverageRuntimeRole): RuntimeProcess {
+    const running = this.processes.get(roleName);
+    if (!running) throw new Error(`${roleName} is not running`);
+    return running;
+  }
+
+  private graph(contextGraphId: string): TestnetOperatorGraphV1 {
+    const graph = this.cfg.graphs.find((candidate) => candidate.contextGraphId === contextGraphId);
+    if (!graph) throw new Error(`context graph is outside the operator plan: ${contextGraphId}`);
+    return graph;
+  }
+}
+
+const controller = new TestnetOperatorController(config);
+const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+let commandTail = Promise.resolve();
+let closing = false;
+
+lines.on('line', (line) => {
+  commandTail = commandTail.then(async () => {
+    const request = parseCommand(line);
+    try {
+      const value = await controller.handle(request.command, request.payload);
+      emit(request, true, value);
+      if (request.command === 'shutdown') {
+        closing = true;
+        lines.close();
+      }
+    } catch (error) {
+      emit(request, false, error instanceof Error ? error.message : String(error));
+    }
+  }).catch((error) => {
+    process.stderr.write(`[rfc64-m1-adapter] command loop failed: ${String(error)}\n`);
+    process.exitCode = 1;
+    lines.close();
+  });
+});
+
+lines.on('close', () => {
+  void commandTail.finally(async () => {
+    if (!closing) await controller.stopAll().catch(() => undefined);
+  });
+});
+
+function launchRole(
+  roleName: SelectiveCoverageRuntimeRole,
+  roleConfig: TestnetOperatorRoleV1,
+): { child: ChildProcessWithoutNullStreams; pid: Promise<number> } {
+  if (roleConfig.transport === 'local') {
+    const child = spawn(roleConfig.command[0]!, [...roleConfig.command.slice(1)], {
+      cwd: roleConfig.repoRoot,
+      env: { ...process.env, ...roleConfig.environment },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    if (child.pid === undefined) throw new Error(`${roleName} local process has no PID`);
+    return { child, pid: Promise.resolve(child.pid) };
+  }
+  const remote = [
+    `cd ${shellQuote(roleConfig.repoRoot)}`,
+    `printf '${REMOTE_PID_PREFIX}%s\\n' "$$" >&2`,
+    `exec env ${Object.entries(roleConfig.environment)
+      .map(([key, value]) => `${key}=${shellQuote(value)}`).join(' ')} `
+      + roleConfig.command.map(shellQuote).join(' '),
+  ].join(' && ');
+  const child = spawn('ssh', ['-T', roleConfig.sshTarget!, remote], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const pid = new Promise<number>((resolvePid, rejectPid) => {
+    let buffer = '';
+    const timeout = setTimeout(() => rejectPid(new Error('remote PID marker timed out')), 30_000);
+    child.stderr.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      const match = new RegExp(`${REMOTE_PID_PREFIX}(\\d+)`, 'u').exec(buffer);
+      if (!match) return;
+      clearTimeout(timeout);
+      const value = Number(match[1]);
+      if (!Number.isSafeInteger(value) || value < 1) rejectPid(new Error('remote PID is invalid'));
+      else resolvePid(value);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      rejectPid(new Error(`remote process exited before PID marker (${String(code)}/${String(signal)})`));
+    });
+  });
+  return { child, pid };
+}
+
+async function runtimeProvenance(role: TestnetOperatorRoleV1): Promise<{
+  sourceCommit: string;
+  runtimeManifestDigest: string;
+}> {
+  if (role.transport === 'local') {
+    const sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: role.repoRoot,
+      encoding: 'utf8',
+    }).trim();
+    const manifest = buildGate2RuntimeManifestV1(role.repoRoot, sourceCommit);
+    return { sourceCommit, runtimeManifestDigest: manifest.manifestDigest };
+  }
+  const output = await roleCapture(role, [
+    'node',
+    '--import',
+    'tsx',
+    'devnet/rfc64-m1-selective-coverage/print-runtime-provenance.ts',
+    role.repoRoot,
+  ], role.repoRoot);
+  let parsed: unknown;
+  try { parsed = JSON.parse(output.trim().split(/\r?\n/u).at(-1) ?? ''); } catch (error) {
+    throw new Error('remote runtime provenance is not JSON', { cause: error });
+  }
+  const row = requiredRecord(parsed, 'remote runtime provenance');
+  return {
+    sourceCommit: requiredText(row['sourceCommit'], 'remote source commit'),
+    runtimeManifestDigest: requiredText(row['runtimeManifestDigest'], 'remote runtime digest'),
+  };
+}
+
+async function waitForStatus(
+  role: TestnetOperatorRoleV1,
+  cfg: TestnetOperatorConfigV1,
+): Promise<Record<string, unknown>> {
+  return await poll('node status', cfg, async () => {
+    const response = await requestJson(role, '/api/status').catch(() => undefined);
+    return response?.status === 200 && looseRecord(response.body)
+      ? response.body as Record<string, unknown>
+      : undefined;
+  });
+}
+
+async function waitForJournal(
+  role: TestnetOperatorRoleV1,
+  cfg: TestnetOperatorConfigV1,
+): Promise<Record<string, unknown>> {
+  return await poll('node sync evidence journal', cfg, async () => {
+    const response = await requestJson(
+      role,
+      '/api/diagnostics/sync-coverage-evidence?afterSequence=0',
+    ).catch(() => undefined);
+    return response?.status === 200 && looseRecord(response.body)
+      ? response.body as Record<string, unknown>
+      : undefined;
+  });
+}
+
+async function dataDirectoryIdentity(role: TestnetOperatorRoleV1): Promise<string> {
+  if (role.transport === 'local') {
+    const path = realpathSync(role.dataDir);
+    const stat = statSync(path);
+    return `${hostname()}|${stat.dev}:${stat.ino}|${path}`;
+  }
+  const output = await roleCapture(role, [
+    'sh', '-lc',
+    `path=$(readlink -f ${shellQuote(role.dataDir)}) && stat -Lc '%d:%i' "$path" && printf '%s\\n' "$path"`,
+  ]);
+  const parts = output.trim().split(/\r?\n/u);
+  if (parts.length !== 2) throw new Error('remote data directory identity is malformed');
+  return `${(await roleCapture(role, ['hostname'])).trim()}|${parts[0]}|${parts[1]}`;
+}
+
+async function roleCapture(
+  role: TestnetOperatorRoleV1,
+  command: readonly string[],
+  cwd?: string,
+): Promise<string> {
+  if (role.transport === 'local') {
+    return execFileSync(command[0]!, [...command.slice(1)], {
+      cwd,
+      encoding: 'utf8',
+      env: { ...process.env, ...role.environment },
+    });
+  }
+  const remote = `${cwd ? `cd ${shellQuote(cwd)} && ` : ''}${command.map(shellQuote).join(' ')}`;
+  return execFileSync('ssh', ['-T', role.sshTarget!, remote], { encoding: 'utf8' });
+}
+
+async function poll<T>(
+  label: string,
+  cfg: TestnetOperatorConfigV1,
+  probe: () => Promise<T | undefined>,
+): Promise<T> {
+  const deadline = Date.now() + cfg.operationTimeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const result = await probe();
+      if (result !== undefined) return result;
+    } catch (error) {
+      if (error instanceof FatalPollError) throw error;
+      lastError = error;
+    }
+    await new Promise((done) => setTimeout(done, cfg.pollIntervalMs));
+  }
+  throw new Error(`timed out waiting for ${label}`, { cause: lastError });
+}
+
+class FatalPollError extends Error {}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function parseCommand(line: string): RuntimeCommand {
+  let parsed: unknown;
+  try { parsed = JSON.parse(line); } catch (error) {
+    throw new Error('M1 operator command is not JSON', { cause: error });
+  }
+  const row = requiredRecord(parsed, 'M1 operator command');
+  if (row['schema'] !== COMMAND_SCHEMA
+    || row['protocol'] !== SELECTIVE_COVERAGE_RUNTIME_PROTOCOL
+    || typeof row['sessionNonce'] !== 'string'
+    || !/^[0-9a-f]{64}$/u.test(row['sessionNonce'])
+    || !Number.isSafeInteger(row['sequence'])
+    || (row['sequence'] as number) < 0
+    || typeof row['command'] !== 'string') {
+    throw new TypeError('M1 operator command envelope is invalid');
+  }
+  return {
+    schema: COMMAND_SCHEMA,
+    protocol: SELECTIVE_COVERAGE_RUNTIME_PROTOCOL,
+    sessionNonce: row['sessionNonce'],
+    sequence: row['sequence'] as number,
+    command: row['command'],
+    payload: requiredRecord(row['payload'], 'M1 operator command payload'),
+  };
+}
+
+function emit(command: RuntimeCommand, ok: boolean, value: unknown): void {
+  const result = ok
+    ? { schema: RESULT_SCHEMA, protocol: SELECTIVE_COVERAGE_RUNTIME_PROTOCOL,
+        sessionNonce: command.sessionNonce, sequence: command.sequence, ok: true, value }
+    : { schema: RESULT_SCHEMA, protocol: SELECTIVE_COVERAGE_RUNTIME_PROTOCOL,
+        sessionNonce: command.sessionNonce, sequence: command.sequence, ok: false, error: value };
+  process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(result)}\n`);
+}
+
+function role(value: unknown): SelectiveCoverageRuntimeRole {
+  if (value !== 'publisher' && value !== 'edge' && value !== 'core') {
+    throw new TypeError('runtime role is invalid');
+  }
+  return value;
+}
+
+function wave(value: unknown): 'selected' | 'final' {
+  if (value !== 'selected' && value !== 'final') throw new TypeError('publication wave is invalid');
+  return value;
+}
+
+function requiredRecord(value: unknown, label: string): Record<string, unknown> {
+  const row = looseRecord(value);
+  if (!row) throw new TypeError(`${label} must be a plain object`);
+  return row;
+}
+
+function looseRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function requiredText(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length < 1 || value.length > 4_096) {
+    throw new TypeError(`${label} must be a bounded non-empty string`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new TypeError(`${label} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function stringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new TypeError(`${label} must be a string array`);
+  }
+  return [...value] as string[];
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/gu, `'"'"'`)}'`;
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts
@@ -8,6 +8,7 @@ import test from 'node:test';
 import { createRfc64SemanticSnapshot } from '../_bootstrap/rfc64-evidence.ts';
 import {
   TESTNET_OPERATOR_CONFIG_SCHEMA,
+  buildTestnetContextGraphCreateRequest,
   observeGraph,
   readTestnetOperatorConfig,
   type TestnetOperatorConfigV1,
@@ -55,6 +56,27 @@ test('operator config decoder accepts the closed five-graph plan and rejects unk
 
   writeFileSync(path, JSON.stringify({ ...config(), typoThatWouldOtherwiseBeIgnored: true }));
   assert.throws(() => readTestnetOperatorConfig(path), /operator config has an invalid key set/u);
+});
+
+test('testnet corpus registration never turns a public cell private through an allowlist', () => {
+  const common = {
+    contextGraphId: 'm1-test',
+    name: 'M1 test',
+    agentAddress: `0x${'a'.repeat(40)}`,
+    publishPolicy: 0 as const,
+  };
+  const publicRequest = buildTestnetContextGraphCreateRequest({
+    ...common,
+    accessPolicy: 0,
+  });
+  const privateRequest = buildTestnetContextGraphCreateRequest({
+    ...common,
+    accessPolicy: 1,
+  });
+  assert.equal(Object.hasOwn(publicRequest, 'allowedAgents'), false);
+  assert.deepEqual(privateRequest['allowedAgents'], [common.agentAddress]);
+  assert.equal(publicRequest['register'], true);
+  assert.equal(privateRequest['register'], true);
 });
 
 test('exact graph observation derives VM and SWM evidence from scoped data and metadata queries', async (context) => {

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { createRfc64SemanticSnapshot } from '../_bootstrap/rfc64-evidence.ts';
+import {
+  TESTNET_OPERATOR_CONFIG_SCHEMA,
+  observeGraph,
+  readTestnetOperatorConfig,
+  type TestnetOperatorConfigV1,
+  type TestnetOperatorGraphV1,
+  type TestnetOperatorRoleV1,
+} from './testnet-operator-common.ts';
+
+const graph = (index: number): TestnetOperatorGraphV1 => ({
+  contextGraphId: `cg-${index}`,
+  accessPolicy: index > 3 ? 1 : 0,
+  publishPolicy: index % 2 as 0 | 1,
+  edgePolicy: index === 1 ? 'on-demand' : index === 2 ? 'always-on' : 'unselected',
+  assets: [
+    { name: `selected-${index}`, subject: `urn:test:g${index}:selected`, ual: `did:dkg:test/0x${'1'.repeat(40)}/${index}`, wave: 'selected' },
+    { name: `final-${index}`, subject: `urn:test:g${index}:final`, ual: `did:dkg:test/0x${'2'.repeat(40)}/${index}`, wave: 'final' },
+  ],
+});
+
+function config(apiUrl = 'http://127.0.0.1:9999'): TestnetOperatorConfigV1 {
+  const role: TestnetOperatorRoleV1 = {
+    transport: 'local',
+    apiUrl,
+    repoRoot: '/tmp/repo',
+    dataDir: '/tmp/data',
+    command: ['node', 'daemon.js'],
+    environment: {},
+  };
+  return {
+    schema: TESTNET_OPERATOR_CONFIG_SCHEMA,
+    roles: { publisher: role, edge: role, core: role },
+    graphs: [1, 2, 3, 4, 5].map(graph),
+    pollIntervalMs: 10,
+    operationTimeoutMs: 100,
+  };
+}
+
+test('operator config decoder accepts the closed five-graph plan and rejects unknown input', (context) => {
+  const directory = mkdtempSync(join(tmpdir(), 'rfc64-m1-operator-'));
+  context.after(() => rmSync(directory, { recursive: true, force: true }));
+  const path = join(directory, 'operator.json');
+  writeFileSync(path, JSON.stringify(config()));
+  const decoded = readTestnetOperatorConfig(path);
+  assert.equal(decoded.graphs.length, 5);
+  assert.equal(Object.isFrozen(decoded.graphs), true);
+
+  writeFileSync(path, JSON.stringify({ ...config(), typoThatWouldOtherwiseBeIgnored: true }));
+  assert.throws(() => readTestnetOperatorConfig(path), /operator config has an invalid key set/u);
+});
+
+test('exact graph observation derives VM and SWM evidence from scoped data and metadata queries', async (context) => {
+  const requests: Array<Record<string, unknown>> = [];
+  const server = createServer((request, response) => {
+    let raw = '';
+    request.setEncoding('utf8');
+    request.on('data', (chunk) => { raw += chunk; });
+    request.on('end', () => {
+      const body = JSON.parse(raw) as Record<string, unknown>;
+      requests.push(body);
+      const sparql = String(body['sparql']);
+      const bindings = sparql.includes('COUNT(*)')
+        ? [{ count: { type: 'literal', value: '7', datatype: 'http://www.w3.org/2001/XMLSchema#integer' } }]
+        : [
+            { s: { type: 'uri', value: 'urn:test:g1:selected' }, p: { type: 'uri', value: 'urn:test:p:1' }, o: { type: 'literal', value: 'alpha' } },
+            { s: '<urn:test:g1:selected>', p: '<urn:test:p:2>', o: '<urn:test:o:2>' },
+          ];
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ result: { bindings } }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  context.after(() => server.close());
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('test server did not bind TCP');
+  const role = config(`http://127.0.0.1:${address.port}`).roles.publisher;
+  const plan = graph(1);
+
+  const observed = await observeGraph(role, plan);
+  const expected = await createRfc64SemanticSnapshot([{
+    ual: plan.assets[0]!.ual,
+    semanticNQuads: [
+      `<${plan.assets[0]!.subject}> <urn:test:p:1> "alpha" .`,
+      `<${plan.assets[0]!.subject}> <urn:test:p:2> <urn:test:o:2> .`,
+    ],
+  }]);
+  for (const plane of [observed.vm, observed.swm]) {
+    assert.equal(plane.reportedComplete, true);
+    assert.equal(plane.headDigest, expected.ualsSha256);
+    assert.equal(plane.inventoryDigest, expected.semanticNQuadsSha256);
+    assert.equal(plane.assetCount, 1);
+    assert.equal(plane.dataTripleCount, 2);
+    assert.equal(plane.metadataTripleCount, 7);
+  }
+  assert.equal(requests.length, 4);
+  assert.equal(requests.filter((body) => body['includeContextGraphPartitions'] === true).length, 2);
+  assert.deepEqual(
+    new Set(requests.filter((body) => body['view']).map((body) => body['view'])),
+    new Set(['verifiable-memory', 'shared-working-memory']),
+  );
+});
+
+test('exact graph observation rejects unplanned payload anywhere in the scoped plane', async (context) => {
+  const server = createServer((request, response) => {
+    let raw = '';
+    request.setEncoding('utf8');
+    request.on('data', (chunk) => { raw += chunk; });
+    request.on('end', () => {
+      const body = JSON.parse(raw) as Record<string, unknown>;
+      const bindings = String(body['sparql']).includes('COUNT(*)')
+        ? [{ count: '"0"^^<http://www.w3.org/2001/XMLSchema#integer>' }]
+        : [{ s: '<urn:test:unexpected>', p: '<urn:test:p>', o: '"extra"' }];
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ result: { bindings } }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  context.after(() => server.close());
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('test server did not bind TCP');
+  const role = config(`http://127.0.0.1:${address.port}`).roles.publisher;
+
+  await assert.rejects(
+    observeGraph(role, graph(1)),
+    /contains an unplanned subject/u,
+  );
+});

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-common.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-common.ts
@@ -1,0 +1,460 @@
+import { readFileSync } from 'node:fs';
+
+import {
+  createRfc64SemanticSnapshot,
+  type Rfc64KnowledgeAssetObservation,
+} from '../_bootstrap/rfc64-evidence.ts';
+import type {
+  GraphObservationV1,
+  GraphSnapshotExpectationV1,
+  PlaneObservationV1,
+} from './manifest.ts';
+
+export const TESTNET_OPERATOR_CONFIG_SCHEMA =
+  'dkg-rfc64-m1-testnet-operator-config-v1' as const;
+
+export interface TestnetOperatorAssetV1 {
+  readonly name: string;
+  readonly subject: string;
+  readonly ual: string;
+  readonly wave: 'selected' | 'final';
+}
+
+export interface TestnetOperatorGraphV1 {
+  readonly contextGraphId: string;
+  readonly accessPolicy: 0 | 1;
+  readonly publishPolicy: 0 | 1;
+  readonly edgePolicy: 'always-on' | 'on-demand' | 'unselected';
+  readonly assets: readonly TestnetOperatorAssetV1[];
+}
+
+export interface TestnetOperatorRoleV1 {
+  readonly transport: 'local' | 'ssh';
+  readonly apiUrl: string;
+  readonly repoRoot: string;
+  readonly dataDir: string;
+  readonly command: readonly string[];
+  readonly environment: Readonly<Record<string, string>>;
+  readonly authTokenFile?: string;
+  readonly sshTarget?: string;
+}
+
+export interface TestnetOperatorConfigV1 {
+  readonly schema: typeof TESTNET_OPERATOR_CONFIG_SCHEMA;
+  readonly roles: Readonly<Record<'publisher' | 'edge' | 'core', TestnetOperatorRoleV1>>;
+  readonly graphs: readonly TestnetOperatorGraphV1[];
+  readonly pollIntervalMs: number;
+  readonly operationTimeoutMs: number;
+}
+
+export interface HttpResult {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+export type SparqlBindingCell = string | {
+  readonly value?: string;
+  readonly datatype?: string;
+  readonly type?: string;
+  readonly 'xml:lang'?: string;
+  readonly lang?: string;
+};
+
+export function readTestnetOperatorConfig(path: string): TestnetOperatorConfigV1 {
+  let input: unknown;
+  try {
+    input = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    throw new Error('M1 testnet operator config is not valid JSON', { cause: error });
+  }
+  const root = record(input, 'operator config');
+  assertExactKeys(root, ['schema', 'roles', 'graphs', 'pollIntervalMs', 'operationTimeoutMs'], 'operator config');
+  if (root['schema'] !== TESTNET_OPERATOR_CONFIG_SCHEMA) {
+    throw new TypeError('M1 testnet operator config schema is unsupported');
+  }
+  const rolesInput = record(root['roles'], 'operator roles');
+  assertExactKeys(rolesInput, ['publisher', 'edge', 'core'], 'operator roles');
+  const roles = {
+    publisher: parseRole(rolesInput['publisher'], 'publisher'),
+    edge: parseRole(rolesInput['edge'], 'edge'),
+    core: parseRole(rolesInput['core'], 'core'),
+  } as const;
+  const graphsInput = array(root['graphs'], 'operator graphs');
+  if (graphsInput.length !== 5) {
+    throw new RangeError('M1 testnet operator config requires exactly five graphs');
+  }
+  const graphs = graphsInput.map((value, index): TestnetOperatorGraphV1 => {
+    const row = record(value, `operator graph ${index}`);
+    assertExactKeys(
+      row,
+      ['contextGraphId', 'accessPolicy', 'publishPolicy', 'edgePolicy', 'assets'],
+      `operator graph ${index}`,
+    );
+    const accessPolicy = row['accessPolicy'];
+    const publishPolicy = row['publishPolicy'];
+    const edgePolicy = row['edgePolicy'];
+    if ((accessPolicy !== 0 && accessPolicy !== 1)
+      || (publishPolicy !== 0 && publishPolicy !== 1)
+      || (edgePolicy !== 'always-on'
+        && edgePolicy !== 'on-demand'
+        && edgePolicy !== 'unselected')) {
+      throw new TypeError(`operator graph ${index} has an invalid policy`);
+    }
+    const assets = array(row['assets'], `operator graph ${index} assets`)
+      .map((asset, assetIndex): TestnetOperatorAssetV1 => {
+        const item = record(asset, `operator graph ${index} asset ${assetIndex}`);
+        assertExactKeys(item, ['name', 'subject', 'ual', 'wave'], `operator graph ${index} asset ${assetIndex}`);
+        const wave = item['wave'];
+        if (wave !== 'selected' && wave !== 'final') {
+          throw new TypeError(`operator graph ${index} asset ${assetIndex} has an invalid wave`);
+        }
+        return {
+          name: boundedText(item['name'], 'asset name'),
+          subject: absoluteIri(item['subject'], 'asset subject'),
+          ual: boundedText(item['ual'], 'asset UAL'),
+          wave,
+        };
+      });
+    if (assets.length !== 2
+      || assets.filter((asset) => asset.wave === 'selected').length !== 1
+      || assets.filter((asset) => asset.wave === 'final').length !== 1) {
+      throw new RangeError(`operator graph ${index} requires one asset per wave`);
+    }
+    return {
+      contextGraphId: boundedText(row['contextGraphId'], 'context graph ID'),
+      accessPolicy,
+      publishPolicy,
+      edgePolicy,
+      assets,
+    };
+  });
+  const pollIntervalMs = positiveInteger(root['pollIntervalMs'], 'pollIntervalMs');
+  const operationTimeoutMs = positiveInteger(root['operationTimeoutMs'], 'operationTimeoutMs');
+  return Object.freeze({
+    schema: TESTNET_OPERATOR_CONFIG_SCHEMA,
+    roles: Object.freeze(roles),
+    graphs: Object.freeze(graphs.map((graph) => Object.freeze({
+      ...graph,
+      assets: Object.freeze(graph.assets.map((asset) => Object.freeze({ ...asset }))),
+    }))),
+    pollIntervalMs,
+    operationTimeoutMs,
+  });
+}
+
+export async function requestJson(
+  role: TestnetOperatorRoleV1,
+  path: string,
+  init: RequestInit = {},
+): Promise<HttpResult> {
+  const headers = new Headers(init.headers);
+  if (init.body !== undefined) headers.set('content-type', 'application/json');
+  if (role.authTokenFile) {
+    const token = readFileSync(role.authTokenFile, 'utf8').trim();
+    if (!token) throw new Error(`empty node-admin token: ${role.authTokenFile}`);
+    headers.set('authorization', `Bearer ${token}`);
+  }
+  const response = await fetch(`${role.apiUrl.replace(/\/$/u, '')}${path}`, {
+    ...init,
+    headers,
+  });
+  const text = await response.text();
+  let body: unknown = null;
+  if (text) {
+    try { body = JSON.parse(text); } catch { body = text; }
+  }
+  return { status: response.status, body };
+}
+
+export async function requireJson(
+  role: TestnetOperatorRoleV1,
+  path: string,
+  init: RequestInit = {},
+  accepted: readonly number[] = [200],
+): Promise<Record<string, unknown>> {
+  const result = await requestJson(role, path, init);
+  if (!accepted.includes(result.status)) {
+    throw new Error(
+      `M1 node request failed ${result.status} ${path}: ${JSON.stringify(result.body).slice(0, 1_000)}`,
+    );
+  }
+  return record(result.body, `response from ${path}`);
+}
+
+export async function observeGraph(
+  role: TestnetOperatorRoleV1,
+  graph: TestnetOperatorGraphV1,
+): Promise<GraphObservationV1> {
+  const [vm, swm] = await Promise.all([
+    observePlane(role, graph, 'vm'),
+    observePlane(role, graph, 'swm'),
+  ]);
+  return { contextGraphId: graph.contextGraphId, vm, swm };
+}
+
+export async function observeGraphSnapshot(
+  role: TestnetOperatorRoleV1,
+  graph: TestnetOperatorGraphV1,
+): Promise<GraphSnapshotExpectationV1> {
+  const observation = await observeGraph(role, graph);
+  if (!observation.vm.reportedComplete || !observation.swm.reportedComplete
+    || observation.vm.headDigest === null || observation.vm.inventoryDigest === null
+    || observation.swm.headDigest === null || observation.swm.inventoryDigest === null) {
+    throw new Error(`context graph ${graph.contextGraphId} is not complete on both planes`);
+  }
+  return {
+    vm: {
+      headDigest: observation.vm.headDigest,
+      inventoryDigest: observation.vm.inventoryDigest,
+      assetCount: observation.vm.assetCount,
+      dataTripleCount: observation.vm.dataTripleCount,
+    },
+    swm: {
+      headDigest: observation.swm.headDigest,
+      inventoryDigest: observation.swm.inventoryDigest,
+      assetCount: observation.swm.assetCount,
+      dataTripleCount: observation.swm.dataTripleCount,
+    },
+  };
+}
+
+async function observePlane(
+  role: TestnetOperatorRoleV1,
+  graph: TestnetOperatorGraphV1,
+  plane: 'vm' | 'swm',
+): Promise<PlaneObservationV1> {
+  const bindings = await queryBindings(role, {
+    sparql: 'SELECT ?s ?p ?o WHERE { ?s ?p ?o } ORDER BY ?s ?p ?o',
+    contextGraphId: graph.contextGraphId,
+    view: plane === 'vm' ? 'verifiable-memory' : 'shared-working-memory',
+  });
+  const assetBySubject = new Map(graph.assets.map((asset) => [asset.subject, asset]));
+  const linesBySubject = new Map<string, string[]>();
+  for (const binding of bindings) {
+    const subject = iriBindingValue(binding['s'], 'subject');
+    const asset = assetBySubject.get(subject);
+    if (!asset) {
+      throw new Error(
+        `${plane.toUpperCase()} scope for ${graph.contextGraphId} contains an unplanned subject: ${subject}`,
+      );
+    }
+    const predicate = bindingTerm(binding['p'], 'predicate');
+    const object = bindingTerm(binding['o'], 'object');
+    const lines = linesBySubject.get(subject) ?? [];
+    lines.push(`<${subject}> ${predicate} ${object} .`);
+    linesBySubject.set(subject, lines);
+  }
+  const observations: Rfc64KnowledgeAssetObservation[] = graph.assets.flatMap((asset) => {
+    const lines = linesBySubject.get(asset.subject);
+    return lines ? [{ ual: asset.ual, semanticNQuads: lines }] : [];
+  });
+  const snapshot = await createRfc64SemanticSnapshot(observations);
+  const metadataTripleCount = await queryMetadataCount(role, graph.contextGraphId, plane);
+  if (snapshot.kaCount === 0) {
+    return {
+      reportedComplete: false,
+      headDigest: null,
+      inventoryDigest: null,
+      assetCount: 0,
+      metadataTripleCount,
+      dataTripleCount: 0,
+    };
+  }
+  return {
+    reportedComplete: true,
+    headDigest: snapshot.ualsSha256,
+    inventoryDigest: snapshot.semanticNQuadsSha256,
+    assetCount: snapshot.kaCount,
+    metadataTripleCount,
+    dataTripleCount: snapshot.quadCount,
+  };
+}
+
+async function queryMetadataCount(
+  role: TestnetOperatorRoleV1,
+  contextGraphId: string,
+  plane: 'vm' | 'swm',
+): Promise<number> {
+  const graphIri = plane === 'vm'
+    ? `did:dkg:context-graph:${contextGraphId}/_meta`
+    : `did:dkg:context-graph:${contextGraphId}/_shared_memory_meta`;
+  const bindings = await queryBindings(role, {
+    sparql: `SELECT (COUNT(*) AS ?count) WHERE { GRAPH <${graphIri}> { ?s ?p ?o } }`,
+    contextGraphId,
+    includeContextGraphPartitions: true,
+  });
+  if (bindings.length !== 1) {
+    throw new Error(`metadata count query returned ${bindings.length} rows for ${contextGraphId}`);
+  }
+  const raw = cellValue(bindings[0]!['count']);
+  const match = /^(?:")?(\d+)/u.exec(raw);
+  if (!match) throw new Error(`metadata count is malformed for ${contextGraphId}`);
+  const count = Number(match[1]);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error(`metadata count is outside the safe integer range for ${contextGraphId}`);
+  }
+  return count;
+}
+
+async function queryBindings(
+  role: TestnetOperatorRoleV1,
+  body: Record<string, unknown>,
+): Promise<Array<Record<string, SparqlBindingCell>>> {
+  const response = await requireJson(role, '/api/query', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  const result = record(response['result'], 'query result');
+  const bindings = result['bindings'];
+  if (!Array.isArray(bindings)) throw new TypeError('query result bindings are not an array');
+  return bindings.map((binding, index) =>
+    record(binding, `query binding ${index}`) as Record<string, SparqlBindingCell>);
+}
+
+function bindingTerm(cell: SparqlBindingCell | undefined, position: 'predicate' | 'object'): string {
+  if (cell === undefined) throw new TypeError(`missing SPARQL ${position} binding`);
+  if (typeof cell === 'string') {
+    if (position === 'predicate' && /^<[^>]+>$/u.test(cell)) return cell;
+    if (position === 'object' && (/^<[^>]+>$/u.test(cell)
+      || /^_:[A-Za-z0-9._-]+$/u.test(cell)
+      || /^"/u.test(cell))) return cell;
+    if (position === 'predicate' && /^[a-z][a-z0-9+.-]*:/iu.test(cell)) return `<${cell}>`;
+    throw new TypeError(`invalid SPARQL ${position} term`);
+  }
+  const value = cell.value;
+  if (typeof value !== 'string') throw new TypeError(`missing SPARQL ${position} value`);
+  if (cell.type === 'uri') return /^<[^>]+>$/u.test(value) ? value : `<${value}>`;
+  if (cell.type === 'bnode') return value.startsWith('_:') ? value : `_:${value}`;
+  if (position === 'predicate') {
+    return /^<[^>]+>$/u.test(value) ? value : `<${value}>`;
+  }
+  const escaped = JSON.stringify(value);
+  const language = cell['xml:lang'] ?? cell.lang;
+  if (language) return `${escaped}@${language}`;
+  if (cell.datatype && cell.datatype !== 'http://www.w3.org/2001/XMLSchema#string') {
+    return `${escaped}^^<${cell.datatype}>`;
+  }
+  return escaped;
+}
+
+function iriBindingValue(cell: SparqlBindingCell | undefined, label: string): string {
+  if (cell === undefined) throw new TypeError(`missing SPARQL ${label} binding`);
+  const value = typeof cell === 'string' ? cell : cell.value;
+  if (typeof value !== 'string') throw new TypeError(`missing SPARQL ${label} value`);
+  const unwrapped = /^<([^>]+)>$/u.exec(value)?.[1] ?? value;
+  return absoluteIri(unwrapped, `SPARQL ${label}`);
+}
+
+function cellValue(cell: SparqlBindingCell | undefined): string {
+  if (typeof cell === 'string') return cell;
+  return cell?.value ?? '';
+}
+
+function parseRole(value: unknown, name: string): TestnetOperatorRoleV1 {
+  const row = record(value, `${name} role`);
+  assertExactKeys(
+    row,
+    ['transport', 'apiUrl', 'repoRoot', 'dataDir', 'command', 'environment', 'authTokenFile', 'sshTarget'],
+    `${name} role`,
+    ['authTokenFile', 'sshTarget'],
+  );
+  const transport = row['transport'];
+  if (transport !== 'local' && transport !== 'ssh') {
+    throw new TypeError(`${name} role transport is invalid`);
+  }
+  const command = array(row['command'], `${name} command`).map((entry) =>
+    boundedText(entry, `${name} command argument`));
+  if (command.length < 1) throw new RangeError(`${name} command is empty`);
+  const envInput = record(row['environment'], `${name} environment`);
+  const environment: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(envInput)) {
+    if (!/^[A-Z_][A-Z0-9_]*$/u.test(key)) throw new TypeError(`${name} environment key is invalid`);
+    environment[key] = boundedText(entry, `${name} environment value`);
+  }
+  const sshTarget = row['sshTarget'] === undefined
+    ? undefined
+    : boundedText(row['sshTarget'], `${name} sshTarget`);
+  if ((transport === 'ssh') !== (sshTarget !== undefined)) {
+    throw new TypeError(`${name} ssh transport requires exactly one sshTarget`);
+  }
+  if (sshTarget !== undefined
+    && (!/^(?:[A-Za-z0-9._-]+@)?[A-Za-z0-9](?:[A-Za-z0-9.:-]*[A-Za-z0-9])?$/u.test(sshTarget)
+      || sshTarget.startsWith('-'))) {
+    throw new TypeError(`${name} sshTarget is invalid`);
+  }
+  return Object.freeze({
+    transport,
+    apiUrl: httpUrl(row['apiUrl'], `${name} apiUrl`),
+    repoRoot: boundedText(row['repoRoot'], `${name} repoRoot`),
+    dataDir: boundedText(row['dataDir'], `${name} dataDir`),
+    command: Object.freeze(command),
+    environment: Object.freeze(environment),
+    ...(row['authTokenFile'] === undefined
+      ? {}
+      : { authTokenFile: boundedText(row['authTokenFile'], `${name} authTokenFile`) }),
+    ...(sshTarget === undefined ? {} : { sshTarget }),
+  });
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)
+    || Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${label} must be a plain object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string,
+  optional: readonly string[] = [],
+): void {
+  const allowedSet = new Set(allowed);
+  const optionalSet = new Set(optional);
+  const unknown = Object.keys(value).filter((key) => !allowedSet.has(key));
+  const missing = allowed.filter((key) => !optionalSet.has(key) && !Object.hasOwn(value, key));
+  if (unknown.length > 0 || missing.length > 0) {
+    throw new TypeError(
+      `${label} has an invalid key set (missing=${missing.join(',') || 'none'}; unknown=${unknown.join(',') || 'none'})`,
+    );
+  }
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new TypeError(`${label} must be an array`);
+  return value;
+}
+
+function boundedText(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length < 1 || value.length > 4_096) {
+    throw new TypeError(`${label} must be a bounded non-empty string`);
+  }
+  return value;
+}
+
+function absoluteIri(value: unknown, label: string): string {
+  const text = boundedText(value, label);
+  let parsed: URL;
+  try { parsed = new URL(text); } catch (error) {
+    throw new TypeError(`${label} must be an absolute IRI`, { cause: error });
+  }
+  if (!parsed.protocol) throw new TypeError(`${label} must be an absolute IRI`);
+  return text;
+}
+
+function httpUrl(value: unknown, label: string): string {
+  const text = absoluteIri(value, label);
+  const parsed = new URL(text);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new TypeError(`${label} must use http or https`);
+  }
+  return text;
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw new TypeError(`${label} must be a positive safe integer`);
+  }
+  return value as number;
+}

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-common.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-common.ts
@@ -52,6 +52,25 @@ export interface HttpResult {
   readonly body: unknown;
 }
 
+export function buildTestnetContextGraphCreateRequest(input: {
+  readonly contextGraphId: string;
+  readonly name: string;
+  readonly agentAddress: string;
+  readonly accessPolicy: 0 | 1;
+  readonly publishPolicy: 0 | 1;
+}): Record<string, unknown> {
+  return {
+    id: boundedText(input.contextGraphId, 'context graph ID'),
+    name: boundedText(input.name, 'context graph name'),
+    accessPolicy: input.accessPolicy,
+    publishPolicy: input.publishPolicy,
+    ...(input.accessPolicy === 1
+      ? { allowedAgents: [boundedText(input.agentAddress, 'agent address')] }
+      : {}),
+    register: true,
+  };
+}
+
 export type SparqlBindingCell = string | {
   readonly value?: string;
   readonly datatype?: string;

--- a/devnet/rfc64-m1-selective-coverage/tsconfig.json
+++ b/devnet/rfc64-m1-selective-coverage/tsconfig.json
@@ -10,5 +10,5 @@
     "sourceMap": false,
     "types": ["node"]
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "../_bootstrap/rdf-canonize.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test:m1:rfc64-selective-coverage": "pnpm run test:m1:rfc64-selective-coverage:generate && pnpm run test:m1:rfc64-selective-coverage:verify",
     "test:m1:rfc64-selective-coverage:generate": "node --import tsx devnet/rfc64-m1-selective-coverage/launch-live.ts",
     "test:m1:rfc64-selective-coverage:verify": "node --import tsx devnet/rfc64-m1-selective-coverage/verify-live.ts",
-    "test:m1:rfc64-selective-coverage:unit": "node --experimental-strip-types --test devnet/rfc64-m1-selective-coverage/verifier.test.ts devnet/rfc64-m1-selective-coverage/runtime.test.ts devnet/rfc64-m1-selective-coverage/process-runtime.test.ts devnet/rfc64-m1-selective-coverage/adapter-environment.test.ts devnet/rfc64-m1-selective-coverage/operator-input.test.ts devnet/rfc64-m1-selective-coverage/boundary-codec.test.ts",
+    "test:m1:rfc64-selective-coverage:unit": "node --experimental-strip-types --test devnet/rfc64-m1-selective-coverage/verifier.test.ts devnet/rfc64-m1-selective-coverage/runtime.test.ts devnet/rfc64-m1-selective-coverage/process-runtime.test.ts devnet/rfc64-m1-selective-coverage/adapter-environment.test.ts devnet/rfc64-m1-selective-coverage/operator-input.test.ts devnet/rfc64-m1-selective-coverage/boundary-codec.test.ts && node --import tsx --test devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts",
     "typecheck:m1:rfc64-selective-coverage": "tsc --project devnet/rfc64-m1-selective-coverage/tsconfig.json",
     "test:devnet:v10-core-flows": "vitest run --config devnet/v10-core-flows/vitest.config.ts",
     "test:devnet:v10-e2e": "vitest run --config devnet/v10-end-to-end/vitest.config.ts",


### PR DESCRIPTION
## Impact

This stacked PR closes the deployment gap between the fail-closed M1 evidence contract and a real testnet run. It adds a closed-schema operator adapter that controls isolated local or SSH-hosted Publisher, Edge, and Core CLI processes while all product data movement still uses DKG and chain paths.

Operators can now create a deterministic five-CG corpus spanning public/private, open/curated, on-demand/always-on/unselected cells; publish two VM and SWM waves; run the exact M1 sequence; and obtain a canonical artifact bound to the clean source head, runtime closure, corpus digest, three stable peer identities, process/restart identities, exact payload inventories, and automatic sync journals.

The adapter:

- cross-checks each live node reported commit against the full tested head;
- rejects unexpected payload anywhere in a scoped VM or SWM plane;
- distinguishes metadata-only state from actual data convergence;
- fails immediately on terminal catch-up errors while retaining bounded retry for transient transport/query errors;
- proves local or remote process and durable-directory identity;
- leaves existing live services untouched by using operator-provided isolated commands, ports, stores, and homes;
- never receives the corpus, trust anchor, or artifact paths from the launcher.

## Before

```mermaid
sequenceDiagram
  participant O as Operator
  participant G as M1 gate
  participant X as Missing deployment adapter
  O->>G: Start live test
  G->>X: Framed runtime command
  X--xG: No implementation supplied
  G-->>O: No testnet evidence
```

## After

```mermaid
sequenceDiagram
  participant O as Operator
  participant G as M1 gate
  participant A as Testnet operator adapter
  participant P as Isolated Publisher
  participant E as Isolated Edge
  participant C as Isolated Core
  O->>G: Start anchored live test
  G->>A: Sequenced runtime commands
  A->>P: Start and publish two VM and SWM waves
  A->>E: Select, sync, restart, and observe
  A->>C: Start cold and observe automatic public coverage
  P-->>A: Live identity and exact snapshots
  E-->>A: Job and reconciler journal evidence
  C-->>A: Bounded scheduler journal evidence
  A-->>G: Closed decoded observations
  G-->>O: Verified canonical PASS artifact
```

## Validation

- `pnpm typecheck:m1:rfc64-selective-coverage`
- `pnpm test:m1:rfc64-selective-coverage:unit` (75 existing contract tests plus 3 operator boundary/observation tests)
- live release-CLI adapter start/readiness/shutdown smoke
- live scoped metadata and VM query probe against the isolated local testnet node
- `git diff --check`

The full three-process testnet evidence run will be posted here after this exact head is staged on the isolated roles. No production or existing canary service is modified by this PR.