### PR TITLE
feat(sync): make Edge system graph catch-up on-demand

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -339,6 +339,7 @@ import {
   type SyncAdmissionSource,
   type SyncSchedulerLane,
 } from './sync/policy.js';
+import { automaticDurableSyncContextGraphs } from './sync/system-context-graph-policy.js';
 import {
   activeSyncAdmissionSource,
   monotonicNowMs,
@@ -3282,8 +3283,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
     }
 
-    // On new peer connection, request sync of system context graphs so we discover
-    // agents that published their profiles before we came online.
+    // On new peer connection, request automatic durable catch-up. Core nodes
+    // include the system Context Graphs; Edge nodes default to the graphs their
+    // operator selected and can fetch system graphs explicitly when needed.
     // Wait for protocol identification to complete, then only sync with
     // peers that actually support the sync protocol (skips raw relay nodes).
     const handleSyncError = (remotePeer: string, err: unknown): void => {
@@ -4002,6 +4004,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       knownCorePeerIds: this.knownCorePeerIds,
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
       getSyncContextGraphs: () => this.config.syncContextGraphs ?? [],
+      getDurableSyncContextGraphs: () => automaticDurableSyncContextGraphs(
+        this.config.syncContextGraphs ?? [],
+        {
+          nodeRole: this.config.nodeRole,
+          configValue: this.config.syncSystemContextGraphsOnConnect,
+          envValue: process.env.DKG_SYNC_SYSTEM_CONTEXT_GRAPHS_ON_CONNECT,
+        },
+      ),
       getSharedMemorySyncContextGraphs: async (peerId) => (await getSharedMemorySyncPlan(peerId)).eligibleContextGraphIds,
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
         peerId,

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1396,6 +1396,12 @@ export interface DKGAgentConfig {
   syncReconcilerEnabled?: boolean;
   /** Emergency switch for all peer-connect sync triggers. Env DKG_SYNC_ON_CONNECT_ENABLED wins. */
   syncOnConnectEnabled?: boolean;
+  /**
+   * Include `agents` and `ontology` in automatic peer-connect/reconciler
+   * durable sync. Defaults true on Core and false on Edge. Explicit catch-up
+   * remains available. Env DKG_SYNC_SYSTEM_CONTEXT_GRAPHS_ON_CONNECT wins.
+   */
+  syncSystemContextGraphsOnConnect?: boolean;
   /** Emergency switch for durable/SWM sync execution. Env DKG_DURABLE_SYNC_ENABLED wins. */
   durableSyncEnabled?: boolean;
   /**
@@ -1600,7 +1606,7 @@ export interface DKGAgentConfig {
   };
   /** Cross-agent query access configuration. */
   queryAccess?: QueryAccessConfig;
-  /** Additional context graph IDs to sync on peer connect (beyond system context graphs). */
+  /** User-selected context graph IDs to sync automatically on peer connect. */
   syncContextGraphs?: string[];
   /** TTL for shared memory data in milliseconds. Expired operations are periodically cleaned up. Default: 48 hours. Set to 0 to disable. */
   sharedMemoryTtlMs?: number;

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -20,6 +20,8 @@ interface SyncOnConnectContext {
   knownCorePeerIds: Set<string>;
   knownCorePeerIdsV2?: Set<string>;
   getSyncContextGraphs: () => string[];
+  /** Exact durable scope for this automatic run; explicit catch-up bypasses it. */
+  getDurableSyncContextGraphs?: () => string[];
   getSharedMemorySyncContextGraphs?: (remotePeerId: string) => string[] | Promise<string[]>;
   syncFromPeer: (peerId: string, contextGraphIds?: string[]) => Promise<SyncFromPeerResult>;
   refreshMetaSyncedFlags: (contextGraphIds: Iterable<string>) => Promise<void>;
@@ -135,6 +137,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     knownCorePeerIds,
     knownCorePeerIdsV2 = new Set<string>(),
     getSyncContextGraphs,
+    getDurableSyncContextGraphs,
     getSharedMemorySyncContextGraphs,
     syncFromPeer,
     refreshMetaSyncedFlags,
@@ -242,36 +245,48 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       return 'skipped-no-sync';
     }
 
-    logInfo(ctx, `Syncing from peer ${shortPeer}...`);
-    const knownCgsBefore = new Set(getSyncContextGraphs() ?? []);
-    const synced = await syncFromPeer(remotePeer);
-    const syncedAccounting = recordSyncAccounting(synced, 'durable');
-    logInfo(ctx, `Synced ${syncedAccounting.insertedTriples} data triples from peer ${shortPeer}`);
-    if (syncedAccounting.deferredByBackpressure) {
-      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after local admission deferral`);
-      return finishSyncAccounting();
-    }
-    // A backoff-worthy per-CG failure must NOT stop the remaining lanes: the
-    // failure is already recorded (the peer will not be stamped fresh), and
-    // stopping here starves CG discovery and shared-memory sync of a peer
-    // that is demonstrably reachable — the small-CG-behind-a-poison-transfer
-    // starvation this accounting exists to prevent. Only a peer that never
-    // answered any round and produced no progress stops the fanout, because
-    // every later lane would just re-dial the same dead peer.
-    if (syncedAccounting.peerUnreachable && !syncedAccounting.madeProgress) {
-      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer}: durable sync could not reach the peer`);
-      return finishSyncAccounting();
-    }
-    if (syncedAccounting.backoffWorthyFailure) {
-      logInfo(ctx, `Durable sync from peer ${shortPeer} hit backoff-worthy pressure; continuing remaining sync-on-connect lanes`);
-    }
-
-    const syncScope = new Set<string>([
+    const durableContextGraphIds = getDurableSyncContextGraphs?.() ?? [
       SYSTEM_CONTEXT_GRAPHS.AGENTS,
       SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
       ...(getSyncContextGraphs() ?? []),
-    ]);
-    await runNonTransportStep(() => refreshMetaSyncedFlags(syncScope));
+    ];
+    logInfo(ctx, `Syncing from peer ${shortPeer}...`);
+    const knownCgsBefore = new Set(getSyncContextGraphs() ?? []);
+    if (durableContextGraphIds.length > 0) {
+      const synced = getDurableSyncContextGraphs
+        ? await syncFromPeer(remotePeer, durableContextGraphIds)
+        : await syncFromPeer(remotePeer);
+      const syncedAccounting = recordSyncAccounting(synced, 'durable');
+      logInfo(ctx, `Synced ${syncedAccounting.insertedTriples} data triples from peer ${shortPeer}`);
+      if (syncedAccounting.deferredByBackpressure) {
+        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after local admission deferral`);
+        return finishSyncAccounting();
+      }
+      // A backoff-worthy per-CG failure must NOT stop the remaining lanes: the
+      // failure is already recorded (the peer will not be stamped fresh), and
+      // stopping here starves CG discovery and shared-memory sync of a peer
+      // that is demonstrably reachable — the small-CG-behind-a-poison-transfer
+      // starvation this accounting exists to prevent. Only a peer that never
+      // answered any round and produced no progress stops the fanout, because
+      // every later lane would just re-dial the same dead peer.
+      if (syncedAccounting.peerUnreachable && !syncedAccounting.madeProgress) {
+        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer}: durable sync could not reach the peer`);
+        return finishSyncAccounting();
+      }
+      if (syncedAccounting.backoffWorthyFailure) {
+        logInfo(ctx, `Durable sync from peer ${shortPeer} hit backoff-worthy pressure; continuing remaining sync-on-connect lanes`);
+      }
+    } else {
+      // An empty automatic scope is a completed no-op. Stamp the peer fresh so
+      // the reconciler does not repeatedly wake an Edge that selected no CGs.
+      cleanDurableDetailedRound = true;
+      logInfo(ctx, `Skipping automatic durable sync from ${shortPeer}: no Context Graphs are eligible`);
+    }
+
+    const syncScope = new Set<string>(durableContextGraphIds);
+    if (syncScope.size > 0) {
+      await runNonTransportStep(() => refreshMetaSyncedFlags(syncScope));
+    }
 
     await runNonTransportStep(() => discoverContextGraphsFromStore());
 

