### PR TITLE
fix(agent): durably preserve finalizations when the live recovery inbox is full

### DIFF
--- a/.github/workflows/rfc64-inventory-windows.yml
+++ b/.github/workflows/rfc64-inventory-windows.yml
@@ -106,6 +106,8 @@ jobs:
         run: >-
           pnpm --filter @origintrail-official/dkg-agent exec vitest run
           --config vitest.unit.config.ts
+          test/finalization-recovery-sqlite-deferred.test.ts
+          test/finalization-recovery-sqlite-migration.test.ts
           test/finalization-recovery-sqlite-store.test.ts
           test/rfc64-inventory-v1
           test/rfc64-agent-inventory-lifecycle.test.ts

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -71,10 +71,12 @@ import {
 } from './finalization-lifecycle-logger.js';
 import type { FinalizationRuntime } from './finalization-runtime.js';
 import {
+  FinalizationRecoveryCapacityError,
   FinalizationRecovery,
   type FinalizationRecoveryApplyOutcome,
   type FinalizationRecoveryInvalidationOutcome,
   type FinalizationRecoveryLiveInput,
+  type FinalizationRecoveryLiveProcessResult,
   type FinalizationRecoveryMaterializer,
   type FinalizationRecoveryPreparedMaterialization,
   type FinalizationRecoveryReplayOutcome,
@@ -485,10 +487,13 @@ export class FinalizationHandler {
     let candidate: ParsedGraphScopedFinalization | undefined;
     if (liveAdmission.status === 'admitted') {
       candidate = liveAdmission.input.candidate;
+      let recoveryResult: FinalizationRecoveryLiveProcessResult;
       try {
-        if (await this.recovery.processLive(liveAdmission.input)) return;
+        recoveryResult = await this.recovery.processLiveOutcome(liveAdmission.input);
       } catch (error) {
-        if (error instanceof StoreSchedulerBusyError) throw error;
+        if (
+          error instanceof StoreSchedulerBusyError
+        ) throw error;
         const ctx = candidate.msg.operationId
           ? createOperationContext('gossip', candidate.msg.operationId)
           : createOperationContext('gossip');
@@ -504,6 +509,18 @@ export class FinalizationHandler {
         }));
         this.log.warn(ctx, `Finalization: failed to process graph-scoped message: ${reason}`);
         return;
+      }
+      switch (recoveryResult.status) {
+        case 'handled':
+          return;
+        case 'retryable-capacity':
+          throw new FinalizationRecoveryCapacityError(recoveryResult.ual);
+        case 'fallback':
+          break;
+        default: {
+          const exhaustive: never = recoveryResult;
+          throw new Error(`Unhandled finalization recovery result: ${JSON.stringify(exhaustive)}`);
+        }
       }
       envelope = {
         rawMessage: data,

--- a/packages/agent/src/finalization-recovery-sqlite-codec.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-codec.ts
@@ -43,13 +43,10 @@ export function finalizationEnvelopeSha256(value: Uint8Array): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
-export function finalizationRecoveryRowToEntry(
+/** Validates the durable envelope bytes shared by live and deferred rows. */
+export function finalizationEnvelopeFromRow(
   row: Record<string, unknown>,
-): FinalizationRecoveryEntry {
-  const state = String(row.state) as FinalizationRecoveryState;
-  if (!LIVE_STATES.has(state) && !TERMINAL_STATES.has(state)) {
-    throw new Error('Finalization inbox row has invalid state');
-  }
+): { raw: Uint8Array; envelopeSha256: string } {
   const raw = row.raw_envelope;
   if (!(raw instanceof Uint8Array)) {
     throw new Error('Finalization inbox row has invalid envelope');
@@ -61,6 +58,17 @@ export function finalizationRecoveryRowToEntry(
   ) {
     throw new Error('Finalization inbox row has invalid envelope integrity');
   }
+  return { raw, envelopeSha256 };
+}
+
+export function finalizationRecoveryRowToEntry(
+  row: Record<string, unknown>,
+): FinalizationRecoveryEntry {
+  const state = String(row.state) as FinalizationRecoveryState;
+  if (!LIVE_STATES.has(state) && !TERMINAL_STATES.has(state)) {
+    throw new Error('Finalization inbox row has invalid state');
+  }
+  const { raw, envelopeSha256 } = finalizationEnvelopeFromRow(row);
   const verifiedEvidence = row.verified_evidence_json === null
     ? undefined
     : VerifiedGraphScopedFinalizationEvidenceCodec.parse(

--- a/packages/agent/src/finalization-recovery-sqlite-policy.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-policy.ts
@@ -8,6 +8,10 @@ const DEFAULT_MAX_TOTAL_BYTES = 16 * 1024 * 1024;
 const DEFAULT_MAX_ENVELOPE_BYTES = 1024 * 1024;
 const DEFAULT_MAX_PER_PEER = 32;
 const DEFAULT_MAX_PER_CONTEXT_GRAPH = 64;
+const DEFAULT_MAX_DEFERRED_ENTRIES = 1_024;
+const DEFAULT_MAX_DEFERRED_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_DEFERRED_PER_PEER = 256;
+const DEFAULT_MAX_DEFERRED_PER_CONTEXT_GRAPH = 512;
 const DEFAULT_RAW_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_TERMINAL_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_MAX_TERMINAL_ENTRIES = 128;
@@ -19,6 +23,10 @@ export interface SqliteFinalizationRecoveryStoreOptions {
   maxEnvelopeBytes?: number;
   maxPerPeer?: number;
   maxPerContextGraph?: number;
+  maxDeferredEntries?: number;
+  maxDeferredBytes?: number;
+  maxDeferredPerPeer?: number;
+  maxDeferredPerContextGraph?: number;
   rawTtlMs?: number;
   terminalTtlMs?: number;
   maxTerminalEntries?: number;
@@ -32,6 +40,10 @@ export interface FinalizationRecoveryRetentionPolicy {
   maxEnvelopeBytes: number;
   maxPerPeer: number;
   maxPerContextGraph: number;
+  maxDeferredEntries: number;
+  maxDeferredBytes: number;
+  maxDeferredPerPeer: number;
+  maxDeferredPerContextGraph: number;
   rawTtlMs: number;
   terminalTtlMs: number;
   maxTerminalEntries: number;
@@ -65,6 +77,22 @@ export function resolveFinalizationRecoveryRetentionPolicy(
       options.maxPerContextGraph,
       DEFAULT_MAX_PER_CONTEXT_GRAPH,
     ),
+    maxDeferredEntries: positiveInteger(
+      options.maxDeferredEntries,
+      DEFAULT_MAX_DEFERRED_ENTRIES,
+    ),
+    maxDeferredBytes: positiveInteger(
+      options.maxDeferredBytes,
+      DEFAULT_MAX_DEFERRED_BYTES,
+    ),
+    maxDeferredPerPeer: positiveInteger(
+      options.maxDeferredPerPeer,
+      DEFAULT_MAX_DEFERRED_PER_PEER,
+    ),
+    maxDeferredPerContextGraph: positiveInteger(
+      options.maxDeferredPerContextGraph,
+      DEFAULT_MAX_DEFERRED_PER_CONTEXT_GRAPH,
+    ),
     rawTtlMs: positiveInteger(options.rawTtlMs, DEFAULT_RAW_TTL_MS),
     terminalTtlMs: positiveInteger(options.terminalTtlMs, DEFAULT_TERMINAL_TTL_MS),
     maxTerminalEntries: positiveInteger(
@@ -89,6 +117,9 @@ export function pruneFinalizationRecoveryRowsWithinTransaction(
      WHERE state IN ('RECEIVED','REORGED') AND updated_at < ?`,
   ).run(now - policy.rawTtlMs);
   database.prepare(
+    `DELETE FROM finalization_pending_v2 WHERE updated_at < ?`,
+  ).run(now - policy.rawTtlMs);
+  database.prepare(
     `DELETE FROM finalization_inbox_v1
      WHERE state IN ('SETTLED','SUPERSEDED','REJECTED','UNSUPPORTED')
        AND publisher_upgrade_pending = 0
@@ -111,6 +142,51 @@ export function pruneFinalizationRecoveryRowsWithinTransaction(
       WHERE row_number > ? OR cumulative_bytes > ?
     )
   `).run(policy.maxTerminalEntries, policy.maxTerminalBytes);
+}
+
+export function hasFinalizationRecoveryDeferredCapacity(
+  database: DatabaseSync,
+  policy: FinalizationRecoveryRetentionPolicy,
+  input: FinalizationRecoveryReceiveInput,
+): boolean {
+  const total = database.prepare(`
+    SELECT COUNT(*) AS count, COALESCE(SUM(length(raw_envelope)), 0) AS bytes
+    FROM finalization_pending_v2
+  `).get();
+  if (
+    Number(total?.count ?? 0) >= policy.maxDeferredEntries
+    || Number(total?.bytes ?? 0) + input.rawMessage.byteLength > policy.maxDeferredBytes
+  ) return false;
+  const graph = database.prepare(`
+    SELECT COUNT(*) AS count FROM finalization_pending_v2
+    WHERE context_graph_id = ?
+  `).get(input.contextGraphId);
+  if (Number(graph?.count ?? 0) >= policy.maxDeferredPerContextGraph) return false;
+  if (input.sourcePeerId) {
+    const peer = database.prepare(`
+      SELECT COUNT(*) AS count FROM finalization_pending_v2
+      WHERE source_peer_id = ?
+    `).get(input.sourcePeerId);
+    if (Number(peer?.count ?? 0) >= policy.maxDeferredPerPeer) return false;
+  }
+  return true;
+}
+
+export function readFinalizationRecoveryDeferredCapacity(
+  database: DatabaseSync,
+): { entries: number; payloadBytes: number; oldest?: number } {
+  const row = database.prepare(`
+    SELECT COUNT(*) AS count,
+           COALESCE(SUM(length(raw_envelope)), 0) AS bytes,
+           MIN(created_at) AS oldest
+    FROM finalization_pending_v2
+  `).get();
+  const oldest = typeof row?.oldest === 'number' ? row.oldest : undefined;
+  return {
+    entries: Number(row?.count ?? 0),
+    payloadBytes: Number(row?.bytes ?? 0),
+    ...(oldest === undefined ? {} : { oldest }),
+  };
 }
 
 export function hasFinalizationRecoveryCapacity(

--- a/packages/agent/src/finalization-recovery-sqlite-schema.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-schema.ts
@@ -27,9 +27,10 @@ import {
 } from './finalization-recovery-sqlite-codec.js';
 
 const APPLICATION_ID = 0x444b4649; // DKFI
-const USER_VERSION = 1;
+const LEGACY_USER_VERSION = 1;
+const USER_VERSION = 2;
 
-const DDL = `
+const DDL_V1 = `
 CREATE TABLE finalization_inbox_v1 (
   key TEXT PRIMARY KEY NOT NULL,
   state TEXT NOT NULL CHECK (
@@ -98,6 +99,41 @@ CREATE INDEX finalization_inbox_state_time_v1
   ON finalization_inbox_v1(state, updated_at);
 `;
 
+const PENDING_DDL_V2 = `
+-- This is a bounded admission spool, not a second recovery state machine.
+-- Canonical recovery states, verification evidence, attempts, and transitions
+-- remain exclusively in finalization_inbox_v1. Keeping the spool separate
+-- avoids rebuilding/copying accepted v1 rows merely to widen that table's
+-- state CHECK during an upgrade; promotion atomically moves immutable envelope
+-- identity into the canonical inbox.
+CREATE TABLE finalization_pending_v2 (
+  key TEXT PRIMARY KEY NOT NULL,
+  chain_id TEXT NOT NULL,
+  context_graph_id TEXT NOT NULL,
+  source_peer_id TEXT,
+  trusted_publisher_peer_id TEXT,
+  ual TEXT NOT NULL,
+  tx_hash TEXT NOT NULL,
+  assertion_version TEXT NOT NULL,
+  merkle_root TEXT NOT NULL,
+  ka_id TEXT NOT NULL,
+  batch_id TEXT NOT NULL,
+  target_context_graph_id TEXT,
+  envelope_sha256 TEXT NOT NULL,
+  raw_envelope BLOB NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+) STRICT;
+CREATE INDEX finalization_pending_time_v2
+  ON finalization_pending_v2(created_at, key);
+CREATE INDEX finalization_pending_graph_v2
+  ON finalization_pending_v2(context_graph_id, created_at);
+CREATE INDEX finalization_pending_peer_v2
+  ON finalization_pending_v2(source_peer_id, created_at);
+`;
+
+const DDL_V2 = `${DDL_V1}\n${PENDING_DDL_V2}`;
+
 export interface OpenedFinalizationRecoveryDatabase {
   databasePath: string;
   database: DatabaseSync;
@@ -150,20 +186,27 @@ function schemaObjects(database: DatabaseSync): Map<string, string> {
   return new Map(rows.map((row) => [String(row.name), normalizeSql(String(row.sql))]));
 }
 
-function expectedSchema(Database: OwnedSqliteModuleV1['DatabaseSync']): Map<string, string> {
+function expectedSchema(
+  Database: OwnedSqliteModuleV1['DatabaseSync'],
+  ddl: string,
+): Map<string, string> {
   const memory = new Database(':memory:');
   try {
-    memory.exec(DDL);
+    memory.exec(ddl);
     return schemaObjects(memory);
   } finally {
     memory.close();
   }
 }
 
-function verifySchema(database: DatabaseSync, expected: Map<string, string>): void {
+function verifySchema(
+  database: DatabaseSync,
+  expected: Map<string, string>,
+  userVersion = USER_VERSION,
+): void {
   if (
     readPragmaInteger(database, 'application_id') !== APPLICATION_ID
-    || readPragmaInteger(database, 'user_version') !== USER_VERSION
+    || readPragmaInteger(database, 'user_version') !== userVersion
   ) {
     throw new Error('Finalization inbox has a foreign or unsupported database identity');
   }
@@ -231,7 +274,7 @@ function initializeFresh(database: DatabaseSync, path: string): void {
     ) {
       throw new Error('Finalization inbox lost its pristine identity before initialization');
     }
-    database.exec(DDL);
+    database.exec(DDL_V2);
     database.exec(`PRAGMA application_id = ${APPLICATION_ID}`);
     database.exec(`PRAGMA user_version = ${USER_VERSION}`);
     database.exec('COMMIT');
@@ -250,6 +293,31 @@ function initializeFresh(database: DatabaseSync, path: string): void {
   fsyncOwnedSqliteFileAndDirectoryV1(path);
 }
 
+function migrateLegacyV1(database: DatabaseSync, databasePath: string): void {
+  let transactionOpen = false;
+  try {
+    database.exec('BEGIN IMMEDIATE');
+    transactionOpen = true;
+    database.exec(PENDING_DDL_V2);
+    database.exec(`PRAGMA user_version = ${USER_VERSION}`);
+    database.exec('COMMIT');
+    transactionOpen = false;
+  } catch (error) {
+    if (transactionOpen) {
+      try { database.exec('ROLLBACK'); } catch { /* retain migration failure */ }
+    }
+    throw error;
+  }
+  const journalMode = database.prepare('PRAGMA journal_mode').get();
+  if (String(journalMode?.journal_mode).toLowerCase() === 'wal') {
+    const checkpoint = database.prepare('PRAGMA wal_checkpoint(TRUNCATE)').get();
+    if (Number(checkpoint?.busy ?? 1) !== 0) {
+      throw new Error('Finalization inbox v1 migration WAL checkpoint remained busy');
+    }
+  }
+  fsyncOwnedSqliteFileAndDirectoryV1(databasePath);
+}
+
 export async function openFinalizationRecoveryDatabase(
   dataDir: string,
 ): Promise<OpenedFinalizationRecoveryDatabase> {
@@ -257,18 +325,40 @@ export async function openFinalizationRecoveryDatabase(
   const fresh = !existsSync(databasePath);
   const sqlite = await loadOwnedSqliteModuleV1('Durable finalization recovery');
   if (!fresh) {
-    assertOwnedSqliteHeaderIdentityV1(
-      databasePath,
-      APPLICATION_ID,
-      USER_VERSION,
-      'Finalization inbox',
-    );
+    try {
+      assertOwnedSqliteHeaderIdentityV1(
+        databasePath,
+        APPLICATION_ID,
+        USER_VERSION,
+        'Finalization inbox',
+      );
+    } catch {
+      // The main-file header can legitimately lag a committed WAL. Accept
+      // exactly the owned v1 header here, then classify from SQLite's recovered
+      // PRAGMA below after the WAL has been replayed.
+      assertOwnedSqliteHeaderIdentityV1(
+        databasePath,
+        APPLICATION_ID,
+        LEGACY_USER_VERSION,
+        'Finalization inbox',
+      );
+    }
   }
   const database = new sqlite.DatabaseSync(databasePath);
   try {
-    const expected = expectedSchema(sqlite.DatabaseSync);
     if (fresh) initializeFresh(database, databasePath);
-    verifySchema(database, expected);
+    const recoveredVersion = readPragmaInteger(database, 'user_version');
+    if (recoveredVersion === LEGACY_USER_VERSION) {
+      verifySchema(
+        database,
+        expectedSchema(sqlite.DatabaseSync, DDL_V1),
+        LEGACY_USER_VERSION,
+      );
+      migrateLegacyV1(database, databasePath);
+    } else if (recoveredVersion !== USER_VERSION) {
+      throw new Error('Finalization inbox has a foreign or unsupported recovered version');
+    }
+    verifySchema(database, expectedSchema(sqlite.DatabaseSync, DDL_V2));
     applyRuntimePragmas(database);
     secureOwnedSqliteFileSetV1(databasePath, 'Finalization inbox');
     return { databasePath, database };

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -13,6 +13,7 @@ import {
   type FinalizationRecoveryVerifyResult,
 } from './finalization-recovery-store.js';
 import {
+  finalizationEnvelopeFromRow,
   finalizationEnvelopeSha256,
   finalizationRecoveryRowToEntry,
   sameFinalizationRecoveryEvidence,
@@ -23,8 +24,10 @@ import {
 } from './finalization-recovery-sqlite-schema.js';
 import {
   hasFinalizationRecoveryCapacity,
+  hasFinalizationRecoveryDeferredCapacity,
   pruneFinalizationRecoveryRowsWithinTransaction,
   readFinalizationRecoveryCapacity,
+  readFinalizationRecoveryDeferredCapacity,
   resolveFinalizationRecoveryRetentionPolicy,
   type FinalizationRecoveryRetentionPolicy,
   type SqliteFinalizationRecoveryStoreOptions,
@@ -58,6 +61,63 @@ function sameFinalizationRecoveryIdentity(
     && existing.kaId === input.kaId
     && existing.batchId === input.batchId
     && existing.targetContextGraphId === input.targetContextGraphId;
+}
+
+interface PendingFinalizationRow {
+  key: string;
+  chain_id: string;
+  context_graph_id: string;
+  source_peer_id: string | null;
+  trusted_publisher_peer_id: string | null;
+  ual: string;
+  tx_hash: string;
+  assertion_version: string;
+  merkle_root: string;
+  ka_id: string;
+  batch_id: string;
+  target_context_graph_id: string | null;
+  envelope_sha256: string;
+  raw_envelope: Uint8Array;
+  created_at: number;
+  updated_at: number;
+}
+
+function pendingRowToReceiveInput(row: PendingFinalizationRow): FinalizationRecoveryReceiveInput {
+  const { raw } = finalizationEnvelopeFromRow(row as unknown as Record<string, unknown>);
+  return {
+    key: row.key,
+    chainId: row.chain_id,
+    contextGraphId: row.context_graph_id,
+    ...(row.source_peer_id ? { sourcePeerId: row.source_peer_id } : {}),
+    ual: row.ual,
+    txHash: row.tx_hash,
+    assertionVersion: row.assertion_version,
+    merkleRoot: row.merkle_root,
+    kaId: row.ka_id,
+    batchId: row.batch_id,
+    ...(row.target_context_graph_id
+      ? { targetContextGraphId: row.target_context_graph_id }
+      : {}),
+    rawMessage: new Uint8Array(raw),
+  };
+}
+
+function samePendingFinalization(
+  row: PendingFinalizationRow,
+  input: FinalizationRecoveryReceiveInput,
+  digest: string,
+): boolean {
+  return row.envelope_sha256 === digest
+    && Buffer.from(row.raw_envelope).equals(Buffer.from(input.rawMessage))
+    && row.chain_id === input.chainId
+    && row.context_graph_id === input.contextGraphId
+    && row.ual === input.ual
+    && row.tx_hash.toLowerCase() === input.txHash.toLowerCase()
+    && row.assertion_version === input.assertionVersion
+    && row.merkle_root.toLowerCase() === input.merkleRoot.toLowerCase()
+    && row.ka_id === input.kaId
+    && row.batch_id === input.batchId
+    && (row.target_context_graph_id ?? undefined) === input.targetContextGraphId;
 }
 
 export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStore {
@@ -101,6 +161,72 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     return row ? finalizationRecoveryRowToEntry(row) : undefined;
   }
 
+  private insertLiveWithinTransaction(
+    input: FinalizationRecoveryReceiveInput,
+    digest: string,
+    createdAt: number,
+    updatedAt = createdAt,
+    trustedPublisherPeerId?: string,
+  ): void {
+    this.database.prepare(`
+      INSERT INTO finalization_inbox_v1 (
+        key, state, chain_id, context_graph_id, source_peer_id,
+        trusted_publisher_peer_id, ual, tx_hash,
+        assertion_version, merkle_root, ka_id, batch_id, target_context_graph_id,
+        envelope_sha256, raw_envelope, created_at, updated_at
+      ) VALUES (?, 'RECEIVED', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      input.key,
+      input.chainId,
+      input.contextGraphId,
+      input.sourcePeerId ?? null,
+      trustedPublisherPeerId ?? null,
+      input.ual,
+      input.txHash.toLowerCase(),
+      input.assertionVersion,
+      input.merkleRoot.toLowerCase(),
+      input.kaId,
+      input.batchId,
+      input.targetContextGraphId ?? null,
+      digest,
+      Buffer.from(input.rawMessage),
+      createdAt,
+      updatedAt,
+    );
+  }
+
+  private insertPendingWithinTransaction(
+    input: FinalizationRecoveryReceiveInput,
+    digest: string,
+    now: number,
+  ): void {
+    this.database.prepare(`
+      INSERT INTO finalization_pending_v2 (
+        key, chain_id, context_graph_id, source_peer_id,
+        trusted_publisher_peer_id, ual, tx_hash,
+        assertion_version, merkle_root, ka_id, batch_id, target_context_graph_id,
+        envelope_sha256, raw_envelope, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      input.key,
+      input.chainId,
+      input.contextGraphId,
+      input.sourcePeerId ?? null,
+      null,
+      input.ual,
+      input.txHash.toLowerCase(),
+      input.assertionVersion,
+      input.merkleRoot.toLowerCase(),
+      input.kaId,
+      input.batchId,
+      input.targetContextGraphId ?? null,
+      digest,
+      Buffer.from(input.rawMessage),
+      now,
+      now,
+    );
+  }
+
   receive(input: FinalizationRecoveryReceiveInput): Promise<FinalizationRecoveryReceiveResult> {
     if (this.#closed || this.#closing) return Promise.resolve({ status: 'closed' });
     return this.mutate(() => {
@@ -136,40 +262,110 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
         ) return { status: 'conflict' };
         return { status: 'existing', entry: existing };
       }
-      if (!hasFinalizationRecoveryCapacity(this.database, this.#policy, input)) {
-        return { status: 'capacity' };
+      const pendingRow = this.database.prepare(
+        'SELECT * FROM finalization_pending_v2 WHERE key = ?',
+      ).get(input.key) as PendingFinalizationRow | undefined;
+      if (pendingRow) {
+        try {
+          pendingRowToReceiveInput(pendingRow);
+          return samePendingFinalization(pendingRow, input, digest)
+            ? { status: 'pending' }
+            : { status: 'conflict' };
+        } catch {
+          this.database.prepare(
+            'DELETE FROM finalization_pending_v2 WHERE key = ?',
+          ).run(pendingRow.key);
+          return { status: 'conflict' };
+        }
       }
       const now = this.#policy.now();
+      if (!hasFinalizationRecoveryCapacity(this.database, this.#policy, input)) {
+        if (!hasFinalizationRecoveryDeferredCapacity(this.database, this.#policy, input)) {
+          return { status: 'capacity' };
+        }
+        this.transaction(() => {
+          this.insertPendingWithinTransaction(input, digest, now);
+        });
+        return { status: 'pending' };
+      }
       this.transaction(() => {
-        this.database.prepare(`
-          INSERT INTO finalization_inbox_v1 (
-            key, state, chain_id, context_graph_id, source_peer_id, ual, tx_hash,
-            assertion_version, merkle_root, ka_id, batch_id, target_context_graph_id,
-            envelope_sha256, raw_envelope, created_at, updated_at
-          ) VALUES (?, 'RECEIVED', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `).run(
-          input.key,
-          input.chainId,
-          input.contextGraphId,
-          input.sourcePeerId ?? null,
-          input.ual,
-          input.txHash.toLowerCase(),
-          input.assertionVersion,
-          input.merkleRoot.toLowerCase(),
-          input.kaId,
-          input.batchId,
-          input.targetContextGraphId ?? null,
-          digest,
-          Buffer.from(input.rawMessage),
-          now,
-          now,
-        );
+        this.insertLiveWithinTransaction(input, digest, now);
       });
       const row = this.database.prepare(
         'SELECT * FROM finalization_inbox_v1 WHERE key = ?',
       ).get(input.key);
       if (!row) throw new Error('Finalization inbox insert returned no row');
       return { status: 'inserted', entry: finalizationRecoveryRowToEntry(row) };
+    });
+  }
+
+  promotePending(limit: number): Promise<number> {
+    if (this.#closed || this.#closing) return Promise.resolve(0);
+    const boundedLimit = Math.max(1, Math.trunc(limit));
+    return this.mutate(() => {
+      if (this.#closed) return 0;
+      let promoted = 0;
+      this.transaction(() => {
+        const now = this.#policy.now();
+        this.pruneWithinTransaction(now);
+        const rows = this.database.prepare(`
+          SELECT * FROM finalization_pending_v2
+          ORDER BY created_at ASC, key ASC
+          LIMIT ?
+        `).all(this.#policy.maxDeferredEntries) as unknown as PendingFinalizationRow[];
+        for (const row of rows) {
+          if (promoted >= boundedLimit) break;
+          let input: FinalizationRecoveryReceiveInput;
+          try {
+            input = pendingRowToReceiveInput(row);
+          } catch {
+            this.database.prepare(
+              'DELETE FROM finalization_pending_v2 WHERE key = ?',
+            ).run(row.key);
+            continue;
+          }
+          if (!hasFinalizationRecoveryCapacity(this.database, this.#policy, input)) {
+            continue;
+          }
+          this.insertLiveWithinTransaction(
+            input,
+            row.envelope_sha256,
+            row.created_at,
+            now,
+            row.trusted_publisher_peer_id ?? undefined,
+          );
+          this.database.prepare(
+            'DELETE FROM finalization_pending_v2 WHERE key = ?',
+          ).run(row.key);
+          promoted += 1;
+        }
+      });
+      return promoted;
+    });
+  }
+
+  recordPendingTrustedPublisher(
+    key: string,
+    publisherPeerId: string,
+  ): Promise<boolean> {
+    if (
+      this.#closed
+      || this.#closing
+      || publisherPeerId.length === 0
+      || publisherPeerId.trim() !== publisherPeerId
+    ) return Promise.resolve(false);
+    return this.mutate(() => {
+      if (this.#closed) return false;
+      const result = this.database.prepare(`
+        UPDATE finalization_pending_v2
+        SET trusted_publisher_peer_id = ?, updated_at = ?
+        WHERE key = ?
+          AND (
+            trusted_publisher_peer_id IS NULL
+            OR trusted_publisher_peer_id = ?
+          )
+      `).run(publisherPeerId, this.#policy.now(), key, publisherPeerId);
+      return result.changes > 0;
     });
   }
 
@@ -596,6 +792,7 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
       WHERE ${DUE_FINALIZATION_SQL_PREDICATE}
     `).get(now) as { count: number | bigint; oldest: number | bigint | null };
     const capacity = readFinalizationRecoveryCapacity(this.database, this.#policy);
+    const deferred = readFinalizationRecoveryDeferredCapacity(this.database);
     return {
       available: true,
       closed: false,
@@ -604,12 +801,17 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
       stateCounts,
       livePayloadBytes: capacity.livePayloadBytes,
       dueEntries: Number(due.count),
+      deferredEntries: deferred.entries,
+      deferredPayloadBytes: deferred.payloadBytes,
       ...(due.oldest === null
         ? {}
         : { oldestDueAgeMs: Math.max(0, now - Number(due.oldest)) }),
       ...(capacity.oldest === undefined
         ? {}
         : { oldestPendingAgeMs: Math.max(0, now - capacity.oldest) }),
+      ...(deferred.oldest === undefined
+        ? {}
+        : { oldestDeferredAgeMs: Math.max(0, now - deferred.oldest) }),
     };
   }
 

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -57,6 +57,7 @@ export interface FinalizationRecoveryReceiveInput {
 export type FinalizationRecoveryReceiveResult =
   | { status: 'inserted'; entry: FinalizationRecoveryEntry }
   | { status: 'existing'; entry: FinalizationRecoveryEntry }
+  | { status: 'pending' }
   | { status: 'conflict' }
   | { status: 'capacity' }
   | { status: 'closed' };
@@ -81,8 +82,11 @@ export interface FinalizationRecoveryHealth {
   stateCounts: Partial<Record<FinalizationRecoveryState, number>>;
   livePayloadBytes: number;
   dueEntries: number;
+  deferredEntries?: number;
+  deferredPayloadBytes?: number;
   oldestDueAgeMs?: number;
   oldestPendingAgeMs?: number;
+  oldestDeferredAgeMs?: number;
 }
 
 export interface FinalizationRecoveryStore {
@@ -90,6 +94,13 @@ export interface FinalizationRecoveryStore {
   /** Reloads one entry after waiting on an in-process serialization boundary. */
   get(key: string): Promise<FinalizationRecoveryEntry | undefined>;
   receive(input: FinalizationRecoveryReceiveInput): Promise<FinalizationRecoveryReceiveResult>;
+  /** Moves a bounded oldest-first deferred snapshot into the live inbox. */
+  promotePending(limit: number): Promise<number>;
+  /** Monotonically records publisher authority validated while an envelope is deferred. */
+  recordPendingTrustedPublisher(
+    key: string,
+    publisherPeerId: string,
+  ): Promise<boolean>;
   recordTrustedPublisher(
     key: string,
     generation: number,

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -36,6 +36,27 @@ export interface FinalizationRecoveryLiveInput {
   candidate: ParsedGraphScopedFinalization;
 }
 
+export type FinalizationRecoveryLiveProcessResult =
+  | { status: 'fallback' }
+  | { status: 'handled' }
+  | { status: 'retryable-capacity'; ual: string };
+
+export class FinalizationRecoveryCapacityError extends Error {
+  readonly code = 'FINALIZATION_RECOVERY_CAPACITY';
+  readonly retryable = true;
+
+  constructor(readonly ual: string) {
+    super(`Finalization recovery durable capacity exhausted for ${ual}`);
+    this.name = 'FinalizationRecoveryCapacityError';
+  }
+}
+
+type FinalizationRecoveryReceiveOutcome =
+  | { status: 'entry'; entry: FinalizationRecoveryEntry }
+  | { status: 'pending' }
+  | { status: 'capacity' }
+  | { status: 'rejected' };
+
 export type FinalizationRecoveryLiveAdmission =
   | {
     status: 'admitted';
@@ -275,12 +296,31 @@ export class FinalizationRecovery<
 
   /**
    * Applies a live graph-scoped finalization behind the durable write-ahead
-   * boundary. Returns false when durable recovery is unavailable so the caller
-   * can preserve the legacy live-verification path.
+   * boundary. Preserves the original boolean contract for external callers:
+   * false means the caller must run the unjournaled compatibility path.
    */
   async processLive(
     input: FinalizationRecoveryLiveInput,
   ): Promise<boolean> {
+    const result = await this.processLiveOutcome(input);
+    switch (result.status) {
+      case 'fallback':
+        return false;
+      case 'handled':
+        return true;
+      case 'retryable-capacity':
+        throw new FinalizationRecoveryCapacityError(result.ual);
+      default: {
+        const exhaustive: never = result;
+        throw new Error(`Unhandled finalization recovery result: ${JSON.stringify(exhaustive)}`);
+      }
+    }
+  }
+
+  /** Structured result used by internal callers that must distinguish capacity. */
+  async processLiveOutcome(
+    input: FinalizationRecoveryLiveInput,
+  ): Promise<FinalizationRecoveryLiveProcessResult> {
     const store = this.getStore();
     // The receipt API is intentionally optional on ChainAdapter. Preserve the
     // legacy live path when it is absent instead of admitting an envelope that
@@ -290,7 +330,7 @@ export class FinalizationRecovery<
       || !this.chain
       || this.chain.chainId === 'none'
       || !this.chain.resolveCanonicalFinalizationReceipt
-    ) return false;
+    ) return { status: 'fallback' };
     const key = finalizationRecoveryEntryKey({
       chainId: this.chain.chainId,
       contextGraphId: input.contextGraphId,
@@ -298,18 +338,31 @@ export class FinalizationRecovery<
       txHash: input.candidate.msg.txHash,
     });
     return this.withEntryLock(key, async () => {
-      let entry = await this.receive(input);
-      // A configured inbox fails closed: capacity, conflict, corruption, and
-      // write failures leave Oxigraph untouched.
-      if (!entry) return true;
+      const received = await this.receiveOutcome(input);
+      if (received.status === 'pending') {
+        await this.recordPendingPublisherAuthority(store, key, input);
+        return { status: 'handled' };
+      }
+      if (received.status === 'capacity') {
+        return {
+          status: 'retryable-capacity',
+          ual: input.candidate.scope.ual,
+        };
+      }
+      // Conflicts, corruption, and write failures fail closed and leave
+      // Oxigraph untouched. Capacity is handled separately above because it is
+      // retryable and must never look successfully consumed.
+      if (received.status === 'rejected') return { status: 'handled' };
+      let { entry } = received;
       if (entry.state === 'SETTLED') {
-        entry = await this.revalidateSettled(input, entry);
-        if (!entry) return true;
+        const revalidated = await this.revalidateSettled(input, entry);
+        if (!revalidated) return { status: 'handled' };
+        entry = revalidated;
       }
       // Terminal rows remain audited and inert until retention removes them.
       // In particular, duplicate gossip must not revive an entry that exhausted
       // the autonomous retry budget.
-      if (!this.isLiveEntry(entry)) return true;
+      if (!this.isLiveEntry(entry)) return { status: 'handled' };
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         try {
@@ -322,7 +375,7 @@ export class FinalizationRecovery<
           } else {
             await this.settleEntry(entry, outcome);
           }
-          return true;
+          return { status: 'handled' };
         } catch (error) {
           if (!this.materializer.isRetryableError(error)) throw error;
           if (attempt === 0) {
@@ -337,11 +390,57 @@ export class FinalizationRecovery<
             entry,
             'store scheduler remained busy',
           );
-          return true;
+          return { status: 'handled' };
         }
       }
-      return true;
+      return { status: 'handled' };
     });
+  }
+
+  private async recordPendingPublisherAuthority(
+    store: FinalizationRecoveryStore,
+    key: string,
+    input: FinalizationRecoveryLiveInput,
+  ): Promise<void> {
+    if (!input.sourcePeerId) return;
+    let prepared: Prepared | undefined;
+    try {
+      prepared = await this.materializer.prepare(input);
+    } catch (error) {
+      this.log.info(
+        `Finalization recovery deferred publisher authority check for `
+          + `${input.candidate.scope.ual}: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+      return;
+    }
+    if (!prepared || input.sourcePeerId !== prepared.publisherPeerId) return;
+    try {
+      if (await store.recordPendingTrustedPublisher(key, prepared.publisherPeerId)) return;
+      // Promotion is serialized by the store but is intentionally independent
+      // of the per-entry recovery lock. If it moved this row between admission
+      // and the authority CAS, preserve the same monotonic evidence on the live row.
+      const promoted = await store.get(key);
+      if (
+        promoted
+        && this.isLiveEntry(promoted)
+        && await store.recordTrustedPublisher(
+          key,
+          promoted.generation,
+          prepared.publisherPeerId,
+        )
+      ) return;
+      this.log.warn(
+        `Finalization recovery inbox refused publisher authority for `
+          + `${input.candidate.scope.ual}`,
+      );
+    } catch (error) {
+      this.log.warn(
+        `Finalization recovery pending publisher authority commit failed for `
+          + `${input.candidate.scope.ual}: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   /**
@@ -354,6 +453,15 @@ export class FinalizationRecovery<
     if (!store) return 0;
     try {
       if (!this.chain || this.chain.chainId === 'none') return 0;
+      let promoted = 0;
+      try {
+        promoted = await store.promotePending(limit);
+      } catch (error) {
+        this.log.warn(
+          `Finalization recovery deferred-inbox promotion failed: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
       let entries: FinalizationRecoveryEntry[];
       try {
         entries = await store.listDue(limit);
@@ -382,7 +490,7 @@ export class FinalizationRecovery<
         }
         getMetrics().finalizationRecoveryAttemptsTotal?.add(1, { outcome });
       }
-      return entries.length;
+      return Math.max(entries.length, promoted);
     } finally {
       await this.recordDueMetrics(store);
     }
@@ -394,6 +502,7 @@ export class FinalizationRecovery<
       const metrics = getMetrics();
       metrics.finalizationRecoveryDueEntries?.record(health.dueEntries);
       metrics.finalizationRecoveryOldestDueAgeMs?.record(health.oldestDueAgeMs ?? 0);
+      metrics.finalizationRecoveryDeferredEntries?.record(health.deferredEntries ?? 0);
     } catch (error) {
       this.log.warn(
         `Finalization recovery metrics snapshot failed: `
@@ -540,8 +649,15 @@ export class FinalizationRecovery<
   async receive(
     input: FinalizationRecoveryLiveInput,
   ): Promise<FinalizationRecoveryEntry | undefined> {
+    const outcome = await this.receiveOutcome(input);
+    return outcome.status === 'entry' ? outcome.entry : undefined;
+  }
+
+  private async receiveOutcome(
+    input: FinalizationRecoveryLiveInput,
+  ): Promise<FinalizationRecoveryReceiveOutcome> {
     const store = this.getStore();
-    if (!store) return undefined;
+    if (!store) return { status: 'rejected' };
     const { candidate } = input;
     const key = finalizationRecoveryEntryKey({
       chainId: this.chain?.chainId ?? 'none',
@@ -578,7 +694,8 @@ export class FinalizationRecovery<
             `Finalization recovery inbox rejected changed immutable envelope for `
               + `${candidate.scope.ual}`,
           );
-          return undefined;
+          getMetrics().finalizationRecoveryAdmissionTotal?.add(1, { outcome: 'conflict' });
+          return { status: 'rejected' };
         }
         if (
           result.entry.state === 'RECEIVED'
@@ -586,20 +703,37 @@ export class FinalizationRecovery<
           || result.entry.state === 'REORGED'
           || result.entry.state === 'SETTLED'
         ) {
-          return result.entry;
+          getMetrics().finalizationRecoveryAdmissionTotal?.add(1, {
+            outcome: result.status,
+          });
+          return { status: 'entry', entry: result.entry };
         }
-        return undefined;
+        getMetrics().finalizationRecoveryAdmissionTotal?.add(1, { outcome: 'conflict' });
+        return { status: 'rejected' };
+      }
+      if (result.status === 'pending') {
+        getMetrics().finalizationRecoveryAdmissionTotal?.add(1, { outcome: 'deferred' });
+        this.log.info(
+          `Finalization recovery deferred ${candidate.scope.ual} until live inbox capacity is available`,
+        );
+        return { status: 'pending' };
       }
       this.log.warn(
         `Finalization recovery inbox rejected ${candidate.scope.ual}: ${result.status}`,
       );
-      return undefined;
+      getMetrics().finalizationRecoveryAdmissionTotal?.add(1, {
+        outcome: result.status,
+      });
+      return result.status === 'capacity'
+        ? { status: 'capacity' }
+        : { status: 'rejected' };
     } catch (error) {
       this.log.warn(
         `Finalization recovery inbox write failed for ${candidate.scope.ual}: `
           + `${error instanceof Error ? error.message : String(error)}`,
       );
-      return undefined;
+      getMetrics().finalizationRecoveryAdmissionTotal?.add(1, { outcome: 'write-failure' });
+      return { status: 'rejected' };
     }
   }
 

--- a/packages/agent/test/finalization-recovery-sqlite-deferred.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-deferred.test.ts
@@ -1,0 +1,360 @@
+import { rm } from 'node:fs/promises';
+import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
+import {
+  openSqliteFinalizationRecoveryStore,
+} from '../src/finalization-recovery-sqlite-store.js';
+import {
+  RAW,
+  evidence,
+  received,
+  temporaryDirectory,
+} from './finalization-recovery-sqlite-test-helpers.js';
+
+describe('SQLite finalization recovery deferred spool', () => {
+  it('preserves a deferred envelope across reopen and promotes it later', async () => {
+    const directory = await temporaryDirectory();
+    let store: Awaited<ReturnType<typeof openSqliteFinalizationRecoveryStore>> | undefined;
+    try {
+      store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
+      await store.receive(received());
+      await expect(store.receive(received({
+        key: 'entry-2',
+        txHash: `0x${'ef'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+      await store.close();
+
+      store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
+      expect(await store.health()).toMatchObject({ deferredEntries: 1 });
+      await store.transition('entry-1', 0, 'SUPERSEDED');
+      await expect(store.promotePending(1)).resolves.toBe(1);
+      expect(await store.get('entry-2')).toMatchObject({
+        key: 'entry-2',
+        state: 'RECEIVED',
+        txHash: `0x${'ef'.repeat(32)}`,
+      });
+      expect(await store.health()).toMatchObject({ deferredEntries: 0 });
+      await store.close();
+      store = undefined;
+    } finally {
+      await store?.close().catch(() => {});
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('drops a corrupt deferred envelope instead of poisoning the live inbox', async () => {
+    const directory = await temporaryDirectory();
+    let store: Awaited<ReturnType<typeof openSqliteFinalizationRecoveryStore>> | undefined;
+    try {
+      store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
+      await store.receive(received());
+      await expect(store.receive(received({
+        key: 'entry-2',
+        txHash: `0x${'ef'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+      const { databasePath } = store;
+      await store.close();
+
+      const database = new DatabaseSync(databasePath);
+      database.prepare(`
+        UPDATE finalization_pending_v2 SET raw_envelope = ? WHERE key = ?
+      `).run(Buffer.from([9, 9, 9]), 'entry-2');
+      database.close();
+
+      store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
+      await store.transition('entry-1', 0, 'SUPERSEDED');
+      await expect(store.promotePending(1)).resolves.toBe(0);
+      await expect(store.get('entry-2')).resolves.toBeUndefined();
+      await expect(store.health()).resolves.toMatchObject({ deferredEntries: 0 });
+    } finally {
+      await store?.close().catch(() => {});
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('durably defers a new envelope when live capacity is full', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
+      await store.receive(received());
+      await store.markVerified('entry-1', 0, evidence());
+      await expect(store.receive(received({
+        key: 'entry-2',
+        txHash: `0x${'ef'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+      expect(await store.list()).toMatchObject([{ key: 'entry-1', state: 'VERIFIED' }]);
+      expect(await store.health()).toMatchObject({
+        available: true,
+        ready: false,
+        degradedReason: 'capacity-exhausted',
+        deferredEntries: 1,
+      });
+
+      await store.transition('entry-1', 0, 'SETTLED');
+      await expect(store.promotePending(16)).resolves.toBe(1);
+      expect(await store.list()).toEqual(expect.arrayContaining([
+        expect.objectContaining({ key: 'entry-2', state: 'RECEIVED' }),
+      ]));
+      expect(await store.health()).toMatchObject({ deferredEntries: 0 });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps pending duplicate admission idempotent and rejects conflicting replacements', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
+      await store.receive(received());
+      const pending = received({
+        key: 'entry-2',
+        txHash: `0x${'ef'.repeat(32)}`,
+      });
+      await expect(store.receive(pending)).resolves.toEqual({ status: 'pending' });
+      await expect(store.receive(pending)).resolves.toEqual({ status: 'pending' });
+      await expect(store.receive(received({
+        ...pending,
+        rawMessage: Uint8Array.from([9, 9, 9]),
+      }))).resolves.toEqual({ status: 'conflict' });
+      await expect(store.receive(received({
+        ...pending,
+        txHash: `0x${'12'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'conflict' });
+
+      await store.transition('entry-1', 0, 'SUPERSEDED');
+      await expect(store.promotePending(1)).resolves.toBe(1);
+      await expect(store.get('entry-2')).resolves.toMatchObject({
+        txHash: `0x${'ef'.repeat(32)}`,
+        rawMessage: RAW,
+      });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('enforces the global deferred-entry quota independently', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 1,
+        maxDeferredEntries: 1,
+        maxDeferredPerPeer: 10,
+        maxDeferredPerContextGraph: 10,
+      });
+      await store.receive(received());
+      await expect(store.receive(received({
+        key: 'entry-2',
+        txHash: `0x${'ef'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+      await expect(store.receive(received({
+        key: 'entry-3',
+        contextGraphId: 'other-graph',
+        sourcePeerId: '12D3KooWOtherPublisher',
+        txHash: `0x${'12'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'capacity' });
+      expect(await store.health()).toMatchObject({ deferredEntries: 1 });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('enforces the per-peer deferred quota independently', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 1,
+        maxDeferredEntries: 10,
+        maxDeferredPerPeer: 1,
+        maxDeferredPerContextGraph: 10,
+      });
+      await store.receive(received());
+      await expect(store.receive(received({
+        key: 'entry-2',
+        contextGraphId: 'graph-2',
+        txHash: `0x${'ef'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+      await expect(store.receive(received({
+        key: 'entry-3',
+        contextGraphId: 'graph-3',
+        txHash: `0x${'12'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'capacity' });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('enforces the per-context-graph deferred quota independently', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 1,
+        maxDeferredEntries: 10,
+        maxDeferredPerPeer: 10,
+        maxDeferredPerContextGraph: 1,
+      });
+      await store.receive(received());
+      await expect(store.receive(received({
+        key: 'entry-2',
+        txHash: `0x${'ef'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+      await expect(store.receive(received({
+        key: 'entry-3',
+        sourcePeerId: '12D3KooWOtherPublisher',
+        txHash: `0x${'12'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'capacity' });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('enforces the deferred-byte quota independently', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 1,
+        maxDeferredEntries: 10,
+        maxDeferredBytes: 6,
+        maxDeferredPerPeer: 10,
+        maxDeferredPerContextGraph: 10,
+      });
+      await store.receive(received());
+      await expect(store.receive(received({
+        key: 'entry-2',
+        txHash: `0x${'ef'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+      await expect(store.receive(received({
+        key: 'entry-3',
+        contextGraphId: 'graph-3',
+        sourcePeerId: '12D3KooWOtherPublisher',
+        txHash: `0x${'12'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'capacity' });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('does not let a quota-blocked oldest graph starve a later eligible graph', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 2,
+        maxPerPeer: 8,
+        maxPerContextGraph: 1,
+      });
+      await store.receive(received({
+        key: 'live-graph-a',
+        contextGraphId: 'graph-a',
+        txHash: `0x${'a1'.repeat(32)}`,
+      }));
+      await store.receive(received({
+        key: 'live-graph-x',
+        contextGraphId: 'graph-x',
+        txHash: `0x${'a2'.repeat(32)}`,
+      }));
+      await expect(store.receive(received({
+        key: 'pending-graph-a',
+        contextGraphId: 'graph-a',
+        txHash: `0x${'b1'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+      await expect(store.receive(received({
+        key: 'pending-graph-b',
+        contextGraphId: 'graph-b',
+        txHash: `0x${'b2'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+
+      await store.transition('live-graph-x', 0, 'SUPERSEDED');
+      await expect(store.promotePending(1)).resolves.toBe(1);
+      expect(await store.get('pending-graph-b')).toMatchObject({
+        key: 'pending-graph-b',
+        state: 'RECEIVED',
+      });
+      expect(await store.get('pending-graph-a')).toBeUndefined();
+      expect(await store.health()).toMatchObject({ deferredEntries: 1 });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts the 129th envelope durably and promotes it after the 128-entry backlog drains', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 128,
+        maxPerPeer: 128,
+        maxPerContextGraph: 128,
+      });
+      for (let index = 0; index < 128; index += 1) {
+        await expect(store.receive(received({
+          key: `entry-${index}`,
+          txHash: `0x${index.toString(16).padStart(64, '0')}`,
+          kaId: String(index),
+        }))).resolves.toMatchObject({ status: 'inserted' });
+      }
+      const overflow = received({
+        key: 'entry-128',
+        txHash: `0x${'ff'.repeat(32)}`,
+        kaId: '128',
+      });
+      await expect(store.receive(overflow)).resolves.toEqual({ status: 'pending' });
+      expect(await store.health()).toMatchObject({
+        deferredEntries: 1,
+        dueEntries: 128,
+      });
+
+      await store.transition('entry-0', 0, 'SUPERSEDED');
+      await expect(store.promotePending(16)).resolves.toBe(1);
+      expect(await store.get('entry-128')).toMatchObject({
+        state: 'RECEIVED',
+        kaId: '128',
+      });
+      expect(await store.health()).toMatchObject({ deferredEntries: 0 });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('expires stale deferred envelopes while preserving VERIFIED live evidence', async () => {
+    const directory = await temporaryDirectory();
+    let now = 1_000;
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 1,
+        maxDeferredEntries: 1,
+        rawTtlMs: 100,
+        now: () => now,
+      });
+      await store.receive(received());
+      await store.markVerified('entry-1', 0, evidence());
+      await expect(store.receive(received({
+        key: 'stale-pending',
+        txHash: `0x${'ef'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+
+      now += 101;
+      await expect(store.receive(received({
+        key: 'fresh-pending',
+        contextGraphId: 'fresh-graph',
+        sourcePeerId: '12D3KooWFreshPublisher',
+        txHash: `0x${'12'.repeat(32)}`,
+      }))).resolves.toEqual({ status: 'pending' });
+
+      expect(await store.list()).toMatchObject([{ key: 'entry-1', state: 'VERIFIED' }]);
+      expect(await store.health()).toMatchObject({
+        deferredEntries: 1,
+        deferredPayloadBytes: RAW.byteLength,
+      });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+});

--- a/packages/agent/test/finalization-recovery-sqlite-migration.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-migration.test.ts
@@ -1,0 +1,188 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
+import {
+  openSqliteFinalizationRecoveryStore,
+} from '../src/finalization-recovery-sqlite-store.js';
+import {
+  FINALIZATION_INBOX_DATABASE_FILENAME,
+} from '../src/finalization-recovery-store.js';
+import {
+  RAW,
+  TX_HASH,
+  received,
+  temporaryDirectory,
+} from './finalization-recovery-sqlite-test-helpers.js';
+
+async function killChildAfterReady(script: string, path: string, label: string): Promise<void> {
+  const child = spawn(process.execPath, ['--experimental-sqlite', '-e', script], {
+    env: { ...process.env, DKG_FINALIZATION_INBOX_PATH: path },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+  await new Promise<void>((resolveReady, rejectReady) => {
+    let stdout = '';
+    const timeout = setTimeout(
+      () => rejectReady(new Error(`finalization inbox ${label} child timed out: ${stderr}`)),
+      10_000,
+    );
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (!stdout.includes('READY\n')) return;
+      clearTimeout(timeout);
+      resolveReady();
+    });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      rejectReady(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      rejectReady(new Error(
+        `finalization inbox ${label} child exited early: code=${code} signal=${signal} ${stderr}`,
+      ));
+    });
+  });
+  const exit = new Promise<void>((resolveExit) => child.once('exit', () => resolveExit()));
+  child.kill('SIGKILL');
+  await exit;
+}
+
+async function leaveCommittedReceivedInCrashedWal(path: string): Promise<void> {
+  const script = String.raw`
+const { createHash } = require('node:crypto');
+const { DatabaseSync } = require('node:sqlite');
+const path = process.env.DKG_FINALIZATION_INBOX_PATH;
+const raw = Buffer.from([1, 2, 3, 4]);
+const digest = createHash('sha256').update(raw).digest('hex');
+const database = new DatabaseSync(path);
+database.exec('PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA wal_autocheckpoint=0');
+database.prepare(
+  "INSERT INTO finalization_inbox_v1 (key,state,chain_id,context_graph_id,ual,tx_hash,"
+  + "assertion_version,merkle_root,ka_id,batch_id,envelope_sha256,raw_envelope,created_at,updated_at)"
+  + " VALUES (?,'RECEIVED',?,?,?,?,?,?,?,?,?,?,?,?)"
+).run(
+  'crash-entry', 'base:84532', 'graph',
+  'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7',
+  '${TX_HASH}', '1', '0x${'01'.repeat(32)}', '7', '7', digest, raw, 1, 1
+);
+process.stdout.write('READY\n');
+setInterval(() => {}, 60_000);
+`;
+  await killChildAfterReady(script, path, 'crash');
+}
+
+async function leaveCommittedV2MigrationInCrashedWal(path: string): Promise<void> {
+  const script = String.raw`
+const { DatabaseSync } = require('node:sqlite');
+const path = process.env.DKG_FINALIZATION_INBOX_PATH;
+const database = new DatabaseSync(path);
+database.exec('PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA wal_autocheckpoint=0');
+database.exec(
+  "BEGIN IMMEDIATE;"
+  + "CREATE TABLE finalization_pending_v2 ("
+  + "key TEXT PRIMARY KEY NOT NULL,chain_id TEXT NOT NULL,context_graph_id TEXT NOT NULL,"
+  + "source_peer_id TEXT,trusted_publisher_peer_id TEXT,ual TEXT NOT NULL,"
+  + "tx_hash TEXT NOT NULL,assertion_version TEXT NOT NULL,"
+  + "merkle_root TEXT NOT NULL,ka_id TEXT NOT NULL,batch_id TEXT NOT NULL,"
+  + "target_context_graph_id TEXT,envelope_sha256 TEXT NOT NULL,raw_envelope BLOB NOT NULL,"
+  + "created_at INTEGER NOT NULL,updated_at INTEGER NOT NULL) STRICT;"
+  + "CREATE INDEX finalization_pending_time_v2 ON finalization_pending_v2(created_at,key);"
+  + "CREATE INDEX finalization_pending_graph_v2 ON finalization_pending_v2(context_graph_id,created_at);"
+  + "CREATE INDEX finalization_pending_peer_v2 ON finalization_pending_v2(source_peer_id,created_at);"
+  + "PRAGMA user_version=2;COMMIT;"
+);
+process.stdout.write('READY\n');
+setInterval(() => {}, 60_000);
+`;
+  await killChildAfterReady(script, path, 'migration');
+}
+
+async function makeDatabaseV1(databasePath: string): Promise<void> {
+  const initial = await openSqliteFinalizationRecoveryStore(dirname(databasePath));
+  await initial.receive(received());
+  await initial.close();
+
+  const legacy = new DatabaseSync(databasePath);
+  legacy.exec(`
+    DROP INDEX finalization_pending_peer_v2;
+    DROP INDEX finalization_pending_graph_v2;
+    DROP INDEX finalization_pending_time_v2;
+    DROP TABLE finalization_pending_v2;
+    PRAGMA user_version = 1;
+  `);
+  legacy.close();
+}
+
+describe('SQLite finalization recovery migration and crash recovery', () => {
+  it('migrates a v1 inbox in place without losing accepted entries', async () => {
+    const directory = await temporaryDirectory();
+    const databasePath = join(directory, FINALIZATION_INBOX_DATABASE_FILENAME);
+    try {
+      await makeDatabaseV1(databasePath);
+
+      const migrated = await openSqliteFinalizationRecoveryStore(directory);
+      expect(await migrated.list()).toMatchObject([{ key: 'entry-1', state: 'RECEIVED' }]);
+      const schema = new DatabaseSync(databasePath, { readOnly: true });
+      expect(schema.prepare('PRAGMA user_version').get()?.user_version).toBe(2);
+      expect(schema.prepare(
+        "SELECT name FROM sqlite_schema WHERE name = 'finalization_pending_v2'",
+      ).get()?.name).toBe('finalization_pending_v2');
+      schema.close();
+      await migrated.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers a committed v2 migration when the main header still says v1', async () => {
+    const directory = await temporaryDirectory();
+    const databasePath = join(directory, FINALIZATION_INBOX_DATABASE_FILENAME);
+    try {
+      await makeDatabaseV1(databasePath);
+      await leaveCommittedV2MigrationInCrashedWal(databasePath);
+      expect(existsSync(`${databasePath}-wal`)).toBe(true);
+      expect((await readFile(databasePath)).readUInt32BE(60)).toBe(1);
+
+      const recovered = await openSqliteFinalizationRecoveryStore(directory);
+      expect(await recovered.list()).toMatchObject([{ key: 'entry-1', state: 'RECEIVED' }]);
+      const schema = new DatabaseSync(databasePath, { readOnly: true });
+      expect(schema.prepare('PRAGMA user_version').get()?.user_version).toBe(2);
+      expect(schema.prepare(
+        "SELECT name FROM sqlite_schema WHERE name = 'finalization_pending_v2'",
+      ).get()?.name).toBe('finalization_pending_v2');
+      schema.close();
+      await recovered.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers a committed RECEIVED row after a process crash with a hot WAL', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const initial = await openSqliteFinalizationRecoveryStore(directory);
+      const path = initial.databasePath;
+      await initial.close();
+
+      await leaveCommittedReceivedInCrashedWal(path);
+      expect(existsSync(`${path}-wal`)).toBe(true);
+
+      const recovered = await openSqliteFinalizationRecoveryStore(directory);
+      expect(await recovered.list()).toMatchObject([{
+        key: 'crash-entry',
+        state: 'RECEIVED',
+        rawMessage: RAW,
+      }]);
+      await recovered.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent/test/finalization-recovery-sqlite-store.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-store.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { spawn } from 'node:child_process';
-import { mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import {
@@ -11,113 +8,13 @@ import {
 import {
   FINALIZATION_INBOX_DATABASE_FILENAME,
 } from '../src/finalization-recovery-store.js';
-import type {
-  VerifiedGraphScopedFinalizationEvidence,
-} from '../src/finalization-graph-envelope.js';
-
-const TX_HASH = `0x${'ab'.repeat(32)}`;
-const BLOCK_HASH = `0x${'cd'.repeat(32)}`;
-const RAW = Uint8Array.from([1, 2, 3, 4]);
-
-function received(overrides: Record<string, unknown> = {}) {
-  return {
-    key: 'entry-1',
-    chainId: 'base:84532',
-    contextGraphId: 'graph',
-    sourcePeerId: '12D3KooWPublisher',
-    ual: 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7',
-    txHash: TX_HASH,
-    assertionVersion: '1',
-    merkleRoot: `0x${'01'.repeat(32)}`,
-    kaId: '7',
-    batchId: '7',
-    targetContextGraphId: '42',
-    rawMessage: RAW,
-    ...overrides,
-  };
-}
-
-function evidence(
-  overrides: Partial<VerifiedGraphScopedFinalizationEvidence> = {},
-): VerifiedGraphScopedFinalizationEvidence {
-  return {
-    assertionVersion: '1',
-    publicTripleCount: 2,
-    privateTripleCount: 0,
-    publicQuadsDigest: `sha256:${'02'.repeat(32)}`,
-    publisherPeerId: '12D3KooWPublisher',
-    publisherAddress: '0x2222222222222222222222222222222222222222',
-    transactionHash: TX_HASH,
-    blockNumber: 123,
-    blockHash: BLOCK_HASH,
-    txIndex: 4,
-    authorAddress: '0x1111111111111111111111111111111111111111',
-    accessPolicy: 'ownerOnly',
-    allowedPeers: [],
-    ...overrides,
-  };
-}
-
-async function temporaryDirectory(): Promise<string> {
-  return mkdtemp(join(tmpdir(), 'dkg-finalization-inbox-'));
-}
-
-async function leaveCommittedReceivedInCrashedWal(path: string): Promise<void> {
-  const script = String.raw`
-const { createHash } = require('node:crypto');
-const { DatabaseSync } = require('node:sqlite');
-const path = process.env.DKG_FINALIZATION_INBOX_PATH;
-const raw = Buffer.from([1, 2, 3, 4]);
-const digest = createHash('sha256').update(raw).digest('hex');
-const database = new DatabaseSync(path);
-database.exec('PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA wal_autocheckpoint=0');
-database.prepare(
-  "INSERT INTO finalization_inbox_v1 (key,state,chain_id,context_graph_id,ual,tx_hash,"
-  + "assertion_version,merkle_root,ka_id,batch_id,envelope_sha256,raw_envelope,created_at,updated_at)"
-  + " VALUES (?,'RECEIVED',?,?,?,?,?,?,?,?,?,?,?,?)"
-).run(
-  'crash-entry', 'base:84532', 'graph',
-  'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7',
-  '${TX_HASH}', '1', '0x${'01'.repeat(32)}', '7', '7', digest, raw, 1, 1
-);
-process.stdout.write('READY\n');
-setInterval(() => {}, 60_000);
-`;
-  const child = spawn(process.execPath, ['--experimental-sqlite', '-e', script], {
-    env: { ...process.env, DKG_FINALIZATION_INBOX_PATH: path },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  let stderr = '';
-  child.stderr.setEncoding('utf8');
-  child.stderr.on('data', (chunk: string) => { stderr += chunk; });
-  await new Promise<void>((resolveReady, rejectReady) => {
-    let stdout = '';
-    const timeout = setTimeout(
-      () => rejectReady(new Error(`finalization inbox crash child timed out: ${stderr}`)),
-      10_000,
-    );
-    child.stdout.setEncoding('utf8');
-    child.stdout.on('data', (chunk: string) => {
-      stdout += chunk;
-      if (!stdout.includes('READY\n')) return;
-      clearTimeout(timeout);
-      resolveReady();
-    });
-    child.once('error', (error) => {
-      clearTimeout(timeout);
-      rejectReady(error);
-    });
-    child.once('exit', (code, signal) => {
-      clearTimeout(timeout);
-      rejectReady(new Error(
-        `finalization inbox crash child exited early: code=${code} signal=${signal} ${stderr}`,
-      ));
-    });
-  });
-  const exit = new Promise<void>((resolveExit) => child.once('exit', () => resolveExit()));
-  child.kill('SIGKILL');
-  await exit;
-}
+import {
+  BLOCK_HASH,
+  RAW,
+  evidence,
+  received,
+  temporaryDirectory,
+} from './finalization-recovery-sqlite-test-helpers.js';
 
 describe('SQLite finalization recovery store', () => {
   it('lists only due live work in bounded oldest-first batches', async () => {
@@ -594,28 +491,6 @@ describe('SQLite finalization recovery store', () => {
     }
   });
 
-  it('keeps VERIFIED evidence when live capacity is full', async () => {
-    const directory = await temporaryDirectory();
-    try {
-      const store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
-      await store.receive(received());
-      await store.markVerified('entry-1', 0, evidence());
-      await expect(store.receive(received({
-        key: 'entry-2',
-        txHash: `0x${'ef'.repeat(32)}`,
-      }))).resolves.toEqual({ status: 'capacity' });
-      expect(await store.list()).toMatchObject([{ key: 'entry-1', state: 'VERIFIED' }]);
-      expect(await store.health()).toMatchObject({
-        available: true,
-        ready: false,
-        degradedReason: 'capacity-exhausted',
-      });
-      await store.close();
-    } finally {
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-
   it('serializes concurrent duplicate admission without duplicate rows', async () => {
     const directory = await temporaryDirectory();
     try {
@@ -649,28 +524,6 @@ describe('SQLite finalization recovery store', () => {
       const reopened = await openSqliteFinalizationRecoveryStore(directory);
       expect(await reopened.list()).toHaveLength(2);
       await reopened.close();
-    } finally {
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-
-  it('recovers a committed RECEIVED row after a process crash with a hot WAL', async () => {
-    const directory = await temporaryDirectory();
-    try {
-      const initial = await openSqliteFinalizationRecoveryStore(directory);
-      const path = initial.databasePath;
-      await initial.close();
-
-      await leaveCommittedReceivedInCrashedWal(path);
-      expect(existsSync(`${path}-wal`)).toBe(true);
-
-      const recovered = await openSqliteFinalizationRecoveryStore(directory);
-      expect(await recovered.list()).toMatchObject([{
-        key: 'crash-entry',
-        state: 'RECEIVED',
-        rawMessage: RAW,
-      }]);
-      await recovered.close();
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/packages/agent/test/finalization-recovery-sqlite-test-helpers.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-test-helpers.ts
@@ -1,0 +1,53 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  VerifiedGraphScopedFinalizationEvidence,
+} from '../src/finalization-graph-envelope.js';
+
+export const TX_HASH = `0x${'ab'.repeat(32)}`;
+export const BLOCK_HASH = `0x${'cd'.repeat(32)}`;
+export const RAW = Uint8Array.from([1, 2, 3, 4]);
+
+export function received(overrides: Record<string, unknown> = {}) {
+  return {
+    key: 'entry-1',
+    chainId: 'base:84532',
+    contextGraphId: 'graph',
+    sourcePeerId: '12D3KooWPublisher',
+    ual: 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7',
+    txHash: TX_HASH,
+    assertionVersion: '1',
+    merkleRoot: `0x${'01'.repeat(32)}`,
+    kaId: '7',
+    batchId: '7',
+    targetContextGraphId: '42',
+    rawMessage: RAW,
+    ...overrides,
+  };
+}
+
+export function evidence(
+  overrides: Partial<VerifiedGraphScopedFinalizationEvidence> = {},
+): VerifiedGraphScopedFinalizationEvidence {
+  return {
+    assertionVersion: '1',
+    publicTripleCount: 2,
+    privateTripleCount: 0,
+    publicQuadsDigest: `sha256:${'02'.repeat(32)}`,
+    publisherPeerId: '12D3KooWPublisher',
+    publisherAddress: '0x2222222222222222222222222222222222222222',
+    transactionHash: TX_HASH,
+    blockNumber: 123,
+    blockHash: BLOCK_HASH,
+    txIndex: 4,
+    authorAddress: '0x1111111111111111111111111111111111111111',
+    accessPolicy: 'ownerOnly',
+    allowedPeers: [],
+    ...overrides,
+  };
+}
+
+export async function temporaryDirectory(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'dkg-finalization-inbox-'));
+}

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -120,6 +120,116 @@ function recoveryMaterializer() {
 }
 
 describe('graph-scoped finalization recovery admission', () => {
+  it('preserves boolean fallback behavior for callers using the original API', async () => {
+    const recovery = new FinalizationRecovery(
+      undefined,
+      recoveryChain(),
+      { info: () => {}, warn: () => {} },
+      recoveryMaterializer(),
+    );
+    const processUnjournaled = vi.spyOn(recovery, 'processUnjournaled')
+      .mockResolvedValue('applied');
+    const input = {
+      rawMessage: encodeFinalizationMessage(message()),
+      contextGraphId: CONTEXT_GRAPH,
+      sourcePeerId: '12D3KooWPublisher',
+      candidate: parsedMessage(),
+    };
+
+    if (!await recovery.processLive(input)) {
+      await recovery.processUnjournaled(input);
+    }
+    expect(processUnjournaled).toHaveBeenCalledOnce();
+    expect(processUnjournaled).toHaveBeenCalledWith(input);
+  });
+
+  it('preserves publisher authority when a trusted duplicate arrives while deferred', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-pending-publisher-'));
+    let store: Awaited<ReturnType<typeof openSqliteFinalizationRecoveryStore>> | undefined;
+    try {
+      store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
+      await store.receive({
+        key: 'capacity-blocker',
+        chainId: 'base:84532',
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWRelay',
+        ual: `${UAL}-blocker`,
+        txHash: `0x${'12'.repeat(32)}`,
+        assertionVersion: '1',
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: '8',
+        batchId: '8',
+        targetContextGraphId: '42',
+        rawMessage: Uint8Array.from([9]),
+      });
+      const preparedSources: Array<string | undefined> = [];
+      let appliedAccess: { policy: string; peers: string[] } | undefined;
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain(),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          prepare: async (input) => {
+            preparedSources.push(input.sourcePeerId);
+            return {
+              onChainContextGraphId: '42',
+              localTopicOnChainContextGraphId: '42',
+              publisherPeerId: '12D3KooWPublisher',
+              accessPolicy: 'allowList' as const,
+              allowedPeers: ['12D3KooWReader'],
+            };
+          },
+          apply: async ({ prepared }) => {
+            appliedAccess = {
+              policy: prepared.accessPolicy,
+              peers: prepared.allowedPeers,
+            };
+            return 'applied' as const;
+          },
+        },
+      );
+      const baseInput = {
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        candidate: parsedMessage(),
+      };
+
+      await recovery.processLiveOutcome({
+        ...baseInput,
+        sourcePeerId: '12D3KooWRelay',
+      });
+      await recovery.processLiveOutcome({
+        ...baseInput,
+        sourcePeerId: '12D3KooWPublisher',
+      });
+      await recovery.processLiveOutcome({
+        ...baseInput,
+        sourcePeerId: '12D3KooWLaterRelay',
+      });
+      expect(await store.health()).toMatchObject({ deferredEntries: 1 });
+
+      await store.transition('capacity-blocker', 0, 'SUPERSEDED');
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      expect(preparedSources.at(-1)).toBe('12D3KooWPublisher');
+      expect(appliedAccess).toEqual({
+        policy: 'allowList',
+        peers: ['12D3KooWReader'],
+      });
+      expect(await store.list()).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          state: 'SETTLED',
+          ual: UAL,
+          sourcePeerId: '12D3KooWRelay',
+          trustedPublisherPeerId: '12D3KooWPublisher',
+        }),
+      ]));
+    } finally {
+      await store?.close().catch(() => {});
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('autonomously settles a durable RECEIVED entry without a chain-cursor replay', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-worker-'));
     try {
@@ -270,7 +380,7 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
-  it('emits due metrics even when the due-inbox read fails', async () => {
+  it('emits deferred admission and due metrics even when the due-inbox read fails', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-due-metrics-'));
     const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
     const meterProvider = new MeterProvider({
@@ -286,24 +396,29 @@ describe('graph-scoped finalization recovery admission', () => {
     expect(metrics.setGlobalMeterProvider(meterProvider)).toBe(true);
     rebuildMetrics();
     try {
-      store = await openSqliteFinalizationRecoveryStore(directory);
-      vi.spyOn(store, 'listDue').mockRejectedValueOnce(
-        new Error('sqlite due read unavailable'),
-      );
-      vi.spyOn(store, 'health').mockResolvedValue({
-        available: true,
-        closed: false,
-        stateCounts: { RECEIVED: 7 },
-        livePayloadBytes: 123,
-        dueEntries: 7,
-        oldestDueAgeMs: 4_321,
-      });
+      store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
       const warn = vi.fn();
       const recovery = new FinalizationRecovery(
         store,
         recoveryChain(),
         { info: () => {}, warn },
         recoveryMaterializer(),
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+      const deferredTxHash = `0x${'bc'.repeat(32)}`;
+      await expect(recovery.receive({
+        rawMessage: encodeFinalizationMessage(message({ txHash: deferredTxHash })),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage({ txHash: deferredTxHash }),
+      })).resolves.toBeUndefined();
+      vi.spyOn(store, 'listDue').mockRejectedValueOnce(
+        new Error('sqlite due read unavailable'),
       );
 
       await expect(recovery.processDueBatch(16)).resolves.toBe(0);
@@ -314,20 +429,42 @@ describe('graph-scoped finalization recovery admission', () => {
         expect.stringContaining('metrics snapshot failed'),
       );
       await meterProvider.forceFlush();
-      const datapoints = new Map<string, number>();
+      const datapoints: Array<{
+        name: string;
+        value: number;
+        attributes: Record<string, unknown>;
+      }> = [];
       for (const resourceMetrics of exporter.getMetrics()) {
         for (const scopeMetrics of resourceMetrics.scopeMetrics) {
           for (const metric of scopeMetrics.metrics) {
             for (const point of metric.dataPoints) {
               if (typeof point.value === 'number') {
-                datapoints.set(metric.descriptor.name, point.value);
+                datapoints.push({
+                  name: metric.descriptor.name,
+                  value: point.value,
+                  attributes: point.attributes,
+                });
               }
             }
           }
         }
       }
-      expect(datapoints.get('dkg.finalization_recovery.due_entries')).toBe(7);
-      expect(datapoints.get('dkg.finalization_recovery.oldest_due_age_ms')).toBe(4_321);
+      expect(datapoints).toContainEqual(expect.objectContaining({
+        name: 'dkg.finalization_recovery.admission_total',
+        value: 1,
+        attributes: { outcome: 'deferred' },
+      }));
+      expect(datapoints).toContainEqual(expect.objectContaining({
+        name: 'dkg.finalization_recovery.due_entries',
+        value: 1,
+      }));
+      expect(datapoints.some(
+        (point) => point.name === 'dkg.finalization_recovery.oldest_due_age_ms',
+      )).toBe(true);
+      expect(datapoints).toContainEqual(expect.objectContaining({
+        name: 'dkg.finalization_recovery.deferred_entries',
+        value: 1,
+      }));
     } finally {
       await store?.close().catch(() => {});
       await meterProvider.shutdown().catch(() => {});
@@ -472,12 +609,12 @@ describe('graph-scoped finalization recovery admission', () => {
         attemptCount: 3,
         lastError: 'autonomous retry budget exhausted after 3 attempts over 10000ms',
       }]);
-      await expect(recovery.processLive({
+      await expect(recovery.processLiveOutcome({
         rawMessage: encodeFinalizationMessage(message()),
         contextGraphId: CONTEXT_GRAPH,
         sourcePeerId: '12D3KooWPublisher',
         candidate: parsedMessage(),
-      })).resolves.toBe(true);
+      })).resolves.toEqual({ status: 'handled' });
       expect(applyCalls).toBe(1);
       expect(await store.list()).toMatchObject([{
         state: 'REJECTED',
@@ -1001,12 +1138,12 @@ describe('graph-scoped finalization recovery admission', () => {
           },
         );
         const initialMessage = message();
-        await expect(recovery.processLive({
+        await expect(recovery.processLiveOutcome({
           rawMessage: encodeFinalizationMessage(initialMessage),
           contextGraphId: CONTEXT_GRAPH,
           sourcePeerId: '12D3KooWPublisher',
           candidate: parsedMessage(initialMessage),
-        })).resolves.toBe(true);
+        })).resolves.toEqual({ status: 'handled' });
         expect(await store.list()).toMatchObject([{
           state: 'SETTLED',
           generation: 0,
@@ -1131,12 +1268,12 @@ describe('graph-scoped finalization recovery admission', () => {
           { info: () => {}, warn: () => {} },
           recoveryMaterializer(),
         );
-        await expect(recovery.processLive({
+        await expect(recovery.processLiveOutcome({
           rawMessage: encodeFinalizationMessage(message()),
           contextGraphId: CONTEXT_GRAPH,
           sourcePeerId: '12D3KooWPublisher',
           candidate: parsedMessage(),
-        })).resolves.toBe(true);
+        })).resolves.toEqual({ status: 'handled' });
         expect(await store.list()).toMatchObject([{
           state: 'SETTLED',
           assertionVersion: '1',

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1286,6 +1286,74 @@ describe('graph-scoped finalization handler', () => {
     }
   });
 
+  it('promotes a durably deferred finalization after live inbox capacity clears', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-deferred-capacity-'));
+    let inbox: SqliteFinalizationRecoveryStore | undefined;
+    let recoveryHandler: FinalizationHandler | undefined;
+    try {
+      const { message, vmGraph } = await stageGraph();
+      const chain = {
+        chainId: 'base:84532',
+        getLatestMerkleRoot: async () => message.kcMerkleRoot,
+        getMerkleRootCount: async () => 1n,
+        getKAContextGraphId: async () => 42n,
+        resolveCanonicalFinalizationReceipt: async () => canonicalReceipt(message),
+      } as ChainAdapter;
+      inbox = await openSqliteFinalizationRecoveryStore(directory, {
+        maxEntries: 1,
+        maxPerPeer: 1,
+        maxPerContextGraph: 1,
+      });
+      const fillerKey = 'capacity-filler';
+      await expect(inbox.receive({
+        key: fillerKey,
+        chainId: 'base:84532',
+        contextGraphId: CG,
+        sourcePeerId: '12D3KooWFiller',
+        ual: `did:dkg:otp:20430/${AUTHOR}/999`,
+        txHash: `0x${'ef'.repeat(32)}`,
+        assertionVersion: '1',
+        merkleRoot: `0x${'12'.repeat(32)}`,
+        kaId: '999',
+        batchId: '999',
+        targetContextGraphId: '42',
+        rawMessage: new Uint8Array([1]),
+      })).resolves.toMatchObject({ status: 'inserted' });
+
+      recoveryHandler = new FinalizationHandler(
+        store,
+        chain,
+        recoveryOptions(inbox),
+      );
+      await recoveryHandler.handleFinalizationMessage(
+        encodeFinalizationMessage(message),
+        CG,
+        '12D3KooWPublisher',
+      );
+
+      expect(await store.countQuads(vmGraph)).toBe(1);
+      expect(await inbox.health()).toMatchObject({
+        deferredEntries: 1,
+        dueEntries: 1,
+      });
+      await expect(inbox.transition(fillerKey, 0, 'SUPERSEDED')).resolves.toBe(true);
+
+      recoveryHandler.startRecoveryWorker();
+      await vi.waitFor(async () => {
+        expect(await inbox!.list()).toMatchObject([
+          { key: fillerKey, state: 'SUPERSEDED' },
+          { state: 'SETTLED', ual: UAL },
+        ]);
+        expect(await inbox!.health()).toMatchObject({ deferredEntries: 0 });
+      });
+      expect(await store.countQuads(vmGraph)).toBe(2);
+    } finally {
+      await recoveryHandler?.stopRecoveryWorker();
+      await closeInbox(inbox);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('does not mutate Oxigraph when the VERIFIED transaction cannot commit', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recovery-'));
     let inbox: SqliteFinalizationRecoveryStore | undefined;
@@ -1301,6 +1369,9 @@ describe('graph-scoped finalization handler', () => {
         get closed() { return inbox!.closed; },
         get: inbox.get.bind(inbox),
         receive: inbox.receive.bind(inbox),
+        promotePending: inbox.promotePending.bind(inbox),
+        recordPendingTrustedPublisher:
+          inbox.recordPendingTrustedPublisher.bind(inbox),
         recordTrustedPublisher: inbox.recordTrustedPublisher.bind(inbox),
         recordSettledPublisherUpgrade:
           inbox.recordSettledPublisherUpgrade.bind(inbox),
@@ -1378,6 +1449,10 @@ describe('graph-scoped finalization handler', () => {
           if (failureMode === 'write-failure') throw new Error('disk full');
           return { status: 'capacity' };
         },
+        promotePending: async () => 0,
+        recordPendingTrustedPublisher: async () => {
+          throw new Error('recordPendingTrustedPublisher must not run after failed admission');
+        },
         recordTrustedPublisher: async () => {
           throw new Error('recordTrustedPublisher must not run after failed admission');
         },
@@ -1417,11 +1492,19 @@ describe('graph-scoped finalization handler', () => {
         return query(sparql, options);
       };
       try {
-        await recoveryHandler.handleFinalizationMessage(
+        const handling = recoveryHandler.handleFinalizationMessage(
           encodeFinalizationMessage(message),
           CG,
           '12D3KooWPublisher',
         );
+        if (failureMode === 'capacity') {
+          await expect(handling).rejects.toMatchObject({
+            code: 'FINALIZATION_RECOVERY_CAPACITY',
+            retryable: true,
+          });
+        } else {
+          await expect(handling).resolves.toBeUndefined();
+        }
       } finally {
         store.query = query;
       }

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -117,6 +117,8 @@ export default defineConfig({
       "test/finalization-handler-defensive-cg-id.test.ts",
       "test/finalization-recovery.test.ts",
       "test/finalization-recovery-worker.test.ts",
+      "test/finalization-recovery-sqlite-deferred.test.ts",
+      "test/finalization-recovery-sqlite-migration.test.ts",
       "test/finalization-recovery-sqlite-store.test.ts",
       "test/named-ka-publish-recovery.test.ts",
       "test/ka-graph-finalization-handler.test.ts",

--- a/packages/core/src/telemetry-api.ts
+++ b/packages/core/src/telemetry-api.ts
@@ -239,6 +239,10 @@ export interface DkgMetrics {
   finalizationRecoveryOldestDueAgeMs: Gauge;
   /** outcome={recovered|invalidated|retry-pending|none} */
   finalizationRecoveryAttemptsTotal: Counter;
+  /** outcome={inserted|existing|deferred|capacity|conflict|closed|write-failure} */
+  finalizationRecoveryAdmissionTotal: Counter;
+  /** durable finalization envelopes waiting for live-inbox capacity */
+  finalizationRecoveryDeferredEntries: Gauge;
   /** process-local sync inflight sample */
   syncGlobalInflight: Histogram;
   /** ms; lane and priority_class are bounded sync scheduler enums */
@@ -459,6 +463,14 @@ function buildMetrics(): DkgMetrics {
     finalizationRecoveryAttemptsTotal: meter.createCounter(
       'dkg.finalization_recovery.attempts_total',
       { description: 'Autonomous finalization replay attempts by bounded outcome' },
+    ),
+    finalizationRecoveryAdmissionTotal: meter.createCounter(
+      'dkg.finalization_recovery.admission_total',
+      { description: 'Durable finalization admission outcomes by bounded result' },
+    ),
+    finalizationRecoveryDeferredEntries: meter.createGauge(
+      'dkg.finalization_recovery.deferred_entries',
+      { description: 'Durable finalization envelopes waiting for live-inbox capacity' },
     ),
     syncGlobalInflight: meter.createHistogram('dkg.sync.global_inflight', {
       description: 'Sampled process-local sync inflight count',


### PR DESCRIPTION
## Summary

When the in-memory recovery inbox hit capacity, a finalization envelope arriving for replay was **dropped**. The publish had already happened on-chain, so the work was real — it simply stopped being recoverable. The inbox fills precisely under saturation, which is exactly when recovery matters most.

Envelopes that cannot be admitted live are now persisted to the SQLite recovery store as `deferred` and promoted when capacity frees up. Saturation therefore **delays** a finalization instead of losing it.

Admission now returns a bounded outcome rather than a boolean:

`inserted` · `existing` · `deferred` · `capacity` · `conflict` · `closed` · `write-failure`

so "we deferred it" is distinguishable from "we dropped it" in both the store API and the metrics — previously both were just *not admitted*.

Two new metrics make the deferral queue observable rather than inferred:

- `dkg.finalization_recovery.admission_total{outcome}`
- `dkg.finalization_recovery.deferred_entries`

**The store schema is migrated, not recreated.** A node that has already written recovery state keeps it across the upgrade; that path has its own test rather than being assumed.

## Related

- Split out of #2092, which bundled three unrelated reliability fixes. Separated so each can be tested and reverted independently.
- Siblings: orphaned Blazegraph queries, and unsupported StorageACK protocols.
- This is the largest of the three (16 files) and the only one that touches persisted state, so it is the one most worth reviewing and rolling out on its own.

## Diagrams

### A finalization arriving while the live inbox is full

Before — the envelope is lost:

```mermaid
sequenceDiagram
    participant Chain
    participant Handler
    participant LiveInbox
    Chain->>Handler: finalization (already on-chain)
    Handler->>LiveInbox: admit
    LiveInbox-->>Handler: at capacity
    Note over Handler: dropped — no longer recoverable
```

After — deferred durably, promoted later:

```mermaid
sequenceDiagram
    participant Chain
    participant Handler
    participant LiveInbox
    participant SQLite
    Chain->>Handler: finalization (already on-chain)
    Handler->>LiveInbox: admit
    LiveInbox-->>Handler: at capacity
    Handler->>SQLite: persist as `deferred`
    Note over SQLite: admission_total{outcome=deferred}<br/>deferred_entries + 1
    LiveInbox-->>Handler: capacity frees
    SQLite->>LiveInbox: promote
```

## Files changed

| File | What |
|------|------|
| `packages/agent/src/finalization-recovery.ts` | Deferred admission + promotion on free capacity |
| `packages/agent/src/finalization-recovery-store.ts` | Bounded admission outcome replaces the boolean |
| `packages/agent/src/finalization-recovery-sqlite-store.ts` | Durable deferred entries, promotion query |
| `packages/agent/src/finalization-recovery-sqlite-schema.ts` | Schema migration preserving existing rows |
| `packages/agent/src/finalization-recovery-sqlite-policy.ts` | New — retention/promotion policy |
| `packages/agent/src/finalization-recovery-sqlite-codec.ts` | Encode/decode the deferred state |
| `packages/agent/src/finalization-handler.ts` | Routes a full-inbox admission to the durable path |
| `packages/core/src/telemetry-api.ts` | `admission_total` counter, `deferred_entries` gauge |
| `packages/agent/test/finalization-recovery-sqlite-deferred.test.ts` | New — deferral and promotion |
| `packages/agent/test/finalization-recovery-sqlite-migration.test.ts` | New — upgrade preserves existing rows |
| `packages/agent/test/finalization-recovery-sqlite-test-helpers.ts` | New — shared fixtures |
| `packages/agent/test/{finalization-recovery,finalization-recovery-sqlite-store,ka-graph-finalization-handler}.test.ts` | Updated for the bounded outcome |
| `packages/agent/vitest.unit.config.ts`, `.github/workflows/rfc64-inventory-windows.yml` | Register the two new test files — the agent include list is hand-maintained, so a new test is silently skipped (incl. on Windows) unless added |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/finalization-recovery-sqlite-deferred.test.ts test/finalization-recovery-sqlite-migration.test.ts test/finalization-recovery-sqlite-store.test.ts test/finalization-recovery.test.ts test/ka-graph-finalization-handler.test.ts` — **111 passed**, on this branch alone off `testnet-canary`
- [x] Covers: admission returns each bounded outcome; a full inbox defers rather than drops; promotion on free capacity; **migration of an existing store preserves rows**
- [ ] Live check under saturation on Base — confirm `deferred_entries` rises and drains rather than finalizations disappearing
- [ ] Upgrade check on a node with pre-existing recovery state, to exercise the migration against real data
