### PR TITLE
refactor(rfc64): keep catalogs in SWM

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -48,6 +48,7 @@
     "./dist/rfc64/inventory-v1/swm-author-inventory-sql-codec.js": null,
     "./dist/rfc64/inventory-v1/swm-author-inventory-contracts.js": null,
     "./dist/rfc64/finalized-policy-agent-precommit-v1.js": null,
+    "./dist/rfc64/finalized-policy-verifier-v1.js": null,
     "./dist/rfc64/finalized-vm-agent-precommit-v1.js": null,
     "./dist/rfc64/finalized-vm-composer-v1.js": null,
     "./dist/rfc64/finalized-vm-runtime-v1.js": null,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -47,6 +47,7 @@
     "./dist/rfc64/inventory-v1/swm-author-inventory-persistence.js": null,
     "./dist/rfc64/inventory-v1/swm-author-inventory-sql-codec.js": null,
     "./dist/rfc64/inventory-v1/swm-author-inventory-contracts.js": null,
+    "./dist/rfc64/finalized-policy-agent-precommit-v1.js": null,
     "./dist/rfc64/finalized-vm-agent-precommit-v1.js": null,
     "./dist/rfc64/finalized-vm-composer-v1.js": null,
     "./dist/rfc64/finalized-vm-runtime-v1.js": null,

--- a/packages/agent/scripts/rfc64-m0-recovery-manifest.mjs
+++ b/packages/agent/scripts/rfc64-m0-recovery-manifest.mjs
@@ -15,7 +15,7 @@ export const RFC64_M0_RECOVERY_SCENARIO_MANIFEST = Object.freeze([
     id: 'curated-parity',
     rowId: 'public-curated-cold-warm-parity',
     label: 'Public-curated cold/warm parity',
-    title: 'keeps warm and cold public-curated receivers at one exact finalized head across restart',
+    title: 'keeps warm and cold public-curated receivers at one exact catalog head and SWM state across restart',
   }),
 ]);
 

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -51,6 +51,7 @@ const requiredCatalogMethods = [
   'publishAuthorCatalogGenesisV1',
   'publishAuthorCatalogExactSetSuccessorV1',
   'recordRfc64PublicCatalogAssetV1',
+  'recordConfirmedRfc64PublicCatalogAssetV1',
   'synchronizeRfc64PublicCatalogFromProviderV1',
   'readRfc64PublicCatalogBootstrapStatusV1',
   'whenRfc64PublicCatalogBootstrapIdleV1',
@@ -62,12 +63,6 @@ for (const method of requiredCatalogMethods) {
   ) {
     throw new Error(`published DKGAgent entry points did not expose ${method}`);
   }
-}
-if (
-  typeof root.DKGAgent.prototype.recordConfirmedRfc64PublicCatalogAssetV1 === 'function'
-  || typeof legacyAgent.DKGAgent.prototype.recordConfirmedRfc64PublicCatalogAssetV1 === 'function'
-) {
-  throw new Error('published DKGAgent entry points still expose the stale confirmed-VM catalog API');
 }
 if (
   !Array.isArray(root.RFC64_POLICY_CELLS_V1)

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -142,6 +142,7 @@ const blockedRfc64Modules = [
   'inventory-v1/swm-author-inventory-persistence.js',
   'inventory-v1/swm-author-inventory-sql-codec.js',
   'finalized-policy-agent-precommit-v1.js',
+  'finalized-policy-verifier-v1.js',
   'finalized-vm-agent-precommit-v1.js',
   'finalized-vm-composer-v1.js',
   'finalized-vm-runtime-v1.js',

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -50,6 +50,7 @@ const requiredCatalogMethods = [
   'acceptRfc64CatalogAccessSnapshotV1',
   'publishAuthorCatalogGenesisV1',
   'publishAuthorCatalogExactSetSuccessorV1',
+  'recordRfc64PublicCatalogAssetV1',
   'recordConfirmedRfc64PublicCatalogAssetV1',
   'synchronizeRfc64PublicCatalogFromProviderV1',
   'readRfc64PublicCatalogBootstrapStatusV1',

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -141,6 +141,7 @@ const blockedRfc64Modules = [
   'inventory-v1/swm-author-inventory-mutation.js',
   'inventory-v1/swm-author-inventory-persistence.js',
   'inventory-v1/swm-author-inventory-sql-codec.js',
+  'finalized-policy-agent-precommit-v1.js',
   'finalized-vm-agent-precommit-v1.js',
   'finalized-vm-composer-v1.js',
   'finalized-vm-runtime-v1.js',

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -51,7 +51,6 @@ const requiredCatalogMethods = [
   'publishAuthorCatalogGenesisV1',
   'publishAuthorCatalogExactSetSuccessorV1',
   'recordRfc64PublicCatalogAssetV1',
-  'recordConfirmedRfc64PublicCatalogAssetV1',
   'synchronizeRfc64PublicCatalogFromProviderV1',
   'readRfc64PublicCatalogBootstrapStatusV1',
   'whenRfc64PublicCatalogBootstrapIdleV1',
@@ -63,6 +62,12 @@ for (const method of requiredCatalogMethods) {
   ) {
     throw new Error(`published DKGAgent entry points did not expose ${method}`);
   }
+}
+if (
+  typeof root.DKGAgent.prototype.recordConfirmedRfc64PublicCatalogAssetV1 === 'function'
+  || typeof legacyAgent.DKGAgent.prototype.recordConfirmedRfc64PublicCatalogAssetV1 === 'function'
+) {
+  throw new Error('published DKGAgent entry points still expose the stale confirmed-VM catalog API');
 }
 if (
   !Array.isArray(root.RFC64_POLICY_CELLS_V1)

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -5628,7 +5628,6 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId: request.contextGraphId,
       subGraphName: request.subGraphName,
       assertionCoordinate: request.name,
-      publicQuads: snapshotQuads,
       seal,
       assertionUri,
       ctx,
@@ -6201,7 +6200,6 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId,
       subGraphName: opts?.subGraphName,
       assertionCoordinate: name,
-      publicQuads: canonicalSwmQuads,
       seal,
       assertionUri,
       ctx: opts?.operationCtx ?? createOperationContext('publishFromSWM'),
@@ -6218,7 +6216,6 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId: string;
       subGraphName?: string;
       assertionCoordinate: string;
-      publicQuads: readonly Quad[];
       seal: AssertionSeal;
       assertionUri: string;
       ctx: OperationContext;

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Opt-in RFC-64 producer bridge from an ordinary confirmed public KA publish
- * to this provider's durable exact author-catalog head.
+ * Opt-in RFC-64 SWM inventory and explicit public-catalog authoring support.
+ * Finalized VM remains inventoried by the chain and never advances this lane.
  */
 
 import {
@@ -97,14 +97,18 @@ function rfc64SwmInventoryAssetKeyV1(input: Readonly<{
   ]);
 }
 
-/** Internal normal-publication handoff after VM confirmation is durable locally. */
-export interface RecordConfirmedRfc64PublicCatalogAssetParamsV1 {
+/** Explicit catalog-authoring input; ordinary VM confirmation never calls it. */
+export interface RecordRfc64PublicCatalogAssetParamsV1 {
   readonly contextGraphId: ContextGraphIdV1;
   readonly subGraphName?: SubGraphNameV1 | null;
   readonly assertionCoordinate: AssertionCoordinateV1;
   readonly publicQuads: readonly Quad[];
   readonly seal: AssertionSeal;
 }
+
+/** @deprecated Use RecordRfc64PublicCatalogAssetParamsV1. */
+export type RecordConfirmedRfc64PublicCatalogAssetParamsV1 =
+  RecordRfc64PublicCatalogAssetParamsV1;
 
 function shadowResult(
   status: Rfc64SwmAuthorInventoryShadowMutationResultV1['status'],
@@ -146,7 +150,6 @@ export interface ObserveRfc64ConfirmedVmParamsV1 {
   readonly contextGraphId: string;
   readonly subGraphName?: string | null;
   readonly assertionCoordinate: string;
-  readonly publicQuads: readonly Quad[];
   readonly seal: AssertionSeal;
   readonly assertionUri: string;
   readonly ctx: OperationContext;
@@ -225,7 +228,11 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     );
   }
 
-  /** Canonical non-blocking observer for catalog advancement and exact SWM removal. */
+  /**
+   * Canonical post-confirmation observer for exact SWM-inventory removal.
+   * Finalized VM is already inventoried by the chain and therefore MUST NOT
+   * advance an RFC-64 catalog head.
+   */
   async observeRfc64ConfirmedVmV1(
     this: DKGAgent,
     params: ObserveRfc64ConfirmedVmParamsV1,
@@ -259,44 +266,23 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       assertionCoordinate,
     });
     shadowRuntime.markVmConfirmed(assetKey, confirmedSeal.assertionVersion);
-    const runObserver = async (
-      failureMessage: string,
-      observer: () => Promise<unknown>,
-    ): Promise<void> => {
-      try {
-        await observer();
-      } catch (cause) {
-        this.log.warn(
-          params.ctx,
-          `${failureMessage}: ${cause instanceof Error ? cause.message : String(cause)}`,
-        );
-      }
-    };
-    await Promise.all([
-      runObserver(
-        `Confirmed ${params.publicationLabel} for <${params.assertionUri}> but RFC-64 catalog advancement failed`,
-        () => this.recordConfirmedRfc64PublicCatalogAssetV1({
-          contextGraphId,
-          subGraphName,
-          assertionCoordinate,
-          publicQuads: params.publicQuads,
-          seal: params.seal,
-        }),
-      ),
-      runObserver(
-        `Confirmed ${params.publicationLabel} but RFC-64 SWM inventory shadow removal escaped its failure boundary`,
-        () => shadowRuntime.runExclusive(
-          assetKey,
-          async () => {
-            await this.removeRfc64SwmAuthorInventoryShadowV1({
-              contextGraphId,
-              subGraphName,
-              seal: params.seal,
-            });
-          },
-        ),
-      ),
-    ]);
+    try {
+      await shadowRuntime.runExclusive(
+        assetKey,
+        async () => {
+          await this.removeRfc64SwmAuthorInventoryShadowV1({
+            contextGraphId,
+            subGraphName,
+            seal: params.seal,
+          });
+        },
+      );
+    } catch (cause) {
+      this.log.warn(
+        params.ctx,
+        `Confirmed ${params.publicationLabel} but RFC-64 SWM inventory shadow removal escaped its failure boundary: ${cause instanceof Error ? cause.message : String(cause)}`,
+      );
+    }
   }
 
   readRfc64SwmAuthorInventorySnapshotV1(
@@ -479,7 +465,7 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     }
   }
 
-  /** Remove a row after VM confirmation, independently of VM catalog advancement. */
+  /** Remove a row after VM confirmation; the chain becomes the VM inventory. */
   async removeRfc64SwmAuthorInventoryShadowV1(
     this: DKGAgent,
     params: RemoveRfc64SwmAuthorInventoryShadowParamsV1,
@@ -542,16 +528,16 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       );
     }
   }
+
   /**
-   * Advance this provider's exact public-root author catalog after an ordinary
-   * graph-scoped KA publish has confirmed. The hook is dormant unless the
-   * preview config is present. Catalog objects and bundles are staged first,
-   * the provider's applied-head pointer advances second, and peer availability
-   * hints are sent last.
+   * Explicit low-level public-root catalog authoring entrypoint. This is kept
+   * for catalog construction and the upcoming SWM producer lane; it is not a
+   * VM lifecycle hook. Objects and bundles are staged before the applied head
+   * advances, then peer availability hints are sent best-effort.
    */
-  async recordConfirmedRfc64PublicCatalogAssetV1(
+  async recordRfc64PublicCatalogAssetV1(
     this: DKGAgent,
-    params: RecordConfirmedRfc64PublicCatalogAssetParamsV1,
+    params: RecordRfc64PublicCatalogAssetParamsV1,
   ): Promise<AppliedCatalogHeadSnapshotV1 | null> {
     const lane = this.resolveRfc64AcceptedPublicRootLaneV1(
       params.contextGraphId,
@@ -560,14 +546,12 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     if (lane === null) return null;
     const seal = canonicalGraphScopedAuthorSealFromAssertionSealV1(params.seal);
     // V1 deliberately catalogs public-only KA projections. Private-bearing
-    // publishes require the reserved cg-shared-v1 anchor/hash statements to be
-    // present in the author-sealed public projection; ordinary publication does
-    // not synthesize those statements yet, so attempting an upsert would always
-    // fail projection verification after chain confirmation.
+    // assets require the reserved cg-shared-v1 anchor/hash statements in the
+    // author-sealed public projection; this entrypoint does not synthesize them.
     if (BigInt(seal.privateTripleCount) > 0n) return null;
     if (params.publicQuads.length !== Number(seal.publicTripleCount)) {
       throw new Error(
-        'RFC-64 auto-publish public projection count differs from the confirmed author seal',
+        'RFC-64 public projection count differs from the supplied author seal',
       );
     }
     const projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(params.publicQuads);
@@ -594,6 +578,17 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       catalogIssuerDelegationExpiresAt:
         lane.autoPublishConfig.catalogIssuerDelegationExpiresAt,
     });
+  }
+
+  /**
+   * @deprecated Explicit compatibility alias only. Ordinary VM confirmation
+   * does not call this method; the chain remains the finalized-VM inventory.
+   */
+  recordConfirmedRfc64PublicCatalogAssetV1(
+    this: DKGAgent,
+    params: RecordConfirmedRfc64PublicCatalogAssetParamsV1,
+  ): Promise<AppliedCatalogHeadSnapshotV1 | null> {
+    return this.recordRfc64PublicCatalogAssetV1(params);
   }
 
   /** One canonical activation, policy, ownership, and era boundary for catalog and SWM. */

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -106,6 +106,10 @@ export interface RecordRfc64PublicCatalogAssetParamsV1 {
   readonly seal: AssertionSeal;
 }
 
+/** @deprecated Use RecordRfc64PublicCatalogAssetParamsV1. */
+export type RecordConfirmedRfc64PublicCatalogAssetParamsV1 =
+  RecordRfc64PublicCatalogAssetParamsV1;
+
 function shadowResult(
   status: Rfc64SwmAuthorInventoryShadowMutationResultV1['status'],
   action: Rfc64SwmAuthorInventoryShadowMutationResultV1['action'],
@@ -574,6 +578,17 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       catalogIssuerDelegationExpiresAt:
         lane.autoPublishConfig.catalogIssuerDelegationExpiresAt,
     });
