### PR TITLE
fix(prime-agent): terminate failed provider turns

### DIFF
--- a/packages/adapter-prime-agent/extension/src/extension.ts
+++ b/packages/adapter-prime-agent/extension/src/extension.ts
@@ -45,10 +45,17 @@ interface SessionManagerLike {
 }
 interface ExtensionCtxLike {
   sessionManager: SessionManagerLike;
+  abort?(): void;
 }
 interface MessageUpdateEvent {
-  assistantMessageEvent?: { type?: string; text?: string; delta?: string };
-  message?: { role?: string; content?: unknown };
+  assistantMessageEvent?: {
+    type?: string;
+    text?: string;
+    delta?: string;
+    reason?: string;
+    error?: { errorMessage?: string; stopReason?: string };
+  };
+  message?: { role?: string; content?: unknown; errorMessage?: string; stopReason?: string };
 }
 interface ExtensionApiLike {
   on(event: string, handler: (event: any, ctx: ExtensionCtxLike) => unknown): void;
@@ -60,6 +67,10 @@ interface ExtensionApiLike {
 
 const ADAPTER_STATE_DIRNAME = '.dkg-adapter-prime-agent';
 const TURN_IDLE_TIMEOUT_MS = 15 * 60_000; // matches the daemon's channel timeout
+// Deliberately below the daemon's 60-minute transport backstop so the bridge
+// emits a terminal verdict and releases its one-turn guard before the daemon
+// has to abort the HTTP connection.
+const TURN_HARD_TIMEOUT_MS = 55 * 60_000;
 // A dead-pid descriptor younger than this is never pruned: it may be a live
 // republication that landed (atomic rename, fresh mtime) between our read and
 // the rm. Mirrored in the daemon-side reader (`session-registry.ts`).
@@ -122,15 +133,54 @@ interface PendingTurn {
   correlationId: string;
   chunks: string[];
   subscribers: Set<ServerResponse>;
-  settled: boolean;
+  responseSettled: boolean;
   resolve: (outcome: TurnOutcome) => void;
-  timer: NodeJS.Timeout;
+  idleTimer: NodeJS.Timeout;
+  hardTimer: NodeJS.Timeout;
 }
 
 interface TurnOutcome {
   text: string;
   timedOut?: true;
   error?: string;
+  errorCode?: PrimeAgentTurnErrorCode;
+}
+
+type PrimeAgentTurnErrorCode =
+  | 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'
+  | 'PRIME_AGENT_PROVIDER_ERROR'
+  | 'PRIME_AGENT_TURN_ABORTED'
+  | 'PRIME_AGENT_TURN_TIMEOUT'
+  | 'PRIME_AGENT_DELIVERY_FAILED';
+
+interface SanitizedTurnFailure {
+  code: PrimeAgentTurnErrorCode;
+  message: string;
+}
+
+function sanitizedProviderFailure(event: MessageUpdateEvent): SanitizedTurnFailure {
+  const assistantEvent = event.assistantMessageEvent;
+  const raw = [assistantEvent?.error?.errorMessage, event.message?.errorMessage]
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n');
+  if (
+    /\bunauthori[sz]ed\b|\bauthentication failed\b|\binvalid[_ ]api[_ ]key\b|\bincorrect api key\b|\b(?:http|status(?: code)?)\s*[:=]?\s*401\b/i.test(raw)
+  ) {
+    return {
+      code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+      message: 'Prime Agent provider authentication failed. Check the configured provider credentials.',
+    };
+  }
+  if (assistantEvent?.reason === 'aborted' || event.message?.stopReason === 'aborted') {
+    return {
+      code: 'PRIME_AGENT_TURN_ABORTED',
+      message: 'Prime Agent turn was aborted.',
+    };
+  }
+  return {
+    code: 'PRIME_AGENT_PROVIDER_ERROR',
+    message: 'Prime Agent provider request failed.',
+  };
 }
 
 class SessionBridge {
@@ -143,17 +193,24 @@ class SessionBridge {
   #startedAt: string | undefined;
   #turn: PendingTurn | undefined;
   #agentActive = false;
+  // A provider error is a terminal stream event, but Prime may still emit the
+  // corresponding agent_end shortly afterwards. If a new bridge request lands
+  // in that small window, the old agent_end must not settle the new request.
+  #discardNextAgentEnd = false;
+  #abortActiveAgent: (() => void) | undefined;
   #closed = false;
   readonly #turnIdleTimeoutMs: number;
+  readonly #turnHardTimeoutMs: number;
 
   constructor(
     pi: ExtensionApiLike,
     sessionId: string,
-    options: { turnIdleTimeoutMs?: number } = {},
+    options: { turnIdleTimeoutMs?: number; turnHardTimeoutMs?: number } = {},
   ) {
     this.#pi = pi;
     this.#sessionId = sessionId;
     this.#turnIdleTimeoutMs = options.turnIdleTimeoutMs ?? TURN_IDLE_TIMEOUT_MS;
+    this.#turnHardTimeoutMs = options.turnHardTimeoutMs ?? TURN_HARD_TIMEOUT_MS;
   }
 
   get sessionId(): string {
@@ -294,9 +351,11 @@ class SessionBridge {
     this.#closed = true;
     this.#cleanupDescriptor();
     if (this.#turn) {
-      this.#resolveTurn({ text: this.#turn.chunks.join(''), error: 'Bridge stopped' });
-      this.#turn = undefined;
+      this.#settleResponse({ text: this.#turn.chunks.join(''), error: 'Bridge stopped' });
+      this.#clearTurn(this.#turn);
     }
+    this.#agentActive = false;
+    this.#abortActiveAgent = undefined;
     const server = this.#server;
     this.#server = undefined;
     if (!server) return;
@@ -367,12 +426,27 @@ class SessionBridge {
         correlationId,
         chunks: [],
         subscribers: new Set(),
-        settled: false,
+        responseSettled: false,
         resolve,
-        timer: undefined as unknown as NodeJS.Timeout,
+        idleTimer: undefined as unknown as NodeJS.Timeout,
+        hardTimer: undefined as unknown as NodeJS.Timeout,
       };
       this.#turn = turn;
       this.#armIdleTimer(turn);
+      turn.hardTimer = setTimeout(() => {
+        if (this.#turn !== turn) return;
+        const abort = this.#abortActiveAgent;
+        this.#failTurn({
+          code: 'PRIME_AGENT_TURN_TIMEOUT',
+          message: `Prime Agent turn exceeded the ${this.#turnHardTimeoutMs}ms hard limit.`,
+        });
+        try {
+          abort?.();
+        } catch {
+          /* the bridge state is already safely released */
+        }
+      }, this.#turnHardTimeoutMs);
+      turn.hardTimer.unref?.();
     });
 
     if (stream) {
@@ -396,14 +470,28 @@ class SessionBridge {
     // Requests observed while the session is active are rejected above. Use a
     // follow-up for the remaining race window so a locally-started turn is
     // never interrupted by a remote UI message.
-    this.#pi.sendUserMessage(text, { deliverAs: 'followUp' });
+    try {
+      this.#pi.sendUserMessage(text, { deliverAs: 'followUp' });
+    } catch {
+      this.#failTurn({
+        code: 'PRIME_AGENT_DELIVERY_FAILED',
+        message: 'Prime Agent rejected the local message before starting the turn.',
+      });
+    }
 
     const outcome = await done;
 
     if (outcome.error || outcome.timedOut) {
       const error = outcome.error ?? `Prime Agent turn idle for ${this.#turnIdleTimeoutMs}ms`;
       if (stream) {
-        writeSse(res, { type: 'error', error, correlationId });
+        writeSse(res, {
+          type: 'error',
+          error,
+          ...(outcome.errorCode ? { code: outcome.errorCode } : {}),
+          source: 'prime-agent-channel',
+          retryable: false,
+          correlationId,
+        });
         writeSse(res, {
           type: 'final',
           text: outcome.text,
@@ -415,6 +503,9 @@ class SessionBridge {
       } else {
         this.#json(res, outcome.timedOut ? 504 : 503, {
           error,
+          ...(outcome.errorCode ? { code: outcome.errorCode } : {}),
+          source: 'prime-agent-channel',
+          retryable: false,
           text: outcome.text,
           correlationId,
           sessionId: this.#sessionId,
@@ -436,9 +527,17 @@ class SessionBridge {
 
   onMessageUpdate(event: MessageUpdateEvent): void {
     const turn = this.#turn;
-    if (!turn || turn.settled) return;
     const assistantEvent = event.assistantMessageEvent;
     const eventType = assistantEvent?.type;
+    // Prime's provider stream contract declares `error` terminal. Treat it as
+    // authoritative even when Prime fails to emit the higher-level agent_end:
+    // finish the HTTP/SSE turn, clear admission, and never expose the raw
+    // provider payload (which may contain credential-bearing diagnostics).
+    if (eventType === 'error') {
+      this.#failTurn(sanitizedProviderFailure(event));
+      return;
+    }
+    if (!turn || turn.responseSettled) return;
     // At the pinned Prime Agent API, only text_delta is user-visible answer
     // text. Thinking/tool-call deltas still prove liveness, but must never leak
     // into the response transcript.
@@ -458,8 +557,12 @@ class SessionBridge {
     }
   }
 
-  onAgentStart(): void {
+  onAgentStart(ctx?: ExtensionCtxLike): void {
+    // If a failed turn never emitted agent_end, this start necessarily belongs
+    // to the successor and supersedes the stale-end guard.
+    if (this.#discardNextAgentEnd) this.#discardNextAgentEnd = false;
     this.#agentActive = true;
+    this.#abortActiveAgent = typeof ctx?.abort === 'function' ? () => ctx.abort!() : undefined;
     // Election stamp, once per turn — agent_start fires for locally-typed and
     // bridge-injected turns alike, so whichever session the operator actually
     // uses wins routing. Not per message_update: thousands of delta events per
@@ -474,31 +577,62 @@ class SessionBridge {
   }
 
   onAgentEnd(): void {
+    if (this.#discardNextAgentEnd) {
+      this.#discardNextAgentEnd = false;
+      this.#agentActive = false;
+      this.#abortActiveAgent = undefined;
+      return;
+    }
     this.#agentActive = false;
+    this.#abortActiveAgent = undefined;
     const turn = this.#turn;
     if (!turn) return;
-    if (!turn.settled) this.#resolveTurn({ text: turn.chunks.join('') });
-    clearTimeout(turn.timer);
-    this.#turn = undefined;
+    if (!turn.responseSettled) this.#settleResponse({ text: turn.chunks.join('') });
+    this.#clearTurn(turn);
   }
 
   #armIdleTimer(turn: PendingTurn): void {
-    clearTimeout(turn.timer);
-    turn.timer = setTimeout(() => {
-      if (this.#turn !== turn || turn.settled) return;
+    clearTimeout(turn.idleTimer);
+    turn.idleTimer = setTimeout(() => {
+      if (this.#turn !== turn || turn.responseSettled) return;
       // Resolve the HTTP request visibly as a timeout, but retain #turn until
-      // the real agent_end. This prevents late deltas from bleeding into a new
-      // request while the old Prime Agent turn is still running.
-      this.#resolveTurn({ text: turn.chunks.join(''), timedOut: true });
+      // agent_end or the separate hard limit. This prevents late deltas from
+      // bleeding into a new request while a merely-slow turn is still running,
+      // while also guaranteeing that the session cannot stay busy forever.
+      this.#settleResponse({ text: turn.chunks.join(''), timedOut: true });
     }, this.#turnIdleTimeoutMs);
   }
 
-  #resolveTurn(outcome: TurnOutcome): void {
+  #settleResponse(outcome: TurnOutcome): void {
     const turn = this.#turn;
-    if (!turn || turn.settled) return;
-    turn.settled = true;
-    clearTimeout(turn.timer);
+    if (!turn || turn.responseSettled) return;
+    turn.responseSettled = true;
+    clearTimeout(turn.idleTimer);
     turn.resolve(outcome);
+  }
+
+  #clearTurn(turn: PendingTurn): void {
+    clearTimeout(turn.idleTimer);
+    clearTimeout(turn.hardTimer);
+    if (this.#turn === turn) this.#turn = undefined;
+  }
+
+  #failTurn(failure: SanitizedTurnFailure): void {
+    const turn = this.#turn;
+    if (turn) {
+      this.#settleResponse({
+        text: turn.chunks.join(''),
+        error: failure.message,
+        errorCode: failure.code,
+      });
+      this.#clearTurn(turn);
+    }
+    // The provider `error` event is terminal, so accepting the next request is
+    // safe. Remember that one stale agent_end may still arrive and must be
+    // consumed without touching that successor request.
+    this.#discardNextAgentEnd = true;
+    this.#agentActive = false;
+    this.#abortActiveAgent = undefined;
   }
 
   #json(res: ServerResponse, status: number, body: unknown): void {
@@ -560,8 +694,8 @@ export default function dkgBridgeExtension(pi: ExtensionApiLike): void {
     bridge?.onMessageUpdate(event);
   });
 
-  pi.on('agent_start', () => {
-    bridge?.onAgentStart();
+  pi.on('agent_start', (_event: unknown, ctx: ExtensionCtxLike) => {
+    bridge?.onAgentStart(ctx);
   });
 
   pi.on('agent_end', () => {

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -328,6 +328,104 @@ describe('/send', () => {
     bridge.onAgentEnd();
   });
 
+  it('releases a provider-auth failure, sanitizes it, and ignores the failed turn late agent_end', async () => {
+    const firstResponse = await fetch(`${base}/stream`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'use the provider', correlationId: 'c-provider-auth' }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({
+      assistantMessageEvent: {
+        type: 'error',
+        reason: 'error',
+        error: {
+          errorMessage: '{"error":{"message":"Unauthorized","providerToken":"must-not-leak"}}',
+        },
+      },
+      message: {
+        role: 'assistant',
+        stopReason: 'error',
+        errorMessage: 'provider key sk-must-not-leak was Unauthorized',
+      },
+    });
+
+    const firstText = await firstResponse.text();
+    expect(firstText).toContain('"type":"error"');
+    expect(firstText).toContain('"code":"PRIME_AGENT_PROVIDER_UNAUTHORIZED"');
+    expect(firstText).toContain('"type":"final"');
+    expect(firstText).not.toContain('must-not-leak');
+    expect(firstText).not.toContain('sk-');
+
+    // Start the successor before Prime emits the failed turn's late agent_end.
+    // That stale event must be consumed without resolving this new request.
+    const second = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'retry after credentials are fixed', correlationId: 'c-retry' }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(sent).toEqual(['use the provider', 'retry after credentials are fixed']);
+    bridge.onAgentEnd();
+    const settledByStaleEnd = await Promise.race([
+      second.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25)),
+    ]);
+    expect(settledByStaleEnd).toBe(false);
+
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'recovered' } });
+    bridge.onAgentEnd();
+    const secondResponse = await second;
+    expect(secondResponse.status).toBe(200);
+    expect(await secondResponse.json()).toMatchObject({ text: 'recovered', correlationId: 'c-retry' });
+  });
+
+  it('uses a separate hard limit to abort and release a turn that never emits agent_end', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-hard-timeout', {
+      turnIdleTimeoutMs: 30,
+      turnHardTimeoutMs: 80,
+    });
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+    let abortCount = 0;
+
+    const firstPromise = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'hung turn', correlationId: 'c-hard-timeout' }),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    bridge.onAgentStart({
+      sessionManager: { getSessionId: () => 'sess-hard-timeout' },
+      abort: () => { abortCount += 1; },
+    });
+
+    const first = await firstPromise;
+    expect(first.status).toBe(504);
+    const whileStillRunning = await fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'too soon', correlationId: 'c-too-soon-hard' }),
+    });
+    expect(whileStillRunning.status).toBe(429);
+
+    await new Promise((r) => setTimeout(r, 70));
+    expect(abortCount).toBe(1);
+    const recovered = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'after hard timeout', correlationId: 'c-after-hard' }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'accepted' } });
+    bridge.onAgentEnd();
+    expect((await recovered).status).toBe(200);
+  });
+
   it('only emits verified text_delta events, not thinking or cumulative snapshots', async () => {
     const pending = fetch(`${base}/send`, {
       method: 'POST',

--- a/packages/cli/src/daemon/routes/prime-agent.ts
+++ b/packages/cli/src/daemon/routes/prime-agent.ts
@@ -100,6 +100,26 @@ function isPrimeAgentTimeoutError(err: unknown): boolean {
   );
 }
 
+const SANITIZED_PRIME_AGENT_BRIDGE_FAILURES: Readonly<Record<string, string>> = {
+  PRIME_AGENT_PROVIDER_UNAUTHORIZED:
+    'Prime Agent provider authentication failed. Check the configured provider credentials.',
+  PRIME_AGENT_PROVIDER_ERROR: 'Prime Agent provider request failed.',
+  PRIME_AGENT_TURN_ABORTED: 'Prime Agent turn was aborted.',
+  PRIME_AGENT_TURN_TIMEOUT: 'Prime Agent turn exceeded its hard limit.',
+  PRIME_AGENT_DELIVERY_FAILED: 'Prime Agent rejected the local message before starting the turn.',
+};
+
+function sanitizedPrimeAgentBridgeFailure(text: string): { code: string; error: string } | null {
+  try {
+    const parsed = JSON.parse(text) as { code?: unknown };
+    const code = typeof parsed?.code === 'string' ? parsed.code : '';
+    const error = SANITIZED_PRIME_AGENT_BRIDGE_FAILURES[code];
+    return error ? { code, error } : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * `timeoutMs` names the limit that actually fired: the bridge's idle window
  * (the response-timeout constant) when we are relaying its 504 verdict, the
@@ -195,6 +215,19 @@ export async function handlePrimeAgentRoutes(ctx: RequestContext): Promise<void>
             ...timeoutBody(payload.correlationId, target.sessionId, PRIME_AGENT_CHANNEL_RESPONSE_TIMEOUT_MS),
             ...('text' in bridgeBody ? { text: bridgeBody.text } : {}),
             ...('timedOut' in bridgeBody ? { timedOut: bridgeBody.timedOut } : {}),
+          });
+        }
+        const terminalFailure = sanitizedPrimeAgentBridgeFailure(text);
+        if (terminalFailure) {
+          // Only forward codes from the fixed allowlist above. The provider's
+          // raw error body may contain credential-bearing diagnostics and must
+          // not cross the bridge/daemon trust boundary.
+          return jsonResponse(res, 502, {
+            ...terminalFailure,
+            source: 'prime-agent-channel',
+            sessionId: target.sessionId,
+            correlationId: payload.correlationId,
+            retryable: false,
           });
         }
         // 429 is the bridge's one-turn-at-a-time guard, and it is a normal

--- a/packages/cli/test/daemon-prime-agent.test.ts
+++ b/packages/cli/test/daemon-prime-agent.test.ts
@@ -352,6 +352,40 @@ describe('/api/prime-agent-channel/send', () => {
     expect(JSON.parse(res.body).code).toBe('PRIME_AGENT_SESSION_BUSY');
   });
 
+  it('preserves an allowlisted provider-auth code without forwarding raw provider details', async () => {
+    const bridge = await startStubBridge({
+      sessionId: 's1',
+      sendStatus: 503,
+      sendBody: {
+        error: 'Unauthorized: provider key sk-must-not-leak',
+        code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+        details: { providerToken: 'must-not-leak' },
+      },
+    });
+    writeDescriptor('s1', bridge.url);
+
+    const res = makeJsonResponse();
+    await handlePrimeAgentRoutes({
+      req: makeJsonRequest('POST', '/api/prime-agent-channel/send', { text: 'hi', correlationId: 'c-auth' }),
+      res,
+      config: enabledConfig(),
+      bridgeAuthToken: 'bridge-token',
+      path: '/api/prime-agent-channel/send',
+    } as any);
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+      error: 'Prime Agent provider authentication failed. Check the configured provider credentials.',
+      source: 'prime-agent-channel',
+      correlationId: 'c-auth',
+      retryable: false,
+    });
+    expect(res.body).not.toContain('must-not-leak');
+    expect(res.body).not.toContain('sk-');
+  });
+
   it('propagates the bridge idle timeout with its partial text instead of a generic 502', async () => {
     const bridge = await startStubBridge({
       sessionId: 's1',

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
@@ -21,6 +21,21 @@ export function formatLocalAgentErrorMessage(
     if (err.code === 'PRIME_AGENT_SESSION_BUSY') {
       return `${integration.name} session is busy — try again in a moment.`;
     }
+    if (err.code === 'PRIME_AGENT_PROVIDER_UNAUTHORIZED') {
+      return `${integration.name} provider authentication failed. Check its provider credentials and try again.`;
+    }
+    if (err.code === 'PRIME_AGENT_PROVIDER_ERROR') {
+      return `${integration.name} provider request failed. Check its provider configuration and try again.`;
+    }
+    if (err.code === 'PRIME_AGENT_TURN_ABORTED') {
+      return `${integration.name} turn was aborted.`;
+    }
+    if (err.code === 'PRIME_AGENT_TURN_TIMEOUT') {
+      return `${integration.name} turn exceeded its maximum run time.`;
+    }
+    if (err.code === 'PRIME_AGENT_DELIVERY_FAILED') {
+      return `${integration.name} rejected the message before starting the turn.`;
+    }
     if (err.code === 'SWM_SYNC_TIMEOUT' || err.source === 'background-sync') {
       return 'Background sync timed out. The chat request was not marked as failed by the local-agent bridge.';
     }
@@ -45,4 +60,3 @@ export function formatLocalAgentErrorMessage(
   }
   return message;
 }
-

--- a/packages/node-ui/test/local-agent-errors.test.ts
+++ b/packages/node-ui/test/local-agent-errors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { LocalAgentApiError, type LocalAgentIntegration } from '../src/ui/api.js';
+import { formatLocalAgentErrorMessage } from '../src/ui/components/Shell/PanelRight/local-agent-errors.js';
+
+const primeAgent = { name: 'Prime Agent' } as LocalAgentIntegration;
+
+describe('Prime Agent terminal error messages', () => {
+  it('renders provider authentication failures as actionable terminal errors', () => {
+    const error = new LocalAgentApiError('sanitized bridge failure', {
+      code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+      source: 'prime-agent-channel',
+    });
+
+    expect(formatLocalAgentErrorMessage(primeAgent, error)).toBe(
+      'Prime Agent provider authentication failed. Check its provider credentials and try again.',
+    );
+  });
+
+  it('does not confuse a hard turn limit with a temporary busy response', () => {
+    const error = new LocalAgentApiError('sanitized bridge failure', {
+      code: 'PRIME_AGENT_TURN_TIMEOUT',
+      source: 'prime-agent-channel',
+    });
+
+    expect(formatLocalAgentErrorMessage(primeAgent, error)).toBe(
+      'Prime Agent turn exceeded its maximum run time.',
+    );
+  });
+});

--- a/packages/node-ui/test/ui-api-stream.test.ts
+++ b/packages/node-ui/test/ui-api-stream.test.ts
@@ -9,6 +9,7 @@ import {
   streamHermesLocalChat,
   streamLocalAgentChat,
   streamOpenClawLocalChat,
+  streamPrimeAgentLocalChat,
 } from '../src/ui/api.js';
 
 let server: Server;
@@ -129,6 +130,42 @@ describe('ui local-agent stream api', () => {
 
     try {
       await expect(streamOpenClawLocalChat('hello')).rejects.toThrow('bridge unavailable');
+    } finally {
+      globalThis.fetch = prevFetch;
+    }
+  });
+
+  it('preserves a terminal Prime Agent provider-auth code for the UI', async () => {
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(
+            'data: {"type":"error","error":"Prime Agent provider authentication failed. Check the configured provider credentials.","code":"PRIME_AGENT_PROVIDER_UNAUTHORIZED","source":"prime-agent-channel","retryable":false,"correlationId":"p-auth"}\n\n',
+          ));
+          controller.enqueue(encoder.encode(
+            'data: {"type":"final","text":"","correlationId":"p-auth","sessionId":"s1"}\n\n',
+          ));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }) as typeof globalThis.fetch;
+
+    try {
+      let caught: unknown;
+      await streamPrimeAgentLocalChat('hello').catch((err) => { caught = err; });
+      expect(caught).toBeInstanceOf(LocalAgentApiError);
+      expect(caught).toMatchObject({
+        code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+        source: 'prime-agent-channel',
+        correlationId: 'p-auth',
+        retryable: false,
+      });
     } finally {
       globalThis.fetch = prevFetch;
     }


### PR DESCRIPTION
## Outcome

Fixes #2121 on the 10.0.13 testnet-canary release head.

A terminal Prime provider failure no longer leaves the Node UI spinning or the Prime session permanently returning `PRIME_AGENT_SESSION_BUSY`. The adapter now converts Prime's terminal provider `error` event into a sanitized DKG error/final sequence, releases its one-turn guard, and safely admits the next request.

## Before

```mermaid
sequenceDiagram
    participant UI as Node UI
    participant D as DKG daemon
    participant B as Prime bridge
    participant P as Prime provider
    UI->>D: Send prompt
    D->>B: Open stream
    B->>P: Start turn
    P-->>B: Terminal Unauthorized error
    Note over B: Error event ignored
    Note over UI,B: Stream waits and bridge stays busy
    UI->>D: Send next prompt
    D-->>UI: 429 session busy
```

## After

```mermaid
sequenceDiagram
    participant UI as Node UI
    participant D as DKG daemon
    participant B as Prime bridge
    participant P as Prime provider
    UI->>D: Send prompt
    D->>B: Open stream
    B->>P: Start turn
    P-->>B: Terminal Unauthorized error
    B-->>D: Sanitized provider auth error and final
    D-->>UI: Terminal actionable error
    Note over B: Busy guard released
    UI->>D: Retry after credentials are fixed
    D->>B: Start successor turn
    B-->>UI: Normal response
```

## Changes

- Recognize Prime 0.7 terminal assistant `error` events.
- Classify provider authentication failures as `PRIME_AGENT_PROVIDER_UNAUTHORIZED` without forwarding raw provider diagnostics.
- Emit terminal SSE error and final frames and clear bridge admission state.
- Consume a late `agent_end` from the failed turn without allowing it to settle a successor request.
- Add a separate 55-minute hard turn limit below the daemon's 60-minute transport backstop; it aborts and releases a turn even if Prime never emits `agent_end`.
- Preserve only allowlisted sanitized bridge codes through the daemon's blocking `/send` path.
- Render actionable Prime provider-auth, provider, abort, delivery, and hard-timeout errors in the Node UI.

## Security properties

- Raw provider errors, keys, and tokens are never returned by the adapter or daemon.
- The daemon only forwards a fixed allowlist of Prime terminal error codes and supplies its own sanitized messages.
- Regression tests inject secret-shaped provider details and assert they do not cross either boundary.

## Validation on exact 10.0.13 canary base `2aa04e2dc`

- Prime adapter: 3 files, 52 tests passed.
- CLI Prime daemon: 22 tests passed.
- Node UI stream/error contract: 3 files, 20 tests passed.
- Adapter, CLI, and Node UI TypeScript builds passed.
- `git diff --check` passed.
