### PR TITLE
fix(prime-agent): harden terminal-turn failure paths from PR #2123 review

### DIFF
--- a/packages/adapter-prime-agent/extension/src/extension.ts
+++ b/packages/adapter-prime-agent/extension/src/extension.ts
@@ -146,6 +146,12 @@ interface TurnOutcome {
   errorCode?: PrimeAgentTurnErrorCode;
 }
 
+// Must stay in lock-step with SANITIZED_PRIME_AGENT_BRIDGE_FAILURES in
+// packages/cli/src/daemon/routes/prime-agent.ts (the daemon's forwarding
+// allowlist) and the per-code branches in
+// packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts:
+// a code missing from the daemon map degrades to a generic BRIDGE_ERROR on
+// /send while /stream forwards it verbatim, and the two transports diverge.
 type PrimeAgentTurnErrorCode =
   | 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'
   | 'PRIME_AGENT_PROVIDER_ERROR'
@@ -158,13 +164,30 @@ interface SanitizedTurnFailure {
   message: string;
 }
 
+// Classification only ever needs the head of each diagnostic; the cap also
+// keeps the regex off provider-sized inputs, which are attacker-influenced.
+// Capped per field (not after joining) so an oversized first diagnostic
+// cannot starve the second out of classification entirely, and the trailing
+// partial token is stripped so truncation cannot fabricate a marker (a cut
+// through "status: 4013" must not leave a matching "status: 401").
+const PROVIDER_FAILURE_CLASSIFICATION_MAX_CHARS = 4096;
+
+function clipDiagnostic(value: string): string {
+  if (value.length <= PROVIDER_FAILURE_CLASSIFICATION_MAX_CHARS) return value;
+  return value.slice(0, PROVIDER_FAILURE_CLASSIFICATION_MAX_CHARS).replace(/\w+$/, '');
+}
+
 function sanitizedProviderFailure(event: MessageUpdateEvent): SanitizedTurnFailure {
   const assistantEvent = event.assistantMessageEvent;
   const raw = [assistantEvent?.error?.errorMessage, event.message?.errorMessage]
     .filter((value): value is string => typeof value === 'string')
+    .map(clipDiagnostic)
     .join('\n');
+  // `\s*(?:[:=]\s*)?` is the linear-time equivalent of `\s*[:=]?\s*`: two
+  // adjacent unbounded \s* backtrack quadratically on a long whitespace run,
+  // and this runs on raw provider error text.
   if (
-    /\bunauthori[sz]ed\b|\bauthentication failed\b|\binvalid[_ ]api[_ ]key\b|\bincorrect api key\b|\b(?:http|status(?: code)?)\s*[:=]?\s*401\b/i.test(raw)
+    /\bunauthori[sz]ed\b|\bauthentication failed\b|\binvalid[_ ]api[_ ]key\b|\bincorrect api key\b|\b(?:http|status(?: code)?)\s*(?:[:=]\s*)?401\b/i.test(raw)
   ) {
     return {
       code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
@@ -193,10 +216,13 @@ class SessionBridge {
   #startedAt: string | undefined;
   #turn: PendingTurn | undefined;
   #agentActive = false;
-  // A provider error is a terminal stream event, but Prime may still emit the
-  // corresponding agent_end shortly afterwards. If a new bridge request lands
-  // in that small window, the old agent_end must not settle the new request.
-  #discardNextAgentEnd = false;
+  // Set by #failTurn, cleared by the next agent_start (or consumed by the
+  // failed turn's own trailing agent_end). While set, every agent event still
+  // belongs to the failed turn: a late agent_end must not settle a successor
+  // request, late text_deltas from a zombie turn the hard-timeout abort could
+  // not stop must not contaminate its transcript, and the trailing
+  // `error`/`aborted` frame the abort itself produces must not fail it.
+  #discardStaleTurnEvents = false;
   #abortActiveAgent: (() => void) | undefined;
   #closed = false;
   readonly #turnIdleTimeoutMs: number;
@@ -526,6 +552,27 @@ class SessionBridge {
   /* ── agent event plumbing ───────────────────────────────────────────────── */
 
   onMessageUpdate(event: MessageUpdateEvent): void {
+    // Everything between #failTurn and the successor's agent_start is the
+    // failed turn talking: deltas from a zombie turn the abort could not stop,
+    // or the trailing `error`/`aborted` frame the abort itself produces. A
+    // successor turn's own events always follow its agent_start, which clears
+    // this flag — so nothing discarded here can belong to a live request.
+    if (this.#discardStaleTurnEvents) {
+      // Content is discarded, but zombie deltas are still proof the session
+      // loop is draining toward a queued successor's followUp — keep that
+      // successor's idle window alive so it does not spuriously 504 while its
+      // message is guaranteed to run next.
+      const pending = this.#turn;
+      const staleType = event.assistantMessageEvent?.type;
+      if (
+        pending &&
+        !pending.responseSettled &&
+        (staleType === 'text_delta' || staleType === 'thinking_delta' || staleType === 'toolcall_delta')
+      ) {
+        this.#armIdleTimer(pending);
+      }
+      return;
+    }
     const turn = this.#turn;
     const assistantEvent = event.assistantMessageEvent;
     const eventType = assistantEvent?.type;
@@ -533,6 +580,12 @@ class SessionBridge {
     // authoritative even when Prime fails to emit the higher-level agent_end:
     // finish the HTTP/SSE turn, clear admission, and never expose the raw
     // provider payload (which may contain credential-bearing diagnostics).
+    // Known gap: the event carries no turn identity, so in the pre-agent_start
+    // admission window (see the followUp comment in #handleSend) an error or
+    // operator abort of a *locally-typed* turn also fails a pending bridge
+    // turn whose message is still queued — the caller may see TURN_ABORTED for
+    // a message that later executes. Closing that needs turn-association data
+    // from the Prime event API.
     if (eventType === 'error') {
       this.#failTurn(sanitizedProviderFailure(event));
       return;
@@ -559,8 +612,8 @@ class SessionBridge {
 
   onAgentStart(ctx?: ExtensionCtxLike): void {
     // If a failed turn never emitted agent_end, this start necessarily belongs
-    // to the successor and supersedes the stale-end guard.
-    if (this.#discardNextAgentEnd) this.#discardNextAgentEnd = false;
+    // to the successor and supersedes the stale-event guard.
+    this.#discardStaleTurnEvents = false;
     this.#agentActive = true;
     this.#abortActiveAgent = typeof ctx?.abort === 'function' ? () => ctx.abort!() : undefined;
     // Election stamp, once per turn — agent_start fires for locally-typed and
@@ -577,8 +630,8 @@ class SessionBridge {
   }
 
   onAgentEnd(): void {
-    if (this.#discardNextAgentEnd) {
-      this.#discardNextAgentEnd = false;
+    if (this.#discardStaleTurnEvents) {
+      this.#discardStaleTurnEvents = false;
       this.#agentActive = false;
       this.#abortActiveAgent = undefined;
       return;
@@ -627,10 +680,11 @@ class SessionBridge {
       });
       this.#clearTurn(turn);
     }
-    // The provider `error` event is terminal, so accepting the next request is
-    // safe. Remember that one stale agent_end may still arrive and must be
-    // consumed without touching that successor request.
-    this.#discardNextAgentEnd = true;
+    // The failure verdict is terminal, so accepting the next request is safe.
+    // Remember that the failed turn may still emit events — trailing deltas,
+    // an abort's own `error` frame, its agent_end — and none of them may touch
+    // a successor request.
+    this.#discardStaleTurnEvents = true;
     this.#agentActive = false;
     this.#abortActiveAgent = undefined;
   }
@@ -712,4 +766,4 @@ export default function dkgBridgeExtension(pi: ExtensionApiLike): void {
   });
 }
 
-export { SessionBridge, tokenMatches, sessionsDir, stateDir };
+export { SessionBridge, sanitizedProviderFailure, tokenMatches, sessionsDir, stateDir };

--- a/packages/adapter-prime-agent/extension/src/extension.ts
+++ b/packages/adapter-prime-agent/extension/src/extension.ts
@@ -57,6 +57,37 @@ interface MessageUpdateEvent {
   };
   message?: { role?: string; content?: unknown; errorMessage?: string; stopReason?: string };
 }
+interface AgentMessageLike {
+  role?: string;
+  content?: unknown;
+  customType?: string;
+  details?: unknown;
+}
+interface BeforeAgentStartEvent {
+  prompt?: string;
+}
+interface BeforeAgentStartEventResult {
+  message: {
+    customType: string;
+    content: string;
+    display: boolean;
+    details: { ownershipToken: string };
+  };
+}
+interface MessageStartEvent {
+  message?: AgentMessageLike;
+}
+interface ContextEvent {
+  messages?: AgentMessageLike[];
+}
+interface InputEvent {
+  text?: string;
+  source?: string;
+}
+type InputEventResult =
+  | { action: 'continue' }
+  | { action: 'transform'; text: string }
+  | { action: 'handled' };
 interface ExtensionApiLike {
   on(event: string, handler: (event: any, ctx: ExtensionCtxLike) => unknown): void;
   sendUserMessage(content: string, options?: { deliverAs?: 'steer' | 'followUp' }): void;
@@ -75,6 +106,11 @@ const TURN_HARD_TIMEOUT_MS = 55 * 60_000;
 // republication that landed (atomic rename, fresh mtime) between our read and
 // the rm. Mirrored in the daemon-side reader (`session-registry.ts`).
 const PRUNE_MIN_AGE_MS = 30_000;
+// Removed by our `input` handler before Prime creates the user message. The
+// opaque tag distinguishes this extension's submission from another extension
+// (or an identical local prompt) without exposing metadata to the model.
+const BRIDGE_INPUT_TAG_PREFIX = '\u2063dkg-bridge-turn:';
+const BRIDGE_TURN_MARKER_TYPE = 'dkg.bridge.turn-owner';
 
 function agentDir(): string {
   return process.env.PRIME_AGENT_CODING_AGENT_DIR ?? join(homedir(), '.prime', 'agent');
@@ -131,12 +167,16 @@ function isProcessAlive(pid: number): boolean {
 
 interface PendingTurn {
   correlationId: string;
+  prompt: string;
+  taggedPrompt: string;
+  ownershipToken: string;
+  inputObserved: boolean;
   chunks: string[];
   subscribers: Set<ServerResponse>;
   responseSettled: boolean;
   resolve: (outcome: TurnOutcome) => void;
-  idleTimer: NodeJS.Timeout;
-  hardTimer: NodeJS.Timeout;
+  idleTimer?: NodeJS.Timeout;
+  hardTimer?: NodeJS.Timeout;
 }
 
 interface TurnOutcome {
@@ -215,14 +255,17 @@ class SessionBridge {
   /** Fixed for the bridge's lifetime; re-publications move only lastActiveAt. */
   #startedAt: string | undefined;
   #turn: PendingTurn | undefined;
+  // `before_agent_start` results are cached on Prime's queued action. The
+  // hidden ownership marker therefore follows the bridge prompt into the run
+  // that actually commits, even if another local/retry run starts after its
+  // preparation hook. Local turns and agent.continue() retries have no marker.
+  #activeRunTurn: PendingTurn | undefined;
+  #runHasFreshPrompt = false;
+  // A terminal HTTP verdict must stop Prime from continuing that logical turn
+  // in the background. Retry starts have no before_agent_start; abort them
+  // until a genuinely fresh prompt boundary supersedes the failed run.
+  #failedRunQuarantined = false;
   #agentActive = false;
-  // Set by #failTurn, cleared by the next agent_start (or consumed by the
-  // failed turn's own trailing agent_end). While set, every agent event still
-  // belongs to the failed turn: a late agent_end must not settle a successor
-  // request, late text_deltas from a zombie turn the hard-timeout abort could
-  // not stop must not contaminate its transcript, and the trailing
-  // `error`/`aborted` frame the abort itself produces must not fail it.
-  #discardStaleTurnEvents = false;
   #abortActiveAgent: (() => void) | undefined;
   #closed = false;
   readonly #turnIdleTimeoutMs: number;
@@ -380,6 +423,9 @@ class SessionBridge {
       this.#settleResponse({ text: this.#turn.chunks.join(''), error: 'Bridge stopped' });
       this.#clearTurn(this.#turn);
     }
+    this.#activeRunTurn = undefined;
+    this.#runHasFreshPrompt = false;
+    this.#failedRunQuarantined = false;
     this.#agentActive = false;
     this.#abortActiveAgent = undefined;
     const server = this.#server;
@@ -448,32 +494,21 @@ class SessionBridge {
     }
 
     const done = new Promise<TurnOutcome>((resolve) => {
+      const ownershipToken = randomUUID();
       const turn: PendingTurn = {
         correlationId,
+        prompt: text,
+        taggedPrompt: `${BRIDGE_INPUT_TAG_PREFIX}${ownershipToken}\u2063${text}`,
+        ownershipToken,
+        inputObserved: false,
         chunks: [],
         subscribers: new Set(),
         responseSettled: false,
         resolve,
-        idleTimer: undefined as unknown as NodeJS.Timeout,
-        hardTimer: undefined as unknown as NodeJS.Timeout,
       };
       this.#turn = turn;
-      this.#armIdleTimer(turn);
-      turn.hardTimer = setTimeout(() => {
-        if (this.#turn !== turn) return;
-        const abort = this.#abortActiveAgent;
-        this.#failTurn({
-          code: 'PRIME_AGENT_TURN_TIMEOUT',
-          message: `Prime Agent turn exceeded the ${this.#turnHardTimeoutMs}ms hard limit.`,
-        });
-        try {
-          abort?.();
-        } catch {
-          /* the bridge state is already safely released */
-        }
-      }, this.#turnHardTimeoutMs);
-      turn.hardTimer.unref?.();
     });
+    const admittedTurn = this.#turn!;
 
     if (stream) {
       res.writeHead(200, {
@@ -486,9 +521,8 @@ class SessionBridge {
       // the first delta — which for a slow first token looks like a hang, and
       // for a turn that produces no tokens at all never resolves.
       res.write(': open\n\n');
-      const turn = this.#turn!;
-      turn.subscribers.add(res);
-      req.on('close', () => turn.subscribers.delete(res));
+      admittedTurn.subscribers.add(res);
+      req.on('close', () => admittedTurn.subscribers.delete(res));
     }
 
     // Inject as a real user message so the turn is indistinguishable from one
@@ -497,9 +531,9 @@ class SessionBridge {
     // follow-up for the remaining race window so a locally-started turn is
     // never interrupted by a remote UI message.
     try {
-      this.#pi.sendUserMessage(text, { deliverAs: 'followUp' });
+      this.#pi.sendUserMessage(admittedTurn.taggedPrompt, { deliverAs: 'followUp' });
     } catch {
-      this.#failTurn({
+      this.#failTurn(admittedTurn, {
         code: 'PRIME_AGENT_DELIVERY_FAILED',
         message: 'Prime Agent rejected the local message before starting the turn.',
       });
@@ -551,46 +585,97 @@ class SessionBridge {
 
   /* ── agent event plumbing ───────────────────────────────────────────────── */
 
-  onMessageUpdate(event: MessageUpdateEvent): void {
-    // Everything between #failTurn and the successor's agent_start is the
-    // failed turn talking: deltas from a zombie turn the abort could not stop,
-    // or the trailing `error`/`aborted` frame the abort itself produces. A
-    // successor turn's own events always follow its agent_start, which clears
-    // this flag — so nothing discarded here can belong to a live request.
-    if (this.#discardStaleTurnEvents) {
-      // Content is discarded, but zombie deltas are still proof the session
-      // loop is draining toward a queued successor's followUp — keep that
-      // successor's idle window alive so it does not spuriously 504 while its
-      // message is guaranteed to run next.
-      const pending = this.#turn;
-      const staleType = event.assistantMessageEvent?.type;
-      if (
-        pending &&
-        !pending.responseSettled &&
-        (staleType === 'text_delta' || staleType === 'thinking_delta' || staleType === 'toolcall_delta')
-      ) {
-        this.#armIdleTimer(pending);
-      }
-      return;
+  onInput(event: InputEvent): InputEventResult {
+    if (event.source !== 'extension' || typeof event.text !== 'string') {
+      return { action: 'continue' };
     }
     const turn = this.#turn;
+    if (turn && !turn.responseSettled && event.text === turn.taggedPrompt) {
+      turn.inputObserved = true;
+      return { action: 'transform', text: turn.prompt };
+    }
+    // A tagged submission whose HTTP request was already cleared must never
+    // execute later. Swallow it instead of letting the internal tag or a
+    // fail-then-execute side effect reach Prime.
+    if (event.text.startsWith(BRIDGE_INPUT_TAG_PREFIX)) return { action: 'handled' };
+    return { action: 'continue' };
+  }
+
+  onBeforeAgentStart(event: BeforeAgentStartEvent): BeforeAgentStartEventResult | undefined {
+    // Prime caches this result on the queued turn action. Unlike transient
+    // bridge state, the marker survives a deferred handoff and is emitted only
+    // when that exact prepared action enters the agent loop.
+    const turn = this.#turn;
+    if (!turn || !turn.inputObserved || turn.responseSettled || event.prompt !== turn.prompt) {
+      return undefined;
+    }
+    return {
+      message: {
+        customType: BRIDGE_TURN_MARKER_TYPE,
+        content: '',
+        display: false,
+        details: { ownershipToken: turn.ownershipToken },
+      },
+    };
+  }
+
+  onMessageStart(event: MessageStartEvent): void {
+    const message = event.message;
+    if (message?.role === 'user') {
+      this.#runHasFreshPrompt = true;
+      this.#failedRunQuarantined = false;
+      return;
+    }
+    if (message?.role !== 'custom' || message.customType !== BRIDGE_TURN_MARKER_TYPE) return;
+    const ownershipToken =
+      message.details && typeof message.details === 'object'
+        ? (message.details as { ownershipToken?: unknown }).ownershipToken
+        : undefined;
+    const turn = this.#turn;
+    if (turn && !turn.responseSettled && ownershipToken === turn.ownershipToken) {
+      this.#activeRunTurn = turn;
+      this.#armTurnTimers(turn);
+    }
+  }
+
+  onContext(event: ContextEvent): { messages: AgentMessageLike[] } | undefined {
+    if (!event.messages?.some((message) => message.customType === BRIDGE_TURN_MARKER_TYPE)) {
+      return undefined;
+    }
+    // The marker is transport metadata, not conversation content. Keep it out
+    // of every provider request while retaining it in Prime's event stream as
+    // a reliable committed-action identity signal.
+    return {
+      messages: event.messages.filter((message) => message.customType !== BRIDGE_TURN_MARKER_TYPE),
+    };
+  }
+
+  onBeforeProviderRequest(ctx?: ExtensionCtxLike): void {
+    if (!this.#failedRunQuarantined || this.#runHasFreshPrompt) return;
+    // Prime retry/continue runs have agent_start but no newly emitted user
+    // message. Abort at the last hook before provider I/O so a turn that has
+    // already returned a terminal HTTP verdict cannot resume or execute tools.
+    try {
+      if (typeof ctx?.abort === 'function') ctx.abort();
+      else this.#abortActiveAgent?.();
+    } catch {
+      /* quarantine still prevents this run from owning a bridge request */
+    }
+  }
+
+  onMessageUpdate(event: MessageUpdateEvent): void {
+    const turn = this.#activeRunTurn;
+    if (!turn || this.#turn !== turn || turn.responseSettled) return;
     const assistantEvent = event.assistantMessageEvent;
     const eventType = assistantEvent?.type;
     // Prime's provider stream contract declares `error` terminal. Treat it as
     // authoritative even when Prime fails to emit the higher-level agent_end:
     // finish the HTTP/SSE turn, clear admission, and never expose the raw
     // provider payload (which may contain credential-bearing diagnostics).
-    // Known gap: the event carries no turn identity, so in the pre-agent_start
-    // admission window (see the followUp comment in #handleSend) an error or
-    // operator abort of a *locally-typed* turn also fails a pending bridge
-    // turn whose message is still queued — the caller may see TURN_ABORTED for
-    // a message that later executes. Closing that needs turn-association data
-    // from the Prime event API.
     if (eventType === 'error') {
-      this.#failTurn(sanitizedProviderFailure(event));
+      this.#failTurn(turn, sanitizedProviderFailure(event));
       return;
     }
-    if (!turn || turn.responseSettled) return;
     // At the pinned Prime Agent API, only text_delta is user-visible answer
     // text. Thinking/tool-call deltas still prove liveness, but must never leak
     // into the response transcript.
@@ -611,9 +696,8 @@ class SessionBridge {
   }
 
   onAgentStart(ctx?: ExtensionCtxLike): void {
-    // If a failed turn never emitted agent_end, this start necessarily belongs
-    // to the successor and supersedes the stale-event guard.
-    this.#discardStaleTurnEvents = false;
+    this.#activeRunTurn = undefined;
+    this.#runHasFreshPrompt = false;
     this.#agentActive = true;
     this.#abortActiveAgent = typeof ctx?.abort === 'function' ? () => ctx.abort!() : undefined;
     // Election stamp, once per turn — agent_start fires for locally-typed and
@@ -630,22 +714,33 @@ class SessionBridge {
   }
 
   onAgentEnd(): void {
-    if (this.#discardStaleTurnEvents) {
-      this.#discardStaleTurnEvents = false;
-      this.#agentActive = false;
-      this.#abortActiveAgent = undefined;
-      return;
-    }
     this.#agentActive = false;
     this.#abortActiveAgent = undefined;
-    const turn = this.#turn;
+    this.#runHasFreshPrompt = false;
+    const turn = this.#activeRunTurn;
+    this.#activeRunTurn = undefined;
     if (!turn) return;
-    if (!turn.responseSettled) this.#settleResponse({ text: turn.chunks.join('') });
+    if (this.#turn === turn && !turn.responseSettled) {
+      this.#settleResponse({ text: turn.chunks.join('') });
+    }
     this.#clearTurn(turn);
   }
 
+  #armTurnTimers(turn: PendingTurn): void {
+    if (turn.idleTimer || turn.hardTimer) return;
+    this.#armIdleTimer(turn);
+    turn.hardTimer = setTimeout(() => {
+      if (this.#turn !== turn) return;
+      this.#failTurn(turn, {
+        code: 'PRIME_AGENT_TURN_TIMEOUT',
+        message: `Prime Agent turn exceeded the ${this.#turnHardTimeoutMs}ms hard limit.`,
+      });
+    }, this.#turnHardTimeoutMs);
+    turn.hardTimer.unref?.();
+  }
+
   #armIdleTimer(turn: PendingTurn): void {
-    clearTimeout(turn.idleTimer);
+    if (turn.idleTimer) clearTimeout(turn.idleTimer);
     turn.idleTimer = setTimeout(() => {
       if (this.#turn !== turn || turn.responseSettled) return;
       // Resolve the HTTP request visibly as a timeout, but retain #turn until
@@ -660,19 +755,19 @@ class SessionBridge {
     const turn = this.#turn;
     if (!turn || turn.responseSettled) return;
     turn.responseSettled = true;
-    clearTimeout(turn.idleTimer);
+    if (turn.idleTimer) clearTimeout(turn.idleTimer);
     turn.resolve(outcome);
   }
 
   #clearTurn(turn: PendingTurn): void {
-    clearTimeout(turn.idleTimer);
-    clearTimeout(turn.hardTimer);
+    if (turn.idleTimer) clearTimeout(turn.idleTimer);
+    if (turn.hardTimer) clearTimeout(turn.hardTimer);
     if (this.#turn === turn) this.#turn = undefined;
   }
 
-  #failTurn(failure: SanitizedTurnFailure): void {
-    const turn = this.#turn;
-    if (turn) {
+  #failTurn(turn: PendingTurn, failure: SanitizedTurnFailure): void {
+    const ownsActiveRun = this.#activeRunTurn === turn;
+    if (this.#turn === turn) {
       this.#settleResponse({
         text: turn.chunks.join(''),
         error: failure.message,
@@ -680,13 +775,15 @@ class SessionBridge {
       });
       this.#clearTurn(turn);
     }
-    // The failure verdict is terminal, so accepting the next request is safe.
-    // Remember that the failed turn may still emit events — trailing deltas,
-    // an abort's own `error` frame, its agent_end — and none of them may touch
-    // a successor request.
-    this.#discardStaleTurnEvents = true;
-    this.#agentActive = false;
-    this.#abortActiveAgent = undefined;
+    if (!ownsActiveRun) return;
+    this.#failedRunQuarantined = true;
+    // Keep #agentActive true until the actual agent_end so the bridge does not
+    // admit a successor into a run that has not reached a boundary yet.
+    try {
+      this.#abortActiveAgent?.();
+    } catch {
+      /* the ownership quarantine remains authoritative */
+    }
   }
 
   #json(res: ServerResponse, status: number, body: unknown): void {
@@ -748,8 +845,22 @@ export default function dkgBridgeExtension(pi: ExtensionApiLike): void {
     bridge?.onMessageUpdate(event);
   });
 
+  pi.on('input', (event: InputEvent) => bridge?.onInput(event) ?? { action: 'continue' });
+
+  pi.on('before_agent_start', (event: BeforeAgentStartEvent) => bridge?.onBeforeAgentStart(event));
+
   pi.on('agent_start', (_event: unknown, ctx: ExtensionCtxLike) => {
     bridge?.onAgentStart(ctx);
+  });
+
+  pi.on('message_start', (event: MessageStartEvent) => {
+    bridge?.onMessageStart(event);
+  });
+
+  pi.on('context', (event: ContextEvent) => bridge?.onContext(event));
+
+  pi.on('before_provider_request', (_event: unknown, ctx: ExtensionCtxLike) => {
+    bridge?.onBeforeProviderRequest(ctx);
   });
 
   pi.on('agent_end', () => {

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -27,6 +27,18 @@ function stubPi(onSend: (text: string, options?: { deliverAs?: 'steer' | 'follow
   };
 }
 
+/**
+ * Deterministic barrier on an observable side effect (usually `sent` growing):
+ * fixed sleeps race the loopback HTTP round-trip under CI load, a poll cannot.
+ */
+async function until(cond: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error('until(): condition not reached in time');
+    await new Promise((r) => setTimeout(r, 2));
+  }
+}
+
 async function bridgeBaseUrl(b: SessionBridge): Promise<string> {
   // The bridge publishes its descriptor; read the port back out of it.
   const { readLiveSessions } = await import('../src/session-registry.js');
@@ -424,6 +436,208 @@ describe('/send', () => {
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'accepted' } });
     bridge.onAgentEnd();
     expect((await recovered).status).toBe(200);
+  });
+
+  it('discards a zombie turn stale deltas and abort error so they never touch the successor', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-stale-events', {
+      turnIdleTimeoutMs: 30,
+      turnHardTimeoutMs: 80,
+    });
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    // No abort in ctx: the hard timeout cannot stop this turn, only release it.
+    const firstPromise = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'zombie turn', correlationId: 'c-zombie' }),
+    });
+    await until(() => sent.length === 1);
+    bridge.onAgentStart();
+    expect((await firstPromise).status).toBe(504);
+
+    await new Promise((r) => setTimeout(r, 90));
+
+    const successor = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'successor', correlationId: 'c-successor' }),
+    });
+    await until(() => sent.length === 2);
+    expect(sent).toEqual(['zombie turn', 'successor']);
+    // The zombie keeps talking before the successor's agent_start: trailing
+    // deltas, an abort's own error frame, then its agent_end. None of it may
+    // contaminate, fail, or settle the successor request.
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie-tail ' } });
+    bridge.onMessageUpdate({
+      assistantMessageEvent: { type: 'error', reason: 'aborted' },
+      message: { role: 'assistant', stopReason: 'aborted' },
+    });
+    bridge.onAgentEnd();
+
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'fresh answer' } });
+    bridge.onAgentEnd();
+    const res = await successor;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ text: 'fresh answer', correlationId: 'c-successor' });
+  });
+
+  it('keeps a queued successor alive on zombie liveness instead of spuriously idling it out', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-zombie-liveness', {
+      turnIdleTimeoutMs: 80,
+      turnHardTimeoutMs: 400,
+    });
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    const firstPromise = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'zombie turn', correlationId: 'c-liveness-zombie' }),
+    });
+    await until(() => sent.length === 1);
+    bridge.onAgentStart();
+    expect((await firstPromise).status).toBe(504);
+    await new Promise((r) => setTimeout(r, 340));
+
+    // Successor admitted while the zombie is still draining. Its idle window
+    // (80ms) is shorter than the zombie's remaining run (5 x 25ms): the
+    // discarded deltas must still count as liveness, or the successor 504s
+    // while its queued message later executes invisibly.
+    const successor = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'queued successor', correlationId: 'c-liveness-succ' }),
+    });
+    await until(() => sent.length === 2);
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((r) => setTimeout(r, 25));
+      bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie noise' } });
+    }
+    bridge.onAgentEnd();
+
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'fresh' } });
+    bridge.onAgentEnd();
+    const res = await successor;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ text: 'fresh', correlationId: 'c-liveness-succ' });
+  });
+
+  it('reports PRIME_AGENT_TURN_TIMEOUT when the hard limit fires while the turn is still live', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-hard-first', {
+      turnIdleTimeoutMs: 5_000,
+      turnHardTimeoutMs: 80,
+    });
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+    let abortCount = 0;
+
+    const pending = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'never ends', correlationId: 'c-hard-first' }),
+    });
+    await until(() => sent.length === 1);
+    bridge.onAgentStart({
+      sessionManager: { getSessionId: () => 'sess-hard-first' },
+      abort: () => { abortCount += 1; },
+    });
+
+    const res = await pending;
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      code: 'PRIME_AGENT_TURN_TIMEOUT',
+      source: 'prime-agent-channel',
+      retryable: false,
+      correlationId: 'c-hard-first',
+    });
+    expect(body.error).toContain('hard limit');
+    expect(abortCount).toBe(1);
+  });
+
+  it('shapes the /send 503 provider-failure body exactly as the daemon allowlist parses it', async () => {
+    const pending = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'use the provider', correlationId: 'c-send-auth' }),
+    });
+    await until(() => sent.length === 1);
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'partial ' } });
+    bridge.onMessageUpdate({
+      assistantMessageEvent: {
+        type: 'error',
+        reason: 'error',
+        error: { errorMessage: 'Unauthorized: provider key sk-must-not-leak' },
+      },
+    });
+
+    const res = await pending;
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    // The daemon's sanitizedPrimeAgentBridgeFailure reads the top-level `code`
+    // of this body, and its terminal branch forwards `text`; this pins the
+    // producer half of that wire contract.
+    expect(body).toMatchObject({
+      code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+      source: 'prime-agent-channel',
+      retryable: false,
+      text: 'partial ',
+      correlationId: 'c-send-auth',
+      sessionId: 'sess-test',
+    });
+    const rawBody = JSON.stringify(body);
+    expect(rawBody).not.toContain('must-not-leak');
+    expect(rawBody).not.toContain('sk-');
+    bridge.onAgentEnd();
+  });
+
+  it('fails fast with PRIME_AGENT_DELIVERY_FAILED when injection throws, then recovers fully', async () => {
+    await bridge.stop();
+    let rejectNext = true;
+    bridge = new SessionBridge(stubPi((t) => {
+      if (rejectNext) {
+        rejectNext = false;
+        throw new Error('session rejected the message');
+      }
+      sent.push(t);
+    }) as never, 'sess-delivery');
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    const failed = await fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'undeliverable', correlationId: 'c-deliver' }),
+    });
+    expect(failed.status).toBe(503);
+    expect(await failed.json()).toMatchObject({
+      code: 'PRIME_AGENT_DELIVERY_FAILED',
+      retryable: false,
+      correlationId: 'c-deliver',
+    });
+
+    // No agent turn ever started, so the stale-event guard set by the failure
+    // must not swallow the next real turn's events.
+    const retry = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'deliverable', correlationId: 'c-deliver-2' }),
+    });
+    await until(() => sent.length === 1);
+    expect(sent).toEqual(['deliverable']);
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'delivered' } });
+    bridge.onAgentEnd();
+    const res = await retry;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ text: 'delivered', correlationId: 'c-deliver-2' });
   });
 
   it('only emits verified text_delta events, not thinking or cumulative snapshots', async () => {

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -23,7 +23,13 @@ let base: string;
 function stubPi(onSend: (text: string, options?: { deliverAs?: 'steer' | 'followUp' }) => void) {
   return {
     on: () => {},
-    sendUserMessage: (content: string, options?: { deliverAs?: 'steer' | 'followUp' }) => onSend(content, options),
+    sendUserMessage: (content: string, options?: { deliverAs?: 'steer' | 'followUp' }) => {
+      // Mirror Prime's input normalization: the bridge tags its own submission
+      // and the input hook removes that tag before the user message is built.
+      const result = bridge.onInput({ source: 'extension', text: content });
+      if (result.action === 'handled') return;
+      onSend(result.action === 'transform' ? result.text : content, options);
+    },
   };
 }
 
@@ -48,6 +54,38 @@ async function bridgeBaseUrl(b: SessionBridge): Promise<string> {
   const mine = sessions.find((s) => s.sessionId === b.sessionId);
   if (!mine) throw new Error('bridge did not publish a descriptor');
   return mine.bridgeUrl;
+}
+
+type PreparedBridgeRun = NonNullable<ReturnType<SessionBridge['onBeforeAgentStart']>>;
+
+/** Commit a bridge action using the marker Prime cached during preparation. */
+function startBridgeRun(
+  ctx?: Parameters<SessionBridge['onAgentStart']>[0],
+  prepared?: PreparedBridgeRun,
+): void {
+  const prompt = sent.at(-1);
+  if (!prompt) throw new Error('startBridgeRun(): no injected prompt');
+  const ownership = prepared ?? bridge.onBeforeAgentStart({ prompt });
+  if (!ownership) throw new Error('startBridgeRun(): prompt did not receive an ownership marker');
+  bridge.onAgentStart(ctx);
+  bridge.onMessageStart({
+    message: { role: 'user', content: [{ type: 'text', text: prompt }] },
+  });
+  bridge.onMessageStart({
+    message: { role: 'custom', ...ownership.message },
+  });
+}
+
+/** A locally typed prompt is a fresh run, but must not claim a bridge request. */
+function startLocalRun(
+  prompt = 'locally typed prompt',
+  ctx?: Parameters<SessionBridge['onAgentStart']>[0],
+): void {
+  bridge.onBeforeAgentStart({ prompt });
+  bridge.onAgentStart(ctx);
+  bridge.onMessageStart({
+    message: { role: 'user', content: [{ type: 'text', text: prompt }] },
+  });
 }
 
 beforeEach(async () => {
@@ -147,7 +185,7 @@ describe('session election', () => {
     // ISO stamps have millisecond resolution; a strictly-newer stamp needs a
     // real gap.
     await new Promise((r) => setTimeout(r, 15));
-    bridge.onAgentStart();
+    startLocalRun();
     const after = readOwn();
     expect(after.startedAt).toBe(before.startedAt);
     expect(after.lastActiveAt > before.lastActiveAt).toBe(true);
@@ -260,6 +298,7 @@ describe('/send', () => {
     await new Promise((r) => setTimeout(r, 30));
     expect(sent).toEqual(['hello agent']);
 
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'hi ' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'there' } });
     bridge.onAgentEnd();
@@ -289,6 +328,7 @@ describe('/send', () => {
       body: JSON.stringify({ text: 'one', correlationId: 'c-a' }),
     });
     await new Promise((r) => setTimeout(r, 30));
+    startBridgeRun();
     const second = await fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
@@ -300,7 +340,7 @@ describe('/send', () => {
   });
 
   it('rejects bridge input while a locally-started agent turn is active', async () => {
-    bridge.onAgentStart();
+    startLocalRun();
     const res = await fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
@@ -319,11 +359,14 @@ describe('/send', () => {
     await bridge.start();
     base = await bridgeBaseUrl(bridge);
 
-    const first = await fetch(`${base}/send`, {
+    const firstPending = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
       body: JSON.stringify({ text: 'long turn', correlationId: 'c-timeout' }),
     });
+    await until(() => sent.length === 1);
+    startBridgeRun();
+    const first = await firstPending;
     expect(first.status).toBe(504);
     expect(await first.json()).toMatchObject({ timedOut: true, correlationId: 'c-timeout' });
 
@@ -340,14 +383,18 @@ describe('/send', () => {
     bridge.onAgentEnd();
   });
 
-  it('releases a provider-auth failure, sanitizes it, and ignores the failed turn late agent_end', async () => {
+  it('sanitizes a provider failure and aborts its auto-retry without touching the successor', async () => {
     const firstResponse = await fetch(`${base}/stream`, {
       method: 'POST',
       headers: authed(),
       body: JSON.stringify({ text: 'use the provider', correlationId: 'c-provider-auth' }),
     });
-    await new Promise((r) => setTimeout(r, 20));
-    bridge.onAgentStart();
+    await until(() => sent.length === 1);
+    let failedRunAbortCount = 0;
+    startBridgeRun({
+      sessionManager: { getSessionId: () => 'sess-test' },
+      abort: () => { failedRunAbortCount += 1; },
+    });
     bridge.onMessageUpdate({
       assistantMessageEvent: {
         type: 'error',
@@ -369,24 +416,62 @@ describe('/send', () => {
     expect(firstText).toContain('"type":"final"');
     expect(firstText).not.toContain('must-not-leak');
     expect(firstText).not.toContain('sk-');
+    expect(failedRunAbortCount).toBe(1);
 
-    // Start the successor before Prime emits the failed turn's late agent_end.
-    // That stale event must be consumed without resolving this new request.
+    // The failed run is still active until its real agent_end, so a successor
+    // cannot be injected into an ambiguous lifecycle window.
+    const tooSoon = await fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'too soon', correlationId: 'c-too-soon' }),
+    });
+    expect(tooSoon.status).toBe(429);
+    expect(sent).toEqual(['use the provider']);
+    bridge.onAgentEnd();
+
     const second = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
       body: JSON.stringify({ text: 'retry after credentials are fixed', correlationId: 'c-retry' }),
     });
-    await new Promise((r) => setTimeout(r, 20));
+    await until(() => sent.length === 2);
     expect(sent).toEqual(['use the provider', 'retry after credentials are fixed']);
+
+    // Prime may prepare the queued action before its retry wins the handoff.
+    // Its hidden ownership marker is cached on that action and excluded from
+    // provider context; it must not be consumed by the intervening retry run.
+    const preparedSuccessor = bridge.onBeforeAgentStart({ prompt: 'retry after credentials are fixed' });
+    expect(preparedSuccessor).toBeDefined();
+    const providerContext = bridge.onContext({
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'retry after credentials are fixed' }] },
+        { role: 'custom', ...preparedSuccessor!.message },
+      ],
+    });
+    expect(providerContext?.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'retry after credentials are fixed' }] },
+    ]);
+
+    // Prime auto-retry uses agent.continue(), so it emits no ownership marker.
+    // It remains unowned, is aborted, and neither its output nor its end can
+    // settle the queued successor.
+    let retryAbortCount = 0;
+    const retryCtx = {
+      sessionManager: { getSessionId: () => 'sess-test' },
+      abort: () => { retryAbortCount += 1; },
+    };
+    bridge.onAgentStart(retryCtx);
+    bridge.onBeforeProviderRequest(retryCtx);
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'retry output from failed turn' } });
     bridge.onAgentEnd();
+    expect(retryAbortCount).toBe(1);
     const settledByStaleEnd = await Promise.race([
       second.then(() => true),
       new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25)),
     ]);
     expect(settledByStaleEnd).toBe(false);
 
