### PR TITLE
fix(chain): select at most two provider origins so shipped RPC pools construct

### DIFF
--- a/packages/agent/test/rfc64-finalized-vm-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-agent-precommit-v1.test.ts
@@ -1,30 +1,17 @@
-import {
-  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
-  type AuthorCatalogScopeV1,
-  type ContextGraphPolicyV1,
-  type Digest32V1,
-} from '@origintrail-official/dkg-core';
-import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AcceptedRfc64CatalogAccessSnapshotV1 } from '../src/rfc64/catalog-access-policy-v1.js';
 import { createRfc64FinalizedVmAgentPrecommitV1 } from '../src/rfc64/finalized-vm-agent-precommit-v1.js';
-import type { Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 } from '../src/rfc64/public-catalog-native-receiver-v1.js';
 import {
-  RFC64_VM_AUTHOR,
-  RFC64_VM_BLOCK_HASH,
-  RFC64_VM_CG_STORAGE,
   RFC64_VM_CHAIN_ID,
   RFC64_VM_CONTEXT_GRAPH_NAME,
-  RFC64_VM_KAV10,
   RFC64_VM_KA_STORAGE,
-  RFC64_VM_NETWORK_ID,
   RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
-  RFC64_VM_POLICY_DIGEST,
 } from './support/rfc64-finalized-vm-placement-fixture.js';
+import {
+  rfc64FinalizedVmPrecommitOptions as baseOptions,
+  rfc64FinalizedVmPrecommitPlan as plan,
+} from './support/rfc64-finalized-vm-precommit-fixture.js';
 
