### PR TITLE
fix(cli): allow bounded graceful shutdown budget

### DIFF
--- a/devnet/rfc64-m1-selective-coverage/README.md
+++ b/devnet/rfc64-m1-selective-coverage/README.md
@@ -55,7 +55,7 @@ process is cryptographically bound to the reviewed source head:
 2. Publish the selected wave and read exact Publisher VM and SWM snapshots.
 3. Prove the Edge has no payload, then issue only the anchored on-demand and
    always-on user selections and retain their returned job IDs.
-4. Publish the final wave, restart the Edge into a new OS process, and require
+4. Publish/share the final plane-specific wave, restart the Edge into a new OS process, and require
    its actual reconciler record for always-on refresh. Observe on-demand data
    still at the selected snapshot with no active runtime mode.
 5. Issue the second explicit on-demand request and require exact final state.
@@ -104,7 +104,7 @@ Commands are:
 | Command | Required runtime action/evidence |
 | --- | --- |
 | `start` | Start the named role; independently return host identity, PID, process instance/wave IDs, `processStartedAt` as integer epoch milliseconds sourced from `Math.floor(performance.timeOrigin)`, durable-directory identity, peer ID, network, commit, and loaded-runtime digest. OS-process uniqueness is evaluated as `(hostIdentity, pid)`, so valid processes on different hosts may reuse a numeric PID. The command contains only the role, never the trust anchor. |
-| `publish-wave` | Publish the named anchored wave; return exact Publisher VM/SWM observations for every graph. |
+| `publish-wave` | Publish the named VM asset and separately share the named SWM asset for every graph; return exact stable Publisher VM/SWM observations. Distinct assets are required because confirmed VM publication intentionally consumes its own SWM root. |
 | `observe-edge` | Return exact Edge VM/SWM observations, effective runtime mode, and the actual producing job ID. |
 | `synchronize-edge` | Issue only the named explicit user selection; return its real job ID and terminal exact snapshot. |
 | `restart-edge` | Stop and restart Edge from the same durable data directory; return a receipt binding the old process instance/PID and observed exit to the new process instance/PID, stable directory identity, and peer identity. |
@@ -223,7 +223,8 @@ For the shipped TypeScript adapter, set the command to `node`, pass
 `["--import","tsx","devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts"]`
 as `DKG_RFC64_M1_ADAPTER_ARGS_JSON`, and provide the closed operator file via
 `DKG_RFC64_M1_OPERATOR_CONFIG`. `prepare-testnet-corpus.ts` creates and seals
-exactly two KAs in each of the five policy/selection cells, then writes both the
+exactly four KAs in each of the five policy/selection cells (one VM and one SWM
+asset per wave), then writes both the
 immutable corpus and the adapter graph plan. After probing stable identities for
 the three isolated data directories, `create-testnet-trust-anchor.ts` binds
 those peer IDs to the clean source/runtime manifest and corpus digest.

--- a/devnet/rfc64-m1-selective-coverage/prepare-testnet-corpus.ts
+++ b/devnet/rfc64-m1-selective-coverage/prepare-testnet-corpus.ts
@@ -73,45 +73,56 @@ for (const [graphIndex, policy] of policyCells.entries()) {
   }
 
   const assets: TestnetOperatorAssetV1[] = [];
