### PR TITLE
feat(w2a): finalized update convergence — canonical contracts + a genuinely per-chain finalized-read lane

### DIFF
--- a/packages/agent/src/ka-identity.ts
+++ b/packages/agent/src/ka-identity.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import { buildKnowledgeAssetUalFromOnChainIdV1 } from '@origintrail-official/dkg-core';
 import { buildKnowledgeAssetUal, type ChainAdapter } from '@origintrail-official/dkg-chain';
 
 export interface KnowledgeAssetIdentity {
@@ -41,12 +42,17 @@ export function buildReconciledKnowledgeAssetUal(
   legacyStorageAddress: string,
   kaId: bigint,
 ): string {
-  if ((kaId >> 96n) === 0n) {
-    return buildKnowledgeAssetUal(chainId, legacyStorageAddress, kaId);
-  }
-
-  const identity = unpackKnowledgeAssetId(kaId);
-  return buildKnowledgeAssetUal(chainId, identity.agentAddress, identity.kaNumber);
+  // Delegates to the single owner of this rule in `core`. It used to branch
+  // here and in `packages/core/src/vm-update-convergence.ts`, guarded by a
+  // cross-package parity test — two production implementations of one identity
+  // rule, with a test that catches drift only after it happens. The dependency
+  // direction never required that: `agent → chain → core`, so `core` can own it
+  // and this can delegate downward.
+  //
+  // Behaviour is unchanged: the owner lowercases the storage address exactly as
+  // `buildKnowledgeAssetUal` did, which the sole caller relies on — it passes
+  // the checksummed address returned by `getDKGKnowledgeAssetsAddress()`.
+  return buildKnowledgeAssetUalFromOnChainIdV1(chainId, legacyStorageAddress, kaId);
 }
 
 export async function resolveAssetUalFromKaIdentity(

--- a/packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts
@@ -94,6 +94,11 @@ export function createRfc64FinalizedVmAgentPrecommitV1(
       snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
         chainId,
         endpoints: options.rpcEndpoints,
+        // This scope is constructed PER precommit invocation, so its admission
+        // must come from the process-wide per-chain registry — a gate private
+        // to this instance would have contended with nothing, and two
+        // concurrent precommits on one chain would both admit.
+        owner: 'rfc64',
       }),
       materialize: createFinalizedVmStoreMaterializerV1({ store: options.store }),
     });

--- a/packages/agent/src/rfc64/public-catalog-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-receiver-v1.ts
@@ -108,6 +108,18 @@ interface ReceiverTaskV1 {
    * about the head or the peer.
    */
   admissionDeferrals?: number;
+  /**
+   * Provider retry bookkeeping, carried ACROSS admission deferrals.
+   *
+   * These were locals in `#runTask`. Because a deferral exits and requeues the
+   * task, the next run restarted them at zero — so `maxAttempts` stopped being a
+   * per-provider bound whenever contention landed between ordinary failures: a
+   * provider could fail twice, hit a busy lane, and then get a fresh three
+   * attempts. Repeated contention multiplied retries without limit.
+   */
+  attemptsByProvider?: Map<string, number>;
+  notFoundProviders?: Set<string>;
+  providerCursor?: number;
 }
 
 interface ReceiverProviderV1 {
@@ -373,9 +385,10 @@ export class Rfc64PublicCatalogReceiverV1 {
 
   async #runTask(task: ReceiverTaskV1): Promise<'done' | 'defer-admission'> {
     let lastError: unknown;
-    const notFoundProviders = new Set<string>();
-    const attemptsByProvider = new Map<string, number>();
-    let providerCursor = 0;
+    // Resumed, not reset: see `ReceiverTaskV1.attemptsByProvider`.
+    const notFoundProviders = (task.notFoundProviders ??= new Set<string>());
+    const attemptsByProvider = (task.attemptsByProvider ??= new Map<string, number>());
+    let providerCursor = task.providerCursor ?? 0;
     while (true) {
       if (this.#closing.signal.aborted) return 'done';
       const selection = nextEligibleProvider(
@@ -399,6 +412,7 @@ export class Rfc64PublicCatalogReceiverV1 {
       }
       const { provider, nextCursor } = selection;
       providerCursor = nextCursor;
+      task.providerCursor = nextCursor;
       const providerAttempt = (attemptsByProvider.get(provider.key) ?? 0) + 1;
       attemptsByProvider.set(provider.key, providerAttempt);
       try {
@@ -424,9 +438,12 @@ export class Rfc64PublicCatalogReceiverV1 {
         return 'done';
       } catch (error) {
         if (this.#isDeferrableError(error)) {
-          // Not this head's fault and not this provider's fault: give the
-          // attempt back and let the task wait for the lane outside the slot.
-          attemptsByProvider.set(provider.key, providerAttempt - 1);
+          // Not this head's fault and not this provider's fault: roll back ONLY
+          // this attempt and let the task wait for the lane outside the slot.
+          // Every other provider's tally survives on the task, so contention
+          // cannot launder a provider back to a full attempt budget.
+          if (providerAttempt <= 1) attemptsByProvider.delete(provider.key);
+          else attemptsByProvider.set(provider.key, providerAttempt - 1);
           return 'defer-admission';
         }
         lastError = error;

--- a/packages/agent/src/rfc64/public-catalog-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-receiver-v1.ts
@@ -48,6 +48,16 @@ export interface Rfc64PublicCatalogReceiverOptionsV1 {
   readonly maxProvidersPerHead?: number;
   /** Base backoff between attempts (doubled per retry). Default 250ms. */
   readonly retryBackoffMs?: number;
+  /**
+   * Wait before re-queuing a task that found the process-wide finalized
+   * chain-read lane busy. Default 500ms.
+   */
+  readonly admissionDeferralMs?: number;
+  /**
+   * Bound on those deferrals so a permanently wedged lane degrades into an
+   * ordinary failure instead of looping. Default 240 (~2 minutes at 500ms).
+   */
+  readonly maxAdmissionDeferrals?: number;
   readonly onHeadApplied?: (
     announcement: Rfc64PublicCatalogHeadAnnouncementV1,
     remotePeerId: string,
@@ -68,6 +78,11 @@ export interface Rfc64PublicCatalogReceiverStatsV1 {
   readonly failed: number;
   readonly droppedQueueFull: number;
   readonly droppedProviders: number;
+  /**
+   * Times a task stepped aside for a busy finalized chain lane. Distinct from
+   * `failed`: the head is still pending, not lost.
+   */
+  readonly admissionDeferred: number;
   readonly inFlight: number;
   readonly queued: number;
 }
@@ -77,6 +92,12 @@ interface ReceiverTaskV1 {
   readonly scopeKey: string;
   readonly providers: ReceiverProviderV1[];
   readonly providerKeys: Set<string>;
+  /**
+   * How many times this task has stepped aside for a busy finalized chain lane.
+   * Mutable, and deliberately NOT a provider attempt: contention says nothing
+   * about the head or the peer.
+   */
+  admissionDeferrals?: number;
 }
 
 interface ReceiverProviderV1 {
@@ -91,7 +112,32 @@ const DEFAULTS = Object.freeze({
   maxAttempts: 3,
   maxProvidersPerHead: 8,
   retryBackoffMs: 250,
+  admissionDeferralMs: 500,
+  maxAdmissionDeferrals: 240,
 });
+
+/**
+ * Is this failure "the chain lane is busy" rather than "this head is bad"?
+ *
+ * The pinned finalized read is one-per-chain PROCESS-WIDE, so an unrelated
+ * context graph on the same chain can legitimately hold it for up to the
+ * snapshot deadline. That is contention, not an error about this head — but the
+ * generic retry path treats it like a provider failure: three attempts and
+ * exponential backoff finish in under two seconds, the task is marked failed,
+ * and its pending key is deleted. The head is then only retried if some later
+ * announcement or explicit pull happens to arrive.
+ *
+ * Matching is on the chain layer's own typed code, not on message text.
+ */
+function isChainAdmissionContention(error: unknown): boolean {
+  for (let cause: unknown = error, depth = 0; cause !== undefined && cause !== null && depth < 8; depth += 1) {
+    if (typeof cause === 'object' && (cause as { code?: unknown }).code === 'concurrency-saturated') {
+      return true;
+    }
+    cause = (cause as { cause?: unknown }).cause;
+  }
+  return false;
+}
 
 export class Rfc64PublicCatalogReceiverV1 {
   readonly #reconciler: Rfc64PublicCatalogReceiverReconcilerV1;
@@ -113,7 +159,12 @@ export class Rfc64PublicCatalogReceiverV1 {
   #closed = false;
   #idleWaiters: Array<() => void> = [];
 
+  readonly #admissionDeferralMs: number;
+  readonly #maxAdmissionDeferrals: number;
+  readonly #deferralTimers = new Set<ReturnType<typeof setTimeout>>();
+
   #scheduled = 0;
+  #admissionDeferred = 0;
   #dedupedInFlight = 0;
   #dedupedAlreadyApplied = 0;
   #applied = 0;
@@ -136,6 +187,14 @@ export class Rfc64PublicCatalogReceiverV1 {
       DEFAULTS.maxProvidersPerHead,
     );
     this.#retryBackoffMs = nonNegativeInt(options.retryBackoffMs, DEFAULTS.retryBackoffMs);
+    this.#admissionDeferralMs = nonNegativeInt(
+      options.admissionDeferralMs,
+      DEFAULTS.admissionDeferralMs,
+    );
+    this.#maxAdmissionDeferrals = positiveInt(
+      options.maxAdmissionDeferrals,
+      DEFAULTS.maxAdmissionDeferrals,
+    );
     this.#onHeadApplied = options.onHeadApplied;
     this.#onError = options.onError;
   }
@@ -199,6 +258,8 @@ export class Rfc64PublicCatalogReceiverV1 {
       return;
     }
     this.#closed = true;
+    for (const timer of this.#deferralTimers) clearTimeout(timer);
+    this.#deferralTimers.clear();
     const abandoned = this.#queue.splice(0);
     for (const task of abandoned) this.#pendingByKey.delete(task.key);
     this.#closing.abort(new Error('RFC-64 public catalog receiver closing'));
@@ -217,6 +278,7 @@ export class Rfc64PublicCatalogReceiverV1 {
       failed: this.#failed,
       droppedQueueFull: this.#droppedQueueFull,
       droppedProviders: this.#droppedProviders,
+      admissionDeferred: this.#admissionDeferred,
       inFlight: this.#active.size,
       queued: this.#queue.length,
     });
@@ -231,10 +293,18 @@ export class Rfc64PublicCatalogReceiverV1 {
       const [task] = this.#queue.splice(taskIndex, 1);
       if (task === undefined) return;
       this.#activeScopeKeys.add(task.scopeKey);
-      const run = this.#runTask(task).finally(() => {
+      const run = this.#runTask(task).then((outcome) => {
+        // A deferral releases the concurrency slot AND the semantic scope lock
+        // before waiting, and keeps the pending key so a duplicate announcement
+        // still dedupes onto this task instead of creating a second writer.
+        if (outcome === 'defer-admission' && !this.#closed) {
+          this.#scheduleAdmissionRetry(task);
+          return;
+        }
+        this.#pendingByKey.delete(task.key);
+      }).finally(() => {
         this.#active.delete(run);
         this.#activeScopeKeys.delete(task.scopeKey);
-        this.#pendingByKey.delete(task.key);
         if (!this.#closed) this.#pump();
         if (this.#isIdle()) this.#resolveIdle();
       });
@@ -242,13 +312,48 @@ export class Rfc64PublicCatalogReceiverV1 {
     }
   }
 
-  async #runTask(task: ReceiverTaskV1): Promise<void> {
+  /**
+   * Re-queue a task whose chain lane was busy, after a bounded delay.
+   *
+   * Detached on purpose: the receiver slot and the per-scope semantic lock are
+   * already released by the time this runs, so waiting here costs no capacity.
+   * The counter bounds it so a permanently wedged lane degrades into a normal
+   * failure instead of looping forever.
+   */
+  #scheduleAdmissionRetry(task: ReceiverTaskV1): void {
+    task.admissionDeferrals = (task.admissionDeferrals ?? 0) + 1;
+    this.#admissionDeferred += 1;
+    if (task.admissionDeferrals > this.#maxAdmissionDeferrals) {
+      this.#failed += 1;
+      this.#pendingByKey.delete(task.key);
+      this.#safeNotify(() => this.#onError?.(
+        task.providers[0]!.announcement,
+        new Error('RFC-64 receiver gave up waiting for the finalized chain-read lane'),
+      ));
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.#deferralTimers.delete(timer);
+      if (this.#closed || this.#closing.signal.aborted) {
+        this.#pendingByKey.delete(task.key);
+        if (this.#isIdle()) this.#resolveIdle();
+        return;
+      }
+      this.#queue.push(task);
+      this.#pump();
+    }, this.#admissionDeferralMs);
+    // Never hold the process open for a retry.
+    (timer as { unref?: () => void }).unref?.();
+    this.#deferralTimers.add(timer);
+  }
+
+  async #runTask(task: ReceiverTaskV1): Promise<'done' | 'defer-admission'> {
     let lastError: unknown;
     const notFoundProviders = new Set<string>();
     const attemptsByProvider = new Map<string, number>();
     let providerCursor = 0;
     while (true) {
-      if (this.#closing.signal.aborted) return;
+      if (this.#closing.signal.aborted) return 'done';
       const selection = nextEligibleProvider(
         task.providers,
         notFoundProviders,
@@ -262,11 +367,11 @@ export class Rfc64PublicCatalogReceiverV1 {
           && task.providers.every((provider) => notFoundProviders.has(provider.key))
         ) {
           this.#notFound += 1;
-          return;
+          return 'done';
         }
         this.#failed += 1;
         this.#safeNotify(() => this.#onError?.(task.providers[0]!.announcement, lastError));
-        return;
+        return 'done';
       }
       const { provider, nextCursor } = selection;
       providerCursor = nextCursor;
@@ -275,7 +380,7 @@ export class Rfc64PublicCatalogReceiverV1 {
       try {
         if (await this.#reconciler.isHeadApplied(provider.announcement)) {
           this.#dedupedAlreadyApplied += 1;
-          return;
+          return 'done';
         }
         const result = await this.#reconciler.reconcileHead(
           provider.peerId,
@@ -288,14 +393,20 @@ export class Rfc64PublicCatalogReceiverV1 {
         }
         if (result === 'staged-only') {
           this.#stagedOnly += 1;
-          return;
+          return 'done';
         }
         this.#applied += 1;
         this.#safeNotify(() => this.#onHeadApplied?.(provider.announcement, provider.peerId));
-        return;
+        return 'done';
       } catch (error) {
+        if (isChainAdmissionContention(error)) {
+          // Not this head's fault and not this provider's fault: give the
+          // attempt back and let the task wait for the lane outside the slot.
+          attemptsByProvider.set(provider.key, providerAttempt - 1);
+          return 'defer-admission';
+        }
         lastError = error;
-        if (this.#closing.signal.aborted) return;
+        if (this.#closing.signal.aborted) return 'done';
         await this.#backoff(providerAttempt - 1);
       }
     }

--- a/packages/agent/src/rfc64/public-catalog-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-receiver-v1.ts
@@ -17,6 +17,8 @@
  * retriggered by a later announcement or reconcile cadence.
  */
 
+import { isFinalizedChainAdmissionContention } from '@origintrail-official/dkg-chain';
+
 import type { Rfc64PublicCatalogHeadAnnouncementV1 } from './public-catalog-transport-v1.js';
 
 export type Rfc64PublicCatalogReconcileResultV1 = 'applied' | 'not-found' | 'staged-only';
@@ -58,6 +60,12 @@ export interface Rfc64PublicCatalogReceiverOptionsV1 {
    * ordinary failure instead of looping. Default 240 (~2 minutes at 500ms).
    */
   readonly maxAdmissionDeferrals?: number;
+  /**
+   * Which failures mean "retry later, nothing is wrong with this head".
+   * Defaults to the chain layer's own contention predicate; injectable so the
+   * receiver does not hardcode another layer's error shapes.
+   */
+  readonly isDeferrableError?: (error: unknown) => boolean;
   readonly onHeadApplied?: (
     announcement: Rfc64PublicCatalogHeadAnnouncementV1,
     remotePeerId: string,
@@ -83,6 +91,8 @@ export interface Rfc64PublicCatalogReceiverStatsV1 {
    * `failed`: the head is still pending, not lost.
    */
   readonly admissionDeferred: number;
+  /** Accepted heads currently waiting on the chain lane: neither queued nor active. */
+  readonly deferred: number;
   readonly inFlight: number;
   readonly queued: number;
 }
@@ -117,27 +127,20 @@ const DEFAULTS = Object.freeze({
 });
 
 /**
- * Is this failure "the chain lane is busy" rather than "this head is bad"?
+ * Default deferral policy: "the chain lane is busy" rather than "this head is bad".
  *
  * The pinned finalized read is one-per-chain PROCESS-WIDE, so an unrelated
  * context graph on the same chain can legitimately hold it for up to the
  * snapshot deadline. That is contention, not an error about this head — but the
- * generic retry path treats it like a provider failure: three attempts and
+ * generic retry path treated it like a provider failure: three attempts and
  * exponential backoff finish in under two seconds, the task is marked failed,
- * and its pending key is deleted. The head is then only retried if some later
- * announcement or explicit pull happens to arrive.
+ * and its pending key is deleted.
  *
- * Matching is on the chain layer's own typed code, not on message text.
+ * The predicate itself is OWNED BY THE CHAIN PACKAGE, whose code
+ * `concurrency-saturated` is, and is injectable here — the receiver should not
+ * be crawling the shape of errors from a layer it does not own.
  */
-function isChainAdmissionContention(error: unknown): boolean {
-  for (let cause: unknown = error, depth = 0; cause !== undefined && cause !== null && depth < 8; depth += 1) {
-    if (typeof cause === 'object' && (cause as { code?: unknown }).code === 'concurrency-saturated') {
-      return true;
-    }
-    cause = (cause as { cause?: unknown }).cause;
-  }
-  return false;
-}
+const DEFAULT_DEFERRABLE_ERROR = isFinalizedChainAdmissionContention;
 
 export class Rfc64PublicCatalogReceiverV1 {
   readonly #reconciler: Rfc64PublicCatalogReceiverReconcilerV1;
@@ -161,7 +164,18 @@ export class Rfc64PublicCatalogReceiverV1 {
 
   readonly #admissionDeferralMs: number;
   readonly #maxAdmissionDeferrals: number;
+  readonly #isDeferrableError: (error: unknown) => boolean;
   readonly #deferralTimers = new Set<ReturnType<typeof setTimeout>>();
+  /**
+   * The third scheduler state, made explicit: accepted work that is neither
+   * queued nor active because it is waiting for the chain lane.
+   *
+   * It MUST be observable by `#isIdle()`. Without it a deferred head sits in
+   * `#pendingByKey` and a timer only, so `whenIdle()` resolved during the retry
+   * window and a caller draining the receiver — `synchronizeCurrentCatalogHead()`
+   * — could conclude scheduling had settled before the head was applied.
+   */
+  readonly #deferred = new Set<ReceiverTaskV1>();
 
   #scheduled = 0;
   #admissionDeferred = 0;
@@ -195,6 +209,7 @@ export class Rfc64PublicCatalogReceiverV1 {
       options.maxAdmissionDeferrals,
       DEFAULTS.maxAdmissionDeferrals,
     );
+    this.#isDeferrableError = options.isDeferrableError ?? DEFAULT_DEFERRABLE_ERROR;
     this.#onHeadApplied = options.onHeadApplied;
     this.#onError = options.onError;
   }
@@ -260,6 +275,8 @@ export class Rfc64PublicCatalogReceiverV1 {
     this.#closed = true;
     for (const timer of this.#deferralTimers) clearTimeout(timer);
     this.#deferralTimers.clear();
+    for (const task of this.#deferred) this.#pendingByKey.delete(task.key);
+    this.#deferred.clear();
     const abandoned = this.#queue.splice(0);
     for (const task of abandoned) this.#pendingByKey.delete(task.key);
     this.#closing.abort(new Error('RFC-64 public catalog receiver closing'));
@@ -279,6 +296,7 @@ export class Rfc64PublicCatalogReceiverV1 {
       droppedQueueFull: this.#droppedQueueFull,
       droppedProviders: this.#droppedProviders,
       admissionDeferred: this.#admissionDeferred,
+      deferred: this.#deferred.size,
       inFlight: this.#active.size,
       queued: this.#queue.length,
     });
@@ -325,15 +343,21 @@ export class Rfc64PublicCatalogReceiverV1 {
     this.#admissionDeferred += 1;
     if (task.admissionDeferrals > this.#maxAdmissionDeferrals) {
       this.#failed += 1;
+      this.#deferred.delete(task);
       this.#pendingByKey.delete(task.key);
       this.#safeNotify(() => this.#onError?.(
         task.providers[0]!.announcement,
         new Error('RFC-64 receiver gave up waiting for the finalized chain-read lane'),
       ));
+      if (this.#isIdle()) this.#resolveIdle();
       return;
     }
+    // Registered BEFORE the timer is armed: between these two statements the
+    // task must never be invisible to the idle predicate.
+    this.#deferred.add(task);
     const timer = setTimeout(() => {
       this.#deferralTimers.delete(timer);
+      this.#deferred.delete(task);
       if (this.#closed || this.#closing.signal.aborted) {
         this.#pendingByKey.delete(task.key);
         if (this.#isIdle()) this.#resolveIdle();
@@ -399,7 +423,7 @@ export class Rfc64PublicCatalogReceiverV1 {
         this.#safeNotify(() => this.#onHeadApplied?.(provider.announcement, provider.peerId));
         return 'done';
       } catch (error) {
-        if (isChainAdmissionContention(error)) {
+        if (this.#isDeferrableError(error)) {
           // Not this head's fault and not this provider's fault: give the
           // attempt back and let the task wait for the lane outside the slot.
           attemptsByProvider.set(provider.key, providerAttempt - 1);
@@ -439,7 +463,7 @@ export class Rfc64PublicCatalogReceiverV1 {
   }
 
   #isIdle(): boolean {
-    return this.#active.size === 0 && this.#queue.length === 0;
+    return this.#active.size === 0 && this.#queue.length === 0 && this.#deferred.size === 0;
   }
 
   #resolveIdle(): void {

--- a/packages/agent/test/rfc64-precommit-owner-attribution.test.ts
+++ b/packages/agent/test/rfc64-precommit-owner-attribution.test.ts
@@ -1,0 +1,200 @@
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import {
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+  type ContextGraphPolicyV1,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  acquireFinalizedChainRead,
+  finalizedChainReadRegistryDepth,
+  type FinalizedChainReadOwnerV1,
+} from '@origintrail-official/dkg-chain';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AcceptedRfc64CatalogAccessSnapshotV1 } from '../src/rfc64/catalog-access-policy-v1.js';
+import { createRfc64FinalizedVmAgentPrecommitV1 } from '../src/rfc64/finalized-vm-agent-precommit-v1.js';
+import type { Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 } from '../src/rfc64/public-catalog-native-receiver-v1.js';
+import {
+  RFC64_VM_AUTHOR,
+  RFC64_VM_BLOCK_HASH,
+  RFC64_VM_CG_STORAGE,
+  RFC64_VM_CHAIN_ID,
+  RFC64_VM_CONTEXT_GRAPH_NAME,
+  RFC64_VM_KAV10,
+  RFC64_VM_KA_STORAGE,
+  RFC64_VM_NETWORK_ID,
+  RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+  RFC64_VM_POLICY_DIGEST,
+} from './support/rfc64-finalized-vm-placement-fixture.js';
+
+/**
+ * The production RFC64 precommit passes `owner: 'rfc64'` into the shared
+ * finalized-read factory. Until now nothing observed that line: the merge-
+ * readiness review showed the label could be changed to `foreground` and the
+ * focused precommit and runtime suites stayed 10/10 green, because they fail
+ * before the real factory or inject mocks.
+ *
+ * This drives the REAL `createRfc64FinalizedVmAgentPrecommitV1` against an RPC
+ * endpoint that accepts the connection and never answers, so the precommit
+ * genuinely takes and holds the process-wide permit. While it is held, another
+ * owner probes the registry and is told who the holder is — which is both proof
+ * that the production path uses the shared registry at all, and the only test
+ * that fails if the label changes.
+ */
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+});
+
+/** Accepts, then never responds. The permit stays held until we abort. */
+async function hangingRpcEndpoint(): Promise<string> {
+  const server = createServer(() => {
+    /* deliberately no response */
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+function acceptedPolicy(): AcceptedRfc64CatalogAccessSnapshotV1 {
+  // Same canonical shape the existing precommit suite uses; a thinner fake is
+  // rejected by `snapshotFinalizedVmRuntimeRequest` before the chain is touched.
+  const policy = Object.freeze({
+    networkId: RFC64_VM_NETWORK_ID,
+    contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
+    governanceChainId: RFC64_VM_CHAIN_ID,
+    governanceContractAddress: RFC64_VM_CG_STORAGE,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy: 0,
+    publishPolicy: 1,
+    publishAuthority: null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'finalized-chain',
+      chainId: RFC64_VM_CHAIN_ID,
+      contractAddress: RFC64_VM_CG_STORAGE,
+      blockNumber: '123',
+      blockHash: RFC64_VM_BLOCK_HASH,
+    },
+    effectiveAt: '1700000000000',
+    issuedAt: '1700000000000',
+  } satisfies ContextGraphPolicyV1);
+  return Object.freeze({
+    policy,
+    policyDigest: RFC64_VM_POLICY_DIGEST,
+    // Explicitly null, not omitted: the runtime rejects a non-null roster, and
+    // `undefined !== null` fails that guard.
+    roster: null,
+  }) as unknown as AcceptedRfc64CatalogAccessSnapshotV1;
+}
+
+function plan(): Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 {
+  return Object.freeze({
+    catalogScope: Object.freeze({
+      networkId: RFC64_VM_NETWORK_ID,
+      contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
+      governanceChainId: RFC64_VM_CHAIN_ID,
+      governanceContractAddress: RFC64_VM_CG_STORAGE,
+      ownershipTransitionDigest: null,
+      subGraphName: null,
+      authorAddress: RFC64_VM_AUTHOR,
+      era: '0',
+      bucketCount: '1',
+    }),
+    catalogHeadDigest: `0x${'91'.repeat(32)}`,
+    inventoryDigest: `0x${'92'.repeat(32)}`,
+    rows: Object.freeze([]),
+  }) as unknown as Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1;
+}
+
+async function options(endpoint: string) {
+  return {
+    acceptedPolicySnapshotForCatalogScope: () => acceptedPolicy(),
+    rpcEndpoints: [endpoint],
+    getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+    getEvmChainId: async () => BigInt(RFC64_VM_CHAIN_ID),
+    getKnowledgeAssetStorageAddress: async () => RFC64_VM_KA_STORAGE,
+    getKnowledgeAssetsLifecycleAddress: async () => RFC64_VM_KAV10,
+    store: new OxigraphStore(),
+  } as const;
+}
+
+async function waitForPermit(timeoutMs = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (finalizedChainReadRegistryDepth(RFC64_VM_CHAIN_ID) === 1) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error('production precommit never took the shared finalized-read permit');
+}
+
+describe('RFC-64 production precommit owner attribution', () => {
+  it('takes the SHARED permit and holds it as `rfc64`', async () => {
+    const endpoint = await hangingRpcEndpoint();
+    const handler = createRfc64FinalizedVmAgentPrecommitV1(await options(endpoint));
+    const abort = new AbortController();
+
+    // Not awaited: the precommit parks inside the pinned read while we observe.
+    const running = handler(plan(), abort.signal).catch(() => undefined);
+    await waitForPermit();
+
+    let holder: FinalizedChainReadOwnerV1 | undefined;
+    await expect(
+      acquireFinalizedChainRead(
+        { chainId: RFC64_VM_CHAIN_ID, owner: 'w2-page' },
+        async () => 'must-not-run',
+        (active, seen) => {
+          holder = seen;
+          return new Error(`saturated:${active}:${seen}`);
+        },
+      ),
+    ).rejects.toThrow('saturated:1:rfc64');
+
+    // THE assertion the review asked for: the production line, observed.
+    expect(holder).toBe('rfc64');
+
+    abort.abort();
+    await running;
+  }, 40_000);
+
+  it('releases the shared permit when the precommit is aborted', async () => {
+    // A production path that leaked the permit would wedge every other caller
+    // on that chain for the life of the process.
+    const endpoint = await hangingRpcEndpoint();
+    const handler = createRfc64FinalizedVmAgentPrecommitV1(await options(endpoint));
+    const abort = new AbortController();
+
+    const running = handler(plan(), abort.signal).catch(() => undefined);
+    await waitForPermit();
+    abort.abort();
+    await running;
+
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline && finalizedChainReadRegistryDepth(RFC64_VM_CHAIN_ID) !== 0) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(finalizedChainReadRegistryDepth(RFC64_VM_CHAIN_ID)).toBe(0);
+
+    // …and the lane is genuinely reusable afterwards.
+    await expect(
+      acquireFinalizedChainRead(
+        { chainId: RFC64_VM_CHAIN_ID, owner: 'w2-page' },
+        async () => 'reusable',
+        (active) => new Error(`saturated:${active}`),
+      ),
+    ).resolves.toBe('reusable');
+  }, 40_000);
+});

--- a/packages/agent/test/rfc64-receiver-admission-deferral.test.ts
+++ b/packages/agent/test/rfc64-receiver-admission-deferral.test.ts
@@ -3,7 +3,18 @@ import { describe, expect, it } from 'vitest';
 import { acquireFinalizedChainRead } from '@origintrail-official/dkg-chain';
 
 import { Rfc64PublicCatalogReceiverV1 } from '../src/rfc64/public-catalog-receiver-v1.js';
-import type { Rfc64PublicCatalogHeadAnnouncementV1 } from '../src/rfc64/public-catalog-transport-v1.js';
+import type {
+  ContextGraphIdV1,
+  DecimalU64V1,
+  Digest32V1,
+  EvmAddressV1,
+  NetworkIdV1,
+} from '@origintrail-official/dkg-core';
+
+import {
+  RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+  type Rfc64PublicCatalogHeadAnnouncementV1,
+} from '../src/rfc64/public-catalog-transport-v1.js';
 
 /**
  * Regression suite for the contention lifecycle the merge-readiness review
@@ -57,15 +68,42 @@ function isFakeContention(error: unknown): boolean {
   return false;
 }
 
-function announcement(headDigest: string): Rfc64PublicCatalogHeadAnnouncementV1 {
+/**
+ * A TYPE-CORRECT announcement.
+ *
+ * An earlier version of this fixture was cast with `as unknown as` and set
+ * `headDigest`/`authorDid` — fields that do not exist on the wire type. Since
+ * `headKey()` is built from `catalogHeadObjectDigest`, `signatureVariantDigest`,
+ * `authorAddress`, `catalogEra` and `catalogVersion`, EVERY announcement
+ * collapsed to one identical key of `undefined`s. The dedupe test therefore
+ * passed no matter what the pending-key lifecycle did — two "different" heads
+ * were the same head.
+ */
+const NETWORK_ID = 'test-network' as NetworkIdV1;
+const CONTEXT_GRAPH_ID =
+  '0x1111111111111111111111111111111111111111/catalog' as ContextGraphIdV1;
+const AUTHOR = `0x${'22'.repeat(20)}` as EvmAddressV1;
+const POLICY_DIGEST = `0x${'33'.repeat(32)}` as Digest32V1;
+const SIGNATURE_VARIANT = `0x${'44'.repeat(32)}` as Digest32V1;
+
+function announcement(
+  headByte: string,
+  overrides: Partial<Rfc64PublicCatalogHeadAnnouncementV1> = {},
+): Rfc64PublicCatalogHeadAnnouncementV1 {
   return {
-    networkId: 'test-network',
-    contextGraphId: '0x1111111111111111111111111111111111111111/catalog',
-    subGraphName: 'catalog',
-    authorDid: 'did:dkg:agent:0x2222222222222222222222222222222222222222',
-    headDigest,
-    headSequence: '1',
-  } as unknown as Rfc64PublicCatalogHeadAnnouncementV1;
+    kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+    networkId: NETWORK_ID,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    subGraphName: null,
+    authorAddress: AUTHOR,
+    catalogEra: '0' as DecimalU64V1,
+    catalogVersion: '1' as DecimalU64V1,
+    policyDigest: POLICY_DIGEST,
+    // THE field `headKey()` actually varies on.
+    catalogHeadObjectDigest: `0x${headByte.repeat(32)}` as Digest32V1,
+    signatureVariantDigest: SIGNATURE_VARIANT,
+    ...overrides,
+  };
 }
 
 /** A reconciler that reports lane contention `saturateTimes` times, then applies. */
@@ -109,7 +147,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       retryBackoffMs: 1,
     });
 
-    receiver.schedule(announcement('0xaa'), 'peer-a');
+    receiver.schedule(announcement('aa'), 'peer-a');
     await settle(receiver, 300);
 
     const stats = receiver.stats();
@@ -133,7 +171,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       admissionDeferralMs: 40,
       maxConcurrent: 1,
     });
-    receiver.schedule(announcement('0xbb'), 'peer-a');
+    receiver.schedule(announcement('bb'), 'peer-a');
 
     await new Promise((resolve) => setTimeout(resolve, 20));
     const midFlight = receiver.stats();
@@ -153,7 +191,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       admissionDeferralMs: 1,
       maxAdmissionDeferrals: 3,
     });
-    receiver.schedule(announcement('0xcc'), 'peer-a');
+    receiver.schedule(announcement('cc'), 'peer-a');
     await settle(receiver, 400);
 
     const stats = receiver.stats();
@@ -175,7 +213,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       } as never,
       { isDeferrableError: isFakeContention, admissionDeferralMs: 5, retryBackoffMs: 1 },
     );
-    receiver.schedule(announcement('0xdd'), 'peer-a');
+    receiver.schedule(announcement('dd'), 'peer-a');
     await settle(receiver, 300);
 
     const stats = receiver.stats();
@@ -195,7 +233,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       isDeferrableError: isFakeContention,
       admissionDeferralMs: 300,
     });
-    receiver.schedule(announcement('0xf1'), 'peer-a');
+    receiver.schedule(announcement('f1'), 'peer-a');
 
     // Wait until the task is genuinely in the deferred state.
     const deadline = Date.now() + 5_000;
@@ -222,6 +260,100 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
     await receiver.close();
   });
 
+  it('distinct heads really do produce distinct keys (guards the fixture itself)', () => {
+    // The dedupe tests are only meaningful if two "different" announcements are
+    // actually different to the scheduler. An earlier casted fixture varied a
+    // field `headKey()` does not read, so every announcement collapsed to one
+    // key and dedupe passed vacuously. This asserts the premise directly.
+    const a = announcement('f2');
+    const b = announcement('f3');
+    expect(a.catalogHeadObjectDigest).not.toBe(b.catalogHeadObjectDigest);
+    for (const field of [
+      'networkId', 'contextGraphId', 'authorAddress', 'catalogEra',
+      'catalogVersion', 'catalogHeadObjectDigest', 'signatureVariantDigest',
+    ] as const) {
+      expect(a[field]).toBeDefined();
+    }
+    // Same scope, different head: the scope key matches, the head key does not.
+    expect(a.contextGraphId).toBe(b.contextGraphId);
+  });
+
+  it('releases the SCOPE lock while deferred, so another head in the same scope runs', async () => {
+    // The scope lock serializes semantic writers per catalog scope. A deferral
+    // must release it as well as the concurrency slot, or one busy chain lane
+    // stalls every other head for that context graph.
+    const seen: string[] = [];
+    let first = true;
+    const receiver = new Rfc64PublicCatalogReceiverV1(
+      {
+        isHeadApplied: async () => false,
+        reconcileHead: async (_peer: string, ann: Rfc64PublicCatalogHeadAnnouncementV1) => {
+          seen.push(ann.catalogHeadObjectDigest);
+          if (first) {
+            first = false;
+            throw saturationError();
+          }
+          return 'applied' as const;
+        },
+      } as never,
+      { isDeferrableError: isFakeContention, admissionDeferralMs: 400 },
+    );
+
+    receiver.schedule(announcement('f4'), 'peer-a');
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline && receiver.stats().deferred === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    // Same scope, DIFFERENT head, scheduled during the deferral window.
+    receiver.schedule(announcement('f5'), 'peer-b');
+    // It must not be deduped — different head key — and must run before the
+    // first head's 400ms retry.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(seen.some((digest) => digest.includes('f5'))).toBe(true);
+    expect(receiver.stats().dedupedInFlight).toBe(0);
+
+    await settle(receiver, 800);
+    expect(receiver.stats().applied).toBe(2);
+    await receiver.close();
+  });
+
+  it('keeps `maxAttempts` a true per-provider bound across a deferral', async () => {
+    // Provider bookkeeping used to be local to `#runTask`, so requeuing after a
+    // deferral restarted it at zero: a provider could fail twice, hit a busy
+    // lane, and then receive a fresh full attempt budget.
+    let ordinaryFailures = 0;
+    let contentionUsed = false;
+    const receiver = new Rfc64PublicCatalogReceiverV1(
+      {
+        isHeadApplied: async () => false,
+        reconcileHead: async () => {
+          if (ordinaryFailures === 2 && !contentionUsed) {
+            contentionUsed = true;
+            throw saturationError();
+          }
+          ordinaryFailures += 1;
+          throw new Error('provider exploded');
+        },
+      } as never,
+      {
+        isDeferrableError: isFakeContention,
+        admissionDeferralMs: 5,
+        retryBackoffMs: 1,
+        maxAttempts: 3,
+      },
+    );
+    receiver.schedule(announcement('f6'), 'peer-a');
+    await settle(receiver, 600);
+
+    expect(receiver.stats().failed).toBe(1);
+    // Exactly the configured bound — contention gave one attempt back and took
+    // nothing else, so the total is still 3 rather than 2 + 3.
+    expect(ordinaryFailures).toBe(3);
+    expect(contentionUsed).toBe(true);
+    await receiver.close();
+  });
+
   it('keeps the pending key while deferred, so a duplicate does not fork a second writer', async () => {
     // The deferral moved `pendingByKey.delete` out of the `finally` path. If a
     // regression moved it back, the single-announcement tests above would still
@@ -232,7 +364,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       isDeferrableError: isFakeContention,
       admissionDeferralMs: 250,
     });
-    receiver.schedule(announcement('0xf2'), 'peer-a');
+    receiver.schedule(announcement('f2'), 'peer-a');
 
     const deadline = Date.now() + 5_000;
     while (Date.now() < deadline && receiver.stats().deferred === 0) {
@@ -241,7 +373,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
     expect(receiver.stats().inFlight).toBe(0);
 
     // Same head, different peer, while the retry timer is pending.
-    receiver.schedule(announcement('0xf2'), 'peer-b');
+    receiver.schedule(announcement('f2'), 'peer-b');
     expect(receiver.stats().dedupedInFlight).toBe(1);
 
     await settle(receiver, 600);
@@ -259,7 +391,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       isDeferrableError: isFakeContention,
       admissionDeferralMs: 10_000,
     });
-    receiver.schedule(announcement('0xee'), 'peer-a');
+    receiver.schedule(announcement('ee'), 'peer-a');
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(receiver.stats().admissionDeferred).toBeGreaterThanOrEqual(1);
     // Must resolve promptly; a retained 10s timer would hang this.
@@ -311,7 +443,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       } as never,
       { admissionDeferralMs: 10 }, // no injected policy — the default is under test
     );
-    receiver.schedule(announcement('0xf9'), 'peer-a');
+    receiver.schedule(announcement('f9'), 'peer-a');
     await settle(receiver, 400);
     expect(receiver.stats().applied).toBe(1);
     expect(receiver.stats().admissionDeferred).toBe(1);
@@ -328,7 +460,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
       } as never,
       { admissionDeferralMs: 10, retryBackoffMs: 1 },
     );
-    lookAlike.schedule(announcement('0xfa'), 'peer-a');
+    lookAlike.schedule(announcement('fa'), 'peer-a');
     await settle(lookAlike, 300);
     expect(lookAlike.stats().failed).toBe(1);
     expect(lookAlike.stats().admissionDeferred).toBe(0);

--- a/packages/agent/test/rfc64-receiver-admission-deferral.test.ts
+++ b/packages/agent/test/rfc64-receiver-admission-deferral.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { acquireFinalizedChainRead } from '@origintrail-official/dkg-chain';
+
 import { Rfc64PublicCatalogReceiverV1 } from '../src/rfc64/public-catalog-receiver-v1.js';
 import type { Rfc64PublicCatalogHeadAnnouncementV1 } from '../src/rfc64/public-catalog-transport-v1.js';
 
@@ -20,15 +22,39 @@ import type { Rfc64PublicCatalogHeadAnnouncementV1 } from '../src/rfc64/public-c
  * consume an attempt, must not hold the receiver slot or the per-scope semantic
  * lock while waiting, and must leave the task pending.
  */
-const CHAIN_SATURATED = 'concurrency-saturated';
+/**
+ * A stand-in refusal for the receiver's own unit tests.
+ *
+ * Deliberately NOT a hand-forged `concurrency-saturated` object: the chain
+ * layer classifies contention by IDENTITY (a `WeakSet` of refusals it actually
+ * threw), precisely so a look-alike error cannot be mistaken for lane
+ * contention. These tests therefore inject the deferral policy — which is the
+ * receiver's real contract, "defer when the policy says so" — and one test
+ * below exercises the DEFAULT chain classifier end to end so the default wiring
+ * is not left unproven.
+ */
+const FAKE_CONTENTION = Symbol('fake-contention');
 
 function saturationError(): Error {
-  // Shaped like the chain layer's typed refusal, including nesting: the
-  // classifier must walk `cause`, not match on message text.
   const inner = Object.assign(new Error('Chain 20430 already has 1 finalized snapshot in flight'), {
-    code: CHAIN_SATURATED,
+    [FAKE_CONTENTION]: true,
   });
+  // Nested: the receiver's policy must be asked about the whole chain, since a
+  // real refusal reaches it wrapped by the precommit.
   return Object.assign(new Error('RFC-64 finalized VM precommit rejected'), { cause: inner });
+}
+
+/** Mirrors how the default policy walks `cause`, over the test's own marker. */
+function isFakeContention(error: unknown): boolean {
+  for (let cause: unknown = error, depth = 0;
+    cause !== undefined && cause !== null && depth < 8;
+    depth += 1) {
+    if (typeof cause === 'object' && (cause as Record<symbol, unknown>)[FAKE_CONTENTION] === true) {
+      return true;
+    }
+    cause = (cause as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 function announcement(headDigest: string): Rfc64PublicCatalogHeadAnnouncementV1 {
@@ -61,6 +87,14 @@ function contendingReconciler(saturateTimes: number) {
   };
 }
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}
+
 async function settle(receiver: Rfc64PublicCatalogReceiverV1, ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
   await receiver.whenIdle?.();
@@ -70,6 +104,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
   it('does not fail the head, and applies it after the lane frees', async () => {
     const { reconciler, calls } = contendingReconciler(2);
     const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      isDeferrableError: isFakeContention,
       admissionDeferralMs: 10,
       retryBackoffMs: 1,
     });
@@ -94,6 +129,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
     // converting one busy chain lane into a stalled receiver.
     const { reconciler } = contendingReconciler(3);
     const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      isDeferrableError: isFakeContention,
       admissionDeferralMs: 40,
       maxConcurrent: 1,
     });
@@ -113,6 +149,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
     // A permanently busy lane must degrade into an ordinary failure, not spin.
     const { reconciler } = contendingReconciler(Number.MAX_SAFE_INTEGER);
     const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      isDeferrableError: isFakeContention,
       admissionDeferralMs: 1,
       maxAdmissionDeferrals: 3,
     });
@@ -136,7 +173,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
           throw new Error('provider exploded');
         },
       } as never,
