### PR TITLE
fix(prime-agent): recover UI lifecycle after provider failures

### DIFF
--- a/packages/adapter-prime-agent/extension/src/extension.ts
+++ b/packages/adapter-prime-agent/extension/src/extension.ts
@@ -57,6 +57,22 @@ interface MessageUpdateEvent {
   };
   message?: { role?: string; content?: unknown; errorMessage?: string; stopReason?: string };
 }
+interface AssistantMessageDiagnosticLike {
+  type: string;
+  timestamp: number;
+  details?: Record<string, unknown>;
+}
+interface MessageEndEvent {
+  message?: {
+    role?: string;
+    stopReason?: string;
+    diagnostics?: AssistantMessageDiagnosticLike[];
+    [key: string]: unknown;
+  };
+}
+interface MessageEndEventResult {
+  message: NonNullable<MessageEndEvent['message']>;
+}
 interface AgentMessageLike {
   role?: string;
   content?: unknown;
@@ -265,6 +281,7 @@ class SessionBridge {
   // in the background. Retry starts have no before_agent_start; abort them
   // until a genuinely fresh prompt boundary supersedes the failed run.
   #failedRunQuarantined = false;
+  #failedRunFailure: SanitizedTurnFailure | undefined;
   #agentActive = false;
   #abortActiveAgent: (() => void) | undefined;
   #closed = false;
@@ -426,6 +443,7 @@ class SessionBridge {
     this.#activeRunTurn = undefined;
     this.#runHasFreshPrompt = false;
     this.#failedRunQuarantined = false;
+    this.#failedRunFailure = undefined;
     this.#agentActive = false;
     this.#abortActiveAgent = undefined;
     const server = this.#server;
@@ -624,6 +642,7 @@ class SessionBridge {
     if (message?.role === 'user') {
       this.#runHasFreshPrompt = true;
       this.#failedRunQuarantined = false;
+      this.#failedRunFailure = undefined;
       return;
     }
     if (message?.role !== 'custom' || message.customType !== BRIDGE_TURN_MARKER_TYPE) return;
@@ -673,7 +692,12 @@ class SessionBridge {
     // finish the HTTP/SSE turn, clear admission, and never expose the raw
     // provider payload (which may contain credential-bearing diagnostics).
     if (eventType === 'error') {
-      this.#failTurn(turn, sanitizedProviderFailure(event));
+      // The provider has already declared this stream terminal. Do not call
+      // ctx.abort() here: Prime may emit agent_end synchronously from abort,
+      // before the matching message_end hook can replace the finalized error
+      // with the non-retryable bridge marker. Genuine timer failures still
+      // abort below because their provider stream is not terminal yet.
+      this.#failTurn(turn, sanitizedProviderFailure(event), false);
       return;
     }
     // At the pinned Prime Agent API, only text_delta is user-visible answer
@@ -695,6 +719,66 @@ class SessionBridge {
     }
   }
 
+  onMessageEnd(event: MessageEndEvent): MessageEndEventResult | undefined {
+    const message = event.message;
+    const activeTurn = this.#activeRunTurn;
+    // Prime Agent 0.7 may finalize a provider failure directly at message_end
+    // without first emitting a message_update error to extensions. Treat the
+    // finalized bridge-owned error as authoritative too; otherwise agent_end
+    // resolves the HTTP turn as an empty success and the UI renders a blank
+    // assistant row while Prime performs its hidden retry.
+    if (
+      !this.#failedRunQuarantined &&
+      activeTurn &&
+      this.#turn === activeTurn &&
+      message?.role === 'assistant' &&
+      message.stopReason === 'error'
+    ) {
+      this.#failTurn(activeTurn, sanitizedProviderFailure({ message }), false);
+    }
+    if (
+      !this.#failedRunQuarantined ||
+      message?.role !== 'assistant' ||
+      message.stopReason !== 'error'
+    ) {
+      return undefined;
+    }
+    const failure = this.#failedRunFailure;
+    const diagnostics = (Array.isArray(message.diagnostics) ? message.diagnostics : [])
+      // A structured auth diagnostic makes Prime force one credential-source
+      // retry even when the message is otherwise marked terminal. The bridge
+      // already returned that failure to its HTTP caller, so retain the safe
+      // classification below instead of the provider payload that triggers a
+      // second hidden request.
+      .filter((diagnostic) => diagnostic.type !== 'provider_stream_failure');
+    const hasLifecycleFailure = diagnostics.some(
+      (diagnostic) => diagnostic.type === 'agent_lifecycle_failure',
+    );
+    // Prime retries every assistant `stopReason: error` unless the finalized
+    // message is explicitly terminal. Mark only the bridge-owned run that has
+    // already returned a terminal HTTP verdict. This is handled synchronously
+    // in Prime's public message_end replacement hook, before its retry decision,
+    // avoiding the race inherent in trying to abort a retry timer later.
+    return {
+      message: {
+        ...message,
+        ...(failure ? { errorMessage: failure.message } : {}),
+        diagnostics: [
+          ...diagnostics,
+          ...(!hasLifecycleFailure ? [{
+            type: 'agent_lifecycle_failure',
+            timestamp: Date.now(),
+            details: {
+              source: 'dkg-bridge',
+              reason: 'terminal_bridge_response_settled',
+              ...(failure ? { code: failure.code } : {}),
+            },
+          }] : []),
+        ],
+      },
+    };
+  }
+
   onAgentStart(ctx?: ExtensionCtxLike): void {
     this.#activeRunTurn = undefined;
     this.#runHasFreshPrompt = false;
@@ -714,16 +798,20 @@ class SessionBridge {
   }
 
   onAgentEnd(): void {
-    this.#agentActive = false;
-    this.#abortActiveAgent = undefined;
     this.#runHasFreshPrompt = false;
     const turn = this.#activeRunTurn;
     this.#activeRunTurn = undefined;
-    if (!turn) return;
-    if (this.#turn === turn && !turn.responseSettled) {
-      this.#settleResponse({ text: turn.chunks.join('') });
+    if (turn) {
+      if (this.#turn === turn && !turn.responseSettled) {
+        this.#settleResponse({ text: turn.chunks.join('') });
+      }
+      this.#clearTurn(turn);
     }
-    this.#clearTurn(turn);
+
+    this.#failedRunQuarantined = false;
+    this.#failedRunFailure = undefined;
+    this.#agentActive = false;
+    this.#abortActiveAgent = undefined;
   }
 
   #armTurnTimers(turn: PendingTurn): void {
@@ -765,7 +853,11 @@ class SessionBridge {
     if (this.#turn === turn) this.#turn = undefined;
   }
 
-  #failTurn(turn: PendingTurn, failure: SanitizedTurnFailure): void {
+  #failTurn(
+    turn: PendingTurn,
+    failure: SanitizedTurnFailure,
+    abortActiveAgent = true,
+  ): void {
     const ownsActiveRun = this.#activeRunTurn === turn;
     if (this.#turn === turn) {
       this.#settleResponse({
@@ -777,12 +869,15 @@ class SessionBridge {
     }
     if (!ownsActiveRun) return;
     this.#failedRunQuarantined = true;
+    this.#failedRunFailure = failure;
     // Keep #agentActive true until the actual agent_end so the bridge does not
     // admit a successor into a run that has not reached a boundary yet.
-    try {
-      this.#abortActiveAgent?.();
-    } catch {
-      /* the ownership quarantine remains authoritative */
+    if (abortActiveAgent) {
+      try {
+        this.#abortActiveAgent?.();
+      } catch {
+        /* the ownership quarantine remains authoritative */
+      }
     }
   }
 
@@ -844,6 +939,8 @@ export default function dkgBridgeExtension(pi: ExtensionApiLike): void {
   pi.on('message_update', (event: MessageUpdateEvent) => {
     bridge?.onMessageUpdate(event);
   });
+
+  pi.on('message_end', (event: MessageEndEvent) => bridge?.onMessageEnd(event));
 
   pi.on('input', (event: InputEvent) => bridge?.onInput(event) ?? { action: 'continue' });
 

--- a/packages/adapter-prime-agent/extension/src/extension.ts
+++ b/packages/adapter-prime-agent/extension/src/extension.ts
@@ -265,6 +265,11 @@ interface SanitizedTurnFailure {
   message: string;
 }
 
+interface TerminalBridgeFailure {
+  turn: PendingTurn;
+  failure: SanitizedTurnFailure;
+}
+
 // Classification only ever needs the head of each diagnostic; the cap also
 // keeps the regex off provider-sized inputs, which are attacker-influenced.
 // Capped per field (not after joining) so an oversized first diagnostic
@@ -332,8 +337,11 @@ class SessionBridge {
   // A terminal HTTP verdict must stop Prime from continuing that logical turn
   // in the background. Retry starts have no before_agent_start; abort them
   // until a genuinely fresh prompt boundary supersedes the failed run.
-  #failedRunQuarantined = false;
-  #failedRunFailure: SanitizedTurnFailure | undefined;
+  #retryQuarantined = false;
+  // Error rewriting is intentionally separate from retry quarantine. Only a
+  // bridge-owned turn that has already returned a sanitized terminal verdict
+  // may replace Prime's finalized assistant error.
+  #terminalBridgeFailure: TerminalBridgeFailure | undefined;
   #agentActive = false;
   #abortActiveAgent: (() => void) | undefined;
   #closed = false;
@@ -502,8 +510,8 @@ class SessionBridge {
     this.#runHasFreshPrompt = false;
     this.#freshPromptFromTurn = undefined;
     this.#runQuarantineLatched = false;
-    this.#failedRunQuarantined = false;
-    this.#failedRunFailure = undefined;
+    this.#retryQuarantined = false;
+    this.#terminalBridgeFailure = undefined;
     this.#agentActive = false;
     this.#abortActiveAgent = undefined;
     const server = this.#server;
@@ -768,7 +776,7 @@ class SessionBridge {
           // before_provider_request aborts it instead of letting a caller who
           // already received a terminal failure produce side effects.
           this.#runHasFreshPrompt = false;
-          this.#failedRunQuarantined = true;
+          this.#retryQuarantined = true;
           this.#runQuarantineLatched = true;
           return;
         }
@@ -780,8 +788,8 @@ class SessionBridge {
       // agent_start may establish a clean prompt boundary.
       if (this.#runQuarantineLatched) return;
       this.#runHasFreshPrompt = true;
-      this.#failedRunQuarantined = false;
-      this.#failedRunFailure = undefined;
+      this.#retryQuarantined = false;
+      this.#terminalBridgeFailure = undefined;
       return;
     }
     if (message?.role !== 'custom' || message.customType !== BRIDGE_TURN_MARKER_TYPE) return;
@@ -823,7 +831,7 @@ class SessionBridge {
   }
 
   onBeforeProviderRequest(ctx?: ExtensionCtxLike): void {
-    if (!this.#failedRunQuarantined || this.#runHasFreshPrompt) return;
+    if (!this.#retryQuarantined || this.#runHasFreshPrompt) return;
     // Prime retry/continue runs have agent_start but no newly emitted user
     // message. Abort at the last hook before provider I/O so a turn that has
     // already returned a terminal HTTP verdict cannot resume or execute tools.
@@ -881,7 +889,7 @@ class SessionBridge {
     // resolves the HTTP turn as an empty success and the UI renders a blank
     // assistant row while Prime performs its hidden retry.
     if (
-      !this.#failedRunQuarantined &&
+      !this.#terminalBridgeFailure &&
       activeTurn &&
       this.#turn === activeTurn &&
       message?.role === 'assistant' &&
@@ -889,14 +897,11 @@ class SessionBridge {
     ) {
       this.#failTurn(activeTurn, sanitizedProviderFailure({ message }), false);
     }
-    if (
-      !this.#failedRunQuarantined ||
-      message?.role !== 'assistant' ||
-      message.stopReason !== 'error'
-    ) {
+    const terminalFailure = this.#terminalBridgeFailure;
+    if (!terminalFailure || message?.role !== 'assistant' || message.stopReason !== 'error') {
       return undefined;
     }
-    const failure = this.#failedRunFailure;
+    const failure = terminalFailure.failure;
     const diagnostics = (Array.isArray(message.diagnostics) ? message.diagnostics : [])
       // A structured auth diagnostic makes Prime force one credential-source
       // retry even when the message is otherwise marked terminal. The bridge
@@ -912,10 +917,10 @@ class SessionBridge {
     // already returned a terminal HTTP verdict. This is handled synchronously
     // in Prime's public message_end replacement hook, before its retry decision,
     // avoiding the race inherent in trying to abort a retry timer later.
-    return {
+    const replacement: MessageEndEventResult = {
       message: {
         ...message,
-        ...(failure ? { errorMessage: failure.message } : {}),
+        errorMessage: failure.message,
         diagnostics: [
           ...diagnostics,
           ...(!hasLifecycleFailure ? [{
@@ -924,12 +929,18 @@ class SessionBridge {
             details: {
               source: 'dkg-bridge',
               reason: 'terminal_bridge_response_settled',
-              ...(failure ? { code: failure.code } : {}),
+              code: failure.code,
             },
           }] : []),
         ],
       },
     };
+    // Some Prime/provider combinations finalize the assistant message but omit
+    // agent_end. The finalized terminal marker is already in place, so release
+    // bridge admission here rather than leaving #agentActive stuck forever.
+    this.#terminalBridgeFailure = undefined;
+    this.#releaseTerminalRun(terminalFailure.turn);
+    return replacement;
   }
 
   onAgentStart(ctx?: ExtensionCtxLike): void {
@@ -968,7 +979,6 @@ class SessionBridge {
     // marker prevents Prime's normal credential retry, while this latch remains
     // defense in depth for any continuation that still arrives without a fresh
     // user message. onMessageStart clears it at the next genuine prompt.
-    this.#failedRunFailure = undefined;
     this.#agentActive = false;
     this.#abortActiveAgent = undefined;
   }
@@ -1038,6 +1048,13 @@ class SessionBridge {
     if (this.#turn === turn) this.#turn = undefined;
   }
 
+  #releaseTerminalRun(turn: PendingTurn): void {
+    if (this.#activeRunTurn === turn) this.#activeRunTurn = undefined;
+    if (this.#freshPromptFromTurn === turn) this.#freshPromptFromTurn = undefined;
+    this.#agentActive = false;
+    this.#abortActiveAgent = undefined;
+  }
+
   #failTurn(
     turn: PendingTurn,
     failure: SanitizedTurnFailure,
@@ -1058,15 +1075,16 @@ class SessionBridge {
       // Poison the assembling run now; replayed foreign markers stay no-ops.
       this.#freshPromptFromTurn = undefined;
       this.#runHasFreshPrompt = false;
-      this.#failedRunQuarantined = true;
+      this.#retryQuarantined = true;
       this.#runQuarantineLatched = true;
     }
     if (!ownsActiveRun) return;
-    this.#failedRunQuarantined = true;
-    this.#failedRunFailure = failure;
+    this.#retryQuarantined = true;
+    this.#terminalBridgeFailure = { turn, failure };
     this.#runQuarantineLatched = true;
-    // Keep #agentActive true until the actual agent_end so the bridge does not
-    // admit a successor into a run that has not reached a boundary yet.
+    // Timer/delivery failures still abort and use agent_end as their boundary.
+    // Terminal provider failures do not abort: message_end first installs the
+    // non-retryable marker and then releases admission via #releaseTerminalRun.
     if (abortActiveAgent) {
       try {
         this.#abortActiveAgent?.();

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -383,7 +383,7 @@ describe('/send', () => {
     bridge.onAgentEnd();
   });
 
-  it('sanitizes a provider failure and aborts its auto-retry without touching the successor', async () => {
+  it('sanitizes a terminal provider failure before Prime can auto-retry it', async () => {
     const firstResponse = await fetch(`${base}/stream`, {
       method: 'POST',
       headers: authed(),
@@ -391,24 +391,20 @@ describe('/send', () => {
     });
     await until(() => sent.length === 1);
     let failedRunAbortCount = 0;
-    startBridgeRun({
+    const failedRunCtx = {
       sessionManager: { getSessionId: () => 'sess-test' },
       abort: () => { failedRunAbortCount += 1; },
-    });
-    bridge.onMessageUpdate({
-      assistantMessageEvent: {
-        type: 'error',
-        reason: 'error',
-        error: {
-          errorMessage: '{"error":{"message":"Unauthorized","providerToken":"must-not-leak"}}',
-        },
-      },
-      message: {
-        role: 'assistant',
-        stopReason: 'error',
-        errorMessage: 'provider key sk-must-not-leak was Unauthorized',
-      },
-    });
+    };
+    startBridgeRun(failedRunCtx);
+    // Prime Agent 0.7 can expose provider failures only at message_end, with no
+    // preceding message_update error for extensions.
+    const finalizedFailure = {
+      role: 'assistant',
+      stopReason: 'error',
+      errorMessage: 'provider key sk-must-not-leak was Unauthorized',
+      diagnostics: [{ type: 'provider_stream_failure', timestamp: 1 }],
+    };
+    const replacement = bridge.onMessageEnd({ message: finalizedFailure });
 
     const firstText = await firstResponse.text();
     expect(firstText).toContain('"type":"error"');
@@ -416,7 +412,10 @@ describe('/send', () => {
     expect(firstText).toContain('"type":"final"');
     expect(firstText).not.toContain('must-not-leak');
     expect(firstText).not.toContain('sk-');
-    expect(failedRunAbortCount).toBe(1);
+    // A terminal provider event must finalize through message_end naturally.
+    // Aborting here can re-enter agent_end first and erase the marker that
+    // makes the finalized error non-retryable.
+    expect(failedRunAbortCount).toBe(0);
 
     // The failed run is still active until its real agent_end, so a successor
     // cannot be injected into an ambiguous lifecycle window.
@@ -427,7 +426,25 @@ describe('/send', () => {
     });
     expect(tooSoon.status).toBe(429);
     expect(sent).toEqual(['use the provider']);
+    expect(replacement?.message).toMatchObject({
+      role: 'assistant',
+      stopReason: 'error',
+      errorMessage: 'Prime Agent provider authentication failed. Check the configured provider credentials.',
+      diagnostics: [
+        {
+          type: 'agent_lifecycle_failure',
+          details: {
+            source: 'dkg-bridge',
+            reason: 'terminal_bridge_response_settled',
+            code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+          },
+        },
+      ],
+    });
     bridge.onAgentEnd();
+    // The finalized message marker makes Prime's retry decision deterministic,
+    // so no abort or deferred retry can race a successor turn.
+    expect(failedRunAbortCount).toBe(0);
 
     const second = fetch(`${base}/send`, {
       method: 'POST',
@@ -436,42 +453,8 @@ describe('/send', () => {
     });
     await until(() => sent.length === 2);
     expect(sent).toEqual(['use the provider', 'retry after credentials are fixed']);
-
-    // Prime may prepare the queued action before its retry wins the handoff.
-    // Its hidden ownership marker is cached on that action and excluded from
-    // provider context; it must not be consumed by the intervening retry run.
-    const preparedSuccessor = bridge.onBeforeAgentStart({ prompt: 'retry after credentials are fixed' });
-    expect(preparedSuccessor).toBeDefined();
-    const providerContext = bridge.onContext({
-      messages: [
-        { role: 'user', content: [{ type: 'text', text: 'retry after credentials are fixed' }] },
-        { role: 'custom', ...preparedSuccessor!.message },
-      ],
-    });
-    expect(providerContext?.messages).toEqual([
-      { role: 'user', content: [{ type: 'text', text: 'retry after credentials are fixed' }] },
-    ]);
-
-    // Prime auto-retry uses agent.continue(), so it emits no ownership marker.
-    // It remains unowned, is aborted, and neither its output nor its end can
-    // settle the queued successor.
-    let retryAbortCount = 0;
-    const retryCtx = {
-      sessionManager: { getSessionId: () => 'sess-test' },
-      abort: () => { retryAbortCount += 1; },
-    };
-    bridge.onAgentStart(retryCtx);
-    bridge.onBeforeProviderRequest(retryCtx);
-    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'retry output from failed turn' } });
-    bridge.onAgentEnd();
-    expect(retryAbortCount).toBe(1);
-    const settledByStaleEnd = await Promise.race([
-      second.then(() => true),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25)),
-    ]);
-    expect(settledByStaleEnd).toBe(false);
-
-    startBridgeRun(undefined, preparedSuccessor);
+    // No unowned retry can get ahead of this successor.
+    startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'recovered' } });
     bridge.onAgentEnd();
     const secondResponse = await second;
@@ -514,6 +497,7 @@ describe('/send', () => {
     // The hard timeout aborts but keeps admission closed until Prime confirms
     // the lifecycle boundary with agent_end.
     bridge.onAgentEnd();
+    expect(abortCount).toBe(1);
     const recovered = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
@@ -526,7 +510,7 @@ describe('/send', () => {
     expect((await recovered).status).toBe(200);
   });
 
-  it('keeps a zombie run closed through its end and discards an unowned retry tail', async () => {
+  it('keeps a zombie run closed through its end, then releases a fresh successor', async () => {
     await bridge.stop();
     bridge = new SessionBridge(stubPi((t, options) => { sent.push(t); sendOptions.push(options); }) as never, 'sess-stale-events', {
       turnIdleTimeoutMs: 30,
@@ -563,6 +547,7 @@ describe('/send', () => {
       message: { role: 'assistant', stopReason: 'aborted' },
     });
     bridge.onAgentEnd();
+    await new Promise((r) => setTimeout(r, 0));
 
     const successor = fetch(`${base}/send`, {
       method: 'POST',
@@ -571,17 +556,6 @@ describe('/send', () => {
     });
     await until(() => sent.length === 2);
     expect(sent).toEqual(['zombie turn', 'successor']);
-
-    // A continuation/retry has no before_agent_start and therefore cannot
-    // claim or settle the pending successor.
-    bridge.onAgentStart();
-    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'zombie-retry-tail ' } });
-    bridge.onAgentEnd();
-    const settledByRetry = await Promise.race([
-      successor.then(() => true),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25)),
-    ]);
-    expect(settledByRetry).toBe(false);
 
     startBridgeRun();
     bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'fresh answer' } });

--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -393,7 +393,7 @@ describe('/send', () => {
     bridge.onAgentEnd();
   });
 
-  it('sanitizes a terminal provider failure before Prime can auto-retry it', async () => {
+  it('sanitizes a terminal provider failure and releases admission without agent_end', async () => {
     const firstResponse = await fetch(`${base}/stream`, {
       method: 'POST',
       headers: authed(),
@@ -427,15 +427,16 @@ describe('/send', () => {
     // makes the finalized error non-retryable.
     expect(failedRunAbortCount).toBe(0);
 
-    // The failed run is still active until its real agent_end, so a successor
-    // cannot be injected into an ambiguous lifecycle window.
-    const tooSoon = await fetch(`${base}/send`, {
+    // Some provider failures never produce agent_end. Once message_end has the
+    // terminal lifecycle marker, the bridge must admit a successor instead of
+    // remaining 429-busy forever.
+    const second = fetch(`${base}/send`, {
       method: 'POST',
       headers: authed(),
-      body: JSON.stringify({ text: 'too soon', correlationId: 'c-too-soon' }),
+      body: JSON.stringify({ text: 'retry after credentials are fixed', correlationId: 'c-retry' }),
     });
-    expect(tooSoon.status).toBe(429);
-    expect(sent.map(visiblePrompt)).toEqual(['use the provider']);
+    await until(() => sent.length === 2);
+    expect(sent.map(visiblePrompt)).toEqual(['use the provider', 'retry after credentials are fixed']);
     expect(replacement?.message).toMatchObject({
       role: 'assistant',
       stopReason: 'error',
@@ -451,18 +452,9 @@ describe('/send', () => {
         },
       ],
     });
-    bridge.onAgentEnd();
     // The finalized message marker makes Prime's retry decision deterministic,
-    // so no abort or deferred retry can race a successor turn.
+    // so no immediate abort races message_end even though admission reopened.
     expect(failedRunAbortCount).toBe(0);
-
-    const second = fetch(`${base}/send`, {
-      method: 'POST',
-      headers: authed(),
-      body: JSON.stringify({ text: 'retry after credentials are fixed', correlationId: 'c-retry' }),
-    });
-    await until(() => sent.length === 2);
-    expect(sent.map(visiblePrompt)).toEqual(['use the provider', 'retry after credentials are fixed']);
 
     // Prime may prepare the queued action before its retry wins the handoff.
     // Its hidden ownership marker is cached on that action and excluded from
@@ -504,6 +496,75 @@ describe('/send', () => {
     const secondResponse = await second;
     expect(secondResponse.status).toBe(200);
     expect(await secondResponse.json()).toMatchObject({ text: 'recovered', correlationId: 'c-retry' });
+  });
+
+  it('carries a message_update provider failure into the terminal message_end marker', async () => {
+    const failedResponse = await fetch(`${base}/stream`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'stream through the provider', correlationId: 'c-update-error' }),
+    });
+    await until(() => sent.length === 1);
+    let abortCount = 0;
+    startBridgeRun({
+      sessionManager: { getSessionId: () => 'sess-test' },
+      abort: () => { abortCount += 1; },
+    });
+
+    bridge.onMessageUpdate({
+      assistantMessageEvent: {
+        type: 'error',
+        error: { errorMessage: 'provider key sk-update-secret was Unauthorized' },
+      },
+    });
+    const replacement = bridge.onMessageEnd({
+      message: {
+        role: 'assistant',
+        stopReason: 'error',
+        errorMessage: 'provider key sk-update-secret was Unauthorized',
+        diagnostics: [{ type: 'provider_stream_failure', timestamp: 1 }],
+      },
+    });
+
+    const failedText = await failedResponse.text();
+    expect(failedText).toContain('"type":"error"');
+    expect(failedText).toContain('"code":"PRIME_AGENT_PROVIDER_UNAUTHORIZED"');
+    expect(failedText).not.toContain('update-secret');
+    expect(failedText).not.toContain('sk-');
+    expect(abortCount).toBe(0);
+    expect(replacement?.message).toMatchObject({
+      role: 'assistant',
+      stopReason: 'error',
+      errorMessage: 'Prime Agent provider authentication failed. Check the configured provider credentials.',
+      diagnostics: [
+        {
+          type: 'agent_lifecycle_failure',
+          details: {
+            source: 'dkg-bridge',
+            reason: 'terminal_bridge_response_settled',
+            code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+          },
+        },
+      ],
+    });
+    expect(replacement?.message.diagnostics).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'provider_stream_failure' })]),
+    );
+
+    bridge.onAgentEnd();
+    const recovered = fetch(`${base}/send`, {
+      method: 'POST',
+      headers: authed(),
+      body: JSON.stringify({ text: 'next real turn', correlationId: 'c-after-update-error' }),
+    });
+    await until(() => sent.length === 2);
+    startBridgeRun();
+    bridge.onMessageUpdate({ assistantMessageEvent: { type: 'text_delta', delta: 'healthy' } });
+    bridge.onAgentEnd();
+    expect(await recovered.then((response) => response.json())).toMatchObject({
+      text: 'healthy',
+      correlationId: 'c-after-update-error',
+    });
   });
 
   it('uses a separate hard limit to abort and release a turn that never emits agent_end', async () => {

--- a/packages/cli/src/daemon/local-agents.ts
+++ b/packages/cli/src/daemon/local-agents.ts
@@ -1064,6 +1064,47 @@ export async function refreshLocalAgentIntegrationFromUi(
     throw new Error(`Unknown integration: ${id}`);
   }
   if (normalizedId !== 'openclaw') {
+    if (normalizedId === 'prime-agent') {
+      // A Prime bridge is session-scoped: connecting the integration before a
+      // session exists stores the expected degraded/idle state, but that state
+      // must not become sticky after a session starts. Refresh discovery and
+      // persist the elected live bridge just like the initial Connect flow.
+      const health = await probePrimeAgentChannelHealth(bridgeAuthToken, {
+        timeoutMs: 3_000,
+      });
+      const live = health.sessions.find((session) => session.sessionId === health.target)
+        ?? health.sessions[0];
+
+      if (health.ok && live) {
+        return updateLocalAgentIntegration(config, normalizedId, {
+          transport: transportPatchFromPrimeAgentTarget(targetFromDescriptor(live)),
+          runtime: {
+            status: 'ready',
+            ready: true,
+            lastError: null,
+          },
+          metadata: {
+            sessionCount: health.sessionCount,
+            activeSessionId: live.sessionId,
+          },
+        });
+      }
+
+      return updateLocalAgentIntegration(config, normalizedId, {
+        runtime: {
+          status: 'degraded',
+          ready: false,
+          lastError: health.error ?? 'no live Prime Agent session',
+        },
+        metadata: {
+          sessionCount: health.sessionCount,
+          // Metadata is merged, so null explicitly retires a session elected
+          // by an earlier refresh instead of leaving a stale route in config.
+          activeSessionId: null,
+        },
+      });
+    }
+
     if (normalizedId === 'hermes') {
       const health = await probeHermesChannelHealth(config, bridgeAuthToken, {
         timeoutMs: 3_000,

--- a/packages/cli/src/daemon/local-agents.ts
+++ b/packages/cli/src/daemon/local-agents.ts
@@ -1071,6 +1071,9 @@ export async function refreshLocalAgentIntegrationFromUi(
     const health = await probePrimeAgentChannelHealth(bridgeAuthToken, { timeoutMs: 3_000 });
     const live = health.sessions.find((session) => session.sessionId === health.target)
       ?? health.sessions[0];
+    // Keep the UI conversation pin on the descriptor-order head, matching the
+    // Connect path. The health probe may fall through to an older survivor for
+    // transport readiness without silently moving the operator to that chat.
     const metadata = {
       sessionCount: health.sessionCount,
       activeSessionId: health.sessions[0]?.sessionId ?? null,
@@ -1092,47 +1095,6 @@ export async function refreshLocalAgentIntegrationFromUi(
     });
   }
   if (normalizedId !== 'openclaw') {
-    if (normalizedId === 'prime-agent') {
-      // A Prime bridge is session-scoped: connecting the integration before a
-      // session exists stores the expected degraded/idle state, but that state
-      // must not become sticky after a session starts. Refresh discovery and
-      // persist the elected live bridge just like the initial Connect flow.
-      const health = await probePrimeAgentChannelHealth(bridgeAuthToken, {
-        timeoutMs: 3_000,
-      });
-      const live = health.sessions.find((session) => session.sessionId === health.target)
-        ?? health.sessions[0];
-
-      if (health.ok && live) {
-        return updateLocalAgentIntegration(config, normalizedId, {
-          transport: transportPatchFromPrimeAgentTarget(targetFromDescriptor(live)),
-          runtime: {
-            status: 'ready',
-            ready: true,
-            lastError: null,
-          },
-          metadata: {
-            sessionCount: health.sessionCount,
-            activeSessionId: live.sessionId,
-          },
-        });
-      }
-
-      return updateLocalAgentIntegration(config, normalizedId, {
-        runtime: {
-          status: 'degraded',
-          ready: false,
-          lastError: health.error ?? 'no live Prime Agent session',
-        },
-        metadata: {
-          sessionCount: health.sessionCount,
-          // Metadata is merged, so null explicitly retires a session elected
-          // by an earlier refresh instead of leaving a stale route in config.
-          activeSessionId: null,
-        },
-      });
-    }
-
     if (normalizedId === 'hermes') {
       const health = await probeHermesChannelHealth(config, bridgeAuthToken, {
         timeoutMs: 3_000,

--- a/packages/cli/test/daemon-prime-agent.test.ts
+++ b/packages/cli/test/daemon-prime-agent.test.ts
@@ -673,6 +673,23 @@ describe('refresh from the Node UI', () => {
     expect(result.metadata).toMatchObject({ sessionCount: 1, activeSessionId: 's1' });
   });
 
+  it('refreshes transport through a survivor without moving the UI conversation pin', async () => {
+    const head = await startStubBridge({ sessionId: 'head', healthSessionId: 'recycled-port' });
+    const survivor = await startStubBridge({ sessionId: 'survivor' });
+    writeDescriptor('head', head.url, process.pid, '2026-08-07T12:00:00.000Z');
+    writeDescriptor('survivor', survivor.url, process.pid, '2026-08-07T11:00:00.000Z');
+    const config = enabledConfig();
+
+    const result = await refreshLocalAgentIntegrationFromUi(config, 'prime-agent', 'bridge-token');
+
+    expect(result.runtime).toMatchObject({ status: 'ready', ready: true, lastError: null });
+    expect(result.transport).toMatchObject({
+      kind: 'prime-agent-channel',
+      bridgeUrl: survivor.url,
+    });
+    expect(result.metadata).toMatchObject({ sessionCount: 2, activeSessionId: 'head' });
+  });
+
   it('returns Prime to idle and clears a stale elected session when none is live', async () => {
     const config = makeConfig({
       localAgentIntegrations: {

--- a/packages/cli/test/daemon-prime-agent.test.ts
+++ b/packages/cli/test/daemon-prime-agent.test.ts
@@ -16,7 +16,10 @@ import {
 } from '../src/daemon/prime-agent.js';
 import { handlePrimeAgentRoutes } from '../src/daemon/routes/prime-agent.js';
 import { handleLocalAgentsRoutes } from '../src/daemon/routes/local-agents.js';
-import { connectLocalAgentIntegrationFromUi } from '../src/daemon/local-agents.js';
+import {
+  connectLocalAgentIntegrationFromUi,
+  refreshLocalAgentIntegrationFromUi,
+} from '../src/daemon/local-agents.js';
 
 // The setup entry pulls in the adapter's runtime; the daemon only ever calls it
 // on disconnect, and none of these tests exercise that path.
@@ -561,6 +564,60 @@ describe('connect from the Node UI', () => {
 
     expect(result.integration.runtime?.status).toBe('error');
     expect(result.integration.runtime?.lastError).toContain('not writable');
+  });
+});
+
+describe('refresh from the Node UI', () => {
+  it('promotes a previously idle Prime integration when a live session appears', async () => {
+    const bridge = await startStubBridge({ sessionId: 's1' });
+    writeDescriptor('s1', bridge.url);
+    const config = makeConfig({
+      localAgentIntegrations: {
+        'prime-agent': {
+          enabled: true,
+          capabilities: { localChat: true },
+          transport: { kind: 'prime-agent-channel' },
+          runtime: {
+            status: 'degraded',
+            ready: false,
+            lastError: 'no live Prime Agent session',
+          },
+          metadata: { sessionCount: 0 },
+        },
+      },
+    } as Partial<DkgConfig>);
+
+    const result = await refreshLocalAgentIntegrationFromUi(config, 'prime-agent', 'bridge-token');
+
+    expect(result.runtime).toMatchObject({ status: 'ready', ready: true, lastError: null });
+    expect(result.transport).toMatchObject({ kind: 'prime-agent-channel', bridgeUrl: bridge.url });
+    expect(result.metadata).toMatchObject({ sessionCount: 1, activeSessionId: 's1' });
+  });
+
+  it('returns Prime to idle and clears a stale elected session when none is live', async () => {
+    const config = makeConfig({
+      localAgentIntegrations: {
+        'prime-agent': {
+          enabled: true,
+          capabilities: { localChat: true },
+          transport: {
+            kind: 'prime-agent-channel',
+            bridgeUrl: 'http://127.0.0.1:4321',
+          },
+          runtime: { status: 'ready', ready: true, lastError: null },
+          metadata: { sessionCount: 1, activeSessionId: 'old-session' },
+        },
+      },
+    } as Partial<DkgConfig>);
+
+    const result = await refreshLocalAgentIntegrationFromUi(config, 'prime-agent', 'bridge-token');
+
+    expect(result.runtime).toMatchObject({
+      status: 'degraded',
+      ready: false,
+      lastError: 'no live Prime Agent session',
+    });
+    expect(result.metadata).toMatchObject({ sessionCount: 0, activeSessionId: null });
   });
 });
 

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/PanelRightContainer.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/PanelRightContainer.tsx
@@ -28,7 +28,12 @@ import { buildChatContextEntries } from './chat-context.js';
 import { ADD_AGENT_TAB_ID, STATIC_DEFAULT_LOCAL_AGENT_HISTORY_INTEGRATIONS } from './constants.js';
 import { formatLocalTimestamp, toIsoTimestamp } from './format.js';
 import { formatLocalAgentErrorMessage } from './local-agent-errors.js';
-import { adoptLocalAgentTurnId, mapHistoryMessage, mergeLocalAgentMessages } from './messages.js';
+import {
+  adoptLocalAgentTurnId,
+  buildLiveFailedTurnDisplay,
+  mapHistoryMessage,
+  mergeLocalAgentMessages,
+} from './messages.js';
 import { ConnectedAgentsTab } from './ConnectedAgentsTab.js';
 import { NetworkTab } from './NetworkTab.js';
 import { SessionsTab } from './SessionsTab.js';
@@ -602,15 +607,14 @@ export function PanelRight() {
       const failureReason = isUserAbort ? 'Request cancelled.' : formatLocalAgentErrorMessage(integration, err);
       const failureContent = isUserAbort ? failureReason : `Error: ${failureReason}`;
       if (assistantId) {
+        const failedDisplay = buildLiveFailedTurnDisplay(assistantPartialText, failureContent);
         updateLocalMessages(conversationKey, (prev) =>
           prev.map((message) =>
             message.id === assistantId
               ? {
                   ...message,
-                  content: assistantPartialText,
-                  failureNotice: failureContent,
+                  ...failedDisplay,
                   streaming: false,
-                  synthesized: !assistantPartialText,
                 }
               : message,
           ),

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/messages.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/messages.tsx
@@ -43,6 +43,25 @@ function buildFailedTurnDisplay(
   return { content: '', failureNotice: failureContent, synthesized: true };
 }
 
+/**
+ * Build the terminal display for a failure observed by the live stream.
+ *
+ * A failure before the first token used to leave the assistant row dependent
+ * on the optional `failureNotice` side channel. Keeping the actionable error
+ * as the row's primary synthetic content makes the terminal state durable
+ * across re-renders, integration refreshes, and renderers that only consume
+ * `content`. Partial real output still keeps markdown and gets a separate
+ * plaintext failure notice.
+ */
+export function buildLiveFailedTurnDisplay(
+  partialText: string,
+  failureContent: string,
+): Pick<LocalAgentMessage, 'content' | 'failureNotice' | 'synthesized'> {
+  return partialText
+    ? { content: partialText, failureNotice: failureContent, synthesized: false }
+    : { content: failureContent, synthesized: true };
+}
+
 export function mapHistoryMessage(message: LocalAgentHistoryMessage, integrationId = ''): LocalAgentMessage {
   const author = message.author.toLowerCase();
   const role: LocalAgentMessage['role'] = author.includes('assistant') || author.includes('agent') ? 'assistant' : 'user';
@@ -205,4 +224,3 @@ export function renderMessageContent(
     </span>
   );
 }
-

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -584,6 +584,77 @@ describe('PanelRight component', () => {
     container.remove();
   });
 
+  it('renders a terminal Prime provider failure before the first token and releases the composer', async () => {
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+    const { LocalAgentApiError } = await import('../src/ui/api.js');
+
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [{
+      id: 'prime-agent',
+      name: 'Prime Agent',
+      description: 'Prime Agent bridge',
+      connectSupported: true,
+      chatSupported: true,
+      chatReady: true,
+      chatAttachments: false,
+      persistentChat: true,
+      bridgeOnline: true,
+      bridgeStatusLabel: 'Connected',
+      configured: true,
+      detected: true,
+      status: 'connected',
+      statusLabel: 'Connected',
+      detail: 'ready',
+      target: 'bridge',
+    }] });
+    streamLocalAgentChatMock.mockRejectedValueOnce(new LocalAgentApiError(
+      'Prime Agent provider authentication failed.',
+      {
+        code: 'PRIME_AGENT_PROVIDER_UNAUTHORIZED',
+        source: 'prime-agent-channel',
+        correlationId: 'corr-prime-auth',
+      },
+    ));
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      valueSetter?.call(textarea, 'Use the provider');
+      textarea!.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const sendButton = container.querySelector('button[aria-label="Send message"]') as HTMLButtonElement | null;
+    expect(sendButton).toBeTruthy();
+    await act(async () => {
+      sendButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(container.textContent).toContain(
+        'Error: Prime Agent provider authentication failed. Check its provider credentials and try again.',
+      );
+      expect(container.textContent).not.toContain('Thinking…');
+      expect((container.querySelector('textarea') as HTMLTextAreaElement).disabled).toBe(false);
+    });
+    expect(persistLocalAgentChatFailureMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   it('imports skipped chat attachments as context entries and clears the composer after send', async () => {
     importFileMock.mockResolvedValue({
       assertionUri: 'urn:dkg:assertion:epub',


### PR DESCRIPTION
## Summary

- Re-probe Prime Agent's live session bridge during UI refresh so an integration connected while idle becomes `ready` as soon as a session starts, and stale session routing is cleared when no session remains.
- Treat a bridge-owned provider failure finalized only at Prime Agent's `message_end` boundary as a sanitized terminal result, replace the retry-triggering diagnostic with a lifecycle marker, and prevent Prime's hidden credential retry from duplicating the failed turn.
- Render failures that happen before the first token as durable assistant content and release the composer so the next UI turn can be sent immediately.

## Related work

- Fixes #2134
- Fixes #2135
- Fixes #2121

## Lifecycle

```mermaid
flowchart LR
  subgraph Before
    A[Provider failure finalized at message_end] --> B[Bridge resolves an empty answer at agent_end]
    B --> C[Blank assistant row]
    A --> D[Prime keeps the provider failure diagnostic]
    D --> E[Hidden retry and blocked next turn]
  end

  subgraph After
    F[Provider failure finalized at message_end] --> G[Bridge returns a sanitized terminal error]
    G --> H[Visible assistant error and enabled composer]
    F --> I[Terminal lifecycle marker replaces retryable diagnostic]
    I --> J[No hidden retry and next turn admitted]
  end
```

## Files changed

| Area | Change |
| --- | --- |
| Prime Agent bridge | Finalize provider errors at both incremental and finalized-message boundaries, sanitize persisted errors, and mark bridge-owned failures non-retryable. |
| Daemon integration refresh | Discover and persist the elected live Prime bridge; retire a stale active session when none is live. |
| Node UI chat | Keep a pre-token failure in primary message content and end the streaming state. |
| Tests | Add finalized-only provider error, refresh transition, stale session cleanup, visible failure, and composer recovery regressions. |

## Test plan

- `pnpm --dir packages/adapter-prime-agent test` — 79 passed
- `pnpm exec vitest run test/daemon-prime-agent.test.ts` from `packages/cli` — 26 passed
- `pnpm --dir packages/node-ui test` — 2,204 passed, 38 skipped
- `pnpm run build:packages` — 23 package builds passed
- `pnpm --dir packages/node-ui build:ui` — production UI build passed
- Real Node UI canary against Prime Agent 0.7 with intentionally invalid provider credentials:
  - first failure rendered as an actionable assistant error, not a blank row;
  - the Prime session recorded exactly one sanitized assistant failure with `agent_lifecycle_failure` and no hidden retry;
  - a second turn was accepted immediately and rendered its own terminal failure;
  - live integration refresh reported `ready`, the current bridge URL, and the active session.