-    bridge.onAgentStart();
+    startBridgeRun(undefined, preparedSuccessor);
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'recovered' } });
     bridge.onAgentEnd();
     const secondResponse = await second;
@@ -410,7 +495,7 @@ describe('/send', () => {
       body: JSON.stringify({ text: 'hung turn', correlationId: 'c-hard-timeout' }),
     });
     await new Promise((r) => setTimeout(r, 10));
-    bridge.onAgentStart({
+    startBridgeRun({
       sessionManager: { getSessionId: () => 'sess-hard-timeout' },
       abort: () => { abortCount += 1; },
     });
@@ -426,19 +511,22 @@ describe('/send', () => {
 
     await new Promise((r) => setTimeout(r, 70));
     expect(abortCount).toBe(1);
+    // The hard timeout aborts but keeps admission closed until Prime confirms
+    // the lifecycle boundary with agent_end.
+    bridge.onAgentEnd();
     const recovered = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
       body: JSON.stringify({ text: 'after hard timeout', correlationId: 'c-after-hard' }),
     });
-    await new Promise((r) => setTimeout(r, 20));
-    bridge.onAgentStart();
+    await until(() => sent.length === 2);
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'accepted' } });
     bridge.onAgentEnd();
     expect((await recovered).status).toBe(200);
   });
 
