### PR TITLE
fix(agent): continue bounded VM provider recovery

### DIFF
--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -73,11 +73,11 @@ export interface PendingOrdinalRecoveryResult {
    */
   continuationOrdinal: number | undefined;
   /**
-   * Retained provider rotation has an untried peer and should be scheduled
-   * immediately. This is deliberately separate from the ordered scan cursor
-   * so provider retries cannot starve untouched ordinals.
+   * Recovery has bounded work that should be scheduled immediately. This is
+   * deliberately separate from the ordered scan cursor so implementation-
+   * specific retries cannot starve untouched ordinals.
    */
-  hasImmediateProviderWork: boolean;
+  hasImmediateRecoveryWork: boolean;
   /**
    * True only when recovery intentionally skipped networking because its
    * per-CG cooldown is active. This preserves the continuation without
@@ -206,7 +206,7 @@ export async function reconcileContextGraph(
   let recoveryContinuationOrdinal: number | undefined;
   let recoveryAttempted = false;
   let recoveryCooldownOnly = false;
-  let recoveryHasImmediateProviderWork = false;
+  let recoveryHasImmediateWork = false;
   const outstandingBefore = ordinalsToReconcile(state, head);
   const configuredLimit = deps.maxOrdinalsPerPass;
   const passLimit = configuredLimit === undefined
@@ -295,7 +295,7 @@ export async function reconcileContextGraph(
         recoveryContinuationOrdinal = recovery.continuationOrdinal;
         recoveryAttempted = recovery.attemptedOrdinals.length > 0;
         recoveryCooldownOnly = recovery.cooldownOnly === true;
-        recoveryHasImmediateProviderWork = recovery.hasImmediateProviderWork;
+        recoveryHasImmediateWork = recovery.hasImmediateRecoveryWork;
       }
     }
 
@@ -341,7 +341,7 @@ export async function reconcileContextGraph(
     && (
       recoveryAttempted
         ? recoveryContinuationOrdinal !== undefined
-          || recoveryHasImmediateProviderWork
+          || recoveryHasImmediateWork
           || hasUnvisitedCandidates
         : hasUnvisitedCandidates
     );

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -73,6 +73,12 @@ export interface PendingOrdinalRecoveryResult {
    */
   continuationOrdinal: number | undefined;
   /**
+   * Retained provider rotation has an untried peer and should be scheduled
+   * immediately. This is deliberately separate from the ordered scan cursor
+   * so provider retries cannot starve untouched ordinals.
+   */
+  hasImmediateProviderWork: boolean;
+  /**
    * True only when recovery intentionally skipped networking because its
    * per-CG cooldown is active. This preserves the continuation without
    * scheduling an immediate retry; ordinary no-eligible-peer outcomes keep
@@ -200,6 +206,7 @@ export async function reconcileContextGraph(
   let recoveryContinuationOrdinal: number | undefined;
   let recoveryAttempted = false;
   let recoveryCooldownOnly = false;
+  let recoveryHasImmediateProviderWork = false;
   const outstandingBefore = ordinalsToReconcile(state, head);
   const configuredLimit = deps.maxOrdinalsPerPass;
   const passLimit = configuredLimit === undefined
@@ -288,6 +295,7 @@ export async function reconcileContextGraph(
         recoveryContinuationOrdinal = recovery.continuationOrdinal;
         recoveryAttempted = recovery.attemptedOrdinals.length > 0;
         recoveryCooldownOnly = recovery.cooldownOnly === true;
+        recoveryHasImmediateProviderWork = recovery.hasImmediateProviderWork;
       }
     }
 
@@ -332,7 +340,9 @@ export async function reconcileContextGraph(
     && !recoveryCooldownOnly
     && (
       recoveryAttempted
-        ? recoveryContinuationOrdinal !== undefined || hasUnvisitedCandidates
+        ? recoveryContinuationOrdinal !== undefined
+          || recoveryHasImmediateProviderWork
+          || hasUnvisitedCandidates
         : hasUnvisitedCandidates
     );
 

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -4675,6 +4675,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       outcomes: new Map(),
       attemptedOrdinals: [],
       continuationOrdinal,
+      hasImmediateProviderWork: false,
       cooldownOnly,
     });
     if (!isRecoveryCurrent() || targets.length === 0) return noRecovery();
@@ -5177,7 +5178,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const eligibleOrdinals = new Set(eligible.map(({ target }) => target.ordinal));
     const unattemptedContinuationOrdinal = currentTargets.find((target) =>
       eligibleOrdinals.has(target.ordinal) && !attemptedOrdinals.has(target.ordinal))?.ordinal;
-    const providerContinuationOrdinal = eligible.find(({ target }) => {
+    const hasImmediateProviderWork = eligible.some(({ target }) => {
       const outcome = outcomes.get(target.ordinal);
       if (
         outcome?.status !== 'pending'
@@ -5189,9 +5190,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
       );
       return record?.phase === 'collecting'
         && this.vmReconcileUncreditedCandidateOrder(record).length > 0;
-    })?.target.ordinal;
-    const continuationOrdinal = unattemptedContinuationOrdinal
-      ?? providerContinuationOrdinal;
+    });
+    const continuationOrdinal = unattemptedContinuationOrdinal;
 
     // Mirror the inline path's cooldown policy, but do not turn a bounded peer
     // slice into a one-minute stall while the retained rotation record proves
@@ -5203,7 +5203,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (!isRecoveryCurrent()) return noRecovery();
     const recoveredAny = [...outcomes.values()]
       .some((outcome) => outcome.status === 'reconciled' || outcome.status === 'already');
-    if (!recoveryWorkRan || recoveredAny || continuationOrdinal !== undefined) {
+    if (
+      !recoveryWorkRan
+      || recoveredAny
+      || continuationOrdinal !== undefined
+      || hasImmediateProviderWork
+    ) {
       this.vmReconcileFetchCooldownAt.delete(localCgId);
     } else {
       this.vmReconcileFetchCooldownAt.delete(localCgId);
@@ -5217,6 +5222,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // next peer, but once every submitted target has consumed one attempt
       // the outer fair scan must wrap from its watermark on the next cycle.
       continuationOrdinal,
+      hasImmediateProviderWork,
       cooldownOnly: false,
     };
   }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -4675,7 +4675,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       outcomes: new Map(),
       attemptedOrdinals: [],
       continuationOrdinal,
-      hasImmediateProviderWork: false,
+      hasImmediateRecoveryWork: false,
       cooldownOnly,
     });
     if (!isRecoveryCurrent() || targets.length === 0) return noRecovery();
@@ -5178,18 +5178,25 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const eligibleOrdinals = new Set(eligible.map(({ target }) => target.ordinal));
     const unattemptedContinuationOrdinal = currentTargets.find((target) =>
       eligibleOrdinals.has(target.ordinal) && !attemptedOrdinals.has(target.ordinal))?.ordinal;
-    const hasImmediateProviderWork = eligible.some(({ target }) => {
+    const hasImmediateRecoveryWork = eligible.some(({ target }) => {
       const outcome = outcomes.get(target.ordinal);
-      if (
-        outcome?.status !== 'pending'
-        || !outcome.recovery
-        || !this.vmReconcileRecoveryTargetMatches(target, outcome.recovery)
-      ) return false;
       const record = this.vmReconcileRotationState.get(
         this.vmReconcileRotationSlotKey(target),
       );
-      return record?.phase === 'collecting'
-        && this.vmReconcileUncreditedCandidateOrder(record).length > 0;
+      if (
+        record?.phase !== 'collecting'
+        || record.fingerprint !== this.vmReconcileRotationFingerprint(target)
+        || this.vmReconcileUncreditedCandidateOrder(record).length === 0
+      ) return false;
+      // When revalidation ran, it must still describe the same pending target.
+      // A protocol/admission failure can consume an attempt before producing
+      // an outcome; the matching retained record is then sufficient proof that
+      // another bounded provider attempt remains immediately runnable.
+      return outcome === undefined
+        ? attemptedOrdinals.has(target.ordinal)
+        : outcome.status === 'pending'
+          && outcome.recovery !== undefined
+          && this.vmReconcileRecoveryTargetMatches(target, outcome.recovery);
     });
     const continuationOrdinal = unattemptedContinuationOrdinal;
 
@@ -5207,7 +5214,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       !recoveryWorkRan
       || recoveredAny
       || continuationOrdinal !== undefined
-      || hasImmediateProviderWork
+      || hasImmediateRecoveryWork
     ) {
       this.vmReconcileFetchCooldownAt.delete(localCgId);
     } else {
@@ -5222,7 +5229,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // next peer, but once every submitted target has consumed one attempt
       // the outer fair scan must wrap from its watermark on the next cycle.
       continuationOrdinal,
-      hasImmediateProviderWork,
+      hasImmediateRecoveryWork,
       cooldownOnly: false,
     };
   }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -5174,17 +5174,36 @@ export class SwmHostModeMethods extends DKGAgentBase {
       }
     }
 
-    // Mirror the inline path's cooldown policy: a pass that performs no
-    // protocol/admission/transport work must not consume the fetch budget, and
-    // completed work resets the damper so the trailing `hasMore` slice of a
-    // draining backlog fetches immediately.
-    // Only a batch that reached a peer and recovered nothing retains the
-    // cooldown. Re-anchor that short damper at completion: a slow or legacy
-    // response may already have outlived the timestamp taken before transfer.
+    const eligibleOrdinals = new Set(eligible.map(({ target }) => target.ordinal));
+    const unattemptedContinuationOrdinal = currentTargets.find((target) =>
+      eligibleOrdinals.has(target.ordinal) && !attemptedOrdinals.has(target.ordinal))?.ordinal;
+    const providerContinuationOrdinal = eligible.find(({ target }) => {
+      const outcome = outcomes.get(target.ordinal);
+      if (
+        outcome?.status !== 'pending'
+        || !outcome.recovery
+        || !this.vmReconcileRecoveryTargetMatches(target, outcome.recovery)
+      ) return false;
+      const record = this.vmReconcileRotationState.get(
+        this.vmReconcileRotationSlotKey(target),
+      );
+      return record?.phase === 'collecting'
+        && this.vmReconcileUncreditedCandidateOrder(record).length > 0;
+    })?.target.ordinal;
+    const continuationOrdinal = unattemptedContinuationOrdinal
+      ?? providerContinuationOrdinal;
+
+    // Mirror the inline path's cooldown policy, but do not turn a bounded peer
+    // slice into a one-minute stall while the retained rotation record proves
+    // there is novel work left. Each trailing pass still obeys the hard peer,
+    // ordinal and global-sync admission caps; it merely reaches the next target
+    // or untried provider without waiting for the periodic safety-net sweep.
+    // Once every retained provider cycle is exhausted, the ordinary cooldown /
+    // negative backoff applies exactly as before.
     if (!isRecoveryCurrent()) return noRecovery();
     const recoveredAny = [...outcomes.values()]
       .some((outcome) => outcome.status === 'reconciled' || outcome.status === 'already');
-    if (!recoveryWorkRan || recoveredAny) {
+    if (!recoveryWorkRan || recoveredAny || continuationOrdinal !== undefined) {
       this.vmReconcileFetchCooldownAt.delete(localCgId);
     } else {
       this.vmReconcileFetchCooldownAt.delete(localCgId);
@@ -5197,10 +5216,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // attempts are rotated inside `remaining` to give untouched targets the
       // next peer, but once every submitted target has consumed one attempt
       // the outer fair scan must wrap from its watermark on the next cycle.
-      continuationOrdinal: currentTargets.find(
-        (target) => eligible.some((entry) => entry.target.ordinal === target.ordinal)
-          && !attemptedOrdinals.has(target.ordinal),
-      )?.ordinal,
+      continuationOrdinal,
       cooldownOnly: false,
     };
   }

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -252,6 +252,7 @@ describe('reconcileContextGraph — sweep', () => {
           ])),
           attemptedOrdinals: targets.map((target) => target.ordinal),
           continuationOrdinal: undefined,
+          hasImmediateProviderWork: false,
         };
       },
     });
@@ -288,6 +289,7 @@ describe('reconcileContextGraph — sweep', () => {
           ])),
           attemptedOrdinals: attempted,
           continuationOrdinal: ordinals[attempted.length],
+          hasImmediateProviderWork: false,
         };
       },
     });
@@ -304,6 +306,45 @@ describe('reconcileContextGraph — sweep', () => {
       [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
       [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
     ]);
+  });
+
+  it('visits an untouched ordinal before reprobing an earlier provider rotation', async () => {
+    const recoveryCalls: number[][] = [];
+    const { deps } = makeDeps({
+      getKCCount: async () => 2,
+      maxOrdinalsPerPass: 1,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => ({
+        status: 'pending',
+        recovery: {
+          ordinal,
+          ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
+          kaId: String(ordinal),
+          reason: 'no-swm',
+        },
+      }),
+      recoverPendingOrdinals: async (_cg, _onchain, targets) => {
+        recoveryCalls.push(targets.map((target) => target.ordinal));
+        const target = targets[0]!;
+        return {
+          outcomes: new Map([[
+            target.ordinal,
+            { status: 'pending', recovery: target } as OrdinalOutcome,
+          ]]),
+          attemptedOrdinals: [target.ordinal],
+          continuationOrdinal: undefined,
+          hasImmediateProviderWork: true,
+        };
+      },
+    });
+    const state = createCursorState(0);
+
+    const first = await reconcileContextGraph(deps, state, 'cg', 1n);
+    expect(first.hasMore).toBe(true);
+    expect(state.scanOrdinal).toBe(1);
+
+    await reconcileContextGraph(deps, state, 'cg', 1n);
+
+    expect(recoveryCalls).toEqual([[0], [1]]);
   });
 
   it('preserves the next recovery target across a cooldown-only pass', async () => {
@@ -329,6 +370,7 @@ describe('reconcileContextGraph — sweep', () => {
             outcomes: new Map(),
             attemptedOrdinals: [],
             continuationOrdinal: targets[0]?.ordinal,
+            hasImmediateProviderWork: false,
             cooldownOnly: true,
           };
         }
@@ -342,6 +384,7 @@ describe('reconcileContextGraph — sweep', () => {
           attemptedOrdinals: [attempted.ordinal],
           continuationOrdinal: targets[1]?.ordinal
             ?? (outcome.status === 'pending' ? attempted.ordinal : undefined),
+          hasImmediateProviderWork: false,
         };
       },
     });
@@ -391,6 +434,7 @@ describe('reconcileContextGraph — sweep', () => {
         outcomes: new Map(),
         attemptedOrdinals: [],
         continuationOrdinal: targets[0]?.ordinal,
+        hasImmediateProviderWork: false,
         cooldownOnly: false,
       }),
     });
@@ -432,6 +476,7 @@ describe('reconcileContextGraph — sweep', () => {
         outcomes: new Map(),
         attemptedOrdinals: [],
         continuationOrdinal: undefined,
+        hasImmediateProviderWork: false,
       }),
     });
     const state = createCursorState(0);
@@ -540,6 +585,7 @@ describe('reconcileContextGraph — sweep', () => {
           ])),
           attemptedOrdinals: targets.map((target) => target.ordinal),
           continuationOrdinal: undefined,
+          hasImmediateProviderWork: false,
         };
       },
     });

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -4,6 +4,7 @@ import {
   VmReconcileDispatcher,
   RecentUalSet,
   type ChainReconcilerDeps,
+  type OrdinalRecoveryTarget,
   type OrdinalOutcome,
 } from '../src/chain-reconciler.js';
 import {
@@ -252,7 +253,7 @@ describe('reconcileContextGraph — sweep', () => {
           ])),
           attemptedOrdinals: targets.map((target) => target.ordinal),
           continuationOrdinal: undefined,
-          hasImmediateProviderWork: false,
+          hasImmediateRecoveryWork: false,
         };
       },
     });
@@ -289,7 +290,7 @@ describe('reconcileContextGraph — sweep', () => {
           ])),
           attemptedOrdinals: attempted,
           continuationOrdinal: ordinals[attempted.length],
-          hasImmediateProviderWork: false,
+          hasImmediateRecoveryWork: false,
         };
       },
     });
@@ -332,7 +333,7 @@ describe('reconcileContextGraph — sweep', () => {
           ]]),
           attemptedOrdinals: [target.ordinal],
           continuationOrdinal: undefined,
-          hasImmediateProviderWork: true,
+          hasImmediateRecoveryWork: true,
         };
       },
     });
@@ -345,6 +346,32 @@ describe('reconcileContextGraph — sweep', () => {
     await reconcileContextGraph(deps, state, 'cg', 1n);
 
     expect(recoveryCalls).toEqual([[0], [1]]);
+  });
+
+  it('schedules another pass when recovery alone reports immediate work', async () => {
+    const target: OrdinalRecoveryTarget = {
+      ordinal: 0,
+      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/0',
+      kaId: '0',
+      reason: 'no-swm',
+    };
+    const { deps } = makeDeps({
+      getKCCount: async () => 1,
+      maxOrdinalsPerPass: 1,
+      reconcileOrdinal: async () => ({ status: 'pending', recovery: target }),
+      recoverPendingOrdinals: async () => ({
+        outcomes: new Map([[0, { status: 'pending', recovery: target }]]),
+        attemptedOrdinals: [0],
+        continuationOrdinal: undefined,
+        hasImmediateRecoveryWork: true,
+      }),
+    });
+    const state = createCursorState(0);
+
+    const result = await reconcileContextGraph(deps, state, 'cg', 1n);
+
+    expect(result.hasMore).toBe(true);
+    expect(state.scanOrdinal).toBe(0);
   });
 
   it('preserves the next recovery target across a cooldown-only pass', async () => {
@@ -370,7 +397,7 @@ describe('reconcileContextGraph — sweep', () => {
             outcomes: new Map(),
             attemptedOrdinals: [],
             continuationOrdinal: targets[0]?.ordinal,
-            hasImmediateProviderWork: false,
+            hasImmediateRecoveryWork: false,
             cooldownOnly: true,
           };
         }
@@ -384,7 +411,7 @@ describe('reconcileContextGraph — sweep', () => {
           attemptedOrdinals: [attempted.ordinal],
           continuationOrdinal: targets[1]?.ordinal
             ?? (outcome.status === 'pending' ? attempted.ordinal : undefined),
-          hasImmediateProviderWork: false,
+          hasImmediateRecoveryWork: false,
         };
       },
     });
@@ -434,7 +461,7 @@ describe('reconcileContextGraph — sweep', () => {
         outcomes: new Map(),
         attemptedOrdinals: [],
         continuationOrdinal: targets[0]?.ordinal,
-        hasImmediateProviderWork: false,
+        hasImmediateRecoveryWork: false,
         cooldownOnly: false,
       }),
     });
@@ -476,7 +503,7 @@ describe('reconcileContextGraph — sweep', () => {
         outcomes: new Map(),
         attemptedOrdinals: [],
         continuationOrdinal: undefined,
-        hasImmediateProviderWork: false,
+        hasImmediateRecoveryWork: false,
       }),
     });
     const state = createCursorState(0);
@@ -585,7 +612,7 @@ describe('reconcileContextGraph — sweep', () => {
           ])),
           attemptedOrdinals: targets.map((target) => target.ordinal),
           continuationOrdinal: undefined,
-          hasImmediateProviderWork: false,
+          hasImmediateRecoveryWork: false,
         };
       },
     });

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -42,6 +42,22 @@ function makeDeps(overrides: Partial<ChainReconcilerDeps> = {}): {
   return { deps, persisted, attempted };
 }
 
+function recoveryTarget(
+  ordinal: number,
+  overrides: Partial<OrdinalRecoveryTarget> = {},
+): OrdinalRecoveryTarget {
+  return {
+    localCgId: 'cg',
+    onChainCgId: '1',
+    ordinal,
+    ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
+    merkleRoot: `0x${ordinal.toString(16).padStart(64, '0')}`,
+    kaId: String(ordinal),
+    reason: 'no-swm',
+    ...overrides,
+  };
+}
+
 describe('reconcileContextGraph — sweep', () => {
   it('reconciles [watermark, head) and advances + persists the watermark', async () => {
     const { deps, persisted, attempted } = makeDeps({ getKCCount: async () => 3 });
@@ -236,12 +252,7 @@ describe('reconcileContextGraph — sweep', () => {
         if (ordinal === 0) return { status: 'already', blockNumber: 100 };
         return {
           status: 'pending',
-          recovery: {
-            ordinal,
-            ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
-            kaId: String(ordinal),
-            reason: 'no-swm',
-          },
+          recovery: recoveryTarget(ordinal),
         };
       },
       recoverPendingOrdinals: async (_cg, _onchain, targets) => {
@@ -272,12 +283,7 @@ describe('reconcileContextGraph — sweep', () => {
       maxOrdinalsPerPass: 10,
       reconcileOrdinal: async (_cg, _onchain, ordinal) => ({
         status: 'pending',
-        recovery: {
-          ordinal,
-          ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
-          kaId: String(ordinal),
-          reason: 'no-swm',
-        },
+        recovery: recoveryTarget(ordinal),
       }),
       recoverPendingOrdinals: async (_cg, _onchain, targets) => {
         const ordinals = targets.map((target) => target.ordinal);
@@ -316,12 +322,7 @@ describe('reconcileContextGraph — sweep', () => {
       maxOrdinalsPerPass: 1,
       reconcileOrdinal: async (_cg, _onchain, ordinal) => ({
         status: 'pending',
-        recovery: {
-          ordinal,
-          ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
-          kaId: String(ordinal),
-          reason: 'no-swm',
-        },
+        recovery: recoveryTarget(ordinal),
       }),
       recoverPendingOrdinals: async (_cg, _onchain, targets) => {
         recoveryCalls.push(targets.map((target) => target.ordinal));
@@ -349,12 +350,7 @@ describe('reconcileContextGraph — sweep', () => {
   });
 
   it('schedules another pass when recovery alone reports immediate work', async () => {
-    const target: OrdinalRecoveryTarget = {
-      ordinal: 0,
-      ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/0',
-      kaId: '0',
-      reason: 'no-swm',
-    };
+    const target = recoveryTarget(0);
     const { deps } = makeDeps({
       getKCCount: async () => 1,
       maxOrdinalsPerPass: 1,
@@ -382,12 +378,7 @@ describe('reconcileContextGraph — sweep', () => {
       maxOrdinalsPerPass: 2,
       reconcileOrdinal: async (_cg, _onchain, ordinal) => ({
         status: 'pending',
-        recovery: {
-          ordinal,
-          ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
-          kaId: String(ordinal),
-          reason: 'no-swm',
-        },
+        recovery: recoveryTarget(ordinal),
       }),
       recoverPendingOrdinals: async (_cg, _onchain, targets) => {
         const ordinals = targets.map((target) => target.ordinal);
@@ -449,12 +440,7 @@ describe('reconcileContextGraph — sweep', () => {
         if (ordinal !== 0) return { status: 'reconciled', blockNumber: 100 };
         return {
           status: 'pending',
-          recovery: {
-            ordinal,
-            ual: 'did:dkg:base:84532/0x0000000000000000000000000000000000000001/0',
-            kaId: '0',
-            reason: 'no-swm',
-          },
+          recovery: recoveryTarget(ordinal),
         };
       },
       recoverPendingOrdinals: async (_cg, _onchain, targets) => ({
@@ -491,12 +477,7 @@ describe('reconcileContextGraph — sweep', () => {
         if (ordinal !== 0) return { status: 'reconciled', blockNumber: 100 };
         return {
           status: 'pending',
-          recovery: {
-            ordinal,
-            ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
-            kaId: String(ordinal),
-            reason: 'no-swm',
-          },
+          recovery: recoveryTarget(ordinal),
         };
       },
       recoverPendingOrdinals: async () => ({
@@ -594,12 +575,7 @@ describe('reconcileContextGraph — sweep', () => {
       isTargetCurrent: async () => current,
       reconcileOrdinal: async (_cg, _onchain, ordinal) => ({
         status: 'pending',
-        recovery: {
-          ordinal,
-          ual: `did:dkg:base:84532/0x0000000000000000000000000000000000000001/${ordinal}`,
-          kaId: String(ordinal),
-          reason: 'no-swm',
-        },
+        recovery: recoveryTarget(ordinal),
       }),
       recoverPendingOrdinals: async (_cg, _onchain, targets) => {
         // The rebind lands while the long recovery await is in flight. The

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2200,6 +2200,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
         ])),
         attemptedOrdinals: targets.map((target) => target.ordinal),
         continuationOrdinal: undefined,
+        hasImmediateProviderWork: false,
       };
     };
 
@@ -2799,7 +2800,8 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(first.outcomes.get(0)).toMatchObject({ status: 'pending' });
     expect(first.outcomes.get(1)).toMatchObject({ status: 'pending' });
     expect(first.attemptedOrdinals).toEqual([0, 1]);
-    expect(first.continuationOrdinal).toBe(0);
+    expect(first.continuationOrdinal).toBeUndefined();
+    expect(first.hasImmediateProviderWork).toBe(true);
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
 
     // Both targets retain one untried provider. The next bounded pass rotates
@@ -2813,6 +2815,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     ]);
     expect(second.attemptedOrdinals).toEqual([0, 1]);
     expect(second.continuationOrdinal).toBeUndefined();
+    expect(second.hasImmediateProviderWork).toBe(false);
     expect(second.cooldownOnly).toBe(false);
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
   });
@@ -2944,7 +2947,8 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       localCgId, 1n, [target], 100, () => true,
     );
     expect(first.outcomes.get(0)).toMatchObject({ status: 'pending' });
-    expect(first.continuationOrdinal).toBe(0);
+    expect(first.continuationOrdinal).toBeUndefined();
+    expect(first.hasImmediateProviderWork).toBe(true);
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
 
     const second = await internals.recoverVmReconcileBatch(

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2748,7 +2748,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(result.continuationOrdinal).toBe(3);
   });
 
-  it('tries each pending target once per eligible pass and damps immediate retries', async () => {
+  it('continues immediately while pending targets still have untried providers', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmBatchCooldown', chainAdapter: chain });
     const internals = agent as unknown as AgentInternals;
@@ -2799,16 +2799,22 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(first.outcomes.get(0)).toMatchObject({ status: 'pending' });
     expect(first.outcomes.get(1)).toMatchObject({ status: 'pending' });
     expect(first.attemptedOrdinals).toEqual([0, 1]);
-    expect(first.continuationOrdinal).toBeUndefined();
+    expect(first.continuationOrdinal).toBe(0);
+    expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
 
-    // Nothing recovered: the cooldown stamped on entry stands, so an immediate
-    // next pass performs no network fetch for this CG.
+    // Both targets retain one untried provider. The next bounded pass rotates
+    // to those providers immediately instead of sleeping for the 60s sweep.
     const second = await internals.recoverVmReconcileBatch(localCgId, 1n, targets, 100, () => true);
-    expect(fetchedUals).toEqual([[target.ual], [deferredTarget.ual]]);
-    expect(second.outcomes.size).toBe(0);
-    expect(second.attemptedOrdinals).toEqual([]);
-    expect(second.continuationOrdinal).toBe(0);
-    expect(second.cooldownOnly).toBe(true);
+    expect(fetchedUals).toEqual([
+      [target.ual],
+      [deferredTarget.ual],
+      [target.ual],
+      [deferredTarget.ual],
+    ]);
+    expect(second.attemptedOrdinals).toEqual([0, 1]);
+    expect(second.continuationOrdinal).toBeUndefined();
+    expect(second.cooldownOnly).toBe(false);
+    expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
   });
 
   it('suppresses completed incomplete cycles after every pending target receives an attempt', async () => {
@@ -2938,8 +2944,9 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       localCgId, 1n, [target], 100, () => true,
     );
     expect(first.outcomes.get(0)).toMatchObject({ status: 'pending' });
+    expect(first.continuationOrdinal).toBe(0);
+    expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
 
-    (internals as any).vmReconcileFetchCooldownAt.delete(localCgId);
     const second = await internals.recoverVmReconcileBatch(
       localCgId, 1n, [target], 100, () => true,
     );

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2200,7 +2200,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
         ])),
         attemptedOrdinals: targets.map((target) => target.ordinal),
         continuationOrdinal: undefined,
-        hasImmediateProviderWork: false,
+        hasImmediateRecoveryWork: false,
       };
     };
 
@@ -2801,7 +2801,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(first.outcomes.get(1)).toMatchObject({ status: 'pending' });
     expect(first.attemptedOrdinals).toEqual([0, 1]);
     expect(first.continuationOrdinal).toBeUndefined();
-    expect(first.hasImmediateProviderWork).toBe(true);
+    expect(first.hasImmediateRecoveryWork).toBe(true);
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
 
     // Both targets retain one untried provider. The next bounded pass rotates
@@ -2815,7 +2815,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     ]);
     expect(second.attemptedOrdinals).toEqual([0, 1]);
     expect(second.continuationOrdinal).toBeUndefined();
-    expect(second.hasImmediateProviderWork).toBe(false);
+    expect(second.hasImmediateRecoveryWork).toBe(false);
     expect(second.cooldownOnly).toBe(false);
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(true);
   });
@@ -2948,7 +2948,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     );
     expect(first.outcomes.get(0)).toMatchObject({ status: 'pending' });
     expect(first.continuationOrdinal).toBeUndefined();
-    expect(first.hasImmediateProviderWork).toBe(true);
+    expect(first.hasImmediateRecoveryWork).toBe(true);
     expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
 
     const second = await internals.recoverVmReconcileBatch(
@@ -2956,6 +2956,63 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     );
 
     expect(networkAttempts).toEqual([peerA, peerB]);
+    expect(second.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+  });
+
+  it('keeps immediate recovery runnable after a provider fails before revalidation', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmProtocolRotation', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peerA = '12D3KooWProtocolRotationPeerA';
+    const peerB = '12D3KooWProtocolRotationPeerB';
+    const localCgId = '0x0000000000000000000000000000000000000001/protocol-rotation';
+    const connected = [peerA, peerB].map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWProtocolRotationLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).preferredSyncPeers.set(localCgId, peerA);
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [peerA, peerB], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    const protocolAttempts: string[] = [];
+    (internals as any).waitForSyncProtocol = async (peer: { toString(): string }) => {
+      const peerId = peer.toString();
+      protocolAttempts.push(peerId);
+      return peerId === peerB;
+    };
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const fetchAttempts: string[] = [];
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      fetchAttempts.push(peerId);
+      return {
+        result: {
+          fetchedDataTriples: 1, fetchedMetaTriples: 8, insertedTriples: 9,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: 'found',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, '7');
+    (internals as any).reconcileChainOrdinal = async () => (
+      fetchAttempts.length > 0
+        ? { status: 'reconciled', blockNumber: 100 }
+        : { status: 'pending', recovery: target }
+    );
+
+    const first = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    expect(first.outcomes.size).toBe(0);
+    expect(first.hasImmediateRecoveryWork).toBe(true);
+    expect((internals as any).vmReconcileFetchCooldownAt.has(localCgId)).toBe(false);
+
+    const second = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, [target], 100, () => true,
+    );
+    expect(protocolAttempts).toEqual([peerA, peerB]);
+    expect(fetchAttempts).toEqual([peerB]);
     expect(second.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
   });
 


### PR DESCRIPTION
## Impact

VM reconciliation already uses the on-chain inventory to identify every missing asset, but a failed exact fetch could wait for the 60-second per-CG cooldown before trying the next known provider. Under a long VM tail, that turned bounded provider rotation into multi-minute convergence even while novel recovery work was immediately runnable.

This change keeps the existing peer, ordinal, and global-sync admission caps. The host exposes a neutral immediate-recovery scheduling directive while retaining provider-rotation details internally. Untouched ordinals keep priority over retrying an earlier provider rotation; when only a provider retry remains, the next bounded slice is scheduled immediately. Once the cycle is exhausted, existing cooldown and negative backoff apply unchanged.

## Before

```mermaid
sequenceDiagram
    participant C as Chain inventory
    participant R as VM reconciler
    participant P1 as Provider A
    participant P2 as Provider B
    C->>R: Missing exact UAL/root
    R->>P1: Bounded exact fetch
    P1-->>R: Not found / protocol failure / incomplete
    R-->>R: Install 60s CG cooldown
    Note over R: Novel provider remains idle
    R->>P2: Try on later sweep
```

## After

```mermaid
sequenceDiagram
    participant C as Chain inventory
    participant R as VM reconciler
    participant P1 as Provider A
    participant P2 as Provider B
    C->>R: Missing exact UAL/root
    R->>P1: Bounded exact fetch
    P1-->>R: Not found / protocol failure / incomplete
    R-->>R: Retained recovery has runnable work
    R->>R: Visit untouched ordinals fairly
    R->>P2: Queue next bounded provider slice
    P2-->>R: Exact asset or bounded failure
    R-->>R: Back off only after provider cycle exhausts
```

## Safety properties

- Does not increase per-pass peer or ordinal concurrency.
- Does not bypass the global sync admission/backpressure lane.
- Does not retry providers already credited in the retained rotation record.
- Preserves fair scan progress for untouched ordinals.
- Preserves cooldown/backoff once no novel recovery work remains.

## Validation

- focused chain-reconciler and VM recovery lanes: 159/159 passed
- protocol-failure provider rotation, untouched-ordinal fairness, and provider-only immediate retry are pinned directly
- agent TypeScript passed
- combined 10.0.14 candidate: ordered runtime build, CLI readiness 78/78, agent recovery/RFC-64 lanes 260/260
- `git diff --check`: passed

## Release role

This is 10.0.14 increment 2 of 3: faster bounded VM recovery. It does not activate RFC-64 catalogs.