### PR TITLE
RFC-64 M1 2/2: activate selected public catalogs

### DIFF
--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -36,7 +36,7 @@ Add the following shape to `~/.dkg/config.json`:
             "issuer": "0x...verified-policy-issuer",
             "objectType": "ContextGraphPolicyV1",
             "payload": {
-              "networkId": "otp:...",
+              "networkId": "base:84532",
               "contextGraphId": "0x.../selected-public-cg",
               "governanceChainId": "...",
               "governanceContractAddress": "0x...",
@@ -80,7 +80,8 @@ The example shows structure only. Do not invent or copy placeholder control
 values. The complete `policyEnvelope` must be the output of an independent
 finality/policy verifier. The daemon validates the canonical policy before the
 network transport starts and rejects non-public policies, duplicate selections,
-unknown fields, non-canonical identifiers, and oversized manifests.
+unknown fields, non-canonical identifiers, oversized manifests, and any policy
+whose `networkId` differs from the daemon's effective `chain.chainId`.
 
 `autoPublish` is optional. Configure it on a publisher that should advance its
 catalog after a confirmed public KA mint. A receiver can omit `autoPublish` and
@@ -92,6 +93,8 @@ KA result into a publication failure.
 is omitted, the agent resolves the chain ID and Knowledge Assets Lifecycle
 address from its trusted chain adapter. An explicit override is intended for a
 deterministic harness and must exactly match the selected network.
+Its `networkId` and numeric `assertedAtChainId` are checked against the same
+effective chain identity before subscriptions, stores, or agent startup begin.
 
 ## Verify activation
 

--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -1,0 +1,137 @@
+# RFC-64 selected-public catalog activation
+
+RFC-64 public catalog synchronization is opt-in. A node with no
+`rfc64PublicCatalog` block, or with `enabled: false`, keeps the catalog lane
+fail-closed: it accepts no catalog policy, starts no bootstrap pulls, and does
+not advance catalogs after ordinary KA publication.
+
+This activation is intentionally selective. The operator supplies a bounded
+manifest of independently verified, finalized public-CG policy envelopes. The
+CG IDs in that manifest are the single source for both:
+
+- durable graph subscriptions; and
+- the optional post-publication catalog producer hook.
+
+There is no `sync all public CGs` mode in this release. Existing `contextGraphs`
+selection continues to work normally, and CGs outside the RFC-64 manifest stay
+on the existing publication and synchronization paths.
+
+## Configuration
+
+Add the following shape to `~/.dkg/config.json`:
+
+```json
+{
+  "rfc64PublicCatalog": {
+    "enabled": true,
+    "autoPublish": {
+      "peers": ["12D3Koo...receiver"],
+      "catalogIssuerDelegationExpiresAt": "1893456000000"
+    },
+    "bootstrap": {
+      "retryIntervalMs": 30000,
+      "acceptedPublicPolicies": [
+        {
+          "policyEnvelope": {
+            "issuer": "0x...verified-policy-issuer",
+            "objectType": "ContextGraphPolicyV1",
+            "payload": {
+              "networkId": "otp:...",
+              "contextGraphId": "0x.../selected-public-cg",
+              "governanceChainId": "...",
+              "governanceContractAddress": "0x...",
+              "ownershipTransitionDigest": null,
+              "era": "0",
+              "version": "0",
+              "previousPolicyDigest": null,
+              "accessPolicy": 0,
+              "publishPolicy": 1,
+              "publishAuthority": null,
+              "publishAuthorityAccountId": "0",
+              "projectionId": "cg-shared-v1",
+              "administrativeDelegationDigest": null,
+              "source": {
+                "kind": "finalized-chain",
+                "chainId": "...",
+                "contractAddress": "0x...",
+                "blockNumber": "...",
+                "blockHash": "0x..."
+              },
+              "effectiveAt": "...",
+              "issuedAt": "..."
+            },
+            "signatureEvidence": { "kind": "none" },
+            "signatureSuite": "eip191-personal-sign-digest-v1"
+          },
+          "targets": [
+            {
+              "authorAddress": "0x...catalog-author",
+              "providers": ["12D3Koo...provider-primary", "12D3Koo...provider-backup"]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+The example shows structure only. Do not invent or copy placeholder control
+values. The complete `policyEnvelope` must be the output of an independent
+finality/policy verifier. The daemon validates the canonical policy before the
+network transport starts and rejects non-public policies, duplicate selections,
+unknown fields, non-canonical identifiers, and oversized manifests.
+
+`autoPublish` is optional. Configure it on a publisher that should advance its
+catalog after a confirmed public KA mint. A receiver can omit `autoPublish` and
+keep only the bootstrap targets. Catalog work after a confirmed mint is
+fail-open: a catalog error is logged but does not rewrite the already-confirmed
+KA result into a publication failure.
+
+`deploymentProfile` is also optional on a normal chain-connected node. When it
+is omitted, the agent resolves the chain ID and Knowledge Assets Lifecycle
+address from its trusted chain adapter. An explicit override is intended for a
+deterministic harness and must exactly match the selected network.
+
+## Verify activation
+
+Restart the daemon and inspect `GET /api/status`:
+
+```json
+{
+  "rfc64PublicCatalog": {
+    "enabled": true,
+    "selectedContextGraphs": ["0x.../selected-public-cg"],
+    "autoPublishEnabled": true,
+    "service": {},
+    "bootstrap": {
+      "running": false,
+      "pass": 1,
+      "targets": [
+        {
+          "outcome": "applied",
+          "providerPeerId": "12D3Koo...provider-primary",
+          "appliedHeadDigest": "0x...",
+          "catalogVersion": "50",
+          "inventoryRowCount": "50",
+          "lastError": null
+        }
+      ]
+    }
+  }
+}
+```
+
+For a release gate, `enabled: true` is not sufficient. Every intended target
+must report `outcome: "applied"`, a non-null `appliedHeadDigest`, and the
+expected `inventoryRowCount`. Validate the same evidence again after receiver
+restart and during provider failover. A `not-found` or `failed` target is a
+failed completeness gate even if the ordinary durable-sync job reports done.
+
+## Current boundary
+
+This release activates the already-built public RFC-64 catalog data plane for
+an explicit operator-selected set. Provider peer IDs and finalized policy
+envelopes are still pinned inputs. Automatic provider discovery and automatic
+chain-to-policy control-plane generation are later work; this activation does
+not claim either capability.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -13,6 +13,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./rfc64/public-catalog-activation-config-v1": {
+      "types": "./dist/rfc64/public-catalog-activation-config-v1.d.ts",
+      "import": "./dist/rfc64/public-catalog-activation-config-v1.js",
+      "default": "./dist/rfc64/public-catalog-activation-config-v1.js"
+    },
     "./package.json": "./package.json",
     "./dist/rfc64/author-catalog-producer.js": "./dist/rfc64/author-catalog-producer.js",
     "./dist/rfc64/catalog-row-authorship.js": "./dist/rfc64/catalog-row-authorship.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -23,6 +23,7 @@
     "./dist/rfc64/inventory-v1/scalars.js": "./dist/rfc64/inventory-v1/scalars.js",
     "./dist/rfc64/inventory-v1/sql.js": "./dist/rfc64/inventory-v1/sql.js",
     "./dist/rfc64/inventory-v1/statements.js": "./dist/rfc64/inventory-v1/statements.js",
+    "./dist/rfc64/public-catalog-activation-config-v1.js": "./dist/rfc64/public-catalog-activation-config-v1.js",
     "./dist/rfc64/control-object-store-v1-internal.js": null,
     "./dist/rfc64/control-object-store-v1.js": null,
     "./dist/rfc64/catalog-access-policy-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 const root = await import('@origintrail-official/dkg-agent');
 const legacyAgent = await import('@origintrail-official/dkg-agent/dist/dkg-agent.js');
 const publicCatalogActivation = await import(
-  '@origintrail-official/dkg-agent/dist/rfc64/public-catalog-activation-config-v1.js'
+  '@origintrail-official/dkg-agent/rfc64/public-catalog-activation-config-v1'
 );
 const require = createRequire(import.meta.url);
 const packageManifest = require('@origintrail-official/dkg-agent/package.json');

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -76,6 +76,15 @@ if (packageManifest.name !== '@origintrail-official/dkg-agent') {
 if (typeof publicCatalogActivation.resolveRfc64PublicCatalogActivationConfigV1 !== 'function') {
   throw new Error('public RFC-64 activation subpath did not expose the complete resolver');
 }
+if (
+  typeof publicCatalogActivation.resolveRfc64PublicCatalogActivationChainIdentityV1
+  !== 'function'
+) {
+  throw new Error('public RFC-64 activation subpath did not expose the chain-identity resolver');
+}
+if (typeof publicCatalogActivation.resolveRfc64PublicCatalogControlsV1 !== 'function') {
+  throw new Error('public RFC-64 activation subpath did not expose catalog-control normalization');
+}
 
 const digestAuthor = '0x1111111111111111111111111111111111111111';
 const digestRows = [10, 2].map((number) => ({

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'node:url';
 
 const root = await import('@origintrail-official/dkg-agent');
 const legacyAgent = await import('@origintrail-official/dkg-agent/dist/dkg-agent.js');
+const publicCatalogActivation = await import(
+  '@origintrail-official/dkg-agent/dist/rfc64/public-catalog-activation-config-v1.js'
+);
 const require = createRequire(import.meta.url);
 const packageManifest = require('@origintrail-official/dkg-agent/package.json');
 const expectedRfc64PolicyCells = [
@@ -69,6 +72,9 @@ if (
 }
 if (packageManifest.name !== '@origintrail-official/dkg-agent') {
   throw new Error('historical package.json subpath no longer resolves');
+}
+if (typeof publicCatalogActivation.resolveRfc64PublicCatalogActivationConfigV1 !== 'function') {
+  throw new Error('public RFC-64 activation subpath did not expose the complete resolver');
 }
 
 const digestAuthor = '0x1111111111111111111111111111111111111111';

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -97,6 +97,7 @@ const publicRfc64Modules = [
   'inventory-v1/scalars.js',
   'inventory-v1/sql.js',
   'inventory-v1/statements.js',
+  'public-catalog-activation-config-v1.js',
 ];
 const blockedRfc64Modules = [
   'catalog-access-policy-v1.js',

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -54,6 +54,7 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
   ): Promise<AppliedCatalogHeadSnapshotV1 | null> {
     const autoPublish = this.config.rfc64PublicCatalogAutoPublish;
     if (autoPublish === undefined) return null;
+    if (!autoPublish.contextGraphIds.includes(params.contextGraphId)) return null;
     if (params.subGraphName !== undefined && params.subGraphName !== null) return null;
     const seal = canonicalGraphScopedAuthorSealFromAssertionSealV1(params.seal);
     // V1 deliberately catalogs public-only KA projections. Private-bearing

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -52,9 +52,12 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     this: DKGAgent,
     params: RecordConfirmedRfc64PublicCatalogAssetParamsV1,
   ): Promise<AppliedCatalogHeadSnapshotV1 | null> {
-    const autoPublish = this.config.rfc64PublicCatalogAutoPublish;
-    if (autoPublish === undefined) return null;
-    if (!autoPublish.contextGraphIds.includes(params.contextGraphId)) return null;
+    const autoPublishPolicy = this.config.rfc64PublicCatalogAutoPublishPolicy;
+    if (autoPublishPolicy === undefined) return null;
+    if (
+      autoPublishPolicy.mode === 'selected-public'
+      && !autoPublishPolicy.selectedContextGraphs.includes(params.contextGraphId)
+    ) return null;
     if (params.subGraphName !== undefined && params.subGraphName !== null) return null;
     const seal = canonicalGraphScopedAuthorSealFromAssertionSealV1(params.seal);
     // V1 deliberately catalogs public-only KA projections. Private-bearing
@@ -108,11 +111,12 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       author: this.createRfc64CatalogAuthorSignerV1(seal.authorAddress),
       asset,
       deployment: await this.resolveRfc64AutoPublishDeploymentProfileV1(networkId),
-      peers: autoPublish.peers,
+      peers: autoPublishPolicy.config.peers,
       catalogIssuerDelegationEffectiveAt:
-        autoPublish.catalogIssuerDelegationEffectiveAt ?? ('0' as TimestampMsV1),
+        autoPublishPolicy.config.catalogIssuerDelegationEffectiveAt
+        ?? ('0' as TimestampMsV1),
       catalogIssuerDelegationExpiresAt:
-        autoPublish.catalogIssuerDelegationExpiresAt,
+        autoPublishPolicy.config.catalogIssuerDelegationExpiresAt,
     });
   }
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -58,7 +58,7 @@ import type { SwmHostModeStoreLimits } from './swm/host-mode-store.js';
 import type { KaNumberAllocator } from './allocator.js';
 import type { SyncPhase } from './sync/auth/request-build.js';
 import type {
-  ResolvedRfc64PublicCatalogActivationConfigV1,
+  Rfc64PublicCatalogActivationInputV1,
   ResolvedRfc64PublicCatalogAutoPublishPolicyV1,
 } from './rfc64/public-catalog-activation-config-v1.js';
 import type {
@@ -1190,7 +1190,7 @@ export interface DKGAgentConfig {
    * deployment, auto-publish, and bootstrap controls; the accepted manifest
    * is its only CG set.
    */
-  rfc64PublicCatalogActivation?: ResolvedRfc64PublicCatalogActivationConfigV1;
+  rfc64PublicCatalogActivation?: Rfc64PublicCatalogActivationInputV1;
   /**
    * Legacy all-accepted-public-CG producer configuration. Omission preserves
    * existing publication behavior. New daemons should use the unified

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -58,6 +58,10 @@ import type { SwmHostModeStoreLimits } from './swm/host-mode-store.js';
 import type { KaNumberAllocator } from './allocator.js';
 import type { SyncPhase } from './sync/auth/request-build.js';
 import type {
+  ResolvedRfc64PublicCatalogActivationConfigV1,
+  ResolvedRfc64PublicCatalogAutoPublishPolicyV1,
+} from './rfc64/public-catalog-activation-config-v1.js';
+import type {
   SyncContextGraphPriorityConfig,
   SyncResponderSnapshotLimitsConfig,
 } from './sync/policy.js';
@@ -1124,8 +1128,6 @@ export interface Rfc64CatalogAccessPolicyAuthorityConfigV1 {
  * pointer remains the correctness source for pull discovery.
  */
 export interface Rfc64PublicCatalogAutoPublishConfigV1 {
-  /** Exact bounded allowlist; confirmed publishes outside it stay on the legacy path. */
-  readonly contextGraphIds: readonly ContextGraphIdV1[];
   readonly peers: readonly string[];
   readonly catalogIssuerDelegationEffectiveAt?: TimestampMsV1;
   readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;
@@ -1182,7 +1184,18 @@ export interface DKGAgentConfig {
    * RFC-64 catalog policy. Omission preserves the legacy open-only lane.
    */
   rfc64CatalogAccessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1;
-  /** Omission preserves the existing publication and synchronization behavior. */
+  /**
+   * Canonical selected-public activation resolved through the versioned,
+   * side-effect-free activation surface. Mutually exclusive with the legacy
+   * deployment, auto-publish, and bootstrap controls; the accepted manifest
+   * is its only CG set.
+   */
+  rfc64PublicCatalogActivation?: ResolvedRfc64PublicCatalogActivationConfigV1;
+  /**
+   * Legacy all-accepted-public-CG producer configuration. Omission preserves
+   * existing publication behavior. New daemons should use the unified
+   * selected-public activation above.
+   */
   rfc64PublicCatalogAutoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
   /** Omission preserves manual RFC-64 current-head discovery. */
   rfc64PublicCatalogBootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
@@ -1592,6 +1605,18 @@ export interface DKGAgentACKTransportOptions {
 }
 
 export type ResolvedDKGAgentConfig =
-  Omit<DKGAgentConfig, 'storageAckTiming' | 'ackHandlerDeadlineMs' | 'ackSendTimeoutMs'> & {
+  Omit<
+    DKGAgentConfig,
+    | 'storageAckTiming'
+    | 'ackHandlerDeadlineMs'
+    | 'ackSendTimeoutMs'
+    | 'rfc64PublicCatalogActivation'
+    | 'rfc64PublicCatalogAutoPublish'
+    | 'rfc64PublicCatalogBootstrap'
+    | 'rfc64CatalogDeploymentProfile'
+  > & {
     storageAckTiming: StorageAckTiming;
+    rfc64CatalogDeploymentProfile?: Readonly<CatalogSealDeploymentProfileV1>;
+    rfc64PublicCatalogAutoPublishPolicy?: ResolvedRfc64PublicCatalogAutoPublishPolicyV1;
+    rfc64PublicCatalogBootstrap?: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
   };

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1124,6 +1124,8 @@ export interface Rfc64CatalogAccessPolicyAuthorityConfigV1 {
  * pointer remains the correctness source for pull discovery.
  */
 export interface Rfc64PublicCatalogAutoPublishConfigV1 {
+  /** Exact bounded allowlist; confirmed publishes outside it stay on the legacy path. */
+  readonly contextGraphIds: readonly ContextGraphIdV1[];
   readonly peers: readonly string[];
   readonly catalogIssuerDelegationEffectiveAt?: TimestampMsV1;
   readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -408,15 +408,14 @@ import { EndorseVerifyMethods } from './dkg-agent-endorse.js';
 import {
   Rfc64CatalogMethods,
   snapshotRfc64CatalogAccessPolicyAuthorityV1,
-  snapshotRfc64CatalogDeploymentProfileV1,
 } from './dkg-agent-rfc64-catalog.js';
 import { Rfc64CatalogAutoPublishMethods } from './dkg-agent-rfc64-catalog-auto-publish.js';
 import { Rfc64CatalogBootstrapMethods } from './dkg-agent-rfc64-catalog-bootstrap.js';
 import { Rfc64CatalogUpsertMethods } from './dkg-agent-rfc64-catalog-upsert.js';
 import {
-  snapshotRfc64PublicCatalogAutoPublishConfigV1,
-  snapshotRfc64PublicCatalogBootstrapConfigV1,
-} from './rfc64/catalog-authority-config-v1.js';
+  resolveRfc64PublicCatalogActivationChainIdentityV1,
+  resolveRfc64PublicCatalogControlsV1,
+} from './rfc64/public-catalog-activation-config-v1.js';
 import { Rfc64CatalogSyncMethods } from './dkg-agent-rfc64-catalog-sync.js';
 import { ContextGraphRegistryMethods } from './dkg-agent-cg-registry.js';
 import { JoinRequestMethods } from './dkg-agent-join.js';
@@ -609,7 +608,33 @@ function throwStorageAckTimingConflict(): never {
   );
 }
 
-function normalizeStorageAckConfig(config: DKGAgentConfig): ResolvedDKGAgentConfig {
+type StorageAckNormalizedDKGAgentConfig = Omit<
+  DKGAgentConfig,
+  'storageAckTiming' | 'ackHandlerDeadlineMs' | 'ackSendTimeoutMs'
+> & Pick<ResolvedDKGAgentConfig, 'storageAckTiming'>;
+
+/**
+ * Resolve the chain id that agent construction will expose before any durable
+ * RFC-64 bootstrap state is opened. This mirrors the adapter construction
+ * branch once, so activation validation and the final network identity cannot
+ * choose different config sources.
+ */
+function resolveConfiguredAgentChainId(config: DKGAgentConfig): string | undefined {
+  if (config.chainAdapter !== undefined) {
+    return config.chainAdapter.chainId === 'none'
+      ? config.networkIdentity?.chainId
+      : config.chainAdapter.chainId;
+  }
+  if (config.chainConfig !== undefined && config.chainConfig.operationalKeys?.length) {
+    // EVMChainAdapter uses the local Hardhat identity when callers omit the
+    // optional chain id. Mirror that construction default here so activation
+    // validation and the final network identity still consume one value.
+    return config.chainConfig.chainId ?? 'evm:31337';
+  }
+  return config.networkIdentity?.chainId;
+}
+
+function normalizeStorageAckConfig(config: DKGAgentConfig): StorageAckNormalizedDKGAgentConfig {
   const hasStorageAckTiming = config.storageAckTiming !== undefined && config.storageAckTiming !== null;
   const hasLegacyTiming =
     config.ackHandlerDeadlineMs !== undefined ||
@@ -704,10 +729,18 @@ export class DKGAgent extends DKGAgentBase {
     | undefined;
 
   static async create(inputConfig: DKGAgentConfig): Promise<DKGAgent> {
+    const activationInput = inputConfig.rfc64PublicCatalogActivation;
+    const configuredAgentChainId = resolveConfiguredAgentChainId(inputConfig);
+    const rfc64PublicCatalogControls = resolveRfc64PublicCatalogControlsV1({
+      activation: activationInput,
+      legacyDeploymentProfile: inputConfig.rfc64CatalogDeploymentProfile,
+      legacyAutoPublish: inputConfig.rfc64PublicCatalogAutoPublish,
+      legacyBootstrap: inputConfig.rfc64PublicCatalogBootstrap,
+    }, resolveRfc64PublicCatalogActivationChainIdentityV1(configuredAgentChainId));
     // RFC-64 bootstrap owns durable catalog and control-object state. Reject
     // an impossible ephemeral configuration before constructing a store or
     // node so start() can never fail after leaving libp2p half-running.
-    if (inputConfig.rfc64PublicCatalogBootstrap !== undefined && !inputConfig.dataDir) {
+    if (rfc64PublicCatalogControls.requiresDataDir && !inputConfig.dataDir) {
       throw new TypeError('rfc64PublicCatalogBootstrap requires dataDir');
     }
     validateSyncResponderSnapshotLimitsConfig(inputConfig.syncResponderSnapshotLimits);
@@ -717,18 +750,13 @@ export class DKGAgent extends DKGAgentBase {
         inputConfig.syncContextGraphPriorities,
       ),
     });
-    const rfc64CatalogDeploymentProfile = snapshotRfc64CatalogDeploymentProfileV1(
-      config.rfc64CatalogDeploymentProfile,
-    );
+    const rfc64CatalogDeploymentProfile = rfc64PublicCatalogControls.deploymentProfile;
     const rfc64CatalogAccessPolicyAuthority = snapshotRfc64CatalogAccessPolicyAuthorityV1(
       config.rfc64CatalogAccessPolicyAuthority,
     );
-    const rfc64PublicCatalogAutoPublish = snapshotRfc64PublicCatalogAutoPublishConfigV1(
-      config.rfc64PublicCatalogAutoPublish,
-    );
-    const rfc64PublicCatalogBootstrap = snapshotRfc64PublicCatalogBootstrapConfigV1(
-      config.rfc64PublicCatalogBootstrap,
-    );
+    const rfc64PublicCatalogAutoPublishPolicy =
+      rfc64PublicCatalogControls.autoPublishPolicy;
+    const rfc64PublicCatalogBootstrap = rfc64PublicCatalogControls.bootstrap;
     let wallet: DKGAgentWallet;
     if (config.dataDir) {
       try {
@@ -823,19 +851,28 @@ export class DKGAgent extends DKGAgentBase {
         `must match the chain adapter id (${adapterChainId})`,
       );
     }
+    const constructedAgentChainId = adapterChainId ?? config.networkIdentity?.chainId;
+    if (constructedAgentChainId !== configuredAgentChainId) {
+      throw new Error('DKGAgent chain identity changed during construction');
+    }
     const networkIdentity = {
       ...config.networkIdentity,
       genesisId,
       networkId: computedNetworkId,
-      chainId: adapterChainId ?? config.networkIdentity?.chainId,
+      chainId: configuredAgentChainId,
     };
+    const configWithoutRfc64CatalogControls = { ...config };
+    delete configWithoutRfc64CatalogControls.rfc64PublicCatalogActivation;
+    delete configWithoutRfc64CatalogControls.rfc64CatalogDeploymentProfile;
+    delete configWithoutRfc64CatalogControls.rfc64PublicCatalogAutoPublish;
+    delete configWithoutRfc64CatalogControls.rfc64PublicCatalogBootstrap;
     const resolvedConfig: ResolvedDKGAgentConfig = {
-      ...config,
+      ...configWithoutRfc64CatalogControls,
       genesisId,
       networkIdentity,
       rfc64CatalogAccessPolicyAuthority,
       rfc64CatalogDeploymentProfile,
-      rfc64PublicCatalogAutoPublish,
+      rfc64PublicCatalogAutoPublishPolicy,
       rfc64PublicCatalogBootstrap,
     };
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -414,6 +414,7 @@ import { Rfc64CatalogBootstrapMethods } from './dkg-agent-rfc64-catalog-bootstra
 import { Rfc64CatalogUpsertMethods } from './dkg-agent-rfc64-catalog-upsert.js';
 import {
   resolveRfc64PublicCatalogActivationChainIdentityV1,
+  resolveRfc64PublicCatalogActivationInputV1,
   resolveRfc64PublicCatalogControlsV1,
 } from './rfc64/public-catalog-activation-config-v1.js';
 import { Rfc64CatalogSyncMethods } from './dkg-agent-rfc64-catalog-sync.js';
@@ -613,27 +614,6 @@ type StorageAckNormalizedDKGAgentConfig = Omit<
   'storageAckTiming' | 'ackHandlerDeadlineMs' | 'ackSendTimeoutMs'
 > & Pick<ResolvedDKGAgentConfig, 'storageAckTiming'>;
 
-/**
- * Resolve the chain id that agent construction will expose before any durable
- * RFC-64 bootstrap state is opened. This mirrors the adapter construction
- * branch once, so activation validation and the final network identity cannot
- * choose different config sources.
- */
-function resolveConfiguredAgentChainId(config: DKGAgentConfig): string | undefined {
-  if (config.chainAdapter !== undefined) {
-    return config.chainAdapter.chainId === 'none'
-      ? config.networkIdentity?.chainId
-      : config.chainAdapter.chainId;
-  }
-  if (config.chainConfig !== undefined && config.chainConfig.operationalKeys?.length) {
-    // EVMChainAdapter uses the local Hardhat identity when callers omit the
-    // optional chain id. Mirror that construction default here so activation
-    // validation and the final network identity still consume one value.
-    return config.chainConfig.chainId ?? 'evm:31337';
-  }
-  return config.networkIdentity?.chainId;
-}
-
 function normalizeStorageAckConfig(config: DKGAgentConfig): StorageAckNormalizedDKGAgentConfig {
   const hasStorageAckTiming = config.storageAckTiming !== undefined && config.storageAckTiming !== null;
   const hasLegacyTiming =
@@ -685,6 +665,42 @@ function normalizeStorageAckConfig(config: DKGAgentConfig): StorageAckNormalized
   };
 }
 
+function constructConfiguredChainAdapter(
+  config: StorageAckNormalizedDKGAgentConfig,
+): Readonly<{ chain: ChainAdapter; operationalKeys: string[] | undefined }> {
+  let operationalKeys = config.chainConfig?.operationalKeys;
+  if (config.chainAdapter) {
+    const chain = config.chainAdapter;
+    if (!operationalKeys?.length && typeof (chain as any).getOperationalPrivateKey === 'function') {
+      operationalKeys = [(chain as any).getOperationalPrivateKey()];
+    }
+    return { chain, operationalKeys };
+  }
+  if (config.chainConfig && operationalKeys?.length) {
+    const evmConfigBase = {
+      rpcUrl: config.chainConfig.rpcUrl,
+      rpcUrls: config.chainConfig.rpcUrls,
+      walletRpcUrls: config.chainConfig.walletRpcUrls,
+      privateKey: operationalKeys[0],
+      additionalKeys: operationalKeys.slice(1),
+      hubAddress: config.chainConfig.hubAddress,
+      tokenAddress: config.chainConfig.tokenAddress,
+      chainId: config.chainConfig.chainId,
+      receiptTimeoutMs: config.chainConfig.receiptTimeoutMs,
+      approvalPolicy: config.chainConfig.approvalPolicy,
+      cgRegistryScanPageSize: config.chainConfig.cgRegistryScanPageSize,
+      minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
+      minPublisherTracWei: config.chainConfig.minPublisherTracWei,
+      contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
+    };
+    const chain = config.chainConfig.adminPrivateKey
+      ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })
+      : new EVMChainAdapter({ ...evmConfigBase, allowNoAdminSigner: true });
+    return { chain, operationalKeys };
+  }
+  return { chain: new NoChainAdapter(), operationalKeys };
+}
+
 interface ACKReliableMessenger {
   sendRequestOwned(
     peerId: string,
@@ -729,27 +745,56 @@ export class DKGAgent extends DKGAgentBase {
     | undefined;
 
   static async create(inputConfig: DKGAgentConfig): Promise<DKGAgent> {
-    const activationInput = inputConfig.rfc64PublicCatalogActivation;
-    const configuredAgentChainId = resolveConfiguredAgentChainId(inputConfig);
-    const rfc64PublicCatalogControls = resolveRfc64PublicCatalogControlsV1({
-      activation: activationInput,
-      legacyDeploymentProfile: inputConfig.rfc64CatalogDeploymentProfile,
-      legacyAutoPublish: inputConfig.rfc64PublicCatalogAutoPublish,
-      legacyBootstrap: inputConfig.rfc64PublicCatalogBootstrap,
-    }, resolveRfc64PublicCatalogActivationChainIdentityV1(configuredAgentChainId));
-    // RFC-64 bootstrap owns durable catalog and control-object state. Reject
-    // an impossible ephemeral configuration before constructing a store or
-    // node so start() can never fail after leaving libp2p half-running.
-    if (rfc64PublicCatalogControls.requiresDataDir && !inputConfig.dataDir) {
-      throw new TypeError('rfc64PublicCatalogBootstrap requires dataDir');
-    }
     validateSyncResponderSnapshotLimitsConfig(inputConfig.syncResponderSnapshotLimits);
-    const config = normalizeStorageAckConfig({
+    const normalizedConfig = normalizeStorageAckConfig({
       ...inputConfig,
       syncContextGraphPriorities: normalizeSyncContextGraphPriorities(
         inputConfig.syncContextGraphPriorities,
       ),
     });
+    const { chain, operationalKeys: opKeys } = constructConfiguredChainAdapter(normalizedConfig);
+    const adapterChainId = chain.chainId !== 'none' ? chain.chainId : undefined;
+    if (
+      normalizedConfig.networkIdentity?.chainId
+      && adapterChainId
+      && normalizedConfig.networkIdentity.chainId !== adapterChainId
+    ) {
+      throw new Error(
+        `DKGAgentConfig.networkIdentity.chainId (${normalizedConfig.networkIdentity.chainId}) `
+        + `must match the chain adapter id (${adapterChainId})`,
+      );
+    }
+    const constructedAgentChainId = adapterChainId ?? normalizedConfig.networkIdentity?.chainId;
+    const chainIdentity = resolveRfc64PublicCatalogActivationChainIdentityV1(
+      constructedAgentChainId,
+    );
+    const activation = normalizedConfig.rfc64PublicCatalogActivation === undefined
+      ? undefined
+      : resolveRfc64PublicCatalogActivationInputV1(
+        normalizedConfig.rfc64PublicCatalogActivation,
+        chainIdentity,
+      );
+    const rfc64PublicCatalogControls = resolveRfc64PublicCatalogControlsV1({
+      activation,
+      legacyDeploymentProfile: normalizedConfig.rfc64CatalogDeploymentProfile,
+      legacyAutoPublish: normalizedConfig.rfc64PublicCatalogAutoPublish,
+      legacyBootstrap: normalizedConfig.rfc64PublicCatalogBootstrap,
+    }, chainIdentity);
+    const config: StorageAckNormalizedDKGAgentConfig = {
+      ...normalizedConfig,
+      syncContextGraphs: [
+        ...new Set([
+          ...(normalizedConfig.syncContextGraphs ?? []),
+          ...(activation?.selectedContextGraphs ?? []),
+        ]),
+      ],
+    };
+    // RFC-64 bootstrap owns durable catalog and control-object state. Reject
+    // an impossible ephemeral configuration before constructing a store or
+    // node so start() can never fail after leaving libp2p half-running.
+    if (rfc64PublicCatalogControls.requiresDataDir && !config.dataDir) {
+      throw new TypeError('rfc64PublicCatalogBootstrap requires dataDir');
+    }
     const rfc64CatalogDeploymentProfile = rfc64PublicCatalogControls.deploymentProfile;
     const rfc64CatalogAccessPolicyAuthority = snapshotRfc64CatalogAccessPolicyAuthorityV1(
       config.rfc64CatalogAccessPolicyAuthority,
@@ -791,39 +836,6 @@ export class DKGAgent extends DKGAgentBase {
     }
 
     const nodeRole = config.nodeRole ?? 'edge';
-    let chain: ChainAdapter;
-    let opKeys = config.chainConfig?.operationalKeys;
-    if (config.chainAdapter) {
-      chain = config.chainAdapter;
-      if (!opKeys?.length && typeof (chain as any).getOperationalPrivateKey === 'function') {
-        opKeys = [(chain as any).getOperationalPrivateKey()];
-      }
-    } else if (config.chainConfig && opKeys?.length) {
-      const evmConfigBase = {
-        rpcUrl: config.chainConfig.rpcUrl,
-        rpcUrls: config.chainConfig.rpcUrls,
-        walletRpcUrls: config.chainConfig.walletRpcUrls,
-        privateKey: opKeys[0],
-        additionalKeys: opKeys.slice(1),
-        hubAddress: config.chainConfig.hubAddress,
-        tokenAddress: config.chainConfig.tokenAddress,
-        chainId: config.chainConfig.chainId,
-        receiptTimeoutMs: config.chainConfig.receiptTimeoutMs,
-        approvalPolicy: config.chainConfig.approvalPolicy,
-        cgRegistryScanPageSize: config.chainConfig.cgRegistryScanPageSize,
-        minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
-        minPublisherTracWei: config.chainConfig.minPublisherTracWei,
-        contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
-      };
-      if (config.chainConfig.adminPrivateKey) {
-        chain = new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey });
-      } else {
-        chain = new EVMChainAdapter({ ...evmConfigBase, allowNoAdminSigner: true });
-      }
-    } else {
-      chain = new NoChainAdapter();
-    }
-
     const eventBus = new TypedEventBus();
     const keypair = wallet.keypair;
 
@@ -844,22 +856,11 @@ export class DKGAgent extends DKGAgentBase {
         `must match computeNetworkId(${genesisId}) (${computedNetworkId})`,
       );
     }
-    const adapterChainId = chain.chainId !== 'none' ? chain.chainId : undefined;
-    if (config.networkIdentity?.chainId && adapterChainId && config.networkIdentity.chainId !== adapterChainId) {
-      throw new Error(
-        `DKGAgentConfig.networkIdentity.chainId (${config.networkIdentity.chainId}) ` +
-        `must match the chain adapter id (${adapterChainId})`,
-      );
-    }
-    const constructedAgentChainId = adapterChainId ?? config.networkIdentity?.chainId;
-    if (constructedAgentChainId !== configuredAgentChainId) {
-      throw new Error('DKGAgent chain identity changed during construction');
-    }
     const networkIdentity = {
       ...config.networkIdentity,
       genesisId,
       networkId: computedNetworkId,
-      chainId: configuredAgentChainId,
+      chainId: constructedAgentChainId,
     };
     const configWithoutRfc64CatalogControls = { ...config };
     delete configWithoutRfc64CatalogControls.rfc64PublicCatalogActivation;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -57,11 +57,6 @@ export * from './rfc64/public-catalog-successor-producer-v1.js';
 export * from './rfc64/public-open-catalog-scope-v1.js';
 export * from './rfc64/public-catalog-native-reconciler-v1.js';
 export * from './rfc64/policy-cell-v1.js';
-export {
-  snapshotRfc64CatalogDeploymentProfileV1,
-  snapshotRfc64PublicCatalogAutoPublishConfigV1,
-  snapshotRfc64PublicCatalogBootstrapConfigV1,
-} from './rfc64/catalog-authority-config-v1.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';
 export { MessageHandler, type SkillRequest, type SkillResponse, type SkillHandler, type ChatHandler, type ChatAclCheck } from './messaging.js';
 export {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -56,6 +56,7 @@ export {
 export * from './rfc64/public-catalog-successor-producer-v1.js';
 export * from './rfc64/public-open-catalog-scope-v1.js';
 export * from './rfc64/public-catalog-native-reconciler-v1.js';
+export * from './rfc64/public-catalog-activation-config-v1.js';
 export * from './rfc64/policy-cell-v1.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';
 export { MessageHandler, type SkillRequest, type SkillResponse, type SkillHandler, type ChatHandler, type ChatAclCheck } from './messaging.js';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -57,6 +57,11 @@ export * from './rfc64/public-catalog-successor-producer-v1.js';
 export * from './rfc64/public-open-catalog-scope-v1.js';
 export * from './rfc64/public-catalog-native-reconciler-v1.js';
 export * from './rfc64/policy-cell-v1.js';
+export {
+  snapshotRfc64CatalogDeploymentProfileV1,
+  snapshotRfc64PublicCatalogAutoPublishConfigV1,
+  snapshotRfc64PublicCatalogBootstrapConfigV1,
+} from './rfc64/catalog-authority-config-v1.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';
 export { MessageHandler, type SkillRequest, type SkillResponse, type SkillHandler, type ChatHandler, type ChatAclCheck } from './messaging.js';
 export {

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -3,7 +3,6 @@
 import {
   assertCanonicalChainId,
   assertCanonicalEvmAddress,
-  assertContextGraphIdV1,
   assertNetworkIdV1,
   canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1,
   parseCanonicalUnsignedContextGraphPolicyEnvelopeV1,
@@ -24,7 +23,6 @@ import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './catalog-peers-v
 const MAX_RFC64_BOOTSTRAP_POLICIES_V1 = 64;
 const MAX_RFC64_BOOTSTRAP_TARGETS_V1 = 256;
 const MAX_RFC64_BOOTSTRAP_PROVIDERS_V1 = 8;
-const MAX_RFC64_AUTO_PUBLISH_CONTEXT_GRAPHS_V1 = 64;
 const DEFAULT_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1 = 30_000;
 const MAX_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1 = 3_600_000;
 
@@ -125,36 +123,14 @@ export function snapshotRfc64PublicCatalogAutoPublishConfigV1(
   const allowed = new Set([
     'catalogIssuerDelegationEffectiveAt',
     'catalogIssuerDelegationExpiresAt',
-    'contextGraphIds',
     'peers',
   ]);
   if (
     keys.some((key) => !allowed.has(key))
-    || !keys.includes('contextGraphIds')
     || !keys.includes('peers')
     || !keys.includes('catalogIssuerDelegationExpiresAt')
   ) {
     throw new TypeError('rfc64PublicCatalogAutoPublish has unknown or missing fields');
-  }
-  if (
-    !Array.isArray(input.contextGraphIds)
-    || input.contextGraphIds.length === 0
-    || input.contextGraphIds.length > MAX_RFC64_AUTO_PUBLISH_CONTEXT_GRAPHS_V1
-  ) {
-    throw new TypeError(
-      `rfc64PublicCatalogAutoPublish.contextGraphIds must contain 1..`
-      + `${MAX_RFC64_AUTO_PUBLISH_CONTEXT_GRAPHS_V1} context graphs`,
-    );
-  }
-  const contextGraphIds = input.contextGraphIds.map((contextGraphId, index) => {
-    assertContextGraphIdV1(
-      contextGraphId,
-      `rfc64PublicCatalogAutoPublish.contextGraphIds[${index}]`,
-    );
-    return contextGraphId;
-  });
-  if (new Set(contextGraphIds).size !== contextGraphIds.length) {
-    throw new TypeError('rfc64PublicCatalogAutoPublish.contextGraphIds must be unique');
   }
   const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
   const effectiveAt = snapshotTimestamp(
@@ -171,7 +147,6 @@ export function snapshotRfc64PublicCatalogAutoPublishConfigV1(
     );
   }
   return Object.freeze({
-    contextGraphIds: Object.freeze(contextGraphIds),
     peers,
     catalogIssuerDelegationEffectiveAt: effectiveAt,
     catalogIssuerDelegationExpiresAt: expiresAt,

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -3,6 +3,7 @@
 import {
   assertCanonicalChainId,
   assertCanonicalEvmAddress,
+  assertContextGraphIdV1,
   assertNetworkIdV1,
   canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1,
   parseCanonicalUnsignedContextGraphPolicyEnvelopeV1,
@@ -23,6 +24,7 @@ import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './catalog-peers-v
 const MAX_RFC64_BOOTSTRAP_POLICIES_V1 = 64;
 const MAX_RFC64_BOOTSTRAP_TARGETS_V1 = 256;
 const MAX_RFC64_BOOTSTRAP_PROVIDERS_V1 = 8;
+const MAX_RFC64_AUTO_PUBLISH_CONTEXT_GRAPHS_V1 = 64;
 const DEFAULT_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1 = 30_000;
 const MAX_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1 = 3_600_000;
 
@@ -123,14 +125,36 @@ export function snapshotRfc64PublicCatalogAutoPublishConfigV1(
   const allowed = new Set([
     'catalogIssuerDelegationEffectiveAt',
     'catalogIssuerDelegationExpiresAt',
+    'contextGraphIds',
     'peers',
   ]);
   if (
     keys.some((key) => !allowed.has(key))
+    || !keys.includes('contextGraphIds')
     || !keys.includes('peers')
     || !keys.includes('catalogIssuerDelegationExpiresAt')
   ) {
     throw new TypeError('rfc64PublicCatalogAutoPublish has unknown or missing fields');
+  }
+  if (
+    !Array.isArray(input.contextGraphIds)
+    || input.contextGraphIds.length === 0
+    || input.contextGraphIds.length > MAX_RFC64_AUTO_PUBLISH_CONTEXT_GRAPHS_V1
+  ) {
+    throw new TypeError(
+      `rfc64PublicCatalogAutoPublish.contextGraphIds must contain 1..`
+      + `${MAX_RFC64_AUTO_PUBLISH_CONTEXT_GRAPHS_V1} context graphs`,
+    );
+  }
+  const contextGraphIds = input.contextGraphIds.map((contextGraphId, index) => {
+    assertContextGraphIdV1(
+      contextGraphId,
+      `rfc64PublicCatalogAutoPublish.contextGraphIds[${index}]`,
+    );
+    return contextGraphId;
+  });
+  if (new Set(contextGraphIds).size !== contextGraphIds.length) {
+    throw new TypeError('rfc64PublicCatalogAutoPublish.contextGraphIds must be unique');
   }
   const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
   const effectiveAt = snapshotTimestamp(
@@ -147,6 +171,7 @@ export function snapshotRfc64PublicCatalogAutoPublishConfigV1(
     );
   }
   return Object.freeze({
+    contextGraphIds: Object.freeze(contextGraphIds),
     peers,
     catalogIssuerDelegationEffectiveAt: effectiveAt,
     catalogIssuerDelegationExpiresAt: expiresAt,

--- a/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
@@ -1,5 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import type { CatalogSealDeploymentProfileV1 } from '@origintrail-official/dkg-core';
+
+import type {
+  Rfc64PublicCatalogAutoPublishConfigV1,
+  Rfc64PublicCatalogBootstrapConfigV1,
+} from '../dkg-agent-types.js';
+import {
+  snapshotRfc64CatalogDeploymentProfileV1,
+  snapshotRfc64PublicCatalogAutoPublishConfigV1,
+  snapshotRfc64PublicCatalogBootstrapConfigV1,
+} from './catalog-authority-config-v1.js';
+
 /**
  * Narrow side-effect-free package surface for daemon/operator activation.
  * Consumers that only normalize RFC-64 configuration must not import the full
@@ -9,4 +21,112 @@ export {
   snapshotRfc64CatalogDeploymentProfileV1,
   snapshotRfc64PublicCatalogAutoPublishConfigV1,
   snapshotRfc64PublicCatalogBootstrapConfigV1,
-} from './catalog-authority-config-v1.js';
+};
+
+/**
+ * One operator-owned selected-public activation. The accepted bootstrap
+ * manifest is deliberately the only graph allowlist; auto-publish graph IDs
+ * are derived from the same detached snapshot.
+ */
+export interface Rfc64PublicCatalogActivationConfigV1 {
+  readonly enabled?: boolean;
+  readonly deploymentProfile?: CatalogSealDeploymentProfileV1;
+  readonly autoPublish?: Omit<Rfc64PublicCatalogAutoPublishConfigV1, 'contextGraphIds'>;
+  readonly bootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
+}
+
+export interface ResolvedRfc64PublicCatalogActivationConfigV1 {
+  readonly enabled: boolean;
+  readonly selectedContextGraphs: readonly string[];
+  readonly deploymentProfile?: Readonly<CatalogSealDeploymentProfileV1>;
+  readonly autoPublish?: Readonly<Rfc64PublicCatalogAutoPublishConfigV1>;
+  readonly bootstrap?: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
+}
+
+export interface Rfc64PublicCatalogActivationChainIdentityV1 {
+  /** Effective chain-adapter network identifier, for example `base:84532`. */
+  readonly chainId: string | undefined;
+}
+
+/**
+ * Resolve the complete fail-closed operator activation into exact agent
+ * inputs. This function owns the cross-field invariants so every daemon uses
+ * one immutable bootstrap snapshot for selection, subscription, and optional
+ * auto-publication.
+ */
+export function resolveRfc64PublicCatalogActivationConfigV1(
+  activation: Rfc64PublicCatalogActivationConfigV1 | undefined,
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): ResolvedRfc64PublicCatalogActivationConfigV1 {
+  if (activation === undefined || activation.enabled === false) {
+    return Object.freeze({
+      enabled: false,
+      selectedContextGraphs: Object.freeze([]),
+    });
+  }
+  if (activation.enabled !== true) {
+    throw new TypeError('rfc64PublicCatalog.enabled must be a boolean');
+  }
+  const bootstrap = snapshotRfc64PublicCatalogBootstrapConfigV1(activation.bootstrap);
+  if (bootstrap === undefined || bootstrap.acceptedPublicPolicies.length === 0) {
+    throw new TypeError(
+      'enabled rfc64PublicCatalog requires a non-empty bootstrap.acceptedPublicPolicies manifest',
+    );
+  }
+  const selectedNetworkId = chainIdentity.chainId;
+  if (typeof selectedNetworkId !== 'string' || selectedNetworkId.length === 0) {
+    throw new TypeError('enabled rfc64PublicCatalog requires an effective chain id');
+  }
+  const selectedEvmChainId = selectedNetworkId.match(/:(0|[1-9][0-9]*)$/u)?.[1];
+  if (selectedEvmChainId === undefined) {
+    throw new TypeError(
+      'enabled rfc64PublicCatalog requires a namespaced numeric EVM chain id',
+    );
+  }
+  for (const { policyEnvelope } of bootstrap.acceptedPublicPolicies) {
+    if (policyEnvelope.payload.networkId !== selectedNetworkId) {
+      throw new TypeError(
+        'rfc64PublicCatalog policy network differs from the daemon effective chain id',
+      );
+    }
+  }
+  const selectedContextGraphs = bootstrap.acceptedPublicPolicies.map(
+    ({ policyEnvelope }) => policyEnvelope.payload.contextGraphId,
+  );
+  if (
+    activation.autoPublish !== undefined
+    && Object.prototype.hasOwnProperty.call(activation.autoPublish, 'contextGraphIds')
+  ) {
+    throw new TypeError(
+      'rfc64PublicCatalog.autoPublish.contextGraphIds is derived from the bootstrap manifest',
+    );
+  }
+  const deploymentProfile = snapshotRfc64CatalogDeploymentProfileV1(
+    activation.deploymentProfile,
+  );
+  if (deploymentProfile !== undefined) {
+    if (deploymentProfile.networkId !== selectedNetworkId) {
+      throw new TypeError(
+        'rfc64PublicCatalog deployment network differs from the daemon effective chain id',
+      );
+    }
+    if (deploymentProfile.assertedAtChainId !== selectedEvmChainId) {
+      throw new TypeError(
+        'rfc64PublicCatalog deployment EVM chain id differs from the daemon effective chain id',
+      );
+    }
+  }
+  const autoPublish = activation.autoPublish === undefined
+    ? undefined
+    : snapshotRfc64PublicCatalogAutoPublishConfigV1({
+        ...activation.autoPublish,
+        contextGraphIds: selectedContextGraphs,
+      });
+  return Object.freeze({
+    enabled: true,
+    selectedContextGraphs: Object.freeze(selectedContextGraphs),
+    deploymentProfile,
+    autoPublish,
+    bootstrap,
+  });
+}

--- a/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Narrow side-effect-free package surface for daemon/operator activation.
+ * Consumers that only normalize RFC-64 configuration must not import the full
+ * DKGAgent runtime (which owns process-global scheduler observability).
+ */
+export {
+  snapshotRfc64CatalogDeploymentProfileV1,
+  snapshotRfc64PublicCatalogAutoPublishConfigV1,
+  snapshotRfc64PublicCatalogBootstrapConfigV1,
+} from './catalog-authority-config-v1.js';

--- a/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CatalogSealDeploymentProfileV1 } from '@origintrail-official/dkg-core';
+import {
+  assertCanonicalChainId,
+  assertNetworkIdV1,
+  type CatalogSealDeploymentProfileV1,
+  type ChainIdV1,
+  type NetworkIdV1,
+} from '@origintrail-official/dkg-core';
 
 import type {
   Rfc64PublicCatalogAutoPublishConfigV1,
@@ -11,6 +17,29 @@ import {
   snapshotRfc64PublicCatalogAutoPublishConfigV1,
   snapshotRfc64PublicCatalogBootstrapConfigV1,
 } from './catalog-authority-config-v1.js';
+
+const MAX_SELECTED_PUBLIC_CONTEXT_GRAPHS_V1 = 64;
+const RFC64_PUBLIC_CATALOG_ACTIVATION_FIELDS_V1 = new Set([
+  'autoPublish',
+  'bootstrap',
+  'deploymentProfile',
+  'enabled',
+]);
+
+function assertRfc64PublicCatalogActivationConfigV1(
+  input: unknown,
+): asserts input is Rfc64PublicCatalogActivationConfigV1 {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('rfc64PublicCatalog must be a plain object');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('rfc64PublicCatalog must be a plain object');
+  }
+  if (Object.keys(input).some((key) => !RFC64_PUBLIC_CATALOG_ACTIVATION_FIELDS_V1.has(key))) {
+    throw new TypeError('rfc64PublicCatalog has unknown fields');
+  }
+}
 
 /**
  * Narrow side-effect-free package surface for daemon/operator activation.
@@ -31,7 +60,7 @@ export {
 export interface Rfc64PublicCatalogActivationConfigV1 {
   readonly enabled?: boolean;
   readonly deploymentProfile?: CatalogSealDeploymentProfileV1;
-  readonly autoPublish?: Omit<Rfc64PublicCatalogAutoPublishConfigV1, 'contextGraphIds'>;
+  readonly autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
   readonly bootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
 }
 
@@ -43,9 +72,83 @@ export interface ResolvedRfc64PublicCatalogActivationConfigV1 {
   readonly bootstrap?: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
 }
 
+export type ResolvedRfc64PublicCatalogAutoPublishPolicyV1 =
+  | Readonly<{
+    mode: 'all-accepted-public';
+    config: Readonly<Rfc64PublicCatalogAutoPublishConfigV1>;
+  }>
+  | Readonly<{
+    mode: 'selected-public';
+    config: Readonly<Rfc64PublicCatalogAutoPublishConfigV1>;
+    selectedContextGraphs: readonly string[];
+  }>;
+
+export interface Rfc64PublicCatalogControlInputsV1 {
+  readonly activation?: ResolvedRfc64PublicCatalogActivationConfigV1;
+  readonly legacyDeploymentProfile?: CatalogSealDeploymentProfileV1;
+  readonly legacyAutoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
+  readonly legacyBootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
+}
+
+export interface ResolvedRfc64PublicCatalogControlsV1 {
+  readonly deploymentProfile?: Readonly<CatalogSealDeploymentProfileV1>;
+  readonly autoPublishPolicy?: ResolvedRfc64PublicCatalogAutoPublishPolicyV1;
+  readonly bootstrap?: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
+  readonly requiresDataDir: boolean;
+}
+
 export interface Rfc64PublicCatalogActivationChainIdentityV1 {
-  /** Effective chain-adapter network identifier, for example `base:84532`. */
-  readonly chainId: string | undefined;
+  /** Effective RFC-64 network identifier, for example `base:84532`. */
+  readonly networkId: NetworkIdV1 | undefined;
+  /** Canonical decimal EVM chain identifier, for example `84532`. */
+  readonly evmChainId: ChainIdV1 | undefined;
+}
+
+/**
+ * Parse the chain adapter's namespaced identifier into the two identities
+ * consumed by RFC-64 activation. Keeping this grammar in one named helper
+ * prevents policy network and deployment chain checks from sharing an
+ * ambiguously named raw string boundary.
+ */
+export function resolveRfc64PublicCatalogActivationChainIdentityV1(
+  networkIdInput: string | undefined,
+): Rfc64PublicCatalogActivationChainIdentityV1 {
+  if (networkIdInput === undefined) {
+    return Object.freeze({ networkId: undefined, evmChainId: undefined });
+  }
+  assertNetworkIdV1(networkIdInput, 'RFC-64 activation networkId');
+  const evmChainIdInput = networkIdInput.match(/:(0|[1-9][0-9]*)$/u)?.[1];
+  if (evmChainIdInput === undefined) {
+    return Object.freeze({ networkId: networkIdInput, evmChainId: undefined });
+  }
+  assertCanonicalChainId(evmChainIdInput, 'RFC-64 activation evmChainId');
+  return Object.freeze({
+    networkId: networkIdInput,
+    evmChainId: evmChainIdInput,
+  });
+}
+
+function requireRfc64PublicCatalogActivationChainIdentityV1(
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): Readonly<Required<Rfc64PublicCatalogActivationChainIdentityV1>> {
+  const selectedNetworkId = chainIdentity.networkId;
+  if (selectedNetworkId === undefined) {
+    throw new TypeError('enabled rfc64PublicCatalog requires an effective network id');
+  }
+  assertNetworkIdV1(selectedNetworkId, 'RFC-64 activation networkId');
+  const selectedEvmChainId = chainIdentity.evmChainId;
+  if (selectedEvmChainId === undefined) {
+    throw new TypeError('enabled rfc64PublicCatalog requires a numeric EVM chain id');
+  }
+  assertCanonicalChainId(selectedEvmChainId, 'RFC-64 activation evmChainId');
+  const derived = resolveRfc64PublicCatalogActivationChainIdentityV1(selectedNetworkId);
+  if (derived.evmChainId !== selectedEvmChainId) {
+    throw new TypeError('RFC-64 activation network and EVM chain ids differ');
+  }
+  return Object.freeze({
+    networkId: selectedNetworkId,
+    evmChainId: selectedEvmChainId,
+  });
 }
 
 /**
@@ -58,31 +161,36 @@ export function resolveRfc64PublicCatalogActivationConfigV1(
   activation: Rfc64PublicCatalogActivationConfigV1 | undefined,
   chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
 ): ResolvedRfc64PublicCatalogActivationConfigV1 {
-  if (activation === undefined || activation.enabled === false) {
+  if (activation === undefined) {
     return Object.freeze({
       enabled: false,
       selectedContextGraphs: Object.freeze([]),
     });
   }
-  if (activation.enabled !== true) {
+  assertRfc64PublicCatalogActivationConfigV1(activation);
+  const enabled = activation.enabled;
+  const bootstrapInput = activation.bootstrap;
+  const autoPublishInput = activation.autoPublish;
+  const deploymentProfileInput = activation.deploymentProfile;
+  if (enabled === false) {
+    return Object.freeze({
+      enabled: false,
+      selectedContextGraphs: Object.freeze([]),
+    });
+  }
+  if (enabled !== true) {
     throw new TypeError('rfc64PublicCatalog.enabled must be a boolean');
   }
-  const bootstrap = snapshotRfc64PublicCatalogBootstrapConfigV1(activation.bootstrap);
+  const bootstrap = snapshotRfc64PublicCatalogBootstrapConfigV1(bootstrapInput);
   if (bootstrap === undefined || bootstrap.acceptedPublicPolicies.length === 0) {
     throw new TypeError(
       'enabled rfc64PublicCatalog requires a non-empty bootstrap.acceptedPublicPolicies manifest',
     );
   }
-  const selectedNetworkId = chainIdentity.chainId;
-  if (typeof selectedNetworkId !== 'string' || selectedNetworkId.length === 0) {
-    throw new TypeError('enabled rfc64PublicCatalog requires an effective chain id');
-  }
-  const selectedEvmChainId = selectedNetworkId.match(/:(0|[1-9][0-9]*)$/u)?.[1];
-  if (selectedEvmChainId === undefined) {
-    throw new TypeError(
-      'enabled rfc64PublicCatalog requires a namespaced numeric EVM chain id',
-    );
-  }
+  const {
+    networkId: selectedNetworkId,
+    evmChainId: selectedEvmChainId,
+  } = requireRfc64PublicCatalogActivationChainIdentityV1(chainIdentity);
   for (const { policyEnvelope } of bootstrap.acceptedPublicPolicies) {
     if (policyEnvelope.payload.networkId !== selectedNetworkId) {
       throw new TypeError(
@@ -94,15 +202,15 @@ export function resolveRfc64PublicCatalogActivationConfigV1(
     ({ policyEnvelope }) => policyEnvelope.payload.contextGraphId,
   );
   if (
-    activation.autoPublish !== undefined
-    && Object.prototype.hasOwnProperty.call(activation.autoPublish, 'contextGraphIds')
+    autoPublishInput !== undefined
+    && Object.prototype.hasOwnProperty.call(autoPublishInput, 'contextGraphIds')
   ) {
     throw new TypeError(
       'rfc64PublicCatalog.autoPublish.contextGraphIds is derived from the bootstrap manifest',
     );
   }
   const deploymentProfile = snapshotRfc64CatalogDeploymentProfileV1(
-    activation.deploymentProfile,
+    deploymentProfileInput,
   );
   if (deploymentProfile !== undefined) {
     if (deploymentProfile.networkId !== selectedNetworkId) {
@@ -116,17 +224,125 @@ export function resolveRfc64PublicCatalogActivationConfigV1(
       );
     }
   }
-  const autoPublish = activation.autoPublish === undefined
-    ? undefined
-    : snapshotRfc64PublicCatalogAutoPublishConfigV1({
-        ...activation.autoPublish,
-        contextGraphIds: selectedContextGraphs,
-      });
+  const autoPublish = snapshotRfc64PublicCatalogAutoPublishConfigV1(autoPublishInput);
   return Object.freeze({
     enabled: true,
     selectedContextGraphs: Object.freeze(selectedContextGraphs),
     deploymentProfile,
     autoPublish,
     bootstrap,
+  });
+}
+
+/**
+ * Re-snapshot a caller-supplied resolved activation at the agent boundary.
+ * The selected graph list must exactly equal the manifest-derived list, so a
+ * direct `DKGAgent.create()` caller cannot express split selection.
+ */
+export function snapshotResolvedRfc64PublicCatalogActivationConfigV1(
+  input: ResolvedRfc64PublicCatalogActivationConfigV1 | undefined,
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): ResolvedRfc64PublicCatalogActivationConfigV1 | undefined {
+  if (input === undefined) return undefined;
+  const enabled = input.enabled;
+  const selectedContextGraphsInput = input.selectedContextGraphs;
+  const deploymentProfileInput = input.deploymentProfile;
+  const autoPublishInput = input.autoPublish;
+  const bootstrapInput = input.bootstrap;
+  if (
+    !Array.isArray(selectedContextGraphsInput)
+    || selectedContextGraphsInput.length > MAX_SELECTED_PUBLIC_CONTEXT_GRAPHS_V1
+  ) {
+    throw new TypeError(
+      'rfc64PublicCatalogActivation selected graphs must be a bounded array',
+    );
+  }
+  const selectedContextGraphs = [...selectedContextGraphsInput];
+  if (enabled === false) {
+    if (
+      selectedContextGraphs.length !== 0
+      || deploymentProfileInput !== undefined
+      || autoPublishInput !== undefined
+      || bootstrapInput !== undefined
+    ) {
+      throw new TypeError('disabled rfc64PublicCatalogActivation must not carry controls');
+    }
+    return Object.freeze({
+      enabled: false,
+      selectedContextGraphs: Object.freeze([]),
+    });
+  }
+  if (enabled !== true) {
+    throw new TypeError('rfc64PublicCatalogActivation.enabled must be a boolean');
+  }
+  const resolved = resolveRfc64PublicCatalogActivationConfigV1({
+    enabled: true,
+    deploymentProfile: deploymentProfileInput,
+    autoPublish: autoPublishInput,
+    bootstrap: bootstrapInput,
+  }, chainIdentity);
+  if (
+    selectedContextGraphs.length !== resolved.selectedContextGraphs.length
+    || selectedContextGraphs.some(
+      (contextGraphId, index) => contextGraphId !== resolved.selectedContextGraphs[index],
+    )
+  ) {
+    throw new TypeError(
+      'rfc64PublicCatalogActivation selected graphs differ from the bootstrap manifest',
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Normalize selected activation and legacy catalog controls into one internal
+ * runtime contract before DKGAgent construction begins. The hot publication
+ * path consumes only `autoPublishPolicy`; it never interprets sibling public
+ * config fields to decide whether graph selection is bounded or legacy-wide.
+ */
+export function resolveRfc64PublicCatalogControlsV1(
+  input: Rfc64PublicCatalogControlInputsV1,
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): ResolvedRfc64PublicCatalogControlsV1 {
+  if (
+    input.activation !== undefined
+    && (
+      input.legacyDeploymentProfile !== undefined
+      || input.legacyAutoPublish !== undefined
+      || input.legacyBootstrap !== undefined
+    )
+  ) {
+    throw new TypeError(
+      'rfc64PublicCatalogActivation is mutually exclusive with legacy catalog controls',
+    );
+  }
+  const activation = snapshotResolvedRfc64PublicCatalogActivationConfigV1(
+    input.activation,
+    chainIdentity,
+  );
+  const deploymentProfile = activation?.deploymentProfile
+    ?? snapshotRfc64CatalogDeploymentProfileV1(input.legacyDeploymentProfile);
+  const legacyAutoPublish = activation === undefined
+    ? snapshotRfc64PublicCatalogAutoPublishConfigV1(input.legacyAutoPublish)
+    : undefined;
+  const autoPublishPolicy = activation?.autoPublish === undefined
+    ? (legacyAutoPublish === undefined
+      ? undefined
+      : Object.freeze({
+        mode: 'all-accepted-public' as const,
+        config: legacyAutoPublish,
+      }))
+    : Object.freeze({
+      mode: 'selected-public' as const,
+      config: activation.autoPublish,
+      selectedContextGraphs: activation.selectedContextGraphs,
+    });
+  const bootstrap = activation?.bootstrap
+    ?? snapshotRfc64PublicCatalogBootstrapConfigV1(input.legacyBootstrap);
+  return Object.freeze({
+    deploymentProfile,
+    autoPublishPolicy,
+    bootstrap,
+    requiresDataDir: bootstrap !== undefined,
   });
 }

--- a/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
@@ -72,6 +72,10 @@ export interface ResolvedRfc64PublicCatalogActivationConfigV1 {
   readonly bootstrap?: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
 }
 
+export type Rfc64PublicCatalogActivationInputV1 =
+  | Rfc64PublicCatalogActivationConfigV1
+  | ResolvedRfc64PublicCatalogActivationConfigV1;
+
 export type ResolvedRfc64PublicCatalogAutoPublishPolicyV1 =
   | Readonly<{
     mode: 'all-accepted-public';
@@ -292,6 +296,26 @@ export function snapshotResolvedRfc64PublicCatalogActivationConfigV1(
     );
   }
   return resolved;
+}
+
+/** Resolve raw operator input, while preserving compatibility with the short-lived resolved input. */
+export function resolveRfc64PublicCatalogActivationInputV1(
+  input: Rfc64PublicCatalogActivationInputV1 | undefined,
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): ResolvedRfc64PublicCatalogActivationConfigV1 {
+  if (
+    input !== undefined
+    && Object.prototype.hasOwnProperty.call(input, 'selectedContextGraphs')
+  ) {
+    return snapshotResolvedRfc64PublicCatalogActivationConfigV1(
+      input as ResolvedRfc64PublicCatalogActivationConfigV1,
+      chainIdentity,
+    )!;
+  }
+  return resolveRfc64PublicCatalogActivationConfigV1(
+    input as Rfc64PublicCatalogActivationConfigV1 | undefined,
+    chainIdentity,
+  );
 }
 
 /**

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -11,6 +11,7 @@ import {
   buildAuthorAttestationTypedData,
   computeAuthorCatalogScopeDigestV1,
   computeContextGraphPolicyObjectDigestV1,
+  computeNetworkId,
   contextGraphLayerUri,
   type CanonicalGraphScopedAuthorSealV1,
   type CatalogSealDeploymentProfileV1,
@@ -40,6 +41,12 @@ import {
   buildOpenOwnerContextGraphPolicyV1,
   unsignedOpenContextGraphPolicyEnvelopeV1,
 } from '../src/rfc64/open-catalog-policy-v1.js';
+import {
+  resolveRfc64PublicCatalogActivationChainIdentityV1,
+  resolveRfc64PublicCatalogActivationConfigV1,
+  resolveRfc64PublicCatalogControlsV1,
+  type ResolvedRfc64PublicCatalogActivationConfigV1,
+} from '../src/rfc64/public-catalog-activation-config-v1.js';
 import type {
   ContextGraphSubscriptionRecord,
   ContextGraphSubscriptionStore,
@@ -184,7 +191,9 @@ interface NativeAgentStartOptionsV1 {
   }>;
   readonly autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
   readonly bootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
+  readonly activation?: ResolvedRfc64PublicCatalogActivationConfigV1;
   readonly persistentStorePath?: string;
+  readonly networkIdentityChainId?: NetworkIdV1;
 }
 
 async function startNativeAgentWithOptions(
@@ -198,7 +207,9 @@ async function startNativeAgentWithOptions(
     finalizedRuntime,
     autoPublish,
     bootstrap,
+    activation,
     persistentStorePath,
+    networkIdentityChainId = activation === undefined ? undefined : deployment.networkId,
   } = options;
   const dataDir = existingDataDir
     ?? await mkdtemp(join(tmpdir(), `dkg-rfc64-native-${name}-`));
@@ -216,10 +227,20 @@ async function startNativeAgentWithOptions(
     syncOnConnectEnabled: false,
     durableSyncEnabled: false,
     agentProfileHeartbeatMs: 0,
-    rfc64CatalogDeploymentProfile: deployment,
     rfc64CatalogAccessPolicyAuthority: accessPolicyAuthority,
-    rfc64PublicCatalogAutoPublish: autoPublish,
-    rfc64PublicCatalogBootstrap: bootstrap,
+    ...(networkIdentityChainId === undefined ? {} : {
+      networkIdentity: {
+        networkId: await computeNetworkId(),
+        chainId: networkIdentityChainId,
+      },
+    }),
+    ...(activation === undefined ? {
+      rfc64CatalogDeploymentProfile: deployment,
+      rfc64PublicCatalogAutoPublish: autoPublish,
+      rfc64PublicCatalogBootstrap: bootstrap,
+    } : {
+      rfc64PublicCatalogActivation: activation,
+    }),
     ...(finalizedRuntime === undefined ? {} : {
       chainAdapter: finalizedRuntime.chainAdapter,
       chainConfig: {
@@ -357,6 +378,24 @@ function privateCatalogRoster(
 }
 
 ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring', () => {
+  it('preserves the EVM default chain identity for a no-admin chain config', async () => {
+    const operational = ethers.Wallet.createRandom();
+    const agent = await DKGAgent.create({
+      name: 'rfc64-no-admin-default-chain',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      chainConfig: {
+        rpcUrl: 'http://127.0.0.1:0',
+        hubAddress: ethers.ZeroAddress,
+        operationalKeys: [operational.privateKey],
+      },
+      nodeRole: 'core',
+    });
+    agents.push(agent);
+
+    expect(agent).toBeInstanceOf(DKGAgent);
+  });
+
   it('snapshots and canonicalizes the deterministic local deployment override', () => {
     const callerOwned = {
       networkId: NETWORK_ID,
@@ -377,38 +416,109 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
 
   it('snapshots the opt-in normal-publication catalog producer configuration', () => {
     const callerOwned = {
-      contextGraphIds: [CONTEXT_GRAPH_ID],
       peers: ['12D3KooReceiver'],
       catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
     };
     const snapshot = snapshotRfc64PublicCatalogAutoPublishConfigV1(callerOwned)!;
-    callerOwned.contextGraphIds.push(
-      '0x2222222222222222222222222222222222222222/late-mutation' as ContextGraphIdV1,
-    );
     callerOwned.peers.push('hostile-late-mutation');
     expect(snapshot).toEqual({
-      contextGraphIds: [CONTEXT_GRAPH_ID],
       peers: ['12D3KooReceiver'],
       catalogIssuerDelegationEffectiveAt: '0',
       catalogIssuerDelegationExpiresAt: '1893456000000',
     });
     expect(Object.isFrozen(snapshot)).toBe(true);
-    expect(Object.isFrozen(snapshot.contextGraphIds)).toBe(true);
     expect(Object.isFrozen(snapshot.peers)).toBe(true);
     expect(() => snapshotRfc64PublicCatalogAutoPublishConfigV1({
-      contextGraphIds: [CONTEXT_GRAPH_ID],
       peers: ['duplicate', 'duplicate'],
       catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
     })).toThrow(/duplicated/u);
-    expect(() => snapshotRfc64PublicCatalogAutoPublishConfigV1({
-      contextGraphIds: [CONTEXT_GRAPH_ID, CONTEXT_GRAPH_ID],
-      peers: [],
-      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
-    })).toThrow(/contextGraphIds must be unique/u);
-    expect(() => snapshotRfc64PublicCatalogAutoPublishConfigV1({
-      peers: [],
-      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
-    } as never)).toThrow(/unknown or missing fields/u);
+  });
+
+  it('keeps direct legacy agent auto-publish configuration source-compatible', async () => {
+    const agent = await startNativeAgent(
+      'legacy-direct-agent-config',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      undefined,
+      {
+        peers: [],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    expect(agent).toBeInstanceOf(DKGAgent);
+  });
+
+  it('normalizes legacy and selected auto-publish into one internal policy', () => {
+    const chainIdentity = resolveRfc64PublicCatalogActivationChainIdentityV1(NETWORK_ID);
+    const selectedPolicy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const activation = resolveRfc64PublicCatalogActivationConfigV1({
+      enabled: true,
+      autoPublish: {
+        peers: ['12D3KooSelected'],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+      bootstrap: {
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(selectedPolicy),
+          targets: [],
+        }],
+      },
+    }, chainIdentity);
+
+    expect(resolveRfc64PublicCatalogControlsV1({ activation }, chainIdentity))
+      .toMatchObject({
+        autoPublishPolicy: {
+          mode: 'selected-public',
+          selectedContextGraphs: [CONTEXT_GRAPH_ID],
+          config: { peers: ['12D3KooSelected'] },
+        },
+        requiresDataDir: true,
+      });
+    expect(resolveRfc64PublicCatalogControlsV1({
+      legacyAutoPublish: {
+        peers: ['12D3KooLegacy'],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    }, resolveRfc64PublicCatalogActivationChainIdentityV1(undefined)))
+      .toMatchObject({
+        autoPublishPolicy: {
+          mode: 'all-accepted-public',
+          config: { peers: ['12D3KooLegacy'] },
+        },
+        requiresDataDir: false,
+      });
+  });
+
+  it('rejects a direct resolved activation whose selection differs from its manifest', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const activation = resolveRfc64PublicCatalogActivationConfigV1({
+      enabled: true,
+      deploymentProfile: NATIVE_DEPLOYMENT,
+      bootstrap: {
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [],
+        }],
+      },
+    }, resolveRfc64PublicCatalogActivationChainIdentityV1(NETWORK_ID));
+
+    await expect(DKGAgent.create({
+      name: 'split-selected-agent-config',
+      networkIdentity: { networkId: 'rfc64-test', chainId: NETWORK_ID },
+      rfc64PublicCatalogActivation: {
+        ...activation,
+        selectedContextGraphs: ['different-selection'],
+      } as never,
+    })).rejects.toThrow(/selected graphs differ from the bootstrap manifest/u);
   });
 
   it('snapshots a bounded public-root bootstrap manifest', () => {
@@ -462,20 +572,109 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).rejects.toThrow(/rfc64PublicCatalogBootstrap requires dataDir/u);
   });
 
-  it('turns one confirmed public KA into the provider current head and one cold receiver apply', async () => {
-    const receiver = await startNativeAgent('auto-publish-receiver');
-    const author = await startNativeAgent(
-      'auto-publish-author',
-      NATIVE_DEPLOYMENT,
-      undefined,
-      undefined,
-      undefined,
-      {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
-        peers: [receiver.peerId],
+  it('rejects selected activation bootstrap without persistence before node startup', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const activation = resolveRfc64PublicCatalogActivationConfigV1({
+      enabled: true,
+      bootstrap: {
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [],
+        }],
+      },
+    }, resolveRfc64PublicCatalogActivationChainIdentityV1(NETWORK_ID));
+    await expect(DKGAgent.create({
+      name: 'ephemeral-selected-activation-is-invalid',
+      networkIdentity: { networkId: 'rfc64-test', chainId: NETWORK_ID },
+      rfc64PublicCatalogActivation: activation,
+    })).rejects.toThrow(/rfc64PublicCatalogBootstrap requires dataDir/u);
+  });
+
+  it('rejects selected activation mixed with a legacy catalog control', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const activation = resolveRfc64PublicCatalogActivationConfigV1({
+      enabled: true,
+      bootstrap: {
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [],
+        }],
+      },
+    }, resolveRfc64PublicCatalogActivationChainIdentityV1(NETWORK_ID));
+    await expect(DKGAgent.create({
+      name: 'mixed-selected-and-legacy-controls',
+      networkIdentity: { networkId: 'rfc64-test', chainId: NETWORK_ID },
+      rfc64PublicCatalogActivation: activation,
+      rfc64PublicCatalogAutoPublish: {
+        peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
-    );
+    })).rejects.toThrow(/mutually exclusive/u);
+  });
+
+  it('does not let an activation deployment profile supply its own chain identity', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const activation = resolveRfc64PublicCatalogActivationConfigV1({
+      enabled: true,
+      deploymentProfile: NATIVE_DEPLOYMENT,
+      bootstrap: {
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [],
+        }],
+      },
+    }, resolveRfc64PublicCatalogActivationChainIdentityV1(NETWORK_ID));
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-rfc64-self-bound-chain-'));
+    tempDirs.push(dataDir);
+    await expect(DKGAgent.create({
+      name: 'self-bound-deployment-is-invalid',
+      dataDir,
+      rfc64PublicCatalogActivation: activation,
+    })).rejects.toThrow(/requires an effective network id/u);
+  });
+
+  it('turns one confirmed public KA into the provider current head and one cold receiver apply', async () => {
+    const acceptedButUnselectedContextGraphId = (
+      '0x1111111111111111111111111111111111111111/accepted-not-selected'
+    ) as ContextGraphIdV1;
+    const receiver = await startNativeAgentWithOptions({
+      name: 'auto-publish-receiver',
+      networkIdentityChainId: NETWORK_ID,
+    });
+    const selectedPolicy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const author = await startNativeAgentWithOptions({
+      name: 'auto-publish-author',
+      activation: resolveRfc64PublicCatalogActivationConfigV1({
+        enabled: true,
+        deploymentProfile: NATIVE_DEPLOYMENT,
+        autoPublish: {
+          peers: [receiver.peerId],
+          catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+        },
+        bootstrap: {
+          acceptedPublicPolicies: [{
+            policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(selectedPolicy),
+            targets: [],
+          }],
+        },
+      }, resolveRfc64PublicCatalogActivationChainIdentityV1(NETWORK_ID)),
+    });
     vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(AUTHOR_WALLET.privateKey);
     for (const agent of [author, receiver]) {
       agent.acceptOpenContextGraphPolicyV1({
@@ -484,11 +683,16 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         ownerAddress: AUTHOR,
       });
     }
+    author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: acceptedButUnselectedContextGraphId,
+      ownerAddress: AUTHOR,
+    });
     await connectBothWays(author, receiver);
 
     const seal = assertionSealFromCanonical(await authorSeal(11n));
     const ignored = await author.recordConfirmedRfc64PublicCatalogAssetV1({
-      contextGraphId: 'not-selected-by-operator' as ContextGraphIdV1,
+      contextGraphId: acceptedButUnselectedContextGraphId,
       assertionCoordinate: 'ordinary-confirmed-publication-other-cg' as never,
       publicQuads: [
         {
@@ -507,6 +711,25 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       seal,
     });
     expect(ignored).toBeNull();
+    const acceptedButUnselectedScopeDigest = computeAuthorCatalogScopeDigestV1({
+      networkId: NETWORK_ID,
+      contextGraphId: acceptedButUnselectedContextGraphId,
+      governanceChainId: null,
+      governanceContractAddress: null,
+      ownershipTransitionDigest: null,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      era: '0' as never,
+      bucketCount: '1' as never,
+    });
+    expect(author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: acceptedButUnselectedScopeDigest,
+      authorAddress: AUTHOR,
+    })).toBeNull();
+    expect(receiver.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: acceptedButUnselectedScopeDigest,
+      authorAddress: AUTHOR,
+    })).toBeNull();
 
     const first = await author.recordConfirmedRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
@@ -613,7 +836,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -647,7 +869,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -706,7 +927,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -762,7 +982,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [receiver.peerId],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -839,7 +1058,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -950,7 +1168,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -1091,7 +1308,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -1133,7 +1349,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -1901,7 +2116,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture),
       },
       {
-        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [warm.peerId],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -394,6 +394,12 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     agents.push(agent);
 
     expect(agent).toBeInstanceOf(DKGAgent);
+    const internals = agent as unknown as {
+      chain: { chainId: string };
+      config: { networkIdentity?: { chainId?: string } };
+    };
+    expect(internals.chain.chainId).toBe('evm:31337');
+    expect(internals.config.networkIdentity?.chainId).toBe('evm:31337');
   });
 
   it('snapshots and canonicalizes the deterministic local deployment override', () => {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -45,7 +45,7 @@ import {
   resolveRfc64PublicCatalogActivationChainIdentityV1,
   resolveRfc64PublicCatalogActivationConfigV1,
   resolveRfc64PublicCatalogControlsV1,
-  type ResolvedRfc64PublicCatalogActivationConfigV1,
+  type Rfc64PublicCatalogActivationInputV1,
 } from '../src/rfc64/public-catalog-activation-config-v1.js';
 import type {
   ContextGraphSubscriptionRecord,
@@ -191,7 +191,7 @@ interface NativeAgentStartOptionsV1 {
   }>;
   readonly autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
   readonly bootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
-  readonly activation?: ResolvedRfc64PublicCatalogActivationConfigV1;
+  readonly activation?: Rfc64PublicCatalogActivationInputV1;
   readonly persistentStorePath?: string;
   readonly networkIdentityChainId?: NetworkIdV1;
 }
@@ -519,6 +519,58 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         selectedContextGraphs: ['different-selection'],
       } as never,
     })).rejects.toThrow(/selected graphs differ from the bootstrap manifest/u);
+  });
+
+  it('projects raw selected activation into direct agent durable sync scope', async () => {
+    const selectedPolicy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const agent = await startNativeAgentWithOptions({
+      name: 'direct-selected-sync-scope',
+      activation: {
+        enabled: true,
+        deploymentProfile: NATIVE_DEPLOYMENT,
+        bootstrap: {
+          acceptedPublicPolicies: [{
+            policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(selectedPolicy),
+            targets: [],
+          }],
+        },
+      },
+    });
+
+    expect((agent as any).config.syncContextGraphs).toContain(CONTEXT_GRAPH_ID);
+  });
+
+  it('keeps direct disabled activation fail-closed even when stale controls are present', async () => {
+    const ignoredPolicy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const agent = await startNativeAgentWithOptions({
+      name: 'direct-disabled-stale-controls',
+      activation: {
+        enabled: false,
+        deploymentProfile: NATIVE_DEPLOYMENT,
+        autoPublish: {
+          peers: ['12D3KooIgnored'],
+          catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+        },
+        bootstrap: {
+          acceptedPublicPolicies: [{
+            policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(ignoredPolicy),
+            targets: [],
+          }],
+        },
+      },
+    });
+
+    expect((agent as any).config.syncContextGraphs).not.toContain(CONTEXT_GRAPH_ID);
+    expect((agent as any).config.rfc64PublicCatalogBootstrap).toBeUndefined();
+    expect((agent as any).config.rfc64PublicCatalogAutoPublishPolicy).toBeUndefined();
   });
 
   it('snapshots a bounded public-root bootstrap manifest', () => {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -377,22 +377,38 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
 
   it('snapshots the opt-in normal-publication catalog producer configuration', () => {
     const callerOwned = {
+      contextGraphIds: [CONTEXT_GRAPH_ID],
       peers: ['12D3KooReceiver'],
       catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
     };
     const snapshot = snapshotRfc64PublicCatalogAutoPublishConfigV1(callerOwned)!;
+    callerOwned.contextGraphIds.push(
+      '0x2222222222222222222222222222222222222222/late-mutation' as ContextGraphIdV1,
+    );
     callerOwned.peers.push('hostile-late-mutation');
     expect(snapshot).toEqual({
+      contextGraphIds: [CONTEXT_GRAPH_ID],
       peers: ['12D3KooReceiver'],
       catalogIssuerDelegationEffectiveAt: '0',
       catalogIssuerDelegationExpiresAt: '1893456000000',
     });
     expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.contextGraphIds)).toBe(true);
     expect(Object.isFrozen(snapshot.peers)).toBe(true);
     expect(() => snapshotRfc64PublicCatalogAutoPublishConfigV1({
+      contextGraphIds: [CONTEXT_GRAPH_ID],
       peers: ['duplicate', 'duplicate'],
       catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
     })).toThrow(/duplicated/u);
+    expect(() => snapshotRfc64PublicCatalogAutoPublishConfigV1({
+      contextGraphIds: [CONTEXT_GRAPH_ID, CONTEXT_GRAPH_ID],
+      peers: [],
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    })).toThrow(/contextGraphIds must be unique/u);
+    expect(() => snapshotRfc64PublicCatalogAutoPublishConfigV1({
+      peers: [],
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    } as never)).toThrow(/unknown or missing fields/u);
   });
 
   it('snapshots a bounded public-root bootstrap manifest', () => {
@@ -455,6 +471,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [receiver.peerId],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -470,6 +487,27 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     await connectBothWays(author, receiver);
 
     const seal = assertionSealFromCanonical(await authorSeal(11n));
+    const ignored = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+      contextGraphId: 'not-selected-by-operator' as ContextGraphIdV1,
+      assertionCoordinate: 'ordinary-confirmed-publication-other-cg' as never,
+      publicQuads: [
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/name',
+          object: '"Alice"',
+          graph: '',
+        },
+        {
+          subject: 'https://example.org/alice',
+          predicate: 'https://schema.org/age',
+          object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          graph: '',
+        },
+      ],
+      seal,
+    });
+    expect(ignored).toBeNull();
+
     const first = await author.recordConfirmedRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'ordinary-confirmed-publication' as never,
@@ -575,6 +613,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -608,6 +647,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -666,6 +706,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -721,6 +762,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [receiver.peerId],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -797,6 +839,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -907,6 +950,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -1047,6 +1091,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -1088,6 +1133,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },
@@ -1855,6 +1901,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture),
       },
       {
+        contextGraphIds: [CONTEXT_GRAPH_ID],
         peers: [warm.peerId],
         catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
       },

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -3,10 +3,13 @@ import { join, dirname, basename } from 'node:path';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
-import type {
-  DKGAgentConfig,
-  SyncContextGraphPriorityConfig,
-  SyncResponderSnapshotLimitsConfig,
+import {
+  snapshotRfc64CatalogDeploymentProfileV1,
+  snapshotRfc64PublicCatalogAutoPublishConfigV1,
+  snapshotRfc64PublicCatalogBootstrapConfigV1,
+  type DKGAgentConfig,
+  type SyncContextGraphPriorityConfig,
+  type SyncResponderSnapshotLimitsConfig,
 } from '@origintrail-official/dkg-agent';
 import {
   blueGreenSlotEntryPoint,
@@ -15,7 +18,6 @@ import {
   isDkgMonorepoRoot,
   resolveDkgConfigHome,
   SELECTABLE_SETUP_NETWORKS,
-  type ContextGraphIdV1,
 } from '@origintrail-official/dkg-core';
 import {
   resolveStorageAckTiming,
@@ -1026,31 +1028,18 @@ export function resolveRfc64PublicCatalogActivation(
   if (activation.enabled !== true) {
     throw new TypeError('rfc64PublicCatalog.enabled must be a boolean');
   }
-  const bootstrap = activation.bootstrap;
-  if (
-    bootstrap === undefined
-    || !Array.isArray(bootstrap.acceptedPublicPolicies)
-    || bootstrap.acceptedPublicPolicies.length === 0
-  ) {
+  const bootstrap = snapshotRfc64PublicCatalogBootstrapConfigV1(activation.bootstrap);
+  if (bootstrap === undefined || bootstrap.acceptedPublicPolicies.length === 0) {
     throw new TypeError(
       'enabled rfc64PublicCatalog requires a non-empty bootstrap.acceptedPublicPolicies manifest',
     );
   }
-  const selectedContextGraphs = bootstrap.acceptedPublicPolicies.map((entry, index) => {
-    const contextGraphId = entry?.policyEnvelope?.payload?.contextGraphId;
-    if (typeof contextGraphId !== 'string' || contextGraphId.length === 0) {
-      throw new TypeError(
-        `rfc64PublicCatalog.bootstrap.acceptedPublicPolicies[${index}] has no context graph id`,
-      );
-    }
-    // The agent snapshots and canonically validates the complete policy before
-    // any transport starts; this early resolver only extracts its graph key so
-    // daemon subscription selection and agent activation share one source.
-    return contextGraphId as ContextGraphIdV1;
-  });
-  if (new Set(selectedContextGraphs).size !== selectedContextGraphs.length) {
-    throw new TypeError('rfc64PublicCatalog selected context graphs must be unique');
-  }
+  // Derive daemon subscriptions only from the same canonical, immutable
+  // manifest snapshot the agent consumes. The snapshotter owns policy shape,
+  // public-access, canonical codec, bounds, and uniqueness validation.
+  const selectedContextGraphs = bootstrap.acceptedPublicPolicies.map(
+    ({ policyEnvelope }) => policyEnvelope.payload.contextGraphId,
+  );
   if (
     activation.autoPublish !== undefined
     && Object.prototype.hasOwnProperty.call(activation.autoPublish, 'contextGraphIds')
@@ -1059,16 +1048,17 @@ export function resolveRfc64PublicCatalogActivation(
       'rfc64PublicCatalog.autoPublish.contextGraphIds is derived from the bootstrap manifest',
     );
   }
+  const autoPublish = activation.autoPublish === undefined
+    ? undefined
+    : snapshotRfc64PublicCatalogAutoPublishConfigV1({
+        ...activation.autoPublish,
+        contextGraphIds: selectedContextGraphs,
+      });
   return Object.freeze({
     enabled: true,
     selectedContextGraphs: Object.freeze(selectedContextGraphs),
-    deploymentProfile: activation.deploymentProfile,
-    autoPublish: activation.autoPublish === undefined
-      ? undefined
-      : Object.freeze({
-          ...activation.autoPublish,
-          contextGraphIds: Object.freeze([...selectedContextGraphs]),
-        }),
+    deploymentProfile: snapshotRfc64CatalogDeploymentProfileV1(activation.deploymentProfile),
+    autoPublish,
     bootstrap,
   });
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -14,7 +14,7 @@ import {
   type ResolvedRfc64PublicCatalogActivationConfigV1,
   type Rfc64PublicCatalogActivationChainIdentityV1,
   type Rfc64PublicCatalogActivationConfigV1,
-} from '@origintrail-official/dkg-agent/dist/rfc64/public-catalog-activation-config-v1.js';
+} from '@origintrail-official/dkg-agent';
 import {
   blueGreenSlotEntryPoint,
   blueGreenSlotReady,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -15,6 +15,7 @@ import {
   isDkgMonorepoRoot,
   resolveDkgConfigHome,
   SELECTABLE_SETUP_NETWORKS,
+  type ContextGraphIdV1,
 } from '@origintrail-official/dkg-core';
 import {
   resolveStorageAckTiming,
@@ -477,6 +478,37 @@ export interface GraphSetIndexConfig {
   revalidateMs?: number;
 }
 
+type Rfc64CatalogDeploymentProfileConfig = NonNullable<
+  DKGAgentConfig['rfc64CatalogDeploymentProfile']
+>;
+type Rfc64CatalogAutoPublishConfig = NonNullable<
+  DKGAgentConfig['rfc64PublicCatalogAutoPublish']
+>;
+type Rfc64CatalogBootstrapConfig = NonNullable<
+  DKGAgentConfig['rfc64PublicCatalogBootstrap']
+>;
+
+/**
+ * Explicit selected-public RFC-64 activation. Omitted or `enabled: false`
+ * leaves the catalog data plane fail-closed with no accepted policies and no
+ * ordinary-publication hook. The bootstrap manifest is the selected CG set;
+ * the daemon adds only those graph IDs to durable synchronization.
+ */
+export interface Rfc64PublicCatalogActivationConfig {
+  readonly enabled?: boolean;
+  readonly deploymentProfile?: Rfc64CatalogDeploymentProfileConfig;
+  readonly autoPublish?: Omit<Rfc64CatalogAutoPublishConfig, 'contextGraphIds'>;
+  readonly bootstrap?: Rfc64CatalogBootstrapConfig;
+}
+
+export interface ResolvedRfc64PublicCatalogActivationConfig {
+  readonly enabled: boolean;
+  readonly selectedContextGraphs: readonly string[];
+  readonly deploymentProfile?: Rfc64CatalogDeploymentProfileConfig;
+  readonly autoPublish?: Rfc64CatalogAutoPublishConfig;
+  readonly bootstrap?: Rfc64CatalogBootstrapConfig;
+}
+
 export interface LoggingConfig {
   /** Emit detailed KA publish lifecycle logs. Default: false. */
   kaPublishLifecycleDebug?: boolean;
@@ -570,6 +602,8 @@ export interface DkgConfig {
   bootstrapPeers?: string[];
   /** V10: context graphs to subscribe. */
   contextGraphs?: string[];
+  /** Opt-in, bounded RFC-64 catalog activation for explicitly selected public CGs. */
+  rfc64PublicCatalog?: Rfc64PublicCatalogActivationConfig;
   /**
    * Explicitly trusted context graphs that daemon startup may create locally
    * instead of treating as remote subscription targets. Intended for local
@@ -976,6 +1010,67 @@ export function resolveContextGraphs(config: DkgConfig): string[] {
 /** Resolve context graphs from network config. */
 export function resolveNetworkDefaultContextGraphs(network: NetworkConfig | null | undefined): string[] {
   return network?.defaultContextGraphs ?? [];
+}
+
+/** Resolve the fail-closed operator activation into exact agent inputs. */
+export function resolveRfc64PublicCatalogActivation(
+  config: Pick<DkgConfig, 'rfc64PublicCatalog'>,
+): ResolvedRfc64PublicCatalogActivationConfig {
+  const activation = config.rfc64PublicCatalog;
+  if (activation === undefined || activation.enabled === false) {
+    return Object.freeze({
+      enabled: false,
+      selectedContextGraphs: Object.freeze([]),
+    });
+  }
+  if (activation.enabled !== true) {
+    throw new TypeError('rfc64PublicCatalog.enabled must be a boolean');
+  }
+  const bootstrap = activation.bootstrap;
+  if (
+    bootstrap === undefined
+    || !Array.isArray(bootstrap.acceptedPublicPolicies)
+    || bootstrap.acceptedPublicPolicies.length === 0
+  ) {
+    throw new TypeError(
+      'enabled rfc64PublicCatalog requires a non-empty bootstrap.acceptedPublicPolicies manifest',
+    );
+  }
+  const selectedContextGraphs = bootstrap.acceptedPublicPolicies.map((entry, index) => {
+    const contextGraphId = entry?.policyEnvelope?.payload?.contextGraphId;
+    if (typeof contextGraphId !== 'string' || contextGraphId.length === 0) {
+      throw new TypeError(
+        `rfc64PublicCatalog.bootstrap.acceptedPublicPolicies[${index}] has no context graph id`,
+      );
+    }
+    // The agent snapshots and canonically validates the complete policy before
+    // any transport starts; this early resolver only extracts its graph key so
+    // daemon subscription selection and agent activation share one source.
+    return contextGraphId as ContextGraphIdV1;
+  });
+  if (new Set(selectedContextGraphs).size !== selectedContextGraphs.length) {
+    throw new TypeError('rfc64PublicCatalog selected context graphs must be unique');
+  }
+  if (
+    activation.autoPublish !== undefined
+    && Object.prototype.hasOwnProperty.call(activation.autoPublish, 'contextGraphIds')
+  ) {
+    throw new TypeError(
+      'rfc64PublicCatalog.autoPublish.contextGraphIds is derived from the bootstrap manifest',
+    );
+  }
+  return Object.freeze({
+    enabled: true,
+    selectedContextGraphs: Object.freeze(selectedContextGraphs),
+    deploymentProfile: activation.deploymentProfile,
+    autoPublish: activation.autoPublish === undefined
+      ? undefined
+      : Object.freeze({
+          ...activation.autoPublish,
+          contextGraphIds: Object.freeze([...selectedContextGraphs]),
+        }),
+    bootstrap,
+  });
 }
 
 type NetworkReadinessValidation =

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -14,7 +14,7 @@ import {
   type ResolvedRfc64PublicCatalogActivationConfigV1,
   type Rfc64PublicCatalogActivationChainIdentityV1,
   type Rfc64PublicCatalogActivationConfigV1,
-} from '@origintrail-official/dkg-agent';
+} from '@origintrail-official/dkg-agent/rfc64/public-catalog-activation-config-v1';
 import {
   blueGreenSlotEntryPoint,
   blueGreenSlotReady,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -9,6 +9,7 @@ import type {
   SyncResponderSnapshotLimitsConfig,
 } from '@origintrail-official/dkg-agent';
 import {
+  resolveRfc64PublicCatalogActivationChainIdentityV1,
   resolveRfc64PublicCatalogActivationConfigV1,
   type ResolvedRfc64PublicCatalogActivationConfigV1,
   type Rfc64PublicCatalogActivationChainIdentityV1,
@@ -1008,6 +1009,8 @@ export function resolveRfc64PublicCatalogActivation(
     chainIdentity,
   );
 }
+
+export { resolveRfc64PublicCatalogActivationChainIdentityV1 };
 
 type NetworkReadinessValidation =
   | { ok: true; messages: [] }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -513,6 +513,11 @@ export interface ResolvedRfc64PublicCatalogActivationConfig {
   readonly bootstrap?: Rfc64CatalogBootstrapConfig;
 }
 
+export interface Rfc64PublicCatalogActivationChainIdentity {
+  /** Effective chain-adapter network identifier, for example `base:84532`. */
+  readonly chainId: string | undefined;
+}
+
 export interface LoggingConfig {
   /** Emit detailed KA publish lifecycle logs. Default: false. */
   kaPublishLifecycleDebug?: boolean;
@@ -1019,6 +1024,7 @@ export function resolveNetworkDefaultContextGraphs(network: NetworkConfig | null
 /** Resolve the fail-closed operator activation into exact agent inputs. */
 export function resolveRfc64PublicCatalogActivation(
   config: Pick<DkgConfig, 'rfc64PublicCatalog'>,
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentity,
 ): ResolvedRfc64PublicCatalogActivationConfig {
   const activation = config.rfc64PublicCatalog;
   if (activation === undefined || activation.enabled === false) {
@@ -1036,6 +1042,23 @@ export function resolveRfc64PublicCatalogActivation(
       'enabled rfc64PublicCatalog requires a non-empty bootstrap.acceptedPublicPolicies manifest',
     );
   }
+  const selectedNetworkId = chainIdentity.chainId;
+  if (typeof selectedNetworkId !== 'string' || selectedNetworkId.length === 0) {
+    throw new TypeError('enabled rfc64PublicCatalog requires an effective chain id');
+  }
+  const selectedEvmChainId = selectedNetworkId.match(/:(0|[1-9][0-9]*)$/u)?.[1];
+  if (selectedEvmChainId === undefined) {
+    throw new TypeError(
+      'enabled rfc64PublicCatalog requires a namespaced numeric EVM chain id',
+    );
+  }
+  for (const { policyEnvelope } of bootstrap.acceptedPublicPolicies) {
+    if (policyEnvelope.payload.networkId !== selectedNetworkId) {
+      throw new TypeError(
+        'rfc64PublicCatalog policy network differs from the daemon effective chain id',
+      );
+    }
+  }
   // Derive daemon subscriptions only from the same canonical, immutable
   // manifest snapshot the agent consumes. The snapshotter owns policy shape,
   // public-access, canonical codec, bounds, and uniqueness validation.
@@ -1050,6 +1073,21 @@ export function resolveRfc64PublicCatalogActivation(
       'rfc64PublicCatalog.autoPublish.contextGraphIds is derived from the bootstrap manifest',
     );
   }
+  const deploymentProfile = snapshotRfc64CatalogDeploymentProfileV1(
+    activation.deploymentProfile,
+  );
+  if (deploymentProfile !== undefined) {
+    if (deploymentProfile.networkId !== selectedNetworkId) {
+      throw new TypeError(
+        'rfc64PublicCatalog deployment network differs from the daemon effective chain id',
+      );
+    }
+    if (deploymentProfile.assertedAtChainId !== selectedEvmChainId) {
+      throw new TypeError(
+        'rfc64PublicCatalog deployment EVM chain id differs from the daemon effective chain id',
+      );
+    }
+  }
   const autoPublish = activation.autoPublish === undefined
     ? undefined
     : snapshotRfc64PublicCatalogAutoPublishConfigV1({
@@ -1059,7 +1097,7 @@ export function resolveRfc64PublicCatalogActivation(
   return Object.freeze({
     enabled: true,
     selectedContextGraphs: Object.freeze(selectedContextGraphs),
-    deploymentProfile: snapshotRfc64CatalogDeploymentProfileV1(activation.deploymentProfile),
+    deploymentProfile,
     autoPublish,
     bootstrap,
   });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -9,9 +9,10 @@ import type {
   SyncResponderSnapshotLimitsConfig,
 } from '@origintrail-official/dkg-agent';
 import {
-  snapshotRfc64CatalogDeploymentProfileV1,
-  snapshotRfc64PublicCatalogAutoPublishConfigV1,
-  snapshotRfc64PublicCatalogBootstrapConfigV1,
+  resolveRfc64PublicCatalogActivationConfigV1,
+  type ResolvedRfc64PublicCatalogActivationConfigV1,
+  type Rfc64PublicCatalogActivationChainIdentityV1,
+  type Rfc64PublicCatalogActivationConfigV1,
 } from '@origintrail-official/dkg-agent/dist/rfc64/public-catalog-activation-config-v1.js';
 import {
   blueGreenSlotEntryPoint,
@@ -482,41 +483,17 @@ export interface GraphSetIndexConfig {
   revalidateMs?: number;
 }
 
-type Rfc64CatalogDeploymentProfileConfig = NonNullable<
-  DKGAgentConfig['rfc64CatalogDeploymentProfile']
->;
-type Rfc64CatalogAutoPublishConfig = NonNullable<
-  DKGAgentConfig['rfc64PublicCatalogAutoPublish']
->;
-type Rfc64CatalogBootstrapConfig = NonNullable<
-  DKGAgentConfig['rfc64PublicCatalogBootstrap']
->;
-
 /**
  * Explicit selected-public RFC-64 activation. Omitted or `enabled: false`
  * leaves the catalog data plane fail-closed with no accepted policies and no
  * ordinary-publication hook. The bootstrap manifest is the selected CG set;
  * the daemon adds only those graph IDs to durable synchronization.
  */
-export interface Rfc64PublicCatalogActivationConfig {
-  readonly enabled?: boolean;
-  readonly deploymentProfile?: Rfc64CatalogDeploymentProfileConfig;
-  readonly autoPublish?: Omit<Rfc64CatalogAutoPublishConfig, 'contextGraphIds'>;
-  readonly bootstrap?: Rfc64CatalogBootstrapConfig;
-}
-
-export interface ResolvedRfc64PublicCatalogActivationConfig {
-  readonly enabled: boolean;
-  readonly selectedContextGraphs: readonly string[];
-  readonly deploymentProfile?: Rfc64CatalogDeploymentProfileConfig;
-  readonly autoPublish?: Rfc64CatalogAutoPublishConfig;
-  readonly bootstrap?: Rfc64CatalogBootstrapConfig;
-}
-
-export interface Rfc64PublicCatalogActivationChainIdentity {
-  /** Effective chain-adapter network identifier, for example `base:84532`. */
-  readonly chainId: string | undefined;
-}
+export type Rfc64PublicCatalogActivationConfig = Rfc64PublicCatalogActivationConfigV1;
+export type ResolvedRfc64PublicCatalogActivationConfig =
+  ResolvedRfc64PublicCatalogActivationConfigV1;
+export type Rfc64PublicCatalogActivationChainIdentity =
+  Rfc64PublicCatalogActivationChainIdentityV1;
 
 export interface LoggingConfig {
   /** Emit detailed KA publish lifecycle logs. Default: false. */
@@ -1026,81 +1003,10 @@ export function resolveRfc64PublicCatalogActivation(
   config: Pick<DkgConfig, 'rfc64PublicCatalog'>,
   chainIdentity: Rfc64PublicCatalogActivationChainIdentity,
 ): ResolvedRfc64PublicCatalogActivationConfig {
-  const activation = config.rfc64PublicCatalog;
-  if (activation === undefined || activation.enabled === false) {
-    return Object.freeze({
-      enabled: false,
-      selectedContextGraphs: Object.freeze([]),
-    });
-  }
-  if (activation.enabled !== true) {
-    throw new TypeError('rfc64PublicCatalog.enabled must be a boolean');
-  }
-  const bootstrap = snapshotRfc64PublicCatalogBootstrapConfigV1(activation.bootstrap);
-  if (bootstrap === undefined || bootstrap.acceptedPublicPolicies.length === 0) {
-    throw new TypeError(
-      'enabled rfc64PublicCatalog requires a non-empty bootstrap.acceptedPublicPolicies manifest',
-    );
-  }
-  const selectedNetworkId = chainIdentity.chainId;
-  if (typeof selectedNetworkId !== 'string' || selectedNetworkId.length === 0) {
-    throw new TypeError('enabled rfc64PublicCatalog requires an effective chain id');
-  }
-  const selectedEvmChainId = selectedNetworkId.match(/:(0|[1-9][0-9]*)$/u)?.[1];
-  if (selectedEvmChainId === undefined) {
-    throw new TypeError(
-      'enabled rfc64PublicCatalog requires a namespaced numeric EVM chain id',
-    );
-  }
-  for (const { policyEnvelope } of bootstrap.acceptedPublicPolicies) {
-    if (policyEnvelope.payload.networkId !== selectedNetworkId) {
-      throw new TypeError(
-        'rfc64PublicCatalog policy network differs from the daemon effective chain id',
-      );
-    }
-  }
-  // Derive daemon subscriptions only from the same canonical, immutable
-  // manifest snapshot the agent consumes. The snapshotter owns policy shape,
-  // public-access, canonical codec, bounds, and uniqueness validation.
-  const selectedContextGraphs = bootstrap.acceptedPublicPolicies.map(
-    ({ policyEnvelope }) => policyEnvelope.payload.contextGraphId,
+  return resolveRfc64PublicCatalogActivationConfigV1(
+    config.rfc64PublicCatalog,
+    chainIdentity,
   );
-  if (
-    activation.autoPublish !== undefined
-    && Object.prototype.hasOwnProperty.call(activation.autoPublish, 'contextGraphIds')
-  ) {
-    throw new TypeError(
-      'rfc64PublicCatalog.autoPublish.contextGraphIds is derived from the bootstrap manifest',
-    );
-  }
-  const deploymentProfile = snapshotRfc64CatalogDeploymentProfileV1(
-    activation.deploymentProfile,
-  );
-  if (deploymentProfile !== undefined) {
-    if (deploymentProfile.networkId !== selectedNetworkId) {
-      throw new TypeError(
-        'rfc64PublicCatalog deployment network differs from the daemon effective chain id',
-      );
-    }
-    if (deploymentProfile.assertedAtChainId !== selectedEvmChainId) {
-      throw new TypeError(
-        'rfc64PublicCatalog deployment EVM chain id differs from the daemon effective chain id',
-      );
-    }
-  }
-  const autoPublish = activation.autoPublish === undefined
-    ? undefined
-    : snapshotRfc64PublicCatalogAutoPublishConfigV1({
-        ...activation.autoPublish,
-        contextGraphIds: selectedContextGraphs,
-      });
-  return Object.freeze({
-    enabled: true,
-    selectedContextGraphs: Object.freeze(selectedContextGraphs),
-    deploymentProfile,
-    autoPublish,
-    bootstrap,
-  });
 }
 
 type NetworkReadinessValidation =

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -3,14 +3,16 @@ import { join, dirname, basename } from 'node:path';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
+import type {
+  DKGAgentConfig,
+  SyncContextGraphPriorityConfig,
+  SyncResponderSnapshotLimitsConfig,
+} from '@origintrail-official/dkg-agent';
 import {
   snapshotRfc64CatalogDeploymentProfileV1,
   snapshotRfc64PublicCatalogAutoPublishConfigV1,
   snapshotRfc64PublicCatalogBootstrapConfigV1,
-  type DKGAgentConfig,
-  type SyncContextGraphPriorityConfig,
-  type SyncResponderSnapshotLimitsConfig,
-} from '@origintrail-official/dkg-agent';
+} from '@origintrail-official/dkg-agent/dist/rfc64/public-catalog-activation-config-v1.js';
 import {
   blueGreenSlotEntryPoint,
   blueGreenSlotReady,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -128,6 +128,7 @@ import {
   type LocalAgentIntegrationTransport,
   resolveContextGraphs,
   resolveNetworkDefaultContextGraphs,
+  resolveRfc64PublicCatalogActivation,
   resolveSharedMemoryTtlMs,
   resolveStorageAckTiming,
   repoDir,
@@ -1303,10 +1304,12 @@ export async function runDaemonInner(
     for (const message of genesisValidation.messages) log(message);
     process.exit(1);
   }
+  const rfc64PublicCatalog = resolveRfc64PublicCatalogActivation(config);
   const syncContextGraphs = [
     ...new Set([
       ...resolveContextGraphs(config),
       ...resolveNetworkDefaultContextGraphs(network),
+      ...rfc64PublicCatalog.selectedContextGraphs,
     ]),
   ];
 
@@ -1743,6 +1746,9 @@ export async function runDaemonInner(
     ...pickNetworkTunables(config.network ?? {}),
     agentProfileHeartbeatMs: config.network?.agentProfileHeartbeatMs,
     syncContextGraphs: syncContextGraphs,
+    rfc64CatalogDeploymentProfile: rfc64PublicCatalog.deploymentProfile,
+    rfc64PublicCatalogAutoPublish: rfc64PublicCatalog.autoPublish,
+    rfc64PublicCatalogBootstrap: rfc64PublicCatalog.bootstrap,
     maxRehydratedContextGraphSubscriptions: config.maxRehydratedContextGraphSubscriptions,
     // OT-RFC-38 LU-6 / OT-RFC-49 WS-A — plumb the host-mode block (eviction
     // tiers, discovery rate limits, and the `stripCiphertext` private-ciphertext

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1753,7 +1753,14 @@ export async function runDaemonInner(
     ...pickNetworkTunables(config.network ?? {}),
     agentProfileHeartbeatMs: config.network?.agentProfileHeartbeatMs,
     syncContextGraphs: syncContextGraphs,
-    rfc64PublicCatalogActivation: rfc64PublicCatalog,
+    // The agent owns authoritative activation against the chain adapter it
+    // actually constructed. This daemon-side resolved value is only a
+    // fail-fast/status preview and must not become a second runtime contract.
+    rfc64PublicCatalogActivation: config.rfc64PublicCatalog === undefined
+      ? undefined
+      : rfc64PublicCatalog.enabled
+        ? config.rfc64PublicCatalog
+        : { enabled: false },
     maxRehydratedContextGraphSubscriptions: config.maxRehydratedContextGraphSubscriptions,
     // OT-RFC-38 LU-6 / OT-RFC-49 WS-A — plumb the host-mode block (eviction
     // tiers, discovery rate limits, and the `stripCiphertext` private-ciphertext

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -3659,6 +3659,7 @@ export async function runDaemonInner(
         publisherControl,
         publisherState,
         config,
+        rfc64PublicCatalog,
         startedAt,
         dashDb,
         opWallets,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1304,7 +1304,13 @@ export async function runDaemonInner(
     for (const message of genesisValidation.messages) log(message);
     process.exit(1);
   }
-  const rfc64PublicCatalog = resolveRfc64PublicCatalogActivation(config);
+  // Resolve the effective chain before activating RFC-64 so a stale/cross-
+  // network manifest fails before subscriptions, stores, wallets, or agent
+  // runtime construction begin. The same immutable chainBase is reused below.
+  const chainBase = resolveChainConfig(config, network);
+  const rfc64PublicCatalog = resolveRfc64PublicCatalogActivation(config, {
+    chainId: chainBase?.chainId,
+  });
   const syncContextGraphs = [
     ...new Set([
       ...resolveContextGraphs(config),
@@ -1526,7 +1532,6 @@ export async function runDaemonInner(
   // Field-level merge of CLI config + network/<env>.json#chain.
   // Operators can override individual fields (e.g. just rpcUrl) without
   // restating the rest; missing fields fall back to the network defaults.
-  const chainBase = resolveChainConfig(config, network);
   const runtimeEvmChainConfig = projectRuntimeEvmChainConfig(chainBase);
 
   // PR3 / RC11 — operator-visible WARN when the node is going to talk

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -129,6 +129,7 @@ import {
   resolveContextGraphs,
   resolveNetworkDefaultContextGraphs,
   resolveRfc64PublicCatalogActivation,
+  resolveRfc64PublicCatalogActivationChainIdentityV1,
   resolveSharedMemoryTtlMs,
   resolveStorageAckTiming,
   repoDir,
@@ -1308,9 +1309,10 @@ export async function runDaemonInner(
   // network manifest fails before subscriptions, stores, wallets, or agent
   // runtime construction begin. The same immutable chainBase is reused below.
   const chainBase = resolveChainConfig(config, network);
-  const rfc64PublicCatalog = resolveRfc64PublicCatalogActivation(config, {
-    chainId: chainBase?.chainId,
-  });
+  const rfc64PublicCatalog = resolveRfc64PublicCatalogActivation(
+    config,
+    resolveRfc64PublicCatalogActivationChainIdentityV1(chainBase?.chainId),
+  );
   const syncContextGraphs = [
     ...new Set([
       ...resolveContextGraphs(config),
@@ -1751,9 +1753,7 @@ export async function runDaemonInner(
     ...pickNetworkTunables(config.network ?? {}),
     agentProfileHeartbeatMs: config.network?.agentProfileHeartbeatMs,
     syncContextGraphs: syncContextGraphs,
-    rfc64CatalogDeploymentProfile: rfc64PublicCatalog.deploymentProfile,
-    rfc64PublicCatalogAutoPublish: rfc64PublicCatalog.autoPublish,
-    rfc64PublicCatalogBootstrap: rfc64PublicCatalog.bootstrap,
+    rfc64PublicCatalogActivation: rfc64PublicCatalog,
     maxRehydratedContextGraphSubscriptions: config.maxRehydratedContextGraphSubscriptions,
     // OT-RFC-38 LU-6 / OT-RFC-49 WS-A — plumb the host-mode block (eviction
     // tiers, discovery rate limits, and the `stripCiphertext` private-ciphertext

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -15,7 +15,11 @@ import type {
   DashboardDB,
   OperationTracker,
 } from '@origintrail-official/dkg-node-ui';
-import type { DkgConfig, loadNetworkConfig } from '../../config.js';
+import type {
+  DkgConfig,
+  ResolvedRfc64PublicCatalogActivationConfig,
+  loadNetworkConfig,
+} from '../../config.js';
 import type { VmPublisherControl } from '@origintrail-official/dkg-publisher';
 import type { PublisherState } from '../../publisher-runner.js';
 import type { ExtractionStatusRecord } from '../../extraction-status.js';
@@ -63,6 +67,8 @@ export interface RequestContext {
   /** Lifecycle-owned runtime and readiness as one correlated state. */
   publisherState: PublisherState;
   config: DkgConfig;
+  /** Immutable RFC-64 activation resolved once during daemon startup. */
+  rfc64PublicCatalog: ResolvedRfc64PublicCatalogActivationConfig;
   startedAt: number;
   dashDb: DashboardDB;
   opWallets: OpWalletsConfig;

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -94,6 +94,7 @@ import {
   type LocalAgentIntegrationTransport,
   resolveContextGraphs,
   resolveNetworkDefaultContextGraphs,
+  resolveRfc64PublicCatalogActivation,
   resolveNetworkConfigName,
   resolveSharedMemoryTtlMs,
   repoDir,
@@ -689,6 +690,15 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     // sentinels when build-info.json is absent (monorepo / dev),
     // so consumers can branch reliably.
     const buildInfo = loadBuildInfo();
+    const rfc64PublicCatalogActivation = resolveRfc64PublicCatalogActivation(config);
+    const rfc64PublicCatalogService =
+      typeof agent.rfc64PublicCatalogStatsV1 === 'function'
+        ? agent.rfc64PublicCatalogStatsV1()
+        : null;
+    const rfc64PublicCatalogBootstrap =
+      typeof agent.readRfc64PublicCatalogBootstrapStatusV1 === 'function'
+        ? agent.readRfc64PublicCatalogBootstrapStatusV1()
+        : null;
     const unavailableFinalizationRecovery = (reason: string) => ({
       available: false,
       closed: false,
@@ -789,6 +799,13 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       hasIdentity: identityId > 0n,
       asyncPublisher: publisherState.availability,
       finalizationRecovery,
+      rfc64PublicCatalog: {
+        enabled: rfc64PublicCatalogActivation.enabled,
+        selectedContextGraphs: rfc64PublicCatalogActivation.selectedContextGraphs,
+        autoPublishEnabled: rfc64PublicCatalogActivation.autoPublish !== undefined,
+        service: rfc64PublicCatalogService,
+        bootstrap: rfc64PublicCatalogBootstrap,
+      },
       hasOpenClawChannel: hasConfiguredLocalAgentChat(config, 'openclaw'),
       localAgentIntegrations,
       connectedLocalAgentIds: localAgentIntegrations.filter((integration) => integration.enabled).map((integration) => integration.id),

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -690,12 +690,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     // so consumers can branch reliably.
     const buildInfo = loadBuildInfo();
     // Runtime projection only: lifecycle owns the single canonical activation
-    // snapshot. Hand-built legacy test/plugin contexts without the new field
-    // remain observably fail-closed rather than reparsing mutable config here.
-    const rfc64PublicCatalogActivation = ctx.rfc64PublicCatalog ?? {
-      enabled: false,
-      selectedContextGraphs: [],
-    };
+    // snapshot. A missing field is broken request-context wiring, not a disabled
+    // feature, so keep the RequestContext contract strict here.
+    const rfc64PublicCatalogActivation = ctx.rfc64PublicCatalog;
     const rfc64PublicCatalogService =
       typeof agent.rfc64PublicCatalogStatsV1 === 'function'
         ? agent.rfc64PublicCatalogStatsV1()

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -694,11 +694,13 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     // feature, so keep the RequestContext contract strict here.
     const rfc64PublicCatalogActivation = ctx.rfc64PublicCatalog;
     const rfc64PublicCatalogService =
-      typeof agent.rfc64PublicCatalogStatsV1 === 'function'
+      rfc64PublicCatalogActivation.enabled
+      && typeof agent.rfc64PublicCatalogStatsV1 === 'function'
         ? agent.rfc64PublicCatalogStatsV1()
         : null;
     const rfc64PublicCatalogBootstrap =
-      typeof agent.readRfc64PublicCatalogBootstrapStatusV1 === 'function'
+      rfc64PublicCatalogActivation.enabled
+      && typeof agent.readRfc64PublicCatalogBootstrapStatusV1 === 'function'
         ? agent.readRfc64PublicCatalogBootstrapStatusV1()
         : null;
     const unavailableFinalizationRecovery = (reason: string) => ({

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -94,7 +94,6 @@ import {
   type LocalAgentIntegrationTransport,
   resolveContextGraphs,
   resolveNetworkDefaultContextGraphs,
-  resolveRfc64PublicCatalogActivation,
   resolveNetworkConfigName,
   resolveSharedMemoryTtlMs,
   repoDir,
@@ -690,7 +689,13 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     // sentinels when build-info.json is absent (monorepo / dev),
     // so consumers can branch reliably.
     const buildInfo = loadBuildInfo();
-    const rfc64PublicCatalogActivation = resolveRfc64PublicCatalogActivation(config);
+    // Runtime projection only: lifecycle owns the single canonical activation
+    // snapshot. Hand-built legacy test/plugin contexts without the new field
+    // remain observably fail-closed rather than reparsing mutable config here.
+    const rfc64PublicCatalogActivation = ctx.rfc64PublicCatalog ?? {
+      enabled: false,
+      selectedContextGraphs: [],
+    };
     const rfc64PublicCatalogService =
       typeof agent.rfc64PublicCatalogStatsV1 === 'function'
         ? agent.rfc64PublicCatalogStatsV1()

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -36,12 +36,13 @@ import {
   resolveChainConfig,
   resolveReadyChainConfig,
   resolveRfc64PublicCatalogActivation,
+  resolveRfc64PublicCatalogActivationChainIdentityV1,
   resolveStorageAckTiming,
 } from '../src/config.js';
 import { rfc64PublicCatalogPolicy as policy } from './helpers/rfc64-public-catalog.js';
 
 describe('resolveRfc64PublicCatalogActivation', () => {
-  const chainIdentity = { chainId: 'otp:20430' };
+  const chainIdentity = resolveRfc64PublicCatalogActivationChainIdentityV1('otp:20430');
 
   it('is fail-closed when omitted or explicitly disabled', () => {
     expect(resolveRfc64PublicCatalogActivation({}, chainIdentity)).toEqual({
@@ -75,7 +76,6 @@ describe('resolveRfc64PublicCatalogActivation', () => {
       enabled: true,
       selectedContextGraphs: ['selected-a', 'selected-b'],
       autoPublish: {
-        contextGraphIds: ['selected-a', 'selected-b'],
         peers: ['12D3KooReceiver'],
       },
     });
@@ -125,6 +125,21 @@ describe('resolveRfc64PublicCatalogActivation', () => {
     }, chainIdentity)).toThrow(/policies must be unique by graph/u);
   });
 
+  it('rejects unknown root activation fields instead of silently changing mode', () => {
+    expect(() => resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: true,
+        autoPublsih: {
+          peers: ['12D3KooReceiver'],
+          catalogIssuerDelegationExpiresAt: '1893456000000',
+        },
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-a')],
+        },
+      } as any,
+    }, chainIdentity)).toThrow(/unknown fields/u);
+  });
+
   it('rejects manifests and deployment overrides for another network', () => {
     const activation = {
       rfc64PublicCatalog: {
@@ -136,12 +151,20 @@ describe('resolveRfc64PublicCatalogActivation', () => {
     };
     expect(() => resolveRfc64PublicCatalogActivation(
       activation,
-      { chainId: undefined },
-    )).toThrow(/requires an effective chain id/u);
+      resolveRfc64PublicCatalogActivationChainIdentityV1(undefined),
+    )).toThrow(/requires an effective network id/u);
     expect(() => resolveRfc64PublicCatalogActivation(
       activation,
-      { chainId: 'none' },
-    )).toThrow(/namespaced numeric EVM chain id/u);
+      resolveRfc64PublicCatalogActivationChainIdentityV1('none'),
+    )).toThrow(/requires a numeric EVM chain id/u);
+
+    expect(() => resolveRfc64PublicCatalogActivation(
+      activation,
+      {
+        networkId: chainIdentity.networkId,
+        evmChainId: '20431' as typeof chainIdentity.evmChainId,
+      },
+    )).toThrow(/network and EVM chain ids differ/u);
 
     expect(() => resolveRfc64PublicCatalogActivation({
       rfc64PublicCatalog: {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -41,14 +41,16 @@ import {
 import { rfc64PublicCatalogPolicy as policy } from './helpers/rfc64-public-catalog.js';
 
 describe('resolveRfc64PublicCatalogActivation', () => {
+  const chainIdentity = { chainId: 'otp:20430' };
+
   it('is fail-closed when omitted or explicitly disabled', () => {
-    expect(resolveRfc64PublicCatalogActivation({})).toEqual({
+    expect(resolveRfc64PublicCatalogActivation({}, chainIdentity)).toEqual({
       enabled: false,
       selectedContextGraphs: [],
     });
     expect(resolveRfc64PublicCatalogActivation({
       rfc64PublicCatalog: { enabled: false },
-    })).toEqual({
+    }, chainIdentity)).toEqual({
       enabled: false,
       selectedContextGraphs: [],
     });
@@ -67,7 +69,7 @@ describe('resolveRfc64PublicCatalogActivation', () => {
           retryIntervalMs: 30_000,
         },
       } as any,
-    });
+    }, chainIdentity);
 
     expect(resolved).toMatchObject({
       enabled: true,
@@ -87,7 +89,7 @@ describe('resolveRfc64PublicCatalogActivation', () => {
           acceptedPublicPolicies: [policy('selected-receiver')],
         },
       },
-    });
+    }, chainIdentity);
 
     expect(resolved).toMatchObject({
       enabled: true,
@@ -101,7 +103,7 @@ describe('resolveRfc64PublicCatalogActivation', () => {
   it('rejects activation without a selected policy and rejects a second allowlist', () => {
     expect(() => resolveRfc64PublicCatalogActivation({
       rfc64PublicCatalog: { enabled: true },
-    })).toThrow(/non-empty bootstrap/u);
+    }, chainIdentity)).toThrow(/non-empty bootstrap/u);
     expect(() => resolveRfc64PublicCatalogActivation({
       rfc64PublicCatalog: {
         enabled: true,
@@ -112,7 +114,7 @@ describe('resolveRfc64PublicCatalogActivation', () => {
         },
         bootstrap: { acceptedPublicPolicies: [policy('selected-a')] },
       } as any,
-    })).toThrow(/derived from the bootstrap manifest/u);
+    }, chainIdentity)).toThrow(/derived from the bootstrap manifest/u);
     expect(() => resolveRfc64PublicCatalogActivation({
       rfc64PublicCatalog: {
         enabled: true,
@@ -120,7 +122,63 @@ describe('resolveRfc64PublicCatalogActivation', () => {
           acceptedPublicPolicies: [policy('selected-a'), policy('selected-a')],
         },
       } as any,
-    })).toThrow(/policies must be unique by graph/u);
+    }, chainIdentity)).toThrow(/policies must be unique by graph/u);
+  });
+
+  it('rejects manifests and deployment overrides for another network', () => {
+    const activation = {
+      rfc64PublicCatalog: {
+        enabled: true,
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-a')],
+        },
+      },
+    };
+    expect(() => resolveRfc64PublicCatalogActivation(
+      activation,
+      { chainId: undefined },
+    )).toThrow(/requires an effective chain id/u);
+    expect(() => resolveRfc64PublicCatalogActivation(
+      activation,
+      { chainId: 'none' },
+    )).toThrow(/namespaced numeric EVM chain id/u);
+
+    expect(() => resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: true,
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-a', 'base:84532')],
+        },
+      },
+    }, chainIdentity)).toThrow(/policy network differs/u);
+
+    expect(() => resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: true,
+        deploymentProfile: {
+          networkId: 'base:84532',
+          assertedAtChainId: '84532',
+          assertedAtKav10Address: `0x${'22'.repeat(20)}`,
+        },
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-a')],
+        },
+      },
+    }, chainIdentity)).toThrow(/deployment network differs/u);
+
+    expect(() => resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: true,
+        deploymentProfile: {
+          networkId: 'otp:20430',
+          assertedAtChainId: '20431',
+          assertedAtKav10Address: `0x${'22'.repeat(20)}`,
+        },
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-a')],
+        },
+      },
+    }, chainIdentity)).toThrow(/deployment EVM chain id differs/u);
   });
 });
 

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -35,8 +35,79 @@ import {
   resolveApprovalPolicy,
   resolveChainConfig,
   resolveReadyChainConfig,
+  resolveRfc64PublicCatalogActivation,
   resolveStorageAckTiming,
 } from '../src/config.js';
+
+describe('resolveRfc64PublicCatalogActivation', () => {
+  const policy = (contextGraphId: string) => ({
+    policyEnvelope: { payload: { contextGraphId } },
+    targets: [],
+  });
+
+  it('is fail-closed when omitted or explicitly disabled', () => {
+    expect(resolveRfc64PublicCatalogActivation({})).toEqual({
+      enabled: false,
+      selectedContextGraphs: [],
+    });
+    expect(resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: { enabled: false },
+    })).toEqual({
+      enabled: false,
+      selectedContextGraphs: [],
+    });
+  });
+
+  it('derives the exact durable and auto-publish allowlist from the pinned manifest', () => {
+    const resolved = resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: true,
+        autoPublish: {
+          peers: ['12D3KooReceiver'],
+          catalogIssuerDelegationExpiresAt: '1893456000000',
+        },
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-a'), policy('selected-b')],
+          retryIntervalMs: 30_000,
+        },
+      } as any,
+    });
+
+    expect(resolved).toMatchObject({
+      enabled: true,
+      selectedContextGraphs: ['selected-a', 'selected-b'],
+      autoPublish: {
+        contextGraphIds: ['selected-a', 'selected-b'],
+        peers: ['12D3KooReceiver'],
+      },
+    });
+  });
+
+  it('rejects activation without a selected policy and rejects a second allowlist', () => {
+    expect(() => resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: { enabled: true },
+    })).toThrow(/non-empty bootstrap/u);
+    expect(() => resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: true,
+        autoPublish: {
+          contextGraphIds: ['different-selection'],
+          peers: [],
+          catalogIssuerDelegationExpiresAt: '1893456000000',
+        },
+        bootstrap: { acceptedPublicPolicies: [policy('selected-a')] },
+      } as any,
+    })).toThrow(/derived from the bootstrap manifest/u);
+    expect(() => resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: true,
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-a'), policy('selected-a')],
+        },
+      } as any,
+    })).toThrow(/selected context graphs must be unique/u);
+  });
+});
 
 describe('classifyMonorepoInit (dkg init monorepo home guard — issue #960)', () => {
   const npmHome = '/home/u/.dkg';

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -55,6 +55,26 @@ describe('resolveRfc64PublicCatalogActivation', () => {
       enabled: false,
       selectedContextGraphs: [],
     });
+    expect(resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: false,
+        deploymentProfile: {
+          networkId: 'otp:20430',
+          assertedAtChainId: '20430',
+          assertedAtKav10Address: `0x${'22'.repeat(20)}`,
+        },
+        autoPublish: {
+          peers: ['12D3KooIgnored'],
+          catalogIssuerDelegationExpiresAt: '1893456000000',
+        },
+        bootstrap: {
+          acceptedPublicPolicies: [policy('ignored-disabled-selection')],
+        },
+      },
+    }, chainIdentity)).toEqual({
+      enabled: false,
+      selectedContextGraphs: [],
+    });
   });
 
   it('derives the exact durable and auto-publish allowlist from the pinned manifest', () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -38,13 +38,9 @@ import {
   resolveRfc64PublicCatalogActivation,
   resolveStorageAckTiming,
 } from '../src/config.js';
+import { rfc64PublicCatalogPolicy as policy } from './helpers/rfc64-public-catalog.js';
 
 describe('resolveRfc64PublicCatalogActivation', () => {
-  const policy = (contextGraphId: string) => ({
-    policyEnvelope: { payload: { contextGraphId } },
-    targets: [],
-  });
-
   it('is fail-closed when omitted or explicitly disabled', () => {
     expect(resolveRfc64PublicCatalogActivation({})).toEqual({
       enabled: false,
@@ -83,6 +79,25 @@ describe('resolveRfc64PublicCatalogActivation', () => {
     });
   });
 
+  it('keeps receiver-only activation selected while leaving auto-publish absent', () => {
+    const resolved = resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: true,
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-receiver')],
+        },
+      },
+    });
+
+    expect(resolved).toMatchObject({
+      enabled: true,
+      selectedContextGraphs: ['selected-receiver'],
+      autoPublish: undefined,
+    });
+    expect(resolved.bootstrap?.acceptedPublicPolicies[0]?.policyEnvelope.payload.contextGraphId)
+      .toBe('selected-receiver');
+  });
+
   it('rejects activation without a selected policy and rejects a second allowlist', () => {
     expect(() => resolveRfc64PublicCatalogActivation({
       rfc64PublicCatalog: { enabled: true },
@@ -105,7 +120,7 @@ describe('resolveRfc64PublicCatalogActivation', () => {
           acceptedPublicPolicies: [policy('selected-a'), policy('selected-a')],
         },
       } as any,
-    })).toThrow(/selected context graphs must be unique/u);
+    })).toThrow(/policies must be unique by graph/u);
   });
 });
 

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -239,14 +239,20 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       'rfc64-selected-a',
       'rfc64-selected-b',
     ]);
-    expect(createArg.rfc64CatalogDeploymentProfile).toEqual(deploymentProfile);
-    expect(createArg.rfc64PublicCatalogAutoPublish).toEqual({
-      contextGraphIds: ['rfc64-selected-a', 'rfc64-selected-b'],
-      peers: ['12D3KooReceiver'],
-      catalogIssuerDelegationEffectiveAt: '0',
-      catalogIssuerDelegationExpiresAt: '1893456000000',
+    expect(createArg.rfc64PublicCatalogActivation).toMatchObject({
+      enabled: true,
+      selectedContextGraphs: ['rfc64-selected-a', 'rfc64-selected-b'],
+      deploymentProfile,
+      autoPublish: {
+        peers: ['12D3KooReceiver'],
+        catalogIssuerDelegationEffectiveAt: '0',
+        catalogIssuerDelegationExpiresAt: '1893456000000',
+      },
+      bootstrap,
     });
-    expect(createArg.rfc64PublicCatalogBootstrap).toEqual(bootstrap);
+    expect(createArg.rfc64CatalogDeploymentProfile).toBeUndefined();
+    expect(createArg.rfc64PublicCatalogAutoPublish).toBeUndefined();
+    expect(createArg.rfc64PublicCatalogBootstrap).toBeUndefined();
   });
 
   it('keeps receiver-only RFC-64 bootstrap active without enabling auto-publish', async () => {
@@ -262,9 +268,9 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     });
 
     expect(createArg.syncContextGraphs).toContain('rfc64-receiver-only');
-    expect(createArg.rfc64PublicCatalogAutoPublish).toBeUndefined();
+    expect(createArg.rfc64PublicCatalogActivation.autoPublish).toBeUndefined();
     expect(
-      createArg.rfc64PublicCatalogBootstrap.acceptedPublicPolicies[0]
+      createArg.rfc64PublicCatalogActivation.bootstrap.acceptedPublicPolicies[0]
         .policyEnvelope.payload.contextGraphId,
     ).toBe('rfc64-receiver-only');
   });
@@ -292,6 +298,10 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     } as any, Date.now())).rejects.toThrow(/policy network differs/u);
 
     expect(mocks.agentCreate).not.toHaveBeenCalled();
+    expect(mocks.chainResetWipe).not.toHaveBeenCalled();
+    expect(mocks.loadOpWallets).not.toHaveBeenCalled();
+    expect(mocks.startPublisherRuntimeWithOutcome).not.toHaveBeenCalled();
+    expect(mocks.createServer).not.toHaveBeenCalled();
   });
 
   it('keeps RFC-64 activation fully absent from agent inputs when disabled', async () => {
@@ -299,6 +309,10 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       rfc64PublicCatalog: { enabled: false },
     });
 
+    expect(createArg.rfc64PublicCatalogActivation).toEqual({
+      enabled: false,
+      selectedContextGraphs: [],
+    });
     expect(createArg.rfc64CatalogDeploymentProfile).toBeUndefined();
     expect(createArg.rfc64PublicCatalogAutoPublish).toBeUndefined();
     expect(createArg.rfc64PublicCatalogBootstrap).toBeUndefined();

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -210,14 +210,14 @@ describe('runDaemonInner StorageACK timing wiring', () => {
 
   it('activates only manifest-selected RFC-64 public CGs and forwards the exact controls', async () => {
     const deploymentProfile = {
-      networkId: 'otp:20430',
-      assertedAtChainId: '20430',
+      networkId: 'evm:100',
+      assertedAtChainId: '100',
       assertedAtKav10Address: `0x${'11'.repeat(20)}`,
     };
     const bootstrap = {
       acceptedPublicPolicies: [
-        rfc64PublicCatalogPolicy('rfc64-selected-a'),
-        rfc64PublicCatalogPolicy('rfc64-selected-b'),
+        rfc64PublicCatalogPolicy('rfc64-selected-a', 'evm:100'),
+        rfc64PublicCatalogPolicy('rfc64-selected-b', 'evm:100'),
       ],
       retryIntervalMs: 30_000,
     };
@@ -254,7 +254,9 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       rfc64PublicCatalog: {
         enabled: true,
         bootstrap: {
-          acceptedPublicPolicies: [rfc64PublicCatalogPolicy('rfc64-receiver-only')],
+          acceptedPublicPolicies: [
+            rfc64PublicCatalogPolicy('rfc64-receiver-only', 'evm:100'),
+          ],
         },
       },
     });
@@ -265,6 +267,31 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       createArg.rfc64PublicCatalogBootstrap.acceptedPublicPolicies[0]
         .policyEnvelope.payload.contextGraphId,
     ).toBe('rfc64-receiver-only');
+  });
+
+  it('rejects a cross-network RFC-64 manifest before DKGAgent.create', async () => {
+    await expect(runDaemonInner(true, {
+      name: 'storage-ack-timing-core-test',
+      networkConfig: 'mainnet-gnosis',
+      listenPort: 0,
+      nodeRole: 'core',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
+      rfc64PublicCatalog: {
+        enabled: true,
+        bootstrap: {
+          acceptedPublicPolicies: [
+            rfc64PublicCatalogPolicy('rfc64-wrong-network', 'base:84532'),
+          ],
+        },
+      },
+    } as any, Date.now())).rejects.toThrow(/policy network differs/u);
+
+    expect(mocks.agentCreate).not.toHaveBeenCalled();
   });
 
   it('keeps RFC-64 activation fully absent from agent inputs when disabled', async () => {

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -207,6 +207,56 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     ]);
   });
 
+  it('activates only manifest-selected RFC-64 public CGs and forwards the exact controls', async () => {
+    const deploymentProfile = {
+      networkId: 'test-network',
+      assertedAtChainId: '20430',
+      assertedAtKav10Address: `0x${'11'.repeat(20)}`,
+    };
+    const bootstrap = {
+      acceptedPublicPolicies: [
+        { policyEnvelope: { payload: { contextGraphId: 'rfc64-selected-a' } }, targets: [] },
+        { policyEnvelope: { payload: { contextGraphId: 'rfc64-selected-b' } }, targets: [] },
+      ],
+      retryIntervalMs: 30_000,
+    };
+    const createArg = await captureCreateArg({
+      contextGraphs: ['ordinary-selection'],
+      rfc64PublicCatalog: {
+        enabled: true,
+        deploymentProfile,
+        autoPublish: {
+          peers: ['12D3KooReceiver'],
+          catalogIssuerDelegationExpiresAt: '1893456000000',
+        },
+        bootstrap,
+      },
+    });
+
+    expect(createArg.syncContextGraphs).toEqual([
+      'ordinary-selection',
+      'rfc64-selected-a',
+      'rfc64-selected-b',
+    ]);
+    expect(createArg.rfc64CatalogDeploymentProfile).toBe(deploymentProfile);
+    expect(createArg.rfc64PublicCatalogAutoPublish).toEqual({
+      contextGraphIds: ['rfc64-selected-a', 'rfc64-selected-b'],
+      peers: ['12D3KooReceiver'],
+      catalogIssuerDelegationExpiresAt: '1893456000000',
+    });
+    expect(createArg.rfc64PublicCatalogBootstrap).toBe(bootstrap);
+  });
+
+  it('keeps RFC-64 activation fully absent from agent inputs when disabled', async () => {
+    const createArg = await captureCreateArg({
+      rfc64PublicCatalog: { enabled: false },
+    });
+
+    expect(createArg.rfc64CatalogDeploymentProfile).toBeUndefined();
+    expect(createArg.rfc64PublicCatalogAutoPublish).toBeUndefined();
+    expect(createArg.rfc64PublicCatalogBootstrap).toBeUndefined();
+  });
+
   it('passes configured StorageACK timing into DKGAgent.create', async () => {
     const createArg = await captureCreateArg({
       storageAck: { handlerDeadlineMs: 55_000, sendTimeoutMs: 60_000 },

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { rfc64PublicCatalogPolicy } from './helpers/rfc64-public-catalog.js';
 
 const mocks = vi.hoisted(() => ({
   agentCreate: vi.fn(),
@@ -209,14 +210,14 @@ describe('runDaemonInner StorageACK timing wiring', () => {
 
   it('activates only manifest-selected RFC-64 public CGs and forwards the exact controls', async () => {
     const deploymentProfile = {
-      networkId: 'test-network',
+      networkId: 'otp:20430',
       assertedAtChainId: '20430',
       assertedAtKav10Address: `0x${'11'.repeat(20)}`,
     };
     const bootstrap = {
       acceptedPublicPolicies: [
-        { policyEnvelope: { payload: { contextGraphId: 'rfc64-selected-a' } }, targets: [] },
-        { policyEnvelope: { payload: { contextGraphId: 'rfc64-selected-b' } }, targets: [] },
+        rfc64PublicCatalogPolicy('rfc64-selected-a'),
+        rfc64PublicCatalogPolicy('rfc64-selected-b'),
       ],
       retryIntervalMs: 30_000,
     };
@@ -238,13 +239,32 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       'rfc64-selected-a',
       'rfc64-selected-b',
     ]);
-    expect(createArg.rfc64CatalogDeploymentProfile).toBe(deploymentProfile);
+    expect(createArg.rfc64CatalogDeploymentProfile).toEqual(deploymentProfile);
     expect(createArg.rfc64PublicCatalogAutoPublish).toEqual({
       contextGraphIds: ['rfc64-selected-a', 'rfc64-selected-b'],
       peers: ['12D3KooReceiver'],
+      catalogIssuerDelegationEffectiveAt: '0',
       catalogIssuerDelegationExpiresAt: '1893456000000',
     });
-    expect(createArg.rfc64PublicCatalogBootstrap).toBe(bootstrap);
+    expect(createArg.rfc64PublicCatalogBootstrap).toEqual(bootstrap);
+  });
+
+  it('keeps receiver-only RFC-64 bootstrap active without enabling auto-publish', async () => {
+    const createArg = await captureCreateArg({
+      rfc64PublicCatalog: {
+        enabled: true,
+        bootstrap: {
+          acceptedPublicPolicies: [rfc64PublicCatalogPolicy('rfc64-receiver-only')],
+        },
+      },
+    });
+
+    expect(createArg.syncContextGraphs).toContain('rfc64-receiver-only');
+    expect(createArg.rfc64PublicCatalogAutoPublish).toBeUndefined();
+    expect(
+      createArg.rfc64PublicCatalogBootstrap.acceptedPublicPolicies[0]
+        .policyEnvelope.payload.contextGraphId,
+    ).toBe('rfc64-receiver-only');
   });
 
   it('keeps RFC-64 activation fully absent from agent inputs when disabled', async () => {

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -241,11 +241,9 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     ]);
     expect(createArg.rfc64PublicCatalogActivation).toMatchObject({
       enabled: true,
-      selectedContextGraphs: ['rfc64-selected-a', 'rfc64-selected-b'],
       deploymentProfile,
       autoPublish: {
         peers: ['12D3KooReceiver'],
-        catalogIssuerDelegationEffectiveAt: '0',
         catalogIssuerDelegationExpiresAt: '1893456000000',
       },
       bootstrap,
@@ -309,11 +307,30 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       rfc64PublicCatalog: { enabled: false },
     });
 
-    expect(createArg.rfc64PublicCatalogActivation).toEqual({
-      enabled: false,
-      selectedContextGraphs: [],
-    });
+    expect(createArg.rfc64PublicCatalogActivation).toEqual({ enabled: false });
     expect(createArg.rfc64CatalogDeploymentProfile).toBeUndefined();
+    expect(createArg.rfc64PublicCatalogAutoPublish).toBeUndefined();
+    expect(createArg.rfc64PublicCatalogBootstrap).toBeUndefined();
+  });
+
+  it('strips stale controls from an explicitly disabled RFC-64 activation', async () => {
+    const createArg = await captureCreateArg({
+      rfc64PublicCatalog: {
+        enabled: false,
+        autoPublish: {
+          peers: ['12D3KooIgnored'],
+          catalogIssuerDelegationExpiresAt: '1893456000000',
+        },
+        bootstrap: {
+          acceptedPublicPolicies: [
+            rfc64PublicCatalogPolicy('rfc64-ignored-disabled', 'evm:100'),
+          ],
+        },
+      },
+    });
+
+    expect(createArg.syncContextGraphs).not.toContain('rfc64-ignored-disabled');
+    expect(createArg.rfc64PublicCatalogActivation).toEqual({ enabled: false });
     expect(createArg.rfc64PublicCatalogAutoPublish).toBeUndefined();
     expect(createArg.rfc64PublicCatalogBootstrap).toBeUndefined();
   });

--- a/packages/cli/test/helpers/rfc64-public-catalog.ts
+++ b/packages/cli/test/helpers/rfc64-public-catalog.ts
@@ -1,0 +1,25 @@
+import {
+  buildOpenOwnerContextGraphPolicyV1,
+  unsignedOpenContextGraphPolicyEnvelopeV1,
+} from '@origintrail-official/dkg-agent';
+import type {
+  ContextGraphIdV1,
+  EvmAddressV1,
+  NetworkIdV1,
+} from '@origintrail-official/dkg-core';
+
+const TEST_NETWORK_ID = 'otp:20430' as NetworkIdV1;
+const TEST_OWNER = `0x${'11'.repeat(20)}` as EvmAddressV1;
+
+/** Canonical public policy fixture accepted by the production RFC-64 snapshotter. */
+export function rfc64PublicCatalogPolicy(contextGraphId: string) {
+  const policy = buildOpenOwnerContextGraphPolicyV1({
+    networkId: TEST_NETWORK_ID,
+    contextGraphId: contextGraphId as ContextGraphIdV1,
+    ownerAddress: TEST_OWNER,
+  });
+  return {
+    policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+    targets: [],
+  };
+}

--- a/packages/cli/test/helpers/rfc64-public-catalog.ts
+++ b/packages/cli/test/helpers/rfc64-public-catalog.ts
@@ -12,9 +12,12 @@ const TEST_NETWORK_ID = 'otp:20430' as NetworkIdV1;
 const TEST_OWNER = `0x${'11'.repeat(20)}` as EvmAddressV1;
 
 /** Canonical public policy fixture accepted by the production RFC-64 snapshotter. */
-export function rfc64PublicCatalogPolicy(contextGraphId: string) {
+export function rfc64PublicCatalogPolicy(
+  contextGraphId: string,
+  networkId = TEST_NETWORK_ID as string,
+) {
   const policy = buildOpenOwnerContextGraphPolicyV1({
-    networkId: TEST_NETWORK_ID,
+    networkId: networkId as NetworkIdV1,
     contextGraphId: contextGraphId as ContextGraphIdV1,
     ownerAddress: TEST_OWNER,
   });

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -53,6 +53,10 @@ const DISABLED_PUBLISHER_STATE: RequestContext['publisherState'] = {
     operatorActionRequired: true,
   },
 };
+const DISABLED_RFC64_PUBLIC_CATALOG: RequestContext['rfc64PublicCatalog'] = {
+  enabled: false,
+  selectedContextGraphs: [],
+};
 
 async function requestStatusWithAgent(
   agentOverrides: Record<string, unknown>,
@@ -74,7 +78,10 @@ async function requestStatusWithAgent(
       url,
       network: null,
       config,
-      rfc64PublicCatalog: resolveRfc64PublicCatalogActivation(config as never),
+      rfc64PublicCatalog: resolveRfc64PublicCatalogActivation(
+        config as never,
+        { chainId: 'otp:20430' },
+      ),
       startedAt: Date.now(),
       agent: {
         peerId: 'peer-status-test',
@@ -341,6 +348,7 @@ describe('/api/status selected overlay details', () => {
           nodeRole: 'edge',
           chain: { type: 'mock' },
         },
+        rfc64PublicCatalog: DISABLED_RFC64_PUBLIC_CATALOG,
         startedAt: Date.now(),
         agent: {
           peerId: 'peer-status-test',
@@ -412,6 +420,7 @@ describe('/api/status selected overlay details', () => {
               chainId: 'evm:31337',
             },
           },
+          rfc64PublicCatalog: DISABLED_RFC64_PUBLIC_CATALOG,
           startedAt: Date.now(),
           agent: {
             peerId: 'peer-status-test',
@@ -472,6 +481,7 @@ describe('/api/status selected overlay details', () => {
           nodeRole: 'edge',
           chain: { type: 'evm', rpcUrl: 'http://127.0.0.1:9', hubAddress: `0x${'ab'.repeat(20)}`, chainId: 'evm:31337' },
         },
+        rfc64PublicCatalog: DISABLED_RFC64_PUBLIC_CATALOG,
         startedAt: Date.now(),
         agent: { ensureIdentity: async () => { throw err; } },
         nodeVersion: '0.0.0-test',

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -33,10 +33,14 @@ import {
 } from '@origintrail-official/dkg-chain';
 import { computeNetworkId } from '../../core/src/genesis.js';
 import { getSharedContext } from '../../chain/test/evm-test-context.js';
-import { loadNetworkConfig } from '../src/config.js';
+import {
+  loadNetworkConfig,
+  resolveRfc64PublicCatalogActivation,
+} from '../src/config.js';
 import { handleStatusRoutes } from '../src/daemon/routes/status.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
 import { startLiveDaemon, stopLiveDaemon, authHeaders, type LiveDaemon } from './helpers/live-daemon.js';
+import { rfc64PublicCatalogPolicy } from './helpers/rfc64-public-catalog.js';
 
 // A port nothing listens on — connecting to it is a REAL refused connection.
 const DEAD_RPC = 'http://127.0.0.1:9';
@@ -56,6 +60,12 @@ async function requestStatusWithAgent(
 ): Promise<{ status: number; body: any }> {
   const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const config = {
+      name: 'status-finalization-recovery-test',
+      nodeRole: 'edge',
+      chain: { type: 'mock' },
+      ...configOverrides,
+    };
     await handleStatusRoutes({
       req,
       res,
@@ -63,12 +73,8 @@ async function requestStatusWithAgent(
       path: url.pathname,
       url,
       network: null,
-      config: {
-        name: 'status-finalization-recovery-test',
-        nodeRole: 'edge',
-        chain: { type: 'mock' },
-        ...configOverrides,
-      },
+      config,
+      rfc64PublicCatalog: resolveRfc64PublicCatalogActivation(config as never),
       startedAt: Date.now(),
       agent: {
         peerId: 'peer-status-test',
@@ -267,10 +273,7 @@ describe('/api/status RFC-64 selected-public activation', () => {
             catalogIssuerDelegationExpiresAt: '1893456000000',
           },
           bootstrap: {
-            acceptedPublicPolicies: [{
-              policyEnvelope: { payload: { contextGraphId: 'selected-public-cg' } },
-              targets: [],
-            }],
+            acceptedPublicPolicies: [rfc64PublicCatalogPolicy('selected-public-cg')],
           },
         },
       },
@@ -282,6 +285,37 @@ describe('/api/status RFC-64 selected-public activation', () => {
       selectedContextGraphs: ['selected-public-cg'],
       autoPublishEnabled: true,
       service,
+      bootstrap,
+    });
+  });
+
+  it('reports receiver-only activation without claiming auto-publish is enabled', async () => {
+    const bootstrap = {
+      running: true,
+      pass: 1,
+      retryIntervalMs: 30_000,
+      targets: [],
+    };
+    const response = await requestStatusWithAgent(
+      {
+        rfc64PublicCatalogStatsV1: () => ({ started: true }),
+        readRfc64PublicCatalogBootstrapStatusV1: () => bootstrap,
+      },
+      {
+        rfc64PublicCatalog: {
+          enabled: true,
+          bootstrap: {
+            acceptedPublicPolicies: [rfc64PublicCatalogPolicy('receiver-only-cg')],
+          },
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.rfc64PublicCatalog).toMatchObject({
+      enabled: true,
+      selectedContextGraphs: ['receiver-only-cg'],
+      autoPublishEnabled: false,
       bootstrap,
     });
   });

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -36,6 +36,7 @@ import { getSharedContext } from '../../chain/test/evm-test-context.js';
 import {
   loadNetworkConfig,
   resolveRfc64PublicCatalogActivation,
+  resolveRfc64PublicCatalogActivationChainIdentityV1,
 } from '../src/config.js';
 import { handleStatusRoutes } from '../src/daemon/routes/status.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
@@ -80,7 +81,7 @@ async function requestStatusWithAgent(
       config,
       rfc64PublicCatalog: resolveRfc64PublicCatalogActivation(
         config as never,
-        { chainId: 'otp:20430' },
+        resolveRfc64PublicCatalogActivationChainIdentityV1('otp:20430'),
       ),
       startedAt: Date.now(),
       agent: {
@@ -238,7 +239,16 @@ describe('/api/status finalization recovery health', () => {
 
 describe('/api/status RFC-64 selected-public activation', () => {
   it('reports the fail-closed disabled state without invoking catalog controls', async () => {
-    const response = await requestStatusWithAgent({});
+    const catalogStats = vi.fn(() => {
+      throw new Error('disabled status must not read catalog service state');
+    });
+    const bootstrapStatus = vi.fn(() => {
+      throw new Error('disabled status must not read catalog bootstrap state');
+    });
+    const response = await requestStatusWithAgent({
+      rfc64PublicCatalogStatsV1: catalogStats,
+      readRfc64PublicCatalogBootstrapStatusV1: bootstrapStatus,
+    });
 
     expect(response.status).toBe(200);
     expect(response.body.rfc64PublicCatalog).toEqual({
@@ -248,6 +258,8 @@ describe('/api/status RFC-64 selected-public activation', () => {
       service: null,
       bootstrap: null,
     });
+    expect(catalogStats).not.toHaveBeenCalled();
+    expect(bootstrapStatus).not.toHaveBeenCalled();
   });
 
   it('exposes selected scopes and exact per-target applied-head evidence', async () => {

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -52,6 +52,7 @@ const DISABLED_PUBLISHER_STATE: RequestContext['publisherState'] = {
 
 async function requestStatusWithAgent(
   agentOverrides: Record<string, unknown>,
+  configOverrides: Record<string, unknown> = {},
 ): Promise<{ status: number; body: any }> {
   const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
@@ -66,6 +67,7 @@ async function requestStatusWithAgent(
         name: 'status-finalization-recovery-test',
         nodeRole: 'edge',
         chain: { type: 'mock' },
+        ...configOverrides,
       },
       startedAt: Date.now(),
       agent: {
@@ -217,6 +219,70 @@ describe('/api/status finalization recovery health', () => {
       stateCounts: {},
       livePayloadBytes: 0,
       dueEntries: 0,
+    });
+  });
+});
+
+describe('/api/status RFC-64 selected-public activation', () => {
+  it('reports the fail-closed disabled state without invoking catalog controls', async () => {
+    const response = await requestStatusWithAgent({});
+
+    expect(response.status).toBe(200);
+    expect(response.body.rfc64PublicCatalog).toEqual({
+      enabled: false,
+      selectedContextGraphs: [],
+      autoPublishEnabled: false,
+      service: null,
+      bootstrap: null,
+    });
+  });
+
+  it('exposes selected scopes and exact per-target applied-head evidence', async () => {
+    const service = {
+      started: true,
+      acceptedPolicies: 1,
+      receiver: { queued: 0, applied: 1, failed: 0 },
+    };
+    const bootstrap = {
+      running: false,
+      pass: 2,
+      retryIntervalMs: 30_000,
+      targets: [{
+        scope: { contextGraphId: 'selected-public-cg', authorAddress: `0x${'22'.repeat(20)}` },
+        outcome: 'applied',
+        appliedHeadDigest: `0x${'33'.repeat(32)}`,
+        inventoryRowCount: '50',
+      }],
+    };
+    const response = await requestStatusWithAgent(
+      {
+        rfc64PublicCatalogStatsV1: () => service,
+        readRfc64PublicCatalogBootstrapStatusV1: () => bootstrap,
+      },
+      {
+        rfc64PublicCatalog: {
+          enabled: true,
+          autoPublish: {
+            peers: ['12D3KooReceiver'],
+            catalogIssuerDelegationExpiresAt: '1893456000000',
+          },
+          bootstrap: {
+            acceptedPublicPolicies: [{
+              policyEnvelope: { payload: { contextGraphId: 'selected-public-cg' } },
+              targets: [],
+            }],
+          },
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.rfc64PublicCatalog).toEqual({
+      enabled: true,
+      selectedContextGraphs: ['selected-public-cg'],
+      autoPublishEnabled: true,
+      service,
+      bootstrap,
     });
   });
 });

--- a/packages/cli/test/status-route-store-quads.test.ts
+++ b/packages/cli/test/status-route-store-quads.test.ts
@@ -16,6 +16,10 @@ const DISABLED_PUBLISHER_STATE: RequestContext['publisherState'] = {
     operatorActionRequired: true,
   },
 };
+const DISABLED_RFC64_PUBLIC_CATALOG: RequestContext['rfc64PublicCatalog'] = {
+  enabled: false,
+  selectedContextGraphs: [],
+};
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -55,6 +59,7 @@ async function startStatusServer(query: () => Promise<unknown>): Promise<{
           options: { url: 'http://127.0.0.1:9/query' },
         },
       },
+      rfc64PublicCatalog: DISABLED_RFC64_PUBLIC_CATALOG,
       startedAt: Date.now(),
       agent: {
         peerId: 'peer-status-store-quads-test',


### PR DESCRIPTION
## User impact

This turns the RFC-64 public catalog data plane into an operable, deliberately
bounded feature. An operator can select specific public Context Graphs; only
those graphs become durable subscriptions, only those graphs can advance a
catalog after an ordinary confirmed KA publication, and receivers expose exact
per-author applied-head evidence through `/api/status`.

The default remains dormant. Omitting `rfc64PublicCatalog`, or setting
`enabled: false`, accepts no policies, starts no catalog bootstrap, and installs
no publication hook.

## Stack

- **Base PR:** #2011 (`codex/rfc64-m1-edge-selection`)
- **This PR:** selected-public activation and observability
- #2076 is intentionally independent. After it lands, this two-PR stack will be
  restacked on its exact `testnet-canary` head and validated as one candidate.

## Before

The catalog transport existed, but normal daemon configuration did not select
policies, producers, or receiver targets. Ordinary publishing and legacy sync
continued, while the RFC-64 catalog lane remained fail-closed and invisible to
operators.

```mermaid
sequenceDiagram
    participant Operator
    participant Daemon
    participant Publisher
    participant Chain
    participant Receiver
    Operator->>Daemon: "Start with normal config"
    Daemon->>Daemon: "RFC-64 transport starts without accepted policy"
    Publisher->>Chain: "Publish public KA"
    Chain-->>Publisher: "Confirmed"
    Publisher->>Publisher: "No RFC-64 auto-publish configuration"
    Receiver->>Receiver: "No pinned catalog target"
    Note over Daemon,Receiver: "Catalog code is present but dormant"
```

## After

One pinned finalized-policy manifest is the sole selection source. The daemon
uses its CG IDs for both durable subscription and the optional producer
allowlist; it rejects a second caller-supplied allowlist. A receiver retries the
explicit provider list, performs the existing policy/catalog/chain checks, and
reports the exact applied head.

```mermaid
sequenceDiagram
    participant Operator
    participant Daemon
    participant Publisher
    participant Chain
    participant Provider
    participant Receiver
    Operator->>Daemon: "Enable with pinned public-policy manifest"
    Daemon->>Daemon: "Validate manifest and derive exact CG allowlist"
    Daemon->>Receiver: "Durably subscribe only selected CGs"
    Publisher->>Chain: "Publish KA in selected public CG"
    Chain-->>Publisher: "Confirmed VM result"
    Publisher->>Provider: "Advance durable signed author-catalog head"
    Provider-->>Receiver: "Availability hint"
    Receiver->>Provider: "Fetch signed head, inventory, and KA bundle"
    Receiver->>Chain: "Verify finalized VM binding"
    Receiver->>Receiver: "Apply content and CAS applied-head pointer"
    Receiver-->>Operator: "Status: applied head, version, row count, provider"
```

## What changed

- adds explicit `rfc64PublicCatalog.enabled` activation to daemon config;
- derives the exact selected-CG set from
  `bootstrap.acceptedPublicPolicies[*].policyEnvelope.payload.contextGraphId`;
- unions only that selected set into durable graph synchronization;
- makes the normal-publication catalog hook enforce the same bounded allowlist;
- forwards the pinned policy/bootstrap and optional producer controls into the
  existing RFC-64 service;
- exposes selected graphs, service stats, bootstrap passes, provider outcome,
  applied-head digest, catalog version, inventory row count, and bounded error
  evidence at `GET /api/status`;
- documents operator configuration and the restart/failover completeness gate.

Catalog advancement happens only after chain confirmation and remains
fail-open relative to the already-confirmed KA: an RFC-64 catalog error is
logged and does not turn a successful mint into a false publication failure.

## Safety boundaries

- No `sync all public CGs` mode.
- Legacy direct `DKGAgent.create` auto-publish callers remain source-compatible;
  selected daemon activation uses one new versioned agent config object.
- Maximum 64 selected producer CGs, canonical and unique.
- Public policies only; the agent performs full canonical manifest validation
  before transport startup.
- This increment catalogs only public KAs that reached confirmed VM. Public
  SWM-only assets remain on the existing live/durable catch-up lane and are not
  an exact-set completeness claim here.
- CGs outside the manifest remain on the existing publication/sync path.
- Policy and explicit deployment network identity must match the daemon effective chain before runtime starts.
- Provider peer IDs and finalized policy envelopes remain pinned inputs.
- Automatic provider discovery, automatic chain-to-policy generation, private
  CG catalogs, and a network-wide Core scheduling policy are not claimed here.

## Validation

- `@origintrail-official/dkg-agent` build, strict type/package-root checks: pass
- `@origintrail-official/dkg` full dependency-chain build: pass
- affected package `tsc --noEmit`: pass
- RFC-64 production native wiring: **1 file / 30 tests passed**
- CLI config + daemon + status focused suites: **4 files / 143 tests passed**
- activation-focused CLI rerun: **5 passed, 120 unrelated skipped**
- real-daemon, real-Hardhat status suite: **1 file / 9 tests passed**
- `git diff --check`: pass

## Canary acceptance after restack

1. Boot exact candidate SHA with activation omitted and prove behavior remains
   dormant.
2. Enable one selected public CG on publisher and receiver.
3. Publish new KAs while receiver is live; require exact applied-head and VM
   content parity.
4. Cold-start a clean receiver; require the same head and inventory count
   without manual catch-up.
5. Restart the receiver and repeat the exact-head check.
6. Remove the primary provider and require bootstrap failover to the pinned
   backup provider.
7. Run the bounded testnet-canary soak only after all prior gates pass.