-  it('discards a zombie turn stale deltas and abort error so they never touch the successor', async () => {
+  it('keeps a zombie run closed through its end and discards an unowned retry tail', async () => {
     await bridge.stop();
     bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-stale-events', {
       turnIdleTimeoutMs: 30,
@@ -454,10 +542,27 @@ describe('/send', () => {
       body: JSON.stringify({ text: 'zombie turn', correlationId: 'c-zombie' }),
     });
     await until(() => sent.length === 1);
-    bridge.onAgentStart();
+    startBridgeRun();
     expect((await firstPromise).status).toBe(504);
 
     await new Promise((r) => setTimeout(r, 90));
+
+    const tooSoon = await fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'successor', correlationId: 'c-successor' }),
+    });
+    expect(tooSoon.status).toBe(429);
+    expect(sent).toEqual(['zombie turn']);
+
+    // The zombie keeps talking after its terminal verdict. It owns no live
+    // bridge request, and admission stays closed until its real agent_end.
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie-tail ' } });
+    bridge.onMessageUpdate({
+      assistantMessageEvent: { type: 'error', reason: 'aborted' },
+      message: { role: 'assistant', stopReason: 'aborted' },
+    });
+    bridge.onAgentEnd();
 
     const successor = fetch(`${base}/send`, {
       method: 'POST',
@@ -466,17 +571,19 @@ describe('/send', () => {
     });
     await until(() => sent.length === 2);
     expect(sent).toEqual(['zombie turn', 'successor']);
-    // The zombie keeps talking before the successor's agent_start: trailing
-    // deltas, an abort's own error frame, then its agent_end. None of it may
-    // contaminate, fail, or settle the successor request.
-    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie-tail ' } });
-    bridge.onMessageUpdate({
-      assistantMessageEvent: { type: 'error', reason: 'aborted' },
-      message: { role: 'assistant', stopReason: 'aborted' },
-    });
-    bridge.onAgentEnd();
 
+    // A continuation/retry has no before_agent_start and therefore cannot
+    // claim or settle the pending successor.
     bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie-retry-tail ' } });
+    bridge.onAgentEnd();
+    const settledByRetry = await Promise.race([
+      successor.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25)),
+    ]);
+    expect(settledByRetry).toBe(false);
+
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'fresh answer' } });
     bridge.onAgentEnd();
     const res = await successor;
