### PR TITLE
fix(storage): stop orphaned Blazegraph queries after a request times out

### DIFF
--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -36,6 +36,14 @@ import { readResponseTextBounded } from '../http-response-limit.js';
 
 export const DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS = 30_000;
 
+/**
+ * BigdataRDFContext reads this request header into maxQueryTimeMillis. The
+ * deployed Blazegraph web.xml leaves queryTimeout at 0, so a client-side
+ * AbortController alone otherwise abandons work that can keep running on the
+ * server for minutes after the DKG request has failed.
+ */
+const BLAZEGRAPH_MAX_QUERY_MILLIS_HEADER = 'X-BIGDATA-MAX-QUERY-MILLIS';
+
 export interface BlazegraphStoreOptions {
   /** End-to-end timeout including scheduler wait, HTTP work, and response decoding. */
   timeout?: number;
@@ -46,6 +54,8 @@ interface StoreOperationDeadline {
   waitFor<T>(work: Promise<T>): Promise<T>;
   check(): void;
   dispose(): void;
+  /** Milliseconds left until the operation deadline (0 when elapsed). */
+  remainingMs(): number;
 }
 
 function parsePositiveIntegerEnv(name: string, fallback: number): number {
@@ -66,6 +76,27 @@ function resolveOperationTimeout(configured: number | undefined): number {
     throw new Error('BlazegraphStore timeout must be a positive integer in milliseconds');
   }
   return configured;
+}
+
+/**
+ * Kill Blazegraph work shortly before the client abandons the request. Keep a
+ * 10% unwind margin for short budgets and cap that margin at two seconds for
+ * normal operations. A 1 ms floor avoids sending 0, which Blazegraph treats as
+ * unlimited, while preserving the server-first deadline after queue wait.
+ */
+export function serverSideQueryTimeoutMillis(remainingMs: number): number {
+  const budget = Math.max(1, Math.floor(remainingMs));
+  const unwindMargin = Math.min(2_000, Math.max(1, Math.floor(budget / 10)));
+  return Math.max(1, budget - unwindMargin);
+}
+
+function serverTimeoutHeaders(deadline: StoreOperationDeadline): Record<string, string> {
+  if (process.env.DKG_BLAZEGRAPH_SERVER_TIMEOUT_DISABLED === '1') return {};
+  return {
+    [BLAZEGRAPH_MAX_QUERY_MILLIS_HEADER]: String(
+      serverSideQueryTimeoutMillis(deadline.remainingMs()),
+    ),
+  };
 }
 
 function abortError(signal: AbortSignal): Error {
@@ -151,6 +182,7 @@ function createStoreOperationDeadline(
       }
       detachCaller();
     },
+    remainingMs: () => Math.max(0, deadlineAt - performance.now()),
   };
 }
 
