### PR TITLE
fix(rfc64): preserve Edge periodic sync scope

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -437,6 +437,7 @@ type ContextGraphDiscoveryDisposition =
 interface PeerSyncScope {
   readonly effectiveBatchSize: number;
   readonly automaticContextGraphIds: readonly string[];
+  readonly initialBootstrapContextGraphIds: readonly string[];
   readonly initialDurableContextGraphIds: readonly string[];
   contextGraphIdsAfterDiscovery(): string[];
 }
@@ -1758,6 +1759,10 @@ export class DKGAgentBase {
     return {
       effectiveBatchSize,
       automaticContextGraphIds,
+      initialBootstrapContextGraphIds: [
+        SYSTEM_CONTEXT_GRAPHS.AGENTS,
+        SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      ],
       initialDurableContextGraphIds,
       contextGraphIdsAfterDiscovery: () => [...new Set([
         ...(this.config.syncContextGraphs ?? []),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -935,13 +935,13 @@ type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'defe
 interface LifecycleSyncScopePlan {
   readonly effectiveBatchSize: number;
   readonly automaticContextGraphIds: readonly string[];
+  readonly initialBootstrapContextGraphIds: readonly string[];
   readonly initialDurableContextGraphIds: readonly string[];
   contextGraphIdsAfterDiscovery(): string[];
 }
 
 interface LifecycleSyncInvocationPolicy {
   readonly canStart: boolean;
-  readonly includeSystemContextGraphs: boolean;
   readonly syncSharedMemory: boolean;
   buildScopePlan(defaultPlan: LifecycleSyncScopePlan): LifecycleSyncScopePlan;
   requestedSharedMemoryContextGraphIds(
@@ -964,19 +964,19 @@ function createLifecycleSyncInvocationPolicy(input: {
   readonly trigger: SyncCoverageEvidenceTrigger | undefined;
   getLiveRehydratedAlwaysOnContextGraphIds(): string[];
 }): LifecycleSyncInvocationPolicy {
-  const periodicEdgeRehydration = input.nodeRole === 'edge'
-    && input.trigger === 'periodic-reconciler';
-  if (periodicEdgeRehydration) {
+  const periodicEdgeScopedResume = input.nodeRole === 'edge'
+    && input.trigger === 'periodic-reconciler'
+    && !input.syncOnConnect;
+  if (periodicEdgeScopedResume) {
     return {
-      canStart: input.syncOnConnect
-        || input.initialRehydratedAlwaysOnContextGraphIds.length > 0,
-      includeSystemContextGraphs: false,
+      canStart: input.initialRehydratedAlwaysOnContextGraphIds.length > 0,
       syncSharedMemory: true,
       buildScopePlan: (defaultPlan) => {
         const live = input.getLiveRehydratedAlwaysOnContextGraphIds();
         return {
           effectiveBatchSize: Math.min(defaultPlan.effectiveBatchSize, live.length),
           automaticContextGraphIds: [],
+          initialBootstrapContextGraphIds: [],
           initialDurableContextGraphIds: [...live],
           contextGraphIdsAfterDiscovery: input.getLiveRehydratedAlwaysOnContextGraphIds,
         };
@@ -996,7 +996,6 @@ function createLifecycleSyncInvocationPolicy(input: {
   }
   return {
     canStart: input.syncOnConnect,
-    includeSystemContextGraphs: true,
     syncSharedMemory: input.syncOnConnect && input.syncSharedMemoryOnConnect,
     buildScopePlan: (defaultPlan) => defaultPlan,
     requestedSharedMemoryContextGraphIds: (contextGraphIdsAfterDiscovery) =>
@@ -4092,7 +4091,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           return result;
         },
         syncSharedMemoryOnConnect: invocationPolicy.syncSharedMemory,
-        includeSystemContextGraphs: invocationPolicy.includeSystemContextGraphs,
         logInfo: (ctx, message) => this.log.info(ctx, message),
         onPeerSkippedNoSync: (peerId) => {
           this.skippedNoSyncPeers.add(peerId);

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -9,6 +9,8 @@ type SyncProgressSummary = DurableProgressSummary & { insertedTriples: number };
 type SyncFromPeerResult = number | SyncProgressSummary;
 
 export interface SyncOnConnectScopePlan {
+  /** Bootstrap graphs frozen into the first durable request. */
+  initialBootstrapContextGraphIds?: readonly string[];
   /** Explicit plus automatic CGs frozen for the first durable request. */
   initialDurableContextGraphIds: readonly string[];
   /** Explicit intent re-read after discovery, merged with the frozen automatic tail. */
@@ -35,12 +37,6 @@ interface SyncOnConnectCommonContext {
   discoverContextGraphsFromStore: () => Promise<number>;
   syncSharedMemoryFromPeer: (peerId: string, contextGraphIds: string[]) => Promise<SyncFromPeerResult>;
   syncSharedMemoryOnConnect?: boolean;
-  /**
-   * Keep the legacy Agents/Ontology bootstrap in the durable request by
-   * default. A narrowly scoped Edge reconciler may disable it when resuming
-   * only persisted, explicit always-on subscriptions.
-   */
-  includeSystemContextGraphs?: boolean;
   logInfo: (ctx: OperationContext, message: string) => void;
   /**
    * Optional. Called when the peer is reachable but does not currently
@@ -147,6 +143,10 @@ export function runSyncOnConnect(context: SyncOnConnectContext): Promise<SyncOnC
     createScopePlan: () => contextGraphScope ?? (() => {
       const initialDurableContextGraphIds = [...(getSyncContextGraphs() ?? [])];
       return {
+        initialBootstrapContextGraphIds: [
+          SYSTEM_CONTEXT_GRAPHS.AGENTS,
+          SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+        ],
         initialDurableContextGraphIds,
         contextGraphIdsAfterDiscovery: () => getSyncContextGraphs() ?? [],
       };
@@ -181,7 +181,6 @@ export async function runSyncOnConnectWithScopePlan(
     discoverContextGraphsFromStore,
     syncSharedMemoryFromPeer,
     syncSharedMemoryOnConnect = true,
-    includeSystemContextGraphs = true,
     logInfo,
   } = context;
 
@@ -284,18 +283,20 @@ export async function runSyncOnConnectWithScopePlan(
     }
 
     const scopePlan = createScopePlan();
+    const bootstrapContextGraphIds = scopePlan.initialBootstrapContextGraphIds ?? [
+      SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+    ];
     const initialDurableContextGraphIds = [...scopePlan.initialDurableContextGraphIds];
-    const systemContextGraphIds = includeSystemContextGraphs
-      ? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]
-      : [];
+    const initialSyncContextGraphIds = [...new Set([
+      ...bootstrapContextGraphIds,
+      ...initialDurableContextGraphIds,
+    ])];
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);
     const knownCgsBefore = new Set(initialDurableContextGraphIds);
     const synced = await syncFromPeer(
       remotePeer,
-      [
-        ...systemContextGraphIds,
-        ...initialDurableContextGraphIds,
-      ],
+      initialSyncContextGraphIds,
     );
     const syncedAccounting = recordSyncAccounting(synced, 'durable');
     logInfo(ctx, `Synced ${syncedAccounting.insertedTriples} data triples from peer ${shortPeer}`);
@@ -308,10 +309,7 @@ export async function runSyncOnConnectWithScopePlan(
       return finishSyncAccounting();
     }
 
-    const syncScope = new Set<string>([
-      ...systemContextGraphIds,
-      ...initialDurableContextGraphIds,
-    ]);
+    const syncScope = new Set<string>(initialSyncContextGraphIds);
     await runNonTransportStep(() => refreshMetaSyncedFlags(syncScope));
 
     await runNonTransportStep(() => discoverContextGraphsFromStore());

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -10,7 +10,7 @@ type SyncFromPeerResult = number | SyncProgressSummary;
 
 export interface SyncOnConnectScopePlan {
   /** Bootstrap graphs frozen into the first durable request. */
-  initialBootstrapContextGraphIds?: readonly string[];
+  initialBootstrapContextGraphIds: readonly string[];
   /** Explicit plus automatic CGs frozen for the first durable request. */
   initialDurableContextGraphIds: readonly string[];
   /** Explicit intent re-read after discovery, merged with the frozen automatic tail. */
@@ -61,11 +61,27 @@ interface SyncOnConnectCommonContext {
   onPeerSynced?: (peerId: string, outcome?: SyncOnConnectPeerOutcome) => void;
 }
 
+interface LegacySyncOnConnectScopePlan {
+  /**
+   * New callers should make the bootstrap scope explicit. This stays optional
+   * only at the legacy adapter boundary so existing deep imports keep their
+   * historical system-graph default.
+   */
+  initialBootstrapContextGraphIds?: readonly string[];
+  initialDurableContextGraphIds: readonly string[];
+  contextGraphIdsAfterDiscovery: () => string[];
+}
+
 interface SyncOnConnectContext extends SyncOnConnectCommonContext {
   /** Legacy dynamic scope callback retained at the compatibility boundary. */
   getSyncContextGraphs?: () => string[];
   /** Legacy two-phase scope retained at the compatibility boundary. */
-  contextGraphScope?: SyncOnConnectScopePlan;
+  contextGraphScope?: LegacySyncOnConnectScopePlan;
+  /**
+   * @deprecated Use contextGraphScope.initialBootstrapContextGraphIds. Kept so
+   * existing deep-import callers can still opt out of Agents/Ontology.
+   */
+  includeSystemContextGraphs?: boolean;
 }
 
 interface PlannedSyncOnConnectContext extends SyncOnConnectCommonContext {
@@ -134,19 +150,25 @@ export function runSyncOnConnect(context: SyncOnConnectContext): Promise<SyncOnC
   const {
     getSyncContextGraphs = () => [],
     contextGraphScope,
+    includeSystemContextGraphs = true,
     syncFromPeer,
     ...common
   } = context;
+  const defaultBootstrapContextGraphIds = includeSystemContextGraphs
+    ? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]
+    : [];
   let initialCall = true;
   return runSyncOnConnectWithScopePlan({
     ...common,
-    createScopePlan: () => contextGraphScope ?? (() => {
+    createScopePlan: () => contextGraphScope ? {
+      initialBootstrapContextGraphIds: contextGraphScope.initialBootstrapContextGraphIds
+        ?? defaultBootstrapContextGraphIds,
+      initialDurableContextGraphIds: contextGraphScope.initialDurableContextGraphIds,
+      contextGraphIdsAfterDiscovery: contextGraphScope.contextGraphIdsAfterDiscovery,
+    } : (() => {
       const initialDurableContextGraphIds = [...(getSyncContextGraphs() ?? [])];
       return {
-        initialBootstrapContextGraphIds: [
-          SYSTEM_CONTEXT_GRAPHS.AGENTS,
-          SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
-        ],
+        initialBootstrapContextGraphIds: defaultBootstrapContextGraphIds,
         initialDurableContextGraphIds,
         contextGraphIdsAfterDiscovery: () => getSyncContextGraphs() ?? [],
       };
@@ -283,10 +305,7 @@ export async function runSyncOnConnectWithScopePlan(
     }
 
     const scopePlan = createScopePlan();
-    const bootstrapContextGraphIds = scopePlan.initialBootstrapContextGraphIds ?? [
-      SYSTEM_CONTEXT_GRAPHS.AGENTS,
-      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
-    ];
+    const bootstrapContextGraphIds = scopePlan.initialBootstrapContextGraphIds;
     const initialDurableContextGraphIds = [...scopePlan.initialDurableContextGraphIds];
     const initialSyncContextGraphIds = [...new Set([
       ...bootstrapContextGraphIds,

--- a/packages/agent/test/sync-coverage-evidence-edge-periodic.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-edge-periodic.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { PROTOCOL_SYNC, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  DKGAgent,
+  type ContextGraphSubscriptionRecord,
+  type ContextGraphSubscriptionStore,
+} from '../src/index.js';
+
+const PEER = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error('condition did not become true');
+}
+
+function cleanDurableSyncResult() {
+  return {
+    insertedTriples: 0,
+    insertedDataTriples: 0,
+    insertedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    fetchedMetaTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 10,
+    checkpointAdvances: 0,
+    emptyResponses: 1,
+    metaOnlyResponses: 0,
+    verifiedPrivateOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    backoffWorthyFailures: 0,
+    deferredBackpressure: 0,
+    complete: true,
+  };
+}
+
+function cleanSharedMemorySyncResult() {
+  return {
+    insertedTriples: 0,
+    insertedDataTriples: 0,
+    insertedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    fetchedMetaTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 1,
+    droppedDataTriples: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    backoffWorthyFailures: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+async function createRehydratedEdgeEvidenceAgent(contextGraphId: string): Promise<DKGAgent> {
+  const persisted = new Map<string, ContextGraphSubscriptionRecord>([[contextGraphId, {
+    id: contextGraphId,
+    subscribed: true,
+    synced: false,
+    sharedMemorySynced: false,
+    metaSynced: false,
+    syncAdmission: 'explicit',
+    syncScoped: true,
+  }]]);
+  const contextGraphSubscriptionStore: ContextGraphSubscriptionStore = {
+    loadAll: async () => [...persisted.values()],
+    save: async (record) => { persisted.set(record.id, { ...record }); },
+    delete: async (id) => { persisted.delete(id); },
+  };
+  const agent = await DKGAgent.create({
+    name: 'SyncEvidenceEdgePeriodic',
+    listenHost: '127.0.0.1',
+    nodeRole: 'edge',
+    syncContextGraphs: [],
+    chainAdapter: new MockChainAdapter(),
+    contextGraphSubscriptionStore,
+  });
+  (agent as any).started = true;
+  (agent as any).networkAdmissionCoordinator.isAcceptedPeer = () => true;
+  (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+  (agent as any).discoverContextGraphsFromStore = async () => 0;
+  (agent as any).planSharedMemorySyncContextGraphs = async (
+    _peerId: string,
+    contextGraphIds: string[],
+  ) => ({
+    publicContextGraphIds: [...contextGraphIds],
+    privateRecoverFromCurator: [],
+    eligibleContextGraphIds: [...contextGraphIds],
+  });
+  (agent as any).refreshMetaSyncedFlags = async () => new Set<string>();
+  (agent as any).hasConfirmedMetaState = async () => true;
+  (agent as any).gossip = {
+    subscribe: () => undefined,
+    unsubscribe: () => undefined,
+    onMessage: () => undefined,
+    offMessage: () => undefined,
+  };
+  (agent.node as any).node = {
+    peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
+  };
+  await (agent as any).rehydrateContextGraphSubscriptions();
+  (agent.node as any).node = {
+    getPeers: () => [{ toString: () => PEER }],
+    getConnections: () => [],
+  };
+  (agent as any).getSyncReconcilerProbe = async () => ({
+    protocolsKey: PROTOCOL_SYNC,
+    connectionKey: PEER,
+  });
+  return agent;
+}
+
+describe('Edge periodic sync scope evidence', () => {
+  it('keeps the normal Edge periodic scope when broad sync-on-connect is enabled', async () => {
+    const rehydrated = 'cg-rehydrated-normal-periodic';
+    const runtimeSelected = 'cg-runtime-normal-periodic';
+    const agent = await createRehydratedEdgeEvidenceAgent(rehydrated);
+    (agent as any).config.syncOnConnectEnabled = true;
+    (agent as any).config.syncSharedMemoryOnConnect = true;
+    (agent as any).config.syncContextGraphs.push(runtimeSelected);
+    (agent as any).subscribedContextGraphs.set(runtimeSelected, {
+      subscribed: true,
+      syncMode: 'always-on',
+      syncAdmission: 'explicit',
+      metaSynced: false,
+    });
+    const durableScopes: string[][] = [];
+    const sharedMemoryScopes: string[][] = [];
+    (agent as any).syncFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      durableScopes.push([...contextGraphIds]);
+      return cleanDurableSyncResult();
+    };
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      sharedMemoryScopes.push([...contextGraphIds]);
+      const summary = cleanSharedMemorySyncResult();
+      return {
+        ...summary,
+        contextGraphTerminals: contextGraphIds.map((id) => ({
+          contextGraphId: id,
+          lane: 'shared_memory' as const,
+          disposition: 'settled' as const,
+          result: { ...summary },
+        })),
+      };
+    };
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    await waitFor(() => (agent as any).lastSuccessfulSyncAt.has(PEER));
+
+    expect(durableScopes).toEqual([[
+      SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      rehydrated,
+      runtimeSelected,
+    ]]);
+    expect(sharedMemoryScopes).toEqual([[rehydrated, runtimeSelected]]);
+  });
+});

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -681,48 +681,6 @@ describe('automatic sync coverage runtime evidence', () => {
     expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
   });
 
-  it('keeps the normal Edge periodic scope when broad sync-on-connect is enabled', async () => {
-    const rehydrated = 'cg-rehydrated-normal-periodic';
-    const runtimeSelected = 'cg-runtime-normal-periodic';
-    const agent = await createRehydratedEdgeEvidenceAgent(rehydrated);
-    (agent as any).config.syncOnConnectEnabled = true;
-    (agent as any).config.syncSharedMemoryOnConnect = true;
-    (agent as any).config.syncContextGraphs.push(runtimeSelected);
-    (agent as any).subscribedContextGraphs.set(runtimeSelected, {
-      subscribed: true,
-      syncMode: 'always-on',
-      syncAdmission: 'explicit',
-      metaSynced: false,
-    });
-    const durableScopes: string[][] = [];
-    const sharedMemoryScopes: string[][] = [];
-    (agent as any).syncFromPeerDetailed = async (
-      _peerId: string,
-      contextGraphIds: string[],
-    ) => {
-      durableScopes.push([...contextGraphIds]);
-      return cleanDurableSyncResult();
-    };
-    (agent as any).syncSharedMemoryFromPeerDetailed = async (
-      _peerId: string,
-      contextGraphIds: string[],
-    ) => {
-      sharedMemoryScopes.push([...contextGraphIds]);
-      return withSettledSharedMemoryTerminals(cleanSharedMemorySyncResult(), contextGraphIds);
-    };
-
-    await (agent as any).reconcileSyncFromConnectedPeers();
-    await waitFor(() => (agent as any).lastSuccessfulSyncAt.has(PEER));
-
-    expect(durableScopes).toEqual([[
-      SYSTEM_CONTEXT_GRAPHS.AGENTS,
-      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
-      rehydrated,
-      runtimeSelected,
-    ]]);
-    expect(sharedMemoryScopes).toEqual([[rehydrated, runtimeSelected]]);
-  });
-
   it('drops a rehydrated Edge selection removed during protocol discovery', async () => {
     const contextGraphId = 'cg-edge-protocol-race';
     const agent = await createRehydratedEdgeEvidenceAgent(contextGraphId);

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -681,6 +681,48 @@ describe('automatic sync coverage runtime evidence', () => {
     expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
   });
 
+  it('keeps the normal Edge periodic scope when broad sync-on-connect is enabled', async () => {
+    const rehydrated = 'cg-rehydrated-normal-periodic';
+    const runtimeSelected = 'cg-runtime-normal-periodic';
+    const agent = await createRehydratedEdgeEvidenceAgent(rehydrated);
+    (agent as any).config.syncOnConnectEnabled = true;
+    (agent as any).config.syncSharedMemoryOnConnect = true;
+    (agent as any).config.syncContextGraphs.push(runtimeSelected);
+    (agent as any).subscribedContextGraphs.set(runtimeSelected, {
+      subscribed: true,
+      syncMode: 'always-on',
+      syncAdmission: 'explicit',
+      metaSynced: false,
+    });
+    const durableScopes: string[][] = [];
+    const sharedMemoryScopes: string[][] = [];
+    (agent as any).syncFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      durableScopes.push([...contextGraphIds]);
+      return cleanDurableSyncResult();
+    };
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      sharedMemoryScopes.push([...contextGraphIds]);
+      return withSettledSharedMemoryTerminals(cleanSharedMemorySyncResult(), contextGraphIds);
+    };
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    await waitFor(() => (agent as any).lastSuccessfulSyncAt.has(PEER));
+
+    expect(durableScopes).toEqual([[
+      SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      rehydrated,
+      runtimeSelected,
+    ]]);
+    expect(sharedMemoryScopes).toEqual([[rehydrated, runtimeSelected]]);
+  });
+
   it('drops a rehydrated Edge selection removed during protocol discovery', async () => {
     const contextGraphId = 'cg-edge-protocol-race';
     const agent = await createRehydratedEdgeEvidenceAgent(contextGraphId);

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -142,6 +142,38 @@ describe('runSyncOnConnect callbacks', () => {
     expect(sharedMemoryScopes).toEqual([['cg-saved-always-on']]);
   });
 
+  it('preserves the legacy scoped system-graph opt-out at the compatibility boundary', async () => {
+    const remotePeer = freshPeerIdString();
+    const durableScopes: string[][] = [];
+    const metadataScopes: string[][] = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      includeSystemContextGraphs: false,
+      contextGraphScope: {
+        initialDurableContextGraphIds: ['cg-legacy-scoped'],
+        contextGraphIdsAfterDiscovery: () => ['cg-legacy-scoped'],
+      },
+      syncFromPeer: async (_peerId, contextGraphIds) => {
+        durableScopes.push([...(contextGraphIds ?? [])]);
+        return 1;
+      },
+      refreshMetaSyncedFlags: async (contextGraphIds) => {
+        metadataScopes.push([...contextGraphIds]);
+      },
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async () => 0,
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(durableScopes).toEqual([['cg-legacy-scoped']]);
+    expect(metadataScopes).toEqual([['cg-legacy-scoped']]);
+  });
+
   it('returns deferred-backpressure without marking a zero-progress peer successful', async () => {
     const remotePeer = freshPeerIdString();
     const synced: SyncOnConnectPeerOutcome[] = [];

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -117,10 +117,10 @@ describe('runSyncOnConnect callbacks', () => {
       getPeerProtocols: async () => [PROTOCOL_SYNC],
       knownCorePeerIds: new Set(),
       contextGraphScope: {
+        initialBootstrapContextGraphIds: [],
         initialDurableContextGraphIds: ['cg-saved-always-on'],
         contextGraphIdsAfterDiscovery: () => ['cg-saved-always-on'],
       },
-      includeSystemContextGraphs: false,
       syncFromPeer: async (_peerId, contextGraphIds) => {
         durableScopes.push([...(contextGraphIds ?? [])]);
         return 1;

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
       "test/sync-fetch-coalescing-durable.test.ts",
       "test/sync-coverage-evidence-journal.test.ts",
       "test/sync-coverage-evidence-runtime.test.ts",
+      "test/sync-coverage-evidence-edge-periodic.test.ts",
       "test/sync-backpressure.test.ts",
       "test/sync-policy.test.ts",
       "test/catchup-policy.test.ts",


### PR DESCRIPTION
## User impact

Edge nodes now keep the exact sync policy the operator selected:

- with normal sync-on-connect enabled, periodic recovery still bootstraps system graphs and includes configured/runtime-selected graphs;
- with normal sync-on-connect disabled, an Edge node resumes only its explicitly persisted `always-on` graphs after restart;
- on-demand graphs remain dormant until explicitly requested.

This prevents the persisted-subscription recovery path from accidentally narrowing every Edge periodic round.

## Before

```mermaid
sequenceDiagram
    participant Timer as Periodic reconciler
    participant Edge as Edge node
    participant Peer as Sync peer
    Timer->>Edge: Start periodic round
    Edge->>Edge: Detect Edge periodic trigger
    Edge->>Edge: Replace normal plan with persisted always-on scope
    Edge->>Peer: Sync only persisted always-on CGs
    Note over Edge,Peer: System and configured runtime scope can be dropped even when broad sync is enabled
```

## After

```mermaid
sequenceDiagram
    participant Timer as Periodic reconciler
    participant Edge as Edge node
    participant Peer as Sync peer
    Timer->>Edge: Start periodic round
    alt Broad sync-on-connect enabled
        Edge->>Edge: Preserve normal data-driven scope plan
        Edge->>Peer: Bootstrap system CGs and sync configured or selected CGs
    else Broad sync-on-connect disabled
        Edge->>Edge: Load persisted explicit always-on CGs
        Edge->>Peer: Resume only those CGs without system bootstrap
    end
```

## Implementation

- moves initial system bootstrap CGs into `SyncOnConnectScopePlan` data;
- limits the scoped Edge resume policy to periodic rounds where broad sync-on-connect is disabled;
- preserves the normal Core and Edge scope plan on unchanged paths;
- adds regression evidence for both broad periodic scope and scoped always-on recovery.

## Validation

- `pnpm --filter @origintrail-official/dkg-agent build`
- focused sync suite: 4 files, 114 tests passed
  - `sync-on-connect-retry.test.ts`
  - `sync-coverage-evidence-runtime.test.ts`
  - `sync-on-connect-churn.test.ts`
  - `discovery-subscription-boundary.test.ts`
- `git diff --check`

Stacked on #2038.