@@ -484,47 +591,54 @@ describe('/send', () => {
     expect(await res.json()).toMatchObject({ text: 'fresh answer', correlationId: 'c-successor' });
   });
 
-  it('keeps a queued successor alive on zombie liveness instead of spuriously idling it out', async () => {
+  it('does not let a local-turn error fail a bridge prompt queued before its own start', async () => {
     await bridge.stop();
-    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-zombie-liveness', {
-      turnIdleTimeoutMs: 80,
-      turnHardTimeoutMs: 400,
+    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-local-race', {
+      turnIdleTimeoutMs: 40,
+      turnHardTimeoutMs: 80,
     });
     await bridge.start();
     base = await bridgeBaseUrl(bridge);
 
-    const firstPromise = fetch(`${base}/send`, {
+    const pending = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
-      body: JSON.stringify({ text: 'zombie turn', correlationId: 'c-liveness-zombie' }),
+      body: JSON.stringify({ text: 'bridge prompt', correlationId: 'c-local-race' }),
     });
     await until(() => sent.length === 1);
-    bridge.onAgentStart();
-    expect((await firstPromise).status).toBe(504);
-    await new Promise((r) => setTimeout(r, 340));
+    expect(sent).toEqual(['bridge prompt']);
 
-    // Successor admitted while the zombie is still draining. Its idle window
-    // (80ms) is shorter than the zombie's remaining run (5 x 25ms): the
-    // discarded deltas must still count as liveness, or the successor 504s
-    // while its queued message later executes invisibly.
-    const successor = fetch(`${base}/send`, {
-      method: 'POST',
-      headers: authed(),
-      body: JSON.stringify({ text: 'queued successor', correlationId: 'c-liveness-succ' }),
+    // Preparation can complete before the competing local run starts. Prime
+    // retains this marker on the queued bridge action until its later commit.
+    const preparedBridge = bridge.onBeforeAgentStart({ prompt: 'bridge prompt' });
+    expect(preparedBridge).toBeDefined();
+
+    // A local prompt won Prime's admission fence just before the bridge's
+    // followUp. Its error belongs to that unowned local run, not to the queued
+    // bridge request.
+    startLocalRun('local prompt that won the race');
+    bridge.onMessageUpdate({
+      assistantMessageEvent: { type: 'error', reason: 'aborted' },
+      message: { role: 'assistant', stopReason: 'aborted' },
     });
-    await until(() => sent.length === 2);
-    for (let i = 0; i < 5; i += 1) {
-      await new Promise((r) => setTimeout(r, 25));
-      bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie noise' } });
-    }
     bridge.onAgentEnd();
 
-    bridge.onAgentStart();
+    // Bridge timers begin only when its cached ownership marker is emitted, so
+    // waiting beyond both configured limits here cannot return a false terminal
+    // verdict for a prompt that is still queued.
+    await new Promise((r) => setTimeout(r, 100));
+    const settledByLocalFailure = await Promise.race([
+      pending.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 20)),
+    ]);
+    expect(settledByLocalFailure).toBe(false);
+
+    startBridgeRun(undefined, preparedBridge);
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'fresh' } });
     bridge.onAgentEnd();
-    const res = await successor;
+    const res = await pending;
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ text: 'fresh', correlationId: 'c-liveness-succ' });
+    expect(await res.json()).toMatchObject({ text: 'fresh', correlationId: 'c-local-race' });
   });
 
   it('reports PRIME_AGENT_TURN_TIMEOUT when the hard limit fires while the turn is still live', async () => {
@@ -543,7 +657,7 @@ describe('/send', () => {
       body: JSON.stringify({ text: 'never ends', correlationId: 'c-hard-first' }),
     });
     await until(() => sent.length === 1);
-    bridge.onAgentStart({
+    startBridgeRun({
       sessionManager: { getSessionId: () => 'sess-hard-first' },
       abort: () => { abortCount += 1; },
     });
@@ -568,7 +682,7 @@ describe('/send', () => {
       body: JSON.stringify({ text: 'use the provider', correlationId: 'c-send-auth' }),
     });
     await until(() => sent.length === 1);
-    bridge.onAgentStart();
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'partial ' } });
     bridge.onMessageUpdate({
       assistantMessageEvent: {
@@ -623,8 +737,8 @@ describe('/send', () => {
       correlationId: 'c-deliver',
     });
 
-    // No agent turn ever started, so the stale-event guard set by the failure
-    // must not swallow the next real turn's events.
+    // No agent turn ever started, so a synchronous delivery rejection creates
+    // no failed-run quarantine and the next admitted prompt can own its run.
     const retry = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
@@ -632,7 +746,7 @@ describe('/send', () => {
     });
     await until(() => sent.length === 1);
     expect(sent).toEqual(['deliverable']);
-    bridge.onAgentStart();
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'delivered' } });
     bridge.onAgentEnd();
     const res = await retry;
@@ -646,7 +760,8 @@ describe('/send', () => {
       headers: authed(),
       body: JSON.stringify({ text: 'filter events', correlationId: 'c-filter' }),
     });
-    await new Promise((r) => setTimeout(r, 30));
+    await until(() => sent.length === 1);
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'thinking_delta', delta: 'secret' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_end', text: 'cumulative' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'visible' } });
@@ -666,7 +781,8 @@ describe('/stream', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/event-stream');
 
-    await new Promise((r) => setTimeout(r, 30));
+    await until(() => sent.length === 1);
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'alpha' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'beta' } });
     bridge.onAgentEnd();

--- a/packages/adapter-prime-agent/test/sanitized-provider-failure.test.ts
+++ b/packages/adapter-prime-agent/test/sanitized-provider-failure.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Pins the pure classification contract of `sanitizedProviderFailure`: which
+ * event fields it reads (assistantMessageEvent.reason / message.stopReason,
+ * NOT the also-declared error.stopReason), the precedence of the credential
+ * regex over the abort marker, and the input cap that keeps the regex off
+ * provider-sized diagnostics.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sanitizedProviderFailure } from '../extension/src/extension.js';
+
+const errorEvent = (errorMessage: string) => ({
+  assistantMessageEvent: { type: 'error', error: { errorMessage } },
+});
+
+describe('sanitizedProviderFailure', () => {
+  it.each([
+    ['Unauthorized', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['request was unauthorised upstream', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['provider authentication failed for account', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['{"error":{"code":"invalid_api_key"}}', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['invalid api key supplied', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['incorrect api key provided', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['http 401 from provider', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['status: 401', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['status code = 401', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['HTTP=401', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['connection reset by peer', 'PRIME_AGENT_PROVIDER_ERROR'],
+    ['status 4011 is not an auth failure', 'PRIME_AGENT_PROVIDER_ERROR'],
+    ['', 'PRIME_AGENT_PROVIDER_ERROR'],
+  ])('classifies %j as %s', (errorMessage, code) => {
+    expect(sanitizedProviderFailure(errorEvent(errorMessage)).code).toBe(code);
+  });
+
+  it('classifies an abort via assistantMessageEvent.reason', () => {
+    expect(
+      sanitizedProviderFailure({ assistantMessageEvent: { type: 'error', reason: 'aborted' } }).code,
+    ).toBe('PRIME_AGENT_TURN_ABORTED');
+  });
+
+  it('classifies an abort via message.stopReason', () => {
+    expect(
+      sanitizedProviderFailure({
+        assistantMessageEvent: { type: 'error' },
+        message: { role: 'assistant', stopReason: 'aborted' },
+      }).code,
+    ).toBe('PRIME_AGENT_TURN_ABORTED');
+  });
+
+  it('reports an event with no diagnostic at all as a generic provider error', () => {
+    expect(sanitizedProviderFailure({ assistantMessageEvent: { type: 'error' } }).code).toBe(
+      'PRIME_AGENT_PROVIDER_ERROR',
+    );
+  });
+
+  it('prefers the credential classification when an aborted turn also carries auth text', () => {
+    expect(
+      sanitizedProviderFailure({
+        assistantMessageEvent: {
+          type: 'error',
+          reason: 'aborted',
+          error: { errorMessage: 'Unauthorized' },
+        },
+      }).code,
+    ).toBe('PRIME_AGENT_PROVIDER_UNAUTHORIZED');
+  });
+
+  it('joins both diagnostic fields for classification', () => {
+    expect(
+      sanitizedProviderFailure({
+        assistantMessageEvent: { type: 'error', error: { errorMessage: 'provider exploded' } },
+        message: { role: 'assistant', errorMessage: 'authentication failed' },
+      }).code,
+    ).toBe('PRIME_AGENT_PROVIDER_UNAUTHORIZED');
+  });
+
+  it('only classifies the capped head of an oversized diagnostic', () => {
+    // A marker past the cap must not flip the classification: the cap exists
+    // so hostile provider-sized payloads never reach the regex.
+    expect(
+      sanitizedProviderFailure(errorEvent(' '.repeat(5000) + 'Unauthorized')).code,
+    ).toBe('PRIME_AGENT_PROVIDER_ERROR');
+  });
+
+  it('still scans the second diagnostic field when the first is oversized', () => {
+    // The cap is per field, not on the joined text: an oversized assistant
+    // diagnostic must not starve message.errorMessage out of classification.
+    expect(
+      sanitizedProviderFailure({
+        assistantMessageEvent: { type: 'error', error: { errorMessage: 'x'.repeat(5000) } },
+        message: { role: 'assistant', errorMessage: 'authentication failed' },
+      }).code,
+    ).toBe('PRIME_AGENT_PROVIDER_UNAUTHORIZED');
+  });
+
+  it('does not let truncation fabricate an auth marker at the cap boundary', () => {
+    // Full text says "status: 4013" (not an auth status); the 4096-char cut
+    // would land exactly after "...status: 401". The trailing partial token is
+    // stripped, so this must stay a generic provider error.
+    const diagnostic = 'x'.repeat(4084) + ' status: 4013 from provider';
+    expect(sanitizedProviderFailure(errorEvent(diagnostic)).code).toBe(
+      'PRIME_AGENT_PROVIDER_ERROR',
+    );
+  });
+
+  it('never leaks the raw diagnostic into the sanitized message', () => {
+    const failure = sanitizedProviderFailure(errorEvent('Unauthorized key sk-must-not-leak'));
+    expect(failure.message).not.toContain('sk-');
+    expect(failure.message).not.toContain('must-not-leak');
+  });
+});

--- a/packages/cli/src/daemon/routes/prime-agent.ts
+++ b/packages/cli/src/daemon/routes/prime-agent.ts
@@ -100,6 +100,12 @@ function isPrimeAgentTimeoutError(err: unknown): boolean {
   );
 }
 
+// Must stay in lock-step with PrimeAgentTurnErrorCode in
+// packages/adapter-prime-agent/extension/src/extension.ts (the producer) and
+// the per-code branches in
+// packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts:
+// a bridge code missing here degrades to a generic BRIDGE_ERROR on /send
+// while /stream forwards the SSE frame verbatim, and the transports diverge.
 const SANITIZED_PRIME_AGENT_BRIDGE_FAILURES: Readonly<Record<string, string>> = {
   PRIME_AGENT_PROVIDER_UNAUTHORIZED:
     'Prime Agent provider authentication failed. Check the configured provider credentials.',
@@ -109,15 +115,17 @@ const SANITIZED_PRIME_AGENT_BRIDGE_FAILURES: Readonly<Record<string, string>> = 
   PRIME_AGENT_DELIVERY_FAILED: 'Prime Agent rejected the local message before starting the turn.',
 };
 
-function sanitizedPrimeAgentBridgeFailure(text: string): { code: string; error: string } | null {
-  try {
-    const parsed = JSON.parse(text) as { code?: unknown };
-    const code = typeof parsed?.code === 'string' ? parsed.code : '';
-    const error = SANITIZED_PRIME_AGENT_BRIDGE_FAILURES[code];
-    return error ? { code, error } : null;
-  } catch {
-    return null;
-  }
+function sanitizedPrimeAgentBridgeFailure(
+  body: Record<string, unknown>,
+): { code: string; error: string } | null {
+  const code = typeof body.code === 'string' ? body.code : '';
+  // Own-property check: a hostile `code` like "constructor" or "__proto__"
+  // must fall through to the generic BRIDGE_ERROR envelope, not resolve a
+  // truthy value off Object.prototype.
+  const error = Object.hasOwn(SANITIZED_PRIME_AGENT_BRIDGE_FAILURES, code)
+    ? SANITIZED_PRIME_AGENT_BRIDGE_FAILURES[code]
+    : undefined;
+  return error ? { code, error } : null;
 }
 
 /**
@@ -200,30 +208,34 @@ export async function handlePrimeAgentRoutes(ctx: RequestContext): Promise<void>
       });
       const text = await forwardRes.text();
       if (!forwardRes.ok) {
+        let bridgeBody: Record<string, unknown> = {};
+        try {
+          const parsed = JSON.parse(text);
+          if (parsed && typeof parsed === 'object') bridgeBody = parsed as Record<string, unknown>;
+        } catch {
+          /* non-JSON body: the fallback envelopes below still tell the UI what happened */
+        }
         if (forwardRes.status === 504) {
           // The bridge's own idle-timeout verdict. Its JSON body carries any
           // partial turn output, which must reach the UI rather than being
           // flattened into a generic bridge fault.
-          let bridgeBody: Record<string, unknown> = {};
-          try {
-            const parsed = JSON.parse(text);
-            if (parsed && typeof parsed === 'object') bridgeBody = parsed as Record<string, unknown>;
-          } catch {
-            /* non-JSON body: the timeout envelope alone still tells the UI what happened */
-          }
           return jsonResponse(res, 504, {
             ...timeoutBody(payload.correlationId, target.sessionId, PRIME_AGENT_CHANNEL_RESPONSE_TIMEOUT_MS),
             ...('text' in bridgeBody ? { text: bridgeBody.text } : {}),
             ...('timedOut' in bridgeBody ? { timedOut: bridgeBody.timedOut } : {}),
           });
         }
-        const terminalFailure = sanitizedPrimeAgentBridgeFailure(text);
+        const terminalFailure = sanitizedPrimeAgentBridgeFailure(bridgeBody);
         if (terminalFailure) {
           // Only forward codes from the fixed allowlist above. The provider's
           // raw error body may contain credential-bearing diagnostics and must
-          // not cross the bridge/daemon trust boundary.
+          // not cross the bridge/daemon trust boundary. The partial transcript
+          // is the exception: it only ever accumulates verified text_delta
+          // frames, and the UI renders it (LocalAgentApiError.text) exactly as
+          // it does for the idle-timeout 504 above.
           return jsonResponse(res, 502, {
             ...terminalFailure,
+            ...(typeof bridgeBody.text === 'string' ? { text: bridgeBody.text } : {}),
             source: 'prime-agent-channel',
             sessionId: target.sessionId,
             correlationId: payload.correlationId,

--- a/packages/cli/test/daemon-prime-agent.test.ts
+++ b/packages/cli/test/daemon-prime-agent.test.ts
@@ -386,6 +386,66 @@ describe('/api/prime-agent-channel/send', () => {
     expect(res.body).not.toContain('sk-');
   });
 
+  it('forwards the partial transcript with a terminal code while replacing the bridge message', async () => {
+    const bridge = await startStubBridge({
+      sessionId: 's1',
+      sendStatus: 503,
+      sendBody: {
+        error: 'Prime Agent turn exceeded the 3300000ms hard limit.',
+        code: 'PRIME_AGENT_TURN_TIMEOUT',
+        text: 'partial answer so far',
+        details: { providerToken: 'must-not-leak' },
+      },
+    });
+    writeDescriptor('s1', bridge.url);
+
+    const res = makeJsonResponse();
+    await handlePrimeAgentRoutes({
+      req: makeJsonRequest('POST', '/api/prime-agent-channel/send', { text: 'hi', correlationId: 'c-hard' }),
+      res,
+      config: enabledConfig(),
+      bridgeAuthToken: 'bridge-token',
+      path: '/api/prime-agent-channel/send',
+    } as any);
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      code: 'PRIME_AGENT_TURN_TIMEOUT',
+      error: 'Prime Agent turn exceeded its hard limit.',
+      // The partial transcript is deltas-only output and reaches the UI, just
+      // like the idle-timeout 504 below preserves it.
+      text: 'partial answer so far',
+      source: 'prime-agent-channel',
+      correlationId: 'c-hard',
+      retryable: false,
+    });
+    // The daemon substitutes its own message and never forwards bridge details.
+    expect(res.body).not.toContain('must-not-leak');
+    expect(res.body).not.toContain('3300000');
+  });
+
+  it('treats a prototype-key bridge code as a generic bridge error, not an allowlist hit', async () => {
+    const bridge = await startStubBridge({
+      sessionId: 's1',
+      sendStatus: 503,
+      sendBody: { error: 'boom', code: 'constructor' },
+    });
+    writeDescriptor('s1', bridge.url);
+
+    const res = makeJsonResponse();
+    await handlePrimeAgentRoutes({
+      req: makeJsonRequest('POST', '/api/prime-agent-channel/send', { text: 'hi', correlationId: 'c-proto' }),
+      res,
+      config: enabledConfig(),
+      bridgeAuthToken: 'bridge-token',
+      path: '/api/prime-agent-channel/send',
+    } as any);
+
+    expect(res.statusCode).toBe(502);
+    expect(JSON.parse(res.body).code).toBe('BRIDGE_ERROR');
+  });
+
   it('propagates the bridge idle timeout with its partial text instead of a generic 502', async () => {
     const bridge = await startStubBridge({
       sessionId: 's1',

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
@@ -21,6 +21,12 @@ export function formatLocalAgentErrorMessage(
     if (err.code === 'PRIME_AGENT_SESSION_BUSY') {
       return `${integration.name} session is busy — try again in a moment.`;
     }
+    // The PRIME_AGENT_* terminal codes below must stay in lock-step with
+    // PrimeAgentTurnErrorCode in
+    // packages/adapter-prime-agent/extension/src/extension.ts and
+    // SANITIZED_PRIME_AGENT_BRIDGE_FAILURES in
+    // packages/cli/src/daemon/routes/prime-agent.ts; an unmatched code falls
+    // through to the raw daemon message at the bottom of this function.
     if (err.code === 'PRIME_AGENT_PROVIDER_UNAUTHORIZED') {
       return `${integration.name} provider authentication failed. Check its provider credentials and try again.`;
     }

--- a/packages/node-ui/test/local-agent-errors.test.ts
+++ b/packages/node-ui/test/local-agent-errors.test.ts
@@ -27,4 +27,19 @@ describe('Prime Agent terminal error messages', () => {
       'Prime Agent turn exceeded its maximum run time.',
     );
   });
+
+  // The mapper falls through to the raw message when no branch matches, so a
+  // dropped branch degrades silently — every terminal code needs a pin.
+  it.each([
+    ['PRIME_AGENT_PROVIDER_ERROR', 'Prime Agent provider request failed. Check its provider configuration and try again.'],
+    ['PRIME_AGENT_TURN_ABORTED', 'Prime Agent turn was aborted.'],
+    ['PRIME_AGENT_DELIVERY_FAILED', 'Prime Agent rejected the message before starting the turn.'],
+  ])('renders %s with its per-code guidance', (code, expected) => {
+    const error = new LocalAgentApiError('sanitized bridge failure', {
+      code,
+      source: 'prime-agent-channel',
+    });
+
+    expect(formatLocalAgentErrorMessage(primeAgent, error)).toBe(expected);
+  });
 });


### PR DESCRIPTION
## Outcome

Follow-up to #2123, closing every finding from its [post-merge review](https://github.com/OriginTrail/dkg/pull/2123#pullrequestreview-4878124925) on the 10.0.13 testnet-canary head.

A failed Prime turn can no longer talk into its successor's transcript, the provider-error sanitizer is no longer a quadratic-backtracking DoS primitive, and a terminal provider failure now reaches the Node UI with the partial answer the turn had already produced.

## Changes

**Stale-event guard hoisted over all agent events** (`adapter-prime-agent/extension.ts`)
`#discardNextAgentEnd` guarded only the failed turn's late `agent_end`. Its trailing `text_delta`s (a zombie turn the hard-timeout `abort` could not stop — `abort` is optional on `ExtensionCtxLike` and a throwing abort is swallowed) landed in the successor's `chunks` and SSE stream, and the `{type:'error', reason:'aborted'}` frame the abort itself produces could instantly fail a freshly admitted successor as `PRIME_AGENT_TURN_ABORTED`. The flag is renamed `#discardStaleTurnEvents` and now short-circuits `onMessageUpdate` entirely: everything between `#failTurn` and the successor's `agent_start` belongs to the failed turn, and a successor's own events always follow the `agent_start` that clears the flag.

**ReDoS fix in `sanitizedProviderFailure`**
`\s*[:=]?\s*` backtracks quadratically when `[:=]` is absent — measured 4× per input doubling on provider-controlled text ("status" + 80K spaces ≈ 3.6 s on an M-series laptop), which pins the extension's event loop. The tail is now the linear `\s*(?:[:=]\s*)?` (match-equivalent, ~1 ms at 1 MB) and classification input is capped at 4096 chars — per field, so an oversized first diagnostic can't starve the second, with the trailing partial token stripped at a truncation so a cut through `status: 4013` can't fabricate a matching `status: 401`.

**Zombie liveness still counts for a queued successor**
With stale deltas discarded, a successor queued behind an abort-less zombie would have lost its only pre-`agent_start` liveness signal and idled out to 504 while its message later executed invisibly. The guard branch re-arms the pending turn's idle timer on delta-type stale events (content still discarded), so the successor stays pending exactly as long as the session loop is provably draining toward its followUp.

**Daemon allowlist lookup is own-property only**
`SANITIZED_PRIME_AGENT_BRIDGE_FAILURES[code]` resolved prototype keys — a bridge body with `code: "constructor"` produced a malformed terminal envelope instead of the generic `BRIDGE_ERROR` fallback. The lookup now goes through `Object.hasOwn`.

**Daemon terminal-failure 502 keeps the partial transcript** (`cli/daemon/routes/prime-agent.ts`)
The bridge's terminal 503 body carries `text` — deltas-only output, never provider diagnostics — and `LocalAgentApiError.text` exists precisely to render it; the idle-timeout 504 branch already forwards it. The allowlist branch now does too, and the non-OK path parses the bridge body once instead of twice. Raw bridge `error`/`details` still never cross the boundary.

**Turn-association gap documented, not fixed**
The `error` event carries no turn identity, so in the pre-`agent_start` admission window an operator abort of a locally-typed turn still fails a pending bridge turn whose followUp may execute later. Closing that needs turn-association data from the Prime event API; the constraint is now stated at the `error` branch rather than left implicit.

**Lock-step comments** at all three hand-maintained code-list sites (adapter union, daemon allowlist, node-ui mapper), each naming the other two.

## Tests (review coverage gaps, all closed)

All new bridge tests synchronize on observable side effects (an `until()` poll on message delivery) instead of fixed sleeps, so they don't race the loopback round-trip under CI load.

- Regression: zombie-turn stale deltas + stale abort-error frame + stale `agent_end` against an admitted successor — successor receives only its own output. Fails on the pre-fix code.
- Regression: a successor queued behind a still-draining zombie survives past its idle window on discarded-delta liveness and resolves with only its own output.
- `PRIME_AGENT_TURN_TIMEOUT` is now observable: hard limit fires while the turn is live (idle quiet), asserting the 503 body + code + abort call.
- Producer-side pin of the `/send` 503 wire shape the daemon allowlist parses (`code`, `source`, `retryable`, partial `text`, no raw provider strings).
- `PRIME_AGENT_DELIVERY_FAILED` end-to-end: injection throw → 503 + code, then full recovery of the next turn despite the guard flag set with no agent running.
- New `sanitized-provider-failure.test.ts`: table-driven classification of every regex alternation, abort via `reason` and via `message.stopReason`, credential-over-abort precedence, the per-field cap, second-field scan under an oversized first field, the truncation-boundary false positive, and no-leak of raw diagnostics.
- Daemon: allowlisted `TURN_TIMEOUT` 502 forwards `text` while substituting the daemon's message and dropping bridge `details`; a prototype-key `code` falls through to `BRIDGE_ERROR`.
- Node UI: `it.each` pins the three previously untested code renderings.

## Validation on `efb04886b` (testnet-canary head)

- Prime adapter: 4 files, 79 tests passed (bridge-contract run 3× for timing stability).
- CLI Prime daemon: 24 tests passed.
- Node UI: 2203 tests passed (38 skipped), full suite.
- Adapter, CLI, and Node UI TypeScript builds passed.
- `git diff --check` clean; regenerated `localhost_contracts.json` excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
