### PR TITLE
feat(agent): resume persisted Edge always-on sync scopes

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3795,7 +3795,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         remotePeer,
         probe,
         'on-connect',
-        'connection-open',
+        automaticSyncInvocation('connection-open'),
       );
     } catch (err: unknown) {
       handleSyncError(remotePeer, err);
@@ -3807,7 +3807,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeer: string,
     probe: SyncReconcilerProbe,
     source: SyncAdmissionSource = 'on-connect',
-    trigger?: SyncCoverageEvidenceTrigger,
+    invocation?: AutomaticSyncInvocation,
   ): Promise<SyncReconcilerAttemptOutcome> {
     const lastOk = this.lastSuccessfulSyncAt.get(remotePeer);
     const lastProgress = this.lastSyncProgressAt.get(remotePeer);
@@ -3819,12 +3819,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // Keep the established three-argument call shape when no internal
       // automatic trigger exists. Some embedders replace this method with a
       // strict-arity seam, and a trailing `undefined` is still observable.
-      const outcome = trigger
+      const outcome = invocation
         ? await this.trySyncFromPeer(
           remotePeer,
           onSyncAccounting,
           source,
-          automaticSyncInvocation(trigger),
+          invocation,
         )
         : await this.trySyncFromPeer(remotePeer, onSyncAccounting, source);
       if (outcome === 'deferred-backpressure') {
@@ -3897,7 +3897,21 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!this.started) {
       return 'not-started';
     }
-    if (!syncOnConnectEnabled(this.config)) {
+    const trigger = invocation?.[automaticSyncInvocationBrand] === true
+      ? invocation.trigger
+      : undefined;
+    const getLiveRehydratedAlwaysOnContextGraphIds = () => {
+      const configured = [...new Set(this.config.syncContextGraphs ?? [])];
+      return this.getRehydratedAlwaysOnEvidenceContextGraphIds(configured);
+    };
+    const scopedEdgePeriodicInvocation = (this.config.nodeRole ?? 'edge') === 'edge'
+      && trigger === 'periodic-reconciler';
+    const initialRehydratedAlwaysOnContextGraphIds =
+      getLiveRehydratedAlwaysOnContextGraphIds();
+    if (
+      !syncOnConnectEnabled(this.config)
+      && !(scopedEdgePeriodicInvocation && initialRehydratedAlwaysOnContextGraphIds.length > 0)
+    ) {
       return 'not-started';
     }
     if (!this.networkAdmissionCoordinator.isAcceptedPeer(remotePeer)) {
@@ -3909,40 +3923,60 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // Runtime-check the module-private brand as well as relying on the type:
       // plain JavaScript callers cannot forge automatic provenance by passing
       // an object with a trigger-shaped public property.
-      trigger: invocation?.[automaticSyncInvocationBrand] === true
-        ? invocation.trigger
-        : undefined,
+      trigger,
       nodeRole: this.config.nodeRole ?? 'edge',
       planningLane: remotePeer,
       configuredBatchSize: coverageStatus.batchSize,
     });
     const createScopePlan = () => {
-      const scopePlan = this.planCorePublicSyncPeerRound(remotePeer);
-      const selectedContextGraphIds = [...new Set(this.config.syncContextGraphs ?? [])];
+      const configuredContextGraphIds = [...new Set(this.config.syncContextGraphs ?? [])];
+      const rehydratedAlwaysOnContextGraphIds =
+        getLiveRehydratedAlwaysOnContextGraphIds();
+      const defaultScopePlan = this.planCorePublicSyncPeerRound(remotePeer);
+      const scopePlan = scopedEdgePeriodicInvocation
+        ? {
+          effectiveBatchSize: Math.min(
+            defaultScopePlan.effectiveBatchSize,
+            rehydratedAlwaysOnContextGraphIds.length,
+          ),
+          automaticContextGraphIds: [],
+          initialDurableContextGraphIds: [...rehydratedAlwaysOnContextGraphIds],
+          contextGraphIdsAfterDiscovery: getLiveRehydratedAlwaysOnContextGraphIds,
+        }
+        : defaultScopePlan;
       evidence.beginRound({
         effectiveBatchSize: scopePlan.effectiveBatchSize,
-        selectedContextGraphIds,
+        selectedContextGraphIds: configuredContextGraphIds,
         automaticContextGraphIds: scopePlan.automaticContextGraphIds,
-        rehydratedAlwaysOnContextGraphIds:
-          this.getRehydratedAlwaysOnEvidenceContextGraphIds(selectedContextGraphIds),
+        rehydratedAlwaysOnContextGraphIds,
       });
       return scopePlan;
     };
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
-    const getSharedMemorySyncPlan = (
+    const getSharedMemorySyncPlan = async (
       peerId: string,
       contextGraphIdsAfterDiscovery: readonly string[],
     ): Promise<SharedMemorySyncContextGraphPlan> => {
-      let plan = sharedMemorySyncPlans.get(peerId);
+      const requestedContextGraphIds = scopedEdgePeriodicInvocation
+        ? getLiveRehydratedAlwaysOnContextGraphIds()
+        : [...new Set(contextGraphIdsAfterDiscovery)];
+      const key = `${peerId}\0${requestedContextGraphIds.join('\0')}`;
+      let plan = sharedMemorySyncPlans.get(key);
       if (!plan) {
         plan = this.planSharedMemorySyncContextGraphs(
           peerId,
-          [...contextGraphIdsAfterDiscovery],
+          requestedContextGraphIds,
           createOperationContext('sync'),
         );
-        sharedMemorySyncPlans.set(peerId, plan);
+        sharedMemorySyncPlans.set(key, plan);
       }
-      return plan;
+      const resolved = await plan;
+      if (!scopedEdgePeriodicInvocation) return resolved;
+      const live = new Set(getLiveRehydratedAlwaysOnContextGraphIds());
+      return {
+        ...resolved,
+        eligibleContextGraphIds: resolved.eligibleContextGraphIds.filter((id) => live.has(id)),
+      };
     };
     let terminalOutcome: SyncOnConnectOutcome | undefined;
     try {
@@ -3978,9 +4012,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
         syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => {
           const plan = await getSharedMemorySyncPlan(peerId, contextGraphIds);
+          const requestedContextGraphIds = scopedEdgePeriodicInvocation
+            ? plan.eligibleContextGraphIds
+            : contextGraphIds;
           const result = await this.syncSharedMemoryFromPeerDetailed(
             peerId,
-            contextGraphIds,
+            requestedContextGraphIds,
             {
             stopOnBackoffWorthyFailure: true,
             source,
@@ -3994,7 +4031,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           return result;
         },
         syncSharedMemoryOnConnect:
-          syncOnConnectEnabled(this.config) && (this.config.syncSharedMemoryOnConnect ?? true),
+          (syncOnConnectEnabled(this.config) || scopedEdgePeriodicInvocation)
+            && (this.config.syncSharedMemoryOnConnect ?? true),
+        includeSystemContextGraphs: !scopedEdgePeriodicInvocation,
         logInfo: (ctx, message) => this.log.info(ctx, message),
         onPeerSkippedNoSync: (peerId) => {
           this.skippedNoSyncPeers.add(peerId);
@@ -4245,7 +4284,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   async reconcileSyncFromConnectedPeers(this: DKGAgent): Promise<void> {
     if (!this.started) return;
-    if (!syncReconcilerEnabled(this.config) || !syncOnConnectEnabled(this.config)) return;
+    if (!syncReconcilerEnabled(this.config)) return;
+    if (!syncOnConnectEnabled(this.config)) {
+      const hasScopedEdgeResume = (this.config.nodeRole ?? 'edge') === 'edge'
+        && this.getRehydratedAlwaysOnEvidenceContextGraphIds(
+          this.config.syncContextGraphs ?? [],
+        ).length > 0;
+      if (!hasScopedEdgeResume) return;
+    }
     const now = Date.now();
     const ctx = createOperationContext('sync');
     this.pruneSyncReconcilerState(now);
@@ -4283,7 +4329,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         peerId,
         probe,
         'reconcile',
-        'periodic-reconciler',
+        automaticSyncInvocation('periodic-reconciler'),
       )
         .then(() => undefined)
         .catch((err: unknown) => {

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -35,6 +35,12 @@ interface SyncOnConnectCommonContext {
   discoverContextGraphsFromStore: () => Promise<number>;
   syncSharedMemoryFromPeer: (peerId: string, contextGraphIds: string[]) => Promise<SyncFromPeerResult>;
   syncSharedMemoryOnConnect?: boolean;
+  /**
+   * Keep the legacy Agents/Ontology bootstrap in the durable request by
+   * default. A narrowly scoped Edge reconciler may disable it when resuming
+   * only persisted, explicit always-on subscriptions.
+   */
+  includeSystemContextGraphs?: boolean;
   logInfo: (ctx: OperationContext, message: string) => void;
   /**
    * Optional. Called when the peer is reachable but does not currently
@@ -175,6 +181,7 @@ export async function runSyncOnConnectWithScopePlan(
     discoverContextGraphsFromStore,
     syncSharedMemoryFromPeer,
     syncSharedMemoryOnConnect = true,
+    includeSystemContextGraphs = true,
     logInfo,
   } = context;
 
@@ -278,13 +285,15 @@ export async function runSyncOnConnectWithScopePlan(
 
     const scopePlan = createScopePlan();
     const initialDurableContextGraphIds = [...scopePlan.initialDurableContextGraphIds];
+    const systemContextGraphIds = includeSystemContextGraphs
+      ? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]
+      : [];
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);
     const knownCgsBefore = new Set(initialDurableContextGraphIds);
     const synced = await syncFromPeer(
       remotePeer,
       [
-        SYSTEM_CONTEXT_GRAPHS.AGENTS,
-        SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+        ...systemContextGraphIds,
         ...initialDurableContextGraphIds,
       ],
     );
@@ -300,8 +309,7 @@ export async function runSyncOnConnectWithScopePlan(
     }
 
     const syncScope = new Set<string>([
-      SYSTEM_CONTEXT_GRAPHS.AGENTS,
-      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      ...systemContextGraphIds,
       ...initialDurableContextGraphIds,
     ]);
     await runNonTransportStep(() => refreshMetaSyncedFlags(syncScope));

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { performance } from 'node:perf_hooks';
-import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
+import { PROTOCOL_SYNC, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import {
   DKGAgent,
@@ -9,6 +9,20 @@ import {
 } from '../src/index.js';
 
 const PEER = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => { resolve = settle; });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error('condition did not become true');
+}
 
 function cleanDurableSyncResult() {
   return {
@@ -118,6 +132,43 @@ async function createEvidenceAgent(
     return confirmed;
   };
   (agent as any).hasConfirmedMetaState = async () => true;
+  return agent;
+}
+
+async function createRehydratedEdgeEvidenceAgent(contextGraphId: string): Promise<DKGAgent> {
+  const persisted = new Map<string, ContextGraphSubscriptionRecord>([[contextGraphId, {
+    id: contextGraphId,
+    subscribed: true,
+    synced: false,
+    sharedMemorySynced: false,
+    metaSynced: false,
+    syncAdmission: 'explicit',
+    syncScoped: true,
+  }]]);
+  const agent = await createEvidenceAgent('edge', [], {
+    loadAll: async () => [...persisted.values()],
+    save: async (record) => { persisted.set(record.id, { ...record }); },
+    delete: async (id) => { persisted.delete(id); },
+  });
+  (agent as any).gossip = {
+    subscribe: () => undefined,
+    unsubscribe: () => undefined,
+    onMessage: () => undefined,
+    offMessage: () => undefined,
+  };
+  (agent.node as any).node = {
+    peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
+  };
+  await (agent as any).rehydrateContextGraphSubscriptions();
+  (agent as any).config.syncOnConnectEnabled = false;
+  (agent.node as any).node = {
+    getPeers: () => [{ toString: () => PEER }],
+    getConnections: () => [],
+  };
+  (agent as any).getSyncReconcilerProbe = async () => ({
+    protocolsKey: PROTOCOL_SYNC,
+    connectionKey: PEER,
+  });
   return agent;
 }
 
@@ -547,6 +598,37 @@ describe('automatic sync coverage runtime evidence', () => {
     expect(agent.getContextGraphSubscriptionRehydrationStatus()?.rehydratedAlwaysOnIds)
       .toEqual([rehydrated]);
 
+    // Edge's broad sync-on-connect switch remains off. Only the internal
+    // periodic reconciler may resume persisted always-on intent.
+    (agent as any).config.syncOnConnectEnabled = false;
+    const durableScopes: string[][] = [];
+    const sharedMemoryScopes: string[][] = [];
+    (agent as any).syncFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      durableScopes.push([...contextGraphIds]);
+      return cleanDurableSyncResult();
+    };
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      sharedMemoryScopes.push([...contextGraphIds]);
+      return withSettledSharedMemoryTerminals(cleanSharedMemorySyncResult(), contextGraphIds);
+    };
+
+    const forgedOutcome = await (agent as any).attemptSyncFromPeerWithReconcilerAccounting(
+      PEER,
+      { protocolsKey: PROTOCOL_SYNC, connectionKey: PEER },
+      'reconcile',
+      'periodic-reconciler',
+    );
+    expect(forgedOutcome).toBe('not-started');
+    expect(agent.getSyncCoverageEvidence().entries).toEqual([]);
+    expect(durableScopes).toEqual([]);
+    expect(sharedMemoryScopes).toEqual([]);
+
     (agent.node as any).node = {
       getPeers: () => [{ toString: () => PEER }],
       getConnections: () => [],
@@ -588,6 +670,130 @@ describe('automatic sync coverage runtime evidence', () => {
       jobId: entries[0]!.jobId,
       state: 'complete',
       verified: { metadata: true, durable: true, sharedMemory: true },
+    });
+    expect(durableScopes).toEqual([[rehydrated]]);
+    expect(sharedMemoryScopes).toEqual([[rehydrated]]);
+    expect(durableScopes.flat()).not.toContain(runtimeSelected);
+    expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+  });
+
+  it('drops a rehydrated Edge selection removed during protocol discovery', async () => {
+    const contextGraphId = 'cg-edge-protocol-race';
+    const agent = await createRehydratedEdgeEvidenceAgent(contextGraphId);
+    const protocols = deferred<string[]>();
+    let protocolLookupStarted = false;
+    const durableScopes: string[][] = [];
+    const sharedMemoryScopes: string[][] = [];
+    (agent as any).getPeerProtocols = async () => {
+      protocolLookupStarted = true;
+      return protocols.promise;
+    };
+    (agent as any).syncFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      durableScopes.push([...contextGraphIds]);
+      return cleanDurableSyncResult();
+    };
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      sharedMemoryScopes.push([...contextGraphIds]);
+      return withSettledSharedMemoryTerminals(cleanSharedMemorySyncResult(), contextGraphIds);
+    };
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    await waitFor(() => protocolLookupStarted);
+    (agent as any).subscribedContextGraphs.get(contextGraphId).syncMode = 'on-demand';
+    protocols.resolve([PROTOCOL_SYNC]);
+    await waitFor(() => (agent as any).lastSuccessfulSyncAt.has(PEER));
+
+    expect(durableScopes.flat()).not.toContain(contextGraphId);
+    expect(sharedMemoryScopes.flat()).not.toContain(contextGraphId);
+    expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    expect(agent.getSyncCoverageEvidence().entries).toEqual([]);
+  });
+
+  it('does not start Edge shared-memory work after intent is removed during durable sync', async () => {
+    const contextGraphId = 'cg-edge-durable-race';
+    const agent = await createRehydratedEdgeEvidenceAgent(contextGraphId);
+    const durableResult = deferred<ReturnType<typeof cleanDurableSyncResult>>();
+    const durableScopes: string[][] = [];
+    const sharedMemoryScopes: string[][] = [];
+    (agent as any).syncFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      durableScopes.push([...contextGraphIds]);
+      return durableResult.promise;
+    };
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      sharedMemoryScopes.push([...contextGraphIds]);
+      return withSettledSharedMemoryTerminals(cleanSharedMemorySyncResult(), contextGraphIds);
+    };
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    await waitFor(() => durableScopes.length === 1);
+    expect(durableScopes).toEqual([[contextGraphId]]);
+    (agent as any).subscribedContextGraphs.get(contextGraphId).syncMode = 'on-demand';
+    durableResult.resolve(cleanDurableSyncResult());
+    await waitFor(() => (agent as any).lastSuccessfulSyncAt.has(PEER));
+
+    expect(sharedMemoryScopes.flat()).not.toContain(contextGraphId);
+    expect(sharedMemoryScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    expect(sharedMemoryScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    expect(agent.getSyncCoverageEvidence().entries.at(-1)).toMatchObject({
+      contextGraphId,
+      state: 'failed',
+      verified: { metadata: true, durable: true, sharedMemory: false },
+    });
+  });
+
+  it('revalidates Edge intent after shared-memory planning resolves', async () => {
+    const contextGraphId = 'cg-edge-plan-race';
+    const agent = await createRehydratedEdgeEvidenceAgent(contextGraphId);
+    const plan = deferred<{
+      publicContextGraphIds: string[];
+      privateRecoverFromCurator: string[];
+      eligibleContextGraphIds: string[];
+    }>();
+    let planStarted = false;
+    const sharedMemoryScopes: string[][] = [];
+    (agent as any).planSharedMemorySyncContextGraphs = async () => {
+      planStarted = true;
+      return plan.promise;
+    };
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      sharedMemoryScopes.push([...contextGraphIds]);
+      return withSettledSharedMemoryTerminals(cleanSharedMemorySyncResult(), contextGraphIds);
+    };
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    await waitFor(() => planStarted);
+    (agent as any).subscribedContextGraphs.get(contextGraphId).syncMode = 'on-demand';
+    plan.resolve({
+      publicContextGraphIds: [contextGraphId],
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: [contextGraphId],
+    });
+    await waitFor(() => (agent as any).lastSuccessfulSyncAt.has(PEER));
+
+    expect(sharedMemoryScopes.flat()).not.toContain(contextGraphId);
+    expect(sharedMemoryScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    expect(sharedMemoryScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    expect(agent.getSyncCoverageEvidence().entries.at(-1)).toMatchObject({
+      contextGraphId,
+      state: 'failed',
+      verified: { metadata: true, durable: true, sharedMemory: false },
     });
   });
 

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -105,6 +105,43 @@ function allowAllNetworkAdmission(agent: DKGAgent): void {
 }
 
 describe('runSyncOnConnect callbacks', () => {
+  it('can resume one explicit Edge scope without bootstrapping system graphs', async () => {
+    const remotePeer = freshPeerIdString();
+    const durableScopes: string[][] = [];
+    const metadataScopes: string[][] = [];
+    const sharedMemoryScopes: string[][] = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      contextGraphScope: {
+        initialDurableContextGraphIds: ['cg-saved-always-on'],
+        contextGraphIdsAfterDiscovery: () => ['cg-saved-always-on'],
+      },
+      includeSystemContextGraphs: false,
+      syncFromPeer: async (_peerId, contextGraphIds) => {
+        durableScopes.push([...(contextGraphIds ?? [])]);
+        return 1;
+      },
+      refreshMetaSyncedFlags: async (contextGraphIds) => {
+        metadataScopes.push([...contextGraphIds]);
+      },
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async (_peerId, contextGraphIds) => {
+        sharedMemoryScopes.push([...contextGraphIds]);
+        return 1;
+      },
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(durableScopes).toEqual([['cg-saved-always-on']]);
+    expect(metadataScopes).toEqual([['cg-saved-always-on']]);
+    expect(sharedMemoryScopes).toEqual([['cg-saved-always-on']]);
+  });
+
   it('returns deferred-backpressure without marking a zero-progress peer successful', async () => {
     const remotePeer = freshPeerIdString();
     const synced: SyncOnConnectPeerOutcome[] = [];


### PR DESCRIPTION
## User impact

An Edge node can keep broad sync-on-connect disabled and still resume only the context graphs that the user explicitly persisted as `always-on` before the process restarted.

- Runtime-only selections, on-demand subscriptions, and unsubscribed graphs are not promoted into automatic work.
- The scoped Edge round does not bootstrap the Agents or Ontology system graphs.
- If the user removes or demotes a subscription while a round is in flight, the agent revalidates intent before every later asynchronous phase and stops work for that graph.
- Only the module-owned periodic reconciler can authorize this exception; JavaScript callers cannot forge the trigger with a public string or object.
- Core behavior and the legacy three-argument sync call shape remain unchanged.

This is stacked on #2031 and should be reviewed after that parent.

## Before

```mermaid
sequenceDiagram
    participant User
    participant Edge
    participant Reconciler
    participant Peer

    User->>Edge: Persist CG A as always-on
    Edge->>Edge: Restart and rehydrate CG A
    Reconciler->>Edge: Periodic retry
    alt Broad sync-on-connect is disabled
        Edge-->>Reconciler: Exit without resuming CG A
    else Broad sync-on-connect is enabled
        Edge->>Peer: Sync system graphs and configured scope
    end
```

## After

```mermaid
sequenceDiagram
    participant User
    participant Edge
    participant Reconciler
    participant Peer

    User->>Edge: Persist CG A as always-on
    Edge->>Edge: Restart and rehydrate explicit CG A
    Reconciler->>Edge: Branded periodic invocation
    Edge->>Edge: Revalidate live persisted intent
    Edge->>Peer: Durable sync for CG A only
    Edge->>Edge: Revalidate after durable work
    Edge->>Peer: Plan SWM for current live scope
    Edge->>Edge: Revalidate after planning
    alt CG A is still always-on
        Edge->>Peer: SWM sync for CG A only
        Edge-->>Reconciler: Record verified scoped evidence
    else User changed CG A to on-demand or unsubscribed
        Edge-->>Reconciler: Stop remaining work for CG A
    end
```

## Verification

- `pnpm --filter @origintrail-official/dkg-storage build`
- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/sync-coverage-evidence-runtime.test.ts test/sync-on-connect-retry.test.ts`
  - 2 files, 76 tests passed
- `git diff --check`

The focused tests cover trigger forgery, runtime-only and on-demand exclusions, no system-graph bootstrap, and subscription demotion during protocol discovery, durable transfer, and SWM planning.