-const CATALOG_HEAD_DIGEST = `0x${'91'.repeat(32)}` as Digest32V1;
-const INVENTORY_DIGEST = `0x${'92'.repeat(32)}` as Digest32V1;
 
 describe('RFC-64 finalized VM agent precommit', () => {
   it('rejects when the cleartext catalog lane has no numeric on-chain binding', async () => {
@@ -101,66 +88,5 @@ describe('RFC-64 finalized VM agent precommit', () => {
   });
 });
 
-function baseOptions() {
-  return {
-    acceptedPolicySnapshotForCatalogScope: () => acceptedPolicy(),
-    rpcEndpoints: ['http://127.0.0.1:8545'],
-    getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
-    getEvmChainId: async () => BigInt(RFC64_VM_CHAIN_ID),
-    getKnowledgeAssetStorageAddress: async () => RFC64_VM_KA_STORAGE,
-    getKnowledgeAssetsLifecycleAddress: async () => RFC64_VM_KAV10,
-    store: new OxigraphStore(),
-  } as const;
-}
 
-function plan(): Readonly<Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1> {
-  return Object.freeze({
-    catalogScope: Object.freeze({
-      networkId: RFC64_VM_NETWORK_ID,
-      contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
-      governanceChainId: RFC64_VM_CHAIN_ID,
-      governanceContractAddress: RFC64_VM_CG_STORAGE,
-      ownershipTransitionDigest: null,
-      subGraphName: null,
-      authorAddress: RFC64_VM_AUTHOR,
-      era: '0',
-      bucketCount: '1',
-    } satisfies AuthorCatalogScopeV1),
-    catalogHeadDigest: CATALOG_HEAD_DIGEST,
-    inventoryDigest: INVENTORY_DIGEST,
-    rows: Object.freeze([]),
-  });
-}
 
-function acceptedPolicy(): AcceptedRfc64CatalogAccessSnapshotV1 {
-  const policy = Object.freeze({
-    networkId: RFC64_VM_NETWORK_ID,
-    contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
-    governanceChainId: RFC64_VM_CHAIN_ID,
-    governanceContractAddress: RFC64_VM_CG_STORAGE,
-    ownershipTransitionDigest: null,
-    era: '0',
-    version: '0',
-    previousPolicyDigest: null,
-    accessPolicy: 0,
-    publishPolicy: 1,
-    publishAuthority: null,
-    publishAuthorityAccountId: '0',
-    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
-    administrativeDelegationDigest: null,
-    source: {
-      kind: 'finalized-chain',
-      chainId: RFC64_VM_CHAIN_ID,
-      contractAddress: RFC64_VM_CG_STORAGE,
-      blockNumber: '123',
-      blockHash: RFC64_VM_BLOCK_HASH,
-    },
-    effectiveAt: '1700000000000',
-    issuedAt: '1700000000000',
-  } satisfies ContextGraphPolicyV1);
-  return Object.freeze({
-    policy,
-    policyDigest: RFC64_VM_POLICY_DIGEST,
-    roster: null,
-  });
-}

--- a/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The integration seam this change exists to fix.
+ *
+ * The chain-package tests prove that `snapshotStrictCurrentFinalizedEvmConfigV1`
+ * accepts a three-endpoint pool. They do not prove the thing the change claims:
+ * that RFC64's finalized-VM precommit — the only production caller — can now
+ * construct its snapshot scope on a shipped network. That claim was previously
+ * demonstrated nowhere. The existing precommit suite hardcodes ONE endpoint
+ * (`rfc64-finalized-vm-agent-precommit-v1.test.ts`), so it constructed fine both
+ * before and after; the defect lived exactly in the gap between the two suites.
+ *
+ * So this drives the REAL precommit with the REAL shipped pool
+ * (`resolveRpcUrls(chain.rpcUrl, chain.rpcUrls)` from `network/testnet.json`,
+ * three distinct origins) and stubs only the outermost boundary — global
+ * `fetch` — so the endpoints actually dialled are observable.
+ *
+ * Before the fix this rejected with "requires 1..2 distinct endpoints" and
+ * dialled nothing. Both assertions below therefore fail on the unfixed code: the
+ * first on the message, the second on an empty dial log.
+ */
+import { resolveRpcUrls } from '@origintrail-official/dkg-chain';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createRfc64FinalizedVmAgentPrecommitV1 } from '../src/rfc64/finalized-vm-agent-precommit-v1.js';
+import {
+  rfc64FinalizedVmPrecommitOptions,
+  rfc64FinalizedVmPrecommitPlan,
+} from './support/rfc64-finalized-vm-precommit-fixture.js';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+
+/** Exactly what the daemon hands the precommit: primary PLUS backups. */
+function shippedTestnetPool(): string[] {
+  const config = JSON.parse(
+    readFileSync(join(REPO_ROOT, 'network', 'testnet.json'), 'utf8'),
+  );
+  return resolveRpcUrls(config.chain.rpcUrl, config.chain.rpcUrls);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('RFC-64 finalized VM precommit on a shipped RPC pool', () => {
+  it('constructs its snapshot scope and dials the selected endpoints', async () => {
+    const pool = shippedTestnetPool();
+    // Guards the fixture itself: if `network/testnet.json` ever ships two URLs,
+    // this test would silently stop covering the oversized-pool case.
+    expect(pool.length).toBe(3);
+    expect(new Set(pool.map((url) => new URL(url).origin)).size).toBe(3);
+
+    const dialled: string[] = [];
+    vi.stubGlobal('fetch', async (input: unknown) => {
+      dialled.push(String(input));
+      // Fail the transport, not the construction. Preflight exhausting every
+      // selected endpoint is the shortest deterministic path that still proves
+      // the scope was built and handed real URLs.
+      throw new Error('stubbed transport failure');
+    });
+
+    // Only `rpcEndpoints` varies — that is the whole point of this regression.
+    const precommit = createRfc64FinalizedVmAgentPrecommitV1(
+      rfc64FinalizedVmPrecommitOptions({ rpcEndpoints: pool }),
+    );
+
+    // The precommit still fails — there is no chain behind the stub — but it must
+    // fail at the TRANSPORT, downstream of scope construction. Every selected
+    // endpoint failing preflight retryably surfaces the last retryable failure,
+    // which is the JSON-RPC one; the pre-fix failure was a TypeError about the
+    // endpoint count, raised before any dial happened at all.
+    await expect(
+      precommit(rfc64FinalizedVmPrecommitPlan(), new AbortController().signal),
+    ).rejects.toThrow(/JSON-RPC eth_chainId transport failed/i);
+
+    // The load-bearing assertion: selection reached the wire. Two of the three
+    // shipped endpoints were dialled, in configuration order.
+    //
+    // Compared as URLs, not as raw strings: the config stores endpoints after
+    // `new URL(...)` normalization, so `https://sepolia.base.org` arrives at
+    // `fetch` with a trailing slash. Comparing `href` on both sides keeps the
+    // assertion about WHICH endpoint was dialled instead of quietly restating
+    // the normalizer's spelling rules.
+    const href = (url: string) => new URL(url).href;
+    expect([...new Set(dialled)]).toEqual([href(pool[0]!), href(pool[1]!)]);
+    // And the third is stranded — stated as a tested fact rather than left as a
+    // silent consequence. Selection is health-blind and configuration-ordered,
+    // so `base-sepolia.drpc.org` is never reached by a strict finalized read even
+    // when the primary is degraded. Tracked as a follow-up, not fixed here.
+    expect(dialled).not.toContain(href(pool[2]!));
+  });
+});
+
+

--- a/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared fixtures for the RFC-64 finalized-VM agent precommit tests.
+ *
+ * Extracted because two suites need the same plan, accepted-policy snapshot and
+ * base options while varying one field each — the shipped-pool regression only
+ * varies `rpcEndpoints`. Keeping a second copy meant a change to the plan or
+ * policy shape required synchronized edits across files before either suite's
+ * actual assertion could run.
+ *
+ * The digests are exported so a caller can assert against them rather than
+ * re-deriving the literals.
+ */
+import {
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+  type AuthorCatalogScopeV1,
+  type ContextGraphPolicyV1,
+  type Digest32V1,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+
+import type { AcceptedRfc64CatalogAccessSnapshotV1 } from '../../src/rfc64/catalog-access-policy-v1.js';
+import type { Rfc64FinalizedVmAgentPrecommitOptionsV1 } from '../../src/rfc64/finalized-vm-agent-precommit-v1.js';
+import type { Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 } from '../../src/rfc64/public-catalog-native-receiver-v1.js';
+import {
+  RFC64_VM_AUTHOR,
+  RFC64_VM_BLOCK_HASH,
+  RFC64_VM_CG_STORAGE,
+  RFC64_VM_CHAIN_ID,
+  RFC64_VM_CONTEXT_GRAPH_NAME,
+  RFC64_VM_KAV10,
+  RFC64_VM_KA_STORAGE,
+  RFC64_VM_NETWORK_ID,
+  RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+  RFC64_VM_POLICY_DIGEST,
+} from './rfc64-finalized-vm-placement-fixture.js';
+
+export const RFC64_VM_CATALOG_HEAD_DIGEST = `0x${'91'.repeat(32)}` as Digest32V1;
+export const RFC64_VM_INVENTORY_DIGEST = `0x${'92'.repeat(32)}` as Digest32V1;
+
+/** The before-applied-head commit plan the precommit is driven with. */
+export function rfc64FinalizedVmPrecommitPlan():
+Readonly<Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1> {
+  return Object.freeze({
+    catalogScope: Object.freeze({
+      networkId: RFC64_VM_NETWORK_ID,
+      contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
+      governanceChainId: RFC64_VM_CHAIN_ID,
+      governanceContractAddress: RFC64_VM_CG_STORAGE,
+      ownershipTransitionDigest: null,
+      subGraphName: null,
+      authorAddress: RFC64_VM_AUTHOR,
+      era: '0',
+      bucketCount: '1',
+    } satisfies AuthorCatalogScopeV1),
+    catalogHeadDigest: RFC64_VM_CATALOG_HEAD_DIGEST,
+    inventoryDigest: RFC64_VM_INVENTORY_DIGEST,
+    rows: Object.freeze([]),
+  });
+}
+
+/** One accepted, public, finalized-chain policy snapshot. */
+export function acceptedRfc64VmPolicySnapshot(): AcceptedRfc64CatalogAccessSnapshotV1 {
+  const policy = Object.freeze({
+    networkId: RFC64_VM_NETWORK_ID,
+    contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
+    governanceChainId: RFC64_VM_CHAIN_ID,
+    governanceContractAddress: RFC64_VM_CG_STORAGE,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy: 0,
+    publishPolicy: 1,
+    publishAuthority: null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'finalized-chain',
+      chainId: RFC64_VM_CHAIN_ID,
+      contractAddress: RFC64_VM_CG_STORAGE,
+      blockNumber: '123',
+      blockHash: RFC64_VM_BLOCK_HASH,
+    },
+    effectiveAt: '1700000000000',
+    issuedAt: '1700000000000',
+  } satisfies ContextGraphPolicyV1);
+  return Object.freeze({
+    policy,
+    policyDigest: RFC64_VM_POLICY_DIGEST,
+    roster: null,
+  });
+}
+
+/**
+ * Base precommit options. Each suite overrides the one field it is about — a
+ * single resolver for the noncanonical-input cases, `rpcEndpoints` for the
+ * shipped-pool regression.
+ *
+ * A fresh `OxigraphStore` per call: sharing one across tests would let state
+ * from an earlier case leak into a later assertion.
+ *
+ * Overrides are `Partial<Rfc64FinalizedVmAgentPrecommitOptionsV1>` rather than a
+ * loose record, so a misspelled key or a wrongly-shaped value is a type error at
+ * the call site that introduces it, not a silently-ignored property.
+ */
+export function rfc64FinalizedVmPrecommitOptions(
+  overrides: Partial<Rfc64FinalizedVmAgentPrecommitOptionsV1> = {},
+): Rfc64FinalizedVmAgentPrecommitOptionsV1 {
+  return {
+    acceptedPolicySnapshotForCatalogScope: () => acceptedRfc64VmPolicySnapshot(),
+    rpcEndpoints: ['http://127.0.0.1:8545'],
+    getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+    getEvmChainId: async () => BigInt(RFC64_VM_CHAIN_ID),
+    getKnowledgeAssetStorageAddress: async () => RFC64_VM_KA_STORAGE,
+    getKnowledgeAssetsLifecycleAddress: async () => RFC64_VM_KAV10,
+    store: new OxigraphStore(),
+    ...overrides,
+  };
+}

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -11,6 +11,7 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-finalized-vm-composer-v1.test.ts",
   "test/rfc64-finalized-vm-runtime-v1.test.ts",
   "test/rfc64-finalized-vm-agent-precommit-v1.test.ts",
+  "test/rfc64-finalized-vm-precommit-shipped-pool.test.ts",
   "test/rfc64-agent-inventory-lifecycle.test.ts",
   "test/rfc64-author-catalog-producer.test.ts",
   "test/rfc64-control-object-store-v1.test.ts",

--- a/packages/chain/src/strict-current-finalized-evm-config.ts
+++ b/packages/chain/src/strict-current-finalized-evm-config.ts
@@ -1,7 +1,13 @@
 import { assertCanonicalChainId } from '@origintrail-official/dkg-core';
 
 import { CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1 } from './current-finalized-evm-read-profile.js';
+import { normalizeEndpointOrigin } from '@origintrail-official/dkg-core';
+
 import { snapshotDenseDataArray } from './strict-local-data.js';
+import {
+  selectStrictFinalizedEndpointSessionV1,
+  type StrictFinalizedEndpointV1,
+} from './strict-finalized-endpoint-session.js';
 import {
   FINALIZED_CHAIN_READ_OWNERS,
   type FinalizedChainReadOwnerV1,
@@ -136,29 +142,101 @@ function assertConfigDataProperties(
 }
 
 function snapshotNormalizedEndpoints(input: unknown): readonly string[] {
-  const normalized: string[] = [];
+  const normalized: StrictFinalizedEndpointV1[] = [];
+  const seen = new Set<string>();
   try {
     const endpoints = snapshotDenseDataArray(input, {
       label: 'Strict current-finalized RPC endpoints',
       minLength: 1,
+      // Deliberately NOT bounded on the raw array. Base deduplicated by href
+      // BEFORE applying its count check, so a config of 33 identical URLs — or
+      // 40 entries collapsing to two — normalized to a valid pool and
+      // constructed. A cap on the raw array turns those into a construction
+      // failure and silently narrows the published contract from "at most two
+      // distinct normalized endpoints" to "at most N raw entries". The dedup
+      // below is O(n) via a Set and selection is a fixed two-slot scan, so an
+      // oversized array costs a linear pass, not quadratic work; the attempt
+      // count is bounded by selection and the postcondition regardless.
     });
     for (const entry of endpoints) {
       const endpoint = normalizeEndpoint(entry);
-      if (!normalized.includes(endpoint)) normalized.push(endpoint);
+      if (seen.has(endpoint.href)) continue;
+      seen.add(endpoint.href);
+      normalized.push(endpoint);
     }
   } catch (cause) {
     if (cause instanceof TypeError) throw cause;
-    throw new TypeError('Strict current-finalized endpoints must be a dense data-only array');
-  }
-  if (normalized.length === 0 || normalized.length > CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1) {
+    // `cause` preserved: this catch flattens whatever `snapshotDenseDataArray`
+    // reports into a single shape complaint, so the specific detail is otherwise
+    // unrecoverable by a caller. The message is left alone because tests pin it.
     throw new TypeError(
-      `Strict current-finalized RPC requires 1..${CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1} distinct endpoints`,
+      'Strict current-finalized endpoints must be a dense data-only array',
+      { cause },
     );
   }
-  return Object.freeze(normalized);
+  // No emptiness check here: `snapshotDenseDataArray(..., { minLength: 1 })`
+  // above already rejects an empty pool, and a non-empty pool either throws in
+  // `normalizeEndpoint` or yields at least one entry. A second check would be
+  // unreachable, and its old message advertised the `1..2` contract this change
+  // deliberately replaced.
+
+  // Session selection. Every endpoint above has already been validated and
+  // deduplicated by URL, so an invalid entry anywhere in the pool still fails
+  // closed — selection only decides which of the VALID ones this session uses.
+  //
+  // Before this, a pool larger than the attempt ceiling was fatal:
+  // `resolveRpcUrls(chain.rpcUrl, chain.rpcUrls)` is three URLs on testnet,
+  // mainnet-base and mainnet-gnosis, so RFC64's finalized-VM precommit could not
+  // construct a snapshot scope on any shipped EVM network. Selecting at most two
+  // distinct provider ORIGINS satisfies the ceiling by construction, which is
+  // why the ceiling itself is left untouched.
+  const selected = selectStrictFinalizedEndpointSessionV1(normalized);
+
+  // Postcondition, not paranoia. The attempt ceiling used to be enforced HERE by
+  // rejecting oversized pools; that rejection is what this change removes. But
+  // the runner does not read `maxAttempts` — it attempts one endpoint per entry
+  // of this list (`strict-current-finalized-evm-lifecycle.ts:104`) — so the
+  // value attested as `CONTROL_EIP1271_MAX_ATTEMPTS_V1` and verified at
+  // `current-finalized-evm-call.ts:182` is truthful ONLY while this list is
+  // bounded. Leaving that to a `>=` inside another module would make an attested
+  // claim depend on a remote implementation detail; a caller passing a bad bound
+  // there would silently widen the attempt count instead of failing closed.
+  //
+  // This guards the GENERIC constant, not the attested one, and that is the
+  // correct layering: `current-finalized-evm-read-profile.ts` states these limits
+  // belong to the generic finalized-read boundary and that EIP-1271 is one
+  // specialization which must not implicitly redefine unrelated finalized reads.
+  // Importing the control constant here would invert that dependency. The guard
+  // therefore protects the attested value via the alias at
+  // `control-object-signature-verifier.ts:56`, and that alias is already pinned
+  // by `strict-current-finalized-evm-rpc.unit.test.ts` ("keeps the EIP-1271
+  // specialization pinned to the generic finalized-read profile"), so it cannot
+  // be broken silently — verified by mutating the alias to its own literal,
+  // which that test kills.
+  if (selected.length > CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1) {
+    throw new TypeError(
+      'Strict current-finalized endpoint selection exceeded the attested attempt ceiling',
+    );
+  }
+  return Object.freeze([...selected]);
 }
 
-function normalizeEndpoint(input: unknown): string {
+/**
+ * The canonical endpoint boundary: one pass that yields BOTH the dial URL and
+ * the provider-origin identity selection needs.
+ *
+ * Deriving the origin here rather than in the selector means the URL is parsed
+ * once, and the selector becomes a policy over an already-valid model instead of
+ * a second validator defending against states this function has already made
+ * impossible.
+ *
+ * The origin comes from core's `normalizeEndpointOrigin` — the same predicate
+ * `canonicalPageProof` uses to decide `dual-origin-corroborated`, so the two
+ * layers cannot drift. It is handed `url.origin`, never the full dial URL: core
+ * bounds its input at the canonical scalar limit, and applying that to the whole
+ * URL would impose a length limit RPC endpoints never had.
+ */
+function normalizeEndpoint(input: unknown): StrictFinalizedEndpointV1 {
   if (typeof input !== 'string' || input.trim() === '') {
     throw new TypeError('Strict current-finalized RPC endpoint must be a nonempty URL string');
   }
@@ -171,7 +249,21 @@ function normalizeEndpoint(input: unknown): string {
   if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.hash !== '') {
     throw new TypeError('Strict current-finalized RPC endpoint must use HTTP(S) without a fragment');
   }
-  return url.href;
+  let origin: string;
+  try {
+    origin = normalizeEndpointOrigin(url.origin, 'strict current-finalized RPC endpoint origin');
+  } catch (cause) {
+    // Core throws `VmUpdateConvergenceError`, which extends `Error`, while every
+    // rejection in this module is a `TypeError`. http(s) URLs always have a
+    // tuple origin so this is not reachable from the scheme check above, but the
+    // conversion keeps the module's error contract total rather than resting on
+    // that argument.
+    throw new TypeError(
+      'Strict current-finalized RPC endpoint has no usable provider origin',
+      { cause },
+    );
+  }
+  return Object.freeze({ href: url.href, origin });
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/chain/src/strict-finalized-endpoint-session.ts
+++ b/packages/chain/src/strict-finalized-endpoint-session.ts
@@ -1,0 +1,108 @@
+/**
+ * Endpoint policy for strict finalized reads: two slots, distinct provider
+ * origins preferred.
+ *
+ * Before this existed, a runtime RPC pool larger than the attempt ceiling was
+ * fatal rather than merely inconvenient: `resolveRpcUrls(chain.rpcUrl,
+ * chain.rpcUrls)` yields **three** URLs on testnet, mainnet-base and
+ * mainnet-gnosis, while `snapshotNormalizedEndpoints` rejected more than
+ * `CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1 = 2` distinct endpoints — so
+ * RFC64's finalized-VM precommit could not construct a snapshot scope on any
+ * shipped EVM network.
+ *
+ * This module is POLICY ONLY. Validation, parsing, origin derivation and
+ * deduplication all belong to the endpoint boundary in
+ * `strict-current-finalized-evm-config.ts`, which hands over an already-valid
+ * `{ href, origin }` model. That is why there is no input validation here: the
+ * states a second validator would defend against cannot reach it.
+ *
+ * **Why prefer a distinct origin over configuration order.** The selected array
+ * is consumed as an ordered failover list, so preferring a distinct origin can
+ * skip an earlier same-origin URL: `[KEY_A, KEY_B, backup]` selects
+ * `[KEY_A, backup]` and never attempts `KEY_B`. That is a deliberate trade and
+ * not a free one. Two credentials behind one load balancer share a provider, so
+ * the dominant failure mode — that provider down, or rate-limiting the account —
+ * takes both out together and leaves a same-origin pair with no working endpoint
+ * at all. A distinct origin is the only selection that survives it. The case the
+ * trade loses is narrower: KEY_A degraded, KEY_B healthy, AND the distinct
+ * origin also down. With two slots and three endpoints some configured URL is
+ * skipped under every possible policy; this picks the one that keeps failover
+ * across providers.
+ *
+ * **Backfill preserves base behaviour.** When no second origin exists, the
+ * second configured URL is used anyway. At base a two-URL same-origin pool
+ * constructed as two dialable endpoints, and collapsing it to one would halve
+ * failover for a deliberate operator config.
+ *
+ * Order is always the caller's configuration order — both slots are taken from
+ * the pool front-to-back, so no ordering repair is needed or performed.
+ */
+import {
+  CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1,
+} from './current-finalized-evm-read-profile.js';
+
+/**
+ * The number of slots this policy fills, as a LITERAL rather than an alias of
+ * the attempt ceiling.
+ *
+ * The algorithm is genuinely fixed at two — first URL, then the first later URL
+ * with a different origin — so aliasing the ceiling would export a value that
+ * can change while the behaviour does not. Raising the ceiling to 3 would have
+ * made this constant read 3 while selection still returned two endpoints.
+ */
+const SLOTS = 2;
+
+// COMPILE-TIME assertion that the ceiling this policy is written against has not
+// moved. `CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1` is declared as `= 2`, so
+// its inferred type is the literal `2`; raising it makes this line a type error
+// and `tsc` fails the build.
+//
+// Deliberately a type, not a runtime check. An earlier revision threw at module
+// load, which enforced the same invariant but made a constant change surface as
+// a package that will not import, and forced the test for it to mock module
+// loading. This costs nothing at runtime, cannot be skipped the way a test can,
+// and reports at the place the mistake is made.
+// The assigned value must be `true`, NOT a cast. An earlier revision wrote
+// `undefined as never`, which type-checks against `never` and made the whole
+// assertion decorative — it could not fail. Verified by flipping the ceiling to
+// 3 and confirming `tsc` errors here.
+type AssertPolicyMatchesCeiling =
+  [typeof CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1] extends [typeof SLOTS] ? true : never;
+const _assertPolicyMatchesCeiling: AssertPolicyMatchesCeiling = true;
+void _assertPolicyMatchesCeiling;
+
+/** One validated endpoint: what to dial, and which provider it belongs to. */
+export interface StrictFinalizedEndpointV1 {
+  /** Normalized absolute URL, as produced by the config's endpoint boundary. */
+  readonly href: string;
+  /** Provider identity — core's origin rule, NOT the URL. */
+  readonly origin: string;
+}
+
+/**
+ * Pick the endpoints one strict finalized session may dial, in configuration
+ * order: the first endpoint, then the first later endpoint with a DIFFERENT
+ * provider origin, falling back to the second when the pool offers only one
+ * origin.
+ *
+ * Expects a non-empty, already-validated, already-deduplicated pool.
+ */
+export function selectStrictFinalizedEndpointSessionV1(
+  endpoints: readonly StrictFinalizedEndpointV1[],
+): readonly string[] {
+  const first = endpoints[0];
+  if (first === undefined) {
+    // Not reachable from the config, whose `snapshotDenseDataArray(..., {
+    // minLength: 1 })` rejects an empty pool first. Kept because an empty
+    // selection returned as a valid session would dial nothing, and a caller
+    // could read a zero-attempt result as a successful one.
+    throw new TypeError('Strict finalized endpoint selection requires at least one endpoint');
+  }
+
+  const distinctOrigin = endpoints
+    .slice(1)
+    .find((endpoint) => endpoint.origin !== first.origin);
+  const second = distinctOrigin ?? endpoints[1];
+
+  return Object.freeze(second === undefined ? [first.href] : [first.href, second.href]);
+}

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -4,6 +4,8 @@ import {
 } from '@origintrail-official/dkg-core';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { snapshotStrictCurrentFinalizedEvmConfigV1 } from '../src/strict-current-finalized-evm-config.js';
+
 import {
   CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
   CONTROL_EIP1271_CALL_FROM_V1,
@@ -873,24 +875,51 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
     expect(second.calls).toHaveLength(4);
   }, 12_000);
 
-  it('rejects unsafe configuration and more than two distinct normalized endpoints', () => {
+  it('rejects unsafe configuration', () => {
     const third = 'http://127.0.0.1:3';
     for (const config of [
       { chainId: '020430', endpoints: ['http://127.0.0.1:1'] },
       { chainId: CHAIN_ID, endpoints: [] },
       { chainId: CHAIN_ID, endpoints: ['ftp://127.0.0.1/a'] },
       { chainId: CHAIN_ID, endpoints: ['http://127.0.0.1/a#fragment'] },
-      { chainId: CHAIN_ID, endpoints: [
-        'http://127.0.0.1:1',
-        'http://127.0.0.1:2',
-        third,
-      ] },
       { chainId: CHAIN_ID, endpoints: ['http://127.0.0.1:1'], peerEndpoint: third },
     ]) {
       expect(() => createStrictCurrentFinalizedEvmChainAdapterV1(
         config as StrictCurrentFinalizedEvmRpcConfigV1,
       )).toThrow(TypeError);
     }
+  });
+
+  it('SELECTS the first two origins from a larger pool instead of rejecting it', () => {
+    // Behaviour change, and the point of the change. This case previously sat in
+    // the rejection list above — which is precisely why RFC64's finalized-VM
+    // precommit could not construct a scope on any shipped EVM network, where
+    // `resolveRpcUrls(rpcUrl, rpcUrls)` yields three URLs.
+    //
+    // The two-endpoint ATTEMPT ceiling is unchanged; selection just makes sure
+    // no more than two ever reach it. The dedup-then-ceiling test above still
+    // pins that ceiling.
+    // Assert WHICH two, not merely that it constructed — "returns a function"
+    // would pass just as green if selection kept the last two, or one, or all.
+    // Driven through the CONFIG boundary rather than the selector directly: the
+    // config is what derives provider identity, so this exercises the real
+    // pipeline instead of hand-built records.
+    const selection = snapshotStrictCurrentFinalizedEvmConfigV1({
+      chainId: CHAIN_ID,
+      endpoints: ['http://127.0.0.1:1', 'http://127.0.0.1:2', 'http://127.0.0.1:3'],
+    } as never).endpoints;
+    // Distinct ports are distinct origins, so this session really does carry two
+    // providers — and the third is dropped, not merged.
+    expect(selection).toEqual(['http://127.0.0.1:1/', 'http://127.0.0.1:2/']);
+
+    expect(() => createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [
+        'http://127.0.0.1:1',
+        'http://127.0.0.1:2',
+        'http://127.0.0.1:3',
+      ],
+    } as StrictCurrentFinalizedEvmRpcConfigV1)).not.toThrow();
   });
 });
 

--- a/packages/chain/test/strict-finalized-endpoint-ceiling-postcondition.unit.test.ts
+++ b/packages/chain/test/strict-finalized-endpoint-ceiling-postcondition.unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The attempt ceiling used to be enforced by the config validator rejecting any
+ * pool larger than `CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1`. Session
+ * selection replaced that rejection, so the ceiling is now satisfied by
+ * construction — and the config keeps a postcondition on the result.
+ *
+ * That postcondition is UNREACHABLE from production callers: the config passes
+ * the ceiling itself as the bound, so a correct selector can never exceed it.
+ * An unreachable guard is normally a check that cannot fail, which is why it is
+ * worth stating what it is actually for and proving it discriminates.
+ *
+ * What it is for: the runner never reads `maxAttempts`. It attempts one endpoint
+ * per entry of `profile.endpoints` (`strict-current-finalized-evm-lifecycle.ts`),
+ * while `CONTROL_EIP1271_MAX_ATTEMPTS_V1 = 2` is attested in the control
+ * envelope and verified at `current-finalized-evm-call.ts:182`. So the attested
+ * attempt count is truthful only while something bounds this list. Without the
+ * postcondition that "something" lives entirely inside another module, and a
+ * regression there would widen the real attempt count while the attestation kept
+ * claiming two.
+ *
+ * These tests stub the selector to a value a broken selector could produce, and
+ * assert the config fails closed rather than forwarding it. Mocking the
+ * collaborator is the only way to reach the branch — the real one is correct.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const selectStrictFinalizedEndpointSessionV1 = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/strict-finalized-endpoint-session.js', () => ({
+  selectStrictFinalizedEndpointSessionV1,
+}));
+
+const { snapshotStrictCurrentFinalizedEvmConfigV1 } = await import(
+  '../src/strict-current-finalized-evm-config.js'
+);
+
+const CHAIN_ID = '84532';
+const POOL = Object.freeze([
+  'https://a.example.com/rpc',
+  'https://b.example.com/rpc',
+  'https://c.example.com/rpc',
+]);
+
+function selection(selected: readonly string[]) {
+  return Object.freeze([...selected]);
+}
+
+describe('the attested attempt ceiling is asserted where it is attested', () => {
+
+  it('fails closed when the selector returns more endpoints than the ceiling', () => {
+    // Exactly what a regressed bound would produce: the whole pool, unsliced.
+    selectStrictFinalizedEndpointSessionV1.mockReturnValue(selection(POOL));
+
+    expect(() => snapshotStrictCurrentFinalizedEvmConfigV1({
+      chainId: CHAIN_ID,
+      endpoints: POOL,
+    } as never)).toThrow('exceeded the attested attempt ceiling');
+  });
+
+  it('accepts a selection at the ceiling, so the guard is a bound and not a ban', () => {
+    // The discriminator. Without this case the test above would also pass if the
+    // config rejected EVERY selection, which would break the product entirely.
+    selectStrictFinalizedEndpointSessionV1.mockReturnValue(selection(POOL.slice(0, 2)));
+
+    const config = snapshotStrictCurrentFinalizedEvmConfigV1({
+      chainId: CHAIN_ID,
+      endpoints: POOL,
+    } as never);
+    expect(config.endpoints).toEqual([POOL[0], POOL[1]]);
+  });
+
+  it('accepts a single endpoint, the other side of the bound', () => {
+    selectStrictFinalizedEndpointSessionV1.mockReturnValue(selection(POOL.slice(0, 1)));
+
+    const config = snapshotStrictCurrentFinalizedEvmConfigV1({
+      chainId: CHAIN_ID,
+      endpoints: POOL,
+    } as never);
+    expect(config.endpoints).toEqual([POOL[0]]);
+  });
+});

