### PR TITLE
fix(sync): give durable meta and data phases independent deadline budgets

### DIFF
--- a/packages/agent/src/sync/requester/durable-sync-budget.ts
+++ b/packages/agent/src/sync/requester/durable-sync-budget.ts
@@ -12,11 +12,14 @@ export const EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS = 600_000;
 // meta stream of a large system CG (agents/ontology run to tens of thousands
 // of rows) over a relayed, page-shrinking transport could consume the whole
 // window. The data phase then reported a timeout with zero triples received
-// having never sent a request — every cycle, forever. Capping meta below half
-// the window guarantees data the majority share each cycle while meta keeps
-// enough room to finish (or at least advance its resume checkpoint). Deadlines
-// are absolute, so a meta phase that finishes early hands its unused time to
-// data for free and the two phases combined can never exceed the CG budget.
+// having never sent a request — every cycle, forever. The requester applies
+// this cap to system CGs only: their unverified payloads can persist and resume
+// after a capped partial meta page. Verified CGs keep the full window for meta,
+// because their meta and data cursors advance only after clean joint
+// verification; capping meta there could pin both cursors on the same partial
+// descriptor window. Deadlines are absolute, so a system-CG meta phase that
+// finishes early hands its unused time to data for free and the two phases
+// combined can never exceed the CG budget.
 export const DURABLE_META_PHASE_BUDGET_FRACTION = 0.4;
 // Wall clock the data phase keeps even when an operation deadline clamps the
 // CG window so tight that the fraction above would leave it less. Must stay
