### PR TITLE
fix(agent): relieve repeated sync pressure

### DIFF
--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -52,8 +52,11 @@ export type OrdinalOutcome =
   | { status: 'skip' };
 
 export interface OrdinalRecoveryTarget {
+  localCgId: string;
+  onChainCgId: string;
   ordinal: number;
   ual: string;
+  merkleRoot: string;
   kaId: string;
   reason: 'no-swm' | 'verified-vm-metadata-pending';
 }

--- a/packages/agent/src/context-graph-binding-generation.ts
+++ b/packages/agent/src/context-graph-binding-generation.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+interface ContextGraphBindingGenerationOwner {
+  readonly contextGraphBindingGenerations?: Map<string, number>;
+}
+
+const fallbackGenerations = new WeakMap<object, Map<string, number>>();
+
+function generationsFor(owner: object): Map<string, number> {
+  const owned = (owner as ContextGraphBindingGenerationOwner).contextGraphBindingGenerations;
+  if (owned) return owned;
+  let fallback = fallbackGenerations.get(owner);
+  if (!fallback) {
+    fallback = new Map<string, number>();
+    fallbackGenerations.set(owner, fallback);
+  }
+  return fallback;
+}
+
+export function bumpContextGraphBindingGeneration(
+  owner: object,
+  localCgId: string,
+): number {
+  const generations = generationsFor(owner);
+  const generation = (generations.get(localCgId) ?? 0) + 1;
+  generations.set(localCgId, generation);
+  return generation;
+}
+
+export function captureContextGraphBindingGeneration(
+  owner: object,
+  localCgId: string,
+): number {
+  return generationsFor(owner).get(localCgId) ?? 0;
+}
+
+export function isContextGraphBindingGenerationCurrent(
+  owner: object,
+  localCgId: string,
+  generation: number,
+): boolean {
+  return captureContextGraphBindingGeneration(owner, localCgId) === generation;
+}
+
+export function clearContextGraphBindingGeneration(
+  owner: object,
+  localCgId: string,
+): void {
+  generationsFor(owner).delete(localCgId);
+}

--- a/packages/agent/src/context-graph-binding-generation.ts
+++ b/packages/agent/src/context-graph-binding-generation.ts
@@ -1,50 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
-interface ContextGraphBindingGenerationOwner {
-  readonly contextGraphBindingGenerations?: Map<string, number>;
-}
-
-const fallbackGenerations = new WeakMap<object, Map<string, number>>();
-
-function generationsFor(owner: object): Map<string, number> {
-  const owned = (owner as ContextGraphBindingGenerationOwner).contextGraphBindingGenerations;
-  if (owned) return owned;
-  let fallback = fallbackGenerations.get(owner);
-  if (!fallback) {
-    fallback = new Map<string, number>();
-    fallbackGenerations.set(owner, fallback);
-  }
-  return fallback;
-}
-
 export function bumpContextGraphBindingGeneration(
-  owner: object,
+  generations: Map<string, number>,
   localCgId: string,
 ): number {
-  const generations = generationsFor(owner);
   const generation = (generations.get(localCgId) ?? 0) + 1;
   generations.set(localCgId, generation);
   return generation;
 }
 
 export function captureContextGraphBindingGeneration(
-  owner: object,
+  generations: Map<string, number>,
   localCgId: string,
 ): number {
-  return generationsFor(owner).get(localCgId) ?? 0;
+  return generations.get(localCgId) ?? 0;
 }
 
 export function isContextGraphBindingGenerationCurrent(
-  owner: object,
+  generations: Map<string, number>,
   localCgId: string,
   generation: number,
 ): boolean {
-  return captureContextGraphBindingGeneration(owner, localCgId) === generation;
+  return captureContextGraphBindingGeneration(generations, localCgId) === generation;
 }
 
 export function clearContextGraphBindingGeneration(
-  owner: object,
+  generations: Map<string, number>,
   localCgId: string,
 ): void {
-  generationsFor(owner).delete(localCgId);
+  generations.delete(localCgId);
 }

--- a/packages/agent/src/context-graph-membership-persist-scheduler.ts
+++ b/packages/agent/src/context-graph-membership-persist-scheduler.ts
@@ -18,8 +18,11 @@ export class ContextGraphMembershipPersistQueueClosedError extends Error {
   }
 }
 
+export const CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_ERROR_CODE =
+  'CG_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT';
+
 export class ContextGraphMembershipPersistShutdownTimeoutError extends Error {
-  readonly code = 'CG_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT';
+  readonly code = CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_ERROR_CODE;
 
   constructor(timeoutMs: number) {
     super(`Context-graph membership persistence did not drain within ${timeoutMs}ms`);

--- a/packages/agent/src/context-graph-membership-persist-scheduler.ts
+++ b/packages/agent/src/context-graph-membership-persist-scheduler.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export class ContextGraphMembershipPersistQueueFullError extends Error {
+  readonly code = 'CG_MEMBERSHIP_PERSIST_QUEUE_FULL';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContextGraphMembershipPersistQueueFullError';
+  }
+}
+
+export class ContextGraphMembershipPersistQueueClosedError extends Error {
+  readonly code = 'CG_MEMBERSHIP_PERSIST_QUEUE_CLOSED';
+
+  constructor() {
+    super('Context-graph membership persistence is closed');
+    this.name = 'ContextGraphMembershipPersistQueueClosedError';
+  }
+}
+
+export class ContextGraphMembershipPersistShutdownTimeoutError extends Error {
+  readonly code = 'CG_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT';
+
+  constructor(timeoutMs: number) {
+    super(`Context-graph membership persistence did not drain within ${timeoutMs}ms`);
+    this.name = 'ContextGraphMembershipPersistShutdownTimeoutError';
+  }
+}
+
+interface PendingWrite {
+  strict: boolean;
+  write: () => Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
+
+interface PersistLane {
+  active: boolean;
+  pending: PendingWrite[];
+  drained: Promise<void>;
+  resolveDrained: () => void;
+}
+
+export interface ContextGraphMembershipPersistSchedulerStatus {
+  closed: boolean;
+  lanes: number;
+  active: number;
+  pending: number;
+}
+
+/**
+ * Bounded keyed serialization for membership-store mutations.
+ *
+ * Strict operations preserve FIFO order and receive explicit backpressure.
+ * Adjacent background mutations coalesce to their latest write while the
+ * displaced caller settles successfully: those callers are deliberately
+ * best-effort, and only the final persisted state is meaningful.
+ */
+export class ContextGraphMembershipPersistScheduler {
+  private readonly lanes = new Map<string, PersistLane>();
+  private closed = false;
+
+  constructor(
+    private readonly maxLanes = 1_000,
+    private readonly maxPendingPerLane = 16,
+  ) {
+    if (!Number.isSafeInteger(maxLanes) || maxLanes < 1) {
+      throw new Error('Membership persistence maxLanes must be a positive safe integer');
+    }
+    if (!Number.isSafeInteger(maxPendingPerLane) || maxPendingPerLane < 1) {
+      throw new Error('Membership persistence maxPendingPerLane must be a positive safe integer');
+    }
+  }
+
+  enqueue(
+    key: string,
+    write: () => Promise<void>,
+    options: { strict?: boolean } = {},
+  ): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(new ContextGraphMembershipPersistQueueClosedError());
+    }
+
+    let lane = this.lanes.get(key);
+    if (!lane) {
+      if (this.lanes.size >= this.maxLanes) {
+        return Promise.reject(new ContextGraphMembershipPersistQueueFullError(
+          `Context-graph membership persistence reached its ${this.maxLanes}-lane limit`,
+        ));
+      }
+      let resolveDrained!: () => void;
+      const drained = new Promise<void>((resolve) => { resolveDrained = resolve; });
+      lane = { active: false, pending: [], drained, resolveDrained };
+      this.lanes.set(key, lane);
+    }
+
+    const strict = options.strict === true;
+    return new Promise<void>((resolve, reject) => {
+      const tail = lane!.pending.at(-1);
+      if (!strict && tail && !tail.strict) {
+        tail.resolve();
+        lane!.pending[lane!.pending.length - 1] = { strict, write, resolve, reject };
+      } else {
+        if (lane!.pending.length >= this.maxPendingPerLane) {
+          reject(new ContextGraphMembershipPersistQueueFullError(
+            `Context-graph membership persistence key "${key}" reached its `
+            + `${this.maxPendingPerLane}-write pending limit`,
+          ));
+          return;
+        }
+        lane!.pending.push({ strict, write, resolve, reject });
+      }
+      if (!lane!.active) {
+        lane!.active = true;
+        void this.runLane(key, lane!);
+      }
+    });
+  }
+
+  closeAndDrain(): Promise<void> {
+    this.closed = true;
+    return Promise.all([...this.lanes.values()].map((lane) => lane.drained)).then(() => undefined);
+  }
+
+  reopen(): void {
+    if (this.lanes.size > 0) {
+      throw new Error('Cannot reopen context-graph membership persistence before it drains');
+    }
+    this.closed = false;
+  }
+
+  status(): ContextGraphMembershipPersistSchedulerStatus {
+    let active = 0;
+    let pending = 0;
+    for (const lane of this.lanes.values()) {
+      if (lane.active) active += 1;
+      pending += lane.pending.length;
+    }
+    return { closed: this.closed, lanes: this.lanes.size, active, pending };
+  }
+
+  private async runLane(key: string, lane: PersistLane): Promise<void> {
+    while (lane.pending.length > 0) {
+      const operation = lane.pending.shift()!;
+      try {
+        await operation.write();
+        operation.resolve();
+      } catch (error) {
+        operation.reject(error);
+      }
+    }
+    lane.active = false;
+    if (this.lanes.get(key) === lane) this.lanes.delete(key);
+    lane.resolveDrained();
+  }
+}

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -113,6 +113,11 @@ export class DiscoveryClient {
     agentAddress: string,
     options: { afterPeerId?: string; limit?: number; signal?: AbortSignal } = {},
   ): Promise<string[]> {
+    const isEvmAddress = /^0x[0-9a-fA-F]{40}$/.test(agentAddress);
+    const addressMatch = isEvmAddress
+      ? `?agent <${DKG}agentAddress> ?storedAgentAddress .
+        FILTER(LCASE(STR(?storedAgentAddress)) = "${escapeSparqlLiteral(agentAddress.toLowerCase())}")`
+      : `?agent <${DKG}agentAddress> "${escapeSparqlLiteral(agentAddress)}" .`;
     const limit = options.limit === undefined
       ? undefined
       : Math.max(1, Math.floor(options.limit));
@@ -122,8 +127,8 @@ export class DiscoveryClient {
     const result = await this.engine.query(`
       SELECT DISTINCT ?peerId WHERE {
         ?agent a <${DKG}Agent> ;
-               <${DKG}agentAddress> "${escapeSparqlLiteral(agentAddress)}" ;
                <${DKG}peerId> ?peerId .
+        ${addressMatch}
         ${afterFilter}
       }
       ORDER BY ASC(STR(?peerId))

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -59,10 +59,18 @@ export class DiscoveryClient {
     this.engine = engine;
   }
 
-  async findAgents(options: { framework?: string; limit?: number } = {}): Promise<DiscoveredAgent[]> {
+  async findAgents(options: {
+    framework?: string;
+    agentAddress?: string;
+    limit?: number;
+    signal?: AbortSignal;
+  } = {}): Promise<DiscoveredAgent[]> {
     let filter = '';
     if (options.framework) {
       filter += `\n      ?agent <${SKILL}framework> "${escapeSparqlLiteral(options.framework)}" .`;
+    }
+    if (options.agentAddress) {
+      filter += `\n      ?agent <${DKG}agentAddress> "${escapeSparqlLiteral(options.agentAddress)}" .`;
     }
 
     const limitClause = options.limit ? `LIMIT ${options.limit}` : '';
@@ -80,7 +88,10 @@ export class DiscoveryClient {
       ${limitClause}
     `;
 
-    const result = await this.engine.query(sparql, { contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH });
+    const result = await this.engine.query(sparql, {
+      contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH,
+      signal: options.signal,
+    });
 
     return result.bindings.map((row) => ({
       agentUri: row['agent'],
@@ -91,6 +102,40 @@ export class DiscoveryClient {
       relayAddress: row['relayAddress'] ? stripQuotes(row['relayAddress']) : undefined,
       agentAddress: row['agentAddress'] ? stripQuotes(row['agentAddress']) : undefined,
     }));
+  }
+
+  /**
+   * Deterministic, duplicate-free wallet-to-peer lookup for bounded recovery.
+   * Rich profile rows are deliberately not selected here: OPTIONAL profile
+   * properties can multiply rows before LIMIT and permanently hide a peer.
+   */
+  async findAgentPeerIdsByAddress(
+    agentAddress: string,
+    options: { afterPeerId?: string; limit?: number; signal?: AbortSignal } = {},
+  ): Promise<string[]> {
+    const limit = options.limit === undefined
+      ? undefined
+      : Math.max(1, Math.floor(options.limit));
+    const afterFilter = options.afterPeerId
+      ? `FILTER(STR(?peerId) > "${escapeSparqlLiteral(options.afterPeerId)}")`
+      : '';
+    const result = await this.engine.query(`
+      SELECT DISTINCT ?peerId WHERE {
+        ?agent a <${DKG}Agent> ;
+               <${DKG}agentAddress> "${escapeSparqlLiteral(agentAddress)}" ;
+               <${DKG}peerId> ?peerId .
+        ${afterFilter}
+      }
+      ORDER BY ASC(STR(?peerId))
+      ${limit === undefined ? '' : `LIMIT ${limit}`}
+    `, {
+      contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH,
+      signal: options.signal,
+    });
+
+    return result.bindings
+      .map((row) => stripQuotes(row['peerId'] ?? ''))
+      .filter((peerId) => peerId.length > 0);
   }
 
   async findSkillOfferings(options: SkillSearchOptions = {}): Promise<DiscoveredOffering[]> {
@@ -144,7 +189,10 @@ export class DiscoveryClient {
     }));
   }
 
-  async findAgentByPeerId(peerId: string): Promise<DiscoveredAgent | null> {
+  async findAgentByPeerId(
+    peerId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<DiscoveredAgent | null> {
     // Two-query path keeps the existing single-row SELECT semantics
     // for scalar columns (name, framework, nodeRole, relayAddress,
     // lastSeen) while a separate query gathers all `dkg:multiaddr`
@@ -174,7 +222,10 @@ export class DiscoveryClient {
       LIMIT 1
     `;
 
-    const scalarResult = await this.engine.query(scalar, { contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH });
+    const scalarResult = await this.engine.query(scalar, {
+      contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH,
+      signal: options.signal,
+    });
     if (scalarResult.bindings.length === 0) return null;
 
     const row = scalarResult.bindings[0];
@@ -202,7 +253,10 @@ export class DiscoveryClient {
         ${sparqlIri(safeAgentIri)} <${DKG}multiaddr> ?multiaddr .
       }
     `;
-    const multiResult = await this.engine.query(multiSparql, { contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH });
+    const multiResult = await this.engine.query(multiSparql, {
+      contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH,
+      signal: options.signal,
+    });
     const multiaddrs = multiResult.bindings
       .map((r) => (r['multiaddr'] ? stripQuotes(r['multiaddr']) : ''))
       .filter((s) => s.length > 0);

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -990,6 +990,9 @@ export class DKGAgentBase {
   protected vmReconcileStartupTimer: ReturnType<typeof setTimeout> | null = null;
   /** Process-wide sweep single-flight; interval/startup callers join this promise. */
   protected vmReconcileSweepInFlight: Promise<void> | null = null;
+  /** Closed dispatcher retained across restart until its old worker and sweep fully drain. */
+  protected vmReconcileRetirementInFlight: Promise<void> | null = null;
+  protected vmReconcileRetiringDispatcher: VmReconcileDispatcher<ContextGraphReconcileResult> | undefined;
   /** Phase B — in-memory reconcile cursor per local CG id (watermark + `ahead`). */
   protected readonly reconcileCursors = new Map<string, CursorState>();
   /** Phase B — bounded dedupe of recently-reconciled UALs (live-burst guard). */
@@ -1015,8 +1018,8 @@ export class DKGAgentBase {
   protected readonly vmReconcileCuratorPeersByCg = new Map<string, string[]>();
   /** Late exact responses must not mutate rotation state after shutdown begins. */
   protected vmReconcileRotationClosed = false;
-  /** Monotonic guard: continuations from an earlier node run stay stale after restart. */
-  protected vmReconcileRotationGeneration = 0;
+  /** Monotonic guard: every VM reconcile continuation from an earlier node run stays stale. */
+  protected vmReconcileLifecycleGeneration = 0;
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();
   /** Phase D/A4 — round-robin cursor over the already ordered catch-up peer list. */

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1015,6 +1015,8 @@ export class DKGAgentBase {
   protected readonly vmReconcileCuratorPeersByCg = new Map<string, string[]>();
   /** Late exact responses must not mutate rotation state after shutdown begins. */
   protected vmReconcileRotationClosed = false;
+  /** Monotonic guard: continuations from an earlier node run stay stale after restart. */
+  protected vmReconcileRotationGeneration = 0;
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();
   /** Phase D/A4 — round-robin cursor over the already ordered catch-up peer list. */

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1002,6 +1002,8 @@ export class DKGAgentBase {
   protected readonly vmReconcileNegativeCacheKeysByCg = new Map<string, Set<string>>();
   /** Bounded, process-local clean-absence rotations for production VM recovery. */
   protected readonly vmReconcileRotationState = new Map<string, VmReconcileRotationRecord>();
+  /** Last resolved curator peers, used to keep the capped exact-recovery roster authoritative. */
+  protected readonly vmReconcileCuratorPeersByCg = new Map<string, string[]>();
   /** Late exact responses must not mutate rotation state after shutdown begins. */
   protected vmReconcileRotationClosed = false;
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -24,6 +24,7 @@ import type { Rfc64PublicCatalogServiceV1 } from './rfc64/public-catalog-service
 import type { Rfc64PublicCatalogNativeSynchronizationEvidenceV1 } from './rfc64/public-catalog-native-receiver-v1.js';
 import { Rfc64PublicCatalogReconciliationFailureRegistryV1 } from './rfc64/public-catalog-reconciliation-failure-v1.js';
 import { resolveVmReconcileStartupMaxDelayMs } from './startup-jitter.js';
+import { ContextGraphMembershipPersistScheduler } from './context-graph-membership-persist-scheduler.js';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -986,6 +987,17 @@ export class DKGAgentBase {
   protected vmReconcileTimer: ReturnType<typeof setInterval> | null = null;
   /** Phase B — unified per-CG coalescing and node-wide admission policy. */
   protected vmReconcileDispatcher?: VmReconcileDispatcher<ContextGraphReconcileResult>;
+  /** Closed dispatcher retained until every physically active worker settles. */
+  protected vmReconcileRetirement: Promise<void> | null = null;
+  /** Reconcile engines may outlive a caller's abort race; stop drains these before store teardown. */
+  protected readonly vmReconcilePhysicalRuns = new Set<Promise<unknown>>();
+  /** Admitted authenticated graph-scoped stores must physically drain before backing-store teardown. */
+  protected readonly graphScopedStorePhysicalRuns = new Set<Promise<unknown>>();
+  protected graphScopedStoreClosed = false;
+  /** True only after startup has installed every dependency the VM worker uses. */
+  protected vmReconcileRuntimeReady = false;
+  /** A timed-out physical retirement quarantines this instance until stop is retried. */
+  protected vmReconcileShutdownBlocked = false;
   /** Next eligible CG index for bounded periodic-sweep admission. */
   protected vmReconcileSweepCursor = 0;
   /** Deterministically staggered cold-start prime, separate from the interval. */
@@ -1008,13 +1020,21 @@ export class DKGAgentBase {
   protected coreHostRecordingGeneration = 0;
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
   protected readonly vmReconcileNegativeCache = new Map<string, Omit<VmReconcileNegativeRecord, 'cacheKey'>>();
-  /** Keys already consulted in the durable store during this process lifetime. */
-  protected readonly vmReconcileNegativeCacheHydrated = new Set<string>();
+  /** Bounded access-ordered keys already consulted in the durable store. */
+  protected readonly vmReconcileNegativeCacheHydrated = new Map<string, string>();
   protected readonly vmReconcileNegativeCacheKeysByCg = new Map<string, Set<string>>();
   /** Bounded, process-local clean-absence rotations for production VM recovery. */
   protected readonly vmReconcileRotationState = new Map<string, VmReconcileRotationRecord>();
+  /** Next stable batch index to consider when the bounded rotation cache has waiters. */
+  protected readonly vmReconcileRotationAdmissionCursorByCg = new Map<string, number>();
   /** Last resolved curator peers, used to keep the capped exact-recovery roster authoritative. */
   protected readonly vmReconcileCuratorPeersByCg = new Map<string, string[]>();
+  /** Exclusive peer-id cursor used to walk oversized curator registries. */
+  protected readonly vmReconcileCuratorPageCursorByCg = new Map<string, string>();
+  /** Bounded per-principal persistence lanes keep compensation ordered without heap backlog. */
+  protected readonly contextGraphMembershipPersistence = new ContextGraphMembershipPersistScheduler();
+  protected contextGraphMembershipPersistenceShutdownBlocked = false;
+  static readonly CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_MS = 5_000;
   /** Late exact responses must not mutate rotation state after shutdown begins. */
   protected vmReconcileRotationClosed = false;
   /** Monotonic guard: every VM reconcile continuation from an earlier node run stays stale. */
@@ -1085,6 +1105,8 @@ export class DKGAgentBase {
   /** Serialize local author-head construction/CAS independently per exact scope. */
   protected readonly rfc64AuthorCatalogMutationQueuesV1 = new Map<string, Promise<void>>();
   protected readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
+  /** Monotonic per-CG fence for async work captured across an on-chain binding transition. */
+  protected readonly contextGraphBindingGenerations = new Map<string, number>();
   protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
   protected readonly contextGraphSubscriptionRehydrationAccountedIds = new Set<string>();
   protected readonly contextGraphSubscriptionPersistRevisions = new Map<string, number>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -916,8 +916,10 @@ export class DKGAgentBase {
   );
   static readonly VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS']) || 2_000);
-  static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES =
-    Math.max(1, Number(process.env['DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES']) || 1_000);
+  static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES = readPositiveSafeIntegerEnv(
+    'DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES',
+    1_000,
+  );
   /** Exact recovery keeps its existing curator/core-first three-peer fanout cap. */
   static readonly VM_RECONCILE_EXACT_PEER_MAX = 3;
   static readonly VM_RECONCILE_QUEUE_MAX_PENDING =

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -420,6 +420,11 @@ function readNonNegativeNumberEnv(name: string, fallback: number): number {
   return Number.isFinite(parsed) ? Math.max(0, parsed) : fallback;
 }
 
+function readPositiveSafeIntegerEnv(name: string, fallback: number): number {
+  const parsed = Number(process.env[name]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export function createListContextGraphsCacheInvalidatingStore(
   innerStore: TripleStore,
   invalidate: () => void,
@@ -905,8 +910,10 @@ export class DKGAgentBase {
       ? configured
       : 10 * 60_000;
   })();
-  static readonly VM_RECONCILE_CACHE_MAX_ENTRIES =
-    Math.max(1, Number(process.env['DKG_VM_RECONCILE_CACHE_MAX_ENTRIES']) || 1_000);
+  static readonly VM_RECONCILE_CACHE_MAX_ENTRIES = readPositiveSafeIntegerEnv(
+    'DKG_VM_RECONCILE_CACHE_MAX_ENTRIES',
+    1_000,
+  );
   static readonly VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS']) || 2_000);
   static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES =

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -362,6 +362,7 @@ import {
   type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
   type VmReconcileNegativeRecord,
+  type VmReconcileRotationRecord,
   type ContextGraphMemberPrincipalType,
   type ContextGraphMemberStatus,
   type ContextGraphMembershipRecord,
@@ -898,14 +899,20 @@ export class DKGAgentBase {
     );
   static readonly VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS =
     Math.max(5_000, DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS);
-  static readonly VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS =
-    Number(process.env['DKG_VM_RECONCILE_BACKOFF_MAX_MS']) || 10 * 60_000;
+  static readonly VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS = (() => {
+    const configured = Number(process.env['DKG_VM_RECONCILE_BACKOFF_MAX_MS']);
+    return Number.isFinite(configured) && configured > 0
+      ? configured
+      : 10 * 60_000;
+  })();
   static readonly VM_RECONCILE_CACHE_MAX_ENTRIES =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CACHE_MAX_ENTRIES']) || 1_000);
   static readonly VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS']) || 2_000);
   static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES']) || 1_000);
+  /** Exact recovery keeps its existing curator/core-first three-peer fanout cap. */
+  static readonly VM_RECONCILE_EXACT_PEER_MAX = 3;
   static readonly VM_RECONCILE_QUEUE_MAX_PENDING =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_QUEUE_MAX_PENDING']) || 256);
   /**
@@ -993,6 +1000,10 @@ export class DKGAgentBase {
   /** Keys already consulted in the durable store during this process lifetime. */
   protected readonly vmReconcileNegativeCacheHydrated = new Set<string>();
   protected readonly vmReconcileNegativeCacheKeysByCg = new Map<string, Set<string>>();
+  /** Bounded, process-local clean-absence rotations for production VM recovery. */
+  protected readonly vmReconcileRotationState = new Map<string, VmReconcileRotationRecord>();
+  /** Late exact responses must not mutate rotation state after shutdown begins. */
+  protected vmReconcileRotationClosed = false;
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();
   /** Phase D/A4 — round-robin cursor over the already ordered catch-up peer list. */

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -920,8 +920,10 @@ export class DKGAgentBase {
     'DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES',
     1_000,
   );
-  /** Exact recovery keeps its existing curator/core-first three-peer fanout cap. */
+  /** Maximum peers connected/probed/transported by one exact-recovery pass. */
   static readonly VM_RECONCILE_EXACT_PEER_MAX = 3;
+  /** Bounded proof universe retained across passes; transport still uses the cap above. */
+  static readonly VM_RECONCILE_EXACT_ROSTER_MAX = MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS;
   static readonly VM_RECONCILE_QUEUE_MAX_PENDING =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_QUEUE_MAX_PENDING']) || 256);
   /**
@@ -990,9 +992,6 @@ export class DKGAgentBase {
   protected vmReconcileStartupTimer: ReturnType<typeof setTimeout> | null = null;
   /** Process-wide sweep single-flight; interval/startup callers join this promise. */
   protected vmReconcileSweepInFlight: Promise<void> | null = null;
-  /** Closed dispatcher retained across restart until its old worker and sweep fully drain. */
-  protected vmReconcileRetirementInFlight: Promise<void> | null = null;
-  protected vmReconcileRetiringDispatcher: VmReconcileDispatcher<ContextGraphReconcileResult> | undefined;
   /** Phase B — in-memory reconcile cursor per local CG id (watermark + `ahead`). */
   protected readonly reconcileCursors = new Map<string, CursorState>();
   /** Phase B — bounded dedupe of recently-reconciled UALs (live-burst guard). */
@@ -1020,6 +1019,8 @@ export class DKGAgentBase {
   protected vmReconcileRotationClosed = false;
   /** Monotonic guard: every VM reconcile continuation from an earlier node run stays stale. */
   protected vmReconcileLifecycleGeneration = 0;
+  /** Abortable boundary paired with the generation guard for restart-safe async work. */
+  protected vmReconcileLifecycleController = new AbortController();
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();
   /** Phase D/A4 — round-robin cursor over the already ordered catch-up peer list. */

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -653,7 +653,7 @@ export async function resolveCuratorSyncPeer(
     if (!resolved) {
       try {
         throwIfSyncAuthAborted(options.signal);
-        const agents = await agent.discovery.findAgents();
+        const agents = await agent.discovery.findAgents({ signal: options.signal });
         throwIfSyncAuthAborted(options.signal);
         const matches = agents.filter(
           (a) => a.agentAddress?.toLowerCase() === curatorIdentifier.toLowerCase(),
@@ -789,12 +789,17 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * ONTOLOGY/_meta count, and storage-backed graph presence also counts so local
    * shared-memory-only survivors are not treated as nonexistent.
    */
-  async contextGraphExists(this: DKGAgent, contextGraphId: string): Promise<boolean> {
+  async contextGraphExists(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<boolean> {
     const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     const result = await this.store.query(
       `SELECT ?g WHERE {
         GRAPH ?g { <${contextGraphUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> }
       } LIMIT 1`,
+      { signal: options.signal, source: 'agent.contextGraph.exists' },
     );
     if (result.type === 'bindings' && result.bindings.length > 0) {
       return true;
@@ -822,7 +827,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       graphManager.sharedMemoryMetaUri(contextGraphId),
     ];
     for (const graphUri of survivorGraphUris) {
-      if (await this.store.hasGraph(graphUri)) return true;
+      if (await this.store.hasGraph(graphUri, { signal: options.signal })) return true;
     }
     return false;
   }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -260,6 +260,10 @@ import {
 } from './sync/requester/durable-sync-budget.js';
 import {
   runDurableSync,
+  runDurableSyncDetailed,
+  type DetailedDurableSyncResult,
+  type DurableSyncContext,
+  type ExactDurableFetchDisposition,
   type VerifiedFullSnapshot,
 } from './sync/requester/durable-sync.js';
 import { resolveSyncAgentsMeta, shouldWithholdAgentsDurableMeta } from './sync/agents-meta-policy.js';
@@ -1040,6 +1044,26 @@ export type DurableSyncOptions = {
    */
   source?: SyncAdmissionSource;
 };
+
+export interface ExactKnowledgeAssetSyncResult {
+  readonly result: DurableSyncResult;
+  readonly disposition: ExactDurableFetchDisposition;
+}
+
+type PhysicalDurableSyncResult = {
+  readonly result: DurableSyncResult;
+  readonly exactFetchDisposition?: ExactDurableFetchDisposition;
+};
+
+function mergeExactDurableFetchDisposition(
+  current: ExactDurableFetchDisposition | undefined,
+  next: ExactDurableFetchDisposition,
+): ExactDurableFetchDisposition {
+  if (current === undefined) return next;
+  if (current === 'incomplete' || next === 'incomplete') return 'incomplete';
+  if (current === 'found' || next === 'found') return 'found';
+  return 'clean-absent';
+}
 
 type LegacyDurableContextGraphOptions = {
   onPhase?: PhaseCallback;
@@ -4634,6 +4658,27 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     sinceBatchIdFor?: (contextGraphId: string) => string | undefined,
     options?: DurableSyncOptions,
   ): Promise<DurableSyncResult> {
+    return (await LifecycleSyncMethods.prototype.runLegacyDurableSyncDetailed.call(
+      this,
+      ctx,
+      remotePeerId,
+      contextGraphIds,
+      onPhase,
+      onAccessDenied,
+      sinceBatchIdFor,
+      options,
+    )).result;
+  }
+
+  async runLegacyDurableSyncDetailed(this: DKGAgent,
+    ctx: OperationContext,
+    remotePeerId: string,
+    contextGraphIds: string[],
+    onPhase?: PhaseCallback,
+    onAccessDenied?: (contextGraphId: string) => void,
+    sinceBatchIdFor?: (contextGraphId: string) => string | undefined,
+    options?: DurableSyncOptions,
+  ): Promise<PhysicalDurableSyncResult> {
     const syncAgentsMeta = resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META);
     const stopOnBackoffWorthyFailure = options?.stopOnBackoffWorthyFailure;
     const operationBoundary = createDurableSyncOperationBoundary({
@@ -4648,79 +4693,105 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphIds,
       this.config.syncContextGraphPriorities,
     );
-    const runSync = async () => finalizeDurableSyncCompletion(await runOrderedContextGraphSyncs<DurableSyncAccumulator>({
-      work: orderedContextGraphIds.map((contextGraphId) => ({
-        contextGraphId,
-        lane: 'durable' as const,
-        operationId: `durable:${contextGraphId}:${remotePeerId.slice(-8)}`,
-        run: async (remainingContextGraphs) => durableSyncAccumulatorFromResult(
-          await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
-            this,
-            ctx,
-            remotePeerId,
-            contextGraphId,
-            remainingContextGraphs,
-            {
-              onPhase,
-              onAtomicCommitStarted: options?.onAtomicCommitStarted,
-              onAccessDenied,
-              sinceBatchIdFor,
-              stopOnBackoffWorthyFailure,
-              fetchTimeoutMs,
-              exactAssetUals: options?.exactAssetUals,
-              authenticationTimeoutMs,
-              operationDeadline: operationBoundary.deadline,
-              signal: operationBoundary.signal,
-            },
-          ),
-        ),
-      })),
-      priorities: this.config.syncContextGraphPriorities,
-      emptyResult: createDurableSyncAccumulator,
-      runWithAdmission: async (item, work) => {
-        try {
-          return await runSerializedDurableContextGraphSync(
-            this,
-            remotePeerId,
-            item.contextGraphId,
-            () => this.runContextGraphSyncWithBackpressure(
+    let exactFetchDisposition: ExactDurableFetchDisposition | undefined;
+    const markExactFetchIncomplete = () => {
+      if (options?.exactAssetUals === undefined) return;
+      exactFetchDisposition = mergeExactDurableFetchDisposition(
+        exactFetchDisposition,
+        'incomplete',
+      );
+    };
+    const runSync = async (): Promise<PhysicalDurableSyncResult> => {
+      const accumulator = await runOrderedContextGraphSyncs<DurableSyncAccumulator>({
+        work: orderedContextGraphIds.map((contextGraphId) => ({
+          contextGraphId,
+          lane: 'durable' as const,
+          operationId: `durable:${contextGraphId}:${remotePeerId.slice(-8)}`,
+          run: async (remainingContextGraphs) => {
+            const detailed = await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraphDetailed.call(
+              this,
               ctx,
-              item.contextGraphId,
-              item.lane,
-              item.operationId,
-              work,
+              remotePeerId,
+              contextGraphId,
+              remainingContextGraphs,
               {
-                priorityOverride: options?.priority,
-                operationSignal: operationBoundary.signal,
-                source: options?.source,
+                onPhase,
+                onAtomicCommitStarted: options?.onAtomicCommitStarted,
+                onAccessDenied,
+                sinceBatchIdFor,
+                stopOnBackoffWorthyFailure,
+                fetchTimeoutMs,
+                exactAssetUals: options?.exactAssetUals,
+                authenticationTimeoutMs,
+                operationDeadline: operationBoundary.deadline,
+                signal: operationBoundary.signal,
               },
-            ),
-            operationBoundary.signal,
-          );
-        } catch (error) {
-          if (!operationBoundary.signal?.aborted) throw error;
-          return markDurableTerminalBoundary(createDurableSyncAccumulator(), false);
-        }
-      },
-      merge: mergeDurableSyncAccumulatorInto,
-      markDeferred: (summary) => {
-        recordDurableSyncDiagnostics(summary, { deferredBackpressure: 1 });
-        return markDurableTerminalBoundary(summary, false);
-      },
-      // Preserve already-merged progress, but record that cancellation left
-      // requested Context Graphs unvisited so the aggregate cannot finalize
-      // as complete.
-      markSkipped: (summary) => markDurableTerminalBoundary(summary, false),
-      shouldContinue: () => !operationBoundary.signal?.aborted,
-      shouldStop: (part) => Boolean(
-        stopOnBackoffWorthyFailure
-        && durableSyncAccumulatorHasBackoffWorthyFailure(part),
-      ),
-      onDeferred: (item, error) => this.log.info(
-        ctx,
-        `Deferring durable sync at CG ${item.contextGraphId} due to local backpressure: ${error.message}`,
-      ),
-    }));
+            );
+            if (detailed.exactFetchDisposition !== undefined) {
+              exactFetchDisposition = mergeExactDurableFetchDisposition(
+                exactFetchDisposition,
+                detailed.exactFetchDisposition,
+              );
+            }
+            return durableSyncAccumulatorFromResult(detailed.result);
+          },
+        })),
+        priorities: this.config.syncContextGraphPriorities,
+        emptyResult: createDurableSyncAccumulator,
+        runWithAdmission: async (item, work) => {
+          try {
+            return await runSerializedDurableContextGraphSync(
+              this,
+              remotePeerId,
+              item.contextGraphId,
+              () => this.runContextGraphSyncWithBackpressure(
+                ctx,
+                item.contextGraphId,
+                item.lane,
+                item.operationId,
+                work,
+                {
+                  priorityOverride: options?.priority,
+                  operationSignal: operationBoundary.signal,
+                  source: options?.source,
+                },
+              ),
+              operationBoundary.signal,
+            );
+          } catch (error) {
+            if (!operationBoundary.signal?.aborted) throw error;
+            markExactFetchIncomplete();
+            return markDurableTerminalBoundary(createDurableSyncAccumulator(), false);
+          }
+        },
+        merge: mergeDurableSyncAccumulatorInto,
+        markDeferred: (summary) => {
+          markExactFetchIncomplete();
+          recordDurableSyncDiagnostics(summary, { deferredBackpressure: 1 });
+          return markDurableTerminalBoundary(summary, false);
+        },
+        // Preserve already-merged progress, but record that cancellation left
+        // requested Context Graphs unvisited so the aggregate cannot finalize
+        // as complete.
+        markSkipped: (summary) => {
+          markExactFetchIncomplete();
+          return markDurableTerminalBoundary(summary, false);
+        },
+        shouldContinue: () => !operationBoundary.signal?.aborted,
+        shouldStop: (part) => Boolean(
+          stopOnBackoffWorthyFailure
+          && durableSyncAccumulatorHasBackoffWorthyFailure(part),
+        ),
+        onDeferred: (item, error) => this.log.info(
+          ctx,
+          `Deferring durable sync at CG ${item.contextGraphId} due to local backpressure: ${error.message}`,
+        ),
+      });
+      return {
+        result: finalizeDurableSyncCompletion(accumulator),
+        ...(exactFetchDisposition ? { exactFetchDisposition } : {}),
+      };
+    };
 
     const singleFlightKey = durableSyncSingleFlightKey({
       remotePeerId,
@@ -4781,6 +4852,34 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     );
   }
 
+  async syncExactKnowledgeAssetsFromPeerDetailed(this: DKGAgent,
+    remotePeerId: string,
+    contextGraphId: string,
+    requestedAssetUals: string[],
+  ): Promise<ExactKnowledgeAssetSyncResult> {
+    const assetUals = requireExactAssetUals(requestedAssetUals);
+    const ctx = createOperationContext('sync');
+    const detailed = await LifecycleSyncMethods.prototype.runLegacyDurableSyncDetailed.call(
+      this,
+      ctx,
+      remotePeerId,
+      [contextGraphId],
+      undefined,
+      undefined,
+      undefined,
+      {
+        exactAssetUals: assetUals,
+        stopOnBackoffWorthyFailure: true,
+        priority: 1_000,
+        source: 'vm-recovery',
+      },
+    );
+    return {
+      result: detailed.result,
+      disposition: detailed.exactFetchDisposition ?? 'incomplete',
+    };
+  }
+
   /** Execute one legacy durable Context Graph after its caller owns admission. */
   async runLegacyDurableSyncForContextGraph(this: DKGAgent,
     ctx: OperationContext,
@@ -4789,6 +4888,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remainingContextGraphs: number,
     options: LegacyDurableContextGraphOptions = {},
   ): Promise<DurableSyncResult> {
+    return (await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraphDetailed.call(
+      this,
+      ctx,
+      remotePeerId,
+      contextGraphId,
+      remainingContextGraphs,
+      options,
+    )).result;
+  }
+
+  async runLegacyDurableSyncForContextGraphDetailed(this: DKGAgent,
+    ctx: OperationContext,
+    remotePeerId: string,
+    contextGraphId: string,
+    remainingContextGraphs: number,
+    options: LegacyDurableContextGraphOptions = {},
+  ): Promise<DetailedDurableSyncResult> {
     const {
       onPhase,
       onAtomicCommitStarted,
@@ -4849,7 +4965,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphId,
       remainingContextGraphs,
     });
-    return runDurableSync({
+    const durableContext: DurableSyncContext = {
       ctx,
       remotePeerId,
       contextGraphIds: [contextGraphId],
@@ -4958,7 +5074,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),
       logDebug: (opCtx, message) => this.log.debug(opCtx, message),
-    });
+    };
+    if (exactAssetUals !== undefined) {
+      return runDurableSyncDetailed(durableContext);
+    }
+    return { result: await runDurableSync(durableContext) };
   }
 
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1474,8 +1474,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       );
     }
     this.started = true;
-    if (this.vmReconcileDispatcher?.snapshot().closed) this.vmReconcileDispatcher = undefined;
     this.openVmReconcileRotationState();
+    this.rearmVmReconcileRuntimeAfterRestart();
     this.finalizationRuntime.markStarted({
       localPeerId: this.peerId,
       localNodeIdentityId: this.identityId.toString(),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5054,13 +5054,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         }
         const subscription = this.subscribedContextGraphs.get(asset.contextGraphId);
         let bindingGeneration = captureContextGraphBindingGeneration(
-          this,
+          this.contextGraphBindingGenerations,
           asset.contextGraphId,
         );
         const bindingIsCurrent = () => (
           this.subscribedContextGraphs.get(asset.contextGraphId) === subscription
           && isContextGraphBindingGenerationCurrent(
-            this,
+            this.contextGraphBindingGenerations,
             asset.contextGraphId,
             bindingGeneration,
           )
@@ -5126,7 +5126,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
               verifiedOnChainId,
             );
             bindingGeneration = captureContextGraphBindingGeneration(
-              this,
+              this.contextGraphBindingGenerations,
               asset.contextGraphId,
             );
             assertLifecycleCurrent();
@@ -5148,9 +5148,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             isCurrent: () => (isCurrent?.() ?? true) && bindingIsCurrent(),
             shouldQuarantineCommitted: () => {
               const current = this.subscribedContextGraphs.get(asset.contextGraphId);
-              return verifiedOnChainId !== null
-                && current !== undefined
-                && current.onChainId !== verifiedOnChainId;
+              return current === undefined
+                || (verifiedOnChainId !== null && current.onChainId !== verifiedOnChainId);
             },
             options: {
               priority: 'background',
@@ -7373,7 +7372,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // Every in-flight binding continuation also captures the subscription
     // object, so deleting this numeric generation cannot revive old work if a
     // new subscription later reuses the same local id.
-    clearContextGraphBindingGeneration(this, contextGraphId);
+    clearContextGraphBindingGeneration(this.contextGraphBindingGenerations, contextGraphId);
     return deleted;
   }
 
@@ -7473,7 +7472,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
     const expectedLiveSub = this.subscribedContextGraphs.get(contextGraphId);
     const expectedBindingGeneration = captureContextGraphBindingGeneration(
-      this,
+      this.contextGraphBindingGenerations,
       contextGraphId,
     );
     const sub = subscription ?? expectedLiveSub;
@@ -7505,7 +7504,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         current !== expectedLiveSub
         || (!current?.subscribed && !current?.coreHosted)
         || !isContextGraphBindingGenerationCurrent(
-          this,
+          this.contextGraphBindingGenerations,
           contextGraphId,
           expectedBindingGeneration,
         )

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1474,6 +1474,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       );
     }
     this.started = true;
+    if (this.vmReconcileDispatcher?.snapshot().closed) this.vmReconcileDispatcher = undefined;
+    this.openVmReconcileRotationState();
     this.finalizationRuntime.markStarted({
       localPeerId: this.peerId,
       localNodeIdentityId: this.identityId.toString(),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5637,8 +5637,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       };
       let resolution = await resolve();
       if (resolution.peerIds.length === 0) {
-        await this.refreshMetaFromCurator(contextGraphId).catch(() => undefined);
+        const refreshed = await this.refreshMetaFromCurator(contextGraphId).catch(() => false);
         resolution = await resolve();
+        // An empty local query after a failed/cooldown refresh is not an
+        // authoritative empty registry. Preserve any caller-side last-known
+        // curator roster unless another writer populated the registry.
+        if (!refreshed && !resolution.lookupFailed && resolution.peerIds.length === 0) {
+          resolution = { ...resolution, lookupFailed: true };
+        }
       }
       return {
         peerIds: resolution.peerIds,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5609,30 +5609,43 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   async resolveCuratorPeerIdsForCg(this: DKGAgent,
     contextGraphId: string,
-  ): Promise<{ peerIds: string[]; curatorIsLocal: boolean; legacyTripleResolved: boolean }> {
+  ): Promise<{
+    peerIds: string[];
+    curatorIsLocal: boolean;
+    legacyTripleResolved: boolean;
+    lookupFailed?: boolean;
+  }> {
     const structuralCuratorDid = deriveCuratorDidFromCgId(contextGraphId);
     if (structuralCuratorDid) {
       const structuralAgent = structuralCuratorDid.slice('did:dkg:agent:'.length).toLowerCase();
       if ([...this.localAgents.keys()].some((addr) => addr.toLowerCase() === structuralAgent)) {
         return { peerIds: [], curatorIsLocal: true, legacyTripleResolved: false };
       }
-      const resolve = async (): Promise<string[]> => {
+      const resolve = async (): Promise<{ peerIds: string[]; lookupFailed: boolean }> => {
         let agents: Array<{ agentAddress?: string; peerId: string }>;
         try {
           agents = await this.discovery.findAgents();
         } catch {
-          agents = [];
+          return { peerIds: [], lookupFailed: true };
         }
-        return agents
-          .filter((a) => a.agentAddress?.toLowerCase() === structuralAgent)
-          .map((a) => a.peerId);
+        return {
+          peerIds: agents
+            .filter((a) => a.agentAddress?.toLowerCase() === structuralAgent)
+            .map((a) => a.peerId),
+          lookupFailed: false,
+        };
       };
-      let curatorPeers = await resolve();
-      if (curatorPeers.length === 0) {
+      let resolution = await resolve();
+      if (resolution.peerIds.length === 0) {
         await this.refreshMetaFromCurator(contextGraphId).catch(() => undefined);
-        curatorPeers = await resolve();
+        resolution = await resolve();
       }
-      return { peerIds: curatorPeers, curatorIsLocal: false, legacyTripleResolved: false };
+      return {
+        peerIds: resolution.peerIds,
+        curatorIsLocal: false,
+        legacyTripleResolved: false,
+        lookupFailed: resolution.lookupFailed,
+      };
     }
     // Legacy non-wallet-scoped CG: fall back to triple-based curator resolution.
     if (await this.isCuratorOf(contextGraphId)) {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -248,7 +248,11 @@ import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-core-connections.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
-import { exactAssetFilterKey, requireExactAssetUals } from './sync/exact-assets.js';
+import {
+  exactAssetFilterKey,
+  exactSyncPhaseAccumulationLimits,
+  requireExactAssetUals,
+} from './sync/exact-assets.js';
 import { insertWithOversizeGuard, type OversizeGuardHooks } from './sync/oversize-filter.js';
 import { runOversizeSweep } from './sync/oversize-sweep.js';
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
@@ -4822,8 +4826,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   /**
    * Foreground VM repair for one bounded set of locally-missing KAs.
    * Upgraded peers serve only these descriptors/payload graphs. Responses from
-   * older peers are accepted for rolling compatibility, but runDurableSync
-   * filters them back to this exact set before verification or storage.
+   * older peers are accepted for rolling compatibility only when their legacy
+   * full-CG prefix fits the exact accumulation bounds and covers the requested
+   * descriptors. Other legacy responses remain incomplete, fail closed, and
+   * rotate to another candidate instead of being verified or stored.
    */
   async syncExactKnowledgeAssetsFromPeer(this: DKGAgent,
     remotePeerId: string,
@@ -5448,6 +5454,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // responder-session identities so offsets can never cross asset batches.
     assetUals?: string[],
   ): Promise<SyncPageResult> {
+    const exactAccumulationLimits = assetUals === undefined
+      ? undefined
+      : exactSyncPhaseAccumulationLimits(assetUals);
     // A caller signal defines an operation-owned cancellation contract. Do not
     // place those fetches in the shared page map: even equal wall-clock
     // deadlines do not make independently abortable operations compatible.
@@ -5511,6 +5520,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       snapshotRef,
       sinceBatchId,
       assetUals,
+      maxAcceptedBytes: exactAccumulationLimits?.maxBytes,
+      maxAcceptedQuads: exactAccumulationLimits?.maxQuads,
       deadline,
       recovery,
       syncPageTimeoutMs: SYNC_PAGE_TIMEOUT_MS,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -248,7 +248,7 @@ import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-core-connections.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
-import { requireExactAssetUals } from './sync/exact-assets.js';
+import { exactAssetFilterKey, requireExactAssetUals } from './sync/exact-assets.js';
 import { insertWithOversizeGuard, type OversizeGuardHooks } from './sync/oversize-filter.js';
 import { runOversizeSweep } from './sync/oversize-sweep.js';
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
@@ -263,9 +263,12 @@ import {
   runDurableSyncDetailed,
   type DetailedDurableSyncResult,
   type DurableSyncContext,
-  type ExactDurableFetchDisposition,
   type VerifiedFullSnapshot,
 } from './sync/requester/durable-sync.js';
+import {
+  mergeExactDurableFetchDisposition,
+  type ExactDurableFetchDisposition,
+} from './sync/requester/exact-durable-fetch.js';
 import { resolveSyncAgentsMeta, shouldWithholdAgentsDurableMeta } from './sync/agents-meta-policy.js';
 import { runSharedMemorySync, sharedMemoryOwnershipKeyFromGraph } from './sync/requester/shared-memory-sync.js';
 import { createSharedMemorySnapshotMaterializer } from './sync/requester/swm-snapshot-materializer.js';
@@ -689,7 +692,7 @@ function syncPageFetchCoalescingKey(params: {
     params.sinceBatchId ?? null,
     params.recovery === true,
     params.forceFreshSession === true,
-    params.assetUals ?? null,
+    params.assetUals === undefined ? null : exactAssetFilterKey(params.assetUals),
   ]);
 }
 
@@ -1054,16 +1057,6 @@ type PhysicalDurableSyncResult = {
   readonly result: DurableSyncResult;
   readonly exactFetchDisposition?: ExactDurableFetchDisposition;
 };
-
-function mergeExactDurableFetchDisposition(
-  current: ExactDurableFetchDisposition | undefined,
-  next: ExactDurableFetchDisposition,
-): ExactDurableFetchDisposition {
-  if (current === undefined) return next;
-  if (current === 'incomplete' || next === 'incomplete') return 'incomplete';
-  if (current === 'found' || next === 'found') return 'found';
-  return 'clean-absent';
-}
 
 type LegacyDurableContextGraphOptions = {
   onPhase?: PhaseCallback;
@@ -4681,12 +4674,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<PhysicalDurableSyncResult> {
     const syncAgentsMeta = resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META);
     const stopOnBackoffWorthyFailure = options?.stopOnBackoffWorthyFailure;
+    const exactAssetUals = options?.exactAssetUals === undefined
+      ? undefined
+      : requireExactAssetUals(options.exactAssetUals);
     const operationBoundary = createDurableSyncOperationBoundary({
       totalTimeoutMs: options?.totalTimeoutMs,
       signal: options?.signal,
     });
     const authenticationTimeoutMs = normalizeDurableSyncTimeoutMs(options?.totalTimeoutMs);
-    const fetchTimeoutMs = options?.exactAssetUals && options.totalTimeoutMs === undefined
+    const fetchTimeoutMs = exactAssetUals && options?.totalTimeoutMs === undefined
       ? EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS
       : authenticationTimeoutMs;
     const orderedContextGraphIds = orderContextGraphIdsByPriority(
@@ -4695,7 +4691,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     );
     let exactFetchDisposition: ExactDurableFetchDisposition | undefined;
     const markExactFetchIncomplete = () => {
-      if (options?.exactAssetUals === undefined) return;
+      if (exactAssetUals === undefined) return;
       exactFetchDisposition = mergeExactDurableFetchDisposition(
         exactFetchDisposition,
         'incomplete',
@@ -4721,7 +4717,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 sinceBatchIdFor,
                 stopOnBackoffWorthyFailure,
                 fetchTimeoutMs,
-                exactAssetUals: options?.exactAssetUals,
+                exactAssetUals,
                 authenticationTimeoutMs,
                 operationDeadline: operationBoundary.deadline,
                 signal: operationBoundary.signal,
@@ -4805,7 +4801,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       hasAccessDeniedCallback: Boolean(onAccessDenied),
       hasSinceBatchIdResolver: Boolean(sinceBatchIdFor),
       hasSignal: Boolean(operationBoundary.signal),
-      exactAssetUals: options?.exactAssetUals,
+      exactAssetUals,
       priority: options?.priority,
     });
     const runWithinBoundary = async () => {
@@ -4834,22 +4830,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     requestedAssetUals: string[],
   ): Promise<DurableSyncResult> {
-    const assetUals = requireExactAssetUals(requestedAssetUals);
-    const ctx = createOperationContext('sync');
-    return this.runLegacyDurableSync(
-      ctx,
+    return (await this.syncExactKnowledgeAssetsFromPeerDetailed(
       remotePeerId,
-      [contextGraphId],
-      undefined,
-      undefined,
-      undefined,
-      {
-        exactAssetUals: assetUals,
-        stopOnBackoffWorthyFailure: true,
-        priority: 1_000,
-        source: 'vm-recovery',
-      },
-    );
+      contextGraphId,
+      requestedAssetUals,
+    )).result;
   }
 
   async syncExactKnowledgeAssetsFromPeerDetailed(this: DKGAgent,
@@ -4859,8 +4844,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<ExactKnowledgeAssetSyncResult> {
     const assetUals = requireExactAssetUals(requestedAssetUals);
     const ctx = createOperationContext('sync');
-    const detailed = await LifecycleSyncMethods.prototype.runLegacyDurableSyncDetailed.call(
-      this,
+    const detailed = await this.runLegacyDurableSyncDetailed(
       ctx,
       remotePeerId,
       [contextGraphId],

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5148,8 +5148,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             isCurrent: () => (isCurrent?.() ?? true) && bindingIsCurrent(),
             shouldQuarantineCommitted: () => {
               const current = this.subscribedContextGraphs.get(asset.contextGraphId);
-              return current === undefined
-                || (verifiedOnChainId !== null && current.onChainId !== verifiedOnChainId);
+              return (subscription !== undefined && current === undefined)
+                || (verifiedOnChainId !== null
+                  && current !== undefined
+                  && current.onChainId !== verifiedOnChainId);
             },
             options: {
               priority: 'background',

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -105,6 +105,7 @@ import { runChangelogSync, planPageApply } from './sync/requester/changelog-sync
 import {
   authenticateVerifiedGraphScopedAsset,
   materializeVerifiedGraphScopedAsset,
+  type GraphScopedMaterializationOutcome,
   type VerifiedGraphScopedAsset,
   type VerifyContextGraphBinding,
 } from './sync/requester/graph-scoped-materialization.js';
@@ -541,7 +542,14 @@ import {
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
+import { VmReconcileShutdownTimeoutError } from './vm-reconcile-service.js';
+import { ContextGraphMembershipPersistShutdownTimeoutError } from './context-graph-membership-persist-scheduler.js';
 import type { DKGAgent } from './dkg-agent.js';
+import {
+  captureContextGraphBindingGeneration,
+  clearContextGraphBindingGeneration,
+  isContextGraphBindingGenerationCurrent,
+} from './context-graph-binding-generation.js';
 import { deterministicStartupJitterMs, scheduleAfterStartupJitter } from './startup-jitter.js';
 
 const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
@@ -800,6 +808,7 @@ function durableSyncSingleFlightKey(params: {
   hasAccessDeniedCallback: boolean;
   hasSinceBatchIdResolver: boolean;
   hasSignal: boolean;
+  hasCurrentFence: boolean;
   exactAssetUals?: readonly string[];
   priority?: number;
 }): string | null {
@@ -809,6 +818,7 @@ function durableSyncSingleFlightKey(params: {
     || params.hasAccessDeniedCallback
     || params.hasSinceBatchIdResolver
     || params.hasSignal
+    || params.hasCurrentFence
   ) {
     return null;
   }
@@ -1027,6 +1037,8 @@ export type DurableSyncOptions = {
    * materialization check it before any subsequent commit boundary.
    */
   signal?: AbortSignal;
+  /** Internal lifecycle fence for exact VM recovery. */
+  isCurrent?: () => boolean;
   /**
    * Called synchronously after graph-scoped authentication succeeds and
    * immediately before atomic materialization is dispatched. This is a
@@ -1074,6 +1086,7 @@ type LegacyDurableContextGraphOptions = {
   authenticationTimeoutMs?: number;
   operationDeadline?: number;
   signal?: AbortSignal;
+  isCurrent?: () => boolean;
 };
 
 const DURABLE_AUTHENTICATION_MAX_ATTEMPTS = 5;
@@ -1430,7 +1443,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   async start(this: DKGAgent): Promise<void> {
+    if (this.vmReconcileShutdownBlocked) {
+      throw new VmReconcileShutdownTimeoutError(DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS);
+    }
+    if (this.contextGraphMembershipPersistenceShutdownBlocked) {
+      throw new ContextGraphMembershipPersistShutdownTimeoutError(
+        DKGAgentBase.CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_MS,
+      );
+    }
     if (this.started) return;
+    this.contextGraphMembershipPersistence.reopen();
+    this.vmReconcileRuntimeReady = false;
+    this.graphScopedStoreClosed = false;
     this.coreHostRecordingGeneration += 1;
     this.coreHostRecordingsClosed = false;
     const ctx = createOperationContext('connect');
@@ -1475,7 +1499,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
     this.started = true;
     this.openVmReconcileRotationState();
-    this.rearmVmReconcileRuntimeAfterRestart();
     this.finalizationRuntime.markStarted({
       localPeerId: this.peerId,
       localNodeIdentityId: this.identityId.toString(),
@@ -3451,42 +3474,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       if (this.warmCoreTimer.unref) this.warmCoreTimer.unref();
     }
 
-    // Phase B — chain-driven VM reconciliation. The coalescer collapses a burst
-    // of live KACG nudges for a CG into a single sweep; the periodic timer is
-    // the safety net that backfills missed events / transient fetch failures and
-    // catches up late subscribers (the "Monday Fun Facts" case). Only armed when
-    // the chain adapter exposes the per-CG registration-ordinal reads.
-    if (this.vmReconcileEnabled()) {
-      this.ensureVmReconcileDispatcher();
-      const runSweep = (): void => {
-        this.runVmReconcileSweep().catch((err: unknown) => {
-          this.log.warn(ctx, `VM reconcile sweep failed: ${err instanceof Error ? err.message : String(err)}`);
-        });
-      };
-      // Prime once after a deterministic per-peer delay. A simultaneous
-      // four-node cold rollout must not turn into four synchronized Oxigraph
-      // scans; keeping this deterministic also makes restart behaviour and
-      // regression tests reproducible.
-      const startupDelayMs = deterministicStartupJitterMs(
-        `${this.node.peerId.toString()}\0${this.chain.chainId}`,
-        DKGAgentBase.VM_RECONCILE_STARTUP_MAX_DELAY_MS,
-      );
-      this.vmReconcileStartupTimer = scheduleAfterStartupJitter(
-        () => {
-          this.vmReconcileStartupTimer = null;
-          runSweep();
-        },
-        startupDelayMs,
-        DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS,
-        (timer) => {
-          this.vmReconcileTimer = timer;
-          if (timer.unref) timer.unref();
-        },
-      );
-      if (this.vmReconcileStartupTimer.unref) this.vmReconcileStartupTimer.unref();
-      this.log.info(ctx, `Chain-driven VM reconciliation armed (startupDelay ${startupDelayMs}ms, sweep ${DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS}ms, depth ${DKGAgentBase.VM_RECONCILE_CONFIRMATION_DEPTH})`);
-    }
-
     // rc.9 PR-10: dedicated join-approval retry tick removed. The
     // substrate's Messenger.processOutboxTick (set up immediately
     // below) now drives retries for /dkg/10.0.2/join-request the
@@ -3539,6 +3526,38 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const rsStart = await this.tryStartRandomSamplingProver(ctx, true);
     if (rsStart === 'retryable') {
       this.scheduleRandomSamplingBindRetry(ctx);
+    }
+
+    // Arm VM work only at the final successful-start boundary. Every network,
+    // subscription, protocol, and persistence dependency is now initialized,
+    // and both initial start and same-object restart retain the cold-start
+    // jitter instead of launching an eager sweep against the old runtime.
+    this.vmReconcileRuntimeReady = true;
+    if (this.vmReconcileEnabled()) {
+      this.ensureVmReconcileDispatcher();
+      const runSweep = (): void => {
+        this.runVmReconcileSweep().catch((err: unknown) => {
+          this.log.warn(ctx, `VM reconcile sweep failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+      };
+      const startupDelayMs = deterministicStartupJitterMs(
+        `${this.node.peerId.toString()}\0${this.chain.chainId}`,
+        DKGAgentBase.VM_RECONCILE_STARTUP_MAX_DELAY_MS,
+      );
+      this.vmReconcileStartupTimer = scheduleAfterStartupJitter(
+        () => {
+          this.vmReconcileStartupTimer = null;
+          runSweep();
+        },
+        startupDelayMs,
+        DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS,
+        (timer) => {
+          this.vmReconcileTimer = timer;
+          if (timer.unref) timer.unref();
+        },
+      );
+      if (this.vmReconcileStartupTimer.unref) this.vmReconcileStartupTimer.unref();
+      this.log.info(ctx, `Chain-driven VM reconciliation armed (startupDelay ${startupDelayMs}ms, sweep ${DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS}ms, depth ${DKGAgentBase.VM_RECONCILE_CONFIRMATION_DEPTH})`);
     }
   }
 
@@ -4126,12 +4145,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     peerId: string,
     ctx: OperationContext,
     label: string,
+    signal?: AbortSignal,
   ): Promise<boolean> {
     if (this.networkAdmissionCoordinator.isAcceptedPeer(peerId)) return true;
     if (this.networkAdmissionCoordinator.isRejectedPeer(peerId)) return false;
     try {
-      return await this.networkAdmissionCoordinator.ensureAdmitted(peerId, ctx);
+      return await this.networkAdmissionCoordinator.ensureAdmitted(peerId, ctx, { signal });
     } catch (err: unknown) {
+      if (signal?.aborted) throw err;
       const message = err instanceof Error ? err.message : String(err);
       this.log.warn(ctx, `${label} admission probe failed for ${peerId.slice(-8)}: ${message}`);
       return false;
@@ -4727,6 +4748,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 authenticationTimeoutMs,
                 operationDeadline: operationBoundary.deadline,
                 signal: operationBoundary.signal,
+                isCurrent: options?.isCurrent,
               },
             );
             if (detailed.exactFetchDisposition !== undefined) {
@@ -4807,6 +4829,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       hasAccessDeniedCallback: Boolean(onAccessDenied),
       hasSinceBatchIdResolver: Boolean(sinceBatchIdFor),
       hasSignal: Boolean(operationBoundary.signal),
+      hasCurrentFence: Boolean(options?.isCurrent),
       exactAssetUals,
       priority: options?.priority,
     });
@@ -4837,11 +4860,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeerId: string,
     contextGraphId: string,
     requestedAssetUals: string[],
+    options: { signal?: AbortSignal; isCurrent?: () => boolean } = {},
   ): Promise<DurableSyncResult> {
     return (await this.syncExactKnowledgeAssetsFromPeerDetailed(
       remotePeerId,
       contextGraphId,
       requestedAssetUals,
+      options,
     )).result;
   }
 
@@ -4849,6 +4874,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeerId: string,
     contextGraphId: string,
     requestedAssetUals: string[],
+    options: { signal?: AbortSignal; isCurrent?: () => boolean } = {},
   ): Promise<ExactKnowledgeAssetSyncResult> {
     const assetUals = requireExactAssetUals(requestedAssetUals);
     const ctx = createOperationContext('sync');
@@ -4864,6 +4890,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         stopOnBackoffWorthyFailure: true,
         priority: 1_000,
         source: 'vm-recovery',
+        signal: options.signal,
+        isCurrent: options.isCurrent,
       },
     );
     return {
@@ -4909,7 +4937,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       authenticationTimeoutMs = fetchTimeoutMs,
       operationDeadline,
       signal,
+      isCurrent,
     } = options;
+    const assertLifecycleCurrent = () => {
+      if (isCurrent?.() === false) {
+        throw asSyncFetchAbortError(new Error(
+          `Exact VM recovery lifecycle for ${contextGraphId} is no longer current`,
+        ));
+      }
+    };
     const syncAgentsMeta = resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META);
     // The CG name commitment is immutable for an on-chain slot. Prove a
     // local/on-chain binding once per durable-sync invocation, then reuse the
@@ -5005,60 +5041,136 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           signal: operationSignal,
         });
       },
-      storeGraphScopedAsset: async ({
+      storeGraphScopedAsset: ({
         asset,
         authenticationDeadline,
         signal: operationSignal,
       }) => {
-        const authentication = await authenticateDurableGraphScopedAsset({
-          chain: this.chain,
-          asset,
-          verifyContextGraphBinding,
-          deadline: authenticationDeadline,
-          signal: operationSignal,
-          onRetry: (error, attempt, maxAttempts) => {
-            this.log.warn(
-              ctx,
-              `Retrying graph-scoped durable authentication for ${asset.ual} `
-              + `after transient chain verification failure (${attempt}/${maxAttempts}): `
-              + `${error instanceof Error ? error.message : String(error)}`,
-            );
-          },
-        });
-        if (operationSignal?.aborted) {
-          throw asSyncFetchAbortError(operationSignal.reason);
+        const shutdownError = () => asSyncFetchAbortError(new Error(
+          `Graph-scoped store for ${asset.ual} is closed for node shutdown`,
+        ));
+        if (this.graphScopedStoreClosed) {
+          return Promise.reject(shutdownError());
         }
-        const verifiedOnChainId = authentication.onChainContextGraphId;
         const subscription = this.subscribedContextGraphs.get(asset.contextGraphId);
-        if (verifiedOnChainId && subscription && subscription.onChainId !== verifiedOnChainId) {
-          this.bindSubscriptionOnChainId(
+        let bindingGeneration = captureContextGraphBindingGeneration(
+          this,
+          asset.contextGraphId,
+        );
+        const bindingIsCurrent = () => (
+          this.subscribedContextGraphs.get(asset.contextGraphId) === subscription
+          && isContextGraphBindingGenerationCurrent(
+            this,
             asset.contextGraphId,
-            subscription,
-            verifiedOnChainId,
-          );
-          this.persistContextGraphSubscriptionState(asset.contextGraphId);
-        }
-        if (operationSignal?.aborted) {
-          throw asSyncFetchAbortError(operationSignal.reason);
-        }
-        onAtomicCommitStarted?.(asset.contextGraphId, asset.ual);
-        const outcome = await materializeVerifiedGraphScopedAsset({
-          store: this.store,
-          asset: authentication.asset,
-          options: {
-            priority: 'background',
-            source: 'agent.durableSync.graphScopedMaterialization',
+            bindingGeneration,
+          )
+        );
+        const physicalStore = Promise.resolve().then(async (): Promise<GraphScopedMaterializationOutcome> => {
+          const authentication = await authenticateDurableGraphScopedAsset({
+            chain: this.chain,
+            asset,
+            verifyContextGraphBinding,
+            deadline: authenticationDeadline,
             signal: operationSignal,
-          },
-          oversizeHooks: {
-            recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
-          },
+            onRetry: (error, attempt, maxAttempts) => {
+              this.log.warn(
+                ctx,
+                `Retrying graph-scoped durable authentication for ${asset.ual} `
+                + `after transient chain verification failure (${attempt}/${maxAttempts}): `
+                + `${error instanceof Error ? error.message : String(error)}`,
+              );
+            },
+          });
+          if (operationSignal?.aborted) {
+            throw asSyncFetchAbortError(operationSignal.reason);
+          }
+          assertLifecycleCurrent();
+          if (this.graphScopedStoreClosed) throw shutdownError();
+          if (!bindingIsCurrent()) {
+            throw asSyncFetchAbortError(new Error(
+              `Context graph binding for ${asset.contextGraphId} changed during authentication`,
+            ));
+          }
+          const verifiedOnChainId = authentication.onChainContextGraphId;
+          assertLifecycleCurrent();
+          if (
+            verifiedOnChainId
+            && subscription?.onChainId
+            && subscription.onChainId !== verifiedOnChainId
+          ) {
+            throw Object.assign(
+              new Error(
+                `Graph-scoped durable sync ${asset.ual} belongs to on-chain context graph `
+                + `${verifiedOnChainId}, but local ${asset.contextGraphId} is already bound to `
+                + `${subscription.onChainId}`,
+              ),
+              { code: 'VM_CHAIN_CONTEXT_GRAPH_MISMATCH' },
+            );
+          }
+          if (verifiedOnChainId && subscription && subscription.onChainId === undefined) {
+            await this.persistContextGraphSubscriptionStrict(
+              asset.contextGraphId,
+              { ...subscription, onChainId: verifiedOnChainId, lastReconciledOrdinal: 0 },
+              undefined,
+              bindingIsCurrent,
+            );
+            assertLifecycleCurrent();
+            if (!bindingIsCurrent()) {
+              throw asSyncFetchAbortError(new Error(
+                `Context graph binding for ${asset.contextGraphId} changed while its authenticated update was persisted`,
+              ));
+            }
+            this.bindSubscriptionOnChainId(
+              asset.contextGraphId,
+              subscription,
+              verifiedOnChainId,
+            );
+            bindingGeneration = captureContextGraphBindingGeneration(
+              this,
+              asset.contextGraphId,
+            );
+            assertLifecycleCurrent();
+          }
+          if (operationSignal?.aborted) {
+            throw asSyncFetchAbortError(operationSignal.reason);
+          }
+          assertLifecycleCurrent();
+          if (!bindingIsCurrent()) {
+            throw asSyncFetchAbortError(new Error(
+              `Context graph binding for ${asset.contextGraphId} changed before materialization`,
+            ));
+          }
+          onAtomicCommitStarted?.(asset.contextGraphId, asset.ual);
+          if (this.graphScopedStoreClosed) throw shutdownError();
+          const outcome = await materializeVerifiedGraphScopedAsset({
+            store: this.store,
+            asset: authentication.asset,
+            isCurrent: () => (isCurrent?.() ?? true) && bindingIsCurrent(),
+            shouldQuarantineCommitted: () => {
+              const current = this.subscribedContextGraphs.get(asset.contextGraphId);
+              return verifiedOnChainId !== null
+                && current !== undefined
+                && current.onChainId !== verifiedOnChainId;
+            },
+            options: {
+              priority: 'background',
+              source: 'agent.durableSync.graphScopedMaterialization',
+              signal: operationSignal,
+            },
+            oversizeHooks: {
+              recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
+            },
+          });
+          if (outcome === 'applied') {
+            this.invalidateListContextGraphsCache();
+            this.contextGraphMetaProjection.markDirtyFromQuads(authentication.asset.metadataQuads);
+          }
+          return outcome;
         });
-        if (outcome === 'applied') {
-          this.invalidateListContextGraphsCache();
-          this.contextGraphMetaProjection.markDirtyFromQuads(authentication.asset.metadataQuads);
-        }
-        return outcome;
+        this.graphScopedStorePhysicalRuns.add(physicalStore);
+        return physicalStore.finally(() => {
+          this.graphScopedStorePhysicalRuns.delete(physicalStore);
+        });
       },
       onVerifiedFullSnapshot,
       deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
@@ -5622,36 +5734,102 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   async resolveCuratorPeerIdsForCg(this: DKGAgent,
     contextGraphId: string,
+    options: {
+      maxPeerIds?: number;
+      pagePeerIds?: number;
+      afterPeerId?: string;
+      signal?: AbortSignal;
+      isCurrent?: () => boolean;
+    } = {},
   ): Promise<{
     peerIds: string[];
     curatorIsLocal: boolean;
     legacyTripleResolved: boolean;
     lookupFailed?: boolean;
+    overflowed?: boolean;
+    nextPageAfterPeerId?: string;
   }> {
+    const assertCurrent = (): void => {
+      if (options.signal?.aborted || options.isCurrent?.() === false) {
+        throw new DOMException('Curator discovery is no longer current', 'AbortError');
+      }
+    };
+    assertCurrent();
     const structuralCuratorDid = deriveCuratorDidFromCgId(contextGraphId);
     if (structuralCuratorDid) {
       const structuralAgent = structuralCuratorDid.slice('did:dkg:agent:'.length).toLowerCase();
       if ([...this.localAgents.keys()].some((addr) => addr.toLowerCase() === structuralAgent)) {
         return { peerIds: [], curatorIsLocal: true, legacyTripleResolved: false };
       }
-      const resolve = async (): Promise<{ peerIds: string[]; lookupFailed: boolean }> => {
-        let agents: Array<{ agentAddress?: string; peerId: string }>;
+      const resolve = async (): Promise<{
+        peerIds: string[];
+        lookupFailed: boolean;
+        overflowed?: boolean;
+        nextPageAfterPeerId?: string;
+      }> => {
+        assertCurrent();
         try {
-          agents = await this.discovery.findAgents();
+          if (options.maxPeerIds !== undefined
+            && typeof this.discovery.findAgentPeerIdsByAddress === 'function') {
+            const pagePeerIds = Math.min(
+              options.maxPeerIds,
+              Math.max(1, Math.floor(options.pagePeerIds ?? options.maxPeerIds)),
+            );
+            const queryPage = (afterPeerId?: string) =>
+              this.discovery.findAgentPeerIdsByAddress(structuralAgent, {
+                ...(afterPeerId ? { afterPeerId } : {}),
+                limit: (afterPeerId ? pagePeerIds : options.maxPeerIds!) + 1,
+                signal: options.signal,
+              });
+            let pageStartedAtBeginning = !options.afterPeerId;
+            let peerIds = await queryPage(options.afterPeerId);
+            assertCurrent();
+            if (options.afterPeerId && peerIds.length === 0) {
+              pageStartedAtBeginning = true;
+              peerIds = await queryPage();
+            }
+            assertCurrent();
+            const overflowed = !pageStartedAtBeginning
+              || peerIds.length > options.maxPeerIds;
+            const bounded = peerIds.slice(0, overflowed ? pagePeerIds : options.maxPeerIds);
+            return {
+              peerIds: bounded,
+              lookupFailed: false,
+              overflowed,
+              ...(overflowed && bounded[0]
+                ? { nextPageAfterPeerId: bounded[bounded.length - 1] }
+                : {}),
+            };
+          }
+
+          const agents = await this.discovery.findAgents({
+            agentAddress: structuralAgent,
+            signal: options.signal,
+          });
+          assertCurrent();
+          const peerIds = [...new Set(agents
+            .filter((a) => a.agentAddress?.toLowerCase() === structuralAgent)
+            .map((a) => a.peerId))]
+            .sort((left, right) => left.localeCompare(right));
+          return { peerIds, lookupFailed: false, overflowed: false };
         } catch {
+          assertCurrent();
           return { peerIds: [], lookupFailed: true };
         }
-        return {
-          peerIds: agents
-            .filter((a) => a.agentAddress?.toLowerCase() === structuralAgent)
-            .map((a) => a.peerId),
-          lookupFailed: false,
-        };
       };
       let resolution = await resolve();
+      assertCurrent();
       if (resolution.peerIds.length === 0) {
-        const refreshed = await this.refreshMetaFromCurator(contextGraphId).catch(() => false);
+        assertCurrent();
+        const refreshed = await this.refreshMetaFromCurator(contextGraphId, {
+          signal: options.signal,
+        }).catch((error) => {
+          assertCurrent();
+          return false;
+        });
+        assertCurrent();
         resolution = await resolve();
+        assertCurrent();
         // An empty local query after a failed/cooldown refresh is not an
         // authoritative empty registry. Preserve any caller-side last-known
         // curator roster unless another writer populated the registry.
@@ -5663,17 +5841,38 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         peerIds: resolution.peerIds,
         curatorIsLocal: false,
         legacyTripleResolved: false,
-        lookupFailed: resolution.lookupFailed,
+        ...(resolution.lookupFailed ? { lookupFailed: true } : {}),
+        ...(resolution.overflowed ? { overflowed: true } : {}),
+        ...(resolution.nextPageAfterPeerId
+          ? { nextPageAfterPeerId: resolution.nextPageAfterPeerId }
+          : {}),
       };
     }
     // Legacy non-wallet-scoped CG: fall back to triple-based curator resolution.
-    if (await this.isCuratorOf(contextGraphId)) {
+    assertCurrent();
+    if (await this.isCuratorOf(contextGraphId, { signal: options.signal })) {
+      assertCurrent();
       return { peerIds: [], curatorIsLocal: true, legacyTripleResolved: true };
     }
-    let curatorPeerId = await this.resolveCuratorPeerId(contextGraphId);
+    assertCurrent();
+    let curatorPeerId = await this.resolveCuratorPeerId(contextGraphId, {
+      signal: options.signal,
+    });
+    assertCurrent();
     if (!curatorPeerId) {
-      await this.refreshMetaFromCurator(contextGraphId).catch(() => undefined);
-      curatorPeerId = await this.resolveCuratorPeerId(contextGraphId);
+      assertCurrent();
+      await this.refreshMetaFromCurator(contextGraphId, {
+        signal: options.signal,
+      })
+        .catch((error) => {
+          assertCurrent();
+          return undefined;
+        });
+      assertCurrent();
+      curatorPeerId = await this.resolveCuratorPeerId(contextGraphId, {
+        signal: options.signal,
+      });
+      assertCurrent();
     }
     if (!curatorPeerId) return { peerIds: [], curatorIsLocal: false, legacyTripleResolved: true };
     if (curatorPeerId === this.peerId) return { peerIds: [], curatorIsLocal: true, legacyTripleResolved: true };
@@ -6798,19 +6997,32 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     );
   }
 
-  async ensurePeerConnected(this: DKGAgent, peerId: string): Promise<void> {
-    await ensurePeerConnectedAtom(this.node.libp2p as any, this.discovery, peerId);
-    if (await this.networkAdmissionCoordinator.ensureAdmitted(peerId, createOperationContext('connect'))) return;
+  async ensurePeerConnected(
+    this: DKGAgent,
+    peerId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<void> {
+    await ensurePeerConnectedAtom(this.node.libp2p as any, this.discovery, peerId, options);
+    if (await this.networkAdmissionCoordinator.ensureAdmitted(
+      peerId,
+      createOperationContext('connect'),
+      options,
+    )) return;
     throw new NetworkAdmissionRejectedError(peerId);
   }
 
-  async waitForSyncProtocol(this: DKGAgent, pid: { toString(): string }): Promise<boolean> {
+  async waitForSyncProtocol(
+    this: DKGAgent,
+    pid: { toString(): string },
+    signal?: AbortSignal,
+  ): Promise<boolean> {
     return waitForPeerProtocol(
       this.node.libp2p.peerStore as any,
       pid,
       PROTOCOL_SYNC,
       SYNC_PROTOCOL_CHECK_ATTEMPTS,
       SYNC_PROTOCOL_CHECK_DELAY_MS,
+      signal,
     );
   }
 
@@ -7018,6 +7230,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return run;
   }
 
+  enqueueContextGraphMembershipPersistWrite(
+    this: DKGAgent,
+    key: string,
+    write: () => Promise<void>,
+    options?: { strict?: boolean },
+  ): Promise<void> {
+    return this.contextGraphMembershipPersistence.enqueue(key, write, options);
+  }
+
   finishContextGraphSubscriptionPersistRevision(this: DKGAgent, contextGraphId: string, revision?: number): void {
     if (revision == null) return;
     const pending = this.contextGraphSubscriptionPersistPendingRevisions.get(contextGraphId);
@@ -7148,15 +7369,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   deleteContextGraphSubscription(this: DKGAgent, contextGraphId: string): boolean {
     this.invalidateListContextGraphsCache();
     this.forceClearVmReconcileStateForContextGraph(contextGraphId);
-    return this.subscribedContextGraphs.delete(contextGraphId);
+    const deleted = this.subscribedContextGraphs.delete(contextGraphId);
+    // Every in-flight binding continuation also captures the subscription
+    // object, so deleting this numeric generation cannot revive old work if a
+    // new subscription later reuses the same local id.
+    clearContextGraphBindingGeneration(this, contextGraphId);
+    return deleted;
   }
 
-  persistContextGraphSubscriptionState(this: DKGAgent, contextGraphId: string): void {
+  persistContextGraphSubscriptionState(this: DKGAgent, contextGraphId: string): Promise<void> {
     if (!this.config.contextGraphSubscriptionStore) {
       this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(contextGraphId);
-      return;
+      return Promise.resolve();
     }
-    this.persistContextGraphSubscription(contextGraphId, {
+    return this.persistContextGraphSubscription(contextGraphId, {
       revision: this.nextContextGraphSubscriptionPersistRevision(contextGraphId),
       updateRehydrationStatus: false,
     });
@@ -7168,12 +7394,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       revision?: number;
       updateRehydrationStatus?: boolean;
     },
-  ): void {
+  ): Promise<void> {
     this.invalidateListContextGraphsCache();
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) {
       this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(contextGraphId);
-      return;
+      return Promise.resolve();
     }
     const sub = this.subscribedContextGraphs.get(contextGraphId);
     // Persist member subscriptions AND (Phase D) public CGs this Core hosts —
@@ -7182,7 +7408,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // row only when the node neither subscribes to nor hosts the CG.
     this.beginContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision);
     if (!sub?.subscribed && !sub?.coreHosted) {
-      void this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, () => store.delete(contextGraphId))
+      return this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, () => store.delete(contextGraphId))
         .then(() => {
           if (
             options?.updateRehydrationStatus === true &&
@@ -7200,7 +7426,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         .finally(() => {
           this.finishContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision);
         });
-      return;
     }
     const record = {
       id: contextGraphId,
@@ -7215,7 +7440,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       coreHosted: sub.coreHosted,
       syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
     };
-    void this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, () => store.save(record))
+    return this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, () => store.save(record))
       .then(() => {
         if (
           options?.updateRehydrationStatus === true &&
@@ -7237,6 +7462,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     subscription?: ContextGraphSub,
     syncScoped?: boolean,
+    isCurrent: () => boolean = () => true,
   ): Promise<void> {
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) {
@@ -7245,10 +7471,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // retains the backward-compatible in-memory approval path.
       return;
     }
-    const sub = subscription ?? this.subscribedContextGraphs.get(contextGraphId);
-    if (!sub?.subscribed) {
+    const expectedLiveSub = this.subscribedContextGraphs.get(contextGraphId);
+    const expectedBindingGeneration = captureContextGraphBindingGeneration(
+      this,
+      contextGraphId,
+    );
+    const sub = subscription ?? expectedLiveSub;
+    if (!sub?.subscribed && !sub?.coreHosted) {
       throw new Error(
-        `Cannot acknowledge join approval for "${contextGraphId}": active subscription state is missing`,
+        `Cannot persist context graph "${contextGraphId}": active subscription or host state is missing`,
       );
     }
     const record = {
@@ -7266,10 +7497,25 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     };
     // Queue behind any fire-and-forget writes scheduled by subscribe/mark so
     // this final authoritative snapshot is the last write before the ACK.
-    await this.enqueueContextGraphSubscriptionPersistWrite(
-      contextGraphId,
-      () => store.save(record),
-    );
+    await this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, async () => {
+      const current = this.subscribedContextGraphs.get(contextGraphId);
+      if (
+        !isCurrent()
+        ||
+        current !== expectedLiveSub
+        || (!current?.subscribed && !current?.coreHosted)
+        || !isContextGraphBindingGenerationCurrent(
+          this,
+          contextGraphId,
+          expectedBindingGeneration,
+        )
+      ) {
+        throw asSyncFetchAbortError(new Error(
+          `Context graph "${contextGraphId}" changed before its strict subscription snapshot was persisted`,
+        ));
+      }
+      await store.save(record);
+    });
   }
 
   /**
@@ -7292,93 +7538,101 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       membership.principalType,
       membership.principalId,
     );
-
-    let previousMembership: (ContextGraphMembershipRecord & {
-      firstSeenAt?: number;
-      updatedAt: number;
-    }) | null = null;
-    let previousMembershipKnown = membershipStore === undefined;
-    if (membershipStore?.loadAll) {
-      const rows = await membershipStore.loadAll();
-      previousMembershipKnown = true;
-      previousMembership = rows.find((row) =>
-        row.contextGraphId === contextGraphId &&
-        row.principalType === membership.principalType &&
-        this.normalizeMembershipPrincipal(row.principalType, row.principalId) === normalizedPrincipalId
-      ) ?? null;
-    }
-
-    let previousSubscription: ContextGraphSubscriptionRecord | null = null;
-    if (subscriptionStore) {
-      previousSubscription = subscriptionStore.load
-        ? await subscriptionStore.load(contextGraphId)
-        : (await subscriptionStore.loadAll()).find((row) => row.id === contextGraphId) ?? null;
-    }
-
-    let membershipAttempted = false;
-    let subscriptionAttempted = false;
-    try {
-      // Membership is the prepare record; the subscription row is the durable
-      // activation/rehydration commit marker and must remain last. A legacy
-      // membership store without a read API may retain an idempotent prepared
-      // row after failure, but it can never leave a restart-visible active
-      // subscription without the membership fact it depends on.
-      if (membershipStore) membershipAttempted = true;
-      await this.upsertContextGraphMember(membership, { strict: true });
-      if (subscriptionStore) subscriptionAttempted = true;
-      await this.persistContextGraphSubscriptionStrict(
-        contextGraphId,
-        subscription,
-        true,
-      );
-    } catch (error) {
-      const rollbackFailures: unknown[] = [];
-      // A store may reject after applying a write, so compensate every
-      // attempted operation whose prior value was observable, including the
-      // one that surfaced the failure. Never guess absence for a legacy
-      // membership store without loadAll(): deleting there could erase a
-      // valid pre-existing row after an upsert that rejected before mutation.
-      if (subscriptionAttempted && subscriptionStore) {
-        try {
-          await this.enqueueContextGraphSubscriptionPersistWrite(
-            contextGraphId,
-            () => previousSubscription
-              ? subscriptionStore.save(previousSubscription)
-              : subscriptionStore.delete(contextGraphId),
-          );
-        } catch (rollbackError) {
-          rollbackFailures.push(rollbackError);
+    const membershipKey = `${contextGraphId}\0${membership.principalType}\0${normalizedPrincipalId}`;
+    await this.enqueueContextGraphMembershipPersistWrite(membershipKey, () =>
+      this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, async () => {
+        let previousMembership: (ContextGraphMembershipRecord & {
+          firstSeenAt?: number;
+          updatedAt: number;
+        }) | null = null;
+        let previousMembershipKnown = membershipStore === undefined;
+        if (membershipStore?.loadAll) {
+          const rows = await membershipStore.loadAll();
+          previousMembershipKnown = true;
+          previousMembership = rows.find((row) =>
+            row.contextGraphId === contextGraphId
+            && row.principalType === membership.principalType
+            && this.normalizeMembershipPrincipal(row.principalType, row.principalId) === normalizedPrincipalId
+          ) ?? null;
         }
-      }
-      if (membershipAttempted && membershipStore && previousMembershipKnown) {
+
+        let previousSubscription: ContextGraphSubscriptionRecord | null = null;
+        if (subscriptionStore) {
+          previousSubscription = subscriptionStore.load
+            ? await subscriptionStore.load(contextGraphId)
+            : (await subscriptionStore.loadAll()).find((row) => row.id === contextGraphId) ?? null;
+        }
+
+        const subscriptionRecord: ContextGraphSubscriptionRecord = {
+          id: contextGraphId,
+          name: subscription.name,
+          subscribed: subscription.subscribed,
+          synced: subscription.synced,
+          sharedMemorySynced: subscription.sharedMemorySynced,
+          metaSynced: subscription.metaSynced,
+          onChainId: subscription.onChainId,
+          onChainHash: subscription.onChainHash,
+          lastReconciledOrdinal: subscription.lastReconciledOrdinal,
+          coreHosted: subscription.coreHosted,
+          syncScoped: true,
+        };
+        let membershipAttempted = false;
+        let subscriptionAttempted = false;
         try {
-          if (previousMembership) {
-            await membershipStore.upsert(previousMembership);
-          } else {
-            await membershipStore.delete(
-              contextGraphId,
-              membership.principalType,
-              normalizedPrincipalId,
+          if (membershipStore) {
+            membershipAttempted = true;
+            await membershipStore.upsert({
+              ...membership,
+              principalId: normalizedPrincipalId,
+              updatedAt: Date.now(),
+            });
+          }
+          if (subscriptionStore) {
+            subscriptionAttempted = true;
+            await subscriptionStore.save(subscriptionRecord);
+          }
+        } catch (error) {
+          const rollbackFailures: unknown[] = [];
+          if (subscriptionAttempted && subscriptionStore) {
+            try {
+              await (previousSubscription
+                ? subscriptionStore.save(previousSubscription)
+                : subscriptionStore.delete(contextGraphId));
+            } catch (rollbackError) {
+              rollbackFailures.push(rollbackError);
+            }
+          }
+          if (membershipAttempted && membershipStore && previousMembershipKnown) {
+            try {
+              if (previousMembership) await membershipStore.upsert(previousMembership);
+              else {
+                await membershipStore.delete(
+                  contextGraphId,
+                  membership.principalType,
+                  normalizedPrincipalId,
+                );
+              }
+            } catch (rollbackError) {
+              rollbackFailures.push(rollbackError);
+            }
+          }
+          if (rollbackFailures.length > 0) {
+            const originalMessage = error instanceof Error ? error.message : String(error);
+            const rollbackMessage = rollbackFailures
+              .map((rollbackError) => rollbackError instanceof Error
+                ? rollbackError.message
+                : String(rollbackError))
+              .join('; ');
+            throw new AggregateError(
+              [error, ...rollbackFailures],
+              `${originalMessage}; join-approval rollback failed: ${rollbackMessage}`,
             );
           }
-        } catch (rollbackError) {
-          rollbackFailures.push(rollbackError);
+          throw error;
         }
-      }
-      if (rollbackFailures.length > 0) {
-        const originalMessage = error instanceof Error ? error.message : String(error);
-        const rollbackMessage = rollbackFailures
-          .map((rollbackError) => rollbackError instanceof Error
-            ? rollbackError.message
-            : String(rollbackError))
-          .join('; ');
-        throw new AggregateError(
-          [error, ...rollbackFailures],
-          `${originalMessage}; join-approval rollback failed: ${rollbackMessage}`,
-        );
-      }
-      throw error;
-    }
+      }),
+      { strict: true },
+    );
   }
 
   async assertAlreadyMemberDelegationRefresh(this: DKGAgent,
@@ -7473,8 +7727,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ...record,
       principalId: this.normalizeMembershipPrincipal(record.principalType, record.principalId),
     };
-    const updatedAt = Date.now();
-    const write = store.upsert({ ...normalizedRecord, updatedAt });
+    const key = `${normalizedRecord.contextGraphId}\0${normalizedRecord.principalType}\0${normalizedRecord.principalId}`;
+    const write = this.enqueueContextGraphMembershipPersistWrite(
+      key,
+      () => store.upsert({ ...normalizedRecord, updatedAt: Date.now() }),
+      { strict: options?.strict === true },
+    );
     if (options?.strict === true) return write;
     // Background callers stay log-and-continue; durability-sensitive callers
     // opt into the strict path above and receive the original rejection.
@@ -7494,7 +7752,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const store = this.config.contextGraphMembershipStore;
     if (!store) return;
     const normalizedPrincipalId = this.normalizeMembershipPrincipal(principalType, principalId);
-    void store.delete(contextGraphId, principalType, normalizedPrincipalId).catch((err) => {
+    const key = `${contextGraphId}\0${principalType}\0${normalizedPrincipalId}`;
+    void this.enqueueContextGraphMembershipPersistWrite(
+      key,
+      () => store.delete(contextGraphId, principalType, normalizedPrincipalId),
+    ).catch((err) => {
       this.log.warn(
         createOperationContext('system'),
         `Failed to delete context-graph membership for "${contextGraphId}" (${principalType}:${normalizedPrincipalId}): ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -669,7 +669,11 @@ export class OwnershipMethods extends DKGAgentBase {
     return false;
   }
 
-  async getContextGraphOwner(this: DKGAgent, contextGraphId: string): Promise<string | null> {
+  async getContextGraphOwner(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<string | null> {
     // Prefer the curator (wallet-scoped owner) so per-agent authorization
     // works on multi-agent nodes. Fall back to the creator (libp2p peer ID)
     // for legacy CGs created before the curator triple existed.
@@ -681,9 +685,9 @@ export class OwnershipMethods extends DKGAgentBase {
     // that preference, the LIMIT-1 lookup here would non-deterministically
     // pick a foreign curator and lock the real local curator out of
     // manage-participants / rename / policy operations.
-    const curatorOwner = await this.getContextGraphCurator(contextGraphId);
+    const curatorOwner = await this.getContextGraphCurator(contextGraphId, options);
     if (curatorOwner) return curatorOwner;
-    const fromCreator = await this.getContextGraphCreator(contextGraphId);
+    const fromCreator = await this.getContextGraphCreator(contextGraphId, options);
     if (fromCreator) return fromCreator;
     // Final fallback: V10 wallet-scoped cgId convention (`0x.../<name>`)
     // encodes the curator structurally, which lets us answer for CGs
@@ -701,7 +705,7 @@ export class OwnershipMethods extends DKGAgentBase {
     // create stray `_meta` rows for graphs that were never created
     // here. The fallback is meant to rescue real-but-half-registered
     // graphs, not impersonate ownership of unknown ones.
-    const exists = await this.contextGraphExists(contextGraphId);
+    const exists = await this.contextGraphExists(contextGraphId, options);
     if (!exists) return null;
     return deriveCuratorDidFromCgId(contextGraphId);
   }
@@ -858,8 +862,12 @@ export class OwnershipMethods extends DKGAgentBase {
    * Emitted approve/revoke binding metadata must use this value so remote
    * peers validating via `gossip-publish-handler` see a matching owner.
    */
-  async getContextGraphCreator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
-    return (await this.getCgMeta(contextGraphId)).creator ?? null;
+  async getContextGraphCreator(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<string | null> {
+    return (await this.getCgMeta(contextGraphId, { signal: options.signal })).creator ?? null;
   }
 
   public async listCclPolicyBindings(this: DKGAgent, opts: {

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1484,8 +1484,12 @@ export class AgentRegistryMethods extends DKGAgentBase {
    * Check whether any locally registered agent is the curator/creator
    * of the given context graph.
    */
-  async isCuratorOf(this: DKGAgent, contextGraphId: string): Promise<boolean> {
-    const owner = await this.getContextGraphOwner(contextGraphId);
+  async isCuratorOf(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<boolean> {
+    const owner = await this.getContextGraphOwner(contextGraphId, options);
     if (!owner) return false;
     // Mirror the comparison in PROTOCOL_JOIN_REQUEST. `normalizeAgentDid`
     // collapses EVM-address case drift but preserves peer-ID case.

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3672,6 +3672,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         ordinal: target.ordinal,
         fingerprint,
         phase: 'collecting',
+        backoffReason: undefined,
         candidatePeerIds: new Set(candidatePeerIds),
         attemptedPeerIds: new Set(),
         cleanAbsentPeerIds: new Set(),
@@ -3702,6 +3703,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Any removal/replacement invalidates the whole cycle so shrink can
         // never manufacture exhaustion or preserve an active suppression.
         record.phase = 'collecting';
+        record.backoffReason = undefined;
         record.nextRetryAt = 0;
         record.attemptedPeerIds.clear();
         record.cleanAbsentPeerIds.clear();
@@ -3712,6 +3714,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Pure growth preserves valid credits for retained identities, but the
         // newly observed peer is uncredited and immediately breaks backoff.
         record.phase = 'collecting';
+        record.backoffReason = undefined;
         record.nextRetryAt = 0;
         record.collectionDeadlineAt = now
           + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
@@ -3724,6 +3727,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // A deadline only opens a new collection cycle. It never earns another
       // failure/backoff without fresh clean-absence evidence from every peer.
       record.phase = 'collecting';
+      record.backoffReason = undefined;
       record.attemptedPeerIds.clear();
       record.cleanAbsentPeerIds.clear();
       record.collectionDeadlineAt = now
@@ -3748,6 +3752,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this: DKGAgent,
     slotKey: string,
     record: VmReconcileRotationRecord,
+    reason: 'clean-absence' | 'no-progress',
   ): void {
     record.failures += 1;
     const exponentialBackoff = Math.min(
@@ -3764,6 +3769,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       Math.max(1, Math.round(exponentialBackoff * (0.8 + jitterSample * 0.4))),
     );
     record.phase = 'backoff';
+    record.backoffReason = reason;
     record.collectionDeadlineAt = 0;
     record.nextRetryAt = this.vmReconcileRotationNow() + backoff;
   }
@@ -3855,15 +3861,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const cleanAbsentFromEveryPeer = [...capturedRecord.candidatePeerIds]
       .every((candidatePeerId) => capturedRecord.cleanAbsentPeerIds.has(candidatePeerId));
     if (cleanAbsentFromEveryPeer) {
-      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord);
+      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord, 'clean-absence');
     } else if (attemptedEveryPeer) {
       // An incomplete, failed, or still-pending result is not absence proof.
-      // Reset the entire proof cycle and rely only on the existing per-CG
-      // sweep cooldown; retain the cursor so the next cycle starts elsewhere.
+      // It still needs completion-anchored retry damping: an exact transfer can
+      // outlast the start-anchored per-CG cooldown, and legacy responders may
+      // return the whole CG while never covering the requested descriptor.
+      // Keep the cause explicit so this backoff can never be mistaken for a
+      // clean-absence proof or advance VM state.
       capturedRecord.attemptedPeerIds.clear();
       capturedRecord.cleanAbsentPeerIds.clear();
-      capturedRecord.collectionDeadlineAt = this.vmReconcileRotationNow()
-        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord, 'no-progress');
     }
     this.touchVmReconcileRotationRecord(slotKey, capturedRecord);
   }
@@ -4124,36 +4132,39 @@ export class SwmHostModeMethods extends DKGAgentBase {
         legacyTripleResolved: false,
         lookupFailed: true,
       }));
+    if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
     const resolutionSucceeded = curatorResolution.lookupFailed !== true;
     const resolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
       .filter((peerId) => peerId && peerId !== this.peerId))]
       .sort((left, right) => left.localeCompare(right))
       .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
-    const authoritativeCuratorPeerIds = resolutionSucceeded
-      ? resolvedCuratorPeerIds
-      : cachedCuratorPeerIds;
-    if (resolutionSucceeded) {
-      // A successful empty/local resolution is authoritative and must clear a
-      // stale prior roster. A failed lookup retains the last known IDs so an
-      // unrelated discovery outage cannot reorder or erase the proof set.
-      this.vmReconcileCuratorPeersByCg.delete(localCgId);
-      if (!curatorResolution.curatorIsLocal && resolvedCuratorPeerIds.length > 0) {
-        this.vmReconcileCuratorPeersByCg.set(localCgId, resolvedCuratorPeerIds);
-      }
-      this.pruneVmReconcileState();
-    }
     let legacyPreferredPeerId: string | undefined;
     if (resolutionSucceeded && !curatorResolution.curatorIsLocal
       && resolvedCuratorPeerIds.length === 0) {
       legacyPreferredPeerId = await this.resolvePreferredSyncPeerId(localCgId);
     }
+    if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+    const authoritativeCuratorPeerIds = resolutionSucceeded
+      ? resolvedCuratorPeerIds
+      : cachedCuratorPeerIds;
     const curatorPeerIds = [...new Set([
       ...authoritativeCuratorPeerIds,
       legacyPreferredPeerId,
       approvedCuratorPeerId,
     ].filter((peerId): peerId is string => Boolean(peerId && peerId !== this.peerId)))]
       .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
+    // Persist the same ranked roster that this pass dials and later uses for
+    // proof canonicalization. A successful empty structural lookup may fall
+    // back to metadata; omitting that peer here lets ordinary peers fill the
+    // cap and repeatedly prove absence without querying the only holder.
+    if (resolutionSucceeded) this.vmReconcileCuratorPeersByCg.delete(localCgId);
+    if (!curatorResolution.curatorIsLocal && curatorPeerIds.length > 0) {
+      this.vmReconcileCuratorPeersByCg.delete(localCgId);
+      this.vmReconcileCuratorPeersByCg.set(localCgId, curatorPeerIds);
+    }
+    this.pruneVmReconcileState();
     for (const peerId of curatorPeerIds) {
+      if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
       await this.ensurePeerConnected(peerId).catch((error) => {
         this.log.info(
           ctx,
@@ -4161,6 +4172,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         );
       });
     }
+    if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
 
     const connectedByPeerId = new Map(
       this.node.libp2p.getConnections()

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3603,13 +3603,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // never replace one member of the bounded proof roster.
     const canonicalPeers = [...peersById.values()].sort((left, right) =>
       left.toString().localeCompare(right.toString()));
-    return this.selectCatchupPeers(
+    const ordinaryOrder = this.selectCatchupPeers(
       canonicalPeers,
       this.preferredSyncPeers.get(localCgId),
       false,
     )
-      .map((peer) => peer.toString())
-      .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
+      .map((peer) => peer.toString());
+    const curatorOrder = this.vmReconcileCuratorPeersByCg.get(localCgId) ?? [];
+    return [...new Set([
+      ...curatorOrder.filter((peerId) => peersById.has(peerId)),
+      ...ordinaryOrder,
+    ])].slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
   }
 
   vmReconcilePeerMembershipMatches(
@@ -3669,6 +3673,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         fingerprint,
         phase: 'collecting',
         candidatePeerIds: new Set(candidatePeerIds),
+        attemptedPeerIds: new Set(),
         cleanAbsentPeerIds: new Set(),
         collectionDeadlineAt: now + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
         failures: 0,
@@ -3687,16 +3692,48 @@ export class SwmHostModeMethods extends DKGAgentBase {
       candidatePeerIds,
     );
     if (!membershipUnchanged) {
+      const nextCandidatePeerIds = new Set(candidatePeerIds);
+      const wasBackoff = record.phase === 'backoff';
+      const activeBackoff = record.phase === 'backoff' && now < record.nextRetryAt;
       record.candidatePeerIds = new Set(candidatePeerIds);
-      record.phase = 'collecting';
-      record.nextRetryAt = 0;
-      record.collectionDeadlineAt = now
-        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
-      record.lastAttemptedPeerId = undefined;
-      // A roster change starts a fresh proof cycle. Mixing credits obtained
-      // against different candidate sets could manufacture exhaustion when a
-      // peer disappears and later rejoins.
-      record.cleanAbsentPeerIds.clear();
+      // Preserve only evidence belonging to retained identities. Added or
+      // rejoined peers remain unattempted and break backoff; removed peers can
+      // never contribute to exhaustion of the new roster.
+      for (const peerId of [...record.attemptedPeerIds]) {
+        if (!nextCandidatePeerIds.has(peerId)) record.attemptedPeerIds.delete(peerId);
+      }
+      for (const peerId of [...record.cleanAbsentPeerIds]) {
+        if (!nextCandidatePeerIds.has(peerId)) record.cleanAbsentPeerIds.delete(peerId);
+      }
+      if (
+        record.lastAttemptedPeerId !== undefined
+        && !nextCandidatePeerIds.has(record.lastAttemptedPeerId)
+      ) record.lastAttemptedPeerId = undefined;
+      const hasUnattemptedPeer = candidatePeerIds.some(
+        (peerId) => !record!.attemptedPeerIds.has(peerId),
+      );
+      if (activeBackoff && !hasUnattemptedPeer) {
+        // A removal-only change cannot reopen work already bounded by the
+        // active retry window.
+        record.phase = 'backoff';
+        record.collectionDeadlineAt = 0;
+      } else if (hasUnattemptedPeer) {
+        record.phase = 'collecting';
+        record.nextRetryAt = 0;
+        record.collectionDeadlineAt = now
+          + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+      } else if (!wasBackoff) {
+        this.enterVmReconcileRotationBackoff(slotKey, record);
+      } else {
+        // An expired backoff opens a genuinely fresh cycle even when the only
+        // topology change was removal.
+        record.phase = 'collecting';
+        record.nextRetryAt = 0;
+        record.attemptedPeerIds.clear();
+        record.cleanAbsentPeerIds.clear();
+        record.collectionDeadlineAt = now
+          + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+      }
     } else if (record.phase === 'backoff') {
       if (now < record.nextRetryAt) {
         this.touchVmReconcileRotationRecord(slotKey, record);
@@ -3705,6 +3742,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // A deadline only opens a new collection cycle. It never earns another
       // failure/backoff without fresh clean-absence evidence from every peer.
       record.phase = 'collecting';
+      record.attemptedPeerIds.clear();
       record.cleanAbsentPeerIds.clear();
       record.collectionDeadlineAt = now
         + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
@@ -3714,6 +3752,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // stable sibling repeatedly fails protocol/admission or returns an
       // incomplete response. Start a fresh proof cycle without treating the
       // incomplete cycle as a failure or scheduling a timer.
+      record.attemptedPeerIds.clear();
       record.cleanAbsentPeerIds.clear();
       record.collectionDeadlineAt = now
         + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
@@ -3721,6 +3760,30 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     this.touchVmReconcileRotationRecord(slotKey, record);
     return { slotKey, record, suppressed: false };
+  }
+
+  enterVmReconcileRotationBackoff(
+    this: DKGAgent,
+    slotKey: string,
+    record: VmReconcileRotationRecord,
+  ): void {
+    record.failures += 1;
+    const exponentialBackoff = Math.min(
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS
+        * 2 ** Math.max(0, record.failures - 1),
+    );
+    const jitterSample = createHash('sha256')
+      .update(`${this.peerId}\0${slotKey}\0${record.fingerprint}\0${record.failures}`)
+      .digest()
+      .readUInt32BE(0) / 0x1_0000_0000;
+    const backoff = Math.min(
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+      Math.max(1, Math.round(exponentialBackoff * (0.8 + jitterSample * 0.4))),
+    );
+    record.phase = 'backoff';
+    record.collectionDeadlineAt = 0;
+    record.nextRetryAt = this.vmReconcileRotationNow() + backoff;
   }
 
   vmReconcileUncreditedCandidateOrder(
@@ -3736,7 +3799,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return [
       ...candidates.slice(start),
       ...candidates.slice(0, start),
-    ].filter((peerId) => !record.cleanAbsentPeerIds.has(peerId));
+    ].filter((peerId) => !record.attemptedPeerIds.has(peerId));
   }
 
   makeRoomForVmReconcileRotationRecord(this: DKGAgent): boolean {
@@ -3767,7 +3830,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   closeVmReconcileRotationState(this: DKGAgent): void {
     this.vmReconcileRotationClosed = true;
-    this.vmReconcileRotationState.clear();
+    // Some lifecycle tests intentionally construct a narrow partial agent
+    // without running the base constructor. Shutdown must remain best-effort
+    // for that supported test seam and never mask later teardown failures.
+    this.vmReconcileRotationState?.clear();
+    this.vmReconcileCuratorPeersByCg?.clear();
   }
 
   vmReconcileRecoveryTargetMatches(
@@ -3782,10 +3849,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
       && expected.merkleRoot.toLowerCase() === actual.merkleRoot.toLowerCase();
   }
 
-  creditVmReconcileCleanAbsence(
+  settleVmReconcileRotationAttempt(
     this: DKGAgent,
     target: OrdinalRecoveryTarget,
     peerId: string,
+    disposition: 'found' | 'clean-absent' | 'incomplete',
     expectedCandidatePeerIds: readonly string[],
     capturedRecord: VmReconcileRotationRecord,
   ): void {
@@ -3798,29 +3866,34 @@ export class SwmHostModeMethods extends DKGAgentBase {
     )) return;
     if (!capturedRecord.candidatePeerIds.has(peerId)) return;
 
-    capturedRecord.cleanAbsentPeerIds.add(peerId);
+    capturedRecord.attemptedPeerIds.add(peerId);
+    if (disposition === 'clean-absent') capturedRecord.cleanAbsentPeerIds.add(peerId);
     const exhausted = [...capturedRecord.candidatePeerIds]
-      .every((candidatePeerId) => capturedRecord.cleanAbsentPeerIds.has(candidatePeerId));
+      .every((candidatePeerId) => capturedRecord.attemptedPeerIds.has(candidatePeerId));
     if (exhausted) {
-      capturedRecord.failures += 1;
-      const exponentialBackoff = Math.min(
-        DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
-        DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS
-          * 2 ** Math.max(0, capturedRecord.failures - 1),
-      );
-      const jitterSample = createHash('sha256')
-        .update(`${this.peerId}\0${slotKey}\0${capturedRecord.fingerprint}\0${capturedRecord.failures}`)
-        .digest()
-        .readUInt32BE(0) / 0x1_0000_0000;
-      const backoff = Math.min(
-        DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
-        Math.max(1, Math.round(exponentialBackoff * (0.8 + jitterSample * 0.4))),
-      );
-      capturedRecord.phase = 'backoff';
-      capturedRecord.collectionDeadlineAt = 0;
-      capturedRecord.nextRetryAt = this.vmReconcileRotationNow() + backoff;
+      // A full cycle of fail-closed incomplete outcomes is not absence proof,
+      // but it is still a bounded no-progress retry cycle. Throttle it without
+      // changing authentication/materialization semantics; a target/root or
+      // candidate change breaks this finite backoff immediately.
+      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord);
     }
     this.touchVmReconcileRotationRecord(slotKey, capturedRecord);
+  }
+
+  creditVmReconcileCleanAbsence(
+    this: DKGAgent,
+    target: OrdinalRecoveryTarget,
+    peerId: string,
+    expectedCandidatePeerIds: readonly string[],
+    capturedRecord: VmReconcileRotationRecord,
+  ): void {
+    this.settleVmReconcileRotationAttempt(
+      target,
+      peerId,
+      'clean-absent',
+      expectedCandidatePeerIds,
+      capturedRecord,
+    );
   }
 
   shouldRunVmReconcileActiveFetch(this: DKGAgent, localCgId: string): boolean {
@@ -3880,6 +3953,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
       this.vmReconcileCatchupPeerOrder.delete(oldestKey);
       this.vmReconcileCatchupPeerCursor.delete(oldestKey);
     }
+    while (this.vmReconcileCuratorPeersByCg.size > DKGAgentBase.VM_RECONCILE_CG_STATE_MAX_ENTRIES) {
+      const oldestKey = this.vmReconcileCuratorPeersByCg.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileCuratorPeersByCg.delete(oldestKey);
+    }
   }
 
   clearVmReconcileStateForContextGraph(this: DKGAgent, localCgId: string): void {
@@ -3902,6 +3980,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       });
     this.reconcileCursors.delete(localCgId);
     this.clearVmReconcileRotationStateForContextGraph(localCgId);
+    this.vmReconcileCuratorPeersByCg.delete(localCgId);
     this.vmReconcileFetchCooldownAt.delete(localCgId);
     this.vmReconcileCatchupPeerCursor.delete(localCgId);
     this.vmReconcileCatchupPeerOrder.delete(localCgId);
@@ -3984,14 +4063,31 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // production ordinal/finalization check proved it still pending locally.
     const observedCandidatePeerIds = this.vmReconcileObservedCandidatePeerIds(localCgId);
     const now = this.vmReconcileRotationNow();
-    const initiallyEligible = currentTargets.filter((target) =>
-      !this.prepareVmReconcileRotationTarget(
+    const initialPreparations = currentTargets.map((target) => ({
+      target,
+      prepared: this.prepareVmReconcileRotationTarget(
         target,
         observedCandidatePeerIds,
         now,
-      ).suppressed);
+      ),
+    }));
+    const initiallyEligible = initialPreparations
+      .filter(({ prepared }) => !prepared.suppressed)
+      .map(({ target }) => target);
     if (initiallyEligible.length === 0) {
-      this.log.info(ctx, `VM exact fetch for "${localCgId}" skipped by exact-absence backoff`);
+      const suppressedRecords = initialPreparations
+        .map(({ prepared }) => prepared.record)
+        .filter((record): record is VmReconcileRotationRecord => record !== undefined);
+      const nextRetryInMs = suppressedRecords.length === 0
+        ? 0
+        : Math.max(0, Math.min(...suppressedRecords.map((record) => record.nextRetryAt)) - now);
+      this.log.info(
+        ctx,
+        `VM exact fetch for "${localCgId}" skipped by exact-recovery backoff `
+          + `(slots=${suppressedRecords.length} candidates=${observedCandidatePeerIds.length} `
+          + `failures=${Math.max(0, ...suppressedRecords.map((record) => record.failures))} `
+          + `retryInMs=${Math.round(nextRetryInMs)})`,
+      );
       return noRecovery();
     }
 
@@ -4024,6 +4120,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
       legacyPreferredPeerId,
     ].filter((peerId): peerId is string => Boolean(peerId && peerId !== this.peerId)))]
       .slice(0, 3);
+    if (curatorPeerIds.length > 0) {
+      // Cache only already-resolved identifiers. This gives the pre-network
+      // suppression gate the same authoritative roster on later sweeps without
+      // adding decision-path discovery, dialing, or chain reads.
+      this.vmReconcileCuratorPeersByCg.delete(localCgId);
+      this.vmReconcileCuratorPeersByCg.set(localCgId, curatorPeerIds);
+      this.pruneVmReconcileState();
+    }
     for (const peerId of curatorPeerIds) {
       await this.ensurePeerConnected(peerId).catch((error) => {
         this.log.info(
@@ -4158,6 +4262,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         attemptedOrdinals.add(target.ordinal);
         if (installedRecord) {
           installedRecord.lastAttemptedPeerId = peerId;
+          installedRecord.attemptedPeerIds.add(peerId);
           this.touchVmReconcileRotationRecord(
             this.vmReconcileRotationSlotKey(target),
             installedRecord,
@@ -4211,13 +4316,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
             candidateMembershipAfter,
             this.vmReconcileRotationNow(),
           );
-        } else if (
-          disposition === 'clean-absent'
-          && this.vmReconcileRecoveryTargetMatches(target, outcome.recovery)
-        ) {
-          this.creditVmReconcileCleanAbsence(
+        } else if (this.vmReconcileRecoveryTargetMatches(target, outcome.recovery)) {
+          this.settleVmReconcileRotationAttempt(
             target,
             peerId,
+            disposition,
             candidatePeerIds,
             installedRecord,
           );

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3672,7 +3672,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
         ordinal: target.ordinal,
         fingerprint,
         phase: 'collecting',
-        backoffReason: undefined,
         candidatePeerIds: new Set(candidatePeerIds),
         attemptedPeerIds: new Set(),
         cleanAbsentPeerIds: new Set(),
@@ -3703,7 +3702,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Any removal/replacement invalidates the whole cycle so shrink can
         // never manufacture exhaustion or preserve an active suppression.
         record.phase = 'collecting';
-        record.backoffReason = undefined;
         record.nextRetryAt = 0;
         record.attemptedPeerIds.clear();
         record.cleanAbsentPeerIds.clear();
@@ -3714,7 +3712,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Pure growth preserves valid credits for retained identities, but the
         // newly observed peer is uncredited and immediately breaks backoff.
         record.phase = 'collecting';
-        record.backoffReason = undefined;
         record.nextRetryAt = 0;
         record.collectionDeadlineAt = now
           + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
@@ -3727,21 +3724,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // A deadline only opens a new collection cycle. It never earns another
       // failure/backoff without fresh clean-absence evidence from every peer.
       record.phase = 'collecting';
-      record.backoffReason = undefined;
       record.attemptedPeerIds.clear();
       record.cleanAbsentPeerIds.clear();
       record.collectionDeadlineAt = now
         + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
       record.nextRetryAt = 0;
     } else if (now >= record.collectionDeadlineAt) {
-      // A partial rotation must not pin already-credited peers forever when a
-      // stable sibling repeatedly fails protocol/admission or returns an
-      // incomplete response. Start a fresh proof cycle without treating the
-      // incomplete cycle as a failure or scheduling a timer.
-      record.attemptedPeerIds.clear();
-      record.cleanAbsentPeerIds.clear();
-      record.collectionDeadlineAt = now
-        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+      // Expired partial evidence fails open and releases its cache slot. Return
+      // evidence-free for this pass so a repeatedly ineligible roster cannot
+      // refresh all collecting entries just before capacity admission runs.
+      this.vmReconcileRotationState.delete(slotKey);
+      return { slotKey, suppressed: false };
     }
 
     this.touchVmReconcileRotationRecord(slotKey, record);
@@ -3752,7 +3745,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this: DKGAgent,
     slotKey: string,
     record: VmReconcileRotationRecord,
-    reason: 'clean-absence' | 'no-progress',
   ): void {
     record.failures += 1;
     const exponentialBackoff = Math.min(
@@ -3769,7 +3761,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
       Math.max(1, Math.round(exponentialBackoff * (0.8 + jitterSample * 0.4))),
     );
     record.phase = 'backoff';
-    record.backoffReason = reason;
     record.collectionDeadlineAt = 0;
     record.nextRetryAt = this.vmReconcileRotationNow() + backoff;
   }
@@ -3794,12 +3785,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (this.vmReconcileRotationState.size < DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
       return true;
     }
-    // Map order is LRU order. A completed backoff record is replaceable: the
-    // evicted slot merely retries fail-open. Collecting records stay installed
-    // until they finish or are invalidated, preventing cap+1 churn from making
-    // every partial rotation useless.
+    // Map order is LRU order. Completed backoff and expired collecting records
+    // are replaceable: eviction merely retries fail-open. Live collectors stay
+    // installed so cap+1 churn cannot make every partial rotation useless.
+    const now = this.vmReconcileRotationNow();
     for (const [key, record] of this.vmReconcileRotationState) {
-      if (record.phase !== 'backoff') continue;
+      if (
+        record.phase !== 'backoff'
+        && (record.phase !== 'collecting' || now < record.collectionDeadlineAt)
+      ) continue;
       this.vmReconcileRotationState.delete(key);
       return true;
     }
@@ -3840,10 +3834,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
   settleVmReconcileRotationAttempt(
     this: DKGAgent,
     target: OrdinalRecoveryTarget,
-    peerId: string,
+    peerId: string | undefined,
     disposition: 'found' | 'clean-absent' | 'incomplete',
     expectedCandidatePeerIds: readonly string[],
     capturedRecord: VmReconcileRotationRecord,
+    unavailablePeerIds: ReadonlySet<string> = new Set(),
   ): void {
     if (this.vmReconcileRotationClosed) return;
     const slotKey = this.vmReconcileRotationSlotKey(target);
@@ -3852,26 +3847,29 @@ export class SwmHostModeMethods extends DKGAgentBase {
       capturedRecord.candidatePeerIds,
       expectedCandidatePeerIds,
     )) return;
-    if (!capturedRecord.candidatePeerIds.has(peerId)) return;
+    if (peerId !== undefined && !capturedRecord.candidatePeerIds.has(peerId)) return;
 
-    capturedRecord.attemptedPeerIds.add(peerId);
-    if (disposition === 'clean-absent') capturedRecord.cleanAbsentPeerIds.add(peerId);
-    const attemptedEveryPeer = [...capturedRecord.candidatePeerIds]
-      .every((candidatePeerId) => capturedRecord.attemptedPeerIds.has(candidatePeerId));
+    if (peerId !== undefined) {
+      capturedRecord.attemptedPeerIds.add(peerId);
+      if (disposition === 'clean-absent') capturedRecord.cleanAbsentPeerIds.add(peerId);
+      // Preserve fairly accumulated proof progress while other targets share
+      // the bounded peer budget. A cycle expires only after this slot itself
+      // stops making physical progress for the effective maximum.
+      capturedRecord.collectionDeadlineAt = this.vmReconcileRotationNow()
+        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+    }
+    const scheduledEveryPeer = [...capturedRecord.candidatePeerIds]
+      .every((candidatePeerId) => capturedRecord.attemptedPeerIds.has(candidatePeerId)
+        || unavailablePeerIds.has(candidatePeerId));
     const cleanAbsentFromEveryPeer = [...capturedRecord.candidatePeerIds]
       .every((candidatePeerId) => capturedRecord.cleanAbsentPeerIds.has(candidatePeerId));
     if (cleanAbsentFromEveryPeer) {
-      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord, 'clean-absence');
-    } else if (attemptedEveryPeer) {
-      // An incomplete, failed, or still-pending result is not absence proof.
-      // It still needs completion-anchored retry damping: an exact transfer can
-      // outlast the start-anchored per-CG cooldown, and legacy responders may
-      // return the whole CG while never covering the requested descriptor.
-      // Keep the cause explicit so this backoff can never be mistaken for a
-      // clean-absence proof or advance VM state.
-      capturedRecord.attemptedPeerIds.clear();
-      capturedRecord.cleanAbsentPeerIds.clear();
-      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord, 'no-progress');
+      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord);
+    } else if (scheduledEveryPeer) {
+      // A physically incomplete result or an ineligible candidate is not
+      // absence proof. It may finish the scheduling cycle, but only by dropping
+      // all evidence. The per-CG cooldown below provides the short retry damper.
+      this.vmReconcileRotationState.delete(slotKey);
     }
     this.touchVmReconcileRotationRecord(slotKey, capturedRecord);
   }
@@ -4231,7 +4229,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const attemptedOrdinals = new Set<number>();
     const usedPeerIds = new Set<string>();
     const unavailablePeerIds = new Set<string>();
-    let attemptedFetch = false;
+    let recoveryWorkRan = false;
 
     for (const entry of eligible) {
       if (!isTargetCurrent()) break;
@@ -4256,6 +4254,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       for (const candidatePeerId of candidateOrder) {
         if (usedPeerIds.has(candidatePeerId) || unavailablePeerIds.has(candidatePeerId)) continue;
         const connectedPeer = connectedByPeerId.get(candidatePeerId);
+        recoveryWorkRan = true;
         if (!connectedPeer || !(await this.waitForSyncProtocol(connectedPeer))) {
           unavailablePeerIds.add(candidatePeerId);
           continue;
@@ -4274,7 +4273,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
         peerId = candidatePeerId;
         break;
       }
-      if (!peerId) continue;
+      if (!peerId) {
+        if (installedRecord) {
+          this.settleVmReconcileRotationAttempt(
+            target,
+            undefined,
+            'incomplete',
+            candidatePeerIds,
+            installedRecord,
+            unavailablePeerIds,
+          );
+        }
+        continue;
+      }
       usedPeerIds.add(peerId);
 
       // A recovery target can approach the frame budget by itself. Each peer
@@ -4295,7 +4306,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
       let disposition: 'found' | 'clean-absent' | 'incomplete' = 'incomplete';
       try {
-        attemptedFetch = true;
         attemptedOrdinals.add(target.ordinal);
         if (installedRecord) {
           installedRecord.lastAttemptedPeerId = peerId;
@@ -4359,6 +4369,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
             disposition,
             candidatePeerIds,
             installedRecord,
+            unavailablePeerIds,
           );
         }
       } else {
@@ -4366,15 +4377,20 @@ export class SwmHostModeMethods extends DKGAgentBase {
       }
     }
 
-    // Mirror the inline path's cooldown policy: an unreachable network must
-    // not consume the fetch budget, and completed work resets the damper so
-    // the trailing `hasMore` slice of a draining backlog fetches immediately.
-    // Only a batch that reached a peer and recovered nothing leaves the
-    // cooldown standing.
+    // Mirror the inline path's cooldown policy: a pass that performs no
+    // protocol/admission/transport work must not consume the fetch budget, and
+    // completed work resets the damper so the trailing `hasMore` slice of a
+    // draining backlog fetches immediately.
+    // Only a batch that reached a peer and recovered nothing retains the
+    // cooldown. Re-anchor that short damper at completion: a slow or legacy
+    // response may already have outlived the timestamp taken before transfer.
     const recoveredAny = [...outcomes.values()]
       .some((outcome) => outcome.status === 'reconciled' || outcome.status === 'already');
-    if (!attemptedFetch || recoveredAny) {
+    if (!recoveryWorkRan || recoveredAny) {
       this.vmReconcileFetchCooldownAt.delete(localCgId);
+    } else {
+      this.vmReconcileFetchCooldownAt.delete(localCgId);
+      this.vmReconcileFetchCooldownAt.set(localCgId, Date.now());
     }
     return {
       outcomes,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3692,45 +3692,27 @@ export class SwmHostModeMethods extends DKGAgentBase {
       candidatePeerIds,
     );
     if (!membershipUnchanged) {
+      const previousCandidatePeerIds = record.candidatePeerIds;
       const nextCandidatePeerIds = new Set(candidatePeerIds);
-      const wasBackoff = record.phase === 'backoff';
-      const activeBackoff = record.phase === 'backoff' && now < record.nextRetryAt;
       record.candidatePeerIds = new Set(candidatePeerIds);
-      // Preserve only evidence belonging to retained identities. Added or
-      // rejoined peers remain unattempted and break backoff; removed peers can
-      // never contribute to exhaustion of the new roster.
-      for (const peerId of [...record.attemptedPeerIds]) {
-        if (!nextCandidatePeerIds.has(peerId)) record.attemptedPeerIds.delete(peerId);
-      }
-      for (const peerId of [...record.cleanAbsentPeerIds]) {
-        if (!nextCandidatePeerIds.has(peerId)) record.cleanAbsentPeerIds.delete(peerId);
-      }
-      if (
-        record.lastAttemptedPeerId !== undefined
-        && !nextCandidatePeerIds.has(record.lastAttemptedPeerId)
-      ) record.lastAttemptedPeerId = undefined;
-      const hasUnattemptedPeer = candidatePeerIds.some(
-        (peerId) => !record!.attemptedPeerIds.has(peerId),
-      );
-      if (activeBackoff && !hasUnattemptedPeer) {
-        // A removal-only change cannot reopen work already bounded by the
-        // active retry window.
-        record.phase = 'backoff';
-        record.collectionDeadlineAt = 0;
-      } else if (hasUnattemptedPeer) {
-        record.phase = 'collecting';
-        record.nextRetryAt = 0;
-        record.collectionDeadlineAt = now
-          + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
-      } else if (!wasBackoff) {
-        this.enterVmReconcileRotationBackoff(slotKey, record);
-      } else {
-        // An expired backoff opens a genuinely fresh cycle even when the only
-        // topology change was removal.
+      const removedPeer = [...previousCandidatePeerIds]
+        .some((peerId) => !nextCandidatePeerIds.has(peerId));
+      if (removedPeer) {
+        // A proof roster is a set, not an accumulation of surviving credits.
+        // Any removal/replacement invalidates the whole cycle so shrink can
+        // never manufacture exhaustion or preserve an active suppression.
         record.phase = 'collecting';
         record.nextRetryAt = 0;
         record.attemptedPeerIds.clear();
         record.cleanAbsentPeerIds.clear();
+        record.lastAttemptedPeerId = undefined;
+        record.collectionDeadlineAt = now
+          + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+      } else {
+        // Pure growth preserves valid credits for retained identities, but the
+        // newly observed peer is uncredited and immediately breaks backoff.
+        record.phase = 'collecting';
+        record.nextRetryAt = 0;
         record.collectionDeadlineAt = now
           + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
       }
@@ -3868,14 +3850,20 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     capturedRecord.attemptedPeerIds.add(peerId);
     if (disposition === 'clean-absent') capturedRecord.cleanAbsentPeerIds.add(peerId);
-    const exhausted = [...capturedRecord.candidatePeerIds]
+    const attemptedEveryPeer = [...capturedRecord.candidatePeerIds]
       .every((candidatePeerId) => capturedRecord.attemptedPeerIds.has(candidatePeerId));
-    if (exhausted) {
-      // A full cycle of fail-closed incomplete outcomes is not absence proof,
-      // but it is still a bounded no-progress retry cycle. Throttle it without
-      // changing authentication/materialization semantics; a target/root or
-      // candidate change breaks this finite backoff immediately.
+    const cleanAbsentFromEveryPeer = [...capturedRecord.candidatePeerIds]
+      .every((candidatePeerId) => capturedRecord.cleanAbsentPeerIds.has(candidatePeerId));
+    if (cleanAbsentFromEveryPeer) {
       this.enterVmReconcileRotationBackoff(slotKey, capturedRecord);
+    } else if (attemptedEveryPeer) {
+      // An incomplete, failed, or still-pending result is not absence proof.
+      // Reset the entire proof cycle and rely only on the existing per-CG
+      // sweep cooldown; retain the cursor so the next cycle starts elsewhere.
+      capturedRecord.attemptedPeerIds.clear();
+      capturedRecord.cleanAbsentPeerIds.clear();
+      capturedRecord.collectionDeadlineAt = this.vmReconcileRotationNow()
+        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
     }
     this.touchVmReconcileRotationRecord(slotKey, capturedRecord);
   }
@@ -4063,14 +4051,32 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // production ordinal/finalization check proved it still pending locally.
     const observedCandidatePeerIds = this.vmReconcileObservedCandidatePeerIds(localCgId);
     const now = this.vmReconcileRotationNow();
-    const initialPreparations = currentTargets.map((target) => ({
-      target,
-      prepared: this.prepareVmReconcileRotationTarget(
+    const initialPreparations = currentTargets.map((target) => {
+      const slotKey = this.vmReconcileRotationSlotKey(target);
+      const existing = this.vmReconcileRotationState.get(slotKey);
+      if (!existing || existing.fingerprint !== this.vmReconcileRotationFingerprint(target)) {
+        // The pre-network pass only consults already-earned suppression. A new
+        // cycle is installed after curator resolution so its first roster is
+        // authoritative-first; a stale fingerprint is invalidated immediately.
+        if (existing) this.vmReconcileRotationState.delete(slotKey);
+        return {
+          target,
+          prepared: {
+            slotKey,
+            record: undefined,
+            suppressed: this.vmReconcileRotationClosed,
+          },
+        };
+      }
+      return {
         target,
-        observedCandidatePeerIds,
-        now,
-      ),
-    }));
+        prepared: this.prepareVmReconcileRotationTarget(
+          target,
+          observedCandidatePeerIds,
+          now,
+        ),
+      };
+    });
     const initiallyEligible = initialPreparations
       .filter(({ prepared }) => !prepared.suppressed)
       .map(({ target }) => target);
@@ -4108,26 +4114,45 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // registry resolver is authoritative for `0x…/slug` graphs and can return
     // every node registered to that curator wallet.
     const approvedCuratorPeerId = this.preferredSyncPeers.get(localCgId);
+    const cachedCuratorPeerIds = [
+      ...(this.vmReconcileCuratorPeersByCg.get(localCgId) ?? []),
+    ].sort((left, right) => left.localeCompare(right));
     const curatorResolution = await this.resolveCuratorPeerIdsForCg(localCgId)
-      .catch(() => ({ peerIds: [] as string[], curatorIsLocal: false, legacyTripleResolved: false }));
+      .catch(() => ({
+        peerIds: [] as string[],
+        curatorIsLocal: false,
+        legacyTripleResolved: false,
+        lookupFailed: true,
+      }));
+    const resolutionSucceeded = curatorResolution.lookupFailed !== true;
+    const resolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
+      .filter((peerId) => peerId && peerId !== this.peerId))]
+      .sort((left, right) => left.localeCompare(right))
+      .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
+    const authoritativeCuratorPeerIds = resolutionSucceeded
+      ? resolvedCuratorPeerIds
+      : cachedCuratorPeerIds;
+    if (resolutionSucceeded) {
+      // A successful empty/local resolution is authoritative and must clear a
+      // stale prior roster. A failed lookup retains the last known IDs so an
+      // unrelated discovery outage cannot reorder or erase the proof set.
+      this.vmReconcileCuratorPeersByCg.delete(localCgId);
+      if (!curatorResolution.curatorIsLocal && resolvedCuratorPeerIds.length > 0) {
+        this.vmReconcileCuratorPeersByCg.set(localCgId, resolvedCuratorPeerIds);
+      }
+      this.pruneVmReconcileState();
+    }
     let legacyPreferredPeerId: string | undefined;
-    if (curatorResolution.peerIds.length === 0) {
+    if (resolutionSucceeded && !curatorResolution.curatorIsLocal
+      && resolvedCuratorPeerIds.length === 0) {
       legacyPreferredPeerId = await this.resolvePreferredSyncPeerId(localCgId);
     }
     const curatorPeerIds = [...new Set([
-      approvedCuratorPeerId,
-      ...curatorResolution.peerIds,
+      ...authoritativeCuratorPeerIds,
       legacyPreferredPeerId,
+      approvedCuratorPeerId,
     ].filter((peerId): peerId is string => Boolean(peerId && peerId !== this.peerId)))]
-      .slice(0, 3);
-    if (curatorPeerIds.length > 0) {
-      // Cache only already-resolved identifiers. This gives the pre-network
-      // suppression gate the same authoritative roster on later sweeps without
-      // adding decision-path discovery, dialing, or chain reads.
-      this.vmReconcileCuratorPeersByCg.delete(localCgId);
-      this.vmReconcileCuratorPeersByCg.set(localCgId, curatorPeerIds);
-      this.pruneVmReconcileState();
-    }
+      .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
     for (const peerId of curatorPeerIds) {
       await this.ensurePeerConnected(peerId).catch((error) => {
         this.log.info(
@@ -4262,7 +4287,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
         attemptedOrdinals.add(target.ordinal);
         if (installedRecord) {
           installedRecord.lastAttemptedPeerId = peerId;
-          installedRecord.attemptedPeerIds.add(peerId);
           this.touchVmReconcileRotationRecord(
             this.vmReconcileRotationSlotKey(target),
             installedRecord,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2310,11 +2310,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   bumpContextGraphBindingGeneration(this: DKGAgent, localCgId: string): number {
-    return bumpBindingGeneration(this, localCgId);
+    return bumpBindingGeneration(this.contextGraphBindingGenerations, localCgId);
   }
 
   captureContextGraphBindingGeneration(this: DKGAgent, localCgId: string): number {
-    return captureBindingGeneration(this, localCgId);
+    return captureBindingGeneration(this.contextGraphBindingGenerations, localCgId);
   }
 
   isContextGraphBindingGenerationCurrent(
@@ -2322,7 +2322,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     localCgId: string,
     generation: number,
   ): boolean {
-    return isBindingGenerationCurrent(this, localCgId, generation);
+    return isBindingGenerationCurrent(
+      this.contextGraphBindingGenerations,
+      localCgId,
+      generation,
+    );
   }
 
   /**
@@ -2340,7 +2344,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
   bindSubscriptionOnChainId(this: DKGAgent, localCgId: string, sub: ContextGraphSub, newOnChainId: string): void {
     const prev = sub.onChainId;
     if (prev === newOnChainId) return;
-    bumpBindingGeneration(this, localCgId);
+    bumpBindingGeneration(this.contextGraphBindingGenerations, localCgId);
     sub.onChainId = newOnChainId;
     if (!prev) return;
     // The bound on-chain id actually CHANGED (repair / recreate / re-register).
@@ -2697,12 +2701,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
     isCurrent: () => boolean = () => true,
     signal?: AbortSignal,
   ): Promise<string | null> {
-    const bindingGeneration = captureBindingGeneration(this, localCgId);
+    const bindingGeneration = captureBindingGeneration(
+      this.contextGraphBindingGenerations,
+      localCgId,
+    );
     const isSubscriptionCurrent = () => isCurrent()
       && this.subscribedContextGraphs.get(localCgId) === sub
       && sub.subscribed
       && !sub.onChainId
-      && isBindingGenerationCurrent(this, localCgId, bindingGeneration);
+      && isBindingGenerationCurrent(
+        this.contextGraphBindingGenerations,
+        localCgId,
+        bindingGeneration,
+      );
     if (!isSubscriptionCurrent()) return null;
     let resolved: string | null = null;
     try {
@@ -2876,7 +2887,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         && this.subscribedContextGraphs.get(localCgId) === target.sub
         && target.sub.onChainId === target.onChainId
         && isBindingGenerationCurrent(
-          this,
+          this.contextGraphBindingGenerations,
           localCgId,
           target.bindingGeneration,
         )
@@ -2992,7 +3003,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
       onChainId: sub.onChainId,
       onChainCgId: BigInt(sub.onChainId),
       cursor,
-      bindingGeneration: captureBindingGeneration(this, localCgId),
+      bindingGeneration: captureBindingGeneration(
+        this.contextGraphBindingGenerations,
+        localCgId,
+      ),
       watermarkBefore: cursor.watermark,
     };
   }
@@ -3008,7 +3022,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const capturedSub = target?.sub ?? this.subscribedContextGraphs.get(localCgId);
     const capturedOnChainId = target?.onChainId ?? capturedSub?.onChainId;
     const capturedBindingGeneration = target?.bindingGeneration
-      ?? captureBindingGeneration(this, localCgId);
+      ?? captureBindingGeneration(this.contextGraphBindingGenerations, localCgId);
     const capturedCursor = execution?.identityCursor
       ?? target?.cursor
       ?? this.reconcileCursors.get(localCgId);
@@ -3019,7 +3033,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         && current === capturedSub
         && current?.onChainId === capturedOnChainId
         && isBindingGenerationCurrent(
-          this,
+          this.contextGraphBindingGenerations,
           localCgId,
           capturedBindingGeneration,
         )
@@ -3080,13 +3094,20 @@ export class SwmHostModeMethods extends DKGAgentBase {
     localCgId: string,
     watermark: number,
     expectedSub?: ContextGraphSub,
-    expectedBindingGeneration = captureBindingGeneration(this, localCgId),
+    expectedBindingGeneration = captureBindingGeneration(
+      this.contextGraphBindingGenerations,
+      localCgId,
+    ),
     expectedCursor?: CursorState,
   ): Promise<void> {
     const sub = this.subscribedContextGraphs.get(localCgId);
     const isTargetCurrent = () => this.subscribedContextGraphs.get(localCgId) === sub
       && (!expectedSub || sub === expectedSub)
-      && isBindingGenerationCurrent(this, localCgId, expectedBindingGeneration)
+      && isBindingGenerationCurrent(
+        this.contextGraphBindingGenerations,
+        localCgId,
+        expectedBindingGeneration,
+      )
       && (!expectedCursor || this.reconcileCursors.get(localCgId) === expectedCursor);
     if (!sub || !isTargetCurrent()) return Promise.resolve();
     const previous = sub.lastReconciledOrdinal ?? 0;

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3649,18 +3649,25 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     const fingerprint = this.vmReconcileRotationFingerprint(target);
     let record = this.vmReconcileRotationState.get(slotKey);
+    if (record && record.fingerprint !== fingerprint) {
+      this.vmReconcileRotationState.delete(slotKey);
+      record = undefined;
+    }
     if (candidatePeerIds.length === 0) {
-      // An empty observed roster cannot prove absence. Drop all partial credit
-      // so a later connection begins a genuinely fresh cycle.
+      // A transient empty socket view cannot invalidate a completed proof: doing
+      // so would redial and refetch every sweep after ordinary disconnects.
+      // Partial evidence is different and remains fail-open; drop it so the next
+      // non-empty roster starts a genuinely fresh cycle.
+      if (record?.phase === 'backoff' && now < record.nextRetryAt) {
+        this.touchVmReconcileRotationRecord(slotKey, record);
+        return { slotKey, record, suppressed: true };
+      }
       this.vmReconcileRotationState.delete(slotKey);
       return { slotKey, suppressed: false };
     }
 
-    if (!record || record.fingerprint !== fingerprint) {
-      const replacingSlot = record !== undefined;
-      if (replacingSlot) {
-        this.vmReconcileRotationState.delete(slotKey);
-      } else if (!this.makeRoomForVmReconcileRotationRecord()) {
+    if (!record) {
+      if (!this.makeRoomForVmReconcileRotationRecord()) {
         // Stable-capacity overflow remains fail-open. It still participates in
         // ordinary exact recovery, but owns no cursor/absence evidence and can
         // neither suppress nor evict an in-progress collection.
@@ -4255,18 +4262,24 @@ export class SwmHostModeMethods extends DKGAgentBase {
         if (usedPeerIds.has(candidatePeerId) || unavailablePeerIds.has(candidatePeerId)) continue;
         const connectedPeer = connectedByPeerId.get(candidatePeerId);
         recoveryWorkRan = true;
-        if (!connectedPeer || !(await this.waitForSyncProtocol(connectedPeer))) {
+        const protocolReady = connectedPeer
+          ? await this.waitForSyncProtocol(connectedPeer)
+          : false;
+        if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+        if (!connectedPeer || !protocolReady) {
           unavailablePeerIds.add(candidatePeerId);
           continue;
         }
         // Network boundary: a merely-connected peer is not necessarily
         // admitted to this DKG network. Never send an authenticated exact
         // request to an unverified or rejected peer.
-        if (!(await this.ensurePeerAdmittedForRecovery(
+        const peerAdmitted = await this.ensurePeerAdmittedForRecovery(
           candidatePeerId,
           ctx,
           'VM exact fetch',
-        ))) {
+        );
+        if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+        if (!peerAdmitted) {
           unavailablePeerIds.add(candidatePeerId);
           continue;
         }
@@ -4294,6 +4307,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // item rotates behind untouched work so one unavailable KA cannot spend
       // every peer budget and starve the rest of the queue.
       if (attemptedOrdinals.has(target.ordinal)) break;
+      if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
       this.emitReplication({
         contextGraphId: localCgId,
         onChainCgId: onChainCgId.toString(),
@@ -4332,7 +4346,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
         );
       }
 
-      if (!isTargetCurrent()) break;
+      // The exact request may have completed after unsubscribe, rebind, or
+      // shutdown. Its authenticated materialization is already fail-closed,
+      // but no process-local evidence or cooldown may outlive that lifecycle.
+      if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
       const outcome = await this.reconcileChainOrdinal(
         localCgId,
         onChainCgId,
@@ -4340,6 +4357,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         headBlock,
         { isTargetCurrent, deferActiveFetch: true },
       );
+      if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
       outcomes.set(target.ordinal, outcome);
       if (outcome.status === 'pending' && outcome.recovery) {
         if (!installedRecord) continue;
@@ -4384,6 +4402,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // Only a batch that reached a peer and recovered nothing retains the
     // cooldown. Re-anchor that short damper at completion: a slow or legacy
     // response may already have outlived the timestamp taken before transfer.
+    if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
     const recoveredAny = [...outcomes.values()]
       .some((outcome) => outcome.status === 'reconciled' || outcome.status === 'already');
     if (!recoveryWorkRan || recoveredAny) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -9,6 +9,7 @@
  */
 
 import { createHash, randomUUID } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -354,6 +355,7 @@ import {
   type ContextGraphSub,
   type ContextGraphSubscriptionRecord,
   type ContextGraphSubscriptionStore,
+  type VmReconcileRotationRecord,
   type ContextGraphMemberPrincipalType,
   type ContextGraphMemberStatus,
   type ContextGraphMembershipRecord,
@@ -3553,6 +3555,274 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this.pruneVmReconcileState();
   }
 
+  vmReconcileRotationNow(this: DKGAgent): number {
+    return performance.now();
+  }
+
+  vmReconcileRotationSlotKey(
+    this: DKGAgent,
+    target: OrdinalRecoveryTarget,
+  ): string {
+    return `${target.localCgId}\0${target.onChainCgId}\0${target.ordinal}`;
+  }
+
+  clearVmReconcileRotationStateForSlot(
+    this: DKGAgent,
+    localCgId: string,
+    onChainCgId: bigint,
+    ordinal: number,
+  ): void {
+    this.vmReconcileRotationState.delete(`${localCgId}\0${onChainCgId.toString()}\0${ordinal}`);
+  }
+
+  vmReconcileRotationFingerprint(
+    this: DKGAgent,
+    target: OrdinalRecoveryTarget,
+  ): string {
+    return `${target.ual}\0${target.merkleRoot.toLowerCase()}`;
+  }
+
+  vmReconcileObservedCandidatePeerIds(
+    this: DKGAgent,
+    localCgId: string,
+  ): string[] {
+    const libp2p = (this.node as any)?.libp2p;
+    const getConnections = libp2p?.getConnections;
+    if (typeof getConnections !== 'function') return [];
+    const peersById = new Map<string, { toString(): string }>();
+    for (const connection of getConnections.call(libp2p) as Array<{
+      remotePeer?: { toString(): string };
+    }>) {
+      const peer = connection.remotePeer;
+      const peerId = peer?.toString();
+      if (!peer || !peerId || peerId === this.peerId || peersById.has(peerId)) continue;
+      peersById.set(peerId, peer);
+    }
+    // `getConnections()` iteration order is transport state, not candidate
+    // identity. Sort before tiering/capping so harmless connection reorder can
+    // never replace one member of the bounded proof roster.
+    const canonicalPeers = [...peersById.values()].sort((left, right) =>
+      left.toString().localeCompare(right.toString()));
+    return this.selectCatchupPeers(
+      canonicalPeers,
+      this.preferredSyncPeers.get(localCgId),
+      false,
+    )
+      .map((peer) => peer.toString())
+      .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
+  }
+
+  vmReconcilePeerMembershipMatches(
+    this: DKGAgent,
+    left: ReadonlySet<string>,
+    right: readonly string[],
+  ): boolean {
+    return left.size === right.length && right.every((peerId) => left.has(peerId));
+  }
+
+  touchVmReconcileRotationRecord(
+    this: DKGAgent,
+    slotKey: string,
+    record: VmReconcileRotationRecord,
+  ): void {
+    if (this.vmReconcileRotationState.get(slotKey) !== record) return;
+    this.vmReconcileRotationState.delete(slotKey);
+    this.vmReconcileRotationState.set(slotKey, record);
+  }
+
+  prepareVmReconcileRotationTarget(
+    this: DKGAgent,
+    target: OrdinalRecoveryTarget,
+    candidatePeerIds: readonly string[],
+    now: number,
+  ): {
+    slotKey: string;
+    record?: VmReconcileRotationRecord;
+    suppressed: boolean;
+  } {
+    const slotKey = this.vmReconcileRotationSlotKey(target);
+    if (this.vmReconcileRotationClosed) return { slotKey, suppressed: true };
+
+    const fingerprint = this.vmReconcileRotationFingerprint(target);
+    let record = this.vmReconcileRotationState.get(slotKey);
+    if (candidatePeerIds.length === 0) {
+      // An empty observed roster cannot prove absence. Drop all partial credit
+      // so a later connection begins a genuinely fresh cycle.
+      this.vmReconcileRotationState.delete(slotKey);
+      return { slotKey, suppressed: false };
+    }
+
+    if (!record || record.fingerprint !== fingerprint) {
+      const replacingSlot = record !== undefined;
+      if (replacingSlot) {
+        this.vmReconcileRotationState.delete(slotKey);
+      } else if (!this.makeRoomForVmReconcileRotationRecord()) {
+        // Stable-capacity overflow remains fail-open. It still participates in
+        // ordinary exact recovery, but owns no cursor/absence evidence and can
+        // neither suppress nor evict an in-progress collection.
+        return { slotKey, suppressed: false };
+      }
+      record = {
+        localCgId: target.localCgId,
+        onChainCgId: target.onChainCgId,
+        ordinal: target.ordinal,
+        fingerprint,
+        phase: 'collecting',
+        candidatePeerIds: new Set(candidatePeerIds),
+        cleanAbsentPeerIds: new Set(),
+        collectionDeadlineAt: now + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+        failures: 0,
+        nextRetryAt: 0,
+      };
+      this.vmReconcileRotationState.set(slotKey, record);
+      return {
+        slotKey,
+        record: this.vmReconcileRotationState.get(slotKey) === record ? record : undefined,
+        suppressed: false,
+      };
+    }
+
+    const membershipUnchanged = this.vmReconcilePeerMembershipMatches(
+      record.candidatePeerIds,
+      candidatePeerIds,
+    );
+    if (!membershipUnchanged) {
+      record.candidatePeerIds = new Set(candidatePeerIds);
+      record.phase = 'collecting';
+      record.nextRetryAt = 0;
+      record.collectionDeadlineAt = now
+        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+      record.lastAttemptedPeerId = undefined;
+      // A roster change starts a fresh proof cycle. Mixing credits obtained
+      // against different candidate sets could manufacture exhaustion when a
+      // peer disappears and later rejoins.
+      record.cleanAbsentPeerIds.clear();
+    } else if (record.phase === 'backoff') {
+      if (now < record.nextRetryAt) {
+        this.touchVmReconcileRotationRecord(slotKey, record);
+        return { slotKey, record, suppressed: true };
+      }
+      // A deadline only opens a new collection cycle. It never earns another
+      // failure/backoff without fresh clean-absence evidence from every peer.
+      record.phase = 'collecting';
+      record.cleanAbsentPeerIds.clear();
+      record.collectionDeadlineAt = now
+        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+      record.nextRetryAt = 0;
+    } else if (now >= record.collectionDeadlineAt) {
+      // A partial rotation must not pin already-credited peers forever when a
+      // stable sibling repeatedly fails protocol/admission or returns an
+      // incomplete response. Start a fresh proof cycle without treating the
+      // incomplete cycle as a failure or scheduling a timer.
+      record.cleanAbsentPeerIds.clear();
+      record.collectionDeadlineAt = now
+        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+    }
+
+    this.touchVmReconcileRotationRecord(slotKey, record);
+    return { slotKey, record, suppressed: false };
+  }
+
+  vmReconcileUncreditedCandidateOrder(
+    this: DKGAgent,
+    record: VmReconcileRotationRecord,
+  ): string[] {
+    const candidates = [...record.candidatePeerIds];
+    if (candidates.length === 0) return candidates;
+    const lastIndex = record.lastAttemptedPeerId === undefined
+      ? -1
+      : candidates.indexOf(record.lastAttemptedPeerId);
+    const start = lastIndex < 0 ? 0 : (lastIndex + 1) % candidates.length;
+    return [
+      ...candidates.slice(start),
+      ...candidates.slice(0, start),
+    ].filter((peerId) => !record.cleanAbsentPeerIds.has(peerId));
+  }
+
+  makeRoomForVmReconcileRotationRecord(this: DKGAgent): boolean {
+    if (this.vmReconcileRotationState.size < DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
+      return true;
+    }
+    // Map order is LRU order. A completed backoff record is replaceable: the
+    // evicted slot merely retries fail-open. Collecting records stay installed
+    // until they finish or are invalidated, preventing cap+1 churn from making
+    // every partial rotation useless.
+    for (const [key, record] of this.vmReconcileRotationState) {
+      if (record.phase !== 'backoff') continue;
+      this.vmReconcileRotationState.delete(key);
+      return true;
+    }
+    return false;
+  }
+
+  clearVmReconcileRotationStateForContextGraph(
+    this: DKGAgent,
+    localCgId: string,
+  ): void {
+    const prefix = `${localCgId}\0`;
+    for (const key of this.vmReconcileRotationState.keys()) {
+      if (key.startsWith(prefix)) this.vmReconcileRotationState.delete(key);
+    }
+  }
+
+  closeVmReconcileRotationState(this: DKGAgent): void {
+    this.vmReconcileRotationClosed = true;
+    this.vmReconcileRotationState.clear();
+  }
+
+  vmReconcileRecoveryTargetMatches(
+    this: DKGAgent,
+    expected: OrdinalRecoveryTarget,
+    actual: OrdinalRecoveryTarget,
+  ): boolean {
+    return expected.localCgId === actual.localCgId
+      && expected.onChainCgId === actual.onChainCgId
+      && expected.ordinal === actual.ordinal
+      && expected.ual === actual.ual
+      && expected.merkleRoot.toLowerCase() === actual.merkleRoot.toLowerCase();
+  }
+
+  creditVmReconcileCleanAbsence(
+    this: DKGAgent,
+    target: OrdinalRecoveryTarget,
+    peerId: string,
+    expectedCandidatePeerIds: readonly string[],
+    capturedRecord: VmReconcileRotationRecord,
+  ): void {
+    if (this.vmReconcileRotationClosed) return;
+    const slotKey = this.vmReconcileRotationSlotKey(target);
+    if (this.vmReconcileRotationState.get(slotKey) !== capturedRecord) return;
+    if (!this.vmReconcilePeerMembershipMatches(
+      capturedRecord.candidatePeerIds,
+      expectedCandidatePeerIds,
+    )) return;
+    if (!capturedRecord.candidatePeerIds.has(peerId)) return;
+
+    capturedRecord.cleanAbsentPeerIds.add(peerId);
+    const exhausted = [...capturedRecord.candidatePeerIds]
+      .every((candidatePeerId) => capturedRecord.cleanAbsentPeerIds.has(candidatePeerId));
+    if (exhausted) {
+      capturedRecord.failures += 1;
+      const exponentialBackoff = Math.min(
+        DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+        DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS
+          * 2 ** Math.max(0, capturedRecord.failures - 1),
+      );
+      const jitterSample = createHash('sha256')
+        .update(`${this.peerId}\0${slotKey}\0${capturedRecord.fingerprint}\0${capturedRecord.failures}`)
+        .digest()
+        .readUInt32BE(0) / 0x1_0000_0000;
+      const backoff = Math.min(
+        DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+        Math.max(1, Math.round(exponentialBackoff * (0.8 + jitterSample * 0.4))),
+      );
+      capturedRecord.phase = 'backoff';
+      capturedRecord.collectionDeadlineAt = 0;
+      capturedRecord.nextRetryAt = this.vmReconcileRotationNow() + backoff;
+    }
+    this.touchVmReconcileRotationRecord(slotKey, capturedRecord);
+  }
+
   shouldRunVmReconcileActiveFetch(this: DKGAgent, localCgId: string): boolean {
     const now = Date.now();
     this.pruneVmReconcileState(now);
@@ -3631,6 +3901,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Best-effort durable cleanup; generation checks still reject stale rows.
       });
     this.reconcileCursors.delete(localCgId);
+    this.clearVmReconcileRotationStateForContextGraph(localCgId);
     this.vmReconcileFetchCooldownAt.delete(localCgId);
     this.vmReconcileCatchupPeerCursor.delete(localCgId);
     this.vmReconcileCatchupPeerOrder.delete(localCgId);
@@ -3702,16 +3973,37 @@ export class SwmHostModeMethods extends DKGAgentBase {
     });
     if (!isTargetCurrent() || targets.length === 0) return noRecovery();
 
+    const expectedOnChainCgId = onChainCgId.toString();
+    const currentTargets = targets.filter((target) =>
+      target.localCgId === localCgId && target.onChainCgId === expectedOnChainCgId);
+    if (currentTargets.length === 0) return noRecovery();
+
+    // Suppression consults only the already-observed, capped connection view.
+    // This is intentionally before curator resolution, dialing, protocol waits,
+    // and admission probes. Every target reached this method only after the
+    // production ordinal/finalization check proved it still pending locally.
+    const observedCandidatePeerIds = this.vmReconcileObservedCandidatePeerIds(localCgId);
+    const now = this.vmReconcileRotationNow();
+    const initiallyEligible = currentTargets.filter((target) =>
+      !this.prepareVmReconcileRotationTarget(
+        target,
+        observedCandidatePeerIds,
+        now,
+      ).suppressed);
+    if (initiallyEligible.length === 0) {
+      this.log.info(ctx, `VM exact fetch for "${localCgId}" skipped by exact-absence backoff`);
+      return noRecovery();
+    }
+
     // Damping: the batched path deliberately skips the per-UAL negative cache
     // (consulting it primes connections to every discovered agent — the walk
     // this path exists to avoid), so the per-CG active-fetch cooldown is the
-    // only damper between this batch and the network. A wholly unproductive
-    // batch (e.g. the curator is offline) therefore costs one bounded exact
-    // fetch per sweep interval, not one per reconcile pass. Progress clears
-    // the cooldown below so a draining backlog proceeds slice after slice.
+    // short-term damper between fresh rotation attempts. Completed clean-
+    // absence rotations use the slot-specific exponential backoff above;
+    // transient/incomplete attempts retain this sweep-interval cooldown.
     if (!this.shouldRunVmReconcileActiveFetch(localCgId)) {
       this.log.info(ctx, `VM exact fetch for "${localCgId}" skipped by per-CG cooldown`);
-      return noRecovery(targets[0]?.ordinal, true);
+      return noRecovery(initiallyEligible[0]?.ordinal, true);
     }
 
     // Capture the authenticated join-approval hint before consulting metadata:
@@ -3745,64 +4037,110 @@ export class SwmHostModeMethods extends DKGAgentBase {
       this.node.libp2p.getConnections()
         .map((connection) => [connection.remotePeer.toString(), connection.remotePeer]),
     );
-    const connected = [...connectedByPeerId.values()];
-    const connectedPeerIds = new Set(connectedByPeerId.keys());
-    const orderedConnectedPeerIds = this.selectCatchupPeers(
-      connected,
-      approvedCuratorPeerId ?? curatorPeerIds[0],
-      false,
-    ).map((peer) => peer.toString());
-    const orderedPeerIds = [...new Set([
-      ...curatorPeerIds.filter((peerId) => connectedPeerIds.has(peerId)),
-      ...orderedConnectedPeerIds,
-    ])].slice(0, 3);
-    const rotationCandidates = orderedPeerIds
-      .map((peerId) => connectedByPeerId.get(peerId))
-      .filter((peer): peer is NonNullable<typeof peer> => peer !== undefined);
-    const peerPriorityRanks = new Map(
-      orderedPeerIds.map((peerId) => [
-        peerId,
-        curatorPeerIds.includes(peerId) ? 2 : this.knownCorePeerIds.has(peerId) ? 1 : 0,
-      ]),
-    );
-    // Preserve curator preference for the first attempt, then rotate the full
-    // connected order one peer per network-eligible window. Exact recovery
-    // often has a single pending KA, so replaying the static preferred-first
-    // order would otherwise pin that KA to the same unproductive peer forever.
-    const rotationAnchor = this.selectCatchupPeerWindow(rotationCandidates, {
-      maxPeers: 1,
-      peerRotationKey: localCgId,
-      peerPriorityRanks,
-    })[0]?.toString();
-    const rotationStart = rotationAnchor === undefined
-      ? 0
-      : Math.max(0, orderedPeerIds.indexOf(rotationAnchor));
-    const peerIds = [
-      ...orderedPeerIds.slice(rotationStart),
-      ...orderedPeerIds.slice(0, rotationStart),
-    ];
+    // Use the exact same memory-only canonicalizer as the suppression gate.
+    // Curator resolution may connect a missing peer, but it must not substitute
+    // a different ranking algorithm and invalidate an otherwise stable roster.
+    const orderedPeerIds = this.vmReconcileObservedCandidatePeerIds(localCgId);
+
+    // Curator preparation may have grown or shrunk the connected candidate
+    // set. Re-evaluate every target against that observed change. Any roster
+    // change breaks backoff and starts a fresh proof cycle.
+    const preparedEntries = currentTargets
+      .map((target, index) => ({
+        index,
+        target,
+        prepared: this.prepareVmReconcileRotationTarget(
+          target,
+          orderedPeerIds,
+          this.vmReconcileRotationNow(),
+        ),
+      }));
+    const eligible = preparedEntries
+      .map((entry) => {
+        const { record } = entry.prepared;
+        if (
+          record
+          && this.vmReconcileRotationState.get(entry.prepared.slotKey) !== record
+        ) {
+          // A later slot may have fairly replaced this backoff record while the
+          // batch was prepared. Continue as evidence-free overflow; never send
+          // transport work against the evicted object or preserve its suppress.
+          return {
+            ...entry,
+            prepared: { slotKey: entry.prepared.slotKey, suppressed: false },
+          };
+        }
+        return entry;
+      })
+      .filter((entry) => !entry.prepared.suppressed)
+      // Installed collecting records get first use of the bounded peer set so
+      // overflow cannot consume the one peer they still need to complete. The
+      // original target order remains stable within each class.
+      .sort((left, right) => {
+        const leftInstalled = left.prepared.record
+          && this.vmReconcileRotationState.get(left.prepared.slotKey) === left.prepared.record
+          ? 1 : 0;
+        const rightInstalled = right.prepared.record
+          && this.vmReconcileRotationState.get(right.prepared.slotKey) === right.prepared.record
+          ? 1 : 0;
+        return rightInstalled - leftInstalled || left.index - right.index;
+      });
+
     const outcomes = new Map<number, OrdinalOutcome>();
     const attemptedOrdinals = new Set<number>();
-    let remaining = [...targets];
+    const usedPeerIds = new Set<string>();
+    const unavailablePeerIds = new Set<string>();
     let attemptedFetch = false;
 
-    for (const peerId of peerIds) {
-      if (!isTargetCurrent() || remaining.length === 0) break;
-      const connectedPeer = connectedByPeerId.get(peerId);
-      if (!connectedPeer || !(await this.waitForSyncProtocol(connectedPeer))) continue;
-      // Network boundary: a merely-connected peer is not necessarily admitted
-      // to this DKG network (curator hints and getConnections() both predate
-      // the identity probe). Never send an authenticated exact request to an
-      // unverified or rejected peer.
-      if (!(await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'VM exact fetch'))) continue;
+    for (const entry of eligible) {
+      if (!isTargetCurrent()) break;
+      const { target } = entry;
+      const record = entry.prepared.record;
+      const installedRecord = record
+        && this.vmReconcileRotationState.get(this.vmReconcileRotationSlotKey(target)) === record
+        ? record
+        : undefined;
+      const candidatePeerIds = installedRecord
+        ? [...installedRecord.candidatePeerIds]
+        : orderedPeerIds;
+
+      // Rotate every physical outcome, including incomplete responses, without
+      // conflating the attempt cursor with clean-absence evidence. Try the
+      // target's next available peer; protocol/admission failures remain
+      // uncredited and fall through to a later candidate in this same pass.
+      let peerId: string | undefined;
+      const candidateOrder = installedRecord
+        ? this.vmReconcileUncreditedCandidateOrder(installedRecord)
+        : orderedPeerIds;
+      for (const candidatePeerId of candidateOrder) {
+        if (usedPeerIds.has(candidatePeerId) || unavailablePeerIds.has(candidatePeerId)) continue;
+        const connectedPeer = connectedByPeerId.get(candidatePeerId);
+        if (!connectedPeer || !(await this.waitForSyncProtocol(connectedPeer))) {
+          unavailablePeerIds.add(candidatePeerId);
+          continue;
+        }
+        // Network boundary: a merely-connected peer is not necessarily
+        // admitted to this DKG network. Never send an authenticated exact
+        // request to an unverified or rejected peer.
+        if (!(await this.ensurePeerAdmittedForRecovery(
+          candidatePeerId,
+          ctx,
+          'VM exact fetch',
+        ))) {
+          unavailablePeerIds.add(candidatePeerId);
+          continue;
+        }
+        peerId = candidatePeerId;
+        break;
+      }
+      if (!peerId) continue;
+      usedPeerIds.add(peerId);
 
       // A recovery target can approach the frame budget by itself. Each peer
       // attempt therefore consumes at most one queue item, and each queue item
       // consumes at most one peer attempt per eligible pass. A still-pending
       // item rotates behind untouched work so one unavailable KA cannot spend
       // every peer budget and starve the rest of the queue.
-      const [target, ...deferredTargets] = remaining;
-      if (!target) break;
       if (attemptedOrdinals.has(target.ordinal)) break;
       this.emitReplication({
         contextGraphId: localCgId,
@@ -3814,17 +4152,27 @@ export class SwmHostModeMethods extends DKGAgentBase {
         detail: 'exact-asset',
       });
 
+      let disposition: 'found' | 'clean-absent' | 'incomplete' = 'incomplete';
       try {
         attemptedFetch = true;
         attemptedOrdinals.add(target.ordinal);
-        const result = await this.syncExactKnowledgeAssetsFromPeer(
+        if (installedRecord) {
+          installedRecord.lastAttemptedPeerId = peerId;
+          this.touchVmReconcileRotationRecord(
+            this.vmReconcileRotationSlotKey(target),
+            installedRecord,
+          );
+        }
+        const detailed = await this.syncExactKnowledgeAssetsFromPeerDetailed(
           peerId,
           localCgId,
           [target.ual],
         );
+        const { result } = detailed;
+        disposition = detailed.disposition;
         this.log.info(
           ctx,
-          `VM exact fetch for "${localCgId}" from ${peerId.slice(-8)}: requested=1 fetched=${result.fetchedDataTriples + result.fetchedMetaTriples} inserted=${result.insertedTriples} failed=${result.failedPeers + result.failedPhases} deferred=${result.deferredBackpressure}`,
+          `VM exact fetch for "${localCgId}" from ${peerId.slice(-8)}: requested=1 fetched=${result.fetchedDataTriples + result.fetchedMetaTriples} inserted=${result.insertedTriples} failed=${result.failedPeers + result.failedPhases} deferred=${result.deferredBackpressure} disposition=${disposition}`,
         );
       } catch (error) {
         this.log.info(
@@ -3843,9 +4191,39 @@ export class SwmHostModeMethods extends DKGAgentBase {
       );
       outcomes.set(target.ordinal, outcome);
       if (outcome.status === 'pending' && outcome.recovery) {
-        remaining = [...deferredTargets, outcome.recovery];
+        if (!installedRecord) continue;
+        if (this.vmReconcileRotationClosed) continue;
+        if (
+          this.vmReconcileRotationState.get(this.vmReconcileRotationSlotKey(target))
+          !== installedRecord
+        ) continue;
+        const candidateMembershipAfter = this.vmReconcileObservedCandidatePeerIds(
+          localCgId,
+        );
+        if (!this.vmReconcilePeerMembershipMatches(
+          installedRecord.candidatePeerIds,
+          candidateMembershipAfter,
+        )) {
+          // Membership changed while the request was in flight. Invalidate the
+          // cycle before considering its response, then fail open.
+          this.prepareVmReconcileRotationTarget(
+            outcome.recovery,
+            candidateMembershipAfter,
+            this.vmReconcileRotationNow(),
+          );
+        } else if (
+          disposition === 'clean-absent'
+          && this.vmReconcileRecoveryTargetMatches(target, outcome.recovery)
+        ) {
+          this.creditVmReconcileCleanAbsence(
+            target,
+            peerId,
+            candidatePeerIds,
+            installedRecord,
+          );
+        }
       } else {
-        remaining = deferredTargets;
+        this.vmReconcileRotationState.delete(this.vmReconcileRotationSlotKey(target));
       }
     }
 
@@ -3866,8 +4244,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // attempts are rotated inside `remaining` to give untouched targets the
       // next peer, but once every submitted target has consumed one attempt
       // the outer fair scan must wrap from its watermark on the next cycle.
-      continuationOrdinal: targets.find(
-        (target) => !attemptedOrdinals.has(target.ordinal),
+      continuationOrdinal: currentTargets.find(
+        (target) => eligible.some((entry) => entry.target.ordinal === target.ordinal)
+          && !attemptedOrdinals.has(target.ordinal),
       )?.ordinal,
       cooldownOnly: false,
     };
@@ -3914,7 +4293,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
       // Recently reconciled (live-burst guard): treat as already-done so the
       // cursor advances without redoing chain reads + an SWM scan.
-      if (this.recentReconciledUals.has(cacheKey)) return { status: 'already', blockNumber: versionBlock };
+      if (this.recentReconciledUals.has(cacheKey)) {
+        this.clearVmReconcileRotationStateForSlot(localCgId, onChainCgId, ordinal);
+        return { status: 'already', blockNumber: versionBlock };
+      }
 
       if (!options.deferActiveFetch && await this.shouldDeferVmReconcileByNegativeCache(cacheKey, localCgId)) {
         this.emitReplication({
@@ -3970,8 +4352,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
         return {
           status: 'pending',
           recovery: {
+            localCgId,
+            onChainCgId: onChainCgId.toString(),
             ordinal,
             ual,
+            merkleRoot: Array.from(
+              merkleRoot,
+              (byte) => byte.toString(16).padStart(2, '0'),
+            ).join(''),
             kaId: kaId.toString(),
             reason: outcome,
           },
@@ -4061,6 +4449,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     switch (outcome) {
       case 'promoted':
+        this.clearVmReconcileRotationStateForSlot(localCgId, onChainCgId, ordinal);
         this.pruneVmReconcileCacheKeySiblings(cacheKey);
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         this.recentReconciledUals.add(cacheKey);
@@ -4070,6 +4459,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         });
         return { status: 'reconciled', blockNumber: versionBlock };
       case 'already-confirmed':
+        this.clearVmReconcileRotationStateForSlot(localCgId, onChainCgId, ordinal);
         this.pruneVmReconcileCacheKeySiblings(cacheKey);
         this.recentReconciledUals.add(cacheKey);
         this.emitReplication({
@@ -4079,6 +4469,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return { status: 'already', blockNumber: versionBlock };
       case 'stale-target':
+        this.clearVmReconcileRotationStateForSlot(localCgId, onChainCgId, ordinal);
         // A newer root won; do not prune its cache/recent state.
         this.recentReconciledUals.add(cacheKey);
         this.emitReplication({

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3818,12 +3818,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   closeVmReconcileRotationState(this: DKGAgent): void {
+    this.vmReconcileRotationGeneration = (this.vmReconcileRotationGeneration ?? 0) + 1;
     this.vmReconcileRotationClosed = true;
     // Some lifecycle tests intentionally construct a narrow partial agent
     // without running the base constructor. Shutdown must remain best-effort
     // for that supported test seam and never mask later teardown failures.
     this.vmReconcileRotationState?.clear();
     this.vmReconcileCuratorPeersByCg?.clear();
+  }
+
+  openVmReconcileRotationState(this: DKGAgent): void {
+    this.vmReconcileRotationClosed = false;
   }
 
   vmReconcileRecoveryTargetMatches(
@@ -4041,6 +4046,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
     headBlock: number | undefined,
     isTargetCurrent: () => boolean,
   ): Promise<PendingOrdinalRecoveryResult> {
+    const rotationGeneration = this.vmReconcileRotationGeneration;
+    const isRecoveryCurrent = () => !this.vmReconcileRotationClosed
+      && this.vmReconcileRotationGeneration === rotationGeneration
+      && isTargetCurrent();
     const ctx = createOperationContext('system');
     const noRecovery = (
       continuationOrdinal?: number,
@@ -4051,7 +4060,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       continuationOrdinal,
       cooldownOnly,
     });
-    if (!isTargetCurrent() || targets.length === 0) return noRecovery();
+    if (!isRecoveryCurrent() || targets.length === 0) return noRecovery();
 
     const expectedOnChainCgId = onChainCgId.toString();
     const currentTargets = targets.filter((target) =>
@@ -4137,7 +4146,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         legacyTripleResolved: false,
         lookupFailed: true,
       }));
-    if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+    if (!isRecoveryCurrent()) return noRecovery();
     const resolutionSucceeded = curatorResolution.lookupFailed !== true;
     const resolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
       .filter((peerId) => peerId && peerId !== this.peerId))]
@@ -4148,7 +4157,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       && resolvedCuratorPeerIds.length === 0) {
       legacyPreferredPeerId = await this.resolvePreferredSyncPeerId(localCgId);
     }
-    if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+    if (!isRecoveryCurrent()) return noRecovery();
     const authoritativeCuratorPeerIds = resolutionSucceeded
       ? resolvedCuratorPeerIds
       : cachedCuratorPeerIds;
@@ -4169,7 +4178,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
     this.pruneVmReconcileState();
     for (const peerId of curatorPeerIds) {
-      if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+      if (!isRecoveryCurrent()) return noRecovery();
       await this.ensurePeerConnected(peerId).catch((error) => {
         this.log.info(
           ctx,
@@ -4177,7 +4186,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         );
       });
     }
-    if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+    if (!isRecoveryCurrent()) return noRecovery();
 
     const connectedByPeerId = new Map(
       this.node.libp2p.getConnections()
@@ -4239,7 +4248,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     let recoveryWorkRan = false;
 
     for (const entry of eligible) {
-      if (!isTargetCurrent()) break;
+      if (!isRecoveryCurrent()) break;
       const { target } = entry;
       const record = entry.prepared.record;
       const installedRecord = record
@@ -4265,7 +4274,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         const protocolReady = connectedPeer
           ? await this.waitForSyncProtocol(connectedPeer)
           : false;
-        if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+        if (!isRecoveryCurrent()) return noRecovery();
         if (!connectedPeer || !protocolReady) {
           unavailablePeerIds.add(candidatePeerId);
           continue;
@@ -4278,7 +4287,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           ctx,
           'VM exact fetch',
         );
-        if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+        if (!isRecoveryCurrent()) return noRecovery();
         if (!peerAdmitted) {
           unavailablePeerIds.add(candidatePeerId);
           continue;
@@ -4307,7 +4316,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // item rotates behind untouched work so one unavailable KA cannot spend
       // every peer budget and starve the rest of the queue.
       if (attemptedOrdinals.has(target.ordinal)) break;
-      if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+      if (!isRecoveryCurrent()) return noRecovery();
       this.emitReplication({
         contextGraphId: localCgId,
         onChainCgId: onChainCgId.toString(),
@@ -4349,15 +4358,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // The exact request may have completed after unsubscribe, rebind, or
       // shutdown. Its authenticated materialization is already fail-closed,
       // but no process-local evidence or cooldown may outlive that lifecycle.
-      if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+      if (!isRecoveryCurrent()) return noRecovery();
       const outcome = await this.reconcileChainOrdinal(
         localCgId,
         onChainCgId,
         target.ordinal,
         headBlock,
-        { isTargetCurrent, deferActiveFetch: true },
+        { isTargetCurrent: isRecoveryCurrent, deferActiveFetch: true },
       );
-      if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+      if (!isRecoveryCurrent()) return noRecovery();
       outcomes.set(target.ordinal, outcome);
       if (outcome.status === 'pending' && outcome.recovery) {
         if (!installedRecord) continue;
@@ -4402,7 +4411,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // Only a batch that reached a peer and recovered nothing retains the
     // cooldown. Re-anchor that short damper at completion: a slow or legacy
     // response may already have outlived the timestamp taken before transfer.
-    if (!isTargetCurrent() || this.vmReconcileRotationClosed) return noRecovery();
+    if (!isRecoveryCurrent()) return noRecovery();
     const recoveredAny = [...outcomes.values()]
       .some((outcome) => outcome.status === 'reconciled' || outcome.status === 'already');
     if (!recoveryWorkRan || recoveredAny) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2571,7 +2571,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
    */
   async runVmReconcileSweep(this: DKGAgent): Promise<void> {
     const lifecycleGeneration = this.vmReconcileLifecycleGeneration;
+    const lifecycleSignal = this.vmReconcileLifecycleController?.signal;
     const isLifecycleCurrent = () => !this.vmReconcileRotationClosed
+      && !lifecycleSignal?.aborted
       && this.vmReconcileLifecycleGeneration === lifecycleGeneration;
     const dispatcher = this.vmReconcileDispatcher;
     if (!isLifecycleCurrent() || !this.vmReconcileEnabled() || !dispatcher) return;
@@ -2584,7 +2586,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // (subscribed BEFORE its first publish, so unbound) before the skip-gate
         // below would pass it over. Shared with the live KACG nudge.
         if (sub.subscribed && !sub.onChainId) {
-          await this.selfPrimeSubscriptionOnChainId(localCgId, sub);
+          await this.selfPrimeSubscriptionOnChainId(
+            localCgId,
+            sub,
+            undefined,
+            isLifecycleCurrent,
+            lifecycleSignal,
+          );
           if (!isLifecycleCurrent()) return;
         }
         // Member subscriptions AND Phase D core-hosted public CGs get swept.
@@ -2637,23 +2645,37 @@ export class SwmHostModeMethods extends DKGAgentBase {
     localCgId: string,
     sub: ContextGraphSub,
     targetOnChainId?: bigint,
+    isCurrent: () => boolean = () => true,
+    signal?: AbortSignal,
   ): Promise<string | null> {
-    if (!sub.subscribed || sub.onChainId) return null;
+    if (
+      !isCurrent()
+      || this.subscribedContextGraphs.get(localCgId) !== sub
+      || !sub.subscribed
+      || sub.onChainId
+    ) return null;
     let resolved: string | null = null;
     try {
       resolved = await this.getContextGraphOnChainId(localCgId, {
+        signal,
         source: 'agent.vmReconcile.resolveOnChainId',
       });
     } catch {
       return null;
     }
-    if (!resolved) return null;
+    if (
+      !isCurrent()
+      || this.subscribedContextGraphs.get(localCgId) !== sub
+      || !resolved
+    ) return null;
     if (targetOnChainId !== undefined) {
       let resolvedNum: bigint | null = null;
       try { resolvedNum = BigInt(resolved); } catch { return null; }
       if (resolvedNum !== targetOnChainId) return null;
     }
+    if (!isCurrent() || this.subscribedContextGraphs.get(localCgId) !== sub) return null;
     this.bindSubscriptionOnChainId(localCgId, sub, resolved);
+    if (!isCurrent() || this.subscribedContextGraphs.get(localCgId) !== sub) return null;
     this.persistContextGraphSubscription(localCgId);
     return resolved;
   }
@@ -2757,15 +2779,26 @@ export class SwmHostModeMethods extends DKGAgentBase {
     source: VmReconcileSource,
   ): Promise<ContextGraphReconcileResult> {
     const lifecycleGeneration = this.vmReconcileLifecycleGeneration;
+    const lifecycleSignal = this.vmReconcileLifecycleController?.signal;
     const isLifecycleCurrent = () => !this.vmReconcileRotationClosed
+      && !lifecycleSignal?.aborted
       && this.vmReconcileLifecycleGeneration === lifecycleGeneration;
     if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
-    const target = await this.resolveVmReconcileTarget(localCgId);
+    const target = await this.resolveVmReconcileTarget(
+      localCgId,
+      isLifecycleCurrent,
+      lifecycleSignal,
+    );
     if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
 
     // Keep the legacy-label -> scoped-VM migration in the admitted lane and
     // before the evidence gate. A current watermark can still need this repair.
-    await this.healStrandedScopedKCs(localCgId, target.sub);
+    await this.healStrandedScopedKCs(
+      localCgId,
+      target.sub,
+      isLifecycleCurrent,
+      lifecycleSignal,
+    );
     if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
 
     const result = await reconcileContextGraph(
@@ -2789,13 +2822,21 @@ export class SwmHostModeMethods extends DKGAgentBase {
   async resolveVmReconcileTarget(
     this: DKGAgent,
     localCgId: string,
+    isCurrent: () => boolean = () => true,
+    signal?: AbortSignal,
   ): Promise<VmReconcileTarget> {
     let sub = this.subscribedContextGraphs.get(localCgId);
     if (!sub?.subscribed && !sub?.coreHosted) {
       throw new ContextGraphNotFoundError(localCgId);
     }
     if (!sub.onChainId && sub.subscribed) {
-      await this.selfPrimeSubscriptionOnChainId(localCgId, sub);
+      await this.selfPrimeSubscriptionOnChainId(
+        localCgId,
+        sub,
+        undefined,
+        isCurrent,
+        signal,
+      );
       sub = this.subscribedContextGraphs.get(localCgId);
     }
     if (!sub?.onChainId) {
@@ -2972,9 +3013,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
    * writer cannot clobber. NEVER calls `isAlreadyConfirmed` — that read-both
    * guard is the permanence mechanism that made the legacy promotion stick.
    */
-  async healStrandedScopedKCs(this: DKGAgent, localCgId: string, sub: ContextGraphSub): Promise<void> {
+  async healStrandedScopedKCs(
+    this: DKGAgent,
+    localCgId: string,
+    sub: ContextGraphSub,
+    isCurrent: () => boolean = () => true,
+    signal?: AbortSignal,
+  ): Promise<void> {
     try {
-      if (!sub.onChainId) return;
+      const canApply = () => isCurrent()
+        && (!(this.subscribedContextGraphs instanceof Map)
+          || this.subscribedContextGraphs.get(localCgId) === sub);
+      if (!canApply() || !sub.onChainId) return;
       // Server-side byte-safe copy is the ONLY safe relocation mechanism; if the
       // backend can't do SPARQL UPDATE we bail rather than risk a lossy JS round-trip.
       if (typeof this.store.update !== 'function') return;
@@ -2989,7 +3039,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           this.store,
           sparql,
           touchedGraphs,
-          { source: 'agent.swm.rsHeal.materialize' },
+          { signal, source: 'agent.swm.rsHeal.materialize' },
         );
         if (!updated) throw new Error('RS heal requires server-side update() support');
       };
@@ -3015,9 +3065,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
            GRAPH <${legacyMeta}> { ?ual <${DKG}batchId> ?b }
            FILTER NOT EXISTS { GRAPH <${scopedMeta}> { ?ual <${DKG}batchId> ?b } }
          }`,
-        { source: 'agent.swm.rsHeal.findLegacyOnly' },
+        { signal, source: 'agent.swm.rsHeal.findLegacyOnly' },
       );
-      if (askGuard.type !== 'boolean' || !askGuard.value) return;
+      if (!canApply() || askGuard.type !== 'boolean' || !askGuard.value) return;
 
       // 2b: enumerate the stranded UALs.
       const stranded = await this.store.query(
@@ -3025,11 +3075,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
            GRAPH <${legacyMeta}> { ?ual <${DKG}batchId> ?b }
            FILTER NOT EXISTS { GRAPH <${scopedMeta}> { ?ual <${DKG}batchId> ?b } }
          }`,
-        { source: 'agent.swm.rsHeal.listLegacyOnly' },
+        { signal, source: 'agent.swm.rsHeal.listLegacyOnly' },
       );
-      if (stranded.type !== 'bindings') return;
+      if (!canApply() || stranded.type !== 'bindings') return;
 
       for (const row of stranded.bindings) {
+        if (!canApply()) return;
         // Bindings come back stripped to bare values by the store adapters
         // (oxigraph/sparql-http both emit IRIs unwrapped); strip + validate
         // exactly as the extractor does for its `ual`.
@@ -3053,6 +3104,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         );
         try {
           await withMaterializationLock(scopedMeta, ual, async () => {
+            if (!canApply()) return;
             // A KC may carry no `dkg:materializedVersion` stamp in legacy meta:
             // the publisher's OWN one-shot publish writes the KC into the legacy
             // label `_meta` but never stamps a version (only the
@@ -3065,7 +3117,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
             // reverse, so it can never clobber a genuine update.
             const version = (await readMaterializedVersion(this.store, legacyMeta, ual))
               ?? { blockNumber: 0, txIndex: 0 };
+            if (!canApply()) return;
             if (!(await shouldApplyMaterialization(this.store, scopedMeta, ual, version))) return; // idempotent
+            if (!canApply()) return;
 
             assertSafeIri(ual);
 
@@ -3078,9 +3132,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
                    { <${ual}> <${DKG}rootEntity> ?root . }
                  }
                }`,
-              { source: 'agent.swm.rsHeal.readRoots' },
+              { signal, source: 'agent.swm.rsHeal.readRoots' },
             );
-            if (rootsRes.type !== 'bindings') return;
+            if (!canApply() || rootsRes.type !== 'bindings') return;
             const roots: string[] = [];
             const seen = new Set<string>();
             for (const r of rootsRes.bindings) {
@@ -3112,9 +3166,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
                      }
                    }
                  }`,
-                { source: 'agent.swm.rsHeal.checkRootData' },
+                { signal, source: 'agent.swm.rsHeal.checkRootData' },
               );
-              if (present.type !== 'boolean' || !present.value) return;
+              if (!canApply() || present.type !== 'boolean' || !present.value) return;
             }
 
             // DATA copy (per root) — MANDATORY server-side, byte-safe, read-both
@@ -3122,6 +3176,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
             // trustLevel stamps in BOTH branches so the recomputed leaf set stays
             // bit-identical with the on-chain merkleLeafCount.
             for (const root of roots) {
+              if (!canApply()) return;
               await update(
                 `INSERT { GRAPH <${scopedData}> { ?s ?p ?o } } WHERE {
                    {
@@ -3140,11 +3195,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
                  }`,
                 [scopedData],
               );
+              if (!canApply()) return;
             }
 
             // META copy — server-side. Carries the `<ual>` subject (batchId
             // discriminator) + the `<ual>/<tokenId>` token rows
             // (rootEntity/privateMerkleRoot).
+            if (!canApply()) return;
             await update(
               `INSERT { GRAPH <${scopedMeta}> { ?s ?p ?o } } WHERE {
                  GRAPH <${legacyMeta}> {
@@ -3154,9 +3211,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
                }`,
               [scopedMeta],
             );
+            if (!canApply()) return;
 
             // Stamp so a later stale writer can't clobber.
             await writeMaterializedVersion(this.store, scopedMeta, ual, version);
+            if (!canApply()) return;
 
             this.log.info(
               createOperationContext('system'),
@@ -3611,9 +3670,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this: DKGAgent,
     localCgId: string,
   ): string[] {
+    const curatorOrder = this.vmReconcileCuratorPeersByCg.get(localCgId) ?? [];
     const libp2p = (this.node as any)?.libp2p;
     const getConnections = libp2p?.getConnections;
-    if (typeof getConnections !== 'function') return [];
+    if (typeof getConnections !== 'function') {
+      return curatorOrder.slice(0, DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX);
+    }
     const peersById = new Map<string, { toString(): string }>();
     for (const connection of getConnections.call(libp2p) as Array<{
       remotePeer?: { toString(): string };
@@ -3634,11 +3696,21 @@ export class SwmHostModeMethods extends DKGAgentBase {
       false,
     )
       .map((peer) => peer.toString());
-    const curatorOrder = this.vmReconcileCuratorPeersByCg.get(localCgId) ?? [];
-    return [...new Set([
-      ...curatorOrder.filter((peerId) => peersById.has(peerId)),
-      ...ordinaryOrder,
-    ])].slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
+    // Structural curators are authoritative and may contain the only holder.
+    // Ordinary connected peers are opportunistic fallback only: cap that tier
+    // separately so connection churn cannot stretch a negative cycle to 256
+    // elevated prefix downloads.
+    const boundedCurators = [...new Set(curatorOrder)]
+      .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX);
+    const curatorSet = new Set(boundedCurators);
+    const ordinaryBudget = Math.min(
+      DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX,
+      Math.max(0, DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX - boundedCurators.length),
+    );
+    const boundedOrdinary = ordinaryOrder
+      .filter((peerId) => !curatorSet.has(peerId))
+      .slice(0, ordinaryBudget);
+    return [...boundedCurators, ...boundedOrdinary];
   }
 
   vmReconcilePeerMembershipMatches(
@@ -3679,7 +3751,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
       this.vmReconcileRotationState.delete(slotKey);
       record = undefined;
     }
-    if (record?.phase === 'backoff' && !record.curatorRosterConfirmed) {
+    if (
+      record?.phase === 'backoff'
+      && (!record.curatorRosterConfirmed || !curatorRosterConfirmed)
+    ) {
       // Absence gathered while curator discovery was unavailable must not
       // suppress the next lookup: that lookup may reveal the only holder.
       this.vmReconcileRotationState.delete(slotKey);
@@ -3700,10 +3775,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     if (!record) {
       if (!this.makeRoomForVmReconcileRotationRecord()) {
-        // Stable-capacity overflow remains fail-open. It still participates in
-        // ordinary exact recovery, but owns no cursor/absence evidence and can
-        // neither suppress nor evict an in-progress collection.
-        return { slotKey, suppressed: false };
+        // Preserve the pressure bound at cap: an unowned target cannot retain
+        // exponential retry state, so running elevated exact transport here
+        // would replay it every sweep. Defer until an expired/resolved slot is
+        // available; this is process-local scheduling, never absence evidence.
+        return { slotKey, suppressed: true };
       }
       record = {
         localCgId: target.localCgId,
@@ -3743,6 +3819,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Any removal/replacement invalidates the whole cycle so shrink can
         // never manufacture exhaustion or preserve an active suppression.
         record.phase = 'collecting';
+        record.backoffKind = undefined;
         record.nextRetryAt = 0;
         record.attemptedPeerIds.clear();
         record.cleanAbsentPeerIds.clear();
@@ -3753,12 +3830,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Pure growth preserves valid credits for retained identities, but the
         // newly observed peer is uncredited and immediately breaks backoff.
         record.phase = 'collecting';
+        record.backoffKind = undefined;
         record.nextRetryAt = 0;
         record.collectionDeadlineAt = now
           + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
       }
-    } else if (curatorRosterConfirmed) {
-      record.curatorRosterConfirmed = true;
+    } else {
+      record.curatorRosterConfirmed = curatorRosterConfirmed;
     }
     if (record.phase === 'backoff') {
       if (now < record.nextRetryAt) {
@@ -3768,6 +3846,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // A deadline only opens a new collection cycle. It never earns another
       // failure/backoff without fresh clean-absence evidence from every peer.
       record.phase = 'collecting';
+      record.backoffKind = undefined;
       record.attemptedPeerIds.clear();
       record.cleanAbsentPeerIds.clear();
       record.collectionDeadlineAt = now
@@ -3789,6 +3868,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this: DKGAgent,
     slotKey: string,
     record: VmReconcileRotationRecord,
+    kind: NonNullable<VmReconcileRotationRecord['backoffKind']> = 'clean-absence',
   ): void {
     record.failures += 1;
     const exponentialBackoff = Math.min(
@@ -3805,6 +3885,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       Math.max(1, Math.round(exponentialBackoff * (0.8 + jitterSample * 0.4))),
     );
     record.phase = 'backoff';
+    record.backoffKind = kind;
     record.collectionDeadlineAt = 0;
     record.nextRetryAt = this.vmReconcileRotationNow() + backoff;
   }
@@ -3829,14 +3910,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (this.vmReconcileRotationState.size < DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
       return true;
     }
-    // Map order is LRU order. Completed backoff and expired collecting records
-    // are replaceable: eviction merely retries fail-open. Live collectors stay
-    // installed so cap+1 churn cannot make every partial rotation useless.
+    // Map order is LRU order. Only expired suppression/collection state is
+    // replaceable; evicting an active backoff would turn the state bound into
+    // an immediate network retry loop under a large missing-ordinal backlog.
     const now = this.vmReconcileRotationNow();
     for (const [key, record] of this.vmReconcileRotationState) {
       if (
-        record.phase !== 'backoff'
-        && (record.phase !== 'collecting' || now < record.collectionDeadlineAt)
+        (record.phase === 'backoff' && now < record.nextRetryAt)
+        || (record.phase === 'collecting' && now < record.collectionDeadlineAt)
       ) continue;
       this.vmReconcileRotationState.delete(key);
       return true;
@@ -3855,6 +3936,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   closeVmReconcileRotationState(this: DKGAgent): void {
+    this.vmReconcileLifecycleController?.abort();
     this.vmReconcileLifecycleGeneration = (this.vmReconcileLifecycleGeneration ?? 0) + 1;
     this.vmReconcileRotationClosed = true;
     // Some lifecycle tests intentionally construct a narrow partial agent
@@ -3865,36 +3947,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   openVmReconcileRotationState(this: DKGAgent): void {
+    if (!this.vmReconcileLifecycleController || this.vmReconcileLifecycleController.signal.aborted) {
+      this.vmReconcileLifecycleController = new AbortController();
+    }
     this.vmReconcileRotationClosed = false;
   }
 
   rearmVmReconcileRuntimeAfterRestart(this: DKGAgent): void {
     const dispatcher = this.vmReconcileDispatcher;
-    if (!dispatcher?.snapshot().closed) return;
-    const sweep = this.vmReconcileSweepInFlight;
-    if (dispatcher.snapshot().active === 0 && !sweep) {
-      this.vmReconcileDispatcher = undefined;
-      return;
+    if (dispatcher?.snapshot().closed) this.vmReconcileDispatcher = undefined;
+    if (this.started && !this.vmReconcileRotationClosed) {
+      this.ensureVmReconcileDispatcher();
+      void this.runVmReconcileSweep();
     }
-    if (this.vmReconcileRetiringDispatcher === dispatcher) return;
-
-    this.vmReconcileRetiringDispatcher = dispatcher;
-    const retirement = (async () => {
-      await dispatcher.waitForIdle();
-      if (sweep) await sweep.catch(() => undefined);
-      if (this.vmReconcileRetiringDispatcher !== dispatcher) return;
-      this.vmReconcileRetiringDispatcher = undefined;
-      this.vmReconcileRetirementInFlight = null;
-      if (this.vmReconcileDispatcher === dispatcher) this.vmReconcileDispatcher = undefined;
-      if (
-        this.started
-        && !this.vmReconcileRotationClosed
-      ) {
-        this.ensureVmReconcileDispatcher();
-        void this.runVmReconcileSweep();
-      }
-    })();
-    this.vmReconcileRetirementInFlight = retirement;
   }
 
   vmReconcileRecoveryTargetMatches(
@@ -3942,12 +4007,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const cleanAbsentFromEveryPeer = [...capturedRecord.candidatePeerIds]
       .every((candidatePeerId) => capturedRecord.cleanAbsentPeerIds.has(candidatePeerId));
     if (cleanAbsentFromEveryPeer) {
-      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord);
+      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord, 'clean-absence');
     } else if (scheduledEveryPeer) {
-      // A physically incomplete result or an ineligible candidate is not
-      // absence proof. It may finish the scheduling cycle, but only by dropping
-      // all evidence. The per-CG cooldown below provides the short retry damper.
-      this.vmReconcileRotationState.delete(slotKey);
+      // This is retry suppression only, never absence proof. It prevents a
+      // legacy peer that ignores the exact filter from replaying the same
+      // bounded prefix at elevated priority every sweep.
+      this.enterVmReconcileRotationBackoff(slotKey, capturedRecord, 'incomplete-cycle');
     }
     this.touchVmReconcileRotationRecord(slotKey, capturedRecord);
   }
@@ -4214,11 +4279,24 @@ export class SwmHostModeMethods extends DKGAgentBase {
         lookupFailed: true,
       }));
     if (!isRecoveryCurrent()) return noRecovery();
-    const resolutionSucceeded = curatorResolution.lookupFailed !== true;
-    const resolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
+    const allResolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
       .filter((peerId) => peerId && peerId !== this.peerId))]
-      .sort((left, right) => left.localeCompare(right))
-      .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
+      .sort((left, right) => left.localeCompare(right));
+    const curatorRosterOverflow = allResolvedCuratorPeerIds.length
+      > DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX;
+    if (curatorRosterOverflow) {
+      this.log.warn(
+        ctx,
+        `VM exact fetch curator roster for "${localCgId}" exceeds bounded proof capacity `
+          + `(${allResolvedCuratorPeerIds.length}>${DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX}); `
+          + 'retaining prior roster without negative-proof suppression',
+      );
+    }
+    const resolutionSucceeded = curatorResolution.lookupFailed !== true
+      && !curatorRosterOverflow;
+    const resolvedCuratorPeerIds = resolutionSucceeded
+      ? allResolvedCuratorPeerIds
+      : [];
     let legacyPreferredPeerId: string | undefined;
     if (resolutionSucceeded && !curatorResolution.curatorIsLocal
       && resolvedCuratorPeerIds.length === 0) {
@@ -4233,27 +4311,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
       legacyPreferredPeerId,
       approvedCuratorPeerId,
     ].filter((peerId): peerId is string => Boolean(peerId && peerId !== this.peerId)))]
-      .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX);
-    // Persist the same ranked roster that this pass dials and later uses for
-    // proof canonicalization. A successful empty structural lookup may fall
-    // back to metadata; omitting that peer here lets ordinary peers fill the
-    // cap and repeatedly prove absence without querying the only holder.
+      .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX);
+    // Persist the bounded full authoritative roster. Individual passes still
+    // connect/probe at most VM_RECONCILE_EXACT_PEER_MAX peers, while each
+    // target's rotation record carries progress across those windows.
     if (resolutionSucceeded) this.vmReconcileCuratorPeersByCg.delete(localCgId);
     if (!curatorResolution.curatorIsLocal && curatorPeerIds.length > 0) {
       this.vmReconcileCuratorPeersByCg.delete(localCgId);
       this.vmReconcileCuratorPeersByCg.set(localCgId, curatorPeerIds);
     }
     this.pruneVmReconcileState();
-    for (const peerId of curatorPeerIds) {
-      if (!isRecoveryCurrent()) return noRecovery();
-      await this.ensurePeerConnected(peerId).catch((error) => {
-        this.log.info(
-          ctx,
-          `VM exact fetch could not connect curator peer ${peerId.slice(-8)}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      });
-    }
-    if (!isRecoveryCurrent()) return noRecovery();
 
     const connectedByPeerId = new Map(
       this.node.libp2p.getConnections()
@@ -4275,7 +4342,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           target,
           orderedPeerIds,
           this.vmReconcileRotationNow(),
-          resolutionSucceeded || cachedCuratorPeerIds.length > 0,
+          resolutionSucceeded,
         ),
       }));
     const eligible = preparedEntries
@@ -4285,12 +4352,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
           record
           && this.vmReconcileRotationState.get(entry.prepared.slotKey) !== record
         ) {
-          // A later slot may have fairly replaced this backoff record while the
-          // batch was prepared. Continue as evidence-free overflow; never send
-          // transport work against the evicted object or preserve its suppress.
+          // A later slot may have replaced an expired record while the batch
+          // was prepared. Defer the now-unowned target: elevated transport
+          // without retained retry state would violate the pressure bound.
           return {
             ...entry,
-            prepared: { slotKey: entry.prepared.slotKey, suppressed: false },
+            prepared: { slotKey: entry.prepared.slotKey, suppressed: true },
           };
         }
         return entry;
@@ -4312,6 +4379,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const outcomes = new Map<number, OrdinalOutcome>();
     const attemptedOrdinals = new Set<number>();
     const usedPeerIds = new Set<string>();
+    const consideredPeerIds = new Set<string>();
     const unavailablePeerIds = new Set<string>();
     let recoveryWorkRan = false;
 
@@ -4337,7 +4405,35 @@ export class SwmHostModeMethods extends DKGAgentBase {
         : orderedPeerIds;
       for (const candidatePeerId of candidateOrder) {
         if (usedPeerIds.has(candidatePeerId) || unavailablePeerIds.has(candidatePeerId)) continue;
-        const connectedPeer = connectedByPeerId.get(candidatePeerId);
+        if (
+          !consideredPeerIds.has(candidatePeerId)
+          && consideredPeerIds.size >= DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX
+        ) break;
+        consideredPeerIds.add(candidatePeerId);
+        if (installedRecord) {
+          installedRecord.lastAttemptedPeerId = candidatePeerId;
+          installedRecord.attemptedPeerIds.add(candidatePeerId);
+          installedRecord.collectionDeadlineAt = this.vmReconcileRotationNow()
+            + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
+          this.touchVmReconcileRotationRecord(
+            this.vmReconcileRotationSlotKey(target),
+            installedRecord,
+          );
+        }
+        let connectedPeer = connectedByPeerId.get(candidatePeerId);
+        if (!connectedPeer) {
+          await this.ensurePeerConnected(candidatePeerId).catch((error) => {
+            this.log.info(
+              ctx,
+              `VM exact fetch could not connect candidate peer ${candidatePeerId.slice(-8)}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          });
+          if (!isRecoveryCurrent()) return noRecovery();
+          const connection = this.node.libp2p.getConnections()
+            .find((candidate) => candidate.remotePeer.toString() === candidatePeerId);
+          connectedPeer = connection?.remotePeer;
+          if (connectedPeer) connectedByPeerId.set(candidatePeerId, connectedPeer);
+        }
         recoveryWorkRan = true;
         const protocolReady = connectedPeer
           ? await this.waitForSyncProtocol(connectedPeer)

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -122,7 +122,7 @@ import {
   type WorkspaceAgentRecipientResolverInput,
   type WorkspaceSenderKeyEncryptInput,
   type SharedMemoryPublicSnapshotStorageConfig, type WorkspacePublicSnapshotStore,
-  readMaterializedVersion, shouldApplyMaterialization, writeMaterializedVersion, withMaterializationLock,
+  readMaterializedVersion, shouldApplyMaterialization, withMaterializationLock,
   type MaterializedVersion,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
@@ -402,6 +402,11 @@ import {
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
+import {
+  bumpContextGraphBindingGeneration as bumpBindingGeneration,
+  captureContextGraphBindingGeneration as captureBindingGeneration,
+  isContextGraphBindingGenerationCurrent as isBindingGenerationCurrent,
+} from './context-graph-binding-generation.js';
 
 const DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE = 32;
 
@@ -411,7 +416,13 @@ type VmReconcileTarget = {
   onChainId: string;
   onChainCgId: bigint;
   cursor: CursorState;
+  bindingGeneration: number;
   watermarkBefore: number;
+};
+
+type VmReconcileExecution = {
+  identityCursor: CursorState;
+  persistWatermark: (localCgId: string, watermark: number) => void;
 };
 
 type VmReconcileOrdinalOptions = {
@@ -456,6 +467,25 @@ function stripBindingQuotes(v: string): string {
     return v.slice(1, ix);
   }
   return v;
+}
+
+async function raceVmReconcileAbort<T>(
+  work: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) return work;
+  void work.catch(() => undefined);
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(new VmReconcileQueueClosedError());
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([work, aborted]);
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+  }
 }
 
 export class SwmHostModeMethods extends DKGAgentBase {
@@ -2279,6 +2309,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return fallback;
   }
 
+  bumpContextGraphBindingGeneration(this: DKGAgent, localCgId: string): number {
+    return bumpBindingGeneration(this, localCgId);
+  }
+
+  captureContextGraphBindingGeneration(this: DKGAgent, localCgId: string): number {
+    return captureBindingGeneration(this, localCgId);
+  }
+
+  isContextGraphBindingGenerationCurrent(
+    this: DKGAgent,
+    localCgId: string,
+    generation: number,
+  ): boolean {
+    return isBindingGenerationCurrent(this, localCgId, generation);
+  }
+
   /**
    * Bind (or rebind) a local CG to an on-chain CG id, resetting the
    * chain-driven reconcile watermark if the bound id actually CHANGES.
@@ -2293,8 +2339,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
    */
   bindSubscriptionOnChainId(this: DKGAgent, localCgId: string, sub: ContextGraphSub, newOnChainId: string): void {
     const prev = sub.onChainId;
+    if (prev === newOnChainId) return;
+    bumpBindingGeneration(this, localCgId);
     sub.onChainId = newOnChainId;
-    if (!prev || prev === newOnChainId) return;
+    if (!prev) return;
     // The bound on-chain id actually CHANGED (repair / recreate / re-register).
     // Any prior reconcile progress refers to the OLD chain graph and must be
     // dropped, otherwise the sweep resumes at the wrong ordinal and skips
@@ -2570,6 +2618,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
    * burst of live nudges) collapse into one sweep per CG.
    */
   async runVmReconcileSweep(this: DKGAgent): Promise<void> {
+    if (this.started && !this.vmReconcileRuntimeReady) return;
     const lifecycleGeneration = this.vmReconcileLifecycleGeneration;
     const lifecycleSignal = this.vmReconcileLifecycleController?.signal;
     const isLifecycleCurrent = () => !this.vmReconcileRotationClosed
@@ -2648,35 +2697,44 @@ export class SwmHostModeMethods extends DKGAgentBase {
     isCurrent: () => boolean = () => true,
     signal?: AbortSignal,
   ): Promise<string | null> {
-    if (
-      !isCurrent()
-      || this.subscribedContextGraphs.get(localCgId) !== sub
-      || !sub.subscribed
-      || sub.onChainId
-    ) return null;
+    const bindingGeneration = captureBindingGeneration(this, localCgId);
+    const isSubscriptionCurrent = () => isCurrent()
+      && this.subscribedContextGraphs.get(localCgId) === sub
+      && sub.subscribed
+      && !sub.onChainId
+      && isBindingGenerationCurrent(this, localCgId, bindingGeneration);
+    if (!isSubscriptionCurrent()) return null;
     let resolved: string | null = null;
     try {
-      resolved = await this.getContextGraphOnChainId(localCgId, {
+      resolved = await raceVmReconcileAbort(
+        this.getContextGraphOnChainId(localCgId, {
+          signal,
+          source: 'agent.vmReconcile.resolveOnChainId',
+        }),
         signal,
-        source: 'agent.vmReconcile.resolveOnChainId',
-      });
+      );
     } catch {
       return null;
     }
-    if (
-      !isCurrent()
-      || this.subscribedContextGraphs.get(localCgId) !== sub
-      || !resolved
-    ) return null;
+    if (!isSubscriptionCurrent() || !resolved) return null;
     if (targetOnChainId !== undefined) {
       let resolvedNum: bigint | null = null;
       try { resolvedNum = BigInt(resolved); } catch { return null; }
       if (resolvedNum !== targetOnChainId) return null;
     }
-    if (!isCurrent() || this.subscribedContextGraphs.get(localCgId) !== sub) return null;
+    if (!isSubscriptionCurrent()) return null;
+    try {
+      await this.persistContextGraphSubscriptionStrict(
+        localCgId,
+        { ...sub, onChainId: resolved },
+        undefined,
+        isSubscriptionCurrent,
+      );
+    } catch {
+      return null;
+    }
+    if (!isSubscriptionCurrent()) return null;
     this.bindSubscriptionOnChainId(localCgId, sub, resolved);
-    if (!isCurrent() || this.subscribedContextGraphs.get(localCgId) !== sub) return null;
-    this.persistContextGraphSubscription(localCgId);
     return resolved;
   }
 
@@ -2704,6 +2762,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     kaId: bigint,
     ctx: OperationContext,
   ): Promise<string | null> {
+    const lifecycleGeneration = this.vmReconcileLifecycleGeneration;
+    const lifecycleSignal = this.vmReconcileLifecycleController?.signal;
+    const isLifecycleCurrent = () => !this.vmReconcileRotationClosed
+      && !lifecycleSignal?.aborted
+      && this.vmReconcileLifecycleGeneration === lifecycleGeneration;
+    if (!isLifecycleCurrent()) return null;
     let targetOnChain: bigint | null = null;
     try { targetOnChain = BigInt(onChainId); } catch { targetOnChain = null; }
 
@@ -2716,10 +2780,20 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // path); the sweep remains the safety net for a CG whose quad hasn't arrived.
       if (targetOnChain !== null) {
         for (const [lcg, sub] of this.subscribedContextGraphs) {
-          const bound = await this.selfPrimeSubscriptionOnChainId(lcg, sub, targetOnChain);
+          if (!isLifecycleCurrent()) return null;
+          const bound = await this.selfPrimeSubscriptionOnChainId(
+            lcg,
+            sub,
+            targetOnChain,
+            isLifecycleCurrent,
+            lifecycleSignal,
+          );
+          if (!isLifecycleCurrent()) return null;
           if (bound) {
             this.log.info(ctx, `Phase B: KACG nudge cg=${onChainId} ka=${kaId} -> bound + reconcile pre-subscribed "${lcg}"`);
-            if (this.vmReconcileDispatcher) void this.vmReconcileDispatcher.triggerLive(lcg);
+            if (this.vmReconcileDispatcher && isLifecycleCurrent()) {
+              void this.vmReconcileDispatcher.triggerLive(lcg);
+            }
             return lcg;
           }
         }
@@ -2730,9 +2804,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const sub = this.subscribedContextGraphs.get(localCgId);
     // Populate VM for CGs we member-subscribe to OR (Phase D) public CGs this
     // Core hosts — a hosted Core fills its own gaps too.
-    if (!sub?.subscribed && !sub?.coreHosted) return null;
+    if (!isLifecycleCurrent() || (!sub?.subscribed && !sub?.coreHosted)) return null;
     this.log.info(ctx, `Phase B: KACG nudge cg=${onChainId} ka=${kaId} -> reconcile "${localCgId}"`);
-    if (this.vmReconcileDispatcher) void this.vmReconcileDispatcher.triggerLive(localCgId);
+    if (this.vmReconcileDispatcher && isLifecycleCurrent()) {
+      void this.vmReconcileDispatcher.triggerLive(localCgId);
+    }
     return localCgId;
   }
 
@@ -2748,12 +2824,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
     localCgId: string,
     source: VmReconcileSource = 'manual',
   ): Promise<ContextGraphReconcileResult> {
+    if (this.started && !this.vmReconcileRuntimeReady) {
+      throw new VmReconcileQueueClosedError();
+    }
     return this.ensureVmReconcileDispatcher().dispatch(localCgId, source);
   }
 
   ensureVmReconcileDispatcher(
     this: DKGAgent,
   ): VmReconcileDispatcher<ContextGraphReconcileResult> {
+    if (this.started && !this.vmReconcileRuntimeReady) {
+      throw new VmReconcileQueueClosedError();
+    }
     if (!this.vmReconcileDispatcher) {
       this.vmReconcileDispatcher = new VmReconcileDispatcher(
         (localCgId, source) => this.executeVmReconcileForCg(localCgId, source),
@@ -2784,39 +2866,93 @@ export class SwmHostModeMethods extends DKGAgentBase {
       && !lifecycleSignal?.aborted
       && this.vmReconcileLifecycleGeneration === lifecycleGeneration;
     if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
-    const target = await this.resolveVmReconcileTarget(
-      localCgId,
-      isLifecycleCurrent,
-      lifecycleSignal,
-    );
-    if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
+    const physicalRun = (async (): Promise<ContextGraphReconcileResult> => {
+      const target = await this.resolveVmReconcileTarget(
+        localCgId,
+        isLifecycleCurrent,
+        lifecycleSignal,
+      );
+      const isTargetCurrent = () => isLifecycleCurrent()
+        && this.subscribedContextGraphs.get(localCgId) === target.sub
+        && target.sub.onChainId === target.onChainId
+        && isBindingGenerationCurrent(
+          this,
+          localCgId,
+          target.bindingGeneration,
+        )
+        && this.reconcileCursors.get(localCgId) === target.cursor;
+      if (!isTargetCurrent()) throw new VmReconcileQueueClosedError();
 
-    // Keep the legacy-label -> scoped-VM migration in the admitted lane and
-    // before the evidence gate. A current watermark can still need this repair.
-    await this.healStrandedScopedKCs(
-      localCgId,
-      target.sub,
-      isLifecycleCurrent,
-      lifecycleSignal,
-    );
-    if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
+      // Keep the legacy-label -> scoped-VM migration in the admitted lane and
+      // before the evidence gate. A current watermark can still need this repair.
+      await this.healStrandedScopedKCs(
+        localCgId,
+        target.sub,
+        isTargetCurrent,
+        lifecycleSignal,
+      );
+      if (!isTargetCurrent()) throw new VmReconcileQueueClosedError();
 
-    const result = await reconcileContextGraph(
-      this.createVmReconcileDeps(localCgId, lifecycleGeneration),
-      target.cursor,
-      localCgId,
-      target.onChainCgId,
-    );
-    if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
-    const response = this.toContextGraphReconcileResult(localCgId, source, target, result);
-    this.emitVmReconcileTelemetry(localCgId, target, result, response.status);
-    // Queue one trailing slice while this key is still active. The dispatcher
-    // places it behind already-waiting live CGs, so a large graph makes steady
-    // progress without monopolising the only VM worker.
-    if (isLifecycleCurrent() && (result.hasMore || result.staleTarget)) {
-      this.vmReconcileDispatcher?.triggerLive(localCgId);
-    }
-    return response;
+      // Reconcile on a private cursor snapshot. The caller-facing abort race may
+      // finish before an adapter physically settles; a stale continuation must
+      // never mutate the live cursor or persist a watermark into a new binding.
+      const workingCursor: CursorState = {
+        watermark: target.cursor.watermark,
+        ahead: new Map(target.cursor.ahead),
+        scanOrdinal: target.cursor.scanOrdinal,
+      };
+      let pendingWatermark: number | undefined;
+      const result = await reconcileContextGraph(
+        this.createVmReconcileDeps(
+          localCgId,
+          lifecycleGeneration,
+          target,
+          lifecycleSignal,
+          {
+            identityCursor: target.cursor,
+            persistWatermark: (_lcg, watermark) => { pendingWatermark = watermark; },
+          },
+        ),
+        workingCursor,
+        localCgId,
+        target.onChainCgId,
+      );
+      if (!isTargetCurrent()) throw new VmReconcileQueueClosedError();
+      if (result.reconciled > 0 || pendingWatermark !== undefined) {
+        await this.store.flush?.({
+          priority: 'background',
+          source: 'agent.vmReconcile.materialization.flush',
+        });
+        if (!isTargetCurrent()) throw new VmReconcileQueueClosedError();
+      }
+      if (pendingWatermark !== undefined) {
+        await this.persistVmReconcileWatermark(
+          localCgId,
+          pendingWatermark,
+          target.sub,
+          target.bindingGeneration,
+          target.cursor,
+        );
+        if (!isTargetCurrent()) throw new VmReconcileQueueClosedError();
+      }
+      target.cursor.watermark = workingCursor.watermark;
+      target.cursor.ahead = new Map(workingCursor.ahead);
+      target.cursor.scanOrdinal = workingCursor.scanOrdinal;
+      const response = this.toContextGraphReconcileResult(localCgId, source, target, result);
+      this.emitVmReconcileTelemetry(localCgId, target, result, response.status);
+      // Queue one trailing slice while this key is still active. The dispatcher
+      // places it behind already-waiting live CGs, so a large graph makes steady
+      // progress without monopolising the only VM worker.
+      if (isLifecycleCurrent() && (result.hasMore || result.staleTarget)) {
+        this.vmReconcileDispatcher?.triggerLive(localCgId);
+      }
+      return response;
+    })();
+    this.vmReconcilePhysicalRuns.add(physicalRun);
+    void physicalRun.finally(() => {
+      this.vmReconcilePhysicalRuns.delete(physicalRun);
+    }).catch(() => undefined);
+    return raceVmReconcileAbort(physicalRun, lifecycleSignal);
   }
 
   async resolveVmReconcileTarget(
@@ -2856,6 +2992,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       onChainId: sub.onChainId,
       onChainCgId: BigInt(sub.onChainId),
       cursor,
+      bindingGeneration: captureBindingGeneration(this, localCgId),
       watermarkBefore: cursor.watermark,
     };
   }
@@ -2864,16 +3001,28 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this: DKGAgent,
     localCgId: string,
     lifecycleGeneration = this.vmReconcileLifecycleGeneration,
+    target?: VmReconcileTarget,
+    signal?: AbortSignal,
+    execution?: VmReconcileExecution,
   ): ChainReconcilerDeps {
-    const capturedSub = this.subscribedContextGraphs.get(localCgId);
-    const capturedOnChainId = capturedSub?.onChainId;
-    const capturedCursor = this.reconcileCursors.get(localCgId);
+    const capturedSub = target?.sub ?? this.subscribedContextGraphs.get(localCgId);
+    const capturedOnChainId = target?.onChainId ?? capturedSub?.onChainId;
+    const capturedBindingGeneration = target?.bindingGeneration
+      ?? captureBindingGeneration(this, localCgId);
+    const capturedCursor = execution?.identityCursor
+      ?? target?.cursor
+      ?? this.reconcileCursors.get(localCgId);
     const isTargetCurrent = (): boolean => {
       const current = this.subscribedContextGraphs.get(localCgId);
       return !this.vmReconcileRotationClosed
         && this.vmReconcileLifecycleGeneration === lifecycleGeneration
         && current === capturedSub
         && current?.onChainId === capturedOnChainId
+        && isBindingGenerationCurrent(
+          this,
+          localCgId,
+          capturedBindingGeneration,
+        )
         && this.reconcileCursors.get(localCgId) === capturedCursor;
     };
     return {
@@ -2899,28 +3048,64 @@ export class SwmHostModeMethods extends DKGAgentBase {
           deferActiveFetch: true,
         }),
       recoverPendingOrdinals: (lcg, ocg, targets, headBlock) =>
-        this.recoverVmReconcileBatch(lcg, ocg, targets, headBlock, isTargetCurrent),
+        this.recoverVmReconcileBatch(
+          lcg,
+          ocg,
+          targets,
+          headBlock,
+          isTargetCurrent,
+          signal,
+        ),
       maxOrdinalsPerPass: DKGAgentBase.VM_RECONCILE_BATCH_SIZE,
       maxOrdinalConcurrency: DKGAgentBase.VM_RECONCILE_ORDINAL_CONCURRENCY,
       isTargetCurrent: () => isTargetCurrent(),
       persistWatermark: (lcg, watermark) => {
         if (!isTargetCurrent()) return;
-        const sub = this.subscribedContextGraphs.get(lcg);
-        if (!sub) return;
-        const previous = sub.lastReconciledOrdinal ?? 0;
-        sub.lastReconciledOrdinal = watermark;
-        this.persistContextGraphSubscription(lcg);
-        this.emitReplication({
-          contextGraphId: lcg,
-          onChainCgId: sub.onChainId,
-          action: 'cursor-advance',
-          fromWatermark: previous,
-          toWatermark: watermark,
-        });
+        if (execution) execution.persistWatermark(lcg, watermark);
+        else void this.persistVmReconcileWatermark(
+          lcg,
+          watermark,
+          capturedSub,
+          capturedBindingGeneration,
+          capturedCursor,
+        );
       },
       confirmationDepth: DKGAgentBase.VM_RECONCILE_CONFIRMATION_DEPTH,
       log: (msg) => this.log.info(createOperationContext('system'), msg),
     };
+  }
+
+  persistVmReconcileWatermark(
+    this: DKGAgent,
+    localCgId: string,
+    watermark: number,
+    expectedSub?: ContextGraphSub,
+    expectedBindingGeneration = captureBindingGeneration(this, localCgId),
+    expectedCursor?: CursorState,
+  ): Promise<void> {
+    const sub = this.subscribedContextGraphs.get(localCgId);
+    const isTargetCurrent = () => this.subscribedContextGraphs.get(localCgId) === sub
+      && (!expectedSub || sub === expectedSub)
+      && isBindingGenerationCurrent(this, localCgId, expectedBindingGeneration)
+      && (!expectedCursor || this.reconcileCursors.get(localCgId) === expectedCursor);
+    if (!sub || !isTargetCurrent()) return Promise.resolve();
+    const previous = sub.lastReconciledOrdinal ?? 0;
+    return this.persistContextGraphSubscriptionStrict(
+      localCgId,
+      { ...sub, lastReconciledOrdinal: watermark },
+      undefined,
+      isTargetCurrent,
+    ).then(() => {
+      if (!isTargetCurrent()) return;
+      sub.lastReconciledOrdinal = watermark;
+      this.emitReplication({
+        contextGraphId: localCgId,
+        onChainCgId: sub.onChainId,
+        action: 'cursor-advance',
+        fromWatermark: previous,
+        toWatermark: watermark,
+      });
+    });
   }
 
   toContextGraphReconcileResult(
@@ -3021,10 +3206,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     signal?: AbortSignal,
   ): Promise<void> {
     try {
+      const capturedOnChainId = sub.onChainId;
       const canApply = () => isCurrent()
         && (!(this.subscribedContextGraphs instanceof Map)
-          || this.subscribedContextGraphs.get(localCgId) === sub);
-      if (!canApply() || !sub.onChainId) return;
+          || this.subscribedContextGraphs.get(localCgId) === sub)
+        && sub.onChainId === capturedOnChainId;
+      if (!canApply() || !capturedOnChainId) return;
       // Server-side byte-safe copy is the ONLY safe relocation mechanism; if the
       // backend can't do SPARQL UPDATE we bail rather than risk a lossy JS round-trip.
       if (typeof this.store.update !== 'function') return;
@@ -3046,9 +3233,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
       const DKG = 'http://dkg.io/ontology/';
       const legacyMeta = contextGraphMetaUri(localCgId);
-      const scopedMeta = contextGraphMetaUri(localCgId, sub.onChainId);
+      const scopedMeta = contextGraphMetaUri(localCgId, capturedOnChainId);
       const rootData = contextGraphDataUri(localCgId);
-      const scopedData = contextGraphDataUri(localCgId, sub.onChainId);
+      const scopedData = contextGraphDataUri(localCgId, capturedOnChainId);
       // The publisher's OWN one-shot publish() writes confirmed PUBLIC data to a
       // per-KA verifiable-memory (VM) graph — NOT the legacy root data graph (the
       // receiver/#1259 strand fills root data). So the data reads below look in
@@ -3057,13 +3244,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // the receiver heal; prefix-scanning every VM graph could pull a DIFFERENT
       // KA's triples for a root IRI that recurs across per-KA VM graphs.
 
-      // 2a ASK-guard: is there at least one legacy-only KC (batchId present in
-      // legacy meta, absent in scoped meta)? In steady state this is one ASK per
-      // bound CG and returns false once healed.
+      // 2a ASK-guard: is there at least one incomplete scoped KC? Requiring the
+      // batch id and materialization version together makes a legacy partial
+      // write retryable instead of permanently hiding it from future sweeps.
       const askGuard = await this.store.query(
         `ASK {
            GRAPH <${legacyMeta}> { ?ual <${DKG}batchId> ?b }
-           FILTER NOT EXISTS { GRAPH <${scopedMeta}> { ?ual <${DKG}batchId> ?b } }
+           FILTER NOT EXISTS {
+             GRAPH <${scopedMeta}> {
+               ?ual <${DKG}batchId> ?b ; <${DKG}materializedVersion> ?version
+             }
+           }
          }`,
         { signal, source: 'agent.swm.rsHeal.findLegacyOnly' },
       );
@@ -3073,7 +3264,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const stranded = await this.store.query(
         `SELECT ?ual ?b WHERE {
            GRAPH <${legacyMeta}> { ?ual <${DKG}batchId> ?b }
-           FILTER NOT EXISTS { GRAPH <${scopedMeta}> { ?ual <${DKG}batchId> ?b } }
+           FILTER NOT EXISTS {
+             GRAPH <${scopedMeta}> {
+               ?ual <${DKG}batchId> ?b ; <${DKG}materializedVersion> ?version
+             }
+           }
          }`,
         { signal, source: 'agent.swm.rsHeal.listLegacyOnly' },
       );
@@ -3198,34 +3393,54 @@ export class SwmHostModeMethods extends DKGAgentBase {
               if (!canApply()) return;
             }
 
-            // META copy — server-side. Carries the `<ual>` subject (batchId
-            // discriminator) + the `<ual>/<tokenId>` token rows
-            // (rootEntity/privateMerkleRoot).
+            // `update()` is not an atomic transaction on every supported HTTP
+            // store. Remove the completion marker first, copy metadata without
+            // that marker, and stamp completion only after the copy succeeds.
+            // Any partial copy therefore remains visible to the next heal.
             if (!canApply()) return;
             await update(
-              `INSERT { GRAPH <${scopedMeta}> { ?s ?p ?o } } WHERE {
-                 GRAPH <${legacyMeta}> {
-                   ?s ?p ?o .
-                   FILTER(?s = <${ual}> || STRSTARTS(STR(?s), "${ual}/"))
+              `DELETE WHERE {
+                 GRAPH <${scopedMeta}> {
+                   <${ual}> <${DKG}materializedVersion> ?oldVersion
                  }
                }`,
               [scopedMeta],
             );
             if (!canApply()) return;
-
-            // Stamp so a later stale writer can't clobber.
-            await writeMaterializedVersion(this.store, scopedMeta, ual, version);
-            if (!canApply()) return;
-
-            this.log.info(
-              createOperationContext('system'),
-              `RS heal: relocated stranded legacy KC ${ual} -> scoped cg=${sub.onChainId} (${roots.length} root(s))`,
+            await update(
+              `INSERT {
+                 GRAPH <${scopedMeta}> { ?s ?p ?o }
+               }
+               WHERE {
+                 GRAPH <${legacyMeta}> {
+                   ?s ?p ?o .
+                   FILTER(?s = <${ual}> || STRSTARTS(STR(?s), "${ual}/"))
+                   FILTER(?p != <${DKG}materializedVersion>)
+                 }
+               }`,
+              [scopedMeta],
             );
-          });
+            if (!canApply()) return;
+            await update(
+              `INSERT DATA {
+                 GRAPH <${scopedMeta}> {
+                   <${ual}> <${DKG}materializedVersion> "${version.blockNumber}:${version.txIndex}"
+                 }
+               }`,
+              [scopedMeta],
+            );
+
+            if (canApply()) {
+              this.log.info(
+                createOperationContext('system'),
+                `RS heal: relocated stranded legacy KC ${ual} -> scoped cg=${capturedOnChainId} (${roots.length} root(s))`,
+              );
+            }
+          }, { signal });
         } catch (err) {
           this.log.warn(
             createOperationContext('system'),
-            `RS heal: relocate failed for ${ual} (cg=${sub.onChainId}): ${err instanceof Error ? err.message : String(err)}`,
+            `RS heal: relocate failed for ${ual} (cg=${capturedOnChainId}): ${err instanceof Error ? err.message : String(err)}`,
           );
         }
       }
@@ -3458,7 +3673,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   deleteVmReconcileNegativeCacheEntry(this: DKGAgent, cacheKey: string): void {
     const existing = this.vmReconcileNegativeCache.get(cacheKey);
-    this.vmReconcileNegativeCacheHydrated.add(cacheKey);
+    this.markVmReconcileNegativeCacheHydrated(
+      cacheKey,
+      existing?.localCgId ?? cacheKey.slice(0, Math.max(0, cacheKey.indexOf('\0'))),
+    );
     if (existing) {
       this.vmReconcileNegativeCache.delete(cacheKey);
       const keys = this.vmReconcileNegativeCacheKeysByCg.get(existing.localCgId);
@@ -3481,13 +3699,30 @@ export class SwmHostModeMethods extends DKGAgentBase {
     keys.add(cacheKey);
   }
 
+  markVmReconcileNegativeCacheHydrated(this: DKGAgent, cacheKey: string, localCgId: string): void {
+    // Access order keeps actively reused keys resident while old one-shot
+    // misses fall out. Eviction is fail-open: it only permits another durable
+    // lookup if the same key is encountered later.
+    this.vmReconcileNegativeCacheHydrated.delete(cacheKey);
+    this.vmReconcileNegativeCacheHydrated.set(cacheKey, localCgId);
+    while (
+      this.vmReconcileNegativeCacheHydrated.size
+      > DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES
+    ) {
+      const oldestKey = this.vmReconcileNegativeCacheHydrated.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileNegativeCacheHydrated.delete(oldestKey);
+    }
+  }
+
   async shouldDeferVmReconcileByNegativeCache(this: DKGAgent,
     cacheKey: string,
     localCgId: string,
   ): Promise<boolean> {
     let cached = this.vmReconcileNegativeCache.get(cacheKey);
-    if (!cached && !this.vmReconcileNegativeCacheHydrated.has(cacheKey)) {
-      this.vmReconcileNegativeCacheHydrated.add(cacheKey);
+    const durableStateAlreadyConsulted = this.vmReconcileNegativeCacheHydrated.has(cacheKey);
+    this.markVmReconcileNegativeCacheHydrated(cacheKey, localCgId);
+    if (!cached && !durableStateAlreadyConsulted) {
       try {
         const durable = await this.config.contextGraphSubscriptionStore
           ?.loadVmReconcileNegative?.(cacheKey);
@@ -3621,7 +3856,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       peerTopologyKey: state.peerTopologyKey,
     };
     this.vmReconcileNegativeCache.set(cacheKey, record);
-    this.vmReconcileNegativeCacheHydrated.add(cacheKey);
+    this.markVmReconcileNegativeCacheHydrated(cacheKey, localCgId);
     this.indexVmReconcileNegativeCacheEntry(localCgId, cacheKey);
     const durableStore = this.config.contextGraphSubscriptionStore;
     if (this.vmReconcileSwmGenSupportsDurableNegative(record.swmGen)) {
@@ -3753,6 +3988,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
     if (
       record?.phase === 'backoff'
+      && record.backoffKind === 'clean-absence'
       && (!record.curatorRosterConfirmed || !curatorRosterConfirmed)
     ) {
       // Absence gathered while curator discovery was unavailable must not
@@ -3774,14 +4010,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
 
     if (!record) {
-      if (!this.makeRoomForVmReconcileRotationRecord()) {
-        // Preserve the pressure bound at cap: an unowned target cannot retain
-        // exponential retry state, so running elevated exact transport here
-        // would replay it every sweep. Defer until an expired/resolved slot is
-        // available; this is process-local scheduling, never absence evidence.
-        return { slotKey, suppressed: true };
-      }
-      record = {
+      const nextRecord: VmReconcileRotationRecord = {
         localCgId: target.localCgId,
         onChainCgId: target.onChainCgId,
         ordinal: target.ordinal,
@@ -3795,10 +4024,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
         failures: 0,
         nextRetryAt: 0,
       };
-      this.vmReconcileRotationState.set(slotKey, record);
+      if (!this.installVmReconcileRotationRecord(slotKey, nextRecord)) {
+        // Preserve the pressure bound at cap: an unowned target cannot retain
+        // exponential retry state, so running elevated exact transport here
+        // would replay it every sweep. Defer until an expired/resolved slot is
+        // available; this is process-local scheduling, never absence evidence.
+        return { slotKey, suppressed: true };
+      }
       return {
         slotKey,
-        record: this.vmReconcileRotationState.get(slotKey) === record ? record : undefined,
+        record: nextRecord,
         suppressed: false,
       };
     }
@@ -3807,6 +4042,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       record.candidatePeerIds,
       candidatePeerIds,
     );
+    const rosterProofUpgraded = !record.curatorRosterConfirmed && curatorRosterConfirmed;
     if (!membershipUnchanged) {
       const previousCandidatePeerIds = record.candidatePeerIds;
       const nextCandidatePeerIds = new Set(candidatePeerIds);
@@ -3826,7 +4062,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         record.lastAttemptedPeerId = undefined;
         record.collectionDeadlineAt = now
           + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
-      } else {
+      } else if (!rosterProofUpgraded) {
         // Pure growth preserves valid credits for retained identities, but the
         // newly observed peer is uncredited and immediately breaks backoff.
         record.phase = 'collecting';
@@ -3837,6 +4073,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
       }
     } else {
       record.curatorRosterConfirmed = curatorRosterConfirmed;
+    }
+    if (rosterProofUpgraded) {
+      // A peer response gathered while curator discovery was unconfirmed is
+      // useful transport evidence, not authoritative absence proof. Reprobe
+      // the complete now-authoritative roster even when that roster also grew.
+      record.phase = 'collecting';
+      record.backoffKind = undefined;
+      record.nextRetryAt = 0;
+      record.attemptedPeerIds.clear();
+      record.cleanAbsentPeerIds.clear();
+      record.lastAttemptedPeerId = undefined;
+      record.collectionDeadlineAt = now
+        + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
     }
     if (record.phase === 'backoff') {
       if (now < record.nextRetryAt) {
@@ -3906,23 +4155,75 @@ export class SwmHostModeMethods extends DKGAgentBase {
     ].filter((peerId) => !record.attemptedPeerIds.has(peerId));
   }
 
-  makeRoomForVmReconcileRotationRecord(this: DKGAgent): boolean {
+  findVmReconcileRotationReplacement(
+    this: DKGAgent,
+    requestingCgId?: string,
+  ): [string, VmReconcileRotationRecord] | undefined {
     if (this.vmReconcileRotationState.size < DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
-      return true;
+      return undefined;
     }
-    // Map order is LRU order. Only expired suppression/collection state is
-    // replaceable; evicting an active backoff would turn the state bound into
-    // an immediate network retry loop under a large missing-ordinal backlog.
     const now = this.vmReconcileRotationNow();
-    for (const [key, record] of this.vmReconcileRotationState) {
+    for (const entry of this.vmReconcileRotationState) {
+      const [, record] = entry;
       if (
         (record.phase === 'backoff' && now < record.nextRetryAt)
         || (record.phase === 'collecting' && now < record.collectionDeadlineAt)
       ) continue;
-      this.vmReconcileRotationState.delete(key);
+      return entry;
+    }
+    if (!requestingCgId) return undefined;
+    const countsByCg = new Map<string, number>();
+    for (const record of this.vmReconcileRotationState.values()) {
+      countsByCg.set(record.localCgId, (countsByCg.get(record.localCgId) ?? 0) + 1);
+    }
+    if ((countsByCg.get(requestingCgId) ?? 0) !== 0) return undefined;
+    for (const entry of this.vmReconcileRotationState) {
+      if ((countsByCg.get(entry[1].localCgId) ?? 0) > 1) return entry;
+    }
+    return undefined;
+  }
+
+  canInstallVmReconcileRotationRecord(this: DKGAgent, requestingCgId?: string): boolean {
+    if (this.vmReconcileRotationState.size < DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
       return true;
     }
-    return false;
+    return this.findVmReconcileRotationReplacement(requestingCgId) !== undefined;
+  }
+
+  installVmReconcileRotationRecord(
+    this: DKGAgent,
+    slotKey: string,
+    record: VmReconcileRotationRecord,
+  ): boolean {
+    if (this.vmReconcileRotationClosed || this.vmReconcileRotationState.has(slotKey)) {
+      return false;
+    }
+    const replacement = this.findVmReconcileRotationReplacement(record.localCgId);
+    if (!replacement) {
+      if (this.vmReconcileRotationState.size >= DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
+        return false;
+      }
+      this.vmReconcileRotationState.set(slotKey, record);
+      return this.vmReconcileRotationState.get(slotKey) === record;
+    }
+
+    // Donation and requester installation are one synchronous state transition.
+    // Restore the donor if installation exits or throws before ownership moves.
+    const [replacementKey, replacementRecord] = replacement;
+    let installed = false;
+    this.vmReconcileRotationState.delete(replacementKey);
+    try {
+      if (this.vmReconcileRotationClosed || this.vmReconcileRotationState.has(slotKey)) {
+        return false;
+      }
+      this.vmReconcileRotationState.set(slotKey, record);
+      installed = this.vmReconcileRotationState.get(slotKey) === record;
+      return installed;
+    } finally {
+      if (!installed && !this.vmReconcileRotationState.has(replacementKey)) {
+        this.vmReconcileRotationState.set(replacementKey, replacementRecord);
+      }
+    }
   }
 
   clearVmReconcileRotationStateForContextGraph(
@@ -3933,6 +4234,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     for (const key of this.vmReconcileRotationState.keys()) {
       if (key.startsWith(prefix)) this.vmReconcileRotationState.delete(key);
     }
+    this.vmReconcileRotationAdmissionCursorByCg.delete(localCgId);
   }
 
   closeVmReconcileRotationState(this: DKGAgent): void {
@@ -3943,7 +4245,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // without running the base constructor. Shutdown must remain best-effort
     // for that supported test seam and never mask later teardown failures.
     this.vmReconcileRotationState?.clear();
+    this.vmReconcileRotationAdmissionCursorByCg?.clear();
     this.vmReconcileCuratorPeersByCg?.clear();
+    this.vmReconcileCuratorPageCursorByCg?.clear();
   }
 
   openVmReconcileRotationState(this: DKGAgent): void {
@@ -3951,15 +4255,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
       this.vmReconcileLifecycleController = new AbortController();
     }
     this.vmReconcileRotationClosed = false;
-  }
-
-  rearmVmReconcileRuntimeAfterRestart(this: DKGAgent): void {
-    const dispatcher = this.vmReconcileDispatcher;
-    if (dispatcher?.snapshot().closed) this.vmReconcileDispatcher = undefined;
-    if (this.started && !this.vmReconcileRotationClosed) {
-      this.ensureVmReconcileDispatcher();
-      void this.runVmReconcileSweep();
-    }
   }
 
   vmReconcileRecoveryTargetMatches(
@@ -4006,9 +4301,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
         || unavailablePeerIds.has(candidatePeerId));
     const cleanAbsentFromEveryPeer = [...capturedRecord.candidatePeerIds]
       .every((candidatePeerId) => capturedRecord.cleanAbsentPeerIds.has(candidatePeerId));
-    if (cleanAbsentFromEveryPeer) {
+    if (cleanAbsentFromEveryPeer && capturedRecord.curatorRosterConfirmed) {
       this.enterVmReconcileRotationBackoff(slotKey, capturedRecord, 'clean-absence');
-    } else if (scheduledEveryPeer) {
+    } else if (scheduledEveryPeer && capturedRecord.curatorRosterConfirmed) {
       // This is retry suppression only, never absence proof. It prevents a
       // legacy peer that ignores the exact filter from replaying the same
       // bounded prefix at elevated priority every sweep.
@@ -4095,6 +4390,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
       if (oldestKey === undefined) break;
       this.vmReconcileCuratorPeersByCg.delete(oldestKey);
     }
+    while (
+      this.vmReconcileCuratorPageCursorByCg.size
+      > DKGAgentBase.VM_RECONCILE_CG_STATE_MAX_ENTRIES
+    ) {
+      const oldestKey = this.vmReconcileCuratorPageCursorByCg.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileCuratorPageCursorByCg.delete(oldestKey);
+    }
+    while (
+      this.vmReconcileRotationAdmissionCursorByCg.size
+      > DKGAgentBase.VM_RECONCILE_CG_STATE_MAX_ENTRIES
+    ) {
+      const oldestKey = this.vmReconcileRotationAdmissionCursorByCg.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileRotationAdmissionCursorByCg.delete(oldestKey);
+    }
   }
 
   clearVmReconcileStateForContextGraph(this: DKGAgent, localCgId: string): void {
@@ -4110,6 +4421,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
       }
     }
+    for (const [cacheKey, hydratedLocalCgId] of this.vmReconcileNegativeCacheHydrated) {
+      if (hydratedLocalCgId === localCgId) {
+        this.vmReconcileNegativeCacheHydrated.delete(cacheKey);
+      }
+    }
     void this.config.contextGraphSubscriptionStore
       ?.deleteVmReconcileNegativesForContextGraph?.(localCgId)
       .catch(() => {
@@ -4118,6 +4434,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this.reconcileCursors.delete(localCgId);
     this.clearVmReconcileRotationStateForContextGraph(localCgId);
     this.vmReconcileCuratorPeersByCg.delete(localCgId);
+    this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
     this.vmReconcileFetchCooldownAt.delete(localCgId);
     this.vmReconcileCatchupPeerCursor.delete(localCgId);
     this.vmReconcileCatchupPeerOrder.delete(localCgId);
@@ -4176,9 +4493,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     targets: readonly OrdinalRecoveryTarget[],
     headBlock: number | undefined,
     isTargetCurrent: () => boolean,
+    signal?: AbortSignal,
   ): Promise<PendingOrdinalRecoveryResult> {
     const rotationGeneration = this.vmReconcileLifecycleGeneration;
     const isRecoveryCurrent = () => !this.vmReconcileRotationClosed
+      && !signal?.aborted
       && this.vmReconcileLifecycleGeneration === rotationGeneration
       && isTargetCurrent();
     const ctx = createOperationContext('system');
@@ -4197,6 +4516,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const currentTargets = targets.filter((target) =>
       target.localCgId === localCgId && target.onChainCgId === expectedOnChainCgId);
     if (currentTargets.length === 0) return noRecovery();
+    const admissionCursor = (
+      this.vmReconcileRotationAdmissionCursorByCg.get(localCgId) ?? 0
+    ) % currentTargets.length;
+    const admissionDistance = (index: number) => (
+      index - admissionCursor + currentTargets.length
+    ) % currentTargets.length;
 
     // Suppression consults only the already-observed, capped connection view.
     // This is intentionally before curator resolution, dialing, protocol waits,
@@ -4204,33 +4529,71 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // production ordinal/finalization check proved it still pending locally.
     const observedCandidatePeerIds = this.vmReconcileObservedCandidatePeerIds(localCgId);
     const now = this.vmReconcileRotationNow();
-    const initialPreparations = currentTargets.map((target) => {
+    const initiallyOwnedSlotKeys = new Set(currentTargets.flatMap((target) => {
       const slotKey = this.vmReconcileRotationSlotKey(target);
-      const existing = this.vmReconcileRotationState.get(slotKey);
-      if (!existing || existing.fingerprint !== this.vmReconcileRotationFingerprint(target)) {
-        // The pre-network pass only consults already-earned suppression. A new
-        // cycle is installed after curator resolution so its first roster is
-        // authoritative-first; a stale fingerprint is invalidated immediately.
-        if (existing) this.vmReconcileRotationState.delete(slotKey);
-        return {
-          target,
-          prepared: {
-            slotKey,
-            record: undefined,
-            suppressed: this.vmReconcileRotationClosed,
-          },
-        };
-      }
-      return {
+      const record = this.vmReconcileRotationState.get(slotKey);
+      return record?.fingerprint === this.vmReconcileRotationFingerprint(target)
+        ? [slotKey]
+        : [];
+    }));
+    const hasUnownedTarget = currentTargets.some((target) =>
+      !initiallyOwnedSlotKeys.has(this.vmReconcileRotationSlotKey(target)));
+    const reservedReplacementSlotKey = hasUnownedTarget
+      ? this.findVmReconcileRotationReplacement(localCgId)?.[0]
+      : undefined;
+    const initialPreparations = currentTargets
+      .map((target, index) => ({
+        index,
         target,
-        prepared: this.prepareVmReconcileRotationTarget(
+        hasOwnedRecord: initiallyOwnedSlotKeys.has(this.vmReconcileRotationSlotKey(target)),
+      }))
+      // Use the same fair admission order before network work. Besides handing
+      // expired capacity to a waiter, this makes an all-live saturated cache
+      // return below without paying curator-resolution cost for work that
+      // cannot retain its retry state.
+      .sort((left, right) => Number(left.hasOwnedRecord) - Number(right.hasOwnedRecord)
+        || admissionDistance(left.index) - admissionDistance(right.index))
+      .map(({ index, target }) => {
+        const slotKey = this.vmReconcileRotationSlotKey(target);
+        const existing = this.vmReconcileRotationState.get(slotKey);
+        if (!existing || existing.fingerprint !== this.vmReconcileRotationFingerprint(target)) {
+          // The pre-network pass only consults already-earned suppression. A new
+          // cycle is installed after curator resolution so its first roster is
+          // authoritative-first; a stale fingerprint is invalidated immediately.
+          if (existing) this.vmReconcileRotationState.delete(slotKey);
+          const capacityAvailable = this.canInstallVmReconcileRotationRecord(localCgId);
+          return {
+            index,
+            target,
+            prepared: {
+              slotKey,
+              record: undefined,
+              suppressed: this.vmReconcileRotationClosed || !capacityAvailable,
+            },
+          };
+        }
+        if (slotKey === reservedReplacementSlotKey) {
+          // Keep the donor intact, but do not renew it before the waiter reaches
+          // post-resolution installation. An earlier lifecycle exit leaves the
+          // original record untouched; a successful install replaces it atomically.
+          return {
+            index,
+            target,
+            prepared: { slotKey, record: existing, suppressed: true },
+          };
+        }
+        return {
+          index,
           target,
-          observedCandidatePeerIds,
-          now,
-          existing.curatorRosterConfirmed,
-        ),
-      };
-    });
+          prepared: this.prepareVmReconcileRotationTarget(
+            target,
+            observedCandidatePeerIds,
+            now,
+            existing.curatorRosterConfirmed,
+          ),
+        };
+      })
+      .sort((left, right) => left.index - right.index);
     const initiallyEligible = initialPreparations
       .filter(({ prepared }) => !prepared.suppressed)
       .map(({ target }) => target);
@@ -4270,33 +4633,72 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const approvedCuratorPeerId = this.preferredSyncPeers.get(localCgId);
     const cachedCuratorPeerIds = [
       ...(this.vmReconcileCuratorPeersByCg.get(localCgId) ?? []),
-    ].sort((left, right) => left.localeCompare(right));
-    const curatorResolution = await this.resolveCuratorPeerIdsForCg(localCgId)
+    ];
+    const curatorPageCursor = this.vmReconcileCuratorPageCursorByCg.get(localCgId);
+    const curatorResolution = await this.resolveCuratorPeerIdsForCg(localCgId, {
+      maxPeerIds: DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX,
+      // Once overflow is proven, expose exactly one new ordered peer per pass.
+      // One target can spend only one peer attempt, so advancing by more would
+      // skip candidates when a CG has a single missing KA.
+      pagePeerIds: 1,
+      afterPeerId: curatorPageCursor,
+      signal,
+      isCurrent: isRecoveryCurrent,
+    })
       .catch(() => ({
         peerIds: [] as string[],
         curatorIsLocal: false,
         legacyTripleResolved: false,
         lookupFailed: true,
+        overflowed: false,
+        nextPageAfterPeerId: undefined,
       }));
     if (!isRecoveryCurrent()) return noRecovery();
     const allResolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
       .filter((peerId) => peerId && peerId !== this.peerId))]
       .sort((left, right) => left.localeCompare(right));
-    const curatorRosterOverflow = allResolvedCuratorPeerIds.length
-      > DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX;
+    const curatorRosterOverflow = curatorResolution.overflowed === true
+      || allResolvedCuratorPeerIds.length > DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX;
     if (curatorRosterOverflow) {
       this.log.warn(
         ctx,
         `VM exact fetch curator roster for "${localCgId}" exceeds bounded proof capacity `
-          + `(${allResolvedCuratorPeerIds.length}>${DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX}); `
-          + 'retaining prior roster without negative-proof suppression',
+          + `(ordered transport page=${allResolvedCuratorPeerIds.length}, `
+          + `proofCap=${DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX}); `
+          + 'walking the registry without negative-proof suppression',
       );
     }
     const resolutionSucceeded = curatorResolution.lookupFailed !== true
       && !curatorRosterOverflow;
-    const resolvedCuratorPeerIds = resolutionSucceeded
-      ? allResolvedCuratorPeerIds
-      : [];
+    // Even an invalid oversized result remains useful for bounded fail-open
+    // transport. Rotate a bounded window through it using the existing cache as
+    // the cursor: a fixed prefix (or a formerly authoritative cached roster)
+    // could otherwise hide a newly added holder forever. The window remains
+    // explicitly unconfirmed below, so it can never support absence proof.
+    const overflowTransportUniverse = [...new Set([
+      ...allResolvedCuratorPeerIds,
+      approvedCuratorPeerId,
+    ].filter((peerId): peerId is string => Boolean(peerId && peerId !== this.peerId)))];
+    const cachedOverflowStart = cachedCuratorPeerIds.length > 0
+      ? overflowTransportUniverse.indexOf(cachedCuratorPeerIds[0]!)
+      : -1;
+    const overflowWindowStart = cachedOverflowStart < 0
+      ? 0
+      : (cachedOverflowStart + 1) % overflowTransportUniverse.length;
+    const overflowTransportPeerIds = Array.from(
+      { length: Math.min(
+        DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX,
+        overflowTransportUniverse.length,
+      ) },
+      (_, offset) => overflowTransportUniverse[
+        (overflowWindowStart + offset) % overflowTransportUniverse.length
+      ]!,
+    );
+    const resolvedCuratorPeerIds = curatorRosterOverflow
+      ? curatorResolution.nextPageAfterPeerId
+        ? allResolvedCuratorPeerIds
+        : overflowTransportPeerIds
+      : allResolvedCuratorPeerIds;
     let legacyPreferredPeerId: string | undefined;
     if (resolutionSucceeded && !curatorResolution.curatorIsLocal
       && resolvedCuratorPeerIds.length === 0) {
@@ -4305,7 +4707,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (!isRecoveryCurrent()) return noRecovery();
     const authoritativeCuratorPeerIds = resolutionSucceeded
       ? resolvedCuratorPeerIds
-      : cachedCuratorPeerIds;
+      : curatorRosterOverflow
+        ? resolvedCuratorPeerIds
+        : cachedCuratorPeerIds;
     const curatorPeerIds = [...new Set([
       ...authoritativeCuratorPeerIds,
       legacyPreferredPeerId,
@@ -4315,7 +4719,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // Persist the bounded full authoritative roster. Individual passes still
     // connect/probe at most VM_RECONCILE_EXACT_PEER_MAX peers, while each
     // target's rotation record carries progress across those windows.
-    if (resolutionSucceeded) this.vmReconcileCuratorPeersByCg.delete(localCgId);
+    if (resolutionSucceeded) {
+      this.vmReconcileCuratorPeersByCg.delete(localCgId);
+      this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
+    } else if (curatorResolution.nextPageAfterPeerId) {
+      this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
+      this.vmReconcileCuratorPageCursorByCg.set(
+        localCgId,
+        curatorResolution.nextPageAfterPeerId,
+      );
+    }
     if (!curatorResolution.curatorIsLocal && curatorPeerIds.length > 0) {
       this.vmReconcileCuratorPeersByCg.delete(localCgId);
       this.vmReconcileCuratorPeersByCg.set(localCgId, curatorPeerIds);
@@ -4338,13 +4751,37 @@ export class SwmHostModeMethods extends DKGAgentBase {
       .map((target, index) => ({
         index,
         target,
+        hasOwnedRecord: initiallyOwnedSlotKeys.has(this.vmReconcileRotationSlotKey(target)),
+      }))
+      // At a full cap, give deferred targets first claim on an expired slot.
+      // Otherwise an expired owner encountered first would renew itself before
+      // any waiter could enter, starving stable-order overflow indefinitely.
+      .sort((left, right) => Number(left.hasOwnedRecord) - Number(right.hasOwnedRecord)
+        || admissionDistance(left.index) - admissionDistance(right.index))
+      .map(({ index, target }) => ({
+        index,
+        target,
         prepared: this.prepareVmReconcileRotationTarget(
           target,
           orderedPeerIds,
           this.vmReconcileRotationNow(),
           resolutionSucceeded,
         ),
-      }));
+      }))
+      .sort((left, right) => left.index - right.index);
+    const newlyAdmitted = preparedEntries
+      .filter(({ target, prepared }) => prepared.record
+        && !initiallyOwnedSlotKeys.has(this.vmReconcileRotationSlotKey(target)));
+    if (newlyAdmitted.length > 0) {
+      const lastAdmitted = newlyAdmitted.reduce((latest, entry) => (
+        admissionDistance(entry.index) > admissionDistance(latest.index) ? entry : latest
+      ));
+      this.vmReconcileRotationAdmissionCursorByCg.delete(localCgId);
+      this.vmReconcileRotationAdmissionCursorByCg.set(
+        localCgId,
+        (lastAdmitted.index + 1) % currentTargets.length,
+      );
+    }
     const eligible = preparedEntries
       .map((entry) => {
         const { record } = entry.prepared;
@@ -4397,8 +4834,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
       // Rotate every physical outcome, including incomplete responses, without
       // conflating the attempt cursor with clean-absence evidence. Try the
-      // target's next available peer; protocol/admission failures remain
-      // uncredited and fall through to a later candidate in this same pass.
+      // target's next available peer. Protocol/admission failures remain
+      // uncredited, but consume this target's turn so another missing KA gets
+      // the next physical peer slot in the same bounded pass.
       let peerId: string | undefined;
       const candidateOrder = installedRecord
         ? this.vmReconcileUncreditedCandidateOrder(installedRecord)
@@ -4410,6 +4848,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           && consideredPeerIds.size >= DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX
         ) break;
         consideredPeerIds.add(candidatePeerId);
+        attemptedOrdinals.add(target.ordinal);
         if (installedRecord) {
           installedRecord.lastAttemptedPeerId = candidatePeerId;
           installedRecord.attemptedPeerIds.add(candidatePeerId);
@@ -4422,7 +4861,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         }
         let connectedPeer = connectedByPeerId.get(candidatePeerId);
         if (!connectedPeer) {
-          await this.ensurePeerConnected(candidatePeerId).catch((error) => {
+          await this.ensurePeerConnected(candidatePeerId, { signal }).catch((error) => {
             this.log.info(
               ctx,
               `VM exact fetch could not connect candidate peer ${candidatePeerId.slice(-8)}: ${error instanceof Error ? error.message : String(error)}`,
@@ -4436,12 +4875,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
         }
         recoveryWorkRan = true;
         const protocolReady = connectedPeer
-          ? await this.waitForSyncProtocol(connectedPeer)
+          ? await this.waitForSyncProtocol(connectedPeer, signal)
           : false;
         if (!isRecoveryCurrent()) return noRecovery();
         if (!connectedPeer || !protocolReady) {
           unavailablePeerIds.add(candidatePeerId);
-          continue;
+          break;
         }
         // Network boundary: a merely-connected peer is not necessarily
         // admitted to this DKG network. Never send an authenticated exact
@@ -4450,11 +4889,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
           candidatePeerId,
           ctx,
           'VM exact fetch',
+          signal,
         );
         if (!isRecoveryCurrent()) return noRecovery();
         if (!peerAdmitted) {
           unavailablePeerIds.add(candidatePeerId);
-          continue;
+          break;
         }
         peerId = candidatePeerId;
         break;
@@ -4479,7 +4919,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // consumes at most one peer attempt per eligible pass. A still-pending
       // item rotates behind untouched work so one unavailable KA cannot spend
       // every peer budget and starve the rest of the queue.
-      if (attemptedOrdinals.has(target.ordinal)) break;
       if (!isRecoveryCurrent()) return noRecovery();
       this.emitReplication({
         contextGraphId: localCgId,
@@ -4493,7 +4932,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
       let disposition: 'found' | 'clean-absent' | 'incomplete' = 'incomplete';
       try {
-        attemptedOrdinals.add(target.ordinal);
         if (installedRecord) {
           installedRecord.lastAttemptedPeerId = peerId;
           this.touchVmReconcileRotationRecord(
@@ -4505,6 +4943,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           peerId,
           localCgId,
           [target.ual],
+          { signal, isCurrent: isRecoveryCurrent },
         );
         const { result } = detailed;
         disposition = detailed.disposition;

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -245,6 +245,7 @@ import {
 import {
   ContextGraphOnChainIdUnresolvedError,
   VmReconcileUnavailableError,
+  VmReconcileQueueClosedError,
   type ContextGraphReconcileResult,
   type VmReconcileSource,
 } from './vm-reconcile-service.js';
@@ -2569,17 +2570,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
    * burst of live nudges) collapse into one sweep per CG.
    */
   async runVmReconcileSweep(this: DKGAgent): Promise<void> {
+    const lifecycleGeneration = this.vmReconcileLifecycleGeneration;
+    const isLifecycleCurrent = () => !this.vmReconcileRotationClosed
+      && this.vmReconcileLifecycleGeneration === lifecycleGeneration;
     const dispatcher = this.vmReconcileDispatcher;
-    if (!this.vmReconcileEnabled() || !dispatcher) return;
+    if (!isLifecycleCurrent() || !this.vmReconcileEnabled() || !dispatcher) return;
     if (this.vmReconcileSweepInFlight) return this.vmReconcileSweepInFlight;
     const running = (async () => {
       const eligible: string[] = [];
       for (const [localCgId, sub] of this.subscribedContextGraphs) {
+        if (!isLifecycleCurrent()) return;
         // GH #1098 — self-prime onChainId for a pre-subscribed PUBLIC member CG
         // (subscribed BEFORE its first publish, so unbound) before the skip-gate
         // below would pass it over. Shared with the live KACG nudge.
         if (sub.subscribed && !sub.onChainId) {
           await this.selfPrimeSubscriptionOnChainId(localCgId, sub);
+          if (!isLifecycleCurrent()) return;
         }
         // Member subscriptions AND Phase D core-hosted public CGs get swept.
         if ((!sub.subscribed && !sub.coreHosted) || !sub.onChainId) continue;
@@ -2596,9 +2602,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // foreground live/manual work can still enter the unified dispatcher.
       const start = this.vmReconcileSweepCursor % eligible.length;
       for (let offset = 0; offset < eligible.length; offset += 1) {
+        if (!isLifecycleCurrent()) return;
         const index = (start + offset) % eligible.length;
         await dispatcher.dispatch(eligible[index]!, 'periodic').catch(() => undefined);
       }
+      if (!isLifecycleCurrent()) return;
       this.vmReconcileSweepCursor = (start + 1) % eligible.length;
     })();
     this.vmReconcileSweepInFlight = running;
@@ -2748,24 +2756,31 @@ export class SwmHostModeMethods extends DKGAgentBase {
     localCgId: string,
     source: VmReconcileSource,
   ): Promise<ContextGraphReconcileResult> {
+    const lifecycleGeneration = this.vmReconcileLifecycleGeneration;
+    const isLifecycleCurrent = () => !this.vmReconcileRotationClosed
+      && this.vmReconcileLifecycleGeneration === lifecycleGeneration;
+    if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
     const target = await this.resolveVmReconcileTarget(localCgId);
+    if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
 
     // Keep the legacy-label -> scoped-VM migration in the admitted lane and
     // before the evidence gate. A current watermark can still need this repair.
     await this.healStrandedScopedKCs(localCgId, target.sub);
+    if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
 
     const result = await reconcileContextGraph(
-      this.createVmReconcileDeps(localCgId),
+      this.createVmReconcileDeps(localCgId, lifecycleGeneration),
       target.cursor,
       localCgId,
       target.onChainCgId,
     );
+    if (!isLifecycleCurrent()) throw new VmReconcileQueueClosedError();
     const response = this.toContextGraphReconcileResult(localCgId, source, target, result);
     this.emitVmReconcileTelemetry(localCgId, target, result, response.status);
     // Queue one trailing slice while this key is still active. The dispatcher
     // places it behind already-waiting live CGs, so a large graph makes steady
     // progress without monopolising the only VM worker.
-    if (result.hasMore || result.staleTarget) {
+    if (isLifecycleCurrent() && (result.hasMore || result.staleTarget)) {
       this.vmReconcileDispatcher?.triggerLive(localCgId);
     }
     return response;
@@ -2804,19 +2819,26 @@ export class SwmHostModeMethods extends DKGAgentBase {
     };
   }
 
-  createVmReconcileDeps(this: DKGAgent, localCgId: string): ChainReconcilerDeps {
+  createVmReconcileDeps(
+    this: DKGAgent,
+    localCgId: string,
+    lifecycleGeneration = this.vmReconcileLifecycleGeneration,
+  ): ChainReconcilerDeps {
     const capturedSub = this.subscribedContextGraphs.get(localCgId);
     const capturedOnChainId = capturedSub?.onChainId;
     const capturedCursor = this.reconcileCursors.get(localCgId);
     const isTargetCurrent = (): boolean => {
       const current = this.subscribedContextGraphs.get(localCgId);
-      return current === capturedSub
+      return !this.vmReconcileRotationClosed
+        && this.vmReconcileLifecycleGeneration === lifecycleGeneration
+        && current === capturedSub
         && current?.onChainId === capturedOnChainId
         && this.reconcileCursors.get(localCgId) === capturedCursor;
     };
     return {
       getKCCount: async (cg) => {
         const head = Number(await this.chain.getContextGraphKCCount!(cg));
+        if (!isTargetCurrent()) throw new VmReconcileQueueClosedError();
         if (!Number.isSafeInteger(head) || head < 0) {
           throw new Error(`Invalid on-chain KC count for context graph "${localCgId}": ${head}`);
         }
@@ -2826,7 +2848,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
         // Capability-absent chains disable the reorg gate; transient RPC
         // failures still throw so the durable watermark cannot advance.
         if (typeof this.chain.getBlockNumber !== 'function') return undefined;
-        return await this.chain.getBlockNumber();
+        const headBlock = await this.chain.getBlockNumber();
+        if (!isTargetCurrent()) throw new VmReconcileQueueClosedError();
+        return headBlock;
       },
       reconcileOrdinal: (lcg, ocg, ordinal, headBlock) =>
         this.reconcileChainOrdinal(lcg, ocg, ordinal, headBlock, {
@@ -2839,6 +2863,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       maxOrdinalConcurrency: DKGAgentBase.VM_RECONCILE_ORDINAL_CONCURRENCY,
       isTargetCurrent: () => isTargetCurrent(),
       persistWatermark: (lcg, watermark) => {
+        if (!isTargetCurrent()) return;
         const sub = this.subscribedContextGraphs.get(lcg);
         if (!sub) return;
         const previous = sub.lastReconciledOrdinal ?? 0;
@@ -3639,6 +3664,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     target: OrdinalRecoveryTarget,
     candidatePeerIds: readonly string[],
     now: number,
+    curatorRosterConfirmed = true,
   ): {
     slotKey: string;
     record?: VmReconcileRotationRecord;
@@ -3650,6 +3676,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const fingerprint = this.vmReconcileRotationFingerprint(target);
     let record = this.vmReconcileRotationState.get(slotKey);
     if (record && record.fingerprint !== fingerprint) {
+      this.vmReconcileRotationState.delete(slotKey);
+      record = undefined;
+    }
+    if (record?.phase === 'backoff' && !record.curatorRosterConfirmed) {
+      // Absence gathered while curator discovery was unavailable must not
+      // suppress the next lookup: that lookup may reveal the only holder.
       this.vmReconcileRotationState.delete(slotKey);
       record = undefined;
     }
@@ -3682,6 +3714,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         candidatePeerIds: new Set(candidatePeerIds),
         attemptedPeerIds: new Set(),
         cleanAbsentPeerIds: new Set(),
+        curatorRosterConfirmed,
         collectionDeadlineAt: now + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
         failures: 0,
         nextRetryAt: 0,
@@ -3702,6 +3735,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const previousCandidatePeerIds = record.candidatePeerIds;
       const nextCandidatePeerIds = new Set(candidatePeerIds);
       record.candidatePeerIds = new Set(candidatePeerIds);
+      record.curatorRosterConfirmed = curatorRosterConfirmed;
       const removedPeer = [...previousCandidatePeerIds]
         .some((peerId) => !nextCandidatePeerIds.has(peerId));
       if (removedPeer) {
@@ -3723,7 +3757,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
         record.collectionDeadlineAt = now
           + DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS;
       }
-    } else if (record.phase === 'backoff') {
+    } else if (curatorRosterConfirmed) {
+      record.curatorRosterConfirmed = true;
+    }
+    if (record.phase === 'backoff') {
       if (now < record.nextRetryAt) {
         this.touchVmReconcileRotationRecord(slotKey, record);
         return { slotKey, record, suppressed: true };
@@ -3818,7 +3855,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   closeVmReconcileRotationState(this: DKGAgent): void {
-    this.vmReconcileRotationGeneration = (this.vmReconcileRotationGeneration ?? 0) + 1;
+    this.vmReconcileLifecycleGeneration = (this.vmReconcileLifecycleGeneration ?? 0) + 1;
     this.vmReconcileRotationClosed = true;
     // Some lifecycle tests intentionally construct a narrow partial agent
     // without running the base constructor. Shutdown must remain best-effort
@@ -3829,6 +3866,35 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   openVmReconcileRotationState(this: DKGAgent): void {
     this.vmReconcileRotationClosed = false;
+  }
+
+  rearmVmReconcileRuntimeAfterRestart(this: DKGAgent): void {
+    const dispatcher = this.vmReconcileDispatcher;
+    if (!dispatcher?.snapshot().closed) return;
+    const sweep = this.vmReconcileSweepInFlight;
+    if (dispatcher.snapshot().active === 0 && !sweep) {
+      this.vmReconcileDispatcher = undefined;
+      return;
+    }
+    if (this.vmReconcileRetiringDispatcher === dispatcher) return;
+
+    this.vmReconcileRetiringDispatcher = dispatcher;
+    const retirement = (async () => {
+      await dispatcher.waitForIdle();
+      if (sweep) await sweep.catch(() => undefined);
+      if (this.vmReconcileRetiringDispatcher !== dispatcher) return;
+      this.vmReconcileRetiringDispatcher = undefined;
+      this.vmReconcileRetirementInFlight = null;
+      if (this.vmReconcileDispatcher === dispatcher) this.vmReconcileDispatcher = undefined;
+      if (
+        this.started
+        && !this.vmReconcileRotationClosed
+      ) {
+        this.ensureVmReconcileDispatcher();
+        void this.runVmReconcileSweep();
+      }
+    })();
+    this.vmReconcileRetirementInFlight = retirement;
   }
 
   vmReconcileRecoveryTargetMatches(
@@ -4046,9 +4112,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
     headBlock: number | undefined,
     isTargetCurrent: () => boolean,
   ): Promise<PendingOrdinalRecoveryResult> {
-    const rotationGeneration = this.vmReconcileRotationGeneration;
+    const rotationGeneration = this.vmReconcileLifecycleGeneration;
     const isRecoveryCurrent = () => !this.vmReconcileRotationClosed
-      && this.vmReconcileRotationGeneration === rotationGeneration
+      && this.vmReconcileLifecycleGeneration === rotationGeneration
       && isTargetCurrent();
     const ctx = createOperationContext('system');
     const noRecovery = (
@@ -4096,6 +4162,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           target,
           observedCandidatePeerIds,
           now,
+          existing.curatorRosterConfirmed,
         ),
       };
     });
@@ -4208,6 +4275,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           target,
           orderedPeerIds,
           this.vmReconcileRotationNow(),
+          resolutionSucceeded || cachedCuratorPeerIds.length > 0,
         ),
       }));
     const eligible = preparedEntries

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -480,6 +480,11 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
     if (!existing) return;
 
+    // A host-only Core may continue chain reconciliation after member
+    // unsubscribe, but peer-rotation evidence collected under the member
+    // lifecycle must not survive that ownership transition.
+    this.clearVmReconcileRotationStateForContextGraph(contextGraphId);
+
     // Drop from the active sync scope so background sweeps no longer treat
     // this as a subscribed CG to keep current.
     const syncSet = new Set<string>(this.config.syncContextGraphs ?? []);

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -766,7 +766,11 @@ export interface VmReconcileRotationRecord {
   /** Peers physically attempted during the current proof cycle. */
   attemptedPeerIds: Set<string>;
   cleanAbsentPeerIds: Set<string>;
-  /** The cycle was built after a successful curator lookup or from a cached successful roster. */
+  /**
+   * A process-local curator lookup completed (or its bounded cached roster was
+   * reused). This is not cryptographic or network-wide completeness evidence;
+   * observed roster changes invalidate the cycle and backoff is time-bounded.
+   */
   curatorRosterConfirmed: boolean;
   /** Monotonic bound after which a partial clean-absence proof restarts. */
   collectionDeadlineAt: number;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -761,10 +761,10 @@ export interface VmReconcileRotationRecord {
   fingerprint: string;
   phase: 'collecting' | 'backoff';
   candidatePeerIds: Set<string>;
-  /** Peers physically attempted during the current bounded retry cycle. */
+  /** Peers physically attempted during the current proof cycle. */
   attemptedPeerIds: Set<string>;
   cleanAbsentPeerIds: Set<string>;
-  /** Monotonic bound after which an incomplete collection retries every peer. */
+  /** Monotonic bound after which a partial clean-absence proof restarts. */
   collectionDeadlineAt: number;
   /** Cursor only; every physical attempt advances it, regardless of outcome. */
   lastAttemptedPeerId?: string;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -760,6 +760,8 @@ export interface VmReconcileRotationRecord {
   ordinal: number;
   fingerprint: string;
   phase: 'collecting' | 'backoff';
+  /** Backoff cause; only `clean-absence` represents a completed absence proof. */
+  backoffReason?: 'clean-absence' | 'no-progress';
   candidatePeerIds: Set<string>;
   /** Peers physically attempted during the current proof cycle. */
   attemptedPeerIds: Set<string>;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -760,8 +760,6 @@ export interface VmReconcileRotationRecord {
   ordinal: number;
   fingerprint: string;
   phase: 'collecting' | 'backoff';
-  /** Backoff cause; only `clean-absence` represents a completed absence proof. */
-  backoffReason?: 'clean-absence' | 'no-progress';
   candidatePeerIds: Set<string>;
   /** Peers physically attempted during the current proof cycle. */
   attemptedPeerIds: Set<string>;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -760,6 +760,8 @@ export interface VmReconcileRotationRecord {
   ordinal: number;
   fingerprint: string;
   phase: 'collecting' | 'backoff';
+  /** Retry suppression is distinct from authenticated clean-absence proof. */
+  backoffKind?: 'clean-absence' | 'incomplete-cycle';
   candidatePeerIds: Set<string>;
   /** Peers physically attempted during the current proof cycle. */
   attemptedPeerIds: Set<string>;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -761,6 +761,8 @@ export interface VmReconcileRotationRecord {
   fingerprint: string;
   phase: 'collecting' | 'backoff';
   candidatePeerIds: Set<string>;
+  /** Peers physically attempted during the current bounded retry cycle. */
+  attemptedPeerIds: Set<string>;
   cleanAbsentPeerIds: Set<string>;
   /** Monotonic bound after which an incomplete collection retries every peer. */
   collectionDeadlineAt: number;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -764,6 +764,8 @@ export interface VmReconcileRotationRecord {
   /** Peers physically attempted during the current proof cycle. */
   attemptedPeerIds: Set<string>;
   cleanAbsentPeerIds: Set<string>;
+  /** The cycle was built after a successful curator lookup or from a cached successful roster. */
+  curatorRosterConfirmed: boolean;
   /** Monotonic bound after which a partial clean-absence proof restarts. */
   collectionDeadlineAt: number;
   /** Cursor only; every physical attempt advances it, regardless of outcome. */

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -753,6 +753,23 @@ export interface VmReconcileNegativeRecord {
   peerTopologyKey: string;
 }
 
+/** Process-local evidence for one chain-ordinal exact-recovery rotation. */
+export interface VmReconcileRotationRecord {
+  localCgId: string;
+  onChainCgId: string;
+  ordinal: number;
+  fingerprint: string;
+  phase: 'collecting' | 'backoff';
+  candidatePeerIds: Set<string>;
+  cleanAbsentPeerIds: Set<string>;
+  /** Monotonic bound after which an incomplete collection retries every peer. */
+  collectionDeadlineAt: number;
+  /** Cursor only; every physical attempt advances it, regardless of outcome. */
+  lastAttemptedPeerId?: string;
+  failures: number;
+  nextRetryAt: number;
+}
+
 export interface ContextGraphSubscriptionRehydrationStatus {
   /** Non-system persisted rows governed by the rehydration cap. */
   persistedTotal: number;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1678,6 +1678,9 @@ export class DKGAgent extends DKGAgentBase {
     // are rejected immediately and therefore can never start after shutdown
     // begins; an already-active pass gets a bounded grace period because
     // cancelling midway could strand a partially applied VM transition.
+    // Clear exact-absence rotations first so a late in-flight response cannot
+    // restore process-local suppression while the dispatcher drains.
+    this.closeVmReconcileRotationState();
     const vmReconcileDispatcher = this.vmReconcileDispatcher;
     if (vmReconcileDispatcher) {
       const drain = vmReconcileDispatcher.close();

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1682,8 +1682,12 @@ export class DKGAgent extends DKGAgentBase {
     // restore process-local suppression while the dispatcher drains.
     this.closeVmReconcileRotationState();
     const vmReconcileDispatcher = this.vmReconcileDispatcher;
-    if (vmReconcileDispatcher) {
-      const drain = vmReconcileDispatcher.close();
+    const vmReconcileSweep = this.vmReconcileSweepInFlight;
+    if (vmReconcileDispatcher || vmReconcileSweep) {
+      const drains: Promise<unknown>[] = [];
+      if (vmReconcileDispatcher) drains.push(vmReconcileDispatcher.close());
+      if (vmReconcileSweep) drains.push(vmReconcileSweep.catch(() => undefined));
+      const drain = Promise.all(drains);
       let drainTimedOut = false;
       let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       const timeout = new Promise<void>((resolve) => {
@@ -1698,9 +1702,18 @@ export class DKGAgent extends DKGAgentBase {
       if (drainTimedOut) {
         this.log.warn(
           createOperationContext('system'),
-          `DKGAgent.stop: ${vmReconcileDispatcher.snapshot().active} VM reconcile job(s) still active after ${DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS}ms drain bound — proceeding with shutdown`,
+          `DKGAgent.stop: ${vmReconcileDispatcher?.snapshot().active ?? 0} VM reconcile job(s) still active after ${DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS}ms drain bound${vmReconcileSweep ? ' (sweep pending)' : ''} — proceeding with shutdown`,
         );
       }
+    }
+    // A timed-out dependency may ignore cancellation forever. Detach the old
+    // runtime by identity after the bounded drain; generation/signal fences
+    // prevent its late continuations from mutating the next node lifecycle.
+    if (this.vmReconcileDispatcher === vmReconcileDispatcher) {
+      this.vmReconcileDispatcher = undefined;
+    }
+    if (this.vmReconcileSweepInFlight === vmReconcileSweep) {
+      this.vmReconcileSweepInFlight = null;
     }
     this.coreHostRecordingsClosed = true;
     await this.drainCoreHostRecordings();

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -396,6 +396,8 @@ import {
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase, createListContextGraphsCacheInvalidatingStore } from './dkg-agent-base.js';
+import { VmReconcileShutdownTimeoutError } from './vm-reconcile-service.js';
+import { ContextGraphMembershipPersistShutdownTimeoutError } from './context-graph-membership-persist-scheduler.js';
 import { reconcileAndAllocateKaNumber } from './allocator.js';
 import { applyMixins } from './dkg-agent-apply-mixins.js';
 import { OwnershipMethods } from './dkg-agent-ownership.js';
@@ -1630,14 +1632,22 @@ export class DKGAgent extends DKGAgentBase {
 
   async stop(): Promise<void> {
     if (!this.started) return;
-    if (this.chainPoller) {
-      // Await so any in-flight poll (and its HTTP keep-alive socket) settles
-      // BEFORE we tear down the chain adapter — otherwise the RPC connection
-      // closure surfaces as an `ECONNRESET` unhandled rejection from inside
-      // ethers (the same flake that has been hitting `publisher [2/4]` in CI).
-      await this.chainPoller.stop();
-      this.chainPoller = null;
-    }
+    // Fence membership persistence before any network callback can enqueue
+    // more work; the physical drain below completes before store teardown.
+    const membershipPersistDrain = this.contextGraphMembershipPersistence?.closeAndDrain()
+      ?? Promise.resolve();
+    // Invalidate VM reconcile callbacks before waiting for the chain poller.
+    // A poll can be inside the KACG nudge's self-prime lookup; aborting the
+    // lifecycle first lets that lookup's bounded race release poller shutdown.
+    this.vmReconcileRuntimeReady = false;
+    this.graphScopedStoreClosed = true;
+    this.closeVmReconcileRotationState();
+    const chainPoller = this.chainPoller;
+    // stop() fences new poll admission synchronously, but its in-flight poll
+    // joins the bounded physical-retirement drain below. An adapter that
+    // ignores cancellation must quarantine shutdown instead of preventing the
+    // retirement timeout from ever being reached.
+    const chainPollerDrain = chainPoller?.stop();
     if (this.swmCleanupTimer) {
       clearInterval(this.swmCleanupTimer);
       this.swmCleanupTimer = null;
@@ -1676,45 +1686,98 @@ export class DKGAgent extends DKGAgentBase {
     }
     // Close admission before any network/store teardown. Pending reconciles
     // are rejected immediately and therefore can never start after shutdown
-    // begins; an already-active pass gets a bounded grace period because
-    // cancelling midway could strand a partially applied VM transition.
-    // Clear exact-absence rotations first so a late in-flight response cannot
-    // restore process-local suppression while the dispatcher drains.
-    this.closeVmReconcileRotationState();
+    // begins. Active callers receive a bounded grace period; generation and
+    // target fences prevent any late continuation from committing lifecycle
+    // state after the cancellation signal.
+    // Exact-absence rotations were cleared before stopping the chain poller,
+    // so a late in-flight response cannot restore process-local suppression.
     const vmReconcileDispatcher = this.vmReconcileDispatcher;
     const vmReconcileSweep = this.vmReconcileSweepInFlight;
-    if (vmReconcileDispatcher || vmReconcileSweep) {
-      const drains: Promise<unknown>[] = [];
-      if (vmReconcileDispatcher) drains.push(vmReconcileDispatcher.close());
-      if (vmReconcileSweep) drains.push(vmReconcileSweep.catch(() => undefined));
-      const drain = Promise.all(drains);
-      let drainTimedOut = false;
-      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-      const timeout = new Promise<void>((resolve) => {
-        timeoutHandle = setTimeout(() => {
-          drainTimedOut = true;
-          resolve();
-        }, DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS);
-        timeoutHandle.unref?.();
-      });
-      await Promise.race([drain, timeout]);
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-      if (drainTimedOut) {
-        this.log.warn(
-          createOperationContext('system'),
-          `DKGAgent.stop: ${vmReconcileDispatcher?.snapshot().active ?? 0} VM reconcile job(s) still active after ${DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS}ms drain bound${vmReconcileSweep ? ' (sweep pending)' : ''} — proceeding with shutdown`,
-        );
+    const priorRetirement = this.vmReconcileRetirement;
+    // close() fences admission synchronously before the physical-set drain is
+    // sampled, so no dispatcher worker can appear behind an observed empty set.
+    const dispatcherDrain = vmReconcileDispatcher?.close();
+    const drainPhysicalRuns = async (): Promise<void> => {
+      while (
+        (this.vmReconcilePhysicalRuns?.size ?? 0) > 0
+        || (this.graphScopedStorePhysicalRuns?.size ?? 0) > 0
+      ) {
+        const snapshot = [
+          ...(this.vmReconcilePhysicalRuns ?? []),
+          ...(this.graphScopedStorePhysicalRuns ?? []),
+        ];
+        await Promise.allSettled(snapshot);
+        for (const settled of snapshot) this.vmReconcilePhysicalRuns?.delete(settled);
+        for (const settled of snapshot) this.graphScopedStorePhysicalRuns?.delete(settled);
       }
+    };
+    const drains: Promise<unknown>[] = [drainPhysicalRuns()];
+    if (chainPollerDrain) drains.push(chainPollerDrain);
+    if (priorRetirement) drains.push(priorRetirement.catch(() => undefined));
+    if (dispatcherDrain) drains.push(dispatcherDrain);
+    if (vmReconcileSweep) drains.push(vmReconcileSweep.catch(() => undefined));
+
+    let retirement!: Promise<void>;
+    retirement = Promise.allSettled(drains).then(() => {
+      if (this.vmReconcileDispatcher === vmReconcileDispatcher) {
+        this.vmReconcileDispatcher = undefined;
+      }
+      if (this.vmReconcileSweepInFlight === vmReconcileSweep) {
+        this.vmReconcileSweepInFlight = null;
+      }
+      if (this.chainPoller === chainPoller) {
+        this.chainPoller = null;
+      }
+      if (this.vmReconcileRetirement === retirement) {
+        this.vmReconcileRetirement = null;
+      }
+    });
+    this.vmReconcileRetirement = retirement;
+
+    let drainTimedOut = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timeoutHandle = setTimeout(() => {
+        drainTimedOut = true;
+        resolve();
+      }, DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS);
+      timeoutHandle.unref?.();
+    });
+    await Promise.race([retirement, timeout]);
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    if (drainTimedOut) {
+      this.vmReconcileShutdownBlocked = true;
+      this.log.warn(
+        createOperationContext('system'),
+        `DKGAgent.stop: graph-scoped sync/reconciliation work did not physically retire within ${DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS}ms; store/network teardown is blocked until stop() is retried`,
+      );
+      throw new VmReconcileShutdownTimeoutError(DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS);
     }
-    // A timed-out dependency may ignore cancellation forever. Detach the old
-    // runtime by identity after the bounded drain; generation/signal fences
-    // prevent its late continuations from mutating the next node lifecycle.
-    if (this.vmReconcileDispatcher === vmReconcileDispatcher) {
-      this.vmReconcileDispatcher = undefined;
+    this.vmReconcileShutdownBlocked = false;
+    let membershipDrainTimedOut = false;
+    let membershipTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const membershipTimeout = new Promise<void>((resolve) => {
+      membershipTimeoutHandle = setTimeout(() => {
+        membershipDrainTimedOut = true;
+        resolve();
+      }, DKGAgentBase.CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_MS);
+      membershipTimeoutHandle.unref?.();
+    });
+    await Promise.race([membershipPersistDrain, membershipTimeout]);
+    if (membershipTimeoutHandle) clearTimeout(membershipTimeoutHandle);
+    if (membershipDrainTimedOut) {
+      this.contextGraphMembershipPersistenceShutdownBlocked = true;
+      this.log.warn(
+        createOperationContext('system'),
+        `DKGAgent.stop: context-graph membership persistence did not drain within `
+        + `${DKGAgentBase.CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_MS}ms; `
+        + `store teardown is blocked until stop() is retried`,
+      );
+      throw new ContextGraphMembershipPersistShutdownTimeoutError(
+        DKGAgentBase.CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_MS,
+      );
     }
-    if (this.vmReconcileSweepInFlight === vmReconcileSweep) {
-      this.vmReconcileSweepInFlight = null;
-    }
+    this.contextGraphMembershipPersistenceShutdownBlocked = false;
     this.coreHostRecordingsClosed = true;
     await this.drainCoreHostRecordings();
     if (this.messengerOutboxTimer) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -78,11 +78,17 @@ export {
   ContextGraphOnChainIdUnresolvedError,
   VmReconcileQueueClosedError,
   VmReconcileQueueFullError,
+  VmReconcileShutdownTimeoutError,
   VmReconcileUnavailableError,
   type ContextGraphReconcileResult,
   type ContextGraphReconcileStatus,
   type VmReconcileSource,
 } from './vm-reconcile-service.js';
+export {
+  ContextGraphMembershipPersistQueueClosedError,
+  ContextGraphMembershipPersistQueueFullError,
+  ContextGraphMembershipPersistShutdownTimeoutError,
+} from './context-graph-membership-persist-scheduler.js';
 export { buildEndorsementQuads, DKG_ENDORSES, DKG_ENDORSED_AT } from './endorse.js';
 export {
   CclEvaluator,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -79,6 +79,7 @@ export {
   VmReconcileQueueClosedError,
   VmReconcileQueueFullError,
   VmReconcileShutdownTimeoutError,
+  VM_RECONCILE_SHUTDOWN_TIMEOUT_ERROR_CODE,
   VmReconcileUnavailableError,
   type ContextGraphReconcileResult,
   type ContextGraphReconcileStatus,
@@ -88,6 +89,7 @@ export {
   ContextGraphMembershipPersistQueueClosedError,
   ContextGraphMembershipPersistQueueFullError,
   ContextGraphMembershipPersistShutdownTimeoutError,
+  CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_ERROR_CODE,
 } from './context-graph-membership-persist-scheduler.js';
 export { buildEndorsementQuads, DKG_ENDORSES, DKG_ENDORSED_AT } from './endorse.js';
 export {

--- a/packages/agent/src/p2p/peer-connect.ts
+++ b/packages/agent/src/p2p/peer-connect.ts
@@ -5,7 +5,7 @@ import {
 
 interface Libp2pLike {
   getConnections(): Array<{ remotePeer: { toString(): string } }>;
-  dial(peer: unknown): Promise<unknown>;
+  dial(peer: unknown, options?: { signal?: AbortSignal }): Promise<unknown>;
   peerStore: {
     merge(peer: unknown, update: { multiaddrs: unknown[] }): Promise<void>;
   };
@@ -76,7 +76,11 @@ export async function ensurePeerConnected(
   libp2p: Libp2pLike,
   discovery: DiscoveryClient,
   peerId: string,
+  options: { signal?: AbortSignal } = {},
 ): Promise<void> {
+  if (options.signal?.aborted) {
+    throw new DOMException('Peer connection aborted', 'AbortError');
+  }
   const existingConnections = libp2p.getConnections()
     .filter((conn) => conn.remotePeer.toString() === peerId);
   if (existingConnections.length > 0) {
@@ -88,18 +92,25 @@ export async function ensurePeerConnected(
     const pid = peerIdFromString(peerId);
 
     try {
-      await libp2p.dial(pid);
+      await libp2p.dial(pid, { signal: options.signal });
       return;
     } catch {
-      const agent = await discovery.findAgentByPeerId(peerId);
+      if (options.signal?.aborted) {
+        throw new DOMException('Peer connection aborted', 'AbortError');
+      }
+      const agent = await discovery.findAgentByPeerId(peerId, { signal: options.signal });
+      if (options.signal?.aborted) {
+        throw new DOMException('Peer connection aborted', 'AbortError');
+      }
       if (!agent?.relayAddress) return;
 
       const { multiaddr } = await import('@multiformats/multiaddr');
       const circuitAddr = multiaddr(`${agent.relayAddress}/p2p-circuit/p2p/${peerId}`);
       await libp2p.peerStore.merge(pid, { multiaddrs: [circuitAddr] });
-      await libp2p.dial(pid);
+      await libp2p.dial(pid, { signal: options.signal });
     }
-  } catch {
+  } catch (error) {
+    if (options.signal?.aborted) throw error;
     // Non-fatal — peer may be unreachable.
   }
 }

--- a/packages/agent/src/p2p/protocol-readiness.ts
+++ b/packages/agent/src/p2p/protocol-readiness.ts
@@ -4,8 +4,12 @@ export async function waitForPeerProtocol(
   protocol: string,
   attempts: number,
   delayMs: number,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   for (let attempt = 0; attempt < attempts; attempt++) {
+    if (signal?.aborted) {
+      throw new DOMException('Protocol readiness wait aborted', 'AbortError');
+    }
     try {
       const peerInfo = await peerStore.get(peer as any);
       if (peerInfo.protocols.includes(protocol)) {
@@ -16,7 +20,23 @@ export async function waitForPeerProtocol(
     }
 
     if (attempt < attempts - 1) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await new Promise<void>((resolve, reject) => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const cleanup = () => {
+          if (timer) clearTimeout(timer);
+          signal?.removeEventListener('abort', onAbort);
+        };
+        const onAbort = () => {
+          cleanup();
+          reject(new DOMException('Protocol readiness wait aborted', 'AbortError'));
+        };
+        timer = setTimeout(() => {
+          cleanup();
+          resolve();
+        }, delayMs);
+        if (signal?.aborted) onAbort();
+        else signal?.addEventListener('abort', onAbort, { once: true });
+      });
     }
   }
 

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -62,7 +62,8 @@ export interface SyncRequestEnvelope {
    * Additive, UNSIGNED exact-KA response filter. It can only narrow an already
    * authorized Context Graph read. Upgraded responders serve metadata and data
    * for these UALs only; old responders ignore it, while the upgraded requester
-   * still filters their full response before verification/storage.
+   * accepts and filters only a bounded legacy prefix that covers every requested
+   * descriptor. An over-limit or incomplete legacy response remains fail-closed.
    */
   assetUals?: string[];
   /**

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks';
 import { getMetrics, type OperationContext } from '@origintrail-official/dkg-core';
 import {
   normalizeSyncAdmissionSource,
@@ -73,6 +74,7 @@ let inflight = 0;
 let lastLimit: number | null = null;
 let lastQueueLimit: number | null = null;
 const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
+  now: () => performance.now(),
   canRun: (entry) => inflight < entry.payload.limit,
   onStart: (entry) => {
     inflight += 1;
@@ -136,7 +138,6 @@ function acquire(
     source: SyncAdmissionSource;
     signal?: AbortSignal;
     agingThresholdMs: number;
-    now: () => number;
   },
 ): PriorityAdmission<GlobalQueuePayload> {
   const { limit } = policy;
@@ -158,7 +159,6 @@ function acquire(
     priorityClass: options.priorityClass,
     signal: options.signal,
     agingThresholdMs: options.agingThresholdMs,
-    now: options.now,
     queueLimit,
     createBusyError: () => new SyncBackpressureBusyError(
       `Sync backpressure rejected ${options.label} `
@@ -246,7 +246,6 @@ export function resolveSyncGlobalBackpressure(
 
 export function getSyncBackpressureSnapshot(
   policy?: SyncGlobalBackpressurePolicy,
-  now = Date.now(),
 ): SyncBackpressureSnapshot {
   const queuedByPriorityClass: Record<SyncPriorityClass, number> = {
     elevated: 0,
@@ -260,7 +259,7 @@ export function getSyncBackpressureSnapshot(
     limit: policy ? policy.limit ?? null : lastLimit,
     queueLimit: policy ? policy.queueLimit ?? null : lastQueueLimit,
     queuedByPriorityClass,
-    oldestQueuedAgeMs: queue.oldestAgeMs(now),
+    oldestQueuedAgeMs: queue.oldestAgeMs(),
   };
 }
 
@@ -282,9 +281,7 @@ export async function withGlobalSyncBackpressure<T>(
      */
     source?: SyncAdmissionSource;
     signal?: AbortSignal;
-    /** Deterministic scheduler injection; not operator configuration. */
     agingThresholdMs?: number;
-    now?: () => number;
     logInfo?: (ctx: OperationContext, message: string) => void;
   },
   work: () => Promise<T>,
@@ -314,7 +311,6 @@ export async function withGlobalSyncBackpressure<T>(
       source: normalizeSyncAdmissionSource(options.source),
       signal: options.signal,
       agingThresholdMs: options.agingThresholdMs ?? DEFAULT_SYNC_PRIORITY_AGING_MS,
-      now: options.now ?? Date.now,
     });
   } catch (error) {
     if (error instanceof SyncBackpressureBusyError) {

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -63,7 +63,7 @@ function syncOperationClass(label: string): string {
  * admission source is what lets an operator attribute a saturated `sync-global`
  * queue to explicit catch-up versus sync-on-connect versus reconcile, and read
  * per-trigger queue/active ages straight off the snapshot. Both halves are
- * closed sets (5 × 7), so the label space stays bounded and free of Context
+ * closed sets (5 × 8), so the label space stays bounded and free of Context
  * Graph and peer identifiers.
  */
 function syncAdmissionOperation(payload: GlobalQueuePayload): string {

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -85,6 +85,10 @@ const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
       getMetrics().syncGlobalInflight.record(inflight);
     };
   },
+  onStartFailureRollback: () => {
+    inflight = Math.max(0, inflight - 1);
+    getMetrics().syncGlobalInflight.record(inflight);
+  },
   onDepthChange: (depth) => getMetrics().syncBackgroundQueueDepth.record(depth),
   observability: {
     scheduler: 'sync-global',

--- a/packages/agent/src/sync/exact-assets.ts
+++ b/packages/agent/src/sync/exact-assets.ts
@@ -3,6 +3,10 @@ import { parseDeterministicKnowledgeAssetUal } from '@origintrail-official/dkg-c
 /** One VM reconciliation slice deliberately fetches at most this many KAs. */
 export const MAX_EXACT_SYNC_ASSETS = 10;
 
+function canonicalExactAssetSetOrder(assetUals: readonly string[]): string[] {
+  return [...new Set(assetUals)].sort();
+}
+
 /**
  * Normalize the additive exact-asset sync filter.
  *
@@ -30,7 +34,7 @@ export function normalizeExactAssetUals(value: unknown): string[] | undefined {
       return [];
     }
   }
-  return normalized;
+  return canonicalExactAssetSetOrder(normalized);
 }
 
 export function requireExactAssetUals(value: unknown): string[] {
@@ -43,11 +47,13 @@ export function requireExactAssetUals(value: unknown): string[] {
 
 /** Stable identity for checkpoints, single-flight keys, and responder plans. */
 export function exactAssetFilterKey(assetUals: readonly string[] | undefined): string {
-  return assetUals === undefined ? 'full' : `exact:${assetUals.join('\u001f')}`;
+  return assetUals === undefined
+    ? 'full'
+    : `exact:${canonicalExactAssetSetOrder(assetUals).join('\u001f')}`;
 }
 
 export function encodeExactAssetUals(assetUals: readonly string[]): string {
-  return encodeURIComponent(JSON.stringify(assetUals));
+  return encodeURIComponent(JSON.stringify(canonicalExactAssetSetOrder(assetUals)));
 }
 
 export function decodeExactAssetUals(encoded: string): string[] {

--- a/packages/agent/src/sync/exact-assets.ts
+++ b/packages/agent/src/sync/exact-assets.ts
@@ -1,7 +1,32 @@
-import { parseDeterministicKnowledgeAssetUal } from '@origintrail-official/dkg-core';
+import {
+  DKG_GOSSIP_MAX_MESSAGE_BYTES,
+  parseDeterministicKnowledgeAssetUal,
+} from '@origintrail-official/dkg-core';
 
 /** One VM reconciliation slice deliberately fetches at most this many KAs. */
 export const MAX_EXACT_SYNC_ASSETS = 10;
+
+/**
+ * A published assertion must already fit one DKG gossip application payload.
+ * Apply that same per-asset wire ceiling to each compatibility phase so a
+ * legacy responder that ignores the additive exact filter cannot turn a
+ * narrow repair into an unbounded full-CG accumulation.
+ */
+export const MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET = DKG_GOSSIP_MAX_MESSAGE_BYTES;
+export const MAX_EXACT_SYNC_PHASE_QUADS_PER_ASSET = 100_000;
+
+export function exactSyncPhaseAccumulationLimits(assetUals: readonly string[]): {
+  maxBytes: number;
+  maxQuads: number;
+} {
+  const assetCount = requireExactAssetUals(assetUals).length;
+  return {
+    maxBytes: assetCount * MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+    // Align with the existing bounded exact-graph read contract so compact
+    // wire data cannot expand into an unbounded retained JS object graph.
+    maxQuads: assetCount * MAX_EXACT_SYNC_PHASE_QUADS_PER_ASSET,
+  };
+}
 
 function canonicalExactAssetSetOrder(assetUals: readonly string[]): string[] {
   return [...new Set(assetUals)].sort();

--- a/packages/agent/src/sync/priority-admission-queue.ts
+++ b/packages/agent/src/sync/priority-admission-queue.ts
@@ -49,6 +49,11 @@ export interface PriorityAdmission<Payload> {
 export interface PriorityAdmissionQueueHooks<Payload> {
   canRun: (entry: PriorityAdmissionEntry<Payload>) => boolean;
   onStart: (entry: PriorityAdmissionEntry<Payload>) => PriorityAdmissionRelease;
+  /** Undo capacity claimed by onStart when it throws before returning its release. */
+  onStartFailureRollback?: (
+    entry: PriorityAdmissionEntry<Payload>,
+    error: unknown,
+  ) => void;
   onDepthChange?: (depth: number) => void;
   /** Queue-wide elapsed-time source; production defaults to a monotonic clock. */
   now?: () => number;
@@ -400,8 +405,9 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
     entry: PriorityAdmissionEntry<Payload>,
     options: Pick<PriorityAdmissionAcquireOptions<Payload>, 'reserveForHandoff' | 'queueLimit' | 'ownerQueueLimit'>,
   ): PriorityAdmissionRelease {
-    const release = this.hooks.onStart(entry);
+    let release: PriorityAdmissionRelease | undefined;
     try {
+      release = this.hooks.onStart(entry);
       if (options.reserveForHandoff) {
         this.handoffReservations.set(entry.sequence, {
           sequence: entry.sequence,
@@ -414,7 +420,8 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
     } catch (error) {
       this.handoffReservations.delete(entry.sequence);
       try {
-        release();
+        if (release) release();
+        else this.hooks.onStartFailureRollback?.(entry, error);
       } catch {
         // Preserve the admission failure; release is best-effort rollback here.
       }

--- a/packages/agent/src/sync/priority-admission-queue.ts
+++ b/packages/agent/src/sync/priority-admission-queue.ts
@@ -191,11 +191,14 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       && options.ownerQueueLimit !== undefined
       && this.countOwner(ownerKey) + reservedOwner >= options.ownerQueueLimit,
     );
+    const queuedRunnable = this.queue.some((entry) => (
+      !entry.settled && this.hooks.canRun(entry)
+    ));
 
     if (
       !handoffReservation
       && this.hooks.canRun(base)
-      && queuedBefore === 0
+      && !queuedRunnable
       && !reservationGlobalFull
       && !reservationOwnerFull
     ) {

--- a/packages/agent/src/sync/priority-admission-queue.ts
+++ b/packages/agent/src/sync/priority-admission-queue.ts
@@ -262,6 +262,7 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
         internal.timer = setTimeout(() => {
           if (!this.remove(internal)) return;
           this.observePressureReject(internal, 'queue_wait_timeout');
+          this.recordDecision(internal, 'rejected');
           this.rejectOnce(
             internal,
             options.createTimeoutError?.() ?? options.createBusyError('global_queue_full'),

--- a/packages/agent/src/sync/priority-admission-queue.ts
+++ b/packages/agent/src/sync/priority-admission-queue.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks';
 import {
   backpressureRegistry,
   getMetrics,
@@ -20,7 +21,6 @@ export interface PriorityAdmissionEntry<Payload> extends PriorityAdmissionSchedu
   ownerKey: string;
   sequence: number;
   enqueuedAt: number;
-  now: () => number;
   agingThresholdMs: number;
 }
 
@@ -50,12 +50,13 @@ export interface PriorityAdmissionQueueHooks<Payload> {
   canRun: (entry: PriorityAdmissionEntry<Payload>) => boolean;
   onStart: (entry: PriorityAdmissionEntry<Payload>) => PriorityAdmissionRelease;
   onDepthChange?: (depth: number) => void;
+  /** Queue-wide elapsed-time source; production defaults to a monotonic clock. */
+  now?: () => number;
   observability?: {
     scheduler: string;
     operation: (entry: PriorityAdmissionEntry<Payload>) => string;
     inflightLimit?: (entry: PriorityAdmissionEntry<Payload>) => number | null;
     thresholds?: SchedulerPressureThresholds;
-    now?: () => number;
     register?: boolean;
   };
 }
@@ -68,7 +69,6 @@ export interface PriorityAdmissionAcquireOptions<Payload> extends PriorityAdmiss
   signal?: AbortSignal;
   timeoutMs?: number;
   agingThresholdMs: number;
-  now?: () => number;
   /** Reserve one bounded queue slot if this running stage may hand off. */
   reserveForHandoff?: boolean;
   createBusyError: (reason: 'global_queue_full' | 'owner_queue_full') => Error;
@@ -104,15 +104,19 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
   private readonly handoffReservations = new Map<number, HandoffReservation>();
   private readonly pressureTickets = new WeakMap<PriorityAdmissionEntry<Payload>, SchedulerPressureTicket>();
   private readonly hooks: PriorityAdmissionQueueHooks<Payload>;
+  private readonly now: () => number;
   private nextSequence = 0;
+  private agedTurnOwed = false;
 
   constructor(hooks: PriorityAdmissionQueueHooks<Payload>) {
+    const now = hooks.now ?? (() => performance.now());
     super({
       scheduler: hooks.observability?.scheduler ?? 'priority-admission',
       thresholds: hooks.observability?.thresholds,
-      now: hooks.observability?.now,
+      now,
     });
     this.hooks = hooks;
+    this.now = now;
     if (hooks.observability?.register) backpressureRegistry.register(this);
   }
 
@@ -136,9 +140,9 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
     return count;
   }
 
-  oldestAgeMs(now = Date.now()): number {
+  oldestAgeMs(): number {
     if (this.queue.length === 0) return 0;
-    return Math.max(0, now - Math.min(...this.queue.map((entry) => entry.enqueuedAt)));
+    return Math.max(0, this.now() - Math.min(...this.queue.map((entry) => entry.enqueuedAt)));
   }
 
   acquire(options: PriorityAdmissionAcquireOptions<Payload>): PriorityAdmission<Payload> {
@@ -150,7 +154,7 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
     handoffReservation?: HandoffReservation,
   ): PriorityAdmission<Payload> {
     if (options.signal?.aborted) throw abortError(options.signal.reason);
-    const now = options.now ?? Date.now;
+    this.reconcileAgedTurnOwed();
     const ownerKey = handoffReservation?.ownerKey ?? options.ownerKey ?? '';
     const queuedBefore = this.queue.length;
     const sequence = handoffReservation?.sequence ?? this.nextSequence++;
@@ -161,8 +165,7 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       priority: options.priority,
       priorityClass: options.priorityClass,
       sequence,
-      enqueuedAt: now(),
-      now,
+      enqueuedAt: this.now(),
       agingThresholdMs: options.agingThresholdMs,
     };
     if (this.hooks.observability) {
@@ -191,14 +194,21 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       && !reservationGlobalFull
       && !reservationOwnerFull
     ) {
-      this.recordDecision(base, 'started');
       this.observePressureEnqueue(base);
+      let release: PriorityAdmissionRelease;
+      try {
+        release = this.start(base, options);
+      } catch (error) {
+        this.observePressureReject(base, 'start_failed');
+        throw error;
+      }
+      this.recordDecision(base, 'started');
       const admission: PriorityAdmission<Payload> = {
         status: 'running',
         queuedBefore,
         sequence,
         entry: base,
-        release: Promise.resolve(this.start(base, options)),
+        release: Promise.resolve(release),
       };
       if (options.reserveForHandoff) {
         admission.handoff = (handoffOptions) => this.handoff(base, handoffOptions);
@@ -210,12 +220,7 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
     const ownerFull = options.ownerQueueLimit !== undefined
       && this.countOwner(ownerKey) + reservedOwner >= options.ownerQueueLimit;
     if (!handoffReservation && (globalFull || ownerFull)) {
-      const victim = this.queue
-        .filter((entry) => (
-          entry.priority < options.priority
-          && (!ownerFull || entry.ownerKey === ownerKey)
-        ))
-        .sort((a, b) => a.priority - b.priority || b.sequence - a.sequence)[0];
+      const victim = this.selectDisplacementVictim(options, ownerKey, ownerFull);
       if (!victim) {
         this.recordDecision(base, 'rejected');
         this.observePressureReject(
@@ -266,7 +271,7 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       };
       this.observePressureEnqueue(internal);
       this.queue.push(internal);
-      this.depthChanged();
+      this.queueChanged();
       if (options.signal) {
         options.signal.addEventListener('abort', internal.onAbort, { once: true });
         if (options.signal.aborted) internal.onAbort();
@@ -294,45 +299,127 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       this.cleanup(entry);
       this.depthChanged();
       if (entry.settled) continue;
+      let release: PriorityAdmissionRelease;
+      try {
+        release = this.start(entry, entry);
+      } catch (error) {
+        this.observePressureReject(entry, 'start_failed');
+        this.recordDecision(entry, 'rejected');
+        this.rejectOnce(entry, error instanceof Error ? error : new Error(String(error)));
+        this.reconcileAgedTurnOwed();
+        continue;
+      }
       entry.settled = true;
-      const waitMs = Math.max(0, entry.now() - entry.enqueuedAt);
+      if (selected.servesDebt) this.agedTurnOwed = false;
+      else if (selected.createsDebt) this.agedTurnOwed = true;
+      this.reconcileAgedTurnOwed();
+      const waitMs = Math.max(0, this.now() - entry.enqueuedAt);
       getMetrics().syncSchedulerQueueWaitMs.record(waitMs, this.metricAttributes(entry));
       this.recordDecision(entry, 'started');
       if (selected.aged) this.recordDecision(entry, 'aged');
-      entry.resolve(this.start(entry, entry));
+      entry.resolve(release);
     }
   }
 
-  private selectNext(): { index: number; aged: boolean } | undefined {
+  private selectNext(): {
+    index: number;
+    aged: boolean;
+    createsDebt: boolean;
+    servesDebt: boolean;
+  } | undefined {
+    this.reconcileAgedTurnOwed();
+    const now = this.now();
     const runnable = this.queue
       .map((entry, index) => ({ entry, index }))
       .filter(({ entry }) => !entry.settled && this.hooks.canRun(entry));
     if (runnable.length === 0) return undefined;
     const aged = runnable
-      .filter(({ entry }) => entry.now() - entry.enqueuedAt >= entry.agingThresholdMs)
+      .filter(({ entry }) => this.isAged(entry, now))
       .sort((a, b) => a.entry.sequence - b.entry.sequence)[0];
-    if (aged) return { index: aged.index, aged: true };
+    if (this.agedTurnOwed && aged) {
+      return {
+        index: aged.index,
+        aged: true,
+        createsDebt: false,
+        servesDebt: true,
+      };
+    }
     const highest = runnable.sort((a, b) => (
       b.entry.priority - a.entry.priority
       || a.entry.sequence - b.entry.sequence
     ))[0];
-    return highest ? { index: highest.index, aged: false } : undefined;
+    if (!highest) return undefined;
+    const createsDebt = !this.agedTurnOwed && this.queue.some((entry) => (
+      !entry.settled
+      && entry !== highest.entry
+      && entry.priority < highest.entry.priority
+      && this.isAged(entry, now)
+    ));
+    return {
+      index: highest.index,
+      aged: this.isAged(highest.entry, now),
+      createsDebt,
+      servesDebt: false,
+    };
+  }
+
+  private isAged(entry: PriorityAdmissionEntry<Payload>, now = this.now()): boolean {
+    return now - entry.enqueuedAt >= entry.agingThresholdMs;
+  }
+
+  private reconcileAgedTurnOwed(): void {
+    if (!this.agedTurnOwed) return;
+    const now = this.now();
+    if (!this.queue.some((entry) => !entry.settled && this.isAged(entry, now))) {
+      this.agedTurnOwed = false;
+    }
+  }
+
+  private selectDisplacementVictim(
+    options: PriorityAdmissionAcquireOptions<Payload>,
+    ownerKey: string,
+    ownerFull: boolean,
+  ): InternalEntry<Payload> | undefined {
+    const candidates = this.queue.filter((entry) => (
+      entry.priority < options.priority
+      && (!ownerFull || entry.ownerKey === ownerKey)
+    ));
+    let protectedAged: InternalEntry<Payload> | undefined;
+    if (options.queueLimit >= 2) {
+      const now = this.now();
+      protectedAged = candidates
+        .filter((entry) => this.isAged(entry, now))
+        .sort((a, b) => a.sequence - b.sequence)[0];
+    }
+    return candidates
+      .filter((entry) => entry !== protectedAged)
+      .sort((a, b) => a.priority - b.priority || b.sequence - a.sequence)[0];
   }
 
   private start(
     entry: PriorityAdmissionEntry<Payload>,
     options: Pick<PriorityAdmissionAcquireOptions<Payload>, 'reserveForHandoff' | 'queueLimit' | 'ownerQueueLimit'>,
   ): PriorityAdmissionRelease {
-    if (options.reserveForHandoff) {
-      this.handoffReservations.set(entry.sequence, {
-        sequence: entry.sequence,
-        ownerKey: entry.ownerKey,
-        queueLimit: options.queueLimit,
-        ownerQueueLimit: options.ownerQueueLimit,
-      });
-    }
-    this.observePressureStart(entry);
     const release = this.hooks.onStart(entry);
+    try {
+      if (options.reserveForHandoff) {
+        this.handoffReservations.set(entry.sequence, {
+          sequence: entry.sequence,
+          ownerKey: entry.ownerKey,
+          queueLimit: options.queueLimit,
+          ownerQueueLimit: options.ownerQueueLimit,
+        });
+      }
+      this.observePressureStart(entry);
+    } catch (error) {
+      this.handoffReservations.delete(entry.sequence);
+      try {
+        release();
+      } catch {
+        // Preserve the admission failure; release is best-effort rollback here.
+      }
+      throw error;
+    }
     let released = false;
     return () => {
       if (released) return;
@@ -367,7 +454,7 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
     if (index < 0) return false;
     this.queue.splice(index, 1);
     this.cleanup(entry);
-    this.depthChanged();
+    this.queueChanged();
     return true;
   }
 
@@ -386,6 +473,11 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
 
   private depthChanged(): void {
     this.hooks.onDepthChange?.(this.queue.length);
+  }
+
+  private queueChanged(): void {
+    this.reconcileAgedTurnOwed();
+    this.depthChanged();
   }
 
   private metricAttributes(entry: PriorityAdmissionScheduling) {

--- a/packages/agent/src/sync/priority-admission-queue.ts
+++ b/packages/agent/src/sync/priority-admission-queue.ts
@@ -390,13 +390,10 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       entry.priority < options.priority
       && (!ownerFull || entry.ownerKey === ownerKey)
     ));
-    let protectedAged: InternalEntry<Payload> | undefined;
-    if (options.queueLimit >= 2) {
-      const now = this.now();
-      protectedAged = candidates
-        .filter((entry) => this.isAged(entry, now))
-        .sort((a, b) => a.sequence - b.sequence)[0];
-    }
+    const now = this.now();
+    const protectedAged = candidates
+      .filter((entry) => this.isAged(entry, now))
+      .sort((a, b) => a.sequence - b.sequence)[0];
     return candidates
       .filter((entry) => entry !== protectedAged)
       .sort((a, b) => a.priority - b.priority || b.sequence - a.sequence)[0];

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -32,6 +32,12 @@ import {
   normalizeDurableSyncContext,
   type LegacyDurableSyncContext,
 } from './durable-sync-compat.js';
+import {
+  classifyExactDurableFetch,
+  filterExactAssetDurablePayload,
+  mergeExactDurableFetchDisposition,
+  type ExactDurableFetchDisposition,
+} from './exact-durable-fetch.js';
 
 export {
   createContextGraphSyncDeadline,
@@ -47,8 +53,8 @@ export type {
   DurableSyncContextGraphBudgetRequest,
 } from './durable-sync-budget.js';
 export type { LegacyDurableSyncContext } from './durable-sync-compat.js';
-
-export type ExactDurableFetchDisposition = 'found' | 'clean-absent' | 'incomplete';
+export { filterExactAssetDurablePayload } from './exact-durable-fetch.js';
+export type { ExactDurableFetchDisposition } from './exact-durable-fetch.js';
 
 export interface DetailedDurableSyncResult {
   readonly result: InitializedDurableSyncResult;
@@ -193,85 +199,6 @@ export interface DurableSyncContext {
   logInfo: (ctx: OperationContext, message: string) => void;
   logWarn: (ctx: OperationContext, message: string) => void;
   logDebug: (ctx: OperationContext, message: string) => void;
-}
-
-/**
- * Rolling-upgrade guard: an old responder may ignore the additive exact-asset
- * filter and return the whole CG. Keep only requested descriptor subjects and
- * their declared assertion graphs before any verification or store write.
- */
-export function filterExactAssetDurablePayload(
-  dataQuads: readonly Quad[],
-  metaQuads: readonly Quad[],
-  assetUals: readonly string[],
-): { dataQuads: Quad[]; metaQuads: Quad[]; descriptorCoverageComplete: boolean } {
-  const exactUals = new Set(assetUals);
-  const exactMeta = metaQuads.filter((quad) => exactUals.has(quad.subject));
-  const returnedDescriptors = new Set(
-    exactMeta
-      .filter((quad) => (
-        quad.predicate === KA_UAL
-        && quad.subject === stripLiteral(quad.object)
-      ))
-      .map((quad) => quad.subject),
-  );
-  const exactGraphs = new Set(
-    exactMeta
-      .filter((quad) => quad.predicate === ASSERTION_GRAPH)
-      .map((quad) => quad.object),
-  );
-  return {
-    metaQuads: exactMeta,
-    dataQuads: dataQuads.filter((quad) => exactGraphs.has(quad.graph)),
-    descriptorCoverageComplete: returnedDescriptors.size === exactUals.size
-      && [...exactUals].every((ual) => returnedDescriptors.has(ual)),
-  };
-}
-
-function classifyExactDurableFetch(params: {
-  requestedAssetCount: number;
-  metaResult: SyncPageResult;
-  dataResult: SyncPageResult;
-  metaFetched: boolean;
-  descriptorCoverageComplete: boolean;
-  rejectedKcs: number;
-  dataRejectedMissingMeta: number;
-}): ExactDurableFetchDisposition {
-  const cleanPhase = (phase: SyncPageResult) => (
-    phase.completed
-    && !phase.timedOut
-    && phase.nextOffset >= phase.resumedFromOffset
-  );
-  if (
-    params.requestedAssetCount === 0
-    || !params.metaFetched
-    || !cleanPhase(params.metaResult)
-    || !cleanPhase(params.dataResult)
-    || params.rejectedKcs !== 0
-    || params.dataRejectedMissingMeta !== 0
-  ) return 'incomplete';
-
-  const freshEmptyPhase = (phase: SyncPageResult) => (
-    phase.responderSessionStartedFresh === true
-    && phase.resumedFromOffset === 0
-    && phase.nextOffset === 0
-    && phase.quads.length === 0
-  );
-  if (freshEmptyPhase(params.metaResult) && freshEmptyPhase(params.dataResult)) {
-    return 'clean-absent';
-  }
-
-  return params.descriptorCoverageComplete ? 'found' : 'incomplete';
-}
-
-function mergeExactDurableFetchDisposition(
-  current: ExactDurableFetchDisposition | undefined,
-  next: ExactDurableFetchDisposition,
-): ExactDurableFetchDisposition {
-  if (current === undefined) return next;
-  if (current === 'incomplete' || next === 'incomplete') return 'incomplete';
-  if (current === 'found' || next === 'found') return 'found';
-  return 'clean-absent';
 }
 
 export function runDurableSync(

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -48,6 +48,14 @@ export type {
 } from './durable-sync-budget.js';
 export type { LegacyDurableSyncContext } from './durable-sync-compat.js';
 
+export type ExactDurableFetchDisposition = 'found' | 'clean-absent' | 'incomplete';
+
+export interface DetailedDurableSyncResult {
+  readonly result: InitializedDurableSyncResult;
+  /** Present only when this physical run used an exact-asset filter. */
+  readonly exactFetchDisposition?: ExactDurableFetchDisposition;
+}
+
 const DKG_NS = 'http://dkg.io/ontology/';
 const CONTENT_SCOPE_VERSION = `${DKG_NS}contentScopeVersion`;
 const KA_UAL = `${DKG_NS}kaUal`;
@@ -220,6 +228,52 @@ export function filterExactAssetDurablePayload(
   };
 }
 
+function classifyExactDurableFetch(params: {
+  requestedAssetCount: number;
+  metaResult: SyncPageResult;
+  dataResult: SyncPageResult;
+  metaFetched: boolean;
+  descriptorCoverageComplete: boolean;
+  rejectedKcs: number;
+  dataRejectedMissingMeta: number;
+}): ExactDurableFetchDisposition {
+  const cleanPhase = (phase: SyncPageResult) => (
+    phase.completed
+    && !phase.timedOut
+    && phase.nextOffset >= phase.resumedFromOffset
+  );
+  if (
+    params.requestedAssetCount === 0
+    || !params.metaFetched
+    || !cleanPhase(params.metaResult)
+    || !cleanPhase(params.dataResult)
+    || params.rejectedKcs !== 0
+    || params.dataRejectedMissingMeta !== 0
+  ) return 'incomplete';
+
+  const freshEmptyPhase = (phase: SyncPageResult) => (
+    phase.responderSessionStartedFresh === true
+    && phase.resumedFromOffset === 0
+    && phase.nextOffset === 0
+    && phase.quads.length === 0
+  );
+  if (freshEmptyPhase(params.metaResult) && freshEmptyPhase(params.dataResult)) {
+    return 'clean-absent';
+  }
+
+  return params.descriptorCoverageComplete ? 'found' : 'incomplete';
+}
+
+function mergeExactDurableFetchDisposition(
+  current: ExactDurableFetchDisposition | undefined,
+  next: ExactDurableFetchDisposition,
+): ExactDurableFetchDisposition {
+  if (current === undefined) return next;
+  if (current === 'incomplete' || next === 'incomplete') return 'incomplete';
+  if (current === 'found' || next === 'found') return 'found';
+  return 'clean-absent';
+}
+
 export function runDurableSync(
   context: DurableSyncContext,
 ): Promise<InitializedDurableSyncResult>;
@@ -229,12 +283,24 @@ export function runDurableSync(
 export async function runDurableSync(
   context: DurableSyncContext | LegacyDurableSyncContext,
 ): Promise<InitializedDurableSyncResult> {
+  return (await runDurableSyncWithBudget(normalizeDurableSyncContext(context))).result;
+}
+
+export function runDurableSyncDetailed(
+  context: DurableSyncContext,
+): Promise<DetailedDurableSyncResult>;
+export function runDurableSyncDetailed(
+  context: LegacyDurableSyncContext,
+): Promise<DetailedDurableSyncResult>;
+export async function runDurableSyncDetailed(
+  context: DurableSyncContext | LegacyDurableSyncContext,
+): Promise<DetailedDurableSyncResult> {
   return runDurableSyncWithBudget(normalizeDurableSyncContext(context));
 }
 
 async function runDurableSyncWithBudget(
   context: DurableSyncContext,
-): Promise<InitializedDurableSyncResult> {
+): Promise<DetailedDurableSyncResult> {
   const {
     ctx,
     remotePeerId,
@@ -273,6 +339,7 @@ async function runDurableSyncWithBudget(
   });
 
   const accumulator = createDurableSyncAccumulator();
+  const exactFetchDispositions: ExactDurableFetchDisposition[] = [];
 
   const recordPhaseOutcome = (
     result: SyncPageResult,
@@ -323,6 +390,7 @@ async function runDurableSyncWithBudget(
   for (const [contextGraphIndex, pid] of contextGraphIds.entries()) {
     let activePhase: 'fetch' | 'verify' | 'store' | undefined;
     let peerRespondedForContextGraph = false;
+    let exactFetchDispositionIndex: number | undefined;
     const startPhase = (phase: 'fetch' | 'verify' | 'store') => {
       activePhase = phase;
       onPhase?.(phase, 'start');
@@ -344,6 +412,9 @@ async function runDurableSyncWithBudget(
       const deadline = contextGraphBudget.fetchDeadline;
       const activeFetchContext = fetchContext(deadline);
       const exactAssetUals = exactAssetUalsFor?.(pid);
+      if (exactAssetUals !== undefined) {
+        exactFetchDispositionIndex = exactFetchDispositions.push('incomplete') - 1;
+      }
 
       logInfo(ctx, `Syncing context graph "${pid}" from ${remotePeerId}`);
 
@@ -564,6 +635,17 @@ async function runDurableSyncWithBudget(
         && !metaResult.timedOut
         && effectiveDataResult.completed
         && !effectiveDataResult.timedOut;
+      const settledExactDisposition = (): ExactDurableFetchDisposition => (
+        classifyExactDurableFetch({
+          requestedAssetCount: exactAssetUals?.length ?? 0,
+          metaResult,
+          dataResult: rawDataResult,
+          metaFetched: !skipAgentsMeta,
+          descriptorCoverageComplete: exactAssetDescriptorCoverageComplete,
+          rejectedKcs: processed.rejectedKcs,
+          dataRejectedMissingMeta: processed.dataRejectedMissingMeta,
+        })
+      );
       // Metadata-only pages may move the meta cursor after storage, but they
       // still are not usable data progress for freshness/backoff accounting.
       if (
@@ -588,6 +670,9 @@ async function runDurableSyncWithBudget(
           emptyPhase,
         });
         markDurableTerminalBoundary(accumulator, reachedContextGraphTerminalBoundary);
+        if (exactFetchDispositionIndex !== undefined) {
+          exactFetchDispositions[exactFetchDispositionIndex] = settledExactDisposition();
+        }
         if ((metaResult.timedOut || effectiveDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
           break;
         }
@@ -666,6 +751,9 @@ async function runDurableSyncWithBudget(
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
       recordPhaseOutcome(effectiveDataResult, { updateCheckpoint: updateDataCheckpoint });
       markDurableTerminalBoundary(accumulator, reachedContextGraphTerminalBoundary);
+      if (exactFetchDispositionIndex !== undefined) {
+        exactFetchDispositions[exactFetchDispositionIndex] = settledExactDisposition();
+      }
       endPhase();
       if ((metaResult.timedOut || effectiveDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
         break;
@@ -719,8 +807,15 @@ async function runDurableSyncWithBudget(
   if (result.insertedTriples > 0) {
     logInfo(ctx, `Sync complete: ${result.insertedTriples} verified triples from ${remotePeerId}`);
   }
+  const exactFetchDisposition = exactFetchDispositions.reduce<ExactDurableFetchDisposition | undefined>(
+    mergeExactDurableFetchDisposition,
+    undefined,
+  );
 
-  return result;
+  return {
+    result,
+    ...(exactFetchDisposition ? { exactFetchDisposition } : {}),
+  };
 }
 
 function partitionVerifiedGraphScopedAssets(

--- a/packages/agent/src/sync/requester/exact-durable-fetch.ts
+++ b/packages/agent/src/sync/requester/exact-durable-fetch.ts
@@ -1,5 +1,6 @@
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from './page-fetch.js';
+import { stripLiteral } from '../../dkg-agent-utils.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
 const KA_UAL = `${DKG_NS}kaUal`;
@@ -84,9 +85,4 @@ export function mergeExactDurableFetchDisposition(
   if (current === 'incomplete' || next === 'incomplete') return 'incomplete';
   if (current === 'found' || next === 'found') return 'found';
   return 'clean-absent';
-}
-
-function stripLiteral(raw: string): string {
-  const match = raw.match(/^"(.*)"(?:\^\^.*|@.*)?$/);
-  return match ? match[1]! : raw;
 }

--- a/packages/agent/src/sync/requester/exact-durable-fetch.ts
+++ b/packages/agent/src/sync/requester/exact-durable-fetch.ts
@@ -1,0 +1,92 @@
+import type { Quad } from '@origintrail-official/dkg-storage';
+import type { SyncPageResult } from './page-fetch.js';
+
+const DKG_NS = 'http://dkg.io/ontology/';
+const KA_UAL = `${DKG_NS}kaUal`;
+const ASSERTION_GRAPH = `${DKG_NS}assertionGraph`;
+
+export type ExactDurableFetchDisposition = 'found' | 'clean-absent' | 'incomplete';
+
+/**
+ * Rolling-upgrade guard: an old responder may ignore the additive exact-asset
+ * filter and return the whole CG. Keep only requested descriptor subjects and
+ * their declared assertion graphs before any verification or store write.
+ */
+export function filterExactAssetDurablePayload(
+  dataQuads: readonly Quad[],
+  metaQuads: readonly Quad[],
+  assetUals: readonly string[],
+): { dataQuads: Quad[]; metaQuads: Quad[]; descriptorCoverageComplete: boolean } {
+  const exactUals = new Set(assetUals);
+  const exactMeta = metaQuads.filter((quad) => exactUals.has(quad.subject));
+  const returnedDescriptors = new Set(
+    exactMeta
+      .filter((quad) => (
+        quad.predicate === KA_UAL
+        && quad.subject === stripLiteral(quad.object)
+      ))
+      .map((quad) => quad.subject),
+  );
+  const exactGraphs = new Set(
+    exactMeta
+      .filter((quad) => quad.predicate === ASSERTION_GRAPH)
+      .map((quad) => quad.object),
+  );
+  return {
+    metaQuads: exactMeta,
+    dataQuads: dataQuads.filter((quad) => exactGraphs.has(quad.graph)),
+    descriptorCoverageComplete: returnedDescriptors.size === exactUals.size
+      && [...exactUals].every((ual) => returnedDescriptors.has(ual)),
+  };
+}
+
+export function classifyExactDurableFetch(params: {
+  requestedAssetCount: number;
+  metaResult: SyncPageResult;
+  dataResult: SyncPageResult;
+  metaFetched: boolean;
+  descriptorCoverageComplete: boolean;
+  rejectedKcs: number;
+  dataRejectedMissingMeta: number;
+}): ExactDurableFetchDisposition {
+  const cleanPhase = (phase: SyncPageResult) => (
+    phase.completed
+    && !phase.timedOut
+    && phase.nextOffset >= phase.resumedFromOffset
+  );
+  if (
+    params.requestedAssetCount === 0
+    || !params.metaFetched
+    || !cleanPhase(params.metaResult)
+    || !cleanPhase(params.dataResult)
+    || params.rejectedKcs !== 0
+    || params.dataRejectedMissingMeta !== 0
+  ) return 'incomplete';
+
+  const freshEmptyPhase = (phase: SyncPageResult) => (
+    phase.responderSessionStartedFresh === true
+    && phase.resumedFromOffset === 0
+    && phase.nextOffset === 0
+    && phase.quads.length === 0
+  );
+  if (freshEmptyPhase(params.metaResult) && freshEmptyPhase(params.dataResult)) {
+    return 'clean-absent';
+  }
+
+  return params.descriptorCoverageComplete ? 'found' : 'incomplete';
+}
+
+export function mergeExactDurableFetchDisposition(
+  current: ExactDurableFetchDisposition | undefined,
+  next: ExactDurableFetchDisposition,
+): ExactDurableFetchDisposition {
+  if (current === undefined) return next;
+  if (current === 'incomplete' || next === 'incomplete') return 'incomplete';
+  if (current === 'found' || next === 'found') return 'found';
+  return 'clean-absent';
+}
+
+function stripLiteral(raw: string): string {
+  const match = raw.match(/^"(.*)"(?:\^\^.*|@.*)?$/);
+  return match ? match[1]! : raw;
+}

--- a/packages/agent/src/sync/requester/graph-scoped-materialization.ts
+++ b/packages/agent/src/sync/requester/graph-scoped-materialization.ts
@@ -310,10 +310,27 @@ export async function authenticateVerifiedGraphScopedAsset(
 export async function materializeVerifiedGraphScopedAsset(params: {
   store: TripleStore;
   asset: VerifiedGraphScopedAsset;
+  isCurrent?: () => boolean;
+  shouldQuarantineCommitted?: () => boolean;
   options?: QueryOptions;
   oversizeHooks?: OversizeGuardHooks;
 }): Promise<GraphScopedMaterializationOutcome> {
-  const { store, asset, options = {}, oversizeHooks } = params;
+  const {
+    store,
+    asset,
+    isCurrent,
+    shouldQuarantineCommitted,
+    options = {},
+    oversizeHooks,
+  } = params;
+  const assertCurrent = () => {
+    if (isCurrent?.() === false) {
+      const error = new Error(`Graph-scoped materialization lifecycle for ${asset.ual} is no longer current`);
+      error.name = 'AbortError';
+      throw error;
+    }
+  };
+  assertCurrent();
   const filtered = filterOversizedSyncQuads([
     ...asset.dataQuads,
     ...asset.metadataQuads,
@@ -324,12 +341,14 @@ export async function materializeVerifiedGraphScopedAsset(params: {
   }
 
   return withMaterializationLock(asset.metaGraph, asset.ual, async () => {
+    assertCurrent();
     const currentVersion = await readCurrentAssertionVersion(
       store,
       asset.metaGraph,
       asset.ual,
       options,
     );
+    assertCurrent();
     if (currentVersion !== undefined && currentVersion > asset.assertionVersion) {
       return 'stale';
     }
@@ -347,6 +366,7 @@ export async function materializeVerifiedGraphScopedAsset(params: {
           currentMetadata,
         );
       }
+      assertCurrent();
     }
     const locallyTrustedMetadata = await readLocallyTrustedKnowledgeAssetControls(
       store,
@@ -355,6 +375,11 @@ export async function materializeVerifiedGraphScopedAsset(params: {
       replacementMetadata,
       options,
     );
+    // This is the last interruptible boundary. Once the atomic replacement is
+    // dispatched, its real completion owns the materialization lock and stop()
+    // must drain it rather than detaching the writer.
+    assertCurrent();
+    const { signal: _lifecycleSignal, ...commitOptions } = options;
 
     const replaced = await tryReplaceGraphAndSubjectAtomically(
       store,
@@ -363,7 +388,7 @@ export async function materializeVerifiedGraphScopedAsset(params: {
       asset.metaGraph,
       asset.ual,
       [...replacementMetadata, ...locallyTrustedMetadata],
-      options,
+      commitOptions,
     );
     if (!replaced) {
       throw Object.assign(
@@ -371,8 +396,27 @@ export async function materializeVerifiedGraphScopedAsset(params: {
         { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
       );
     }
+    if (shouldQuarantineCommitted?.() === true) {
+      const quarantined = await tryReplaceGraphAndSubjectAtomically(
+        store,
+        asset.assertionGraph,
+        [],
+        asset.metaGraph,
+        asset.ual,
+        [],
+        commitOptions,
+      );
+      if (!quarantined) {
+        throw Object.assign(
+          new Error('Graph-scoped durable sync requires atomic stale-binding quarantine support'),
+          { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
+        );
+      }
+      return 'quarantined';
+    }
+    if (isCurrent?.() === false) return 'quarantined';
     return 'applied';
-  });
+  }, { signal: options.signal });
 }
 
 /** Read the current subject once; publisher metadata helpers own typed merging. */

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -124,6 +124,19 @@ export interface SyncPageResult {
   timedOut: boolean;
 }
 
+export class SyncPageAccumulationLimitError extends Error {
+  readonly code = 'SYNC_PAGE_ACCUMULATION_LIMIT' as const;
+
+  constructor(
+    readonly dimension: 'bytes' | 'quads',
+    readonly actual: number,
+    readonly limit: number,
+  ) {
+    super(`Sync phase ${dimension} accumulation ${actual} exceeds limit ${limit}`);
+    this.name = 'SyncPageAccumulationLimitError';
+  }
+}
+
 interface FetchSyncPagesParams {
   ctx: OperationContext;
   remotePeerId: string;
@@ -179,6 +192,9 @@ interface FetchSyncPagesParams {
   sinceBatchId?: string;
   /** Exact KAs requested by VM recovery. Undefined retains ordinary full sync. */
   assetUals?: string[];
+  /** Optional cumulative ceilings for proof-sensitive narrow fetches. */
+  maxAcceptedBytes?: number;
+  maxAcceptedQuads?: number;
   parseAndFilter: (nquadsText: string, graphUri: string, contextGraphId: string) => Promise<{ quads: Quad[]; totalQuads: number }>;
   /**
    * Per-attempt send hook. `DKGAgent`'s production adapter sends raw
@@ -257,6 +273,8 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     buildSyncRequest,
     sinceBatchId,
     assetUals,
+    maxAcceptedBytes,
+    maxAcceptedQuads,
     parseAndFilter,
     send,
     logWarn,
@@ -404,6 +422,17 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       responsePages += 1;
       phaseTelemetry.recordPage();
 
+      const nextBytesReceived = bytesReceived + responseBytes.byteLength;
+      if (maxAcceptedBytes !== undefined && nextBytesReceived > maxAcceptedBytes) {
+        const error = new SyncPageAccumulationLimitError(
+          'bytes',
+          nextBytesReceived,
+          maxAcceptedBytes,
+        );
+        markSyncPeerResponded(error);
+        throw error;
+      }
+
       let parsed: { quads: Quad[]; totalQuads: number };
       let decodeDurationMs = 0;
       let parseDurationMs = 0;
@@ -411,7 +440,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         const decodeStartedAt = Date.now();
         const nquadsText = decodeSyncResponse(responseBytes);
         decodeDurationMs = Date.now() - decodeStartedAt;
-        bytesReceived += responseBytes.byteLength;
+        bytesReceived = nextBytesReceived;
         if (
           nquadsText === syncDeniedResponse ||
           (extraDeniedResponses && extraDeniedResponses.includes(nquadsText))
@@ -427,6 +456,14 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         throwIfAborted(signal);
         parseDurationMs = Date.now() - parseStartedAt;
         phaseTelemetry.recordQuads(parsed.quads);
+        const nextAcceptedQuads = allQuads.length + parsed.quads.length;
+        if (maxAcceptedQuads !== undefined && nextAcceptedQuads > maxAcceptedQuads) {
+          throw new SyncPageAccumulationLimitError(
+            'quads',
+            nextAcceptedQuads,
+            maxAcceptedQuads,
+          );
+        }
       } catch (error) {
         markSyncPeerResponded(error);
         throw error;
@@ -475,7 +512,13 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     }
   } catch (err) {
     const denied = (err as Error & { syncDenied?: boolean }).syncDenied === true;
-    if (usesPageSession && isSyncResponderSessionInvalidError(err)) {
+    if (usesPageSession && err instanceof SyncPageAccumulationLimitError) {
+      // The exact response proved that this responder ignored (or violated)
+      // the requested narrow scope. Never resume that incompatible row list:
+      // a later retry must mint a fresh session and start from offset zero.
+      unfinishedSyncResponderSessions.delete(checkpointKey);
+      checkpointStore.delete(checkpointKey);
+    } else if (usesPageSession && isSyncResponderSessionInvalidError(err)) {
       // A responder-declared superseded/expired token can never make progress.
       // Rotate it immediately even at offset zero instead of re-saving the
       // terminal token until its requester-side TTL elapses. Some transports

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -112,6 +112,12 @@ export interface SyncPageResult {
   quads: Quad[];
   bytesReceived: number;
   resumedFromOffset: number;
+  /**
+   * True only when this phase started without reusing a requester-side
+   * responder snapshot token. Optional for rolling deep-import compatibility;
+   * proof-sensitive callers must treat an omitted value as unknown.
+   */
+  responderSessionStartedFresh?: boolean;
   nextOffset: number;
   checkpointKey: string;
   completed: boolean;
@@ -286,6 +292,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         ?? getPersistedSyncResponderSession(checkpoint, sessionStartedAt)
       )
     : undefined;
+  const responderSessionStartedFresh = savedResponderSession === undefined;
   if (usesPageSession && offset > 0 && !savedResponderSession) {
     checkpointStore.delete(checkpointKey);
     offset = 0;
@@ -554,6 +561,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         quads: allQuads,
         bytesReceived,
         resumedFromOffset,
+        responderSessionStartedFresh,
         nextOffset: offset,
         checkpointKey,
         completed: false,
@@ -612,6 +620,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     quads: allQuads,
     bytesReceived,
     resumedFromOffset,
+    responderSessionStartedFresh,
     nextOffset: offset,
     checkpointKey,
     completed: !timedOut,

--- a/packages/agent/src/vm-reconcile-service.ts
+++ b/packages/agent/src/vm-reconcile-service.ts
@@ -60,3 +60,12 @@ export class VmReconcileQueueClosedError extends Error {
     this.name = 'VmReconcileQueueClosedError';
   }
 }
+
+export class VmReconcileShutdownTimeoutError extends Error {
+  readonly code = 'VmReconcileShutdownTimeout';
+
+  constructor(readonly timeoutMs: number) {
+    super(`Graph-scoped sync/reconciliation work did not retire within the ${timeoutMs}ms shutdown bound`);
+    this.name = 'VmReconcileShutdownTimeoutError';
+  }
+}

--- a/packages/agent/src/vm-reconcile-service.ts
+++ b/packages/agent/src/vm-reconcile-service.ts
@@ -61,8 +61,10 @@ export class VmReconcileQueueClosedError extends Error {
   }
 }
 
+export const VM_RECONCILE_SHUTDOWN_TIMEOUT_ERROR_CODE = 'VmReconcileShutdownTimeout';
+
 export class VmReconcileShutdownTimeoutError extends Error {
-  readonly code = 'VmReconcileShutdownTimeout';
+  readonly code = VM_RECONCILE_SHUTDOWN_TIMEOUT_ERROR_CODE;
 
   constructor(readonly timeoutMs: number) {
     super(`Graph-scoped sync/reconciliation work did not retire within the ${timeoutMs}ms shutdown bound`);

--- a/packages/agent/test/context-graph-membership-persist-scheduler.test.ts
+++ b/packages/agent/test/context-graph-membership-persist-scheduler.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ContextGraphMembershipPersistQueueClosedError,
+  ContextGraphMembershipPersistQueueFullError,
+  ContextGraphMembershipPersistScheduler,
+} from '../src/context-graph-membership-persist-scheduler.js';
+
+describe('ContextGraphMembershipPersistScheduler', () => {
+  it('keeps one active and one latest background mutation per busy key', async () => {
+    const scheduler = new ContextGraphMembershipPersistScheduler(4, 4);
+    let releaseActive!: () => void;
+    let markActive!: () => void;
+    const activeEntered = new Promise<void>((resolve) => { markActive = resolve; });
+    const activeGate = new Promise<void>((resolve) => { releaseActive = resolve; });
+    const executed: number[] = [];
+    const active = scheduler.enqueue('cg\0node\0peer', async () => {
+      executed.push(0);
+      markActive();
+      await activeGate;
+    });
+    await activeEntered;
+
+    const pending = Array.from({ length: 1_000 }, (_, index) =>
+      scheduler.enqueue('cg\0node\0peer', async () => { executed.push(index + 1); }));
+    expect(scheduler.status()).toMatchObject({ lanes: 1, active: 1, pending: 1 });
+
+    releaseActive();
+    await Promise.all([active, ...pending]);
+    expect(executed).toEqual([0, 1_000]);
+    expect(scheduler.status()).toEqual({ closed: false, lanes: 0, active: 0, pending: 0 });
+  });
+
+  it('preserves strict FIFO writes and rejects work beyond bounded capacity', async () => {
+    const scheduler = new ContextGraphMembershipPersistScheduler(2, 2);
+    let releaseA!: () => void;
+    let releaseB!: () => void;
+    const gateA = new Promise<void>((resolve) => { releaseA = resolve; });
+    const gateB = new Promise<void>((resolve) => { releaseB = resolve; });
+    const executed: string[] = [];
+    const activeA = scheduler.enqueue('a', async () => { executed.push('a0'); await gateA; });
+    const activeB = scheduler.enqueue('b', async () => { executed.push('b0'); await gateB; });
+    await Promise.resolve();
+
+    const strictA1 = scheduler.enqueue('a', async () => { executed.push('a1'); }, { strict: true });
+    const strictA2 = scheduler.enqueue('a', async () => { executed.push('a2'); }, { strict: true });
+    await expect(scheduler.enqueue('a', async () => undefined, { strict: true }))
+      .rejects.toBeInstanceOf(ContextGraphMembershipPersistQueueFullError);
+    await expect(scheduler.enqueue('c', async () => undefined, { strict: true }))
+      .rejects.toBeInstanceOf(ContextGraphMembershipPersistQueueFullError);
+
+    releaseA();
+    releaseB();
+    await Promise.all([activeA, activeB, strictA1, strictA2]);
+    expect(executed.filter((item) => item.startsWith('a'))).toEqual(['a0', 'a1', 'a2']);
+  });
+
+  it('closes admission and drains physical writes before resolving', async () => {
+    const scheduler = new ContextGraphMembershipPersistScheduler();
+    let release!: () => void;
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const write = scheduler.enqueue('key', async () => { markEntered(); await gate; });
+    await entered;
+    const drained = scheduler.closeAndDrain();
+    const drainSettled = vi.fn();
+    void drained.then(drainSettled);
+
+    await expect(scheduler.enqueue('late', async () => undefined))
+      .rejects.toBeInstanceOf(ContextGraphMembershipPersistQueueClosedError);
+    await Promise.resolve();
+    expect(drainSettled).not.toHaveBeenCalled();
+
+    release();
+    await Promise.all([write, drained]);
+    expect(drainSettled).toHaveBeenCalledOnce();
+    expect(scheduler.status()).toEqual({ closed: true, lanes: 0, active: 0, pending: 0 });
+  });
+});

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -843,6 +843,77 @@ describe('Phase D - VM reconcile damping', () => {
     });
   });
 
+  it('clears exact-recovery rotation state on the direct recent-cache terminal path', async () => {
+    const internals = await boot();
+    const localCgId = '68';
+    const onChainCgId = 68n;
+    const kaId = 9068n;
+    registerUnmatchedKC(internals.chain, kaId, onChainCgId);
+    const storageAddress = await internals.chain.getDKGKnowledgeAssetsAddress();
+    const ual = buildKnowledgeAssetUal(internals.chain.chainId, storageAddress, kaId);
+    const merkleRoot = await internals.chain.getLatestMerkleRoot(kaId);
+    const target = {
+      localCgId,
+      onChainCgId: onChainCgId.toString(),
+      ordinal: 0,
+      ual,
+      merkleRoot: bytesToHex(merkleRoot),
+      kaId: kaId.toString(),
+      reason: 'no-swm' as const,
+    };
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+    (internals as any).prepareVmReconcileRotationTarget(
+      target, ['12D3KooWDirectTerminalRecent'], 100,
+    );
+    ((internals as any).recentReconciledUals as { add(key: string): void }).add(
+      (internals as any).vmReconcileCacheKey(localCgId, ual, merkleRoot),
+    );
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(true);
+
+    await expect(internals.reconcileChainOrdinal(localCgId, onChainCgId, 0, undefined))
+      .resolves.toEqual({ status: 'already', blockNumber: 0 });
+
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+  });
+
+  it.each([
+    ['promoted', 'reconciled'],
+    ['already-confirmed', 'already'],
+    ['stale-target', 'already'],
+  ] as const)(
+    'clears exact-recovery rotation state on direct %s finalization',
+    async (finalizationOutcome, expectedStatus) => {
+      const internals = await boot();
+      const ordinalByOutcome = {
+        promoted: 69,
+        'already-confirmed': 70,
+        'stale-target': 71,
+      } as const;
+      const graphOrdinal = ordinalByOutcome[finalizationOutcome];
+      const localCgId = String(graphOrdinal);
+      const onChainCgId = BigInt(graphOrdinal);
+      const kaId = BigInt(9_000 + graphOrdinal);
+      registerUnmatchedKC(internals.chain, kaId, onChainCgId);
+      const target = {
+        ...vmRecoveryTarget(localCgId, 0, kaId.toString()),
+        onChainCgId: onChainCgId.toString(),
+      };
+      const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+      (internals as any).prepareVmReconcileRotationTarget(
+        target, [`12D3KooWDirectTerminal${graphOrdinal}`], 100,
+      );
+      (internals as any).getOrCreateFinalizationHandler = () => ({
+        handleChainReconciledKC: async () => finalizationOutcome,
+      });
+      expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(true);
+
+      await expect(internals.reconcileChainOrdinal(localCgId, onChainCgId, 0, undefined))
+        .resolves.toMatchObject({ status: expectedStatus });
+
+      expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    },
+  );
+
   it('negative-caches a missing SWM snapshot and skips the expensive scan plus active fetch during backoff', async () => {
     const internals = await boot();
     const onChainCgId = 42n;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2203,7 +2203,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       () => true,
     );
 
-    expect(connectionAttempts).toEqual([registryPeer, approvedPeer]);
+    expect(connectionAttempts).toEqual([]);
     expect(protocolPeers[0]?.toString()).toBe(registryPeer);
     expect(fetches).toEqual([{ peerId: registryPeer, uals: [ual] }]);
     expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
@@ -2258,10 +2258,136 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       localCgId, 1n, [vmRecoveryTarget(localCgId, 0, '85')], 100, () => true,
     );
 
-    expect(connectionAttempts).toEqual(curators.slice(0, 3));
+    expect(connectionAttempts).toEqual([]);
     expect(fetches).toEqual([curators[0]]);
     expect((internals as any).vmReconcileCuratorPeersByCg.get(localCgId))
-      .toEqual(curators.slice(0, 3));
+      .toEqual([...curators, staleHint]);
+  });
+
+  it('retains four curators and eventually recovers an asset held only by curator four', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmFourthCurator', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/fourth-curator';
+    const curators = [1, 2, 3, 4].map((n) => `12D3KooWFourthCurator${n}`);
+    const connected = curators.map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWFourthCuratorLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [...curators].reverse(), curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const attempts: string[] = [];
+    let lastPeerId: string | undefined;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      attempts.push(peerId);
+      lastPeerId = peerId;
+      const found = peerId === curators[3];
+      return {
+        result: {
+          fetchedDataTriples: found ? 1 : 0,
+          fetchedMetaTriples: found ? 8 : 0,
+          insertedTriples: found ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: found ? 'found' : 'clean-absent',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, 'fourth-holder');
+    (internals as any).reconcileChainOrdinal = async () => (
+      lastPeerId === curators[3]
+        ? { status: 'reconciled', blockNumber: 100 }
+        : { status: 'pending', recovery: target }
+    );
+
+    for (let pass = 0; pass < 3; pass += 1) {
+      const result = await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [target], 100, () => true,
+      );
+      expect(result.outcomes.get(0)).toMatchObject({ status: 'pending' });
+      expect((internals as any).vmReconcileRotationState.get(
+        (internals as any).vmReconcileRotationSlotKey(target),
+      )).toMatchObject({ phase: 'collecting' });
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    }
+    const recovered = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+
+    expect(attempts).toEqual(curators);
+    expect(recovered.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+    expect((internals as any).vmReconcileCuratorPeersByCg.get(localCgId)).toEqual(curators);
+  });
+
+  it('treats an oversized curator roster as unconfirmed and never suppresses discovery', async () => {
+    const rosterDescriptor = Object.getOwnPropertyDescriptor(
+      DKGAgentBase,
+      'VM_RECONCILE_EXACT_ROSTER_MAX',
+    )!;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_EXACT_ROSTER_MAX', {
+      ...rosterDescriptor,
+      value: 4,
+    });
+    try {
+      const chain = new MockChainAdapter();
+      agent = await DKGAgent.create({ name: 'ExactVmRosterOverflow', chainAdapter: chain });
+      const internals = agent as unknown as AgentInternals;
+      const localCgId = '0x0000000000000000000000000000000000000001/roster-overflow';
+      const preferred = '12D3KooWRosterOverflowPreferred';
+      const connectedPeer = { toString: () => preferred };
+      (internals as any).node = {
+        peerId: '12D3KooWRosterOverflowLocal',
+        libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+      };
+      (internals as any).preferredSyncPeers.set(localCgId, preferred);
+      let resolutions = 0;
+      (internals as any).resolveCuratorPeerIdsForCg = async () => {
+        resolutions += 1;
+        return {
+          peerIds: Array.from({ length: 5 }, (_, i) => `12D3KooWRosterOverflow${i}`),
+          curatorIsLocal: false,
+          legacyTripleResolved: false,
+        };
+      };
+      (internals as any).ensurePeerConnected = async () => undefined;
+      (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+      (internals as any).waitForSyncProtocol = async () => true;
+      (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+      const fetch = vi.fn(async () => ({
+        result: {
+          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'clean-absent' as const,
+      }));
+      (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+      const target = vmRecoveryTarget(localCgId, 0, 'roster-overflow');
+      (internals as any).reconcileChainOrdinal = async () => ({
+        status: 'pending', recovery: target,
+      });
+
+      await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+      const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+      expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
+        phase: 'backoff', curatorRosterConfirmed: false,
+      });
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+
+      expect(resolutions).toBe(2);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      Object.defineProperty(
+        DKGAgentBase,
+        'VM_RECONCILE_EXACT_ROSTER_MAX',
+        rosterDescriptor,
+      );
+    }
   });
 
   it('keeps a successful-empty metadata fallback ahead of the ordinary roster cap', async () => {
@@ -2530,7 +2656,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(second.cooldownOnly).toBe(true);
   });
 
-  it('wraps recovery after the last pending target receives an eligible attempt', async () => {
+  it('suppresses completed incomplete cycles after every pending target receives an attempt', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmBatchWrap', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
@@ -2591,19 +2717,18 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(second.continuationOrdinal).toBeUndefined();
 
     const rotationState = (internals as any).vmReconcileRotationState as Map<string, unknown>;
-    expect(rotationState.size).toBe(0);
+    expect(rotationState.size).toBe(2);
+    for (const target of targets) {
+      expect(rotationState.get(
+        (internals as any).vmReconcileRotationSlotKey(target),
+      )).toMatchObject({ phase: 'backoff', backoffKind: 'incomplete-cycle' });
+    }
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const wrapped = await internals.recoverVmReconcileBatch(
       localCgId, 1n, targets, 100, () => true,
     );
-    expect(wrapped.attemptedOrdinals).toEqual([0]);
-    expect(networkAttempts).toEqual([0, 1, 0]);
-    expect(rotationState.has(
-      (internals as any).vmReconcileRotationSlotKey(targets[0]),
-    )).toBe(false);
-    expect(rotationState.has(
-      (internals as any).vmReconcileRotationSlotKey(targets[1]),
-    )).toBe(true);
+    expect(wrapped.attemptedOrdinals).toEqual([]);
+    expect(networkAttempts).toEqual([0, 1]);
   });
 
   it('rotates one pending recovery target across eligible peers between windows', async () => {
@@ -2743,9 +2868,14 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
     expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB]);
     const slotKey = (internals as any).vmReconcileRotationSlotKey(activeTarget);
-    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    const incompleteBackoff = (internals as any).vmReconcileRotationState.get(slotKey);
+    expect(incompleteBackoff).toMatchObject({
+      phase: 'backoff', backoffKind: 'incomplete-cycle', failures: 1,
+    });
+    expect([...incompleteBackoff.cleanAbsentPeerIds]).toEqual([]);
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
 
+    now = incompleteBackoff.nextRetryAt + 1;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const retried = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [activeTarget], 100, () => true,
@@ -2753,13 +2883,15 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
     expect(retried.outcomes.get(1)).toMatchObject({ status: 'pending' });
     expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
-      phase: 'collecting', failures: 0,
+      phase: 'collecting', failures: 1,
     });
 
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
     expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA, peerB]);
-    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
+      phase: 'backoff', backoffKind: 'incomplete-cycle', failures: 2,
+    });
   });
 
   it('backs off only after a complete clean-absence rotation and requires a fresh next cycle', async () => {
@@ -2833,7 +2965,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       .toMatchObject({ phase: 'backoff', failures: 2 });
   });
 
-  it('drops a scheduling-exhausted cycle when one peer is rejected and one is incomplete', async () => {
+  it('backs off a scheduling-exhausted cycle when one peer is rejected and one is incomplete', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmSchedulingExhaustion', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
@@ -2877,13 +3009,19 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
     expect(networkAttempts).toEqual([incompletePeer]);
     expect(result.attemptedOrdinals).toEqual([0]);
-    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    const incompleteBackoff = (internals as any).vmReconcileRotationState.get(slotKey);
+    expect(incompleteBackoff).toMatchObject({
+      phase: 'backoff', backoffKind: 'incomplete-cycle', failures: 1,
+    });
+    expect([...incompleteBackoff.attemptedPeerIds])
+      .toEqual([rejectedPeer, incompletePeer]);
+    expect([...incompleteBackoff.cleanAbsentPeerIds]).toEqual([]);
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
 
     const damped = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
     );
-    expect(damped.cooldownOnly).toBe(true);
+    expect(damped.cooldownOnly).toBe(false);
     expect(networkAttempts).toEqual([incompletePeer]);
   });
 
@@ -2984,8 +3122,16 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(curatorResolutions).toBe(3);
 
     await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
-    expect(networkAttempts).toEqual([peerA, peerD, peerB]);
-    expect(curatorResolutions).toBe(3);
+    expect(networkAttempts).toEqual([peerA, peerD, peerB, peerC]);
+    expect(curatorResolutions).toBe(4);
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+    expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
+      phase: 'backoff', backoffKind: 'clean-absence', failures: 1,
+    });
+
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(networkAttempts).toEqual([peerA, peerD, peerB, peerC]);
+    expect(curatorResolutions).toBe(4);
   });
 
   it('ranks a resolved structural curator ahead of an ordinary capped roster', async () => {
@@ -3102,15 +3248,19 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
 
     const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
     expect(networkAttempts).toEqual([peerA, peerB]);
-    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    const incompleteBackoff = (internals as any).vmReconcileRotationState.get(slotKey);
+    expect(incompleteBackoff).toMatchObject({
+      phase: 'backoff', backoffKind: 'incomplete-cycle', failures: 1,
+    });
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
 
     const damped = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
     );
     expect(networkAttempts).toEqual([peerA, peerB]);
-    expect(damped.cooldownOnly).toBe(true);
+    expect(damped.cooldownOnly).toBe(false);
 
+    now = incompleteBackoff.nextRetryAt + 1;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const recovered = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
@@ -3121,7 +3271,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
   });
 
-  it('keeps collecting records stable at cap while cap+1 overflow still fetches fairly', async () => {
+  it('defers cap overflow until an expired slot can be replaced without retry churn', async () => {
     const capDescriptor = Object.getOwnPropertyDescriptor(
       DKGAgentBase,
       'VM_RECONCILE_CACHE_MAX_ENTRIES',
@@ -3190,7 +3340,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       expect(rotationState.get(firstKey)).toMatchObject({ phase: 'collecting' });
       expect([...rotationState.get(firstKey)!.cleanAbsentPeerIds]).toEqual([peerA]);
       expect(attemptsByUal.get(first.ual)).toEqual([peerA]);
-      expect(attemptsByUal.get(overflow.ual)).toEqual([peerB]);
+      expect(attemptsByUal.get(overflow.ual)).toBeUndefined();
 
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
       await internals.recoverVmReconcileBatch(
@@ -3199,30 +3349,30 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       expect(rotationState.size).toBe(1);
       expect(rotationState.get(firstKey)).toMatchObject({ phase: 'backoff' });
       expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB]);
-      expect(attemptsByUal.get(overflow.ual)).toEqual([peerB, peerA]);
+      expect(attemptsByUal.get(overflow.ual)).toBeUndefined();
 
-      // The overflow slot may fairly replace the completed backoff record, but
-      // the evicted object is never used for evidence. Its target still takes a
-      // normal fail-open exact attempt with the remaining peer.
+      // An unexpired backoff remains installed and the overflow target performs
+      // no evidence-free exact request.
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
       await internals.recoverVmReconcileBatch(
         localCgId, 1n, [first, overflow], 100, () => true,
+      );
+      expect(rotationState.size).toBe(1);
+      expect(rotationState.get(firstKey)).toMatchObject({ phase: 'backoff' });
+      expect(rotationState.has(overflowKey)).toBe(false);
+      expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB]);
+      expect(attemptsByUal.get(overflow.ual)).toBeUndefined();
+
+      const firstBackoff = rotationState.get(firstKey) as any;
+      (internals as any).vmReconcileRotationNow = () => firstBackoff.nextRetryAt + 1;
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [overflow], 100, () => true,
       );
       expect(rotationState.size).toBe(1);
       expect(rotationState.has(firstKey)).toBe(false);
       expect(rotationState.get(overflowKey)).toMatchObject({ phase: 'collecting' });
-      expect([...rotationState.get(overflowKey)!.cleanAbsentPeerIds]).toEqual([peerA]);
-      expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB, peerB]);
-      expect(attemptsByUal.get(overflow.ual)).toEqual([peerB, peerA, peerA]);
-
-      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
-      await internals.recoverVmReconcileBatch(
-        localCgId, 1n, [first, overflow], 100, () => true,
-      );
-      expect(rotationState.size).toBe(1);
-      expect(rotationState.get(overflowKey)).toMatchObject({ phase: 'backoff' });
-      expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB, peerB, peerA]);
-      expect(attemptsByUal.get(overflow.ual)).toEqual([peerB, peerA, peerA, peerB]);
+      expect(attemptsByUal.get(overflow.ual)).toEqual([peerA]);
     } finally {
       Object.defineProperty(
         DKGAgentBase,
@@ -3232,7 +3382,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     }
   });
 
-  it('drops a completed incomplete rotation so it cannot pin the state cap', async () => {
+  it('retains an incomplete-cycle backoff until expiry, then releases its state slot', async () => {
     const capDescriptor = Object.getOwnPropertyDescriptor(
       DKGAgentBase,
       'VM_RECONCILE_CACHE_MAX_ENTRIES',
@@ -3251,21 +3401,34 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       const second = vmRecoveryTarget('no-progress-capacity', 1, 'second');
       const firstKey = (internals as any).vmReconcileRotationSlotKey(first);
       const secondKey = (internals as any).vmReconcileRotationSlotKey(second);
+      let now = 100;
+      (internals as any).vmReconcileRotationNow = () => now;
       const firstRecord = (internals as any).prepareVmReconcileRotationTarget(
-        first, [peer], 100,
+        first, [peer], now,
       ).record;
 
       (internals as any).settleVmReconcileRotationAttempt(
         first, peer, 'incomplete', [peer], firstRecord,
       );
-      expect((internals as any).vmReconcileRotationState.has(firstKey)).toBe(false);
+      expect((internals as any).vmReconcileRotationState.get(firstKey)).toMatchObject({
+        phase: 'backoff', backoffKind: 'incomplete-cycle', failures: 1,
+      });
 
       const secondRecord = (internals as any).prepareVmReconcileRotationTarget(
-        second, [peer], 101,
+        second, [peer], now + 1,
       ).record;
-      expect(secondRecord).toBeDefined();
+      expect(secondRecord).toBeUndefined();
+      expect((internals as any).vmReconcileRotationState.has(firstKey)).toBe(true);
+      expect((internals as any).vmReconcileRotationState.has(secondKey)).toBe(false);
+
+      now = (internals as any).vmReconcileRotationState.get(firstKey).nextRetryAt + 1;
+      const admittedAfterExpiry = (internals as any).prepareVmReconcileRotationTarget(
+        second, [peer], now,
+      ).record;
+      expect(admittedAfterExpiry).toBeDefined();
       expect((internals as any).vmReconcileRotationState.has(firstKey)).toBe(false);
-      expect((internals as any).vmReconcileRotationState.get(secondKey)).toBe(secondRecord);
+      expect((internals as any).vmReconcileRotationState.get(secondKey))
+        .toBe(admittedAfterExpiry);
     } finally {
       Object.defineProperty(
         DKGAgentBase,

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -463,13 +463,22 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     const internals = await boot();
     internals.chain.getContextGraphAccessPolicy = async () => new Promise<number>(() => undefined);
     (internals.chain as { isContextGraphActiveOnChain?: unknown }).isContextGraphActiveOnChain = undefined;
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const recording = internals.recordCoreHostedPublicCg('44')
+        .finally(() => { settled = true; });
+      await vi.advanceTimersByTimeAsync(2_499);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await recording;
 
-    const startedAt = Date.now();
-    await internals.recordCoreHostedPublicCg('44');
-
-    expect(Date.now() - startedAt).toBeLessThan(5_000);
-    expect(internals.subscribedContextGraphs.get('44')).toBeUndefined();
-    expect(saved.find((r) => r.id === '44')).toBeUndefined();
+      expect(settled).toBe(true);
+      expect(internals.subscribedContextGraphs.get('44')).toBeUndefined();
+      expect(saved.find((r) => r.id === '44')).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('stops accepting and drains core-host recordings deterministically', async () => {
@@ -2265,6 +2274,8 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmBatchWrap', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
+    let now = 100;
+    (internals as any).vmReconcileRotationNow = () => now;
     const peer = '12D3KooWExactWrapPeer';
     const localCgId = '0x0000000000000000000000000000000000000001/exact-wrap';
     const connectedPeer = { toString: () => peer };
@@ -2323,7 +2334,18 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const wrapped = await internals.recoverVmReconcileBatch(
       localCgId, 1n, targets, 100, () => true,
     );
-    expect(wrapped.attemptedOrdinals).toEqual([0]);
+    expect(wrapped.attemptedOrdinals).toEqual([]);
+    expect(networkAttempts).toEqual([0, 1]);
+
+    const firstRecord = (internals as any).vmReconcileRotationState.get(
+      (internals as any).vmReconcileRotationSlotKey(targets[0]),
+    );
+    now = firstRecord.nextRetryAt + 1;
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    const retried = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, targets, 100, () => true,
+    );
+    expect(retried.attemptedOrdinals).toEqual([0]);
     expect(networkAttempts).toEqual([0, 1, 0]);
   });
 
@@ -2393,6 +2415,8 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmIncompleteRotation', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
+    let now = 100;
+    (internals as any).vmReconcileRotationNow = () => now;
     const peerA = '12D3KooWIncompleteRotationPeerA';
     const peerB = '12D3KooWIncompleteRotationPeerB';
     const localCgId = '0x0000000000000000000000000000000000000001/incomplete-rotation';
@@ -2453,12 +2477,20 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
       await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
     }
-    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB]);
     const record = (internals as any).vmReconcileRotationState.get(
       (internals as any).vmReconcileRotationSlotKey(activeTarget),
     );
     expect(record.cleanAbsentPeerIds.size).toBe(0);
-    expect(record).toMatchObject({ phase: 'collecting', failures: 0 });
+    expect(record).toMatchObject({ phase: 'backoff', failures: 1 });
+
+    now = record.nextRetryAt + 1;
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
+    expect((internals as any).vmReconcileRotationState.get(
+      (internals as any).vmReconcileRotationSlotKey(activeTarget),
+    )).toMatchObject({ phase: 'collecting', failures: 1 });
   });
 
   it('backs off only after a complete clean-absence rotation and requires a fresh next cycle', async () => {
@@ -2592,15 +2624,69 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     }
-    expect(networkAttempts).toEqual([peerA, peerB, peerC]);
+    expect(networkAttempts).toEqual([peerA, peerD, peerB]);
     expect(curatorResolutions).toBe(3);
 
     await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
-    expect(networkAttempts).toEqual([peerA, peerB, peerC]);
+    expect(networkAttempts).toEqual([peerA, peerD, peerB]);
     expect(curatorResolutions).toBe(3);
   });
 
-  it('retries credited peers after an incomplete collection cycle expires', async () => {
+  it('ranks a resolved structural curator ahead of an ordinary capped roster', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmResolvedCuratorRoster', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peers = [
+      '12D3KooWResolvedCuratorA',
+      '12D3KooWResolvedCuratorB',
+      '12D3KooWResolvedCuratorC',
+      '12D3KooWResolvedCuratorD',
+    ];
+    const curatorPeerId = peers[3]!;
+    const localCgId = '0x0000000000000000000000000000000000000001/resolved-curator';
+    const connected = peers.map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWResolvedCuratorLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [curatorPeerId], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (ordered: Array<{ toString(): string }>) => ordered;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const attempts: string[] = [];
+    let lastPeerId: string | undefined;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      attempts.push(peerId);
+      lastPeerId = peerId;
+      return {
+        result: {
+          fetchedDataTriples: peerId === curatorPeerId ? 1 : 0,
+          fetchedMetaTriples: peerId === curatorPeerId ? 8 : 0,
+          insertedTriples: peerId === curatorPeerId ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: peerId === curatorPeerId ? 'found' : 'clean-absent',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, '80');
+    (internals as any).reconcileChainOrdinal = async () => (
+      lastPeerId === curatorPeerId
+        ? { status: 'reconciled', blockNumber: 100 }
+        : { status: 'pending', recovery: target }
+    );
+
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+
+    expect(attempts).toEqual([curatorPeerId]);
+    expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+  });
+
+  it('backs off a mixed no-progress rotation and retries after expiry', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmPartialCycleExpiry', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
@@ -2658,9 +2744,9 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const partial = (internals as any).vmReconcileRotationState.get(slotKey);
     expect(networkAttempts).toEqual([peerA, peerB]);
     expect([...partial.cleanAbsentPeerIds]).toEqual([peerA]);
-    expect(partial).toMatchObject({ phase: 'collecting', failures: 0 });
+    expect(partial).toMatchObject({ phase: 'backoff', failures: 1 });
 
-    now = partial.collectionDeadlineAt + 1;
+    now = partial.nextRetryAt + 1;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const recovered = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
@@ -2782,7 +2868,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     }
   });
 
-  it('starts a fresh clean-absence proof after candidate growth and ignores evicted records', async () => {
+  it('preserves retained proof across candidate growth and ignores evicted records', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmRotationIdentity', chainAdapter: chain });
     stubNode(agent);
@@ -2805,7 +2891,8 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     );
     expect(grown.record).toBe(initial.record);
     expect(grown.record.phase).toBe('collecting');
-    expect([...grown.record.cleanAbsentPeerIds]).toEqual([]);
+    expect([...grown.record.cleanAbsentPeerIds]).toEqual([peerA]);
+    expect([...grown.record.attemptedPeerIds]).toEqual([peerA]);
 
     const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
     (internals as any).vmReconcileRotationState.delete(slotKey);
@@ -2838,6 +2925,72 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     (internals as any).creditVmReconcileCleanAbsence(
       target, peerA, [peerA], shutdownRecord,
     );
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+  });
+
+  it('preserves retained attempts across capped-roster replacement and rejoin', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmRotationReplacement', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const target = vmRecoveryTarget('rotation-replacement', 0, '81');
+    const peerA = '12D3KooWRotationReplacementA';
+    const peerB = '12D3KooWRotationReplacementB';
+    const peerC = '12D3KooWRotationReplacementC';
+    const peerD = '12D3KooWRotationReplacementD';
+    let now = 100;
+    (internals as any).vmReconcileRotationNow = () => now;
+
+    const initial = (internals as any).prepareVmReconcileRotationTarget(
+      target, [peerA, peerB, peerC], now,
+    ).record;
+    for (const peerId of [peerA, peerB, peerC]) {
+      (internals as any).settleVmReconcileRotationAttempt(
+        target, peerId, 'incomplete', [peerA, peerB, peerC], initial,
+      );
+    }
+    expect(initial).toMatchObject({ phase: 'backoff', failures: 1 });
+
+    now += 1;
+    const replaced = (internals as any).prepareVmReconcileRotationTarget(
+      target, [peerA, peerC, peerD], now,
+    ).record;
+    expect(replaced).toBe(initial);
+    expect([...replaced.attemptedPeerIds]).toEqual([peerA, peerC]);
+    expect((internals as any).vmReconcileUncreditedCandidateOrder(replaced)).toEqual([peerD]);
+    (internals as any).settleVmReconcileRotationAttempt(
+      target, peerD, 'incomplete', [peerA, peerC, peerD], replaced,
+    );
+    expect(replaced).toMatchObject({ phase: 'backoff', failures: 2 });
+
+    now += 1;
+    const rejoined = (internals as any).prepareVmReconcileRotationTarget(
+      target, [peerA, peerB, peerC], now,
+    ).record;
+    expect(rejoined).toBe(initial);
+    expect([...rejoined.attemptedPeerIds]).toEqual([peerA, peerC]);
+    expect((internals as any).vmReconcileUncreditedCandidateOrder(rejoined)).toEqual([peerB]);
+  });
+
+  it('ignores stale exact-recovery targets before creating state or fetching', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmStaleTarget', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const fetch = vi.fn();
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+    const staleLocal = vmRecoveryTarget('other-context-graph', 0, '82');
+    const staleOnChain = {
+      ...vmRecoveryTarget('current-context-graph', 1, '83'),
+      onChainCgId: '2',
+    };
+
+    const result = await internals.recoverVmReconcileBatch(
+      'current-context-graph', 1n, [staleLocal, staleOnChain], 100, () => true,
+    );
+
+    expect(result.attemptedOrdinals).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
     expect((internals as any).vmReconcileRotationState.size).toBe(0);
   });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2193,6 +2193,59 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       .toEqual(curators.slice(0, 3));
   });
 
+  it('keeps a successful-empty metadata fallback ahead of the ordinary roster cap', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmFallbackCurator', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/fallback-curator';
+    const fallbackPeer = '12D3KooWFallbackCuratorHolder';
+    const ordinaryPeers = [1, 2, 3].map((n) => `12D3KooWFallbackOrdinary${n}`);
+    const connectedById = new Map(
+      ordinaryPeers.map((peerId) => [peerId, { toString: () => peerId }]),
+    );
+    (internals as any).node = {
+      peerId: '12D3KooWFallbackCuratorLocal',
+      libp2p: {
+        getConnections: () => [...connectedById.values()].map((remotePeer) => ({ remotePeer })),
+      },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [], curatorIsLocal: false, legacyTripleResolved: false, lookupFailed: false,
+    });
+    (internals as any).resolvePreferredSyncPeerId = async () => fallbackPeer;
+    (internals as any).ensurePeerConnected = async (peerId: string) => {
+      connectedById.set(peerId, { toString: () => peerId });
+    };
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const fetches: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      fetches.push(peerId);
+      return {
+        result: {
+          fetchedDataTriples: peerId === fallbackPeer ? 1 : 0,
+          fetchedMetaTriples: peerId === fallbackPeer ? 8 : 0,
+          insertedTriples: peerId === fallbackPeer ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: peerId === fallbackPeer ? 'found' : 'clean-absent',
+      };
+    };
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [vmRecoveryTarget(localCgId, 0, 'fallback')], 100, () => true,
+    );
+
+    expect(fetches).toEqual([fallbackPeer]);
+    expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+    expect((internals as any).vmReconcileCuratorPeersByCg.get(localCgId))
+      .toEqual([fallbackPeer]);
+  });
+
   it('clears cached authoritative curators after a successful empty resolution', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmClearCuratorCache', chainAdapter: chain });
@@ -2204,7 +2257,6 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       peerId: '12D3KooWClearCuratorLocal',
       libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
     };
-    (internals as any).preferredSyncPeers.set(localCgId, stalePeer);
     (internals as any).vmReconcileCuratorPeersByCg.set(localCgId, [stalePeer]);
     (internals as any).resolveCuratorPeerIdsForCg = async () => ({
       peerIds: [], curatorIsLocal: false, legacyTripleResolved: false, lookupFailed: false,
@@ -2244,9 +2296,10 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
     };
     (internals as any).vmReconcileCuratorPeersByCg.set(localCgId, [cachedPeer]);
-    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
-      peerIds: [], curatorIsLocal: false, legacyTripleResolved: false, lookupFailed: true,
-    });
+    (internals as any).discovery.findAgents = async () => {
+      throw new Error('agent registry unavailable');
+    };
+    (internals as any).refreshMetaFromCurator = async () => false;
     (internals as any).ensurePeerConnected = async () => undefined;
     (internals as any).selectCatchupPeers = () => [connectedPeer];
     (internals as any).waitForSyncProtocol = async () => true;
@@ -2466,6 +2519,13 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(second.attemptedOrdinals).toEqual([1]);
     expect(second.continuationOrdinal).toBeUndefined();
 
+    const rotationState = (internals as any).vmReconcileRotationState as Map<
+      string,
+      { nextRetryAt: number }
+    >;
+    now = Math.max(...targets.map((target) => rotationState.get(
+      (internals as any).vmReconcileRotationSlotKey(target),
+    )!.nextRetryAt));
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const wrapped = await internals.recoverVmReconcileBatch(
       localCgId, 1n, targets, 100, () => true,
@@ -2475,7 +2535,9 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const firstRecord = (internals as any).vmReconcileRotationState.get(
       (internals as any).vmReconcileRotationSlotKey(targets[0]),
     );
-    expect(firstRecord).toMatchObject({ phase: 'collecting', failures: 0 });
+    expect(firstRecord).toMatchObject({
+      phase: 'backoff', backoffReason: 'no-progress', failures: 2,
+    });
   });
 
   it('rotates one pending recovery target across eligible peers between windows', async () => {
@@ -2613,20 +2675,23 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
       await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
     }
-    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB]);
     const record = (internals as any).vmReconcileRotationState.get(
       (internals as any).vmReconcileRotationSlotKey(activeTarget),
     );
     expect(record.cleanAbsentPeerIds.size).toBe(0);
-    expect(record).toMatchObject({ phase: 'collecting', failures: 0 });
-    expect([...record.attemptedPeerIds]).toEqual([peerA]);
+    expect(record).toMatchObject({
+      phase: 'backoff', backoffReason: 'no-progress', failures: 1,
+    });
+    expect([...record.attemptedPeerIds]).toEqual([]);
 
+    now = record.nextRetryAt;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
-    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA, peerB]);
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
     expect((internals as any).vmReconcileRotationState.get(
       (internals as any).vmReconcileRotationSlotKey(activeTarget),
-    )).toMatchObject({ phase: 'collecting', failures: 0 });
+    )).toMatchObject({ phase: 'collecting', failures: 1 });
   });
 
   it('backs off only after a complete clean-absence rotation and requires a fresh next cycle', async () => {
@@ -2822,7 +2887,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
   });
 
-  it('fails open after a mixed clean-absence and incomplete rotation', async () => {
+  it('completion-anchors no-progress backoff after a legacy full-CG incomplete rotation', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmPartialCycleExpiry', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
@@ -2857,7 +2922,11 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
           : 'incomplete';
       return {
         result: {
-          fetchedDataTriples: lastDisposition === 'found' ? 1 : 0,
+          fetchedDataTriples: lastDisposition === 'found'
+            ? 1
+            : lastDisposition === 'incomplete'
+              ? 50_000
+              : 0,
           fetchedMetaTriples: lastDisposition === 'found' ? 8 : 0,
           insertedTriples: lastDisposition === 'found' ? 9 : 0,
           failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
@@ -2881,8 +2950,16 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(networkAttempts).toEqual([peerA, peerB]);
     expect([...partial.cleanAbsentPeerIds]).toEqual([]);
     expect([...partial.attemptedPeerIds]).toEqual([]);
-    expect(partial).toMatchObject({ phase: 'collecting', failures: 0, nextRetryAt: 0 });
+    expect(partial).toMatchObject({
+      phase: 'backoff', backoffReason: 'no-progress', failures: 1,
+    });
+    expect(partial.nextRetryAt).toBeGreaterThan(now);
 
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(networkAttempts).toEqual([peerA, peerB]);
+
+    now = partial.nextRetryAt;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const recovered = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
@@ -2995,6 +3072,51 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       expect(rotationState.get(overflowKey)).toMatchObject({ phase: 'backoff' });
       expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB, peerB, peerA]);
       expect(attemptsByUal.get(overflow.ual)).toEqual([peerB, peerA, peerA, peerB]);
+    } finally {
+      Object.defineProperty(
+        DKGAgentBase,
+        'VM_RECONCILE_CACHE_MAX_ENTRIES',
+        capDescriptor,
+      );
+    }
+  });
+
+  it('makes a completed no-progress rotation evictable at the state cap', async () => {
+    const capDescriptor = Object.getOwnPropertyDescriptor(
+      DKGAgentBase,
+      'VM_RECONCILE_CACHE_MAX_ENTRIES',
+    )!;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_CACHE_MAX_ENTRIES', {
+      ...capDescriptor,
+      value: 1,
+    });
+    try {
+      const chain = new MockChainAdapter();
+      agent = await DKGAgent.create({ name: 'ExactVmNoProgressCapacity', chainAdapter: chain });
+      stubNode(agent);
+      const internals = agent as unknown as AgentInternals;
+      const peer = '12D3KooWNoProgressCapacityPeer';
+      const first = vmRecoveryTarget('no-progress-capacity', 0, 'first');
+      const second = vmRecoveryTarget('no-progress-capacity', 1, 'second');
+      const firstKey = (internals as any).vmReconcileRotationSlotKey(first);
+      const secondKey = (internals as any).vmReconcileRotationSlotKey(second);
+      const firstRecord = (internals as any).prepareVmReconcileRotationTarget(
+        first, [peer], 100,
+      ).record;
+
+      (internals as any).settleVmReconcileRotationAttempt(
+        first, peer, 'incomplete', [peer], firstRecord,
+      );
+      expect(firstRecord).toMatchObject({
+        phase: 'backoff', backoffReason: 'no-progress', failures: 1,
+      });
+
+      const secondRecord = (internals as any).prepareVmReconcileRotationTarget(
+        second, [peer], 101,
+      ).record;
+      expect(secondRecord).toBeDefined();
+      expect((internals as any).vmReconcileRotationState.has(firstKey)).toBe(false);
+      expect((internals as any).vmReconcileRotationState.get(secondKey)).toBe(secondRecord);
     } finally {
       Object.defineProperty(
         DKGAgentBase,
@@ -3182,6 +3304,123 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
 
     expect(result.attemptedOrdinals).toEqual([]);
     expect(fetch).not.toHaveBeenCalled();
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+  });
+
+  it.each(['unsubscribe', 'rebind'])('does not recreate state after %s during curator resolution', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmResolutionInvalidation', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/resolution-invalidation';
+    const peer = '12D3KooWResolutionInvalidationPeer';
+    const connectedPeer = { toString: () => peer };
+    (internals as any).node = {
+      peerId: '12D3KooWResolutionInvalidationLocal',
+      libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+    };
+    let releaseResolution!: () => void;
+    let markResolutionStarted!: () => void;
+    const resolutionStarted = new Promise<void>((resolve) => { markResolutionStarted = resolve; });
+    const resolutionRelease = new Promise<void>((resolve) => { releaseResolution = resolve; });
+    (internals as any).resolveCuratorPeerIdsForCg = async () => {
+      markResolutionStarted();
+      await resolutionRelease;
+      return { peerIds: [peer], curatorIsLocal: false, legacyTripleResolved: false };
+    };
+    const connect = recorder(async () => undefined);
+    const fetch = recorder(async () => undefined);
+    (internals as any).ensurePeerConnected = connect;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+    let current = true;
+    const target = vmRecoveryTarget(localCgId, 0, 'resolution-invalidation');
+    const recovery = internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => current,
+    );
+    await resolutionStarted;
+    current = false;
+    (internals as any).forceClearVmReconcileStateForContextGraph(localCgId);
+    releaseResolution();
+
+    await expect(recovery).resolves.toMatchObject({ attemptedOrdinals: [] });
+    expect(connect.calls).toEqual([]);
+    expect(fetch.calls).toEqual([]);
+    expect((internals as any).vmReconcileCuratorPeersByCg.has(localCgId)).toBe(false);
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+  });
+
+  it('does not recreate state after shutdown during fallback resolution', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmFallbackShutdown', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/fallback-shutdown';
+    const peer = '12D3KooWFallbackShutdownPeer';
+    const connectedPeer = { toString: () => peer };
+    (internals as any).node = {
+      peerId: '12D3KooWFallbackShutdownLocal',
+      libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    let releaseFallback!: () => void;
+    let markFallbackStarted!: () => void;
+    const fallbackStarted = new Promise<void>((resolve) => { markFallbackStarted = resolve; });
+    const fallbackRelease = new Promise<void>((resolve) => { releaseFallback = resolve; });
+    (internals as any).resolvePreferredSyncPeerId = async () => {
+      markFallbackStarted();
+      await fallbackRelease;
+      return peer;
+    };
+    const connect = recorder(async () => undefined);
+    (internals as any).ensurePeerConnected = connect;
+    const recovery = internals.recoverVmReconcileBatch(
+      localCgId, 1n, [vmRecoveryTarget(localCgId, 0, 'fallback-shutdown')], 100, () => true,
+    );
+    await fallbackStarted;
+    (internals as any).closeVmReconcileRotationState();
+    releaseFallback();
+
+    await expect(recovery).resolves.toMatchObject({ attemptedOrdinals: [] });
+    expect(connect.calls).toEqual([]);
+    expect((internals as any).vmReconcileCuratorPeersByCg.size).toBe(0);
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+  });
+
+  it('does not recreate state after a rebind while dialing the curator', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmDialInvalidation', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/dial-invalidation';
+    const peer = '12D3KooWDialInvalidationPeer';
+    (internals as any).node = {
+      peerId: '12D3KooWDialInvalidationLocal',
+      libp2p: { getConnections: () => [] },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peer], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    let releaseDial!: () => void;
+    let markDialStarted!: () => void;
+    const dialStarted = new Promise<void>((resolve) => { markDialStarted = resolve; });
+    const dialRelease = new Promise<void>((resolve) => { releaseDial = resolve; });
+    (internals as any).ensurePeerConnected = async () => {
+      markDialStarted();
+      await dialRelease;
+    };
+    const fetch = recorder(async () => undefined);
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+    let current = true;
+    const recovery = internals.recoverVmReconcileBatch(
+      localCgId, 1n, [vmRecoveryTarget(localCgId, 0, 'dial-invalidation')], 100, () => current,
+    );
+    await dialStarted;
+    current = false;
+    (internals as any).forceClearVmReconcileStateForContextGraph(localCgId);
+    releaseDial();
+
+    await expect(recovery).resolves.toMatchObject({ attemptedOrdinals: [] });
+    expect(fetch.calls).toEqual([]);
+    expect((internals as any).vmReconcileCuratorPeersByCg.has(localCgId)).toBe(false);
     expect((internals as any).vmReconcileRotationState.size).toBe(0);
   });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2132,11 +2132,147 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       () => true,
     );
 
-    expect(connectionAttempts).toEqual([approvedPeer, registryPeer]);
-    expect(protocolPeers[0]).toBe(connected[0]);
-    expect(fetches).toEqual([{ peerId: approvedPeer, uals: [ual] }]);
+    expect(connectionAttempts).toEqual([registryPeer, approvedPeer]);
+    expect(protocolPeers[0]?.toString()).toBe(registryPeer);
+    expect(fetches).toEqual([{ peerId: registryPeer, uals: [ual] }]);
     expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
     expect(result.attemptedOrdinals).toEqual([0]);
+  });
+
+  it('canonicalizes authoritative curators before the cap and ahead of a stale hint', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmCanonicalCurators', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/canonical-curators';
+    const staleHint = '12D3KooWCanonicalCuratorHint';
+    const curators = [1, 2, 3, 4].map((n) => `12D3KooWCanonicalCurator${n}`);
+    const connectedById = new Map(
+      [staleHint, ...curators].map((peerId) => [peerId, { toString: () => peerId }]),
+    );
+    (internals as any).node = {
+      peerId: '12D3KooWCanonicalCuratorLocal',
+      libp2p: {
+        getConnections: () => [...connectedById.values()].map((remotePeer) => ({ remotePeer })),
+      },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, staleHint);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [curators[3], curators[1], curators[2], curators[0]],
+      curatorIsLocal: false,
+      legacyTripleResolved: false,
+    });
+    const connectionAttempts: string[] = [];
+    (internals as any).ensurePeerConnected = async (peerId: string) => {
+      connectionAttempts.push(peerId);
+    };
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const fetches: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      fetches.push(peerId);
+      return {
+        result: {
+          fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'found',
+      };
+    };
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+
+    await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [vmRecoveryTarget(localCgId, 0, '85')], 100, () => true,
+    );
+
+    expect(connectionAttempts).toEqual(curators.slice(0, 3));
+    expect(fetches).toEqual([curators[0]]);
+    expect((internals as any).vmReconcileCuratorPeersByCg.get(localCgId))
+      .toEqual(curators.slice(0, 3));
+  });
+
+  it('clears cached authoritative curators after a successful empty resolution', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmClearCuratorCache', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/clear-curators';
+    const stalePeer = '12D3KooWClearCuratorStale';
+    const connectedPeer = { toString: () => stalePeer };
+    (internals as any).node = {
+      peerId: '12D3KooWClearCuratorLocal',
+      libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, stalePeer);
+    (internals as any).vmReconcileCuratorPeersByCg.set(localCgId, [stalePeer]);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [], curatorIsLocal: false, legacyTripleResolved: false, lookupFailed: false,
+    });
+    (internals as any).resolvePreferredSyncPeerId = async () => undefined;
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = () => [connectedPeer];
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async () => ({
+      result: {
+        fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+        failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+      },
+      disposition: 'found',
+    });
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+
+    await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [vmRecoveryTarget(localCgId, 0, '86')], 100, () => true,
+    );
+
+    expect((internals as any).vmReconcileCuratorPeersByCg.has(localCgId)).toBe(false);
+  });
+
+  it('retains cached authoritative curators when curator discovery fails', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmRetainCuratorCache', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/retain-curators';
+    const cachedPeer = '12D3KooWRetainCuratorCached';
+    const connectedPeer = { toString: () => cachedPeer };
+    (internals as any).node = {
+      peerId: '12D3KooWRetainCuratorLocal',
+      libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+    };
+    (internals as any).vmReconcileCuratorPeersByCg.set(localCgId, [cachedPeer]);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [], curatorIsLocal: false, legacyTripleResolved: false, lookupFailed: true,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = () => [connectedPeer];
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const fetches: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      fetches.push(peerId);
+      return {
+        result: {
+          fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'found',
+      };
+    };
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+
+    await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [vmRecoveryTarget(localCgId, 0, '87')], 100, () => true,
+    );
+
+    expect(fetches).toEqual([cachedPeer]);
+    expect((internals as any).vmReconcileCuratorPeersByCg.get(localCgId))
+      .toEqual([cachedPeer]);
   });
 
   it('fetches one large recovery KA per peer attempt and defers the rest', async () => {
@@ -2334,19 +2470,12 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const wrapped = await internals.recoverVmReconcileBatch(
       localCgId, 1n, targets, 100, () => true,
     );
-    expect(wrapped.attemptedOrdinals).toEqual([]);
-    expect(networkAttempts).toEqual([0, 1]);
-
+    expect(wrapped.attemptedOrdinals).toEqual([0]);
+    expect(networkAttempts).toEqual([0, 1, 0]);
     const firstRecord = (internals as any).vmReconcileRotationState.get(
       (internals as any).vmReconcileRotationSlotKey(targets[0]),
     );
-    now = firstRecord.nextRetryAt + 1;
-    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
-    const retried = await internals.recoverVmReconcileBatch(
-      localCgId, 1n, targets, 100, () => true,
-    );
-    expect(retried.attemptedOrdinals).toEqual([0]);
-    expect(networkAttempts).toEqual([0, 1, 0]);
+    expect(firstRecord).toMatchObject({ phase: 'collecting', failures: 0 });
   });
 
   it('rotates one pending recovery target across eligible peers between windows', async () => {
@@ -2411,7 +2540,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(second.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
   });
 
-  it('rotates incomplete exact attempts without granting absence credit', async () => {
+  it('rotates incomplete, thrown, and still-pending found attempts without absence credit', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmIncompleteRotation', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
@@ -2444,7 +2573,14 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       const attempts = attemptsByUal.get(ual) ?? [];
       attempts.push(peerId);
       attemptsByUal.set(ual, attempts);
-      lastDisposition = ual.endsWith('/76') && peerId === peerB ? 'found' : 'incomplete';
+      if (ual.endsWith('/77') && peerId === peerB) {
+        lastDisposition = 'incomplete';
+        throw new Error('transport failed');
+      }
+      lastDisposition = (ual.endsWith('/76') && peerId === peerB)
+        || (ual.endsWith('/77') && peerId === peerA)
+        ? 'found'
+        : 'incomplete';
       return {
         result: {
           fetchedDataTriples: lastDisposition === 'found' ? 1 : 0,
@@ -2458,7 +2594,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     };
     let activeTarget = vmRecoveryTarget(localCgId, 0, '76');
     (internals as any).reconcileChainOrdinal = async () => (
-      lastDisposition === 'found'
+      activeTarget.ual.endsWith('/76') && lastDisposition === 'found'
         ? { status: 'reconciled', blockNumber: 100 }
         : { status: 'pending', recovery: activeTarget }
     );
@@ -2477,20 +2613,20 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
       await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
     }
-    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB]);
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
     const record = (internals as any).vmReconcileRotationState.get(
       (internals as any).vmReconcileRotationSlotKey(activeTarget),
     );
     expect(record.cleanAbsentPeerIds.size).toBe(0);
-    expect(record).toMatchObject({ phase: 'backoff', failures: 1 });
+    expect(record).toMatchObject({ phase: 'collecting', failures: 0 });
+    expect([...record.attemptedPeerIds]).toEqual([peerA]);
 
-    now = record.nextRetryAt + 1;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
-    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA, peerB]);
     expect((internals as any).vmReconcileRotationState.get(
       (internals as any).vmReconcileRotationSlotKey(activeTarget),
-    )).toMatchObject({ phase: 'collecting', failures: 1 });
+    )).toMatchObject({ phase: 'collecting', failures: 0 });
   });
 
   it('backs off only after a complete clean-absence rotation and requires a fresh next cycle', async () => {
@@ -2686,7 +2822,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
   });
 
-  it('backs off a mixed no-progress rotation and retries after expiry', async () => {
+  it('fails open after a mixed clean-absence and incomplete rotation', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmPartialCycleExpiry', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
@@ -2743,10 +2879,10 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
     const partial = (internals as any).vmReconcileRotationState.get(slotKey);
     expect(networkAttempts).toEqual([peerA, peerB]);
-    expect([...partial.cleanAbsentPeerIds]).toEqual([peerA]);
-    expect(partial).toMatchObject({ phase: 'backoff', failures: 1 });
+    expect([...partial.cleanAbsentPeerIds]).toEqual([]);
+    expect([...partial.attemptedPeerIds]).toEqual([]);
+    expect(partial).toMatchObject({ phase: 'collecting', failures: 0, nextRetryAt: 0 });
 
-    now = partial.nextRetryAt + 1;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const recovered = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
@@ -2928,7 +3064,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect((internals as any).vmReconcileRotationState.size).toBe(0);
   });
 
-  it('preserves retained attempts across capped-roster replacement and rejoin', async () => {
+  it('clears the complete proof cycle across capped-roster replacement and rejoin', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmRotationReplacement', chainAdapter: chain });
     stubNode(agent);
@@ -2946,7 +3082,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     ).record;
     for (const peerId of [peerA, peerB, peerC]) {
       (internals as any).settleVmReconcileRotationAttempt(
-        target, peerId, 'incomplete', [peerA, peerB, peerC], initial,
+        target, peerId, 'clean-absent', [peerA, peerB, peerC], initial,
       );
     }
     expect(initial).toMatchObject({ phase: 'backoff', failures: 1 });
@@ -2956,20 +3092,75 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       target, [peerA, peerC, peerD], now,
     ).record;
     expect(replaced).toBe(initial);
-    expect([...replaced.attemptedPeerIds]).toEqual([peerA, peerC]);
-    expect((internals as any).vmReconcileUncreditedCandidateOrder(replaced)).toEqual([peerD]);
+    expect(replaced).toMatchObject({ phase: 'collecting', failures: 1, nextRetryAt: 0 });
+    expect([...replaced.attemptedPeerIds]).toEqual([]);
+    expect([...replaced.cleanAbsentPeerIds]).toEqual([]);
+    expect((internals as any).vmReconcileUncreditedCandidateOrder(replaced))
+      .toEqual([peerA, peerC, peerD]);
     (internals as any).settleVmReconcileRotationAttempt(
-      target, peerD, 'incomplete', [peerA, peerC, peerD], replaced,
+      target, peerA, 'clean-absent', [peerA, peerC, peerD], replaced,
     );
-    expect(replaced).toMatchObject({ phase: 'backoff', failures: 2 });
+    expect([...replaced.cleanAbsentPeerIds]).toEqual([peerA]);
 
     now += 1;
     const rejoined = (internals as any).prepareVmReconcileRotationTarget(
       target, [peerA, peerB, peerC], now,
     ).record;
     expect(rejoined).toBe(initial);
-    expect([...rejoined.attemptedPeerIds]).toEqual([peerA, peerC]);
-    expect((internals as any).vmReconcileUncreditedCandidateOrder(rejoined)).toEqual([peerB]);
+    expect(rejoined).toMatchObject({ phase: 'collecting', failures: 1, nextRetryAt: 0 });
+    expect([...rejoined.attemptedPeerIds]).toEqual([]);
+    expect([...rejoined.cleanAbsentPeerIds]).toEqual([]);
+    expect((internals as any).vmReconcileUncreditedCandidateOrder(rejoined))
+      .toEqual([peerA, peerB, peerC]);
+  });
+
+  it('clears partial and active-backoff evidence on roster shrink', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmRotationShrink', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const peerA = '12D3KooWRotationShrinkA';
+    const peerB = '12D3KooWRotationShrinkB';
+
+    const partialTarget = vmRecoveryTarget('rotation-shrink', 0, '87');
+    const partial = (internals as any).prepareVmReconcileRotationTarget(
+      partialTarget, [peerA, peerB], 100,
+    ).record;
+    (internals as any).settleVmReconcileRotationAttempt(
+      partialTarget, peerA, 'incomplete', [peerA, peerB], partial,
+    );
+    expect([...partial.attemptedPeerIds]).toEqual([peerA]);
+
+    const shrunkPartial = (internals as any).prepareVmReconcileRotationTarget(
+      partialTarget, [peerA], 101,
+    );
+    expect(shrunkPartial.suppressed).toBe(false);
+    expect(shrunkPartial.record).toMatchObject({ phase: 'collecting', failures: 0 });
+    expect([...shrunkPartial.record.attemptedPeerIds]).toEqual([]);
+    expect([...shrunkPartial.record.cleanAbsentPeerIds]).toEqual([]);
+    // A response captured against the old roster is inert after shrink.
+    (internals as any).settleVmReconcileRotationAttempt(
+      partialTarget, peerB, 'clean-absent', [peerA, peerB], partial,
+    );
+    expect([...shrunkPartial.record.cleanAbsentPeerIds]).toEqual([]);
+
+    const backoffTarget = vmRecoveryTarget('rotation-shrink', 1, '88');
+    const backoff = (internals as any).prepareVmReconcileRotationTarget(
+      backoffTarget, [peerA, peerB], 200,
+    ).record;
+    for (const peerId of [peerA, peerB]) {
+      (internals as any).settleVmReconcileRotationAttempt(
+        backoffTarget, peerId, 'clean-absent', [peerA, peerB], backoff,
+      );
+    }
+    expect(backoff.phase).toBe('backoff');
+    const shrunkBackoff = (internals as any).prepareVmReconcileRotationTarget(
+      backoffTarget, [peerA], 201,
+    );
+    expect(shrunkBackoff.suppressed).toBe(false);
+    expect(shrunkBackoff.record).toMatchObject({ phase: 'collecting', failures: 1 });
+    expect([...shrunkBackoff.record.attemptedPeerIds]).toEqual([]);
+    expect([...shrunkBackoff.record.cleanAbsentPeerIds]).toEqual([]);
   });
 
   it('ignores stale exact-recovery targets before creating state or fetching', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -3305,6 +3305,35 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect((internals as any).vmReconcileRotationState.size).toBe(0);
   });
 
+  it('closes exact-recovery rotation state through the public stop path', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmRotationPublicStop', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const target = vmRecoveryTarget('rotation-public-stop', 0, 'stop');
+    const peer = '12D3KooWRotationPublicStop';
+    (internals as any).started = true;
+    (internals as any).node = {
+      peerId: '12D3KooWRotationPublicStopLocal',
+      libp2p: { getPeers: () => [] },
+      stop: vi.fn(async () => undefined),
+    };
+    (internals as any).messenger = { stopOutboxDrain: vi.fn(async () => undefined) };
+    const record = (internals as any).prepareVmReconcileRotationTarget(
+      target, [peer], 100,
+    ).record;
+    expect((internals as any).vmReconcileRotationState.size).toBe(1);
+
+    await agent.stop();
+
+    expect((internals as any).vmReconcileRotationClosed).toBe(true);
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+    (internals as any).settleVmReconcileRotationAttempt(
+      target, peer, 'clean-absent', [peer], record,
+    );
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+    agent = null;
+  });
+
   it('clears the complete proof cycle across capped-roster replacement and rejoin', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmRotationReplacement', chainAdapter: chain });
@@ -3402,6 +3431,65 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(shrunkBackoff.record).toMatchObject({ phase: 'collecting', failures: 1 });
     expect([...shrunkBackoff.record.attemptedPeerIds]).toEqual([]);
     expect([...shrunkBackoff.record.cleanAbsentPeerIds]).toEqual([]);
+  });
+
+  it('preserves active backoff across an empty socket view but drops partial evidence', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmEmptyRoster', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peer = '12D3KooWEmptyRosterPeer';
+    const otherPeer = '12D3KooWEmptyRosterOther';
+    const localCgId = '0x0000000000000000000000000000000000000001/empty-roster';
+    (internals as any).node = {
+      peerId: '12D3KooWEmptyRosterLocal',
+      libp2p: { getConnections: () => [] },
+    };
+    let now = 100;
+    (internals as any).vmReconcileRotationNow = () => now;
+
+    const partialTarget = vmRecoveryTarget(localCgId, 0, 'partial-empty');
+    const partial = (internals as any).prepareVmReconcileRotationTarget(
+      partialTarget, [peer, otherPeer], now,
+    ).record;
+    (internals as any).settleVmReconcileRotationAttempt(
+      partialTarget, peer, 'incomplete', [peer, otherPeer], partial,
+    );
+    expect([...partial.attemptedPeerIds]).toEqual([peer]);
+    const partialKey = (internals as any).vmReconcileRotationSlotKey(partialTarget);
+    const emptyPartial = (internals as any).prepareVmReconcileRotationTarget(
+      partialTarget, [], now + 1,
+    );
+    expect(emptyPartial.suppressed).toBe(false);
+    expect((internals as any).vmReconcileRotationState.has(partialKey)).toBe(false);
+    const rejoinedPartial = (internals as any).prepareVmReconcileRotationTarget(
+      partialTarget, [peer], now + 2,
+    ).record;
+    expect([...rejoinedPartial.attemptedPeerIds]).toEqual([]);
+    expect([...rejoinedPartial.cleanAbsentPeerIds]).toEqual([]);
+
+    const backoffTarget = vmRecoveryTarget(localCgId, 1, 'backoff-empty');
+    const backoff = (internals as any).prepareVmReconcileRotationTarget(
+      backoffTarget, [peer], now,
+    ).record;
+    (internals as any).settleVmReconcileRotationAttempt(
+      backoffTarget, peer, 'clean-absent', [peer], backoff,
+    );
+    expect(backoff.phase).toBe('backoff');
+    now += 1;
+
+    const resolveCurators = vi.fn();
+    (internals as any).resolveCuratorPeerIdsForCg = resolveCurators;
+    const fetch = vi.fn();
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [backoffTarget], 100, () => true,
+    );
+    expect(result.attemptedOrdinals).toEqual([]);
+    expect(resolveCurators).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect((internals as any).vmReconcileRotationState.get(
+      (internals as any).vmReconcileRotationSlotKey(backoffTarget),
+    )).toBe(backoff);
   });
 
   it('ignores stale exact-recovery targets before creating state or fetching', async () => {
@@ -3540,6 +3628,112 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     await expect(recovery).resolves.toMatchObject({ attemptedOrdinals: [] });
     expect(fetch.calls).toEqual([]);
     expect((internals as any).vmReconcileCuratorPeersByCg.has(localCgId)).toBe(false);
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+  });
+
+  it.each(['protocol', 'admission'] as const)(
+    'does not start stale transport after invalidation during the %s wait',
+    async (stage) => {
+      const chain = new MockChainAdapter();
+      agent = await DKGAgent.create({ name: 'ExactVmBoundaryInvalidation', chainAdapter: chain });
+      const internals = agent as unknown as AgentInternals;
+      const localCgId = `0x0000000000000000000000000000000000000001/${stage}-invalidation`;
+      const peer = `12D3KooW${stage}InvalidationPeer`;
+      const connectedPeer = { toString: () => peer };
+      (internals as any).node = {
+        peerId: '12D3KooWBoundaryInvalidationLocal',
+        libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+      };
+      (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+        peerIds: [peer], curatorIsLocal: false, legacyTripleResolved: false,
+      });
+      (internals as any).ensurePeerConnected = async () => undefined;
+      (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+      let releaseBoundary!: () => void;
+      let markBoundaryStarted!: () => void;
+      const boundaryStarted = new Promise<void>((resolve) => { markBoundaryStarted = resolve; });
+      const boundaryRelease = new Promise<void>((resolve) => { releaseBoundary = resolve; });
+      (internals as any).waitForSyncProtocol = async () => {
+        if (stage === 'protocol') {
+          markBoundaryStarted();
+          await boundaryRelease;
+        }
+        return true;
+      };
+      (internals as any).ensurePeerAdmittedForRecovery = async () => {
+        if (stage === 'admission') {
+          markBoundaryStarted();
+          await boundaryRelease;
+        }
+        return true;
+      };
+      const fetch = vi.fn();
+      (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+      let current = true;
+      const target = vmRecoveryTarget(localCgId, 0, `${stage}-invalidation`);
+      const recovery = internals.recoverVmReconcileBatch(
+        localCgId, 1n, [target], 100, () => current,
+      );
+      await boundaryStarted;
+      current = false;
+      (internals as any).forceClearVmReconcileStateForContextGraph(localCgId);
+      releaseBoundary();
+
+      await expect(recovery).resolves.toMatchObject({ attemptedOrdinals: [] });
+      expect(fetch).not.toHaveBeenCalled();
+      expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
+      expect((internals as any).vmReconcileRotationState.size).toBe(0);
+    },
+  );
+
+  it('does not restore cooldown after invalidation during exact transport', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmTransportInvalidation', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/transport-invalidation';
+    const peer = '12D3KooWTransportInvalidationPeer';
+    const connectedPeer = { toString: () => peer };
+    (internals as any).node = {
+      peerId: '12D3KooWTransportInvalidationLocal',
+      libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peer], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    let releaseFetch!: () => void;
+    let markFetchStarted!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => { markFetchStarted = resolve; });
+    const fetchRelease = new Promise<void>((resolve) => { releaseFetch = resolve; });
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async () => {
+      markFetchStarted();
+      await fetchRelease;
+      return {
+        result: {
+          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'clean-absent',
+      };
+    };
+    const reconcile = vi.fn();
+    (internals as any).reconcileChainOrdinal = reconcile;
+    let current = true;
+    const target = vmRecoveryTarget(localCgId, 0, 'transport-invalidation');
+    const recovery = internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => current,
+    );
+    await fetchStarted;
+    current = false;
+    (internals as any).forceClearVmReconcileStateForContextGraph(localCgId);
+    releaseFetch();
+
+    await expect(recovery).resolves.toMatchObject({ attemptedOrdinals: [] });
+    expect(reconcile).not.toHaveBeenCalled();
+    expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
     expect((internals as any).vmReconcileRotationState.size).toBe(0);
   });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -3593,6 +3593,52 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect((internals as any).vmReconcileRotationState.size).toBe(0);
   });
 
+  it('keeps a pre-stop exact recovery stale after rotation state reopens', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmRestartGeneration', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/restart-generation';
+    const peer = '12D3KooWRestartGenerationPeer';
+    const connectedPeer = { toString: () => peer };
+    (internals as any).node = {
+      peerId: '12D3KooWRestartGenerationLocal',
+      libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    let releaseFallback!: () => void;
+    let markFallbackStarted!: () => void;
+    const fallbackStarted = new Promise<void>((resolve) => { markFallbackStarted = resolve; });
+    const fallbackRelease = new Promise<void>((resolve) => { releaseFallback = resolve; });
+    (internals as any).resolvePreferredSyncPeerId = async () => {
+      markFallbackStarted();
+      await fallbackRelease;
+      return peer;
+    };
+    const connect = recorder(async () => undefined);
+    const fetch = recorder(async () => undefined);
+    (internals as any).ensurePeerConnected = connect;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+
+    const recovery = internals.recoverVmReconcileBatch(
+      localCgId, 1n, [vmRecoveryTarget(localCgId, 0, 'restart-generation')], 100, () => true,
+    );
+    await fallbackStarted;
+    const priorGeneration = (internals as any).vmReconcileRotationGeneration;
+    (internals as any).closeVmReconcileRotationState();
+    (internals as any).openVmReconcileRotationState();
+    expect((internals as any).vmReconcileRotationClosed).toBe(false);
+    expect((internals as any).vmReconcileRotationGeneration).toBe(priorGeneration + 1);
+    releaseFallback();
+
+    await expect(recovery).resolves.toMatchObject({ attemptedOrdinals: [] });
+    expect(connect.calls).toEqual([]);
+    expect(fetch.calls).toEqual([]);
+    expect((internals as any).vmReconcileCuratorPeersByCg.size).toBe(0);
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+  });
+
   it('does not recreate state after a rebind while dialing the curator', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmDialInvalidation', chainAdapter: chain });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -3492,6 +3492,118 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     )).toBe(backoff);
   });
 
+  it('does not let an unconfirmed curator roster suppress the next discovery attempt', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmUnconfirmedCuratorBackoff', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/unconfirmed-curator';
+    const ordinaryPeer = '12D3KooWUnconfirmedOrdinary';
+    const target = vmRecoveryTarget(localCgId, 0, 'unconfirmed');
+    const first = (internals as any).prepareVmReconcileRotationTarget(
+      target, [ordinaryPeer], 100, false,
+    );
+    (internals as any).settleVmReconcileRotationAttempt(
+      target, ordinaryPeer, 'clean-absent', [ordinaryPeer], first.record,
+    );
+    expect(first.record).toMatchObject({
+      phase: 'backoff',
+      curatorRosterConfirmed: false,
+    });
+
+    const retry = (internals as any).prepareVmReconcileRotationTarget(
+      target, [ordinaryPeer], 101, false,
+    );
+    expect(retry.suppressed).toBe(false);
+    expect(retry.record).not.toBe(first.record);
+    expect(retry.record).toMatchObject({
+      phase: 'collecting',
+      curatorRosterConfirmed: false,
+    });
+
+    (internals as any).settleVmReconcileRotationAttempt(
+      target, ordinaryPeer, 'clean-absent', [ordinaryPeer], retry.record,
+    );
+    const confirmed = (internals as any).prepareVmReconcileRotationTarget(
+      target, [ordinaryPeer], 102, true,
+    );
+    expect(confirmed.suppressed).toBe(false);
+    expect(confirmed.record).not.toBe(retry.record);
+    expect(confirmed.record.curatorRosterConfirmed).toBe(true);
+    (internals as any).settleVmReconcileRotationAttempt(
+      target, ordinaryPeer, 'clean-absent', [ordinaryPeer], confirmed.record,
+    );
+    expect((internals as any).prepareVmReconcileRotationTarget(
+      target, [ordinaryPeer], 103, true,
+    ).suppressed).toBe(true);
+  });
+
+  it('retries curator discovery after an unconfirmed clean-absence cycle', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmCuratorDiscoveryRetry', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/curator-retry';
+    const ordinaryPeer = '12D3KooWCuratorRetryOrdinary';
+    const curatorPeer = '12D3KooWCuratorRetryAuthoritative';
+    const connectedById = new Map([
+      [ordinaryPeer, { toString: () => ordinaryPeer }],
+    ]);
+    (internals as any).node = {
+      peerId: '12D3KooWCuratorRetryLocal',
+      libp2p: {
+        getConnections: () => [...connectedById.values()]
+          .map((remotePeer) => ({ remotePeer })),
+      },
+    };
+    const resolveCurators = vi.fn()
+      .mockResolvedValueOnce({
+        peerIds: [], curatorIsLocal: false, legacyTripleResolved: false, lookupFailed: true,
+      })
+      .mockResolvedValueOnce({
+        peerIds: [curatorPeer], curatorIsLocal: false,
+        legacyTripleResolved: false, lookupFailed: false,
+      });
+    (internals as any).resolveCuratorPeerIdsForCg = resolveCurators;
+    (internals as any).ensurePeerConnected = async (peerId: string) => {
+      connectedById.set(peerId, { toString: () => peerId });
+    };
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const fetches: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      fetches.push(peerId);
+      const found = peerId === curatorPeer;
+      return {
+        result: {
+          fetchedDataTriples: found ? 1 : 0,
+          fetchedMetaTriples: found ? 8 : 0,
+          insertedTriples: found ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: found ? 'found' : 'clean-absent',
+      };
+    };
+    (internals as any).reconcileChainOrdinal = vi.fn()
+      .mockResolvedValueOnce({ status: 'pending' })
+      .mockResolvedValue({ status: 'reconciled', blockNumber: 100 });
+    const target = vmRecoveryTarget(localCgId, 0, 'curator-retry');
+
+    const first = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    expect(first.outcomes.get(0)).toEqual({ status: 'pending' });
+    expect(fetches).toEqual([ordinaryPeer]);
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+
+    const second = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    expect(resolveCurators).toHaveBeenCalledTimes(2);
+    expect(fetches).toEqual([ordinaryPeer, curatorPeer]);
+    expect(second.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+  });
+
   it('ignores stale exact-recovery targets before creating state or fetching', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmStaleTarget', chainAdapter: chain });
@@ -3625,11 +3737,11 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       localCgId, 1n, [vmRecoveryTarget(localCgId, 0, 'restart-generation')], 100, () => true,
     );
     await fallbackStarted;
-    const priorGeneration = (internals as any).vmReconcileRotationGeneration;
+    const priorGeneration = (internals as any).vmReconcileLifecycleGeneration;
     (internals as any).closeVmReconcileRotationState();
     (internals as any).openVmReconcileRotationState();
     expect((internals as any).vmReconcileRotationClosed).toBe(false);
-    expect((internals as any).vmReconcileRotationGeneration).toBe(priorGeneration + 1);
+    expect((internals as any).vmReconcileLifecycleGeneration).toBe(priorGeneration + 1);
     releaseFallback();
 
     await expect(recovery).resolves.toMatchObject({ attemptedOrdinals: [] });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2519,25 +2519,20 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(second.attemptedOrdinals).toEqual([1]);
     expect(second.continuationOrdinal).toBeUndefined();
 
-    const rotationState = (internals as any).vmReconcileRotationState as Map<
-      string,
-      { nextRetryAt: number }
-    >;
-    now = Math.max(...targets.map((target) => rotationState.get(
-      (internals as any).vmReconcileRotationSlotKey(target),
-    )!.nextRetryAt));
+    const rotationState = (internals as any).vmReconcileRotationState as Map<string, unknown>;
+    expect(rotationState.size).toBe(0);
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const wrapped = await internals.recoverVmReconcileBatch(
       localCgId, 1n, targets, 100, () => true,
     );
     expect(wrapped.attemptedOrdinals).toEqual([0]);
     expect(networkAttempts).toEqual([0, 1, 0]);
-    const firstRecord = (internals as any).vmReconcileRotationState.get(
+    expect(rotationState.has(
       (internals as any).vmReconcileRotationSlotKey(targets[0]),
-    );
-    expect(firstRecord).toMatchObject({
-      phase: 'backoff', backoffReason: 'no-progress', failures: 2,
-    });
+    )).toBe(false);
+    expect(rotationState.has(
+      (internals as any).vmReconcileRotationSlotKey(targets[1]),
+    )).toBe(true);
   });
 
   it('rotates one pending recovery target across eligible peers between windows', async () => {
@@ -2671,27 +2666,29 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
 
     activeTarget = vmRecoveryTarget(localCgId, 1, '77');
     lastDisposition = 'incomplete';
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
-      await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
-    }
-    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB]);
-    const record = (internals as any).vmReconcileRotationState.get(
-      (internals as any).vmReconcileRotationSlotKey(activeTarget),
-    );
-    expect(record.cleanAbsentPeerIds.size).toBe(0);
-    expect(record).toMatchObject({
-      phase: 'backoff', backoffReason: 'no-progress', failures: 1,
-    });
-    expect([...record.attemptedPeerIds]).toEqual([]);
-
-    now = record.nextRetryAt;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB]);
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(activeTarget);
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
+
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    const retried = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [activeTarget], 100, () => true,
+    );
     expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
-    expect((internals as any).vmReconcileRotationState.get(
-      (internals as any).vmReconcileRotationSlotKey(activeTarget),
-    )).toMatchObject({ phase: 'collecting', failures: 1 });
+    expect(retried.outcomes.get(1)).toMatchObject({ status: 'pending' });
+    expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
+      phase: 'collecting', failures: 0,
+    });
+
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA, peerB]);
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
   });
 
   it('backs off only after a complete clean-absence rotation and requires a fresh next cycle', async () => {
@@ -2763,6 +2760,93 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(networkAttempts).toEqual([peerA, peerB, peerA, peerB]);
     expect((internals as any).vmReconcileRotationState.get(slotKey))
       .toMatchObject({ phase: 'backoff', failures: 2 });
+  });
+
+  it('drops a scheduling-exhausted cycle when one peer is rejected and one is incomplete', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmSchedulingExhaustion', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const rejectedPeer = '12D3KooWSchedulingRejected';
+    const incompletePeer = '12D3KooWSchedulingIncomplete';
+    const localCgId = '0x0000000000000000000000000000000000000001/scheduling-exhaustion';
+    const connected = [rejectedPeer, incompletePeer]
+      .map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWSchedulingLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, rejectedPeer);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [rejectedPeer], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async (peerId: string) =>
+      peerId !== rejectedPeer;
+    const networkAttempts: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      networkAttempts.push(peerId);
+      return {
+        result: {
+          fetchedDataTriples: 50_000, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'incomplete',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, 'scheduling');
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'pending', recovery: target,
+    });
+
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+    expect(networkAttempts).toEqual([incompletePeer]);
+    expect(result.attemptedOrdinals).toEqual([0]);
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
+
+    const damped = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    expect(damped.cooldownOnly).toBe(true);
+    expect(networkAttempts).toEqual([incompletePeer]);
+  });
+
+  it('retains max-batch proof progress while each slot continues making progress', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmRollingCollectionDeadline', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const peers = ['12D3KooWRollingA', '12D3KooWRollingB', '12D3KooWRollingC'];
+    const targets = Array.from({ length: DKGAgent.VM_RECONCILE_BATCH_SIZE }, (_, ordinal) =>
+      vmRecoveryTarget('rolling-collection-deadline', ordinal, `rolling-${ordinal}`));
+    let now = 0;
+    (internals as any).vmReconcileRotationNow = () => now;
+
+    for (const peerId of peers) {
+      for (const target of targets) {
+        now += 25_000;
+        const prepared = (internals as any).prepareVmReconcileRotationTarget(
+          target, peers, now,
+        );
+        expect(prepared.suppressed).toBe(false);
+        expect(prepared.record).toBeDefined();
+        (internals as any).settleVmReconcileRotationAttempt(
+          target, peerId, 'clean-absent', peers, prepared.record,
+        );
+      }
+    }
+
+    expect(now).toBeGreaterThan(DKGAgent.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS);
+    for (const target of targets) {
+      expect((internals as any).vmReconcileRotationState.get(
+        (internals as any).vmReconcileRotationSlotKey(target),
+      )).toMatchObject({ phase: 'backoff', failures: 1 });
+    }
   });
 
   it('keeps the pre-suppression roster stable across connection reorder and curator discovery', async () => {
@@ -2887,7 +2971,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
   });
 
-  it('completion-anchors no-progress backoff after a legacy full-CG incomplete rotation', async () => {
+  it('completion-anchors the per-CG retry damper after a legacy incomplete rotation', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmPartialCycleExpiry', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
@@ -2946,20 +3030,16 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
 
     const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
-    const partial = (internals as any).vmReconcileRotationState.get(slotKey);
     expect(networkAttempts).toEqual([peerA, peerB]);
-    expect([...partial.cleanAbsentPeerIds]).toEqual([]);
-    expect([...partial.attemptedPeerIds]).toEqual([]);
-    expect(partial).toMatchObject({
-      phase: 'backoff', backoffReason: 'no-progress', failures: 1,
-    });
-    expect(partial.nextRetryAt).toBeGreaterThan(now);
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
 
-    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
-    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    const damped = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
     expect(networkAttempts).toEqual([peerA, peerB]);
+    expect(damped.cooldownOnly).toBe(true);
 
-    now = partial.nextRetryAt;
     (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const recovered = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
@@ -3081,7 +3161,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     }
   });
 
-  it('makes a completed no-progress rotation evictable at the state cap', async () => {
+  it('drops a completed incomplete rotation so it cannot pin the state cap', async () => {
     const capDescriptor = Object.getOwnPropertyDescriptor(
       DKGAgentBase,
       'VM_RECONCILE_CACHE_MAX_ENTRIES',
@@ -3107,12 +3187,51 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       (internals as any).settleVmReconcileRotationAttempt(
         first, peer, 'incomplete', [peer], firstRecord,
       );
-      expect(firstRecord).toMatchObject({
-        phase: 'backoff', backoffReason: 'no-progress', failures: 1,
-      });
+      expect((internals as any).vmReconcileRotationState.has(firstKey)).toBe(false);
 
       const secondRecord = (internals as any).prepareVmReconcileRotationTarget(
         second, [peer], 101,
+      ).record;
+      expect(secondRecord).toBeDefined();
+      expect((internals as any).vmReconcileRotationState.has(firstKey)).toBe(false);
+      expect((internals as any).vmReconcileRotationState.get(secondKey)).toBe(secondRecord);
+    } finally {
+      Object.defineProperty(
+        DKGAgentBase,
+        'VM_RECONCILE_CACHE_MAX_ENTRIES',
+        capDescriptor,
+      );
+    }
+  });
+
+  it('evicts an expired collecting rotation when the next slot reaches the state cap', async () => {
+    const capDescriptor = Object.getOwnPropertyDescriptor(
+      DKGAgentBase,
+      'VM_RECONCILE_CACHE_MAX_ENTRIES',
+    )!;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_CACHE_MAX_ENTRIES', {
+      ...capDescriptor,
+      value: 1,
+    });
+    try {
+      const chain = new MockChainAdapter();
+      agent = await DKGAgent.create({ name: 'ExactVmExpiredCapacity', chainAdapter: chain });
+      stubNode(agent);
+      const internals = agent as unknown as AgentInternals;
+      const peer = '12D3KooWExpiredCapacityPeer';
+      const first = vmRecoveryTarget('expired-capacity', 0, 'first');
+      const second = vmRecoveryTarget('expired-capacity', 1, 'second');
+      let now = 100;
+      (internals as any).vmReconcileRotationNow = () => now;
+      const firstKey = (internals as any).vmReconcileRotationSlotKey(first);
+      const secondKey = (internals as any).vmReconcileRotationSlotKey(second);
+      expect((internals as any).prepareVmReconcileRotationTarget(
+        first, [peer], now,
+      ).record).toBeDefined();
+
+      now += DKGAgent.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS + 1;
+      const secondRecord = (internals as any).prepareVmReconcileRotationTarget(
+        second, [peer], now,
       ).record;
       expect(secondRecord).toBeDefined();
       expect((internals as any).vmReconcileRotationState.has(firstKey)).toBe(false);

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -87,6 +87,7 @@ interface AgentInternals {
     }>,
     headBlock: number | undefined,
     isTargetCurrent: () => boolean,
+    signal?: AbortSignal,
   ): Promise<PendingOrdinalRecoveryResult>;
   syncContextGraphFromConnectedPeers(contextGraphId: string, options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string }): Promise<unknown>;
   runVmReconcileForCg(localCgId: string, source?: 'live' | 'periodic' | 'manual'): Promise<{
@@ -658,6 +659,39 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(sub!.onChainId).toBe('9');              // rebound to the new graph
     expect(sub!.lastReconciledOrdinal).toBe(0);    // stale watermark dropped
     expect(((internals as any).recentReconciledUals as { has(key: string): boolean }).has(recentKey)).toBe(false);
+  });
+
+  it('reclaims binding generations when subscription records are deleted', async () => {
+    const internals = await boot();
+    const generations = (internals as any).contextGraphBindingGenerations as Map<string, number>;
+
+    for (let index = 0; index < 32; index += 1) {
+      const localCgId = `deleted-binding-${index}`;
+      const subscription = { subscribed: true };
+      internals.subscribedContextGraphs.set(localCgId, subscription);
+      (internals as any).bindSubscriptionOnChainId(localCgId, subscription, String(index + 1));
+      expect((internals as any).deleteContextGraphSubscription(localCgId)).toBe(true);
+    }
+
+    expect(generations.size).toBe(0);
+
+    const reusedCgId = 'deleted-binding-reused';
+    const oldSubscription = { subscribed: true };
+    internals.subscribedContextGraphs.set(reusedCgId, oldSubscription);
+    (internals as any).bindSubscriptionOnChainId(reusedCgId, oldSubscription, '100');
+    const oldGeneration = (internals as any).captureContextGraphBindingGeneration(reusedCgId);
+    (internals as any).deleteContextGraphSubscription(reusedCgId);
+    const replacement = { subscribed: true };
+    internals.subscribedContextGraphs.set(reusedCgId, replacement);
+    (internals as any).bindSubscriptionOnChainId(reusedCgId, replacement, '101');
+
+    expect(
+      internals.subscribedContextGraphs.get(reusedCgId) === oldSubscription
+      && (internals as any).isContextGraphBindingGenerationCurrent(
+        reusedCgId,
+        oldGeneration,
+      ),
+    ).toBe(false);
   });
 
   it('clears VM reconcile state when stale inactive on-chain ids are re-registered', async () => {
@@ -1870,6 +1904,37 @@ describe('Phase D - VM reconcile damping', () => {
     expect(negativeCache.get(cacheKey)?.nextRetryAt).toBeGreaterThan(now);
   });
 
+  it('bounds durable negative-cache hydration guards and safely reloads evicted keys', async () => {
+    const loads: string[] = [];
+    const internals = await boot({
+      loadAll: async () => [],
+      save: async () => undefined,
+      delete: async () => undefined,
+      loadVmReconcileNegative: async (cacheKey) => {
+        loads.push(cacheKey);
+        return undefined;
+      },
+    });
+    const hydrated = (internals as any).vmReconcileNegativeCacheHydrated as Map<string, string>;
+    const cap = DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES;
+
+    for (let index = 0; index < cap + 2; index += 1) {
+      (internals as any).markVmReconcileNegativeCacheHydrated(
+        `hydrated-cg\0ual-${index}#root`,
+        'hydrated-cg',
+      );
+    }
+
+    expect(hydrated.size).toBe(cap);
+    expect(hydrated.has('hydrated-cg\0ual-0#root')).toBe(false);
+    await expect((internals as any).shouldDeferVmReconcileByNegativeCache(
+      'hydrated-cg\0ual-0#root',
+      'hydrated-cg',
+    )).resolves.toBe(false);
+    expect(loads).toEqual(['hydrated-cg\0ual-0#root']);
+    expect(hydrated.size).toBe(cap);
+  });
+
   it('prunes oversized VM reconcile state and clears non-hosted CG state on unsubscribe', async () => {
     const internals = await boot();
     const negativeCache = (internals as any).vmReconcileNegativeCache as Map<string, {
@@ -1883,6 +1948,7 @@ describe('Phase D - VM reconcile damping', () => {
     const peerCursor = (internals as any).vmReconcileCatchupPeerCursor as Map<string, number>;
     const peerOrder = (internals as any).vmReconcileCatchupPeerOrder as Map<string, { orderedPeers: string[]; nextPeerId?: string }>;
     const rotationState = (internals as any).vmReconcileRotationState as Map<string, unknown>;
+    const hydrated = (internals as any).vmReconcileNegativeCacheHydrated as Map<string, string>;
     const recent = (internals as any).recentReconciledUals as { add(key: string): void; has(key: string): boolean };
     const now = Date.now();
 
@@ -1921,6 +1987,7 @@ describe('Phase D - VM reconcile damping', () => {
       peerTopologyKey: '',
     });
     (internals as any).indexVmReconcileNegativeCacheEntry('cleanup-cg', 'cleanup-cache');
+    (internals as any).markVmReconcileNegativeCacheHydrated('cleanup-hydrated', 'cleanup-cg');
     fetchCooldown.set('cleanup-cg', now);
     peerCursor.set('cleanup-cg', 7);
     peerOrder.set('cleanup-cg', { orderedPeers: ['peer-a'], nextPeerId: 'peer-a' });
@@ -1931,6 +1998,7 @@ describe('Phase D - VM reconcile damping', () => {
     recent.add('cleanup-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/1#01');
     (agent as any).unsubscribeFromContextGraph('cleanup-cg');
     expect(negativeCache.has('cleanup-cache')).toBe(false);
+    expect(hydrated.has('cleanup-hydrated')).toBe(false);
     expect(fetchCooldown.has('cleanup-cg')).toBe(false);
     expect(peerCursor.has('cleanup-cg')).toBe(false);
     expect(peerOrder.has('cleanup-cg')).toBe(false);
@@ -1947,6 +2015,7 @@ describe('Phase D - VM reconcile damping', () => {
       peerTopologyKey: '',
     });
     (internals as any).indexVmReconcileNegativeCacheEntry('hosted-cg', 'hosted-cache');
+    (internals as any).markVmReconcileNegativeCacheHydrated('hosted-hydrated', 'hosted-cg');
     fetchCooldown.set('hosted-cg', now);
     peerCursor.set('hosted-cg', 3);
     peerOrder.set('hosted-cg', { orderedPeers: ['peer-b'], nextPeerId: 'peer-b' });
@@ -1957,6 +2026,7 @@ describe('Phase D - VM reconcile damping', () => {
     recent.add('hosted-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/2#02');
     (agent as any).unsubscribeFromContextGraph('hosted-cg');
     expect(negativeCache.has('hosted-cache')).toBe(true);
+    expect(hydrated.has('hosted-hydrated')).toBe(true);
     expect(fetchCooldown.has('hosted-cg')).toBe(true);
     expect(peerCursor.has('hosted-cg')).toBe(true);
     expect(peerOrder.has('hosted-cg')).toBe(true);
@@ -2324,7 +2394,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect((internals as any).vmReconcileCuratorPeersByCg.get(localCgId)).toEqual(curators);
   });
 
-  it('treats an oversized curator roster as unconfirmed and never suppresses discovery', async () => {
+  it('rotates a bounded oversized-roster transport window without treating it as absence proof', async () => {
     const rosterDescriptor = Object.getOwnPropertyDescriptor(
       DKGAgentBase,
       'VM_RECONCILE_EXACT_ROSTER_MAX',
@@ -2338,49 +2408,87 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       agent = await DKGAgent.create({ name: 'ExactVmRosterOverflow', chainAdapter: chain });
       const internals = agent as unknown as AgentInternals;
       const localCgId = '0x0000000000000000000000000000000000000001/roster-overflow';
-      const preferred = '12D3KooWRosterOverflowPreferred';
-      const connectedPeer = { toString: () => preferred };
+      const overflowPeers = Array.from({ length: 5 }, (_, i) => `12D3KooWRosterOverflow${i}`);
+      const connectedById = new Map<string, { toString(): string }>();
       (internals as any).node = {
         peerId: '12D3KooWRosterOverflowLocal',
-        libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+        libp2p: {
+          getConnections: () => [...connectedById.values()].map((remotePeer) => ({ remotePeer })),
+        },
       };
-      (internals as any).preferredSyncPeers.set(localCgId, preferred);
       let resolutions = 0;
-      (internals as any).resolveCuratorPeerIdsForCg = async () => {
+      (internals as any).resolveCuratorPeerIdsForCg = async (
+        _cgId: string,
+        options: { afterPeerId?: string },
+      ) => {
         resolutions += 1;
+        const previousIndex = options.afterPeerId
+          ? overflowPeers.indexOf(options.afterPeerId)
+          : -1;
+        const peerId = overflowPeers[(previousIndex + 1) % overflowPeers.length]!;
         return {
-          peerIds: Array.from({ length: 5 }, (_, i) => `12D3KooWRosterOverflow${i}`),
+          peerIds: [peerId],
           curatorIsLocal: false,
           legacyTripleResolved: false,
+          overflowed: true,
+          nextPageAfterPeerId: peerId,
         };
       };
-      (internals as any).ensurePeerConnected = async () => undefined;
+      (internals as any).ensurePeerConnected = async (peerId: string) => {
+        connectedById.set(peerId, { toString: () => peerId });
+      };
       (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
       (internals as any).waitForSyncProtocol = async () => true;
       (internals as any).ensurePeerAdmittedForRecovery = async () => true;
-      const fetch = vi.fn(async () => ({
-        result: {
-          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
-          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
-        },
-        disposition: 'clean-absent' as const,
-      }));
-      (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+      const fetches: string[] = [];
       const target = vmRecoveryTarget(localCgId, 0, 'roster-overflow');
-      (internals as any).reconcileChainOrdinal = async () => ({
-        status: 'pending', recovery: target,
-      });
+      const holderPeerId = overflowPeers[4]!;
+      let lastPeerId: string | undefined;
+      (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+        fetches.push(peerId);
+        lastPeerId = peerId;
+        const found = peerId === holderPeerId;
+        return {
+          result: {
+            fetchedDataTriples: found ? 1 : 0,
+            fetchedMetaTriples: found ? 8 : 0,
+            insertedTriples: found ? 9 : 0,
+            failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+          },
+          disposition: found ? 'found' as const : 'clean-absent' as const,
+        };
+      };
+      (internals as any).reconcileChainOrdinal = async () => (
+        lastPeerId === holderPeerId
+          ? { status: 'reconciled', blockNumber: 100 }
+          : { status: 'pending', recovery: target }
+      );
 
-      await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
-      const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
-      expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
-        phase: 'backoff', curatorRosterConfirmed: false,
-      });
-      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
-      await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+      // Simulate a formerly authoritative prefix cached before the registry
+      // grew beyond the proof cap. The current oversized result must replace it
+      // with rotating transport windows instead of querying that prefix forever.
+      (internals as any).vmReconcileCuratorPeersByCg.set(
+        localCgId,
+        overflowPeers.slice(0, 4),
+      );
 
-      expect(resolutions).toBe(2);
-      expect(fetch).toHaveBeenCalledTimes(2);
+      let result;
+      for (let pass = 0; pass < 5; pass += 1) {
+        result = await internals.recoverVmReconcileBatch(
+          localCgId, 1n, [target], 100, () => true,
+        );
+        if (pass < 4) {
+          const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+          expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
+            phase: 'collecting', curatorRosterConfirmed: false,
+          });
+          (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+        }
+      }
+
+      expect(resolutions).toBe(5);
+      expect(fetches).toEqual(overflowPeers);
+      expect(result?.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
     } finally {
       Object.defineProperty(
         DKGAgentBase,
@@ -2591,6 +2699,47 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(result.outcomes.size).toBe(2);
     expect(result.attemptedOrdinals).toEqual([0, 1]);
     expect(result.continuationOrdinal).toBe(2);
+  });
+
+  it('spreads unavailable-peer probes across targets within the global peer budget', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmUnavailableFairness', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peers = [1, 2, 3, 4].map((n) => `12D3KooWUnavailableFairness${n}`);
+    const localCgId = '0x0000000000000000000000000000000000000001/unavailable-fairness';
+    (internals as any).node = {
+      peerId: '12D3KooWUnavailableFairnessLocal',
+      libp2p: { getConnections: () => [] },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: peers, curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    const connectionAttempts: string[] = [];
+    (internals as any).ensurePeerConnected = async (peerId: string) => {
+      connectionAttempts.push(peerId);
+    };
+    (internals as any).selectCatchupPeers = (candidates: Array<{ toString(): string }>) => candidates;
+    const protocolWaits: string[] = [];
+    (internals as any).waitForSyncProtocol = async (peerId: string) => {
+      protocolWaits.push(peerId);
+      return false;
+    };
+    const fetch = vi.fn();
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = fetch;
+    const targets = Array.from({ length: 4 }, (_, ordinal) =>
+      vmRecoveryTarget(localCgId, ordinal, `unavailable-${ordinal}`));
+
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, targets, 100, () => true,
+    );
+
+    expect(connectionAttempts).toEqual(peers.slice(0, 3));
+    // The dial stub deliberately leaves each peer disconnected, so protocol
+    // probing is skipped after each failed connection boundary.
+    expect(protocolWaits).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.attemptedOrdinals).toEqual([0, 1, 2]);
+    expect(result.continuationOrdinal).toBe(3);
   });
 
   it('tries each pending target once per eligible pass and damps immediate retries', async () => {
@@ -3003,6 +3152,12 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       status: 'pending', recovery: target,
     });
 
+    const first = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    expect(first.attemptedOrdinals).toEqual([0]);
+    expect(networkAttempts).toEqual([]);
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const result = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
     );
@@ -3293,9 +3448,11 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
         libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
       };
       (internals as any).preferredSyncPeers.set(localCgId, peerA);
-      (internals as any).resolveCuratorPeerIdsForCg = async () => ({
-        peerIds: [peerA], curatorIsLocal: false, legacyTripleResolved: false,
-      });
+      let curatorResolutions = 0;
+      (internals as any).resolveCuratorPeerIdsForCg = async () => {
+        curatorResolutions += 1;
+        return { peerIds: [peerA], curatorIsLocal: false, legacyTripleResolved: false };
+      };
       (internals as any).ensurePeerConnected = async () => undefined;
       (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
       (internals as any).waitForSyncProtocol = async () => true;
@@ -3320,7 +3477,9 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       };
       const first = vmRecoveryTarget(localCgId, 0, '78');
       const overflow = vmRecoveryTarget(localCgId, 1, '79');
-      const byOrdinal = new Map([[first.ordinal, first], [overflow.ordinal, overflow]]);
+      const secondOverflow = vmRecoveryTarget(localCgId, 2, '80');
+      const targets = [first, overflow, secondOverflow];
+      const byOrdinal = new Map(targets.map((target) => [target.ordinal, target]));
       (internals as any).reconcileChainOrdinal = async (
         _lcg: string,
         _ocg: bigint,
@@ -3332,30 +3491,42 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       >;
       const firstKey = (internals as any).vmReconcileRotationSlotKey(first);
       const overflowKey = (internals as any).vmReconcileRotationSlotKey(overflow);
+      const secondOverflowKey = (internals as any).vmReconcileRotationSlotKey(secondOverflow);
 
       await internals.recoverVmReconcileBatch(
-        localCgId, 1n, [first, overflow], 100, () => true,
+        localCgId, 1n, targets, 100, () => true,
       );
       expect(rotationState.size).toBe(1);
       expect(rotationState.get(firstKey)).toMatchObject({ phase: 'collecting' });
       expect([...rotationState.get(firstKey)!.cleanAbsentPeerIds]).toEqual([peerA]);
       expect(attemptsByUal.get(first.ual)).toEqual([peerA]);
       expect(attemptsByUal.get(overflow.ual)).toBeUndefined();
+      expect(attemptsByUal.get(secondOverflow.ual)).toBeUndefined();
 
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
       await internals.recoverVmReconcileBatch(
-        localCgId, 1n, [first, overflow], 100, () => true,
+        localCgId, 1n, targets, 100, () => true,
       );
       expect(rotationState.size).toBe(1);
       expect(rotationState.get(firstKey)).toMatchObject({ phase: 'backoff' });
       expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB]);
       expect(attemptsByUal.get(overflow.ual)).toBeUndefined();
 
+      // A batch containing only an unowned target can be rejected from the
+      // live capacity state without paying curator discovery or transport.
+      const resolutionsBeforeCapacityDeferral = curatorResolutions;
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [overflow], 100, () => true,
+      );
+      expect(curatorResolutions).toBe(resolutionsBeforeCapacityDeferral);
+      expect(attemptsByUal.get(overflow.ual)).toBeUndefined();
+
       // An unexpired backoff remains installed and the overflow target performs
       // no evidence-free exact request.
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
       await internals.recoverVmReconcileBatch(
-        localCgId, 1n, [first, overflow], 100, () => true,
+        localCgId, 1n, targets, 100, () => true,
       );
       expect(rotationState.size).toBe(1);
       expect(rotationState.get(firstKey)).toMatchObject({ phase: 'backoff' });
@@ -3367,12 +3538,143 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       (internals as any).vmReconcileRotationNow = () => firstBackoff.nextRetryAt + 1;
       (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
       await internals.recoverVmReconcileBatch(
-        localCgId, 1n, [overflow], 100, () => true,
+        localCgId, 1n, targets, 100, () => true,
       );
       expect(rotationState.size).toBe(1);
       expect(rotationState.has(firstKey)).toBe(false);
       expect(rotationState.get(overflowKey)).toMatchObject({ phase: 'collecting' });
       expect(attemptsByUal.get(overflow.ual)).toEqual([peerA]);
+
+      // Complete B's roster, expire it, and prove the third stable-order waiter
+      // receives the next slot instead of A/B alternating forever.
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(
+        localCgId, 1n, targets, 100, () => true,
+      );
+      const overflowBackoff = rotationState.get(overflowKey) as any;
+      expect(overflowBackoff).toMatchObject({ phase: 'backoff' });
+      expect(attemptsByUal.get(overflow.ual)).toEqual([peerA, peerB]);
+
+      (internals as any).vmReconcileRotationNow = () => overflowBackoff.nextRetryAt + 1;
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(
+        localCgId, 1n, targets, 100, () => true,
+      );
+      expect(rotationState.size).toBe(1);
+      expect(rotationState.has(overflowKey)).toBe(false);
+      expect(rotationState.get(secondOverflowKey)).toMatchObject({ phase: 'collecting' });
+      expect(attemptsByUal.get(secondOverflow.ual)).toEqual([peerA]);
+    } finally {
+      Object.defineProperty(
+        DKGAgentBase,
+        'VM_RECONCILE_CACHE_MAX_ENTRIES',
+        capDescriptor,
+      );
+    }
+  });
+
+  it('reserves a live rotation slot for an unrelated CG at the node-wide cache cap', async () => {
+    const capDescriptor = Object.getOwnPropertyDescriptor(
+      DKGAgentBase,
+      'VM_RECONCILE_CACHE_MAX_ENTRIES',
+    )!;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_CACHE_MAX_ENTRIES', {
+      ...capDescriptor,
+      value: 3,
+    });
+    try {
+      const chain = new MockChainAdapter();
+      agent = await DKGAgent.create({ name: 'ExactVmCrossCgCapacity', chainAdapter: chain });
+      stubNode(agent);
+      const internals = agent as unknown as AgentInternals;
+      const peer = '12D3KooWCrossCgCapacityPeer';
+      const dominantCg = '0x0000000000000000000000000000000000000001/dominant-capacity';
+      const waitingCg = '0x0000000000000000000000000000000000000002/waiting-capacity';
+      const dominantTargets = [0, 1, 2]
+        .map((ordinal) => vmRecoveryTarget(dominantCg, ordinal, `dominant-${ordinal}`));
+      for (const target of dominantTargets) {
+        expect((internals as any).prepareVmReconcileRotationTarget(
+          target,
+          [peer],
+          100,
+        ).suppressed).toBe(false);
+      }
+      const state = (internals as any).vmReconcileRotationState as Map<
+        string,
+        { localCgId: string }
+      >;
+      expect(state.size).toBe(3);
+      expect([...state.values()].filter((record) => record.localCgId === dominantCg)).toHaveLength(3);
+
+      const waiting = vmRecoveryTarget(waitingCg, 0, 'waiting');
+      const admitted = (internals as any).prepareVmReconcileRotationTarget(
+        waiting,
+        [peer],
+        100,
+      );
+
+      expect(admitted.suppressed).toBe(false);
+      expect(admitted.record?.localCgId).toBe(waitingCg);
+      expect(state.size).toBe(3);
+      expect([...state.values()].filter((record) => record.localCgId === dominantCg)).toHaveLength(2);
+      expect([...state.values()].filter((record) => record.localCgId === waitingCg)).toHaveLength(1);
+    } finally {
+      Object.defineProperty(
+        DKGAgentBase,
+        'VM_RECONCILE_CACHE_MAX_ENTRIES',
+        capDescriptor,
+      );
+    }
+  });
+
+  it('does not evict a cross-CG donor when recovery exits before requester installation', async () => {
+    const capDescriptor = Object.getOwnPropertyDescriptor(
+      DKGAgentBase,
+      'VM_RECONCILE_CACHE_MAX_ENTRIES',
+    )!;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_CACHE_MAX_ENTRIES', {
+      ...capDescriptor,
+      value: 3,
+    });
+    try {
+      const chain = new MockChainAdapter();
+      agent = await DKGAgent.create({ name: 'ExactVmDonationRollback', chainAdapter: chain });
+      stubNode(agent);
+      const internals = agent as unknown as AgentInternals;
+      const peer = '12D3KooWDonationRollbackPeer';
+      const dominantCg = '0x0000000000000000000000000000000000000001/donation-owner';
+      const waitingCg = '0x0000000000000000000000000000000000000002/donation-waiter';
+      (internals as any).vmReconcileRotationNow = () => 100;
+      for (let ordinal = 0; ordinal < 3; ordinal += 1) {
+        const target = vmRecoveryTarget(dominantCg, ordinal, `donor-${ordinal}`);
+        expect((internals as any).prepareVmReconcileRotationTarget(
+          target,
+          [peer],
+          100,
+        ).record).toBeDefined();
+      }
+      const state = (internals as any).vmReconcileRotationState as Map<string, unknown>;
+      const before = [...state.entries()];
+      (internals as any).vmReconcileCuratorPeersByCg.set(waitingCg, [peer]);
+      let current = true;
+      (internals as any).resolveCuratorPeerIdsForCg = async () => {
+        current = false;
+        return {
+          peerIds: [peer], curatorIsLocal: false, legacyTripleResolved: false,
+        };
+      };
+      const waiting = vmRecoveryTarget(waitingCg, 0, 'waiting');
+
+      await internals.recoverVmReconcileBatch(
+        waitingCg,
+        1n,
+        [waiting],
+        100,
+        () => current,
+      );
+
+      expect([...state.entries()]).toEqual(before);
+      expect(state.has((internals as any).vmReconcileRotationSlotKey(waiting))).toBe(false);
     } finally {
       Object.defineProperty(
         DKGAgentBase,
@@ -3741,7 +4043,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       target, ordinaryPeer, 'clean-absent', [ordinaryPeer], first.record,
     );
     expect(first.record).toMatchObject({
-      phase: 'backoff',
+      phase: 'collecting',
       curatorRosterConfirmed: false,
     });
 
@@ -3749,7 +4051,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       target, [ordinaryPeer], 101, false,
     );
     expect(retry.suppressed).toBe(false);
-    expect(retry.record).not.toBe(first.record);
+    expect(retry.record).toBe(first.record);
     expect(retry.record).toMatchObject({
       phase: 'collecting',
       curatorRosterConfirmed: false,
@@ -3762,14 +4064,94 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       target, [ordinaryPeer], 102, true,
     );
     expect(confirmed.suppressed).toBe(false);
-    expect(confirmed.record).not.toBe(retry.record);
+    expect(confirmed.record).toBe(retry.record);
     expect(confirmed.record.curatorRosterConfirmed).toBe(true);
+    expect([...confirmed.record.attemptedPeerIds]).toEqual([]);
     (internals as any).settleVmReconcileRotationAttempt(
       target, ordinaryPeer, 'clean-absent', [ordinaryPeer], confirmed.record,
     );
     expect((internals as any).prepareVmReconcileRotationTarget(
       target, [ordinaryPeer], 103, true,
     ).suppressed).toBe(true);
+  });
+
+  it('reprobes retained peers when curator proof arrives with roster growth', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmCuratorProofGrowth', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/proof-growth';
+    const ordinaryPeer = '12D3KooWProofGrowthOrdinary';
+    const curatorPeer = '12D3KooWProofGrowthCurator';
+    const target = vmRecoveryTarget(localCgId, 0, 'proof-growth');
+    const unconfirmed = (internals as any).prepareVmReconcileRotationTarget(
+      target, [ordinaryPeer], 100, false,
+    );
+    (internals as any).settleVmReconcileRotationAttempt(
+      target, ordinaryPeer, 'clean-absent', [ordinaryPeer], unconfirmed.record,
+    );
+    expect([...unconfirmed.record.cleanAbsentPeerIds]).toEqual([ordinaryPeer]);
+
+    const confirmed = (internals as any).prepareVmReconcileRotationTarget(
+      target, [ordinaryPeer, curatorPeer], 101, true,
+    );
+    expect(confirmed.suppressed).toBe(false);
+    expect(confirmed.record).toBe(unconfirmed.record);
+    expect(confirmed.record.curatorRosterConfirmed).toBe(true);
+    expect([...confirmed.record.candidatePeerIds]).toEqual([ordinaryPeer, curatorPeer]);
+    expect([...confirmed.record.attemptedPeerIds]).toEqual([]);
+    expect([...confirmed.record.cleanAbsentPeerIds]).toEqual([]);
+  });
+
+  it('does not persist incomplete-cycle suppression when curator discovery is unconfirmed', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmUnconfirmedIncompleteBackoff', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/unconfirmed-incomplete';
+    const peer = '12D3KooWUnconfirmedIncomplete';
+    const connectedPeer = { toString: () => peer };
+    (internals as any).node = {
+      peerId: '12D3KooWUnconfirmedIncompleteLocal',
+      libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peer);
+    let curatorResolutions = 0;
+    (internals as any).resolveCuratorPeerIdsForCg = async () => {
+      curatorResolutions += 1;
+      return {
+        peerIds: [], curatorIsLocal: false, legacyTripleResolved: false, lookupFailed: true,
+      };
+    };
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = () => [connectedPeer];
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    let fetches = 0;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async () => {
+      fetches += 1;
+      return {
+        result: {
+          fetchedDataTriples: 50_000, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'incomplete',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, 'unconfirmed-incomplete');
+    (internals as any).reconcileChainOrdinal = async () => ({ status: 'pending', recovery: target });
+
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+    expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
+      phase: 'collecting', curatorRosterConfirmed: false,
+    });
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    const suppressed = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+
+    expect(suppressed.attemptedOrdinals).toEqual([]);
+    expect(curatorResolutions).toBe(2);
+    expect(fetches).toBe(1);
   });
 
   it('retries curator discovery after an unconfirmed clean-absence cycle', async () => {
@@ -4267,11 +4649,330 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     });
     const target = vmRecoveryTarget(localCgId, 0, '7');
 
-    const result = await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    const first = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    expect(first.attemptedOrdinals).toEqual([0]);
+    expect(fetches).toEqual([]);
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
 
     expect(fetches).toEqual([admittedPeer]);
     expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
     expect(result.attemptedOrdinals).toEqual([0]);
+  });
+
+  it('propagates lifecycle cancellation into an in-flight exact recovery', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmLifecycleAbort', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peerId = '12D3KooWExactLifecycleAbortPeer';
+    const localCgId = '0x0000000000000000000000000000000000000001/exact-abort';
+    const remotePeer = { toString: () => peerId };
+    (internals as any).node = {
+      peerId: '12D3KooWExactLifecycleAbortLocal',
+      libp2p: { getConnections: () => [{ remotePeer }] },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peerId], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+    let receivedSignal: AbortSignal | undefined;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
+      _peerId: string,
+      _cgId: string,
+      _uals: string[],
+      options: { signal?: AbortSignal },
+    ) => {
+      receivedSignal = options.signal;
+      markEntered();
+      await new Promise<void>((_resolve, reject) => {
+        const onAbort = () => reject(new DOMException('aborted', 'AbortError'));
+        if (options.signal?.aborted) onAbort();
+        else options.signal?.addEventListener('abort', onAbort, { once: true });
+      });
+      throw new Error('unreachable');
+    };
+    const target = vmRecoveryTarget(localCgId, 0, 'exact-abort');
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'pending', recovery: target,
+    });
+    const controller = new AbortController();
+
+    const recovery = internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true, controller.signal,
+    );
+    await entered;
+    controller.abort();
+
+    await expect(recovery).resolves.toMatchObject({ outcomes: new Map() });
+    expect(receivedSignal).toBe(controller.signal);
+  });
+
+  it('abandons a same-object context-graph rebind that lands during stranded-KC repair', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillHealBindingFence', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'heal-binding-fence';
+    const sub = {
+      subscribed: true,
+      onChainId: '321',
+      lastReconciledOrdinal: 0,
+    };
+    internals.subscribedContextGraphs.set(localCgId, sub);
+    let releaseHeal!: () => void;
+    let markHealStarted!: () => void;
+    const healStarted = new Promise<void>((resolve) => { markHealStarted = resolve; });
+    const healRelease = new Promise<void>((resolve) => { releaseHeal = resolve; });
+    (internals as any).healStrandedScopedKCs = async () => {
+      markHealStarted();
+      await healRelease;
+    };
+    const getCount = vi.fn(async () => 0n);
+    chain.getContextGraphKCCount = getCount;
+
+    const reconcile = (internals as any).executeVmReconcileForCg(localCgId, 'manual');
+    await healStarted;
+    sub.onChainId = '322';
+    releaseHeal();
+
+    await expect(reconcile).rejects.toMatchObject({ name: 'VmReconcileQueueClosedError' });
+    expect(getCount).not.toHaveBeenCalled();
+    expect(sub.lastReconciledOrdinal).toBe(0);
+  });
+
+  it('retires an aborted reconcile even when stranded-KC repair ignores cancellation', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillHealAbortRace', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'heal-abort-race';
+    internals.subscribedContextGraphs.set(localCgId, {
+      subscribed: true,
+      onChainId: '323',
+      lastReconciledOrdinal: 0,
+    });
+    let markHealStarted!: () => void;
+    const healStarted = new Promise<void>((resolve) => { markHealStarted = resolve; });
+    let healCalls = 0;
+    (internals as any).healStrandedScopedKCs = async () => {
+      healCalls += 1;
+      if (healCalls === 1) {
+        markHealStarted();
+        await new Promise<void>(() => undefined);
+      }
+    };
+    chain.getContextGraphKCCount = async () => 0n;
+
+    const abandoned = (internals as any).executeVmReconcileForCg(localCgId, 'manual');
+    await healStarted;
+    (internals as any).closeVmReconcileRotationState();
+    await expect(abandoned).rejects.toMatchObject({ name: 'VmReconcileQueueClosedError' });
+
+    (internals as any).openVmReconcileRotationState();
+    await expect((internals as any).executeVmReconcileForCg(localCgId, 'manual'))
+      .resolves.toMatchObject({ status: 'current' });
+    expect(healCalls).toBe(2);
+  });
+
+  it('keeps watermark persistence inside the tracked physical reconcile', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillWatermarkDrain', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'watermark-drain';
+    internals.subscribedContextGraphs.set(localCgId, {
+      subscribed: true,
+      onChainId: '324',
+      lastReconciledOrdinal: 0,
+    });
+    chain.getContextGraphKCCount = async () => 1n;
+    (internals as any).healStrandedScopedKCs = async () => undefined;
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+    let markPersistStarted!: () => void;
+    const persistStarted = new Promise<void>((resolve) => { markPersistStarted = resolve; });
+    let releasePersist!: () => void;
+    const persistGate = new Promise<void>((resolve) => { releasePersist = resolve; });
+    (internals as any).persistVmReconcileWatermark = async () => {
+      markPersistStarted();
+      await persistGate;
+    };
+
+    const reconcile = (internals as any).executeVmReconcileForCg(localCgId, 'manual');
+    await persistStarted;
+    expect((internals as any).vmReconcilePhysicalRuns.size).toBe(1);
+    let settled = false;
+    void reconcile.finally(() => { settled = true; });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+
+    releasePersist();
+    await expect(reconcile).resolves.toMatchObject({ watermarkAfter: 1 });
+    expect((internals as any).vmReconcilePhysicalRuns.size).toBe(0);
+  });
+
+  it('does not expose an advanced watermark when its durable save fails', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillWatermarkSaveFailure', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'watermark-save-failure';
+    const subscription = {
+      subscribed: true,
+      onChainId: '325',
+      lastReconciledOrdinal: 0,
+    };
+    internals.subscribedContextGraphs.set(localCgId, subscription);
+    chain.getContextGraphKCCount = async () => 1n;
+    (internals as any).healStrandedScopedKCs = async () => undefined;
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+    (internals as any).persistVmReconcileWatermark = async () => {
+      throw new Error('subscription store unavailable');
+    };
+
+    await expect((internals as any).executeVmReconcileForCg(localCgId, 'manual'))
+      .rejects.toThrow('subscription store unavailable');
+    expect(subscription.lastReconciledOrdinal).toBe(0);
+    expect((internals as any).reconcileCursors.get(localCgId)?.watermark).toBe(0);
+  });
+
+  it('flushes reconcile materialization before strictly saving its watermark', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillWatermarkFlushOrder', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'watermark-flush-order';
+    const subscription = {
+      subscribed: true,
+      onChainId: '326',
+      lastReconciledOrdinal: 0,
+    };
+    internals.subscribedContextGraphs.set(localCgId, subscription);
+    chain.getContextGraphKCCount = async () => 1n;
+    (internals as any).healStrandedScopedKCs = async () => undefined;
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+    const durabilityOrder: string[] = [];
+    internals.store.flush = async () => { durabilityOrder.push('flush'); };
+    (internals as any).persistContextGraphSubscriptionStrict = async () => {
+      durabilityOrder.push('save');
+    };
+
+    await expect((internals as any).executeVmReconcileForCg(localCgId, 'manual'))
+      .resolves.toMatchObject({ watermarkAfter: 1 });
+    expect(durabilityOrder).toEqual(['flush', 'save']);
+    expect(subscription.lastReconciledOrdinal).toBe(1);
+  });
+
+  it('flushes reconcile materialization while confirmation depth holds the watermark', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillHeldWatermarkFlush', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'held-watermark-flush';
+    const subscription = {
+      subscribed: true,
+      onChainId: '330',
+      lastReconciledOrdinal: 0,
+    };
+    internals.subscribedContextGraphs.set(localCgId, subscription);
+    chain.getContextGraphKCCount = async () => 1n;
+    chain.getBlockNumber = async () => 100;
+    (internals as any).healStrandedScopedKCs = async () => undefined;
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+    const flush = vi.fn(async () => undefined);
+    internals.store.flush = flush;
+    const persistStrict = vi.fn(async () => undefined);
+    (internals as any).persistContextGraphSubscriptionStrict = persistStrict;
+
+    await expect((internals as any).executeVmReconcileForCg(localCgId, 'manual'))
+      .resolves.toMatchObject({ watermarkAfter: 0, reconciledOrdinals: 1 });
+    expect(flush).toHaveBeenCalledOnce();
+    expect(persistStrict).not.toHaveBeenCalled();
+    expect(subscription.lastReconciledOrdinal).toBe(0);
+  });
+
+  it('does not save or expose a watermark when reconcile materialization flush fails', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillWatermarkFlushFailure', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'watermark-flush-failure';
+    const subscription = {
+      subscribed: true,
+      onChainId: '327',
+      lastReconciledOrdinal: 0,
+    };
+    internals.subscribedContextGraphs.set(localCgId, subscription);
+    chain.getContextGraphKCCount = async () => 1n;
+    (internals as any).healStrandedScopedKCs = async () => undefined;
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+    internals.store.flush = async () => { throw new Error('triple-store flush failed'); };
+    const persistStrict = vi.fn(async () => undefined);
+    (internals as any).persistContextGraphSubscriptionStrict = persistStrict;
+
+    await expect((internals as any).executeVmReconcileForCg(localCgId, 'manual'))
+      .rejects.toThrow('triple-store flush failed');
+    expect(persistStrict).not.toHaveBeenCalled();
+    expect(subscription.lastReconciledOrdinal).toBe(0);
+    expect((internals as any).reconcileCursors.get(localCgId)?.watermark).toBe(0);
+  });
+
+  it('fences a watermark save continuation across a same-object binding ABA', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillWatermarkBindingAba', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'watermark-binding-aba';
+    const subscription = {
+      subscribed: true,
+      onChainId: '328',
+      lastReconciledOrdinal: 0,
+    };
+    internals.subscribedContextGraphs.set(localCgId, subscription);
+    chain.getContextGraphKCCount = async () => 1n;
+    (internals as any).healStrandedScopedKCs = async () => undefined;
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'reconciled', blockNumber: 100,
+    });
+    internals.store.flush = async () => undefined;
+    let markSaveStarted!: () => void;
+    const saveStarted = new Promise<void>((resolve) => { markSaveStarted = resolve; });
+    let releaseSave!: () => void;
+    const saveGate = new Promise<void>((resolve) => { releaseSave = resolve; });
+    (internals as any).persistContextGraphSubscriptionStrict = async () => {
+      markSaveStarted();
+      await saveGate;
+    };
+
+    const reconcile = (internals as any).executeVmReconcileForCg(localCgId, 'manual');
+    await saveStarted;
+    const originalCursor = (internals as any).reconcileCursors.get(localCgId);
+    (internals as any).bindSubscriptionOnChainId(localCgId, subscription, '329');
+    (internals as any).bindSubscriptionOnChainId(localCgId, subscription, '328');
+    (internals as any).reconcileCursors.set(localCgId, originalCursor);
+    releaseSave();
+
+    await expect(reconcile).rejects.toMatchObject({ name: 'VmReconcileQueueClosedError' });
+    expect(subscription.onChainId).toBe('328');
+    expect(subscription.lastReconciledOrdinal).toBe(0);
+    expect(originalCursor.watermark).toBe(0);
   });
 
   it('reports a durable watermark ahead of the chain head without ordinal work', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -50,6 +50,7 @@ import type {
   VmReconcileNegativeRecord,
 } from '../src/dkg-agent-types.js';
 import { DKGAgent } from '../src/index.js';
+import { DKGAgentBase } from '../src/dkg-agent-base.js';
 import {
   VmReconcileDispatcher,
   type PendingOrdinalRecoveryResult,
@@ -76,8 +77,11 @@ interface AgentInternals {
     localCgId: string,
     onChainCgId: bigint,
     targets: readonly Array<{
+      localCgId: string;
+      onChainCgId: string;
       ordinal: number;
       ual: string;
+      merkleRoot: string;
       kaId: string;
       reason: 'no-swm' | 'verified-vm-metadata-pending';
     }>,
@@ -157,6 +161,22 @@ function emptyCatchupStats() {
         failedPeers: 0,
       },
     },
+  };
+}
+
+function vmRecoveryTarget(
+  localCgId: string,
+  ordinal: number,
+  kaId = String(ordinal),
+) {
+  return {
+    localCgId,
+    onChainCgId: '1',
+    ordinal,
+    ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${kaId}`,
+    merkleRoot: `root-${kaId}`,
+    kaId,
+    reason: 'no-swm' as const,
   };
 }
 
@@ -1782,6 +1802,7 @@ describe('Phase D - VM reconcile damping', () => {
     const fetchCooldown = (internals as any).vmReconcileFetchCooldownAt as Map<string, number>;
     const peerCursor = (internals as any).vmReconcileCatchupPeerCursor as Map<string, number>;
     const peerOrder = (internals as any).vmReconcileCatchupPeerOrder as Map<string, { orderedPeers: string[]; nextPeerId?: string }>;
+    const rotationState = (internals as any).vmReconcileRotationState as Map<string, unknown>;
     const recent = (internals as any).recentReconciledUals as { add(key: string): void; has(key: string): boolean };
     const now = Date.now();
 
@@ -1823,12 +1844,17 @@ describe('Phase D - VM reconcile damping', () => {
     fetchCooldown.set('cleanup-cg', now);
     peerCursor.set('cleanup-cg', 7);
     peerOrder.set('cleanup-cg', { orderedPeers: ['peer-a'], nextPeerId: 'peer-a' });
+    const cleanupRotationKey = (internals as any).vmReconcileRotationSlotKey(
+      vmRecoveryTarget('cleanup-cg', 0),
+    );
+    rotationState.set(cleanupRotationKey, {});
     recent.add('cleanup-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/1#01');
     (agent as any).unsubscribeFromContextGraph('cleanup-cg');
     expect(negativeCache.has('cleanup-cache')).toBe(false);
     expect(fetchCooldown.has('cleanup-cg')).toBe(false);
     expect(peerCursor.has('cleanup-cg')).toBe(false);
     expect(peerOrder.has('cleanup-cg')).toBe(false);
+    expect(rotationState.has(cleanupRotationKey)).toBe(false);
     expect(recent.has('cleanup-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/1#01')).toBe(false);
 
     internals.subscribedContextGraphs.set('hosted-cg', { subscribed: true, coreHosted: true });
@@ -1844,12 +1870,17 @@ describe('Phase D - VM reconcile damping', () => {
     fetchCooldown.set('hosted-cg', now);
     peerCursor.set('hosted-cg', 3);
     peerOrder.set('hosted-cg', { orderedPeers: ['peer-b'], nextPeerId: 'peer-b' });
+    const hostedRotationKey = (internals as any).vmReconcileRotationSlotKey(
+      vmRecoveryTarget('hosted-cg', 0),
+    );
+    rotationState.set(hostedRotationKey, {});
     recent.add('hosted-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/2#02');
     (agent as any).unsubscribeFromContextGraph('hosted-cg');
     expect(negativeCache.has('hosted-cache')).toBe(true);
     expect(fetchCooldown.has('hosted-cg')).toBe(true);
     expect(peerCursor.has('hosted-cg')).toBe(true);
     expect(peerOrder.has('hosted-cg')).toBe(true);
+    expect(rotationState.has(hostedRotationKey)).toBe(false);
     expect(recent.has('hosted-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/2#02')).toBe(true);
   });
 });
@@ -2060,19 +2091,22 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       return true;
     };
     const fetches: Array<{ peerId: string; uals: string[] }> = [];
-    (internals as any).syncExactKnowledgeAssetsFromPeer = async (
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
       peerId: string,
       _cg: string,
       uals: string[],
     ) => {
       fetches.push({ peerId, uals });
       return {
-        fetchedDataTriples: 1,
-        fetchedMetaTriples: 8,
-        insertedTriples: 9,
-        failedPeers: 0,
-        failedPhases: 0,
-        deferredBackpressure: 0,
+        result: {
+          fetchedDataTriples: 1,
+          fetchedMetaTriples: 8,
+          insertedTriples: 9,
+          failedPeers: 0,
+          failedPhases: 0,
+          deferredBackpressure: 0,
+        },
+        disposition: 'found',
       };
     };
     (internals as any).reconcileChainOrdinal = async () => ({
@@ -2084,7 +2118,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     const result = await internals.recoverVmReconcileBatch(
       localCgId,
       1n,
-      [{ ordinal: 0, ual, kaId: '7', reason: 'no-swm' }],
+      [{ ...vmRecoveryTarget(localCgId, 0, '7'), ual }],
       100,
       () => true,
     );
@@ -2118,15 +2152,18 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
     (internals as any).waitForSyncProtocol = async () => true;
     const fetches: Array<{ peerId: string; uals: string[] }> = [];
-    (internals as any).syncExactKnowledgeAssetsFromPeer = async (
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
       peerId: string,
       _cg: string,
       uals: string[],
     ) => {
       fetches.push({ peerId, uals });
       return {
-        fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
-        failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        result: {
+          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'incomplete',
       };
     };
     const revalidated: number[] = [];
@@ -2142,12 +2179,8 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       }
       return { status: 'reconciled', blockNumber: 100 };
     };
-    const targets = Array.from({ length: 4 }, (_, ordinal) => ({
-      ordinal,
-      ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
-      kaId: String(ordinal),
-      reason: 'no-swm' as const,
-    }));
+    const targets = Array.from({ length: 4 }, (_, ordinal) =>
+      vmRecoveryTarget(localCgId, ordinal));
 
     const result = await internals.recoverVmReconcileBatch(localCgId, 1n, targets, 100, () => true);
 
@@ -2185,29 +2218,22 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
     (internals as any).waitForSyncProtocol = async () => true;
     const fetchedUals: string[][] = [];
-    (internals as any).syncExactKnowledgeAssetsFromPeer = async (
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
       _peerId: string,
       _cgId: string,
       uals: string[],
     ) => {
       fetchedUals.push(uals);
       return {
-        fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
-        failedPeers: 1, failedPhases: 0, deferredBackpressure: 0,
+        result: {
+          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 1, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'incomplete',
       };
     };
-    const target = {
-      ordinal: 0,
-      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
-      kaId: '7',
-      reason: 'no-swm' as const,
-    };
-    const deferredTarget = {
-      ordinal: 1,
-      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/8',
-      kaId: '8',
-      reason: 'no-swm' as const,
-    };
+    const target = vmRecoveryTarget(localCgId, 0, '7');
+    const deferredTarget = vmRecoveryTarget(localCgId, 1, '8');
     (internals as any).reconcileChainOrdinal = async (
       _lcg: string,
       _ocg: bigint,
@@ -2256,21 +2282,19 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     (internals as any).selectCatchupPeers = () => [connectedPeer];
     (internals as any).waitForSyncProtocol = async () => true;
     const networkAttempts: number[] = [];
-    const targets = [0, 1].map((ordinal) => ({
-      ordinal,
-      ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
-      kaId: String(ordinal),
-      reason: 'no-swm' as const,
-    }));
-    (internals as any).syncExactKnowledgeAssetsFromPeer = async (
+    const targets = [0, 1].map((ordinal) => vmRecoveryTarget(localCgId, ordinal));
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
       _peerId: string,
       _cgId: string,
       uals: string[],
     ) => {
       networkAttempts.push(Number(uals[0]!.split('/').at(-1)));
       return {
-        fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
-        failedPeers: 1, failedPhases: 0, deferredBackpressure: 0,
+        result: {
+          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 1, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'incomplete',
       };
     };
     (internals as any).reconcileChainOrdinal = async (
@@ -2329,24 +2353,22 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     (internals as any).ensurePeerAdmittedForRecovery = async () => true;
     const networkAttempts: string[] = [];
     let lastPeerId: string | undefined;
-    (internals as any).syncExactKnowledgeAssetsFromPeer = async (peerId: string) => {
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
       networkAttempts.push(peerId);
       lastPeerId = peerId;
       return {
-        fetchedDataTriples: peerId === peerB ? 1 : 0,
-        fetchedMetaTriples: peerId === peerB ? 8 : 0,
-        insertedTriples: peerId === peerB ? 9 : 0,
-        failedPeers: 0,
-        failedPhases: 0,
-        deferredBackpressure: 0,
+        result: {
+          fetchedDataTriples: peerId === peerB ? 1 : 0,
+          fetchedMetaTriples: peerId === peerB ? 8 : 0,
+          insertedTriples: peerId === peerB ? 9 : 0,
+          failedPeers: 0,
+          failedPhases: 0,
+          deferredBackpressure: 0,
+        },
+        disposition: peerId === peerB ? 'found' : 'clean-absent',
       };
     };
-    const target = {
-      ordinal: 0,
-      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
-      kaId: '7',
-      reason: 'no-swm' as const,
-    };
+    const target = vmRecoveryTarget(localCgId, 0, '7');
     (internals as any).reconcileChainOrdinal = async () => (
       lastPeerId === peerB
         ? { status: 'reconciled', blockNumber: 100 }
@@ -2365,6 +2387,510 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
 
     expect(networkAttempts).toEqual([peerA, peerB]);
     expect(second.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+  });
+
+  it('rotates incomplete exact attempts without granting absence credit', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmIncompleteRotation', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peerA = '12D3KooWIncompleteRotationPeerA';
+    const peerB = '12D3KooWIncompleteRotationPeerB';
+    const localCgId = '0x0000000000000000000000000000000000000001/incomplete-rotation';
+    const connected = [peerA, peerB].map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWIncompleteRotationLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peerA);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peerA], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const attemptsByUal = new Map<string, string[]>();
+    let lastDisposition: 'found' | 'incomplete' = 'incomplete';
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
+      peerId: string,
+      _cgId: string,
+      requestedUals: string[],
+    ) => {
+      const ual = requestedUals[0]!;
+      const attempts = attemptsByUal.get(ual) ?? [];
+      attempts.push(peerId);
+      attemptsByUal.set(ual, attempts);
+      lastDisposition = ual.endsWith('/76') && peerId === peerB ? 'found' : 'incomplete';
+      return {
+        result: {
+          fetchedDataTriples: lastDisposition === 'found' ? 1 : 0,
+          fetchedMetaTriples: lastDisposition === 'found' ? 8 : 0,
+          insertedTriples: lastDisposition === 'found' ? 9 : 0,
+          failedPeers: 0, failedPhases: lastDisposition === 'incomplete' ? 1 : 0,
+          deferredBackpressure: 0,
+        },
+        disposition: lastDisposition,
+      };
+    };
+    let activeTarget = vmRecoveryTarget(localCgId, 0, '76');
+    (internals as any).reconcileChainOrdinal = async () => (
+      lastDisposition === 'found'
+        ? { status: 'reconciled', blockNumber: 100 }
+        : { status: 'pending', recovery: activeTarget }
+    );
+
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    const recovered = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [activeTarget], 100, () => true,
+    );
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB]);
+    expect(recovered.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+
+    activeTarget = vmRecoveryTarget(localCgId, 1, '77');
+    lastDisposition = 'incomplete';
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(localCgId, 1n, [activeTarget], 100, () => true);
+    }
+    expect(attemptsByUal.get(activeTarget.ual)).toEqual([peerA, peerB, peerA]);
+    const record = (internals as any).vmReconcileRotationState.get(
+      (internals as any).vmReconcileRotationSlotKey(activeTarget),
+    );
+    expect(record.cleanAbsentPeerIds.size).toBe(0);
+    expect(record).toMatchObject({ phase: 'collecting', failures: 0 });
+  });
+
+  it('backs off only after a complete clean-absence rotation and requires a fresh next cycle', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmCleanAbsenceBackoff', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peerA = '12D3KooWCleanAbsentPeerA';
+    const peerB = '12D3KooWCleanAbsentPeerB';
+    const localCgId = '0x0000000000000000000000000000000000000001/clean-absence';
+    const connected = [peerA, peerB].map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWCleanAbsentLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peerA);
+    let curatorResolutions = 0;
+    (internals as any).resolveCuratorPeerIdsForCg = async () => {
+      curatorResolutions += 1;
+      return { peerIds: [peerA], curatorIsLocal: false, legacyTripleResolved: false };
+    };
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    let now = 100;
+    (internals as any).vmReconcileRotationNow = () => now;
+    const networkAttempts: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      networkAttempts.push(peerId);
+      return {
+        result: {
+          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'clean-absent',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, '71');
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'pending',
+      recovery: target,
+    });
+
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+    const firstBackoff = (internals as any).vmReconcileRotationState.get(slotKey);
+    expect(networkAttempts).toEqual([peerA, peerB]);
+    expect(firstBackoff).toMatchObject({ phase: 'backoff', failures: 1 });
+
+    const suppressed = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    expect(suppressed.attemptedOrdinals).toEqual([]);
+    expect(curatorResolutions).toBe(2);
+
+    now = firstBackoff.nextRetryAt + 1;
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    const freshPartial = (internals as any).vmReconcileRotationState.get(slotKey);
+    expect(networkAttempts).toEqual([peerA, peerB, peerA]);
+    expect(freshPartial).toMatchObject({ phase: 'collecting', failures: 1 });
+    expect([...freshPartial.cleanAbsentPeerIds]).toEqual([peerA]);
+
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(networkAttempts).toEqual([peerA, peerB, peerA, peerB]);
+    expect((internals as any).vmReconcileRotationState.get(slotKey))
+      .toMatchObject({ phase: 'backoff', failures: 2 });
+  });
+
+  it('keeps the pre-suppression roster stable across connection reorder and curator discovery', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmCanonicalRoster', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peerA = '12D3KooWCanonicalRosterA';
+    const peerB = '12D3KooWCanonicalRosterB';
+    const peerC = '12D3KooWCanonicalRosterC';
+    const peerD = '12D3KooWCanonicalRosterD';
+    const localCgId = '0x0000000000000000000000000000000000000001/canonical-roster';
+    const peerById = new Map(
+      [peerA, peerB, peerC, peerD].map((peerId) => [peerId, { toString: () => peerId }]),
+    );
+    let connectionRead = 0;
+    (internals as any).node = {
+      peerId: '12D3KooWCanonicalRosterLocal',
+      libp2p: {
+        getConnections: () => {
+          connectionRead += 1;
+          const ids = connectionRead % 2 === 0
+            ? [peerD, peerC, peerB, peerA]
+            : [peerB, peerD, peerA, peerC];
+          return ids.map((peerId) => ({ remotePeer: peerById.get(peerId)! }));
+        },
+      },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peerA);
+    let curatorResolutions = 0;
+    (internals as any).resolveCuratorPeerIdsForCg = async () => {
+      curatorResolutions += 1;
+      return {
+        // The secondary curator would displace C if this list were prepended to
+        // the post-discovery roster instead of using the canonicalizer.
+        peerIds: [peerA, peerD],
+        curatorIsLocal: false,
+        legacyTripleResolved: false,
+      };
+    };
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const networkAttempts: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      networkAttempts.push(peerId);
+      return {
+        result: {
+          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'clean-absent',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, '75');
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'pending', recovery: target,
+    });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    }
+    expect(networkAttempts).toEqual([peerA, peerB, peerC]);
+    expect(curatorResolutions).toBe(3);
+
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    expect(networkAttempts).toEqual([peerA, peerB, peerC]);
+    expect(curatorResolutions).toBe(3);
+  });
+
+  it('retries credited peers after an incomplete collection cycle expires', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmPartialCycleExpiry', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peerA = '12D3KooWPartialCyclePeerA';
+    const peerB = '12D3KooWPartialCyclePeerB';
+    const localCgId = '0x0000000000000000000000000000000000000001/partial-cycle';
+    const connected = [peerA, peerB].map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWPartialCycleLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peerA);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peerA], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    let now = 100;
+    (internals as any).vmReconcileRotationNow = () => now;
+    const networkAttempts: string[] = [];
+    let peerAFetches = 0;
+    let lastDisposition: 'found' | 'clean-absent' | 'incomplete' = 'incomplete';
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      networkAttempts.push(peerId);
+      if (peerId === peerA) peerAFetches += 1;
+      lastDisposition = peerId === peerA && peerAFetches > 1
+        ? 'found'
+        : peerId === peerA
+          ? 'clean-absent'
+          : 'incomplete';
+      return {
+        result: {
+          fetchedDataTriples: lastDisposition === 'found' ? 1 : 0,
+          fetchedMetaTriples: lastDisposition === 'found' ? 8 : 0,
+          insertedTriples: lastDisposition === 'found' ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: lastDisposition,
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, '74');
+    (internals as any).reconcileChainOrdinal = async () => (
+      lastDisposition === 'found'
+        ? { status: 'reconciled', blockNumber: 100 }
+        : { status: 'pending', recovery: target }
+    );
+
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
+
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+    const partial = (internals as any).vmReconcileRotationState.get(slotKey);
+    expect(networkAttempts).toEqual([peerA, peerB]);
+    expect([...partial.cleanAbsentPeerIds]).toEqual([peerA]);
+    expect(partial).toMatchObject({ phase: 'collecting', failures: 0 });
+
+    now = partial.collectionDeadlineAt + 1;
+    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+    const recovered = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+
+    expect(networkAttempts).toEqual([peerA, peerB, peerA]);
+    expect(recovered.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+  });
+
+  it('keeps collecting records stable at cap while cap+1 overflow still fetches fairly', async () => {
+    const capDescriptor = Object.getOwnPropertyDescriptor(
+      DKGAgentBase,
+      'VM_RECONCILE_CACHE_MAX_ENTRIES',
+    )!;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_CACHE_MAX_ENTRIES', {
+      ...capDescriptor,
+      value: 1,
+    });
+    try {
+      const chain = new MockChainAdapter();
+      agent = await DKGAgent.create({ name: 'ExactVmStableRotationCapacity', chainAdapter: chain });
+      const internals = agent as unknown as AgentInternals;
+      const peerA = '12D3KooWStableCapacityPeerA';
+      const peerB = '12D3KooWStableCapacityPeerB';
+      const localCgId = '0x0000000000000000000000000000000000000001/stable-capacity';
+      const connected = [peerA, peerB].map((peerId) => ({ toString: () => peerId }));
+      (internals as any).node = {
+        peerId: '12D3KooWStableCapacityLocal',
+        libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+      };
+      (internals as any).preferredSyncPeers.set(localCgId, peerA);
+      (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+        peerIds: [peerA], curatorIsLocal: false, legacyTripleResolved: false,
+      });
+      (internals as any).ensurePeerConnected = async () => undefined;
+      (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+      (internals as any).waitForSyncProtocol = async () => true;
+      (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+      const attemptsByUal = new Map<string, string[]>();
+      (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
+        peerId: string,
+        _cgId: string,
+        requestedUals: string[],
+      ) => {
+        const ual = requestedUals[0]!;
+        const attempts = attemptsByUal.get(ual) ?? [];
+        attempts.push(peerId);
+        attemptsByUal.set(ual, attempts);
+        return {
+          result: {
+            fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+            failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+          },
+          disposition: 'clean-absent',
+        };
+      };
+      const first = vmRecoveryTarget(localCgId, 0, '78');
+      const overflow = vmRecoveryTarget(localCgId, 1, '79');
+      const byOrdinal = new Map([[first.ordinal, first], [overflow.ordinal, overflow]]);
+      (internals as any).reconcileChainOrdinal = async (
+        _lcg: string,
+        _ocg: bigint,
+        ordinal: number,
+      ) => ({ status: 'pending', recovery: byOrdinal.get(ordinal)! });
+      const rotationState = (internals as any).vmReconcileRotationState as Map<
+        string,
+        { phase: string; cleanAbsentPeerIds: Set<string> }
+      >;
+      const firstKey = (internals as any).vmReconcileRotationSlotKey(first);
+      const overflowKey = (internals as any).vmReconcileRotationSlotKey(overflow);
+
+      await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [first, overflow], 100, () => true,
+      );
+      expect(rotationState.size).toBe(1);
+      expect(rotationState.get(firstKey)).toMatchObject({ phase: 'collecting' });
+      expect([...rotationState.get(firstKey)!.cleanAbsentPeerIds]).toEqual([peerA]);
+      expect(attemptsByUal.get(first.ual)).toEqual([peerA]);
+      expect(attemptsByUal.get(overflow.ual)).toEqual([peerB]);
+
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [first, overflow], 100, () => true,
+      );
+      expect(rotationState.size).toBe(1);
+      expect(rotationState.get(firstKey)).toMatchObject({ phase: 'backoff' });
+      expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB]);
+      expect(attemptsByUal.get(overflow.ual)).toEqual([peerB, peerA]);
+
+      // The overflow slot may fairly replace the completed backoff record, but
+      // the evicted object is never used for evidence. Its target still takes a
+      // normal fail-open exact attempt with the remaining peer.
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [first, overflow], 100, () => true,
+      );
+      expect(rotationState.size).toBe(1);
+      expect(rotationState.has(firstKey)).toBe(false);
+      expect(rotationState.get(overflowKey)).toMatchObject({ phase: 'collecting' });
+      expect([...rotationState.get(overflowKey)!.cleanAbsentPeerIds]).toEqual([peerA]);
+      expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB, peerB]);
+      expect(attemptsByUal.get(overflow.ual)).toEqual([peerB, peerA, peerA]);
+
+      (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
+      await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [first, overflow], 100, () => true,
+      );
+      expect(rotationState.size).toBe(1);
+      expect(rotationState.get(overflowKey)).toMatchObject({ phase: 'backoff' });
+      expect(attemptsByUal.get(first.ual)).toEqual([peerA, peerB, peerB, peerA]);
+      expect(attemptsByUal.get(overflow.ual)).toEqual([peerB, peerA, peerA, peerB]);
+    } finally {
+      Object.defineProperty(
+        DKGAgentBase,
+        'VM_RECONCILE_CACHE_MAX_ENTRIES',
+        capDescriptor,
+      );
+    }
+  });
+
+  it('starts a fresh clean-absence proof after candidate growth and ignores evicted records', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmRotationIdentity', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const target = vmRecoveryTarget('rotation-identity', 0, '72');
+    const peerA = '12D3KooWRotationIdentityA';
+    const peerB = '12D3KooWRotationIdentityB';
+    const peerC = '12D3KooWRotationIdentityC';
+
+    const initial = (internals as any).prepareVmReconcileRotationTarget(
+      target, [peerA, peerB], 0,
+    );
+    (internals as any).creditVmReconcileCleanAbsence(
+      target, peerA, [peerA, peerB], initial.record,
+    );
+    expect([...initial.record.cleanAbsentPeerIds]).toEqual([peerA]);
+
+    const grown = (internals as any).prepareVmReconcileRotationTarget(
+      target, [peerA, peerB, peerC], 1,
+    );
+    expect(grown.record).toBe(initial.record);
+    expect(grown.record.phase).toBe('collecting');
+    expect([...grown.record.cleanAbsentPeerIds]).toEqual([]);
+
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+    (internals as any).vmReconcileRotationState.delete(slotKey);
+    (internals as any).creditVmReconcileCleanAbsence(
+      target, peerA, [peerA, peerB, peerC], grown.record,
+    );
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+
+    const rootB = { ...target, merkleRoot: 'root-b' };
+    const replacement = (internals as any).prepareVmReconcileRotationTarget(
+      rootB, [peerA], 2,
+    ).record;
+    expect(replacement).not.toBe(grown.record);
+    const rootAAgain = (internals as any).prepareVmReconcileRotationTarget(
+      target, [peerA], 2,
+    ).record;
+    expect(rootAAgain).not.toBe(initial.record);
+    expect(rootAAgain).not.toBe(replacement);
+    (internals as any).forceClearVmReconcileStateForContextGraph(target.localCgId);
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+    (internals as any).creditVmReconcileCleanAbsence(
+      target, peerA, [peerA], rootAAgain,
+    );
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
+
+    const shutdownRecord = (internals as any).prepareVmReconcileRotationTarget(
+      target, [peerA], 3,
+    ).record;
+    (internals as any).closeVmReconcileRotationState();
+    (internals as any).creditVmReconcileCleanAbsence(
+      target, peerA, [peerA], shutdownRecord,
+    );
+    expect((internals as any).vmReconcileRotationState.size).toBe(0);
+  });
+
+  it('does not resurrect a rotation record evicted while the exact request is pending', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmLateEviction', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peer = '12D3KooWLateEvictionPeer';
+    const localCgId = '0x0000000000000000000000000000000000000001/late-eviction';
+    const connectedPeer = { toString: () => peer };
+    (internals as any).node = {
+      peerId: '12D3KooWLateEvictionLocal',
+      libp2p: { getConnections: () => [{ remotePeer: connectedPeer }] },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peer);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peer], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = () => [connectedPeer];
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    let releaseFetch!: () => void;
+    let markFetchStarted!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => { markFetchStarted = resolve; });
+    const fetchRelease = new Promise<void>((resolve) => { releaseFetch = resolve; });
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async () => {
+      markFetchStarted();
+      await fetchRelease;
+      return {
+        result: {
+          fetchedDataTriples: 0, fetchedMetaTriples: 0, insertedTriples: 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'clean-absent',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, '73');
+    (internals as any).reconcileChainOrdinal = async () => ({
+      status: 'pending', recovery: target,
+    });
+
+    const recovery = internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    await fetchStarted;
+    const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(true);
+    (internals as any).vmReconcileRotationState.delete(slotKey);
+    releaseFetch();
+    await recovery;
+
+    expect((internals as any).vmReconcileRotationState.has(slotKey)).toBe(false);
   });
 
   it('clears the fetch cooldown after a productive exact batch so the next slice proceeds', async () => {
@@ -2386,23 +2912,21 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
     (internals as any).waitForSyncProtocol = async () => true;
     let fetchCount = 0;
-    (internals as any).syncExactKnowledgeAssetsFromPeer = async () => {
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async () => {
       fetchCount += 1;
       return {
-        fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
-        failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        result: {
+          fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'found',
       };
     };
     (internals as any).reconcileChainOrdinal = async () => ({
       status: 'reconciled',
       blockNumber: 100,
     });
-    const target = {
-      ordinal: 0,
-      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
-      kaId: '7',
-      reason: 'no-swm' as const,
-    };
+    const target = vmRecoveryTarget(localCgId, 0, '7');
 
     await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
     expect(fetchCount).toBe(1);
@@ -2439,23 +2963,21 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       ensureAdmitted: async () => false,
     };
     const fetches: string[] = [];
-    (internals as any).syncExactKnowledgeAssetsFromPeer = async (peerId: string) => {
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
       fetches.push(peerId);
       return {
-        fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
-        failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        result: {
+          fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'found',
       };
     };
     (internals as any).reconcileChainOrdinal = async () => ({
       status: 'reconciled',
       blockNumber: 100,
     });
-    const target = {
-      ordinal: 0,
-      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
-      kaId: '7',
-      reason: 'no-swm' as const,
-    };
+    const target = vmRecoveryTarget(localCgId, 0, '7');
 
     const result = await internals.recoverVmReconcileBatch(localCgId, 1n, [target], 100, () => true);
 

--- a/packages/agent/test/discovery-peer-pagination.test.ts
+++ b/packages/agent/test/discovery-peer-pagination.test.ts
@@ -51,4 +51,27 @@ describe('DiscoveryClient curator peer pagination', () => {
       await store.close();
     }
   });
+
+  it('matches legacy mixed-case EVM wallet rows case-insensitively', async () => {
+    const store = new OxigraphStore();
+    const lowerAddress = '0xabcdef00000000000000000000000000000000ab';
+    const mixedAddress = '0xAbCdEf00000000000000000000000000000000aB';
+    try {
+      const profile = buildAgentProfile({
+        peerId: 'peer-checksum', name: 'Checksum Curator', agentAddress: lowerAddress, skills: [],
+      });
+      const legacyQuads = profile.quads.map((quad) => (
+        quad.predicate === 'https://dkg.network/ontology#agentAddress'
+          ? { ...quad, object: `"${mixedAddress}"` }
+          : quad
+      ));
+      await store.insert(legacyQuads);
+      const discovery = new DiscoveryClient(new DKGQueryEngine(store));
+
+      await expect(discovery.findAgentPeerIdsByAddress(lowerAddress))
+        .resolves.toEqual(['peer-checksum']);
+    } finally {
+      await store.close();
+    }
+  });
 });

--- a/packages/agent/test/discovery-peer-pagination.test.ts
+++ b/packages/agent/test/discovery-peer-pagination.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DKGQueryEngine } from '@origintrail-official/dkg-query';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { DiscoveryClient } from '../src/discovery.js';
+import { buildAgentProfile } from '../src/profile.js';
+
+describe('DiscoveryClient curator peer pagination', () => {
+  it('queries distinct peer IDs in deterministic exclusive-cursor order', async () => {
+    const query = vi.fn(async () => ({
+      type: 'bindings' as const,
+      bindings: [
+        { peerId: '"peer-011"' },
+        { peerId: '"peer-012"' },
+      ],
+    }));
+    const discovery = new DiscoveryClient({ query } as any);
+
+    await expect(discovery.findAgentPeerIdsByAddress(
+      '0xabc',
+      { afterPeerId: 'peer-010', limit: 2 },
+    )).resolves.toEqual(['peer-011', 'peer-012']);
+
+    const [sparql, options] = query.mock.calls[0]!;
+    expect(sparql).toContain('SELECT DISTINCT ?peerId');
+    expect(sparql).toContain('FILTER(STR(?peerId) > "peer-010")');
+    expect(sparql).toContain('ORDER BY ASC(STR(?peerId))');
+    expect(sparql).toContain('LIMIT 2');
+    expect(options).toMatchObject({ contextGraphId: 'agents' });
+  });
+
+  it('pages real agent-registry data without duplicate profile rows', async () => {
+    const store = new OxigraphStore();
+    const curator = '0x00000000000000000000000000000000000000ab';
+    try {
+      const first = buildAgentProfile({
+        peerId: 'peer-001', name: 'First', agentAddress: curator, skills: [],
+      });
+      const second = buildAgentProfile({
+        peerId: 'peer-002', name: 'Second', agentAddress: curator, skills: [],
+      });
+      await store.insert([...first.quads, ...second.quads]);
+      const discovery = new DiscoveryClient(new DKGQueryEngine(store));
+
+      await expect(discovery.findAgentPeerIdsByAddress(curator, { limit: 1 }))
+        .resolves.toEqual(['peer-001']);
+      await expect(discovery.findAgentPeerIdsByAddress(
+        curator,
+        { afterPeerId: 'peer-001', limit: 2 },
+      )).resolves.toEqual(['peer-002']);
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
+++ b/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
@@ -1573,6 +1573,113 @@ describe('durable graph-scoped KA materialization', () => {
     expect(await values(store, 'assertionVersion')).toEqual(['"1"']);
   });
 
+  it('does not pass a lifecycle abort signal into an entered atomic replacement', async () => {
+    const store = new OxigraphStore();
+    const controller = new AbortController();
+    let releaseReplace!: () => void;
+    let markReplaceEntered!: () => void;
+    const replaceEntered = new Promise<void>((resolve) => { markReplaceEntered = resolve; });
+    const replaceGate = new Promise<void>((resolve) => { releaseReplace = resolve; });
+    const replaceGraphAndSubject = store.replaceGraphAndSubject!.bind(store);
+    let observedCommitSignal: AbortSignal | undefined;
+    const gatedStore = new Proxy(store, {
+      get(target, property) {
+        if (property === 'replaceGraphAndSubject') {
+          return async (...args: Parameters<NonNullable<TripleStore['replaceGraphAndSubject']>>) => {
+            observedCommitSignal = args[5]?.signal;
+            markReplaceEntered();
+            await replaceGate;
+            if (observedCommitSignal?.aborted) {
+              throw Object.assign(new Error('transport aborted'), { name: 'AbortError' });
+            }
+            return replaceGraphAndSubject(...args);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    let current = true;
+    let settled = false;
+    const materialization = materializeVerifiedGraphScopedAsset({
+      store: gatedStore,
+      asset: {
+        contextGraphId,
+        ual,
+        assertionVersion: 2n,
+        assertionGraph,
+        metaGraph,
+        dataQuads: [dataQuad(2)],
+        metadataQuads: metadata(2),
+      },
+      isCurrent: () => current,
+      options: { signal: controller.signal },
+    }).finally(() => { settled = true; });
+
+    await replaceEntered;
+    current = false;
+    controller.abort();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(observedCommitSignal).toBeUndefined();
+
+    releaseReplace();
+    await expect(materialization).resolves.toBe('quarantined');
+    expect(await values(store, 'assertionVersion')).toEqual(['"2"']);
+  });
+
+  it('atomically removes an asset committed against a binding that changed in flight', async () => {
+    const store = new OxigraphStore();
+    let releaseReplace!: () => void;
+    let markReplaceEntered!: () => void;
+    const replaceEntered = new Promise<void>((resolve) => { markReplaceEntered = resolve; });
+    const replaceGate = new Promise<void>((resolve) => { releaseReplace = resolve; });
+    const replaceGraphAndSubject = store.replaceGraphAndSubject!.bind(store);
+    let replaceCalls = 0;
+    const gatedStore = new Proxy(store, {
+      get(target, property) {
+        if (property === 'replaceGraphAndSubject') {
+          return async (...args: Parameters<NonNullable<TripleStore['replaceGraphAndSubject']>>) => {
+            replaceCalls += 1;
+            if (replaceCalls === 1) {
+              markReplaceEntered();
+              await replaceGate;
+            }
+            return replaceGraphAndSubject(...args);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    let current = true;
+    let bindingChanged = false;
+    const materialization = materializeVerifiedGraphScopedAsset({
+      store: gatedStore,
+      asset: {
+        contextGraphId,
+        ual,
+        assertionVersion: 2n,
+        assertionGraph,
+        metaGraph,
+        dataQuads: [dataQuad(2)],
+        metadataQuads: metadata(2),
+      },
+      isCurrent: () => current,
+      shouldQuarantineCommitted: () => bindingChanged,
+    });
+
+    await replaceEntered;
+    current = false;
+    bindingChanged = true;
+    releaseReplace();
+
+    await expect(materialization).resolves.toBe('quarantined');
+    expect(replaceCalls).toBe(2);
+    expect(await store.countQuads(assertionGraph)).toBe(0);
+    expect(await values(store, 'assertionVersion')).toEqual([]);
+  });
+
   it('leaves both old partitions intact when the atomic store update fails', async () => {
     const store = new OxigraphStore();
     const v1Data = dataQuad(1);

--- a/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
+++ b/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
@@ -1628,7 +1628,7 @@ describe('durable graph-scoped KA materialization', () => {
     expect(await values(store, 'assertionVersion')).toEqual(['"2"']);
   });
 
-  it('atomically removes an asset committed against a binding that changed in flight', async () => {
+  it('atomically removes an asset when its subscription is deleted after commit starts', async () => {
     const store = new OxigraphStore();
     let releaseReplace!: () => void;
     let markReplaceEntered!: () => void;
@@ -1652,8 +1652,7 @@ describe('durable graph-scoped KA materialization', () => {
         return typeof value === 'function' ? value.bind(target) : value;
       },
     }) as TripleStore;
-    let current = true;
-    let bindingChanged = false;
+    let subscriptionPresent = true;
     const materialization = materializeVerifiedGraphScopedAsset({
       store: gatedStore,
       asset: {
@@ -1665,13 +1664,12 @@ describe('durable graph-scoped KA materialization', () => {
         dataQuads: [dataQuad(2)],
         metadataQuads: metadata(2),
       },
-      isCurrent: () => current,
-      shouldQuarantineCommitted: () => bindingChanged,
+      isCurrent: () => true,
+      shouldQuarantineCommitted: () => !subscriptionPresent,
     });
 
     await replaceEntered;
-    current = false;
-    bindingChanged = true;
+    subscriptionPresent = false;
     releaseReplace();
 
     await expect(materialization).resolves.toBe('quarantined');

--- a/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
+++ b/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
@@ -1631,8 +1631,8 @@ describe('durable graph-scoped KA materialization', () => {
   it('atomically removes an asset when its subscription is deleted after commit starts', async () => {
     const store = new OxigraphStore();
     let releaseReplace!: () => void;
-    let markReplaceEntered!: () => void;
-    const replaceEntered = new Promise<void>((resolve) => { markReplaceEntered = resolve; });
+    let markReplaceCommitted!: () => void;
+    const replaceCommitted = new Promise<void>((resolve) => { markReplaceCommitted = resolve; });
     const replaceGate = new Promise<void>((resolve) => { releaseReplace = resolve; });
     const replaceGraphAndSubject = store.replaceGraphAndSubject!.bind(store);
     let replaceCalls = 0;
@@ -1641,11 +1641,12 @@ describe('durable graph-scoped KA materialization', () => {
         if (property === 'replaceGraphAndSubject') {
           return async (...args: Parameters<NonNullable<TripleStore['replaceGraphAndSubject']>>) => {
             replaceCalls += 1;
+            const result = await replaceGraphAndSubject(...args);
             if (replaceCalls === 1) {
-              markReplaceEntered();
+              markReplaceCommitted();
               await replaceGate;
             }
-            return replaceGraphAndSubject(...args);
+            return result;
           };
         }
         const value = Reflect.get(target, property, target);
@@ -1668,7 +1669,7 @@ describe('durable graph-scoped KA materialization', () => {
       shouldQuarantineCommitted: () => !subscriptionPresent,
     });
 
-    await replaceEntered;
+    await replaceCommitted;
     subscriptionPresent = false;
     releaseReplace();
 

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -5,7 +5,11 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 
 vi.mock('../src/sync/requester/durable-sync.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/sync/requester/durable-sync.js')>();
-  return { ...actual, runDurableSync: vi.fn(async () => ({})) };
+  return {
+    ...actual,
+    runDurableSync: vi.fn(async () => ({})),
+    runDurableSyncDetailed: vi.fn(async () => ({ result: {} })),
+  };
 });
 
 vi.mock('../src/sync/requester/graph-scoped-materialization.js', async (importOriginal) => {
@@ -24,6 +28,7 @@ import { DKGAgent } from '../src/dkg-agent.js';
 import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 import {
   runDurableSync,
+  runDurableSyncDetailed,
   type DurableSyncContext,
   type DurableSyncGraphScopedStoreRequest,
 } from '../src/sync/requester/durable-sync.js';
@@ -40,6 +45,7 @@ const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
 const ctx = { kind: 'sync', id: 'lifecycle-binding-test', startedAt: 0 } as OperationContext;
 
 const mockedRunDurableSync = vi.mocked(runDurableSync);
+const mockedRunDurableSyncDetailed = vi.mocked(runDurableSyncDetailed);
 const mockedMaterialize = vi.mocked(materializeVerifiedGraphScopedAsset);
 
 function graphScopedAsset(
@@ -138,6 +144,7 @@ async function captureGraphScopedStore(
 describe('durable sync lifecycle chain binding', () => {
   beforeEach(() => {
     mockedRunDurableSync.mockClear();
+    mockedRunDurableSyncDetailed.mockClear();
     mockedMaterialize.mockClear();
   });
 
@@ -480,14 +487,14 @@ describe('durable sync lifecycle chain binding', () => {
         totalTimeoutMs: 30_000,
       },
     );
-    expect(mockedRunDurableSync).toHaveBeenCalledTimes(1);
+    expect(mockedRunDurableSyncDetailed).toHaveBeenCalledTimes(1);
     expect(
-      mockedRunDurableSync.mock.calls[0]![0].durableSyncBudget
+      mockedRunDurableSyncDetailed.mock.calls[0]![0].durableSyncBudget
         .createContextGraphBudget({ contextGraphId, remainingContextGraphs: 1 })
         .fetchDeadline,
     ).toBe(1_800_000_030_000);
 
-    mockedRunDurableSync.mockClear();
+    mockedRunDurableSyncDetailed.mockClear();
     agentLike.runLegacyDurableSync = LifecycleSyncMethods.prototype.runLegacyDurableSync;
     await LifecycleSyncMethods.prototype.syncExactKnowledgeAssetsFromPeer.call(
       agentLike,
@@ -495,12 +502,51 @@ describe('durable sync lifecycle chain binding', () => {
       contextGraphId,
       [exactUal],
     );
-    expect(mockedRunDurableSync).toHaveBeenCalledTimes(1);
+    expect(mockedRunDurableSyncDetailed).toHaveBeenCalledTimes(1);
     expect(
-      mockedRunDurableSync.mock.calls[0]![0].durableSyncBudget
+      mockedRunDurableSyncDetailed.mock.calls[0]![0].durableSyncBudget
         .createContextGraphBudget({ contextGraphId, remainingContextGraphs: 1 })
         .fetchDeadline,
     ).toBe(1_800_000_600_000);
+  });
+
+  it('keeps a multi-graph exact lifecycle result incomplete after a later clean absence', async () => {
+    const exactUal = 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/1';
+    const agentLike: any = {
+      config: {},
+      processDurableBatchInWorker: async () => ({}),
+      runContextGraphSyncWithBackpressure: async (
+        _ctx: unknown,
+        _contextGraphId: string,
+        _lane: string,
+        _operationId: string,
+        work: () => Promise<unknown>,
+      ) => work(),
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+    mockedRunDurableSyncDetailed
+      .mockResolvedValueOnce({
+        result: {} as Awaited<ReturnType<typeof runDurableSync>>,
+        exactFetchDisposition: 'incomplete',
+      })
+      .mockResolvedValueOnce({
+        result: {} as Awaited<ReturnType<typeof runDurableSync>>,
+        exactFetchDisposition: 'clean-absent',
+      });
+
+    const detailed = await LifecycleSyncMethods.prototype.runLegacyDurableSyncDetailed.call(
+      agentLike,
+      ctx,
+      'peer-multi-exact',
+      ['exact-incomplete-cg', 'exact-clean-cg'],
+      undefined,
+      undefined,
+      undefined,
+      { exactAssetUals: [exactUal] },
+    );
+
+    expect(mockedRunDurableSyncDetailed).toHaveBeenCalledTimes(2);
+    expect(detailed.exactFetchDisposition).toBe('incomplete');
   });
 
   it('keeps caller-signalled durable sync off the non-cancellable changelog lane', async () => {

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -807,6 +807,36 @@ describe('durable sync lifecycle chain binding', () => {
     expect(mockedMaterialize).toHaveBeenCalledTimes(materializationsBeforeRejectedSave);
   });
 
+  it('retains a chain-authenticated public asset when no subscription exists', async () => {
+    const root = new Uint8Array(32);
+    root[31] = 2;
+    const chain = {
+      chainId: 'otp:2043',
+      getLatestMerkleRoot: async () => root,
+      getMerkleRootCount: async () => 2n,
+      getKAContextGraphId: async () => 14n,
+      getContextGraphNameHash: async () => (
+        ethers.keccak256(ethers.toUtf8Bytes(contextGraphId))
+      ),
+      getLatestMerkleRootPublisher: async () => '0x2222222222222222222222222222222222222222',
+      verifyKAUpdate: async () => ({
+        verified: true,
+        onChainMerkleRoot: root,
+        blockNumber: 123,
+        txIndex: 4,
+        merkleRootCount: 2n,
+      }),
+    } as ChainAdapter;
+
+    const storeGraphScopedAsset = await captureGraphScopedStore(chain);
+    await expect(storeGraphScopedAsset(
+      graphScopedStoreRequest(graphScopedAsset(root), Date.now() + 60_000),
+    )).resolves.toBe('applied');
+
+    expect(mockedMaterialize).toHaveBeenCalledOnce();
+    expect(mockedMaterialize.mock.calls[0]![0].shouldQuarantineCommitted?.()).toBe(false);
+  });
+
   it('does not let a stale strict snapshot overwrite a newer host-only persistence write', async () => {
     const oldSubscription = { subscribed: true, onChainId: '14' };
     const hostOnlySubscription = { subscribed: false, coreHosted: true, onChainId: '14' };

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -328,19 +328,23 @@ describe('durable sync lifecycle chain binding', () => {
   });
 
   it('selects the dedicated field-sized exact-recovery transfer policy', async () => {
-    const runLegacyDurableSync = vi.fn(async () => ({}));
-    const agentLike = { runLegacyDurableSync };
+    const physicalResult = {} as Awaited<ReturnType<typeof runDurableSync>>;
+    const runLegacyDurableSyncDetailed = vi.fn(async () => ({
+      result: physicalResult,
+      exactFetchDisposition: 'clean-absent' as const,
+    }));
+    const agentLike = { runLegacyDurableSyncDetailed };
     const exactUal = 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/1';
 
-    await LifecycleSyncMethods.prototype.syncExactKnowledgeAssetsFromPeer.call(
+    const detailed = await LifecycleSyncMethods.prototype.syncExactKnowledgeAssetsFromPeerDetailed.call(
       agentLike as any,
       '12D3KooWExactRecoveryPeer',
       '0x1111111111111111111111111111111111111111/blackbox',
       [exactUal],
     );
 
-    expect(runLegacyDurableSync).toHaveBeenCalledTimes(1);
-    expect(runLegacyDurableSync.mock.calls[0]?.[6]).toMatchObject({
+    expect(runLegacyDurableSyncDetailed).toHaveBeenCalledTimes(1);
+    expect(runLegacyDurableSyncDetailed.mock.calls[0]?.[6]).toMatchObject({
       exactAssetUals: [exactUal],
       stopOnBackoffWorthyFailure: true,
       priority: 1_000,
@@ -350,7 +354,31 @@ describe('durable sync lifecycle chain binding', () => {
       // call site keeps every test green and only the Grafana attribution rots.
       source: 'vm-recovery',
     });
-    expect(runLegacyDurableSync.mock.calls[0]?.[6]).not.toHaveProperty('totalTimeoutMs');
+    expect(runLegacyDurableSyncDetailed.mock.calls[0]?.[6]).not.toHaveProperty('totalTimeoutMs');
+    expect(detailed).toEqual({ result: physicalResult, disposition: 'clean-absent' });
+  });
+
+  it('projects the public exact-sync result from the detailed implementation', async () => {
+    const result = {} as Awaited<ReturnType<typeof runDurableSync>>;
+    const syncExactKnowledgeAssetsFromPeerDetailed = vi.fn(async () => ({
+      result,
+      disposition: 'found' as const,
+    }));
+    const requestedAssetUals = [ual];
+
+    const projected = await LifecycleSyncMethods.prototype.syncExactKnowledgeAssetsFromPeer.call(
+      { syncExactKnowledgeAssetsFromPeerDetailed } as any,
+      '12D3KooWExactProjectionPeer',
+      contextGraphId,
+      requestedAssetUals,
+    );
+
+    expect(syncExactKnowledgeAssetsFromPeerDetailed).toHaveBeenCalledWith(
+      '12D3KooWExactProjectionPeer',
+      contextGraphId,
+      requestedAssetUals,
+    );
+    expect(projected).toBe(result);
   });
 
   it.each([
@@ -495,7 +523,9 @@ describe('durable sync lifecycle chain binding', () => {
     ).toBe(1_800_000_030_000);
 
     mockedRunDurableSyncDetailed.mockClear();
-    agentLike.runLegacyDurableSync = LifecycleSyncMethods.prototype.runLegacyDurableSync;
+    agentLike.runLegacyDurableSyncDetailed = LifecycleSyncMethods.prototype.runLegacyDurableSyncDetailed;
+    agentLike.syncExactKnowledgeAssetsFromPeerDetailed =
+      LifecycleSyncMethods.prototype.syncExactKnowledgeAssetsFromPeerDetailed;
     await LifecycleSyncMethods.prototype.syncExactKnowledgeAssetsFromPeer.call(
       agentLike,
       'peer-internal-exact-recovery',

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -104,6 +104,7 @@ async function captureGraphScopedStore(
     chain,
     store: {},
     subscribedContextGraphs: new Map(),
+    contextGraphBindingGenerations: new Map(),
     wireIdToLocalCgId: new Map(),
     graphScopedStoreClosed: false,
     graphScopedStorePhysicalRuns: new Set<Promise<unknown>>(),
@@ -299,6 +300,7 @@ describe('durable sync lifecycle chain binding', () => {
       chain: { chainId: 'none' },
       store: {},
       subscribedContextGraphs: new Map(),
+      contextGraphBindingGenerations: new Map(),
       wireIdToLocalCgId: new Map(),
       bindSubscriptionOnChainId: vi.fn(),
       persistContextGraphSubscriptionStrict: vi.fn(),
@@ -672,6 +674,7 @@ describe('durable sync lifecycle chain binding', () => {
       chain,
       store: {},
       subscribedContextGraphs: new Map([[contextGraphId, subscription]]),
+      contextGraphBindingGenerations: new Map(),
       wireIdToLocalCgId: new Map(),
       graphScopedStoreClosed: false,
       graphScopedStorePhysicalRuns: new Set<Promise<unknown>>(),
@@ -788,6 +791,9 @@ describe('durable sync lifecycle chain binding', () => {
     subscription.onChainId = undefined;
     expect(shouldQuarantineCommitted?.()).toBe(true);
     subscription.onChainId = '14';
+    agentLike.subscribedContextGraphs.delete(contextGraphId);
+    expect(shouldQuarantineCommitted?.()).toBe(true);
+    agentLike.subscribedContextGraphs.set(contextGraphId, subscription);
 
     subscription.onChainId = undefined;
     persistContextGraphSubscriptionStrict.mockRejectedValueOnce(new Error('subscription store unavailable'));
@@ -879,6 +885,7 @@ describe('durable sync lifecycle chain binding', () => {
       chain,
       store: {},
       subscribedContextGraphs: new Map([[contextGraphId, subscription]]),
+      contextGraphBindingGenerations: new Map(),
       wireIdToLocalCgId: new Map(),
       graphScopedStoreClosed: false,
       graphScopedStorePhysicalRuns: new Set<Promise<unknown>>(),
@@ -1078,6 +1085,7 @@ describe('durable sync lifecycle chain binding', () => {
       chain,
       store: {},
       subscribedContextGraphs: new Map([[contextGraphId, subscription]]),
+      contextGraphBindingGenerations: new Map(),
       wireIdToLocalCgId: new Map(),
       graphScopedStoreClosed: false,
       graphScopedStorePhysicalRuns: new Set<Promise<unknown>>(),

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -96,6 +96,7 @@ async function captureGraphScopedStore(
     totalTimeoutMs?: number;
     signal?: AbortSignal;
     onAtomicCommitStarted?: (contextGraphId: string, ual: string) => void;
+    onAgentLike?: (agentLike: any) => void;
   } = {},
 ) {
   const agentLike: any = {
@@ -104,8 +105,10 @@ async function captureGraphScopedStore(
     store: {},
     subscribedContextGraphs: new Map(),
     wireIdToLocalCgId: new Map(),
+    graphScopedStoreClosed: false,
+    graphScopedStorePhysicalRuns: new Set<Promise<unknown>>(),
     bindSubscriptionOnChainId: vi.fn(),
-    persistContextGraphSubscriptionState: vi.fn(),
+    persistContextGraphSubscriptionStrict: vi.fn(),
     processDurableBatchInWorker: async () => ({}),
     insertSyncedQuadsAndInvalidateListCache: async () => {},
     syncCheckpoints: new Map(),
@@ -120,6 +123,7 @@ async function captureGraphScopedStore(
   ).requireLocalCgMatchesOnChainSlot;
   agentLike.isWireIdKeyedSubscription = (DKGAgent.prototype as any).isWireIdKeyedSubscription;
   agentLike.raceChainPolicyRead = (DKGAgent.prototype as any).raceChainPolicyRead;
+  options.onAgentLike?.(agentLike);
 
   await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
     agentLike,
@@ -297,7 +301,7 @@ describe('durable sync lifecycle chain binding', () => {
       subscribedContextGraphs: new Map(),
       wireIdToLocalCgId: new Map(),
       bindSubscriptionOnChainId: vi.fn(),
-      persistContextGraphSubscriptionState: vi.fn(),
+      persistContextGraphSubscriptionStrict: vi.fn(),
       processDurableBatchInWorker: async () => ({}),
       insertSyncedQuadsAndInvalidateListCache,
       syncCheckpoints: new Map(),
@@ -335,12 +339,14 @@ describe('durable sync lifecycle chain binding', () => {
     }));
     const agentLike = { runLegacyDurableSyncDetailed };
     const exactUal = 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/1';
+    const controller = new AbortController();
 
     const detailed = await LifecycleSyncMethods.prototype.syncExactKnowledgeAssetsFromPeerDetailed.call(
       agentLike as any,
       '12D3KooWExactRecoveryPeer',
       '0x1111111111111111111111111111111111111111/blackbox',
       [exactUal],
+      { signal: controller.signal },
     );
 
     expect(runLegacyDurableSyncDetailed).toHaveBeenCalledTimes(1);
@@ -353,6 +359,7 @@ describe('durable sync lifecycle chain binding', () => {
       // the whole point of the label. Without this line, deleting it from the
       // call site keeps every test green and only the Grafana attribution rots.
       source: 'vm-recovery',
+      signal: controller.signal,
     });
     expect(runLegacyDurableSyncDetailed.mock.calls[0]?.[6]).not.toHaveProperty('totalTimeoutMs');
     expect(detailed).toEqual({ result: physicalResult, disposition: 'clean-absent' });
@@ -377,6 +384,7 @@ describe('durable sync lifecycle chain binding', () => {
       '12D3KooWExactProjectionPeer',
       contextGraphId,
       requestedAssetUals,
+      {},
     );
     expect(projected).toBe(result);
   });
@@ -657,7 +665,7 @@ describe('durable sync lifecycle chain binding', () => {
         sub.onChainId = onChainId;
       },
     );
-    const persistContextGraphSubscriptionState = vi.fn();
+    const persistContextGraphSubscriptionStrict = vi.fn();
     const onAtomicCommitStarted = vi.fn();
     const agentLike: any = {
       config: {},
@@ -665,8 +673,10 @@ describe('durable sync lifecycle chain binding', () => {
       store: {},
       subscribedContextGraphs: new Map([[contextGraphId, subscription]]),
       wireIdToLocalCgId: new Map(),
+      graphScopedStoreClosed: false,
+      graphScopedStorePhysicalRuns: new Set<Promise<unknown>>(),
       bindSubscriptionOnChainId,
-      persistContextGraphSubscriptionState,
+      persistContextGraphSubscriptionStrict,
       processDurableBatchInWorker: async () => ({}),
       insertSyncedQuadsAndInvalidateListCache: async () => {},
       syncCheckpoints: new Map(),
@@ -725,7 +735,7 @@ describe('durable sync lifecycle chain binding', () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(getContextGraphNameHash).toHaveBeenCalledTimes(1);
       expect(bindSubscriptionOnChainId).not.toHaveBeenCalled();
-      expect(persistContextGraphSubscriptionState).not.toHaveBeenCalled();
+      expect(persistContextGraphSubscriptionStrict).not.toHaveBeenCalled();
       expect(onAtomicCommitStarted).not.toHaveBeenCalled();
       expect(mockedMaterialize).not.toHaveBeenCalled();
       expect(agentLike.invalidateListContextGraphsCache).not.toHaveBeenCalled();
@@ -751,11 +761,16 @@ describe('durable sync lifecycle chain binding', () => {
       '14',
     );
     expect(subscription.onChainId).toBe('14');
-    expect(persistContextGraphSubscriptionState).toHaveBeenCalledWith(contextGraphId);
+    expect(persistContextGraphSubscriptionStrict).toHaveBeenCalledWith(
+      contextGraphId,
+      expect.objectContaining({ onChainId: '14', lastReconciledOrdinal: 0 }),
+      undefined,
+      expect.any(Function),
+    );
     expect(bindSubscriptionOnChainId.mock.invocationCallOrder[0]).toBeLessThan(
       mockedMaterialize.mock.invocationCallOrder[0]!,
     );
-    expect(persistContextGraphSubscriptionState.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(persistContextGraphSubscriptionStrict.mock.invocationCallOrder[0]).toBeLessThan(
       mockedMaterialize.mock.invocationCallOrder[0]!,
     );
     expect(onAtomicCommitStarted.mock.invocationCallOrder[0]).toBeLessThan(
@@ -767,18 +782,79 @@ describe('durable sync lifecycle chain binding', () => {
       unknown
     >;
     expect('verifiedOnChainContextGraphId' in materializedAsset).toBe(false);
+    const shouldQuarantineCommitted = mockedMaterialize.mock.calls[0]![0]
+      .shouldQuarantineCommitted;
+    expect(shouldQuarantineCommitted?.()).toBe(false);
+    subscription.onChainId = undefined;
+    expect(shouldQuarantineCommitted?.()).toBe(true);
+    subscription.onChainId = '14';
+
+    subscription.onChainId = undefined;
+    persistContextGraphSubscriptionStrict.mockRejectedValueOnce(new Error('subscription store unavailable'));
+    const bindsBeforeRejectedSave = bindSubscriptionOnChainId.mock.calls.length;
+    const materializationsBeforeRejectedSave = mockedMaterialize.mock.calls.length;
+    await expect(storeGraphScopedAsset!(
+      graphScopedStoreRequest(asset, Date.now() + 60_000),
+    )).rejects.toThrow('subscription store unavailable');
+    expect(subscription.onChainId).toBeUndefined();
+    expect(bindSubscriptionOnChainId).toHaveBeenCalledTimes(bindsBeforeRejectedSave);
+    expect(mockedMaterialize).toHaveBeenCalledTimes(materializationsBeforeRejectedSave);
   });
 
-  it('does not reuse a binding proof across different on-chain CG slots', async () => {
+  it('does not let a stale strict snapshot overwrite a newer host-only persistence write', async () => {
+    const oldSubscription = { subscribed: true, onChainId: '14' };
+    const hostOnlySubscription = { subscribed: false, coreHosted: true, onChainId: '14' };
+    let durableRecord: Record<string, unknown> | undefined;
+    let releaseHostWrite!: () => void;
+    const hostWriteGate = new Promise<void>((resolve) => { releaseHostWrite = resolve; });
+    let persistChain = Promise.resolve();
+    const enqueueContextGraphSubscriptionPersistWrite = (
+      _contextGraphId: string,
+      write: () => Promise<void>,
+    ) => {
+      const run = persistChain.then(write);
+      persistChain = run.catch(() => undefined);
+      return run;
+    };
+    const agentLike: any = {
+      config: {
+        contextGraphSubscriptionStore: {
+          loadAll: async () => [],
+          save: async (record: Record<string, unknown>) => { durableRecord = { ...record }; },
+          delete: async () => { durableRecord = undefined; },
+        },
+      },
+      subscribedContextGraphs: new Map([[contextGraphId, oldSubscription]]),
+      contextGraphBindingGenerations: new Map(),
+      enqueueContextGraphSubscriptionPersistWrite,
+    };
+
+    const capturedSubscription = oldSubscription;
+    agentLike.subscribedContextGraphs.set(contextGraphId, hostOnlySubscription);
+    const hostWrite = enqueueContextGraphSubscriptionPersistWrite(contextGraphId, async () => {
+      await hostWriteGate;
+      durableRecord = { id: contextGraphId, ...hostOnlySubscription };
+    });
+    const staleStrictWrite = LifecycleSyncMethods.prototype.persistContextGraphSubscriptionStrict.call(
+      agentLike,
+      contextGraphId,
+      { ...capturedSubscription, onChainId: '15', lastReconciledOrdinal: 0 },
+      undefined,
+      () => agentLike.subscribedContextGraphs.get(contextGraphId) === capturedSubscription,
+    );
+
+    releaseHostWrite();
+    await hostWrite;
+    await expect(staleStrictWrite).rejects.toThrow(/changed before.*persisted/);
+    expect(durableRecord).toEqual({ id: contextGraphId, ...hostOnlySubscription });
+  });
+
+  it('does not reuse a proof or roll an authoritative binding across same-name CG slots', async () => {
     const root = new Uint8Array(32);
     root[31] = 2;
     const rootHex = Array.from(root, (byte) => byte.toString(16).padStart(2, '0')).join('');
     const expectedNameHash = ethers.keccak256(ethers.toUtf8Bytes(contextGraphId));
-    const getContextGraphNameHash = vi.fn(async (onChainId: bigint) => (
-      onChainId === 14n
-        ? expectedNameHash
-        : ethers.keccak256(ethers.toUtf8Bytes('different-context-graph'))
-    ));
+    const getContextGraphNameHash = vi.fn(async () => expectedNameHash);
     const kaNumberMask = (1n << 96n) - 1n;
     const chain = {
       chainId: 'otp:2043',
@@ -804,12 +880,14 @@ describe('durable sync lifecycle chain binding', () => {
       store: {},
       subscribedContextGraphs: new Map([[contextGraphId, subscription]]),
       wireIdToLocalCgId: new Map(),
+      graphScopedStoreClosed: false,
+      graphScopedStorePhysicalRuns: new Set<Promise<unknown>>(),
       bindSubscriptionOnChainId: vi.fn(
         (_localId: string, sub: typeof subscription, onChainId: string) => {
           sub.onChainId = onChainId;
         },
       ),
-      persistContextGraphSubscriptionState: vi.fn(),
+      persistContextGraphSubscriptionStrict: vi.fn(),
       processDurableBatchInWorker: async () => ({}),
       insertSyncedQuadsAndInvalidateListCache: async () => {},
       syncCheckpoints: new Map(),
@@ -870,6 +948,9 @@ describe('durable sync lifecycle chain binding', () => {
 
     expect(getContextGraphNameHash).toHaveBeenCalledTimes(2);
     expect(getContextGraphNameHash.mock.calls.map(([id]) => id)).toEqual([14n, 15n]);
+    expect(agentLike.persistContextGraphSubscriptionStrict).toHaveBeenCalledOnce();
+    expect(agentLike.bindSubscriptionOnChainId).toHaveBeenCalledOnce();
+    expect(subscription.onChainId).toBe('14');
     expect(mockedMaterialize).toHaveBeenCalledTimes(1);
   });
 
@@ -925,6 +1006,122 @@ describe('durable sync lifecycle chain binding', () => {
     expect(authenticationSignal?.aborted).toBe(true);
     expect(onAtomicCommitStarted).not.toHaveBeenCalled();
     expect(mockedMaterialize).not.toHaveBeenCalled();
+  });
+
+  it('registers the physical store before invoking a pluggable chain adapter', async () => {
+    const root = new Uint8Array(32);
+    let agentLike: any;
+    let physicalRunsSeenByAdapter = -1;
+    const chain = {
+      chainId: 'otp:2043',
+      getLatestMerkleRoot: async () => {
+        physicalRunsSeenByAdapter = agentLike.graphScopedStorePhysicalRuns.size;
+        return root;
+      },
+      getMerkleRootCount: async () => 2n,
+      getKAContextGraphId: async () => 14n,
+      getContextGraphNameHash: async () => ethers.keccak256(ethers.toUtf8Bytes(contextGraphId)),
+      getLatestMerkleRootPublisher: async () => '0x2222222222222222222222222222222222222222',
+      verifyKAUpdate: async () => ({
+        verified: true,
+        onChainMerkleRoot: root,
+        blockNumber: 123,
+        txIndex: 4,
+        merkleRootCount: 2n,
+      }),
+    } as ChainAdapter;
+    const storeGraphScopedAsset = await captureGraphScopedStore(chain, vi.fn(), {
+      onAgentLike: (captured) => { agentLike = captured; },
+    });
+
+    const pending = storeGraphScopedAsset(graphScopedStoreRequest(
+      graphScopedAsset(root),
+      Date.now() + 120_000,
+    ));
+    expect(agentLike.graphScopedStorePhysicalRuns.size).toBe(1);
+    await expect(pending).resolves.toBe('applied');
+    expect(physicalRunsSeenByAdapter).toBe(1);
+    expect(agentLike.graphScopedStorePhysicalRuns.size).toBe(0);
+  });
+
+  it('rejects an ordinary durable asset when its subscription rebinds during authentication', async () => {
+    const root = new Uint8Array(32);
+    let releaseRoot!: () => void;
+    let markRootReadStarted!: () => void;
+    const rootReadStarted = new Promise<void>((resolve) => { markRootReadStarted = resolve; });
+    const rootGate = new Promise<void>((resolve) => { releaseRoot = resolve; });
+    const chain = {
+      chainId: 'otp:2043',
+      getLatestMerkleRoot: async () => {
+        markRootReadStarted();
+        await rootGate;
+        return root;
+      },
+      getMerkleRootCount: async () => 2n,
+      getKAContextGraphId: async () => 14n,
+      getContextGraphNameHash: async () => ethers.keccak256(ethers.toUtf8Bytes(contextGraphId)),
+      getLatestMerkleRootPublisher: async () => '0x2222222222222222222222222222222222222222',
+      verifyKAUpdate: async () => ({
+        verified: true,
+        onChainMerkleRoot: root,
+        blockNumber: 123,
+        txIndex: 4,
+        merkleRootCount: 2n,
+      }),
+    } as ChainAdapter;
+    const subscription = { subscribed: true, onChainId: '14', lastReconciledOrdinal: 9 };
+    const bindSubscriptionOnChainId = vi.fn();
+    const persistContextGraphSubscriptionStrict = vi.fn();
+    const syncCheckpoints = new Map([['unchanged', 17]]);
+    const agentLike: any = {
+      config: {},
+      chain,
+      store: {},
+      subscribedContextGraphs: new Map([[contextGraphId, subscription]]),
+      wireIdToLocalCgId: new Map(),
+      graphScopedStoreClosed: false,
+      graphScopedStorePhysicalRuns: new Set<Promise<unknown>>(),
+      bindSubscriptionOnChainId,
+      persistContextGraphSubscriptionStrict,
+      processDurableBatchInWorker: async () => ({}),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      syncCheckpoints,
+      oversizeTombstoneLog: { record: () => {} },
+      invalidateListContextGraphsCache: vi.fn(),
+      contextGraphMetaProjection: { markDirtyFromQuads: vi.fn() },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+    agentLike.localCgMatchesOnChainSlot = (DKGAgent.prototype as any).localCgMatchesOnChainSlot;
+    agentLike.requireLocalCgMatchesOnChainSlot = (
+      DKGAgent.prototype as any
+    ).requireLocalCgMatchesOnChainSlot;
+    agentLike.isWireIdKeyedSubscription = (DKGAgent.prototype as any).isWireIdKeyedSubscription;
+    agentLike.raceChainPolicyRead = (DKGAgent.prototype as any).raceChainPolicyRead;
+    await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
+      agentLike,
+      ctx,
+      'peer-stale-exact',
+      contextGraphId,
+      1,
+    );
+    const storeGraphScopedAsset = mockedRunDurableSync.mock.calls[0]![0]
+      .storeGraphScopedAsset!;
+    const pending = storeGraphScopedAsset(graphScopedStoreRequest(
+      graphScopedAsset(root),
+      Date.now() + 120_000,
+    ));
+    await rootReadStarted;
+    const reboundSubscription = { subscribed: true, onChainId: '15', lastReconciledOrdinal: 0 };
+    agentLike.subscribedContextGraphs.set(contextGraphId, reboundSubscription);
+    releaseRoot();
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(bindSubscriptionOnChainId).not.toHaveBeenCalled();
+    expect(persistContextGraphSubscriptionStrict).not.toHaveBeenCalled();
+    expect(mockedMaterialize).not.toHaveBeenCalled();
+    expect(syncCheckpoints).toEqual(new Map([['unchanged', 17]]));
+    expect(subscription).toEqual({ subscribed: true, onChainId: '14', lastReconciledOrdinal: 9 });
+    expect(agentLike.subscribedContextGraphs.get(contextGraphId)).toBe(reboundSubscription);
   });
 
   it('cancels and retries a hung root read within the graph deadline', async () => {

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -1585,24 +1585,25 @@ describe('rootless graph-scoped KA lifecycle', () => {
   // assertion below (the CG would already be on-chain after the share).
   it('seals a FULL share on an UNregistered CG (no seal-time registration); registers + publishes at publish time', async () => {
     const agent = await createAgent('UnregisteredCgSealBot');
+    const unregisteredCgId = `${CG_ID}-full-share-deferred-registration`;
     // LOCAL-ONLY CG: created but DELIBERATELY never registered on-chain.
-    await agent.createContextGraph({ id: CG_ID, name: 'Unregistered CG Seal E2E' });
+    await agent.createContextGraph({ id: unregisteredCgId, name: 'Unregistered CG Seal E2E' });
 
     const name = 'unregistered-cg-seal';
-    await agent.assertion.create(CG_ID, name);
-    await agent.assertion.write(CG_ID, name, [
+    await agent.assertion.create(unregisteredCgId, name);
+    await agent.assertion.write(unregisteredCgId, name, [
       { subject: `${ENTITY_BASE}:ucs`, predicate: 'http://schema.org/name', object: '"Unregistered CG Seal"' },
     ]);
 
     // Default FULL share — must SEAL despite the CG being unregistered (the seal
     // no longer depends on CG registration).
-    const fullShare = await agent.assertion.promote(CG_ID, name);
+    const fullShare = await agent.assertion.promote(unregisteredCgId, name);
     expect(fullShare.sealed).toBe(true);
     expect(fullShare.publishReady).toBe(true);
 
     // CORE ASSERTION: the CG is STILL unregistered after sealing — sealing did
     // NOT register it on-chain. Reintroducing seal-time registration breaks here.
-    const onChainIdAfterSeal = await agent.getContextGraphOnChainId(CG_ID);
+    const onChainIdAfterSeal = await agent.getContextGraphOnChainId(unregisteredCgId);
     expect(onChainIdAfterSeal == null).toBe(true);
 
     // And publishing the unregistered CG fails CLOSED for that exact reason —
@@ -1612,7 +1613,7 @@ describe('rootless graph-scoped KA lifecycle', () => {
     // .code convention for SWM_SUBSET_NOT_SEALABLE / UNSEALED_SHARE_BLOCKED).
     let notRegisteredErr: any;
     try {
-      await agent.publishFromFinalizedAssertion(CG_ID, name);
+      await agent.publishFromFinalizedAssertion(unregisteredCgId, name);
     } catch (e) {
       notRegisteredErr = e;
     }
@@ -1623,11 +1624,11 @@ describe('rootless graph-scoped KA lifecycle', () => {
     // Registration happens at PUBLISH time (the /vm/publish route's
     // ensureRegisteredForPublish step). After it, the same sealed asset publishes
     // to VM and confirms — no re-seal, no recreate.
-    await agent.ensureRegisteredForPublish(CG_ID);
-    const onChainIdAfterRegister = await agent.getContextGraphOnChainId(CG_ID);
+    await agent.ensureRegisteredForPublish(unregisteredCgId);
+    const onChainIdAfterRegister = await agent.getContextGraphOnChainId(unregisteredCgId);
     expect(onChainIdAfterRegister).toBeTruthy();
 
-    const pub = await agent.publishFromFinalizedAssertion(CG_ID, name);
+    const pub = await agent.publishFromFinalizedAssertion(unregisteredCgId, name);
     expect(pub.status).toBe('confirmed');
     expect(pub.ual).toBeDefined();
     expect(pub.seal).toBeDefined();

--- a/packages/agent/test/exact-assets.test.ts
+++ b/packages/agent/test/exact-assets.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   MAX_EXACT_SYNC_ASSETS,
+  MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+  MAX_EXACT_SYNC_PHASE_QUADS_PER_ASSET,
   decodeExactAssetUals,
   encodeExactAssetUals,
   exactAssetFilterKey,
+  exactSyncPhaseAccumulationLimits,
   normalizeExactAssetUals,
 } from '../src/sync/exact-assets.js';
 
@@ -25,5 +28,12 @@ describe('exact VM sync asset filter', () => {
       { length: MAX_EXACT_SYNC_ASSETS + 1 },
       (_, index) => ual(index),
     ))).toEqual([]);
+  });
+
+  it('scales exact phase limits by the canonical asset count', () => {
+    expect(exactSyncPhaseAccumulationLimits([ual(2), ual(1), ual(2)])).toEqual({
+      maxBytes: 2 * MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+      maxQuads: 2 * MAX_EXACT_SYNC_PHASE_QUADS_PER_ASSET,
+    });
   });
 });

--- a/packages/agent/test/exact-assets.test.ts
+++ b/packages/agent/test/exact-assets.test.ts
@@ -3,6 +3,7 @@ import {
   MAX_EXACT_SYNC_ASSETS,
   decodeExactAssetUals,
   encodeExactAssetUals,
+  exactAssetFilterKey,
   normalizeExactAssetUals,
 } from '../src/sync/exact-assets.js';
 
@@ -11,9 +12,11 @@ const ual = (number: number) =>
 
 describe('exact VM sync asset filter', () => {
   it('canonicalizes, deduplicates, and round-trips a bounded KA batch', () => {
-    const normalized = normalizeExactAssetUals([ual(1), ual(1), ual(2)]);
+    const normalized = normalizeExactAssetUals([ual(2), ual(1), ual(2)]);
     expect(normalized).toEqual([ual(1), ual(2)]);
-    expect(decodeExactAssetUals(encodeExactAssetUals(normalized!))).toEqual(normalized);
+    expect(decodeExactAssetUals(encodeExactAssetUals([ual(2), ual(1)]))).toEqual(normalized);
+    expect(exactAssetFilterKey([ual(2), ual(1)]))
+      .toBe(exactAssetFilterKey([ual(1), ual(2)]));
   });
 
   it('fails closed for malformed or oversized present filters', () => {

--- a/packages/agent/test/outbox-shutdown-lifecycle.test.ts
+++ b/packages/agent/test/outbox-shutdown-lifecycle.test.ts
@@ -3,9 +3,60 @@ import { DKGAgent } from '../src/dkg-agent.js';
 import { DKGAgentBase } from '../src/dkg-agent-base.js';
 import { VmReconcileDispatcher } from '../src/chain-reconciler.js';
 import { FinalizationRuntime } from '../src/finalization-runtime.js';
-import { VmReconcileQueueClosedError } from '../src/vm-reconcile-service.js';
+import {
+  ContextGraphMembershipPersistScheduler,
+  ContextGraphMembershipPersistShutdownTimeoutError,
+} from '../src/context-graph-membership-persist-scheduler.js';
+import {
+  VmReconcileQueueClosedError,
+  VmReconcileShutdownTimeoutError,
+} from '../src/vm-reconcile-service.js';
 
 describe('DKGAgent outbox shutdown lifecycle', () => {
+  it('closes and drains membership persistence before network and store teardown', async () => {
+    const membershipPersistence = new ContextGraphMembershipPersistScheduler();
+    let releaseWrite!: () => void;
+    let markWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => { markWriteStarted = resolve; });
+    const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    const write = membershipPersistence.enqueue('cg\0node\0peer', async () => {
+      markWriteStarted();
+      await writeGate;
+    });
+    await writeStarted;
+    const closeStore = vi.fn(async () => {});
+    const stopNode = vi.fn(async () => {});
+    const agent = Object.create(DKGAgent.prototype) as any;
+    Object.assign(agent, {
+      started: true,
+      chainPoller: null,
+      contextGraphMembershipPersistence: membershipPersistence,
+      coreHostRecordingsClosed: false,
+      drainCoreHostRecordings: vi.fn(async () => {}),
+      messenger: { stopOutboxDrain: vi.fn(async () => {}) },
+      clearRandomSamplingBindRetry: vi.fn(),
+      clearStorageACKRegistrationRetry: vi.fn(),
+      storageACKRegistrationRetryInFlight: false,
+      randomSamplingHandle: null,
+      inFlightSubstrateFanOutCount: () => 0,
+      router: { closePooling: vi.fn(async () => {}) },
+      node: { stop: stopNode },
+      finalizationRuntime: new FinalizationRuntime(),
+      store: { close: closeStore },
+      log: { warn: vi.fn() },
+    });
+
+    const stopping = agent.stop();
+    await Promise.resolve();
+    expect(stopNode).not.toHaveBeenCalled();
+    expect(closeStore).not.toHaveBeenCalled();
+
+    releaseWrite();
+    await Promise.all([write, stopping]);
+    expect(stopNode).toHaveBeenCalledOnce();
+    expect(closeStore).toHaveBeenCalledOnce();
+  });
+
   it('closes reconcile admission and cancels queued jobs before store teardown', async () => {
     let releaseActive!: () => void;
     let queuedStarted = false;
@@ -23,7 +74,11 @@ describe('DKGAgent outbox shutdown lifecycle', () => {
     const agent = Object.create(DKGAgent.prototype) as any;
     Object.assign(agent, {
       started: true,
-      chainPoller: null,
+      chainPoller: {
+        stop: vi.fn(async () => {
+          expect(agent.vmReconcileRotationClosed).toBe(true);
+        }),
+      },
       vmReconcileDispatcher: dispatcher,
       coreHostRecordingsClosed: false,
       drainCoreHostRecordings: vi.fn(async () => {}),
@@ -55,15 +110,17 @@ describe('DKGAgent outbox shutdown lifecycle', () => {
     expect(closeStore).toHaveBeenCalledOnce();
   });
 
-  it('continues shutdown after the bounded reconcile drain timeout', async () => {
+  it('quarantines the instance after the bounded reconcile drain timeout', async () => {
     const originalTimeout = DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS;
     Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS', {
       configurable: true,
       value: 1,
     });
     try {
+      let release!: () => void;
+      const activeGate = new Promise<void>((resolve) => { release = resolve; });
       const dispatcher = new VmReconcileDispatcher(
-        async () => new Promise<void>(() => undefined),
+        async () => activeGate,
         () => undefined,
       );
       void dispatcher.triggerManual('stuck');
@@ -87,20 +144,232 @@ describe('DKGAgent outbox shutdown lifecycle', () => {
         inFlightSubstrateFanOutCount: () => 0,
         router: { closePooling: vi.fn(async () => {}) },
         node: { stop: stopNode },
+        chain: { chainId: 'none' },
         finalizationRuntime: new FinalizationRuntime(),
         store: { close: closeStore },
         log: { warn },
       });
 
-      await expect(agent.stop()).resolves.toBeUndefined();
+      await expect(agent.stop()).rejects.toBeInstanceOf(VmReconcileShutdownTimeoutError);
 
-      expect(stopNode).toHaveBeenCalledOnce();
-      expect(closeStore).toHaveBeenCalledOnce();
+      expect(stopNode).not.toHaveBeenCalled();
+      expect(closeStore).not.toHaveBeenCalled();
       expect(warn).toHaveBeenCalledWith(
         expect.anything(),
-        expect.stringContaining('1 VM reconcile job(s) still active after 1ms drain bound'),
+        expect.stringContaining('store/network teardown is blocked until stop() is retried'),
       );
+
+      // Even after physical retirement, start remains blocked until a second
+      // stop finishes the deliberately incomplete teardown.
+      await expect(agent.start()).rejects.toBeInstanceOf(VmReconcileShutdownTimeoutError);
+
+      release();
+      await agent.vmReconcileRetirement;
+      await expect(agent.start()).rejects.toBeInstanceOf(VmReconcileShutdownTimeoutError);
+      await expect(agent.stop()).resolves.toBeUndefined();
+      expect(stopNode).toHaveBeenCalledOnce();
+      expect(closeStore).toHaveBeenCalledOnce();
+      expect(agent.started).toBe(false);
     } finally {
+      Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS', {
+        configurable: true,
+        value: originalTimeout,
+      });
+    }
+  });
+
+  it('quarantines start and backing-store teardown after membership persistence times out', async () => {
+    const originalTimeout = DKGAgentBase.CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_MS;
+    Object.defineProperty(DKGAgentBase, 'CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_MS', {
+      configurable: true,
+      value: 1,
+    });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const membershipPersistence = new ContextGraphMembershipPersistScheduler();
+    void membershipPersistence.enqueue('stuck', async () => gate);
+    await Promise.resolve();
+    const closeStore = vi.fn(async () => {});
+    const stopNode = vi.fn(async () => {});
+    const agent = Object.create(DKGAgent.prototype) as any;
+    Object.assign(agent, {
+      started: true,
+      chainPoller: null,
+      contextGraphMembershipPersistence: membershipPersistence,
+      coreHostRecordingsClosed: false,
+      drainCoreHostRecordings: vi.fn(async () => {}),
+      messenger: { stopOutboxDrain: vi.fn(async () => {}) },
+      clearRandomSamplingBindRetry: vi.fn(),
+      clearStorageACKRegistrationRetry: vi.fn(),
+      storageACKRegistrationRetryInFlight: false,
+      randomSamplingHandle: null,
+      inFlightSubstrateFanOutCount: () => 0,
+      router: { closePooling: vi.fn(async () => {}) },
+      node: { stop: stopNode },
+      chain: { chainId: 'none' },
+      finalizationRuntime: new FinalizationRuntime(),
+      store: { close: closeStore },
+      log: { warn: vi.fn() },
+    });
+
+    try {
+      await expect(agent.stop()).rejects.toBeInstanceOf(
+        ContextGraphMembershipPersistShutdownTimeoutError,
+      );
+      expect(stopNode).not.toHaveBeenCalled();
+      expect(closeStore).not.toHaveBeenCalled();
+      await expect(agent.start()).rejects.toBeInstanceOf(
+        ContextGraphMembershipPersistShutdownTimeoutError,
+      );
+
+      release();
+      await membershipPersistence.closeAndDrain();
+      await expect(agent.start()).rejects.toBeInstanceOf(
+        ContextGraphMembershipPersistShutdownTimeoutError,
+      );
+      await expect(agent.stop()).resolves.toBeUndefined();
+      expect(stopNode).toHaveBeenCalledOnce();
+      expect(closeStore).toHaveBeenCalledOnce();
+      expect(agent.started).toBe(false);
+    } finally {
+      release();
+      Object.defineProperty(DKGAgentBase, 'CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_MS', {
+        configurable: true,
+        value: originalTimeout,
+      });
+    }
+  });
+
+  it('drains physically active VM reconciliation before closing the store', async () => {
+    const originalTimeout = DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS', {
+      configurable: true,
+      value: 1,
+    });
+    let release!: () => void;
+    const physical = new Promise<void>((resolve) => { release = resolve; });
+    const closeStore = vi.fn(async () => {});
+    const stopNode = vi.fn(async () => {});
+    const agent = Object.create(DKGAgent.prototype) as any;
+    Object.assign(agent, {
+      started: true,
+      chainPoller: null,
+      vmReconcilePhysicalRuns: new Set([physical]),
+      coreHostRecordingsClosed: false,
+      drainCoreHostRecordings: vi.fn(async () => {}),
+      messenger: { stopOutboxDrain: vi.fn(async () => {}) },
+      clearRandomSamplingBindRetry: vi.fn(),
+      clearStorageACKRegistrationRetry: vi.fn(),
+      storageACKRegistrationRetryInFlight: false,
+      randomSamplingHandle: null,
+      inFlightSubstrateFanOutCount: () => 0,
+      router: { closePooling: vi.fn(async () => {}) },
+      node: { stop: stopNode },
+      finalizationRuntime: new FinalizationRuntime(),
+      store: { close: closeStore },
+      log: { warn: vi.fn() },
+    });
+
+    try {
+      await expect(agent.stop()).rejects.toBeInstanceOf(VmReconcileShutdownTimeoutError);
+      expect(stopNode).not.toHaveBeenCalled();
+      expect(closeStore).not.toHaveBeenCalled();
+
+      release();
+      await agent.vmReconcileRetirement;
+      await agent.stop();
+      expect(stopNode).toHaveBeenCalledOnce();
+      expect(closeStore).toHaveBeenCalledOnce();
+    } finally {
+      release();
+      Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS', {
+        configurable: true,
+        value: originalTimeout,
+      });
+    }
+  });
+
+  it('drains an entered ordinary graph-scoped commit before closing the store', async () => {
+    let release!: () => void;
+    const physicalCommit = new Promise<void>((resolve) => { release = resolve; });
+    const closeStore = vi.fn(async () => {});
+    const stopNode = vi.fn(async () => {});
+    const agent = Object.create(DKGAgent.prototype) as any;
+    Object.assign(agent, {
+      started: true,
+      chainPoller: null,
+      graphScopedStorePhysicalRuns: new Set([physicalCommit]),
+      coreHostRecordingsClosed: false,
+      drainCoreHostRecordings: vi.fn(async () => {}),
+      messenger: { stopOutboxDrain: vi.fn(async () => {}) },
+      clearRandomSamplingBindRetry: vi.fn(),
+      clearStorageACKRegistrationRetry: vi.fn(),
+      storageACKRegistrationRetryInFlight: false,
+      randomSamplingHandle: null,
+      inFlightSubstrateFanOutCount: () => 0,
+      router: { closePooling: vi.fn(async () => {}) },
+      node: { stop: stopNode },
+      finalizationRuntime: new FinalizationRuntime(),
+      store: { close: closeStore },
+      log: { warn: vi.fn() },
+    });
+
+    const stopping = agent.stop();
+    await Promise.resolve();
+    expect(stopNode).not.toHaveBeenCalled();
+    expect(closeStore).not.toHaveBeenCalled();
+
+    release();
+    await stopping;
+    expect(stopNode).toHaveBeenCalledOnce();
+    expect(closeStore).toHaveBeenCalledOnce();
+  });
+
+  it('bounds chain-poller retirement before network and store teardown', async () => {
+    const originalTimeout = DKGAgentBase.VM_RECONCILE_SHUTDOWN_TIMEOUT_MS;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS', {
+      configurable: true,
+      value: 1,
+    });
+    let release!: () => void;
+    const pollerDrain = new Promise<void>((resolve) => { release = resolve; });
+    const chainPoller = { stop: vi.fn(() => pollerDrain) };
+    const closeStore = vi.fn(async () => {});
+    const stopNode = vi.fn(async () => {});
+    const agent = Object.create(DKGAgent.prototype) as any;
+    Object.assign(agent, {
+      started: true,
+      chainPoller,
+      coreHostRecordingsClosed: false,
+      drainCoreHostRecordings: vi.fn(async () => {}),
+      messenger: { stopOutboxDrain: vi.fn(async () => {}) },
+      clearRandomSamplingBindRetry: vi.fn(),
+      clearStorageACKRegistrationRetry: vi.fn(),
+      storageACKRegistrationRetryInFlight: false,
+      randomSamplingHandle: null,
+      inFlightSubstrateFanOutCount: () => 0,
+      router: { closePooling: vi.fn(async () => {}) },
+      node: { stop: stopNode },
+      finalizationRuntime: new FinalizationRuntime(),
+      store: { close: closeStore },
+      log: { warn: vi.fn() },
+    });
+
+    try {
+      await expect(agent.stop()).rejects.toBeInstanceOf(VmReconcileShutdownTimeoutError);
+      expect(chainPoller.stop).toHaveBeenCalledOnce();
+      expect(agent.chainPoller).toBe(chainPoller);
+      expect(stopNode).not.toHaveBeenCalled();
+      expect(closeStore).not.toHaveBeenCalled();
+
+      release();
+      await agent.vmReconcileRetirement;
+      expect(agent.chainPoller).toBeNull();
+      await agent.stop();
+      expect(stopNode).toHaveBeenCalledOnce();
+      expect(closeStore).toHaveBeenCalledOnce();
+    } finally {
+      release();
       Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS', {
         configurable: true,
         value: originalTimeout,

--- a/packages/agent/test/p2p-peer-connect.test.ts
+++ b/packages/agent/test/p2p-peer-connect.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { parseMultiaddrConnectTarget } from '../src/p2p/multiaddr-peer-target.js';
-import { connectToMultiaddr, primeCatchupConnections } from '../src/p2p/peer-connect.js';
+import {
+  connectToMultiaddr,
+  ensurePeerConnected,
+  primeCatchupConnections,
+} from '../src/p2p/peer-connect.js';
+import { waitForPeerProtocol } from '../src/p2p/protocol-readiness.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -126,5 +131,64 @@ describe('primeCatchupConnections', () => {
     expect(merge.calls).toHaveLength(2);
     expect(dial.calls).toHaveLength(2);
     expect(admissionCalls).toEqual([foreignPeer, eligiblePeer]);
+  });
+});
+
+describe('abortable recovery connection helpers', () => {
+  it('forwards cancellation to the real direct-dial path', async () => {
+    const peerId = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+    const controller = new AbortController();
+    let observedSignal: AbortSignal | undefined;
+    const dialStarted = Promise.withResolvers<void>();
+    const dial = (_peer: unknown, options?: { signal?: AbortSignal }) => {
+      observedSignal = options?.signal;
+      dialStarted.resolve();
+      return new Promise<never>((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('dial aborted', 'AbortError'));
+        }, { once: true });
+      });
+    };
+    let discoveryCalled = false;
+
+    const connection = ensurePeerConnected({
+      getConnections: () => [],
+      dial,
+      peerStore: { merge: async () => undefined },
+    }, {
+      findAgentByPeerId: async () => {
+        discoveryCalled = true;
+        return undefined;
+      },
+    } as any, peerId, { signal: controller.signal });
+
+    await dialStarted.promise;
+    controller.abort();
+    await expect(connection).rejects.toMatchObject({ name: 'AbortError' });
+    expect(observedSignal).toBe(controller.signal);
+    expect(discoveryCalled).toBe(false);
+  });
+
+  it('interrupts the real protocol-readiness delay', async () => {
+    const controller = new AbortController();
+    let reads = 0;
+    const readiness = waitForPeerProtocol(
+      {
+        get: async () => {
+          reads += 1;
+          return { protocols: [] };
+        },
+      },
+      { toString: () => 'peer-under-test' },
+      '/dkg/test/sync',
+      3,
+      10_000,
+      controller.signal,
+    );
+
+    await Promise.resolve();
+    controller.abort();
+    await expect(readiness).rejects.toMatchObject({ name: 'AbortError' });
+    expect(reads).toBe(1);
   });
 });

--- a/packages/agent/test/p2p-peer-connect.test.ts
+++ b/packages/agent/test/p2p-peer-connect.test.ts
@@ -169,6 +169,59 @@ describe('abortable recovery connection helpers', () => {
     expect(discoveryCalled).toBe(false);
   });
 
+  it('forwards cancellation through discovery after direct dial fails', async () => {
+    const peerId = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+    const controller = new AbortController();
+    const discoveryStarted = Promise.withResolvers<void>();
+    let observedSignal: AbortSignal | undefined;
+
+    const connection = ensurePeerConnected({
+      getConnections: () => [],
+      dial: async () => { throw new Error('direct dial failed'); },
+      peerStore: { merge: async () => undefined },
+    }, {
+      findAgentByPeerId: async (_peerId: string, options?: { signal?: AbortSignal }) => {
+        observedSignal = options?.signal;
+        discoveryStarted.resolve();
+        return new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('discovery aborted', 'AbortError'));
+          }, { once: true });
+        });
+      },
+    } as any, peerId, { signal: controller.signal });
+
+    await discoveryStarted.promise;
+    controller.abort();
+    await expect(connection).rejects.toMatchObject({ name: 'AbortError' });
+    expect(observedSignal).toBe(controller.signal);
+  });
+
+  it('forwards cancellation to the relay fallback dial', async () => {
+    const peerId = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+    const relayAddress = '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+    const dialSignals: Array<AbortSignal | undefined> = [];
+    const merge = recorder(async () => undefined);
+    let dialAttempt = 0;
+    const dial = async (_peer: unknown, options?: { signal?: AbortSignal }) => {
+      dialSignals.push(options?.signal);
+      dialAttempt += 1;
+      if (dialAttempt === 1) throw new Error('direct dial failed');
+    };
+
+    const controller = new AbortController();
+    await ensurePeerConnected({
+      getConnections: () => [],
+      dial,
+      peerStore: { merge },
+    }, {
+      findAgentByPeerId: async () => ({ peerId, relayAddress }),
+    } as any, peerId, { signal: controller.signal });
+
+    expect(dialSignals).toEqual([controller.signal, controller.signal]);
+    expect(merge.calls).toHaveLength(1);
+  });
+
   it('interrupts the real protocol-readiness delay', async () => {
     const controller = new AbortController();
     let reads = 0;

--- a/packages/agent/test/private-cg-membership-bootstrap.test.ts
+++ b/packages/agent/test/private-cg-membership-bootstrap.test.ts
@@ -1581,5 +1581,67 @@ describe('private CG membership bootstrap recovery', () => {
       .get(member.address.toLowerCase())).toEqual([newPeerId]);
     expect((await agent.getContextGraphAllowedDelegateeKeys(contextGraphId))
       .get(member.address.toLowerCase())).toEqual([newOpKey.toLowerCase()]);
+    });
+  it('keeps join-approval snapshot and compensation inside the per-CG write lanes', async () => {
+    ({ agent } = await createAgent('PrivateBootstrapSerializedCompensation'));
+    const contextGraphId = 'private-bootstrap-serialized-compensation';
+    const approvedAddress = agent.getDefaultAgentAddress()!;
+    const subscriptionRows = new Map<string, any>();
+    const membershipRows = new Map<string, any>();
+    let signalFirstSave!: () => void;
+    let releaseFirstSave!: () => void;
+    const firstSaveStarted = new Promise<void>((resolve) => { signalFirstSave = resolve; });
+    const firstSaveGate = new Promise<void>((resolve) => { releaseFirstSave = resolve; });
+    let saveCount = 0;
+    (agent as any).config.contextGraphSubscriptionStore = {
+      load: async (id: string) => subscriptionRows.get(id) ?? null,
+      loadAll: async () => [...subscriptionRows.values()],
+      save: async (record: any) => {
+        saveCount += 1;
+        if (saveCount === 1) {
+          signalFirstSave();
+          await firstSaveGate;
+        }
+        subscriptionRows.set(record.id, { ...record });
+        if (record.name === 'approval-B') throw new Error('approval B save failed after write');
+      },
+      delete: async (id: string) => { subscriptionRows.delete(id); },
+    };
+    const membershipKey = (record: any) =>
+      `${record.contextGraphId}:${record.principalType}:${record.principalId.toLowerCase()}`;
+    (agent as any).config.contextGraphMembershipStore = {
+      loadAll: async () => [...membershipRows.values()],
+      upsert: async (record: any) => { membershipRows.set(membershipKey(record), { ...record }); },
+      delete: async (cgId: string, principalType: string, principalId: string) => {
+        membershipRows.delete(`${cgId}:${principalType}:${principalId.toLowerCase()}`);
+      },
+    };
+
+    const subscriptionA = { subscribed: true, name: 'ordinary-A' };
+    (agent as any).subscribedContextGraphs.set(contextGraphId, subscriptionA);
+    const saveA = (agent as any).persistContextGraphSubscription(contextGraphId);
+    await firstSaveStarted;
+
+    const subscriptionC = { subscribed: true, name: 'ordinary-C' };
+    (agent as any).subscribedContextGraphs.set(contextGraphId, subscriptionC);
+    const saveC = (agent as any).persistContextGraphSubscription(contextGraphId);
+    const approvalB = (agent as any).persistJoinApprovalStateStrict(
+      contextGraphId,
+      {
+        contextGraphId,
+        principalType: 'agent',
+        principalId: approvedAddress,
+        role: 'participant',
+        status: 'active',
+        source: 'join-approved',
+      },
+      { subscribed: true, name: 'approval-B' },
+    );
+    releaseFirstSave();
+
+    await expect(Promise.all([saveA, saveC])).resolves.toEqual([undefined, undefined]);
+    await expect(approvalB).rejects.toThrow('approval B save failed after write');
+    expect(subscriptionRows.get(contextGraphId)).toMatchObject({ name: 'ordinary-C' });
+    expect(membershipRows.size).toBe(0);
   });
 });

--- a/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
@@ -15,6 +15,7 @@ import { ethers } from 'ethers';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DKGAgent } from '../src/dkg-agent.js';
+import { ContextGraphMembershipPersistScheduler } from '../src/context-graph-membership-persist-scheduler.js';
 import { FinalizationRuntime } from '../src/finalization-runtime.js';
 import {
   INVENTORY_V1_RELATIVE_PATH,
@@ -49,6 +50,7 @@ function syntheticAgent(dataDirectory?: string): any {
   const agent = Object.create(DKGAgent.prototype) as any;
   Object.assign(agent, {
     config: dataDirectory === undefined ? {} : { dataDir: dataDirectory },
+    contextGraphMembershipPersistence: new ContextGraphMembershipPersistScheduler(),
     finalizationRuntime: new FinalizationRuntime(),
     rfc64PersistenceV1: undefined,
   });

--- a/packages/agent/test/rs-heal-stranded-kc.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc.test.ts
@@ -233,6 +233,7 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
         lastReconciledOrdinal: 0,
       },
     ]]);
+    agentLike.contextGraphBindingGenerations = new Map();
     agentLike.reconcileCursors = new Map();
     agentLike.vmReconcilePhysicalRuns = new Set();
     agentLike.vmReconcileDispatcher = {

--- a/packages/agent/test/rs-heal-stranded-kc.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc.test.ts
@@ -234,6 +234,7 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
       },
     ]]);
     agentLike.reconcileCursors = new Map();
+    agentLike.vmReconcilePhysicalRuns = new Set();
     agentLike.vmReconcileDispatcher = {
       dispatch: async <T>(_key: string, source: string): Promise<T> => {
         priorities.push(source === 'periodic' ? 'background' : 'foreground');
@@ -289,7 +290,8 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
     const countAfterFirst = await scopedTripleCount(store, TEST_CG, TEST_ONCHAIN);
     expect(countAfterFirst).toBeGreaterThan(0);
 
-    // Second run: the ASK-guard short-circuits (scoped now has batchId), so the
+    // Second run: the ASK-guard short-circuits (scoped now has batchId plus a
+    // materialization version), so the
     // scoped triple count is UNCHANGED — no re-copy, no duplication, no throw.
     await runHeal(store, TEST_CG, TEST_ONCHAIN);
     const countAfterSecond = await scopedTripleCount(store, TEST_CG, TEST_ONCHAIN);
@@ -333,10 +335,80 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
     const nsScopedMeta = contextGraphMetaUri(NS_CG, NS_ONCHAIN);
     expect(await readMaterializedVersion(store, nsScopedMeta, NS_UAL)).toEqual({ blockNumber: 0, txIndex: 0 });
 
-    // Idempotent: a second run is a no-op (ASK-guard short-circuits on the now-present batchId).
+    // Idempotent: a second run is a no-op once both completion markers exist.
     const c1 = await scopedTripleCount(store, NS_CG, NS_ONCHAIN);
     await runHeal(store, NS_CG, NS_ONCHAIN);
     expect(await scopedTripleCount(store, NS_CG, NS_ONCHAIN)).toBe(c1);
+  });
+
+  it('repairs scoped metadata that has a batchId but no completion version', async () => {
+    const cg = 'partial-meta-cg';
+    const onChainId = '23';
+    const ual = 'did:dkg:hardhat:31337/0xpartial/42';
+    await seedOntology(store, cg, onChainId);
+    await store.insert([
+      ...metaQuads(ual, contextGraphMetaUri(cg)),
+      ...publicTriples().map((triple) => ({ ...triple, graph: contextGraphDataUri(cg) })),
+      // Simulate the old crash window: metadata including batchId committed,
+      // but the separate materializedVersion write never did.
+      ...metaQuads(ual, contextGraphMetaUri(cg, onChainId)),
+    ]);
+    expect(await readMaterializedVersion(store, contextGraphMetaUri(cg, onChainId), ual)).toBeNull();
+
+    await runHeal(store, cg, onChainId);
+
+    expect(await readMaterializedVersion(store, contextGraphMetaUri(cg, onChainId), ual))
+      .toEqual({ blockNumber: 0, txIndex: 0 });
+    await expect(extractV10KCFromStore(store, BigInt(onChainId), KA_ID)).resolves.toBeTruthy();
+  });
+
+  it('retries after a non-transactional endpoint partially copies metadata', async () => {
+    const cg = 'atomic-meta-retry-cg';
+    const onChainId = '29';
+    const ual = 'did:dkg:hardhat:31337/0xatomicretry/42';
+    await seedOntology(store, cg, onChainId);
+    await store.insert([
+      ...metaQuads(ual, contextGraphMetaUri(cg)),
+      ...publicTriples().map((triple) => ({ ...triple, graph: contextGraphDataUri(cg) })),
+    ]);
+
+    const originalUpdate = store.update.bind(store);
+    const scopedMeta = contextGraphMetaUri(cg, onChainId);
+    let failMetadataCopyOnce = true;
+    store.update = async (sparql, options) => {
+      if (
+        failMetadataCopyOnce
+        && sparql.includes(`FILTER(?p != <${DKG}materializedVersion>)`)
+      ) {
+        failMetadataCopyOnce = false;
+        await originalUpdate(sparql, options);
+        // Model a non-transactional endpoint that applied only part of the
+        // metadata INSERT before reporting failure. Completion must remain
+        // unstamped so the next sweep repairs the missing child row.
+        await originalUpdate(
+          `DELETE WHERE {
+             GRAPH <${scopedMeta}> {
+               <${ual}/1> <${RDF}type> ?type
+             }
+           }`,
+          options,
+        );
+        throw new Error('injected partial metadata copy failure');
+      }
+      return originalUpdate(sparql, options);
+    };
+
+    await runHeal(store, cg, onChainId);
+    expect(await readMaterializedVersion(store, scopedMeta, ual)).toBeNull();
+    const missingChild = await store.query(
+      `ASK { GRAPH <${scopedMeta}> { <${ual}/1> <${RDF}type> ?type } }`,
+    );
+    expect(missingChild.type === 'boolean' && missingChild.value).toBe(false);
+
+    await runHeal(store, cg, onChainId);
+    expect(await readMaterializedVersion(store, scopedMeta, ual))
+      .toEqual({ blockNumber: 0, txIndex: 0 });
+    await expect(extractV10KCFromStore(store, BigInt(onChainId), KA_ID)).resolves.toBeTruthy();
   });
 
   it('relocates a publisher one-shot strand whose public data is in the VM graph only (read-both)', async () => {

--- a/packages/agent/test/swm-curator-recovery-plan.test.ts
+++ b/packages/agent/test/swm-curator-recovery-plan.test.ts
@@ -108,6 +108,92 @@ describe('private SWM curator recovery planning', () => {
     });
   });
 
+  it('stops structural curator discovery when its recovery target becomes stale', async () => {
+    const curator = ethers.Wallet.createRandom().address.toLowerCase();
+    const contextGraphId = `${curator}/stale-curator-plan`;
+    const agent = await createAgent('CuratorRecoveryStaleTarget');
+    const internals = agent as any;
+    internals.localAgents.clear();
+    let releaseLookup!: () => void;
+    let markLookupStarted!: () => void;
+    const lookupStarted = new Promise<void>((resolve) => { markLookupStarted = resolve; });
+    const lookupGate = new Promise<void>((resolve) => { releaseLookup = resolve; });
+    let lookups = 0;
+    let refreshes = 0;
+    internals.discovery = {
+      findAgents: async () => {
+        lookups += 1;
+        markLookupStarted();
+        await lookupGate;
+        return [];
+      },
+    };
+    internals.refreshMetaFromCurator = async () => {
+      refreshes += 1;
+      return false;
+    };
+    let current = true;
+    const resolution = internals.resolveCuratorPeerIdsForCg(contextGraphId, {
+      isCurrent: () => current,
+    });
+
+    await lookupStarted;
+    current = false;
+    releaseLookup();
+
+    await expect(resolution).rejects.toMatchObject({ name: 'AbortError' });
+    expect(lookups).toBe(1);
+    expect(refreshes).toBe(0);
+  });
+
+  it('walks an oversized structural-curator roster with an exclusive peer cursor', async () => {
+    const curator = ethers.Wallet.createRandom().address.toLowerCase();
+    const contextGraphId = `${curator}/paged-curator-plan`;
+    const agent = await createAgent('CuratorRecoveryPagination');
+    const pages = [
+      ['peer-001', 'peer-002', 'peer-003'],
+      ['peer-002', 'peer-003', 'peer-004'],
+    ];
+    const calls: Array<{ afterPeerId?: string; limit?: number }> = [];
+    const internals = agent as any;
+    internals.localAgents.clear();
+    internals.discovery = {
+      findAgentPeerIdsByAddress: async (
+        _address: string,
+        options: { afterPeerId?: string; limit?: number },
+      ) => {
+        calls.push(options);
+        return pages[calls.length - 1] ?? [];
+      },
+      findAgents: async () => [],
+    };
+
+    const first = await internals.resolveCuratorPeerIdsForCg(contextGraphId, {
+      maxPeerIds: 2,
+      pagePeerIds: 1,
+    });
+    const second = await internals.resolveCuratorPeerIdsForCg(contextGraphId, {
+      maxPeerIds: 2,
+      pagePeerIds: 1,
+      afterPeerId: first.nextPageAfterPeerId,
+    });
+
+    expect(first).toMatchObject({
+      peerIds: ['peer-001'],
+      overflowed: true,
+      nextPageAfterPeerId: 'peer-001',
+    });
+    expect(second).toMatchObject({
+      peerIds: ['peer-002'],
+      overflowed: true,
+      nextPageAfterPeerId: 'peer-002',
+    });
+    expect(calls).toEqual([
+      { limit: 3, signal: undefined },
+      { afterPeerId: 'peer-001', limit: 2, signal: undefined },
+    ]);
+  });
+
   async function createAgent(name: string): Promise<DKGAgent> {
     const agent = await DKGAgent.create({
       name,

--- a/packages/agent/test/swm-curator-recovery-plan.test.ts
+++ b/packages/agent/test/swm-curator-recovery-plan.test.ts
@@ -72,6 +72,42 @@ describe('private SWM curator recovery planning', () => {
     expect(plan.eligibleContextGraphIds).toEqual([]);
   });
 
+  it('does not treat an empty registry after a failed metadata refresh as authoritative', async () => {
+    const curator = ethers.Wallet.createRandom().address.toLowerCase();
+    const contextGraphId = `${curator}/refresh-failed-plan`;
+    const agent = await createAgent('CuratorRecoveryRefreshFailure');
+    const internals = agent as unknown as {
+      localAgents: Map<string, unknown>;
+      discovery: { findAgents: () => Promise<Array<{ agentAddress?: string; peerId: string }>> };
+      refreshMetaFromCurator: (contextGraphId: string) => Promise<boolean>;
+      resolveCuratorPeerIdsForCg: (contextGraphId: string) => Promise<{
+        peerIds: string[];
+        curatorIsLocal: boolean;
+        legacyTripleResolved: boolean;
+        lookupFailed?: boolean;
+      }>;
+    };
+    internals.localAgents.clear();
+    let lookups = 0;
+    internals.discovery = {
+      findAgents: async () => {
+        lookups += 1;
+        return [];
+      },
+    };
+    internals.refreshMetaFromCurator = async () => false;
+
+    const result = await internals.resolveCuratorPeerIdsForCg(contextGraphId);
+
+    expect(lookups).toBe(2);
+    expect(result).toEqual({
+      peerIds: [],
+      curatorIsLocal: false,
+      legacyTripleResolved: false,
+      lookupFailed: true,
+    });
+  });
+
   async function createAgent(name: string): Promise<DKGAgent> {
     const agent = await DKGAgent.create({
       name,

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -11,10 +11,32 @@ import {
   SyncBackpressureBusyError,
   withGlobalSyncBackpressure,
 } from '../src/sync/backpressure.js';
-import { PriorityAdmissionQueue } from '../src/sync/priority-admission-queue.js';
+import {
+  PriorityAdmissionQueue,
+  type PriorityAdmissionAcquireOptions,
+} from '../src/sync/priority-admission-queue.js';
 import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+function queueOptions(
+  payload: string,
+  priority: number,
+  overrides: Partial<PriorityAdmissionAcquireOptions<string>> = {},
+): PriorityAdmissionAcquireOptions<string> {
+  return {
+    payload,
+    ownerKey: payload,
+    lane: 'durable',
+    priority,
+    priorityClass: priority >= 2_000 ? 'elevated' : 'default',
+    queueLimit: 8,
+    agingThresholdMs: 10,
+    createBusyError: (reason) => new Error(reason),
+    createDisplacedError: () => new Error('displaced'),
+    ...overrides,
+  };
+}
 
 describe('sync global backpressure', () => {
   it('preserves the original FIFO sequence across a running-to-queued handoff', async () => {
@@ -380,29 +402,365 @@ describe('sync global backpressure', () => {
     expect(events).toEqual(['running', 'high', 'low']);
   });
 
-  it('runs the oldest aged entry before newer elevated work', async () => {
+  it('bounds an aged lower-priority entry behind one raw-priority overtake', async () => {
     const ctx = createOperationContext('sync');
     const policy = resolveSyncGlobalBackpressure({ syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 3 });
     const events: string[] = [];
-    let now = 0;
     let unblock!: () => void;
-    const running = withGlobalSyncBackpressure({ policy, ctx, label: 'running', now: () => now }, async () => {
+    const running = withGlobalSyncBackpressure({ policy, ctx, label: 'running' }, async () => {
       await new Promise<void>((resolve) => { unblock = resolve; });
     });
     await tick();
     const agedLow = withGlobalSyncBackpressure({
       policy, ctx, label: 'aged-low', priority: -1, priorityClass: 'deprioritized',
-      agingThresholdMs: 10, now: () => now,
+      agingThresholdMs: 0,
     }, async () => { events.push('aged-low'); });
-    now = 5;
     const high = withGlobalSyncBackpressure({
       policy, ctx, label: 'high', priority: 100, priorityClass: 'elevated',
-      agingThresholdMs: 10, now: () => now,
+      agingThresholdMs: 0,
     }, async () => { events.push('high'); });
-    now = 11;
     unblock();
     await Promise.all([running, agedLow, high]);
-    expect(events).toEqual(['aged-low', 'high']);
+    expect(events).toEqual(['high', 'aged-low']);
+  });
+
+  it('uses raw numeric priority and pays one aged-service debt after an overtake', async () => {
+    let now = 0;
+    let running = 0;
+    let enabled = false;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => enabled && running < 1,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+
+    const low = queue.acquire(queueOptions('low-1000', 1_000, {
+      priorityClass: 'elevated',
+    }));
+    const high = queue.acquire(queueOptions('high-2000', 2_000, {
+      priorityClass: 'deprioritized',
+    }));
+    now = 20;
+    enabled = true;
+    queue.pump();
+
+    const releaseHigh = await high.release;
+    expect(starts).toEqual(['high-2000']);
+    releaseHigh();
+    const releaseLow = await low.release;
+    expect(starts).toEqual(['high-2000', 'low-1000']);
+    releaseLow();
+  });
+
+  it('does not let a newly arriving higher maximum rearm an existing debt', async () => {
+    let now = 0;
+    let running = 0;
+    let enabled = false;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => enabled && running < 1,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+
+    const low = queue.acquire(queueOptions('aged-1000', 1_000));
+    const firstHigh = queue.acquire(queueOptions('high-2000', 2_000));
+    now = 20;
+    enabled = true;
+    queue.pump();
+    const releaseFirstHigh = await firstHigh.release;
+    const laterMaximum = queue.acquire(queueOptions('later-3000', 3_000));
+
+    releaseFirstHigh();
+    const releaseLow = await low.release;
+    expect(starts).toEqual(['high-2000', 'aged-1000']);
+    releaseLow();
+    const releaseLaterMaximum = await laterMaximum.release;
+    expect(starts).toEqual(['high-2000', 'aged-1000', 'later-3000']);
+    releaseLaterMaximum();
+  });
+
+  it('keeps debt while its aged recipient is temporarily not runnable', async () => {
+    let now = 0;
+    let running = 0;
+    let enabled = false;
+    let lowBlocked = true;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: (entry) => (
+        enabled
+        && running < 1
+        && (entry.payload !== 'aged-low' || !lowBlocked)
+      ),
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+
+    const low = queue.acquire(queueOptions('aged-low', 1_000));
+    const firstHigh = queue.acquire(queueOptions('high-1', 2_000));
+    now = 20;
+    enabled = true;
+    queue.pump();
+    const releaseFirstHigh = await firstHigh.release;
+    const secondHigh = queue.acquire(queueOptions('high-2', 2_000));
+
+    releaseFirstHigh();
+    const releaseSecondHigh = await secondHigh.release;
+    expect(starts).toEqual(['high-1', 'high-2']);
+    releaseSecondHigh();
+    lowBlocked = false;
+    queue.pump();
+    const releaseLow = await low.release;
+    expect(starts).toEqual(['high-1', 'high-2', 'aged-low']);
+    releaseLow();
+  });
+
+  it('fills two free slots with one high overtake and the owed aged turn', async () => {
+    let now = 0;
+    let running = 0;
+    let enabled = false;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => enabled && running < 2,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+
+    const low1 = queue.acquire(queueOptions('low-1', 1_000));
+    const low2 = queue.acquire(queueOptions('low-2', 1_000));
+    const high = queue.acquire(queueOptions('high', 2_000));
+    now = 20;
+    enabled = true;
+    queue.pump();
+
+    const releaseHigh = await high.release;
+    const releaseLow1 = await low1.release;
+    expect(running).toBe(2);
+    expect(starts).toEqual(['high', 'low-1']);
+    releaseHigh();
+    const releaseLow2 = await low2.release;
+    expect(starts).toEqual(['high', 'low-1', 'low-2']);
+    releaseLow1();
+    releaseLow2();
+  });
+
+  it('protects one oldest aged lower-priority entry from a displacement flood', async () => {
+    let now = 0;
+    let running = 0;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => running < 1,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+    const atCapacity = { queueLimit: 4 };
+
+    const blocker = queue.acquire(queueOptions('blocker', 0, atCapacity));
+    const releaseBlocker = await blocker.release;
+    const oldest = queue.acquire(queueOptions('oldest-aged', 0, atCapacity));
+    const replaceable = queue.acquire(queueOptions('replaceable-aged', 0, atCapacity));
+    const medium = queue.acquire(queueOptions('medium', 5, atCapacity));
+    const upper = queue.acquire(queueOptions('upper', 6, atCapacity));
+    const displaced = replaceable.release.catch((error: unknown) => error);
+    now = 20;
+    const high = queue.acquire(queueOptions('high', 10, atCapacity));
+
+    expect(await displaced).toMatchObject({ message: 'displaced' });
+    expect(queue.entries().map((entry) => entry.payload)).toContain('oldest-aged');
+    expect(queue.entries().map((entry) => entry.payload)).not.toContain('replaceable-aged');
+
+    releaseBlocker();
+    const releaseHigh = await high.release;
+    releaseHigh();
+    const releaseOldest = await oldest.release;
+    releaseOldest();
+    const releaseUpper = await upper.release;
+    releaseUpper();
+    const releaseMedium = await medium.release;
+    releaseMedium();
+    expect(starts).toEqual(['blocker', 'high', 'oldest-aged', 'upper', 'medium']);
+  });
+
+  it('clears debt when its last aged recipient is cancelled', async () => {
+    let now = 0;
+    let running = 0;
+    let enabled = false;
+    const starts: string[] = [];
+    const controller = new AbortController();
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => enabled && running < 1,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+
+    const cancelled = queue.acquire(queueOptions('cancelled-low', 1_000, {
+      signal: controller.signal,
+    }));
+    const firstHigh = queue.acquire(queueOptions('first-high', 2_000));
+    now = 20;
+    enabled = true;
+    queue.pump();
+    const releaseFirstHigh = await firstHigh.release;
+    controller.abort(new Error('cancelled'));
+    await expect(cancelled.release).rejects.toThrow('cancelled');
+
+    const nextLow = queue.acquire(queueOptions('next-low', 1_000));
+    const nextHigh = queue.acquire(queueOptions('next-high', 2_000));
+    now = 40;
+    releaseFirstHigh();
+    const releaseNextHigh = await nextHigh.release;
+    expect(starts).toEqual(['first-high', 'next-high']);
+    releaseNextHigh();
+    const releaseNextLow = await nextLow.release;
+    releaseNextLow();
+  });
+
+  it('clears debt when its last aged recipient times out', async () => {
+    let now = 0;
+    let running = 0;
+    let enabled = false;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => enabled && running < 1,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+
+    const timedOut = queue.acquire(queueOptions('timed-out-low', 1_000, {
+      timeoutMs: 5,
+      createTimeoutError: () => new Error('timed out'),
+    }));
+    const timeoutResult = timedOut.release.catch((error: unknown) => error);
+    const firstHigh = queue.acquire(queueOptions('first-high', 2_000));
+    now = 20;
+    enabled = true;
+    queue.pump();
+    const releaseFirstHigh = await firstHigh.release;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(await timeoutResult).toMatchObject({ message: 'timed out' });
+
+    const nextLow = queue.acquire(queueOptions('next-low', 1_000));
+    const nextHigh = queue.acquire(queueOptions('next-high', 2_000));
+    now = 40;
+    releaseFirstHigh();
+    const releaseNextHigh = await nextHigh.release;
+    expect(starts).toEqual(['first-high', 'next-high']);
+    releaseNextHigh();
+    const releaseNextLow = await nextLow.release;
+    releaseNextLow();
+  });
+
+  it('preserves debt across a running-to-queued responder handoff', async () => {
+    let now = 0;
+    let running = 0;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => running < 1,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+
+    const first = queue.acquire(queueOptions('first-stage', 0, {
+      ownerKey: 'peer-a',
+      queueLimit: 4,
+      ownerQueueLimit: 4,
+      reserveForHandoff: true,
+    }));
+    const releaseFirst = await first.release;
+    const low = queue.acquire(queueOptions('aged-low', 1_000, {
+      ownerKey: 'peer-b',
+      queueLimit: 4,
+      ownerQueueLimit: 4,
+    }));
+    now = 20;
+    const high = queue.acquire(queueOptions('high-2000', 2_000, {
+      ownerKey: 'peer-c',
+      queueLimit: 4,
+      ownerQueueLimit: 4,
+    }));
+    const handoff = first.handoff!({
+      payload: 'handoff-3000',
+      lane: 'responder',
+      priority: 3_000,
+      priorityClass: 'deprioritized',
+      agingThresholdMs: 10,
+      createBusyError: (reason) => new Error(reason),
+      createDisplacedError: () => new Error('displaced'),
+    });
+
+    releaseFirst();
+    const releaseHandoff = await handoff.release;
+    releaseHandoff();
+    const releaseLow = await low.release;
+    expect(starts).toEqual(['first-stage', 'handoff-3000', 'aged-low']);
+    releaseLow();
+    const releaseHigh = await high.release;
+    releaseHigh();
+  });
+
+  it('creates fairness debt only after onStart succeeds', async () => {
+    let now = 0;
+    let running = 0;
+    let enabled = false;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => enabled && running < 1,
+      onStart: (entry) => {
+        if (entry.payload === 'failing-3000') throw new Error('start failed');
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+
+    const low = queue.acquire(queueOptions('aged-1000', 1_000));
+    const medium = queue.acquire(queueOptions('medium-2000', 2_000));
+    const failing = queue.acquire(queueOptions('failing-3000', 3_000));
+    const failed = failing.release.catch((error: unknown) => error);
+    now = 20;
+    enabled = true;
+    queue.pump();
+
+    expect(await failed).toMatchObject({ message: 'start failed' });
+    const releaseMedium = await medium.release;
+    expect(starts).toEqual(['medium-2000']);
+    releaseMedium();
+    const releaseLow = await low.release;
+    releaseLow();
   });
 
   it('displaces only strictly lower-priority queued work when the queue is full', async () => {
@@ -639,6 +997,7 @@ describe('sync global backpressure', () => {
     let running = 0;
     let now = 1_000;
     const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
       canRun: () => running < 1,
       onStart: () => {
         running += 1;
@@ -649,7 +1008,6 @@ describe('sync global backpressure', () => {
         operation: (entry) => entry.payload,
         inflightLimit: () => 1,
         thresholds: { degradedQueueAgeMs: 5_000 },
-        now: () => now,
       },
     });
     const options = (payload: string) => ({
@@ -659,7 +1017,6 @@ describe('sync global backpressure', () => {
       priorityClass: 'default' as const,
       queueLimit: 2,
       agingThresholdMs: 30_000,
-      now: () => now,
       createBusyError: () => new Error('full'),
       createDisplacedError: () => new Error('displaced'),
     });
@@ -687,6 +1044,7 @@ describe('sync global backpressure', () => {
         }],
       }],
     });
+    expect(queue.oldestAgeMs()).toBe(6_000);
 
     releaseFirst();
     const releaseSecond = await second.release;

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -763,6 +763,65 @@ describe('sync global backpressure', () => {
     releaseLow();
   });
 
+  it('rolls back direct-start capacity when onStart throws after claiming it', async () => {
+    let running = 0;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      canRun: () => running < 1,
+      onStart: (entry) => {
+        running += 1;
+        if (entry.payload === 'failing') throw new Error('start failed after claim');
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+      onStartFailureRollback: () => { running -= 1; },
+    });
+
+    expect(() => queue.acquire(queueOptions('failing', 0))).toThrow(
+      'start failed after claim',
+    );
+    expect(running).toBe(0);
+
+    const subsequent = queue.acquire(queueOptions('subsequent', 0));
+    const releaseSubsequent = await subsequent.release;
+    expect(subsequent.status).toBe('running');
+    expect(starts).toEqual(['subsequent']);
+    expect(running).toBe(1);
+    releaseSubsequent();
+    expect(running).toBe(0);
+  });
+
+  it('rolls back queued-start capacity and starts the next waiter in the same pump', async () => {
+    let running = 0;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      canRun: () => running < 1,
+      onStart: (entry) => {
+        running += 1;
+        if (entry.payload === 'failing') throw new Error('queued start failed after claim');
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+      onStartFailureRollback: () => { running -= 1; },
+    });
+
+    const blocker = queue.acquire(queueOptions('blocker', 0));
+    const releaseBlocker = await blocker.release;
+    const failing = queue.acquire(queueOptions('failing', 10));
+    const failingResult = failing.release.catch((error: unknown) => error);
+    const subsequent = queue.acquire(queueOptions('subsequent', 0));
+
+    releaseBlocker();
+
+    expect(await failingResult).toMatchObject({ message: 'queued start failed after claim' });
+    const releaseSubsequent = await subsequent.release;
+    expect(starts).toEqual(['blocker', 'subsequent']);
+    expect(running).toBe(1);
+    expect(queue.length).toBe(0);
+    releaseSubsequent();
+    expect(running).toBe(0);
+  });
+
   it('displaces only strictly lower-priority queued work when the queue is full', async () => {
     const ctx = createOperationContext('sync');
     const policy = resolveSyncGlobalBackpressure({ syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 1 });

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -873,6 +873,54 @@ describe('sync global backpressure', () => {
     releaseLow();
   });
 
+  it('uses genuinely free capacity when older work is blocked by its own lower limit', async () => {
+    type MixedPolicyPayload = { name: string; inflightLimit: number };
+    let now = 0;
+    let running = 0;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<MixedPolicyPayload>({
+      now: () => now,
+      canRun: (entry) => running < entry.payload.inflightLimit,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload.name);
+        return () => { running -= 1; };
+      },
+    });
+    const options = (name: string, inflightLimit: number, priority: number) => ({
+      payload: { name, inflightLimit },
+      ownerKey: name,
+      lane: 'durable' as const,
+      priority,
+      priorityClass: priority > 0 ? 'elevated' as const : 'default' as const,
+      queueLimit: 1,
+      agingThresholdMs: 10,
+      createBusyError: (reason: string) => new Error(reason),
+      createDisplacedError: () => new Error('displaced'),
+    });
+
+    const blocker = queue.acquire(options('limit-one-blocker', 1, 0));
+    const releaseBlocker = await blocker.release;
+    const aged = queue.acquire(options('aged-limit-one', 1, 0));
+    now = 20;
+
+    const higherCapacity = queue.acquire(options('limit-two-foreground', 2, 1));
+    expect(higherCapacity.status).toBe('running');
+    const releaseHigherCapacity = await higherCapacity.release;
+    expect(starts).toEqual(['limit-one-blocker', 'limit-two-foreground']);
+    expect(aged.status).toBe('queued');
+
+    releaseHigherCapacity();
+    releaseBlocker();
+    const releaseAged = await aged.release;
+    expect(starts).toEqual([
+      'limit-one-blocker',
+      'limit-two-foreground',
+      'aged-limit-one',
+    ]);
+    releaseAged();
+  });
+
   it('rolls back direct-start capacity when onStart throws after claiming it', async () => {
     let running = 0;
     const starts: string[] = [];

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   backpressureRegistry,
   createOperationContext,
+  getMetrics,
 } from '@origintrail-official/dkg-core';
 import {
   getSyncBackpressureSnapshot,
@@ -237,6 +238,53 @@ describe('sync global backpressure', () => {
       'second-start',
       'third-start',
     ]);
+  });
+
+  it('starts foreground on the next release without preempting two active VM recoveries', async () => {
+    const ctx = createOperationContext('sync');
+    const policy = resolveSyncGlobalBackpressure({
+      syncGlobalMaxInflight: 2,
+      syncGlobalQueueLimit: 4,
+    });
+    const events: string[] = [];
+    let releaseVmA!: () => void;
+    let releaseVmB!: () => void;
+    let releaseForeground!: () => void;
+    const blockingWork = (label: string, setRelease: (release: () => void) => void) =>
+      async () => {
+        events.push(`${label}-start`);
+        await new Promise<void>((resolve) => setRelease(resolve));
+        events.push(`${label}-end`);
+      };
+
+    const vmA = withGlobalSyncBackpressure({
+      policy, ctx, label: 'durable:vm-a', priority: 1_000, source: 'vm-recovery',
+    }, blockingWork('vm-a', (release) => { releaseVmA = release; }));
+    const vmB = withGlobalSyncBackpressure({
+      policy, ctx, label: 'durable:vm-b', priority: 1_000, source: 'vm-recovery',
+    }, blockingWork('vm-b', (release) => { releaseVmB = release; }));
+    await tick();
+
+    const queuedVm = withGlobalSyncBackpressure({
+      policy, ctx, label: 'durable:vm-c', priority: 1_000, source: 'vm-recovery',
+    }, async () => { events.push('vm-c-start'); });
+    const foreground = withGlobalSyncBackpressure({
+      policy, ctx, label: 'durable:foreground', priority: 2_000,
+      source: 'catchup-foreground',
+    }, blockingWork('foreground', (release) => { releaseForeground = release; }));
+    await tick();
+
+    expect(events).toEqual(['vm-a-start', 'vm-b-start']);
+    releaseVmA();
+    await tick();
+    expect(events).toEqual(['vm-a-start', 'vm-b-start', 'vm-a-end', 'foreground-start']);
+
+    releaseForeground();
+    await foreground;
+    await tick();
+    expect(events).toContain('vm-c-start');
+    releaseVmB();
+    await Promise.all([vmA, vmB, queuedVm]);
   });
 
   it('carries the admission source from the production helper through to the scheduler', async () => {
@@ -677,6 +725,39 @@ describe('sync global backpressure', () => {
     releaseNextHigh();
     const releaseNextLow = await nextLow.release;
     releaseNextLow();
+  });
+
+  it('records a queued timeout as a rejected scheduler decision', async () => {
+    let running = 0;
+    const decisionCounter = getMetrics().syncSchedulerDecisionsTotal as unknown as {
+      add(value: number, attributes: Record<string, unknown>): void;
+    };
+    const originalAdd = decisionCounter.add;
+    const decisions: Array<Record<string, unknown>> = [];
+    decisionCounter.add = (_value, attributes) => { decisions.push(attributes); };
+    try {
+      const queue = new PriorityAdmissionQueue<string>({
+        canRun: () => running < 1,
+        onStart: () => {
+          running += 1;
+          return () => { running -= 1; };
+        },
+      });
+      const active = queue.acquire(queueOptions('active', 0));
+      const releaseActive = await active.release;
+      const timedOut = queue.acquire(queueOptions('timed-out', 0, {
+        timeoutMs: 5,
+        createTimeoutError: () => new Error('timed out'),
+      }));
+
+      await expect(timedOut.release).rejects.toThrow('timed out');
+      expect(decisions).toContainEqual({
+        lane: 'durable', priority_class: 'default', outcome: 'rejected',
+      });
+      releaseActive();
+    } finally {
+      decisionCounter.add = originalAdd;
+    }
   });
 
   it('preserves debt across a running-to-queued responder handoff', async () => {

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -650,6 +650,35 @@ describe('sync global backpressure', () => {
     expect(starts).toEqual(['blocker', 'high', 'oldest-aged', 'upper', 'medium']);
   });
 
+  it('protects the sole aged entry when the queue limit is one', async () => {
+    let now = 0;
+    let running = 0;
+    const starts: string[] = [];
+    const queue = new PriorityAdmissionQueue<string>({
+      now: () => now,
+      canRun: () => running < 1,
+      onStart: (entry) => {
+        running += 1;
+        starts.push(entry.payload);
+        return () => { running -= 1; };
+      },
+    });
+    const oneSlot = { queueLimit: 1 };
+
+    const blocker = queue.acquire(queueOptions('blocker', 0, oneSlot));
+    const releaseBlocker = await blocker.release;
+    const aged = queue.acquire(queueOptions('aged', 0, oneSlot));
+    now = 20;
+
+    expect(() => queue.acquire(queueOptions('high', 10, oneSlot))).toThrow('global_queue_full');
+    expect(queue.entries().map((entry) => entry.payload)).toEqual(['aged']);
+
+    releaseBlocker();
+    const releaseAged = await aged.release;
+    releaseAged();
+    expect(starts).toEqual(['blocker', 'aged']);
+  });
+
   it('clears debt when its last aged recipient is cancelled', async () => {
     let now = 0;
     let running = 0;

--- a/packages/agent/test/sync-exact-accumulation.test.ts
+++ b/packages/agent/test/sync-exact-accumulation.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import {
+  exactAssetFilterKey,
+  MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+} from '../src/sync/exact-assets.js';
+import {
+  getSyncCheckpointKey,
+  MemorySyncCheckpointStore,
+} from '../src/sync/checkpoint/state.js';
+import { fetchSyncPages } from '../src/sync/requester/page-fetch.js';
+
+const EXACT_UAL = 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7';
+const encoder = new TextEncoder();
+type FetchParams = Parameters<typeof fetchSyncPages>[0];
+
+function fetchParams(overrides: Partial<FetchParams> = {}): FetchParams {
+  return {
+    ctx: { operationId: 'test', operationName: 'sync' },
+    remotePeerId: 'legacy-peer',
+    contextGraphId: 'large-legacy-cg',
+    includeSharedMemory: false,
+    phase: 'data',
+    graphUri: 'urn:data',
+    deadline: Date.now() + 10_000,
+    syncPageTimeoutMs: 1_000,
+    syncRouterAttempts: 1,
+    syncPageRetryAttempts: 1,
+    syncPageSize: 8_192,
+    syncDeniedResponse: 'denied',
+    debugSyncProgress: false,
+    protocolSync: '/dkg/test/sync',
+    checkpointStore: new MemorySyncCheckpointStore(),
+    assetUals: [EXACT_UAL],
+    maxAcceptedBytes: 1_000,
+    maxAcceptedQuads: 100,
+    buildSyncRequest: async () => encoder.encode('request'),
+    parseAndFilter: async () => ({ quads: [], totalQuads: 0 }),
+    send: async () => new Uint8Array(),
+    logWarn: () => {},
+    logInfo: () => {},
+    logDebug: () => {},
+    ...overrides,
+  };
+}
+
+describe('exact sync accumulation limits', () => {
+  it('rejects excess wire bytes before parsing and clears resumable state', async () => {
+    const firstPage = encoder.encode('page-one');
+    const secondPage = encoder.encode('page-two');
+    const checkpointStore = new MemorySyncCheckpointStore();
+    const checkpointKey = getSyncCheckpointKey(
+      'legacy-peer',
+      'large-legacy-cg',
+      false,
+      'data',
+      undefined,
+      undefined,
+      undefined,
+      exactAssetFilterKey([EXACT_UAL]),
+    );
+    checkpointStore.set(checkpointKey, 7);
+    checkpointStore.setResponderSession?.(
+      checkpointKey,
+      'legacy-session',
+      Date.now() + 60_000,
+    );
+    const requestedOffsets: number[] = [];
+    let sends = 0;
+    let parses = 0;
+
+    await expect(fetchSyncPages(fetchParams({
+      checkpointStore,
+      maxAcceptedBytes: firstPage.byteLength,
+      buildSyncRequest: async (_contextGraphId, offset) => {
+        requestedOffsets.push(offset);
+        return encoder.encode('request');
+      },
+      parseAndFilter: async () => {
+        parses += 1;
+        return {
+          quads: [{ subject: 'urn:s', predicate: 'urn:p', object: '"o"', graph: 'urn:data' }],
+          totalQuads: 1,
+        };
+      },
+      send: async () => {
+        sends += 1;
+        return sends === 1 ? firstPage : secondPage;
+      },
+    }))).rejects.toMatchObject({
+      code: 'SYNC_PAGE_ACCUMULATION_LIMIT',
+      dimension: 'bytes',
+      actual: firstPage.byteLength + secondPage.byteLength,
+      limit: firstPage.byteLength,
+    });
+
+    expect(requestedOffsets[0]).toBe(7);
+    expect(sends).toBe(2);
+    expect(parses).toBe(1);
+    expect(checkpointStore.get(checkpointKey)).toBeUndefined();
+
+    const retry = await fetchSyncPages(fetchParams({
+      checkpointStore,
+      send: async () => new Uint8Array(),
+    }));
+    expect(retry.resumedFromOffset).toBe(0);
+    expect(retry.responderSessionStartedFresh).toBe(true);
+  });
+
+  it('rejects excess parsed quads before retaining another legacy page', async () => {
+    let sends = 0;
+    let parses = 0;
+
+    await expect(fetchSyncPages(fetchParams({
+      phase: 'meta',
+      graphUri: 'urn:meta',
+      maxAcceptedQuads: 1,
+      parseAndFilter: async () => {
+        parses += 1;
+        return {
+          quads: [{ subject: `urn:s:${parses}`, predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+          totalQuads: 1,
+        };
+      },
+      send: async () => {
+        sends += 1;
+        return encoder.encode(`page-${sends}`);
+      },
+    }))).rejects.toMatchObject({
+      code: 'SYNC_PAGE_ACCUMULATION_LIMIT',
+      dimension: 'quads',
+      actual: 2,
+      limit: 1,
+    });
+
+    expect(sends).toBe(2);
+    expect(parses).toBe(2);
+  });
+
+  it('accepts the exact 4 MiB per-asset boundary and rejects one byte more', async () => {
+    const boundaryPage = new Uint8Array(MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET).fill(97);
+    let equalitySends = 0;
+    const result = await fetchSyncPages(fetchParams({
+      remotePeerId: 'compatible-peer',
+      contextGraphId: 'bounded-exact-cg',
+      maxAcceptedBytes: MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+      maxAcceptedQuads: 1,
+      parseAndFilter: async () => ({
+        quads: [{ subject: 'urn:s', predicate: 'urn:p', object: '"o"', graph: 'urn:data' }],
+        totalQuads: 1,
+      }),
+      send: async () => {
+        equalitySends += 1;
+        return equalitySends === 1 ? boundaryPage : new Uint8Array();
+      },
+    }));
+
+    let overBoundaryParsed = false;
+    await expect(fetchSyncPages(fetchParams({
+      remotePeerId: 'over-boundary-peer',
+      contextGraphId: 'bounded-exact-cg',
+      maxAcceptedBytes: MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+      maxAcceptedQuads: 1,
+      parseAndFilter: async () => {
+        overBoundaryParsed = true;
+        return { quads: [], totalQuads: 0 };
+      },
+      send: async () => new Uint8Array(MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET + 1),
+    }))).rejects.toMatchObject({
+      code: 'SYNC_PAGE_ACCUMULATION_LIMIT',
+      dimension: 'bytes',
+      actual: MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET + 1,
+      limit: MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+    });
+
+    expect(result.completed).toBe(true);
+    expect(result.quads).toHaveLength(1);
+    expect(result.bytesReceived).toBe(MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET);
+    expect(equalitySends).toBe(2);
+    expect(overBoundaryParsed).toBe(false);
+  });
+});

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -105,6 +105,7 @@ function emptySyncPage(phase: string): SyncPageResult {
     quads: [],
     bytesReceived: 0,
     resumedFromOffset: 0,
+    responderSessionStartedFresh: true,
     nextOffset: 0,
     checkpointKey: `checkpoint:${phase}`,
     completed: true,
@@ -460,6 +461,69 @@ describe('DKGAgent sync fetch coalescing', () => {
       expect(exactRecoveryDeadlineHeadroom.every(
         (remainingMs) => remainingMs > 599_000 && remainingMs <= 600_000,
       )).toBe(true);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('shares one physical exact outcome across public and detailed joiners', async () => {
+    const firstMetaFetch = deferred<SyncPageResult>();
+    let fetchCalls = 0;
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    stubLifecycleFetch(agent, async ({ phase }) => {
+      fetchCalls++;
+      if (fetchCalls === 1) return firstMetaFetch.promise;
+      return emptySyncPage(phase);
+    });
+    (agent as any).processDurableBatchInWorker = async () => ({
+      verifiedData: [],
+      verifiedMeta: [],
+      consumedUnpersistedMetaTriples: 0,
+      totalFetchedDataQuads: 0,
+      totalFetchedMetaQuads: 0,
+      rejectedKcs: 0,
+      emptyResponses: 1,
+      metaOnlyResponses: 0,
+      verifiedPrivateOnlyResponses: 0,
+      dataRejectedMissingMeta: 0,
+    });
+
+    try {
+      const publicResult = (agent as any).syncExactKnowledgeAssetsFromPeer(
+        PEER_A,
+        'coalesced-cg',
+        [EXACT_UAL_7],
+      );
+      await waitFor(() => fetchCalls === 1);
+      const detailedResult = (agent as any).syncExactKnowledgeAssetsFromPeerDetailed(
+        PEER_A,
+        'coalesced-cg',
+        [EXACT_UAL_7],
+      );
+      firstMetaFetch.resolve(emptySyncPage('meta'));
+
+      const [projected, detailed] = await Promise.all([publicResult, detailedResult]);
+      expect(fetchCalls).toBe(2);
+      expect(projected).toBe(detailed.result);
+      expect(projected).not.toHaveProperty('disposition');
+      expect(detailed.disposition).toBe('clean-absent');
+
+      fetchCalls = 0;
+      const firstDetailed = (agent as any).syncExactKnowledgeAssetsFromPeerDetailed(
+        PEER_A,
+        'coalesced-cg',
+        [EXACT_UAL_7],
+      );
+      const secondDetailed = (agent as any).syncExactKnowledgeAssetsFromPeerDetailed(
+        PEER_A,
+        'coalesced-cg',
+        [EXACT_UAL_7],
+      );
+      const [first, second] = await Promise.all([firstDetailed, secondDetailed]);
+      expect(fetchCalls).toBe(2);
+      expect(first.result).toBe(second.result);
+      expect(first.disposition).toBe('clean-absent');
+      expect(second.disposition).toBe('clean-absent');
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -132,6 +132,26 @@ async function createAgentWithSend(
   return agent;
 }
 
+describe('exact VM recovery lifecycle', () => {
+  it('reopens rotation admission when the same agent is restarted', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    try {
+      await agent.start();
+      const initialGeneration = (agent as any).vmReconcileRotationGeneration;
+      await agent.stop();
+      expect((agent as any).vmReconcileRotationClosed).toBe(true);
+      expect((agent as any).vmReconcileRotationGeneration).toBe(initialGeneration + 1);
+
+      await agent.start();
+      expect((agent as any).vmReconcileRotationClosed).toBe(false);
+      expect((agent as any).vmReconcileRotationGeneration).toBe(initialGeneration + 1);
+      expect((agent as any).vmReconcileDispatcher.snapshot().closed).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+});
+
 function fetchPages(agent: DKGAgent, args: FetchArgs = {}): Promise<SyncPageResult> {
   return (agent as any).fetchSyncPages(
     createOperationContext('sync'),

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -153,7 +153,7 @@ describe('exact VM recovery lifecycle', () => {
     }
   });
 
-  it('retires a timed-out dispatcher before admitting reconcile work after restart', async () => {
+  it('quarantines a timed-out dispatcher and admits fresh reconcile work after restart', async () => {
     const timeoutDescriptor = Object.getOwnPropertyDescriptor(
       DKGAgentBase,
       'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS',
@@ -177,28 +177,25 @@ describe('exact VM recovery lifecycle', () => {
       (agent as any).healStrandedScopedKCs = heal;
 
       const oldRun = (agent as any).runVmReconcileForCg('restart-retirement', 'manual');
+      const oldOutcome = oldRun.catch((error: unknown) => error);
       await targetEntered.promise;
       await agent.stop();
       expect(oldDispatcher.snapshot()).toMatchObject({ active: 1, closed: true });
 
       await agent.start();
-      expect((agent as any).vmReconcileDispatcher).toBe(oldDispatcher);
+      const newDispatcher = (agent as any).vmReconcileDispatcher;
+      expect(newDispatcher).not.toBe(oldDispatcher);
+      expect(newDispatcher.snapshot().closed).toBe(false);
+      const freshResult = { status: 'current', contextGraphId: 'restart-retirement-new' };
+      (agent as any).executeVmReconcileForCg = vi.fn(async () => freshResult);
       await expect(
         (agent as any).runVmReconcileForCg('restart-retirement-new', 'manual'),
-      ).rejects.toBeInstanceOf(VmReconcileQueueClosedError);
-
-      await agent.stop();
-      await agent.start();
-      expect((agent as any).vmReconcileDispatcher).toBe(oldDispatcher);
-      expect((agent as any).vmReconcileRetiringDispatcher).toBe(oldDispatcher);
+      ).resolves.toBe(freshResult);
 
       releaseTarget.resolve();
-      await expect(oldRun).rejects.toBeInstanceOf(VmReconcileQueueClosedError);
+      await expect(oldOutcome).resolves.toBeInstanceOf(VmReconcileQueueClosedError);
       expect(heal).not.toHaveBeenCalled();
-      await waitFor(() => (
-        (agent as any).vmReconcileDispatcher !== oldDispatcher
-        && (agent as any).vmReconcileDispatcher?.snapshot().closed === false
-      ));
+      expect((agent as any).vmReconcileDispatcher).toBe(newDispatcher);
     } finally {
       releaseTarget.resolve();
       await agent.stop().catch(() => {});

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -12,7 +12,10 @@ import { resolveSyncGlobalBackpressure, SyncBackpressureBusyError, withGlobalSyn
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { DKGAgentBase } from '../src/dkg-agent-base.js';
-import { VmReconcileQueueClosedError } from '../src/vm-reconcile-service.js';
+import {
+  VmReconcileQueueClosedError,
+  VmReconcileShutdownTimeoutError,
+} from '../src/vm-reconcile-service.js';
 import { stubLifecycleFetch } from './_helpers/sync-fetch-coalescing.js';
 
 const PEER_A = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
@@ -153,7 +156,7 @@ describe('exact VM recovery lifecycle', () => {
     }
   });
 
-  it('quarantines a timed-out dispatcher and admits fresh reconcile work after restart', async () => {
+  it('quarantines a physically active reconcile until shutdown is retried', async () => {
     const timeoutDescriptor = Object.getOwnPropertyDescriptor(
       DKGAgentBase,
       'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS',
@@ -179,23 +182,20 @@ describe('exact VM recovery lifecycle', () => {
       const oldRun = (agent as any).runVmReconcileForCg('restart-retirement', 'manual');
       const oldOutcome = oldRun.catch((error: unknown) => error);
       await targetEntered.promise;
+      await expect(agent.stop()).rejects.toBeInstanceOf(VmReconcileShutdownTimeoutError);
+      expect(oldDispatcher.snapshot()).toMatchObject({ active: 0, closed: true });
+      await expect(oldOutcome).resolves.toBeInstanceOf(VmReconcileQueueClosedError);
+      await expect(agent.start()).rejects.toBeInstanceOf(VmReconcileShutdownTimeoutError);
+
+      releaseTarget.resolve();
+      await (agent as any).vmReconcileRetirement;
+      expect(heal).not.toHaveBeenCalled();
       await agent.stop();
-      expect(oldDispatcher.snapshot()).toMatchObject({ active: 1, closed: true });
 
       await agent.start();
       const newDispatcher = (agent as any).vmReconcileDispatcher;
       expect(newDispatcher).not.toBe(oldDispatcher);
       expect(newDispatcher.snapshot().closed).toBe(false);
-      const freshResult = { status: 'current', contextGraphId: 'restart-retirement-new' };
-      (agent as any).executeVmReconcileForCg = vi.fn(async () => freshResult);
-      await expect(
-        (agent as any).runVmReconcileForCg('restart-retirement-new', 'manual'),
-      ).resolves.toBe(freshResult);
-
-      releaseTarget.resolve();
-      await expect(oldOutcome).resolves.toBeInstanceOf(VmReconcileQueueClosedError);
-      expect(heal).not.toHaveBeenCalled();
-      expect((agent as any).vmReconcileDispatcher).toBe(newDispatcher);
     } finally {
       releaseTarget.resolve();
       await agent.stop().catch(() => {});

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -8,6 +8,7 @@ import {
   DKGAgent,
   FOREGROUND_CATCHUP_SYNC_PRIORITY,
 } from '../src/index.js';
+import type { ContextGraphMembershipStore } from '../src/dkg-agent-types.js';
 import { resolveSyncGlobalBackpressure, SyncBackpressureBusyError, withGlobalSyncBackpressure } from '../src/sync/backpressure.js';
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
@@ -125,11 +126,13 @@ async function createAgentWithSend(
     syncGlobalQueueLimit: number;
     syncContextGraphPriorities?: Record<string, number>;
   },
+  contextGraphMembershipStore?: ContextGraphMembershipStore,
 ): Promise<DKGAgent> {
   const agent = await DKGAgent.create({
     name: 'SyncFetchCoalescing',
     listenHost: '127.0.0.1',
     chainAdapter: new MockChainAdapter(),
+    contextGraphMembershipStore,
     ...backpressure,
   });
   (agent as any).messenger = { sendToPeer };
@@ -138,19 +141,38 @@ async function createAgentWithSend(
 }
 
 describe('exact VM recovery lifecycle', () => {
-  it('reopens rotation admission when the same agent is restarted', async () => {
-    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+  it('reopens reconcile and membership persistence admission on same-object restart', async () => {
+    const membershipUpsert = vi.fn(async () => undefined);
+    const agent = await createAgentWithSend(
+      async () => new Uint8Array(0),
+      undefined,
+      {
+        loadAll: async () => [],
+        upsert: membershipUpsert,
+        delete: async () => undefined,
+      },
+    );
     try {
       await agent.start();
       const initialGeneration = (agent as any).vmReconcileLifecycleGeneration;
       await agent.stop();
       expect((agent as any).vmReconcileRotationClosed).toBe(true);
       expect((agent as any).vmReconcileLifecycleGeneration).toBe(initialGeneration + 1);
+      expect((agent as any).contextGraphMembershipPersistence.status().closed).toBe(true);
 
       await agent.start();
       expect((agent as any).vmReconcileRotationClosed).toBe(false);
       expect((agent as any).vmReconcileLifecycleGeneration).toBe(initialGeneration + 1);
       expect((agent as any).vmReconcileDispatcher.snapshot().closed).toBe(false);
+      expect((agent as any).contextGraphMembershipPersistence.status().closed).toBe(false);
+      const upsertsBeforeRestartProbe = membershipUpsert.mock.calls.length;
+      await agent.upsertContextGraphMember({
+        contextGraphId: 'restart-membership',
+        principalType: 'node',
+        principalId: PEER_A,
+        status: 'active',
+      }, { strict: true });
+      expect(membershipUpsert).toHaveBeenCalledTimes(upsertsBeforeRestartProbe + 1);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -524,6 +524,22 @@ describe('DKGAgent sync fetch coalescing', () => {
       expect(first.result).toBe(second.result);
       expect(first.disposition).toBe('clean-absent');
       expect(second.disposition).toBe('clean-absent');
+
+      fetchCalls = 0;
+      const forwardOrder = (agent as any).syncExactKnowledgeAssetsFromPeer(
+        PEER_A,
+        'coalesced-cg',
+        [EXACT_UAL_7, EXACT_UAL_8],
+      );
+      const reverseOrder = (agent as any).syncExactKnowledgeAssetsFromPeerDetailed(
+        PEER_A,
+        'coalesced-cg',
+        [EXACT_UAL_8, EXACT_UAL_7],
+      );
+      const [forward, reverse] = await Promise.all([forwardOrder, reverseOrder]);
+      expect(fetchCalls).toBe(2);
+      expect(forward).toBe(reverse.result);
+      expect(reverse.disposition).toBe('clean-absent');
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createOperationContext,
   PROTOCOL_SYNC,
@@ -11,6 +11,8 @@ import {
 import { resolveSyncGlobalBackpressure, SyncBackpressureBusyError, withGlobalSyncBackpressure } from '../src/sync/backpressure.js';
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import { DKGAgentBase } from '../src/dkg-agent-base.js';
+import { VmReconcileQueueClosedError } from '../src/vm-reconcile-service.js';
 import { stubLifecycleFetch } from './_helpers/sync-fetch-coalescing.js';
 
 const PEER_A = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
@@ -137,17 +139,74 @@ describe('exact VM recovery lifecycle', () => {
     const agent = await createAgentWithSend(async () => new Uint8Array(0));
     try {
       await agent.start();
-      const initialGeneration = (agent as any).vmReconcileRotationGeneration;
+      const initialGeneration = (agent as any).vmReconcileLifecycleGeneration;
       await agent.stop();
       expect((agent as any).vmReconcileRotationClosed).toBe(true);
-      expect((agent as any).vmReconcileRotationGeneration).toBe(initialGeneration + 1);
+      expect((agent as any).vmReconcileLifecycleGeneration).toBe(initialGeneration + 1);
 
       await agent.start();
       expect((agent as any).vmReconcileRotationClosed).toBe(false);
-      expect((agent as any).vmReconcileRotationGeneration).toBe(initialGeneration + 1);
+      expect((agent as any).vmReconcileLifecycleGeneration).toBe(initialGeneration + 1);
       expect((agent as any).vmReconcileDispatcher.snapshot().closed).toBe(false);
     } finally {
       await agent.stop().catch(() => {});
+    }
+  });
+
+  it('retires a timed-out dispatcher before admitting reconcile work after restart', async () => {
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(
+      DKGAgentBase,
+      'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS',
+    )!;
+    Object.defineProperty(DKGAgentBase, 'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS', {
+      ...timeoutDescriptor,
+      value: 1,
+    });
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const targetEntered = deferred<void>();
+    const releaseTarget = deferred<void>();
+    const heal = vi.fn(async () => undefined);
+    try {
+      await agent.start();
+      const oldDispatcher = (agent as any).vmReconcileDispatcher;
+      (agent as any).resolveVmReconcileTarget = async () => {
+        targetEntered.resolve();
+        await releaseTarget.promise;
+        return {};
+      };
+      (agent as any).healStrandedScopedKCs = heal;
+
+      const oldRun = (agent as any).runVmReconcileForCg('restart-retirement', 'manual');
+      await targetEntered.promise;
+      await agent.stop();
+      expect(oldDispatcher.snapshot()).toMatchObject({ active: 1, closed: true });
+
+      await agent.start();
+      expect((agent as any).vmReconcileDispatcher).toBe(oldDispatcher);
+      await expect(
+        (agent as any).runVmReconcileForCg('restart-retirement-new', 'manual'),
+      ).rejects.toBeInstanceOf(VmReconcileQueueClosedError);
+
+      await agent.stop();
+      await agent.start();
+      expect((agent as any).vmReconcileDispatcher).toBe(oldDispatcher);
+      expect((agent as any).vmReconcileRetiringDispatcher).toBe(oldDispatcher);
+
+      releaseTarget.resolve();
+      await expect(oldRun).rejects.toBeInstanceOf(VmReconcileQueueClosedError);
+      expect(heal).not.toHaveBeenCalled();
+      await waitFor(() => (
+        (agent as any).vmReconcileDispatcher !== oldDispatcher
+        && (agent as any).vmReconcileDispatcher?.snapshot().closed === false
+      ));
+    } finally {
+      releaseTarget.resolve();
+      await agent.stop().catch(() => {});
+      Object.defineProperty(
+        DKGAgentBase,
+        'VM_RECONCILE_SHUTDOWN_TIMEOUT_MS',
+        timeoutDescriptor,
+      );
     }
   });
 });

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1064,6 +1064,72 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(observedSessionIds.at(-1)).not.toBe('expired-responder-token');
   });
 
+  it('reports whether an offset-zero phase reused an unfinished responder snapshot', async () => {
+    const contextGraphId = 'offset-zero-session-evidence-cg';
+    const checkpointKey = getSyncCheckpointKey(
+      REMOTE_PEER_ID,
+      contextGraphId,
+      false,
+      'data',
+    );
+    const checkpointStore = new MemorySyncCheckpointStore({ clock: () => Date.now() });
+    checkpointStore.set(checkpointKey, 0);
+    checkpointStore.setResponderSession(
+      checkpointKey,
+      'unfinished-offset-zero-token',
+      Date.now() + DURABLE_DATA_SYNC_SESSION_TTL_MS,
+    );
+    const observedSessionIds: Array<string | undefined> = [];
+
+    const runFetch = (forceFreshSession = false) => runFetchWithFakeTimers(fetchSyncPages({
+      ctx: makeCtx(),
+      remotePeerId: REMOTE_PEER_ID,
+      contextGraphId,
+      includeSharedMemory: false,
+      phase: 'data',
+      graphUri: GRAPH_URI,
+      deadline: Date.now() + 60_000,
+      syncPageTimeoutMs: 5_000,
+      syncRouterAttempts: 1,
+      syncPageRetryAttempts: 1,
+      syncPageSize: 1,
+      syncDeniedResponse: '#DENIED',
+      debugSyncProgress: false,
+      protocolSync: PROTOCOL_ID,
+      checkpointStore,
+      forceFreshSession,
+      buildSyncRequest: async (
+        _contextGraphId,
+        _offset,
+        _limit,
+        _includeSharedMemory,
+        _remotePeerId,
+        _phase,
+        _snapshotRef,
+        _sinceBatchId,
+        syncSessionId,
+      ) => {
+        observedSessionIds.push(syncSessionId);
+        return new TextEncoder().encode('request');
+      },
+      parseAndFilter: singleQuadParser,
+      send: async () => new Uint8Array(),
+      logWarn: noopLog,
+      logInfo: noopLog,
+      logDebug: noopLog,
+    }));
+
+    const reused = await runFetch();
+    expect(reused.resumedFromOffset).toBe(0);
+    expect(reused.responderSessionStartedFresh).toBe(false);
+    expect(observedSessionIds.at(-1)).toBe('unfinished-offset-zero-token');
+
+    const fresh = await runFetch(true);
+    expect(fresh.resumedFromOffset).toBe(0);
+    expect(fresh.responderSessionStartedFresh).toBe(true);
+    expect(observedSessionIds.at(-1)).not.toBe('unfinished-offset-zero-token');
+  });
+
   it('drops a RESUMED session that aborts with a GENERIC transport error (network-path R1 fix)', async () => {
     // 2026-07-07 sync storm. Over the wire the responder's "superseded" message
     // is destroyed by the router's stream.abort, so the requester sees a

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -9,7 +9,10 @@ import {
 } from '../src/sync/requester/durable-sync.js';
 import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
 import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
-import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import {
+  SyncPageAccumulationLimitError,
+  type SyncPageResult,
+} from '../src/sync/requester/page-fetch.js';
 import { markSyncTransportFailure } from '../src/sync/error-tags.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
@@ -1334,6 +1337,36 @@ describe('exact durable fetch disposition', () => {
       data: { nextOffset: 1 },
     });
     expect(detailed.exactFetchDisposition).toBe('incomplete');
+  });
+
+  it('does not verify or store an exact phase rejected by its accumulation limit', async () => {
+    const processDurableBatchInWorker = recorder(async () => durableProcessResult());
+    const storeInsert = recorder(async (_request: DurableSyncStoreInsertRequest) => {});
+    const fetchSyncPages = durableFetchRecorder(async () => {
+      throw new SyncPageAccumulationLimitError('bytes', 11, 10);
+    });
+    const detailed = await runDurableSyncDetailed({
+      ctx,
+      remotePeerId: 'legacy-exact-peer',
+      contextGraphIds: ['exact-cg'],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      exactAssetUalsFor: () => [EXACT_UAL],
+      fetchSyncPages,
+      processDurableBatchInWorker,
+      storeInsert,
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(detailed.exactFetchDisposition).toBe('incomplete');
+    expect(detailed.result.failedPhases).toBe(1);
+    expect(fetchSyncPages.calls).toHaveLength(1);
+    expect(fetchSyncPages.calls[0][0].phase).toBe('meta');
+    expect(processDurableBatchInWorker.calls).toHaveLength(0);
+    expect(storeInsert.calls).toHaveLength(0);
   });
 
   it('does not treat skipped agents metadata as a clean exact response', async () => {

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { OperationContext } from '@origintrail-official/dkg-core';
+import { SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
   runDurableSync,
+  runDurableSyncDetailed,
   type DurableSyncFetchRequest,
   type DurableSyncStoreInsertRequest,
 } from '../src/sync/requester/durable-sync.js';
@@ -25,6 +26,7 @@ function durableFetchRecorder(
 
 const ctx = { kind: 'system', id: 'test', startedAt: 0 } as OperationContext;
 const noop = () => {};
+const EXACT_UAL = 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7';
 
 function pageResult(
   contextGraphId: string,
@@ -35,6 +37,7 @@ function pageResult(
     quads: [],
     bytesReceived: 0,
     resumedFromOffset: 0,
+    responderSessionStartedFresh: true,
     nextOffset: 0,
     checkpointKey: `${contextGraphId}:${phase}`,
     completed: true,
@@ -1201,5 +1204,195 @@ describe('sync requester progress accounting', () => {
     expect(setCheckpoint.calls).toContainEqual(['large-swm:data', 7]);
     expect(setCheckpoint.calls).not.toContainEqual(['large-swm:meta', expect.any(Number)]);
     expect(deleteCheckpoint.calls).toContainEqual(['large-swm:snapshot:snapshot-ref']);
+  });
+});
+
+describe('exact durable fetch disposition', () => {
+  async function runExact(options: {
+    meta?: Partial<SyncPageResult>;
+    data?: Partial<SyncPageResult>;
+    rawMeta?: Quad[];
+    rawData?: Quad[];
+    rejectedKcs?: number;
+    dataRejectedMissingMeta?: number;
+    fetchError?: Error;
+    abortAfterMeta?: boolean;
+  } = {}) {
+    const controller = new AbortController();
+    return runDurableSyncDetailed({
+      ctx,
+      remotePeerId: 'exact-peer',
+      contextGraphIds: ['exact-cg'],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      exactAssetUalsFor: () => [EXACT_UAL],
+      fetchSyncPages: async ({ phase }) => {
+        if (options.fetchError) throw options.fetchError;
+        const page = pageResult('exact-cg', phase, {
+          quads: phase === 'meta' ? (options.rawMeta ?? []) : (options.rawData ?? []),
+          ...(phase === 'meta' ? options.meta : options.data),
+        });
+        if (phase === 'meta' && options.abortAfterMeta) {
+          controller.abort(new Error('cancelled after exact metadata'));
+        }
+        return page;
+      },
+      signal: controller.signal,
+      processDurableBatchInWorker: async (data, meta) => ({
+        ...durableProcessResult(),
+        verifiedData: data,
+        verifiedMeta: meta,
+        totalFetchedDataQuads: data.length,
+        totalFetchedMetaQuads: meta.length,
+        emptyResponses: data.length === 0 && meta.length === 0 ? 1 : 0,
+        rejectedKcs: options.rejectedKcs ?? 0,
+        dataRejectedMissingMeta: options.dataRejectedMissingMeta ?? 0,
+      }),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+  }
+
+  it('distinguishes fresh clean absence without changing public completion', async () => {
+    const detailed = await runExact();
+    const projected = await runDurableSync({
+      ctx,
+      remotePeerId: 'exact-peer-public',
+      contextGraphIds: ['exact-cg'],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      exactAssetUalsFor: () => [EXACT_UAL],
+      fetchSyncPages: async ({ phase }) => pageResult('exact-cg', phase),
+      processDurableBatchInWorker: async () => durableProcessResult(),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(detailed.exactFetchDisposition).toBe('clean-absent');
+    expect(detailed.result.complete).toBe(false);
+    expect(projected.complete).toBe(false);
+    expect(projected).not.toHaveProperty('exactFetchDisposition');
+  });
+
+  it('classifies returned exact descriptor and content as found', async () => {
+    const assertionGraph = 'did:dkg:context-graph:exact-cg/_verifiable_memory/asset/7';
+    const detailed = await runExact({
+      rawMeta: [
+        {
+          subject: EXACT_UAL,
+          predicate: 'http://dkg.io/ontology/kaUal',
+          object: EXACT_UAL,
+          graph: 'did:dkg:context-graph:exact-cg/_meta',
+        } as Quad,
+        {
+          subject: EXACT_UAL,
+          predicate: 'http://dkg.io/ontology/assertionGraph',
+          object: assertionGraph,
+          graph: 'did:dkg:context-graph:exact-cg/_meta',
+        } as Quad,
+      ],
+      rawData: [{
+        subject: 'http://example.com/entity',
+        predicate: 'http://example.com/value',
+        object: '"present"',
+        graph: assertionGraph,
+      } as Quad],
+      meta: { nextOffset: 2 },
+      data: { nextOffset: 1 },
+    });
+
+    expect(detailed.exactFetchDisposition).toBe('found');
+  });
+
+  it.each([
+    ['resumed empty suffix', { meta: { resumedFromOffset: 4, nextOffset: 4 } }],
+    ['reused offset-zero responder session', { meta: { responderSessionStartedFresh: false } }],
+    ['partial phase', { data: { completed: false } }],
+    ['timed out phase', { data: { completed: false, timedOut: true } }],
+    ['integrity rejection', { rejectedKcs: 1 }],
+    ['missing metadata rejection', { dataRejectedMissingMeta: 1 }],
+    ['denial', { fetchError: deniedError() }],
+    ['abort', { abortAfterMeta: true }],
+  ])('keeps %s incomplete', async (_label, options) => {
+    const detailed = await runExact(options);
+    expect(detailed.exactFetchDisposition).toBe('incomplete');
+  });
+
+  it('keeps an old responder filtered prefix incomplete', async () => {
+    const detailed = await runExact({
+      rawMeta: [quad('did:dkg:other-asset')],
+      rawData: [quad('http://example.com/unrelated')],
+      meta: { nextOffset: 1 },
+      data: { nextOffset: 1 },
+    });
+    expect(detailed.exactFetchDisposition).toBe('incomplete');
+  });
+
+  it('does not treat skipped agents metadata as a clean exact response', async () => {
+    const fetchedPhases: string[] = [];
+    const detailed = await runDurableSyncDetailed({
+      ctx,
+      remotePeerId: 'exact-agents-peer',
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.AGENTS],
+      syncAgentsMeta: false,
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      exactAssetUalsFor: () => [EXACT_UAL],
+      fetchSyncPages: async ({ contextGraphId, phase }) => {
+        fetchedPhases.push(phase);
+        return pageResult(contextGraphId, phase);
+      },
+      processDurableBatchInWorker: async () => durableProcessResult(),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(fetchedPhases).toEqual(['data']);
+    expect(detailed.exactFetchDisposition).toBe('incomplete');
+  });
+
+  it('aggregates exact outcomes across Context Graphs without overwriting an incomplete result', async () => {
+    const detailed = await runDurableSyncDetailed({
+      ctx,
+      remotePeerId: 'exact-multi-cg-peer',
+      contextGraphIds: ['exact-incomplete-cg', 'exact-clean-cg'],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      exactAssetUalsFor: () => [EXACT_UAL],
+      fetchSyncPages: async ({ contextGraphId, phase }) => pageResult(contextGraphId, phase, {
+        ...(contextGraphId === 'exact-incomplete-cg' && phase === 'data'
+          ? { completed: false }
+          : {}),
+      }),
+      processDurableBatchInWorker: async () => durableProcessResult(),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(detailed.exactFetchDisposition).toBe('incomplete');
+  });
+
+  it('keeps normalization failures on the asynchronous requester boundary', async () => {
+    let publicResult: ReturnType<typeof runDurableSync> | undefined;
+    let detailedResult: ReturnType<typeof runDurableSyncDetailed> | undefined;
+
+    expect(() => {
+      publicResult = runDurableSync(null as never);
+      detailedResult = runDurableSyncDetailed(null as never);
+    }).not.toThrow();
+    await expect(publicResult).rejects.toThrow();
+    await expect(detailedResult).rejects.toThrow();
   });
 });

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1313,6 +1313,8 @@ describe('exact durable fetch disposition', () => {
   it.each([
     ['resumed empty suffix', { meta: { resumedFromOffset: 4, nextOffset: 4 } }],
     ['reused offset-zero responder session', { meta: { responderSessionStartedFresh: false } }],
+    ['resumed empty data suffix', { data: { resumedFromOffset: 4, nextOffset: 4 } }],
+    ['reused offset-zero data responder session', { data: { responderSessionStartedFresh: false } }],
     ['partial phase', { data: { completed: false } }],
     ['timed out phase', { data: { completed: false, timedOut: true } }],
     ['integrity rejection', { rejectedKcs: 1 }],

--- a/packages/agent/test/sync-single-use-policy-wiring.test.ts
+++ b/packages/agent/test/sync-single-use-policy-wiring.test.ts
@@ -26,6 +26,10 @@ vi.mock('../src/sync/requester/page-fetch.js', () => ({
 
 import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
 import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
+import {
+  MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+  MAX_EXACT_SYNC_PHASE_QUADS_PER_ASSET,
+} from '../src/sync/exact-assets.js';
 
 describe('LifecycleSyncMethods sync transport policy wiring', () => {
   beforeEach(() => {
@@ -67,5 +71,43 @@ describe('LifecycleSyncMethods sync transport policy wiring', () => {
         signal: expect.any(AbortSignal),
       },
     );
+  });
+
+  it('wires exact-asset accumulation limits into the lifecycle page fetch', async () => {
+    const agent: any = {
+      node: { stopSignal: new AbortController().signal },
+      messenger: { sendToPeer: vi.fn(async () => new Uint8Array()) },
+      syncCheckpoints: new Map(),
+      buildSyncRequest: vi.fn(),
+      getOrCreateSyncVerifyWorker: () => ({ parseAndFilter: vi.fn() }),
+      log: { warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    };
+    const uals = [
+      'did:dkg:base:84532/0x0000000000000000000000000000000000000001/7',
+      'did:dkg:base:84532/0x0000000000000000000000000000000000000001/8',
+    ];
+
+    await (LifecycleSyncMethods.prototype.fetchSyncPages as any).call(
+      agent,
+      { operationId: 'exact-limit-wiring' },
+      'remote-peer',
+      'public-context-graph',
+      false,
+      'data',
+      'did:dkg:public-context-graph',
+      Date.now() + 60_000,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      uals,
+    );
+
+    expect(fetchSyncPagesMock).toHaveBeenCalledWith(expect.objectContaining({
+      assetUals: uals,
+      maxAcceptedBytes: 2 * MAX_EXACT_SYNC_PHASE_BYTES_PER_ASSET,
+      maxAcceptedQuads: 2 * MAX_EXACT_SYNC_PHASE_QUADS_PER_ASSET,
+    }));
   });
 });

--- a/packages/agent/test/vm-reconcile-self-prime.test.ts
+++ b/packages/agent/test/vm-reconcile-self-prime.test.ts
@@ -10,7 +10,7 @@
  * ontology OnChainId quad is locally present gets bound + persisted, and the
  * sweep then triggers its reconcile. Hermetic — MockChainAdapter, no network.
  */
-import { afterEach, describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import {
   DKG_ONTOLOGY,
@@ -21,12 +21,23 @@ import {
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import { DKGAgent } from '../src/index.js';
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
 interface AgentInternals {
   runVmReconcileSweep(): Promise<void>;
   selfPrimeSubscriptionOnChainId(
     localCgId: string,
     sub: { subscribed: boolean; coreHosted?: boolean; onChainId?: string },
     targetOnChainId?: bigint,
+    isCurrent?: () => boolean,
+    signal?: AbortSignal,
   ): Promise<string | null>;
   handleKARegisteredNudge(onChainId: string, kaId: bigint, ctx: unknown): Promise<string | null>;
   subscribedContextGraphs: Map<string, { subscribed: boolean; coreHosted?: boolean; onChainId?: string }>;
@@ -132,6 +143,50 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     const matched = await internals.selfPrimeSubscriptionOnChainId(CG_MATCH, internals.subscribedContextGraphs.get(CG_MATCH)!, BigInt(ON_MATCH));
     expect(matched).toBe(ON_MATCH);
     expect(internals.subscribedContextGraphs.get(CG_MATCH)?.onChainId).toBe(ON_MATCH);
+  });
+
+  it('does not bind or persist a replacement subscription after delayed self-prime is invalidated', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'SelfPrimeLifecycleFence', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'gh1098-stale-self-prime';
+    const original: { subscribed: boolean; onChainId?: string } = { subscribed: true };
+    const replacement = { subscribed: true, onChainId: '9002' };
+    internals.subscribedContextGraphs.set(localCgId, original);
+
+    const lookup = deferred<string | null>();
+    let receivedSignal: AbortSignal | undefined;
+    (internals as any).getContextGraphOnChainId = async (
+      _id: string,
+      options: { signal?: AbortSignal },
+    ) => {
+      receivedSignal = options.signal;
+      return lookup.promise;
+    };
+    const persist = vi.fn();
+    (internals as any).persistContextGraphSubscription = persist;
+    let current = true;
+    const controller = new AbortController();
+
+    const prime = internals.selfPrimeSubscriptionOnChainId(
+      localCgId,
+      original,
+      undefined,
+      () => current,
+      controller.signal,
+    );
+    await Promise.resolve();
+    current = false;
+    controller.abort();
+    internals.subscribedContextGraphs.set(localCgId, replacement);
+    lookup.resolve('9001');
+
+    await expect(prime).resolves.toBeNull();
+    expect(receivedSignal).toBe(controller.signal);
+    expect(original.onChainId).toBeUndefined();
+    expect(internals.subscribedContextGraphs.get(localCgId)).toBe(replacement);
+    expect(persist).not.toHaveBeenCalled();
   });
 
   it('live KACG nudge handler: with multiple subscribed-unbound CGs, binds + reconciles ONLY the one matching the event id', async () => {

--- a/packages/agent/test/vm-reconcile-self-prime.test.ts
+++ b/packages/agent/test/vm-reconcile-self-prime.test.ts
@@ -189,6 +189,127 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     expect(persist).not.toHaveBeenCalled();
   });
 
+  it('does not overwrite a same-object binding that lands during self-prime', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'SelfPrimeSameObjectFence', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'gh1098-same-object-self-prime';
+    const original: { subscribed: boolean; onChainId?: string } = { subscribed: true };
+    internals.subscribedContextGraphs.set(localCgId, original);
+
+    const lookup = deferred<string | null>();
+    (internals as any).getContextGraphOnChainId = async () => lookup.promise;
+    const persist = vi.fn();
+    (internals as any).persistContextGraphSubscription = persist;
+
+    const prime = internals.selfPrimeSubscriptionOnChainId(localCgId, original);
+    await Promise.resolve();
+    original.onChainId = '9002';
+    lookup.resolve('9001');
+
+    await expect(prime).resolves.toBeNull();
+    expect(original.onChainId).toBe('9002');
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('strict-persists the resolved binding before exposing it to live reconcile state', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'SelfPrimeStrictOrdering', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'gh1098-strict-ordering';
+    const original: { subscribed: boolean; onChainId?: string } = { subscribed: true };
+    internals.subscribedContextGraphs.set(localCgId, original);
+    (internals as any).getContextGraphOnChainId = async () => '9010';
+    const persistStrict = vi.fn(async (
+      _id: string,
+      candidate: { onChainId?: string },
+    ) => {
+      expect(candidate.onChainId).toBe('9010');
+      expect(original.onChainId).toBeUndefined();
+    });
+    (internals as any).persistContextGraphSubscriptionStrict = persistStrict;
+
+    await expect(internals.selfPrimeSubscriptionOnChainId(localCgId, original))
+      .resolves.toBe('9010');
+
+    expect(persistStrict).toHaveBeenCalledOnce();
+    expect(original.onChainId).toBe('9010');
+  });
+
+  it('leaves self-prime unbound when strict persistence fails', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'SelfPrimeStrictFailure', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'gh1098-strict-failure';
+    const original: { subscribed: boolean; onChainId?: string } = { subscribed: true };
+    internals.subscribedContextGraphs.set(localCgId, original);
+    (internals as any).getContextGraphOnChainId = async () => '9011';
+    (internals as any).persistContextGraphSubscriptionStrict = async () => {
+      throw new Error('subscription store unavailable');
+    };
+
+    await expect(internals.selfPrimeSubscriptionOnChainId(localCgId, original))
+      .resolves.toBeNull();
+    expect(original.onChainId).toBeUndefined();
+  });
+
+  it('rechecks the binding generation after strict self-prime persistence', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'SelfPrimeStrictGeneration', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'gh1098-strict-generation';
+    const original: { subscribed: boolean; onChainId?: string } = { subscribed: true };
+    internals.subscribedContextGraphs.set(localCgId, original);
+    (internals as any).getContextGraphOnChainId = async () => '9012';
+    const persisted = deferred<void>();
+    let markPersistStarted!: () => void;
+    const persistStarted = new Promise<void>((resolve) => { markPersistStarted = resolve; });
+    (internals as any).persistContextGraphSubscriptionStrict = async () => {
+      markPersistStarted();
+      await persisted.promise;
+    };
+
+    const prime = internals.selfPrimeSubscriptionOnChainId(localCgId, original);
+    await persistStarted;
+    (internals as any).bindSubscriptionOnChainId(localCgId, original, '9999');
+    original.onChainId = undefined;
+    persisted.resolve();
+
+    await expect(prime).resolves.toBeNull();
+    expect(original.onChainId).toBeUndefined();
+  });
+
+  it('settles promptly on lifecycle abort even when the lookup ignores its signal', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'SelfPrimeAbortRace', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = 'gh1098-abort-race';
+    const original = { subscribed: true };
+    internals.subscribedContextGraphs.set(localCgId, original);
+    (internals as any).getContextGraphOnChainId = async () => new Promise<string | null>(() => undefined);
+    const persist = vi.fn();
+    (internals as any).persistContextGraphSubscription = persist;
+    const controller = new AbortController();
+
+    const prime = internals.selfPrimeSubscriptionOnChainId(
+      localCgId,
+      original,
+      undefined,
+      () => !controller.signal.aborted,
+      controller.signal,
+    );
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(prime).resolves.toBeNull();
+    expect(persist).not.toHaveBeenCalled();
+  });
+
   it('live KACG nudge handler: with multiple subscribed-unbound CGs, binds + reconciles ONLY the one matching the event id', async () => {
     // Exercises the EXACT branch the live `onKARegisteredToContextGraph` poller
     // hook runs (extracted to `handleKARegisteredNudge`), not just the underlying

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -218,6 +218,7 @@ import { drainCatchupJobs } from './catchup-telemetry.js';
 import {
   beginGracefulShutdown,
   buildProducerQuiescentTeardownSteps,
+  closeDaemonBackingStoresAfterTeardown,
   runProducerQuiescentTeardown,
 } from './teardown.js';
 import {
@@ -3834,16 +3835,17 @@ export async function runDaemonInner(
           );
         }
 
-        // Stop the managed Oxigraph child AFTER the agent has stopped
-        // issuing store queries, so an in-flight SPARQL request never
-        // races the killed server. No-op when not using oxigraph-server.
-        await managedOxigraph
-          ?.stop()
-          .catch((err: any) =>
-            log(`Managed Oxigraph stop error: ${err?.message ?? String(err)}`),
-          );
-        dashDb.close();
-        log("Stopped.");
+        // Stop backing stores only after physical agent work retired. A typed
+        // retirement timeout is a dependency quarantine, not an ordinary
+        // best-effort cleanup failure: killing Oxigraph/SQLite underneath the
+        // still-running writer would defeat the agent's fail-stop boundary.
+        const backingStoresClosed = await closeDaemonBackingStoresAfterTeardown(teardown, {
+          retryAgentStop: () => agent.stop(),
+          stopManagedOxigraph: () => managedOxigraph?.stop() ?? Promise.resolve(),
+          closeDashboardDb: () => dashDb.close(),
+          log,
+        });
+        if (backingStoresClosed) log("Stopped.");
       } finally {
         await cleanupStateFiles();
       }

--- a/packages/cli/src/daemon/teardown.ts
+++ b/packages/cli/src/daemon/teardown.ts
@@ -153,6 +153,20 @@ export interface TeardownStepFailure {
 export interface TeardownOutcome {
   /** Empty on a fully clean teardown. Order matches execution order. */
   failures: TeardownStepFailure[];
+  /** Agent physical work is still alive; backing stores must remain open. */
+  dependencyQuarantined: boolean;
+}
+
+const DEPENDENCY_QUARANTINE_ERROR_CODES = new Set([
+  'VmReconcileShutdownTimeout',
+  'CG_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT',
+]);
+
+function isDependencyQuarantineError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && DEPENDENCY_QUARANTINE_ERROR_CODES.has(String((error as { code?: unknown }).code));
 }
 
 /**
@@ -213,18 +227,58 @@ export async function runProducerQuiescentTeardown(
   log: (message: string) => void = () => {},
 ): Promise<TeardownOutcome> {
   const failures: TeardownStepFailure[] = [];
+  let dependencyQuarantined = false;
   for (const step of TEARDOWN_ORDER) {
     try {
       await steps[step]();
     } catch (error) {
       failures.push({ step, error });
+      if (step === 'stopAgent' && isDependencyQuarantineError(error)) {
+        dependencyQuarantined = true;
+      }
       log(
         `[shutdown] teardown step "${step}" failed: ` +
           `${error instanceof Error ? error.message : String(error)} — continuing with the rest.`,
       );
     }
   }
-  return { failures };
+  return { failures, dependencyQuarantined };
+}
+
+export async function closeDaemonBackingStoresAfterTeardown(
+  outcome: TeardownOutcome,
+  deps: {
+    retryAgentStop: () => Promise<void>;
+    stopManagedOxigraph: () => Promise<void>;
+    closeDashboardDb: () => void;
+    log: (message: string) => void;
+  },
+): Promise<boolean> {
+  if (outcome.dependencyQuarantined) {
+    deps.log(
+      '[shutdown] backing stores remain live because agent physical work did not retire; '
+      + 'retrying retirement until it succeeds or the outer shutdown deadline forces exit',
+    );
+    while (true) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      try {
+        await deps.retryAgentStop();
+        break;
+      } catch (error) {
+        if (isDependencyQuarantineError(error)) continue;
+        deps.log(
+          `[shutdown] agent retirement retry completed with a non-quarantine error: `
+          + `${error instanceof Error ? error.message : String(error)}; continuing backing-store teardown`,
+        );
+        break;
+      }
+    }
+  }
+  await deps.stopManagedOxigraph().catch((error: unknown) => {
+    deps.log(`Managed Oxigraph stop error: ${error instanceof Error ? error.message : String(error)}`);
+  });
+  deps.closeDashboardDb();
+  return true;
 }
 
 /**

--- a/packages/cli/src/daemon/teardown.ts
+++ b/packages/cli/src/daemon/teardown.ts
@@ -36,6 +36,10 @@
 //     that belong to them — numerator and denominator from different
 //     lifecycles.
 
+import {
+  CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_ERROR_CODE,
+  VM_RECONCILE_SHUTDOWN_TIMEOUT_ERROR_CODE,
+} from '@origintrail-official/dkg-agent';
 import { CATCHUP_SHUTDOWN_DRAIN_BUDGET_MS } from './catchup-telemetry.js';
 
 /**
@@ -157,9 +161,9 @@ export interface TeardownOutcome {
   dependencyQuarantined: boolean;
 }
 
-const DEPENDENCY_QUARANTINE_ERROR_CODES = new Set([
-  'VmReconcileShutdownTimeout',
-  'CG_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT',
+const DEPENDENCY_QUARANTINE_ERROR_CODES = new Set<string>([
+  VM_RECONCILE_SHUTDOWN_TIMEOUT_ERROR_CODE,
+  CONTEXT_GRAPH_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT_ERROR_CODE,
 ]);
 
 function isDependencyQuarantineError(error: unknown): boolean {

--- a/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
+++ b/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
@@ -77,8 +77,10 @@ const {
 const {
   beginGracefulShutdown,
   buildProducerQuiescentTeardownSteps,
+  closeDaemonBackingStoresAfterTeardown,
   runProducerQuiescentTeardown,
 } = await import('../src/daemon/teardown.js');
+const { raceShutdownWithTimeout } = await import('../src/daemon/shutdown.js');
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -954,6 +956,83 @@ describe('A24 — a failing step never strands the steps after it', () => {
     const { steps } = recordingSteps();
     const outcome = await runProducerQuiescentTeardown(steps);
     expect(outcome.failures).toEqual([]);
+    expect(outcome.dependencyQuarantined).toBe(false);
+  });
+
+  it.each([
+    'VmReconcileShutdownTimeout',
+    'CG_MEMBERSHIP_PERSIST_SHUTDOWN_TIMEOUT',
+  ])('quarantines backing stores when stopAgent fails with %s', async (code) => {
+    const { steps } = recordingSteps();
+    steps.stopAgent = async () => {
+      throw Object.assign(new Error('physical work still active'), { code });
+    };
+    const outcome = await runProducerQuiescentTeardown(steps);
+    const stopManagedOxigraph = vi.fn(async () => undefined);
+    const closeDashboardDb = vi.fn();
+    const logged: string[] = [];
+    const retryAgentStop = vi.fn(async () => undefined);
+
+    expect(outcome.dependencyQuarantined).toBe(true);
+    await expect(closeDaemonBackingStoresAfterTeardown(outcome, {
+      retryAgentStop,
+      stopManagedOxigraph,
+      closeDashboardDb,
+      log: (message) => logged.push(message),
+    })).resolves.toBe(true);
+    expect(retryAgentStop).toHaveBeenCalledOnce();
+    expect(stopManagedOxigraph).toHaveBeenCalledOnce();
+    expect(closeDashboardDb).toHaveBeenCalledOnce();
+    expect(logged.join(' ')).toContain('backing stores remain live');
+  });
+
+  it('still closes backing stores after an ordinary agent-stop failure', async () => {
+    const { steps } = recordingSteps('stopAgent');
+    const outcome = await runProducerQuiescentTeardown(steps);
+    const stopManagedOxigraph = vi.fn(async () => undefined);
+    const closeDashboardDb = vi.fn();
+
+    await expect(closeDaemonBackingStoresAfterTeardown(outcome, {
+      retryAgentStop: vi.fn(async () => undefined),
+      stopManagedOxigraph,
+      closeDashboardDb,
+      log: () => undefined,
+    })).resolves.toBe(true);
+    expect(stopManagedOxigraph).toHaveBeenCalledOnce();
+    expect(closeDashboardDb).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a permanent retirement quarantine pending through the hard shutdown deadline', async () => {
+    const outcome = {
+      failures: [{
+        step: 'stopAgent' as const,
+        error: Object.assign(new Error('still active'), { code: 'VmReconcileShutdownTimeout' }),
+      }],
+      dependencyQuarantined: true,
+    };
+    let canRetire = false;
+    const stopManagedOxigraph = vi.fn(async () => undefined);
+    const closeDashboardDb = vi.fn();
+    const cleanup = closeDaemonBackingStoresAfterTeardown(outcome, {
+      retryAgentStop: async () => {
+        if (!canRetire) {
+          throw Object.assign(new Error('still active'), { code: 'VmReconcileShutdownTimeout' });
+        }
+      },
+      stopManagedOxigraph,
+      closeDashboardDb,
+      log: () => undefined,
+    }).then(() => undefined);
+
+    await expect(raceShutdownWithTimeout(cleanup, 250, () => undefined))
+      .resolves.toEqual({ forced: true });
+    expect(stopManagedOxigraph).not.toHaveBeenCalled();
+    expect(closeDashboardDb).not.toHaveBeenCalled();
+
+    canRetire = true;
+    await cleanup;
+    expect(stopManagedOxigraph).toHaveBeenCalledOnce();
+    expect(closeDashboardDb).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -294,6 +294,7 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       start: vi.fn(async () => undefined),
       stop: vi.fn(async () => undefined),
       publishProfile: vi.fn(async () => undefined),
+      ensureProfilePublished: vi.fn(async () => undefined),
       publishRelayRegistry: vi.fn(async () => undefined),
       ensureContextGraphLocal: vi.fn(async () => undefined),
       getSubscribedContextGraphs: vi.fn(() => new Map()),

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -1329,9 +1329,11 @@ export async function withMaterializationLock<T>(
   metaGraph: string,
   ual: string,
   fn: () => Promise<T>,
+  options: { signal?: AbortSignal } = {},
 ): Promise<T> {
   const key = `${metaGraph}\u0000${ual}`;
   const prev = _materializationLocks.get(key);
+  let entered = false;
   // Build our work promise so subsequent callers can chain after us
   // BEFORE we start awaiting prev (otherwise two near-simultaneous
   // callers would both see `prev === undefined` and run in parallel).
@@ -1339,17 +1341,49 @@ export async function withMaterializationLock<T>(
     if (prev) {
       try { await prev; } catch { /* prev's caller already handled it */ }
     }
+    if (options.signal?.aborted) {
+      throw new DOMException('Materialization lock wait aborted', 'AbortError');
+    }
+    entered = true;
     return fn();
   })();
   _materializationLocks.set(key, work);
-  try {
-    return await work;
-  } finally {
+  // Cleanup follows the serialized tail, not the caller-facing abort race. If
+  // a waiter aborts behind an active owner, deleting the key immediately would
+  // let a third writer bypass that owner and violate the TOCTOU guarantee.
+  void work.finally(() => {
     // GC: if no one else queued after us, drop the entry so the map
     // doesn't grow unbounded across long-running daemons.
     if (_materializationLocks.get(key) === work) {
       _materializationLocks.delete(key);
     }
+  }).catch(() => undefined);
+  if (!options.signal) return work;
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<T>((_resolve, reject) => {
+    onAbort = () => {
+      // Once the critical section has started it is an atomic durability unit:
+      // its caller must observe its real completion before shutdown can close
+      // the store. Cancellation only removes callers still waiting for the
+      // previous owner; it must never detach an entered writer.
+      if (entered) return;
+      // An aborted waiter that never entered the critical section contributes
+      // no serialization work. Restore the prior owner as the visible tail so
+      // repeated stop/restart cycles cannot accumulate an unbounded promise
+      // chain behind one physically hung store mutation.
+      if (!entered && prev && _materializationLocks.get(key) === work) {
+        _materializationLocks.set(key, prev);
+      }
+      reject(new DOMException('Materialization lock wait aborted', 'AbortError'));
+    };
+    if (options.signal!.aborted) onAbort();
+    else options.signal!.addEventListener('abort', onAbort, { once: true });
+  });
+  try {
+    return entered ? await work : await Promise.race([work, aborted]);
+  } finally {
+    if (onAbort) options.signal.removeEventListener('abort', onAbort);
   }
 }
 

--- a/packages/publisher/test/materialization-lock.test.ts
+++ b/packages/publisher/test/materialization-lock.test.ts
@@ -103,6 +103,55 @@ describe('withMaterializationLock — serialises check + write per (metaGraph, u
     });
     expect(secondRan).toBe(true);
   });
+
+  it('lets an aborted waiter leave without bypassing the active same-key writer', async () => {
+    let releaseOwner!: () => void;
+    const ownerGate = new Promise<void>((resolve) => { releaseOwner = resolve; });
+    const owner = withMaterializationLock(LABEL_META, UAL, async () => ownerGate);
+    const controller = new AbortController();
+    let waiterRan = false;
+    const waiter = withMaterializationLock(LABEL_META, UAL, async () => {
+      waiterRan = true;
+    }, { signal: controller.signal });
+
+    await Promise.resolve();
+    controller.abort();
+    await expect(waiter).rejects.toMatchObject({ name: 'AbortError' });
+    expect(waiterRan).toBe(false);
+
+    let successorRan = false;
+    const successor = withMaterializationLock(LABEL_META, UAL, async () => {
+      successorRan = true;
+    });
+    await Promise.resolve();
+    expect(successorRan).toBe(false);
+
+    releaseOwner();
+    await Promise.all([owner, successor]);
+    expect(successorRan).toBe(true);
+  });
+
+  it('waits for an entered atomic writer even when its signal aborts', async () => {
+    const controller = new AbortController();
+    let release!: () => void;
+    let entered!: () => void;
+    const enteredGate = new Promise<void>((resolve) => { entered = resolve; });
+    const workGate = new Promise<void>((resolve) => { release = resolve; });
+    let settled = false;
+    const owner = withMaterializationLock(LABEL_META, UAL, async () => {
+      entered();
+      await workGate;
+      return 'committed';
+    }, { signal: controller.signal }).finally(() => { settled = true; });
+
+    await enteredGate;
+    controller.abort();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    release();
+    await expect(owner).resolves.toBe('committed');
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

- Preserve configured numeric sync priorities while guaranteeing one bounded service turn for aged lower-priority work. The existing global scheduler remains work-conserving: no slot is reserved, active work is not preempted, and foreground catch-up can no longer be displaced indefinitely by reconnect/reconcile churn.
- Carry a private `found | clean-absent | incomplete` disposition through the existing exact-request single-flight, rotate each missing VM slot/fingerprint across a bounded canonical peer roster, and enter exponential backoff only after every current candidate independently proves clean absence. Suppressed passes perform no discovery, dial, protocol probe, or decision-only store/chain work.
- Bound exact-response accumulation before decode/materialization, page oversized curator peer registries, and cap/process-clean all new recovery, binding, negative-cache, and membership-persistence state.
- Harden graph-scoped sync across unsubscribe, rebind, restart, and shutdown: capture binding generations before authentication, reject conflicting same-name chain slots, serialize strict subscription persistence, keep materialization atomic, and physically drain admitted authentication/persistence/materialization before backing stores close.
- Preserve fail-closed chain authentication and legacy/system-graph repair. This PR relieves the measured pressure but intentionally does not claim complete resolution of #2052's unchanged legacy replay.

## Related

- Partially addresses #2052
- Regression context: #2050
- Related scheduler/read-admission work: #2051
- Fairness, compatibility, lifecycle, and bounds follow-ups: #2054, #2055, #2056, #2057, #2058
- Crash consistency, bounded-work, and observability follow-ups: #2060, #2061, #2062, #2063
- Persistence and lifecycle ownership refactors: #2064, #2065, #2068, #2069, #2070

## Diagrams

### Global sync admission

Before:

```mermaid
sequenceDiagram
    participant Foreground
    participant Queue
    participant Background
    participant Worker
    Background->>Queue: Enqueue older reconnect/reconcile work
    Foreground->>Queue: Enqueue priority 2000 catch-up
    Worker-->>Queue: Release a global slot
    Queue->>Worker: Start aged background by effective priority
    Queue-->>Foreground: Remain queued or be displaced
```

After:

```mermaid
sequenceDiagram
    participant Foreground
    participant Queue
    participant Background
    participant Worker
    Background->>Queue: Enqueue lower-priority reconnect/reconcile work
    Foreground->>Queue: Enqueue priority 2000 catch-up
    Worker-->>Queue: Release a global slot
    Queue->>Worker: Start highest raw priority when no debt is owed
    Queue-->>Foreground: Foreground starts at the bounded release
    Worker-->>Queue: Release the next slot
    Queue->>Worker: Serve one retained aged debt without idling capacity
```

### Missing VM asset recovery

Before:

```mermaid
sequenceDiagram
    participant Sweep
    participant Recovery
    participant Roster
    participant Peer
    participant ChainStore
    Sweep->>ChainStore: Reconcile missing ordinal
    Sweep->>Recovery: Recover missing asset
    Recovery->>Roster: Resolve and prepare peers each sweep
    Recovery->>Peer: Exact fetch
    Peer-->>Recovery: Empty or incomplete aggregate result
    Recovery->>ChainStore: Reconcile again
    Sweep->>Recovery: Retry without slot-specific absence proof
```

After:

```mermaid
sequenceDiagram
    participant Sweep
    participant Recovery
    participant Roster
    participant Peer
    participant ChainStore
    Sweep->>ChainStore: Reconcile missing ordinal and fingerprint
    Sweep->>Recovery: Check bounded slot record
    alt Backoff proof is current
        Recovery-->>Sweep: Suppress before roster, dial, or admission work
    else Fresh candidate evidence required
        Recovery->>Roster: Resolve bounded canonical candidates
        Recovery->>Peer: Fresh exact fetch from an uncredited peer
        Peer-->>Recovery: Found, clean-absent, or incomplete
        Recovery->>ChainStore: Authenticate and reconcile current binding
        Recovery-->>Sweep: Back off only after a complete clean-absence rotation
    end
```

### Graph-scoped shutdown ownership

Before:

```mermaid
sequenceDiagram
    participant DurableSync
    participant Agent
    participant Chain
    participant Store
    participant Daemon
    DurableSync->>Agent: Store verified graph-scoped asset
    Agent->>Chain: Authenticate asset and binding
    Daemon->>Agent: Stop node
    Agent-->>Daemon: VM reconcile work retired
    Daemon->>Store: Close backing stores
    Chain-->>Agent: Authentication completes late
    Agent->>Store: Persist binding or materialize after teardown
```

After:

```mermaid
sequenceDiagram
    participant DurableSync
    participant Agent
    participant Chain
    participant Store
    participant Daemon
    DurableSync->>Agent: Store verified graph-scoped asset
    Agent->>Agent: Register deferred physical store promise
    Agent->>Chain: Authenticate captured binding generation
    Daemon->>Agent: Stop node and close admission
    Agent->>Agent: Drain all admitted graph-scoped work
    Chain-->>Agent: Authentication completes
    Agent->>Store: Strictly persist and atomically materialize if current
    Store-->>Agent: Physical work settles
    Agent-->>Daemon: Retirement complete or typed quarantine
    Daemon->>Store: Close only after retirement
```

## Files changed

| File | What |
|------|------|
| `packages/agent/src/sync/priority-admission-queue.ts`, `packages/agent/src/sync/backpressure.ts` | Preserve raw priority, add one bounded aged-service debt, protect an aged displacement recipient, and keep queue timing monotonic/work-conserving. |
| `packages/agent/src/sync/requester/*`, `packages/agent/src/sync/exact-assets.ts` | Derive exact-fetch dispositions from fresh complete phase evidence, share physical results across coalesced callers, and cap cumulative accepted bytes/quads. |
| `packages/agent/src/dkg-agent-swm-host.ts`, `packages/agent/src/vm-reconcile-service.ts` | Add bounded slot/fingerprint peer rotations, proof expiry/backoff, currentness guards, paged curator walking, and lifecycle cleanup. |
| `packages/agent/src/dkg-agent*.ts`, `packages/agent/src/context-graph-*.ts` | Fence subscription/binding persistence, bound membership writes, capture binding generations, and physically own graph-scoped work through shutdown. |
| `packages/agent/src/discovery.ts`, `packages/agent/src/p2p/*` | Add abortable duplicate-free curator peer paging and lifecycle-aware peer preparation. |
| `packages/publisher/src/metadata.ts` | Hold the per-KA materialization lock through stale-binding validation and compensating quarantine. |
| `packages/cli/src/daemon/lifecycle.ts`, `packages/cli/src/daemon/teardown.ts` | Keep backing stores alive while typed sync retirement quarantine is retried or forces a nonzero hard-timeout exit. |
| `packages/agent/test/*`, `packages/publisher/test/*`, `packages/cli/test/*` | Cover fairness, exact evidence, bounded state, discovery, binding races, atomic materialization, restart, and shutdown fault paths. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-agent exec tsc --noEmit`
- [x] `pnpm --filter @origintrail-official/dkg exec tsc --noEmit`
- [x] `pnpm --filter @origintrail-official/dkg-publisher exec tsc --noEmit`
- [x] 18-file final sync/reconcile matrix: 475 tests passed
- [x] Exact-requester matrix: 79 tests passed
- [x] CLI teardown/quarantine matrix: 36 tests passed
- [x] Publisher materialization-lock matrix: 8 tests passed
- [x] Detached final-head workspace build at `4bd402de89af4b73a200cf120796c3617474edbe`
- [x] Three independent final adversarial reviews: protocol, fault injection, and resource/liveness; no blockers remain
- [x] `git diff --check` and clean final candidate worktree
- [x] Matched Base Sepolia fixture-A baseline/candidate run from the same immutable receiver snapshot: candidate materialized 57 versus 19 VM asset graphs, reduced maximum active age by 51.9%, reduced second-half saturation by 21.2%, and ended idle. Result is intentionally **inconclusive** for a regression-free claim because the curator was unreachable, no clean-absence rotation formed, final work was unequal, and resource/API ceilings need controlled retest.
- [ ] Post-merge Blackbox conductor run on `testnet-canary`: require full VM convergence, clean-absence/backoff suppression, curator-arrival freshness, foreground fairness, and normalized API/Oxigraph resource ceilings before promotion beyond canary.
