### PR TITLE
fix(sync): converge public SWM catch-up across bounded repeat passes (#2050)

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -297,9 +297,16 @@ import { mapWithConcurrency } from './map-with-concurrency.js';
 import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/catchup-concurrency.js';
 import {
   catchupAdmissionSource,
+  runCatchupPlaneWithPolicy,
   runCatchupPlanesWithPolicy,
   type CatchupMode,
 } from './sync/catchup-policy.js';
+import {
+  SwmCatchupPassTracker,
+  catchupPassNowMs,
+  resolveSwmCatchupPassConfig,
+  type CatchupPassConfig,
+} from './sync/catchup-pass-policy.js';
 import {
   classifyDurableProgress,
   createDurableSyncAccumulator,
@@ -500,6 +507,7 @@ import {
   type CatchupSyncDiagnostics,
   type DurableSyncResult,
   type SharedMemorySyncResult,
+  type SwmSnapshotCoverage,
   type DKGAgentConfig,
   type ReplicationEvent,
   type SyncReconcilerProbe,
@@ -6435,7 +6443,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     includeSharedMemory: boolean,
     peers: Array<{ toString(): string }>,
-    stats?: { totalPeers?: number; mode?: CatchupMode; sourceOverride?: SyncAdmissionSource },
+    stats?: {
+      totalPeers?: number;
+      mode?: CatchupMode;
+      sourceOverride?: SyncAdmissionSource;
+      /** Explicit test/embedding override; production resolves the operator env per job. */
+      swmCatchupPassConfig?: CatchupPassConfig;
+    },
   ): Promise<{
     /** Ordered connected peers before optional caller windowing. */
     connectedPeers: number;
@@ -6459,7 +6473,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const ctx = createOperationContext('sync');
     let syncCapablePeers = 0;
     let peersTried = 0;
-    let peersResponded = 0;
+    const peersResponded = new Set<string>();
     let deferredBackpressure = 0;
     let dataSynced = 0;
     let sharedMemorySynced = 0;
@@ -6500,8 +6514,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         failedPeers: 0,
         failedPhases: 0,
         deferredBackpressure: 0,
+        snapshotPlaneIncomplete: 0,
+        continuationPasses: 0,
+        replayPhaseBytesReceived: 0,
+        snapshotPhaseBytesReceived: 0,
       },
     };
+    const passTracker = new SwmCatchupPassTracker<SwmSnapshotCoverage>();
 
     if (DEBUG_SYNC_PROGRESS) {
       this.log.info(
@@ -6592,12 +6611,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         });
       },
     );
-    let accessDeniedPeers = 0;
+    const accessDeniedPeers = new Set<string>();
     let cleanDurableDataSynced = 0;
     let cleanDurablePrivateOnlyCompletions = 0;
     let cleanSharedMemoryDataSynced = 0;
-    let peersSucceeded = 0;
-    for (const r of results) {
+    const peersSucceeded = new Set<string>();
+    for (const [resultIndex, r] of results.entries()) {
+      const remotePeerId = syncCapable[resultIndex]!;
       // A peer "succeeded" when its sync round finished without a transport
       // failure, denial, or timeout and either made phase/checkpoint progress,
       // or cleanly completed empty. Empty responses still count as a
@@ -6607,6 +6627,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         complete: r.durable.complete,
       });
       const sharedProgress = r.shared ? classifyDurableProgress(r.shared) : null;
+      if (r.shared) {
+        passTracker.recordPeerRound(
+          remotePeerId,
+          r.shared.swmCoverage,
+          Boolean(sharedProgress?.completedWithoutFailure),
+        );
+      }
       const durableFailed = durableProgress.transportFailed;
       const sharedFailed = Boolean(sharedProgress?.transportFailed);
       const durablePhaseFailed = durableProgress.phaseFailed;
@@ -6656,7 +6683,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         cleanSharedMemoryDataSynced += r.shared!.insertedDataTriples;
       }
       if (durableResponded || sharedResponded) {
-        peersResponded++;
+        peersResponded.add(remotePeerId);
       }
       if (
         !durableFailed &&
@@ -6671,7 +6698,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         !durableProgress.integrityRejected &&
         (peerMadeProgress || !peerMetadataOnly)
       ) {
-        peersSucceeded++;
+        peersSucceeded.add(remotePeerId);
       }
       dataSynced += r.durable.insertedDataTriples;
       diagnostics.durable.fetchedMetaTriples += r.durable.fetchedMetaTriples;
@@ -6737,13 +6764,137 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         deferredBackpressure += r.shared.deferredBackpressure ?? 0;
         peerDenied = peerDenied || Boolean(sharedProgress?.denied);
       }
-      if (peerDenied) accessDeniedPeers++;
+      if (peerDenied) accessDeniedPeers.add(remotePeerId);
+    }
+
+    const accumulateContinuationShared = (
+      remotePeerId: string,
+      shared: SharedMemorySyncResult,
+    ): void => {
+      const progress = classifyDurableProgress(shared);
+      passTracker.recordPeerRound(
+        remotePeerId,
+        shared.swmCoverage,
+        progress.completedWithoutFailure,
+      );
+
+      sharedMemorySynced += shared.insertedDataTriples;
+      if (shared.swmCoverage) {
+        diagnostics.sharedMemory.swmCoverage = selectSwmSnapshotCoverage(
+          diagnostics.sharedMemory.swmCoverage,
+          shared.swmCoverage,
+        );
+      }
+      diagnostics.sharedMemory.snapshotPlaneIncomplete =
+        (diagnostics.sharedMemory.snapshotPlaneIncomplete ?? 0)
+        + (shared.snapshotPlaneIncomplete ?? 0);
+      diagnostics.sharedMemory.replayPhaseBytesReceived =
+        (diagnostics.sharedMemory.replayPhaseBytesReceived ?? 0)
+        + (shared.replayPhaseBytesReceived ?? 0);
+      diagnostics.sharedMemory.snapshotPhaseBytesReceived =
+        (diagnostics.sharedMemory.snapshotPhaseBytesReceived ?? 0)
+        + (shared.snapshotPhaseBytesReceived ?? 0);
+      diagnostics.sharedMemory.fetchedMetaTriples += shared.fetchedMetaTriples;
+      diagnostics.sharedMemory.fetchedDataTriples += shared.fetchedDataTriples;
+      diagnostics.sharedMemory.insertedMetaTriples += shared.insertedMetaTriples;
+      diagnostics.sharedMemory.insertedDataTriples += shared.insertedDataTriples;
+      diagnostics.sharedMemory.bytesReceived += shared.bytesReceived;
+      diagnostics.sharedMemory.resumedPhases += shared.resumedPhases;
+      diagnostics.sharedMemory.timedOutPhases += shared.timedOutPhases;
+      diagnostics.sharedMemory.completedPhases += shared.completedPhases;
+      diagnostics.sharedMemory.checkpointAdvances += shared.checkpointAdvances;
+      diagnostics.sharedMemory.emptyResponses += shared.emptyResponses;
+      diagnostics.sharedMemory.droppedDataTriples += shared.droppedDataTriples;
+      diagnostics.sharedMemory.failedPeers += shared.failedPeers;
+      diagnostics.sharedMemory.failedPhases += shared.failedPhases ?? 0;
+      diagnostics.sharedMemory.deferredBackpressure =
+        (diagnostics.sharedMemory.deferredBackpressure ?? 0)
+        + (shared.deferredBackpressure ?? 0);
+      deferredBackpressure += shared.deferredBackpressure ?? 0;
+
+      const responded = !progress.transportFailed
+        && (!progress.deferredByBackpressure || (
+          shared.bytesReceived > 0
+          || shared.completedPhases > 0
+          || shared.emptyResponses > 0
+          || shared.insertedMetaTriples > 0
+          || shared.insertedDataTriples > 0
+        ));
+      if (responded) peersResponded.add(remotePeerId);
+      if (
+        !progress.transportFailed
+        && !progress.phaseFailed
+        && !progress.denied
+        && !progress.deferredByBackpressure
+        && !progress.timedOut
+        && !progress.integrityRejected
+        && (progress.madeReadinessProgress || !progress.hasMetadataEvidence)
+      ) {
+        peersSucceeded.add(remotePeerId);
+      }
+      if (progress.denied) accessDeniedPeers.add(remotePeerId);
+
+      if (shared.insertedDataTriples > 0 && progress.completedWithoutFailure) {
+        cleanSharedMemoryDataSynced += shared.insertedDataTriples;
+      }
+    };
+
+    if (includeSharedMemory) {
+      const passConfig = stats?.swmCatchupPassConfig ?? resolveSwmCatchupPassConfig();
+      const passDeadlineMs = catchupPassNowMs() + passConfig.budgetMs;
+      for (;;) {
+        const decision = passTracker.decide({
+          nowMs: catchupPassNowMs(),
+          deadlineMs: passDeadlineMs,
+          maxPasses: passConfig.maxPasses,
+          planeProven: cleanSharedMemoryDataSynced > 0,
+        });
+        if (!decision.continue) {
+          diagnostics.sharedMemory.continuationStopReason = decision.reason;
+          this.log.info(
+            ctx,
+            `Catch-up SWM pass loop for "${contextGraphId}" stopped after `
+            + `${1 + passTracker.continuationPasses()} pass(es): ${decision.reason}`,
+          );
+          break;
+        }
+
+        const before = passTracker.startContinuationPass();
+        const mode = stats?.mode ?? 'background';
+        const continuationResults = await mapWithConcurrency(
+          decision.peers,
+          CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
+          async (remotePeerId) => {
+            if (catchupPassNowMs() >= passDeadlineMs) return null;
+            const shared = await runCatchupPlaneWithPolicy(
+              mode,
+              ({ priority, source }) => this.syncSharedMemoryFromPeerDetailed(
+                remotePeerId,
+                [contextGraphId],
+                { ...(priority === undefined ? {} : { priority }), source },
+              ).catch(emptyShared),
+              { sourceOverride: stats?.sourceOverride },
+            );
+            return { remotePeerId, shared };
+          },
+        );
+        for (const result of continuationResults) {
+          if (result) accumulateContinuationShared(result.remotePeerId, result.shared);
+        }
+        this.log.info(
+          ctx,
+          `Catch-up SWM pass ${1 + passTracker.continuationPasses()} for `
+          + `"${contextGraphId}": ${decision.peers.length} capable peer(s), progress `
+          + `${before} -> ${passTracker.progress()} resolved summed across peers`,
+        );
+      }
+      diagnostics.sharedMemory.continuationPasses = passTracker.continuationPasses();
     }
     diagnostics.noProtocolPeers = noProtocolPeers;
 
     this.log.info(
       ctx,
-      `Catch-up sync for "${contextGraphId}": peers=${peersTried}/${syncCapablePeers} data=${dataSynced} sharedMemory=${sharedMemorySynced} denied=${accessDeniedPeers} deferred=${deferredBackpressure}`,
+      `Catch-up sync for "${contextGraphId}": peers=${peersTried}/${syncCapablePeers} data=${dataSynced} sharedMemory=${sharedMemorySynced} denied=${accessDeniedPeers.size} deferred=${deferredBackpressure}`,
     );
 
     await this.refreshMetaSyncedFlags([contextGraphId]);
@@ -6781,14 +6932,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       selectedPeers: peers.length,
       syncCapablePeers,
       peersTried,
-      peersResponded,
-      peersSucceeded,
+      peersResponded: peersResponded.size,
+      peersSucceeded: peersSucceeded.size,
       deferredBackpressure,
       dataSynced,
       sharedMemorySynced,
       sharedMemoryCompletedCleanly,
-      denied: accessDeniedPeers > 0,
-      deniedPeers: accessDeniedPeers,
+      denied: accessDeniedPeers.size > 0,
+      deniedPeers: accessDeniedPeers.size,
       diagnostics,
     };
   }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -275,7 +275,7 @@ import {
   type ExactDurableFetchDisposition,
 } from './sync/requester/exact-durable-fetch.js';
 import { resolveSyncAgentsMeta, shouldWithholdAgentsDurableMeta } from './sync/agents-meta-policy.js';
-import { runSharedMemorySync, sharedMemoryOwnershipKeyFromGraph } from './sync/requester/shared-memory-sync.js';
+import { runSharedMemorySync, selectSwmSnapshotCoverage, sharedMemoryOwnershipKeyFromGraph } from './sync/requester/shared-memory-sync.js';
 import { createSharedMemorySnapshotMaterializer } from './sync/requester/swm-snapshot-materializer.js';
 import {
   runOrderedContextGraphSyncs,
@@ -1237,6 +1237,9 @@ function emptySharedMemorySyncResult(): SharedMemorySyncResult {
     deniedPhases: 0,
     backoffWorthyFailures: 0,
     deferredBackpressure: 0,
+    snapshotPlaneIncomplete: 0,
+    replayPhaseBytesReceived: 0,
+    snapshotPhaseBytesReceived: 0,
   };
 }
 
@@ -1244,6 +1247,7 @@ function mergeSharedMemorySyncResults(
   a: SharedMemorySyncResult,
   b: SharedMemorySyncResult,
 ): SharedMemorySyncResult {
+  const swmCoverage = selectSwmSnapshotCoverage(a.swmCoverage, b.swmCoverage);
   return {
     insertedTriples: a.insertedTriples + b.insertedTriples,
     fetchedMetaTriples: a.fetchedMetaTriples + b.fetchedMetaTriples,
@@ -1263,6 +1267,17 @@ function mergeSharedMemorySyncResults(
     deniedPhases: a.deniedPhases + b.deniedPhases,
     backoffWorthyFailures: (a.backoffWorthyFailures ?? 0) + (b.backoffWorthyFailures ?? 0),
     deferredBackpressure: (a.deferredBackpressure ?? 0) + (b.deferredBackpressure ?? 0),
+    snapshotPlaneIncomplete: (a.snapshotPlaneIncomplete ?? 0) + (b.snapshotPlaneIncomplete ?? 0),
+    continuationPasses: (a.continuationPasses ?? 0) + (b.continuationPasses ?? 0),
+    // The two halves of `bytesReceived`, kept apart so replay cost stays
+    // measurable once passes repeat.
+    replayPhaseBytesReceived: (a.replayPhaseBytesReceived ?? 0) + (b.replayPhaseBytesReceived ?? 0),
+    snapshotPhaseBytesReceived:
+      (a.snapshotPhaseBytesReceived ?? 0) + (b.snapshotPhaseBytesReceived ?? 0),
+    // Scalars above sum; coverage does NOT. It is selected whole from one round
+    // so the counts, their peer and the sample can never be spliced together
+    // from different manifests — see `selectSwmSnapshotCoverage`.
+    ...(swmCoverage ? { swmCoverage } : {}),
   };
 }
 
@@ -6682,6 +6697,28 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       let peerDenied = durableProgress.denied;
       if (r.shared) {
         sharedMemorySynced += r.shared.insertedDataTriples;
+        // The #2050 signals. Without these the in-agent walk silently drops the
+        // only per-graph SWM coverage the plane has ever produced, and a job run
+        // through the inline runner reports a shortfall it cannot name — while
+        // the worker-backed runner reports it fully. Coverage is SELECTED, never
+        // summed: independent maxima over resolved and total would combine a peer
+        // reporting 178/250 with one reporting 200/200 into 200/250, a state no
+        // peer described.
+        if (r.shared.swmCoverage) {
+          diagnostics.sharedMemory.swmCoverage = selectSwmSnapshotCoverage(
+            diagnostics.sharedMemory.swmCoverage,
+            r.shared.swmCoverage,
+          );
+        }
+        diagnostics.sharedMemory.snapshotPlaneIncomplete =
+          (diagnostics.sharedMemory.snapshotPlaneIncomplete ?? 0)
+          + (r.shared.snapshotPlaneIncomplete ?? 0);
+        diagnostics.sharedMemory.replayPhaseBytesReceived =
+          (diagnostics.sharedMemory.replayPhaseBytesReceived ?? 0)
+          + (r.shared.replayPhaseBytesReceived ?? 0);
+        diagnostics.sharedMemory.snapshotPhaseBytesReceived =
+          (diagnostics.sharedMemory.snapshotPhaseBytesReceived ?? 0)
+          + (r.shared.snapshotPhaseBytesReceived ?? 0);
         diagnostics.sharedMemory.fetchedMetaTriples += r.shared.fetchedMetaTriples;
         diagnostics.sharedMemory.fetchedDataTriples += r.shared.fetchedDataTriples;
         diagnostics.sharedMemory.insertedMetaTriples += r.shared.insertedMetaTriples;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1003,6 +1003,52 @@ export interface DurableSyncDiagnostics {
   deferredBackpressure?: number;
 }
 
+/**
+ * ONE peer's public-SWM snapshot coverage for ONE round, and the ONLY shape in
+ * which that coverage travels.
+ *
+ * **Reduced whole or not at all.** Numerator and denominator are never reduced
+ * independently: an independent `max` over ready and total combines peers
+ * reporting `178/250` and `200/200` into `200/250` — a state no peer reported,
+ * attributed to a peer that never said it, alongside a missing sample drawn
+ * from a third inventory. Every reducer therefore picks one record and keeps it
+ * intact; `selectSwmSnapshotCoverage` in `sync/requester/shared-memory-sync.ts`
+ * is that reducer, and it is the only one.
+ */
+export interface SwmSnapshotCoverage {
+  /**
+   * The Context Graph this coverage describes. Required, because the reduction
+   * runs INSIDE the `contextGraphIds` loop: on a multi-CG call exactly one
+   * graph's record survives, and without this field no consumer can tell which
+   * graph the surviving counts belong to.
+   */
+  contextGraphId: string;
+  /** Last 8 chars of the peer id this whole record came from. */
+  peerIdSuffix: string;
+  /** Snapshot refs already valid locally or fetched in this round. */
+  snapshotsResolved: number;
+  /** Snapshot refs declared by this peer's verified SWM metadata. */
+  snapshotsTotal: number;
+  /**
+   * The peer's SWM metadata phase paged to completion, so `snapshotsTotal` is
+   * its full manifest rather than a truncated prefix. False means the
+   * denominator is a lower bound.
+   */
+  manifestComplete: boolean;
+  missingCount: number;
+  /**
+   * Bounded identifiers for the shortfall — a public peer controls manifest
+   * size, so this is a sample, never the full inventory. Always drawn from the
+   * same round as the counts above.
+   */
+  missingSample: string[];
+  /**
+   * This round came from the metadata-resolved curator. Set only by the
+   * catch-up walk, which knows peer roles; the agent-side sync does not.
+   */
+  fromAuthority?: boolean;
+}
+
 export interface SharedMemorySyncDiagnostics {
   fetchedMetaTriples: number;
   fetchedDataTriples: number;
@@ -1020,6 +1066,31 @@ export interface SharedMemorySyncDiagnostics {
   backoffWorthyFailures?: number;
   /** Context Graph admissions deferred by local scheduler pressure. */
   deferredBackpressure?: number;
+  /** Coverage for the graph this round touched; see {@link SwmSnapshotCoverage}. */
+  swmCoverage?: SwmSnapshotCoverage;
+  /**
+   * Snapshot phases that stopped on the local clock with unfetched refs
+   * remaining — a VOLUNTARY yield, not a peer fault. Deliberately distinct from
+   * `timedOutPhases`, which marks the round backoff-worthy
+   * (`durable-progress.ts` `backoffWorthyFailure`) and would put a healthy peer
+   * into backoff for our own budget decision.
+   */
+  snapshotPlaneIncomplete?: number;
+  /** Extra catch-up passes spent over the peer set beyond the first. */
+  continuationPasses?: number;
+  /**
+   * The REPLAY half of `bytesReceived`: the metadata and aggregate-data phases,
+   * which a repeated pass re-fetches in full. Named for the plan's single
+   * "metadata/aggregate replay" bucket — it spans BOTH phases, not just meta.
+   *
+   * Split out because `bytesReceived` merges replay and useful bytes into one
+   * scalar, which makes the accepted cost of repeating the peer walk
+   * unmeasurable in bytes — exactly the quantity the efficiency gate exists to
+   * bound. `replayPhaseBytesReceived + snapshotPhaseBytesReceived === bytesReceived`.
+   */
+  replayPhaseBytesReceived?: number;
+  /** The USEFUL half of `bytesReceived`: immutable snapshot content. */
+  snapshotPhaseBytesReceived?: number;
 }
 
 export interface CatchupSyncDiagnostics {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ethers } from 'ethers';
+import type { CatchupPassDecisionReason } from './sync/catchup-pass-policy.js';
 import type {
   Quad,
   TripleStore,
@@ -1078,6 +1079,13 @@ export interface SharedMemorySyncDiagnostics {
   snapshotPlaneIncomplete?: number;
   /** Extra catch-up passes spent over the peer set beyond the first. */
   continuationPasses?: number;
+  /**
+   * Why the bounded repeat stopped. Typed as the policy's own closed union
+   * rather than `string`, so a new stop reason cannot reach the terminal message
+   * unnoticed — the terminal text renders this, and an unhandled reason there
+   * would read as a missing explanation rather than as a new state.
+   */
+  continuationStopReason?: CatchupPassDecisionReason;
   /**
    * The REPLAY half of `bytesReceived`: the metadata and aggregate-data phases,
    * which a repeated pass re-fetches in full. Named for the plan's single

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1044,6 +1044,21 @@ export interface SwmSnapshotCoverage {
    */
   missingSample: string[];
   /**
+   * Snapshots that FETCHED and digest-verified but could not be written to the
+   * store.
+   *
+   * A separate axis from `missingCount`, which measures retrieval only. A round
+   * can retrieve every declared ref (`missingCount === 0`) and still fail to
+   * materialize some of them — a store error inside the KA write lock — which
+   * is exactly the failure class the G7 repair exists for, and is likeliest
+   * under the same store pressure that produces incomplete rounds.
+   *
+   * Kept separate because the two send an operator to different places: "we
+   * could not fetch it" is a network and peer-set problem; "we fetched it and
+   * could not write it" is a store problem.
+   */
+  materializationFailures: number;
+  /**
    * This round came from the metadata-resolved curator. Set only by the
    * catch-up walk, which knows peer roles; the agent-side sync does not.
    */

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1026,7 +1026,17 @@ export interface SwmSnapshotCoverage {
   contextGraphId: string;
   /** Last 8 chars of the peer id this whole record came from. */
   peerIdSuffix: string;
-  /** Snapshot refs already valid locally or fetched in this round. */
+  /**
+   * Snapshot refs whose Knowledge Assets are MATERIALIZED — written and locally
+   * visible — either already present before this round or made visible by it.
+   *
+   * Not "fetched". A ref sitting valid in the blob cache whose write failed does
+   * NOT count here, and that is deliberate: the capability gate reads this field
+   * to decide whether a peer still owes us anything, and a round that cached
+   * every ref while writing none would otherwise report `N/N`, drop the peer as
+   * satisfied, and disable the retry loop in exactly the failure class it exists
+   * for.
+   */
   snapshotsResolved: number;
   /** Snapshot refs declared by this peer's verified SWM metadata. */
   snapshotsTotal: number;
@@ -1036,26 +1046,41 @@ export interface SwmSnapshotCoverage {
    * denominator is a lower bound.
    */
   manifestComplete: boolean;
+  /**
+   * Refs NOT materialized: `snapshotsTotal - snapshotsResolved`, by
+   * construction, so `resolved + missing === total` always holds.
+   *
+   * Covers both causes at once — never fetched, and fetched-but-unwritten. It is
+   * NOT a retrieval-only count, and it must never be added to
+   * `materializationFailures`; every unwritten ref is already in here.
+   */
   missingCount: number;
   /**
    * Bounded identifiers for the shortfall — a public peer controls manifest
    * size, so this is a sample, never the full inventory. Always drawn from the
-   * same round as the counts above.
+   * same round as the counts above, and deduplicated, so it can never exceed
+   * `missingCount`.
    */
   missingSample: string[];
   /**
-   * Snapshots that FETCHED and digest-verified but could not be written to the
-   * store.
+   * Descriptor writes that FAILED after their snapshot fetched and
+   * digest-verified — a store error inside the KA write lock, the failure class
+   * the G7 repair exists for, likeliest under the same store pressure that
+   * produces incomplete rounds.
    *
-   * A separate axis from `missingCount`, which measures retrieval only. A round
-   * can retrieve every declared ref (`missingCount === 0`) and still fail to
-   * materialize some of them — a store error inside the KA write lock — which
-   * is exactly the failure class the G7 repair exists for, and is likeliest
-   * under the same store pressure that produces incomplete rounds.
+   * A CAUSE indicator for `missingCount`, not a second disjoint count. Those
+   * refs are already counted as missing; this field says the shortfall is a
+   * store problem rather than a network one, which is what sends an operator to
+   * the right place.
    *
-   * Kept separate because the two send an operator to different places: "we
-   * could not fetch it" is a network and peer-set problem; "we fetched it and
-   * could not write it" is a store problem.
+   * Note the unit: this counts failing DESCRIPTORS while `missingCount` counts
+   * REFS, and one ref can carry several descriptors. Neither is a subset count
+   * of the other, so never render them as "N of which K".
+   *
+   * `materializationFailures > 0` with `missingCount === 0` is unrepresentable:
+   * a ref with a failing descriptor is excluded from the materialized set, which
+   * forces `resolved < total`. A fixture asserting that pair is testing a state
+   * the producer cannot emit.
    */
   materializationFailures: number;
   /**

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -354,10 +354,14 @@ export {
 // retry policy's do: in-package tests import them from
 // `./sync/catchup-pass-policy.js` directly rather than pinning them here.
 export {
-  SWM_CATCHUP_MAX_PASSES,
-  SWM_CATCHUP_PASS_BUDGET_MS,
+  DEFAULT_SWM_CATCHUP_MAX_PASSES,
+  DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS,
+  SwmCatchupPassTracker,
   catchupPassNowMs,
+  resolveSwmCatchupPassConfig,
   shouldRunAnotherCatchupPass,
+  type CatchupPassConfig,
+  type CatchupPassCoverage,
   type CatchupPassDecision,
   type CatchupPassDecisionReason,
   type CatchupPassPolicyInput,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -235,6 +235,7 @@ export {
   type DurableSyncResult,
   type SharedMemorySyncDiagnostics,
   type SharedMemorySyncResult,
+  type SwmSnapshotCoverage,
 } from './dkg-agent-types.js';
 export {
   computeImportedArtifactSelector,
@@ -346,6 +347,21 @@ export {
   type CatchupPlaneSourceOverride,
   type CatchupPlaneResult,
 } from './sync/catchup-policy.js';
+// #2050 — the bounded repeat of the public SWM peer walk. Both drivers of that
+// walk call the same stop rule, and one of them is the CLI daemon's Worker
+// runner, so the rule and the operator-facing bounds it reads must be on the
+// published surface. The env PARSERS stay in-package for the same reason the
+// retry policy's do: in-package tests import them from
+// `./sync/catchup-pass-policy.js` directly rather than pinning them here.
+export {
+  SWM_CATCHUP_MAX_PASSES,
+  SWM_CATCHUP_PASS_BUDGET_MS,
+  catchupPassNowMs,
+  shouldRunAnotherCatchupPass,
+  type CatchupPassDecision,
+  type CatchupPassDecisionReason,
+  type CatchupPassPolicyInput,
+} from './sync/catchup-pass-policy.js';
 // Which peer may let one answer stand for a WHOLE Context Graph is the load-
 // bearing distinction of the foreground catch-up walk (#2006), and the walk
 // lives in the CLI's worker. Publishing the model — rather than letting the
@@ -365,6 +381,11 @@ export {
   type DurableProgressClassificationOptions,
   type DurableProgressSummary,
 } from './sync/durable-progress.js';
+// The ONE reduction for `SwmSnapshotCoverage`. Exported so the CLI catch-up
+// walk reduces across peers with the same rule the agent uses across Context
+// Graphs — two implementations is how a numerator and a denominator end up
+// coming from different peers.
+export { selectSwmSnapshotCoverage } from './sync/requester/shared-memory-sync.js';
 // 2026-07-08 sync-storm mitigation (#1233) — resolve the opt-in `agents/_meta`
 // fetch flag. Exported on the public surface so the CLI daemon lifecycle resolves
 // it identically to the in-agent lifecycle, without deep-importing `dist/`.

--- a/packages/agent/src/sync/catchup-pass-policy.ts
+++ b/packages/agent/src/sync/catchup-pass-policy.ts
@@ -1,0 +1,187 @@
+/**
+ * The stop rule for the bounded, progress-aware repeat of the public SWM peer
+ * walk (issue #2050).
+ *
+ * A receiver subscribing to a large public Context Graph gets exactly ONE round
+ * per peer and exactly ONE walk over the peer set. When a round's 120 s deadline
+ * expires mid-snapshot-list the tail is abandoned, and once the peer set is
+ * exhausted the job terminates `unreachable` with a partial graph and no resume
+ * path. The fix is to repeat the walk — bounded, and only while it is provably
+ * getting somewhere.
+ *
+ * This module is ONLY the decision. It runs no I/O, reads no clock and holds no
+ * state, so the rule that decides how much extra network and store work a node
+ * may spend exists in one place and is tested in one place. Both drivers — the
+ * CLI worker's `runCatchup` and the in-agent `runCatchupOverPeers` — call it, so
+ * they cannot drift apart.
+ *
+ * It is deliberately NOT a new mechanism: the repo already runs a bounded round
+ * loop with a clean-completion stop on this exact lane for post-approval curator
+ * sync (`dkg-agent-lifecycle.ts`, `MAX_POST_APPROVAL_CURATOR_SYNC_ROUNDS`). #2050
+ * is that loop missing from the general foreground catch-up.
+ */
+import { monotonicNow } from './catchup-policy.js';
+
+/**
+ * Elapsed-time source for the pass budget.
+ *
+ * Re-exported from `catchup-policy.ts` rather than redefined so the pass budget
+ * and the sibling admission-retry budget read the SAME clock. It is monotonic
+ * for the reason stated there: the budget is a duration, not a point in time, so
+ * it must not follow a wall-clock correction. The walk never compares this
+ * against the per-Context-Graph round deadline — that one is computed inside the
+ * agent from its own clock and is never read here — so there is nothing to keep
+ * the two comparable and no reason to inherit `Date.now`'s NTP hazard.
+ */
+export const catchupPassNowMs: () => number = monotonicNow;
+
+/** Why the loop stopped, or that it did not. A closed vocabulary: the terminal
+ * message and the per-pass log line both render it, and an open-ended string
+ * would make those untestable. */
+export type CatchupPassDecisionReason =
+  | 'continue'
+  | 'plane-proven'
+  | 'coverage-stalled'
+  | 'no-capable-peers'
+  | 'max-passes-reached'
+  | 'budget-exhausted';
+
+export interface CatchupPassPolicyInput {
+  /** Monotonic reading from `catchupPassNowMs`; injected so the rule is pure. */
+  nowMs: number;
+  /**
+   * Monotonic instant after which no new pass may START. Computed once per job
+   * as `catchupPassNowMs() + budgetMs`. A budget of `0` therefore makes this
+   * equal to the job start, which expires immediately — that is exactly how the
+   * `DKG_SWM_CATCHUP_PASS_BUDGET_MS=0` kill switch disables extra passes, with
+   * no separate disabled branch to keep correct.
+   */
+  deadlineMs: number;
+  /** Passes COMPLETED so far, including the initial walk — so never below 1. */
+  passesRun: number;
+  /** Total passes permitted, initial walk included. */
+  maxPasses: number;
+  /**
+   * The highest `snapshotsResolved` observed BEFORE the pass that just ran.
+   *
+   * Initialised to 0, not −1. The difference is load-bearing: with −1 a first
+   * pass that resolved nothing at all would still count as "advanced" and earn a
+   * repeat, which is precisely the barren-retry the wall-clock budget then has to
+   * absorb. A pass that resolved zero snapshots has produced no evidence that
+   * another one would do better.
+   */
+  coverageHighWaterMark: number;
+  /** The highest `snapshotsResolved` observed IN the pass that just ran. */
+  lastPassCoverage: number;
+  /** A clean peer round already proved the shared-memory plane. */
+  planeProven: boolean;
+  /**
+   * Peers that demonstrably still hold descriptors we lack — the caller derives
+   * this from each peer's own reported coverage, never from the absence of
+   * failure counters. Barren, cleanly-empty, empty-and-timed-out and
+   * meta-truncation peers are not capable and must get zero extra passes.
+   */
+  capablePeers: readonly string[];
+}
+
+export interface CatchupPassDecision {
+  continue: boolean;
+  /** The peers the next pass may contact — the capable set, or empty on a stop. */
+  peers: string[];
+  reason: CatchupPassDecisionReason;
+}
+
+/**
+ * Decide whether the walk gets another pass, and over which peers.
+ *
+ * Every condition below is independently sufficient to stop, so several are
+ * routinely true at once. `reason` reports the FIRST match in the order written,
+ * which is chosen by how actionable it is rather than by severity:
+ *
+ *   1. `plane-proven` — a success, and it outranks everything else.
+ *   2. `coverage-stalled` — the walk is not converging. Reported ahead of the
+ *      hard bounds because it changes what an operator should do: a stalled run
+ *      that also hit the budget would otherwise read as "raise the budget", and
+ *      raising it would buy nothing.
+ *   3. `no-capable-peers` — nobody left who admits to holding what we lack.
+ *   4. `max-passes-reached`, 5. `budget-exhausted` — the backstops. They bound
+ *      the loop; they rarely explain it.
+ */
+export function shouldRunAnotherCatchupPass(input: CatchupPassPolicyInput): CatchupPassDecision {
+  const stop = (reason: CatchupPassDecisionReason): CatchupPassDecision =>
+    ({ continue: false, peers: [], reason });
+
+  if (input.planeProven) return stop('plane-proven');
+  // Strictly greater: a pass that resolved exactly as much as every pass before
+  // it moved nothing, however large the number is.
+  if (input.lastPassCoverage <= input.coverageHighWaterMark) return stop('coverage-stalled');
+  if (input.capablePeers.length === 0) return stop('no-capable-peers');
+  if (input.passesRun >= input.maxPasses) return stop('max-passes-reached');
+  // `>=`, so a budget of 0 stops before the first repeat rather than granting one.
+  if (input.nowMs >= input.deadlineMs) return stop('budget-exhausted');
+
+  return { continue: true, peers: [...input.capablePeers], reason: 'continue' };
+}
+
+/**
+ * Wall-clock budget for the whole repeat loop, in ms.
+ *
+ * Sized so at least two extra passes fit even when a peer's plane is deferred and
+ * burns its full admission-retry budget (`CATCHUP_BACKPRESSURE_MAX_WAIT_MS`,
+ * 180 s). It is wall-clock rather than a pass count because the dominant per-pass
+ * cost on a warm store is local: re-verifying an already-held KA is a full blob
+ * read, parse, sort and SHA-256, plus a COUNT and a full CONSTRUCT against the
+ * store — O(KA size) per cached snapshot, with no bytes on the wire.
+ */
+export const DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS = 600_000;
+
+/** Backstop on the pass count: the initial walk plus three repeats. The budget
+ * and the coverage gate are the real bounds; this exists so a pathological
+ * always-advancing-by-one peer cannot spin. */
+export const DEFAULT_SWM_CATCHUP_MAX_PASSES = 4;
+
+/**
+ * Parse the operator-facing pass budget.
+ *
+ * Exported as a pure function for the same reason `resolveCatchupBackpressureMaxWaitMs`
+ * is: the constant below resolves once at module load, which makes the env
+ * contract untestable in place — and it has the same sharp edge. A BLANK
+ * assignment is the normal docker-compose / `.env` / systemd shape for "not set",
+ * but `Number('')` is `0`, which here would silently disable every extra pass and
+ * leave the node with exactly the #2050 behaviour the operator was trying to fix.
+ * Blank is unset; an explicit `0` still means "no extra passes".
+ */
+export function resolveSwmCatchupPassBudgetMs(raw: string | undefined): number {
+  const trimmed = raw?.trim();
+  if (!trimmed) return DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS;
+  const parsed = Number(trimmed);
+  // `Number.isInteger` alone accepts `1e308`, an integer by IEEE-754 and a budget
+  // no operator meant. Require a SAFE integer so an unusable value falls back to
+  // the documented default instead of becoming an effectively unbounded loop.
+  return Number.isSafeInteger(parsed) && parsed >= 0
+    ? parsed
+    : DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS;
+}
+
+/**
+ * Parse the operator-facing pass cap.
+ *
+ * Same contract as the budget, with one difference: the floor is 1, not 0. Zero
+ * passes would skip the initial walk itself — catch-up would fetch nothing at all
+ * — so a `0` here is a misconfiguration rather than a kill switch, and falls back
+ * to the default. Disabling repeats is the budget's job.
+ */
+export function resolveSwmCatchupMaxPasses(raw: string | undefined): number {
+  const trimmed = raw?.trim();
+  if (!trimmed) return DEFAULT_SWM_CATCHUP_MAX_PASSES;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed >= 1
+    ? parsed
+    : DEFAULT_SWM_CATCHUP_MAX_PASSES;
+}
+
+export const SWM_CATCHUP_PASS_BUDGET_MS: number =
+  resolveSwmCatchupPassBudgetMs(process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS);
+
+export const SWM_CATCHUP_MAX_PASSES: number =
+  resolveSwmCatchupMaxPasses(process.env.DKG_SWM_CATCHUP_MAX_PASSES);

--- a/packages/agent/src/sync/catchup-pass-policy.ts
+++ b/packages/agent/src/sync/catchup-pass-policy.ts
@@ -98,7 +98,15 @@ export interface CatchupPassDecision {
  * routinely true at once. `reason` reports the FIRST match in the order written,
  * which is chosen by how actionable it is rather than by severity:
  *
- *   1. `plane-proven` — a success, and it outranks everything else.
+ *   1. `plane-proven` — a success, and it outranks everything else, but ONLY
+ *      once no capable peer is left. The plane is proven by an aggregate over
+ *      every peer, so a member serving its own shared-memory rows and no
+ *      snapshot refs proves it — the ordinary shape in a multi-member public
+ *      Context Graph. Stopping on that alone abandons a peer that reported a
+ *      complete manifest with refs still unresolved, which is the abandonment
+ *      #2050 exists to remove; the aggregate would make the fix inert exactly
+ *      where it was aimed. Proof of the plane says the graph is reachable, not
+ *      that this peer has nothing left to give.
  *   2. `coverage-stalled` — the walk is not converging. Reported ahead of the
  *      hard bounds because it changes what an operator should do: a stalled run
  *      that also hit the budget would otherwise read as "raise the budget", and
@@ -111,7 +119,10 @@ export function shouldRunAnotherCatchupPass(input: CatchupPassPolicyInput): Catc
   const stop = (reason: CatchupPassDecisionReason): CatchupPassDecision =>
     ({ continue: false, peers: [], reason });
 
-  if (input.planeProven) return stop('plane-proven');
+  // Gated on the capable set: proof-by-data is an aggregate over every peer, so
+  // an unrelated clean round must not end the walk while a peer that declared a
+  // complete manifest still has refs outstanding.
+  if (input.planeProven && input.capablePeers.length === 0) return stop('plane-proven');
   // Strictly greater: a pass that resolved exactly as much as every pass before
   // it moved nothing, however large the number is.
   if (input.lastPassCoverage <= input.coverageHighWaterMark) return stop('coverage-stalled');

--- a/packages/agent/src/sync/catchup-pass-policy.ts
+++ b/packages/agent/src/sync/catchup-pass-policy.ts
@@ -91,6 +91,104 @@ export interface CatchupPassDecision {
   reason: CatchupPassDecisionReason;
 }
 
+export interface CatchupPassConfig {
+  /** Wall-clock budget for continuation passes only. */
+  budgetMs: number;
+  /** Total passes permitted, including the initial walk. */
+  maxPasses: number;
+}
+
+/** The coverage fields needed by the shared continuation ledger. */
+export interface CatchupPassCoverage {
+  snapshotsResolved: number;
+  snapshotsTotal: number;
+  manifestComplete: boolean;
+}
+
+/**
+ * Shared state owner for both catch-up drivers.
+ *
+ * Last-round coverage decides which peers are still capable, while a separate
+ * monotone per-peer high-water ledger decides whether the most recent pass made
+ * progress. Keeping both maps here prevents the worker and inline agent from
+ * silently acquiring different retry semantics.
+ */
+export class SwmCatchupPassTracker<TCoverage extends CatchupPassCoverage> {
+  private readonly lastCoverageByPeer = new Map<string, TCoverage>();
+
+  private readonly peerProgressHighWater = new Map<string, number>();
+
+  private coverageHighWaterMark = 0;
+
+  private completedContinuationPasses = 0;
+
+  recordPeerRound(
+    peerId: string,
+    coverage: TCoverage | undefined,
+    completedWithoutFailure: boolean,
+  ): void {
+    if (coverage) {
+      this.lastCoverageByPeer.set(peerId, coverage);
+      const seen = this.peerProgressHighWater.get(peerId) ?? 0;
+      if (coverage.snapshotsResolved > seen) {
+        this.peerProgressHighWater.set(peerId, coverage.snapshotsResolved);
+      }
+      return;
+    }
+
+    // A clean coverage-free response is evidence that this peer has no manifest.
+    // A failed response proves no such thing, so retain the last positive record.
+    if (completedWithoutFailure) this.lastCoverageByPeer.delete(peerId);
+  }
+
+  capablePeers(): string[] {
+    const capable: string[] = [];
+    for (const [peerId, coverage] of this.lastCoverageByPeer) {
+      if (
+        coverage.manifestComplete
+        && coverage.snapshotsTotal > 0
+        && coverage.snapshotsResolved < coverage.snapshotsTotal
+      ) {
+        capable.push(peerId);
+      }
+    }
+    return capable;
+  }
+
+  progress(): number {
+    let total = 0;
+    for (const resolved of this.peerProgressHighWater.values()) total += resolved;
+    return total;
+  }
+
+  continuationPasses(): number {
+    return this.completedContinuationPasses;
+  }
+
+  decide(input: {
+    nowMs: number;
+    deadlineMs: number;
+    maxPasses: number;
+    planeProven: boolean;
+  }): CatchupPassDecision {
+    return shouldRunAnotherCatchupPass({
+      ...input,
+      passesRun: 1 + this.completedContinuationPasses,
+      coverageHighWaterMark: this.coverageHighWaterMark,
+      lastPassCoverage: this.progress(),
+      capablePeers: this.capablePeers(),
+    });
+  }
+
+  /** Mark a continuation as started and return the progress reading before it. */
+  startContinuationPass(): number {
+    const before = this.progress();
+    this.coverageHighWaterMark = before;
+    this.completedContinuationPasses += 1;
+    return before;
+  }
+}
+
 /**
  * Decide whether the walk gets another pass, and over which peers.
  *
@@ -178,8 +276,8 @@ export const DEFAULT_SWM_CATCHUP_MAX_PASSES = 4;
  * Parse the operator-facing pass budget.
  *
  * Exported as a pure function for the same reason `resolveCatchupBackpressureMaxWaitMs`
- * is: the constant below resolves once at module load, which makes the env
- * contract untestable in place — and it has the same sharp edge. A BLANK
+ * is: configuration is resolved into an explicit per-job value, and the parser
+ * has the same sharp edge. A BLANK
  * assignment is the normal docker-compose / `.env` / systemd shape for "not set",
  * but `Number('')` is `0`, which here would silently disable every extra pass and
  * leave the node with exactly the #2050 behaviour the operator was trying to fix.
@@ -214,8 +312,24 @@ export function resolveSwmCatchupMaxPasses(raw: string | undefined): number {
     : DEFAULT_SWM_CATCHUP_MAX_PASSES;
 }
 
-export const SWM_CATCHUP_PASS_BUDGET_MS: number =
-  resolveSwmCatchupPassBudgetMs(process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS);
-
-export const SWM_CATCHUP_MAX_PASSES: number =
-  resolveSwmCatchupMaxPasses(process.env.DKG_SWM_CATCHUP_MAX_PASSES);
+/**
+ * Resolve continuation limits at job start rather than module load.
+ *
+ * Long-lived agents and worker test processes may run many jobs. Capturing the
+ * environment on first import made later jobs depend on import order and forced
+ * every configuration test into a separate module registry. Returning one
+ * explicit value keeps parsing pure and lets each driver inject the same shape
+ * into its continuation loop.
+ */
+export function resolveSwmCatchupPassConfig(environment: {
+  DKG_SWM_CATCHUP_PASS_BUDGET_MS?: string;
+  DKG_SWM_CATCHUP_MAX_PASSES?: string;
+} = {
+  DKG_SWM_CATCHUP_PASS_BUDGET_MS: process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS,
+  DKG_SWM_CATCHUP_MAX_PASSES: process.env.DKG_SWM_CATCHUP_MAX_PASSES,
+}): CatchupPassConfig {
+  return {
+    budgetMs: resolveSwmCatchupPassBudgetMs(environment.DKG_SWM_CATCHUP_PASS_BUDGET_MS),
+    maxPasses: resolveSwmCatchupMaxPasses(environment.DKG_SWM_CATCHUP_MAX_PASSES),
+  };
+}

--- a/packages/agent/src/sync/catchup-pass-policy.ts
+++ b/packages/agent/src/sync/catchup-pass-policy.ts
@@ -125,7 +125,30 @@ export function shouldRunAnotherCatchupPass(input: CatchupPassPolicyInput): Catc
   if (input.planeProven && input.capablePeers.length === 0) return stop('plane-proven');
   // Strictly greater: a pass that resolved exactly as much as every pass before
   // it moved nothing, however large the number is.
-  if (input.lastPassCoverage <= input.coverageHighWaterMark) return stop('coverage-stalled');
+  //
+  // Suppressed at the pass-1 boundary while a capable peer exists. There
+  // `coverageHighWaterMark` is 0 by initialization, so the test collapses to
+  // "the whole walk materialized zero" — and that is a state a CAPABLE peer
+  // routinely reports: a store fault that failed every write, or a round whose
+  // deadline was spent by the metadata and aggregate phases so the snapshot walk
+  // yielded at index 0. Such a peer emits `{resolved: 0, total: 250,
+  // manifestComplete: true}`, which says "I hold 250 refs you do not have", and
+  // it earned ZERO repeats while the message told the operator more passes would
+  // not help. That is the same abandonment the plane-proven gate above was
+  // narrowed to prevent, one clause further down.
+  //
+  // This does NOT re-admit the barren-retry the high-water 0-init guards
+  // against. A barren peer emits no coverage record at all
+  // (`recordSnapshotCoverage` returns early when the manifest is empty), and a
+  // truncated-manifest peer is excluded by `capablePeersForNextPass`. So a
+  // non-empty capable set at the pass-1 boundary IS the positive evidence that a
+  // repeat could pay — it is a peer's own statement that it holds what we lack,
+  // not an absence of failure. Later passes still stall normally, and the pass
+  // cap and wall-clock budget still bound the loop.
+  const firstPassWithCapablePeers = input.passesRun === 1 && input.capablePeers.length > 0;
+  if (input.lastPassCoverage <= input.coverageHighWaterMark && !firstPassWithCapablePeers) {
+    return stop('coverage-stalled');
+  }
   if (input.capablePeers.length === 0) return stop('no-capable-peers');
   if (input.passesRun >= input.maxPasses) return stop('max-passes-reached');
   // `>=`, so a budget of 0 stops before the first repeat rather than granting one.

--- a/packages/agent/src/sync/catchup-policy.ts
+++ b/packages/agent/src/sync/catchup-policy.ts
@@ -182,7 +182,7 @@ export function catchupSourceForMode(mode: CatchupMode): CatchupAdmissionSource 
  * duration rather than a point in time, so it must not follow a wall-clock
  * correction. Falls back to `Date.now` only if `performance` is unavailable.
  */
-const monotonicNow: () => number = typeof performance?.now === 'function'
+export const monotonicNow: () => number = typeof performance?.now === 'function'
   ? () => performance.now()
   : Date.now;
 

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -374,6 +374,71 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       let materializationFailures = 0;
       let materializedQuads = 0;
       const materializedKeys = new Set<string>();
+
+      // #2050 G7. `replaceHeadMetadata` is DELETE-ONLY, and the compensating
+      // `storeInsert(processed.verifiedMeta)` sits below the `continue` on the
+      // incomplete branch — so a round that ran out of clock mid-list deleted the
+      // head rows of the KAs it had just materialized and never rewrote them:
+      // content present, heads absent, invisible to every head reader, and
+      // permanent, because the next round sees the content and skips.
+      //
+      // Each KA's own verified metadata is therefore rewritten here, inside the
+      // same write lock, immediately after the delete — narrowing a window that
+      // already exists rather than opening a new one.
+      const quadKey = (quad: Quad): string =>
+        `${quad.graph} ${quad.subject} ${quad.predicate} ${quad.object}`;
+      const verifiedMetaKeys = new Set(processed.verifiedMeta.map(quadKey));
+      // Which verified meta rows the per-KA path has already written this round.
+      // Plain accumulation, NOT overlap compensation: descriptor `metadataQuads`
+      // are pairwise disjoint by construction — a head subject belongs to one
+      // descriptor by the parser's grouping key, and an operation subject is
+      // pinned to a single `kaUal`/`assertionVersion` by `validateOperationRows`.
+      const perKaInsertedMetaKeys = new Set<string>();
+      let contextGraphEnsured = false;
+      const ensureContextGraphOnce = async (): Promise<void> => {
+        if (contextGraphEnsured) return;
+        await ensureContextGraph(pid);
+        contextGraphEnsured = true;
+      };
+      /**
+       * True when the stored head already certifies exactly THIS descriptor's
+       * version. Anything else — no head at all, or an older one — must be
+       * rewritten: by this point `storedVersionOutranksDescriptor` has already
+       * returned for every stored version that outranks or fails to parse, so a
+       * surviving mismatch is a head that under-states what the store holds.
+       * That is reachable whenever a pass replaced the graph and stopped before
+       * the head swap, and it never self-heals through partial rounds — which is
+       * the only kind of round #2050's scenario gets.
+       */
+      const headCertifiesDescriptor = (stored: string | null, descriptorVersion: string): boolean => {
+        if (stored === null) return false;
+        try {
+          return BigInt(stored) === BigInt(descriptorVersion);
+        } catch {
+          return false;
+        }
+      };
+      /**
+       * Write this descriptor's verified metadata, and count each distinct row
+       * once. The filter is defensive only: on the public lane descriptors are
+       * parsed from `processed.verifiedMeta` itself and `metadataQuads` is a
+       * partition of that same input, so it cannot drop a row here — but it is
+       * what makes the ledger provably a subset of this round's verified keys,
+       * which is what makes the bulk subtraction below exact.
+       */
+      const insertVerifiedDescriptorMeta = async (
+        descriptor: GraphScopedSwmRecoveryDescriptor,
+      ): Promise<void> => {
+        const rows = descriptor.metadataQuads.filter(
+          (quad) => verifiedMetaKeys.has(quadKey(quad)) && !perKaInsertedMetaKeys.has(quadKey(quad)),
+        );
+        if (rows.length === 0) return;
+        await ensureContextGraphOnce();
+        await storeInsert([...rows]);
+        for (const quad of rows) perKaInsertedMetaKeys.add(quadKey(quad));
+        summary.insertedTriples += rows.length;
+        summary.insertedMetaTriples += rows.length;
+      };
       const materializeReadySnapshot = async (snapshotRef: string): Promise<void> => {
         const descriptors = snapshotDescriptorsByRef.get(snapshotRef);
         if (!descriptors?.length || !snapshotMaterializer || !publicSnapshotStore) return;
@@ -416,15 +481,27 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
                 // digest is an OLDER version of the same size and must be
                 // replaced, not skipped.
                 if (await snapshotMaterializer.isGraphAssetMaterialized(descriptor)) {
-                  if (storedHead.needsRepair) {
-                    // Content is already this descriptor's, but the head
-                    // subject still carries union-insert residue (several
-                    // version/operation rows) — e.g. a prior round replaced
-                    // the graph and then failed before finishing the metadata
-                    // swap. Collapse the head now; the fresh verified meta for
-                    // this descriptor is re-inserted after the snapshot phase,
-                    // exactly like the replace path below.
+                  // Content is already this descriptor's. Two states still need
+                  // the head rewritten, and BOTH are invisible to a reader that
+                  // only looks at content:
+                  //
+                  // (1) union-insert residue — several version/operation rows on
+                  //     one subject, left by a prior round that replaced the
+                  //     graph and failed before finishing the metadata swap;
+                  // (2) a head that does not certify THIS descriptor's version —
+                  //     absent entirely (the r26 residual: content written, head
+                  //     deleted, never rewritten), or an older version left by a
+                  //     pass that stopped between the replace and the swap.
+                  //
+                  // Both are repaired the same way and for the same reason: on a
+                  // partial round nothing else writes this head, so leaving it
+                  // means the KA stays unreadable no matter how many passes run.
+                  if (
+                    storedHead.needsRepair
+                    || !headCertifiesDescriptor(storedHead.version, descriptor.assertionVersion)
+                  ) {
                     await snapshotMaterializer.replaceHeadMetadata(pid, descriptor);
+                    await insertVerifiedDescriptorMeta(descriptor);
                   }
                   materializedKeys.add(graphKey);
                   return;
@@ -434,19 +511,38 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
                   fetchedDataQuads: [],
                   publicSnapshotStore,
                 });
-                await ensureContextGraph(pid);
+                await ensureContextGraphOnce();
                 await snapshotMaterializer.replaceGraph(asset.assertionGraph, [...asset.quads]);
                 // Graph first, THEN the head swap — a crash between the two
                 // leaves content newer than the head, which the next round
-                // repairs (digest matches → head collapsed above). The swap
-                // deletes the old head + its operations so the append-style
-                // `storeInsert(processed.verifiedMeta)` below lands on a clean
-                // subject instead of stacking a second version onto it
-                // (LIMIT-1 head readers would otherwise see an arbitrary mix).
+                // repairs (digest matches → head rewritten above). The swap
+                // deletes the old head + its operations so the insert that
+                // follows lands on a clean subject instead of stacking a second
+                // version onto it (LIMIT-1 head readers would otherwise see an
+                // arbitrary mix).
                 await snapshotMaterializer.replaceHeadMetadata(pid, descriptor);
+                // Immediately, and inside this KA's lock: the delete above is
+                // the whole of G7 without it. `storeInsert(processed.verifiedMeta)`
+                // is below the incomplete branch's `continue`, so on a partial
+                // round it never runs and this KA's head would stay deleted.
+                await insertVerifiedDescriptorMeta(descriptor);
                 materializedKeys.add(graphKey);
                 materializedGraphs += 1;
                 materializedQuads += asset.quads.length;
+                // Counted HERE, not after the snapshot phase returns. A
+                // snapshot-phase transport failure THROWS, and the prefix-salvage
+                // path does not cover this phase, so the throw unwinds past every
+                // post-call merge — a round that materialized 120 KAs and then
+                // threw used to report zero inserted triples. The KA is already
+                // committed at this point (graph replaced, head rewritten, both
+                // inside this lock), so the counter is describing work that is
+                // durably done rather than work still in flight.
+                summary.insertedTriples += asset.quads.length;
+                // Also DATA progress: lifecycle readiness classifies a round with
+                // zero `insertedDataTriples` as metadata-only, which would
+                // mis-report a successful graph-scoped materialization as "no
+                // data".
+                summary.insertedDataTriples += asset.quads.length;
                 logInfo(ctx, `SWM sync for "${pid}": materialized snapshot ${snapshotRef} `
                   + `as ${asset.assertionGraph} (${asset.quads.length} triples)`);
               },
@@ -485,11 +581,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           : {}),
       });
       if (materializedGraphs > 0) {
-        summary.insertedTriples += materializedQuads;
-        // Also data progress: lifecycle readiness classifies a round with zero
-        // insertedDataTriples as metadata-only, which would mis-report a
-        // successful graph-scoped materialization as "no data".
-        summary.insertedDataTriples += materializedQuads;
+        // Reporting only — the counters were already added per KA, inside the
+        // write lock, so they survive a snapshot-phase throw. Adding them again
+        // here would double-count every materialized triple.
         logInfo(ctx, `SWM sync for "${pid}": materialized ${materializedGraphs} graph-scoped `
           + `KA snapshot(s) totalling ${materializedQuads} triples`);
       }
@@ -582,9 +676,34 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         summary.insertedDataTriples += validWsQuads.length;
       }
       if (processed.verifiedMeta.length > 0) {
+        // Still written in full — an RDF store is a set, so rewriting the rows
+        // the per-KA path already wrote is a no-op, and the rows for KAs that
+        // were NOT materialized still have to land.
+        //
+        // The COUNT subtracts what was already counted, which makes
+        // `insertedMetaTriples` mean this:
+        //   - usable round  → `processed.verifiedMeta.length`, byte-identical to
+        //     the pre-#2050 counter. No existing round's number moves.
+        //   - partial round → the rows the per-KA path wrote: strictly > 0 when
+        //     anything materialized, strictly < the full meta length.
+        //
+        // That second line INVERTS the field's diagnostic meaning, which matters
+        // because `insertedMetaTriples === 0` is the discriminator for whether a
+        // job hit G7 at all. Pre-fix, zero on a partial round WAS the symptom.
+        // Post-fix, non-zero on a partial round is the expected repair signal,
+        // and zero means nothing was materialized rather than that the writes
+        // were thrown away.
+        //
+        // Subtracting the ledger SIZE rather than re-filtering `verifiedMeta` is
+        // what keeps the usable-round identity exact if a meta response ever
+        // carries the same quad twice (an OFFSET-window overlap under concurrent
+        // insert is the plausible source): a re-filter drops both copies and
+        // undercounts by one. Valid because every per-KA row is filtered through
+        // `verifiedMetaKeys`, so the ledger is always a subset of these keys.
         await storeInsert(processed.verifiedMeta);
-        summary.insertedTriples += processed.verifiedMeta.length;
-        summary.insertedMetaTriples += processed.verifiedMeta.length;
+        const newlyCountedMeta = processed.verifiedMeta.length - perKaInsertedMetaKeys.size;
+        summary.insertedTriples += newlyCountedMeta;
+        summary.insertedMetaTriples += newlyCountedMeta;
       }
       recordPhaseOutcome(wsMetaResult);
       recordPhaseOutcome(wsDataResult);

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -487,6 +487,18 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // otherwise abort the whole CG fanout. A parse failure here must degrade to
       // "no materialization this round" — never take down the sync.
       const snapshotDescriptorsByRef = new Map<string, GraphScopedSwmRecoveryDescriptor[]>();
+      // Whether the descriptor map is an AUTHORITATIVE statement about this
+      // round's metadata, i.e. whether "this ref has no descriptor" may be read
+      // as "this ref has nothing to materialize".
+      //
+      // `manifestComplete` cannot answer that. The parse below runs INSIDE a
+      // block whose entry condition is `wsMetaResult.completed`, so on the
+      // failure path `manifestComplete` is guaranteed true exactly where the map
+      // is guaranteed empty-for-the-wrong-reason. Manifest complete AND
+      // descriptors never parsed is a third state, distinct both from a
+      // truncated meta phase and from a genuine entity-share manifest that has
+      // no head rows to describe.
+      let descriptorsAuthoritative = true;
       if (snapshotMaterializer && publicSnapshotStore && wsMetaResult.completed) {
         try {
           for (const descriptor of parseGraphScopedSwmRecoveryDescriptors({
@@ -510,6 +522,13 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           logWarn(ctx, `SWM sync could not parse graph-scoped snapshot descriptors for "${pid}": `
             + `${err instanceof Error ? err.message : String(err)}`);
           snapshotDescriptorsByRef.clear();
+          // The map is now empty because parsing FAILED, not because there was
+          // nothing to describe. Without this the vacuity rule would read every
+          // manifest ref as "nothing to write" and report the graph fully
+          // materialized while zero assertion graphs were written — and because
+          // the parser builds its whole array before returning, ONE malformed
+          // head discards the descriptors of every valid KA alongside it.
+          descriptorsAuthoritative = false;
         }
       }
       let materializedGraphs = 0;
@@ -609,7 +628,12 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // descriptors at all — there "no descriptor" means "not known yet", and
         // counting it would inflate coverage for a peer that advertised nothing.
         if (!descriptors?.length) {
-          if (manifestComplete) {
+          // `descriptorsAuthoritative` as well as `manifestComplete`: a parse
+          // failure empties this map while the meta phase reports complete, and
+          // treating that as vacuity reports full coverage on a round that wrote
+          // nothing — wrong in the flattering direction, which is the direction
+          // no downstream reader can detect.
+          if (manifestComplete && descriptorsAuthoritative) {
             materializedRefs.add(snapshotRef);
             materializedRefsForCg = materializedRefs.size;
           }
@@ -852,10 +876,26 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // insert below stamps a graph-scoped head marker for an assertion graph
       // that was never materialized, and every later pass skips it as already
       // present — turning a transient store error into permanent, silent loss.
-      const snapshotPhaseUsable = snapshotSync.completed && materializationFailures === 0;
+      // `descriptorsAuthoritative` belongs in this conjunction for the same
+      // reason `materializationFailures` does: in both cases snapshots were
+      // fetched and verified but the Knowledge Assets behind them were NOT
+      // written. A parse failure produces no `materializationFailures` — nothing
+      // was ever attempted — so without this the phase reads usable, the bulk
+      // `storeInsert(processed.verifiedMeta)` below lands head rows certifying
+      // assertion graphs that hold nothing, and the next round's
+      // `isGraphAssetMaterialized` sees those markers and skips the KAs for
+      // good. That is the same permanent-invisibility failure the G7 repair in
+      // this PR exists to prevent, arrived at from a different direction.
+      const snapshotPhaseUsable = snapshotSync.completed
+        && materializationFailures === 0
+        && descriptorsAuthoritative;
       if (materializationFailures > 0) {
         logWarn(ctx, `SWM sync for "${pid}": ${materializationFailures} snapshot(s) verified but `
           + `not materialized — holding the phase incomplete so metadata cannot certify them`);
+      }
+      if (!descriptorsAuthoritative) {
+        logWarn(ctx, `SWM sync for "${pid}": snapshot descriptors could not be parsed — holding `
+          + `the phase incomplete so metadata cannot certify Knowledge Assets that were never written`);
       }
       if (!snapshotPhaseUsable) {
         // The responder was reachable, but the snapshot phase did not produce

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -587,11 +587,34 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       };
       const materializeReadySnapshot = async (snapshotRef: string): Promise<void> => {
         const descriptors = snapshotDescriptorsByRef.get(snapshotRef);
-        // No descriptors, no materializer, or no store means nothing is
-        // written, so this ref stays UNRESOLVED. Returning without recording it
-        // is the point: a fetched-but-unwritten ref must never look like
-        // progress to the continuation loop.
-        if (!descriptors?.length || !snapshotMaterializer || !publicSnapshotStore) return;
+        // Missing WIRING means nothing CAN be written, so the ref stays
+        // UNRESOLVED: a fetched-but-unwritten ref must never look like progress
+        // to the continuation loop.
+        if (!snapshotMaterializer || !publicSnapshotStore) return;
+        // No descriptors is a DIFFERENT case, and collapsing the two made a
+        // fully-synced peer permanently capable.
+        //
+        // The denominator (`snapshotsTotal`) counts refs in the peer's manifest;
+        // the numerator counts refs we materialized. A manifest ref that this
+        // round's verified metadata does not describe — a superseded
+        // share-operation row, say — has no descriptor, so it could never enter
+        // `materializedRefs`. `snapshotsResolved < snapshotsTotal` then held
+        // FOREVER: `capablePeersForNextPass` kept calling that peer capable, and
+        // every future catch-up job spent its whole pass budget re-walking a
+        // graph that was already complete, at O(KA size) per cached ref.
+        //
+        // When the manifest is complete, "no descriptor" means there is genuinely
+        // nothing to write for this ref, so it is resolved by vacuity. Gated on
+        // `manifestComplete` because a truncated meta phase never parsed
+        // descriptors at all — there "no descriptor" means "not known yet", and
+        // counting it would inflate coverage for a peer that advertised nothing.
+        if (!descriptors?.length) {
+          if (manifestComplete) {
+            materializedRefs.add(snapshotRef);
+            materializedRefsForCg = materializedRefs.size;
+          }
+          return;
+        }
         let refMaterialized = true;
         for (const descriptor of descriptors) {
           const graphKey = `${descriptor.metaGraph}\u0000${descriptor.assertionGraph}`;

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -1,6 +1,7 @@
 import { contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri, validateSubGraphName } from '@origintrail-official/dkg-core';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
+import type { SwmSnapshotCoverage } from '../../dkg-agent-types.js';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncPhase } from '../auth/request-build.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
@@ -34,6 +35,72 @@ export interface SharedMemorySyncSummary {
   backoffWorthyFailures: number;
   /** Context Graph admissions deferred by local scheduler pressure. */
   deferredBackpressure: number;
+  /**
+   * Snapshot phases that stopped on the local clock with refs still unfetched.
+   * A voluntary yield, NOT a peer fault — see `SwmSnapshotCoverage` and the
+   * note on `SharedMemorySyncDiagnostics.snapshotPlaneIncomplete`.
+   */
+  snapshotPlaneIncomplete: number;
+  /** Coherent snapshot coverage for this round; reduced only by {@link selectSwmSnapshotCoverage}. */
+  swmCoverage?: SwmSnapshotCoverage;
+  /**
+   * The REPLAY half of `bytesReceived` — metadata AND aggregate data, the two
+   * phases a repeated pass re-fetches in full. `bytesReceived` merges these
+   * with snapshot bytes into one scalar, which leaves the accepted cost of
+   * repeating the peer walk unmeasurable in bytes.
+   */
+  replayPhaseBytesReceived: number;
+  /** The USEFUL half of `bytesReceived` — immutable snapshot content. */
+  snapshotPhaseBytesReceived: number;
+}
+
+/**
+ * Pick the coverage record a caller should report, WHOLE.
+ *
+ * This is the single reduction for {@link SwmSnapshotCoverage}, used both when
+ * one peer's rounds are merged across Context Graphs (`mergeSharedMemorySyncResults`)
+ * and when a catch-up walk merges across peers. It never builds a new pair of
+ * counts — the returned record is byte-for-byte one of its inputs, so the
+ * counts, the peer they are attributed to, and the missing sample always
+ * describe the same round.
+ *
+ * Order: authority evidence, then a complete manifest (an incomplete one's
+ * denominator is only a lower bound), then the LARGEST manifest, then the most
+ * resolved within that manifest, then a lexicographic peer-id tiebreak.
+ *
+ * **Largest manifest, not best fraction.** Ranking by `resolved/total` picks
+ * `200/200` over `178/250` and so reports "0 outstanding" on a job that is 72
+ * Knowledge Assets short. That is worse than the synthetic `200/250` this
+ * record shape exists to prevent, because it is internally self-consistent and
+ * nothing downstream can detect it. The largest complete manifest is the best
+ * known lower bound on what the graph actually holds, so the shortfall is
+ * reported against that.
+ *
+ * Residual, stated: a peer that sorts first on authority still wins with a
+ * stale or smaller manifest, and can report converged while a
+ * non-authoritative peer knows of more. That one is accepted — the curator is
+ * definitionally authoritative about its own Context Graph's inventory.
+ */
+export function selectSwmSnapshotCoverage(
+  a: SwmSnapshotCoverage | undefined,
+  b: SwmSnapshotCoverage | undefined,
+): SwmSnapshotCoverage | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  if ((a.fromAuthority ?? false) !== (b.fromAuthority ?? false)) {
+    return a.fromAuthority ? a : b;
+  }
+  if (a.manifestComplete !== b.manifestComplete) return a.manifestComplete ? a : b;
+  if (a.snapshotsTotal !== b.snapshotsTotal) return a.snapshotsTotal > b.snapshotsTotal ? a : b;
+  if (a.snapshotsResolved !== b.snapshotsResolved) {
+    return a.snapshotsResolved > b.snapshotsResolved ? a : b;
+  }
+  // Genuinely indistinguishable records. This settles a cross-PEER tie only:
+  // in the cross-Context-Graph merge both records come from the SAME peer, so
+  // the suffixes are equal and the choice falls through to `a` — that is,
+  // to Context Graph iteration order. Deterministic either way, but not
+  // because of this comparison.
+  return a.peerIdSuffix <= b.peerIdSuffix ? a : b;
 }
 
 interface SharedMemorySyncContext {
@@ -149,6 +216,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     failedPhases: 0,
     backoffWorthyFailures: 0,
     deferredBackpressure: 0,
+    snapshotPlaneIncomplete: 0,
+    replayPhaseBytesReceived: 0,
+    snapshotPhaseBytesReceived: 0,
   };
 
   const recordPhaseOutcome = (
@@ -222,6 +292,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const verifyDurationMs = Date.now() - verifyStartedAt;
       logInfo(ctx, `  shared memory: ${processed.totalFetchedDataQuads} data + ${processed.totalFetchedMetaQuads} meta triples fetched`);
       summary.bytesReceived += wsMetaResult.bytesReceived + wsDataResult.bytesReceived;
+      summary.replayPhaseBytesReceived += wsMetaResult.bytesReceived + wsDataResult.bytesReceived;
       summary.fetchedMetaTriples += processed.totalFetchedMetaQuads;
       summary.fetchedDataTriples += processed.totalFetchedDataQuads;
       summary.emptyResponses += processed.emptyResponses;
@@ -416,10 +487,39 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           + `KA snapshot(s) totalling ${materializedQuads} triples`);
       }
       summary.bytesReceived += snapshotSync.bytesReceived;
+      summary.snapshotPhaseBytesReceived += snapshotSync.bytesReceived;
       summary.resumedPhases += snapshotSync.resumedPhases;
       summary.timedOutPhases += snapshotSync.timedOutPhases;
       summary.completedPhases += snapshotSync.completedPhases;
       summary.checkpointAdvances += snapshotSync.checkpointAdvances;
+      // Coverage is recorded HERE — above the incomplete branch below — because
+      // a partial round is exactly the round whose coverage the caller needs.
+      // The counts, the peer they are attributed to and the missing sample all
+      // come from this one round and stay together from here on.
+      //
+      // No record for a graph that declared no snapshot refs. `0/0` is not a
+      // shortfall, and a peer with nothing to offer must not look like a peer
+      // that still owes us KAs — an absent record reads as "not capable".
+      //
+      // Across a MULTI-CG call the reduction keeps exactly ONE graph's record,
+      // named by its `contextGraphId`; the others are dropped. Foreground
+      // catch-up always passes a single CG (`dkg-agent-lifecycle.ts:5982`), so
+      // that only bites the on-connect fan-out, where this field is a
+      // diagnostic rather than a decision input.
+      if (snapshotSync.totalSnapshots > 0) {
+        summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
+          contextGraphId: pid,
+          peerIdSuffix: remotePeerId.slice(-8),
+          snapshotsResolved: snapshotSync.readySnapshots,
+          snapshotsTotal: snapshotSync.totalSnapshots,
+          // A truncated meta phase makes `totalSnapshots` a lower bound, and is
+          // also the state in which `snapshotDescriptorsByRef` is empty (:270)
+          // so nothing materializes at all.
+          manifestComplete: wsMetaResult.completed,
+          missingCount: snapshotSync.totalSnapshots - snapshotSync.readySnapshots,
+          missingSample: [],
+        });
+      }
       const snapshotDurationMs = Date.now() - snapshotStartedAt;
       // A snapshot that verified but could not be written must be treated
       // exactly like a snapshot phase that did not complete. Otherwise the meta
@@ -577,6 +677,20 @@ export async function syncPublicSnapshotsForMeta(params: {
   /** Total immutable snapshot refs declared by the verified SWM metadata. */
   totalSnapshots: number;
   completed: boolean;
+  /** Exact count of declared refs this round did not resolve. */
+  missingCount: number;
+  /**
+   * Bounded identifiers for the shortfall. A public peer controls manifest
+   * size, so this is capped; `missingCount` carries the true figure.
+   */
+  missingSample: string[];
+  /**
+   * The round stopped on OUR OWN clock with refs still unfetched — a voluntary
+   * yield, not a peer fault. Callers must surface this as
+   * `snapshotPlaneIncomplete` and must NOT fold it into `timedOutPhases`, which
+   * marks the peer backoff-worthy (`durable-progress.ts` `backoffWorthyFailure`).
+   */
+  yieldedAtDeadline: boolean;
 }> {
   const snapshots = collectPublicSnapshotMetadata(params.metaQuads);
   if (snapshots.length === 0) {
@@ -589,6 +703,9 @@ export async function syncPublicSnapshotsForMeta(params: {
       readySnapshots: 0,
       totalSnapshots: 0,
       completed: true,
+      missingCount: 0,
+      missingSample: [],
+      yieldedAtDeadline: false,
     };
   }
   if (!params.publicSnapshotStore) {
@@ -603,7 +720,37 @@ export async function syncPublicSnapshotsForMeta(params: {
   let completedPhases = 0;
   let checkpointAdvances = 0;
   let readySnapshots = 0;
-  for (const snapshot of snapshots) {
+  let missingCount = 0;
+  let yieldedAtDeadline = false;
+  const missingSample: string[] = [];
+  const noteMissing = (ref: string): void => {
+    missingCount += 1;
+    if (missingSample.length < PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT) missingSample.push(ref);
+  };
+  /** Every ref from `index` onward is unresolved; record them and stop. */
+  const abandonFrom = (index: number): void => {
+    for (let i = index; i < snapshots.length; i += 1) noteMissing(snapshots[i]!.ref);
+  };
+
+  for (const [index, snapshot] of snapshots.entries()) {
+    // Yield BETWEEN Knowledge Assets, and check the clock BEFORE doing any work
+    // for this one. Both halves matter:
+    //
+    // - Before, not after: a cache "hit" is O(KA size) — a full `.nq` read plus
+    //   a SHA-256 — and a miss is a network round trip. Checking afterwards
+    //   would let one KA overrun the budget it was supposed to respect.
+    // - Before the fetch specifically: no `SyncPageResult` exists yet, so
+    //   `timedOutPhases` structurally CANNOT move on this path. That is what
+    //   keeps a local budget decision from being reported as a peer timeout and
+    //   putting a healthy responder into backoff.
+    //
+    // Never mid-KA: a snapshot is applied whole or not at all, so stopping here
+    // can never leave a partially materialized asset.
+    if (Date.now() >= params.deadline) {
+      yieldedAtDeadline = true;
+      abandonFrom(index);
+      break;
+    }
     if (await hasValidSnapshot(params.publicSnapshotStore, snapshot)) {
       await params.onSnapshotReady?.(snapshot, 'cache');
       readySnapshots += 1;
@@ -633,16 +780,8 @@ export async function syncPublicSnapshotsForMeta(params: {
       // monotonic recovery progress across the CG without accepting a partial
       // asset.
       params.deleteCheckpoint(result.checkpointKey);
-      return {
-        bytesReceived,
-        resumedPhases,
-        timedOutPhases,
-        completedPhases,
-        checkpointAdvances,
-        readySnapshots,
-        totalSnapshots: snapshots.length,
-        completed: false,
-      };
+      abandonFrom(index);
+      break;
     }
 
     const snapshotQuads = result.quads.map((quad) => ({ ...quad, graph: '' }));
@@ -654,17 +793,17 @@ export async function syncPublicSnapshotsForMeta(params: {
       // in a later bounded recovery round. Equal-count digest mismatches remain
       // fatal below so a complete but tampered snapshot is never softened into
       // a transport retry.
+      //
+      // SKIP this ref and keep walking, rather than returning. Ref order is
+      // byte-identical on every pass (`Map` insertion order), so returning here
+      // would pin every future pass at this same index: one permanently
+      // unserveable ref would stall the whole manifest forever and drive a
+      // repeat-pass design to a fixed point at zero progress. Skipping costs
+      // this KA and nothing else — it stays uncached and unapplied, and is
+      // retried from offset zero next pass.
       params.deleteCheckpoint(result.checkpointKey);
-      return {
-        bytesReceived,
-        resumedPhases,
-        timedOutPhases,
-        completedPhases,
-        checkpointAdvances,
-        readySnapshots,
-        totalSnapshots: snapshots.length,
-        completed: false,
-      };
+      noteMissing(snapshot.ref);
+      continue;
     }
     const actualDigest = workspacePublicQuadsDigest(snapshotQuads);
     if (actualDigest !== snapshot.digest || snapshotQuads.length !== snapshot.count) {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -321,12 +321,48 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     logInfo(ctx, `Stopping SWM sync fanout for ${remotePeerId} after "${contextGraphId}" (${reason})`);
     return true;
   };
+  /**
+   * The ONE place a coverage record is built. Both the success path and the
+   * throw path go through it, so a record can never be reassembled in a catch
+   * block from scalars that did not travel together — the failure mode the
+   * whole-record contract exists to prevent.
+   *
+   * `walk` supplies every count as one coherent group; only the round-level
+   * attribution is added here.
+   */
+  const recordSnapshotCoverage = (
+    walk: PublicSnapshotWalkProgress,
+    manifestComplete: boolean,
+    materializationFailures: number,
+    contextGraphId: string,
+  ): void => {
+    // No record for a graph that declared no snapshot refs. `0/0` is not a
+    // shortfall, and a peer with nothing to offer must not look like a peer
+    // that still owes us KAs — an absent record reads as "not capable".
+    if (walk.totalSnapshots <= 0) return;
+    summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
+      contextGraphId,
+      peerIdSuffix: remotePeerId.slice(-8),
+      // Refs FETCHED and digest-valid, which is not the same as Knowledge
+      // Assets written — see `materializationFailures`.
+      snapshotsResolved: walk.readySnapshots,
+      snapshotsTotal: walk.totalSnapshots,
+      manifestComplete,
+      missingCount: walk.missingCount,
+      missingSample: walk.missingSample,
+      materializationFailures,
+    });
+  };
+
   for (const [index, pid] of contextGraphIds.entries()) {
     let peerRespondedForContextGraph = false;
     // Hoisted out of the `try` so the `catch` can still say whether this peer's
     // manifest was whole. Without it a throwing round could only report a
     // denominator with no way to mark it a lower bound.
     let manifestComplete = false;
+    // Likewise: materialization failures recorded before the throw are real and
+    // must reach the coverage record, not be lost with the stack.
+    let materializedFailuresForCg = 0;
     try {
       const wsGraph = contextGraphWorkspaceGraphUri(pid);
       const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(pid);
@@ -620,6 +656,8 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
             // the caller keeps the phase incomplete and withholds the metadata
             // that would otherwise certify a graph that was never written.
             materializationFailures += 1;
+            // Mirrored outside the `try` so a later throw cannot lose it.
+            materializedFailuresForCg = materializationFailures;
             logWarn(ctx, `SWM sync failed to materialize snapshot ${snapshotRef} for "${pid}": `
               + `${err instanceof Error ? err.message : String(err)}`);
           }
@@ -672,22 +710,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // `dkg-agent-lifecycle.ts`, the only caller of this function), so that
       // only bites the on-connect fan-out, where this field is a diagnostic
       // rather than a decision input.
-      if (snapshotSync.totalSnapshots > 0) {
-        summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
-          contextGraphId: pid,
-          peerIdSuffix: remotePeerId.slice(-8),
-          snapshotsResolved: snapshotSync.readySnapshots,
-          snapshotsTotal: snapshotSync.totalSnapshots,
-          // A truncated meta phase makes `totalSnapshots` a lower bound, and is
-          // also the state in which `snapshotDescriptorsByRef` is empty (:270)
-          // so nothing materializes at all.
-          manifestComplete: wsMetaResult.completed,
-          // Both come from the snapshot walk itself, so the sample always
-          // names refs counted by `missingCount` in this same round.
-          missingCount: snapshotSync.missingCount,
-          missingSample: snapshotSync.missingSample,
-        });
-      }
+      recordSnapshotCoverage(snapshotSync, wsMetaResult.completed, materializationFailures, pid);
       // A voluntary yield is OUR budget decision, not the peer's fault. It is
       // recorded here and deliberately kept out of `timedOutPhases`, which
       // feeds `backoffWorthyFailure` and would back the peer off for it. It is
@@ -792,16 +815,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // `snapshotsResolved`, so it would see a converging peer as stalled and
       // drop it. Recover the walk's own counts and record them here.
       const thrownProgress = readPublicSnapshotWalkProgress(err);
-      if (thrownProgress && thrownProgress.totalSnapshots > 0) {
-        summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
-          contextGraphId: pid,
-          peerIdSuffix: remotePeerId.slice(-8),
-          snapshotsResolved: thrownProgress.readySnapshots,
-          snapshotsTotal: thrownProgress.totalSnapshots,
-          manifestComplete,
-          missingCount: thrownProgress.missingCount,
-          missingSample: thrownProgress.missingSample,
-        });
+      if (thrownProgress) {
+        // Same builder as the success path — the counts arrive as one coherent
+        // group attached by the walk, never reassembled here.
+        recordSnapshotCoverage(thrownProgress, manifestComplete, materializedFailuresForCg, pid);
       }
       logWarn(ctx, `SWM sync for context graph "${pid}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
       if (isSyncPermanentRejection(err)) {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -22,6 +22,26 @@ const DKG = 'http://dkg.io/ontology/';
  * structure on this node; the exact figure travels as `missingCount`.
  */
 const PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT = 10;
+/**
+ * Stored length of ONE sampled ref.
+ *
+ * A ref is a `dkg:publicSnapshotRef` literal chosen by a remote peer and only
+ * `.trim()`ed on the way in, so its length is peer-controlled. Capping the
+ * SAMPLE SIZE bounds how many we keep, not how big each one is: ten refs of a
+ * megabyte each still cross the worker RPC and sit in the diagnostics record.
+ *
+ * Bounded at the source as well as at the renderer. The renderer's bound is what
+ * protects the operator-facing sentence; this one keeps an oversized literal out
+ * of memory and off the wire, which the renderer cannot do from the far side.
+ */
+const PUBLIC_SNAPSHOT_REF_SAMPLE_MAX_CHARS = 128;
+
+/** Bound one sampled ref. Truncation is marked so it cannot read as complete. */
+function boundSampledRef(ref: string): string {
+  return ref.length > PUBLIC_SNAPSHOT_REF_SAMPLE_MAX_CHARS
+    ? `${ref.slice(0, PUBLIC_SNAPSHOT_REF_SAMPLE_MAX_CHARS)}\u2026`
+    : ref;
+}
 
 /**
  * Snapshot-walk progress carried OUT of a throw.
@@ -699,10 +719,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
               unresolvedRefSample.length < PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT
               && !unresolvedRefSample.includes(snapshotRef)
             ) {
-              unresolvedRefSample.push(snapshotRef);
+              unresolvedRefSample.push(boundSampledRef(snapshotRef));
               // Mirrored outside the `try`, like the counters, so a later throw
               // cannot lose refs we already know failed to write.
-              unresolvedRefSampleForCg.push(snapshotRef);
+              unresolvedRefSampleForCg.push(boundSampledRef(snapshotRef));
             }
             // Mirrored outside the `try` so a later throw cannot lose it.
             materializedFailuresForCg = materializationFailures;
@@ -1020,7 +1040,9 @@ export async function syncPublicSnapshotsForMeta(params: {
   const missingSample: string[] = [];
   const noteMissing = (ref: string): void => {
     missingCount += 1;
-    if (missingSample.length < PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT) missingSample.push(ref);
+    if (missingSample.length < PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT) {
+      missingSample.push(boundSampledRef(ref));
+    }
   };
   /** Every ref from `index` onward is unresolved; record them and stop. */
   const abandonFrom = (index: number): void => {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -886,9 +886,18 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // `isGraphAssetMaterialized` sees those markers and skips the KAs for
       // good. That is the same permanent-invisibility failure the G7 repair in
       // this PR exists to prevent, arrived at from a different direction.
+      // The `descriptorsAuthoritative` conjunct is scoped to rounds that
+      // actually declared snapshot refs. With an empty manifest there is no
+      // snapshot the metadata could wrongly certify, so holding the phase down
+      // protects nothing and only discards this round's verified metadata — and
+      // `recordSnapshotCoverage` returns early on an empty manifest, so no
+      // coverage record exists to explain the shortfall either. A Context Graph
+      // whose slices are all graph-backed (`dkg:publicSnapshotGraph`, written
+      // when the publisher has no snapshot store) declares zero refs and hit
+      // exactly that.
       const snapshotPhaseUsable = snapshotSync.completed
         && materializationFailures === 0
-        && descriptorsAuthoritative;
+        && (descriptorsAuthoritative || snapshotSync.totalSnapshots === 0);
       if (materializationFailures > 0) {
         logWarn(ctx, `SWM sync for "${pid}": ${materializationFailures} snapshot(s) verified but `
           + `not materialized — holding the phase incomplete so metadata cannot certify them`);

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -778,9 +778,33 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // Fires for BOTH 'cache' and 'network' sources, so a node whose earlier
         // runs already cached the blobs materializes them on the next pass
         // without refetching a byte.
-        ...(snapshotDescriptorsByRef.size > 0
-          ? { onSnapshotReady: (snapshot: PublicSnapshotMetadata) => materializeReadySnapshot(snapshot.ref) }
-          : {}),
+        //
+        // Wired UNCONDITIONALLY. It used to be gated on
+        // `snapshotDescriptorsByRef.size > 0`, which looked like an optimisation
+        // and was the reason a whole class of Context Graph reported `0/N`
+        // snapshots for ever.
+        //
+        // The manifest and the descriptors come from different readers.
+        // `collectPublicSnapshotMetadata` accepts any subject carrying
+        // `dkg:publicQuadsDigest` + `dkg:publicQuadsCount`, while
+        // `parseGraphScopedSwmRecoveryDescriptors` anchors on `#dkg-swm-head`
+        // subjects only. An entity-level share writes its public slice under a
+        // `urn:dkg:public-stage:...` subject and no head row, so a CG written
+        // entirely by that path — the primary shared-memory write API — produces
+        // refs in the manifest and NO descriptors at all. The hook was then never
+        // wired, `materializeReadySnapshot` never ran, and the ref could not be
+        // counted resolved by any path.
+        //
+        // `snapshotsResolved < snapshotsTotal` therefore held permanently, so
+        // `capablePeersForNextPass` kept nominating a peer that owed us nothing,
+        // on every pass of every catch-up job, at O(KA size) per cached ref.
+        //
+        // Wiring it always is what makes the descriptor-less branch inside
+        // `materializeReadySnapshot` reachable, and that branch is where the
+        // vacuity decision — and its `manifestComplete` guard — actually lives.
+        // The hook still early-returns when the materializer or the store is
+        // absent, so this costs nothing when there is genuinely no wiring.
+        onSnapshotReady: (snapshot: PublicSnapshotMetadata) => materializeReadySnapshot(snapshot.ref),
       });
       if (materializedGraphs > 0) {
         // Reporting only — the counters were already added per KA, inside the

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -23,6 +23,65 @@ const DKG = 'http://dkg.io/ontology/';
  */
 const PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT = 10;
 
+/**
+ * Snapshot-walk progress carried OUT of a throw.
+ *
+ * A snapshot-phase transport failure throws, and the throw unwinds past the
+ * point where the caller reads the walk's return value — so a round that
+ * materialized 120 Knowledge Assets and then failed on the 121st reported
+ * ZERO. That is not merely a diagnostics gap: the continuation loop's progress
+ * signal is `swmCoverage.snapshotsResolved`, so the high-water mark never
+ * moved, and the loop declared `coverage-stalled` and abandoned a peer that
+ * was converging — the exact behaviour #2050 exists to remove.
+ *
+ * The counts are the walk's own, so `snapshotsResolved + missingCount ===
+ * snapshotsTotal` holds on this path exactly as it does on the returned one.
+ */
+export interface PublicSnapshotWalkProgress {
+  readySnapshots: number;
+  totalSnapshots: number;
+  missingCount: number;
+  missingSample: string[];
+}
+
+/** Non-enumerable so the payload never widens a structured-clone or log dump. */
+const PUBLIC_SNAPSHOT_PROGRESS_KEY = '__swmPublicSnapshotProgress';
+
+function attachPublicSnapshotWalkProgress(err: unknown, progress: PublicSnapshotWalkProgress): void {
+  if (typeof err !== 'object' || err === null) return;
+  try {
+    Object.defineProperty(err, PUBLIC_SNAPSHOT_PROGRESS_KEY, {
+      value: progress,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  } catch {
+    // A frozen or exotic error is not worth failing the round over; the
+    // caller simply records no coverage for it, exactly as before.
+  }
+}
+
+/** Read progress attached by {@link syncPublicSnapshotsForMeta} before it rethrew. */
+export function readPublicSnapshotWalkProgress(err: unknown): PublicSnapshotWalkProgress | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const progress = (err as Record<string, unknown>)[PUBLIC_SNAPSHOT_PROGRESS_KEY];
+  if (typeof progress !== 'object' || progress === null) return undefined;
+  const candidate = progress as Partial<PublicSnapshotWalkProgress>;
+  // Validated rather than trusted: this crosses an `unknown` boundary, and a
+  // fabricated denominator would corrupt the coverage record the pass loop and
+  // the terminal message both read.
+  if (
+    !Number.isSafeInteger(candidate.readySnapshots)
+    || !Number.isSafeInteger(candidate.totalSnapshots)
+    || !Number.isSafeInteger(candidate.missingCount)
+    || !Array.isArray(candidate.missingSample)
+  ) {
+    return undefined;
+  }
+  return candidate as PublicSnapshotWalkProgress;
+}
+
 export interface SharedMemorySyncSummary {
   insertedTriples: number;
   fetchedMetaTriples: number;
@@ -264,6 +323,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
   };
   for (const [index, pid] of contextGraphIds.entries()) {
     let peerRespondedForContextGraph = false;
+    // Hoisted out of the `try` so the `catch` can still say whether this peer's
+    // manifest was whole. Without it a throwing round could only report a
+    // denominator with no way to mark it a lower bound.
+    let manifestComplete = false;
     try {
       const wsGraph = contextGraphWorkspaceGraphUri(pid);
       const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(pid);
@@ -273,6 +336,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
 
       const fetchStartedAt = Date.now();
       const wsMetaResult = await fetchSyncPages(ctx, remotePeerId, pid, true, 'meta', wsMetaGraph, deadline);
+      manifestComplete = wsMetaResult.completed;
       peerRespondedForContextGraph = true;
       if (wsMetaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
         recordPhaseOutcome(wsMetaResult, { updateCheckpoint: false });
@@ -722,6 +786,23 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         );
       }
     } catch (err) {
+      // A snapshot-phase failure unwinds past the coverage record built on the
+      // success path, so a round that materialized 120 Knowledge Assets and then
+      // threw would report NOTHING — and the continuation loop reads
+      // `snapshotsResolved`, so it would see a converging peer as stalled and
+      // drop it. Recover the walk's own counts and record them here.
+      const thrownProgress = readPublicSnapshotWalkProgress(err);
+      if (thrownProgress && thrownProgress.totalSnapshots > 0) {
+        summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
+          contextGraphId: pid,
+          peerIdSuffix: remotePeerId.slice(-8),
+          snapshotsResolved: thrownProgress.readySnapshots,
+          snapshotsTotal: thrownProgress.totalSnapshots,
+          manifestComplete,
+          missingCount: thrownProgress.missingCount,
+          missingSample: thrownProgress.missingSample,
+        });
+      }
       logWarn(ctx, `SWM sync for context graph "${pid}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
       if (isSyncPermanentRejection(err)) {
         // Missed-seam alarm (OT-RFC-56) — see durable-sync.ts: the oversize
@@ -872,6 +953,26 @@ export async function syncPublicSnapshotsForMeta(params: {
     for (let i = index; i < snapshots.length; i += 1) noteMissing(snapshots[i]!.ref);
   };
 
+  /**
+   * Carry what the walk achieved out through a throw.
+   *
+   * Everything from `index` on is unresolved — the ref that threw included —
+   * so the counts obey the same `resolved + missing === total` invariant the
+   * returned value does. Without this the caller's `catch` sees only an error,
+   * builds no coverage record, and the continuation loop reads a pass that
+   * materialized real Knowledge Assets as non-advancing.
+   */
+  const rethrowWithProgress = (err: unknown, index: number): never => {
+    abandonFrom(index);
+    attachPublicSnapshotWalkProgress(err, {
+      readySnapshots,
+      totalSnapshots: snapshots.length,
+      missingCount,
+      missingSample,
+    });
+    throw err;
+  };
+
   for (const [index, snapshot] of snapshots.entries()) {
     // Yield BETWEEN Knowledge Assets, and check the clock BEFORE doing any work
     // for this one. Both halves matter:
@@ -891,71 +992,78 @@ export async function syncPublicSnapshotsForMeta(params: {
       abandonFrom(index);
       break;
     }
-    if (await hasValidSnapshot(params.publicSnapshotStore, snapshot)) {
-      await params.onSnapshotReady?.(snapshot, 'cache');
-      readySnapshots += 1;
-      continue;
-    }
+    try {
+      if (await hasValidSnapshot(params.publicSnapshotStore, snapshot)) {
+        await params.onSnapshotReady?.(snapshot, 'cache');
+        readySnapshots += 1;
+        continue;
+      }
 
-    const result = await params.fetchSyncPages(
-      params.ctx,
-      params.remotePeerId,
-      params.contextGraphId,
-      true,
-      'snapshot',
-      '',
-      params.deadline,
-      snapshot.ref,
-    );
-    bytesReceived += result.bytesReceived;
-    resumedPhases += result.resumedFromOffset > 0 ? 1 : 0;
-    timedOutPhases += result.timedOut ? 1 : 0;
-    if (result.completed) params.deleteCheckpoint(result.checkpointKey);
-    else {
-      // `fetchSyncPages` returns only the quads fetched during THIS call. We do
-      // not persist an unverified prefix, so resuming a snapshot at nextOffset
-      // would validate only the tail against the full digest/count and can never
-      // succeed. Restart this one immutable KA at offset zero on the next round;
-      // already completed snapshots remain cached and are skipped, preserving
-      // monotonic recovery progress across the CG without accepting a partial
-      // asset.
-      params.deleteCheckpoint(result.checkpointKey);
-      abandonFrom(index);
-      break;
-    }
-
-    const snapshotQuads = result.quads.map((quad) => ({ ...quad, graph: '' }));
-    if (snapshotQuads.length < snapshot.count) {
-      // A relayed stream can terminate cleanly after returning a prefix. The
-      // requester then sees `completed=true`, but the signed metadata gives us
-      // an authoritative expected count and proves that this is incomplete,
-      // not corrupt. Never cache or apply the prefix; retry it from offset zero
-      // in a later bounded recovery round. Equal-count digest mismatches remain
-      // fatal below so a complete but tampered snapshot is never softened into
-      // a transport retry.
-      //
-      // SKIP this ref and keep walking, rather than returning. Ref order is
-      // byte-identical on every pass (`Map` insertion order), so returning here
-      // would pin every future pass at this same index: one permanently
-      // unserveable ref would stall the whole manifest forever and drive a
-      // repeat-pass design to a fixed point at zero progress. Skipping costs
-      // this KA and nothing else — it stays uncached and unapplied, and is
-      // retried from offset zero next pass.
-      params.deleteCheckpoint(result.checkpointKey);
-      noteMissing(snapshot.ref);
-      continue;
-    }
-    const actualDigest = workspacePublicQuadsDigest(snapshotQuads);
-    if (actualDigest !== snapshot.digest || snapshotQuads.length !== snapshot.count) {
-      throw new Error(
-        `Shared-memory public snapshot ${snapshot.ref} failed digest/count validation ` +
-        `(expected ${snapshot.digest}/${snapshot.count}, got ${actualDigest}/${snapshotQuads.length})`,
+      const result = await params.fetchSyncPages(
+        params.ctx,
+        params.remotePeerId,
+        params.contextGraphId,
+        true,
+        'snapshot',
+        '',
+        params.deadline,
+        snapshot.ref,
       );
+      bytesReceived += result.bytesReceived;
+      resumedPhases += result.resumedFromOffset > 0 ? 1 : 0;
+      timedOutPhases += result.timedOut ? 1 : 0;
+      if (result.completed) params.deleteCheckpoint(result.checkpointKey);
+      else {
+        // `fetchSyncPages` returns only the quads fetched during THIS call. We do
+        // not persist an unverified prefix, so resuming a snapshot at nextOffset
+        // would validate only the tail against the full digest/count and can never
+        // succeed. Restart this one immutable KA at offset zero on the next round;
+        // already completed snapshots remain cached and are skipped, preserving
+        // monotonic recovery progress across the CG without accepting a partial
+        // asset.
+        params.deleteCheckpoint(result.checkpointKey);
+        abandonFrom(index);
+        break;
+      }
+
+      const snapshotQuads = result.quads.map((quad) => ({ ...quad, graph: '' }));
+      if (snapshotQuads.length < snapshot.count) {
+        // A relayed stream can terminate cleanly after returning a prefix. The
+        // requester then sees `completed=true`, but the signed metadata gives us
+        // an authoritative expected count and proves that this is incomplete,
+        // not corrupt. Never cache or apply the prefix; retry it from offset zero
+        // in a later bounded recovery round. Equal-count digest mismatches remain
+        // fatal below so a complete but tampered snapshot is never softened into
+        // a transport retry.
+        //
+        // SKIP this ref and keep walking, rather than returning. Ref order is
+        // byte-identical on every pass (`Map` insertion order), so returning here
+        // would pin every future pass at this same index: one permanently
+        // unserveable ref would stall the whole manifest forever and drive a
+        // repeat-pass design to a fixed point at zero progress. Skipping costs
+        // this KA and nothing else — it stays uncached and unapplied, and is
+        // retried from offset zero next pass.
+        params.deleteCheckpoint(result.checkpointKey);
+        noteMissing(snapshot.ref);
+        continue;
+      }
+      const actualDigest = workspacePublicQuadsDigest(snapshotQuads);
+      if (actualDigest !== snapshot.digest || snapshotQuads.length !== snapshot.count) {
+        throw new Error(
+          `Shared-memory public snapshot ${snapshot.ref} failed digest/count validation ` +
+          `(expected ${snapshot.digest}/${snapshot.count}, got ${actualDigest}/${snapshotQuads.length})`,
+        );
+      }
+      await params.publicSnapshotStore.putSnapshot({ digest: snapshot.digest, quads: snapshotQuads });
+      await params.onSnapshotReady?.(snapshot, 'network');
+      completedPhases += 1;
+      readySnapshots += 1;
+    } catch (err) {
+      // Any failure in this KA's work — the blob read, the fetch, the
+      // digest check, the store write, or materialization — leaves the walk
+      // here. Carry what earlier iterations achieved out with it.
+      rethrowWithProgress(err, index);
     }
-    await params.publicSnapshotStore.putSnapshot({ digest: snapshot.digest, quads: snapshotQuads });
-    await params.onSnapshotReady?.(snapshot, 'network');
-    completedPhases += 1;
-    readySnapshots += 1;
   }
 
   return {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -334,22 +334,40 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     walk: PublicSnapshotWalkProgress,
     manifestComplete: boolean,
     materializationFailures: number,
+    materializedRefCount: number,
+    unwrittenRefSample: readonly string[],
     contextGraphId: string,
   ): void => {
     // No record for a graph that declared no snapshot refs. `0/0` is not a
     // shortfall, and a peer with nothing to offer must not look like a peer
     // that still owes us KAs — an absent record reads as "not capable".
     if (walk.totalSnapshots <= 0) return;
+    // RESOLVED MEANS LOCALLY MATERIALIZED, not fetched.
+    //
+    // `walk.readySnapshots` counts refs retrieved and digest-valid in the blob
+    // cache, and the walk increments it unconditionally after the
+    // materialization hook — the hook swallows its own failures. Reporting that
+    // as resolved made an all-cached round whose writes ALL failed look like
+    // `250/250`: the capability gate computed `250 < 250` false and dropped the
+    // peer, the high-water mark advanced to maximal, and the continuation
+    // stopped silently having written nothing — inside the fix meant to prevent
+    // exactly that.
+    //
+    // Deriving `missingCount` from the same figure keeps
+    // `resolved + missing === total` true by construction, and makes it cover
+    // both never-fetched and fetched-but-unwritten refs without either being
+    // tracked twice.
+    const snapshotsResolved = Math.min(materializedRefCount, walk.totalSnapshots);
     summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
       contextGraphId,
       peerIdSuffix: remotePeerId.slice(-8),
-      // Refs FETCHED and digest-valid, which is not the same as Knowledge
-      // Assets written — see `materializationFailures`.
-      snapshotsResolved: walk.readySnapshots,
+      snapshotsResolved,
       snapshotsTotal: walk.totalSnapshots,
       manifestComplete,
-      missingCount: walk.missingCount,
-      missingSample: walk.missingSample,
+      missingCount: walk.totalSnapshots - snapshotsResolved,
+      // Never-retrieved refs first, then retrieved-but-unwritten ones.
+      missingSample: [...walk.missingSample, ...unwrittenRefSample]
+        .slice(0, PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT),
       materializationFailures,
     });
   };
@@ -363,6 +381,8 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     // Likewise: materialization failures recorded before the throw are real and
     // must reach the coverage record, not be lost with the stack.
     let materializedFailuresForCg = 0;
+    let materializedRefsForCg = 0;
+    const unresolvedRefSampleForCg: string[] = [];
     try {
       const wsGraph = contextGraphWorkspaceGraphUri(pid);
       const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(pid);
@@ -474,6 +494,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       let materializationFailures = 0;
       let materializedQuads = 0;
       const materializedKeys = new Set<string>();
+      /** Snapshot refs whose every descriptor is locally present. */
+      const materializedRefs = new Set<string>();
+      /** Refs that fetched but could not be written; named in the shortfall. */
+      const unresolvedRefSample: string[] = [];
 
       // #2050 G7. `replaceHeadMetadata` is DELETE-ONLY, and the compensating
       // `storeInsert(processed.verifiedMeta)` sits below the `continue` on the
@@ -541,7 +565,12 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       };
       const materializeReadySnapshot = async (snapshotRef: string): Promise<void> => {
         const descriptors = snapshotDescriptorsByRef.get(snapshotRef);
+        // No descriptors, no materializer, or no store means nothing is
+        // written, so this ref stays UNRESOLVED. Returning without recording it
+        // is the point: a fetched-but-unwritten ref must never look like
+        // progress to the continuation loop.
         if (!descriptors?.length || !snapshotMaterializer || !publicSnapshotStore) return;
+        let refMaterialized = true;
         for (const descriptor of descriptors) {
           const graphKey = `${descriptor.metaGraph}\u0000${descriptor.assertionGraph}`;
           if (materializedKeys.has(graphKey)) continue;
@@ -656,11 +685,27 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
             // the caller keeps the phase incomplete and withholds the metadata
             // that would otherwise certify a graph that was never written.
             materializationFailures += 1;
+            refMaterialized = false;
+            if (unresolvedRefSample.length < PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT) {
+              unresolvedRefSample.push(snapshotRef);
+              // Mirrored outside the `try`, like the counters, so a later throw
+              // cannot lose refs we already know failed to write.
+              unresolvedRefSampleForCg.push(snapshotRef);
+            }
             // Mirrored outside the `try` so a later throw cannot lose it.
             materializedFailuresForCg = materializationFailures;
             logWarn(ctx, `SWM sync failed to materialize snapshot ${snapshotRef} for "${pid}": `
               + `${err instanceof Error ? err.message : String(err)}`);
           }
+        }
+        // Resolved means LOCALLY MATERIALIZED — every descriptor for this ref
+        // written or already present. A ref that fetched and then failed to
+        // write is not resolved, which is what stops an all-cached round whose
+        // writes all failed from reporting maximal coverage and silently
+        // ending the continuation.
+        if (refMaterialized) {
+          materializedRefs.add(snapshotRef);
+          materializedRefsForCg = materializedRefs.size;
         }
       };
 
@@ -710,7 +755,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // `dkg-agent-lifecycle.ts`, the only caller of this function), so that
       // only bites the on-connect fan-out, where this field is a diagnostic
       // rather than a decision input.
-      recordSnapshotCoverage(snapshotSync, wsMetaResult.completed, materializationFailures, pid);
+      recordSnapshotCoverage(snapshotSync, wsMetaResult.completed, materializationFailures, materializedRefs.size, unresolvedRefSample, pid);
       // A voluntary yield is OUR budget decision, not the peer's fault. It is
       // recorded here and deliberately kept out of `timedOutPhases`, which
       // feeds `backoffWorthyFailure` and would back the peer off for it. It is
@@ -818,7 +863,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       if (thrownProgress) {
         // Same builder as the success path — the counts arrive as one coherent
         // group attached by the walk, never reassembled here.
-        recordSnapshotCoverage(thrownProgress, manifestComplete, materializedFailuresForCg, pid);
+        recordSnapshotCoverage(thrownProgress, manifestComplete, materializedFailuresForCg, materializedRefsForCg, unresolvedRefSampleForCg, pid);
       }
       logWarn(ctx, `SWM sync for context graph "${pid}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
       if (isSyncPermanentRejection(err)) {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -16,6 +16,13 @@ import type { SharedMemorySnapshotMaterializer } from './swm-snapshot-materializ
 
 const DKG = 'http://dkg.io/ontology/';
 
+/**
+ * Cap on identifiers reported for an unresolved manifest. A public peer chooses
+ * how many snapshots it advertises, so an unbounded list would let it size a
+ * structure on this node; the exact figure travels as `missingCount`.
+ */
+const PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT = 10;
+
 export interface SharedMemorySyncSummary {
   insertedTriples: number;
   fetchedMetaTriples: number;
@@ -503,9 +510,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       //
       // Across a MULTI-CG call the reduction keeps exactly ONE graph's record,
       // named by its `contextGraphId`; the others are dropped. Foreground
-      // catch-up always passes a single CG (`dkg-agent-lifecycle.ts:5982`), so
-      // that only bites the on-connect fan-out, where this field is a
-      // diagnostic rather than a decision input.
+      // catch-up always passes a single CG (`syncPublicContextGraph` in
+      // `dkg-agent-lifecycle.ts`, the only caller of this function), so that
+      // only bites the on-connect fan-out, where this field is a diagnostic
+      // rather than a decision input.
       if (snapshotSync.totalSnapshots > 0) {
         summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
           contextGraphId: pid,
@@ -516,9 +524,22 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           // also the state in which `snapshotDescriptorsByRef` is empty (:270)
           // so nothing materializes at all.
           manifestComplete: wsMetaResult.completed,
-          missingCount: snapshotSync.totalSnapshots - snapshotSync.readySnapshots,
-          missingSample: [],
+          // Both come from the snapshot walk itself, so the sample always
+          // names refs counted by `missingCount` in this same round.
+          missingCount: snapshotSync.missingCount,
+          missingSample: snapshotSync.missingSample,
         });
+      }
+      // A voluntary yield is OUR budget decision, not the peer's fault. It is
+      // recorded here and deliberately kept out of `timedOutPhases`, which
+      // feeds `backoffWorthyFailure` and would back the peer off for it. It is
+      // NOT kept out of `failedPhases` below: the round really did not complete
+      // the plane, and without that the round classifies as clean and reports
+      // the graph `done` while Knowledge Assets are still missing.
+      if (snapshotSync.yieldedAtDeadline) {
+        summary.snapshotPlaneIncomplete += 1;
+        logInfo(ctx, `SWM sync for "${pid}": yielded at the round deadline with `
+          + `${snapshotSync.missingCount} of ${snapshotSync.totalSnapshots} snapshot(s) unresolved`);
       }
       const snapshotDurationMs = Date.now() - snapshotStartedAt;
       // A snapshot that verified but could not be written must be treated
@@ -826,7 +847,16 @@ export async function syncPublicSnapshotsForMeta(params: {
     checkpointAdvances,
     readySnapshots,
     totalSnapshots: snapshots.length,
-    completed: true,
+    // The ONLY completion expression, and it is derived rather than asserted.
+    // Every path that gives up on a ref — the deadline yield, a fetch that did
+    // not complete, and the skipped short prefix — routes through
+    // `noteMissing`, so a round can no longer fall out of the loop claiming
+    // success while having abandoned work. A hardcoded `true` here is exactly
+    // how skip-and-continue would have silently reported a complete manifest.
+    completed: missingCount === 0,
+    missingCount,
+    missingSample,
+    yieldedAtDeadline,
   };
 }
 

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -365,8 +365,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       snapshotsTotal: walk.totalSnapshots,
       manifestComplete,
       missingCount: walk.totalSnapshots - snapshotsResolved,
-      // Never-retrieved refs first, then retrieved-but-unwritten ones.
-      missingSample: [...walk.missingSample, ...unwrittenRefSample]
+      // Never-retrieved refs first, then retrieved-but-unwritten ones. Deduped
+      // across BOTH sources so the sample can never exceed `missingCount`, which
+      // is what the renderer subtracts it from to size its "(+N more)" suffix.
+      missingSample: [...new Set([...walk.missingSample, ...unwrittenRefSample])]
         .slice(0, PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT),
       materializationFailures,
     });
@@ -686,7 +688,17 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
             // that would otherwise certify a graph that was never written.
             materializationFailures += 1;
             refMaterialized = false;
-            if (unresolvedRefSample.length < PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT) {
+            // Deduped by ref, not merely capped: `materializationFailures`
+            // increments per DESCRIPTOR, so one ref carrying several descriptors
+            // pushed itself once per failure and the sample read
+            // "including refX, refX, refX". The count it is a sample OF is per
+            // REF, so an undeduped sample can also grow longer than
+            // `missingCount`, driving the renderer's `missingCount - sample.length`
+            // negative and silently suppressing the "(+N more)" suffix.
+            if (
+              unresolvedRefSample.length < PUBLIC_SNAPSHOT_MISSING_SAMPLE_LIMIT
+              && !unresolvedRefSample.includes(snapshotRef)
+            ) {
               unresolvedRefSample.push(snapshotRef);
               // Mirrored outside the `try`, like the counters, so a later throw
               // cannot lose refs we already know failed to write.

--- a/packages/agent/test/catchup-pass-policy.test.ts
+++ b/packages/agent/test/catchup-pass-policy.test.ts
@@ -71,21 +71,54 @@ describe('shouldRunAnotherCatchupPass', () => {
   it('stops when coverage did not advance, including when it went nowhere at all', () => {
     // Equal is not advancement, however large: 178 resolved twice running means
     // the second pass bought nothing and a third would buy nothing either.
+    // `passesRun: 2` throughout: on pass 1 the mark is 0 only because nothing
+    // has run, and a capable peer there earns its repeat (see the rows below).
     expect(shouldRunAnotherCatchupPass(
-      base({ coverageHighWaterMark: 178, lastPassCoverage: 178 }),
+      base({ passesRun: 2, coverageHighWaterMark: 178, lastPassCoverage: 178 }),
     ).reason).toBe('coverage-stalled');
     expect(shouldRunAnotherCatchupPass(
-      base({ coverageHighWaterMark: 178, lastPassCoverage: 120 }),
+      base({ passesRun: 2, coverageHighWaterMark: 178, lastPassCoverage: 120 }),
     ).reason).toBe('coverage-stalled');
   });
 
-  it('gives a first pass that resolved nothing zero repeats', () => {
+  it('gives a first pass that resolved nothing zero repeats when nobody is capable', () => {
     // This is the whole reason the high-water mark is initialised to 0 rather
     // than −1. At −1 a barren first pass would read as "advanced to 0" and earn
     // a repeat — for a peer that has just demonstrated it can deliver nothing.
     expect(shouldRunAnotherCatchupPass(
-      base({ coverageHighWaterMark: 0, lastPassCoverage: 0 }),
+      base({ coverageHighWaterMark: 0, lastPassCoverage: 0, capablePeers: [] }),
     ).reason).toBe('coverage-stalled');
+  });
+
+  it('DOES repeat a first pass that materialized nothing while a capable peer remains', () => {
+    // The counterpart, and the distinction the barren guard above cannot make on
+    // its own: `resolved 0` is reported both by a peer with nothing to give and
+    // by a peer holding 250 refs whose every write failed, or whose round
+    // deadline was spent before the snapshot walk began. The second states it
+    // holds what we lack — `capablePeersForNextPass` already filtered out the
+    // barren (`0/0`, no record at all) and truncated-manifest peers, so a
+    // non-empty capable set at the pass-1 boundary IS the evidence a repeat can
+    // pay. Stopping here reported "more passes would not help" on a graph 250
+    // Knowledge Assets short, with the blobs already cached.
+    expect(shouldRunAnotherCatchupPass(base({
+      passesRun: 1, coverageHighWaterMark: 0, lastPassCoverage: 0,
+      capablePeers: ['peer-holding-250'],
+    }))).toEqual({
+      continue: true,
+      peers: ['peer-holding-250'],
+      reason: 'continue',
+    });
+  });
+
+  it('still stalls on a LATER pass that made no progress, capable peers or not', () => {
+    // The suppression is scoped to the pass-1 boundary, where the high-water
+    // mark is 0 only because nothing has run yet. Once a pass has established a
+    // baseline, a repeat that beats nobody's record is genuine evidence that
+    // more passes would not help — which is exactly what the reason says.
+    expect(shouldRunAnotherCatchupPass(base({
+      passesRun: 2, coverageHighWaterMark: 190, lastPassCoverage: 190,
+      capablePeers: ['peer-a'],
+    })).reason).toBe('coverage-stalled');
   });
 
   it('stops when no peer admits to holding anything we lack', () => {
@@ -137,10 +170,10 @@ describe('shouldRunAnotherCatchupPass', () => {
     // Same two stops, but a capable peer is left: plane-proven no longer applies
     // at all, so the honest reason is the one that actually held.
     expect(shouldRunAnotherCatchupPass(base({
-      planeProven: true, coverageHighWaterMark: 178, lastPassCoverage: 178,
+      planeProven: true, passesRun: 2, coverageHighWaterMark: 178, lastPassCoverage: 178,
     })).reason).toBe('coverage-stalled');
     expect(shouldRunAnotherCatchupPass(base({
-      coverageHighWaterMark: 178, lastPassCoverage: 178, nowMs: 999_999,
+      passesRun: 2, coverageHighWaterMark: 178, lastPassCoverage: 178, nowMs: 999_999,
     })).reason).toBe('coverage-stalled');
     expect(shouldRunAnotherCatchupPass(base({
       coverageHighWaterMark: 178, lastPassCoverage: 178, passesRun: 4,

--- a/packages/agent/test/catchup-pass-policy.test.ts
+++ b/packages/agent/test/catchup-pass-policy.test.ts
@@ -41,13 +41,30 @@ describe('shouldRunAnotherCatchupPass', () => {
     });
   });
 
-  it('stops once a clean peer round has proven the plane', () => {
+  it('stops once a clean peer round has proven the plane and nobody is left to ask', () => {
     // r26's shape ends here on the pass that finally completes: coverage is still
-    // advancing and budget remains, but there is nothing left to fetch.
-    expect(shouldRunAnotherCatchupPass(base({ planeProven: true }))).toEqual({
+    // advancing and budget remains, but there is nothing left to fetch. Note the
+    // empty capable set is what makes this a stop — see the row below.
+    expect(shouldRunAnotherCatchupPass(base({ planeProven: true, capablePeers: [] }))).toEqual({
       continue: false,
       peers: [],
       reason: 'plane-proven',
+    });
+  });
+
+  it('keeps going for a capable peer even once another peer has proven the plane', () => {
+    // The plane is proven by an aggregate over EVERY peer, so a member serving
+    // its own shared-memory rows and no snapshot refs proves it — the ordinary
+    // shape in a multi-member public CG. Letting that stop the walk abandons the
+    // peer that declared a complete manifest with refs still outstanding, which
+    // is the abandonment #2050 exists to remove: the repeat loop would contribute
+    // zero passes in exactly the topology it was written for.
+    expect(shouldRunAnotherCatchupPass(base({
+      planeProven: true, capablePeers: ['peer-big'],
+    }))).toEqual({
+      continue: true,
+      peers: ['peer-big'],
+      reason: 'continue',
     });
   });
 
@@ -115,8 +132,13 @@ describe('shouldRunAnotherCatchupPass', () => {
     // of budget must not read as "raise the budget", because raising it buys
     // nothing. Each case below satisfies BOTH stops and pins which is reported.
     expect(shouldRunAnotherCatchupPass(base({
-      planeProven: true, coverageHighWaterMark: 178, lastPassCoverage: 178,
+      planeProven: true, capablePeers: [], coverageHighWaterMark: 178, lastPassCoverage: 178,
     })).reason).toBe('plane-proven');
+    // Same two stops, but a capable peer is left: plane-proven no longer applies
+    // at all, so the honest reason is the one that actually held.
+    expect(shouldRunAnotherCatchupPass(base({
+      planeProven: true, coverageHighWaterMark: 178, lastPassCoverage: 178,
+    })).reason).toBe('coverage-stalled');
     expect(shouldRunAnotherCatchupPass(base({
       coverageHighWaterMark: 178, lastPassCoverage: 178, nowMs: 999_999,
     })).reason).toBe('coverage-stalled');

--- a/packages/agent/test/catchup-pass-policy.test.ts
+++ b/packages/agent/test/catchup-pass-policy.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_SWM_CATCHUP_MAX_PASSES,
   DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS,
+  SwmCatchupPassTracker,
   resolveSwmCatchupMaxPasses,
+  resolveSwmCatchupPassConfig,
   resolveSwmCatchupPassBudgetMs,
   shouldRunAnotherCatchupPass,
   type CatchupPassPolicyInput,
@@ -196,7 +198,40 @@ describe('shouldRunAnotherCatchupPass', () => {
   });
 });
 
+describe('SwmCatchupPassTracker', () => {
+  it('owns last-round capability and monotone per-peer progress', () => {
+    const tracker = new SwmCatchupPassTracker();
+    tracker.recordPeerRound('peer-a', {
+      snapshotsResolved: 2,
+      snapshotsTotal: 5,
+      manifestComplete: true,
+    }, false);
+
+    expect(tracker.capablePeers()).toEqual(['peer-a']);
+    expect(tracker.progress()).toBe(2);
+    expect(tracker.startContinuationPass()).toBe(2);
+
+    tracker.recordPeerRound('peer-a', {
+      snapshotsResolved: 1,
+      snapshotsTotal: 5,
+      manifestComplete: true,
+    }, false);
+    expect(tracker.progress()).toBe(2);
+
+    tracker.recordPeerRound('peer-a', undefined, true);
+    expect(tracker.capablePeers()).toEqual([]);
+    expect(tracker.progress()).toBe(2);
+  });
+});
+
 describe('pass budget and cap env contract', () => {
+  it('resolves both operator levers into one explicit job config', () => {
+    expect(resolveSwmCatchupPassConfig({
+      DKG_SWM_CATCHUP_PASS_BUDGET_MS: '0',
+      DKG_SWM_CATCHUP_MAX_PASSES: '2',
+    })).toEqual({ budgetMs: 0, maxPasses: 2 });
+  });
+
   it('treats a blank assignment as unset, not as zero', () => {
     // `DKG_SWM_CATCHUP_PASS_BUDGET_MS=` is the normal docker-compose/.env shape
     // for "not set", and `Number('')` is 0 — which would silently leave the node

--- a/packages/agent/test/catchup-pass-policy.test.ts
+++ b/packages/agent/test/catchup-pass-policy.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SWM_CATCHUP_MAX_PASSES,
+  DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS,
+  resolveSwmCatchupMaxPasses,
+  resolveSwmCatchupPassBudgetMs,
+  shouldRunAnotherCatchupPass,
+  type CatchupPassPolicyInput,
+} from '../src/sync/catchup-pass-policy.js';
+
+/**
+ * An input on which EVERY continue condition holds, so each test below can
+ * override exactly one field and know the stop it observes came from that field.
+ * Without this the suite would be full of tests that pass for the wrong reason —
+ * a "budget exhausted" case that actually stopped on a stalled coverage mark
+ * still goes green if it only asserts `continue === false`. Every case therefore
+ * asserts the `reason`, not just the boolean.
+ */
+function base(overrides: Partial<CatchupPassPolicyInput> = {}): CatchupPassPolicyInput {
+  return {
+    nowMs: 10_000,
+    deadlineMs: 610_000,
+    passesRun: 1,
+    maxPasses: 4,
+    coverageHighWaterMark: 0,
+    lastPassCoverage: 178,
+    planeProven: false,
+    capablePeers: ['peer-a', 'peer-b'],
+    ...overrides,
+  };
+}
+
+describe('shouldRunAnotherCatchupPass', () => {
+  it('continues over exactly the capable peers when every gate holds', () => {
+    // Guards the whole suite: if this ever stops, every "stops when X" case below
+    // becomes vacuous, because they would stop with or without their override.
+    expect(shouldRunAnotherCatchupPass(base())).toEqual({
+      continue: true,
+      peers: ['peer-a', 'peer-b'],
+      reason: 'continue',
+    });
+  });
+
+  it('stops once a clean peer round has proven the plane', () => {
+    // r26's shape ends here on the pass that finally completes: coverage is still
+    // advancing and budget remains, but there is nothing left to fetch.
+    expect(shouldRunAnotherCatchupPass(base({ planeProven: true }))).toEqual({
+      continue: false,
+      peers: [],
+      reason: 'plane-proven',
+    });
+  });
+
+  it('stops when coverage did not advance, including when it went nowhere at all', () => {
+    // Equal is not advancement, however large: 178 resolved twice running means
+    // the second pass bought nothing and a third would buy nothing either.
+    expect(shouldRunAnotherCatchupPass(
+      base({ coverageHighWaterMark: 178, lastPassCoverage: 178 }),
+    ).reason).toBe('coverage-stalled');
+    expect(shouldRunAnotherCatchupPass(
+      base({ coverageHighWaterMark: 178, lastPassCoverage: 120 }),
+    ).reason).toBe('coverage-stalled');
+  });
+
+  it('gives a first pass that resolved nothing zero repeats', () => {
+    // This is the whole reason the high-water mark is initialised to 0 rather
+    // than −1. At −1 a barren first pass would read as "advanced to 0" and earn
+    // a repeat — for a peer that has just demonstrated it can deliver nothing.
+    expect(shouldRunAnotherCatchupPass(
+      base({ coverageHighWaterMark: 0, lastPassCoverage: 0 }),
+    ).reason).toBe('coverage-stalled');
+  });
+
+  it('stops when no peer admits to holding anything we lack', () => {
+    // Barren, cleanly-empty, empty-and-timed-out and meta-truncation peers all
+    // arrive here as an empty capable set — in r26 that was ~10 of the 12 peers.
+    expect(shouldRunAnotherCatchupPass(base({ capablePeers: [] }))).toEqual({
+      continue: false,
+      peers: [],
+      reason: 'no-capable-peers',
+    });
+  });
+
+  it('stops at the pass cap even while coverage is still advancing', () => {
+    expect(shouldRunAnotherCatchupPass(base({ passesRun: 4, maxPasses: 4 })).reason)
+      .toBe('max-passes-reached');
+    expect(shouldRunAnotherCatchupPass(base({ passesRun: 5, maxPasses: 4 })).reason)
+      .toBe('max-passes-reached');
+    // One below the cap still runs, so the cap is a bound rather than an off switch.
+    expect(shouldRunAnotherCatchupPass(base({ passesRun: 3, maxPasses: 4 })).continue)
+      .toBe(true);
+  });
+
+  it('stops at the budget, and treats the deadline instant itself as spent', () => {
+    expect(shouldRunAnotherCatchupPass(base({ nowMs: 610_000, deadlineMs: 610_000 })).reason)
+      .toBe('budget-exhausted');
+    expect(shouldRunAnotherCatchupPass(base({ nowMs: 610_001, deadlineMs: 610_000 })).reason)
+      .toBe('budget-exhausted');
+    expect(shouldRunAnotherCatchupPass(base({ nowMs: 609_999, deadlineMs: 610_000 })).continue)
+      .toBe(true);
+  });
+
+  it('runs no extra pass at all when the budget is zero', () => {
+    // The operator kill switch. A zero budget makes the deadline equal the job
+    // start, so it expires through the ordinary comparison — there is no separate
+    // "disabled" branch that could rot.
+    const startedAt = 10_000;
+    expect(shouldRunAnotherCatchupPass(
+      base({ nowMs: startedAt, deadlineMs: startedAt + 0 }),
+    ).reason).toBe('budget-exhausted');
+  });
+
+  it('reports the most actionable stop when several hold at once', () => {
+    // Precedence is a contract, not an accident: a stalled run that also ran out
+    // of budget must not read as "raise the budget", because raising it buys
+    // nothing. Each case below satisfies BOTH stops and pins which is reported.
+    expect(shouldRunAnotherCatchupPass(base({
+      planeProven: true, coverageHighWaterMark: 178, lastPassCoverage: 178,
+    })).reason).toBe('plane-proven');
+    expect(shouldRunAnotherCatchupPass(base({
+      coverageHighWaterMark: 178, lastPassCoverage: 178, nowMs: 999_999,
+    })).reason).toBe('coverage-stalled');
+    expect(shouldRunAnotherCatchupPass(base({
+      coverageHighWaterMark: 178, lastPassCoverage: 178, passesRun: 4,
+    })).reason).toBe('coverage-stalled');
+    expect(shouldRunAnotherCatchupPass(base({
+      capablePeers: [], passesRun: 4, nowMs: 999_999,
+    })).reason).toBe('no-capable-peers');
+    expect(shouldRunAnotherCatchupPass(base({
+      passesRun: 4, nowMs: 999_999,
+    })).reason).toBe('max-passes-reached');
+  });
+
+  it('hands back a copy of the capable set', () => {
+    // The caller walks the returned list while recomputing capability for the
+    // next pass; aliasing the input would let one mutate the other.
+    const capablePeers = ['peer-a'];
+    const decision = shouldRunAnotherCatchupPass(base({ capablePeers }));
+    decision.peers.push('peer-z');
+    expect(capablePeers).toEqual(['peer-a']);
+  });
+});
+
+describe('pass budget and cap env contract', () => {
+  it('treats a blank assignment as unset, not as zero', () => {
+    // `DKG_SWM_CATCHUP_PASS_BUDGET_MS=` is the normal docker-compose/.env shape
+    // for "not set", and `Number('')` is 0 — which would silently leave the node
+    // with exactly the #2050 behaviour the operator was trying to configure away.
+    expect(resolveSwmCatchupPassBudgetMs(undefined)).toBe(DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS);
+    expect(resolveSwmCatchupPassBudgetMs('')).toBe(DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS);
+    expect(resolveSwmCatchupPassBudgetMs('   ')).toBe(DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS);
+  });
+
+  it('honours an explicit zero budget as the kill switch', () => {
+    expect(resolveSwmCatchupPassBudgetMs('0')).toBe(0);
+  });
+
+  it('falls back on values no operator meant', () => {
+    expect(resolveSwmCatchupPassBudgetMs('-1')).toBe(DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS);
+    expect(resolveSwmCatchupPassBudgetMs('abc')).toBe(DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS);
+    expect(resolveSwmCatchupPassBudgetMs('1.5')).toBe(DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS);
+    // An integer by IEEE-754, and an effectively unbounded loop in practice.
+    expect(resolveSwmCatchupPassBudgetMs('1e308')).toBe(DEFAULT_SWM_CATCHUP_PASS_BUDGET_MS);
+    expect(resolveSwmCatchupPassBudgetMs('300000')).toBe(300_000);
+  });
+
+  it('floors the pass cap at 1, because zero passes would skip the walk itself', () => {
+    // Unlike the budget, `0` here is a misconfiguration rather than a switch:
+    // it would mean catch-up fetches nothing at all. Disabling repeats is the
+    // budget's job, so this falls back instead.
+    expect(resolveSwmCatchupMaxPasses('0')).toBe(DEFAULT_SWM_CATCHUP_MAX_PASSES);
+    expect(resolveSwmCatchupMaxPasses('')).toBe(DEFAULT_SWM_CATCHUP_MAX_PASSES);
+    expect(resolveSwmCatchupMaxPasses('-3')).toBe(DEFAULT_SWM_CATCHUP_MAX_PASSES);
+    expect(resolveSwmCatchupMaxPasses('1')).toBe(1);
+    expect(resolveSwmCatchupMaxPasses('7')).toBe(7);
+  });
+});

--- a/packages/agent/test/swm-descriptor-fixtures.ts
+++ b/packages/agent/test/swm-descriptor-fixtures.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared graph-scoped SWM share fixtures (#2050).
+ *
+ * Extracted from `swm-snapshot-materializer.test.ts` so the throw-path row in
+ * `sync-requester-progress.test.ts` can build DESCRIPTOR-shaped metadata rather
+ * than hand-rolling a fourth one.
+ *
+ * Why sharing matters more than the duplication it saves: materialization is
+ * gated on `snapshotDescriptorsByRef.size > 0`, which is populated by
+ * `parseGraphScopedSwmRecoveryDescriptors`. Metadata that carries only
+ * `publicQuadsDigest`/`publicQuadsCount` is `collectPublicSnapshotMetadata`
+ * shape — enough to enumerate refs, NOT enough to produce a descriptor. A
+ * fixture in that shape leaves the map empty, so nothing materializes and
+ * `snapshotsResolved` stays 0 for a reason that has nothing to do with the code
+ * under test.
+ *
+ * Worse, getting it subtly wrong does not error: `validateOperationRows` throws
+ * on a `kaUal`/`assertionVersion` mismatch, `runSharedMemorySync` catches it and
+ * calls `snapshotDescriptorsByRef.clear()`, and materialization is SILENTLY
+ * disabled for the whole Context Graph. A wrong fixture stops testing rather
+ * than failing.
+ *
+ * These builders are known-good by provenance: the partial-round row built on
+ * them failed on the pre-fix tree with `expected [] to deeply equal [ …(2) ]`
+ * against a real `OxigraphStore`, which is only reachable if the descriptors
+ * they produce are real.
+ */
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  contextGraphWorkspaceMetaGraphUri,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import {
+  generateKnowledgeAssetShareMetadata,
+  workspacePublicQuadsDigest,
+} from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+const DKG = 'http://dkg.io/ontology/';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+export interface ShareOptions {
+  version: number;
+  operationId: string;
+  marker: string;
+  ual: string;
+  /**
+   * Payload size. Distinct sizes across a manifest make a KA materialized in
+   * place of another visible in the counters instead of cancelling out.
+   */
+  payloadCount?: number;
+}
+
+export type SwmShare = ReturnType<ReturnType<typeof swmFixtures>['share']>;
+
+/**
+ * Builders bound to one Context Graph id. Bound rather than passed per call so
+ * a fixture cannot accidentally mix graphs — the meta graph URI, the operation
+ * subject and the assertion graph must all agree or the parser rejects the KA.
+ */
+export function swmFixtures(contextGraphId: string) {
+  const metaGraph = contextGraphWorkspaceMetaGraphUri(contextGraphId);
+
+  /** One complete graph-scoped share: head rows, operation rows, payload, digest. */
+  function share(opts: ShareOptions) {
+    const scope = createGraphKnowledgeAssetScope(opts.ual, opts.version);
+    const assertionGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    );
+    const operationSubject = `urn:dkg:share:${contextGraphId}:${opts.operationId}`;
+    const headSubject = `${opts.ual}#dkg-swm-head`;
+    const payload: Quad[] = Array.from({ length: opts.payloadCount ?? 2 }, (_, i) => ({
+      subject: `urn:snap:${opts.marker}:${i}`,
+      predicate: 'http://schema.org/status',
+      object: `"${opts.marker}"`,
+      graph: '',
+    }));
+    const digest = workspacePublicQuadsDigest(payload);
+    const meta: Quad[] = [
+      ...generateKnowledgeAssetShareMetadata({
+        shareOperationId: opts.operationId,
+        contextGraphId,
+        kaUal: opts.ual,
+        assertionVersion: opts.version,
+        publicTripleCount: payload.length,
+        privateTripleCount: 0,
+        publisherPeerId: 'peer-source',
+        timestamp: new Date(0),
+      }, metaGraph),
+      { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${digest}"`, graph: metaGraph },
+      { subject: operationSubject, predicate: `${DKG}publicSnapshotRef`, object: `"${digest}"`, graph: metaGraph },
+      { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, graph: metaGraph },
+      { subject: headSubject, predicate: `${DKG}kaUal`, object: opts.ual, graph: metaGraph },
+      { subject: headSubject, predicate: `${DKG}assertionVersion`, object: `"${opts.version}"^^<${XSD_INTEGER}>`, graph: metaGraph },
+      { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: metaGraph },
+      { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${opts.operationId}"`, graph: metaGraph },
+    ];
+    return {
+      version: opts.version, operationId: opts.operationId, operationSubject,
+      headSubject, assertionGraph, payload, digest, meta,
+    };
+  }
+
+  /**
+   * N independent KAs — distinct UAL, operation and payload size each.
+   *
+   * Distinct operations are not cosmetic: two descriptors cannot share an
+   * operation subject, because `validateOperationRows` pins it to exactly one
+   * `kaUal` at one `assertionVersion`.
+   */
+  function manifest(count: number, ualPrefix = 'did:dkg:hardhat:31337/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb') {
+    return Array.from({ length: count }, (_, i) => share({
+      version: 1,
+      operationId: `op-ka-${i + 1}`,
+      marker: `ka-${i + 1}`,
+      ual: `${ualPrefix}/${i + 1}`,
+      payloadCount: 2 + i,
+    }));
+  }
+
+  return { metaGraph, share, manifest };
+}

--- a/packages/agent/test/swm-public-snapshot-materialization.test.ts
+++ b/packages/agent/test/swm-public-snapshot-materialization.test.ts
@@ -179,10 +179,18 @@ function harness(overrides: HarnessOverrides = {}) {
         inserted.push(quads);
       },
       snapshotMaterializer: {
-        withKaWriteLock: (contextGraphId, subGraphName, kaUal, fn) => {
+        withKaWriteLock: async (contextGraphId, subGraphName, kaUal, fn) => {
           events.push('lock-requested');
           overrides.onLockRequested?.();
-          return withKeyedLocks(lockMap, [swmKaWriteLockKey(contextGraphId, subGraphName, kaUal)], fn);
+          try {
+            return await withKeyedLocks(lockMap, [swmKaWriteLockKey(contextGraphId, subGraphName, kaUal)], fn);
+          } finally {
+            // Records the CLOSE of the window, not just its open. Without it the
+            // tape cannot tell a write made UNDER the lock from one made after it
+            // released — which is the entire claim of the per-KA meta insert.
+            // `finally`, so a KA that threw still closes its own window.
+            events.push('lock-released');
+          }
         },
         isGraphAssetMaterialized: async () => {
           events.push('content-checked');

--- a/packages/agent/test/swm-public-snapshot-materialization.test.ts
+++ b/packages/agent/test/swm-public-snapshot-materialization.test.ts
@@ -328,6 +328,34 @@ describe('public SWM snapshot materialization', () => {
     expect(summary.failedPhases).toBe(0);
   });
 
+  it('writes the KA\'s verified metadata INSIDE the write lock, right after the head swap', async () => {
+    // #2050 G7. `replaceHeadMetadata` is delete-only, and the compensating
+    // `storeInsert(processed.verifiedMeta)` sits below the `continue` on the
+    // incomplete branch — so a round that ran out of clock mid-list deleted the
+    // head rows of the KAs it had just materialized and never rewrote them.
+    // Content present, heads absent, invisible to every head reader.
+    //
+    // The existing ordering assertions ("...BEFORE the meta append") do NOT pin
+    // this. They use `indexOf`, and pre-fix the first `meta-inserted` was the
+    // bulk append, which already landed after the swap — so they stayed green
+    // whether or not the per-KA write existed. This case is separate rather than
+    // an edit to them for exactly that reason.
+    //
+    // Pre-fix this failed with `expected 6 to be less than 5`: the meta write
+    // landed AFTER the lock released. What must hold is that the KA's own
+    // verified metadata is rewritten before its lock releases, so the
+    // head-absent window is one operation wide instead of one round wide.
+    const h = harness();
+    await h.run();
+    const headSwapped = h.events.indexOf('head-swapped');
+    const metaInserted = h.events.indexOf('meta-inserted');
+    const lockReleased = h.events.indexOf('lock-released');
+    expect(headSwapped).toBeGreaterThan(-1);
+    expect(lockReleased).toBeGreaterThan(-1);
+    expect(metaInserted).toBeGreaterThan(headSwapped);
+    expect(metaInserted).toBeLessThan(lockReleased);
+  });
+
   it('withholds the meta insert when a replace fails, and marks the phase failed', async () => {
     const h = harness({ replaceImpl: async () => { throw new Error('store unavailable'); } });
     const summary = await h.run();

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -192,6 +192,216 @@ describe('syncPublicSnapshotsForMeta', () => {
     });
     expect(deletedCheckpoints).toBeGreaterThan(0);
     await expect(snapshotStore.getSnapshot(digest)).resolves.toBeNull();
+  });
+
+  it('skips one short-prefix ref and still fetches the rest of the manifest', async () => {
+    // TWO declared refs, and that is the whole point of the row. The sibling
+    // test above — and every other short-prefix assertion in the repo —
+    // declares exactly ONE ref, where "skip this ref and keep walking" and
+    // "abandon the manifest at this ref" produce byte-identical results. With
+    // one ref this branch cannot be observed at all.
+    //
+    // Why the second ref matters in production: ref order is byte-identical on
+    // every pass (`collectPublicSnapshotMetadata` returns `Map` insertion
+    // order over the signed metadata), so returning/breaking here would pin
+    // every future pass at this same index. One permanently unserveable
+    // Knowledge Asset — a relay that always closes cleanly after a prefix —
+    // would stall the entire context graph at zero progress forever, and the
+    // bounded repeat-pass driver would converge on a fixed point having
+    // materialized nothing. Skipping costs that one KA and nothing else.
+    //
+    // Ordering is load-bearing: the SHORT ref is declared FIRST so that a
+    // `return`/`break` regression never reaches the second ref. If the full
+    // snapshot were declared first, the walk would resolve it before ever
+    // touching the short one and the row would pass under the bug.
+    const shortPayload: Quad[] = [
+      { subject: 'urn:snapshot:short:a', predicate: STATUS, object: '"one"', graph: '' },
+      { subject: 'urn:snapshot:short:b', predicate: STATUS, object: '"two"', graph: '' },
+    ];
+    // Deliberately a DIFFERENT payload, so the two digests (and therefore the
+    // two refs) cannot collide and `requestedRefs` can distinguish them.
+    const fullPayload: Quad[] = [
+      { subject: 'urn:snapshot:full:a', predicate: STATUS, object: '"three"', graph: '' },
+    ];
+    const shortDigest = workspacePublicQuadsDigest(shortPayload);
+    const fullDigest = workspacePublicQuadsDigest(fullPayload);
+    const shortSubject = 'urn:dkg:share:short-prefix-ka';
+    const fullSubject = 'urn:dkg:share:complete-ka';
+    const snapshotStore = new MemorySnapshotStore();
+    const requestedRefs: string[] = [];
+    const deletedCheckpoints: string[] = [];
+
+    const result = await syncPublicSnapshotsForMeta({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      // Not the deadline branch: this row must isolate the short-prefix skip.
+      // An expired deadline would abandon the tail for an unrelated reason and
+      // the row would pass even with the skip reverted.
+      deadline: Number.MAX_SAFE_INTEGER,
+      // Digest-only (store-backed) rows: no explicit `dkg:publicSnapshotRef`,
+      // so each ref IS its digest. Both rows carry digest AND count — a row
+      // missing either is silently dropped from the manifest, which would
+      // quietly shrink `totalSnapshots` to 1 and re-create the blind spot.
+      metaQuads: [
+        { subject: shortSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${shortDigest}"`, graph: WS_META },
+        { subject: shortSubject, predicate: `${DKG}publicQuadsCount`, object: `"${shortPayload.length}"^^<${XSD_INTEGER}>`, graph: WS_META },
+        { subject: fullSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${fullDigest}"`, graph: WS_META },
+        { subject: fullSubject, predicate: `${DKG}publicQuadsCount`, object: `"${fullPayload.length}"^^<${XSD_INTEGER}>`, graph: WS_META },
+      ],
+      publicSnapshotStore: snapshotStore,
+      fetchSyncPages: async (_c, _p, _cg, _inc, _phase, _graph, _deadline, snapshotRef): Promise<SyncPageResult> => {
+        requestedRefs.push(snapshotRef ?? '');
+        // `completed: true` with FEWER quads than the signed count — a relayed
+        // stream that terminated cleanly on a prefix. Not corrupt (the digest
+        // check is only reached at equal count), so it must stay a retryable
+        // skip rather than the fatal throw.
+        if (snapshotRef === shortDigest) {
+          return { ...page([shortPayload[0]!]), checkpointKey: `snapshot:${shortDigest}` };
+        }
+        return { ...page(fullPayload), checkpointKey: `snapshot:${fullDigest}` };
+      },
+      deleteCheckpoint: (key) => { deletedCheckpoints.push(key); },
+      setCheckpoint: () => {},
+    });
+
+    // The walk reached the SECOND ref. Without this the skip is unproven: a
+    // `break` leaves `requestedRefs` at `[shortDigest]`.
+    expect(requestedRefs).toEqual([shortDigest, fullDigest]);
+    expect(result).toMatchObject({
+      // Still not a clean round — the manifest is NOT satisfied. `completed` is
+      // derived from `missingCount === 0`, so continuing past a skipped ref must
+      // never be mistaken for success; the caller has to come back for it.
+      completed: false,
+      readySnapshots: 1,
+      totalSnapshots: 2,
+      missingCount: 1,
+      completedPhases: 1,
+      // A skip is OUR classification of the peer's response, not a local budget
+      // decision, so the voluntary-yield flag must stay down.
+      yieldedAtDeadline: false,
+    });
+    // The shortfall names the ref that was skipped, not the one that succeeded.
+    expect(result.missingSample).toEqual([shortDigest]);
+    // `MemorySnapshotStore.putSnapshot` genuinely persists into `this.snapshots`,
+    // so these two are real round-trips through the cache, not stub echoes: the
+    // second KA was verified and written, and the unverified prefix was not.
+    await expect(snapshotStore.getSnapshot(fullDigest)).resolves.toEqual(fullPayload);
+    await expect(snapshotStore.getSnapshot(shortDigest)).resolves.toBeNull();
+    // The skipped ref's checkpoint is dropped so its retry restarts at offset
+    // zero — resuming at nextOffset would validate only the tail against the
+    // full digest and could never succeed.
+    expect(deletedCheckpoints).toContain(`snapshot:${shortDigest}`);
+  });
+
+  it('yields at the round deadline without charging the peer a timeout', async () => {
+    // Every OTHER direct call of `syncPublicSnapshotsForMeta` in this repo —
+    // including the two rows above — passes `deadline: Number.MAX_SAFE_INTEGER`,
+    // so the voluntary-yield branch is never entered anywhere. This row is the
+    // only thing driving it.
+    //
+    // The contract being pinned is an ATTRIBUTION rule, not a counting rule:
+    // stopping on OUR OWN round budget is a local scheduling decision, so it
+    // must surface as an incomplete snapshot plane (`yieldedAtDeadline`, which
+    // the caller in `runSharedMemorySync` turns into `snapshotPlaneIncomplete`
+    // + `failedPhases`) and must NEVER touch `timedOutPhases` — that field
+    // feeds `backoffWorthyFailure` in `durable-progress.ts`, so folding a
+    // yield into it would back off a perfectly healthy responder for the
+    // crime of us running out of clock.
+    //
+    // Fake timers rather than a real short deadline: the clock has to cross the
+    // deadline BETWEEN the first and second Knowledge Asset, deterministically.
+    // A wall-clock margin would race the first `Date.now() >= deadline` check
+    // and flake on a loaded machine, and a busy-wait would burn real time.
+    const BASE_TIME = 1_700_000_000_000;
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(BASE_TIME);
+      const deadline = BASE_TIME + 1_000;
+
+      const cachedPayload: Quad[] = [
+        { subject: 'urn:snapshot:before-deadline', predicate: STATUS, object: '"kept"', graph: '' },
+      ];
+      const deferredPayload: Quad[] = [
+        { subject: 'urn:snapshot:after-deadline', predicate: STATUS, object: '"deferred"', graph: '' },
+      ];
+      const cachedDigest = workspacePublicQuadsDigest(cachedPayload);
+      const deferredDigest = workspacePublicQuadsDigest(deferredPayload);
+      const cachedSubject = 'urn:dkg:share:before-deadline-ka';
+      const deferredSubject = 'urn:dkg:share:after-deadline-ka';
+      const snapshotStore = new MemorySnapshotStore();
+      // Pre-seeded so the FIRST ref resolves from the CACHE. That keeps the
+      // pre-yield progress entirely off the network: `readySnapshots: 1` below
+      // therefore cannot be confused with a fetch, and `fetches: 0` stays a
+      // clean statement about the whole round.
+      await snapshotStore.putSnapshot({ digest: cachedDigest, quads: cachedPayload });
+      let fetches = 0;
+
+      const result = await syncPublicSnapshotsForMeta({
+        ctx,
+        remotePeerId: 'peer-source',
+        contextGraphId: CG,
+        deadline,
+        // Order is load-bearing: the cached ref FIRST, the deferred ref second.
+        // The clock is only pushed past the deadline once the first one is
+        // resolved, so the walk is forced to stop mid-manifest — which is the
+        // only shape that can show a yield PRESERVING earlier progress rather
+        // than discarding the round.
+        metaQuads: [
+          { subject: cachedSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${cachedDigest}"`, graph: WS_META },
+          { subject: cachedSubject, predicate: `${DKG}publicQuadsCount`, object: `"${cachedPayload.length}"^^<${XSD_INTEGER}>`, graph: WS_META },
+          { subject: deferredSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${deferredDigest}"`, graph: WS_META },
+          { subject: deferredSubject, predicate: `${DKG}publicQuadsCount`, object: `"${deferredPayload.length}"^^<${XSD_INTEGER}>`, graph: WS_META },
+        ],
+        publicSnapshotStore: snapshotStore,
+        fetchSyncPages: async (): Promise<SyncPageResult> => {
+          fetches += 1;
+          return page([]);
+        },
+        // The hook that burns the budget. It fires for the cache hit, so by the
+        // time the loop re-checks the clock for the second ref the round is
+        // over. Nothing here touches the transport.
+        onSnapshotReady: async () => { vi.setSystemTime(deadline); },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+      });
+
+      expect(result).toMatchObject({
+        // The local yield signal the caller maps to `snapshotPlaneIncomplete`.
+        yieldedAtDeadline: true,
+        // A yield is not a clean round: `completed` is derived from
+        // `missingCount === 0`, so the abandoned tail keeps the graph from
+        // being stamped caught-up while Knowledge Assets are still missing.
+        completed: false,
+        // Progress made BEFORE the deadline survives it.
+        readySnapshots: 1,
+        totalSnapshots: 2,
+        // `readySnapshots + missingCount === totalSnapshots` still holds across
+        // the yield — the abandoned tail is counted, not dropped.
+        missingCount: 1,
+        // The whole point. No peer fault was observed, so none is recorded:
+        // nothing here may reach `backoffWorthyFailure`.
+        timedOutPhases: 0,
+        // No network work happened at all this round.
+        completedPhases: 0,
+        resumedPhases: 0,
+        bytesReceived: 0,
+      });
+      // Names the ref we still owe, not the one we already have.
+      expect(result.missingSample).toEqual([deferredDigest]);
+      // The clock is checked BEFORE the fetch, so no `SyncPageResult` for the
+      // deferred ref ever exists — which is structurally why `timedOutPhases`
+      // cannot move on this path. If the check ever migrates below the fetch,
+      // this is the assertion that catches it.
+      expect(fetches).toBe(0);
+      // The yield left the deferred snapshot unfetched and uncached, so the
+      // next round restarts it from offset zero rather than resuming a prefix.
+      await expect(snapshotStore.getSnapshot(deferredDigest)).resolves.toBeNull();
+    } finally {
+      // Scoped to this row: the rest of the file (and the OxigraphStore-backed
+      // suite below) runs on the real clock.
+      vi.useRealTimers();
+    }
   });
 });
 const UAL = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/7';

--- a/packages/agent/test/swm-snapshot-materializer.test.ts
+++ b/packages/agent/test/swm-snapshot-materializer.test.ts
@@ -21,7 +21,7 @@
  *     ambiguous mix. A second round is a pure no-op, which also proves the
  *     digest survives the store round-trip (no churn).
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
@@ -66,21 +66,25 @@ class MemorySnapshotStore implements WorkspacePublicSnapshotStore {
  * count with different content: only a digest-binding guard can tell them
  * apart.
  */
-function share(version: number, operationId: string, marker: string) {
-  const scope = createGraphKnowledgeAssetScope(UAL, version);
+function share(version: number, operationId: string, marker: string, ual: string = UAL, payloadCount = 2) {
+  const scope = createGraphKnowledgeAssetScope(ual, version);
   const assertionGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, scope);
   const operationSubject = `urn:dkg:share:${CG}:${operationId}`;
-  const headSubject = `${UAL}#dkg-swm-head`;
-  const payload: Quad[] = [
-    { subject: 'urn:snap:a', predicate: 'http://schema.org/status', object: `"${marker}"`, graph: '' },
-    { subject: 'urn:snap:b', predicate: 'http://schema.org/status', object: `"${marker}"`, graph: '' },
-  ];
+  const headSubject = `${ual}#dkg-swm-head`;
+  // `ual`/`payloadCount` default to the original single-KA values, so `v1`/`v2`
+  // and every test built on them are behaviourally unchanged. The multi-KA
+  // manifest below varies both: distinct UALs give distinct head subjects, and
+  // distinct payload SIZES mean a KA materialized in place of another shows up
+  // in the counters instead of cancelling out.
+  const payload: Quad[] = Array.from({ length: payloadCount }, (_, i) => ({
+    subject: `urn:snap:${marker}:${i}`, predicate: 'http://schema.org/status', object: `"${marker}"`, graph: '',
+  }));
   const digest = workspacePublicQuadsDigest(payload);
   const meta: Quad[] = [
     ...generateKnowledgeAssetShareMetadata({
       shareOperationId: operationId,
       contextGraphId: CG,
-      kaUal: UAL,
+      kaUal: ual,
       assertionVersion: version,
       publicTripleCount: payload.length,
       privateTripleCount: 0,
@@ -90,12 +94,23 @@ function share(version: number, operationId: string, marker: string) {
     { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${digest}"`, graph: WS_META },
     { subject: operationSubject, predicate: `${DKG}publicSnapshotRef`, object: `"${digest}"`, graph: WS_META },
     { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, graph: WS_META },
-    { subject: headSubject, predicate: `${DKG}kaUal`, object: UAL, graph: WS_META },
+    { subject: headSubject, predicate: `${DKG}kaUal`, object: ual, graph: WS_META },
     { subject: headSubject, predicate: `${DKG}assertionVersion`, object: `"${version}"^^<${XSD_INTEGER}>`, graph: WS_META },
     { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: WS_META },
     { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${operationId}"`, graph: WS_META },
   ];
   return { version, operationId, operationSubject, headSubject, assertionGraph, payload, digest, meta };
+}
+
+/** N independent KAs — distinct UAL, operation and payload size each. */
+function manifest(count: number) {
+  return Array.from({ length: count }, (_, i) => share(
+    1,
+    `op-ka-${i + 1}`,
+    `ka-${i + 1}`,
+    `did:dkg:hardhat:31337/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/${i + 1}`,
+    2 + i,
+  ));
 }
 
 const v1 = share(1, 'op-v1', 'version-one');
@@ -362,5 +377,127 @@ describe('createSharedMemorySnapshotMaterializer against a real OxigraphStore', 
       expect(again.failedPhases).toBe(0);
       expect(h.replaceCalls()).toBe(1);
     });
+  });
+});
+
+/**
+ * T9 / T9b (#2050) — a PARTIAL round must leave its own progress readable.
+ *
+ * The G7 defect: `replaceHeadMetadata` is delete-only, and the only statement
+ * that writes head rows — `storeInsert(processed.verifiedMeta)` — sits BELOW the
+ * `continue` on the incomplete branch. So a round that materializes some KAs and
+ * then abandons the rest writes their assertion graphs and no head rows at all:
+ * content present, heads absent, invisible to every head reader. That is the
+ * r26 residual.
+ *
+ * This needs no Chunk 2 yield to reproduce. A snapshot-phase fetch that returns
+ * `completed: false` already drives `syncPublicSnapshotsForMeta` to its early
+ * return, which makes `snapshotPhaseUsable` false and skips the bulk insert —
+ * the same branch a deadline yield will take.
+ *
+ * Asserted over the FULL final quad set rather than per-KA presence, so an
+ * over-broad "insert everything" implementation fails here too: heads must exist
+ * for exactly the KAs that were materialized, and for no others.
+ */
+describe('T9 — a partial round leaves content AND head rows for what it materialized', () => {
+  const stores: OxigraphStore[] = [];
+  afterEach(async () => { await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {}))); });
+
+  /** Which of these KAs currently carry ANY head row in the store. */
+  async function headsPresent(store: TripleStore, shares: ReturnType<typeof manifest>): Promise<string[]> {
+    const present: string[] = [];
+    for (const s of shares) {
+      const r = await store.query(`ASK { GRAPH <${WS_META}> { <${s.headSubject}> ?p ?o } }`);
+      if (r.type === 'boolean' && r.value) present.push(s.headSubject);
+    }
+    return present.sort();
+  }
+
+  async function graphsPresent(store: TripleStore, shares: ReturnType<typeof manifest>): Promise<string[]> {
+    const present: string[] = [];
+    for (const s of shares) {
+      const r = await store.query(`ASK { GRAPH <${s.assertionGraph}> { ?s ?p ?o } }`);
+      if (r.type === 'boolean' && r.value) present.push(s.assertionGraph);
+    }
+    return present.sort();
+  }
+
+  /**
+   * Runs a round over `shares` where the first `materializeCount` snapshots are
+   * pre-cached (so they materialize from cache) and the next one is NOT cached
+   * and its network fetch returns incomplete — the partial-round branch.
+   */
+  async function runPartial(store: OxigraphStore, shares: ReturnType<typeof manifest>, materializeCount: number) {
+    const snapshotStore = new MemorySnapshotStore();
+    for (const s of shares.slice(0, materializeCount)) {
+      await snapshotStore.putSnapshot({ digest: s.digest, quads: s.payload });
+    }
+    const { materializer } = materializerFor(store);
+    return runSharedMemorySync({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphIds: [CG],
+      createContextGraphSyncDeadline: () => Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase): Promise<SyncPageResult> => {
+        if (phase === 'meta') {
+          const quads = shares.flatMap((s) => s.meta);
+          return { quads, bytesReceived: 0, resumedFromOffset: 0, nextOffset: quads.length, checkpointKey: 'k', completed: true, timedOut: false };
+        }
+        if (phase === 'snapshot') {
+          // The uncached snapshot cannot be served: the phase ends incomplete,
+          // which is exactly what a mid-list deadline produces.
+          return { quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 0, checkpointKey: 'snap', completed: false, timedOut: true };
+        }
+        return { quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 0, checkpointKey: 'k', completed: true, timedOut: false };
+      },
+      processSharedMemoryBatch: async (wsDataQuads, wsMetaQuads) => ({
+        verifiedData: wsDataQuads, verifiedMeta: wsMetaQuads,
+        totalFetchedDataQuads: wsDataQuads.length, totalFetchedMetaQuads: wsMetaQuads.length,
+        droppedDataTriples: 0, emptyResponses: 0, entityCreators: [],
+      }),
+      ensureContextGraph: async () => {},
+      storeInsert: async (quads) => { await store.insert(quads); },
+      snapshotMaterializer: materializer,
+      publicSnapshotStore: snapshotStore,
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      ensureOwnedMap: () => new Map(),
+      logInfo: () => {}, logWarn: () => {}, logDebug: () => {},
+    });
+  }
+
+  it('writes head rows for exactly the KAs it materialized, and none for the rest', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const shares = manifest(5);
+
+    await runPartial(store, shares, 2);
+
+    // The two cached KAs were written to the store...
+    expect(await graphsPresent(store, shares))
+      .toEqual([shares[0]!.assertionGraph, shares[1]!.assertionGraph].sort());
+
+    // ...and their heads must be readable, or the content is invisible to every
+    // head reader. PRE-FIX THIS IS `[]`: the bulk meta insert is skipped on the
+    // incomplete branch and nothing else writes a head row.
+    expect(await headsPresent(store, shares))
+      .toEqual([shares[0]!.headSubject, shares[1]!.headSubject].sort());
+  });
+
+  it('does not certify a KA it never materialized', async () => {
+    // The over-broad direction: an implementation that inserts all verified meta
+    // on the partial branch would stamp head rows for KAs 3-5, whose assertion
+    // graphs were never written — a head certifying an unwritten graph, which is
+    // the precise failure the withhold rule exists to prevent.
+    const store = new OxigraphStore();
+    stores.push(store);
+    const shares = manifest(5);
+
+    await runPartial(store, shares, 2);
+
+    const heads = await headsPresent(store, shares);
+    for (const s of shares.slice(2)) {
+      expect(heads).not.toContain(s.headSubject);
+    }
   });
 });

--- a/packages/agent/test/swm-snapshot-materializer.test.ts
+++ b/packages/agent/test/swm-snapshot-materializer.test.ts
@@ -41,6 +41,7 @@ import { parseGraphScopedSwmRecoveryDescriptors } from '../src/sync/graph-scoped
 import { createSharedMemorySnapshotMaterializer } from '../src/sync/requester/swm-snapshot-materializer.js';
 import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import { swmFixtures } from './swm-descriptor-fixtures.js';
 
 const CG = 'ws00-materializer-real-store';
 const WS_META = contextGraphWorkspaceMetaGraphUri(CG);
@@ -66,51 +67,23 @@ class MemorySnapshotStore implements WorkspacePublicSnapshotStore {
  * count with different content: only a digest-binding guard can tell them
  * apart.
  */
+/**
+ * Thin adapters over the shared builders in `swm-descriptor-fixtures.ts`.
+ *
+ * The bodies moved so the throw-path row in `sync-requester-progress.test.ts`
+ * can build DESCRIPTOR-shaped metadata from the same known-good source instead
+ * of hand-rolling a fourth SWM fixture. The positional signatures are kept so
+ * every existing call site here is untouched — the 13 pre-existing tests are
+ * re-proven behaviourally identical by RUN, not by reading this diff.
+ */
+const swmFx = swmFixtures(CG);
+
 function share(version: number, operationId: string, marker: string, ual: string = UAL, payloadCount = 2) {
-  const scope = createGraphKnowledgeAssetScope(ual, version);
-  const assertionGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, scope);
-  const operationSubject = `urn:dkg:share:${CG}:${operationId}`;
-  const headSubject = `${ual}#dkg-swm-head`;
-  // `ual`/`payloadCount` default to the original single-KA values, so `v1`/`v2`
-  // and every test built on them are behaviourally unchanged. The multi-KA
-  // manifest below varies both: distinct UALs give distinct head subjects, and
-  // distinct payload SIZES mean a KA materialized in place of another shows up
-  // in the counters instead of cancelling out.
-  const payload: Quad[] = Array.from({ length: payloadCount }, (_, i) => ({
-    subject: `urn:snap:${marker}:${i}`, predicate: 'http://schema.org/status', object: `"${marker}"`, graph: '',
-  }));
-  const digest = workspacePublicQuadsDigest(payload);
-  const meta: Quad[] = [
-    ...generateKnowledgeAssetShareMetadata({
-      shareOperationId: operationId,
-      contextGraphId: CG,
-      kaUal: ual,
-      assertionVersion: version,
-      publicTripleCount: payload.length,
-      privateTripleCount: 0,
-      publisherPeerId: 'peer-source',
-      timestamp: new Date(0),
-    }, WS_META),
-    { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${digest}"`, graph: WS_META },
-    { subject: operationSubject, predicate: `${DKG}publicSnapshotRef`, object: `"${digest}"`, graph: WS_META },
-    { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, graph: WS_META },
-    { subject: headSubject, predicate: `${DKG}kaUal`, object: ual, graph: WS_META },
-    { subject: headSubject, predicate: `${DKG}assertionVersion`, object: `"${version}"^^<${XSD_INTEGER}>`, graph: WS_META },
-    { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: WS_META },
-    { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${operationId}"`, graph: WS_META },
-  ];
-  return { version, operationId, operationSubject, headSubject, assertionGraph, payload, digest, meta };
+  return swmFx.share({ version, operationId, marker, ual, payloadCount });
 }
 
-/** N independent KAs — distinct UAL, operation and payload size each. */
 function manifest(count: number) {
-  return Array.from({ length: count }, (_, i) => share(
-    1,
-    `op-ka-${i + 1}`,
-    `ka-${i + 1}`,
-    `did:dkg:hardhat:31337/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/${i + 1}`,
-    2 + i,
-  ));
+  return swmFx.manifest(count);
 }
 
 const v1 = share(1, 'op-v1', 'version-one');

--- a/packages/agent/test/swm-snapshot-materializer.test.ts
+++ b/packages/agent/test/swm-snapshot-materializer.test.ts
@@ -399,6 +399,50 @@ describe('createSharedMemorySnapshotMaterializer against a real OxigraphStore', 
  * over-broad "insert everything" implementation fails here too: heads must exist
  * for exactly the KAs that were materialized, and for no others.
  */
+/**
+ * Runs a round over `shares` where the first `materializeCount` snapshots are
+ * pre-cached (so they materialize from cache) and the next one is NOT cached
+ * and its network fetch returns incomplete — the partial-round branch.
+ */
+async function runPartial(store: OxigraphStore, shares: ReturnType<typeof manifest>, materializeCount: number) {
+  const snapshotStore = new MemorySnapshotStore();
+  for (const s of shares.slice(0, materializeCount)) {
+    await snapshotStore.putSnapshot({ digest: s.digest, quads: s.payload });
+  }
+  const { materializer } = materializerFor(store);
+  return runSharedMemorySync({
+    ctx,
+    remotePeerId: 'peer-source',
+    contextGraphIds: [CG],
+    createContextGraphSyncDeadline: () => Number.MAX_SAFE_INTEGER,
+    fetchSyncPages: async (_c, _p, _cg, _inc, phase): Promise<SyncPageResult> => {
+      if (phase === 'meta') {
+        const quads = shares.flatMap((s) => s.meta);
+        return { quads, bytesReceived: 0, resumedFromOffset: 0, nextOffset: quads.length, checkpointKey: 'k', completed: true, timedOut: false };
+      }
+      if (phase === 'snapshot') {
+        // The uncached snapshot cannot be served: the phase ends incomplete,
+        // which is exactly what a mid-list deadline produces.
+        return { quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 0, checkpointKey: 'snap', completed: false, timedOut: true };
+      }
+      return { quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 0, checkpointKey: 'k', completed: true, timedOut: false };
+    },
+    processSharedMemoryBatch: async (wsDataQuads, wsMetaQuads) => ({
+      verifiedData: wsDataQuads, verifiedMeta: wsMetaQuads,
+      totalFetchedDataQuads: wsDataQuads.length, totalFetchedMetaQuads: wsMetaQuads.length,
+      droppedDataTriples: 0, emptyResponses: 0, entityCreators: [],
+    }),
+    ensureContextGraph: async () => {},
+    storeInsert: async (quads) => { await store.insert(quads); },
+    snapshotMaterializer: materializer,
+    publicSnapshotStore: snapshotStore,
+    deleteCheckpoint: () => {},
+    setCheckpoint: () => {},
+    ensureOwnedMap: () => new Map(),
+    logInfo: () => {}, logWarn: () => {}, logDebug: () => {},
+  });
+}
+
 describe('T9 — a partial round leaves content AND head rows for what it materialized', () => {
   const stores: OxigraphStore[] = [];
   afterEach(async () => { await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {}))); });
@@ -422,49 +466,6 @@ describe('T9 — a partial round leaves content AND head rows for what it materi
     return present.sort();
   }
 
-  /**
-   * Runs a round over `shares` where the first `materializeCount` snapshots are
-   * pre-cached (so they materialize from cache) and the next one is NOT cached
-   * and its network fetch returns incomplete — the partial-round branch.
-   */
-  async function runPartial(store: OxigraphStore, shares: ReturnType<typeof manifest>, materializeCount: number) {
-    const snapshotStore = new MemorySnapshotStore();
-    for (const s of shares.slice(0, materializeCount)) {
-      await snapshotStore.putSnapshot({ digest: s.digest, quads: s.payload });
-    }
-    const { materializer } = materializerFor(store);
-    return runSharedMemorySync({
-      ctx,
-      remotePeerId: 'peer-source',
-      contextGraphIds: [CG],
-      createContextGraphSyncDeadline: () => Number.MAX_SAFE_INTEGER,
-      fetchSyncPages: async (_c, _p, _cg, _inc, phase): Promise<SyncPageResult> => {
-        if (phase === 'meta') {
-          const quads = shares.flatMap((s) => s.meta);
-          return { quads, bytesReceived: 0, resumedFromOffset: 0, nextOffset: quads.length, checkpointKey: 'k', completed: true, timedOut: false };
-        }
-        if (phase === 'snapshot') {
-          // The uncached snapshot cannot be served: the phase ends incomplete,
-          // which is exactly what a mid-list deadline produces.
-          return { quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 0, checkpointKey: 'snap', completed: false, timedOut: true };
-        }
-        return { quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 0, checkpointKey: 'k', completed: true, timedOut: false };
-      },
-      processSharedMemoryBatch: async (wsDataQuads, wsMetaQuads) => ({
-        verifiedData: wsDataQuads, verifiedMeta: wsMetaQuads,
-        totalFetchedDataQuads: wsDataQuads.length, totalFetchedMetaQuads: wsMetaQuads.length,
-        droppedDataTriples: 0, emptyResponses: 0, entityCreators: [],
-      }),
-      ensureContextGraph: async () => {},
-      storeInsert: async (quads) => { await store.insert(quads); },
-      snapshotMaterializer: materializer,
-      publicSnapshotStore: snapshotStore,
-      deleteCheckpoint: () => {},
-      setCheckpoint: () => {},
-      ensureOwnedMap: () => new Map(),
-      logInfo: () => {}, logWarn: () => {}, logDebug: () => {},
-    });
-  }
 
   it('writes head rows for exactly the KAs it materialized, and none for the rest', async () => {
     const store = new OxigraphStore();
@@ -499,5 +500,84 @@ describe('T9 — a partial round leaves content AND head rows for what it materi
     for (const s of shares.slice(2)) {
       expect(heads).not.toContain(s.headSubject);
     }
+  });
+});
+
+/**
+ * T9b (#2050) — the r26 RESIDUAL: content already materialized, head row absent
+ * or stale. Nothing rewrites it pre-fix, so the KA stays invisible forever.
+ *
+ * This is the third head-deleting exit, and it is the one neither T9 row can
+ * reach: both of those go through the MATERIALIZE path, while this state short-
+ * circuits at `isGraphAssetMaterialized() === true` and returns early. A node
+ * that ran a partial round before the fix is left in exactly this state — the
+ * graph is written, so the content guard says "already materialized", and the
+ * head that would advertise it was deleted and never rewritten.
+ *
+ * Both cases run on the PARTIAL branch deliberately. On a complete round the
+ * bulk `storeInsert(processed.verifiedMeta)` writes every head anyway and would
+ * mask the exit entirely — the assertion would pass with the repair removed.
+ * With the round incomplete, the exit's own insert is the ONLY thing that can
+ * write these head rows, which is what makes the mutant `storedHead.needsRepair
+ * || !headCertifiesDescriptor(…)` → `storedHead.needsRepair` fail here.
+ */
+describe('T9b — the already-materialized exit repairs an absent or stale head', () => {
+  const stores: OxigraphStore[] = [];
+  afterEach(async () => { await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {}))); });
+
+  async function headVersions(store: TripleStore, headSubject: string): Promise<string[]> {
+    return distinctObjects(store, WS_META, headSubject, `${DKG}assertionVersion`);
+  }
+
+  it('writes the head for content that is present with NO head row at all', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const shares = manifest(3);
+    const target = shares[0]!;
+
+    // The r26 residual, reproduced exactly: assertion graph written by an
+    // earlier partial round, zero head rows. `needsRepair` is FALSE here
+    // (`readStoredHead` returns `{version: null, needsRepair: false}` when the
+    // subject carries nothing), so a repair gated only on `needsRepair` never
+    // fires and the KA stays stranded.
+    await store.insert(inGraph(target.payload, target.assertionGraph));
+    expect(await headVersions(store, target.headSubject)).toEqual([]);
+
+    await runPartial(store, shares, 2);
+
+    expect(await headVersions(store, target.headSubject))
+      .toEqual([`"1"^^<${XSD_INTEGER}>`]);
+  });
+
+  it('replaces a head pinned at an OLDER version than the content', async () => {
+    // Same exit, stale rather than absent: the head advertises v1 while the
+    // graph already holds the descriptor's content. One version row before,
+    // exactly one after — and it must be the descriptor's, not the stale one.
+    const store = new OxigraphStore();
+    stores.push(store);
+    // The stored head must be STRICTLY OLDER than the descriptor, or the in-lock
+    // version guard short-circuits at `storedVersionOutranksDescriptor` and exit
+    // 3 is never reached. An earlier draft pre-seeded a v1 head against a v1
+    // descriptor: the guard returned early, the stale rows survived untouched —
+    // and the version assertion STILL PASSED, because both heads read "1". It
+    // could not tell the two states apart.
+    const base = manifest(3);
+    const ual = base[0]!.headSubject.replace('#dkg-swm-head', '');
+    // Same UAL, payload and digest, VERSION 2. A graph-scoped KA keeps ONE
+    // assertion graph across versions, so the pre-seeded content still matches.
+    const target = share(2, 'op-ka-1-v2', 'ka-1', ual, 2);
+    const shares = [target, ...base.slice(1)];
+
+    await store.insert(inGraph(target.payload, target.assertionGraph));
+    await store.insert(base[0]!.meta.filter((q) => q.subject === base[0]!.headSubject));
+    expect(await headVersions(store, target.headSubject)).toEqual([`"1"^^<${XSD_INTEGER}>`]);
+
+    await runPartial(store, shares, 2);
+
+    const versions = await headVersions(store, target.headSubject);
+    expect(versions).toEqual([`"2"^^<${XSD_INTEGER}>`]);
+    // The stale operation subject must not survive alongside the fresh one.
+    expect(await distinctObjects(store, WS_META, target.headSubject, `${DKG}shareOperationId`))
+      .toEqual([`"${target.operationId}"`]);
   });
 });

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -1260,9 +1260,12 @@ describe('DKGAgent sync fetch coalescing', () => {
         };
       };
 
-      const result = await agent.syncContextGraphFromConnectedPeers('coalesced-cg', {
-        includeSharedMemory: true,
-      });
+      const result = await (agent as any).runCatchupOverPeers(
+        'coalesced-cg',
+        true,
+        [peerA, peerB],
+        { swmCatchupPassConfig: { budgetMs: 0, maxPasses: 4 } },
+      );
 
       // Guard the fixture itself: if the SWM plane were skipped (for example by
       // a durable result carrying deferredBackpressure), every assertion below
@@ -1296,6 +1299,61 @@ describe('DKGAgent sync fetch coalescing', () => {
       expect(
         (swm.replayPhaseBytesReceived ?? 0) + (swm.snapshotPhaseBytesReceived ?? 0),
       ).toBe(swm.bytesReceived);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('runs the bounded SWM continuation policy on the inline agent path', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const remotePeer = { toString: () => PEER_A };
+    const durableCalls: string[] = [];
+    const sharedCalls: string[] = [];
+
+    const coverage = (resolved: number): SwmSnapshotCoverage => ({
+      contextGraphId: 'coalesced-cg',
+      peerIdSuffix: PEER_A.slice(-8),
+      snapshotsResolved: resolved,
+      snapshotsTotal: 3,
+      manifestComplete: true,
+      missingCount: 3 - resolved,
+      missingSample: resolved < 3 ? ['sha256:remaining'] : [],
+      materializationFailures: 0,
+    });
+
+    try {
+      await agent.start();
+      (agent as any).isPrivateContextGraph = async () => false;
+      (agent as any).resolvePreferredSyncPeerId = async () => undefined;
+      (agent as any).primeCatchupConnections = async () => undefined;
+      (agent as any).ensurePeerAdmittedForRecovery = async () => true;
+      (agent as any).waitForSyncProtocol = async () => true;
+      (agent as any).refreshMetaSyncedFlags = async () => undefined;
+      (agent.node.libp2p as any).getConnections = () => [{ remotePeer }];
+      (agent.node.libp2p.peerStore as any).get = async () => ({ protocols: [PROTOCOL_SYNC] });
+      (agent as any).syncFromPeerDetailed = async (peerId: string) => {
+        durableCalls.push(peerId);
+        return cleanDurableSyncResult();
+      };
+      (agent as any).syncSharedMemoryFromPeerDetailed = async (peerId: string) => {
+        sharedCalls.push(peerId);
+        const resolved = sharedCalls.length === 1 ? 2 : 3;
+        return {
+          ...cleanSharedMemorySyncResult(),
+          ...(resolved < 3 ? { failedPhases: 1, snapshotPlaneIncomplete: 1 } : {}),
+          swmCoverage: coverage(resolved),
+        };
+      };
+
+      const result = await agent.syncContextGraphFromConnectedPeers('coalesced-cg', {
+        includeSharedMemory: true,
+      });
+
+      expect(durableCalls).toEqual([PEER_A]);
+      expect(sharedCalls).toEqual([PEER_A, PEER_A]);
+      expect(result.diagnostics.sharedMemory.swmCoverage).toEqual(coverage(3));
+      expect(result.diagnostics.sharedMemory.continuationPasses).toBe(1);
+      expect(result.diagnostics.sharedMemory.continuationStopReason).toBe('no-capable-peers');
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -8,7 +8,7 @@ import {
   DKGAgent,
   FOREGROUND_CATCHUP_SYNC_PRIORITY,
 } from '../src/index.js';
-import type { ContextGraphMembershipStore } from '../src/dkg-agent-types.js';
+import type { ContextGraphMembershipStore, SwmSnapshotCoverage } from '../src/dkg-agent-types.js';
 import { resolveSyncGlobalBackpressure, SyncBackpressureBusyError, withGlobalSyncBackpressure } from '../src/sync/backpressure.js';
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
@@ -1153,6 +1153,151 @@ describe('DKGAgent sync fetch coalescing', () => {
       } finally {
         await agent.stop().catch(() => {});
       }
+    }
+  });
+
+  // #2050. The IN-AGENT catch-up walk (`runCatchupOverPeers`) has to publish the
+  // same SWM diagnostics the worker-backed CLI runner does, or a job that happens
+  // to take the inline path reports a shortfall it cannot name while an identical
+  // job through the worker names it fully. The aggregation is three statements
+  // inside the `if (r.shared)` arm; deleting them leaves every other suite green,
+  // which is exactly why this row exists.
+  //
+  // TWO peers, not one. With a single peer `+=` is indistinguishable from `=`, and
+  // last-writer-wins is indistinguishable from whole-record selection — a one-peer
+  // fixture here passes against a completely broken aggregator.
+  it('preserves whole-record SWM coverage and sums snapshot-phase counters across catch-up peers', async () => {
+    // Peer A: a LARGER manifest that is still 72 refs short. Peer B: a smaller
+    // manifest that fully converged. This pair is chosen precisely because the
+    // two plausible wrong reductions produce visibly wrong answers:
+    //   - independent field-wise maxima yield 200/250, a state NO peer reported
+    //     and one nothing downstream can detect as synthetic;
+    //   - ranking by resolved/total picks B's 200/200 and reports "0 outstanding"
+    //     on a graph that is 72 Knowledge Assets short.
+    // `selectSwmSnapshotCoverage` ranks by LARGEST manifest, so A must win WHOLE.
+    // Weakening either peer to the same snapshotsTotal would collapse the tie into
+    // the peerIdSuffix tiebreak and stop testing the selection rule at all.
+    const peerACoverage = (): SwmSnapshotCoverage => ({
+      contextGraphId: 'coalesced-cg',
+      peerIdSuffix: PEER_A.slice(-8),
+      snapshotsResolved: 178,
+      snapshotsTotal: 250,
+      manifestComplete: true,
+      // resolved + missing === total, by construction. A fixture that broke this
+      // would be asserting a state the producer cannot emit.
+      missingCount: 72,
+      missingSample: ['swm-ref-a1', 'swm-ref-a2'],
+      // Legal only because missingCount > 0: `materializationFailures > 0` with
+      // `missingCount === 0` is unrepresentable (see SwmSnapshotCoverage docs).
+      materializationFailures: 3,
+      fromAuthority: false,
+    });
+    const peerBCoverage = (): SwmSnapshotCoverage => ({
+      contextGraphId: 'coalesced-cg',
+      peerIdSuffix: PEER_B.slice(-8),
+      snapshotsResolved: 200,
+      snapshotsTotal: 200,
+      manifestComplete: true,
+      missingCount: 0,
+      missingSample: [],
+      materializationFailures: 0,
+      fromAuthority: false,
+    });
+
+    // Distinct NON-ZERO values on both peers for every summed counter, and sums
+    // that equal neither operand. If either peer contributed 0, or the two
+    // contributed the same value, `=` would be indistinguishable from `+=`.
+    // Per-peer `bytesReceived` is kept equal to replay + snapshot so the
+    // aggregate preserves the documented identity
+    // `replayPhaseBytesReceived + snapshotPhaseBytesReceived === bytesReceived`.
+    const peerARound = {
+      swmCoverage: peerACoverage(),
+      snapshotPlaneIncomplete: 1,
+      replayPhaseBytesReceived: 4_096,
+      snapshotPhaseBytesReceived: 65_536,
+      bytesReceived: 69_632,
+    };
+    const peerBRound = {
+      swmCoverage: peerBCoverage(),
+      snapshotPlaneIncomplete: 2,
+      replayPhaseBytesReceived: 1_024,
+      snapshotPhaseBytesReceived: 16_384,
+      bytesReceived: 17_408,
+    };
+
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const peerA = { toString: () => PEER_A };
+    const peerB = { toString: () => PEER_B };
+    const sharedSyncPeers: string[] = [];
+
+    try {
+      await agent.start();
+      (agent as any).isPrivateContextGraph = async () => false;
+      // No preferred peer and no core peers, so `orderCatchupPeers` returns the
+      // connection order untouched: A is walked first, B last. That ordering is
+      // load-bearing — it is what makes last-writer-wins select B and fail the
+      // whole-record assertion below.
+      (agent as any).resolvePreferredSyncPeerId = async () => undefined;
+      (agent as any).primeCatchupConnections = async () => undefined;
+      (agent as any).ensurePeerAdmittedForRecovery = async () => true;
+      (agent as any).waitForSyncProtocol = async () => true;
+      (agent as any).refreshMetaSyncedFlags = async () => undefined;
+      (agent.node.libp2p as any).getConnections = () => [
+        { remotePeer: peerA },
+        { remotePeer: peerB },
+      ];
+      (agent.node.libp2p.peerStore as any).get = async () => ({ protocols: [PROTOCOL_SYNC] });
+      (agent as any).syncFromPeerDetailed = async () => cleanDurableSyncResult();
+      (agent as any).syncSharedMemoryFromPeerDetailed = async (remotePeerId: string) => {
+        sharedSyncPeers.push(remotePeerId);
+        // Fresh objects per call: returning a shared const would let an
+        // in-place mutation of the coverage record pass unnoticed, because the
+        // expected value below would mutate with it.
+        return {
+          ...cleanSharedMemorySyncResult(),
+          ...(remotePeerId === PEER_A ? peerARound : peerBRound),
+          swmCoverage: remotePeerId === PEER_A ? peerACoverage() : peerBCoverage(),
+        };
+      };
+
+      const result = await agent.syncContextGraphFromConnectedPeers('coalesced-cg', {
+        includeSharedMemory: true,
+      });
+
+      // Guard the fixture itself: if the SWM plane were skipped (for example by
+      // a durable result carrying deferredBackpressure), every assertion below
+      // would read zeros and "pass" a broken aggregator by accident.
+      expect(sharedSyncPeers.sort()).toEqual([PEER_A, PEER_B].sort());
+      expect(result.peersTried).toBe(2);
+
+      const swm = result.diagnostics.sharedMemory;
+
+      // WHOLE-RECORD selection. Compared as one object on purpose: a per-field
+      // reduction that took max(resolved)=200 from B and max(total)=250 from A
+      // would satisfy any pair of independent per-field assertions while
+      // describing a round no peer ever ran.
+      expect(swm.swmCoverage).toEqual(peerACoverage());
+      // Spelled out as well, because these three are the fields an operator
+      // reads and the ones a synthetic mix corrupts: all three must come from A.
+      expect(swm.swmCoverage?.snapshotsResolved).toBe(178);
+      expect(swm.swmCoverage?.snapshotsTotal).toBe(250);
+      expect(swm.swmCoverage?.peerIdSuffix).toBe(PEER_A.slice(-8));
+      // B's converged record must not survive anywhere in the selected row.
+      expect(swm.swmCoverage?.missingCount).toBe(72);
+
+      // SUMMATION across both peers. Each expected value differs from both
+      // operands, so neither `=` (last write) nor a dropped forward can produce it.
+      expect(swm.snapshotPlaneIncomplete).toBe(3); // 1 + 2
+      expect(swm.replayPhaseBytesReceived).toBe(5_120); // 4_096 + 1_024
+      expect(swm.snapshotPhaseBytesReceived).toBe(81_920); // 65_536 + 16_384
+      // The documented split identity has to survive aggregation, not just hold
+      // per round: replay + snapshot must still account for every byte received.
+      expect(swm.bytesReceived).toBe(87_040); // 69_632 + 17_408
+      expect(
+        (swm.replayPhaseBytesReceived ?? 0) + (swm.snapshotPhaseBytesReceived ?? 0),
+      ).toBe(swm.bytesReceived);
+    } finally {
+      await agent.stop().catch(() => {});
     }
   });
 });

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1602,3 +1602,193 @@ describe('public SWM snapshot coverage (#2050)', () => {
     });
   });
 });
+
+/**
+ * T13 (#2050) — the coverage reduction reduces COHERENTLY and selects the
+ * record that names the shortfall.
+ *
+ * Two properties, and the second is the one that matters. Every return in
+ * `selectSwmSnapshotCoverage` yields `a` or `b` — it never constructs — so a
+ * whole-record assertion is satisfied BY CONSTRUCTION and cannot fail for any
+ * mutation confined to the comparison logic. It dies only under a mutant that
+ * SYNTHESIZES a record. That is real coverage of the no-synthesis property and
+ * it is worth keeping, but it is not what AC-5 depends on.
+ *
+ * The defect it cannot see: ranking by `resolved/total` returns `200/200` with
+ * `missingCount: 0` for a job 72 Knowledge Assets short — a real record, from a
+ * real peer, internally self-consistent, and wrong. Assert selection too, or the
+ * ordering is untested.
+ */
+function t13Coverage(over: Partial<SwmSnapshotCoverage> & {
+  peerIdSuffix: string; snapshotsResolved: number; snapshotsTotal: number;
+}): SwmSnapshotCoverage {
+  return {
+    contextGraphId: 'cg-t13',
+    manifestComplete: true,
+    missingCount: over.snapshotsTotal - over.snapshotsResolved,
+    missingSample: [],
+    ...over,
+  };
+}
+
+describe('T13 — swmCoverage reduction', () => {
+  /** The r26 shape: the peer that actually holds the graph, 72 short. */
+  const shortfallPeer = t13Coverage({ peerIdSuffix: 'aaaa1111', snapshotsResolved: 178, snapshotsTotal: 250 });
+  /** A peer hosting a SMALLER view of the same graph, fully resolved against it. */
+  const smallerPeer = t13Coverage({ peerIdSuffix: 'bbbb2222', snapshotsResolved: 200, snapshotsTotal: 200 });
+
+  it('never synthesizes a pair: the result is always one whole input record', () => {
+    for (const [a, b] of [[shortfallPeer, smallerPeer], [smallerPeer, shortfallPeer]] as const) {
+      expect([a, b]).toContainEqual(selectSwmSnapshotCoverage(a, b));
+    }
+  });
+
+  it('selects the record that NAMES THE SHORTFALL, not the best-looking fraction', () => {
+    for (const [a, b] of [[shortfallPeer, smallerPeer], [smallerPeer, shortfallPeer]] as const) {
+      const selected = selectSwmSnapshotCoverage(a, b);
+      expect(selected).toEqual(shortfallPeer);
+      expect(selected?.missingCount).toBe(72);
+      expect(selected?.peerIdSuffix).toBe('aaaa1111');
+    }
+  });
+
+  it('prefers a large partial manifest over a tiny complete one', () => {
+    // The residual the original implementation accepted in its own doc comment:
+    // `1/1` is complete and fully resolved, and reporting it would tell the
+    // operator the graph had converged.
+    const tiny = t13Coverage({ peerIdSuffix: 'cccc3333', snapshotsResolved: 1, snapshotsTotal: 1 });
+    expect(selectSwmSnapshotCoverage(tiny, shortfallPeer)).toEqual(shortfallPeer);
+    expect(selectSwmSnapshotCoverage(shortfallPeer, tiny)).toEqual(shortfallPeer);
+  });
+
+  it('prefers a complete manifest over an incomplete one, whatever the counts', () => {
+    // An incomplete manifest's denominator is only a lower bound, so its
+    // shortfall is not comparable. Completeness outranks size.
+    const truncatedButBigger = t13Coverage({
+      peerIdSuffix: 'dddd4444', snapshotsResolved: 250, snapshotsTotal: 400, manifestComplete: false,
+    });
+    expect(selectSwmSnapshotCoverage(truncatedButBigger, shortfallPeer)).toEqual(shortfallPeer);
+    expect(selectSwmSnapshotCoverage(shortfallPeer, truncatedButBigger)).toEqual(shortfallPeer);
+  });
+
+  it('lets authority evidence outrank everything below it', () => {
+    // Residual, stated deliberately: a stale or smaller CURATOR manifest still
+    // reports converged. Accepted — the curator is definitionally authoritative
+    // about its own graph's inventory — but it is a property of trusting the
+    // curator, not an artefact of the reduction.
+    const curator = t13Coverage({ peerIdSuffix: '9999cccc', snapshotsResolved: 5, snapshotsTotal: 5, fromAuthority: true });
+    expect(selectSwmSnapshotCoverage(curator, shortfallPeer)).toEqual(curator);
+    expect(selectSwmSnapshotCoverage(shortfallPeer, curator)).toEqual(curator);
+  });
+
+  it('is order-independent across records with DISTINCT peer suffixes', () => {
+    // Scoped to distinct suffixes, which is what this asserts and all it
+    // asserts — the final tiebreak is only asymmetric when they differ.
+    const records = [shortfallPeer, smallerPeer,
+      t13Coverage({ peerIdSuffix: 'cccc3333', snapshotsResolved: 1, snapshotsTotal: 1 }),
+      t13Coverage({ peerIdSuffix: 'dddd4444', snapshotsResolved: 250, snapshotsTotal: 400, manifestComplete: false }),
+    ];
+    for (const a of records) {
+      for (const b of records) {
+        expect(selectSwmSnapshotCoverage(a, b)).toEqual(selectSwmSnapshotCoverage(b, a));
+      }
+    }
+  });
+
+  it('passes absent operands through rather than erasing the known record', () => {
+    expect(selectSwmSnapshotCoverage(undefined, shortfallPeer)).toEqual(shortfallPeer);
+    expect(selectSwmSnapshotCoverage(shortfallPeer, undefined)).toEqual(shortfallPeer);
+    expect(selectSwmSnapshotCoverage(undefined, undefined)).toBeUndefined();
+  });
+});
+
+/**
+ * T14 (#2050) — a throw must not erase the progress the round actually made.
+ *
+ * This is a CONVERGENCE property, not a diagnostics one. The continuation loop
+ * reads `swmCoverage.snapshotsResolved` as its progress signal, and that record
+ * is assembled from `syncPublicSnapshotsForMeta`'s RETURN value. A snapshot-
+ * phase transport failure throws, so before this fix the return never happened,
+ * no coverage record was built, the high-water mark did not move, and the loop
+ * declared `coverage-stalled` and abandoned a peer that had just materialized
+ * real Knowledge Assets — the r26 shape, and the exact behaviour #2050 exists
+ * to remove.
+ */
+describe('T14 — a throwing snapshot round still reports what it resolved', () => {
+  const T14_CG = 'throwing-swm';
+  const T14_META = `did:dkg:context-graph:${T14_CG}/_shared_memory_meta`;
+
+  function snapshotRow(subject: string, digest: string, count: number): Quad[] {
+    return [
+      { subject, predicate: 'http://dkg.io/ontology/publicQuadsDigest', object: `"${digest}"`, graph: T14_META } as Quad,
+      { subject, predicate: 'http://dkg.io/ontology/publicQuadsCount', object: `"${count}"`, graph: T14_META } as Quad,
+    ];
+  }
+
+  it('carries the resolved count out through the throw instead of reporting zero', async () => {
+    // Two snapshots cached and resolvable, then one whose fetch blows up.
+    const cachedA = [quad('t14-a')];
+    const cachedB = [quad('t14-b')];
+    const digestA = workspacePublicQuadsDigest(cachedA);
+    const digestB = workspacePublicQuadsDigest(cachedB);
+    const meta = [
+      ...snapshotRow('did:dkg:assertion:a', digestA, cachedA.length),
+      ...snapshotRow('did:dkg:assertion:b', digestB, cachedB.length),
+      ...snapshotRow('did:dkg:assertion:boom', 'digest-that-throws', 4),
+    ];
+
+    const summary = await runSharedMemorySync({
+      ctx,
+      remotePeerId: 'peer-throwing-99887766',
+      contextGraphIds: [T14_CG],
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx: OperationContext,
+        _peer: string,
+        contextGraphId: string,
+        _includeSharedMemory: boolean,
+        phase: string,
+      ) => {
+        if (phase === 'snapshot') throw transportError('snapshot stream reset');
+        return pageResult(contextGraphId, phase);
+      },
+      processSharedMemoryBatch: async () => ({
+        ...sharedMemoryProcessResult(),
+        emptyResponses: 0,
+        verifiedMeta: meta,
+        totalFetchedMetaQuads: meta.length,
+      }),
+      ensureContextGraph: async () => {},
+      storeInsert: async () => {},
+      publicSnapshotStore: {
+        getSnapshot: async (ref: string) => {
+          if (ref === digestA) return cachedA;
+          if (ref === digestB) return cachedB;
+          return null;
+        },
+        putSnapshot: async () => ({ ref: 'unused', byteLength: 0 }),
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      ensureOwnedMap: () => new Map(),
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    // Pre-fix this was `undefined` — the throw unwound past the record, the
+    // pass looked non-advancing, and the peer was dropped.
+    expect(summary.swmCoverage).toEqual({
+      contextGraphId: T14_CG,
+      peerIdSuffix: '99887766',
+      snapshotsResolved: 2,
+      snapshotsTotal: 3,
+      manifestComplete: true,
+      missingCount: 1,
+      missingSample: ['digest-that-throws'],
+    });
+    // The walk's invariant survives the failure path too.
+    expect(summary.swmCoverage!.snapshotsResolved + summary.swmCoverage!.missingCount)
+      .toBe(summary.swmCoverage!.snapshotsTotal);
+  });
+});

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
-import type { Quad } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { createSharedMemorySnapshotMaterializer } from '../src/sync/requester/swm-snapshot-materializer.js';
+import { swmFixtures } from './swm-descriptor-fixtures.js';
 import {
   runDurableSync,
   runDurableSyncDetailed,
@@ -1718,26 +1720,53 @@ describe('T13 — swmCoverage reduction', () => {
  */
 describe('T14 — a throwing snapshot round still reports what it resolved', () => {
   const T14_CG = 'throwing-swm';
-  const T14_META = `did:dkg:context-graph:${T14_CG}/_shared_memory_meta`;
+  const T14_UAL = 'did:dkg:hardhat:31337/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const { share } = swmFixtures(T14_CG);
 
-  function snapshotRow(subject: string, digest: string, count: number): Quad[] {
-    return [
-      { subject, predicate: 'http://dkg.io/ontology/publicQuadsDigest', object: `"${digest}"`, graph: T14_META } as Quad,
-      { subject, predicate: 'http://dkg.io/ontology/publicQuadsCount', object: `"${count}"`, graph: T14_META } as Quad,
-    ];
-  }
+  const stores: OxigraphStore[] = [];
+  afterEach(async () => {
+    await Promise.all(stores.splice(0).map((store) => store.close().catch(() => {})));
+  });
 
   it('carries the resolved count out through the throw instead of reporting zero', async () => {
-    // Two snapshots cached and resolvable, then one whose fetch blows up.
-    const cachedA = [quad('t14-a')];
-    const cachedB = [quad('t14-b')];
-    const digestA = workspacePublicQuadsDigest(cachedA);
-    const digestB = workspacePublicQuadsDigest(cachedB);
-    const meta = [
-      ...snapshotRow('did:dkg:assertion:a', digestA, cachedA.length),
-      ...snapshotRow('did:dkg:assertion:b', digestB, cachedB.length),
-      ...snapshotRow('did:dkg:assertion:boom', 'digest-that-throws', 4),
-    ];
+    // Two Knowledge Assets whose snapshots are already cached — and therefore
+    // materializable without a fetch — then a third whose fetch blows up.
+    //
+    // The metadata is DESCRIPTOR-shaped, built by the shared fixtures, rather
+    // than the bare `publicQuadsDigest`/`publicQuadsCount` pair this row used
+    // to carry. That is the entire point of the row. Materialization is gated
+    // on `snapshotDescriptorsByRef.size > 0`, which only descriptor-shaped meta
+    // populates — so under the old shape nothing could ever materialize and
+    // `snapshotsResolved` was `0` BY CONSTRUCTION, under a title promising a
+    // non-zero count. The row passed while unable to observe its own property.
+    //
+    // Two opposite properties live on this field and a no-materializer fixture
+    // collapses them to the same number:
+    //   - do not OVER-report: a round that fetches N and materializes 0 must
+    //     not claim `N/N` (covered by the coverage rows in this file);
+    //   - do not UNDER-report: a round that materializes some and then THROWS
+    //     must report what it wrote, not zero — which is what this row pins,
+    //     and the reason the carry-through-the-throw change exists at all.
+    const resolvedA = share({ version: 1, operationId: 'op-a', marker: 't14-a', ual: `${T14_UAL}/1` });
+    const resolvedB = share({ version: 1, operationId: 'op-b', marker: 't14-b', ual: `${T14_UAL}/2`, payloadCount: 3 });
+    const unreachable = share({ version: 1, operationId: 'op-boom', marker: 't14-boom', ual: `${T14_UAL}/3`, payloadCount: 4 });
+    const meta = [...resolvedA.meta, ...resolvedB.meta, ...unreachable.meta];
+
+    // A real store and the real materializer: a hand-rolled stub that silently
+    // fails to materialize would reproduce `resolved: 0` for a NEW reason and
+    // look identical to a pass.
+    const store = new OxigraphStore();
+    stores.push(store);
+    const materializer = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+
+    const cached = new Map<string, Quad[]>([
+      [resolvedA.digest, resolvedA.payload],
+      [resolvedB.digest, resolvedB.payload],
+    ]);
 
     const summary = await runSharedMemorySync({
       ctx,
@@ -1751,6 +1780,8 @@ describe('T14 — a throwing snapshot round still reports what it resolved', () 
         _includeSharedMemory: boolean,
         phase: string,
       ) => {
+        // Only the uncached third ref reaches a fetch; the other two are served
+        // from cache and never touch the transport.
         if (phase === 'snapshot') throw transportError('snapshot stream reset');
         return pageResult(contextGraphId, phase);
       },
@@ -1761,13 +1792,10 @@ describe('T14 — a throwing snapshot round still reports what it resolved', () 
         totalFetchedMetaQuads: meta.length,
       }),
       ensureContextGraph: async () => {},
-      storeInsert: async () => {},
+      storeInsert: async (quads: Quad[]) => { await store.insert(quads); },
+      snapshotMaterializer: materializer,
       publicSnapshotStore: {
-        getSnapshot: async (ref: string) => {
-          if (ref === digestA) return cachedA;
-          if (ref === digestB) return cachedB;
-          return null;
-        },
+        getSnapshot: async (ref: string) => cached.get(ref) ?? null,
         putSnapshot: async () => ({ ref: 'unused', byteLength: 0 }),
       },
       deleteCheckpoint: () => {},
@@ -1778,25 +1806,18 @@ describe('T14 — a throwing snapshot round still reports what it resolved', () 
       logDebug: noop,
     });
 
-    // Pre-fix this was `undefined` — the throw unwound past the record
-    // entirely, so the pass looked non-advancing and the peer was dropped.
-    // Existence of the record, with the peer's real denominator, is what this
-    // row pins.
-    //
-    // `snapshotsResolved` is 0 because this fixture wires no
-    // `snapshotMaterializer`, so nothing is written — and resolved counts
-    // Knowledge Assets MATERIALIZED, not refs fetched. That is deliberate:
-    // counting fetches here is the defect that let an all-cached round whose
-    // writes all failed report maximal coverage and silently end the
-    // continuation.
+    // Pre-fix the whole record was `undefined` — the throw unwound past it, so
+    // the pass looked non-advancing and the peer was dropped. What this row now
+    // pins is stronger: the record survives the throw carrying the count of
+    // Knowledge Assets actually MATERIALIZED (2), not refs fetched and not zero.
     expect(summary.swmCoverage).toEqual({
       contextGraphId: T14_CG,
       peerIdSuffix: '99887766',
-      snapshotsResolved: 0,
+      snapshotsResolved: 2,
       snapshotsTotal: 3,
       manifestComplete: true,
-      missingCount: 3,
-      missingSample: ['digest-that-throws'],
+      missingCount: 1,
+      missingSample: [unreachable.digest],
       materializationFailures: 0,
     });
   });

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1596,7 +1596,9 @@ describe('public SWM snapshot coverage (#2050)', () => {
       snapshotsTotal: 2,
       manifestComplete: true,
       missingCount: 1,
-      missingSample: [],
+      // The ref that was never served, named — not an empty placeholder. The
+      // sample and the count come from the same walk, so they cannot disagree.
+      missingSample: ['digest-never-served'],
     });
   });
 });

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1592,10 +1592,10 @@ describe('public SWM snapshot coverage (#2050)', () => {
     expect(summary.swmCoverage).toEqual({
       contextGraphId: COVERAGE_CG,
       peerIdSuffix: 'abcd1234',
-      snapshotsResolved: 1,
+      snapshotsResolved: 0,
       snapshotsTotal: 2,
       manifestComplete: true,
-      missingCount: 1,
+      missingCount: 2,
       // The ref that was never served, named — not an empty placeholder. The
       // sample and the count come from the same walk, so they cannot disagree.
       missingSample: ['digest-never-served'],
@@ -1778,20 +1778,33 @@ describe('T14 — a throwing snapshot round still reports what it resolved', () 
       logDebug: noop,
     });
 
-    // Pre-fix this was `undefined` — the throw unwound past the record, the
-    // pass looked non-advancing, and the peer was dropped.
+    // Pre-fix this was `undefined` — the throw unwound past the record
+    // entirely, so the pass looked non-advancing and the peer was dropped.
+    // Existence of the record, with the peer's real denominator, is what this
+    // row pins.
+    //
+    // `snapshotsResolved` is 0 because this fixture wires no
+    // `snapshotMaterializer`, so nothing is written — and resolved counts
+    // Knowledge Assets MATERIALIZED, not refs fetched. That is deliberate:
+    // counting fetches here is the defect that let an all-cached round whose
+    // writes all failed report maximal coverage and silently end the
+    // continuation.
     expect(summary.swmCoverage).toEqual({
       contextGraphId: T14_CG,
       peerIdSuffix: '99887766',
-      snapshotsResolved: 2,
+      snapshotsResolved: 0,
       snapshotsTotal: 3,
       manifestComplete: true,
-      missingCount: 1,
+      missingCount: 3,
       missingSample: ['digest-that-throws'],
       materializationFailures: 0,
     });
-    // The walk's invariant survives the failure path too.
-    expect(summary.swmCoverage!.snapshotsResolved + summary.swmCoverage!.missingCount)
-      .toBe(summary.swmCoverage!.snapshotsTotal);
   });
+
+  // The `resolved + missing === total` invariant is deliberately NOT asserted
+  // here. `recordSnapshotCoverage` derives `missingCount` as
+  // `totalSnapshots - snapshotsResolved`, so the invariant holds by
+  // construction and any test of it restates numbers the deep-equal above
+  // already pinned. An assertion that cannot fail is worse than none: it reads
+  // as coverage of a property nothing is checking.
 });

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -10,8 +10,13 @@ import {
   type DurableSyncStoreInsertRequest,
 } from '../src/sync/requester/durable-sync.js';
 import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
-import { workspacePublicQuadsDigest } from '@origintrail-official/dkg-publisher';
-import { runSharedMemorySync, selectSwmSnapshotCoverage } from '../src/sync/requester/shared-memory-sync.js';
+import { generateShareMetadata, workspacePublicQuadsDigest } from '@origintrail-official/dkg-publisher';
+import { parseGraphScopedSwmRecoveryDescriptors } from '../src/sync/graph-scoped-swm-recovery.js';
+import {
+  collectPublicSnapshotMetadata,
+  runSharedMemorySync,
+  selectSwmSnapshotCoverage,
+} from '../src/sync/requester/shared-memory-sync.js';
 import type { SwmSnapshotCoverage } from '../src/dkg-agent-types.js';
 import {
   SyncPageAccumulationLimitError,
@@ -1624,12 +1629,17 @@ describe('public SWM snapshot coverage (#2050)', () => {
     // passes could ever clear it.
     //
     // THE MANIFEST MUST BE MIXED, and that is the whole difficulty of this
-    // fixture. `onSnapshotReady` is wired only when `snapshotDescriptorsByRef`
-    // is non-empty, so a manifest in which NO ref has a descriptor never calls
+    // fixture. `onSnapshotReady` USED TO BE wired only when
+    // `snapshotDescriptorsByRef` was non-empty, so on the pre-fix tree a
+    // manifest in which NO ref had a descriptor never called
     // `materializeReadySnapshot` at all: it would report `0/N` for a reason
     // that has nothing to do with the code under test, and would read green
     // both with the fix and without it. At least one described ref is what
-    // opens the hook the undescribed ref then has to travel through.
+    // opened the hook the undescribed ref then had to travel through — which is
+    // why THIS row, and not an all-undescribed one, is the row that fails on
+    // the pre-fix tree. The hook is now wired unconditionally, and the
+    // all-undescribed manifest that guard hid — the entity-share shape, which
+    // is most Context Graphs — is pinned by the row below.
     //
     // The two halves are the real production shape rather than two invented
     // rows: ONE Knowledge Asset shared TWICE. `replaceHeadMetadata` is
@@ -1753,6 +1763,192 @@ describe('public SWM snapshot coverage (#2050)', () => {
         peerIdSuffix: '5a5a5a5a',
         snapshotsResolved: 2,
         snapshotsTotal: 2,
+        manifestComplete: true,
+        missingCount: 0,
+        missingSample: [],
+        materializationFailures: 0,
+      });
+    } finally {
+      await store.close().catch(() => {});
+    }
+  });
+
+  it('counts a complete manifest with NO descriptor on ANY ref as resolved, so an entity-share Context Graph stops nominating its peer', async () => {
+    // The row above has to build a MIXED manifest — one described ref, one
+    // undescribed — because the old `snapshotDescriptorsByRef.size > 0` guard
+    // wired `onSnapshotReady` only when SOMETHING was described. That guard hid
+    // the larger case: a Context Graph in which NOTHING is described.
+    //
+    // That case is not a corner, it is the primary shared-memory write API.
+    // `storeWorkspaceOperationPublicQuads` (packages/publisher/src/
+    // workspace-resolution.ts) — the entity-level share — writes each root's
+    // public slice under a `urn:dkg:public-stage:<cg>:<subGraph>:<op>:<root>`
+    // subject carrying `dkg:publicQuadsDigest` + `dkg:publicQuadsCount`, and
+    // writes NO `#dkg-swm-head` row at all; heads belong to the graph-scoped KA
+    // path (`storeKnowledgeAssetOperationPublicQuads`). The two readers then
+    // disagree about the very same metadata: `collectPublicSnapshotMetadata`
+    // accepts ANY subject with digest+count, so the slice IS a manifest ref,
+    // while `parseGraphScopedSwmRecoveryDescriptors` anchors ONLY on head
+    // subjects, so it yields nothing. A Context Graph written entirely by
+    // entity shares therefore advertises refs and produces zero descriptors —
+    // for EVERY ref, not just one.
+    //
+    // Pre-fix such a graph could not reach `snapshotsResolved ===
+    // snapshotsTotal` by ANY path: the hook was never wired, so
+    // `materializeReadySnapshot` — and with it the vacuity branch the row above
+    // pins — never ran. `snapshotsResolved < snapshotsTotal` is exactly the
+    // predicate `capablePeersForNextPass` (packages/cli/src/
+    // catchup-runner-worker-impl.ts) reads as "this peer still owes us
+    // Knowledge Assets", so it nominated a peer that owed nothing on every pass
+    // of every catch-up job, at O(KA size) per cached ref, for ever.
+    //
+    // BOTH writers are wired here, and that is the whole difference from
+    // 'carries the round coverage onto the summary when the snapshot phase does
+    // not finish' above, which asserts `0/2` with NO materializer. The two must
+    // stay distinct: missing WIRING means nothing CAN be written, so those refs
+    // are unresolved; no DESCRIPTOR under a COMPLETE manifest means there is
+    // nothing to write, so these are resolved. Wiring the hook unconditionally
+    // must not collapse that.
+    //
+    // The meta graph comes from `swmFixtures(COVERAGE_CG)` — the same builder
+    // whose rows parse into REAL descriptors in the row above — so the empty
+    // descriptor list asserted below is attributable to the subject shape
+    // alone, not to a meta-graph URI the parser refuses to visit.
+    const { metaGraph } = swmFixtures(COVERAGE_CG);
+    const SHARE_OP = 'op-entity-share-1';
+    const ROOT = 'https://example.org/thing/1';
+    // One root's public slice, as `filterQuadsForRoot` hands it to
+    // `putSnapshot`. Digest and count are taken FROM this payload because
+    // `hasValidSnapshot` re-checks both against the cached blob: a hand-written
+    // count would turn a cache hit into a network fetch and quietly move the
+    // row onto a different branch of the walk.
+    const payload: Quad[] = [
+      { subject: ROOT, predicate: 'https://schema.org/name', object: '"Thing One"', graph: '' } as Quad,
+      { subject: ROOT, predicate: 'https://schema.org/color', object: '"blue"', graph: '' } as Quad,
+    ];
+    const digest = workspacePublicQuadsDigest(payload);
+    const sliceSubject = `urn:dkg:public-stage:${[COVERAGE_CG, '_', SHARE_OP, ROOT].map(encodeURIComponent).join(':')}`;
+    const meta: Quad[] = [
+      // Production-generated, not invented: these are the share-operation rows
+      // an entity share writes alongside the slice. They contribute neither a
+      // manifest ref (no digest/count) nor a descriptor (no head names this
+      // operation), which is what leaves the slice row as the only thing under
+      // test while keeping the fixture the shape a real peer would serve.
+      ...generateShareMetadata({
+        shareOperationId: SHARE_OP,
+        contextGraphId: COVERAGE_CG,
+        rootEntities: [ROOT],
+        publisherPeerId: 'peer-source',
+        timestamp: new Date(0),
+      }, metaGraph),
+      // The slice rows themselves, in `storeWorkspaceOperationPublicQuads`
+      // order. Deliberately NO `dkg:publicSnapshotGraph` row: with a snapshot
+      // store configured the blob is keyed by its digest and `ref === digest`,
+      // and that absence is precisely what makes this row a snapshot-FETCH
+      // target instead of a graph-sync one. `publicQuadsCount` keeps its
+      // `xsd:integer` type because that is how production writes it.
+      { subject: sliceSubject, predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${COVERAGE_CG}"`, graph: metaGraph } as Quad,
+      { subject: sliceSubject, predicate: 'http://dkg.io/ontology/shareOperationId', object: `"${SHARE_OP}"`, graph: metaGraph } as Quad,
+      { subject: sliceSubject, predicate: 'http://dkg.io/ontology/publicSliceRootEntity', object: ROOT, graph: metaGraph } as Quad,
+      { subject: sliceSubject, predicate: 'http://dkg.io/ontology/publicQuadsDigest', object: `"${digest}"`, graph: metaGraph } as Quad,
+      {
+        subject: sliceSubject,
+        predicate: 'http://dkg.io/ontology/publicQuadsCount',
+        object: `"${payload.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+        graph: metaGraph,
+      } as Quad,
+      { subject: sliceSubject, predicate: 'http://dkg.io/ontology/publisherPeerId', object: '"peer-source"', graph: metaGraph } as Quad,
+      { subject: sliceSubject, predicate: 'http://dkg.io/ontology/publishedAt', object: `"${new Date(0).toISOString()}"`, graph: metaGraph } as Quad,
+    ];
+
+    // Fixture integrity across BOTH readers, asserted before the sync so a
+    // fixture that drifted names itself instead of surfacing as an unexplained
+    // count. The manifest must really carry this one ref (or `snapshotsTotal:
+    // 1` below would be measuring something else), and NOTHING may be
+    // described (or this row would silently become a second copy of the mixed
+    // row above, travelling the described path it is meant to avoid).
+    expect(collectPublicSnapshotMetadata(meta)).toEqual([{ ref: digest, digest, count: payload.length }]);
+    expect(parseGraphScopedSwmRecoveryDescriptors({ contextGraphId: COVERAGE_CG, metaQuads: meta })).toEqual([]);
+
+    // The blob is already cached: the state of a node whose earlier pass
+    // fetched it. Nothing here is missing — the peer owes this node nothing.
+    const cached = new Map<string, Quad[]>([[digest, payload]]);
+    const snapshotFetches: string[] = [];
+
+    // A real store and the real materializer, as the rows above use them: with
+    // a hand-rolled stub, "nothing was written" would be unfalsifiable, and the
+    // `insertedDataTriples` witness below could not distinguish a vacuous
+    // resolution from a materializer that silently does nothing.
+    const store = new OxigraphStore();
+    const materializer = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx,
+        remotePeerId: 'peer-entity-share-1a2b3c4d',
+        contextGraphIds: [COVERAGE_CG],
+        createContextGraphSyncDeadline: () => Date.now() + 60_000,
+        fetchSyncPages: async (
+          _ctx: OperationContext,
+          _peer: string,
+          contextGraphId: string,
+          _includeSharedMemory: boolean,
+          phase: string,
+          _graph: string,
+          _deadline: number,
+          snapshotRef?: string,
+        ) => {
+          if (phase === 'snapshot') snapshotFetches.push(String(snapshotRef));
+          // Every phase completes cleanly, so `manifestComplete` is true — the
+          // other half of the vacuity gate. A truncated meta phase parses no
+          // descriptors either, and there "no descriptor" means "not known
+          // yet"; that boundary is a separate row and is not smuggled in here.
+          return pageResult(contextGraphId, phase);
+        },
+        processSharedMemoryBatch: async () => ({
+          ...sharedMemoryProcessResult(),
+          emptyResponses: 0,
+          verifiedMeta: meta,
+          totalFetchedMetaQuads: meta.length,
+        }),
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads: Quad[]) => { await store.insert(quads); },
+        snapshotMaterializer: materializer,
+        publicSnapshotStore: {
+          getSnapshot: async (ref: string) => cached.get(ref) ?? null,
+          putSnapshot: async () => ({ ref: 'unused', byteLength: 0 }),
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map(),
+        logInfo: noop,
+        logWarn: noop,
+        logDebug: noop,
+      });
+
+      // Pre-cached, so the ref must not touch the transport; a digest that
+      // stopped matching the payload would turn this into a fetch.
+      expect(snapshotFetches).toEqual([]);
+      expect(summary.failedPhases).toBe(0);
+      // The vacuity witness, and what separates this row from the mixed one
+      // above, where the described half genuinely writes: here there is nothing
+      // to write, so nothing IS written. The ref is resolved because a complete
+      // manifest does not describe it — not because a materializer ran.
+      expect(summary.insertedDataTriples).toBe(0);
+      // Pre-fix: `0/1`, `missingCount: 1`, permanently — for a peer this node
+      // was fully synced with, and for EVERY Context Graph written by entity
+      // shares. `snapshotsResolved === snapshotsTotal` is what makes
+      // `capablePeersForNextPass`'s `resolved < total` false and finally stops
+      // the nomination.
+      expect(summary.swmCoverage).toEqual({
+        contextGraphId: COVERAGE_CG,
+        peerIdSuffix: '1a2b3c4d',
+        snapshotsResolved: 1,
+        snapshotsTotal: 1,
         manifestComplete: true,
         missingCount: 0,
         missingSample: [],

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1608,6 +1608,160 @@ describe('public SWM snapshot coverage (#2050)', () => {
       materializationFailures: 0,
     });
   });
+
+  it('counts a complete manifest ref with NO descriptor as resolved, so a fully synced peer stops being capable', async () => {
+    // The defect behind this row is NON-TERMINATION, not a cosmetically wrong
+    // number. `snapshotsTotal` counts refs in the PEER'S MANIFEST
+    // (`collectPublicSnapshotMetadata` over the round's verified meta);
+    // `snapshotsResolved` counts refs this node MATERIALIZED. A manifest ref
+    // that the round's verified metadata does not DESCRIBE has no descriptor,
+    // so it could never enter `materializedRefs` — and `snapshotsResolved <
+    // snapshotsTotal` is exactly the predicate `capablePeersForNextPass`
+    // (packages/cli/src/catchup-runner-worker-impl.ts) uses to decide a peer
+    // still owes us Knowledge Assets. It therefore held FOREVER: every later
+    // catch-up job spent its whole pass budget re-walking a Context Graph that
+    // was already complete, at O(KA size) per cached ref, and no number of
+    // passes could ever clear it.
+    //
+    // THE MANIFEST MUST BE MIXED, and that is the whole difficulty of this
+    // fixture. `onSnapshotReady` is wired only when `snapshotDescriptorsByRef`
+    // is non-empty, so a manifest in which NO ref has a descriptor never calls
+    // `materializeReadySnapshot` at all: it would report `0/N` for a reason
+    // that has nothing to do with the code under test, and would read green
+    // both with the fix and without it. At least one described ref is what
+    // opens the hook the undescribed ref then has to travel through.
+    //
+    // The two halves are the real production shape rather than two invented
+    // rows: ONE Knowledge Asset shared TWICE. `replaceHeadMetadata` is
+    // head-subject scoped, so a peer that re-shares a KA keeps the SUPERSEDED
+    // share-operation row in its metadata graph while its head names the
+    // current operation. `parseGraphScopedSwmRecoveryDescriptors` only visits
+    // operation subjects a head names, so the superseded row yields no
+    // descriptor — while still carrying `publicQuadsDigest`/`publicQuadsCount`,
+    // which is all `collectPublicSnapshotMetadata` needs to put it in the
+    // manifest. That asymmetry between the two readers IS the bug.
+    //
+    // Only the CURRENT share's head rows are kept. Both versions share one head
+    // subject (`<ual>#dkg-swm-head`), so including both would merge their rows
+    // and `requirePositiveInteger(assertionVersion)` would throw; the surrounding
+    // catch clears ALL descriptors and materialization is silently disabled for
+    // the whole Context Graph — the fixture would stop testing rather than fail.
+    //
+    // Both halves come from ONE `swmFixtures(COVERAGE_CG)` call, so every
+    // metadata-graph URI agrees with the Context Graph under sync by
+    // construction instead of by a hand-matched constant.
+    //
+    // What this row does NOT pin: the `manifestComplete` half of the gate. A
+    // truncated meta phase parses no descriptors at all, so "no descriptor"
+    // there means "not known yet" and must NOT count — that boundary needs its
+    // own row and is deliberately not smuggled into this one.
+    const { share } = swmFixtures(COVERAGE_CG);
+    const RESHARED_UAL = 'did:dkg:hardhat:31337/0xcccccccccccccccccccccccccccccccccccccccc/1';
+    const superseded = share({
+      version: 1, operationId: 'op-superseded', marker: 'superseded', ual: RESHARED_UAL, payloadCount: 2,
+    });
+    const current = share({
+      version: 2, operationId: 'op-current', marker: 'current', ual: RESHARED_UAL, payloadCount: 3,
+    });
+    const meta = [
+      ...current.meta,
+      ...superseded.meta.filter((quadRow) => quadRow.subject === superseded.operationSubject),
+    ];
+
+    // Both snapshots already cached: this is the state of a node whose earlier
+    // passes did the work. Distinct payload sizes give distinct digests, so the
+    // manifest really carries two refs (see the `snapshotsTotal` note below).
+    const cached = new Map<string, Quad[]>([
+      [current.digest, current.payload],
+      [superseded.digest, superseded.payload],
+    ]);
+    const snapshotFetches: string[] = [];
+
+    // A real store and the real materializer, for the same reason T14 uses
+    // them: a hand-rolled stub that silently fails to materialize reproduces a
+    // shortfall for a NEW reason and looks identical to the defect under test.
+    const store = new OxigraphStore();
+    const materializer = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx,
+        remotePeerId: 'peer-resharing-5a5a5a5a',
+        contextGraphIds: [COVERAGE_CG],
+        createContextGraphSyncDeadline: () => Date.now() + 60_000,
+        fetchSyncPages: async (
+          _ctx: OperationContext,
+          _peer: string,
+          contextGraphId: string,
+          _includeSharedMemory: boolean,
+          phase: string,
+          _graph: string,
+          _deadline: number,
+          snapshotRef?: string,
+        ) => {
+          if (phase === 'snapshot') snapshotFetches.push(String(snapshotRef));
+          return pageResult(contextGraphId, phase);
+        },
+        processSharedMemoryBatch: async () => ({
+          ...sharedMemoryProcessResult(),
+          emptyResponses: 0,
+          verifiedMeta: meta,
+          totalFetchedMetaQuads: meta.length,
+        }),
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads: Quad[]) => { await store.insert(quads); },
+        snapshotMaterializer: materializer,
+        publicSnapshotStore: {
+          getSnapshot: async (ref: string) => cached.get(ref) ?? null,
+          putSnapshot: async () => ({ ref: 'unused', byteLength: 0 }),
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map(),
+        logInfo: noop,
+        logWarn: noop,
+        logDebug: noop,
+      });
+
+      // Fixture integrity first, so a broken fixture names itself instead of
+      // surfacing as an unexplained count: both refs are pre-cached, so neither
+      // may touch the transport. A digest that stopped matching would turn a
+      // cache hit into a fetch and quietly change what the row measures.
+      expect(snapshotFetches).toEqual([]);
+      // The DESCRIBED half genuinely WROTE — which is what makes this manifest
+      // mixed rather than two vacuous resolutions. If the described half ever
+      // stopped materializing (a fixture the parser silently rejects, a
+      // `replaceGraph` that no-ops, wiring that drops the materializer), the
+      // coverage record could still read `2/2` by counting two undescribed refs
+      // while nothing at all was written; the counters alone cannot see that.
+      // `verifiedData` is empty here, so in-lock materialization is the only
+      // possible source of data triples.
+      expect(summary.insertedDataTriples).toBeGreaterThanOrEqual(current.payload.length);
+      expect(summary.failedPhases).toBe(0);
+      // Pre-fix this record was `1/2` with `missingCount: 1` — a peer that owed
+      // this node nothing, reported as still owing it one Knowledge Asset, on
+      // every pass forever. `snapshotsTotal: 2` doubles as the anti-vacuity
+      // guard: if the two payloads ever collided on a digest, `byRef` would fold
+      // them into a single ref and the manifest would stop being mixed while the
+      // row went on passing.
+      expect(summary.swmCoverage).toEqual({
+        contextGraphId: COVERAGE_CG,
+        peerIdSuffix: '5a5a5a5a',
+        snapshotsResolved: 2,
+        snapshotsTotal: 2,
+        manifestComplete: true,
+        missingCount: 0,
+        missingSample: [],
+        materializationFailures: 0,
+      });
+    } finally {
+      await store.close().catch(() => {});
+    }
+  });
 });
 
 /**

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1599,6 +1599,8 @@ describe('public SWM snapshot coverage (#2050)', () => {
       // The ref that was never served, named — not an empty placeholder. The
       // sample and the count come from the same walk, so they cannot disagree.
       missingSample: ['digest-never-served'],
+      // Fetch shortfall only — every ref that DID arrive was written.
+      materializationFailures: 0,
     });
   });
 });
@@ -1786,6 +1788,7 @@ describe('T14 — a throwing snapshot round still reports what it resolved', () 
       manifestComplete: true,
       missingCount: 1,
       missingSample: ['digest-that-throws'],
+      materializationFailures: 0,
     });
     // The walk's invariant survives the failure path too.
     expect(summary.swmCoverage!.snapshotsResolved + summary.swmCoverage!.missingCount)

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1467,6 +1467,7 @@ describe('public SWM snapshot coverage (#2050)', () => {
     manifestComplete: true,
     missingCount: 72,
     missingSample: ['did:dkg:ka:from-the-large-manifest'],
+    materializationFailures: 0,
   };
   const completeSmaller: SwmSnapshotCoverage = {
     contextGraphId: COVERAGE_CG,
@@ -1476,6 +1477,7 @@ describe('public SWM snapshot coverage (#2050)', () => {
     manifestComplete: true,
     missingCount: 0,
     missingSample: [],
+    materializationFailures: 0,
   };
 
   it('reports the shortfall against the largest manifest, not the best fraction', () => {
@@ -1521,6 +1523,7 @@ describe('public SWM snapshot coverage (#2050)', () => {
       manifestComplete: false,
       missingCount: 291,
       missingSample: [],
+      materializationFailures: 0,
     };
 
     expect(selectSwmSnapshotCoverage(truncatedButLarger, partialOfLarge)).toEqual(partialOfLarge);

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -8,7 +8,9 @@ import {
   type DurableSyncStoreInsertRequest,
 } from '../src/sync/requester/durable-sync.js';
 import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
-import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
+import { workspacePublicQuadsDigest } from '@origintrail-official/dkg-publisher';
+import { runSharedMemorySync, selectSwmSnapshotCoverage } from '../src/sync/requester/shared-memory-sync.js';
+import type { SwmSnapshotCoverage } from '../src/dkg-agent-types.js';
 import {
   SyncPageAccumulationLimitError,
   type SyncPageResult,
@@ -1429,5 +1431,172 @@ describe('exact durable fetch disposition', () => {
     }).not.toThrow();
     await expect(publicResult).rejects.toThrow();
     await expect(detailedResult).rejects.toThrow();
+  });
+});
+
+describe('public SWM snapshot coverage (#2050)', () => {
+  const COVERAGE_CG = 'coverage-swm';
+  const META_GRAPH = `did:dkg:context-graph:${COVERAGE_CG}/_shared_memory_meta`;
+
+  function snapshotMeta(subject: string, digest: string, count: number): Quad[] {
+    return [
+      {
+        subject,
+        predicate: 'http://dkg.io/ontology/publicQuadsDigest',
+        object: `"${digest}"`,
+        graph: META_GRAPH,
+      } as Quad,
+      {
+        subject,
+        predicate: 'http://dkg.io/ontology/publicQuadsCount',
+        object: `"${count}"`,
+        graph: META_GRAPH,
+      } as Quad,
+    ];
+  }
+
+  // The external review's M2 case, verbatim: independent maxima over ready and
+  // total turn these two peers into `200/250` — a graph state neither reported.
+  const partialOfLarge: SwmSnapshotCoverage = {
+    contextGraphId: COVERAGE_CG,
+    peerIdSuffix: 'aaaa1111',
+    snapshotsResolved: 178,
+    snapshotsTotal: 250,
+    manifestComplete: true,
+    missingCount: 72,
+    missingSample: ['did:dkg:ka:from-the-large-manifest'],
+  };
+  const completeSmaller: SwmSnapshotCoverage = {
+    contextGraphId: COVERAGE_CG,
+    peerIdSuffix: 'bbbb2222',
+    snapshotsResolved: 200,
+    snapshotsTotal: 200,
+    manifestComplete: true,
+    missingCount: 0,
+    missingSample: [],
+  };
+
+  it('reports the shortfall against the largest manifest, not the best fraction', () => {
+    const bothOrders = [
+      selectSwmSnapshotCoverage(partialOfLarge, completeSmaller),
+      selectSwmSnapshotCoverage(completeSmaller, partialOfLarge),
+    ];
+
+    for (const selected of bothOrders) {
+      // Whole record from ONE peer: reducing numerator and denominator
+      // independently would give 200/250, which equals neither input and
+      // carries a sample from neither manifest.
+      expect([partialOfLarge, completeSmaller]).toContainEqual(selected);
+      expect(selected).not.toMatchObject({ snapshotsResolved: 200, snapshotsTotal: 250 });
+      // And the winner must be the peer that knows the graph is 250 KAs, not
+      // the one whose smaller view is fully resolved. Picking `200/200` would
+      // report "0 outstanding" on a job that is 72 short — self-consistent,
+      // undetectable downstream, and worse than the synthetic pair above.
+      expect(selected).toEqual(partialOfLarge);
+      expect(selected?.missingCount).toBe(72);
+    }
+    expect(bothOrders[0]).toEqual(bothOrders[1]);
+  });
+
+  it('prefers authority evidence even when another peer knows a larger manifest', () => {
+    // Deliberately the record that LOSES on every later rule: smaller total,
+    // fewer outstanding. Only the authority rule can select it, so this fails
+    // if authority stops sorting first.
+    const authoritySmaller: SwmSnapshotCoverage = { ...completeSmaller, fromAuthority: true };
+
+    expect(selectSwmSnapshotCoverage(authoritySmaller, partialOfLarge)).toEqual(authoritySmaller);
+    expect(selectSwmSnapshotCoverage(partialOfLarge, authoritySmaller)).toEqual(authoritySmaller);
+  });
+
+  it('prefers a complete manifest, whose denominator is not merely a lower bound', () => {
+    // Larger total than `partialOfLarge`, so the largest-manifest rule alone
+    // would select it; only `manifestComplete` rejects it.
+    const truncatedButLarger: SwmSnapshotCoverage = {
+      contextGraphId: COVERAGE_CG,
+      peerIdSuffix: 'cccc3333',
+      snapshotsResolved: 9,
+      snapshotsTotal: 300,
+      manifestComplete: false,
+      missingCount: 291,
+      missingSample: [],
+    };
+
+    expect(selectSwmSnapshotCoverage(truncatedButLarger, partialOfLarge)).toEqual(partialOfLarge);
+    expect(selectSwmSnapshotCoverage(partialOfLarge, truncatedButLarger)).toEqual(partialOfLarge);
+  });
+
+  it('prefers the most resolved when two peers report the same manifest size', () => {
+    const behind: SwmSnapshotCoverage = {
+      ...partialOfLarge,
+      peerIdSuffix: 'dddd4444',
+      snapshotsResolved: 12,
+      missingCount: 238,
+    };
+
+    expect(selectSwmSnapshotCoverage(behind, partialOfLarge)).toEqual(partialOfLarge);
+    expect(selectSwmSnapshotCoverage(partialOfLarge, behind)).toEqual(partialOfLarge);
+  });
+
+  it('breaks a genuine tie deterministically on the peer id', () => {
+    const later: SwmSnapshotCoverage = { ...partialOfLarge, peerIdSuffix: 'zzzz9999' };
+
+    expect(selectSwmSnapshotCoverage(partialOfLarge, later)).toEqual(partialOfLarge);
+    expect(selectSwmSnapshotCoverage(later, partialOfLarge)).toEqual(partialOfLarge);
+  });
+
+  it('carries the round coverage onto the summary when the snapshot phase does not finish', async () => {
+    const cachedQuads = [quad('cached-snapshot-row')];
+    const cachedDigest = workspacePublicQuadsDigest(cachedQuads);
+    const meta = [
+      ...snapshotMeta('did:dkg:assertion:cached', cachedDigest, cachedQuads.length),
+      ...snapshotMeta('did:dkg:assertion:unreachable', 'digest-never-served', 5),
+    ];
+
+    const summary = await runSharedMemorySync({
+      ctx,
+      remotePeerId: 'peer-coverage-abcd1234',
+      contextGraphIds: [COVERAGE_CG],
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx: OperationContext,
+        _peer: string,
+        contextGraphId: string,
+        _includeSharedMemory: boolean,
+        phase: string,
+      ) => (phase === 'snapshot'
+        ? pageResult(contextGraphId, phase, { completed: false, timedOut: true })
+        : pageResult(contextGraphId, phase)),
+      processSharedMemoryBatch: async () => ({
+        ...sharedMemoryProcessResult(),
+        emptyResponses: 0,
+        verifiedMeta: meta,
+        totalFetchedMetaQuads: meta.length,
+      }),
+      ensureContextGraph: async () => {},
+      storeInsert: async () => {},
+      publicSnapshotStore: {
+        getSnapshot: async (ref: string) => (ref === cachedDigest ? cachedQuads : null),
+        putSnapshot: async () => ({ ref: 'unused', byteLength: 0 }),
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      ensureOwnedMap: () => new Map(),
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    // One cached snapshot resolved, one never served, and the manifest itself
+    // paged cleanly — so the shortfall is real rather than an artefact of a
+    // truncated denominator.
+    expect(summary.swmCoverage).toEqual({
+      contextGraphId: COVERAGE_CG,
+      peerIdSuffix: 'abcd1234',
+      snapshotsResolved: 1,
+      snapshotsTotal: 2,
+      manifestComplete: true,
+      missingCount: 1,
+      missingSample: [],
+    });
   });
 });

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import { createSharedMemorySnapshotMaterializer } from '../src/sync/requester/swm-snapshot-materializer.js';
+import {
+  createSharedMemorySnapshotMaterializer,
+  type SharedMemorySnapshotMaterializer,
+} from '../src/sync/requester/swm-snapshot-materializer.js';
 import { swmFixtures } from './swm-descriptor-fixtures.js';
 import {
   runDurableSync,
@@ -1954,6 +1957,220 @@ describe('public SWM snapshot coverage (#2050)', () => {
         missingSample: [],
         materializationFailures: 0,
       });
+    } finally {
+      await store.close().catch(() => {});
+    }
+  });
+
+  it('does NOT resolve a manifest ref when the descriptors failed to PARSE, so a round that wrote nothing cannot report full coverage', async () => {
+    // THE THIRD STATE, and the one neither row above can see. Both of them
+    // reach the vacuity branch of `materializeReadySnapshot` with an EMPTY
+    // descriptor map under a COMPLETE manifest, and both are right to count the
+    // ref resolved: nothing was described because there was nothing to
+    // describe. A parse FAILURE lands on the same branch with the same two
+    // observables — and there "no descriptor" means the round never learned
+    // what it was supposed to write.
+    //
+    // `manifestComplete` cannot discriminate, and that is the whole defect.
+    // `parseGraphScopedSwmRecoveryDescriptors` is called inside a block whose
+    // entry condition is `wsMetaResult.completed` — the same value that becomes
+    // `manifestComplete` — so on the failure path it is guaranteed TRUE exactly
+    // where the map is guaranteed empty for the wrong reason. With the hook now
+    // wired unconditionally (see the row above, which is what opened this path
+    // to every ref), the consequences compounded: every manifest ref took the
+    // vacuity branch, a round that wrote ZERO Knowledge Assets reported FULL
+    // coverage, `materializationFailures` stayed 0 because nothing was ever
+    // ATTEMPTED, `snapshotPhaseUsable` therefore read true, the bulk
+    // `storeInsert(processed.verifiedMeta)` landed head rows certifying
+    // assertion graphs that hold nothing, the peer was dropped as satisfied,
+    // and the next round's `isGraphAssetMaterialized` sees those markers and
+    // skips the Knowledge Assets for good. Every one of those is wrong in the
+    // FLATTERING direction, which is the direction no downstream reader can
+    // detect — the operator is told the graph is complete.
+    //
+    // THE POISON IS PRODUCTION-REACHABLE, which is why it is this shape and not
+    // an invented malformed row. Two `dkg:assertionVersion` rows on one
+    // `#dkg-swm-head` subject is union-insert residue: what a pass that
+    // replaced a graph and stopped before the metadata swap leaves behind. This
+    // branch's own materializer names and REPAIRS that state
+    // (`storedHead.needsRepair`), so it demonstrably occurs — and any peer
+    // still running the pre-repair code serves it to us verbatim. (A head at a
+    // `contentScopeVersion` above `GRAPH_KA_CONTENT_SCOPE_VERSION`, written by
+    // a newer node, is the other reachable trigger for the same catch and
+    // produces these same numbers by the same path.)
+    //
+    // The residue sits on the SECOND Knowledge Asset deliberately. The first
+    // one's rows are impeccable and it is STILL not written, because the parser
+    // builds its whole array before returning: one malformed head discards the
+    // descriptors of every valid KA alongside it. On the first KA the counters
+    // would come out identical while pinning none of that.
+    const { manifest, metaGraph } = swmFixtures(COVERAGE_CG);
+    const [validKa, residueKa] = manifest(2);
+    const meta: Quad[] = [
+      ...validKa.meta,
+      ...residueKa.meta,
+      {
+        subject: residueKa.headSubject,
+        predicate: 'http://dkg.io/ontology/assertionVersion',
+        object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: metaGraph,
+      } as Quad,
+    ];
+
+    // Fixture integrity BY MESSAGE and before the sync, because every counter
+    // below is `0` and a fixture that started throwing for an unrelated reason
+    // (a meta-graph URI the parser refuses to visit, a drifted operation
+    // subject) would reproduce all of them while testing nothing — the "a wrong
+    // fixture stops testing rather than failing" trap `swm-descriptor-fixtures`
+    // documents. Called the way production calls it: no `registeredSubGraphNames`,
+    // since both Knowledge Assets are root-lane.
+    expect(() => parseGraphScopedSwmRecoveryDescriptors({
+      contextGraphId: COVERAGE_CG,
+      metaQuads: meta,
+    })).toThrow(/ambiguous assertionVersion/);
+    // ...and the manifest really carries TWO refs, so `snapshotsTotal: 2` below
+    // is measuring what it claims. `manifest()` gives the two KAs different
+    // payload sizes precisely so their digests cannot collide; a collision
+    // would fold them into one ref and `snapshotsResolved: 0` would go on
+    // passing against a one-ref manifest.
+    expect(collectPublicSnapshotMetadata(meta).map((entry) => entry.ref).sort())
+      .toEqual([validKa.digest, residueKa.digest].sort());
+
+    // Both blobs already cached — the state of a node whose earlier passes
+    // fetched them. Nothing here is missing from the TRANSPORT's point of view,
+    // so the shortfall asserted below can only come from the parse failure.
+    const cached = new Map<string, Quad[]>([
+      [validKa.digest, validKa.payload],
+      [residueKa.digest, residueKa.payload],
+    ]);
+    const snapshotFetches: string[] = [];
+
+    // The real materializer over a real store, as the rows above use it — a
+    // hand-rolled stub that silently writes nothing would reproduce
+    // `resolved: 0` for a NEW reason and look identical to a pass. Wrapped in
+    // an explicitly delegating counter rather than a spread: `withKaWriteLock`
+    // is the gate everything else runs behind, and a wrapper that broke it
+    // would make "nothing was written" true for the wrong reason.
+    const store = new OxigraphStore();
+    const real = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+    const replacedGraphs: string[] = [];
+    const materializer: SharedMemorySnapshotMaterializer = {
+      withKaWriteLock: (contextGraphId, subGraphName, kaUal, fn) => (
+        real.withKaWriteLock(contextGraphId, subGraphName, kaUal, fn)
+      ),
+      readStoredHead: (descriptor) => real.readStoredHead(descriptor),
+      isGraphAssetMaterialized: (descriptor) => real.isGraphAssetMaterialized(descriptor),
+      replaceGraph: async (graphUri, quads) => {
+        replacedGraphs.push(graphUri);
+        await real.replaceGraph(graphUri, quads);
+      },
+      replaceHeadMetadata: (contextGraphId, descriptor) => (
+        real.replaceHeadMetadata(contextGraphId, descriptor)
+      ),
+    };
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx,
+        remotePeerId: 'peer-head-residue-7c7c7c7c',
+        contextGraphIds: [COVERAGE_CG],
+        createContextGraphSyncDeadline: () => Date.now() + 60_000,
+        fetchSyncPages: async (
+          _ctx: OperationContext,
+          _peer: string,
+          contextGraphId: string,
+          _includeSharedMemory: boolean,
+          phase: string,
+          _graph: string,
+          _deadline: number,
+          snapshotRef?: string,
+        ) => {
+          if (phase === 'snapshot') snapshotFetches.push(String(snapshotRef));
+          // Every phase completes cleanly. That is not incidental: it is what
+          // makes `manifestComplete` true, which is the field that turns this
+          // into the third state rather than the truncated-meta one.
+          return pageResult(contextGraphId, phase);
+        },
+        processSharedMemoryBatch: async () => ({
+          ...sharedMemoryProcessResult(),
+          emptyResponses: 0,
+          verifiedMeta: meta,
+          totalFetchedMetaQuads: meta.length,
+        }),
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads: Quad[]) => { await store.insert(quads); },
+        snapshotMaterializer: materializer,
+        publicSnapshotStore: {
+          getSnapshot: async (ref: string) => cached.get(ref) ?? null,
+          putSnapshot: async () => ({ ref: 'unused', byteLength: 0 }),
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map(),
+        logInfo: noop,
+        logWarn: noop,
+        logDebug: noop,
+      });
+
+      // Both refs were served from cache, so the snapshot plane completed and
+      // the transport is exonerated: a digest that stopped matching its payload
+      // would turn a cache hit into a fetch and move this row onto the
+      // fetch-shortfall branch that the first coverage row already owns.
+      expect(snapshotFetches).toEqual([]);
+      // THE ANTI-VACUITY WITNESS, and the reason this row cannot pass under an
+      // implementation that writes everything correctly: not one assertion
+      // graph was replaced. Without it, `snapshotsResolved: 0` alone would also
+      // be satisfied by a materializer that ran and wrote all of them, and the
+      // coverage number would have nothing to agree WITH.
+      //
+      // That the builder's descriptors are MATERIALIZABLE at all is the one
+      // property this row cannot self-witness, and it is pinned by T14 below,
+      // which shares this builder and asserts two Knowledge Assets written
+      // against a real store. An empty list here is therefore attributable to
+      // the parse failure rather than to a fixture that could never have
+      // written anything — the `/ambiguous assertionVersion/` guard above
+      // constrains the parser, not the materializer.
+      expect(replacedGraphs).toEqual([]);
+      // Corroboration from the summary's own ledger: `verifiedData` is empty
+      // here, so in-lock materialization is the only possible source of data
+      // triples, and there were none.
+      expect(summary.insertedDataTriples).toBe(0);
+      // Pre-fix this record read `2/2` with `missingCount: 0` for a round that
+      // wrote nothing at all. `manifestComplete: true` is the discriminator and
+      // is pinned deliberately: if it ever came out `false`, these counts would
+      // be right for the FIRST coverage row's reason (a truncated meta phase)
+      // and this row would silently stop testing the flag. `missingSample` is
+      // empty because the sample is only populated on the materialization-
+      // FAILURE path, and here nothing was ever attempted — a known diagnostics
+      // residual, not a disagreement with `missingCount`.
+      expect(summary.swmCoverage).toEqual({
+        contextGraphId: COVERAGE_CG,
+        peerIdSuffix: '7c7c7c7c',
+        snapshotsResolved: 0,
+        snapshotsTotal: 2,
+        manifestComplete: true,
+        missingCount: 2,
+        missingSample: [],
+        materializationFailures: 0,
+      });
+      // The second half of the flag, and an INDEPENDENT one: coverage is what
+      // the continuation loop reads, `failedPhases` is what stops the round
+      // being stamped as caught up. A parse failure produces no
+      // `materializationFailures` — nothing was attempted — so
+      // `snapshotPhaseUsable` needs `descriptorsAuthoritative` in its
+      // conjunction or the phase reads usable on a round that wrote nothing.
+      expect(summary.failedPhases).toBeGreaterThanOrEqual(1);
+      // ...which is what withholds the CERTIFICATION, the durable half of the
+      // harm: the bulk `storeInsert(processed.verifiedMeta)` sits below the
+      // unusable-phase `continue`, so no head row landed claiming an assertion
+      // graph that holds nothing. Had it landed, the next round's
+      // `isGraphAssetMaterialized` would see the marker and skip these
+      // Knowledge Assets permanently.
+      expect(summary.insertedMetaTriples).toBe(0);
     } finally {
       await store.close().catch(() => {});
     }

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -88,6 +88,8 @@ export default defineConfig({
       "test/sync-policy.test.ts",
       "test/catchup-policy.test.ts",
       "test/catchup-concurrency.test.ts",
+      // #2050 — the stop rule for the bounded repeat of the public SWM peer walk.
+      "test/catchup-pass-policy.test.ts",
       "test/map-with-concurrency.test.ts",
       "test/peer-selection.test.ts",
       "test/sync-requester-priority.test.ts",

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -114,8 +114,19 @@ interface CatchupPassContext {
  * passes to the two peers that mattered in the r26 incident, and extra passes to
  * the ten barren ones.
  *
- * `snapshotsTotal > 0` is what excludes the barren and cleanly-empty peers;
- * `snapshotsResolved < snapshotsTotal` is what excludes the ones already done.
+ * `snapshotsResolved < snapshotsTotal` is what does the excluding — both for the
+ * peers already done AND for the barren and cleanly-empty ones, which report
+ * `0/0` and fail it at `0 < 0`.
+ *
+ * `snapshotsTotal > 0` is therefore a **defensive restatement with no reachable
+ * effect**, kept because it states the intent legibly. Do NOT treat it as a live
+ * guard: mutating it to `>= 0` leaves the entire suite green, and no honest
+ * fixture can kill it — changing any outcome would need `resolved < total` to
+ * hold while `total <= 0`, i.e. a negative resolved count, which no path
+ * produces. A row written to kill it would pass only because its fixture is
+ * impossible. Stated here rather than left in a commit message because the next
+ * mutation window would otherwise re-derive it from scratch, and the next
+ * refactor would preserve an inert clause believing it load-bearing.
  *
  * `manifestComplete` IS required, and it is not a failure signal — it states that
  * the denominator is the peer's whole manifest rather than a truncated prefix.

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -717,11 +717,17 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
         planeProven: catchupPlaneProvenByData(cleanPlaneCompletions.sharedMemory),
         capablePeers: capablePeersForNextPass(lastCoverageByPeer),
       });
-      // Recorded on every decision, the stopping one included — "why did it
-      // stop" is the question a partial catch-up actually raises, and Chunk 5's
-      // terminal message renders this.
-      diagnostics.sharedMemory.continuationStopReason = decision.reason;
       if (!decision.continue) {
+        // Published ONLY on the decision that stops the loop, so `'continue'` is
+        // structurally unrepresentable in this field rather than merely
+        // unreachable-by-inspection. Assigning on every decision left the field
+        // transiently holding `'continue'` and one added exit path — a
+        // cancellation `break` after a pass, say — from publishing it. The
+        // terminal message absorbs that value today (`SWM_STOP_REASON_TEXT.continue`
+        // is `''`, which is falsy and omits the clause), so it would have degraded
+        // quietly instead of rendering malformed text; this makes the defensive
+        // entry provably dead rather than load-bearing.
+        diagnostics.sharedMemory.continuationStopReason = decision.reason;
         // Logged even when no extra pass ran. "Why did it stop" is the question a
         // partial catch-up raises, and the answer is otherwise only reconstructable
         // from counters — `no-capable-peers` after a converged walk and after an

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -149,6 +149,34 @@ function capablePeersForNextPass(coverageByPeer: Map<string, SwmSnapshotCoverage
 }
 
 /**
+ * Emit one observability line through the host, and NEVER let it affect the job.
+ *
+ * The Worker has no logger, so the line travels as an RPC — and an RPC can
+ * reject. A catch-up that failed because a log line could not be delivered would
+ * be a strictly worse outcome than a catch-up with a missing log line, so the
+ * rejection is swallowed here rather than unwinding `runCatchup`. This is also
+ * what keeps a host that does not implement the method (older host, or a test
+ * double that rejects unknown invokes) from turning observability into a
+ * dependency.
+ */
+async function logPassLine(message: string): Promise<void> {
+  await invoke<null>('logCatchupPass', message).catch(() => {});
+}
+
+/**
+ * Render the reported coverage for the per-pass log line, naming the peer it came
+ * from. Coverage is always attributed: the record is selected whole from one
+ * round, so `178/250` and the peer that said it belong together, and a line that
+ * printed the counts without the peer would invite reading them as a fleet total.
+ */
+function describeCoverage(coverage: SwmSnapshotCoverage | undefined): string {
+  if (!coverage) return 'no peer reported snapshot coverage';
+  const manifest = coverage.manifestComplete ? '' : ' (manifest truncated; total is a lower bound)';
+  return `${coverage.snapshotsResolved}/${coverage.snapshotsTotal} snapshots from `
+    + `...${coverage.peerIdSuffix}${manifest}`;
+}
+
+/**
  * The walk's coverage high-water reading: the best any single peer reported.
  *
  * A progress signal, never a correctness denominator — peers describe different
@@ -693,10 +721,28 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       // stop" is the question a partial catch-up actually raises, and Chunk 5's
       // terminal message renders this.
       diagnostics.sharedMemory.continuationStopReason = decision.reason;
-      if (!decision.continue) break;
+      if (!decision.continue) {
+        // Logged even when no extra pass ran. "Why did it stop" is the question a
+        // partial catch-up raises, and the answer is otherwise only reconstructable
+        // from counters — `no-capable-peers` after a converged walk and after an
+        // abandoned one look identical in the numbers.
+        await logPassLine(`Catch-up SWM pass loop for "${request.contextGraphId}" `
+          + `stopped after ${1 + continuationPasses} pass(es): ${decision.reason}; `
+          + `${describeCoverage(diagnostics.sharedMemory.swmCoverage)}`);
+        break;
+      }
       coverageHighWaterMark = lastPassCoverage;
       continuationPasses += 1;
+      const passStartedMs = catchupPassNowMs();
       await runWalk(decision.peers, { sharedMemoryOnly: true, deadlineMs: passDeadlineMs });
+      // Coverage BEFORE and AFTER on one line: a pass whose elapsed time is large
+      // and whose coverage did not move is the signature of a job that is not
+      // converging, and that is not visible from either number alone.
+      await logPassLine(`Catch-up SWM pass ${1 + continuationPasses} for `
+        + `"${request.contextGraphId}": ${decision.peers.length} capable peer(s), coverage `
+        + `${lastPassCoverage} -> ${highestResolvedCoverage(lastCoverageByPeer)} resolved, `
+        + `${Math.round(catchupPassNowMs() - passStartedMs)}ms; `
+        + `${describeCoverage(diagnostics.sharedMemory.swmCoverage)}`);
     }
     if (continuationPasses > 0) {
       diagnostics.sharedMemory.continuationPasses = continuationPasses;

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -188,18 +188,38 @@ function describeCoverage(coverage: SwmSnapshotCoverage | undefined): string {
 }
 
 /**
- * The walk's coverage high-water reading: the best any single peer reported.
+ * The walk's progress reading: the sum of every peer's OWN high-water resolved
+ * count.
  *
  * A progress signal, never a correctness denominator — peers describe different
- * manifests, and the completion proof stays `catchupPlaneProvenByData`. Taken as a
- * max over whole per-peer records so no synthetic pair is ever formed.
+ * manifests, and the completion proof stays `catchupPlaneProvenByData`.
+ *
+ * Why a per-peer ledger rather than a max over `lastCoverageByPeer`: the two
+ * gates read different peer sets. `capablePeersForNextPass` retries only peers
+ * with `resolved < total`, while a fleet-wide max includes peers the pass will
+ * never contact again. A peer sitting at `400/400` therefore pinned the reading,
+ * and a capable peer converging `30 -> 55` against a 120-ref manifest could
+ * never clear that bar — its whole manifest is smaller than the pinned number —
+ * so it got exactly one continuation pass however well it was doing, and the
+ * stop was reported as `coverage-stalled`, whose text tells an operator more
+ * passes would not help. That is the abandonment #2050 exists to remove.
+ *
+ * Summing per-peer high-waters, rather than maxing the capable set, is what
+ * makes the reading monotone. Filtering the max to capable peers inverts the
+ * bug: the capable set SHRINKS as peers finish, so a peer completing `200/200`
+ * and dropping out would make the reading FALL and stall the loop from the other
+ * direction. `snapshotsResolved` is also a per-round count — `materializedRefs`
+ * is rebuilt each round — so a pass that yields earlier can legitimately report
+ * a LOWER number for the same peer; taking each peer's max absorbs that.
+ *
+ * With a monotone total, `lastPassCoverage <= coverageHighWaterMark` means
+ * exactly "no peer beat its own record", which is the signal the policy
+ * docstring describes.
  */
-function highestResolvedCoverage(coverageByPeer: Map<string, SwmSnapshotCoverage>): number {
-  let highest = 0;
-  for (const coverage of coverageByPeer.values()) {
-    if (coverage.snapshotsResolved > highest) highest = coverage.snapshotsResolved;
-  }
-  return highest;
+function totalPeerProgress(progressByPeer: Map<string, number>): number {
+  let total = 0;
+  for (const resolved of progressByPeer.values()) total += resolved;
+  return total;
 }
 
 function emptyShared(): CatchupSharedMemoryResult {
@@ -256,6 +276,16 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   const peersSucceeded = new Set<string>();
   /** Each peer's own coverage from its LAST round; the capability gate's input. */
   const lastCoverageByPeer = new Map<string, SwmSnapshotCoverage>();
+  /**
+   * Each peer's own HIGH-WATER `snapshotsResolved`; the progress gate's input.
+   *
+   * Separate from `lastCoverageByPeer` on both axes that map varies on: this one
+   * only ever rises, and nothing removes an entry. The forgetting branch below
+   * deletes a peer's coverage after a clean empty round, which would make a sum
+   * over that map fall and report `coverage-stalled` for what was really a peer
+   * dropping out. See `totalPeerProgress`.
+   */
+  const peerProgressHighWater = new Map<string, number>();
   let deferredBackpressure = 0;
   let dataSynced = 0;
   let sharedMemorySynced = 0;
@@ -507,14 +537,20 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       // the authority-answering logic below uses, so the two cannot disagree, and
       // it already counts a deferred plane as not completed.
       //
-      // For whoever reads a stop reason later: `highestResolvedCoverage` is a max
-      // over this map, so any forgetting can make the reading DECREASE between
-      // passes, which trips the stalled check and reports `coverage-stalled` for
-      // what was really a transport failure. Requiring a clean round removes the
-      // common cause; a decrease stays reachable when a barren round follows a
-      // productive one against a different peer.
+      // For whoever reads a stop reason later: the progress gate no longer reads
+      // this map at all — it reads `peerProgressHighWater`, which is monotone and
+      // never forgotten, so the forgetting below can no longer make the reading
+      // DECREASE between passes and report `coverage-stalled` for what was really
+      // a transport failure or a peer dropping out. This map now feeds only the
+      // capability gate, where forgetting is the intended behaviour.
       if (shared.swmCoverage) {
         lastCoverageByPeer.set(peerId, shared.swmCoverage);
+        // Max, never assign: `snapshotsResolved` is a per-round count, so a pass
+        // that yields earlier can report a lower number for the same peer.
+        const seen = peerProgressHighWater.get(peerId) ?? 0;
+        if (shared.swmCoverage.snapshotsResolved > seen) {
+          peerProgressHighWater.set(peerId, shared.swmCoverage.snapshotsResolved);
+        }
       } else if (catchupPlaneCompletedWithoutFailure(shared)) {
         lastCoverageByPeer.delete(peerId);
       }
@@ -717,7 +753,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   if (request.includeSharedMemory) {
     const passDeadlineMs = catchupPassNowMs() + SWM_CATCHUP_PASS_BUDGET_MS;
     for (;;) {
-      const lastPassCoverage = highestResolvedCoverage(lastCoverageByPeer);
+      const lastPassCoverage = totalPeerProgress(peerProgressHighWater);
       const decision = shouldRunAnotherCatchupPass({
         nowMs: catchupPassNowMs(),
         deadlineMs: passDeadlineMs,
@@ -757,7 +793,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       // converging, and that is not visible from either number alone.
       await logPassLine(`Catch-up SWM pass ${1 + continuationPasses} for `
         + `"${request.contextGraphId}": ${decision.peers.length} capable peer(s), coverage `
-        + `${lastPassCoverage} -> ${highestResolvedCoverage(lastCoverageByPeer)} resolved, `
+        + `${lastPassCoverage} -> ${totalPeerProgress(peerProgressHighWater)} resolved, `
         + `${Math.round(catchupPassNowMs() - passStartedMs)}ms; `
         + `${describeCoverage(diagnostics.sharedMemory.swmCoverage)}`);
     }

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -2,14 +2,20 @@ import { parentPort } from 'node:worker_threads';
 import {
   CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
   CATCHUP_STOP_ON_PROOF,
+  SWM_CATCHUP_MAX_PASSES,
+  SWM_CATCHUP_PASS_BUDGET_MS,
+  catchupPassNowMs,
   catchupWaveSizes,
   createFailedPeerDurableSyncResult,
   mapWithConcurrency,
   runCatchupPlaneWithPolicy,
   runCatchupPlanesWithPolicy,
+  selectSwmSnapshotCoverage,
+  shouldRunAnotherCatchupPass,
   type CatchupPlaneContext,
   type DurableSyncResult,
   type SharedMemorySyncResult,
+  type SwmSnapshotCoverage,
 } from '@origintrail-official/dkg-agent';
 import {
   addCatchupPlaneEvidence,
@@ -85,6 +91,60 @@ interface PeerRound {
   shared: CatchupSharedMemoryResult | null;
 }
 
+/** What distinguishes one pass of the peer walk from the next. */
+interface CatchupPassContext {
+  /** Continuation passes re-pull only the shared-memory plane. */
+  sharedMemoryOnly: boolean;
+  /** Absent on pass 1: the budget bounds the REPEAT, not the original walk. */
+  deadlineMs?: number;
+}
+
+/**
+ * The peers a further pass may contact — the CAPABILITY GATE.
+ *
+ * Read this and nothing else: a peer is capable exactly when its own last round
+ * said it holds refs we have not resolved.
+ *
+ * It deliberately does NOT consult `failedPhases`, `hasBlockingFailure`,
+ * `peersSucceeded`, or membership in `cleanPlaneCompletions`. That looks like the
+ * obvious tidy-up and it inverts the fix: a peer that yielded mid-manifest on the
+ * local clock sets `failedPhases` (so a partial round cannot report `done`) and is
+ * therefore absent from every one of those — and it is precisely the peer the next
+ * pass exists to revisit. Gating on "no failures" would have given zero extra
+ * passes to the two peers that mattered in the r26 incident, and extra passes to
+ * the ten barren ones.
+ *
+ * `snapshotsTotal > 0` is what excludes the barren and cleanly-empty peers;
+ * `snapshotsResolved < snapshotsTotal` is what excludes the ones already done.
+ * `manifestComplete` is deliberately NOT required: a peer whose metadata was
+ * truncated still has real, fetchable refs in the prefix it did serve, and
+ * excluding it would strand exactly the work it can still deliver.
+ */
+function capablePeersForNextPass(coverageByPeer: Map<string, SwmSnapshotCoverage>): string[] {
+  const capable: string[] = [];
+  for (const [peerId, coverage] of coverageByPeer) {
+    if (coverage.snapshotsTotal > 0 && coverage.snapshotsResolved < coverage.snapshotsTotal) {
+      capable.push(peerId);
+    }
+  }
+  return capable;
+}
+
+/**
+ * The walk's coverage high-water reading: the best any single peer reported.
+ *
+ * A progress signal, never a correctness denominator — peers describe different
+ * manifests, and the completion proof stays `catchupPlaneProvenByData`. Taken as a
+ * max over whole per-peer records so no synthetic pair is ever formed.
+ */
+function highestResolvedCoverage(coverageByPeer: Map<string, SwmSnapshotCoverage>): number {
+  let highest = 0;
+  for (const coverage of coverageByPeer.values()) {
+    if (coverage.snapshotsResolved > highest) highest = coverage.snapshotsResolved;
+  }
+  return highest;
+}
+
 function emptyShared(): CatchupSharedMemoryResult {
   return {
     insertedTriples: 0,
@@ -103,6 +163,14 @@ function emptyShared(): CatchupSharedMemoryResult {
     failedPhases: 0,
     deniedPhases: 0,
     deferredBackpressure: 0,
+    snapshotPlaneIncomplete: 0,
+    replayPhaseBytesReceived: 0,
+    snapshotPhaseBytesReceived: 0,
+    // `swmCoverage` stays ABSENT here on purpose. This is the fallback for a
+    // peer whose round threw, so it has no manifest to report; a fabricated
+    // `0/0` would be a record the reduction could select and Chunk 5 could
+    // print. Absent and `0/0` both read as "not capable", but only absent is
+    // honest.
   };
 }
 
@@ -121,9 +189,16 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   }>('prepareCatchup', request.contextGraphId);
 
   let syncCapablePeers = 0;
-  let peersTried = 0;
-  let peersResponded = 0;
-  let peersSucceeded = 0;
+  // DISTINCT peers, not peer-passes. Once the walk can repeat, `+= 1` per round
+  // counts the same peer once per pass — which inflates every one of these and
+  // drives `peersNotAttempted` (`syncCapable.length - peersTried`) NEGATIVE on the
+  // second pass. `continuationPasses` is the separate signal for how many passes
+  // were spent.
+  const peersTried = new Set<string>();
+  const peersResponded = new Set<string>();
+  const peersSucceeded = new Set<string>();
+  /** Each peer's own coverage from its LAST round; the capability gate's input. */
+  const lastCoverageByPeer = new Map<string, SwmSnapshotCoverage>();
   let deferredBackpressure = 0;
   let dataSynced = 0;
   let sharedMemorySynced = 0;
@@ -178,6 +253,10 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       failedPhases: 0,
       deferredBackpressure: 0,
       deniedPhases: 0,
+      snapshotPlaneIncomplete: 0,
+      continuationPasses: 0,
+      replayPhaseBytesReceived: 0,
+      snapshotPhaseBytesReceived: 0,
     },
   };
 
@@ -280,7 +359,23 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
 
   // Isolate per-peer failures: if one peer's sync steps throw, aggregate what we
   // can from the other peers instead of failing the entire subscribe/catch-up.
-  const syncPeer = async (peerId: string): Promise<PeerRound> => {
+  const syncPeer = async (peerId: string, pass: CatchupPassContext): Promise<PeerRound> => {
+    const fromAuthorityPeer = prepared.authoritativePeerId !== undefined
+      && peerId === prepared.authoritativePeerId;
+    // A deferred plane can burn up to CATCHUP_BACKPRESSURE_MAX_WAIT_MS (180 s)
+    // inside a single admission, so a continuation pass can go past its budget
+    // between one peer and the next. Decline to START another peer rather than
+    // interrupt one: a wave member already in flight is never cancelled, for the
+    // same reason the wave loop below never cancels one — an aborted resumed
+    // session is indistinguishable from a responder supersede.
+    //
+    // Pass 1 has no deadline. It is today's walk unchanged, and the budget bounds
+    // the REPEAT, not the original: a zero budget would otherwise expire before
+    // the first peer and turn the kill switch into "fetch nothing".
+    if (pass.deadlineMs !== undefined && catchupPassNowMs() >= pass.deadlineMs) {
+      return { peerId, fromAuthority: fromAuthorityPeer, durable: null, shared: null };
+    }
+    peersTried.add(peerId);
     const syncDurable = (
       { priority, source }: CatchupPlaneContext,
     ): Promise<CatchupDurableResult> =>
@@ -304,11 +399,16 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     // amplification this fix exists to remove. The kill-switch restores the
     // previous fan-out faithfully: every peer, both requested planes.
     const optimize = CATCHUP_STOP_ON_PROOF;
-    const needDurable = !optimize || !authorityProven.durable;
+    // A continuation pass is shared-memory only. The capability gate that put
+    // this peer here is defined purely on SWM coverage, so re-pulling the durable
+    // plane would be amplification with nothing selecting for it — and the whole
+    // accepted cost of repeating the walk is per-pass replay. Pass 1's durable
+    // evidence is already in `cleanPlaneCompletions`; a later pass producing none
+    // cannot take it away.
+    const needDurable = !pass.sharedMemoryOnly && (!optimize || !authorityProven.durable);
     const needSharedMemory = request.includeSharedMemory
       && (!optimize || !authorityProven.sharedMemory);
-    const fromAuthority = prepared.authoritativePeerId !== undefined
-      && peerId === prepared.authoritativePeerId;
+    const fromAuthority = fromAuthorityPeer;
     if (!needDurable) {
       const shared = needSharedMemory
         ? await runCatchupPlaneWithPolicy('foreground', syncSharedMemory)
@@ -324,8 +424,44 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     return { peerId, fromAuthority, ...round };
   };
 
-  const accumulate = ({ durable, shared, fromAuthority }: PeerRound): void => {
+  const accumulate = ({ peerId, durable, shared, fromAuthority }: PeerRound): void => {
     let peerDenied = false;
+    if (shared) {
+      // This peer's OWN latest coverage, kept apart from the reduced record in
+      // `diagnostics`. The reduction picks one peer's record to REPORT; the
+      // capability gate needs each peer's own, and last-round-wins is what makes
+      // "still has refs we lack" a statement about now rather than about pass 1.
+      //
+      // A round that reports no coverage is forgotten ONLY when it completed
+      // cleanly — a genuinely barren peer, whose record Chunk 1 suppresses at
+      // `snapshotsTotal === 0`. A FAILED round retains what the peer last told
+      // us, because a throw is not evidence of absence: `syncSharedMemory`'s
+      // `.catch(() => emptyShared())` returns a truthy result carrying no
+      // coverage, so forgetting on it would erase a peer's `178/250` the moment
+      // one pass against it threw. If that was the last capable peer, the next
+      // decision sees an empty set and stops at `no-capable-peers` — abandoning a
+      // graph we have positive evidence is recoverable. That is the #2050
+      // scenario itself: those peers were recorded with SWM transport failures,
+      // and surviving them is the whole reason the walk repeats.
+      //
+      // The asymmetry is deliberate. A stale-but-positive record can only
+      // over-attempt one peer, bounded by the pass cap and the budget; deleting
+      // it gives up. `catchupPlaneCompletedWithoutFailure` is the same predicate
+      // the authority-answering logic below uses, so the two cannot disagree, and
+      // it already counts a deferred plane as not completed.
+      //
+      // For whoever reads a stop reason later: `highestResolvedCoverage` is a max
+      // over this map, so any forgetting can make the reading DECREASE between
+      // passes, which trips the stalled check and reports `coverage-stalled` for
+      // what was really a transport failure. Requiring a clean round removes the
+      // common cause; a decrease stays reachable when a barren round follows a
+      // productive one against a different peer.
+      if (shared.swmCoverage) {
+        lastCoverageByPeer.set(peerId, shared.swmCoverage);
+      } else if (catchupPlaneCompletedWithoutFailure(shared)) {
+        lastCoverageByPeer.delete(peerId);
+      }
+    }
     if (durable) {
       dataSynced += durable.insertedDataTriples ?? 0;
       diagnostics.durable.fetchedMetaTriples += durable.fetchedMetaTriples;
@@ -381,7 +517,22 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       diagnostics.sharedMemory.failedPeers += shared.failedPeers;
       diagnostics.sharedMemory.failedPhases += shared.failedPhases ?? 0;
       diagnostics.sharedMemory.deferredBackpressure += shared.deferredBackpressure ?? 0;
+      diagnostics.sharedMemory.snapshotPlaneIncomplete += shared.snapshotPlaneIncomplete ?? 0;
+      diagnostics.sharedMemory.replayPhaseBytesReceived += shared.replayPhaseBytesReceived ?? 0;
+      diagnostics.sharedMemory.snapshotPhaseBytesReceived += shared.snapshotPhaseBytesReceived ?? 0;
       deferredBackpressure += shared.deferredBackpressure ?? 0;
+      // Coverage is the one field here that is SELECTED, not summed. Summing —
+      // or taking independent maxima over resolved and total — would let a peer
+      // reporting 178/250 and a peer reporting 200/200 combine into 200/250: a
+      // graph state no peer described, carrying a missing sample from neither.
+      // `fromAuthority` is attached here because peer roles are the walk's
+      // knowledge, not the agent-side sync's.
+      if (shared.swmCoverage) {
+        diagnostics.sharedMemory.swmCoverage = selectSwmSnapshotCoverage(
+          diagnostics.sharedMemory.swmCoverage,
+          { ...shared.swmCoverage, fromAuthority },
+        );
+      }
       diagnostics.sharedMemory.deniedPhases =
         (diagnostics.sharedMemory.deniedPhases ?? 0) + (shared.deniedPhases ?? 0);
       peerDenied = peerDenied || shared.deniedPhases > 0;
@@ -403,7 +554,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     }
 
     if (catchupPeerResponded(durable, shared)) {
-      peersResponded += 1;
+      peersResponded.add(peerId);
     }
 
     // Count peers that completed a sync round without a transport
@@ -412,7 +563,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     // `syncContextGraphFromConnectedPeers` path so both runners report the
     // same shape.
     if (catchupPeerSucceeded(durable, shared, peerDenied, durable?.complete)) {
-      peersSucceeded += 1;
+      peersSucceeded.add(peerId);
     }
   };
 
@@ -456,8 +607,9 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   // waves and the opening width is unobservable. The comparison is what
   // actually decides: narrow the opening wave only when the authority IS the
   // peer that wave would contact.
+  const runWalk = async (walkPeers: string[], pass: CatchupPassContext): Promise<void> => {
   const authorityFirst = prepared.authoritativePeerId !== undefined
-    && syncCapable[0] === prepared.authoritativePeerId;
+    && walkPeers[0] === prepared.authoritativePeerId;
   // Waves exist ONLY so an authority can cut the walk short. With no authority
   // resolvable nothing can ever break the loop, so splitting the peer set into
   // waves cannot save a single fetch — it only adds a barrier between them,
@@ -466,28 +618,67 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   const canStopEarly = CATCHUP_STOP_ON_PROOF && prepared.authoritativePeerId !== undefined;
   const waveSizes = canStopEarly
     ? catchupWaveSizes(
-      syncCapable.length,
+      walkPeers.length,
       CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
       authorityFirst ? 1 : CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
     )
-    : [syncCapable.length];
+    : [walkPeers.length];
   let cursor = 0;
   for (const waveSize of waveSizes) {
-    const wave = syncCapable.slice(cursor, cursor + waveSize);
+    const wave = walkPeers.slice(cursor, cursor + waveSize);
     if (wave.length === 0) break;
     cursor += wave.length;
-    peersTried += wave.length;
     // Never cancel a wave member mid-stream: an aborted resumed session is
     // indistinguishable from a responder supersede. Let the wave finish, then
     // stop before dispatching the next one.
     const rounds = await mapWithConcurrency(
       wave,
       Math.min(CATCHUP_MAX_CONCURRENT_PEER_SYNCS, wave.length),
-      syncPeer,
+      (peerId) => syncPeer(peerId, pass),
     );
     for (const round of rounds) accumulate(round);
     settleAuthorityForWave();
     if (CATCHUP_STOP_ON_PROOF && authorityProvedEverything()) break;
+  }
+  };
+
+  // Pass 1 IS today's walk: same peers, both planes, no deadline. Everything the
+  // repeat loop adds happens after it returns, so a node with extra passes
+  // disabled behaves exactly as it did before #2050.
+  await runWalk(syncCapable, { sharedMemoryOnly: false });
+
+  // The bounded, progress-aware repeat (#2050). A receiver that ran out of clock
+  // mid-manifest used to terminate `unreachable` with a partial graph and no
+  // resume path; now the walk repeats while it is provably converging.
+  //
+  // The budget is read from the environment rather than passed per request
+  // because this runner has exactly one caller shape — the daemon's foreground
+  // catch-up job. `DKG_SWM_CATCHUP_PASS_BUDGET_MS=0` is the operator kill switch
+  // and needs no redeploy; it makes the deadline expire before the first repeat.
+  let continuationPasses = 0;
+  let coverageHighWaterMark = 0;
+  if (request.includeSharedMemory) {
+    const passDeadlineMs = catchupPassNowMs() + SWM_CATCHUP_PASS_BUDGET_MS;
+    for (;;) {
+      const lastPassCoverage = highestResolvedCoverage(lastCoverageByPeer);
+      const decision = shouldRunAnotherCatchupPass({
+        nowMs: catchupPassNowMs(),
+        deadlineMs: passDeadlineMs,
+        passesRun: 1 + continuationPasses,
+        maxPasses: SWM_CATCHUP_MAX_PASSES,
+        coverageHighWaterMark,
+        lastPassCoverage,
+        planeProven: catchupPlaneProvenByData(cleanPlaneCompletions.sharedMemory),
+        capablePeers: capablePeersForNextPass(lastCoverageByPeer),
+      });
+      if (!decision.continue) break;
+      coverageHighWaterMark = lastPassCoverage;
+      continuationPasses += 1;
+      await runWalk(decision.peers, { sharedMemoryOnly: true, deadlineMs: passDeadlineMs });
+    }
+    if (continuationPasses > 0) {
+      diagnostics.sharedMemory.continuationPasses = continuationPasses;
+    }
   }
 
   // A curator we resolved but never heard cleanly from makes the round
@@ -510,10 +701,10 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     totalPeers: prepared.connectedPeers,
     selectedPeers: prepared.peerIds.length,
     syncCapablePeers,
-    peersTried,
-    peersResponded,
-    peersSucceeded,
-    peersNotAttempted: syncCapable.length - peersTried,
+    peersTried: peersTried.size,
+    peersResponded: peersResponded.size,
+    peersSucceeded: peersSucceeded.size,
+    peersNotAttempted: syncCapable.length - peersTried.size,
     deferredBackpressure,
     dataSynced,
     sharedMemorySynced,

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -116,14 +116,32 @@ interface CatchupPassContext {
  *
  * `snapshotsTotal > 0` is what excludes the barren and cleanly-empty peers;
  * `snapshotsResolved < snapshotsTotal` is what excludes the ones already done.
- * `manifestComplete` is deliberately NOT required: a peer whose metadata was
- * truncated still has real, fetchable refs in the prefix it did serve, and
- * excluding it would strand exactly the work it can still deliver.
+ *
+ * `manifestComplete` IS required, and it is not a failure signal — it states that
+ * the denominator is the peer's whole manifest rather than a truncated prefix.
+ * A truncated manifest is the one shape that can advance coverage forever while
+ * materializing nothing: `runSharedMemorySync` parses descriptors only when the
+ * meta phase completed, and wires `onSnapshotReady` only when descriptors exist,
+ * so a truncated-meta round still fetches and caches blobs — advancing
+ * `snapshotsResolved`, and so satisfying the coverage-advance gate — while
+ * writing zero KAs. Every repeat would re-pay a full metadata phase to warm a
+ * cache that cannot become visible until the manifest completes, and a fresh
+ * per-round deadline is no more generous than the one that truncated it.
+ *
+ * This does NOT re-admit the failure-counter mistake above. A peer that yielded
+ * mid-snapshot-list on the local clock — the peer this loop exists to revisit —
+ * completed its META phase first and therefore carries `manifestComplete: true`,
+ * so it stays capable. The two conditions are orthogonal: one says the
+ * denominator is whole, the other would have said the peer faulted.
  */
 function capablePeersForNextPass(coverageByPeer: Map<string, SwmSnapshotCoverage>): string[] {
   const capable: string[] = [];
   for (const [peerId, coverage] of coverageByPeer) {
-    if (coverage.snapshotsTotal > 0 && coverage.snapshotsResolved < coverage.snapshotsTotal) {
+    if (
+      coverage.manifestComplete
+      && coverage.snapshotsTotal > 0
+      && coverage.snapshotsResolved < coverage.snapshotsTotal
+    ) {
       capable.push(peerId);
     }
   }
@@ -671,6 +689,10 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
         planeProven: catchupPlaneProvenByData(cleanPlaneCompletions.sharedMemory),
         capablePeers: capablePeersForNextPass(lastCoverageByPeer),
       });
+      // Recorded on every decision, the stopping one included — "why did it
+      // stop" is the question a partial catch-up actually raises, and Chunk 5's
+      // terminal message renders this.
+      diagnostics.sharedMemory.continuationStopReason = decision.reason;
       if (!decision.continue) break;
       coverageHighWaterMark = lastPassCoverage;
       continuationPasses += 1;

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -2,16 +2,15 @@ import { parentPort } from 'node:worker_threads';
 import {
   CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
   CATCHUP_STOP_ON_PROOF,
-  SWM_CATCHUP_MAX_PASSES,
-  SWM_CATCHUP_PASS_BUDGET_MS,
+  SwmCatchupPassTracker,
   catchupPassNowMs,
   catchupWaveSizes,
   createFailedPeerDurableSyncResult,
   mapWithConcurrency,
+  resolveSwmCatchupPassConfig,
   runCatchupPlaneWithPolicy,
   runCatchupPlanesWithPolicy,
   selectSwmSnapshotCoverage,
-  shouldRunAnotherCatchupPass,
   type CatchupPlaneContext,
   type DurableSyncResult,
   type SharedMemorySyncResult,
@@ -100,66 +99,6 @@ interface CatchupPassContext {
 }
 
 /**
- * The peers a further pass may contact — the CAPABILITY GATE.
- *
- * Read this and nothing else: a peer is capable exactly when its own last round
- * said it holds refs we have not resolved.
- *
- * It deliberately does NOT consult `failedPhases`, `hasBlockingFailure`,
- * `peersSucceeded`, or membership in `cleanPlaneCompletions`. That looks like the
- * obvious tidy-up and it inverts the fix: a peer that yielded mid-manifest on the
- * local clock sets `failedPhases` (so a partial round cannot report `done`) and is
- * therefore absent from every one of those — and it is precisely the peer the next
- * pass exists to revisit. Gating on "no failures" would have given zero extra
- * passes to the two peers that mattered in the r26 incident, and extra passes to
- * the ten barren ones.
- *
- * `snapshotsResolved < snapshotsTotal` is what does the excluding — both for the
- * peers already done AND for the barren and cleanly-empty ones, which report
- * `0/0` and fail it at `0 < 0`.
- *
- * `snapshotsTotal > 0` is therefore a **defensive restatement with no reachable
- * effect**, kept because it states the intent legibly. Do NOT treat it as a live
- * guard: mutating it to `>= 0` leaves the entire suite green, and no honest
- * fixture can kill it — changing any outcome would need `resolved < total` to
- * hold while `total <= 0`, i.e. a negative resolved count, which no path
- * produces. A row written to kill it would pass only because its fixture is
- * impossible. Stated here rather than left in a commit message because the next
- * mutation window would otherwise re-derive it from scratch, and the next
- * refactor would preserve an inert clause believing it load-bearing.
- *
- * `manifestComplete` IS required, and it is not a failure signal — it states that
- * the denominator is the peer's whole manifest rather than a truncated prefix.
- * A truncated manifest is the one shape that can advance coverage forever while
- * materializing nothing: `runSharedMemorySync` parses descriptors only when the
- * meta phase completed, and wires `onSnapshotReady` only when descriptors exist,
- * so a truncated-meta round still fetches and caches blobs — advancing
- * `snapshotsResolved`, and so satisfying the coverage-advance gate — while
- * writing zero KAs. Every repeat would re-pay a full metadata phase to warm a
- * cache that cannot become visible until the manifest completes, and a fresh
- * per-round deadline is no more generous than the one that truncated it.
- *
- * This does NOT re-admit the failure-counter mistake above. A peer that yielded
- * mid-snapshot-list on the local clock — the peer this loop exists to revisit —
- * completed its META phase first and therefore carries `manifestComplete: true`,
- * so it stays capable. The two conditions are orthogonal: one says the
- * denominator is whole, the other would have said the peer faulted.
- */
-function capablePeersForNextPass(coverageByPeer: Map<string, SwmSnapshotCoverage>): string[] {
-  const capable: string[] = [];
-  for (const [peerId, coverage] of coverageByPeer) {
-    if (
-      coverage.manifestComplete
-      && coverage.snapshotsTotal > 0
-      && coverage.snapshotsResolved < coverage.snapshotsTotal
-    ) {
-      capable.push(peerId);
-    }
-  }
-  return capable;
-}
-
-/**
  * Emit one observability line through the host, and NEVER let it affect the job.
  *
  * The Worker has no logger, so the line travels as an RPC — and an RPC can
@@ -185,41 +124,6 @@ function describeCoverage(coverage: SwmSnapshotCoverage | undefined): string {
   const manifest = coverage.manifestComplete ? '' : ' (manifest truncated; total is a lower bound)';
   return `${coverage.snapshotsResolved}/${coverage.snapshotsTotal} snapshots from `
     + `...${coverage.peerIdSuffix}${manifest}`;
-}
-
-/**
- * The walk's progress reading: the sum of every peer's OWN high-water resolved
- * count.
- *
- * A progress signal, never a correctness denominator — peers describe different
- * manifests, and the completion proof stays `catchupPlaneProvenByData`.
- *
- * Why a per-peer ledger rather than a max over `lastCoverageByPeer`: the two
- * gates read different peer sets. `capablePeersForNextPass` retries only peers
- * with `resolved < total`, while a fleet-wide max includes peers the pass will
- * never contact again. A peer sitting at `400/400` therefore pinned the reading,
- * and a capable peer converging `30 -> 55` against a 120-ref manifest could
- * never clear that bar — its whole manifest is smaller than the pinned number —
- * so it got exactly one continuation pass however well it was doing, and the
- * stop was reported as `coverage-stalled`, whose text tells an operator more
- * passes would not help. That is the abandonment #2050 exists to remove.
- *
- * Summing per-peer high-waters, rather than maxing the capable set, is what
- * makes the reading monotone. Filtering the max to capable peers inverts the
- * bug: the capable set SHRINKS as peers finish, so a peer completing `200/200`
- * and dropping out would make the reading FALL and stall the loop from the other
- * direction. `snapshotsResolved` is also a per-round count — `materializedRefs`
- * is rebuilt each round — so a pass that yields earlier can legitimately report
- * a LOWER number for the same peer; taking each peer's max absorbs that.
- *
- * With a monotone total, `lastPassCoverage <= coverageHighWaterMark` means
- * exactly "no peer beat its own record", which is the signal the policy
- * docstring describes.
- */
-function totalPeerProgress(progressByPeer: Map<string, number>): number {
-  let total = 0;
-  for (const resolved of progressByPeer.values()) total += resolved;
-  return total;
 }
 
 function emptyShared(): CatchupSharedMemoryResult {
@@ -274,18 +178,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   const peersTried = new Set<string>();
   const peersResponded = new Set<string>();
   const peersSucceeded = new Set<string>();
-  /** Each peer's own coverage from its LAST round; the capability gate's input. */
-  const lastCoverageByPeer = new Map<string, SwmSnapshotCoverage>();
-  /**
-   * Each peer's own HIGH-WATER `snapshotsResolved`; the progress gate's input.
-   *
-   * Separate from `lastCoverageByPeer` on both axes that map varies on: this one
-   * only ever rises, and nothing removes an entry. The forgetting branch below
-   * deletes a peer's coverage after a clean empty round, which would make a sum
-   * over that map fall and report `coverage-stalled` for what was really a peer
-   * dropping out. See `totalPeerProgress`.
-   */
-  const peerProgressHighWater = new Map<string, number>();
+  const passTracker = new SwmCatchupPassTracker<SwmSnapshotCoverage>();
   let deferredBackpressure = 0;
   let dataSynced = 0;
   let sharedMemorySynced = 0;
@@ -493,8 +386,11 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     // evidence is already in `cleanPlaneCompletions`; a later pass producing none
     // cannot take it away.
     const needDurable = !pass.sharedMemoryOnly && (!optimize || !authorityProven.durable);
+    // A policy-selected continuation peer is here precisely because its latest
+    // complete manifest still names unresolved snapshots. Authority proof may
+    // optimize pass 1, but it must never turn that selected retry into a no-op.
     const needSharedMemory = request.includeSharedMemory
-      && (!optimize || !authorityProven.sharedMemory);
+      && (pass.sharedMemoryOnly || !optimize || !authorityProven.sharedMemory);
     const fromAuthority = fromAuthorityPeer;
     if (!needDurable) {
       const shared = needSharedMemory
@@ -514,46 +410,11 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   const accumulate = ({ peerId, durable, shared, fromAuthority }: PeerRound): void => {
     let peerDenied = false;
     if (shared) {
-      // This peer's OWN latest coverage, kept apart from the reduced record in
-      // `diagnostics`. The reduction picks one peer's record to REPORT; the
-      // capability gate needs each peer's own, and last-round-wins is what makes
-      // "still has refs we lack" a statement about now rather than about pass 1.
-      //
-      // A round that reports no coverage is forgotten ONLY when it completed
-      // cleanly — a genuinely barren peer, whose record Chunk 1 suppresses at
-      // `snapshotsTotal === 0`. A FAILED round retains what the peer last told
-      // us, because a throw is not evidence of absence: `syncSharedMemory`'s
-      // `.catch(() => emptyShared())` returns a truthy result carrying no
-      // coverage, so forgetting on it would erase a peer's `178/250` the moment
-      // one pass against it threw. If that was the last capable peer, the next
-      // decision sees an empty set and stops at `no-capable-peers` — abandoning a
-      // graph we have positive evidence is recoverable. That is the #2050
-      // scenario itself: those peers were recorded with SWM transport failures,
-      // and surviving them is the whole reason the walk repeats.
-      //
-      // The asymmetry is deliberate. A stale-but-positive record can only
-      // over-attempt one peer, bounded by the pass cap and the budget; deleting
-      // it gives up. `catchupPlaneCompletedWithoutFailure` is the same predicate
-      // the authority-answering logic below uses, so the two cannot disagree, and
-      // it already counts a deferred plane as not completed.
-      //
-      // For whoever reads a stop reason later: the progress gate no longer reads
-      // this map at all — it reads `peerProgressHighWater`, which is monotone and
-      // never forgotten, so the forgetting below can no longer make the reading
-      // DECREASE between passes and report `coverage-stalled` for what was really
-      // a transport failure or a peer dropping out. This map now feeds only the
-      // capability gate, where forgetting is the intended behaviour.
-      if (shared.swmCoverage) {
-        lastCoverageByPeer.set(peerId, shared.swmCoverage);
-        // Max, never assign: `snapshotsResolved` is a per-round count, so a pass
-        // that yields earlier can report a lower number for the same peer.
-        const seen = peerProgressHighWater.get(peerId) ?? 0;
-        if (shared.swmCoverage.snapshotsResolved > seen) {
-          peerProgressHighWater.set(peerId, shared.swmCoverage.snapshotsResolved);
-        }
-      } else if (catchupPlaneCompletedWithoutFailure(shared)) {
-        lastCoverageByPeer.delete(peerId);
-      }
+      passTracker.recordPeerRound(
+        peerId,
+        shared.swmCoverage,
+        catchupPlaneCompletedWithoutFailure(shared),
+      );
     }
     if (durable) {
       dataSynced += durable.insertedDataTriples ?? 0;
@@ -744,25 +605,18 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   // mid-manifest used to terminate `unreachable` with a partial graph and no
   // resume path; now the walk repeats while it is provably converging.
   //
-  // The budget is read from the environment rather than passed per request
-  // because this runner has exactly one caller shape — the daemon's foreground
-  // catch-up job. `DKG_SWM_CATCHUP_PASS_BUDGET_MS=0` is the operator kill switch
-  // and needs no redeploy; it makes the deadline expire before the first repeat.
-  let continuationPasses = 0;
-  let coverageHighWaterMark = 0;
+  // Resolve once per job, then pass one explicit value into every decision.
+  // This avoids module-import order becoming hidden configuration state while
+  // retaining the operator kill switches.
+  const passConfig = resolveSwmCatchupPassConfig();
   if (request.includeSharedMemory) {
-    const passDeadlineMs = catchupPassNowMs() + SWM_CATCHUP_PASS_BUDGET_MS;
+    const passDeadlineMs = catchupPassNowMs() + passConfig.budgetMs;
     for (;;) {
-      const lastPassCoverage = totalPeerProgress(peerProgressHighWater);
-      const decision = shouldRunAnotherCatchupPass({
+      const decision = passTracker.decide({
         nowMs: catchupPassNowMs(),
         deadlineMs: passDeadlineMs,
-        passesRun: 1 + continuationPasses,
-        maxPasses: SWM_CATCHUP_MAX_PASSES,
-        coverageHighWaterMark,
-        lastPassCoverage,
+        maxPasses: passConfig.maxPasses,
         planeProven: catchupPlaneProvenByData(cleanPlaneCompletions.sharedMemory),
-        capablePeers: capablePeersForNextPass(lastCoverageByPeer),
       });
       if (!decision.continue) {
         // Published ONLY on the decision that stops the loop, so `'continue'` is
@@ -780,12 +634,11 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
         // from counters — `no-capable-peers` after a converged walk and after an
         // abandoned one look identical in the numbers.
         await logPassLine(`Catch-up SWM pass loop for "${request.contextGraphId}" `
-          + `stopped after ${1 + continuationPasses} pass(es): ${decision.reason}; `
+          + `stopped after ${1 + passTracker.continuationPasses()} pass(es): ${decision.reason}; `
           + `${describeCoverage(diagnostics.sharedMemory.swmCoverage)}`);
         break;
       }
-      coverageHighWaterMark = lastPassCoverage;
-      continuationPasses += 1;
+      const lastPassCoverage = passTracker.startContinuationPass();
       const passStartedMs = catchupPassNowMs();
       await runWalk(decision.peers, { sharedMemoryOnly: true, deadlineMs: passDeadlineMs });
       // Progress BEFORE and AFTER on one line: a pass whose elapsed time is large
@@ -799,15 +652,15 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       // peer invite being read as a fleet total. Two different quantities on one
       // line need the more surprising one named, or the reader will assume both
       // describe the record at the end of the sentence.
-      await logPassLine(`Catch-up SWM pass ${1 + continuationPasses} for `
+      await logPassLine(`Catch-up SWM pass ${1 + passTracker.continuationPasses()} for `
         + `"${request.contextGraphId}": ${decision.peers.length} capable peer(s), progress `
-        + `${lastPassCoverage} -> ${totalPeerProgress(peerProgressHighWater)} resolved `
+        + `${lastPassCoverage} -> ${passTracker.progress()} resolved `
         + 'summed across peers, '
         + `${Math.round(catchupPassNowMs() - passStartedMs)}ms; `
         + `${describeCoverage(diagnostics.sharedMemory.swmCoverage)}`);
     }
-    if (continuationPasses > 0) {
-      diagnostics.sharedMemory.continuationPasses = continuationPasses;
+    if (passTracker.continuationPasses() > 0) {
+      diagnostics.sharedMemory.continuationPasses = passTracker.continuationPasses();
     }
   }
 

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -788,12 +788,21 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       continuationPasses += 1;
       const passStartedMs = catchupPassNowMs();
       await runWalk(decision.peers, { sharedMemoryOnly: true, deadlineMs: passDeadlineMs });
-      // Coverage BEFORE and AFTER on one line: a pass whose elapsed time is large
-      // and whose coverage did not move is the signature of a job that is not
+      // Progress BEFORE and AFTER on one line: a pass whose elapsed time is large
+      // and whose progress did not move is the signature of a job that is not
       // converging, and that is not visible from either number alone.
+      //
+      // Labelled "summed across peers" because that is exactly what it is — a
+      // total over every peer's own high-water, spanning peers with different
+      // manifests. It sits beside `describeCoverage`, which is ONE whole record
+      // from ONE peer, and whose own doc warns that counts printed without their
+      // peer invite being read as a fleet total. Two different quantities on one
+      // line need the more surprising one named, or the reader will assume both
+      // describe the record at the end of the sentence.
       await logPassLine(`Catch-up SWM pass ${1 + continuationPasses} for `
-        + `"${request.contextGraphId}": ${decision.peers.length} capable peer(s), coverage `
-        + `${lastPassCoverage} -> ${totalPeerProgress(peerProgressHighWater)} resolved, `
+        + `"${request.contextGraphId}": ${decision.peers.length} capable peer(s), progress `
+        + `${lastPassCoverage} -> ${totalPeerProgress(peerProgressHighWater)} resolved `
+        + 'summed across peers, '
         + `${Math.round(catchupPassNowMs() - passStartedMs)}ms; `
         + `${describeCoverage(diagnostics.sharedMemory.swmCoverage)}`);
     }

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -182,7 +182,11 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   let deferredBackpressure = 0;
   let dataSynced = 0;
   let sharedMemorySynced = 0;
-  let deniedPeers = 0;
+  // Also DISTINCT peers, for the reason above — a peer that denies on every
+  // pass would otherwise be counted once per pass. The agent driver already
+  // models this as a set (`accessDeniedPeers`), so a scalar here additionally
+  // made the two drivers disagree on the semantics of a field they both return.
+  const deniedPeers = new Set<string>();
   let noProtocolPeers = 0;
 
   const cleanPlaneCompletions: NonNullable<CatchupJobResult['cleanPlaneCompletions']> = {
@@ -407,7 +411,10 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     return { peerId, fromAuthority, ...round };
   };
 
-  const accumulate = ({ peerId, durable, shared, fromAuthority }: PeerRound): void => {
+  const accumulate = (
+    { peerId, durable, shared, fromAuthority }: PeerRound,
+    isContinuationRound = false,
+  ): void => {
     let peerDenied = false;
     if (shared) {
       passTracker.recordPeerRound(
@@ -474,7 +481,30 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       diagnostics.sharedMemory.snapshotPlaneIncomplete += shared.snapshotPlaneIncomplete ?? 0;
       diagnostics.sharedMemory.replayPhaseBytesReceived += shared.replayPhaseBytesReceived ?? 0;
       diagnostics.sharedMemory.snapshotPhaseBytesReceived += shared.snapshotPhaseBytesReceived ?? 0;
-      deferredBackpressure += shared.deferredBackpressure ?? 0;
+      // The DIAGNOSTIC above counts every deferral, including continuation
+      // ones — that is the honest observability number. The JOB-LEVEL scalar
+      // below must not, and the reason is a behaviour change rather than a
+      // tidy-up.
+      //
+      // `deferredBackpressure > 0` makes the daemon route short-circuit BEFORE
+      // classification (`routes/context-graph.ts`), which is the only path to
+      // `classifyContextGraphCatchupReadiness`, the readiness write, the
+      // subscription state patch and `PROJECT_SYNCED`. Its premise — "an
+      // incomplete round has no readiness to inspect" — holds when the round
+      // was cut short. It is FALSE when pass 1 completed and only a
+      // best-effort EXTRA pass was refused capacity: nothing was lost, and the
+      // readiness pass 1 earned is real.
+      //
+      // Without this gate the continuation loop can demote an already
+      // successful job to `deferred` and discard its readiness, on exactly the
+      // workload #2050 targets — a large public graph under store pressure is
+      // precisely when admission defers. The pass budget's own rationale
+      // anticipates it ("sized so at least two extra passes fit even when a
+      // peer's plane is deferred"), so this is a designed-for state, not an
+      // edge case.
+      if (!isContinuationRound) {
+        deferredBackpressure += shared.deferredBackpressure ?? 0;
+      }
       // Coverage is the one field here that is SELECTED, not summed. Summing —
       // or taking independent maxima over resolved and total — would let a peer
       // reporting 178/250 and a peer reporting 200/200 combine into 200/250: a
@@ -504,7 +534,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     }
 
     if (peerDenied) {
-      deniedPeers += 1;
+      deniedPeers.add(peerId);
     }
 
     if (catchupPeerResponded(durable, shared)) {
@@ -590,7 +620,9 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       Math.min(CATCHUP_MAX_CONCURRENT_PEER_SYNCS, wave.length),
       (peerId) => syncPeer(peerId, pass),
     );
-    for (const round of rounds) accumulate(round);
+    // `sharedMemoryOnly` is set only by the continuation loop; pass 1 is the
+    // mandatory round. See the deferral gate inside `accumulate`.
+    for (const round of rounds) accumulate(round, pass.sharedMemoryOnly);
     settleAuthorityForWave();
     if (CATCHUP_STOP_ON_PROOF && authorityProvedEverything()) break;
   }
@@ -691,8 +723,8 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     deferredBackpressure,
     dataSynced,
     sharedMemorySynced,
-    denied: deniedPeers > 0,
-    deniedPeers,
+    denied: deniedPeers.size > 0,
+    deniedPeers: deniedPeers.size,
     cleanPlaneCompletions,
     diagnostics,
   };

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -14,7 +14,7 @@ import {
   type SwmSnapshotCoverage,
   type SyncPeerResolution,
 } from '@origintrail-official/dkg-agent';
-import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
+import { PROTOCOL_SYNC, createOperationContext } from '@origintrail-official/dkg-core';
 
 const SYNC_PROTOCOL_CHECK_ATTEMPTS = 3;
 const SYNC_PROTOCOL_CHECK_DELAY_MS = 500;
@@ -1142,6 +1142,16 @@ class WorkerCatchupRunner implements CatchupRunner {
             ),
           },
         );
+      }
+      case 'logCatchupPass': {
+        // The pass loop runs inside the Worker, which has no logger of its own,
+        // so the line is FORMATTED there — where the coverage records live — and
+        // only emitted here. Deliberately `info`: an operator diagnosing a job
+        // that will not converge needs this without raising the log level, and a
+        // catch-up emits at most a handful of these.
+        const [message] = args as [string];
+        agent.log.info(createOperationContext('sync'), message);
+        return null;
       }
       case 'finalizeCatchup': {
         const [contextGraphId] = args as [string, number, number];

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -7,6 +7,7 @@ import {
   normalizeDurableSyncResult,
   normalizeSyncAdmissionSource,
   type DKGAgent,
+  type CatchupPassDecisionReason,
   type DurableProgressSummary,
   type DurableSyncDiagnostics,
   type DurableSyncResult,
@@ -120,6 +121,11 @@ export interface CatchupJobResult {
       snapshotPlaneIncomplete: number;
       /** Extra passes over the peer set beyond the first. */
       continuationPasses: number;
+      /**
+       * Why the bounded repeat stopped, as the policy's own closed union — so a
+       * new reason cannot reach the terminal message unnoticed.
+       */
+      continuationStopReason?: CatchupPassDecisionReason;
       /**
        * `bytesReceived` split into its replay half (metadata + aggregate data,
        * which every pass re-fetches in full) and its useful half (snapshot

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -10,6 +10,7 @@ import {
   type DurableProgressSummary,
   type DurableSyncDiagnostics,
   type DurableSyncResult,
+  type SwmSnapshotCoverage,
   type SyncPeerResolution,
 } from '@origintrail-official/dkg-agent';
 import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
@@ -109,6 +110,24 @@ export interface CatchupJobResult {
       /** A resolvable curator never cleanly answered this plane; see
        * `catchupPlaneProvenByUnanimousEmpty`. */
       authorityUnanswered?: boolean;
+      /**
+       * Public-SWM snapshot coverage for this graph, selected WHOLE from one
+       * peer round by `selectSwmSnapshotCoverage`. The counts, the peer they
+       * are attributed to and the missing sample are never mixed across peers.
+       */
+      swmCoverage?: SwmSnapshotCoverage;
+      /** Snapshot phases that yielded on the local clock — see the agent-side field. */
+      snapshotPlaneIncomplete: number;
+      /** Extra passes over the peer set beyond the first. */
+      continuationPasses: number;
+      /**
+       * `bytesReceived` split into its replay half (metadata + aggregate data,
+       * which every pass re-fetches in full) and its useful half (snapshot
+       * content), so the cost of repeating the walk stays measurable instead of
+       * being merged into one scalar. The two sum to `bytesReceived`.
+       */
+      replayPhaseBytesReceived: number;
+      snapshotPhaseBytesReceived: number;
     };
   };
 }

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -1,4 +1,8 @@
-import type { DKGAgent, SwmSnapshotCoverage } from '@origintrail-official/dkg-agent';
+import type {
+  CatchupPassDecisionReason,
+  DKGAgent,
+  SwmSnapshotCoverage,
+} from '@origintrail-official/dkg-agent';
 import { DKGEvent, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import type {
   ContextGraphReadinessProvenance,
@@ -26,6 +30,29 @@ export const CONTEXT_GRAPH_READINESS_VERSION = 1;
 const SWM_SHORTFALL_SAMPLE_LIMIT = 10;
 
 /**
+ * Why the continuation loop stopped, in operator-facing words.
+ *
+ * An exhaustive `Record` rather than a `switch` with a default: the vocabulary
+ * is closed precisely so this message stays testable, and a new reason should
+ * fail the build here rather than silently render nothing.
+ *
+ * `coverage-stalled` deliberately outranks `budget-exhausted` in the policy, so
+ * a run that stalled AND ran out of time reports the stall. Its wording must
+ * therefore never mention time: "ran out of time" would send an operator to
+ * raise a budget that buys nothing, which is the precise misdirection that
+ * precedence exists to prevent.
+ */
+const SWM_STOP_REASON_TEXT: Record<CatchupPassDecisionReason, string> = {
+  // Not a stop at all — the loop was still willing to continue.
+  continue: '',
+  'plane-proven': 'the plane was proven by another peer',
+  'coverage-stalled': 'a further pass stopped making progress, so more passes would not help',
+  'no-capable-peers': 'no remaining peer reported holding the missing snapshots',
+  'max-passes-reached': 'the pass limit was reached',
+  'budget-exhausted': 'the time budget was exhausted',
+};
+
+/**
  * The shared-memory shortfall clause appended to the incomplete-progress
  * terminal message.
  *
@@ -43,6 +70,7 @@ const SWM_SHORTFALL_SAMPLE_LIMIT = 10;
 export function swmShortfallClause(
   coverage: SwmSnapshotCoverage | undefined,
   continuationPasses: number | undefined,
+  stopReason?: CatchupPassDecisionReason,
 ): string {
   if (!coverage || coverage.missingCount <= 0) return '';
 
@@ -54,11 +82,22 @@ export function swmShortfallClause(
     ? `, including ${sample.join(', ')}${unnamed > 0 ? ` (+${unnamed} more)` : ''}`
     : '';
   // An incomplete manifest means the denominator is only what this peer managed
-  // to advertise before its metadata phase ran out, not what the graph holds.
-  // Presenting it as the total would understate the shortfall.
+  // to advertise before its metadata phase ran out, not what the graph holds —
+  // presenting it as the total would understate the shortfall. It is also why
+  // this peer got no further passes: the capability gate requires a complete
+  // manifest, because a truncated round advances `snapshotsResolved` against a
+  // truncated denominator while materializing nothing. Both facts belong here;
+  // "the count is a lower bound" and "we stopped asking" are different things
+  // for the person reading it.
   const lowerBound = coverage.manifestComplete
     ? ''
-    : ` The peer's snapshot manifest was itself incomplete, so ${coverage.snapshotsTotal} is a lower bound.`;
+    : ` The peer's snapshot manifest was itself incomplete, so ${coverage.snapshotsTotal}`
+      + ' is a lower bound and that peer was not retried.';
+  // Absent whenever the continuation loop did not run — shared memory was not
+  // requested, or no decision was reached.
+  const stopped = stopReason && SWM_STOP_REASON_TEXT[stopReason]
+    ? ` Continuation stopped because ${SWM_STOP_REASON_TEXT[stopReason]}.`
+    : '';
 
   // Scoped to "Shared memory" throughout: continuation passes repeat the
   // shared-memory peer walk only, and the wording must not suggest the durable
@@ -66,7 +105,7 @@ export function swmShortfallClause(
   return ` (Shared memory: ${coverage.snapshotsResolved}/${coverage.snapshotsTotal}`
     + ` snapshots verified from peer …${coverage.peerIdSuffix}`
     + ` after ${passes} ${passes === 1 ? 'pass' : 'passes'};`
-    + ` ${coverage.missingCount} outstanding${named}.)${lowerBound}`;
+    + ` ${coverage.missingCount} outstanding${named}.)${lowerBound}${stopped}`;
 }
 
 export type ContextGraphReadinessStore = Pick<
@@ -433,6 +472,7 @@ export function classifyContextGraphCatchupReadiness(input: {
           + swmShortfallClause(
             result.diagnostics?.sharedMemory?.swmCoverage,
             result.diagnostics?.sharedMemory?.continuationPasses,
+            result.diagnostics?.sharedMemory?.continuationStopReason,
           );
       } else if (input.isPrivate && missingGraphProof) {
         error = 'No authorized context-graph peer delivered verified durable or shared-memory data — empty or metadata-only responses cannot prove a private graph is fully synchronized, and the curator may be offline.';

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -73,13 +73,19 @@ export function swmShortfallClause(
   stopReason?: CatchupPassDecisionReason,
 ): string {
   if (!coverage) return '';
-  // TWO independent shortfalls, and gating on retrieval alone went silent on
-  // the second. `missingCount` measures FETCH completeness only: a round can
-  // retrieve every declared ref and still fail to WRITE some of them — a store
-  // error inside the KA write lock, which is the G7 failure class and is
-  // likeliest under exactly the store pressure that produces incomplete rounds.
-  // Gating on `missingCount` alone printed nothing at all about shared memory
-  // in the one case where shared memory was the thing that failed.
+  // `missingCount` is MATERIALIZATION completeness, not fetch completeness: the
+  // producer derives it as `snapshotsTotal - min(materializedRefCount, total)`,
+  // so a ref that was fetched and digest-verified but failed to write to the
+  // store raises it exactly like a ref that never arrived. The two are NOT
+  // independent axes and must never be added together — `missingCount` already
+  // includes every unwritten ref.
+  //
+  // `materializationFailures` is kept as the CAUSE indicator: it says the
+  // shortfall is a store problem rather than a network one, which is the whole
+  // reason the distinction is worth printing. It counts failing DESCRIPTORS
+  // while `missingCount` counts REFS, so the two are not in the same unit and
+  // neither is a subset count of the other — phrase them as separate facts, and
+  // never as "N of which".
   // Defaulted, not trusted: this record crosses a worker RPC boundary, and an
   // absent counter must read as "none known" rather than making `<= 0` false
   // and forcing a clause onto a round with nothing to report.
@@ -93,15 +99,21 @@ export function swmShortfallClause(
   const named = sample.length > 0
     ? `, including ${sample.join(', ')}${unnamed > 0 ? ` (+${unnamed} more)` : ''}`
     : '';
-  // The two failures are reported as separate clauses because they send an
-  // operator to different places: a retrieval shortfall is a network and
-  // peer-set problem, a write shortfall is a store problem. Conflating them
-  // wastes the hour the stop-reason wording exists to save.
-  const retrieval = coverage.missingCount > 0
-    ? ` ${coverage.missingCount} not retrieved${named}`
+  // Reported as separate clauses because they send an operator to different
+  // places: the outstanding count is what is still missing locally, the write
+  // failures say the store is why. Conflating them wastes the hour the
+  // stop-reason wording exists to save.
+  //
+  // "not materialized", NOT "not retrieved": these refs are the ones absent from
+  // the local store, and under a store fault they were fetched and digest-valid
+  // before they failed. Naming a ref that arrived intact as "not retrieved"
+  // sends the reader to the network and the peer set when the fault is entirely
+  // local — the one misdirection this clause exists to prevent.
+  const outstanding = coverage.missingCount > 0
+    ? ` ${coverage.missingCount} not materialized${named}`
     : '';
   const writes = failedToWrite > 0
-    ? `${retrieval ? ';' : ''} ${failedToWrite} retrieved but not written to the store`
+    ? `${outstanding ? ';' : ''} ${failedToWrite} store write failure(s)`
     : '';
   // An incomplete manifest means the denominator is only what this peer managed
   // to advertise before its metadata phase ran out, not what the graph holds —
@@ -124,15 +136,18 @@ export function swmShortfallClause(
   // Scoped to "Shared memory" throughout: continuation passes repeat the
   // shared-memory peer walk only, and the wording must not suggest the durable
   // plane was retried.
-  // "fetched", NOT "verified": `snapshotsResolved` counts refs retrieved and
-  // digest-valid in the blob cache, which is not the same as Knowledge Assets
-  // WRITTEN. Rendering it as "verified" would report "250/250 snapshots
-  // verified" on a graph where every write failed and nothing landed — the
-  // flattering direction, and undetectable by the reader.
+  // "materialized", NOT "fetched": `snapshotsResolved` counts refs whose
+  // Knowledge Assets are WRITTEN and locally visible, not refs sitting valid in
+  // the blob cache. Rendering it as "fetched" reported "250/250 snapshots
+  // fetched" on a graph where every write failed and nothing landed — the
+  // flattering direction, and undetectable by the reader. The word has to track
+  // the producer: `snapshotsResolved` was redefined to mean materialized so the
+  // capability gate could not be fooled by a cached-but-unwritten round, and
+  // this sentence is the same number's operator-facing face.
   return ` (Shared memory: ${coverage.snapshotsResolved}/${coverage.snapshotsTotal}`
-    + ` snapshots fetched from peer …${coverage.peerIdSuffix}`
+    + ` snapshots materialized from peer …${coverage.peerIdSuffix}`
     + ` after ${passes} ${passes === 1 ? 'pass' : 'passes'};`
-    + `${retrieval}${writes}.)${lowerBound}${stopped}`;
+    + `${outstanding}${writes}.)${lowerBound}${stopped}`;
 }
 
 export type ContextGraphReadinessStore = Pick<

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -30,6 +30,45 @@ export const CONTEXT_GRAPH_READINESS_VERSION = 1;
 const SWM_SHORTFALL_SAMPLE_LIMIT = 10;
 
 /**
+ * Rendered length of ONE identifier in that clause.
+ *
+ * Bounding the count is not enough: each identifier is a literal a public peer
+ * put in its own SWM metadata, and the producer only trims it. Ten refs are ten
+ * peer-chosen strings of any length.
+ */
+const SWM_SHORTFALL_REF_MAX_CHARS = 96;
+
+/**
+ * Make one peer-supplied snapshot ref safe to put in an operator-facing string.
+ *
+ * These identifiers are UNTRUSTED. They arrive as `dkg:publicSnapshotRef`
+ * literals in a remote peer's shared-memory metadata, and the producer applies
+ * only `.trim()`. Rendered verbatim into the terminal error — which surfaces
+ * through the API and the node UI — a peer could:
+ *
+ *   - forge structure, e.g. a ref containing "\nSync denied by 3 remote peers",
+ *     which reads as an additional line of our own diagnostics;
+ *   - inflate the message without bound, which matters here specifically because
+ *     oversized peer literals are a phenomenon this codebase has already met on
+ *     the sync path, not a hypothetical.
+ *
+ * So: fold every C0/C1 control character (newlines and tabs included) to U+FFFD
+ * rather than dropping it — dropping would let "a\nb" masquerade as the real ref
+ * "ab" — then bound the length with a visible marker so a truncated identifier
+ * cannot be mistaken for a complete one.
+ *
+ * Sanitising at the RENDERER is deliberate: it is the last point before the
+ * string reaches an operator, so it holds regardless of which producer path
+ * filled the sample or what a future one does.
+ */
+function sanitizeSnapshotRef(ref: string): string {
+  const flattened = ref.replace(/[\u0000-\u001F\u007F-\u009F]/gu, '\uFFFD');
+  return flattened.length > SWM_SHORTFALL_REF_MAX_CHARS
+    ? `${flattened.slice(0, SWM_SHORTFALL_REF_MAX_CHARS)}\u2026(truncated)`
+    : flattened;
+}
+
+/**
  * Why the continuation loop stopped, in operator-facing words.
  *
  * An exhaustive `Record` rather than a `switch` with a default: the vocabulary
@@ -94,7 +133,13 @@ export function swmShortfallClause(
 
   // `continuationPasses` counts the REPEATS, so the walk itself is one more.
   const passes = (continuationPasses ?? 0) + 1;
-  const sample = coverage.missingSample.slice(0, SWM_SHORTFALL_SAMPLE_LIMIT);
+  // Sanitized per identifier, not merely capped in count. See
+  // `sanitizeSnapshotRef`: these are untrusted peer literals. Mapping after the
+  // slice keeps `unnamed` arithmetic on the SAMPLE COUNT, which sanitizing
+  // cannot change — so the "(+N more)" accounting is unaffected by construction.
+  const sample = coverage.missingSample
+    .slice(0, SWM_SHORTFALL_SAMPLE_LIMIT)
+    .map(sanitizeSnapshotRef);
   const unnamed = coverage.missingCount - sample.length;
   const named = sample.length > 0
     ? `, including ${sample.join(', ')}${unnamed > 0 ? ` (+${unnamed} more)` : ''}`

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -62,17 +62,29 @@ const SWM_STOP_REASON_TEXT: Record<CatchupPassDecisionReason, string> = {
  * always belong to the manifest the counts came from.
  *
  * Returns `''` whenever there is nothing to add, which is what keeps the base
- * sentence byte-identical on every other path. Two cases qualify: no snapshot
- * inventory was observed at all, and a selected manifest that was fully
- * resolved — in the latter the shortfall lies on another plane, and reporting
- * "0 outstanding" beside an `unreachable` verdict would misdirect the reader.
+ * sentence byte-identical on every other path: no snapshot inventory was
+ * observed, or the selected manifest was fully retrieved AND fully written — in
+ * which case the shortfall lies on another plane, and reporting "0 outstanding"
+ * beside an `unreachable` verdict would misdirect the reader.
  */
 export function swmShortfallClause(
   coverage: SwmSnapshotCoverage | undefined,
   continuationPasses: number | undefined,
   stopReason?: CatchupPassDecisionReason,
 ): string {
-  if (!coverage || coverage.missingCount <= 0) return '';
+  if (!coverage) return '';
+  // TWO independent shortfalls, and gating on retrieval alone went silent on
+  // the second. `missingCount` measures FETCH completeness only: a round can
+  // retrieve every declared ref and still fail to WRITE some of them — a store
+  // error inside the KA write lock, which is the G7 failure class and is
+  // likeliest under exactly the store pressure that produces incomplete rounds.
+  // Gating on `missingCount` alone printed nothing at all about shared memory
+  // in the one case where shared memory was the thing that failed.
+  // Defaulted, not trusted: this record crosses a worker RPC boundary, and an
+  // absent counter must read as "none known" rather than making `<= 0` false
+  // and forcing a clause onto a round with nothing to report.
+  const failedToWrite = coverage.materializationFailures ?? 0;
+  if (coverage.missingCount <= 0 && failedToWrite <= 0) return '';
 
   // `continuationPasses` counts the REPEATS, so the walk itself is one more.
   const passes = (continuationPasses ?? 0) + 1;
@@ -80,6 +92,16 @@ export function swmShortfallClause(
   const unnamed = coverage.missingCount - sample.length;
   const named = sample.length > 0
     ? `, including ${sample.join(', ')}${unnamed > 0 ? ` (+${unnamed} more)` : ''}`
+    : '';
+  // The two failures are reported as separate clauses because they send an
+  // operator to different places: a retrieval shortfall is a network and
+  // peer-set problem, a write shortfall is a store problem. Conflating them
+  // wastes the hour the stop-reason wording exists to save.
+  const retrieval = coverage.missingCount > 0
+    ? ` ${coverage.missingCount} not retrieved${named}`
+    : '';
+  const writes = failedToWrite > 0
+    ? `${retrieval ? ';' : ''} ${failedToWrite} retrieved but not written to the store`
     : '';
   // An incomplete manifest means the denominator is only what this peer managed
   // to advertise before its metadata phase ran out, not what the graph holds —
@@ -102,10 +124,15 @@ export function swmShortfallClause(
   // Scoped to "Shared memory" throughout: continuation passes repeat the
   // shared-memory peer walk only, and the wording must not suggest the durable
   // plane was retried.
+  // "fetched", NOT "verified": `snapshotsResolved` counts refs retrieved and
+  // digest-valid in the blob cache, which is not the same as Knowledge Assets
+  // WRITTEN. Rendering it as "verified" would report "250/250 snapshots
+  // verified" on a graph where every write failed and nothing landed — the
+  // flattering direction, and undetectable by the reader.
   return ` (Shared memory: ${coverage.snapshotsResolved}/${coverage.snapshotsTotal}`
-    + ` snapshots verified from peer …${coverage.peerIdSuffix}`
+    + ` snapshots fetched from peer …${coverage.peerIdSuffix}`
     + ` after ${passes} ${passes === 1 ? 'pass' : 'passes'};`
-    + ` ${coverage.missingCount} outstanding${named}.)${lowerBound}${stopped}`;
+    + `${retrieval}${writes}.)${lowerBound}${stopped}`;
 }
 
 export type ContextGraphReadinessStore = Pick<

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -1,4 +1,4 @@
-import type { DKGAgent } from '@origintrail-official/dkg-agent';
+import type { DKGAgent, SwmSnapshotCoverage } from '@origintrail-official/dkg-agent';
 import { DKGEvent, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import type {
   ContextGraphReadinessProvenance,
@@ -17,6 +17,57 @@ import {
 export { catchupPlaneCompletedWithoutFailure } from './catchup-runner.js';
 
 export const CONTEXT_GRAPH_READINESS_VERSION = 1;
+
+/**
+ * Identifiers named in the terminal shortfall clause. The producer already caps
+ * the sample; this bounds the SENTENCE independently, so a future producer
+ * change cannot silently grow an operator-facing error string.
+ */
+const SWM_SHORTFALL_SAMPLE_LIMIT = 10;
+
+/**
+ * The shared-memory shortfall clause appended to the incomplete-progress
+ * terminal message.
+ *
+ * Every figure comes from ONE {@link SwmSnapshotCoverage} record — the counts,
+ * the peer they are attributed to, and the sample — so the sentence can never
+ * describe a graph state no peer reported, and the named Knowledge Assets
+ * always belong to the manifest the counts came from.
+ *
+ * Returns `''` whenever there is nothing to add, which is what keeps the base
+ * sentence byte-identical on every other path. Two cases qualify: no snapshot
+ * inventory was observed at all, and a selected manifest that was fully
+ * resolved — in the latter the shortfall lies on another plane, and reporting
+ * "0 outstanding" beside an `unreachable` verdict would misdirect the reader.
+ */
+export function swmShortfallClause(
+  coverage: SwmSnapshotCoverage | undefined,
+  continuationPasses: number | undefined,
+): string {
+  if (!coverage || coverage.missingCount <= 0) return '';
+
+  // `continuationPasses` counts the REPEATS, so the walk itself is one more.
+  const passes = (continuationPasses ?? 0) + 1;
+  const sample = coverage.missingSample.slice(0, SWM_SHORTFALL_SAMPLE_LIMIT);
+  const unnamed = coverage.missingCount - sample.length;
+  const named = sample.length > 0
+    ? `, including ${sample.join(', ')}${unnamed > 0 ? ` (+${unnamed} more)` : ''}`
+    : '';
+  // An incomplete manifest means the denominator is only what this peer managed
+  // to advertise before its metadata phase ran out, not what the graph holds.
+  // Presenting it as the total would understate the shortfall.
+  const lowerBound = coverage.manifestComplete
+    ? ''
+    : ` The peer's snapshot manifest was itself incomplete, so ${coverage.snapshotsTotal} is a lower bound.`;
+
+  // Scoped to "Shared memory" throughout: continuation passes repeat the
+  // shared-memory peer walk only, and the wording must not suggest the durable
+  // plane was retried.
+  return ` (Shared memory: ${coverage.snapshotsResolved}/${coverage.snapshotsTotal}`
+    + ` snapshots verified from peer …${coverage.peerIdSuffix}`
+    + ` after ${passes} ${passes === 1 ? 'pass' : 'passes'};`
+    + ` ${coverage.missingCount} outstanding${named}.)${lowerBound}`;
+}
 
 export type ContextGraphReadinessStore = Pick<
   DashboardDB,
@@ -373,7 +424,16 @@ export function classifyContextGraphCatchupReadiness(input: {
     if (missingGraphProof || missingRequestedSharedMemory) {
       jobStatus = 'unreachable';
       if (madeIncompleteProgress) {
-        error = 'Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.';
+        // The base sentence is byte-identical to what it has always been; the
+        // shortfall is APPENDED. This is the r26 terminal — "some verified data
+        // landed, the plane is still unready" — and it was the one message that
+        // could not say WHAT was missing even though the answer was computable
+        // in memory at the moment the round gave up.
+        error = 'Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.'
+          + swmShortfallClause(
+            result.diagnostics?.sharedMemory?.swmCoverage,
+            result.diagnostics?.sharedMemory?.continuationPasses,
+          );
       } else if (input.isPrivate && missingGraphProof) {
         error = 'No authorized context-graph peer delivered verified durable or shared-memory data — empty or metadata-only responses cannot prove a private graph is fully synchronized, and the curator may be offline.';
       } else if (input.isPrivate) {

--- a/packages/cli/test/catchup-runner-worker-continuation-deferral.test.ts
+++ b/packages/cli/test/catchup-runner-worker-continuation-deferral.test.ts
@@ -1,0 +1,160 @@
+// A best-effort CONTINUATION pass must never demote a job that already
+// succeeded, and denial must count DISTINCT peers once the walk can repeat.
+//
+// Both of these are consequences of making the walk repeatable, and neither is
+// visible in the terminal record — they are visible only in the two scalars the
+// daemon route branches on. See the deferral gate in `accumulate`.
+import {
+  durableCatchupResult as durableResult,
+  runWorkerCatchup,
+  sharedCatchupResult as sharedResult,
+} from './helpers/catchup-runner-worker-test-harness.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A locally-deferred plane is RETRIED first, and only surfaces as
+// `deferredBackpressure` once its admission-retry budget expires
+// (`CATCHUP_BACKPRESSURE_MAX_WAIT_MS`, 180 s by default). Left at the default
+// these rows sit in that wait and die on the vitest timeout — which would read
+// as a failing assertion while proving nothing. Collapsing the budget to zero
+// makes "pressure never cleared" immediate, which is the state the daemon route
+// actually branches on.
+beforeEach(() => {
+  vi.stubEnv('DKG_CATCHUP_BACKPRESSURE_MAX_WAIT_MS', '0');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('#2050 continuation passes must not demote a successful job', () => {
+  const CG = 'continuation-deferral-cg';
+  const PEER = 'peer-continuation-0001';
+
+  /**
+   * A round that resolved part of its manifest and did NOT complete cleanly.
+   *
+   * `failedPhases: 1` is load-bearing: without it the shared plane is proven by
+   * data and the loop stops at `plane-proven` BEFORE the capability gate is
+   * consulted, so no continuation pass would run at all and the row would pass
+   * for a reason unrelated to what it claims.
+   *
+   * `manifestComplete: true` with `resolved < total` is what makes the peer
+   * CAPABLE — the peer's own statement that it holds a ref we lack.
+   */
+  function partialSharedRound(resolved: number, total: number) {
+    return {
+      ...sharedResult(),
+      failedPhases: 1,
+      swmCoverage: {
+        contextGraphId: CG,
+        peerIdSuffix: PEER.slice(-8),
+        snapshotsResolved: resolved,
+        snapshotsTotal: total,
+        manifestComplete: true,
+        missingCount: total - resolved,
+        missingSample: [],
+        materializationFailures: 0,
+      },
+    };
+  }
+
+  it('does NOT report job-level backpressure when only a CONTINUATION pass is deferred', async () => {
+    // Pass 1 does its mandatory work with no deferral. The extra pass — which
+    // the job never needed — is refused capacity by the local scheduler.
+    const sharedCalls: string[] = [];
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory': {
+            sharedCalls.push(String(args[0]));
+            return sharedCalls.length === 1
+              ? partialSharedRound(2, 3)
+              : { ...partialSharedRound(2, 3), deferredBackpressure: 1 };
+          }
+          default:
+            return null;
+        }
+      },
+    );
+
+    // The continuation pass really ran and really was deferred — without this
+    // the row proves nothing, because a job that never reached pass 2 trivially
+    // reports zero deferrals.
+    expect(sharedCalls).toHaveLength(2);
+    expect(result.diagnostics?.sharedMemory?.deferredBackpressure).toBe(1);
+
+    // ...and yet the JOB-LEVEL scalar stays 0. This is the whole property:
+    // `deferredBackpressure > 0` makes the daemon route short-circuit before
+    // classification, which is the only path to the readiness write, the
+    // subscription patch and PROJECT_SYNCED. A refused OPTIONAL pass must not
+    // discard the readiness that pass 1 legitimately earned.
+    expect(result.deferredBackpressure).toBe(0);
+  });
+
+  it('DOES report job-level backpressure when the MANDATORY first pass is deferred', async () => {
+    // The negative control, and the reason the row above is not vacuous: gating
+    // on the wrong thing (or on nothing) would make both rows agree. Here the
+    // deferral happens in pass 1, where the route's premise — "an incomplete
+    // round has no readiness to inspect" — is true and must still hold.
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory':
+            return { ...sharedResult(), deferredBackpressure: 1 };
+          default:
+            return null;
+        }
+      },
+    );
+
+    expect(result.deferredBackpressure).toBe(1);
+  });
+
+  it('counts DISTINCT denied peers, not peer-passes', async () => {
+    // Denial from inside the snapshot walk still attaches progress, so the peer
+    // stays capable and is contacted again. A scalar `+= 1` per round counted
+    // the same peer twice — the drift the review predicted, and a disagreement
+    // with the agent driver, which already models this as a set.
+    const sharedCalls: string[] = [];
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory': {
+            sharedCalls.push(String(args[0]));
+            return { ...partialSharedRound(2, 3), deniedPhases: 1 };
+          }
+          default:
+            return null;
+        }
+      },
+    );
+
+    // One peer, contacted on two passes, denying on both.
+    expect(sharedCalls).toHaveLength(2);
+    expect(result.deniedPeers).toBe(1);
+    expect(result.denied).toBe(true);
+  });
+});

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -14,12 +14,16 @@
 //     transfers one payload instead of one per peer. A non-authoritative peer's
 //     clean round settles nothing — it can neither stop the walk nor narrow a
 //     later peer to one plane.
+import {
+  durableCatchupResult as durableResult,
+  runWorkerCatchup,
+  sharedCatchupResult as sharedResult,
+} from './helpers/catchup-runner-worker-test-harness.js';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import {
   CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
   FOREGROUND_CATCHUP_SYNC_PRIORITY,
 } from '@origintrail-official/dkg-agent';
-import type { CatchupJobResult, CatchupRunRequest } from '../src/catchup-runner.js';
 
 // The foreground backpressure budget is wall-clock (default 180s). Shrink it
 // for this file so the persistently-deferred case settles quickly; the exact
@@ -48,109 +52,7 @@ afterAll(() => {
   else process.env.DKG_CATCHUP_BACKPRESSURE_MAX_WAIT_MS = previousCATCHUPBACKPRESSUREMAXWAITMS;
 });
 
-// The worker impl wires itself to `parentPort` at module load, so a
-// controllable port has to be in place BEFORE the module is imported.
-// Everything else from node:worker_threads stays real.
-const fakeParentPort = vi.hoisted(() => {
-  const messageListeners: Array<(message: any) => void> = [];
-  const port = {
-    on(event: string, listener: (message: any) => void) {
-      if (event === 'message') messageListeners.push(listener);
-    },
-    /** Set per run by `runWorkerCatchup`; receives what the impl posts back. */
-    onPosted: undefined as ((message: any) => void) | undefined,
-    postMessage(message: any) {
-      port.onPosted?.(message);
-    },
-    emitMessage(message: any) {
-      for (const listener of messageListeners) listener(message);
-    },
-  };
-  return port;
-});
-
-vi.mock('node:worker_threads', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('node:worker_threads')>()),
-  parentPort: fakeParentPort,
-}));
-
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-function durableResult() {
-  return {
-    insertedTriples: 1,
-    complete: true,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 1,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 1,
-    bytesReceived: 10,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 1,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    metaOnlyResponses: 0,
-    dataRejectedMissingMeta: 0,
-    rejectedKcs: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    deniedPhases: 0,
-    deferredBackpressure: 0,
-  };
-}
-
-function sharedResult() {
-  return {
-    insertedTriples: 1,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 1,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 1,
-    bytesReceived: 10,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 1,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    droppedDataTriples: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    deniedPhases: 0,
-    deferredBackpressure: 0,
-  };
-}
-
-type InvokeHandler = (method: string, args: unknown[]) => Promise<unknown>;
-
-let nextRunId = 1;
-
-async function runWorkerCatchup(request: CatchupRunRequest, handler: InvokeHandler): Promise<CatchupJobResult> {
-  // The first call loads the module, which registers its message listener on
-  // the mocked parentPort; later calls reuse it (distinct runIds).
-  await import('../src/catchup-runner-worker-impl.js');
-  const runId = nextRunId++;
-  return new Promise<CatchupJobResult>((resolve, reject) => {
-    fakeParentPort.onPosted = (message: any) => {
-      if (message.type === 'invoke') {
-        handler(message.method, message.args).then(
-          (result) => fakeParentPort.emitMessage({ type: 'invoke-result', invokeId: message.invokeId, result }),
-          (error: unknown) => fakeParentPort.emitMessage({
-            type: 'invoke-result',
-            invokeId: message.invokeId,
-            error: error instanceof Error ? error.message : String(error),
-          }),
-        );
-        return;
-      }
-      if (message.type === 'run-result' && message.runId === runId) {
-        if (message.error) reject(new Error(message.error));
-        else resolve(message.result as CatchupJobResult);
-      }
-    };
-    fakeParentPort.emitMessage({ type: 'run', runId, request });
-  });
-}
 
 /**
  * SCOPE OF THESE TESTS — read before trusting a green run.
@@ -1870,6 +1772,62 @@ describe('#2050 continuation loop — a failed-but-productive pass earns another
     // `peersNotAttempted` negative once a pass repeated.
     expect(result.peersTried).toBe(1);
     expect(result.peersNotAttempted).toBe(0);
+  });
+
+  it('still runs a selected SWM continuation after authority proof', async () => {
+    const CURATOR = 'peer-curator-0001';
+    const OTHER = 'peer-capable-0002';
+    const sharedCalls: string[] = [];
+    const durableCalls: string[] = [];
+    let otherSharedCalls = 0;
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        const peerId = String(args[0]);
+        switch (method) {
+          case 'prepareCatchup':
+            return {
+              authoritativePeerId: CURATOR,
+              isPrivateContextGraph: false,
+              // Same opening wave: the authority can prove SWM while the other
+              // peer reports the still-capable record the next pass must retry.
+              peerIds: [OTHER, CURATOR],
+              connectedPeers: 2,
+            };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            durableCalls.push(peerId);
+            return {
+              ...durableResult(),
+              complete: false,
+              insertedTriples: 0,
+              fetchedDataTriples: 0,
+              insertedDataTriples: 0,
+              failedPhases: 1,
+            };
+          case 'syncSharedMemory':
+            sharedCalls.push(peerId);
+            if (peerId === CURATOR) return sharedResult();
+            otherSharedCalls += 1;
+            return otherSharedCalls === 1
+              ? partialSharedRound(2, 3)
+              : partialSharedRound(3, 3);
+          default:
+            return null;
+        }
+      },
+    );
+
+    expect(sharedCalls.filter((peerId) => peerId === CURATOR)).toHaveLength(1);
+    expect(sharedCalls.filter((peerId) => peerId === OTHER)).toHaveLength(2);
+    expect(durableCalls.filter((peerId) => peerId === OTHER)).toHaveLength(1);
+    expect(result.diagnostics?.sharedMemory?.swmCoverage).toMatchObject({
+      snapshotsResolved: 3,
+      snapshotsTotal: 3,
+    });
+    expect(result.diagnostics?.sharedMemory?.continuationPasses).toBe(1);
   });
 
   it('emits one per-pass log line carrying the coverage transition', async () => {

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -1866,6 +1866,54 @@ describe('#2050 continuation loop — a failed-but-productive pass earns another
     expect(result.peersNotAttempted).toBe(0);
   });
 
+  it('emits one per-pass log line carrying the coverage transition', async () => {
+    // The per-pass line is the only PER-PASS observability an operator gets:
+    // the terminal record reports the FINAL state, so without it a job that
+    // converged in four passes is indistinguishable from one that converged in
+    // one. It travels as a fire-and-forget RPC whose rejection is deliberately
+    // swallowed, so a line that stops being emitted fails completely silently
+    // — which is exactly the shape that needs a row rather than a reader.
+    const sharedCalls: string[] = [];
+    const passLines: string[] = [];
+
+    await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory': {
+            sharedCalls.push(String(args[0]));
+            return sharedCalls.length === 1
+              ? partialSharedRound(2, 3)
+              : partialSharedRound(3, 3);
+          }
+          case 'logCatchupPass':
+            passLines.push(String(args[0]));
+            return null;
+          default:
+            return null;
+        }
+      },
+    );
+
+    // Two shared rounds ran, so exactly one CONTINUATION pass was logged —
+    // numbered 2, because the first round is not a continuation.
+    const continuationLines = passLines.filter((line) => line.startsWith('Catch-up SWM pass 2'));
+    expect(continuationLines).toHaveLength(1);
+
+    // The TRANSITION, not just the endpoint. A line reporting only the final
+    // `3` could not distinguish a pass that advanced coverage from one that ran
+    // and achieved nothing — which is the single fact this line exists to give
+    // an operator.
+    expect(continuationLines[0]).toContain('2 -> 3');
+    expect(continuationLines[0]).toContain(CG);
+  });
+
   it('does NOT run a second pass when the first pass resolved nothing', async () => {
     // The high-water mark starts at 0, so a pass that resolved zero has not
     // advanced it — a peer that just demonstrated it can deliver nothing does not

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -1989,3 +1989,112 @@ describe('#2050 capability gate — which peers earn a second pass', () => {
     expect(shared.filter((p) => p === PRODUCTIVE).length).toBeGreaterThan(1);
   });
 });
+
+/**
+ * Retention of a peer's coverage across a FAILED round.
+ *
+ * The discriminator is which peers a LATER pass contacts, and finding it took
+ * ruling two others out. After a throwing pass the stop reason cannot tell
+ * retention from forgetting — retained leaves coverage equal to the high-water
+ * mark, forgotten makes the max over an empty map `0`, and both are `<=` the
+ * mark, so both report `coverage-stalled`. The terminal message cannot either:
+ * it renders `diagnostics.sharedMemory.swmCoverage`, which `accumulate` reduces
+ * independently of `lastCoverageByPeer`, so forgetting a peer there is invisible
+ * to it.
+ *
+ * A second, still-productive peer keeps the mark advancing so the loop runs a
+ * further pass at all — and then membership of that pass is the observable.
+ */
+describe('#2050 coverage retention across a failed round', () => {
+  const CG = 'retention-cg';
+  const STEADY = 'peer-steady-4444';
+  const OTHER = 'peer-other-5555';
+
+  function cov(peerId: string, resolved: number, total: number) {
+    return {
+      contextGraphId: CG,
+      peerIdSuffix: peerId.slice(-8),
+      snapshotsResolved: resolved,
+      snapshotsTotal: total,
+      manifestComplete: true,
+      missingCount: Math.max(0, total - resolved),
+      missingSample: [],
+      materializationFailures: 0,
+    };
+  }
+
+  /** `otherRound` decides what the peer under test returns on its Nth round. */
+  async function walk(otherRound: (nth: number) => unknown) {
+    const shared: string[] = [];
+    let steadySeen = 0;
+    let otherSeen = 0;
+    await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [STEADY, OTHER], connectedPeers: 2 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory': {
+            const peerId = String(args[0]);
+            shared.push(peerId);
+            if (peerId === STEADY) {
+              steadySeen += 1;
+              // Advances by a WIDE margin each pass, and the margin is
+              // load-bearing. `highestResolvedCoverage` is a max over all peers,
+              // so at +1 per pass the peer under test — retained at 2 — would hold
+              // the max flat and the loop would stop at `coverage-stalled` before
+              // a third pass ever ran. The row would then fail for a reason having
+              // nothing to do with retention.
+              return {
+                ...sharedResult(),
+                failedPhases: 1,
+                swmCoverage: cov(STEADY, steadySeen * 10, 99),
+              };
+            }
+            otherSeen += 1;
+            return otherRound(otherSeen);
+          }
+          default:
+            return null;
+        }
+      },
+    );
+    return shared;
+  }
+
+  it('RETAINS coverage when a round fails, so the peer is contacted again', async () => {
+    // Round 1 reports real progress; round 2 throws, which `syncSharedMemory`
+    // turns into `emptyShared()` — truthy, and carrying no coverage.
+    const shared = await walk((nth) => {
+      if (nth === 1) return { ...sharedResult(), failedPhases: 1, swmCoverage: cov(OTHER, 2, 3) };
+      throw new Error('transport failure');
+    });
+    // Contacted in pass 1, again in pass 2 (where it threw), and STILL in pass 3
+    // — a throw is not evidence that the peer has nothing left.
+    expect(shared.filter((p) => p === OTHER).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('FORGETS coverage when a CLEAN round reports none, so the peer is dropped', async () => {
+    // The other direction, and it is what stops "always retain" from satisfying
+    // the row above: a peer that cleanly says it has nothing must not be revisited.
+    const shared = await walk((nth) => (nth === 1
+      ? { ...sharedResult(), failedPhases: 1, swmCoverage: cov(OTHER, 2, 3) }
+      : {
+        ...sharedResult(),
+        // Clean — `completedPhases > 0`, no failures — so the record is
+        // legitimately forgotten. But carrying NO data, deliberately: a clean
+        // DATA-BEARING round proves the plane, and the loop then stops at
+        // `plane-proven` before the capability gate is ever consulted. With the
+        // default `sharedResult()` this row passed with the delete branch removed
+        // entirely, which is the collapse it exists to rule out.
+        insertedTriples: 0,
+        insertedDataTriples: 0,
+        completedPhases: 1,
+      }));
+    expect(shared.filter((p) => p === OTHER)).toHaveLength(2);
+  });
+});

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -2025,6 +2025,27 @@ describe('#2050 capability gate — which peers earn a second pass', () => {
     expect(shared.filter((p) => p === PRODUCTIVE).length).toBeGreaterThan(1);
   });
 
+  it('keeps retrying a converging peer that a FINISHED peer would otherwise pin', async () => {
+    // The progress gate and the capability gate read different peer sets, and
+    // that is the whole bug: a peer at `400/400` is not capable, so it is never
+    // re-contacted and its record can never move — but a fleet-wide max over all
+    // retained records still counts it. The converging peer's entire manifest is
+    // 9 refs, so it can NEVER exceed 400 however well it does, and the loop
+    // stopped at `coverage-stalled` after exactly one continuation pass, which
+    // renders as "more passes would not help" — the opposite of true.
+    //
+    // Summing each peer's OWN high-water makes the reading move whenever any peer
+    // advances. Under the fleet-wide max this row sees exactly 2 contacts and
+    // `coverage-stalled`; the assertions below are chosen to fail in that case.
+    const PINNED = 'peer-finished-4444';
+    const { shared, result } = await walkWith(PINNED, () => round(PINNED, 400, 400));
+
+    expect(shared.filter((p) => p === PINNED)).toHaveLength(1);
+    expect(shared.filter((p) => p === PRODUCTIVE).length).toBeGreaterThan(2);
+    expect(result.diagnostics?.sharedMemory?.continuationStopReason)
+      .not.toBe('coverage-stalled');
+  });
+
   it('does not re-contact a peer whose MANIFEST was truncated', async () => {
     // Resolved < total, so the resolved/total clause alone would call it capable.
     // Only `manifestComplete` excludes it — and it must be excluded, because a

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -2112,12 +2112,18 @@ describe('#2050 coverage retention across a failed round', () => {
             shared.push(peerId);
             if (peerId === STEADY) {
               steadySeen += 1;
-              // Advances by a WIDE margin each pass, and the margin is
-              // load-bearing. `highestResolvedCoverage` is a max over all peers,
-              // so at +1 per pass the peer under test — retained at 2 — would hold
-              // the max flat and the loop would stop at `coverage-stalled` before
-              // a third pass ever ran. The row would then fail for a reason having
-              // nothing to do with retention.
+              // Advances every pass so the loop keeps running and the row can
+              // actually reach the retention question.
+              //
+              // The WIDTH of the margin is no longer load-bearing. It was: the
+              // progress gate used to be a max over all peers, so at +1 per pass
+              // the peer under test — retained at 2 — held the max flat and the
+              // loop stopped at `coverage-stalled` before a third pass ran, and
+              // the row failed for a reason having nothing to do with retention.
+              // That fixture-shaped dodge was evidence of a real defect, and the
+              // gate is now a sum over each peer's OWN high-water
+              // (`totalPeerProgress`), which rises whenever ANY peer advances.
+              // The margin is kept as belt-and-braces, not as a workaround.
               return {
                 ...sharedResult(),
                 failedPhases: 1,

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -1901,3 +1901,91 @@ describe('#2050 continuation loop — a failed-but-productive pass earns another
     expect(result.diagnostics?.sharedMemory?.continuationStopReason).toBe('coverage-stalled');
   });
 });
+
+/**
+ * The two capability-gate clauses, each pinned by WHICH peers a second pass
+ * contacts rather than by whether one happens.
+ *
+ * That shape is deliberate. The obvious fixture — one peer, barren — cannot see
+ * either clause: with `snapshotsResolved: 0` the high-water mark has not advanced,
+ * so the loop stops at `coverage-stalled` before the gate is consulted, and the
+ * row passes whether the guard exists or not. It is the T14 fixture-collapse
+ * pattern exactly, and it is why these clauses were unpinned.
+ *
+ * Pairing a productive peer with the peer under test fixes it: the productive one
+ * advances coverage so the loop genuinely reaches the gate, and the assertion is
+ * the *membership* of the second pass.
+ */
+describe('#2050 capability gate — which peers earn a second pass', () => {
+  const CG = 'gate-cg';
+  const PRODUCTIVE = 'peer-productive-1111';
+
+  function round(peerId: string, resolved: number, total: number, manifestComplete = true) {
+    return {
+      ...sharedResult(),
+      failedPhases: 1,
+      swmCoverage: {
+        contextGraphId: CG,
+        peerIdSuffix: peerId.slice(-8),
+        snapshotsResolved: resolved,
+        snapshotsTotal: total,
+        manifestComplete,
+        missingCount: Math.max(0, total - resolved),
+        missingSample: [],
+        materializationFailures: 0,
+      },
+    };
+  }
+
+  /** Runs a walk over the productive peer plus one peer under test. */
+  async function walkWith(other: string, otherRound: () => ReturnType<typeof round>) {
+    const shared: string[] = [];
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PRODUCTIVE, other], connectedPeers: 2 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory': {
+            const peerId = String(args[0]);
+            shared.push(peerId);
+            if (peerId !== PRODUCTIVE) return otherRound();
+            // Advances coverage every pass, so the loop keeps reaching the gate
+            // instead of stopping at `coverage-stalled`.
+            const seen = shared.filter((p) => p === PRODUCTIVE).length;
+            return round(PRODUCTIVE, seen, 9);
+          }
+          default:
+            return null;
+        }
+      },
+    );
+    return { shared, result };
+  }
+
+  it('does not re-contact a BARREN peer (snapshotsTotal === 0)', async () => {
+    const BARREN = 'peer-barren-2222';
+    const { shared } = await walkWith(BARREN, () => round(BARREN, 0, 0));
+
+    // Pass 1 contacts both; every later pass contacts only the productive peer.
+    expect(shared.slice(0, 2).sort()).toEqual([BARREN, PRODUCTIVE].sort());
+    expect(shared.filter((p) => p === BARREN)).toHaveLength(1);
+    expect(shared.filter((p) => p === PRODUCTIVE).length).toBeGreaterThan(1);
+  });
+
+  it('does not re-contact a peer whose MANIFEST was truncated', async () => {
+    // Resolved < total, so the resolved/total clause alone would call it capable.
+    // Only `manifestComplete` excludes it — and it must be excluded, because a
+    // truncated round advances `snapshotsResolved` while materializing nothing.
+    const TRUNCATED = 'peer-truncated-3333';
+    const { shared } = await walkWith(TRUNCATED, () => round(TRUNCATED, 1, 5, false));
+
+    expect(shared.slice(0, 2).sort()).toEqual([PRODUCTIVE, TRUNCATED].sort());
+    expect(shared.filter((p) => p === TRUNCATED)).toHaveLength(1);
+    expect(shared.filter((p) => p === PRODUCTIVE).length).toBeGreaterThan(1);
+  });
+});

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -1765,3 +1765,139 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
     });
   });
 });
+
+/**
+ * #2050 — the COMPOSED continuation chain, executed rather than reasoned about.
+ *
+ * Every link in this chain is pinned individually elsewhere: the coverage record
+ * survives a throwing round (agent-side T14), the capability gate reads coverage
+ * and not failure counters, the high-water mark advances, and the pure stop rule
+ * decides correctly. What nothing executed was the SEAM — that a round which
+ * materialized some Knowledge Assets and then failed actually causes a **second
+ * pass to run**.
+ *
+ * That distinction is not pedantic. Both of the last two defects on this change
+ * survived precisely because each piece was individually correct: a coverage
+ * record that was fabricated-but-plausible, and a counter whose name outlived its
+ * meaning. A chain of correct links can still fail to be connected.
+ *
+ * The load-bearing assertion here is the **pass count**, not the terminal record.
+ * A test that only checks the final coverage passes whether the loop ran once or
+ * twice — the first pass's own record already carries the converged numbers if
+ * the second pass simply overwrites it.
+ */
+describe('#2050 continuation loop — a failed-but-productive pass earns another one', () => {
+  const CG = 'continuation-chain-cg';
+  const PEER = 'peer-continuation-0001';
+
+  /** A round that resolved some of its manifest and did NOT complete cleanly. */
+  function partialSharedRound(resolved: number, total: number) {
+    return {
+      ...sharedResult(),
+      // Not clean: without this the plane is proven by data and the loop stops at
+      // `plane-proven` before the capability gate is ever consulted — which would
+      // make this test pass for a reason that has nothing to do with the seam.
+      failedPhases: 1,
+      swmCoverage: {
+        contextGraphId: CG,
+        peerIdSuffix: PEER.slice(-8),
+        snapshotsResolved: resolved,
+        snapshotsTotal: total,
+        manifestComplete: true,
+        missingCount: total - resolved,
+        missingSample: resolved < total ? ['sha256:unresolved'] : [],
+        materializationFailures: 0,
+      },
+    };
+  }
+
+  it('runs a SECOND shared-memory pass, and only the shared-memory plane', async () => {
+    const sharedCalls: string[] = [];
+    const durableCalls: string[] = [];
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            durableCalls.push(String(args[0]));
+            return durableResult();
+          case 'syncSharedMemory': {
+            sharedCalls.push(String(args[0]));
+            // Pass 1 resolved 2 of 3 and did not finish; pass 2 finishes the
+            // manifest, which takes the peer out of the capable set.
+            return sharedCalls.length === 1
+              ? partialSharedRound(2, 3)
+              : partialSharedRound(3, 3);
+          }
+          default:
+            return null;
+        }
+      },
+    );
+
+    // (5) THE seam: a second pass was actually dispatched. Asserted as a COUNT,
+    // because the terminal record below is identical whether the loop ran once
+    // or twice.
+    expect(sharedCalls).toEqual([PEER, PEER]);
+
+    // Continuation passes are shared-memory only — re-pulling durable would be
+    // amplification that nothing in the capability gate selects for.
+    expect(durableCalls).toEqual([PEER]);
+
+    // (2)-(4) The chain that produced it: the second pass's record replaced the
+    // first, coverage advanced, and the loop then stopped because the peer had
+    // nothing left rather than because it gave up.
+    expect(result.diagnostics?.sharedMemory?.swmCoverage).toMatchObject({
+      snapshotsResolved: 3,
+      snapshotsTotal: 3,
+      missingCount: 0,
+    });
+    expect(result.diagnostics?.sharedMemory?.continuationPasses).toBe(1);
+    expect(result.diagnostics?.sharedMemory?.continuationStopReason).toBe('no-capable-peers');
+
+    // Distinct peers, not peer-passes. Pre-fix this counted rounds, which drove
+    // `peersNotAttempted` negative once a pass repeated.
+    expect(result.peersTried).toBe(1);
+    expect(result.peersNotAttempted).toBe(0);
+  });
+
+  it('does NOT run a second pass when the first pass resolved nothing', async () => {
+    // The high-water mark starts at 0, so a pass that resolved zero has not
+    // advanced it — a peer that just demonstrated it can deliver nothing does not
+    // earn a repeat. This is the negative half: without it, the row above would
+    // pass under an implementation that always ran a second pass.
+    const sharedCalls: string[] = [];
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory':
+            sharedCalls.push(String(args[0]));
+            return partialSharedRound(0, 3);
+          default:
+            return null;
+        }
+      },
+    );
+
+    expect(sharedCalls).toEqual([PEER]);
+    // `0`, not absent: the field is initialised on the diagnostics object and is
+    // overwritten only when a repeat actually ran. Asserting `undefined` here was
+    // my own error, and the comment stays because a reader who assumes absence
+    // means "no repeats" would write the same wrong assertion again.
+    expect(result.diagnostics?.sharedMemory?.continuationPasses).toBe(0);
+    expect(result.diagnostics?.sharedMemory?.continuationStopReason).toBe('coverage-stalled');
+  });
+});

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -1791,6 +1791,12 @@ describe('#2050 continuation loop — a failed-but-productive pass earns another
   const PEER = 'peer-continuation-0001';
 
   /** A round that resolved some of its manifest and did NOT complete cleanly. */
+  /** Same shape but the manifest is a truncated prefix, so the peer is NOT capable. */
+  function truncatedSharedRound(resolved: number, total: number) {
+    const round = partialSharedRound(resolved, total);
+    return { ...round, swmCoverage: { ...round.swmCoverage, manifestComplete: false } };
+  }
+
   function partialSharedRound(resolved: number, total: number) {
     return {
       ...sharedResult(),
@@ -1914,11 +1920,17 @@ describe('#2050 continuation loop — a failed-but-productive pass earns another
     expect(continuationLines[0]).toContain(CG);
   });
 
-  it('does NOT run a second pass when the first pass resolved nothing', async () => {
-    // The high-water mark starts at 0, so a pass that resolved zero has not
-    // advanced it — a peer that just demonstrated it can deliver nothing does not
-    // earn a repeat. This is the negative half: without it, the row above would
-    // pass under an implementation that always ran a second pass.
+  it('does NOT run a second pass when nothing was resolved AND nobody is capable', async () => {
+    // The negative half: without it, the row above would pass under an
+    // implementation that always ran a second pass.
+    //
+    // The peer here reports a TRUNCATED manifest, so it is not capable and there
+    // is nothing a repeat could collect. That distinction is the whole point.
+    // This row used to use a peer reporting `0/3` with a COMPLETE manifest and
+    // assert no repeat — but such a peer is capable by construction: it has just
+    // said it holds three refs we do not have. Stopping there reported
+    // "more passes would not help" on a graph three Knowledge Assets short. See
+    // the row below for the corrected behaviour.
     const sharedCalls: string[] = [];
 
     const result = await runWorkerCatchup(
@@ -1933,7 +1945,7 @@ describe('#2050 continuation loop — a failed-but-productive pass earns another
             return durableResult();
           case 'syncSharedMemory':
             sharedCalls.push(String(args[0]));
-            return partialSharedRound(0, 3);
+            return truncatedSharedRound(0, 3);
           default:
             return null;
         }
@@ -1947,6 +1959,48 @@ describe('#2050 continuation loop — a failed-but-productive pass earns another
     // means "no repeats" would write the same wrong assertion again.
     expect(result.diagnostics?.sharedMemory?.continuationPasses).toBe(0);
     expect(result.diagnostics?.sharedMemory?.continuationStopReason).toBe('coverage-stalled');
+  });
+
+  it('DOES repeat for a capable peer whose first pass materialized nothing', async () => {
+    // The #2050 headline shape, end to end: a store fault failed every write, or
+    // the round deadline was spent by the metadata and aggregate phases before
+    // the snapshot walk began. Either way the peer reports `0/3` with a COMPLETE
+    // manifest — it holds three refs we lack, and on a warm cache a repeat costs
+    // no network bytes at all.
+    //
+    // Before the pass-1 suppression this stopped at `coverage-stalled` after one
+    // contact, rendering "more passes would not help" while the graph stayed
+    // three Knowledge Assets short. The peer advances by one per pass here, so a
+    // correct loop keeps going.
+    const sharedCalls: string[] = [];
+    let seen = 0;
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory': {
+            sharedCalls.push(String(args[0]));
+            const resolved = seen;
+            seen += 1;
+            return partialSharedRound(resolved, 3);
+          }
+          default:
+            return null;
+        }
+      },
+    );
+
+    expect(sharedCalls.length).toBeGreaterThan(1);
+    expect(result.diagnostics?.sharedMemory?.continuationPasses).toBeGreaterThan(0);
+    expect(result.diagnostics?.sharedMemory?.continuationStopReason)
+      .not.toBe('coverage-stalled');
   });
 });
 

--- a/packages/cli/test/catchup-runner-worker-lifecycle.test.ts
+++ b/packages/cli/test/catchup-runner-worker-lifecycle.test.ts
@@ -331,4 +331,20 @@ describe('WorkerCatchupRunner agent bridge', () => {
       source: 'catchup-foreground',
     });
   });
+
+  it('emits worker pass diagnostics through the parent logger bridge', async () => {
+    const info = vi.fn();
+    const { agent } = bridgeAgent({ log: { info } });
+
+    const posted = await invokeThroughBridge(
+      agent,
+      'logCatchupPass',
+      ['Catch-up SWM pass 2: 2 -> 3'],
+    );
+
+    expect(posted.error).toBeUndefined();
+    expect(posted.result).toBeNull();
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info.mock.calls[0]?.[1]).toBe('Catch-up SWM pass 2: 2 -> 3');
+  });
 });

--- a/packages/cli/test/catchup-runner-worker-max-passes-cap.test.ts
+++ b/packages/cli/test/catchup-runner-worker-max-passes-cap.test.ts
@@ -1,0 +1,279 @@
+// Pins the operator PASS CAP for the issue #2050 continuation passes, END TO
+// END through the daemon-side Worker catch-up implementation.
+//
+// `DKG_SWM_CATCHUP_MAX_PASSES=1` is the second of the two levers an operator has
+// over the repeat walk, and the sibling of
+// `catchup-runner-worker-pass-budget-killswitch.test.ts`. It bounds the loop by
+// COUNT rather than by wall clock: `1` means "the original walk and nothing
+// more", because `passesRun` counts the initial walk. Zero is deliberately NOT
+// the disable value — it would skip the initial walk itself and is documented as
+// a misconfiguration that falls back to the default; disabling repeats is the
+// budget's job.
+//
+// WHAT THIS FILE ADDS OVER THE EXISTING COVERAGE. The agent-side row
+// (`packages/agent/test/catchup-pass-policy.test.ts`) exercises the PURE parser
+// — `resolveSwmCatchupMaxPasses('1')` returns 1 — and the pure stop rule.
+// Neither touches `process.env`, and neither runs the worker. So the delivery
+// path was unproven: `SWM_CATCHUP_MAX_PASSES` is resolved ONCE AT MODULE LOAD in
+// `catchup-pass-policy.ts` from `process.env.DKG_SWM_CATCHUP_MAX_PASSES`,
+// exported from the agent, imported by `catchup-runner-worker-impl.ts`, and only
+// there passed as the policy's `maxPasses`. A typo in the env NAME, a broken
+// export/import, or a worker that passed a literal default instead of the
+// constant would leave every existing test green while the cap did nothing.
+//
+// WHY IT IS ITS OWN FILE, SEPARATE FROM THE BUDGET ONE. Two reasons, and the
+// second is the load-bearing one. (1) The constant freezes at the first import
+// of the policy module, so the env has to be set before that import, and
+// `vi.hoisted` + vitest's per-FILE module registry is the shape the harness
+// supports. (2) `max-passes-reached` is checked BEFORE `budget-exhausted` in the
+// stop rule, so a single file setting both switches would report
+// `max-passes-reached` for every row and the budget row would go green without
+// its own lever ever being consulted.
+//
+// ANTI-VACUITY. The fixture below is copied verbatim from the control row
+// `'runs a SECOND shared-memory pass, and only the shared-memory plane'` in
+// `catchup-runner-worker-impl.test.ts`, which asserts that this exact fixture
+// produces TWO `syncSharedMemory` calls under the default cap of 4. The env var
+// is therefore the ONLY difference between a fixture that continues and this one
+// that does not; a row whose fixture could never have continued would prove
+// nothing about the cap.
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { SWM_CATCHUP_MAX_PASSES } from '@origintrail-official/dkg-agent';
+import type { CatchupJobResult, CatchupRunRequest } from '../src/catchup-runner.js';
+
+// Mutates the REAL process env, and vitest can reuse a worker process across
+// files in a shard (both CLI configs run `maxWorkers: 1`). Without the restore
+// below, anything loaded afterwards — a sibling suite's worker impl, a spawned
+// daemon — would inherit a node that never runs a continuation pass, and those
+// files would go green for a reason none of them state.
+const previousSWMCATCHUPMAXPASSES = vi.hoisted(() => {
+  const before = process.env.DKG_SWM_CATCHUP_MAX_PASSES;
+  process.env.DKG_SWM_CATCHUP_MAX_PASSES = '1';
+  return before;
+});
+
+afterAll(() => {
+  if (previousSWMCATCHUPMAXPASSES === undefined) delete process.env.DKG_SWM_CATCHUP_MAX_PASSES;
+  else process.env.DKG_SWM_CATCHUP_MAX_PASSES = previousSWMCATCHUPMAXPASSES;
+});
+
+// The worker impl wires itself to `parentPort` at module load, so a
+// controllable port has to be in place BEFORE the module is imported.
+// Everything else from node:worker_threads stays real.
+const fakeParentPort = vi.hoisted(() => {
+  const messageListeners: Array<(message: any) => void> = [];
+  const port = {
+    on(event: string, listener: (message: any) => void) {
+      if (event === 'message') messageListeners.push(listener);
+    },
+    /** Set per run by `runWorkerCatchup`; receives what the impl posts back. */
+    onPosted: undefined as ((message: any) => void) | undefined,
+    postMessage(message: any) {
+      port.onPosted?.(message);
+    },
+    emitMessage(message: any) {
+      for (const listener of messageListeners) listener(message);
+    },
+  };
+  return port;
+});
+
+vi.mock('node:worker_threads', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:worker_threads')>()),
+  parentPort: fakeParentPort,
+}));
+
+function durableResult() {
+  return {
+    insertedTriples: 1,
+    complete: true,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 1,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 1,
+    bytesReceived: 10,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    metaOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+function sharedResult() {
+  return {
+    insertedTriples: 1,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 1,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 1,
+    bytesReceived: 10,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    droppedDataTriples: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+let nextRunId = 1;
+
+async function runWorkerCatchup(
+  request: CatchupRunRequest,
+  handler: (method: string, args: unknown[]) => Promise<unknown>,
+): Promise<CatchupJobResult> {
+  // The first call loads the module, which registers its message listener on
+  // the mocked parentPort; later calls reuse it (distinct runIds).
+  await import('../src/catchup-runner-worker-impl.js');
+  const runId = nextRunId++;
+  return new Promise<CatchupJobResult>((resolve, reject) => {
+    fakeParentPort.onPosted = (message: any) => {
+      if (message.type === 'invoke') {
+        handler(message.method, message.args).then(
+          (result) => fakeParentPort.emitMessage({ type: 'invoke-result', invokeId: message.invokeId, result }),
+          (error: unknown) => fakeParentPort.emitMessage({
+            type: 'invoke-result',
+            invokeId: message.invokeId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+        return;
+      }
+      if (message.type === 'run-result' && message.runId === runId) {
+        if (message.error) reject(new Error(message.error));
+        else resolve(message.result as CatchupJobResult);
+      }
+    };
+    fakeParentPort.emitMessage({ type: 'run', runId, request });
+  });
+}
+
+describe('#2050 continuation-pass cap (DKG_SWM_CATCHUP_MAX_PASSES=1)', () => {
+  const CG = 'continuation-maxpasses-cg';
+  const PEER = 'peer-continuation-0001';
+
+  /**
+   * A round that resolved part of its manifest and did NOT complete cleanly —
+   * the shape the repeat loop exists for, and the shape that makes this row
+   * meaningful.
+   *
+   * `failedPhases: 1` is load-bearing: without it the shared plane is proven by
+   * data and the loop stops at `plane-proven` BEFORE the cap is ever consulted,
+   * so the row would pass or fail for reasons unrelated to the env var.
+   *
+   * `manifestComplete: true` with `2 < 3` is what makes the peer CAPABLE: it is
+   * the peer's own statement that it holds a ref we lack. Weaken it (truncate
+   * the manifest, or report `3/3`) and the loop stops at `no-capable-peers` or
+   * `coverage-stalled` whether the cap is set or not — a green row that proves
+   * the cap is wired would then be pure coincidence.
+   */
+  function partialSharedRound(resolved: number, total: number) {
+    return {
+      ...sharedResult(),
+      failedPhases: 1,
+      swmCoverage: {
+        contextGraphId: CG,
+        peerIdSuffix: PEER.slice(-8),
+        snapshotsResolved: resolved,
+        snapshotsTotal: total,
+        manifestComplete: true,
+        missingCount: total - resolved,
+        missingSample: resolved < total ? ['sha256:unresolved'] : [],
+        materializationFailures: 0,
+      },
+    };
+  }
+
+  it('stops after ONE shared-memory round instead of continuing', async () => {
+    const sharedCalls: string[] = [];
+    const durableCalls: string[] = [];
+    const passLines: string[] = [];
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            durableCalls.push(String(args[0]));
+            return durableResult();
+          case 'syncSharedMemory': {
+            sharedCalls.push(String(args[0]));
+            // Kept identical to the control row in
+            // `catchup-runner-worker-impl.test.ts`, second branch included: there
+            // the peer finishes its manifest on the repeat. Here the repeat must
+            // never happen, so the branch is deliberately unreachable — and its
+            // presence is what makes the env var the ONLY difference between the
+            // two fixtures.
+            //
+            // The peer therefore ends the job still one Knowledge Asset short.
+            // That is the cap doing its job, not a defect: it is an explicit
+            // operator instruction to stop paying for repeats, and the
+            // background reconcile lane remains the convergence path.
+            return sharedCalls.length === 1
+              ? partialSharedRound(2, 3)
+              : partialSharedRound(3, 3);
+          }
+          case 'logCatchupPass':
+            passLines.push(String(args[0]));
+            return null;
+          default:
+            return null;
+        }
+      },
+    );
+
+    // THE row. Asserted as the call list, not as a diagnostic counter: the
+    // counters are written by the same loop that would have dispatched the
+    // repeat, while this is the network work the operator actually pulled the
+    // lever to stop.
+    expect(sharedCalls).toEqual([PEER]);
+
+    // Pass 1 is the ORIGINAL walk, which the cap of 1 must still permit — a cap
+    // that suppressed the first durable+SWM round would disable catch-up rather
+    // than disable repeats, and `sharedCalls` alone cannot tell those apart.
+    expect(durableCalls).toEqual([PEER]);
+    expect(result.sharedMemorySynced).toBe(1);
+    expect(result.dataSynced).toBe(1);
+
+    // `0`, not absent: the field is initialised on the diagnostics object and
+    // overwritten only when a repeat actually ran.
+    expect(result.diagnostics?.sharedMemory?.continuationPasses).toBe(0);
+    // The REASON, not merely the absence of repeats. On this fixture the capable
+    // peer clears the plane-proven, stall and capability gates, and the wall-clock
+    // budget is still its 600 s default — so `max-passes-reached` is reachable
+    // ONLY through this env var. Any other reason here would mean the loop
+    // declined for its own reasons and the cap was never consulted.
+    expect(result.diagnostics?.sharedMemory?.continuationStopReason).toBe('max-passes-reached');
+
+    // What an operator reads back to confirm the lever took effect. The pass
+    // loop's only per-pass observability is fire-and-forget, so a terminal line
+    // that stopped naming the reason would fail silently.
+    expect(passLines.filter((line) => line.includes('stopped after 1 pass(es): max-passes-reached')))
+      .toHaveLength(1);
+    expect(passLines.filter((line) => line.startsWith('Catch-up SWM pass 2'))).toHaveLength(0);
+  });
+
+  it('resolves the module-load constant from the environment', async () => {
+    // A localization aid, deliberately kept OUT of the behavioural row above so
+    // that row proves the end-to-end path on its own. When both fail, the break
+    // is in the env→constant hop (name, parse, export); when only the row above
+    // fails, the constant is fine and the worker stopped using it.
+    expect(SWM_CATCHUP_MAX_PASSES).toBe(1);
+  });
+});

--- a/packages/cli/test/catchup-runner-worker-max-passes-cap.test.ts
+++ b/packages/cli/test/catchup-runner-worker-max-passes-cap.test.ts
@@ -1,164 +1,21 @@
-// Pins the operator PASS CAP for the issue #2050 continuation passes, END TO
-// END through the daemon-side Worker catch-up implementation.
-//
-// `DKG_SWM_CATCHUP_MAX_PASSES=1` is the second of the two levers an operator has
-// over the repeat walk, and the sibling of
-// `catchup-runner-worker-pass-budget-killswitch.test.ts`. It bounds the loop by
-// COUNT rather than by wall clock: `1` means "the original walk and nothing
-// more", because `passesRun` counts the initial walk. Zero is deliberately NOT
-// the disable value — it would skip the initial walk itself and is documented as
-// a misconfiguration that falls back to the default; disabling repeats is the
-// budget's job.
-//
-// WHAT THIS FILE ADDS OVER THE EXISTING COVERAGE. The agent-side row
-// (`packages/agent/test/catchup-pass-policy.test.ts`) exercises the PURE parser
-// — `resolveSwmCatchupMaxPasses('1')` returns 1 — and the pure stop rule.
-// Neither touches `process.env`, and neither runs the worker. So the delivery
-// path was unproven: `SWM_CATCHUP_MAX_PASSES` is resolved ONCE AT MODULE LOAD in
-// `catchup-pass-policy.ts` from `process.env.DKG_SWM_CATCHUP_MAX_PASSES`,
-// exported from the agent, imported by `catchup-runner-worker-impl.ts`, and only
-// there passed as the policy's `maxPasses`. A typo in the env NAME, a broken
-// export/import, or a worker that passed a literal default instead of the
-// constant would leave every existing test green while the cap did nothing.
-//
-// WHY IT IS ITS OWN FILE, SEPARATE FROM THE BUDGET ONE. Two reasons, and the
-// second is the load-bearing one. (1) The constant freezes at the first import
-// of the policy module, so the env has to be set before that import, and
-// `vi.hoisted` + vitest's per-FILE module registry is the shape the harness
-// supports. (2) `max-passes-reached` is checked BEFORE `budget-exhausted` in the
-// stop rule, so a single file setting both switches would report
-// `max-passes-reached` for every row and the budget row would go green without
-// its own lever ever being consulted.
-//
-// ANTI-VACUITY. The fixture below is copied verbatim from the control row
-// `'runs a SECOND shared-memory pass, and only the shared-memory plane'` in
-// `catchup-runner-worker-impl.test.ts`, which asserts that this exact fixture
-// produces TWO `syncSharedMemory` calls under the default cap of 4. The env var
-// is therefore the ONLY difference between a fixture that continues and this one
-// that does not; a row whose fixture could never have continued would prove
-// nothing about the cap.
-import { afterAll, describe, expect, it, vi } from 'vitest';
-import { SWM_CATCHUP_MAX_PASSES } from '@origintrail-official/dkg-agent';
-import type { CatchupJobResult, CatchupRunRequest } from '../src/catchup-runner.js';
+// Proves the one-pass operator cap through the real worker loop.
+// Configuration is resolved at job start, so this suite shares the canonical
+// worker harness and no longer depends on module-import order.
+import {
+  durableCatchupResult as durableResult,
+  runWorkerCatchup,
+  sharedCatchupResult as sharedResult,
+} from './helpers/catchup-runner-worker-test-harness.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveSwmCatchupPassConfig } from '@origintrail-official/dkg-agent';
 
-// Mutates the REAL process env, and vitest can reuse a worker process across
-// files in a shard (both CLI configs run `maxWorkers: 1`). Without the restore
-// below, anything loaded afterwards — a sibling suite's worker impl, a spawned
-// daemon — would inherit a node that never runs a continuation pass, and those
-// files would go green for a reason none of them state.
-const previousSWMCATCHUPMAXPASSES = vi.hoisted(() => {
-  const before = process.env.DKG_SWM_CATCHUP_MAX_PASSES;
-  process.env.DKG_SWM_CATCHUP_MAX_PASSES = '1';
-  return before;
+beforeEach(() => {
+  vi.stubEnv('DKG_SWM_CATCHUP_MAX_PASSES', '1');
 });
 
-afterAll(() => {
-  if (previousSWMCATCHUPMAXPASSES === undefined) delete process.env.DKG_SWM_CATCHUP_MAX_PASSES;
-  else process.env.DKG_SWM_CATCHUP_MAX_PASSES = previousSWMCATCHUPMAXPASSES;
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
-
-// The worker impl wires itself to `parentPort` at module load, so a
-// controllable port has to be in place BEFORE the module is imported.
-// Everything else from node:worker_threads stays real.
-const fakeParentPort = vi.hoisted(() => {
-  const messageListeners: Array<(message: any) => void> = [];
-  const port = {
-    on(event: string, listener: (message: any) => void) {
-      if (event === 'message') messageListeners.push(listener);
-    },
-    /** Set per run by `runWorkerCatchup`; receives what the impl posts back. */
-    onPosted: undefined as ((message: any) => void) | undefined,
-    postMessage(message: any) {
-      port.onPosted?.(message);
-    },
-    emitMessage(message: any) {
-      for (const listener of messageListeners) listener(message);
-    },
-  };
-  return port;
-});
-
-vi.mock('node:worker_threads', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('node:worker_threads')>()),
-  parentPort: fakeParentPort,
-}));
-
-function durableResult() {
-  return {
-    insertedTriples: 1,
-    complete: true,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 1,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 1,
-    bytesReceived: 10,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 1,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    metaOnlyResponses: 0,
-    dataRejectedMissingMeta: 0,
-    rejectedKcs: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    deniedPhases: 0,
-    deferredBackpressure: 0,
-  };
-}
-
-function sharedResult() {
-  return {
-    insertedTriples: 1,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 1,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 1,
-    bytesReceived: 10,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 1,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    droppedDataTriples: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    deniedPhases: 0,
-    deferredBackpressure: 0,
-  };
-}
-
-let nextRunId = 1;
-
-async function runWorkerCatchup(
-  request: CatchupRunRequest,
-  handler: (method: string, args: unknown[]) => Promise<unknown>,
-): Promise<CatchupJobResult> {
-  // The first call loads the module, which registers its message listener on
-  // the mocked parentPort; later calls reuse it (distinct runIds).
-  await import('../src/catchup-runner-worker-impl.js');
-  const runId = nextRunId++;
-  return new Promise<CatchupJobResult>((resolve, reject) => {
-    fakeParentPort.onPosted = (message: any) => {
-      if (message.type === 'invoke') {
-        handler(message.method, message.args).then(
-          (result) => fakeParentPort.emitMessage({ type: 'invoke-result', invokeId: message.invokeId, result }),
-          (error: unknown) => fakeParentPort.emitMessage({
-            type: 'invoke-result',
-            invokeId: message.invokeId,
-            error: error instanceof Error ? error.message : String(error),
-          }),
-        );
-        return;
-      }
-      if (message.type === 'run-result' && message.runId === runId) {
-        if (message.error) reject(new Error(message.error));
-        else resolve(message.result as CatchupJobResult);
-      }
-    };
-    fakeParentPort.emitMessage({ type: 'run', runId, request });
-  });
-}
 
 describe('#2050 continuation-pass cap (DKG_SWM_CATCHUP_MAX_PASSES=1)', () => {
   const CG = 'continuation-maxpasses-cg';
@@ -269,11 +126,7 @@ describe('#2050 continuation-pass cap (DKG_SWM_CATCHUP_MAX_PASSES=1)', () => {
     expect(passLines.filter((line) => line.startsWith('Catch-up SWM pass 2'))).toHaveLength(0);
   });
 
-  it('resolves the module-load constant from the environment', async () => {
-    // A localization aid, deliberately kept OUT of the behavioural row above so
-    // that row proves the end-to-end path on its own. When both fail, the break
-    // is in the env→constant hop (name, parse, export); when only the row above
-    // fails, the constant is fine and the worker stopped using it.
-    expect(SWM_CATCHUP_MAX_PASSES).toBe(1);
+  it('resolves the per-job config from the environment', () => {
+    expect(resolveSwmCatchupPassConfig().maxPasses).toBe(1);
   });
 });

--- a/packages/cli/test/catchup-runner-worker-pass-budget-killswitch.test.ts
+++ b/packages/cli/test/catchup-runner-worker-pass-budget-killswitch.test.ts
@@ -1,0 +1,275 @@
+// Pins the operator kill switch for the issue #2050 continuation passes,
+// END TO END through the daemon-side Worker catch-up implementation.
+//
+// `DKG_SWM_CATCHUP_PASS_BUDGET_MS=0` is what an operator reaches for during an
+// incident when a node's repeat walk is costing more than the partial graph it
+// is chasing: it makes `deadlineMs` equal the job start, so the policy's `>=`
+// comparison stops the loop before the first repeat, with no redeploy and no
+// separate disabled branch in the walk.
+//
+// WHAT THIS FILE ADDS OVER THE EXISTING COVERAGE. The agent-side row
+// (`packages/agent/test/catchup-pass-policy.test.ts`) exercises the PURE
+// parser — `resolveSwmCatchupPassBudgetMs('0')` returns 0 — and the pure stop
+// rule. Neither touches `process.env`, and neither runs the worker. So the
+// whole delivery path was unproven: `SWM_CATCHUP_PASS_BUDGET_MS` is resolved
+// ONCE AT MODULE LOAD in `catchup-pass-policy.ts` from
+// `process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS`, exported from the agent,
+// imported by `catchup-runner-worker-impl.ts`, and only there added to
+// `catchupPassNowMs()` to form the deadline. A typo in the env NAME, a broken
+// export/import, or a worker that used a literal default instead of the
+// constant would leave every existing test green while the switch did nothing
+// — and an operator would be pulling a lever wired to nothing, mid-incident.
+//
+// WHY IT IS ITS OWN FILE. The constant freezes at the first import of the
+// policy module, so the env has to be set before that import. `vi.hoisted`
+// runs before imports, and vitest gives each test FILE a fresh module registry,
+// so a whole file under the switch is the shape the harness supports. It also
+// keeps the switch off every other file: `runWorkerCatchup` here is a
+// deliberate copy of the helper in `catchup-runner-worker-impl.test.ts` rather
+// than a shared import, matching what `catchup-runner-worker-killswitch.test.ts`
+// already does for `DKG_CATCHUP_STOP_ON_PROOF`.
+//
+// ANTI-VACUITY. The fixture below is copied verbatim from the control row
+// `'runs a SECOND shared-memory pass, and only the shared-memory plane'` in
+// `catchup-runner-worker-impl.test.ts`, which asserts that this exact fixture
+// produces TWO `syncSharedMemory` calls. The env var is therefore the ONLY
+// difference between a fixture that continues and this one that does not; a
+// row whose fixture could never have continued would prove nothing about the
+// switch.
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { SWM_CATCHUP_PASS_BUDGET_MS } from '@origintrail-official/dkg-agent';
+import type { CatchupJobResult, CatchupRunRequest } from '../src/catchup-runner.js';
+
+// Mutates the REAL process env, and vitest can reuse a worker process across
+// files in a shard (both CLI configs run `maxWorkers: 1`). Without the restore
+// below, anything loaded afterwards — a sibling suite's worker impl, a spawned
+// daemon — would inherit a node that never runs a continuation pass, and those
+// files would go green for a reason none of them state.
+const previousSWMCATCHUPPASSBUDGETMS = vi.hoisted(() => {
+  const before = process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+  process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = '0';
+  return before;
+});
+
+afterAll(() => {
+  if (previousSWMCATCHUPPASSBUDGETMS === undefined) delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+  else process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = previousSWMCATCHUPPASSBUDGETMS;
+});
+
+// The worker impl wires itself to `parentPort` at module load, so a
+// controllable port has to be in place BEFORE the module is imported.
+// Everything else from node:worker_threads stays real.
+const fakeParentPort = vi.hoisted(() => {
+  const messageListeners: Array<(message: any) => void> = [];
+  const port = {
+    on(event: string, listener: (message: any) => void) {
+      if (event === 'message') messageListeners.push(listener);
+    },
+    /** Set per run by `runWorkerCatchup`; receives what the impl posts back. */
+    onPosted: undefined as ((message: any) => void) | undefined,
+    postMessage(message: any) {
+      port.onPosted?.(message);
+    },
+    emitMessage(message: any) {
+      for (const listener of messageListeners) listener(message);
+    },
+  };
+  return port;
+});
+
+vi.mock('node:worker_threads', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:worker_threads')>()),
+  parentPort: fakeParentPort,
+}));
+
+function durableResult() {
+  return {
+    insertedTriples: 1,
+    complete: true,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 1,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 1,
+    bytesReceived: 10,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    metaOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+function sharedResult() {
+  return {
+    insertedTriples: 1,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 1,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 1,
+    bytesReceived: 10,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    droppedDataTriples: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+let nextRunId = 1;
+
+async function runWorkerCatchup(
+  request: CatchupRunRequest,
+  handler: (method: string, args: unknown[]) => Promise<unknown>,
+): Promise<CatchupJobResult> {
+  // The first call loads the module, which registers its message listener on
+  // the mocked parentPort; later calls reuse it (distinct runIds).
+  await import('../src/catchup-runner-worker-impl.js');
+  const runId = nextRunId++;
+  return new Promise<CatchupJobResult>((resolve, reject) => {
+    fakeParentPort.onPosted = (message: any) => {
+      if (message.type === 'invoke') {
+        handler(message.method, message.args).then(
+          (result) => fakeParentPort.emitMessage({ type: 'invoke-result', invokeId: message.invokeId, result }),
+          (error: unknown) => fakeParentPort.emitMessage({
+            type: 'invoke-result',
+            invokeId: message.invokeId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+        return;
+      }
+      if (message.type === 'run-result' && message.runId === runId) {
+        if (message.error) reject(new Error(message.error));
+        else resolve(message.result as CatchupJobResult);
+      }
+    };
+    fakeParentPort.emitMessage({ type: 'run', runId, request });
+  });
+}
+
+describe('#2050 continuation-pass kill switch (DKG_SWM_CATCHUP_PASS_BUDGET_MS=0)', () => {
+  const CG = 'continuation-killswitch-cg';
+  const PEER = 'peer-continuation-0001';
+
+  /**
+   * A round that resolved part of its manifest and did NOT complete cleanly —
+   * the shape the repeat loop exists for, and the shape that makes this row
+   * meaningful.
+   *
+   * `failedPhases: 1` is load-bearing: without it the shared plane is proven by
+   * data and the loop stops at `plane-proven` BEFORE the budget is ever
+   * consulted, so the row would report `budget-exhausted`... never, and would
+   * pass or fail for reasons unrelated to the switch.
+   *
+   * `manifestComplete: true` with `2 < 3` is what makes the peer CAPABLE: it is
+   * the peer's own statement that it holds a ref we lack. Weaken it (truncate
+   * the manifest, or report `3/3`) and the loop stops at `no-capable-peers` or
+   * `coverage-stalled` whether the switch is set or not — a green row that
+   * proves the switch is wired would then be pure coincidence.
+   */
+  function partialSharedRound(resolved: number, total: number) {
+    return {
+      ...sharedResult(),
+      failedPhases: 1,
+      swmCoverage: {
+        contextGraphId: CG,
+        peerIdSuffix: PEER.slice(-8),
+        snapshotsResolved: resolved,
+        snapshotsTotal: total,
+        manifestComplete: true,
+        missingCount: total - resolved,
+        missingSample: resolved < total ? ['sha256:unresolved'] : [],
+        materializationFailures: 0,
+      },
+    };
+  }
+
+  it('stops after ONE shared-memory round instead of continuing', async () => {
+    const sharedCalls: string[] = [];
+    const durableCalls: string[] = [];
+    const passLines: string[] = [];
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: CG, includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return { isPrivateContextGraph: false, peerIds: [PEER], connectedPeers: 1 };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            durableCalls.push(String(args[0]));
+            return durableResult();
+          case 'syncSharedMemory': {
+            sharedCalls.push(String(args[0]));
+            // Kept identical to the control row in
+            // `catchup-runner-worker-impl.test.ts`, second branch included: there
+            // the peer finishes its manifest on the repeat. Here the repeat must
+            // never happen, so the branch is deliberately unreachable — and its
+            // presence is what makes the env var the ONLY difference between the
+            // two fixtures.
+            return sharedCalls.length === 1
+              ? partialSharedRound(2, 3)
+              : partialSharedRound(3, 3);
+          }
+          case 'logCatchupPass':
+            passLines.push(String(args[0]));
+            return null;
+          default:
+            return null;
+        }
+      },
+    );
+
+    // THE row. Asserted as the call list, not as a diagnostic counter: the
+    // counters are written by the same loop that would have dispatched the
+    // repeat, while this is the network work the operator actually pulled the
+    // lever to stop.
+    expect(sharedCalls).toEqual([PEER]);
+
+    // Pass 1 is the ORIGINAL walk, which the budget must not touch — a switch
+    // that also suppressed the first durable+SWM round would disable catch-up
+    // rather than disable repeats, and `sharedCalls` alone cannot tell those
+    // apart.
+    expect(durableCalls).toEqual([PEER]);
+    expect(result.sharedMemorySynced).toBe(1);
+    expect(result.dataSynced).toBe(1);
+
+    // `0`, not absent: the field is initialised on the diagnostics object and
+    // overwritten only when a repeat actually ran.
+    expect(result.diagnostics?.sharedMemory?.continuationPasses).toBe(0);
+    // The REASON, not merely the absence of repeats. Every other stop reason on
+    // this fixture would mean the loop declined for its own reasons and the
+    // switch was never consulted; only `budget-exhausted` is reachable through
+    // the env var, because the capable peer clears the plane-proven, stall and
+    // capability gates ahead of it and `maxPasses` is still its default 4.
+    expect(result.diagnostics?.sharedMemory?.continuationStopReason).toBe('budget-exhausted');
+
+    // What an operator reads back to confirm the lever took effect. The pass
+    // loop's only per-pass observability is fire-and-forget, so a terminal line
+    // that stopped naming the reason would fail silently.
+    expect(passLines.filter((line) => line.includes('stopped after 1 pass(es): budget-exhausted')))
+      .toHaveLength(1);
+    expect(passLines.filter((line) => line.startsWith('Catch-up SWM pass 2'))).toHaveLength(0);
+  });
+
+  it('resolves the module-load constant from the environment', async () => {
+    // A localization aid, deliberately kept OUT of the behavioural row above so
+    // that row proves the end-to-end path on its own. When both fail, the break
+    // is in the env→constant hop (name, parse, export); when only the row above
+    // fails, the constant is fine and the worker stopped using it.
+    expect(SWM_CATCHUP_PASS_BUDGET_MS).toBe(0);
+  });
+});

--- a/packages/cli/test/catchup-runner-worker-pass-budget-killswitch.test.ts
+++ b/packages/cli/test/catchup-runner-worker-pass-budget-killswitch.test.ts
@@ -1,163 +1,21 @@
-// Pins the operator kill switch for the issue #2050 continuation passes,
-// END TO END through the daemon-side Worker catch-up implementation.
-//
-// `DKG_SWM_CATCHUP_PASS_BUDGET_MS=0` is what an operator reaches for during an
-// incident when a node's repeat walk is costing more than the partial graph it
-// is chasing: it makes `deadlineMs` equal the job start, so the policy's `>=`
-// comparison stops the loop before the first repeat, with no redeploy and no
-// separate disabled branch in the walk.
-//
-// WHAT THIS FILE ADDS OVER THE EXISTING COVERAGE. The agent-side row
-// (`packages/agent/test/catchup-pass-policy.test.ts`) exercises the PURE
-// parser — `resolveSwmCatchupPassBudgetMs('0')` returns 0 — and the pure stop
-// rule. Neither touches `process.env`, and neither runs the worker. So the
-// whole delivery path was unproven: `SWM_CATCHUP_PASS_BUDGET_MS` is resolved
-// ONCE AT MODULE LOAD in `catchup-pass-policy.ts` from
-// `process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS`, exported from the agent,
-// imported by `catchup-runner-worker-impl.ts`, and only there added to
-// `catchupPassNowMs()` to form the deadline. A typo in the env NAME, a broken
-// export/import, or a worker that used a literal default instead of the
-// constant would leave every existing test green while the switch did nothing
-// — and an operator would be pulling a lever wired to nothing, mid-incident.
-//
-// WHY IT IS ITS OWN FILE. The constant freezes at the first import of the
-// policy module, so the env has to be set before that import. `vi.hoisted`
-// runs before imports, and vitest gives each test FILE a fresh module registry,
-// so a whole file under the switch is the shape the harness supports. It also
-// keeps the switch off every other file: `runWorkerCatchup` here is a
-// deliberate copy of the helper in `catchup-runner-worker-impl.test.ts` rather
-// than a shared import, matching what `catchup-runner-worker-killswitch.test.ts`
-// already does for `DKG_CATCHUP_STOP_ON_PROOF`.
-//
-// ANTI-VACUITY. The fixture below is copied verbatim from the control row
-// `'runs a SECOND shared-memory pass, and only the shared-memory plane'` in
-// `catchup-runner-worker-impl.test.ts`, which asserts that this exact fixture
-// produces TWO `syncSharedMemory` calls. The env var is therefore the ONLY
-// difference between a fixture that continues and this one that does not; a
-// row whose fixture could never have continued would prove nothing about the
-// switch.
-import { afterAll, describe, expect, it, vi } from 'vitest';
-import { SWM_CATCHUP_PASS_BUDGET_MS } from '@origintrail-official/dkg-agent';
-import type { CatchupJobResult, CatchupRunRequest } from '../src/catchup-runner.js';
+// Proves the zero-budget operator kill switch through the real worker loop.
+// Configuration is resolved at job start, so this suite shares the canonical
+// worker harness and no longer depends on module-import order.
+import {
+  durableCatchupResult as durableResult,
+  runWorkerCatchup,
+  sharedCatchupResult as sharedResult,
+} from './helpers/catchup-runner-worker-test-harness.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveSwmCatchupPassConfig } from '@origintrail-official/dkg-agent';
 
-// Mutates the REAL process env, and vitest can reuse a worker process across
-// files in a shard (both CLI configs run `maxWorkers: 1`). Without the restore
-// below, anything loaded afterwards — a sibling suite's worker impl, a spawned
-// daemon — would inherit a node that never runs a continuation pass, and those
-// files would go green for a reason none of them state.
-const previousSWMCATCHUPPASSBUDGETMS = vi.hoisted(() => {
-  const before = process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
-  process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = '0';
-  return before;
+beforeEach(() => {
+  vi.stubEnv('DKG_SWM_CATCHUP_PASS_BUDGET_MS', '0');
 });
 
-afterAll(() => {
-  if (previousSWMCATCHUPPASSBUDGETMS === undefined) delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
-  else process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = previousSWMCATCHUPPASSBUDGETMS;
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
-
-// The worker impl wires itself to `parentPort` at module load, so a
-// controllable port has to be in place BEFORE the module is imported.
-// Everything else from node:worker_threads stays real.
-const fakeParentPort = vi.hoisted(() => {
-  const messageListeners: Array<(message: any) => void> = [];
-  const port = {
-    on(event: string, listener: (message: any) => void) {
-      if (event === 'message') messageListeners.push(listener);
-    },
-    /** Set per run by `runWorkerCatchup`; receives what the impl posts back. */
-    onPosted: undefined as ((message: any) => void) | undefined,
-    postMessage(message: any) {
-      port.onPosted?.(message);
-    },
-    emitMessage(message: any) {
-      for (const listener of messageListeners) listener(message);
-    },
-  };
-  return port;
-});
-
-vi.mock('node:worker_threads', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('node:worker_threads')>()),
-  parentPort: fakeParentPort,
-}));
-
-function durableResult() {
-  return {
-    insertedTriples: 1,
-    complete: true,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 1,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 1,
-    bytesReceived: 10,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 1,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    metaOnlyResponses: 0,
-    dataRejectedMissingMeta: 0,
-    rejectedKcs: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    deniedPhases: 0,
-    deferredBackpressure: 0,
-  };
-}
-
-function sharedResult() {
-  return {
-    insertedTriples: 1,
-    fetchedMetaTriples: 0,
-    fetchedDataTriples: 1,
-    insertedMetaTriples: 0,
-    insertedDataTriples: 1,
-    bytesReceived: 10,
-    resumedPhases: 0,
-    timedOutPhases: 0,
-    completedPhases: 1,
-    checkpointAdvances: 0,
-    emptyResponses: 0,
-    droppedDataTriples: 0,
-    failedPeers: 0,
-    failedPhases: 0,
-    deniedPhases: 0,
-    deferredBackpressure: 0,
-  };
-}
-
-let nextRunId = 1;
-
-async function runWorkerCatchup(
-  request: CatchupRunRequest,
-  handler: (method: string, args: unknown[]) => Promise<unknown>,
-): Promise<CatchupJobResult> {
-  // The first call loads the module, which registers its message listener on
-  // the mocked parentPort; later calls reuse it (distinct runIds).
-  await import('../src/catchup-runner-worker-impl.js');
-  const runId = nextRunId++;
-  return new Promise<CatchupJobResult>((resolve, reject) => {
-    fakeParentPort.onPosted = (message: any) => {
-      if (message.type === 'invoke') {
-        handler(message.method, message.args).then(
-          (result) => fakeParentPort.emitMessage({ type: 'invoke-result', invokeId: message.invokeId, result }),
-          (error: unknown) => fakeParentPort.emitMessage({
-            type: 'invoke-result',
-            invokeId: message.invokeId,
-            error: error instanceof Error ? error.message : String(error),
-          }),
-        );
-        return;
-      }
-      if (message.type === 'run-result' && message.runId === runId) {
-        if (message.error) reject(new Error(message.error));
-        else resolve(message.result as CatchupJobResult);
-      }
-    };
-    fakeParentPort.emitMessage({ type: 'run', runId, request });
-  });
-}
 
 describe('#2050 continuation-pass kill switch (DKG_SWM_CATCHUP_PASS_BUDGET_MS=0)', () => {
   const CG = 'continuation-killswitch-cg';
@@ -265,11 +123,7 @@ describe('#2050 continuation-pass kill switch (DKG_SWM_CATCHUP_PASS_BUDGET_MS=0)
     expect(passLines.filter((line) => line.startsWith('Catch-up SWM pass 2'))).toHaveLength(0);
   });
 
-  it('resolves the module-load constant from the environment', async () => {
-    // A localization aid, deliberately kept OUT of the behavioural row above so
-    // that row proves the end-to-end path on its own. When both fail, the break
-    // is in the env→constant hop (name, parse, export); when only the row above
-    // fails, the constant is fine and the worker stopped using it.
-    expect(SWM_CATCHUP_PASS_BUDGET_MS).toBe(0);
+  it('resolves the per-job config from the environment', () => {
+    expect(resolveSwmCatchupPassConfig().budgetMs).toBe(0);
   });
 });

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -750,7 +750,7 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
 
   it('calls an incomplete manifest a lower bound rather than a total', () => {
     expect(swmShortfallClause({ ...r26, manifestComplete: false }, 0))
-      .toContain("The peer's snapshot manifest was itself incomplete, so 250 is a lower bound.");
+      .toContain("The peer's snapshot manifest was itself incomplete, so 250 is a lower bound");
   });
 
   it('caps the named identifiers and accounts for the ones it omits', () => {
@@ -803,6 +803,39 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
     expect(c.error).toContain('72 outstanding');
   });
 
+  it('says why continuation stopped, in words that match the reason', () => {
+    expect(swmShortfallClause(r26, 2, 'budget-exhausted'))
+      .toContain('Continuation stopped because the time budget was exhausted.');
+    expect(swmShortfallClause(r26, 2, 'max-passes-reached'))
+      .toContain('Continuation stopped because the pass limit was reached.');
+    expect(swmShortfallClause(r26, 2, 'no-capable-peers'))
+      .toContain('Continuation stopped because no remaining peer reported holding the missing snapshots.');
+  });
+
+  it('never blames the clock for a stall, since a stall outranks the budget', () => {
+    // `coverage-stalled` outranks `budget-exhausted` in the policy, so a run
+    // that stalled AND expired reports the stall. If this text mentioned time
+    // it would send an operator to raise a budget that buys nothing — the
+    // precise misdirection that precedence exists to prevent.
+    const clause = swmShortfallClause(r26, 3, 'coverage-stalled');
+
+    expect(clause).toContain('a further pass stopped making progress, so more passes would not help');
+    expect(clause).not.toMatch(/budget|time|timed out|expired/i);
+  });
+
+  it('omits the stop reason when the continuation loop never ran', () => {
+    // Absent when shared memory was not requested; `continue` is not a stop.
+    expect(swmShortfallClause(r26, 0, undefined)).not.toContain('Continuation stopped');
+    expect(swmShortfallClause(r26, 0, 'continue')).not.toContain('Continuation stopped');
+  });
+
+  it('says an incomplete manifest was not retried, not merely that it is a bound', () => {
+    // Two distinct facts: the count understates the shortfall, AND that peer
+    // was dropped from later passes by the capability gate.
+    expect(swmShortfallClause({ ...r26, manifestComplete: false }, 1))
+      .toContain('250 is a lower bound and that peer was not retried.');
+  });
+
   it('leaves that terminal byte-identical when the round reported no coverage', () => {
     const c = classifyContextGraphCatchupReadiness({
       result: swmIncompleteProgress(),
@@ -838,4 +871,120 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
     result.diagnostics!.sharedMemory.insertedDataTriples = 5;
     return result;
   }
+});
+
+/**
+ * T16b (#2050) — the shortfall clause reaches the USER-VISIBLE error.
+ *
+ * Deliberately complementary to the implementer's own T16b, which asserts
+ * `swmShortfallClause` directly. This one never calls the formatter: it drives
+ * `classifyContextGraphCatchupReadiness` and asserts the composed terminal
+ * string, so it covers the SEAM — that the clause is actually appended, from
+ * the right fields, on the right branch.
+ *
+ * That seam is exactly what T16's prefix pin cannot see. Mutating the clause to
+ * return `''` leaves `startsWith(...)` green, because a prefix is satisfied by
+ * the prefix followed by nothing; these rows die. Two independent tests of an
+ * operator-facing string is not redundancy — the formatter test is the floor,
+ * this is the check.
+ */
+describe('T16b — the shortfall clause reaches the terminal message', () => {
+  const before = { version: 0, durableVerified: false, sharedMemoryVerified: false, updatedAt: 0 };
+  const PREFIX = 'Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.';
+
+  /** The r26 shape: data inserted, plane unproven, coverage 72 short. */
+  function shortfallResult(over: Partial<{
+    resolved: number; total: number; missingCount: number; missingSample: string[];
+    manifestComplete: boolean; continuationPasses: number;
+  }> = {}): CatchupJobResult {
+    const r = unresponsiveBase();
+    r.dataSynced = 5;
+    r.diagnostics!.durable.insertedDataTriples = 5;
+    r.diagnostics!.durable.timedOutPhases = 1;
+    const sm = r.diagnostics!.sharedMemory as Record<string, unknown>;
+    sm['swmCoverage'] = {
+      contextGraphId: 'cg-under-test',
+      peerIdSuffix: 'abcd1234',
+      snapshotsResolved: over.resolved ?? 178,
+      snapshotsTotal: over.total ?? 250,
+      manifestComplete: over.manifestComplete ?? true,
+      missingCount: over.missingCount ?? 72,
+      missingSample: over.missingSample ?? ['ref-a', 'ref-b'],
+    };
+    sm['continuationPasses'] = over.continuationPasses ?? 2;
+    return r;
+  }
+
+  function unresponsiveBase(): CatchupJobResult {
+    const plane = () => ({
+      fetchedMetaTriples: 0, fetchedDataTriples: 0, insertedMetaTriples: 0,
+      insertedDataTriples: 0, bytesReceived: 0, resumedPhases: 0, timedOutPhases: 0,
+      completedPhases: 0, checkpointAdvances: 0, emptyResponses: 0, metaOnlyResponses: 0,
+      dataRejectedMissingMeta: 0, rejectedKcs: 0, droppedDataTriples: 0,
+      failedPeers: 0, failedPhases: 0, deniedPhases: 0,
+    });
+    return {
+      connectedPeers: 1, totalPeers: 1, selectedPeers: 1, syncCapablePeers: 1,
+      peersTried: 1, peersResponded: 1, peersSucceeded: 1,
+      dataSynced: 0, sharedMemorySynced: 0, denied: false, deniedPeers: 0,
+      cleanPlaneCompletions: {
+        durable: { verifiedDataPeers: 0, emptyPeers: 0 },
+        sharedMemory: { verifiedDataPeers: 0, emptyPeers: 0 },
+      },
+      diagnostics: { noProtocolPeers: 0, durable: plane(), sharedMemory: plane() },
+    };
+  }
+
+  const errorFor = (result: CatchupJobResult) => classifyContextGraphCatchupReadiness({
+    result, includeSharedMemory: true, hasConfirmedMeta: true, isPrivate: false,
+    readinessBeforeCatchup: before,
+  }).error ?? '';
+
+  it('appends the shortfall AFTER the byte-identical existing sentence', () => {
+    const error = errorFor(shortfallResult());
+    expect(error.startsWith(PREFIX)).toBe(true);
+    // The part `startsWith` cannot see. A clause mutated to '' leaves the
+    // assertion above green and kills this one.
+    expect(error.length).toBeGreaterThan(PREFIX.length);
+    // The `(+70 more)` marker is not incidental: 72 outstanding against a
+    // 2-ref sample leaves 70 unnamed, and the reader must not mistake the named
+    // refs for the whole inventory. An earlier draft of this expectation omitted
+    // it — the producer caps the sample at 10, so a clause without a marker
+    // would silently understate every shortfall larger than the cap.
+    expect(error.slice(PREFIX.length)).toBe(
+      ' (Shared memory: 178/250 snapshots verified from peer …abcd1234'
+      + ' after 3 passes; 72 outstanding, including ref-a, ref-b (+70 more).)',
+    );
+  });
+
+  it('names the peer, the counts and the outstanding total from ONE record', () => {
+    const error = errorFor(shortfallResult());
+    expect(error).toContain('178/250');
+    expect(error).toContain('…abcd1234');
+    expect(error).toContain('72 outstanding');
+    // Never a synthetic pair, and never the durable plane: continuation passes
+    // repeat the shared-memory walk only.
+    expect(error).not.toContain('200/250');
+    expect(error.slice(PREFIX.length)).not.toContain('durable');
+  });
+
+  it('reports the WALK plus its repeats, not the repeat count alone', () => {
+    // `continuationPasses` counts repeats, so the text must read passes + 1.
+    expect(errorFor(shortfallResult({ continuationPasses: 0 }))).toContain('after 1 pass;');
+    expect(errorFor(shortfallResult({ continuationPasses: 1 }))).toContain('after 2 passes;');
+  });
+
+  it('emits NO clause when nothing is outstanding', () => {
+    // With largest-manifest ordering, `missingCount === 0` means the SWM plane
+    // resolved everything the best-informed peer knew of and the `unreachable`
+    // came from elsewhere. "0 outstanding" beside a failure verdict would
+    // misdirect, so the sentence must end byte-identical to pre-fix.
+    expect(errorFor(shortfallResult({ resolved: 250, missingCount: 0 }))).toBe(PREFIX);
+  });
+
+  it('flags a truncated manifest as a lower bound and says the peer was not retried', () => {
+    const error = errorFor(shortfallResult({ manifestComplete: false }));
+    expect(error).toContain('is a lower bound');
+    expect(error).toContain('not retried');
+  });
 });

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -728,8 +728,8 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
 
   it('names the counts, the peer, the pass count and the outstanding work', () => {
     expect(swmShortfallClause(r26, 2)).toBe(
-      ' (Shared memory: 178/250 snapshots verified from peer …abcd1234 after 3 passes;'
-      + ' 72 outstanding, including did:dkg:ka:one, did:dkg:ka:two (+70 more).)',
+      ' (Shared memory: 178/250 snapshots fetched from peer …abcd1234 after 3 passes;'
+      + ' 72 not retrieved, including did:dkg:ka:one, did:dkg:ka:two (+70 more).)',
     );
   });
 
@@ -770,7 +770,7 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
       0,
     );
 
-    expect(clause).toContain('2 outstanding, including did:dkg:ka:one, did:dkg:ka:two.)');
+    expect(clause).toContain('2 not retrieved, including did:dkg:ka:one, did:dkg:ka:two.)');
     expect(clause).not.toContain('more)');
   });
 
@@ -800,7 +800,7 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
     // Whole-string equality: the prefix pin in T16 cannot see the append.
     expect(c.error).toBe(INCOMPLETE_PROGRESS + swmShortfallClause(r26, 2));
     expect(c.error).toContain('178/250');
-    expect(c.error).toContain('72 outstanding');
+    expect(c.error).toContain('72 not retrieved');
   });
 
   it('says why continuation stopped, in words that match the reason', () => {
@@ -952,8 +952,8 @@ describe('T16b — the shortfall clause reaches the terminal message', () => {
     // it — the producer caps the sample at 10, so a clause without a marker
     // would silently understate every shortfall larger than the cap.
     expect(error.slice(PREFIX.length)).toBe(
-      ' (Shared memory: 178/250 snapshots verified from peer …abcd1234'
-      + ' after 3 passes; 72 outstanding, including ref-a, ref-b (+70 more).)',
+      ' (Shared memory: 178/250 snapshots fetched from peer …abcd1234'
+      + ' after 3 passes; 72 not retrieved, including ref-a, ref-b (+70 more).)',
     );
   });
 
@@ -961,7 +961,7 @@ describe('T16b — the shortfall clause reaches the terminal message', () => {
     const error = errorFor(shortfallResult());
     expect(error).toContain('178/250');
     expect(error).toContain('…abcd1234');
-    expect(error).toContain('72 outstanding');
+    expect(error).toContain('72 not retrieved');
     // Never a synthetic pair, and never the durable plane: continuation passes
     // repeat the shared-memory walk only.
     expect(error).not.toContain('200/250');
@@ -986,5 +986,69 @@ describe('T16b — the shortfall clause reaches the terminal message', () => {
     const error = errorFor(shortfallResult({ manifestComplete: false }));
     expect(error).toContain('is a lower bound');
     expect(error).toContain('not retried');
+  });
+});
+
+/**
+ * The two shortfall AXES (#2050). `missingCount` measures retrieval; writes are
+ * a separate counter. Gating the clause on retrieval alone made it go silent in
+ * exactly the failure class the G7 repair exists for — every ref fetched
+ * cleanly, some could not be written to the store — so the operator got the
+ * base sentence and nothing at all about shared memory.
+ */
+describe('T16c — retrieval and write shortfalls are reported separately', () => {
+  const base: SwmSnapshotCoverage = {
+    contextGraphId: 'medical-research',
+    peerIdSuffix: 'abcd1234',
+    snapshotsResolved: 250,
+    snapshotsTotal: 250,
+    manifestComplete: true,
+    missingCount: 0,
+    missingSample: [],
+    materializationFailures: 0,
+  };
+
+  it('speaks up when everything fetched but some writes failed', () => {
+    // Pre-fix this returned '' — the one case where shared memory WAS the
+    // problem was the one case the message said nothing about.
+    const clause = swmShortfallClause({ ...base, materializationFailures: 12 }, 0);
+
+    expect(clause).not.toBe('');
+    expect(clause).toContain('12 retrieved but not written to the store');
+  });
+
+  it('never claims snapshots were "verified" when none were written', () => {
+    // `snapshotsResolved` counts refs present and digest-valid in the blob
+    // cache, NOT Knowledge Assets written. Calling that "verified" would report
+    // "250/250 snapshots verified" on a graph where every write failed — wrong
+    // in the flattering direction and undetectable by the reader.
+    const clause = swmShortfallClause({ ...base, materializationFailures: 250 }, 0);
+
+    expect(clause).toContain('250/250 snapshots fetched');
+    expect(clause).not.toContain('verified');
+  });
+
+  it('reports both axes distinctly when both fail', () => {
+    const clause = swmShortfallClause(
+      { ...base, snapshotsResolved: 200, missingCount: 50, missingSample: ['ref-x'], materializationFailures: 7 },
+      1,
+    );
+
+    expect(clause).toContain('50 not retrieved, including ref-x');
+    expect(clause).toContain('7 retrieved but not written to the store');
+    // Separate clauses, not one conflated number: a retrieval shortfall sends
+    // an operator to the network, a write shortfall to the store.
+    expect(clause).toContain('50 not retrieved, including ref-x (+49 more); 7 retrieved but not written');
+  });
+
+  it('still says nothing when both axes are clean', () => {
+    expect(swmShortfallClause(base, 3)).toBe('');
+  });
+
+  it('treats an absent write counter as none known, not as a shortfall', () => {
+    // The record crosses a worker RPC boundary; an older or partial payload
+    // must not force a clause onto a round with nothing to report.
+    const { materializationFailures: _omitted, ...withoutCounter } = base;
+    expect(swmShortfallClause(withoutCounter as SwmSnapshotCoverage, 0)).toBe('');
   });
 });

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -531,3 +531,175 @@ describe('context graph catch-up readiness classification', () => {
     }).jobStatus).toBe('unreachable');
   });
 });
+
+/**
+ * T16 (#2050) — byte-equality characterization of EVERY terminal `error` string
+ * this module can emit.
+ *
+ * WHY THESE PASS ON THE PRE-FIX TREE, DELIBERATELY. These are characterization
+ * tests, written BEFORE Chunk 5 appends anything. All ten strings previously
+ * appeared ONLY in `context-graph-readiness.ts` — no test, no node-ui reference,
+ * no snapshot — so "the other strings are unchanged" was unverifiable. Passing
+ * pre-fix is their entire purpose; they are not evidence that any fix works.
+ * T16b (the appended shortfall) is the row that must fail pre-fix.
+ *
+ * Chunk 5 appends to exactly ONE of these — the `madeIncompleteProgress`
+ * message — which is therefore asserted as an exact PREFIX. The other nine are
+ * full equality and must stay byte-identical.
+ */
+describe('T16 — terminal readiness strings are byte-identical', () => {
+  const before = { version: 0, durableVerified: false, sharedMemoryVerified: false, updatedAt: 0 };
+
+  function zeroPlane() {
+    return {
+      fetchedMetaTriples: 0, fetchedDataTriples: 0, insertedMetaTriples: 0,
+      insertedDataTriples: 0, bytesReceived: 0, resumedPhases: 0, timedOutPhases: 0,
+      completedPhases: 0, checkpointAdvances: 0, emptyResponses: 0, metaOnlyResponses: 0,
+      dataRejectedMissingMeta: 0, rejectedKcs: 0, droppedDataTriples: 0,
+      failedPeers: 0, failedPhases: 0, deniedPhases: 0,
+    };
+  }
+
+  /** Every disjunct of `catchupResultHasCleanResponse` false — what the tail branches need. */
+  function unresponsive(): CatchupJobResult {
+    return {
+      connectedPeers: 0, totalPeers: 0, selectedPeers: 0, syncCapablePeers: 0,
+      peersTried: 0, peersResponded: 0, peersSucceeded: 0,
+      dataSynced: 0, sharedMemorySynced: 0, denied: false, deniedPeers: 0,
+      cleanPlaneCompletions: {
+        durable: { verifiedDataPeers: 0, emptyPeers: 0 },
+        sharedMemory: { verifiedDataPeers: 0, emptyPeers: 0 },
+      },
+      diagnostics: { noProtocolPeers: 0, durable: zeroPlane(), sharedMemory: zeroPlane() },
+    };
+  }
+
+  function responding(): CatchupJobResult {
+    const r = unresponsive();
+    r.connectedPeers = 1; r.totalPeers = 1; r.selectedPeers = 1; r.syncCapablePeers = 1;
+    r.peersTried = 1; r.peersResponded = 1; r.peersSucceeded = 1;
+    return r;
+  }
+
+  /**
+   * A clean response that proves NOTHING. Proving the plane instead
+   * (`verifiedDataPeers = 1`) makes `catchupPlaneProvenByData` fire, so
+   * `missingGraphProof` is false and the classification returns `done` with no
+   * error at all — the metadata-only route reaches the clean-response gate while
+   * leaving every proof path false.
+   */
+  function metadataOnly(): CatchupJobResult {
+    const r = responding();
+    r.diagnostics!.durable.fetchedMetaTriples = 10;
+    r.diagnostics!.durable.metaOnlyResponses = 1;
+    return r;
+  }
+
+  function durableProven(): CatchupJobResult {
+    const r = responding();
+    r.dataSynced = 5;
+    r.diagnostics!.durable.insertedDataTriples = 5;
+    r.diagnostics!.durable.completedPhases = 1;
+    r.cleanPlaneCompletions!.durable.verifiedDataPeers = 1;
+    return r;
+  }
+
+  const classify = (
+    result: CatchupJobResult,
+    over: Partial<{ includeSharedMemory: boolean; hasConfirmedMeta: boolean; isPrivate: boolean }> = {},
+  ) => classifyContextGraphCatchupReadiness({
+    result, includeSharedMemory: false, hasConfirmedMeta: true, isPrivate: false,
+    readinessBeforeCatchup: before, ...over,
+  });
+
+  it('pins the missing-authoritative-metadata string', () => {
+    const c = classify(metadataOnly(), { hasConfirmedMeta: false });
+    expect(c.jobStatus).toBe('unreachable');
+    expect(c.error).toBe('No peer delivered authoritative context-graph metadata — the curator may be offline, or responding peers do not host this project.');
+  });
+
+  it('pins the incomplete-progress sentence as an exact PREFIX (Chunk 5 appends here)', () => {
+    const r = responding();
+    r.dataSynced = 5;
+    r.diagnostics!.durable.insertedDataTriples = 5;
+    r.diagnostics!.durable.timedOutPhases = 1;
+    const c = classify(r);
+    expect(c.jobStatus).toBe('unreachable');
+    expect(c.error?.startsWith('Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.')).toBe(true);
+  });
+
+  it('pins the private missing-graph-proof string', () => {
+    const c = classify(metadataOnly(), { isPrivate: true });
+    expect(c.jobStatus).toBe('unreachable');
+    expect(c.error).toBe('No authorized context-graph peer delivered verified durable or shared-memory data — empty or metadata-only responses cannot prove a private graph is fully synchronized, and the curator may be offline.');
+  });
+
+  it('pins the private durable-ok-shared-memory-incomplete string', () => {
+    const c = classify(durableProven(), { isPrivate: true, includeSharedMemory: true });
+    expect(c.jobStatus).toBe('unreachable');
+    expect(c.error).toBe('Durable context-graph data synchronized, but shared-memory catch-up did not complete. Retry to finish shared-memory synchronization.');
+  });
+
+  it('pins the public not-clean-for-every-plane string', () => {
+    const c = classify(metadataOnly());
+    expect(c.jobStatus).toBe('unreachable');
+    expect(c.error).toBe('Context-graph catch-up did not complete cleanly for every requested data plane. Retry once the network is healthier.');
+  });
+
+  it('pins the no-peer-could-deliver string', () => {
+    const r = unresponsive();
+    r.peersTried = 2; r.peersResponded = 0;
+    const c = classify(r);
+    expect(c.jobStatus).toBe('unreachable');
+    expect(c.error).toBe("No peer could deliver this project's data — the curator may be offline, or no node currently holds the data. You can still send a signed join request; they will receive it next time they come online.");
+  });
+
+  it('pins the all-reachable-peers-failed string', () => {
+    const r = unresponsive();
+    r.peersTried = 2; r.peersResponded = 1;
+    const c = classify(r);
+    expect(c.jobStatus).toBe('failed');
+    expect(c.error).toBe('Sync did not complete — all reachable peers failed (timeouts or transport errors). Retry once the network is healthier.');
+  });
+
+  it('pins the no-sync-capable-peers string', () => {
+    const r = unresponsive();
+    r.connectedPeers = 3; r.totalPeers = 3; r.selectedPeers = 3; r.syncCapablePeers = 0;
+    const c = classify(r);
+    expect(c.jobStatus).toBe('unreachable');
+    expect(c.error).toBe('No sync-capable peers found for catch-up — the curator may be offline.');
+  });
+
+  it('pins the no-peers-connected string', () => {
+    const c = classify(unresponsive());
+    expect(c.jobStatus).toBe('unreachable');
+    expect(c.error).toBe("No peers connected — couldn't reach the curator. They may be offline, or your node hasn't bootstrapped to the network yet.");
+  });
+
+  it('pins both denial strings, singular and plural', () => {
+    // Field-by-field rather than `toMatchObject`: this is the one pair in the
+    // set where a partial match would tolerate an extra field appearing on the
+    // classification without anyone noticing.
+    const one = unresponsive();
+    one.denied = true; one.deniedPeers = 1;
+    const c1 = classify(one);
+    expect(c1.jobStatus).toBe('denied');
+    expect(c1.error).toBe('Sync denied by remote peer');
+
+    const many = unresponsive();
+    many.denied = true; many.deniedPeers = 3;
+    const c3 = classify(many);
+    expect(c3.jobStatus).toBe('denied');
+    expect(c3.error).toBe('Sync denied by 3 remote peers');
+  });
+
+  it('leaves `error` ABSENT on a clean `done` classification', () => {
+    // The other direction, and nothing else in this file can see it. Every row
+    // above pins a POPULATED error, so all of them would still pass if the
+    // module grew a spurious message on the success path — a user-visible
+    // regression that a suite of positive assertions is blind to.
+    const c = classify(durableProven());
+    expect(c.jobStatus).toBe('done');
+    expect(c.error).toBeUndefined();
+  });
+});

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -1079,6 +1079,56 @@ describe('T16c — retrieval and write shortfalls are reported separately', () =
     expect(clause).not.toContain('57');
   });
 
+  it('neutralises control characters in a peer-supplied ref', () => {
+    // The refs named here are `dkg:publicSnapshotRef` literals chosen by a
+    // REMOTE peer and only `.trim()`ed by the producer. Rendered verbatim into
+    // a message that reaches the API and the node UI, a peer could forge a line
+    // that reads as our own diagnostics.
+    const clause = swmShortfallClause(
+      {
+        ...base,
+        snapshotsResolved: 249,
+        missingCount: 1,
+        missingSample: ['ref-a\nSync denied by 3 remote peers'],
+      },
+      0,
+    );
+
+    // The forged sentence must not survive as a separate line...
+    expect(clause).not.toContain('\n');
+    expect(clause).not.toMatch(/[\u0000-\u001F\u007F-\u009F]/u);
+    // ...and the ref must not collapse to 'ref-aSync denied...' either, which
+    // would let a crafted literal impersonate a DIFFERENT real ref. The control
+    // character is replaced, not deleted.
+    expect(clause).not.toContain('ref-aSync denied');
+    expect(clause).toContain('ref-a\uFFFDSync denied by 3 remote peers');
+  });
+
+  it('bounds one overlong peer-supplied ref without breaking the (+N more) count', () => {
+    // Capping the SAMPLE SIZE bounds how many refs are named, not how long each
+    // one is. Ten peer-chosen megabyte literals would otherwise be ten megabytes
+    // of operator-facing error string.
+    const overlong = 'x'.repeat(5000);
+    const clause = swmShortfallClause(
+      {
+        ...base,
+        snapshotsResolved: 200,
+        missingCount: 50,
+        missingSample: [overlong, 'ref-b'],
+      },
+      0,
+    );
+
+    expect(clause).not.toContain(overlong);
+    expect(clause).toContain('\u2026(truncated)');
+    expect(clause.length).toBeLessThan(500);
+    // Accounting is on the SAMPLE COUNT, which sanitising cannot change: 50
+    // outstanding, 2 named, so 48 unnamed — unchanged by truncation.
+    expect(clause).toContain('(+48 more)');
+    // The surviving ref is still rendered whole.
+    expect(clause).toContain('ref-b');
+  });
+
   it('still says nothing when both axes are clean', () => {
     expect(swmShortfallClause(base, 3)).toBe('');
   });

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -737,8 +737,8 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
 
   it('names the counts, the peer, the pass count and the outstanding work', () => {
     expect(swmShortfallClause(r26, 2)).toBe(
-      ' (Shared memory: 178/250 snapshots fetched from peer …abcd1234 after 3 passes;'
-      + ' 72 not retrieved, including did:dkg:ka:one, did:dkg:ka:two (+70 more).)',
+      ' (Shared memory: 178/250 snapshots materialized from peer …abcd1234 after 3 passes;'
+      + ' 72 not materialized, including did:dkg:ka:one, did:dkg:ka:two (+70 more).)',
     );
   });
 
@@ -779,7 +779,7 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
       0,
     );
 
-    expect(clause).toContain('2 not retrieved, including did:dkg:ka:one, did:dkg:ka:two.)');
+    expect(clause).toContain('2 not materialized, including did:dkg:ka:one, did:dkg:ka:two.)');
     expect(clause).not.toContain('more)');
   });
 
@@ -809,7 +809,7 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
     // Whole-string equality: the prefix pin in T16 cannot see the append.
     expect(c.error).toBe(INCOMPLETE_PROGRESS + swmShortfallClause(r26, 2));
     expect(c.error).toContain('178/250');
-    expect(c.error).toContain('72 not retrieved');
+    expect(c.error).toContain('72 not materialized');
   });
 
   it('says why continuation stopped, in words that match the reason', () => {
@@ -910,8 +910,12 @@ describe('T16b — the shortfall clause reaches the terminal message', () => {
     r.dataSynced = 5;
     r.diagnostics!.durable.insertedDataTriples = 5;
     r.diagnostics!.durable.timedOutPhases = 1;
-    const sm = r.diagnostics!.sharedMemory as Record<string, unknown>;
-    sm['swmCoverage'] = {
+    // Typed, NOT an untyped literal behind the Record cast. The cast is needed
+    // to assign onto the diagnostics bag, but letting it swallow the literal too
+    // meant this fixture omitted `materializationFailures` — a required field —
+    // and would have kept compiling if the production shape grew another one.
+    // The cast belongs on the assignment target, never on the value.
+    const coverage: SwmSnapshotCoverage = {
       contextGraphId: 'cg-under-test',
       peerIdSuffix: 'abcd1234',
       snapshotsResolved: over.resolved ?? 178,
@@ -919,7 +923,10 @@ describe('T16b — the shortfall clause reaches the terminal message', () => {
       manifestComplete: over.manifestComplete ?? true,
       missingCount: over.missingCount ?? 72,
       missingSample: over.missingSample ?? ['ref-a', 'ref-b'],
+      materializationFailures: 0,
     };
+    const sm = r.diagnostics!.sharedMemory as Record<string, unknown>;
+    sm['swmCoverage'] = coverage;
     sm['continuationPasses'] = over.continuationPasses ?? 2;
     return r;
   }
@@ -961,8 +968,8 @@ describe('T16b — the shortfall clause reaches the terminal message', () => {
     // it — the producer caps the sample at 10, so a clause without a marker
     // would silently understate every shortfall larger than the cap.
     expect(error.slice(PREFIX.length)).toBe(
-      ' (Shared memory: 178/250 snapshots fetched from peer …abcd1234'
-      + ' after 3 passes; 72 not retrieved, including ref-a, ref-b (+70 more).)',
+      ' (Shared memory: 178/250 snapshots materialized from peer …abcd1234'
+      + ' after 3 passes; 72 not materialized, including ref-a, ref-b (+70 more).)',
     );
   });
 
@@ -970,7 +977,7 @@ describe('T16b — the shortfall clause reaches the terminal message', () => {
     const error = errorFor(shortfallResult());
     expect(error).toContain('178/250');
     expect(error).toContain('…abcd1234');
-    expect(error).toContain('72 not retrieved');
+    expect(error).toContain('72 not materialized');
     // Never a synthetic pair, and never the durable plane: continuation passes
     // repeat the shared-memory walk only.
     expect(error).not.toContain('200/250');
@@ -1017,37 +1024,58 @@ describe('T16c — retrieval and write shortfalls are reported separately', () =
     materializationFailures: 0,
   };
 
-  it('speaks up when everything fetched but some writes failed', () => {
+  it('speaks up when refs fetched cleanly but their writes failed', () => {
     // Pre-fix this returned '' — the one case where shared memory WAS the
     // problem was the one case the message said nothing about.
-    const clause = swmShortfallClause({ ...base, materializationFailures: 12 }, 0);
+    //
+    // The fixture is a REPRESENTABLE record, which the original was not: it
+    // paired `missingCount: 0` with 12 write failures, and the producer cannot
+    // emit that. A ref whose descriptor throws is excluded from the materialized
+    // set, so `snapshotsResolved` falls and `missingCount` rises with it. Pinning
+    // an impossible pair meant this row could not have caught the producer
+    // drifting away from it.
+    const clause = swmShortfallClause(
+      { ...base, snapshotsResolved: 238, missingCount: 12, materializationFailures: 12 },
+      0,
+    );
 
     expect(clause).not.toBe('');
-    expect(clause).toContain('12 retrieved but not written to the store');
+    expect(clause).toContain('238/250 snapshots materialized');
+    expect(clause).toContain('12 not materialized');
+    expect(clause).toContain('12 store write failure(s)');
   });
 
-  it('never claims snapshots were "verified" when none were written', () => {
-    // `snapshotsResolved` counts refs present and digest-valid in the blob
-    // cache, NOT Knowledge Assets written. Calling that "verified" would report
-    // "250/250 snapshots verified" on a graph where every write failed — wrong
-    // in the flattering direction and undetectable by the reader.
-    const clause = swmShortfallClause({ ...base, materializationFailures: 250 }, 0);
+  it('never claims snapshots were fetched or verified when none were written', () => {
+    // `snapshotsResolved` counts Knowledge Assets WRITTEN, so a round that
+    // cached all 250 blobs and wrote none reports 0, not 250. Reporting either
+    // "250/250 fetched" or "verified" here would be wrong in the flattering
+    // direction and undetectable by the reader.
+    const clause = swmShortfallClause(
+      { ...base, snapshotsResolved: 0, missingCount: 250, materializationFailures: 250 },
+      0,
+    );
 
-    expect(clause).toContain('250/250 snapshots fetched');
+    expect(clause).toContain('0/250 snapshots materialized');
     expect(clause).not.toContain('verified');
+    expect(clause).not.toContain('fetched');
   });
 
-  it('reports both axes distinctly when both fail', () => {
+  it('names the outstanding work and the store cause as separate facts', () => {
     const clause = swmShortfallClause(
       { ...base, snapshotsResolved: 200, missingCount: 50, missingSample: ['ref-x'], materializationFailures: 7 },
       1,
     );
 
-    expect(clause).toContain('50 not retrieved, including ref-x');
-    expect(clause).toContain('7 retrieved but not written to the store');
-    // Separate clauses, not one conflated number: a retrieval shortfall sends
-    // an operator to the network, a write shortfall to the store.
-    expect(clause).toContain('50 not retrieved, including ref-x (+49 more); 7 retrieved but not written');
+    expect(clause).toContain('50 not materialized, including ref-x');
+    expect(clause).toContain('7 store write failure(s)');
+    // Separate clauses, and deliberately NOT phrased as "50, of which 7":
+    // `missingCount` counts REFS while `materializationFailures` counts
+    // DESCRIPTORS, so neither is a subset count of the other. The write count is
+    // a CAUSE indicator — it says the shortfall is the store, not the network.
+    expect(clause).toContain('50 not materialized, including ref-x (+49 more); 7 store write failure(s)');
+    // The two are never added: 50 is the whole shortfall, already including
+    // every unwritten ref.
+    expect(clause).not.toContain('57');
   });
 
   it('still says nothing when both axes are clean', () => {

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -627,7 +627,7 @@ describe('T16 — terminal readiness strings are byte-identical', () => {
     r.diagnostics!.durable.timedOutPhases = 1;
     const c = classify(r);
     expect(c.jobStatus).toBe('unreachable');
-    expect(c.error?.startsWith('Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.')).toBe(true);
+    expect(c.error).toBe('Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.');
   });
 
   it('pins the private missing-graph-proof string', () => {

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { CatchupJobResult } from '../src/catchup-runner.js';
+import type { SwmSnapshotCoverage } from '@origintrail-official/dkg-agent';
 import {
   CONTEXT_GRAPH_READINESS_VERSION,
   classifyContextGraphCatchupReadiness,
+  swmShortfallClause,
 } from '../src/context-graph-readiness.js';
 
 function mixedPeerResult(verifiedDataPeers: number): CatchupJobResult {
@@ -702,4 +704,138 @@ describe('T16 — terminal readiness strings are byte-identical', () => {
     expect(c.jobStatus).toBe('done');
     expect(c.error).toBeUndefined();
   });
+});
+
+/**
+ * The shortfall clause Chunk 5 appends. Kept separate from T16 above, which
+ * pins the ten base strings: T16 asserts the incomplete-progress message as a
+ * PREFIX, so it is satisfied by that prefix followed by anything at all — it
+ * cannot see whether this clause is correct, malformed, or absent. These rows
+ * are the ones that can.
+ */
+describe('T16b — the shared-memory shortfall clause (#2050)', () => {
+  const INCOMPLETE_PROGRESS = 'Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.';
+
+  const r26: SwmSnapshotCoverage = {
+    contextGraphId: 'medical-research',
+    peerIdSuffix: 'abcd1234',
+    snapshotsResolved: 178,
+    snapshotsTotal: 250,
+    manifestComplete: true,
+    missingCount: 72,
+    missingSample: ['did:dkg:ka:one', 'did:dkg:ka:two'],
+  };
+
+  it('names the counts, the peer, the pass count and the outstanding work', () => {
+    expect(swmShortfallClause(r26, 2)).toBe(
+      ' (Shared memory: 178/250 snapshots verified from peer …abcd1234 after 3 passes;'
+      + ' 72 outstanding, including did:dkg:ka:one, did:dkg:ka:two (+70 more).)',
+    );
+  });
+
+  it('says "1 pass" when the walk was never repeated', () => {
+    // `continuationPasses` counts the REPEATS, so zero repeats is still one walk.
+    expect(swmShortfallClause(r26, 0)).toContain('after 1 pass;');
+    expect(swmShortfallClause(r26, undefined)).toContain('after 1 pass;');
+  });
+
+  it('adds nothing when there is no shortfall to report', () => {
+    // Both must be exactly '' or the base sentence stops being byte-identical
+    // on every path that has nothing to say. The second case matters most: a
+    // fully-resolved manifest beside an `unreachable` verdict means the
+    // shortfall is on another plane, and "0 outstanding" would misdirect.
+    expect(swmShortfallClause(undefined, 3)).toBe('');
+    expect(swmShortfallClause({ ...r26, missingCount: 0, missingSample: [] }, 3)).toBe('');
+  });
+
+  it('calls an incomplete manifest a lower bound rather than a total', () => {
+    expect(swmShortfallClause({ ...r26, manifestComplete: false }, 0))
+      .toContain("The peer's snapshot manifest was itself incomplete, so 250 is a lower bound.");
+  });
+
+  it('caps the named identifiers and accounts for the ones it omits', () => {
+    const many = Array.from({ length: 25 }, (_, i) => `did:dkg:ka:${i}`);
+    const clause = swmShortfallClause({ ...r26, missingCount: 90, missingSample: many }, 1);
+
+    // Exactly ten named — ka:0 through ka:9, the tenth followed by the marker
+    // rather than a comma — and the marker accounts for the other eighty.
+    expect(clause).toContain('did:dkg:ka:9 (+80 more)');
+    expect(clause).not.toContain('did:dkg:ka:10');
+    expect(clause.match(/did:dkg:ka:\d+/g)).toHaveLength(10);
+  });
+
+  it('drops the marker when every outstanding ref is named', () => {
+    const clause = swmShortfallClause(
+      { ...r26, missingCount: 2, missingSample: ['did:dkg:ka:one', 'did:dkg:ka:two'] },
+      0,
+    );
+
+    expect(clause).toContain('2 outstanding, including did:dkg:ka:one, did:dkg:ka:two.)');
+    expect(clause).not.toContain('more)');
+  });
+
+  it('scopes every figure to shared memory, never implying a durable retry', () => {
+    // Continuation passes repeat the shared-memory peer walk ONLY. A reader
+    // must not infer the durable plane was retried three times.
+    const clause = swmShortfallClause(r26, 2);
+
+    expect(clause).toContain('Shared memory:');
+    expect(clause.toLowerCase()).not.toContain('durable');
+  });
+
+  it('appends to the incomplete-progress terminal, leaving its sentence byte-identical', () => {
+    const result = swmIncompleteProgress();
+    result.diagnostics!.sharedMemory.swmCoverage = r26;
+    result.diagnostics!.sharedMemory.continuationPasses = 2;
+
+    const c = classifyContextGraphCatchupReadiness({
+      result,
+      includeSharedMemory: true,
+      hasConfirmedMeta: true,
+      isPrivate: false,
+      readinessBeforeCatchup: { version: 0, durableVerified: false, sharedMemoryVerified: false, updatedAt: 0 },
+    });
+
+    expect(c.jobStatus).toBe('unreachable');
+    // Whole-string equality: the prefix pin in T16 cannot see the append.
+    expect(c.error).toBe(INCOMPLETE_PROGRESS + swmShortfallClause(r26, 2));
+    expect(c.error).toContain('178/250');
+    expect(c.error).toContain('72 outstanding');
+  });
+
+  it('leaves that terminal byte-identical when the round reported no coverage', () => {
+    const c = classifyContextGraphCatchupReadiness({
+      result: swmIncompleteProgress(),
+      includeSharedMemory: true,
+      hasConfirmedMeta: true,
+      isPrivate: false,
+      readinessBeforeCatchup: { version: 0, durableVerified: false, sharedMemoryVerified: false, updatedAt: 0 },
+    });
+
+    expect(c.error).toBe(INCOMPLETE_PROGRESS);
+  });
+
+  /** A responding round that stored verified SWM data without completing the plane. */
+  function swmIncompleteProgress(): CatchupJobResult {
+    const plane = () => ({
+      fetchedMetaTriples: 0, fetchedDataTriples: 0, insertedMetaTriples: 0,
+      insertedDataTriples: 0, bytesReceived: 0, resumedPhases: 0, timedOutPhases: 0,
+      completedPhases: 0, checkpointAdvances: 0, emptyResponses: 0, metaOnlyResponses: 0,
+      dataRejectedMissingMeta: 0, rejectedKcs: 0, droppedDataTriples: 0,
+      failedPeers: 0, failedPhases: 0, deniedPhases: 0,
+    });
+    const result = {
+      connectedPeers: 1, totalPeers: 1, selectedPeers: 1, syncCapablePeers: 1,
+      peersTried: 1, peersResponded: 1, peersSucceeded: 1,
+      dataSynced: 0, sharedMemorySynced: 5, denied: false, deniedPeers: 0,
+      cleanPlaneCompletions: {
+        durable: { verifiedDataPeers: 0, emptyPeers: 0 },
+        sharedMemory: { verifiedDataPeers: 0, emptyPeers: 0 },
+      },
+      diagnostics: { noProtocolPeers: 0, durable: plane(), sharedMemory: plane() },
+    } as unknown as CatchupJobResult;
+    // Progress without proof: this is what `madeIncompleteProgress` reads.
+    result.diagnostics!.sharedMemory.insertedDataTriples = 5;
+    return result;
+  }
 });

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -733,6 +733,7 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
     manifestComplete: true,
     missingCount: 72,
     missingSample: ['did:dkg:ka:one', 'did:dkg:ka:two'],
+    materializationFailures: 0,
   };
 
   it('names the counts, the peer, the pass count and the outstanding work', () => {

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -708,10 +708,19 @@ describe('T16 — terminal readiness strings are byte-identical', () => {
 
 /**
  * The shortfall clause Chunk 5 appends. Kept separate from T16 above, which
- * pins the ten base strings: T16 asserts the incomplete-progress message as a
- * PREFIX, so it is satisfied by that prefix followed by anything at all — it
- * cannot see whether this clause is correct, malformed, or absent. These rows
- * are the ones that can.
+ * pins the ten base strings.
+ *
+ * T16 used to assert the incomplete-progress message as a PREFIX — satisfied by
+ * that prefix followed by anything at all, including nothing. It now pins the
+ * whole string with `toBe`, because the weaker form bought nothing: that
+ * fixture appends no shortfall, so full equality passes unchanged and can
+ * additionally catch a clause wrongly appended there.
+ *
+ * The strengthening does NOT make these rows redundant, for the reason that
+ * matters: T16's scenario never appends a clause, so no assertion of any
+ * strength in it can observe whether THIS clause is correct, malformed or
+ * absent. Strength and reachability are different properties — these rows are
+ * the ones that reach it.
  */
 describe('T16b — the shared-memory shortfall clause (#2050)', () => {
   const INCOMPLETE_PROGRESS = 'Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.';

--- a/packages/cli/test/helpers/catchup-runner-worker-test-harness.ts
+++ b/packages/cli/test/helpers/catchup-runner-worker-test-harness.ts
@@ -1,0 +1,111 @@
+import { vi } from 'vitest';
+import type { CatchupJobResult, CatchupRunRequest } from '../../src/catchup-runner.js';
+
+export type CatchupWorkerInvokeHandler = (
+  method: string,
+  args: unknown[],
+) => Promise<unknown>;
+
+// The worker implementation binds parentPort at module load. Keeping this mock
+// in one helper gives every worker suite the same RPC boundary and prevents a
+// future protocol change from being patched into several copied harnesses.
+const fakeCatchupParentPort = vi.hoisted(() => {
+  const messageListeners: Array<(message: any) => void> = [];
+  const port = {
+    on(event: string, listener: (message: any) => void) {
+      if (event === 'message') messageListeners.push(listener);
+    },
+    onPosted: undefined as ((message: any) => void) | undefined,
+    postMessage(message: any) {
+      port.onPosted?.(message);
+    },
+    emitMessage(message: any) {
+      for (const listener of messageListeners) listener(message);
+    },
+  };
+  return port;
+});
+
+vi.mock('node:worker_threads', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:worker_threads')>()),
+  parentPort: fakeCatchupParentPort,
+}));
+
+export function durableCatchupResult() {
+  return {
+    insertedTriples: 1,
+    complete: true,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 1,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 1,
+    bytesReceived: 10,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    metaOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+export function sharedCatchupResult() {
+  return {
+    insertedTriples: 1,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 1,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 1,
+    bytesReceived: 10,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    droppedDataTriples: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    deferredBackpressure: 0,
+  };
+}
+
+let nextRunId = 1;
+
+export async function runWorkerCatchup(
+  request: CatchupRunRequest,
+  handler: CatchupWorkerInvokeHandler,
+): Promise<CatchupJobResult> {
+  await import('../../src/catchup-runner-worker-impl.js');
+  const runId = nextRunId++;
+  return new Promise<CatchupJobResult>((resolve, reject) => {
+    fakeCatchupParentPort.onPosted = (message: any) => {
+      if (message.type === 'invoke') {
+        handler(message.method, message.args).then(
+          (result) => fakeCatchupParentPort.emitMessage({
+            type: 'invoke-result',
+            invokeId: message.invokeId,
+            result,
+          }),
+          (error: unknown) => fakeCatchupParentPort.emitMessage({
+            type: 'invoke-result',
+            invokeId: message.invokeId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+        return;
+      }
+      if (message.type === 'run-result' && message.runId === runId) {
+        if (message.error) reject(new Error(message.error));
+        else resolve(message.result as CatchupJobResult);
+      }
+    };
+    fakeCatchupParentPort.emitMessage({ type: 'run', runId, request });
+  });
+}

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -73,6 +73,15 @@ export default defineConfig({
           // a fake worker thread; no hardhat.
           'test/daemon-catchup-telemetry-shutdown.test.ts',
           'test/catchup-runner-worker-killswitch.test.ts',
+          // #2050 — `DKG_SWM_CATCHUP_PASS_BUDGET_MS=0` continuation-pass kill
+          // switch, end to end through the worker. Its own file because the
+          // budget constant freezes at module load, so the env must be set
+          // before the policy module is imported.
+          'test/catchup-runner-worker-pass-budget-killswitch.test.ts',
+          // #2050 — the sibling lever, `DKG_SWM_CATCHUP_MAX_PASSES=1`. Separate
+          // file from the budget one because `max-passes-reached` is checked
+          // first, so one file holding both switches would mask the budget row.
+          'test/catchup-runner-worker-max-passes-cap.test.ts',
           'test/relay-status-block.test.ts',
           'test/supervisor-liveness.test.ts',
           'test/promote-async-routes.test.ts',

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -78,6 +78,10 @@ export default defineConfig({
           'test/catchup-runner-worker-pass-budget-killswitch.test.ts',
           // #2050 — the sibling lever, `DKG_SWM_CATCHUP_MAX_PASSES=1`.
           'test/catchup-runner-worker-max-passes-cap.test.ts',
+          // #2050 — a deferred CONTINUATION pass must not demote a job that
+          // already succeeded (the daemon route short-circuits classification
+          // on the job-level scalar), and denial counts DISTINCT peers.
+          'test/catchup-runner-worker-continuation-deferral.test.ts',
           'test/relay-status-block.test.ts',
           'test/supervisor-liveness.test.ts',
           'test/promote-async-routes.test.ts',

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -74,13 +74,9 @@ export default defineConfig({
           'test/daemon-catchup-telemetry-shutdown.test.ts',
           'test/catchup-runner-worker-killswitch.test.ts',
           // #2050 — `DKG_SWM_CATCHUP_PASS_BUDGET_MS=0` continuation-pass kill
-          // switch, end to end through the worker. Its own file because the
-          // budget constant freezes at module load, so the env must be set
-          // before the policy module is imported.
+          // switch, end to end through the worker with per-job config resolution.
           'test/catchup-runner-worker-pass-budget-killswitch.test.ts',
-          // #2050 — the sibling lever, `DKG_SWM_CATCHUP_MAX_PASSES=1`. Separate
-          // file from the budget one because `max-passes-reached` is checked
-          // first, so one file holding both switches would mask the budget row.
+          // #2050 — the sibling lever, `DKG_SWM_CATCHUP_MAX_PASSES=1`.
           'test/catchup-runner-worker-max-passes-cap.test.ts',
           'test/relay-status-block.test.ts',
           'test/supervisor-liveness.test.ts',


### PR DESCRIPTION
## Summary

- **Public SWM catch-up now repeats, bounded and progress-aware.** A receiver fetches SWM content as immutable content-addressed snapshots, one KA at a time, inside a **single 120 s deadline that also covers the metadata and aggregate-data phases**. When it expired mid-list, `syncPublicSnapshotsForMeta` abandoned every remaining snapshot, and the identity of the missing set — fully computable in memory at that instant — was discarded one stack frame later. Each peer got one round, the walk ran once, and the job terminated `unreachable` with a partial graph and no resume path. Another pass now runs while the job budget allows, coverage is still advancing, and at least one peer demonstrably holds descriptors we lack.
- **This is not a new mechanism.** The repo already runs a bounded round loop on this lane for post-approval curator sync (`MAX_POST_APPROVAL_CURATOR_SYNC_ROUNDS`). #2050 is that loop missing from the general foreground catch-up. Admission is acquired and released per peer per pass **by the existing code**, so scheduler fairness is preserved by construction — no coordinator, no manifest freeze, no new admission primitive, no change to `ordered-sync.ts` or the single-flight keys.
- **A second defect, not in the issue: head rows were deleted and never rewritten.** `replaceHeadMetadata` is delete-only, and the compensating bulk `storeInsert(processed.verifiedMeta)` sits **below the `continue`** on the failure branch. A partial round therefore deleted head rows for the KAs it had just materialized: **content present, heads absent, invisible to every head reader, and permanent** — the next round sees the content and skips. Now compensated immediately after **every** call that deletes a head, inside the existing write lock.
- **A third defect, caught by this PR's own review, in this PR's own fix.** `snapshotsResolved` counted refs **fetched**, not KAs **materialized** — and that field is read by three consumers: the terminal message, the capability gate, and the coverage high-water mark. A round that cached all N refs and failed every materialization reported `N/N`, so the gate computed `N < N` → false and dropped the peer while the mark saturated. **The walk stopped having written zero KAs, silently disabling the retry loop in exactly the failure class the loop exists for.** It presented as a reporting defect and was classified as one. `missingCount` is now *derived* from the resolved count, so `resolved + missing === total` holds by construction.
- **Terminal reporting now names the shortfall and why the loop stopped.** Previously a job could end `unreachable` saying nothing about shared memory at all. Stop reasons render through an exhaustive `Record` over a closed union, so a new reason fails the build rather than rendering nothing.

### Deferred deliberately — please read before approving

- **Metadata and aggregate-data replay per pass.** Each pass re-fetches the manifest per capable peer. This is the accepted cost of the chosen design and is now **measurable**: `replayPhaseBytesReceived` / `snapshotPhaseBytesReceived` split the previously-merged `bytesReceived` scalar. → #2078
- **The paired Base Sepolia acceptance runs have NOT been run.** Methodology is prepared: rows normalized **per job and per materialized KA** (never per admission — extra passes create admissions by construction), queue-wait labelled **admitted-only** because `syncSchedulerQueueWaitMs` is recorded only after `start()` succeeds, and validity gated on comparable rejection counts. In a change that *increases* admissions, an unlabelled p95 would be unfalsifiable in the flattering direction.
- **In-agent `runCatchupOverPeers` parity is not implemented.** All three live callers are already bounded retry loops, so naive parity would nest a loop inside loops that already retry — a defect, not a missing half. That path still propagates every #2050 diagnostic; it does not repeat the walk.
- **`snapshotsTotal > 0` in the capability gate is inert** — a defensive restatement its neighbour already enforces at `0 < 0`. Documented in code as unpinnable-by-construction rather than patched around with an impossible fixture.

## Related

- Fixes #2050
- Follows #2053 (sync pressure, #2052) — this branch is based on its merge commit `31be166b8`
- Follow-ups filed: #2077 fetch concurrency · #2078 frozen manifest · #2079 O(1) materialized witness · #2080 private-driver wall clock · #2081 last-round-only counters · #2082 NUL-byte CI guard · #2083 adopt `shared-memory-sync-ownership.test.ts` · #2084 no chain-anchored SWM inventory · #2085 blob-store GC

## Diagrams

### Flow 1 — the snapshot walk when the deadline expires mid-list

Before — one pass per peer; the tail is abandoned and the missing set is discarded:

```mermaid
sequenceDiagram
    participant Job as Catch-up job
    participant Walk as syncPublicSnapshotsForMeta
    participant Peer
    participant Store as Triple store
    Job->>Walk: one pass (120s deadline covers meta + data + ALL snapshots)
    Walk->>Peer: fetch manifest (250 snapshots)
    loop until the deadline expires
        Walk->>Peer: fetch snapshot[i]
        Walk->>Store: materialize KA[i]
    end
    Note over Walk: deadline expires at i=178
    Walk-->>Job: return (72 snapshots abandoned, identity DISCARDED)
    Job-->>Job: terminal "unreachable", partial graph, no resume path
```

After — the walk repeats while coverage advances and a peer still holds what we lack:

```mermaid
sequenceDiagram
    participant Job as Catch-up job
    participant Walk as syncPublicSnapshotsForMeta
    participant Peer
    participant Store as Triple store
    Job->>Walk: pass 1
    Walk->>Peer: fetch manifest (250 snapshots)
    Walk->>Store: materialize 178 KAs
    Walk-->>Job: coverage {resolved 178, total 250, missing 72}
    Job->>Job: shouldRunAnotherCatchupPass -> continue
    Job->>Walk: pass 2 (shared-memory plane only)
    Walk->>Peer: re-fetch manifest (accepted replay cost)
    Walk->>Store: materialize remaining 72 KAs
    Walk-->>Job: coverage {resolved 250, total 250, missing 0}
    Job->>Job: no capable peers left -> stop
    Job-->>Job: terminal "done", complete graph
```

### Flow 2 — head metadata on a partial round (the defect not in the issue)

Before — the head is deleted and its rewrite is unreachable:

```mermaid
sequenceDiagram
    participant Walk as syncPublicSnapshotsForMeta
    participant Mat as snapshotMaterializer
    participant Store as Triple store
    Walk->>Mat: replaceHeadMetadata(KA)
    Mat->>Store: deleteByPattern(head + operations)
    Note over Mat,Store: delete-only, no insert
    Walk->>Store: write assertion graph (content)
    Note over Walk: snapshot phase incomplete -> continue
    Walk--xStore: storeInsert(verifiedMeta) NEVER REACHED (below the continue)
    Note over Store: content present, heads ABSENT<br/>invisible to every head reader, and permanent
```

After — each KA's verified metadata is rewritten immediately, inside the same lock:

```mermaid
sequenceDiagram
    participant Walk as syncPublicSnapshotsForMeta
    participant Mat as snapshotMaterializer
    participant Store as Triple store
    Walk->>Mat: replaceHeadMetadata(KA)
    Mat->>Store: deleteByPattern(head + operations)
    Walk->>Store: insertVerifiedDescriptorMeta(KA), same write lock
    Note over Store: head + operations restored per KA
    Walk->>Store: write assertion graph (content)
    Note over Walk: snapshot phase incomplete, continue
    Note over Store: content AND heads present<br/>the round is durable
```

## Files changed

| File | What |
|------|------|
| `packages/agent/src/sync/requester/shared-memory-sync.ts` | The walk. Per-peer coverage record; `snapshotsResolved` counts **materialized** refs with `missingCount` derived from it; progress carried out through a throw on a non-enumerable, validated-on-read payload; per-KA verified-meta insert at **both** head-deleting call sites, with a `perKaInsertedMetaKeys` ledger so `insertedMetaTriples` stays byte-identical on a usable round; `bytesReceived` split into replay vs snapshot phases |
| `packages/agent/src/sync/catchup-pass-policy.ts` | **New.** `shouldRunAnotherCatchupPass` over a closed `CatchupPassDecisionReason` union, plus budget/max-pass resolvers. Lives in `packages/agent` because `packages/agent` has no dependency on `packages/cli` |
| `packages/agent/src/dkg-agent-types.ts` | `SwmSnapshotCoverage`, continuation diagnostics, the byte-split fields |
| `packages/agent/src/dkg-agent-lifecycle.ts` | Threads the new diagnostics through the single `runSharedMemorySync` caller |
| `packages/agent/src/index.ts` | Exports the pass policy and coverage types for the CLI |
| `packages/agent/src/sync/catchup-policy.ts` | One-line type touch |
| `packages/cli/src/catchup-runner-worker-impl.ts` | The bounded pass loop; `capablePeersForNextPass`; `highestResolvedCoverage`; per-pass structured log line; retention of a peer's coverage across a failed round (delete only on a clean round that reported none) |
| `packages/cli/src/context-graph-readiness.ts` | `swmShortfallClause`; stop reasons rendered through an exhaustive `Record` |
| `packages/cli/src/catchup-runner.ts` | Passes the continuation config through to the worker |
| `packages/agent/test/sync-requester-progress.test.ts` | Coverage-record rows, the throw-path row (T14), the reduction/selection rows |
| `packages/agent/test/swm-snapshot-materializer.test.ts` | T9/T9b against a real `OxigraphStore` — partial-round heads, and the already-materialized repair for an absent or older-version head |
| `packages/agent/test/swm-descriptor-fixtures.ts` | **New.** Shared descriptor-shaped SWM share builders, so a fourth hand-rolled fixture is not needed |
| `packages/agent/test/catchup-pass-policy.test.ts` | **New.** Stop-reason precedence and budget/max-pass resolution |
| `packages/agent/test/swm-public-snapshot-materialization.test.ts` | Materialization-failure accounting |
| `packages/cli/test/catchup-runner-worker-impl.test.ts` | The composed continuation chain end to end; capability-gate rows; coverage-retention pair; per-pass log line |
| `packages/cli/test/context-graph-catchup-readiness.test.ts` | T16 — all ten terminal error strings, previously with **zero** coverage — and T16b, the shortfall clause |
| `packages/agent/vitest.unit.config.ts` | Adds the new test files to the `include` allow-list (it is an allow-list; a file not added is silently uncollected) |

## Test plan

- [x] `packages/agent` and `packages/cli` unit lanes, as **"baseline + exactly N named new tests"** rather than "identical to baseline"
- [x] **Attribution guarantee: 20/20 files any chunk touches are green at base** (`31be166b8`), enumerated by name — 9 CLI, 11 agent. Three agent files the full run never reached were run **separately at the same commit in the same pristine worktree** (`3 passed | 35 passed`) rather than assumed. Red in any of those 20 now is a real regression.
- [x] **Mutation set, serial, kill sets predicted in advance.** 5 killed, 1 documented survival:

  | Mutant | Result |
  |---|---|
  | coverage high-water `<=` → `<` | killed (3 rows) |
  | loop stops after the first pass | killed — the seam row, on the **pass count** |
  | `manifestComplete` → `true` | killed (truncated-peer row) |
  | `snapshotsTotal > 0` → `>= 0` | **survives — the clause is redundant**, unpinnable by construction, documented in code |
  | unconditional delete of peer coverage | killed (RETAINS row) |
  | unconditional retain | killed (FORGETS row) — **disjoint** subsets, so the pair tests the predicate |
  | `materializedRefsForCg` → `0` on the throw path | killed T14 (`2 → 0`); the **previous** T14 asserted `0` and would have passed |
  | `logPassLine` emits nothing | killed exactly one row (`expected [] to have a length of 1`) |

  All kills are **assertion deaths, not timeouts** — 10–21 ms against vitest's 5000 ms minimum, checked because a test that times out under load reads as a killed mutant.
- [x] Removing the widened already-materialized repair **survived 26/26** rows — not thin coverage, *none*. Reachability, not assertion strength: both existing rows go through the materialize path while that exit short-circuits earlier. Closed by T9/T9b.
- [ ] **Paired Base Sepolia runs — NOT DONE.** Same receiver snapshot and fixture, baseline commit then candidate; exact 250 KA / 30,900 triple parity and terminal `done`; scheduler metrics normalized per job and per materialized KA; replay reported separately from useful bytes.

### Known-red at base, not caused by this PR

Neither lane is green at base on Windows, and this PR does not claim otherwise. **There is no whole-lane agent total and none is invented here** — the deepest run reached 72 of ~151 files with **52 failures confined to 4 RFC-64 files** (`native-gate1.integration` 29, `dkg-agent-native-wiring.integration` 16, `current-head-discovery-v1` 4, `transport-v1` 3). No chunk touches any of them.

That red is **deterministic, not flaky and not contention**: gate1 fails 29/29, measured three times — 904 s contended, **941 s alone on a verified-clear box**, 965 s. The chain is `EBUSY: resource busy or locked, unlink …inventory-v1.lease.sqlite3` → `Hook timed out in 10000ms` → every test timing out at its 30 s limit awaiting `setupLiveReceiver()`. A teardown file-handle failure, not an assertion, so the four files should be subtracted **by name** rather than re-measured.

**This does not mean the branch lost its CI signal.** Those files are in the local `test:unit` allow-list, not in `rfc64-inventory-windows.yml`, and #2053's `SQLite lifecycle (Windows)` passed on this same base.
