### PR TITLE
fix(sync): raise the responder snapshot build caps, and pin the two ceilings that must not move

### DIFF
--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -21,6 +21,8 @@ import type { SyncRow, SyncRowListMemo } from './snapshot-cache.js';
 import {
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
+  SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS,
+  SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS,
 } from './snapshot-cache.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
@@ -2960,13 +2962,16 @@ async function buildFreshSwmMetaPlan(
     for (const entry of subjects) {
       bytesEstimate += estimateStringRowHeapBytes(entry.subject, '', '', graph);
     }
-    if (bytesEstimate > SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE) {
+    // Pinned to SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE: a plan holds scalars
+    // (subject IRI + row count), so its ceiling is independent of how large a
+    // materialized snapshot may be.
+    if (bytesEstimate > SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE) {
       throw snapshotBudgetError({
         key: budgetKey,
         reason: 'snapshot_bytes',
         rows: subjects.length,
         bytesEstimate,
-        limit: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+        limit: SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE,
       });
     }
     entries.push({
@@ -3115,13 +3120,16 @@ async function readFreshSwmMetaRowsPageFromPlan(
         continue;
       }
       if (window.length === 0) windowStart = beforeWindow;
-      if (subject.rowCount > SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS) {
+      // Pinned to SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS, NOT the snapshot
+      // build cap: this guards row-group atomicity (#1788), not materialization
+      // size, so it must not drift when the snapshot caps move.
+      if (subject.rowCount > SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS) {
         throw snapshotBudgetError({
           key: budgetKey,
           reason: 'snapshot_rows',
           rows: subject.rowCount,
           bytesEstimate: 0,
-          limit: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
+          limit: SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS,
         });
       }
       window.push(subject);

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -21,8 +21,6 @@ import type { SyncRow, SyncRowListMemo } from './snapshot-cache.js';
 import {
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
-  SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS,
-  SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS,
 } from './snapshot-cache.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
@@ -2757,6 +2755,21 @@ async function readSwmMetaRowsPage(
 const FRESH_SWM_META_PLAN_SUBJECT_CHUNK = 100;
 
 /**
+ * Ceiling for one subject row-group in the fresh-SWM plan lane. Whole-subject
+ * windows are its consistency unit (#1788), so an oversized subject cannot be
+ * served atomically and receives a bounded refusal. This limit is intentionally
+ * independent of snapshot materialization limits.
+ */
+export const FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS = 64_000;
+
+/**
+ * Retained-heap ceiling for fresh-SWM plan scalars (subject IRIs + row counts).
+ * A plan is control-plane state and must remain much smaller than the rows it
+ * describes, independently of snapshot materialization limits.
+ */
+export const FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE = 32 * 1024 * 1024;
+
+/**
  * Hard cardinality cap for a TTL meta session plan's admitted subjects, across
  * all candidate graphs of the phase. The discovery queries are LIMIT-bounded to
  * this cap (plus one sentinel row), so plan construction can never materialize
@@ -2765,7 +2778,7 @@ const FRESH_SWM_META_PLAN_SUBJECT_CHUNK = 100;
  * plan. Sizing: every admitted subject serves at least one row, so this cap
  * alone admits sessions far past the point where they run plan-paged, while
  * the retained plan stays a few megabytes at worst (also capped by the fixed
- * build byte estimate below, which bounds pathological IRI lengths).
+ * plan byte estimate below, which bounds pathological IRI lengths).
  */
 export const FRESH_SWM_META_PLAN_MAX_SUBJECTS = 32_000;
 
@@ -2773,7 +2786,7 @@ export const FRESH_SWM_META_PLAN_MAX_SUBJECTS = 32_000;
  * Discover the TTL-admitted subjects of one SWM meta graph with two
  * small-result queries (no payload rows, no sort, no OFFSET), each bounded by
  * construction: LIMIT (remaining subject allowance + 1 sentinel) and the fixed
- * snapshot-build response byte cap. Crossing either bound is a typed
+ * plan response byte cap. Crossing either bound is a typed
  * per-snapshot budget refusal — the plan lane's one remaining bounded refusal
  * besides the single-oversized-subject case.
  *
@@ -2962,16 +2975,16 @@ async function buildFreshSwmMetaPlan(
     for (const entry of subjects) {
       bytesEstimate += estimateStringRowHeapBytes(entry.subject, '', '', graph);
     }
-    // Pinned to SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE: a plan holds scalars
+    // Pinned to FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE: a plan holds scalars
     // (subject IRI + row count), so its ceiling is independent of how large a
     // materialized snapshot may be.
-    if (bytesEstimate > SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE) {
+    if (bytesEstimate > FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE) {
       throw snapshotBudgetError({
         key: budgetKey,
         reason: 'snapshot_bytes',
         rows: subjects.length,
         bytesEstimate,
-        limit: SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE,
+        limit: FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE,
       });
     }
     entries.push({
@@ -3120,16 +3133,16 @@ async function readFreshSwmMetaRowsPageFromPlan(
         continue;
       }
       if (window.length === 0) windowStart = beforeWindow;
-      // Pinned to SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS, NOT the snapshot
+      // Pinned to FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS, NOT the snapshot
       // build cap: this guards row-group atomicity (#1788), not materialization
       // size, so it must not drift when the snapshot caps move.
-      if (subject.rowCount > SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS) {
+      if (subject.rowCount > FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS) {
         throw snapshotBudgetError({
           key: budgetKey,
           reason: 'snapshot_rows',
           rows: subject.rowCount,
           bytesEstimate: 0,
-          limit: SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS,
+          limit: FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS,
         });
       }
       window.push(subject);

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -2769,6 +2769,10 @@ export const FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS = 64_000;
  */
 export const FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE = 32 * 1024 * 1024;
 
+function freshSwmMetaPlanResponseByteLimit(): number {
+  return snapshotResponseByteLimit(FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE);
+}
+
 /**
  * Hard cardinality cap for a TTL meta session plan's admitted subjects, across
  * all candidate graphs of the phase. The discovery queries are LIMIT-bounded to
@@ -2820,9 +2824,7 @@ async function readFreshSwmMetaSubjects(
     try {
       res = await store.query(sparql, {
         ...syncResponderStoreOptions(signal, operation),
-        maxResponseBytes: snapshotResponseByteLimit(
-          SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
-        ),
+        maxResponseBytes: freshSwmMetaPlanResponseByteLimit(),
       });
     } catch (error) {
       if (!(error instanceof StoreResponseTooLargeError)) throw error;
@@ -2831,7 +2833,7 @@ async function readFreshSwmMetaSubjects(
         reason: 'snapshot_bytes',
         rows: subjects.size,
         bytesEstimate: storeResponseActualBytes(error),
-        limit: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+        limit: FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE,
       });
     }
     if (res.type !== 'bindings') return;
@@ -2902,9 +2904,7 @@ async function countFreshSwmMetaSubjectRows(
         GROUP BY ?s
       `, {
         ...syncResponderStoreOptions(signal, 'sync.responder.countFreshSwmMetaSubjectRows'),
-        maxResponseBytes: snapshotResponseByteLimit(
-          SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
-        ),
+        maxResponseBytes: freshSwmMetaPlanResponseByteLimit(),
       });
     } catch (error) {
       if (!(error instanceof StoreResponseTooLargeError)) throw error;
@@ -2913,7 +2913,7 @@ async function countFreshSwmMetaSubjectRows(
         reason: 'snapshot_bytes',
         rows: chunk.length,
         bytesEstimate: storeResponseActualBytes(error),
-        limit: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+        limit: FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE,
       });
     }
     if (res.type !== 'bindings') continue;
@@ -2927,6 +2927,20 @@ async function countFreshSwmMetaSubjectRows(
     .filter((entry) => entry.rowCount > 0);
 }
 
+function assertFreshSwmMetaSubjectWindowRows(
+  subject: FreshSwmMetaSubjectEntry,
+  budgetKey: string,
+): void {
+  if (subject.rowCount <= FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS) return;
+  throw snapshotBudgetError({
+    key: budgetKey,
+    reason: 'snapshot_rows',
+    rows: subject.rowCount,
+    bytesEstimate: 0,
+    limit: FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS,
+  });
+}
+
 /**
  * Build the tiny, stable pagination plan for a TTL-filtered SWM meta phase.
  * Only graph/subject/count scalars are computed and cached; the payload rows
@@ -2937,10 +2951,11 @@ async function countFreshSwmMetaSubjectRows(
  *
  * The plan itself is bounded by construction: subject cardinality by
  * {@link FRESH_SWM_META_PLAN_MAX_SUBJECTS} (enforced inside the LIMIT-bounded
- * discovery), and the retained scalar estimate by the FIXED snapshot build
- * byte cap — deliberately the constant, not the test/operator-shrinkable
- * session budget, so shrinking the session budget forces plan-paged mode
- * without ever refusing the plan that paged mode needs (#1847 class).
+ * discovery), and the retained scalar estimate and construction-query response
+ * caps by the FIXED plan byte cap — deliberately the constant, not the
+ * test/operator-shrinkable session budget, so shrinking the session budget
+ * forces plan-paged mode without ever refusing the plan that paged mode needs
+ * (#1847 class).
  */
 async function buildFreshSwmMetaPlan(
   store: TripleStore,
@@ -2973,6 +2988,10 @@ async function buildFreshSwmMetaPlan(
     );
     if (subjects.length === 0) continue;
     for (const entry of subjects) {
+      // This is a plan invariant, not just a plan-paged reader guard: the
+      // ordinary snapshot lane also consumes this plan and must refuse the
+      // same pathological row-group under default budgets.
+      assertFreshSwmMetaSubjectWindowRows(entry, budgetKey);
       bytesEstimate += estimateStringRowHeapBytes(entry.subject, '', '', graph);
     }
     // Pinned to FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE: a plan holds scalars
@@ -3136,15 +3155,7 @@ async function readFreshSwmMetaRowsPageFromPlan(
       // Pinned to FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS, NOT the snapshot
       // build cap: this guards row-group atomicity (#1788), not materialization
       // size, so it must not drift when the snapshot caps move.
-      if (subject.rowCount > FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS) {
-        throw snapshotBudgetError({
-          key: budgetKey,
-          reason: 'snapshot_rows',
-          rows: subject.rowCount,
-          bytesEstimate: 0,
-          limit: FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS,
-        });
-      }
+      assertFreshSwmMetaSubjectWindowRows(subject, budgetKey);
       window.push(subject);
       windowRows += subject.rowCount;
       if (windowStart + windowRows >= skip + remaining) break;

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -43,30 +43,6 @@ export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS = 200_000;
 export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE = 96 * 1024 * 1024;
 export const SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS = 500;
 
-/**
- * Ceiling for a SINGLE subject's row group, deliberately NOT raised with the
- * snapshot build caps.
- *
- * Whole-subject windows are the consistency unit of the plan lane (#1788): a
- * seal/head row-group must be served atomically, so a subject larger than this
- * can never be served coherently and a bounded refusal is the correct answer.
- * That is a statement about row-group atomicity, not about how much a snapshot
- * may materialize, so it stays pinned at the historical 64,000 while the
- * snapshot caps move.
- */
-export const SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS = 64_000;
-
-/**
- * Retained-heap ceiling for PLAN SCALARS (subject IRIs + row counts), also
- * deliberately NOT raised with the snapshot build caps.
- *
- * A plan is control-plane state whose whole purpose is to be far smaller than
- * the rows it describes. Letting it grow with the snapshot ceiling would triple
- * the retained plan (~250k subjects) for no benefit, so it stays at the
- * historical 32 MiB.
- */
-export const SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE = 32 * 1024 * 1024;
-
 export interface SyncRowSnapshotLoadLimits {
   maxRows: number;
   maxBytesEstimate: number;

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -20,12 +20,52 @@ export type SyncRow = Readonly<{ s: string; p: string; o: string; g: string }>;
  * They bound temporary materialization even when an operator configures a very
  * large cache. Larger phases use direct store paging instead of being cached.
  */
-// Keep the ordinary 50 x 1,000-triple release gate on the snapshot path. The
-// byte ceiling remains the primary heap bound, so raising the row ceiling does
-// not permit a large-literal snapshot to exceed 32 MiB of estimated row data.
-export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS = 64_000;
-export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE = 32 * 1024 * 1024;
+// Sized against measured mainnet `_meta` density (fifa-world-cup-2026,
+// 2026-08-05: 76,265 rows / 34.5 MiB => 474.5 B/row via
+// estimateStringRowHeapBytes). The two caps are CO-TUNED: 200,000 x 474.5 B
+// ~= 90.5 MiB, just under the 96 MiB ceiling, so neither cap is dead code —
+// ordinary rows bind on ROWS and large-literal rows bind on BYTES.
+//
+// Both stay strictly below the retained per-snapshot caps
+// (SYNC_RESPONDER_PER_SNAPSHOT_ROW_LIMIT = 250_000,
+// SYNC_RESPONDER_PER_SNAPSHOT_BYTES_ESTIMATE_LIMIT = 128 MiB), preserving the
+// "hard build caps < retained-cache defaults" ordering documented above: a
+// snapshot that passes the build check is always admissible, never built and
+// then rejected.
+//
+// Why raised from 64,000 / 32 MiB: a CG whose `_meta` crossed the old ceiling
+// fell off the in-memory predicate (filterDurableMetaSnapshotRows) onto the
+// SPARQL fallback (buildDurableMetaRowsQuery), whose assertion-name branch is
+// O(candidates x assertionName-lifecycles) and is re-paid per page. Measured on
+// mainnet that fallback exceeded a 120s server-side query deadline; fifa was
+// only 1.19x over the row cap and 1.08x over the byte cap when it fell off.
+export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS = 200_000;
+export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE = 96 * 1024 * 1024;
 export const SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS = 500;
+
+/**
+ * Ceiling for a SINGLE subject's row group, deliberately NOT raised with the
+ * snapshot build caps.
+ *
+ * Whole-subject windows are the consistency unit of the plan lane (#1788): a
+ * seal/head row-group must be served atomically, so a subject larger than this
+ * can never be served coherently and a bounded refusal is the correct answer.
+ * That is a statement about row-group atomicity, not about how much a snapshot
+ * may materialize, so it stays pinned at the historical 64,000 while the
+ * snapshot caps move.
+ */
+export const SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS = 64_000;
+
+/**
+ * Retained-heap ceiling for PLAN SCALARS (subject IRIs + row counts), also
+ * deliberately NOT raised with the snapshot build caps.
+ *
+ * A plan is control-plane state whose whole purpose is to be far smaller than
+ * the rows it describes. Letting it grow with the snapshot ceiling would triple
+ * the retained plan (~250k subjects) for no benefit, so it stays at the
+ * historical 32 MiB.
+ */
+export const SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE = 32 * 1024 * 1024;
 
 export interface SyncRowSnapshotLoadLimits {
   maxRows: number;

--- a/packages/agent/test/sync-responder-snapshot-cache.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-cache.test.ts
@@ -7,8 +7,6 @@ import {
   type SyncRowListMemo,
 } from '../src/sync/responder/graph-plan.js';
 import {
-  SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS,
-  SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
 } from '../src/sync/responder/snapshot-cache.js';
@@ -80,18 +78,6 @@ describe('sync responder snapshot budget defaults', () => {
       .toBeLessThan(SYNC_RESPONDER_PER_SNAPSHOT_BYTES_ESTIMATE_LIMIT);
   });
 
-  it('keeps the row-group atomicity and plan-scalar ceilings pinned to their own constants', () => {
-    // These two guard different things from snapshot materialization size and
-    // must NOT drift with the build caps: the first is #1788 row-group
-    // atomicity, the second bounds control-plane scalars.
-    expect(SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS).toBe(64_000);
-    expect(SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE).toBe(32 * 1024 * 1024);
-    expect(SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS)
-      .toBeLessThan(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS);
-    expect(SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE)
-      .toBeLessThan(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE);
-  });
-
   it('resolves memo build limits to the build caps under default budgets', () => {
     // snapshotLoadLimits is min(BUILD_CAP, configured). Under production
     // defaults the build cap must be the binding one, or the raise is inert.
@@ -104,6 +90,51 @@ describe('sync responder snapshot budget defaults', () => {
     expect(memo.snapshotLoadLimits?.maxRows).toBe(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS);
     expect(memo.snapshotLoadLimits?.maxBytesEstimate)
       .toBe(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE);
+  });
+
+  it('keeps a 64,001-row durable-meta graph on the memoized snapshot lane', async () => {
+    const contextGraphId = 'snapshot-cap-regression';
+    const rawRowCount = 64_001;
+    const querySources: string[] = [];
+    const store = {
+      query: vi.fn(async (_sparql: string, options?: { source?: string }) => {
+        const source = options?.source ?? 'unknown';
+        querySources.push(source);
+        if (source === 'sync.responder.readDurableMetaGraphSnapshot') {
+          return {
+            type: 'bindings' as const,
+            bindings: Array.from({ length: rawRowCount }, (_, index) => ({
+              s: `did:dkg:activity:${contextGraphId}:${index}`,
+              p: `${DKG_NS}status`,
+              o: '"confirmed"',
+            })),
+          };
+        }
+        if (source === 'sync.responder.readDurableMetaRowsPage') {
+          throw new Error('store-paged durable-meta fallback must not run');
+        }
+        throw new Error(`unexpected durable-meta query source: ${source}`);
+      }),
+    } as unknown as OxigraphStore;
+    const memo = createResponderSyncRowListMemo(120_000, 64, {
+      phase: 'durable_meta',
+      budget: createSyncResponderSnapshotBudget(
+        resolveSyncResponderSnapshotBudgetOptions(undefined, {}),
+      ),
+    });
+    const readPage = (offset: number) => readDurableMetaPage({
+      store,
+      contextGraphId,
+      registeredSubGraphNames: [],
+      offset,
+      limit: 500,
+      rowListMemo: memo,
+      rowListCacheKey: 'durable-meta:64k-regression',
+    });
+
+    await expect(readPage(0)).resolves.toHaveLength(500);
+    await expect(readPage(500)).resolves.toHaveLength(500);
+    expect(querySources).toEqual(['sync.responder.readDurableMetaGraphSnapshot']);
   });
 
   it('allows operators to override every responder snapshot budget limit', () => {

--- a/packages/agent/test/sync-responder-snapshot-cache.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-cache.test.ts
@@ -7,6 +7,12 @@ import {
   type SyncRowListMemo,
 } from '../src/sync/responder/graph-plan.js';
 import {
+  SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS,
+  SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE,
+  SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+  SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
+} from '../src/sync/responder/snapshot-cache.js';
+import {
   SYNC_RESPONDER_DURABLE_DATA_SNAPSHOT_LIMIT,
   SYNC_RESPONDER_DURABLE_META_SNAPSHOT_LIMIT,
   SYNC_RESPONDER_GLOBAL_SNAPSHOT_BYTES_ESTIMATE_LIMIT,
@@ -58,6 +64,46 @@ describe('sync responder snapshot budget defaults', () => {
       maxSnapshotRows: SYNC_RESPONDER_PER_SNAPSHOT_ROW_LIMIT,
       maxSnapshotBytesEstimate: SYNC_RESPONDER_PER_SNAPSHOT_BYTES_ESTIMATE_LIMIT,
     });
+  });
+
+  it('keeps hard build caps below the retained per-snapshot caps', () => {
+    // The documented ordering ("hard build caps are intentionally lower than
+    // the retained-cache defaults") is what guarantees a snapshot that passes
+    // the build check is always admissible, rather than being built and then
+    // rejected by budget.admit(). If a future bump inverts this, that failure
+    // mode returns silently — so pin it.
+    expect(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS).toBe(200_000);
+    expect(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE).toBe(96 * 1024 * 1024);
+    expect(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS)
+      .toBeLessThan(SYNC_RESPONDER_PER_SNAPSHOT_ROW_LIMIT);
+    expect(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE)
+      .toBeLessThan(SYNC_RESPONDER_PER_SNAPSHOT_BYTES_ESTIMATE_LIMIT);
+  });
+
+  it('keeps the row-group atomicity and plan-scalar ceilings pinned to their own constants', () => {
+    // These two guard different things from snapshot materialization size and
+    // must NOT drift with the build caps: the first is #1788 row-group
+    // atomicity, the second bounds control-plane scalars.
+    expect(SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS).toBe(64_000);
+    expect(SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE).toBe(32 * 1024 * 1024);
+    expect(SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS)
+      .toBeLessThan(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS);
+    expect(SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE)
+      .toBeLessThan(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE);
+  });
+
+  it('resolves memo build limits to the build caps under default budgets', () => {
+    // snapshotLoadLimits is min(BUILD_CAP, configured). Under production
+    // defaults the build cap must be the binding one, or the raise is inert.
+    const memo = createResponderSyncRowListMemo(120_000, 64, {
+      phase: 'durable_meta',
+      budget: createSyncResponderSnapshotBudget(
+        resolveSyncResponderSnapshotBudgetOptions(undefined, {}),
+      ),
+    });
+    expect(memo.snapshotLoadLimits?.maxRows).toBe(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS);
+    expect(memo.snapshotLoadLimits?.maxBytesEstimate)
+      .toBe(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE);
   });
 
   it('allows operators to override every responder snapshot budget limit', () => {

--- a/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
+++ b/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
@@ -6,6 +6,7 @@ import {
   type Quad,
 } from '@origintrail-official/dkg-storage';
 import { createSyncResponderSnapshotBudget } from '../src/sync/responder/snapshot-budget.js';
+import { estimateStringRowHeapBytes } from '../src/sync/memory-telemetry.js';
 import {
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
@@ -551,6 +552,101 @@ describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', (
     await store.close();
   });
 
+  it('refuses fresh-SWM plan scalar growth at the plan byte cap, independent of snapshot caps', async () => {
+    const cgId = `plan-bytes-${'g'.repeat(2_048)}`;
+    const metaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
+    const subjects = Array.from(
+      { length: 16_000 },
+      (_, index) => `urn:plan-subject:${String(index).padStart(5, '0')}`,
+    );
+    const planBytesEstimate = subjects.reduce(
+      (sum, subject) => sum + estimateStringRowHeapBytes(subject, '', '', metaGraph),
+      0,
+    );
+    expect(planBytesEstimate).toBeGreaterThan(FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE);
+    expect(planBytesEstimate).toBeLessThan(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE);
+
+    const store = new OxigraphStore();
+    await store.insert([{
+      graph: metaGraph,
+      subject: 'urn:plan-seed',
+      predicate: `${DKG_NS}publishedAt`,
+      object: `"${freshIso()}"^^<${XSD_DT}>`,
+    }]);
+    const originalQuery = store.query.bind(store);
+    const planResponseCaps: number[] = [];
+    let failPlanResponse = false;
+    store.query = (async (sparql: string, options?: unknown) => {
+      const queryOptions = options as { source?: string; maxResponseBytes?: number } | undefined;
+      const source = queryOptions?.source;
+      if (
+        source === 'sync.responder.readFreshSwmMetaSubjects' ||
+        source === 'sync.responder.readFreshSwmMetaHeadSubjects'
+      ) {
+        planResponseCaps.push(queryOptions?.maxResponseBytes ?? 0);
+        if (failPlanResponse) {
+          throw new StoreResponseTooLargeError(
+            FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE * 2,
+            FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE * 2 + 1,
+          );
+        }
+        return {
+          type: 'bindings' as const,
+          bindings: source === 'sync.responder.readFreshSwmMetaSubjects'
+            ? subjects.map((subject) => ({ s: subject }))
+            : [],
+        };
+      }
+      if (source === 'sync.responder.countFreshSwmMetaSubjectRows') {
+        planResponseCaps.push(queryOptions?.maxResponseBytes ?? 0);
+        const requestedSubjects = [...sparql.matchAll(/<(urn:plan-subject:[^>]+)>/g)]
+          .map((match) => match[1] as string);
+        return {
+          type: 'bindings' as const,
+          bindings: requestedSubjects.map((subject) => ({ s: subject, count: '1' })),
+        };
+      }
+      return originalQuery(sparql, options as never);
+    }) as OxigraphStore['query'];
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: TTL_MS, syncPageSize: 500 });
+    await expect(cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta',
+      offset: 0,
+      limit: 500,
+      syncSessionId: 'plan-byte-cap-session',
+    })).rejects.toMatchObject({
+      name: 'QuietRetryableHandlerError',
+      message: expect.stringContaining(`limit=${FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE}`),
+    });
+    expect(planResponseCaps.length).toBeGreaterThan(2);
+    expect(new Set(planResponseCaps)).toEqual(new Set([
+      FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE * 2,
+    ]));
+
+    // The store-cap translation must report the same PLAN heap ceiling, not
+    // the larger snapshot materialization ceiling.
+    failPlanResponse = true;
+    const storeCapHandler = registerTestSyncHandler(store, {
+      sharedMemoryTtlMs: TTL_MS,
+      syncPageSize: 500,
+    });
+    await expect(storeCapHandler.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta',
+      offset: 0,
+      limit: 500,
+      syncSessionId: 'plan-byte-store-cap-session',
+    })).rejects.toMatchObject({
+      name: 'QuietRetryableHandlerError',
+      message: expect.stringContaining(`limit=${FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE}`),
+    });
+    await store.close();
+  }, 120_000);
+
   it('refuses a fresh subject set beyond the plan cardinality cap as a TYPED bounded refusal, via LIMIT-bounded discovery', async () => {
     const cgId = 'meta-ceiling-cardinality';
     const metaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
@@ -665,29 +761,33 @@ describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', (
     }
     await insertChunked(store, monsterQuads);
 
-    const cap = registerTestSyncHandler(store, {
-      sharedMemoryTtlMs: TTL_MS,
-      syncPageSize: 500,
-      snapshotBudget: PLAN_FORCED_SNAPSHOT_BUDGET,
-    });
-
-    await expect(cap.invoke({
-      contextGraphId: cgId,
-      includeSharedMemory: true,
-      phase: 'meta',
-      offset: 0,
-      limit: 500,
-      syncSessionId: 'monster-session',
-    })).rejects.toMatchObject({
-      // The protocol boundary deliberately converts the internal
-      // SyncRowSnapshotBudgetError into a quiet retryable response while
-      // preserving its typed budget details in the message.
-      name: 'QuietRetryableHandlerError',
-      message: expect.stringContaining(
-        `actual=${FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS + 1}, ` +
-        `limit=${FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS}`,
-      ),
-    });
+    for (const [sessionSuffix, snapshotBudget] of [
+      ['default', undefined],
+      ['forced-plan', PLAN_FORCED_SNAPSHOT_BUDGET],
+    ] as const) {
+      const cap = registerTestSyncHandler(store, {
+        sharedMemoryTtlMs: TTL_MS,
+        syncPageSize: 500,
+        ...(snapshotBudget ? { snapshotBudget } : {}),
+      });
+      await expect(cap.invoke({
+        contextGraphId: cgId,
+        includeSharedMemory: true,
+        phase: 'meta',
+        offset: 0,
+        limit: 500,
+        syncSessionId: `monster-session-${sessionSuffix}`,
+      })).rejects.toMatchObject({
+        // The protocol boundary deliberately converts the internal
+        // SyncRowSnapshotBudgetError into a quiet retryable response while
+        // preserving its typed budget details in the message.
+        name: 'QuietRetryableHandlerError',
+        message: expect.stringContaining(
+          `actual=${FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS + 1}, ` +
+          `limit=${FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS}`,
+        ),
+      });
+    }
     await store.close();
   }, 120_000);
 

--- a/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
+++ b/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
@@ -6,6 +6,7 @@ import {
   type Quad,
 } from '@origintrail-official/dkg-storage';
 import { createSyncResponderSnapshotBudget } from '../src/sync/responder/snapshot-budget.js';
+import { SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS } from '../src/sync/responder/snapshot-cache.js';
 import {
   createResponderFreshSwmMetaPlanMemo,
   FRESH_SWM_META_PLAN_MAX_SUBJECTS,
@@ -200,7 +201,23 @@ describe('SWM meta lane above the 64,000-row snapshot ceiling (#1847)', () => {
     await insertChunked(store, quads);
     const seedDurationMs = Date.now() - seedStartedAt;
 
-    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: TTL_MS, syncPageSize: 5000 });
+    // The point of this test is the DEGRADATION path — an admitted set larger
+    // than the per-snapshot ceiling must still be served, page by page, rather
+    // than refused. Express that ceiling EXPLICITLY instead of relying on the
+    // global build cap: snapshotLoadLimits is min(BUILD_CAP, configured), so a
+    // 60,000-row session limit forces degradation no matter what the build cap
+    // is. Relying on the constant is how this test would silently stop
+    // exercising the degradation path the next time the cap moves.
+    const cap = registerTestSyncHandler(store, {
+      sharedMemoryTtlMs: TTL_MS,
+      syncPageSize: 5000,
+      snapshotBudget: {
+        maxRows: 1_000_000,
+        maxBytesEstimate: Number.MAX_SAFE_INTEGER,
+        maxSnapshotRows: 60_000,
+        maxSnapshotBytesEstimate: Number.MAX_SAFE_INTEGER,
+      },
+    });
     const watch = forbidSwmMetaSortOrOffsetQueries(store);
 
     const serveStartedAt = Date.now();
@@ -604,22 +621,29 @@ describe('SWM meta lane above the 64,000-row snapshot ceiling (#1847)', () => {
     await store.close();
   }, 120_000);
 
-  it('keeps a bounded refusal ONLY for a single pathological subject exceeding the hard 64,000-row build cap', async () => {
+  it('keeps a bounded refusal ONLY for a single pathological subject exceeding the hard build cap', async () => {
     const cgId = 'meta-ceiling-monster';
     const metaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
     const fresh = freshIso();
     const store = new OxigraphStore();
-    // ONE fresh subject carrying 64,001 rows. Whole-subject windows are the
-    // consistency unit of the plan lane (they are what keeps a seal/head
-    // row-group atomic per #1788), so this single row-group can never be
-    // served coherently within the hard build cap — a bounded refusal, at
-    // DEFAULT budgets, is the correct answer. Ordinary multi-row subjects
-    // under a shrunken session budget are covered by the paged tests above.
+    // ONE fresh subject carrying SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS + 1 rows.
+    // Whole-subject windows are the consistency unit of the plan lane (they are
+    // what keeps a seal/head row-group atomic per #1788), so this single
+    // row-group can never be served coherently within the hard build cap — a
+    // bounded refusal, at DEFAULT budgets, is the correct answer. Ordinary
+    // multi-row subjects under a shrunken session budget are covered by the
+    // paged tests above.
+    //
+    // The seed is sized off the CONSTANT, not a literal: the subject must
+    // exceed the build cap to be forced into the plan lane at all, and only
+    // there does the pinned SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS check fire.
+    // Hard-coding 64,000 here is exactly how this test silently stopped
+    // exercising the refusal when the build cap was raised to 200,000.
     const subject = 'urn:monster';
     const monsterQuads: Quad[] = [
       { graph: metaGraph, subject, predicate: `${DKG_NS}publishedAt`, object: `"${fresh}"^^<${XSD_DT}>` },
     ];
-    for (let index = 1; index <= 64_000; index += 1) {
+    for (let index = 1; index <= SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS; index += 1) {
       monsterQuads.push({
         graph: metaGraph, subject, predicate: `${DKG_NS}note`, object: `"filler-${index}"`,
       });

--- a/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
+++ b/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
@@ -6,10 +6,15 @@ import {
   type Quad,
 } from '@origintrail-official/dkg-storage';
 import { createSyncResponderSnapshotBudget } from '../src/sync/responder/snapshot-budget.js';
-import { SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS } from '../src/sync/responder/snapshot-cache.js';
+import {
+  SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+  SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
+} from '../src/sync/responder/snapshot-cache.js';
 import {
   createResponderFreshSwmMetaPlanMemo,
+  FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE,
   FRESH_SWM_META_PLAN_MAX_SUBJECTS,
+  FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS,
 } from '../src/sync/responder/graph-plan.js';
 import {
   DKG_NS,
@@ -26,7 +31,7 @@ import type { SyncRequestEnvelope } from '../src/sync/auth/request-build.js';
 
 /**
  * #1847 — SWM meta lane ceiling. A CG whose `_meta` crossed
- * SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS (64,000) raw rows became permanently
+ * the legacy 64,000-row snapshot build limit became permanently
  * unsyncable for TTL-filtered sessions: the bounded snapshot applied its budget
  * to the RAW graph before the TTL filter, and `readSwmMetaPage` passed
  * `params.cutoffIso == null` POSITIONALLY as `fallbackOnPerSnapshotBudget`, so
@@ -43,6 +48,13 @@ const TINY_SNAPSHOT_BUDGET = {
   maxRows: 1_000_000,
   maxBytesEstimate: Number.MAX_SAFE_INTEGER,
   maxSnapshotRows: 1,
+  maxSnapshotBytesEstimate: Number.MAX_SAFE_INTEGER,
+} as const;
+
+const PLAN_FORCED_SNAPSHOT_BUDGET = {
+  maxRows: 1_000_000,
+  maxBytesEstimate: Number.MAX_SAFE_INTEGER,
+  maxSnapshotRows: 60_000,
   maxSnapshotBytesEstimate: Number.MAX_SAFE_INTEGER,
 } as const;
 
@@ -122,7 +134,16 @@ function forbidSwmMetaSortOrOffsetQueries(store: OxigraphStore) {
   };
 }
 
-describe('SWM meta lane above the 64,000-row snapshot ceiling (#1847)', () => {
+describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', () => {
+  it('keeps plan-only ceilings pinned below the snapshot materialization caps', () => {
+    expect(FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS).toBe(64_000);
+    expect(FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE).toBe(32 * 1024 * 1024);
+    expect(FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS)
+      .toBeLessThan(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS);
+    expect(FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE)
+      .toBeLessThan(SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE);
+  });
+
   it('serves a 64,000+-row _meta with a small fresh subset completely at DEFAULT budgets (the fifa-world-cup-2026 shape)', async () => {
     const cgId = 'meta-ceiling-fifa';
     const metaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
@@ -621,36 +642,34 @@ describe('SWM meta lane above the 64,000-row snapshot ceiling (#1847)', () => {
     await store.close();
   }, 120_000);
 
-  it('keeps a bounded refusal ONLY for a single pathological subject exceeding the hard build cap', async () => {
+  it('keeps a bounded refusal for a single subject above the independent row-group cap', async () => {
     const cgId = 'meta-ceiling-monster';
     const metaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
     const fresh = freshIso();
     const store = new OxigraphStore();
-    // ONE fresh subject carrying SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS + 1 rows.
+    // ONE fresh subject carrying the plan lane's subject-window cap + 1 rows.
     // Whole-subject windows are the consistency unit of the plan lane (they are
     // what keeps a seal/head row-group atomic per #1788), so this single
-    // row-group can never be served coherently within the hard build cap — a
-    // bounded refusal, at DEFAULT budgets, is the correct answer. Ordinary
-    // multi-row subjects under a shrunken session budget are covered by the
-    // paged tests above.
-    //
-    // The seed is sized off the CONSTANT, not a literal: the subject must
-    // exceed the build cap to be forced into the plan lane at all, and only
-    // there does the pinned SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS check fire.
-    // Hard-coding 64,000 here is exactly how this test silently stopped
-    // exercising the refusal when the build cap was raised to 200,000.
+    // row-group can never be served coherently. A local 60,000-row snapshot
+    // budget forces plan mode independently of the production build cap, so a
+    // future snapshot-cap change cannot make this regression test expensive or
+    // silently stop exercising the row-group refusal.
     const subject = 'urn:monster';
     const monsterQuads: Quad[] = [
       { graph: metaGraph, subject, predicate: `${DKG_NS}publishedAt`, object: `"${fresh}"^^<${XSD_DT}>` },
     ];
-    for (let index = 1; index <= SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS; index += 1) {
+    for (let index = 1; index <= FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS; index += 1) {
       monsterQuads.push({
         graph: metaGraph, subject, predicate: `${DKG_NS}note`, object: `"filler-${index}"`,
       });
     }
     await insertChunked(store, monsterQuads);
 
-    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: TTL_MS, syncPageSize: 500 });
+    const cap = registerTestSyncHandler(store, {
+      sharedMemoryTtlMs: TTL_MS,
+      syncPageSize: 500,
+      snapshotBudget: PLAN_FORCED_SNAPSHOT_BUDGET,
+    });
 
     await expect(cap.invoke({
       contextGraphId: cgId,
@@ -659,7 +678,16 @@ describe('SWM meta lane above the 64,000-row snapshot ceiling (#1847)', () => {
       offset: 0,
       limit: 500,
       syncSessionId: 'monster-session',
-    })).rejects.toThrow(/per-snapshot rows budget/);
+    })).rejects.toMatchObject({
+      // The protocol boundary deliberately converts the internal
+      // SyncRowSnapshotBudgetError into a quiet retryable response while
+      // preserving its typed budget details in the message.
+      name: 'QuietRetryableHandlerError',
+      message: expect.stringContaining(
+        `actual=${FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS + 1}, ` +
+        `limit=${FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS}`,
+      ),
+    });
     await store.close();
   }, 120_000);
 


### PR DESCRIPTION
## Summary

A context graph whose `_meta` crosses the snapshot build cap falls off the in-memory admission predicate
(`filterDurableMetaSnapshotRows`, `graph-plan.ts:3655-3756`) onto the SPARQL fallback
(`buildDurableMetaRowsQuery`, `:3459-3520`). That fallback's assertion-name branch (`:3507-3515`) is
O(candidates × assertionName-lifecycles):

```sparql
|| ( CONTAINS(STR(?s), "/assertion/") &&
     EXISTS { GRAPH ?g { ?anLifecycle <…/assertionName> ?an ; <…/memoryLayer> ?ml }
              FILTER(STRENDS(STR(?s), CONCAT("/", STR(?an)))) } )
```

`?anLifecycle` has **no triple-pattern correlation to `?s`**, so per candidate subject the engine scans every
lifecycle and evaluates an unindexable `STRENDS` — and the entire filter is re-paid per page under
`ORDER BY ?g ?s ?p ?o OFFSET n LIMIT 501`.

## Measured on Base mainnet

Against `0x633E5a7C…/fifa-world-cup-2026` (dmaast, 2026-08-05):

| | |
|---|---|
| `_meta` size | **76,265 rows** / 11,525 subjects / 1,553 assertionName lifecycles / **~34.5 MiB** |
| branch-9 over all subjects | **HTTP 500 at 120.008 s** (hit a server-side query deadline) |
| branch-9 over its 1,553 real candidates | **49.97 s** |
| indexed replacement (2 discovery queries + JS tail match) | **1.78 s**, admitted sets identical 1553/1553 |

The CG was only **1.19× over the row cap and 1.08× over the byte cap** when it fell off. That's a cliff, not a
gradient — 19% more data moved it from "in-memory, milliseconds" to ">120 seconds".

## The change

Raise the build caps to **200,000 rows / 96 MiB**, co-tuned against measured density (474.5 B/row via
`estimateStringRowHeapBytes`): 200,000 × 474.5 B ≈ 90.5 MiB, just under the byte ceiling — so neither cap is dead
code (ordinary rows bind on ROWS, large-literal rows bind on BYTES).

Both stay strictly below the retained per-snapshot caps (250,000 / 128 MiB), preserving the documented
*"hard build caps are intentionally lower than the retained-cache defaults"* ordering. That ordering is what
guarantees a snapshot passing the build check is always admissible, rather than built and then rejected by
`budget.admit()`.

**Two use sites are not graph-level snapshot sizing and must not drift with it.** They move to their own constants,
at their historical values — zero behaviour change:

| New constant | Guards | Why pinned |
|---|---|---|
| `SYNC_RESPONDER_MAX_SINGLE_SUBJECT_ROWS = 64_000` | plan lane's single-oversized-subject refusal (`graph-plan.ts:3126`) | whole-subject windows are the consistency unit (#1788) — a statement about row-group atomicity, not materialization size |
| `SYNC_RESPONDER_PLAN_MAX_BYTES_ESTIMATE = 32 MiB` | retained ceiling for plan scalars (`graph-plan.ts:2968`) | a plan holds subject IRIs + row counts; growing it with the snapshot ceiling would triple retained plan state for no benefit |

## Two existing tests were defanged — this is the part worth reviewing

Both would have stayed **green while testing nothing**:

1. **Single-pathological-subject refusal** hard-coded a 64,000-row subject. At a 200,000 cap that subject now builds
   as an ordinary snapshot and never reaches the plan lane where the refusal lives, so the assertion silently
   stopped firing. Now sized off `SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS` directly, so it tracks the cap forever.
2. **Intrinsically-oversized-fresh-set** relied on 65,000 admitted rows exceeding the cap to force the degradation
   path. Now declares an explicit `maxSnapshotRows: 60_000` session budget — `snapshotLoadLimits` is
   `min(BUILD_CAP, configured)`, so degradation is forced regardless of the constant.

The fifa-shape test needs no change: it's a TTL session, so it takes the fresh-plan path regardless of raw graph
size, and its `assertWindowQueriesObserved()` still passes. (I verified this rather than assuming it.)

New invariant tests pin both constants, the build-caps-below-retained-caps ordering, and that a default-budget memo
resolves its build limits to the build caps — otherwise the raise would be inert.

## Memory cost

`SYNC_RESPONDER_GLOBAL_CONCURRENCY = 3`.

- **Retained:** 3 × 96 MiB = **288 MiB**, inside the 384 MiB global ceiling.
- **Parse peak** (not bounded by the budget, and the real cost): `readBoundedDurableMetaSnapshot` materializes raw
  rows *before* checking `bytesEstimate`. The only pre-materialization bound is
  `snapshotResponseByteLimit(maxBytesEstimate)` = 2 × 96 MiB = **192 MiB transport per query**, up from 64 MiB.
  This is why the byte cap is 96 MiB rather than bumped to the 128 MiB retained ceiling. For fifa concretely:
  34.5 MiB estimated / ~69 MiB transport.

## Honest limitation

This **moves the cliff from 64,000 to 200,000 raw rows; it does not remove it.** `_meta` is append-mostly and fifa
is at 76,265 today, so this buys headroom, not permanence. It also raises transport and parse peaks for every lane,
not just durable meta. A follow-up PR fixing the fallback query itself is still required — this is the fleet fix,
not the design fix.

## Testing

169 sync-responder tests pass, 0 failures. `tsc --noEmit` clean.