+  }
+
+  /**
+   * @deprecated Explicit compatibility alias only. Ordinary VM confirmation
+   * does not call this method; the chain remains the finalized-VM inventory.
+   */
+  recordConfirmedRfc64PublicCatalogAssetV1(
+    this: DKGAgent,
+    params: RecordConfirmedRfc64PublicCatalogAssetParamsV1,
+  ): Promise<AppliedCatalogHeadSnapshotV1 | null> {
+    return this.recordRfc64PublicCatalogAssetV1(params);
   }
 
   /** One canonical activation, policy, ownership, and era boundary for catalog and SWM. */

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -106,10 +106,6 @@ export interface RecordRfc64PublicCatalogAssetParamsV1 {
   readonly seal: AssertionSeal;
 }
 
-/** @deprecated Use RecordRfc64PublicCatalogAssetParamsV1. */
-export type RecordConfirmedRfc64PublicCatalogAssetParamsV1 =
-  RecordRfc64PublicCatalogAssetParamsV1;
-
 function shadowResult(
   status: Rfc64SwmAuthorInventoryShadowMutationResultV1['status'],
   action: Rfc64SwmAuthorInventoryShadowMutationResultV1['action'],
@@ -578,17 +574,6 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       catalogIssuerDelegationExpiresAt:
         lane.autoPublishConfig.catalogIssuerDelegationExpiresAt,
     });