@@ -33,10 +36,11 @@ export interface DurableSyncContextGraphBudget {
   readonly fetchDeadline: number;
   /**
    * Earlier deadline for the meta phase alone, keeping a bounded fraction of
-   * the CG window so a slow meta transfer cannot starve the data phase.
-   * Optional for rolling deep-import compatibility: budgets minted before the
-   * phases split share `fetchDeadline`, preserving their single-deadline
-   * behaviour.
+   * the CG window so a slow system-CG meta transfer cannot starve the data
+   * phase. The requester deliberately ignores this earlier deadline for
+   * verified CGs. Optional for rolling deep-import compatibility: budgets
+   * minted before the phases split share `fetchDeadline`, preserving their
+   * single-deadline behaviour.
    */
   readonly metaFetchDeadline?: number;
   /** Fresh deadline for authenticating graph-scoped assets from one verified page. */

--- a/packages/agent/src/sync/requester/durable-sync-budget.ts
+++ b/packages/agent/src/sync/requester/durable-sync-budget.ts
@@ -8,10 +8,37 @@ export const MAX_DURABLE_SYNC_TOTAL_TIMEOUT_MS = 300_000;
 // observed canary path project roughly 425 seconds for its byte-paged transfer,
 // so exact VM repair gets a separate hard 10-minute transfer ceiling.
 export const EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS = 600_000;
+// Meta and data historically drew down ONE shared per-CG deadline, and the
+// meta stream of a large system CG (agents/ontology run to tens of thousands
+// of rows) over a relayed, page-shrinking transport could consume the whole
+// window. The data phase then reported a timeout with zero triples received
+// having never sent a request — every cycle, forever. Capping meta below half
+// the window guarantees data the majority share each cycle while meta keeps
+// enough room to finish (or at least advance its resume checkpoint). Deadlines
+// are absolute, so a meta phase that finishes early hands its unused time to
+// data for free and the two phases combined can never exceed the CG budget.
+export const DURABLE_META_PHASE_BUDGET_FRACTION = 0.4;
+// Wall clock the data phase keeps even when an operation deadline clamps the
+// CG window so tight that the fraction above would leave it less. Must stay
+// below SYNC_MIN_GRAPH_BUDGET_MS * (1 - DURABLE_META_PHASE_BUDGET_FRACTION)
+// so a minimum-budget CG still gives meta a usable slice.
+export const DURABLE_DATA_PHASE_MIN_BUDGET_MS = SYNC_MIN_GRAPH_BUDGET_MS / 2;
 
 export interface DurableSyncContextGraphBudget {
-  /** Deadline for fetching this Context Graph's durable snapshot. */
+  /**
+   * Deadline for fetching this Context Graph's durable snapshot. This bounds
+   * the whole per-CG fetch, so the data phase (which runs last) uses it
+   * directly and unused meta time rolls over to data.
+   */
   readonly fetchDeadline: number;
+  /**
+   * Earlier deadline for the meta phase alone, keeping a bounded fraction of
+   * the CG window so a slow meta transfer cannot starve the data phase.
+   * Optional for rolling deep-import compatibility: budgets minted before the
+   * phases split share `fetchDeadline`, preserving their single-deadline
+   * behaviour.
+   */
+  readonly metaFetchDeadline?: number;
   /** Fresh deadline for authenticating graph-scoped assets from one verified page. */
   readonly createGraphScopedAuthenticationDeadline: () => number;
 }
@@ -69,6 +96,28 @@ export function createGraphScopedAuthenticationDeadline(options: {
 }
 
 /**
+ * Bound the meta phase inside one Context Graph's fetch window. Meta gets at
+ * most its budget fraction, and never so much that less than the data floor
+ * remains before `fetchDeadline`. A window already too small to reserve that
+ * floor has nothing meaningful to split, so it keeps the shared deadline:
+ * a tightly clamped operation window degrades exactly as it always did
+ * instead of failing meta instantly.
+ */
+export function createDurableMetaPhaseFetchDeadline(options: {
+  fetchDeadline: number;
+  now?: () => number;
+}): number {
+  const now = (options.now ?? Date.now)();
+  const totalBudgetMs = options.fetchDeadline - now;
+  const metaBudgetMs = Math.min(
+    Math.floor(totalBudgetMs * DURABLE_META_PHASE_BUDGET_FRACTION),
+    totalBudgetMs - DURABLE_DATA_PHASE_MIN_BUDGET_MS,
+  );
+  if (metaBudgetMs <= 0) return options.fetchDeadline;
+  return now + metaBudgetMs;
+}
+
+/**
  * Construct the requester-owned fetch/authentication phase policy. Lifecycle
  * supplies only caller configuration and whether this is exact VM recovery.
  */
@@ -80,8 +129,8 @@ export function createDurableSyncBudget(options: {
   now?: () => number;
 }): DurableSyncBudget {
   return {
-    createContextGraphBudget: ({ remainingContextGraphs }) => ({
-      fetchDeadline: Math.min(
+    createContextGraphBudget: ({ remainingContextGraphs }) => {
+      const fetchDeadline = Math.min(
         createContextGraphSyncDeadline({
           remainingContextGraphs,
           totalTimeoutMs: options.fetchTimeoutMs,
@@ -91,14 +140,21 @@ export function createDurableSyncBudget(options: {
           now: options.now,
         }),
         options.operationDeadline ?? Number.POSITIVE_INFINITY,
-      ),
-      createGraphScopedAuthenticationDeadline: () => Math.min(
-        createGraphScopedAuthenticationDeadline({
-          totalTimeoutMs: options.authenticationTimeoutMs,
+      );
+      return {
+        fetchDeadline,
+        metaFetchDeadline: createDurableMetaPhaseFetchDeadline({
+          fetchDeadline,
           now: options.now,
         }),
-        options.operationDeadline ?? Number.POSITIVE_INFINITY,
-      ),
-    }),
+        createGraphScopedAuthenticationDeadline: () => Math.min(
+          createGraphScopedAuthenticationDeadline({
+            totalTimeoutMs: options.authenticationTimeoutMs,
+            now: options.now,
+          }),
+          options.operationDeadline ?? Number.POSITIVE_INFINITY,
+        ),
+      };
+    },
   };
 }

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -41,8 +41,11 @@ import {
 
 export {
   createContextGraphSyncDeadline,
+  createDurableMetaPhaseFetchDeadline,
   createDurableSyncBudget,
   createGraphScopedAuthenticationDeadline,
+  DURABLE_DATA_PHASE_MIN_BUDGET_MS,
+  DURABLE_META_PHASE_BUDGET_FRACTION,
   EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS,
   MAX_DURABLE_SYNC_TOTAL_TIMEOUT_MS,
   normalizeDurableSyncTimeoutMs,
@@ -337,7 +340,14 @@ async function runDurableSyncWithBudget(
         remainingContextGraphs: contextGraphIds.length - contextGraphIndex,
       });
       const deadline = contextGraphBudget.fetchDeadline;
-      const activeFetchContext = fetchContext(deadline);
+      // Meta may never outlive the CG window even if a budget hands out a
+      // later phase deadline, so both phases combined stay inside the per-CG
+      // wall clock. The data phase runs to the full CG deadline, which is how
+      // a meta phase that finishes early rolls its unused time into data.
+      const metaFetchDeadline = Math.min(
+        contextGraphBudget.metaFetchDeadline ?? deadline,
+        deadline,
+      );
       const exactAssetUals = exactAssetUalsFor?.(pid);
       if (exactAssetUals !== undefined) {
         exactFetchDispositionIndex = exactFetchDispositions.push('incomplete') - 1;
@@ -363,7 +373,7 @@ async function runDurableSyncWithBudget(
         graphUri,
         sinceBatchId,
         exactAssetUals,
-        fetchContext: activeFetchContext,
+        fetchContext: fetchContext(phase === 'meta' ? metaFetchDeadline : deadline),
       });
       const metaResult: SyncPageResult = skipAgentsMeta
         ? {

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -335,6 +335,7 @@ async function runDurableSyncWithBudget(
       throwIfOperationAborted();
       const dataGraph = contextGraphDataGraphUri(pid);
       const metaGraph = contextGraphMetaGraphUri(pid);
+      const isSystemContextGraph = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(pid);
       const contextGraphBudget = durableSyncBudget.createContextGraphBudget({
         contextGraphId: pid,
         remainingContextGraphs: contextGraphIds.length - contextGraphIndex,
@@ -344,10 +345,14 @@ async function runDurableSyncWithBudget(
       // later phase deadline, so both phases combined stay inside the per-CG
       // wall clock. The data phase runs to the full CG deadline, which is how
       // a meta phase that finishes early rolls its unused time into data.
-      const metaFetchDeadline = Math.min(
-        contextGraphBudget.metaFetchDeadline ?? deadline,
-        deadline,
-      );
+      // System CGs accept unverified payloads, so a capped partial meta page
+      // can persist and resume. Verified CGs require joint meta/data
+      // verification before either cursor advances; giving their meta phase an
+      // earlier cap could make the same incomplete descriptor page repeat
+      // forever.
+      const metaFetchDeadline = isSystemContextGraph
+        ? Math.min(contextGraphBudget.metaFetchDeadline ?? deadline, deadline)
+        : deadline;
       const exactAssetUals = exactAssetUalsFor?.(pid);
       if (exactAssetUals !== undefined) {
         exactFetchDispositionIndex = exactFetchDispositions.push('incomplete') - 1;
@@ -398,8 +403,6 @@ async function runDurableSyncWithBudget(
       peerRespondedForContextGraph = true;
       endPhase();
       const fetchDurationMs = Date.now() - fetchStartedAt;
-      const isSystemContextGraph = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(pid);
-
       let effectiveMetaResult = metaResult;
       let dataResult = rawDataResult;
       let exactAssetDescriptorCoverageComplete = true;

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -387,12 +387,10 @@ async function runDurableSyncWithBudget(
           }
         : await fetchPhase('meta', metaGraph);
       if (!skipAgentsMeta) peerRespondedForContextGraph = true;
-      if (metaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
-        markDurableTerminalBoundary(accumulator, false);
-        recordPhaseOutcome(metaResult, { updateCheckpoint: false });
-        endPhase();
-        break;
-      }
+      // A meta timeout can be the intentional phase boundary assigned by the
+      // per-phase budget. Keep going so data can use the time reserved for it;
+      // the post-processing timeout gate below still prevents fanout to the
+      // next context graph when stopOnBackoffWorthyFailure is enabled.
       throwIfOperationAborted();
       const sinceBatchId = sinceBatchIdFor?.(pid);
       const rawDataResult = await fetchPhase('data', dataGraph, sinceBatchId);

--- a/packages/agent/test/durable-sync-budget.test.ts
+++ b/packages/agent/test/durable-sync-budget.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { OperationContext } from '@origintrail-official/dkg-core';
+import { SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
 import {
   createContextGraphSyncDeadline,
+  createDurableMetaPhaseFetchDeadline,
   createDurableSyncBudget,
   createGraphScopedAuthenticationDeadline,
+  DURABLE_DATA_PHASE_MIN_BUDGET_MS,
+  DURABLE_META_PHASE_BUDGET_FRACTION,
   type DurableSyncBudget,
 } from '../src/sync/requester/durable-sync-budget.js';
 import {
@@ -78,6 +81,7 @@ function requesterBudgetContext(options: {
   graphScoped?: boolean;
   onFetchPhase?: (phase: 'data' | 'meta') => void;
   onFetchContext?: (fetchContext: DurableSyncFetchContext) => void;
+  mapFetchResult?: (phase: 'data' | 'meta', page: SyncPageResult) => SyncPageResult;
   onVerify?: () => void;
   onVerifiedFullSnapshot?: DurableSyncContext['onVerifiedFullSnapshot'];
   emptyResponses?: number;
@@ -105,9 +109,10 @@ function requesterBudgetContext(options: {
     }) => {
       options.onFetchPhase?.(phase);
       options.onFetchContext?.(fetchContext);
-      return phase === 'data'
+      const page = phase === 'data'
         ? requesterPage(phase, dataQuads)
         : requesterPage(phase, metadataQuads);
+      return options.mapFetchResult?.(phase, page) ?? page;
     },
     processDurableBatchInWorker: async () => {
       options.onVerify?.();
@@ -687,5 +692,194 @@ describe('durable sync deadline budget', () => {
       failedPhases: 1,
     });
     expect(storeInsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('durable sync per-phase deadline split', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('caps meta at its budget fraction while data keeps the full CG deadline', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    const budget = createDurableSyncBudget({ fetchTimeoutMs: 100_000 })
+      .createContextGraphBudget({ contextGraphId, remainingContextGraphs: 1 });
+
+    expect(budget.fetchDeadline).toBe(1_100_000);
+    expect(budget.metaFetchDeadline).toBe(
+      1_000_000 + 100_000 * DURABLE_META_PHASE_BUDGET_FRACTION,
+    );
+  });
+
+  it('reserves the data floor when an operation deadline clamps the CG window', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    const budget = createDurableSyncBudget({
+      fetchTimeoutMs: 100_000,
+      operationDeadline: 1_008_000,
+    }).createContextGraphBudget({ contextGraphId, remainingContextGraphs: 1 });
+
+    expect(budget.fetchDeadline).toBe(1_008_000);
+    expect(budget.metaFetchDeadline).toBe(1_003_000);
+    expect(budget.fetchDeadline - budget.metaFetchDeadline!)
+      .toBe(DURABLE_DATA_PHASE_MIN_BUDGET_MS);
+  });
+
+  it('keeps the shared deadline when the window cannot reserve the data floor', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    expect(createDurableMetaPhaseFetchDeadline({
+      fetchDeadline: 1_000_000 + DURABLE_DATA_PHASE_MIN_BUDGET_MS - 1_000,
+    })).toBe(1_000_000 + DURABLE_DATA_PHASE_MIN_BUDGET_MS - 1_000);
+    expect(createDurableMetaPhaseFetchDeadline({ fetchDeadline: 999_000 }))
+      .toBe(999_000);
+  });
+
+  it('never lets the phase deadlines extend the prior single-deadline total', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    for (const remainingContextGraphs of [1, 2, 7]) {
+      const budget = createDurableSyncBudget({ fetchTimeoutMs: 100_000 })
+        .createContextGraphBudget({ contextGraphId, remainingContextGraphs });
+      const priorSharedDeadline = createContextGraphSyncDeadline({
+        remainingContextGraphs,
+        totalTimeoutMs: 100_000,
+      });
+      expect(budget.fetchDeadline).toBe(priorSharedDeadline);
+      expect(budget.metaFetchDeadline!).toBeLessThanOrEqual(priorSharedDeadline);
+      expect(budget.metaFetchDeadline!).toBeGreaterThan(1_000_000);
+    }
+  });
+
+  it('threads the bounded meta deadline and full CG deadline through per-phase fetch contexts', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => observed.push({
+        phase: activeFetchPhase,
+        deadline: fetchContext.deadline,
+      }),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    expect(observed).toEqual([
+      { phase: 'meta', deadline: 1_040_000 },
+      { phase: 'data', deadline: 1_100_000 },
+    ]);
+  });
+
+  it('leaves the data phase at least the floor after meta exhausts its slice', async () => {
+    let nowMs = 1_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    const dataWindows: number[] = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: createDurableSyncBudget({
+        fetchTimeoutMs: 100_000,
+        operationDeadline: 1_008_000,
+      }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => {
+        if (activeFetchPhase === 'meta') {
+          // Burn the whole meta slice: the transfer times out exactly at its
+          // own phase deadline instead of the shared CG deadline.
+          nowMs = fetchContext.deadline;
+        } else {
+          dataWindows.push(fetchContext.deadline - nowMs);
+        }
+      },
+      mapFetchResult: (phase, page) => (phase === 'meta'
+        ? { ...page, quads: [], nextOffset: 0, completed: false, timedOut: true }
+        : page),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    expect(dataWindows).toEqual([DURABLE_DATA_PHASE_MIN_BUDGET_MS]);
+  });
+
+  it('rolls unused meta time into the data phase', async () => {
+    let nowMs = 1_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    const dataWindows: number[] = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => {
+        if (activeFetchPhase === 'meta') {
+          nowMs += 5_000;
+          expect(fetchContext.deadline).toBe(1_040_000);
+        } else {
+          dataWindows.push(fetchContext.deadline - nowMs);
+        }
+      },
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    // 100s window minus the 5s meta actually used: the unused 35s of meta's
+    // slice belongs to data, not merely the 60s reserved remainder.
+    expect(dataWindows).toEqual([95_000]);
+  });
+
+  it('gives a meta-skipping system CG its full deadline for the only data phase', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+    const syncContext = requesterBudgetContext({
+      durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => observed.push({
+        phase: activeFetchPhase,
+        deadline: fetchContext.deadline,
+      }),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+    syncContext.contextGraphIds = [SYSTEM_CONTEXT_GRAPHS.AGENTS];
+    syncContext.syncAgentsMeta = false;
+
+    await runDurableSync(syncContext);
+
+    expect(observed).toEqual([
+      { phase: 'data', deadline: 1_100_000 },
+    ]);
+  });
+
+  it('clamps a budget-supplied meta deadline to the CG fetch deadline', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: {
+        createContextGraphBudget: () => ({
+          fetchDeadline: 1_060_000,
+          metaFetchDeadline: 1_090_000,
+          createGraphScopedAuthenticationDeadline: () => 1_060_000,
+        }),
+      },
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => observed.push({
+        phase: activeFetchPhase,
+        deadline: fetchContext.deadline,
+      }),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    expect(observed).toEqual([
+      { phase: 'meta', deadline: 1_060_000 },
+      { phase: 'data', deadline: 1_060_000 },
+    ]);
   });
 });

--- a/packages/agent/test/durable-sync-budget.test.ts
+++ b/packages/agent/test/durable-sync-budget.test.ts
@@ -76,6 +76,7 @@ function requesterPage(phase: 'data' | 'meta', quads: Quad[]): SyncPageResult {
 
 function requesterBudgetContext(options: {
   assetCount?: number;
+  contextGraphIds?: string[];
   durableSyncBudget: DurableSyncBudget;
   signal?: AbortSignal;
   graphScoped?: boolean;
@@ -100,7 +101,7 @@ function requesterBudgetContext(options: {
   return {
     ctx,
     remotePeerId: 'peer-durable-sync-budget',
-    contextGraphIds: [contextGraphId],
+    contextGraphIds: options.contextGraphIds ?? [contextGraphId],
     durableSyncBudget: options.durableSyncBudget,
     signal: options.signal,
     fetchSyncPages: async ({
@@ -752,12 +753,13 @@ describe('durable sync per-phase deadline split', () => {
     }
   });
 
-  it('threads the bounded meta deadline and full CG deadline through per-phase fetch contexts', async () => {
+  it('threads the bounded meta deadline and full CG deadline through system-CG fetch contexts', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
     const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
     let activeFetchPhase: 'data' | 'meta' = 'meta';
 
     await runRequesterBudgetHarness({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
       durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
       graphScoped: false,
       onFetchPhase: (phase) => { activeFetchPhase = phase; },
@@ -774,13 +776,36 @@ describe('durable sync per-phase deadline split', () => {
     ]);
   });
 
-  it('leaves the data phase at least the floor after meta exhausts its slice', async () => {
+  it('keeps the full CG deadline for both phases of a verified CG', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => observed.push({
+        phase: activeFetchPhase,
+        deadline: fetchContext.deadline,
+      }),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    expect(observed).toEqual([
+      { phase: 'meta', deadline: 1_100_000 },
+      { phase: 'data', deadline: 1_100_000 },
+    ]);
+  });
+
+  it('leaves the data phase at least the floor after system-CG meta exhausts its slice', async () => {
     let nowMs = 1_000_000;
     vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
     const dataWindows: number[] = [];
     let activeFetchPhase: 'data' | 'meta' = 'meta';
 
     await runRequesterBudgetHarness({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
       durableSyncBudget: createDurableSyncBudget({
         fetchTimeoutMs: 100_000,
         operationDeadline: 1_008_000,
@@ -805,13 +830,14 @@ describe('durable sync per-phase deadline split', () => {
     expect(dataWindows).toEqual([DURABLE_DATA_PHASE_MIN_BUDGET_MS]);
   });
 
-  it('rolls unused meta time into the data phase', async () => {
+  it('rolls unused system-CG meta time into the data phase', async () => {
     let nowMs = 1_000_000;
     vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
     const dataWindows: number[] = [];
     let activeFetchPhase: 'data' | 'meta' = 'meta';
 
     await runRequesterBudgetHarness({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
       durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
       graphScoped: false,
       onFetchPhase: (phase) => { activeFetchPhase = phase; },
@@ -861,6 +887,7 @@ describe('durable sync per-phase deadline split', () => {
     let activeFetchPhase: 'data' | 'meta' = 'meta';
 
     await runRequesterBudgetHarness({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
       durableSyncBudget: {
         createContextGraphBudget: () => ({
           fetchDeadline: 1_060_000,

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -197,6 +197,40 @@ describe('sync requester bailout', () => {
     ))).toBe(false);
   });
 
+  it('uses the reserved data window after a meta phase timeout', async () => {
+    const fetchSyncPages = recorder(async ({
+      contextGraphId,
+      phase,
+    }: DurableSyncFetchRequest) => phase === 'meta'
+      ? pageResult(contextGraphId, phase, { completed: false, timedOut: true })
+      : pageResult(contextGraphId, phase));
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: ['slow-cg', 'next-cg'],
+      stopOnBackoffWorthyFailure: true,
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages,
+      processDurableBatchInWorker: async () => durableProcessResult(),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(summary.timedOutPhases).toBe(1);
+    expect(fetchSyncPages.calls.map(([request]) => ({
+      contextGraphId: request.contextGraphId,
+      phase: request.phase,
+    }))).toEqual([
+      { contextGraphId: 'slow-cg', phase: 'meta' },
+      { contextGraphId: 'slow-cg', phase: 'data' },
+    ]);
+  });
+
   it('stops shared-memory context-graph fanout after a backoff-worthy transport failure', async () => {
     const fetchSyncPages = recorder(async (
       _ctx: OperationContext,

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { OperationContext } from '@origintrail-official/dkg-core';
+import { SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
   runDurableSync,
@@ -208,7 +208,7 @@ describe('sync requester bailout', () => {
     const summary = await runDurableSync({
       ctx,
       remotePeerId: 'peer-a',
-      contextGraphIds: ['slow-cg', 'next-cg'],
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'next-cg'],
       stopOnBackoffWorthyFailure: true,
       durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
       fetchSyncPages,
@@ -226,8 +226,8 @@ describe('sync requester bailout', () => {
       contextGraphId: request.contextGraphId,
       phase: request.phase,
     }))).toEqual([
-      { contextGraphId: 'slow-cg', phase: 'meta' },
-      { contextGraphId: 'slow-cg', phase: 'data' },
+      { contextGraphId: SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, phase: 'meta' },
+      { contextGraphId: SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, phase: 'data' },
     ]);
   });
 


### PR DESCRIPTION
## Problem

Durable sync's meta and data phases draw down one shared per-CG deadline. On the affected live 10.0.12 node, the large system-CG meta stream consumed the whole window; the data phase then reported a timeout with zero triples received without sending a request, every reconciler cycle.

## Fix

Introduce an optional per-phase deadline inside the existing per-CG budget:

- For system Context Graphs (`agents` and `ontology`), meta gets at most **40%** of the remaining CG window and never consumes the data floor (`DURABLE_DATA_PHASE_MIN_BUDGET_MS`).
- Data runs to the full CG deadline. If meta finishes early, its unused time rolls into data; total wall clock never exceeds the previous per-CG deadline.
- A capped meta timeout no longer exits before the reserved data phase runs. The normal post-phase timeout gate still stops later-CG fanout when requested.
- Verified user CGs deliberately keep the full deadline for both phases. Their meta/data cursors advance only after joint verification, so capping a partial descriptor stream could pin both cursors on the same window.
- Tiny/clamped windows preserve the former shared-deadline behavior. Meta-skipping `agents` sync still gives its only data phase the full window.

## User/runtime impact

A large system directory can no longer consume the complete durable-sync window before the node even asks for its data, while verified user CGs retain their fail-closed cursor semantics. This is additive scheduling behavior; no protocol, storage, or configuration migration is required.

## Validation

- full dependency-closure build: 17/17 packages green
- agent build: TypeScript, type tests, and package-root checks green
- focused deadline/bailout/rootless suites: 45/45 tests green
- combined four-PR main-based suite: 5 files / 101 tests green before the follow-up; targeted follow-up suites green
- current `testnet-canary` composition builds cleanly; network smoke follows after merge/promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code) and completed by Codex.
