### PR TITLE
fix(prime-agent): keep long UI turns alive

### DIFF
--- a/packages/adapter-prime-agent/extension/src/extension.ts
+++ b/packages/adapter-prime-agent/extension/src/extension.ts
@@ -67,6 +67,11 @@ interface ExtensionApiLike {
 
 const ADAPTER_STATE_DIRNAME = '.dkg-adapter-prime-agent';
 const TURN_IDLE_TIMEOUT_MS = 15 * 60_000; // matches the daemon's channel timeout
+// Keep every HTTP hop alive while Prime is doing non-text work. Thinking and
+// tool-call deltas reset the agent idle timer below, but they are intentionally
+// not exposed as transcript bytes; without an independent transport heartbeat,
+// a browser/proxy can abandon an otherwise healthy turn as an idle response.
+const SSE_KEEPALIVE_INTERVAL_MS = 15_000;
 // Deliberately below the daemon's 60-minute transport backstop so the bridge
 // emits a terminal verdict and releases its one-turn guard before the daemon
 // has to abort the HTTP connection.
@@ -137,6 +142,7 @@ interface PendingTurn {
   resolve: (outcome: TurnOutcome) => void;
   idleTimer: NodeJS.Timeout;
   hardTimer: NodeJS.Timeout;
+  keepaliveTimer: NodeJS.Timeout | undefined;
 }
 
 interface TurnOutcome {
@@ -201,16 +207,22 @@ class SessionBridge {
   #closed = false;
   readonly #turnIdleTimeoutMs: number;
   readonly #turnHardTimeoutMs: number;
+  readonly #sseKeepaliveIntervalMs: number;
 
   constructor(
     pi: ExtensionApiLike,
     sessionId: string,
-    options: { turnIdleTimeoutMs?: number; turnHardTimeoutMs?: number } = {},
+    options: {
+      turnIdleTimeoutMs?: number;
+      turnHardTimeoutMs?: number;
+      sseKeepaliveIntervalMs?: number;
+    } = {},
   ) {
     this.#pi = pi;
     this.#sessionId = sessionId;
     this.#turnIdleTimeoutMs = options.turnIdleTimeoutMs ?? TURN_IDLE_TIMEOUT_MS;
     this.#turnHardTimeoutMs = options.turnHardTimeoutMs ?? TURN_HARD_TIMEOUT_MS;
+    this.#sseKeepaliveIntervalMs = options.sseKeepaliveIntervalMs ?? SSE_KEEPALIVE_INTERVAL_MS;
   }
 
   get sessionId(): string {
@@ -430,6 +442,7 @@ class SessionBridge {
         resolve,
         idleTimer: undefined as unknown as NodeJS.Timeout,
         hardTimer: undefined as unknown as NodeJS.Timeout,
+        keepaliveTimer: undefined,
       };
       this.#turn = turn;
       this.#armIdleTimer(turn);
@@ -462,7 +475,14 @@ class SessionBridge {
       res.write(': open\n\n');
       const turn = this.#turn!;
       turn.subscribers.add(res);
-      req.on('close', () => turn.subscribers.delete(res));
+      this.#startSseKeepalive(turn);
+      const detach = () => {
+        turn.subscribers.delete(res);
+        if (turn.subscribers.size === 0) this.#stopSseKeepalive(turn);
+      };
+      req.on('aborted', detach);
+      res.on('close', detach);
+      res.on('error', detach);
     }
 
     // Inject as a real user message so the turn is indistinguishable from one
@@ -603,17 +623,51 @@ class SessionBridge {
     }, this.#turnIdleTimeoutMs);
   }
 
+  #startSseKeepalive(turn: PendingTurn): void {
+    if (turn.keepaliveTimer || this.#sseKeepaliveIntervalMs <= 0) return;
+    turn.keepaliveTimer = setInterval(() => {
+      if (this.#turn !== turn || turn.responseSettled) {
+        this.#stopSseKeepalive(turn);
+        return;
+      }
+      for (const res of turn.subscribers) {
+        if (res.destroyed || res.writableEnded) {
+          turn.subscribers.delete(res);
+          continue;
+        }
+        try {
+          // SSE comments are valid heartbeat frames. Every daemon/UI reader
+          // already forwards or ignores comments, so this carries liveness
+          // without inventing a transcript event or exposing hidden work.
+          res.write(': keepalive\n\n');
+        } catch {
+          turn.subscribers.delete(res);
+        }
+      }
+      if (turn.subscribers.size === 0) this.#stopSseKeepalive(turn);
+    }, this.#sseKeepaliveIntervalMs);
+    turn.keepaliveTimer.unref?.();
+  }
+
+  #stopSseKeepalive(turn: PendingTurn): void {
+    if (!turn.keepaliveTimer) return;
+    clearInterval(turn.keepaliveTimer);
+    turn.keepaliveTimer = undefined;
+  }
+
   #settleResponse(outcome: TurnOutcome): void {
     const turn = this.#turn;
     if (!turn || turn.responseSettled) return;
     turn.responseSettled = true;
     clearTimeout(turn.idleTimer);
+    this.#stopSseKeepalive(turn);
     turn.resolve(outcome);
   }
 
   #clearTurn(turn: PendingTurn): void {
     clearTimeout(turn.idleTimer);
     clearTimeout(turn.hardTimer);
+    this.#stopSseKeepalive(turn);
     if (this.#turn === turn) this.#turn = undefined;
   }
 

--- a/packages/adapter-prime-agent/extension/src/extension.ts
+++ b/packages/adapter-prime-agent/extension/src/extension.ts
@@ -57,6 +57,37 @@ interface MessageUpdateEvent {
   };
   message?: { role?: string; content?: unknown; errorMessage?: string; stopReason?: string };
 }
+interface AgentMessageLike {
+  role?: string;
+  content?: unknown;
+  customType?: string;
+  details?: unknown;
+}
+interface BeforeAgentStartEvent {
+  prompt?: string;
+}
+interface BeforeAgentStartEventResult {
+  message: {
+    customType: string;
+    content: string;
+    display: boolean;
+    details: { ownershipToken: string };
+  };
+}
+interface MessageStartEvent {
+  message?: AgentMessageLike;
+}
+interface ContextEvent {
+  messages?: AgentMessageLike[];
+}
+interface InputEvent {
+  text?: string;
+  source?: string;
+}
+type InputEventResult =
+  | { action: 'continue' }
+  | { action: 'transform'; text: string }
+  | { action: 'handled' };
 interface ExtensionApiLike {
   on(event: string, handler: (event: any, ctx: ExtensionCtxLike) => unknown): void;
   sendUserMessage(content: string, options?: { deliverAs?: 'steer' | 'followUp' }): void;
@@ -80,6 +111,11 @@ const TURN_HARD_TIMEOUT_MS = 55 * 60_000;
 // republication that landed (atomic rename, fresh mtime) between our read and
 // the rm. Mirrored in the daemon-side reader (`session-registry.ts`).
 const PRUNE_MIN_AGE_MS = 30_000;
+// Removed by our `input` handler before Prime creates the user message. The
+// opaque tag distinguishes this extension's submission from another extension
+// (or an identical local prompt) without exposing metadata to the model.
+const BRIDGE_INPUT_TAG_PREFIX = '\u2063dkg-bridge-turn:';
+const BRIDGE_TURN_MARKER_TYPE = 'dkg.bridge.turn-owner';
 
 function agentDir(): string {
   return process.env.PRIME_AGENT_CODING_AGENT_DIR ?? join(homedir(), '.prime', 'agent');
@@ -136,13 +172,19 @@ function isProcessAlive(pid: number): boolean {
 
 interface PendingTurn {
   correlationId: string;
+  prompt: string;
+  taggedPrompt: string;
+  ownershipToken: string;
+  inputObserved: boolean;
   chunks: string[];
   subscribers: Set<ServerResponse>;
+  streamRequested: boolean;
+  clientDisconnectedAt?: string;
   responseSettled: boolean;
   resolve: (outcome: TurnOutcome) => void;
-  idleTimer: NodeJS.Timeout;
-  hardTimer: NodeJS.Timeout;
-  keepaliveTimer: NodeJS.Timeout | undefined;
+  idleTimer?: NodeJS.Timeout;
+  hardTimer?: NodeJS.Timeout;
+  keepaliveTimer?: NodeJS.Timeout;
 }
 
 interface TurnOutcome {
@@ -152,6 +194,12 @@ interface TurnOutcome {
   errorCode?: PrimeAgentTurnErrorCode;
 }
 
+// Must stay in lock-step with SANITIZED_PRIME_AGENT_BRIDGE_FAILURES in
+// packages/cli/src/daemon/routes/prime-agent.ts (the daemon's forwarding
+// allowlist) and the per-code branches in
+// packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts:
+// a code missing from the daemon map degrades to a generic BRIDGE_ERROR on
+// /send while /stream forwards it verbatim, and the two transports diverge.
 type PrimeAgentTurnErrorCode =
   | 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'
   | 'PRIME_AGENT_PROVIDER_ERROR'
@@ -164,13 +212,30 @@ interface SanitizedTurnFailure {
   message: string;
 }
 
+// Classification only ever needs the head of each diagnostic; the cap also
+// keeps the regex off provider-sized inputs, which are attacker-influenced.
+// Capped per field (not after joining) so an oversized first diagnostic
+// cannot starve the second out of classification entirely, and the trailing
+// partial token is stripped so truncation cannot fabricate a marker (a cut
+// through "status: 4013" must not leave a matching "status: 401").
+const PROVIDER_FAILURE_CLASSIFICATION_MAX_CHARS = 4096;
+
+function clipDiagnostic(value: string): string {
+  if (value.length <= PROVIDER_FAILURE_CLASSIFICATION_MAX_CHARS) return value;
+  return value.slice(0, PROVIDER_FAILURE_CLASSIFICATION_MAX_CHARS).replace(/\w+$/, '');
+}
+
 function sanitizedProviderFailure(event: MessageUpdateEvent): SanitizedTurnFailure {
   const assistantEvent = event.assistantMessageEvent;
   const raw = [assistantEvent?.error?.errorMessage, event.message?.errorMessage]
     .filter((value): value is string => typeof value === 'string')
+    .map(clipDiagnostic)
     .join('\n');
+  // `\s*(?:[:=]\s*)?` is the linear-time equivalent of `\s*[:=]?\s*`: two
+  // adjacent unbounded \s* backtrack quadratically on a long whitespace run,
+  // and this runs on raw provider error text.
   if (
-    /\bunauthori[sz]ed\b|\bauthentication failed\b|\binvalid[_ ]api[_ ]key\b|\bincorrect api key\b|\b(?:http|status(?: code)?)\s*[:=]?\s*401\b/i.test(raw)
+    /\bunauthori[sz]ed\b|\bauthentication failed\b|\binvalid[_ ]api[_ ]key\b|\bincorrect api key\b|\b(?:http|status(?: code)?)\s*(?:[:=]\s*)?401\b/i.test(raw)
   ) {
     return {
       code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
@@ -198,11 +263,17 @@ class SessionBridge {
   /** Fixed for the bridge's lifetime; re-publications move only lastActiveAt. */
   #startedAt: string | undefined;
   #turn: PendingTurn | undefined;
+  // `before_agent_start` results are cached on Prime's queued action. The
+  // hidden ownership marker therefore follows the bridge prompt into the run
+  // that actually commits, even if another local/retry run starts after its
+  // preparation hook. Local turns and agent.continue() retries have no marker.
+  #activeRunTurn: PendingTurn | undefined;
+  #runHasFreshPrompt = false;
+  // A terminal HTTP verdict must stop Prime from continuing that logical turn
+  // in the background. Retry starts have no before_agent_start; abort them
+  // until a genuinely fresh prompt boundary supersedes the failed run.
+  #failedRunQuarantined = false;
   #agentActive = false;
-  // A provider error is a terminal stream event, but Prime may still emit the
-  // corresponding agent_end shortly afterwards. If a new bridge request lands
-  // in that small window, the old agent_end must not settle the new request.
-  #discardNextAgentEnd = false;
   #abortActiveAgent: (() => void) | undefined;
   #closed = false;
   readonly #turnIdleTimeoutMs: number;
@@ -366,6 +437,9 @@ class SessionBridge {
       this.#settleResponse({ text: this.#turn.chunks.join(''), error: 'Bridge stopped' });
       this.#clearTurn(this.#turn);
     }
+    this.#activeRunTurn = undefined;
+    this.#runHasFreshPrompt = false;
+    this.#failedRunQuarantined = false;
     this.#agentActive = false;
     this.#abortActiveAgent = undefined;
     const server = this.#server;
@@ -398,7 +472,26 @@ class SessionBridge {
     if (req.method === 'GET' && path === '/health') {
       // Echo the session id: this is how the daemon detects a descriptor that
       // points at a recycled port now owned by a different session.
-      this.#json(res, 200, { ok: true, sessionId: this.#sessionId, pid: process.pid });
+      const turn = this.#turn;
+      this.#json(res, 200, {
+        ok: true,
+        sessionId: this.#sessionId,
+        pid: process.pid,
+        busy: Boolean(turn || this.#agentActive),
+        ...(turn
+          ? {
+              turnState: this.#activeRunTurn === turn ? 'running' : 'queued',
+              ...(turn.streamRequested
+                ? {
+                    clientConnected: turn.subscribers.size > 0,
+                    ...(turn.clientDisconnectedAt
+                      ? { clientDisconnectedAt: turn.clientDisconnectedAt }
+                      : {}),
+                  }
+                : {}),
+            }
+          : {}),
+      });
       return;
     }
     if (req.method === 'POST' && path === '/send') {
@@ -434,38 +527,29 @@ class SessionBridge {
     }
 
     const done = new Promise<TurnOutcome>((resolve) => {
+      const ownershipToken = randomUUID();
       const turn: PendingTurn = {
         correlationId,
+        prompt: text,
+        taggedPrompt: `${BRIDGE_INPUT_TAG_PREFIX}${ownershipToken}\u2063${text}`,
+        ownershipToken,
+        inputObserved: false,
         chunks: [],
         subscribers: new Set(),
+        streamRequested: stream,
         responseSettled: false,
         resolve,
-        idleTimer: undefined as unknown as NodeJS.Timeout,
-        hardTimer: undefined as unknown as NodeJS.Timeout,
         keepaliveTimer: undefined,
       };
       this.#turn = turn;
-      this.#armIdleTimer(turn);
-      turn.hardTimer = setTimeout(() => {
-        if (this.#turn !== turn) return;
-        const abort = this.#abortActiveAgent;
-        this.#failTurn({
-          code: 'PRIME_AGENT_TURN_TIMEOUT',
-          message: `Prime Agent turn exceeded the ${this.#turnHardTimeoutMs}ms hard limit.`,
-        });
-        try {
-          abort?.();
-        } catch {
-          /* the bridge state is already safely released */
-        }
-      }, this.#turnHardTimeoutMs);
-      turn.hardTimer.unref?.();
     });
+    const admittedTurn = this.#turn!;
 
     if (stream) {
       res.writeHead(200, {
         'Content-Type': 'text/event-stream; charset=utf-8',
         'Cache-Control': 'no-cache',
+        'X-Accel-Buffering': 'no',
         Connection: 'keep-alive',
       });
       // Flush headers immediately with an SSE comment. Without a first write,
@@ -473,12 +557,18 @@ class SessionBridge {
       // the first delta — which for a slow first token looks like a hang, and
       // for a turn that produces no tokens at all never resolves.
       res.write(': open\n\n');
-      const turn = this.#turn!;
-      turn.subscribers.add(res);
-      this.#startSseKeepalive(turn);
+      admittedTurn.subscribers.add(res);
+      this.#startSseKeepalive(admittedTurn);
       const detach = () => {
-        turn.subscribers.delete(res);
-        if (turn.subscribers.size === 0) this.#stopSseKeepalive(turn);
+        admittedTurn.subscribers.delete(res);
+        if (
+          this.#turn === admittedTurn
+          && admittedTurn.subscribers.size === 0
+          && !admittedTurn.clientDisconnectedAt
+        ) {
+          admittedTurn.clientDisconnectedAt = new Date().toISOString();
+        }
+        if (admittedTurn.subscribers.size === 0) this.#stopSseKeepalive(admittedTurn);
       };
       req.on('aborted', detach);
       res.on('close', detach);
@@ -491,9 +581,9 @@ class SessionBridge {
     // follow-up for the remaining race window so a locally-started turn is
     // never interrupted by a remote UI message.
     try {
-      this.#pi.sendUserMessage(text, { deliverAs: 'followUp' });
+      this.#pi.sendUserMessage(admittedTurn.taggedPrompt, { deliverAs: 'followUp' });
     } catch {
-      this.#failTurn({
+      this.#failTurn(admittedTurn, {
         code: 'PRIME_AGENT_DELIVERY_FAILED',
         message: 'Prime Agent rejected the local message before starting the turn.',
       });
@@ -545,8 +635,87 @@ class SessionBridge {
 
   /* ── agent event plumbing ───────────────────────────────────────────────── */
 
-  onMessageUpdate(event: MessageUpdateEvent): void {
+  onInput(event: InputEvent): InputEventResult {
+    if (event.source !== 'extension' || typeof event.text !== 'string') {
+      return { action: 'continue' };
+    }
     const turn = this.#turn;
+    if (turn && !turn.responseSettled && event.text === turn.taggedPrompt) {
+      turn.inputObserved = true;
+      return { action: 'transform', text: turn.prompt };
+    }
+    // A tagged submission whose HTTP request was already cleared must never
+    // execute later. Swallow it instead of letting the internal tag or a
+    // fail-then-execute side effect reach Prime.
+    if (event.text.startsWith(BRIDGE_INPUT_TAG_PREFIX)) return { action: 'handled' };
+    return { action: 'continue' };
+  }
+
+  onBeforeAgentStart(event: BeforeAgentStartEvent): BeforeAgentStartEventResult | undefined {
+    // Prime caches this result on the queued turn action. Unlike transient
+    // bridge state, the marker survives a deferred handoff and is emitted only
+    // when that exact prepared action enters the agent loop.
+    const turn = this.#turn;
+    if (!turn || !turn.inputObserved || turn.responseSettled || event.prompt !== turn.prompt) {
+      return undefined;
+    }
+    return {
+      message: {
+        customType: BRIDGE_TURN_MARKER_TYPE,
+        content: '',
+        display: false,
+        details: { ownershipToken: turn.ownershipToken },
+      },
+    };
+  }
+
+  onMessageStart(event: MessageStartEvent): void {
+    const message = event.message;
+    if (message?.role === 'user') {
+      this.#runHasFreshPrompt = true;
+      this.#failedRunQuarantined = false;
+      return;
+    }
+    if (message?.role !== 'custom' || message.customType !== BRIDGE_TURN_MARKER_TYPE) return;
+    const ownershipToken =
+      message.details && typeof message.details === 'object'
+        ? (message.details as { ownershipToken?: unknown }).ownershipToken
+        : undefined;
+    const turn = this.#turn;
+    if (turn && !turn.responseSettled && ownershipToken === turn.ownershipToken) {
+      this.#activeRunTurn = turn;
+      this.#armTurnTimers(turn);
+    }
+  }
+
+  onContext(event: ContextEvent): { messages: AgentMessageLike[] } | undefined {
+    if (!event.messages?.some((message) => message.customType === BRIDGE_TURN_MARKER_TYPE)) {
+      return undefined;
+    }
+    // The marker is transport metadata, not conversation content. Keep it out
+    // of every provider request while retaining it in Prime's event stream as
+    // a reliable committed-action identity signal.
+    return {
+      messages: event.messages.filter((message) => message.customType !== BRIDGE_TURN_MARKER_TYPE),
+    };
+  }
+
+  onBeforeProviderRequest(ctx?: ExtensionCtxLike): void {
+    if (!this.#failedRunQuarantined || this.#runHasFreshPrompt) return;
+    // Prime retry/continue runs have agent_start but no newly emitted user
+    // message. Abort at the last hook before provider I/O so a turn that has
+    // already returned a terminal HTTP verdict cannot resume or execute tools.
+    try {
+      if (typeof ctx?.abort === 'function') ctx.abort();
+      else this.#abortActiveAgent?.();
+    } catch {
+      /* quarantine still prevents this run from owning a bridge request */
+    }
+  }
+
+  onMessageUpdate(event: MessageUpdateEvent): void {
+    const turn = this.#activeRunTurn;
+    if (!turn || this.#turn !== turn || turn.responseSettled) return;
     const assistantEvent = event.assistantMessageEvent;
     const eventType = assistantEvent?.type;
     // Prime's provider stream contract declares `error` terminal. Treat it as
@@ -554,10 +723,9 @@ class SessionBridge {
     // finish the HTTP/SSE turn, clear admission, and never expose the raw
     // provider payload (which may contain credential-bearing diagnostics).
     if (eventType === 'error') {
-      this.#failTurn(sanitizedProviderFailure(event));
+      this.#failTurn(turn, sanitizedProviderFailure(event));
       return;
     }
-    if (!turn || turn.responseSettled) return;
     // At the pinned Prime Agent API, only text_delta is user-visible answer
     // text. Thinking/tool-call deltas still prove liveness, but must never leak
     // into the response transcript.
@@ -578,9 +746,8 @@ class SessionBridge {
   }
 
   onAgentStart(ctx?: ExtensionCtxLike): void {
-    // If a failed turn never emitted agent_end, this start necessarily belongs
-    // to the successor and supersedes the stale-end guard.
-    if (this.#discardNextAgentEnd) this.#discardNextAgentEnd = false;
+    this.#activeRunTurn = undefined;
+    this.#runHasFreshPrompt = false;
     this.#agentActive = true;
     this.#abortActiveAgent = typeof ctx?.abort === 'function' ? () => ctx.abort!() : undefined;
     // Election stamp, once per turn — agent_start fires for locally-typed and
@@ -597,22 +764,33 @@ class SessionBridge {
   }
 
   onAgentEnd(): void {
-    if (this.#discardNextAgentEnd) {
-      this.#discardNextAgentEnd = false;
-      this.#agentActive = false;
-      this.#abortActiveAgent = undefined;
-      return;
-    }
     this.#agentActive = false;
     this.#abortActiveAgent = undefined;
-    const turn = this.#turn;
+    this.#runHasFreshPrompt = false;
+    const turn = this.#activeRunTurn;
+    this.#activeRunTurn = undefined;
     if (!turn) return;
-    if (!turn.responseSettled) this.#settleResponse({ text: turn.chunks.join('') });
+    if (this.#turn === turn && !turn.responseSettled) {
+      this.#settleResponse({ text: turn.chunks.join('') });
+    }
     this.#clearTurn(turn);
   }
 
+  #armTurnTimers(turn: PendingTurn): void {
+    if (turn.idleTimer || turn.hardTimer) return;
+    this.#armIdleTimer(turn);
+    turn.hardTimer = setTimeout(() => {
+      if (this.#turn !== turn) return;
+      this.#failTurn(turn, {
+        code: 'PRIME_AGENT_TURN_TIMEOUT',
+        message: `Prime Agent turn exceeded the ${this.#turnHardTimeoutMs}ms hard limit.`,
+      });
+    }, this.#turnHardTimeoutMs);
+    turn.hardTimer.unref?.();
+  }
+
   #armIdleTimer(turn: PendingTurn): void {
-    clearTimeout(turn.idleTimer);
+    if (turn.idleTimer) clearTimeout(turn.idleTimer);
     turn.idleTimer = setTimeout(() => {
       if (this.#turn !== turn || turn.responseSettled) return;
       // Resolve the HTTP request visibly as a timeout, but retain #turn until
@@ -659,21 +837,21 @@ class SessionBridge {
     const turn = this.#turn;
     if (!turn || turn.responseSettled) return;
     turn.responseSettled = true;
-    clearTimeout(turn.idleTimer);
+    if (turn.idleTimer) clearTimeout(turn.idleTimer);
     this.#stopSseKeepalive(turn);
     turn.resolve(outcome);
   }
 
   #clearTurn(turn: PendingTurn): void {
-    clearTimeout(turn.idleTimer);
-    clearTimeout(turn.hardTimer);
+    if (turn.idleTimer) clearTimeout(turn.idleTimer);
+    if (turn.hardTimer) clearTimeout(turn.hardTimer);
     this.#stopSseKeepalive(turn);
     if (this.#turn === turn) this.#turn = undefined;
   }
 
-  #failTurn(failure: SanitizedTurnFailure): void {
-    const turn = this.#turn;
-    if (turn) {
+  #failTurn(turn: PendingTurn, failure: SanitizedTurnFailure): void {
+    const ownsActiveRun = this.#activeRunTurn === turn;
+    if (this.#turn === turn) {
       this.#settleResponse({
         text: turn.chunks.join(''),
         error: failure.message,
@@ -681,12 +859,15 @@ class SessionBridge {
       });
       this.#clearTurn(turn);
     }
-    // The provider `error` event is terminal, so accepting the next request is
-    // safe. Remember that one stale agent_end may still arrive and must be
-    // consumed without touching that successor request.
-    this.#discardNextAgentEnd = true;
-    this.#agentActive = false;
-    this.#abortActiveAgent = undefined;
+    if (!ownsActiveRun) return;
+    this.#failedRunQuarantined = true;
+    // Keep #agentActive true until the actual agent_end so the bridge does not
+    // admit a successor into a run that has not reached a boundary yet.
+    try {
+      this.#abortActiveAgent?.();
+    } catch {
+      /* the ownership quarantine remains authoritative */
+    }
   }
 
   #json(res: ServerResponse, status: number, body: unknown): void {
@@ -748,8 +929,22 @@ export default function dkgBridgeExtension(pi: ExtensionApiLike): void {
     bridge?.onMessageUpdate(event);
   });
 
+  pi.on('input', (event: InputEvent) => bridge?.onInput(event) ?? { action: 'continue' });
+
+  pi.on('before_agent_start', (event: BeforeAgentStartEvent) => bridge?.onBeforeAgentStart(event));
+
   pi.on('agent_start', (_event: unknown, ctx: ExtensionCtxLike) => {
     bridge?.onAgentStart(ctx);
+  });
+
+  pi.on('message_start', (event: MessageStartEvent) => {
+    bridge?.onMessageStart(event);
+  });
+
+  pi.on('context', (event: ContextEvent) => bridge?.onContext(event));
+
+  pi.on('before_provider_request', (_event: unknown, ctx: ExtensionCtxLike) => {
+    bridge?.onBeforeProviderRequest(ctx);
   });
 
   pi.on('agent_end', () => {
@@ -766,4 +961,4 @@ export default function dkgBridgeExtension(pi: ExtensionApiLike): void {
   });
 }
 
-export { SessionBridge, tokenMatches, sessionsDir, stateDir };
+export { SessionBridge, sanitizedProviderFailure, tokenMatches, sessionsDir, stateDir };

--- a/packages/adapter-prime-agent/src/types.ts
+++ b/packages/adapter-prime-agent/src/types.ts
@@ -234,6 +234,10 @@ export interface PrimeAgentChannelHealthResponse {
   /** Which session answered; lets the daemon detect a recycled port. */
   sessionId?: string;
   sessions?: PrimeAgentSessionDescriptor[];
+  busy?: boolean;
+  turnState?: 'queued' | 'running';
+  clientConnected?: boolean;
+  clientDisconnectedAt?: string;
   error?: string;
 }
 

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -443,6 +443,51 @@ describe('/send', () => {
 });
 
 describe('/stream', () => {
+  it('keeps a non-text turn alive without exposing thinking or tool-call content', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(
+      stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never,
+      'sess-keepalive',
+      { sseKeepaliveIntervalMs: 20 },
+    );
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    const res = await fetch(`${base}/stream`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'work silently', correlationId: 'c-keepalive' }),
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toContain(': open');
+
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'thinking_delta', delta: 'hidden reasoning' } });
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'toolcall_delta', delta: 'secret tool args' } });
+
+    const heartbeat = await Promise.race([
+      reader.read(),
+      new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 150)),
+    ]);
+    expect(heartbeat).toBeDefined();
+    const heartbeatText = decoder.decode(heartbeat?.value);
+    expect(heartbeatText).toContain(': keepalive');
+    expect(heartbeatText).not.toContain('hidden reasoning');
+    expect(heartbeatText).not.toContain('secret tool args');
+
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'visible' } });
+    bridge.onAgentEnd();
+    const remainder: string[] = [];
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      remainder.push(decoder.decode(chunk.value));
+    }
+    expect(remainder.join('')).toContain('"type":"final"');
+    expect(remainder.join('')).toContain('visible');
+  });
+
   it('emits data: <json> frames of delta then final', async () => {
     const res = await fetch(`${base}/stream`, {
       method: 'POST',

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -857,10 +857,26 @@ describe('/stream', () => {
       });
       expect(health.clientDisconnectedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
-      // Disconnecting the HTTP subscriber does not cancel the Prime turn. Its
-      // real lifecycle boundary still settles and releases the bridge cleanly.
+      // Several keepalive intervals with the subscriber gone must not write to
+      // the dead response or keep an interval alive. The Prime turn itself is
+      // not cancelled and still settles at its real lifecycle boundary.
+      await new Promise((r) => setTimeout(r, 70));
       startBridgeRun();
+      bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'unseen tail' } });
       bridge.onAgentEnd();
+
+      const next = fetch(`${base}/send`, {
+        method: 'POST',
+        headers: authed(),
+        body: JSON.stringify({ text: 'after abort', correlationId: 'c-after-abort' }),
+      });
+      await until(() => sent.length === 2);
+      startBridgeRun();
+      bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'accepted' } });
+      bridge.onAgentEnd();
+      const recovered = await next;
+      expect(recovered.status).toBe(200);
+      expect(await recovered.json()).toMatchObject({ text: 'accepted', correlationId: 'c-after-abort' });
     } finally {
       setIntervalSpy.mockRestore();
       clearIntervalSpy.mockRestore();

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -488,6 +488,56 @@ describe('/stream', () => {
     expect(remainder.join('')).toContain('visible');
   });
 
+  it('prunes an aborted subscriber, keeps the turn settling, and admits the next turn', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(
+      stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never,
+      'sess-keepalive-abort',
+      { sseKeepaliveIntervalMs: 20 },
+    );
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    const controller = new AbortController();
+    const res = await fetch(`${base}/stream`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'work silently', correlationId: 'c-keepalive-abort' }),
+      signal: controller.signal,
+    });
+    const reader = res.body!.getReader();
+    await reader.read();
+    controller.abort();
+
+    // Several keepalive intervals with the subscriber gone: detach must have
+    // pruned the aborted response, and writes to it must never crash the
+    // bridge process (the exact regression an unref'd leaked interval hides).
+    await new Promise((r) => setTimeout(r, 70));
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'unseen tail' } });
+    bridge.onAgentEnd();
+
+    // The turn settled and released admission: a fresh turn runs end-to-end.
+    const next = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'after abort', correlationId: 'c-after-abort' }),
+    });
+    // Bounded poll rather than a fixed sleep: the loopback dispatch plus the
+    // bridge's admission can exceed a fixed budget on a loaded CI worker.
+    const deliveryDeadline = Date.now() + 2_000;
+    while (sent.length < 2 && Date.now() < deliveryDeadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(sent).toEqual(['work silently', 'after abort']);
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'accepted' } });
+    bridge.onAgentEnd();
+    const recovered = await next;
+    expect(recovered.status).toBe(200);
+    expect(await recovered.json()).toMatchObject({ text: 'accepted', correlationId: 'c-after-abort' });
+  });
+
   it('emits data: <json> frames of delta then final', async () => {
     const res = await fetch(`${base}/stream`, {
       method: 'POST',

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -9,7 +9,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, w
 import { createServer, Server as HttpServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SessionBridge, tokenMatches } from '../extension/src/extension.js';
 
 const TOKEN = 'test-bridge-token-value';
@@ -23,8 +23,26 @@ let base: string;
 function stubPi(onSend: (text: string, options?: { deliverAs?: 'steer' | 'followUp' }) => void) {
   return {
     on: () => {},
-    sendUserMessage: (content: string, options?: { deliverAs?: 'steer' | 'followUp' }) => onSend(content, options),
+    sendUserMessage: (content: string, options?: { deliverAs?: 'steer' | 'followUp' }) => {
+      // Mirror Prime's input normalization: the bridge tags its own submission
+      // and the input hook removes that tag before the user message is built.
+      const result = bridge.onInput({ source: 'extension', text: content });
+      if (result.action === 'handled') return;
+      onSend(result.action === 'transform' ? result.text : content, options);
+    },
   };
+}
+
+/**
+ * Deterministic barrier on an observable side effect (usually `sent` growing):
+ * fixed sleeps race the loopback HTTP round-trip under CI load, a poll cannot.
+ */
+async function until(cond: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error('until(): condition not reached in time');
+    await new Promise((r) => setTimeout(r, 2));
+  }
 }
 
 async function bridgeBaseUrl(b: SessionBridge): Promise<string> {
@@ -36,6 +54,38 @@ async function bridgeBaseUrl(b: SessionBridge): Promise<string> {
   const mine = sessions.find((s) => s.sessionId === b.sessionId);
   if (!mine) throw new Error('bridge did not publish a descriptor');
   return mine.bridgeUrl;
+}
+
+type PreparedBridgeRun = NonNullable<ReturnType<SessionBridge['onBeforeAgentStart']>>;
+
+/** Commit a bridge action using the marker Prime cached during preparation. */
+function startBridgeRun(
+  ctx?: Parameters<SessionBridge['onAgentStart']>[0],
+  prepared?: PreparedBridgeRun,
+): void {
+  const prompt = sent.at(-1);
+  if (!prompt) throw new Error('startBridgeRun(): no injected prompt');
+  const ownership = prepared ?? bridge.onBeforeAgentStart({ prompt });
+  if (!ownership) throw new Error('startBridgeRun(): prompt did not receive an ownership marker');
+  bridge.onAgentStart(ctx);
+  bridge.onMessageStart({
+    message: { role: 'user', content: [{ type: 'text', text: prompt }] },
+  });
+  bridge.onMessageStart({
+    message: { role: 'custom', ...ownership.message },
+  });
+}
+
+/** A locally typed prompt is a fresh run, but must not claim a bridge request. */
+function startLocalRun(
+  prompt = 'locally typed prompt',
+  ctx?: Parameters<SessionBridge['onAgentStart']>[0],
+): void {
+  bridge.onBeforeAgentStart({ prompt });
+  bridge.onAgentStart(ctx);
+  bridge.onMessageStart({
+    message: { role: 'user', content: [{ type: 'text', text: prompt }] },
+  });
 }
 
 beforeEach(async () => {
@@ -135,7 +185,7 @@ describe('session election', () => {
     // ISO stamps have millisecond resolution; a strictly-newer stamp needs a
     // real gap.
     await new Promise((r) => setTimeout(r, 15));
-    bridge.onAgentStart();
+    startLocalRun();
     const after = readOwn();
     expect(after.startedAt).toBe(before.startedAt);
     expect(after.lastActiveAt > before.lastActiveAt).toBe(true);
@@ -248,6 +298,7 @@ describe('/send', () => {
     await new Promise((r) => setTimeout(r, 30));
     expect(sent).toEqual(['hello agent']);
 
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'hi ' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'there' } });
     bridge.onAgentEnd();
@@ -277,6 +328,7 @@ describe('/send', () => {
       body: JSON.stringify({ text: 'one', correlationId: 'c-a' }),
     });
     await new Promise((r) => setTimeout(r, 30));
+    startBridgeRun();
     const second = await fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
@@ -288,7 +340,7 @@ describe('/send', () => {
   });
 
   it('rejects bridge input while a locally-started agent turn is active', async () => {
-    bridge.onAgentStart();
+    startLocalRun();
     const res = await fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
@@ -307,11 +359,14 @@ describe('/send', () => {
     await bridge.start();
     base = await bridgeBaseUrl(bridge);
 
-    const first = await fetch(`${base}/send`, {
+    const firstPending = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
       body: JSON.stringify({ text: 'long turn', correlationId: 'c-timeout' }),
     });
+    await until(() => sent.length === 1);
+    startBridgeRun();
+    const first = await firstPending;
     expect(first.status).toBe(504);
     expect(await first.json()).toMatchObject({ timedOut: true, correlationId: 'c-timeout' });
 
@@ -328,14 +383,18 @@ describe('/send', () => {
     bridge.onAgentEnd();
   });
 
-  it('releases a provider-auth failure, sanitizes it, and ignores the failed turn late agent_end', async () => {
+  it('sanitizes a provider failure and aborts its auto-retry without touching the successor', async () => {
     const firstResponse = await fetch(`${base}/stream`, {
       method: 'POST',
       headers: authed(),
       body: JSON.stringify({ text: 'use the provider', correlationId: 'c-provider-auth' }),
     });
-    await new Promise((r) => setTimeout(r, 20));
-    bridge.onAgentStart();
+    await until(() => sent.length === 1);
+    let failedRunAbortCount = 0;
+    startBridgeRun({
+      sessionManager: { getSessionId: () => 'sess-test' },
+      abort: () => { failedRunAbortCount += 1; },
+    });
     bridge.onMessageUpdate({
       assistantMessageEvent: {
         type: 'error',
@@ -357,24 +416,62 @@ describe('/send', () => {
     expect(firstText).toContain('"type":"final"');
     expect(firstText).not.toContain('must-not-leak');
     expect(firstText).not.toContain('sk-');
+    expect(failedRunAbortCount).toBe(1);
 
-    // Start the successor before Prime emits the failed turn's late agent_end.
-    // That stale event must be consumed without resolving this new request.
+    // The failed run is still active until its real agent_end, so a successor
+    // cannot be injected into an ambiguous lifecycle window.
+    const tooSoon = await fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'too soon', correlationId: 'c-too-soon' }),
+    });
+    expect(tooSoon.status).toBe(429);
+    expect(sent).toEqual(['use the provider']);
+    bridge.onAgentEnd();
+
     const second = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
       body: JSON.stringify({ text: 'retry after credentials are fixed', correlationId: 'c-retry' }),
     });
-    await new Promise((r) => setTimeout(r, 20));
+    await until(() => sent.length === 2);
     expect(sent).toEqual(['use the provider', 'retry after credentials are fixed']);
+
+    // Prime may prepare the queued action before its retry wins the handoff.
+    // Its hidden ownership marker is cached on that action and excluded from
+    // provider context; it must not be consumed by the intervening retry run.
+    const preparedSuccessor = bridge.onBeforeAgentStart({ prompt: 'retry after credentials are fixed' });
+    expect(preparedSuccessor).toBeDefined();
+    const providerContext = bridge.onContext({
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'retry after credentials are fixed' }] },
+        { role: 'custom', ...preparedSuccessor!.message },
+      ],
+    });
+    expect(providerContext?.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'retry after credentials are fixed' }] },
+    ]);
+
+    // Prime auto-retry uses agent.continue(), so it emits no ownership marker.
+    // It remains unowned, is aborted, and neither its output nor its end can
+    // settle the queued successor.
+    let retryAbortCount = 0;
+    const retryCtx = {
+      sessionManager: { getSessionId: () => 'sess-test' },
+      abort: () => { retryAbortCount += 1; },
+    };
+    bridge.onAgentStart(retryCtx);
+    bridge.onBeforeProviderRequest(retryCtx);
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'retry output from failed turn' } });
     bridge.onAgentEnd();
+    expect(retryAbortCount).toBe(1);
     const settledByStaleEnd = await Promise.race([
       second.then(() => true),
       new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25)),
     ]);
     expect(settledByStaleEnd).toBe(false);
 
-    bridge.onAgentStart();
+    startBridgeRun(undefined, preparedSuccessor);
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'recovered' } });
     bridge.onAgentEnd();
     const secondResponse = await second;