-  }
-
-  /**
-   * @deprecated Explicit compatibility alias only. Ordinary VM confirmation
-   * does not call this method; the chain remains the finalized-VM inventory.
-   */
-  recordConfirmedRfc64PublicCatalogAssetV1(
-    this: DKGAgent,
-    params: RecordConfirmedRfc64PublicCatalogAssetParamsV1,
-  ): Promise<AppliedCatalogHeadSnapshotV1 | null> {
-    return this.recordRfc64PublicCatalogAssetV1(params);
   }
 
   /** One canonical activation, policy, ownership, and era boundary for catalog and SWM. */

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -47,7 +47,10 @@ import {
   type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
   type SignedAuthorCatalogHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core';
-import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+import {
+  resolveRpcUrls,
+  verifyControlEnvelopeIssuerSignatureV1,
+} from '@origintrail-official/dkg-chain';
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 import type { Rfc64AuthorCatalogEip191SignerV1 } from './rfc64/author-catalog-producer.js';
@@ -76,9 +79,9 @@ import {
 import {
   Rfc64PublicCatalogNativeReceiverErrorV1,
   Rfc64PublicCatalogNativeReceiverV1,
-  type Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1,
   type Rfc64PublicCatalogNativeSynchronizationEvidenceV1,
 } from './rfc64/public-catalog-native-receiver-v1.js';
+import { createRfc64FinalizedPolicyAgentPrecommitV1 } from './rfc64/finalized-policy-agent-precommit-v1.js';
 import {
   createRfc64BoundedPublicRootCatalogNativeReconcilerV1,
   type Rfc64BoundedPublicRootCatalogDeploymentResolverV1,
@@ -764,18 +767,18 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       },
       readKaBundleByDigest: persistence.kaBundles.readKaBundleByDigest,
       createReconciler: (clients: Readonly<Rfc64PublicCatalogReconcilerClientsV1>) => {
-        const beforeAppliedHeadCommit:
-          Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1 =
-          async (plan, signal) => {
-            signal.throwIfAborted();
-            const acceptedPolicy = this.requireRfc64PublicCatalogServiceV1()
-              .acceptedPolicySnapshotForCatalogScope(plan.catalogScope);
-            if (acceptedPolicy.policy.source.kind === 'finalized-chain') {
-              throw new Error(
-                'RFC-64 SWM-only catalog activation does not yet admit finalized-chain policies',
-              );
-            }
-          };
+        const chainConfig = this.config.chainConfig;
+        const beforeAppliedHeadCommit = createRfc64FinalizedPolicyAgentPrecommitV1({
+          acceptedPolicySnapshotForCatalogScope: (scope) =>
+            this.requireRfc64PublicCatalogServiceV1()
+              .acceptedPolicySnapshotForCatalogScope(scope),
+          rpcEndpoints: chainConfig === undefined
+            ? null
+            : resolveRpcUrls(chainConfig.rpcUrl, chainConfig.rpcUrls),
+          getOnChainContextGraphId: (contextGraphId, signal) =>
+            this.getContextGraphOnChainId(contextGraphId, { signal }),
+          getEvmChainId: () => this.chain.getEvmChainId(),
+        });
         const nativeReceiver = new Rfc64PublicCatalogNativeReceiverV1({
           headTransport: clients.headTransport,
           contentTransport: clients.contentTransport,

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -76,6 +76,7 @@ import {
 import {
   Rfc64PublicCatalogNativeReceiverErrorV1,
   Rfc64PublicCatalogNativeReceiverV1,
+  type Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1,
   type Rfc64PublicCatalogNativeSynchronizationEvidenceV1,
 } from './rfc64/public-catalog-native-receiver-v1.js';
 import {
@@ -763,6 +764,18 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       },
       readKaBundleByDigest: persistence.kaBundles.readKaBundleByDigest,
       createReconciler: (clients: Readonly<Rfc64PublicCatalogReconcilerClientsV1>) => {
+        const beforeAppliedHeadCommit:
+          Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1 =
+          async (plan, signal) => {
+            signal.throwIfAborted();
+            const acceptedPolicy = this.requireRfc64PublicCatalogServiceV1()
+              .acceptedPolicySnapshotForCatalogScope(plan.catalogScope);
+            if (acceptedPolicy.policy.source.kind === 'finalized-chain') {
+              throw new Error(
+                'RFC-64 SWM-only catalog activation does not yet admit finalized-chain policies',
+              );
+            }
+          };
         const nativeReceiver = new Rfc64PublicCatalogNativeReceiverV1({
           headTransport: clients.headTransport,
           contentTransport: clients.contentTransport,
@@ -770,6 +783,7 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
           inventory: persistence.inventory,
           kaBundles: persistence.kaBundles,
           store: this.store,
+          beforeAppliedHeadCommit,
           transportTimeoutMs: clients.transportTimeoutMs,
         });
         const reconciler = createRfc64BoundedPublicRootCatalogNativeReconcilerV1({

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -47,10 +47,7 @@ import {
   type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
   type SignedAuthorCatalogHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core';
-import {
-  resolveRpcUrls,
-  verifyControlEnvelopeIssuerSignatureV1,
-} from '@origintrail-official/dkg-chain';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 import type { Rfc64AuthorCatalogEip191SignerV1 } from './rfc64/author-catalog-producer.js';
@@ -81,7 +78,6 @@ import {
   Rfc64PublicCatalogNativeReceiverV1,
   type Rfc64PublicCatalogNativeSynchronizationEvidenceV1,
 } from './rfc64/public-catalog-native-receiver-v1.js';
-import { createRfc64FinalizedVmAgentPrecommitV1 } from './rfc64/finalized-vm-agent-precommit-v1.js';
 import {
   createRfc64BoundedPublicRootCatalogNativeReconcilerV1,
   type Rfc64BoundedPublicRootCatalogDeploymentResolverV1,
@@ -767,29 +763,6 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       },
       readKaBundleByDigest: persistence.kaBundles.readKaBundleByDigest,
       createReconciler: (clients: Readonly<Rfc64PublicCatalogReconcilerClientsV1>) => {
-        const chainConfig = this.config.chainConfig;
-        const finalizedVmPrecommit = createRfc64FinalizedVmAgentPrecommitV1({
-          acceptedPolicySnapshotForCatalogScope: (scope) =>
-            this.requireRfc64PublicCatalogServiceV1()
-              .acceptedPolicySnapshotForCatalogScope(scope),
-          rpcEndpoints: chainConfig === undefined
-            ? null
-            : resolveRpcUrls(chainConfig.rpcUrl, chainConfig.rpcUrls),
-          getOnChainContextGraphId: (contextGraphId, signal) =>
-            this.getContextGraphOnChainId(contextGraphId, { signal }),
-          getEvmChainId: () => this.chain.getEvmChainId(),
-          getKnowledgeAssetStorageAddress: async () => {
-            if (typeof this.chain.getDKGKnowledgeAssetsAddress !== 'function') {
-              throw new Error(
-                'RFC-64 finalized VM precommit requires DKGKnowledgeAssets resolution',
-              );
-            }
-            return this.chain.getDKGKnowledgeAssetsAddress();
-          },
-          getKnowledgeAssetsLifecycleAddress: () =>
-            this.chain.getKnowledgeAssetsLifecycleAddress(),
-          store: this.store,
-        });
         const nativeReceiver = new Rfc64PublicCatalogNativeReceiverV1({
           headTransport: clients.headTransport,
           contentTransport: clients.contentTransport,
@@ -797,7 +770,6 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
           inventory: persistence.inventory,
           kaBundles: persistence.kaBundles,
           store: this.store,
-          beforeAppliedHeadCommit: finalizedVmPrecommit,
           transportTimeoutMs: clients.transportTimeoutMs,
         });
         const reconciler = createRfc64BoundedPublicRootCatalogNativeReconcilerV1({

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1242,9 +1242,9 @@ export interface Rfc64CatalogAccessPolicyAuthorityConfigV1 {
 }
 
 /**
- * Opt-in RFC-64 author-catalog production for ordinary confirmed public KA
- * publishes. Peer fan-out is an availability hint; the durable applied-head
- * pointer remains the correctness source for pull discovery.
+ * Opt-in RFC-64 SWM author-catalog production. Peer fan-out is an availability
+ * hint; the durable applied-head pointer remains the correctness source for
+ * pull discovery. Finalized VM inventory remains on chain.
  */
 export interface Rfc64PublicCatalogAutoPublishConfigV1 {
   readonly peers: readonly string[];

--- a/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
@@ -1,0 +1,68 @@
+import {
+  assertCanonicalDecimalU256,
+  type AuthorCatalogScopeV1,
+  type ContextGraphIdV1,
+} from '@origintrail-official/dkg-core';
+
+import type { AcceptedRfc64CatalogAccessSnapshotV1 } from './catalog-access-policy-v1.js';
+import type {
+  Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1,
+} from './public-catalog-native-receiver-v1.js';
+
+export interface Rfc64FinalizedPolicyAgentPrecommitOptionsV1 {
+  readonly acceptedPolicySnapshotForCatalogScope:
+    (scope: Readonly<AuthorCatalogScopeV1>) => AcceptedRfc64CatalogAccessSnapshotV1;
+  readonly rpcEndpoints: readonly string[] | null;
+  readonly getOnChainContextGraphId:
+    (contextGraphId: ContextGraphIdV1, signal: AbortSignal) => Promise<string | null>;
+  readonly getEvmChainId: () => Promise<bigint>;
+}
+
+/**
+ * Guard a finalized-chain SWM catalog before its applied-head CAS without
+ * treating catalog rows as a second VM inventory. The chain remains the VM
+ * catalog; this barrier establishes only that the already-accepted policy is
+ * bound to the configured live chain and to a resolvable on-chain CG id.
+ */
+export function createRfc64FinalizedPolicyAgentPrecommitV1(
+  options: Rfc64FinalizedPolicyAgentPrecommitOptionsV1,
+): Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1 {
+  return Object.freeze(async (plan, signal): Promise<void> => {
+    signal.throwIfAborted();
+    const acceptedPolicy = options.acceptedPolicySnapshotForCatalogScope(plan.catalogScope);
+    const { policy } = acceptedPolicy;
+    if (policy.source.kind !== 'finalized-chain') return;
+    if (
+      policy.accessPolicy !== 0
+      || policy.governanceChainId === null
+      || policy.governanceContractAddress === null
+    ) {
+      throw new Error('RFC-64 finalized policy precommit requires one public finalized policy');
+    }
+    if (
+      policy.source.chainId !== policy.governanceChainId
+      || policy.source.contractAddress !== policy.governanceContractAddress
+    ) {
+      throw new Error('RFC-64 finalized policy source differs from its governance binding');
+    }
+    if (options.rpcEndpoints === null || options.rpcEndpoints.length === 0) {
+      throw new Error('RFC-64 finalized policy precommit requires trusted RPC configuration');
+    }
+
+    const [onChainContextGraphId, liveChainId] = await Promise.all([
+      options.getOnChainContextGraphId(plan.catalogScope.contextGraphId, signal),
+      options.getEvmChainId(),
+    ]);
+    signal.throwIfAborted();
+    if (onChainContextGraphId === null) {
+      throw new Error('RFC-64 finalized policy precommit could not resolve the numeric context graph id');
+    }
+    if (liveChainId.toString() !== policy.governanceChainId) {
+      throw new Error('RFC-64 finalized policy differs from the configured chain id');
+    }
+    assertCanonicalDecimalU256(
+      onChainContextGraphId,
+      'RFC-64 finalized policy on-chain context graph id',
+    );
+  });
+}

--- a/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
@@ -1,15 +1,26 @@
 import {
   assertCanonicalDecimalU256,
+  assertCanonicalDigest,
+  canonicalizeContextGraphPolicyPayloadV1,
+  parseCanonicalContextGraphPolicyPayloadV1,
   type AuthorCatalogScopeV1,
+  type ChainIdV1,
   type ContextGraphIdV1,
+  type DecimalU256V1,
+  type EvmAddressV1,
 } from '@origintrail-official/dkg-core';
+import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
 
 import type { AcceptedRfc64CatalogAccessSnapshotV1 } from './catalog-access-policy-v1.js';
+import {
+  resolveAndVerifyRfc64FinalizedPolicyInSnapshotV1,
+} from './finalized-policy-verifier-v1.js';
 import type {
   Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1,
+  Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1,
 } from './public-catalog-native-receiver-v1.js';
 
-export interface Rfc64FinalizedPolicyAgentPrecommitOptionsV1 {
+export interface Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 {
   readonly acceptedPolicySnapshotForCatalogScope:
     (scope: Readonly<AuthorCatalogScopeV1>) => AcceptedRfc64CatalogAccessSnapshotV1;
   readonly rpcEndpoints: readonly string[] | null;
@@ -18,51 +29,141 @@ export interface Rfc64FinalizedPolicyAgentPrecommitOptionsV1 {
   readonly getEvmChainId: () => Promise<bigint>;
 }
 
+export interface Rfc64FinalizedPolicyAgentPrecommitOptionsV1
+  extends Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 {}
+
+export interface ResolvedRfc64FinalizedPolicyAgentPrecommitV1 {
+  readonly acceptedPolicy: AcceptedRfc64CatalogAccessSnapshotV1;
+  readonly chainId: ChainIdV1;
+  readonly contextGraphStorageAddress: EvmAddressV1;
+  readonly onChainContextGraphId: DecimalU256V1;
+  readonly rpcEndpoints: readonly string[];
+}
+
+/**
+ * Resolve and snapshot the shared agent/chain boundary used by both finalized
+ * policy-only and VM-materializing precommits. Returning null means the
+ * accepted policy is not chain-finalized and therefore needs no EVM barrier.
+ */
+export async function resolveRfc64FinalizedPolicyAgentPrecommitV1(
+  options: Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1,
+  plan: Readonly<Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1>,
+  signal: AbortSignal,
+): Promise<Readonly<ResolvedRfc64FinalizedPolicyAgentPrecommitV1> | null> {
+  signal.throwIfAborted();
+  const untrustedAcceptedPolicy = options.acceptedPolicySnapshotForCatalogScope(
+    plan.catalogScope,
+  );
+  let policy: AcceptedRfc64CatalogAccessSnapshotV1['policy'];
+  try {
+    assertCanonicalDigest(
+      untrustedAcceptedPolicy.policyDigest,
+      'RFC-64 finalized precommit policy digest',
+    );
+    policy = parseCanonicalContextGraphPolicyPayloadV1(
+      canonicalizeContextGraphPolicyPayloadV1(untrustedAcceptedPolicy.policy),
+    );
+  } catch (cause) {
+    throw new Error('RFC-64 finalized precommit accepted policy is not canonical', { cause });
+  }
+  if (policy.source.kind !== 'finalized-chain') return null;
+  if (untrustedAcceptedPolicy.roster !== null) {
+    throw new Error('RFC-64 finalized precommit public policy forbids a private member roster');
+  }
+  const acceptedPolicy = Object.freeze({
+    policy,
+    policyDigest: untrustedAcceptedPolicy.policyDigest,
+    roster: null,
+  });
+  const chainId = policy.governanceChainId;
+  const contextGraphStorageAddress = policy.governanceContractAddress;
+  if (
+    policy.accessPolicy !== 0
+    || chainId === null
+    || contextGraphStorageAddress === null
+  ) {
+    throw new Error('RFC-64 finalized precommit requires one public finalized policy');
+  }
+  if (
+    policy.source.chainId !== chainId
+    || policy.source.contractAddress !== contextGraphStorageAddress
+  ) {
+    throw new Error('RFC-64 finalized precommit source differs from its governance binding');
+  }
+  if (options.rpcEndpoints === null || options.rpcEndpoints.length === 0) {
+    throw new Error('RFC-64 finalized precommit requires trusted RPC configuration');
+  }
+  const rpcEndpoints = Object.freeze([...options.rpcEndpoints]);
+
+  const [untrustedContextGraphId, liveChainId] = await Promise.all([
+    options.getOnChainContextGraphId(plan.catalogScope.contextGraphId, signal),
+    options.getEvmChainId(),
+  ]);
+  signal.throwIfAborted();
+  if (untrustedContextGraphId === null) {
+    throw new Error('RFC-64 finalized precommit could not resolve the numeric context graph id');
+  }
+  if (liveChainId.toString() !== chainId) {
+    throw new Error('RFC-64 finalized precommit policy differs from the configured chain id');
+  }
+  assertCanonicalDecimalU256(
+    untrustedContextGraphId,
+    'RFC-64 finalized precommit on-chain context graph id',
+  );
+  if (untrustedContextGraphId === '0') {
+    throw new Error('RFC-64 finalized precommit on-chain context graph id must be nonzero');
+  }
+  return Object.freeze({
+    acceptedPolicy,
+    chainId,
+    contextGraphStorageAddress,
+    onChainContextGraphId: untrustedContextGraphId,
+    rpcEndpoints,
+  });
+}
+
 /**
  * Guard a finalized-chain SWM catalog before its applied-head CAS without
  * treating catalog rows as a second VM inventory. The chain remains the VM
- * catalog; this barrier establishes only that the already-accepted policy is
- * bound to the configured live chain and to a resolvable on-chain CG id.
+ * catalog; this barrier verifies the accepted public policy, cleartext CG name,
+ * governance binding, and finality anchor against live chain state only.
  */
 export function createRfc64FinalizedPolicyAgentPrecommitV1(
   options: Rfc64FinalizedPolicyAgentPrecommitOptionsV1,
 ): Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1 {
   return Object.freeze(async (plan, signal): Promise<void> => {
-    signal.throwIfAborted();
-    const acceptedPolicy = options.acceptedPolicySnapshotForCatalogScope(plan.catalogScope);
-    const { policy } = acceptedPolicy;
-    if (policy.source.kind !== 'finalized-chain') return;
-    if (
-      policy.accessPolicy !== 0
-      || policy.governanceChainId === null
-      || policy.governanceContractAddress === null
-    ) {
-      throw new Error('RFC-64 finalized policy precommit requires one public finalized policy');
-    }
-    if (
-      policy.source.chainId !== policy.governanceChainId
-      || policy.source.contractAddress !== policy.governanceContractAddress
-    ) {
-      throw new Error('RFC-64 finalized policy source differs from its governance binding');
-    }
-    if (options.rpcEndpoints === null || options.rpcEndpoints.length === 0) {
-      throw new Error('RFC-64 finalized policy precommit requires trusted RPC configuration');
-    }
-
-    const [onChainContextGraphId, liveChainId] = await Promise.all([
-      options.getOnChainContextGraphId(plan.catalogScope.contextGraphId, signal),
-      options.getEvmChainId(),
-    ]);
-    signal.throwIfAborted();
-    if (onChainContextGraphId === null) {
-      throw new Error('RFC-64 finalized policy precommit could not resolve the numeric context graph id');
-    }
-    if (liveChainId.toString() !== policy.governanceChainId) {
-      throw new Error('RFC-64 finalized policy differs from the configured chain id');
-    }
-    assertCanonicalDecimalU256(
-      onChainContextGraphId,
-      'RFC-64 finalized policy on-chain context graph id',
+    const resolved = await resolveRfc64FinalizedPolicyAgentPrecommitV1(
+      options,
+      plan,
+      signal,
+    );
+    if (resolved === null) return;
+    const snapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      chainId: resolved.chainId,
+      endpoints: resolved.rpcEndpoints,
+      // One process-wide per-chain gate protects concurrent policy and VM
+      // reads even though each precommit owns its own snapshot scope.
+      owner: 'rfc64',
+    });
+    await snapshot(
+      { chainId: resolved.chainId, signal },
+      (session) => resolveAndVerifyRfc64FinalizedPolicyInSnapshotV1(
+        {
+          networkId: plan.catalogScope.networkId,
+          chainId: resolved.chainId,
+          contextGraphStorageAddress: resolved.contextGraphStorageAddress,
+        },
+        {
+          catalogLane: Object.freeze({
+            contextGraphId: plan.catalogScope.contextGraphId,
+            subGraphName: plan.catalogScope.subGraphName,
+          }),
+          onChainContextGraphId: resolved.onChainContextGraphId,
+          acceptedPolicy: resolved.acceptedPolicy.policy,
+          signal,
+        },
+        session,
+      ),
     );
   });
 }

--- a/packages/agent/src/rfc64/finalized-policy-verifier-v1.ts
+++ b/packages/agent/src/rfc64/finalized-policy-verifier-v1.ts
@@ -1,0 +1,222 @@
+import {
+  assertCanonicalChainId,
+  assertCanonicalDecimalU256,
+  assertCanonicalEvmAddress,
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
+  assertSubGraphNameV1,
+  canonicalizeContextGraphPolicyPayloadV1,
+  parseCanonicalContextGraphPolicyPayloadV1,
+  type ChainIdV1,
+  type ContextGraphIdV1,
+  type ContextGraphPolicyV1,
+  type DecimalU256V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
+  type SubGraphNameV1,
+} from '@origintrail-official/dkg-core';
+import {
+  createFinalizedContextGraphRpcResolverV1,
+  resolveFinalizedContextGraphReadWithSignalV1,
+  type FinalizedContextGraphReadV1,
+  type StrictCurrentFinalizedEvmReadV1,
+  type StrictCurrentFinalizedEvmSnapshotSessionV1,
+} from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
+
+const ZERO_EVM_ADDRESS = `0x${'00'.repeat(20)}`;
+
+export interface Rfc64FinalizedPolicyVerifierConfigV1 {
+  readonly networkId: NetworkIdV1;
+  readonly chainId: ChainIdV1;
+  readonly contextGraphStorageAddress: EvmAddressV1;
+}
+
+export interface Rfc64FinalizedPolicyVerifierRequestV1 {
+  readonly catalogLane: Readonly<{
+    readonly contextGraphId: ContextGraphIdV1;
+    readonly subGraphName: SubGraphNameV1 | null;
+  }>;
+  readonly onChainContextGraphId: DecimalU256V1;
+  readonly acceptedPolicy: Readonly<ContextGraphPolicyV1>;
+  readonly signal: AbortSignal;
+}
+
+export type Rfc64FinalizedPolicyVerifierErrorCodeV1 =
+  | 'finalized-policy-verifier-config'
+  | 'finalized-policy-verifier-request'
+  | 'finalized-policy-verifier-anchor'
+  | 'finalized-policy-verifier-policy';
+
+export class Rfc64FinalizedPolicyVerifierErrorV1 extends Error {
+  constructor(
+    readonly code: Rfc64FinalizedPolicyVerifierErrorCodeV1,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'Rfc64FinalizedPolicyVerifierErrorV1';
+  }
+}
+
+/**
+ * Resolve and verify the accepted RFC-64 policy at the caller's exact pinned
+ * finalized snapshot. Both the SWM-only precommit and the legacy VM runtime
+ * compose this function so their policy, name, governance, and anchor
+ * invariants cannot drift apart.
+ */
+export async function resolveAndVerifyRfc64FinalizedPolicyInSnapshotV1(
+  inputConfig: Rfc64FinalizedPolicyVerifierConfigV1,
+  inputRequest: Rfc64FinalizedPolicyVerifierRequestV1,
+  session: StrictCurrentFinalizedEvmSnapshotSessionV1,
+): Promise<Readonly<FinalizedContextGraphReadV1>> {
+  const config = snapshotConfig(inputConfig);
+  const request = snapshotRequest(inputRequest);
+  request.signal.throwIfAborted();
+  if (session.chainId !== config.chainId) {
+    fail('finalized-policy-verifier-anchor', 'snapshot session uses a different chain');
+  }
+
+  const read: StrictCurrentFinalizedEvmReadV1 = async (readRequest) => {
+    if (readRequest.chainId !== session.chainId) {
+      fail('finalized-policy-verifier-anchor', 'policy read requested a different chain');
+    }
+    const returnData = await session.read(readRequest.calls);
+    return Object.freeze({
+      chainId: session.chainId,
+      blockNumber: session.blockNumber,
+      blockHash: session.blockHash,
+      returnData,
+    });
+  };
+  const finalized = await resolveFinalizedContextGraphReadWithSignalV1(
+    createFinalizedContextGraphRpcResolverV1(read),
+    {
+      chainId: config.chainId,
+      contextGraphId: request.onChainContextGraphId,
+      governanceContract: config.contextGraphStorageAddress,
+    },
+    request.signal,
+  );
+  request.signal.throwIfAborted();
+  assertAcceptedRfc64FinalizedPublicPolicyV1(
+    config,
+    request.catalogLane,
+    request.acceptedPolicy,
+    finalized,
+  );
+  return finalized;
+}
+
+/** Single-source policy predicate shared by every finalized RFC-64 consumer. */
+export function assertAcceptedRfc64FinalizedPublicPolicyV1(
+  config: Readonly<Rfc64FinalizedPolicyVerifierConfigV1>,
+  catalogLane: Readonly<Rfc64FinalizedPolicyVerifierRequestV1['catalogLane']>,
+  policy: Readonly<ContextGraphPolicyV1>,
+  finalized: Readonly<FinalizedContextGraphReadV1>,
+): void {
+  const source = policy.source;
+  const expectedNameHash = ethers.keccak256(
+    ethers.toUtf8Bytes(catalogLane.contextGraphId),
+  ).toLowerCase();
+  const sourcePrecedesAnchor = source.kind === 'finalized-chain'
+    && BigInt(source.blockNumber) <= BigInt(finalized.blockNumber);
+  const sameSourceAnchor = source.kind === 'finalized-chain'
+    && source.blockNumber === finalized.blockNumber;
+  if (
+    policy.accessPolicy !== 0
+    || policy.networkId !== config.networkId
+    || policy.contextGraphId !== catalogLane.contextGraphId
+    || policy.governanceChainId !== config.chainId
+    || policy.governanceContractAddress !== config.contextGraphStorageAddress
+    || source.kind !== 'finalized-chain'
+    || source.chainId !== config.chainId
+    || source.contractAddress !== config.contextGraphStorageAddress
+    || !sourcePrecedesAnchor
+    || (sameSourceAnchor && source.blockHash !== finalized.blockHash)
+    || !finalized.active
+    || finalized.nameHash !== expectedNameHash
+    || finalized.accessPolicy !== policy.accessPolicy
+    || finalized.publishPolicy !== policy.publishPolicy
+    || finalized.publishAuthority !== policy.publishAuthority
+    || finalized.publishAuthorityAccountId !== policy.publishAuthorityAccountId
+  ) {
+    fail(
+      'finalized-policy-verifier-policy',
+      'accepted public policy or cleartext name binding differs from finalized chain truth',
+    );
+  }
+}
+
+function snapshotConfig(
+  input: Rfc64FinalizedPolicyVerifierConfigV1,
+): Readonly<Rfc64FinalizedPolicyVerifierConfigV1> {
+  try {
+    assertNetworkIdV1(input.networkId, 'finalized policy verifier networkId');
+    assertCanonicalChainId(input.chainId, 'finalized policy verifier chainId');
+    assertCanonicalEvmAddress(
+      input.contextGraphStorageAddress,
+      'finalized policy verifier contextGraphStorageAddress',
+    );
+    if (input.contextGraphStorageAddress === ZERO_EVM_ADDRESS) {
+      throw new TypeError('contextGraphStorageAddress must be nonzero');
+    }
+  } catch (cause) {
+    fail('finalized-policy-verifier-config', 'verifier config is not canonical', cause);
+  }
+  return Object.freeze({
+    networkId: input.networkId,
+    chainId: input.chainId,
+    contextGraphStorageAddress: input.contextGraphStorageAddress,
+  });
+}
+
+function snapshotRequest(
+  input: Rfc64FinalizedPolicyVerifierRequestV1,
+): Readonly<Rfc64FinalizedPolicyVerifierRequestV1> {
+  try {
+    assertContextGraphIdV1(
+      input.catalogLane.contextGraphId,
+      'finalized policy verifier catalogLane.contextGraphId',
+    );
+    if (input.catalogLane.subGraphName !== null) {
+      assertSubGraphNameV1(
+        input.catalogLane.subGraphName,
+        'finalized policy verifier catalogLane.subGraphName',
+      );
+    }
+    assertCanonicalDecimalU256(
+      input.onChainContextGraphId,
+      'finalized policy verifier onChainContextGraphId',
+    );
+    if (input.onChainContextGraphId === '0') {
+      throw new TypeError('onChainContextGraphId must be nonzero');
+    }
+    const acceptedPolicy = parseCanonicalContextGraphPolicyPayloadV1(
+      canonicalizeContextGraphPolicyPayloadV1(input.acceptedPolicy),
+    );
+    return Object.freeze({
+      catalogLane: Object.freeze({
+        contextGraphId: input.catalogLane.contextGraphId,
+        subGraphName: input.catalogLane.subGraphName,
+      }),
+      onChainContextGraphId: input.onChainContextGraphId,
+      acceptedPolicy,
+      signal: input.signal,
+    });
+  } catch (cause) {
+    fail('finalized-policy-verifier-request', 'verifier request is not canonical', cause);
+  }
+}
+
+function fail(
+  code: Rfc64FinalizedPolicyVerifierErrorCodeV1,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new Rfc64FinalizedPolicyVerifierErrorV1(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts
@@ -1,5 +1,4 @@
 import {
-  assertCanonicalDecimalU256,
   assertCanonicalEvmAddress,
   type AuthorCatalogScopeV1,
   type ContextGraphIdV1,
@@ -11,6 +10,7 @@ import type { AcceptedRfc64CatalogAccessSnapshotV1 } from './catalog-access-poli
 import type {
   Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1,
 } from './public-catalog-native-receiver-v1.js';
+import { resolveRfc64FinalizedPolicyAgentPrecommitV1 } from './finalized-policy-agent-precommit-v1.js';
 import { createFinalizedVmRuntimeV1 } from './finalized-vm-runtime-v1.js';
 import { createFinalizedVmStoreMaterializerV1 } from './finalized-vm-store-materializer-v1.js';
 
@@ -35,45 +35,17 @@ export function createRfc64FinalizedVmAgentPrecommitV1(
   options: Rfc64FinalizedVmAgentPrecommitOptionsV1,
 ): Rfc64PublicCatalogNativeBeforeAppliedHeadCommitHandlerV1 {
   return Object.freeze(async (plan, signal): Promise<void> => {
-    signal.throwIfAborted();
-    const acceptedPolicy = options.acceptedPolicySnapshotForCatalogScope(plan.catalogScope);
-    const { policy } = acceptedPolicy;
-    if (policy.source.kind !== 'finalized-chain') return;
-    if (
-      policy.accessPolicy !== 0
-      || policy.governanceChainId === null
-      || policy.governanceContractAddress === null
-    ) {
-      throw new Error('RFC-64 finalized VM precommit requires one public finalized policy');
-    }
-    if (options.rpcEndpoints === null || options.rpcEndpoints.length === 0) {
-      throw new Error('RFC-64 finalized VM precommit requires trusted RPC configuration');
-    }
-
-    const [
-      onChainContextGraphId,
-      liveChainId,
-      knowledgeAssetStorageAddress,
-      knowledgeAssetsLifecycleAddress,
-    ] =
-      await Promise.all([
-        options.getOnChainContextGraphId(plan.catalogScope.contextGraphId, signal),
-        options.getEvmChainId(),
-        options.getKnowledgeAssetStorageAddress(),
-        options.getKnowledgeAssetsLifecycleAddress(),
-      ]);
-    signal.throwIfAborted();
-    if (onChainContextGraphId === null) {
-      throw new Error('RFC-64 finalized VM precommit could not resolve the numeric context graph id');
-    }
-    if (liveChainId.toString() !== policy.governanceChainId) {
-      throw new Error('RFC-64 finalized VM policy differs from the configured chain id');
-    }
-
-    assertCanonicalDecimalU256(
-      onChainContextGraphId,
-      'RFC-64 finalized VM on-chain context graph id',
+    const resolved = await resolveRfc64FinalizedPolicyAgentPrecommitV1(
+      options,
+      plan,
+      signal,
     );
+    if (resolved === null) return;
+    const [knowledgeAssetStorageAddress, knowledgeAssetsLifecycleAddress] = await Promise.all([
+      options.getKnowledgeAssetStorageAddress(),
+      options.getKnowledgeAssetsLifecycleAddress(),
+    ]);
+    signal.throwIfAborted();
     const canonicalKnowledgeAssetStorageAddress = knowledgeAssetStorageAddress.toLowerCase();
     assertCanonicalEvmAddress(
       canonicalKnowledgeAssetStorageAddress,
@@ -84,16 +56,15 @@ export function createRfc64FinalizedVmAgentPrecommitV1(
       canonicalKnowledgeAssetsLifecycleAddress,
       'RFC-64 finalized VM knowledge assets lifecycle address',
     );
-    const chainId = policy.governanceChainId;
     const runtime = createFinalizedVmRuntimeV1({
       networkId: plan.catalogScope.networkId,
-      chainId,
-      contextGraphStorageAddress: policy.governanceContractAddress,
+      chainId: resolved.chainId,
+      contextGraphStorageAddress: resolved.contextGraphStorageAddress,
       knowledgeAssetStorageAddress: canonicalKnowledgeAssetStorageAddress,
       knowledgeAssetsLifecycleAddress: canonicalKnowledgeAssetsLifecycleAddress,
       snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
-        chainId,
-        endpoints: options.rpcEndpoints,
+        chainId: resolved.chainId,
+        endpoints: resolved.rpcEndpoints,
         // This scope is constructed PER precommit invocation, so its admission
         // must come from the process-wide per-chain registry — a gate private
         // to this instance would have contended with nothing, and two
@@ -107,8 +78,8 @@ export function createRfc64FinalizedVmAgentPrecommitV1(
         contextGraphId: plan.catalogScope.contextGraphId,
         subGraphName: plan.catalogScope.subGraphName,
       }),
-      onChainContextGraphId,
-      acceptedPolicy,
+      onChainContextGraphId: resolved.onChainContextGraphId,
+      acceptedPolicy: resolved.acceptedPolicy,
       placements: Object.freeze(plan.rows.map((row) => Object.freeze({
         authorship: row.authorship,
         sealBinding: row.sealBinding,

--- a/packages/agent/src/rfc64/finalized-vm-runtime-v1.ts
+++ b/packages/agent/src/rfc64/finalized-vm-runtime-v1.ts
@@ -23,18 +23,19 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   FINALIZED_VM_CHAIN_SCAN_MAX_ROWS_V1,
-  createFinalizedContextGraphRpcResolverV1,
-  resolveFinalizedContextGraphReadWithSignalV1,
   scanFinalizedVmChainInventoryInSnapshotV1,
   type FinalizedContextGraphReadV1,
   type FinalizedVmChainCandidateV1,
   type FinalizedVmChainInventoryV1,
-  type StrictCurrentFinalizedEvmReadV1,
   type StrictCurrentFinalizedEvmSnapshotScopeV1,
+  type StrictCurrentFinalizedEvmSnapshotSessionV1,
 } from '@origintrail-official/dkg-chain';
-import { ethers } from 'ethers';
 
 import type { AcceptedRfc64CatalogAccessSnapshotV1 } from './catalog-access-policy-v1.js';
+import {
+  Rfc64FinalizedPolicyVerifierErrorV1,
+  resolveAndVerifyRfc64FinalizedPolicyInSnapshotV1,
+} from './finalized-policy-verifier-v1.js';
 import {
   composeFinalizedVmSetV1,
   type ComposedFinalizedVmSetV1,
@@ -165,26 +166,10 @@ export function createFinalizedVmRuntimeV1(
     const verified = await config.snapshot(
       { chainId: config.chainId, signal: request.signal },
       async (session): Promise<VerifiedSnapshotV1> => {
-        const read: StrictCurrentFinalizedEvmReadV1 = async (readRequest) => {
-          if (readRequest.chainId !== session.chainId) {
-            fail('finalized-vm-runtime-anchor', 'policy read requested a different chain');
-          }
-          const returnData = await session.read(readRequest.calls);
-          return Object.freeze({
-            chainId: session.chainId,
-            blockNumber: session.blockNumber,
-            blockHash: session.blockHash,
-            returnData,
-          });
-        };
-        const finalizedContextGraph = await resolveFinalizedContextGraphReadWithSignalV1(
-          createFinalizedContextGraphRpcResolverV1(read),
-          {
-            chainId: config.chainId,
-            contextGraphId: request.onChainContextGraphId,
-            governanceContract: config.contextGraphStorageAddress,
-          },
-          request.signal,
+        const finalizedContextGraph = await resolveFinalizedPolicyForVmRuntime(
+          config,
+          request,
+          session,
         );
         const inventory = await scanFinalizedVmChainInventoryInSnapshotV1(
           {
@@ -197,12 +182,6 @@ export function createFinalizedVmRuntimeV1(
           session,
         );
         assertExactAnchor(finalizedContextGraph, inventory);
-        assertAcceptedPublicPolicy(
-          config,
-          request.catalogLane,
-          request.acceptedPolicy,
-          finalizedContextGraph,
-        );
 
         const composed = composeFinalizedVmSetV1({
           assertedAtKav10Address: config.knowledgeAssetsLifecycleAddress,
@@ -327,42 +306,44 @@ function snapshotCatalogLane(input: FinalizedVmCatalogLaneV1): FinalizedVmCatalo
   });
 }
 
-function assertAcceptedPublicPolicy(
+async function resolveFinalizedPolicyForVmRuntime(
   config: RuntimeConfigSnapshotV1,
-  catalogLane: FinalizedVmCatalogLaneV1,
-  policy: Readonly<ContextGraphPolicyV1>,
-  finalized: Readonly<FinalizedContextGraphReadV1>,
-): void {
-  const source = policy.source;
-  const expectedNameHash = ethers.keccak256(
-    ethers.toUtf8Bytes(catalogLane.contextGraphId),
-  ).toLowerCase();
-  const sourcePrecedesAnchor = source.kind === 'finalized-chain'
-    && BigInt(source.blockNumber) <= BigInt(finalized.blockNumber);
-  const sameSourceAnchor = source.kind === 'finalized-chain'
-    && source.blockNumber === finalized.blockNumber;
-  if (
-    policy.accessPolicy !== 0
-    || policy.networkId !== config.networkId
-    || policy.contextGraphId !== catalogLane.contextGraphId
-    || policy.governanceChainId !== config.chainId
-    || policy.governanceContractAddress !== config.contextGraphStorageAddress
-    || source.kind !== 'finalized-chain'
-    || source.chainId !== config.chainId
-    || source.contractAddress !== config.contextGraphStorageAddress
-    || !sourcePrecedesAnchor
-    || (sameSourceAnchor && source.blockHash !== finalized.blockHash)
-    || !finalized.active
-    || finalized.nameHash !== expectedNameHash
-    || finalized.accessPolicy !== policy.accessPolicy
-    || finalized.publishPolicy !== policy.publishPolicy
-    || finalized.publishAuthority !== policy.publishAuthority
-    || finalized.publishAuthorityAccountId !== policy.publishAuthorityAccountId
-  ) {
-    fail(
-      'finalized-vm-runtime-policy',
-      'accepted public policy or cleartext name binding differs from finalized chain truth',
+  request: RuntimeRequestSnapshotV1,
+  session: StrictCurrentFinalizedEvmSnapshotSessionV1,
+): Promise<Readonly<FinalizedContextGraphReadV1>> {
+  try {
+    return await resolveAndVerifyRfc64FinalizedPolicyInSnapshotV1(
+      {
+        networkId: config.networkId,
+        chainId: config.chainId,
+        contextGraphStorageAddress: config.contextGraphStorageAddress,
+      },
+      {
+        catalogLane: request.catalogLane,
+        onChainContextGraphId: request.onChainContextGraphId,
+        acceptedPolicy: request.acceptedPolicy,
+        signal: request.signal,
+      },
+      session,
     );
+  } catch (cause) {
+    if (cause instanceof Rfc64FinalizedPolicyVerifierErrorV1) {
+      if (cause.code === 'finalized-policy-verifier-policy') {
+        fail(
+          'finalized-vm-runtime-policy',
+          'accepted public policy or cleartext name binding differs from finalized chain truth',
+          cause,
+        );
+      }
+      if (cause.code === 'finalized-policy-verifier-anchor') {
+        fail('finalized-vm-runtime-anchor', 'finalized policy anchor is invalid', cause);
+      }
+      if (cause.code === 'finalized-policy-verifier-config') {
+        fail('finalized-vm-runtime-config', 'finalized policy config is invalid', cause);
+      }
+      fail('finalized-vm-runtime-request', 'finalized policy request is invalid', cause);
+    }
+    throw cause;
   }
 }
 

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -282,6 +282,24 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     this.#timeoutMs = timeoutMs;
   }
 
+  private async runBeforeAppliedHeadCommitV1(
+    plan: Readonly<Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1>,
+    signal: AbortSignal | undefined,
+    failureMessage: string,
+    rollback?: (cause: unknown) => Promise<void>,
+  ): Promise<void> {
+    const precommitSignal = signal ?? new AbortController().signal;
+    try {
+      throwIfAborted(precommitSignal);
+      await this.options.beforeAppliedHeadCommit?.(Object.freeze(plan), precommitSignal);
+      throwIfAborted(precommitSignal);
+    } catch (cause) {
+      await rollback?.(cause);
+      if (precommitSignal.aborted && cause === precommitSignal.reason) throw cause;
+      fail('catalog-native-receiver-activation', failureMessage, cause);
+    }
+  }
+
   async synchronizeOneBoundedPublicRootRow(
     remotePeerId: string,
     announcement: Rfc64PublicCatalogHeadAnnouncementV1,
@@ -496,24 +514,16 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       fail('catalog-native-receiver-catalog', 'verified genesis objects could not be staged', cause);
     }
 
-    const precommitSignal = signal ?? new AbortController().signal;
-    try {
-      throwIfAborted(precommitSignal);
-      await this.options.beforeAppliedHeadCommit?.(Object.freeze({
+    await this.runBeforeAppliedHeadCommitV1(
+      Object.freeze({
         catalogScope: trustedCatalogScope,
         catalogHeadDigest: head.objectDigest as Digest32V1,
         inventoryDigest,
         rows: Object.freeze([]),
-      }), precommitSignal);
-      throwIfAborted(precommitSignal);
-    } catch (cause) {
-      if (precommitSignal.aborted && cause === precommitSignal.reason) throw cause;
-      fail(
-        'catalog-native-receiver-activation',
-        'catalog applied-head precommit rejected the exact empty inventory',
-        cause,
-      );
-    }
+      }),
+      signal,
+      'catalog applied-head precommit rejected the exact empty inventory',
+    );
 
     let appliedHeadStatus: 'applied' | 'existing';
     if (replay) {
@@ -973,10 +983,8 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       );
     }
 
-    const precommitSignal = signal ?? new AbortController().signal;
-    try {
-      throwIfAborted(precommitSignal);
-      await this.options.beforeAppliedHeadCommit?.(Object.freeze({
+    await this.runBeforeAppliedHeadCommitV1(
+      Object.freeze({
         catalogScope: trustedCatalogScope,
         catalogHeadDigest: head.objectDigest as Digest32V1,
         inventoryDigest: completion.inventoryDigest,
@@ -984,17 +992,14 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
           authorship: prepared.authorshipCapability,
           sealBinding: prepared.sealBindingCapability,
         }))),
-      }), precommitSignal);
-      throwIfAborted(precommitSignal);
-    } catch (cause) {
-      await restoreExactPredecessorAfterFailure(cause, 'catalog applied-head precommit');
-      if (precommitSignal.aborted && cause === precommitSignal.reason) throw cause;
-      fail(
-        'catalog-native-receiver-activation',
-        'catalog applied-head precommit rejected the exact activated inventory',
+      }),
+      signal,
+      'catalog applied-head precommit rejected the exact activated inventory',
+      (cause) => restoreExactPredecessorAfterFailure(
         cause,
-      );
-    }
+        'catalog applied-head precommit',
+      ),
+    );
 
     let appliedHeadStatus: 'applied' | 'existing';
     if (historyDisposition === 'replay') {

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -898,6 +898,21 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     let completion!: ReturnType<typeof verifyRfc64PublicCatalogInventoryCompletenessV1>;
     let activatedTripleCount = 0;
     let semanticMutationAttempted = false;
+    const restoreExactPredecessorAfterFailure = async (
+      cause: unknown,
+      failureStage: 'semantic transition' | 'catalog applied-head precommit',
+    ): Promise<void> => {
+      if (!semanticMutationAttempted) return;
+      try {
+        await restoreSemanticTransitionV1(this.options.store, transitionJournal);
+      } catch (rollbackCause) {
+        fail(
+          'catalog-native-receiver-activation',
+          `${failureStage} failed and its exact predecessor rollback also failed`,
+          new AggregateError([cause, rollbackCause]),
+        );
+      }
+    };
     try {
       for (const removal of plannedRemovals) {
         throwIfAborted(signal);
@@ -948,17 +963,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         );
       }
     } catch (cause) {
-      if (semanticMutationAttempted) {
-        try {
-          await restoreSemanticTransitionV1(this.options.store, transitionJournal);
-        } catch (rollbackCause) {
-          fail(
-            'catalog-native-receiver-activation',
-            'semantic transition failed and its exact predecessor rollback also failed',
-            new AggregateError([cause, rollbackCause]),
-          );
-        }
-      }
+      await restoreExactPredecessorAfterFailure(cause, 'semantic transition');
       if (signal?.aborted && cause === signal.reason) throw cause;
       if (cause instanceof Rfc64PublicCatalogNativeReceiverErrorV1) throw cause;
       fail(
@@ -982,17 +987,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       }), precommitSignal);
       throwIfAborted(precommitSignal);
     } catch (cause) {
-      if (semanticMutationAttempted) {
-        try {
-          await restoreSemanticTransitionV1(this.options.store, transitionJournal);
-        } catch (rollbackCause) {
-          fail(
-            'catalog-native-receiver-activation',
-            'catalog applied-head precommit failed and its exact predecessor rollback also failed',
-            new AggregateError([cause, rollbackCause]),
-          );
-        }
-      }
+      await restoreExactPredecessorAfterFailure(cause, 'catalog applied-head precommit');
       if (precommitSignal.aborted && cause === precommitSignal.reason) throw cause;
       fail(
         'catalog-native-receiver-activation',

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -496,6 +496,25 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       fail('catalog-native-receiver-catalog', 'verified genesis objects could not be staged', cause);
     }
 
+    const precommitSignal = signal ?? new AbortController().signal;
+    try {
+      throwIfAborted(precommitSignal);
+      await this.options.beforeAppliedHeadCommit?.(Object.freeze({
+        catalogScope: trustedCatalogScope,
+        catalogHeadDigest: head.objectDigest as Digest32V1,
+        inventoryDigest,
+        rows: Object.freeze([]),
+      }), precommitSignal);
+      throwIfAborted(precommitSignal);
+    } catch (cause) {
+      if (precommitSignal.aborted && cause === precommitSignal.reason) throw cause;
+      fail(
+        'catalog-native-receiver-activation',
+        'catalog applied-head precommit rejected the exact empty inventory',
+        cause,
+      );
+    }
+
     let appliedHeadStatus: 'applied' | 'existing';
     if (replay) {
       appliedHeadStatus = 'existing';

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -963,10 +963,21 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       }), precommitSignal);
       throwIfAborted(precommitSignal);
     } catch (cause) {
+      if (semanticMutationAttempted) {
+        try {
+          await restoreSemanticTransitionV1(this.options.store, transitionJournal);
+        } catch (rollbackCause) {
+          fail(
+            'catalog-native-receiver-activation',
+            'catalog applied-head precommit failed and its exact predecessor rollback also failed',
+            new AggregateError([cause, rollbackCause]),
+          );
+        }
+      }
       if (precommitSignal.aborted && cause === precommitSignal.reason) throw cause;
       fail(
         'catalog-native-receiver-activation',
-        'finalized VM precommit rejected the exact activated inventory',
+        'catalog applied-head precommit rejected the exact activated inventory',
         cause,
       );
     }

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -1002,7 +1002,9 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
     }));
     agentLike.removeRfc64SwmAuthorInventoryShadowV1 = removal;
     const catalogAuthoring = recorder(async () => null);
+    const legacyCatalogAuthoring = recorder(async () => null);
     agentLike.recordRfc64PublicCatalogAssetV1 = catalogAuthoring;
+    agentLike.recordConfirmedRfc64PublicCatalogAssetV1 = legacyCatalogAuthoring;
     const snapshotQuads = [{
       subject: 'urn:test:queued-public',
       predicate: 'http://schema.org/name',
@@ -1032,8 +1034,24 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       },
     });
     expect(catalogAuthoring.calls).toHaveLength(0);
-    expect((DKGAgent.prototype as any).recordConfirmedRfc64PublicCatalogAssetV1)
-      .toBeUndefined();
+    expect(legacyCatalogAuthoring.calls).toHaveLength(0);
+  });
+
+  it('keeps the deprecated confirmed-catalog method as an explicit-authoring adapter', async () => {
+    const expected = Object.freeze({ objectDigest: 'sha256:compatibility-head' });
+    const canonicalCatalogAuthoring = recorder(async () => expected);
+    const agentLike = {
+      recordRfc64PublicCatalogAssetV1: canonicalCatalogAuthoring,
+    };
+    const params = Object.freeze({ contextGraphId: 'public-cg' });
+
+    await expect(
+      (DKGAgent.prototype as any).recordConfirmedRfc64PublicCatalogAssetV1.call(
+        agentLike,
+        params,
+      ),
+    ).resolves.toBe(expected);
+    expect(canonicalCatalogAuthoring.calls).toEqual([[params]]);
   });
 
   it('keeps a confirmed queued VM publish successful when SWM inventory removal fails', async () => {

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -1032,6 +1032,8 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       },
     });
     expect(catalogAuthoring.calls).toHaveLength(0);
+    expect((DKGAgent.prototype as any).recordConfirmedRfc64PublicCatalogAssetV1)
+      .toBeUndefined();
   });
 
   it('keeps a confirmed queued VM publish successful when SWM inventory removal fails', async () => {

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -987,14 +987,22 @@ async function makeQueuedPublishRequest(options: {
 }
 
 describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routing', () => {
-  it('hands one confirmed queued public publish to the RFC-64 catalog bridge', async () => {
+  it('uses a confirmed queued VM publish only to remove the RFC-64 SWM inventory row', async () => {
     const { agentLike } = makeQueuedAgentHarness({
-      peerId: 'did:dkg:agent:queued-catalog',
-      ual: 'did:dkg:local/queued-catalog',
+      peerId: 'did:dkg:agent:queued-swm-removal',
+      ual: 'did:dkg:local/queued-swm-removal',
       publishStatus: 'confirmed',
     });
-    const catalogAdvance = recorder(async () => null);
-    agentLike.recordConfirmedRfc64PublicCatalogAssetV1 = catalogAdvance;
+    const removal = recorder(async () => ({
+      status: 'applied',
+      action: 'remove',
+      attempts: 1,
+      headObjectDigest: null,
+      error: null,
+    }));
+    agentLike.removeRfc64SwmAuthorInventoryShadowV1 = removal;
+    const catalogAuthoring = recorder(async () => null);
+    agentLike.recordRfc64PublicCatalogAssetV1 = catalogAuthoring;
     const snapshotQuads = [{
       subject: 'urn:test:queued-public',
       predicate: 'http://schema.org/name',
@@ -1015,26 +1023,25 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       { contextGraphId: request.contextGraphId, quads: snapshotQuads },
     );
 
-    expect(catalogAdvance.calls).toHaveLength(1);
-    expect(catalogAdvance.calls[0]?.[0]).toMatchObject({
+    expect(removal.calls).toHaveLength(1);
+    expect(removal.calls[0]?.[0]).toMatchObject({
       contextGraphId: 'public-cg',
-      assertionCoordinate: 'queued-public-ka',
-      publicQuads: snapshotQuads,
       seal: {
         authorAddress: QUEUED_TEST_AUTHOR,
         contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
       },
     });
+    expect(catalogAuthoring.calls).toHaveLength(0);
   });
 
-  it('keeps a confirmed queued publish successful when catalog advancement fails', async () => {
+  it('keeps a confirmed queued VM publish successful when SWM inventory removal fails', async () => {
     const { agentLike } = makeQueuedAgentHarness({
-      peerId: 'did:dkg:agent:queued-catalog-failure',
-      ual: 'did:dkg:local/queued-catalog-failure',
+      peerId: 'did:dkg:agent:queued-swm-removal-failure',
+      ual: 'did:dkg:local/queued-swm-removal-failure',
       publishStatus: 'confirmed',
     });
-    agentLike.recordConfirmedRfc64PublicCatalogAssetV1 = recorder(async () => {
-      throw new Error('simulated RFC-64 catalog failure');
+    agentLike.removeRfc64SwmAuthorInventoryShadowV1 = recorder(async () => {
+      throw new Error('simulated RFC-64 SWM removal failure');
     });
     const snapshotQuads = [{
       subject: 'urn:test:queued-public-failure',
@@ -1058,55 +1065,9 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
 
     expect(result).toMatchObject({ status: 'confirmed' });
     expect(agentLike.log.warn.calls.some((call: unknown[]) => (
-      String(call[1]).includes('RFC-64 catalog advancement failed')
-      && String(call[1]).includes('simulated RFC-64 catalog failure')
+      String(call[1]).includes('RFC-64 SWM inventory shadow removal')
+      && String(call[1]).includes('simulated RFC-64 SWM removal failure')
     ))).toBe(true);
-  });
-
-  it('starts independent confirmed-VM observers without serial catalog blocking', async () => {
-    const { agentLike } = makeQueuedAgentHarness({
-      peerId: 'did:dkg:agent:queued-parallel-observers',
-      ual: 'did:dkg:local/queued-parallel-observers',
-      publishStatus: 'confirmed',
-    });
-    let releaseCatalog!: () => void;
-    const catalogGate = new Promise<void>((resolve) => { releaseCatalog = resolve; });
-    agentLike.recordConfirmedRfc64PublicCatalogAssetV1 = recorder(
-      async () => catalogGate,
-    );
-    const removal = recorder(async () => ({
-      status: 'absent',
-      action: 'remove',
-      attempts: 1,
-      headObjectDigest: null,
-      error: null,
-    }));
-    agentLike.removeRfc64SwmAuthorInventoryShadowV1 = removal;
-    const snapshotQuads = [{
-      subject: 'urn:test:queued-parallel-observers',
-      predicate: 'http://schema.org/name',
-      object: '"Queued Public"',
-      graph: '',
-    }];
-    const request = await makeQueuedPublishRequest({
-      contextGraphId: 'public-cg',
-      name: 'queued-parallel-observers-ka',
-      shareOperationId: 'share-op-parallel-observers',
-      intentByte: 'af',
-      quads: snapshotQuads,
-    });
-
-    const pending = (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(
-      agentLike,
-      request,
-      { contextGraphId: request.contextGraphId, quads: snapshotQuads },
-    );
-    await vi.waitFor(() => {
-      expect(agentLike.recordConfirmedRfc64PublicCatalogAssetV1.calls).toHaveLength(1);
-      expect(removal.calls).toHaveLength(1);
-    });
-    releaseCatalog();
-    await expect(pending).resolves.toMatchObject({ status: 'confirmed' });
   });
 
   it('keeps the V2 snapshot exact while passing a detached catalog capability', async () => {

--- a/packages/agent/test/publish-finalized-agent-lane.test.ts
+++ b/packages/agent/test/publish-finalized-agent-lane.test.ts
@@ -142,7 +142,6 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
     }> = [];
     const publishCalls: Array<{ contextGraphId: string; selection: any; opts: any }> = [];
     const remainingClearCalls: any[][] = [];
-    const rfc64CatalogCalls: any[] = [];
     const rfc64SwmInventoryRemovalCalls: any[] = [];
     const warnings: string[] = [];
 
@@ -181,10 +180,6 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
         status: 'confirmed',
         publicQuads: [],
       };
-    };
-    agent.recordConfirmedRfc64PublicCatalogAssetV1 = async (input: any) => {
-      rfc64CatalogCalls.push(input);
-      throw new Error('simulated finalized RFC-64 catalog failure');
     };
     agent.removeRfc64SwmAuthorInventoryShadowV1 = async (input: any) => {
       rfc64SwmInventoryRemovalCalls.push(input);
@@ -237,17 +232,6 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
     expect(remainingClearCalls).toHaveLength(1);
     expect(remainingClearCalls[0].slice(0, 2)).toEqual([CG, undefined]);
     expect(result.status).toBe('confirmed');
-    expect(rfc64CatalogCalls).toHaveLength(1);
-    expect(rfc64CatalogCalls[0]).toMatchObject({
-      contextGraphId: CG,
-      assertionCoordinate: NAME,
-      publicQuads: [PUBLIC_QUAD],
-    });
-    expect(rfc64CatalogCalls[0].seal).toMatchObject({
-      authorAddress: AGENT_B,
-      reservedKaId: RESERVED_KA_ID,
-      kaUal: KA_UAL,
-    });
     expect(rfc64SwmInventoryRemovalCalls).toHaveLength(1);
     expect(rfc64SwmInventoryRemovalCalls[0]).toMatchObject({
       contextGraphId: CG,
@@ -258,7 +242,6 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
       },
     });
     expect(warnings).toEqual(expect.arrayContaining([
-      expect.stringContaining('simulated finalized RFC-64 catalog failure'),
       expect.stringContaining('simulated escaped RFC-64 SWM inventory removal failure'),
     ]));
   });

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -720,7 +720,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     const confirmed = restarted.observeRfc64ConfirmedVmV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate,
-      publicQuads,
       seal,
       assertionUri,
       ctx,
@@ -984,7 +983,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).rejects.toThrow(/requires an effective network id/u);
   });
 
-  it('turns one confirmed public KA into the provider current head and one cold receiver apply', async () => {
+  it('authors one explicit public catalog row and applies it on one cold receiver', async () => {
     const acceptedButUnselectedContextGraphId = (
       '0x1111111111111111111111111111111111111111/accepted-not-selected'
     ) as ContextGraphIdV1;
@@ -1030,7 +1029,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     await connectBothWays(author, receiver);
 
     const seal = assertionSealFromCanonical(await authorSeal(11n));
-    const ignored = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    const ignored = await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: acceptedButUnselectedContextGraphId,
       assertionCoordinate: 'ordinary-confirmed-publication-other-cg' as never,
       publicQuads: [
@@ -1070,7 +1069,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       authorAddress: AUTHOR,
     })).toBeNull();
 
-    const first = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    const first = await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'ordinary-confirmed-publication' as never,
       publicQuads: [
@@ -1110,7 +1109,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       failed: 0,
     });
 
-    const replay = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    const replay = await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'ordinary-confirmed-publication' as never,
       publicQuads: [
@@ -1132,7 +1131,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect(replay).toEqual(first);
     expect(receiver.rfc64PublicCatalogStatsV1()?.receiver.applied).toBe(1);
 
-    const second = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    const second = await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'second-ordinary-confirmed-publication' as never,
       publicQuads: [
@@ -1167,7 +1166,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     });
   }, 60_000);
 
-  it('canonicalizes ordinary literal lexical forms before catalog projection verification', async () => {
+  it('canonicalizes literal lexical forms before explicit catalog projection verification', async () => {
     const author = await startNativeAgent(
       'auto-publish-canonical-literal',
       NATIVE_DEPLOYMENT,
@@ -1192,7 +1191,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       graph: 'urn:ignored-local-graph',
     }];
 
-    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1({
+    await expect(author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'ordinary-noncanonical-literal' as never,
       publicQuads,
@@ -1200,7 +1199,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).resolves.toMatchObject({ catalogVersion: '1', inventoryRowCount: '1' });
   }, 60_000);
 
-  it('uses the chain signer for a confirmed author when no custodial key is available', async () => {
+  it('uses the chain signer for explicit catalog authoring when no custodial key is available', async () => {
     const author = await startNativeAgent(
       'auto-publish-chain-signer',
       NATIVE_DEPLOYMENT,
@@ -1236,7 +1235,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       ownerAddress: AUTHOR,
     });
 
-    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1({
+    await expect(author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'ordinary-chain-signed-publication' as never,
       publicQuads: [
@@ -1298,7 +1297,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     };
     const publishSuccessor = vi.spyOn(author, 'publishAuthorCatalogExactSetSuccessorV1')
       .mockRejectedValueOnce(new Error('simulated successor staging failure'));
-    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1(params))
+    await expect(author.recordRfc64PublicCatalogAssetV1(params))
       .rejects.toThrow('simulated successor staging failure');
     expect(author.readRfc64AppliedCatalogHeadV1({
       catalogScopeDigest: catalogScopeDigest(),
@@ -1306,7 +1305,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).toBeNull();
 
     publishSuccessor.mockRestore();
-    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1(params)).resolves.toMatchObject({
+    await expect(author.recordRfc64PublicCatalogAssetV1(params)).resolves.toMatchObject({
       catalogVersion: '1',
       inventoryRowCount: '1',
     });
@@ -1351,7 +1350,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     ];
     const kaNumbers = [61n, 62n] as const;
     const results = await Promise.all(kaNumbers.map(async (kaNumber, index) => (
-      author.recordConfirmedRfc64PublicCatalogAssetV1({
+      author.recordRfc64PublicCatalogAssetV1({
         contextGraphId: CONTEXT_GRAPH_ID,
         assertionCoordinate: `concurrent-confirmed-${index + 1}` as never,
         publicQuads,
@@ -1421,13 +1420,13 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         graph: '',
       },
     ] as const;
-    await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'bootstrap-publication-1' as never,
       publicQuads,
       seal: assertionSealFromCanonical(await authorSeal(21n)),
     });
-    const published = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    const published = await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'bootstrap-publication-2' as never,
       publicQuads,
@@ -1563,7 +1562,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         graph: '',
       },
     ];
-    const published = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    const published = await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'bootstrap-retry-publication' as never,
       publicQuads,
@@ -1671,7 +1670,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         graph: '',
       },
     ];
-    const applied = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    const applied = await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'mixed-case-byte-order' as never,
       publicQuads,
@@ -1680,7 +1679,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect(applied).toMatchObject({ catalogVersion: '1', inventoryRowCount: '1' });
   }, 60_000);
 
-  it('explicitly skips private-bearing ordinary publishes in the public-only V1 bridge', async () => {
+  it('explicitly skips private-bearing assets in the public-only V1 authoring entrypoint', async () => {
     const author = await startNativeAgent(
       'auto-publish-private-skip',
       NATIVE_DEPLOYMENT,
@@ -1703,7 +1702,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       privateTripleCount: 1,
       privateMerkleRoot: ethers.getBytes(`0x${'99'.repeat(32)}`),
     };
-    await expect(author.recordConfirmedRfc64PublicCatalogAssetV1({
+    await expect(author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'private-bearing-skip' as never,
       publicQuads: [
@@ -2187,7 +2186,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).toBeNull();
   }, 60_000);
 
-  it('materializes finalized VM through production two-agent wiring before applying the head', async () => {
+  it('keeps production RFC-64 catalog activation in SWM without materializing VM', async () => {
     const kaNumber = 7n;
     const kaId = ((BigInt(AUTHOR) << 96n) | kaNumber).toString();
     const nameHash = ethers.keccak256(ethers.toUtf8Bytes(CONTEXT_GRAPH_ID)).toLowerCase();
@@ -2325,6 +2324,12 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect(successor.announcedPeers).toEqual([receiver.peerId]);
     await receiver.whenRfc64PublicCatalogReceiverIdleV1();
 
+    const swmGraph = contextGraphLayerUri(
+      CONTEXT_GRAPH_ID,
+      MemoryLayer.SharedWorkingMemory,
+      AUTHOR,
+      Number(kaNumber),
+    );
     const vmGraph = contextGraphLayerUri(
       CONTEXT_GRAPH_ID,
       MemoryLayer.VerifiableMemory,
@@ -2335,13 +2340,16 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       successor.headObjectDigest,
     )).toBeNull();
     await expect((receiver as any).store.query(
-      `SELECT ?s ?p ?o WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+      `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
     )).resolves.toMatchObject({
       type: 'bindings',
       bindings: expect.arrayContaining([
         expect.objectContaining({ s: 'https://example.org/alice' }),
       ]),
     });
+    await expect((receiver as any).store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+    )).resolves.toMatchObject({ type: 'bindings', bindings: [] });
     expect(receiver.readRfc64AppliedCatalogHeadV1({
       catalogScopeDigest: computeAuthorCatalogScopeDigestV1(scope),
       authorAddress: AUTHOR,
@@ -2352,8 +2360,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     const finalizedCallTargets = finalizedRpc.calls.slice(callsBeforeRuntime)
       .filter(({ method }) => method === 'eth_call')
       .map(({ params }) => (params[0] as { readonly to?: string }).to?.toLowerCase());
-    expect(finalizedCallTargets).toContain(CONTEXT_GRAPH_STORAGE);
-    expect(finalizedCallTargets).toContain(KA_STORAGE);
+    expect(finalizedCallTargets).not.toContain(KA_STORAGE);
     expect(finalizedCallTargets).not.toContain(KAV10);
   }, 60_000);
 
@@ -2502,7 +2509,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         graph: '',
       },
     ];
-    const published = await author.recordConfirmedRfc64PublicCatalogAssetV1({
+    const published = await author.recordRfc64PublicCatalogAssetV1({
       contextGraphId: CONTEXT_GRAPH_ID,
       assertionCoordinate: 'release-proof-1' as never,
       publicQuads,
@@ -2524,6 +2531,12 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         inventoryRowCount: '1',
       });
       for (const kaNumber of kaNumbers) {
+        const swmGraph = contextGraphLayerUri(
+          CONTEXT_GRAPH_ID,
+          MemoryLayer.SharedWorkingMemory,
+          AUTHOR,
+          Number(kaNumber),
+        );
         const vmGraph = contextGraphLayerUri(
           CONTEXT_GRAPH_ID,
           MemoryLayer.VerifiableMemory,
@@ -2531,13 +2544,16 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
           Number(kaNumber),
         );
         await expect((receiver as any).store.query(
-          `SELECT ?s ?p ?o WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+          `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
         )).resolves.toMatchObject({
           type: 'bindings',
           bindings: expect.arrayContaining([
             expect.objectContaining({ s: 'https://example.org/alice' }),
           ]),
         });
+        await expect((receiver as any).store.query(
+          `SELECT ?s ?p ?o WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+        )).resolves.toMatchObject({ type: 'bindings', bindings: [] });
       }
     };
     await vi.waitFor(() => {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -2187,7 +2187,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
   }, 60_000);
 
   it('leaves the applied head null for finalized-chain policy in the dormant SWM-only lane', async () => {
-    const kaNumber = 7n;
     const [author, receiver] = await Promise.all([
       startNativeAgent('finalized-policy-author', NATIVE_DEPLOYMENT),
       startNativeAgent('finalized-policy-receiver', NATIVE_DEPLOYMENT),
@@ -2223,50 +2222,13 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     });
     expect(genesis.announcedPeers).toEqual([receiver.peerId]);
     await receiver.whenRfc64PublicCatalogReceiverIdleV1();
-    const successor = await author.publishAuthorCatalogExactSetSuccessorV1({
-      previousHead: {
-        objectDigest: genesis.headObjectDigest,
-        signatureVariantDigest: genesis.signatureVariantDigest,
-      },
-      author: AUTHOR_WALLET,
-      catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
-      assets: [{
-        assertionCoordinate: 'finalized-vm-production-wire' as never,
-        projectionBytes: PROJECTION,
-        seal: await authorSeal(kaNumber),
-      }],
-      deployment: NATIVE_DEPLOYMENT,
-      issuedAt: SUCCESSOR_ISSUED_AT,
-      peers: [receiver.peerId],
-    });
-    expect(successor.announcedPeers).toEqual([receiver.peerId]);
-    await receiver.whenRfc64PublicCatalogReceiverIdleV1();
-
-    const swmGraph = contextGraphLayerUri(
-      CONTEXT_GRAPH_ID,
-      MemoryLayer.SharedWorkingMemory,
-      AUTHOR,
-      Number(kaNumber),
-    );
-    const vmGraph = contextGraphLayerUri(
-      CONTEXT_GRAPH_ID,
-      MemoryLayer.VerifiableMemory,
-      AUTHOR,
-      Number(kaNumber),
-    );
     expect(receiver.readRfc64PublicCatalogReconciliationFailureV1(
-      successor.headObjectDigest,
+      genesis.headObjectDigest,
     )).toEqual({
-      catalogHeadDigest: successor.headObjectDigest,
+      catalogHeadDigest: genesis.headObjectDigest,
       errorName: 'Rfc64PublicCatalogNativeReceiverErrorV1',
       errorCode: 'catalog-native-receiver-activation',
     });
-    await expect((receiver as any).store.query(
-      `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
-    )).resolves.toMatchObject({ type: 'bindings', bindings: [] });
-    await expect((receiver as any).store.query(
-      `SELECT ?s ?p ?o WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
-    )).resolves.toMatchObject({ type: 'bindings', bindings: [] });
     expect(receiver.readRfc64AppliedCatalogHeadV1({
       catalogScopeDigest: computeAuthorCatalogScopeDigestV1(scope),
       authorAddress: AUTHOR,

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -2235,6 +2235,145 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).toBeNull();
   }, 60_000);
 
+  it('applies a finalized-policy SWM successor through production wiring without VM writes', async () => {
+    const nameHash = ethers.keccak256(ethers.toUtf8Bytes(CONTEXT_GRAPH_ID)).toLowerCase();
+    const fixture = Object.freeze({
+      accessPolicy: 0,
+      active: true,
+      assertedAtChainId: NATIVE_DEPLOYMENT.assertedAtChainId,
+      assertedAtKav10Address: KAV10,
+      knowledgeAssetStorageAddress: KA_STORAGE,
+      assets: Object.freeze([]),
+      blockHash: FINALIZED_BLOCK_HASH,
+      blockNumberQuantity: '0x7c',
+      contextGraphStorageAddress: CONTEXT_GRAPH_STORAGE,
+      nameHash: nameHash as Digest32V1,
+      networkId: NETWORK_ID,
+      onChainContextGraphId: ON_CHAIN_CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+      publishPolicy: 1,
+    } satisfies FinalizedVmLoopbackFixtureConfigV1);
+    const finalizedRpc = createFinalizedVmLoopbackRpcV1(fixture);
+    const rpc = await rpcHarness.start((call, response) => {
+      try {
+        sendJsonRpcResult(response, call, finalizedRpc.respond(call.method, call.params));
+      } catch (cause) {
+        sendJsonRpcError(
+          response,
+          call,
+          -32602,
+          cause instanceof Error ? cause.message : String(cause),
+        );
+      }
+    });
+    const receiverChain = new FinalizedVmLoopbackMockChainAdapterV1(fixture);
+    await receiverChain.createOnChainContextGraph({
+      accessPolicy: 0,
+      publishPolicy: 1,
+      nameHash,
+    });
+    const receiver = await startNativeAgent(
+      'finalized-policy-production-receiver',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      {
+        rpcUrl: rpc.url,
+        chainAdapter: receiverChain,
+        initialSubscription: CONTEXT_GRAPH_ID,
+      },
+    );
+    const author = await startNativeAgent(
+      'finalized-policy-production-author',
+      NATIVE_DEPLOYMENT,
+      undefined,
+      undefined,
+      {
+        rpcUrl: rpc.url,
+        chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture),
+      },
+      {
+        peers: [receiver.peerId],
+        catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+      },
+    );
+    vi.spyOn(author, 'getCustodialAgentPrivateKey').mockReturnValue(
+      AUTHOR_WALLET.privateKey,
+    );
+    const policy = finalizedPublicCatalogPolicy();
+    const policyEnvelope = {
+      issuer: CONTEXT_GRAPH_STORAGE,
+      objectType: CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+      payload: policy,
+      signatureEvidence: { kind: 'none' },
+      signatureSuite: 'eip191-personal-sign-digest-v1',
+    } as UnsignedContextGraphPolicyEnvelopeV1;
+    const policyDigest = computeContextGraphPolicyObjectDigestV1(policyEnvelope);
+    for (const agent of [author, receiver]) {
+      agent.acceptRfc64CatalogAccessSnapshotV1({ policy, policyDigest, roster: null });
+    }
+    await connectBothWays(author, receiver);
+
+    const publicQuads = [{
+      subject: 'https://example.org/policy-only',
+      predicate: 'https://schema.org/name',
+      object: '"Policy-only SWM"',
+      graph: '',
+    }];
+    const kaNumber = 42n;
+    const published = await author.recordRfc64PublicCatalogAssetV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: 'finalized-policy-production-success' as never,
+      publicQuads,
+      seal: assertionSealFromCanonical(await authorSeal(kaNumber, publicQuads)),
+    });
+    if (published === null) throw new Error('explicit RFC-64 catalog authoring was not enabled');
+    await receiver.whenRfc64PublicCatalogReceiverIdleV1();
+
+    const scope = {
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      governanceChainId: '20430',
+      governanceContractAddress: CONTEXT_GRAPH_STORAGE,
+      ownershipTransitionDigest: null,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      era: '0',
+      bucketCount: '1',
+    } as const;
+    expect(receiver.readRfc64PublicCatalogReconciliationFailureV1(
+      published.currentCatalogHeadDigest,
+    )).toBeNull();
+    expect(receiver.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: computeAuthorCatalogScopeDigestV1(scope),
+      authorAddress: AUTHOR,
+    })).toMatchObject({
+      currentCatalogHeadDigest: published.currentCatalogHeadDigest,
+      inventoryRowCount: '1',
+    });
+    const swmGraph = contextGraphLayerUri(
+      CONTEXT_GRAPH_ID,
+      MemoryLayer.SharedWorkingMemory,
+      AUTHOR,
+      Number(kaNumber),
+    );
+    const vmGraph = contextGraphLayerUri(
+      CONTEXT_GRAPH_ID,
+      MemoryLayer.VerifiableMemory,
+      AUTHOR,
+      Number(kaNumber),
+    );
+    await expect((receiver as any).store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
+    )).resolves.toMatchObject({
+      type: 'bindings',
+      bindings: [expect.objectContaining({ s: 'https://example.org/policy-only' })],
+    });
+    await expect((receiver as any).store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+    )).resolves.toMatchObject({ type: 'bindings', bindings: [] });
+  }, 60_000);
+
   registerM0RecoveryScenario('curated-parity', rfc64M0RecoveryTitle('curated-parity'), async () => {
     const kaNumbers = [41n] as const;
     const assets = kaNumbers.map((kaNumber) => Object.freeze({

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -2186,83 +2186,11 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).toBeNull();
   }, 60_000);
 
-  it('keeps production RFC-64 catalog activation in SWM without materializing VM', async () => {
+  it('leaves the applied head null for finalized-chain policy in the dormant SWM-only lane', async () => {
     const kaNumber = 7n;
-    const kaId = ((BigInt(AUTHOR) << 96n) | kaNumber).toString();
-    const nameHash = ethers.keccak256(ethers.toUtf8Bytes(CONTEXT_GRAPH_ID)).toLowerCase();
-    const fixture = Object.freeze({
-      accessPolicy: 0,
-      active: true,
-      assertedAtChainId: NATIVE_DEPLOYMENT.assertedAtChainId,
-      assertedAtKav10Address: KAV10,
-      knowledgeAssetStorageAddress: KA_STORAGE,
-      assets: Object.freeze([Object.freeze({
-        assertionRoot: ASSERTION_ROOT,
-        assertionVersion: '1',
-        authorAddress: AUTHOR,
-        kaId,
-        publisherAddress: `0x${'66'.repeat(20)}` as EvmAddressV1,
-      })]),
-      blockHash: FINALIZED_BLOCK_HASH,
-      blockNumberQuantity: '0x7b',
-      contextGraphStorageAddress: CONTEXT_GRAPH_STORAGE,
-      nameHash: nameHash as Digest32V1,
-      networkId: NETWORK_ID,
-      onChainContextGraphId: ON_CHAIN_CONTEXT_GRAPH_ID,
-      ownerAddress: AUTHOR,
-      publishPolicy: 1,
-    } satisfies FinalizedVmLoopbackFixtureConfigV1);
-    const finalizedRpc = createFinalizedVmLoopbackRpcV1(fixture);
-    const contextGraphInterface = new ethers.Interface([
-      'function getNameHash(uint256 contextGraphId) view returns (bytes32)',
-    ]);
-    expect(() => finalizedRpc.respond('eth_call', [{
-      to: KAV10,
-      data: contextGraphInterface.encodeFunctionData(
-        'getNameHash',
-        [BigInt(ON_CHAIN_CONTEXT_GRAPH_ID)],
-      ),
-    }, 'finalized'])).toThrow('context graph target');
-    const callsBeforeRuntime = finalizedRpc.calls.length;
-    const rpc = await rpcHarness.start((call, response) => {
-      try {
-        sendJsonRpcResult(response, call, finalizedRpc.respond(call.method, call.params));
-      } catch (cause) {
-        sendJsonRpcError(
-          response,
-          call,
-          -32602,
-          cause instanceof Error ? cause.message : String(cause),
-        );
-      }
-    });
-    const authorChain = new FinalizedVmLoopbackMockChainAdapterV1(fixture);
-    const receiverChain = new FinalizedVmLoopbackMockChainAdapterV1(fixture);
-    const created = await receiverChain.createOnChainContextGraph({
-      accessPolicy: 0,
-      publishPolicy: 1,
-      nameHash,
-    });
-    expect(created.contextGraphId.toString()).toBe(ON_CHAIN_CONTEXT_GRAPH_ID);
     const [author, receiver] = await Promise.all([
-      startNativeAgent(
-        'vm-author',
-        NATIVE_DEPLOYMENT,
-        undefined,
-        undefined,
-        { rpcUrl: rpc.url, chainAdapter: authorChain },
-      ),
-      startNativeAgent(
-        'vm-receiver',
-        NATIVE_DEPLOYMENT,
-        undefined,
-        undefined,
-        {
-          rpcUrl: rpc.url,
-          chainAdapter: receiverChain,
-          initialSubscription: CONTEXT_GRAPH_ID,
-        },
-      ),
+      startNativeAgent('finalized-policy-author', NATIVE_DEPLOYMENT),
+      startNativeAgent('finalized-policy-receiver', NATIVE_DEPLOYMENT),
     ]);
     const policy = finalizedPublicCatalogPolicy();
     for (const agent of [author, receiver]) {
@@ -2272,16 +2200,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         roster: null,
       });
     }
-    await receiver.awaitInitialChainPoll();
-    const storeQuery = vi.spyOn((receiver as any).store, 'query');
-    await expect(receiver.getContextGraphOnChainId(CONTEXT_GRAPH_ID)).resolves.toBe(
-      ON_CHAIN_CONTEXT_GRAPH_ID,
-    );
-    await expect(receiver.getContextGraphOnChainId(nameHash)).resolves.toBe(
-      ON_CHAIN_CONTEXT_GRAPH_ID,
-    );
-    expect(storeQuery.mock.calls.some(([query]) => String(query).includes('OnChainId'))).toBe(false);
-    storeQuery.mockRestore();
     await connectBothWays(author, receiver);
 
     const scope = {
@@ -2338,30 +2256,21 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     );
     expect(receiver.readRfc64PublicCatalogReconciliationFailureV1(
       successor.headObjectDigest,
-    )).toBeNull();
+    )).toEqual({
+      catalogHeadDigest: successor.headObjectDigest,
+      errorName: 'Rfc64PublicCatalogNativeReceiverErrorV1',
+      errorCode: 'catalog-native-receiver-activation',
+    });
     await expect((receiver as any).store.query(
       `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
-    )).resolves.toMatchObject({
-      type: 'bindings',
-      bindings: expect.arrayContaining([
-        expect.objectContaining({ s: 'https://example.org/alice' }),
-      ]),
-    });
+    )).resolves.toMatchObject({ type: 'bindings', bindings: [] });
     await expect((receiver as any).store.query(
       `SELECT ?s ?p ?o WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
     )).resolves.toMatchObject({ type: 'bindings', bindings: [] });
     expect(receiver.readRfc64AppliedCatalogHeadV1({
       catalogScopeDigest: computeAuthorCatalogScopeDigestV1(scope),
       authorAddress: AUTHOR,
-    })).toMatchObject({
-      currentCatalogHeadDigest: successor.headObjectDigest,
-      inventoryRowCount: '1',
-    });
-    const finalizedCallTargets = finalizedRpc.calls.slice(callsBeforeRuntime)
-      .filter(({ method }) => method === 'eth_call')
-      .map(({ params }) => (params[0] as { readonly to?: string }).to?.toLowerCase());
-    expect(finalizedCallTargets).not.toContain(KA_STORAGE);
-    expect(finalizedCallTargets).not.toContain(KAV10);
+    })).toBeNull();
   }, 60_000);
 
   registerM0RecoveryScenario('curated-parity', rfc64M0RecoveryTitle('curated-parity'), async () => {

--- a/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createRfc64FinalizedPolicyAgentPrecommitV1 } from '../src/rfc64/finalized-policy-agent-precommit-v1.js';
+import {
+  RFC64_VM_CHAIN_ID,
+  RFC64_VM_CONTEXT_GRAPH_NAME,
+  RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+} from './support/rfc64-finalized-vm-placement-fixture.js';
+import {
+  rfc64FinalizedVmPrecommitOptions,
+  rfc64FinalizedVmPrecommitPlan,
+} from './support/rfc64-finalized-vm-precommit-fixture.js';
+
+function options() {
+  const fixture = rfc64FinalizedVmPrecommitOptions();
+  return {
+    acceptedPolicySnapshotForCatalogScope: fixture.acceptedPolicySnapshotForCatalogScope,
+    rpcEndpoints: fixture.rpcEndpoints,
+    getOnChainContextGraphId: fixture.getOnChainContextGraphId,
+    getEvmChainId: fixture.getEvmChainId,
+  };
+}
+
+describe('RFC-64 finalized policy agent precommit', () => {
+  it('accepts a chain-bound SWM catalog without invoking VM materialization', async () => {
+    const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
+    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      getOnChainContextGraphId,
+      getEvmChainId,
+    });
+
+    await expect(handler(
+      rfc64FinalizedVmPrecommitPlan(),
+      new AbortController().signal,
+    )).resolves.toBeUndefined();
+    expect(getOnChainContextGraphId).toHaveBeenCalledWith(
+      RFC64_VM_CONTEXT_GRAPH_NAME,
+      expect.any(AbortSignal),
+    );
+    expect(getEvmChainId).toHaveBeenCalledOnce();
+  });
+
+  it('rejects before chain resolution when trusted RPC endpoints are absent', async () => {
+    const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
+    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      rpcEndpoints: [],
+      getOnChainContextGraphId,
+      getEvmChainId,
+    });
+
+    await expect(handler(
+      rfc64FinalizedVmPrecommitPlan(),
+      new AbortController().signal,
+    )).rejects.toThrow('requires trusted RPC configuration');
+    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
+    expect(getEvmChainId).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing CG mapping or a different live chain', async () => {
+    const missingContextGraph = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      getOnChainContextGraphId: async () => null,
+    });
+    await expect(missingContextGraph(
+      rfc64FinalizedVmPrecommitPlan(),
+      new AbortController().signal,
+    )).rejects.toThrow('could not resolve the numeric context graph id');
+
+    const differentChain = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      getEvmChainId: async () => 1n,
+    });
+    await expect(differentChain(
+      rfc64FinalizedVmPrecommitPlan(),
+      new AbortController().signal,
+    )).rejects.toThrow('differs from the configured chain id');
+  });
+});

--- a/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
@@ -1,15 +1,39 @@
-import { describe, expect, it, vi } from 'vitest';
+import type { ContextGraphPolicyV1 } from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createRfc64FinalizedPolicyAgentPrecommitV1 } from '../src/rfc64/finalized-policy-agent-precommit-v1.js';
 import {
+  createLoopbackJsonRpcTestHarness,
+  sendJsonRpcError,
+  sendJsonRpcResult,
+} from '../../chain/test/loopback-rpc-harness.js';
+import {
+  RFC64_VM_AUTHOR,
+  RFC64_VM_BLOCK_HASH,
+  RFC64_VM_CG_STORAGE,
   RFC64_VM_CHAIN_ID,
   RFC64_VM_CONTEXT_GRAPH_NAME,
+  RFC64_VM_KAV10,
+  RFC64_VM_KA_STORAGE,
+  RFC64_VM_NETWORK_ID,
   RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
 } from './support/rfc64-finalized-vm-placement-fixture.js';
 import {
+  acceptedRfc64VmPolicySnapshot,
   rfc64FinalizedVmPrecommitOptions,
   rfc64FinalizedVmPrecommitPlan,
 } from './support/rfc64-finalized-vm-precommit-fixture.js';
+import {
+  createFinalizedVmLoopbackRpcV1,
+  type FinalizedVmLoopbackFixtureConfigV1,
+} from './support/rfc64-finalized-vm-loopback-fixture.js';
+
+const rpcHarness = createLoopbackJsonRpcTestHarness();
+
+afterEach(async () => {
+  await rpcHarness.stopAll();
+});
 
 function options() {
   const fixture = rfc64FinalizedVmPrecommitOptions();
@@ -21,12 +45,67 @@ function options() {
   };
 }
 
+function finalizedChainFixture(
+  overrides: Partial<FinalizedVmLoopbackFixtureConfigV1> = {},
+): FinalizedVmLoopbackFixtureConfigV1 {
+  return {
+    accessPolicy: 0,
+    active: true,
+    assertedAtChainId: RFC64_VM_CHAIN_ID,
+    assertedAtKav10Address: RFC64_VM_KAV10,
+    knowledgeAssetStorageAddress: RFC64_VM_KA_STORAGE,
+    assets: [],
+    blockHash: RFC64_VM_BLOCK_HASH,
+    blockNumberQuantity: '0x7c',
+    contextGraphStorageAddress: RFC64_VM_CG_STORAGE,
+    nameHash: ethers.keccak256(ethers.toUtf8Bytes(RFC64_VM_CONTEXT_GRAPH_NAME)) as never,
+    networkId: RFC64_VM_NETWORK_ID,
+    onChainContextGraphId: RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+    ownerAddress: RFC64_VM_AUTHOR,
+    publishPolicy: 1,
+    ...overrides,
+  };
+}
+
+async function liveOptions(
+  overrides: Partial<FinalizedVmLoopbackFixtureConfigV1> = {},
+) {
+  const rpc = createFinalizedVmLoopbackRpcV1(finalizedChainFixture(overrides));
+  const server = await rpcHarness.start((call, response) => {
+    try {
+      sendJsonRpcResult(response, call, rpc.respond(call.method, call.params));
+    } catch (cause) {
+      sendJsonRpcError(
+        response,
+        call,
+        -32602,
+        cause instanceof Error ? cause.message : String(cause),
+      );
+    }
+  });
+  return {
+    options: { ...options(), rpcEndpoints: [server.url] },
+    rpc,
+  };
+}
+
+function acceptedPolicyWith(
+  overrides: Partial<ContextGraphPolicyV1>,
+) {
+  const accepted = acceptedRfc64VmPolicySnapshot();
+  return Object.freeze({
+    ...accepted,
+    policy: Object.freeze({ ...accepted.policy, ...overrides }),
+  });
+}
+
 describe('RFC-64 finalized policy agent precommit', () => {
   it('accepts a chain-bound SWM catalog without invoking VM materialization', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
     const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const live = await liveOptions();
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
-      ...options(),
+      ...live.options,
       getOnChainContextGraphId,
       getEvmChainId,
     });
@@ -40,6 +119,10 @@ describe('RFC-64 finalized policy agent precommit', () => {
       expect.any(AbortSignal),
     );
     expect(getEvmChainId).toHaveBeenCalledOnce();
+    expect(live.rpc.calls.filter((call) => (
+      call.method === 'eth_call'
+      && (call.params[0] as { data?: string } | undefined)?.data !== '0x'
+    ))).toHaveLength(2);
   });
 
   it('rejects before chain resolution when trusted RPC endpoints are absent', async () => {
@@ -56,6 +139,32 @@ describe('RFC-64 finalized policy agent precommit', () => {
       rfc64FinalizedVmPrecommitPlan(),
       new AbortController().signal,
     )).rejects.toThrow('requires trusted RPC configuration');
+    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
+    expect(getEvmChainId).not.toHaveBeenCalled();
+  });
+
+  it('leaves non-finalized owner policy outside the EVM precommit lane', async () => {
+    const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
+    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      acceptedPolicySnapshotForCatalogScope: () => acceptedPolicyWith({
+        governanceChainId: null,
+        governanceContractAddress: null,
+        source: {
+          kind: 'owner-signed-unregistered',
+          ownerAddress: RFC64_VM_AUTHOR,
+          ownerAuthorityEra: '0',
+        },
+      }),
+      getOnChainContextGraphId,
+      getEvmChainId,
+    });
+
+    await expect(handler(
+      rfc64FinalizedVmPrecommitPlan(),
+      new AbortController().signal,
+    )).resolves.toBeUndefined();
     expect(getOnChainContextGraphId).not.toHaveBeenCalled();
     expect(getEvmChainId).not.toHaveBeenCalled();
   });
@@ -78,5 +187,61 @@ describe('RFC-64 finalized policy agent precommit', () => {
       rfc64FinalizedVmPrecommitPlan(),
       new AbortController().signal,
     )).rejects.toThrow('differs from the configured chain id');
+  });
+
+  it.each([
+    ['non-public access', { accessPolicy: 1 }],
+    ['missing governance', {
+      governanceChainId: null,
+      governanceContractAddress: null,
+    }],
+    ['source/governance mismatch', {
+      source: {
+        ...acceptedRfc64VmPolicySnapshot().policy.source,
+        contractAddress: `0x${'99'.repeat(20)}`,
+      },
+    }],
+  ] as const)('rejects %s before resolving chain state', async (_label, policyOverrides) => {
+    const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
+    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      acceptedPolicySnapshotForCatalogScope: () => acceptedPolicyWith(
+        policyOverrides as Partial<ContextGraphPolicyV1>,
+      ),
+      getOnChainContextGraphId,
+      getEvmChainId,
+    });
+
+    await expect(handler(
+      rfc64FinalizedVmPrecommitPlan(),
+      new AbortController().signal,
+    )).rejects.toThrow();
+    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
+    expect(getEvmChainId).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale accepted policy that differs from live finalized chain state', async () => {
+    const live = await liveOptions();
+    const accepted = acceptedRfc64VmPolicySnapshot();
+    const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...live.options,
+      acceptedPolicySnapshotForCatalogScope: () => acceptedPolicyWith({
+        publishPolicy: 0,
+        publishAuthority: RFC64_VM_AUTHOR,
+        source: accepted.policy.source,
+      }),
+    });
+
+    await expect(handler(
+      rfc64FinalizedVmPrecommitPlan(),
+      new AbortController().signal,
+    )).rejects.toMatchObject({
+      code: 'finalized-policy-verifier-policy',
+    });
+    expect(live.rpc.calls.filter((call) => (
+      call.method === 'eth_call'
+      && (call.params[0] as { data?: string } | undefined)?.data !== '0x'
+    ))).toHaveLength(2);
   });
 });

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -1326,7 +1326,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       rejectingReceiver,
     )).rejects.toMatchObject({
       code: 'catalog-native-receiver-activation',
-      message: expect.stringContaining('finalized VM precommit rejected'),
+      message: expect.stringContaining('catalog applied-head precommit rejected'),
     });
     expect(partialPrecommit).toHaveBeenCalledOnce();
     const [rejectedPlan, rejectedSignal] = partialPrecommit.mock.calls[0]!;
@@ -1354,7 +1354,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       fixture.scopeDigest,
       AUTHOR,
     )?.currentCatalogHeadDigest).toBe(fixture.successor.head.objectDigest);
-    await expect(fixture.receiverStore.countQuads()).resolves.toBe(32);
+    await expect(fixture.receiverStore.countQuads()).resolves.toBe(16);
 
     const repaired = await fixture.synchronizeAny(
       fixture.multiAssetAnnouncement,
@@ -1445,7 +1445,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     compareAndSwapAppliedCatalogHeadV1.mockClear();
     await expect(fixture.synchronizeGoverned(receiver)).rejects.toMatchObject({
       code: 'catalog-native-receiver-activation',
-      message: expect.stringContaining('finalized VM precommit rejected'),
+      message: expect.stringContaining('catalog applied-head precommit rejected'),
     });
 
     expect(getOnChainContextGraphId).not.toHaveBeenCalled();

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -1385,7 +1385,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     await expect(fixture.receiverStore.countQuads()).resolves.toBe(32);
   }, 30_000);
 
-  it('keeps the governed successor head unapplied when an explicit VM precommit lacks RPC', async () => {
+  it('keeps the governed genesis head unapplied when an explicit VM precommit lacks RPC', async () => {
     const fixture = await setupLiveReceiver();
     const compareAndSwapAppliedCatalogHeadV1 = vi.fn(
       fixture.receiverPersistence.inventory.compareAndSwapAppliedCatalogHeadV1.bind(
@@ -1441,9 +1441,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       compareAndSwapAppliedCatalogHeadV1,
     }, undefined, undefined, fixture.receiverStore, precommit);
 
-    await fixture.bootstrapGoverned(receiver);
-    compareAndSwapAppliedCatalogHeadV1.mockClear();
-    await expect(fixture.synchronizeGoverned(receiver)).rejects.toMatchObject({
+    await expect(fixture.bootstrapGoverned(receiver)).rejects.toMatchObject({
       code: 'catalog-native-receiver-activation',
       message: expect.stringContaining('catalog applied-head precommit rejected'),
     });
@@ -1455,7 +1453,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
       computeAuthorCatalogScopeDigestV1(fixture.governedScope),
       AUTHOR,
-    )?.currentCatalogHeadDigest).toBe(fixture.governedGenesis.head.objectDigest);
+    )).toBeNull();
   }, 30_000);
 });
 

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -1385,7 +1385,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     await expect(fixture.receiverStore.countQuads()).resolves.toBe(32);
   }, 30_000);
 
-  it('keeps the governed successor head unapplied when the production VM precommit lacks RPC', async () => {
+  it('keeps the governed successor head unapplied when an explicit VM precommit lacks RPC', async () => {
     const fixture = await setupLiveReceiver();
     const compareAndSwapAppliedCatalogHeadV1 = vi.fn(
       fixture.receiverPersistence.inventory.compareAndSwapAppliedCatalogHeadV1.bind(

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -13,6 +13,7 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-catalog-row-authorship.test.ts",
   "test/rfc64-finalized-vm-composer-v1.test.ts",
   "test/rfc64-finalized-vm-runtime-v1.test.ts",
+  "test/rfc64-finalized-policy-agent-precommit-v1.test.ts",
   "test/rfc64-finalized-vm-agent-precommit-v1.test.ts",
   "test/rfc64-finalized-vm-precommit-shipped-pool.test.ts",
   "test/rfc64-agent-inventory-lifecycle.test.ts",


### PR DESCRIPTION
## Impact

This PR makes the 10.0.14 RFC-64 lifecycle boundary explicit while keeping the feature opt-in and dormant:

- ordinary finalized VM publications remain inventoried by the blockchain and no longer advance an RFC-64 catalog;
- VM confirmation still removes the matching RFC-64 SWM author-inventory row;
- the production RFC-64 receiver applies verified catalog contents to SWM only and never materializes a second VM copy;
- explicit catalog authoring uses the neutral `recordRfc64PublicCatalogAssetV1` entrypoint for the upcoming SWM producer lane;
- the previously published `recordConfirmedRfc64PublicCatalogAssetV1` name remains as a deprecated forwarding adapter for patch-release compatibility, but ordinary VM confirmation calls neither name;
- finalized-chain SWM catalog heads pass a named policy-only precommit that reads one pinned finalized chain snapshot and verifies active state, cleartext name hash, access policy, publish policy, authority, source, governance binding, chain ID, numeric CG mapping, and finality;
- the policy precommit never scans KA inventory or invokes VM materialization: the blockchain and VM reconciler remain the only VM inventory path;
- missing or mismatched trusted chain context fails closed before even an empty genesis applied-head CAS;
- any applied-head precommit rejection restores the exact predecessor SWM state through the same centralized rollback path used by activation failures.

A follow-up release will add and validate the SWM producer/discovery activation path. This PR establishes the safe boundary without enabling catalogs on existing nodes.

## Before

```mermaid
sequenceDiagram
    participant P as VM publisher
    participant C as RFC-64 catalog
    participant R as Receiver
    participant S as SWM
    participant V as Local finalized VM

    P->>C: Advance catalog after VM confirmation
    C->>R: Signed catalog successor
    R->>R: Verify policy, issuer, head, and projection
    R->>S: Activate projection
    R->>V: Precommit and materialize finalized VM
    R->>C: Commit applied head
```

## After

```mermaid
sequenceDiagram
    participant P as Publisher
    participant C as RFC-64 SWM catalog
    participant R as Receiver
    participant S as SWM
    participant B as Blockchain inventory
    participant V as VM reconciler

    P->>C: Explicitly author catalog only for SWM content
    C->>R: Signed SWM catalog head
    R->>R: Verify issuer, head, projection, and accepted policy
    R->>S: Apply exact SWM transition
    alt Owner-signed policy
        R->>C: Commit applied head
    else Finalized-chain policy
        R->>B: Read one pinned finalized CG policy snapshot
        B-->>R: Verify identity, policy, governance, and finality
        R->>C: Commit applied head
    else Verification fails
        R->>S: Restore exact predecessor state
        R-->>C: Reject; applied head remains unchanged
    end
    P->>B: Finalized VM publication
    B->>V: Canonical VM inventory
    V->>V: Normal VM reconciliation
```

## Validation

- agent build passed: TypeScript, type tests, and package-root API contract
- focused finalized-policy and finalized-VM verification: 18/18 passed
- production two-real-DKGAgent finalized-policy SWM success path: 1/1 passed with VM graph remaining empty
- native receiver precommit and rollback regressions: 2/2 passed
- shipped RPC-pool and shared owner-attribution coverage: 3/3 passed
- full PR-branch agent lane: 309/309 test files passed, 3,833 tests passed, 10 skipped, 0 failed
- `git diff --check`
