### PR TITLE
fix(cli): carry bounded Blazegraph runtime storage onto canary

### DIFF
--- a/blazegraph-image.json
+++ b/blazegraph-image.json
@@ -1,4 +1,5 @@
 {
   "image": "islandora/blazegraph:6.4.3@sha256:015e308ae0a296cdb87c83c10da976ed970d2bfa971290aa1147593df8cf445d",
-  "containerPort": 8080
+  "containerPort": 8080,
+  "dataPath": "/data"
 }

--- a/docs/use-dkg/storage-sparql-http.md
+++ b/docs/use-dkg/storage-sparql-http.md
@@ -97,6 +97,12 @@ Size the daemon service and Oxigraph scope independently, while keeping their co
 - **Apache Jena Fuseki:** Typically `http://host:3030/dataset/query` and `http://host:3030/dataset/update`.
 - **GraphDB, Neptune, Stardog:** Use the vendor’s SPARQL query and update URLs; add `auth` if required.
 
+### Blazegraph provisioned by `dkg init` (Docker)
+
+When you pick the `blazegraph` backend in `dkg init` and leave the URL blank, the CLI offers to provision a container itself. For new containers, the provisioner uses the pinned multi-architecture image and data path declared in `blazegraph-image.json`, stores the journal in a named Docker volume, and uses `--restart unless-stopped`. Blazegraph output uses Docker's compressed `local` log driver with a 4 GB rotation budget (`200m` × 20 files), so an unattended container cannot fill the host disk. The provisioner auto-bumps the host port if 9999 is taken and is idempotent — re-running `dkg init` against an already-provisioned namespace reuses the running container.
+
+A reused legacy container is never recreated automatically, because doing so could discard its journal. If its volume or log policy does not match the current configuration, the CLI prints explicit backup/migration and unbounded-log warnings instead.
+
 ## Programmatic (DKGAgent)
 
 When creating an agent in code, pass `storeConfig`:

--- a/packages/cli/blazegraph-image-metadata.cjs
+++ b/packages/cli/blazegraph-image-metadata.cjs
@@ -65,8 +65,10 @@ function parseBlazegraphImageMetadata(value, source = 'Blazegraph image metadata
   }
 
   const dataPath = typeof value.dataPath === 'string' ? value.dataPath.trim() : '';