@@ -398,7 +495,7 @@ describe('/send', () => {
       body: JSON.stringify({ text: 'hung turn', correlationId: 'c-hard-timeout' }),
     });
     await new Promise((r) => setTimeout(r, 10));
-    bridge.onAgentStart({
+    startBridgeRun({
       sessionManager: { getSessionId: () => 'sess-hard-timeout' },
       abort: () => { abortCount += 1; },
     });
@@ -414,16 +511,247 @@ describe('/send', () => {
 
     await new Promise((r) => setTimeout(r, 70));
     expect(abortCount).toBe(1);
+    // The hard timeout aborts but keeps admission closed until Prime confirms
+    // the lifecycle boundary with agent_end.
+    bridge.onAgentEnd();
     const recovered = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
       body: JSON.stringify({ text: 'after hard timeout', correlationId: 'c-after-hard' }),
     });
-    await new Promise((r) => setTimeout(r, 20));
-    bridge.onAgentStart();
+    await until(() => sent.length === 2);
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'accepted' } });
     bridge.onAgentEnd();
     expect((await recovered).status).toBe(200);
+  });
+
+  it('keeps a zombie run closed through its end and discards an unowned retry tail', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-stale-events', {
+      turnIdleTimeoutMs: 30,
+      turnHardTimeoutMs: 80,
+    });
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    // No abort in ctx: the hard timeout cannot stop this turn, only release it.
+    const firstPromise = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'zombie turn', correlationId: 'c-zombie' }),
+    });
+    await until(() => sent.length === 1);
+    startBridgeRun();
+    expect((await firstPromise).status).toBe(504);
+
+    await new Promise((r) => setTimeout(r, 90));
+
+    const tooSoon = await fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'successor', correlationId: 'c-successor' }),
+    });
+    expect(tooSoon.status).toBe(429);
+    expect(sent).toEqual(['zombie turn']);
+
+    // The zombie keeps talking after its terminal verdict. It owns no live
+    // bridge request, and admission stays closed until its real agent_end.
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie-tail ' } });
+    bridge.onMessageUpdate({
+      assistantMessageEvent: { type: 'error', reason: 'aborted' },
+      message: { role: 'assistant', stopReason: 'aborted' },
+    });
+    bridge.onAgentEnd();
+
+    const successor = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'successor', correlationId: 'c-successor' }),
+    });
+    await until(() => sent.length === 2);
+    expect(sent).toEqual(['zombie turn', 'successor']);
+
+    // A continuation/retry has no before_agent_start and therefore cannot
+    // claim or settle the pending successor.
+    bridge.onAgentStart();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie-retry-tail ' } });
+    bridge.onAgentEnd();
+    const settledByRetry = await Promise.race([
+      successor.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25)),
+    ]);
+    expect(settledByRetry).toBe(false);
+
+    startBridgeRun();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'fresh answer' } });
+    bridge.onAgentEnd();
+    const res = await successor;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ text: 'fresh answer', correlationId: 'c-successor' });
+  });
+
+  it('does not let a local-turn error fail a bridge prompt queued before its own start', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-local-race', {
+      turnIdleTimeoutMs: 40,
+      turnHardTimeoutMs: 80,
+    });
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    const pending = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'bridge prompt', correlationId: 'c-local-race' }),
+    });
+    await until(() => sent.length === 1);
+    expect(sent).toEqual(['bridge prompt']);
+
+    // Preparation can complete before the competing local run starts. Prime
+    // retains this marker on the queued bridge action until its later commit.
+    const preparedBridge = bridge.onBeforeAgentStart({ prompt: 'bridge prompt' });
+    expect(preparedBridge).toBeDefined();
+
+    // A local prompt won Prime's admission fence just before the bridge's
+    // followUp. Its error belongs to that unowned local run, not to the queued
+    // bridge request.
+    startLocalRun('local prompt that won the race');
+    bridge.onMessageUpdate({
+      assistantMessageEvent: { type: 'error', reason: 'aborted' },
+      message: { role: 'assistant', stopReason: 'aborted' },
+    });
+    bridge.onAgentEnd();
+
+    // Bridge timers begin only when its cached ownership marker is emitted, so
+    // waiting beyond both configured limits here cannot return a false terminal
+    // verdict for a prompt that is still queued.
+    await new Promise((r) => setTimeout(r, 100));
+    const settledByLocalFailure = await Promise.race([
+      pending.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 20)),
+    ]);
+    expect(settledByLocalFailure).toBe(false);
+
+    startBridgeRun(undefined, preparedBridge);
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'fresh' } });
+    bridge.onAgentEnd();
+    const res = await pending;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ text: 'fresh', correlationId: 'c-local-race' });
+  });
+
+  it('reports PRIME_AGENT_TURN_TIMEOUT when the hard limit fires while the turn is still live', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-hard-first', {
+      turnIdleTimeoutMs: 5_000,
+      turnHardTimeoutMs: 80,
+    });
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+    let abortCount = 0;
+
+    const pending = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'never ends', correlationId: 'c-hard-first' }),
+    });
+    await until(() => sent.length === 1);
+    startBridgeRun({
+      sessionManager: { getSessionId: () => 'sess-hard-first' },
+      abort: () => { abortCount += 1; },
+    });
+
+    const res = await pending;
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      code: 'PRIME_AGENT_TURN_TIMEOUT',
+      source: 'prime-agent-channel',
+      retryable: false,
+      correlationId: 'c-hard-first',
+    });
+    expect(body.error).toContain('hard limit');
+    expect(abortCount).toBe(1);
+  });
+
+  it('shapes the /send 503 provider-failure body exactly as the daemon allowlist parses it', async () => {
+    const pending = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'use the provider', correlationId: 'c-send-auth' }),
+    });
+    await until(() => sent.length === 1);
+    startBridgeRun();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'partial ' } });
+    bridge.onMessageUpdate({
+      assistantMessageEvent: {
+        type: 'error',
+        reason: 'error',
+        error: { errorMessage: 'Unauthorized: provider key sk-must-not-leak' },
+      },
+    });
+
+    const res = await pending;
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    // The daemon's sanitizedPrimeAgentBridgeFailure reads the top-level `code`
+    // of this body, and its terminal branch forwards `text`; this pins the
+    // producer half of that wire contract.
+    expect(body).toMatchObject({
+      code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+      source: 'prime-agent-channel',
+      retryable: false,
+      text: 'partial ',
+      correlationId: 'c-send-auth',
+      sessionId: 'sess-test',
+    });
+    const rawBody = JSON.stringify(body);
+    expect(rawBody).not.toContain('must-not-leak');
+    expect(rawBody).not.toContain('sk-');
+    bridge.onAgentEnd();
+  });
+
+  it('fails fast with PRIME_AGENT_DELIVERY_FAILED when injection throws, then recovers fully', async () => {
+    await bridge.stop();
+    let rejectNext = true;
+    bridge = new SessionBridge(stubPi((t) => {
+      if (rejectNext) {
+        rejectNext = false;
+        throw new Error('session rejected the message');
+      }
+      sent.push(t);
+    }) as never, 'sess-delivery');
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    const failed = await fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'undeliverable', correlationId: 'c-deliver' }),
+    });
+    expect(failed.status).toBe(503);
+    expect(await failed.json()).toMatchObject({
+      code: 'PRIME_AGENT_DELIVERY_FAILED',
+      retryable: false,
+      correlationId: 'c-deliver',
+    });
+
+    // No agent turn ever started, so a synchronous delivery rejection creates
+    // no failed-run quarantine and the next admitted prompt can own its run.
+    const retry = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'deliverable', correlationId: 'c-deliver-2' }),
+    });
+    await until(() => sent.length === 1);
+    expect(sent).toEqual(['deliverable']);
+    startBridgeRun();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'delivered' } });
+    bridge.onAgentEnd();
+    const res = await retry;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ text: 'delivered', correlationId: 'c-deliver-2' });
   });
 
   it('only emits verified text_delta events, not thinking or cumulative snapshots', async () => {
@@ -432,7 +760,8 @@ describe('/send', () => {
       headers: authed(),
       body: JSON.stringify({ text: 'filter events', correlationId: 'c-filter' }),
     });
-    await new Promise((r) => setTimeout(r, 30));
+    await until(() => sent.length === 1);
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'thinking_delta', delta: 'secret' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_end', text: 'cumulative' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'visible' } });
@@ -458,10 +787,13 @@ describe('/stream', () => {
       headers: authed(),
       body: JSON.stringify({ text: 'work silently', correlationId: 'c-keepalive' }),
     });
+    expect(res.headers.get('x-accel-buffering')).toBe('no');
     const reader = res.body!.getReader();
     const decoder = new TextDecoder();
     const first = await reader.read();
     expect(decoder.decode(first.value)).toContain(': open');
+    await until(() => sent.length === 1);
+    startBridgeRun();
 
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'thinking_delta', delta: 'hidden reasoning' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'toolcall_delta', delta: 'secret tool args' } });
@@ -488,6 +820,53 @@ describe('/stream', () => {
     expect(remainder.join('')).toContain('visible');
   });
 
