### PR TITLE
fix(sync): promote discovery after partial bootstrap

### DIFF
--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -289,6 +289,13 @@ export async function runSyncOnConnectWithScopePlan(
     contextGraphIds: readonly string[];
     /** Preserve the legacy initial probe/accounting call even for an empty scope. */
     runWhenEmpty?: boolean;
+    /**
+     * Run a local commit-side step after the transport result is accounted,
+     * including when that result asks the peer fanout to stop. A durable
+     * prefix may already contain authoritative discovery records even when a
+     * later graph in the same phase timed out.
+     */
+    afterResult?: () => Promise<void>;
   }>;
   const runSyncPhase = async (
     phase: OrderedSyncPhase,
@@ -305,6 +312,7 @@ export async function runSyncOnConnectWithScopePlan(
       `Synced ${accounting.insertedTriples} ${phase.label} ${dataLabel} triples from peer ${shortPeer}`,
     );
     if (accounting.deferredByBackpressure) {
+      if (phase.afterResult) await runNonTransportStep(phase.afterResult);
       logInfo(
         ctx,
         `Stopping sync-on-connect fanout for peer ${shortPeer} after ${phase.label} ${phase.kind} admission deferral`,
@@ -312,6 +320,7 @@ export async function runSyncOnConnectWithScopePlan(
       return finishSyncAccounting();
     }
     if (accounting.backoffWorthyFailure) {
+      if (phase.afterResult) await runNonTransportStep(phase.afterResult);
       logInfo(
         ctx,
         `Stopping sync-on-connect fanout for peer ${shortPeer} after ${phase.label} ${phase.kind} sync hit backoff-worthy pressure`,
@@ -321,6 +330,7 @@ export async function runSyncOnConnectWithScopePlan(
     if (phase.kind === 'durable') {
       await runNonTransportStep(() => refreshMetaSyncedFlags(contextGraphIds));
     }
+    if (phase.afterResult) await runNonTransportStep(phase.afterResult);
     return undefined;
   };
 
@@ -401,10 +411,17 @@ export async function runSyncOnConnectWithScopePlan(
       label: 'bootstrap',
       contextGraphIds: bootstrapAndConfiguredContextGraphIds,
       runWhenEmpty: true,
+      // The durable requester returns one aggregate result for the whole
+      // bootstrap scope. Ontology can complete before a later large system
+      // graph times out, so promote its already-committed definitions before
+      // honoring the aggregate stop signal. Core coverage-epoch accounting
+      // then wakes a fresh bounded public round without continuing this
+      // pressured peer fanout.
+      afterResult: async () => {
+        await discoverContextGraphsFromStore();
+      },
     });
     if (bootstrapOutcome) return bootstrapOutcome;
-
-    await runNonTransportStep(() => discoverContextGraphsFromStore());
 
     const allCgsAfter = scopePlan.contextGraphIdsAfterDiscovery();
     const newlyDiscovered = allCgsAfter.filter((id) => !knownCgsBefore.has(id));

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -362,7 +362,7 @@ describe('sync-on-connect churn gates', () => {
     });
   });
 
-  it('records progress before stopping post-durable sync-on-connect fanout after backoff-worthy durable pressure', async () => {
+  it('promotes committed discovery before stopping post-bootstrap fanout after durable pressure', async () => {
     const refreshMetaSyncedFlags = recorder(async () => undefined);
     const discoverContextGraphsFromStore = recorder(async () => 0);
     const syncSharedMemoryFromPeer = recorder(async () => 0);
@@ -393,7 +393,7 @@ describe('sync-on-connect churn gates', () => {
 
     expect(outcome).toBe('synced');
     expect(refreshMetaSyncedFlags.calls).toEqual([]);
-    expect(discoverContextGraphsFromStore.calls).toEqual([]);
+    expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([]);
     expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
   });

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -164,6 +164,7 @@ describe('runSyncOnConnect callbacks', () => {
       'meta:public-a,public-b',
       'shared:public-a,public-b',
       `durable:${SYSTEM_CONTEXT_GRAPHS.AGENTS},${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY}`,
+      'discover',
     ]);
     expect(peerOutcomes).toEqual([{ fresh: false, progress: true }]);
   });


### PR DESCRIPTION
## User impact

A cold Core can now turn public Context Graph definitions that were already durably received during a partial system bootstrap into bounded automatic VM and SWM coverage. A timeout later in the same bootstrap batch no longer leaves those public graphs invisible until an unrelated future discovery event.

The pressure stop remains intact: the node records the committed discovery state, stops the pressured peer fanout, and lets the existing coverage-epoch reconciler schedule a fresh bounded public round. Edge selection rules, private-CG exclusion, batch size, and concurrency are unchanged.

## Live failure reproduced

The anchored M1 testnet run placed all five fresh graph definitions and on-chain bindings in the cold Core store. A large `agents` transfer later returned a verified prefix with a backoff-worthy timeout. The peer round exited before `discoverContextGraphsFromStore`, leaving `trackedContextGraphs: 0` and producing no public Core VM/SWM work.

## Before

```mermaid
sequenceDiagram
  participant P as Sync peer
  participant C as Cold Core
  participant S as Coverage scheduler
  P->>C: Bootstrap ontology plus agents
  C->>C: Commit fresh public definitions
  P--xC: Later agents page times out
  C->>C: Stop before store discovery
  C-->>S: No public admission
  Note over C,S: trackedContextGraphs stays zero
```

## After

```mermaid
sequenceDiagram
  participant P as Sync peer
  participant C as Cold Core
  participant S as Coverage scheduler
  participant R as Reconciler
  P->>C: Bootstrap ontology plus agents
  C->>C: Commit fresh public definitions
  P--xC: Later agents page times out
  C->>C: Discover committed definitions
  C->>S: Admit public graphs and advance coverage epoch
  C->>C: Stop pressured peer fanout
  R->>S: Plan fresh bounded public batch
  R->>P: Fetch exact public VM and SWM
```

## Implementation

- Add a commit-side callback to an ordered sync phase.
- Run bootstrap store discovery after result accounting even when backpressure or a backoff-worthy transport result stops further fanout.
- Preserve the existing successful ordering: durable refresh, then discovery, then newly discovered graph work.
- Keep discovery failures classified as local post-sync failures, so they do not incorrectly grow peer transport backoff.

## Validation

- `pnpm exec vitest run packages/agent/test/sync-on-connect-churn.test.ts packages/agent/test/sync-on-connect-retry.test.ts --reporter=dot`: 77 passed
- `pnpm --filter @origintrail-official/dkg-agent build`: TypeScript, type tests, package-root test passed
- `pnpm test:m1:rfc64-selective-coverage:unit`: 82 passed
- `git diff --check`: passed

## Stack

Base: #2048 (`codex/rfc64-m1-live-gate-timeout`)

This is the next independently reviewable M1 PR and is not merged into `testnet-canary` or `main`.
