### PR TITLE
fix(agent): settle finalized SWM after catch-up

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5685,6 +5685,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 writeLocks: this.writeLocks,
                 invalidateListContextGraphsCache: () => this.invalidateListContextGraphsCache(),
               }),
+              onGraphScopedSnapshotSettled: async (contextGraphId, descriptor) => {
+                await this.getOrCreateFinalizationHandler()
+                  .retireSyncedGraphScopedSwmIfFinalized({
+                    contextGraphId,
+                    ual: descriptor.kaUal,
+                    assertionVersion: descriptor.assertionVersion,
+                    ...(descriptor.subGraphName
+                      ? { subGraphName: descriptor.subGraphName }
+                      : {}),
+                  }, ctx);
+              },
               storeInsert: async (quads) => {
                 // Oversize guard (OT-RFC-56): drop+tombstone protocol-violating
                 // literals BEFORE insert so the SWM page cursor advances instead

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5684,18 +5684,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 store: this.store,
                 writeLocks: this.writeLocks,
                 invalidateListContextGraphsCache: () => this.invalidateListContextGraphsCache(),
+                settleGraphScopedSnapshot: async (contextGraphId, descriptor) => {
+                  await this.getOrCreateFinalizationHandler()
+                    .retireSyncedGraphScopedSwmIfFinalized({
+                      contextGraphId,
+                      ual: descriptor.kaUal,
+                      assertionVersion: descriptor.assertionVersion,
+                      ...(descriptor.subGraphName
+                        ? { subGraphName: descriptor.subGraphName }
+                        : {}),
+                    }, ctx);
+                },
               }),
-              onGraphScopedSnapshotSettled: async (contextGraphId, descriptor) => {
-                await this.getOrCreateFinalizationHandler()
-                  .retireSyncedGraphScopedSwmIfFinalized({
-                    contextGraphId,
-                    ual: descriptor.kaUal,
-                    assertionVersion: descriptor.assertionVersion,
-                    ...(descriptor.subGraphName
-                      ? { subGraphName: descriptor.subGraphName }
-                      : {}),
-                  }, ctx);
-              },
               storeInsert: async (quads) => {
                 // Oversize guard (OT-RFC-56): drop+tombstone protocol-violating
                 // literals BEFORE insert so the SWM page cursor advances instead

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -12,6 +12,7 @@ import {
   MemoryLayer,
   createGraphKnowledgeAssetScope,
   knowledgeAssetLayerGraphUri,
+  parseDeterministicKnowledgeAssetUal,
   DKG_ENTITY,
   DKG_ROOT_ENTITY_LEGACY,
   ENTITY_PRED_ALT,
@@ -98,6 +99,7 @@ import {
   type VerifiedGraphScopedFinalizationEvidence,
 } from './finalization-graph-envelope.js';
 import { protobufScalarToBigInt, protobufScalarToNumber } from './protobuf-scalars.js';
+import { packKnowledgeAssetIdFromIdentity } from './ka-identity.js';
 
 /**
  * Predicate for the durable per-root keep-root-copy signal the publisher
@@ -1998,8 +2000,17 @@ export class FinalizationHandler {
     merkleRoot: Uint8Array;
     subGraphName?: string;
     ctx: OperationContext;
+    /** Optional current-chain proof, re-run while the per-KA SWM lock is held. */
+    revalidate?: () => Promise<boolean>;
   }): Promise<boolean> {
-    const { contextGraphId, scope, merkleRoot, subGraphName, ctx } = input;
+    const {
+      contextGraphId,
+      scope,
+      merkleRoot,
+      subGraphName,
+      ctx,
+      revalidate,
+    } = input;
     const writeLocks = this.writeLocks;
     if (!writeLocks) return false;
     return withKeyedLocks(
@@ -2015,6 +2026,7 @@ export class FinalizationHandler {
           subGraphName,
         });
         if (!head || head.assertionVersion !== scope.assertionVersion) return false;
+        if (revalidate && !(await revalidate())) return false;
 
         let privateMerkleRoot: Uint8Array | undefined;
         try {
@@ -2051,6 +2063,106 @@ export class FinalizationHandler {
         return true;
       },
     );
+  }
+
+  /**
+   * Close the foreground cold-join seam after a verified SWM snapshot lands.
+   *
+   * Durable VM catch-up runs before SWM catch-up. A receiver can therefore
+   * hold the exact, chain-authenticated VM assertion and later materialize the
+   * publisher's retained SWM recovery copy without ever seeing live
+   * finalization gossip. This method hides only that exact current SWM head.
+   *
+   * Peer metadata is never sufficient: the method first requires surviving
+   * local confirmed VM metadata, re-verifies the exact VM graph against that
+   * commitment, and then re-reads root/version/KA-to-CG binding from chain
+   * while the shared per-KA writer lock is held. Physical SWM data remains for
+   * recovery and a newer/unmatched workspace head remains visible.
+   */
+  async retireSyncedGraphScopedSwmIfFinalized(input: {
+    contextGraphId: string;
+    ual: string;
+    assertionVersion: string;
+    subGraphName?: string;
+  }, ctx: OperationContext): Promise<'retired' | 'not-finalized'> {
+    const { contextGraphId, ual, assertionVersion, subGraphName } = input;
+    const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(this.store, {
+      contextGraphId,
+      ual,
+    });
+    if (stored.state === 'absent') return 'not-finalized';
+    if (stored.state === 'invalid') {
+      throw new Error(`Cannot reconcile synced SWM for ${ual}: confirmed VM metadata is invalid`);
+    }
+
+    const { envelope } = stored;
+    if (
+      envelope.assertionVersion !== assertionVersion
+      || (envelope.subGraphName ?? undefined) !== (subGraphName ?? undefined)
+    ) {
+      return 'not-finalized';
+    }
+
+    let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+    let kaId: bigint;
+    try {
+      scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
+      const identity = parseDeterministicKnowledgeAssetUal(ual);
+      if (!this.chain || identity.chainId !== this.chain.chainId) return 'not-finalized';
+      kaId = packKnowledgeAssetIdFromIdentity(identity);
+    } catch {
+      return 'not-finalized';
+    }
+    if (envelope.batchId !== kaId) return 'not-finalized';
+
+    const vmVerification = await this.verifyExactGraphScopedLayer({
+      contextGraphId,
+      scope,
+      layer: MemoryLayer.VerifiableMemory,
+      publicTripleCount: envelope.publicTripleCount,
+      ...(envelope.privateMerkleRoot
+        ? { privateMerkleRoot: envelope.privateMerkleRoot }
+        : {}),
+      expectedMerkleRoot: envelope.merkleRoot,
+      ...(subGraphName ? { subGraphName } : {}),
+    });
+    if (vmVerification.status !== 'verified') return 'not-finalized';
+
+    const chain = this.chain;
+    if (
+      !chain
+      || chain.chainId === 'none'
+      || typeof chain.getLatestMerkleRoot !== 'function'
+      || typeof chain.getMerkleRootCount !== 'function'
+      || typeof chain.getKAContextGraphId !== 'function'
+    ) {
+      return 'not-finalized';
+    }
+    const revalidate = async (): Promise<boolean> => {
+      const [latestRoot, rootCount, boundContextGraphId] = await Promise.all([
+        chain.getLatestMerkleRoot!(kaId),
+        chain.getMerkleRootCount!(kaId),
+        chain.getKAContextGraphId!(kaId),
+      ]);
+      return latestRoot.length === 32
+        && equalBytes(latestRoot, envelope.merkleRoot)
+        && BigInt(rootCount) === BigInt(assertionVersion)
+        && BigInt(boundContextGraphId) > 0n
+        && await this.onChainContextGraphMatchesLocalId(
+          contextGraphId,
+          BigInt(boundContextGraphId),
+        );
+    };
+
+    const retired = await this.markMatchingGraphScopedSwmFinalized({
+      contextGraphId,
+      scope,
+      merkleRoot: envelope.merkleRoot,
+      ...(subGraphName ? { subGraphName } : {}),
+      ctx,
+      revalidate,
+    });
+    return retired ? 'retired' : 'not-finalized';
   }
 
   /** Re-expose the same SWM assertion when its canonical receipt is invalidated. */

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -56,6 +56,7 @@ import {
   workspacePublicQuadsDigest,
   type MaterializedVersion,
   type KnowledgeAssetWorkspaceHead,
+  type ConfirmedGraphKnowledgeAssetMetadataEnvelope,
   type KCMetadata, type KAMetadata, type OnChainProvenance,
 } from '@origintrail-official/dkg-publisher';
 const DKG_NS = 'http://dkg.io/ontology/';
