### PR TITLE
fix(sync): stop letting one Context Graph's failure abort the per-peer fanout

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -305,7 +305,7 @@ import {
   createDurableSyncAccumulator,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
-  durableSyncAccumulatorHasBackoffWorthyFailure,
+  durableSyncAccumulatorHasPeerTransportFailure,
   durableSyncAccumulatorHasTerminalBoundary,
   durableSyncAccumulatorFromResult,
   finalizeDurableSyncCompletion,
@@ -4802,9 +4802,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           return markDurableTerminalBoundary(summary, false);
         },
         shouldContinue: () => !operationBoundary.signal?.aborted,
-        shouldStop: (part) => Boolean(
+        // One CG's backoff-worthy round stays in the merged summary (its
+        // terminal boundary is false, so the aggregate cannot finalize
+        // complete, and the peer is not stamped fresh) while the remaining
+        // CGs still get their turn. Only peer-never-responded rounds may
+        // stop the batch, via the ordered fanout's consecutive-failure guard.
+        isPeerTransportFailure: (part) => Boolean(
           stopOnBackoffWorthyFailure
-          && durableSyncAccumulatorHasBackoffWorthyFailure(part),
+          && durableSyncAccumulatorHasPeerTransportFailure(part),
         ),
         onDeferred: (item, error) => this.log.info(
           ctx,
@@ -6125,8 +6130,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           ...summary,
           deferredBackpressure: (summary.deferredBackpressure ?? 0) + 1,
         }),
