### PR TITLE
fix(agent): retire cold-joined finalized SWM heads

### DIFF
--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -1586,6 +1586,19 @@ export class FinalizationHandler {
       subGraphName,
     });
     if (vmVerification.status === 'verified') {
+      // A cold join can receive the durable VM snapshot and its still-present
+      // SWM recovery snapshot from different catch-up planes without ever
+      // seeing the live finalization envelope. Exact VM content plus the
+      // chain-resolved root is sufficient to retire only the matching current
+      // SWM head from the user-facing view. This does not synthesize confirmed
+      // transaction metadata: provenance repair remains pending below.
+      await this.markMatchingGraphScopedSwmFinalized({
+        contextGraphId,
+        scope,
+        merkleRoot,
+        subGraphName,
+        ctx,
+      });
       const access = resolveGraphScopedAccessEnvelope(
         head,
         trustedAssertionEvidence?.accessPolicy,
@@ -1604,13 +1617,6 @@ export class FinalizationHandler {
         subGraphName,
       });
       if (metadataState === 'matching') {
-        await this.markMatchingGraphScopedSwmFinalized({
-          contextGraphId,
-          scope,
-          merkleRoot,
-          subGraphName,
-          ctx,
-        });
         await this.advanceExactGraphScopedVersion({
           contextGraphId,
           scope,

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -2235,6 +2235,59 @@ describe('graph-scoped finalization handler', () => {
     )).resolves.toMatchObject({ type: 'boolean', value: false });
   });
 
+  it('retires an exact cold-joined SWM copy while VM provenance remains pending', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+    const swmResult = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
+    );
+    if (swmResult.type !== 'quads') throw new Error('expected staged SWM quads');
+    await store.dropGraph(vmGraph);
+    await store.insert(swmResult.quads.map((quad) => ({ ...quad, graph: vmGraph })));
+    await store.deleteByPattern({
+      graph: `did:dkg:context-graph:${CG}/_meta`,
+      subject: UAL,
+    });
+
+    const recoveryHandler = new FinalizationHandler(
+      store,
+      legacyFinalizationChain(),
+      { writeLocks: new Map() },
+    );
+    const internals = recoveryHandler as unknown as {
+      verifyChainCgBinding: (kaId: bigint, cgId: string) => Promise<boolean>;
+    };
+    internals.verifyChainCgBinding = async () => true;
+
+    await expect(recoveryHandler.handleChainReconciledKC({
+      contextGraphId: CG,
+      onChainCgId: '42',
+      ual: UAL,
+      merkleRoot: message.kcMerkleRoot,
+      publisherAddress: PUBLISHER,
+      kaId: PACKED_KA_ID,
+      versionBlock: 123,
+      authorAddress: AUTHOR,
+    }, createOperationContext('system'))).resolves.toBe('verified-vm-metadata-pending');
+
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    expect(await store.countQuads(swmGraph)).toBe(2);
+    await expect(store.query(
+      `ASK { GRAPH <${LOCAL_TRUSTED_KA_CONTROLS_GRAPH}> {
+        <${swmGraph}> <${DKG_SWM_FINALIZED_PREDICATE}>
+          "1"^^<http://www.w3.org/2001/XMLSchema#integer> .
+      } }`,
+    )).resolves.toMatchObject({ type: 'boolean', value: true });
+    await expect(new DKGQueryEngine(store).query(
+      'SELECT ?value WHERE { ?s <urn:predicate:value> ?value }',
+      { contextGraphId: CG, view: 'shared-working-memory' },
+    )).resolves.toEqual({ bindings: [] });
+    await expect(store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}/_meta> { <${UAL}>
+        <http://dkg.io/ontology/transactionHash> ?tx .
+      } }`,
+    )).resolves.toMatchObject({ type: 'boolean', value: false });
+  });
+
   it('verifies chain binding and exact private VM metadata without deleting unverified SWM', async () => {
     const { message, swmGraph, vmGraph } = await stageGraph();
     await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);


### PR DESCRIPTION
## User impact

A cold-joining Edge node can receive both a finalized VM copy and the still-retained SWM recovery copy of the same Knowledge Asset. Before this change, the user-facing SWM view could show that finalized asset as if it were still live whenever the receiver had not observed the original finalization transaction envelope.

After this change, once the node independently verifies the exact VM content against the current chain-resolved root, it retires only the matching current SWM head from user queries. The physical SWM copy remains available for recovery, and the node does not invent missing transaction provenance.

This is a bounded correction discovered by the M1 testnet canary. It does not broaden Edge subscriptions, does not activate unselected CGs, and does not weaken VM verification.

## Before

```mermaid
sequenceDiagram
    participant Core as Core peer
    participant Edge as Cold Edge node
    participant Chain as Chain
    participant User as User query

    Core->>Edge: Durable VM snapshot
    Core->>Edge: Retained SWM recovery snapshot
    Edge->>Chain: Resolve current KA root
    Chain-->>Edge: Current root
    Edge->>Edge: Verify exact VM content
    Edge->>Edge: Transaction provenance unavailable
    Edge-->>User: VM asset plus stale SWM asset
```

## After

```mermaid
sequenceDiagram
    participant Core as Core peer
    participant Edge as Cold Edge node
    participant Chain as Chain
    participant Store as Local store
    participant User as User query

    Core->>Edge: Durable VM snapshot
    Core->>Edge: Retained SWM recovery snapshot
    Edge->>Chain: Resolve current KA root
    Chain-->>Edge: Current root
    Edge->>Edge: Verify exact VM content
    Edge->>Store: Mark only matching current SWM head finalized
    Edge->>Edge: Keep provenance state pending
    Edge-->>User: Finalized VM asset only
    Note over Store: SWM recovery quads remain physically stored
```

## Safety properties

- The VM assertion must verify against the current chain-resolved Merkle root.
- The SWM head is re-read and matched under the existing per-KA write lock before retirement.
- Only the exact matching current SWM head receives the local retirement marker.
- Missing transaction metadata remains pending; no transaction hash or confirmed metadata is synthesized.
- The physical SWM recovery snapshot is retained.

## Canary evidence

The initial M1 three-role canary reproduced the defect on the selected public on-demand CG: one exact finalized VM asset was present in both VM and the user-facing SWM view. Logs showed that VM content verification succeeded while transaction provenance remained unavailable. This change turns that exact state into a retired SWM view while preserving the recovery copy and pending provenance state.

## Verification

- Agent dependency build chain: passed
- Focused graph finalization tests: 49 passed
- Full Agent unit lane: 165 files, 2238 passed, 5 skipped, 0 failed
- `git diff --check`: passed

## Stack

- Base: #2032
- Depends on: #2031
- This PR is intentionally not merged; the next gate is a repeat of the M1 three-role testnet canary from this exact head.