@@ -434,6 +466,7 @@ export class BlazegraphStore implements TripleStore {
         headers: {
           'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
           Accept: 'application/sparql-results+json',
+          ...serverTimeoutHeaders(deadline),
         },
         body: trimmed,
         signal: deadline.signal,
@@ -473,6 +506,7 @@ export class BlazegraphStore implements TripleStore {
       headers: {
         'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
         Accept: 'text/x-nquads, application/n-quads',
+        ...serverTimeoutHeaders(deadline),
       },
       body: sparql,
       signal: deadline.signal,
@@ -576,7 +610,10 @@ export class BlazegraphStore implements TripleStore {
     await this.runStoreWork(operation, options, async (deadline) => {
       const res = await deadline.waitFor(fetch(this.url, {
         method: 'POST',
-        headers: { 'Content-Type': SPARQL_UPDATE_CONTENT_TYPE },
+        headers: {
+          'Content-Type': SPARQL_UPDATE_CONTENT_TYPE,
+          ...serverTimeoutHeaders(deadline),
+        },
         body: update,
         signal: deadline.signal,
       }));

--- a/packages/storage/test/blazegraph-server-timeout.unit.test.ts
+++ b/packages/storage/test/blazegraph-server-timeout.unit.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BlazegraphStore,
+  serverSideQueryTimeoutMillis,
+} from '../src/adapters/blazegraph.js';
+
+const HEADER = 'X-BIGDATA-MAX-QUERY-MILLIS';
+
+describe('serverSideQueryTimeoutMillis', () => {
+  it('expires server work before the client deadline', () => {
+    expect(serverSideQueryTimeoutMillis(30_000)).toBe(28_000);
+    expect(serverSideQueryTimeoutMillis(500_000)).toBe(498_000);
+    expect(serverSideQueryTimeoutMillis(1_000)).toBe(900);
+  });
+
+  it('never sends zero, which Blazegraph treats as unlimited', () => {
+    expect(serverSideQueryTimeoutMillis(6_000)).toBe(5_400);
+    expect(serverSideQueryTimeoutMillis(0)).toBe(1);
+  });
+});
+
+describe('BlazegraphStore server-side timeout header', () => {
+  const baseUrl = 'http://blaze.test/sparql';
+  let calls: Array<[string | URL | Request, RequestInit | undefined]>;
+  let originalFetch: typeof globalThis.fetch;
+
+  function installFetch(
+    response: (body: string) => Response,
+  ): void {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push([input, init]);
+      return response(String(init?.body ?? ''));
+    }) as typeof fetch;
+  }
+
+  function header(index: number): number | undefined {
+    const headers = calls[index]?.[1]?.headers as Record<string, string> | undefined;
+    const value = headers?.[HEADER];
+    return value === undefined ? undefined : Number(value);
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    calls = [];
+    installFetch((body) => body.startsWith('SELECT')
+      ? new Response(
+        JSON.stringify({ head: { vars: [] }, results: { bindings: [] } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+      : body.startsWith('CONSTRUCT')
+        ? new Response('', { status: 200, headers: { 'Content-Type': 'text/x-nquads' } })
+        : new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.DKG_BLAZEGRAPH_SERVER_TIMEOUT_DISABLED;
+  });
+
+  it('bounds SELECT, CONSTRUCT, and UPDATE on the server', async () => {
+    const store = new BlazegraphStore(baseUrl);
+    await store.query('SELECT ?s WHERE { ?s ?p ?o }');
+    await store.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }');
+    await store.update('DELETE WHERE { ?s ?p ?o }');
+
+    expect(calls).toHaveLength(3);
+    for (let index = 0; index < calls.length; index += 1) {
+      expect(header(index)).toBeGreaterThanOrEqual(1);
+      expect(header(index)).toBeLessThanOrEqual(28_000);
+    }
+  });
+
+  it('derives the bound from the remaining instance deadline', async () => {
+    const store = new BlazegraphStore(baseUrl, { timeout: 10_000 });
+    await store.query('SELECT ?s WHERE { ?s ?p ?o }');
+    expect(header(0)).toBeGreaterThan(8_000);
+    expect(header(0)).toBeLessThanOrEqual(9_000);
+  });
+
+  it('derives the bound after scheduler queue wait, not from the original timeout', async () => {
+    const releases: Array<() => void> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push([input, init]);
+      if (calls.length <= 2) {
+        await new Promise<void>((resolve) => releases.push(resolve));
+      }
+      return new Response(
+        JSON.stringify({ head: { vars: [] }, results: { bindings: [] } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+    const store = new BlazegraphStore(baseUrl, { timeout: 2_500 });
+    const first = store.query('SELECT ?s WHERE { ?s ?p ?o }');
+    const second = store.query('SELECT ?s WHERE { ?s ?p ?o }');
+    await vi.waitFor(() => expect(calls).toHaveLength(2));
+
+    const queued = store.query('SELECT ?s WHERE { ?s ?p ?o }');
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(calls).toHaveLength(2);
+    releases.shift()?.();
+    await vi.waitFor(() => expect(calls).toHaveLength(3));
+
+    expect(header(2)).toBeLessThan((header(0) ?? 0) - 150);
+    expect(header(2)).toBeGreaterThan(1);
+    releases.shift()?.();
+    await Promise.all([first, second, queued]);
+  });
+
+  it('keeps an operator escape hatch without a restart-time code change', async () => {
+    process.env.DKG_BLAZEGRAPH_SERVER_TIMEOUT_DISABLED = '1';
+    const store = new BlazegraphStore(baseUrl);
+    await store.query('SELECT ?s WHERE { ?s ?p ?o }');
+    await store.update('DELETE WHERE { ?s ?p ?o }');
+    expect(header(0)).toBeUndefined();
+    expect(header(1)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Under saturation on Base, a Blazegraph query that the DKG side has already given up on **keeps running on the server**. The deployed `web.xml` leaves `queryTimeout` at `0` (unlimited), so the client-side `AbortController` only abandons the HTTP request — it does not stop the work. Those orphans accumulate and consume exactly the capacity the retry needs, which is why saturation compounds instead of recovering.

Blazegraph's `BigdataRDFContext` reads a per-request header, `X-BIGDATA-MAX-QUERY-MILLIS`, into `maxQueryTimeMillis`. Every query, construct and update now sends it, giving the server its own deadline.

Two details that are load-bearing rather than cosmetic:

- **The value is the remaining budget minus an unwind margin** (10%, capped at 2s), so the server gives up shortly *before* the client does and can return an error instead of being cut off mid-flight.
- **The margin is floored at 1ms**, because Blazegraph reads `0` as *unlimited* — sending `0` would silently reinstate the exact bug this fixes.

Because the header is computed from the deadline *after* scheduler queue wait, a request that sat in the queue asks the server for correspondingly less time rather than for its original full budget.

`DKG_BLAZEGRAPH_SERVER_TIMEOUT_DISABLED=1` opts out for a store that does not honour the header.

## Related

- Split out of #2092, which bundled three unrelated reliability fixes. Separated so each can be tested and reverted independently.
- Siblings: unsupported StorageACK protocols, and durable finalization deferral.

## Diagrams

### A query that exceeds its timeout

Before — the server never learns the client gave up:

```mermaid
sequenceDiagram
    participant DKG
    participant Blazegraph
    DKG->>Blazegraph: POST /sparql (no server deadline)
    Note over Blazegraph: web.xml queryTimeout = 0
    DKG->>DKG: AbortController fires at 30s
    DKG--xBlazegraph: request abandoned
    Note over Blazegraph: query keeps executing<br/>for minutes, holding capacity
```

After — the server has a deadline of its own:

```mermaid
sequenceDiagram
    participant DKG
    participant Blazegraph
    DKG->>Blazegraph: POST /sparql<br/>X-BIGDATA-MAX-QUERY-MILLIS: remaining - margin
    Note over Blazegraph: maxQueryTimeMillis set per request
    Blazegraph-->>DKG: error at its own deadline
    Note over DKG: client abort is the fallback,<br/>not the only stop
```

## Files changed

| File | What |
|------|------|
| `packages/storage/src/adapters/blazegraph.ts` | `serverSideQueryTimeoutMillis()` + `remainingMs()` on the operation deadline; header attached to query, construct and update |
| `packages/storage/test/blazegraph-server-timeout.unit.test.ts` | New — 6 tests |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-storage exec vitest run test/blazegraph-server-timeout.unit.test.ts` — **6 passed**, on this branch alone off `testnet-canary`
- [x] Covers: header present on all three verbs; margin arithmetic; the 1ms floor (never emit `0`); the bound derived **after** scheduler queue wait rather than from the original timeout; opt-out env var
- [ ] Live check on Base under saturation — confirm orphaned queries no longer accumulate after a request timeout
