### PR TITLE
RFC-64 P3 1/3: define signed SWM-only inventory

### DIFF
--- a/packages/core/src/author-catalog-codec.ts
+++ b/packages/core/src/author-catalog-codec.ts
@@ -12,13 +12,11 @@ import {
   type KaTransferDescriptorV1,
 } from './ka-transfer-descriptor.js';
 import {
-  assertCanonicalChainId,
   assertCanonicalDigest,
   assertCanonicalEvmAddress,
   assertCanonicalKaId,
   parseCanonicalDecimalU64,
   parseCanonicalDecimalU256,
-  type ChainIdV1,
   type CountV1,
   type DecimalU64V1,
   type Digest32V1,
@@ -31,16 +29,33 @@ import {
   type NetworkIdV1,
 } from './sync-wire-identifiers.js';
 import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+import {
+  AUTHOR_LANE_SCOPE_KEYS_V1,
+  MAX_AUTHOR_LANE_IDENTIFIER_BYTES_V1,
+  AuthorLaneScopeErrorV1,
+  assertAuthorLaneContextGraphIdV1,
+  assertAuthorLaneScopeFieldsV1 as assertSharedAuthorLaneScopeFieldsV1,
+  assertAuthorLaneScopeV1 as assertSharedAuthorLaneScopeV1,
+  assertAuthorLaneSubGraphNameV1,
+  snapshotAuthorLaneScopeV1 as snapshotSharedAuthorLaneScopeV1,
+  type AuthorLaneScopeV1,
+  type CatalogLaneV1,
+  type ContextGraphIdV1,
+  type SubGraphNameV1,
+} from './author-lane-scope-v1.js';
 
-declare const CONTEXT_GRAPH_ID_V1_BRAND: unique symbol;
-declare const SUBGRAPH_NAME_V1_BRAND: unique symbol;
 declare const ASSERTION_COORDINATE_V1_BRAND: unique symbol;
 declare const CATALOG_ASSERTION_SCOPE_V1_BRAND: unique symbol;
 declare const CATALOG_ASSERTION_SUBJECT_V1_BRAND: unique symbol;
 
 export type { NetworkIdV1 } from './sync-wire-identifiers.js';
-export type ContextGraphIdV1 = string & { readonly [CONTEXT_GRAPH_ID_V1_BRAND]: true };
-export type SubGraphNameV1 = string & { readonly [SUBGRAPH_NAME_V1_BRAND]: true };
+export {
+  AUTHOR_LANE_SCOPE_KEYS_V1,
+  type AuthorLaneScopeV1,
+  type CatalogLaneV1,
+  type ContextGraphIdV1,
+  type SubGraphNameV1,
+} from './author-lane-scope-v1.js';
 export type AssertionCoordinateV1 = string & {
   readonly [ASSERTION_COORDINATE_V1_BRAND]: true;
 };
@@ -59,14 +74,13 @@ export const AUTHOR_CATALOG_ROW_DIGEST_DOMAIN_V1 =
   'dkg-author-catalog-row-v1\n' as const;
 
 export const MAX_AUTHOR_CATALOG_NETWORK_ID_BYTES_V1 = MAX_NETWORK_ID_BYTES_V1;
-export const MAX_AUTHOR_CATALOG_IDENTIFIER_BYTES_V1 = 256;
+export const MAX_AUTHOR_CATALOG_IDENTIFIER_BYTES_V1 = MAX_AUTHOR_LANE_IDENTIFIER_BYTES_V1;
 export const MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1 = 2048;
 export const MAX_AUTHOR_CATALOG_ROW_BYTES_V1 = 2048;
 export const MAX_AUTHOR_CATALOG_ROW_DIGEST_INPUT_BYTES_V1 = 4096;
 export const MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1 = 9_223_372_036_854_775_808n;
 export const PACKED_KA_NUMBER_BITS_V1 = 96n;
 
-const CONTEXT_GRAPH_ID_PATTERN = /^[A-Za-z0-9_:/\.@-]+$/;
 const CATALOG_IDENTIFIER_ASCII_FORBIDDEN = new Set([
   '<',
   '>',
@@ -78,37 +92,10 @@ const CATALOG_IDENTIFIER_ASCII_FORBIDDEN = new Set([
   '`',
   '\\',
 ]);
-const RESERVED_SUBGRAPH_NAMES = new Set(['context', 'assertion', 'draft']);
 const UTF8 = new TextEncoder();
 const SCOPE_DOMAIN_BYTES = UTF8.encode(AUTHOR_CATALOG_SCOPE_DIGEST_DOMAIN_V1);
 const KEY_DOMAIN_BYTES = UTF8.encode(AUTHOR_CATALOG_KEY_DIGEST_DOMAIN_V1);
 const ROW_DOMAIN_BYTES = UTF8.encode(AUTHOR_CATALOG_ROW_DIGEST_DOMAIN_V1);
-
-export interface CatalogLaneV1 {
-  readonly contextGraphId: ContextGraphIdV1;
-  readonly subGraphName: SubGraphNameV1 | null;
-}
-
-/** Shared author lane governed by one exact public-CG policy era. */
-export interface AuthorLaneScopeV1 extends CatalogLaneV1 {
-  readonly networkId: NetworkIdV1;
-  readonly governanceChainId: ChainIdV1 | null;
-  readonly governanceContractAddress: EvmAddressV1 | null;
-  readonly ownershipTransitionDigest: Digest32V1 | null;
-  readonly authorAddress: EvmAddressV1;
-  readonly era: DecimalU64V1;
-}
-
-export const AUTHOR_LANE_SCOPE_KEYS_V1 = Object.freeze([
-  'authorAddress',
-  'contextGraphId',
-  'era',
-  'governanceChainId',
-  'governanceContractAddress',
-  'networkId',
-  'ownershipTransitionDigest',
-  'subGraphName',
-] as const);
 
 /** Exact nine-key scope committed by every author-catalog era. */
 export interface AuthorCatalogScopeV1 extends AuthorLaneScopeV1 {
@@ -165,30 +152,14 @@ export function assertContextGraphIdV1(
   value: unknown,
   label = 'contextGraphId',
 ): asserts value is ContextGraphIdV1 {
-  const identifier = assertNfcUtf8Identifier(
-    value,
-    label,
-    MAX_AUTHOR_CATALOG_IDENTIFIER_BYTES_V1,
-  );
-  if (!CONTEXT_GRAPH_ID_PATTERN.test(identifier)) {
-    fail(
-      'catalog-identifier',
-      `${label} contains a character outside the contextGraphId grammar`,
-    );
-  }
+  adaptAuthorLane(() => assertAuthorLaneContextGraphIdV1(value, label));
 }
 
 export function assertSubGraphNameV1(
   value: unknown,
   label = 'subGraphName',
 ): asserts value is SubGraphNameV1 {
-  const identifier = assertCatalogLaneIdentifier(value, label);
-  if (identifier.startsWith('_')) {
-    fail('catalog-identifier', `${label} must not start with underscore`);
-  }
-  if (RESERVED_SUBGRAPH_NAMES.has(identifier)) {
-    fail('catalog-identifier', `${label} is a reserved subgraph name`);
-  }
+  adaptAuthorLane(() => assertAuthorLaneSubGraphNameV1(value, label));
 }
 
 export function assertAssertionCoordinateV1(
@@ -271,7 +242,7 @@ export function assertAuthorCatalogScopeV1(
     'bucketCount',
   ], 'author catalog scope');
 
-  assertAuthorLaneScopeFieldsV1(scope);
+  adaptAuthorLane(() => assertSharedAuthorLaneScopeFieldsV1(scope));
   assertAuthorCatalogBucketCountV1(scope.bucketCount);
 }
 
@@ -279,57 +250,12 @@ export function assertAuthorCatalogScopeV1(
 export function assertAuthorLaneScopeV1(
   scope: unknown,
 ): asserts scope is AuthorLaneScopeV1 {
-  if (!isPlainRecord(scope)) {
-    fail('catalog-schema', 'author lane scope must be a plain JSON object');
-  }
-  assertClosedKeys(scope, AUTHOR_LANE_SCOPE_KEYS_V1, 'author lane scope');
-  assertAuthorLaneScopeFieldsV1(scope);
+  adaptAuthorLane(() => assertSharedAuthorLaneScopeV1(scope));
 }
 
 /** Copy a validated structural superset into one exact immutable author-lane scope. */
 export function snapshotAuthorLaneScopeV1(scope: AuthorLaneScopeV1): AuthorLaneScopeV1 {
-  const snapshot = {
-    authorAddress: scope.authorAddress,
-    contextGraphId: scope.contextGraphId,
-    era: scope.era,
-    governanceChainId: scope.governanceChainId,
-    governanceContractAddress: scope.governanceContractAddress,
-    networkId: scope.networkId,
-    ownershipTransitionDigest: scope.ownershipTransitionDigest,
-    subGraphName: scope.subGraphName,
-  };
-  assertAuthorLaneScopeV1(snapshot);
-  return Object.freeze(snapshot);
-}
-
-function assertAuthorLaneScopeFieldsV1(scope: Record<string, unknown>): void {
-  assertNetworkIdV1(scope.networkId);
-  assertContextGraphIdV1(scope.contextGraphId);
-  if (scope.subGraphName !== null) assertSubGraphNameV1(scope.subGraphName);
-  assertCatalogScalar(() => assertCanonicalEvmAddress(scope.authorAddress, 'authorAddress'));
-  assertCatalogU64(scope.era, 'era');
-
-  const chainIsNull = scope.governanceChainId === null;
-  const contractIsNull = scope.governanceContractAddress === null;
-  if (chainIsNull !== contractIsNull) {
-    fail(
-      'catalog-governance-tuple',
-      'governanceChainId and governanceContractAddress must both be null or both be non-null',
-    );
-  }
-  if (!chainIsNull) {
-    assertCatalogScalar(() => assertCanonicalChainId(scope.governanceChainId, 'governanceChainId'));
-    assertCatalogScalar(() => assertCanonicalEvmAddress(
-      scope.governanceContractAddress,
-      'governanceContractAddress',
-    ));
-  }
-  if (scope.ownershipTransitionDigest !== null) {
-    assertCatalogScalar(() => assertCanonicalDigest(
-      scope.ownershipTransitionDigest,
-      'ownershipTransitionDigest',
-    ));
-  }
+  return adaptAuthorLane(() => snapshotSharedAuthorLaneScopeV1(scope));
 }
 
 export function canonicalizeAuthorCatalogScopeV1(scope: AuthorCatalogScopeV1): string {
@@ -633,6 +559,22 @@ function assertClosedKeys(
     assertExactKeys(record, keys, label);
   } catch (cause) {
     fail('catalog-schema', `${label} has an invalid field set`, cause);
+  }
+}
+
+function adaptAuthorLane<T>(operation: () => T): T {
+  try {
+    return operation();
+  } catch (cause) {
+    if (!(cause instanceof AuthorLaneScopeErrorV1)) throw cause;
+    const code: AuthorCatalogCodecErrorCode = cause.code === 'author-lane-schema'
+      ? 'catalog-schema'
+      : cause.code === 'author-lane-identifier'
+        ? 'catalog-identifier'
+        : cause.code === 'author-lane-governance-tuple'
+          ? 'catalog-governance-tuple'
+          : 'catalog-scalar';
+    fail(code, cause.message, cause);
   }
 }
 

--- a/packages/core/src/author-catalog-codec.ts
+++ b/packages/core/src/author-catalog-codec.ts
@@ -89,14 +89,29 @@ export interface CatalogLaneV1 {
   readonly subGraphName: SubGraphNameV1 | null;
 }
 
-/** Exact nine-key scope committed by every author-catalog era. */
-export interface AuthorCatalogScopeV1 extends CatalogLaneV1 {
+/** Shared author lane governed by one exact public-CG policy era. */
+export interface AuthorLaneScopeV1 extends CatalogLaneV1 {
   readonly networkId: NetworkIdV1;
   readonly governanceChainId: ChainIdV1 | null;
   readonly governanceContractAddress: EvmAddressV1 | null;
   readonly ownershipTransitionDigest: Digest32V1 | null;
   readonly authorAddress: EvmAddressV1;
   readonly era: DecimalU64V1;
+}
+
+export const AUTHOR_LANE_SCOPE_KEYS_V1 = Object.freeze([
+  'authorAddress',
+  'contextGraphId',
+  'era',
+  'governanceChainId',
+  'governanceContractAddress',
+  'networkId',
+  'ownershipTransitionDigest',
+  'subGraphName',
+] as const);
+
+/** Exact nine-key scope committed by every author-catalog era. */
+export interface AuthorCatalogScopeV1 extends AuthorLaneScopeV1 {
   readonly bucketCount: CountV1;
 }
 
@@ -252,23 +267,47 @@ export function assertAuthorCatalogScopeV1(
     fail('catalog-schema', 'author catalog scope must be a plain JSON object');
   }
   assertClosedKeys(scope, [
-    'authorAddress',
+    ...AUTHOR_LANE_SCOPE_KEYS_V1,
     'bucketCount',
-    'contextGraphId',
-    'era',
-    'governanceChainId',
-    'governanceContractAddress',
-    'networkId',
-    'ownershipTransitionDigest',
-    'subGraphName',
   ], 'author catalog scope');
 
+  assertAuthorLaneScopeFieldsV1(scope);
+  assertAuthorCatalogBucketCountV1(scope.bucketCount);
+}
+
+/** Validate the exact shared author-lane scope used by catalog and SWM commitments. */
+export function assertAuthorLaneScopeV1(
+  scope: unknown,
+): asserts scope is AuthorLaneScopeV1 {
+  if (!isPlainRecord(scope)) {
+    fail('catalog-schema', 'author lane scope must be a plain JSON object');
+  }
+  assertClosedKeys(scope, AUTHOR_LANE_SCOPE_KEYS_V1, 'author lane scope');
+  assertAuthorLaneScopeFieldsV1(scope);
+}
+
+/** Copy a validated structural superset into one exact immutable author-lane scope. */
+export function snapshotAuthorLaneScopeV1(scope: AuthorLaneScopeV1): AuthorLaneScopeV1 {
+  const snapshot = {
+    authorAddress: scope.authorAddress,
+    contextGraphId: scope.contextGraphId,
+    era: scope.era,
+    governanceChainId: scope.governanceChainId,
+    governanceContractAddress: scope.governanceContractAddress,
+    networkId: scope.networkId,
+    ownershipTransitionDigest: scope.ownershipTransitionDigest,
+    subGraphName: scope.subGraphName,
+  };
+  assertAuthorLaneScopeV1(snapshot);
+  return Object.freeze(snapshot);
+}
+
+function assertAuthorLaneScopeFieldsV1(scope: Record<string, unknown>): void {
   assertNetworkIdV1(scope.networkId);
   assertContextGraphIdV1(scope.contextGraphId);
   if (scope.subGraphName !== null) assertSubGraphNameV1(scope.subGraphName);
   assertCatalogScalar(() => assertCanonicalEvmAddress(scope.authorAddress, 'authorAddress'));
   assertCatalogU64(scope.era, 'era');
-  assertAuthorCatalogBucketCountV1(scope.bucketCount);
 
   const chainIsNull = scope.governanceChainId === null;
   const contractIsNull = scope.governanceContractAddress === null;

--- a/packages/core/src/author-lane-scope-v1.ts
+++ b/packages/core/src/author-lane-scope-v1.ts
@@ -1,0 +1,267 @@
+import {
+  assertCanonicalChainId,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  parseCanonicalDecimalU64,
+  type ChainIdV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+} from './sync-wire-scalars.js';
+import {
+  assertNetworkIdV1,
+  type NetworkIdV1,
+} from './sync-wire-identifiers.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+
+declare const CONTEXT_GRAPH_ID_V1_BRAND: unique symbol;
+declare const SUBGRAPH_NAME_V1_BRAND: unique symbol;
+
+export type ContextGraphIdV1 = string & { readonly [CONTEXT_GRAPH_ID_V1_BRAND]: true };
+export type SubGraphNameV1 = string & { readonly [SUBGRAPH_NAME_V1_BRAND]: true };
+
+export const MAX_AUTHOR_LANE_IDENTIFIER_BYTES_V1 = 256;
+
+const CONTEXT_GRAPH_ID_PATTERN = /^[A-Za-z0-9_:/\.@-]+$/;
+const AUTHOR_LANE_IDENTIFIER_ASCII_FORBIDDEN = new Set([
+  '<',
+  '>',
+  '"',
+  '{',
+  '}',
+  '|',
+  '^',
+  '`',
+  '\\',
+]);
+const RESERVED_SUBGRAPH_NAMES = new Set(['context', 'assertion', 'draft']);
+const UTF8 = new TextEncoder();
+
+export interface CatalogLaneV1 {
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly subGraphName: SubGraphNameV1 | null;
+}
+
+/** Shared author lane governed by one exact public-CG policy era. */
+export interface AuthorLaneScopeV1 extends CatalogLaneV1 {
+  readonly networkId: NetworkIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly era: DecimalU64V1;
+}
+
+export const AUTHOR_LANE_SCOPE_KEYS_V1 = Object.freeze([
+  'authorAddress',
+  'contextGraphId',
+  'era',
+  'governanceChainId',
+  'governanceContractAddress',
+  'networkId',
+  'ownershipTransitionDigest',
+  'subGraphName',
+] as const);
+
+export type AuthorLaneScopeErrorCodeV1 =
+  | 'author-lane-schema'
+  | 'author-lane-identifier'
+  | 'author-lane-scalar'
+  | 'author-lane-governance-tuple';
+
+export class AuthorLaneScopeErrorV1 extends Error {
+  constructor(
+    readonly code: AuthorLaneScopeErrorCodeV1,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'AuthorLaneScopeErrorV1';
+  }
+}
+
+export function assertAuthorLaneContextGraphIdV1(
+  value: unknown,
+  label = 'contextGraphId',
+): asserts value is ContextGraphIdV1 {
+  const identifier = assertNfcUtf8Identifier(value, label);
+  if (!CONTEXT_GRAPH_ID_PATTERN.test(identifier)) {
+    fail(
+      'author-lane-identifier',
+      `${label} contains a character outside the contextGraphId grammar`,
+    );
+  }
+}
+
+export function assertAuthorLaneSubGraphNameV1(
+  value: unknown,
+  label = 'subGraphName',
+): asserts value is SubGraphNameV1 {
+  const identifier = assertAuthorLaneIdentifier(value, label);
+  if (identifier.startsWith('_')) {
+    fail('author-lane-identifier', `${label} must not start with underscore`);
+  }
+  if (RESERVED_SUBGRAPH_NAMES.has(identifier)) {
+    fail('author-lane-identifier', `${label} is a reserved subgraph name`);
+  }
+}
+
+/** Validate the exact shared author-lane scope used by catalog and SWM commitments. */
+export function assertAuthorLaneScopeV1(
+  scope: unknown,
+): asserts scope is AuthorLaneScopeV1 {
+  if (!isPlainRecord(scope)) {
+    fail('author-lane-schema', 'author lane scope must be a plain JSON object');
+  }
+  try {
+    assertExactKeys(scope, AUTHOR_LANE_SCOPE_KEYS_V1, 'author lane scope');
+  } catch (cause) {
+    fail('author-lane-schema', 'author lane scope has an invalid field set', cause);
+  }
+  assertAuthorLaneScopeFieldsV1(scope);
+}
+
+/** Validate the shared fields on a structural superset such as a catalog scope. */
+export function assertAuthorLaneScopeFieldsV1(scope: Record<string, unknown>): void {
+  scalar(() => assertNetworkIdV1(scope.networkId, 'networkId'), 'networkId');
+  assertAuthorLaneContextGraphIdV1(scope.contextGraphId);
+  if (scope.subGraphName !== null) assertAuthorLaneSubGraphNameV1(scope.subGraphName);
+  scalar(() => assertCanonicalEvmAddress(scope.authorAddress, 'authorAddress'), 'authorAddress');
+  scalar(() => parseCanonicalDecimalU64(scope.era, 'era'), 'era');
+
+  const chainIsNull = scope.governanceChainId === null;
+  const contractIsNull = scope.governanceContractAddress === null;
+  if (chainIsNull !== contractIsNull) {
+    fail(
+      'author-lane-governance-tuple',
+      'governanceChainId and governanceContractAddress must both be null or both be non-null',
+    );
+  }
+  if (!chainIsNull) {
+    scalar(
+      () => assertCanonicalChainId(scope.governanceChainId, 'governanceChainId'),
+      'governanceChainId',
+    );
+    scalar(
+      () => assertCanonicalEvmAddress(
+        scope.governanceContractAddress,
+        'governanceContractAddress',
+      ),
+      'governanceContractAddress',
+    );
+  }
+  if (scope.ownershipTransitionDigest !== null) {
+    scalar(
+      () => assertCanonicalDigest(scope.ownershipTransitionDigest, 'ownershipTransitionDigest'),
+      'ownershipTransitionDigest',
+    );
+  }
+}
+
+/** Copy a validated structural superset into one exact immutable author-lane scope. */
+export function snapshotAuthorLaneScopeV1(scope: AuthorLaneScopeV1): AuthorLaneScopeV1 {
+  const snapshot = {
+    authorAddress: scope.authorAddress,
+    contextGraphId: scope.contextGraphId,
+    era: scope.era,
+    governanceChainId: scope.governanceChainId,
+    governanceContractAddress: scope.governanceContractAddress,
+    networkId: scope.networkId,
+    ownershipTransitionDigest: scope.ownershipTransitionDigest,
+    subGraphName: scope.subGraphName,
+  };
+  assertAuthorLaneScopeV1(snapshot);
+  return Object.freeze(snapshot);
+}
+
+function assertAuthorLaneIdentifier(value: unknown, label: string): string {
+  const identifier = assertNfcUtf8Identifier(value, label);
+  for (const character of identifier) {
+    const codePoint = character.codePointAt(0) as number;
+    if (
+      character === '/'
+      || AUTHOR_LANE_IDENTIFIER_ASCII_FORBIDDEN.has(character)
+      || isAuthorLaneForbiddenCodePointV1(codePoint)
+    ) {
+      fail(
+        'author-lane-identifier',
+        `${label} contains a forbidden character or code point`,
+      );
+    }
+  }
+  return identifier;
+}
+
+function assertNfcUtf8Identifier(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    fail('author-lane-identifier', `${label} must be a non-empty string`);
+  }
+  if (value.length > MAX_AUTHOR_LANE_IDENTIFIER_BYTES_V1) {
+    fail(
+      'author-lane-identifier',
+      `${label} exceeds ${MAX_AUTHOR_LANE_IDENTIFIER_BYTES_V1} UTF-8 bytes`,
+    );
+  }
+  assertWellFormedUnicode(value, label);
+  if (value.normalize('NFC') !== value) {
+    fail('author-lane-identifier', `${label} must already be NFC-normalized`);
+  }
+  if (UTF8.encode(value).byteLength > MAX_AUTHOR_LANE_IDENTIFIER_BYTES_V1) {
+    fail(
+      'author-lane-identifier',
+      `${label} exceeds ${MAX_AUTHOR_LANE_IDENTIFIER_BYTES_V1} UTF-8 bytes`,
+    );
+  }
+  return value;
+}
+
+function isAuthorLaneForbiddenCodePointV1(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x0000 && codePoint <= 0x001f)
+    || (codePoint >= 0x007f && codePoint <= 0x009f)
+    || codePoint === 0x00a0
+    || codePoint === 0x1680
+    || (codePoint >= 0x2000 && codePoint <= 0x200b)
+    || codePoint === 0x2028
+    || codePoint === 0x2029
+    || codePoint === 0x202f
+    || codePoint === 0x205f
+    || codePoint === 0x3000
+    || codePoint === 0xfeff
+  );
+}
+
+function assertWellFormedUnicode(value: string, label: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        fail('author-lane-identifier', `${label} contains an unpaired UTF-16 surrogate`);
+      }
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      fail('author-lane-identifier', `${label} contains an unpaired UTF-16 surrogate`);
+    }
+  }
+}
+
+function scalar(operation: () => void, label: string): void {
+  try {
+    operation();
+  } catch (cause) {
+    fail('author-lane-scalar', `${label} is not canonical`, cause);
+  }
+}
+
+function fail(
+  code: AuthorLaneScopeErrorCodeV1,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new AuthorLaneScopeErrorV1(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/core/src/canonical-graph-scoped-author-seal.ts
+++ b/packages/core/src/canonical-graph-scoped-author-seal.ts
@@ -42,7 +42,11 @@ import {
   type EvmAddressV1,
   type KaIdV1,
 } from './sync-wire-scalars.js';
-import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+import {
+  assertExactKeys,
+  isPlainRecord,
+  snapshotExactDataRecord,
+} from './sync-wire-objects.js';
 
 declare const HEX_32_V1_BRAND: unique symbol;
 declare const POSITIVE_DECIMAL_U64_V1_BRAND: unique symbol;
@@ -249,7 +253,7 @@ export function assertCanonicalGraphScopedAuthorSealV1(
   if (!isPlainRecord(payload)) {
     fail('canonical-seal-schema', 'canonical author seal must be a plain JSON object');
   }
-  assertClosedKeys(payload, [
+  const sealedPayload = snapshotClosedKeys(payload, [
     'assertedAtChainId',
     'assertedAtKav10Address',
     'assertionFinalizedAt',
@@ -267,37 +271,51 @@ export function assertCanonicalGraphScopedAuthorSealV1(
     'reservedKaId',
   ], 'canonical graph-scoped author seal');
 
+  // Preserve the outer wire-envelope limit as the first failure for hostile
+  // oversized scalar input. The snapshot above guarantees this scan cannot
+  // invoke accessors or observe a field twice.
+  rejectOversizedPayloadScalars(sealedPayload);
+
   assertSealScalar(() => assertCanonicalDigest(
-    payload.assertionMerkleRoot,
+    sealedPayload.assertionMerkleRoot,
     'assertionMerkleRoot',
   ));
-  assertSealScalar(() => assertCanonicalEvmAddress(payload.authorAddress, 'authorAddress'));
-  assertHex32V1(payload.authorAttestationR, 'authorAttestationR');
-  assertHex32V1(payload.authorAttestationVS, 'authorAttestationVS');
-  if (payload.authorSchemeVersion !== '1') {
+  assertSealScalar(() => assertCanonicalEvmAddress(sealedPayload.authorAddress, 'authorAddress'));
+  assertHex32V1(sealedPayload.authorAttestationR, 'authorAttestationR');
+  assertHex32V1(sealedPayload.authorAttestationVS, 'authorAttestationVS');
+  if (sealedPayload.authorSchemeVersion !== '1') {
     fail('canonical-seal-schema', 'authorSchemeVersion must be the exact string "1"');
   }
-  assertSealScalar(() => assertCanonicalChainId(payload.assertedAtChainId, 'assertedAtChainId'));
+  assertSealScalar(() => assertCanonicalChainId(
+    sealedPayload.assertedAtChainId,
+    'assertedAtChainId',
+  ));
   assertSealScalar(() => assertCanonicalEvmAddress(
-    payload.assertedAtKav10Address,
+    sealedPayload.assertedAtKav10Address,
     'assertedAtKav10Address',
   ));
-  const reservedKaId = assertSealU256(payload.reservedKaId, 'reservedKaId');
-  assertCanonicalIsoUtcMillisV1(payload.assertionFinalizedAt);
-  if (payload.contentScopeVersion !== '2') {
+  const reservedKaId = assertSealU256(sealedPayload.reservedKaId, 'reservedKaId');
+  assertCanonicalIsoUtcMillisV1(sealedPayload.assertionFinalizedAt);
+  if (sealedPayload.contentScopeVersion !== '2') {
     fail('canonical-seal-schema', 'contentScopeVersion must be the exact string "2"');
   }
-  const ual = assertCanonicalSealDeterministicUalV1(payload.kaUal);
-  const assertionVersion = assertSealU64(payload.assertionVersion, 'assertionVersion');
+  const ual = assertCanonicalSealDeterministicUalV1(sealedPayload.kaUal);
+  const assertionVersion = assertSealU64(sealedPayload.assertionVersion, 'assertionVersion');
   if (assertionVersion < 1n) {
     fail('canonical-seal-scalar', 'assertionVersion must be in 1..2^64-1');
   }
-  const publicCount = assertSealTripleCountV1(payload.publicTripleCount, 'publicTripleCount');
-  const privateCount = assertSealTripleCountV1(payload.privateTripleCount, 'privateTripleCount');
+  const publicCount = assertSealTripleCountV1(
+    sealedPayload.publicTripleCount,
+    'publicTripleCount',
+  );
+  const privateCount = assertSealTripleCountV1(
+    sealedPayload.privateTripleCount,
+    'privateTripleCount',
+  );
   if (publicCount + privateCount < 1n) {
     fail('canonical-seal-count', 'publicTripleCount + privateTripleCount must be positive');
   }
-  if (payload.privateMerkleRoot === null) {
+  if (sealedPayload.privateMerkleRoot === null) {
     if (privateCount !== 0n) {
       fail(
         'canonical-seal-private-root',
@@ -305,7 +323,10 @@ export function assertCanonicalGraphScopedAuthorSealV1(
       );
     }
   } else {
-    assertSealScalar(() => assertCanonicalDigest(payload.privateMerkleRoot, 'privateMerkleRoot'));
+    assertSealScalar(() => assertCanonicalDigest(
+      sealedPayload.privateMerkleRoot,
+      'privateMerkleRoot',
+    ));
     if (privateCount === 0n) {
       fail(
         'canonical-seal-private-root',
@@ -314,7 +335,7 @@ export function assertCanonicalGraphScopedAuthorSealV1(
     }
   }
 
-  if (ual.agentAddress !== payload.authorAddress) {
+  if (ual.agentAddress !== sealedPayload.authorAddress) {
     fail('canonical-seal-binding', 'kaUal author must equal authorAddress');
   }
   const packedKaId = (BigInt(ual.agentAddress) << 96n) | BigInt(ual.kaNumber);
@@ -324,7 +345,9 @@ export function assertCanonicalGraphScopedAuthorSealV1(
 
   // The structural domain is intentionally capped even though the frozen field
   // widths currently keep every valid payload well below it.
-  canonicalizePayloadAfterValidation(payload as unknown as CanonicalGraphScopedAuthorSealV1);
+  canonicalizePayloadAfterValidation(
+    sealedPayload as unknown as CanonicalGraphScopedAuthorSealV1,
+  );
 }
 
 export function canonicalizeCanonicalGraphScopedAuthorSealV1(
@@ -821,15 +844,26 @@ function assertSealScalar(operation: () => void): void {
   }
 }
 
-function assertClosedKeys(
+function snapshotClosedKeys<const Keys extends readonly string[]>(
   record: Record<string, unknown>,
-  keys: readonly string[],
+  keys: Keys,
   label: string,
-): void {
+): Readonly<Record<Keys[number], unknown>> {
   try {
-    assertExactKeys(record, keys, label);
+    return snapshotExactDataRecord(record, keys, label);
   } catch (cause) {
     fail('canonical-seal-schema', `${label} has an invalid field set`, cause);
+  }
+}
+
+function rejectOversizedPayloadScalars(record: Readonly<Record<string, unknown>>): void {
+  let scalarBytes = 0;
+  for (const value of Object.values(record)) {
+    if (typeof value !== 'string') continue;
+    scalarBytes += UTF8.encode(value).byteLength;
+    if (scalarBytes > MAX_CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_BYTES_V1) {
+      fail('canonical-seal-too-large', 'canonical author-seal payload exceeds its v1 bounds');
+    }
   }
 }
 

--- a/packages/core/src/canonical-graph-scoped-author-seal.ts
+++ b/packages/core/src/canonical-graph-scoped-author-seal.ts
@@ -769,7 +769,7 @@ function assertCanonicalIsoUtcMillisV1(
   }
 }
 
-function assertCanonicalDeterministicUalV1(value: unknown): {
+export function assertCanonicalDeterministicUalV1(value: unknown): {
   ual: CanonicalDeterministicUalV1;
   agentAddress: EvmAddressV1;
   kaNumber: string;

--- a/packages/core/src/canonical-graph-scoped-author-seal.ts
+++ b/packages/core/src/canonical-graph-scoped-author-seal.ts
@@ -26,7 +26,8 @@ import {
 } from './canonical-json.js';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
-  parseDeterministicKnowledgeAssetUal,
+  assertCanonicalDeterministicUalV1 as assertSharedCanonicalDeterministicUalV1,
+  type CanonicalDeterministicUalV1,
 } from './ka-content-scope.js';
 import { isSafeIri } from './sparql-safe.js';
 import {
@@ -47,7 +48,6 @@ declare const HEX_32_V1_BRAND: unique symbol;
 declare const POSITIVE_DECIMAL_U64_V1_BRAND: unique symbol;
 declare const SEAL_TRIPLE_COUNT_V1_BRAND: unique symbol;
 declare const CANONICAL_ISO_UTC_MILLIS_V1_BRAND: unique symbol;
-declare const CANONICAL_DETERMINISTIC_UAL_V1_BRAND: unique symbol;
 
 export type Hex32V1 = string & { readonly [HEX_32_V1_BRAND]: true };
 export type PositiveDecimalU64V1 = DecimalU64V1 & {
@@ -59,9 +59,7 @@ export type SealTripleCountV1 = DecimalU64V1 & {
 export type CanonicalIsoUtcMillisV1 = string & {
   readonly [CANONICAL_ISO_UTC_MILLIS_V1_BRAND]: true;
 };
-export type CanonicalDeterministicUalV1 = string & {
-  readonly [CANONICAL_DETERMINISTIC_UAL_V1_BRAND]: true;
-};
+export type { CanonicalDeterministicUalV1 } from './ka-content-scope.js';
 
 export const CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_DIGEST_DOMAIN_V1 =
   'dkg-ka-author-seal-v1\n' as const;
@@ -289,7 +287,7 @@ export function assertCanonicalGraphScopedAuthorSealV1(
   if (payload.contentScopeVersion !== '2') {
     fail('canonical-seal-schema', 'contentScopeVersion must be the exact string "2"');
   }
-  const ual = assertCanonicalDeterministicUalV1(payload.kaUal);
+  const ual = assertCanonicalSealDeterministicUalV1(payload.kaUal);
   const assertionVersion = assertSealU64(payload.assertionVersion, 'assertionVersion');
   if (assertionVersion < 1n) {
     fail('canonical-seal-scalar', 'assertionVersion must be in 1..2^64-1');
@@ -769,23 +767,16 @@ function assertCanonicalIsoUtcMillisV1(
   }
 }
 
-export function assertCanonicalDeterministicUalV1(value: unknown): {
+function assertCanonicalSealDeterministicUalV1(value: unknown): {
   ual: CanonicalDeterministicUalV1;
   agentAddress: EvmAddressV1;
   kaNumber: string;
 } {
-  if (typeof value !== 'string') {
-    fail('canonical-seal-ual', 'kaUal must be a string');
-  }
   try {
-    const parsed = parseDeterministicKnowledgeAssetUal(value);
-    assertCanonicalEvmAddress(parsed.agentAddress, 'kaUal author');
-    if (parsed.ual !== value) {
-      fail('canonical-seal-ual', 'kaUal must already be in canonical form');
-    }
+    const parsed = assertSharedCanonicalDeterministicUalV1(value);
     return {
-      ual: parsed.ual as CanonicalDeterministicUalV1,
-      agentAddress: parsed.agentAddress as EvmAddressV1,
+      ual: parsed.ual,
+      agentAddress: parsed.agentAddress,
       kaNumber: parsed.kaNumber,
     };
   } catch (cause) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export {
 export * from './author-catalog-codec.js';
 export * from './author-catalog-objects.js';
 export * from './author-catalog-directory.js';
+export * from './swm-author-inventory-v1.js';
 export * from './event-bus.js';
 export * from './backpressure-observability.js';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -386,7 +386,6 @@ export {
   type PositiveDecimalU64V1,
   type SealTripleCountV1,
   type CanonicalIsoUtcMillisV1,
-  type CanonicalDeterministicUalV1,
   type CanonicalGraphScopedAuthorSealV1,
   type CanonicalGraphScopedAuthorSealCoordinateV1,
   type CanonicalGraphScopedAuthorSealRowV1,

--- a/packages/core/src/ka-content-scope.ts
+++ b/packages/core/src/ka-content-scope.ts
@@ -5,9 +5,20 @@ import {
 import type { MemoryLayer } from './memory-model.js';
 import { assertSafeIri, isSafeIri } from './sparql-safe.js';
 import {
+  assertCanonicalEvmAddress,
+  type EvmAddressV1,
+} from './sync-wire-scalars.js';
+import {
   assertNetworkIdV1,
   type NetworkIdV1,
 } from './sync-wire-identifiers.js';
+
+declare const CANONICAL_DETERMINISTIC_UAL_V1_BRAND: unique symbol;
+
+/** A deterministic KA UAL that has already passed the canonical wire check. */
+export type CanonicalDeterministicUalV1 = string & {
+  readonly [CANONICAL_DETERMINISTIC_UAL_V1_BRAND]: true;
+};
 
 /** Existing V10 KAs may be resolved through the quarantined read-only path. */
 export const LEGACY_ROOT_CONTENT_SCOPE_VERSION = 1 as const;
@@ -62,6 +73,13 @@ export interface DeterministicKnowledgeAssetUalParts {
   readonly chainId: string;
   readonly agentAddress: string;
   readonly kaNumber: string;
+}
+
+/** Complete canonical identity returned to every seal/catalog/inventory consumer. */
+export interface CanonicalDeterministicKnowledgeAssetUalPartsV1
+  extends Omit<DeterministicKnowledgeAssetUalParts, 'ual' | 'agentAddress'> {
+  readonly ual: CanonicalDeterministicUalV1;
+  readonly agentAddress: EvmAddressV1;
 }
 
 export interface DeterministicRootlessKnowledgeAssetIdentity
@@ -125,6 +143,30 @@ export function parseDeterministicKnowledgeAssetUal(
     agentAddress,
     kaNumber,
   };
+}
+
+/**
+ * Assert the exact deterministic KA wire identity without coupling callers to
+ * an author-seal codec. Unlike the lower-level canonicalizer, this refuses
+ * aliases and returns every parsed identity component in one pass.
+ */
+export function assertCanonicalDeterministicUalV1(
+  value: unknown,
+): Readonly<CanonicalDeterministicKnowledgeAssetUalPartsV1> {
+  if (typeof value !== 'string') {
+    throw new Error('kaUal must be a string');
+  }
+  const parsed = parseDeterministicKnowledgeAssetUal(value);
+  assertCanonicalEvmAddress(parsed.agentAddress, 'kaUal author');
+  if (parsed.ual !== value) {
+    throw new Error('kaUal must already be in canonical form');
+  }
+  return Object.freeze({
+    ual: parsed.ual as CanonicalDeterministicUalV1,
+    chainId: parsed.chainId,
+    agentAddress: parsed.agentAddress as EvmAddressV1,
+    kaNumber: parsed.kaNumber,
+  });
 }
 
 /**

--- a/packages/core/src/ka-content-scope.ts
+++ b/packages/core/src/ka-content-scope.ts
@@ -14,10 +14,16 @@ import {
 } from './sync-wire-identifiers.js';
 
 declare const CANONICAL_DETERMINISTIC_UAL_V1_BRAND: unique symbol;
+declare const CANONICAL_KNOWLEDGE_ASSET_NUMBER_V1_BRAND: unique symbol;
 
 /** A deterministic KA UAL that has already passed the canonical wire check. */
 export type CanonicalDeterministicUalV1 = string & {
   readonly [CANONICAL_DETERMINISTIC_UAL_V1_BRAND]: true;
+};
+
+/** Canonical base-10 uint96 KA number extracted from a deterministic UAL. */
+export type CanonicalKnowledgeAssetNumberV1 = string & {
+  readonly [CANONICAL_KNOWLEDGE_ASSET_NUMBER_V1_BRAND]: true;
 };
 
 /** Existing V10 KAs may be resolved through the quarantined read-only path. */
@@ -76,10 +82,11 @@ export interface DeterministicKnowledgeAssetUalParts {
 }
 
 /** Complete canonical identity returned to every seal/catalog/inventory consumer. */
-export interface CanonicalDeterministicKnowledgeAssetUalPartsV1
-  extends Omit<DeterministicKnowledgeAssetUalParts, 'ual' | 'agentAddress'> {
+export interface CanonicalDeterministicKnowledgeAssetUalPartsV1 {
   readonly ual: CanonicalDeterministicUalV1;
+  readonly chainId: NetworkIdV1;
   readonly agentAddress: EvmAddressV1;
+  readonly kaNumber: CanonicalKnowledgeAssetNumberV1;
 }
 
 export interface DeterministicRootlessKnowledgeAssetIdentity
@@ -157,6 +164,7 @@ export function assertCanonicalDeterministicUalV1(
     throw new Error('kaUal must be a string');
   }
   const parsed = parseDeterministicKnowledgeAssetUal(value);
+  assertNetworkIdV1(parsed.chainId, 'kaUal network');
   assertCanonicalEvmAddress(parsed.agentAddress, 'kaUal author');
   if (parsed.ual !== value) {
     throw new Error('kaUal must already be in canonical form');
@@ -165,7 +173,7 @@ export function assertCanonicalDeterministicUalV1(
     ual: parsed.ual as CanonicalDeterministicUalV1,
     chainId: parsed.chainId,
     agentAddress: parsed.agentAddress as EvmAddressV1,
-    kaNumber: parsed.kaNumber,
+    kaNumber: parsed.kaNumber as CanonicalKnowledgeAssetNumberV1,
   });
 }
 

--- a/packages/core/src/ka-content-scope.ts
+++ b/packages/core/src/ka-content-scope.ts
@@ -9,6 +9,7 @@ import {
   type EvmAddressV1,
 } from './sync-wire-scalars.js';
 import {
+  MAX_NETWORK_ID_BYTES_V1,
   assertNetworkIdV1,
   type NetworkIdV1,
 } from './sync-wire-identifiers.js';
@@ -112,6 +113,16 @@ const DETERMINISTIC_KA_UAL_RE = /^did:dkg:([^/]+)\/(0x[0-9a-fA-F]{40})\/([0-9]+)
  * through the packed identity are valid graph identities.
  */
 export const MAX_KNOWLEDGE_ASSET_NUMBER = (1n << 96n) - 1n;
+export const MAX_CANONICAL_KNOWLEDGE_ASSET_NUMBER_DIGITS_V1 =
+  MAX_KNOWLEDGE_ASSET_NUMBER.toString(10).length;
+export const MAX_CANONICAL_DETERMINISTIC_UAL_BYTES_V1 =
+  'did:dkg:'.length
+  + MAX_NETWORK_ID_BYTES_V1
+  + '/'.length
+  + '0x'.length
+  + 40
+  + '/'.length
+  + MAX_CANONICAL_KNOWLEDGE_ASSET_NUMBER_DIGITS_V1;
 const MAX_PACKED_ROOTLESS_KNOWLEDGE_ASSET_ID = (1n << 256n) - 1n;
 const PACKED_ROOTLESS_KNOWLEDGE_ASSET_NUMBER_BITS = 96n;
 
@@ -124,6 +135,13 @@ export function parseDeterministicKnowledgeAssetUal(
   rawUal: string,
 ): DeterministicKnowledgeAssetUalParts {
   const input = String(rawUal ?? '').trim();
+  // Every canonical component is ASCII. Bound the full hostile scalar before
+  // IRI validation, regexp traversal, or BigInt parsing can allocate from it.
+  if (input.length > MAX_CANONICAL_DETERMINISTIC_UAL_BYTES_V1) {
+    throw new Error(
+      `Graph-scoped KA UAL exceeds ${MAX_CANONICAL_DETERMINISTIC_UAL_BYTES_V1} bytes`,
+    );
+  }
   if (!isSafeIri(input)) {
     throw new Error(`Invalid graph-scoped KA UAL: ${input || '(empty)'}`);
   }
@@ -135,6 +153,14 @@ export function parseDeterministicKnowledgeAssetUal(
   }
 
   const [, chainId, rawAgentAddress, rawKaNumber] = match;
+  if (chainId.length > MAX_NETWORK_ID_BYTES_V1) {
+    throw new Error(`Graph-scoped KA network exceeds ${MAX_NETWORK_ID_BYTES_V1} bytes`);
+  }
+  if (rawKaNumber.length > MAX_CANONICAL_KNOWLEDGE_ASSET_NUMBER_DIGITS_V1) {
+    throw new Error(
+      'Graph-scoped KA number exceeds the packed uint96 decimal width',
+    );
+  }
   const agentAddress = canonicalKnowledgeAssetAgentAddress(rawAgentAddress);
   // BigInt canonicalisation prevents leading-zero aliases for one graph.
   const kaNumberValue = BigInt(rawKaNumber);

--- a/packages/core/src/swm-author-inventory-v1.ts
+++ b/packages/core/src/swm-author-inventory-v1.ts
@@ -53,6 +53,13 @@ export const MAX_SWM_AUTHOR_INVENTORY_ROWS_BYTES_V1 = 8 * 1024 * 1024;
 export const MAX_SWM_AUTHOR_INVENTORY_ROWS_V1 = 100_000;
 export const MAX_SWM_AUTHOR_INVENTORY_SHARE_OPERATION_ID_BYTES_V1 = 256;
 
+declare const SWM_AUTHOR_INVENTORY_SHARE_OPERATION_ID_V1_BRAND: unique symbol;
+
+/** Canonical publisher-minted operation identity committed by an SWM inventory row. */
+export type SwmAuthorInventoryShareOperationIdV1 = string & {
+  readonly [SWM_AUTHOR_INVENTORY_SHARE_OPERATION_ID_V1_BRAND]: true;
+};
+
 const UTF8 = new TextEncoder();
 const SCOPE_DOMAIN_BYTES = UTF8.encode(SWM_AUTHOR_INVENTORY_SCOPE_DIGEST_DOMAIN_V1);
 const ROWS_DOMAIN_BYTES = UTF8.encode(SWM_AUTHOR_INVENTORY_ROWS_DIGEST_DOMAIN_V1);
@@ -81,7 +88,7 @@ export interface SwmAuthorInventoryRowV1 {
   readonly assertionCoordinate: AssertionCoordinateV1;
   readonly assertionVersion: DecimalU64V1;
   readonly kaUal: CanonicalDeterministicUalV1;
-  readonly shareOperationId: string;
+  readonly shareOperationId: SwmAuthorInventoryShareOperationIdV1;
   readonly projectionDigest: Digest32V1;
   readonly publicTripleCount: CountV1;
   readonly privateTripleCount: CountV1;
@@ -181,7 +188,7 @@ export function assertSwmAuthorInventoryRowV1(
     const assertionVersion = parseCanonicalDecimalU64(value.assertionVersion, 'assertionVersion');
     if (assertionVersion < 1n) throw new Error('assertionVersion must be positive');
     assertCanonicalDeterministicUalV1(value.kaUal);
-    assertBoundedIdentifier(value.shareOperationId, 'shareOperationId');
+    assertSwmAuthorInventoryShareOperationIdV1(value.shareOperationId);
     assertCanonicalDigest(value.projectionDigest, 'projectionDigest');
     const publicTripleCount = parseCanonicalDecimalU64(
       value.publicTripleCount,
@@ -209,6 +216,12 @@ export function assertSwmAuthorInventoryRowV1(
       }
     }
   });
+}
+
+export function assertSwmAuthorInventoryShareOperationIdV1(
+  value: unknown,
+): asserts value is SwmAuthorInventoryShareOperationIdV1 {
+  assertBoundedIdentifier(value, 'shareOperationId');
 }
 
 export function compareSwmAuthorInventoryRowsV1(

--- a/packages/core/src/swm-author-inventory-v1.ts
+++ b/packages/core/src/swm-author-inventory-v1.ts
@@ -21,11 +21,16 @@ import {
   type CanonicalDeterministicUalV1,
 } from './canonical-graph-scoped-author-seal.js';
 import {
+  assertUnsignedControlEnvelope,
   assertSignedControlEnvelope,
+  canonicalizeUnsignedControlEnvelopeBytes,
   canonicalizeSignedControlEnvelopeBytes,
+  computeControlObjectDigestHex,
   parseCanonicalSignedControlEnvelope,
   type SignedControlEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
 } from './sync-control-object.js';
+import { parseDeterministicKnowledgeAssetUal } from './ka-content-scope.js';
 import {
   assertCanonicalChainId,
   assertCanonicalDigest,
@@ -55,6 +60,27 @@ export const MAX_SWM_AUTHOR_INVENTORY_SHARE_OPERATION_ID_BYTES_V1 = 256;
 const UTF8 = new TextEncoder();
 const SCOPE_DOMAIN_BYTES = UTF8.encode(SWM_AUTHOR_INVENTORY_SCOPE_DIGEST_DOMAIN_V1);
 const ROWS_DOMAIN_BYTES = UTF8.encode(SWM_AUTHOR_INVENTORY_ROWS_DIGEST_DOMAIN_V1);
+const SWM_AUTHOR_INVENTORY_SCOPE_KEYS = Object.freeze([
+  'networkId',
+  'contextGraphId',
+  'governanceChainId',
+  'governanceContractAddress',
+  'ownershipTransitionDigest',
+  'subGraphName',
+  'authorAddress',
+  'era',
+] as const);
+const SWM_AUTHOR_INVENTORY_HEAD_ONLY_KEYS = Object.freeze([
+  'version',
+  'previousHeadDigest',
+  'totalRows',
+  'rowsDigest',
+  'issuedAt',
+] as const);
+const SWM_AUTHOR_INVENTORY_HEAD_KEYS = Object.freeze([
+  ...SWM_AUTHOR_INVENTORY_SCOPE_KEYS,
+  ...SWM_AUTHOR_INVENTORY_HEAD_ONLY_KEYS,
+] as const);
 
 /**
  * Exact public-CG lane whose active, author-sealed SWM-only set is attested.
@@ -95,6 +121,11 @@ export interface SwmAuthorInventoryHeadV1 extends SwmAuthorInventoryScopeV1 {
   readonly issuedAt: TimestampMsV1;
 }
 
+export type UnsignedSwmAuthorInventoryHeadEnvelopeV1 = UnsignedControlEnvelopeV1 & {
+  readonly objectType: typeof SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1;
+  readonly payload: SwmAuthorInventoryHeadV1;
+};
+
 export type SignedSwmAuthorInventoryHeadEnvelopeV1 = SignedControlEnvelopeV1 & {
   readonly objectType: typeof SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1;
   readonly payload: SwmAuthorInventoryHeadV1;
@@ -128,16 +159,7 @@ export function assertSwmAuthorInventoryScopeV1(
   value: unknown,
 ): asserts value is SwmAuthorInventoryScopeV1 {
   if (!isPlainRecord(value)) fail('swm-inventory-schema', 'scope must be a plain object');
-  assertExactKeysAdapted(value, [
-    'networkId',
-    'contextGraphId',
-    'governanceChainId',
-    'governanceContractAddress',
-    'ownershipTransitionDigest',
-    'subGraphName',
-    'authorAddress',
-    'era',
-  ], 'scope');
+  assertExactKeysAdapted(value, SWM_AUTHOR_INVENTORY_SCOPE_KEYS, 'scope');
   adaptScalars(() => {
     assertNetworkIdV1(value.networkId);
     assertContextGraphIdV1(value.contextGraphId);
@@ -258,21 +280,7 @@ export function assertSwmAuthorInventoryHeadV1(
   value: unknown,
 ): asserts value is SwmAuthorInventoryHeadV1 {
   if (!isPlainRecord(value)) fail('swm-inventory-schema', 'head must be a plain object');
-  assertExactKeysAdapted(value, [
-    'networkId',
-    'contextGraphId',
-    'governanceChainId',
-    'governanceContractAddress',
-    'ownershipTransitionDigest',
-    'subGraphName',
-    'authorAddress',
-    'era',
-    'version',
-    'previousHeadDigest',
-    'totalRows',
-    'rowsDigest',
-    'issuedAt',
-  ], 'head');
+  assertExactKeysAdapted(value, SWM_AUTHOR_INVENTORY_HEAD_KEYS, 'head');
   const scope = scopeFromHead(value);
   assertSwmAuthorInventoryScopeV1(scope);
   adaptScalars(() => {
@@ -304,6 +312,43 @@ export function deriveSwmAuthorInventoryScopeFromHeadV1(
   return Object.freeze(scopeFromHead(head as unknown as Record<string, unknown>));
 }
 
+export function assertUnsignedSwmAuthorInventoryHeadEnvelopeV1(
+  value: unknown,
+): asserts value is UnsignedSwmAuthorInventoryHeadEnvelopeV1 {
+  try {
+    assertUnsignedControlEnvelope(value as UnsignedControlEnvelopeV1);
+  } catch (cause) {
+    fail('swm-inventory-schema', 'head envelope is not an unsigned control object', cause);
+  }
+  const envelope = value as UnsignedControlEnvelopeV1;
+  assertSwmAuthorInventoryEnvelopeBinding(envelope);
+  try {
+    const bytes = canonicalizeUnsignedControlEnvelopeBytes(envelope);
+    if (bytes.length > MAX_SWM_AUTHOR_INVENTORY_HEAD_BYTES_V1) {
+      fail('swm-inventory-too-large', 'unsigned head exceeds the v1 byte limit');
+    }
+  } catch (cause) {
+    if (cause instanceof SwmAuthorInventoryCodecErrorV1) throw cause;
+    fail('swm-inventory-too-large', 'unsigned head exceeds control-object bounds', cause);
+  }
+}
+
+export function canonicalizeUnsignedSwmAuthorInventoryHeadEnvelopeBytesV1(
+  envelope: UnsignedSwmAuthorInventoryHeadEnvelopeV1,
+): Uint8Array {
+  assertUnsignedSwmAuthorInventoryHeadEnvelopeV1(envelope);
+  return canonicalizeUnsignedControlEnvelopeBytes(envelope);
+}
+
+export function computeSwmAuthorInventoryHeadObjectDigestV1(
+  envelope: UnsignedSwmAuthorInventoryHeadEnvelopeV1,
+): Digest32V1 {
+  assertUnsignedSwmAuthorInventoryHeadEnvelopeV1(envelope);
+  const digest = computeControlObjectDigestHex(envelope);
+  assertCanonicalDigest(digest, 'SWM author inventory head objectDigest');
+  return digest;
+}
+
 export function assertSignedSwmAuthorInventoryHeadEnvelopeV1(
   value: unknown,
 ): asserts value is SignedSwmAuthorInventoryHeadEnvelopeV1 {
@@ -313,13 +358,7 @@ export function assertSignedSwmAuthorInventoryHeadEnvelopeV1(
     fail('swm-inventory-schema', 'head envelope is not a signed control object', cause);
   }
   const envelope = value as SignedControlEnvelopeV1;
-  if (envelope.objectType !== SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1) {
-    fail('swm-inventory-schema', 'head envelope has the wrong objectType');
-  }
-  assertSwmAuthorInventoryHeadV1(envelope.payload);
-  if (envelope.issuer !== envelope.payload.authorAddress) {
-    fail('swm-inventory-binding', 'head issuer must equal the scoped authorAddress');
-  }
+  assertSwmAuthorInventoryEnvelopeBinding(envelope);
   try {
     const bytes = canonicalizeSignedControlEnvelopeBytes(envelope);
     if (bytes.length > MAX_SWM_AUTHOR_INVENTORY_HEAD_BYTES_V1) {
@@ -373,11 +412,21 @@ export function assertSwmAuthorInventorySnapshotBindingV1(
   }
   for (const row of snapshot.rows) {
     const parsedUal = assertCanonicalDeterministicUalV1(row.kaUal);
+    const parsedNetworkId = parseDeterministicKnowledgeAssetUal(row.kaUal).chainId;
+    if (parsedNetworkId !== snapshot.head.payload.networkId) {
+      fail('swm-inventory-binding', 'row kaUal network does not equal the scoped networkId');
+    }
     if (parsedUal.agentAddress !== snapshot.head.payload.authorAddress) {
       fail('swm-inventory-binding', 'row kaUal author does not equal the scoped authorAddress');
     }
     if (BigInt(row.sharedAt) > BigInt(snapshot.head.payload.issuedAt)) {
       fail('swm-inventory-binding', 'row sharedAt must not be later than head issuedAt');
+    }
+    if (
+      row.expiresAt !== null
+      && BigInt(row.expiresAt) <= BigInt(snapshot.head.payload.issuedAt)
+    ) {
+      fail('swm-inventory-binding', 'row expiresAt must be later than head issuedAt');
     }
   }
 }
@@ -440,16 +489,21 @@ function assertBoundedIdentifier(value: unknown, label: string): void {
 }
 
 function scopeFromHead(value: Record<string, unknown>): SwmAuthorInventoryScopeV1 {
-  return {
-    networkId: value.networkId as NetworkIdV1,
-    contextGraphId: value.contextGraphId as ContextGraphIdV1,
-    governanceChainId: value.governanceChainId as ChainIdV1 | null,
-    governanceContractAddress: value.governanceContractAddress as EvmAddressV1 | null,
-    ownershipTransitionDigest: value.ownershipTransitionDigest as Digest32V1 | null,
-    subGraphName: value.subGraphName as SubGraphNameV1 | null,
-    authorAddress: value.authorAddress as EvmAddressV1,
-    era: value.era as DecimalU64V1,
-  };
+  const scope: Record<string, unknown> = {};
+  for (const key of SWM_AUTHOR_INVENTORY_SCOPE_KEYS) scope[key] = value[key];
+  return scope as unknown as SwmAuthorInventoryScopeV1;
+}
+
+function assertSwmAuthorInventoryEnvelopeBinding(
+  envelope: UnsignedControlEnvelopeV1,
+): void {
+  if (envelope.objectType !== SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1) {
+    fail('swm-inventory-schema', 'head envelope has the wrong objectType');
+  }
+  assertSwmAuthorInventoryHeadV1(envelope.payload);
+  if (envelope.issuer !== envelope.payload.authorAddress) {
+    fail('swm-inventory-binding', 'head issuer must equal the scoped authorAddress');
+  }
 }
 
 function adaptScalars(operation: () => void): void {

--- a/packages/core/src/swm-author-inventory-v1.ts
+++ b/packages/core/src/swm-author-inventory-v1.ts
@@ -461,7 +461,15 @@ function assertSwmAuthorInventoryRowsV1(
 }
 
 function assertBoundedIdentifier(value: unknown, label: string): void {
-  if (typeof value !== 'string' || value.length === 0 || value.normalize('NFC') !== value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a nonempty NFC string`);
+  }
+  // One UTF-16 code unit always encodes to at least one UTF-8 byte. Reject an
+  // oversized hostile scalar before normalization performs proportional work.
+  if (value.length > MAX_SWM_AUTHOR_INVENTORY_SHARE_OPERATION_ID_BYTES_V1) {
+    throw new Error(`${label} exceeds its v1 byte limit`);
+  }
+  if (value.normalize('NFC') !== value) {
     throw new Error(`${label} must be a nonempty NFC string`);
   }
   const bytes = UTF8.encode(value);

--- a/packages/core/src/swm-author-inventory-v1.ts
+++ b/packages/core/src/swm-author-inventory-v1.ts
@@ -1,13 +1,15 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import {
+  assertAssertionCoordinateV1,
+  type AssertionCoordinateV1,
+} from './author-catalog-codec.js';
+import {
   AUTHOR_LANE_SCOPE_KEYS_V1,
   assertAuthorLaneScopeV1,
-  assertAssertionCoordinateV1,
   snapshotAuthorLaneScopeV1,
-  type AssertionCoordinateV1,
   type AuthorLaneScopeV1,
-} from './author-catalog-codec.js';
+} from './author-lane-scope-v1.js';
 import {
   MAX_SEAL_TRIPLE_COUNT_V1,
 } from './canonical-graph-scoped-author-seal.js';
@@ -228,7 +230,17 @@ export function compareSwmAuthorInventoryRowsV1(
   left: SwmAuthorInventoryRowV1,
   right: SwmAuthorInventoryRowV1,
 ): number {
-  return left.kaUal < right.kaUal ? -1 : left.kaUal > right.kaUal ? 1 : 0;
+  const leftIdentity = assertCanonicalDeterministicUalV1(left.kaUal);
+  const rightIdentity = assertCanonicalDeterministicUalV1(right.kaUal);
+  if (leftIdentity.chainId !== rightIdentity.chainId) {
+    return leftIdentity.chainId < rightIdentity.chainId ? -1 : 1;
+  }
+  if (leftIdentity.agentAddress !== rightIdentity.agentAddress) {
+    return leftIdentity.agentAddress < rightIdentity.agentAddress ? -1 : 1;
+  }
+  const leftNumber = BigInt(leftIdentity.kaNumber);
+  const rightNumber = BigInt(rightIdentity.kaNumber);
+  return leftNumber < rightNumber ? -1 : leftNumber > rightNumber ? 1 : 0;
 }
 
 export function canonicalizeSwmAuthorInventoryRowsBytesV1(

--- a/packages/core/src/swm-author-inventory-v1.ts
+++ b/packages/core/src/swm-author-inventory-v1.ts
@@ -1,14 +1,12 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import {
+  AUTHOR_LANE_SCOPE_KEYS_V1,
+  assertAuthorLaneScopeV1,
   assertAssertionCoordinateV1,
-  assertContextGraphIdV1,
-  assertNetworkIdV1,
-  assertSubGraphNameV1,
+  snapshotAuthorLaneScopeV1,
   type AssertionCoordinateV1,
-  type ContextGraphIdV1,
-  type NetworkIdV1,
-  type SubGraphNameV1,
+  type AuthorLaneScopeV1,
 } from './author-catalog-codec.js';
 import {
   canonicalizeJson,
@@ -19,7 +17,7 @@ import {
 import {
   assertCanonicalDeterministicUalV1,
   type CanonicalDeterministicUalV1,
-} from './canonical-graph-scoped-author-seal.js';
+} from './ka-content-scope.js';
 import {
   assertUnsignedControlEnvelope,
   assertSignedControlEnvelope,
@@ -30,18 +28,13 @@ import {
   type SignedControlEnvelopeV1,
   type UnsignedControlEnvelopeV1,
 } from './sync-control-object.js';
-import { parseDeterministicKnowledgeAssetUal } from './ka-content-scope.js';
 import {
-  assertCanonicalChainId,
   assertCanonicalDigest,
-  assertCanonicalEvmAddress,
   assertCanonicalTimestampMs,
   parseCanonicalDecimalU64,
-  type ChainIdV1,
   type CountV1,
   type DecimalU64V1,
   type Digest32V1,
-  type EvmAddressV1,
   type TimestampMsV1,
 } from './sync-wire-scalars.js';
 import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
@@ -60,16 +53,7 @@ export const MAX_SWM_AUTHOR_INVENTORY_SHARE_OPERATION_ID_BYTES_V1 = 256;
 const UTF8 = new TextEncoder();
 const SCOPE_DOMAIN_BYTES = UTF8.encode(SWM_AUTHOR_INVENTORY_SCOPE_DIGEST_DOMAIN_V1);
 const ROWS_DOMAIN_BYTES = UTF8.encode(SWM_AUTHOR_INVENTORY_ROWS_DIGEST_DOMAIN_V1);
-const SWM_AUTHOR_INVENTORY_SCOPE_KEYS = Object.freeze([
-  'networkId',
-  'contextGraphId',
-  'governanceChainId',
-  'governanceContractAddress',
-  'ownershipTransitionDigest',
-  'subGraphName',
-  'authorAddress',
-  'era',
-] as const);
+const SWM_AUTHOR_INVENTORY_SCOPE_KEYS = AUTHOR_LANE_SCOPE_KEYS_V1;
 const SWM_AUTHOR_INVENTORY_HEAD_ONLY_KEYS = Object.freeze([
   'version',
   'previousHeadDigest',
@@ -87,16 +71,7 @@ const SWM_AUTHOR_INVENTORY_HEAD_KEYS = Object.freeze([
  * The separate object type and digest domain deliberately prevent this
  * pre-finalization claim from being mistaken for a finalized-VM catalog.
  */
-export interface SwmAuthorInventoryScopeV1 {
-  readonly networkId: NetworkIdV1;
-  readonly contextGraphId: ContextGraphIdV1;
-  readonly governanceChainId: ChainIdV1 | null;
-  readonly governanceContractAddress: EvmAddressV1 | null;
-  readonly ownershipTransitionDigest: Digest32V1 | null;
-  readonly subGraphName: SubGraphNameV1 | null;
-  readonly authorAddress: EvmAddressV1;
-  readonly era: DecimalU64V1;
-}
+export interface SwmAuthorInventoryScopeV1 extends AuthorLaneScopeV1 {}
 
 /** One active, completely committed SWM assertion. */
 export interface SwmAuthorInventoryRowV1 {
@@ -160,17 +135,7 @@ export function assertSwmAuthorInventoryScopeV1(
 ): asserts value is SwmAuthorInventoryScopeV1 {
   if (!isPlainRecord(value)) fail('swm-inventory-schema', 'scope must be a plain object');
   assertExactKeysAdapted(value, SWM_AUTHOR_INVENTORY_SCOPE_KEYS, 'scope');
-  adaptScalars(() => {
-    assertNetworkIdV1(value.networkId);
-    assertContextGraphIdV1(value.contextGraphId);
-    assertGovernanceTuple(value);
-    if (value.ownershipTransitionDigest !== null) {
-      assertCanonicalDigest(value.ownershipTransitionDigest, 'ownershipTransitionDigest');
-    }
-    if (value.subGraphName !== null) assertSubGraphNameV1(value.subGraphName);
-    assertCanonicalEvmAddress(value.authorAddress, 'authorAddress');
-    parseCanonicalDecimalU64(value.era, 'era');
-  });
+  adaptScalars(() => assertAuthorLaneScopeV1(value));
 }
 
 export function canonicalizeSwmAuthorInventoryScopeV1(
@@ -281,7 +246,7 @@ export function assertSwmAuthorInventoryHeadV1(
 ): asserts value is SwmAuthorInventoryHeadV1 {
   if (!isPlainRecord(value)) fail('swm-inventory-schema', 'head must be a plain object');
   assertExactKeysAdapted(value, SWM_AUTHOR_INVENTORY_HEAD_KEYS, 'head');
-  const scope = scopeFromHead(value);
+  const scope = scopeCandidateFromHead(value);
   assertSwmAuthorInventoryScopeV1(scope);
   adaptScalars(() => {
     const version = parseCanonicalDecimalU64(value.version, 'version');
@@ -309,7 +274,7 @@ export function deriveSwmAuthorInventoryScopeFromHeadV1(
   head: SwmAuthorInventoryHeadV1,
 ): SwmAuthorInventoryScopeV1 {
   assertSwmAuthorInventoryHeadV1(head);
-  return Object.freeze(scopeFromHead(head as unknown as Record<string, unknown>));
+  return snapshotAuthorLaneScopeV1(head);
 }
 
 export function assertUnsignedSwmAuthorInventoryHeadEnvelopeV1(
@@ -412,8 +377,7 @@ export function assertSwmAuthorInventorySnapshotBindingV1(
   }
   for (const row of snapshot.rows) {
     const parsedUal = assertCanonicalDeterministicUalV1(row.kaUal);
-    const parsedNetworkId = parseDeterministicKnowledgeAssetUal(row.kaUal).chainId;
-    if (parsedNetworkId !== snapshot.head.payload.networkId) {
+    if (parsedUal.chainId !== snapshot.head.payload.networkId) {
       fail('swm-inventory-binding', 'row kaUal network does not equal the scoped networkId');
     }
     if (parsedUal.agentAddress !== snapshot.head.payload.authorAddress) {
@@ -462,16 +426,6 @@ function assertSwmAuthorInventoryRowsV1(
   }
 }
 
-function assertGovernanceTuple(value: Record<string, unknown>): void {
-  const chain = value.governanceChainId;
-  const contract = value.governanceContractAddress;
-  if ((chain === null) !== (contract === null)) {
-    throw new Error('governanceChainId and governanceContractAddress must both be null or non-null');
-  }
-  if (chain !== null) assertCanonicalChainId(chain, 'governanceChainId');
-  if (contract !== null) assertCanonicalEvmAddress(contract, 'governanceContractAddress');
-}
-
 function assertBoundedIdentifier(value: unknown, label: string): void {
   if (typeof value !== 'string' || value.length === 0 || value.normalize('NFC') !== value) {
     throw new Error(`${label} must be a nonempty NFC string`);
@@ -488,10 +442,17 @@ function assertBoundedIdentifier(value: unknown, label: string): void {
   }
 }
 
-function scopeFromHead(value: Record<string, unknown>): SwmAuthorInventoryScopeV1 {
-  const scope: Record<string, unknown> = {};
-  for (const key of SWM_AUTHOR_INVENTORY_SCOPE_KEYS) scope[key] = value[key];
-  return scope as unknown as SwmAuthorInventoryScopeV1;
+function scopeCandidateFromHead(value: Record<string, unknown>): Record<string, unknown> {
+  return {
+    authorAddress: value.authorAddress,
+    contextGraphId: value.contextGraphId,
+    era: value.era,
+    governanceChainId: value.governanceChainId,
+    governanceContractAddress: value.governanceContractAddress,
+    networkId: value.networkId,
+    ownershipTransitionDigest: value.ownershipTransitionDigest,
+    subGraphName: value.subGraphName,
+  };
 }
 
 function assertSwmAuthorInventoryEnvelopeBinding(

--- a/packages/core/src/swm-author-inventory-v1.ts
+++ b/packages/core/src/swm-author-inventory-v1.ts
@@ -1,0 +1,497 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  assertAssertionCoordinateV1,
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
+  assertSubGraphNameV1,
+  type AssertionCoordinateV1,
+  type ContextGraphIdV1,
+  type NetworkIdV1,
+  type SubGraphNameV1,
+} from './author-catalog-codec.js';
+import {
+  canonicalizeJson,
+  parseCanonicalJson,
+  type CanonicalJsonValue,
+  type StrictJsonParseOptions,
+} from './canonical-json.js';
+import {
+  assertCanonicalDeterministicUalV1,
+  type CanonicalDeterministicUalV1,
+} from './canonical-graph-scoped-author-seal.js';
+import {
+  assertSignedControlEnvelope,
+  canonicalizeSignedControlEnvelopeBytes,
+  parseCanonicalSignedControlEnvelope,
+  type SignedControlEnvelopeV1,
+} from './sync-control-object.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertCanonicalTimestampMs,
+  parseCanonicalDecimalU64,
+  type ChainIdV1,
+  type CountV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type TimestampMsV1,
+} from './sync-wire-scalars.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+
+export const SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1 =
+  'SwmAuthorInventoryHeadV1' as const;
+export const SWM_AUTHOR_INVENTORY_SCOPE_DIGEST_DOMAIN_V1 =
+  'dkg-swm-author-inventory-scope-v1\n' as const;
+export const SWM_AUTHOR_INVENTORY_ROWS_DIGEST_DOMAIN_V1 =
+  'dkg-swm-author-inventory-rows-v1\n' as const;
+export const MAX_SWM_AUTHOR_INVENTORY_HEAD_BYTES_V1 = 4 * 1024;
+export const MAX_SWM_AUTHOR_INVENTORY_ROWS_BYTES_V1 = 8 * 1024 * 1024;
+export const MAX_SWM_AUTHOR_INVENTORY_ROWS_V1 = 100_000;
+export const MAX_SWM_AUTHOR_INVENTORY_SHARE_OPERATION_ID_BYTES_V1 = 256;
+
+const UTF8 = new TextEncoder();
+const SCOPE_DOMAIN_BYTES = UTF8.encode(SWM_AUTHOR_INVENTORY_SCOPE_DIGEST_DOMAIN_V1);
+const ROWS_DOMAIN_BYTES = UTF8.encode(SWM_AUTHOR_INVENTORY_ROWS_DIGEST_DOMAIN_V1);
+
+/**
+ * Exact public-CG lane whose active, author-sealed SWM-only set is attested.
+ * The separate object type and digest domain deliberately prevent this
+ * pre-finalization claim from being mistaken for a finalized-VM catalog.
+ */
+export interface SwmAuthorInventoryScopeV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly era: DecimalU64V1;
+}
+
+/** One active, completely committed SWM assertion. */
+export interface SwmAuthorInventoryRowV1 {
+  readonly assertionCoordinate: AssertionCoordinateV1;
+  readonly assertionVersion: DecimalU64V1;
+  readonly kaUal: CanonicalDeterministicUalV1;
+  readonly shareOperationId: string;
+  readonly projectionDigest: Digest32V1;
+  readonly publicTripleCount: CountV1;
+  readonly privateTripleCount: CountV1;
+  readonly sealDigest: Digest32V1;
+  readonly sharedAt: TimestampMsV1;
+  readonly expiresAt: TimestampMsV1 | null;
+}
+
+/** Constant-size signed exact-set commitment. The rows remain a separate blob. */
+export interface SwmAuthorInventoryHeadV1 extends SwmAuthorInventoryScopeV1 {
+  readonly version: DecimalU64V1;
+  readonly previousHeadDigest: Digest32V1 | null;
+  readonly totalRows: CountV1;
+  readonly rowsDigest: Digest32V1;
+  readonly issuedAt: TimestampMsV1;
+}
+
+export type SignedSwmAuthorInventoryHeadEnvelopeV1 = SignedControlEnvelopeV1 & {
+  readonly objectType: typeof SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1;
+  readonly payload: SwmAuthorInventoryHeadV1;
+};
+
+export interface SwmAuthorInventorySnapshotV1 {
+  readonly head: SignedSwmAuthorInventoryHeadEnvelopeV1;
+  readonly rows: readonly SwmAuthorInventoryRowV1[];
+}
+
+export type SwmAuthorInventoryCodecErrorCodeV1 =
+  | 'swm-inventory-schema'
+  | 'swm-inventory-scalar'
+  | 'swm-inventory-order'
+  | 'swm-inventory-duplicate'
+  | 'swm-inventory-binding'
+  | 'swm-inventory-too-large';
+
+export class SwmAuthorInventoryCodecErrorV1 extends Error {
+  constructor(
+    readonly code: SwmAuthorInventoryCodecErrorCodeV1,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'SwmAuthorInventoryCodecErrorV1';
+  }
+}
+
+export function assertSwmAuthorInventoryScopeV1(
+  value: unknown,
+): asserts value is SwmAuthorInventoryScopeV1 {
+  if (!isPlainRecord(value)) fail('swm-inventory-schema', 'scope must be a plain object');
+  assertExactKeysAdapted(value, [
+    'networkId',
+    'contextGraphId',
+    'governanceChainId',
+    'governanceContractAddress',
+    'ownershipTransitionDigest',
+    'subGraphName',
+    'authorAddress',
+    'era',
+  ], 'scope');
+  adaptScalars(() => {
+    assertNetworkIdV1(value.networkId);
+    assertContextGraphIdV1(value.contextGraphId);
+    assertGovernanceTuple(value);
+    if (value.ownershipTransitionDigest !== null) {
+      assertCanonicalDigest(value.ownershipTransitionDigest, 'ownershipTransitionDigest');
+    }
+    if (value.subGraphName !== null) assertSubGraphNameV1(value.subGraphName);
+    assertCanonicalEvmAddress(value.authorAddress, 'authorAddress');
+    parseCanonicalDecimalU64(value.era, 'era');
+  });
+}
+
+export function canonicalizeSwmAuthorInventoryScopeV1(
+  scope: SwmAuthorInventoryScopeV1,
+): string {
+  assertSwmAuthorInventoryScopeV1(scope);
+  return canonicalizeJson(scope as unknown as CanonicalJsonValue, {
+    maxBytes: MAX_SWM_AUTHOR_INVENTORY_HEAD_BYTES_V1,
+    maxDepth: 1,
+  });
+}
+
+export function computeSwmAuthorInventoryScopeDigestV1(
+  scope: SwmAuthorInventoryScopeV1,
+): Digest32V1 {
+  return digestWithDomain(
+    SCOPE_DOMAIN_BYTES,
+    UTF8.encode(canonicalizeSwmAuthorInventoryScopeV1(scope)),
+  );
+}
+
+export function assertSwmAuthorInventoryRowV1(
+  value: unknown,
+): asserts value is SwmAuthorInventoryRowV1 {
+  if (!isPlainRecord(value)) fail('swm-inventory-schema', 'row must be a plain object');
+  assertExactKeysAdapted(value, [
+    'assertionCoordinate',
+    'assertionVersion',
+    'kaUal',
+    'shareOperationId',
+    'projectionDigest',
+    'publicTripleCount',
+    'privateTripleCount',
+    'sealDigest',
+    'sharedAt',
+    'expiresAt',
+  ], 'row');
+  adaptScalars(() => {
+    assertAssertionCoordinateV1(value.assertionCoordinate);
+    const assertionVersion = parseCanonicalDecimalU64(value.assertionVersion, 'assertionVersion');
+    if (assertionVersion < 1n) throw new Error('assertionVersion must be positive');
+    assertCanonicalDeterministicUalV1(value.kaUal);
+    assertBoundedIdentifier(value.shareOperationId, 'shareOperationId');
+    assertCanonicalDigest(value.projectionDigest, 'projectionDigest');
+    parseCanonicalDecimalU64(value.publicTripleCount, 'publicTripleCount');
+    parseCanonicalDecimalU64(value.privateTripleCount, 'privateTripleCount');
+    assertCanonicalDigest(value.sealDigest, 'sealDigest');
+    assertCanonicalTimestampMs(value.sharedAt, 'sharedAt');
+    if (value.expiresAt !== null) {
+      assertCanonicalTimestampMs(value.expiresAt, 'expiresAt');
+      if (BigInt(value.expiresAt) <= BigInt(value.sharedAt)) {
+        throw new Error('expiresAt must be later than sharedAt');
+      }
+    }
+  });
+}
+
+export function compareSwmAuthorInventoryRowsV1(
+  left: SwmAuthorInventoryRowV1,
+  right: SwmAuthorInventoryRowV1,
+): number {
+  return left.kaUal < right.kaUal ? -1 : left.kaUal > right.kaUal ? 1 : 0;
+}
+
+export function canonicalizeSwmAuthorInventoryRowsBytesV1(
+  rows: readonly SwmAuthorInventoryRowV1[],
+): Uint8Array {
+  assertSwmAuthorInventoryRowsV1(rows);
+  try {
+    return UTF8.encode(canonicalizeJson(rows as unknown as CanonicalJsonValue, {
+      maxBytes: MAX_SWM_AUTHOR_INVENTORY_ROWS_BYTES_V1,
+      maxDepth: 2,
+    }));
+  } catch (cause) {
+    fail('swm-inventory-too-large', 'row set exceeds the canonical v1 byte limit', cause);
+  }
+}
+
+export function parseCanonicalSwmAuthorInventoryRowsV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): readonly SwmAuthorInventoryRowV1[] {
+  let parsed: CanonicalJsonValue;
+  try {
+    parsed = parseCanonicalJson(input, {
+      ...options,
+      maxBytes: Math.min(
+        options.maxBytes ?? MAX_SWM_AUTHOR_INVENTORY_ROWS_BYTES_V1,
+        MAX_SWM_AUTHOR_INVENTORY_ROWS_BYTES_V1,
+      ),
+      maxDepth: Math.min(options.maxDepth ?? 2, 2),
+    });
+  } catch (cause) {
+    fail('swm-inventory-schema', 'rows are not strict canonical JSON', cause);
+  }
+  assertSwmAuthorInventoryRowsV1(parsed);
+  return Object.freeze(parsed.map((row) => Object.freeze({ ...row })));
+}
+
+export function computeSwmAuthorInventoryRowsDigestV1(
+  rows: readonly SwmAuthorInventoryRowV1[],
+): Digest32V1 {
+  return digestWithDomain(ROWS_DOMAIN_BYTES, canonicalizeSwmAuthorInventoryRowsBytesV1(rows));
+}
+
+export function assertSwmAuthorInventoryHeadV1(
+  value: unknown,
+): asserts value is SwmAuthorInventoryHeadV1 {
+  if (!isPlainRecord(value)) fail('swm-inventory-schema', 'head must be a plain object');
+  assertExactKeysAdapted(value, [
+    'networkId',
+    'contextGraphId',
+    'governanceChainId',
+    'governanceContractAddress',
+    'ownershipTransitionDigest',
+    'subGraphName',
+    'authorAddress',
+    'era',
+    'version',
+    'previousHeadDigest',
+    'totalRows',
+    'rowsDigest',
+    'issuedAt',
+  ], 'head');
+  const scope = scopeFromHead(value);
+  assertSwmAuthorInventoryScopeV1(scope);
+  adaptScalars(() => {
+    const version = parseCanonicalDecimalU64(value.version, 'version');
+    if (value.previousHeadDigest !== null) {
+      assertCanonicalDigest(value.previousHeadDigest, 'previousHeadDigest');
+    }
+    if ((version === 0n) !== (value.previousHeadDigest === null)) {
+      throw new Error('only version 0 may have a null previousHeadDigest');
+    }
+    parseCanonicalDecimalU64(value.totalRows, 'totalRows');
+    assertCanonicalDigest(value.rowsDigest, 'rowsDigest');
+    assertCanonicalTimestampMs(value.issuedAt, 'issuedAt');
+  });
+  try {
+    canonicalizeJson(value as unknown as CanonicalJsonValue, {
+      maxBytes: MAX_SWM_AUTHOR_INVENTORY_HEAD_BYTES_V1,
+      maxDepth: 1,
+    });
+  } catch (cause) {
+    fail('swm-inventory-too-large', 'head exceeds the canonical v1 byte limit', cause);
+  }
+}
+
+export function deriveSwmAuthorInventoryScopeFromHeadV1(
+  head: SwmAuthorInventoryHeadV1,
+): SwmAuthorInventoryScopeV1 {
+  assertSwmAuthorInventoryHeadV1(head);
+  return Object.freeze(scopeFromHead(head as unknown as Record<string, unknown>));
+}
+
+export function assertSignedSwmAuthorInventoryHeadEnvelopeV1(
+  value: unknown,
+): asserts value is SignedSwmAuthorInventoryHeadEnvelopeV1 {
+  try {
+    assertSignedControlEnvelope(value as SignedControlEnvelopeV1);
+  } catch (cause) {
+    fail('swm-inventory-schema', 'head envelope is not a signed control object', cause);
+  }
+  const envelope = value as SignedControlEnvelopeV1;
+  if (envelope.objectType !== SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1) {
+    fail('swm-inventory-schema', 'head envelope has the wrong objectType');
+  }
+  assertSwmAuthorInventoryHeadV1(envelope.payload);
+  if (envelope.issuer !== envelope.payload.authorAddress) {
+    fail('swm-inventory-binding', 'head issuer must equal the scoped authorAddress');
+  }
+  try {
+    const bytes = canonicalizeSignedControlEnvelopeBytes(envelope);
+    if (bytes.length > MAX_SWM_AUTHOR_INVENTORY_HEAD_BYTES_V1) {
+      fail('swm-inventory-too-large', 'signed head exceeds the v1 byte limit');
+    }
+  } catch (cause) {
+    if (cause instanceof SwmAuthorInventoryCodecErrorV1) throw cause;
+    fail('swm-inventory-too-large', 'signed head exceeds control-object bounds', cause);
+  }
+}
+
+export function canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1(
+  envelope: SignedSwmAuthorInventoryHeadEnvelopeV1,
+): Uint8Array {
+  assertSignedSwmAuthorInventoryHeadEnvelopeV1(envelope);
+  const bytes = canonicalizeSignedControlEnvelopeBytes(envelope);
+  if (bytes.length > MAX_SWM_AUTHOR_INVENTORY_HEAD_BYTES_V1) {
+    fail('swm-inventory-too-large', 'signed head exceeds the v1 byte limit');
+  }
+  return bytes;
+}
+
+export function parseCanonicalSignedSwmAuthorInventoryHeadEnvelopeV1(
+  input: string | Uint8Array,
+): SignedSwmAuthorInventoryHeadEnvelopeV1 {
+  let parsed: SignedControlEnvelopeV1;
+  try {
+    parsed = parseCanonicalSignedControlEnvelope(input, {
+      maxBytes: MAX_SWM_AUTHOR_INVENTORY_HEAD_BYTES_V1,
+      maxDepth: 3,
+    });
+  } catch (cause) {
+    fail('swm-inventory-schema', 'signed head is not strict canonical JSON', cause);
+  }
+  assertSignedSwmAuthorInventoryHeadEnvelopeV1(parsed);
+  return parsed;
+}
+
+export function assertSwmAuthorInventorySnapshotBindingV1(
+  snapshot: SwmAuthorInventorySnapshotV1,
+): void {
+  assertSignedSwmAuthorInventoryHeadEnvelopeV1(snapshot.head);
+  assertSwmAuthorInventoryRowsV1(snapshot.rows);
+  const expectedCount = BigInt(snapshot.rows.length);
+  if (BigInt(snapshot.head.payload.totalRows) !== expectedCount) {
+    fail('swm-inventory-binding', 'head totalRows does not equal the exact row set');
+  }
+  const expectedRowsDigest = computeSwmAuthorInventoryRowsDigestV1(snapshot.rows);
+  if (snapshot.head.payload.rowsDigest !== expectedRowsDigest) {
+    fail('swm-inventory-binding', 'head rowsDigest does not commit to the exact row set');
+  }
+  for (const row of snapshot.rows) {
+    const parsedUal = assertCanonicalDeterministicUalV1(row.kaUal);
+    if (parsedUal.agentAddress !== snapshot.head.payload.authorAddress) {
+      fail('swm-inventory-binding', 'row kaUal author does not equal the scoped authorAddress');
+    }
+    if (BigInt(row.sharedAt) > BigInt(snapshot.head.payload.issuedAt)) {
+      fail('swm-inventory-binding', 'row sharedAt must not be later than head issuedAt');
+    }
+  }
+}
+
+function assertSwmAuthorInventoryRowsV1(
+  value: unknown,
+): asserts value is SwmAuthorInventoryRowV1[] {
+  if (!Array.isArray(value)) fail('swm-inventory-schema', 'rows must be an array');
+  if (value.length > MAX_SWM_AUTHOR_INVENTORY_ROWS_V1) {
+    fail('swm-inventory-too-large', 'row set exceeds the v1 row limit');
+  }
+  let previous: SwmAuthorInventoryRowV1 | undefined;
+  const coordinates = new Set<string>();
+  const operations = new Set<string>();
+  for (let index = 0; index < value.length; index += 1) {
+    const row = value[index];
+    assertSwmAuthorInventoryRowV1(row);
+    if (previous && compareSwmAuthorInventoryRowsV1(previous, row) >= 0) {
+      fail(
+        previous.kaUal === row.kaUal ? 'swm-inventory-duplicate' : 'swm-inventory-order',
+        `rows must be strictly ordered by canonical kaUal at index ${index}`,
+      );
+    }
+    if (coordinates.has(row.assertionCoordinate)) {
+      fail('swm-inventory-duplicate', 'assertionCoordinate must be unique within a row set');
+    }
+    if (operations.has(row.shareOperationId)) {
+      fail('swm-inventory-duplicate', 'shareOperationId must be unique within a row set');
+    }
+    coordinates.add(row.assertionCoordinate);
+    operations.add(row.shareOperationId);
+    previous = row;
+  }
+}
+
+function assertGovernanceTuple(value: Record<string, unknown>): void {
+  const chain = value.governanceChainId;
+  const contract = value.governanceContractAddress;
+  if ((chain === null) !== (contract === null)) {
+    throw new Error('governanceChainId and governanceContractAddress must both be null or non-null');
+  }
+  if (chain !== null) assertCanonicalChainId(chain, 'governanceChainId');
+  if (contract !== null) assertCanonicalEvmAddress(contract, 'governanceContractAddress');
+}
+
+function assertBoundedIdentifier(value: unknown, label: string): void {
+  if (typeof value !== 'string' || value.length === 0 || value.normalize('NFC') !== value) {
+    throw new Error(`${label} must be a nonempty NFC string`);
+  }
+  const bytes = UTF8.encode(value);
+  if (bytes.length > MAX_SWM_AUTHOR_INVENTORY_SHARE_OPERATION_ID_BYTES_V1) {
+    throw new Error(`${label} exceeds its v1 byte limit`);
+  }
+  for (const codePoint of value) {
+    const point = codePoint.codePointAt(0)!;
+    if (point <= 0x1f || (point >= 0x7f && point <= 0x9f)) {
+      throw new Error(`${label} contains a forbidden control character`);
+    }
+  }
+}
+
+function scopeFromHead(value: Record<string, unknown>): SwmAuthorInventoryScopeV1 {
+  return {
+    networkId: value.networkId as NetworkIdV1,
+    contextGraphId: value.contextGraphId as ContextGraphIdV1,
+    governanceChainId: value.governanceChainId as ChainIdV1 | null,
+    governanceContractAddress: value.governanceContractAddress as EvmAddressV1 | null,
+    ownershipTransitionDigest: value.ownershipTransitionDigest as Digest32V1 | null,
+    subGraphName: value.subGraphName as SubGraphNameV1 | null,
+    authorAddress: value.authorAddress as EvmAddressV1,
+    era: value.era as DecimalU64V1,
+  };
+}
+
+function adaptScalars(operation: () => void): void {
+  try {
+    operation();
+  } catch (cause) {
+    if (cause instanceof SwmAuthorInventoryCodecErrorV1) throw cause;
+    const detail = cause instanceof Error ? `: ${cause.message}` : '';
+    fail('swm-inventory-scalar', `inventory scalar is not canonical${detail}`, cause);
+  }
+}
+
+function assertExactKeysAdapted(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): void {
+  try {
+    assertExactKeys(value, keys, `SWM author inventory ${label}`);
+  } catch (cause) {
+    fail('swm-inventory-schema', `${label} has unexpected or missing keys`, cause);
+  }
+}
+
+function digestWithDomain(domain: Uint8Array, bytes: Uint8Array): Digest32V1 {
+  const hasher = sha256.create();
+  hasher.update(domain);
+  hasher.update(bytes);
+  return `0x${Array.from(
+    hasher.digest() as Uint8Array,
+    (byte: number) => byte.toString(16).padStart(2, '0'),
+  ).join('')}` as Digest32V1;
+}
+
+function fail(
+  code: SwmAuthorInventoryCodecErrorCodeV1,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new SwmAuthorInventoryCodecErrorV1(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/core/src/swm-author-inventory-v1.ts
+++ b/packages/core/src/swm-author-inventory-v1.ts
@@ -9,6 +9,9 @@ import {
   type AuthorLaneScopeV1,
 } from './author-catalog-codec.js';
 import {
+  MAX_SEAL_TRIPLE_COUNT_V1,
+} from './canonical-graph-scoped-author-seal.js';
+import {
   canonicalizeJson,
   parseCanonicalJson,
   type CanonicalJsonValue,
@@ -180,8 +183,23 @@ export function assertSwmAuthorInventoryRowV1(
     assertCanonicalDeterministicUalV1(value.kaUal);
     assertBoundedIdentifier(value.shareOperationId, 'shareOperationId');
     assertCanonicalDigest(value.projectionDigest, 'projectionDigest');
-    parseCanonicalDecimalU64(value.publicTripleCount, 'publicTripleCount');
-    parseCanonicalDecimalU64(value.privateTripleCount, 'privateTripleCount');
+    const publicTripleCount = parseCanonicalDecimalU64(
+      value.publicTripleCount,
+      'publicTripleCount',
+    );
+    const privateTripleCount = parseCanonicalDecimalU64(
+      value.privateTripleCount,
+      'privateTripleCount',
+    );
+    if (
+      publicTripleCount > MAX_SEAL_TRIPLE_COUNT_V1
+      || privateTripleCount > MAX_SEAL_TRIPLE_COUNT_V1
+    ) {
+      throw new Error('triple counts must fit the canonical author seal bounds');
+    }
+    if (publicTripleCount + privateTripleCount === 0n) {
+      throw new Error('inventory row must commit at least one triple');
+    }
     assertCanonicalDigest(value.sealDigest, 'sealDigest');
     assertCanonicalTimestampMs(value.sharedAt, 'sharedAt');
     if (value.expiresAt !== null) {
@@ -256,7 +274,10 @@ export function assertSwmAuthorInventoryHeadV1(
     if ((version === 0n) !== (value.previousHeadDigest === null)) {
       throw new Error('only version 0 may have a null previousHeadDigest');
     }
-    parseCanonicalDecimalU64(value.totalRows, 'totalRows');
+    const totalRows = parseCanonicalDecimalU64(value.totalRows, 'totalRows');
+    if (totalRows > BigInt(MAX_SWM_AUTHOR_INVENTORY_ROWS_V1)) {
+      throw new Error(`totalRows must not exceed ${MAX_SWM_AUTHOR_INVENTORY_ROWS_V1}`);
+    }
     assertCanonicalDigest(value.rowsDigest, 'rowsDigest');
     assertCanonicalTimestampMs(value.issuedAt, 'issuedAt');
   });

--- a/packages/core/test/author-catalog-codec.test.ts
+++ b/packages/core/test/author-catalog-codec.test.ts
@@ -10,6 +10,7 @@ import {
   assertAuthorCatalogRowScopeBindingV1,
   assertAuthorCatalogRowV1,
   assertAuthorCatalogScopeV1,
+  assertAuthorLaneScopeV1,
   assertContextGraphIdV1,
   assertNetworkIdV1,
   assertPackedKaIdAuthorBindingV1,
@@ -27,6 +28,7 @@ import {
   iriComponentV1,
   parseCanonicalAuthorCatalogRowV1,
   parseCanonicalAuthorCatalogScopeV1,
+  snapshotAuthorLaneScopeV1,
   type AssertionCoordinateV1,
   type AuthorCatalogRowV1,
   type AuthorCatalogScopeV1,
@@ -111,6 +113,14 @@ describe('RFC-64 author catalog identifiers and graph names', () => {
 });
 
 describe('AuthorCatalogScopeV1', () => {
+  it('shares one exact author-lane boundary with non-catalog commitments', () => {
+    const { bucketCount: _bucketCount, ...lane } = VALID_SCOPE;
+    expect(() => assertAuthorLaneScopeV1(lane)).not.toThrow();
+    expect(snapshotAuthorLaneScopeV1(VALID_SCOPE)).toEqual(lane);
+    expect(Object.isFrozen(snapshotAuthorLaneScopeV1(VALID_SCOPE))).toBe(true);
+    expect(() => assertAuthorLaneScopeV1(VALID_SCOPE)).toThrow(/catalog-schema/);
+  });
+
   it('pins the exact 346-byte canonical fixture and scope digest', () => {
     expect(canonicalizeAuthorCatalogScopeV1(VALID_SCOPE)).toBe(SCOPE_CANONICAL);
     expect(new TextEncoder().encode(SCOPE_CANONICAL).byteLength).toBe(346);

--- a/packages/core/test/ka-content-scope.test.ts
+++ b/packages/core/test/ka-content-scope.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { NetworkIdV1 } from '../src/index.js';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -36,13 +36,18 @@ describe('KA content scope', () => {
   });
 
   it('asserts one canonical deterministic UAL and returns every identity part', () => {
-    expect(assertCanonicalDeterministicUalV1(CANONICAL_UAL)).toEqual({
+    const parts = assertCanonicalDeterministicUalV1(CANONICAL_UAL);
+    expect(parts).toEqual({
       ual: CANONICAL_UAL,
       chainId: 'base:8453',
       agentAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
       kaNumber: '7',
     });
+    expectTypeOf(parts.chainId).toEqualTypeOf<NetworkIdV1>();
     expect(() => assertCanonicalDeterministicUalV1(UAL)).toThrow(/canonical form/);
+    expect(() => assertCanonicalDeterministicUalV1(
+      'did:dkg:base%2F8453/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/7',
+    )).toThrow(/networkId grammar/);
   });
 
   it('rejects KA numbers outside the uint96 on-chain identity domain', () => {

--- a/packages/core/test/ka-content-scope.test.ts
+++ b/packages/core/test/ka-content-scope.test.ts
@@ -6,6 +6,7 @@ import {
   LegacyKnowledgeAssetReadOnlyError,
   MAX_KNOWLEDGE_ASSET_NUMBER,
   MemoryLayer,
+  assertCanonicalDeterministicUalV1,
   createGraphKnowledgeAssetScope,
   knowledgeAssetLayerGraphUri,
   parseDeterministicKnowledgeAssetUal,
@@ -32,6 +33,16 @@ describe('KA content scope', () => {
       assertionVersion: '2',
       access: 'read-write',
     });
+  });
+
+  it('asserts one canonical deterministic UAL and returns every identity part', () => {
+    expect(assertCanonicalDeterministicUalV1(CANONICAL_UAL)).toEqual({
+      ual: CANONICAL_UAL,
+      chainId: 'base:8453',
+      agentAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      kaNumber: '7',
+    });
+    expect(() => assertCanonicalDeterministicUalV1(UAL)).toThrow(/canonical form/);
   });
 
   it('rejects KA numbers outside the uint96 on-chain identity domain', () => {

--- a/packages/core/test/ka-content-scope.test.ts
+++ b/packages/core/test/ka-content-scope.test.ts
@@ -58,6 +58,13 @@ describe('KA content scope', () => {
       .toThrow(/packed uint96 identity domain/);
   });
 
+  it('rejects oversized deterministic UAL components before numeric parsing', () => {
+    const oversizedNumber = '9'.repeat(1_000_000);
+    const ual = `did:dkg:base:8453/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/${oversizedNumber}`;
+
+    expect(() => assertCanonicalDeterministicUalV1(ual)).toThrow(/UAL exceeds/);
+  });
+
   it('canonically unpacks rootless ids and rejects legacy or out-of-range ids', () => {
     const author = 0x70997970c51812dc3a010c7d01b50e0d17dc79c8n;
     const packed = (author << 96n) | 7n;

--- a/packages/core/test/swm-author-inventory-v1.test.ts
+++ b/packages/core/test/swm-author-inventory-v1.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import {
   MAX_SWM_AUTHOR_INVENTORY_ROWS_V1,
   SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1,
   SwmAuthorInventoryCodecErrorV1,
   assertSignedSwmAuthorInventoryHeadEnvelopeV1,
+  assertSwmAuthorInventoryShareOperationIdV1,
   assertSwmAuthorInventorySnapshotBindingV1,
   canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1,
   canonicalizeSwmAuthorInventoryRowsBytesV1,
@@ -18,6 +19,7 @@ import {
   type SwmAuthorInventoryHeadV1,
   type SwmAuthorInventoryRowV1,
   type SwmAuthorInventoryScopeV1,
+  type SwmAuthorInventoryShareOperationIdV1,
   type UnsignedSwmAuthorInventoryHeadEnvelopeV1,
 } from '../src/swm-author-inventory-v1.js';
 import {
@@ -98,6 +100,15 @@ function signedHead(
 }
 
 describe('SWM author inventory v1', () => {
+  it('brands only canonical bounded share operation ids', () => {
+    const candidate: unknown = 'swm-operation-typed';
+    assertSwmAuthorInventoryShareOperationIdV1(candidate);
+    expectTypeOf(candidate).toEqualTypeOf<SwmAuthorInventoryShareOperationIdV1>();
+    expect(candidate).toBe('swm-operation-typed');
+    expect(() => assertSwmAuthorInventoryShareOperationIdV1('bad\u0000operation'))
+      .toThrow(/forbidden control character/);
+  });
+
   it('commits a domain-separated signed head to one canonical exact row set', () => {
     const rows = Object.freeze([ROW_A, ROW_B]);
     const head = signedHead(rows);

--- a/packages/core/test/swm-author-inventory-v1.test.ts
+++ b/packages/core/test/swm-author-inventory-v1.test.ts
@@ -21,6 +21,9 @@ import {
   type UnsignedSwmAuthorInventoryHeadEnvelopeV1,
 } from '../src/swm-author-inventory-v1.js';
 import {
+  MAX_SEAL_TRIPLE_COUNT_V1,
+} from '../src/canonical-graph-scoped-author-seal.js';
+import {
   computeControlObjectDigestHex,
   type UnsignedControlEnvelopeV1,
 } from '../src/sync-control-object.js';
@@ -218,6 +221,35 @@ describe('SWM author inventory v1', () => {
       ...ROW_A,
       expiresAt: ROW_A.sharedAt,
     } as SwmAuthorInventoryRowV1])).toThrow(/expiresAt must be later/);
+  });
+
+  it('keeps row counts within canonical author-seal bounds', () => {
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([{
+      ...ROW_A,
+      publicTripleCount: '0',
+      privateTripleCount: '0',
+    } as SwmAuthorInventoryRowV1])).toThrow(/at least one triple/);
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([{
+      ...ROW_A,
+      publicTripleCount: (MAX_SEAL_TRIPLE_COUNT_V1 + 1n).toString(),
+    } as SwmAuthorInventoryRowV1])).toThrow(/canonical author seal bounds/);
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([{
+      ...ROW_A,
+      privateTripleCount: (MAX_SEAL_TRIPLE_COUNT_V1 + 1n).toString(),
+    } as SwmAuthorInventoryRowV1])).toThrow(/canonical author seal bounds/);
+  });
+
+  it('rejects signed heads whose declared row count exceeds the protocol cap', () => {
+    expect(() => assertSignedSwmAuthorInventoryHeadEnvelopeV1(
+      signedHead([ROW_A], {
+        totalRows: (MAX_SWM_AUTHOR_INVENTORY_ROWS_V1 + 1).toString(),
+      }),
+    )).toThrow(/totalRows must not exceed/);
+    expect(() => assertSignedSwmAuthorInventoryHeadEnvelopeV1(
+      signedHead([ROW_A], {
+        totalRows: MAX_SWM_AUTHOR_INVENTORY_ROWS_V1.toString(),
+      }),
+    )).not.toThrow();
   });
 
   it('enforces SWM-specific row, scalar, and signed-head size limits', () => {

--- a/packages/core/test/swm-author-inventory-v1.test.ts
+++ b/packages/core/test/swm-author-inventory-v1.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1,
+  SwmAuthorInventoryCodecErrorV1,
+  assertSignedSwmAuthorInventoryHeadEnvelopeV1,
+  assertSwmAuthorInventorySnapshotBindingV1,
+  canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1,
+  canonicalizeSwmAuthorInventoryRowsBytesV1,
+  computeSwmAuthorInventoryRowsDigestV1,
+  computeSwmAuthorInventoryScopeDigestV1,
+  parseCanonicalSignedSwmAuthorInventoryHeadEnvelopeV1,
+  parseCanonicalSwmAuthorInventoryRowsV1,
+  type SignedSwmAuthorInventoryHeadEnvelopeV1,
+  type SwmAuthorInventoryHeadV1,
+  type SwmAuthorInventoryRowV1,
+  type SwmAuthorInventoryScopeV1,
+} from '../src/swm-author-inventory-v1.js';
+import {
+  computeControlObjectDigestHex,
+  type UnsignedControlEnvelopeV1,
+} from '../src/sync-control-object.js';
+
+const AUTHOR = '0x3333333333333333333333333333333333333333';
+const OTHER_AUTHOR = '0x5555555555555555555555555555555555555555';
+const SIGNATURE = `0x${'77'.repeat(65)}`;
+
+const SCOPE = Object.freeze({
+  networkId: 'otp:20430',
+  contextGraphId: 'public-swm-fixture',
+  governanceChainId: '20430',
+  governanceContractAddress: '0x2222222222222222222222222222222222222222',
+  ownershipTransitionDigest: null,
+  subGraphName: null,
+  authorAddress: AUTHOR,
+  era: '0',
+}) as SwmAuthorInventoryScopeV1;
+
+const ROW_A = Object.freeze({
+  assertionCoordinate: 'draft-a',
+  assertionVersion: '1',
+  kaUal: `did:dkg:otp:20430/${AUTHOR}/7`,
+  shareOperationId: 'swm-operation-a',
+  projectionDigest: `0x${'11'.repeat(32)}`,
+  publicTripleCount: '17',
+  privateTripleCount: '0',
+  sealDigest: `0x${'22'.repeat(32)}`,
+  sharedAt: '1700000000000',
+  expiresAt: '1700003600000',
+}) as SwmAuthorInventoryRowV1;
+
+const ROW_B = Object.freeze({
+  assertionCoordinate: 'draft-b',
+  assertionVersion: '2',
+  kaUal: `did:dkg:otp:20430/${AUTHOR}/8`,
+  shareOperationId: 'swm-operation-b',
+  projectionDigest: `0x${'33'.repeat(32)}`,
+  publicTripleCount: '29',
+  privateTripleCount: '3',
+  sealDigest: `0x${'44'.repeat(32)}`,
+  sharedAt: '1700000000100',
+  expiresAt: null,
+}) as SwmAuthorInventoryRowV1;
+
+function signedHead(
+  rows: readonly SwmAuthorInventoryRowV1[],
+  overrides: Partial<SwmAuthorInventoryHeadV1> = {},
+  issuer = AUTHOR,
+): SignedSwmAuthorInventoryHeadEnvelopeV1 {
+  const payload = Object.freeze({
+    ...SCOPE,
+    version: '0',
+    previousHeadDigest: null,
+    totalRows: rows.length.toString(),
+    rowsDigest: computeSwmAuthorInventoryRowsDigestV1(rows),
+    issuedAt: '1700000000200',
+    ...overrides,
+  }) as SwmAuthorInventoryHeadV1;
+  const unsigned = Object.freeze({
+    issuer,
+    objectType: SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1,
+    payload,
+    signatureEvidence: Object.freeze({ kind: 'none' }),
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  }) as UnsignedControlEnvelopeV1;
+  return Object.freeze({
+    ...unsigned,
+    objectDigest: computeControlObjectDigestHex(unsigned),
+    signature: SIGNATURE,
+  }) as SignedSwmAuthorInventoryHeadEnvelopeV1;
+}
+
+describe('SWM author inventory v1', () => {
+  it('commits a domain-separated signed head to one canonical exact row set', () => {
+    const rows = Object.freeze([ROW_A, ROW_B]);
+    const head = signedHead(rows);
+    expect(() => assertSwmAuthorInventorySnapshotBindingV1({ head, rows })).not.toThrow();
+    expect(computeSwmAuthorInventoryScopeDigestV1(SCOPE)).toBe(
+      '0xa800a7ca2211c3b9c7061d088ccbbcab26c6043a87e2c0f96e3526154c2a015d',
+    );
+    expect(head.payload.rowsDigest).toBe(
+      '0xeb09f41f4283d16eb30c23412979bad975e59fb04e8eccd07335c46303d0269e',
+    );
+    expect(head.objectDigest).toBe(
+      '0xfe169b0aae3336138b32cd368c5ff33a1ccb30f3147085a80f29cba017fa0c7a',
+    );
+    expect(new TextDecoder().decode(canonicalizeSwmAuthorInventoryRowsBytesV1(rows)))
+      .toBe(new TextDecoder().decode(canonicalizeSwmAuthorInventoryRowsBytesV1(
+        parseCanonicalSwmAuthorInventoryRowsV1(
+          canonicalizeSwmAuthorInventoryRowsBytesV1(rows),
+        ),
+      )));
+    expect(parseCanonicalSignedSwmAuthorInventoryHeadEnvelopeV1(
+      canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1(head),
+    )).toEqual(head);
+  });
+
+  it('rejects row reordering and duplicate active identities', () => {
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([ROW_B, ROW_A]))
+      .toThrow(/strictly ordered/);
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([
+      ROW_A,
+      { ...ROW_A, assertionCoordinate: 'different', shareOperationId: 'different' },
+    ] as SwmAuthorInventoryRowV1[])).toThrow(/duplicate/);
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([
+      ROW_A,
+      { ...ROW_B, shareOperationId: ROW_A.shareOperationId },
+    ] as SwmAuthorInventoryRowV1[])).toThrow(/shareOperationId must be unique/);
+  });
+
+  it('rejects count, digest, author, and temporal binding failures', () => {
+    const rows = Object.freeze([ROW_A, ROW_B]);
+    expect(() => assertSwmAuthorInventorySnapshotBindingV1({
+      head: signedHead(rows, { totalRows: '1' }),
+      rows,
+    })).toThrow(/totalRows/);
+    expect(() => assertSwmAuthorInventorySnapshotBindingV1({
+      head: signedHead(rows, { rowsDigest: `0x${'99'.repeat(32)}` }),
+      rows,
+    })).toThrow(/rowsDigest/);
+    const foreignRow = Object.freeze({
+      ...ROW_A,
+      kaUal: `did:dkg:otp:20430/${OTHER_AUTHOR}/7`,
+    }) as SwmAuthorInventoryRowV1;
+    expect(() => assertSwmAuthorInventorySnapshotBindingV1({
+      head: signedHead([foreignRow]),
+      rows: [foreignRow],
+    })).toThrow(/row kaUal author/);
+    expect(() => assertSwmAuthorInventorySnapshotBindingV1({
+      head: signedHead([ROW_A], { issuedAt: '1699999999999' }),
+      rows: [ROW_A],
+    })).toThrow(/sharedAt/);
+  });
+
+  it('keeps SWM authority distinct and chains every non-genesis head', () => {
+    const rows = [ROW_A];
+    const head = signedHead(rows);
+    expect(head.objectType).toBe('SwmAuthorInventoryHeadV1');
+    expect(() => assertSignedSwmAuthorInventoryHeadEnvelopeV1(
+      signedHead(rows, {}, OTHER_AUTHOR),
+    )).toThrow(/issuer must equal/);
+    expect(() => assertSignedSwmAuthorInventoryHeadEnvelopeV1(
+      signedHead(rows, { version: '1', previousHeadDigest: null }),
+    ))
+      .toThrowError(SwmAuthorInventoryCodecErrorV1);
+    expect(() => assertSignedSwmAuthorInventoryHeadEnvelopeV1(signedHead(rows, {
+      version: '0',
+      previousHeadDigest: `0x${'55'.repeat(32)}`,
+    }))).toThrow(/only version 0/);
+  });
+
+  it('rejects noncanonical wire JSON and invalid expiry', () => {
+    const canonical = canonicalizeSwmAuthorInventoryRowsBytesV1([ROW_A]);
+    expect(() => parseCanonicalSwmAuthorInventoryRowsV1(
+      ` ${new TextDecoder().decode(canonical)}`,
+    )).toThrow(/canonical/);
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([{
+      ...ROW_A,
+      expiresAt: ROW_A.sharedAt,
+    } as SwmAuthorInventoryRowV1])).toThrow(/expiresAt must be later/);
+  });
+});

--- a/packages/core/test/swm-author-inventory-v1.test.ts
+++ b/packages/core/test/swm-author-inventory-v1.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  MAX_SWM_AUTHOR_INVENTORY_ROWS_V1,
   SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1,
   SwmAuthorInventoryCodecErrorV1,
   assertSignedSwmAuthorInventoryHeadEnvelopeV1,
   assertSwmAuthorInventorySnapshotBindingV1,
   canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1,
   canonicalizeSwmAuthorInventoryRowsBytesV1,
+  canonicalizeUnsignedSwmAuthorInventoryHeadEnvelopeBytesV1,
+  computeSwmAuthorInventoryHeadObjectDigestV1,
   computeSwmAuthorInventoryRowsDigestV1,
   computeSwmAuthorInventoryScopeDigestV1,
   parseCanonicalSignedSwmAuthorInventoryHeadEnvelopeV1,
@@ -15,6 +18,7 @@ import {
   type SwmAuthorInventoryHeadV1,
   type SwmAuthorInventoryRowV1,
   type SwmAuthorInventoryScopeV1,
+  type UnsignedSwmAuthorInventoryHeadEnvelopeV1,
 } from '../src/swm-author-inventory-v1.js';
 import {
   computeControlObjectDigestHex,
@@ -82,10 +86,10 @@ function signedHead(
     payload,
     signatureEvidence: Object.freeze({ kind: 'none' }),
     signatureSuite: 'eip191-personal-sign-digest-v1',
-  }) as UnsignedControlEnvelopeV1;
+  }) as UnsignedSwmAuthorInventoryHeadEnvelopeV1;
   return Object.freeze({
     ...unsigned,
-    objectDigest: computeControlObjectDigestHex(unsigned),
+    objectDigest: computeSwmAuthorInventoryHeadObjectDigestV1(unsigned),
     signature: SIGNATURE,
   }) as SignedSwmAuthorInventoryHeadEnvelopeV1;
 }
@@ -113,6 +117,13 @@ describe('SWM author inventory v1', () => {
     expect(parseCanonicalSignedSwmAuthorInventoryHeadEnvelopeV1(
       canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1(head),
     )).toEqual(head);
+    expect(canonicalizeUnsignedSwmAuthorInventoryHeadEnvelopeBytesV1({
+      issuer: head.issuer,
+      objectType: head.objectType,
+      payload: head.payload,
+      signatureEvidence: head.signatureEvidence,
+      signatureSuite: head.signatureSuite,
+    })).toBeInstanceOf(Uint8Array);
   });
 
   it('rejects row reordering and duplicate active identities', () => {
@@ -146,10 +157,26 @@ describe('SWM author inventory v1', () => {
       head: signedHead([foreignRow]),
       rows: [foreignRow],
     })).toThrow(/row kaUal author/);
+    const foreignNetworkRow = Object.freeze({
+      ...ROW_A,
+      kaUal: `did:dkg:base:8453/${AUTHOR}/7`,
+    }) as SwmAuthorInventoryRowV1;
+    expect(() => assertSwmAuthorInventorySnapshotBindingV1({
+      head: signedHead([foreignNetworkRow]),
+      rows: [foreignNetworkRow],
+    })).toThrow(/row kaUal network/);
     expect(() => assertSwmAuthorInventorySnapshotBindingV1({
       head: signedHead([ROW_A], { issuedAt: '1699999999999' }),
       rows: [ROW_A],
     })).toThrow(/sharedAt/);
+    const expiredRow = Object.freeze({
+      ...ROW_A,
+      expiresAt: '1700000000100',
+    }) as SwmAuthorInventoryRowV1;
+    expect(() => assertSwmAuthorInventorySnapshotBindingV1({
+      head: signedHead([expiredRow]),
+      rows: [expiredRow],
+    })).toThrow(/expiresAt/);
   });
 
   it('keeps SWM authority distinct and chains every non-genesis head', () => {
@@ -167,6 +194,19 @@ describe('SWM author inventory v1', () => {
       version: '0',
       previousHeadDigest: `0x${'55'.repeat(32)}`,
     }))).toThrow(/only version 0/);
+    const valid = signedHead(rows);
+    const wrongTypeUnsigned = Object.freeze({
+      issuer: valid.issuer,
+      objectType: 'AuthorCatalogHeadV1',
+      payload: valid.payload,
+      signatureEvidence: valid.signatureEvidence,
+      signatureSuite: valid.signatureSuite,
+    }) as UnsignedControlEnvelopeV1;
+    expect(() => assertSignedSwmAuthorInventoryHeadEnvelopeV1(Object.freeze({
+      ...wrongTypeUnsigned,
+      objectDigest: computeControlObjectDigestHex(wrongTypeUnsigned),
+      signature: SIGNATURE,
+    }))).toThrow(/wrong objectType/);
   });
 
   it('rejects noncanonical wire JSON and invalid expiry', () => {
@@ -178,5 +218,35 @@ describe('SWM author inventory v1', () => {
       ...ROW_A,
       expiresAt: ROW_A.sharedAt,
     } as SwmAuthorInventoryRowV1])).toThrow(/expiresAt must be later/);
+  });
+
+  it('enforces SWM-specific row, scalar, and signed-head size limits', () => {
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1(
+      new Array(MAX_SWM_AUTHOR_INVENTORY_ROWS_V1 + 1) as SwmAuthorInventoryRowV1[],
+    )).toThrowError(expect.objectContaining({ code: 'swm-inventory-too-large' }));
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([{
+      ...ROW_A,
+      shareOperationId: 'x'.repeat(257),
+    } as SwmAuthorInventoryRowV1])).toThrow(/byte limit/);
+
+    const payload = signedHead([ROW_A]).payload;
+    const oversizedUnsigned = Object.freeze({
+      issuer: AUTHOR,
+      objectType: SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1,
+      payload,
+      signatureEvidence: Object.freeze({
+        kind: 'eip1271-current-finalized',
+        chainId: '20430',
+        contractAddress: AUTHOR,
+      }),
+      signatureSuite: 'eip1271-current-finalized-v1',
+    }) as UnsignedSwmAuthorInventoryHeadEnvelopeV1;
+    expect(() => canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1({
+      ...oversizedUnsigned,
+      objectDigest: computeSwmAuthorInventoryHeadObjectDigestV1(oversizedUnsigned),
+      signature: `0x${'77'.repeat(4096)}`,
+    } as SignedSwmAuthorInventoryHeadEnvelopeV1)).toThrowError(
+      expect.objectContaining({ code: 'swm-inventory-too-large' }),
+    );
   });
 });

--- a/packages/core/test/swm-author-inventory-v1.test.ts
+++ b/packages/core/test/swm-author-inventory-v1.test.ts
@@ -271,6 +271,12 @@ describe('SWM author inventory v1', () => {
       ...ROW_A,
       shareOperationId: 'x'.repeat(257),
     } as SwmAuthorInventoryRowV1])).toThrow(/byte limit/);
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([{
+      ...ROW_A,
+      kaUal: `did:dkg:otp:20430/${AUTHOR}/${'9'.repeat(1_000_000)}`,
+    } as SwmAuthorInventoryRowV1])).toThrowError(expect.objectContaining({
+      code: 'swm-inventory-scalar',
+    }));
 
     const payload = signedHead([ROW_A]).payload;
     const oversizedUnsigned = Object.freeze({

--- a/packages/core/test/swm-author-inventory-v1.test.ts
+++ b/packages/core/test/swm-author-inventory-v1.test.ts
@@ -153,6 +153,23 @@ describe('SWM author inventory v1', () => {
     ] as SwmAuthorInventoryRowV1[])).toThrow(/shareOperationId must be unique/);
   });
 
+  it('orders canonical KA identities by their numeric uint96 asset number', () => {
+    const row2 = Object.freeze({
+      ...ROW_A,
+      kaUal: `did:dkg:otp:20430/${AUTHOR}/2`,
+      shareOperationId: 'swm-operation-2',
+    }) as SwmAuthorInventoryRowV1;
+    const row10 = Object.freeze({
+      ...ROW_B,
+      kaUal: `did:dkg:otp:20430/${AUTHOR}/10`,
+      shareOperationId: 'swm-operation-10',
+    }) as SwmAuthorInventoryRowV1;
+
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([row2, row10])).not.toThrow();
+    expect(() => canonicalizeSwmAuthorInventoryRowsBytesV1([row10, row2]))
+      .toThrow(/strictly ordered/);
+  });
+
   it('rejects count, digest, author, and temporal binding failures', () => {
     const rows = Object.freeze([ROW_A, ROW_B]);
     expect(() => assertSwmAuthorInventorySnapshotBindingV1({


### PR DESCRIPTION
## Impact

This is the protocol-foundation PR for the RFC-64 P3 shadow/audit milestone.

It adds a **separate, domain-separated signed inventory for author-sealed assets that are active in SWM but not yet finalized in VM**. It deliberately does not extend or reinterpret `AuthorCatalogV1`: an SWM claim cannot be mistaken for finalized-VM authority.

This PR is runtime-dormant. It does not publish an inventory, change receiver state, or alter SWM/VM behavior. The next stacked PR adds restart-safe producer persistence; the following PR wires the producer at the complete SWM commit boundary and exposes shadow evidence.

### Guarantees introduced

- Exact canonical scope, row, head, and snapshot-binding codecs.
- Independent object type and scope/row digest domains for SWM-only state.
- A constant-size signed head committing to exact row count and row-set digest.
- Strict row ordering and uniqueness for UAL, assertion coordinate, and share operation.
- Head predecessor-chain rules: only version 0 has no predecessor.
- Author binding: envelope issuer, scoped author, and deterministic UAL author must agree.
- Temporal binding: a row cannot be issued before it was shared; expiry must follow sharing.
- Strict canonical JSON, byte/row caps, and pinned digest vectors.

## Before

```mermaid
sequenceDiagram
    participant SWM as "SWM commit"
    participant VM as "Finalized VM catalog"
    participant Audit as "Completeness audit"
    SWM->>VM: "Only confirmed VM assets enter AuthorCatalogV1"
    Audit-->>SWM: "No domain-specific exact-set object for SWM-only assets"
```

## After this PR

```mermaid
sequenceDiagram
    participant Producer as "Future P3 producer"
    participant Codec as "SWM inventory codec"
    participant Signer as "KA author signer"
    participant Audit as "Shadow verifier"
    Producer->>Codec: "Canonical active SWM-only rows"
    Codec-->>Producer: "rowsDigest + exact totalRows"
    Producer->>Signer: "Domain-separated head objectDigest"
    Signer-->>Producer: "EIP-191 signature"
    Producer->>Audit: "Signed head + exact row set"
    Audit->>Codec: "Verify type, chain, ordering, count, digest, author, time"
    Codec-->>Audit: "Exact-set verdict"
```

## Validation

- `pnpm --filter @origintrail-official/dkg-rdf-utils build`
- `pnpm --filter @origintrail-official/dkg-core build`
- `pnpm --filter @origintrail-official/dkg-core exec vitest run --reporter=dot`
  - 106 test files passed
  - 1,658 tests passed
- Focused SWM inventory suite: 5/5 passed