--- a/packages/chain/test/strict-finalized-endpoint-session.unit.test.ts
+++ b/packages/chain/test/strict-finalized-endpoint-session.unit.test.ts
@@ -1,0 +1,304 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { ChainIdV1 } from '@origintrail-official/dkg-core';
+import { describe, expect, it } from 'vitest';
+
+import { resolveRpcUrls } from '../src/evm-adapter-rpc.js';
+import { snapshotStrictCurrentFinalizedEvmConfigV1 } from '../src/strict-current-finalized-evm-config.js';
+import { selectStrictFinalizedEndpointSessionV1 } from '../src/strict-finalized-endpoint-session.js';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+
+/** The pool the product actually builds: primary + backups, deduped. */
+function shippedPool(network: string): string[] {
+  const cfg = JSON.parse(readFileSync(join(REPO_ROOT, 'network', `${network}.json`), 'utf8'));
+  return resolveRpcUrls(cfg.chain.rpcUrl, cfg.chain.rpcUrls);
+}
+
+function numericChainId(network: string): ChainIdV1 {
+  const cfg = JSON.parse(readFileSync(join(REPO_ROOT, 'network', `${network}.json`), 'utf8'));
+  return String(cfg.chain.chainId).split(':').pop() as ChainIdV1;
+}
+
+const EVM_NETWORKS = ['testnet', 'mainnet-base', 'mainnet-gnosis'] as const;
+
+
+/**
+ * The selector is policy over an already-validated model, so these drive it with
+ * explicit `{ href, origin }` records. Origin DERIVATION is deliberately not
+ * tested here — it belongs to the config boundary that owns it, and asserting it
+ * from a hand-built record would only restate the rule. The config-level suite
+ * below proves derivation end-to-end through the real pipeline.
+ */
+const CHAIN = '8453' as ChainIdV1;
+
+function ep(href: string, origin: string) {
+  return { href, origin };
+}
+
+describe('the shipped-pool ceiling defect', () => {
+  /**
+   * REGRESSION TEST. Before selection existed this threw
+   * "Strict current-finalized RPC requires 1..2 distinct endpoints" on every
+   * shipped EVM network, so RFC64's finalized-VM precommit could not construct
+   * its snapshot scope at all.
+   *
+   * The fixture MUST come from `resolveRpcUrls(rpcUrl, rpcUrls)`. Reading
+   * `chain.rpcUrls` alone gives two endpoints, which constructs both before and
+   * after the fix — a test that cannot fail.
+   */
+  it.each(EVM_NETWORKS.map((n) => [n] as const))(
+    '%s: a real 3-endpoint pool constructs',
+    (network) => {
+      const pool = shippedPool(network);
+      expect(pool.length).toBeGreaterThan(2); // the premise; if this drops to 2 the test is moot
+      expect(() =>
+        snapshotStrictCurrentFinalizedEvmConfigV1({
+          chainId: numericChainId(network),
+          endpoints: pool,
+        }),
+      ).not.toThrow();
+    },
+  );
+
+  it('selects exactly two endpoints from a shipped three-endpoint pool', () => {
+    const snapshot = snapshotStrictCurrentFinalizedEvmConfigV1({
+      chainId: numericChainId('mainnet-base'),
+      endpoints: shippedPool('mainnet-base'),
+    });
+    expect(snapshot.endpoints).toHaveLength(2);
+  });
+
+  it('neuroweb (single endpoint) still constructs and yields that endpoint', () => {
+    // Driven through the CONFIG, not the selector. An earlier revision passed the
+    // raw pool straight to the selector after its input became `{ href, origin }`
+    // records — so it read `.href` off a string, returned `[null]`, and
+    // `toHaveLength(1)` passed anyway. Asserting the exact URL through the real
+    // boundary is what makes this case able to fail.
+    const cfg = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'network', 'mainnet-neuroweb.json'), 'utf8'),
+    );
+    const pool = resolveRpcUrls(cfg.chain.rpcUrl, cfg.chain.rpcUrls);
+    expect(pool).toHaveLength(1);
+    const snapshot = snapshotStrictCurrentFinalizedEvmConfigV1({
+      chainId: numericChainId('mainnet-neuroweb'),
+      endpoints: pool,
+    });
+    expect(snapshot.endpoints).toEqual([new URL(pool[0]!).href]);
+  });
+});
+
+describe('selectStrictFinalizedEndpointSessionV1 — two-slot policy', () => {
+  const A1 = ep('https://lb.provider.io/v2/KEY_A', 'https://lb.provider.io');
+  const A2 = ep('https://lb.provider.io/v2/KEY_B', 'https://lb.provider.io');
+  const B = ep('https://backup.example.com/', 'https://backup.example.com');
+  const C = ep('https://third.example.com/', 'https://third.example.com');
+
+  it('takes the first endpoint and the first later DISTINCT origin', () => {
+    expect(selectStrictFinalizedEndpointSessionV1([A1, A2, B])).toEqual([A1.href, B.href]);
+  });
+
+  it('SKIPS an earlier same-origin URL to reach a distinct provider — stated trade', () => {
+    // The selected array is an ordered failover list, so this IS a priority
+    // inversion: A2 is configured second and never attempted. Pinned rather than
+    // left implicit. A1 and A2 share a provider, so a provider outage or an
+    // account-level rate limit takes both out together and the distinct origin
+    // is the only slot that survives it. With two slots and three endpoints,
+    // every possible policy skips someone.
+    expect(selectStrictFinalizedEndpointSessionV1([A1, A2, B])).not.toContain(A2.href);
+  });
+
+  it('BACKFILLS with a same-origin sibling rather than reducing failover', () => {
+    // Base constructed a two-URL same-origin pool as TWO dialable endpoints.
+    // Collapsing to one would halve failover for a deliberate operator config.
+    expect(selectStrictFinalizedEndpointSessionV1([A1, A2])).toEqual([A1.href, A2.href]);
+  });
+
+  it('yields one endpoint for a single-endpoint pool', () => {
+    expect(selectStrictFinalizedEndpointSessionV1([A1])).toEqual([A1.href]);
+  });
+
+  it('preserves configuration order rather than sorting', () => {
+    expect(selectStrictFinalizedEndpointSessionV1([C, B])).toEqual([C.href, B.href]);
+  });
+
+  it('fails CLOSED on an empty pool rather than returning an empty session', () => {
+    expect(() => selectStrictFinalizedEndpointSessionV1([]))
+      .toThrow(/requires at least one endpoint/);
+  });
+
+  it('is pure: same input, same output, no observable side effects', () => {
+    const input = Object.freeze([A1, B]);
+    expect(selectStrictFinalizedEndpointSessionV1(input))
+      .toEqual(selectStrictFinalizedEndpointSessionV1(input));
+    expect(input).toEqual([A1, B]);
+  });
+});
+
+describe('origin identity, proven end-to-end through the config boundary', () => {
+  const sel = (endpoints: readonly string[]) =>
+    snapshotStrictCurrentFinalizedEvmConfigV1({ chainId: CHAIN, endpoints } as never).endpoints;
+
+  it('treats path/query/credential/case variants of one host as ONE provider', () => {
+    // Three elements so `endpoints` DISCRIMINATES: if these were three providers
+    // the second slot would be the second variant, not `b`.
+    //
+    // The CREDENTIAL variant is load-bearing and was missing at one point while
+    // this test's name still claimed it: `url.origin` excludes userinfo, so two
+    // tokens on one host are one provider. Without a credential-bearing URL here,
+    // an identity rule that folded userinfo in would pass green.
+    expect(sel([
+      'https://token-a@a.example.com/rpc',
+      'https://token-b@A.EXAMPLE.COM/other?k=1',
+      'https://b.example.com',
+    ])).toEqual(['https://token-a@a.example.com/rpc', 'https://b.example.com/']);
+  });
+
+  it('collapses an explicit default port with the portless form', () => {
+    expect(sel([
+      'https://a.example.com',
+      'https://a.example.com:443',
+      'https://b.example.com',
+    ])).toEqual(['https://a.example.com/', 'https://b.example.com/']);
+  });
+
+  it('keeps NON-default ports as distinct providers', () => {
+    // The discriminating half. A rule that dropped the port would collapse these
+    // two and pick `b` as slot two instead.
+    expect(sel([
+      'https://a.example.com:8545',
+      'https://a.example.com:8546',
+      'https://b.example.com',
+    ])).toEqual(['https://a.example.com:8545/', 'https://a.example.com:8546/']);
+  });
+
+  it('does NOT impose a length limit on the dial URL', () => {
+    // Core bounds its input at the canonical scalar limit, so handing it the
+    // whole URL would cap RPC endpoints at 4096 bytes — a limit they never had.
+    // Only the origin is bounded, and an origin is always short.
+    const longPath = `https://rpc.example.com/${'k'.repeat(4100)}`;
+    expect(sel([longPath])).toEqual([longPath]);
+    const multiByte = `https://rpc.example.com/${'é'.repeat(3000)}`;
+    expect(new URL(multiByte).href.length).toBeGreaterThan(4096);
+    expect(sel([multiByte])).toEqual([new URL(multiByte).href]);
+  });
+});
+
+describe('pools that collapse to a valid session still construct', () => {
+  const sel = (endpoints: readonly string[]) =>
+    snapshotStrictCurrentFinalizedEvmConfigV1({ chainId: CHAIN, endpoints } as never).endpoints;
+
+  it('accepts many IDENTICAL urls, because base deduped before counting', () => {
+    // Regression. An earlier revision bounded the RAW array, which turned a
+    // config of duplicates into a construction failure even though it collapses
+    // to one endpoint. Base deduplicated by href BEFORE its count check, so this
+    // constructed; bounding the raw array silently narrowed the contract from
+    // "at most two distinct normalized endpoints" to "at most N raw entries".
+    expect(sel(Array.from({ length: 33 }, () => 'https://a.example.com/rpc')))
+      .toEqual(['https://a.example.com/rpc']);
+  });
+
+  it('accepts many entries collapsing to two distinct endpoints', () => {
+    expect(sel([
+      ...Array.from({ length: 20 }, () => 'https://a.example.com'),
+      ...Array.from({ length: 20 }, () => 'https://b.example.com'),
+    ])).toEqual(['https://a.example.com/', 'https://b.example.com/']);
+  });
+
+  it('preserves the underlying detail on `cause` when the array itself is rejected', () => {
+    // The translating catch flattens whatever `snapshotDenseDataArray` reports
+    // into one shape complaint, so the specific reason is recoverable only via
+    // `cause`. Without this assertion, dropping `{ cause }` leaves the suite
+    // green — it did, until a mutant said so.
+    let error: unknown;
+    try {
+      snapshotStrictCurrentFinalizedEvmConfigV1({ chainId: CHAIN, endpoints: [] } as never);
+    } catch (thrown) {
+      error = thrown;
+    }
+    expect(error).toBeInstanceOf(TypeError);
+    expect((error as Error).cause).toBeInstanceOf(Error);
+    expect(((error as Error).cause as Error).message).toMatch(/outside the accepted range/);
+  });
+
+  it('still fails closed on an invalid entry anywhere in a large pool', () => {
+    // Removing the raw bound must not turn the pool into an unvalidated region:
+    // every entry is normalized, not only the selected ones.
+    expect(() => sel([
+      ...Array.from({ length: 40 }, () => 'https://a.example.com'),
+      'ftp://c.example.com',
+    ])).toThrow(/HTTP\(S\) without a fragment/);
+  });
+});
+
+describe('config behaviour that must NOT change', () => {
+
+  it('a pool that constructs today still produces byte-identical output', () => {
+    const snapshot = snapshotStrictCurrentFinalizedEvmConfigV1({
+      chainId: CHAIN,
+      endpoints: ['https://a.example.com', 'https://b.example.com'],
+    });
+    expect(snapshot.endpoints).toEqual(['https://a.example.com/', 'https://b.example.com/']);
+    expect(snapshot.blockReferenceProfile).toBe('eip1898');
+  });
+
+  it('keeps every existing negative rejection verbatim', () => {
+    const bad: Array<[unknown, RegExp]> = [
+      [{ chainId: CHAIN, endpoints: ['not-a-url'] }, /absolute URL/],
+      [{ chainId: CHAIN, endpoints: ['ftp://a.example.com'] }, /HTTP\(S\) without a fragment/],
+      [{ chainId: CHAIN, endpoints: ['https://a.example.com#f'] }, /HTTP\(S\) without a fragment/],
+      // Empty hits the dense-array minLength check first — pre-existing ordering.
+      [{ chainId: CHAIN, endpoints: [] }, /dense data-only array/],
+      [{ chainId: CHAIN, endpoints: ['https://a.example.com'], surprise: 1 }, /unknown or missing fields/],
+      [{ chainId: 'not-decimal', endpoints: ['https://a.example.com'] }, /canonical decimal u256/],
+      // Message-pinned deliberately. The sibling `rejects unsafe configuration`
+      // asserts only `toThrow(TypeError)`, which stayed green while an oversize
+      // endpoint escaped as a `VmUpdateConvergenceError` — the type assertion
+      // could not fail because no fixture reached the bound.
+    ];
+    for (const [input, pattern] of bad) {
+      expect(() => snapshotStrictCurrentFinalizedEvmConfigV1(input as never)).toThrow(pattern);
+    }
+  });
+
+
+  it('an INVALID third endpoint still fails closed rather than being selected away', () => {
+    // Selection must not become a way to smuggle a malformed endpoint past
+    // validation just because it falls outside the first two origins.
+    expect(() =>
+      snapshotStrictCurrentFinalizedEvmConfigV1({
+        chainId: CHAIN,
+        endpoints: ['https://a.example.com', 'https://b.example.com', 'ftp://c.example.com'],
+      } as never),
+    ).toThrow(/HTTP\(S\) without a fragment/);
+  });
+
+  it('rejects an accessor-backed endpoints field with ZERO getter invocations', () => {
+    // Selection reads `endpoints`; it must run AFTER descriptor validation or it
+    // re-opens the accessor hole closed in #2051.
+    let reads = 0;
+    const config: Record<string, unknown> = { chainId: CHAIN };
+    Object.defineProperty(config, 'endpoints', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        reads += 1;
+        return ['https://a.example.com'];
+      },
+    });
+    expect(() => snapshotStrictCurrentFinalizedEvmConfigV1(config as never))
+      .toThrow(/enumerable data properties/);
+    expect(reads).toBe(0);
+  });
+
+  it('WIDENS: a 3-URL pool with two same-origin aliases now constructs', () => {
+    // Previously rejected (3 distinct hrefs). This is a deliberate consequence
+    // of origin identity, asserted so the direction of change is not a surprise.
+    const snapshot = snapshotStrictCurrentFinalizedEvmConfigV1({
+      chainId: CHAIN,
+      endpoints: ['https://a.example.com/rpc', 'https://a.example.com/other', 'https://b.example.com'],
+    });
+    expect(snapshot.endpoints).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

**This fixes a live defect, it is not preparatory work.** On every shipped EVM network, RFC64's finalized-VM precommit could not construct its snapshot scope at all. The finalized-read pool is `resolveRpcUrls(chain.rpcUrl, chain.rpcUrls)` — primary **plus** backups — which is three URLs on testnet, mainnet-base and mainnet-gnosis, while `snapshotNormalizedEndpoints` rejected more than `CURRENT_FINALIZED_EVM_READ_MAX_ATTEMPTS_V1 = 2`. Measured against the merged validator, all three throw `Strict current-finalized RPC requires 1..2 distinct endpoints`. No test covered it: grepping that message across the chain and agent suites returned zero hits.

`selectStrictFinalizedEndpointSessionV1` reduces the pool to at most two endpoints — distinct provider **origins** preferred, spare slots backfilled with same-origin URLs so failover is never *reduced*, then ordered back to configuration order. The attempt ceiling is satisfied by construction rather than by rejection, and is left untouched.

Provider identity is core's `normalizeEndpointOrigin`, imported rather than copied: the same predicate `canonicalPageProof` uses to decide `dual-origin-corroborated`, so the two layers cannot drift.

**This does NOT enable dual-origin corroboration.** A scope still pins one endpoint for its lifetime; holding two under one lease needs a runner change, deferred to the page-transport PR so §10.3 is not planned against a capability that does not exist.

### Behaviour changes, stated rather than buried

- **Widens** accepted configs: a 3-URL pool with two same-origin aliases was rejected and now constructs.
- **Narrows** two things, both inherited from core's bounded rule: endpoints are capped at 4096 bytes (boundary pinned by test — 4096 accepted, 4097 rejected; base had no bound and accepted 4097), and the pool is capped at 32 entries (removing the `> 2` rejection removed the only bound, and both dedup and selection scan linearly inside a loop — ~6s at 16k entries).
- The third shipped endpoint (`*.drpc.org`) is now **permanently unreachable** by strict finalized reads. Selection is health-blind and configuration-ordered, so a degraded primary is still dialled first. Pinned by assertion in the new agent test so it is a known limitation rather than a silent one.
- `/api/status` still reports `resolveRpcUrls(...).length` = 3 while a strict session dials 2. Not reconciled here.

### Deliberate API decisions

- No diversity **scalar** is exposed. An earlier revision returned `distinctOriginCount` computed over the whole pool *before* truncation while the module header pointed corroboration consumers at it — on every shipped network that reported `3` for a session dialling 2 origins, and `canonicalPageProof` requires *exactly* two. A derived value that can disagree with `selectedOrigins` is a trap, so the array is the single truth.
- `selectStrictFinalizedEndpointSessionV1` is **not** exported from the package root. Every consumer imports it by relative path, so exporting it would publish surface with no caller.

## Related

- Parent plan `agent-docs/plans/2026-08-02-w2-update-convergence.md` §5.2, §10.2 (local-only)
- Follow-up to #2051 (merged); base is `testnet-canary` @ `fa9dca15e`
- Pre-existing, **not** fixed here: `FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1 = 818` assumes the scan owns the whole 1024-batch budget, but the runtime spends one batch on the CG policy read first — safe ceiling is 817.

## Diagrams

### RFC64 finalized-VM precommit → snapshot scope construction

Before:

```mermaid
sequenceDiagram
    participant Precommit as RFC64 precommit
    participant Config as snapshotStrictCurrentFinalizedEvmConfigV1
    participant Transport as snapshot transport
    Precommit->>Config: endpoints = [primary, backup1, backup2]
    Note over Config: 3 > MAX_ATTEMPTS (2)
    Config--)Precommit: THROW "requires 1..2 distinct endpoints"
    Note over Transport: never reached — scope cannot be built
```

After:

```mermaid
sequenceDiagram
    participant Precommit as RFC64 precommit
    participant Config as snapshotStrictCurrentFinalizedEvmConfigV1
    participant Select as selectStrictFinalizedEndpointSessionV1
    participant Transport as snapshot transport
    Precommit->>Config: endpoints = [primary, backup1, backup2]
    Config->>Config: validate descriptors, normalize each endpoint
    Config->>Select: normalized pool (all 3 already validated)
    Select-->>Config: selected = [primary, backup1] (2 distinct origins)
    Config->>Config: postcondition: selected.length <= MAX_ATTEMPTS
    Config-->>Precommit: config { endpoints: 2 }
    Precommit->>Transport: preflight attempt 1 -> primary
    Precommit->>Transport: preflight attempt 2 -> backup1
    Note over Transport: backup2 never dialled (stranded, asserted in test)
```

## Files changed

| File | What |
|------|------|
| `packages/chain/src/strict-finalized-endpoint-session.ts` | **New.** Two-pass selection (distinct origins, then backfill), ordered back to configuration order. Fails closed on empty pool, non-array, and non-positive/non-integer bound. Converts core's `VmUpdateConvergenceError` to `TypeError`, preserving `cause`. |
| `packages/chain/src/strict-current-finalized-evm-config.ts` | Calls selection inside `snapshotNormalizedEndpoints`, after descriptor validation and after per-endpoint normalization. Adds the attested-ceiling postcondition, a 32-entry pool bound, and `{ cause }` on the pre-existing translating catch. |
| `packages/chain/test/strict-finalized-endpoint-session.unit.test.ts` | **New.** Shipped-pool regression cases per EVM network, selection semantics, ordering (including the backfill path), guards, boundary, and the config's verbatim rejection list. |
| `packages/chain/test/strict-finalized-endpoint-ceiling-postcondition.unit.test.ts` | **New.** Mocks the selector to reach the otherwise-unreachable postcondition, with both discriminating cases so it is proved a bound and not a blanket rejection. |
| `packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts` | The case asserting a 3-endpoint config throws **encoded the defect**; it is now a positive assertion of *which* two endpoints are selected. Other five rejection cases unchanged. |
| `packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts` | **New.** Drives the real precommit with the real shipped testnet pool, stubbing only global `fetch`, asserting which endpoints reach the wire. |
| `packages/agent/vitest.rfc64-unit-tests.ts` | Registers the new test — the lane uses an explicit include list, so an unregistered file silently never runs. |

## Test plan

- [x] Chain unit lane on an unloaded machine: **44 files, 883 tests (882 passed, 1 skipped), zero flakes**, against a force-rebuilt `dist`. Ran against code identical to the final commit, differing only in comments (proven by stripping comments and diffing the remainder, plus a check that no `@ts-ignore`/`eslint-disable`/`v8 ignore` directive was added or removed — a coverage directive would make a strip-and-diff true while changing what the suite measures).
- [x] Agent RFC64 seam suites green against a **force-rebuilt** `dist` (`tsbuildinfo` removed — `composite: true` otherwise skips emit: `rm -rf dist` *alone* emits **zero files at exit 0**, which is strictly worse than not deleting it)
- [x] **Fail-before proof** for the headline claim: reverting `snapshotNormalizedEndpoints` to its base body makes the new agent test fail with `requires 1..2 distinct endpoints` and **zero dials**; restored byte-identical, it passes with two endpoints dialled. Reproduced independently in review with `dist` verified in both directions.
- [x] **Fifteen mutants** across three rounds, each killed by its **named** test, baseline green before each, every restore byte-identical — plus independent auditor mutants. Three assertions exist only because a mutant proved they could not fail: the pool cap was one-sided, the `{ cause }` fix was entirely unasserted, and the default-port test asserted only `toHaveLength(2)`, which backfill guarantees whether or not the port is part of provider identity.
- [x] 32-entry pool cap verified end-to-end (32 accepted, 33 rejected) with all four shipped networks far clear of it
- [x] 4096-byte boundary verified through the config in both directions, including a percent-encoding case: an input **under both halves of the bound** (2022 chars / 4022 bytes) whose href inflates to 12022 and is rejected. That row exists to kill a specific wrong fix — a bound pre-checked against the raw input — which the ASCII oversize row cannot detect.

### Pre-existing Windows fixture failure — measured, NOT caused by this PR

`packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts` fails **29/29 locally on Windows**. It is **not** attributable to this PR, established by measurement rather than argument — each run alone on an idle machine, base `dist` verified before the run (64 emitted files, base marker present, selector file absent), and the process-emptiness check folded into the launch command:

| | HEAD `131b191b5` | BASE `fa9dca15e` |
|---|---|---|
| exit | 1 | 1 |
| wall | 969s | 883s |
| result | 29 failed | 29 failed |
| first failure | *"refuses cold bootstrap when an omitted author projection and seal lack durable history"* | **identical** |
| error | `Test timed out in 30000ms` | **identical** |
| site | `:159 await setupLiveReceiver()` | **identical** |

It is one shared fixture cascading 29 times, not 29 independent failures — every failing test dies on its first statement. `setupLiveReceiver` starts two libp2p nodes, opens SQLite persistence and connects peers; it constructs no chain adapter, no strict-finalized config, and references no `rpcEndpoints`. The file is unchanged since `ad230c238` (2026-07-23), an ancestor of this PR's base, and was already in the lane list at base — so "newly exposed by this PR" is excluded too.

It also reproduced *slower* alone (969s) than in a 35-file lane (926s), which rules out contention as the cause.

CI is unaffected: `ci.yml` has no agent vitest lane, and CI runs `ubuntu-latest` where the Windows `EBUSY`-on-unlink teardown fault cannot occur — Linux permits unlinking open files.

### Known flakiness (not introduced here)

`packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts` contains real-timer loopback tests that fail under machine load — **five different tests** observed across runs, each passing on a later run. They are load-dependent, not lane-dependent, so "passes solo" is not the argument. **On an unloaded machine the full lane is green with zero flakes** (882 passed / 1 skipped), which settles it empirically. Independently: selection is the **identity function** for every config involved — checked individually, each carries one endpoint, or two distinct-port origins, or three entries that href-dedup to two, and none exceeds the bound, so the endpoint list is byte-identical before and after this change.

