### PR TITLE
fix(sync): default-deprioritize system Context Graphs in sync scheduling

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1252,7 +1252,11 @@ export interface DKGAgentConfig {
   syncGlobalQueueLimit?: number;
   /** Daemon-local retained responder snapshot row/estimated-byte policy. */
   syncResponderSnapshotLimits?: SyncResponderSnapshotLimitsConfig;
-  /** Local requester/responder priority by Context Graph ID. Higher runs first. */
+  /**
+   * Local requester/responder priority by Context Graph ID. Higher runs first.
+   * System Context Graphs default to a deprioritized priority so they run
+   * last; an explicit entry here (including 0) overrides that default.
+   */
   syncContextGraphPriorities?: SyncContextGraphPriorityConfig;
   /** StorageACK handler deadline override in milliseconds. Env DKG_STORAGE_ACK_HANDLER_DEADLINE_MS wins. */
   storageAckHandlerDeadlineMs?: number;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -218,7 +218,7 @@ import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-bu
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
 import {
-  normalizeSyncContextGraphPriorities,
+  resolveSyncContextGraphPriorities,
   validateSyncResponderSnapshotLimitsConfig,
 } from './sync/policy.js';
 import { runSyncOnConnect } from './sync/on-connect/sync-on-connect.js';
@@ -711,7 +711,7 @@ export class DKGAgent extends DKGAgentBase {
     validateSyncResponderSnapshotLimitsConfig(inputConfig.syncResponderSnapshotLimits);
     const config = normalizeStorageAckConfig({
       ...inputConfig,
-      syncContextGraphPriorities: normalizeSyncContextGraphPriorities(
+      syncContextGraphPriorities: resolveSyncContextGraphPriorities(
         inputConfig.syncContextGraphPriorities,
       ),
     });

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -135,12 +135,14 @@ export type {
   AcceptedRfc64CatalogAccessSnapshotV1,
 } from './rfc64/catalog-access-policy-v1.js';
 export {
+  DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY,
   SYNC_ADMISSION_SOURCES,
   contextGraphPriority,
   countSyncPriorityClasses,
   normalizeSyncAdmissionSource,
   normalizeSyncContextGraphPriorities,
   orderContextGraphIdsByPriority,
+  resolveSyncContextGraphPriorities,
   syncPriorityClass,
   validateSyncResponderSnapshotLimitsConfig,
   type SyncAdmissionSource,

--- a/packages/agent/src/sync/policy.ts
+++ b/packages/agent/src/sync/policy.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+
 export interface SyncResponderSnapshotLimitsConfig {
   global?: {
     rows?: number;
@@ -123,11 +125,56 @@ export function normalizeSyncContextGraphPriorities(
   return Object.freeze(normalized);
 }
 
+/**
+ * System Context Graphs are broadcast directories: every peer replicates them,
+ * they grow with the network (tens of thousands of triples), and any connected
+ * peer can serve them. A user Context Graph has none of those properties — its
+ * one reachable curator may be the only source in a fanout that stops on the
+ * first failure, so a system graph failing mid-transfer ahead of user work
+ * starves every user graph behind it on every cycle. Running system graphs
+ * LAST bounds that blast radius to the graphs that can afford it. Operators
+ * override by naming the graph in `syncContextGraphPriorities`; an explicit 0
+ * restores ordinary scheduling.
+ */
+export const DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY = -100;
+
+const SYSTEM_CONTEXT_GRAPH_IDS: ReadonlySet<string> = new Set(
+  Object.values(SYSTEM_CONTEXT_GRAPHS),
+);
+
+/**
+ * Normalize the operator config and fill in the system-graph defaults. Applied
+ * where the config is normalized (agent construction) so every consumer —
+ * fanout ordering, admission scheduling, responder scheduling, and the
+ * "Resolved sync policy" boot log's class counts — acts on and reports the
+ * same effective map.
+ */
+export function resolveSyncContextGraphPriorities(
+  config: SyncContextGraphPriorityConfig | undefined,
+): Readonly<SyncContextGraphPriorityConfig> {
+  const resolved: SyncContextGraphPriorityConfig = {
+    ...normalizeSyncContextGraphPriorities(config),
+  };
+  for (const contextGraphId of SYSTEM_CONTEXT_GRAPH_IDS) {
+    resolved[contextGraphId] ??= DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY;
+  }
+  return Object.freeze(resolved);
+}
+
 export function contextGraphPriority(
   priorities: Readonly<SyncContextGraphPriorityConfig> | undefined,
   contextGraphId: string,
 ): number {
-  return priorities?.[contextGraphId] ?? 0;
+  const configured = priorities?.[contextGraphId];
+  if (configured !== undefined) return configured;
+  // Read-side backstop for maps that never passed through
+  // resolveSyncContextGraphPriorities (a raw config object, or none at all):
+  // system graphs sorting last must not depend on every caller remembering
+  // the resolve step. A resolved map already carries the same value, so the
+  // two layers can never disagree.
+  return SYSTEM_CONTEXT_GRAPH_IDS.has(contextGraphId)
+    ? DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY
+    : 0;
 }
 
 export function syncPriorityClass(priority: number): SyncPriorityClass {

--- a/packages/agent/test/sync-policy.test.ts
+++ b/packages/agent/test/sync-policy.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import {
+  DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY,
   SYNC_ADMISSION_SOURCES,
   contextGraphPriority,
   countSyncPriorityClasses,
   normalizeSyncAdmissionSource,
   normalizeSyncContextGraphPriorities,
   orderContextGraphIdsByPriority,
+  resolveSyncContextGraphPriorities,
   syncPriorityClass,
   validateSyncResponderSnapshotLimitsConfig,
 } from '../src/sync/policy.js';
@@ -39,6 +42,79 @@ describe('sync Context Graph policy', () => {
       default: 1,
       deprioritized: 1,
     });
+  });
+});
+
+describe('system Context Graph default deprioritization', () => {
+  const systemIds = Object.values(SYSTEM_CONTEXT_GRAPHS) as string[];
+
+  it('resolves defaults for every system graph the operator did not configure', () => {
+    for (const config of [undefined, {}]) {
+      const resolved = resolveSyncContextGraphPriorities(config);
+      for (const systemId of systemIds) {
+        expect(resolved[systemId]).toBe(DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY);
+      }
+      expect(Object.isFrozen(resolved)).toBe(true);
+    }
+    // The plain normalizer stays default-free: the defaults enter exactly once,
+    // at the resolve step, so a config round-trip cannot re-apply them.
+    expect(normalizeSyncContextGraphPriorities({})).toEqual({});
+  });
+
+  it('lets an explicit operator value win — positive, zero, and negative', () => {
+    const resolved = resolveSyncContextGraphPriorities({
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS]: 0,
+      [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]: 7,
+      'user-bulk': -3,
+    });
+    // Explicit 0 is a real override back to ordinary scheduling, not "unset".
+    expect(resolved[SYSTEM_CONTEXT_GRAPHS.AGENTS]).toBe(0);
+    expect(resolved[SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]).toBe(7);
+    expect(resolved['user-bulk']).toBe(-3);
+    expect(resolveSyncContextGraphPriorities({
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS]: -1,
+    })[SYSTEM_CONTEXT_GRAPHS.AGENTS]).toBe(-1);
+  });
+
+  it('orders system graphs after all user graphs, even explicitly deprioritized ones', () => {
+    const resolved = resolveSyncContextGraphPriorities({ 'user-bulk': -3 });
+    expect(orderContextGraphIdsByPriority(
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, 'user-a', SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'user-bulk', 'user-b'],
+      resolved,
+    )).toEqual([
+      'user-a', 'user-b', 'user-bulk',
+      SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+    ]);
+    // An elevated override moves a system graph ahead of default user graphs.
+    expect(orderContextGraphIdsByPriority(
+      ['user-a', SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
+      resolveSyncContextGraphPriorities({ [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]: 1 }),
+    )).toEqual([SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'user-a']);
+  });
+
+  it('sorts system graphs last through the read-side backstop for unresolved maps', () => {
+    // Callers holding a raw config (or none) must not lose the invariant.
+    expect(contextGraphPriority(undefined, SYSTEM_CONTEXT_GRAPHS.AGENTS))
+      .toBe(DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY);
+    expect(contextGraphPriority({}, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY))
+      .toBe(DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY);
+    expect(contextGraphPriority(undefined, 'user-a')).toBe(0);
+    expect(contextGraphPriority({ [SYSTEM_CONTEXT_GRAPHS.AGENTS]: 0 }, SYSTEM_CONTEXT_GRAPHS.AGENTS)).toBe(0);
+    expect(orderContextGraphIdsByPriority(
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, 'user-a'],
+      undefined,
+    )).toEqual(['user-a', SYSTEM_CONTEXT_GRAPHS.AGENTS]);
+  });
+
+  it('reports the defaults in the resolved class counts', () => {
+    // The "Resolved sync policy" boot log counts the RESOLVED map, so an
+    // operator can see the system graphs running deprioritized without
+    // having configured anything.
+    expect(countSyncPriorityClasses(resolveSyncContextGraphPriorities({ urgent: 5 })))
+      .toEqual({ elevated: 1, default: 0, deprioritized: systemIds.length });
+    expect(countSyncPriorityClasses(resolveSyncContextGraphPriorities({
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS]: 0,
+    }))).toEqual({ elevated: 0, default: 1, deprioritized: systemIds.length - 1 });
   });
 });
 

