### PR TITLE
fix(rfc64): resolve cold selected CG name hashes

### DIFF
--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -446,9 +446,16 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       || localSubscription.coreHosted === true
     );
     if (locallyAdmitted && typeof resolveHistorical === 'function') {
+      // A direct subscription key is the original local identifier, including
+      // its spelling/case when a legitimate cleartext id happens to look like
+      // a bytes32 wire hash. Only use mappedLocalId when admission was found
+      // through the reverse wire-id index.
+      const localIdForCommitment = directSubscription !== undefined
+        ? contextGraphId
+        : mappedLocalId;
       const wireId = localSubscription.onChainHash
         ? this.contextGraphWireId(localSubscription.onChainHash)
-        : this.contextGraphNameCommitment(mappedLocalId);
+        : this.contextGraphNameCommitment(localIdForCommitment);
       const resolved = options.signal === undefined
         ? await resolveHistorical.call(this.chain, wireId)
         : await resolveHistorical.call(this.chain, wireId, { signal: options.signal });

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -418,7 +418,8 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal; source?: string } = {},
   ): Promise<string | null> {
-    const subscribed = this.subscribedContextGraphs.get(contextGraphId)?.onChainId;
+    const directSubscription = this.subscribedContextGraphs.get(contextGraphId);
+    const subscribed = directSubscription?.onChainId;
     if (subscribed) return subscribed;
 
     // Registered CG events carry only the curator-committed name hash. Resolve
@@ -428,8 +429,37 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     const mappedLocalId = this.localCgIdForWireId(
       this.contextGraphWireId(contextGraphId),
     );
-    const mapped = this.subscribedContextGraphs.get(mappedLocalId)?.onChainId;
+    const mappedSubscription = this.subscribedContextGraphs.get(mappedLocalId);
+    const mapped = mappedSubscription?.onChainId;
     if (mapped) return mapped;
+
+    // A cold node may select a CG long after ContextGraphCreated fell outside
+    // the live event poller's bounded lookback. Resolve the exact indexed
+    // nameHash from chain before consulting the legacy ontology projection.
+    // Scope this expensive historical operation to a locally admitted
+    // subscription (explicit Edge selection or Core-hosted record): an
+    // arbitrary remote id must never trigger a chain crawl.
+    const localSubscription = directSubscription ?? mappedSubscription;
+    const resolveHistorical = this.chain?.resolveContextGraphIdByNameHash;
+    const locallyAdmitted = localSubscription !== undefined && (
+      localSubscription.syncAdmission !== 'none'
+      || localSubscription.coreHosted === true
+    );
+    if (locallyAdmitted && typeof resolveHistorical === 'function') {
+      const wireId = localSubscription.onChainHash
+        ? this.contextGraphWireId(localSubscription.onChainHash)
+        : this.contextGraphNameCommitment(mappedLocalId);
+      const resolved = options.signal === undefined
+        ? await resolveHistorical.call(this.chain, wireId)
+        : await resolveHistorical.call(this.chain, wireId, { signal: options.signal });
+      if (resolved !== null) {
+        const boundLocalId = this.bindOnChainContextGraphIdFromNameHash(
+          wireId,
+          resolved.toString(),
+        );
+        if (boundLocalId !== null) return resolved.toString();
+      }
+    }
 
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;

--- a/packages/agent/test/context-graph-historical-name-binding.test.ts
+++ b/packages/agent/test/context-graph-historical-name-binding.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+import { ContextGraphRegistryMethods } from '../src/dkg-agent-cg-registry.js';
+
+const LOCAL_ID = 'selected-public-cg';
+const NAME_HASH = `0x${'ab'.repeat(32)}`;
+
+function selectedFixture(resolved: bigint | null = 42n) {
+  const query = vi.fn<TripleStore['query']>(async () => ({
+    type: 'bindings',
+    bindings: [],
+  }));
+  const resolveContextGraphIdByNameHash = vi.fn(async () => resolved);
+  const bindOnChainContextGraphIdFromNameHash = vi.fn(() => LOCAL_ID);
+  const subscription = {
+    subscribed: true,
+    synced: false,
+    syncMode: 'always-on',
+    syncAdmission: 'explicit',
+    onChainHash: NAME_HASH,
+  };
+  return {
+    query,
+    resolveContextGraphIdByNameHash,
+    bindOnChainContextGraphIdFromNameHash,
+    agent: {
+      store: { query } as unknown as TripleStore,
+      chain: { resolveContextGraphIdByNameHash },
+      subscribedContextGraphs: new Map([[LOCAL_ID, subscription]]),
+      contextGraphWireId: (id: string) => id === LOCAL_ID ? NAME_HASH : id.toLowerCase(),
+      contextGraphNameCommitment: (id: string) => id === LOCAL_ID ? NAME_HASH : id.toLowerCase(),
+      localCgIdForWireId: (id: string) => id.toLowerCase() === NAME_HASH ? LOCAL_ID : id,
+      bindOnChainContextGraphIdFromNameHash,
+    },
+  };
+}
+
+describe('cold historical Context Graph name binding', () => {
+  it('resolves and binds an explicit cleartext selection without ontology data', async () => {
+    const fixture = selectedFixture();
+    const signal = new AbortController().signal;
+
+    await expect(
+      ContextGraphRegistryMethods.prototype.getContextGraphOnChainId.call(
+        fixture.agent as never,
+        LOCAL_ID,
+        { signal },
+      ),
+    ).resolves.toBe('42');
+
+    expect(fixture.resolveContextGraphIdByNameHash).toHaveBeenCalledWith(
+      NAME_HASH,
+      { signal },
+    );
+    expect(fixture.bindOnChainContextGraphIdFromNameHash).toHaveBeenCalledWith(
+      NAME_HASH,
+      '42',
+    );
+    expect(fixture.query).not.toHaveBeenCalled();
+  });
+
+  it('uses the same binding for a selected wire-hash request', async () => {
+    const fixture = selectedFixture();
+    await expect(
+      ContextGraphRegistryMethods.prototype.getContextGraphOnChainId.call(
+        fixture.agent as never,
+        NAME_HASH,
+      ),
+    ).resolves.toBe('42');
+    expect(fixture.resolveContextGraphIdByNameHash).toHaveBeenCalledWith(
+      NAME_HASH,
+    );
+  });
+
+  it('never lets an arbitrary unselected id trigger a historical chain scan', async () => {
+    const fixture = selectedFixture();
+    await expect(
+      ContextGraphRegistryMethods.prototype.getContextGraphOnChainId.call(
+        fixture.agent as never,
+        'unselected-remote-cg',
+      ),
+    ).resolves.toBeNull();
+    expect(fixture.resolveContextGraphIdByNameHash).not.toHaveBeenCalled();
+    expect(fixture.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a passive non-admitted local record trigger a historical chain scan', async () => {
+    const fixture = selectedFixture();
+    fixture.agent.subscribedContextGraphs.get(LOCAL_ID)!.syncAdmission = 'none';
+    await expect(
+      ContextGraphRegistryMethods.prototype.getContextGraphOnChainId.call(
+        fixture.agent as never,
+        LOCAL_ID,
+      ),
+    ).resolves.toBeNull();
+    expect(fixture.resolveContextGraphIdByNameHash).not.toHaveBeenCalled();
+    expect(fixture.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains the legacy ontology fallback for a selected pre-name-hash miss', async () => {
+    const fixture = selectedFixture(null);
+    fixture.query.mockResolvedValueOnce({
+      type: 'bindings',
+      bindings: [{ id: '"7"' }],
+    });
+    await expect(
+      ContextGraphRegistryMethods.prototype.getContextGraphOnChainId.call(
+        fixture.agent as never,
+        LOCAL_ID,
+      ),
+    ).resolves.toBe('7');
+    expect(fixture.bindOnChainContextGraphIdFromNameHash).not.toHaveBeenCalled();
+  });
+
+  it('propagates ambiguous or failed chain resolution instead of trusting local metadata', async () => {
+    const fixture = selectedFixture();
+    fixture.resolveContextGraphIdByNameHash.mockRejectedValueOnce(
+      new Error('ambiguous name hash'),
+    );
+    await expect(
+      ContextGraphRegistryMethods.prototype.getContextGraphOnChainId.call(
+        fixture.agent as never,
+        LOCAL_ID,
+      ),
+    ).rejects.toThrow('ambiguous name hash');
+    expect(fixture.query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/test/context-graph-historical-name-binding.test.ts
+++ b/packages/agent/test/context-graph-historical-name-binding.test.ts
@@ -97,6 +97,47 @@ describe('cold historical Context Graph name binding', () => {
     expect(fixture.query).toHaveBeenCalledTimes(1);
   });
 
+  it('allows a host-only Core record to recover its historical binding', async () => {
+    const fixture = selectedFixture();
+    const subscription = fixture.agent.subscribedContextGraphs.get(LOCAL_ID)!;
+    subscription.subscribed = false;
+    subscription.syncAdmission = 'none';
+    subscription.coreHosted = true;
+
+    await expect(
+      ContextGraphRegistryMethods.prototype.getContextGraphOnChainId.call(
+        fixture.agent as never,
+        LOCAL_ID,
+      ),
+    ).resolves.toBe('42');
+    expect(fixture.resolveContextGraphIdByNameHash).toHaveBeenCalledWith(NAME_HASH);
+  });
+
+  it('hashes the original spelling of a hash-shaped cleartext subscription id', async () => {
+    const fixture = selectedFixture();
+    const localId = `0x${'AB'.repeat(32)}`;
+    const committedHash = `0x${'cd'.repeat(32)}`;
+    const subscription = fixture.agent.subscribedContextGraphs.get(LOCAL_ID)!;
+    fixture.agent.subscribedContextGraphs = new Map([[
+      localId,
+      { ...subscription, onChainHash: undefined },
+    ]]);
+    fixture.agent.contextGraphWireId = (id: string) => id.toLowerCase();
+    fixture.agent.localCgIdForWireId = (id: string) => id.toLowerCase();
+    fixture.agent.contextGraphNameCommitment = vi.fn((id: string) =>
+      id === localId ? committedHash : NAME_HASH);
+    fixture.bindOnChainContextGraphIdFromNameHash.mockReturnValue(localId);
+
+    await expect(
+      ContextGraphRegistryMethods.prototype.getContextGraphOnChainId.call(
+        fixture.agent as never,
+        localId,
+      ),
+    ).resolves.toBe('42');
+    expect(fixture.agent.contextGraphNameCommitment).toHaveBeenCalledWith(localId);
+    expect(fixture.resolveContextGraphIdByNameHash).toHaveBeenCalledWith(committedHash);
+  });
+
   it('retains the legacy ontology fallback for a selected pre-name-hash miss', async () => {
     const fixture = selectedFixture(null);
     fixture.query.mockResolvedValueOnce({

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1840,6 +1840,22 @@ export interface ChainAdapter {
     contextGraphId: bigint,
     options?: ChainReadOptions,
   ): Promise<string | null>;
+
+  /**
+   * Resolve the numeric ContextGraphStorage slot committed to an exact
+   * `ContextGraphCreated.nameHash` topic.
+   *
+   * This is the cold-start inverse of {@link getContextGraphNameHash}: a node
+   * that selected a CG after its creation event fell outside the live poller's
+   * lookback still needs an authoritative hash -> numeric-id binding before it
+   * can evaluate policy or authorize SWM. Implementations MUST fail closed on
+   * ambiguous matches and independently verify the current slot still commits
+   * to `nameHash` before returning it.
+   */
+  resolveContextGraphIdByNameHash?(
+    nameHash: string,
+    options?: ChainReadOptions,
+  ): Promise<bigint | null>;
 }
 
 // ----- Backward-compat deprecated aliases -----

--- a/packages/chain/src/context-graph-name-hash-resolver.ts
+++ b/packages/chain/src/context-graph-name-hash-resolver.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ethers } from 'ethers';
+import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
+
+const CONTEXT_GRAPH_NAME_HASH_NEGATIVE_TTL_MS = 30_000;
+
+export interface ContextGraphNameHashResolutionScope {
+  /** Deployment address plus normalized name hash. */
+  readonly cacheKey: string;
+  /** One exact-topic, deploy-anchored historical scan. */
+  readonly scan: () => Promise<bigint | null>;
+}
+
+export interface ContextGraphNameHashResolverDependencies {
+  prepare(nameHash: string): Promise<ContextGraphNameHashResolutionScope>;
+}
+
+export interface ContextGraphNameHashScanInput<Preferred, Log> {
+  readonly nameHash: string;
+  readonly fromBlock: number;
+  readonly head: number;
+  readonly pageSize: number;
+  readonly maxPages: number;
+  readonly queryPage: (
+    lo: number,
+    hi: number,
+    preferred: Preferred | undefined,
+  ) => Promise<{ logs: ReadonlyArray<Log>; preferred: Preferred }>;
+  readonly parseContextGraphId: (log: Log) => bigint | null;
+  readonly readCurrentNameHash: (contextGraphId: bigint) => Promise<string | null>;
+}
+
+/**
+ * Deployment-scoped, single-flight reverse lookup for cold Context Graphs.
+ *
+ * Only misses are cached. A positive binding is returned to the caller and
+ * persisted by the Agent subscription layer, but it is deliberately not kept
+ * here: ContextGraphStorage does not enforce name-hash uniqueness, so a later
+ * duplicate event must be visible to the next independent lookup.
+ */
+export class ContextGraphNameHashResolver {
+  private readonly cache = new ReadThroughTtlCache<string, bigint | null>({
+    ttlMs: (value) => value === null
+      ? CONTEXT_GRAPH_NAME_HASH_NEGATIVE_TTL_MS
+      : 0,
+  });
+
+  constructor(
+    private readonly dependencies: ContextGraphNameHashResolverDependencies,
+  ) {}
+
+  async resolve(
+    rawNameHash: string,
+    signal?: AbortSignal,
+  ): Promise<bigint | null> {
+    signal?.throwIfAborted();
+    const nameHash = normalizeContextGraphNameHash(rawNameHash);
+    if (nameHash === ethers.ZeroHash) return null;
+
+    const scope = await this.dependencies.prepare(nameHash);
+    signal?.throwIfAborted();
+    const shared = this.cache.getOrLoad(
+      scope.cacheKey,
+      scope.cacheKey,
+      scope.scan,
+    );
+    return waitForResolution(shared, signal);
+  }
+
+  invalidateAll(): void {
+    this.cache.invalidateAll();
+  }
+}
+
+/** Execute and verify one bounded exact-topic historical scan. */
+export async function scanContextGraphIdByNameHash<Preferred, Log>(
+  input: ContextGraphNameHashScanInput<Preferred, Log>,
+): Promise<bigint | null> {
+  if (input.fromBlock > input.head) return null;
+
+  const pages = Math.ceil((input.head - input.fromBlock + 1) / input.pageSize);
+  if (pages > input.maxPages) {
+    throw new Error(
+      `resolveContextGraphIdByNameHash: historical ContextGraphCreated scan ` +
+      `would need ${pages} eth_getLogs calls over blocks ` +
+      `[${input.fromBlock}, ${input.head}] at a ${input.pageSize}-block window ` +
+      `(budget ${input.maxPages} pages).`,
+    );
+  }
+
+  const ids = new Set<bigint>();
+  let preferred: Preferred | undefined;
+  for (let lo = input.fromBlock; lo <= input.head; lo += input.pageSize) {
+    const hi = Math.min(lo + input.pageSize - 1, input.head);
+    const page = await input.queryPage(lo, hi, preferred);
+    preferred = page.preferred;
+    for (const log of page.logs) {
+      const id = input.parseContextGraphId(log);
+      if (id === null) continue;
+      if (id <= 0n) {
+        throw new Error(
+          `resolveContextGraphIdByNameHash: invalid Context Graph id ` +
+          `${id.toString()} for ${input.nameHash}`,
+        );
+      }
+      ids.add(id);
+    }
+  }
+
+  if (ids.size === 0) return null;
+  if (ids.size !== 1) {
+    throw new Error(
+      `resolveContextGraphIdByNameHash: ambiguous ${input.nameHash}; ` +
+      `ContextGraphCreated committed it to ${ids.size} numeric ids`,
+    );
+  }
+
+  const id = ids.values().next().value as bigint;
+  const currentHash = await input.readCurrentNameHash(id);
+  if (currentHash !== input.nameHash) {
+    throw new Error(
+      `resolveContextGraphIdByNameHash: slot ${id.toString()} currently commits ` +
+      `${currentHash ?? ethers.ZeroHash}, expected ${input.nameHash}`,
+    );
+  }
+  return id;
+}
+
+function normalizeContextGraphNameHash(value: string): string {
+  if (!ethers.isHexString(value, 32)) {
+    throw new TypeError('resolveContextGraphIdByNameHash requires a bytes32 nameHash');
+  }
+  return value.toLowerCase();
+}
+
+function waitForResolution<T>(
+  work: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) return work;
+  signal.throwIfAborted();
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(
+      signal.reason instanceof Error
+        ? signal.reason
+        : Object.assign(new Error('Context Graph name-hash resolution aborted'), {
+            name: 'AbortError',
+          }),
+    );
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}

--- a/packages/chain/src/context-graph-name-hash-resolver.ts
+++ b/packages/chain/src/context-graph-name-hash-resolver.ts
@@ -5,30 +5,9 @@ import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
 
 const CONTEXT_GRAPH_NAME_HASH_NEGATIVE_TTL_MS = 30_000;
 
-export interface ContextGraphNameHashResolutionScope {
-  /** Deployment address plus normalized name hash. */
-  readonly cacheKey: string;
-  /** One exact-topic, deploy-anchored historical scan. */
-  readonly scan: () => Promise<bigint | null>;
-}
-
 export interface ContextGraphNameHashResolverDependencies {
-  prepare(nameHash: string): Promise<ContextGraphNameHashResolutionScope>;
-}
-
-export interface ContextGraphNameHashScanInput<Preferred, Log> {
-  readonly nameHash: string;
-  readonly fromBlock: number;
-  readonly head: number;
-  readonly pageSize: number;
-  readonly maxPages: number;
-  readonly queryPage: (
-    lo: number,
-    hi: number,
-    preferred: Preferred | undefined,
-  ) => Promise<{ logs: ReadonlyArray<Log>; preferred: Preferred }>;
-  readonly parseContextGraphId: (log: Log) => bigint | null;
-  readonly readCurrentNameHash: (contextGraphId: bigint) => Promise<string | null>;
+  /** One concrete adapter-owned lookup for a normalized bytes32 commitment. */
+  readonly load: (nameHash: string) => Promise<bigint | null>;
 }
 
 /**
@@ -58,12 +37,10 @@ export class ContextGraphNameHashResolver {
     const nameHash = normalizeContextGraphNameHash(rawNameHash);
     if (nameHash === ethers.ZeroHash) return null;
 
-    const scope = await this.dependencies.prepare(nameHash);
-    signal?.throwIfAborted();
     const shared = this.cache.getOrLoad(
-      scope.cacheKey,
-      scope.cacheKey,
-      scope.scan,
+      nameHash,
+      nameHash,
+      () => this.dependencies.load(nameHash),
     );
     return waitForResolution(shared, signal);
   }
@@ -71,60 +48,6 @@ export class ContextGraphNameHashResolver {
   invalidateAll(): void {
     this.cache.invalidateAll();
   }
-}
-
-/** Execute and verify one bounded exact-topic historical scan. */
-export async function scanContextGraphIdByNameHash<Preferred, Log>(
-  input: ContextGraphNameHashScanInput<Preferred, Log>,
-): Promise<bigint | null> {
-  if (input.fromBlock > input.head) return null;
-
-  const pages = Math.ceil((input.head - input.fromBlock + 1) / input.pageSize);
-  if (pages > input.maxPages) {
-    throw new Error(
-      `resolveContextGraphIdByNameHash: historical ContextGraphCreated scan ` +
-      `would need ${pages} eth_getLogs calls over blocks ` +
-      `[${input.fromBlock}, ${input.head}] at a ${input.pageSize}-block window ` +
-      `(budget ${input.maxPages} pages).`,
-    );
-  }
-
-  const ids = new Set<bigint>();
-  let preferred: Preferred | undefined;
-  for (let lo = input.fromBlock; lo <= input.head; lo += input.pageSize) {
-    const hi = Math.min(lo + input.pageSize - 1, input.head);
-    const page = await input.queryPage(lo, hi, preferred);
-    preferred = page.preferred;
-    for (const log of page.logs) {
-      const id = input.parseContextGraphId(log);
-      if (id === null) continue;
-      if (id <= 0n) {
-        throw new Error(
-          `resolveContextGraphIdByNameHash: invalid Context Graph id ` +
-          `${id.toString()} for ${input.nameHash}`,
-        );
-      }
-      ids.add(id);
-    }
-  }
-
-  if (ids.size === 0) return null;
-  if (ids.size !== 1) {
-    throw new Error(
-      `resolveContextGraphIdByNameHash: ambiguous ${input.nameHash}; ` +
-      `ContextGraphCreated committed it to ${ids.size} numeric ids`,
-    );
-  }
-
-  const id = ids.values().next().value as bigint;
-  const currentHash = await input.readCurrentNameHash(id);
-  if (currentHash !== input.nameHash) {
-    throw new Error(
-      `resolveContextGraphIdByNameHash: slot ${id.toString()} currently commits ` +
-      `${currentHash ?? ethers.ZeroHash}, expected ${input.nameHash}`,
-    );
-  }
-  return id;
 }
 
 function normalizeContextGraphNameHash(value: string): string {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -38,6 +38,7 @@ import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
 import { PcaReadCache } from './pca-read-cache.js';
 import { HubRotationPoller } from './hub-rotation-poller.js';
 import { ContextGraphRegistryScanCursor } from './context-graph-registry-scan-cursor.js';
+import type { ContextGraphNameHashResolver } from './context-graph-name-hash-resolver.js';
 import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, resolveReceiptTimeoutMs, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
@@ -914,22 +915,8 @@ export class EVMChainAdapterBase {
    */
   protected readonly cachedContractDeployBlocks: Map<string, number> = new Map();
 
-  /**
-   * Deployment-scoped reverse bindings recovered from indexed
-   * ContextGraphCreated.nameHash logs. Positive results are immutable for a
-   * contract address. Negative results use a short TTL so a configured CG that
-   * is registered later becomes visible without restarting the adapter.
-   */
-  protected readonly contextGraphIdsByNameHash = new Map<
-    string,
-    { value: bigint | null; cachedAt: number }
-  >();
-
-  /** One bounded historical scan per deployment + name hash at a time. */
-  protected readonly contextGraphIdByNameHashInflight = new Map<
-    string,
-    Promise<bigint | null>
-  >();
+  /** Lazily constructed by the context-graph mixin; state must live on base. */
+  protected contextGraphNameHashResolver: ContextGraphNameHashResolver | undefined;
 
   protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryScanCursor;
 
@@ -956,8 +943,7 @@ export class EVMChainAdapterBase {
     this.cachedKav10Address = undefined;
     this.cachedMinRequiredSignatures = undefined;
     this.cachedContractDeployBlocks.clear();
-    this.contextGraphIdsByNameHash.clear();
-    this.contextGraphIdByNameHashInflight.clear();
+    this.contextGraphNameHashResolver?.invalidateAll();
     this.contextGraphRegistryScanCursor.clearMemoryCache();
   }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -914,6 +914,23 @@ export class EVMChainAdapterBase {
    */
   protected readonly cachedContractDeployBlocks: Map<string, number> = new Map();
 
+  /**
+   * Deployment-scoped reverse bindings recovered from indexed
+   * ContextGraphCreated.nameHash logs. Positive results are immutable for a
+   * contract address. Negative results use a short TTL so a configured CG that
+   * is registered later becomes visible without restarting the adapter.
+   */
+  protected readonly contextGraphIdsByNameHash = new Map<
+    string,
+    { value: bigint | null; cachedAt: number }
+  >();
+
+  /** One bounded historical scan per deployment + name hash at a time. */
+  protected readonly contextGraphIdByNameHashInflight = new Map<
+    string,
+    Promise<bigint | null>
+  >();
+
   protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryScanCursor;
 
   /**
@@ -939,6 +956,8 @@ export class EVMChainAdapterBase {
     this.cachedKav10Address = undefined;
     this.cachedMinRequiredSignatures = undefined;
     this.cachedContractDeployBlocks.clear();
+    this.contextGraphIdsByNameHash.clear();
+    this.contextGraphIdByNameHashInflight.clear();
     this.contextGraphRegistryScanCursor.clearMemoryCache();
   }
 

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -20,6 +20,10 @@ import {
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
+import {
+  ContextGraphNameHashResolver,
+  scanContextGraphIdByNameHash,
+} from './context-graph-name-hash-resolver.js';
 
 type ContextGraphRegistryScanPlan =
   | {
@@ -59,36 +63,6 @@ function normalizePageBudget(value: number | undefined): number | undefined {
   return Number.isFinite(value) && (value ?? 0) >= 1
     ? Math.floor(value ?? 0)
     : undefined;
-}
-
-const CONTEXT_GRAPH_NAME_HASH_NEGATIVE_TTL_MS = 30_000;
-
-function normalizeContextGraphNameHash(value: string): string {
-  if (!ethers.isHexString(value, 32)) {
-    throw new TypeError('resolveContextGraphIdByNameHash requires a bytes32 nameHash');
-  }
-  return value.toLowerCase();
-}
-
-function waitForContextGraphNameHashResolution<T>(
-  work: Promise<T>,
-  signal: AbortSignal | undefined,
-): Promise<T> {
-  if (!signal) return work;
-  signal.throwIfAborted();
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(
-      signal.reason instanceof Error
-        ? signal.reason
-        : Object.assign(new Error('Context Graph name-hash resolution aborted'), {
-            name: 'AbortError',
-          }),
-    );
-    signal.addEventListener('abort', onAbort, { once: true });
-    work.then(resolve, reject).finally(() => {
-      signal.removeEventListener('abort', onAbort);
-    });
-  });
 }
 
 function buildPublicContextGraphRegistryScanPlan(
@@ -910,117 +884,63 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     nameHash: string,
     options: ChainReadOptions = {},
   ): Promise<bigint | null> {
-    options.signal?.throwIfAborted();
-    const normalized = normalizeContextGraphNameHash(nameHash);
-    if (normalized === ethers.ZeroHash) return null;
-
-    await this.init();
-    options.signal?.throwIfAborted();
-    const cgs = this.requireContextGraphStorage();
-    const storageAddress = (await cgs.getAddress()).toLowerCase();
-    const cacheKey = `${storageAddress}:${normalized}`;
-    const cached = this.contextGraphIdsByNameHash.get(cacheKey);
-    if (
-      cached
-      && (
-        cached.value !== null
-        || Date.now() - cached.cachedAt < CONTEXT_GRAPH_NAME_HASH_NEGATIVE_TTL_MS
-      )
-    ) {
-      return cached.value;
-    }
-
-    let inflight = this.contextGraphIdByNameHashInflight.get(cacheKey);
-    if (!inflight) {
-      inflight = this.scanContextGraphIdByNameHash(cgs, storageAddress, normalized)
-        .then((value) => {
-          this.contextGraphIdsByNameHash.set(cacheKey, {
-            value,
-            cachedAt: Date.now(),
-          });
-          return value;
-        })
-        .finally(() => {
-          if (this.contextGraphIdByNameHashInflight.get(cacheKey) === inflight) {
-            this.contextGraphIdByNameHashInflight.delete(cacheKey);
-          }
-        });
-      this.contextGraphIdByNameHashInflight.set(cacheKey, inflight);
-    }
-    return waitForContextGraphNameHashResolution(inflight, options.signal);
-  }
-
-  private async scanContextGraphIdByNameHash(
-    cgs: Contract,
-    storageAddress: string,
-    nameHash: string,
-  ): Promise<bigint | null> {
-    const { fromBlock, head, scanProviders } = await this.resolveContractDeployBlock(
-      storageAddress,
-      'resolveContextGraphIdByNameHash',
-      'ContextGraphStorage',
-    );
-    if (fromBlock > head) return null;
-
-    const pageSize = this.cgRegistryScanPageSize;
-    const pages = Math.ceil((head - fromBlock + 1) / pageSize);
-    if (pages > CG_REGISTRY_MAX_SCAN_PAGES) {
-      throw new Error(
-        `resolveContextGraphIdByNameHash: historical ContextGraphCreated scan ` +
-        `would need ${pages} eth_getLogs calls over blocks [${fromBlock}, ${head}] ` +
-        `at a ${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages).`,
-      );
-    }
-
-    const filter = cgs.filters.ContextGraphCreated(null, null, nameHash);
-    const connected = new Map<JsonRpcProvider, Contract>();
-    const ids = new Set<bigint>();
-    let preferred: JsonRpcProvider | undefined;
-    for (let lo = fromBlock; lo <= head; lo += pageSize) {
-      const hi = Math.min(lo + pageSize - 1, head);
-      const page = await this.queryEventLogsPage(
-        cgs,
-        filter,
-        lo,
-        hi,
-        scanProviders,
-        connected,
-        'resolveContextGraphIdByNameHash ContextGraphCreated',
-        preferred,
-      );
-      preferred = page.provider;
-      for (const log of page.logs) {
-        const parsed = cgs.interface.parseLog({
-          topics: [...log.topics],
-          data: log.data,
-        });
-        if (!parsed || parsed.name !== 'ContextGraphCreated') continue;
-        const id = BigInt(parsed.args.contextGraphId);
-        if (id <= 0n) {
-          throw new Error(
-            `resolveContextGraphIdByNameHash: invalid Context Graph id ${id.toString()} ` +
-            `for ${nameHash}`,
-          );
-        }
-        ids.add(id);
-      }
-    }
-
-    if (ids.size === 0) return null;
-    if (ids.size !== 1) {
-      throw new Error(
-        `resolveContextGraphIdByNameHash: ambiguous ${nameHash}; ` +
-        `ContextGraphCreated committed it to ${ids.size} numeric ids`,
-      );
-    }
-    const id = ids.values().next().value as bigint;
-    const currentHash = await this.getContextGraphNameHash(id);
-    if (currentHash !== nameHash) {
-      throw new Error(
-        `resolveContextGraphIdByNameHash: slot ${id.toString()} currently commits ` +
-        `${currentHash ?? ethers.ZeroHash}, expected ${nameHash}`,
-      );
-    }
-    return id;
+    this.contextGraphNameHashResolver ??= new ContextGraphNameHashResolver({
+      prepare: async (normalizedNameHash) => {
+        await this.init();
+        const cgs = this.requireContextGraphStorage();
+        const storageAddress = (await cgs.getAddress()).toLowerCase();
+        return {
+          cacheKey: `${storageAddress}:${normalizedNameHash}`,
+          scan: async () => {
+            const { fromBlock, head, scanProviders } =
+              await this.resolveContractDeployBlock(
+                storageAddress,
+                'resolveContextGraphIdByNameHash',
+                'ContextGraphStorage',
+              );
+            const filter = cgs.filters.ContextGraphCreated(
+              null,
+              null,
+              normalizedNameHash,
+            );
+            const connected = new Map<JsonRpcProvider, Contract>();
+            return scanContextGraphIdByNameHash<
+              JsonRpcProvider,
+              ethers.EventLog | ethers.Log
+            >({
+              nameHash: normalizedNameHash,
+              fromBlock,
+              head,
+              pageSize: this.cgRegistryScanPageSize,
+              maxPages: CG_REGISTRY_MAX_SCAN_PAGES,
+              queryPage: async (lo, hi, preferred) => {
+                const page = await this.queryEventLogsPage(
+                  cgs,
+                  filter,
+                  lo,
+                  hi,
+                  scanProviders,
+                  connected,
+                  'resolveContextGraphIdByNameHash ContextGraphCreated',
+                  preferred,
+                );
+                return { logs: page.logs, preferred: page.provider };
+              },
+              parseContextGraphId: (log) => {
+                const parsed = cgs.interface.parseLog({
+                  topics: [...log.topics],
+                  data: log.data,
+                });
+                return parsed?.name === 'ContextGraphCreated'
+                  ? BigInt(parsed.args.contextGraphId)
+                  : null;
+              },
+              readCurrentNameHash: (id) => this.getContextGraphNameHash(id),
+            });
+          },
+        };
+      },
+    });
+    return this.contextGraphNameHashResolver.resolve(nameHash, options.signal);
   }
 }

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -61,6 +61,36 @@ function normalizePageBudget(value: number | undefined): number | undefined {
     : undefined;
 }
 
+const CONTEXT_GRAPH_NAME_HASH_NEGATIVE_TTL_MS = 30_000;
+
+function normalizeContextGraphNameHash(value: string): string {
+  if (!ethers.isHexString(value, 32)) {
+    throw new TypeError('resolveContextGraphIdByNameHash requires a bytes32 nameHash');
+  }
+  return value.toLowerCase();
+}
+
+function waitForContextGraphNameHashResolution<T>(
+  work: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) return work;
+  signal.throwIfAborted();
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(
+      signal.reason instanceof Error
+        ? signal.reason
+        : Object.assign(new Error('Context Graph name-hash resolution aborted'), {
+            name: 'AbortError',
+          }),
+    );
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
 function buildPublicContextGraphRegistryScanPlan(
   fromBlock: number | undefined,
   options: ContextGraphChainScanOptions | undefined,
@@ -868,5 +898,129 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     );
     if (!raw || raw === ethers.ZeroHash) return null;
     return raw.toLowerCase();
+  }
+
+  /**
+   * Cold-start inverse name binding. ContextGraphStorage has no reverse view,
+   * but `nameHash` is the third indexed ContextGraphCreated topic, so this scans
+   * only exact-topic matches in deploy-block-anchored, RPC-safe pages. The
+   * resulting slot is re-read through getNameHash before it is trusted.
+   */
+  async resolveContextGraphIdByNameHash(
+    nameHash: string,
+    options: ChainReadOptions = {},
+  ): Promise<bigint | null> {
+    options.signal?.throwIfAborted();
+    const normalized = normalizeContextGraphNameHash(nameHash);
+    if (normalized === ethers.ZeroHash) return null;
+
+    await this.init();
+    options.signal?.throwIfAborted();
+    const cgs = this.requireContextGraphStorage();
+    const storageAddress = (await cgs.getAddress()).toLowerCase();
+    const cacheKey = `${storageAddress}:${normalized}`;
+    const cached = this.contextGraphIdsByNameHash.get(cacheKey);
+    if (
+      cached
+      && (
+        cached.value !== null
+        || Date.now() - cached.cachedAt < CONTEXT_GRAPH_NAME_HASH_NEGATIVE_TTL_MS
+      )
+    ) {
+      return cached.value;
+    }
+
+    let inflight = this.contextGraphIdByNameHashInflight.get(cacheKey);
+    if (!inflight) {
+      inflight = this.scanContextGraphIdByNameHash(cgs, storageAddress, normalized)
+        .then((value) => {
+          this.contextGraphIdsByNameHash.set(cacheKey, {
+            value,
+            cachedAt: Date.now(),
+          });
+          return value;
+        })
+        .finally(() => {
+          if (this.contextGraphIdByNameHashInflight.get(cacheKey) === inflight) {
+            this.contextGraphIdByNameHashInflight.delete(cacheKey);
+          }
+        });
+      this.contextGraphIdByNameHashInflight.set(cacheKey, inflight);
+    }
+    return waitForContextGraphNameHashResolution(inflight, options.signal);
+  }
+
+  private async scanContextGraphIdByNameHash(
+    cgs: Contract,
+    storageAddress: string,
+    nameHash: string,
+  ): Promise<bigint | null> {
+    const { fromBlock, head, scanProviders } = await this.resolveContractDeployBlock(
+      storageAddress,
+      'resolveContextGraphIdByNameHash',
+      'ContextGraphStorage',
+    );
+    if (fromBlock > head) return null;
+
+    const pageSize = this.cgRegistryScanPageSize;
+    const pages = Math.ceil((head - fromBlock + 1) / pageSize);
+    if (pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+      throw new Error(
+        `resolveContextGraphIdByNameHash: historical ContextGraphCreated scan ` +
+        `would need ${pages} eth_getLogs calls over blocks [${fromBlock}, ${head}] ` +
+        `at a ${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages).`,
+      );
+    }
+
+    const filter = cgs.filters.ContextGraphCreated(null, null, nameHash);
+    const connected = new Map<JsonRpcProvider, Contract>();
+    const ids = new Set<bigint>();
+    let preferred: JsonRpcProvider | undefined;
+    for (let lo = fromBlock; lo <= head; lo += pageSize) {
+      const hi = Math.min(lo + pageSize - 1, head);
+      const page = await this.queryEventLogsPage(
+        cgs,
+        filter,
+        lo,
+        hi,
+        scanProviders,
+        connected,
+        'resolveContextGraphIdByNameHash ContextGraphCreated',
+        preferred,
+      );
+      preferred = page.provider;
+      for (const log of page.logs) {
+        const parsed = cgs.interface.parseLog({
+          topics: [...log.topics],
+          data: log.data,
+        });
+        if (!parsed || parsed.name !== 'ContextGraphCreated') continue;
+        const id = BigInt(parsed.args.contextGraphId);
+        if (id <= 0n) {
+          throw new Error(
+            `resolveContextGraphIdByNameHash: invalid Context Graph id ${id.toString()} ` +
+            `for ${nameHash}`,
+          );
+        }
+        ids.add(id);
+      }
+    }
+
+    if (ids.size === 0) return null;
+    if (ids.size !== 1) {
+      throw new Error(
+        `resolveContextGraphIdByNameHash: ambiguous ${nameHash}; ` +
+        `ContextGraphCreated committed it to ${ids.size} numeric ids`,
+      );
+    }
+    const id = ids.values().next().value as bigint;
+    const currentHash = await this.getContextGraphNameHash(id);
+    if (currentHash !== nameHash) {
+      throw new Error(
+        `resolveContextGraphIdByNameHash: slot ${id.toString()} currently commits ` +
+        `${currentHash ?? ethers.ZeroHash}, expected ${nameHash}`,
+      );
+    }
+    return id;
   }
 }

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -20,10 +20,7 @@ import {
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
-import {
-  ContextGraphNameHashResolver,
-  scanContextGraphIdByNameHash,
-} from './context-graph-name-hash-resolver.js';
+import { ContextGraphNameHashResolver } from './context-graph-name-hash-resolver.js';
 
 type ContextGraphRegistryScanPlan =
   | {
@@ -885,60 +882,75 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     options: ChainReadOptions = {},
   ): Promise<bigint | null> {
     this.contextGraphNameHashResolver ??= new ContextGraphNameHashResolver({
-      prepare: async (normalizedNameHash) => {
+      load: async (normalizedNameHash) => {
         await this.init();
         const cgs = this.requireContextGraphStorage();
         const storageAddress = (await cgs.getAddress()).toLowerCase();
-        return {
-          cacheKey: `${storageAddress}:${normalizedNameHash}`,
-          scan: async () => {
-            const { fromBlock, head, scanProviders } =
-              await this.resolveContractDeployBlock(
-                storageAddress,
-                'resolveContextGraphIdByNameHash',
-                'ContextGraphStorage',
+        const { fromBlock, head, scanProviders } = await this.resolveContractDeployBlock(
+          storageAddress,
+          'resolveContextGraphIdByNameHash',
+          'ContextGraphStorage',
+        );
+        if (fromBlock > head) return null;
+
+        const pages = Math.ceil((head - fromBlock + 1) / this.cgRegistryScanPageSize);
+        if (pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+          throw new Error(
+            `resolveContextGraphIdByNameHash: historical ContextGraphCreated scan ` +
+            `would need ${pages} eth_getLogs calls over blocks ` +
+            `[${fromBlock}, ${head}] at a ${this.cgRegistryScanPageSize}-block window ` +
+            `(budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages).`,
+          );
+        }
+
+        const filter = cgs.filters.ContextGraphCreated(null, null, normalizedNameHash);
+        const connected = new Map<JsonRpcProvider, Contract>();
+        const ids = new Set<bigint>();
+        let preferred: JsonRpcProvider | undefined;
+        for (let lo = fromBlock; lo <= head; lo += this.cgRegistryScanPageSize) {
+          const hi = Math.min(lo + this.cgRegistryScanPageSize - 1, head);
+          const page = await this.queryEventLogsPage(
+            cgs,
+            filter,
+            lo,
+            hi,
+            scanProviders,
+            connected,
+            'resolveContextGraphIdByNameHash ContextGraphCreated',
+            preferred,
+          );
+          preferred = page.provider;
+          for (const log of page.logs) {
+            const parsed = cgs.interface.parseLog({ topics: [...log.topics], data: log.data });
+            if (parsed?.name !== 'ContextGraphCreated') continue;
+            const id = BigInt(parsed.args.contextGraphId);
+            if (id <= 0n) {
+              throw new Error(
+                `resolveContextGraphIdByNameHash: invalid Context Graph id ` +
+                `${id.toString()} for ${normalizedNameHash}`,
               );
-            const filter = cgs.filters.ContextGraphCreated(
-              null,
-              null,
-              normalizedNameHash,
-            );
-            const connected = new Map<JsonRpcProvider, Contract>();
-            return scanContextGraphIdByNameHash<
-              JsonRpcProvider,
-              ethers.EventLog | ethers.Log
-            >({
-              nameHash: normalizedNameHash,
-              fromBlock,
-              head,
-              pageSize: this.cgRegistryScanPageSize,
-              maxPages: CG_REGISTRY_MAX_SCAN_PAGES,
-              queryPage: async (lo, hi, preferred) => {
-                const page = await this.queryEventLogsPage(
-                  cgs,
-                  filter,
-                  lo,
-                  hi,
-                  scanProviders,
-                  connected,
-                  'resolveContextGraphIdByNameHash ContextGraphCreated',
-                  preferred,
-                );
-                return { logs: page.logs, preferred: page.provider };
-              },
-              parseContextGraphId: (log) => {
-                const parsed = cgs.interface.parseLog({
-                  topics: [...log.topics],
-                  data: log.data,
-                });
-                return parsed?.name === 'ContextGraphCreated'
-                  ? BigInt(parsed.args.contextGraphId)
-                  : null;
-              },
-              readCurrentNameHash: (id) => this.getContextGraphNameHash(id),
-            });
-          },
-        };
+            }
+            ids.add(id);
+          }
+        }
+
+        if (ids.size === 0) return null;
+        if (ids.size !== 1) {
+          throw new Error(
+            `resolveContextGraphIdByNameHash: ambiguous ${normalizedNameHash}; ` +
+            `ContextGraphCreated committed it to ${ids.size} numeric ids`,
+          );
+        }
+
+        const id = ids.values().next().value as bigint;
+        const currentHash = await this.getContextGraphNameHash(id);
+        if (currentHash !== normalizedNameHash) {
+          throw new Error(
+            `resolveContextGraphIdByNameHash: slot ${id.toString()} currently commits ` +
+            `${currentHash ?? ethers.ZeroHash}, expected ${normalizedNameHash}`,
+          );
+        }
+        return id;
       },
     });
     return this.contextGraphNameHashResolver.resolve(nameHash, options.signal);

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -1474,6 +1474,26 @@ export class MockChainAdapter implements ChainAdapter {
     return cg.nameHash ?? null;
   }
 
+  /** Offline-development parity for the EVM exact name-hash reverse lookup. */
+  async resolveContextGraphIdByNameHash(nameHash: string): Promise<bigint | null> {
+    if (!ethers.isHexString(nameHash, 32)) {
+      throw new TypeError('resolveContextGraphIdByNameHash requires a bytes32 nameHash');
+    }
+    const normalized = nameHash.toLowerCase();
+    if (normalized === ethers.ZeroHash) return null;
+    const matches = [...this.contextGraphs.entries()]
+      .filter(([, cg]) => cg.nameHash === normalized)
+      .map(([id]) => id);
+    if (matches.length === 0) return null;
+    if (matches.length !== 1) {
+      throw new Error(
+        `resolveContextGraphIdByNameHash: ambiguous ${normalized}; ` +
+        `ContextGraphCreated committed it to ${matches.length} numeric ids`,
+      );
+    }
+    return matches[0];
+  }
+
   // --- V10 Publish (KnowledgeAssetsV10 → KnowledgeCollectionStorage) ---
 
   async getKnowledgeAssetsLifecycleAddress(): Promise<string> {

--- a/packages/chain/test/context-graph-name-hash-reverse-resolution.unit.test.ts
+++ b/packages/chain/test/context-graph-name-hash-reverse-resolution.unit.test.ts
@@ -180,6 +180,22 @@ describe('ContextGraphCreated name-hash reverse resolution', () => {
     }
   });
 
+  it('invalidates a cached miss immediately with the adapter-wide cache reset', async () => {
+    const { adapter, queryEventLogsPage } = fixture([[]]);
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBeNull();
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBeNull();
+    expect(queryEventLogsPage).toHaveBeenCalledTimes(1);
+
+    queryEventLogsPage.mockResolvedValue({
+      logs: [{ topics: [], data: '42' }],
+      provider: {},
+    });
+    adapter.invalidatePublishPreflightCache();
+
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBe(42n);
+    expect(queryEventLogsPage).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects malformed inputs before chain initialisation and treats zero as opt-out', async () => {
     const { adapter } = fixture();
     await expect(adapter.resolveContextGraphIdByNameHash('not-a-hash')).rejects.toThrow(

--- a/packages/chain/test/context-graph-name-hash-reverse-resolution.unit.test.ts
+++ b/packages/chain/test/context-graph-name-hash-reverse-resolution.unit.test.ts
@@ -89,15 +89,13 @@ describe('ContextGraphCreated name-hash reverse resolution', () => {
     ]);
     expect(adapter.getContextGraphNameHash).toHaveBeenCalledWith(42n);
 
-    // Positive bindings are immutable for this storage deployment.
-    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBe(42n);
     expect(queryEventLogsPage).toHaveBeenCalledTimes(3);
   });
 
   it('single-flights concurrent callers and lets one caller stop waiting', async () => {
-    const { adapter } = fixture();
-    const pending = deferred<bigint | null>();
-    adapter.scanContextGraphIdByNameHash = vi.fn(() => pending.promise);
+    const { adapter, queryEventLogsPage } = fixture();
+    const pending = deferred<{ logs: Array<{ topics: string[]; data: string }>; provider: object }>();
+    queryEventLogsPage.mockImplementation(() => pending.promise);
     const controller = new AbortController();
 
     const aborted = adapter.resolveContextGraphIdByNameHash(NAME_HASH, {
@@ -107,9 +105,28 @@ describe('ContextGraphCreated name-hash reverse resolution', () => {
     controller.abort(new Error('caller stopped'));
 
     await expect(aborted).rejects.toThrow('caller stopped');
-    pending.resolve(42n);
+    pending.resolve({
+      logs: [{ topics: [], data: '42' }],
+      provider: {},
+    });
     await expect(survivor).resolves.toBe(42n);
-    expect(adapter.scanContextGraphIdByNameHash).toHaveBeenCalledTimes(1);
+    expect(queryEventLogsPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('rescans a positive result so a later duplicate fails closed', async () => {
+    const { adapter, queryEventLogsPage } = fixture([[42n]]);
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBe(42n);
+
+    queryEventLogsPage.mockResolvedValue({
+      logs: [
+        { topics: [], data: '42' },
+        { topics: [], data: '43' },
+      ],
+      provider: {},
+    });
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      /ambiguous.*2 numeric ids/i,
+    );
   });
 
   it('fails closed when one name hash was committed to multiple numeric slots', async () => {
@@ -128,11 +145,24 @@ describe('ContextGraphCreated name-hash reverse resolution', () => {
     );
   });
 
-  it('short-caches an exact-topic miss without making it permanent', async () => {
-    const { adapter, queryEventLogsPage } = fixture([[]]);
-    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBeNull();
-    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBeNull();
-    expect(queryEventLogsPage).toHaveBeenCalledTimes(1);
+  it('short-caches an exact-topic miss and retries after the TTL', async () => {
+    vi.useFakeTimers({ now: 0 });
+    try {
+      const { adapter, queryEventLogsPage } = fixture([[]]);
+      await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBeNull();
+      await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBeNull();
+      expect(queryEventLogsPage).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(30_001);
+      queryEventLogsPage.mockResolvedValueOnce({
+        logs: [{ topics: [], data: '42' }],
+        provider: {},
+      });
+      await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBe(42n);
+      expect(queryEventLogsPage).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('rejects malformed inputs before chain initialisation and treats zero as opt-out', async () => {

--- a/packages/chain/test/context-graph-name-hash-reverse-resolution.unit.test.ts
+++ b/packages/chain/test/context-graph-name-hash-reverse-resolution.unit.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+
+const PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const STORAGE = '0x00000000000000000000000000000000000000c6';
+const NAME_HASH = `0x${'ab'.repeat(32)}`;
+const OTHER_HASH = `0x${'cd'.repeat(32)}`;
+
+function minimalConfig(): EVMAdapterConfig {
+  return {
+    rpcUrl: 'http://127.0.0.1:59998',
+    privateKey: PRIVATE_KEY,
+    hubAddress: '0x0000000000000000000000000000000000000001',
+    chainId: 'evm:31337',
+    staticNetwork: false,
+    cgRegistryScanPageSize: 2,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function fixture(pages: ReadonlyArray<ReadonlyArray<bigint>> = [[42n]]) {
+  const adapter: any = new EVMChainAdapter(minimalConfig());
+  adapter.initialized = true;
+  adapter.init = vi.fn(async () => {});
+  const provider = {};
+  const filter = { exactNameHash: NAME_HASH };
+  const filterFactory = vi.fn(() => filter);
+  const parseLog = vi.fn(({ data }: { data: string }) => ({
+    name: 'ContextGraphCreated',
+    args: { contextGraphId: BigInt(data) },
+  }));
+  const storage = {
+    getAddress: vi.fn(async () => STORAGE),
+    filters: { ContextGraphCreated: filterFactory },
+    interface: { parseLog },
+  };
+  adapter.contracts = { contextGraphStorage: storage };
+  adapter.resolveContractDeployBlock = vi.fn(async () => ({
+    fromBlock: 100,
+    head: 100 + pages.length * 2 - 1,
+    scanProviders: [{ provider, backendHead: 100 + pages.length * 2 - 1 }],
+  }));
+  const queryEventLogsPage = vi.fn(async (...args: unknown[]) => {
+    const lo = Number(args[2]);
+    const pageIndex = Math.floor((lo - 100) / 2);
+    return {
+      logs: (pages[pageIndex] ?? []).map((id) => ({
+        topics: [],
+        data: id.toString(),
+      })),
+      provider,
+    };
+  });
+  adapter.queryEventLogsPage = queryEventLogsPage;
+  adapter.getContextGraphNameHash = vi.fn(async () => NAME_HASH);
+  return {
+    adapter,
+    filter,
+    filterFactory,
+    queryEventLogsPage,
+  };
+}
+
+describe('ContextGraphCreated name-hash reverse resolution', () => {
+  it('queries the exact indexed topic in deploy-anchored pages and verifies the live slot', async () => {
+    const { adapter, filter, filterFactory, queryEventLogsPage } = fixture([
+      [],
+      [42n],
+      [],
+    ]);
+
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBe(42n);
+
+    expect(filterFactory).toHaveBeenCalledWith(null, null, NAME_HASH);
+    expect(queryEventLogsPage.mock.calls.map((call) => [call[1], call[2], call[3]])).toEqual([
+      [filter, 100, 101],
+      [filter, 102, 103],
+      [filter, 104, 105],
+    ]);
+    expect(adapter.getContextGraphNameHash).toHaveBeenCalledWith(42n);
+
+    // Positive bindings are immutable for this storage deployment.
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBe(42n);
+    expect(queryEventLogsPage).toHaveBeenCalledTimes(3);
+  });
+
+  it('single-flights concurrent callers and lets one caller stop waiting', async () => {
+    const { adapter } = fixture();
+    const pending = deferred<bigint | null>();
+    adapter.scanContextGraphIdByNameHash = vi.fn(() => pending.promise);
+    const controller = new AbortController();
+
+    const aborted = adapter.resolveContextGraphIdByNameHash(NAME_HASH, {
+      signal: controller.signal,
+    });
+    const survivor = adapter.resolveContextGraphIdByNameHash(NAME_HASH);
+    controller.abort(new Error('caller stopped'));
+
+    await expect(aborted).rejects.toThrow('caller stopped');
+    pending.resolve(42n);
+    await expect(survivor).resolves.toBe(42n);
+    expect(adapter.scanContextGraphIdByNameHash).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when one name hash was committed to multiple numeric slots', async () => {
+    const { adapter } = fixture([[42n, 43n]]);
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      /ambiguous.*2 numeric ids/i,
+    );
+    expect(adapter.getContextGraphNameHash).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the live slot no longer matches the indexed commitment', async () => {
+    const { adapter } = fixture([[42n]]);
+    adapter.getContextGraphNameHash = vi.fn(async () => OTHER_HASH);
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      /currently commits.*expected/i,
+    );
+  });
+
+  it('short-caches an exact-topic miss without making it permanent', async () => {
+    const { adapter, queryEventLogsPage } = fixture([[]]);
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBeNull();
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBeNull();
+    expect(queryEventLogsPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects malformed inputs before chain initialisation and treats zero as opt-out', async () => {
+    const { adapter } = fixture();
+    await expect(adapter.resolveContextGraphIdByNameHash('not-a-hash')).rejects.toThrow(
+      /bytes32 nameHash/,
+    );
+    await expect(adapter.resolveContextGraphIdByNameHash(`0x${'00'.repeat(32)}`)).resolves.toBeNull();
+    expect(adapter.init).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chain/test/context-graph-name-hash-reverse-resolution.unit.test.ts
+++ b/packages/chain/test/context-graph-name-hash-reverse-resolution.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import { CG_REGISTRY_MAX_SCAN_PAGES } from '../src/evm-adapter-base.js';
 
 const PRIVATE_KEY =
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -135,6 +136,20 @@ describe('ContextGraphCreated name-hash reverse resolution', () => {
       /ambiguous.*2 numeric ids/i,
     );
     expect(adapter.getContextGraphNameHash).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-budget historical span before issuing any page query', async () => {
+    const { adapter, queryEventLogsPage } = fixture();
+    adapter.resolveContractDeployBlock = vi.fn(async () => ({
+      fromBlock: 100,
+      head: 100 + (CG_REGISTRY_MAX_SCAN_PAGES * 2),
+      scanProviders: [{ provider: {}, backendHead: 100 + (CG_REGISTRY_MAX_SCAN_PAGES * 2) }],
+    }));
+
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      new RegExp(`budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages`),
+    );
+    expect(queryEventLogsPage).not.toHaveBeenCalled();
   });
 
   it('fails closed when the live slot no longer matches the indexed commitment', async () => {

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -535,6 +535,35 @@ describe('MockChainAdapter API parity with EVMChainAdapter [CH-8]', () => {
     })).resolves.toMatchObject({ contextGraphId: 3n });
   });
 
+  it('mirrors exact name-hash reverse-resolution behavior', async () => {
+    const mock = new MockChainAdapter();
+    const nameHash = `0x${'ab'.repeat(32)}`;
+    const upperCaseHash = `0x${nameHash.slice(2).toUpperCase()}`;
+    const unknownHash = `0x${'cd'.repeat(32)}`;
+
+    await expect(mock.resolveContextGraphIdByNameHash('not-a-hash')).rejects.toThrow(
+      /bytes32 nameHash/,
+    );
+    await expect(mock.resolveContextGraphIdByNameHash(ethers.ZeroHash)).resolves.toBeNull();
+    await expect(mock.resolveContextGraphIdByNameHash(unknownHash)).resolves.toBeNull();
+
+    await expect(mock.createOnChainContextGraph({
+      accessPolicy: 0,
+      publishPolicy: 1,
+      nameHash,
+    })).resolves.toMatchObject({ contextGraphId: 1n });
+    await expect(mock.resolveContextGraphIdByNameHash(upperCaseHash)).resolves.toBe(1n);
+
+    await expect(mock.createOnChainContextGraph({
+      accessPolicy: 0,
+      publishPolicy: 1,
+      nameHash: upperCaseHash,
+    })).resolves.toMatchObject({ contextGraphId: 2n });
+    await expect(mock.resolveContextGraphIdByNameHash(nameHash)).rejects.toThrow(
+      /ambiguous.*2 numeric ids/i,
+    );
+  });
+
   it('requires explicit mock support for address-specific V10 publishing', async () => {
     const mock = new MockChainAdapter('mock:31337', '0x1111111111111111111111111111111111111111');
     mock.minimumRequiredSignatures = 0;


### PR DESCRIPTION
## User impact

An Edge user can select an existing public Context Graph after its creation event has aged out of the node's bounded live-event lookback. The node can now recover that selected graph's authoritative numeric on-chain ID directly from the indexed creation commitment, without requiring the ontology graph to have synchronized first.

This removes the cold-start identity deadlock that kept policy, ownership, era, VM and SWM validation pending for an otherwise valid selected graph.

It does **not** make Edge nodes enumerate or synchronize every public Context Graph. Historical lookup is admitted only for an explicitly selected subscription or a Core-hosted record; arbitrary remote identifiers and passive records cannot start a chain scan.

Stack base: #2041

## Before

```mermaid
sequenceDiagram
    actor User
    participant Edge
    participant Poller as "Live event poller"
    participant Ontology as "Local ontology graph"
    participant Chain

    User->>Edge: Select an existing public CG
    Edge->>Poller: Resolve creation event
    Poller-->>Edge: Event is older than bounded lookback
    Edge->>Ontology: Legacy reverse lookup
    Ontology-->>Edge: No binding in cold store
    Edge-->>Edge: Numeric CG ID remains unresolved
    Note over Edge,Chain: Policy, VM and SWM validation cannot establish the authoritative CG binding
```

## After

```mermaid
sequenceDiagram
    actor User
    participant Edge
    participant Chain as "ContextGraphStorage"
    participant DKG

    User->>Edge: Select an existing public CG
    Edge->>Edge: Confirm local sync admission
    Edge->>Chain: Exact indexed ContextGraphCreated(nameHash) lookup
    Chain-->>Edge: One numeric CG ID candidate
    Edge->>Chain: getNameHash(CG ID)
    Chain-->>Edge: Current matching commitment
    Edge->>Edge: Persist hash-to-ID binding
    Edge->>Chain: Read policy, ownership and era
    Edge->>DKG: Continue selected VM/SWM synchronization
```

## Implementation

- adds an optional chain-adapter reverse-resolution capability;
- keeps normalization, TTL/single-flight behavior and abortable waiting in a focused `ContextGraphNameHashResolver`;
- injects one concrete EVM-owned loader rather than a generic scan framework;
- scans exact indexed `ContextGraphCreated.nameHash` topics in deploy-block-anchored, RPC-safe pages;
- rejects an over-budget historical span before making any page query;
- single-flights concurrent requests and short-caches misses so a later registration is discoverable without restart;
- deliberately does not retain positive results in the adapter: every independent lookup can detect a duplicate commitment created later, while the Agent persists an admitted successful binding;
- fails closed for duplicate historical commitments or a current-slot hash mismatch;
- lets an aborted caller stop waiting without cancelling shared work needed by other callers;
- gates historical scans on explicit local selection or Core-hosted admission before retaining the ontology projection as a legacy miss fallback;
- preserves the original spelling of hash-shaped cleartext Context Graph IDs;
- keeps the production mock adapter behaviorally aligned with the EVM adapter;
- preserves existing call shapes when no abort signal is supplied.

## Validation

- full 17-package dependency/build chain: **17/17 passed**;
- full Chain suite: **69 files, 1,224 passed, 1 skipped, 0 failed**;
- focused Chain reverse-resolution tests: **8/8 passed**;
- focused resolver plus production Mock/EVM adapter parity: **23/23 passed**;
- Agent historical-binding, source-label, host-mode and hash-shaped-ID coverage plus relevant integration: **4 files, 46/46 passed**;
- staged diff check: **passed**.

## Isolated testnet canary evidence

Production Core services were not changed. A fresh isolated Edge used only three selected cleartext public CG IDs and the exact stack head.

- cold binding persisted **3/3** authoritative mappings without ontology catch-up: `m1-20260803o-1 -> 222`, `-2 -> 223`, `-3 -> 224`;
- the Edge assembled **18/18 data graphs** and **432/432 data triples**: 12 SWM graphs plus 6 finalized VM graphs, 24 triples each;
- every graph's canonical triple digest matched at least one production Core source exactly; no metadata-only result was counted;
- four SWM graphs were fragmented across individual Cores, but the Edge assembled the complete union across providers;
- the exact final head `ec7f2bd9` restarted healthy with the same peer identity, 3/3 bindings, 18 graphs and 432 triples intact;
- restart reached API readiness in seconds from persisted bindings; the genuinely cold three-CG run took about 5m26s and recorded RPC 429 failover without exhaustion;
- store and sync-global schedulers recovered healthy with zero rejected work.

## Review feedback closed

- `11b87b893`: removed permanent positive caching, preserved hash-shaped cleartext IDs, extracted resolver state, reused the canonical cache, and added Core-hosted plus negative-TTL coverage;
- `ec7f2bd9e`: collapsed the generic scan framework into one concrete EVM loader and added fail-closed scan-budget coverage.

## M1 gate status

This PR removes the observed cold selected-CG identity-resolution blocker and has a real-network cold Edge VM+SWM payload proof. It does not by itself claim the entire M1 release gate: the final release evidence must compose the full stack's on-demand, always-on, unselected, restart and Core-coverage cells without treating legacy `synced` metadata as payload completion.
