### PR TITLE
fix(cli): mount the Blazegraph journal on a named volume, and never guess its name

### DIFF
--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -262,10 +262,45 @@ async function findFreePort(
   );
 }
 
+/**
+ * Journal location *inside* the container. The image pins
+ * `com.bigdata.journal.AbstractJournal.file=/data/bigdata.jnl` in
+ * `WEB-INF/classes/RWStore.properties`, so everything Blazegraph durably
+ * writes lives under this directory. Without a volume mounted here the
+ * journal is written into the container's writable layer and `docker rm`
+ * destroys it.
+ */
+export const BLAZEGRAPH_DATA_DIR = '/data';
+
+/**
+ * Named docker volume holding the journal.
+ *
+ * Deliberately NOT derived from the container name: the volume and the
+ * container are independent objects with independent lifetimes, and an
+ * already-provisioned host may carry either name. The authoritative source
+ * for an existing container is always its own `.Mounts` — see
+ * {@link ContainerInspectInfo.dataVolume}. This constant is only the name
+ * used when creating a store that does not have one yet.
+ */
+export const DEFAULT_BLAZEGRAPH_VOLUME = 'dkg-blazegraph-data';
+
 interface ContainerInspectInfo {
   exists: boolean;
   running: boolean;
   hostPort?: number;
+  /**
+   * Name of the named volume mounted at {@link BLAZEGRAPH_DATA_DIR}, when the
+   * container has one. This is the ONLY trustworthy way to learn where an
+   * existing container's journal lives.
+   */
+  dataVolume?: string;
+  /**
+   * True when something is mounted at {@link BLAZEGRAPH_DATA_DIR} that is not
+   * a named volume (e.g. an operator's bind mount). We must never silently
+   * recreate over one of these — we cannot reproduce the mount, so the
+   * replacement container would come up on an empty store.
+   */
+  foreignDataMount?: boolean;
 }
 
 async function inspectContainer(
@@ -294,7 +329,19 @@ async function inspectContainer(
     const hostPort = Array.isArray(portBinding) && portBinding.length > 0
       ? Number(portBinding[0].HostPort)
       : undefined;
-    return { exists: true, running, hostPort };
+    // Resolve the journal mount from the container itself. Never infer it
+    // from the container name — a host provisioned by an earlier tool may
+    // use any volume name, and guessing wrong means recreating onto an
+    // empty store while the real journal is orphaned.
+    const mounts = Array.isArray(info.Mounts) ? info.Mounts : [];
+    const dataMount = mounts.find(
+      (m: { Destination?: unknown }) => m?.Destination === BLAZEGRAPH_DATA_DIR,
+    );
+    const dataVolume = dataMount?.Type === 'volume' && typeof dataMount.Name === 'string'
+      ? dataMount.Name
+      : undefined;
+    const foreignDataMount = dataMount !== undefined && dataVolume === undefined;
+    return { exists: true, running, hostPort, dataVolume, foreignDataMount };
   } catch {
     return { exists: true, running: false };
   }
@@ -429,6 +476,11 @@ export async function provisionBlazegraphDocker(
     };
   }
 
