### PR TITLE
fix(sync): make Edge on-demand synchronization point-in-time

### DIFF
--- a/packages/cli/src/daemon/context-graph-catchup-coordinator.ts
+++ b/packages/cli/src/daemon/context-graph-catchup-coordinator.ts
@@ -38,6 +38,12 @@ export interface ContextGraphCatchupCoordinatorEffects {
       verifiedPrivateOnlyResponses: number;
     },
   ) => void;
+  /**
+   * Close any process-local subscription whose requested lifetime ended with
+   * this serialized catch-up. Implementations must re-read live state so an
+   * in-flight promotion to always-on wins over the original on-demand request.
+   */
+  settleSubscriptionLifetime?: (contextGraphId: string) => void;
   now?: () => number;
   createJobId?: () => string;
   trace?: (message: string) => void;
@@ -107,6 +113,11 @@ export class ContextGraphCatchupCoordinatorService {
     this.pruneCompletedJobs();
     void this.run(coordinator, input.readinessBeforeCatchup);
     return this.markLatest(job);
+  }
+
+  /** Settle an already-ready request that did not need a detached worker. */
+  settleSubscriptionLifetime(contextGraphId: string): void {
+    this.effects.settleSubscriptionLifetime?.(contextGraphId);
   }
 
   private toScope(includeSharedMemory: boolean): CatchupScope {
@@ -180,10 +191,33 @@ export class ContextGraphCatchupCoordinatorService {
         await this.runFullFirst(coordinator, readinessBeforeCatchup);
       }
     } finally {
+      try {
+        this.settleSubscriptionLifetime(coordinator.contextGraphId);
+      } catch (error) {
+        this.failSubscriptionLifetimeSettlement(coordinator, error);
+      }
       if (this.inFlightByContextGraph.get(coordinator.contextGraphId) === coordinator) {
         this.inFlightByContextGraph.delete(coordinator.contextGraphId);
       }
     }
+  }
+
+  private failSubscriptionLifetimeSettlement(
+    coordinator: CatchupCoordinator,
+    error: unknown,
+  ): void {
+    const message = error instanceof Error ? error.message : String(error);
+    for (const jobId of [coordinator.durableJobId, coordinator.fullJobId]) {
+      if (!jobId) continue;
+      const job = this.tracker.jobs.get(jobId);
+      if (!job) continue;
+      job.status = 'failed';
+      job.error = `Catch-up finished but subscription lifetime settlement failed: ${message}`;
+      job.finishedAt = this.now();
+    }
+    this.effects.trace?.(
+      `[catchup] contextGraph=${coordinator.contextGraphId} lifetime settlement failed: ${message}`,
+    );
   }
 
   private async runDurableFirst(

--- a/packages/cli/src/daemon/context-graph-catchup-coordinator.ts
+++ b/packages/cli/src/daemon/context-graph-catchup-coordinator.ts
@@ -38,12 +38,6 @@ export interface ContextGraphCatchupCoordinatorEffects {
       verifiedPrivateOnlyResponses: number;
     },
   ) => void;
-  /**
-   * Close any process-local subscription whose requested lifetime ended with
-   * this serialized catch-up. Implementations must re-read live state so an
-   * in-flight promotion to always-on wins over the original on-demand request.
-   */
-  settleSubscriptionLifetime?: (contextGraphId: string) => void;
   now?: () => number;
   createJobId?: () => string;
   trace?: (message: string) => void;
@@ -55,6 +49,10 @@ export class ContextGraphCatchupCoordinatorService {
   private readonly now: () => number;
   private readonly createJobId: () => string;
   private readonly inFlightByContextGraph = new Map<string, CatchupCoordinator>();
+  private readonly runSettlementByContextGraph = new Map<string, {
+    promise: Promise<void>;
+    resolve: () => void;
+  }>();
 
   constructor(
     private readonly tracker: CatchupTracker,
@@ -109,15 +107,23 @@ export class ContextGraphCatchupCoordinatorService {
         ? { durableJobId: job.jobId }
         : { fullJobId: job.jobId }),
     };
+    let resolveSettlement!: () => void;
+    const settlement = new Promise<void>((resolve) => {
+      resolveSettlement = resolve;
+    });
+    this.runSettlementByContextGraph.set(input.contextGraphId, {
+      promise: settlement,
+      resolve: resolveSettlement,
+    });
     this.inFlightByContextGraph.set(input.contextGraphId, coordinator);
     this.pruneCompletedJobs();
     void this.run(coordinator, input.readinessBeforeCatchup);
     return this.markLatest(job);
   }
 