+  it('stops the keepalive interval when the downstream stream disconnects', async () => {
+    await bridge.stop();
+    bridge = new SessionBridge(
+      stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never,
+      'sess-keepalive-disconnect',
+      { sseKeepaliveIntervalMs: 20 },
+    );
+    await bridge.start();
+    base = await bridgeBaseUrl(bridge);
+
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+    try {
+      const controller = new AbortController();
+      const res = await fetch(`${base}/stream`, {
+        method: 'POST',
+        headers: authed(),
+        body: JSON.stringify({ text: 'disconnect me', correlationId: 'c-disconnect' }),
+        signal: controller.signal,
+      });
+      const reader = res.body!.getReader();
+      await reader.read(); // consume `: open` so the body is actively observed
+      const keepaliveTimer = setIntervalSpy.mock.results.at(-1)?.value;
+      expect(keepaliveTimer).toBeDefined();
+
+      controller.abort();
+      await reader.read().catch(() => undefined);
+      await until(() => clearIntervalSpy.mock.calls.some(([timer]) => timer === keepaliveTimer));
+      const health = await fetch(`${base}/health`, { headers: authed() }).then((response) => response.json());
+      expect(health).toMatchObject({
+        ok: true,
+        busy: true,
+        turnState: 'queued',
+        clientConnected: false,
+      });
+      expect(health.clientDisconnectedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+      // Disconnecting the HTTP subscriber does not cancel the Prime turn. Its
+      // real lifecycle boundary still settles and releases the bridge cleanly.
+      startBridgeRun();
+      bridge.onAgentEnd();
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+
   it('emits data: <json> frames of delta then final', async () => {
     const res = await fetch(`${base}/stream`, {
       method: 'POST',
@@ -497,7 +876,8 @@ describe('/stream', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/event-stream');
 
-    await new Promise((r) => setTimeout(r, 30));
+    await until(() => sent.length === 1);
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'alpha' } });
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'beta' } });
     bridge.onAgentEnd();

--- a/packages/adapter-prime-agent/test/sanitized-provider-failure.test.ts
+++ b/packages/adapter-prime-agent/test/sanitized-provider-failure.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Pins the pure classification contract of `sanitizedProviderFailure`: which
+ * event fields it reads (assistantMessageEvent.reason / message.stopReason,
+ * NOT the also-declared error.stopReason), the precedence of the credential
+ * regex over the abort marker, and the input cap that keeps the regex off
+ * provider-sized diagnostics.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sanitizedProviderFailure } from '../extension/src/extension.js';
+
+const errorEvent = (errorMessage: string) => ({
+  assistantMessageEvent: { type: 'error', error: { errorMessage } },
+});
+
+describe('sanitizedProviderFailure', () => {
+  it.each([
+    ['Unauthorized', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['request was unauthorised upstream', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['provider authentication failed for account', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['{"error":{"code":"invalid_api_key"}}', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['invalid api key supplied', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['incorrect api key provided', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['http 401 from provider', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['status: 401', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['status code = 401', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['HTTP=401', 'PRIME_AGENT_PROVIDER_UNAUTHORIZED'],
+    ['connection reset by peer', 'PRIME_AGENT_PROVIDER_ERROR'],
+    ['status 4011 is not an auth failure', 'PRIME_AGENT_PROVIDER_ERROR'],
+    ['', 'PRIME_AGENT_PROVIDER_ERROR'],
+  ])('classifies %j as %s', (errorMessage, code) => {
+    expect(sanitizedProviderFailure(errorEvent(errorMessage)).code).toBe(code);
+  });
+
+  it('classifies an abort via assistantMessageEvent.reason', () => {
+    expect(
+      sanitizedProviderFailure({ assistantMessageEvent: { type: 'error', reason: 'aborted' } }).code,
+    ).toBe('PRIME_AGENT_TURN_ABORTED');
+  });
+
+  it('classifies an abort via message.stopReason', () => {
+    expect(
+      sanitizedProviderFailure({
+        assistantMessageEvent: { type: 'error' },
+        message: { role: 'assistant', stopReason: 'aborted' },
+      }).code,
+    ).toBe('PRIME_AGENT_TURN_ABORTED');
+  });
+
+  it('reports an event with no diagnostic at all as a generic provider error', () => {
+    expect(sanitizedProviderFailure({ assistantMessageEvent: { type: 'error' } }).code).toBe(
+      'PRIME_AGENT_PROVIDER_ERROR',
+    );
+  });
+
+  it('prefers the credential classification when an aborted turn also carries auth text', () => {
+    expect(
+      sanitizedProviderFailure({
+        assistantMessageEvent: {
+          type: 'error',
+          reason: 'aborted',
+          error: { errorMessage: 'Unauthorized' },
+        },
+      }).code,
+    ).toBe('PRIME_AGENT_PROVIDER_UNAUTHORIZED');
+  });
+
+  it('joins both diagnostic fields for classification', () => {
+    expect(
+      sanitizedProviderFailure({
+        assistantMessageEvent: { type: 'error', error: { errorMessage: 'provider exploded' } },
+        message: { role: 'assistant', errorMessage: 'authentication failed' },
+      }).code,
+    ).toBe('PRIME_AGENT_PROVIDER_UNAUTHORIZED');
+  });
+
+  it('only classifies the capped head of an oversized diagnostic', () => {
+    // A marker past the cap must not flip the classification: the cap exists
+    // so hostile provider-sized payloads never reach the regex.
+    expect(
+      sanitizedProviderFailure(errorEvent(' '.repeat(5000) + 'Unauthorized')).code,
+    ).toBe('PRIME_AGENT_PROVIDER_ERROR');
+  });
+
+  it('still scans the second diagnostic field when the first is oversized', () => {
+    // The cap is per field, not on the joined text: an oversized assistant
+    // diagnostic must not starve message.errorMessage out of classification.
+    expect(
+      sanitizedProviderFailure({
+        assistantMessageEvent: { type: 'error', error: { errorMessage: 'x'.repeat(5000) } },
+        message: { role: 'assistant', errorMessage: 'authentication failed' },
+      }).code,
+    ).toBe('PRIME_AGENT_PROVIDER_UNAUTHORIZED');
+  });
+
+  it('does not let truncation fabricate an auth marker at the cap boundary', () => {
+    // Full text says "status: 4013" (not an auth status); the 4096-char cut
+    // would land exactly after "...status: 401". The trailing partial token is
+    // stripped, so this must stay a generic provider error.
+    const diagnostic = 'x'.repeat(4084) + ' status: 4013 from provider';
+    expect(sanitizedProviderFailure(errorEvent(diagnostic)).code).toBe(
+      'PRIME_AGENT_PROVIDER_ERROR',
+    );
+  });
+
+  it('never leaks the raw diagnostic into the sanitized message', () => {
+    const failure = sanitizedProviderFailure(errorEvent('Unauthorized key sk-must-not-leak'));
+    expect(failure.message).not.toContain('sk-');
+    expect(failure.message).not.toContain('must-not-leak');
+  });
+});

--- a/packages/cli/src/daemon/local-agents.ts
+++ b/packages/cli/src/daemon/local-agents.ts
@@ -589,7 +589,15 @@ export async function connectLocalAgentIntegrationFromUi(
       const integration = updateLocalAgentIntegration(config, requested.id, {
         transport: transportPatchFromPrimeAgentTarget(targetFromDescriptor(live)),
         runtime: { status: 'ready', ready: true, lastError: null },
-        metadata: { sessionCount: health.sessionCount, activeSessionId: live.sessionId },
+        // activeSessionId must be the ELECTION HEAD (sessions[0], most recently
+        // active), not `live`: node-ui pins chat to this id, and routing takes
+        // the head unconditionally, so a probe-survivor stamp would silently
+        // deliver operator chat into a different session than unaddressed
+        // sends. `live` (the probe survivor) is only the transport target.
+        metadata: {
+          sessionCount: health.sessionCount,
+          activeSessionId: health.sessions[0].sessionId,
+        },
       });
       return {
         integration,

--- a/packages/cli/src/daemon/local-agents.ts
+++ b/packages/cli/src/daemon/local-agents.ts
@@ -584,12 +584,16 @@ export async function connectLocalAgentIntegrationFromUi(
 
     const health = await probePrimeAgentChannelHealth(bridgeAuthToken, { timeoutMs: 3_000 });
     const live = health.sessions.find((s) => s.sessionId === health.target) ?? health.sessions[0];
+    // Routing always elects the descriptor-order head. The health probe may
+    // fall through to an older survivor, which is suitable for the transport
+    // readiness check but must never become the UI's conversation pin.
+    const activeSessionId = health.sessions[0]?.sessionId ?? null;
 
     if (health.ok && live) {
       const integration = updateLocalAgentIntegration(config, requested.id, {
         transport: transportPatchFromPrimeAgentTarget(targetFromDescriptor(live)),
         runtime: { status: 'ready', ready: true, lastError: null },
-        metadata: { sessionCount: health.sessionCount, activeSessionId: live.sessionId },
+        metadata: { sessionCount: health.sessionCount, activeSessionId },
       });
       return {
         integration,
@@ -609,7 +613,7 @@ export async function connectLocalAgentIntegrationFromUi(
         ready: false,
         lastError: health.error ?? 'no live Prime Agent session',
       },
-      metadata: { sessionCount: health.sessionCount },
+      metadata: { sessionCount: health.sessionCount, activeSessionId },
     });
     return {
       integration,
@@ -1062,6 +1066,30 @@ export async function refreshLocalAgentIntegrationFromUi(
   const existing = getLocalAgentIntegration(config, normalizedId);
   if (!existing) {
     throw new Error(`Unknown integration: ${id}`);
+  }
+  if (normalizedId === 'prime-agent') {
+    const health = await probePrimeAgentChannelHealth(bridgeAuthToken, { timeoutMs: 3_000 });
+    const live = health.sessions.find((session) => session.sessionId === health.target)
+      ?? health.sessions[0];
+    const metadata = {
+      sessionCount: health.sessionCount,
+      activeSessionId: health.sessions[0]?.sessionId ?? null,
+    };
+    if (health.ok && live) {
+      return updateLocalAgentIntegration(config, normalizedId, {
+        transport: transportPatchFromPrimeAgentTarget(targetFromDescriptor(live)),
+        runtime: { status: 'ready', ready: true, lastError: null },
+        metadata,
+      });
+    }
+    return updateLocalAgentIntegration(config, normalizedId, {
+      runtime: {
+        status: 'degraded',
+        ready: false,
+        lastError: health.error ?? 'no live Prime Agent session',
+      },
+      metadata,
+    });
   }
   if (normalizedId !== 'openclaw') {
     if (normalizedId === 'hermes') {

--- a/packages/cli/src/daemon/prime-agent.ts
+++ b/packages/cli/src/daemon/prime-agent.ts
@@ -50,6 +50,10 @@ export interface PrimeAgentChannelHealthReport {
   sessionCount: number;
   sessions: PrimeAgentSessionDescriptor[];
   target?: string;
+  busy?: boolean;
+  turnState?: 'queued' | 'running';
+  clientConnected?: boolean;
+  clientDisconnectedAt?: string;
   error?: string;
 }
 
@@ -166,7 +170,14 @@ export async function probePrimeAgentChannelHealth(
         },
         timeout,
       );
-      const parsed = body as { ok?: boolean; sessionId?: string };
+      const parsed = body as {
+        ok?: boolean;
+        sessionId?: string;
+        busy?: boolean;
+        turnState?: string;
+        clientConnected?: boolean;
+        clientDisconnectedAt?: string;
+      };
       if (ok && parsed?.ok === true) {
         // Detect a recycled port: the descriptor claims one session, the
         // process answering claims another.
@@ -174,7 +185,22 @@ export async function probePrimeAgentChannelHealth(
           lastError = `bridge at ${target.healthUrl} reports session ${parsed.sessionId}, expected ${descriptor.sessionId}`;
           continue;
         }
-        return { ok: true, sessionCount: sessions.length, sessions, target: descriptor.sessionId };
+        return {
+          ok: true,
+          sessionCount: sessions.length,
+          sessions,
+          target: descriptor.sessionId,
+          ...(typeof parsed.busy === 'boolean' ? { busy: parsed.busy } : {}),
+          ...(parsed.turnState === 'queued' || parsed.turnState === 'running'
+            ? { turnState: parsed.turnState }
+            : {}),
+          ...(typeof parsed.clientConnected === 'boolean'
+            ? { clientConnected: parsed.clientConnected }
+            : {}),
+          ...(typeof parsed.clientDisconnectedAt === 'string' && parsed.clientDisconnectedAt
+            ? { clientDisconnectedAt: parsed.clientDisconnectedAt }
+            : {}),
+        };
       }
       lastError = `health check failed for session ${descriptor.sessionId}`;
     } catch (err) {

--- a/packages/cli/src/daemon/routes/local-agents.ts
+++ b/packages/cli/src/daemon/routes/local-agents.ts
@@ -347,7 +347,10 @@ function withPrimeAgentSessionCounts<T extends { id: string; metadata?: Record<s
       metadata: {
         ...(integration.metadata ?? {}),
         sessionCount: sessions.length,
-        ...(sessions[0] ? { activeSessionId: sessions[0].sessionId } : {}),
+        // `null` intentionally overwrites a persisted connect-time id. Omitting
+        // the field would leave the UI pinned to a session that no longer has
+        // a descriptor after Prime restarts.
+        activeSessionId: sessions[0]?.sessionId ?? null,
       },
     };
   });

--- a/packages/cli/src/daemon/routes/local-agents.ts
+++ b/packages/cli/src/daemon/routes/local-agents.ts
@@ -342,18 +342,32 @@ function withPrimeAgentSessionCounts<T extends { id: string; metadata?: Record<s
       // the whole integrations listing.
       return integration;
     }
-    return {
-      ...integration,
-      metadata: {
-        ...(integration.metadata ?? {}),
-        sessionCount: sessions.length,
-        // `null` intentionally overwrites a persisted connect-time id. Omitting
-        // the field would leave the UI pinned to a session that no longer has
-        // a descriptor after Prime restarts.
-        activeSessionId: sessions[0]?.sessionId ?? null,
-      },
+    const metadata: Record<string, unknown> = {
+      ...(integration.metadata ?? {}),
+      sessionCount: sessions.length,
     };
+    if (sessions[0]) {
+      metadata.activeSessionId = sessions[0].sessionId;
+    } else {
+      // A zero-session listing must not keep advertising the connect-time
+      // session id: node-ui pins chat to activeSessionId, and a stale id
+      // routes every send into a guaranteed 409.
+      delete metadata.activeSessionId;
+    }
+    return { ...integration, metadata };
   });
+}
+
+/**
+ * Single-integration responses (get / connect / refresh) need the same overlay
+ * as the listing: node-ui upserts each of them into its integrations state, so
+ * any un-overlaid response would regress the pinned session to the persisted
+ * connect-time id until the next listing poll.
+ */
+function withPrimeAgentSessionCount<T extends { id: string; metadata?: Record<string, unknown> }>(
+  integration: T,
+): T {
+  return withPrimeAgentSessionCounts([integration])[0];
 }
 
 export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void> {
@@ -402,7 +416,7 @@ export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void
     if (!id) return jsonResponse(res, 404, { error: 'Integration not found' });
     const integration = getLocalAgentIntegration(config, id);
     if (!integration) return jsonResponse(res, 404, { error: `Unknown integration: ${id}` });
-    return jsonResponse(res, 200, { integration });
+    return jsonResponse(res, 200, { integration: withPrimeAgentSessionCount(integration) });
   }
 
   // POST /api/local-agent-integrations/connect — upsert/connect an integration
@@ -418,7 +432,11 @@ export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void
         ? await connectLocalAgentIntegrationFromUi(config, parsed, bridgeAuthToken, { saveConfig })
         : { integration: connectLocalAgentIntegration(config, parsed) };
       await saveConfig(config);
-      return jsonResponse(res, 200, { ok: true, integration: result.integration, notice: result.notice });
+      return jsonResponse(res, 200, {
+        ok: true,
+        integration: withPrimeAgentSessionCount(result.integration),
+        notice: result.notice,
+      });
     } catch (err: any) {
       try { await saveConfig(config); } catch { /* best effort: preserve failed attach state when available */ }
       return jsonResponse(res, 400, { error: err?.message ?? 'Invalid local agent integration payload' });
@@ -444,7 +462,7 @@ export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void
     try {
       const integration = await refreshLocalAgentIntegrationFromUi(config, normalizedId, bridgeAuthToken);
       await saveConfig(config);
-      return jsonResponse(res, 200, { ok: true, integration });
+      return jsonResponse(res, 200, { ok: true, integration: withPrimeAgentSessionCount(integration) });
     } catch (err: any) {
       return jsonResponse(res, 400, { error: err?.message ?? 'Integration refresh failed' });
     }

--- a/packages/cli/src/daemon/routes/local-agents.ts
+++ b/packages/cli/src/daemon/routes/local-agents.ts
@@ -342,15 +342,32 @@ function withPrimeAgentSessionCounts<T extends { id: string; metadata?: Record<s
       // the whole integrations listing.
       return integration;
     }
-    return {
-      ...integration,
-      metadata: {
-        ...(integration.metadata ?? {}),
-        sessionCount: sessions.length,
-        ...(sessions[0] ? { activeSessionId: sessions[0].sessionId } : {}),
-      },
+    const metadata: Record<string, unknown> = {
+      ...(integration.metadata ?? {}),
+      sessionCount: sessions.length,
     };
+    if (sessions[0]) {
+      metadata.activeSessionId = sessions[0].sessionId;
+    } else {
+      // A zero-session listing must not keep advertising the connect-time
+      // session id: node-ui pins chat to activeSessionId, and a stale id
+      // routes every send into a guaranteed 409.
+      delete metadata.activeSessionId;
+    }
+    return { ...integration, metadata };
   });
+}
+
+/**
+ * Single-integration responses (get / connect / refresh) need the same overlay
+ * as the listing: node-ui upserts each of them into its integrations state, so
+ * any un-overlaid response would regress the pinned session to the persisted
+ * connect-time id until the next listing poll.
+ */
+function withPrimeAgentSessionCount<T extends { id: string; metadata?: Record<string, unknown> }>(
+  integration: T,
+): T {
+  return withPrimeAgentSessionCounts([integration])[0];
 }
 
 export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void> {
@@ -399,7 +416,7 @@ export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void
     if (!id) return jsonResponse(res, 404, { error: 'Integration not found' });
     const integration = getLocalAgentIntegration(config, id);
     if (!integration) return jsonResponse(res, 404, { error: `Unknown integration: ${id}` });
-    return jsonResponse(res, 200, { integration });
+    return jsonResponse(res, 200, { integration: withPrimeAgentSessionCount(integration) });
   }
 
   // POST /api/local-agent-integrations/connect — upsert/connect an integration
@@ -415,7 +432,11 @@ export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void
         ? await connectLocalAgentIntegrationFromUi(config, parsed, bridgeAuthToken, { saveConfig })
         : { integration: connectLocalAgentIntegration(config, parsed) };
       await saveConfig(config);
-      return jsonResponse(res, 200, { ok: true, integration: result.integration, notice: result.notice });
+      return jsonResponse(res, 200, {
+        ok: true,
+        integration: withPrimeAgentSessionCount(result.integration),
+        notice: result.notice,
+      });
     } catch (err: any) {
       try { await saveConfig(config); } catch { /* best effort: preserve failed attach state when available */ }
       return jsonResponse(res, 400, { error: err?.message ?? 'Invalid local agent integration payload' });
@@ -441,7 +462,7 @@ export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void
     try {
       const integration = await refreshLocalAgentIntegrationFromUi(config, normalizedId, bridgeAuthToken);
       await saveConfig(config);
-      return jsonResponse(res, 200, { ok: true, integration });
+      return jsonResponse(res, 200, { ok: true, integration: withPrimeAgentSessionCount(integration) });
     } catch (err: any) {
       return jsonResponse(res, 400, { error: err?.message ?? 'Integration refresh failed' });
     }

--- a/packages/cli/src/daemon/routes/prime-agent.ts
+++ b/packages/cli/src/daemon/routes/prime-agent.ts
@@ -100,6 +100,12 @@ function isPrimeAgentTimeoutError(err: unknown): boolean {
   );
 }
 
+// Must stay in lock-step with PrimeAgentTurnErrorCode in
+// packages/adapter-prime-agent/extension/src/extension.ts (the producer) and
+// the per-code branches in
+// packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts:
+// a bridge code missing here degrades to a generic BRIDGE_ERROR on /send
+// while /stream forwards the SSE frame verbatim, and the transports diverge.
 const SANITIZED_PRIME_AGENT_BRIDGE_FAILURES: Readonly<Record<string, string>> = {
   PRIME_AGENT_PROVIDER_UNAUTHORIZED:
     'Prime Agent provider authentication failed. Check the configured provider credentials.',
@@ -109,15 +115,17 @@ const SANITIZED_PRIME_AGENT_BRIDGE_FAILURES: Readonly<Record<string, string>> = 
   PRIME_AGENT_DELIVERY_FAILED: 'Prime Agent rejected the local message before starting the turn.',
 };
 
-function sanitizedPrimeAgentBridgeFailure(text: string): { code: string; error: string } | null {
-  try {
-    const parsed = JSON.parse(text) as { code?: unknown };
-    const code = typeof parsed?.code === 'string' ? parsed.code : '';
-    const error = SANITIZED_PRIME_AGENT_BRIDGE_FAILURES[code];
-    return error ? { code, error } : null;
-  } catch {
-    return null;
-  }
+function sanitizedPrimeAgentBridgeFailure(
+  body: Record<string, unknown>,
+): { code: string; error: string } | null {
+  const code = typeof body.code === 'string' ? body.code : '';
+  // Own-property check: a hostile `code` like "constructor" or "__proto__"
+  // must fall through to the generic BRIDGE_ERROR envelope, not resolve a
+  // truthy value off Object.prototype.
+  const error = Object.hasOwn(SANITIZED_PRIME_AGENT_BRIDGE_FAILURES, code)
+    ? SANITIZED_PRIME_AGENT_BRIDGE_FAILURES[code]
+    : undefined;
+  return error ? { code, error } : null;
 }
 
 /**
@@ -200,30 +208,34 @@ export async function handlePrimeAgentRoutes(ctx: RequestContext): Promise<void>
       });
       const text = await forwardRes.text();
       if (!forwardRes.ok) {
+        let bridgeBody: Record<string, unknown> = {};
+        try {
+          const parsed = JSON.parse(text);
+          if (parsed && typeof parsed === 'object') bridgeBody = parsed as Record<string, unknown>;
+        } catch {
+          /* non-JSON body: the fallback envelopes below still tell the UI what happened */
+        }
         if (forwardRes.status === 504) {
           // The bridge's own idle-timeout verdict. Its JSON body carries any
           // partial turn output, which must reach the UI rather than being
           // flattened into a generic bridge fault.
-          let bridgeBody: Record<string, unknown> = {};
-          try {
-            const parsed = JSON.parse(text);
-            if (parsed && typeof parsed === 'object') bridgeBody = parsed as Record<string, unknown>;
-          } catch {
-            /* non-JSON body: the timeout envelope alone still tells the UI what happened */
-          }
           return jsonResponse(res, 504, {
             ...timeoutBody(payload.correlationId, target.sessionId, PRIME_AGENT_CHANNEL_RESPONSE_TIMEOUT_MS),
             ...('text' in bridgeBody ? { text: bridgeBody.text } : {}),
             ...('timedOut' in bridgeBody ? { timedOut: bridgeBody.timedOut } : {}),
           });
         }
-        const terminalFailure = sanitizedPrimeAgentBridgeFailure(text);
+        const terminalFailure = sanitizedPrimeAgentBridgeFailure(bridgeBody);
         if (terminalFailure) {
           // Only forward codes from the fixed allowlist above. The provider's
           // raw error body may contain credential-bearing diagnostics and must
-          // not cross the bridge/daemon trust boundary.
+          // not cross the bridge/daemon trust boundary. The partial transcript
+          // is the exception: it only ever accumulates verified text_delta
+          // frames, and the UI renders it (LocalAgentApiError.text) exactly as
+          // it does for the idle-timeout 504 above.
           return jsonResponse(res, 502, {
             ...terminalFailure,
+            ...(typeof bridgeBody.text === 'string' ? { text: bridgeBody.text } : {}),
             source: 'prime-agent-channel',
             sessionId: target.sessionId,
             correlationId: payload.correlationId,
@@ -325,6 +337,7 @@ export async function handlePrimeAgentRoutes(ctx: RequestContext): Promise<void>
       res.writeHead(200, {
         'Content-Type': 'text/event-stream; charset=utf-8',
         'Cache-Control': 'no-cache, no-transform',
+        'X-Accel-Buffering': 'no',
         Connection: 'keep-alive',
         ...corsHeaders(resolveCorsOrigin(req, daemonState.moduleCorsAllowed)),
       });

--- a/packages/cli/src/daemon/routes/prime-agent.ts
+++ b/packages/cli/src/daemon/routes/prime-agent.ts
@@ -326,6 +326,12 @@ export async function handlePrimeAgentRoutes(ctx: RequestContext): Promise<void>
         'Content-Type': 'text/event-stream; charset=utf-8',
         'Cache-Control': 'no-cache, no-transform',
         Connection: 'keep-alive',
+        // The keepalive comments the bridge now emits only defeat proxy idle
+        // timeouts if they are FLUSHED to the client. Cache-Control does not
+        // govern proxy buffering; this header disables it on nginx-family
+        // fronts, whose default proxy_buffering would otherwise hold small
+        // comment frames in a buffer while the client sees a silent stream.
+        'X-Accel-Buffering': 'no',
         ...corsHeaders(resolveCorsOrigin(req, daemonState.moduleCorsAllowed)),
       });
 

--- a/packages/cli/src/daemon/routes/prime-agent.ts
+++ b/packages/cli/src/daemon/routes/prime-agent.ts
@@ -337,8 +337,13 @@ export async function handlePrimeAgentRoutes(ctx: RequestContext): Promise<void>
       res.writeHead(200, {
         'Content-Type': 'text/event-stream; charset=utf-8',
         'Cache-Control': 'no-cache, no-transform',
-        'X-Accel-Buffering': 'no',
         Connection: 'keep-alive',
+        // The keepalive comments the bridge now emits only defeat proxy idle
+        // timeouts if they are FLUSHED to the client. Cache-Control does not
+        // govern proxy buffering; this header disables it on nginx-family
+        // fronts, whose default proxy_buffering would otherwise hold small
+        // comment frames in a buffer while the client sees a silent stream.
+        'X-Accel-Buffering': 'no',
         ...corsHeaders(resolveCorsOrigin(req, daemonState.moduleCorsAllowed)),
       });
 

--- a/packages/cli/test/daemon-prime-agent.test.ts
+++ b/packages/cli/test/daemon-prime-agent.test.ts
@@ -442,6 +442,9 @@ describe('/api/prime-agent-channel/stream', () => {
     expect(res.headers['Content-Type']).toBe('text/event-stream; charset=utf-8');
     expect(res.headers['Cache-Control']).toBe('no-cache, no-transform');
     expect(res.headers.Connection).toBe('keep-alive');
+    // Keepalive comments only defeat proxy idle timeouts if fronting proxies
+    // flush them; nginx-family buffering is disabled per response.
+    expect(res.headers['X-Accel-Buffering']).toBe('no');
     expect(res.writableEnded).toBe(true);
     expect(res.body).toContain('"type":"final"');
     expect(res.body).toContain('Hello!');
@@ -485,6 +488,37 @@ describe('connect from the Node UI', () => {
     expect(result.integration.transport).toMatchObject({ kind: 'prime-agent-channel', bridgeUrl: bridge.url });
   });
 
+  it('stamps the election head as activeSessionId even when only an older session answers the probe', async () => {
+    // The head (most recently active) is unprobeable — dead port — while an
+    // older session answers. Routing takes the head unconditionally, and
+    // node-ui pins chat to activeSessionId, so stamping the probe survivor
+    // here would silently deliver operator chat into the older session.
+    const older = await startStubBridge({ sessionId: 's-old' });
+    writeDescriptor('s-old', older.url);
+    writeFileSync(
+      join(sessionsDir, 's-head.json'),
+      JSON.stringify({
+        sessionId: 's-head',
+        bridgeUrl: 'http://127.0.0.1:1',
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        lastActiveAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    const runPrimeAgentSetup = vi.fn(async () => ({ ok: true, errors: [], warnings: [] }));
+
+    const result = await connectLocalAgentIntegrationFromUi(
+      makeConfig(),
+      { id: 'prime-agent' } as any,
+      'bridge-token',
+      { runPrimeAgentSetup } as any,
+    );
+
+    expect(result.integration.runtime?.status).toBe('ready');
+    // Transport may point at the probe survivor; the pin must not.
+    expect(result.integration.metadata).toMatchObject({ sessionCount: 2, activeSessionId: 's-head' });
+  });
+
   it('does not claim to be connected when setup itself failed', async () => {
     const runPrimeAgentSetup = vi.fn(async () => ({
       ok: false,
@@ -525,5 +559,66 @@ describe('local-agent integrations listing', () => {
 
     // Single-session agents must not grow a phantom counter.
     expect(integrations.find((entry) => entry.id === 'hermes')?.metadata?.sessionCount).toBeUndefined();
+  });
+
+  it('drops a stale persisted activeSessionId when no session is live', async () => {
+    // node-ui pins chat to activeSessionId. A zero-session listing that keeps
+    // advertising the connect-time id routes every send into a guaranteed 409.
+    const config = makeConfig({
+      localAgentIntegrations: {
+        'prime-agent': {
+          enabled: true,
+          capabilities: { localChat: true },
+          transport: { kind: 'prime-agent-channel' },
+          metadata: { sessionCount: 1, activeSessionId: 'stale-connect-time-uuid' },
+        },
+      },
+    } as Partial<DkgConfig>);
+
+    const res = makeJsonResponse();
+    await handleLocalAgentsRoutes({
+      req: makeJsonRequest('GET', '/api/local-agent-integrations'),
+      res,
+      config,
+      path: '/api/local-agent-integrations',
+      url: new URL('http://127.0.0.1:9200/api/local-agent-integrations'),
+    } as any);
+
+    expect(res.statusCode).toBe(200);
+    const integrations = JSON.parse(res.body).integrations as Array<{ id: string; metadata?: any }>;
+    const primeAgent = integrations.find((entry) => entry.id === 'prime-agent');
+    expect(primeAgent?.metadata?.sessionCount).toBe(0);
+    expect(primeAgent?.metadata?.activeSessionId).toBeUndefined();
+    expect(res.body).not.toContain('stale-connect-time-uuid');
+  });
+
+  it('applies the session overlay to the single-integration GET as well as the listing', async () => {
+    const bridge = await startStubBridge({ sessionId: 's-live' });
+    writeDescriptor('s-live', bridge.url);
+    // Both persisted fields are deliberately wrong so each overlay half fails
+    // independently if the single-integration path bypasses it.
+    const config = makeConfig({
+      localAgentIntegrations: {
+        'prime-agent': {
+          enabled: true,
+          capabilities: { localChat: true },
+          transport: { kind: 'prime-agent-channel' },
+          metadata: { sessionCount: 5, activeSessionId: 'stale-connect-time-uuid' },
+        },
+      },
+    } as Partial<DkgConfig>);
+
+    const res = makeJsonResponse();
+    await handleLocalAgentsRoutes({
+      req: makeJsonRequest('GET', '/api/local-agent-integrations/prime-agent'),
+      res,
+      config,
+      path: '/api/local-agent-integrations/prime-agent',
+      url: new URL('http://127.0.0.1:9200/api/local-agent-integrations/prime-agent'),
+    } as any);
+
+    expect(res.statusCode).toBe(200);
+    const integration = JSON.parse(res.body).integration as { metadata?: any };
+    expect(integration.metadata).toMatchObject({ sessionCount: 1, activeSessionId: 's-live' });
   });
 });

--- a/packages/cli/test/daemon-prime-agent.test.ts
+++ b/packages/cli/test/daemon-prime-agent.test.ts
@@ -544,6 +544,9 @@ describe('/api/prime-agent-channel/stream', () => {
     expect(res.headers['Cache-Control']).toBe('no-cache, no-transform');
     expect(res.headers['X-Accel-Buffering']).toBe('no');
     expect(res.headers.Connection).toBe('keep-alive');
+    // Keepalive comments only defeat proxy idle timeouts if fronting proxies
+    // flush them; nginx-family buffering is disabled per response.
+    expect(res.headers['X-Accel-Buffering']).toBe('no');
     expect(res.writableEnded).toBe(true);
     expect(res.body).toContain('"type":"final"');
     expect(res.body).toContain('Hello!');
@@ -666,18 +669,21 @@ describe('local-agent integrations listing', () => {
     expect(integrations.find((entry) => entry.id === 'hermes')?.metadata?.sessionCount).toBeUndefined();
   });
 
-  it('overwrites a stale persisted pin when no Prime session is live', async () => {
+  it('drops a stale persisted activeSessionId when no session is live', async () => {
+    // node-ui pins chat to activeSessionId. A zero-session listing that keeps
+    // advertising the connect-time id routes every send into a guaranteed 409.
     const config = makeConfig({
       localAgentIntegrations: {
         'prime-agent': {
           enabled: true,
           capabilities: { localChat: true },
-          metadata: { sessionCount: 1, activeSessionId: 'stale-session' },
+          transport: { kind: 'prime-agent-channel' },
+          metadata: { sessionCount: 1, activeSessionId: 'stale-connect-time-uuid' },
         },
       },
     } as Partial<DkgConfig>);
-    const res = makeJsonResponse();
 
+    const res = makeJsonResponse();
     await handleLocalAgentsRoutes({
       req: makeJsonRequest('GET', '/api/local-agent-integrations'),
       res,
@@ -686,10 +692,41 @@ describe('local-agent integrations listing', () => {
       url: new URL('http://127.0.0.1:9200/api/local-agent-integrations'),
     } as any);
 
+    expect(res.statusCode).toBe(200);
     const integrations = JSON.parse(res.body).integrations as Array<{ id: string; metadata?: any }>;
-    expect(integrations.find((entry) => entry.id === 'prime-agent')?.metadata).toMatchObject({
-      sessionCount: 0,
-      activeSessionId: null,
-    });
+    const primeAgent = integrations.find((entry) => entry.id === 'prime-agent');
+    expect(primeAgent?.metadata?.sessionCount).toBe(0);
+    expect(primeAgent?.metadata?.activeSessionId).toBeUndefined();
+    expect(res.body).not.toContain('stale-connect-time-uuid');
+  });
+
+  it('applies the session overlay to the single-integration GET as well as the listing', async () => {
+    const bridge = await startStubBridge({ sessionId: 's-live' });
+    writeDescriptor('s-live', bridge.url);
+    // Both persisted fields are deliberately wrong so each overlay half fails
+    // independently if the single-integration path bypasses it.
+    const config = makeConfig({
+      localAgentIntegrations: {
+        'prime-agent': {
+          enabled: true,
+          capabilities: { localChat: true },
+          transport: { kind: 'prime-agent-channel' },
+          metadata: { sessionCount: 5, activeSessionId: 'stale-connect-time-uuid' },
+        },
+      },
+    } as Partial<DkgConfig>);
+
+    const res = makeJsonResponse();
+    await handleLocalAgentsRoutes({
+      req: makeJsonRequest('GET', '/api/local-agent-integrations/prime-agent'),
+      res,
+      config,
+      path: '/api/local-agent-integrations/prime-agent',
+      url: new URL('http://127.0.0.1:9200/api/local-agent-integrations/prime-agent'),
+    } as any);
+
+    expect(res.statusCode).toBe(200);
+    const integration = JSON.parse(res.body).integration as { metadata?: any };
+    expect(integration.metadata).toMatchObject({ sessionCount: 1, activeSessionId: 's-live' });
   });
 });

--- a/packages/cli/test/daemon-prime-agent.test.ts
+++ b/packages/cli/test/daemon-prime-agent.test.ts
@@ -16,7 +16,10 @@ import {
 } from '../src/daemon/prime-agent.js';
 import { handlePrimeAgentRoutes } from '../src/daemon/routes/prime-agent.js';
 import { handleLocalAgentsRoutes } from '../src/daemon/routes/local-agents.js';
-import { connectLocalAgentIntegrationFromUi } from '../src/daemon/local-agents.js';
+import {
+  connectLocalAgentIntegrationFromUi,
+  refreshLocalAgentIntegrationFromUi,
+} from '../src/daemon/local-agents.js';
 
 // The setup entry pulls in the adapter's runtime; the daemon only ever calls it
 // on disconnect, and none of these tests exercise that path.
@@ -111,6 +114,7 @@ async function startStubBridge(opts: {
   sendStatus?: number;
   sendBody?: unknown;
   healthSessionId?: string;
+  healthState?: Record<string, unknown>;
   /** SSE frames served from `/stream`, verbatim. */
   streamFrames?: string[];
 } ): Promise<{ url: string; seen: { headers: Record<string, string | undefined>; body: any } | null }> {
@@ -126,6 +130,7 @@ async function startStubBridge(opts: {
           ok: true,
           sessionId: opts.healthSessionId ?? opts.sessionId,
           pid: process.pid,
+          ...(opts.healthState ?? {}),
         }));
         return;
       }
@@ -151,10 +156,15 @@ async function startStubBridge(opts: {
   return { url: `http://127.0.0.1:${port}`, get seen() { return state.value; } } as any;
 }
 
-function writeDescriptor(sessionId: string, bridgeUrl: string, pid = process.pid): void {
+function writeDescriptor(
+  sessionId: string,
+  bridgeUrl: string,
+  pid = process.pid,
+  activeAt = new Date().toISOString(),
+): void {
   writeFileSync(
     join(sessionsDir, `${sessionId}.json`),
-    JSON.stringify({ sessionId, bridgeUrl, pid, startedAt: new Date().toISOString() }),
+    JSON.stringify({ sessionId, bridgeUrl, pid, startedAt: activeAt, lastActiveAt: activeAt }),
   );
 }
 
@@ -225,6 +235,37 @@ describe('/api/prime-agent-channel/health', () => {
 
     const report = await probePrimeAgentChannelHealth('bridge-token');
     expect(report).toMatchObject({ ok: true, sessionCount: 1, target: 's1' });
+  });
+
+  it('surfaces a recoverable disconnected-client turn state from the selected session', async () => {
+    const bridge = await startStubBridge({
+      sessionId: 's-working',
+      healthState: {
+        busy: true,
+        turnState: 'running',
+        clientConnected: false,
+        clientDisconnectedAt: '2026-08-07T12:34:56.000Z',
+      },
+    });
+    writeDescriptor('s-working', bridge.url);
+    const res = makeJsonResponse();
+
+    await handlePrimeAgentRoutes({
+      req: makeJsonRequest('GET', '/api/prime-agent-channel/health'),
+      res,
+      config: makeConfig(),
+      bridgeAuthToken: 'bridge-token',
+      path: '/api/prime-agent-channel/health',
+    } as any);
+
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      target: 's-working',
+      busy: true,
+      turnState: 'running',
+      clientConnected: false,
+      clientDisconnectedAt: '2026-08-07T12:34:56.000Z',
+    });
   });
 
   it('rejects a bridge whose session id does not match the descriptor', async () => {
@@ -386,6 +427,66 @@ describe('/api/prime-agent-channel/send', () => {
     expect(res.body).not.toContain('sk-');
   });
 
+  it('forwards the partial transcript with a terminal code while replacing the bridge message', async () => {
+    const bridge = await startStubBridge({
+      sessionId: 's1',
+      sendStatus: 503,
+      sendBody: {
+        error: 'Prime Agent turn exceeded the 3300000ms hard limit.',
+        code: 'PRIME_AGENT_TURN_TIMEOUT',
+        text: 'partial answer so far',
+        details: { providerToken: 'must-not-leak' },
+      },
+    });
+    writeDescriptor('s1', bridge.url);
+
+    const res = makeJsonResponse();
+    await handlePrimeAgentRoutes({
+      req: makeJsonRequest('POST', '/api/prime-agent-channel/send', { text: 'hi', correlationId: 'c-hard' }),
+      res,
+      config: enabledConfig(),
+      bridgeAuthToken: 'bridge-token',
+      path: '/api/prime-agent-channel/send',
+    } as any);
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      code: 'PRIME_AGENT_TURN_TIMEOUT',
+      error: 'Prime Agent turn exceeded its hard limit.',
+      // The partial transcript is deltas-only output and reaches the UI, just
+      // like the idle-timeout 504 below preserves it.
+      text: 'partial answer so far',
+      source: 'prime-agent-channel',
+      correlationId: 'c-hard',
+      retryable: false,
+    });
+    // The daemon substitutes its own message and never forwards bridge details.
+    expect(res.body).not.toContain('must-not-leak');
+    expect(res.body).not.toContain('3300000');
+  });
+
+  it('treats a prototype-key bridge code as a generic bridge error, not an allowlist hit', async () => {
+    const bridge = await startStubBridge({
+      sessionId: 's1',
+      sendStatus: 503,
+      sendBody: { error: 'boom', code: 'constructor' },
+    });
+    writeDescriptor('s1', bridge.url);
+
+    const res = makeJsonResponse();
+    await handlePrimeAgentRoutes({
+      req: makeJsonRequest('POST', '/api/prime-agent-channel/send', { text: 'hi', correlationId: 'c-proto' }),
+      res,
+      config: enabledConfig(),
+      bridgeAuthToken: 'bridge-token',
+      path: '/api/prime-agent-channel/send',
+    } as any);
+
+    expect(res.statusCode).toBe(502);
+    expect(JSON.parse(res.body).code).toBe('BRIDGE_ERROR');
+  });
+
   it('propagates the bridge idle timeout with its partial text instead of a generic 502', async () => {
     const bridge = await startStubBridge({
       sessionId: 's1',
@@ -441,6 +542,7 @@ describe('/api/prime-agent-channel/stream', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['Content-Type']).toBe('text/event-stream; charset=utf-8');
     expect(res.headers['Cache-Control']).toBe('no-cache, no-transform');
+    expect(res.headers['X-Accel-Buffering']).toBe('no');
     expect(res.headers.Connection).toBe('keep-alive');
     expect(res.writableEnded).toBe(true);
     expect(res.body).toContain('"type":"final"');
@@ -485,6 +587,43 @@ describe('connect from the Node UI', () => {
     expect(result.integration.transport).toMatchObject({ kind: 'prime-agent-channel', bridgeUrl: bridge.url });
   });
 
+  it('pins the routing head even when the health probe falls through to an older survivor', async () => {
+    const head = await startStubBridge({ sessionId: 'head', healthSessionId: 'recycled-port' });
+    const survivor = await startStubBridge({ sessionId: 'survivor' });
+    writeDescriptor('head', head.url, process.pid, '2026-08-07T12:00:00.000Z');
+    writeDescriptor('survivor', survivor.url, process.pid, '2026-08-07T11:00:00.000Z');
+
+    const result = await connectLocalAgentIntegrationFromUi(
+      makeConfig(),
+      { id: 'prime-agent' } as any,
+      'bridge-token',
+      { runPrimeAgentSetup: vi.fn(async () => ({ ok: true, errors: [], warnings: [] })) } as any,
+    );
+
+    expect(result.integration.metadata).toMatchObject({
+      sessionCount: 2,
+      activeSessionId: 'head',
+    });
+    expect(result.integration.transport?.bridgeUrl).toBe(survivor.url);
+  });
+
+  it('refreshes the Prime session pin and clears it after the last session exits', async () => {
+    const bridge = await startStubBridge({ sessionId: 'current' });
+    writeDescriptor('current', bridge.url);
+    const config = enabledConfig();
+    config.localAgentIntegrations!['prime-agent'].metadata = {
+      sessionCount: 1,
+      activeSessionId: 'stale',
+    };
+
+    const live = await refreshLocalAgentIntegrationFromUi(config, 'prime-agent', 'bridge-token');
+    expect(live.metadata).toMatchObject({ sessionCount: 1, activeSessionId: 'current' });
+
+    rmSync(join(sessionsDir, 'current.json'));
+    const idle = await refreshLocalAgentIntegrationFromUi(config, 'prime-agent', 'bridge-token');
+    expect(idle.metadata).toMatchObject({ sessionCount: 0, activeSessionId: null });
+  });
+
   it('does not claim to be connected when setup itself failed', async () => {
     const runPrimeAgentSetup = vi.fn(async () => ({
       ok: false,
@@ -525,5 +664,32 @@ describe('local-agent integrations listing', () => {
 
     // Single-session agents must not grow a phantom counter.
     expect(integrations.find((entry) => entry.id === 'hermes')?.metadata?.sessionCount).toBeUndefined();
+  });
+
+  it('overwrites a stale persisted pin when no Prime session is live', async () => {
+    const config = makeConfig({
+      localAgentIntegrations: {
+        'prime-agent': {
+          enabled: true,
+          capabilities: { localChat: true },
+          metadata: { sessionCount: 1, activeSessionId: 'stale-session' },
+        },
+      },
+    } as Partial<DkgConfig>);
+    const res = makeJsonResponse();
+
+    await handleLocalAgentsRoutes({
+      req: makeJsonRequest('GET', '/api/local-agent-integrations'),
+      res,
+      config,
+      path: '/api/local-agent-integrations',
+      url: new URL('http://127.0.0.1:9200/api/local-agent-integrations'),
+    } as any);
+
+    const integrations = JSON.parse(res.body).integrations as Array<{ id: string; metadata?: any }>;
+    expect(integrations.find((entry) => entry.id === 'prime-agent')?.metadata).toMatchObject({
+      sessionCount: 0,
+      activeSessionId: null,
+    });
   });
 });

--- a/packages/cli/test/daemon-sse-final-frame.test.ts
+++ b/packages/cli/test/daemon-sse-final-frame.test.ts
@@ -96,6 +96,28 @@ describe('local-agent SSE proxy: terminal frame handling', () => {
     expect(state.cancelled).toBe(1);
   });
 
+  it.each([
+    [
+      'comment text split across reads',
+      [': keepal', 'ive\n\n', 'data: {"type":"final","text":"done"}\n\n'],
+    ],
+    [
+      'comment terminator split into the final-frame read',
+      [': keepalive\n', '\ndata: {"type":"final","text":"done"}\n\n'],
+    ],
+  ])('forwards a %s and still detects the terminal frame', async (_name, frames) => {
+    const req = new EventEmitter() as any;
+    const res = makeRes();
+    const { reader, state } = makeReader(frames);
+
+    await pipeOpenClawStream(req, res, reader);
+
+    expect(res.chunks.join('')).toContain(': keepalive\n\n');
+    expect(res.chunks.join('')).toContain('"type":"final"');
+    expect(res.writableEnded).toBe(true);
+    expect(state.cancelled).toBe(1);
+  });
+
   it('drops frames coalesced after final while forwarding the final frame itself', async () => {
     const req = new EventEmitter() as any;
     const res = makeRes();

--- a/packages/cli/test/daemon-sse-final-frame.test.ts
+++ b/packages/cli/test/daemon-sse-final-frame.test.ts
@@ -62,6 +62,7 @@ describe('local-agent SSE proxy: terminal frame handling', () => {
     const req = new EventEmitter() as any;
     const res = makeRes();
     const { reader, state } = makeReader([
+      ': keepalive\n\n',
       'data: {"type":"delta","text":"He"}\n\n',
       'data: {"type":"final","text":"Hello!","correlationId":"c1"}\n\n',
     ]);
@@ -77,6 +78,7 @@ describe('local-agent SSE proxy: terminal frame handling', () => {
     // Every byte still reached the browser before we closed.
     expect(res.chunks.join('')).toContain('"type":"final"');
     expect(res.chunks.join('')).toContain('"type":"delta"');
+    expect(res.chunks.join('')).toContain(': keepalive');
   });
 
   it('detects a final frame split across chunk boundaries', async () => {

--- a/packages/cli/test/daemon-sse-final-frame.test.ts
+++ b/packages/cli/test/daemon-sse-final-frame.test.ts
@@ -81,6 +81,54 @@ describe('local-agent SSE proxy: terminal frame handling', () => {
     expect(res.chunks.join('')).toContain(': keepalive');
   });
 
+  it('forwards a keepalive comment split mid-word across reads', async () => {
+    // With 15s keepalives on multi-minute turns, comments split across reads
+    // are a routine wire shape, not an edge case.
+    const req = new EventEmitter() as any;
+    const res = makeRes();
+    const { reader, state } = makeReader([
+      ': keepal',
+      'ive\n\n',
+      'data: {"type":"final","text":"done","correlationId":"c1"}\n\n',
+    ]);
+
+    await pipeOpenClawStream(req, res, reader);
+
+    expect(res.writableEnded).toBe(true);
+    expect(state.cancelled).toBe(1);
+    // Byte-exact: a tail re-send regression would still satisfy toContain by
+    // carrying the straddled comment bytes twice.
+    expect(
+      Buffer.concat(res.byteChunks).equals(Buffer.from(
+        ': keepalive\n\ndata: {"type":"final","text":"done","correlationId":"c1"}\n\n',
+        'utf8',
+      )),
+    ).toBe(true);
+  });
+
+  it('detects a final frame whose chunk begins with a straddled comment separator', async () => {
+    // The comment's closing blank line arrives glued to the final frame.
+    const req = new EventEmitter() as any;
+    const res = makeRes();
+    const { reader, state } = makeReader([
+      'data: {"type":"delta","text":"He"}\n\n: keepalive\n',
+      '\ndata: {"type":"final","text":"Hello!","correlationId":"c1"}\n\n',
+    ]);
+
+    await pipeOpenClawStream(req, res, reader);
+
+    expect(res.writableEnded).toBe(true);
+    expect(state.cancelled).toBe(1);
+    // Byte-exact for the same reason as the mid-word split above.
+    expect(
+      Buffer.concat(res.byteChunks).equals(Buffer.from(
+        'data: {"type":"delta","text":"He"}\n\n: keepalive\n'
+          + '\ndata: {"type":"final","text":"Hello!","correlationId":"c1"}\n\n',
+        'utf8',
+      )),
+    ).toBe(true);
+  });
+
   it('detects a final frame split across chunk boundaries', async () => {
     const req = new EventEmitter() as any;
     const res = makeRes();

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -2391,7 +2391,7 @@ const LOCAL_AGENT_SURFACES: Record<string, LocalAgentSurface> = {
     // node must not synthesise one. The integrations endpoint already elects a
     // live session; pin the UI conversation to that exact id instead of asking
     // the daemon to run a second most-recently-active election on every turn.
-    defaultSessionId: ({ record }) => firstTrimmedString(record?.metadata?.activeSessionId),
+    defaultSessionId: ({ record }) => firstTrimmedString(record?.metadata?.activeSessionId) ?? undefined,
     resolveChatContext: ({ sessionId }) => (sessionId ? { sessionId } : {}),
     fetchHealth: fetchPrimeAgentLocalHealth,
     streamChat: streamPrimeAgentLocalChat,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -2341,7 +2341,7 @@ interface LocalAgentSurface {
     integrationId: string;
     record?: LocalAgentIntegrationRecord;
     health?: LocalAgentHealthResponse | null;
-  }) => string;
+  }) => string | undefined;
   resolveChatContext?: (args: {
     integrationId: string;
     sessionId?: string;
@@ -2387,10 +2387,11 @@ const LOCAL_AGENT_SURFACES: Record<string, LocalAgentSurface> = {
   'prime-agent': {
     connectSupported: true,
     chatSupported: true,
-    // No synthesised default. A Prime Agent session id is a uuidv7 minted by the
-    // agent itself, so the node cannot invent one — leaving it undefined makes
-    // the daemon route to the most recently active live session, which is what
-    // the operator means by "the session I'm in" until they pick another.
+    // A Prime Agent session id is a uuidv7 minted by the agent itself, so the
+    // node must not synthesise one. The integrations endpoint already elects a
+    // live session; pin the UI conversation to that exact id instead of asking
+    // the daemon to run a second most-recently-active election on every turn.
+    defaultSessionId: ({ record }) => firstTrimmedString(record?.metadata?.activeSessionId),
     resolveChatContext: ({ sessionId }) => (sessionId ? { sessionId } : {}),
     fetchHealth: fetchPrimeAgentLocalHealth,
     streamChat: streamPrimeAgentLocalChat,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1886,6 +1886,12 @@ export interface LocalAgentHealthResponse {
     error?: string;
   };
   status?: string;
+  sessionCount?: number;
+  sessions?: Array<{ sessionId: string; startedAt?: string; sessionName?: string }>;
+  busy?: boolean;
+  turnState?: 'queued' | 'running';
+  clientConnected?: boolean;
+  clientDisconnectedAt?: string;
   bridge?: Omit<LocalAgentHealthResponse, 'bridge' | 'gateway'>;
   gateway?: Omit<LocalAgentHealthResponse, 'bridge' | 'gateway'>;
 }
@@ -2185,10 +2191,7 @@ export const streamPrimeAgentLocalChat = (
  * caller decides how to render it.
  */
 export const fetchPrimeAgentLocalHealth = () =>
-  get<LocalAgentHealthResponse & {
-    sessionCount?: number;
-    sessions?: Array<{ sessionId: string; startedAt?: string; sessionName?: string }>;
-  }>('/api/prime-agent-channel/health');
+  get<LocalAgentHealthResponse>('/api/prime-agent-channel/health');
 
 function formatLocalAgentError(body: unknown, fallback: string): string {
   if (!body || typeof body !== 'object' || Array.isArray(body)) return fallback;
@@ -2315,6 +2318,10 @@ export interface LocalAgentIntegration {
   sessionCount?: number;
   /** Which session the node is currently routing to, when several are live. */
   activeSessionId?: string;
+  /** The selected Prime session currently owns an agent turn. */
+  busy?: boolean;
+  /** Live Prime sessions available for an explicit UI routing choice. */
+  liveSessions?: Array<{ sessionId: string; startedAt?: string; sessionName?: string }>;
 }
 
 export interface LocalAgentConnectResult {
@@ -2347,14 +2354,7 @@ interface LocalAgentSurface {
     sessionId?: string;
     profile?: string;
   }) => Record<string, unknown>;
-  fetchHealth?: () => Promise<{
-    ok: boolean;
-    target?: LocalAgentChannelTarget;
-    error?: string;
-    profile?: string;
-    memory?: LocalAgentHealthResponse['memory'];
-    status?: string;
-  }>;
+  fetchHealth?: () => Promise<LocalAgentHealthResponse>;
   streamChat?: typeof streamOpenClawLocalChat;
 }
 
@@ -2391,7 +2391,7 @@ const LOCAL_AGENT_SURFACES: Record<string, LocalAgentSurface> = {
     // node must not synthesise one. The integrations endpoint already elects a
     // live session; pin the UI conversation to that exact id instead of asking
     // the daemon to run a second most-recently-active election on every turn.
-    defaultSessionId: ({ record }) => firstTrimmedString(record?.metadata?.activeSessionId),
+    defaultSessionId: ({ record }) => firstTrimmedString(record?.metadata?.activeSessionId) ?? undefined,
     resolveChatContext: ({ sessionId }) => (sessionId ? { sessionId } : {}),
     fetchHealth: fetchPrimeAgentLocalHealth,
     streamChat: streamPrimeAgentLocalChat,
@@ -2642,8 +2642,14 @@ async function mapLocalAgentIntegrationRecord(record: LocalAgentIntegrationRecor
   );
   const hermesRuntimeDetail = hermesDetail(record, health);
   const defaultSessionId = surface?.defaultSessionId?.({ integrationId: id, record, health });
+  const primeTurnDetached = id === 'prime-agent'
+    && health?.busy === true
+    && health.clientConnected === false;
+  const liveSessions = id === 'prime-agent' && Array.isArray(health?.sessions)
+    ? health.sessions.filter((session) => typeof session?.sessionId === 'string' && session.sessionId.trim())
+    : undefined;
   const profile = id === 'hermes'
-    ? firstTrimmedString(health?.profile, record.metadata?.profileName, record.metadata?.profile)
+    ? firstTrimmedString(health?.profile, record.metadata?.profileName, record.metadata?.profile) ?? undefined
     : undefined;
 
   let status: LocalAgentIntegrationStatus;
@@ -2663,8 +2669,12 @@ async function mapLocalAgentIntegrationRecord(record: LocalAgentIntegrationRecor
       ?? `${record.name} is registered and still starting up.`;
   } else if (bridgeOnline) {
     status = 'chat_ready';
-    statusLabel = 'Chat ready';
-    detail = `${record.name} is connected to this node and ready for chat.`;
+    statusLabel = primeTurnDetached ? 'Still working' : health?.busy ? 'Working' : 'Chat ready';
+    detail = primeTurnDetached
+      ? `${record.name} is still working after the browser stream disconnected. Wait for it to finish before sending another message.`
+      : health?.busy
+        ? `${record.name} is working on the current turn.`
+        : `${record.name} is connected to this node and ready for chat.`;
   } else if (persistentChat) {
     status = 'bridge_offline';
     statusLabel = 'Bridge offline';
@@ -2730,6 +2740,8 @@ async function mapLocalAgentIntegrationRecord(record: LocalAgentIntegrationRecor
     ...(typeof record.metadata?.activeSessionId === 'string'
       ? { activeSessionId: record.metadata.activeSessionId as string }
       : {}),
+    ...(liveSessions?.length ? { liveSessions } : {}),
+    ...(typeof health?.busy === 'boolean' ? { busy: health.busy } : {}),
   } satisfies LocalAgentIntegration;
 }
 
@@ -2887,14 +2899,31 @@ export async function streamLocalAgentChat(
   const surface = LOCAL_AGENT_SURFACES[normalizedId];
   if (surface?.streamChat) {
     const { sessionId, profile, ...transportOpts } = opts;
-    return surface.streamChat(text, {
+    const chatOptions = (resolvedSessionId?: string) => ({
       ...transportOpts,
       ...surface.resolveChatContext?.({
         integrationId: normalizedId,
-        sessionId,
+        sessionId: resolvedSessionId,
         profile,
       }),
     });
+    try {
+      return await surface.streamChat(text, chatOptions(sessionId));
+    } catch (err) {
+      // A Prime session id is an automatic live-session pin, not a durable
+      // user-owned conversation id. If Prime restarted after the panel pinned
+      // it, an explicit miss is guaranteed to have executed nothing; retry
+      // once without the stale id so the daemon can elect the current head.
+      if (
+        normalizedId === 'prime-agent'
+        && sessionId
+        && err instanceof LocalAgentApiError
+        && err.code === 'PRIME_AGENT_NO_SESSION'
+      ) {
+        return surface.streamChat(text, chatOptions());
+      }
+      throw err;
+    }
   }
   throw new Error(`${id} local chat is not available yet.`);
 }

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/ConnectedAgentsTab.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/ConnectedAgentsTab.tsx
@@ -260,7 +260,7 @@ export function ConnectedAgentsTab(props: {
     localHistoryLoaded,
     localMessagesCount: localMessages.length,
   });
-  const inputDisabled = localSending || !selected?.chatReady;
+  const inputDisabled = localSending || !selected?.chatReady || selected.busy === true;
   // Single source of truth for "is the user allowed to fire a send right
   // now". Both the button click AND the keyboard Enter / Cmd+Enter
   // handlers gate on this — earlier the button correctly disabled while
@@ -387,7 +387,7 @@ export function ConnectedAgentsTab(props: {
                 {integration.id === 'prime-agent' && (
                   <>
                     <p className="v10-local-agent-copy">
-                      Connect a local Prime Agent through the node, then this tab becomes the persistent chat surface for it. Unlike the other agents, Prime Agent publishes a bridge per live session, and the node talks to the most recently active one.
+                      Connect a local Prime Agent through the node, then this tab becomes the persistent chat surface for it. Prime Agent publishes a bridge per live session; the first chat pins one session, and you can switch explicitly when several are live.
                     </p>
                     {/*
                       Sessions are ephemeral by nature, so "none live" is normal
@@ -403,7 +403,7 @@ export function ConnectedAgentsTab(props: {
                           ? 'No live session. Start a Prime Agent session, then refresh — the extension publishes its bridge on session start.'
                           : integration.sessionCount === 1
                           ? '1 live session.'
-                          : `${integration.sessionCount} live sessions — the most recently active one is used.`}
+                          : `${integration.sessionCount} live sessions — choose which session this chat should use.`}
                       </p>
                     )}
                     {integration.connectSupported && (
@@ -459,6 +459,34 @@ export function ConnectedAgentsTab(props: {
                   : showingStoredSessions
                   ? `${selected.name} has saved sessions on this node. Open one from Sessions or reconnect from the + tab to resume live chat here.`
                   : `${selected.name} is temporarily unavailable. Refresh after it recovers to resume chatting here.`}
+              </div>
+            )}
+
+            {selected.id === 'prime-agent' && selected.busy === true && (
+              <div
+                className="v10-local-agent-warning connecting"
+                role="status"
+                data-testid="prime-agent-active-turn-status"
+              >
+                {selected.detail}
+              </div>
+            )}
+
+            {selected.id === 'prime-agent' && (selected.liveSessions?.length ?? 0) > 1 && (
+              <div className="v10-composer-target" data-testid="prime-agent-session-picker">
+                <span className="v10-local-agent-target-label">Prime session</span>
+                <Select
+                  className="v10-local-agent-target-select"
+                  value={selectedSessionId ?? selected.defaultSessionId ?? ''}
+                  onChange={(sessionId) => onSelectIntegration(selected.id, { sessionId })}
+                  options={selected.liveSessions!.map((session, index) => ({
+                    value: session.sessionId,
+                    label: session.sessionName?.trim()
+                      || `${index === 0 ? 'Most recent' : `Session ${index + 1}`} · ${session.sessionId.slice(0, 8)}…`,
+                  }))}
+                  ariaLabel="Prime Agent session"
+                  disabled={localSending || selected.busy === true}
+                />
               </div>
             )}
 

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/PanelRightContainer.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/PanelRightContainer.tsx
@@ -86,6 +86,13 @@ export function PanelRight() {
   // abort the wrong request. Codex CIV4a / CIcaM / CIlg0.
   const localAbortRef = useRef<Map<string, AbortController>>(new Map());
   const autoFocusedLocalAgentRef = useRef(false);
+  // Session ids whose explicit sends came back PRIME_AGENT_NO_SESSION: the
+  // daemon never falls back on an explicit id, so these can only 409 forever.
+  // The selection is deliberately NOT cleared when one is detected — that
+  // would flip the visible stateKey and vanish the thread (and the failure
+  // bubble explaining the heal). Instead, the next send re-homes the
+  // conversation onto the refreshed pin.
+  const deadLocalAgentSessionsRef = useRef<Set<string>>(new Set());
   const localChatEndRef = useRef<HTMLDivElement>(null);
   const memorySessionsRef = useRef<MemorySession[]>([]);
   const localMessagesByConversationRef = useRef<Record<string, LocalAgentMessage[]>>({});
@@ -189,6 +196,36 @@ export function PanelRight() {
       ...prev,
       [conversationKey]: value,
     }));
+  }, []);
+
+  // Re-homes a conversation's visible state under a successor stateKey so a
+  // session heal never makes the on-screen thread disappear: messages (the
+  // prior turns plus the failure bubble), composer input, and queued
+  // attachment drafts all follow the user to the live session.
+  const migrateLocalConversationState = useCallback((fromKey: string, toKey: string) => {
+    if (fromKey === toKey) return;
+    setLocalMessagesByConversation((prev) => {
+      const moved = prev[fromKey];
+      if (!moved || moved.length === 0) return prev;
+      // Append: the migrated thread ends with the just-failed turn, which is
+      // the newest content whenever the successor key already has messages.
+      const next = { ...prev, [toKey]: [...(prev[toKey] ?? []), ...moved] };
+      delete next[fromKey];
+      return next;
+    });
+    setLocalInputByConversation((prev) => {
+      if (prev[fromKey] === undefined) return prev;
+      const next = { ...prev, [toKey]: prev[toKey] || prev[fromKey] };
+      delete next[fromKey];
+      return next;
+    });
+    setAttachmentDraftsByConversation((prev) => {
+      const moved = prev[fromKey];
+      if (!moved || moved.length === 0) return prev;
+      const next = { ...prev, [toKey]: [...moved, ...(prev[toKey] ?? [])] };
+      delete next[fromKey];
+      return next;
+    });
   }, []);
 
   const updateAttachmentDrafts = useCallback((
@@ -471,12 +508,35 @@ export function PanelRight() {
 
   const sendLocalMessage = useCallback(async () => {
     const integration = selectedIntegration;
-    const conversation = selectedConversation;
+    let conversation = selectedConversation;
     const text = localInput.trim();
     const drafts = selectedAttachmentDrafts;
     const hasSendableDrafts = drafts.some(isSendableAttachmentDraft);
     if (!integration?.chatSupported || !integration.chatReady || localSending || !conversation || (!text && !hasSendableDrafts)) return;
     const integrationId = integration.id;
+    // A send aimed at a session known to be dead re-homes the conversation
+    // onto the refreshed pin BEFORE any state key is derived, carrying the
+    // visible thread along. Without a live successor pin the send stays aimed
+    // at the dead session and fails visibly again — never silently rehomed.
+    const deadSessions = deadLocalAgentSessionsRef.current;
+    if (conversation.sessionId && deadSessions.has(conversation.sessionId)) {
+      const successorPin =
+        integration.defaultSessionId && !deadSessions.has(integration.defaultSessionId)
+          ? integration.defaultSessionId
+          : null;
+      if (successorPin) {
+        const successor = resolveLocalAgentConversation({ integrationId, sessionId: successorPin });
+        // Decline the heal while the successor conversation is mid-stream:
+        // two concurrent sends under one key would collide on the abort
+        // registry and the sending flag. The send below then fails visibly
+        // against the dead session instead of silently rehoming.
+        if (!localSendingByConversation[successor.stateKey]) {
+          migrateLocalConversationState(conversation.stateKey, successor.stateKey);
+          setSelectedSessionId(successorPin);
+          conversation = successor;
+        }
+      }
+    }
     const conversationKey = conversation.stateKey;
     setLocalSendingForConversation(conversationKey, true);
     setConnectError(null);
@@ -654,6 +714,15 @@ export function PanelRight() {
           return { ...prev, [conversationKey]: [...restored, ...current] };
         });
       }
+      // A pinned session that is no longer live can never succeed again — the
+      // daemon 409s explicit ids without fallback, and nothing else resets the
+      // sticky selection for a persistentChat integration. Mark it dead; the
+      // selection is left alone so this thread and its failure bubble stay on
+      // screen, and the NEXT send re-homes the conversation onto the pin the
+      // refresh below fetches.
+      if (!isUserAbort && err?.code === 'PRIME_AGENT_NO_SESSION' && conversation.sessionId) {
+        deadLocalAgentSessionsRef.current.add(conversation.sessionId);
+      }
       void refreshLocalIntegrations();
     } finally {
       setLocalSendingForConversation(conversationKey, false);
@@ -673,6 +742,8 @@ export function PanelRight() {
     loadSessions,
     localInput,
     localSending,
+    localSendingByConversation,
+    migrateLocalConversationState,
     prepareAttachmentDraftsForSend,
     selectedAttachmentDrafts,
     refreshLocalIntegrations,

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/PanelRightContainer.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/PanelRightContainer.tsx
@@ -34,6 +34,7 @@ import { NetworkTab } from './NetworkTab.js';
 import { SessionsTab } from './SessionsTab.js';
 import {
   compareLocalAgentIntegrations,
+  getLocalAgentConversationStateKey,
   markLocalAgentIntegrationDisconnected,
   resolveLocalAgentConversation,
   resolveLocalAgentSelectionState,
@@ -595,6 +596,37 @@ export function PanelRight() {
             : message,
         ),
       );
+      const resolvedPrimeSessionId = integrationId === 'prime-agent'
+        ? result.sessionId?.trim()
+        : undefined;
+      if (
+        resolvedPrimeSessionId
+        && resolvedPrimeSessionId !== conversation.sessionId
+        && selectedIntegrationIdRef.current === integrationId
+        && selectedSessionIdRef.current === conversation.sessionId
+      ) {
+        const nextConversationKey = getLocalAgentConversationStateKey(
+          integrationId,
+          resolvedPrimeSessionId,
+        );
+        // Preserve the just-finished transcript while moving the routing pin
+        // to the replacement Prime session. The API retries only the explicit
+        // PRIME_AGENT_NO_SESSION miss, which is a pre-delivery failure, so this
+        // migration cannot duplicate an executed turn.
+        setLocalMessagesByConversation((prev) => ({
+          ...prev,
+          [nextConversationKey]: mergeLocalAgentMessages(
+            prev[nextConversationKey] ?? [],
+            prev[conversationKey] ?? [],
+          ),
+        }));
+        setLocalHistoryLoadedByConversation((prev) => ({
+          ...prev,
+          [nextConversationKey]: prev[conversationKey] ?? true,
+        }));
+        setSelectedIntegration(integrationId, { sessionId: resolvedPrimeSessionId });
+        setConnectNotice(`${integration.name} restarted; switched chat to the live session.`);
+      }
       loadSessions();
       if (stage === 0) advance();
     } catch (err: any) {
@@ -681,6 +713,7 @@ export function PanelRight() {
     clearCompletedAttachmentsForConversation,
     setLocalInputForConversation,
     setLocalSendingForConversation,
+    setSelectedIntegration,
     stage,
     updateLocalMessages,
   ]);

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
@@ -21,6 +21,9 @@ export function formatLocalAgentErrorMessage(
     if (err.code === 'PRIME_AGENT_SESSION_BUSY') {
       return `${integration.name} session is busy — try again in a moment.`;
     }
+    if (err.code === 'PRIME_AGENT_NO_SESSION') {
+      return `${integration.name} session is no longer live. Send again to reach the current session, or start one if none is running.`;
+    }
     if (err.code === 'PRIME_AGENT_PROVIDER_UNAUTHORIZED') {
       return `${integration.name} provider authentication failed. Check its provider credentials and try again.`;
     }

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
@@ -21,6 +21,15 @@ export function formatLocalAgentErrorMessage(
     if (err.code === 'PRIME_AGENT_SESSION_BUSY') {
       return `${integration.name} session is busy — try again in a moment.`;
     }
+    if (err.code === 'PRIME_AGENT_NO_SESSION') {
+      return `No live ${integration.name} session is available. Start or resume a session and try again.`;
+    }
+    // The PRIME_AGENT_* terminal codes below must stay in lock-step with
+    // PrimeAgentTurnErrorCode in
+    // packages/adapter-prime-agent/extension/src/extension.ts and
+    // SANITIZED_PRIME_AGENT_BRIDGE_FAILURES in
+    // packages/cli/src/daemon/routes/prime-agent.ts; an unmatched code falls
+    // through to the raw daemon message at the bottom of this function.
     if (err.code === 'PRIME_AGENT_PROVIDER_UNAUTHORIZED') {
       return `${integration.name} provider authentication failed. Check its provider credentials and try again.`;
     }

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/local-agent-errors.ts
@@ -22,7 +22,7 @@ export function formatLocalAgentErrorMessage(
       return `${integration.name} session is busy — try again in a moment.`;
     }
     if (err.code === 'PRIME_AGENT_NO_SESSION') {
-      return `No live ${integration.name} session is available. Start or resume a session and try again.`;
+      return `No live ${integration.name} session is available. Start or resume a session, then send again.`;
     }
     // The PRIME_AGENT_* terminal codes below must stay in lock-step with
     // PrimeAgentTurnErrorCode in

--- a/packages/node-ui/test/local-agent-errors.test.ts
+++ b/packages/node-ui/test/local-agent-errors.test.ts
@@ -27,4 +27,17 @@ describe('Prime Agent terminal error messages', () => {
       'Prime Agent turn exceeded its maximum run time.',
     );
   });
+
+  it('renders a dead pinned session as an actionable message, not the raw daemon 409', () => {
+    const error = new LocalAgentApiError('No live Prime Agent session 019f-dead-uuid', {
+      code: 'PRIME_AGENT_NO_SESSION',
+      source: 'prime-agent-channel',
+    });
+
+    const message = formatLocalAgentErrorMessage(primeAgent, error);
+    expect(message).toBe(
+      'Prime Agent session is no longer live. Send again to reach the current session, or start one if none is running.',
+    );
+    expect(message).not.toContain('019f-dead-uuid');
+  });
 });

--- a/packages/node-ui/test/local-agent-errors.test.ts
+++ b/packages/node-ui/test/local-agent-errors.test.ts
@@ -31,7 +31,6 @@ describe('Prime Agent terminal error messages', () => {
   // The mapper falls through to the raw message when no branch matches, so a
   // dropped branch degrades silently — every terminal code needs a pin.
   it.each([
-    ['PRIME_AGENT_NO_SESSION', 'No live Prime Agent session is available. Start or resume a session and try again.'],
     ['PRIME_AGENT_PROVIDER_ERROR', 'Prime Agent provider request failed. Check its provider configuration and try again.'],
     ['PRIME_AGENT_TURN_ABORTED', 'Prime Agent turn was aborted.'],
     ['PRIME_AGENT_DELIVERY_FAILED', 'Prime Agent rejected the message before starting the turn.'],
@@ -42,5 +41,18 @@ describe('Prime Agent terminal error messages', () => {
     });
 
     expect(formatLocalAgentErrorMessage(primeAgent, error)).toBe(expected);
+  });
+
+  it('renders a dead pinned session as an actionable message, not the raw daemon 409', () => {
+    const error = new LocalAgentApiError('No live Prime Agent session 019f-dead-uuid', {
+      code: 'PRIME_AGENT_NO_SESSION',
+      source: 'prime-agent-channel',
+    });
+
+    const message = formatLocalAgentErrorMessage(primeAgent, error);
+    expect(message).toBe(
+      'No live Prime Agent session is available. Start or resume a session, then send again.',
+    );
+    expect(message).not.toContain('019f-dead-uuid');
   });
 });

--- a/packages/node-ui/test/local-agent-errors.test.ts
+++ b/packages/node-ui/test/local-agent-errors.test.ts
@@ -27,4 +27,20 @@ describe('Prime Agent terminal error messages', () => {
       'Prime Agent turn exceeded its maximum run time.',
     );
   });
+
+  // The mapper falls through to the raw message when no branch matches, so a
+  // dropped branch degrades silently — every terminal code needs a pin.
+  it.each([
+    ['PRIME_AGENT_NO_SESSION', 'No live Prime Agent session is available. Start or resume a session and try again.'],
+    ['PRIME_AGENT_PROVIDER_ERROR', 'Prime Agent provider request failed. Check its provider configuration and try again.'],
+    ['PRIME_AGENT_TURN_ABORTED', 'Prime Agent turn was aborted.'],
+    ['PRIME_AGENT_DELIVERY_FAILED', 'Prime Agent rejected the message before starting the turn.'],
+  ])('renders %s with its per-code guidance', (code, expected) => {
+    const error = new LocalAgentApiError('sanitized bridge failure', {
+      code,
+      source: 'prime-agent-channel',
+    });
+
+    expect(formatLocalAgentErrorMessage(primeAgent, error)).toBe(expected);
+  });
 });

--- a/packages/node-ui/test/local-agent-selection.test.ts
+++ b/packages/node-ui/test/local-agent-selection.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Pins the session-pin plumbing this side of the wire: an integration's
+ * defaultSessionId (mapped from the daemon's metadata.activeSessionId) must
+ * reach an outgoing chat request whenever the panel holds no sticky selection,
+ * and a sticky selection must win over the pin. The api-level pass-through of
+ * an explicit sessionId is covered separately in ui-api-stream.test.ts — this
+ * suite covers the hop that test does not: defaultSessionId → conversation →
+ * request body.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { LocalAgentApiError, streamLocalAgentChat, type LocalAgentIntegration } from '../src/ui/api.js';
+import {
+  resolveLocalAgentConversation,
+  resolveLocalAgentSelectionState,
+} from '../src/ui/components/Shell/PanelRight/selection.js';
+
+const pinnedIntegration = {
+  id: 'prime-agent',
+  name: 'Prime Agent',
+  persistentChat: true,
+  defaultSessionId: '019f-session-a',
+} as unknown as LocalAgentIntegration;
+
+describe('prime-agent session pin plumbing', () => {
+  it('resolves the conversation to the pin when no sticky session is selected', () => {
+    const conversation = resolveLocalAgentConversation({
+      integrationId: 'prime-agent',
+      sessionId: null,
+      defaultSessionId: pinnedIntegration.defaultSessionId,
+    });
+    expect(conversation.sessionId).toBe('019f-session-a');
+    expect(conversation.stateKey).toBe('019f-session-a');
+  });
+
+  it('lets a sticky selection win over the pin, and a cleared selection fall back to it', () => {
+    expect(
+      resolveLocalAgentConversation({
+        integrationId: 'prime-agent',
+        sessionId: '019f-session-b',
+        defaultSessionId: '019f-session-a',
+      }).sessionId,
+    ).toBe('019f-session-b');
+    // The self-heal re-homes a dead-pinned conversation by resolving against
+    // the refreshed pin as an explicit session — same resolution shape.
+    expect(
+      resolveLocalAgentConversation({
+        integrationId: 'prime-agent',
+        sessionId: null,
+        defaultSessionId: '019f-session-c',
+      }).sessionId,
+    ).toBe('019f-session-c');
+  });
+
+  it('selection state carries the pin into the selected conversation', () => {
+    const state = resolveLocalAgentSelectionState({
+      integrations: [pinnedIntegration],
+      selectedIntegrationId: 'prime-agent',
+      selectedSessionId: null,
+      localMessagesByConversation: {},
+      sessions: [],
+    });
+    expect(state.selectedConversation?.sessionId).toBe('019f-session-a');
+  });
+
+  it('sends the pin-resolved conversation sessionId in the outgoing request body', async () => {
+    const savedFetch = globalThis.fetch;
+    let payload: Record<string, unknown> = {};
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      payload = JSON.parse(String(init?.body ?? '{}'));
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(
+            'data: {"type":"final","text":"ok","correlationId":"c-pin","sessionId":"019f-session-a"}\n\n',
+          ));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }) as typeof globalThis.fetch;
+
+    try {
+      // The exact hop PanelRightContainer performs: resolve the conversation
+      // from the mapped integration, then send with the resolved sessionId.
+      const conversation = resolveLocalAgentConversation({
+        integrationId: 'prime-agent',
+        sessionId: null,
+        defaultSessionId: pinnedIntegration.defaultSessionId,
+      });
+      await streamLocalAgentChat('prime-agent', 'hello', {
+        sessionId: conversation.sessionId ?? undefined,
+      });
+      expect(payload).toMatchObject({ text: 'hello', sessionId: '019f-session-a' });
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  });
+
+  it('maps the daemon 409 body into the code the self-heal path keys on', async () => {
+    // End-to-end through the real error path: if the daemon renamed the field
+    // or buildLocalAgentApiError stopped copying `code`, the dead-session pin
+    // would never be marked and every retry would 409 — this must fail then.
+    const savedFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: 'No live Prime Agent session 019f-dead',
+          code: 'PRIME_AGENT_NO_SESSION',
+          source: 'prime-agent-channel',
+          correlationId: 'c-409',
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } },
+      )) as typeof globalThis.fetch;
+
+    try {
+      let caught: unknown;
+      await streamLocalAgentChat('prime-agent', 'hello', { sessionId: '019f-dead' })
+        .catch((err) => { caught = err; });
+      expect(caught).toBeInstanceOf(LocalAgentApiError);
+      expect(caught).toMatchObject({ code: 'PRIME_AGENT_NO_SESSION', status: 409 });
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  });
+});

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -860,9 +860,13 @@ describe('OpenClaw bridge behavioral tests', () => {
           ok: true,
           sessionCount: 2,
           target: '019f-session-a',
+          busy: true,
+          turnState: 'running',
+          clientConnected: false,
+          clientDisconnectedAt: '2026-08-07T12:34:56.000Z',
           sessions: [
-            { sessionId: '019f-session-a' },
-            { sessionId: '019f-session-b' },
+            { sessionId: '019f-session-a', sessionName: 'Research' },
+            { sessionId: '019f-session-b', sessionName: 'Publishing' },
           ],
         }),
       },
@@ -875,6 +879,13 @@ describe('OpenClaw bridge behavioral tests', () => {
       const prime = result.integrations.find((item) => item.id === 'prime-agent');
       expect(prime?.activeSessionId).toBe('019f-session-a');
       expect(prime?.defaultSessionId).toBe('019f-session-a');
+      expect(prime?.busy).toBe(true);
+      expect(prime?.liveSessions?.map((session) => session.sessionId)).toEqual([
+        '019f-session-a',
+        '019f-session-b',
+      ]);
+      expect(prime?.statusLabel).toBe('Still working');
+      expect(prime?.detail).toContain('browser stream disconnected');
     } finally {
       globalThis.fetch = original;
     }

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -836,6 +836,50 @@ describe('OpenClaw bridge behavioral tests', () => {
     }
   });
 
+  it('pins Prime Agent chat to the elected live session', async () => {
+    const { fetch } = createTrackingFetch([
+      {
+        ok: true,
+        json: async () => ({
+          integrations: [
+            {
+              id: 'prime-agent',
+              name: 'Prime Agent',
+              description: 'Prime Agent framework adapter',
+              enabled: true,
+              capabilities: { localChat: true, connectFromUi: true },
+              runtime: { status: 'ready', ready: true },
+              metadata: { sessionCount: 2, activeSessionId: '019f-session-a' },
+            },
+          ],
+        }),
+      },
+      {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          sessionCount: 2,
+          target: '019f-session-a',
+          sessions: [
+            { sessionId: '019f-session-a' },
+            { sessionId: '019f-session-b' },
+          ],
+        }),
+      },
+    ]);
+    const original = globalThis.fetch;
+    globalThis.fetch = fetch;
+    try {
+      const { fetchLocalAgentIntegrations } = await import('../src/ui/api.js');
+      const result = await fetchLocalAgentIntegrations();
+      const prime = result.integrations.find((item) => item.id === 'prime-agent');
+      expect(prime?.activeSessionId).toBe('019f-session-a');
+      expect(prime?.defaultSessionId).toBe('019f-session-a');
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
   it('fetchLocalAgentIntegrations maps Hermes health metadata into degraded detail', async () => {
     const { fetch } = createTrackingFetch([
       {

--- a/packages/node-ui/test/prime-agent-panel.test.ts
+++ b/packages/node-ui/test/prime-agent-panel.test.ts
@@ -8,7 +8,7 @@
 // these tests assert the copy, not just the presence of an element.
 
 import React, { act } from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
 
 // The pinned happy-dom build exposes a `localStorage` that lacks the Storage
@@ -108,6 +108,65 @@ async function renderAddSurface(primeAgent: Record<string, unknown>) {
   };
 }
 
+async function renderChatSurface(
+  primeAgent: Record<string, unknown>,
+  onSelectIntegration: (...args: any[]) => void = noop,
+) {
+  const { ConnectedAgentsTab } = await import('../src/ui/components/Shell/PanelRight.js');
+  const selected = integration({
+    configured: true,
+    detected: true,
+    persistentChat: true,
+    chatReady: true,
+    bridgeOnline: true,
+    status: 'chat_ready',
+    statusLabel: 'Chat ready',
+    ...primeAgent,
+  });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(ConnectedAgentsTab, {
+      integrations: [selected],
+      selectedIntegrationId: 'prime-agent',
+      selectedIntegration: selected,
+      selectedSessionId: selected.activeSessionId ?? null,
+      selectedHasConversation: false,
+      selectedIntegrationHasAnyConversation: false,
+      onSelectIntegration,
+      onConnectIntegration: noop,
+      onDisconnectIntegration: noop,
+      onRefreshIntegration: noop,
+      connectBusyId: null,
+      refreshBusyId: null,
+      connectNotice: null,
+      connectError: null,
+      localMessages: [],
+      localHistoryLoaded: true,
+      localChatEndRef: { current: null },
+      localInput: '',
+      onLocalInputChange: noop,
+      onSendLocalMessage: noop,
+      onStopLocalStream: noop,
+      localSending: false,
+      activeProjectId: 'testing',
+      availableProjects: [{ id: 'testing', name: 'Testing' }],
+      projectsLoading: false,
+      attachments: [],
+      onAddAttachments: noop,
+      onRemoveAttachment: noop,
+    } as any));
+  });
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => { root.unmount(); });
+      container.remove();
+    },
+  };
+}
+
 describe('Prime Agent panel block', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -146,6 +205,41 @@ describe('Prime Agent panel block', () => {
     expect(logo).not.toBeNull();
     // Painted as a mask so it follows the theme's text colour.
     expect((logo as HTMLElement).style.maskImage).toContain('data:image/png;base64,');
+    await unmount();
+  });
+
+  it('shows a recoverable working state after the browser stream disconnects', async () => {
+    const { container, unmount } = await renderChatSurface({
+      busy: true,
+      detail: 'Prime Agent is still working after the browser stream disconnected.',
+    });
+    const status = container.querySelector('[data-testid="prime-agent-active-turn-status"]');
+    expect(status?.textContent).toContain('still working');
+    const composer = container.querySelector('textarea');
+    expect(composer?.hasAttribute('disabled')).toBe(true);
+    await unmount();
+  });
+
+  it('lets the operator explicitly switch among live Prime sessions', async () => {
+    const onSelect = vi.fn();
+    const { container, unmount } = await renderChatSurface({
+      activeSessionId: 'session-a',
+      defaultSessionId: 'session-a',
+      liveSessions: [
+        { sessionId: 'session-a', sessionName: 'Research' },
+        { sessionId: 'session-b', sessionName: 'Publishing' },
+      ],
+    }, onSelect);
+    const trigger = container.querySelector('button[aria-label="Prime Agent session"]') as HTMLButtonElement;
+    expect(trigger).not.toBeNull();
+    expect(trigger.textContent).toContain('Research');
+
+    await act(async () => { trigger.click(); });
+    const publishing = [...document.querySelectorAll('[role="option"]')]
+      .find((option) => option.textContent?.includes('Publishing')) as HTMLElement;
+    expect(publishing).toBeDefined();
+    await act(async () => { publishing.click(); });
+    expect(onSelect).toHaveBeenCalledWith('prime-agent', { sessionId: 'session-b' });
     await unmount();
   });
 });

--- a/packages/node-ui/test/ui-api-stream.test.ts
+++ b/packages/node-ui/test/ui-api-stream.test.ts
@@ -171,6 +171,37 @@ describe('ui local-agent stream api', () => {
     }
   });
 
+  it('forwards the pinned Prime Agent session through the generic chat transport', async () => {
+    const savedFetch = globalThis.fetch;
+    let payload: Record<string, unknown> = {};
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      payload = JSON.parse(String(init?.body ?? '{}'));
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(
+            'data: {"type":"final","text":"Prime","correlationId":"p-pinned","sessionId":"019f-session-a"}\n\n',
+          ));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }) as typeof globalThis.fetch;
+
+    try {
+      const result = await streamLocalAgentChat('prime-agent', 'hello', {
+        sessionId: '019f-session-a',
+      });
+      expect(result.sessionId).toBe('019f-session-a');
+      expect(payload).toMatchObject({ text: 'hello', sessionId: '019f-session-a' });
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  });
+
   it('parses Hermes SSE frames and resolves the final payload', async () => {
     requestLog.length = 0;
 

--- a/packages/node-ui/test/ui-api-stream.test.ts
+++ b/packages/node-ui/test/ui-api-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import {
   fetchMemorySessionGraphDelta,
+  fetchLocalAgentIntegrations,
   importFile,
   persistLocalAgentChatFailure,
   LocalAgentApiError,
@@ -11,6 +12,7 @@ import {
   streamOpenClawLocalChat,
   streamPrimeAgentLocalChat,
 } from '../src/ui/api.js';
+import { resolveLocalAgentConversation } from '../src/ui/components/Shell/PanelRight/selection.js';
 
 let server: Server;
 let baseUrl: string;
@@ -171,10 +173,32 @@ describe('ui local-agent stream api', () => {
     }
   });
 
-  it('forwards the pinned Prime Agent session through the generic chat transport', async () => {
+  it('maps the elected Prime session through selection into the generic chat transport', async () => {
     const savedFetch = globalThis.fetch;
     let payload: Record<string, unknown> = {};
-    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations')) {
+        return Response.json({
+          integrations: [{
+            id: 'prime-agent',
+            name: 'Prime Agent',
+            description: 'Prime Agent framework adapter',
+            enabled: true,
+            capabilities: { localChat: true, connectFromUi: true },
+            runtime: { status: 'ready', ready: true },
+            metadata: { sessionCount: 2, activeSessionId: '019f-session-a' },
+          }],
+        });
+      }
+      if (url.includes('/api/prime-agent-channel/health')) {
+        return Response.json({
+          ok: true,
+          sessionCount: 2,
+          target: '019f-session-a',
+          sessions: [{ sessionId: '019f-session-a' }, { sessionId: '019f-session-b' }],
+        });
+      }
       payload = JSON.parse(String(init?.body ?? '{}'));
       const encoder = new TextEncoder();
       const stream = new ReadableStream<Uint8Array>({
@@ -192,11 +216,58 @@ describe('ui local-agent stream api', () => {
     }) as typeof globalThis.fetch;
 
     try {
+      const { integrations } = await fetchLocalAgentIntegrations();
+      const prime = integrations.find((integration) => integration.id === 'prime-agent');
+      const conversation = resolveLocalAgentConversation({
+        integrationId: 'prime-agent',
+        sessionId: null,
+        defaultSessionId: prime?.defaultSessionId,
+      });
       const result = await streamLocalAgentChat('prime-agent', 'hello', {
-        sessionId: '019f-session-a',
+        sessionId: conversation.sessionId ?? undefined,
       });
       expect(result.sessionId).toBe('019f-session-a');
       expect(payload).toMatchObject({ text: 'hello', sessionId: '019f-session-a' });
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  });
+
+  it('re-elects once when an automatically pinned Prime session has exited', async () => {
+    const savedFetch = globalThis.fetch;
+    const payloads: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      payloads.push(JSON.parse(String(init?.body ?? '{}')));
+      if (payloads.length === 1) {
+        return Response.json({
+          error: 'No live Prime Agent session stale-session',
+          code: 'PRIME_AGENT_NO_SESSION',
+          source: 'prime-agent-channel',
+        }, { status: 409 });
+      }
+      const encoder = new TextEncoder();
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(
+            'data: {"type":"final","text":"Recovered","correlationId":"p-retry","sessionId":"live-session"}\n\n',
+          ));
+          controller.close();
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }) as typeof globalThis.fetch;
+
+    try {
+      const result = await streamLocalAgentChat('prime-agent', 'hello', {
+        sessionId: 'stale-session',
+      });
+      expect(result).toMatchObject({ text: 'Recovered', sessionId: 'live-session' });
+      expect(payloads).toHaveLength(2);
+      expect(payloads[0]).toMatchObject({ text: 'hello', sessionId: 'stale-session' });
+      expect(payloads[1]).toMatchObject({ text: 'hello' });
+      expect(payloads[1].sessionId).toBeUndefined();
     } finally {
       globalThis.fetch = savedFetch;
     }

--- a/packages/node-ui/test/ui-sse-final-frame.test.ts
+++ b/packages/node-ui/test/ui-sse-final-frame.test.ts
@@ -36,7 +36,10 @@ beforeAll(async () => {
       const url = req.url ?? '/';
       if (url.includes('/api/prime-agent-channel/stream')) {
         writeStreamAndHold(res, [
+          ': open\n\n',
+          ': keepalive\n\n',
           'data: {"type":"delta","text":"Hel"}\n\n',
+          ': keepalive\n\n',
           'data: {"type":"delta","text":"lo!"}\n\n',
           'data: {"type":"final","text":"Hello!","correlationId":"p1","sessionId":"s1"}\n\n',
         ]);


### PR DESCRIPTION
## Summary

- emit sanitized `: keepalive` SSE comments during Prime thinking/tool work and disable proxy buffering on both bridge and daemon SSE responses
- stop heartbeat timers on settle, disconnect, error, and bridge shutdown, while exposing recoverable disconnected-busy state through daemon health and the Node UI
- pin chat to the actual Prime election head, keep all integration responses overlaid with current live-session metadata, and clear stale pins when no session remains
- retry one explicit stale-session miss in the same send without a pin, then adopt the elected replacement session, retain the completed transcript, and show a visible switch notice
- let operators choose among multiple live Prime sessions rather than silently following a changing head

## Why

Prime can spend several minutes on thinking and tool calls before producing visible text. The old bridge emitted no transport bytes during that interval, so a browser/proxy could abandon a healthy turn and surface `Load failed`. The first pinning fix also needed stronger election semantics and restart recovery to avoid routing to an older probe survivor or leaving the UI stuck on a dead session.

## Regression coverage

- non-text turns remain alive without exposing hidden thinking/tool content
- downstream disconnect clears the keepalive timer and leaves a recoverable busy health state
- split SSE comment frames pass byte-for-byte through the daemon and still terminate on the final frame
- connect, refresh, list, and single-integration reads report the current election head and remove stale persisted pins
- an unprobeable head is not replaced by the older health-probe survivor for routing
- a stale automatic pin retries only after `PRIME_AGENT_NO_SESSION`, whose explicit miss is guaranteed pre-delivery, and adopts the returned live session
- Prime multi-session selection flows through the conversation key into the outgoing request

## Validation

- Prime adapter: 81/81 tests
- daemon Prime/SSE proxy: 41/41 tests
- focused Node UI: 113/113 tests
- Prime adapter extension build, CLI TypeScript check, and Node UI production build
- explicit Node UI TypeScript scan reports no errors in the touched files
- clean `git diff --check`

Merged current `testnet-canary` after #2126 and reconciled the overlapping bridge tests.

Fixes #2125
