### PR TITLE
fix(sync): prioritize bounded public coverage

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -248,7 +248,7 @@ import { runSharedMemorySync } from './sync/requester/shared-memory-sync.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
-import { runSyncOnConnect } from './sync/on-connect/sync-on-connect.js';
+import type { SyncOnConnectScopePlan } from './sync/on-connect/sync-on-connect.js';
 import {
   generateCustodialAgent, registerSelfSovereignAgent, agentFromPrivateKey,
   ensureWorkspaceEncryptionKey,
@@ -434,15 +434,11 @@ type ContextGraphDiscoveryDisposition =
   | 'automatic-public-coverage';
 
 /** Internal peer-round policy: initial durable scope is frozen; later explicit intent is live. */
-interface PeerSyncScope {
+interface PeerSyncScope extends SyncOnConnectScopePlan {
   readonly effectiveBatchSize: number;
   /** Automatic public-coverage generation frozen with this peer plan. */
   readonly automaticCoverageEpoch?: number;
   readonly automaticContextGraphIds: readonly string[];
-  readonly initialBootstrapContextGraphIds: readonly string[];
-  readonly initialDurableContextGraphIds: readonly string[];
-  readonly prioritizeInitialDurableBeforeBootstrap?: boolean;
-  contextGraphIdsAfterDiscovery(): string[];
 }
 
 function readNonNegativeNumberEnv(name: string, fallback: number): number {
@@ -1777,8 +1773,7 @@ export class DKGAgentBase {
         ? { automaticCoverageEpoch: this.corePublicSyncCoverageScheduler.getCoverageEpoch() }
         : {}),
       automaticContextGraphIds,
-      prioritizeInitialDurableBeforeBootstrap:
-        (this.config.nodeRole ?? 'edge') === 'core' && automaticContextGraphIds.length > 0,
+      preBootstrapPublicContextGraphIds: automaticContextGraphIds,
       initialBootstrapContextGraphIds: [
         SYSTEM_CONTEXT_GRAPHS.AGENTS,
         SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -441,6 +441,7 @@ interface PeerSyncScope {
   readonly automaticContextGraphIds: readonly string[];
   readonly initialBootstrapContextGraphIds: readonly string[];
   readonly initialDurableContextGraphIds: readonly string[];
+  readonly prioritizeInitialDurableBeforeBootstrap?: boolean;
   contextGraphIdsAfterDiscovery(): string[];
 }
 
@@ -1776,6 +1777,8 @@ export class DKGAgentBase {
         ? { automaticCoverageEpoch: this.corePublicSyncCoverageScheduler.getCoverageEpoch() }
         : {}),
       automaticContextGraphIds,
+      prioritizeInitialDurableBeforeBootstrap:
+        (this.config.nodeRole ?? 'edge') === 'core' && automaticContextGraphIds.length > 0,
       initialBootstrapContextGraphIds: [
         SYSTEM_CONTEXT_GRAPHS.AGENTS,
         SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -282,7 +282,13 @@ import {
   registerSyncHandler,
   resolveSyncResponderSnapshotPolicy,
 } from './sync/responder/sync-handler.js';
-import { runSyncOnConnectWithScopePlan, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
+import {
+  runSyncOnConnectWithScopePlan,
+  SyncOnConnectPostSyncError,
+  type SyncOnConnectOutcome,
+  type SyncOnConnectPeerOutcome,
+  type SyncOnConnectScopePlan,
+} from './sync/on-connect/sync-on-connect.js';
 import { mapWithConcurrency } from './map-with-concurrency.js';
 import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
 import {
@@ -932,14 +938,10 @@ interface RecoverContextGraphSwmFromPeerDependencies {
 
 type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
 
-interface LifecycleSyncScopePlan {
+interface LifecycleSyncScopePlan extends SyncOnConnectScopePlan {
   readonly effectiveBatchSize: number;
   readonly automaticCoverageEpoch?: number;
   readonly automaticContextGraphIds: readonly string[];
-  readonly initialBootstrapContextGraphIds: readonly string[];
-  readonly initialDurableContextGraphIds: readonly string[];
-  readonly prioritizeInitialDurableBeforeBootstrap?: boolean;
-  contextGraphIdsAfterDiscovery(): string[];
 }
 
 interface LifecycleSyncInvocationPolicy {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -938,6 +938,7 @@ interface LifecycleSyncScopePlan {
   readonly automaticContextGraphIds: readonly string[];
   readonly initialBootstrapContextGraphIds: readonly string[];
   readonly initialDurableContextGraphIds: readonly string[];
+  readonly prioritizeInitialDurableBeforeBootstrap?: boolean;
   contextGraphIdsAfterDiscovery(): string[];
 }
 

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -13,8 +13,12 @@ export interface SyncOnConnectScopePlan {
   initialBootstrapContextGraphIds: readonly string[];
   /** Explicit plus automatic CGs frozen for the first durable request. */
   initialDurableContextGraphIds: readonly string[];
-  /** Complete the bounded durable scope, including SWM, before bootstrap backlog. */
-  prioritizeInitialDurableBeforeBootstrap?: boolean;
+  /**
+   * Scheduler-vetted automatic public CGs to complete before bootstrap.
+   * Configured/private CGs must stay in the normal post-bootstrap path because
+   * private SWM recovery depends on the refreshed Agents registry.
+   */
+  preBootstrapPublicContextGraphIds?: readonly string[];
   /** Explicit intent re-read after discovery, merged with the frozen automatic tail. */
   contextGraphIdsAfterDiscovery: () => string[];
 }
@@ -279,6 +283,46 @@ export async function runSyncOnConnectWithScopePlan(
       throw new SyncOnConnectPostSyncError(remotePeer, err, { backoffEligible: false });
     }
   };
+  type OrderedSyncPhase = Readonly<{
+    kind: 'durable' | 'shared';
+    label: string;
+    contextGraphIds: readonly string[];
+    /** Preserve the legacy initial probe/accounting call even for an empty scope. */
+    runWhenEmpty?: boolean;
+  }>;
+  const runSyncPhase = async (
+    phase: OrderedSyncPhase,
+  ): Promise<SyncOnConnectOutcome | undefined> => {
+    const contextGraphIds = [...new Set(phase.contextGraphIds)];
+    if (contextGraphIds.length === 0 && phase.runWhenEmpty !== true) return undefined;
+    const result = phase.kind === 'durable'
+      ? await syncFromPeer(remotePeer, contextGraphIds)
+      : await syncSharedMemoryFromPeer(remotePeer, contextGraphIds);
+    const accounting = recordSyncAccounting(result, phase.kind);
+    const dataLabel = phase.kind === 'durable' ? 'data' : 'shared memory';
+    logInfo(
+      ctx,
+      `Synced ${accounting.insertedTriples} ${phase.label} ${dataLabel} triples from peer ${shortPeer}`,
+    );
+    if (accounting.deferredByBackpressure) {
+      logInfo(
+        ctx,
+        `Stopping sync-on-connect fanout for peer ${shortPeer} after ${phase.label} ${phase.kind} admission deferral`,
+      );
+      return finishSyncAccounting();
+    }
+    if (accounting.backoffWorthyFailure) {
+      logInfo(
+        ctx,
+        `Stopping sync-on-connect fanout for peer ${shortPeer} after ${phase.label} ${phase.kind} sync hit backoff-worthy pressure`,
+      );
+      return finishSyncAccounting();
+    }
+    if (phase.kind === 'durable') {
+      await runNonTransportStep(() => refreshMetaSyncedFlags(contextGraphIds));
+    }
+    return undefined;
+  };
 
   try {
     const protocols = await getPeerProtocols(remotePeer);
@@ -307,79 +351,58 @@ export async function runSyncOnConnectWithScopePlan(
     }
 
     const scopePlan = createScopePlan();
-    const bootstrapContextGraphIds = scopePlan.initialBootstrapContextGraphIds;
-    const initialDurableContextGraphIds = [...scopePlan.initialDurableContextGraphIds];
-    const prioritizeInitialDurable = scopePlan.prioritizeInitialDurableBeforeBootstrap === true
-      && initialDurableContextGraphIds.length > 0;
-    const initialSyncContextGraphIds = prioritizeInitialDurable
-      ? [...new Set(bootstrapContextGraphIds)]
-      : [...new Set([
-        ...bootstrapContextGraphIds,
-        ...initialDurableContextGraphIds,
+    const bootstrapContextGraphIds = [...new Set(scopePlan.initialBootstrapContextGraphIds)];
+    const initialDurableContextGraphIds = [...new Set(scopePlan.initialDurableContextGraphIds)];
+    const initialDurableSet = new Set(initialDurableContextGraphIds);
+    const preBootstrapPublicContextGraphIds = [
+      ...new Set(scopePlan.preBootstrapPublicContextGraphIds ?? []),
+    ].filter((contextGraphId) => initialDurableSet.has(contextGraphId));
+    const preBootstrapPublicSet = new Set(preBootstrapPublicContextGraphIds);
+    const bootstrapAndConfiguredContextGraphIds = [...new Set([
+      ...bootstrapContextGraphIds,
+      ...initialDurableContextGraphIds.filter(
+        (contextGraphId) => !preBootstrapPublicSet.has(contextGraphId),
+      ),
     ])];
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);
     const knownCgsBefore = new Set(initialDurableContextGraphIds);
-    const sharedMemoryContextGraphsAlreadyAttempted = new Set<string>();
+    let completedPreBootstrapSharedMemoryIds: readonly string[] = [];
 
-    if (prioritizeInitialDurable) {
-      logInfo(ctx, `Prioritizing ${initialDurableContextGraphIds.length} bounded context graph(s) before bootstrap backlog from ${shortPeer}`);
-      const prioritySynced = await syncFromPeer(remotePeer, initialDurableContextGraphIds);
-      const priorityAccounting = recordSyncAccounting(prioritySynced, 'durable');
-      logInfo(ctx, `Synced ${priorityAccounting.insertedTriples} priority data triples from peer ${shortPeer}`);
-      if (priorityAccounting.deferredByBackpressure) {
-        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after priority admission deferral`);
-        return finishSyncAccounting();
-      }
-      if (priorityAccounting.backoffWorthyFailure) {
-        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after priority durable sync hit backoff-worthy pressure`);
-        return finishSyncAccounting();
-      }
-      await runNonTransportStep(() => refreshMetaSyncedFlags(initialDurableContextGraphIds));
+    if (preBootstrapPublicContextGraphIds.length > 0) {
+      logInfo(
+        ctx,
+        `Prioritizing ${preBootstrapPublicContextGraphIds.length} bounded public context graph(s) before bootstrap backlog from ${shortPeer}`,
+      );
+      const priorityDurableOutcome = await runSyncPhase({
+        kind: 'durable',
+        label: 'priority public',
+        contextGraphIds: preBootstrapPublicContextGraphIds,
+      });
+      if (priorityDurableOutcome) return priorityDurableOutcome;
 
       if (syncSharedMemoryOnConnect) {
         const prioritySharedMemoryContextGraphIds = getSharedMemorySyncContextGraphs
           ? await runNonTransportStep(() => Promise.resolve(
-            getSharedMemorySyncContextGraphs(remotePeer, initialDurableContextGraphIds),
+            getSharedMemorySyncContextGraphs(remotePeer, preBootstrapPublicContextGraphIds),
           ))
-          : initialDurableContextGraphIds;
-        if (prioritySharedMemoryContextGraphIds.length > 0) {
-          const priorityShared = await syncSharedMemoryFromPeer(
-            remotePeer,
-            prioritySharedMemoryContextGraphIds,
-          );
-          const prioritySharedAccounting = recordSyncAccounting(priorityShared, 'shared');
-          logInfo(ctx, `Synced ${prioritySharedAccounting.insertedTriples} priority shared memory triples from peer ${shortPeer}`);
-          for (const contextGraphId of prioritySharedMemoryContextGraphIds) {
-            sharedMemoryContextGraphsAlreadyAttempted.add(contextGraphId);
-          }
-          if (prioritySharedAccounting.deferredByBackpressure) {
-            logInfo(ctx, `Priority shared-memory sync from peer ${shortPeer} deferred by local admission pressure`);
-            return finishSyncAccounting();
-          }
-          if (prioritySharedAccounting.backoffWorthyFailure) {
-            logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after priority shared-memory sync hit backoff-worthy pressure`);
-            return finishSyncAccounting();
-          }
-        }
+          : preBootstrapPublicContextGraphIds;
+        const prioritySharedOutcome = await runSyncPhase({
+          kind: 'shared',
+          label: 'priority public',
+          contextGraphIds: prioritySharedMemoryContextGraphIds,
+        });
+        if (prioritySharedOutcome) return prioritySharedOutcome;
+        completedPreBootstrapSharedMemoryIds = prioritySharedMemoryContextGraphIds;
       }
     }
 
-    const synced = await syncFromPeer(
-      remotePeer,
-      initialSyncContextGraphIds,
-    );
-    const syncedAccounting = recordSyncAccounting(synced, 'durable');
-    logInfo(ctx, `Synced ${syncedAccounting.insertedTriples} data triples from peer ${shortPeer}`);
-    if (syncedAccounting.deferredByBackpressure) {
-      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after local admission deferral`);
-      return finishSyncAccounting();
-    }
-    if (syncedAccounting.backoffWorthyFailure) {
-      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after durable sync hit backoff-worthy pressure`);
-      return finishSyncAccounting();
-    }
-
-    await runNonTransportStep(() => refreshMetaSyncedFlags(initialSyncContextGraphIds));
+    const bootstrapOutcome = await runSyncPhase({
+      kind: 'durable',
+      label: 'bootstrap',
+      contextGraphIds: bootstrapAndConfiguredContextGraphIds,
+      runWhenEmpty: true,
+    });
+    if (bootstrapOutcome) return bootstrapOutcome;
 
     await runNonTransportStep(() => discoverContextGraphsFromStore());
 
@@ -387,18 +410,12 @@ export async function runSyncOnConnectWithScopePlan(
     const newlyDiscovered = allCgsAfter.filter((id) => !knownCgsBefore.has(id));
     if (newlyDiscovered.length > 0) {
       logInfo(ctx, `Discovered ${newlyDiscovered.length} new CG(s) — syncing durable data from ${shortPeer}`);
-      const discoverSynced = await syncFromPeer(remotePeer, newlyDiscovered);
-      const discoverAccounting = recordSyncAccounting(discoverSynced, 'durable');
-      logInfo(ctx, `Synced ${discoverAccounting.insertedTriples} durable triples for newly discovered CG(s) from ${shortPeer}`);
-      if (discoverAccounting.deferredByBackpressure) {
-        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after discovered-CG admission deferral`);
-        return finishSyncAccounting();
-      }
-      if (discoverAccounting.backoffWorthyFailure) {
-        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after discovered-CG durable sync hit backoff-worthy pressure`);
-        return finishSyncAccounting();
-      }
-      await runNonTransportStep(() => refreshMetaSyncedFlags(newlyDiscovered));
+      const discoveredOutcome = await runSyncPhase({
+        kind: 'durable',
+        label: 'discovered',
+        contextGraphIds: newlyDiscovered,
+      });
+      if (discoveredOutcome) return discoveredOutcome;
     }
 
     durableSyncCompleted = true;
@@ -407,16 +424,19 @@ export async function runSyncOnConnectWithScopePlan(
         getSharedMemorySyncContextGraphs(remotePeer, allCgsAfter),
       ))
       : allCgsAfter;
+    const completedPreBootstrapSharedMemory = new Set(
+      completedPreBootstrapSharedMemoryIds,
+    );
     const remainingWsContextGraphIds = wsContextGraphIds.filter(
-      (contextGraphId) => !sharedMemoryContextGraphsAlreadyAttempted.has(contextGraphId),
+      (contextGraphId) => !completedPreBootstrapSharedMemory.has(contextGraphId),
     );
     if (syncSharedMemoryOnConnect && remainingWsContextGraphIds.length > 0) {
-      const wsSynced = await syncSharedMemoryFromPeer(remotePeer, remainingWsContextGraphIds);
-      const sharedAccounting = recordSyncAccounting(wsSynced, 'shared');
-      logInfo(ctx, `Synced ${sharedAccounting.insertedTriples} shared memory triples from peer ${shortPeer}`);
-      if (sharedAccounting.deferredByBackpressure) {
-        logInfo(ctx, `Shared-memory sync from peer ${shortPeer} deferred by local admission pressure`);
-      }
+      const remainingSharedOutcome = await runSyncPhase({
+        kind: 'shared',
+        label: 'remaining',
+        contextGraphIds: remainingWsContextGraphIds,
+      });
+      if (remainingSharedOutcome) return remainingSharedOutcome;
     } else if (!syncSharedMemoryOnConnect && remainingWsContextGraphIds.length > 0) {
       logInfo(ctx, `Skipping shared memory sync from peer ${shortPeer} (syncSharedMemoryOnConnect=false)`);
     }

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -13,6 +13,8 @@ export interface SyncOnConnectScopePlan {
   initialBootstrapContextGraphIds: readonly string[];
   /** Explicit plus automatic CGs frozen for the first durable request. */
   initialDurableContextGraphIds: readonly string[];
+  /** Complete the bounded durable scope, including SWM, before bootstrap backlog. */
+  prioritizeInitialDurableBeforeBootstrap?: boolean;
   /** Explicit intent re-read after discovery, merged with the frozen automatic tail. */
   contextGraphIdsAfterDiscovery: () => string[];
 }
@@ -307,12 +309,61 @@ export async function runSyncOnConnectWithScopePlan(
     const scopePlan = createScopePlan();
     const bootstrapContextGraphIds = scopePlan.initialBootstrapContextGraphIds;
     const initialDurableContextGraphIds = [...scopePlan.initialDurableContextGraphIds];
-    const initialSyncContextGraphIds = [...new Set([
-      ...bootstrapContextGraphIds,
-      ...initialDurableContextGraphIds,
+    const prioritizeInitialDurable = scopePlan.prioritizeInitialDurableBeforeBootstrap === true
+      && initialDurableContextGraphIds.length > 0;
+    const initialSyncContextGraphIds = prioritizeInitialDurable
+      ? [...new Set(bootstrapContextGraphIds)]
+      : [...new Set([
+        ...bootstrapContextGraphIds,
+        ...initialDurableContextGraphIds,
     ])];
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);
     const knownCgsBefore = new Set(initialDurableContextGraphIds);
+    const sharedMemoryContextGraphsAlreadyAttempted = new Set<string>();
+
+    if (prioritizeInitialDurable) {
+      logInfo(ctx, `Prioritizing ${initialDurableContextGraphIds.length} bounded context graph(s) before bootstrap backlog from ${shortPeer}`);
+      const prioritySynced = await syncFromPeer(remotePeer, initialDurableContextGraphIds);
+      const priorityAccounting = recordSyncAccounting(prioritySynced, 'durable');
+      logInfo(ctx, `Synced ${priorityAccounting.insertedTriples} priority data triples from peer ${shortPeer}`);
+      if (priorityAccounting.deferredByBackpressure) {
+        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after priority admission deferral`);
+        return finishSyncAccounting();
+      }
+      if (priorityAccounting.backoffWorthyFailure) {
+        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after priority durable sync hit backoff-worthy pressure`);
+        return finishSyncAccounting();
+      }
+      await runNonTransportStep(() => refreshMetaSyncedFlags(initialDurableContextGraphIds));
+
+      if (syncSharedMemoryOnConnect) {
+        const prioritySharedMemoryContextGraphIds = getSharedMemorySyncContextGraphs
+          ? await runNonTransportStep(() => Promise.resolve(
+            getSharedMemorySyncContextGraphs(remotePeer, initialDurableContextGraphIds),
+          ))
+          : initialDurableContextGraphIds;
+        if (prioritySharedMemoryContextGraphIds.length > 0) {
+          const priorityShared = await syncSharedMemoryFromPeer(
+            remotePeer,
+            prioritySharedMemoryContextGraphIds,
+          );
+          const prioritySharedAccounting = recordSyncAccounting(priorityShared, 'shared');
+          logInfo(ctx, `Synced ${prioritySharedAccounting.insertedTriples} priority shared memory triples from peer ${shortPeer}`);
+          for (const contextGraphId of prioritySharedMemoryContextGraphIds) {
+            sharedMemoryContextGraphsAlreadyAttempted.add(contextGraphId);
+          }
+          if (prioritySharedAccounting.deferredByBackpressure) {
+            logInfo(ctx, `Priority shared-memory sync from peer ${shortPeer} deferred by local admission pressure`);
+            return finishSyncAccounting();
+          }
+          if (prioritySharedAccounting.backoffWorthyFailure) {
+            logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after priority shared-memory sync hit backoff-worthy pressure`);
+            return finishSyncAccounting();
+          }
+        }
+      }
+    }
+
     const synced = await syncFromPeer(
       remotePeer,
       initialSyncContextGraphIds,
@@ -328,8 +379,7 @@ export async function runSyncOnConnectWithScopePlan(
       return finishSyncAccounting();
     }
 
-    const syncScope = new Set<string>(initialSyncContextGraphIds);
-    await runNonTransportStep(() => refreshMetaSyncedFlags(syncScope));
+    await runNonTransportStep(() => refreshMetaSyncedFlags(initialSyncContextGraphIds));
 
     await runNonTransportStep(() => discoverContextGraphsFromStore());
 
@@ -357,14 +407,17 @@ export async function runSyncOnConnectWithScopePlan(
         getSharedMemorySyncContextGraphs(remotePeer, allCgsAfter),
       ))
       : allCgsAfter;
-    if (syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
-      const wsSynced = await syncSharedMemoryFromPeer(remotePeer, wsContextGraphIds);
+    const remainingWsContextGraphIds = wsContextGraphIds.filter(
+      (contextGraphId) => !sharedMemoryContextGraphsAlreadyAttempted.has(contextGraphId),
+    );
+    if (syncSharedMemoryOnConnect && remainingWsContextGraphIds.length > 0) {
+      const wsSynced = await syncSharedMemoryFromPeer(remotePeer, remainingWsContextGraphIds);
       const sharedAccounting = recordSyncAccounting(wsSynced, 'shared');
       logInfo(ctx, `Synced ${sharedAccounting.insertedTriples} shared memory triples from peer ${shortPeer}`);
       if (sharedAccounting.deferredByBackpressure) {
         logInfo(ctx, `Shared-memory sync from peer ${shortPeer} deferred by local admission pressure`);
       }
-    } else if (!syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
+    } else if (!syncSharedMemoryOnConnect && remainingWsContextGraphIds.length > 0) {
       logInfo(ctx, `Skipping shared memory sync from peer ${shortPeer} (syncSharedMemoryOnConnect=false)`);
     }
 

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -12,6 +12,7 @@ import {
 import { peerIdFromString } from '@libp2p/peer-id';
 import {
   runSyncOnConnect,
+  runSyncOnConnectWithScopePlan,
   SyncOnConnectPostSyncError,
   type SyncOnConnectPeerOutcome,
 } from '../src/sync/on-connect/sync-on-connect.js';
@@ -105,6 +106,68 @@ function allowAllNetworkAdmission(agent: DKGAgent): void {
 }
 
 describe('runSyncOnConnect callbacks', () => {
+  it('completes bounded public VM and SWM before a bootstrap backlog can time out', async () => {
+    const remotePeer = freshPeerIdString();
+    const phases: string[] = [];
+    const peerOutcomes: SyncOnConnectPeerOutcome[] = [];
+    let durableCall = 0;
+
+    const outcome = await runSyncOnConnectWithScopePlan({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      createScopePlan: () => ({
+        initialBootstrapContextGraphIds: [
+          SYSTEM_CONTEXT_GRAPHS.AGENTS,
+          SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+        ],
+        initialDurableContextGraphIds: ['public-a', 'public-b'],
+        prioritizeInitialDurableBeforeBootstrap: true,
+        contextGraphIdsAfterDiscovery: () => ['public-a', 'public-b'],
+      }),
+      syncFromPeer: async (_peerId, contextGraphIds) => {
+        durableCall += 1;
+        phases.push(`durable:${(contextGraphIds ?? []).join(',')}`);
+        if (durableCall === 1) return 12;
+        return {
+          insertedTriples: 0,
+          completedPhases: 0,
+          checkpointAdvances: 0,
+          timedOutPhases: 1,
+          failedPeers: 0,
+          deniedPhases: 0,
+        };
+      },
+      refreshMetaSyncedFlags: async (contextGraphIds) => {
+        phases.push(`meta:${[...contextGraphIds].join(',')}`);
+      },
+      discoverContextGraphsFromStore: async () => {
+        phases.push('discover');
+        return 0;
+      },
+      getSharedMemorySyncContextGraphs: async (_peerId, contextGraphIds) =>
+        [...contextGraphIds],
+      syncSharedMemoryFromPeer: async (_peerId, contextGraphIds) => {
+        phases.push(`shared:${contextGraphIds.join(',')}`);
+        return 8;
+      },
+      logInfo: noopLog,
+      onPeerSynced: (_peerId, peerOutcome) => {
+        if (peerOutcome) peerOutcomes.push(peerOutcome);
+      },
+    });
+
+    expect(outcome).toBe('synced');
+    expect(phases).toEqual([
+      'durable:public-a,public-b',
+      'meta:public-a,public-b',
+      'shared:public-a,public-b',
+      `durable:${SYSTEM_CONTEXT_GRAPHS.AGENTS},${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY}`,
+    ]);
+    expect(peerOutcomes).toEqual([{ fresh: false, progress: true }]);
+  });
+
   it('can resume one explicit Edge scope without bootstrapping system graphs', async () => {
     const remotePeer = freshPeerIdString();
     const durableScopes: string[][] = [];
@@ -1308,22 +1371,23 @@ describe('DKGAgent peer-round scope wiring', () => {
       await (agent as any).trySyncFromPeer(remotePeer);
 
       expect(durable.calls[0]?.[1]).toEqual([
-        SYSTEM_CONTEXT_GRAPHS.AGENTS,
-        SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
         'initial-selected',
         'automatic-public-a',
       ]);
-      expect(durable.calls[1]?.[1]).toEqual(['restored-private']);
+      expect(durable.calls[1]?.[1]).toEqual([
+        SYSTEM_CONTEXT_GRAPHS.AGENTS,
+        SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      ]);
+      expect(durable.calls[2]?.[1]).toEqual(['restored-private']);
       expect(planShared.calls[0]?.[1]).toEqual([
         'initial-selected',
-        'restored-private',
         'automatic-public-a',
       ]);
       expect(shared.calls[0]?.[1]).toEqual([
         'initial-selected',
-        'restored-private',
         'automatic-public-a',
       ]);
+      expect(shared.calls[1]?.[1]).toEqual(['restored-private']);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -123,7 +123,7 @@ describe('runSyncOnConnect callbacks', () => {
           SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
         ],
         initialDurableContextGraphIds: ['public-a', 'public-b'],
-        prioritizeInitialDurableBeforeBootstrap: true,
+        preBootstrapPublicContextGraphIds: ['public-a', 'public-b'],
         contextGraphIdsAfterDiscovery: () => ['public-a', 'public-b'],
       }),
       syncFromPeer: async (_peerId, contextGraphIds) => {
@@ -1333,7 +1333,7 @@ describe('DKGAgent peer-round scope wiring', () => {
       listenHost: '127.0.0.1',
       chainAdapter: new MockChainAdapter(),
       nodeRole: 'core',
-      syncContextGraphs: ['initial-selected'],
+      syncContextGraphs: ['initial-private'],
       syncCorePublicBatchSize: 1,
     });
     try {
@@ -1349,45 +1349,63 @@ describe('DKGAgent peer-round scope wiring', () => {
       (agent as any).getPeerProtocols = async () => [];
       expect(await (agent as any).trySyncFromPeer(remotePeer)).toBe('skipped-no-sync');
       (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
-      (agent as any).refreshMetaSyncedFlags = async () => {};
+      const phases: string[] = [];
+      (agent as any).refreshMetaSyncedFlags = async (contextGraphIds: Iterable<string>) => {
+        phases.push(`meta:${[...contextGraphIds].join(',')}`);
+      };
       (agent as any).discoverContextGraphsFromStore = async () => {
+        phases.push('discover');
         (agent as any).config.syncContextGraphs = [
           ...(agent as any).config.syncContextGraphs,
           'restored-private',
         ];
         return 1;
       };
-      const durable = recorder(async (..._args: unknown[]) => 1);
+      const durable = recorder(async (_peerId: string, contextGraphIds: string[]) => {
+        phases.push(`durable:${contextGraphIds.join(',')}`);
+        return 1;
+      });
       const planShared = recorder(async (_peerId: string, contextGraphIds: string[]) => ({
         publicContextGraphIds: contextGraphIds,
         privateRecoverFromCurator: [],
         eligibleContextGraphIds: contextGraphIds,
       }));
-      const shared = recorder(async (..._args: unknown[]) => 1);
+      const shared = recorder(async (_peerId: string, contextGraphIds: string[]) => {
+        phases.push(`shared:${contextGraphIds.join(',')}`);
+        return 1;
+      });
       (agent as any).syncFromPeerDetailed = durable;
       (agent as any).planSharedMemorySyncContextGraphs = planShared;
       (agent as any).syncSharedMemoryFromPeerDetailed = shared;
 
       await (agent as any).trySyncFromPeer(remotePeer);
 
-      expect(durable.calls[0]?.[1]).toEqual([
-        'initial-selected',
-        'automatic-public-a',
-      ]);
+      expect(durable.calls[0]?.[1]).toEqual(['automatic-public-a']);
       expect(durable.calls[1]?.[1]).toEqual([
         SYSTEM_CONTEXT_GRAPHS.AGENTS,
         SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+        'initial-private',
       ]);
       expect(durable.calls[2]?.[1]).toEqual(['restored-private']);
-      expect(planShared.calls[0]?.[1]).toEqual([
-        'initial-selected',
+      expect(planShared.calls[0]?.[1]).toEqual(['automatic-public-a']);
+      expect(shared.calls[0]?.[1]).toEqual(['automatic-public-a']);
+      expect(planShared.calls[1]?.[1]).toEqual([
+        'initial-private',
+        'restored-private',
         'automatic-public-a',
       ]);
-      expect(shared.calls[0]?.[1]).toEqual([
-        'initial-selected',
-        'automatic-public-a',
+      expect(shared.calls[1]?.[1]).toEqual(['initial-private', 'restored-private']);
+      expect(phases).toEqual([
+        'durable:automatic-public-a',
+        'meta:automatic-public-a',
+        'shared:automatic-public-a',
+        `durable:${SYSTEM_CONTEXT_GRAPHS.AGENTS},${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY},initial-private`,
+        `meta:${SYSTEM_CONTEXT_GRAPHS.AGENTS},${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY},initial-private`,
+        'discover',
+        'durable:restored-private',
+        'meta:restored-private',
+        'shared:initial-private,restored-private',
       ]);
-      expect(shared.calls[1]?.[1]).toEqual(['restored-private']);
     } finally {
       await agent.stop().catch(() => {});
     }


### PR DESCRIPTION
## User impact

When a Core node has admitted a bounded batch of public Context Graphs, it now synchronizes both their finalized VM data and live SWM before spending the rest of the peer round on the potentially large `agents`/`ontology` bootstrap backlog.

Only scheduler-vetted automatic public CGs receive this priority. Configured or private CGs remain after the Agents/Ontology bootstrap, so private SWM authorization and key recovery always use a refreshed Agents registry. Edge opt-in behavior is unchanged.

## Problem

The previous peer round combined system graphs and the bounded public batch into one durable request, then deferred all SWM until that combined request completed. A large or pressured `agents` graph could therefore time out first and terminate the round even though the user-facing public CGs were ready to converge.

The formal M1 gate reproduced this: the Core spent its round transferring tens of thousands of system triples and hit store/RPC pressure before emitting an automatic coverage entry for the three fresh public graphs.

### Before

```mermaid
sequenceDiagram
    participant C as "Core"
    participant P as "Peer"

    C->>P: Durable sync agents + ontology + public/configured CGs
    P-->>C: Large agents backlog
    P--xC: Timeout or backpressure
    Note over C: Round stops
    Note over C: Public VM incomplete and public SWM never attempted
```

### After

```mermaid
sequenceDiagram
    participant C as "Core"
    participant P as "Peer"

    C->>P: Durable sync scheduler-vetted public batch
    P-->>C: Public VM data
    C->>P: Sync public SWM for the same batch
    P-->>C: Public SWM data
    C->>P: Bootstrap agents + ontology + configured scope
    P-->>C: Refreshed registry and configured VM data
    C->>P: Sync configured/private SWM
    Note over C: Public VM and SWM are already evidenced
    Note over C: Private SWM runs only after registry refresh
```

## Implementation

- Define one canonical `SyncOnConnectScopePlan`; the base and lifecycle plans extend it instead of duplicating the contract.
- Pass only scheduler-vetted automatic public CGs through `preBootstrapPublicContextGraphIds`.
- Execute durable and shared phases through one ordered helper with common accounting, metadata refresh, and stop-on-pressure behavior.
- Preserve the legacy empty initial probe for Edge accounting compatibility.
- Avoid repeating SWM work for graphs completed by the early public phase.
- Keep configured/private graphs in the post-bootstrap path.

## Validation

- 139 focused tests passed across:
  - `sync-on-connect-retry.test.ts`
  - `sync-on-connect-churn.test.ts`
  - `core-public-coverage-scheduler.test.ts`
  - `discovery-subscription-boundary.test.ts`
  - `sync-coverage-evidence-runtime.test.ts`
  - `sync-coverage-evidence-edge-periodic.test.ts`
- Includes an exact phase-order regression proving private SWM is attempted only after Agents/Ontology and metadata refresh.
- `pnpm --filter @origintrail-official/dkg-agent run build`
  - TypeScript, type tests, and package-root test passed.
- `git diff --check`
  - passed.

## Stack

- Base: #2046 (`codex/rfc64-m1-core-discovery-wakeup`)
- This PR is the next independently reviewable M1 layer.
- It addresses the scheduling blocker exposed by the formal three-node gate; the gate must still be rerun on the exact reviewed stack before M1 can pass.