-      { admissionDeferralMs: 5, retryBackoffMs: 1 },
+      { isDeferrableError: isFakeContention, admissionDeferralMs: 5, retryBackoffMs: 1 },
     );
     receiver.schedule(announcement('0xdd'), 'peer-a');
     await settle(receiver, 300);
@@ -155,6 +192,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
     // had settled before the head was applied, staged, not-found or failed.
     const { reconciler } = contendingReconciler(1);
     const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      isDeferrableError: isFakeContention,
       admissionDeferralMs: 300,
     });
     receiver.schedule(announcement('0xf1'), 'peer-a');
@@ -191,6 +229,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
     // the existing task and create a second semantic writer for one head.
     const { reconciler, calls } = contendingReconciler(1);
     const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      isDeferrableError: isFakeContention,
       admissionDeferralMs: 250,
     });
     receiver.schedule(announcement('0xf2'), 'peer-a');
@@ -217,6 +256,7 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
   it('drops pending deferrals on close without leaking a timer', async () => {
     const { reconciler } = contendingReconciler(Number.MAX_SAFE_INTEGER);
     const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      isDeferrableError: isFakeContention,
       admissionDeferralMs: 10_000,
     });
     receiver.schedule(announcement('0xee'), 'peer-a');
@@ -225,5 +265,73 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
     // Must resolve promptly; a retained 10s timer would hang this.
     await receiver.close();
     expect(receiver.stats().queued).toBe(0);
+  });
+  it('DEFAULT policy defers a REAL chain refusal, and only a real one', async () => {
+    // Proves the default wiring, which the injected-policy tests above cannot:
+    // the receiver with no `isDeferrableError` must defer on a refusal that
+    // genuinely came out of `acquireFinalizedChainRead`, and must NOT defer on
+    // a look-alike carrying the same `concurrency-saturated` code.
+    // No registry reset needed: this test acquires and releases the lane within
+    // itself, and `…ForTests` is deliberately not part of the package's public
+    // surface.
+    const gate = deferred<void>();
+    const held = acquireFinalizedChainRead(
+      { chainId: '20430', owner: 'rfc64' },
+      () => gate.promise,
+      (active, holder) => Object.assign(
+        new Error(`Chain 20430 already has ${active} in flight (held by ${holder})`),
+        { code: 'concurrency-saturated' },
+      ),
+    );
+    await Promise.resolve();
+
+    // Capture a genuine refusal, wrapped the way the precommit wraps it.
+    let realRefusal: unknown;
+    try {
+      await acquireFinalizedChainRead(
+        { chainId: '20430', owner: 'w2-page' },
+        async () => 'x',
+        (active) => Object.assign(new Error(`busy:${active}`), { code: 'concurrency-saturated' }),
+      );
+    } catch (error) {
+      realRefusal = Object.assign(new Error('precommit rejected'), { cause: error });
+    }
+    gate.resolve();
+    await held;
+
+    let thrown = 0;
+    const receiver = new Rfc64PublicCatalogReceiverV1(
+      {
+        isHeadApplied: async () => false,
+        reconcileHead: async () => {
+          thrown += 1;
+          if (thrown === 1) throw realRefusal;
+          return 'applied' as const;
+        },
+      } as never,
+      { admissionDeferralMs: 10 }, // no injected policy — the default is under test
+    );
+    receiver.schedule(announcement('0xf9'), 'peer-a');
+    await settle(receiver, 400);
+    expect(receiver.stats().applied).toBe(1);
+    expect(receiver.stats().admissionDeferred).toBe(1);
+    expect(receiver.stats().failed).toBe(0);
+    await receiver.close();
+
+    // The look-alike must fail fast under the same default policy.
+    const lookAlike = new Rfc64PublicCatalogReceiverV1(
+      {
+        isHeadApplied: async () => false,
+        reconcileHead: async () => {
+          throw Object.assign(new Error('nice try'), { code: 'concurrency-saturated' });
+        },
+      } as never,
+      { admissionDeferralMs: 10, retryBackoffMs: 1 },
+    );
+    lookAlike.schedule(announcement('0xfa'), 'peer-a');
+    await settle(lookAlike, 300);
+    expect(lookAlike.stats().failed).toBe(1);
+    expect(lookAlike.stats().admissionDeferred).toBe(0);
+    await lookAlike.close();
   });
 });

--- a/packages/agent/test/rfc64-receiver-admission-deferral.test.ts
+++ b/packages/agent/test/rfc64-receiver-admission-deferral.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import { Rfc64PublicCatalogReceiverV1 } from '../src/rfc64/public-catalog-receiver-v1.js';
+import type { Rfc64PublicCatalogHeadAnnouncementV1 } from '../src/rfc64/public-catalog-transport-v1.js';
+
+/**
+ * Regression suite for the contention lifecycle the merge-readiness review
+ * flagged (P1-3).
+ *
+ * Routing RFC64 through the process-wide one-per-chain finalized-read permit is
+ * the right strain bound, but the permit is nonqueueing: a legitimate pinned
+ * scan for one context graph can hold it for up to the snapshot deadline (60s),
+ * while a second CG's receiver burned its three generic provider attempts and
+ * exponential backoff in about 1.75 seconds, marked the task FAILED, and deleted
+ * its pending key. The head was then only reconsidered if some later
+ * announcement or explicit pull happened to arrive — a valid finalized head lost
+ * to ordinary contention.
+ *
+ * Contention is not an error about the head or the provider, so it must not
+ * consume an attempt, must not hold the receiver slot or the per-scope semantic
+ * lock while waiting, and must leave the task pending.
+ */
+const CHAIN_SATURATED = 'concurrency-saturated';
+
+function saturationError(): Error {
+  // Shaped like the chain layer's typed refusal, including nesting: the
+  // classifier must walk `cause`, not match on message text.
+  const inner = Object.assign(new Error('Chain 20430 already has 1 finalized snapshot in flight'), {
+    code: CHAIN_SATURATED,
+  });
+  return Object.assign(new Error('RFC-64 finalized VM precommit rejected'), { cause: inner });
+}
+
+function announcement(headDigest: string): Rfc64PublicCatalogHeadAnnouncementV1 {
+  return {
+    networkId: 'test-network',
+    contextGraphId: '0x1111111111111111111111111111111111111111/catalog',
+    subGraphName: 'catalog',
+    authorDid: 'did:dkg:agent:0x2222222222222222222222222222222222222222',
+    headDigest,
+    headSequence: '1',
+  } as unknown as Rfc64PublicCatalogHeadAnnouncementV1;
+}
+
+/** A reconciler that reports lane contention `saturateTimes` times, then applies. */
+function contendingReconciler(saturateTimes: number) {
+  const calls = { reconcile: 0, isHeadApplied: 0 };
+  return {
+    calls,
+    reconciler: {
+      isHeadApplied: async () => {
+        calls.isHeadApplied += 1;
+        return false;
+      },
+      reconcileHead: async () => {
+        calls.reconcile += 1;
+        if (calls.reconcile <= saturateTimes) throw saturationError();
+        return 'applied' as const;
+      },
+    },
+  };
+}
+
+async function settle(receiver: Rfc64PublicCatalogReceiverV1, ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+  await receiver.whenIdle?.();
+}
+
+describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
+  it('does not fail the head, and applies it after the lane frees', async () => {
+    const { reconciler, calls } = contendingReconciler(2);
+    const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      admissionDeferralMs: 10,
+      retryBackoffMs: 1,
+    });
+
+    receiver.schedule(announcement('0xaa'), 'peer-a');
+    await settle(receiver, 300);
+
+    const stats = receiver.stats();
+    // The head is APPLIED, not failed — the whole point.
+    expect(stats.applied).toBe(1);
+    expect(stats.failed).toBe(0);
+    // …and it took real deferrals to get there, so the assertion is not vacuous.
+    expect(stats.admissionDeferred).toBeGreaterThanOrEqual(2);
+    // It was retried WITHOUT a second `schedule()` call.
+    expect(stats.scheduled).toBe(1);
+    expect(calls.reconcile).toBe(3);
+    await receiver.close();
+  });
+
+  it('releases the concurrency slot and scope lock while waiting', async () => {
+    // A deferral that kept the slot would block every other head on the node,
+    // converting one busy chain lane into a stalled receiver.
+    const { reconciler } = contendingReconciler(3);
+    const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      admissionDeferralMs: 40,
+      maxConcurrent: 1,
+    });
+    receiver.schedule(announcement('0xbb'), 'peer-a');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const midFlight = receiver.stats();
+    expect(midFlight.inFlight).toBe(0);
+    expect(midFlight.admissionDeferred).toBeGreaterThanOrEqual(1);
+
+    await settle(receiver, 400);
+    expect(receiver.stats().applied).toBe(1);
+    await receiver.close();
+  });
+
+  it('gives up in bounded time rather than looping on a wedged lane', async () => {
+    // A permanently busy lane must degrade into an ordinary failure, not spin.
+    const { reconciler } = contendingReconciler(Number.MAX_SAFE_INTEGER);
+    const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      admissionDeferralMs: 1,
+      maxAdmissionDeferrals: 3,
+    });
+    receiver.schedule(announcement('0xcc'), 'peer-a');
+    await settle(receiver, 400);
+
+    const stats = receiver.stats();
+    expect(stats.failed).toBe(1);
+    expect(stats.applied).toBe(0);
+    expect(stats.admissionDeferred).toBe(4); // 3 allowed + the one that gave up
+    await receiver.close();
+  });
+
+  it('still fails fast on an ordinary error, which must NOT be deferred', async () => {
+    // The classifier must be narrow. A generic failure keeps the pre-existing
+    // three-attempt behaviour; widening it would hide real breakage as patience.
+    const receiver = new Rfc64PublicCatalogReceiverV1(
+      {
+        isHeadApplied: async () => false,
+        reconcileHead: async () => {
+          throw new Error('provider exploded');
+        },
+      } as never,
+      { admissionDeferralMs: 5, retryBackoffMs: 1 },
+    );
+    receiver.schedule(announcement('0xdd'), 'peer-a');
+    await settle(receiver, 300);
+
+    const stats = receiver.stats();
+    expect(stats.failed).toBe(1);
+    expect(stats.admissionDeferred).toBe(0);
+    await receiver.close();
+  });
+
+  it('drops pending deferrals on close without leaking a timer', async () => {
+    const { reconciler } = contendingReconciler(Number.MAX_SAFE_INTEGER);
+    const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      admissionDeferralMs: 10_000,
+    });
+    receiver.schedule(announcement('0xee'), 'peer-a');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(receiver.stats().admissionDeferred).toBeGreaterThanOrEqual(1);
+    // Must resolve promptly; a retained 10s timer would hang this.
+    await receiver.close();
+    expect(receiver.stats().queued).toBe(0);
+  });
+});

--- a/packages/agent/test/rfc64-receiver-admission-deferral.test.ts
+++ b/packages/agent/test/rfc64-receiver-admission-deferral.test.ts
@@ -147,6 +147,73 @@ describe('RFC-64 receiver defers on finalized chain-lane contention', () => {
     await receiver.close();
   });
 
+  it('does NOT report idle while a head is waiting on the chain lane', async () => {
+    // The deferral releases the slot and the queue entry by design, so without
+    // an explicit deferred state `#isIdle()` saw `active=0, queue=0` and
+    // `whenIdle()` resolved during the retry window. A caller draining the
+    // receiver (`synchronizeCurrentCatalogHead`) would then conclude scheduling
+    // had settled before the head was applied, staged, not-found or failed.
+    const { reconciler } = contendingReconciler(1);
+    const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      admissionDeferralMs: 300,
+    });
+    receiver.schedule(announcement('0xf1'), 'peer-a');
+
+    // Wait until the task is genuinely in the deferred state.
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline && receiver.stats().deferred === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    const waiting = receiver.stats();
+    expect(waiting.deferred).toBe(1);
+    expect(waiting.inFlight).toBe(0);
+    expect(waiting.queued).toBe(0);
+
+    let idleResolved = false;
+    const idle = receiver.whenIdle().then(() => {
+      idleResolved = true;
+    });
+    // Long enough to catch an immediate resolve, short of the 300ms retry.
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(idleResolved).toBe(false);
+
+    await idle;
+    // Idle only after the deferred work reached a terminal outcome.
+    expect(receiver.stats().applied).toBe(1);
+    expect(receiver.stats().deferred).toBe(0);
+    await receiver.close();
+  });
+
+  it('keeps the pending key while deferred, so a duplicate does not fork a second writer', async () => {
+    // The deferral moved `pendingByKey.delete` out of the `finally` path. If a
+    // regression moved it back, the single-announcement tests above would still
+    // pass — but a re-announcement during the detached retry window would miss
+    // the existing task and create a second semantic writer for one head.
+    const { reconciler, calls } = contendingReconciler(1);
+    const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {
+      admissionDeferralMs: 250,
+    });
+    receiver.schedule(announcement('0xf2'), 'peer-a');
+
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline && receiver.stats().deferred === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(receiver.stats().inFlight).toBe(0);
+
+    // Same head, different peer, while the retry timer is pending.
+    receiver.schedule(announcement('0xf2'), 'peer-b');
+    expect(receiver.stats().dedupedInFlight).toBe(1);
+
+    await settle(receiver, 600);
+    const stats = receiver.stats();
+    expect(stats.applied).toBe(1);
+    expect(stats.failed).toBe(0);
+    // One writer, not two: the second announcement contributed a provider.
+    expect(calls.reconcile).toBe(2);
+    await receiver.close();
+  });
+
   it('drops pending deferrals on close without leaking a timer', async () => {
     const { reconciler } = contendingReconciler(Number.MAX_SAFE_INTEGER);
     const receiver = new Rfc64PublicCatalogReceiverV1(reconciler as never, {

--- a/packages/agent/test/w2-ual-parity.test.ts
+++ b/packages/agent/test/w2-ual-parity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_ROOTLESS_KA_NUMBER,
+  buildScopedKnowledgeAssetUal,
+  canonicalScopedKaCandidatesFromVerifiedUal,
+  deriveVmUpdateScopeId,
+  type VmUpdateScopeV1,
+} from '@origintrail-official/dkg-core';
+
+import { buildReconciledKnowledgeAssetUal } from '../src/ka-identity.js';
+
+/**
+ * W2's candidate parser lives in `packages/core` (it must be reachable from the
+ * node-UI store and the chain adapter, neither of which may depend on `agent`),
+ * so `buildScopedKnowledgeAssetUal` restates the legacy/rootless UAL rule that
+ * `buildReconciledKnowledgeAssetUal` already owns here in `agent`. Core cannot
+ * import it: `agent` depends on `core`, not the reverse.
+ *
+ * A restated rule with no external anchor is a rule that can drift silently, and
+ * this particular drift is not cosmetic — W2's mutation fence selects which KA a
+ * graph write belongs to by round-tripping candidates through this function. If
+ * the two spellings diverge at the `kaId >> 96` boundary, the fence either
+ * refuses every legal write or attributes one to the wrong KA.
+ *
+ * This file is that anchor. It is the ONLY place both implementations are
+ * visible at once, and it fails if either side changes alone.
+ */
+const KA_STORAGE = `0x${'a1'.repeat(20)}`;
+const CG_STORAGE = `0x${'b2'.repeat(20)}`;
+const AUTHOR = `0x${'c3'.repeat(20)}`;
+const CHAIN_ID = '84532';
+
+const IDENTITY = {
+  chainId: CHAIN_ID,
+  deploymentId: `${CHAIN_ID}:hub=0x00000000000000000000000000000000000000ff`,
+  knowledgeAssetStorageAddress: KA_STORAGE,
+  contextGraphStorageAddress: CG_STORAGE,
+};
+
+const SCOPE: VmUpdateScopeV1 = {
+  ...IDENTITY,
+  scopeId: deriveVmUpdateScopeId(IDENTITY),
+  deploymentBlock: 47_682_200,
+  deploymentBlockSource: 'shipped',
+  deploymentBlockHistoricallyValidated: true,
+};
+
+/**
+ * Ids chosen to straddle the classifier boundary in both directions, because
+ * that boundary is where a divergence would actually live: the largest legacy
+ * id, the smallest rootless id, and a packed id whose low bits are zero.
+ */
+const BOUNDARY_IDS: readonly bigint[] = [
+  1n,
+  7n,
+  MAX_ROOTLESS_KA_NUMBER, // largest id still classified legacy (`>> 96n === 0n`)
+  1n << 96n, // smallest rootless id: address 0x…01, number 0
+  (BigInt(AUTHOR) << 96n) | 0n, // rootless, zero KA number
+  (BigInt(AUTHOR) << 96n) | 1n,
+  (BigInt(AUTHOR) << 96n) | MAX_ROOTLESS_KA_NUMBER,
+  (BigInt(KA_STORAGE) << 96n) | 7n, // rootless packed AT the storage address
+];
+
+describe('W2 core UAL construction is byte-identical to the agent reconciled builder', () => {
+  it.each(BOUNDARY_IDS.map((kaId) => [kaId.toString()] as const))(
+    'agrees for kaId %s',
+    (kaIdText) => {
+      const kaId = BigInt(kaIdText);
+      expect(buildScopedKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, kaId)).toBe(
+        buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, kaId),
+      );
+    },
+  );
+
+  it('covers both sides of the classifier boundary, so agreement is not vacuous', () => {
+    // Without this, a builder that returned the legacy form unconditionally
+    // would still "agree" on a table that happened to hold only legacy ids.
+    const forms = BOUNDARY_IDS.map((kaId) =>
+      kaId >> 96n === 0n ? 'legacy' : 'rootless',
+    );
+    expect(new Set(forms)).toEqual(new Set(['legacy', 'rootless']));
+
+    // And prove the two forms really do produce different UALs for one id, so
+    // the comparison above has something to discriminate.
+    const rootless = (BigInt(AUTHOR) << 96n) | 7n;
+    expect(buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, rootless)).toBe(
+      `did:dkg:${CHAIN_ID}/${AUTHOR}/7`,
+    );
+    expect(buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, 7n)).toBe(
+      `did:dkg:${CHAIN_ID}/${KA_STORAGE}/7`,
+    );
+  });
+
+  it('round-trips every parsed candidate back through the agent builder', () => {
+    // The parser's own round-trip check uses the core builder. This closes the
+    // loop against the agent builder instead, so a candidate the parser accepts
+    // cannot denote a different KA in the rest of the codebase.
+    for (const ual of [
+      `did:dkg:${CHAIN_ID}/${KA_STORAGE}/7`,
+      `did:dkg:${CHAIN_ID}/${AUTHOR}/0`,
+      `did:dkg:${CHAIN_ID}/${AUTHOR}/${MAX_ROOTLESS_KA_NUMBER.toString()}`,
+    ]) {
+      const set = canonicalScopedKaCandidatesFromVerifiedUal(SCOPE, ual);
+      expect(set.candidates.length).toBeGreaterThan(0);
+      for (const candidate of set.candidates) {
+        expect(
+          buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, BigInt(candidate.kaId)),
+        ).toBe(ual);
+      }
+    }
+  });
+});

--- a/packages/agent/test/w2-ual-parity.test.ts
+++ b/packages/agent/test/w2-ual-parity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   MAX_ROOTLESS_KA_NUMBER,
+  buildKnowledgeAssetUalFromOnChainIdV1,
   buildScopedKnowledgeAssetUal,
   canonicalScopedKaCandidatesFromVerifiedUal,
   deriveVmUpdateScopeId,
