### PR TITLE
test(prime-agent): remove hard-timeout bridge race

### DIFF
--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -582,7 +582,7 @@ describe('/send', () => {
       headers: authed(),
       body: JSON.stringify({ text: 'hung turn', correlationId: 'c-hard-timeout' }),
     });
-    await new Promise((r) => setTimeout(r, 10));
+    await until(() => sent.length === 1);
     startBridgeRun({
       sessionManager: { getSessionId: () => 'sess-hard-timeout' },
       abort: () => { abortCount += 1; },


### PR DESCRIPTION
## Summary

Makes the Prime Agent hard-timeout bridge test wait for the observable prompt-injection boundary instead of assuming the loopback HTTP request completes within 10 ms.

This is a test-only, one-line change. Runtime behavior is unchanged.

## Failure mechanism

The `uses a separate hard limit to abort and release a turn that never emits agent_end` test started `fetch(/send)`, slept for 10 ms, then called `startBridgeRun()`. Under load, the request had not yet reached `sendUserMessage`, so `sent` was empty and the harness threw:

```text
startBridgeRun(): no injected prompt
```

The later `ECONNRESET` was a teardown consequence. The file already provides `until()` specifically because fixed sleeps race the loopback round trip, and the same test uses that barrier for its successor request.

Failed canary job: https://github.com/OriginTrail/dkg/actions/runs/31176749760/job/92860927271

## Change

```ts
await until(() => sent.length === 1);
```

This waits on the exact side effect required by `startBridgeRun()` while retaining the existing bounded 2-second failure deadline.

## Validation

- focused hard-timeout case: 15/15 consecutive runs passed
- complete `@origintrail-official/dkg-adapter-prime-agent` suite: 4 files, 88 tests passed
- extension TypeScript build: passed
- `git diff --check`: passed

The initial fresh-worktree package run could not resolve `@origintrail-official/dkg-core` because its `dist` output was absent. After building the minimal `rdf-utils -> core` dependency chain, the full package suite passed; this is the expected local prerequisite and is unrelated to the edit.

## Release relationship

Merge this into `testnet-canary` before the 10.0.13 promotion. Promotion PR #2142 will then pick up the new canary head and rerun its merge-candidate gates.