+  // Journal volume used by any container created below. An existing container
+  // is authoritative about where its own journal lives; the default name is
+  // only for a store that does not have one yet.
+  const journalVolume = inspectInfo.dataVolume ?? DEFAULT_BLAZEGRAPH_VOLUME;
+
   // 3. Stopped-but-exists path — start it back up before re-creating.
   if (inspectInfo.exists && !inspectInfo.running) {
     log(`  Container "${containerName}" exists but is stopped; starting it.`);
@@ -436,7 +488,24 @@ export async function provisionBlazegraphDocker(
     if (startResult.exitCode !== 0) {
       // Fall through to recreate — `docker start` failed for some
       // reason (e.g. config drift); remove and start fresh.
-      log(`  docker start failed (${startResult.stderr.trim() || 'unknown'}); recreating.`);
+      //
+      // Fail closed when the journal mount cannot be reproduced. Recreating
+      // over a bind mount we cannot reconstruct brings the node up on an
+      // EMPTY store while the real journal survives unreferenced on disk —
+      // silent total data unavailability for that node. An operator fixing
+      // one stopped container by hand is strictly cheaper than that.
+      if (inspectInfo.foreignDataMount) {
+        throw new Error(
+          `Blazegraph container "${containerName}" failed to start and has a non-volume mount at ` +
+          `${BLAZEGRAPH_DATA_DIR}; refusing to recreate because the replacement would start on an empty ` +
+          `store and orphan the existing journal. Recover the container manually, then re-run. ` +
+          `docker start stderr: ${startResult.stderr.trim() || '(empty)'}`,
+        );
+      }
+      log(
+        `  docker start failed (${startResult.stderr.trim() || 'unknown'}); ` +
+        `recreating with journal volume "${journalVolume}".`,
+      );
       await docker.run(['rm', '-f', containerName]);
     } else {
       const port = (await inspectContainer(docker, containerName)).hostPort
@@ -473,6 +542,13 @@ export async function provisionBlazegraphDocker(
     // Blazegraph is an implementation detail of the local node. Do not publish
     // its unauthenticated SPARQL/update endpoint on every host interface.
     '-p', `127.0.0.1:${chosenPort}:${BLAZEGRAPH_CONTAINER_PORT}`,
+    // Keep the journal OUTSIDE the container's writable layer. Without this
+    // the store lives and dies with the container, so any recreate (including
+    // the `docker rm -f` recovery above) silently destroys the graph.
+    // `docker volume create` is implicit: `docker run -v <name>:<path>`
+    // creates the named volume when it does not already exist, and reuses it
+    // — with its contents — when it does.
+    '-v', `${journalVolume}:${BLAZEGRAPH_DATA_DIR}`,
     BLAZEGRAPH_IMAGE,
   ]);
   if (runResult.exitCode !== 0) {

--- a/packages/cli/test/blazegraph-docker.test.ts
+++ b/packages/cli/test/blazegraph-docker.test.ts
@@ -43,6 +43,8 @@ import {
   isDockerAvailable,
   BLAZEGRAPH_IMAGE,
   BLAZEGRAPH_CONTAINER_PORT,
+  BLAZEGRAPH_DATA_DIR,
+  DEFAULT_BLAZEGRAPH_VOLUME,
   BLAZEGRAPH_NAMESPACE_XML_TEMPLATE,
   type DockerRunner,
   type DockerCommandResult,
@@ -141,11 +143,12 @@ function dockerInspectRunning(hostPort = 9999): DockerCommandResult {
   };
 }
 
-function dockerInspectStopped(): DockerCommandResult {
+function dockerInspectStopped(mounts?: unknown[]): DockerCommandResult {
   return {
     stdout: JSON.stringify([
       {
         State: { Running: false },
+        ...(mounts ? { Mounts: mounts } : {}),
         NetworkSettings: {
           Ports: {
             [`${BLAZEGRAPH_CONTAINER_PORT}/tcp`]: [{ HostIp: '0.0.0.0', HostPort: '9999' }],
@@ -349,6 +352,100 @@ describe('provisionBlazegraphDocker', () => {
     expect(result.reused).toBe(false);
     expect(calls.some((c) => c[0] === 'rm')).toBe(true);
     expect(calls.some((c) => c[0] === 'run')).toBe(true);
+  });
+
+  it('mounts a named journal volume at /data on a fresh create', async () => {
+    // Without this the journal lives in the container's writable layer and
+    // `docker rm` destroys the entire graph.
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+      ],
+    });
+    const { fn } = mockFetch(() => new Response('ok', { status: 200 }));
+    await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    const runCall = calls.find((c) => c[0] === 'run');
+    expect(runCall).toBeDefined();
+    const vIdx = runCall!.indexOf('-v');
+    expect(vIdx).toBeGreaterThan(-1);
+    expect(runCall![vIdx + 1]).toBe(`${DEFAULT_BLAZEGRAPH_VOLUME}:${BLAZEGRAPH_DATA_DIR}`);
+    // The image must remain the final argument.
+    expect(runCall?.at(-1)).toBe(BLAZEGRAPH_IMAGE);
+  });
+
+  it('reuses the EXISTING journal volume when recreating, rather than a name derived from the container', async () => {
+    // Regression guard for the mainnet fleet: containers are named
+    // `dkg-blazegraph-dkg` but the journal volume is `dkg-blazegraph-data`.
+    // Deriving the volume from the container name yields
+    // `dkg-blazegraph-dkg-data`, which does not exist — docker would create it
+    // empty and the node would come up serving zero triples while the real
+    // 11-18 GB journal sat orphaned.
+    const FLEET_VOLUME = 'dkg-blazegraph-data';
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        {
+          when: (a) => a[0] === 'inspect',
+          respond: () => dockerInspectStopped([
+            { Type: 'volume', Name: FLEET_VOLUME, Destination: BLAZEGRAPH_DATA_DIR },
+          ]),
+        },
+        { when: (a) => a[0] === 'start', respond: () => ({ stdout: '', stderr: 'config drift', exitCode: 1 }) },
+        { when: (a) => a[0] === 'rm', respond: () => ({ stdout: '', stderr: '', exitCode: 0 }) },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'container-id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch(() => new Response('ok', { status: 200 }));
+    await provisionBlazegraphDocker({
+      namespace: 'dkg',
+      containerName: 'dkg-blazegraph-dkg',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    const runCall = calls.find((c) => c[0] === 'run');
+    expect(runCall).toBeDefined();
+    const vIdx = runCall!.indexOf('-v');
+    expect(runCall![vIdx + 1]).toBe(`${FLEET_VOLUME}:${BLAZEGRAPH_DATA_DIR}`);
+    // Explicitly NOT the container-name-derived form.
+    expect(runCall![vIdx + 1]).not.toContain('dkg-blazegraph-dkg-data');
+  });
+
+  it('refuses to recreate over a bind mount it cannot reproduce', async () => {
+    // A bind mount at /data cannot be reconstructed from `docker inspect`
+    // alone in a way we can trust, so recreating would silently start an
+    // empty store. Fail closed instead.
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        {
+          when: (a) => a[0] === 'inspect',
+          respond: () => dockerInspectStopped([
+            { Type: 'bind', Source: '/srv/blazegraph', Destination: BLAZEGRAPH_DATA_DIR },
+          ]),
+        },
+        { when: (a) => a[0] === 'start', respond: () => ({ stdout: '', stderr: 'config drift', exitCode: 1 }) },
+      ],
+    });
+    const { fn } = mockFetch(() => new Response('ok', { status: 200 }));
+    await expect(provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    })).rejects.toThrow(/refusing to recreate/i);
+    // Critically: it must not have removed the container.
+    expect(calls.some((c) => c[0] === 'rm')).toBe(false);
+    expect(calls.some((c) => c[0] === 'run')).toBe(false);
   });
 
   it('auto-bumps to the next free loopback port and uses the multi-architecture image', async () => {


### PR DESCRIPTION
## Summary

The daemon's Blazegraph container-recovery path can silently destroy a node's entire graph. This fixes it.

`provisionBlazegraphDocker` creates the container with `-d --restart --name -p <image>` and **no `-v`**
([`blazegraph-docker.ts` step 4](https://github.com/OriginTrail/dkg/blob/main/packages/cli/src/daemon/blazegraph-docker.ts)),
so the journal lives in the container's writable layer. The image pins
`com.bigdata.journal.AbstractJournal.file=/data/bigdata.jnl` in `WEB-INF/classes/RWStore.properties`, so everything
durable is under `/data`.

Step 3 of the same function issues `docker rm -f` whenever a stopped container fails to `docker start`, and then
falls through to that create path:

```ts
const startResult = await docker.run(['start', containerName]);
if (startResult.exitCode !== 0) {
  log(`  docker start failed (...); recreating.`);
  await docker.run(['rm', '-f', containerName]);   // journal gone
}
// ... step 4: docker run, no -v
```

The node comes back **serving zero triples**, with no error surfaced.

## Why this is not hypothetical

The V10 mainnet fleet runs with `store.options.managedByDkg = true` (verified on sbb and dmaast), so this code owns
those containers. The fleet's journals were migrated to a named volume out-of-band:

```
$ docker volume ls
DRIVER    VOLUME NAME
local     dkg-blazegraph-data

$ docker inspect dkg-blazegraph-dkg --format '{{range .Mounts}}{{.Name}}:{{.Destination}}{{end}}'
dkg-blazegraph-data:/data
```

So the data currently survives — but only by luck. The daemon doesn't know the volume exists and would recreate
without mounting it, orphaning 11–18 GB of graph per node behind an empty store.

## Changes

**1. Always mount a named volume at `/data` on create.** `docker run -v <name>:<path>` creates the volume on demand
and reuses it with its contents when it already exists, so this is correct for both fresh and already-provisioned
hosts.

**2. Resolve the volume from the container's own `.Mounts`, never from the container name.** This is the important
one. The fleet's containers are named `dkg-blazegraph-dkg` while the volume is `dkg-blazegraph-data` — so a
`` `${containerName}-data` `` derivation produces `dkg-blazegraph-dkg-data`, a volume that does not exist and which
docker would helpfully create **empty**. The container is the only authoritative source for where its own journal
lives.

> Note for #1817, which is unmerged and contains exactly that derivation
> (`blazegraphVolumeName(c) => \`${c}-data\``): it would misclassify every fleet node as needing migration and then
> recreate onto an empty volume. That PR should adopt the `.Mounts` resolution from this one before it lands.

**3. Fail closed instead of recreating over a mount we cannot reproduce.** If something non-volume (e.g. an operator
bind mount) is at `/data` and the container won't start, throw rather than `rm -f`. Recovering one stopped container
by hand is strictly cheaper than silently emptying a store.

## Testing

Three new tests in `packages/cli/test/blazegraph-docker.test.ts`:

- fresh create mounts `dkg-blazegraph-data:/data` and keeps the image as the final argument
- recreate reuses the **existing** volume, explicitly asserting it is *not* the container-name-derived form
- bind mount at `/data` → throws, and asserts **no `rm` and no `run` were issued**

`22 passed` in the file; `tsc --noEmit` clean.

**Mutation-verified:** reintroducing `` const journalVolume = `${containerName}-data` `` fails two of the three new
tests. The guards have teeth rather than merely passing.

## Risk

Low. Behaviour is unchanged for a running container (the reuse path is untouched). The only new failure mode is the
deliberate fail-closed throw, which replaces a silent data-availability loss with an actionable error.

Existing fleet containers already mount `dkg-blazegraph-data:/data`, so this change is a no-op for them until
something triggers a recreate — which is precisely the case it makes safe.