--- a/packages/agent/src/sync/system-context-graph-policy.ts
+++ b/packages/agent/src/sync/system-context-graph-policy.ts
@@ -1,0 +1,32 @@
+import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import { parseBooleanEnv } from './agents-meta-policy.js';
+
+export interface AutomaticSystemContextGraphSyncOptions {
+  nodeRole?: 'core' | 'edge';
+  configValue?: boolean;
+  envValue?: string;
+}
+
+/**
+ * Core nodes retain the complete network catalogue needed for hosting, while
+ * Edge nodes fetch only graphs their operator selected. Explicit catch-up and
+ * the live system GossipSub subscriptions are outside this policy.
+ */
+export function resolveAutomaticSystemContextGraphSync(
+  options: AutomaticSystemContextGraphSyncOptions,
+): boolean {
+  const envValue = parseBooleanEnv(options.envValue);
+  if (envValue !== undefined) return envValue;
+  if (options.configValue !== undefined) return options.configValue;
+  return options.nodeRole === 'core';
+}
+
+export function automaticDurableSyncContextGraphs(
+  selectedContextGraphIds: readonly string[],
+  options: AutomaticSystemContextGraphSyncOptions,
+): string[] {
+  const ordered = resolveAutomaticSystemContextGraphSync(options)
+    ? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...selectedContextGraphIds]
+    : [...selectedContextGraphIds];
+  return [...new Set(ordered)];
+}

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -1267,6 +1267,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       const agent = await DKGAgent.create({
         name: 'SyncDedupTest',
         listenHost: '127.0.0.1',
+        nodeRole: 'core',
         chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
       });
       try {

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -738,6 +738,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       const agent = await DKGAgent.create({
         name: 'SyncOnConnectDiscoveryRefresh',
         listenHost: '127.0.0.1',
+        nodeRole: 'core',
         chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
       });
 

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -31,6 +31,13 @@ async function createUnstartedAgent(name: string): Promise<DKGAgent> {
   });
 }
 
