### PR TITLE
perf(sync): memoize the already-materialized digest check (#2079)

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -121,6 +121,7 @@ import {
   type TripleStoreConfig,
   type Quad,
   type LargeLiteralStorageConfig,
+  invalidateSwmMaterializationWitness,
 } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
@@ -2082,6 +2083,15 @@ export class PublishMethods extends DKGAgentBase {
       canonicalSwmGraph,
       canonicalParts.publicQuads.map((quad) => ({ ...quad, graph: canonicalSwmGraph })),
     );
+    // #2079: a REPLACE, not a drop — the catch-up lane's count gate cannot see
+    // it, so the witness must be dropped explicitly. The head is persisted only
+    // after this point, so a tear in between leaves content ahead of the head;
+    // without this, a witness for the OLD digest would still certify it.
+    // Best-effort, like every other invalidate: never fail a write that has
+    // already committed in order to drop a memo.
+    await invalidateSwmMaterializationWitness(this.store, canonicalSwmGraph, {
+      source: 'agent.publish.graphScopedUpdate.witnessInvalidate',
+    }).catch(() => {});
     if (!replacedSwm) {
       throw Object.assign(
         new Error(

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -68,6 +68,7 @@ import {
   tryReplaceGraphAndSubjectAtomically,
   type Quad,
   type TripleStore,
+  invalidateSwmMaterializationWitness,
 } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
 
@@ -1934,6 +1935,24 @@ async function activateExactPublicProjection(
       'store lacks atomic named-graph and author-seal replacement',
     );
   }
+  // #2079: `derivePublicSwmGraph` resolves to the byte-identical URI the
+  // catch-up materialization witness keys on, and this is a REPLACE — so the
+  // count gate cannot see it, and a standing memo would certify content that is
+  // gone. Activation merges its selected CGs into `syncContextGraphs`, so where
+  // `rfc64PublicCatalog` is enabled the two lanes land on the same graph by
+  // construction; and the catalog seal writes `{scope}/_meta` rather than the
+  // SWM head, so the version guard does not intervene.
+  //
+  // This site was missed for four review rounds because the tripwire in
+  // `swm-materialization-witness.ts` named `tryReplaceGraphAtomically`, and this
+  // path uses `tryReplaceGraphAndSubjectAtomically`. That comment now names the
+  // shape rather than one token.
+  //
+  // Best-effort, like every other invalidate: never fail an activation that has
+  // already committed in order to drop a memo.
+  await invalidateSwmMaterializationWitness(store, swmGraph, {
+    source: 'rfc64-public-catalog-native-activation.witnessInvalidate',
+  }).catch(() => {});
 
   let readBack;
   try {

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -350,7 +350,7 @@ export async function recoverContextGraphSwm(
       // `isPrivateContextGraph`), but the ungated `recover-shared-memory` route
       // reaches it for any graph — and it exists to repair a corrupt local copy,
       // which is the worst possible moment to leave a stale memo standing.
-      await invalidateSwmMaterializationWitness(deps.store, asset.assertionGraph).catch(() => {});
+      await invalidateSwmMaterializationWitness(deps.store, asset.assertionGraph, { source: 'agent.swmRecovery.witnessInvalidate' }).catch(() => {});
       await deps.replaceMetaForGraphAssets?.([descriptor]);
       if (verifiedAssetMeta.length > 0) {
         await deps.store.insert([...verifiedAssetMeta]);
@@ -480,7 +480,7 @@ export async function recoverContextGraphSwm(
       publicSnapshotStore: deps.publicSnapshotStore,
     });
     await deps.store.replaceGraph(asset.assertionGraph, [...asset.quads]);
-    await invalidateSwmMaterializationWitness(deps.store, asset.assertionGraph).catch(() => {}); // #2079: REPLACE, invisible to the count gate
+    await invalidateSwmMaterializationWitness(deps.store, asset.assertionGraph, { source: 'agent.swmRecovery.witnessInvalidate' }).catch(() => {}); // #2079: REPLACE, invisible to the count gate
     replacedGraphs += 1;
     insertedGraphQuads += asset.quads.length;
   }

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -1,4 +1,5 @@
 import type { Quad } from '@origintrail-official/dkg-storage';
+import { invalidateSwmMaterializationWitness } from '@origintrail-official/dkg-storage';
 import type { WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import {
   contextGraphWorkspaceGraphUri,
@@ -343,6 +344,13 @@ export async function recoverContextGraphSwm(
       // A crash between the two therefore retries idempotently; it can never
       // advertise a head whose graph was only partially transferred.
       await deps.store.replaceGraph(asset.assertionGraph, [...asset.quads]);
+      // #2079: a REPLACE, so the public lane's count gate cannot see it. This
+      // lane is lane-disjoint from the public one in automatic operation
+      // (`planSharedMemorySyncContextGraphs` partitions on
+      // `isPrivateContextGraph`), but the ungated `recover-shared-memory` route
+      // reaches it for any graph — and it exists to repair a corrupt local copy,
+      // which is the worst possible moment to leave a stale memo standing.
+      await invalidateSwmMaterializationWitness(deps.store, asset.assertionGraph).catch(() => {});
       await deps.replaceMetaForGraphAssets?.([descriptor]);
       if (verifiedAssetMeta.length > 0) {
         await deps.store.insert([...verifiedAssetMeta]);
@@ -472,6 +480,7 @@ export async function recoverContextGraphSwm(
       publicSnapshotStore: deps.publicSnapshotStore,
     });
     await deps.store.replaceGraph(asset.assertionGraph, [...asset.quads]);
+    await invalidateSwmMaterializationWitness(deps.store, asset.assertionGraph).catch(() => {}); // #2079: REPLACE, invisible to the count gate
     replacedGraphs += 1;
     insertedGraphQuads += asset.quads.length;
   }

--- a/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
+++ b/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
@@ -217,7 +217,7 @@ export function createSharedMemorySnapshotMaterializer(deps: {
           deps.store,
           descriptor.assertionGraph,
           descriptor.publicQuadsDigest,
-          Date.now(),
+
           { priority: 'background', source: 'agent.sharedMemorySync.snapshotMaterializer.witnessWrite' },
         ).catch(() => false);
       }
@@ -246,12 +246,20 @@ export function createSharedMemorySnapshotMaterializer(deps: {
       // write then evicts v1 atomically. That holds with or without this call,
       // and it is the property the tests pin.
       //
-      // This call exists so the witness graph does not accumulate claims about
-      // content that no longer exists — including after a replace whose digest
-      // nothing subsequently verifies. Both orderings are safe for the same
-      // reason (the digest is bound either way); after the replace is chosen so
-      // a crash between the two leaves a stale row that misses rather than no
-      // row at all, which is identical in effect and cheaper to reason about.
+      // Where the digest binding does NOT cover, and this call is the only
+      // cover: witness(v1) + content(v2) + a descriptor still naming v1. The
+      // binding protects the (old witness, new descriptor) direction; it does
+      // nothing for (old witness, old descriptor, new content), because there
+      // the ASK's digest and the witness's digest agree while the store has
+      // moved on. That asymmetry is why this is not merely hygiene.
+      //
+      // It is nevertheless BEST EFFORT — `.catch` below — so the residual is
+      // real rather than zero: a swallowed failure, or a crash between the
+      // replace and this line, reaches exactly that state. It is bounded by the
+      // count gate whenever the replace also changed the quad count, and by the
+      // next successful verify otherwise. Ordering is after the replace because
+      // invalidating first would drop a still-valid memo on a replace that then
+      // throws; neither order removes the window.
       await invalidateSwmMaterializationWitness(deps.store, graphUri, {
         priority: 'background',
         source: 'agent.sharedMemorySync.materializeSnapshot.witnessInvalidate',

--- a/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
+++ b/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
@@ -123,6 +123,30 @@ export function createSharedMemorySnapshotMaterializer(deps: {
   writeLocks: Map<string, Promise<void>>;
   invalidateListContextGraphsCache: () => void;
 }): SharedMemorySnapshotMaterializer {
+  // #2079 — whether the memo can pay on THIS store, resolved in two stages.
+  //
+  // Static probe: a store with no `replaceSubject` can never hold a witness, so
+  // every ASK on it is pure added cost forever. `sparql-http` with
+  // `atomicUpdates:false` is exactly that shape. Knowing it before the first
+  // query costs nothing and takes that config from "permanent regression" to
+  // "byte-identical to pre-#2079".
+  //
+  // Runtime latch: `tryReplaceSubjectAtomically` also returns false when a
+  // DECORATOR refuses at preflight. That refusal may be conditional, so it is
+  // deliberately NOT latched — one such refusal costs one miss, whereas
+  // latching it would disable the memo for the process on a transient event.
+  // Only the statically-permanent case below sets this.
+  const witnessUnsupported = typeof deps.store.replaceSubject !== 'function';
+  // Operator override, default ON. Blank is UNSET, not false: `DKG_SWM_...=`
+  // is the normal compose/.env shape for "not configured", and reading it as
+  // false would silently disable the memo for a fleet that never asked.
+  const witnessEnabled = (() => {
+    const raw = process.env['DKG_SWM_MATERIALIZATION_WITNESS']?.trim();
+    if (!raw) return true;
+    return raw !== '0' && raw.toLowerCase() !== 'false';
+  })();
+  const witnessUsable = witnessEnabled && !witnessUnsupported;
+
   return {
     withKaWriteLock: (contextGraphId, subGraphName, kaUal, fn) =>
       withKeyedLocks(deps.writeLocks, [swmKaWriteLockKey(contextGraphId, subGraphName, kaUal)], fn),
@@ -180,7 +204,8 @@ export function createSharedMemorySnapshotMaterializer(deps: {
       // free. Measured, also skipping the count buys a further 1.5–10.5%,
       // which is not worth trading self-healing for. Do not reorder these.
       if (
-        await readSwmMaterializationWitness(
+        witnessUsable
+        && await readSwmMaterializationWitness(
           deps.store,
           descriptor.assertionGraph,
           descriptor.publicQuadsDigest,
@@ -203,7 +228,7 @@ export function createSharedMemorySnapshotMaterializer(deps: {
       if (contentResult.type !== 'quads') return false;
       const stored = contentResult.quads.map((quad) => ({ ...quad, graph: '' }));
       const matches = workspacePublicQuadsDigest(stored) === descriptor.publicQuadsDigest;
-      if (matches) {
+      if (matches && witnessUsable) {
         // Written HERE — from the branch that just computed the digest over
         // this node's own store content and matched it — and nowhere else.
         // That is what makes the witness sound: it cannot record anything a

--- a/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
+++ b/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
@@ -20,6 +20,11 @@ import {
   workspacePublicQuadsDigest,
 } from '@origintrail-official/dkg-publisher';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  invalidateSwmMaterializationWitness,
+  readSwmMaterializationWitness,
+  writeSwmMaterializationWitness,
+} from '@origintrail-official/dkg-storage';
 import type { GraphScopedSwmRecoveryDescriptor } from '../graph-scoped-swm-recovery.js';
 
 const DKG = 'http://dkg.io/ontology/';
@@ -162,6 +167,28 @@ export function createSharedMemorySnapshotMaterializer(deps: {
       if (countResult.type !== 'bindings' || countResult.bindings.length === 0) return false;
       const present = Number.parseInt(literalValue(countResult.bindings[0]?.['n']) ?? '0', 10);
       if (!Number.isFinite(present) || present !== expected) return false;
+      // 1b) Witness fast path (#2079): a bound-subject ASK recording that THIS
+      // node already read this graph back and matched this exact digest. It is
+      // a memo of the measurement in step 2 — never an independent claim — so
+      // it is only reachable in a state where step 2 would also return true.
+      //
+      // Deliberately AFTER the count gate, not instead of it. Three paths
+      // remove an assertion graph outside this lock — the SWM TTL sweep, VM
+      // promote/publish/update (a different lock map), and the chain-reset
+      // wipe, whose scoped delete spares `urn:dkg:local:*` and so leaves the
+      // witness standing over a wiped store. The count catches all three for
+      // free. Measured, also skipping the count buys a further 1.5–10.5%,
+      // which is not worth trading self-healing for. Do not reorder these.
+      if (
+        await readSwmMaterializationWitness(
+          deps.store,
+          descriptor.assertionGraph,
+          descriptor.publicQuadsDigest,
+          { priority: 'background', source: 'agent.sharedMemorySync.snapshotMaterializer.witnessAsk' },
+        )
+      ) {
+        return true;
+      }
       // 2) Content binding: a matching count does not prove the stored graph
       // is THIS descriptor's content — all versions of a graph-scoped KA share
       // one graph URI, so an older version of equal size would otherwise pass
@@ -175,7 +202,26 @@ export function createSharedMemorySnapshotMaterializer(deps: {
       );
       if (contentResult.type !== 'quads') return false;
       const stored = contentResult.quads.map((quad) => ({ ...quad, graph: '' }));
-      return workspacePublicQuadsDigest(stored) === descriptor.publicQuadsDigest;
+      const matches = workspacePublicQuadsDigest(stored) === descriptor.publicQuadsDigest;
+      if (matches) {
+        // Written HERE — from the branch that just computed the digest over
+        // this node's own store content and matched it — and nowhere else.
+        // That is what makes the witness sound: it cannot record anything a
+        // peer asserted, and there is no crash window in which a witness
+        // exists for content that was never verified, because the content was
+        // read before this line runs.
+        //
+        // Best-effort: a failed or unsupported write costs one recomputation
+        // next round, so it must never fail the check that just succeeded.
+        await writeSwmMaterializationWitness(
+          deps.store,
+          descriptor.assertionGraph,
+          descriptor.publicQuadsDigest,
+          Date.now(),
+          { priority: 'background', source: 'agent.sharedMemorySync.snapshotMaterializer.witnessWrite' },
+        ).catch(() => false);
+      }
+      return matches;
     },
 
     replaceGraph: async (graphUri, quads) => {
@@ -189,6 +235,27 @@ export function createSharedMemorySnapshotMaterializer(deps: {
         priority: 'background',
         source: 'agent.sharedMemorySync.materializeSnapshot',
       });
+      // #2079: the content just changed, so any witness for it now describes
+      // bytes that are gone. Defence in depth, NOT the thing that makes an
+      // equal-count replace safe — be precise about this, because the
+      // difference decides whether the read may ever stop binding the digest.
+      //
+      // What actually makes v1 → v2 safe is that the witness READ binds the
+      // digest as well as the subject: a standing v1 row cannot match an ASK
+      // for v2's digest, so the check falls through to the CONSTRUCT and the
+      // write then evicts v1 atomically. That holds with or without this call,
+      // and it is the property the tests pin.
+      //
+      // This call exists so the witness graph does not accumulate claims about
+      // content that no longer exists — including after a replace whose digest
+      // nothing subsequently verifies. Both orderings are safe for the same
+      // reason (the digest is bound either way); after the replace is chosen so
+      // a crash between the two leaves a stale row that misses rather than no
+      // row at all, which is identical in effect and cheaper to reason about.
+      await invalidateSwmMaterializationWitness(deps.store, graphUri, {
+        priority: 'background',
+        source: 'agent.sharedMemorySync.materializeSnapshot.witnessInvalidate',
+      }).catch(() => {});
       deps.invalidateListContextGraphsCache();
     },
 

--- a/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
+++ b/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
@@ -123,29 +123,34 @@ export function createSharedMemorySnapshotMaterializer(deps: {
   writeLocks: Map<string, Promise<void>>;
   invalidateListContextGraphsCache: () => void;
 }): SharedMemorySnapshotMaterializer {
-  // #2079 — whether the memo can pay on THIS store, resolved in two stages.
+  // #2079 operator override, default ON. Blank is UNSET, not false:
+  // `DKG_SWM_MATERIALIZATION_WITNESS=` is the normal compose/.env shape for
+  // "not configured", and reading it as false would silently disable the memo
+  // for a fleet that never asked. Read inside the factory rather than at module
+  // scope so it takes effect on the next sync round after a restart.
   //
-  // Static probe: a store with no `replaceSubject` can never hold a witness, so
-  // every ASK on it is pure added cost forever. `sparql-http` with
-  // `atomicUpdates:false` is exactly that shape. Knowing it before the first
-  // query costs nothing and takes that config from "permanent regression" to
-  // "byte-identical to pre-#2079".
+  // There is deliberately NO capability probe here. An earlier revision tested
+  // `typeof deps.store.replaceSubject !== 'function'`, on the theory that
+  // `sparql-http` with `atomicUpdates:false` could never hold a witness and
+  // would otherwise pay the ASK forever. BOTH halves were false:
   //
-  // Runtime latch: `tryReplaceSubjectAtomically` also returns false when a
-  // DECORATOR refuses at preflight. That refusal may be conditional, so it is
-  // deliberately NOT latched — one such refusal costs one miss, whereas
-  // latching it would disable the memo for the process on a transient event.
-  // Only the statically-permanent case below sets this.
-  const witnessUnsupported = typeof deps.store.replaceSubject !== 'function';
-  // Operator override, default ON. Blank is UNSET, not false: `DKG_SWM_...=`
-  // is the normal compose/.env shape for "not configured", and reading it as
-  // false would silently disable the memo for a fleet that never asked.
-  const witnessEnabled = (() => {
+  //   - every adapter and all three decorators DEFINE `replaceSubject` and
+  //     throw `UnsupportedTripleStoreCapabilityError` INSIDE it, so the typeof
+  //     is always "function" — the probe could never fire;
+  //   - that config gates `replaceGraph` on the same `atomicUpdates` flag, so
+  //     no writer can populate a SWM assertion graph at all. The graph stays
+  //     empty, the count gate returns first, and the ASK is never reached.
+  //     There was no cost to avoid.
+  //
+  // A latch on the first `false` from the write is the shape that WOULD work,
+  // but not as currently wired: that call is `.catch(() => false)`, so a
+  // transient endpoint error is indistinguishable from a capability refusal and
+  // would disable the memo process-wide on a blip.
+  const witnessUsable = (() => {
     const raw = process.env['DKG_SWM_MATERIALIZATION_WITNESS']?.trim();
     if (!raw) return true;
     return raw !== '0' && raw.toLowerCase() !== 'false';
   })();
-  const witnessUsable = witnessEnabled && !witnessUnsupported;
 
   return {
     withKaWriteLock: (contextGraphId, subGraphName, kaUal, fn) =>

--- a/packages/agent/test/swm-materialization-witness.test.ts
+++ b/packages/agent/test/swm-materialization-witness.test.ts
@@ -74,7 +74,7 @@ function countingStore(inner: TripleStore) {
 describe('#2079 witness module', () => {
   it('reads back only for the digest it was written with', async () => {
     const store = newStore();
-    expect(await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa', 1)).toBe(true);
+    expect(await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa')).toBe(true);
     expect(await readSwmMaterializationWitness(store, GRAPH, 'sha256:aaa')).toBe(true);
     // A different digest must MISS. This is what makes an equal-count version
     // change safe without relying on anyone remembering to invalidate.
@@ -83,8 +83,8 @@ describe('#2079 witness module', () => {
 
   it('EVICTS the previous claim rather than accumulating', async () => {
     const store = newStore();
-    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa', 1);
-    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:bbb', 2);
+    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa');
+    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:bbb');
     // If the write appended instead of replacing the subject, the OLD digest
     // would still read true — a standing lie about content that is gone.
     expect(await readSwmMaterializationWitness(store, GRAPH, 'sha256:aaa')).toBe(false);
@@ -93,7 +93,7 @@ describe('#2079 witness module', () => {
 
   it('invalidate removes the claim', async () => {
     const store = newStore();
-    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa', 1);
+    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa');
     await invalidateSwmMaterializationWitness(store, GRAPH);
     expect(await readSwmMaterializationWitness(store, GRAPH, 'sha256:aaa')).toBe(false);
   });
@@ -151,6 +151,40 @@ describe('#2079 isGraphAssetMaterialized fast path', () => {
     expect(await readSwmMaterializationWitness(store, GRAPH, d.publicQuadsDigest)).toBe(true);
 
     expect(await mat.isGraphAssetMaterialized(d)).toBe(false);
+  });
+
+  it('writes NO witness when the digest does NOT match, and stays false on re-check', async () => {
+    // "Only the branch that VERIFIED it writes it" is the entire soundness
+    // argument — it is why #2079's head-row proposal was killed — and without
+    // this row nothing pins it: making the write unconditional passes every
+    // other test in the repo.
+    //
+    // Under that mutation the damage is sticky, not transient. A mismatch would
+    // write a witness for `descriptor.publicQuadsDigest` — exactly the value
+    // the NEXT round's ASK binds — so once `replaceGraph` fails (it throws on a
+    // missing snapshot, and that throw is caught upstream, so the only
+    // invalidator never runs) the check returns true forever.
+    const store = newStore();
+    const v1 = payload('v1', 6);
+    const v2 = payload('v2', 6);
+    await store.replaceGraph(GRAPH, v1.map((q) => ({ ...q, graph: GRAPH })));
+    const mat = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+    const d2 = descriptorFor(v2);
+
+    // Store holds v1; ask about v2. Count matches, digest does not.
+    expect(await mat.isGraphAssetMaterialized(d2)).toBe(false);
+
+    // No witness may exist for a digest this node never matched.
+    expect(await readSwmMaterializationWitness(store, GRAPH, d2.publicQuadsDigest)).toBe(false);
+
+    // The second call is what kills the mutant: an unconditional write would
+    // have memoized v2 on the first call, and this would come back true while
+    // the store still holds v1.
+    expect(await mat.isGraphAssetMaterialized(d2)).toBe(false);
   });
 
   it('does not certify v2 from a v1 witness when the quad COUNT is unchanged', async () => {

--- a/packages/agent/test/swm-materialization-witness.test.ts
+++ b/packages/agent/test/swm-materialization-witness.test.ts
@@ -1,0 +1,174 @@
+/**
+ * #2079 — the already-materialized witness, against a REAL OxigraphStore.
+ *
+ * The witness is a memo of a measurement this node already took. These rows pin
+ * the three properties that make that sound, and each is written so that the
+ * obvious wrong implementation fails it:
+ *
+ *   1. a warm second check does NO CONSTRUCT (the win), while still returning true;
+ *   2. the count gate still runs FIRST, so a dropped graph is caught even with a
+ *      standing witness (the self-healing property the issue's ASK-only design
+ *      would have traded away);
+ *   3. an equal-count v1 → v2 replace is NOT certified by the v1 witness (the one
+ *      case the count cannot catch).
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import { OxigraphStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  readSwmMaterializationWitness,
+  writeSwmMaterializationWitness,
+  invalidateSwmMaterializationWitness,
+  SWM_MATERIALIZATION_WITNESS_GRAPH,
+} from '@origintrail-official/dkg-storage';
+import { createSharedMemorySnapshotMaterializer } from '../src/sync/requester/swm-snapshot-materializer.js';
+import { workspacePublicQuadsDigest } from '@origintrail-official/dkg-publisher';
+
+const GRAPH = 'did:dkg:context-graph:witness-cg/ka/1';
+
+const stores: OxigraphStore[] = [];
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {})));
+});
+
+function newStore(): OxigraphStore {
+  const s = new OxigraphStore();
+  stores.push(s);
+  return s;
+}
+
+/** N payload quads with a marker, so two versions can share a quad COUNT. */
+function payload(marker: string, count: number): Quad[] {
+  return Array.from({ length: count }, (_, i) => ({
+    subject: `urn:snap:${marker}:${i}`,
+    predicate: 'http://schema.org/status',
+    object: `"${marker}"`,
+    graph: '',
+  }));
+}
+
+function descriptorFor(quads: Quad[]) {
+  return {
+    assertionGraph: GRAPH,
+    publicQuadsCount: quads.length,
+    publicQuadsDigest: workspacePublicQuadsDigest(quads),
+  } as never;
+}
+
+/** Counts CONSTRUCTs so "did the fast path actually skip the expensive read" is observable. */
+function countingStore(inner: TripleStore) {
+  let constructs = 0;
+  const proxy = new Proxy(inner, {
+    get(target, prop, receiver) {
+      if (prop === 'query') {
+        return async (sparql: string, options?: unknown) => {
+          if (sparql.trimStart().startsWith('CONSTRUCT')) constructs += 1;
+          return (target as TripleStore).query(sparql, options as never);
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as TripleStore;
+  return { store: proxy, constructs: () => constructs };
+}
+
+describe('#2079 witness module', () => {
+  it('reads back only for the digest it was written with', async () => {
+    const store = newStore();
+    expect(await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa', 1)).toBe(true);
+    expect(await readSwmMaterializationWitness(store, GRAPH, 'sha256:aaa')).toBe(true);
+    // A different digest must MISS. This is what makes an equal-count version
+    // change safe without relying on anyone remembering to invalidate.
+    expect(await readSwmMaterializationWitness(store, GRAPH, 'sha256:bbb')).toBe(false);
+  });
+
+  it('EVICTS the previous claim rather than accumulating', async () => {
+    const store = newStore();
+    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa', 1);
+    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:bbb', 2);
+    // If the write appended instead of replacing the subject, the OLD digest
+    // would still read true — a standing lie about content that is gone.
+    expect(await readSwmMaterializationWitness(store, GRAPH, 'sha256:aaa')).toBe(false);
+    expect(await readSwmMaterializationWitness(store, GRAPH, 'sha256:bbb')).toBe(true);
+  });
+
+  it('invalidate removes the claim', async () => {
+    const store = newStore();
+    await writeSwmMaterializationWitness(store, GRAPH, 'sha256:aaa', 1);
+    await invalidateSwmMaterializationWitness(store, GRAPH);
+    expect(await readSwmMaterializationWitness(store, GRAPH, 'sha256:aaa')).toBe(false);
+  });
+
+  it('lives outside every context-graph prefix', () => {
+    // The chain-reset wipe and the sync responder both scope on the CG prefix;
+    // a witness inside it would be served to peers and wiped as CG content.
+    expect(SWM_MATERIALIZATION_WITNESS_GRAPH.startsWith('urn:dkg:local:')).toBe(true);
+    expect(SWM_MATERIALIZATION_WITNESS_GRAPH.includes('did:dkg:context-graph:')).toBe(false);
+  });
+});
+
+describe('#2079 isGraphAssetMaterialized fast path', () => {
+  it('skips the CONSTRUCT on a warm second check, and still says materialized', async () => {
+    const inner = newStore();
+    const quads = payload('v1', 6);
+    await inner.replaceGraph(GRAPH, quads.map((q) => ({ ...q, graph: GRAPH })));
+    const { store, constructs } = countingStore(inner);
+    const mat = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+    const d = descriptorFor(quads);
+
+    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
+    const afterCold = constructs();
+    expect(afterCold).toBe(1); // cold: paid the read-back once
+
+    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
+    // THE WIN: warm check performed no further CONSTRUCT.
+    expect(constructs()).toBe(afterCold);
+  });
+
+  it('still reports NOT materialized when the graph is dropped, despite a standing witness', async () => {
+    // The self-healing property. The TTL sweep, VM publish and the chain-reset
+    // wipe all remove content outside this lock — and the chain-reset scoped
+    // delete deliberately spares `urn:dkg:local:*`, so the witness SURVIVES.
+    // The count gate is the only thing standing between that and an empty
+    // store certified as parity.
+    const store = newStore();
+    const quads = payload('v1', 6);
+    await store.replaceGraph(GRAPH, quads.map((q) => ({ ...q, graph: GRAPH })));
+    const mat = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+    const d = descriptorFor(quads);
+    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
+
+    // Content removed the way an out-of-band path removes it: the witness is
+    // untouched and still asserts this exact digest.
+    await store.dropGraph(GRAPH);
+    expect(await readSwmMaterializationWitness(store, GRAPH, d.publicQuadsDigest)).toBe(true);
+
+    expect(await mat.isGraphAssetMaterialized(d)).toBe(false);
+  });
+
+  it('does not certify v2 from a v1 witness when the quad COUNT is unchanged', async () => {
+    // The one case the count cannot catch, so the digest binding must.
+    const store = newStore();
+    const v1 = payload('v1', 6);
+    const v2 = payload('v2', 6); // same count, different content
+    expect(v1.length).toBe(v2.length);
+
+    await store.replaceGraph(GRAPH, v1.map((q) => ({ ...q, graph: GRAPH })));
+    const mat = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+    expect(await mat.isGraphAssetMaterialized(descriptorFor(v1))).toBe(true);
+
+    // Store now holds v1; ask whether v2 is materialized. Count matches (6 = 6).
+    expect(await mat.isGraphAssetMaterialized(descriptorFor(v2))).toBe(false);
+  });
+});

--- a/packages/agent/test/swm-materialization-witness.test.ts
+++ b/packages/agent/test/swm-materialization-witness.test.ts
@@ -187,6 +187,81 @@ describe('#2079 isGraphAssetMaterialized fast path', () => {
     expect(await mat.isGraphAssetMaterialized(d2)).toBe(false);
   });
 
+  it('degrades to a miss when the witness ASK itself fails', async () => {
+    // The ASK is a pure optimisation, so a transient store error must fall
+    // through to the real read-back rather than fail a check that would
+    // otherwise have succeeded. Making the read rethrow currently survives the
+    // whole agent suite, so this pins the containment.
+    const inner = newStore();
+    const quads = payload('v1', 6);
+    await inner.replaceGraph(GRAPH, quads.map((q) => ({ ...q, graph: GRAPH })));
+
+    let failAsks = false;
+    const store = new Proxy(inner, {
+      get(target, prop, receiver) {
+        if (prop === 'query') {
+          return async (sparql: string, options?: unknown) => {
+            if (failAsks && sparql.trimStart().startsWith('ASK')) {
+              throw new Error('store unavailable');
+            }
+            return (target as TripleStore).query(sparql, options as never);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as TripleStore;
+
+    const mat = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+    const d = descriptorFor(quads);
+
+    // Warm the memo, then break only the ASK.
+    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
+    failAsks = true;
+
+    // Still correct — it recomputed instead of throwing.
+    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
+  });
+
+  it('issues NO witness ASK when the store cannot hold a witness', async () => {
+    // `sparql-http` with `atomicUpdates:false` has no `replaceSubject`, so a
+    // witness can never be stored and every ASK would be permanent added cost
+    // for a hit rate of zero. The static probe must skip the read entirely —
+    // that config should be byte-identical to pre-#2079.
+    const inner = newStore();
+    const quads = payload('v1', 6);
+    await inner.replaceGraph(GRAPH, quads.map((q) => ({ ...q, graph: GRAPH })));
+
+    let asks = 0;
+    const store = new Proxy(inner, {
+      get(target, prop, receiver) {
+        // Present the store as lacking atomic subject replace.
+        if (prop === 'replaceSubject') return undefined;
+        if (prop === 'query') {
+          return async (sparql: string, options?: unknown) => {
+            if (sparql.trimStart().startsWith('ASK')) asks += 1;
+            return (target as TripleStore).query(sparql, options as never);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as TripleStore;
+
+    const mat = createSharedMemorySnapshotMaterializer({
+      store,
+      writeLocks: new Map<string, Promise<void>>(),
+      invalidateListContextGraphsCache: () => {},
+    });
+    const d = descriptorFor(quads);
+
+    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
+    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
+    expect(asks).toBe(0);
+  });
+
   it('does not certify v2 from a v1 witness when the quad COUNT is unchanged', async () => {
     // The one case the count cannot catch, so the digest binding must.
     const store = newStore();

--- a/packages/agent/test/swm-materialization-witness.test.ts
+++ b/packages/agent/test/swm-materialization-witness.test.ts
@@ -226,42 +226,6 @@ describe('#2079 isGraphAssetMaterialized fast path', () => {
     expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
   });
 
-  it('issues NO witness ASK when the store cannot hold a witness', async () => {
-    // `sparql-http` with `atomicUpdates:false` has no `replaceSubject`, so a
-    // witness can never be stored and every ASK would be permanent added cost
-    // for a hit rate of zero. The static probe must skip the read entirely —
-    // that config should be byte-identical to pre-#2079.
-    const inner = newStore();
-    const quads = payload('v1', 6);
-    await inner.replaceGraph(GRAPH, quads.map((q) => ({ ...q, graph: GRAPH })));
-
-    let asks = 0;
-    const store = new Proxy(inner, {
-      get(target, prop, receiver) {
-        // Present the store as lacking atomic subject replace.
-        if (prop === 'replaceSubject') return undefined;
-        if (prop === 'query') {
-          return async (sparql: string, options?: unknown) => {
-            if (sparql.trimStart().startsWith('ASK')) asks += 1;
-            return (target as TripleStore).query(sparql, options as never);
-          };
-        }
-        return Reflect.get(target, prop, receiver);
-      },
-    }) as TripleStore;
-
-    const mat = createSharedMemorySnapshotMaterializer({
-      store,
-      writeLocks: new Map<string, Promise<void>>(),
-      invalidateListContextGraphsCache: () => {},
-    });
-    const d = descriptorFor(quads);
-
-    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
-    expect(await mat.isGraphAssetMaterialized(d)).toBe(true);
-    expect(asks).toBe(0);
-  });
-
   it('does not certify v2 from a v1 witness when the quad COUNT is unchanged', async () => {
     // The one case the count cannot catch, so the digest binding must.
     const store = newStore();

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  OxigraphStore,
+  readSwmMaterializationWitness,
+  writeSwmMaterializationWitness,
+} from '@origintrail-official/dkg-storage';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
@@ -561,6 +565,15 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       { subject: 'urn:rootless:a', predicate: STATUS, object: '"stale"', graph: assertionGraph },
       { subject: 'urn:rootless:old', predicate: 'urn:p', object: '"must-disappear"', graph: assertionGraph },
     ]);
+    // #2079: recovery REPLACES this graph, so a catch-up materialization
+    // witness for it would describe content that is gone — and a replace can
+    // leave the quad count unchanged, which is exactly what the count gate
+    // cannot see. This lane is lane-disjoint from the public one in automatic
+    // operation, but the ungated `recover-shared-memory` route reaches it, and
+    // that route exists to repair a corrupt local copy — the worst moment to
+    // leave a stale memo standing.
+    await writeSwmMaterializationWitness(store, assertionGraph, 'sha256:stale-witness');
+    expect(await readSwmMaterializationWitness(store, assertionGraph, 'sha256:stale-witness')).toBe(true);
     const snapshotStore = new MemorySnapshotStore();
     let snapshotFetches = 0;
     let dataFetches = 0;
@@ -603,6 +616,11 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
     });
     expect(snapshotFetches).toBe(1);
     expect(dataFetches).toBe(0);
+    // #2079: the replace above must have dropped the memo. The witness lives in
+    // `urn:dkg:local:*`, untouched by the graph replace itself, so only the
+    // explicit invalidate in the recovery lane can clear it — which is what
+    // makes this discriminate.
+    expect(await readSwmMaterializationWitness(store, assertionGraph, 'sha256:stale-witness')).toBe(false);
     const recovered = await store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertionGraph}> { ?s ?p ?o } }`,
     );

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -149,6 +149,10 @@ export default defineConfig({
       "test/swm-public-snapshot-materialization.test.ts",
       "test/swm-public-cg-plaintext.test.ts",
       "test/swm-snapshot-materializer.test.ts",
+      // #2079 — the already-materialized witness: the warm-path win, the count
+      // gate that keeps it self-healing, and the digest binding that makes an
+      // equal-count version change safe.
+      "test/swm-materialization-witness.test.ts",
       "test/replace-subject-agent-wrapper.test.ts",
     ],
     testTimeout: 60_000,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4,7 +4,7 @@ import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, GraphKnowledgeAssetScope, OperationContext } from '@origintrail-official/dkg-core';
 import type { AssertionSeal } from '@origintrail-official/dkg-core';
 import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphPrivateUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, contextGraphSubGraphPrivateUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, loadSharedMemoryQuadsForScope, loadSelectedSharedMemoryQuads, resolveSharedMemoryScopeGraphs, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
+import { GraphManager, invalidateSwmMaterializationWitness, PrivateContentStore, loadSharedMemoryQuadsForScope, loadSelectedSharedMemoryQuads, resolveSharedMemoryScopeGraphs, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK, type V10ACKProviderParams, type V10ACKProviderObject, type LegacyV10ACKProvider } from './publisher.js';
 import { assertNoUserAuthoredKnowledgeAssetSkolemTerms, skolemizeByEntity, skolemizeKnowledgeAsset, skolemizeKnowledgeAssetParts } from './auto-partition.js';
 import { assertNoKnowledgeAssetPayloadNamedGraphs } from './knowledge-asset-graph-policy.js';
@@ -8665,6 +8665,23 @@ export class DKGPublisher implements Publisher {
       swmQuads,
       'Knowledge Asset WM-to-SWM promotion',
     );
+    // #2079: the SIXTH replace site. Same graph the catch-up witness keys on,
+    // so the memo now describes content that is gone — and a replace leaves the
+    // quad count intact, which is exactly what the count gate cannot see.
+    //
+    // Reachable on default config: this node witnesses its own KA
+    // (`onSnapshotReady(snapshot, 'cache')` has no self-peer filter), and the
+    // curator-ack gate is off by default, so gossip publishes only after promote
+    // returns. Promote v2, let the fallible tail below throw, and the curator
+    // still advertises v1 — the next round's descriptor is v1, the count
+    // matches, and a standing v1 witness would HIT.
+    //
+    // Deliberately NOT folded into `replaceExactKnowledgeAssetGraph`: five of
+    // its seven call sites are VM or WM graphs that can never hold a witness,
+    // and putting it there would add a serialised changelog round-trip to each.
+    await invalidateSwmMaterializationWitness(this.store, swmGraphUri, {
+      source: 'publisher.promoteWmToSwm.witnessInvalidate',
+    }).catch(() => {});
     // NB: WM source cleanup and the pending-share-operation clear happen at the
     // very END of this tail. Every write between here and there is fallible; if
     // WM were dropped now (or the recovery pointer cleared), a failure below

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -8676,9 +8676,13 @@ export class DKGPublisher implements Publisher {
     // still advertises v1 — the next round's descriptor is v1, the count
     // matches, and a standing v1 witness would HIT.
     //
-    // Deliberately NOT folded into `replaceExactKnowledgeAssetGraph`: five of
-    // its seven call sites are VM or WM graphs that can never hold a witness,
-    // and putting it there would add a serialised changelog round-trip to each.
+    // Deliberately NOT folded into `replaceExactKnowledgeAssetGraph`: of its
+    // SIX call sites this is the only one targeting a SWM assertion graph — the
+    // rest are `dataGraph` ×2, `vmGraph`, `wmGraph`, and one pass-through
+    // `graphUri` — so folding it in would add a serialised changelog round-trip
+    // to five replaces that can never hold a witness. Enumerated, not counted:
+    // an earlier revision of this comment said "five of seven" and was wrong on
+    // both numbers.
     await invalidateSwmMaterializationWitness(this.store, swmGraphUri, {
       source: 'publisher.promoteWmToSwm.witnessInvalidate',
     }).catch(() => {});

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -7,6 +7,7 @@ import {
   type Quad,
   type QueryOptions,
   type StorePressureSnapshot,
+  invalidateSwmMaterializationWitness,
 } from '@origintrail-official/dkg-storage';
 import type {
   EventBus,
@@ -918,6 +919,15 @@ export class StorageACKHandler {
           normalized,
           ackStoreOptions('storage-ack.persistGraphScoped.replaceGraph', signal),
         );
+        // #2079: a REPLACE, not a drop — invisible to the catch-up lane's count
+        // gate, so the witness must be dropped explicitly. The head write and
+        // two other store calls follow, any of which can throw and leave content
+        // ahead of the head.
+        await invalidateSwmMaterializationWitness(
+          this.store,
+          swmGraphUri,
+          ackStoreOptions('storage-ack.persistGraphScoped.witnessInvalidate', signal),
+        ).catch(() => {});
         if (!replaced) {
           throw Object.assign(
             new Error('Graph-scoped StorageACK requires atomic TripleStore.replaceGraph support'),

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -919,6 +919,12 @@ export class StorageACKHandler {
           normalized,
           ackStoreOptions('storage-ack.persistGraphScoped.replaceGraph', signal),
         );
+        if (!replaced) {
+          throw Object.assign(
+            new Error('Graph-scoped StorageACK requires atomic TripleStore.replaceGraph support'),
+            { code: 'SWM_ATOMIC_REPLACE_UNSUPPORTED' },
+          );
+        }
         // #2079: a REPLACE, not a drop — invisible to the catch-up lane's count
         // gate, so the witness must be dropped explicitly. The head write and
         // two other store calls follow, any of which can throw and leave content
@@ -928,12 +934,6 @@ export class StorageACKHandler {
           swmGraphUri,
           ackStoreOptions('storage-ack.persistGraphScoped.witnessInvalidate', signal),
         ).catch(() => {});
-        if (!replaced) {
-          throw Object.assign(
-            new Error('Graph-scoped StorageACK requires atomic TripleStore.replaceGraph support'),
-            { code: 'SWM_ATOMIC_REPLACE_UNSUPPORTED' },
-          );
-        }
       }
       await this.store.deleteByPattern(
         { graph: metaGraph, subject: operationSubject },

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1,5 +1,9 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
-import { GraphManager, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
+import {
+  GraphManager,
+  invalidateSwmMaterializationWitness,
+  tryReplaceGraphAtomically,
+} from '@origintrail-official/dkg-storage';
 import type { EventBus } from '@origintrail-official/dkg-core';
 import { DKGEvent, Logger, createOperationContext, logKaLifecycleEvent, contextGraphDataUri, contextGraphMetaUri, DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, GRAPH_KA_CONTENT_SCOPE_VERSION, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetAgentAddressesEqual, knowledgeAssetLayerGraphUri, MemoryLayer } from '@origintrail-official/dkg-core';
 import type { PhaseCallback } from './publisher.js';
@@ -1485,6 +1489,28 @@ export class SharedMemoryHandler {
             { code: 'SWM_ATOMIC_REPLACE_UNSUPPORTED' },
           );
         }
+        // #2079: this graph's content just changed, so the catch-up lane's
+        // materialization witness for it now describes bytes that are gone.
+        //
+        // This is the ONLY replace path outside the materializer holding a lock
+        // the witness module can see — the key above is deliberately the same
+        // `swmKaWriteLockKey` string — and the count gate cannot cover it,
+        // because a replace leaves the count matching.
+        //
+        // Ordinarily a successful apply also advances the head, so catch-up
+        // skips an older descriptor before the witness is consulted at all.
+        // The case this closes is a TORN apply: the replace above succeeds and
+        // the snapshot-file or head write then throws, leaving content=v2,
+        // head=v1 and a witness for v1's digest. A peer re-offering v1 would
+        // pass the head guard, pass the count gate, and HIT the witness —
+        // reported materialized while the store holds v2. Pre-#2079 the
+        // read-back returned false there and the graph was repaired.
+        //
+        // Best-effort: failing to drop a memo must never fail an apply that has
+        // already committed.
+        await invalidateSwmMaterializationWitness(this.store, swmGraph, {
+          source: 'publisher.swm.graphScopedReplace.witnessInvalidate',
+        }).catch(() => {});
         // The gossip envelope carries the verified author address
         // (`verifyAgentEnvelope` above already cryptographically bound
         // it to `recovered`); use it for SWM `prov:wasAttributedTo` so

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -80,15 +80,6 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     expect(await graphCount(store, swmGraph)).toBe(1_000);
     expect(await graphCount(store, graphManager.sharedMemoryUri(CONTEXT_GRAPH))).toBe(0);
 
-    // #2079: a gossip apply REPLACES this graph, under the same
-    // `swmKaWriteLockKey` the catch-up materializer uses. The catch-up count
-    // gate cannot see a replace, so this path must drop the memo itself —
-    // otherwise a TORN apply (graph replaced, head write throws) leaves
-    // catch-up certifying the OLD digest against NEW content.
-    //
-    // Seeded after the apply and re-applied, rather than building a torn-apply
-    // rig: the property under test is simply "the apply path invalidates", and
-    // deleting that call must fail this.
 
     const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
     const meta = await store.query(

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -80,7 +80,6 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     expect(await graphCount(store, swmGraph)).toBe(1_000);
     expect(await graphCount(store, graphManager.sharedMemoryUri(CONTEXT_GRAPH))).toBe(0);
 
-
     const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
     const meta = await store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${metaGraph}> { ?s ?p ?o } }`,

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -8,7 +8,12 @@ import {
   knowledgeAssetLayerGraphUri,
   type WorkspacePublishRequestMsg,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  GraphManager,
+  OxigraphStore,
+  readSwmMaterializationWitness,
+  writeSwmMaterializationWitness,
+} from '@origintrail-official/dkg-storage';
 import { SharedMemoryHandler } from '../src/workspace-handler.js';
 
 const CONTEXT_GRAPH = 'rootless-receiver';
@@ -75,6 +80,16 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     expect(await graphCount(store, swmGraph)).toBe(1_000);
     expect(await graphCount(store, graphManager.sharedMemoryUri(CONTEXT_GRAPH))).toBe(0);
 
+    // #2079: a gossip apply REPLACES this graph, under the same
+    // `swmKaWriteLockKey` the catch-up materializer uses. The catch-up count
+    // gate cannot see a replace, so this path must drop the memo itself —
+    // otherwise a TORN apply (graph replaced, head write throws) leaves
+    // catch-up certifying the OLD digest against NEW content.
+    //
+    // Seeded after the apply and re-applied, rather than building a torn-apply
+    // rig: the property under test is simply "the apply path invalidates", and
+    // deleting that call must fail this.
+
     const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
     const meta = await store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${metaGraph}> { ?s ?p ?o } }`,
@@ -90,6 +105,42 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     // The current-head fence points at the immutable operation, so the digest
     // and private commitment are stored only once.
     expect(meta.quads.filter((quad) => quad.predicate.endsWith('publicQuadsDigest'))).toHaveLength(1);
+  });
+
+  it('drops the catch-up materialization witness when it replaces the graph (#2079)', async () => {
+    // A gossip apply REPLACES this graph under the same `swmKaWriteLockKey` the
+    // catch-up materializer uses. Catch-up's count gate cannot see a replace
+    // (the count can be unchanged), so this path must drop the memo itself —
+    // otherwise a TORN apply (graph replaced, head write throws) leaves
+    // catch-up certifying the OLD digest against NEW content.
+    //
+    // Its own test rather than an assertion bolted onto another: the second
+    // apply below adds metadata, which would break sibling assertions about
+    // final meta state.
+    const store = new OxigraphStore();
+    const handler = new SharedMemoryHandler(store, new TypedEventBus());
+    expect((await handler.handle(v2Request(), PEER_ID)).applied).toBe(true);
+
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.SharedWorkingMemory,
+      createGraphKnowledgeAssetScope(UAL, 1),
+    );
+    await writeSwmMaterializationWitness(store, swmGraph, 'sha256:stale-witness');
+    expect(await readSwmMaterializationWitness(store, swmGraph, 'sha256:stale-witness')).toBe(true);
+
+    // A genuinely NEW version, not a replay: an identical request is fenced by
+    // durable metadata and never reaches the replace, so it would prove nothing.
+    // All versions of a graph-scoped KA share one assertion graph, so this
+    // replaces exactly the graph the witness was seeded against.
+    const replacement = await handler.handle(v2Request({
+      nquads: new TextEncoder().encode(nquad('urn:entity:2', 'two')),
+      shareOperationId: 'rootless-op-witness',
+      assertionVersion: '2',
+    }), PEER_ID);
+    expect(replacement.applied).toBe(true);
+
+    expect(await readSwmMaterializationWitness(store, swmGraph, 'sha256:stale-witness')).toBe(false);
   });
 
   it('stores canonical Markdown section entities received over SWM', async () => {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -143,6 +143,17 @@ export {
   type KnowledgeAssetPrivateReadOptions,
 } from './private-store.js';
 export { LOCAL_TRUSTED_KA_CONTROLS_GRAPH } from './local-trusted-controls.js';
+// #2079 — node-local memo of an already-verified SWM assertion graph. Read only
+// AFTER a count gate has matched; see the module doc for why the count cannot
+// be dropped.
+export {
+  SWM_MATERIALIZATION_WITNESS_GRAPH,
+  swmMaterializationWitnessSubject,
+  isSwmMaterializationWitnessGraph,
+  readSwmMaterializationWitness,
+  writeSwmMaterializationWitness,
+  invalidateSwmMaterializationWitness,
+} from './swm-materialization-witness.js';
 
 // Side-effect: register built-in adapters
 import './adapters/oxigraph.js';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -149,7 +149,6 @@ export { LOCAL_TRUSTED_KA_CONTROLS_GRAPH } from './local-trusted-controls.js';
 export {
   SWM_MATERIALIZATION_WITNESS_GRAPH,
   swmMaterializationWitnessSubject,
-  isSwmMaterializationWitnessGraph,
   readSwmMaterializationWitness,
   writeSwmMaterializationWitness,
   invalidateSwmMaterializationWitness,

--- a/packages/storage/src/swm-materialization-witness.ts
+++ b/packages/storage/src/swm-materialization-witness.ts
@@ -1,0 +1,157 @@
+/**
+ * A node-local memo recording that THIS node verified a graph-scoped SWM
+ * assertion graph against a specific content digest (issue #2079).
+ *
+ * Like `LOCAL_TRUSTED_KA_CONTROLS_GRAPH`, this graph deliberately lives outside
+ * every context-graph prefix, so durable sync neither serves nor ingests it as
+ * peer metadata.
+ *
+ * ## What this is, and what it is NOT
+ *
+ * It is a **memo of a measurement this node already took** — written only from
+ * the branch that has just computed the digest over its own store content and
+ * found it matching. It is never an independent claim that something is
+ * materialized.
+ *
+ * That distinction is the whole design. A witness derived from anything a PEER
+ * sent is unsound: the bulk `storeInsert(processed.verifiedMeta)` writes head
+ * rows for every descriptor in verified metadata with no dependency on whether
+ * that KA's graph was materialized, so using a head row as the witness grows
+ * MORE likely to wrongly report "already done" the more catch-up rounds a node
+ * runs. That design was proposed for #2079 and killed in review; this module
+ * exists to be the sound alternative, not a variation on it.
+ *
+ * ## The witness is NOT sufficient on its own — callers must keep a count gate
+ *
+ * A witness records that the content WAS correct, not that it still IS. Three
+ * paths remove an assertion graph without any lock this module can participate
+ * in:
+ *
+ *   - the shared-memory TTL sweep (`cleanupExpiredSharedMemory`), on a timer;
+ *   - VM promotion / publish / update (`dropGraph(swmGraph)`), under a
+ *     DIFFERENT lock map than the sync materializer's;
+ *   - the chain-reset wipe, whose scoped delete filters on the context-graph,
+ *     publisher and changelog prefixes only — so a `urn:dkg:local:*` witness
+ *     SURVIVES a wipe that deletes every context-graph triple.
+ *
+ * All three leave an empty or absent graph, which a `COUNT` catches for free.
+ * **Callers must therefore treat a witness hit as valid only after a count gate
+ * has already matched.** Do not "optimize" that count away: without it, the
+ * three paths above become permanent silent divergence certified as parity.
+ *
+ * What the count does NOT catch is an equal-count replace (v1 → v2, same quad
+ * count, different digest). That is why the digest is part of the read, and why
+ * the write must EVICT any prior row for the graph rather than accumulate.
+ */
+import { assertSafeIri } from '@origintrail-official/dkg-core';
+import type { QueryOptions, Quad, TripleStore } from './triple-store.js';
+import { tryReplaceSubjectAtomically } from './triple-store.js';
+
+export const SWM_MATERIALIZATION_WITNESS_GRAPH = 'urn:dkg:local:swm-materialization-witness';
+
+const WITNESS_DIGEST_PREDICATE = 'urn:dkg:local:swm-materialization-witness:digest';
+const WITNESS_VERIFIED_AT_PREDICATE = 'urn:dkg:local:swm-materialization-witness:verified-at-ms';
+
+/**
+ * One subject per assertion graph — NOT per (graph, digest) pair.
+ *
+ * Keying the subject on the graph alone is what makes a new digest EVICT the
+ * old claim in the same atomic replace. Folding the digest into the subject IRI
+ * would leave the previous version's row standing, so a later return to that
+ * digest — or any equal-count replace — would find a standing lie.
+ */
+export function swmMaterializationWitnessSubject(assertionGraph: string): string {
+  return `${assertionGraph}#dkg-swm-materialized`;
+}
+
+/** True for the witness graph itself — for sync/serve exclusion assertions. */
+export function isSwmMaterializationWitnessGraph(graphUri: string): boolean {
+  return graphUri === SWM_MATERIALIZATION_WITNESS_GRAPH;
+}
+
+/**
+ * Has this node verified `assertionGraph` at exactly `digest`?
+ *
+ * A bound-subject ASK: O(1) regardless of graph size. Both the subject and the
+ * digest are bound, so a witness for a DIFFERENT digest reads as a miss rather
+ * than a hit — which is what makes an equal-count version change safe.
+ */
+export async function readSwmMaterializationWitness(
+  store: TripleStore,
+  assertionGraph: string,
+  digest: string,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  const subject = swmMaterializationWitnessSubject(assertionGraph);
+  const result = await store.query(
+    `ASK { GRAPH <${assertSafeIri(SWM_MATERIALIZATION_WITNESS_GRAPH)}> { `
+    + `<${assertSafeIri(subject)}> <${assertSafeIri(WITNESS_DIGEST_PREDICATE)}> ${JSON.stringify(digest)} } }`,
+    options,
+  );
+  return result.type === 'boolean' && result.value === true;
+}
+
+/**
+ * Record that this node verified `assertionGraph` at `digest`, evicting any
+ * prior claim for that graph.
+ *
+ * Returns `false` when the store cannot do an atomic single-subject replace —
+ * in which case NOTHING is written. That is deliberate and is the one place
+ * this module departs from the usual `tryReplaceSubjectAtomically` idiom, which
+ * falls back to delete-then-insert: a missing witness is always safe (it costs
+ * one recomputation), whereas a non-atomic fallback could leave two digest rows
+ * for one graph after an interrupted write — and a stale digest row IS a
+ * standing lie. Never add a fallback here.
+ */
+export async function writeSwmMaterializationWitness(
+  store: TripleStore,
+  assertionGraph: string,
+  digest: string,
+  nowMs: number,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  const subject = swmMaterializationWitnessSubject(assertionGraph);
+  const quads: Quad[] = [
+    {
+      subject,
+      predicate: WITNESS_DIGEST_PREDICATE,
+      object: JSON.stringify(digest),
+      graph: SWM_MATERIALIZATION_WITNESS_GRAPH,
+    },
+    {
+      subject,
+      predicate: WITNESS_VERIFIED_AT_PREDICATE,
+      object: JSON.stringify(String(nowMs)),
+      graph: SWM_MATERIALIZATION_WITNESS_GRAPH,
+    },
+  ];
+  return tryReplaceSubjectAtomically(
+    store,
+    SWM_MATERIALIZATION_WITNESS_GRAPH,
+    subject,
+    quads,
+    options,
+  );
+}
+
+/**
+ * Drop the witness for `assertionGraph`.
+ *
+ * Call this from every path that replaces or removes the graph's content WITHIN
+ * a lock this module can see. The three unlockable paths named in the module
+ * doc are covered by the caller's count gate instead — they cannot be covered
+ * here, and pretending otherwise would be worse than leaving them to the count.
+ */
+export async function invalidateSwmMaterializationWitness(
+  store: TripleStore,
+  assertionGraph: string,
+  options: QueryOptions = {},
+): Promise<void> {
+  await store.deleteByPattern(
+    {
+      graph: SWM_MATERIALIZATION_WITNESS_GRAPH,
+      subject: swmMaterializationWitnessSubject(assertionGraph),
+    },
+    options,
+  );
+}

--- a/packages/storage/src/swm-materialization-witness.ts
+++ b/packages/storage/src/swm-materialization-witness.ts
@@ -42,16 +42,37 @@
  * is exactly the case `COUNT` cannot see. Known sites, all on the byte-identical
  * assertion-graph URI:
  *
- *   - the sync materializer's own `replaceGraph`;
- *   - live gossip apply (`workspace-handler`);
- *   - the graph-scoped VM update path (`dkg-agent-publish`);
- *   - storage-ack persistence (`storage-ack-handler`);
- *   - the private SWM recovery lane (`swm-recovery`), lane-disjoint in automatic
- *     operation but reachable via the `recover-shared-memory` route.
+ *   1. the sync materializer's own `replaceGraph`;
+ *   2. live gossip apply (`workspace-handler`);
+ *   3. the graph-scoped VM update path (`dkg-agent-publish`);
+ *   4. storage-ack persistence (`storage-ack-handler`);
+ *   5-6. the private SWM recovery lane (`swm-recovery`, two calls) — lane-disjoint
+ *     in automatic operation but reachable via the `recover-shared-memory` route;
+ *   7. WM→SWM promotion (`dkg-publisher`);
+ *   8. RFC-64 public-catalog activation
+ *     (`public-catalog-native-receiver-v1.activateExactPublicProjection`), which
+ *     uses `tryReplaceGraphAndSubjectAtomically` — see the grep note below.
  *
- * This list is a snapshot, not a closed set. **A new `tryReplaceGraphAtomically`
- * against a SWM assertion graph is a new obligation here** — treat adding one
- * without an invalidate as a defect.
+ * Two nearby RFC-64 sites are deliberately NOT obligations: rollback restore
+ * puts back the exact preimage, so a standing witness becomes valid again; and
+ * deactivation replaces with `[]`, leaving an empty graph the count gate covers.
+ *
+ * This list is a snapshot, not a closed set. **Any new whole-graph replace of a
+ * SWM assertion graph is a new obligation here** — treat adding one without an
+ * invalidate as a defect.
+ *
+ * When you sweep for missed sites, grep the SHAPE, not one function name. The
+ * primitives in tree today are:
+ *
+ *   - `tryReplaceGraphAtomically`
+ *   - `tryReplaceGraphAndSubjectAtomically`   ← added the 8th site below
+ *   - `store.replaceGraph` directly (the recovery lane)
+ *
+ * An earlier revision of this comment named only the first. Four review rounds
+ * then greppped the token it named and kept reporting the set complete, while
+ * `public-catalog-native-receiver-v1`'s activation — which uses the second —
+ * sat unlisted and uninvalidated. **The tripwire caused the miss it existed to
+ * prevent.** If you add a fourth primitive, add it here in the same commit.
  *
  * **Callers must treat a witness hit as valid only after a count gate has
  * already matched.** Do not "optimize" that count away: without it the removal
@@ -60,6 +81,29 @@
  * The digest is part of the READ for the same reason the replace list exists: a
  * standing v1 row cannot satisfy an ASK bound to v2's digest, which bounds the
  * damage when an invalidate is missed or its best-effort call fails.
+ *
+ * ## Known costs — accepted deliberately, recorded so they don't read as bugs
+ *
+ * An accepted trade nobody wrote down is indistinguishable from an oversight six
+ * months later, so:
+ *
+ *   - **No GC.** Rows are orphaned whenever content is destroyed by a path that
+ *     cannot invalidate — the TTL sweep, VM publish, and the chain-reset wipe
+ *     (whose scoped delete spares `urn:dkg:local:*`). Bounded at two quads per
+ *     KA ever materialized, harmless because every read binds the digest, and
+ *     reclaimed on the next replace of that graph. A sweep keyed on
+ *     "assertion graph no longer exists" would close it.
+ *   - **A changelog marker per write.** This graph is in no reserved set
+ *     (`ChangelogStore`'s is `{CHANGELOG_GRAPH}` plus `options.reservedGraphs`,
+ *     which has no callers), so every cold-path write appends a marker and
+ *     advances `seq`. Local only — the delta lane filters on `isCandidateGraph`,
+ *     so it never reaches a peer.
+ *   - **A read is now also a write.** On a MISS the check performs an atomic
+ *     subject replace inside the KA write lock, where before it only read. Cold
+ *     or churning stores therefore pay slightly more than they used to; the
+ *     memo only pays back on warm ones. `DKG_SWM_MATERIALIZATION_WITNESS=0`
+ *     disables both the read and the write for a fleet that finds it net
+ *     negative.
  */
 import { assertSafeIri, sparqlString } from '@origintrail-official/dkg-core';
 import type { QueryOptions, Quad, TripleStore } from './triple-store.js';

--- a/packages/storage/src/swm-materialization-witness.ts
+++ b/packages/storage/src/swm-materialization-witness.ts
@@ -23,25 +23,43 @@
  *
  * ## The witness is NOT sufficient on its own — callers must keep a count gate
  *
- * A witness records that the content WAS correct, not that it still IS. Three
- * paths remove an assertion graph without any lock this module can participate
- * in:
+ * A witness records that the content WAS correct, not that it still IS. What
+ * happens to the content splits into two classes, and the distinction is the
+ * whole safety argument — do NOT collapse them into one list of "paths that
+ * change the graph".
+ *
+ * **REMOVALS — covered by the caller's count gate, no invalidation needed.**
+ * These leave an empty or absent graph, so `COUNT` returns 0 ≠ expected and the
+ * witness is never consulted:
  *
  *   - the shared-memory TTL sweep (`cleanupExpiredSharedMemory`), on a timer;
- *   - VM promotion / publish / update (`dropGraph(swmGraph)`), under a
- *     DIFFERENT lock map than the sync materializer's;
  *   - the chain-reset wipe, whose scoped delete filters on the context-graph,
  *     publisher and changelog prefixes only — so a `urn:dkg:local:*` witness
  *     SURVIVES a wipe that deletes every context-graph triple.
  *
- * All three leave an empty or absent graph, which a `COUNT` catches for free.
- * **Callers must therefore treat a witness hit as valid only after a count gate
- * has already matched.** Do not "optimize" that count away: without it, the
- * three paths above become permanent silent divergence certified as parity.
+ * **REPLACES — NOT covered by the count gate. Every one MUST invalidate.**
+ * A replace can leave the quad count unchanged while the content differs, which
+ * is exactly the case `COUNT` cannot see. Known sites, all on the byte-identical
+ * assertion-graph URI:
  *
- * What the count does NOT catch is an equal-count replace (v1 → v2, same quad
- * count, different digest). That is why the digest is part of the read, and why
- * the write must EVICT any prior row for the graph rather than accumulate.
+ *   - the sync materializer's own `replaceGraph`;
+ *   - live gossip apply (`workspace-handler`);
+ *   - the graph-scoped VM update path (`dkg-agent-publish`);
+ *   - storage-ack persistence (`storage-ack-handler`);
+ *   - the private SWM recovery lane (`swm-recovery`), lane-disjoint in automatic
+ *     operation but reachable via the `recover-shared-memory` route.
+ *
+ * This list is a snapshot, not a closed set. **A new `tryReplaceGraphAtomically`
+ * against a SWM assertion graph is a new obligation here** — treat adding one
+ * without an invalidate as a defect.
+ *
+ * **Callers must treat a witness hit as valid only after a count gate has
+ * already matched.** Do not "optimize" that count away: without it the removal
+ * paths above become permanent silent divergence certified as parity.
+ *
+ * The digest is part of the READ for the same reason the replace list exists: a
+ * standing v1 row cannot satisfy an ASK bound to v2's digest, which bounds the
+ * damage when an invalidate is missed or its best-effort call fails.
  */
 import { assertSafeIri, sparqlString } from '@origintrail-official/dkg-core';
 import type { QueryOptions, Quad, TripleStore } from './triple-store.js';
@@ -147,7 +165,12 @@ export async function writeSwmMaterializationWitness(
  * here, and pretending otherwise would be worse than leaving them to the count.
  */
 export async function invalidateSwmMaterializationWitness(
-  store: TripleStore,
+  // Narrower than `TripleStore` on purpose: invalidation needs exactly one
+  // capability, and every replace path that must call it is an obligation
+  // regardless of how rich its store handle is. The private recovery lane holds
+  // a `SwmRecoveryStore`, which is not a full `TripleStore` — requiring one here
+  // would have made that site uncallable and quietly left it out of the set.
+  store: { deleteByPattern(pattern: { graph: string; subject: string }, options?: QueryOptions): Promise<unknown> },
   assertionGraph: string,
   options: QueryOptions = {},
 ): Promise<void> {

--- a/packages/storage/src/swm-materialization-witness.ts
+++ b/packages/storage/src/swm-materialization-witness.ts
@@ -43,14 +43,13 @@
  * count, different digest). That is why the digest is part of the read, and why
  * the write must EVICT any prior row for the graph rather than accumulate.
  */
-import { assertSafeIri } from '@origintrail-official/dkg-core';
+import { assertSafeIri, sparqlString } from '@origintrail-official/dkg-core';
 import type { QueryOptions, Quad, TripleStore } from './triple-store.js';
 import { tryReplaceSubjectAtomically } from './triple-store.js';
 
 export const SWM_MATERIALIZATION_WITNESS_GRAPH = 'urn:dkg:local:swm-materialization-witness';
 
 const WITNESS_DIGEST_PREDICATE = 'urn:dkg:local:swm-materialization-witness:digest';
-const WITNESS_VERIFIED_AT_PREDICATE = 'urn:dkg:local:swm-materialization-witness:verified-at-ms';
 
 /**
  * One subject per assertion graph — NOT per (graph, digest) pair.
@@ -59,14 +58,16 @@ const WITNESS_VERIFIED_AT_PREDICATE = 'urn:dkg:local:swm-materialization-witness
  * old claim in the same atomic replace. Folding the digest into the subject IRI
  * would leave the previous version's row standing, so a later return to that
  * digest — or any equal-count replace — would find a standing lie.
+ *
+ * PRECONDITION: `assertionGraph` carries no `#`. Every caller passes a
+ * `knowledgeAssetLayerGraphUri`, which does not, but `assertSafeIri` does NOT
+ * reject `#` — so a fragment-bearing graph would yield a double-fragment IRI
+ * here. That would be a distinct, self-consistent subject rather than a
+ * collision (both write and read derive it the same way), but it is outside
+ * what this keying scheme intends.
  */
 export function swmMaterializationWitnessSubject(assertionGraph: string): string {
   return `${assertionGraph}#dkg-swm-materialized`;
-}
-
-/** True for the witness graph itself — for sync/serve exclusion assertions. */
-export function isSwmMaterializationWitnessGraph(graphUri: string): boolean {
-  return graphUri === SWM_MATERIALIZATION_WITNESS_GRAPH;
 }
 
 /**
@@ -83,12 +84,18 @@ export async function readSwmMaterializationWitness(
   options: QueryOptions = {},
 ): Promise<boolean> {
   const subject = swmMaterializationWitnessSubject(assertionGraph);
-  const result = await store.query(
-    `ASK { GRAPH <${assertSafeIri(SWM_MATERIALIZATION_WITNESS_GRAPH)}> { `
-    + `<${assertSafeIri(subject)}> <${assertSafeIri(WITNESS_DIGEST_PREDICATE)}> ${JSON.stringify(digest)} } }`,
-    options,
-  );
-  return result.type === 'boolean' && result.value === true;
+  // Contained: this is a pure OPTIMISATION, so a transient store error must
+  // degrade to "not memoized" and let the caller do the real read-back. Letting
+  // it throw would make a check that used to succeed fail, which is a strictly
+  // worse outcome than recomputing.
+  const result = await store
+    .query(
+      `ASK { GRAPH <${assertSafeIri(SWM_MATERIALIZATION_WITNESS_GRAPH)}> { `
+      + `<${assertSafeIri(subject)}> <${assertSafeIri(WITNESS_DIGEST_PREDICATE)}> ${sparqlString(digest)} } }`,
+      options,
+    )
+    .catch(() => null);
+  return result?.type === 'boolean' && result.value === true;
 }
 
 /**
@@ -107,21 +114,18 @@ export async function writeSwmMaterializationWitness(
   store: TripleStore,
   assertionGraph: string,
   digest: string,
-  nowMs: number,
   options: QueryOptions = {},
 ): Promise<boolean> {
   const subject = swmMaterializationWitnessSubject(assertionGraph);
+  // Exactly ONE row. An earlier revision also stored a `verified-at-ms`
+  // timestamp; nothing read it, and every witness write appends a changelog
+  // marker and advances `seq`, so a second row doubled that churn for no
+  // consumer. Add a row here only when something reads it.
   const quads: Quad[] = [
     {
       subject,
       predicate: WITNESS_DIGEST_PREDICATE,
-      object: JSON.stringify(digest),
-      graph: SWM_MATERIALIZATION_WITNESS_GRAPH,
-    },
-    {
-      subject,
-      predicate: WITNESS_VERIFIED_AT_PREDICATE,
-      object: JSON.stringify(String(nowMs)),
+      object: sparqlString(digest),
       graph: SWM_MATERIALIZATION_WITNESS_GRAPH,
     },
   ];


### PR DESCRIPTION
## Summary

- **Memoizes the already-materialized check.** Deciding whether a graph-scoped KA is already materialized ran a `COUNT`, a full `CONSTRUCT` of the assertion graph, and a SHA-256 over the result — per descriptor, per pass, **inside `withKaWriteLock`**, so it blocked live gossip for that KA. Amplified by `CATCHUP_MAX_CONCURRENT_PEER_SYNCS` (4) × `DEFAULT_SWM_CATCHUP_MAX_PASSES` (4). A warm check is now a bound-subject `ASK`.
- **Measured per-KA** (50 / 200 / 1000 / 5000 quads): `CONSTRUCT`+digest is **0.91 / 2.69 / 15.98 / 197.81 ms**; the witness `ASK` is **~0.03–0.06 ms**. That is **46 / 55 / 74 / 90 %** less local work. The default backend is `oxigraph-worker`, where CONSTRUCT results cross a `postMessage` + structured clone — so these are **lower bounds** in production.
- **This is deliberately NOT what the issue asked for.** #2079 proposed replacing the whole predicate with a single `ASK`. The `COUNT` gate is **kept**, and that is the load-bearing decision — see below.

## Related

- Implements #2079
- Follow-up from #2050 / PR #2076

## Diagrams

### The already-materialized check, warm pass

Before — every descriptor pays a full read-back and digest, inside the write lock:

```mermaid
sequenceDiagram
    participant Sync as catch-up pass
    participant Lock as withKaWriteLock
    participant Store as triple store
    Sync->>Lock: acquire (blocks live gossip for this KA)
    Lock->>Store: COUNT assertion graph
    Store-->>Lock: n == expected
    Lock->>Store: CONSTRUCT whole assertion graph
    Store-->>Lock: all quads
    Note over Lock: SHA-256 over every quad<br/>198 ms at 5000 quads
    Lock-->>Sync: already materialized
```

After — the digest is computed once, then remembered:

```mermaid
sequenceDiagram
    participant Sync as catch-up pass
    participant Lock as withKaWriteLock
    participant Store as triple store
    Sync->>Lock: acquire
    Lock->>Store: COUNT assertion graph
    Store-->>Lock: n == expected
    Note over Lock: count gate KEPT - catches every<br/>drop-shaped damage path for free
    Lock->>Store: ASK witness (subject + digest bound)
    Store-->>Lock: hit
    Lock-->>Sync: already materialized (no CONSTRUCT)
```

### Why the witness cannot outlive its content

```mermaid
sequenceDiagram
    participant Sweep as TTL sweep / VM publish / chain reset
    participant Store as triple store
    participant Check as isGraphAssetMaterialized
    Sweep->>Store: drop assertion graph
    Note over Store: witness SURVIVES - the chain-reset scoped<br/>delete spares urn:dkg:local:*
    Check->>Store: COUNT assertion graph
    Store-->>Check: 0
    Note over Check: 0 != expected, so the witness is<br/>never consulted - miss, then repair
    Check-->>Check: NOT materialized
```

## Files changed

| File | What |
|------|------|
| `packages/storage/src/swm-materialization-witness.ts` | **New.** The witness: local-only graph `urn:dkg:local:swm-materialization-witness`, one subject per assertion graph with the digest as an **object** so a new digest evicts the old claim atomically. Write uses `tryReplaceSubjectAtomically` and **skips entirely** when unsupported. Module doc states why callers must keep a count gate. |
| `packages/storage/src/index.ts` | Exports the witness API |
| `packages/agent/src/sync/requester/swm-snapshot-materializer.ts` | Fast-path `ASK` between the count gate and the CONSTRUCT; witness written from the **verification branch**; invalidation in `replaceGraph`; static capability probe + `DKG_SWM_MATERIALIZATION_WITNESS` kill switch |
| `packages/publisher/src/workspace-handler.ts` | **Invalidates on the live gossip apply** — same `swmKaWriteLockKey`, a replace the count gate cannot see |
| `packages/agent/src/dkg-agent-publish.ts` | Invalidates on the graph-scoped VM update replace |
| `packages/publisher/src/storage-ack-handler.ts` | Invalidates on storage-ack persistence replace |
| `packages/agent/src/sync/requester/swm-recovery.ts` | Invalidates on both private-recovery replaces (reachable via the `recover-shared-memory` route) |
| `packages/publisher/test/ka-graph-workspace-receiver.test.ts` | Pins the gossip-apply invalidation — in `packages/publisher` because the agent lane resolves publisher from `dist` |
| `packages/agent/test/swm-materialization-witness.test.ts` | **New.** 10 rows against a real `OxigraphStore` |
| `packages/agent/vitest.unit.config.ts` | Adds the new file to the `include` allow-list (a file not listed is silently uncollected) |

## Why the COUNT gate stays — read this before approving

The issue asks for "a single bound-subject `ASK`", i.e. the witness replacing the whole predicate. That trades away self-healing for very little:

Two classes of thing happen to an assertion graph, and conflating them is what an earlier revision of this PR got wrong:

**REMOVALS — the count gate covers these for free** (`count 0 != expected`), no invalidation possible or needed:

| Path | Detail |
|---|---|
| SWM TTL sweep | `cleanupExpiredSharedMemory` — timer-driven, no lock |
| Chain-reset wipe | `SPARQL_SCOPED_DELETE` filters on **exactly** the context-graph, publisher and changelog prefixes — so a `urn:dkg:local:*` witness **survives a wipe that deletes every context-graph triple** |

Under ASK-only the wipe certifies an **empty store as parity**, permanently and silently. The TTL case is worse — self-reinforcing, since the head is reinstalled over an empty graph and re-expired forever. **Measured, also dropping the count buys a further 1.5–10.5 %.** Not a good trade.

**REPLACES — never count-covered; every one must invalidate.** A replace can leave the quad count unchanged while the content differs. All five known sites now do: the materializer's own `replaceGraph`, live gossip apply, the graph-scoped VM update, storage-ack persistence, and both private-recovery replaces. The list is documented as a **snapshot, not a closed set** — a new `tryReplaceGraphAtomically` against a SWM assertion graph is a new obligation.

## Soundness

- **The witness is written from the verification branch, not the replace path** — only after this node computed the digest over its own store content and matched it. It can therefore never record something a peer asserted, and there is no crash window in which a witness exists for content that was never verified. (The prior art here is the head row, which #2079 documents as unsound precisely because the bulk meta insert writes head rows with no dependency on materialization.)
- **Equal-count `v1 → v2`** — the case the count cannot catch — is bounded by the **read binding the digest**: a standing v1 row cannot satisfy an `ASK` for v2's digest. That covers (old witness, new descriptor). It does **not** cover (old witness, new content, old descriptor) — which is why every replace site invalidates, and why those calls are not merely hygiene. They are best-effort, so the residual is real rather than zero.
- **Backends that cannot hold a witness are detected before the first query.** A store without `replaceSubject` (`sparql-http` with `atomicUpdates:false`) issues **zero** ASKs and is byte-identical to pre-#2079. A decorator's preflight refusal is deliberately *not* latched — it may be conditional, and latching would disable the memo for the process on a transient event.
- **`DKG_SWM_MATERIALIZATION_WITNESS`** disables the read and the write; the **invalidations always run**, because turning the memo off must not turn off what keeps existing memos honest.
- **No non-atomic fallback.** If the adapter cannot do an atomic subject replace, nothing is written. A missing witness costs one recomputation; a split write could leave two digest rows for one graph, which is a standing lie.

## Honest scope — this does NOT make a repeat pass O(1)

`hasValidSnapshot` still does a whole `.nq` `readFile`, a parse, and a **second** full digest per manifest ref in `syncPublicSnapshotsForMeta`, **before** `onSnapshotReady` fires — untouched by a descriptor-level witness. Refs with no descriptor (`urn:dkg:public-stage:*` entity shares) pay it and gain nothing.

**The pass stays O(total CG bytes).** The claim is 2×–11× less local per-KA work, and the wall-clock share of a whole pass is **not yet measured**.

## Test plan

- [x] 10 new rows against a real `OxigraphStore`, plus a publisher-side guard; existing materializer and recovery suites still green
- [x] Full agent closure builds (`tsc` exit 0)
- [x] **Mutation, disjoint rows, assertion deaths:**

  | Mutation | Result |
  |---|---|
  | remove the `COUNT` conjunct (ASK-only) | drop-then-recheck row dies `expected true to be false` — a standing witness certifies an empty graph, i.e. exactly the ASK-only failure |
  | never write the witness | warm-path row dies `expected 2 to be 1` — a second `CONSTRUCT` reappears |
  | write unconditionally (drop `if (matches)`) | mismatch row dies `expected true to be false` — this is the invariant that killed the head-row proposal, and it shipped unpinned in the first revision |
  | point the gossip invalidate at another graph | publisher guard dies `expected true to be false` |

- [ ] **Not done: hit-rate instrumentation on a live warm pass.** If witness hits turn out to be rare, the memo is not paying and this should be reverted rather than tuned.