-  const semantic: Rfc64KnowledgeAssetObservation[] = [];
+  const semantic: Record<'vm' | 'swm', Rfc64KnowledgeAssetObservation[]> = {
+    vm: [],
+    swm: [],
+  };
   let selectedSnapshot: GraphSnapshotExpectationV1 | undefined;
   for (const wave of ['selected', 'final'] as const) {
-    const name = `${wave}-${graphIndex + 1}`;
-    const subject = `urn:dkg:rfc64:m1:${runId}:g${graphIndex + 1}:${wave}`;
-    const lines = Array.from({ length: 24 }, (_, tripleIndex) => {
-      const predicate = `urn:dkg:rfc64:m1:predicate:${tripleIndex.toString().padStart(2, '0')}`;
-      const object = JSON.stringify(`${runId}|g${graphIndex + 1}|${wave}|${tripleIndex}`);
-      return `<${subject}> <${predicate}> ${object} .`;
-    });
-    const quads = lines.map((line) => {
-      const match = /^<([^>]+)> <([^>]+)> (.+) \.$/u.exec(line);
-      if (!match) throw new Error('generated M1 N-Quad is malformed');
-      return { subject: match[1], predicate: match[2], object: match[3] };
-    });
-    await requireJson(publisher, '/api/knowledge-assets', {
-      method: 'POST',
-      body: JSON.stringify({ contextGraphId, name, quads, finalize: true }),
-    }, [201]);
-    const descriptor = await requireJson(
-      publisher,
-      `/api/knowledge-assets/${encodeURIComponent(name)}?contextGraphId=${encodeURIComponent(contextGraphId)}`,
-    );
-    const ual = requiredText(descriptor['reservedUal'], `${contextGraphId}/${name} reserved UAL`);
-    assets.push({ name, subject, ual, wave });
-    semantic.push({ ual, semanticNQuads: lines });
-    const snapshot = await createRfc64SemanticSnapshot(semantic);
+    for (const plane of ['vm', 'swm'] as const) {
+      const name = `${wave}-${plane}-${graphIndex + 1}`;
+      const subject = `urn:dkg:rfc64:m1:${runId}:g${graphIndex + 1}:${wave}:${plane}`;
+      const lines = Array.from({ length: 24 }, (_, tripleIndex) => {
+        const predicate = `urn:dkg:rfc64:m1:predicate:${tripleIndex.toString().padStart(2, '0')}`;
+        const object = JSON.stringify(
+          `${runId}|g${graphIndex + 1}|${wave}|${plane}|${tripleIndex}`,
+        );
+        return `<${subject}> <${predicate}> ${object} .`;
+      });
+      const quads = lines.map((line) => {
+        const match = /^<([^>]+)> <([^>]+)> (.+) \.$/u.exec(line);
+        if (!match) throw new Error('generated M1 N-Quad is malformed');
+        return { subject: match[1], predicate: match[2], object: match[3] };
+      });
+      await requireJson(publisher, '/api/knowledge-assets', {
+        method: 'POST',
+        body: JSON.stringify({ contextGraphId, name, quads, finalize: true }),
+      }, [201]);
+      const descriptor = await requireJson(
+        publisher,
+        `/api/knowledge-assets/${encodeURIComponent(name)}?contextGraphId=${encodeURIComponent(contextGraphId)}`,
+      );
+      const ual = requiredText(
+        descriptor['reservedUal'],
+        `${contextGraphId}/${name} reserved UAL`,
+      );
+      assets.push({ name, subject, ual, wave, plane });
+      semantic[plane].push({ ual, semanticNQuads: lines });
+    }
+    const vmSnapshot = await createRfc64SemanticSnapshot(semantic.vm);
+    const swmSnapshot = await createRfc64SemanticSnapshot(semantic.swm);
     const expectation = {
       vm: {
-        headDigest: snapshot.ualsSha256,
-        inventoryDigest: snapshot.semanticNQuadsSha256,
-        assetCount: snapshot.kaCount,
-        dataTripleCount: snapshot.quadCount,
+        headDigest: vmSnapshot.ualsSha256,
+        inventoryDigest: vmSnapshot.semanticNQuadsSha256,
+        assetCount: vmSnapshot.kaCount,
+        dataTripleCount: vmSnapshot.quadCount,
       },
       swm: {
-        headDigest: snapshot.ualsSha256,
-        inventoryDigest: snapshot.semanticNQuadsSha256,
-        assetCount: snapshot.kaCount,
-        dataTripleCount: snapshot.quadCount,
+        headDigest: swmSnapshot.ualsSha256,
+        inventoryDigest: swmSnapshot.semanticNQuadsSha256,
+        assetCount: swmSnapshot.kaCount,
+        dataTripleCount: swmSnapshot.quadCount,
       },
     } satisfies GraphSnapshotExpectationV1;
     if (wave === 'selected') selectedSnapshot = expectation;
@@ -152,7 +163,7 @@ const operatorConfig = {
 writeJson(corpusPath, corpus);
 writeJson(configPath, operatorConfig);
 process.stdout.write(
-  `[rfc64-m1] prepared ${operatorGraphs.length} registered CGs and 10 sealed KAs; `
+  `[rfc64-m1] prepared ${operatorGraphs.length} registered CGs and 20 sealed KAs; `
     + `corpus=${corpusPath} operatorConfig=${configPath}\n`,
 );
 

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts
@@ -23,6 +23,7 @@ import type {
 import {
   observeGraph,
   readTestnetOperatorConfig,
+  resolveTestnetOperatorShutdownExitTimeoutMs,
   requestJson,
   requireJson,
   type TestnetOperatorConfigV1,
@@ -169,7 +170,10 @@ class TestnetOperatorController {
       }
       outcome = await withTimeout(
         running.exited,
-        Math.min(90_000, this.cfg.operationTimeoutMs),
+        resolveTestnetOperatorShutdownExitTimeoutMs(
+          this.cfg.roles[roleName],
+          this.cfg.operationTimeoutMs,
+        ),
         `${roleName} process exit after shutdown`,
       );
     } finally {

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts
@@ -198,7 +198,11 @@ class TestnetOperatorController {
     this.requireRunning('publisher');
     const publisher = this.cfg.roles.publisher;
     for (const graph of this.cfg.graphs) {
-      for (const asset of graph.assets.filter((candidate) => candidate.wave === selectedWave)) {
+      const waveAssets = graph.assets.filter((candidate) => candidate.wave === selectedWave);
+      // A confirmed VM publish intentionally consumes that asset's SWM root.
+      // Use distinct plane assets and publish VM first so the stable snapshot
+      // contains a real finalized VM asset plus a real off-chain SWM asset.
+      for (const asset of waveAssets.filter((candidate) => candidate.plane === 'vm')) {
         await requireJson(
           publisher,
           `/api/knowledge-assets/${encodeURIComponent(asset.name)}/swm/share`,
@@ -212,6 +216,16 @@ class TestnetOperatorController {
         const returnedUal = published['ual'];
         if (typeof returnedUal === 'string' && returnedUal.toLowerCase() !== asset.ual.toLowerCase()) {
           throw new Error(`${graph.contextGraphId}/${asset.name} published an unexpected UAL`);
+        }
+      }
+      for (const asset of waveAssets.filter((candidate) => candidate.plane === 'swm')) {
+        const shared = await requireJson(
+          publisher,
+          `/api/knowledge-assets/${encodeURIComponent(asset.name)}/swm/share`,
+          { method: 'POST', body: JSON.stringify({ contextGraphId: graph.contextGraphId }) },
+        );
+        if (shared['swmShared'] !== true || shared['sealed'] !== true) {
+          throw new Error(`${graph.contextGraphId}/${asset.name} did not produce a sealed SWM share`);
         }
       }
     }

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-adapter.ts
@@ -169,7 +169,7 @@ class TestnetOperatorController {
       }
       outcome = await withTimeout(
         running.exited,
-        30_000,
+        Math.min(90_000, this.cfg.operationTimeoutMs),
         `${roleName} process exit after shutdown`,
       );
     } finally {

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts
@@ -23,8 +23,10 @@ const graph = (index: number): TestnetOperatorGraphV1 => ({
   publishPolicy: index % 2 as 0 | 1,
   edgePolicy: index === 1 ? 'on-demand' : index === 2 ? 'always-on' : 'unselected',
   assets: [
-    { name: `selected-${index}`, subject: `urn:test:g${index}:selected`, ual: `did:dkg:test/0x${'1'.repeat(40)}/${index}`, wave: 'selected' },
-    { name: `final-${index}`, subject: `urn:test:g${index}:final`, ual: `did:dkg:test/0x${'2'.repeat(40)}/${index}`, wave: 'final' },
+    { name: `selected-vm-${index}`, subject: `urn:test:g${index}:selected:vm`, ual: `did:dkg:test/0x${'1'.repeat(40)}/${index}1`, wave: 'selected', plane: 'vm' },
+    { name: `selected-swm-${index}`, subject: `urn:test:g${index}:selected:swm`, ual: `did:dkg:test/0x${'1'.repeat(40)}/${index}2`, wave: 'selected', plane: 'swm' },
+    { name: `final-vm-${index}`, subject: `urn:test:g${index}:final:vm`, ual: `did:dkg:test/0x${'2'.repeat(40)}/${index}1`, wave: 'final', plane: 'vm' },
+    { name: `final-swm-${index}`, subject: `urn:test:g${index}:final:swm`, ual: `did:dkg:test/0x${'2'.repeat(40)}/${index}2`, wave: 'final', plane: 'swm' },
   ],
 });
 
@@ -57,6 +59,18 @@ test('operator config decoder accepts the closed five-graph plan and rejects unk
 
   writeFileSync(path, JSON.stringify({ ...config(), typoThatWouldOtherwiseBeIgnored: true }));
   assert.throws(() => readTestnetOperatorConfig(path), /operator config has an invalid key set/u);
+
+  const missingSwmAsset = config();
+  writeFileSync(path, JSON.stringify({
+    ...missingSwmAsset,
+    graphs: missingSwmAsset.graphs.map((item, index) => index === 0
+      ? { ...item, assets: item.assets.filter((asset) => asset.plane !== 'swm') }
+      : item),
+  }));
+  assert.throws(
+    () => readTestnetOperatorConfig(path),
+    /requires one asset per wave and plane/u,
+  );
 });
 
 test('testnet corpus registration never turns a public cell private through an allowlist', () => {
@@ -107,8 +121,8 @@ test('exact graph observation derives VM and SWM evidence from scoped data and m
       const bindings = sparql.includes('COUNT(*)')
         ? [{ count: { type: 'literal', value: '7', datatype: 'http://www.w3.org/2001/XMLSchema#integer' } }]
         : [
-            { s: { type: 'uri', value: 'urn:test:g1:selected' }, p: { type: 'uri', value: 'urn:test:p:1' }, o: { type: 'literal', value: 'alpha' } },
-            { s: '<urn:test:g1:selected>', p: '<urn:test:p:2>', o: '<urn:test:o:2>' },
+            { s: { type: 'uri', value: 'urn:test:g1:selected:vm' }, p: { type: 'uri', value: 'urn:test:p:1' }, o: { type: 'literal', value: 'alpha' } },
+            { s: '<urn:test:g1:selected:vm>', p: '<urn:test:p:2>', o: '<urn:test:o:2>' },
           ];
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end(JSON.stringify({ result: { bindings } }));

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-common.test.ts
@@ -11,6 +11,7 @@ import {
   buildTestnetContextGraphCreateRequest,
   observeGraph,
   readTestnetOperatorConfig,
+  resolveTestnetOperatorShutdownExitTimeoutMs,
   type TestnetOperatorConfigV1,
   type TestnetOperatorGraphV1,
   type TestnetOperatorRoleV1,
@@ -77,6 +78,20 @@ test('testnet corpus registration never turns a public cell private through an a
   assert.deepEqual(privateRequest['allowedAgents'], [common.agentAddress]);
   assert.equal(publicRequest['register'], true);
   assert.equal(privateRequest['register'], true);
+});
+
+test('shutdown observer budget follows the worker and cannot be undercut', () => {
+  const baseRole = config().roles.publisher;
+  assert.equal(resolveTestnetOperatorShutdownExitTimeoutMs(baseRole, 45_000), 30_000);
+  const extendedRole: TestnetOperatorRoleV1 = {
+    ...baseRole,
+    environment: { DKG_SHUTDOWN_HARD_TIMEOUT_MS: '60000' },
+  };
+  assert.equal(resolveTestnetOperatorShutdownExitTimeoutMs(extendedRole, 120_000), 66_000);
+  assert.throws(
+    () => resolveTestnetOperatorShutdownExitTimeoutMs(extendedRole, 65_000),
+    /undercuts the 66000ms shutdown exit budget/u,
+  );
 });
 
 test('exact graph observation derives VM and SWM evidence from scoped data and metadata queries', async (context) => {

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-common.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-common.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from 'node:fs';
 
 import {
+  resolveShutdownHardTimeoutMs,
+  SHUTDOWN_FORCED_CLEANUP_TIMEOUT_MS,
+} from '../../packages/cli/src/daemon/shutdown.ts';
+
+import {
   createRfc64SemanticSnapshot,
   type Rfc64KnowledgeAssetObservation,
 } from '../_bootstrap/rfc64-evidence.ts';
@@ -12,6 +17,8 @@ import type {
 
 export const TESTNET_OPERATOR_CONFIG_SCHEMA =
   'dkg-rfc64-m1-testnet-operator-config-v1' as const;
+export const TESTNET_OPERATOR_DEFAULT_SHUTDOWN_EXIT_TIMEOUT_MS = 30_000;
+export const TESTNET_OPERATOR_SHUTDOWN_EXIT_SLACK_MS = 5_000;
 
 export interface TestnetOperatorAssetV1 {
   readonly name: string;
@@ -50,6 +57,32 @@ export interface TestnetOperatorConfigV1 {
 export interface HttpResult {
   readonly status: number;
   readonly body: unknown;
+}
+
+/**
+ * Resolve the adapter observer budget from the exact worker environment.
+ * The run-wide operation timeout is a hard ceiling, but may never cut short
+ * the daemon's own hard timeout plus forced-cleanup and process-exit slack.
+ */
+export function resolveTestnetOperatorShutdownExitTimeoutMs(
+  role: TestnetOperatorRoleV1,
+  operationTimeoutMs: number,
+): number {
+  const hardTimeoutMs = resolveShutdownHardTimeoutMs(
+    role.environment['DKG_SHUTDOWN_HARD_TIMEOUT_MS'],
+  );
+  const requiredMs = Math.max(
+    TESTNET_OPERATOR_DEFAULT_SHUTDOWN_EXIT_TIMEOUT_MS,
+    hardTimeoutMs
+      + SHUTDOWN_FORCED_CLEANUP_TIMEOUT_MS
+      + TESTNET_OPERATOR_SHUTDOWN_EXIT_SLACK_MS,
+  );
+  if (!Number.isSafeInteger(operationTimeoutMs) || operationTimeoutMs < requiredMs) {
+    throw new RangeError(
+      `operationTimeoutMs ${operationTimeoutMs} undercuts the ${requiredMs}ms shutdown exit budget`,
+    );
+  }
+  return requiredMs;
 }
 
 export function buildTestnetContextGraphCreateRequest(input: {

--- a/devnet/rfc64-m1-selective-coverage/testnet-operator-common.ts
+++ b/devnet/rfc64-m1-selective-coverage/testnet-operator-common.ts
@@ -25,6 +25,7 @@ export interface TestnetOperatorAssetV1 {
   readonly subject: string;
   readonly ual: string;
   readonly wave: 'selected' | 'final';
+  readonly plane: 'vm' | 'swm';
 }
 
 export interface TestnetOperatorGraphV1 {
@@ -155,22 +156,28 @@ export function readTestnetOperatorConfig(path: string): TestnetOperatorConfigV1
     const assets = array(row['assets'], `operator graph ${index} assets`)
       .map((asset, assetIndex): TestnetOperatorAssetV1 => {
         const item = record(asset, `operator graph ${index} asset ${assetIndex}`);
-        assertExactKeys(item, ['name', 'subject', 'ual', 'wave'], `operator graph ${index} asset ${assetIndex}`);
+        assertExactKeys(item, ['name', 'subject', 'ual', 'wave', 'plane'], `operator graph ${index} asset ${assetIndex}`);
         const wave = item['wave'];
+        const plane = item['plane'];
         if (wave !== 'selected' && wave !== 'final') {
           throw new TypeError(`operator graph ${index} asset ${assetIndex} has an invalid wave`);
+        }
+        if (plane !== 'vm' && plane !== 'swm') {
+          throw new TypeError(`operator graph ${index} asset ${assetIndex} has an invalid plane`);
         }
         return {
           name: boundedText(item['name'], 'asset name'),
           subject: absoluteIri(item['subject'], 'asset subject'),
           ual: boundedText(item['ual'], 'asset UAL'),
           wave,
+          plane,
         };
       });
-    if (assets.length !== 2
-      || assets.filter((asset) => asset.wave === 'selected').length !== 1
-      || assets.filter((asset) => asset.wave === 'final').length !== 1) {
-      throw new RangeError(`operator graph ${index} requires one asset per wave`);
+    if (assets.length !== 4
+      || (['selected', 'final'] as const).some((wave) =>
+        (['vm', 'swm'] as const).some((plane) =>
+          assets.filter((asset) => asset.wave === wave && asset.plane === plane).length !== 1))) {
+      throw new RangeError(`operator graph ${index} requires one asset per wave and plane`);
     }
     return {
       contextGraphId: boundedText(row['contextGraphId'], 'context graph ID'),

--- a/packages/cli/src/cli-supervisor.ts
+++ b/packages/cli/src/cli-supervisor.ts
@@ -7,7 +7,9 @@ import {
 import { DAEMON_EXIT_CODE_RESTART, decodeForcedExitCode } from './daemon.js';
 import {
   isLivenessProbeEnabled, startLivenessWatcher, LIVENESS_CONSECUTIVE_FAILURES_TO_KILL,
+  shutdownGraceMsForHardTimeout,
 } from './daemon/supervisor-liveness.js';
+import { resolveShutdownHardTimeoutMs } from './daemon/shutdown.js';
 import {
   sleep, withSelectedDkgHome, selectedDkgHomeForEnv, probeHostForApiHost,
 } from './cli-helpers.js';
@@ -37,8 +39,10 @@ function supervisorWarn(message: string): void {
  */
 async function maybeStartSupervisorLivenessWatcher(
   child: { kill(signal: 'SIGKILL'): boolean },
+  childEnv: NodeJS.ProcessEnv = process.env,
+  shutdownGraceMs = resolveSupervisorShutdownGraceMs(childEnv),
 ): Promise<() => void> {
-  if (!isLivenessProbeEnabled(process.env.DKG_SUPERVISOR_LIVENESS_PROBE)) {
+  if (!isLivenessProbeEnabled(childEnv.DKG_SUPERVISOR_LIVENESS_PROBE)) {
     return () => {};
   }
 
@@ -63,6 +67,7 @@ async function maybeStartSupervisorLivenessWatcher(
           // intentionally shutting down" signal. Without this the watcher
           // would race a slow teardown and SIGKILL mid-cleanup.
           isShuttingDown: () => !existsSync(apiPortPath()),
+          shutdownGraceMs,
           onUnresponsive: () => {
             supervisorWarn(
               `[supervisor] worker unresponsive after ${LIVENESS_CONSECUTIVE_FAILURES_TO_KILL} consecutive liveness probes; SIGKILL + respawn.`,
@@ -89,8 +94,16 @@ async function maybeStartSupervisorLivenessWatcher(
   };
 }
 
+function resolveSupervisorShutdownGraceMs(env: NodeJS.ProcessEnv): number {
+  return shutdownGraceMsForHardTimeout(
+    resolveShutdownHardTimeoutMs(env.DKG_SHUTDOWN_HARD_TIMEOUT_MS),
+  );
+}
+
 async function runDaemonSupervisor(): Promise<void> {
   process.env.DKG_HOME = selectedDkgHomeForEnv(process.env);
+  const childEnv = withSelectedDkgHome(process.env);
+  const shutdownGraceMs = resolveSupervisorShutdownGraceMs(childEnv);
   const maxCrashRestarts = 5;
   let crashRestartCount = 0;
 
@@ -106,7 +119,7 @@ async function runDaemonSupervisor(): Promise<void> {
       daemonCommand.args,
       {
         stdio: ['ignore', 'ignore', 'ignore'],
-        env: withSelectedDkgHome(process.env),
+        env: childEnv,
       },
     );
 
@@ -116,7 +129,11 @@ async function runDaemonSupervisor(): Promise<void> {
     // takes it from there. Gated by DKG_SUPERVISOR_LIVENESS_PROBE so
     // tests + headless-worker scenarios can opt out. See
     // packages/cli/src/daemon/supervisor-liveness.ts for the full rationale.
-    const stopWatcher = await maybeStartSupervisorLivenessWatcher(child);
+    const stopWatcher = await maybeStartSupervisorLivenessWatcher(
+      child,
+      childEnv,
+      shutdownGraceMs,
+    );
 
     const rawExitCode = await new Promise<number | null>((resolve) => {
       child.once('exit', (code) => resolve(code));
@@ -145,6 +162,7 @@ async function runDaemonSupervisor(): Promise<void> {
 }
 
 async function runForegroundSupervisor(childEnv: NodeJS.ProcessEnv = process.env): Promise<void> {
+  const shutdownGraceMs = resolveSupervisorShutdownGraceMs(childEnv);
   const maxCrashRestarts = 5;
   let crashRestartCount = 0;
   let currentChild: ReturnType<typeof spawn> | null = null;
@@ -176,7 +194,11 @@ async function runForegroundSupervisor(childEnv: NodeJS.ProcessEnv = process.env
       },
     );
 
-    const stopWatcher = await maybeStartSupervisorLivenessWatcher(currentChild);
+    const stopWatcher = await maybeStartSupervisorLivenessWatcher(
+      currentChild,
+      childEnv,
+      shutdownGraceMs,
+    );
 
     const rawExitCode = await new Promise<number | null>((resolve) => {
       currentChild!.once('exit', (code) => resolve(code));
@@ -214,6 +236,7 @@ export {
   appendSupervisorLog,
   supervisorWarn,
   maybeStartSupervisorLivenessWatcher,
+  resolveSupervisorShutdownGraceMs,
   runDaemonSupervisor,
   runForegroundSupervisor,
 };

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -256,9 +256,9 @@ import {
   carryForwardBundledMarkItDownBinary,
 } from './manifest.js';
 import {
-  SHUTDOWN_HARD_TIMEOUT_MS,
   encodeForcedShutdownExitCode,
   raceShutdownWithTimeout,
+  resolveShutdownHardTimeoutMs,
 } from './shutdown.js';
 import {
   resolveNameToPeerId,
@@ -1148,6 +1148,9 @@ export async function runDaemonInner(
   config: Awaited<ReturnType<typeof loadConfig>>,
   startedAt: number,
 ): Promise<void> {
+  // Resolve operator input once at the canonical daemon startup boundary.
+  // Shutdown mechanics stay independent of ambient module-import order.
+  const shutdownHardTimeoutMs = resolveDaemonShutdownHardTimeoutMs(process.env);
   configureKaPublishLifecycleDebugLogging(config);
   // Resolve the local collector toggle before constructing daemon resources.
   // This is independent from OTLP metrics export configuration.
@@ -3798,7 +3801,7 @@ export async function runDaemonInner(
     });
     const { forced } = await raceShutdownWithTimeout(
       cleanup,
-      SHUTDOWN_HARD_TIMEOUT_MS,
+      shutdownHardTimeoutMs,
       log,
       cleanupStateFiles,
     );
@@ -3807,4 +3810,8 @@ export async function runDaemonInner(
 
   process.on("SIGINT", () => shutdown(0));
   process.on("SIGTERM", () => shutdown(0));
+}
+
+export function resolveDaemonShutdownHardTimeoutMs(env: NodeJS.ProcessEnv): number {
+  return resolveShutdownHardTimeoutMs(env.DKG_SHUTDOWN_HARD_TIMEOUT_MS);
 }

--- a/packages/cli/src/daemon/shutdown.ts
+++ b/packages/cli/src/daemon/shutdown.ts
@@ -26,7 +26,35 @@
 import { DAEMON_EXIT_CODE_RESTART } from './manifest.js';
 
 /** Default deadline for graceful shutdown before we hard-exit. */
-export const SHUTDOWN_HARD_TIMEOUT_MS = 15_000;
+export const DEFAULT_SHUTDOWN_HARD_TIMEOUT_MS = 15_000;
+export const MIN_SHUTDOWN_HARD_TIMEOUT_MS = 5_000;
+export const MAX_SHUTDOWN_HARD_TIMEOUT_MS = 300_000;
+
+/**
+ * Resolve the hard-stop guard without weakening the default fleet behavior.
+ *
+ * RPC-heavy publishers can legitimately spend more than 15 seconds draining
+ * an already-started chain-event callback. Operators may raise the bound for
+ * an isolated run, but malformed or unbounded values fail startup rather than
+ * silently disabling the anti-zombie guard.
+ */
+export function resolveShutdownHardTimeoutMs(
+  value = process.env['DKG_SHUTDOWN_HARD_TIMEOUT_MS'],
+): number {
+  if (value === undefined || value.trim() === '') return DEFAULT_SHUTDOWN_HARD_TIMEOUT_MS;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)
+    || parsed < MIN_SHUTDOWN_HARD_TIMEOUT_MS
+    || parsed > MAX_SHUTDOWN_HARD_TIMEOUT_MS) {
+    throw new TypeError(
+      `DKG_SHUTDOWN_HARD_TIMEOUT_MS must be an integer from `
+        + `${MIN_SHUTDOWN_HARD_TIMEOUT_MS} to ${MAX_SHUTDOWN_HARD_TIMEOUT_MS}`,
+    );
+  }
+  return parsed;
+}
+
+export const SHUTDOWN_HARD_TIMEOUT_MS = resolveShutdownHardTimeoutMs();
 
 /**
  * Per-callsite budget for the best-effort forced-cleanup hook (state-file

--- a/packages/cli/src/daemon/shutdown.ts
+++ b/packages/cli/src/daemon/shutdown.ts
@@ -9,7 +9,8 @@
  * (`kill -9`) is the only recovery. This module provides:
  *
  *   1. A wall-clock deadline ({@link raceShutdownWithTimeout}) so a stuck
- *      graceful path always yields to a forced exit within {@link SHUTDOWN_HARD_TIMEOUT_MS}
+ *      graceful path always yields to a forced exit within the explicitly
+ *      resolved shutdown hard timeout
  *      (plus at most {@link SHUTDOWN_FORCED_CLEANUP_TIMEOUT_MS} for best-effort
  *      forced cleanup — see below).
  *   2. An exit-code convention ({@link SHUTDOWN_FORCED_OFFSET}) so the supervisor
@@ -39,7 +40,7 @@ export const MAX_SHUTDOWN_HARD_TIMEOUT_MS = 300_000;
  * silently disabling the anti-zombie guard.
  */
 export function resolveShutdownHardTimeoutMs(
-  value = process.env['DKG_SHUTDOWN_HARD_TIMEOUT_MS'],
+  value: string | undefined,
 ): number {
   if (value === undefined || value.trim() === '') return DEFAULT_SHUTDOWN_HARD_TIMEOUT_MS;
   const parsed = Number(value);
@@ -54,7 +55,8 @@ export function resolveShutdownHardTimeoutMs(
   return parsed;
 }
 
-export const SHUTDOWN_HARD_TIMEOUT_MS = resolveShutdownHardTimeoutMs();
+/** Backward-compatible name for the unchanged fleet default. */
+export const SHUTDOWN_HARD_TIMEOUT_MS = DEFAULT_SHUTDOWN_HARD_TIMEOUT_MS;
 
 /**
  * Per-callsite budget for the best-effort forced-cleanup hook (state-file

--- a/packages/cli/src/daemon/supervisor-liveness.ts
+++ b/packages/cli/src/daemon/supervisor-liveness.ts
@@ -43,6 +43,8 @@
 
 import { connect, type Socket } from 'node:net';
 
+import { SHUTDOWN_FORCED_CLEANUP_TIMEOUT_MS } from './shutdown.js';
+
 /** Default tick — 30s. Picked to be longer than typical request handling but short enough that a 5-failure quorum triggers within ~2.5 min. */
 export const LIVENESS_PROBE_INTERVAL_MS = 30_000;
 
@@ -51,6 +53,23 @@ export const LIVENESS_PROBE_TIMEOUT_MS = 5_000;
 
 /** Default trigger threshold — 5 consecutive failures. With 30s tick → ~2.5 min unresponsive before SIGKILL. */
 export const LIVENESS_CONSECUTIVE_FAILURES_TO_KILL = 5;
+
+/** Preserve the existing fleet default while allowing longer worker budgets. */
+export const DEFAULT_LIVENESS_SHUTDOWN_GRACE_MS = 30_000;
+
+/**
+ * Give the worker its full hard timeout, forced-cleanup budget, and one
+ * in-flight probe timeout before the supervisor can begin counting failures.
+ */
+export function shutdownGraceMsForHardTimeout(hardTimeoutMs: number): number {
+  if (!Number.isSafeInteger(hardTimeoutMs) || hardTimeoutMs < 1) {
+    throw new TypeError('shutdown hard timeout must be a positive integer');
+  }
+  return Math.max(
+    DEFAULT_LIVENESS_SHUTDOWN_GRACE_MS,
+    hardTimeoutMs + SHUTDOWN_FORCED_CLEANUP_TIMEOUT_MS + LIVENESS_PROBE_TIMEOUT_MS,
+  );
+}
 
 /**
  * One-shot probe: connect to `host:port`, return `true` on success, `false`
@@ -152,11 +171,10 @@ export interface LivenessWatcherOpts {
   /**
    * Maximum time to wait after the worker enters graceful shutdown before
    * the watcher resumes counting failures toward `consecutiveFailuresToKill`.
-   * Default is 2× `SHUTDOWN_HARD_TIMEOUT_MS` (30s) — comfortably longer than
-   * the daemon's own self-force-exit deadline so a healthy graceful shutdown
-   * finishes inside the window; only a wedged teardown reaches the SIGKILL
-   * path. Set to a negative value to disable the bounded fallback (legacy
-   * "disarm forever" behavior).
+   * Default remains 30s. The CLI supervisor supplies a value derived from the
+   * worker's resolved hard timeout so an operator override cannot be
+   * preempted. Set to a negative value to disable the bounded fallback
+   * (legacy "disarm forever" behavior).
    */
   shutdownGraceMs?: number;
 }
@@ -177,9 +195,7 @@ export function startLivenessWatcher(opts: LivenessWatcherOpts): { stop(): void 
   const threshold = opts.consecutiveFailuresToKill ?? LIVENESS_CONSECUTIVE_FAILURES_TO_KILL;
   const probe = opts.probe ?? probeWorkerAlive;
   const host = opts.host ?? '127.0.0.1';
-  // Default to 2× the worker's own hard-shutdown deadline; if the worker's
-  // self-force-exit fires first the watcher never needs to kill anyway.
-  const shutdownGraceMs = opts.shutdownGraceMs ?? 2 * 15_000;
+  const shutdownGraceMs = opts.shutdownGraceMs ?? DEFAULT_LIVENESS_SHUTDOWN_GRACE_MS;
 
   let consecutiveFailures = 0;
   let probing = false;

--- a/packages/cli/test/foreground-supervisor-command.test.ts
+++ b/packages/cli/test/foreground-supervisor-command.test.ts
@@ -7,9 +7,21 @@ import { promisify } from 'node:util';
 
 import { describe, expect, it } from 'vitest';
 
+import { resolveSupervisorShutdownGraceMs } from '../src/cli-supervisor.js';
+
 const execFileAsync = promisify(execFile);
 
 describe('foreground supervisor restart command', () => {
+  it('derives watcher grace from the exact child environment', () => {
+    expect(resolveSupervisorShutdownGraceMs({})).toBe(30_000);
+    expect(resolveSupervisorShutdownGraceMs({
+      DKG_SHUTDOWN_HARD_TIMEOUT_MS: '60000',
+    })).toBe(66_000);
+    expect(() => resolveSupervisorShutdownGraceMs({
+      DKG_SHUTDOWN_HARD_TIMEOUT_MS: 'invalid',
+    })).toThrow(/DKG_SHUTDOWN_HARD_TIMEOUT_MS/u);
+  });
+
   it('spawns the active entrypoint with Node exec argv and the foreground worker argument', async () => {
     const root = await mkdtemp(join(tmpdir(), 'dkg-foreground-command-'));
     try {

--- a/packages/cli/test/shutdown-timeout.test.ts
+++ b/packages/cli/test/shutdown-timeout.test.ts
@@ -11,6 +11,7 @@ import {
   raceShutdownWithTimeout,
 } from '../src/daemon/shutdown.js';
 import { DAEMON_EXIT_CODE_RESTART } from '../src/daemon/manifest.js';
+import { resolveDaemonShutdownHardTimeoutMs } from '../src/daemon/lifecycle.js';
 
 describe('shutdown constants', () => {
   it('declares SHUTDOWN_FORCED_OFFSET = 100 so 0+offset and 75+offset both fit in an 8-bit exit code', () => {
@@ -45,6 +46,16 @@ describe('resolveShutdownHardTimeoutMs', () => {
       );
     },
   );
+
+  it('is resolved from the explicit daemon startup environment', () => {
+    expect(resolveDaemonShutdownHardTimeoutMs({})).toBe(15_000);
+    expect(resolveDaemonShutdownHardTimeoutMs({
+      DKG_SHUTDOWN_HARD_TIMEOUT_MS: '60000',
+    })).toBe(60_000);
+    expect(() => resolveDaemonShutdownHardTimeoutMs({
+      DKG_SHUTDOWN_HARD_TIMEOUT_MS: 'invalid',
+    })).toThrow(/DKG_SHUTDOWN_HARD_TIMEOUT_MS/u);
+  });
 });
 
 describe('isForcedShutdownExitCode', () => {

--- a/packages/cli/test/shutdown-timeout.test.ts
+++ b/packages/cli/test/shutdown-timeout.test.ts
@@ -3,6 +3,8 @@ import {
   SHUTDOWN_FORCED_CLEANUP_TIMEOUT_MS,
   SHUTDOWN_FORCED_OFFSET,
   SHUTDOWN_HARD_TIMEOUT_MS,
+  DEFAULT_SHUTDOWN_HARD_TIMEOUT_MS,
+  resolveShutdownHardTimeoutMs,
   decodeForcedExitCode,
   encodeForcedShutdownExitCode,
   isForcedShutdownExitCode,
@@ -21,12 +23,28 @@ describe('shutdown constants', () => {
   });
 
   it('uses a 15s default hard-timeout — generous enough to let normal shutdowns finish, tight enough to recover from a stuck Core in one update cycle', () => {
-    expect(SHUTDOWN_HARD_TIMEOUT_MS).toBe(15_000);
+    expect(SHUTDOWN_HARD_TIMEOUT_MS).toBe(DEFAULT_SHUTDOWN_HARD_TIMEOUT_MS);
   });
 
   it('uses a 1s default forced-cleanup timeout — bounded separately from the wall-clock cutoff so a stalled FS op cannot recreate the zombie shape', () => {
     expect(SHUTDOWN_FORCED_CLEANUP_TIMEOUT_MS).toBe(1_000);
   });
+});
+
+describe('resolveShutdownHardTimeoutMs', () => {
+  it('preserves the 15 second fleet default and accepts a bounded override', () => {
+    expect(resolveShutdownHardTimeoutMs(undefined)).toBe(15_000);
+    expect(resolveShutdownHardTimeoutMs('60000')).toBe(60_000);
+  });
+
+  it.each(['4999', '300001', '1.5', 'not-a-number'])(
+    'rejects unsafe override %s',
+    (value) => {
+      expect(() => resolveShutdownHardTimeoutMs(value)).toThrow(
+        /DKG_SHUTDOWN_HARD_TIMEOUT_MS must be an integer/u,
+      );
+    },
+  );
 });
 
 describe('isForcedShutdownExitCode', () => {

--- a/packages/cli/test/supervisor-liveness.test.ts
+++ b/packages/cli/test/supervisor-liveness.test.ts
@@ -31,6 +31,8 @@ import {
   LIVENESS_CONSECUTIVE_FAILURES_TO_KILL,
   LIVENESS_PROBE_INTERVAL_MS,
   LIVENESS_PROBE_TIMEOUT_MS,
+  DEFAULT_LIVENESS_SHUTDOWN_GRACE_MS,
+  shutdownGraceMsForHardTimeout,
 } from '../src/daemon/supervisor-liveness.js';
 
 // Plain DI recorder (no vitest mock API): captures every call's args and
@@ -73,6 +75,13 @@ describe('module constants', () => {
     expect(LIVENESS_CONSECUTIVE_FAILURES_TO_KILL).toBe(5);
     expect(LIVENESS_PROBE_INTERVAL_MS).toBe(30_000);
     expect(LIVENESS_PROBE_TIMEOUT_MS).toBe(5_000);
+    expect(DEFAULT_LIVENESS_SHUTDOWN_GRACE_MS).toBe(30_000);
+  });
+
+  it('never lets supervisor shutdown grace preempt the worker hard timeout', () => {
+    expect(shutdownGraceMsForHardTimeout(15_000)).toBe(30_000);
+    expect(shutdownGraceMsForHardTimeout(60_000)).toBe(66_000);
+    expect(shutdownGraceMsForHardTimeout(300_000)).toBe(306_000);
   });
 });
 


### PR DESCRIPTION
## Impact

This keeps the production shutdown hard-stop at 15 seconds by default, while allowing an operator to select a validated bounded budget between 5 seconds and 5 minutes for RPC-heavy processes that are already draining an in-flight chain callback. Invalid values fail startup instead of disabling the guard.

The RFC-64 M1 real-node adapter now waits for that bounded graceful exit before deciding whether cleanup passed. A forced or non-zero exit still fails the evidence gate and prevents a PASS artifact.

## Before

```mermaid
sequenceDiagram
    participant Operator
    participant Daemon
    participant Chain as Chain callback
    Operator->>Daemon: POST /shutdown
    Daemon->>Chain: Wait for in-flight callback
    Note over Daemon: Fixed 15 second hard stop
    Daemon--xOperator: Forced exit 100
    Note over Operator: Valid canary cannot publish PASS
```

## After

```mermaid
sequenceDiagram
    participant Operator
    participant Daemon
    participant Chain as Chain callback
    Operator->>Daemon: Start with optional bounded shutdown budget
    Daemon->>Daemon: Validate 5s to 5m or fail startup
    Operator->>Daemon: POST /shutdown
    Daemon->>Chain: Drain in-flight callback
    Chain-->>Daemon: Callback complete
    Daemon-->>Operator: Clean exit 0 within bound
    Note over Operator: Forced or non-zero exit still fails M1
```

## Validation

- CLI shutdown suite: 36 passed
- RFC-64 M1 verifier and adapter suites: 79 passed
- M1 TypeScript project: clean
- `git diff --check`: clean

## Scope

- Stacked on #2028.
- Does not change the default fleet timeout.
- Does not merge or deploy anything by itself.
