### PR TITLE
canary: promote bounded sync scheduling and relay resilience fixes

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -305,7 +305,7 @@ import {
   createDurableSyncAccumulator,
   createFailedPeerDurableSyncResult,
   createIncompleteDurableSyncResult,
-  durableSyncAccumulatorHasBackoffWorthyFailure,
+  durableSyncAccumulatorHasPeerTransportFailure,
   durableSyncAccumulatorHasTerminalBoundary,
   durableSyncAccumulatorFromResult,
   finalizeDurableSyncCompletion,
@@ -4802,9 +4802,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           return markDurableTerminalBoundary(summary, false);
         },
         shouldContinue: () => !operationBoundary.signal?.aborted,
-        shouldStop: (part) => Boolean(
+        // One CG's backoff-worthy round stays in the merged summary (its
+        // terminal boundary is false, so the aggregate cannot finalize
+        // complete, and the peer is not stamped fresh) while the remaining
+        // CGs still get their turn. Only peer-never-responded rounds may
+        // stop the batch, via the ordered fanout's consecutive-failure guard.
+        isPeerTransportFailure: (part) => Boolean(
           stopOnBackoffWorthyFailure
-          && durableSyncAccumulatorHasBackoffWorthyFailure(part),
+          && durableSyncAccumulatorHasPeerTransportFailure(part),
         ),
         onDeferred: (item, error) => this.log.info(
           ctx,
@@ -6125,8 +6130,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           ...summary,
           deferredBackpressure: (summary.deferredBackpressure ?? 0) + 1,
         }),
