### PR TITLE
fix(rfc64): resume fresh durable Edge selections

### DIFF
--- a/devnet/rfc64-m1-selective-coverage/runtime.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/runtime.test.ts
@@ -311,7 +311,7 @@ class ScriptedRuntime implements SelectiveCoverageRuntimeV1 {
       source: 'reconciler',
       trigger: 'periodic-reconciler',
       syncMode: 'always-on',
-      rehydratedSelectionCount: 1,
+      durableSelectionCount: 1,
       evidenceTruncated: false,
       state: 'complete',
       verified: { metadata: true, durable: true, sharedMemory: true },

--- a/devnet/rfc64-m1-selective-coverage/sync-coverage-journal.ts
+++ b/devnet/rfc64-m1-selective-coverage/sync-coverage-journal.ts
@@ -50,7 +50,7 @@ export function assertEdgeReconcilerJournalV1(
     || entry['source'] !== 'reconciler'
     || entry['trigger'] !== 'periodic-reconciler'
     || entry['syncMode'] !== 'always-on'
-    || !positiveInteger(entry['rehydratedSelectionCount'])
+    || !positiveInteger(entry['durableSelectionCount'])
     || !verifiedPlanes(entry['verified'])) {
     throw new Error('Edge automatic completion lacks exact reconciler journal provenance');
   }

--- a/devnet/rfc64-m1-selective-coverage/verifier.test.ts
+++ b/devnet/rfc64-m1-selective-coverage/verifier.test.ts
@@ -193,7 +193,7 @@ function fixture(): SelectiveCoverageEvidenceV1 {
         source: 'reconciler',
         trigger: 'periodic-reconciler',
         syncMode: 'always-on',
-        rehydratedSelectionCount: 1,
+        durableSelectionCount: 1,
         evidenceTruncated: false,
         state: 'complete',
         verified: { metadata: true, durable: true, sharedMemory: true },

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1574,6 +1574,12 @@ export class DKGAgentBase {
    * `SYNC_BACKOFF_BASE_MS`.
    */
   protected readonly syncReconcilerBackoff = new Map<string, SyncReconcilerBackoff>();
+  /**
+   * Edge periodic-sync admission derived only from committed durable explicit
+   * always-on member intent. Kept separate from startup rehydration diagnostics
+   * so post-boot persistence cannot redefine rehydration bookkeeping.
+   */
+  protected readonly durableAlwaysOnEdgeIds = new Set<string>();
   protected syncReconcilerTimer: ReturnType<typeof setInterval> | null = null;
   /** A.4-lite+: periodic warm/pinned Core-connection reconcile (opt-in). */
   protected warmCoreTimer: ReturnType<typeof setInterval> | null = null;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -6976,7 +6976,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
   updateContextGraphSubscriptionRehydrationStatusAfterPersist(this: DKGAgent,
     contextGraphId: string,
-    next?: Pick<ContextGraphSubscriptionRecord, 'subscribed' | 'coreHosted'>,
+    next?: Pick<ContextGraphSubscriptionRecord, 'subscribed' | 'coreHosted' | 'syncAdmission'>,
   ): void {
     const status = this.contextGraphSubscriptionRehydrationStatus;
     if (!status) return;
@@ -6992,8 +6992,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let activated = status.activated;
     let dormantIds = status.dormantIds.filter((id) => id !== contextGraphId);
     let nextHostedActivatedIds = hostedActivatedIds.filter((id) => id !== contextGraphId);
+    let nextRehydratedAlwaysOnIds = (status.rehydratedAlwaysOnIds ?? [])
+      .filter((id) => id !== contextGraphId);
     if (next?.coreHosted === true) {
       nextHostedActivatedIds = sortIds([...nextHostedActivatedIds, contextGraphId]);
+    }
+    // A freshly configured Edge selection is just as durable as one loaded
+    // from a previous process once this save commits. Admit it to the bounded
+    // periodic lane now so a first cold boot with broad sync-on-connect
+    // disabled does not require an otherwise pointless restart. On-demand
+    // subscriptions never reach this branch because their persistence
+    // projection is `skip`.
+    if (
+      (this.config.nodeRole ?? 'edge') === 'edge'
+      && next?.subscribed === true
+      && next.syncAdmission === 'explicit'
+    ) {
+      nextRehydratedAlwaysOnIds = sortIds([
+        ...nextRehydratedAlwaysOnIds,
+        contextGraphId,
+      ]);
     }
 
     if (isPersisted) {
@@ -7017,6 +7035,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       persistedTotal,
       hostedActivated: nextHostedActivatedIds.length,
       hostedActivatedIds: nextHostedActivatedIds,
+      rehydratedAlwaysOnIds: nextRehydratedAlwaysOnIds,
       activated,
       dormant: dormantIds.length,
       dormantIds,
@@ -7033,6 +7052,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const systemContextGraphs = new Set<string>(Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]);
     const dormantIds = [...status.dormantIds];
     const hostedActivatedIds = [...(status.hostedActivatedIds ?? [])];
+    const rehydratedAlwaysOnIds = [...(status.rehydratedAlwaysOnIds ?? [])];
     const removeFrom = (ids: string[], id: string): boolean => {
       const index = ids.indexOf(id);
       if (index < 0) return false;
@@ -7048,6 +7068,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const wasAccounted = this.contextGraphSubscriptionRehydrationAccountedIds.delete(id);
       const wasDormant = removeFrom(dormantIds, id);
       removeFrom(hostedActivatedIds, id);
+      removeFrom(rehydratedAlwaysOnIds, id);
       if (!wasAccounted) continue;
       persistedTotal = Math.max(0, persistedTotal - 1);
       if (!wasDormant) {
@@ -7058,6 +7079,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       if (systemContextGraphs.has(id) || clearedSet.has(id)) continue;
       if (!this.contextGraphSubscriptionRehydrationAccountedIds.has(id)) continue;
       removeFrom(hostedActivatedIds, id);
+      removeFrom(rehydratedAlwaysOnIds, id);
       if (!dormantIds.includes(id)) {
         activated = Math.max(0, activated - 1);
         dormantIds.push(id);
@@ -7070,6 +7092,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       persistedTotal,
       hostedActivated: hostedActivatedIds.length,
       hostedActivatedIds,
+      rehydratedAlwaysOnIds,
       activated,
       dormant: dormantIds.length,
       dormantIds,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -957,34 +957,34 @@ interface LifecycleSyncInvocationPolicy {
 }
 
 function createLifecycleSyncInvocationPolicy(input: {
-  readonly initialRehydratedAlwaysOnContextGraphIds: readonly string[];
+  readonly initialDurableAlwaysOnEdgeContextGraphIds: readonly string[];
   readonly nodeRole: 'core' | 'edge';
   readonly syncOnConnect: boolean;
   readonly syncSharedMemoryOnConnect: boolean;
   readonly trigger: SyncCoverageEvidenceTrigger | undefined;
-  getLiveRehydratedAlwaysOnContextGraphIds(): string[];
+  getLiveDurableAlwaysOnEdgeContextGraphIds(): string[];
 }): LifecycleSyncInvocationPolicy {
   const periodicEdgeScopedResume = input.nodeRole === 'edge'
     && input.trigger === 'periodic-reconciler'
     && !input.syncOnConnect;
   if (periodicEdgeScopedResume) {
     return {
-      canStart: input.initialRehydratedAlwaysOnContextGraphIds.length > 0,
+      canStart: input.initialDurableAlwaysOnEdgeContextGraphIds.length > 0,
       syncSharedMemory: true,
       buildScopePlan: (defaultPlan) => {
-        const live = input.getLiveRehydratedAlwaysOnContextGraphIds();
+        const live = input.getLiveDurableAlwaysOnEdgeContextGraphIds();
         return {
           effectiveBatchSize: Math.min(defaultPlan.effectiveBatchSize, live.length),
           automaticContextGraphIds: [],
           initialBootstrapContextGraphIds: [],
           initialDurableContextGraphIds: [...live],
-          contextGraphIdsAfterDiscovery: input.getLiveRehydratedAlwaysOnContextGraphIds,
+          contextGraphIdsAfterDiscovery: input.getLiveDurableAlwaysOnEdgeContextGraphIds,
         };
       },
       requestedSharedMemoryContextGraphIds: () =>
-        input.getLiveRehydratedAlwaysOnContextGraphIds(),
+        input.getLiveDurableAlwaysOnEdgeContextGraphIds(),
       filterSharedMemoryPlan: (plan) => {
-        const live = new Set(input.getLiveRehydratedAlwaysOnContextGraphIds());
+        const live = new Set(input.getLiveDurableAlwaysOnEdgeContextGraphIds());
         return {
           ...plan,
           eligibleContextGraphIds: plan.eligibleContextGraphIds.filter((id) => live.has(id)),
@@ -3939,17 +3939,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
   }
 
-  /** Canonical live subset of this process's startup-rehydrated Edge intent. */
-  protected getRehydratedAlwaysOnEvidenceContextGraphIds(
+  /** Canonical live subset of committed durable explicit Edge intent. */
+  protected getDurableAlwaysOnEdgeContextGraphIds(
     this: DKGAgent,
     selectedContextGraphIds: readonly string[],
   ): string[] {
-    const startupRehydrated = new Set(
-      this.contextGraphSubscriptionRehydrationStatus?.rehydratedAlwaysOnIds ?? [],
-    );
     return [...new Set(selectedContextGraphIds)].filter((contextGraphId) => {
       const subscription = this.subscribedContextGraphs.get(contextGraphId);
-      return startupRehydrated.has(contextGraphId)
+      return this.durableAlwaysOnEdgeIds.has(contextGraphId)
         && subscription?.subscribed === true
         && subscription.syncAdmission === 'explicit'
         && subscription.syncMode === 'always-on';
@@ -3974,19 +3971,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const trigger = invocation?.[automaticSyncInvocationBrand] === true
       ? invocation.trigger
       : undefined;
-    const getLiveRehydratedAlwaysOnContextGraphIds = () => {
+    const getLiveDurableAlwaysOnEdgeContextGraphIds = () => {
       const configured = [...new Set(this.config.syncContextGraphs ?? [])];
-      return this.getRehydratedAlwaysOnEvidenceContextGraphIds(configured);
+      return this.getDurableAlwaysOnEdgeContextGraphIds(configured);
     };
-    const initialRehydratedAlwaysOnContextGraphIds =
-      getLiveRehydratedAlwaysOnContextGraphIds();
+    const initialDurableAlwaysOnEdgeContextGraphIds =
+      getLiveDurableAlwaysOnEdgeContextGraphIds();
     const invocationPolicy = createLifecycleSyncInvocationPolicy({
-      initialRehydratedAlwaysOnContextGraphIds,
+      initialDurableAlwaysOnEdgeContextGraphIds,
       nodeRole: this.config.nodeRole ?? 'edge',
       syncOnConnect: syncOnConnectEnabled(this.config),
       syncSharedMemoryOnConnect: this.config.syncSharedMemoryOnConnect ?? true,
       trigger,
-      getLiveRehydratedAlwaysOnContextGraphIds,
+      getLiveDurableAlwaysOnEdgeContextGraphIds,
     });
     if (!invocationPolicy.canStart) {
       return 'not-started';
@@ -4007,15 +4004,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
     const createScopePlan = () => {
       const configuredContextGraphIds = [...new Set(this.config.syncContextGraphs ?? [])];
-      const rehydratedAlwaysOnContextGraphIds =
-        getLiveRehydratedAlwaysOnContextGraphIds();
+      const durableAlwaysOnEdgeContextGraphIds =
+        getLiveDurableAlwaysOnEdgeContextGraphIds();
       const defaultScopePlan = this.planCorePublicSyncPeerRound(remotePeer);
       const scopePlan = invocationPolicy.buildScopePlan(defaultScopePlan);
       evidence.beginRound({
         effectiveBatchSize: scopePlan.effectiveBatchSize,
         selectedContextGraphIds: configuredContextGraphIds,
         automaticContextGraphIds: scopePlan.automaticContextGraphIds,
-        rehydratedAlwaysOnContextGraphIds,
+        durableAlwaysOnEdgeContextGraphIds,
       });
       return scopePlan;
     };
@@ -4344,7 +4341,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!syncReconcilerEnabled(this.config)) return;
     if (!syncOnConnectEnabled(this.config)) {
       const hasScopedEdgeResume = (this.config.nodeRole ?? 'edge') === 'edge'
-        && this.getRehydratedAlwaysOnEvidenceContextGraphIds(
+        && this.getDurableAlwaysOnEdgeContextGraphIds(
           this.config.syncContextGraphs ?? [],
         ).length > 0;
       if (!hasScopedEdgeResume) return;
@@ -6974,9 +6971,34 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.contextGraphSubscriptionPersistCanceledRevisions.delete(contextGraphId);
   }
 
-  updateContextGraphSubscriptionRehydrationStatusAfterPersist(this: DKGAgent,
+  updateDurableAlwaysOnEdgeAdmissionAfterPersist(this: DKGAgent,
     contextGraphId: string,
     next?: Pick<ContextGraphSubscriptionRecord, 'subscribed' | 'coreHosted' | 'syncAdmission'>,
+  ): void {
+    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) return;
+    this.durableAlwaysOnEdgeIds.delete(contextGraphId);
+    // The persistence projection is the canonical boundary: on-demand member
+    // intent is projected to `skip` and can never reach this committed-write
+    // callback. Only an authoritative successful Edge save may enter the
+    // periodic lane.
+    if (
+      (this.config.nodeRole ?? 'edge') === 'edge'
+      && next?.subscribed === true
+      && next.syncAdmission === 'explicit'
+    ) {
+      this.durableAlwaysOnEdgeIds.add(contextGraphId);
+    }
+  }
+
+  removeDurableAlwaysOnEdgeAdmission(this: DKGAgent, contextGraphIds: Iterable<string>): void {
+    for (const contextGraphId of contextGraphIds) {
+      this.durableAlwaysOnEdgeIds.delete(contextGraphId);
+    }
+  }
+
+  updateContextGraphSubscriptionRehydrationStatusAfterPersist(this: DKGAgent,
+    contextGraphId: string,
+    next?: Pick<ContextGraphSubscriptionRecord, 'subscribed' | 'coreHosted'>,
   ): void {
     const status = this.contextGraphSubscriptionRehydrationStatus;
     if (!status) return;
@@ -6992,26 +7014,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let activated = status.activated;
     let dormantIds = status.dormantIds.filter((id) => id !== contextGraphId);
     let nextHostedActivatedIds = hostedActivatedIds.filter((id) => id !== contextGraphId);
-    let nextRehydratedAlwaysOnIds = (status.rehydratedAlwaysOnIds ?? [])
-      .filter((id) => id !== contextGraphId);
     if (next?.coreHosted === true) {
       nextHostedActivatedIds = sortIds([...nextHostedActivatedIds, contextGraphId]);
-    }
-    // A freshly configured Edge selection is just as durable as one loaded
-    // from a previous process once this save commits. Admit it to the bounded
-    // periodic lane now so a first cold boot with broad sync-on-connect
-    // disabled does not require an otherwise pointless restart. On-demand
-    // subscriptions never reach this branch because their persistence
-    // projection is `skip`.
-    if (
-      (this.config.nodeRole ?? 'edge') === 'edge'
-      && next?.subscribed === true
-      && next.syncAdmission === 'explicit'
-    ) {
-      nextRehydratedAlwaysOnIds = sortIds([
-        ...nextRehydratedAlwaysOnIds,
-        contextGraphId,
-      ]);
     }
 
     if (isPersisted) {
@@ -7035,7 +7039,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       persistedTotal,
       hostedActivated: nextHostedActivatedIds.length,
       hostedActivatedIds: nextHostedActivatedIds,
-      rehydratedAlwaysOnIds: nextRehydratedAlwaysOnIds,
       activated,
       dormant: dormantIds.length,
       dormantIds,
@@ -7052,7 +7055,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const systemContextGraphs = new Set<string>(Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]);
     const dormantIds = [...status.dormantIds];
     const hostedActivatedIds = [...(status.hostedActivatedIds ?? [])];
-    const rehydratedAlwaysOnIds = [...(status.rehydratedAlwaysOnIds ?? [])];
     const removeFrom = (ids: string[], id: string): boolean => {
       const index = ids.indexOf(id);
       if (index < 0) return false;
@@ -7068,7 +7070,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const wasAccounted = this.contextGraphSubscriptionRehydrationAccountedIds.delete(id);
       const wasDormant = removeFrom(dormantIds, id);
       removeFrom(hostedActivatedIds, id);
-      removeFrom(rehydratedAlwaysOnIds, id);
       if (!wasAccounted) continue;
       persistedTotal = Math.max(0, persistedTotal - 1);
       if (!wasDormant) {
@@ -7079,7 +7080,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       if (systemContextGraphs.has(id) || clearedSet.has(id)) continue;
       if (!this.contextGraphSubscriptionRehydrationAccountedIds.has(id)) continue;
       removeFrom(hostedActivatedIds, id);
-      removeFrom(rehydratedAlwaysOnIds, id);
       if (!dormantIds.includes(id)) {
         activated = Math.max(0, activated - 1);
         dormantIds.push(id);
@@ -7092,7 +7092,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       persistedTotal,
       hostedActivated: hostedActivatedIds.length,
       hostedActivatedIds,
-      rehydratedAlwaysOnIds,
       activated,
       dormant: dormantIds.length,
       dormantIds,
@@ -7156,10 +7155,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (persistence.action === 'delete') {
       void this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, () => store.delete(contextGraphId))
         .then(() => {
-          if (
-            options?.updateRehydrationStatus === true &&
-            this.claimContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
-          ) {
+          if (!this.claimContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision)) return;
+          this.updateDurableAlwaysOnEdgeAdmissionAfterPersist(contextGraphId, undefined);
+          if (options?.updateRehydrationStatus === true) {
             this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, undefined);
           }
         })
@@ -7177,10 +7175,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const record = persistence.record;
     void this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, () => store.save(record))
       .then(() => {
-        if (
-          options?.updateRehydrationStatus === true &&
-          this.claimContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
-        ) {
+        if (!this.claimContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision)) return;
+        this.updateDurableAlwaysOnEdgeAdmissionAfterPersist(contextGraphId, record);
+        if (options?.updateRehydrationStatus === true) {
           this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, record);
         }
       }).catch((err) => {
@@ -7493,6 +7490,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ...status,
       hostedActivatedIds: [...(status.hostedActivatedIds ?? [])],
       rehydratedAlwaysOnIds: [...(status.rehydratedAlwaysOnIds ?? [])],
+      durableAlwaysOnEdgeIds: [...this.durableAlwaysOnEdgeIds]
+        .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
       dormantIds: [...status.dormantIds],
     };
   }
@@ -7500,6 +7499,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async rehydrateContextGraphSubscriptions(this: DKGAgent): Promise<void> {
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) return;
+    this.durableAlwaysOnEdgeIds.clear();
     const ctx = createOperationContext('init');
     try {
       // System context graphs (AGENTS/ONTOLOGY) are auto-subscribed separately
@@ -7710,6 +7710,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           && syncAdmission === 'explicit'
         ) {
           rehydratedAlwaysOnIds.push(row.id);
+          this.durableAlwaysOnEdgeIds.add(row.id);
         }
         if (row.subscribed) {
           this.subscribeToContextGraph(row.id, {
@@ -7793,6 +7794,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         );
       }
     } catch (err) {
+      // Rehydration is an all-or-nothing admission boundary. A partially
+      // visited durable row set must not become eligible after startup failed.
+      this.durableAlwaysOnEdgeIds.clear();
       this.log.warn(ctx, `Failed to rehydrate persisted context-graph subscriptions: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
@@ -7914,6 +7918,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
     }
     if (cleared > 0 || deactivatedIds.length > 0) {
+      this.removeDurableAlwaysOnEdgeAdmission([...clearedIds, ...deactivatedIds]);
       this.updateContextGraphSubscriptionRehydrationStatusAfterClear(clearedIds, deactivatedIds);
     }
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -809,12 +809,14 @@ export interface ContextGraphSubscriptionRehydrationStatus {
   systemExcluded: number;
   hostedActivated: number;
   hostedActivatedIds: string[];
-  /**
-   * Edge always-on selections backed by durable subscription intent in this
-   * process. This includes rows restored during startup and selections whose
-   * first durable write completes after startup.
-   */
+  /** Explicit Edge always-on selections restored during startup rehydration. */
   rehydratedAlwaysOnIds?: string[];
+  /**
+   * Live periodic-admission set backed by committed durable explicit Edge
+   * always-on intent. Includes startup-restored rows and successful post-boot
+   * writes; excludes on-demand, deactivated, and cleared selections.
+   */
+  durableAlwaysOnEdgeIds?: string[];
   activated: number;
   dormant: number;
   activationCap: number;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -809,7 +809,11 @@ export interface ContextGraphSubscriptionRehydrationStatus {
   systemExcluded: number;
   hostedActivated: number;
   hostedActivatedIds: string[];
-  /** Edge always-on selections restored during this process's startup wave. */
+  /**
+   * Edge always-on selections backed by durable subscription intent in this
+   * process. This includes rows restored during startup and selections whose
+   * first durable write completes after startup.
+   */
   rehydratedAlwaysOnIds?: string[];
   activated: number;
   dormant: number;

--- a/packages/agent/src/sync/coverage-evidence-journal.ts
+++ b/packages/agent/src/sync/coverage-evidence-journal.ts
@@ -32,7 +32,7 @@ export interface EdgeReconcilerSyncCoverageEvidence extends SyncCoverageEvidence
   source: 'reconciler';
   trigger: 'periodic-reconciler';
   syncMode: 'always-on';
-  rehydratedSelectionCount: number;
+  durableSelectionCount: number;
   evidenceTruncated: boolean;
   verified: SyncCoverageVerifiedPlanes;
 }
@@ -283,7 +283,7 @@ export class SyncCoverageEvidenceJournal {
         source: 'reconciler',
         trigger: 'periodic-reconciler',
         syncMode: 'always-on',
-        rehydratedSelectionCount: bounded.count,
+        durableSelectionCount: bounded.count,
         evidenceTruncated: bounded.truncated,
         state: 'running',
         verified: { metadata: false, durable: false, sharedMemory: false },
@@ -319,7 +319,7 @@ export class SyncCoverageEvidenceJournal {
       source: 'reconciler',
       trigger: 'periodic-reconciler',
       syncMode: 'always-on',
-      rehydratedSelectionCount: running.rehydratedSelectionCount,
+      durableSelectionCount: running.durableSelectionCount,
       evidenceTruncated: running.evidenceTruncated,
       state: input.operationCompleted
         && !running.evidenceTruncated

--- a/packages/agent/src/sync/coverage-evidence-recorder.ts
+++ b/packages/agent/src/sync/coverage-evidence-recorder.ts
@@ -22,7 +22,7 @@ export interface SyncCoverageEvidenceRoundInput {
   effectiveBatchSize: number;
   selectedContextGraphIds: readonly string[];
   automaticContextGraphIds: readonly string[];
-  rehydratedAlwaysOnContextGraphIds: readonly string[];
+  durableAlwaysOnEdgeContextGraphIds: readonly string[];
   startedAt?: number;
 }
 
@@ -64,11 +64,11 @@ export class SyncCoverageEvidenceRecorder {
       });
     }
     if (this.options.nodeRole === 'edge' && trigger === 'periodic-reconciler') {
-      for (const contextGraphId of input.rehydratedAlwaysOnContextGraphIds) {
+      for (const contextGraphId of input.durableAlwaysOnEdgeContextGraphIds) {
         this.evidenceContextGraphs.add(contextGraphId);
       }
       this.edgeRunning = this.options.journal.startEdgeReconcilerJobs({
-        contextGraphIds: input.rehydratedAlwaysOnContextGraphIds,
+        contextGraphIds: input.durableAlwaysOnEdgeContextGraphIds,
         startedAt,
       });
     }

--- a/packages/agent/test/sync-coverage-evidence-edge-periodic.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-edge-periodic.test.ts
@@ -65,26 +65,41 @@ function cleanSharedMemorySyncResult() {
   };
 }
 
-async function createRehydratedEdgeEvidenceAgent(contextGraphId: string): Promise<DKGAgent> {
-  const persisted = new Map<string, ContextGraphSubscriptionRecord>([[contextGraphId, {
-    id: contextGraphId,
-    subscribed: true,
-    synced: false,
-    sharedMemorySynced: false,
-    metaSynced: false,
-    syncAdmission: 'explicit',
-    syncScoped: true,
-  }]]);
+interface EdgeEvidenceFixtureOptions {
+  name: string;
+  persistedRows?: ContextGraphSubscriptionRecord[];
+  syncContextGraphs?: string[];
+  syncOnConnectEnabled?: boolean;
+  syncSharedMemoryOnConnect?: boolean;
+  failDeletes?: ReadonlySet<string>;
+  afterRehydrate?: (
+    agent: DKGAgent,
+    persisted: Map<string, ContextGraphSubscriptionRecord>,
+  ) => void | Promise<void>;
+}
+
+async function createEdgeEvidenceAgent(options: EdgeEvidenceFixtureOptions): Promise<{
+  agent: DKGAgent;
+  persisted: Map<string, ContextGraphSubscriptionRecord>;
+}> {
+  const persisted = new Map<string, ContextGraphSubscriptionRecord>(
+    (options.persistedRows ?? []).map((row) => [row.id, { ...row }]),
+  );
   const contextGraphSubscriptionStore: ContextGraphSubscriptionStore = {
     loadAll: async () => [...persisted.values()],
     save: async (record) => { persisted.set(record.id, { ...record }); },
-    delete: async (id) => { persisted.delete(id); },
+    delete: async (id) => {
+      if (options.failDeletes?.has(id)) throw new Error(`delete failed for ${id}`);
+      persisted.delete(id);
+    },
   };
   const agent = await DKGAgent.create({
-    name: 'SyncEvidenceEdgePeriodic',
+    name: options.name,
     listenHost: '127.0.0.1',
     nodeRole: 'edge',
-    syncContextGraphs: [],
+    syncContextGraphs: options.syncContextGraphs ?? [],
+    syncOnConnectEnabled: options.syncOnConnectEnabled,
+    syncSharedMemoryOnConnect: options.syncSharedMemoryOnConnect,
     chainAdapter: new MockChainAdapter(),
     contextGraphSubscriptionStore,
   });
@@ -112,6 +127,7 @@ async function createRehydratedEdgeEvidenceAgent(contextGraphId: string): Promis
     peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
   };
   await (agent as any).rehydrateContextGraphSubscriptions();
+  await options.afterRehydrate?.(agent, persisted);
   (agent.node as any).node = {
     getPeers: () => [{ toString: () => PEER }],
     getConnections: () => [],
@@ -119,72 +135,48 @@ async function createRehydratedEdgeEvidenceAgent(contextGraphId: string): Promis
   (agent as any).getSyncReconcilerProbe = async () => ({
     protocolsKey: PROTOCOL_SYNC,
     connectionKey: PEER,
+  });
+  return { agent, persisted };
+}
+
+async function createRehydratedEdgeEvidenceAgent(contextGraphId: string): Promise<DKGAgent> {
+  const { agent } = await createEdgeEvidenceAgent({
+    name: 'SyncEvidenceEdgePeriodic',
+    persistedRows: [{
+      id: contextGraphId,
+      subscribed: true,
+      synced: false,
+      sharedMemorySynced: false,
+      metaSynced: false,
+      syncAdmission: 'explicit',
+      syncScoped: true,
+    }],
   });
   return agent;
 }
 
 async function createFreshConfiguredEdgeEvidenceAgent(contextGraphId: string): Promise<DKGAgent> {
-  const persisted = new Map<string, ContextGraphSubscriptionRecord>();
-  const contextGraphSubscriptionStore: ContextGraphSubscriptionStore = {
-    loadAll: async () => [...persisted.values()],
-    save: async (record) => { persisted.set(record.id, { ...record }); },
-    delete: async (id) => { persisted.delete(id); },
-  };
-  const agent = await DKGAgent.create({
+  const { agent, persisted } = await createEdgeEvidenceAgent({
     name: 'SyncEvidenceFreshConfiguredEdgePeriodic',
-    listenHost: '127.0.0.1',
-    nodeRole: 'edge',
     syncContextGraphs: [contextGraphId],
     syncOnConnectEnabled: false,
     syncSharedMemoryOnConnect: false,
-    chainAdapter: new MockChainAdapter(),
-    contextGraphSubscriptionStore,
-  });
-  (agent as any).started = true;
-  (agent as any).networkAdmissionCoordinator.isAcceptedPeer = () => true;
-  (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
-  (agent as any).discoverContextGraphsFromStore = async () => 0;
-  (agent as any).planSharedMemorySyncContextGraphs = async (
-    _peerId: string,
-    contextGraphIds: string[],
-  ) => ({
-    publicContextGraphIds: [...contextGraphIds],
-    privateRecoverFromCurator: [],
-    eligibleContextGraphIds: [...contextGraphIds],
-  });
-  (agent as any).refreshMetaSyncedFlags = async () => new Set<string>();
-  (agent as any).hasConfirmedMetaState = async () => true;
-  (agent as any).gossip = {
-    subscribe: () => undefined,
-    unsubscribe: () => undefined,
-    onMessage: () => undefined,
-    offMessage: () => undefined,
-  };
-  (agent.node as any).node = {
-    peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
-  };
-  await (agent as any).rehydrateContextGraphSubscriptions();
-  (agent as any).setContextGraphSubscription(contextGraphId, {
-    subscribed: true,
-    synced: false,
-    sharedMemorySynced: false,
-    metaSynced: false,
-    syncMode: 'always-on',
-    syncAdmission: 'explicit',
+    afterRehydrate: (freshAgent) => {
+      (freshAgent as any).setContextGraphSubscription(contextGraphId, {
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncMode: 'always-on',
+        syncAdmission: 'explicit',
+      });
+    },
   });
   await waitFor(() => (
     persisted.has(contextGraphId)
     && agent.getContextGraphSubscriptionRehydrationStatus()
-      ?.rehydratedAlwaysOnIds?.includes(contextGraphId) === true
+      ?.durableAlwaysOnEdgeIds?.includes(contextGraphId) === true
   ));
-  (agent.node as any).node = {
-    getPeers: () => [{ toString: () => PEER }],
-    getConnections: () => [],
-  };
-  (agent as any).getSyncReconcilerProbe = async () => ({
-    protocolsKey: PROTOCOL_SYNC,
-    connectionKey: PEER,
-  });
   return agent;
 }
 
@@ -225,6 +217,58 @@ describe('Edge periodic sync scope evidence', () => {
     expect(sharedMemoryScopes).toEqual([[configured]]);
     expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.AGENTS);
     expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+  });
+
+  it.each([
+    { label: 'cleared', failDelete: false },
+    { label: 'deactivated after a failed delete', failDelete: true },
+  ])('removes a $label durable Edge selection from periodic admission', async ({ failDelete }) => {
+    const contextGraphId = `cg-periodic-cleanup-${failDelete ? 'deactivated' : 'cleared'}`;
+    const { agent } = await createEdgeEvidenceAgent({
+      name: 'SyncEvidenceEdgePeriodicCleanup',
+      persistedRows: [{
+        id: contextGraphId,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncAdmission: 'explicit',
+        syncScoped: true,
+      }],
+      syncContextGraphs: [contextGraphId],
+      syncOnConnectEnabled: false,
+      syncSharedMemoryOnConnect: false,
+      failDeletes: failDelete ? new Set([contextGraphId]) : undefined,
+    });
+    expect(agent.getContextGraphSubscriptionRehydrationStatus()?.durableAlwaysOnEdgeIds)
+      .toEqual([contextGraphId]);
+
+    const cleared = await agent.clearContextGraphSubscriptions();
+    expect(cleared).toBe(failDelete ? 0 : 1);
+    const status = agent.getContextGraphSubscriptionRehydrationStatus();
+    expect(status?.durableAlwaysOnEdgeIds).toEqual([]);
+    expect(status?.dormantIds.includes(contextGraphId)).toBe(failDelete);
+
+    const durableScopes: string[][] = [];
+    const sharedMemoryScopes: string[][] = [];
+    (agent as any).syncFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      durableScopes.push([...contextGraphIds]);
+      return cleanDurableSyncResult();
+    };
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      sharedMemoryScopes.push([...contextGraphIds]);
+      return cleanSharedMemorySyncResult();
+    };
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    expect(durableScopes).toEqual([]);
+    expect(sharedMemoryScopes).toEqual([]);
   });
 
   it('keeps the normal Edge periodic scope when broad sync-on-connect is enabled', async () => {

--- a/packages/agent/test/sync-coverage-evidence-edge-periodic.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-edge-periodic.test.ts
@@ -123,7 +123,110 @@ async function createRehydratedEdgeEvidenceAgent(contextGraphId: string): Promis
   return agent;
 }
 
+async function createFreshConfiguredEdgeEvidenceAgent(contextGraphId: string): Promise<DKGAgent> {
+  const persisted = new Map<string, ContextGraphSubscriptionRecord>();
+  const contextGraphSubscriptionStore: ContextGraphSubscriptionStore = {
+    loadAll: async () => [...persisted.values()],
+    save: async (record) => { persisted.set(record.id, { ...record }); },
+    delete: async (id) => { persisted.delete(id); },
+  };
+  const agent = await DKGAgent.create({
+    name: 'SyncEvidenceFreshConfiguredEdgePeriodic',
+    listenHost: '127.0.0.1',
+    nodeRole: 'edge',
+    syncContextGraphs: [contextGraphId],
+    syncOnConnectEnabled: false,
+    syncSharedMemoryOnConnect: false,
+    chainAdapter: new MockChainAdapter(),
+    contextGraphSubscriptionStore,
+  });
+  (agent as any).started = true;
+  (agent as any).networkAdmissionCoordinator.isAcceptedPeer = () => true;
+  (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+  (agent as any).discoverContextGraphsFromStore = async () => 0;
+  (agent as any).planSharedMemorySyncContextGraphs = async (
+    _peerId: string,
+    contextGraphIds: string[],
+  ) => ({
+    publicContextGraphIds: [...contextGraphIds],
+    privateRecoverFromCurator: [],
+    eligibleContextGraphIds: [...contextGraphIds],
+  });
+  (agent as any).refreshMetaSyncedFlags = async () => new Set<string>();
+  (agent as any).hasConfirmedMetaState = async () => true;
+  (agent as any).gossip = {
+    subscribe: () => undefined,
+    unsubscribe: () => undefined,
+    onMessage: () => undefined,
+    offMessage: () => undefined,
+  };
+  (agent.node as any).node = {
+    peerId: { toString: () => '12D3KooWLocalEvidencePeer' },
+  };
+  await (agent as any).rehydrateContextGraphSubscriptions();
+  (agent as any).setContextGraphSubscription(contextGraphId, {
+    subscribed: true,
+    synced: false,
+    sharedMemorySynced: false,
+    metaSynced: false,
+    syncMode: 'always-on',
+    syncAdmission: 'explicit',
+  });
+  await waitFor(() => (
+    persisted.has(contextGraphId)
+    && agent.getContextGraphSubscriptionRehydrationStatus()
+      ?.rehydratedAlwaysOnIds?.includes(contextGraphId) === true
+  ));
+  (agent.node as any).node = {
+    getPeers: () => [{ toString: () => PEER }],
+    getConnections: () => [],
+  };
+  (agent as any).getSyncReconcilerProbe = async () => ({
+    protocolsKey: PROTOCOL_SYNC,
+    connectionKey: PEER,
+  });
+  return agent;
+}
+
 describe('Edge periodic sync scope evidence', () => {
+  it('admits a freshly persisted configured Edge selection on its first periodic tick', async () => {
+    const configured = 'cg-fresh-configured-periodic';
+    const agent = await createFreshConfiguredEdgeEvidenceAgent(configured);
+    const durableScopes: string[][] = [];
+    const sharedMemoryScopes: string[][] = [];
+    (agent as any).syncFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      durableScopes.push([...contextGraphIds]);
+      return cleanDurableSyncResult();
+    };
+    (agent as any).syncSharedMemoryFromPeerDetailed = async (
+      _peerId: string,
+      contextGraphIds: string[],
+    ) => {
+      sharedMemoryScopes.push([...contextGraphIds]);
+      const summary = cleanSharedMemorySyncResult();
+      return {
+        ...summary,
+        contextGraphTerminals: contextGraphIds.map((id) => ({
+          contextGraphId: id,
+          lane: 'shared_memory' as const,
+          disposition: 'settled' as const,
+          result: { ...summary },
+        })),
+      };
+    };
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    await waitFor(() => (agent as any).lastSuccessfulSyncAt.has(PEER));
+
+    expect(durableScopes).toEqual([[configured]]);
+    expect(sharedMemoryScopes).toEqual([[configured]]);
+    expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    expect(durableScopes.flat()).not.toContain(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+  });
+
   it('keeps the normal Edge periodic scope when broad sync-on-connect is enabled', async () => {
     const rehydrated = 'cg-rehydrated-normal-periodic';
     const runtimeSelected = 'cg-runtime-normal-periodic';

--- a/packages/agent/test/sync-coverage-evidence-runtime.test.ts
+++ b/packages/agent/test/sync-coverage-evidence-runtime.test.ts
@@ -553,7 +553,7 @@ describe('automatic sync coverage runtime evidence', () => {
     });
   });
 
-  it('records only startup-rehydrated always-on Edge selections on periodic work', async () => {
+  it('records only durable always-on Edge selections on periodic work', async () => {
     const rehydrated = 'cg-rehydrated';
     const runtimeSelected = 'cg-runtime-selected';
     const persisted = new Map<string, ContextGraphSubscriptionRecord>([[rehydrated, {
@@ -596,6 +596,8 @@ describe('automatic sync coverage runtime evidence', () => {
       expect.arrayContaining([rehydrated, runtimeSelected]),
     );
     expect(agent.getContextGraphSubscriptionRehydrationStatus()?.rehydratedAlwaysOnIds)
+      .toEqual([rehydrated]);
+    expect(agent.getContextGraphSubscriptionRehydrationStatus()?.durableAlwaysOnEdgeIds)
       .toEqual([rehydrated]);
 
     // Edge's broad sync-on-connect switch remains off. Only the internal
@@ -665,7 +667,7 @@ describe('automatic sync coverage runtime evidence', () => {
       source: 'reconciler',
       trigger: 'periodic-reconciler',
       syncMode: 'always-on',
-      rehydratedSelectionCount: 1,
+      durableSelectionCount: 1,
       evidenceTruncated: false,
       state: 'running',
     });


### PR DESCRIPTION
## User impact

An Edge operator can put selected Context Graph IDs in `config.json`, keep broad `syncOnConnectEnabled=false`, and have those selections enter the bounded periodic VM + SWM catch-up lane on the first cold boot. A restart is no longer required before selective synchronization begins.

This does **not** enable sync for every public CG. Admission still requires all of the following:

- Edge role;
- an explicit subscription;
- always-on intent whose durable store save completed successfully; and
- a still-live subscribed/always-on state when the periodic round is planned.

On-demand selections remain process-local and excluded. The agents and ontology system graphs also remain outside this bounded Edge lane.

## Why

The exact-head isolated testnet canary for the M1 stack exposed a first-boot gap. Five configured selections were persisted as explicit always-on subscriptions, but the periodic lane admitted only IDs restored from a previous process. After the first five-minute reconciler tick the fresh node remained at 0/5 and had created no sync job. Restarting would have hidden the defect by turning the same rows into rehydrated state.

## Before

```mermaid
sequenceDiagram
    participant Operator
    participant Edge
    participant Store as Durable subscription store
    participant Timer as Periodic reconciler
    participant Peer as DKG peer

    Operator->>Edge: Configure selected CGs
    Edge->>Store: Persist explicit always-on rows
    Store-->>Edge: Save committed
    Timer->>Edge: First periodic tick
    Edge->>Edge: Check startup-rehydrated IDs only
    Edge-->>Timer: Empty scope
    Note over Edge,Peer: No VM or SWM catch-up until restart
```

## After

```mermaid
sequenceDiagram
    participant Operator
    participant Edge
    participant Store as Durable subscription store
    participant Timer as Periodic reconciler
    participant Peer as DKG peer

    Operator->>Edge: Configure selected CGs
    Edge->>Store: Persist explicit always-on rows
    Store-->>Edge: Save committed
    Edge->>Edge: Admit committed durable IDs
    Timer->>Edge: First periodic tick
    Edge->>Edge: Revalidate live subscribed/always-on state
    Edge->>Peer: Catch up selected CGs only (VM + SWM)
    Peer-->>Edge: Verified bounded results
```

## Implementation

- Maintain a dedicated `durableAlwaysOnEdgeIds` runtime admission set, separate from startup rehydration/cap diagnostics.
- Seed it from restored explicit Edge always-on rows and update it only after the canonical persistence projection commits an authoritative save/delete.
- Remove cleared and failed-delete deactivated rows; clear partially accumulated admission fail-closed if startup rehydration fails.
- Keep `rehydratedAlwaysOnIds` startup-only and expose the live durable set separately as `durableAlwaysOnEdgeIds`.
- Rename Edge automatic evidence to `durableSelectionCount` so the journal does not describe post-boot writes as rehydrated.
- Consolidate the Edge evidence fixture into one parameterized factory.

## Validation

Exact head: `82123c71da2166d91f74a292827ac3a99657fc39`.

- GitHub: SPARQL scalability lint passed; Windows SQLite lifecycle passed; all review threads resolved.
- `pnpm --filter @origintrail-official/dkg-agent build`: passed.
- Full Agent lane: 166 files passed; 2,250 tests passed, 5 skipped, 0 failed.
- Focused Agent evidence suite: 3 files, 33 passed, 0 failed.
- M1 selective-coverage proof harness: 80 passed, 0 failed.
- Exact remote full build: all 22 workspace tasks passed, including the UI build.
- Fresh-home isolated testnet Edge booted from the exact head with no prior SQLite DB, Oxigraph data, agent key, auth state, network state, or RFC64 checkpoints.
- Five explicit configured selections were durably admitted on that first boot while `rehydratedAlwaysOnIds` correctly remained empty.
- The first automatic five-minute round created exactly 20 bounded jobs: five selected CGs across four Core peers. Every job carried `trigger=periodic-reconciler`, `syncMode=always-on`, and `durableSelectionCount=5`.
- No agents or ontology system graph entered the automatic scope.
- Successful clear and failed-delete deactivation tests both prove the periodic VM/SWM scope becomes empty afterward.

## Testnet observation outside this PR's bounded claim

The first-boot admission behavior above passed. The full M1 distributed completeness gate did **not** pass yet: the 20 peer jobs ended incomplete because the cold Edge had no historical hash-to-numeric-CG binding, Core responses contained zero metadata/data for those requests, and SWM authorization therefore remained unconfirmed. That is being handled as a separate stacked fix rather than broadening this PR.

Stack base: #2040