-  /** Settle an already-ready request that did not need a detached worker. */
-  settleSubscriptionLifetime(contextGraphId: string): void {
-    this.effects.settleSubscriptionLifetime?.(contextGraphId);
+  /** Observe completion of the currently serialized catch-up, if any. */
+  whenCurrentRunSettles(contextGraphId: string): Promise<void> {
+    return this.runSettlementByContextGraph.get(contextGraphId)?.promise ?? Promise.resolve();
   }
 
   private toScope(includeSharedMemory: boolean): CatchupScope {
@@ -191,33 +197,15 @@ export class ContextGraphCatchupCoordinatorService {
         await this.runFullFirst(coordinator, readinessBeforeCatchup);
       }
     } finally {
-      try {
-        this.settleSubscriptionLifetime(coordinator.contextGraphId);
-      } catch (error) {
-        this.failSubscriptionLifetimeSettlement(coordinator, error);
-      }
       if (this.inFlightByContextGraph.get(coordinator.contextGraphId) === coordinator) {
         this.inFlightByContextGraph.delete(coordinator.contextGraphId);
       }
+      const settlement = this.runSettlementByContextGraph.get(coordinator.contextGraphId);
+      if (settlement) {
+        this.runSettlementByContextGraph.delete(coordinator.contextGraphId);
+        settlement.resolve();
+      }
     }
-  }
-
-  private failSubscriptionLifetimeSettlement(
-    coordinator: CatchupCoordinator,
-    error: unknown,
-  ): void {
-    const message = error instanceof Error ? error.message : String(error);
-    for (const jobId of [coordinator.durableJobId, coordinator.fullJobId]) {
-      if (!jobId) continue;
-      const job = this.tracker.jobs.get(jobId);
-      if (!job) continue;
-      job.status = 'failed';
-      job.error = `Catch-up finished but subscription lifetime settlement failed: ${message}`;
-      job.finishedAt = this.now();
-    }
-    this.effects.trace?.(
-      `[catchup] contextGraph=${coordinator.contextGraphId} lifetime settlement failed: ${message}`,
-    );
   }
 
   private async runDurableFirst(

--- a/packages/cli/src/daemon/context-graph-catchup-route-adapter.ts
+++ b/packages/cli/src/daemon/context-graph-catchup-route-adapter.ts
@@ -11,6 +11,23 @@ import { ContextGraphCatchupCoordinatorService } from './context-graph-catchup-c
 import type { CatchupTracker } from './types.js';
 
 /**
+ * End one point-in-time Edge subscription without deleting synchronized data.
+ * The live mode is read at settlement time: a concurrent always-on promotion
+ * therefore wins and remains attached.
+ */
+export function settleOnDemandContextGraphSubscription(
+  agent: DKGAgent,
+  contextGraphId: string,
+): boolean {
+  const subscription = agent.getSubscribedContextGraphs().get(contextGraphId);
+  if (subscription?.subscribed !== true || subscription.syncMode !== 'on-demand') {
+    return false;
+  }
+  agent.unsubscribeFromContextGraph(contextGraphId, { persist: false });
+  return true;
+}
+
+/**
  * Bind daemon-owned persistence, agent, and event effects once at the route
  * boundary. The subscribe route only chooses a scope and delegates
  * start/coalescing; readiness classification and side effects stay behind the
@@ -43,6 +60,9 @@ export function createContextGraphCatchupRouteAdapter(input: {
         contextGraphId,
         ...payload,
       });
+    },
+    settleSubscriptionLifetime: (contextGraphId) => {
+      settleOnDemandContextGraphSubscription(input.agent, contextGraphId);
     },
     ...(input.trace ? { trace: input.trace } : {}),
   });

--- a/packages/cli/src/daemon/context-graph-catchup-route-adapter.ts
+++ b/packages/cli/src/daemon/context-graph-catchup-route-adapter.ts
@@ -61,9 +61,6 @@ export function createContextGraphCatchupRouteAdapter(input: {
         ...payload,
       });
     },
-    settleSubscriptionLifetime: (contextGraphId) => {
-      settleOnDemandContextGraphSubscription(input.agent, contextGraphId);
-    },
     ...(input.trace ? { trace: input.trace } : {}),
   });
 }

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1791,6 +1791,11 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           catchupTracker.jobs.set(jobId, syntheticJob);
           catchupTracker.latestByContextGraph.set(contextGraphId, jobId);
         }
+        // No detached coordinator worker will run for this fast path, so end
+        // a point-in-time on-demand subscription here. The coordinator-owned
+        // settlement callback re-reads the live mode and preserves a request
+        // that was promoted to always-on while readiness was evaluated.
+        catchupCoordinator.settleSubscriptionLifetime(contextGraphId);
         return jsonResponse(res, 200, {
           subscribed: contextGraphId,
           syncMode: effectiveSyncMode,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -166,6 +166,7 @@ import {
   type CatchupJob,
   type CatchupTracker,
 } from '../types.js';
+import { settleOnDemandContextGraphSubscription } from '../context-graph-catchup-route-adapter.js';
 import {
   type MarkItDownTarget,
   manifestRepoRoot,
@@ -1738,6 +1739,21 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       syncMode: requestedSyncMode,
     });
     const effectiveSyncMode = appliedSubscription.syncMode;
+    const settleOnDemandLifetime = () => {
+      if (effectiveSyncMode !== 'on-demand') return;
+      try {
+        settleOnDemandContextGraphSubscription(agent, contextGraphId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[subscribe] contextGraph=${contextGraphId} on-demand lifetime settlement failed: ${message}`);
+      }
+    };
+    const settleOnDemandLifetimeAfterCurrentCatchup = () => {
+      if (effectiveSyncMode !== 'on-demand') return;
+      void catchupCoordinator.whenCurrentRunSettles(contextGraphId).then(
+        settleOnDemandLifetime,
+      );
+    };
     const existingJobId = catchupTracker.latestByContextGraph.get(contextGraphId);
     const existingJob = existingJobId ? catchupTracker.jobs.get(existingJobId) : undefined;
     let readinessBeforeCatchup = readContextGraphReadiness(dashDb, contextGraphId);
@@ -1748,6 +1764,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         includeSharedMemory: shouldSyncSharedMemory,
       });
       if (responseJob) {
+        settleOnDemandLifetimeAfterCurrentCatchup();
         return jsonResponse(res, 200, {
           subscribed: contextGraphId,
           syncMode: effectiveSyncMode,
@@ -1791,11 +1808,10 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           catchupTracker.jobs.set(jobId, syntheticJob);
           catchupTracker.latestByContextGraph.set(contextGraphId, jobId);
         }
-        // No detached coordinator worker will run for this fast path, so end
-        // a point-in-time on-demand subscription here. The coordinator-owned
-        // settlement callback re-reads the live mode and preserves a request
-        // that was promoted to always-on while readiness was evaluated.
-        catchupCoordinator.settleSubscriptionLifetime(contextGraphId);
+        // No detached coordinator worker will run for this fast path. The
+        // route-owned finalizer re-reads live mode so an in-flight always-on
+        // promotion wins over this original point-in-time request.
+        settleOnDemandLifetime();
         return jsonResponse(res, 200, {
           subscribed: contextGraphId,
           syncMode: effectiveSyncMode,
@@ -1837,6 +1853,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       includeSharedMemory: shouldSyncSharedMemory,
       readinessBeforeCatchup,
     });
+    settleOnDemandLifetimeAfterCurrentCatchup();
 
     return jsonResponse(res, 200, {
       subscribed: contextGraphId,

--- a/packages/cli/test/context-graph-catchup-coordinator.test.ts
+++ b/packages/cli/test/context-graph-catchup-coordinator.test.ts
@@ -2,6 +2,7 @@ import type { ContextGraphReadinessProvenance } from '@origintrail-official/dkg-
 import { describe, expect, it, vi } from 'vitest';
 import type { CatchupJobResult } from '../src/catchup-runner.js';
 import { ContextGraphCatchupCoordinatorService } from '../src/daemon/context-graph-catchup-coordinator.js';
+import { settleOnDemandContextGraphSubscription } from '../src/daemon/context-graph-catchup-route-adapter.js';
 import type { CatchupJob, CatchupTracker } from '../src/daemon/types.js';
 import {
   cleanEmptyResult,
@@ -86,6 +87,7 @@ function coordinatorFixture(options: {
   const markSubscriptionState = vi.fn();
   const hasConfirmedMeta = vi.fn(async () => true);
   const isPrivate = vi.fn(async () => false);
+  const settleSubscriptionLifetime = vi.fn();
   const service = new ContextGraphCatchupCoordinatorService(tracker, {
     runner: { run },
     readReadiness: () => readiness,
@@ -94,6 +96,7 @@ function coordinatorFixture(options: {
     writeReadiness,
     markSubscriptionState,
     emitProjectSynced: vi.fn(),
+    settleSubscriptionLifetime,
     createJobId: () => `job-${++sequence}`,
   });
   return {
@@ -106,6 +109,7 @@ function coordinatorFixture(options: {
     markSubscriptionState,
     hasConfirmedMeta,
     isPrivate,
+    settleSubscriptionLifetime,
   };
 }
 
@@ -334,6 +338,9 @@ describe('ContextGraphCatchupCoordinatorService', () => {
     ]);
     expect(base).toMatchObject({ includeSharedMemory: false, status: 'done' });
     expect(upgrade).toMatchObject({ includeSharedMemory: true, status: 'done' });
+    await vi.waitFor(() => {
+      expect(fixture.settleSubscriptionLifetime).toHaveBeenCalledExactlyOnceWith('cg:one');
+    });
     expect(fixture.service.coalesceActive({
       contextGraphId: 'cg:one',
       includeSharedMemory: true,
@@ -434,5 +441,79 @@ describe('ContextGraphCatchupCoordinatorService', () => {
     });
     expect(fixture.hasConfirmedMeta).not.toHaveBeenCalled();
     expect(fixture.isPrivate).not.toHaveBeenCalled();
+  });
+
+  it('fails every coalesced view when subscription lifetime settlement fails', async () => {
+    const fixture = coordinatorFixture();
+    fixture.settleSubscriptionLifetime.mockImplementation(() => {
+      throw new Error('detach failed');
+    });
+    const narrow = fixture.service.start({
+      contextGraphId: 'cg:lifetime-failure',
+      includeSharedMemory: false,
+      readinessBeforeCatchup: {
+        version: 1,
+        durableVerified: false,
+        sharedMemoryVerified: false,
+        updatedAt: 1,
+      },
+    });
+    await fixture.firstRunStarted.promise;
+    const broad = fixture.service.coalesceActive({
+      contextGraphId: 'cg:lifetime-failure',
+      includeSharedMemory: true,
+    });
+
+    fixture.releaseFirstRun.resolve();
+    if (!broad) throw new Error('broad view missing');
+    await vi.waitFor(() => {
+      expect(narrow.status).toBe('failed');
+      expect(broad.status).toBe('failed');
+    });
+    expect(narrow.error).toContain('subscription lifetime settlement failed: detach failed');
+    expect(broad.error).toContain('subscription lifetime settlement failed: detach failed');
+  });
+});
+
+describe('settleOnDemandContextGraphSubscription', () => {
+  it('detaches point-in-time live traffic while retaining the synchronized row', () => {
+    const subscriptions = new Map<string, any>([[
+      'cg:on-demand',
+      { subscribed: true, synced: true, syncMode: 'on-demand' },
+    ]]);
+    const unsubscribeFromContextGraph = vi.fn((contextGraphId: string) => {
+      const current = subscriptions.get(contextGraphId);
+      subscriptions.set(contextGraphId, { ...current, subscribed: false });
+    });
+    const agent = {
+      getSubscribedContextGraphs: () => subscriptions,
+      unsubscribeFromContextGraph,
+    } as any;
+
+    expect(settleOnDemandContextGraphSubscription(agent, 'cg:on-demand')).toBe(true);
+    expect(unsubscribeFromContextGraph).toHaveBeenCalledExactlyOnceWith(
+      'cg:on-demand',
+      { persist: false },
+    );
+    expect(subscriptions.get('cg:on-demand')).toMatchObject({
+      subscribed: false,
+      synced: true,
+      syncMode: 'on-demand',
+    });
+  });
+
+  it('preserves a live subscription promoted to always-on before settlement', () => {
+    const subscriptions = new Map<string, any>([[
+      'cg:promoted',
+      { subscribed: true, synced: true, syncMode: 'always-on' },
+    ]]);
+    const unsubscribeFromContextGraph = vi.fn();
+    const agent = {
+      getSubscribedContextGraphs: () => subscriptions,
+      unsubscribeFromContextGraph,
+    } as any;
+
+    expect(settleOnDemandContextGraphSubscription(agent, 'cg:promoted')).toBe(false);
+    expect(unsubscribeFromContextGraph).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/context-graph-catchup-coordinator.test.ts
+++ b/packages/cli/test/context-graph-catchup-coordinator.test.ts
@@ -87,7 +87,6 @@ function coordinatorFixture(options: {
   const markSubscriptionState = vi.fn();
   const hasConfirmedMeta = vi.fn(async () => true);
   const isPrivate = vi.fn(async () => false);
-  const settleSubscriptionLifetime = vi.fn();
   const service = new ContextGraphCatchupCoordinatorService(tracker, {
     runner: { run },
     readReadiness: () => readiness,
@@ -96,7 +95,6 @@ function coordinatorFixture(options: {
     writeReadiness,
     markSubscriptionState,
     emitProjectSynced: vi.fn(),
-    settleSubscriptionLifetime,
     createJobId: () => `job-${++sequence}`,
   });
   return {
@@ -109,7 +107,6 @@ function coordinatorFixture(options: {
     markSubscriptionState,
     hasConfirmedMeta,
     isPrivate,
-    settleSubscriptionLifetime,
   };
 }
 
@@ -338,9 +335,6 @@ describe('ContextGraphCatchupCoordinatorService', () => {
     ]);
     expect(base).toMatchObject({ includeSharedMemory: false, status: 'done' });
     expect(upgrade).toMatchObject({ includeSharedMemory: true, status: 'done' });
-    await vi.waitFor(() => {
-      expect(fixture.settleSubscriptionLifetime).toHaveBeenCalledExactlyOnceWith('cg:one');
-    });
     expect(fixture.service.coalesceActive({
       contextGraphId: 'cg:one',
       includeSharedMemory: true,
@@ -443,13 +437,10 @@ describe('ContextGraphCatchupCoordinatorService', () => {
     expect(fixture.isPrivate).not.toHaveBeenCalled();
   });
 
-  it('fails every coalesced view when subscription lifetime settlement fails', async () => {
+  it('exposes run settlement without rewriting coalesced catch-up outcomes', async () => {
     const fixture = coordinatorFixture();
-    fixture.settleSubscriptionLifetime.mockImplementation(() => {
-      throw new Error('detach failed');
-    });
     const narrow = fixture.service.start({
-      contextGraphId: 'cg:lifetime-failure',
+      contextGraphId: 'cg:run-settlement',
       includeSharedMemory: false,
       readinessBeforeCatchup: {
         version: 1,
@@ -460,18 +451,17 @@ describe('ContextGraphCatchupCoordinatorService', () => {
     });
     await fixture.firstRunStarted.promise;
     const broad = fixture.service.coalesceActive({
-      contextGraphId: 'cg:lifetime-failure',
+      contextGraphId: 'cg:run-settlement',
       includeSharedMemory: true,
     });
+    const settled = fixture.service.whenCurrentRunSettles('cg:run-settlement');
 
     fixture.releaseFirstRun.resolve();
     if (!broad) throw new Error('broad view missing');
-    await vi.waitFor(() => {
-      expect(narrow.status).toBe('failed');
-      expect(broad.status).toBe('failed');
-    });
-    expect(narrow.error).toContain('subscription lifetime settlement failed: detach failed');
-    expect(broad.error).toContain('subscription lifetime settlement failed: detach failed');
+    await settled;
+    expect(narrow).toMatchObject({ status: 'done', error: undefined });
+    expect(broad).toMatchObject({ status: 'done', error: undefined });
+    await expect(fixture.service.whenCurrentRunSettles('cg:run-settlement')).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -35,6 +35,87 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     expect(result.state.syncMode).toBe('on-demand');
   });
 
+  it('settles an already-ready on-demand fast path without starting catch-up', async () => {
+    const result = await subscribe({
+      hasConfirmedMeta: true,
+      syncMode: 'on-demand',
+      readiness: {
+        version: 1,
+        durableVerified: true,
+        sharedMemoryVerified: true,
+      },
+      initial: {
+        subscribed: true,
+        synced: true,
+        sharedMemorySynced: true,
+        metaSynced: true,
+        syncMode: 'on-demand',
+      },
+    });
+
+    expect(result.response.catchup.status).toBe('done');
+    expect(result.runCalls).toBe(0);
+    expect(result.unsubscribeCalls).toEqual([{
+      id: expect.any(String),
+      options: { persist: false },
+    }]);
+    expect(result.state).toMatchObject({
+      subscribed: false,
+      synced: true,
+      sharedMemorySynced: true,
+      syncMode: 'on-demand',
+    });
+  });
+
+  it('keeps an already-ready catch-up result done when on-demand cleanup fails', async () => {
+    const result = await subscribe({
+      hasConfirmedMeta: true,
+      syncMode: 'on-demand',
+      unsubscribeError: new Error('detach failed'),
+      readiness: {
+        version: 1,
+        durableVerified: true,
+        sharedMemoryVerified: true,
+      },
+      initial: {
+        subscribed: true,
+        synced: true,
+        sharedMemorySynced: true,
+        metaSynced: true,
+        syncMode: 'on-demand',
+      },
+    });
+
+    expect(result.response.catchup.status).toBe('done');
+    expect(result.job?.status).toBe('done');
+    expect(result.job?.error).toBeUndefined();
+    expect(result.runCalls).toBe(0);
+    expect(result.unsubscribeCalls).toHaveLength(1);
+    expect(result.state.subscribed).toBe(true);
+  });
+
+  it('keeps a worker catch-up result done when on-demand cleanup fails', async () => {
+    const result = await subscribe({
+      hasConfirmedMeta: true,
+      syncMode: 'on-demand',
+      unsubscribeError: new Error('detach failed'),
+      result: publicDurableAndSharedMemoryResult(),
+      initial: {
+        subscribed: false,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncMode: 'on-demand',
+      },
+    });
+
+    expect(result.response.catchup.status).toBe('queued');
+    expect(result.job).toMatchObject({ status: 'done', error: undefined });
+    expect(result.runCalls).toBe(1);
+    expect(result.unsubscribeCalls).toHaveLength(1);
+    expect(result.state.subscribed).toBe(true);
+  });
+
   it('reports the agent-applied mode when an on-demand open cannot downgrade always-on', async () => {
     const result = await subscribe({
       hasConfirmedMeta: false,
@@ -51,6 +132,8 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     ]);
     expect(result.response.syncMode).toBe('always-on');
     expect(result.state.syncMode).toBe('always-on');
+    expect(result.state.subscribed).toBe(true);
+    expect(result.unsubscribeCalls).toEqual([]);
   });
 
   it('rejects unknown sync modes before changing subscription state', async () => {

--- a/packages/cli/test/helpers/context-graph-subscribe-route-harness.ts
+++ b/packages/cli/test/helpers/context-graph-subscribe-route-harness.ts
@@ -22,6 +22,7 @@ export interface SubscribeRouteHarnessOptions {
   isPrivate?: boolean;
   allowedAgents?: string[];
   callerAddress?: string;
+  unsubscribeError?: Error;
   readiness?: {
     version: number;
     durableVerified: boolean;
@@ -42,6 +43,10 @@ export class ContextGraphSubscribeRouteHarness {
   readonly subscribeCalls: Array<{
     id: string;
     options: { syncMode?: SyncMode } | undefined;
+  }> = [];
+  readonly unsubscribeCalls: Array<{
+    id: string;
+    options: { persist?: boolean } | undefined;
   }> = [];
   readonly metadataCheckOptions: Array<
     { rejectUnregisteredPlaceholder?: boolean } | undefined
@@ -198,6 +203,14 @@ export class ContextGraphSubscribeRouteHarness {
         this.state.set(id, applied);
         return applied;
       },
+      unsubscribeFromContextGraph: (
+        id: string,
+        options?: { persist?: boolean },
+      ) => {
+        this.unsubscribeCalls.push({ id, options });
+        if (this.options.unsubscribeError) throw this.options.unsubscribeError;
+        this.state.set(id, { ...this.state.get(id), subscribed: false });
+      },
       markContextGraphSubscriptionState: (
         id: string,
         patch: Record<string, unknown>,
@@ -320,6 +333,7 @@ export async function runSubscribeScenario(
   runCalls: number;
   runRequests: CatchupRunRequest[];
   subscribeCalls: ContextGraphSubscribeRouteHarness['subscribeCalls'];
+  unsubscribeCalls: ContextGraphSubscribeRouteHarness['unsubscribeCalls'];
   state: Record<string, any>;
   patches: Array<Record<string, unknown>>;
   readiness: Record<string, unknown> | undefined;
@@ -345,6 +359,7 @@ export async function runSubscribeScenario(
       runCalls: harness.runCalls,
       runRequests: [...harness.runRequests],
       subscribeCalls: [...harness.subscribeCalls],
+      unsubscribeCalls: [...harness.unsubscribeCalls],
       state: harness.state.get(harness.contextGraphId) ?? {},
       patches: [...harness.patches],
       readiness: harness.readiness,


### PR DESCRIPTION
## Stack position

- Base: #2044
- This PR is independently reviewable and must not be merged into `main` or `testnet-canary` during RFC-64 validation.

## User impact

An Edge request with `syncMode: on-demand` now produces a point-in-time local snapshot:

- VM and SWM catch-up complete as before.
- The synchronized data remains queryable locally.
- Live CG gossip subscriptions are detached when the serialized catch-up settles, so later publications are not downloaded without another user request.
- If the same CG is promoted to `always-on` while catch-up is running, the live mode is re-read at settlement and the promotion wins.
- If lifetime settlement fails, every coalesced catch-up view is marked failed instead of reporting a misleading successful point-in-time result.
- The already-ready shortcut applies the same lifetime rule.

The live M1 gate exposed the prior behavior: the selected on-demand graph advanced from 24 to 48 VM and SWM triples after a later publication wave, before the second explicit request.

## Before

```mermaid
sequenceDiagram
    participant U as Edge user
    participant E as Edge node
    participant C as Catch-up coordinator
    participant P as Publisher

    U->>E: Subscribe CG (on-demand)
    E->>C: Start VM and SWM catch-up
    C->>P: Fetch selected snapshot
    P-->>C: Snapshot data
    C-->>E: Catch-up done
    E-->>U: status=done
    Note over E: Live CG topics remain subscribed
    P-->>E: Later VM/SWM publication
    Note over E: Snapshot advances without another user request
```

## After

```mermaid
sequenceDiagram
    participant U as Edge user
    participant E as Edge node
    participant C as Catch-up coordinator
    participant P as Publisher

    U->>E: Subscribe CG (on-demand)
    E->>C: Start VM and SWM catch-up
    C->>P: Fetch selected snapshot
    P-->>C: Snapshot data
    C-->>E: Catch-up settled
    E->>E: Re-read current subscription mode
    alt Still on-demand
        E->>E: Detach live CG topics
        Note over E: Local VM/SWM snapshot is retained
    else Promoted to always-on
        E->>E: Keep live CG topics attached
    end
    E-->>U: status=done
    P--xE: Later publication is not delivered to on-demand CG
```

## Verification

- `pnpm --filter @origintrail-official/dkg run build`
- `pnpm --filter @origintrail-official/dkg exec vitest run test/context-graph-catchup-coordinator.test.ts test/daemon-http-behavior-extra.test.ts`
  - 2 files
  - 73 tests passed
- Tests cover:
  - one settlement after serialized narrow/wide coalescing;
  - fail-visible settlement errors;
  - on-demand detachment with retained synchronized state;
  - concurrent promotion to always-on.

## Remaining release evidence

The complete five-cell M1 gate will be rerun from fresh state on the exact stacked head. That gate remains the authority for live/cold VM+SWM behavior and is not replaced by these focused tests.
