### PR TITLE
fix(cli): detect PATH-shadowed DKG installs

### DIFF
--- a/packages/cli/src/doctor/checks/version-skew.ts
+++ b/packages/cli/src/doctor/checks/version-skew.ts
@@ -60,6 +60,32 @@ export async function runVersionSkewCheck(
   }
 
   // Edge.
+  if (
+    state.cli.version
+    && state.cli.version !== state.daemon.version
+  ) {
+    const cliSubject = state.cli.globalPath ?? 'dkg';
+    findings.push({
+      check: 'version-skew',
+      severity: 'warning',
+      message:
+        `CLI on PATH (${state.cli.version} at ${cliSubject}) differs from `
+        + `running daemon (${state.daemon.version})`,
+      advisory:
+        "The shell is resolving a stale or different DKG install. Prepend "
+        + "'$(npm config get prefix)/bin' to PATH, open a new shell, verify "
+        + "'command -v dkg' and 'dkg --version', then remove the obsolete "
+        + 'global install.',
+      subject: state.cli.globalPath ?? undefined,
+      details: {
+        cliPath: state.cli.globalPath,
+        cliVersion: state.cli.version,
+        daemonVersion: state.daemon.version,
+        npmGlobalDkg: state.paths.npmGlobalDkg,
+      },
+    });
+  }
+
   if (!state.paths.npmGlobalDkg) return findings;
   const npmGlobalPkgPath = join(state.paths.npmGlobalDkg, 'package.json');
   const npmGlobalVersion = await readPackageVersion(deps, npmGlobalPkgPath);

--- a/packages/cli/test/dkg-doctor.test.ts
+++ b/packages/cli/test/dkg-doctor.test.ts
@@ -749,6 +749,38 @@ describe('version-skew check (§4.7.4)', () => {
     expect(findings.find((f) => f.message.includes('Running daemon is ahead'))).toBeDefined();
   });
 
+  it('Edge: warns when PATH resolves a stale CLI even though npm-global matches the daemon', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+        '/home/ubuntu/.npm-global/lib/node_modules/@origintrail-official/dkg/package.json':
+          JSON.stringify({ version: '10.0.12' }),
+      },
+      apiStatus: { version: '10.0.12' },
+    });
+    const state = await collectStateSummary(deps);
+    state.paths.npmGlobalDkg =
+      '/home/ubuntu/.npm-global/lib/node_modules/@origintrail-official/dkg';
+    state.cli.globalPath = '/usr/bin/dkg';
+    state.cli.version = '10.0.5-canary.1';
+
+    const findings = await runVersionSkewCheck(deps, state);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      check: 'version-skew',
+      severity: 'warning',
+      subject: '/usr/bin/dkg',
+      details: {
+        cliPath: '/usr/bin/dkg',
+        cliVersion: '10.0.5-canary.1',
+        daemonVersion: '10.0.12',
+      },
+    });
+    expect(findings[0].message).toContain('CLI on PATH');
+    expect(findings[0].advisory).toContain("$(npm config get prefix)/bin");
+  });
+
   it('Core: warns on slot-vs-daemon mismatch', async () => {
     const deps = makeDeps({
       fs: {


### PR DESCRIPTION
## Summary

- detect Edge nodes where the `dkg` executable resolved from `PATH` differs from the running daemon
- report the resolved CLI path and both versions with actionable npm-prefix/PATH remediation
- cover the case where the configured npm-global install matches the daemon but an older root-owned global install shadows it

This closes a gap in the existing version-skew check: the state summary already collected `which dkg` and its version, but the check only compared the npm-global package to the daemon.

## Testing

- `pnpm --filter @origintrail-official/dkg exec vitest run test/dkg-doctor.test.ts` (49/49)
- `pnpm build`