-        shouldStop: (part) => Boolean(
-          stopOnBackoffWorthyFailure && (part.backoffWorthyFailures ?? 0) > 0,
+        // Mirrors the durable fanout: a failed CG round is already recorded in
+        // the merged counters and must not cost the remaining CGs their turn.
+        // `failedPeers` is the peer-never-responded signal on the public lane;
+        // the private curator-recovery lane also reports it for its whole-round
+        // failures, which the consecutive-failure guard bounds instead of
+        // aborting on the first one.
+        isPeerTransportFailure: (part) => Boolean(
+          stopOnBackoffWorthyFailure && part.failedPeers > 0,
         ),
         onDeferred: (item, error) => this.log.info(
           ctx,

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -280,6 +280,20 @@ export class DurableSyncAccumulator {
     return this.diagnostics.backoffWorthyFailures > 0;
   }
 
+  /**
+   * The peer never responded for a folded round. `failedPeers` is recorded by
+   * the requester runners only when a round's error carried the transport tag
+   * AND no phase of that round saw a response (`error-tags.ts`
+   * `isSyncTransportFailure` / `didSyncPeerRespond`); everything the peer did
+   * answer — denials, post-response failures, timeouts with pages — lands in
+   * the per-phase counters instead. That makes this the one signal that
+   * distinguishes "the peer is unreachable" from "this Context Graph's round
+   * went wrong".
+   */
+  hasPeerTransportFailure(): boolean {
+    return this.diagnostics.failedPeers > 0;
+  }
+
   hasTerminalBoundary(): boolean {
     return this.observedTerminalBoundaries > 0;
   }
@@ -350,6 +364,12 @@ export function durableSyncAccumulatorHasBackoffWorthyFailure(
   accumulator: DurableSyncAccumulator,
 ): boolean {
   return accumulator.hasBackoffWorthyFailure();
+}
+
+export function durableSyncAccumulatorHasPeerTransportFailure(
+  accumulator: DurableSyncAccumulator,
+): boolean {
+  return accumulator.hasPeerTransportFailure();
 }
 
 export function durableSyncAccumulatorHasTerminalBoundary(

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -69,6 +69,13 @@ interface SyncResultAccounting {
   insertedTriples: number;
   madeProgress: boolean;
   backoffWorthyFailure: boolean;
+  /**
+   * The peer never answered at least one Context Graph's round
+   * (`failedPeers`), as opposed to a round that failed after a response.
+   * Only this — combined with zero progress — may stop the on-connect
+   * fanout early; per-CG failures are isolated inside the sync itself.
+   */
+  peerUnreachable: boolean;
   denied: boolean;
   failed: boolean;
   deferredByBackpressure: boolean;
@@ -85,6 +92,7 @@ function classifySyncResult(
       insertedTriples: result,
       madeProgress: true,
       backoffWorthyFailure: false,
+      peerUnreachable: false,
       denied: false,
       failed: false,
       deferredByBackpressure: false,
@@ -98,6 +106,7 @@ function classifySyncResult(
     insertedTriples: result.insertedTriples,
     madeProgress: progress.madeReconnectProgress,
     backoffWorthyFailure: progress.backoffWorthyFailure,
+    peerUnreachable: progress.transportFailed,
     denied: progress.denied,
     failed: progress.phaseFailed || progress.integrityRejected,
     deferredByBackpressure: progress.deferredByBackpressure,
@@ -230,9 +239,19 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after local admission deferral`);
       return finishSyncAccounting();
     }
-    if (syncedAccounting.backoffWorthyFailure) {
-      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after durable sync hit backoff-worthy pressure`);
+    // A backoff-worthy per-CG failure must NOT stop the remaining lanes: the
+    // failure is already recorded (the peer will not be stamped fresh), and
+    // stopping here starves CG discovery and shared-memory sync of a peer
+    // that is demonstrably reachable — the small-CG-behind-a-poison-transfer
+    // starvation this accounting exists to prevent. Only a peer that never
+    // answered any round and produced no progress stops the fanout, because
+    // every later lane would just re-dial the same dead peer.
+    if (syncedAccounting.peerUnreachable && !syncedAccounting.madeProgress) {
+      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer}: durable sync could not reach the peer`);
       return finishSyncAccounting();
+    }
+    if (syncedAccounting.backoffWorthyFailure) {
+      logInfo(ctx, `Durable sync from peer ${shortPeer} hit backoff-worthy pressure; continuing remaining sync-on-connect lanes`);
     }
 
     const syncScope = new Set<string>([
@@ -255,8 +274,10 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
         logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after discovered-CG admission deferral`);
         return finishSyncAccounting();
       }
-      if (discoverAccounting.backoffWorthyFailure) {
-        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after discovered-CG durable sync hit backoff-worthy pressure`);
+      // Same policy as the primary durable leg: per-CG pressure continues,
+      // only an unanswered round with no progress stops the fanout.
+      if (discoverAccounting.peerUnreachable && !discoverAccounting.madeProgress) {
+        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer}: discovered-CG durable sync could not reach the peer`);
         return finishSyncAccounting();
       }
       await runNonTransportStep(() => refreshMetaSyncedFlags(newlyDiscovered));

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -102,11 +102,23 @@ function classifySyncResult(
   }
 
   const progress = classifyDurableProgress(result, { complete });
+  // `failedPeers` is folded across every Context Graph in this lane. It says
+  // at least one round never got a response; it does not mean the peer failed
+  // to answer every round. Preserve any response evidence from sibling CGs so
+  // one unreachable/poisoned CG cannot suppress discovery and SWM fanout from
+  // a peer that demonstrably answered elsewhere.
+  const peerRespondedInLane = progress.madeReconnectProgress
+    || progress.denied
+    || progress.phaseFailed
+    || progress.integrityRejected
+    || progress.timedOut
+    || progress.hasMetadataEvidence
+    || progress.hasVerifiedPrivateOnlyResponse;
   return {
     insertedTriples: result.insertedTriples,
     madeProgress: progress.madeReconnectProgress,
     backoffWorthyFailure: progress.backoffWorthyFailure,
-    peerUnreachable: progress.transportFailed,
+    peerUnreachable: progress.transportFailed && !peerRespondedInLane,
     denied: progress.denied,
     failed: progress.phaseFailed || progress.integrityRejected,
     deferredByBackpressure: progress.deferredByBackpressure,

--- a/packages/agent/src/sync/requester/ordered-sync.ts
+++ b/packages/agent/src/sync/requester/ordered-sync.ts
@@ -5,6 +5,20 @@ import {
   type SyncContextGraphPriorityConfig,
 } from '../policy.js';
 
+/**
+ * Peer-dead cutoff for one fanout batch. One Context Graph's failed round must
+ * never cost the remaining CGs their turn — a single poisoned transfer (an
+ * oversized system CG dying mid-stream every cycle) otherwise starves every
+ * small CG behind it indefinitely. But the inverse is also real: when the peer
+ * itself is dead or unreachable, every remaining item re-dials it and burns a
+ * full transport timeout, so a long CG list turns one dead peer into an
+ * hours-long stall. Three consecutive rounds in which the peer never responded
+ * is treated as peer-dead evidence and stops the batch; any round the peer
+ * answered — cleanly, denied, or failed after responding — resets the streak,
+ * so per-CG failures alone can never trip this guard.
+ */
+export const MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES = 3;
+
 export interface ContextGraphSyncWork<Result> {
   contextGraphId: string;
   /**
@@ -38,7 +52,15 @@ export interface OrderedContextGraphSyncOptions<Result> {
     skipped: readonly ContextGraphSyncWork<Result>[],
   ) => Result;
   shouldContinue?: () => boolean;
-  shouldStop?: (part: Result) => boolean;
+  /**
+   * True when one merged item result shows the PEER never responded for that
+   * Context Graph's round (transport-class: dial/stream death before any
+   * answer). Failures the peer did respond to must return false — they are
+   * already recorded in the merged summary, and the fanout continues to the
+   * next CG. Consecutive true verdicts feed the peer-dead cutoff
+   * ({@link MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES}).
+   */
+  isPeerTransportFailure?: (part: Result) => boolean;
   onDeferred?: (item: ContextGraphSyncWork<Result>, error: Error) => void;
 }
 
@@ -72,6 +94,7 @@ export async function runOrderedContextGraphSyncs<Result>(
 ): Promise<Result> {
   let summary = options.emptyResult();
   const orderedWork = orderWork(options.work, options.priorities);
+  let consecutivePeerTransportFailures = 0;
   for (const [index, item] of orderedWork.entries()) {
     if (options.shouldContinue && !options.shouldContinue()) {
       summary = options.markSkipped?.(summary, orderedWork.slice(index)) ?? summary;
@@ -84,8 +107,16 @@ export async function runOrderedContextGraphSyncs<Result>(
         () => item.run(remaining),
       );
       summary = options.merge(summary, part);
-      if (options.shouldStop?.(part)) break;
+      if (options.isPeerTransportFailure?.(part)) {
+        consecutivePeerTransportFailures += 1;
+        if (consecutivePeerTransportFailures >= MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES) break;
+      } else {
+        consecutivePeerTransportFailures = 0;
+      }
     } catch (error) {
+      // The GLOBAL admission queue rejected this item, so every later item
+      // would be rejected identically — stopping here is correct and cheap,
+      // unlike a per-CG failure, which stays isolated above.
       const backpressureError = getSyncBackpressureBusyError(error);
       if (!backpressureError) throw error;
       summary = options.markDeferred(summary);

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -334,7 +334,7 @@ describe('sync-on-connect churn gates', () => {
     });
   });
 
-  it('records progress before stopping post-durable sync-on-connect fanout after backoff-worthy durable pressure', async () => {
+  it('continues post-durable sync-on-connect fanout past backoff-worthy per-CG durable pressure', async () => {
     const refreshMetaSyncedFlags = recorder(async () => undefined);
     const discoverContextGraphsFromStore = recorder(async () => 0);
     const syncSharedMemoryFromPeer = recorder(async () => 0);
@@ -363,14 +363,50 @@ describe('sync-on-connect churn gates', () => {
       },
     });
 
+    // The peer answered (failedPeers: 0), so one CG's backoff-worthy round may
+    // not starve CG discovery or shared-memory sync; only peer accounting
+    // remembers the pressure (fresh: false).
+    expect(outcome).toBe('synced');
+    expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
+    expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['cg-a']]]);
+    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+  });
+
+  it('stops post-durable sync-on-connect fanout when the peer never answered and nothing progressed', async () => {
+    const refreshMetaSyncedFlags = recorder(async () => undefined);
+    const discoverContextGraphsFromStore = recorder(async () => 0);
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['cg-a'],
+      syncFromPeer: async () => emptyDetailedSync({
+        failedPeers: 1,
+        backoffWorthyFailures: 1,
+      }),
+      refreshMetaSyncedFlags,
+      discoverContextGraphsFromStore,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => {
+        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+      },
+    });
+
+    // A dead/unreachable peer must not be re-dialed by every later lane.
     expect(outcome).toBe('synced');
     expect(refreshMetaSyncedFlags.calls).toEqual([]);
     expect(discoverContextGraphsFromStore.calls).toEqual([]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([]);
-    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+    expect(syncedPeers).toEqual([]);
   });
 
-  it('records progress before stopping newly discovered CG fanout after durable pressure', async () => {
+  it('continues newly discovered CG fanout past per-CG durable pressure with progress', async () => {
     let contextGraphs = ['cg-a'];
     const refreshMetaSyncedFlags = recorder(async () => undefined);
     const discoverContextGraphsFromStore = recorder(async () => {
@@ -411,9 +447,9 @@ describe('sync-on-connect churn gates', () => {
 
     expect(outcome).toBe('synced');
     expect(syncFromPeer.calls).toEqual([[PEER_A], [PEER_A, ['cg-b']]]);
-    expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
+    expect(refreshMetaSyncedFlags.calls).toHaveLength(2);
     expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
-    expect(syncSharedMemoryFromPeer.calls).toEqual([]);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['cg-a', 'cg-b']]]);
     expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
   });
 

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -406,6 +406,38 @@ describe('sync-on-connect churn gates', () => {
     expect(syncedPeers).toEqual([]);
   });
 
+  it('continues sync-on-connect when a sibling CG proves the peer answered', async () => {
+    const refreshMetaSyncedFlags = recorder(async () => undefined);
+    const discoverContextGraphsFromStore = recorder(async () => 0);
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['unreachable-cg', 'denied-cg'],
+      syncFromPeer: async () => emptyDetailedSync({
+        failedPeers: 1,
+        deniedPhases: 1,
+        backoffWorthyFailures: 1,
+      }),
+      refreshMetaSyncedFlags,
+      discoverContextGraphsFromStore,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+    });
+
+    // `failedPeers` came from one unanswered CG, but the denial proves this
+    // peer answered another round. Discovery and SWM must still get a turn.
+    expect(outcome).toBe('synced');
+    expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
+    expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([
+      [PEER_A, ['unreachable-cg', 'denied-cg']],
+    ]);
+  });
+
   it('continues newly discovered CG fanout past per-CG durable pressure with progress', async () => {
     let contextGraphs = ['cg-a'];
     const refreshMetaSyncedFlags = recorder(async () => undefined);

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -7,8 +7,14 @@ import {
 } from '../src/sync/requester/durable-sync.js';
 import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
 import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
+import {
+  MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES,
+  runOrderedContextGraphSyncs,
+} from '../src/sync/requester/ordered-sync.js';
+import { SyncBackpressureBusyError } from '../src/sync/backpressure.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { markSyncTransportFailure } from '../src/sync/error-tags.js';
+import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 
 const ctx = { kind: 'system', id: 'test', startedAt: 0 } as OperationContext;
 const noop = () => {};
@@ -234,5 +240,318 @@ describe('sync requester bailout', () => {
     expect(fetchSyncPages.calls).toEqual([
       [ctx, 'peer-a', 'pressured-swm', true, 'meta', expect.any(String), expect.any(Number)],
     ]);
+  });
+});
+
+describe('ordered fanout failure isolation', () => {
+  type RoundRecord = { contextGraphId: string; transport: boolean };
+  type Summary = { rounds: RoundRecord[]; deferred: number };
+  const emptySummary = (): Summary => ({ rounds: [], deferred: 0 });
+  const mergeSummaries = (a: Summary, b: Summary): Summary => ({
+    rounds: [...a.rounds, ...b.rounds],
+    deferred: a.deferred + b.deferred,
+  });
+
+  function runBatch(
+    contextGraphIds: string[],
+    transportFailing: (contextGraphId: string) => boolean,
+    options: {
+      admissionError?: (contextGraphId: string) => Error | undefined;
+      priorities?: Record<string, number>;
+    } = {},
+  ) {
+    return runOrderedContextGraphSyncs<Summary>({
+      work: contextGraphIds.map((contextGraphId) => ({
+        contextGraphId,
+        lane: 'durable' as const,
+        operationId: contextGraphId,
+        run: async () => ({
+          rounds: [{ contextGraphId, transport: transportFailing(contextGraphId) }],
+          deferred: 0,
+        }),
+      })),
+      priorities: options.priorities,
+      emptyResult: emptySummary,
+      runWithAdmission: async (item, work) => {
+        const error = options.admissionError?.(item.contextGraphId);
+        if (error) throw error;
+        return work();
+      },
+      merge: mergeSummaries,
+      markDeferred: (summary) => ({ ...summary, deferred: summary.deferred + 1 }),
+      isPeerTransportFailure: (part) => part.rounds.some((round) => round.transport),
+    });
+  }
+
+  it('continues past a failed Context Graph and keeps its failure in the merged summary', async () => {
+    const summary = await runBatch(
+      ['a', 'poison', 'c', 'd'],
+      (contextGraphId) => contextGraphId === 'poison',
+      { priorities: { poison: 100 } },
+    );
+
+    expect(summary.rounds.map((round) => round.contextGraphId)).toEqual(['poison', 'a', 'c', 'd']);
+    expect(summary.rounds.filter((round) => round.transport)).toEqual([
+      { contextGraphId: 'poison', transport: true },
+    ]);
+  });
+
+  it('stops the batch after consecutive peer transport failures', async () => {
+    const summary = await runBatch(
+      ['a', 'b', 'c', 'd', 'e'],
+      () => true,
+    );
+
+    expect(summary.rounds).toHaveLength(MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES);
+    expect(summary.rounds.map((round) => round.contextGraphId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('resets the transport-failure streak whenever the peer answers a round', async () => {
+    const summary = await runBatch(
+      ['a', 'b', 'ok-1', 'c', 'd', 'ok-2'],
+      (contextGraphId) => !contextGraphId.startsWith('ok'),
+    );
+
+    expect(summary.rounds).toHaveLength(6);
+  });
+
+  it('still stops the whole batch on a backpressure deferral', async () => {
+    const summary = await runBatch(
+      ['a', 'b', 'c'],
+      () => false,
+      {
+        admissionError: (contextGraphId) => (
+          contextGraphId === 'b' ? new SyncBackpressureBusyError('queue full') : undefined
+        ),
+      },
+    );
+
+    expect(summary.rounds.map((round) => round.contextGraphId)).toEqual(['a']);
+    expect(summary.deferred).toBe(1);
+  });
+});
+
+describe('lifecycle durable fanout isolation', () => {
+  function fanoutAgent(
+    admissions: string[],
+    failFor: (contextGraphId: string) => Error | undefined,
+    priorities: Record<string, number> = {},
+  ) {
+    return {
+      config: { syncContextGraphPriorities: priorities },
+      fetchSyncPages: async (
+        _ctx: unknown,
+        _peer: string,
+        contextGraphId: string,
+        _swm: boolean,
+        phase: 'data' | 'meta',
+      ) => {
+        const error = failFor(contextGraphId);
+        if (error) throw error;
+        return {
+          ...pageResult(contextGraphId, phase),
+          quads: phase === 'data'
+            ? [{
+                subject: `urn:${contextGraphId}`,
+                predicate: 'urn:predicate',
+                object: 'urn:object',
+                graph: 'urn:graph',
+              }]
+            : [],
+        };
+      },
+      processDurableBatchInWorker: async (dataQuads: Quad[], metaQuads: Quad[]) => ({
+        verifiedData: dataQuads,
+        verifiedMeta: metaQuads,
+        consumedUnpersistedMetaTriples: 0,
+        totalFetchedDataQuads: dataQuads.length,
+        totalFetchedMetaQuads: metaQuads.length,
+        rejectedKcs: 0,
+        emptyResponses: 0,
+        metaOnlyResponses: 0,
+        verifiedPrivateOnlyResponses: 0,
+        dataRejectedMissingMeta: 0,
+      }),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      syncCheckpoints: new Map(),
+      runContextGraphSyncWithBackpressure: async (
+        _ctx: unknown,
+        contextGraphId: string,
+        _lane: string,
+        _label: string,
+        work: () => Promise<unknown>,
+      ) => {
+        admissions.push(contextGraphId);
+        return work();
+      },
+      log: { info: noop, warn: noop, debug: noop },
+    };
+  }
+
+  it('keeps syncing later Context Graphs after a poison CG dies mid-stream', async () => {
+    const admissions: string[] = [];
+    const agent = fanoutAgent(
+      admissions,
+      // Untagged relay-stream death: without the transport tag there is no
+      // proof the peer never answered, so this must NOT read as peer-dead.
+      (contextGraphId) => (contextGraphId === 'poison' ? new Error('pooled stream reset') : undefined),
+      { poison: 100 },
+    );
+
+    const summary = await (LifecycleSyncMethods.prototype.runLegacyDurableSync as any).call(
+      agent,
+      ctx,
+      'peer-a',
+      ['second', 'poison', 'third'],
+      undefined,
+      undefined,
+      undefined,
+      { stopOnBackoffWorthyFailure: true },
+    );
+
+    expect(admissions).toEqual(['poison', 'second', 'third']);
+    expect(summary.insertedTriples).toBe(2);
+    expect(summary.insertedDataTriples).toBe(2);
+    expect(summary.backoffWorthyFailures).toBe(1);
+    expect(summary.failedPhases).toBe(1);
+    expect(summary.failedPeers).toBe(0);
+    expect(summary.complete).toBe(false);
+  });
+
+  it('stops dialing a peer that never responds after consecutive transport failures', async () => {
+    const admissions: string[] = [];
+    const agent = fanoutAgent(admissions, () => transportError('all multiaddr dials failed'));
+
+    const summary = await (LifecycleSyncMethods.prototype.runLegacyDurableSync as any).call(
+      agent,
+      ctx,
+      'peer-a',
+      ['cg-1', 'cg-2', 'cg-3', 'cg-4', 'cg-5'],
+      undefined,
+      undefined,
+      undefined,
+      { stopOnBackoffWorthyFailure: true },
+    );
+
+    expect(admissions).toEqual(['cg-1', 'cg-2', 'cg-3']);
+    expect(summary.failedPeers).toBe(1);
+    expect(summary.backoffWorthyFailures).toBe(MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES);
+    expect(summary.insertedTriples).toBe(0);
+    expect(summary.complete).toBe(false);
+  });
+
+  it('leaves the batch unguarded when the caller did not opt into early stopping', async () => {
+    const admissions: string[] = [];
+    const agent = fanoutAgent(admissions, () => transportError('all multiaddr dials failed'));
+
+    await (LifecycleSyncMethods.prototype.runLegacyDurableSync as any).call(
+      agent,
+      ctx,
+      'peer-a',
+      ['cg-1', 'cg-2', 'cg-3', 'cg-4', 'cg-5'],
+    );
+
+    expect(admissions).toEqual(['cg-1', 'cg-2', 'cg-3', 'cg-4', 'cg-5']);
+  });
+});
+
+describe('lifecycle shared-memory fanout isolation', () => {
+  function swmAgent(
+    admissions: string[],
+    failFor: (contextGraphId: string) => Error | undefined,
+  ) {
+    return {
+      config: { syncContextGraphPriorities: {} },
+      store: {},
+      listSubGraphs: async () => [],
+      createContextGraphSyncDeadline: () => Date.now() + 1_000,
+      fetchSyncPages: async (
+        _ctx: unknown,
+        _peer: string,
+        contextGraphId: string,
+        _swm: boolean,
+        phase: string,
+      ) => {
+        const error = failFor(contextGraphId);
+        if (error) throw error;
+        return {
+          ...pageResult(contextGraphId, phase),
+          nextOffset: 1,
+        };
+      },
+      getOrCreateSyncVerifyWorker: () => ({
+        processSharedMemoryBatch: async () => ({
+          verifiedData: [],
+          verifiedMeta: [],
+          totalFetchedDataQuads: 0,
+          totalFetchedMetaQuads: 0,
+          droppedDataTriples: 0,
+          emptyResponses: 1,
+          entityCreators: [],
+        }),
+      }),
+      runContextGraphSyncWithBackpressure: async (
+        _ctx: unknown,
+        contextGraphId: string,
+        _lane: string,
+        _label: string,
+        work: () => Promise<unknown>,
+      ) => {
+        admissions.push(contextGraphId);
+        return work();
+      },
+      syncCheckpoints: new Map(),
+      workspaceOwnedEntities: new Map(),
+      log: { info: noop, warn: noop, debug: noop },
+    };
+  }
+
+  function swmPlan(contextGraphIds: string[]) {
+    return {
+      publicContextGraphIds: contextGraphIds,
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: contextGraphIds,
+    };
+  }
+
+  it('keeps syncing later Context Graphs after a poison SWM round the peer answered', async () => {
+    const admissions: string[] = [];
+    const contextGraphIds = ['poison', 'second', 'third'];
+    const agent = swmAgent(
+      admissions,
+      (contextGraphId) => (contextGraphId === 'poison' ? new Error('pooled stream reset') : undefined),
+    );
+
+    const summary = await (
+      LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailed as any
+    ).call(agent, 'peer-a', contextGraphIds, {
+      stopOnBackoffWorthyFailure: true,
+      sharedMemorySyncPlan: swmPlan(contextGraphIds),
+    });
+
+    expect(admissions).toEqual(contextGraphIds);
+    expect(summary.backoffWorthyFailures).toBe(1);
+    expect(summary.failedPhases).toBe(1);
+    expect(summary.failedPeers).toBe(0);
+    // Both clean CGs completed both their phases (meta + data).
+    expect(summary.completedPhases).toBe(4);
+    expect(summary.checkpointAdvances).toBe(4);
+  });
+
+  it('stops the SWM fanout after consecutive unanswered transport failures', async () => {
+    const admissions: string[] = [];
+    const contextGraphIds = ['cg-1', 'cg-2', 'cg-3', 'cg-4'];
+    const agent = swmAgent(admissions, () => transportError('connection reset'));
+
+    const summary = await (
+      LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailed as any
+    ).call(agent, 'peer-a', contextGraphIds, {
+      stopOnBackoffWorthyFailure: true,
+      sharedMemorySyncPlan: swmPlan(contextGraphIds),
+    });
+
+    expect(admissions).toEqual(['cg-1', 'cg-2', 'cg-3']);
+    expect(summary.failedPeers).toBe(1);
+    expect(summary.backoffWorthyFailures).toBe(MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES);
   });
 });


### PR DESCRIPTION
## Problem

`runOrderedContextGraphSyncs` breaks out of the whole per-peer batch when one CG's round reports a backoff-worthy failure, and `runSyncOnConnect` stops all remaining lanes (discovery, SWM) the same way. Field evidence (10.0.12 Base-mainnet edge, 2026-08-06): a poison system-CG transfer (~16k triples, dying mid-stream against a relay-only peer) aborted the fanout every 5-minute cycle, permanently starving a 604-triple user CG queued behind it — while the peer was demonstrably reachable (it had just served meta pages).

## Fix

Failure isolation with a bounded peer-dead guard:

- **Per-CG failures continue.** A backoff-worthy round is recorded in the merged summary (terminal boundary stays false, the peer is not stamped fresh) and the fanout moves to the next CG.
- **Peer-dead stops.** `shouldStop` is replaced by `isPeerTransportFailure`, fed by the one signal that distinguishes "peer never responded" from "this CG's round went wrong" (`failedPeers`, which the runners record only for transport-class errors with zero responses). Three **consecutive** unanswered rounds (`MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES = 3`) stop the batch, so a dead peer doesn't burn one transport timeout per remaining CG; any answered round — clean, denied, or failed-after-response — resets the streak.
- **Global backpressure deferral still stops** (later items would be rejected identically).
- `runSyncOnConnect` mirrors the policy: per-CG pressure logs and continues to discovery/SWM lanes; only unreachable-with-no-progress stops the fanout.

## Notes

- Supersedes the fanout part of draft #1946 (implemented fresh against current main).
- Consistent with OT-RFC-64 Rev 4.7's independence principle ("one unavailable ordinal MUST NOT block later independent ordinals") and its retryable-transport vs poison classification discipline; ships as legacy-path repair ahead of Track 2.

## Tests

New `sync-requester-bailout.test.ts` (durable + SWM fanouts): poison CG mid-stream → later CGs still sync and the failure stays in the summary; 3 consecutive unanswered rounds → early stop; answered rounds reset the streak; backpressure deferral still stops; no-opt-in callers unguarded. Updated `sync-on-connect-churn.test.ts` for the continue-lanes semantics. Full agent package build (tsc + type tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)