+function allowAllNetworkAdmission(agent: DKGAgent): void {
+  const coordinator = (agent as any).networkAdmissionCoordinator;
+  coordinator.isAcceptedPeer = () => true;
+  coordinator.isRejectedPeer = () => false;
+  coordinator.ensureAdmitted = async () => true;
+}
+
 const noopLog = (_ctx: OperationContext, _message: string) => {};
 
 function emptyDetailedSync(overrides: Record<string, number> = {}) {
@@ -75,6 +82,101 @@ describe('sync-on-connect churn gates', () => {
       SYSTEM_CONTEXT_GRAPHS.AGENTS,
       SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
       configuredGraph,
+    ]);
+  });
+
+  it('uses the exact automatic durable scope supplied by the role policy', async () => {
+    const syncFromPeer = recorder(async () => 0);
+    const refreshMetaSyncedFlags = recorder(async () => undefined);
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['selected-cg'],
+      getDurableSyncContextGraphs: () => ['selected-cg'],
+      getSharedMemorySyncContextGraphs: () => [],
+      syncFromPeer,
+      refreshMetaSyncedFlags,
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async () => 0,
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(syncFromPeer.calls).toEqual([[PEER_A, ['selected-cg']]]);
+    expect([...refreshMetaSyncedFlags.calls[0][0]]).toEqual(['selected-cg']);
+  });
+
+  it('treats an empty automatic durable scope as a clean no-op', async () => {
+    const syncFromPeer = recorder(async () => 0);
+    const refreshMetaSyncedFlags = recorder(async () => undefined);
+    const discoverContextGraphsFromStore = recorder(async () => 0);
+    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => [],
+      getDurableSyncContextGraphs: () => [],
+      getSharedMemorySyncContextGraphs: () => [],
+      syncFromPeer,
+      refreshMetaSyncedFlags,
+      discoverContextGraphsFromStore,
+      syncSharedMemoryFromPeer: async () => 0,
+      logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => {
+        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+      },
+    });
+
+    expect(outcome).toBe('synced');
+    expect(syncFromPeer.calls).toEqual([]);
+    expect(refreshMetaSyncedFlags.calls).toEqual([]);
+    expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
+    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: true, progress: false }]);
+  });
+
+  it.each([
+    ['edge', ['selected-cg']],
+    ['core', [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, 'selected-cg']],
+  ] as const)('wires the %s role into the automatic durable scope', async (nodeRole, expectedScope) => {
+    const agent = await createUnstartedAgent(`AutomaticSystemScope-${nodeRole}`);
+    allowAllNetworkAdmission(agent);
+    (agent as any).started = true;
+    (agent as any).config.nodeRole = nodeRole;
+    (agent as any).config.syncContextGraphs = ['selected-cg'];
+    (agent as any).config.syncSharedMemoryOnConnect = false;
+    (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+    const syncFromPeerDetailed = recorder(async () => emptyDetailedSync({ completedPhases: 1 }));
+    (agent as any).syncFromPeerDetailed = syncFromPeerDetailed;
+    (agent as any).refreshMetaSyncedFlags = async () => undefined;
+    (agent as any).discoverContextGraphsFromStore = async () => 0;
+    (agent as any).planSharedMemorySyncContextGraphs = async () => ({
+      eligibleContextGraphIds: [],
+    });
+
+    expect(await (agent as any).trySyncFromPeer(PEER_A)).toBe('synced');
+    expect(syncFromPeerDetailed.calls[0][1]).toEqual(expectedScope);
+  });
+
+  it('keeps explicit Edge catch-up available for system Context Graphs', async () => {
+    const agent = await createUnstartedAgent('ExplicitSystemGraphCatchup');
+    (agent as any).config.nodeRole = 'edge';
+    const syncFromPeerDetailed = recorder(async () => emptyDetailedSync());
+    (agent as any).syncFromPeerDetailed = syncFromPeerDetailed;
+
+    await agent.syncFromPeer(PEER_A, [
+      SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+    ]);
+
+    expect(syncFromPeerDetailed.calls[0][1]).toEqual([
+      SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
     ]);
   });
 

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1528,6 +1528,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     const agent = await DKGAgent.create({
       name: 'ReconcilerLocalBackpressureRetry',
       listenHost: '127.0.0.1',
+      nodeRole: 'core',
       chainAdapter: new MockChainAdapter(),
       syncGlobalMaxInflight: 1,
       syncGlobalQueueLimit: 0,
@@ -1899,6 +1900,7 @@ describe('DKGAgent sync state lifecycle', () => {
     const agent = await DKGAgent.create({
       name: 'DenialOnlyNoProgressCooldown',
       listenHost: '127.0.0.1',
+      nodeRole: 'core',
       chainAdapter: new MockChainAdapter(),
     });
     try {

--- a/packages/agent/test/system-context-graph-policy.test.ts
+++ b/packages/agent/test/system-context-graph-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import {
+  automaticDurableSyncContextGraphs,
+  resolveAutomaticSystemContextGraphSync,
+} from '../src/sync/system-context-graph-policy.js';
+
+describe('automatic system Context Graph sync policy', () => {
+  it('defaults automatic system graph replay on for Core and off for Edge', () => {
+    expect(resolveAutomaticSystemContextGraphSync({ nodeRole: 'core' })).toBe(true);
+    expect(resolveAutomaticSystemContextGraphSync({ nodeRole: 'edge' })).toBe(false);
+    expect(resolveAutomaticSystemContextGraphSync({})).toBe(false);
+  });
+
+  it('allows an explicit config override for either role', () => {
+    expect(resolveAutomaticSystemContextGraphSync({
+      nodeRole: 'core',
+      configValue: false,
+    })).toBe(false);
+    expect(resolveAutomaticSystemContextGraphSync({
+      nodeRole: 'edge',
+      configValue: true,
+    })).toBe(true);
+  });
+
+  it('gives a recognized environment override precedence over config', () => {
+    expect(resolveAutomaticSystemContextGraphSync({
+      nodeRole: 'edge',
+      configValue: false,
+      envValue: '1',
+    })).toBe(true);
+    expect(resolveAutomaticSystemContextGraphSync({
+      nodeRole: 'core',
+      configValue: true,
+      envValue: '0',
+    })).toBe(false);
+    expect(resolveAutomaticSystemContextGraphSync({
+      nodeRole: 'edge',
+      configValue: true,
+      envValue: 'not-a-boolean',
+    })).toBe(true);
+  });
+
+  it('keeps an Edge automatic durable scope limited to selected graphs', () => {
+    expect(automaticDurableSyncContextGraphs(['selected-cg', 'selected-cg'], {
+      nodeRole: 'edge',
+    })).toEqual(['selected-cg']);
+  });
+
+  it('retains system graphs in the Core automatic durable scope', () => {
+    expect(automaticDurableSyncContextGraphs([
+      SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      'selected-cg',
+    ], {
+      nodeRole: 'core',
+    })).toEqual([
+      SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      'selected-cg',
+    ]);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -103,6 +103,7 @@ export default defineConfig({
       "test/sync-responder-protection.test.ts",
       "test/sync-on-connect-retry.test.ts",
       "test/sync-on-connect-churn.test.ts",
+      "test/system-context-graph-policy.test.ts",
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",
       "test/swm-fanout-peer-selection.test.ts",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -638,6 +638,12 @@ export interface DkgConfig {
   syncReconcilerEnabled?: boolean;
   /** Emergency switch for all peer-connect sync triggers. Env DKG_SYNC_ON_CONNECT_ENABLED wins. */
   syncOnConnectEnabled?: boolean;
+  /**
+   * Include `agents` and `ontology` in automatic peer-connect/reconciler
+   * durable sync. Defaults true on Core and false on Edge. Explicit catch-up
+   * remains available. Env DKG_SYNC_SYSTEM_CONTEXT_GRAPHS_ON_CONNECT wins.
+   */
+  syncSystemContextGraphsOnConnect?: boolean;
   /** Emergency switch for durable/SWM sync execution. Env DKG_DURABLE_SYNC_ENABLED wins. */
   durableSyncEnabled?: boolean;
   /**

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1789,6 +1789,7 @@ export async function runDaemonInner(
     syncSharedMemoryOnConnect: config.syncSharedMemoryOnConnect,
     syncReconcilerEnabled: config.syncReconcilerEnabled,
     syncOnConnectEnabled: config.syncOnConnectEnabled,
+    syncSystemContextGraphsOnConnect: config.syncSystemContextGraphsOnConnect,
     durableSyncEnabled: config.durableSyncEnabled,
     syncGlobalMaxInflight: config.syncGlobalMaxInflight,
     syncGlobalLimit: config.syncGlobalLimit,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -860,6 +860,19 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(loaded.syncAgentsMeta).toBe(false);
   });
 
+  it('round-trips the automatic system Context Graph sync override', async () => {
+    await saveConfig({
+      name: 'test-node',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'edge',
+      syncSystemContextGraphsOnConnect: true,
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.syncSystemContextGraphsOnConnect).toBe(true);
+  });
+
   it('round-trips sync snapshot limits and Context Graph priorities', async () => {
     await saveConfig({
       name: 'test-node',

--- a/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
+++ b/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
@@ -162,6 +162,14 @@ describe('runDaemonInner wires sync options into DKGAgent.create', () => {
     expect(createArg.syncGlobalQueueLimit).toBe(0);
   });
 
+  it('passes the automatic system Context Graph sync override through unchanged', async () => {
+    const createArg = await captureCreateArg({
+      syncSystemContextGraphsOnConnect: false,
+    });
+
+    expect(createArg.syncSystemContextGraphsOnConnect).toBe(false);
+  });
+
   it('passes snapshot limits and Context Graph priorities through unchanged', async () => {
     const syncResponderSnapshotLimits = {
       global: { rows: 500, bytesEstimate: 600 },


### PR DESCRIPTION
## Impact

Edge nodes no longer replay the complete `agents` and `ontology` histories on every peer-connect/reconciler run. Their automatic durable scope now contains only Context Graphs selected by the operator through `syncContextGraphs`.

Core nodes keep the existing complete-catalog behavior. Edge operators can still explicitly catch up either system graph, and live GossipSub subscriptions are unchanged.

This reduces automatic store, network, and sync-queue work on Edge nodes without changing publication, VM/SWM handling, existing stored data, or Core hosting behavior.

## Before

```mermaid
sequenceDiagram
    participant E as Edge
    participant P as DKG peer
    loop Peer connect and reconciler retry
        E->>P: Durable sync agents, ontology, and selected CGs
        P-->>E: Full system histories and selected data
    end
```

## After

```mermaid
sequenceDiagram
    participant N as Local node
    participant P as DKG peer
    alt Core node
        N->>P: Durable sync agents, ontology, and selected CGs
        P-->>N: Complete automatic catalogue scope
    else Edge node
        N->>P: Durable sync selected CGs only
        P-->>N: Operator-selected data
        opt Operator explicitly requests a system graph
            N->>P: Exact catch-up for agents or ontology
            P-->>N: Requested system graph history
        end
    end
```

## Policy and rollback

- Default: system-graph automatic catch-up is enabled on Core and disabled on Edge.
- Config override: `syncSystemContextGraphsOnConnect`.
- Emergency/runtime override: `DKG_SYNC_SYSTEM_CONTEXT_GRAPHS_ON_CONNECT` takes precedence.
- Setting either override to `true` restores the prior Edge behavior.
- An Edge with no selected CGs treats durable catch-up as a clean no-op, avoiding repeated reconciler churn.

## Validation

- Agent policy and production wiring: 29/29 tests passed.
- CLI config round-trip and daemon forwarding: 127/127 tests passed.
- Full 17-package Agent/CLI dependency build passed, including package-root/type checks.
- Mutation checks proved role default, environment precedence, empty-scope no-op, and CLI forwarding assertions fail when their implementation is removed or inverted.
- `git diff --check` passed.
- Supplemental broad Agent unit run completed many RFC-64, durable-sync, SWM, and transport suites with zero assertion failures before the local runner's 10-minute limit terminated it (exit 143); CI remains the authoritative full-lane completion.

## Out of scope

- No system GossipSub topic is removed.
- No stored system data is deleted.
- No Core default changes.
- No VM or SWM publication/synchronization semantics change outside automatic durable-scope selection.
