### PR TITLE
fix(storage): bound Blazegraph queries server-side, and refuse truncated CONSTRUCT results

### DIFF
--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -36,6 +36,44 @@ import { readResponseTextBounded } from '../http-response-limit.js';
 
 export const DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS = 30_000;
 
+/**
+ * Blazegraph's per-request server-side query deadline. The deployed 2.1.x
+ * engine honours this header (`BigdataRDFContext$AbstractQueryTask` reads it
+ * via `getQueryTimeout`); `web.xml`'s `queryTimeout` context-param is the
+ * global equivalent and ships as `0` — unbounded.
+ */
+const MAX_QUERY_MILLIS_HEADER = 'X-BIGDATA-MAX-QUERY-MILLIS';
+
+/**
+ * Multiplier applied to the client deadline to derive the server-side bound.
+ *
+ * This is deliberately > 1: the server deadline must be WIDER than the
+ * client's, never tighter. Two reasons, and the second is a correctness trap:
+ *
+ * 1. The problem being solved is *abandoned* work. When the client aborts at
+ *    its deadline the HTTP connection goes away but Blazegraph keeps executing
+ *    the query — observed on mainnet running 10-32+ minutes past a 30s client
+ *    abort, with `queryErrorCount = 0` across 20,953 queries confirming the
+ *    server never cancelled anything. A handful of these saturate a core. Any
+ *    finite server bound fixes that; it does not need to be tight.
+ *
+ * 2. A tight bound introduces silent data loss. Blazegraph commits `200 OK`
+ *    and begins streaming before the deadline fires, then appends its error
+ *    into the already-committed body. A CONSTRUCT killed mid-stream therefore
+ *    returns a SHORT BUT STRUCTURALLY VALID n-quads document. Since the client
+ *    is still reading at that point, it parses the truncated result as a
+ *    complete one — a sync page that looks whole and is not. Keeping the
+ *    server bound comfortably above the client deadline means the client
+ *    always aborts first, so no caller is ever parsing a truncated body.
+ *    ({@link assertCompleteNQuads} is the belt-and-braces guard for the
+ *    residual case.)
+ *
+ * With the 30s default this yields a 120s server bound: orphan lifetime drops
+ * from unbounded to at most 2 minutes, while the truncation path stays
+ * unreachable.
+ */
+export const SERVER_QUERY_DEADLINE_FACTOR = 4;
+
 export interface BlazegraphStoreOptions {
   /** End-to-end timeout including scheduler wait, HTTP work, and response decoding. */
   timeout?: number;
@@ -434,6 +472,7 @@ export class BlazegraphStore implements TripleStore {
         headers: {
           'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
           Accept: 'application/sparql-results+json',
+          [MAX_QUERY_MILLIS_HEADER]: String(this.serverQueryDeadlineMs()),
         },
         body: trimmed,
         signal: deadline.signal,
@@ -463,6 +502,15 @@ export class BlazegraphStore implements TripleStore {
     });
   }
 
