### PR TITLE
fix(sync): wake Core coverage after scope expansion

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1693,7 +1693,15 @@ export class DKGAgentBase {
 
   protected registerCorePublicSyncContextGraph(contextGraphId: string): boolean {
     if ((this.config.nodeRole ?? 'edge') !== 'core') return false;
-    return this.corePublicSyncCoverageScheduler.register(contextGraphId);
+    const changed = this.corePublicSyncCoverageScheduler.register(contextGraphId);
+    if (changed) {
+      // A prior peer success only proves the old frozen scope. Make every
+      // connected lane eligible to plan a bounded round for the expanded
+      // public catalogue; transport backoff remains independent and intact.
+      this.lastSuccessfulSyncAt.clear();
+      this.lastSyncProgressAt.clear();
+    }
+    return changed;
   }
 
   protected unregisterCorePublicSyncContextGraph(contextGraphId: string): boolean {

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -436,6 +436,8 @@ type ContextGraphDiscoveryDisposition =
 /** Internal peer-round policy: initial durable scope is frozen; later explicit intent is live. */
 interface PeerSyncScope {
   readonly effectiveBatchSize: number;
+  /** Automatic public-coverage generation frozen with this peer plan. */
+  readonly automaticCoverageEpoch?: number;
   readonly automaticContextGraphIds: readonly string[];
   readonly initialBootstrapContextGraphIds: readonly string[];
   readonly initialDurableContextGraphIds: readonly string[];
@@ -1566,6 +1568,12 @@ export class DKGAgentBase {
    */
   protected readonly lastSyncProgressAt = new Map<string, number>();
   /**
+   * Core-only automatic public-coverage generation represented by this
+   * peer's freshness/progress timestamps. Kept per peer so one concurrent
+   * old-scope round cannot make another lane appear fresh.
+   */
+  protected readonly lastSyncCoverageEpoch = new Map<string, number>();
+  /**
    * Per-peer sync-reconciler backoff. `failures` is the count of
    * consecutive reconciler attempts that did NOT produce a successful
    * sync; `nextRetryAt` is the epoch-ms before which the reconciler
@@ -1693,15 +1701,7 @@ export class DKGAgentBase {
 
   protected registerCorePublicSyncContextGraph(contextGraphId: string): boolean {
     if ((this.config.nodeRole ?? 'edge') !== 'core') return false;
-    const changed = this.corePublicSyncCoverageScheduler.register(contextGraphId);
-    if (changed) {
-      // A prior peer success only proves the old frozen scope. Make every
-      // connected lane eligible to plan a bounded round for the expanded
-      // public catalogue; transport backoff remains independent and intact.
-      this.lastSuccessfulSyncAt.clear();
-      this.lastSyncProgressAt.clear();
-    }
-    return changed;
+    return this.corePublicSyncCoverageScheduler.register(contextGraphId);
   }
 
   protected unregisterCorePublicSyncContextGraph(contextGraphId: string): boolean {
@@ -1772,6 +1772,9 @@ export class DKGAgentBase {
     ])];
     return {
       effectiveBatchSize,
+      ...((this.config.nodeRole ?? 'edge') === 'core'
+        ? { automaticCoverageEpoch: this.corePublicSyncCoverageScheduler.getCoverageEpoch() }
+        : {}),
       automaticContextGraphIds,
       initialBootstrapContextGraphIds: [
         SYSTEM_CONTEXT_GRAPHS.AGENTS,
@@ -1783,6 +1786,10 @@ export class DKGAgentBase {
         ...automaticContextGraphIds,
       ])],
     };
+  }
+
+  protected getCorePublicSyncCoverageEpoch(): number {
+    return this.corePublicSyncCoverageScheduler.getCoverageEpoch();
   }
 
   getCorePublicSyncCoverageStatus(): CorePublicSyncCoverageStatus {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -934,6 +934,7 @@ type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'defe
 
 interface LifecycleSyncScopePlan {
   readonly effectiveBatchSize: number;
+  readonly automaticCoverageEpoch?: number;
   readonly automaticContextGraphIds: readonly string[];
   readonly initialBootstrapContextGraphIds: readonly string[];
   readonly initialDurableContextGraphIds: readonly string[];
@@ -3804,6 +3805,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.lastSyncDisconnectedAt.delete(remotePeer);
     this.lastSuccessfulSyncAt.delete(remotePeer);
     this.lastSyncProgressAt.delete(remotePeer);
+    this.lastSyncCoverageEpoch.delete(remotePeer);
     this.syncReconcilerBackoff.delete(remotePeer);
     this.warmedCores.delete(remotePeer);
     this.warmCoreFailedUnpins.delete(remotePeer);
@@ -3824,7 +3826,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const now = Date.now();
     const disconnectBoundary = this.syncOnConnectDisconnectBoundary(remotePeer, now);
     const lastSuccessfulSync = this.lastSuccessfulSyncAt.get(remotePeer);
+    const currentCorePublicCoverageEpoch = (this.config.nodeRole ?? 'edge') === 'core'
+      ? this.getCorePublicSyncCoverageEpoch()
+      : undefined;
+    const coverageEpochCurrent = currentCorePublicCoverageEpoch === undefined
+      || this.lastSyncCoverageEpoch.get(remotePeer) === currentCorePublicCoverageEpoch;
     if (
+      coverageEpochCurrent &&
       lastSuccessfulSync != null &&
       lastSuccessfulSync > disconnectBoundary &&
       now - lastSuccessfulSync < SYNC_STALENESS_THRESHOLD_MS
@@ -4002,12 +4010,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       planningLane: remotePeer,
       configuredBatchSize: coverageStatus.batchSize,
     });
+    let plannedCorePublicCoverageEpoch: number | undefined;
     const createScopePlan = () => {
       const configuredContextGraphIds = [...new Set(this.config.syncContextGraphs ?? [])];
       const durableAlwaysOnEdgeContextGraphIds =
         getLiveDurableAlwaysOnEdgeContextGraphIds();
       const defaultScopePlan = this.planCorePublicSyncPeerRound(remotePeer);
       const scopePlan = invocationPolicy.buildScopePlan(defaultScopePlan);
+      plannedCorePublicCoverageEpoch = scopePlan.automaticCoverageEpoch;
       evidence.beginRound({
         effectiveBatchSize: scopePlan.effectiveBatchSize,
         selectedContextGraphIds: configuredContextGraphIds,
@@ -4037,7 +4047,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return invocationPolicy.filterSharedMemoryPlan(resolved);
     };
     let terminalOutcome: SyncOnConnectOutcome | undefined;
-    let coreCoverageExpandedDuringRound = false;
     try {
       terminalOutcome = await runSyncOnConnectWithScopePlan({
       remotePeer,
@@ -4068,22 +4077,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           const confirmed = await this.refreshMetaSyncedFlags(contextGraphIds);
           evidence.markMetadata(confirmed);
         },
-        discoverContextGraphsFromStore: async () => {
-          const trackedBefore = this.getCorePublicSyncCoverageStatus().trackedContextGraphs;
-          const discovered = await this.discoverContextGraphsFromStore();
-          const trackedAfter = this.getCorePublicSyncCoverageStatus().trackedContextGraphs;
-          if (trackedAfter > trackedBefore) {
-            // The peer-round plan is intentionally frozen before durable sync.
-            // Definitions learned from that sync therefore cannot be covered by
-            // the same round. Do not let its accounting make this peer look
-            // fresh for a scope it never attempted; the reconciler must plan a
-            // bounded follow-up round from the expanded scheduler catalogue.
-            coreCoverageExpandedDuringRound = true;
-            this.lastSuccessfulSyncAt.delete(remotePeer);
-            this.lastSyncProgressAt.delete(remotePeer);
-          }
-          return discovered;
-        },
+        discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
         syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => {
           const plan = await getSharedMemorySyncPlan(peerId, contextGraphIds);
           const requestedContextGraphIds =
@@ -4110,15 +4104,36 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         },
         onPeerSynced: (peerId, outcome) => {
           const progressAt = Math.max(Date.now(), (this.lastSyncProgressAt.get(peerId) ?? 0) + 1);
-          if (coreCoverageExpandedDuringRound) {
+          const coreCoverageEpoch = (this.config.nodeRole ?? 'edge') === 'core'
+            ? this.getCorePublicSyncCoverageEpoch()
+            : undefined;
+          const plannedCoverageIsCurrent = coreCoverageEpoch === undefined
+            || plannedCorePublicCoverageEpoch === coreCoverageEpoch;
+          if (!plannedCoverageIsCurrent) {
+            // Another peer (or a concurrent local discovery path) changed the
+            // automatic catalogue after this round froze its scope. Its result
+            // is useful, but it cannot prove freshness for the newer epoch.
             this.lastSyncProgressAt.delete(peerId);
             this.lastSuccessfulSyncAt.delete(peerId);
+            this.lastSyncCoverageEpoch.delete(peerId);
           } else {
+            if (
+              coreCoverageEpoch !== undefined
+              && this.lastSyncCoverageEpoch.get(peerId) !== coreCoverageEpoch
+            ) {
+              // Existing timestamps describe an older automatic scope. Keep
+              // only accounting produced by this current-generation round.
+              this.lastSyncProgressAt.delete(peerId);
+              this.lastSuccessfulSyncAt.delete(peerId);
+            }
             if (outcome?.progress) {
               this.lastSyncProgressAt.set(peerId, progressAt);
             }
             if (outcome?.fresh ?? true) {
               this.lastSuccessfulSyncAt.set(peerId, progressAt);
+            }
+            if (coreCoverageEpoch !== undefined) {
+              this.lastSyncCoverageEpoch.set(peerId, coreCoverageEpoch);
             }
           }
           this.skippedNoSyncPeers.delete(peerId);
@@ -4369,6 +4384,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
     const now = Date.now();
     const ctx = createOperationContext('sync');
+    const corePublicCoverageEpoch = (this.config.nodeRole ?? 'edge') === 'core'
+      ? this.getCorePublicSyncCoverageEpoch()
+      : undefined;
 
     this.pruneSyncReconcilerState(now);
     for (const pid of this.node.libp2p.getPeers()) {
@@ -4379,7 +4397,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
       const lastProgress = this.lastSyncProgressAt.get(peerId);
       const lastSyncCooldown = Math.max(lastOk ?? 0, lastProgress ?? 0);
-      const stale = lastSyncCooldown === 0
+      const coverageEpochStale = corePublicCoverageEpoch !== undefined
+        && this.lastSyncCoverageEpoch.get(peerId) !== corePublicCoverageEpoch;
+      const stale = coverageEpochStale
+        || lastSyncCooldown === 0
         || lastSyncCooldown <= lastDisconnected
         || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS;
       if (!stale) continue;
@@ -4441,6 +4462,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     for (const [peerId, ts] of this.lastSyncProgressAt) {
       if (!connected.has(peerId) && now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
         this.lastSyncProgressAt.delete(peerId);
+      }
+    }
+    for (const peerId of this.lastSyncCoverageEpoch.keys()) {
+      if (
+        !connected.has(peerId)
+        && !this.lastSuccessfulSyncAt.has(peerId)
+        && !this.lastSyncProgressAt.has(peerId)
+      ) {
+        this.lastSyncCoverageEpoch.delete(peerId);
       }
     }
     for (const [peerId, backoff] of this.syncReconcilerBackoff) {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4037,6 +4037,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return invocationPolicy.filterSharedMemoryPlan(resolved);
     };
     let terminalOutcome: SyncOnConnectOutcome | undefined;
+    let coreCoverageExpandedDuringRound = false;
     try {
       terminalOutcome = await runSyncOnConnectWithScopePlan({
       remotePeer,
@@ -4067,7 +4068,22 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           const confirmed = await this.refreshMetaSyncedFlags(contextGraphIds);
           evidence.markMetadata(confirmed);
         },
-        discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
+        discoverContextGraphsFromStore: async () => {
+          const trackedBefore = this.getCorePublicSyncCoverageStatus().trackedContextGraphs;
+          const discovered = await this.discoverContextGraphsFromStore();
+          const trackedAfter = this.getCorePublicSyncCoverageStatus().trackedContextGraphs;
+          if (trackedAfter > trackedBefore) {
+            // The peer-round plan is intentionally frozen before durable sync.
+            // Definitions learned from that sync therefore cannot be covered by
+            // the same round. Do not let its accounting make this peer look
+            // fresh for a scope it never attempted; the reconciler must plan a
+            // bounded follow-up round from the expanded scheduler catalogue.
+            coreCoverageExpandedDuringRound = true;
+            this.lastSuccessfulSyncAt.delete(remotePeer);
+            this.lastSyncProgressAt.delete(remotePeer);
+          }
+          return discovered;
+        },
         syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => {
           const plan = await getSharedMemorySyncPlan(peerId, contextGraphIds);
           const requestedContextGraphIds =
@@ -4094,11 +4110,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         },
         onPeerSynced: (peerId, outcome) => {
           const progressAt = Math.max(Date.now(), (this.lastSyncProgressAt.get(peerId) ?? 0) + 1);
-          if (outcome?.progress) {
-            this.lastSyncProgressAt.set(peerId, progressAt);
-          }
-          if (outcome?.fresh ?? true) {
-            this.lastSuccessfulSyncAt.set(peerId, progressAt);
+          if (coreCoverageExpandedDuringRound) {
+            this.lastSyncProgressAt.delete(peerId);
+            this.lastSuccessfulSyncAt.delete(peerId);
+          } else {
+            if (outcome?.progress) {
+              this.lastSyncProgressAt.set(peerId, progressAt);
+            }
+            if (outcome?.fresh ?? true) {
+              this.lastSuccessfulSyncAt.set(peerId, progressAt);
+            }
           }
           this.skippedNoSyncPeers.delete(peerId);
           this.syncReconcilerBackoff.delete(peerId);
@@ -4348,6 +4369,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
     const now = Date.now();
     const ctx = createOperationContext('sync');
+
     this.pruneSyncReconcilerState(now);
     for (const pid of this.node.libp2p.getPeers()) {
       const peerId = pid.toString();

--- a/packages/agent/src/sync/core-public-coverage-scheduler.ts
+++ b/packages/agent/src/sync/core-public-coverage-scheduler.ts
@@ -83,6 +83,14 @@ export function resolveCorePublicSyncBatchSize(
 export class CorePublicSyncCoverageScheduler {
   private readonly tracked = new Set<string>();
   /**
+   * Monotonic generation of the automatic public-coverage catalogue.
+   * Peer rounds snapshot this value when they plan their frozen automatic
+   * tail; a round may refresh peer freshness only while the generation is
+   * unchanged. This closes the cross-peer race where an old-scope round
+   * finishes after another peer expands the catalogue.
+   */
+  private coverageEpoch = 0;
+  /**
    * Bounded LRU lane anchors keep active-peer fairness without a lifecycle cleanup contract.
    * Each value names the graph that most recently occupied the lane's first slot, so the
    * state remains meaningful when priorities or tracked membership rebuild the ordered list.
@@ -107,11 +115,14 @@ export class CorePublicSyncCoverageScheduler {
     if (!normalized) return false;
     const sizeBefore = this.tracked.size;
     this.tracked.add(normalized);
-    return this.tracked.size !== sizeBefore;
+    const changed = this.tracked.size !== sizeBefore;
+    if (changed) this.coverageEpoch += 1;
+    return changed;
   }
 
   unregister(contextGraphId: string): boolean {
     const removed = this.tracked.delete(contextGraphId);
+    if (removed) this.coverageEpoch += 1;
     if (this.tracked.size === 0) {
       this.laneAnchors.clear();
     } else if (removed) {
@@ -122,6 +133,10 @@ export class CorePublicSyncCoverageScheduler {
       }
     }
     return removed;
+  }
+
+  getCoverageEpoch(): number {
+    return this.coverageEpoch;
   }
 
   planAutomaticCoverage(

--- a/packages/agent/test/core-public-coverage-scheduler.test.ts
+++ b/packages/agent/test/core-public-coverage-scheduler.test.ts
@@ -7,6 +7,21 @@ import {
 } from '../src/sync/core-public-coverage-scheduler.js';
 
 describe('Core public Context Graph coverage scheduler', () => {
+  it('advances its coverage epoch only for real catalogue mutations', () => {
+    const scheduler = new CorePublicSyncCoverageScheduler(1);
+
+    expect(scheduler.getCoverageEpoch()).toBe(0);
+    expect(scheduler.register('public-a')).toBe(true);
+    expect(scheduler.getCoverageEpoch()).toBe(1);
+    expect(scheduler.register('public-a')).toBe(false);
+    expect(scheduler.register('   ')).toBe(false);
+    expect(scheduler.getCoverageEpoch()).toBe(1);
+    expect(scheduler.unregister('missing')).toBe(false);
+    expect(scheduler.getCoverageEpoch()).toBe(1);
+    expect(scheduler.unregister('public-a')).toBe(true);
+    expect(scheduler.getCoverageEpoch()).toBe(2);
+  });
+
   it('always admits explicit selections outside the automatic coverage cap', () => {
     const scheduler = new CorePublicSyncCoverageScheduler(1, () => 123);
     scheduler.register('public-a');

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -118,6 +118,31 @@ describe('sync-on-connect churn gates', () => {
     expect(calls).toEqual([PEER_A]);
   });
 
+  it('does not suppress connection-open catch-up with an older Core coverage epoch', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SyncReconnectCoreCoverageEpoch',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      nodeRole: 'core',
+    });
+    const calls: string[] = [];
+    (agent as any).runSyncFromPeerOnConnect = async (peerId: string) => {
+      calls.push(peerId);
+    };
+    (agent as any).lastSuccessfulSyncAt.set(PEER_A, Date.now());
+    (agent as any).lastSyncCoverageEpoch.set(
+      PEER_A,
+      (agent as any).getCorePublicSyncCoverageEpoch(),
+    );
+
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(false);
+    expect((agent as any).registerCorePublicSyncContextGraph('new-public-cg')).toBe(true);
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(true);
+
+    await flushTimers();
+    expect(calls).toEqual([PEER_A]);
+  });
+
   it('labels the connect-driven admission on-connect, not unspecified', async () => {
     // The complement of the reconciler assertion below, and the source with the
     // highest production volume: every reconnect sync flows through this

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1161,6 +1161,50 @@ describe('runSyncOnConnect callbacks', () => {
 });
 
 describe('DKGAgent peer-round scope wiring', () => {
+  it('keeps a peer immediately eligible when its frozen round discovers new automatic coverage', async () => {
+    const agent = await DKGAgent.create({
+      name: 'FrozenCoreCoverageExpansion',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      nodeRole: 'core',
+      syncCorePublicBatchSize: 1,
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+      const remotePeer = freshPeerIdString();
+      (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+      (agent as any).refreshMetaSyncedFlags = async () => {};
+      (agent as any).discoverContextGraphsFromStore = async () => {
+        (agent as any).registerCorePublicSyncContextGraph('public-after-plan');
+        return 1;
+      };
+      const durable = recorder(async (..._args: unknown[]) => 1);
+      (agent as any).syncFromPeerDetailed = durable;
+      (agent as any).planSharedMemorySyncContextGraphs = async () => ({
+        publicContextGraphIds: [],
+        privateRecoverFromCurator: [],
+        eligibleContextGraphIds: [],
+      });
+      (agent as any).syncSharedMemoryFromPeerDetailed = async () => 0;
+
+      const priorFreshness = Date.now() - 30_000;
+      (agent as any).lastSuccessfulSyncAt.set(remotePeer, priorFreshness);
+      (agent as any).lastSyncProgressAt.set(remotePeer, priorFreshness);
+
+      expect(await (agent as any).trySyncFromPeer(remotePeer)).toBe('synced');
+      expect(durable.calls[0]?.[1]).toEqual([
+        SYSTEM_CONTEXT_GRAPHS.AGENTS,
+        SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      ]);
+      expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(1);
+      expect((agent as any).lastSuccessfulSyncAt.has(remotePeer)).toBe(false);
+      expect((agent as any).lastSyncProgressAt.has(remotePeer)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('keeps newly restored explicit CGs live while freezing only the automatic tail', async () => {
     const agent = await DKGAgent.create({
       name: 'DynamicExplicitScope',
@@ -1358,6 +1402,56 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
 });
 
 describe('DKGAgent sync retry — periodic reconciler', () => {
+  it('wakes fresh Core peers when public coverage admission expands', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerCoreCoverageDiscoveryWakeup',
+      listenHost: '127.0.0.1',
+      nodeRole: 'core',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      (agent.node.libp2p as any).getPeers = recorder(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+
+      const freshAt = Date.now() - 30_000;
+      (agent as any).lastSuccessfulSyncAt.set(peerA, freshAt);
+      (agent as any).lastSyncProgressAt.set(peerA, freshAt);
+
+      const trySyncFromPeer = recorder(async (peerId: string) => {
+        (agent as any).lastSuccessfulSyncAt.set(peerId, Date.now());
+        return 'synced';
+      });
+      (agent as any).trySyncFromPeer = trySyncFromPeer;
+
+      expect((agent as any).registerCorePublicSyncContextGraph('public-from-ontology')).toBe(true);
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect(trySyncFromPeer.calls).toEqual([[
+        peerA,
+        expect.any(Function),
+        'reconcile',
+        expect.any(Object),
+      ]]);
+      expect(agent.getCorePublicSyncCoverageStatus().trackedContextGraphs).toBe(1);
+
+      // The wake-up is edge-triggered. Once the peer has refreshed the new
+      // scope, an unchanged local catalogue does not defeat normal freshness.
+      expect((agent as any).registerCorePublicSyncContextGraph('public-from-ontology')).toBe(false);
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+      expect(trySyncFromPeer.calls).toHaveLength(1);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('retries connected peers with no successful sync on record', async () => {
     const agent = await DKGAgent.create({
       name: 'ReconcilerNeverSynced',

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1161,6 +1161,65 @@ describe('runSyncOnConnect callbacks', () => {
 });
 
 describe('DKGAgent peer-round scope wiring', () => {
+  it('does not let concurrent old-scope Core rounds refresh a newer coverage epoch', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ConcurrentCoreCoverageExpansion',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      nodeRole: 'core',
+      syncCorePublicBatchSize: 1,
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+      const peerA = freshPeerIdString();
+      const peerB = freshPeerIdString();
+      (agent as any).registerCorePublicSyncContextGraph('public-before-plan');
+      const plannedEpoch = (agent as any).getCorePublicSyncCoverageEpoch();
+      const peerAStarted = deferred<void>();
+      const releasePeerA = deferred<void>();
+      let expanded = false;
+
+      (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+      (agent as any).refreshMetaSyncedFlags = async () => {};
+      (agent as any).syncFromPeerDetailed = async (peerId: string) => {
+        if (peerId === peerA) {
+          peerAStarted.resolve();
+          await releasePeerA.promise;
+        }
+        return 1;
+      };
+      (agent as any).discoverContextGraphsFromStore = async () => {
+        if (!expanded) {
+          expanded = true;
+          (agent as any).registerCorePublicSyncContextGraph('public-after-plan');
+        }
+        return expanded ? 1 : 0;
+      };
+      (agent as any).planSharedMemorySyncContextGraphs = async () => ({
+        publicContextGraphIds: [],
+        privateRecoverFromCurator: [],
+        eligibleContextGraphIds: [],
+      });
+
+      const peerARound = (agent as any).trySyncFromPeer(peerA);
+      await peerAStarted.promise;
+      expect((agent as any).getCorePublicSyncCoverageEpoch()).toBe(plannedEpoch);
+
+      expect(await (agent as any).trySyncFromPeer(peerB)).toBe('synced');
+      expect((agent as any).getCorePublicSyncCoverageEpoch()).toBe(plannedEpoch + 1);
+      expect((agent as any).lastSuccessfulSyncAt.has(peerB)).toBe(false);
+      expect((agent as any).lastSyncCoverageEpoch.has(peerB)).toBe(false);
+
+      releasePeerA.resolve();
+      expect(await peerARound).toBe('synced');
+      expect((agent as any).lastSuccessfulSyncAt.has(peerA)).toBe(false);
+      expect((agent as any).lastSyncCoverageEpoch.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('keeps a peer immediately eligible when its frozen round discovers new automatic coverage', async () => {
     const agent = await DKGAgent.create({
       name: 'FrozenCoreCoverageExpansion',
@@ -1422,9 +1481,17 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       const freshAt = Date.now() - 30_000;
       (agent as any).lastSuccessfulSyncAt.set(peerA, freshAt);
       (agent as any).lastSyncProgressAt.set(peerA, freshAt);
+      (agent as any).lastSyncCoverageEpoch.set(
+        peerA,
+        (agent as any).getCorePublicSyncCoverageEpoch(),
+      );
 
       const trySyncFromPeer = recorder(async (peerId: string) => {
         (agent as any).lastSuccessfulSyncAt.set(peerId, Date.now());
+        (agent as any).lastSyncCoverageEpoch.set(
+          peerId,
+          (agent as any).getCorePublicSyncCoverageEpoch(),
+        );
         return 'synced';
       });
       (agent as any).trySyncFromPeer = trySyncFromPeer;


### PR DESCRIPTION
## User impact

Core nodes no longer leave a newly discovered public Context Graph outside automatic RFC-64 coverage until the ordinary peer-staleness window expires.

The automatic set remains bounded by `syncCorePublicBatchSize`. Edge behavior is unchanged: Edge nodes still synchronize only explicitly selected graphs. This PR does not increase concurrency, rescan the catalogue on every tick, or broaden private-CG admission.

## Problem

A peer round freezes its bounded automatic scope before fetching `ontology`. If that fetch materializes a new public CG, discovery admits it to the Core scheduler only after the frozen plan has already run. The same round could then stamp the peer fresh, suppressing the follow-up round that would actually request the new graph.

A count-based in-round check was also insufficient: peer A could finish an old-scope round after peer B expanded the catalogue and incorrectly restore freshness for A.

The formal three-node M1 gate reproduced the original symptom as `timed out waiting for core automatic journal entry`: the Core possessed the public definitions but had no automatic coverage journal entry for the new corpus.

### Before

```mermaid
sequenceDiagram
    participant A as "Core peer round A"
    participant B as "Core peer round B"
    participant C as "Coverage scheduler"

    A->>C: Freeze bounded old scope
    B->>C: Freeze bounded old scope
    B->>C: Discover and admit new public CG
    C-->>B: Catalogue expanded
    B->>B: Avoid freshness stamp
    A->>A: Finish later and stamp old scope fresh
    Note over A,C: New CG can remain uncovered on peer A
```

### After

```mermaid
sequenceDiagram
    participant A as "Core peer round A"
    participant B as "Core peer round B"
    participant C as "Coverage scheduler"
    participant R as "Core reconciler"

    A->>C: Plan at coverage epoch N
    B->>C: Plan at coverage epoch N
    B->>C: Discover and admit new public CG
    C->>C: Advance to epoch N plus 1
    B->>C: Complete with planned epoch N
    C-->>B: Stale epoch; do not refresh
    A->>C: Complete later with planned epoch N
    C-->>A: Stale epoch; do not refresh
    R->>C: Retry peers against epoch N plus 1
```

## Implementation

- Maintain a monotonic scheduler-owned coverage epoch that advances only on real register/unregister mutations.
- Capture that epoch with each frozen Core peer-round plan.
- Associate peer success/progress timestamps with the epoch they actually attempted.
- Refuse to restore freshness when the planned epoch differs from the current catalogue epoch, including across concurrent peers.
- Make both connection-open scheduling and the periodic reconciler treat an older peer epoch as stale.
- Keep transport backoff independent; catalogue expansion does not claim that an unhealthy peer became healthy.
- Prune the per-peer epoch marker with the existing sync lifecycle state.

## Validation

- `sync-on-connect-retry.test.ts`, `sync-on-connect-churn.test.ts`, and `core-public-coverage-scheduler.test.ts`: 92 passed
- `discovery-subscription-boundary.test.ts`: 20 passed
- New deterministic two-peer regression proves that neither old-scope round can refresh the newer epoch.
- `pnpm --filter @origintrail-official/dkg-agent build`: TypeScript, type tests, and package-root test passed
- `git diff --check`: passed

## Stack

- Base: #2045 (`codex/rfc64-m1-on-demand-lifetime`)
- This is the next independently reviewable M1 PR.
- The following PR prioritizes bounded public VM and SWM coverage ahead of unrelated large system-graph backlog; that remains a separate review surface.