--- a/packages/agent/test/sync-requester-priority.test.ts
+++ b/packages/agent/test/sync-requester-priority.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createOperationContext, PROTOCOL_SYNC_CHANGELOG } from '@origintrail-official/dkg-core';
+import { createOperationContext, PROTOCOL_SYNC_CHANGELOG, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import {
   runDurableSync,
   type DurableSyncFetchRequest,
@@ -121,6 +121,32 @@ describe('requester per-CG priority admission', () => {
     );
 
     expect(admissions).toEqual(['high', 'default', 'low']);
+  });
+
+  it('admits system Context Graphs last so their failures cannot starve user graphs', async () => {
+    // System graphs are the observed poison transfers in the per-peer fanout,
+    // and the fanout stops on the first failure — so they must run after every
+    // user graph even when the agent config never mentions them. An explicit
+    // operator entry (0 here) restores ordinary scheduling.
+    const admissions: string[] = [];
+    const agent = lifecycleAgent(
+      { [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]: 0 },
+      async (contextGraphId, work) => {
+        admissions.push(contextGraphId);
+        return work();
+      },
+    );
+
+    await (LifecycleSyncMethods.prototype.runLegacyDurableSync as any).call(
+      agent,
+      ctx,
+      'peer',
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, 'user-a', SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'user-b'],
+    );
+
+    expect(admissions).toEqual([
+      'user-a', SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'user-b', SYSTEM_CONTEXT_GRAPHS.AGENTS,
+    ]);
   });
 
   it('preserves completed durable progress when a later admission is deferred', async () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -630,7 +630,11 @@ export interface DkgConfig {
   syncGlobalQueueLimit?: number;
   /** Retained sync responder snapshot limits (rows and estimated bytes). */
   syncResponderSnapshotLimits?: SyncResponderSnapshotLimitsConfig;
-  /** Local sync scheduling priority by Context Graph ID. */
+  /**
+   * Local sync scheduling priority by Context Graph ID. Higher runs first.
+   * System Context Graphs default to a deprioritized priority so they run
+   * last; an explicit entry here (including 0) overrides that default.
+   */
   syncContextGraphPriorities?: SyncContextGraphPriorityConfig;
   /** StorageACK handler deadline override in milliseconds. Env DKG_STORAGE_ACK_HANDLER_DEADLINE_MS wins. */
   storageAckHandlerDeadlineMs?: number;


### PR DESCRIPTION
## Problem

System CGs (`agents`, `ontology`) are broadcast directories, yet they bulk-replicate through the same per-peer sync fanout as user data — ahead of it, at default priority. On a live 10.0.12 Base-mainnet edge node (2026-08-06) they were the observed poison transfers: ~16k-triple rounds dying mid-stream against a relay-only curator every 5-minute cycle, and because the fanout stops on the first backoff-worthy failure, a trivial 604-triple user CG behind them could not receive its curator's SWM updates for hours.

## Fix

System CGs now default to priority **-100** (`DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY`), so they sort **last** in every fanout and admission-queue ordering. Two layers that can never disagree:

- `resolveSyncContextGraphPriorities(...)` fills defaults at agent construction, so every consumer — fanout ordering, admission scheduling, and the "Resolved sync policy" boot log's class counts — sees the same effective map.
- `contextGraphPriority(...)` carries a read-side backstop for maps that never passed through the resolve step.

An explicit operator entry in `syncContextGraphPriorities` (including `0`) always wins.

Running system CGs last also bounds the fanout-abort blast radius: their failures can no longer starve user CGs — only each other. (Fanout abort semantics themselves are fixed separately in the sibling PR `fix/sync-fanout-isolation`.)

## Notes

- Field-verified equivalent: setting `"agents": -100, "ontology": -100` in config on the affected node moved user-CG rounds ahead of the poison transfers in the very next cycle.
- Supersedes part of draft #1946.
- OT-RFC-64 Rev 4.7 is silent on system-CG scheduling; this is a legacy-path repair that also improves the fixed Track-1 baseline its §10.4 A/B gate measures against.

## Tests

`sync-policy.test.ts` + `sync-requester-priority.test.ts`: defaults applied; explicit override wins (positive/zero/negative); system CGs order last incl. the read-side backstop path; resolved class counts reflect defaults. Full `@origintrail-official/dkg-agent` build (tsc + type tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)