-  if (!dataPath.startsWith('/') || dataPath.includes(',')) {
-    throw new Error(`${source}: dataPath must be an absolute container path without commas`);
+  if (!dataPath.startsWith('/') || /[\s,]/.test(dataPath)) {
+    throw new Error(
+      `${source}: dataPath must be an absolute container path without commas or whitespace`,
+    );
   }
 
   return { image, containerPort, dataPath };
@@ -94,7 +96,7 @@ function readBlazegraphImageMetadata(filePath) {
 function formatBlazegraphImageMetadata(metadata) {
   const parsed = parseBlazegraphImageMetadata(metadata);
   return Object.entries(parsed)
-    // Values may themselves contain '=' (dataPath only bans commas), so
+    // Values may themselves contain '=' (dataPath bans commas and whitespace), so
     // consumers must split on the FIRST '=' only — or use field mode, which
     // prints bare values and has no delimiter at all.
     .map(([key, value]) => `${key}=${value}`)

--- a/packages/cli/blazegraph-image-metadata.cjs
+++ b/packages/cli/blazegraph-image-metadata.cjs
@@ -1,11 +1,57 @@
 #!/usr/bin/env node
+/*
+ * Single plain-CJS source of the Blazegraph runtime contract: the pinned
+ * image metadata (blazegraph-image.json) AND the namespace-properties XML
+ * template. TypeScript consumes it via createRequire
+ * (packages/cli/src/daemon/blazegraph-docker.ts); shell consumes it via the
+ * CLI below (scripts/devnet.sh, scripts/devnet-blazegraph-native.sh,
+ * scripts/ci/verify-blazegraph-image-contract.sh).
+ *
+ * Must stay dependency-free and buildless: shell callers run this file
+ * straight from the repo checkout (or the packed tarball) with a bare `node`,
+ * before any workspace build exists.
+ */
 'use strict';
 
 const fs = require('node:fs');
 
+/**
+ * Canonical XML template for a Blazegraph namespace tuned for DKG V10
+ * (quads enabled, no truth maintenance, no text index, no statement
+ * identifiers). Substitutes `{namespace}` for the namespace name.
+ *
+ * Blazegraph's loadFromXML matches the SYSTEM DOCTYPE literally (it is never
+ * fetched; the dead java.sun.com URL is fine). quads=true is mandatory: the
+ * DKG uses named graphs, and quads mode requires inference disabled via
+ * NoAxioms.
+ */
+const BLAZEGRAPH_NAMESPACE_XML_TEMPLATE = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+  <entry key="com.bigdata.rdf.sail.namespace">{namespace}</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.quads">true</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers">false</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.textIndex">false</entry>
+  <entry key="com.bigdata.rdf.sail.truthMaintenance">false</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.axiomsClass">com.bigdata.rdf.axioms.NoAxioms</entry>
+</properties>`;
+
+// Namespace names are templated into XML verbatim, so only accept a
+// conservative charset — anything needing escaping is rejected outright.
+const BLAZEGRAPH_NAMESPACE_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+
+function renderBlazegraphNamespaceXml(namespace) {
+  if (typeof namespace !== 'string' || !BLAZEGRAPH_NAMESPACE_PATTERN.test(namespace)) {
+    throw new Error(
+      `Blazegraph namespace ${JSON.stringify(namespace)} is invalid: it is templated into XML, so it must match ${BLAZEGRAPH_NAMESPACE_PATTERN}`,
+    );
+  }
+  return BLAZEGRAPH_NAMESPACE_XML_TEMPLATE.replace('{namespace}', namespace);
+}
+
 function parseBlazegraphImageMetadata(value, source = 'Blazegraph image metadata') {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`${source}: expected an object with image and containerPort`);
+    throw new Error(`${source}: expected an object with image, containerPort, and dataPath`);
   }
 
   const image = typeof value.image === 'string' ? value.image.trim() : '';
@@ -18,7 +64,12 @@ function parseBlazegraphImageMetadata(value, source = 'Blazegraph image metadata
     throw new Error(`${source}: containerPort must be an integer from 1 through 65535`);
   }
 
-  return { image, containerPort };
+  const dataPath = typeof value.dataPath === 'string' ? value.dataPath.trim() : '';
+  if (!dataPath.startsWith('/') || dataPath.includes(',')) {
+    throw new Error(`${source}: dataPath must be an absolute container path without commas`);
+  }
+
+  return { image, containerPort, dataPath };
 }
 
 function readBlazegraphImageMetadata(filePath) {
@@ -38,28 +89,73 @@ function readBlazegraphImageMetadata(filePath) {
   return parseBlazegraphImageMetadata(value, filePath);
 }
 
+// Self-describing key=value lines — consumers address fields by NAME, never
+// by position.
 function formatBlazegraphImageMetadata(metadata) {
   const parsed = parseBlazegraphImageMetadata(metadata);
-  return `${parsed.image}\t${parsed.containerPort}`;
+  return Object.entries(parsed)
+    // Values may themselves contain '=' (dataPath only bans commas), so
+    // consumers must split on the FIRST '=' only — or use field mode, which
+    // prints bare values and has no delimiter at all.
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
 }
 
 module.exports = {
+  BLAZEGRAPH_NAMESPACE_XML_TEMPLATE,
   formatBlazegraphImageMetadata,
   parseBlazegraphImageMetadata,
   readBlazegraphImageMetadata,
+  renderBlazegraphNamespaceXml,
 };
 
 if (require.main === module) {
-  const [filePath, ...extraArgs] = process.argv.slice(2);
-  if (!filePath || extraArgs.length > 0) {
-    console.error('Usage: node blazegraph-image-metadata.cjs <blazegraph-image.json>');
-    process.exitCode = 2;
-  } else {
-    try {
-      console.log(formatBlazegraphImageMetadata(readBlazegraphImageMetadata(filePath)));
-    } catch (error) {
-      console.error(error instanceof Error ? error.message : String(error));
-      process.exitCode = 1;
+  const usage = [
+    'Usage:',
+    '  node blazegraph-image-metadata.cjs <blazegraph-image.json> [field ...]',
+    '      No fields: print every field as key=value lines.',
+    '      With fields: print one requested field value per line.',
+    '  node blazegraph-image-metadata.cjs --namespace-xml <namespace>',
+    '      Print the canonical Blazegraph namespace-properties XML.',
+  ].join('\n');
+  const args = process.argv.slice(2);
+  try {
+    if (args[0] === '--namespace-xml') {
+      if (args.length !== 2) {
+        console.error(usage);
+        process.exitCode = 2;
+      } else {
+        console.log(renderBlazegraphNamespaceXml(args[1]));
+      }
+    } else {
+      const [filePath, ...fields] = args;
+      if (!filePath) {
+        console.error(usage);
+        process.exitCode = 2;
+      } else {
+        // The whole object is validated first even when a single field is
+        // requested — an invalid contract must never half-succeed.
+        const metadata = readBlazegraphImageMetadata(filePath);
+        if (fields.length === 0) {
+          console.log(formatBlazegraphImageMetadata(metadata));
+        } else {
+          const values = fields.map((field) => {
+            if (!Object.hasOwn(metadata, field)) {
+              throw new Error(
+                `Unknown Blazegraph metadata field "${field}" — known fields: ${Object.keys(metadata).join(', ')}`,
+              );
+            }
+            return String(metadata[field]);
+          });
+          console.log(values.join('\n'));
+        }
+      }
     }
+  } catch (error) {
+    // Surface the underlying errno (ENOENT vs EACCES vs EISDIR) — shell
+    // callers only see this one line.
+    const detail = error instanceof Error && error.cause ? ` (${String(error.cause)})` : '';
+    console.error(`${error instanceof Error ? error.message : String(error)}${detail}`);
+    process.exitCode = 1;
   }
 }

--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -14,6 +14,8 @@
  *  3. Port-collision auto-bump — try ports `[9999, 9999+range)`
  *     before giving up. Operators may have V6 nodes on 9999 from
  *     prior installs.
+ *  4. Durable, bounded storage — persist the journal in a named volume and
+ *     retain at most 4 GB of compressed local-driver container logs.
  *
  * Every external dependency (docker CLI, fetch, port-free check) is
  * injectable so the unit tests run in <50 ms without spawning real
@@ -33,25 +35,6 @@ import * as net from 'node:net';
 import { runtimeAssetPaths } from '../runtime-assets.js';
 
 /**
- * Shared XML template for a Blazegraph namespace tuned for DKG V10
- * (quads enabled, no truth maintenance, no text index, no statement
- * identifiers). Substitutes `{namespace}` for the namespace name.
- *
- * Mirrors the body inlined at scripts/devnet.sh:287-294. Kept here so
- * future tweaks land in one place.
- */
-export const BLAZEGRAPH_NAMESPACE_XML_TEMPLATE = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
-<properties>
-  <entry key="com.bigdata.rdf.sail.namespace">{namespace}</entry>
-  <entry key="com.bigdata.rdf.store.AbstractTripleStore.quads">true</entry>
-  <entry key="com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers">false</entry>
-  <entry key="com.bigdata.rdf.store.AbstractTripleStore.textIndex">false</entry>
-  <entry key="com.bigdata.rdf.sail.truthMaintenance">false</entry>
-  <entry key="com.bigdata.rdf.store.AbstractTripleStore.axiomsClass">com.bigdata.rdf.axioms.NoAxioms</entry>
-</properties>`;
-
-/**
  * Pinned multi-architecture image index — matches the deployed mainnet fleet.
  * `lyrasis/blazegraph:2.1.5` is amd64-only and fails with `exec format error`
  * when the provisioner runs on an arm64 Linux node.
@@ -62,16 +45,30 @@ export const BLAZEGRAPH_NAMESPACE_XML_TEMPLATE = `<?xml version="1.0" encoding="
 interface BlazegraphImageMetadata {
   image: string;
   containerPort: number;
+  dataPath: string;
 }
 
-interface BlazegraphImageMetadataParser {
+interface BlazegraphRuntimeContract {
+  BLAZEGRAPH_NAMESPACE_XML_TEMPLATE: string;
   readBlazegraphImageMetadata(path: string): BlazegraphImageMetadata;
 }
 
 const require = createRequire(import.meta.url);
-const { readBlazegraphImageMetadata } = require(
+const { BLAZEGRAPH_NAMESPACE_XML_TEMPLATE: NAMESPACE_XML_TEMPLATE, readBlazegraphImageMetadata } = require(
   '../../blazegraph-image-metadata.cjs',
-) as BlazegraphImageMetadataParser;
+) as BlazegraphRuntimeContract;
+
+/**
+ * Shared XML template for a Blazegraph namespace tuned for DKG V10
+ * (quads enabled, no truth maintenance, no text index, no statement
+ * identifiers). Substitutes `{namespace}` for the namespace name.
+ *
+ * The canonical copy lives in packages/cli/blazegraph-image-metadata.cjs so
+ * shell consumers (devnet + CI scripts) render the SAME document via its
+ * `--namespace-xml` CLI mode — future tweaks land in exactly one place.
+ * Re-exported here so TypeScript importers keep their existing name.
+ */
+export const BLAZEGRAPH_NAMESPACE_XML_TEMPLATE = NAMESPACE_XML_TEMPLATE;
 
 function loadBlazegraphImageMetadata(): BlazegraphImageMetadata {
   for (const path of runtimeAssetPaths('blazegraph-image.json')) {
@@ -90,10 +87,16 @@ export const BLAZEGRAPH_IMAGE = BLAZEGRAPH_IMAGE_METADATA.image;
 /** Container HTTP port declared alongside the selected image. */
 export const BLAZEGRAPH_CONTAINER_PORT = BLAZEGRAPH_IMAGE_METADATA.containerPort;
 
+/** Image-specific path containing the Blazegraph journal. */
+export const BLAZEGRAPH_DATA_PATH = BLAZEGRAPH_IMAGE_METADATA.dataPath;
+
 /** Default starting host port, matches devnet.sh and Blazegraph defaults. */
 const DEFAULT_HOST_PORT_START = 9999;
 /** Inclusive range above start to scan for a free port before failing. */
 const DEFAULT_HOST_PORT_RANGE = 12; // 9999..10010
+/** Keep enough Blazegraph history for incident response without filling the host disk. */
+export const BLAZEGRAPH_LOG_MAX_SIZE = '200m';
+export const BLAZEGRAPH_LOG_MAX_FILE = '20';
 
 // --------------------------------------------------------------------
 // Injectable types — tests pass mocks for every external boundary.
@@ -262,7 +265,99 @@ async function findFreePort(
   );
 }
 
-interface ContainerInspectInfo {
+interface BlazegraphContainerPolicyStatus {
+  durableStorage: boolean;
+  boundedLogs: boolean;
+}
+
+interface BlazegraphContainerSpec {
+  containerName: string;
+  volumeName: string;
+  dataPath: string;
+  mountSpec: string;
+  logDriver: string;
+  logOptions: readonly { name: string; value: string }[];
+  dockerRunArgs(hostPort: number): readonly string[];
+  inspectPolicy(info: unknown): BlazegraphContainerPolicyStatus;
+  warningMessages(status: BlazegraphContainerPolicyStatus): string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function createBlazegraphContainerSpec(containerName: string): BlazegraphContainerSpec {
+  const volumeName = `${containerName}-data`;
+  const dataPath = BLAZEGRAPH_DATA_PATH;
+  const mountSpec = `type=volume,source=${volumeName},target=${dataPath}`;
+  const logDriver = 'local';
+  const logOptions = [
+    { name: 'max-size', value: BLAZEGRAPH_LOG_MAX_SIZE },
+    { name: 'max-file', value: BLAZEGRAPH_LOG_MAX_FILE },
+  ] as const;
+
+  return {
+    containerName,
+    volumeName,
+    dataPath,
+    mountSpec,
+    logDriver,
+    logOptions,
+    dockerRunArgs(hostPort) {
+      return [
+        'run',
+        '-d',
+        '--restart', 'unless-stopped',
+        '--name', containerName,
+        // Blazegraph is an implementation detail of the local node. Do not
+        // publish its unauthenticated SPARQL/update endpoint on every interface.
+        '-p', `127.0.0.1:${hostPort}:${BLAZEGRAPH_CONTAINER_PORT}`,
+        '--mount', mountSpec,
+        // The local driver rotates and compresses logs. Explicit options keep
+        // the bound independent of host-wide Docker daemon defaults.
+        '--log-driver', logDriver,
+        ...logOptions.flatMap(({ name, value }) => ['--log-opt', `${name}=${value}`]),
+        BLAZEGRAPH_IMAGE,
+      ];
+    },
+    inspectPolicy(info) {
+      if (!isRecord(info)) return { durableStorage: false, boundedLogs: false };
+      const mounts: unknown[] = Array.isArray(info.Mounts) ? info.Mounts : [];
+      const durableStorage = mounts.some((mount) => {
+        if (!isRecord(mount)) return false;
+        return mount.Type === 'volume'
+          && mount.Name === volumeName
+          && mount.Destination === dataPath;
+      });
+      const hostConfig = isRecord(info.HostConfig) ? info.HostConfig : undefined;
+      const logConfig = isRecord(hostConfig?.LogConfig) ? hostConfig.LogConfig : undefined;
+      const config = isRecord(logConfig?.Config) ? logConfig.Config : undefined;
+      const boundedLogs = logConfig?.Type === logDriver
+        && logOptions.every(({ name, value }) => config?.[name] === value);
+      return { durableStorage, boundedLogs };
+    },
+    warningMessages(status) {
+      const warnings: string[] = [];
+      if (!status.durableStorage) {
+        warnings.push(
+          `  WARNING: Reused container "${containerName}" does not use the expected named Docker volume ` +
+          `"${volumeName}" at ${dataPath}. ` +
+          'DKG will not recreate it automatically because that could discard Blazegraph data; back up the journal before migrating or recreating the container.',
+        );
+      }
+      if (!status.boundedLogs) {
+        const policy = logOptions.map(({ name, value }) => `${name}=${value}`).join(', ');
+        warnings.push(
+          `  WARNING: Reused container "${containerName}" does not use the bounded ${logDriver} log policy ` +
+          `(${policy}). Its Docker logs remain outside the configured 4 GB rotation budget.`,
+        );
+      }
+      return warnings;
+    },
+  };
+}
+
+interface ContainerInspectInfo extends BlazegraphContainerPolicyStatus {
   exists: boolean;
   running: boolean;
   hostPort?: number;
@@ -270,19 +365,31 @@ interface ContainerInspectInfo {
 
 async function inspectContainer(
   docker: DockerRunner,
-  name: string,
+  spec: BlazegraphContainerSpec,
 ): Promise<ContainerInspectInfo> {
   // `docker inspect <name>` exits non-zero with "No such object" when
   // the container doesn't exist; non-zero is our "doesn't exist"
   // signal. Otherwise parse the JSON to get state + port mapping.
-  const result = await docker.run(['inspect', name]);
+  const result = await docker.run(['inspect', spec.containerName]);
   if (result.exitCode !== 0) {
-    return { exists: false, running: false };
+    return {
+      exists: false,
+      running: false,
+      durableStorage: false,
+      boundedLogs: false,
+    };
   }
   try {
     const arr = JSON.parse(result.stdout);
     const info = Array.isArray(arr) && arr.length > 0 ? arr[0] : null;
-    if (!info) return { exists: true, running: false };
+    if (!info) {
+      return {
+        exists: true,
+        running: false,
+        durableStorage: false,
+        boundedLogs: false,
+      };
+    }
     const running = info.State?.Running === true;
     const ports = info.NetworkSettings?.Ports;
     // Containers provisioned before the islandora image migration expose the
@@ -294,10 +401,28 @@ async function inspectContainer(
     const hostPort = Array.isArray(portBinding) && portBinding.length > 0
       ? Number(portBinding[0].HostPort)
       : undefined;
-    return { exists: true, running, hostPort };
+    return {
+      exists: true,
+      running,
+      hostPort,
+      ...spec.inspectPolicy(info),
+    };
   } catch {
-    return { exists: true, running: false };
+    return {
+      exists: true,
+      running: false,
+      durableStorage: false,
+      boundedLogs: false,
+    };
   }
+}
+
+function warnForLegacyContainerConfiguration(
+  info: ContainerInspectInfo,
+  spec: BlazegraphContainerSpec,
+  log: (msg: string) => void,
+): void {
+  for (const warning of spec.warningMessages(info)) log(warning);
 }
 
 /**
@@ -376,6 +501,61 @@ async function createNamespace(opts: {
   opts.log(`  Created Blazegraph namespace "${opts.namespace}".`);
 }
 
+async function reconcileNamespace(opts: {
+  url: string;
+  namespace: string;
+  fetch: typeof globalThis.fetch;
+  log: (msg: string) => void;
+}): Promise<boolean> {
+  const created = !(await namespaceExists(opts));
+  if (created) {
+    await createNamespace(opts);
+  } else {
+    opts.log(`  Namespace "${opts.namespace}" already exists.`);
+  }
+  return created;
+}
+
+async function finaliseReusedContainer(opts: {
+  inspectInfo: ContainerInspectInfo;
+  spec: BlazegraphContainerSpec;
+  fallbackPort: number;
+  namespace: string;
+  fetch: typeof globalThis.fetch;
+  pollIntervalMs: number;
+  pollTimeoutMs: number;
+  log: (msg: string) => void;
+  announceReuse: boolean;
+}): Promise<ProvisionBlazegraphDockerResult> {
+  const port = opts.inspectInfo.hostPort ?? opts.fallbackPort;
+  const url = `http://127.0.0.1:${port}`;
+  if (opts.announceReuse) {
+    opts.log(`  Reusing running container "${opts.spec.containerName}" on port ${port}.`);
+  }
+  warnForLegacyContainerConfiguration(opts.inspectInfo, opts.spec, opts.log);
+  await waitForBlazegraphReady({
+    url,
+    fetch: opts.fetch,
+    intervalMs: opts.pollIntervalMs,
+    timeoutMs: opts.pollTimeoutMs,
+    log: opts.log,
+  });
+  const namespaceCreated = await reconcileNamespace({
+    url,
+    namespace: opts.namespace,
+    fetch: opts.fetch,
+    log: opts.log,
+  });
+  return {
+    url: sparqlUrlForNamespace(url, opts.namespace),
+    port,
+    containerName: opts.spec.containerName,
+    managedByDkg: true,
+    reused: true,
+    namespaceCreated,
+  };
+}
+
 // --------------------------------------------------------------------
 // Public entry point
 // --------------------------------------------------------------------
@@ -395,6 +575,7 @@ export async function provisionBlazegraphDocker(
     log(`  Normalized Blazegraph namespace "${opts.namespace}" → "${namespace}".`);
   }
   const containerName = opts.containerName ?? sanitiseContainerName(namespace);
+  const containerSpec = createBlazegraphContainerSpec(containerName);
 
   // 1. Pre-flight: is docker installed?
   const versionResult = await docker.run(['--version'], { timeoutMs: 5000 });
@@ -407,26 +588,19 @@ export async function provisionBlazegraphDocker(
   log(`  Docker available: ${versionResult.stdout.trim().split('\n')[0]}`);
 
   // 2. Reuse path — is the container already running?
-  const inspectInfo = await inspectContainer(docker, containerName);
+  const inspectInfo = await inspectContainer(docker, containerSpec);
   if (inspectInfo.exists && inspectInfo.running) {
-    const port = inspectInfo.hostPort ?? opts.port ?? DEFAULT_HOST_PORT_START;
-    const url = `http://127.0.0.1:${port}`;
-    log(`  Reusing running container "${containerName}" on port ${port}.`);
-    await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-    const created = !(await namespaceExists({ url, namespace, fetch }));
-    if (created) {
-      await createNamespace({ url, namespace, fetch, log });
-    } else {
-      log(`  Namespace "${namespace}" already exists.`);
-    }
-    return {
-      url: sparqlUrlForNamespace(url, namespace),
-      port,
-      containerName,
-      managedByDkg: true,
-      reused: true,
-      namespaceCreated: created,
-    };
+    return finaliseReusedContainer({
+      inspectInfo,
+      spec: containerSpec,
+      fallbackPort: opts.port ?? DEFAULT_HOST_PORT_START,
+      namespace,
+      fetch,
+      pollIntervalMs,
+      pollTimeoutMs,
+      log,
+      announceReuse: true,
+    });
   }
 
   // 3. Stopped-but-exists path — start it back up before re-creating.
@@ -434,30 +608,31 @@ export async function provisionBlazegraphDocker(
     log(`  Container "${containerName}" exists but is stopped; starting it.`);
     const startResult = await docker.run(['start', containerName]);
     if (startResult.exitCode !== 0) {
-      // Fall through to recreate — `docker start` failed for some
-      // reason (e.g. config drift); remove and start fresh.
+      if (!inspectInfo.durableStorage) {
+        warnForLegacyContainerConfiguration(inspectInfo, containerSpec, log);
+        throw new Error(
+          `Cannot safely recreate stopped legacy container "${containerName}" after docker start failed ` +
+          `(${startResult.stderr.trim() || 'unknown'}): its Blazegraph journal is not in the expected ` +
+          `named volume "${containerSpec.volumeName}". Back up and migrate it before retrying.`,
+        );
+      }
+      // The expected named volume preserves the journal, so removing only the
+      // broken container is safe. The fresh path below reattaches that volume.
       log(`  docker start failed (${startResult.stderr.trim() || 'unknown'}); recreating.`);
       await docker.run(['rm', '-f', containerName]);
     } else {
-      const port = (await inspectContainer(docker, containerName)).hostPort
-        ?? opts.port
-        ?? DEFAULT_HOST_PORT_START;
-      const url = `http://127.0.0.1:${port}`;
-      await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-      const created = !(await namespaceExists({ url, namespace, fetch }));
-      if (created) {
-        await createNamespace({ url, namespace, fetch, log });
-      } else {
-        log(`  Namespace "${namespace}" already exists.`);
-      }
-      return {
-        url: sparqlUrlForNamespace(url, namespace),
-        port,
-        containerName,
-        managedByDkg: true,
-        reused: true,
-        namespaceCreated: created,
-      };
+      const restartedInfo = await inspectContainer(docker, containerSpec);
+      return finaliseReusedContainer({
+        inspectInfo: restartedInfo,
+        spec: containerSpec,
+        fallbackPort: opts.port ?? DEFAULT_HOST_PORT_START,
+        namespace,
+        fetch,
+        pollIntervalMs,
+        pollTimeoutMs,
+        log,
+        announceReuse: false,
+      });
     }
   }
 
@@ -465,16 +640,7 @@ export async function provisionBlazegraphDocker(
   const portStart = opts.port ?? DEFAULT_HOST_PORT_START;
   const chosenPort = await findFreePort(portStart, portRange, isPortFree, log);
   log(`  Starting Blazegraph container "${containerName}" on port ${chosenPort}…`);
-  const runResult = await docker.run([
-    'run',
-    '-d',
-    '--restart', 'unless-stopped',
-    '--name', containerName,
-    // Blazegraph is an implementation detail of the local node. Do not publish
-    // its unauthenticated SPARQL/update endpoint on every host interface.
-    '-p', `127.0.0.1:${chosenPort}:${BLAZEGRAPH_CONTAINER_PORT}`,
-    BLAZEGRAPH_IMAGE,
-  ]);
+  const runResult = await docker.run(containerSpec.dockerRunArgs(chosenPort));
   if (runResult.exitCode !== 0) {
     throw new Error(
       `Failed to start Blazegraph container — docker run exited ${runResult.exitCode}. ` +
@@ -484,7 +650,7 @@ export async function provisionBlazegraphDocker(
 
   const url = `http://127.0.0.1:${chosenPort}`;
   await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-  await createNamespace({ url, namespace, fetch, log });
+  const namespaceCreated = await reconcileNamespace({ url, namespace, fetch, log });
 
   return {
     url: sparqlUrlForNamespace(url, namespace),
@@ -492,7 +658,7 @@ export async function provisionBlazegraphDocker(
     containerName,
     managedByDkg: true,
     reused: false,
-    namespaceCreated: true,
+    namespaceCreated,
   };
 }
 

--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -340,7 +340,7 @@ function createBlazegraphContainerSpec(containerName: string): BlazegraphContain
       const warnings: string[] = [];
       if (!status.durableStorage) {
         warnings.push(
-          `  WARNING: Reused container "${containerName}" does not use the expected named Docker volume ` +
+          `  WARNING: Reused container "${containerName}" is not confirmed to use the expected named Docker volume ` +
           `"${volumeName}" at ${dataPath}. ` +
           'DKG will not recreate it automatically because that could discard Blazegraph data; back up the journal before migrating or recreating the container.',
         );
@@ -612,7 +612,7 @@ export async function provisionBlazegraphDocker(
         warnForLegacyContainerConfiguration(inspectInfo, containerSpec, log);
         throw new Error(
           `Cannot safely recreate stopped legacy container "${containerName}" after docker start failed ` +
-          `(${startResult.stderr.trim() || 'unknown'}): its Blazegraph journal is not in the expected ` +
+          `(${startResult.stderr.trim() || 'unknown'}): its Blazegraph journal could not be confirmed in the expected ` +
           `named volume "${containerSpec.volumeName}". Back up and migrate it before retrying.`,
         );
       }

--- a/packages/cli/test/blazegraph-docker.test.ts
+++ b/packages/cli/test/blazegraph-docker.test.ts
@@ -53,8 +53,9 @@ import {
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
-function runDevnetBlazegraphSmoke(metadata: string): {
+function runDevnetBlazegraphSmoke(metadata: string, namespaceStatus = '201'): {
   status: number | null;
+  stdout: string;
   stderr: string;
   dockerArgs: string[] | null;
 } {
@@ -72,9 +73,16 @@ function runDevnetBlazegraphSmoke(metadata: string): {
       resolve(REPO_ROOT, 'packages/cli/test/fixtures/devnet-blazegraph-smoke.sh'),
       root,
       capture,
-    ], { encoding: 'utf-8' });
+    ], {
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        DEVNET_BLAZEGRAPH_SMOKE_NAMESPACE_STATUS: namespaceStatus,
+      },
+    });
     return {
       status: result.status,
+      stdout: result.stdout,
       stderr: result.stderr,
       dockerArgs: existsSync(capture)
         ? readFileSync(capture, 'utf-8').trim().split('\n')
@@ -305,7 +313,7 @@ describe('provisionBlazegraphDocker', () => {
     expect(calls.some((call) => call[0] === 'run')).toBe(false);
     expect(logs.some((message) => (
       message.includes('WARNING: Reused container')
-      && message.includes(`expected named Docker volume "dkg-blazegraph-mynode-data" at ${BLAZEGRAPH_DATA_PATH}`)
+      && message.includes(`is not confirmed to use the expected named Docker volume "dkg-blazegraph-mynode-data" at ${BLAZEGRAPH_DATA_PATH}`)
       && message.includes('will not recreate it automatically')
     ))).toBe(true);
     expect(logs.some((message) => (
@@ -421,11 +429,44 @@ describe('provisionBlazegraphDocker', () => {
       fetch: globalThis.fetch,
       isPortFree: async () => true,
       log: (message) => logs.push(message),
-    })).rejects.toThrow(/Cannot safely recreate stopped legacy container.*Back up and migrate/s);
+    })).rejects.toThrow(
+      /Cannot safely recreate stopped legacy container.*journal could not be confirmed.*Back up and migrate/s,
+    );
 
     expect(calls.some((call) => call[0] === 'rm')).toBe(false);
     expect(calls.some((call) => call[0] === 'run')).toBe(false);
     expect(logs.some((message) => message.includes('will not recreate it automatically'))).toBe(true);
+  });
+
+  it('does not claim a journal policy when docker inspect JSON is malformed', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        {
+          when: (a) => a[0] === 'inspect',
+          respond: () => ({ stdout: '{not-json', stderr: '', exitCode: 0 }),
+        },
+        {
+          when: (a) => a[0] === 'start',
+          respond: () => ({ stdout: '', stderr: 'inspect unavailable', exitCode: 1 }),
+        },
+      ],
+    });
+    const logs: string[] = [];
+
+    await expect(provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: globalThis.fetch,
+      isPortFree: async () => true,
+      log: (message) => logs.push(message),
+    })).rejects.toThrow(/journal could not be confirmed in the expected named volume/s);
+
+    expect(calls.some((call) => call[0] === 'rm')).toBe(false);
+    expect(logs.some((message) => (
+      message.includes('is not confirmed to use the expected named Docker volume')
+      && !message.includes('does not use the expected named Docker volume')
+    ))).toBe(true);
   });
 
   it('reattaches a persisted volume without recreating its existing namespace', async () => {
@@ -510,7 +551,7 @@ describe('provisionBlazegraphDocker', () => {
     );
   });
 
-  it('executes the devnet Docker path with the exact shared image and loopback port mapping', () => {
+  it('executes the devnet Docker path with the shared image, bounded logs, and loopback port', () => {
     const image = 'example/blazegraph@sha256:smoke';
     const result = runDevnetBlazegraphSmoke(JSON.stringify({
       image,
@@ -524,10 +565,42 @@ describe('provisionBlazegraphDocker', () => {
       '-d',
       '--name',
       'devnet-blazegraph-smoke',
+      '--log-driver',
+      'local',
+      '--log-opt',
+      'max-size=200m',
+      '--log-opt',
+      'max-file=20',
       '-p',
       '127.0.0.1:19099:80',
       image,
     ]);
+    expect(result.stdout).toContain('Created Blazegraph namespace: node3');
+    expect(result.stdout).toContain('Created Blazegraph namespace: node4');
+  });
+
+  it('treats an existing devnet Blazegraph namespace as an idempotent success', () => {
+    const result = runDevnetBlazegraphSmoke(JSON.stringify({
+      image: 'example/blazegraph@sha256:smoke',
+      containerPort: 80,
+      dataPath: '/data',
+    }), '409');
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Blazegraph namespace already exists: node3');
+    expect(result.stdout).not.toContain('Created Blazegraph namespace: node3');
+  });
+
+  it('warns instead of claiming a failed devnet namespace creation succeeded', () => {
+    const result = runDevnetBlazegraphSmoke(JSON.stringify({
+      image: 'example/blazegraph@sha256:smoke',
+      containerPort: 80,
+      dataPath: '/data',
+    }), '500');
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('WARNING: Failed to create Blazegraph namespace: node3 (HTTP 500)');
+    expect(result.stdout).not.toContain('Created Blazegraph namespace: node3');
   });
 
   it('fails closed before docker run when devnet image metadata is invalid', () => {

--- a/packages/cli/test/blazegraph-docker.test.ts
+++ b/packages/cli/test/blazegraph-docker.test.ts
@@ -43,6 +43,9 @@ import {
   isDockerAvailable,
   BLAZEGRAPH_IMAGE,
   BLAZEGRAPH_CONTAINER_PORT,
+  BLAZEGRAPH_DATA_PATH,
+  BLAZEGRAPH_LOG_MAX_SIZE,
+  BLAZEGRAPH_LOG_MAX_FILE,
   BLAZEGRAPH_NAMESPACE_XML_TEMPLATE,
   type DockerRunner,
   type DockerCommandResult,
@@ -134,6 +137,20 @@ function dockerInspectRunning(hostPort = 9999): DockerCommandResult {
             [`${BLAZEGRAPH_CONTAINER_PORT}/tcp`]: [{ HostIp: '0.0.0.0', HostPort: String(hostPort) }],
           },
         },
+        Mounts: [{
+          Type: 'volume',
+          Name: 'dkg-blazegraph-mynode-data',
+          Destination: BLAZEGRAPH_DATA_PATH,
+        }],
+        HostConfig: {
+          LogConfig: {
+            Type: 'local',
+            Config: {
+              'max-size': BLAZEGRAPH_LOG_MAX_SIZE,
+              'max-file': BLAZEGRAPH_LOG_MAX_FILE,
+            },
+          },
+        },
       },
     ]),
     stderr: '',
@@ -151,8 +168,37 @@ function dockerInspectStopped(): DockerCommandResult {
             [`${BLAZEGRAPH_CONTAINER_PORT}/tcp`]: [{ HostIp: '0.0.0.0', HostPort: '9999' }],
           },
         },
+        Mounts: [{
+          Type: 'volume',
+          Name: 'dkg-blazegraph-mynode-data',
+          Destination: BLAZEGRAPH_DATA_PATH,
+        }],
+        HostConfig: {
+          LogConfig: {
+            Type: 'local',
+            Config: {
+              'max-size': BLAZEGRAPH_LOG_MAX_SIZE,
+              'max-file': BLAZEGRAPH_LOG_MAX_FILE,
+            },
+          },
+        },
       },
     ]),
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+function dockerInspectLegacy(running: boolean, hostPort = 10001): DockerCommandResult {
+  return {
+    stdout: JSON.stringify([{
+      State: { Running: running },
+      NetworkSettings: {
+        Ports: {
+          '8080/tcp': [{ HostIp: '127.0.0.1', HostPort: String(hostPort) }],
+        },
+      },
+    }]),
     stderr: '',
     exitCode: 0,
   };
@@ -165,6 +211,12 @@ function mockFetch(handler: (url: string, init?: any) => Response | Promise<Resp
     return handler(String(input), init);
   }) as typeof globalThis.fetch;
   return { fn, calls };
+}
+
+function valuesForDockerFlag(args: readonly string[], flag: string): string[] {
+  return args.flatMap((arg, index) => (
+    arg === flag && typeof args[index + 1] === 'string' ? [args[index + 1]] : []
+  ));
 }
 
 describe('provisionBlazegraphDocker', () => {
@@ -226,33 +278,22 @@ describe('provisionBlazegraphDocker', () => {
     expect(httpCalls.some((c) => c.url.endsWith('/bigdata/status'))).toBe(true);
   });
 
-  it('reuses the mapped host port from a legacy 8080/tcp container', async () => {
+  it('warns about legacy storage and logs while reusing its mapped host port', async () => {
     const legacyHostPort = 10001;
-    const legacyInspect: DockerCommandResult = {
-      stdout: JSON.stringify([{
-        State: { Running: true },
-        NetworkSettings: {
-          Ports: {
-            '8080/tcp': [{ HostIp: '127.0.0.1', HostPort: String(legacyHostPort) }],
-          },
-        },
-      }]),
-      stderr: '',
-      exitCode: 0,
-    };
     const { runner, calls } = mockDocker({
       matchers: [
         { when: (a) => a[0] === '--version', respond: dockerVersionOk },
-        { when: (a) => a[0] === 'inspect', respond: () => legacyInspect },
+        { when: (a) => a[0] === 'inspect', respond: () => dockerInspectLegacy(true, legacyHostPort) },
       ],
     });
     const { fn, calls: httpCalls } = mockFetch(() => new Response('ok', { status: 200 }));
+    const logs: string[] = [];
 
     const result = await provisionBlazegraphDocker({
       namespace: 'mynode',
       docker: runner,
       fetch: fn,
-      log: () => {},
+      log: (message) => logs.push(message),
     });
 
     expect(result.reused).toBe(true);
@@ -262,6 +303,16 @@ describe('provisionBlazegraphDocker', () => {
     );
     expect(httpCalls[0]?.url).toBe(`http://127.0.0.1:${legacyHostPort}/bigdata/status`);
     expect(calls.some((call) => call[0] === 'run')).toBe(false);
+    expect(logs.some((message) => (
+      message.includes('WARNING: Reused container')
+      && message.includes(`expected named Docker volume "dkg-blazegraph-mynode-data" at ${BLAZEGRAPH_DATA_PATH}`)
+      && message.includes('will not recreate it automatically')
+    ))).toBe(true);
+    expect(logs.some((message) => (
+      message.includes('WARNING: Reused container')
+      && message.includes('does not use the bounded local log policy')
+      && message.includes('4 GB rotation budget')
+    ))).toBe(true);
   });
 
   it('creates the namespace when reusing a container with no existing namespace', async () => {
@@ -334,9 +385,10 @@ describe('provisionBlazegraphDocker', () => {
         { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'container-id', stderr: '', exitCode: 0 }) },
       ],
     });
-    const { fn } = mockFetch((url) => {
+    const { fn, calls: httpCalls } = mockFetch((url) => {
       if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
-      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response('unexpected', { status: 500 });
       return new Response(null, { status: 200 });
     });
     const result = await provisionBlazegraphDocker({
@@ -347,11 +399,67 @@ describe('provisionBlazegraphDocker', () => {
       log: () => {},
     });
     expect(result.reused).toBe(false);
+    expect(result.namespaceCreated).toBe(false);
     expect(calls.some((c) => c[0] === 'rm')).toBe(true);
     expect(calls.some((c) => c[0] === 'run')).toBe(true);
+    expect(httpCalls.some((call) => call.url.endsWith('/bigdata/namespace'))).toBe(false);
   });
 
-  it('auto-bumps to the next free loopback port and uses the multi-architecture image', async () => {
+  it('does not delete a stopped legacy container when `docker start` fails', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: () => dockerInspectLegacy(false) },
+        { when: (a) => a[0] === 'start', respond: () => ({ stdout: '', stderr: 'legacy config drift', exitCode: 1 }) },
+      ],
+    });
+    const logs: string[] = [];
+
+    await expect(provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: globalThis.fetch,
+      isPortFree: async () => true,
+      log: (message) => logs.push(message),
+    })).rejects.toThrow(/Cannot safely recreate stopped legacy container.*Back up and migrate/s);
+
+    expect(calls.some((call) => call[0] === 'rm')).toBe(false);
+    expect(calls.some((call) => call[0] === 'run')).toBe(false);
+    expect(logs.some((message) => message.includes('will not recreate it automatically'))).toBe(true);
+  });
+
+  it('reattaches a persisted volume without recreating its existing namespace', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'container-id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn, calls: httpCalls } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response('unexpected', { status: 500 });
+      return new Response(null, { status: 200 });
+    });
+
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+
+    expect(result.reused).toBe(false);
+    expect(result.namespaceCreated).toBe(false);
+    expect(valuesForDockerFlag(calls.find((call) => call[0] === 'run') ?? [], '--mount')).toEqual([
+      `type=volume,source=dkg-blazegraph-mynode-data,target=${BLAZEGRAPH_DATA_PATH}`,
+    ]);
+    expect(httpCalls.some((call) => call.url.endsWith('/bigdata/namespace'))).toBe(false);
+  });
+
+  it('auto-bumps the port and provisions durable data with bounded local-driver logs', async () => {
     const takenPorts = new Set([9999, 10000]);
     const { runner, calls } = mockDocker({
       matchers: [
@@ -361,6 +469,7 @@ describe('provisionBlazegraphDocker', () => {
     });
     const { fn } = mockFetch((url) => {
       if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 404 });
       if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
       return new Response(null, { status: 200 });
     });
@@ -372,15 +481,30 @@ describe('provisionBlazegraphDocker', () => {
       log: () => {},
     });
     expect(result.port).toBe(10001);
+    expect(result.namespaceCreated).toBe(true);
     const runCall = calls.find((c) => c[0] === 'run');
+    expect(BLAZEGRAPH_LOG_MAX_SIZE).toBe('200m');
+    expect(BLAZEGRAPH_LOG_MAX_FILE).toBe('20');
     expect(runCall).toBeDefined();
-    expect(runCall).toContain(`127.0.0.1:10001:${BLAZEGRAPH_CONTAINER_PORT}`);
-    expect(runCall?.at(-1)).toBe(BLAZEGRAPH_IMAGE);
+    const runArgs = runCall ?? [];
+    expect(valuesForDockerFlag(runArgs, '-p')).toEqual([
+      `127.0.0.1:10001:${BLAZEGRAPH_CONTAINER_PORT}`,
+    ]);
+    expect(valuesForDockerFlag(runArgs, '--mount')).toEqual([
+      `type=volume,source=dkg-blazegraph-mynode-data,target=${BLAZEGRAPH_DATA_PATH}`,
+    ]);
+    expect(valuesForDockerFlag(runArgs, '--log-driver')).toEqual(['local']);
+    expect(valuesForDockerFlag(runArgs, '--log-opt')).toEqual([
+      `max-size=${BLAZEGRAPH_LOG_MAX_SIZE}`,
+      `max-file=${BLAZEGRAPH_LOG_MAX_FILE}`,
+    ]);
+    expect(runArgs.at(-1)).toBe(BLAZEGRAPH_IMAGE);
     const metadata = JSON.parse(
       readFileSync(resolve(REPO_ROOT, 'blazegraph-image.json'), 'utf-8'),
-    ) as { image: string; containerPort: number };
+    ) as { image: string; containerPort: number; dataPath: string };
     expect(BLAZEGRAPH_IMAGE).toBe(metadata.image);
     expect(BLAZEGRAPH_CONTAINER_PORT).toBe(metadata.containerPort);
+    expect(BLAZEGRAPH_DATA_PATH).toBe(metadata.dataPath);
     expect(runtimeAssetPaths('blazegraph-image.json')[0]).toBe(
       resolve(REPO_ROOT, 'blazegraph-image.json'),
     );
@@ -388,7 +512,11 @@ describe('provisionBlazegraphDocker', () => {
 
   it('executes the devnet Docker path with the exact shared image and loopback port mapping', () => {
     const image = 'example/blazegraph@sha256:smoke';
-    const result = runDevnetBlazegraphSmoke(JSON.stringify({ image, containerPort: 80 }));
+    const result = runDevnetBlazegraphSmoke(JSON.stringify({
+      image,
+      containerPort: 80,
+      dataPath: '/data',
+    }));
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.dockerArgs).toEqual([
@@ -462,6 +590,7 @@ describe('provisionBlazegraphDocker', () => {
     });
     const { fn } = mockFetch((url) => {
       if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 404 });
       if (url.endsWith('/bigdata/namespace')) return new Response('namespace exists already', { status: 409 });
       return new Response(null, { status: 200 });
     });
@@ -486,6 +615,7 @@ describe('provisionBlazegraphDocker', () => {
     });
     const { fn, calls: httpCalls } = mockFetch((url) => {
       if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 404 });
       if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
       return new Response(null, { status: 200 });
     });

--- a/packages/cli/test/blazegraph-image-metadata.test.ts
+++ b/packages/cli/test/blazegraph-image-metadata.test.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
@@ -56,8 +58,32 @@ describe('Blazegraph image metadata contract', () => {
     { image: 'example/blazegraph', containerPort: 8080 },
     { image: 'example/blazegraph', containerPort: 8080, dataPath: 'data' },
     { image: 'example/blazegraph', containerPort: 8080, dataPath: '/bad,path' },
+    { image: 'example/blazegraph', containerPort: 8080, dataPath: '/bad path' },
+    { image: 'example/blazegraph', containerPort: 8080, dataPath: '/bad\tpath' },
+    { image: 'example/blazegraph', containerPort: 8080, dataPath: '/bad\npath' },
   ])('rejects invalid metadata: %j', (metadata) => {
     expect(() => contract.parseBlazegraphImageMetadata(metadata)).toThrow();
+  });
+
+  it('rejects line-breaking data paths through the CLI field contract', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dkg-blazegraph-metadata-'));
+    const invalidMetadataPath = join(root, 'blazegraph-image.json');
+    writeFileSync(
+      invalidMetadataPath,
+      JSON.stringify({
+        image: 'example/blazegraph',
+        containerPort: 8080,
+        dataPath: '/data\ncorrupted-field=value',
+      }),
+    );
+    const result = spawnSync(process.execPath, [parserPath, invalidMetadataPath, 'dataPath'], {
+      encoding: 'utf8',
+    });
+    rmSync(root, { recursive: true, force: true });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('without commas or whitespace');
   });
 
   it('prints every field as self-describing key=value lines by default', () => {

--- a/packages/cli/test/blazegraph-image-metadata.test.ts
+++ b/packages/cli/test/blazegraph-image-metadata.test.ts
@@ -7,12 +7,15 @@ import { describe, expect, it } from 'vitest';
 interface BlazegraphImageMetadata {
   image: string;
   containerPort: number;
+  dataPath: string;
 }
 
-interface BlazegraphImageMetadataParser {
+interface BlazegraphRuntimeContract {
+  BLAZEGRAPH_NAMESPACE_XML_TEMPLATE: string;
   formatBlazegraphImageMetadata(metadata: unknown): string;
   parseBlazegraphImageMetadata(value: unknown, source?: string): BlazegraphImageMetadata;
   readBlazegraphImageMetadata(filePath: string): BlazegraphImageMetadata;
+  renderBlazegraphNamespaceXml(namespace: string): string;
 }
 
 const require = createRequire(import.meta.url);
@@ -21,18 +24,24 @@ const parserPath = resolve(
   '../blazegraph-image-metadata.cjs',
 );
 const metadataPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../../blazegraph-image.json');
-const parser = require(parserPath) as BlazegraphImageMetadataParser;
+const contract = require(parserPath) as BlazegraphRuntimeContract;
+
+function runCli(...args: string[]) {
+  return spawnSync(process.execPath, [parserPath, ...args], { encoding: 'utf8' });
+}
 
 describe('Blazegraph image metadata contract', () => {
   it('normalizes the accepted image and port shape', () => {
     expect(
-      parser.parseBlazegraphImageMetadata({
+      contract.parseBlazegraphImageMetadata({
         image: '  example/blazegraph@sha256:abc  ',
         containerPort: 8080,
+        dataPath: '  /data  ',
       }),
     ).toEqual({
       image: 'example/blazegraph@sha256:abc',
       containerPort: 8080,
+      dataPath: '/data',
     });
   });
 
@@ -40,23 +49,104 @@ describe('Blazegraph image metadata contract', () => {
     null,
     [],
     {},
-    { image: '', containerPort: 8080 },
-    { image: 'example/blazegraph', containerPort: 0 },
-    { image: 'example/blazegraph', containerPort: 65_536 },
-    { image: 'example/blazegraph', containerPort: 8080.5 },
+    { image: '', containerPort: 8080, dataPath: '/data' },
+    { image: 'example/blazegraph', containerPort: 0, dataPath: '/data' },
+    { image: 'example/blazegraph', containerPort: 65_536, dataPath: '/data' },
+    { image: 'example/blazegraph', containerPort: 8080.5, dataPath: '/data' },
+    { image: 'example/blazegraph', containerPort: 8080 },
+    { image: 'example/blazegraph', containerPort: 8080, dataPath: 'data' },
+    { image: 'example/blazegraph', containerPort: 8080, dataPath: '/bad,path' },
   ])('rejects invalid metadata: %j', (metadata) => {
-    expect(() => parser.parseBlazegraphImageMetadata(metadata)).toThrow();
+    expect(() => contract.parseBlazegraphImageMetadata(metadata)).toThrow();
   });
 
-  it('emits the same tab-separated output consumed by CI and devnet', () => {
-    const metadata = parser.readBlazegraphImageMetadata(metadataPath);
-    const result = spawnSync(process.execPath, [parserPath, metadataPath], { encoding: 'utf8' });
+  it('prints every field as self-describing key=value lines by default', () => {
+    const metadata = contract.readBlazegraphImageMetadata(metadataPath);
+    const result = runCli(metadataPath);
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout.trim()).toBe(parser.formatBlazegraphImageMetadata(metadata));
-    expect(result.stdout.trim().split('\t')).toEqual([
-      metadata.image,
+    expect(result.stdout.trim()).toBe(contract.formatBlazegraphImageMetadata(metadata));
+    expect(result.stdout.trim().split('\n').sort()).toEqual([
+      `containerPort=${metadata.containerPort}`,
+      `dataPath=${metadata.dataPath}`,
+      `image=${metadata.image}`,
+    ]);
+  });
+
+  it('prints requested fields by name, one value per line', () => {
+    const metadata = contract.readBlazegraphImageMetadata(metadataPath);
+
+    const single = runCli(metadataPath, 'image');
+    expect(single.status, single.stderr).toBe(0);
+    expect(single.stdout.trim()).toBe(metadata.image);
+
+    const multiple = runCli(metadataPath, 'dataPath', 'containerPort');
+    expect(multiple.status, multiple.stderr).toBe(0);
+    expect(multiple.stdout.trim().split('\n')).toEqual([
+      metadata.dataPath,
       String(metadata.containerPort),
     ]);
+  });
+
+  it('fails on an unknown field name', () => {
+    const result = runCli(metadataPath, 'image', 'journalPath');
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('journalPath');
+    expect(result.stderr).toContain('image, containerPort, dataPath');
+  });
+
+  it('validates the whole contract before serving any single field', () => {
+    const result = spawnSync(
+      process.execPath,
+      [parserPath, '/nonexistent/blazegraph-image.json', 'image'],
+      { encoding: 'utf8' },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+  });
+
+  it('prints usage and exits 2 without a metadata file', () => {
+    const result = runCli();
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Usage');
+  });
+});
+
+describe('Blazegraph namespace XML rendering', () => {
+  it('renders the canonical template with the namespace substituted', () => {
+    expect(contract.renderBlazegraphNamespaceXml('mynode')).toBe(
+      contract.BLAZEGRAPH_NAMESPACE_XML_TEMPLATE.replace('{namespace}', 'mynode'),
+    );
+  });
+
+  it('serves the rendered XML over the CLI for shell consumers', () => {
+    const result = runCli('--namespace-xml', 'dkg-ci-persistence-contract');
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe(
+      contract.renderBlazegraphNamespaceXml('dkg-ci-persistence-contract'),
+    );
+    expect(result.stdout).toContain(
+      '<entry key="com.bigdata.rdf.sail.namespace">dkg-ci-persistence-contract</entry>',
+    );
+  });
+
+  it.each([
+    '', // empty
+    'has space',
+    'quote"break',
+    '<entry>', // XML injection
+    'a'.repeat(129), // over the length cap
+  ])('rejects namespaces outside the conservative charset: %j', (namespace) => {
+    expect(() => contract.renderBlazegraphNamespaceXml(namespace)).toThrow(/must match/);
+    const result = runCli('--namespace-xml', namespace);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+  });
+
+  it('prints usage and exits 2 when --namespace-xml lacks its argument', () => {
+    const result = runCli('--namespace-xml');
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Usage');
   });
 });

--- a/packages/cli/test/fixtures/devnet-blazegraph-smoke.sh
+++ b/packages/cli/test/fixtures/devnet-blazegraph-smoke.sh
@@ -27,7 +27,14 @@ docker() {
   esac
 }
 curl() {
-  [ "$blazegraph_started" = "1" ]
+  [ "$blazegraph_started" = "1" ] || return 1
+  local arg
+  for arg in "$@"; do
+    if [ "$arg" = "-w" ]; then
+      printf '%s' "${DEVNET_BLAZEGRAPH_SMOKE_NAMESPACE_STATUS:-201}"
+      break
+    fi
+  done
 }
 
 if start_blazegraph; then

--- a/scripts/ci/verify-blazegraph-image-contract.sh
+++ b/scripts/ci/verify-blazegraph-image-contract.sh
@@ -5,9 +5,14 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 cd "$repo_root"
 
-runtime="$(node packages/cli/blazegraph-image-metadata.cjs blazegraph-image.json)"
-IFS=$'\t' read -r image container_port <<< "$runtime"
-if [[ -z "$image" || -z "$container_port" ]]; then
+# Fields are requested by NAME — the metadata contract is JSON, never
+# positional output.
+read_contract_field() {
+  node packages/cli/blazegraph-image-metadata.cjs blazegraph-image.json "$1"
+}
+if ! image="$(read_contract_field image)" \
+  || ! container_port="$(read_contract_field containerPort)" \
+  || ! data_path="$(read_contract_field dataPath)"; then
   echo "::error::Could not read image contract from blazegraph-image.json"
   exit 1
 fi
@@ -28,30 +33,71 @@ printf '%s\n' "$manifest" | jq -e '
   ([.manifests[] | select(.platform.os == "linux") | .platform.architecture] | index("arm64") != null)
 '
 
-container="dkg-ci-blazegraph-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-${platform##*/}"
+resource_suffix="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-${platform##*/}"
+container="dkg-ci-blazegraph-${resource_suffix}"
+volume="dkg-ci-blazegraph-data-${resource_suffix}"
+namespace="dkg-ci-persistence-contract"
+host_port=""
 # Invoked indirectly by the EXIT trap below.
 # shellcheck disable=SC2329
 cleanup() {
   docker rm -f "$container" >/dev/null 2>&1 || true
+  docker volume rm -f "$volume" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
-docker run -d \
-  --platform "$platform" \
-  --name "$container" \
-  -p "127.0.0.1::${container_port}" \
-  "$image" >/dev/null
-binding="$(docker port "$container" "${container_port}/tcp")"
-host_port="${binding##*:}"
+start_contract_container() {
+  docker run -d \
+    --platform "$platform" \
+    --name "$container" \
+    --mount "type=volume,source=${volume},target=${data_path}" \
+    -p "127.0.0.1::${container_port}" \
+    "$image" >/dev/null
+  local binding
+  binding="$(docker port "$container" "${container_port}/tcp")"
+  host_port="${binding##*:}"
 
-for _ in $(seq 1 120); do
-  if curl -fsS --max-time 2 "http://127.0.0.1:${host_port}/bigdata/status" >/dev/null; then
-    echo "Verified Blazegraph ${platform} runtime on declared container port ${container_port}."
-    exit 0
-  fi
-  sleep 1
-done
+  for _ in $(seq 1 120); do
+    if curl -fsS --max-time 2 "http://127.0.0.1:${host_port}/bigdata/status" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  docker logs "$container" || true
+  return 1
+}
 
-docker logs "$container" || true
-echo "::error::Pinned Blazegraph image did not serve /bigdata/status for ${platform} on declared container port ${container_port}"
-exit 1
+if ! start_contract_container; then
+  echo "::error::Pinned Blazegraph image did not serve /bigdata/status for ${platform} on declared container port ${container_port}"
+  exit 1
+fi
+
+# The canonical namespace-properties XML is rendered by the shared contract
+# module — no inline copy to drift.
+node packages/cli/blazegraph-image-metadata.cjs --namespace-xml "$namespace" \
+  | curl -fsS --max-time 10 -X POST \
+    "http://127.0.0.1:${host_port}/bigdata/namespace" \
+    -H 'Content-Type: application/xml' \
+    --data-binary @- >/dev/null
+
+curl -fsS --max-time 10 \
+  "http://127.0.0.1:${host_port}/bigdata/namespace/${namespace}/sparql/properties" \
+  >/dev/null
+
+# Recreate only the container, preserving the named volume. The namespace must
+# still exist; this proves dataPath is the image's real durable journal path.
+docker rm -f "$container" >/dev/null
+if ! start_contract_container; then
+  echo "::error::Pinned Blazegraph image did not restart with its declared dataPath volume"
+  exit 1
+fi
+
+if ! curl -fsS --max-time 10 \
+  "http://127.0.0.1:${host_port}/bigdata/namespace/${namespace}/sparql/properties" \
+  >/dev/null; then
+  docker logs "$container" || true
+  echo "::error::Declared Blazegraph dataPath ${data_path} did not preserve namespace ${namespace} across container recreation"
+  exit 1
+fi
+
+echo "Verified Blazegraph ${platform} runtime on port ${container_port} and durable journal path ${data_path}."

--- a/scripts/devnet-blazegraph-native.sh
+++ b/scripts/devnet-blazegraph-native.sh
@@ -36,21 +36,16 @@ is_up() { curl -sf --max-time 4 "$(status_url)" >/dev/null 2>&1; }
 
 seed_namespace() {
   local ns="$1"
-  # Properties XML — loadFromXML requires EXACTLY this SYSTEM DOCTYPE (it is matched
-  # literally, NOT fetched; the dead java.sun.com URL is fine). quads=true is
-  # mandatory: the DKG uses named graphs. Idempotent: 409 EXISTS is success.
+  # Properties XML comes from the shared contract module (this script's old
+  # inline copy had drifted: canonical wins, adding statementIdentifiers=false
+  # and textIndex=false). Idempotent: 409 EXISTS is success.
   local xml
   xml=$(mktemp)
-  cat > "$xml" <<EOF
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
-<properties>
-<entry key="com.bigdata.rdf.sail.namespace">$ns</entry>
-<entry key="com.bigdata.rdf.store.AbstractTripleStore.quads">true</entry>
-<entry key="com.bigdata.rdf.sail.truthMaintenance">false</entry>
-<entry key="com.bigdata.rdf.store.AbstractTripleStore.axiomsClass">com.bigdata.rdf.axioms.NoAxioms</entry>
-</properties>
-EOF
+  if ! node "$REPO_ROOT/packages/cli/blazegraph-image-metadata.cjs" --namespace-xml "$ns" > "$xml"; then
+    rm -f "$xml"
+    log "namespace $ns: FATAL could not render namespace properties XML"
+    return 1
+  fi
   local code
   code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$(ns_url)" -H "Content-Type: application/xml" --data-binary "@$xml")
   rm -f "$xml"

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -368,9 +368,11 @@ deploy_contracts() {
 
 BLAZEGRAPH_AVAILABLE=false
 
+# Prints the named metadata fields, one value per line — callers ask for
+# fields by NAME; the JSON contract has no positional output form.
 read_blazegraph_metadata() {
   node "$REPO_ROOT/packages/cli/blazegraph-image-metadata.cjs" \
-    "$REPO_ROOT/blazegraph-image.json"
+    "$REPO_ROOT/blazegraph-image.json" "$@"
 }
 
 start_blazegraph() {
@@ -395,12 +397,12 @@ start_blazegraph() {
     docker rm -f "$BLAZEGRAPH_CONTAINER" > /dev/null 2>&1 || true
   fi
 
-  local blazegraph_metadata blazegraph_image blazegraph_container_port
-  if ! blazegraph_metadata="$(read_blazegraph_metadata)"; then
+  local blazegraph_image blazegraph_container_port
+  if ! blazegraph_image="$(read_blazegraph_metadata image)" \
+    || ! blazegraph_container_port="$(read_blazegraph_metadata containerPort)"; then
     log "ERROR: Could not read the pinned Blazegraph image metadata"
     return 1
   fi
-  IFS=$'\t' read -r blazegraph_image blazegraph_container_port <<< "$blazegraph_metadata"
 
   log "Starting Blazegraph (Docker) on port $BLAZEGRAPH_PORT..."
   if ! docker run -d --name "$BLAZEGRAPH_CONTAINER" \
@@ -415,21 +417,15 @@ start_blazegraph() {
     if curl -s "http://127.0.0.1:$BLAZEGRAPH_PORT/bigdata/status" > /dev/null 2>&1; then
       log "Blazegraph ready"
       BLAZEGRAPH_AVAILABLE=true
-      # Create per-node namespaces for nodes 3–4 (Blazegraph)
+      # Create per-node namespaces for nodes 3–4 (Blazegraph). The
+      # namespace-properties XML comes from the shared contract module —
+      # no inline copy to drift.
       for n in 3 4; do
         local ns="node${n}"
-        curl -s -X POST "http://127.0.0.1:$BLAZEGRAPH_PORT/bigdata/namespace" \
-          -H "Content-Type: application/xml" \
-          -d "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>
-<!DOCTYPE properties SYSTEM \"http://java.sun.com/dtd/properties.dtd\">
-<properties>
-  <entry key=\"com.bigdata.rdf.sail.namespace\">$ns</entry>
-  <entry key=\"com.bigdata.rdf.store.AbstractTripleStore.quads\">true</entry>
-  <entry key=\"com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers\">false</entry>
-  <entry key=\"com.bigdata.rdf.store.AbstractTripleStore.textIndex\">false</entry>
-  <entry key=\"com.bigdata.rdf.sail.truthMaintenance\">false</entry>
-  <entry key=\"com.bigdata.rdf.store.AbstractTripleStore.axiomsClass\">com.bigdata.rdf.axioms.NoAxioms</entry>
-</properties>" > /dev/null 2>&1
+        node "$REPO_ROOT/packages/cli/blazegraph-image-metadata.cjs" --namespace-xml "$ns" \
+          | curl -s -X POST "http://127.0.0.1:$BLAZEGRAPH_PORT/bigdata/namespace" \
+            -H "Content-Type: application/xml" \
+            --data-binary @- > /dev/null 2>&1
         log "Created Blazegraph namespace: $ns"
       done
       return 0

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -75,6 +75,8 @@ HARDHAT_BLOCK_INTERVAL_MS="${HARDHAT_BLOCK_INTERVAL_MS:-1000}"
 DEVNET_DOCKER_NAME_PREFIX="${DEVNET_DOCKER_NAME_PREFIX:-devnet}"
 BLAZEGRAPH_PORT="${DEVNET_BLAZEGRAPH_PORT:-9999}"
 BLAZEGRAPH_CONTAINER="${DEVNET_DOCKER_NAME_PREFIX}-blazegraph"
+BLAZEGRAPH_LOG_MAX_SIZE="200m"
+BLAZEGRAPH_LOG_MAX_FILE="20"
 # Webapp context path: the 2.1.5 Docker image serves under /bigdata; a native
 # 2.1.6 JAR (the Apple-silicon workaround) serves under /blazegraph. Override with
 # DEVNET_BLAZEGRAPH_CTX to match whichever Blazegraph is actually running.
@@ -375,6 +377,40 @@ read_blazegraph_metadata() {
     "$REPO_ROOT/blazegraph-image.json" "$@"
 }
 
+create_blazegraph_namespace() {
+  local ns="$1"
+  local namespace_xml response_code
+  if ! namespace_xml="$(
+    node "$REPO_ROOT/packages/cli/blazegraph-image-metadata.cjs" --namespace-xml "$ns"
+  )"; then
+    log "WARNING: Failed to render Blazegraph namespace properties: $ns"
+    return 1
+  fi
+  if ! response_code="$(
+    curl -sS -o /dev/null -w '%{http_code}' -X POST \
+      "http://127.0.0.1:$BLAZEGRAPH_PORT/bigdata/namespace" \
+      -H "Content-Type: application/xml" \
+      --data-binary "$namespace_xml"
+  )"; then
+    log "WARNING: Failed to create Blazegraph namespace: $ns (request failed)"
+    return 1
+  fi
+  case "$response_code" in
+    2??)
+      log "Created Blazegraph namespace: $ns"
+      return 0
+      ;;
+    409)
+      log "Blazegraph namespace already exists: $ns"
+      return 0
+      ;;
+    *)
+      log "WARNING: Failed to create Blazegraph namespace: $ns (HTTP ${response_code:-unknown})"
+      return 1
+      ;;
+  esac
+}
+
 start_blazegraph() {
   # Use an EXTERNAL Blazegraph already serving on the port. Skips Docker entirely;
   # namespaces are the operator's job here.
@@ -406,6 +442,9 @@ start_blazegraph() {
 
   log "Starting Blazegraph (Docker) on port $BLAZEGRAPH_PORT..."
   if ! docker run -d --name "$BLAZEGRAPH_CONTAINER" \
+    --log-driver local \
+    --log-opt "max-size=$BLAZEGRAPH_LOG_MAX_SIZE" \
+    --log-opt "max-file=$BLAZEGRAPH_LOG_MAX_FILE" \
     -p "127.0.0.1:$BLAZEGRAPH_PORT:$blazegraph_container_port" \
     "$blazegraph_image" > /dev/null 2>&1; then
     log "WARNING: Failed to start Blazegraph container — nodes 3-4 will use Oxigraph"
@@ -422,11 +461,7 @@ start_blazegraph() {
       # no inline copy to drift.
       for n in 3 4; do
         local ns="node${n}"
-        node "$REPO_ROOT/packages/cli/blazegraph-image-metadata.cjs" --namespace-xml "$ns" \
-          | curl -s -X POST "http://127.0.0.1:$BLAZEGRAPH_PORT/bigdata/namespace" \
-            -H "Content-Type: application/xml" \
-            --data-binary @- > /dev/null 2>&1
-        log "Created Blazegraph namespace: $ns"
+        create_blazegraph_namespace "$ns" || true
       done
       return 0
     fi

--- a/scripts/lib/__tests__/release-packages.test.mjs
+++ b/scripts/lib/__tests__/release-packages.test.mjs
@@ -19,6 +19,11 @@ import { cliRuntimeAssetManifest, copyCliRuntimeAssets } from '../../copy-cli-ru
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const COPY_SCRIPT = path.join(REPO_ROOT, 'scripts', 'copy-cli-runtime-assets.mjs');
 const BLAZEGRAPH_METADATA_PARSER = path.join(REPO_ROOT, 'packages', 'cli', 'blazegraph-image-metadata.cjs');
+const VALID_BLAZEGRAPH_METADATA = `${JSON.stringify({
+  image: 'example/blazegraph@sha256:test',
+  containerPort: 80,
+  dataPath: '/data',
+})}\n`;
 
 const NPM_AVAILABLE = (() => {
   try {
@@ -219,7 +224,7 @@ function writeCliPackFixture(root) {
   fs.writeFileSync(path.join(root, 'network', 'testnet.json'), '{}\n');
   fs.writeFileSync(path.join(root, 'network', 'mainnet-base.json'), '{}\n');
   fs.writeFileSync(path.join(root, 'project.json'), '{}\n');
-  fs.writeFileSync(path.join(root, 'blazegraph-image.json'), '{"image":"example/blazegraph@sha256:test","containerPort":80}\n');
+  fs.writeFileSync(path.join(root, 'blazegraph-image.json'), VALID_BLAZEGRAPH_METADATA);
 }
 
 test('flags a cli tarball missing required runtime assets (the 10.0.4 drop)', () => withFixture((root) => {
@@ -259,7 +264,7 @@ test('copyCliRuntimeAssets materializes package-local assets and mirrors (drops 
   fs.writeFileSync(path.join(root, 'network', 'testnet.json'), '{"a":1}\n');
   fs.writeFileSync(path.join(root, 'network', 'mainnet-base.json'), '{"b":2}\n');
   fs.writeFileSync(path.join(root, 'project.json'), '{"name":"x"}\n');
-  fs.writeFileSync(path.join(root, 'blazegraph-image.json'), '{"image":"example/blazegraph@sha256:test","containerPort":80}\n');
+  fs.writeFileSync(path.join(root, 'blazegraph-image.json'), VALID_BLAZEGRAPH_METADATA);
   // A stale overlay left in the package from an earlier build/branch.
   fs.mkdirSync(path.join(root, 'packages', 'cli', 'network'), { recursive: true });
   fs.writeFileSync(path.join(root, 'packages', 'cli', 'network', 'devnet.json'), '{"stale":true}\n');
@@ -377,7 +382,7 @@ test('real npm pack --dry-run runs prepack and includes every runtime asset', { 
   fs.writeFileSync(path.join(root, 'network', 'testnet.json'), '{}\n');
   fs.writeFileSync(path.join(root, 'network', 'mainnet-base.json'), '{}\n');
   fs.writeFileSync(path.join(root, 'project.json'), '{}\n');
-  fs.writeFileSync(path.join(root, 'blazegraph-image.json'), '{"image":"example/blazegraph@sha256:test","containerPort":80}\n');
+  fs.writeFileSync(path.join(root, 'blazegraph-image.json'), VALID_BLAZEGRAPH_METADATA);
   const cliDir = path.join(root, 'packages', 'cli');
   fs.mkdirSync(cliDir, { recursive: true });
   fs.copyFileSync(BLAZEGRAPH_METADATA_PARSER, path.join(cliDir, 'blazegraph-image-metadata.cjs'));


### PR DESCRIPTION
## Summary

Carries the reviewed Blazegraph provisioning hardening from #2086 onto the current testnet-canary without importing unrelated main history.

- persist DKG-managed Blazegraph journals in a per-container named volume
- use Docker's compressed local log driver with a bounded 4 GB budget
- keep legacy containers untouched and emit explicit migration/log-policy warnings
- keep image metadata, namespace XML, devnet scripts, and packaged runtime assets on one validated contract

## Release impact

Newly provisioned DKG-managed Blazegraph containers receive durable journal storage and bounded logs. Existing containers are never recreated automatically, so this does not risk deleting an existing journal; operators receive warnings when an old container does not match the policy.

## Provenance

The resulting 10-file binary patch matches #2086 byte-for-byte. A new canary-based PR is used because retargeting the historical branch would also import unrelated documentation history from its old main merge.

## Validation

- exact binary patch comparison against #2086: pass
- CLI dependency graph build: 18 workspace packages passed
- Blazegraph provisioner and metadata tests: 45/45 passed
- release-package tests: 23/23 passed
- git diff --check: passed
- prior #2086 GitHub CI, including its Docker runtime lane: 64 checks passed
- fresh canary CI: required before merge

Supersedes #2086 for the 10.0.13 canary release path.