@@ -214,6 +215,24 @@ type GraphScopedMaterializationEnvelope = Pick<
   | 'accessPolicy'
   | 'allowedPeers'
 >;
+
+type ConfirmedGraphScopedVmEvidence = {
+  envelope: ConfirmedGraphKnowledgeAssetMetadataEnvelope;
+  scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  kaId: bigint;
+  chainId: string;
+};
+
+type ConfirmedGraphScopedVmEvidenceRead =
+  | { state: 'verified'; evidence: ConfirmedGraphScopedVmEvidence }
+  | { state: 'absent' | 'invalid' | 'content-mismatch' };
+
+type CurrentGraphScopedKaCommitment = {
+  contextGraphId: string;
+  kaId: bigint;
+  assertionVersion: string;
+  merkleRoot: Uint8Array;
+};
 
 /** Immutable queued assertion envelope supplied only after receipt/seal validation. */
 type TrustedGraphScopedAssertionEvidence = VerifiedGraphScopedFinalizationEvidence;
@@ -1373,46 +1392,30 @@ export class FinalizationHandler {
     return { status: 'verified', graphUri, quads, merkleRoot };
   }
 
-  /** Recognize exact confirmed VM state from surviving immutable metadata. */
-  private async reconcileConfirmedGraphScopedVmWithoutWorkspaceHead(input: {
+  /**
+   * Load the canonical local proof that one graph-scoped assertion is already
+   * confirmed VM. Receipt `batchId` is provenance, not KA identity: adapters
+   * may use a separate batch identifier while the deterministic UAL still
+   * supplies the packed KA id used for chain reads.
+   */
+  private async loadConfirmedGraphScopedVmEvidence(input: {
     contextGraphId: string;
     ual: string;
-    merkleRoot: Uint8Array;
-    kaId: bigint;
-    versionBlock: number;
-    subGraphName?: string;
-  }, ctx: OperationContext): Promise<'already-confirmed' | 'no-swm' | undefined> {
-    const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(this.store, {
-      contextGraphId: input.contextGraphId,
-      ual: input.ual,
-    });
-    if (stored.state === 'absent') return undefined;
-    if (stored.state === 'invalid') {
-      this.log.warn(ctx, `Chain-reconcile: invalid confirmed graph-scoped metadata for ${input.ual}`);
-      return 'no-swm';
-    }
+  }): Promise<ConfirmedGraphScopedVmEvidenceRead> {
+    const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(this.store, input);
+    if (stored.state === 'absent') return { state: 'absent' };
+    if (stored.state === 'invalid') return { state: 'invalid' };
 
     const { envelope } = stored;
     let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+    let identity: ReturnType<typeof parseDeterministicKnowledgeAssetUal>;
     try {
       scope = createGraphKnowledgeAssetScope(input.ual, envelope.assertionVersion);
+      identity = parseDeterministicKnowledgeAssetUal(input.ual);
     } catch {
-      return 'no-swm';
+      return { state: 'invalid' };
     }
-    const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
-    if (
-      scope.ual !== input.ual
-      || packedKaId !== input.kaId
-      || envelope.batchId !== input.kaId
-      || !equalBytes(envelope.merkleRoot, input.merkleRoot)
-      || (input.subGraphName !== undefined && input.subGraphName !== envelope.subGraphName)
-    ) {
-      this.log.warn(
-        ctx,
-        `Chain-reconcile: confirmed graph-scoped metadata does not match chain identity for ${input.ual}`,
-      );
-      return 'no-swm';
-    }
+    if (scope.ual !== input.ual) return { state: 'invalid' };
 
     const verification = await this.verifyExactGraphScopedLayer({
       contextGraphId: input.contextGraphId,
@@ -1422,13 +1425,82 @@ export class FinalizationHandler {
       ...(envelope.privateMerkleRoot
         ? { privateMerkleRoot: envelope.privateMerkleRoot }
         : {}),
-      expectedMerkleRoot: input.merkleRoot,
+      expectedMerkleRoot: envelope.merkleRoot,
       ...(envelope.subGraphName ? { subGraphName: envelope.subGraphName } : {}),
     });
-    if (verification.status !== 'verified') {
+    if (verification.status !== 'verified') return { state: 'content-mismatch' };
+
+    return {
+      state: 'verified',
+      evidence: {
+        envelope,
+        scope,
+        kaId: packKnowledgeAssetIdFromIdentity(identity),
+        chainId: identity.chainId,
+      },
+    };
+  }
+
+  /** Re-read the exact current chain commitment while the SWM writer lock is held. */
+  private async verifyCurrentGraphScopedKaCommitment(
+    commitment: CurrentGraphScopedKaCommitment,
+  ): Promise<boolean> {
+    const chain = this.chain;
+    if (
+      !chain
+      || chain.chainId === 'none'
+      || typeof chain.getLatestMerkleRoot !== 'function'
+      || typeof chain.getMerkleRootCount !== 'function'
+      || typeof chain.getKAContextGraphId !== 'function'
+    ) {
+      return false;
+    }
+    const [latestRoot, rootCount, boundContextGraphId] = await Promise.all([
+      chain.getLatestMerkleRoot(commitment.kaId),
+      chain.getMerkleRootCount(commitment.kaId),
+      chain.getKAContextGraphId(commitment.kaId),
+    ]);
+    return latestRoot.length === 32
+      && equalBytes(latestRoot, commitment.merkleRoot)
+      && BigInt(rootCount) === BigInt(commitment.assertionVersion)
+      && BigInt(boundContextGraphId) > 0n
+      && await this.onChainContextGraphMatchesLocalId(
+        commitment.contextGraphId,
+        BigInt(boundContextGraphId),
+      );
+  }
+
+  /** Recognize exact confirmed VM state from surviving immutable metadata. */
+  private async reconcileConfirmedGraphScopedVmWithoutWorkspaceHead(input: {
+    contextGraphId: string;
+    ual: string;
+    merkleRoot: Uint8Array;
+    kaId: bigint;
+    versionBlock: number;
+    subGraphName?: string;
+  }, ctx: OperationContext): Promise<'already-confirmed' | 'no-swm' | undefined> {
+    const stored = await this.loadConfirmedGraphScopedVmEvidence({
+      contextGraphId: input.contextGraphId,
+      ual: input.ual,
+    });
+    if (stored.state === 'absent') return undefined;
+    if (stored.state !== 'verified') {
       this.log.warn(
         ctx,
-        `Chain-reconcile: confirmed metadata exists but exact VM content is invalid for ${input.ual}`,
+        `Chain-reconcile: ${stored.state} confirmed graph-scoped VM evidence for ${input.ual}`,
+      );
+      return 'no-swm';
+    }
+
+    const { envelope, scope, kaId } = stored.evidence;
+    if (
+      kaId !== input.kaId
+      || !equalBytes(envelope.merkleRoot, input.merkleRoot)
+      || (input.subGraphName !== undefined && input.subGraphName !== envelope.subGraphName)
+    ) {
+      this.log.warn(
+        ctx,
+        `Chain-reconcile: confirmed graph-scoped metadata does not match chain identity for ${input.ual}`,
       );
       return 'no-swm';
     }
@@ -2000,8 +2072,8 @@ export class FinalizationHandler {
     merkleRoot: Uint8Array;
     subGraphName?: string;
     ctx: OperationContext;
-    /** Optional current-chain proof, re-run while the per-KA SWM lock is held. */
-    revalidate?: () => Promise<boolean>;
+    /** Optional typed current-chain proof, re-run while the SWM lock is held. */
+    currentChainCommitment?: CurrentGraphScopedKaCommitment;
   }): Promise<boolean> {
     const {
       contextGraphId,
@@ -2009,7 +2081,7 @@ export class FinalizationHandler {
       merkleRoot,
       subGraphName,
       ctx,
-      revalidate,
+      currentChainCommitment,
     } = input;
     const writeLocks = this.writeLocks;
     if (!writeLocks) return false;
@@ -2026,7 +2098,10 @@ export class FinalizationHandler {
           subGraphName,
         });
         if (!head || head.assertionVersion !== scope.assertionVersion) return false;
-        if (revalidate && !(await revalidate())) return false;
+        if (
+          currentChainCommitment
+          && !(await this.verifyCurrentGraphScopedKaCommitment(currentChainCommitment))
+        ) return false;
 
         let privateMerkleRoot: Uint8Array | undefined;
         try {
@@ -2086,7 +2161,7 @@ export class FinalizationHandler {
     subGraphName?: string;
   }, ctx: OperationContext): Promise<'retired' | 'not-finalized'> {
     const { contextGraphId, ual, assertionVersion, subGraphName } = input;
-    const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(this.store, {
+    const stored = await this.loadConfirmedGraphScopedVmEvidence({
       contextGraphId,
       ual,
     });
@@ -2094,65 +2169,17 @@ export class FinalizationHandler {
     if (stored.state === 'invalid') {
       throw new Error(`Cannot reconcile synced SWM for ${ual}: confirmed VM metadata is invalid`);
     }
+    if (stored.state !== 'verified') return 'not-finalized';
 
-    const { envelope } = stored;
+    const { envelope, scope, kaId, chainId } = stored.evidence;
     if (
       envelope.assertionVersion !== assertionVersion
       || (envelope.subGraphName ?? undefined) !== (subGraphName ?? undefined)
+      || !this.chain
+      || chainId !== this.chain.chainId
     ) {
       return 'not-finalized';
     }
-
-    let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
-    let kaId: bigint;
-    try {
-      scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
-      const identity = parseDeterministicKnowledgeAssetUal(ual);
-      if (!this.chain || identity.chainId !== this.chain.chainId) return 'not-finalized';
-      kaId = packKnowledgeAssetIdFromIdentity(identity);
-    } catch {
-      return 'not-finalized';
-    }
-    if (envelope.batchId !== kaId) return 'not-finalized';
-
-    const vmVerification = await this.verifyExactGraphScopedLayer({
-      contextGraphId,
-      scope,
-      layer: MemoryLayer.VerifiableMemory,
-      publicTripleCount: envelope.publicTripleCount,
-      ...(envelope.privateMerkleRoot
-        ? { privateMerkleRoot: envelope.privateMerkleRoot }
-        : {}),
-      expectedMerkleRoot: envelope.merkleRoot,
-      ...(subGraphName ? { subGraphName } : {}),
-    });
-    if (vmVerification.status !== 'verified') return 'not-finalized';
-
-    const chain = this.chain;
-    if (
-      !chain
-      || chain.chainId === 'none'
-      || typeof chain.getLatestMerkleRoot !== 'function'
-      || typeof chain.getMerkleRootCount !== 'function'
-      || typeof chain.getKAContextGraphId !== 'function'
-    ) {
-      return 'not-finalized';
-    }
-    const revalidate = async (): Promise<boolean> => {
-      const [latestRoot, rootCount, boundContextGraphId] = await Promise.all([
-        chain.getLatestMerkleRoot!(kaId),
-        chain.getMerkleRootCount!(kaId),
-        chain.getKAContextGraphId!(kaId),
-      ]);
-      return latestRoot.length === 32
-        && equalBytes(latestRoot, envelope.merkleRoot)
-        && BigInt(rootCount) === BigInt(assertionVersion)
-        && BigInt(boundContextGraphId) > 0n
-        && await this.onChainContextGraphMatchesLocalId(
-          contextGraphId,
-          BigInt(boundContextGraphId),
-        );
-    };
 
     const retired = await this.markMatchingGraphScopedSwmFinalized({
       contextGraphId,
@@ -2160,7 +2187,12 @@ export class FinalizationHandler {
       merkleRoot: envelope.merkleRoot,
       ...(subGraphName ? { subGraphName } : {}),
       ctx,
-      revalidate,
+      currentChainCommitment: {
+        contextGraphId,
+        kaId,
+        assertionVersion,
+        merkleRoot: envelope.merkleRoot,
+      },
     });
     return retired ? 'retired' : 'not-finalized';
   }

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -81,6 +81,15 @@ interface SharedMemorySyncContext {
    * Absent entirely => materialization is skipped (never half-applied).
    */
   snapshotMaterializer?: SharedMemorySnapshotMaterializer;
+  /**
+   * Runs after a graph-scoped snapshot and its verified head metadata are in
+   * the store, but before phase checkpoints advance. Used to retire an exact
+   * finalized SWM recovery copy from the user-facing view.
+   */
+  onGraphScopedSnapshotSettled?: (
+    contextGraphId: string,
+    descriptor: GraphScopedSwmRecoveryDescriptor,
+  ) => Promise<void>;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   getRegisteredSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
   getExcludedSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
@@ -119,6 +128,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     ensureContextGraph,
     storeInsert,
     snapshotMaterializer,
+    onGraphScopedSnapshotSettled,
     publicSnapshotStore,
     getRegisteredSubGraphNames,
     getExcludedSubGraphNames,
@@ -296,6 +306,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       let materializationFailures = 0;
       let materializedQuads = 0;
       const materializedKeys = new Set<string>();
+      const settledDescriptors = new Map<string, GraphScopedSwmRecoveryDescriptor>();
       const materializeReadySnapshot = async (snapshotRef: string): Promise<void> => {
         const descriptors = snapshotDescriptorsByRef.get(snapshotRef);
         if (!descriptors?.length || !snapshotMaterializer || !publicSnapshotStore) return;
@@ -349,6 +360,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
                     await snapshotMaterializer.replaceHeadMetadata(pid, descriptor);
                   }
                   materializedKeys.add(graphKey);
+                  settledDescriptors.set(graphKey, descriptor);
                   return;
                 }
                 const asset = await materializeGraphScopedSwmRecoveryAsset({
@@ -367,6 +379,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
                 // (LIMIT-1 head readers would otherwise see an arbitrary mix).
                 await snapshotMaterializer.replaceHeadMetadata(pid, descriptor);
                 materializedKeys.add(graphKey);
+                settledDescriptors.set(graphKey, descriptor);
                 materializedGraphs += 1;
                 materializedQuads += asset.quads.length;
                 logInfo(ctx, `SWM sync for "${pid}": materialized snapshot ${snapshotRef} `
@@ -464,6 +477,14 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         await storeInsert(processed.verifiedMeta);
         summary.insertedTriples += processed.verifiedMeta.length;
         summary.insertedMetaTriples += processed.verifiedMeta.length;
+      }
+      if (onGraphScopedSnapshotSettled) {
+        // Deliberately outside the per-KA snapshot lock above: the finalizer
+        // acquires the same lock before stamping the local retirement marker.
+        // Running it inside the materializer critical section would deadlock.
+        for (const descriptor of settledDescriptors.values()) {
+          await onGraphScopedSnapshotSettled(pid, descriptor);
+        }
       }
       recordPhaseOutcome(wsMetaResult);
       recordPhaseOutcome(wsDataResult);

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -81,15 +81,6 @@ interface SharedMemorySyncContext {
    * Absent entirely => materialization is skipped (never half-applied).
    */
   snapshotMaterializer?: SharedMemorySnapshotMaterializer;
-  /**
-   * Runs after a graph-scoped snapshot and its verified head metadata are in
-   * the store, but before phase checkpoints advance. Used to retire an exact
-   * finalized SWM recovery copy from the user-facing view.
-   */
-  onGraphScopedSnapshotSettled?: (
-    contextGraphId: string,
-    descriptor: GraphScopedSwmRecoveryDescriptor,
-  ) => Promise<void>;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   getRegisteredSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
   getExcludedSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
@@ -128,7 +119,6 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     ensureContextGraph,
     storeInsert,
     snapshotMaterializer,
-    onGraphScopedSnapshotSettled,
     publicSnapshotStore,
     getRegisteredSubGraphNames,
     getExcludedSubGraphNames,
@@ -478,14 +468,15 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         summary.insertedTriples += processed.verifiedMeta.length;
         summary.insertedMetaTriples += processed.verifiedMeta.length;
       }
-      if (onGraphScopedSnapshotSettled) {
-        // Deliberately outside the per-KA snapshot lock above: the finalizer
-        // acquires the same lock before stamping the local retirement marker.
-        // Running it inside the materializer critical section would deadlock.
-        for (const descriptor of settledDescriptors.values()) {
-          await onGraphScopedSnapshotSettled(pid, descriptor);
-        }
-      }
+      // Deliberately outside the per-KA snapshot lock above: the finalizer
+      // acquires the same lock before stamping the local retirement marker.
+      // Running settlement inside the materializer critical section would
+      // deadlock. The handoff remains part of the ONE required materializer
+      // contract, so production cannot wire materialization without it.
+      await snapshotMaterializer?.settleCommittedSnapshots(
+        pid,
+        [...settledDescriptors.values()],
+      );
       recordPhaseOutcome(wsMetaResult);
       recordPhaseOutcome(wsDataResult);
       if ((wsMetaResult.timedOut || wsDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {

--- a/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
+++ b/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
@@ -103,6 +103,19 @@ export interface SharedMemorySnapshotMaterializer {
     contextGraphId: string,
     descriptor: GraphScopedSwmRecoveryDescriptor,
   ): Promise<void>;
+  /**
+   * Complete the graph-scoped snapshot transaction after the caller has
+   * inserted the verified head metadata. Keeping this handoff on the same
+   * required abstraction prevents a caller from materializing snapshots while
+   * silently omitting post-commit finalization settlement.
+   *
+   * This MUST be invoked outside `withKaWriteLock`: the finalization owner
+   * takes that same per-KA lock while revalidating the current SWM head.
+   */
+  settleCommittedSnapshots(
+    contextGraphId: string,
+    descriptors: readonly GraphScopedSwmRecoveryDescriptor[],
+  ): Promise<void>;
 }
 
 /**
@@ -117,6 +130,10 @@ export function createSharedMemorySnapshotMaterializer(deps: {
    */
   writeLocks: Map<string, Promise<void>>;
   invalidateListContextGraphsCache: () => void;
+  settleGraphScopedSnapshot: (
+    contextGraphId: string,
+    descriptor: GraphScopedSwmRecoveryDescriptor,
+  ) => Promise<void>;
 }): SharedMemorySnapshotMaterializer {
   return {
     withKaWriteLock: (contextGraphId, subGraphName, kaUal, fn) =>
@@ -229,6 +246,12 @@ export function createSharedMemorySnapshotMaterializer(deps: {
           { graph: descriptor.metaGraph, subject: operationSubject },
           { priority: 'background', source: 'agent.sharedMemorySync.snapshotMaterializer.deleteOperation' },
         );
+      }
+    },
+
+    settleCommittedSnapshots: async (contextGraphId, descriptors) => {
+      for (const descriptor of descriptors) {
+        await deps.settleGraphScopedSnapshot(contextGraphId, descriptor);
       }
     },
   };

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -2288,6 +2288,49 @@ describe('graph-scoped finalization handler', () => {
     )).resolves.toMatchObject({ type: 'boolean', value: false });
   });
 
+  it('retires a synced SWM copy only after revalidating exact VM state against chain', async () => {
+    const { message, swmGraph } = await stageGraph();
+    const chain = legacyFinalizationChain(4, {
+      chainId: 'otp:20430',
+      getLatestMerkleRoot: async () => message.kcMerkleRoot,
+      getMerkleRootCount: async () => 1n,
+      getKAContextGraphId: async () => 42n,
+    });
+    const recoveryHandler = new FinalizationHandler(store, chain, {
+      writeLocks: new Map(),
+      resolveContextGraphOnChainId: async () => '42',
+    });
+    await recoveryHandler.handleFinalizationMessage(
+      encodeFinalizationMessage(message),
+      CG,
+      '12D3KooWPublisher',
+    );
+    // Simulate the real cold-join order: durable VM is present, then a later
+    // SWM catch-up materializes the retained recovery copy without the live
+    // finalization message that originally stamped this local-only marker.
+    await store.deleteByPattern({
+      graph: LOCAL_TRUSTED_KA_CONTROLS_GRAPH,
+      subject: swmGraph,
+    });
+
+    await expect(recoveryHandler.retireSyncedGraphScopedSwmIfFinalized({
+      contextGraphId: CG,
+      ual: UAL,
+      assertionVersion: VERSION,
+    }, createOperationContext('sync'))).resolves.toBe('retired');
+
+    await expect(store.query(
+      `ASK { GRAPH <${LOCAL_TRUSTED_KA_CONTROLS_GRAPH}> {
+        <${swmGraph}> <${DKG_SWM_FINALIZED_PREDICATE}>
+          "1"^^<http://www.w3.org/2001/XMLSchema#integer> .
+      } }`,
+    )).resolves.toMatchObject({ type: 'boolean', value: true });
+    await expect(new DKGQueryEngine(store).query(
+      'SELECT ?value WHERE { ?s <urn:predicate:value> ?value }',
+      { contextGraphId: CG, view: 'shared-working-memory' },
+    )).resolves.toEqual({ bindings: [] });
+  });
+
   it('verifies chain binding and exact private VM metadata without deleting unverified SWM', async () => {
     const { message, swmGraph, vmGraph } = await stageGraph();
     await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -2288,8 +2288,12 @@ describe('graph-scoped finalization handler', () => {
     )).resolves.toMatchObject({ type: 'boolean', value: false });
   });
 
-  it('retires a synced SWM copy only after revalidating exact VM state against chain', async () => {
-    const { message, swmGraph } = await stageGraph();
+  it('retires a synced SWM copy with separate batch provenance after exact chain revalidation', async () => {
+    const staged = await stageGraph();
+    // `batchId` is adapter provenance and need not equal the UAL-derived packed
+    // KA id. Chain identity/binding must continue to use PACKED_KA_ID.
+    const message = { ...staged.message, batchId: 42n };
+    const { swmGraph } = staged;
     const chain = legacyFinalizationChain(4, {
       chainId: 'otp:20430',
       getLatestMerkleRoot: async () => message.kcMerkleRoot,
@@ -2329,6 +2333,89 @@ describe('graph-scoped finalization handler', () => {
       'SELECT ?value WHERE { ?s <urn:predicate:value> ?value }',
       { contextGraphId: CG, view: 'shared-working-memory' },
     )).resolves.toEqual({ bindings: [] });
+  });
+
+  it('keeps synced SWM visible when any current-chain retirement proof is missing or stale', async () => {
+    const cases: Array<{
+      name: string;
+      chain: (root: Uint8Array) => Partial<ChainAdapter>;
+    }> = [
+      {
+        name: 'latest root mismatch',
+        chain: () => ({
+          getLatestMerkleRoot: async () => new Uint8Array(32),
+          getMerkleRootCount: async () => 1n,
+          getKAContextGraphId: async () => 42n,
+        }),
+      },
+      {
+        name: 'version/root-count mismatch',
+        chain: (root) => ({
+          getLatestMerkleRoot: async () => root,
+          getMerkleRootCount: async () => 2n,
+          getKAContextGraphId: async () => 42n,
+        }),
+      },
+      {
+        name: 'zero context graph binding',
+        chain: (root) => ({
+          getLatestMerkleRoot: async () => root,
+          getMerkleRootCount: async () => 1n,
+          getKAContextGraphId: async () => 0n,
+        }),
+      },
+      {
+        name: 'mismatched context graph binding',
+        chain: (root) => ({
+          getLatestMerkleRoot: async () => root,
+          getMerkleRootCount: async () => 1n,
+          getKAContextGraphId: async () => 43n,
+        }),
+      },
+      {
+        name: 'missing chain support',
+        chain: () => ({}),
+      },
+    ];
+
+    for (const scenario of cases) {
+      store = new OxigraphStore();
+      graphManager = new GraphManager(store);
+      const { message, swmGraph } = await stageGraph();
+      const chain = legacyFinalizationChain(4, {
+        chainId: 'otp:20430',
+        ...scenario.chain(message.kcMerkleRoot),
+      });
+      const recoveryHandler = new FinalizationHandler(store, chain, {
+        writeLocks: new Map(),
+        resolveContextGraphOnChainId: async () => '42',
+      });
+      await recoveryHandler.handleFinalizationMessage(
+        encodeFinalizationMessage(message),
+        CG,
+        '12D3KooWPublisher',
+      );
+      await store.deleteByPattern({
+        graph: LOCAL_TRUSTED_KA_CONTROLS_GRAPH,
+        subject: swmGraph,
+      });
+
+      await expect(recoveryHandler.retireSyncedGraphScopedSwmIfFinalized({
+        contextGraphId: CG,
+        ual: UAL,
+        assertionVersion: VERSION,
+      }, createOperationContext('sync')), scenario.name).resolves.toBe('not-finalized');
+      await expect(store.query(
+        `ASK { GRAPH <${LOCAL_TRUSTED_KA_CONTROLS_GRAPH}> {
+          <${swmGraph}> <${DKG_SWM_FINALIZED_PREDICATE}> ?version .
+        } }`,
+      ), scenario.name).resolves.toMatchObject({ type: 'boolean', value: false });
+      const visible = await new DKGQueryEngine(store).query(
+        'SELECT ?value WHERE { ?s <urn:predicate:value> ?value }',
+        { contextGraphId: CG, view: 'shared-working-memory' },
+      );
+      expect(visible.bindings, scenario.name).toHaveLength(2);
+    }
   });
 
   it('verifies chain binding and exact private VM metadata without deleting unverified SWM', async () => {

--- a/packages/agent/test/swm-public-snapshot-materialization.test.ts
+++ b/packages/agent/test/swm-public-snapshot-materialization.test.ts
@@ -202,12 +202,14 @@ function harness(overrides: HarnessOverrides = {}) {
           events.push('head-swapped');
           headSwaps.push({ contextGraphId, headSubject: descriptor.headSubject });
         },
-      },
-      onGraphScopedSnapshotSettled: async (contextGraphId, descriptor) => {
-        expect(contextGraphId).toBe(CG);
-        expect(descriptor.kaUal).toBe(UAL);
-        events.push('snapshot-settled');
-        await overrides.onGraphScopedSnapshotSettled?.();
+        settleCommittedSnapshots: async (contextGraphId, descriptors) => {
+          for (const descriptor of descriptors) {
+            expect(contextGraphId).toBe(CG);
+            expect(descriptor.kaUal).toBe(UAL);
+            events.push('snapshot-settled');
+            await overrides.onGraphScopedSnapshotSettled?.();
+          }
+        },
       },
       publicSnapshotStore: snapshotStore,
       deleteCheckpoint: () => {},
@@ -336,9 +338,25 @@ describe('public SWM snapshot materialization', () => {
     const h = harness({ storedHead: () => ({ version: '1', needsRepair: false }), contentPresent: () => true });
     const summary = await h.run();
     expect(h.events).toContain('content-checked');
+    expect(h.events).toContain('snapshot-settled');
+    expect(h.events.indexOf('snapshot-settled')).toBeGreaterThan(h.events.indexOf('meta-inserted'));
     expect(h.events).not.toContain('replaced');
     expect(h.events).not.toContain('head-swapped');
     expect(summary.failedPhases).toBe(0);
+  });
+
+  it('holds an already-materialized snapshot incomplete when settlement fails', async () => {
+    const h = harness({
+      storedHead: () => ({ version: '1', needsRepair: false }),
+      contentPresent: () => true,
+      onGraphScopedSnapshotSettled: async () => { throw new Error('chain unavailable'); },
+    });
+    const summary = await h.run();
+    expect(h.events).toContain('content-checked');
+    expect(h.events).toContain('snapshot-settled');
+    expect(h.events).not.toContain('replaced');
+    expect(summary.failedPhases).toBe(1);
+    expect(summary.completedPhases).toBe(0);
   });
 
   it('collapses union-insert residue on the skip path when the head needs repair', async () => {

--- a/packages/agent/test/swm-public-snapshot-materialization.test.ts
+++ b/packages/agent/test/swm-public-snapshot-materialization.test.ts
@@ -123,6 +123,7 @@ interface HarnessOverrides {
   subGraphName?: string;
   /** Skip the snapshot-store preseed to force the network (phase='snapshot') fetch. */
   preseedSnapshot?: boolean;
+  onGraphScopedSnapshotSettled?: () => Promise<void>;
 }
 
 function harness(overrides: HarnessOverrides = {}) {
@@ -202,6 +203,12 @@ function harness(overrides: HarnessOverrides = {}) {
           headSwaps.push({ contextGraphId, headSubject: descriptor.headSubject });
         },
       },
+      onGraphScopedSnapshotSettled: async (contextGraphId, descriptor) => {
+        expect(contextGraphId).toBe(CG);
+        expect(descriptor.kaUal).toBe(UAL);
+        events.push('snapshot-settled');
+        await overrides.onGraphScopedSnapshotSettled?.();
+      },
       publicSnapshotStore: snapshotStore,
       deleteCheckpoint: () => {},
       setCheckpoint: () => {},
@@ -242,6 +249,33 @@ describe('public SWM snapshot materialization', () => {
     expect(h.events.indexOf('head-swapped')).toBeGreaterThan(h.events.indexOf('replaced'));
     expect(h.events.indexOf('meta-inserted')).toBeGreaterThan(h.events.indexOf('head-swapped'));
     expect(h.headSwaps).toEqual([{ contextGraphId: CG, headSubject: `${UAL}#dkg-swm-head` }]);
+  });
+
+  it('runs post-sync finalization after verified head metadata lands and before completion', async () => {
+    const h = harness();
+    const summary = await h.run();
+    expect(h.events.indexOf('snapshot-settled')).toBeGreaterThan(
+      h.events.indexOf('meta-inserted'),
+    );
+    expect(summary.failedPhases).toBe(0);
+    // This fixture has one advancing meta page, an empty data page, and a
+    // cache-hit snapshot (no network page). Only the meta checkpoint counts as
+    // advancing completion, and it is recorded after the callback succeeds.
+    expect(summary.completedPhases).toBe(1);
+  });
+
+  it('holds the SWM phase incomplete when post-sync finalization cannot settle', async () => {
+    const h = harness({
+      onGraphScopedSnapshotSettled: async () => {
+        throw new Error('chain unavailable');
+      },
+    });
+    const summary = await h.run();
+    expect(h.events).toContain('snapshot-settled');
+    expect(summary.failedPhases).toBe(1);
+    // The cache-hit snapshot has no network checkpoint of its own, and the
+    // meta/data checkpoints did not advance past the failed handoff.
+    expect(summary.completedPhases).toBe(0);
   });
 
   it('closes the gossip race: in-lock version re-check skips a superseded snapshot', async () => {

--- a/packages/agent/test/swm-snapshot-materializer.test.ts
+++ b/packages/agent/test/swm-snapshot-materializer.test.ts
@@ -116,6 +116,7 @@ function materializerFor(store: TripleStore) {
     store,
     writeLocks: new Map<string, Promise<void>>(),
     invalidateListContextGraphsCache: () => { invalidations += 1; },
+    settleGraphScopedSnapshot: async () => {},
   });
   return { materializer, invalidations: () => invalidations };
 }


### PR DESCRIPTION
## User impact

A cold Edge receiver that explicitly subscribes to a public Context Graph now converges to one user-visible finalized state after foreground catch-up:

- finalized content remains visible in Verifiable Memory;
- the publisher's physically retained SWM recovery copy is hidden from the user-facing SWM view;
- a newer or unmatched SWM draft remains visible;
- no global subscription or all-CG synchronization is introduced.

This closes the testnet-canary seam where durable VM catch-up succeeded first, then public SWM snapshot materialization re-exposed the same finalized assertion as live SWM.

## Before

```mermaid
sequenceDiagram
    participant E as Cold Edge
    participant C as Core provider
    participant S as Local store
    participant Q as User query

    E->>C: Foreground durable VM catch-up
    C-->>E: Finalized assertion and confirmed metadata
    E->>S: Store exact VM
    E->>C: Public SWM snapshot catch-up
    C-->>E: Retained recovery snapshot and verified head
    E->>S: Materialize SWM and advance checkpoint
    Q->>S: Query VM and SWM
    S-->>Q: Finalized assertion appears in both views
```

## After

```mermaid
sequenceDiagram
    participant E as Cold Edge
    participant C as Core provider
    participant B as Chain
    participant S as Local store
    participant Q as User query

    E->>C: Foreground durable VM catch-up
    C-->>E: Finalized assertion and confirmed metadata
    E->>S: Store exact VM
    E->>C: Public SWM snapshot catch-up
    C-->>E: Retained recovery snapshot and verified head
    E->>S: Materialize SWM and verified metadata
    E->>S: Reverify exact confirmed VM
    E->>B: Read latest root, version, and CG binding
    B-->>E: Current canonical state
    E->>S: Recheck exact SWM under per-KA writer lock
    E->>S: Stamp local retirement marker
    E->>E: Advance sync checkpoint
    Q->>S: Query VM and SWM
    S-->>Q: Finalized assertion only in VM; newer SWM drafts remain
```

## Safety properties

- Peer metadata alone cannot retire SWM. The receiver requires surviving confirmed VM metadata and exact local VM content.
- Root, assertion version, KA-to-CG binding, and local CG identity are re-read from chain while the shared per-KA writer lock is held.
- The exact current SWM head is re-read and verified under that lock before the marker is written.
- The physical SWM snapshot is retained for recovery or reorg handling.
- If chain verification or the retirement handoff fails, meta/data checkpoints do not advance and the sync remains retryable/incomplete.
- Unfinalized drafts and superseded snapshots are not retired.

## Validation

- Focused finalization and SWM materialization lane: 62 passed.
- Full Agent unit lane: 165 files, 2,241 passed, 5 skipped, 0 failed.
- Agent build: TypeScript, type-contract tests, and package-root test passed.
- `git diff --check` passed.

## Stack

Stacked on #2034. The fresh two-node testnet-canary validation runs against this exact head after review CI starts; no production Core deployment and no merge are part of this PR.
