### PR TITLE
fix(core): bypass pooled sync wire for peers reachable only via circuit relay

### DIFF
--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -574,6 +574,28 @@ export class MessageStreamPool {
   }
 
   /**
+   * Close the stream held for `peerIdStr` once it is quiescent.
+   * Returns `true` when a live stream existed and was closed;
+   * `false` when the peer holds no stream OR the stream still has
+   * in-flight / queued work.
+   *
+   * The busy case is deliberately left alone rather than force-
+   * aborted: rejecting live requests here would reproduce the exact
+   * all-in-flight-requests-die failure the caller is trying to route
+   * around. Callers that want the stream gone stop feeding it new
+   * sends and invoke this again on their next pass — an active
+   * stream drains naturally (or hits the pool's own idle/reset
+   * teardown) and the retire lands then.
+   */
+  async closePeerIfIdle(peerIdStr: string, reason = 'peer stream retired'): Promise<boolean> {
+    const state = this.peers.get(peerIdStr);
+    if (!state || state.closed) return false;
+    if (state.inFlight !== null || state.queue.length > 0) return false;
+    await this.closePeer(state, reason);
+    return true;
+  }
+
+  /**
    * Close every pooled stream and reject all pending requests.
    * Safe to call multiple times. After close, further `send()` calls
    * throw {@link PooledStreamResetError}.

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -638,7 +638,37 @@ export class ProtocolRouter {
     // is exhausted.
     const overlay = this.pooledByLogical.get(protocolId);
     const memoizedVariant = this.peerWireVariantFor(peerIdStr, protocolId);
-    if (overlay && memoizedVariant !== 'one-shot') {
+    // Relay-only gate for the pooled wire. The pooled variant
+    // multiplexes every request for a peer onto ONE long-lived
+    // substream; over a circuit-relay connection that substream's
+    // life is bounded by the relay's reservation churn (~300 s), and
+    // one request timeout aborts the shared stream — rejecting every
+    // in-flight and queued request at once. Observed on a 10.0.12
+    // Base-mainnet edge node (2026-08-06): sync to a NAT-only peer
+    // reachable exclusively via circuit relays died 4/4 with "pooled
+    // stream reset: request aborted/timeout" while one-shot streams
+    // to the same peer succeeded immediately. So: use the pool only
+    // when the peer has at least one DIRECT connection. Re-evaluated
+    // per send — a later direct connection (e.g. DCUtR upgrade)
+    // re-enables the pool with no memo to clear, and a pool stream
+    // already held for a now-relay-only peer is retired once
+    // quiescent instead of being reused. Cold peers (no connections
+    // at all) keep the pooled path: there is no relayed connection
+    // to observe yet and the pool's own dial may come up direct.
+    // Requester-side selection only — responders that don't
+    // advertise the pooled wire already fall back via
+    // multistream-select.
+    let usePooledWire = overlay !== undefined && memoizedVariant !== 'one-shot';
+    if (usePooledWire && overlay && this.peerHasOnlyRelayedConnections(peerIdStr)) {
+      usePooledWire = false;
+      // Fire-and-forget: retiring the held stream must not delay or
+      // fail this send; if the stream is still busy the retire is a
+      // no-op and a later send's pass lands it once drained.
+      overlay.pool
+        .closePeerIfIdle(peerIdStr, 'relay-only peer: pooled wire bypassed')
+        .catch(() => undefined);
+    }
+    if (overlay && usePooledWire) {
       try {
         const remainingForPool = Math.max(0, timeoutMs - (Date.now() - overallStartedAt));
         const response = await overlay.pool.send(peerIdStr, data, {
@@ -1024,6 +1054,80 @@ export class ProtocolRouter {
     }
     throw lastErr;
   }
+
+  /**
+   * True when the peer currently has at least one OPEN connection and
+   * every one of them rides a circuit relay. Three shapes:
+   *
+   *   * a direct connection is present → false (pooling is safe);
+   *   * open connections exist, all relayed → true;
+   *   * no open connections at all → false — nothing observed yet, so
+   *     the caller keeps its existing behavior rather than penalizing
+   *     a cold peer for connections it doesn't have.
+   *
+   * Walks the RAW connection table and filters by `remotePeer`
+   * ourselves — same Window D rationale as the one-shot fast path
+   * (libp2p's peerId-keyed lookup can return `[]` while the raw walk
+   * shows live matching connections). Matching is by peerId string:
+   * the router, the pool, and libp2p's `PeerId.toString()` all use
+   * the same canonical text form as the peer key.
+   */
+  private peerHasOnlyRelayedConnections(peerIdStr: string): boolean {
+    let all: ReadonlyArray<ObservedConnection>;
+    try {
+      all = this.node.libp2p.getConnections() as ReadonlyArray<ObservedConnection>;
+    } catch {
+      return false;
+    }
+    let sawOpenRelayed = false;
+    for (const conn of all) {
+      let matches = false;
+      try {
+        matches = conn.remotePeer?.toString() === peerIdStr;
+      } catch {
+        matches = false;
+      }
+      if (!matches) continue;
+      if (conn.status && conn.status !== 'open') continue;
+      if (!isRelayedConnection(conn)) return false;
+      sawOpenRelayed = true;
+    }
+    return sawOpenRelayed;
+  }
+}
+
+/**
+ * Structural subset of a libp2p `Connection` used for transport-path
+ * classification. Kept minimal (and every access defensive) for the
+ * same reason as {@link ReusableConnection}: unit tests pass fakes
+ * without re-exporting libp2p internals.
+ */
+interface ObservedConnection {
+  status?: string;
+  limits?: unknown;
+  remotePeer?: { toString: () => string };
+  remoteAddr?: { toString: () => string };
+}
+
+/**
+ * True when the connection reaches the peer via a circuit relay.
+ * `remoteAddr` containing the `/p2p-circuit` component is the
+ * authoritative signal — a direct connection's remote address never
+ * carries it. Fall back to libp2p's limited-connection marker when
+ * the address is unavailable (limited ⇒ circuit-relay-v2 in our
+ * transport set); absent both signals, classify as direct so the
+ * caller defaults to the status quo.
+ */
+function isRelayedConnection(conn: ObservedConnection): boolean {
+  try {
+    const addr = conn.remoteAddr?.toString();
+    if (typeof addr === 'string' && addr.length > 0) {
+      return addr.includes('/p2p-circuit');
+    }
+  } catch {
+    // fall through to the limits marker
+  }
+  return Boolean(conn.limits);
 }
 
 /**

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -593,6 +593,53 @@ describe('MessageStreamPool', () => {
     expect(POOLED_MESSAGE_PROTOCOL).toBe('/dkg/10.0.2/message');
   });
 
+  // closePeerIfIdle exists so a caller that has stopped routing sends
+  // through the pool for a peer (e.g. the peer is currently reachable
+  // only via circuit relays) can retire the held stream WITHOUT
+  // rejecting live work — force-closing a busy stream would reproduce
+  // the exact all-in-flight-requests-die teardown the caller is
+  // routing around.
+  it('closePeerIfIdle retires a quiescent stream but leaves an in-flight one alone', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    // No stream held yet — nothing to retire.
+    await expect(pool.closePeerIfIdle(PEER_A)).resolves.toBe(false);
+
+    const pending = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    await flush();
+
+    // Request in flight — retire must refuse and leave it untouched.
+    await expect(pool.closePeerIfIdle(PEER_A)).resolves.toBe(false);
+    const stream = node.state.streams.get(PEER_A)!;
+    stream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    expect(new TextDecoder().decode(await pending)).toBe('ok');
+    await flush();
+
+    // Quiescent — retire closes the held stream and drops the peer.
+    await expect(pool.closePeerIfIdle(PEER_A)).resolves.toBe(true);
+    expect(pool.size()).toBe(0);
+    expect(stream.writeStatus).toBe('closed');
+
+    // Next send re-dials from scratch rather than reusing the retired
+    // stream.
+    const second = pool.send(PEER_A, new TextEncoder().encode('again'));
+    await flush();
+    await flush();
+    expect(node.state.dials.get(PEER_A)).toBe(2);
+    node.state.streams
+      .get(PEER_A)!
+      .feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok2')));
+    expect(new TextDecoder().decode(await second)).toBe('ok2');
+
+    await pool.close();
+  });
+
   it('aborting an in-flight request tears down the stream so the pool does not stall (Codex #560 round 1)', async () => {
     const node = makeFakeNode();
     const pool = new MessageStreamPool(node, {

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -862,6 +862,227 @@ describe('ProtocolRouter', () => {
     });
   });
 
+  // The pooled wire multiplexes every request for a peer onto one
+  // long-lived substream. Over a circuit-relay connection the relay's
+  // reservation churn bounds that substream's life and one request
+  // timeout kills every in-flight request with it — observed as
+  // deterministic "pooled stream reset" against a NAT-only peer whose
+  // one-shot streams succeeded immediately (10.0.12 Base-mainnet edge
+  // node, 2026-08-06). The router therefore bypasses the pool for any
+  // send whose peer currently has ONLY relayed connections, re-checking
+  // per send so a later direct connection re-enables pooling.
+  describe('send() pooled-wire relay-only bypass', () => {
+    const FAKE_PEER_ID = '12D3KooWBzj7Hg2cKCdsKL6QcjC5UbLztKTvzCZQHaT4P4ZyJEAA';
+    const PROTOCOL_ID = '/dkg/test/1.0.0';
+
+    function makeStubStream(response: Uint8Array) {
+      let returned = false;
+      return {
+        writeStatus: 'open' as const,
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => undefined,
+        async *[Symbol.asyncIterator]() {
+          if (!returned) {
+            returned = true;
+            yield response;
+          }
+        },
+      };
+    }
+
+    function makeConn(opts: {
+      remoteAddr: string;
+      limits?: unknown;
+      remotePeerStr?: string;
+      newStream?: () => Promise<unknown>;
+    }) {
+      const remotePeerStr = opts.remotePeerStr ?? FAKE_PEER_ID;
+      return {
+        status: 'open' as const,
+        limits: opts.limits,
+        remotePeer: {
+          equals: (other: unknown) => String(other) === remotePeerStr,
+          toString: () => remotePeerStr,
+        },
+        remoteAddr: { toString: () => opts.remoteAddr },
+        newStream:
+          opts.newStream ??
+          (async () => {
+            throw new Error('newStream not expected on this connection');
+          }),
+      };
+    }
+
+    function makeRouterWithPool(opts: {
+      connections: () => ReadonlyArray<unknown>;
+      poolSend: () => Promise<Uint8Array>;
+      onClosePeerIfIdle?: (peerIdStr: string) => void;
+      dialBehavior?: () => Promise<unknown>;
+    }): ProtocolRouter {
+      const node = {
+        libp2p: {
+          getConnections: () => opts.connections(),
+          dialProtocol:
+            opts.dialBehavior ??
+            (async () => {
+              throw new Error('dialProtocol not expected');
+            }),
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+      (router as any).pooledByLogical.set(PROTOCOL_ID, {
+        logicalProtocolId: PROTOCOL_ID,
+        wireProtocolId: '/dkg/10.0.2/message',
+        pool: {
+          send: opts.poolSend,
+          closePeerIfIdle: async (peerIdStr: string) => {
+            opts.onClosePeerIfIdle?.(peerIdStr);
+            return false;
+          },
+        },
+      });
+      return router;
+    }
+
+    it('bypasses the pool for a relayed-only peer — one-shot path runs, pool is never dialed', async () => {
+      let poolSends = 0;
+      let newStreamCalls = 0;
+      const retired: string[] = [];
+      const relayedConn = makeConn({
+        remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${FAKE_PEER_ID}`,
+        limits: { bytes: 1024 * 1024 },
+        newStream: async () => {
+          newStreamCalls += 1;
+          return makeStubStream(new Uint8Array([0x42])) as any;
+        },
+      });
+      const router = makeRouterWithPool({
+        connections: () => [relayedConn],
+        poolSend: async () => {
+          poolSends += 1;
+          throw new Error('pool must not be used for a relay-only peer');
+        },
+        onClosePeerIfIdle: (p) => { retired.push(p); },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+
+      expect(out).toEqual(new Uint8Array([0x42]));
+      expect(poolSends).toBe(0);
+      // One-shot path served the send over the relayed connection
+      // (fast-path reuse — same wire shape that succeeded in the field
+      // while pooled sends reset).
+      expect(newStreamCalls).toBe(1);
+      // A pool stream already held for the peer must be retired (once
+      // quiescent) rather than reused on the relayed connection.
+      expect(retired).toEqual([FAKE_PEER_ID]);
+    });
+
+    it('keeps the pooled path when a direct connection is present alongside a relayed one', async () => {
+      let poolSends = 0;
+      let newStreamCalls = 0;
+      const countNewStream = async (): Promise<unknown> => {
+        newStreamCalls += 1;
+        throw new Error('one-shot path must not run when pooled path is selected');
+      };
+      const router = makeRouterWithPool({
+        connections: () => [
+          makeConn({
+            remoteAddr: '/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit',
+            limits: { bytes: 1024 * 1024 },
+            newStream: countNewStream,
+          }),
+          makeConn({ remoteAddr: '/ip4/1.2.3.4/tcp/4001', newStream: countNewStream }),
+        ],
+        poolSend: async () => {
+          poolSends += 1;
+          return new Uint8Array([0x07]);
+        },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+
+      expect(out).toEqual(new Uint8Array([0x07]));
+      expect(poolSends).toBe(1);
+      expect(newStreamCalls).toBe(0);
+    });
+
+    it('re-enables pooling when a direct connection appears after a relayed-only send', async () => {
+      let poolSends = 0;
+      const connections: unknown[] = [
+        makeConn({
+          remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${FAKE_PEER_ID}`,
+          limits: { bytes: 1024 * 1024 },
+          newStream: async () => makeStubStream(new Uint8Array([0x11])) as any,
+        }),
+      ];
+      const router = makeRouterWithPool({
+        connections: () => connections,
+        poolSend: async () => {
+          poolSends += 1;
+          return new Uint8Array([0x22]);
+        },
+      });
+
+      // Relayed-only: one-shot serves the send; crucially the bypass
+      // must NOT pin the peer's wire memo to one-shot — the peer DOES
+      // speak the pooled wire, only the current transport path is bad.
+      const first = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+      expect(first).toEqual(new Uint8Array([0x11]));
+      expect(poolSends).toBe(0);
+
+      // DCUtR (or a fresh dial) lands a direct connection.
+      connections.push(makeConn({ remoteAddr: '/ip4/1.2.3.4/tcp/4001' }));
+
+      const second = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([2]), 5000);
+      expect(second).toEqual(new Uint8Array([0x22]));
+      expect(poolSends).toBe(1);
+    });
+
+    it('keeps the pooled path for a cold peer with no connections at all', async () => {
+      let poolSends = 0;
+      const router = makeRouterWithPool({
+        connections: () => [],
+        poolSend: async () => {
+          poolSends += 1;
+          return new Uint8Array([0x33]);
+        },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+
+      expect(out).toEqual(new Uint8Array([0x33]));
+      expect(poolSends).toBe(1);
+    });
+
+    it('ignores relayed connections that belong to a different peer', async () => {
+      let poolSends = 0;
+      const router = makeRouterWithPool({
+        connections: () => [
+          makeConn({
+            remoteAddr: '/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit',
+            limits: { bytes: 1024 * 1024 },
+            remotePeerStr: '12D3KooWSomeOtherPeer00000000000000000000000000000000zzzz',
+          }),
+        ],
+        poolSend: async () => {
+          poolSends += 1;
+          return new Uint8Array([0x44]);
+        },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+
+      expect(out).toEqual(new Uint8Array([0x44]));
+      expect(poolSends).toBe(1);
+    });
+  });
+
   describe('composeAbortSignals', () => {
     it('manual fallback removes both listeners after either source aborts', () => {
       const originalAny = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;


### PR DESCRIPTION
## Problem

The pooled sync wire multiplexes every request for a peer onto one long-lived substream. Over a circuit-relay connection that substream's life is bounded by relay reservation churn (~300 s), and one request timeout aborts the shared stream — rejecting every in-flight and queued request at once. Field evidence (10.0.12 Base-mainnet edge, 2026-08-06): SWM recovery from a NAT-only peer reachable exclusively via relays failed deterministically 4/4 with "pooled stream reset: request aborted/timeout"; after restarting with `DKG_POOLED_SYNC=0`, the very first one-shot attempt succeeded in ~90 s (1093 triples).

## Fix

Requester-side wire selection at the pooled short-circuit in `ProtocolRouter.send`: use the pool only when the peer has at least one **direct** (non-relayed, open) connection.

- Relay detection: `remoteAddr` containing `/p2p-circuit` (authoritative), falling back to libp2p's limited-connection marker; absent both, classify direct (status quo).
- Re-evaluated per send — a later direct connection (e.g. DCUtR upgrade) re-enables pooling with no memo to clear.
- A pool stream already held for a now-relay-only peer is retired via new `MessageStreamPool.closePeerIfIdle` — only when quiescent, so live requests are never force-aborted (that would reproduce the exact failure this routes around).
- Cold peers (no observed connections) keep the pooled path; responders that don't advertise the pooled wire already fall back via multistream-select. The global `DKG_POOLED_SYNC=0` escape hatch is untouched.

## Notes

OT-RFC-64 Rev 4.7's bounded request/response transfer model structurally obsoletes pooled streams; until then this closes the relay failure mode on the legacy wire without giving up pooling on direct connections.

## Tests

`protocol-router.test.ts`: relayed-only peer → one-shot path, pool never dialed; direct alongside relayed → pooled; relayed→direct transition re-enables pooling; cold peer keeps pooled; other peers' relayed connections ignored. `message-stream-pool.test.ts`: `closePeerIfIdle` closes idle streams, refuses busy ones. Full `@origintrail-official/dkg-core` build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)