### PR TITLE
fix(sync): require durable VM readiness for completion

### DIFF
--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -240,6 +240,32 @@ export function missingMetadataReadinessPatches(): MissingMetadataReadinessPatch
   };
 }
 
+interface ContextGraphPlaneReadinessVerdict {
+  /** Compatibility/write-readiness: either persisted usable plane opens the graph. */
+  readonly writeReady: boolean;
+  /** Catch-up completion: durable VM plus SWM when the caller requested it. */
+  readonly requestedPlanesVerified: boolean;
+  readonly missingRequestedDurable: boolean;
+  readonly missingRequestedSharedMemory: boolean;
+}
+
+function contextGraphPlaneReadinessVerdict(input: {
+  durableVerified: boolean;
+  sharedMemoryVerified: boolean;
+  includeSharedMemory: boolean;
+}): ContextGraphPlaneReadinessVerdict {
+  const missingRequestedDurable = !input.durableVerified;
+  const missingRequestedSharedMemory =
+    input.includeSharedMemory && !input.sharedMemoryVerified;
+  return {
+    writeReady: input.durableVerified || input.sharedMemoryVerified,
+    requestedPlanesVerified:
+      !missingRequestedDurable && !missingRequestedSharedMemory,
+    missingRequestedDurable,
+    missingRequestedSharedMemory,
+  };
+}
+
 export function classifyExistingContextGraphReadiness(input: {
   subscription: ContextGraphSubscriptionReadinessState;
   readiness: ContextGraphReadinessProvenance;
@@ -252,15 +278,18 @@ export function classifyExistingContextGraphReadiness(input: {
 } {
   const currentReadinessProvenance =
     input.readiness.version >= CONTEXT_GRAPH_READINESS_VERSION;
-  const overallReadinessVerified =
-    input.readiness.durableVerified || input.readiness.sharedMemoryVerified;
-  const requestedPlanesVerified =
-    currentReadinessProvenance &&
-    overallReadinessVerified &&
-    (!input.includeSharedMemory || input.readiness.sharedMemoryVerified);
+  const durableVerified =
+    currentReadinessProvenance && input.readiness.durableVerified;
+  const sharedMemoryVerified =
+    currentReadinessProvenance && input.readiness.sharedMemoryVerified;
+  const planeReadiness = contextGraphPlaneReadinessVerdict({
+    durableVerified,
+    sharedMemoryVerified,
+    includeSharedMemory: input.includeSharedMemory,
+  });
   const alreadyReady =
     input.hasConfirmedMeta &&
-    requestedPlanesVerified &&
+    planeReadiness.requestedPlanesVerified &&
     input.subscription.synced === true &&
     (!input.includeSharedMemory || input.subscription.sharedMemorySynced === true);
 
@@ -286,16 +315,11 @@ export function classifyExistingContextGraphReadiness(input: {
     };
   }
 
-  const durableVerified =
-    currentReadinessProvenance && input.readiness.durableVerified;
-  const sharedMemoryVerified =
-    currentReadinessProvenance && input.readiness.sharedMemoryVerified;
-  const overallVerified = durableVerified || sharedMemoryVerified;
   const statePatch =
-    input.subscription.synced !== overallVerified ||
+    input.subscription.synced !== planeReadiness.writeReady ||
     input.subscription.sharedMemorySynced !== sharedMemoryVerified
       ? {
-          synced: overallVerified,
+          synced: planeReadiness.writeReady,
           sharedMemorySynced: sharedMemoryVerified,
           metaSynced: true,
           pendingMeta: false,
@@ -536,16 +560,23 @@ export function classifyContextGraphCatchupReadiness(input: {
     // it derives `synced` from the persisted provenance and patches the row
     // back into line, so letting them diverge here would be corrected away on
     // the next pass anyway — after a window in which the graph looked writable.
-    const overallVerifiedPersisted = durableVerifiedPersisted || sharedMemoryVerifiedPersisted;
-    // Durable VM is part of every catch-up request. Shared-memory proof may
-    // make the subscription usable, but it must never make the request itself
-    // report `done` while finalized VM is still incomplete. This distinction
-    // matters for mixed SWM/VM callers: `statePatch.synced` remains the
-    // compatibility/write-readiness bit below, while `jobStatus` truthfully
-    // covers every requested plane.
-    const missingRequestedDurable = !durableVerified;
-    const missingRequestedSharedMemory =
-      input.includeSharedMemory && !sharedMemoryVerified;
+    const persistedPlaneReadiness = contextGraphPlaneReadinessVerdict({
+      durableVerified: durableVerifiedPersisted,
+      sharedMemoryVerified: sharedMemoryVerifiedPersisted,
+      includeSharedMemory: input.includeSharedMemory,
+    });
+    // Use the same requested-plane contract as the pre-catch-up fast path so
+    // SWM-only provenance can never synthesize or terminate a `done` job while
+    // finalized VM remains unverified.
+    const planeReadiness = contextGraphPlaneReadinessVerdict({
+      durableVerified,
+      sharedMemoryVerified,
+      includeSharedMemory: input.includeSharedMemory,
+    });
+    const {
+      missingRequestedDurable,
+      missingRequestedSharedMemory,
+    } = planeReadiness;
     const madeIncompleteProgress =
       (durableDataProgress && !durableReadyThisRun) ||
       (sharedMemoryProgress && !sharedMemoryReadyThisRun);
@@ -581,7 +612,7 @@ export function classifyContextGraphCatchupReadiness(input: {
       jobStatus,
       error,
       statePatch: {
-        synced: overallVerifiedPersisted,
+        synced: persistedPlaneReadiness.writeReady,
         sharedMemorySynced: sharedMemoryVerifiedPersisted,
         metaSynced: true,
         pendingMeta: false,

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -537,8 +537,13 @@ export function classifyContextGraphCatchupReadiness(input: {
     // back into line, so letting them diverge here would be corrected away on
     // the next pass anyway — after a window in which the graph looked writable.
     const overallVerifiedPersisted = durableVerifiedPersisted || sharedMemoryVerifiedPersisted;
-    const overallVerified = durableVerified || sharedMemoryVerified;
-    const missingGraphProof = !overallVerified;
+    // Durable VM is part of every catch-up request. Shared-memory proof may
+    // make the subscription usable, but it must never make the request itself
+    // report `done` while finalized VM is still incomplete. This distinction
+    // matters for mixed SWM/VM callers: `statePatch.synced` remains the
+    // compatibility/write-readiness bit below, while `jobStatus` truthfully
+    // covers every requested plane.
+    const missingRequestedDurable = !durableVerified;
     const missingRequestedSharedMemory =
       input.includeSharedMemory && !sharedMemoryVerified;
     const madeIncompleteProgress =
@@ -547,7 +552,7 @@ export function classifyContextGraphCatchupReadiness(input: {
 
     let jobStatus: ContextGraphCatchupReadinessClassification['jobStatus'] = 'done';
     let error: string | undefined;
-    if (missingGraphProof || missingRequestedSharedMemory) {
+    if (missingRequestedDurable || missingRequestedSharedMemory) {
       jobStatus = 'unreachable';
       if (madeIncompleteProgress) {
         // The base sentence is byte-identical to what it has always been; the
@@ -561,8 +566,10 @@ export function classifyContextGraphCatchupReadiness(input: {
             result.diagnostics?.sharedMemory?.continuationPasses,
             result.diagnostics?.sharedMemory?.continuationStopReason,
           );
-      } else if (input.isPrivate && missingGraphProof) {
+      } else if (input.isPrivate && missingRequestedDurable && !sharedMemoryVerified) {
         error = 'No authorized context-graph peer delivered verified durable or shared-memory data — empty or metadata-only responses cannot prove a private graph is fully synchronized, and the curator may be offline.';
+      } else if (input.isPrivate && missingRequestedDurable) {
+        error = 'Shared-memory context-graph data synchronized, but durable VM catch-up did not complete. Retry to finish finalized VM synchronization.';
       } else if (input.isPrivate) {
         error = 'Durable context-graph data synchronized, but shared-memory catch-up did not complete. Retry to finish shared-memory synchronization.';
       } else {

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -191,6 +191,78 @@ describe('context graph catch-up readiness classification', () => {
     expect(classification.eventPayload).toBeUndefined();
   });
 
+  it('does not let clean shared memory mask incomplete durable VM', () => {
+    const result = mixedPeerResult(0);
+    result.denied = false;
+    result.deniedPeers = 0;
+    result.peersSucceeded = 1;
+    result.sharedMemorySynced = 7;
+    result.cleanPlaneCompletions!.sharedMemory.verifiedDataPeers = 1;
+    result.diagnostics!.sharedMemory.fetchedDataTriples = 7;
+    result.diagnostics!.sharedMemory.insertedDataTriples = 7;
+    result.diagnostics!.sharedMemory.completedPhases = 1;
+
+    const classification = classifyContextGraphCatchupReadiness({
+      result,
+      includeSharedMemory: true,
+      hasConfirmedMeta: true,
+      isPrivate: false,
+      readinessBeforeCatchup,
+    });
+
+    expect(classification).toMatchObject({
+      jobStatus: 'unreachable',
+      statePatch: {
+        // The existing compatibility/write-readiness bit may be opened by a
+        // persisted usable plane; the terminal job verdict may not.
+        synced: true,
+        sharedMemorySynced: true,
+      },
+      readinessPatch: {
+        durableVerified: false,
+        sharedMemoryVerified: true,
+      },
+      eventPayload: {
+        dataSynced: 0,
+        sharedMemorySynced: 7,
+      },
+    });
+    expect(classification.error).toContain('incomplete plane remains unready');
+  });
+
+  it('does not let previously verified shared memory mask a later durable-only request', () => {
+    const result = mixedPeerResult(0);
+    result.dataSynced = 0;
+    result.denied = false;
+    result.deniedPeers = 0;
+    result.peersSucceeded = 1;
+    result.diagnostics!.durable.fetchedDataTriples = 0;
+    result.diagnostics!.durable.insertedDataTriples = 0;
+    result.diagnostics!.durable.fetchedMetaTriples = 8;
+    result.diagnostics!.durable.insertedMetaTriples = 8;
+    result.diagnostics!.durable.metaOnlyResponses = 1;
+    result.diagnostics!.durable.timedOutPhases = 0;
+
+    const classification = classifyContextGraphCatchupReadiness({
+      result,
+      includeSharedMemory: false,
+      hasConfirmedMeta: true,
+      isPrivate: false,
+      readinessBeforeCatchup: {
+        version: CONTEXT_GRAPH_READINESS_VERSION,
+        durableVerified: false,
+        sharedMemoryVerified: true,
+        updatedAt: Date.now(),
+      },
+    });
+
+    expect(classification).toMatchObject({
+      jobStatus: 'unreachable',
+      statePatch: { synced: true, sharedMemorySynced: true },
+      readinessPatch: { durableVerified: false, sharedMemoryVerified: true },
+    });
+  });
+
   // Emptiness is only provable as a whole-round verdict: an empty response is
   // byte-identical whether the peer hosts an empty graph or has never heard of
   // it, so a clean-empty peer proves the plane only when NOBODY in the round

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -263,6 +263,40 @@ describe('context graph catch-up readiness classification', () => {
     });
   });
 
+  it('reports the private durable-VM shortfall when SWM was already verified', () => {
+    const result = mixedPeerResult(0);
+    result.dataSynced = 0;
+    result.denied = false;
+    result.deniedPeers = 0;
+    result.peersSucceeded = 1;
+    result.diagnostics!.durable.fetchedDataTriples = 0;
+    result.diagnostics!.durable.insertedDataTriples = 0;
+    result.diagnostics!.durable.fetchedMetaTriples = 8;
+    result.diagnostics!.durable.insertedMetaTriples = 8;
+    result.diagnostics!.durable.metaOnlyResponses = 1;
+    result.diagnostics!.durable.timedOutPhases = 0;
+
+    const classification = classifyContextGraphCatchupReadiness({
+      result,
+      includeSharedMemory: true,
+      hasConfirmedMeta: true,
+      isPrivate: true,
+      readinessBeforeCatchup: {
+        version: CONTEXT_GRAPH_READINESS_VERSION,
+        durableVerified: false,
+        sharedMemoryVerified: true,
+        updatedAt: Date.now(),
+      },
+    });
+
+    expect(classification).toMatchObject({
+      jobStatus: 'unreachable',
+      error: 'Shared-memory context-graph data synchronized, but durable VM catch-up did not complete. Retry to finish finalized VM synchronization.',
+      statePatch: { synced: true, sharedMemorySynced: true },
+      readinessPatch: { durableVerified: false, sharedMemoryVerified: true },
+    });
+  });
+
   // Emptiness is only provable as a whole-round verdict: an empty response is
   // byte-identical whether the peer hosts an empty graph or has never heard of
   // it, so a clean-empty peer proves the plane only when NOBODY in the round

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -64,12 +64,36 @@ function mixedPeerResult(verifiedDataPeers: number): CatchupJobResult {
   };
 }
 
+function durableMetaOnlyResult(): CatchupJobResult {
+  const result = mixedPeerResult(0);
+  result.dataSynced = 0;
+  result.denied = false;
+  result.deniedPeers = 0;
+  result.peersSucceeded = 1;
+  if (!result.diagnostics?.durable) {
+    throw new Error('durable diagnostics missing');
+  }
+  result.diagnostics.durable.fetchedDataTriples = 0;
+  result.diagnostics.durable.insertedDataTriples = 0;
+  result.diagnostics.durable.fetchedMetaTriples = 8;
+  result.diagnostics.durable.insertedMetaTriples = 8;
+  result.diagnostics.durable.metaOnlyResponses = 1;
+  result.diagnostics.durable.timedOutPhases = 0;
+  return result;
+}
+
 describe('context graph catch-up readiness classification', () => {
   const readinessBeforeCatchup = {
     version: 0,
     durableVerified: false,
     sharedMemoryVerified: false,
     updatedAt: 0,
+  };
+  const swmVerifiedReadinessBeforeCatchup = {
+    version: CONTEXT_GRAPH_READINESS_VERSION,
+    durableVerified: false,
+    sharedMemoryVerified: true,
+    updatedAt: 1,
   };
 
   it('uses a clean per-peer completion even when aggregate diagnostics contain denial and timeout', () => {
@@ -231,29 +255,14 @@ describe('context graph catch-up readiness classification', () => {
   });
 
   it('does not let previously verified shared memory mask a later durable-only request', () => {
-    const result = mixedPeerResult(0);
-    result.dataSynced = 0;
-    result.denied = false;
-    result.deniedPeers = 0;
-    result.peersSucceeded = 1;
-    result.diagnostics!.durable.fetchedDataTriples = 0;
-    result.diagnostics!.durable.insertedDataTriples = 0;
-    result.diagnostics!.durable.fetchedMetaTriples = 8;
-    result.diagnostics!.durable.insertedMetaTriples = 8;
-    result.diagnostics!.durable.metaOnlyResponses = 1;
-    result.diagnostics!.durable.timedOutPhases = 0;
+    const result = durableMetaOnlyResult();
 
     const classification = classifyContextGraphCatchupReadiness({
       result,
       includeSharedMemory: false,
       hasConfirmedMeta: true,
       isPrivate: false,
-      readinessBeforeCatchup: {
-        version: CONTEXT_GRAPH_READINESS_VERSION,
-        durableVerified: false,
-        sharedMemoryVerified: true,
-        updatedAt: Date.now(),
-      },
+      readinessBeforeCatchup: swmVerifiedReadinessBeforeCatchup,
     });
 
     expect(classification).toMatchObject({
@@ -264,29 +273,14 @@ describe('context graph catch-up readiness classification', () => {
   });
 
   it('reports the private durable-VM shortfall when SWM was already verified', () => {
-    const result = mixedPeerResult(0);
-    result.dataSynced = 0;
-    result.denied = false;
-    result.deniedPeers = 0;
-    result.peersSucceeded = 1;
-    result.diagnostics!.durable.fetchedDataTriples = 0;
-    result.diagnostics!.durable.insertedDataTriples = 0;
-    result.diagnostics!.durable.fetchedMetaTriples = 8;
-    result.diagnostics!.durable.insertedMetaTriples = 8;
-    result.diagnostics!.durable.metaOnlyResponses = 1;
-    result.diagnostics!.durable.timedOutPhases = 0;
+    const result = durableMetaOnlyResult();
 
     const classification = classifyContextGraphCatchupReadiness({
       result,
       includeSharedMemory: true,
       hasConfirmedMeta: true,
       isPrivate: true,
-      readinessBeforeCatchup: {
-        version: CONTEXT_GRAPH_READINESS_VERSION,
-        durableVerified: false,
-        sharedMemoryVerified: true,
-        updatedAt: Date.now(),
-      },
+      readinessBeforeCatchup: swmVerifiedReadinessBeforeCatchup,
     });
 
     expect(classification).toMatchObject({

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -923,6 +923,39 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     });
   });
 
+  it('does not synthesize done from existing SWM-only provenance when VM is unverified', async () => {
+    const result = await subscribe({
+      hasConfirmedMeta: true,
+      isPrivate: true,
+      includeSharedMemory: false,
+      result: privateSharedMemoryOnlyResult(),
+      readiness: {
+        version: 1,
+        durableVerified: false,
+        sharedMemoryVerified: true,
+      },
+      initial: {
+        subscribed: true,
+        synced: true,
+        sharedMemorySynced: true,
+        metaSynced: true,
+      },
+    });
+
+    expect(result.response.catchup.status).toBe('queued');
+    expect(result.runCalls).toBe(1);
+    expect(result.job.status).toBe('unreachable');
+    expect(result.state).toMatchObject({
+      synced: true,
+      sharedMemorySynced: true,
+      metaSynced: true,
+    });
+    expect(result.readiness).toMatchObject({
+      durableVerified: false,
+      sharedMemoryVerified: true,
+    });
+  });
+
   it('only returns synthetic done when all ready flags include metaSynced=true', async () => {
     const result = await subscribe({
       hasConfirmedMeta: true,

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -758,7 +758,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     });
   });
 
-  it('records clean private shared-memory progress without fabricating durable readiness', async () => {
+  it('records clean private shared-memory progress without reporting VM-complete catch-up', async () => {
     const result = await subscribe({
       hasConfirmedMeta: true,
       isPrivate: true,
@@ -772,8 +772,10 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     });
 
     expect(result.runCalls).toBe(1);
-    expect(result.job.status).toBe('done');
-    expect(result.job.error).toBeUndefined();
+    expect(result.job).toMatchObject({
+      status: 'unreachable',
+      error: expect.stringContaining('durable VM catch-up did not complete'),
+    });
     expect(result.job.result).toMatchObject({
       dataSynced: 0,
       sharedMemorySynced: 4,


### PR DESCRIPTION
## Impact

A mixed SWM/VM catch-up can no longer report `done` merely because shared-memory synchronization succeeded. Finalized VM is requested on every context-graph catch-up, so both the existing-readiness fast path and the terminal job verdict now require durable VM verification, plus SWM verification when SWM was requested.

This keeps the existing subscription compatibility behavior: a previously persisted usable plane can still leave `statePatch.synced` true. The stricter requirement applies to completion, preventing automation and the harness from treating partial convergence as full success.

## Before

```mermaid
sequenceDiagram
    participant R as Receiver
    participant S as SWM provider
    participant V as VM providers
    participant J as Catch-up job
    R->>S: Request shared-memory state
    S-->>R: Verified SWM data
    R->>V: Request finalized VM data
    V-->>R: Incomplete or metadata-only VM responses
    R->>J: SWM verified OR VM verified
    J-->>R: done
```

## After

```mermaid
sequenceDiagram
    participant R as Receiver
    participant S as SWM provider
    participant V as VM providers
    participant J as Catch-up job
    R->>S: Request shared-memory state when selected
    S-->>R: Verified SWM data
    R->>V: Request finalized VM data
    V-->>R: Incomplete or metadata-only VM responses
    R->>J: VM incomplete
    J-->>R: unreachable with retryable evidence
    Note over R,J: done only after VM and requested SWM are verified
```

## Validation

- focused CLI readiness lane: 78/78 passed
- CLI TypeScript: passed
- combined 10.0.14 candidate: ordered runtime build passed
- GitHub CI and merge-queue gates: green
- `git diff --check`: passed

## Release role

This is 10.0.14 increment 1 of 3: truthful VM completion. It does not enable RFC-64 catalogs.