-        shouldStop: (part) => Boolean(
-          stopOnBackoffWorthyFailure && (part.backoffWorthyFailures ?? 0) > 0,
+        // Mirrors the durable fanout: a failed CG round is already recorded in
+        // the merged counters and must not cost the remaining CGs their turn.
+        // `failedPeers` is the peer-never-responded signal on the public lane;
+        // the private curator-recovery lane also reports it for its whole-round
+        // failures, which the consecutive-failure guard bounds instead of
+        // aborting on the first one.
+        isPeerTransportFailure: (part) => Boolean(
+          stopOnBackoffWorthyFailure && part.failedPeers > 0,
         ),
         onDeferred: (item, error) => this.log.info(
           ctx,

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1252,7 +1252,11 @@ export interface DKGAgentConfig {
   syncGlobalQueueLimit?: number;
   /** Daemon-local retained responder snapshot row/estimated-byte policy. */
   syncResponderSnapshotLimits?: SyncResponderSnapshotLimitsConfig;
-  /** Local requester/responder priority by Context Graph ID. Higher runs first. */
+  /**
+   * Local requester/responder priority by Context Graph ID. Higher runs first.
+   * System Context Graphs default to a deprioritized priority so they run
+   * last; an explicit entry here (including 0) overrides that default.
+   */
   syncContextGraphPriorities?: SyncContextGraphPriorityConfig;
   /** StorageACK handler deadline override in milliseconds. Env DKG_STORAGE_ACK_HANDLER_DEADLINE_MS wins. */
   storageAckHandlerDeadlineMs?: number;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -218,7 +218,7 @@ import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-bu
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
 import {
-  normalizeSyncContextGraphPriorities,
+  resolveSyncContextGraphPriorities,
   validateSyncResponderSnapshotLimitsConfig,
 } from './sync/policy.js';
 import { runSyncOnConnect } from './sync/on-connect/sync-on-connect.js';
@@ -711,7 +711,7 @@ export class DKGAgent extends DKGAgentBase {
     validateSyncResponderSnapshotLimitsConfig(inputConfig.syncResponderSnapshotLimits);
     const config = normalizeStorageAckConfig({
       ...inputConfig,
-      syncContextGraphPriorities: normalizeSyncContextGraphPriorities(
+      syncContextGraphPriorities: resolveSyncContextGraphPriorities(
         inputConfig.syncContextGraphPriorities,
       ),
     });

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -135,12 +135,14 @@ export type {
   AcceptedRfc64CatalogAccessSnapshotV1,
 } from './rfc64/catalog-access-policy-v1.js';
 export {
+  DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY,
   SYNC_ADMISSION_SOURCES,
   contextGraphPriority,
   countSyncPriorityClasses,
   normalizeSyncAdmissionSource,
   normalizeSyncContextGraphPriorities,
   orderContextGraphIdsByPriority,
+  resolveSyncContextGraphPriorities,
   syncPriorityClass,
   validateSyncResponderSnapshotLimitsConfig,
   type SyncAdmissionSource,

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -280,6 +280,20 @@ export class DurableSyncAccumulator {
     return this.diagnostics.backoffWorthyFailures > 0;
   }
 
+  /**
+   * The peer never responded for a folded round. `failedPeers` is recorded by
+   * the requester runners only when a round's error carried the transport tag
+   * AND no phase of that round saw a response (`error-tags.ts`
+   * `isSyncTransportFailure` / `didSyncPeerRespond`); everything the peer did
+   * answer — denials, post-response failures, timeouts with pages — lands in
+   * the per-phase counters instead. That makes this the one signal that
+   * distinguishes "the peer is unreachable" from "this Context Graph's round
+   * went wrong".
+   */
+  hasPeerTransportFailure(): boolean {
+    return this.diagnostics.failedPeers > 0;
+  }
+
   hasTerminalBoundary(): boolean {
     return this.observedTerminalBoundaries > 0;
   }
@@ -350,6 +364,12 @@ export function durableSyncAccumulatorHasBackoffWorthyFailure(
   accumulator: DurableSyncAccumulator,
 ): boolean {
   return accumulator.hasBackoffWorthyFailure();
+}
+
+export function durableSyncAccumulatorHasPeerTransportFailure(
+  accumulator: DurableSyncAccumulator,
+): boolean {
+  return accumulator.hasPeerTransportFailure();
 }
 
 export function durableSyncAccumulatorHasTerminalBoundary(

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -69,6 +69,13 @@ interface SyncResultAccounting {
   insertedTriples: number;
   madeProgress: boolean;
   backoffWorthyFailure: boolean;
+  /**
+   * The peer never answered at least one Context Graph's round
+   * (`failedPeers`), as opposed to a round that failed after a response.
+   * Only this — combined with zero progress — may stop the on-connect
+   * fanout early; per-CG failures are isolated inside the sync itself.
+   */
+  peerUnreachable: boolean;
   denied: boolean;
   failed: boolean;
   deferredByBackpressure: boolean;
@@ -85,6 +92,7 @@ function classifySyncResult(
       insertedTriples: result,
       madeProgress: true,
       backoffWorthyFailure: false,
+      peerUnreachable: false,
       denied: false,
       failed: false,
       deferredByBackpressure: false,
@@ -98,6 +106,7 @@ function classifySyncResult(
     insertedTriples: result.insertedTriples,
     madeProgress: progress.madeReconnectProgress,
     backoffWorthyFailure: progress.backoffWorthyFailure,
+    peerUnreachable: progress.transportFailed,
     denied: progress.denied,
     failed: progress.phaseFailed || progress.integrityRejected,
     deferredByBackpressure: progress.deferredByBackpressure,
@@ -230,9 +239,19 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after local admission deferral`);
       return finishSyncAccounting();
     }
-    if (syncedAccounting.backoffWorthyFailure) {
-      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after durable sync hit backoff-worthy pressure`);
+    // A backoff-worthy per-CG failure must NOT stop the remaining lanes: the
+    // failure is already recorded (the peer will not be stamped fresh), and
+    // stopping here starves CG discovery and shared-memory sync of a peer
+    // that is demonstrably reachable — the small-CG-behind-a-poison-transfer
+    // starvation this accounting exists to prevent. Only a peer that never
+    // answered any round and produced no progress stops the fanout, because
+    // every later lane would just re-dial the same dead peer.
+    if (syncedAccounting.peerUnreachable && !syncedAccounting.madeProgress) {
+      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer}: durable sync could not reach the peer`);
       return finishSyncAccounting();
+    }
+    if (syncedAccounting.backoffWorthyFailure) {
+      logInfo(ctx, `Durable sync from peer ${shortPeer} hit backoff-worthy pressure; continuing remaining sync-on-connect lanes`);
     }
 
     const syncScope = new Set<string>([
@@ -255,8 +274,10 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
         logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after discovered-CG admission deferral`);
         return finishSyncAccounting();
       }
-      if (discoverAccounting.backoffWorthyFailure) {
-        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after discovered-CG durable sync hit backoff-worthy pressure`);
+      // Same policy as the primary durable leg: per-CG pressure continues,
+      // only an unanswered round with no progress stops the fanout.
+      if (discoverAccounting.peerUnreachable && !discoverAccounting.madeProgress) {
+        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer}: discovered-CG durable sync could not reach the peer`);
         return finishSyncAccounting();
       }
       await runNonTransportStep(() => refreshMetaSyncedFlags(newlyDiscovered));

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -102,11 +102,23 @@ function classifySyncResult(
   }
 
   const progress = classifyDurableProgress(result, { complete });
+  // `failedPeers` is folded across every Context Graph in this lane. It says
+  // at least one round never got a response; it does not mean the peer failed
+  // to answer every round. Preserve any response evidence from sibling CGs so
+  // one unreachable/poisoned CG cannot suppress discovery and SWM fanout from
+  // a peer that demonstrably answered elsewhere.
+  const peerRespondedInLane = progress.madeReconnectProgress
+    || progress.denied
+    || progress.phaseFailed
+    || progress.integrityRejected
+    || progress.timedOut
+    || progress.hasMetadataEvidence
+    || progress.hasVerifiedPrivateOnlyResponse;
   return {
     insertedTriples: result.insertedTriples,
     madeProgress: progress.madeReconnectProgress,
     backoffWorthyFailure: progress.backoffWorthyFailure,
-    peerUnreachable: progress.transportFailed,
+    peerUnreachable: progress.transportFailed && !peerRespondedInLane,
     denied: progress.denied,
     failed: progress.phaseFailed || progress.integrityRejected,
     deferredByBackpressure: progress.deferredByBackpressure,

--- a/packages/agent/src/sync/policy.ts
+++ b/packages/agent/src/sync/policy.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+
 export interface SyncResponderSnapshotLimitsConfig {
   global?: {
     rows?: number;
@@ -123,11 +125,56 @@ export function normalizeSyncContextGraphPriorities(
   return Object.freeze(normalized);
 }
 
+/**
+ * System Context Graphs are broadcast directories: every peer replicates them,
+ * they grow with the network (tens of thousands of triples), and any connected
+ * peer can serve them. A user Context Graph has none of those properties — its
+ * one reachable curator may be the only source in a fanout that stops on the
+ * first failure, so a system graph failing mid-transfer ahead of user work
+ * starves every user graph behind it on every cycle. Running system graphs
+ * LAST bounds that blast radius to the graphs that can afford it. Operators
+ * override by naming the graph in `syncContextGraphPriorities`; an explicit 0
+ * restores ordinary scheduling.
+ */
+export const DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY = -100;
+
+const SYSTEM_CONTEXT_GRAPH_IDS: ReadonlySet<string> = new Set(
+  Object.values(SYSTEM_CONTEXT_GRAPHS),
+);
+
+/**
+ * Normalize the operator config and fill in the system-graph defaults. Applied
+ * where the config is normalized (agent construction) so every consumer —
+ * fanout ordering, admission scheduling, responder scheduling, and the
+ * "Resolved sync policy" boot log's class counts — acts on and reports the
+ * same effective map.
+ */
+export function resolveSyncContextGraphPriorities(
+  config: SyncContextGraphPriorityConfig | undefined,
+): Readonly<SyncContextGraphPriorityConfig> {
+  const resolved: SyncContextGraphPriorityConfig = {
+    ...normalizeSyncContextGraphPriorities(config),
+  };
+  for (const contextGraphId of SYSTEM_CONTEXT_GRAPH_IDS) {
+    resolved[contextGraphId] ??= DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY;
+  }
+  return Object.freeze(resolved);
+}
+
 export function contextGraphPriority(
   priorities: Readonly<SyncContextGraphPriorityConfig> | undefined,
   contextGraphId: string,
 ): number {
-  return priorities?.[contextGraphId] ?? 0;
+  const configured = priorities?.[contextGraphId];
+  if (configured !== undefined) return configured;
+  // Read-side backstop for maps that never passed through
+  // resolveSyncContextGraphPriorities (a raw config object, or none at all):
+  // system graphs sorting last must not depend on every caller remembering
+  // the resolve step. A resolved map already carries the same value, so the
+  // two layers can never disagree.
+  return SYSTEM_CONTEXT_GRAPH_IDS.has(contextGraphId)
+    ? DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY
+    : 0;
 }
 
 export function syncPriorityClass(priority: number): SyncPriorityClass {

--- a/packages/agent/src/sync/requester/durable-sync-budget.ts
+++ b/packages/agent/src/sync/requester/durable-sync-budget.ts
@@ -12,11 +12,14 @@ export const EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS = 600_000;
 // meta stream of a large system CG (agents/ontology run to tens of thousands
 // of rows) over a relayed, page-shrinking transport could consume the whole
 // window. The data phase then reported a timeout with zero triples received
-// having never sent a request — every cycle, forever. Capping meta below half
-// the window guarantees data the majority share each cycle while meta keeps
-// enough room to finish (or at least advance its resume checkpoint). Deadlines
-// are absolute, so a meta phase that finishes early hands its unused time to
-// data for free and the two phases combined can never exceed the CG budget.
+// having never sent a request — every cycle, forever. The requester applies
+// this cap to system CGs only: their unverified payloads can persist and resume
+// after a capped partial meta page. Verified CGs keep the full window for meta,
+// because their meta and data cursors advance only after clean joint
+// verification; capping meta there could pin both cursors on the same partial
+// descriptor window. Deadlines are absolute, so a system-CG meta phase that
+// finishes early hands its unused time to data for free and the two phases
+// combined can never exceed the CG budget.
 export const DURABLE_META_PHASE_BUDGET_FRACTION = 0.4;
 // Wall clock the data phase keeps even when an operation deadline clamps the
 // CG window so tight that the fraction above would leave it less. Must stay
@@ -33,10 +36,11 @@ export interface DurableSyncContextGraphBudget {
   readonly fetchDeadline: number;
   /**
    * Earlier deadline for the meta phase alone, keeping a bounded fraction of
-   * the CG window so a slow meta transfer cannot starve the data phase.
-   * Optional for rolling deep-import compatibility: budgets minted before the
-   * phases split share `fetchDeadline`, preserving their single-deadline
-   * behaviour.
+   * the CG window so a slow system-CG meta transfer cannot starve the data
+   * phase. The requester deliberately ignores this earlier deadline for
+   * verified CGs. Optional for rolling deep-import compatibility: budgets
+   * minted before the phases split share `fetchDeadline`, preserving their
+   * single-deadline behaviour.
    */
   readonly metaFetchDeadline?: number;
   /** Fresh deadline for authenticating graph-scoped assets from one verified page. */

--- a/packages/agent/src/sync/requester/durable-sync-budget.ts
+++ b/packages/agent/src/sync/requester/durable-sync-budget.ts
@@ -8,10 +8,37 @@ export const MAX_DURABLE_SYNC_TOTAL_TIMEOUT_MS = 300_000;
 // observed canary path project roughly 425 seconds for its byte-paged transfer,
 // so exact VM repair gets a separate hard 10-minute transfer ceiling.
 export const EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS = 600_000;
+// Meta and data historically drew down ONE shared per-CG deadline, and the
+// meta stream of a large system CG (agents/ontology run to tens of thousands
+// of rows) over a relayed, page-shrinking transport could consume the whole
+// window. The data phase then reported a timeout with zero triples received
+// having never sent a request — every cycle, forever. Capping meta below half
+// the window guarantees data the majority share each cycle while meta keeps
+// enough room to finish (or at least advance its resume checkpoint). Deadlines
+// are absolute, so a meta phase that finishes early hands its unused time to
+// data for free and the two phases combined can never exceed the CG budget.
+export const DURABLE_META_PHASE_BUDGET_FRACTION = 0.4;
+// Wall clock the data phase keeps even when an operation deadline clamps the
+// CG window so tight that the fraction above would leave it less. Must stay
+// below SYNC_MIN_GRAPH_BUDGET_MS * (1 - DURABLE_META_PHASE_BUDGET_FRACTION)
+// so a minimum-budget CG still gives meta a usable slice.
+export const DURABLE_DATA_PHASE_MIN_BUDGET_MS = SYNC_MIN_GRAPH_BUDGET_MS / 2;
 
 export interface DurableSyncContextGraphBudget {
-  /** Deadline for fetching this Context Graph's durable snapshot. */
+  /**
+   * Deadline for fetching this Context Graph's durable snapshot. This bounds
+   * the whole per-CG fetch, so the data phase (which runs last) uses it
+   * directly and unused meta time rolls over to data.
+   */
   readonly fetchDeadline: number;
+  /**
+   * Earlier deadline for the meta phase alone, keeping a bounded fraction of
+   * the CG window so a slow meta transfer cannot starve the data phase.
+   * Optional for rolling deep-import compatibility: budgets minted before the
+   * phases split share `fetchDeadline`, preserving their single-deadline
+   * behaviour.
+   */
+  readonly metaFetchDeadline?: number;
   /** Fresh deadline for authenticating graph-scoped assets from one verified page. */
   readonly createGraphScopedAuthenticationDeadline: () => number;
 }
@@ -69,6 +96,28 @@ export function createGraphScopedAuthenticationDeadline(options: {
 }
 
 /**
+ * Bound the meta phase inside one Context Graph's fetch window. Meta gets at
+ * most its budget fraction, and never so much that less than the data floor
+ * remains before `fetchDeadline`. A window already too small to reserve that
+ * floor has nothing meaningful to split, so it keeps the shared deadline:
+ * a tightly clamped operation window degrades exactly as it always did
+ * instead of failing meta instantly.
+ */
+export function createDurableMetaPhaseFetchDeadline(options: {
+  fetchDeadline: number;
+  now?: () => number;
+}): number {
+  const now = (options.now ?? Date.now)();
+  const totalBudgetMs = options.fetchDeadline - now;
+  const metaBudgetMs = Math.min(
+    Math.floor(totalBudgetMs * DURABLE_META_PHASE_BUDGET_FRACTION),
+    totalBudgetMs - DURABLE_DATA_PHASE_MIN_BUDGET_MS,
+  );
+  if (metaBudgetMs <= 0) return options.fetchDeadline;
+  return now + metaBudgetMs;
+}
+
+/**
  * Construct the requester-owned fetch/authentication phase policy. Lifecycle
  * supplies only caller configuration and whether this is exact VM recovery.
  */
@@ -80,8 +129,8 @@ export function createDurableSyncBudget(options: {
   now?: () => number;
 }): DurableSyncBudget {
   return {
-    createContextGraphBudget: ({ remainingContextGraphs }) => ({
-      fetchDeadline: Math.min(
+    createContextGraphBudget: ({ remainingContextGraphs }) => {
+      const fetchDeadline = Math.min(
         createContextGraphSyncDeadline({
           remainingContextGraphs,
           totalTimeoutMs: options.fetchTimeoutMs,
@@ -91,14 +140,21 @@ export function createDurableSyncBudget(options: {
           now: options.now,
         }),
         options.operationDeadline ?? Number.POSITIVE_INFINITY,
-      ),
-      createGraphScopedAuthenticationDeadline: () => Math.min(
-        createGraphScopedAuthenticationDeadline({
-          totalTimeoutMs: options.authenticationTimeoutMs,
+      );
+      return {
+        fetchDeadline,
+        metaFetchDeadline: createDurableMetaPhaseFetchDeadline({
+          fetchDeadline,
           now: options.now,
         }),
-        options.operationDeadline ?? Number.POSITIVE_INFINITY,
-      ),
-    }),
+        createGraphScopedAuthenticationDeadline: () => Math.min(
+          createGraphScopedAuthenticationDeadline({
+            totalTimeoutMs: options.authenticationTimeoutMs,
+            now: options.now,
+          }),
+          options.operationDeadline ?? Number.POSITIVE_INFINITY,
+        ),
+      };
+    },
   };
 }

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -41,8 +41,11 @@ import {
 
 export {
   createContextGraphSyncDeadline,
+  createDurableMetaPhaseFetchDeadline,
   createDurableSyncBudget,
   createGraphScopedAuthenticationDeadline,
+  DURABLE_DATA_PHASE_MIN_BUDGET_MS,
+  DURABLE_META_PHASE_BUDGET_FRACTION,
   EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS,
   MAX_DURABLE_SYNC_TOTAL_TIMEOUT_MS,
   normalizeDurableSyncTimeoutMs,
@@ -337,7 +340,14 @@ async function runDurableSyncWithBudget(
         remainingContextGraphs: contextGraphIds.length - contextGraphIndex,
       });
       const deadline = contextGraphBudget.fetchDeadline;
-      const activeFetchContext = fetchContext(deadline);
+      // Meta may never outlive the CG window even if a budget hands out a
+      // later phase deadline, so both phases combined stay inside the per-CG
+      // wall clock. The data phase runs to the full CG deadline, which is how
+      // a meta phase that finishes early rolls its unused time into data.
+      const metaFetchDeadline = Math.min(
+        contextGraphBudget.metaFetchDeadline ?? deadline,
+        deadline,
+      );
       const exactAssetUals = exactAssetUalsFor?.(pid);
       if (exactAssetUals !== undefined) {
         exactFetchDispositionIndex = exactFetchDispositions.push('incomplete') - 1;
@@ -363,7 +373,7 @@ async function runDurableSyncWithBudget(
         graphUri,
         sinceBatchId,
         exactAssetUals,
-        fetchContext: activeFetchContext,
+        fetchContext: fetchContext(phase === 'meta' ? metaFetchDeadline : deadline),
       });
       const metaResult: SyncPageResult = skipAgentsMeta
         ? {

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -335,6 +335,7 @@ async function runDurableSyncWithBudget(
       throwIfOperationAborted();
       const dataGraph = contextGraphDataGraphUri(pid);
       const metaGraph = contextGraphMetaGraphUri(pid);
+      const isSystemContextGraph = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(pid);
       const contextGraphBudget = durableSyncBudget.createContextGraphBudget({
         contextGraphId: pid,
         remainingContextGraphs: contextGraphIds.length - contextGraphIndex,
@@ -344,10 +345,14 @@ async function runDurableSyncWithBudget(
       // later phase deadline, so both phases combined stay inside the per-CG
       // wall clock. The data phase runs to the full CG deadline, which is how
       // a meta phase that finishes early rolls its unused time into data.
-      const metaFetchDeadline = Math.min(
-        contextGraphBudget.metaFetchDeadline ?? deadline,
-        deadline,
-      );
+      // System CGs accept unverified payloads, so a capped partial meta page
+      // can persist and resume. Verified CGs require joint meta/data
+      // verification before either cursor advances; giving their meta phase an
+      // earlier cap could make the same incomplete descriptor page repeat
+      // forever.
+      const metaFetchDeadline = isSystemContextGraph
+        ? Math.min(contextGraphBudget.metaFetchDeadline ?? deadline, deadline)
+        : deadline;
       const exactAssetUals = exactAssetUalsFor?.(pid);
       if (exactAssetUals !== undefined) {
         exactFetchDispositionIndex = exactFetchDispositions.push('incomplete') - 1;
@@ -398,8 +403,6 @@ async function runDurableSyncWithBudget(
       peerRespondedForContextGraph = true;
       endPhase();
       const fetchDurationMs = Date.now() - fetchStartedAt;
-      const isSystemContextGraph = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(pid);
-
       let effectiveMetaResult = metaResult;
       let dataResult = rawDataResult;
       let exactAssetDescriptorCoverageComplete = true;

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -387,12 +387,10 @@ async function runDurableSyncWithBudget(
           }
         : await fetchPhase('meta', metaGraph);
       if (!skipAgentsMeta) peerRespondedForContextGraph = true;
-      if (metaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
-        markDurableTerminalBoundary(accumulator, false);
-        recordPhaseOutcome(metaResult, { updateCheckpoint: false });
-        endPhase();
-        break;
-      }
+      // A meta timeout can be the intentional phase boundary assigned by the
+      // per-phase budget. Keep going so data can use the time reserved for it;
+      // the post-processing timeout gate below still prevents fanout to the
+      // next context graph when stopOnBackoffWorthyFailure is enabled.
       throwIfOperationAborted();
       const sinceBatchId = sinceBatchIdFor?.(pid);
       const rawDataResult = await fetchPhase('data', dataGraph, sinceBatchId);

--- a/packages/agent/src/sync/requester/ordered-sync.ts
+++ b/packages/agent/src/sync/requester/ordered-sync.ts
@@ -5,6 +5,20 @@ import {
   type SyncContextGraphPriorityConfig,
 } from '../policy.js';
 
+/**
+ * Peer-dead cutoff for one fanout batch. One Context Graph's failed round must
+ * never cost the remaining CGs their turn — a single poisoned transfer (an
+ * oversized system CG dying mid-stream every cycle) otherwise starves every
+ * small CG behind it indefinitely. But the inverse is also real: when the peer
+ * itself is dead or unreachable, every remaining item re-dials it and burns a
+ * full transport timeout, so a long CG list turns one dead peer into an
+ * hours-long stall. Three consecutive rounds in which the peer never responded
+ * is treated as peer-dead evidence and stops the batch; any round the peer
+ * answered — cleanly, denied, or failed after responding — resets the streak,
+ * so per-CG failures alone can never trip this guard.
+ */
+export const MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES = 3;
+
 export interface ContextGraphSyncWork<Result> {
   contextGraphId: string;
   /**
@@ -38,7 +52,15 @@ export interface OrderedContextGraphSyncOptions<Result> {
     skipped: readonly ContextGraphSyncWork<Result>[],
   ) => Result;
   shouldContinue?: () => boolean;
-  shouldStop?: (part: Result) => boolean;
+  /**
+   * True when one merged item result shows the PEER never responded for that
+   * Context Graph's round (transport-class: dial/stream death before any
+   * answer). Failures the peer did respond to must return false — they are
+   * already recorded in the merged summary, and the fanout continues to the
+   * next CG. Consecutive true verdicts feed the peer-dead cutoff
+   * ({@link MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES}).
+   */
+  isPeerTransportFailure?: (part: Result) => boolean;
   onDeferred?: (item: ContextGraphSyncWork<Result>, error: Error) => void;
 }
 
@@ -72,6 +94,7 @@ export async function runOrderedContextGraphSyncs<Result>(
 ): Promise<Result> {
   let summary = options.emptyResult();
   const orderedWork = orderWork(options.work, options.priorities);
+  let consecutivePeerTransportFailures = 0;
   for (const [index, item] of orderedWork.entries()) {
     if (options.shouldContinue && !options.shouldContinue()) {
       summary = options.markSkipped?.(summary, orderedWork.slice(index)) ?? summary;
@@ -84,8 +107,16 @@ export async function runOrderedContextGraphSyncs<Result>(
         () => item.run(remaining),
       );
       summary = options.merge(summary, part);
-      if (options.shouldStop?.(part)) break;
+      if (options.isPeerTransportFailure?.(part)) {
+        consecutivePeerTransportFailures += 1;
+        if (consecutivePeerTransportFailures >= MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES) break;
+      } else {
+        consecutivePeerTransportFailures = 0;
+      }
     } catch (error) {
+      // The GLOBAL admission queue rejected this item, so every later item
+      // would be rejected identically — stopping here is correct and cheap,
+      // unlike a per-CG failure, which stays isolated above.
       const backpressureError = getSyncBackpressureBusyError(error);
       if (!backpressureError) throw error;
       summary = options.markDeferred(summary);

--- a/packages/agent/test/durable-sync-budget.test.ts
+++ b/packages/agent/test/durable-sync-budget.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { OperationContext } from '@origintrail-official/dkg-core';
+import { SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
 import {
   createContextGraphSyncDeadline,
+  createDurableMetaPhaseFetchDeadline,
   createDurableSyncBudget,
   createGraphScopedAuthenticationDeadline,
+  DURABLE_DATA_PHASE_MIN_BUDGET_MS,
+  DURABLE_META_PHASE_BUDGET_FRACTION,
   type DurableSyncBudget,
 } from '../src/sync/requester/durable-sync-budget.js';
 import {
@@ -78,6 +81,7 @@ function requesterBudgetContext(options: {
   graphScoped?: boolean;
   onFetchPhase?: (phase: 'data' | 'meta') => void;
   onFetchContext?: (fetchContext: DurableSyncFetchContext) => void;
+  mapFetchResult?: (phase: 'data' | 'meta', page: SyncPageResult) => SyncPageResult;
   onVerify?: () => void;
   onVerifiedFullSnapshot?: DurableSyncContext['onVerifiedFullSnapshot'];
   emptyResponses?: number;
@@ -105,9 +109,10 @@ function requesterBudgetContext(options: {
     }) => {
       options.onFetchPhase?.(phase);
       options.onFetchContext?.(fetchContext);
-      return phase === 'data'
+      const page = phase === 'data'
         ? requesterPage(phase, dataQuads)
         : requesterPage(phase, metadataQuads);
+      return options.mapFetchResult?.(phase, page) ?? page;
     },
     processDurableBatchInWorker: async () => {
       options.onVerify?.();
@@ -687,5 +692,194 @@ describe('durable sync deadline budget', () => {
       failedPhases: 1,
     });
     expect(storeInsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('durable sync per-phase deadline split', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('caps meta at its budget fraction while data keeps the full CG deadline', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    const budget = createDurableSyncBudget({ fetchTimeoutMs: 100_000 })
+      .createContextGraphBudget({ contextGraphId, remainingContextGraphs: 1 });
+
+    expect(budget.fetchDeadline).toBe(1_100_000);
+    expect(budget.metaFetchDeadline).toBe(
+      1_000_000 + 100_000 * DURABLE_META_PHASE_BUDGET_FRACTION,
+    );
+  });
+
+  it('reserves the data floor when an operation deadline clamps the CG window', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    const budget = createDurableSyncBudget({
+      fetchTimeoutMs: 100_000,
+      operationDeadline: 1_008_000,
+    }).createContextGraphBudget({ contextGraphId, remainingContextGraphs: 1 });
+
+    expect(budget.fetchDeadline).toBe(1_008_000);
+    expect(budget.metaFetchDeadline).toBe(1_003_000);
+    expect(budget.fetchDeadline - budget.metaFetchDeadline!)
+      .toBe(DURABLE_DATA_PHASE_MIN_BUDGET_MS);
+  });
+
+  it('keeps the shared deadline when the window cannot reserve the data floor', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    expect(createDurableMetaPhaseFetchDeadline({
+      fetchDeadline: 1_000_000 + DURABLE_DATA_PHASE_MIN_BUDGET_MS - 1_000,
+    })).toBe(1_000_000 + DURABLE_DATA_PHASE_MIN_BUDGET_MS - 1_000);
+    expect(createDurableMetaPhaseFetchDeadline({ fetchDeadline: 999_000 }))
+      .toBe(999_000);
+  });
+
+  it('never lets the phase deadlines extend the prior single-deadline total', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    for (const remainingContextGraphs of [1, 2, 7]) {
+      const budget = createDurableSyncBudget({ fetchTimeoutMs: 100_000 })
+        .createContextGraphBudget({ contextGraphId, remainingContextGraphs });
+      const priorSharedDeadline = createContextGraphSyncDeadline({
+        remainingContextGraphs,
+        totalTimeoutMs: 100_000,
+      });
+      expect(budget.fetchDeadline).toBe(priorSharedDeadline);
+      expect(budget.metaFetchDeadline!).toBeLessThanOrEqual(priorSharedDeadline);
+      expect(budget.metaFetchDeadline!).toBeGreaterThan(1_000_000);
+    }
+  });
+
+  it('threads the bounded meta deadline and full CG deadline through per-phase fetch contexts', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => observed.push({
+        phase: activeFetchPhase,
+        deadline: fetchContext.deadline,
+      }),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    expect(observed).toEqual([
+      { phase: 'meta', deadline: 1_040_000 },
+      { phase: 'data', deadline: 1_100_000 },
+    ]);
+  });
+
+  it('leaves the data phase at least the floor after meta exhausts its slice', async () => {
+    let nowMs = 1_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    const dataWindows: number[] = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: createDurableSyncBudget({
+        fetchTimeoutMs: 100_000,
+        operationDeadline: 1_008_000,
+      }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => {
+        if (activeFetchPhase === 'meta') {
+          // Burn the whole meta slice: the transfer times out exactly at its
+          // own phase deadline instead of the shared CG deadline.
+          nowMs = fetchContext.deadline;
+        } else {
+          dataWindows.push(fetchContext.deadline - nowMs);
+        }
+      },
+      mapFetchResult: (phase, page) => (phase === 'meta'
+        ? { ...page, quads: [], nextOffset: 0, completed: false, timedOut: true }
+        : page),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    expect(dataWindows).toEqual([DURABLE_DATA_PHASE_MIN_BUDGET_MS]);
+  });
+
+  it('rolls unused meta time into the data phase', async () => {
+    let nowMs = 1_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    const dataWindows: number[] = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => {
+        if (activeFetchPhase === 'meta') {
+          nowMs += 5_000;
+          expect(fetchContext.deadline).toBe(1_040_000);
+        } else {
+          dataWindows.push(fetchContext.deadline - nowMs);
+        }
+      },
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    // 100s window minus the 5s meta actually used: the unused 35s of meta's
+    // slice belongs to data, not merely the 60s reserved remainder.
+    expect(dataWindows).toEqual([95_000]);
+  });
+
+  it('gives a meta-skipping system CG its full deadline for the only data phase', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+    const syncContext = requesterBudgetContext({
+      durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => observed.push({
+        phase: activeFetchPhase,
+        deadline: fetchContext.deadline,
+      }),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+    syncContext.contextGraphIds = [SYSTEM_CONTEXT_GRAPHS.AGENTS];
+    syncContext.syncAgentsMeta = false;
+
+    await runDurableSync(syncContext);
+
+    expect(observed).toEqual([
+      { phase: 'data', deadline: 1_100_000 },
+    ]);
+  });
+
+  it('clamps a budget-supplied meta deadline to the CG fetch deadline', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: {
+        createContextGraphBudget: () => ({
+          fetchDeadline: 1_060_000,
+          metaFetchDeadline: 1_090_000,
+          createGraphScopedAuthenticationDeadline: () => 1_060_000,
+        }),
+      },
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => observed.push({
+        phase: activeFetchPhase,
+        deadline: fetchContext.deadline,
+      }),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    expect(observed).toEqual([
+      { phase: 'meta', deadline: 1_060_000 },
+      { phase: 'data', deadline: 1_060_000 },
+    ]);
   });
 });

--- a/packages/agent/test/durable-sync-budget.test.ts
+++ b/packages/agent/test/durable-sync-budget.test.ts
@@ -76,6 +76,7 @@ function requesterPage(phase: 'data' | 'meta', quads: Quad[]): SyncPageResult {
 
 function requesterBudgetContext(options: {
   assetCount?: number;
+  contextGraphIds?: string[];
   durableSyncBudget: DurableSyncBudget;
   signal?: AbortSignal;
   graphScoped?: boolean;
@@ -100,7 +101,7 @@ function requesterBudgetContext(options: {
   return {
     ctx,
     remotePeerId: 'peer-durable-sync-budget',
-    contextGraphIds: [contextGraphId],
+    contextGraphIds: options.contextGraphIds ?? [contextGraphId],
     durableSyncBudget: options.durableSyncBudget,
     signal: options.signal,
     fetchSyncPages: async ({
@@ -752,12 +753,13 @@ describe('durable sync per-phase deadline split', () => {
     }
   });
 
-  it('threads the bounded meta deadline and full CG deadline through per-phase fetch contexts', async () => {
+  it('threads the bounded meta deadline and full CG deadline through system-CG fetch contexts', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
     const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
     let activeFetchPhase: 'data' | 'meta' = 'meta';
 
     await runRequesterBudgetHarness({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
       durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
       graphScoped: false,
       onFetchPhase: (phase) => { activeFetchPhase = phase; },
@@ -774,13 +776,36 @@ describe('durable sync per-phase deadline split', () => {
     ]);
   });
 
-  it('leaves the data phase at least the floor after meta exhausts its slice', async () => {
+  it('keeps the full CG deadline for both phases of a verified CG', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const observed: Array<{ phase: 'data' | 'meta'; deadline: number }> = [];
+    let activeFetchPhase: 'data' | 'meta' = 'meta';
+
+    await runRequesterBudgetHarness({
+      durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
+      graphScoped: false,
+      onFetchPhase: (phase) => { activeFetchPhase = phase; },
+      onFetchContext: (fetchContext) => observed.push({
+        phase: activeFetchPhase,
+        deadline: fetchContext.deadline,
+      }),
+      storeGraphScopedAsset: async () => 'applied',
+    });
+
+    expect(observed).toEqual([
+      { phase: 'meta', deadline: 1_100_000 },
+      { phase: 'data', deadline: 1_100_000 },
+    ]);
+  });
+
+  it('leaves the data phase at least the floor after system-CG meta exhausts its slice', async () => {
     let nowMs = 1_000_000;
     vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
     const dataWindows: number[] = [];
     let activeFetchPhase: 'data' | 'meta' = 'meta';
 
     await runRequesterBudgetHarness({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
       durableSyncBudget: createDurableSyncBudget({
         fetchTimeoutMs: 100_000,
         operationDeadline: 1_008_000,
@@ -805,13 +830,14 @@ describe('durable sync per-phase deadline split', () => {
     expect(dataWindows).toEqual([DURABLE_DATA_PHASE_MIN_BUDGET_MS]);
   });
 
-  it('rolls unused meta time into the data phase', async () => {
+  it('rolls unused system-CG meta time into the data phase', async () => {
     let nowMs = 1_000_000;
     vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
     const dataWindows: number[] = [];
     let activeFetchPhase: 'data' | 'meta' = 'meta';
 
     await runRequesterBudgetHarness({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
       durableSyncBudget: createDurableSyncBudget({ fetchTimeoutMs: 100_000 }),
       graphScoped: false,
       onFetchPhase: (phase) => { activeFetchPhase = phase; },
@@ -861,6 +887,7 @@ describe('durable sync per-phase deadline split', () => {
     let activeFetchPhase: 'data' | 'meta' = 'meta';
 
     await runRequesterBudgetHarness({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
       durableSyncBudget: {
         createContextGraphBudget: () => ({
           fetchDeadline: 1_060_000,

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -334,7 +334,7 @@ describe('sync-on-connect churn gates', () => {
     });
   });
 
-  it('records progress before stopping post-durable sync-on-connect fanout after backoff-worthy durable pressure', async () => {
+  it('continues post-durable sync-on-connect fanout past backoff-worthy per-CG durable pressure', async () => {
     const refreshMetaSyncedFlags = recorder(async () => undefined);
     const discoverContextGraphsFromStore = recorder(async () => 0);
     const syncSharedMemoryFromPeer = recorder(async () => 0);
@@ -363,14 +363,50 @@ describe('sync-on-connect churn gates', () => {
       },
     });
 
+    // The peer answered (failedPeers: 0), so one CG's backoff-worthy round may
+    // not starve CG discovery or shared-memory sync; only peer accounting
+    // remembers the pressure (fresh: false).
+    expect(outcome).toBe('synced');
+    expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
+    expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['cg-a']]]);
+    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+  });
+
+  it('stops post-durable sync-on-connect fanout when the peer never answered and nothing progressed', async () => {
+    const refreshMetaSyncedFlags = recorder(async () => undefined);
+    const discoverContextGraphsFromStore = recorder(async () => 0);
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['cg-a'],
+      syncFromPeer: async () => emptyDetailedSync({
+        failedPeers: 1,
+        backoffWorthyFailures: 1,
+      }),
+      refreshMetaSyncedFlags,
+      discoverContextGraphsFromStore,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => {
+        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+      },
+    });
+
+    // A dead/unreachable peer must not be re-dialed by every later lane.
     expect(outcome).toBe('synced');
     expect(refreshMetaSyncedFlags.calls).toEqual([]);
     expect(discoverContextGraphsFromStore.calls).toEqual([]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([]);
-    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+    expect(syncedPeers).toEqual([]);
   });
 
-  it('records progress before stopping newly discovered CG fanout after durable pressure', async () => {
+  it('continues newly discovered CG fanout past per-CG durable pressure with progress', async () => {
     let contextGraphs = ['cg-a'];
     const refreshMetaSyncedFlags = recorder(async () => undefined);
     const discoverContextGraphsFromStore = recorder(async () => {
@@ -411,9 +447,9 @@ describe('sync-on-connect churn gates', () => {
 
     expect(outcome).toBe('synced');
     expect(syncFromPeer.calls).toEqual([[PEER_A], [PEER_A, ['cg-b']]]);
-    expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
+    expect(refreshMetaSyncedFlags.calls).toHaveLength(2);
     expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
-    expect(syncSharedMemoryFromPeer.calls).toEqual([]);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['cg-a', 'cg-b']]]);
     expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
   });
 

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -406,6 +406,38 @@ describe('sync-on-connect churn gates', () => {
     expect(syncedPeers).toEqual([]);
   });
 
+  it('continues sync-on-connect when a sibling CG proves the peer answered', async () => {
+    const refreshMetaSyncedFlags = recorder(async () => undefined);
+    const discoverContextGraphsFromStore = recorder(async () => 0);
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['unreachable-cg', 'denied-cg'],
+      syncFromPeer: async () => emptyDetailedSync({
+        failedPeers: 1,
+        deniedPhases: 1,
+        backoffWorthyFailures: 1,
+      }),
+      refreshMetaSyncedFlags,
+      discoverContextGraphsFromStore,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+    });
+
+    // `failedPeers` came from one unanswered CG, but the denial proves this
+    // peer answered another round. Discovery and SWM must still get a turn.
+    expect(outcome).toBe('synced');
+    expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
+    expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([
+      [PEER_A, ['unreachable-cg', 'denied-cg']],
+    ]);
+  });
+
   it('continues newly discovered CG fanout past per-CG durable pressure with progress', async () => {
     let contextGraphs = ['cg-a'];
     const refreshMetaSyncedFlags = recorder(async () => undefined);

--- a/packages/agent/test/sync-policy.test.ts
+++ b/packages/agent/test/sync-policy.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import {
+  DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY,
   SYNC_ADMISSION_SOURCES,
   contextGraphPriority,
   countSyncPriorityClasses,
   normalizeSyncAdmissionSource,
   normalizeSyncContextGraphPriorities,
   orderContextGraphIdsByPriority,
+  resolveSyncContextGraphPriorities,
   syncPriorityClass,
   validateSyncResponderSnapshotLimitsConfig,
 } from '../src/sync/policy.js';
@@ -39,6 +42,79 @@ describe('sync Context Graph policy', () => {
       default: 1,
       deprioritized: 1,
     });
+  });
+});
+
+describe('system Context Graph default deprioritization', () => {
+  const systemIds = Object.values(SYSTEM_CONTEXT_GRAPHS) as string[];
+
+  it('resolves defaults for every system graph the operator did not configure', () => {
+    for (const config of [undefined, {}]) {
+      const resolved = resolveSyncContextGraphPriorities(config);
+      for (const systemId of systemIds) {
+        expect(resolved[systemId]).toBe(DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY);
+      }
+      expect(Object.isFrozen(resolved)).toBe(true);
+    }
+    // The plain normalizer stays default-free: the defaults enter exactly once,
+    // at the resolve step, so a config round-trip cannot re-apply them.
+    expect(normalizeSyncContextGraphPriorities({})).toEqual({});
+  });
+
+  it('lets an explicit operator value win — positive, zero, and negative', () => {
+    const resolved = resolveSyncContextGraphPriorities({
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS]: 0,
+      [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]: 7,
+      'user-bulk': -3,
+    });
+    // Explicit 0 is a real override back to ordinary scheduling, not "unset".
+    expect(resolved[SYSTEM_CONTEXT_GRAPHS.AGENTS]).toBe(0);
+    expect(resolved[SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]).toBe(7);
+    expect(resolved['user-bulk']).toBe(-3);
+    expect(resolveSyncContextGraphPriorities({
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS]: -1,
+    })[SYSTEM_CONTEXT_GRAPHS.AGENTS]).toBe(-1);
+  });
+
+  it('orders system graphs after all user graphs, even explicitly deprioritized ones', () => {
+    const resolved = resolveSyncContextGraphPriorities({ 'user-bulk': -3 });
+    expect(orderContextGraphIdsByPriority(
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, 'user-a', SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'user-bulk', 'user-b'],
+      resolved,
+    )).toEqual([
+      'user-a', 'user-b', 'user-bulk',
+      SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+    ]);
+    // An elevated override moves a system graph ahead of default user graphs.
+    expect(orderContextGraphIdsByPriority(
+      ['user-a', SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
+      resolveSyncContextGraphPriorities({ [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]: 1 }),
+    )).toEqual([SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'user-a']);
+  });
+
+  it('sorts system graphs last through the read-side backstop for unresolved maps', () => {
+    // Callers holding a raw config (or none) must not lose the invariant.
+    expect(contextGraphPriority(undefined, SYSTEM_CONTEXT_GRAPHS.AGENTS))
+      .toBe(DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY);
+    expect(contextGraphPriority({}, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY))
+      .toBe(DEFAULT_SYSTEM_CONTEXT_GRAPH_PRIORITY);
+    expect(contextGraphPriority(undefined, 'user-a')).toBe(0);
+    expect(contextGraphPriority({ [SYSTEM_CONTEXT_GRAPHS.AGENTS]: 0 }, SYSTEM_CONTEXT_GRAPHS.AGENTS)).toBe(0);
+    expect(orderContextGraphIdsByPriority(
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, 'user-a'],
+      undefined,
+    )).toEqual(['user-a', SYSTEM_CONTEXT_GRAPHS.AGENTS]);
+  });
+
+  it('reports the defaults in the resolved class counts', () => {
+    // The "Resolved sync policy" boot log counts the RESOLVED map, so an
+    // operator can see the system graphs running deprioritized without
+    // having configured anything.
+    expect(countSyncPriorityClasses(resolveSyncContextGraphPriorities({ urgent: 5 })))
+      .toEqual({ elevated: 1, default: 0, deprioritized: systemIds.length });
+    expect(countSyncPriorityClasses(resolveSyncContextGraphPriorities({
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS]: 0,
+    }))).toEqual({ elevated: 0, default: 1, deprioritized: systemIds.length - 1 });
   });
 });
 

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -7,8 +7,14 @@ import {
 } from '../src/sync/requester/durable-sync.js';
 import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
 import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
+import {
+  MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES,
+  runOrderedContextGraphSyncs,
+} from '../src/sync/requester/ordered-sync.js';
+import { SyncBackpressureBusyError } from '../src/sync/backpressure.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { markSyncTransportFailure } from '../src/sync/error-tags.js';
+import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 
 const ctx = { kind: 'system', id: 'test', startedAt: 0 } as OperationContext;
 const noop = () => {};
@@ -234,5 +240,318 @@ describe('sync requester bailout', () => {
     expect(fetchSyncPages.calls).toEqual([
       [ctx, 'peer-a', 'pressured-swm', true, 'meta', expect.any(String), expect.any(Number)],
     ]);
+  });
+});
+
+describe('ordered fanout failure isolation', () => {
+  type RoundRecord = { contextGraphId: string; transport: boolean };
+  type Summary = { rounds: RoundRecord[]; deferred: number };
+  const emptySummary = (): Summary => ({ rounds: [], deferred: 0 });
+  const mergeSummaries = (a: Summary, b: Summary): Summary => ({
+    rounds: [...a.rounds, ...b.rounds],
+    deferred: a.deferred + b.deferred,
+  });
+
+  function runBatch(
+    contextGraphIds: string[],
+    transportFailing: (contextGraphId: string) => boolean,
+    options: {
+      admissionError?: (contextGraphId: string) => Error | undefined;
+      priorities?: Record<string, number>;
+    } = {},
+  ) {
+    return runOrderedContextGraphSyncs<Summary>({
+      work: contextGraphIds.map((contextGraphId) => ({
+        contextGraphId,
+        lane: 'durable' as const,
+        operationId: contextGraphId,
+        run: async () => ({
+          rounds: [{ contextGraphId, transport: transportFailing(contextGraphId) }],
+          deferred: 0,
+        }),
+      })),
+      priorities: options.priorities,
+      emptyResult: emptySummary,
+      runWithAdmission: async (item, work) => {
+        const error = options.admissionError?.(item.contextGraphId);
+        if (error) throw error;
+        return work();
+      },
+      merge: mergeSummaries,
+      markDeferred: (summary) => ({ ...summary, deferred: summary.deferred + 1 }),
+      isPeerTransportFailure: (part) => part.rounds.some((round) => round.transport),
+    });
+  }
+
+  it('continues past a failed Context Graph and keeps its failure in the merged summary', async () => {
+    const summary = await runBatch(
+      ['a', 'poison', 'c', 'd'],
+      (contextGraphId) => contextGraphId === 'poison',
+      { priorities: { poison: 100 } },
+    );
+
+    expect(summary.rounds.map((round) => round.contextGraphId)).toEqual(['poison', 'a', 'c', 'd']);
+    expect(summary.rounds.filter((round) => round.transport)).toEqual([
+      { contextGraphId: 'poison', transport: true },
+    ]);
+  });
+
+  it('stops the batch after consecutive peer transport failures', async () => {
+    const summary = await runBatch(
+      ['a', 'b', 'c', 'd', 'e'],
+      () => true,
+    );
+
+    expect(summary.rounds).toHaveLength(MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES);
+    expect(summary.rounds.map((round) => round.contextGraphId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('resets the transport-failure streak whenever the peer answers a round', async () => {
+    const summary = await runBatch(
+      ['a', 'b', 'ok-1', 'c', 'd', 'ok-2'],
+      (contextGraphId) => !contextGraphId.startsWith('ok'),
+    );
+
+    expect(summary.rounds).toHaveLength(6);
+  });
+
+  it('still stops the whole batch on a backpressure deferral', async () => {
+    const summary = await runBatch(
+      ['a', 'b', 'c'],
+      () => false,
+      {
+        admissionError: (contextGraphId) => (
+          contextGraphId === 'b' ? new SyncBackpressureBusyError('queue full') : undefined
+        ),
+      },
+    );
+
+    expect(summary.rounds.map((round) => round.contextGraphId)).toEqual(['a']);
+    expect(summary.deferred).toBe(1);
+  });
+});
+
+describe('lifecycle durable fanout isolation', () => {
+  function fanoutAgent(
+    admissions: string[],
+    failFor: (contextGraphId: string) => Error | undefined,
+    priorities: Record<string, number> = {},
+  ) {
+    return {
+      config: { syncContextGraphPriorities: priorities },
+      fetchSyncPages: async (
+        _ctx: unknown,
+        _peer: string,
+        contextGraphId: string,
+        _swm: boolean,
+        phase: 'data' | 'meta',
+      ) => {
+        const error = failFor(contextGraphId);
+        if (error) throw error;
+        return {
+          ...pageResult(contextGraphId, phase),
+          quads: phase === 'data'
+            ? [{
+                subject: `urn:${contextGraphId}`,
+                predicate: 'urn:predicate',
+                object: 'urn:object',
+                graph: 'urn:graph',
+              }]
+            : [],
+        };
+      },
+      processDurableBatchInWorker: async (dataQuads: Quad[], metaQuads: Quad[]) => ({
+        verifiedData: dataQuads,
+        verifiedMeta: metaQuads,
+        consumedUnpersistedMetaTriples: 0,
+        totalFetchedDataQuads: dataQuads.length,
+        totalFetchedMetaQuads: metaQuads.length,
+        rejectedKcs: 0,
+        emptyResponses: 0,
+        metaOnlyResponses: 0,
+        verifiedPrivateOnlyResponses: 0,
+        dataRejectedMissingMeta: 0,
+      }),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      syncCheckpoints: new Map(),
+      runContextGraphSyncWithBackpressure: async (
+        _ctx: unknown,
+        contextGraphId: string,
+        _lane: string,
+        _label: string,
+        work: () => Promise<unknown>,
+      ) => {
+        admissions.push(contextGraphId);
+        return work();
+      },
+      log: { info: noop, warn: noop, debug: noop },
+    };
+  }
+
+  it('keeps syncing later Context Graphs after a poison CG dies mid-stream', async () => {
+    const admissions: string[] = [];
+    const agent = fanoutAgent(
+      admissions,
+      // Untagged relay-stream death: without the transport tag there is no
+      // proof the peer never answered, so this must NOT read as peer-dead.
+      (contextGraphId) => (contextGraphId === 'poison' ? new Error('pooled stream reset') : undefined),
+      { poison: 100 },
+    );
+
+    const summary = await (LifecycleSyncMethods.prototype.runLegacyDurableSync as any).call(
+      agent,
+      ctx,
+      'peer-a',
+      ['second', 'poison', 'third'],
+      undefined,
+      undefined,
+      undefined,
+      { stopOnBackoffWorthyFailure: true },
+    );
+
+    expect(admissions).toEqual(['poison', 'second', 'third']);
+    expect(summary.insertedTriples).toBe(2);
+    expect(summary.insertedDataTriples).toBe(2);
+    expect(summary.backoffWorthyFailures).toBe(1);
+    expect(summary.failedPhases).toBe(1);
+    expect(summary.failedPeers).toBe(0);
+    expect(summary.complete).toBe(false);
+  });
+
+  it('stops dialing a peer that never responds after consecutive transport failures', async () => {
+    const admissions: string[] = [];
+    const agent = fanoutAgent(admissions, () => transportError('all multiaddr dials failed'));
+
+    const summary = await (LifecycleSyncMethods.prototype.runLegacyDurableSync as any).call(
+      agent,
+      ctx,
+      'peer-a',
+      ['cg-1', 'cg-2', 'cg-3', 'cg-4', 'cg-5'],
+      undefined,
+      undefined,
+      undefined,
+      { stopOnBackoffWorthyFailure: true },
+    );
+
+    expect(admissions).toEqual(['cg-1', 'cg-2', 'cg-3']);
+    expect(summary.failedPeers).toBe(1);
+    expect(summary.backoffWorthyFailures).toBe(MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES);
+    expect(summary.insertedTriples).toBe(0);
+    expect(summary.complete).toBe(false);
+  });
+
+  it('leaves the batch unguarded when the caller did not opt into early stopping', async () => {
+    const admissions: string[] = [];
+    const agent = fanoutAgent(admissions, () => transportError('all multiaddr dials failed'));
+
+    await (LifecycleSyncMethods.prototype.runLegacyDurableSync as any).call(
+      agent,
+      ctx,
+      'peer-a',
+      ['cg-1', 'cg-2', 'cg-3', 'cg-4', 'cg-5'],
+    );
+
+    expect(admissions).toEqual(['cg-1', 'cg-2', 'cg-3', 'cg-4', 'cg-5']);
+  });
+});
+
+describe('lifecycle shared-memory fanout isolation', () => {
+  function swmAgent(
+    admissions: string[],
+    failFor: (contextGraphId: string) => Error | undefined,
+  ) {
+    return {
+      config: { syncContextGraphPriorities: {} },
+      store: {},
+      listSubGraphs: async () => [],
+      createContextGraphSyncDeadline: () => Date.now() + 1_000,
+      fetchSyncPages: async (
+        _ctx: unknown,
+        _peer: string,
+        contextGraphId: string,
+        _swm: boolean,
+        phase: string,
+      ) => {
+        const error = failFor(contextGraphId);
+        if (error) throw error;
+        return {
+          ...pageResult(contextGraphId, phase),
+          nextOffset: 1,
+        };
+      },
+      getOrCreateSyncVerifyWorker: () => ({
+        processSharedMemoryBatch: async () => ({
+          verifiedData: [],
+          verifiedMeta: [],
+          totalFetchedDataQuads: 0,
+          totalFetchedMetaQuads: 0,
+          droppedDataTriples: 0,
+          emptyResponses: 1,
+          entityCreators: [],
+        }),
+      }),
+      runContextGraphSyncWithBackpressure: async (
+        _ctx: unknown,
+        contextGraphId: string,
+        _lane: string,
+        _label: string,
+        work: () => Promise<unknown>,
+      ) => {
+        admissions.push(contextGraphId);
+        return work();
+      },
+      syncCheckpoints: new Map(),
+      workspaceOwnedEntities: new Map(),
+      log: { info: noop, warn: noop, debug: noop },
+    };
+  }
+
+  function swmPlan(contextGraphIds: string[]) {
+    return {
+      publicContextGraphIds: contextGraphIds,
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: contextGraphIds,
+    };
+  }
+
+  it('keeps syncing later Context Graphs after a poison SWM round the peer answered', async () => {
+    const admissions: string[] = [];
+    const contextGraphIds = ['poison', 'second', 'third'];
+    const agent = swmAgent(
+      admissions,
+      (contextGraphId) => (contextGraphId === 'poison' ? new Error('pooled stream reset') : undefined),
+    );
+
+    const summary = await (
+      LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailed as any
+    ).call(agent, 'peer-a', contextGraphIds, {
+      stopOnBackoffWorthyFailure: true,
+      sharedMemorySyncPlan: swmPlan(contextGraphIds),
+    });
+
+    expect(admissions).toEqual(contextGraphIds);
+    expect(summary.backoffWorthyFailures).toBe(1);
+    expect(summary.failedPhases).toBe(1);
+    expect(summary.failedPeers).toBe(0);
+    // Both clean CGs completed both their phases (meta + data).
+    expect(summary.completedPhases).toBe(4);
+    expect(summary.checkpointAdvances).toBe(4);
+  });
+
+  it('stops the SWM fanout after consecutive unanswered transport failures', async () => {
+    const admissions: string[] = [];
+    const contextGraphIds = ['cg-1', 'cg-2', 'cg-3', 'cg-4'];
+    const agent = swmAgent(admissions, () => transportError('connection reset'));
+
+    const summary = await (
+      LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailed as any
+    ).call(agent, 'peer-a', contextGraphIds, {
+      stopOnBackoffWorthyFailure: true,
+      sharedMemorySyncPlan: swmPlan(contextGraphIds),
+    });
+
+    expect(admissions).toEqual(['cg-1', 'cg-2', 'cg-3']);
+    expect(summary.failedPeers).toBe(1);
+    expect(summary.backoffWorthyFailures).toBe(MAX_CONSECUTIVE_PEER_TRANSPORT_FAILURES);
   });
 });

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -197,6 +197,40 @@ describe('sync requester bailout', () => {
     ))).toBe(false);
   });
 
+  it('uses the reserved data window after a meta phase timeout', async () => {
+    const fetchSyncPages = recorder(async ({
+      contextGraphId,
+      phase,
+    }: DurableSyncFetchRequest) => phase === 'meta'
+      ? pageResult(contextGraphId, phase, { completed: false, timedOut: true })
+      : pageResult(contextGraphId, phase));
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: ['slow-cg', 'next-cg'],
+      stopOnBackoffWorthyFailure: true,
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages,
+      processDurableBatchInWorker: async () => durableProcessResult(),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(summary.timedOutPhases).toBe(1);
+    expect(fetchSyncPages.calls.map(([request]) => ({
+      contextGraphId: request.contextGraphId,
+      phase: request.phase,
+    }))).toEqual([
+      { contextGraphId: 'slow-cg', phase: 'meta' },
+      { contextGraphId: 'slow-cg', phase: 'data' },
+    ]);
+  });
+
   it('stops shared-memory context-graph fanout after a backoff-worthy transport failure', async () => {
     const fetchSyncPages = recorder(async (
       _ctx: OperationContext,

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { OperationContext } from '@origintrail-official/dkg-core';
+import { SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
   runDurableSync,
@@ -208,7 +208,7 @@ describe('sync requester bailout', () => {
     const summary = await runDurableSync({
       ctx,
       remotePeerId: 'peer-a',
-      contextGraphIds: ['slow-cg', 'next-cg'],
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'next-cg'],
       stopOnBackoffWorthyFailure: true,
       durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
       fetchSyncPages,
@@ -226,8 +226,8 @@ describe('sync requester bailout', () => {
       contextGraphId: request.contextGraphId,
       phase: request.phase,
     }))).toEqual([
-      { contextGraphId: 'slow-cg', phase: 'meta' },
-      { contextGraphId: 'slow-cg', phase: 'data' },
+      { contextGraphId: SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, phase: 'meta' },
+      { contextGraphId: SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, phase: 'data' },
     ]);
   });
 

--- a/packages/agent/test/sync-requester-priority.test.ts
+++ b/packages/agent/test/sync-requester-priority.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createOperationContext, PROTOCOL_SYNC_CHANGELOG } from '@origintrail-official/dkg-core';
+import { createOperationContext, PROTOCOL_SYNC_CHANGELOG, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import {
   runDurableSync,
   type DurableSyncFetchRequest,
@@ -121,6 +121,32 @@ describe('requester per-CG priority admission', () => {
     );
 
     expect(admissions).toEqual(['high', 'default', 'low']);
+  });
+
+  it('admits system Context Graphs last so their failures cannot starve user graphs', async () => {
+    // System graphs are the observed poison transfers in the per-peer fanout,
+    // and the fanout stops on the first failure — so they must run after every
+    // user graph even when the agent config never mentions them. An explicit
+    // operator entry (0 here) restores ordinary scheduling.
+    const admissions: string[] = [];
+    const agent = lifecycleAgent(
+      { [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]: 0 },
+      async (contextGraphId, work) => {
+        admissions.push(contextGraphId);
+        return work();
+      },
+    );
+
+    await (LifecycleSyncMethods.prototype.runLegacyDurableSync as any).call(
+      agent,
+      ctx,
+      'peer',
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, 'user-a', SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'user-b'],
+    );
+
+    expect(admissions).toEqual([
+      'user-a', SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'user-b', SYSTEM_CONTEXT_GRAPHS.AGENTS,
+    ]);
   });
 
   it('preserves completed durable progress when a later admission is deferred', async () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -630,7 +630,11 @@ export interface DkgConfig {
   syncGlobalQueueLimit?: number;
   /** Retained sync responder snapshot limits (rows and estimated bytes). */
   syncResponderSnapshotLimits?: SyncResponderSnapshotLimitsConfig;
-  /** Local sync scheduling priority by Context Graph ID. */
+  /**
+   * Local sync scheduling priority by Context Graph ID. Higher runs first.
+   * System Context Graphs default to a deprioritized priority so they run
+   * last; an explicit entry here (including 0) overrides that default.
+   */
   syncContextGraphPriorities?: SyncContextGraphPriorityConfig;
   /** StorageACK handler deadline override in milliseconds. Env DKG_STORAGE_ACK_HANDLER_DEADLINE_MS wins. */
   storageAckHandlerDeadlineMs?: number;

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -574,6 +574,28 @@ export class MessageStreamPool {
   }
 
   /**
+   * Close the stream held for `peerIdStr` once it is quiescent.
+   * Returns `true` when a live stream existed and was closed;
+   * `false` when the peer holds no stream OR the stream still has
+   * in-flight / queued work.
+   *
+   * The busy case is deliberately left alone rather than force-
+   * aborted: rejecting live requests here would reproduce the exact
+   * all-in-flight-requests-die failure the caller is trying to route
+   * around. Callers that want the stream gone stop feeding it new
+   * sends and invoke this again on their next pass — an active
+   * stream drains naturally (or hits the pool's own idle/reset
+   * teardown) and the retire lands then.
+   */
+  async closePeerIfIdle(peerIdStr: string, reason = 'peer stream retired'): Promise<boolean> {
+    const state = this.peers.get(peerIdStr);
+    if (!state || state.closed) return false;
+    if (state.inFlight !== null || state.queue.length > 0) return false;
+    await this.closePeer(state, reason);
+    return true;
+  }
+
+  /**
    * Close every pooled stream and reject all pending requests.
    * Safe to call multiple times. After close, further `send()` calls
    * throw {@link PooledStreamResetError}.

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -638,7 +638,37 @@ export class ProtocolRouter {
     // is exhausted.
     const overlay = this.pooledByLogical.get(protocolId);
     const memoizedVariant = this.peerWireVariantFor(peerIdStr, protocolId);
-    if (overlay && memoizedVariant !== 'one-shot') {
+    // Relay-only gate for the pooled wire. The pooled variant
+    // multiplexes every request for a peer onto ONE long-lived
+    // substream; over a circuit-relay connection that substream's
+    // life is bounded by the relay's reservation churn (~300 s), and
+    // one request timeout aborts the shared stream — rejecting every
+    // in-flight and queued request at once. Observed on a 10.0.12
+    // Base-mainnet edge node (2026-08-06): sync to a NAT-only peer
+    // reachable exclusively via circuit relays died 4/4 with "pooled
+    // stream reset: request aborted/timeout" while one-shot streams
+    // to the same peer succeeded immediately. So: use the pool only
+    // when the peer has at least one DIRECT connection. Re-evaluated
+    // per send — a later direct connection (e.g. DCUtR upgrade)
+    // re-enables the pool with no memo to clear, and a pool stream
+    // already held for a now-relay-only peer is retired once
+    // quiescent instead of being reused. Cold peers (no connections
+    // at all) keep the pooled path: there is no relayed connection
+    // to observe yet and the pool's own dial may come up direct.
+    // Requester-side selection only — responders that don't
+    // advertise the pooled wire already fall back via
+    // multistream-select.
+    let usePooledWire = overlay !== undefined && memoizedVariant !== 'one-shot';
+    if (usePooledWire && overlay && this.peerHasOnlyRelayedConnections(peerIdStr)) {
+      usePooledWire = false;
+      // Fire-and-forget: retiring the held stream must not delay or
+      // fail this send; if the stream is still busy the retire is a
+      // no-op and a later send's pass lands it once drained.
+      overlay.pool
+        .closePeerIfIdle(peerIdStr, 'relay-only peer: pooled wire bypassed')
+        .catch(() => undefined);
+    }
+    if (overlay && usePooledWire) {
       try {
         const remainingForPool = Math.max(0, timeoutMs - (Date.now() - overallStartedAt));
         const response = await overlay.pool.send(peerIdStr, data, {
@@ -1024,6 +1054,80 @@ export class ProtocolRouter {
     }
     throw lastErr;
   }
+
+  /**
+   * True when the peer currently has at least one OPEN connection and
+   * every one of them rides a circuit relay. Three shapes:
+   *
+   *   * a direct connection is present → false (pooling is safe);
+   *   * open connections exist, all relayed → true;
+   *   * no open connections at all → false — nothing observed yet, so
+   *     the caller keeps its existing behavior rather than penalizing
+   *     a cold peer for connections it doesn't have.
+   *
+   * Walks the RAW connection table and filters by `remotePeer`
+   * ourselves — same Window D rationale as the one-shot fast path
+   * (libp2p's peerId-keyed lookup can return `[]` while the raw walk
+   * shows live matching connections). Matching is by peerId string:
+   * the router, the pool, and libp2p's `PeerId.toString()` all use
+   * the same canonical text form as the peer key.
+   */
+  private peerHasOnlyRelayedConnections(peerIdStr: string): boolean {
+    let all: ReadonlyArray<ObservedConnection>;
+    try {
+      all = this.node.libp2p.getConnections() as ReadonlyArray<ObservedConnection>;
+    } catch {
+      return false;
+    }
+    let sawOpenRelayed = false;
+    for (const conn of all) {
+      let matches = false;
+      try {
+        matches = conn.remotePeer?.toString() === peerIdStr;
+      } catch {
+        matches = false;
+      }
+      if (!matches) continue;
+      if (conn.status && conn.status !== 'open') continue;
+      if (!isRelayedConnection(conn)) return false;
+      sawOpenRelayed = true;
+    }
+    return sawOpenRelayed;
+  }
+}
+
+/**
+ * Structural subset of a libp2p `Connection` used for transport-path
+ * classification. Kept minimal (and every access defensive) for the
+ * same reason as {@link ReusableConnection}: unit tests pass fakes
+ * without re-exporting libp2p internals.
+ */
+interface ObservedConnection {
+  status?: string;
+  limits?: unknown;
+  remotePeer?: { toString: () => string };
+  remoteAddr?: { toString: () => string };
+}
+
+/**
+ * True when the connection reaches the peer via a circuit relay.
+ * `remoteAddr` containing the `/p2p-circuit` component is the
+ * authoritative signal — a direct connection's remote address never
+ * carries it. Fall back to libp2p's limited-connection marker when
+ * the address is unavailable (limited ⇒ circuit-relay-v2 in our
+ * transport set); absent both signals, classify as direct so the
+ * caller defaults to the status quo.
+ */
+function isRelayedConnection(conn: ObservedConnection): boolean {
+  try {
+    const addr = conn.remoteAddr?.toString();
+    if (typeof addr === 'string' && addr.length > 0) {
+      return addr.includes('/p2p-circuit');
+    }
+  } catch {
+    // fall through to the limits marker
+  }
+  return Boolean(conn.limits);
 }
 
 /**

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -593,6 +593,53 @@ describe('MessageStreamPool', () => {
     expect(POOLED_MESSAGE_PROTOCOL).toBe('/dkg/10.0.2/message');
   });
 
+  // closePeerIfIdle exists so a caller that has stopped routing sends
+  // through the pool for a peer (e.g. the peer is currently reachable
+  // only via circuit relays) can retire the held stream WITHOUT
+  // rejecting live work — force-closing a busy stream would reproduce
+  // the exact all-in-flight-requests-die teardown the caller is
+  // routing around.
+  it('closePeerIfIdle retires a quiescent stream but leaves an in-flight one alone', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    // No stream held yet — nothing to retire.
+    await expect(pool.closePeerIfIdle(PEER_A)).resolves.toBe(false);
+
+    const pending = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    await flush();
+
+    // Request in flight — retire must refuse and leave it untouched.
+    await expect(pool.closePeerIfIdle(PEER_A)).resolves.toBe(false);
+    const stream = node.state.streams.get(PEER_A)!;
+    stream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    expect(new TextDecoder().decode(await pending)).toBe('ok');
+    await flush();
+
+    // Quiescent — retire closes the held stream and drops the peer.
+    await expect(pool.closePeerIfIdle(PEER_A)).resolves.toBe(true);
+    expect(pool.size()).toBe(0);
+    expect(stream.writeStatus).toBe('closed');
+
+    // Next send re-dials from scratch rather than reusing the retired
+    // stream.
+    const second = pool.send(PEER_A, new TextEncoder().encode('again'));
+    await flush();
+    await flush();
+    expect(node.state.dials.get(PEER_A)).toBe(2);
+    node.state.streams
+      .get(PEER_A)!
+      .feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok2')));
+    expect(new TextDecoder().decode(await second)).toBe('ok2');
+
+    await pool.close();
+  });
+
   it('aborting an in-flight request tears down the stream so the pool does not stall (Codex #560 round 1)', async () => {
     const node = makeFakeNode();
     const pool = new MessageStreamPool(node, {

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -862,6 +862,227 @@ describe('ProtocolRouter', () => {
     });
   });
 
+  // The pooled wire multiplexes every request for a peer onto one
+  // long-lived substream. Over a circuit-relay connection the relay's
+  // reservation churn bounds that substream's life and one request
+  // timeout kills every in-flight request with it — observed as
+  // deterministic "pooled stream reset" against a NAT-only peer whose
+  // one-shot streams succeeded immediately (10.0.12 Base-mainnet edge
+  // node, 2026-08-06). The router therefore bypasses the pool for any
+  // send whose peer currently has ONLY relayed connections, re-checking
+  // per send so a later direct connection re-enables pooling.
+  describe('send() pooled-wire relay-only bypass', () => {
+    const FAKE_PEER_ID = '12D3KooWBzj7Hg2cKCdsKL6QcjC5UbLztKTvzCZQHaT4P4ZyJEAA';
+    const PROTOCOL_ID = '/dkg/test/1.0.0';
+
+    function makeStubStream(response: Uint8Array) {
+      let returned = false;
+      return {
+        writeStatus: 'open' as const,
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => undefined,
+        async *[Symbol.asyncIterator]() {
+          if (!returned) {
+            returned = true;
+            yield response;
+          }
+        },
+      };
+    }
+
+    function makeConn(opts: {
+      remoteAddr: string;
+      limits?: unknown;
+      remotePeerStr?: string;
+      newStream?: () => Promise<unknown>;
+    }) {
+      const remotePeerStr = opts.remotePeerStr ?? FAKE_PEER_ID;
+      return {
+        status: 'open' as const,
+        limits: opts.limits,
+        remotePeer: {
+          equals: (other: unknown) => String(other) === remotePeerStr,
+          toString: () => remotePeerStr,
+        },
+        remoteAddr: { toString: () => opts.remoteAddr },
+        newStream:
+          opts.newStream ??
+          (async () => {
+            throw new Error('newStream not expected on this connection');
+          }),
+      };
+    }
+
+    function makeRouterWithPool(opts: {
+      connections: () => ReadonlyArray<unknown>;
+      poolSend: () => Promise<Uint8Array>;
+      onClosePeerIfIdle?: (peerIdStr: string) => void;
+      dialBehavior?: () => Promise<unknown>;
+    }): ProtocolRouter {
+      const node = {
+        libp2p: {
+          getConnections: () => opts.connections(),
+          dialProtocol:
+            opts.dialBehavior ??
+            (async () => {
+              throw new Error('dialProtocol not expected');
+            }),
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+      (router as any).pooledByLogical.set(PROTOCOL_ID, {
+        logicalProtocolId: PROTOCOL_ID,
+        wireProtocolId: '/dkg/10.0.2/message',
+        pool: {
+          send: opts.poolSend,
+          closePeerIfIdle: async (peerIdStr: string) => {
+            opts.onClosePeerIfIdle?.(peerIdStr);
+            return false;
+          },
+        },
+      });
+      return router;
+    }
+
+    it('bypasses the pool for a relayed-only peer — one-shot path runs, pool is never dialed', async () => {
+      let poolSends = 0;
+      let newStreamCalls = 0;
+      const retired: string[] = [];
+      const relayedConn = makeConn({
+        remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${FAKE_PEER_ID}`,
+        limits: { bytes: 1024 * 1024 },
+        newStream: async () => {
+          newStreamCalls += 1;
+          return makeStubStream(new Uint8Array([0x42])) as any;
+        },
+      });
+      const router = makeRouterWithPool({
+        connections: () => [relayedConn],
+        poolSend: async () => {
+          poolSends += 1;
+          throw new Error('pool must not be used for a relay-only peer');
+        },
+        onClosePeerIfIdle: (p) => { retired.push(p); },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+
+      expect(out).toEqual(new Uint8Array([0x42]));
+      expect(poolSends).toBe(0);
+      // One-shot path served the send over the relayed connection
+      // (fast-path reuse — same wire shape that succeeded in the field
+      // while pooled sends reset).
+      expect(newStreamCalls).toBe(1);
+      // A pool stream already held for the peer must be retired (once
+      // quiescent) rather than reused on the relayed connection.
+      expect(retired).toEqual([FAKE_PEER_ID]);
+    });
+
+    it('keeps the pooled path when a direct connection is present alongside a relayed one', async () => {
+      let poolSends = 0;
+      let newStreamCalls = 0;
+      const countNewStream = async (): Promise<unknown> => {
+        newStreamCalls += 1;
+        throw new Error('one-shot path must not run when pooled path is selected');
+      };
+      const router = makeRouterWithPool({
+        connections: () => [
+          makeConn({
+            remoteAddr: '/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit',
+            limits: { bytes: 1024 * 1024 },
+            newStream: countNewStream,
+          }),
+          makeConn({ remoteAddr: '/ip4/1.2.3.4/tcp/4001', newStream: countNewStream }),
+        ],
+        poolSend: async () => {
+          poolSends += 1;
+          return new Uint8Array([0x07]);
+        },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+
+      expect(out).toEqual(new Uint8Array([0x07]));
+      expect(poolSends).toBe(1);
+      expect(newStreamCalls).toBe(0);
+    });
+
+    it('re-enables pooling when a direct connection appears after a relayed-only send', async () => {
+      let poolSends = 0;
+      const connections: unknown[] = [
+        makeConn({
+          remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${FAKE_PEER_ID}`,
+          limits: { bytes: 1024 * 1024 },
+          newStream: async () => makeStubStream(new Uint8Array([0x11])) as any,
+        }),
+      ];
+      const router = makeRouterWithPool({
+        connections: () => connections,
+        poolSend: async () => {
+          poolSends += 1;
+          return new Uint8Array([0x22]);
+        },
+      });
+
+      // Relayed-only: one-shot serves the send; crucially the bypass
+      // must NOT pin the peer's wire memo to one-shot — the peer DOES
+      // speak the pooled wire, only the current transport path is bad.
+      const first = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+      expect(first).toEqual(new Uint8Array([0x11]));
+      expect(poolSends).toBe(0);
+
+      // DCUtR (or a fresh dial) lands a direct connection.
+      connections.push(makeConn({ remoteAddr: '/ip4/1.2.3.4/tcp/4001' }));
+
+      const second = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([2]), 5000);
+      expect(second).toEqual(new Uint8Array([0x22]));
+      expect(poolSends).toBe(1);
+    });
+
+    it('keeps the pooled path for a cold peer with no connections at all', async () => {
+      let poolSends = 0;
+      const router = makeRouterWithPool({
+        connections: () => [],
+        poolSend: async () => {
+          poolSends += 1;
+          return new Uint8Array([0x33]);
+        },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+
+      expect(out).toEqual(new Uint8Array([0x33]));
+      expect(poolSends).toBe(1);
+    });
+
+    it('ignores relayed connections that belong to a different peer', async () => {
+      let poolSends = 0;
+      const router = makeRouterWithPool({
+        connections: () => [
+          makeConn({
+            remoteAddr: '/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit',
+            limits: { bytes: 1024 * 1024 },
+            remotePeerStr: '12D3KooWSomeOtherPeer00000000000000000000000000000000zzzz',
+          }),
+        ],
+        poolSend: async () => {
+          poolSends += 1;
+          return new Uint8Array([0x44]);
+        },
+      });
+
+      const out = await router.send(FAKE_PEER_ID, PROTOCOL_ID, new Uint8Array([1]), 5000);
+
+      expect(out).toEqual(new Uint8Array([0x44]));
+      expect(poolSends).toBe(1);
+    });
+  });
+
   describe('composeAbortSignals', () => {
     it('manual fallback removes both listeners after either source aborts', () => {
       const originalAny = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;


### PR DESCRIPTION
## Summary

Promotes the following independently reviewed sync fixes from `main` to `testnet-canary`:

- #2115: default-deprioritize system Context Graphs so user-selected graphs run first
- #2116: isolate per-CG fanout failures so one graph cannot abort sibling work for the same peer
- #2117: bypass the pooled sync wire when a peer is reachable only through circuit relay
- #2118: give durable metadata and data phases independent budgets, while limiting the short metadata cap to system graphs

No configuration defaults are changed and the dormant RFC-64 catalog feature is not activated by this promotion. The runtime effect is confined to durable-sync requester scheduling, failure accounting, deadlines, and relay transport selection.

## Validation

Validated on the exact current `testnet-canary` composition plus all four PR heads and follow-ups:

- complete agent unit lane: 170 files, 2,425 passed, 5 skipped, 0 failed
- focused sync regression lane: 114 passed
- core relay/transport lane: 98 passed
- agent build, type tests, and package-root tests: passed
- full 17-package dependency build: passed

Two additional correctness gaps found during combined review were fixed before merge: sibling response evidence is now preserved in aggregate peer accounting, and a metadata timeout no longer suppresses the data phase.

GitHub Actions is currently in a declared critical outage; observed red jobs failed during runner setup/action download before repository code executed. The exact candidate was therefore validated locally before this promotion.

## Canary gate

After promotion, verify the exact SHA on all four testnet beacons, inspect backpressure and logs, then run bounded multi-CG SWM and VM sync/query smoke tests over DKG transport.