@@ -11,20 +12,19 @@ import {
 import { buildReconciledKnowledgeAssetUal } from '../src/ka-identity.js';
 
 /**
- * W2's candidate parser lives in `packages/core` (it must be reachable from the
- * node-UI store and the chain adapter, neither of which may depend on `agent`),
- * so `buildScopedKnowledgeAssetUal` restates the legacy/rootless UAL rule that
- * `buildReconciledKnowledgeAssetUal` already owns here in `agent`. Core cannot
- * import it: `agent` depends on `core`, not the reverse.
+ * The legacy/rootless KA UAL rule has ONE owner: `ka-ual-identity.ts` in `core`.
  *
- * A restated rule with no external anchor is a rule that can drift silently, and
- * this particular drift is not cosmetic — W2's mutation fence selects which KA a
- * graph write belongs to by round-tripping candidates through this function. If
- * the two spellings diverge at the `kaId >> 96` boundary, the fence either
- * refuses every legal write or attributes one to the wrong KA.
+ * An earlier revision of this PR restated the rule inside
+ * `vm-update-convergence.ts` and used this file as a cross-package parity guard,
+ * on the reasoning that `core` could not import the agent builder. That was
+ * true but beside the point — the dependency direction is `agent → chain →
+ * core`, so `core` can own the rule and `agent` can delegate downward. A parity
+ * test detects drift only after it exists; deleting the duplicate removes the
+ * possibility.
  *
- * This file is that anchor. It is the ONLY place both implementations are
- * visible at once, and it fails if either side changes alone.
+ * So this file no longer compares two implementations. It proves the delegation
+ * is real — that the agent export and the W2 wrapper both resolve to the single
+ * owner — and keeps the boundary cases as direct coverage of that owner.
  */
 const KA_STORAGE = `0x${'a1'.repeat(20)}`;
 const CG_STORAGE = `0x${'b2'.repeat(20)}`;
@@ -47,9 +47,9 @@ const SCOPE: VmUpdateScopeV1 = {
 };
 
 /**
- * Ids chosen to straddle the classifier boundary in both directions, because
- * that boundary is where a divergence would actually live: the largest legacy
- * id, the smallest rootless id, and a packed id whose low bits are zero.
+ * Ids that straddle the classifier boundary in both directions — the largest
+ * legacy id, the smallest rootless id, and a packed id whose low bits are zero.
+ * That boundary is where a divergence would actually live.
  */
 const BOUNDARY_IDS: readonly bigint[] = [
   1n,
@@ -62,27 +62,58 @@ const BOUNDARY_IDS: readonly bigint[] = [
   (BigInt(KA_STORAGE) << 96n) | 7n, // rootless packed AT the storage address
 ];
 
-describe('W2 core UAL construction is byte-identical to the agent reconciled builder', () => {
+describe('the KA UAL rule has a single owner, and both entry points delegate to it', () => {
   it.each(BOUNDARY_IDS.map((kaId) => [kaId.toString()] as const))(
-    'agrees for kaId %s',
+    'agent and core agree with the owner for kaId %s',
     (kaIdText) => {
       const kaId = BigInt(kaIdText);
-      expect(buildScopedKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, kaId)).toBe(
-        buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, kaId),
-      );
+      const owned = buildKnowledgeAssetUalFromOnChainIdV1(CHAIN_ID, KA_STORAGE, kaId);
+      expect(buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, kaId)).toBe(owned);
+      expect(buildScopedKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, kaId)).toBe(owned);
     },
   );
 
-  it('covers both sides of the classifier boundary, so agreement is not vacuous', () => {
-    // Without this, a builder that returned the legacy form unconditionally
-    // would still "agree" on a table that happened to hold only legacy ids.
-    const forms = BOUNDARY_IDS.map((kaId) =>
-      kaId >> 96n === 0n ? 'legacy' : 'rootless',
+  it('pins the classifier boundary ABSOLUTELY, because agreement alone cannot', () => {
+    // With one owner, comparing the two entry points is vacuous for any change
+    // to the rule itself: mutating the owner moves both sides together and they
+    // still agree. Proven — changing `kaId >> 96n` to `>> 95n` in the owner left
+    // the whole agreement suite green. Only absolute expectations catch it.
+    //
+    // These four ids are exactly where the 96-bit split decides the form.
+    const largestLegacy = MAX_ROOTLESS_KA_NUMBER; // 2^96 - 1, still legacy
+    const smallestRootless = 1n << 96n; // author 0x…01, number 0
+
+    expect(buildKnowledgeAssetUalFromOnChainIdV1(CHAIN_ID, KA_STORAGE, largestLegacy)).toBe(
+      `did:dkg:${CHAIN_ID}/${KA_STORAGE}/${largestLegacy.toString()}`,
     );
+    expect(buildKnowledgeAssetUalFromOnChainIdV1(CHAIN_ID, KA_STORAGE, smallestRootless)).toBe(
+      `did:dkg:${CHAIN_ID}/0x${'0'.repeat(39)}1/0`,
+    );
+    expect(buildKnowledgeAssetUalFromOnChainIdV1(CHAIN_ID, KA_STORAGE, 0n)).toBe(
+      `did:dkg:${CHAIN_ID}/${KA_STORAGE}/0`,
+    );
+    expect(
+      buildKnowledgeAssetUalFromOnChainIdV1(CHAIN_ID, KA_STORAGE, (BigInt(AUTHOR) << 96n) | MAX_ROOTLESS_KA_NUMBER),
+    ).toBe(`did:dkg:${CHAIN_ID}/${AUTHOR}/${MAX_ROOTLESS_KA_NUMBER.toString()}`);
+
+    // The agent entry point must produce those same absolute strings, which is
+    // what makes the delegation meaningful rather than merely self-consistent.
+    expect(buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, largestLegacy)).toBe(
+      `did:dkg:${CHAIN_ID}/${KA_STORAGE}/${largestLegacy.toString()}`,
+    );
+    expect(buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, smallestRootless)).toBe(
+      `did:dkg:${CHAIN_ID}/0x${'0'.repeat(39)}1/0`,
+    );
+  });
+
+  it('covers both sides of the classifier boundary, so agreement is not vacuous', () => {
+    // Without this, an owner that returned the legacy form unconditionally would
+    // still "agree" on a table that happened to hold only legacy ids.
+    const forms = BOUNDARY_IDS.map((kaId) => (kaId >> 96n === 0n ? 'legacy' : 'rootless'));
     expect(new Set(forms)).toEqual(new Set(['legacy', 'rootless']));
 
-    // And prove the two forms really do produce different UALs for one id, so
-    // the comparison above has something to discriminate.
+    // And the two forms really do produce different UALs for one id, so the
+    // comparison above has something to discriminate.
     const rootless = (BigInt(AUTHOR) << 96n) | 7n;
     expect(buildReconciledKnowledgeAssetUal(CHAIN_ID, KA_STORAGE, rootless)).toBe(
       `did:dkg:${CHAIN_ID}/${AUTHOR}/7`,
@@ -92,10 +123,21 @@ describe('W2 core UAL construction is byte-identical to the agent reconciled bui
     );
   });
 
-  it('round-trips every parsed candidate back through the agent builder', () => {
-    // The parser's own round-trip check uses the core builder. This closes the
-    // loop against the agent builder instead, so a candidate the parser accepts
-    // cannot denote a different KA in the rest of the codebase.
+  it('preserves the checksummed-address behaviour the sole caller depends on', () => {
+    // `dkg-agent-swm-host.ts` passes the address straight from
+    // `getDKGKnowledgeAssetsAddress()`, which returns the checksummed form. The
+    // owner lowercases it, exactly as `buildKnowledgeAssetUal` always did —
+    // delegating must not have made this path stricter.
+    const checksummed = `0x${'A1'.repeat(20)}`;
+    expect(buildReconciledKnowledgeAssetUal(CHAIN_ID, checksummed, 7n)).toBe(
+      `did:dkg:${CHAIN_ID}/${KA_STORAGE}/7`,
+    );
+  });
+
+  it('round-trips every parsed candidate back through the agent entry point', () => {
+    // The parser's own round-trip check uses the core wrapper. This closes the
+    // loop against the agent export, so a candidate the parser accepts cannot
+    // denote a different KA in the rest of the codebase.
     for (const ual of [
       `did:dkg:${CHAIN_ID}/${KA_STORAGE}/7`,
       `did:dkg:${CHAIN_ID}/${AUTHOR}/0`,

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       "test/sync-envelope-cursor.test.ts",
       "test/w2-ual-parity.test.ts",
       "test/rfc64-receiver-admission-deferral.test.ts",
+      "test/rfc64-precommit-owner-attribution.test.ts",
       "test/exact-assets.test.ts",
       "test/exact-asset-responder.test.ts",
       "test/exact-asset-wire-parse.test.ts",

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
       "test/context-graph-on-chain-id-source-labels.test.ts",
       "test/confirmed-meta-source-labels.test.ts",
       "test/sync-envelope-cursor.test.ts",
+      "test/w2-ual-parity.test.ts",
       "test/exact-assets.test.ts",
       "test/exact-asset-responder.test.ts",
       "test/exact-asset-wire-parse.test.ts",

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       "test/confirmed-meta-source-labels.test.ts",
       "test/sync-envelope-cursor.test.ts",
       "test/w2-ual-parity.test.ts",
+      "test/rfc64-receiver-admission-deferral.test.ts",
       "test/exact-assets.test.ts",
       "test/exact-asset-responder.test.ts",
       "test/exact-asset-wire-parse.test.ts",

--- a/packages/chain/src/finalized-chain-read-admission.ts
+++ b/packages/chain/src/finalized-chain-read-admission.ts
@@ -1,0 +1,132 @@
+/**
+ * Process-wide per-chain admission for heavyweight pinned finalized reads.
+ *
+ * `CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CONCURRENT_PER_CHAIN_V1 = 1` has always
+ * documented "one heavyweight pinned scan per chain", but it was enforced by a
+ * gate constructed **inside** `createStrictFinalizedEndpointRunnerV1`, i.e. one
+ * gate per transport instance. Callers that build their own transport therefore
+ * never contended with each other — and RFC64 builds its snapshot scope inside
+ * the precommit handler, so it constructs a fresh one **per invocation**
+ * (`packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts:94`). Two
+ * concurrent precommits on one chain both admitted.
+ *
+ * W2 makes that visible rather than merely worse: the update-page scanner is a
+ * second independent caller on the same chain, and the plan requires combined
+ * RFC64 + W2 concurrency to never exceed one. So the permit state moves here,
+ * to module scope, where "per chain" actually means per chain.
+ *
+ * **The key is the canonical chain id ALONE.** Adding the owner to the key
+ * would produce one lane per owner, which is the precise bug this module
+ * exists to remove; `owner` is carried for attribution only — it labels who is
+ * holding the lane when another caller is refused, and it is what the W2
+ * metrics' `owner` dimension reports.
+ *
+ * Admission is **non-queueing**, exactly as before: a saturated caller is
+ * refused immediately and decides its own backoff. Queueing here would turn a
+ * refusal that callers already handle into an unbounded wait inside a
+ * transport that has no deadline of its own until after admission.
+ */
+import { parseCanonicalDecimalU256, type ChainIdV1 } from '@origintrail-official/dkg-core';
+
+/**
+ * Closed owner vocabulary. Exported as a value tuple so callers can iterate it
+ * and a test can prove every owner shares the one lane; a bare type union is
+ * invisible at runtime and cannot be checked.
+ */
+export const FINALIZED_CHAIN_READ_OWNERS = [
+  'rfc64',
+  'current-finalized',
+  'w2-page',
+  'w2-target',
+] as const;
+export type FinalizedChainReadOwnerV1 = (typeof FINALIZED_CHAIN_READ_OWNERS)[number];
+
+const OWNER_SET: ReadonlySet<string> = new Set(FINALIZED_CHAIN_READ_OWNERS);
+
+/** One heavyweight pinned finalized read per chain, across every owner. */
+export const FINALIZED_CHAIN_READ_MAX_CONCURRENT_PER_CHAIN_V1 = 1;
+
+export interface FinalizedChainReadAdmissionRequestV1 {
+  readonly chainId: ChainIdV1 | string;
+  readonly owner: FinalizedChainReadOwnerV1;
+}
+
+interface LaneStateV1 {
+  active: number;
+  /** The owner that took the lane, for attribution in the refusal. */
+  holder: FinalizedChainReadOwnerV1;
+}
+
+/**
+ * Module-scoped on purpose. A registry handed out per construction site is the
+ * defect described in this file's header.
+ */
+const lanes = new Map<string, LaneStateV1>();
+
+function canonicalChainKey(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError('Finalized chain-read admission requires a chain id');
+  }
+  // Canonicalize rather than trust the caller's spelling: '084532' and '84532'
+  // are one chain, and accepting both would make the guarantee hold per
+  // spelling instead of per chain.
+  try {
+    return parseCanonicalDecimalU256(value, 'finalized chain-read chain id').toString();
+  } catch (cause) {
+    throw new TypeError(
+      `Finalized chain-read admission requires a canonical decimal chain id, got "${value}"`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Run `operation` holding this chain's sole finalized-read permit.
+ *
+ * `saturated` builds the refusal; it receives the active count and the owner
+ * currently holding the lane so the error can say who to look at.
+ */
+export async function acquireFinalizedChainRead<T>(
+  request: FinalizedChainReadAdmissionRequestV1,
+  operation: () => Promise<T>,
+  saturated: (active: number, holder: FinalizedChainReadOwnerV1) => Error,
+): Promise<T> {
+  if (!OWNER_SET.has(request.owner)) {
+    throw new TypeError(
+      `Finalized chain-read admission received an unknown owner "${request.owner}"`,
+    );
+  }
+  const key = canonicalChainKey(request.chainId);
+
+  const lane = lanes.get(key);
+  if (lane !== undefined && lane.active >= FINALIZED_CHAIN_READ_MAX_CONCURRENT_PER_CHAIN_V1) {
+    throw saturated(lane.active, lane.holder);
+  }
+  lanes.set(key, { active: (lane?.active ?? 0) + 1, holder: request.owner });
+  try {
+    return await operation();
+  } finally {
+    const current = lanes.get(key);
+    const remaining = (current?.active ?? 1) - 1;
+    // Delete rather than leave a zero row, so `lanes` does not grow one entry
+    // per chain id ever seen and a stale holder label cannot outlive its holder.
+    if (remaining <= 0) lanes.delete(key);
+    else lanes.set(key, { active: remaining, holder: current?.holder ?? request.owner });
+  }
+}
+
+/** Active permit count for one chain. Diagnostics and tests only. */
+export function finalizedChainReadRegistryDepth(chainId: ChainIdV1 | string): number {
+  return lanes.get(canonicalChainKey(chainId))?.active ?? 0;
+}
+
+/**
+ * Drop all lane state.
+ *
+ * Module-scoped state is shared by every test in a worker, so a test that
+ * leaves a permit held would make the NEXT test's admission fail for a reason
+ * it never caused. Tests call this first.
+ */
+export function resetFinalizedChainReadRegistryForTests(): void {
+  lanes.clear();
+}

--- a/packages/chain/src/finalized-chain-read-admission.ts
+++ b/packages/chain/src/finalized-chain-read-admission.ts
@@ -33,14 +33,20 @@ import { parseCanonicalDecimalU256, type ChainIdV1 } from '@origintrail-official
  * and a test can prove every owner shares the one lane; a bare type union is
  * invisible at runtime and cannot be checked.
  */
-export const FINALIZED_CHAIN_READ_OWNERS = [
+export const FINALIZED_CHAIN_READ_OWNERS = Object.freeze([
   'foreground',
   'rfc64',
   'w2-page',
   'w2-target',
-] as const;
+] as const);
 export type FinalizedChainReadOwnerV1 = (typeof FINALIZED_CHAIN_READ_OWNERS)[number];
 
+/**
+ * Derived from the frozen tuple. It was previously a `Set` captured at module
+ * initialization while config validation read the (then-mutable) array — two
+ * sources of truth that could disagree. The tuple is frozen now, so the snapshot
+ * is safe, and this comment records why it must stay that way.
+ */
 const OWNER_SET: ReadonlySet<string> = new Set(FINALIZED_CHAIN_READ_OWNERS);
 
 /** One heavyweight pinned finalized read per chain, across every owner. */

--- a/packages/chain/src/finalized-chain-read-admission.ts
+++ b/packages/chain/src/finalized-chain-read-admission.ts
@@ -108,7 +108,13 @@ export async function acquireFinalizedChainRead<T>(
 
   const lane = lanes.get(key);
   if (lane !== undefined && lane.active >= FINALIZED_CHAIN_READ_MAX_CONCURRENT_PER_CHAIN_V1) {
-    throw saturated(lane.active, lane.holder);
+    const refusal = saturated(lane.active, lane.holder);
+    // Marked HERE and only here: this is the one place that refuses because the
+    // process-wide lane is occupied.
+    if (typeof refusal === 'object' && refusal !== null) {
+      ADMISSION_CONTENTION_ERRORS.add(refusal as object);
+    }
+    throw refusal;
   }
   lanes.set(key, { active: (lane?.active ?? 0) + 1, holder: request.owner });
   try {
@@ -124,19 +130,38 @@ export async function acquireFinalizedChainRead<T>(
 }
 
 /**
- * Is this failure "the chain lane is busy" rather than "the work is bad"?
+ * Errors this module itself raised because the process-wide lane was busy.
  *
- * Owned HERE because `concurrency-saturated` is a chain-layer code. Consumers —
- * notably the RFC64 receiver, which must treat contention as a deferral rather
- * than a provider failure — should ask this instead of crawling error shapes
+ * Identity, not shape. `concurrency-saturated` is a SHARED code with at least
+ * two other emitters — the snapshot session's "only one dynamic batch at a
+ * time" reentrancy guard (`strict-current-finalized-evm-snapshot-rpc.ts:61-64`)
+ * and the one-shot read's own limit-of-4 gate (`current-finalized-evm-call.ts:100-103`).
+ * Matching the code alone would classify a genuine integration bug — two
+ * concurrent `session.read()` calls — as harmless lane contention, silently
+ * retry it for the whole deferral bound, and then report a misleading
+ * "gave up waiting for the lane" instead of surfacing the misuse.
+ *
+ * A `WeakSet` keyed on the thrown error object cannot be forged by a caller
+ * constructing a similar-looking error, and holds no reference once the error
+ * is collected.
+ */
+const ADMISSION_CONTENTION_ERRORS = new WeakSet<object>();
+
+/**
+ * Is this failure "the process-wide finalized chain lane is busy" rather than
+ * "the work is bad"?
+ *
+ * Owned HERE because only this module knows which refusals it issued. Consumers
+ * — notably the RFC64 receiver, which must treat contention as a deferral
+ * rather than a provider failure — ask this instead of crawling error shapes
  * they do not own.
  */
 export function isFinalizedChainAdmissionContention(error: unknown): boolean {
   for (let cause: unknown = error, depth = 0;
     cause !== undefined && cause !== null && depth < 8;
     depth += 1) {
-    if (typeof cause === 'object'
-      && (cause as { code?: unknown }).code === 'concurrency-saturated') {
+    // Walk the chain: callers wrap this refusal before it reaches the receiver.
+    if (typeof cause === 'object' && ADMISSION_CONTENTION_ERRORS.has(cause as object)) {
       return true;
     }
     cause = (cause as { cause?: unknown }).cause;

--- a/packages/chain/src/finalized-chain-read-admission.ts
+++ b/packages/chain/src/finalized-chain-read-admission.ts
@@ -34,8 +34,8 @@ import { parseCanonicalDecimalU256, type ChainIdV1 } from '@origintrail-official
  * invisible at runtime and cannot be checked.
  */
 export const FINALIZED_CHAIN_READ_OWNERS = [
+  'foreground',
   'rfc64',
-  'current-finalized',
   'w2-page',
   'w2-target',
 ] as const;

--- a/packages/chain/src/finalized-chain-read-admission.ts
+++ b/packages/chain/src/finalized-chain-read-admission.ts
@@ -28,6 +28,8 @@
  */
 import { parseCanonicalDecimalU256, type ChainIdV1 } from '@origintrail-official/dkg-core';
 
+import type { EndpointAdmissionPolicyV1 } from './nonqueueing-admission.js';
+
 /**
  * Closed owner vocabulary. Exported as a value tuple so callers can iterate it
  * and a test can prove every owner shares the one lane; a bare type union is
@@ -122,26 +124,30 @@ export async function acquireFinalizedChainRead<T>(
 }
 
 /**
- * An admission policy the endpoint runner can execute without knowing what kind
- * of policy it is.
+ * Is this failure "the chain lane is busy" rather than "the work is bad"?
  *
- * The runner used to own endpoint lifecycle only. Giving it a `sharedOwner` mode
- * flag made it also understand a snapshot-specific owner vocabulary — a boundary
- * leak that would grow an enum in the generic lifecycle every time another
- * shared caller appeared. It now runs whatever policy its factory supplies.
+ * Owned HERE because `concurrency-saturated` is a chain-layer code. Consumers —
+ * notably the RFC64 receiver, which must treat contention as a deferral rather
+ * than a provider failure — should ask this instead of crawling error shapes
+ * they do not own.
  */
-export interface FinalizedReadAdmissionV1 {
-  run<T>(
-    chainId: ChainIdV1,
-    operation: () => Promise<T>,
-    saturated: (active: number, holder?: string) => Error,
-  ): Promise<T>;
+export function isFinalizedChainAdmissionContention(error: unknown): boolean {
+  for (let cause: unknown = error, depth = 0;
+    cause !== undefined && cause !== null && depth < 8;
+    depth += 1) {
+    if (typeof cause === 'object'
+      && (cause as { code?: unknown }).code === 'concurrency-saturated') {
+      return true;
+    }
+    cause = (cause as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 /** The process-wide single-permit policy, bound to one owner label. */
 export function createSharedFinalizedReadAdmissionV1(
   owner: FinalizedChainReadOwnerV1,
-): FinalizedReadAdmissionV1 {
+): EndpointAdmissionPolicyV1<ChainIdV1> {
   return Object.freeze({
     run: <T>(
       chainId: ChainIdV1,

--- a/packages/chain/src/finalized-chain-read-admission.ts
+++ b/packages/chain/src/finalized-chain-read-admission.ts
@@ -115,6 +115,36 @@ export async function acquireFinalizedChainRead<T>(
   }
 }
 
+/**
+ * An admission policy the endpoint runner can execute without knowing what kind
+ * of policy it is.
+ *
+ * The runner used to own endpoint lifecycle only. Giving it a `sharedOwner` mode
+ * flag made it also understand a snapshot-specific owner vocabulary — a boundary
+ * leak that would grow an enum in the generic lifecycle every time another
+ * shared caller appeared. It now runs whatever policy its factory supplies.
+ */
+export interface FinalizedReadAdmissionV1 {
+  run<T>(
+    chainId: ChainIdV1,
+    operation: () => Promise<T>,
+    saturated: (active: number, holder?: string) => Error,
+  ): Promise<T>;
+}
+
+/** The process-wide single-permit policy, bound to one owner label. */
+export function createSharedFinalizedReadAdmissionV1(
+  owner: FinalizedChainReadOwnerV1,
+): FinalizedReadAdmissionV1 {
+  return Object.freeze({
+    run: <T>(
+      chainId: ChainIdV1,
+      operation: () => Promise<T>,
+      saturated: (active: number, holder?: string) => Error,
+    ) => acquireFinalizedChainRead({ chainId, owner }, operation, saturated),
+  });
+}
+
 /** Active permit count for one chain. Diagnostics and tests only. */
 export function finalizedChainReadRegistryDepth(chainId: ChainIdV1 | string): number {
   return lanes.get(canonicalChainKey(chainId))?.active ?? 0;

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -69,6 +69,13 @@ export {
 } from './strict-current-finalized-evm-rpc.js';
 export { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from './strict-current-finalized-evm-snapshot-factory.js';
 export {
+  FINALIZED_CHAIN_READ_MAX_CONCURRENT_PER_CHAIN_V1,
+  FINALIZED_CHAIN_READ_OWNERS,
+  acquireFinalizedChainRead,
+  finalizedChainReadRegistryDepth,
+  type FinalizedChainReadOwnerV1,
+} from './finalized-chain-read-admission.js';
+export {
   type StrictCurrentFinalizedEvmReadCallV1,
   type StrictCurrentFinalizedEvmReadRequestV1,
   type StrictCurrentFinalizedEvmReadResultV1,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -73,8 +73,10 @@ export {
   FINALIZED_CHAIN_READ_OWNERS,
   acquireFinalizedChainRead,
   finalizedChainReadRegistryDepth,
+  isFinalizedChainAdmissionContention,
   type FinalizedChainReadOwnerV1,
 } from './finalized-chain-read-admission.js';
+export type { EndpointAdmissionPolicyV1 } from './nonqueueing-admission.js';
 export {
   type StrictCurrentFinalizedEvmReadCallV1,
   type StrictCurrentFinalizedEvmReadRequestV1,

--- a/packages/chain/src/nonqueueing-admission.ts
+++ b/packages/chain/src/nonqueueing-admission.ts
@@ -6,6 +6,31 @@ export interface NonqueueingAdmissionGateV1<K> {
   ): Promise<T>;
 }
 
+/**
+ * A per-instance policy, for callers whose limit is genuinely local.
+ *
+ * The one-shot finalized read is the only such caller today: its limit is 4 and
+ * folding it into the snapshot's single process-wide lane would throttle an
+ * unrelated path. Its saturation reports no holder, because a local gate has no
+ * owner concept to report.
+ */
+export function createLocalNonqueueingAdmissionV1<K>(limit: number): {
+  run<T>(
+    key: K,
+    operation: () => Promise<T>,
+    saturated: (active: number, holder?: string) => Error,
+  ): Promise<T>;
+} {
+  const gate = createNonqueueingAdmissionGateV1<K>(limit);
+  return Object.freeze({
+    run: <T>(
+      key: K,
+      operation: () => Promise<T>,
+      saturated: (active: number, holder?: string) => Error,
+    ) => gate.run(key, operation, (active) => saturated(active, undefined)),
+  });
+}
+
 /** Shared non-queueing permit state used by finalized routers and transports. */
 export function createNonqueueingAdmissionGateV1<K>(
   limit: number,

--- a/packages/chain/src/nonqueueing-admission.ts
+++ b/packages/chain/src/nonqueueing-admission.ts
@@ -7,6 +7,24 @@ export interface NonqueueingAdmissionGateV1<K> {
 }
 
 /**
+ * How the endpoint lifecycle admits work, without knowing what kind of policy
+ * it is.
+ *
+ * This lives here, in the neutral admission layer, rather than with the
+ * process-wide registry: a LOCAL policy should not have to import its own type
+ * from a feature-specific module that owns owner vocabulary and lane state, and
+ * the alternative — restating the structural `run` shape at each factory — is
+ * the anonymous-duplicate problem in another form.
+ */
+export interface EndpointAdmissionPolicyV1<K> {
+  run<T>(
+    key: K,
+    operation: () => Promise<T>,
+    saturated: (active: number, holder?: string) => Error,
+  ): Promise<T>;
+}
+
+/**
  * A per-instance policy, for callers whose limit is genuinely local.
  *
  * The one-shot finalized read is the only such caller today: its limit is 4 and
@@ -14,13 +32,9 @@ export interface NonqueueingAdmissionGateV1<K> {
  * unrelated path. Its saturation reports no holder, because a local gate has no
  * owner concept to report.
  */
-export function createLocalNonqueueingAdmissionV1<K>(limit: number): {
-  run<T>(
-    key: K,
-    operation: () => Promise<T>,
-    saturated: (active: number, holder?: string) => Error,
-  ): Promise<T>;
-} {
+export function createLocalNonqueueingAdmissionV1<K>(
+  limit: number,
+): EndpointAdmissionPolicyV1<K> {
   const gate = createNonqueueingAdmissionGateV1<K>(limit);
   return Object.freeze({
     run: <T>(

--- a/packages/chain/src/strict-current-finalized-evm-config.ts
+++ b/packages/chain/src/strict-current-finalized-evm-config.ts
@@ -3,13 +3,44 @@ import { assertCanonicalChainId } from '@origintrail-official/dkg-core';
 import { CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1 } from './current-finalized-evm-read-profile.js';
 import { snapshotDenseDataArray } from './strict-local-data.js';
 import {
+  FINALIZED_CHAIN_READ_OWNERS,
+  type FinalizedChainReadOwnerV1,
+} from './finalized-chain-read-admission.js';
+import {
   CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1,
   type StrictCurrentFinalizedEvmRpcConfigV1,
+  type StrictFinalizedSnapshotConfigSnapshotV1,
+  type StrictFinalizedSnapshotRpcConfigV1,
   type StrictRpcConfigSnapshotV1,
 } from './strict-current-finalized-evm-types.js';
 
 const CONFIG_REQUIRED_KEYS = Object.freeze(['chainId', 'endpoints'] as const);
 const CONFIG_OPTIONAL_KEYS = Object.freeze(['blockReferenceProfile'] as const);
+
+/**
+ * Snapshot-path config: identical validation plus a REQUIRED owner.
+ *
+ * `owner` is peeled off before delegating rather than added to the shared
+ * allowlist, because the one-shot read path has no owner concept and silently
+ * accepting a field it ignores is worse than rejecting it.
+ */
+export function snapshotStrictFinalizedSnapshotConfigV1(
+  input: StrictFinalizedSnapshotRpcConfigV1,
+): StrictFinalizedSnapshotConfigSnapshotV1 {
+  if (!isPlainRecord(input)) {
+    throw new TypeError('Strict finalized snapshot RPC config must be a plain data record');
+  }
+  const { owner, ...rest } = input;
+  if (!FINALIZED_CHAIN_READ_OWNERS.includes(owner as FinalizedChainReadOwnerV1)) {
+    throw new TypeError(
+      `Strict finalized snapshot RPC config requires a known owner, got "${String(owner)}"`,
+    );
+  }
+  return Object.freeze({
+    ...snapshotStrictCurrentFinalizedEvmConfigV1(rest as StrictCurrentFinalizedEvmRpcConfigV1),
+    owner: owner as FinalizedChainReadOwnerV1,
+  });
+}
 
 export function snapshotStrictCurrentFinalizedEvmConfigV1(
   input: StrictCurrentFinalizedEvmRpcConfigV1,

--- a/packages/chain/src/strict-current-finalized-evm-config.ts
+++ b/packages/chain/src/strict-current-finalized-evm-config.ts
@@ -16,6 +16,7 @@ import {
 
 const CONFIG_REQUIRED_KEYS = Object.freeze(['chainId', 'endpoints'] as const);
 const CONFIG_OPTIONAL_KEYS = Object.freeze(['blockReferenceProfile'] as const);
+const SNAPSHOT_CONFIG_OPTIONAL_KEYS = Object.freeze([...CONFIG_OPTIONAL_KEYS, 'owner'] as const);
 
 /**
  * Snapshot-path config: identical validation plus a REQUIRED owner.
@@ -30,7 +31,14 @@ export function snapshotStrictFinalizedSnapshotConfigV1(
   if (!isPlainRecord(input)) {
     throw new TypeError('Strict finalized snapshot RPC config must be a plain data record');
   }
-  const { owner, ...rest } = input;
+  // DESCRIPTORS FIRST — before `owner`, before object rest, before any read.
+  // An earlier revision destructured `{ owner, ...rest }` up front. That both
+  // executed enumerable getters on the caller's object AND converted them into
+  // plain data properties, so the descriptor check downstream saw a clean object
+  // and ACCEPTED a config the base validator rejects untouched. Object rest is a
+  // read; it cannot precede the check that decides whether reading is allowed.
+  assertConfigDataProperties(input, SNAPSHOT_CONFIG_OPTIONAL_KEYS);
+
   // `@origintrail-official/dkg-chain` is PUBLISHED (npm 10.0.11, not private),
   // and this factory is part of its public surface. Requiring `owner` would
   // break every external `{ chainId, endpoints }` caller at compile time and at
@@ -39,15 +47,30 @@ export function snapshotStrictFinalizedSnapshotConfigV1(
   // this work exists to add is preserved, because the registry is process-wide
   // regardless of who holds it, and RFC64/W2 pass their owner explicitly rather
   // than relying on the default.
-  const resolved = owner ?? 'foreground';
-  if (!FINALIZED_CHAIN_READ_OWNERS.includes(resolved as FinalizedChainReadOwnerV1)) {
+  const owner = input.owner ?? 'foreground';
+  if (!FINALIZED_CHAIN_READ_OWNERS.includes(owner as FinalizedChainReadOwnerV1)) {
     throw new TypeError(
-      `Strict finalized snapshot RPC config received an unknown owner "${String(owner)}"`,
+      `Strict finalized snapshot RPC config received an unknown owner "${String(input.owner)}"`,
     );
   }
+
+  // Rebuild explicitly from the now-proven data properties rather than spreading
+  // the caller's object: the base validator must receive exactly the keys it
+  // declares, and `blockReferenceProfile` is only present when the caller set it
+  // (its allowlist rejects an explicit `undefined` key).
+  const base: Record<string, unknown> = {
+    chainId: input.chainId,
+    endpoints: input.endpoints,
+  };
+  if (Object.prototype.hasOwnProperty.call(input, 'blockReferenceProfile')) {
+    base.blockReferenceProfile = input.blockReferenceProfile;
+  }
+
   return Object.freeze({
-    ...snapshotStrictCurrentFinalizedEvmConfigV1(rest as StrictCurrentFinalizedEvmRpcConfigV1),
-    owner: resolved as FinalizedChainReadOwnerV1,
+    ...snapshotStrictCurrentFinalizedEvmConfigV1(
+      base as unknown as StrictCurrentFinalizedEvmRpcConfigV1,
+    ),
+    owner: owner as FinalizedChainReadOwnerV1,
   });
 }
 
@@ -76,12 +99,23 @@ export function snapshotStrictCurrentFinalizedEvmConfigV1(
   });
 }
 
-function assertConfigDataProperties(input: Record<string, unknown>): void {
+/**
+ * Prove an input is data-only BEFORE any field is read.
+ *
+ * The ordering is the contract, not an implementation detail: an accessor-backed
+ * config must be rejected without its getter ever running. Reading a field first
+ * — including implicitly, via object rest/spread — executes attacker-supplied
+ * code and then hands the validator a plain object that trivially passes.
+ */
+function assertConfigDataProperties(
+  input: Record<string, unknown>,
+  optionalKeys: readonly string[] = CONFIG_OPTIONAL_KEYS,
+): void {
   const keys = Reflect.ownKeys(input);
   if (keys.some((key) => typeof key !== 'string')) {
     throw new TypeError('Strict current-finalized RPC config cannot contain symbol keys');
   }
-  const allowed = new Set<string>([...CONFIG_REQUIRED_KEYS, ...CONFIG_OPTIONAL_KEYS]);
+  const allowed = new Set<string>([...CONFIG_REQUIRED_KEYS, ...optionalKeys]);
   if (
     !CONFIG_REQUIRED_KEYS.every((key) => keys.includes(key))
     || (keys as string[]).some((key) => !allowed.has(key))

--- a/packages/chain/src/strict-current-finalized-evm-config.ts
+++ b/packages/chain/src/strict-current-finalized-evm-config.ts
@@ -47,7 +47,12 @@ export function snapshotStrictFinalizedSnapshotConfigV1(
   // this work exists to add is preserved, because the registry is process-wide
   // regardless of who holds it, and RFC64/W2 pass their owner explicitly rather
   // than relying on the default.
-  const owner = input.owner ?? 'foreground';
+  // OMITTED means foreground. An explicitly PRESENT `owner` must be a known
+  // value — including `null`/`undefined`, which are rejected rather than
+  // silently treated as omission. `??` would have let the API contract for an
+  // explicit null be decided by accident.
+  const ownerPresent = Object.prototype.hasOwnProperty.call(input, 'owner');
+  const owner = ownerPresent ? input.owner : 'foreground';
   if (!FINALIZED_CHAIN_READ_OWNERS.includes(owner as FinalizedChainReadOwnerV1)) {
     throw new TypeError(
       `Strict finalized snapshot RPC config received an unknown owner "${String(input.owner)}"`,

--- a/packages/chain/src/strict-current-finalized-evm-config.ts
+++ b/packages/chain/src/strict-current-finalized-evm-config.ts
@@ -31,14 +31,23 @@ export function snapshotStrictFinalizedSnapshotConfigV1(
     throw new TypeError('Strict finalized snapshot RPC config must be a plain data record');
   }
   const { owner, ...rest } = input;
-  if (!FINALIZED_CHAIN_READ_OWNERS.includes(owner as FinalizedChainReadOwnerV1)) {
+  // `@origintrail-official/dkg-chain` is PUBLISHED (npm 10.0.11, not private),
+  // and this factory is part of its public surface. Requiring `owner` would
+  // break every external `{ chainId, endpoints }` caller at compile time and at
+  // runtime for no gain: `foreground` is a real, meaningful owner label — those
+  // callers genuinely ARE foreground — not an "unknown" bucket. The attribution
+  // this work exists to add is preserved, because the registry is process-wide
+  // regardless of who holds it, and RFC64/W2 pass their owner explicitly rather
+  // than relying on the default.
+  const resolved = owner ?? 'foreground';
+  if (!FINALIZED_CHAIN_READ_OWNERS.includes(resolved as FinalizedChainReadOwnerV1)) {
     throw new TypeError(
-      `Strict finalized snapshot RPC config requires a known owner, got "${String(owner)}"`,
+      `Strict finalized snapshot RPC config received an unknown owner "${String(owner)}"`,
     );
   }
   return Object.freeze({
     ...snapshotStrictCurrentFinalizedEvmConfigV1(rest as StrictCurrentFinalizedEvmRpcConfigV1),
-    owner: owner as FinalizedChainReadOwnerV1,
+    owner: resolved as FinalizedChainReadOwnerV1,
   });
 }
 

--- a/packages/chain/src/strict-current-finalized-evm-lifecycle.ts
+++ b/packages/chain/src/strict-current-finalized-evm-lifecycle.ts
@@ -1,11 +1,7 @@
 import type { ChainIdV1 } from '@origintrail-official/dkg-core';
 
 import { CurrentFinalizedEvmCallErrorV1 } from './current-finalized-evm-read-profile.js';
-import {
-  acquireFinalizedChainRead,
-  type FinalizedChainReadOwnerV1,
-} from './finalized-chain-read-admission.js';
-import { createNonqueueingAdmissionGateV1 } from './nonqueueing-admission.js';
+import type { FinalizedReadAdmissionV1 } from './finalized-chain-read-admission.js';
 import {
   cancelled,
   isAnchorDependentResourceLimit,
@@ -22,24 +18,21 @@ import type {
 export interface StrictFinalizedEndpointRunnerProfileV1 {
   readonly chainId: ChainIdV1;
   readonly endpoints: readonly string[];
-  readonly maxConcurrentPerChain: number;
   readonly totalDeadlineMs: number;
   readonly attemptTimeoutMs: number;
   readonly messages: StrictFinalizedEndpointRunnerMessagesV1;
   /**
-   * When set, admission comes from the PROCESS-WIDE per-chain registry in
-   * `finalized-chain-read-admission.ts` instead of a gate private to this
-   * runner instance, and `maxConcurrentPerChain` is ignored in favour of that
-   * registry's single permit.
+   * The admission policy to run under. The runner does not know, and must not
+   * know, whether this is a per-instance gate or the process-wide per-chain
+   * registry — that is the caller's decision, and keeping it here would put a
+   * feature-specific owner vocabulary inside a generic endpoint lifecycle.
    *
-   * Heavyweight pinned snapshots set it, because their invariant is "one per
-   * chain across every caller" and a per-instance gate cannot express that —
-   * RFC64 builds its scope per precommit invocation, so it previously
-   * contended with nothing. The one-shot read primitive deliberately does NOT
-   * set it: its limit is 4 and folding it into the snapshot's single lane
-   * would throttle an unrelated path.
+   * Heavyweight pinned snapshots inject the shared policy, because their
+   * invariant is "one per chain across every caller". The one-shot read
+   * primitive injects a local gate: its limit is 4, and folding it into the
+   * snapshot's single lane would throttle an unrelated path.
    */
-  readonly sharedOwner?: FinalizedChainReadOwnerV1;
+  readonly admission: FinalizedReadAdmissionV1;
 }
 
 export interface StrictFinalizedEndpointRunnerMessagesV1 {
@@ -52,7 +45,8 @@ export interface StrictFinalizedEndpointRunnerMessagesV1 {
   readonly attemptDeadline: (timeoutMs: number) => string;
   readonly attemptFailure: string;
   readonly noEndpoint: string;
-  readonly saturated: (active: number, holder?: FinalizedChainReadOwnerV1) => string;
+  /** `holder` is supplied by policies that track one; a local gate passes none. */
+  readonly saturated: (active: number, holder?: string) => string;
 }
 
 interface StrictFinalizedEndpointRunInputV1<AttemptResult, Result> {
@@ -86,12 +80,7 @@ export interface StrictFinalizedEndpointRunnerV1 {
 export function createStrictFinalizedEndpointRunnerV1(
   profile: StrictFinalizedEndpointRunnerProfileV1,
 ): StrictFinalizedEndpointRunnerV1 {
-  const { messages, sharedOwner } = profile;
-  // Built unconditionally so the local path keeps identical semantics, but left
-  // unused when `sharedOwner` routes admission to the process-wide registry.
-  const localAdmission = createNonqueueingAdmissionGateV1<ChainIdV1>(
-    profile.maxConcurrentPerChain,
-  );
+  const { messages, admission } = profile;
   const run: StrictFinalizedEndpointRunnerV1 = async <AttemptResult, Result>(
     input: StrictFinalizedEndpointRunInputV1<AttemptResult, Result>,
   ): Promise<Result> => {
@@ -182,18 +171,14 @@ export function createStrictFinalizedEndpointRunnerV1(
         totalDeadline.close();
       }
     };
-    const saturatedError = (active: number, holder?: FinalizedChainReadOwnerV1) =>
-      new CurrentFinalizedEvmCallErrorV1(
+    return admission.run(
+      input.chainId,
+      admitted,
+      (active, holder) => new CurrentFinalizedEvmCallErrorV1(
         'concurrency-saturated',
         messages.saturated(active, holder),
-      );
-    return sharedOwner === undefined
-      ? localAdmission.run(input.chainId, admitted, saturatedError)
-      : acquireFinalizedChainRead(
-        { chainId: input.chainId, owner: sharedOwner },
-        admitted,
-        saturatedError,
-      );
+      ),
+    );
   };
   return Object.freeze(run);
 }

--- a/packages/chain/src/strict-current-finalized-evm-lifecycle.ts
+++ b/packages/chain/src/strict-current-finalized-evm-lifecycle.ts
@@ -1,6 +1,10 @@
 import type { ChainIdV1 } from '@origintrail-official/dkg-core';
 
 import { CurrentFinalizedEvmCallErrorV1 } from './current-finalized-evm-read-profile.js';
+import {
+  acquireFinalizedChainRead,
+  type FinalizedChainReadOwnerV1,
+} from './finalized-chain-read-admission.js';
 import { createNonqueueingAdmissionGateV1 } from './nonqueueing-admission.js';
 import {
   cancelled,
@@ -22,6 +26,20 @@ export interface StrictFinalizedEndpointRunnerProfileV1 {
   readonly totalDeadlineMs: number;
   readonly attemptTimeoutMs: number;
   readonly messages: StrictFinalizedEndpointRunnerMessagesV1;
+  /**
+   * When set, admission comes from the PROCESS-WIDE per-chain registry in
+   * `finalized-chain-read-admission.ts` instead of a gate private to this
+   * runner instance, and `maxConcurrentPerChain` is ignored in favour of that
+   * registry's single permit.
+   *
+   * Heavyweight pinned snapshots set it, because their invariant is "one per
+   * chain across every caller" and a per-instance gate cannot express that —
+   * RFC64 builds its scope per precommit invocation, so it previously
+   * contended with nothing. The one-shot read primitive deliberately does NOT
+   * set it: its limit is 4 and folding it into the snapshot's single lane
+   * would throttle an unrelated path.
+   */
+  readonly sharedOwner?: FinalizedChainReadOwnerV1;
 }
 
 export interface StrictFinalizedEndpointRunnerMessagesV1 {
@@ -34,7 +52,7 @@ export interface StrictFinalizedEndpointRunnerMessagesV1 {
   readonly attemptDeadline: (timeoutMs: number) => string;
   readonly attemptFailure: string;
   readonly noEndpoint: string;
-  readonly saturated: (active: number) => string;
+  readonly saturated: (active: number, holder?: FinalizedChainReadOwnerV1) => string;
 }
 
 interface StrictFinalizedEndpointRunInputV1<AttemptResult, Result> {
@@ -68,8 +86,10 @@ export interface StrictFinalizedEndpointRunnerV1 {
 export function createStrictFinalizedEndpointRunnerV1(
   profile: StrictFinalizedEndpointRunnerProfileV1,
 ): StrictFinalizedEndpointRunnerV1 {
-  const { messages } = profile;
-  const admission = createNonqueueingAdmissionGateV1<ChainIdV1>(
+  const { messages, sharedOwner } = profile;
+  // Built unconditionally so the local path keeps identical semantics, but left
+  // unused when `sharedOwner` routes admission to the process-wide registry.
+  const localAdmission = createNonqueueingAdmissionGateV1<ChainIdV1>(
     profile.maxConcurrentPerChain,
   );
   const run: StrictFinalizedEndpointRunnerV1 = async <AttemptResult, Result>(
@@ -84,7 +104,7 @@ export function createStrictFinalizedEndpointRunnerV1(
     if (input.signal.aborted) {
       throw cancelled(messages.cancelledBeforeAdmission);
     }
-    return admission.run(input.chainId, async () => {
+    const admitted = async (): Promise<Result> => {
       const totalDeadline = createDeadlineScopeV1(
         input.signal,
         profile.totalDeadlineMs,
@@ -161,10 +181,19 @@ export function createStrictFinalizedEndpointRunnerV1(
       } finally {
         totalDeadline.close();
       }
-    }, (active) => new CurrentFinalizedEvmCallErrorV1(
-      'concurrency-saturated',
-      messages.saturated(active),
-    ));
+    };
+    const saturatedError = (active: number, holder?: FinalizedChainReadOwnerV1) =>
+      new CurrentFinalizedEvmCallErrorV1(
+        'concurrency-saturated',
+        messages.saturated(active, holder),
+      );
+    return sharedOwner === undefined
+      ? localAdmission.run(input.chainId, admitted, saturatedError)
+      : acquireFinalizedChainRead(
+        { chainId: input.chainId, owner: sharedOwner },
+        admitted,
+        saturatedError,
+      );
   };
   return Object.freeze(run);
 }

--- a/packages/chain/src/strict-current-finalized-evm-lifecycle.ts
+++ b/packages/chain/src/strict-current-finalized-evm-lifecycle.ts
@@ -1,7 +1,7 @@
 import type { ChainIdV1 } from '@origintrail-official/dkg-core';
 
 import { CurrentFinalizedEvmCallErrorV1 } from './current-finalized-evm-read-profile.js';
-import type { FinalizedReadAdmissionV1 } from './finalized-chain-read-admission.js';
+import type { EndpointAdmissionPolicyV1 } from './nonqueueing-admission.js';
 import {
   cancelled,
   isAnchorDependentResourceLimit,
@@ -32,7 +32,7 @@ export interface StrictFinalizedEndpointRunnerProfileV1 {
    * primitive injects a local gate: its limit is 4, and folding it into the
    * snapshot's single lane would throttle an unrelated path.
    */
-  readonly admission: FinalizedReadAdmissionV1;
+  readonly admission: EndpointAdmissionPolicyV1<ChainIdV1>;
 }
 
 export interface StrictFinalizedEndpointRunnerMessagesV1 {

--- a/packages/chain/src/strict-current-finalized-evm-snapshot-factory.ts
+++ b/packages/chain/src/strict-current-finalized-evm-snapshot-factory.ts
@@ -1,6 +1,6 @@
 import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from './current-finalized-evm-snapshot.js';
-import type { StrictCurrentFinalizedEvmRpcConfigV1 } from './strict-current-finalized-evm-types.js';
-import { snapshotStrictCurrentFinalizedEvmConfigV1 } from './strict-current-finalized-evm-config.js';
+import type { StrictFinalizedSnapshotRpcConfigV1 } from './strict-current-finalized-evm-types.js';
+import { snapshotStrictFinalizedSnapshotConfigV1 } from './strict-current-finalized-evm-config.js';
 import { createStrictFinalizedSnapshotRpcRuntimeV1 } from './strict-current-finalized-evm-snapshot-rpc.js';
 
 /**
@@ -9,9 +9,9 @@ import { createStrictFinalizedSnapshotRpcRuntimeV1 } from './strict-current-fina
  * the callback begins it is never replayed on another endpoint.
  */
 export function createStrictCurrentFinalizedEvmSnapshotScopeV1(
-  input: StrictCurrentFinalizedEvmRpcConfigV1,
+  input: StrictFinalizedSnapshotRpcConfigV1,
 ): StrictCurrentFinalizedEvmSnapshotScopeV1 {
   return createStrictFinalizedSnapshotRpcRuntimeV1(
-    snapshotStrictCurrentFinalizedEvmConfigV1(input),
+    snapshotStrictFinalizedSnapshotConfigV1(input),
   );
 }

--- a/packages/chain/src/strict-current-finalized-evm-snapshot-rpc.ts
+++ b/packages/chain/src/strict-current-finalized-evm-snapshot-rpc.ts
@@ -17,7 +17,7 @@ import {
   createStrictFinalizedSnapshotTransportV1,
   type StrictFinalizedSnapshotTransportSessionV1,
 } from './strict-current-finalized-evm-snapshot-transport.js';
-import type { StrictRpcConfigSnapshotV1 } from './strict-current-finalized-evm-types.js';
+import type { StrictFinalizedSnapshotConfigSnapshotV1 } from './strict-current-finalized-evm-types.js';
 
 interface SnapshotReadSessionControllerV1 {
   readonly session: StrictCurrentFinalizedEvmSnapshotSessionV1;
@@ -26,7 +26,7 @@ interface SnapshotReadSessionControllerV1 {
 
 /** Package-internal runtime for a scoped, pinned finalized snapshot. */
 export function createStrictFinalizedSnapshotRpcRuntimeV1(
-  config: StrictRpcConfigSnapshotV1,
+  config: StrictFinalizedSnapshotConfigSnapshotV1,
 ): StrictCurrentFinalizedEvmSnapshotScopeV1 {
   const transport = createStrictFinalizedSnapshotTransportV1(config);
   const withSnapshot: StrictCurrentFinalizedEvmSnapshotScopeV1 = async (

--- a/packages/chain/src/strict-current-finalized-evm-snapshot-transport.ts
+++ b/packages/chain/src/strict-current-finalized-evm-snapshot-transport.ts
@@ -48,7 +48,7 @@ import {
 } from './strict-current-finalized-evm-read-operations.js';
 import type {
   DeadlineScopeV1,
-  StrictRpcConfigSnapshotV1,
+  StrictFinalizedSnapshotConfigSnapshotV1,
 } from './strict-current-finalized-evm-types.js';
 
 interface SnapshotEndpointPreflightV1 {
@@ -86,11 +86,14 @@ const SNAPSHOT_PREFLIGHT_PROBE_ADDRESS_V1 =
  * internals never leak into the snapshot materialization layer.
  */
 export function createStrictFinalizedSnapshotTransportV1(
-  config: StrictRpcConfigSnapshotV1,
+  config: StrictFinalizedSnapshotConfigSnapshotV1,
 ): StrictFinalizedSnapshotTransportV1 {
   const runEndpoint = createStrictFinalizedEndpointRunnerV1({
     chainId: config.chainId,
     endpoints: config.endpoints,
+    // Process-wide: the invariant is one pinned scan per CHAIN, across RFC64,
+    // W2 and any future owner — not one per transport instance.
+    sharedOwner: config.owner,
     maxConcurrentPerChain: CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CONCURRENT_PER_CHAIN_V1,
     totalDeadlineMs: CURRENT_FINALIZED_EVM_SNAPSHOT_TOTAL_DEADLINE_MS_V1,
     attemptTimeoutMs: CURRENT_FINALIZED_EVM_READ_ATTEMPT_TIMEOUT_MS_V1,
@@ -134,13 +137,14 @@ function createSnapshotEndpointRunnerMessagesV1(
       `Current-finalized snapshot preflight exceeded ${timeoutMs}ms`,
     attemptFailure: 'Current-finalized snapshot preflight failed closed',
     noEndpoint: 'No configured endpoint completed finalized snapshot preflight',
-    saturated: (active: number) =>
-      `Chain ${chainId} already has ${active} finalized snapshot in flight`,
+    saturated: (active: number, holder?: string) =>
+      `Chain ${chainId} already has ${active} finalized snapshot in flight`
+      + (holder === undefined ? '' : ` (held by ${holder})`),
   });
 }
 
 async function preflightSnapshotEndpoint(
-  config: StrictRpcConfigSnapshotV1,
+  config: StrictFinalizedSnapshotConfigSnapshotV1,
   endpoint: string,
   signal: AbortSignal,
 ): Promise<SnapshotEndpointPreflightV1> {
@@ -222,7 +226,7 @@ async function probeSnapshotReadProfile(
 }
 
 async function executePinnedSnapshotScope<T>(
-  config: StrictRpcConfigSnapshotV1,
+  config: StrictFinalizedSnapshotConfigSnapshotV1,
   endpoint: string,
   preflight: SnapshotEndpointPreflightV1,
   request: StrictCurrentFinalizedEvmSnapshotRequestV1,

--- a/packages/chain/src/strict-current-finalized-evm-snapshot-transport.ts
+++ b/packages/chain/src/strict-current-finalized-evm-snapshot-transport.ts
@@ -12,8 +12,8 @@ import {
   CurrentFinalizedEvmCallErrorV1,
 } from './current-finalized-evm-read-profile.js';
 import type { StrictCurrentFinalizedEvmReadCallV1 } from './current-finalized-evm-read-model.js';
+import { createSharedFinalizedReadAdmissionV1 } from './finalized-chain-read-admission.js';
 import {
-  CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CONCURRENT_PER_CHAIN_V1,
   CURRENT_FINALIZED_EVM_SNAPSHOT_TOTAL_DEADLINE_MS_V1,
   type StrictCurrentFinalizedEvmSnapshotRequestV1,
 } from './current-finalized-evm-snapshot.js';
@@ -93,8 +93,7 @@ export function createStrictFinalizedSnapshotTransportV1(
     endpoints: config.endpoints,
     // Process-wide: the invariant is one pinned scan per CHAIN, across RFC64,
     // W2 and any future owner — not one per transport instance.
-    sharedOwner: config.owner,
-    maxConcurrentPerChain: CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CONCURRENT_PER_CHAIN_V1,
+    admission: createSharedFinalizedReadAdmissionV1(config.owner),
     totalDeadlineMs: CURRENT_FINALIZED_EVM_SNAPSHOT_TOTAL_DEADLINE_MS_V1,
     attemptTimeoutMs: CURRENT_FINALIZED_EVM_READ_ATTEMPT_TIMEOUT_MS_V1,
     messages: createSnapshotEndpointRunnerMessagesV1(config.chainId),

--- a/packages/chain/src/strict-current-finalized-evm-transport.ts
+++ b/packages/chain/src/strict-current-finalized-evm-transport.ts
@@ -20,6 +20,7 @@ import {
 } from './current-finalized-evm-read-model.js';
 import { snapshotCurrentFinalizedEvmReadRequestV1 } from './current-finalized-evm-read-validation.js';
 import { executeStrictFinalizedEvmBatchV1 } from './strict-current-finalized-evm-batch-executor.js';
+import { createLocalNonqueueingAdmissionV1 } from './nonqueueing-admission.js';
 import { snapshotStrictCurrentFinalizedEvmConfigV1 } from './strict-current-finalized-evm-config.js';
 import {
   readStrictCurrentFinalizedEvmRevertDataV1,
@@ -98,7 +99,9 @@ export function createStrictCurrentFinalizedEvmReadV1(
   const runEndpoint = createStrictFinalizedEndpointRunnerV1({
     chainId: config.chainId,
     endpoints: config.endpoints,
-    maxConcurrentPerChain: CURRENT_FINALIZED_EVM_READ_MAX_CONCURRENT_PER_CHAIN_V1,
+    admission: createLocalNonqueueingAdmissionV1<ChainIdV1>(
+      CURRENT_FINALIZED_EVM_READ_MAX_CONCURRENT_PER_CHAIN_V1,
+    ),
     totalDeadlineMs: CURRENT_FINALIZED_EVM_READ_TOTAL_DEADLINE_MS_V1,
     attemptTimeoutMs: CURRENT_FINALIZED_EVM_READ_ATTEMPT_TIMEOUT_MS_V1,
     messages: createReadEndpointRunnerMessagesV1(config.chainId),

--- a/packages/chain/src/strict-current-finalized-evm-types.ts
+++ b/packages/chain/src/strict-current-finalized-evm-types.ts
@@ -33,14 +33,16 @@ export interface StrictRpcConfigSnapshotV1 {
 }
 
 /**
- * Snapshot callers must declare an owner. It is REQUIRED, not optional: an
- * ownerless snapshot path cannot be attributed in the `owner` metric dimension
- * and cannot participate in the fairness rules W2 adds later, so leaving a
- * default would quietly recreate the unattributed lane this work removes.
+ * Snapshot callers MAY declare an owner; omitting it means `foreground`.
+ *
+ * This factory is published API, so the field is optional — see the rationale in
+ * `snapshotStrictFinalizedSnapshotConfigV1`. Callers that matter for fairness
+ * and for the `owner` metric dimension (RFC64, W2) pass it explicitly and must
+ * never rely on the default.
  */
 export interface StrictFinalizedSnapshotRpcConfigV1
   extends StrictCurrentFinalizedEvmRpcConfigV1 {
-  readonly owner: FinalizedChainReadOwnerV1;
+  readonly owner?: FinalizedChainReadOwnerV1;
 }
 
 export interface StrictFinalizedSnapshotConfigSnapshotV1 extends StrictRpcConfigSnapshotV1 {

--- a/packages/chain/src/strict-current-finalized-evm-types.ts
+++ b/packages/chain/src/strict-current-finalized-evm-types.ts
@@ -4,6 +4,8 @@ import type {
   Digest32V1,
 } from '@origintrail-official/dkg-core';
 
+import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
+
 export const CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1 = Object.freeze([
   'eip1898',
   'trusted-block-number-hash-sandwich',
@@ -28,6 +30,21 @@ export interface StrictRpcConfigSnapshotV1 {
   readonly chainId: ChainIdV1;
   readonly endpoints: readonly string[];
   readonly blockReferenceProfile: CurrentFinalizedEvmBlockReferenceProfileV1;
+}
+
+/**
+ * Snapshot callers must declare an owner. It is REQUIRED, not optional: an
+ * ownerless snapshot path cannot be attributed in the `owner` metric dimension
+ * and cannot participate in the fairness rules W2 adds later, so leaving a
+ * default would quietly recreate the unattributed lane this work removes.
+ */
+export interface StrictFinalizedSnapshotRpcConfigV1
+  extends StrictCurrentFinalizedEvmRpcConfigV1 {
+  readonly owner: FinalizedChainReadOwnerV1;
+}
+
+export interface StrictFinalizedSnapshotConfigSnapshotV1 extends StrictRpcConfigSnapshotV1 {
+  readonly owner: FinalizedChainReadOwnerV1;
 }
 
 export interface FinalizedAnchorV1 {

--- a/packages/chain/test/finalized-chain-read-admission.unit.test.ts
+++ b/packages/chain/test/finalized-chain-read-admission.unit.test.ts
@@ -4,9 +4,11 @@ import {
   FINALIZED_CHAIN_READ_OWNERS,
   acquireFinalizedChainRead,
   finalizedChainReadRegistryDepth,
+  isFinalizedChainAdmissionContention,
   resetFinalizedChainReadRegistryForTests,
   type FinalizedChainReadOwnerV1,
 } from '../src/finalized-chain-read-admission.js';
+import { CurrentFinalizedEvmCallErrorV1 } from '../src/current-finalized-evm-read-profile.js';
 
 const CHAIN = '84532';
 const OTHER_CHAIN = '31337';
@@ -21,6 +23,75 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   });
   return { promise, resolve };
 }
+
+describe('contention classification is by IDENTITY, not by error code', () => {
+  // `concurrency-saturated` is a SHARED code. Classifying on it would make the
+  // RFC64 receiver defer — and silently retry for the whole deferral bound —
+  // on failures that are real bugs or unrelated local overload.
+  it('classifies only the refusal this module actually threw', async () => {
+    resetFinalizedChainReadRegistryForTests();
+    const gate = deferred<void>();
+    const held = acquireFinalizedChainRead(
+      { chainId: CHAIN, owner: 'rfc64' },
+      () => gate.promise,
+      (active, holder) => new CurrentFinalizedEvmCallErrorV1(
+        'concurrency-saturated',
+        `Chain ${CHAIN} already has ${active} in flight (held by ${holder})`,
+      ),
+    );
+    await Promise.resolve();
+
+    let refusal: unknown;
+    try {
+      await acquireFinalizedChainRead(
+        { chainId: CHAIN, owner: 'w2-page' },
+        async () => 'x',
+        (active) => new CurrentFinalizedEvmCallErrorV1('concurrency-saturated', `busy:${active}`),
+      );
+    } catch (error) {
+      refusal = error;
+    }
+    expect(isFinalizedChainAdmissionContention(refusal)).toBe(true);
+    // …and through a wrapper, which is how it reaches the receiver.
+    expect(isFinalizedChainAdmissionContention(
+      Object.assign(new Error('precommit rejected'), { cause: refusal }),
+    )).toBe(true);
+
+    gate.resolve();
+    await held;
+  });
+
+  it('does NOT classify the snapshot session reentrancy guard', () => {
+    // `strict-current-finalized-evm-snapshot-rpc.ts` throws this when two
+    // `session.read()` calls overlap. That is an integration bug: deferring it
+    // would retry the misuse and then report a misleading lane-wait failure.
+    const reentrancy = new CurrentFinalizedEvmCallErrorV1(
+      'concurrency-saturated',
+      'Current-finalized snapshot permits only one dynamic batch at a time',
+    );
+    expect(reentrancy.code).toBe('concurrency-saturated');
+    expect(isFinalizedChainAdmissionContention(reentrancy)).toBe(false);
+  });
+
+  it('does NOT classify the one-shot read limit', () => {
+    // The one-shot read has its own local gate with limit 4. Its saturation is
+    // local overload, not the shared pinned-scan lane.
+    const localLimit = new CurrentFinalizedEvmCallErrorV1(
+      'concurrency-saturated',
+      `Chain ${CHAIN} already has 4 current-finalized calls in flight`,
+    );
+    expect(isFinalizedChainAdmissionContention(localLimit)).toBe(false);
+  });
+
+  it('cannot be forged by constructing a look-alike error', () => {
+    expect(isFinalizedChainAdmissionContention(
+      Object.assign(new Error('nice try'), { code: 'concurrency-saturated' }),
+    )).toBe(false);
+    expect(isFinalizedChainAdmissionContention(undefined)).toBe(false);
+    expect(isFinalizedChainAdmissionContention(null)).toBe(false);
+    expect(isFinalizedChainAdmissionContention('concurrency-saturated')).toBe(false);
+  });
+});
 
 describe('finalized chain-read admission registry', () => {
   it('is PROCESS-WIDE: two independently obtained handles share one permit', async () => {

--- a/packages/chain/test/finalized-chain-read-admission.unit.test.ts
+++ b/packages/chain/test/finalized-chain-read-admission.unit.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FINALIZED_CHAIN_READ_OWNERS,
+  acquireFinalizedChainRead,
+  finalizedChainReadRegistryDepth,
+  resetFinalizedChainReadRegistryForTests,
+  type FinalizedChainReadOwnerV1,
+} from '../src/finalized-chain-read-admission.js';
+
+const CHAIN = '84532';
+const OTHER_CHAIN = '31337';
+
+/** A saturation error factory shaped like the transport's own. */
+const saturated = (active: number) => new Error(`saturated:${active}`);
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('finalized chain-read admission registry', () => {
+  it('is PROCESS-WIDE: two independently obtained handles share one permit', async () => {
+    // This is the whole point of the module, and the reason it exists at all.
+    // The pre-existing gate was created inside `createStrictFinalizedEndpointRunnerV1`,
+    // so every caller that built its own transport got its OWN gate — and
+    // `CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CONCURRENT_PER_CHAIN_V1 = 1` ("one
+    // heavyweight pinned scan per chain") enforced nothing between callers.
+    // RFC64 constructs its scope per precommit invocation, so two concurrent
+    // precommits on one chain both admitted.
+    resetFinalizedChainReadRegistryForTests();
+    const first = deferred<string>();
+
+    const held = acquireFinalizedChainRead(
+      { chainId: CHAIN, owner: 'rfc64' },
+      () => first.promise,
+      saturated,
+    );
+    await Promise.resolve();
+    expect(finalizedChainReadRegistryDepth(CHAIN)).toBe(1);
+
+    await expect(
+      acquireFinalizedChainRead({ chainId: CHAIN, owner: 'w2-page' }, async () => 'second', saturated),
+    ).rejects.toThrow('saturated:1');
+
+    first.resolve('first');
+    expect(await held).toBe('first');
+    expect(finalizedChainReadRegistryDepth(CHAIN)).toBe(0);
+  });
+
+  it('keys on the chain id ALONE, so a different owner is not a different lane', async () => {
+    // If the key were `${chainId}:${owner}`, the assertion above would pass
+    // vacuously for two same-owner callers while RFC64 and W2 still ran
+    // concurrently — the exact failure this registry exists to prevent.
+    resetFinalizedChainReadRegistryForTests();
+    const gate = deferred<void>();
+    const owners: FinalizedChainReadOwnerV1[] = [...FINALIZED_CHAIN_READ_OWNERS];
+    expect(owners.length).toBeGreaterThan(1);
+
+    const held = acquireFinalizedChainRead(
+      { chainId: CHAIN, owner: owners[0]! },
+      () => gate.promise,
+      saturated,
+    );
+    await Promise.resolve();
+
+    for (const owner of owners.slice(1)) {
+      await expect(
+        acquireFinalizedChainRead({ chainId: CHAIN, owner }, async () => 'x', saturated),
+      ).rejects.toThrow(/^saturated:1$/);
+    }
+
+    gate.resolve();
+    await held;
+  });
+
+  it('does not couple distinct chains', async () => {
+    resetFinalizedChainReadRegistryForTests();
+    const gate = deferred<void>();
+    const held = acquireFinalizedChainRead(
+      { chainId: CHAIN, owner: 'rfc64' },
+      () => gate.promise,
+      saturated,
+    );
+    await Promise.resolve();
+
+    await expect(
+      acquireFinalizedChainRead({ chainId: OTHER_CHAIN, owner: 'w2-page' }, async () => 'ok', saturated),
+    ).resolves.toBe('ok');
+
+    gate.resolve();
+    await held;
+  });
+
+  it('releases the permit on throw, not only on success', async () => {
+    resetFinalizedChainReadRegistryForTests();
+    await expect(
+      acquireFinalizedChainRead({ chainId: CHAIN, owner: 'rfc64' }, async () => {
+        throw new Error('boom');
+      }, saturated),
+    ).rejects.toThrow('boom');
+    expect(finalizedChainReadRegistryDepth(CHAIN)).toBe(0);
+
+    // …and the lane is genuinely reusable afterwards, which a decrement that
+    // ran but left the map at a stale value would not give us.
+    await expect(
+      acquireFinalizedChainRead({ chainId: CHAIN, owner: 'w2-page' }, async () => 'after', saturated),
+    ).resolves.toBe('after');
+  });
+
+  it('reports the holding owner to the saturation factory', async () => {
+    // Without this, an operator seeing "chain 84532 already has 1 in flight"
+    // cannot tell whether RFC64 or W2 is the one holding it, which is the
+    // first question asked when a lane appears stuck.
+    resetFinalizedChainReadRegistryForTests();
+    const gate = deferred<void>();
+    const held = acquireFinalizedChainRead(
+      { chainId: CHAIN, owner: 'rfc64' },
+      () => gate.promise,
+      saturated,
+    );
+    await Promise.resolve();
+
+    let seenHolder: FinalizedChainReadOwnerV1 | undefined;
+    await expect(
+      acquireFinalizedChainRead({ chainId: CHAIN, owner: 'w2-page' }, async () => 'x', (active, holder) => {
+        seenHolder = holder;
+        return new Error(`saturated:${active}:${holder}`);
+      }),
+    ).rejects.toThrow('saturated:1:rfc64');
+    expect(seenHolder).toBe('rfc64');
+
+    gate.resolve();
+    await held;
+  });
+
+  it('rejects an unknown owner rather than silently admitting it', async () => {
+    resetFinalizedChainReadRegistryForTests();
+    await expect(
+      acquireFinalizedChainRead(
+        { chainId: CHAIN, owner: 'not-an-owner' as FinalizedChainReadOwnerV1 },
+        async () => 'x',
+        saturated,
+      ),
+    ).rejects.toThrow(/owner/i);
+    expect(finalizedChainReadRegistryDepth(CHAIN)).toBe(0);
+  });
+
+  it('rejects a noncanonical chain id so two spellings cannot become two lanes', async () => {
+    // '084532' and '84532' are the same chain. If both were accepted as keys,
+    // the process-wide guarantee would hold per SPELLING, not per chain.
+    resetFinalizedChainReadRegistryForTests();
+    await expect(
+      acquireFinalizedChainRead({ chainId: '084532', owner: 'rfc64' }, async () => 'x', saturated),
+    ).rejects.toThrow(/chain id/i);
+    await expect(
+      acquireFinalizedChainRead({ chainId: '', owner: 'rfc64' }, async () => 'x', saturated),
+    ).rejects.toThrow(/chain id/i);
+  });
+});

--- a/packages/chain/test/finalized-chain-read-admission.unit.test.ts
+++ b/packages/chain/test/finalized-chain-read-admission.unit.test.ts
@@ -137,6 +137,17 @@ describe('finalized chain-read admission registry', () => {
     await held;
   });
 
+  it('exposes a runtime-FROZEN owner tuple, not just an `as const` one', async () => {
+    // `as const` is compile-time only. Config validation reads this tuple while
+    // admission checks a Set derived from it — if the tuple were mutable, a
+    // consumer could widen one side and create split-brain behaviour where a
+    // config validates but the run is refused.
+    expect(Object.isFrozen(FINALIZED_CHAIN_READ_OWNERS)).toBe(true);
+    const before = [...FINALIZED_CHAIN_READ_OWNERS];
+    expect(() => (FINALIZED_CHAIN_READ_OWNERS as unknown as string[]).push('mutant-owner')).toThrow();
+    expect([...FINALIZED_CHAIN_READ_OWNERS]).toEqual(before);
+  });
+
   it('rejects an unknown owner rather than silently admitting it', async () => {
     resetFinalizedChainReadRegistryForTests();
     await expect(

--- a/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
+++ b/packages/chain/test/finalized-vm-chain-scanner.unit.test.ts
@@ -469,6 +469,7 @@ describe('RFC-64 finalized VM chain scanner', () => {
       }
     });
     const snapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [rpc.url],
     });

--- a/packages/chain/test/snapshot-test-fixtures.ts
+++ b/packages/chain/test/snapshot-test-fixtures.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared fixtures for the finalized-snapshot suites.
+ *
+ * `strict-current-finalized-evm-snapshot.unit.test.ts` already covers endpoint
+ * pinning, preflight, budgets, cancellation, forged selectors and session
+ * behaviour. Process-wide admission is a separate concern with its own file, and
+ * both need the same loopback handler and request/call shapes — so the helpers
+ * live here rather than being duplicated or absorbed into the behaviour matrix.
+ */
+import type { ChainIdV1, EvmAddressV1 } from '@origintrail-official/dkg-core';
+
+import type { StrictCurrentFinalizedEvmReadCallV1 } from '../src/current-finalized-evm-read-model.js';
+
+import {
+  sendJsonRpcError,
+  sendJsonRpcResult,
+  type LoopbackJsonRpcHandler,
+} from './loopback-rpc-harness.js';
+
+export const CHAIN_ID = '20430' as ChainIdV1;
+export const CHAIN_QUANTITY = '0x4fce';
+export const TO = '0x1111111111111111111111111111111111111111' as EvmAddressV1;
+export const PREFLIGHT_PROBE_TO = '0x0000000000000000000000000000000000000000';
+export const BLOCK_HASH = `0x${'22'.repeat(32)}`;
+export const FIRST_DATA = '0x11111111';
+export const SECOND_DATA = '0x22222222';
+
+export function request(): { readonly chainId: ChainIdV1; readonly signal: AbortSignal } {
+  return { chainId: CHAIN_ID, signal: new AbortController().signal };
+}
+
+export function call(data: string, maxReturnBytes = 2): StrictCurrentFinalizedEvmReadCallV1 {
+  return Object.freeze({ to: TO, data, maxReturnBytes });
+}
+
+export function successfulHandler(): LoopbackJsonRpcHandler {
+  return (rpcCall, response) => {
+    switch (rpcCall.method) {
+      case 'eth_chainId':
+        sendJsonRpcResult(response, rpcCall, CHAIN_QUANTITY);
+        return;
+      case 'eth_getBlockByNumber':
+        sendJsonRpcResult(response, rpcCall, { number: '0x7b', hash: BLOCK_HASH });
+        return;
+      case 'eth_getCode':
+        sendJsonRpcResult(response, rpcCall, '0x6000');
+        return;
+      case 'eth_call': {
+        const callObject = rpcCall.params[0] as { readonly data?: unknown };
+        if (callObject.data === '0x') sendJsonRpcResult(response, rpcCall, '0x');
+        else if (callObject.data === FIRST_DATA) sendJsonRpcResult(response, rpcCall, '0xaaaa');
+        else if (callObject.data === SECOND_DATA) sendJsonRpcResult(response, rpcCall, '0xbbbb');
+        else sendJsonRpcError(response, rpcCall, -32602, 'unexpected calldata');
+        return;
+      }
+      default:
+        sendJsonRpcError(response, rpcCall, -32601, 'method not found');
+    }
+  };
+}
+
+export function isPreflightProbe(rpcCall: { readonly params: readonly unknown[] }): boolean {
+  const callObject = rpcCall.params[0] as { readonly to?: unknown; readonly data?: unknown };
+  return callObject.to === PREFLIGHT_PROBE_TO && callObject.data === '0x';
+}
+
+export function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}

--- a/packages/chain/test/strict-current-finalized-evm-snapshot.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-snapshot.unit.test.ts
@@ -501,55 +501,6 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
     ]);
   });
 
-  it('contends across INDEPENDENTLY constructed scopes on one chain', async () => {
-    // The two saturation tests below both reuse a single `withSnapshot`
-    // handle, so they pass identically whether the permit is per-instance or
-    // per-chain — they cannot discriminate the thing that actually matters.
-    // Production builds a fresh scope per RFC64 precommit invocation
-    // (`finalized-vm-agent-precommit-v1.ts`), so THIS is the real shape: two
-    // handles, one chain, one permit.
-    const callStarted = deferred<void>();
-    const releaseCall = deferred<void>();
-    const baseHandler = successfulHandler();
-    const server = await rpcHarness.start(async (rpcCall, response, rawRequest) => {
-      if (rpcCall.method === 'eth_call' && !isPreflightProbe(rpcCall)) {
-        callStarted.resolve(undefined);
-        await releaseCall.promise;
-      }
-      await baseHandler(rpcCall, response, rawRequest);
-    });
-    const holder = createStrictCurrentFinalizedEvmSnapshotScopeV1({
-      owner: 'rfc64',
-      chainId: CHAIN_ID,
-      endpoints: [server.url],
-    });
-    const contender = createStrictCurrentFinalizedEvmSnapshotScopeV1({
-      owner: 'w2-page',
-      chainId: CHAIN_ID,
-      endpoints: [server.url],
-    });
-    expect(holder).not.toBe(contender);
-
-    const first = holder(request(), async (session) => {
-      await session.read([call(FIRST_DATA)]);
-      return 'first';
-    });
-    await callStarted.promise;
-
-    await expect(contender(request(), async () => 'second')).rejects.toMatchObject({
-      code: 'concurrency-saturated',
-      // The refusal names the owner holding the lane, so an operator can tell
-      // which path to look at.
-      message: expect.stringContaining('held by rfc64'),
-    });
-
-    releaseCall.resolve(undefined);
-    await expect(first).resolves.toBe('first');
-
-    // The lane is genuinely reusable by the other owner once released.
-    await expect(contender(request(), async () => 'third')).resolves.toBe('third');
-  });
-
   it('drains an unawaited batch before releasing its single snapshot permit', async () => {
     const callStarted = deferred<void>();
     const releaseCall = deferred<void>();

--- a/packages/chain/test/strict-current-finalized-evm-snapshot.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-snapshot.unit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   type ChainIdV1,
@@ -22,6 +22,7 @@ import {
   type StrictCurrentFinalizedEvmReadCallV1,
 } from '../src/strict-current-finalized-evm-rpc.js';
 import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '../src/index.js';
+import { resetFinalizedChainReadRegistryForTests } from '../src/finalized-chain-read-admission.js';
 import {
   createLoopbackJsonRpcTestHarness,
   sendJsonRpcError,
@@ -45,10 +46,17 @@ afterEach(async () => {
   await rpcHarness.stopAll();
 });
 
+// The snapshot permit now lives in a PROCESS-WIDE registry, so a test that
+// leaves one held would fail the next test for a reason it never caused.
+beforeEach(() => {
+  resetFinalizedChainReadRegistryForTests();
+});
+
 describe('RFC-64 scoped current-finalized EVM snapshot', () => {
   it('pins dynamic batches to one endpoint and EIP-1898 anchor with one code check', async () => {
     const server = await rpcHarness.start(successfulHandler());
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -97,6 +105,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
     });
     const second = await rpcHarness.start(successfulHandler());
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [first.url, second.url],
     });
@@ -130,6 +139,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
     });
     const second = await rpcHarness.start(successfulHandler());
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [first.url, second.url],
     });
@@ -168,6 +178,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
     });
     const backup = await rpcHarness.start(successfulHandler());
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [malformed.url, backup.url],
     });
@@ -204,6 +215,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       return baseHandler(rpcCall, response, rawRequest);
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -231,6 +243,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
     });
     const second = await rpcHarness.start(successfulHandler());
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [first.url, second.url],
     });
@@ -276,6 +289,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       }
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
       blockReferenceProfile: 'trusted-block-number-hash-sandwich',
@@ -322,6 +336,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       }
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
       blockReferenceProfile: 'trusted-block-number-hash-sandwich',
@@ -389,6 +404,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
           }
         });
         const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+          owner: 'rfc64',
           chainId: CHAIN_ID,
           endpoints: [server.url],
           blockReferenceProfile: 'trusted-block-number-hash-sandwich',
@@ -437,6 +453,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       }
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
       blockReferenceProfile: 'trusted-block-number-hash-sandwich',
@@ -453,10 +470,12 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
     const first = await rpcHarness.start(successfulHandler());
     const second = await rpcHarness.start(successfulHandler());
     const firstScope = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [first.url],
     });
     const secondScope = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [second.url],
     });
@@ -482,6 +501,55 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
     ]);
   });
 
+  it('contends across INDEPENDENTLY constructed scopes on one chain', async () => {
+    // The two saturation tests below both reuse a single `withSnapshot`
+    // handle, so they pass identically whether the permit is per-instance or
+    // per-chain — they cannot discriminate the thing that actually matters.
+    // Production builds a fresh scope per RFC64 precommit invocation
+    // (`finalized-vm-agent-precommit-v1.ts`), so THIS is the real shape: two
+    // handles, one chain, one permit.
+    const callStarted = deferred<void>();
+    const releaseCall = deferred<void>();
+    const baseHandler = successfulHandler();
+    const server = await rpcHarness.start(async (rpcCall, response, rawRequest) => {
+      if (rpcCall.method === 'eth_call' && !isPreflightProbe(rpcCall)) {
+        callStarted.resolve(undefined);
+        await releaseCall.promise;
+      }
+      await baseHandler(rpcCall, response, rawRequest);
+    });
+    const holder = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+    });
+    const contender = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'w2-page',
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+    });
+    expect(holder).not.toBe(contender);
+
+    const first = holder(request(), async (session) => {
+      await session.read([call(FIRST_DATA)]);
+      return 'first';
+    });
+    await callStarted.promise;
+
+    await expect(contender(request(), async () => 'second')).rejects.toMatchObject({
+      code: 'concurrency-saturated',
+      // The refusal names the owner holding the lane, so an operator can tell
+      // which path to look at.
+      message: expect.stringContaining('held by rfc64'),
+    });
+
+    releaseCall.resolve(undefined);
+    await expect(first).resolves.toBe('first');
+
+    // The lane is genuinely reusable by the other owner once released.
+    await expect(contender(request(), async () => 'third')).resolves.toBe('third');
+  });
+
   it('drains an unawaited batch before releasing its single snapshot permit', async () => {
     const callStarted = deferred<void>();
     const releaseCall = deferred<void>();
@@ -494,6 +562,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       await baseHandler(rpcCall, response, rawRequest);
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -526,6 +595,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       sendJsonRpcError(response, rpcCall, -32000, 'forced rejection');
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -562,6 +632,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       await baseHandler(rpcCall, response, rawRequest);
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -595,6 +666,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       started.resolve(undefined);
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -627,6 +699,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       started.resolve(undefined);
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -671,6 +744,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       started.resolve(undefined);
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -732,6 +806,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       });
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: ['https://snapshot-rpc.test'],
     });
@@ -772,6 +847,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
       siblingStarted.resolve(undefined);
     });
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -796,6 +872,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
   it('rejects forged block selectors, hostile batches, and non-callable consumers pre-I/O', async () => {
     const server = await rpcHarness.start(successfulHandler());
     const withSnapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [server.url],
     });
@@ -856,6 +933,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
   it('enforces aggregate budgets through the public snapshot session before extra I/O', async () => {
     const batchServer = await rpcHarness.start(successfulHandler());
     const batchScope = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [batchServer.url],
     });
@@ -871,6 +949,7 @@ describe('RFC-64 scoped current-finalized EVM snapshot', () => {
 
     const returnServer = await rpcHarness.start(successfulHandler());
     const returnScope = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
       chainId: CHAIN_ID,
       endpoints: [returnServer.url],
     });

--- a/packages/chain/test/strict-finalized-snapshot-admission.unit.test.ts
+++ b/packages/chain/test/strict-finalized-snapshot-admission.unit.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '../src/index.js';
+import {
+  finalizedChainReadRegistryDepth,
+  resetFinalizedChainReadRegistryForTests,
+} from '../src/finalized-chain-read-admission.js';
+import { createLoopbackJsonRpcTestHarness } from './loopback-rpc-harness.js';
+import {
+  CHAIN_ID,
+  FIRST_DATA,
+  call,
+  deferred,
+  isPreflightProbe,
+  request,
+  successfulHandler,
+} from './snapshot-test-fixtures.js';
+
+/**
+ * Process-wide snapshot admission.
+ *
+ * This is deliberately NOT in the snapshot behaviour matrix. The two saturation
+ * cases that live there both reuse a single `withSnapshot` handle, so they pass
+ * identically whether the permit is per-instance or per-chain — they cannot
+ * discriminate the property this file exists to pin. Production builds a fresh
+ * scope per RFC64 precommit invocation
+ * (`packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts`), so the real
+ * shape is two handles, one chain, one permit.
+ */
+const rpcHarness = createLoopbackJsonRpcTestHarness();
+
+afterEach(async () => {
+  await rpcHarness.stopAll();
+});
+
+beforeEach(() => {
+  // Module-scoped permit state is shared by every test in the worker; a leaked
+  // permit would fail the NEXT test for a reason it never caused.
+  resetFinalizedChainReadRegistryForTests();
+});
+
+/** Start a server that parks inside the first non-preflight `eth_call`. */
+async function parkedServer() {
+  const callStarted = deferred<void>();
+  const releaseCall = deferred<void>();
+  const baseHandler = successfulHandler();
+  const server = await rpcHarness.start(async (rpcCall, response, rawRequest) => {
+    if (rpcCall.method === 'eth_call' && !isPreflightProbe(rpcCall)) {
+      callStarted.resolve(undefined);
+      await releaseCall.promise;
+    }
+    await baseHandler(rpcCall, response, rawRequest);
+  });
+  return { server, callStarted, releaseCall };
+}
+
+describe('process-wide finalized snapshot admission', () => {
+  it('contends across INDEPENDENTLY constructed scopes on one chain', async () => {
+    const { server, callStarted, releaseCall } = await parkedServer();
+    const holder = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'rfc64',
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+    });
+    const contender = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'w2-page',
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+    });
+    expect(holder).not.toBe(contender);
+
+    const first = holder(request(), async (session) => {
+      await session.read([call(FIRST_DATA)]);
+      return 'first';
+    });
+    await callStarted.promise;
+
+    await expect(contender(request(), async () => 'second')).rejects.toMatchObject({
+      code: 'concurrency-saturated',
+      // The refusal names the owner holding the lane, so an operator can tell
+      // which path to look at.
+      message: expect.stringContaining('held by rfc64'),
+    });
+
+    releaseCall.resolve(undefined);
+    await expect(first).resolves.toBe('first');
+
+    // The lane is genuinely reusable by the other owner once released.
+    await expect(contender(request(), async () => 'third')).resolves.toBe('third');
+  });
+
+  it('keeps the pre-existing ownerless public call shape working', async () => {
+    // `@origintrail-official/dkg-chain` is published, and this factory is part
+    // of its public surface. `{ chainId, endpoints }` must keep constructing a
+    // scope — a required `owner` would break every external caller.
+    const server = await rpcHarness.start(successfulHandler());
+    const legacyShape = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+    });
+    await expect(legacyShape(request(), async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('does NOT let the default owner bypass the shared lane', async () => {
+    // The whole point of defaulting rather than requiring is that `foreground`
+    // is a real owner, not an escape hatch. If an omitted owner took a private
+    // gate, the default would silently reintroduce the defect this work fixes.
+    const { server, callStarted, releaseCall } = await parkedServer();
+    const ownerless = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+    });
+    const w2 = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'w2-page',
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+    });
+
+    const first = ownerless(request(), async (session) => {
+      await session.read([call(FIRST_DATA)]);
+      return 'first';
+    });
+    await callStarted.promise;
+
+    await expect(w2(request(), async () => 'second')).rejects.toMatchObject({
+      code: 'concurrency-saturated',
+      message: expect.stringContaining('held by foreground'),
+    });
+
+    releaseCall.resolve(undefined);
+    await expect(first).resolves.toBe('first');
+    expect(finalizedChainReadRegistryDepth(CHAIN_ID)).toBe(0);
+  });
+
+  it('rejects an unknown explicit owner instead of falling back to the default', async () => {
+    const server = await rpcHarness.start(successfulHandler());
+    expect(() =>
+      createStrictCurrentFinalizedEvmSnapshotScopeV1({
+        owner: 'not-an-owner' as never,
+        chainId: CHAIN_ID,
+        endpoints: [server.url],
+      }),
+    ).toThrow(/unknown owner/i);
+  });
+
+  it('releases the permit when the consumer throws', async () => {
+    const server = await rpcHarness.start(successfulHandler());
+    const scope = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      owner: 'w2-page',
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+    });
+    await expect(
+      scope(request(), async () => {
+        throw new Error('consumer exploded');
+      }),
+    ).rejects.toThrow('consumer exploded');
+    expect(finalizedChainReadRegistryDepth(CHAIN_ID)).toBe(0);
+    await expect(scope(request(), async () => 'after')).resolves.toBe('after');
+  });
+});

--- a/packages/chain/test/strict-finalized-snapshot-config.unit.test.ts
+++ b/packages/chain/test/strict-finalized-snapshot-config.unit.test.ts
@@ -109,6 +109,28 @@ describe('strict finalized snapshot config validation', () => {
     ).toThrow(/unknown or missing fields/);
   });
 
+  it('distinguishes an OMITTED owner from an explicitly present null/undefined', () => {
+    // `??` would have treated all three the same. Omission is the documented
+    // default; an explicit value is a caller assertion and must be a real owner.
+    expect(
+      snapshotStrictFinalizedSnapshotConfigV1({ chainId: CHAIN_ID, endpoints: [ENDPOINT] }),
+    ).toMatchObject({ owner: 'foreground' });
+    expect(() =>
+      snapshotStrictFinalizedSnapshotConfigV1({
+        chainId: CHAIN_ID,
+        endpoints: [ENDPOINT],
+        owner: null,
+      } as never),
+    ).toThrow(/unknown owner/i);
+    expect(() =>
+      snapshotStrictFinalizedSnapshotConfigV1({
+        chainId: CHAIN_ID,
+        endpoints: [ENDPOINT],
+        owner: undefined,
+      } as never),
+    ).toThrow(/unknown owner/i);
+  });
+
   it('accepts the ordinary plain-data shapes, with and without owner', () => {
     expect(
       snapshotStrictFinalizedSnapshotConfigV1({ chainId: CHAIN_ID, endpoints: [ENDPOINT] }),

--- a/packages/chain/test/strict-finalized-snapshot-config.unit.test.ts
+++ b/packages/chain/test/strict-finalized-snapshot-config.unit.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ChainIdV1 } from '@origintrail-official/dkg-core';
+
+import {
+  snapshotStrictCurrentFinalizedEvmConfigV1,
+  snapshotStrictFinalizedSnapshotConfigV1,
+} from '../src/strict-current-finalized-evm-config.js';
+
+const CHAIN_ID = '20430' as ChainIdV1;
+const ENDPOINT = 'https://rpc.example.test/';
+
+/**
+ * The snapshot wrapper must not weaken the strict plain-data config contract it
+ * wraps. The ordering is the contract: an accessor-backed field is rejected
+ * WITHOUT its getter ever running.
+ *
+ * This is a regression suite. An earlier revision destructured
+ * `{ owner, ...rest }` before validating, which both executed enumerable getters
+ * on the caller's object and converted them into plain data properties — so the
+ * descriptor check downstream saw a clean object and ACCEPTED a config the base
+ * validator rejects untouched.
+ */
+function accessorBackedConfig(field: 'chainId' | 'endpoints', counter: { runs: number }) {
+  const config: Record<string, unknown> = {
+    chainId: CHAIN_ID,
+    endpoints: [ENDPOINT],
+  };
+  const value = config[field];
+  delete config[field];
+  Object.defineProperty(config, field, {
+    enumerable: true,
+    configurable: true,
+    get() {
+      counter.runs += 1;
+      return value;
+    },
+  });
+  return config;
+}
+
+describe('strict finalized snapshot config validation', () => {
+  it.each(['chainId', 'endpoints'] as const)(
+    'rejects an accessor-backed %s without invoking its getter',
+    (field) => {
+      const counter = { runs: 0 };
+      expect(() =>
+        snapshotStrictFinalizedSnapshotConfigV1(
+          accessorBackedConfig(field, counter) as never,
+        ),
+      ).toThrow(/enumerable data properties/);
+      // The count is the whole point. A wrapper that rejects only AFTER reading
+      // has already run attacker-supplied code.
+      expect(counter.runs).toBe(0);
+    },
+  );
+
+  it('matches the base validator exactly on accessor inputs', () => {
+    // Same input, same verdict, same zero reads — the wrapper must not be a
+    // weaker door into the same room.
+    const wrapped = { runs: 0 };
+    const base = { runs: 0 };
+    const wrappedError = (() => {
+      try {
+        snapshotStrictFinalizedSnapshotConfigV1(accessorBackedConfig('chainId', wrapped) as never);
+        return null;
+      } catch (error) {
+        return (error as Error).message;
+      }
+    })();
+    const baseError = (() => {
+      try {
+        snapshotStrictCurrentFinalizedEvmConfigV1(accessorBackedConfig('chainId', base) as never);
+        return null;
+      } catch (error) {
+        return (error as Error).message;
+      }
+    })();
+    expect(wrappedError).not.toBeNull();
+    expect(wrappedError).toBe(baseError);
+    expect(wrapped.runs).toBe(0);
+    expect(base.runs).toBe(0);
+  });
+
+  it('rejects an accessor-backed owner too', () => {
+    let runs = 0;
+    const config: Record<string, unknown> = { chainId: CHAIN_ID, endpoints: [ENDPOINT] };
+    Object.defineProperty(config, 'owner', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        runs += 1;
+        return 'rfc64';
+      },
+    });
+    expect(() => snapshotStrictFinalizedSnapshotConfigV1(config as never)).toThrow(
+      /enumerable data properties/,
+    );
+    expect(runs).toBe(0);
+  });
+
+  it('rejects unknown fields rather than silently dropping them', () => {
+    expect(() =>
+      snapshotStrictFinalizedSnapshotConfigV1({
+        chainId: CHAIN_ID,
+        endpoints: [ENDPOINT],
+        surprise: 1,
+      } as never),
+    ).toThrow(/unknown or missing fields/);
+  });
+
+  it('accepts the ordinary plain-data shapes, with and without owner', () => {
+    expect(
+      snapshotStrictFinalizedSnapshotConfigV1({ chainId: CHAIN_ID, endpoints: [ENDPOINT] }),
+    ).toMatchObject({ chainId: CHAIN_ID, owner: 'foreground', blockReferenceProfile: 'eip1898' });
+    expect(
+      snapshotStrictFinalizedSnapshotConfigV1({
+        chainId: CHAIN_ID,
+        endpoints: [ENDPOINT],
+        owner: 'w2-page',
+      }),
+    ).toMatchObject({ owner: 'w2-page' });
+  });
+
+  it('passes an explicit blockReferenceProfile through, and omits it when absent', () => {
+    // The base allowlist rejects an explicit `undefined` key, so the rebuild must
+    // add the key only when the caller actually set it.
+    expect(
+      snapshotStrictFinalizedSnapshotConfigV1({
+        chainId: CHAIN_ID,
+        endpoints: [ENDPOINT],
+        blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+      }),
+    ).toMatchObject({ blockReferenceProfile: 'trusted-block-number-hash-sandwich' });
+    expect(
+      snapshotStrictFinalizedSnapshotConfigV1({ chainId: CHAIN_ID, endpoints: [ENDPOINT] }),
+    ).toMatchObject({ blockReferenceProfile: 'eip1898' });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -399,3 +399,4 @@ export {
 export * from './catalog-seal-binding.js';
 export * from './transferred-catalog-bundle.js';
 export * from './vm-update-convergence.js';
+export * from './ka-ual-identity.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -398,3 +398,4 @@ export {
 } from './canonical-graph-scoped-author-seal.js';
 export * from './catalog-seal-binding.js';
 export * from './transferred-catalog-bundle.js';
+export * from './vm-update-convergence.js';

--- a/packages/core/src/ka-ual-identity.ts
+++ b/packages/core/src/ka-ual-identity.ts
@@ -1,0 +1,94 @@
+/**
+ * The single owner of the legacy/rootless Knowledge Asset UAL rule.
+ *
+ * V10 rootless KA ids pack the author address into the high 160 bits and the
+ * per-author KA number into the low 96 bits, so their canonical identity is
+ * author/number. Legacy sequential ids have no author bits and keep the older
+ * storage-contract/id form. Which branch applies is decided by `kaId >> 96n`.
+ *
+ * This lives in `core` because it is the lowest package that every consumer can
+ * reach: `agent → chain → core`. An earlier revision restated the rule inside
+ * `vm-update-convergence.ts` and guarded the copy with a cross-package parity
+ * test. That test does detect drift — but only after it exists, and it left two
+ * production implementations of one identity rule to keep in step. The rule now
+ * has one home and `buildReconciledKnowledgeAssetUal` delegates to it.
+ */
+import { parseCanonicalDecimalU256 } from './sync-wire-scalars.js';
+
+/** `(1 << 96) - 1` — the rootless KA-number field width. */
+export const MAX_ROOTLESS_KA_NUMBER_V1 = (1n << 96n) - 1n;
+/** Upper bound of the on-chain id domain. */
+export const MAX_KA_ID_V1 = (1n << 256n) - 1n;
+
+const EVM_ADDRESS_ANY_CASE = /^0x[0-9a-fA-F]{40}$/;
+const CANONICAL_UNSIGNED_DECIMAL = /^(?:0|[1-9][0-9]*)$/;
+
+export class KaUalIdentityError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'KaUalIdentityError';
+  }
+}
+
+/**
+ * A canonical UAL chain id: optional lowercase namespace, canonical decimal tail.
+ *
+ * NOT the numeric EVM chain id. `ChainAdapter.chainId` is namespaced —
+ * `base:84532`, `otp:20430`, `evm:31337` — and its own doc comment says it is
+ * "not directly parseable with `BigInt()`".
+ */
+export function assertCanonicalUalChainIdV1(value: unknown, label = 'chainId'): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 256) {
+    throw new KaUalIdentityError(`${label} must be a nonempty string`);
+  }
+  const separator = value.lastIndexOf(':');
+  const namespace = separator === -1 ? '' : value.slice(0, separator);
+  const decimal = separator === -1 ? value : value.slice(separator + 1);
+  if (separator !== -1 && !/^[a-z][a-z0-9-]*(?::[a-z0-9-]+)*$/.test(namespace)) {
+    throw new KaUalIdentityError(`${label} namespace must be lowercase alphanumeric`);
+  }
+  if (!CANONICAL_UNSIGNED_DECIMAL.test(decimal)) {
+    throw new KaUalIdentityError(`${label} must end in a canonical decimal chain number`);
+  }
+  try {
+    parseCanonicalDecimalU256(decimal, label);
+  } catch (cause) {
+    throw new KaUalIdentityError(`${label} is not a canonical u256 chain number`, { cause });
+  }
+  return value;
+}
+
+/**
+ * Build the canonical UAL for a resolved on-chain KA id.
+ *
+ * The address is **normalized to lowercase**, not rejected for case. That is
+ * deliberate and is what a builder should do: the output is canonical either
+ * way, and the sole production caller passes an address straight from
+ * `getDKGKnowledgeAssetsAddress()`, which returns the checksummed form. The
+ * strictness belongs on the PARSE side — accepting a mixed-case address when
+ * turning a UAL back into candidates would make two spellings denote one KA —
+ * and that is enforced separately in `vm-update-convergence.ts`.
+ *
+ * Genuinely invalid input still fails: a non-address string, a negative id, an
+ * id above uint256, or a noncanonical chain id.
+ */
+export function buildKnowledgeAssetUalFromOnChainIdV1(
+  chainId: string,
+  legacyStorageAddress: string,
+  kaId: bigint,
+): string {
+  const canonicalChain = assertCanonicalUalChainIdV1(chainId, 'ual chainId');
+  if (typeof legacyStorageAddress !== 'string' || !EVM_ADDRESS_ANY_CASE.test(legacyStorageAddress)) {
+    throw new KaUalIdentityError('ual storage address must be a 20-byte 0x EVM address');
+  }
+  if (typeof kaId !== 'bigint') throw new KaUalIdentityError('kaId must be a bigint');
+  if (kaId < 0n) throw new KaUalIdentityError('kaId must not be negative');
+  if (kaId > MAX_KA_ID_V1) throw new KaUalIdentityError('kaId exceeds uint256');
+
+  if (kaId >> 96n === 0n) {
+    return `did:dkg:${canonicalChain}/${legacyStorageAddress.toLowerCase()}/${kaId.toString()}`;
+  }
+  const authorAddress = `0x${(kaId >> 96n).toString(16).padStart(40, '0')}`;
+  const kaNumber = kaId & MAX_ROOTLESS_KA_NUMBER_V1;
+  return `did:dkg:${canonicalChain}/${authorAddress}/${kaNumber.toString()}`;
+}

--- a/packages/core/src/vm-update-convergence.ts
+++ b/packages/core/src/vm-update-convergence.ts
@@ -23,17 +23,35 @@ import { sha256 } from '@noble/hashes/sha2.js';
 
 import {
   assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertCanonicalHexBytes,
   parseCanonicalDecimalU256,
   type Digest32V1,
   type EvmAddressV1,
 } from './sync-wire-scalars.js';
 
-const EVM_ADDRESS = /^0x[0-9a-f]{40}$/;
-const CANONICAL_DIGEST_32 = /^0x[0-9a-f]{64}$/;
-const CANONICAL_UNSIGNED_DECIMAL = /^(?:0|[1-9][0-9]*)$/;
-const LOWER_HEX_BYTES = /^0x(?:[0-9a-f]{2})*$/;
+/**
+ * `sync-wire-scalars.ts` is the single source of truth for canonical EVM
+ * addresses, digests, unsigned decimals and hex bytes. This module deliberately
+ * holds NO copies of those regexes: a second transcription drifts silently, and
+ * the drift would be two different canonical-scalar policies inside one package.
+ * Everything below adapts those assertions into W2's typed error codes.
+ *
+ * The one constant that stays is the zero address, and only because W2 must
+ * ACCEPT it for `author` where every shipped helper rejects it — see
+ * {@link canonicalNullableAuthorAddress}. It is a literal, not a validator.
+ */
 const ZERO_EVM_ADDRESS = `0x${'00'.repeat(20)}`;
 const UTF8 = new TextEncoder();
+
+/** Run a shipped canonical-scalar assertion, re-raised as a W2 error code. */
+function adapt<T>(label: string, assertion: () => T, code: VmUpdateErrorCodeV1 = 'noncanonical-scalar'): T {
+  try {
+    return assertion();
+  } catch (cause) {
+    fail(code, `${label} is not canonical: ${(cause as Error)?.message ?? String(cause)}`, cause);
+  }
+}
 
 /** `(1 << 96) - 1` — the rootless KA-number field width. */
 export const MAX_ROOTLESS_KA_NUMBER = (1n << 96n) - 1n;
@@ -41,6 +59,13 @@ export const MAX_ROOTLESS_KA_NUMBER = (1n << 96n) - 1n;
 const MAX_SCALAR_BYTES = 4_096;
 /** Bound on one page's event count, mirroring the transport's own page bound. */
 export const MAX_UPDATE_PAGE_EVENTS = 4_096;
+/**
+ * A valid EVM log carries 0..4 topics (LOG0..LOG4). The page-count bound alone
+ * does not constrain this: ONE log with a million topics passes it, then
+ * allocates and hashes a million entries. Since these logs come straight off an
+ * untrusted RPC response, the per-log bound has to be here.
+ */
+export const MAX_LOG_TOPICS = 4;
 
 // ── closed outcome vocabularies ───────────────────────────────────────────
 // Closed unions, exported as value tuples so a consumer can iterate them and a
@@ -138,11 +163,10 @@ function boundedString(value: unknown, label: string): string {
 /** Canonical lowercase 20-byte address; the zero address is REJECTED. */
 export function canonicalEvmAddress(value: unknown, label = 'address'): EvmAddressV1 {
   const text = boundedString(value, label);
-  if (!EVM_ADDRESS.test(text)) {
-    fail('noncanonical-scalar', `${label} must be a lowercase 20-byte 0x EVM address`);
-  }
-  if (text === ZERO_EVM_ADDRESS) fail('noncanonical-scalar', `${label} must not be the zero address`);
-  return text as EvmAddressV1;
+  return adapt(label, () => {
+    assertCanonicalEvmAddress(text, label);
+    return text;
+  });
 }
 
 /**
@@ -165,18 +189,19 @@ export function canonicalNullableAuthorAddress(
 ): EvmAddressV1 | null {
   if (value === null) return null;
   const text = boundedString(value, label);
-  if (!EVM_ADDRESS.test(text)) {
-    fail('noncanonical-scalar', `${label} must be a lowercase 20-byte 0x EVM address or null`);
-  }
-  return text === ZERO_EVM_ADDRESS ? null : (text as EvmAddressV1);
+  // Only the CANONICAL zero spelling short-circuits. A noncanonical zero such as
+  // `0X00…` misses this equality and falls through to the shipped assertion,
+  // which rejects it — so permitting zero does not also permit sloppy zero.
+  if (text === ZERO_EVM_ADDRESS) return null;
+  return canonicalEvmAddress(text, label);
 }
 
 export function canonicalDigest32(value: unknown, label = 'digest'): Digest32V1 {
   const text = boundedString(value, label);
-  if (!CANONICAL_DIGEST_32.test(text)) {
-    fail('noncanonical-scalar', `${label} must be a lowercase 32-byte 0x digest`);
-  }
-  return text as Digest32V1;
+  return adapt(label, () => {
+    assertCanonicalDigest(text, label);
+    return text;
+  });
 }
 
 /**
@@ -202,20 +227,17 @@ export function canonicalUalChainId(value: unknown, label = 'chainId'): string {
   if (separator !== -1 && !/^[a-z][a-z0-9-]*(?::[a-z0-9-]+)*$/.test(namespace)) {
     fail('noncanonical-scalar', `${label} namespace must be lowercase alphanumeric`);
   }
-  if (!CANONICAL_UNSIGNED_DECIMAL.test(decimal)) {
-    fail('noncanonical-scalar', `${label} must end in a canonical decimal chain number`);
-  }
-  parseCanonicalDecimalU256(decimal, label);
+  // `parseCanonicalDecimalU256` already rejects leading-zero aliases and
+  // out-of-range values; restating that rule here as a regex is the drift this
+  // module refuses to introduce.
+  adapt(label, () => parseCanonicalDecimalU256(decimal, label));
   return text;
 }
 
 /** A canonical unsigned decimal with no leading-zero alias. */
 export function canonicalUnsignedDecimal(value: unknown, label = 'value'): bigint {
   const text = boundedString(value, label);
-  if (!CANONICAL_UNSIGNED_DECIMAL.test(text)) {
-    fail('noncanonical-scalar', `${label} must be a canonical unsigned decimal`);
-  }
-  return parseCanonicalDecimalU256(text, label);
+  return adapt(label, () => parseCanonicalDecimalU256(text, label));
 }
 
 /** A non-negative safe integer; block numbers and log indices are numbers on this wire. */
@@ -443,7 +465,16 @@ export function orderedLogCommitment(logs: readonly RawLogV1[]): Digest32V1 {
     }
     previous = position;
     const data = boundedString(log.data, 'log.data');
-    if (!LOWER_HEX_BYTES.test(data)) fail('noncanonical-scalar', 'log.data must be lowercase 0x bytes');
+    adapt('log.data', () => assertCanonicalHexBytes(data, 'log.data', 0, MAX_SCALAR_BYTES));
+    // Bound BEFORE expanding: `topics.map` on an unbounded array is the
+    // allocation this guard exists to prevent, so it cannot come after.
+    if (!Array.isArray(log.topics)) fail('page-malformed', 'log.topics must be an array');
+    if (log.topics.length > MAX_LOG_TOPICS) {
+      fail(
+        'page-malformed',
+        `log carries ${log.topics.length} topics, above the EVM bound of ${MAX_LOG_TOPICS}`,
+      );
+    }
     parts.push(
       canonicalEvmAddress(log.address, 'log.address'),
       String(log.topics.length),
@@ -546,6 +577,23 @@ export function canonicalPageProof(
   // endpoint claimed.
   if (through.blockNumber > finalizedAnchor.blockNumber) {
     fail('page-malformed', 'proof.through is above the finalized anchor');
+  }
+  // One block cannot have two hashes. A single-block page has `from === through`,
+  // and a page that reaches the anchor has `through === finalizedAnchor`; without
+  // this, such a proof could claim three different hashes at one height and still
+  // be marked corroborated. Empty and sparse pages are exactly where no log
+  // position would expose the contradiction.
+  for (const [left, right] of [
+    [from, through],
+    [from, finalizedAnchor],
+    [through, finalizedAnchor],
+  ] as const) {
+    if (left.blockNumber === right.blockNumber && left.blockHash !== right.blockHash) {
+      fail(
+        'page-malformed',
+        `proof references block ${left.blockNumber} with two different hashes`,
+      );
+    }
   }
   return Object.freeze({
     assurance: input.assurance,
@@ -708,13 +756,18 @@ export function canonicalScopedKaCandidatesFromVerifiedUal(
   // Round-trip, not `toLowerCase()`: accepting a mixed-case address here and
   // normalizing it would make two distinct UAL spellings denote one KA, so a
   // caller could address the same fence row two ways.
-  if (!EVM_ADDRESS.test(addressSegment)) {
-    fail('noncanonical-ual', 'ual address segment is not a lowercase 20-byte 0x address');
-  }
-  if (!CANONICAL_UNSIGNED_DECIMAL.test(numberSegment)) {
-    fail('noncanonical-ual', 'ual number segment is not a canonical decimal (leading-zero alias?)');
-  }
-  const number = BigInt(numberSegment);
+  adapt(
+    'ual address segment',
+    () => assertCanonicalEvmAddress(addressSegment, 'ual address segment'),
+    'noncanonical-ual',
+  );
+  // The shipped decimal parser owns the leading-zero-alias rule; restating it
+  // here would be a second canonical-scalar policy.
+  const number = adapt(
+    'ual number segment',
+    () => parseCanonicalDecimalU256(numberSegment, 'ual number segment'),
+    'noncanonical-ual',
+  );
   if (number > MAX_ROOTLESS_KA_NUMBER) {
     fail('ka-number-overflow', 'ual number segment exceeds the uint96 KA-number field');
   }

--- a/packages/core/src/vm-update-convergence.ts
+++ b/packages/core/src/vm-update-convergence.ts
@@ -179,6 +179,36 @@ export function canonicalDigest32(value: unknown, label = 'digest'): Digest32V1 
   return text as Digest32V1;
 }
 
+/**
+ * A canonical UAL chain id.
+ *
+ * This is NOT the numeric EVM chain id. `ChainAdapter.chainId` is **namespaced**
+ * — `base:84532`, `otp:20430`, `evm:31337` — and its own doc comment says it is
+ * "not directly parseable with `BigInt()`"; `getEvmChainId()` is the numeric
+ * one. UALs are built from the namespaced form
+ * (`chain-adapter.ts:960,1534-1540`), so a scope validated as a bare decimal
+ * would reject every real mainnet and testnet UAL while passing a test suite
+ * that only used `31337`.
+ *
+ * Accepted: an optional lowercase namespace, then a canonical decimal with no
+ * leading-zero alias. The decimal tail is canonicalized so `base:084532` cannot
+ * become a second spelling of one chain.
+ */
+export function canonicalUalChainId(value: unknown, label = 'chainId'): string {
+  const text = boundedString(value, label);
+  const separator = text.lastIndexOf(':');
+  const namespace = separator === -1 ? '' : text.slice(0, separator);
+  const decimal = separator === -1 ? text : text.slice(separator + 1);
+  if (separator !== -1 && !/^[a-z][a-z0-9-]*(?::[a-z0-9-]+)*$/.test(namespace)) {
+    fail('noncanonical-scalar', `${label} namespace must be lowercase alphanumeric`);
+  }
+  if (!CANONICAL_UNSIGNED_DECIMAL.test(decimal)) {
+    fail('noncanonical-scalar', `${label} must end in a canonical decimal chain number`);
+  }
+  parseCanonicalDecimalU256(decimal, label);
+  return text;
+}
+
 /** A canonical unsigned decimal with no leading-zero alias. */
 export function canonicalUnsignedDecimal(value: unknown, label = 'value'): bigint {
   const text = boundedString(value, label);
@@ -251,7 +281,7 @@ function lengthPrefixed(parts: readonly string[]): Uint8Array {
  * not include `deploymentBlock` — see the module header.
  */
 export function deriveVmUpdateScopeId(identity: VmUpdateScopeIdentityV1): string {
-  const chainId = canonicalUnsignedDecimal(identity.chainId, 'scope.chainId').toString();
+  const chainId = canonicalUalChainId(identity.chainId, 'scope.chainId');
   const deploymentId = boundedString(identity.deploymentId, 'scope.deploymentId');
   if (deploymentId.length === 0) fail('noncanonical-scalar', 'scope.deploymentId must not be empty');
   const kaStorage = canonicalEvmAddress(
@@ -271,7 +301,7 @@ export function deriveVmUpdateScopeId(identity: VmUpdateScopeIdentityV1): string
 /** Canonicalize a scope and recompute its `scopeId`; a supplied mismatch fails closed. */
 export function canonicalVmUpdateScope(input: VmUpdateScopeV1): Readonly<VmUpdateScopeV1> {
   const identity: VmUpdateScopeIdentityV1 = {
-    chainId: canonicalUnsignedDecimal(input.chainId, 'scope.chainId').toString(),
+    chainId: canonicalUalChainId(input.chainId, 'scope.chainId'),
     deploymentId: boundedString(input.deploymentId, 'scope.deploymentId'),
     knowledgeAssetStorageAddress: canonicalEvmAddress(
       input.knowledgeAssetStorageAddress,

--- a/packages/core/src/vm-update-convergence.ts
+++ b/packages/core/src/vm-update-convergence.ts
@@ -22,6 +22,12 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import {
+  MAX_KA_ID_V1,
+  MAX_ROOTLESS_KA_NUMBER_V1,
+  assertCanonicalUalChainIdV1,
+  buildKnowledgeAssetUalFromOnChainIdV1,
+} from './ka-ual-identity.js';
+import {
   assertCanonicalDigest,
   assertCanonicalEvmAddress,
   assertCanonicalHexBytes,
@@ -53,10 +59,9 @@ function adapt<T>(label: string, assertion: () => T, code: VmUpdateErrorCodeV1 =
   }
 }
 
-/** `(1 << 96) - 1` — the rootless KA-number field width. */
-export const MAX_ROOTLESS_KA_NUMBER = (1n << 96n) - 1n;
-/** Upper bound of the on-chain id domain. */
-const MAX_UINT256 = (1n << 256n) - 1n;
+/** `(1 << 96) - 1` — the rootless KA-number field width. Re-exported from the owner. */
+export const MAX_ROOTLESS_KA_NUMBER = MAX_ROOTLESS_KA_NUMBER_V1;
+const MAX_UINT256 = MAX_KA_ID_V1;
 /**
  * Bound on an IDENTITY scalar — chain id, deployment id, UAL, origin.
  *
@@ -290,17 +295,9 @@ export function canonicalDigest32(value: unknown, label = 'digest'): Digest32V1 
  */
 export function canonicalUalChainId(value: unknown, label = 'chainId'): string {
   const text = boundedString(value, label);
-  const separator = text.lastIndexOf(':');
-  const namespace = separator === -1 ? '' : text.slice(0, separator);
-  const decimal = separator === -1 ? text : text.slice(separator + 1);
-  if (separator !== -1 && !/^[a-z][a-z0-9-]*(?::[a-z0-9-]+)*$/.test(namespace)) {
-    fail('noncanonical-scalar', `${label} namespace must be lowercase alphanumeric`);
-  }
-  // `parseCanonicalDecimalU256` already rejects leading-zero aliases and
-  // out-of-range values; restating that rule here as a regex is the drift this
-  // module refuses to introduce.
-  adapt(label, () => parseCanonicalDecimalU256(decimal, label));
-  return text;
+  // The rule itself is owned by `ka-ual-identity.ts`; this adapts its error into
+  // W2's typed code rather than restating the rule.
+  return adapt(label, () => assertCanonicalUalChainIdV1(text, label));
 }
 
 /** A canonical unsigned decimal with no leading-zero alias. */
@@ -831,36 +828,29 @@ export interface CanonicalScopedKaCandidateSetV1 {
 const UAL_PATTERN = /^did:dkg:([^/]+)\/([^/]+)\/([^/]+)$/;
 
 /**
- * Build the canonical UAL for a resolved on-chain KA id.
+ * Build the canonical UAL for a resolved on-chain KA id, as a W2-typed wrapper.
  *
- * Mirrors `buildReconciledKnowledgeAssetUal` in `packages/agent/src/ka-identity.ts`.
- * It cannot import it — `agent` depends on `core`, not the reverse — so
- * `packages/agent/test/w2-ual-parity.test.ts` asserts the two produce
- * byte-identical output across the legacy/rootless boundary. That parity test is
- * the external anchor: without it this is a transcription that can drift
- * silently, and the drift would make W2's fence select the wrong KA.
+ * The rule has ONE owner: `ka-ual-identity.ts`. `buildReconciledKnowledgeAssetUal`
+ * in the agent package delegates to the same function, so there is no second
+ * production implementation to keep in step — an earlier revision restated the
+ * rule here and guarded the copy with a cross-package parity test, which detects
+ * drift only after it exists.
  */
 export function buildScopedKnowledgeAssetUal(
   chainId: string,
   legacyStorageAddress: string,
   kaId: bigint,
 ): string {
-  // Validate before formatting. An exported builder that accepts a negative
-  // kaId, a value above uint256, a noncanonical chain id, or an arbitrary
-  // address string emits a syntactically well-formed UAL that denotes nothing —
-  // and silently lowercasing the address would make two spellings one identity.
-  const canonicalChain = canonicalUalChainId(chainId, 'ual chainId');
-  const canonicalStorage = canonicalEvmAddress(legacyStorageAddress, 'ual storage address');
-  if (typeof kaId !== 'bigint') fail('noncanonical-scalar', 'kaId must be a bigint');
-  if (kaId < 0n) fail('noncanonical-scalar', 'kaId must not be negative');
-  if (kaId > MAX_UINT256) fail('ka-number-overflow', 'kaId exceeds uint256');
-
-  if (kaId >> 96n === 0n) {
-    return `did:dkg:${canonicalChain}/${canonicalStorage}/${kaId.toString()}`;
+  // Delegates: `ka-ual-identity.ts` is the single owner of this rule, and
+  // `buildReconciledKnowledgeAssetUal` in the agent package delegates to the
+  // same function. This wrapper only re-raises as a W2 typed error.
+  try {
+    return buildKnowledgeAssetUalFromOnChainIdV1(chainId, legacyStorageAddress, kaId);
+  } catch (cause) {
+    const message = (cause as Error)?.message ?? String(cause);
+    if (message.includes('exceeds uint256')) fail('ka-number-overflow', message, cause);
+    fail('noncanonical-scalar', message, cause);
   }
-  const agentAddress = `0x${(kaId >> 96n).toString(16).padStart(40, '0')}`;
-  const kaNumber = kaId & MAX_ROOTLESS_KA_NUMBER;
-  return `did:dkg:${canonicalChain}/${agentAddress}/${kaNumber.toString()}`;
 }
 
 /**

--- a/packages/core/src/vm-update-convergence.ts
+++ b/packages/core/src/vm-update-convergence.ts
@@ -1,0 +1,778 @@
+/**
+ * W2 — finalized update convergence: canonical value contracts.
+ *
+ * This module owns the package-neutral half of W2: scope identity, exact
+ * finalized-event identity, the ordered raw-log commitment, page-assurance
+ * proofs, the two-cursor model, the scoped KA candidate parser, and the closed
+ * outcome vocabularies. It deliberately holds no chain client, no store, and no
+ * I/O, so every rule below is testable without a node, an RPC endpoint, or a
+ * database.
+ *
+ * Two conventions are load-bearing and are asserted rather than assumed:
+ *
+ * 1. **`scopeId` is derived from the four IDENTITY fields only** — never from
+ *    `deploymentBlock`. The deployment anchor is scope *metadata*: proving a
+ *    lower anchor must trigger a revision reset and replay *within the same
+ *    scope*, which is impossible if lowering it silently mints a new scope id.
+ * 2. **Every public input is canonicalized and frozen before it is returned.**
+ *    W2's callers hand these values across `await` boundaries into SQLite
+ *    transactions; a caller that mutates a page proof after validation would
+ *    otherwise persist evidence that was never checked.
+ */
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  assertCanonicalDigest,
+  parseCanonicalDecimalU256,
+  type Digest32V1,
+  type EvmAddressV1,
+} from './sync-wire-scalars.js';
+
+const EVM_ADDRESS = /^0x[0-9a-f]{40}$/;
+const CANONICAL_DIGEST_32 = /^0x[0-9a-f]{64}$/;
+const CANONICAL_UNSIGNED_DECIMAL = /^(?:0|[1-9][0-9]*)$/;
+const LOWER_HEX_BYTES = /^0x(?:[0-9a-f]{2})*$/;
+const ZERO_EVM_ADDRESS = `0x${'00'.repeat(20)}`;
+const UTF8 = new TextEncoder();
+
+/** `(1 << 96) - 1` — the rootless KA-number field width. */
+export const MAX_ROOTLESS_KA_NUMBER = (1n << 96n) - 1n;
+/** Bound on any single canonicalized string this module will hash or persist. */
+const MAX_SCALAR_BYTES = 4_096;
+/** Bound on one page's event count, mirroring the transport's own page bound. */
+export const MAX_UPDATE_PAGE_EVENTS = 4_096;
+
+// ── closed outcome vocabularies ───────────────────────────────────────────
+// Closed unions, exported as value tuples so a consumer can iterate them and a
+// verifier can prove the runtime set matches the type. A bare `type` union is
+// invisible at runtime and cannot be checked for drift.
+
+export const UPDATE_PAGE_ASSURANCES = ['unattested', 'dual-origin-corroborated'] as const;
+export type UpdatePageAssuranceV1 = (typeof UPDATE_PAGE_ASSURANCES)[number];
+
+export const VM_UPDATE_SCAN_OUTCOMES = [
+  'corroborated',
+  'unattested',
+  'empty',
+  'no_new_range',
+  'rpc_error',
+  'malformed',
+  'reorg',
+  'corroboration_disagreement',
+  'oversized',
+  'unsupported',
+] as const;
+export type VmUpdateScanOutcomeV1 = (typeof VM_UPDATE_SCAN_OUTCOMES)[number];
+
+export const VM_UPDATE_EVENT_RESULTS = [
+  'newer',
+  'duplicate',
+  'discarded_resume',
+  'invalid',
+  'unsupported',
+  'unbound',
+  'promoted',
+] as const;
+export type VmUpdateEventResultV1 = (typeof VM_UPDATE_EVENT_RESULTS)[number];
+
+export const VM_UPDATE_COVERAGE_STATES = [
+  'bootstrapping',
+  'caught_up',
+  'reorg_recovering',
+  'unavailable',
+] as const;
+export type VmUpdateCoverageStateV1 = (typeof VM_UPDATE_COVERAGE_STATES)[number];
+
+export const VM_UPDATE_ERROR_CODES = [
+  'scope-drift',
+  'noncanonical-scalar',
+  'foreign-chain',
+  'noncanonical-ual',
+  'ka-number-overflow',
+  'ual-round-trip-failed',
+  'ambiguous-w2-identity',
+  'page-malformed',
+  'page-oversized',
+  'assurance-insufficient',
+  'origin-not-distinct',
+  'commitment-mismatch',
+  'cursor-regression',
+  'coverage-invalid',
+] as const;
+export type VmUpdateErrorCodeV1 = (typeof VM_UPDATE_ERROR_CODES)[number];
+
+/**
+ * A bounded, redactable failure.
+ *
+ * `detail` is capped and carries only values this module itself canonicalized —
+ * never raw RPC payloads, endpoint URLs, or peer identifiers. W2's structured
+ * logs emit `code` and `detail`; anything unbounded belongs in neither.
+ */
+export class VmUpdateConvergenceError extends Error {
+  readonly code: VmUpdateErrorCodeV1;
+  readonly detail: string;
+
+  constructor(code: VmUpdateErrorCodeV1, detail: string, options?: { cause?: unknown }) {
+    const bounded = detail.length > 200 ? `${detail.slice(0, 197)}...` : detail;
+    super(`vm-update: ${code}: ${bounded}`, options);
+    this.name = 'VmUpdateConvergenceError';
+    this.code = code;
+    this.detail = bounded;
+  }
+}
+
+function fail(code: VmUpdateErrorCodeV1, detail: string, cause?: unknown): never {
+  throw new VmUpdateConvergenceError(code, detail, cause === undefined ? undefined : { cause });
+}
+
+// ── canonical scalars ─────────────────────────────────────────────────────
+
+function boundedString(value: unknown, label: string): string {
+  if (typeof value !== 'string') fail('noncanonical-scalar', `${label} must be a string`);
+  if (value.length > MAX_SCALAR_BYTES || UTF8.encode(value).byteLength > MAX_SCALAR_BYTES) {
+    fail('noncanonical-scalar', `${label} exceeds ${MAX_SCALAR_BYTES} bytes`);
+  }
+  return value;
+}
+
+/** Canonical lowercase 20-byte address; the zero address is REJECTED. */
+export function canonicalEvmAddress(value: unknown, label = 'address'): EvmAddressV1 {
+  const text = boundedString(value, label);
+  if (!EVM_ADDRESS.test(text)) {
+    fail('noncanonical-scalar', `${label} must be a lowercase 20-byte 0x EVM address`);
+  }
+  if (text === ZERO_EVM_ADDRESS) fail('noncanonical-scalar', `${label} must not be the zero address`);
+  return text as EvmAddressV1;
+}
+
+/**
+ * The zero-permitting address canonicalizer, written for exactly one field.
+ *
+ * `author` is legally `address(0)` on the admin path: `updateKnowledgeAsset` is
+ * `onlyContracts`, which `HubDependent._checkHubContract()` also satisfies for
+ * the Hub OWNER EOA, so the lifecycle's `AuthorRequired()` guard is bypassable
+ * and `DKGKnowledgeAssets.sol` emits the zero author verbatim. Both shipped
+ * helpers — `assertCanonicalNonzeroEvmAddress` and `assertCanonicalEvmAddress` —
+ * reject zero, which would turn a legal on-chain event into an undecodable page.
+ * A decode error is not a `blockingMutation` and therefore never latches, so the
+ * indexer would wedge with no operator-visible reason.
+ *
+ * Use this for `author`. Use {@link canonicalEvmAddress} everywhere else.
+ */
+export function canonicalNullableAuthorAddress(
+  value: unknown,
+  label = 'author',
+): EvmAddressV1 | null {
+  if (value === null) return null;
+  const text = boundedString(value, label);
+  if (!EVM_ADDRESS.test(text)) {
+    fail('noncanonical-scalar', `${label} must be a lowercase 20-byte 0x EVM address or null`);
+  }
+  return text === ZERO_EVM_ADDRESS ? null : (text as EvmAddressV1);
+}
+
+export function canonicalDigest32(value: unknown, label = 'digest'): Digest32V1 {
+  const text = boundedString(value, label);
+  if (!CANONICAL_DIGEST_32.test(text)) {
+    fail('noncanonical-scalar', `${label} must be a lowercase 32-byte 0x digest`);
+  }
+  return text as Digest32V1;
+}
+
+/** A canonical unsigned decimal with no leading-zero alias. */
+export function canonicalUnsignedDecimal(value: unknown, label = 'value'): bigint {
+  const text = boundedString(value, label);
+  if (!CANONICAL_UNSIGNED_DECIMAL.test(text)) {
+    fail('noncanonical-scalar', `${label} must be a canonical unsigned decimal`);
+  }
+  return parseCanonicalDecimalU256(text, label);
+}
+
+/** A non-negative safe integer; block numbers and log indices are numbers on this wire. */
+export function canonicalBlockNumber(value: unknown, label = 'blockNumber'): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    fail('noncanonical-scalar', `${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+// ── scope identity ────────────────────────────────────────────────────────
+
+export interface VmUpdateScopeIdentityV1 {
+  chainId: string;
+  deploymentId: string;
+  knowledgeAssetStorageAddress: string;
+  contextGraphStorageAddress: string;
+}
+
+export type DeploymentBlockSourceV1 = 'shipped' | 'configured' | 'historical';
+
+export interface VmUpdateScopeV1 extends VmUpdateScopeIdentityV1 {
+  scopeId: string;
+  /** Scope METADATA. It never changes `scopeId` (see invariant 11). */
+  deploymentBlock: number;
+  deploymentBlockSource: DeploymentBlockSourceV1;
+  deploymentBlockHistoricallyValidated: boolean;
+}
+
+const SCOPE_ID_DOMAIN = UTF8.encode('dkg:w2:vm-update-scope:v1');
+
+function digestWithDomain(domain: Uint8Array, canonicalBytes: Uint8Array): Digest32V1 {
+  const hasher = sha256.create();
+  hasher.update(domain);
+  hasher.update(canonicalBytes);
+  let result = '0x';
+  for (const byte of hasher.digest()) result += byte.toString(16).padStart(2, '0');
+  assertCanonicalDigest(result, 'computed vm-update digest');
+  return result;
+}
+
+/**
+ * Length-prefixed join. Concatenating with a separator would let two distinct
+ * field tuples hash identically whenever a field can contain the separator.
+ */
+function lengthPrefixed(parts: readonly string[]): Uint8Array {
+  const encoded = parts.map((part) => UTF8.encode(part));
+  const total = encoded.reduce((sum, part) => sum + 4 + part.byteLength, 0);
+  const out = new Uint8Array(total);
+  const view = new DataView(out.buffer);
+  let offset = 0;
+  for (const part of encoded) {
+    view.setUint32(offset, part.byteLength, false);
+    offset += 4;
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+/**
+ * THE scope-id helper. It is not hand-concatenated at call sites, and it does
+ * not include `deploymentBlock` — see the module header.
+ */
+export function deriveVmUpdateScopeId(identity: VmUpdateScopeIdentityV1): string {
+  const chainId = canonicalUnsignedDecimal(identity.chainId, 'scope.chainId').toString();
+  const deploymentId = boundedString(identity.deploymentId, 'scope.deploymentId');
+  if (deploymentId.length === 0) fail('noncanonical-scalar', 'scope.deploymentId must not be empty');
+  const kaStorage = canonicalEvmAddress(
+    identity.knowledgeAssetStorageAddress,
+    'scope.knowledgeAssetStorageAddress',
+  );
+  const cgStorage = canonicalEvmAddress(
+    identity.contextGraphStorageAddress,
+    'scope.contextGraphStorageAddress',
+  );
+  return digestWithDomain(
+    SCOPE_ID_DOMAIN,
+    lengthPrefixed([chainId, deploymentId, kaStorage, cgStorage]),
+  );
+}
+
+/** Canonicalize a scope and recompute its `scopeId`; a supplied mismatch fails closed. */
+export function canonicalVmUpdateScope(input: VmUpdateScopeV1): Readonly<VmUpdateScopeV1> {
+  const identity: VmUpdateScopeIdentityV1 = {
+    chainId: canonicalUnsignedDecimal(input.chainId, 'scope.chainId').toString(),
+    deploymentId: boundedString(input.deploymentId, 'scope.deploymentId'),
+    knowledgeAssetStorageAddress: canonicalEvmAddress(
+      input.knowledgeAssetStorageAddress,
+      'scope.knowledgeAssetStorageAddress',
+    ),
+    contextGraphStorageAddress: canonicalEvmAddress(
+      input.contextGraphStorageAddress,
+      'scope.contextGraphStorageAddress',
+    ),
+  };
+  const scopeId = deriveVmUpdateScopeId(identity);
+  if (typeof input.scopeId === 'string' && input.scopeId !== scopeId) {
+    fail('scope-drift', 'supplied scopeId does not match its identity fields');
+  }
+  if (
+    input.deploymentBlockSource !== 'shipped' &&
+    input.deploymentBlockSource !== 'configured' &&
+    input.deploymentBlockSource !== 'historical'
+  ) {
+    fail('noncanonical-scalar', 'scope.deploymentBlockSource is not a known source');
+  }
+  if (typeof input.deploymentBlockHistoricallyValidated !== 'boolean') {
+    fail('noncanonical-scalar', 'scope.deploymentBlockHistoricallyValidated must be a boolean');
+  }
+  return Object.freeze({
+    ...identity,
+    scopeId,
+    deploymentBlock: canonicalBlockNumber(input.deploymentBlock, 'scope.deploymentBlock'),
+    deploymentBlockSource: input.deploymentBlockSource,
+    deploymentBlockHistoricallyValidated: input.deploymentBlockHistoricallyValidated,
+  });
+}
+
+// ── exact event identity ──────────────────────────────────────────────────
+
+export interface FinalizedEventPositionV1 {
+  blockNumber: number;
+  blockHash: string;
+  transactionHash: string;
+  transactionIndex: number;
+  logIndex: number;
+}
+
+export interface FinalizedKnowledgeAssetUpdateV1 extends FinalizedEventPositionV1 {
+  kind: 'lifecycle-update' | 'root-added';
+  kaId: string;
+  author: string | null;
+  merkleRoot: string;
+}
+
+export interface FinalizedUnsupportedKnowledgeAssetRootMutationV1 extends FinalizedEventPositionV1 {
+  kind: 'roots-replaced' | 'root-removed';
+  kaId: string;
+}
+
+function canonicalPosition(input: FinalizedEventPositionV1, label: string): FinalizedEventPositionV1 {
+  return {
+    blockNumber: canonicalBlockNumber(input.blockNumber, `${label}.blockNumber`),
+    blockHash: canonicalDigest32(input.blockHash, `${label}.blockHash`),
+    transactionHash: canonicalDigest32(input.transactionHash, `${label}.transactionHash`),
+    transactionIndex: canonicalBlockNumber(input.transactionIndex, `${label}.transactionIndex`),
+    logIndex: canonicalBlockNumber(input.logIndex, `${label}.logIndex`),
+  };
+}
+
+export function canonicalFinalizedUpdate(
+  input: FinalizedKnowledgeAssetUpdateV1,
+): Readonly<FinalizedKnowledgeAssetUpdateV1> {
+  if (input.kind !== 'lifecycle-update' && input.kind !== 'root-added') {
+    fail('page-malformed', 'update.kind is not a supported v1 repair event');
+  }
+  // `root-added` carries no author field at all; a non-null author on one is a
+  // decode bug, not a legal event, and silently dropping it would let a faulty
+  // decoder attribute an update to the wrong address.
+  if (input.kind === 'root-added' && input.author !== null) {
+    fail('page-malformed', 'root-added carries no author field; author must be null');
+  }
+  return Object.freeze({
+    kind: input.kind,
+    kaId: canonicalUnsignedDecimal(input.kaId, 'update.kaId').toString(),
+    author: canonicalNullableAuthorAddress(input.author, 'update.author'),
+    merkleRoot: canonicalDigest32(input.merkleRoot, 'update.merkleRoot'),
+    ...canonicalPosition(input, 'update'),
+  });
+}
+
+/**
+ * Lexicographic order over `(blockNumber, transactionIndex, logIndex)`.
+ *
+ * `transactionHash` is an identity/equality check, NOT an ordering dimension:
+ * ordering by it would make the reducer's resume point depend on hash bytes,
+ * which carry no chain order.
+ */
+export function compareEventPosition(a: FinalizedEventPositionV1, b: FinalizedEventPositionV1): number {
+  if (a.blockNumber !== b.blockNumber) return a.blockNumber < b.blockNumber ? -1 : 1;
+  if (a.transactionIndex !== b.transactionIndex) return a.transactionIndex < b.transactionIndex ? -1 : 1;
+  if (a.logIndex !== b.logIndex) return a.logIndex < b.logIndex ? -1 : 1;
+  return 0;
+}
+
+export function sameEventIdentity(a: FinalizedEventPositionV1, b: FinalizedEventPositionV1): boolean {
+  return (
+    compareEventPosition(a, b) === 0 &&
+    a.blockHash === b.blockHash &&
+    a.transactionHash === b.transactionHash
+  );
+}
+
+// ── ordered raw-log commitment ────────────────────────────────────────────
+
+export interface RawLogV1 {
+  address: string;
+  topics: readonly string[];
+  data: string;
+  position: FinalizedEventPositionV1;
+}
+
+const LOG_COMMITMENT_DOMAIN = UTF8.encode('dkg:w2:ordered-log-commitment:v1');
+
+/**
+ * Ordered commitment over address, topics, data AND exact identity.
+ *
+ * Committing to identity alone would let a faulty endpoint return altered
+ * payload bytes at the same positions and still corroborate — which is the
+ * exact failure the two-origin comparison exists to catch.
+ */
+export function orderedLogCommitment(logs: readonly RawLogV1[]): Digest32V1 {
+  if (logs.length > MAX_UPDATE_PAGE_EVENTS) {
+    fail('page-oversized', `page carries ${logs.length} logs, above ${MAX_UPDATE_PAGE_EVENTS}`);
+  }
+  const parts: string[] = [];
+  let previous: FinalizedEventPositionV1 | undefined;
+  for (const log of logs) {
+    const position = canonicalPosition(log.position, 'log');
+    if (previous !== undefined) {
+      const order = compareEventPosition(previous, position);
+      if (order > 0) fail('page-malformed', 'logs are not in ascending chain order');
+      if (order === 0) fail('page-malformed', 'two logs occupy one ordering position');
+    }
+    previous = position;
+    const data = boundedString(log.data, 'log.data');
+    if (!LOWER_HEX_BYTES.test(data)) fail('noncanonical-scalar', 'log.data must be lowercase 0x bytes');
+    parts.push(
+      canonicalEvmAddress(log.address, 'log.address'),
+      String(log.topics.length),
+      ...log.topics.map((topic, index) => canonicalDigest32(topic, `log.topics[${index}]`)),
+      data,
+      String(position.blockNumber),
+      position.blockHash,
+      position.transactionHash,
+      String(position.transactionIndex),
+      String(position.logIndex),
+    );
+  }
+  return digestWithDomain(LOG_COMMITMENT_DOMAIN, lengthPrefixed(parts));
+}
+
+// ── page assurance proof ──────────────────────────────────────────────────
+
+export interface BlockRefV1 {
+  blockNumber: number;
+  blockHash: string;
+}
+
+export interface FinalizedUpdatePageProofV1 {
+  assurance: UpdatePageAssuranceV1;
+  normalizedOrigins: readonly string[];
+  from: BlockRefV1;
+  through: BlockRefV1;
+  finalizedAnchor: BlockRefV1;
+  orderedLogCommitment: string;
+}
+
+function canonicalBlockRef(input: BlockRefV1, label: string): Readonly<BlockRefV1> {
+  return Object.freeze({
+    blockNumber: canonicalBlockNumber(input.blockNumber, `${label}.blockNumber`),
+    blockHash: canonicalDigest32(input.blockHash, `${label}.blockHash`),
+  });
+}
+
+/**
+ * Normalize an endpoint origin for the distinctness test.
+ *
+ * Distinctness is by ORIGIN, not by URL: two URLs differing only in path or
+ * query are one provider and corroborate nothing. The normalized form is
+ * lowercase `scheme://host:port` with no credentials, path, query, or fragment,
+ * so a credentialed and an uncredentialed URL for one host collapse together
+ * rather than counting as two origins.
+ */
+export function normalizeEndpointOrigin(value: unknown, label = 'origin'): string {
+  const text = boundedString(value, label);
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch (cause) {
+    fail('origin-not-distinct', `${label} is not a valid absolute URL`, cause);
+  }
+  const port = url.port === '' ? '' : `:${url.port}`;
+  return `${url.protocol.toLowerCase()}//${url.hostname.toLowerCase()}${port}`;
+}
+
+/**
+ * Validate a page proof.
+ *
+ * `dual-origin-corroborated` requires exactly two DISTINCT normalized origins.
+ * One origin, or two spellings of one origin, is `unattested` — it may move
+ * observation but never authorizes the reducer, `caught-up`, target resolution,
+ * or W2b.
+ */
+export function canonicalPageProof(
+  input: FinalizedUpdatePageProofV1,
+): Readonly<FinalizedUpdatePageProofV1> {
+  if (input.assurance !== 'unattested' && input.assurance !== 'dual-origin-corroborated') {
+    fail('assurance-insufficient', 'proof.assurance is not a known assurance level');
+  }
+  if (!Array.isArray(input.normalizedOrigins) || input.normalizedOrigins.length === 0) {
+    fail('origin-not-distinct', 'proof.normalizedOrigins must carry at least one origin');
+  }
+  const origins = input.normalizedOrigins.map((origin, index) =>
+    normalizeEndpointOrigin(origin, `proof.normalizedOrigins[${index}]`),
+  );
+  const distinct = new Set(origins);
+  if (distinct.size !== origins.length) {
+    fail('origin-not-distinct', 'proof.normalizedOrigins repeats one normalized origin');
+  }
+  if (input.assurance === 'dual-origin-corroborated' && distinct.size !== 2) {
+    fail(
+      'origin-not-distinct',
+      `dual-origin-corroborated requires exactly two distinct origins, got ${distinct.size}`,
+    );
+  }
+  if (input.assurance === 'unattested' && distinct.size > 2) {
+    fail('origin-not-distinct', 'a proof carries at most two origins');
+  }
+  const from = canonicalBlockRef(input.from, 'proof.from');
+  const through = canonicalBlockRef(input.through, 'proof.through');
+  const finalizedAnchor = canonicalBlockRef(input.finalizedAnchor, 'proof.finalizedAnchor');
+  if (through.blockNumber < from.blockNumber) {
+    fail('page-malformed', 'proof.through is below proof.from');
+  }
+  // A page above the finalized anchor is not finalized evidence, whatever the
+  // endpoint claimed.
+  if (through.blockNumber > finalizedAnchor.blockNumber) {
+    fail('page-malformed', 'proof.through is above the finalized anchor');
+  }
+  return Object.freeze({
+    assurance: input.assurance,
+    normalizedOrigins: Object.freeze([...origins]),
+    from,
+    through,
+    finalizedAnchor,
+    orderedLogCommitment: canonicalDigest32(
+      input.orderedLogCommitment,
+      'proof.orderedLogCommitment',
+    ),
+  });
+}
+
+/** Only a corroborated page may move authoritative coverage or feed the reducer. */
+export function isAuthoritativePage(proof: FinalizedUpdatePageProofV1): boolean {
+  return proof.assurance === 'dual-origin-corroborated';
+}
+
+// ── two-cursor model ──────────────────────────────────────────────────────
+
+export interface UnattestedObservationV1 extends BlockRefV1 {
+  normalizedOrigin: string;
+}
+
+export interface UpdateCoverageCursorV1 {
+  scannedThroughUnattested?: UnattestedObservationV1;
+  coveredThrough: null | BlockRefV1;
+  resumeAfter?: FinalizedEventPositionV1;
+}
+
+export function canonicalCoverageCursor(
+  input: UpdateCoverageCursorV1,
+): Readonly<UpdateCoverageCursorV1> {
+  const coveredThrough =
+    input.coveredThrough === null || input.coveredThrough === undefined
+      ? null
+      : canonicalBlockRef(input.coveredThrough, 'cursor.coveredThrough');
+  const resumeAfter =
+    input.resumeAfter === undefined
+      ? undefined
+      : Object.freeze(canonicalPosition(input.resumeAfter, 'cursor.resumeAfter'));
+  const scanned =
+    input.scannedThroughUnattested === undefined
+      ? undefined
+      : Object.freeze({
+          ...canonicalBlockRef(input.scannedThroughUnattested, 'cursor.scannedThroughUnattested'),
+          normalizedOrigin: normalizeEndpointOrigin(
+            input.scannedThroughUnattested.normalizedOrigin,
+            'cursor.scannedThroughUnattested.normalizedOrigin',
+          ),
+        });
+  // A resume point below covered coverage would re-reduce settled events; one
+  // far above it would skip a range that was never corroborated.
+  if (coveredThrough !== null && resumeAfter !== undefined) {
+    if (resumeAfter.blockNumber <= coveredThrough.blockNumber) {
+      fail('cursor-regression', 'resumeAfter is at or below coveredThrough');
+    }
+  }
+  return Object.freeze({
+    ...(scanned === undefined ? {} : { scannedThroughUnattested: scanned }),
+    coveredThrough,
+    ...(resumeAfter === undefined ? {} : { resumeAfter }),
+  });
+}
+
+/**
+ * The next block to scan.
+ *
+ * With a partial page the scan RESTARTS at `resumeAfter.blockNumber` — it does
+ * not skip to the next block — because the reducer must re-validate that
+ * block's hash and discard only identities at or below `resumeAfter`. Starting
+ * one block later would silently drop the rest of a partially reduced block.
+ */
+export function nextScanFromBlock(
+  cursor: UpdateCoverageCursorV1,
+  deploymentBlock: number,
+): number {
+  if (cursor.resumeAfter !== undefined) return cursor.resumeAfter.blockNumber;
+  if (cursor.coveredThrough === null) return deploymentBlock;
+  return cursor.coveredThrough.blockNumber + 1;
+}
+
+/** True when this identity was already reduced under the current resume point. */
+export function isDiscardedByResume(
+  event: FinalizedEventPositionV1,
+  resumeAfter: FinalizedEventPositionV1 | undefined,
+): boolean {
+  if (resumeAfter === undefined) return false;
+  return compareEventPosition(event, resumeAfter) <= 0;
+}
+
+// ── scoped KA candidate parser ────────────────────────────────────────────
+
+export type CanonicalScopedKaCandidateKindV1 = 'legacy-sequential' | 'rootless-packed';
+
+export interface CanonicalScopedKaCandidateV1 {
+  kind: CanonicalScopedKaCandidateKindV1;
+  kaId: string;
+}
+
+export interface CanonicalScopedKaCandidateSetV1 {
+  scopeId: string;
+  ual: string;
+  candidates: readonly CanonicalScopedKaCandidateV1[];
+}
+
+const UAL_PATTERN = /^did:dkg:([^/]+)\/([^/]+)\/([^/]+)$/;
+
+/**
+ * Build the canonical UAL for a resolved on-chain KA id.
+ *
+ * Mirrors `buildReconciledKnowledgeAssetUal` in `packages/agent/src/ka-identity.ts`.
+ * It cannot import it — `agent` depends on `core`, not the reverse — so
+ * `packages/agent/test/w2-ual-parity.test.ts` asserts the two produce
+ * byte-identical output across the legacy/rootless boundary. That parity test is
+ * the external anchor: without it this is a transcription that can drift
+ * silently, and the drift would make W2's fence select the wrong KA.
+ */
+export function buildScopedKnowledgeAssetUal(
+  chainId: string,
+  legacyStorageAddress: string,
+  kaId: bigint,
+): string {
+  if (kaId >> 96n === 0n) {
+    return `did:dkg:${chainId}/${legacyStorageAddress.toLowerCase()}/${kaId.toString()}`;
+  }
+  const agentAddress = `0x${(kaId >> 96n).toString(16).padStart(40, '0')}`;
+  const kaNumber = kaId & MAX_ROOTLESS_KA_NUMBER;
+  return `did:dkg:${chainId}/${agentAddress.toLowerCase()}/${kaNumber.toString()}`;
+}
+
+/**
+ * Parse a verified UAL into the one or two on-chain ids it could denote.
+ *
+ * The two RESOLVED domains are disjoint by authenticated on-chain semantics —
+ * legacy has `kaId >> 96 === 0`, rootless has `kaId >> 96 !== 0` — but the UAL
+ * SYNTAX is not: for `did:dkg:<chain>/<KA-storage>/7` both candidates round-trip
+ * byte-for-byte. This function therefore refuses to guess. It returns both, and
+ * the store resolves which is live by intersecting them with that exact
+ * scope/revision's chain-derived provenance. Two live matches is
+ * `ambiguous-w2-identity` and fails the graph mutation closed; picking either
+ * would silently attribute a write to the wrong KA.
+ */
+export function canonicalScopedKaCandidatesFromVerifiedUal(
+  scope: VmUpdateScopeV1,
+  verifiedUal: string,
+): Readonly<CanonicalScopedKaCandidateSetV1> {
+  const canonicalScope = canonicalVmUpdateScope(scope);
+  const ual = boundedString(verifiedUal, 'ual');
+  const match = UAL_PATTERN.exec(ual);
+  if (match === null) {
+    fail('noncanonical-ual', 'ual is not the canonical did:dkg:<chain>/<address>/<number> form');
+  }
+  const [, chainSegment, addressSegment, numberSegment] = match;
+
+  if (chainSegment !== canonicalScope.chainId) {
+    fail('foreign-chain', 'ual chain id is not this scope chain id');
+  }
+  // Round-trip, not `toLowerCase()`: accepting a mixed-case address here and
+  // normalizing it would make two distinct UAL spellings denote one KA, so a
+  // caller could address the same fence row two ways.
+  if (!EVM_ADDRESS.test(addressSegment)) {
+    fail('noncanonical-ual', 'ual address segment is not a lowercase 20-byte 0x address');
+  }
+  if (!CANONICAL_UNSIGNED_DECIMAL.test(numberSegment)) {
+    fail('noncanonical-ual', 'ual number segment is not a canonical decimal (leading-zero alias?)');
+  }
+  const number = BigInt(numberSegment);
+  if (number > MAX_ROOTLESS_KA_NUMBER) {
+    fail('ka-number-overflow', 'ual number segment exceeds the uint96 KA-number field');
+  }
+
+  const candidates: CanonicalScopedKaCandidateV1[] = [];
+
+  // The bounded rootless candidate always exists — including number zero, which
+  // is a legal per-author KA number.
+  const packed = (BigInt(addressSegment) << 96n) | number;
+  candidates.push({ kind: 'rootless-packed', kaId: packed.toString() });
+
+  // The sequential candidate exists only when the UAL addresses the scope's own
+  // KA storage contract with a nonzero id. `number` is already known to be
+  // below 2^96 from the overflow check above, so it cannot itself be a packed
+  // id — restating that here would be a condition that can never be false.
+  if (addressSegment === canonicalScope.knowledgeAssetStorageAddress && number !== 0n) {
+    candidates.push({ kind: 'legacy-sequential', kaId: number.toString() });
+  }
+
+  for (const candidate of candidates) {
+    const roundTrip = buildScopedKnowledgeAssetUal(
+      canonicalScope.chainId,
+      canonicalScope.knowledgeAssetStorageAddress,
+      BigInt(candidate.kaId),
+    );
+    if (roundTrip !== ual) {
+      fail(
+        'ual-round-trip-failed',
+        `${candidate.kind} candidate does not round-trip to the supplied ual`,
+      );
+    }
+  }
+
+  const distinct = new Set(candidates.map((candidate) => candidate.kaId));
+  if (distinct.size !== candidates.length) {
+    fail('noncanonical-ual', 'candidate set is not distinct');
+  }
+
+  return Object.freeze({
+    scopeId: canonicalScope.scopeId,
+    ual,
+    candidates: Object.freeze(candidates.map((candidate) => Object.freeze(candidate))),
+  });
+}
+
+// ── store interface ───────────────────────────────────────────────────────
+
+export interface FinalizedKaTargetV1 {
+  scopeId: string;
+  coverageRevision: number;
+  generation: number;
+  orphanGeneration?: number;
+  anchor: BlockRefV1;
+  localCgId: string;
+  onChainCgId: string;
+  kaId: string;
+  ual: string;
+  root: string;
+  rootCount: string;
+  publisher: string | null;
+  latestUpdate?: FinalizedKnowledgeAssetUpdateV1;
+  materializedVersion: { blockNumber: number; txIndex: number };
+}
+
+/**
+ * The durable surface W2a needs. Implemented by the node-UI SQLite store; kept
+ * here so the reducer's rules can be tested against an in-memory fake without
+ * the store package.
+ */
+export interface VmUpdateConvergenceStoreV1 {
+  loadScope(scopeId: string): Promise<Readonly<VmUpdateScopeV1> | null>;
+  loadCursor(scopeId: string): Promise<Readonly<UpdateCoverageCursorV1> | null>;
+  /** Reducing a chunk advances only `resumeAfter`, atomically with the events. */
+  reduceChunk(input: {
+    scopeId: string;
+    coverageRevision: number;
+    events: readonly Readonly<FinalizedKnowledgeAssetUpdateV1>[];
+    resumeAfter: FinalizedEventPositionV1;
+  }): Promise<void>;
+  /** Completing a page advances `coveredThrough` and clears `resumeAfter`. */
+  completePage(input: {
+    scopeId: string;
+    coverageRevision: number;
+    coveredThrough: BlockRefV1;
+  }): Promise<void>;
+  /** An unattested page moves observation only; it never touches coverage. */
+  recordUnattestedObservation(input: {
+    scopeId: string;
+    observation: UnattestedObservationV1;
+  }): Promise<void>;
+}

--- a/packages/core/src/vm-update-convergence.ts
+++ b/packages/core/src/vm-update-convergence.ts
@@ -55,8 +55,30 @@ function adapt<T>(label: string, assertion: () => T, code: VmUpdateErrorCodeV1 =
 
 /** `(1 << 96) - 1` — the rootless KA-number field width. */
 export const MAX_ROOTLESS_KA_NUMBER = (1n << 96n) - 1n;
-/** Bound on any single canonicalized string this module will hash or persist. */
+/** Upper bound of the on-chain id domain. */
+const MAX_UINT256 = (1n << 256n) - 1n;
+/**
+ * Bound on an IDENTITY scalar — chain id, deployment id, UAL, origin.
+ *
+ * Deliberately NOT applied to raw event data. `log.data` for a legal
+ * `KnowledgeAssetMerkleRootsUpdated` is `64 + n * 96` bytes: 21 MerkleRoot
+ * entries is 2,080 bytes, i.e. 4,162 hex characters, which this cap would
+ * reject. That event is a BLOCKING mutation, so rejecting it would stop W2
+ * before it can persist the unsupported-mutation latch that is supposed to fail
+ * closed — a legal on-chain event turned into a wedge. Raw log bytes are bounded
+ * by {@link MAX_ENCODED_UPDATE_LOG_BYTES_PER_PAGE} instead, per page, as the
+ * plan specifies.
+ */
 const MAX_SCALAR_BYTES = 4_096;
+
+/**
+ * Aggregate bound on the raw topic+data hex a single page may carry.
+ *
+ * Enforced while walking the page, before the commitment input is assembled, so
+ * an oversized page is refused rather than expanded. The transport answers this
+ * with adaptive range halving.
+ */
+export const MAX_ENCODED_UPDATE_LOG_BYTES_PER_PAGE = 8 * 1024 * 1024;
 /** Bound on one page's event count, mirroring the transport's own page bound. */
 export const MAX_UPDATE_PAGE_EVENTS = 4_096;
 /**
@@ -72,10 +94,10 @@ export const MAX_LOG_TOPICS = 4;
 // verifier can prove the runtime set matches the type. A bare `type` union is
 // invisible at runtime and cannot be checked for drift.
 
-export const UPDATE_PAGE_ASSURANCES = ['unattested', 'dual-origin-corroborated'] as const;
+export const UPDATE_PAGE_ASSURANCES = Object.freeze(['unattested', 'dual-origin-corroborated'] as const);
 export type UpdatePageAssuranceV1 = (typeof UPDATE_PAGE_ASSURANCES)[number];
 
-export const VM_UPDATE_SCAN_OUTCOMES = [
+export const VM_UPDATE_SCAN_OUTCOMES = Object.freeze([
   'corroborated',
   'unattested',
   'empty',
@@ -86,10 +108,10 @@ export const VM_UPDATE_SCAN_OUTCOMES = [
   'corroboration_disagreement',
   'oversized',
   'unsupported',
-] as const;
+] as const);
 export type VmUpdateScanOutcomeV1 = (typeof VM_UPDATE_SCAN_OUTCOMES)[number];
 
-export const VM_UPDATE_EVENT_RESULTS = [
+export const VM_UPDATE_EVENT_RESULTS = Object.freeze([
   'newer',
   'duplicate',
   'discarded_resume',
@@ -97,18 +119,18 @@ export const VM_UPDATE_EVENT_RESULTS = [
   'unsupported',
   'unbound',
   'promoted',
-] as const;
+] as const);
 export type VmUpdateEventResultV1 = (typeof VM_UPDATE_EVENT_RESULTS)[number];
 
-export const VM_UPDATE_COVERAGE_STATES = [
+export const VM_UPDATE_COVERAGE_STATES = Object.freeze([
   'bootstrapping',
   'caught_up',
   'reorg_recovering',
   'unavailable',
-] as const;
+] as const);
 export type VmUpdateCoverageStateV1 = (typeof VM_UPDATE_COVERAGE_STATES)[number];
 
-export const VM_UPDATE_ERROR_CODES = [
+export const VM_UPDATE_ERROR_CODES = Object.freeze([
   'scope-drift',
   'noncanonical-scalar',
   'foreign-chain',
@@ -122,8 +144,9 @@ export const VM_UPDATE_ERROR_CODES = [
   'origin-not-distinct',
   'commitment-mismatch',
   'cursor-regression',
+  'resume-identity-conflict',
   'coverage-invalid',
-] as const;
+] as const);
 export type VmUpdateErrorCodeV1 = (typeof VM_UPDATE_ERROR_CODES)[number];
 
 /**
@@ -148,6 +171,52 @@ export class VmUpdateConvergenceError extends Error {
 
 function fail(code: VmUpdateErrorCodeV1, detail: string, cause?: unknown): never {
   throw new VmUpdateConvergenceError(code, detail, cause === undefined ? undefined : { cause });
+}
+
+/**
+ * Snapshot an array as dense, own, enumerable DATA properties — or fail.
+ *
+ * `Array.isArray` plus `.map()` is not enough, and the gap is exploitable:
+ * `map` skips holes while `new Set(sparse)` observes them as `undefined`, so
+ * `['https://a', <hole>]` has length 2 AND set size 2 and was accepted as two
+ * distinct corroborating origins. The frozen proof then serialized as one URL
+ * and a `null`.
+ *
+ * Descriptors are read with `getOwnPropertyDescriptor`, which does NOT invoke
+ * getters, so an accessor-backed element is refused without running caller code.
+ * Holes and inherited indices have no own descriptor and are refused the same
+ * way.
+ *
+ * `Array.from` is not a substitute: it materializes holes as `undefined` and can
+ * invoke an iterator and getters. `Object.isFrozen` is not a substitute either —
+ * a caller can freeze a malformed object itself.
+ */
+function denseDataArray(
+  value: unknown,
+  label: string,
+  maxLength: number,
+): readonly unknown[] {
+  if (!Array.isArray(value)) fail('page-malformed', `${label} must be an array`);
+  // Length is checked BEFORE any iteration, so an absurd length cannot cost a
+  // walk before it is refused.
+  if (value.length > maxLength) {
+    fail('page-oversized', `${label} carries ${value.length} entries, above ${maxLength}`);
+  }
+  const out: unknown[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, index);
+    if (descriptor === undefined) {
+      fail('page-malformed', `${label}[${index}] is a hole or inherited, not own data`);
+    }
+    if (!Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail('page-malformed', `${label}[${index}] is an accessor, not a data property`);
+    }
+    if (!descriptor.enumerable) {
+      fail('page-malformed', `${label}[${index}] is not enumerable`);
+    }
+    out.push(descriptor.value);
+  }
+  return out;
 }
 
 // ── canonical scalars ─────────────────────────────────────────────────────
@@ -451,12 +520,28 @@ const LOG_COMMITMENT_DOMAIN = UTF8.encode('dkg:w2:ordered-log-commitment:v1');
  * exact failure the two-origin comparison exists to catch.
  */
 export function orderedLogCommitment(logs: readonly RawLogV1[]): Digest32V1 {
-  if (logs.length > MAX_UPDATE_PAGE_EVENTS) {
-    fail('page-oversized', `page carries ${logs.length} logs, above ${MAX_UPDATE_PAGE_EVENTS}`);
-  }
+  // The page itself must be dense own data before anything is read from it: a
+  // hole here would reach the loop as `undefined` and blow up inside a
+  // canonicalizer with an untyped error instead of a typed malformed page.
+  const dense = denseDataArray(logs, 'page logs', MAX_UPDATE_PAGE_EVENTS);
+
   const parts: string[] = [];
   let previous: FinalizedEventPositionV1 | undefined;
-  for (const log of logs) {
+  // Aggregate raw-bytes budget for the whole page, charged as we walk so an
+  // oversized page is refused before its commitment input is assembled.
+  let encodedBytes = 0;
+  const charge = (hex: string, label: string) => {
+    encodedBytes += hex.length;
+    if (encodedBytes > MAX_ENCODED_UPDATE_LOG_BYTES_PER_PAGE) {
+      fail(
+        'page-oversized',
+        `page raw log bytes exceed ${MAX_ENCODED_UPDATE_LOG_BYTES_PER_PAGE} at ${label}`,
+      );
+    }
+  };
+
+  for (const entry of dense) {
+    const log = entry as RawLogV1;
     const position = canonicalPosition(log.position, 'log');
     if (previous !== undefined) {
       const order = compareEventPosition(previous, position);
@@ -464,22 +549,32 @@ export function orderedLogCommitment(logs: readonly RawLogV1[]): Digest32V1 {
       if (order === 0) fail('page-malformed', 'two logs occupy one ordering position');
     }
     previous = position;
-    const data = boundedString(log.data, 'log.data');
-    adapt('log.data', () => assertCanonicalHexBytes(data, 'log.data', 0, MAX_SCALAR_BYTES));
-    // Bound BEFORE expanding: `topics.map` on an unbounded array is the
-    // allocation this guard exists to prevent, so it cannot come after.
-    if (!Array.isArray(log.topics)) fail('page-malformed', 'log.topics must be an array');
-    if (log.topics.length > MAX_LOG_TOPICS) {
-      fail(
-        'page-malformed',
-        `log carries ${log.topics.length} topics, above the EVM bound of ${MAX_LOG_TOPICS}`,
-      );
-    }
+
+    // Topics: dense own data, bounded at the EVM's own LOG0..LOG4 limit, and
+    // bounded BEFORE expansion.
+    const topics = denseDataArray(log.topics, 'log.topics', MAX_LOG_TOPICS);
+
+    if (typeof log.data !== 'string') fail('page-malformed', 'log.data must be a string');
+    charge(log.data, 'log.data');
+    // Raw event data is bounded by the PAGE budget, not the identity-scalar cap.
+    adapt('log.data', () => assertCanonicalHexBytes(
+      log.data,
+      'log.data',
+      0,
+      MAX_ENCODED_UPDATE_LOG_BYTES_PER_PAGE,
+    ));
+
+    const canonicalTopics = topics.map((topic, index) => {
+      const digest = canonicalDigest32(topic, `log.topics[${index}]`);
+      charge(digest, `log.topics[${index}]`);
+      return digest;
+    });
+
     parts.push(
       canonicalEvmAddress(log.address, 'log.address'),
-      String(log.topics.length),
-      ...log.topics.map((topic, index) => canonicalDigest32(topic, `log.topics[${index}]`)),
-      data,
+      String(canonicalTopics.length),
+      ...canonicalTopics,
+      log.data,
       String(position.blockNumber),
       position.blockHash,
       position.transactionHash,
@@ -548,10 +643,14 @@ export function canonicalPageProof(
   if (input.assurance !== 'unattested' && input.assurance !== 'dual-origin-corroborated') {
     fail('assurance-insufficient', 'proof.assurance is not a known assurance level');
   }
-  if (!Array.isArray(input.normalizedOrigins) || input.normalizedOrigins.length === 0) {
+  // Dense own data BEFORE mapping. `map` skips holes while `new Set` observes
+  // them as `undefined`, so `['https://a', <hole>]` previously had length 2 and
+  // set size 2 and minted a false `dual-origin-corroborated` proof.
+  const rawOrigins = denseDataArray(input.normalizedOrigins, 'proof.normalizedOrigins', 2);
+  if (rawOrigins.length === 0) {
     fail('origin-not-distinct', 'proof.normalizedOrigins must carry at least one origin');
   }
-  const origins = input.normalizedOrigins.map((origin, index) =>
+  const origins = rawOrigins.map((origin, index) =>
     normalizeEndpointOrigin(origin, `proof.normalizedOrigins[${index}]`),
   );
   const distinct = new Set(origins);
@@ -608,9 +707,19 @@ export function canonicalPageProof(
   });
 }
 
-/** Only a corroborated page may move authoritative coverage or feed the reducer. */
+/**
+ * Only a corroborated page may move authoritative coverage or feed the reducer.
+ *
+ * This CANONICALIZES rather than reading `proof.assurance` off whatever it was
+ * handed. Reading the string alone made authority a declaration: any object
+ * literal carrying `assurance: 'dual-origin-corroborated'` — including one whose
+ * origin list was sparse or accessor-backed — answered true. It throws a typed
+ * error on malformed evidence rather than quietly answering `false`, because a
+ * page that cannot be canonicalized is a defect to surface, not an unattested
+ * page to skip.
+ */
 export function isAuthoritativePage(proof: FinalizedUpdatePageProofV1): boolean {
-  return proof.assurance === 'dual-origin-corroborated';
+  return canonicalPageProof(proof).assurance === 'dual-origin-corroborated';
 }
 
 // ── two-cursor model ──────────────────────────────────────────────────────
@@ -683,7 +792,25 @@ export function isDiscardedByResume(
   resumeAfter: FinalizedEventPositionV1 | undefined,
 ): boolean {
   if (resumeAfter === undefined) return false;
-  return compareEventPosition(event, resumeAfter) <= 0;
+  const order = compareEventPosition(event, resumeAfter);
+  if (order < 0) return true;
+  if (order > 0) return false;
+  // Equal ORDER is not equal IDENTITY. `(block, txIndex, logIndex)` is the chain
+  // order; `blockHash` and `transactionHash` are part of the event's identity.
+  // A different event at the same numeric position means the page is malformed
+  // or the chain reorganised exactly at the resume boundary — treating it as
+  // "already reduced" silently drops that event AND destroys the only signal
+  // that would have caught the reorg.
+  //
+  // The hashes are deliberately NOT added to `compareEventPosition`:
+  // lexicographic hash ordering would invent a position the chain never assigned.
+  if (!sameEventIdentity(event, resumeAfter)) {
+    fail(
+      'resume-identity-conflict',
+      'a different event occupies the resume position; page is malformed or reorged',
+    );
+  }
+  return true;
 }
 
 // ── scoped KA candidate parser ────────────────────────────────────────────
@@ -718,12 +845,22 @@ export function buildScopedKnowledgeAssetUal(
   legacyStorageAddress: string,
   kaId: bigint,
 ): string {
+  // Validate before formatting. An exported builder that accepts a negative
+  // kaId, a value above uint256, a noncanonical chain id, or an arbitrary
+  // address string emits a syntactically well-formed UAL that denotes nothing —
+  // and silently lowercasing the address would make two spellings one identity.
+  const canonicalChain = canonicalUalChainId(chainId, 'ual chainId');
+  const canonicalStorage = canonicalEvmAddress(legacyStorageAddress, 'ual storage address');
+  if (typeof kaId !== 'bigint') fail('noncanonical-scalar', 'kaId must be a bigint');
+  if (kaId < 0n) fail('noncanonical-scalar', 'kaId must not be negative');
+  if (kaId > MAX_UINT256) fail('ka-number-overflow', 'kaId exceeds uint256');
+
   if (kaId >> 96n === 0n) {
-    return `did:dkg:${chainId}/${legacyStorageAddress.toLowerCase()}/${kaId.toString()}`;
+    return `did:dkg:${canonicalChain}/${canonicalStorage}/${kaId.toString()}`;
   }
   const agentAddress = `0x${(kaId >> 96n).toString(16).padStart(40, '0')}`;
   const kaNumber = kaId & MAX_ROOTLESS_KA_NUMBER;
-  return `did:dkg:${chainId}/${agentAddress.toLowerCase()}/${kaNumber.toString()}`;
+  return `did:dkg:${canonicalChain}/${agentAddress}/${kaNumber.toString()}`;
 }
 
 /**
@@ -833,29 +970,19 @@ export interface FinalizedKaTargetV1 {
 }
 
 /**
- * The durable surface W2a needs. Implemented by the node-UI SQLite store; kept
- * here so the reducer's rules can be tested against an in-memory fake without
- * the store package.
+ * The durable store contract is intentionally NOT exported from this PR.
+ *
+ * An earlier revision published `VmUpdateConvergenceStoreV1` with five broad
+ * operations. It had no in-repository implementation or consumer, and its shape
+ * could not express the contract the plan actually requires: every cursor
+ * mutation is an expected-revision PLUS expected-prior-cursor CAS, with the
+ * canonical proof supplied to the atomic boundary. Two stale callers can
+ * legitimately hold the same revision, so a bare `expectedRevision` does not
+ * make the operations safe, and accepting an assurance string would re-open the
+ * forgeable-evidence hole this module closes.
+ *
+ * Publishing that shape as `V1` would turn a placeholder into an API promise and
+ * force a breaking change later. It lands with the SQLite store slice (plan
+ * §10.4), where its operations and CAS predicates can be defined and tested
+ * together.
  */
-export interface VmUpdateConvergenceStoreV1 {
-  loadScope(scopeId: string): Promise<Readonly<VmUpdateScopeV1> | null>;
-  loadCursor(scopeId: string): Promise<Readonly<UpdateCoverageCursorV1> | null>;
-  /** Reducing a chunk advances only `resumeAfter`, atomically with the events. */
-  reduceChunk(input: {
-    scopeId: string;
-    coverageRevision: number;
-    events: readonly Readonly<FinalizedKnowledgeAssetUpdateV1>[];
-    resumeAfter: FinalizedEventPositionV1;
-  }): Promise<void>;
-  /** Completing a page advances `coveredThrough` and clears `resumeAfter`. */
-  completePage(input: {
-    scopeId: string;
-    coverageRevision: number;
-    coveredThrough: BlockRefV1;
-  }): Promise<void>;
-  /** An unattested page moves observation only; it never touches coverage. */
-  recordUnattestedObservation(input: {
-    scopeId: string;
-    observation: UnattestedObservationV1;
-  }): Promise<void>;
-}

--- a/packages/core/test/vm-update-convergence.test.ts
+++ b/packages/core/test/vm-update-convergence.test.ts
@@ -1,0 +1,574 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_ROOTLESS_KA_NUMBER,
+  MAX_UPDATE_PAGE_EVENTS,
+  UPDATE_PAGE_ASSURANCES,
+  VM_UPDATE_COVERAGE_STATES,
+  VM_UPDATE_ERROR_CODES,
+  VM_UPDATE_EVENT_RESULTS,
+  VM_UPDATE_SCAN_OUTCOMES,
+  VmUpdateConvergenceError,
+  buildScopedKnowledgeAssetUal,
+  canonicalCoverageCursor,
+  canonicalDigest32,
+  canonicalEvmAddress,
+  canonicalFinalizedUpdate,
+  canonicalNullableAuthorAddress,
+  canonicalPageProof,
+  canonicalScopedKaCandidatesFromVerifiedUal,
+  canonicalUnsignedDecimal,
+  canonicalVmUpdateScope,
+  compareEventPosition,
+  deriveVmUpdateScopeId,
+  isAuthoritativePage,
+  isDiscardedByResume,
+  nextScanFromBlock,
+  normalizeEndpointOrigin,
+  orderedLogCommitment,
+  sameEventIdentity,
+  type FinalizedEventPositionV1,
+  type FinalizedUpdatePageProofV1,
+  type RawLogV1,
+  type VmUpdateScopeV1,
+} from '../src/vm-update-convergence.js';
+
+const KA_STORAGE = `0x${'a1'.repeat(20)}`;
+const CG_STORAGE = `0x${'b2'.repeat(20)}`;
+const OTHER_ADDRESS = `0x${'c3'.repeat(20)}`;
+const ZERO_ADDRESS = `0x${'00'.repeat(20)}`;
+const HASH_A = `0x${'11'.repeat(32)}`;
+const HASH_B = `0x${'22'.repeat(32)}`;
+const HASH_C = `0x${'33'.repeat(32)}`;
+
+function scope(overrides: Partial<VmUpdateScopeV1> = {}): VmUpdateScopeV1 {
+  const identity = {
+    chainId: '84532',
+    deploymentId: '84532:hub=0x00000000000000000000000000000000000000ff',
+    knowledgeAssetStorageAddress: KA_STORAGE,
+    contextGraphStorageAddress: CG_STORAGE,
+    ...overrides,
+  };
+  return {
+    ...identity,
+    scopeId: deriveVmUpdateScopeId(identity),
+    deploymentBlock: 47_682_200,
+    deploymentBlockSource: 'shipped',
+    deploymentBlockHistoricallyValidated: true,
+    ...overrides,
+  } as VmUpdateScopeV1;
+}
+
+function position(overrides: Partial<FinalizedEventPositionV1> = {}): FinalizedEventPositionV1 {
+  return {
+    blockNumber: 100,
+    blockHash: HASH_A,
+    transactionHash: HASH_B,
+    transactionIndex: 0,
+    logIndex: 0,
+    ...overrides,
+  };
+}
+
+function proof(overrides: Partial<FinalizedUpdatePageProofV1> = {}): FinalizedUpdatePageProofV1 {
+  return {
+    assurance: 'dual-origin-corroborated',
+    normalizedOrigins: ['https://a.example.com', 'https://b.example.com'],
+    from: { blockNumber: 100, blockHash: HASH_A },
+    through: { blockNumber: 200, blockHash: HASH_B },
+    finalizedAnchor: { blockNumber: 300, blockHash: HASH_C },
+    orderedLogCommitment: `0x${'44'.repeat(32)}`,
+    ...overrides,
+  };
+}
+
+function codeOf(fn: () => unknown): string {
+  try {
+    fn();
+  } catch (error) {
+    if (error instanceof VmUpdateConvergenceError) return error.code;
+    throw error;
+  }
+  throw new Error('expected the call to throw a VmUpdateConvergenceError, but it returned');
+}
+
+describe('closed vocabularies', () => {
+  it('exposes each vocabulary as a runtime tuple with no duplicates', () => {
+    for (const vocabulary of [
+      UPDATE_PAGE_ASSURANCES,
+      VM_UPDATE_SCAN_OUTCOMES,
+      VM_UPDATE_EVENT_RESULTS,
+      VM_UPDATE_COVERAGE_STATES,
+      VM_UPDATE_ERROR_CODES,
+    ]) {
+      expect(vocabulary.length).toBeGreaterThan(0);
+      expect(new Set(vocabulary).size).toBe(vocabulary.length);
+    }
+  });
+
+  it('keeps every error code the module can actually raise inside the vocabulary', () => {
+    // Each entry is a call that MUST fail with that exact code. A code with no
+    // reachable producer is dead vocabulary; a producer whose code is missing
+    // from the tuple is drift. Both are caught here.
+    const producers: Record<string, () => unknown> = {
+      'scope-drift': () => canonicalVmUpdateScope({ ...scope(), scopeId: HASH_A }),
+      'noncanonical-scalar': () => canonicalEvmAddress('0xNOTANADDRESS'),
+      'foreign-chain': () =>
+        canonicalScopedKaCandidatesFromVerifiedUal(scope(), `did:dkg:1/${KA_STORAGE}/7`),
+      'noncanonical-ual': () =>
+        canonicalScopedKaCandidatesFromVerifiedUal(scope(), 'not-a-ual'),
+      'ka-number-overflow': () =>
+        canonicalScopedKaCandidatesFromVerifiedUal(
+          scope(),
+          `did:dkg:84532/${KA_STORAGE}/${(MAX_ROOTLESS_KA_NUMBER + 1n).toString()}`,
+        ),
+      'page-malformed': () =>
+        canonicalPageProof(proof({ through: { blockNumber: 400, blockHash: HASH_B } })),
+      'assurance-insufficient': () =>
+        canonicalPageProof(proof({ assurance: 'trust-me' as never })),
+      'origin-not-distinct': () =>
+        canonicalPageProof(proof({ normalizedOrigins: ['https://a.example.com'] })),
+      'page-oversized': () =>
+        orderedLogCommitment(
+          Array.from({ length: MAX_UPDATE_PAGE_EVENTS + 1 }, (_unused, index) => ({
+            address: KA_STORAGE,
+            topics: [HASH_A],
+            data: '0x',
+            position: position({ logIndex: index }),
+          })),
+        ),
+      'cursor-regression': () =>
+        canonicalCoverageCursor({
+          coveredThrough: { blockNumber: 200, blockHash: HASH_A },
+          resumeAfter: position({ blockNumber: 150 }),
+        }),
+    };
+
+    for (const [expected, produce] of Object.entries(producers)) {
+      expect(VM_UPDATE_ERROR_CODES).toContain(expected);
+      expect(codeOf(produce)).toBe(expected);
+    }
+  });
+
+  it('bounds the error detail so an unbounded payload cannot reach a log line', () => {
+    const error = new VmUpdateConvergenceError('page-malformed', 'x'.repeat(5_000));
+    expect(error.detail.length).toBeLessThanOrEqual(200);
+    expect(error.detail.endsWith('...')).toBe(true);
+    expect(error.message.length).toBeLessThan(300);
+  });
+});
+
+describe('canonical scalars', () => {
+  it('rejects the zero address for ordinary addresses but maps it to null for author', () => {
+    expect(codeOf(() => canonicalEvmAddress(ZERO_ADDRESS))).toBe('noncanonical-scalar');
+    expect(canonicalNullableAuthorAddress(ZERO_ADDRESS)).toBeNull();
+    expect(canonicalNullableAuthorAddress(null)).toBeNull();
+    expect(canonicalNullableAuthorAddress(OTHER_ADDRESS)).toBe(OTHER_ADDRESS);
+  });
+
+  it('rejects mixed case rather than normalizing it', () => {
+    const mixed = `0x${'A1'.repeat(20)}`;
+    expect(codeOf(() => canonicalEvmAddress(mixed))).toBe('noncanonical-scalar');
+    expect(codeOf(() => canonicalNullableAuthorAddress(mixed))).toBe('noncanonical-scalar');
+    expect(codeOf(() => canonicalDigest32(`0x${'AB'.repeat(32)}`))).toBe('noncanonical-scalar');
+  });
+
+  it('rejects the leading-zero decimal alias', () => {
+    expect(canonicalUnsignedDecimal('0')).toBe(0n);
+    expect(canonicalUnsignedDecimal('7')).toBe(7n);
+    expect(codeOf(() => canonicalUnsignedDecimal('007'))).toBe('noncanonical-scalar');
+  });
+});
+
+describe('scope identity', () => {
+  it('derives one id from the four identity fields', () => {
+    expect(deriveVmUpdateScopeId(scope())).toBe(deriveVmUpdateScopeId(scope()));
+    expect(deriveVmUpdateScopeId(scope())).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it('does NOT include deploymentBlock — a proven lower anchor must stay in its scope', () => {
+    // If this ever changes, an anchor correction would silently mint a new
+    // scope instead of triggering revision reset and replay inside the old one,
+    // and every persisted cursor for that chain would be orphaned.
+    const high = canonicalVmUpdateScope(scope());
+    const low = canonicalVmUpdateScope({ ...scope(), deploymentBlock: 1 });
+    expect(low.scopeId).toBe(high.scopeId);
+    expect(low.deploymentBlock).not.toBe(high.deploymentBlock);
+  });
+
+  it('changes the id when any one identity field changes', () => {
+    const base = deriveVmUpdateScopeId(scope());
+    expect(deriveVmUpdateScopeId(scope({ chainId: '31337' }))).not.toBe(base);
+    expect(deriveVmUpdateScopeId(scope({ deploymentId: 'other' }))).not.toBe(base);
+    expect(
+      deriveVmUpdateScopeId(scope({ knowledgeAssetStorageAddress: OTHER_ADDRESS })),
+    ).not.toBe(base);
+    expect(deriveVmUpdateScopeId(scope({ contextGraphStorageAddress: OTHER_ADDRESS }))).not.toBe(
+      base,
+    );
+  });
+
+  it('cannot be collided by moving a boundary between two fields', () => {
+    // These two identities CONCATENATE to the same bytes — '84532' + 'abc' and
+    // '8453' + '2abc' — and differ only in where the field boundary falls. A
+    // digest over a plain join, or over a join whose length prefix is not
+    // actually written, hashes them identically and lets one chain's scope
+    // impersonate another's. Only the length prefix separates them.
+    //
+    // An earlier version of this test compared inputs of different total
+    // content, which every encoding distinguishes; it passed under a mutant
+    // that zeroed the length field entirely.
+    const shared = { knowledgeAssetStorageAddress: KA_STORAGE, contextGraphStorageAddress: CG_STORAGE };
+    const left = deriveVmUpdateScopeId({ chainId: '84532', deploymentId: 'abc', ...shared });
+    const right = deriveVmUpdateScopeId({ chainId: '8453', deploymentId: '2abc', ...shared });
+    expect(left).not.toBe(right);
+  });
+
+  it('fails closed on caller scope-id drift and freezes what it returns', () => {
+    expect(codeOf(() => canonicalVmUpdateScope({ ...scope(), scopeId: HASH_A }))).toBe(
+      'scope-drift',
+    );
+    const frozen = canonicalVmUpdateScope(scope());
+    expect(Object.isFrozen(frozen)).toBe(true);
+  });
+});
+
+describe('exact event identity and ordering', () => {
+  it('orders by (block, txIndex, logIndex) and ignores transactionHash', () => {
+    const a = position({ blockNumber: 10, transactionIndex: 2, logIndex: 5 });
+    const b = position({ blockNumber: 10, transactionIndex: 3, logIndex: 0 });
+    expect(compareEventPosition(a, b)).toBeLessThan(0);
+    expect(compareEventPosition(b, a)).toBeGreaterThan(0);
+
+    // Same ordering coordinates, different tx hash: ordering says equal…
+    const sameOrder = position({ transactionHash: HASH_C });
+    expect(compareEventPosition(position(), sameOrder)).toBe(0);
+    // …but identity says different, which is how a malformed page is caught.
+    expect(sameEventIdentity(position(), sameOrder)).toBe(false);
+    expect(sameEventIdentity(position(), position())).toBe(true);
+  });
+
+  it('accepts a legal zero author on the admin path', () => {
+    const update = canonicalFinalizedUpdate({
+      kind: 'lifecycle-update',
+      kaId: '7',
+      author: ZERO_ADDRESS,
+      merkleRoot: HASH_C,
+      ...position(),
+    });
+    expect(update.author).toBeNull();
+    expect(Object.isFrozen(update)).toBe(true);
+  });
+
+  it('rejects a root-added event that claims an author', () => {
+    expect(
+      codeOf(() =>
+        canonicalFinalizedUpdate({
+          kind: 'root-added',
+          kaId: '7',
+          author: OTHER_ADDRESS,
+          merkleRoot: HASH_C,
+          ...position(),
+        }),
+      ),
+    ).toBe('page-malformed');
+  });
+});
+
+describe('ordered log commitment', () => {
+  const log = (overrides: Partial<RawLogV1> = {}): RawLogV1 => ({
+    address: KA_STORAGE,
+    topics: [HASH_A, HASH_B],
+    data: '0xdeadbeef',
+    position: position(),
+    ...overrides,
+  });
+
+  it('is stable for identical input', () => {
+    expect(orderedLogCommitment([log()])).toBe(orderedLogCommitment([log()]));
+  });
+
+  it('changes when payload bytes change at an unchanged identity', () => {
+    // This is the whole point: an identity-only commitment would call these
+    // two pages corroborated while one endpoint altered the event data.
+    expect(orderedLogCommitment([log()])).not.toBe(
+      orderedLogCommitment([log({ data: '0xdeadbeee' })]),
+    );
+    expect(orderedLogCommitment([log()])).not.toBe(
+      orderedLogCommitment([log({ topics: [HASH_A, HASH_C] })]),
+    );
+    expect(orderedLogCommitment([log()])).not.toBe(
+      orderedLogCommitment([log({ address: OTHER_ADDRESS })]),
+    );
+  });
+
+  it('cannot be collided by moving a boundary between two adjacent fields', () => {
+    // `transactionIndex` and `logIndex` are adjacent variable-width numerics.
+    // (1, 23) and (12, 3) concatenate to the same '123', so a commitment whose
+    // length prefix is not actually written would call two different log
+    // positions equal — and two endpoints returning different events would
+    // corroborate. Only the length prefix separates them.
+    const left = orderedLogCommitment([
+      log({ position: position({ transactionIndex: 1, logIndex: 23 }) }),
+    ]);
+    const right = orderedLogCommitment([
+      log({ position: position({ transactionIndex: 12, logIndex: 3 }) }),
+    ]);
+    expect(left).not.toBe(right);
+  });
+
+  it('rejects unordered logs and two logs at one ordering position', () => {
+    expect(
+      codeOf(() =>
+        orderedLogCommitment([
+          log({ position: position({ logIndex: 5 }) }),
+          log({ position: position({ logIndex: 1 }) }),
+        ]),
+      ),
+    ).toBe('page-malformed');
+    expect(
+      codeOf(() =>
+        orderedLogCommitment([
+          log(),
+          log({ data: '0xcafe' }),
+        ]),
+      ),
+    ).toBe('page-malformed');
+  });
+
+  it('commits to an empty page distinctly from a one-log page', () => {
+    expect(orderedLogCommitment([])).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(orderedLogCommitment([])).not.toBe(orderedLogCommitment([log()]));
+  });
+});
+
+describe('page assurance', () => {
+  it('requires exactly two distinct origins to corroborate', () => {
+    expect(isAuthoritativePage(canonicalPageProof(proof()))).toBe(true);
+    expect(
+      codeOf(() => canonicalPageProof(proof({ normalizedOrigins: ['https://a.example.com'] }))),
+    ).toBe('origin-not-distinct');
+  });
+
+  it('treats two spellings of one origin as one origin', () => {
+    // A path/credential/case difference is not a second provider; accepting it
+    // would let a single faulty endpoint corroborate itself.
+    expect(
+      codeOf(() =>
+        canonicalPageProof(
+          proof({
+            normalizedOrigins: ['https://a.example.com/rpc', 'https://A.example.com/other?k=1'],
+          }),
+        ),
+      ),
+    ).toBe('origin-not-distinct');
+    expect(normalizeEndpointOrigin('https://user:pw@A.Example.com:8545/rpc?k=1#f')).toBe(
+      'https://a.example.com:8545',
+    );
+  });
+
+  it('lets an unattested proof carry a single origin', () => {
+    const unattested = canonicalPageProof(
+      proof({ assurance: 'unattested', normalizedOrigins: ['https://a.example.com'] }),
+    );
+    expect(isAuthoritativePage(unattested)).toBe(false);
+  });
+
+  it('rejects a page above the finalized anchor or inverted in range', () => {
+    expect(
+      codeOf(() => canonicalPageProof(proof({ through: { blockNumber: 400, blockHash: HASH_B } }))),
+    ).toBe('page-malformed');
+    expect(
+      codeOf(() => canonicalPageProof(proof({ from: { blockNumber: 250, blockHash: HASH_A } }))),
+    ).toBe('page-malformed');
+  });
+
+  it('freezes the proof and its origin list', () => {
+    const frozen = canonicalPageProof(proof());
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen(frozen.normalizedOrigins)).toBe(true);
+  });
+});
+
+describe('two-cursor model', () => {
+  it('starts the first authoritative page at the deployment block', () => {
+    const cursor = canonicalCoverageCursor({
+      coveredThrough: null,
+      scannedThroughUnattested: {
+        blockNumber: 9_000_000,
+        blockHash: HASH_A,
+        normalizedOrigin: 'https://a.example.com',
+      },
+    });
+    // Unattested observation is far ahead and must NOT be used as a start.
+    expect(nextScanFromBlock(cursor, 500)).toBe(500);
+  });
+
+  it('resumes AT the partial block, not one past it', () => {
+    const cursor = canonicalCoverageCursor({
+      coveredThrough: { blockNumber: 100, blockHash: HASH_A },
+      resumeAfter: position({ blockNumber: 101, logIndex: 3 }),
+    });
+    expect(nextScanFromBlock(cursor, 1)).toBe(101);
+  });
+
+  it('advances past coveredThrough when no partial page is open', () => {
+    const cursor = canonicalCoverageCursor({
+      coveredThrough: { blockNumber: 100, blockHash: HASH_A },
+    });
+    expect(nextScanFromBlock(cursor, 1)).toBe(101);
+  });
+
+  it('discards only identities at or below resumeAfter', () => {
+    const resume = position({ blockNumber: 101, transactionIndex: 2, logIndex: 3 });
+    expect(isDiscardedByResume(position({ blockNumber: 101, transactionIndex: 2, logIndex: 3 }), resume)).toBe(true);
+    expect(isDiscardedByResume(position({ blockNumber: 101, transactionIndex: 2, logIndex: 2 }), resume)).toBe(true);
+    expect(isDiscardedByResume(position({ blockNumber: 101, transactionIndex: 2, logIndex: 4 }), resume)).toBe(false);
+    expect(isDiscardedByResume(position({ blockNumber: 102, transactionIndex: 0, logIndex: 0 }), resume)).toBe(false);
+    expect(isDiscardedByResume(position(), undefined)).toBe(false);
+  });
+
+  it('rejects a resume point at or below covered coverage', () => {
+    expect(
+      codeOf(() =>
+        canonicalCoverageCursor({
+          coveredThrough: { blockNumber: 200, blockHash: HASH_A },
+          resumeAfter: position({ blockNumber: 200 }),
+        }),
+      ),
+    ).toBe('cursor-regression');
+  });
+});
+
+describe('scoped KA candidate parser', () => {
+  it('always builds the rootless candidate, including KA number zero', () => {
+    const set = canonicalScopedKaCandidatesFromVerifiedUal(
+      scope(),
+      `did:dkg:84532/${OTHER_ADDRESS}/0`,
+    );
+    expect(set.candidates).toHaveLength(1);
+    expect(set.candidates[0].kind).toBe('rootless-packed');
+    expect(BigInt(set.candidates[0].kaId) >> 96n).toBe(BigInt(OTHER_ADDRESS));
+    expect(BigInt(set.candidates[0].kaId) & MAX_ROOTLESS_KA_NUMBER).toBe(0n);
+  });
+
+  it('returns BOTH candidates for the same-address collision and refuses to choose', () => {
+    // did:dkg:<chain>/<KA-storage>/7 round-trips under both forms. Choosing
+    // either here would attribute a graph write to the wrong KA; the store
+    // resolves it against chain provenance instead.
+    const set = canonicalScopedKaCandidatesFromVerifiedUal(
+      scope(),
+      `did:dkg:84532/${KA_STORAGE}/7`,
+    );
+    expect(set.candidates.map((candidate) => candidate.kind).sort()).toEqual([
+      'legacy-sequential',
+      'rootless-packed',
+    ]);
+    expect(new Set(set.candidates.map((candidate) => candidate.kaId)).size).toBe(2);
+  });
+
+  it('omits the legacy candidate for a zero id at the KA storage address', () => {
+    // Legacy sequential ids start at 1; id 0 at the storage address is only the
+    // rootless (address<<96 | 0) form.
+    const set = canonicalScopedKaCandidatesFromVerifiedUal(
+      scope(),
+      `did:dkg:84532/${KA_STORAGE}/0`,
+    );
+    expect(set.candidates).toHaveLength(1);
+    expect(set.candidates[0].kind).toBe('rootless-packed');
+  });
+
+  it('omits the legacy candidate for a foreign address', () => {
+    const set = canonicalScopedKaCandidatesFromVerifiedUal(
+      scope(),
+      `did:dkg:84532/${OTHER_ADDRESS}/7`,
+    );
+    expect(set.candidates).toHaveLength(1);
+    expect(set.candidates[0].kind).toBe('rootless-packed');
+  });
+
+  it('round-trips every returned candidate byte-for-byte', () => {
+    for (const ual of [
+      `did:dkg:84532/${KA_STORAGE}/7`,
+      `did:dkg:84532/${OTHER_ADDRESS}/0`,
+      `did:dkg:84532/${OTHER_ADDRESS}/${MAX_ROOTLESS_KA_NUMBER.toString()}`,
+    ]) {
+      const set = canonicalScopedKaCandidatesFromVerifiedUal(scope(), ual);
+      for (const candidate of set.candidates) {
+        expect(buildScopedKnowledgeAssetUal('84532', KA_STORAGE, BigInt(candidate.kaId))).toBe(ual);
+      }
+    }
+  });
+
+  it('fails closed on a foreign chain', () => {
+    expect(
+      codeOf(() =>
+        canonicalScopedKaCandidatesFromVerifiedUal(scope(), `did:dkg:1/${KA_STORAGE}/7`),
+      ),
+    ).toBe('foreign-chain');
+  });
+
+  it('fails closed on a leading-zero alias and on mixed case', () => {
+    expect(
+      codeOf(() =>
+        canonicalScopedKaCandidatesFromVerifiedUal(scope(), `did:dkg:84532/${KA_STORAGE}/007`),
+      ),
+    ).toBe('noncanonical-ual');
+    expect(
+      codeOf(() =>
+        canonicalScopedKaCandidatesFromVerifiedUal(
+          scope(),
+          `did:dkg:84532/0x${'A1'.repeat(20)}/7`,
+        ),
+      ),
+    ).toBe('noncanonical-ual');
+  });
+
+  it('fails closed on uint96 overflow at the exact boundary', () => {
+    expect(() =>
+      canonicalScopedKaCandidatesFromVerifiedUal(
+        scope(),
+        `did:dkg:84532/${OTHER_ADDRESS}/${MAX_ROOTLESS_KA_NUMBER.toString()}`,
+      ),
+    ).not.toThrow();
+    expect(
+      codeOf(() =>
+        canonicalScopedKaCandidatesFromVerifiedUal(
+          scope(),
+          `did:dkg:84532/${OTHER_ADDRESS}/${(MAX_ROOTLESS_KA_NUMBER + 1n).toString()}`,
+        ),
+      ),
+    ).toBe('ka-number-overflow');
+  });
+
+  it('fails closed on a malformed UAL shape', () => {
+    for (const bad of [
+      'did:dkg:84532/only-two-segments',
+      `did:dkg:84532/${KA_STORAGE}/7/extra`,
+      `dld:dkg:84532/${KA_STORAGE}/7`,
+      '',
+    ]) {
+      expect(codeOf(() => canonicalScopedKaCandidatesFromVerifiedUal(scope(), bad))).toBe(
+        'noncanonical-ual',
+      );
+    }
+  });
+
+  it('recomputes scopeId from the supplied scope rather than trusting the caller', () => {
+    expect(
+      codeOf(() =>
+        canonicalScopedKaCandidatesFromVerifiedUal(
+          { ...scope(), scopeId: HASH_A },
+          `did:dkg:84532/${KA_STORAGE}/7`,
+        ),
+      ),
+    ).toBe('scope-drift');
+    const set = canonicalScopedKaCandidatesFromVerifiedUal(
+      scope(),
+      `did:dkg:84532/${KA_STORAGE}/7`,
+    );
+    expect(set.scopeId).toBe(deriveVmUpdateScopeId(scope()));
+    expect(Object.isFrozen(set)).toBe(true);
+    expect(Object.isFrozen(set.candidates)).toBe(true);
+  });
+});

--- a/packages/core/test/vm-update-convergence.test.ts
+++ b/packages/core/test/vm-update-convergence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  MAX_LOG_TOPICS,
   MAX_ROOTLESS_KA_NUMBER,
   MAX_UPDATE_PAGE_EVENTS,
   UPDATE_PAGE_ASSURANCES,
@@ -408,6 +409,28 @@ describe('ordered log commitment', () => {
     ).toBe('page-malformed');
   });
 
+  it('rejects a log with more topics than the EVM allows, BEFORE expanding them', () => {
+    // The page-count bound does not constrain this: one log with a million
+    // topics passes it, then allocates and hashes a million entries. These logs
+    // come straight off an untrusted RPC response.
+    expect(MAX_LOG_TOPICS).toBe(4);
+    expect(() => orderedLogCommitment([log({ topics: Array(4).fill(HASH_A) })])).not.toThrow();
+    expect(codeOf(() => orderedLogCommitment([log({ topics: Array(5).fill(HASH_A) })]))).toBe(
+      'page-malformed',
+    );
+
+    // A hostile page must be refused without the allocation. If the guard ran
+    // after `topics.map`, this call would build a million-entry array first.
+    const hostile = log({ topics: Array.from({ length: 1_000_000 }, () => HASH_A) });
+    expect(codeOf(() => orderedLogCommitment([hostile]))).toBe('page-malformed');
+  });
+
+  it('rejects a non-array topics field rather than throwing a TypeError', () => {
+    expect(codeOf(() => orderedLogCommitment([log({ topics: 'not-an-array' as never })]))).toBe(
+      'page-malformed',
+    );
+  });
+
   it('commits to an empty page distinctly from a one-log page', () => {
     expect(orderedLogCommitment([])).toMatch(/^0x[0-9a-f]{64}$/);
     expect(orderedLogCommitment([])).not.toBe(orderedLogCommitment([log()]));
@@ -455,10 +478,68 @@ describe('page assurance', () => {
     ).toBe('page-malformed');
   });
 
-  it('freezes the proof and its origin list', () => {
+  it('rejects one block number carrying two different hashes', () => {
+    // A single-block page has from === through; a page reaching the anchor has
+    // through === finalizedAnchor. Empty and sparse pages are exactly where no
+    // log position would expose the contradiction, so the proof must.
+    expect(
+      codeOf(() =>
+        canonicalPageProof(
+          proof({
+            from: { blockNumber: 100, blockHash: HASH_A },
+            through: { blockNumber: 100, blockHash: HASH_B },
+          }),
+        ),
+      ),
+    ).toBe('page-malformed');
+    expect(
+      codeOf(() =>
+        canonicalPageProof(
+          proof({
+            through: { blockNumber: 300, blockHash: HASH_B },
+            finalizedAnchor: { blockNumber: 300, blockHash: HASH_C },
+          }),
+        ),
+      ),
+    ).toBe('page-malformed');
+    expect(
+      codeOf(() =>
+        canonicalPageProof(
+          proof({
+            from: { blockNumber: 300, blockHash: HASH_A },
+            through: { blockNumber: 300, blockHash: HASH_A },
+            finalizedAnchor: { blockNumber: 300, blockHash: HASH_C },
+          }),
+        ),
+      ),
+    ).toBe('page-malformed');
+    // …and the consistent single-block page is still accepted.
+    expect(() =>
+      canonicalPageProof(
+        proof({
+          from: { blockNumber: 300, blockHash: HASH_A },
+          through: { blockNumber: 300, blockHash: HASH_A },
+          finalizedAnchor: { blockNumber: 300, blockHash: HASH_A },
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('freezes the proof and EVERY nested record it returns', () => {
+    // Shallow freezing is not the contract. These values are handed across
+    // `await` boundaries into SQLite transactions; a caller that mutated
+    // `proof.from` after validation would persist evidence never checked.
     const frozen = canonicalPageProof(proof());
     expect(Object.isFrozen(frozen)).toBe(true);
     expect(Object.isFrozen(frozen.normalizedOrigins)).toBe(true);
+    for (const ref of [frozen.from, frozen.through, frozen.finalizedAnchor]) {
+      expect(Object.isFrozen(ref)).toBe(true);
+    }
+    // Behaviour, not just the flag: a write must not take effect.
+    expect(() => {
+      (frozen.from as { blockNumber: number }).blockNumber = 999;
+    }).toThrow();
+    expect(frozen.from.blockNumber).toBe(100);
   });
 });
 
@@ -498,6 +579,25 @@ describe('two-cursor model', () => {
     expect(isDiscardedByResume(position({ blockNumber: 101, transactionIndex: 2, logIndex: 4 }), resume)).toBe(false);
     expect(isDiscardedByResume(position({ blockNumber: 102, transactionIndex: 0, logIndex: 0 }), resume)).toBe(false);
     expect(isDiscardedByResume(position(), undefined)).toBe(false);
+  });
+
+  it('freezes every nested cursor record it returns', () => {
+    const frozen = canonicalCoverageCursor({
+      coveredThrough: { blockNumber: 100, blockHash: HASH_A },
+      resumeAfter: position({ blockNumber: 101 }),
+      scannedThroughUnattested: {
+        blockNumber: 900,
+        blockHash: HASH_B,
+        normalizedOrigin: 'https://a.example.com',
+      },
+    });
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen(frozen.coveredThrough)).toBe(true);
+    expect(Object.isFrozen(frozen.resumeAfter)).toBe(true);
+    expect(Object.isFrozen(frozen.scannedThroughUnattested)).toBe(true);
+    expect(() => {
+      (frozen.resumeAfter as { logIndex: number }).logIndex = 42;
+    }).toThrow();
   });
 
   it('rejects a resume point at or below covered coverage', () => {
@@ -642,5 +742,11 @@ describe('scoped KA candidate parser', () => {
     expect(set.scopeId).toBe(deriveVmUpdateScopeId(scope()));
     expect(Object.isFrozen(set)).toBe(true);
     expect(Object.isFrozen(set.candidates)).toBe(true);
+    // Each candidate object too — the array being frozen says nothing about
+    // whether a caller can rewrite the kaId inside one of them.
+    for (const candidate of set.candidates) expect(Object.isFrozen(candidate)).toBe(true);
+    expect(() => {
+      (set.candidates[0] as { kaId: string }).kaId = '1';
+    }).toThrow();
   });
 });

--- a/packages/core/test/vm-update-convergence.test.ts
+++ b/packages/core/test/vm-update-convergence.test.ts
@@ -423,10 +423,24 @@ describe('the exported UAL builder validates its inputs (review P2-2)', () => {
     );
   });
 
-  it('rejects a mixed-case storage address rather than silently lowercasing it', () => {
-    expect(codeOf(() => buildScopedKnowledgeAssetUal('84532', `0x${'A1'.repeat(20)}`, 7n))).toBe(
-      'noncanonical-scalar',
+  it('NORMALIZES a mixed-case storage address, and that is deliberate', () => {
+    // Reversing an earlier choice of mine. A BUILDER's job is to emit canonical
+    // output; the sole production caller passes the checksummed address returned
+    // by `getDKGKnowledgeAssetsAddress()`, and the shipped `buildKnowledgeAssetUal`
+    // has always lowercased it. Rejecting case here would have broken that path
+    // for no gain.
+    //
+    // The strictness belongs on the PARSE side, where accepting a mixed-case
+    // address really would let two spellings denote one KA — and it is still
+    // enforced there (see the candidate-parser suite).
+    expect(buildScopedKnowledgeAssetUal('84532', `0x${'A1'.repeat(20)}`, 7n)).toBe(
+      `did:dkg:84532/0x${'a1'.repeat(20)}/7`,
     );
+    expect(
+      codeOf(() =>
+        canonicalScopedKaCandidatesFromVerifiedUal(scope(), `did:dkg:84532/0x${'A1'.repeat(20)}/7`),
+      ),
+    ).toBe('noncanonical-ual');
   });
 
   it('still builds both canonical forms', () => {

--- a/packages/core/test/vm-update-convergence.test.ts
+++ b/packages/core/test/vm-update-convergence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  MAX_ENCODED_UPDATE_LOG_BYTES_PER_PAGE,
   MAX_LOG_TOPICS,
   MAX_ROOTLESS_KA_NUMBER,
   MAX_UPDATE_PAGE_EVENTS,
@@ -253,6 +254,210 @@ describe('UAL chain ids are NAMESPACED, not bare decimals', () => {
   });
 });
 
+describe('malformed arrays cannot mint authority (review P1-1)', () => {
+  const originProof = (origins: unknown) => proof({ normalizedOrigins: origins as string[] });
+
+  function holed(...entries: (string | undefined)[]): string[] {
+    // A genuine hole, not an `undefined` element: index 1 is never assigned.
+    const out = new Array<string>(entries.length);
+    entries.forEach((value, index) => {
+      if (value !== undefined) out[index] = value;
+    });
+    return out;
+  }
+
+  it('refuses one URL plus a HOLE as two distinct origins', () => {
+    // `map` skips holes while `new Set` observes them as `undefined`, so this
+    // array had length 2 AND set size 2, minting a corroborated proof that
+    // serialized as one URL plus a null.
+    const origins = holed('https://a.example.com', undefined);
+    expect(origins.length).toBe(2);
+    expect(new Set(origins).size).toBe(2); // the trap, still true of raw JS
+    expect(codeOf(() => canonicalPageProof(originProof(origins)))).toBe('page-malformed');
+  });
+
+  it('refuses an accessor-backed origin WITHOUT invoking its getter', () => {
+    let reads = 0;
+    const origins: string[] = ['https://a.example.com'];
+    Object.defineProperty(origins, 1, {
+      enumerable: true,
+      configurable: true,
+      get() {
+        reads += 1;
+        return 'https://b.example.com';
+      },
+    });
+    expect(codeOf(() => canonicalPageProof(originProof(origins)))).toBe('page-malformed');
+    expect(reads).toBe(0);
+  });
+
+  it('refuses sparse and accessor-backed topics', () => {
+    const base = { address: KA_STORAGE, data: '0x', position: position() };
+
+    const sparseTopics = new Array<string>(2);
+    sparseTopics[0] = HASH_A;
+    expect(codeOf(() => orderedLogCommitment([{ ...base, topics: sparseTopics }]))).toBe(
+      'page-malformed',
+    );
+
+    let reads = 0;
+    const accessorTopics: string[] = [HASH_A];
+    Object.defineProperty(accessorTopics, 1, {
+      enumerable: true,
+      configurable: true,
+      get() {
+        reads += 1;
+        return HASH_B;
+      },
+    });
+    expect(codeOf(() => orderedLogCommitment([{ ...base, topics: accessorTopics }]))).toBe(
+      'page-malformed',
+    );
+    expect(reads).toBe(0);
+  });
+
+  it('refuses a sparse PAGE, not just sparse fields inside a log', () => {
+    const page = new Array<RawLogV1>(2);
+    page[0] = { address: KA_STORAGE, topics: [HASH_A], data: '0x', position: position() };
+    expect(codeOf(() => orderedLogCommitment(page))).toBe('page-malformed');
+  });
+
+  it('authority is not claimable by declaration', () => {
+    // The predicate canonicalizes. A hand-built object carrying the right
+    // assurance string but malformed evidence must not answer true.
+    expect(
+      codeOf(() => isAuthoritativePage(originProof(holed('https://a.example.com', undefined)))),
+    ).toBe('page-malformed');
+    // …and a genuinely corroborated proof still answers true.
+    expect(isAuthoritativePage(proof())).toBe(true);
+  });
+});
+
+describe('raw event data is bounded per page, not by the identity cap (review P1-2)', () => {
+  const logWith = (data: string, logIndex = 0): RawLogV1 => ({
+    address: KA_STORAGE,
+    topics: [HASH_A],
+    data,
+    position: position({ logIndex }),
+  });
+
+  it('accepts a legal 21-entry MerkleRoot[] payload the 4096 identity cap rejected', () => {
+    // `setMerkleRoots` emits `KnowledgeAssetMerkleRootsUpdated(uint256,MerkleRoot[])`;
+    // each MerkleRoot is three ABI words, so 21 entries is 64 + 21*96 = 2080
+    // data bytes = 4162 hex chars. Under the old shared 4096-byte scalar cap this
+    // legal event was rejected — and it is a BLOCKING mutation, so W2 would have
+    // halted before persisting the latch that is supposed to fail closed.
+    const payloadBytes = 64 + 21 * 96;
+    expect(payloadBytes).toBe(2_080);
+    const data = `0x${'ab'.repeat(payloadBytes)}`;
+    expect(data.length).toBeGreaterThan(4_096);
+    expect(() => orderedLogCommitment([logWith(data)])).not.toThrow();
+  });
+
+  it('still refuses a page above the aggregate raw-bytes budget', () => {
+    const oversized = `0x${'ab'.repeat(MAX_ENCODED_UPDATE_LOG_BYTES_PER_PAGE / 2 + 8)}`;
+    expect(codeOf(() => orderedLogCommitment([logWith(oversized)]))).toBe('page-oversized');
+  });
+
+  it('charges the budget ACROSS logs, not per log', () => {
+    // Two logs each under the cap but jointly over it must still be refused.
+    const chunk = `0x${'cd'.repeat(Math.floor(MAX_ENCODED_UPDATE_LOG_BYTES_PER_PAGE / 3))}`;
+    expect(codeOf(() => orderedLogCommitment([logWith(chunk, 0), logWith(chunk, 1)]))).toBe(
+      'page-oversized',
+    );
+  });
+
+  it('keeps the tight cap on identity scalars', () => {
+    expect(codeOf(() => canonicalUalChainId(`base:${'9'.repeat(5_000)}`))).toBe(
+      'noncanonical-scalar',
+    );
+  });
+});
+
+describe('resume filtering compares identity at equality (review P1-4)', () => {
+  const resume = position({ blockNumber: 101, transactionIndex: 2, logIndex: 3 });
+
+  it('throws rather than silently discarding a DIFFERENT event at the same position', () => {
+    const impostor = { ...resume, transactionHash: HASH_C };
+    expect(compareEventPosition(impostor, resume)).toBe(0);
+    expect(sameEventIdentity(impostor, resume)).toBe(false);
+    expect(codeOf(() => isDiscardedByResume(impostor, resume))).toBe('resume-identity-conflict');
+  });
+
+  it('also catches a different block hash at the same position', () => {
+    expect(
+      codeOf(() => isDiscardedByResume({ ...resume, blockHash: HASH_C }, resume)),
+    ).toBe('resume-identity-conflict');
+  });
+
+  it('still discards the genuinely identical event and retains later ones', () => {
+    expect(isDiscardedByResume({ ...resume }, resume)).toBe(true);
+    expect(
+      isDiscardedByResume(position({ blockNumber: 101, transactionIndex: 2, logIndex: 4 }), resume),
+    ).toBe(false);
+    expect(
+      isDiscardedByResume(position({ blockNumber: 101, transactionIndex: 2, logIndex: 2 }), resume),
+    ).toBe(true);
+  });
+});
+
+describe('the exported UAL builder validates its inputs (review P2-2)', () => {
+  it('rejects a negative kaId instead of emitting a nonsense UAL', () => {
+    expect(codeOf(() => buildScopedKnowledgeAssetUal('84532', KA_STORAGE, -1n))).toBe(
+      'noncanonical-scalar',
+    );
+  });
+
+  it('rejects a kaId above uint256', () => {
+    expect(codeOf(() => buildScopedKnowledgeAssetUal('84532', KA_STORAGE, 1n << 256n))).toBe(
+      'ka-number-overflow',
+    );
+  });
+
+  it('rejects a noncanonical chain id and a non-address storage segment', () => {
+    expect(codeOf(() => buildScopedKnowledgeAssetUal('Base:84532', KA_STORAGE, 7n))).toBe(
+      'noncanonical-scalar',
+    );
+    expect(codeOf(() => buildScopedKnowledgeAssetUal('84532', 'not-an-address', 7n))).toBe(
+      'noncanonical-scalar',
+    );
+  });
+
+  it('rejects a mixed-case storage address rather than silently lowercasing it', () => {
+    expect(codeOf(() => buildScopedKnowledgeAssetUal('84532', `0x${'A1'.repeat(20)}`, 7n))).toBe(
+      'noncanonical-scalar',
+    );
+  });
+
+  it('still builds both canonical forms', () => {
+    expect(buildScopedKnowledgeAssetUal('84532', KA_STORAGE, 7n)).toBe(
+      `did:dkg:84532/${KA_STORAGE}/7`,
+    );
+    expect(
+      buildScopedKnowledgeAssetUal('84532', KA_STORAGE, (BigInt(OTHER_ADDRESS) << 96n) | 7n),
+    ).toBe(`did:dkg:84532/${OTHER_ADDRESS}/7`);
+  });
+});
+
+describe('closed vocabularies are frozen at runtime (review P2-1)', () => {
+  it('refuses mutation of every exported tuple', () => {
+    for (const vocabulary of [
+      UPDATE_PAGE_ASSURANCES,
+      VM_UPDATE_SCAN_OUTCOMES,
+      VM_UPDATE_EVENT_RESULTS,
+      VM_UPDATE_COVERAGE_STATES,
+      VM_UPDATE_ERROR_CODES,
+    ]) {
+      expect(Object.isFrozen(vocabulary)).toBe(true);
+      const before = [...vocabulary];
+      // `as const` is compile-time only; without a runtime freeze a consumer
+      // could widen a "closed" vocabulary at import time.
+      expect(() => (vocabulary as unknown as string[]).push('injected')).toThrow();
+      expect([...vocabulary]).toEqual(before);
+    }
+  });
+});
+
 describe('scope identity', () => {
   it('derives one id from the four identity fields', () => {
     expect(deriveVmUpdateScopeId(scope())).toBe(deriveVmUpdateScopeId(scope()));
@@ -415,14 +620,17 @@ describe('ordered log commitment', () => {
     // come straight off an untrusted RPC response.
     expect(MAX_LOG_TOPICS).toBe(4);
     expect(() => orderedLogCommitment([log({ topics: Array(4).fill(HASH_A) })])).not.toThrow();
+    // A length violation is `page-oversized`; a shape violation (non-array,
+    // hole, accessor) is `page-malformed`. Both refuse, but an operator reading
+    // the metric should be able to tell "too big" from "not well formed".
     expect(codeOf(() => orderedLogCommitment([log({ topics: Array(5).fill(HASH_A) })]))).toBe(
-      'page-malformed',
+      'page-oversized',
     );
 
     // A hostile page must be refused without the allocation. If the guard ran
     // after `topics.map`, this call would build a million-entry array first.
     const hostile = log({ topics: Array.from({ length: 1_000_000 }, () => HASH_A) });
-    expect(codeOf(() => orderedLogCommitment([hostile]))).toBe('page-malformed');
+    expect(codeOf(() => orderedLogCommitment([hostile]))).toBe('page-oversized');
   });
 
   it('rejects a non-array topics field rather than throwing a TypeError', () => {

--- a/packages/core/test/vm-update-convergence.test.ts
+++ b/packages/core/test/vm-update-convergence.test.ts
@@ -17,6 +17,7 @@ import {
   canonicalNullableAuthorAddress,
   canonicalPageProof,
   canonicalScopedKaCandidatesFromVerifiedUal,
+  canonicalUalChainId,
   canonicalUnsignedDecimal,
   canonicalVmUpdateScope,
   compareEventPosition,
@@ -177,6 +178,77 @@ describe('canonical scalars', () => {
     expect(canonicalUnsignedDecimal('0')).toBe(0n);
     expect(canonicalUnsignedDecimal('7')).toBe(7n);
     expect(codeOf(() => canonicalUnsignedDecimal('007'))).toBe('noncanonical-scalar');
+  });
+});
+
+describe('UAL chain ids are NAMESPACED, not bare decimals', () => {
+  // `ChainAdapter.chainId` is namespaced — its own doc comment says it is "not
+  // directly parseable with `BigInt()`" and that `getEvmChainId()` is the
+  // numeric one. Real UALs are `did:dkg:base:84532/…`, `did:dkg:otp:20430/…`,
+  // `did:dkg:hardhat:31337/…`. An earlier version of this module validated the
+  // scope's chain id as a bare decimal; every test used `84532` so the suite was
+  // green while the code would have rejected every mainnet and testnet UAL.
+  it('accepts the namespaced forms actually shipped', () => {
+    for (const chainId of ['base:84532', 'base:8453', 'gnosis:100', 'otp:20430', 'evm:31337', '31337', '1']) {
+      expect(canonicalUalChainId(chainId)).toBe(chainId);
+    }
+  });
+
+  it('still rejects a leading-zero alias in the decimal tail', () => {
+    // Otherwise `base:084532` and `base:84532` would be two scopes for one chain.
+    expect(codeOf(() => canonicalUalChainId('base:084532'))).toBe('noncanonical-scalar');
+    expect(codeOf(() => canonicalUalChainId('007'))).toBe('noncanonical-scalar');
+  });
+
+  it('rejects an uppercase namespace, an empty namespace, and a missing number', () => {
+    expect(codeOf(() => canonicalUalChainId('Base:84532'))).toBe('noncanonical-scalar');
+    expect(codeOf(() => canonicalUalChainId(':84532'))).toBe('noncanonical-scalar');
+    expect(codeOf(() => canonicalUalChainId('base:'))).toBe('noncanonical-scalar');
+    expect(codeOf(() => canonicalUalChainId('base'))).toBe('noncanonical-scalar');
+  });
+
+  it('parses a real namespaced UAL end to end', () => {
+    const namespaced = scope({ chainId: 'base:84532' });
+    const set = canonicalScopedKaCandidatesFromVerifiedUal(
+      namespaced,
+      `did:dkg:base:84532/${KA_STORAGE}/7`,
+    );
+    // Both candidates, exactly as for the bare-decimal chain: the namespace is
+    // carried through, not stripped.
+    expect(set.candidates.map((candidate) => candidate.kind).sort()).toEqual([
+      'legacy-sequential',
+      'rootless-packed',
+    ]);
+    for (const candidate of set.candidates) {
+      expect(buildScopedKnowledgeAssetUal('base:84532', KA_STORAGE, BigInt(candidate.kaId)))
+        .toBe(`did:dkg:base:84532/${KA_STORAGE}/7`);
+    }
+  });
+
+  it('still rejects a UAL from a different namespaced chain', () => {
+    expect(
+      codeOf(() =>
+        canonicalScopedKaCandidatesFromVerifiedUal(
+          scope({ chainId: 'base:84532' }),
+          `did:dkg:base:8453/${KA_STORAGE}/7`,
+        ),
+      ),
+    ).toBe('foreign-chain');
+    // …and one that drops the namespace entirely is a DIFFERENT chain id, not
+    // the same chain written another way.
+    expect(
+      codeOf(() =>
+        canonicalScopedKaCandidatesFromVerifiedUal(
+          scope({ chainId: 'base:84532' }),
+          `did:dkg:84532/${KA_STORAGE}/7`,
+        ),
+      ),
+    ).toBe('foreign-chain');
+  });
+
+  it('gives a namespaced and a bare chain id different scope ids', () => {
+    expect(deriveVmUpdateScopeId(scope({ chainId: 'base:84532' })))
+      .not.toBe(deriveVmUpdateScopeId(scope({ chainId: '84532' })));
   });
 });
 


### PR DESCRIPTION
﻿## Summary

**W2a part 1 of N.** W2 is the *update-convergence* half of D1 — making a node converge on finalized KA updates it never saw. This PR lands the two foundation chunks (plan §10.1 and the admission half of §10.2) and, along the way, fixes a live defect it uncovered. It is deliberately scoped so each piece is independently reviewable; §10.3 onward follow as separate PRs (list at the bottom).

**1. `packages/core/src/vm-update-convergence.ts` — the canonical value contracts (§10.1).** Scope identity, exact finalized-event identity, the ordered raw-log commitment, page-assurance proofs, the two-cursor model, the scoped KA candidate parser, and the closed outcome vocabularies. No chain client, no store, no I/O — every rule is testable without a node, an RPC endpoint, or a database.

Two rules in it are load-bearing and are pinned by tests that can fail:

- **`scopeId` is derived from the four IDENTITY fields only, never from `deploymentBlock`.** Including the anchor would make an anchor correction mint a *new* scope instead of triggering revision reset and replay inside the old one — orphaning every persisted cursor for that chain.
- **The candidate parser refuses to guess.** `did:dkg:<chain>/<KA-storage>/7` round-trips byte-for-byte under *both* the legacy-sequential and rootless-packed forms. It returns both and lets the store resolve which is live against chain provenance. Choosing either here would attribute a graph write to the wrong KA.

**2. `packages/chain/src/finalized-chain-read-admission.ts` — a per-chain limit that is actually per chain (§10.2, admission half). This is a live bug fix, not just W2 scaffolding.**

`CURRENT_FINALIZED_EVM_SNAPSHOT_MAX_CONCURRENT_PER_CHAIN_V1 = 1` has always documented *"one heavyweight pinned scan per chain"* — but it was enforced by a gate constructed **inside** `createStrictFinalizedEndpointRunnerV1`, i.e. one gate per transport instance. RFC64 builds its snapshot scope inside the precommit handler (`finalized-vm-agent-precommit-v1.ts:94`), so it built a fresh gate **per invocation** and contended with nothing. Two concurrent precommits on one chain both admitted, each running a full pinned multi-batch scan against the same RPC pool.

Permit state moves to module scope, keyed on the canonical chain id **alone**. `owner` (`foreground | rfc64 | w2-page | w2-target`) is carried for attribution only — putting it in the key would produce one lane per owner, which is the exact bug being removed. It is **optional and defaults to `foreground`** — a real label, not an "unknown" bucket — because this factory is published API; a test pins that the default takes the same shared permit rather than escaping it.

The one-shot read primitive deliberately keeps its own gate: its limit is 4, and folding it into the snapshot's single lane would throttle an unrelated path.

**3. `packages/core/src/ka-ual-identity.ts` — one owner for the legacy/rootless KA UAL rule.** `buildReconciledKnowledgeAssetUal` (agent) and `buildScopedKnowledgeAssetUal` (W2) both delegate to it, so there is no second production implementation of an identity rule. An earlier revision of this PR restated the rule in `core` and guarded the copy with a cross-package parity test; that was corrected in review — the dependency direction (`agent → chain → core`) never required the duplication.

**4. A second real defect, caught by re-reading the shipped contracts rather than my own tests.** `ChainAdapter.chainId` is **namespaced** — `base:84532`, `otp:20430`, `evm:31337` — and its own doc comment says it is *"not directly parseable with `BigInt()`"* (`getEvmChainId()` is the numeric one). UALs are built from the namespaced form. My scope validator required a canonical decimal, so `canonicalScopedKaCandidatesFromVerifiedUal` would have thrown for **every real mainnet and testnet UAL**. Every test used `84532`, so the suite was green against code that could not run anywhere real. Fixed, with the namespaced forms now covered explicitly.

## Related

- Part of #2018 (D1 from #2006) — the **update-convergence** half. #2033 (W1) delivered the measurement half and is the base for this branch.
- Follows #2033 / #2007 / #2006.
- Plan: `agent-docs/plans/2026-08-02-w2-update-convergence.md` (v13, local-only — `agent-docs/` is git-excluded).

**W2b is NOT in this PR and is gated on two open questions**, both of the same shape — a typed, designed, *green* outcome that satisfies every acceptance criterion while the feature does nothing:

- **§8.4.1** — W2b resolves its repair target with a pinned historical `eth_call` at the *covered* anchor, on shipped **non-archive** pools. If they will not serve it, W2b is permanently `finalized-state-unavailable` and every zero-side-effect criterion still passes. Needs one probe.
- **§8.4.2** — W2b admits only on a store declaring `processBoundMutationCompletionV1`. The plan excludes HTTP Blazegraph, **managed Oxigraph**, and generic SPARQL — and `oxigraph-server` *is* managed Oxigraph over `sparql-http`. So the only family that can declare it is `oxigraph`/`oxigraph-worker`/`oxigraph-persistent`, which is being retired. Needs a named successor backend, or W2b needs a design change.

W2a is unaffected by both: it is backend-agnostic and installs no mutation hook.

## Diagrams

### Finalized-read admission on one chain

Before:

```mermaid
sequenceDiagram
    participant P1 as RFC64 precommit #1
    participant P2 as RFC64 precommit #2
    participant F as createSnapshotScope()
    participant RPC as Chain RPC pool
    P1->>F: build scope (per invocation)
    F-->>P1: transport + its OWN gate(limit=1)
    P2->>F: build scope (per invocation)
    F-->>P2: transport + a SECOND gate(limit=1)
    P1->>RPC: pinned multi-batch scan
    P2->>RPC: pinned multi-batch scan (also admitted)
    Note over RPC: two heavyweight scans, limit says "1 per chain"
```

After:

```mermaid
sequenceDiagram
    participant P1 as RFC64 precommit #1
    participant P2 as W2 page scanner
    participant R as finalized-chain-read-admission (module scope)
    participant RPC as Chain RPC pool
    P1->>R: acquire(chainId, owner=rfc64)
    R-->>P1: permit
    P1->>RPC: pinned multi-batch scan
    P2->>R: acquire(chainId, owner=w2-page)
    R-->>P2: refused — concurrency-saturated (held by rfc64)
    P1->>R: release
    P2->>R: acquire(chainId, owner=w2-page)
    R-->>P2: permit
```

### Resolving which KA a verified UAL denotes

Before: no W2 path existed — the UAL's last segment was the identity.

After:

```mermaid
sequenceDiagram
    participant C as Caller (verified UAL)
    participant P as canonicalScopedKaCandidates…
    participant S as W2 store (later PR)
    C->>P: scope + did:dkg:base:84532/<KA-storage>/7
    P->>P: round-trip BOTH forms byte-for-byte
    P-->>C: [rootless-packed, legacy-sequential]
    C->>S: intersect candidates with this revision's chain provenance
    alt exactly one live
        S-->>C: selected KA + open mutation intent
    else two live
        S-->>C: ambiguous-w2-identity — mutation fails CLOSED
    end
```

## Files changed

| File | What |
|------|------|
| `packages/core/src/vm-update-convergence.ts` | New. §10.1 canonical contracts: scope id, event identity, log commitment, page proof, cursors, candidate parser, closed vocabularies |
| `packages/core/test/vm-update-convergence.test.ts` | New. 67 tests: namespaced chain ids, dense/accessor evidence, per-page byte budget, resume identity, frozen vocabularies, builder validation |
| `packages/core/src/index.ts` | Export the new module |
| `packages/chain/src/finalized-chain-read-admission.ts` | New. Process-wide per-chain permit, keyed on chain id alone, `owner` for attribution |
| `packages/chain/test/finalized-chain-read-admission.unit.test.ts` | New. 12 tests incl. every owner sharing one lane, release-on-throw, the frozen owner tuple, and contention classified by **identity** rather than by the shared `concurrency-saturated` code |
| `packages/chain/src/strict-current-finalized-evm-lifecycle.ts` | Takes an **injected** `EndpointAdmissionPolicyV1<K>` instead of knowing about owners; `maxConcurrentPerChain` left the runner contract; `saturated` reports the holder as a plain string |
| `packages/chain/src/strict-current-finalized-evm-types.ts` | Snapshot config types carrying an **optional** `owner` (defaults to `foreground`) |
| `packages/chain/src/strict-current-finalized-evm-config.ts` | Snapshot-path validator: **descriptors first**, then owner; rebuilds the base config from proven data properties. The read path is untouched |
| `packages/chain/src/strict-current-finalized-evm-snapshot-{transport,rpc,factory}.ts` | Thread the owner from public config to the runner |
| `packages/chain/src/index.ts` | Export the registry surface |
| `packages/chain/test/strict-current-finalized-evm-snapshot.unit.test.ts` | Registry reset hook; **new** cross-instance contention test; `owner` on 23 existing sites |
| `packages/chain/test/finalized-vm-chain-scanner.unit.test.ts` | `owner` on the one construction site |
| `packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts` | Pass `owner: 'rfc64'` — this is the per-invocation construction site |
| `packages/core/src/ka-ual-identity.ts` | New. **The single owner** of the legacy/rootless KA UAL rule; both entry points delegate to it |
| `packages/agent/src/ka-identity.ts` | `buildReconciledKnowledgeAssetUal` delegates to that owner; behaviour unchanged, including lowercasing the checksummed address its sole caller passes |
| `packages/agent/test/w2-ual-parity.test.ts` | Proves the delegation is real, and pins the `kaId >> 96` boundary with **absolute** expected strings — with one owner, comparing the two entry points is vacuous |
| `packages/chain/src/nonqueueing-admission.ts` | Owns the neutral `EndpointAdmissionPolicyV1<K>`, plus `createLocalNonqueueingAdmissionV1` — the per-instance policy for the one-shot read, whose limit is genuinely local |
| `packages/chain/test/snapshot-test-fixtures.ts` | New. Shared loopback/request helpers so the behaviour matrix and the admission suite do not duplicate them |
| `packages/chain/test/strict-finalized-snapshot-admission.unit.test.ts` | New. Cross-instance contention, published-shape compatibility, default-owner-does-not-bypass, release on throw |
| `packages/chain/test/strict-finalized-snapshot-config.unit.test.ts` | New. Accessor rejection with zero getter reads, parity with the base validator, explicit `null` owner policy |
| `packages/chain/src/finalized-chain-read-admission.ts` | Process-wide per-chain permit; also owns `isFinalizedChainAdmissionContention`, which matches refusals this module actually threw (a `WeakSet`) rather than a code three other paths also emit |
| `packages/agent/src/rfc64/public-catalog-receiver-v1.ts` | Chain-lane contention becomes a bounded, **detached** admission deferral instead of a provider failure. `deferred` is an explicit scheduler state observed by `whenIdle()`; provider retry bookkeeping moved onto the task so a deferral cannot reset `maxAttempts`; the deferral predicate is injectable |
| `packages/agent/test/rfc64-receiver-admission-deferral.test.ts` | New. 11 tests: head applies after contention rather than being lost; slot **and** scope lock released while waiting; `whenIdle()` does not resolve while deferred; duplicate-head dedupe and same-scope/different-head scheduling during a deferral; `maxAttempts` stays a true per-provider bound across deferrals; bounded give-up; ordinary errors still fail fast |
| `packages/agent/test/rfc64-precommit-owner-attribution.test.ts` | New. Drives the **real** precommit against a hanging RPC so the permit is genuinely held, then asserts the holder is `rfc64` — the only test that fails if the production owner label changes |
| `packages/agent/vitest.unit.config.ts` | Allowlist the three new agent tests (`include` is explicit — an unlisted file runs nothing) |

## Test plan

Run from the repo root. `packages/agent` resolves `dkg-core` through `dist`, so build first.

- [x] `pnpm --filter @origintrail-official/dkg-core build && pnpm --filter @origintrail-official/dkg-chain build && pnpm --filter @origintrail-official/dkg-agent build`
- [x] `pnpm --filter @origintrail-official/dkg-core exec vitest run test/vm-update-convergence.test.ts` → **67 passed**
- [x] `pnpm --filter @origintrail-official/dkg-chain exec vitest run --config vitest.unit.config.ts` (whole unit lane) → **854 passed, 1 skipped**
- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/w2-ual-parity.test.ts test/rfc64-receiver-admission-deferral.test.ts test/rfc64-precommit-owner-attribution.test.ts test/rfc64-finalized-vm-agent-precommit-v1.test.ts test/rfc64-finalized-vm-runtime-v1.test.ts test/rfc64-public-catalog-receiver-v1.test.ts` → **51 passed** (six suites, including the receiver's pre-existing one)
- [x] `pnpm --filter @origintrail-official/dkg-chain exec tsc --noEmit -p tsconfig.json` → clean

### Evidence the tests can fail

Green counts prove little on their own, so each claim below is a recorded **negative**.

- **Reachability sentinels.** A `throw` in `deriveVmUpdateScopeId` fails 16 core tests; a `throw` injected into the rebuilt `packages/core/dist/…` fails 9 of the 10 agent parity tests — proving the agent suite executes the rebuilt `dist` and not a stale copy. Both restored byte-identical (hash-verified).
- **8 behavioural mutants on §10.1**, applied serially with hash-verified restore: scopeId including `deploymentBlock`; `lengthPrefixed` → plain join; commitment dropping the raw payload; corroboration accepting one origin; resume skipping the partial block; the parser returning one candidate instead of the ambiguous pair; the author canonicalizer rejecting zero; the cursor guard weakened `<=` → `<`. **All 8 killed.**
- **The admission fix is proven by a negative.** Routing admission back to the per-instance gate fails **exactly one** test — the new *"contends across INDEPENDENTLY constructed scopes"* case. The two pre-existing saturation tests stay **green** under that mutant, because both reuse a single handle and so could never discriminate per-instance from per-chain. That is why the defect survived.
- **The chain-id fix is proven by a negative.** Restoring the bare-decimal validator fails exactly the 4 new namespaced tests and leaves the other 41 green.

### One finding worth flagging to the reviewer

A mutant **survived** during §10.1, and it was my own test's fault: two "boundary collision" assertions compared inputs of *different total content*, which any encoding distinguishes — they could never have failed for the property they claimed to pin. They now compare tuples with identical concatenations and differing field boundaries (`'84532'+'abc'` vs `'8453'+'2abc'`; adjacent variable-width `txIndex`/`logIndex` `(1,23)` vs `(12,3)`). The original mutant was *also* wrong — zeroing a length field leaves four constant NUL bytes still acting as a delimiter — so the corrected mutant collapses `lengthPrefixed` to a plain join, and kills exactly those two tests.

### Known, and not caused by this PR

`packages/core/test/{project-ontology,sync-control-object}.test.ts` fail locally with 5 s timeouts. Verified pre-existing by removing this PR's single barrel-export line and re-running — both still red with the branch's only shared-surface change reverted.

## What follows

Remaining W2a chunks, in order. Each is its own PR.

| Chunk | Scope |
|---|---|
| §10.2 (rest) | Historical-anchor snapshot generalization; two-distinct-origin session selection (`CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1` is 2 while shipped pools carry 3 URLs, and origin normalization currently dedups on full `url.href`, not origin); the fairness/reservation contract |
| §10.3 | Finalized update-page transport: pinned primary + distinct-origin corroboration, four-topic root-mutation scan, adaptive range, typed errors. Needs shipped `knowledgeAssetStorageDeployment` anchors, which **no network overlay carries today** |
| §10.4 | SQLite schema 32 + store |
| §10.5–10.6 | Daemon wiring and the W2a runtime |
| §10.10 | Config, telemetry (`EXPECTED_CORROBORATING`, not `EXPECTED_INSTRUMENTS` — the latter reds the build), docs |


---

## Review rounds applied

This description reflects head `3c5ebb995`. Three rounds have landed since the PR opened; the sections above are current, and the substantive changes are:

**Round 1 — `otReviewAgent`, 8 findings, 7 accepted (`977e02a43`).** The `owner` API break (now defaults to `foreground`), an unbounded `topics` array, a page proof accepting impossible same-height hashes, duplicated canonical-scalar regexes, the `sharedOwner` mode flag replaced by an injected admission policy, admission tests split out, and shallow freeze assertions made behavioural. Deferred: splitting the core module into ~8 files, with reasoning on the thread.

**Round 2 — `otReviewAgent`, 1 finding (`36332221f`).** A regression I introduced in round 1: `{ owner, ...rest }` ran before validation, so object rest executed the caller's enumerable getters and flattened them into data properties — the wrapper then **accepted** a config the base validator rejects untouched (measured: base rejected with 0 getter invocations, wrapper accepted with 1). Descriptors are now validated on the original input first.

**Round 3 — merge-readiness review (`3c5ebb995`).** All six P1s and all three P2s:

| Finding | Resolution |
|---|---|
| P1 sparse arrays mint false corroboration | `denseDataArray` — length before iteration, own-descriptor per index, getters never invoked; applied to origins, the page, and topics. `isAuthoritativePage` canonicalizes instead of trusting the assurance string |
| P1 4,096-byte cap rejects valid events | Raw log bytes moved to a per-page 8 MiB budget; a legal 21-entry `MerkleRoot[]` (2,080 bytes) now passes. Identity scalars keep the tight cap |
| P1 contention discards an RFC64 head | Nested `concurrency-saturated` becomes a detached, bounded deferral that gives the attempt back and releases both the slot and the scope lock |
| P1 resume identity conflict | Equal ordering now requires `sameEventIdentity`; otherwise the new typed `resume-identity-conflict`. Hashes stay out of the comparator |
| P1 store interface cannot enforce CAS | Removed; lands with the store slice |
| P1 config getters before validation | Fixed in round 2; this round adds the explicit `null`/`undefined` owner policy |
| P2 mutable vocabularies | All six tuples `Object.freeze`d |
| P2 builder accepts invalid input | Validates chain id, address, and `0 <= kaId <= uint256.max` |
| P2 no test reaches the real RFC64 factory | Done in `1999de2bc` — see round 3b below |

**Round 3b — the item round 3 left open (`1999de2bc`).** The merge-readiness review showed `owner: 'rfc64'` → `'foreground'` surviving the focused RFC64 suites 10/10, because nothing reached the real factory. `rfc64-precommit-owner-attribution.test.ts` now drives the real precommit against an RPC that accepts and never answers, so the permit is genuinely held; a second owner then probes the registry for the holder. That mutant now fails exactly one test.

**Round 4 — 4 findings, 1 🔴 (`4c874a582`).** The 🔴 was a regression from round 3: the deferral released the slot *and* the queue entry, so a deferred head was invisible to `#isIdle()` and `whenIdle()` resolved mid-retry — a caller draining the receiver could conclude scheduling had settled before the head applied. `deferred` is now an explicit state observed by idle, reported in `stats()`, cleared on close and on give-up. Also: contention classification moved out of the receiver into the chain package that owns the code (injectable via `isDeferrableError`); `EndpointAdmissionPolicyV1` moved to the neutral module; deferred-head dedupe covered. One suggestion declined with reasoning on its thread (moving deferral into the reconciler's return type).

**Round 5 — 1 🔴 (`80d53fc3e`).** The classifier matched the `concurrency-saturated` **code**, which is shared: the snapshot session's reentrancy guard and the one-shot read's limit gate both emit it. A genuine integration bug would have been deferred as contention and reported as a lane-wait failure. Now matched by identity — a `WeakSet` of refusals `acquireFinalizedChainRead` actually threw. This also invalidated my own test fixture, correctly; those tests now inject the policy, and a new test proves the *default* wiring end to end against a real refusal plus a look-alike that must still fail fast.

**Round 6 — 1 🟡 (`8ef662661`).** The KA UAL rule now has a single owner in `core`; my earlier deferral rationale was wrong (I had conflated it with moving `buildKnowledgeAssetUal` out of `chain` — 62 references — when the real change is one function with one production caller). Two notes: I reversed my own mixed-case rejection, because the sole caller passes the checksummed address from `getDKGKnowledgeAssetsAddress()` and builders should normalize; and the consolidation silently weakened the test until a mutant caught it — with one owner, comparing the two entry points is vacuous, so the boundary is now pinned with absolute expected strings.

**Round 7 — 2 findings, 1 🔴 (`da575b511`).** The 🔴: my deferral tests used a casted fixture setting fields that do not exist on the wire type, so every announcement collapsed to one `headKey` of `undefined`s — the dedupe test **could not fail**. Replaced with a type-correct fixture, plus a test that asserts the premise itself, plus the same-scope/different-head case proving the scope lock is released. The 🟡: provider retry bookkeeping was local to `#runTask`, so a deferral reset it and `maxAttempts` stopped bounding anything once contention interleaved with ordinary failures; it now lives on the task, with contention refunding only its own attempt.

## Open by choice

Two items are deliberately not done, both argued on their threads rather than quietly dropped:

1. **Splitting the core module into ~8 files.** Deferred until §10.3–§10.6 land. The section comments are my *predicted* seams; once the chain transport, the SQLite store and the runtime consume these contracts, some will merge or move rather than split 1:1, and doing it now churns the same files twice. Proposed as a pure no-behaviour-change move at the end of W2a.
2. **Moving deferral into the reconciler's return type.** The precommit throws from deep in the chain stack, so something must still classify a thrown error — this relocates the classification rather than removing it, and changes a contract shared with the native receiver. I offered to do it if the reviewer disagrees.

**On the local Windows test noise** the merge-readiness review also saw: I re-ran the six RFC64 files that fail locally, on a clean build, and read the actual failure text rather than inferring. It is `EBUSY: resource busy or locked, unlink '…inventory-v1.lease.sqlite3'` plus `AbortError: The operation was aborted due to timeout` in the protocol router — Windows file locking and libp2p dial timeouts, in code paths this PR does not touch. Applying the receiver deferral did not change them, which further separates them from the contention finding. Linux CI is green on those same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaXdkmteqStxGBpXcUPGd1
