### PR TITLE
feat(node-ui): add connecting orb to thinking state

### DIFF
--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -40,6 +40,7 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",
+    "thinking-orbs": "^0.2.0",
     "viem": "^2.53.1",
     "zod": "^3.25.76",
     "zustand": "^5.0.12"

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/messages.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/messages.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ThinkingOrb } from 'thinking-orbs';
 import type { LocalAgentHistoryMessage } from '../../../api.js';
 import { MarkdownMessage } from '../../chat/MarkdownMessage.js';
 import { buildAttachmentSummary } from './attachments.js';
@@ -166,7 +167,14 @@ export function renderMessageContent(
   if (role === 'assistant' && streaming && normalized.trim() === '' && !normalizedFailure) {
     return (
       <span className="v10-chat-thinking" role="status" aria-live="polite">
-        Thinking…
+        <ThinkingOrb
+          aria-hidden="true"
+          className="v10-chat-thinking-orb"
+          state="connecting"
+          size={20}
+          theme="auto"
+        />
+        <span>Thinking…</span>
       </span>
     );
   }
@@ -205,4 +213,3 @@ export function renderMessageContent(
     </span>
   );
 }
-

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/messages.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/messages.tsx
@@ -171,7 +171,8 @@ export function renderMessageContent(
           aria-hidden="true"
           className="v10-chat-thinking-orb"
           state="connecting"
-          size={20}
+          size={64}
+          style={{ width: 28, height: 28 }}
           theme="auto"
         />
         <span>Thinking…</span>

--- a/packages/node-ui/src/ui/components/Shell/PanelRight/messages.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight/messages.tsx
@@ -161,7 +161,7 @@ export function renderMessageContent(
   // true, content: '' }`. The inline streaming caret lives inside the
   // last text node, so with no content yet there is nothing to anchor
   // it to and the row would render blank. Show an explicit animated
-  // "Thinking…" indicator until the first token arrives, at which
+  // "Connecting dots..." indicator until the first token arrives, at which
   // point this falls through to the markdown path (whose inline caret
   // then takes over). `role=status`/`aria-live` announces it to AT.
   if (role === 'assistant' && streaming && normalized.trim() === '' && !normalizedFailure) {
@@ -175,7 +175,7 @@ export function renderMessageContent(
           style={{ width: 28, height: 28 }}
           theme="auto"
         />
-        <span>Thinking…</span>
+        <span>Connecting dots...</span>
       </span>
     );
   }

--- a/packages/node-ui/src/ui/lib/applyTheme.ts
+++ b/packages/node-ui/src/ui/lib/applyTheme.ts
@@ -1,6 +1,7 @@
 /**
- * Toggles the `light` class on BOTH `<html>` (documentElement) and
- * `<body>`. The `<html>`-level toggle is what BUG-004 fixed: `:root`
+ * Publishes the active theme on `<html>` and toggles the `light` class
+ * on BOTH `<html>` (documentElement) and `<body>`. The `<html>`-level
+ * class toggle is what BUG-004 fixed: `:root`
  * defines `--bg-root: #000000`, and the `html, body, #root { background:
  * var(--bg-root) }` rule applies that variable to `<html>` first. Putting
  * the override class on `<body>` alone re-cascaded the variable to the
@@ -8,12 +9,18 @@
  * flashed a black strip in light mode. We keep `body.light` as well so
  * pre-rc.11 selectors (`body.light .v10-modal-box`, etc.) still apply.
  *
- * Pulling the toggle into a pure helper lets a unit test pin the
- * contract: a regression that drops the documentElement half — or starts
- * applying `.light` to one and `.dark` to the other — fails immediately.
+ * The explicit `data-theme` marker is also the integration boundary for
+ * auto-themed child components. Dark mode used to be represented only by
+ * the absence of `.light`, which made those components fall back to the OS
+ * preference instead of the app's saved theme.
+ *
+ * Pulling the update into a pure helper lets a unit test pin both contracts:
+ * the CSS class stays synchronized across `<html>` / `<body>`, and the root
+ * always exposes the selected theme to descendants.
  */
 export function applyTheme(theme: 'light' | 'dark', doc: Document = document): void {
   const isLight = theme === 'light';
+  doc.documentElement.setAttribute('data-theme', theme);
   doc.documentElement.classList.toggle('light', isLight);
   doc.body.classList.toggle('light', isLight);
 }

--- a/packages/node-ui/src/ui/styles/08-markdown.css
+++ b/packages/node-ui/src/ui/styles/08-markdown.css
@@ -301,16 +301,22 @@
   vertical-align: text-bottom;
 }
 
-/* Pre-first-token "thinking" indicator (ChatGPT-style sheen sweep).
+/* Pre-first-token "thinking" indicator (inline connecting orb + subtle sheen).
    `color: var(--text-secondary)` is declared first as the graceful
    fallback — if `background-clip: text` is unsupported the word still
    shows at the AA-clearing secondary tone (5.58:1 dark / 7.17:1
    light). The animated highlight only sweeps brighter (toward
    --text-primary), so contrast never drops below the base. */
 .v10-chat-thinking {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   font-size: 13px;
+  line-height: 20px;
   color: var(--text-secondary);
+}
+
+.v10-chat-thinking > span {
   background: linear-gradient(
     90deg,
     var(--text-secondary) 0%,
@@ -325,6 +331,12 @@
   -webkit-text-fill-color: transparent;
   animation: v10-thinking-sheen 1.6s ease-in-out infinite;
 }
+
+.v10-chat-thinking-orb {
+  flex: 0 0 20px;
+  opacity: 0.86;
+}
+
 @keyframes v10-thinking-sheen {
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
@@ -332,6 +344,9 @@
 @media (prefers-reduced-motion: reduce) {
   /* Static, fully legible — no sweep. */
   .v10-chat-thinking {
+    gap: 6px;
+  }
+  .v10-chat-thinking > span {
     animation: none;
     background: none;
     -webkit-text-fill-color: var(--text-secondary);

--- a/packages/node-ui/src/ui/styles/08-markdown.css
+++ b/packages/node-ui/src/ui/styles/08-markdown.css
@@ -310,9 +310,9 @@
 .v10-chat-thinking {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   font-size: 13px;
-  line-height: 20px;
+  line-height: 28px;
   color: var(--text-secondary);
 }
 
@@ -333,7 +333,7 @@
 }
 
 .v10-chat-thinking-orb {
-  flex: 0 0 20px;
+  flex: 0 0 28px;
   opacity: 0.86;
 }
 

--- a/packages/node-ui/test/apply-theme.test.ts
+++ b/packages/node-ui/test/apply-theme.test.ts
@@ -14,28 +14,34 @@ import { applyTheme } from '../src/ui/lib/applyTheme.js';
  *   - dark   → neither element carries the `light` class
  *   - toggling back to dark must remove the class from BOTH (no orphan
  *     class on `<html>` after a dark→light→dark cycle)
+ *   - `<html>` always carries `data-theme="light|dark"` so auto-themed
+ *     descendants follow the app setting instead of the OS preference
  */
 describe('applyTheme (BUG-004)', () => {
   beforeEach(() => {
     document.documentElement.classList.remove('light');
     document.body.classList.remove('light');
+    document.documentElement.removeAttribute('data-theme');
   });
 
   afterEach(() => {
     document.documentElement.classList.remove('light');
     document.body.classList.remove('light');
+    document.documentElement.removeAttribute('data-theme');
   });
 
   it('light: adds .light to BOTH documentElement AND body', () => {
     applyTheme('light');
     expect(document.documentElement.classList.contains('light')).toBe(true);
     expect(document.body.classList.contains('light')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 
-  it('dark: ensures NEITHER element carries .light (clean dark baseline)', () => {
+  it('dark: keeps the clean no-.light baseline and publishes an explicit root marker', () => {
     applyTheme('dark');
     expect(document.documentElement.classList.contains('light')).toBe(false);
     expect(document.body.classList.contains('light')).toBe(false);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 
   it('dark→light→dark: cleanly removes the class from documentElement (the BUG-004 reproducer)', () => {
@@ -47,6 +53,7 @@ describe('applyTheme (BUG-004)', () => {
     // so the rubber-band area kept a stale background colour.
     expect(document.documentElement.classList.contains('light')).toBe(false);
     expect(document.body.classList.contains('light')).toBe(false);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 
   it('idempotent: applying the same theme twice does not stack duplicate tokens', () => {
@@ -84,8 +91,10 @@ describe('applyTheme (BUG-004)', () => {
     applyTheme('light', fakeDoc);
     expect(fakeHtml.classList.contains('light')).toBe(true);
     expect(fakeBody.classList.contains('light')).toBe(true);
+    expect(fakeHtml.getAttribute('data-theme')).toBe('light');
     // The real document must NOT have been touched.
     expect(document.documentElement.classList.contains('light')).toBe(false);
     expect(document.body.classList.contains('light')).toBe(false);
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
   });
 });

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -519,6 +519,7 @@ describe('ConnectedAgentsTab rendering', () => {
       localSending: true,
     });
     expect(markup).toContain('v10-chat-thinking');
+    expect(markup).toContain('v10-chat-thinking-orb');
     expect(markup).toContain('Thinking');
     expect(markup).toContain('role="status"');
     // No inline caret yet — there is no text node to anchor it to.

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -510,7 +510,7 @@ describe('ConnectedAgentsTab rendering', () => {
     expect(markup).not.toContain('aria-label="Uploading attachments"');
   });
 
-  it('shows the animated "Thinking…" indicator while an assistant turn is streaming with no content yet (PR5)', () => {
+  it('shows the animated "Connecting dots..." indicator while an assistant turn is streaming with no content yet (PR5)', () => {
     const markup = renderConnectedAgentsTab({
       localMessages: [
         { id: 'u', role: 'user', content: 'give me some friday ideas', ts: '10:00' },
@@ -520,7 +520,7 @@ describe('ConnectedAgentsTab rendering', () => {
     });
     expect(markup).toContain('v10-chat-thinking');
     expect(markup).toContain('v10-chat-thinking-orb');
-    expect(markup).toContain('Thinking');
+    expect(markup).toContain('Connecting dots...');
     expect(markup).toContain('role="status"');
     // No inline caret yet — there is no text node to anchor it to.
     expect(markup).not.toContain('v10-chat-cursor');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1055,6 +1055,9 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      thinking-orbs:
+        specifier: ^0.2.0
+        version: 0.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       viem:
         specifier: ^2.53.1
         version: 2.53.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -6403,6 +6406,12 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thinking-orbs@0.2.0:
+    resolution: {integrity: sha512-CQux/YsLlB9nY60BDpZ/uW7knAvXg+U2T/gzrzuLRw8xlzfJPLXZxAg2tbbIBGp/nE2Kol1GfbMOJnoH+tcb/A==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   three-forcegraph@1.43.4:
     resolution: {integrity: sha512-FtmiZP/T16ZQaHza3JDaDn0YTXFtg9e7pGnTeU8nzu0NNkx7MpWbF/GvmpbQsWHx3rukHtkRv1fTorLPB3FDEA==}
@@ -13136,6 +13145,11 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thinking-orbs@0.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   three-forcegraph@1.43.4(three@0.184.0):
     dependencies:


### PR DESCRIPTION
## Summary
- adds the MIT `thinking-orbs` package to the Node UI
- renders the `connecting` inline orb next to the pre-token `Thinking…` status
- keeps the existing accessible status text and updates the focused render test

## Validation
- `pnpm exec vitest run packages/node-ui/test/panel-right.logic.test.ts`
- `pnpm -r --filter @origintrail-official/dkg-node-ui... run build`
- `pnpm --filter @origintrail-official/dkg-node-ui build:ui`