+  /**
+   * Server-side query bound sent with every read. See
+   * {@link SERVER_QUERY_DEADLINE_FACTOR} for why this is wider than the
+   * client deadline rather than tighter.
+   */
+  private serverQueryDeadlineMs(): number {
+    return this.operationTimeoutMs * SERVER_QUERY_DEADLINE_FACTOR;
+  }
+
   private async queryConstruct(
     sparql: string,
     deadline: StoreOperationDeadline,
@@ -473,6 +521,7 @@ export class BlazegraphStore implements TripleStore {
       headers: {
         'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
         Accept: 'text/x-nquads, application/n-quads',
+        [MAX_QUERY_MILLIS_HEADER]: String(this.serverQueryDeadlineMs()),
       },
       body: sparql,
       signal: deadline.signal,
@@ -487,6 +536,7 @@ export class BlazegraphStore implements TripleStore {
     const text = await deadline.waitFor(options?.maxResponseBytes === undefined
       ? res.text()
       : readResponseTextBounded(res, options.maxResponseBytes));
+    assertCompleteNQuads(text);
     const quads = parseNQuadsText(text);
     deadline.check();
     return { type: 'quads', quads };
@@ -624,6 +674,46 @@ function formatTerm(term: string): string {
   if (term.startsWith('_:')) return term;
   if (term.startsWith('<')) return term;
   return `<${term}>`;
+}
+
+/**
+ * Reject a CONSTRUCT body that Blazegraph cut short.
+ *
+ * Blazegraph commits `200 OK` and starts streaming before it knows whether the
+ * query will finish. If the query is then killed — by the server-side deadline,
+ * or by an engine error mid-result — the error text is appended to the
+ * already-committed body. {@link parseNQuadsText} skips any line it cannot
+ * match, so without this check that body parses into a short, structurally
+ * valid, silently-incomplete quad set: a sync page that looks whole and is not.
+ *
+ * The check is deliberately narrow — it looks for *truncation*, not for any
+ * unparseable line — so it cannot start rejecting the odd-but-harmless
+ * serialisations the tolerant parser has always accepted:
+ *
+ *  - a well-formed n-quads document ends its last statement with `.`
+ *  - Blazegraph's appended failure text carries a Java exception marker
+ */
+function assertCompleteNQuads(text: string): void {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return;
+
+  const javaError = /^(?:[\w.$]+\.)?(?:\w*Exception|\w*Error)\b|\bat com\.bigdata\./m.exec(trimmed);
+  if (javaError) {
+    throw new Error(
+      'Blazegraph returned a truncated CONSTRUCT result: the response body carries an engine error '
+      + `(${javaError[0].slice(0, 120)}). Treating this as a failure rather than as an empty/partial `
+      + 'result — see assertCompleteNQuads.',
+    );
+  }
+
+  const lastLine = trimmed.slice(trimmed.lastIndexOf('\n') + 1).trim();
+  if (!lastLine.endsWith('.')) {
+    throw new Error(
+      'Blazegraph returned a truncated CONSTRUCT result: the final statement is incomplete '
+      + `(${JSON.stringify(lastLine.slice(-120))}). Treating this as a failure rather than as a `
+      + 'partial result — see assertCompleteNQuads.',
+    );
+  }
 }
 
 function parseNQuadsText(text: string): DKGQuad[] {

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -697,7 +697,14 @@ function assertCompleteNQuads(text: string): void {
   const trimmed = text.trim();
   if (trimmed.length === 0) return;
 
-  const javaError = /^(?:[\w.$]+\.)?(?:\w*Exception|\w*Error)\b|\bat com\.bigdata\./m.exec(trimmed);
+  // Both alternatives are line-start anchored on purpose. The engine appends
+  // its failure text as standalone lines ("java.util.…Exception", "\tat
+  // com.bigdata.…"), while the same words inside a *stored literal* sit
+  // mid-line: n-quads forbids raw newlines in literals (they arrive as the
+  // two-character escape \n), and a valid statement line always starts with an
+  // IRI or blank node. An unanchored match here would let user-published
+  // content containing a Java stack trace poison every read of its graph.
+  const javaError = /^(?:[\w.$]+\.)?(?:\w*Exception|\w*Error)\b|^\s*at com\.bigdata\./m.exec(trimmed);
   if (javaError) {
     throw new Error(
       'Blazegraph returned a truncated CONSTRUCT result: the response body carries an engine error '
@@ -706,13 +713,20 @@ function assertCompleteNQuads(text: string): void {
     );
   }
 
-  const lastLine = trimmed.slice(trimmed.lastIndexOf('\n') + 1).trim();
-  if (!lastLine.endsWith('.')) {
-    throw new Error(
-      'Blazegraph returned a truncated CONSTRUCT result: the final statement is incomplete '
-      + `(${JSON.stringify(lastLine.slice(-120))}). Treating this as a failure rather than as a `
-      + 'partial result — see assertCompleteNQuads.',
-    );
+  // Find the final *statement*, skipping blank and comment-only lines — a body
+  // that ends with a comment is complete, not truncated.
+  const lines = trimmed.split('\n');
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i].trim();
+    if (line.length === 0 || line.startsWith('#')) continue;
+    if (!line.endsWith('.')) {
+      throw new Error(
+        'Blazegraph returned a truncated CONSTRUCT result: the final statement is incomplete '
+        + `(${JSON.stringify(line.slice(-120))}). Treating this as a failure rather than as a `
+        + 'partial result — see assertCompleteNQuads.',
+      );
+    }
+    break;
   }
 }
 

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -65,14 +65,14 @@ const MAX_QUERY_MILLIS_HEADER = 'X-BIGDATA-MAX-QUERY-MILLIS';
  *    complete one — a sync page that looks whole and is not. Keeping the
  *    server bound comfortably above the client deadline means the client
  *    always aborts first, so no caller is ever parsing a truncated body.
- *    ({@link assertCompleteNQuads} is the belt-and-braces guard for the
+ *    ({@link parseBlazegraphConstructNQuads} is the belt-and-braces guard for the
  *    residual case.)
  *
  * With the 30s default this yields a 120s server bound: orphan lifetime drops
  * from unbounded to at most 2 minutes, while the truncation path stays
  * unreachable.
  */
-export const SERVER_QUERY_DEADLINE_FACTOR = 4;
+const SERVER_QUERY_DEADLINE_FACTOR = 4;
 
 export interface BlazegraphStoreOptions {
   /** End-to-end timeout including scheduler wait, HTTP work, and response decoding. */
@@ -467,23 +467,13 @@ export class BlazegraphStore implements TripleStore {
       // "Unable to parse form content". The direct-POST body is not form
       // parsed, so large queries (e.g. CONSTRUCT/VALUES) are not capped.
       // SPARQL_QUERY_CONTENT_TYPE carries charset=utf-8 (see sparql-content-types.ts).
-      const res = await deadline.waitFor(fetch(this.url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
-          Accept: 'application/sparql-results+json',
-          [MAX_QUERY_MILLIS_HEADER]: String(this.serverQueryDeadlineMs()),
-        },
-        body: trimmed,
-        signal: deadline.signal,
-      }));
-      if (!res.ok) {
-        const text = await deadline.waitFor((options?.maxResponseBytes === undefined
-          ? res.text()
-          : readResponseTextBounded(res, options.maxResponseBytes)
-        ).catch(() => ''));
-        throw new Error(`Blazegraph query failed (${res.status}): ${text.slice(0, 300)}`);
-      }
+      const res = await this.postReadQuery(
+        trimmed,
+        'application/sparql-results+json',
+        deadline,
+        options,
+        'query',
+      );
 
       const json = options?.maxResponseBytes === undefined
         ? await deadline.waitFor(
@@ -511,16 +501,24 @@ export class BlazegraphStore implements TripleStore {
     return this.operationTimeoutMs * SERVER_QUERY_DEADLINE_FACTOR;
   }
 
-  private async queryConstruct(
+  /**
+   * Canonical request boundary for Blazegraph reads. Keeping transport and
+   * deadline setup here makes it impossible for SELECT/ASK and
+   * CONSTRUCT/DESCRIBE to drift on the server-side cancellation policy while
+   * leaving their distinct response decoding in the callers.
+   */
+  private async postReadQuery(
     sparql: string,
+    accept: string,
     deadline: StoreOperationDeadline,
-    options?: TripleStoreQueryOptions,
-  ): Promise<ConstructResult> {
+    options: TripleStoreQueryOptions | undefined,
+    failureLabel: 'query' | 'construct',
+  ): Promise<Response> {
     const res = await deadline.waitFor(fetch(this.url, {
       method: 'POST',
       headers: {
         'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
-        Accept: 'text/x-nquads, application/n-quads',
+        Accept: accept,
         [MAX_QUERY_MILLIS_HEADER]: String(this.serverQueryDeadlineMs()),
       },
       body: sparql,
@@ -531,13 +529,27 @@ export class BlazegraphStore implements TripleStore {
         ? res.text()
         : readResponseTextBounded(res, options.maxResponseBytes)
       ).catch(() => ''));
-      throw new Error(`Blazegraph construct failed (${res.status}): ${text.slice(0, 300)}`);
+      throw new Error(`Blazegraph ${failureLabel} failed (${res.status}): ${text.slice(0, 300)}`);
     }
+    return res;
+  }
+
+  private async queryConstruct(
+    sparql: string,
+    deadline: StoreOperationDeadline,
+    options?: TripleStoreQueryOptions,
+  ): Promise<ConstructResult> {
+    const res = await this.postReadQuery(
+      sparql,
+      'text/x-nquads, application/n-quads',
+      deadline,
+      options,
+      'construct',
+    );
     const text = await deadline.waitFor(options?.maxResponseBytes === undefined
       ? res.text()
       : readResponseTextBounded(res, options.maxResponseBytes));
-    assertCompleteNQuads(text);
-    const quads = parseNQuadsText(text);
+    const quads = parseBlazegraphConstructNQuads(text);
     deadline.check();
     return { type: 'quads', quads };
   }
@@ -677,76 +689,75 @@ function formatTerm(term: string): string {
 }
 
 /**
- * Reject a CONSTRUCT body that Blazegraph cut short.
+ * Parse a Blazegraph CONSTRUCT body and reject one that the engine cut short.
  *
  * Blazegraph commits `200 OK` and starts streaming before it knows whether the
  * query will finish. If the query is then killed — by the server-side deadline,
  * or by an engine error mid-result — the error text is appended to the
- * already-committed body. {@link parseNQuadsText} skips any line it cannot
- * match, so without this check that body parses into a short, structurally
- * valid, silently-incomplete quad set: a sync page that looks whole and is not.
+ * already-committed body. The historical parser skips any line it cannot
+ * match, so without an integrity check that body parses into a short,
+ * structurally valid, silently-incomplete quad set: a sync page that looks
+ * whole and is not.
  *
  * The check is deliberately narrow — it looks for *truncation*, not for any
  * unparseable line — so it cannot start rejecting the odd-but-harmless
  * serialisations the tolerant parser has always accepted:
  *
- *  - a well-formed n-quads document ends its last statement with `.`
+ *  - the final non-comment line must parse as a complete N-Quad statement
  *  - Blazegraph's appended failure text carries a Java exception marker
+ *
+ * Parsing and final-line validation intentionally share {@link parseNQuadLine}
+ * so there is one definition of a statement. Interior unparseable lines retain
+ * the adapter's historical tolerant behaviour; an unparseable final statement
+ * is the truncation signal that must fail closed.
  */
-function assertCompleteNQuads(text: string): void {
-  const trimmed = text.trim();
-  if (trimmed.length === 0) return;
-
-  // Both alternatives are line-start anchored on purpose. The engine appends
-  // its failure text as standalone lines ("java.util.…Exception", "\tat
-  // com.bigdata.…"), while the same words inside a *stored literal* sit
-  // mid-line: n-quads forbids raw newlines in literals (they arrive as the
-  // two-character escape \n), and a valid statement line always starts with an
-  // IRI or blank node. An unanchored match here would let user-published
-  // content containing a Java stack trace poison every read of its graph.
-  const javaError = /^(?:[\w.$]+\.)?(?:\w*Exception|\w*Error)\b|^\s*at com\.bigdata\./m.exec(trimmed);
-  if (javaError) {
-    throw new Error(
-      'Blazegraph returned a truncated CONSTRUCT result: the response body carries an engine error '
-      + `(${javaError[0].slice(0, 120)}). Treating this as a failure rather than as an empty/partial `
-      + 'result — see assertCompleteNQuads.',
-    );
-  }
-
-  // Find the final *statement*, skipping blank and comment-only lines — a body
-  // that ends with a comment is complete, not truncated.
-  const lines = trimmed.split('\n');
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    const line = lines[i].trim();
-    if (line.length === 0 || line.startsWith('#')) continue;
-    if (!line.endsWith('.')) {
-      throw new Error(
-        'Blazegraph returned a truncated CONSTRUCT result: the final statement is incomplete '
-        + `(${JSON.stringify(line.slice(-120))}). Treating this as a failure rather than as a `
-        + 'partial result — see assertCompleteNQuads.',
-      );
-    }
-    break;
-  }
-}
-
-function parseNQuadsText(text: string): DKGQuad[] {
+function parseBlazegraphConstructNQuads(text: string): DKGQuad[] {
   const quads: DKGQuad[] = [];
+  let finalStatement: { line: string; parsed: boolean } | undefined;
+
   for (const raw of text.split('\n')) {
     const line = raw.trim();
     if (!line || line.startsWith('#')) continue;
-    const match = line.match(
-      /^(<[^>]+>|_:\S+)\s+(<[^>]+>)\s+(<[^>]+>|_:\S+|"(?:[^"\\]|\\.)*"(?:@\S+|\^\^<[^>]+>)?)\s*(?:(<[^>]+>)\s*)?\.$/,
-    );
-    if (!match) continue;
-    quads.push({
-      subject: stripAngle(match[1]),
-      predicate: stripAngle(match[2]),
-      object: match[3].startsWith('<') ? stripAngle(match[3]) : match[3],
-      graph: match[4] ? stripAngle(match[4]) : '',
-    });
+
+    // Both alternatives are line-start anchored on purpose. The engine
+    // appends failure text as standalone lines, while the same words inside a
+    // stored literal occur after the subject and predicate on a valid N-Quad.
+    const javaError = /^(?:[\w.$]+\.)?(?:\w*Exception|\w*Error)\b|^\s*at com\.bigdata\./.exec(line);
+    if (javaError) {
+      throw new Error(
+        'Blazegraph returned a truncated CONSTRUCT result: the response body carries an engine '
+        + `error (${javaError[0].slice(0, 120)}). Treating this as a failure rather than as an `
+        + 'empty/partial result — see parseBlazegraphConstructNQuads.',
+      );
+    }
+
+    const quad = parseNQuadLine(line);
+    finalStatement = { line, parsed: quad !== undefined };
+    if (quad) quads.push(quad);
   }
+
+  if (finalStatement && !finalStatement.parsed) {
+    throw new Error(
+      'Blazegraph returned a truncated CONSTRUCT result: the final statement is incomplete '
+      + `(${JSON.stringify(finalStatement.line.slice(-120))}). Treating this as a failure rather `
+      + 'than as a partial result — see parseBlazegraphConstructNQuads.',
+    );
+  }
+
   return quads;
+}
+
+function parseNQuadLine(line: string): DKGQuad | undefined {
+  const match = line.match(
+    /^(<[^>]+>|_:\S+)\s+(<[^>]+>)\s+(<[^>]+>|_:\S+|"(?:[^"\\]|\\.)*"(?:@\S+|\^\^<[^>]+>)?)\s*(?:(<[^>]+>)\s*)?\.$/,
+  );
+  if (!match) return undefined;
+  return {
+    subject: stripAngle(match[1]),
+    predicate: stripAngle(match[2]),
+    object: match[3].startsWith('<') ? stripAngle(match[3]) : match[3],
+    graph: match[4] ? stripAngle(match[4]) : '',
+  };
 }
 
 function stripAngle(s: string): string {

--- a/packages/storage/test/blazegraph.integration.test.ts
+++ b/packages/storage/test/blazegraph.integration.test.ts
@@ -80,6 +80,47 @@ describe.skipIf(!BLAZEGRAPH_URL)('BlazegraphStore integration (live server)', ()
   });
 
   it(
+    'honours X-BIGDATA-MAX-QUERY-MILLIS on the supported live Blazegraph image',
+    async () => {
+      const GRAPH_DEADLINE = `${GRAPH}:deadline`;
+      const quads = makeQuads(150).map((quad) => ({ ...quad, graph: GRAPH_DEADLINE }));
+      await store.insert(quads);
+
+      // ORDER BY forces Blazegraph to buffer the complete Cartesian result,
+      // so it cannot finish or commit a successful response before the tiny
+      // server deadline. This direct POST deliberately has no adapter/client
+      // abort: it proves the external contract the adapter relies on rather
+      // than merely proving that our mock observed a header.
+      const expensiveQuery = `SELECT ?s1 ?s2 ?s3 WHERE {
+        GRAPH <${GRAPH_DEADLINE}> {
+          ?s1 <${PRED}> ?o1 .
+          ?s2 <${PRED}> ?o2 .
+          ?s3 <${PRED}> ?o3 .
+        }
+      } ORDER BY ?s1 ?s2 ?s3`;
+      const startedAt = Date.now();
+      const response = await fetch(BLAZEGRAPH_URL as string, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/sparql-query; charset=utf-8',
+          Accept: 'application/sparql-results+json',
+          'X-BIGDATA-MAX-QUERY-MILLIS': '25',
+        },
+        body: expensiveQuery,
+        signal: AbortSignal.timeout(5_000),
+      });
+      const body = await response.text();
+
+      expect(response.ok, body.slice(0, 500)).toBe(false);
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+      expect(body).toMatch(/(?:timeout|cancel|deadline|max query)/i);
+
+      await store.dropGraph(GRAPH_DEADLINE);
+    },
+    15_000,
+  );
+
+  it(
     'large DELETE DATA (publish path) succeeds — the form-content-limit regression',
     async () => {
       // 2 000 quads → a single DELETE DATA body of ~600 KB raw. Form-encoded

--- a/packages/storage/test/blazegraph.integration.test.ts
+++ b/packages/storage/test/blazegraph.integration.test.ts
@@ -86,36 +86,38 @@ describe.skipIf(!BLAZEGRAPH_URL)('BlazegraphStore integration (live server)', ()
       const quads = makeQuads(150).map((quad) => ({ ...quad, graph: GRAPH_DEADLINE }));
       await store.insert(quads);
 
-      // ORDER BY forces Blazegraph to buffer the complete Cartesian result,
-      // so it cannot finish or commit a successful response before the tiny
-      // server deadline. This direct POST deliberately has no adapter/client
-      // abort: it proves the external contract the adapter relies on rather
-      // than merely proving that our mock observed a header.
-      const expensiveQuery = `SELECT ?s1 ?s2 ?s3 WHERE {
-        GRAPH <${GRAPH_DEADLINE}> {
-          ?s1 <${PRED}> ?o1 .
-          ?s2 <${PRED}> ?o2 .
-          ?s3 <${PRED}> ?o3 .
-        }
-      } ORDER BY ?s1 ?s2 ?s3`;
-      const startedAt = Date.now();
-      const response = await fetch(BLAZEGRAPH_URL as string, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/sparql-query; charset=utf-8',
-          Accept: 'application/sparql-results+json',
-          'X-BIGDATA-MAX-QUERY-MILLIS': '25',
-        },
-        body: expensiveQuery,
-        signal: AbortSignal.timeout(5_000),
-      });
-      const body = await response.text();
+      try {
+        // ORDER BY forces Blazegraph to buffer the complete Cartesian result,
+        // so it cannot finish or commit a successful response before the tiny
+        // server deadline. This direct POST deliberately has no adapter/client
+        // abort: it proves the external contract the adapter relies on rather
+        // than merely proving that our mock observed a header.
+        const expensiveQuery = `SELECT ?s1 ?s2 ?s3 WHERE {
+          GRAPH <${GRAPH_DEADLINE}> {
+            ?s1 <${PRED}> ?o1 .
+            ?s2 <${PRED}> ?o2 .
+            ?s3 <${PRED}> ?o3 .
+          }
+        } ORDER BY ?s1 ?s2 ?s3`;
+        const startedAt = Date.now();
+        const response = await fetch(BLAZEGRAPH_URL as string, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/sparql-query; charset=utf-8',
+            Accept: 'application/sparql-results+json',
+            'X-BIGDATA-MAX-QUERY-MILLIS': '25',
+          },
+          body: expensiveQuery,
+          signal: AbortSignal.timeout(5_000),
+        });
+        const body = await response.text();
 
-      expect(response.ok, body.slice(0, 500)).toBe(false);
-      expect(Date.now() - startedAt).toBeLessThan(5_000);
-      expect(body).toMatch(/(?:timeout|cancel|deadline|max query)/i);
-
-      await store.dropGraph(GRAPH_DEADLINE);
+        expect(response.ok, body.slice(0, 500)).toBe(false);
+        expect(Date.now() - startedAt).toBeLessThan(5_000);
+        expect(body).toMatch(/(?:timeout|cancel|deadline|max query)/i);
+      } finally {
+        await store.dropGraph(GRAPH_DEADLINE).catch(() => {});
+      }
     },
     15_000,
   );

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { performance } from 'node:perf_hooks';
-import { BlazegraphStore, SERVER_QUERY_DEADLINE_FACTOR } from '../src/adapters/blazegraph.js';
+import { BlazegraphStore } from '../src/adapters/blazegraph.js';
 import { getExternalStorePrioritySchedulerSnapshot } from '../src/store-priority-scheduler.js';
 
 async function waitForCondition(
@@ -244,13 +244,14 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     // on Blazegraph indefinitely (observed on mainnet: 10-32+ min past a 30s
     // abort, queryErrorCount=0 across 20,953 queries). The bound must be
     // WIDER than the client deadline so the client always aborts first —
-    // see SERVER_QUERY_DEADLINE_FACTOR.
+    // The wire-level 120s expectation below independently documents the
+    // operational contract for the default 30s client deadline.
     setFetch(async () => blazeSelectResponse());
     const s = new BlazegraphStore(baseUrl, { timeout: 30_000 });
     await s.query('SELECT ?s WHERE { ?s ?p ?o }');
     const selectHeaders = fetchCalls[0][1]?.headers as Record<string, string>;
     const sent = Number(selectHeaders['X-BIGDATA-MAX-QUERY-MILLIS']);
-    expect(sent).toBe(30_000 * SERVER_QUERY_DEADLINE_FACTOR);
+    expect(sent).toBe(120_000);
     expect(sent).toBeGreaterThan(30_000);
 
     fetchCalls.length = 0;
@@ -261,7 +262,7 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     await s.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }');
     const constructHeaders = fetchCalls[0][1]?.headers as Record<string, string>;
     expect(Number(constructHeaders['X-BIGDATA-MAX-QUERY-MILLIS']))
-      .toBe(30_000 * SERVER_QUERY_DEADLINE_FACTOR);
+      .toBe(120_000);
   });
 
   it('scales the server-side deadline with a custom client timeout', async () => {
@@ -270,7 +271,7 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     await s.query('SELECT ?s WHERE { ?s ?p ?o }');
     const headers = fetchCalls[0][1]?.headers as Record<string, string>;
     expect(Number(headers['X-BIGDATA-MAX-QUERY-MILLIS']))
-      .toBe(5_000 * SERVER_QUERY_DEADLINE_FACTOR);
+      .toBe(20_000);
   });
 
   it('rejects a CONSTRUCT body truncated by an engine error instead of parsing it as partial data', async () => {
@@ -293,6 +294,20 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     setFetch(async () => new Response(
       '<http://ex.org/s> <http://ex.org/p> <http://ex.org/o> <http://ctx/1> .\n'
       + '<http://ex.org/s2> <http://ex.org/p2> <http://ex.or',
+      { status: 200, headers: { 'Content-Type': 'text/x-nquads' } },
+    ));
+    const s = new BlazegraphStore(baseUrl);
+    await expect(s.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'))
+      .rejects.toThrow(/truncated CONSTRUCT result/i);
+  });
+
+  it('rejects a final truncated literal even when the fragment ends with a period', async () => {
+    // A punctuation-only guard mistakes the period inside this unfinished
+    // literal for an N-Quads statement terminator, after which the tolerant
+    // parser silently skips the line and returns only the first quad.
+    setFetch(async () => new Response(
+      '<http://ex.org/s1> <http://ex.org/p> <http://ex.org/o> <http://ctx/1> .\n'
+      + '<http://ex.org/s2> <http://ex.org/p> "partial.',
       { status: 200, headers: { 'Content-Type': 'text/x-nquads' } },
     ));
     const s = new BlazegraphStore(baseUrl);

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { performance } from 'node:perf_hooks';
-import { BlazegraphStore } from '../src/adapters/blazegraph.js';
+import { BlazegraphStore, SERVER_QUERY_DEADLINE_FACTOR } from '../src/adapters/blazegraph.js';
 import { getExternalStorePrioritySchedulerSnapshot } from '../src/store-priority-scheduler.js';
 
 async function waitForCondition(
@@ -237,6 +237,86 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     const [, init] = fetchCalls[0];
     expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/sparql-query; charset=utf-8');
     expect(String(init?.body)).toMatch(/^CONSTRUCT /);
+  });
+
+  it('sends a server-side query deadline on SELECT and CONSTRUCT, wider than the client deadline', async () => {
+    // Without a server-side bound, a client abort leaves the query executing
+    // on Blazegraph indefinitely (observed on mainnet: 10-32+ min past a 30s
+    // abort, queryErrorCount=0 across 20,953 queries). The bound must be
+    // WIDER than the client deadline so the client always aborts first —
+    // see SERVER_QUERY_DEADLINE_FACTOR.
+    setFetch(async () => blazeSelectResponse());
+    const s = new BlazegraphStore(baseUrl, { timeout: 30_000 });
+    await s.query('SELECT ?s WHERE { ?s ?p ?o }');
+    const selectHeaders = fetchCalls[0][1]?.headers as Record<string, string>;
+    const sent = Number(selectHeaders['X-BIGDATA-MAX-QUERY-MILLIS']);
+    expect(sent).toBe(30_000 * SERVER_QUERY_DEADLINE_FACTOR);
+    expect(sent).toBeGreaterThan(30_000);
+
+    fetchCalls.length = 0;
+    setFetch(async () => new Response(
+      '<http://ex.org/s> <http://ex.org/p> <http://ex.org/o> <http://ctx/1> .\n',
+      { status: 200, headers: { 'Content-Type': 'text/x-nquads' } },
+    ));
+    await s.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }');
+    const constructHeaders = fetchCalls[0][1]?.headers as Record<string, string>;
+    expect(Number(constructHeaders['X-BIGDATA-MAX-QUERY-MILLIS']))
+      .toBe(30_000 * SERVER_QUERY_DEADLINE_FACTOR);
+  });
+
+  it('scales the server-side deadline with a custom client timeout', async () => {
+    setFetch(async () => blazeSelectResponse());
+    const s = new BlazegraphStore(baseUrl, { timeout: 5_000 });
+    await s.query('SELECT ?s WHERE { ?s ?p ?o }');
+    const headers = fetchCalls[0][1]?.headers as Record<string, string>;
+    expect(Number(headers['X-BIGDATA-MAX-QUERY-MILLIS']))
+      .toBe(5_000 * SERVER_QUERY_DEADLINE_FACTOR);
+  });
+
+  it('rejects a CONSTRUCT body truncated by an engine error instead of parsing it as partial data', async () => {
+    // Blazegraph commits 200 and streams before it knows the query will fail,
+    // then appends the error into the committed body. The tolerant n-quads
+    // parser skips unmatched lines, so without the guard this returns a short
+    // but structurally valid quad set — silent data loss.
+    setFetch(async () => new Response(
+      '<http://ex.org/s> <http://ex.org/p> <http://ex.org/o> <http://ctx/1> .\n'
+      + 'java.util.concurrent.TimeoutException: query deadline exceeded\n'
+      + '\tat com.bigdata.rdf.sail.webapp.BigdataRDFContext.run(BigdataRDFContext.java:1)\n',
+      { status: 200, headers: { 'Content-Type': 'text/x-nquads' } },
+    ));
+    const s = new BlazegraphStore(baseUrl);
+    await expect(s.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'))
+      .rejects.toThrow(/truncated CONSTRUCT result/i);
+  });
+
+  it('rejects a CONSTRUCT body cut mid-statement', async () => {
+    setFetch(async () => new Response(
+      '<http://ex.org/s> <http://ex.org/p> <http://ex.org/o> <http://ctx/1> .\n'
+      + '<http://ex.org/s2> <http://ex.org/p2> <http://ex.or',
+      { status: 200, headers: { 'Content-Type': 'text/x-nquads' } },
+    ));
+    const s = new BlazegraphStore(baseUrl);
+    await expect(s.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'))
+      .rejects.toThrow(/truncated CONSTRUCT result/i);
+  });
+
+  it('still accepts complete CONSTRUCT bodies, including empty results and comments', async () => {
+    // The guard must not start rejecting shapes the tolerant parser has
+    // always accepted, or it becomes a worse bug than the one it fixes.
+    setFetch(async () => new Response('', { status: 200, headers: { 'Content-Type': 'text/x-nquads' } }));
+    const empty = await new BlazegraphStore(baseUrl)
+      .query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }');
+    expect(empty.type).toBe('quads');
+    expect((empty as { quads: unknown[] }).quads).toHaveLength(0);
+
+    setFetch(async () => new Response(
+      '# a comment line\n'
+      + '<http://ex.org/s> <http://ex.org/p> "lit"@en <http://ctx/1> .\n',
+      { status: 200, headers: { 'Content-Type': 'text/x-nquads' } },
+    ));
+    const ok = await new BlazegraphStore(baseUrl)
+      .query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }');
+    expect((ok as { quads: unknown[] }).quads).toHaveLength(1);
   });
 
   it.each([

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -300,6 +300,24 @@ describe('BlazegraphStore (mocked HTTP)', () => {
       .rejects.toThrow(/truncated CONSTRUCT result/i);
   });
 
+  it('does not misread a trailing comment or an error-like literal as truncation', async () => {
+    // Two false positives a narrower guard must not have: (1) a body whose
+    // final line is a comment is complete, not cut short; (2) a STORED literal
+    // containing Java-stack-trace text sits mid-line inside its quad (n-quads
+    // forbids raw newlines in literals), so the line-start-anchored error scan
+    // must not fire on it. User-published content is arbitrary — a KA holding
+    // error logs must not poison every read of its graph.
+    setFetch(async () => new Response(
+      '<http://ex.org/s> <http://ex.org/p> "logs: at com.bigdata.Journal.run TimeoutException" <http://ctx/1> .\n'
+      + '# end of results\n',
+      { status: 200, headers: { 'Content-Type': 'text/x-nquads' } },
+    ));
+    const r = await new BlazegraphStore(baseUrl)
+      .query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }');
+    expect(r.type).toBe('quads');
+    expect((r as { quads: unknown[] }).quads).toHaveLength(1);
+  });
+
   it('still accepts complete CONSTRUCT bodies, including empty results and comments', async () => {
     // The guard must not start rejecting shapes the tolerant parser has
     // always accepted, or it becomes a worse bug than the one it fixes.


### PR DESCRIPTION
## Summary

**Aborting a query client-side does not stop it.** The adapter puts a 30s `AbortController` on every store request
but sends no server-side deadline, so when the client gives up Blazegraph keeps executing and allocating.

This is the root cause behind the two error classes that dominate Base mainnet publish failures
(`store scheduler queue wait timeout (normal: blazegraph.query)` ×151 and
`blazegraph operation exceeded its 30000ms deadline` ×123, together ~86% of the counted publish errors).

## Measured on the fleet

`/bigdata/status?showQueries=details` on a Base core, container up with no restart in the window:

| observation | value |
|---|---|
| abandoned queries in flight | steady 2–5 |
| longest observed elapsed | **32.5 min** |
| same query re-sampled 576s later | elapsed **+617s** — i.e. still executing |
| `queryErrorCount` over 20,953 accepted queries | **0** — the server never cancelled anything |
| Blazegraph CPU | 307–670% of 400% available |

Thread dumps showed 9 `RUNNABLE com.bigdata.journal.Journal.executorService*` threads in query operator frames while
**all 10 Tomcat `http-nio-8080-exec` threads were idle** — nobody was waiting on those queries. They are pure waste,
and a handful of them saturate a 4-CPU core.

## The fix

Send `X-BIGDATA-MAX-QUERY-MILLIS` on both read paths (SELECT/ASK and CONSTRUCT). The deployed 2.1.x engine honours
it (`BigdataRDFContext$AbstractQueryTask` reads it via `getQueryTimeout`).

### Why the bound is *wider* than the client deadline, not tighter

This is the design decision worth reviewing. `SERVER_QUERY_DEADLINE_FACTOR = 4`, so the 30s default yields a 120s
server bound.

1. **Bounding abandoned work doesn't need a tight bound.** Any finite value converts "unbounded" into "at most 2
   minutes". The orphan pool is what saturates the core, and the pool size is a function of arrival rate × lifetime
   — cutting lifetime from 32 min to 2 min is a ~16× reduction.

2. **A tight bound introduces silent data loss.** Blazegraph commits `200 OK` and begins streaming *before* it knows
   the query will finish, then appends its error into the already-committed body. A CONSTRUCT killed mid-stream
   while the client is still reading yields a **short but structurally valid** n-quads document — and
   `parseNQuadsText` does `if (!match) continue;`, silently discarding the truncated tail and the appended error.
   The caller gets a sync page that looks complete and is not.

   Keeping the server bound comfortably above the client deadline means **the client always aborts first**, so no
   caller is ever parsing a truncated body. The failure stays loud.

> This is the one substantive difference from the equivalent slice in #1817, which computes
> `max(5000, remaining - 2000)`. That inverts the invariant exactly where it matters most: under the queue pressure
> that produces the `queue wait timeout` errors, a query is often admitted with near-zero remaining budget, gets
> granted the 5000ms floor, and the *server* then outlives the client — reaching the truncation path.

### Belt-and-braces: `assertCompleteNQuads`

For the residual case (an operator-set global `web.xml queryTimeout`, or an engine error mid-result), CONSTRUCT
bodies are checked for truncation before parsing.

Deliberately **narrow** — it detects *truncation*, not any unparseable line — so it cannot start rejecting the
odd-but-harmless serialisations the tolerant parser has always accepted. It fires on exactly two signals:

- the body carries an appended Java exception marker
- the final statement does not end in `.`

## Testing

Six new cases in `packages/storage/test/blazegraph.unit.test.ts`:

- header present on SELECT **and** CONSTRUCT, and asserted `> ` the client deadline
- scales with a custom client timeout
- rejects a body truncated by an appended engine error
- rejects a body cut mid-statement
- still accepts complete bodies, **including empty results and comment lines** (the anti-regression case)

**Mutation-verified:** `SERVER_QUERY_DEADLINE_FACTOR = 1` fails the width assertion; removing `assertCompleteNQuads`
fails both truncation tests.

Full storage suite: **477 passed, 0 failures** (32 files). `tsc --noEmit` clean.

## Scope / risk

- **Reads only.** `getQueryTimeout` is referenced only from `AbstractQueryTask` — not from `UpdateTask` — so the
  header is inert on `sparqlUpdate`. Long INSERT/replaceGraph/deleteByPattern work remains unbounded server-side;
  that is a separate change and is *not* claimed here.
- No behaviour change on the success path: a query that completes within the client budget is unaffected.
- Reversible: the factor is a single exported constant.

## Related

- #2093 — journal volume / recreate safety (independent, no overlap)
- #1817 — the larger survivability PR; this is the narrow adapter slice, with the deadline-direction correction above
- #1990 — the store-scheduler timeout symptom this addresses upstream of
