### PR TITLE
fix(agent): align curated V2 catalog routing with chain policy

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -6576,11 +6576,9 @@ export class PublishMethods extends DKGAgentBase {
     // derives a detached catalog commitment without altering the exact KA
     // graph or its author seal.
     const graphScopedPublish = options?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION;
-    const hasLocallyGeneratedPrivateCatalog = onChainId != null && (await this.isPrivateContextGraph(contextGraphId));
-    const localTrustedNonManifestCatalogTriples = hasLocallyGeneratedPrivateCatalog
-      ? generatedPrivateCatalogTripleKeys(contextGraphId)
-      : undefined;
-    if (hasLocallyGeneratedPrivateCatalog && !graphScopedPublish) {
+    let localTrustedNonManifestCatalogTriples: PublishOptions['trustedNonManifestCatalogTriples'];
+    if (!graphScopedPublish && onChainId != null && (await this.isPrivateContextGraph(contextGraphId))) {
+      localTrustedNonManifestCatalogTriples = generatedPrivateCatalogTripleKeys(contextGraphId);
       selection = await this._ensureCuratedCatalogInSwm(
         contextGraphId,
         selection,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -669,6 +669,37 @@ export function buildPrivateCatalogDefaultGraphQuads(cgDid: string, assertionUri
     .map((quad) => ({ ...quad, graph: '' }));
 }
 
+/**
+ * Resolve the detached public-catalog capability for an on-chain V2 publish.
+ *
+ * The encryption callback is produced by the chain-aware curated-policy
+ * resolver. It is therefore the authoritative decision for the same publish
+ * operation. Re-reading only local `_meta` here can disagree on an edge whose
+ * catalog metadata has not converged yet: the payload is encrypted as curated,
+ * while the catalog capability is omitted and cores (which intentionally do
+ * not custody curated ciphertext) can only decline the StorageACK with
+ * `MERKLE_MISMATCH_IN_SWM`.
+ */
+export function resolveCuratedV2CatalogCapability(input: {
+  contextGraphId: string;
+  graphScoped: boolean;
+  onChainContextGraphId?: string | bigint;
+  encryptInlinePayload: PublishOptions['encryptInlinePayload'];
+}): PublishOptions['trustedNonManifestCatalogTriples'] {
+  const hasOnChainContextGraphId = typeof input.onChainContextGraphId === 'bigint'
+    ? input.onChainContextGraphId > 0n
+    : typeof input.onChainContextGraphId === 'string'
+      && input.onChainContextGraphId.trim().length > 0;
+  if (
+    !input.graphScoped
+    || !hasOnChainContextGraphId
+    || typeof input.encryptInlinePayload !== 'function'
+  ) {
+    return undefined;
+  }
+  return generatedPrivateCatalogTripleKeys(input.contextGraphId);
+}
+
 export function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
   contextGraphId: string;
   snapshotQuads: readonly Quad[];
@@ -694,7 +725,13 @@ export function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
         ? input.resolvedEncryptInlineChunked
         : input.queuedEncryptInlineChunked,
   };
-  if (!input.onChainContextGraphId || !input.resolvedEncryptInlinePayload) {
+  const trustedNonManifestCatalogTriples = resolveCuratedV2CatalogCapability({
+    contextGraphId: input.contextGraphId,
+    graphScoped: true,
+    onChainContextGraphId: input.onChainContextGraphId,
+    encryptInlinePayload: input.resolvedEncryptInlinePayload,
+  });
+  if (!trustedNonManifestCatalogTriples) {
     return { quads: [...input.snapshotQuads], ...encryptionOptions };
   }
 
@@ -704,8 +741,7 @@ export function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
     // the publisher; never append it to a queued snapshot.
     quads: [...input.snapshotQuads],
     ...encryptionOptions,
-    trustedNonManifestCatalogTriples:
-      generatedPrivateCatalogTripleKeys(input.contextGraphId),
+    trustedNonManifestCatalogTriples,
   };
 }
 
@@ -1615,10 +1651,6 @@ export class PublishMethods extends DKGAgentBase {
       // WM/SWM/VM graph, so reject it instead of signing ambiguous content.
       assertNoKnowledgeAssetPayloadNamedGraphs(quads, privateQuads ?? []);
     }
-    const trustedNonManifestCatalogTriples = graphScopedDirectPublish
-      && await this.isPrivateContextGraph(contextGraphId)
-      ? generatedPrivateCatalogTripleKeys(contextGraphId)
-      : undefined;
     const publishQuads = quads;
 
     // RFC-001 §9.x — sign-at-creation. The publisher refuses on-chain
@@ -1731,6 +1763,17 @@ export class PublishMethods extends DKGAgentBase {
       explicitPublishPolicyTarget,
       publishBindingOptions,
     );
+    // Use the same chain-aware curated decision that selected encryption.
+    // Local `_meta` can legitimately lag chain registration; consulting it a
+    // second time here used to omit the detached catalog from an otherwise
+    // curated V2 publish, leaving every strip-ciphertext core with zero bytes
+    // to verify for StorageACK.
+    const trustedNonManifestCatalogTriples = resolveCuratedV2CatalogCapability({
+      contextGraphId,
+      graphScoped: graphScopedDirectPublish,
+      onChainContextGraphId: onChainId,
+      encryptInlinePayload,
+    });
 
     const result = await this.publisher.publish({
       contextGraphId,
@@ -6533,11 +6576,11 @@ export class PublishMethods extends DKGAgentBase {
     // derives a detached catalog commitment without altering the exact KA
     // graph or its author seal.
     const graphScopedPublish = options?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION;
-    const hasGeneratedPrivateCatalog = onChainId != null && (await this.isPrivateContextGraph(contextGraphId));
-    const trustedNonManifestCatalogTriples = hasGeneratedPrivateCatalog
+    const hasLocallyGeneratedPrivateCatalog = onChainId != null && (await this.isPrivateContextGraph(contextGraphId));
+    const localTrustedNonManifestCatalogTriples = hasLocallyGeneratedPrivateCatalog
       ? generatedPrivateCatalogTripleKeys(contextGraphId)
       : undefined;
-    if (hasGeneratedPrivateCatalog && !graphScopedPublish) {
+    if (hasLocallyGeneratedPrivateCatalog && !graphScopedPublish) {
       selection = await this._ensureCuratedCatalogInSwm(
         contextGraphId,
         selection,
@@ -6628,6 +6671,19 @@ export class PublishMethods extends DKGAgentBase {
     if (encryptInlineChunked) {
       this.log.info(ctx, `LU-11: curated CG ${contextGraphId} — chunked path active (per-chunk SWM gossip + V2 ACK)`);
     }
+
+    // V2 curation is decided by the live chain-aware encryption resolver, not
+    // by a second local `_meta` read. Keep the legacy combined-model behavior
+    // unchanged, but make graph-scoped publishes carry the detached catalog
+    // whenever the exact same operation was resolved as curated.
+    const trustedNonManifestCatalogTriples = graphScopedPublish
+      ? resolveCuratedV2CatalogCapability({
+          contextGraphId,
+          graphScoped: true,
+          onChainContextGraphId: onChainId,
+          encryptInlinePayload,
+        })
+      : localTrustedNonManifestCatalogTriples;
 
     const publisher = options?.publisherOverride ?? this.publisher;
     const result = await publisher.publishFromSharedMemory(contextGraphId, selection, {

--- a/packages/agent/test/direct-rootless-publish.test.ts
+++ b/packages/agent/test/direct-rootless-publish.test.ts
@@ -82,7 +82,7 @@ describe('direct rootless agent publish entrypoint', () => {
     internals.getContextGraphOnChainId = vi.fn(async () => '42');
     internals.isPrivateContextGraph = vi.fn(async () => true);
     internals.createV10ACKProvider = vi.fn(() => undefined);
-    internals._resolveEncryptInlinePayload = vi.fn(async () => undefined);
+    internals._resolveEncryptInlinePayload = vi.fn(async () => async (plaintext: Uint8Array) => plaintext);
     internals._resolveEncryptInlineChunked = vi.fn(async () => undefined);
     internals.emitPublicProjectionAfterPublish = vi.fn(async () => undefined);
     let capturedOptions: PublishOptions | undefined;

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -378,6 +378,69 @@ describe('DKGAgent._resolveEncryptInlinePayload policy lookup', () => {
 });
 
 describe('DKGAgent._publish inline encryption routing', () => {
+  it('uses chain-confirmed V2 encryption to attach the catalog when local meta is stale', async () => {
+    const authorAddress = '0x1111111111111111111111111111111111111111';
+    const reservedKaId = (BigInt(authorAddress) << 96n) | 1n;
+    const encryptInlinePayload = async (plaintext: Uint8Array) => plaintext;
+    const encryptInlineChunked = async () => ({
+      ciphertextChunksRoot: new Uint8Array(32),
+      ciphertextChunkCount: 1,
+      totalCiphertextBytes: 1,
+    });
+    const publisherPublish = recorder(async () => ({
+      status: 'tentative',
+      kaId: reservedKaId.toString(),
+    }));
+    const agentLike = {
+      log: {
+        info: recorder(() => undefined),
+        warn: recorder(() => undefined),
+        error: recorder(() => undefined),
+        debug: recorder(() => undefined),
+      },
+      subscribedContextGraphs: new Set(['private-cg']),
+      contextGraphExists: recorder(async () => true),
+      createV10ACKProvider: recorder(() => undefined),
+      getContextGraphOnChainId: recorder(async () => '4'),
+      isPrivateContextGraph: recorder(async () => false),
+      chain: {
+        chainId: 'base:8453',
+        isV10Ready: () => true,
+        getEvmChainId: async () => 8453n,
+        getKnowledgeAssetsLifecycleAddress: async () =>
+          '0x2222222222222222222222222222222222222222',
+      },
+      peerId: 'peer-1',
+      publisher: { publish: publisherPublish },
+      _buildPrecomputedAttestationForSelection: recorder(async () => ({
+        expectedMerkleRoot: new Uint8Array(32),
+        authorAddress,
+        signature: { r: new Uint8Array(32), vs: new Uint8Array(32) },
+        schemeVersion: 1,
+        reservedKaId,
+      })),
+      _resolveEncryptInlinePayload: recorder(async () => encryptInlinePayload),
+      _resolveEncryptInlineChunked: recorder(async () => encryptInlineChunked),
+      broadcastPublish: recorder(async () => undefined),
+      emitPublicProjectionAfterPublish: recorder(async () => undefined),
+    } as any;
+
+    await (DKGAgent.prototype as any)._publish.call(
+      agentLike,
+      'private-cg',
+      [{ subject: 'urn:test:s', predicate: 'urn:test:p', object: '"value"', graph: '' }],
+    );
+
+    expect(agentLike.isPrivateContextGraph.calls).toEqual([]);
+    expect(publisherPublish.calls.at(-1)?.[0]).toEqual(expect.objectContaining({
+      contextGraphId: 'private-cg',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      encryptInlinePayload,
+      encryptInlineChunked,
+      trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys('private-cg'),
+    }));
+  });
+
   it('does not trust caller accessPolicy=public to bypass chain-confirmed encryption resolution', async () => {
     const encryptInlinePayload = recorder(async (plaintext: Uint8Array) => plaintext);
     const encryptInlineChunked = recorder(() => undefined);
@@ -755,6 +818,38 @@ describe('DKGAgent.publishFromSharedMemory inline encryption routing', () => {
         onChainContextGraphId: '1',
       }),
     ]);
+  });
+
+  it('uses chain-confirmed V2 encryption to attach the catalog when local meta is stale', async () => {
+    const agentLike = makeSwmPublishAgentLike('4');
+    const encryptInlinePayload = async (plaintext: Uint8Array) => plaintext;
+    const encryptInlineChunked = async () => ({
+      ciphertextChunksRoot: new Uint8Array(32),
+      ciphertextChunkCount: 1,
+      totalCiphertextBytes: 1,
+    });
+    agentLike._resolveEncryptInlinePayload = recorder(async () => encryptInlinePayload);
+    agentLike._resolveEncryptInlineChunked = recorder(async () => encryptInlineChunked);
+
+    await (DKGAgent.prototype as any).publishFromSharedMemory.call(
+      agentLike,
+      '0x37b1Fdfd134e2b17583bCBdD3034F91504cD9C70/TrueSeal',
+      'all',
+      { contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION },
+    );
+
+    expect(agentLike.isPrivateContextGraph.calls).toEqual([
+      ['0x37b1Fdfd134e2b17583bCBdD3034F91504cD9C70/TrueSeal'],
+    ]);
+    const publishOptions = agentLike.publisher.publishFromSharedMemory.calls.at(-1)?.[2];
+    expect(publishOptions).toEqual(expect.objectContaining({
+      onChainContextGraphId: '4',
+      encryptInlinePayload,
+      encryptInlineChunked,
+      trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(
+        '0x37b1Fdfd134e2b17583bCBdD3034F91504cD9C70/TrueSeal',
+      ),
+    }));
   });
 });
 

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -838,9 +838,7 @@ describe('DKGAgent.publishFromSharedMemory inline encryption routing', () => {
       { contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION },
     );
 
-    expect(agentLike.isPrivateContextGraph.calls).toEqual([
-      ['0x37b1Fdfd134e2b17583bCBdD3034F91504cD9C70/TrueSeal'],
-    ]);
+    expect(agentLike.isPrivateContextGraph.calls).toEqual([]);
     const publishOptions = agentLike.publisher.publishFromSharedMemory.calls.at(-1)?.[2];
     expect(publishOptions).toEqual(expect.objectContaining({
       onChainContextGraphId: '4',
@@ -850,6 +848,35 @@ describe('DKGAgent.publishFromSharedMemory inline encryption routing', () => {
         '0x37b1Fdfd134e2b17583bCBdD3034F91504cD9C70/TrueSeal',
       ),
     }));
+  });
+
+  it('keeps local-meta catalog mutation for legacy private SWM publishes', async () => {
+    const agentLike = makeSwmPublishAgentLike('4');
+    agentLike.isPrivateContextGraph = recorder(async () => true);
+    agentLike._ensureCuratedCatalogInSwm = recorder(async (
+      _contextGraphId: string,
+      selection: 'all' | { rootEntities: string[] },
+    ) => selection);
+
+    await (DKGAgent.prototype as any).publishFromSharedMemory.call(
+      agentLike,
+      'private-cg',
+      'all',
+    );
+
+    expect(agentLike.isPrivateContextGraph.calls).toEqual([['private-cg']]);
+    expect(agentLike._ensureCuratedCatalogInSwm.calls.at(-1)?.slice(0, 2)).toEqual([
+      'private-cg',
+      'all',
+    ]);
+    expect(agentLike.publisher.publishFromSharedMemory.calls.at(-1)).toEqual([
+      'private-cg',
+      'all',
+      expect.objectContaining({
+        onChainContextGraphId: '4',
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys('private-cg'),
+      }),
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

A V2 publish could make two contradictory curation decisions when local context-graph metadata lagged chain truth:

- the chain-aware policy resolver correctly selected curated encryption and chunked member fanout;
- a separate local `_meta` read omitted the detached public catalog capability.

Cores intentionally do not custody curated private SWM ciphertext. Without the catalog payload, StorageACK fell through to the ordinary SWM lookup and every core declined with `MERKLE_MISMATCH_IN_SWM (intent=1, local=0)`.

This PR makes the resolved encryption callback authoritative for the catalog decision in both direct and shared-memory V2 publish paths. The already-correct queued path now shares the same helper. Legacy root-scoped catalog behavior is unchanged.

## Production evidence

For on-chain CG 4, matched mainnet cores recorded both:

- `SWM host-mode subscription DECLINED ... private-ciphertext strip is ON`
- repeated StorageACK declines with `graph-scoped public triple count mismatch (intent=1, local=0)`

The publisher had emitted curated ciphertext, but the ACK intent carried no verifiable public catalog because its local `_meta` classification disagreed with the live on-chain policy.

## Tests

- `pnpm --filter @origintrail-official/dkg-agent exec vitest run test/encrypt-inline-policy.test.ts test/queued-publish-options.test.ts` — 34 passed
- `pnpm --filter @origintrail-official/dkg-agent run build` — passed (`tsc`, type tests, package-root test)

Regression coverage exercises both direct and shared-memory V2 publishing with stale local metadata (`isPrivateContextGraph=false`) and chain-confirmed curated encryption.
