### PR TITLE
fix(prime): migrate legacy chat working memory safely

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2597,8 +2597,13 @@ export class DKGAgent extends DKGAgentBase {
     } => {
       const author = explicitAuthor ?? agentAddress;
       const isEvmAuthor = /^0x[a-fA-F0-9]{40}$/.test(author);
+      // The allocator MUST consume `author`'s lane, never the outer default:
+      // the number is minted into the reserved UAL the lifecycle is stamped
+      // with, so allocating from a different address strands the draft under
+      // one author with an identity from another (finalize then fails with
+      // KaIdNamespaceMismatch, OT-RFC-43 §F2).
       const allocateKaNumber = agent.kaNumberAllocator && isEvmAuthor
-        ? () => reconcileAndAllocateKaNumber(agent.kaNumberAllocator!, agent.chain, agent.reconciledKaAuthors, agentAddress)
+        ? () => reconcileAndAllocateKaNumber(agent.kaNumberAllocator!, agent.chain, agent.reconciledKaAuthors, author)
         : undefined;
       return { author, allocateKaNumber };
     };

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2600,6 +2600,30 @@ export class DKGAgent extends DKGAgentBase {
         return agent.publisher.assertionCreate(contextGraphId, name, author, opts?.subGraphName, { allocateKaNumber });
       },
 
+      async migrateLegacyRootScopedWorkingMemory(
+        contextGraphId: string,
+        name: string,
+        opts?: { subGraphName?: string; agentAddress?: string },
+      ) {
+        const author = opts?.agentAddress ?? agentAddress;
+        const isEvmAuthor = /^0x[a-fA-F0-9]{40}$/.test(author);
+        const allocateKaNumber = agent.kaNumberAllocator && isEvmAuthor
+          ? () => reconcileAndAllocateKaNumber(
+              agent.kaNumberAllocator!,
+              agent.chain,
+              agent.reconciledKaAuthors,
+              author,
+            )
+          : undefined;
+        return agent.publisher.migrateLegacyRootScopedWorkingMemory(
+          contextGraphId,
+          name,
+          author,
+          opts?.subGraphName,
+          { allocateKaNumber },
+        );
+      },
+
       /**
        * Write triples to a WM assertion. Accepts:
        * - `Quad[]` — standard quad array (same as publish/share)

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2576,27 +2576,39 @@ export class DKGAgent extends DKGAgentBase {
   get assertion() {
     const agent = this;
     const agentAddress = this.defaultAgentAddress ?? this.peerId;
+    // The single identity-allocation lane for every operation that can mint a
+    // graph-scoped KA number (create + legacy-WM migrate). Both operations
+    // MUST allocate identity for the same resolved author, so the gate lives
+    // in one place:
+    //
+    // Gate on a valid 0x EVM author: when no default agent is registered,
+    // `agentAddress` falls back to the libp2p peerId, which the allocator
+    // rejects (`ethers.getAddress` throws). A peerId-author draft falls back
+    // to the legacy name-keyed WM graph instead of hard-failing. Mirrors the
+    // publisher's own self-allocation guard.
+    // Allow an explicit author (the daemon's import-file route acts for the
+    // request's agent) so the kaNumber mints for the RIGHT address and data
+    // lands in that agent's per-KA …/_working_memory/{addr}/{number} graph
+    // (not the default agent's, and not the legacy name-keyed fallback used
+    // when no number is minted).
+    const resolveAuthorAndAllocator = (explicitAuthor: string | undefined): {
+      author: string;
+      allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }>;
+    } => {
+      const author = explicitAuthor ?? agentAddress;
+      const isEvmAuthor = /^0x[a-fA-F0-9]{40}$/.test(author);
+      const allocateKaNumber = agent.kaNumberAllocator && isEvmAuthor
+        ? () => reconcileAndAllocateKaNumber(agent.kaNumberAllocator!, agent.chain, agent.reconciledKaAuthors, agentAddress)
+        : undefined;
+      return { author, allocateKaNumber };
+    };
     return {
       async create(contextGraphId: string, name: string, opts?: { subGraphName?: string; agentAddress?: string }): Promise<string> {
         // D1 (identity-at-create): mint the KA number/UAL at create so the UAL is the
         // KA's identity from the first write. assertionCreate only allocates when the
         // draft has no preserved kaId (the re-open guard lives there), so passing the
         // callback is safe — re-opens reuse the preserved identity.
-        //
-        // Gate on a valid 0x EVM author: when no default agent is registered,
-        // `agentAddress` falls back to the libp2p peerId, which the allocator rejects
-        // (`ethers.getAddress` throws). A peerId-author draft falls back to the legacy
-        // name-keyed WM graph instead of hard-failing create. Mirrors the publisher's
-        // own self-allocation guard.
-        // Allow an explicit author (the daemon's import-file route acts for the request's
-        // agent) so the kaNumber mints for the RIGHT address and data lands in that agent's
-        // per-KA …/_working_memory/{addr}/{number} graph (not the default agent's, and not
-        // the legacy name-keyed fallback used when no number is minted).
-        const author = opts?.agentAddress ?? agentAddress;
-        const isEvmAuthor = /^0x[a-fA-F0-9]{40}$/.test(author);
-        const allocateKaNumber = agent.kaNumberAllocator && isEvmAuthor
-          ? () => reconcileAndAllocateKaNumber(agent.kaNumberAllocator!, agent.chain, agent.reconciledKaAuthors, author)
-          : undefined;
+        const { author, allocateKaNumber } = resolveAuthorAndAllocator(opts?.agentAddress);
         return agent.publisher.assertionCreate(contextGraphId, name, author, opts?.subGraphName, { allocateKaNumber });
       },
 
@@ -2605,16 +2617,7 @@ export class DKGAgent extends DKGAgentBase {
         name: string,
         opts?: { subGraphName?: string; agentAddress?: string },
       ) {
-        const author = opts?.agentAddress ?? agentAddress;
-        const isEvmAuthor = /^0x[a-fA-F0-9]{40}$/.test(author);
-        const allocateKaNumber = agent.kaNumberAllocator && isEvmAuthor
-          ? () => reconcileAndAllocateKaNumber(
-              agent.kaNumberAllocator!,
-              agent.chain,
-              agent.reconciledKaAuthors,
-              author,
-            )
-          : undefined;
+        const { author, allocateKaNumber } = resolveAuthorAndAllocator(opts?.agentAddress);
         return agent.publisher.migrateLegacyRootScopedWorkingMemory(
           contextGraphId,
           name,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -87,6 +87,7 @@ import {
   pickNetworkTunables,
   ENTITY_PRED_ALT,
   LegacyKnowledgeAssetReadOnlyError,
+  isAllocatableKaAuthorV1,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { canonicalRootlessLifecycleGraph } from './rootless-lifecycle-graph.js';
@@ -2596,7 +2597,7 @@ export class DKGAgent extends DKGAgentBase {
       allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }>;
     } => {
       const author = explicitAuthor ?? agentAddress;
-      const isEvmAuthor = /^0x[a-fA-F0-9]{40}$/.test(author);
+      const isEvmAuthor = isAllocatableKaAuthorV1(author);
       // The allocator MUST consume `author`'s lane, never the outer default:
       // the number is minted into the reserved UAL the lifecycle is stamped
       // with, so allocating from a different address strands the draft under

--- a/packages/agent/test/assertion-identity-lane.test.ts
+++ b/packages/agent/test/assertion-identity-lane.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Identity-allocation lane guard for `DKGAgent.get assertion()` (#2149).
+ *
+ * `assertion.create` and `assertion.migrateLegacyRootScopedWorkingMemory`
+ * MUST resolve the author and mint the KA number through the same lane —
+ * the graph-scoped KA identity a migration allocates has to be the one
+ * create/write resolve later. These tests pin the shared
+ * `resolveAuthorAndAllocator` wiring at the agent→publisher boundary with a
+ * recording fake publisher, without booting a full agent (no Hardhat/libp2p:
+ * the getter closure only touches `defaultAgentAddress`/`node.peerId` plus
+ * the publisher/allocator fields, so a bare prototype instance suffices).
+ */
+import { describe, it, expect } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+
+const EVM_AUTHOR = '0xbb765f337e251c1f18dfbec1a45ca56001b15e54';
+const DEFAULT_EVM = '0x1111111111111111111111111111111111111111';
+const PEER_ID = '12D3KooWFHUALUrdSfrVHSxtCRCJC9xvxS7nYfM6T1sbYVak9HTu';
+
+function makeBareAgent(fields: Record<string, unknown>): any {
+  const agent = Object.create(DKGAgent.prototype);
+  Object.assign(agent, {
+    kaNumberAllocator: {},
+    chain: {},
+    reconciledKaAuthors: new Set<string>(),
+    ...fields,
+  });
+  return agent;
+}
+
+function recordingPublisher() {
+  const createCalls: unknown[][] = [];
+  const migrateCalls: unknown[][] = [];
+  return {
+    createCalls,
+    migrateCalls,
+    publisher: {
+      assertionCreate: async (...args: unknown[]) => {
+        createCalls.push(args);
+        return 'urn:test:assertion';
+      },
+      migrateLegacyRootScopedWorkingMemory: async (...args: unknown[]) => {
+        migrateCalls.push(args);
+        return {
+          status: 'not-needed',
+          copiedPublic: 0,
+          preservedPrivate: 0,
+          sourceGraph: 'urn:test:source',
+          backupGraph: 'urn:test:backup',
+        };
+      },
+    },
+  };
+}
+
+describe('DKGAgent assertion identity lane — create + legacy-WM migrate', () => {
+  it(
+    'migrate forwards contextGraphId, name, the EXPLICIT agentAddress, subGraphName, ' +
+      'and an allocator callback to the publisher',
+    async () => {
+      const rec = recordingPublisher();
+      const agent = makeBareAgent({
+        defaultAgentAddress: DEFAULT_EVM,
+        publisher: rec.publisher,
+      });
+
+      await agent.assertion.migrateLegacyRootScopedWorkingMemory('agent-context', 'chat-turns', {
+        agentAddress: EVM_AUTHOR,
+        subGraphName: 'sub-a',
+      });
+
+      expect(rec.migrateCalls).toHaveLength(1);
+      const [contextGraphId, name, author, subGraphName, opts] = rec.migrateCalls[0]! as any[];
+      expect(contextGraphId).toBe('agent-context');
+      expect(name).toBe('chat-turns');
+      expect(author).toBe(EVM_AUTHOR);
+      expect(subGraphName).toBe('sub-a');
+      expect(typeof opts?.allocateKaNumber).toBe('function');
+    },
+  );
+
+  it('create and migrate resolve the identical author + allocator for the same opts', async () => {
+    const rec = recordingPublisher();
+    const agent = makeBareAgent({
+      defaultAgentAddress: DEFAULT_EVM,
+      publisher: rec.publisher,
+    });
+
+    await agent.assertion.create('agent-context', 'chat-turns', { agentAddress: EVM_AUTHOR });
+    await agent.assertion.migrateLegacyRootScopedWorkingMemory('agent-context', 'chat-turns', {
+      agentAddress: EVM_AUTHOR,
+    });
+
+    const createAuthor = (rec.createCalls[0] as any[])[2];
+    const migrateAuthor = (rec.migrateCalls[0] as any[])[2];
+    expect(createAuthor).toBe(EVM_AUTHOR);
+    expect(migrateAuthor).toBe(EVM_AUTHOR);
+    expect(typeof (rec.createCalls[0] as any[])[4]?.allocateKaNumber).toBe('function');
+    expect(typeof (rec.migrateCalls[0] as any[])[4]?.allocateKaNumber).toBe('function');
+  });
+
+  it(
+    'a non-EVM author (peerId fallback, no default agent) gets NO allocator on either ' +
+      'lane — the draft falls back to the legacy name-keyed WM graph instead of hard-failing',
+    async () => {
+      const rec = recordingPublisher();
+      const agent = makeBareAgent({
+        defaultAgentAddress: undefined,
+        node: { peerId: PEER_ID },
+        publisher: rec.publisher,
+      });
+
+      await agent.assertion.create('agent-context', 'chat-turns');
+      await agent.assertion.migrateLegacyRootScopedWorkingMemory('agent-context', 'chat-turns');
+
+      expect((rec.createCalls[0] as any[])[2]).toBe(PEER_ID);
+      expect((rec.migrateCalls[0] as any[])[2]).toBe(PEER_ID);
+      expect((rec.createCalls[0] as any[])[4]?.allocateKaNumber).toBeUndefined();
+      expect((rec.migrateCalls[0] as any[])[4]?.allocateKaNumber).toBeUndefined();
+    },
+  );
+
+  it('without a configured kaNumberAllocator no lane mints identity, even for an EVM author', async () => {
+    const rec = recordingPublisher();
+    const agent = makeBareAgent({
+      defaultAgentAddress: DEFAULT_EVM,
+      kaNumberAllocator: undefined,
+      publisher: rec.publisher,
+    });
+
+    await agent.assertion.create('agent-context', 'chat-turns', { agentAddress: EVM_AUTHOR });
+    await agent.assertion.migrateLegacyRootScopedWorkingMemory('agent-context', 'chat-turns', {
+      agentAddress: EVM_AUTHOR,
+    });
+
+    expect((rec.createCalls[0] as any[])[4]?.allocateKaNumber).toBeUndefined();
+    expect((rec.migrateCalls[0] as any[])[4]?.allocateKaNumber).toBeUndefined();
+  });
+});

--- a/packages/agent/test/assertion-identity-lane.test.ts
+++ b/packages/agent/test/assertion-identity-lane.test.ts
@@ -17,6 +17,37 @@ const EVM_AUTHOR = '0xbb765f337e251c1f18dfbec1a45ca56001b15e54';
 const DEFAULT_EVM = '0x1111111111111111111111111111111111111111';
 const PEER_ID = '12D3KooWFHUALUrdSfrVHSxtCRCJC9xvxS7nYfM6T1sbYVak9HTu';
 
+/**
+ * A recording allocator/chain pair standing in for the real KA-number lane.
+ * `allocate(author)` is the call that consumes an author's sequence, so
+ * capturing its argument is what proves WHICH lane a mint came from.
+ */
+function recordingAllocator() {
+  const allocatedFor: string[] = [];
+  const reconciledFor: string[] = [];
+  return {
+    allocatedFor,
+    reconciledFor,
+    kaNumberAllocator: {
+      allocate: (author: string) => {
+        allocatedFor.push(author);
+        return { number: 7n };
+      },
+      reconcile: (author: string) => {
+        reconciledFor.push(author);
+      },
+      markReconciled: () => {},
+    },
+    chain: {
+      chainId: 31337,
+      getMaxKaNumberForAuthor: async (author: string) => {
+        reconciledFor.push(author);
+        return 0n;
+      },
+    },
+  };
+}
+
 function makeBareAgent(fields: Record<string, unknown>): any {
   const agent = Object.create(DKGAgent.prototype);
   Object.assign(agent, {
@@ -78,6 +109,57 @@ describe('DKGAgent assertion identity lane — create + legacy-WM migrate', () =
       expect(typeof opts?.allocateKaNumber).toBe('function');
     },
   );
+
+  it(
+    'INVOKING the allocator callback mints in the EXPLICIT author\'s lane, not the ' +
+      'default agent\'s — a callback that closes over the wrong address strands the ' +
+      'draft under one author with an identity minted from another (KaIdNamespaceMismatch)',
+    async () => {
+      const rec = recordingPublisher();
+      const alloc = recordingAllocator();
+      const agent = makeBareAgent({
+        defaultAgentAddress: DEFAULT_EVM,
+        kaNumberAllocator: alloc.kaNumberAllocator,
+        chain: alloc.chain,
+        publisher: rec.publisher,
+      });
+
+      await agent.assertion.create('agent-context', 'chat-turns', { agentAddress: EVM_AUTHOR });
+      await agent.assertion.migrateLegacyRootScopedWorkingMemory('agent-context', 'chat-turns', {
+        agentAddress: EVM_AUTHOR,
+      });
+
+      const createAllocate = (rec.createCalls[0] as any[])[4].allocateKaNumber;
+      const migrateAllocate = (rec.migrateCalls[0] as any[])[4].allocateKaNumber;
+      const createIdentity = await createAllocate();
+      const migrateIdentity = await migrateAllocate();
+
+      // Every consumed lane must be the explicit author's, on BOTH operations.
+      expect(alloc.allocatedFor).toEqual([EVM_AUTHOR, EVM_AUTHOR]);
+      expect(alloc.allocatedFor).not.toContain(DEFAULT_EVM);
+      expect(alloc.reconciledFor.every((a) => a === EVM_AUTHOR)).toBe(true);
+      // ...and the reserved UAL it derives must carry that same author.
+      expect(createIdentity.reservedUal).toBe(`did:dkg:31337/${EVM_AUTHOR.toLowerCase()}/7`);
+      expect(migrateIdentity.reservedUal).toBe(`did:dkg:31337/${EVM_AUTHOR.toLowerCase()}/7`);
+    },
+  );
+
+  it('with no explicit author the allocator mints in the default agent\'s lane', async () => {
+    const rec = recordingPublisher();
+    const alloc = recordingAllocator();
+    const agent = makeBareAgent({
+      defaultAgentAddress: DEFAULT_EVM,
+      kaNumberAllocator: alloc.kaNumberAllocator,
+      chain: alloc.chain,
+      publisher: rec.publisher,
+    });
+
+    await agent.assertion.create('agent-context', 'chat-turns');
+    await (rec.createCalls[0] as any[])[4].allocateKaNumber();
+
+    expect((rec.createCalls[0] as any[])[2]).toBe(DEFAULT_EVM);
+    expect(alloc.allocatedFor).toEqual([DEFAULT_EVM]);
+  });
 
   it('create and migrate resolve the identical author + allocator for the same opts', async () => {
     const rec = recordingPublisher();

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -19,6 +19,7 @@ export * from './daemon/openclaw.js';
 export * from './daemon/hermes.js';
 export * from './daemon/local-agents.js';
 export * from './daemon/lifecycle.js';
+export * from './daemon/memory-tool-context.js';
 export * from './daemon/handle-request.js';
 export * from './daemon/shutdown.js';
 export * from './daemon/core-prereq-check.js';

--- a/packages/cli/src/daemon/index.ts
+++ b/packages/cli/src/daemon/index.ts
@@ -19,4 +19,5 @@ export * from './auto-update.js';
 export * from './openclaw.js';
 export * from './local-agents.js';
 export * from './lifecycle.js';
+export * from './memory-tool-context.js';
 export * from './handle-request.js';

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -3220,13 +3220,15 @@ export async function runDaemonInner(
     createAssertion: async (
       contextGraphId: string,
       name: string,
-      opts?: { subGraphName?: string },
+      opts?: { subGraphName?: string; agentAddress?: string },
     ): Promise<{ assertionUri: string | null; alreadyExists: boolean }> => {
       try {
         const assertionUri = await agent.assertion.create(
           contextGraphId,
           name,
-          opts?.subGraphName ? { subGraphName: opts.subGraphName } : undefined,
+          opts?.subGraphName || opts?.agentAddress
+            ? { subGraphName: opts?.subGraphName, agentAddress: opts?.agentAddress }
+            : undefined,
         );
         return { assertionUri, alreadyExists: false };
       } catch (err: any) {
@@ -3240,13 +3242,15 @@ export async function runDaemonInner(
       contextGraphId: string,
       name: string,
       quads: any[],
-      opts?: { subGraphName?: string },
+      opts?: { subGraphName?: string; agentAddress?: string },
     ): Promise<{ written: number }> => {
       await agent.assertion.write(
         contextGraphId,
         name,
         quads,
-        opts?.subGraphName ? { subGraphName: opts.subGraphName } : undefined,
+        opts?.subGraphName || opts?.agentAddress
+          ? { subGraphName: opts?.subGraphName, agentAddress: opts?.agentAddress }
+          : undefined,
       );
       emitMemoryGraphChanged({
         contextGraphId,
@@ -3258,6 +3262,15 @@ export async function runDaemonInner(
       });
       return { written: quads.length };
     },
+    migrateLegacyAssertion: (
+      contextGraphId: string,
+      name: string,
+      opts?: { subGraphName?: string; agentAddress?: string },
+    ) => agent.assertion.migrateLegacyRootScopedWorkingMemory(
+      contextGraphId,
+      name,
+      opts,
+    ),
     createContextGraph: (opts: {
       id: string;
       name: string;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -416,6 +416,7 @@ import { handleRequest } from './handle-request.js';
 import { configureApiQueryPriority } from './api-query-priority.js';
 import { loadRoutePlugins, countConfiguredPluginSpecs } from './plugin-loader.js';
 import type { MemoryGraphChangedEvent, MemoryGraphLayer } from './routes/context.js';
+import { buildMemoryToolContext } from './memory-tool-context.js';
 import {
   createPromoteWorkerSupervisor,
   type PromoteWorkerConfig,
@@ -3204,81 +3205,10 @@ export async function runDaemonInner(
     }
   });
 
-  const agentToolsContext = {
-    query: (
-      sparql: string,
-      opts?: {
-        contextGraphId?: string;
-        graphSuffix?: "_shared_memory";
-        includeSharedMemory?: boolean;
-        view?: "working-memory" | "shared-working-memory" | "verifiable-memory";
-        agentAddress?: string;
-        assertionName?: string;
-        subGraphName?: string;
-      },
-    ) => agent.query(sparql, opts),
-    createAssertion: async (
-      contextGraphId: string,
-      name: string,
-      opts?: { subGraphName?: string; agentAddress?: string },
-    ): Promise<{ assertionUri: string | null; alreadyExists: boolean }> => {
-      try {
-        const assertionUri = await agent.assertion.create(
-          contextGraphId,
-          name,
-          opts?.subGraphName || opts?.agentAddress
-            ? { subGraphName: opts?.subGraphName, agentAddress: opts?.agentAddress }
-            : undefined,
-        );
-        return { assertionUri, alreadyExists: false };
-      } catch (err: any) {
-        if (err?.message?.includes("already exists")) {
-          return { assertionUri: null, alreadyExists: true };
-        }
-        throw err;
-      }
-    },
-    writeAssertion: async (
-      contextGraphId: string,
-      name: string,
-      quads: any[],
-      opts?: { subGraphName?: string; agentAddress?: string },
-    ): Promise<{ written: number }> => {
-      await agent.assertion.write(
-        contextGraphId,
-        name,
-        quads,
-        opts?.subGraphName || opts?.agentAddress
-          ? { subGraphName: opts?.subGraphName, agentAddress: opts?.agentAddress }
-          : undefined,
-      );
-      emitMemoryGraphChanged({
-        contextGraphId,
-        layers: ["wm"],
-        subGraphName: opts?.subGraphName,
-        operation: "assertion_written",
-        source: "agent_tool",
-        counts: { triples: quads.length },
-      });
-      return { written: quads.length };
-    },
-    migrateLegacyAssertion: (
-      contextGraphId: string,
-      name: string,
-      opts?: { subGraphName?: string; agentAddress?: string },
-    ) => agent.assertion.migrateLegacyRootScopedWorkingMemory(
-      contextGraphId,
-      name,
-      opts,
-    ),
-    createContextGraph: (opts: {
-      id: string;
-      name: string;
-      description?: string;
-      private?: boolean;
-    }) => agent.createContextGraph(opts),
-    listContextGraphs: () => agent.listContextGraphs(),
-  };
+  // The chat-memory glue (query/create/write surface + the legacy chat-WM
+  // migration behind `createAssertion`) lives in `buildMemoryToolContext` so
+  // the daemon-wiring contract stays unit-testable without a real agent.
+  const agentToolsContext = buildMemoryToolContext(agent, emitMemoryGraphChanged);
   // See `resolveMemoryAgentAddress` for the write/read-URI invariant
   // this encodes (issue #277). The helper is exported purely so the
   // daemon-wiring contract stays unit-testable without a real agent.

--- a/packages/cli/src/daemon/memory-tool-context.ts
+++ b/packages/cli/src/daemon/memory-tool-context.ts
@@ -1,0 +1,142 @@
+/**
+ * Memory tool-context wiring for the daemon's `ChatMemoryManager`.
+ *
+ * Extracted from `runDaemonInner` so the production glue between the chat
+ * memory layer and the DKG agent — the exact query/createAssertion/
+ * writeAssertion surface, the memory-graph-changed emission, and the legacy
+ * chat-WM migration (#2149) — is unit-testable without booting a daemon.
+ * `resolveMemoryAgentAddress` in `lifecycle.ts` is the sibling contract for
+ * WHICH agentAddress this context is driven with.
+ *
+ * The legacy migration lives HERE, not in `ChatMemoryManager`: the manager
+ * describes the assertion it wants (`createAssertion` has ensure semantics),
+ * while this daemon boundary owns publisher storage-upgrade concerns. The
+ * migration is keyed to exactly `AGENT_CONTEXT_GRAPH`/`CHAT_TURNS_ASSERTION`
+ * — the caller-selected assertion #2149 is about — so every other legacy KA
+ * stays read-only, exactly as the publisher guarantees.
+ */
+import {
+  AGENT_CONTEXT_GRAPH,
+  CHAT_TURNS_ASSERTION,
+  type MemoryToolContext,
+} from "@origintrail-official/dkg-node-ui";
+import type { MemoryGraphChangedEvent } from "./routes/context.js";
+
+/** The minimal agent surface the memory tool context drives. */
+export interface MemoryToolContextAgent {
+  query(
+    sparql: string,
+    opts?: {
+      contextGraphId?: string;
+      graphSuffix?: "_shared_memory";
+      includeSharedMemory?: boolean;
+      view?: "working-memory" | "shared-working-memory" | "verifiable-memory";
+      agentAddress?: string;
+      assertionName?: string;
+      subGraphName?: string;
+    },
+  ): Promise<any>;
+  assertion: {
+    create(
+      contextGraphId: string,
+      name: string,
+      opts?: { subGraphName?: string; agentAddress?: string },
+    ): Promise<string>;
+    write(
+      contextGraphId: string,
+      name: string,
+      quads: any[],
+      opts?: { subGraphName?: string; agentAddress?: string },
+    ): Promise<unknown>;
+    migrateLegacyRootScopedWorkingMemory(
+      contextGraphId: string,
+      name: string,
+      opts?: { subGraphName?: string; agentAddress?: string },
+    ): Promise<unknown>;
+  };
+  createContextGraph(opts: {
+    id: string;
+    name: string;
+    description?: string;
+    private?: boolean;
+  }): Promise<void>;
+  listContextGraphs(): Promise<any[]>;
+}
+
+export function buildMemoryToolContext(
+  agent: MemoryToolContextAgent,
+  emitMemoryGraphChanged: (event: MemoryGraphChangedEvent) => void,
+): MemoryToolContext {
+  return {
+    query: (sparql, opts) => agent.query(sparql, opts),
+    createAssertion: async (
+      contextGraphId: string,
+      name: string,
+      opts?: { subGraphName?: string; agentAddress?: string },
+    ): Promise<{ assertionUri: string | null; alreadyExists: boolean }> => {
+      // Upgraded nodes can still hold the pre-graph-scope, name-keyed
+      // `agent-context/chat-turns` draft, which the normal create/write APIs
+      // keep read-only by design. Front-load the one explicit,
+      // data-preserving migration for exactly this assertion before ensuring
+      // it exists (#2149); a healthy or absent draft resolves as
+      // `not-needed` and costs one metadata lookup.
+      //
+      // Deliberately OUTSIDE the try below: that catch exists to make
+      // `create` idempotent, and must never reinterpret a failed migration
+      // as "the assertion already exists".
+      if (contextGraphId === AGENT_CONTEXT_GRAPH && name === CHAT_TURNS_ASSERTION) {
+        await agent.assertion.migrateLegacyRootScopedWorkingMemory(
+          contextGraphId,
+          name,
+          opts,
+        );
+      }
+      try {
+        const assertionUri = await agent.assertion.create(
+          contextGraphId,
+          name,
+          opts?.subGraphName || opts?.agentAddress
+            ? { subGraphName: opts?.subGraphName, agentAddress: opts?.agentAddress }
+            : undefined,
+        );
+        return { assertionUri, alreadyExists: false };
+      } catch (err: any) {
+        if (err?.message?.includes("already exists")) {
+          return { assertionUri: null, alreadyExists: true };
+        }
+        throw err;
+      }
+    },
+    writeAssertion: async (
+      contextGraphId: string,
+      name: string,
+      quads: any[],
+      opts?: { subGraphName?: string; agentAddress?: string },
+    ): Promise<{ written: number }> => {
+      await agent.assertion.write(
+        contextGraphId,
+        name,
+        quads,
+        opts?.subGraphName || opts?.agentAddress
+          ? { subGraphName: opts?.subGraphName, agentAddress: opts?.agentAddress }
+          : undefined,
+      );
+      emitMemoryGraphChanged({
+        contextGraphId,
+        layers: ["wm"],
+        subGraphName: opts?.subGraphName,
+        operation: "assertion_written",
+        source: "agent_tool",
+        counts: { triples: quads.length },
+      });
+      return { written: quads.length };
+    },
+    createContextGraph: (opts: {
+      id: string;
+      name: string;
+      description?: string;
+      private?: boolean;
+    }) => agent.createContextGraph(opts),
+    listContextGraphs: () => agent.listContextGraphs(),
+  };
+}

--- a/packages/cli/test/daemon-memory-tool-context.test.ts
+++ b/packages/cli/test/daemon-memory-tool-context.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Daemon-wiring guard for `buildMemoryToolContext` — the production glue
+ * between `ChatMemoryManager` and the DKG agent (#2149).
+ *
+ * Why this file exists: the node-ui tests construct the manager with their
+ * own mock tool context, and the publisher tests exercise
+ * `migrateLegacyRootScopedWorkingMemory` directly, so neither can catch a
+ * regression in the MIDDLE of the migration path — the daemon forgetting to
+ * migrate before create, migrating the wrong assertion, or dropping the
+ * resolved `agentAddress` on the way to the agent. This file locks that glue
+ * by exercising the extracted builder against a recording fake agent.
+ *
+ * Companion to `daemon-lifecycle-memory-agent-address.test.ts`, which locks
+ * WHICH agentAddress the daemon drives this context with.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildMemoryToolContext, type MemoryToolContextAgent } from '../src/daemon.js';
+
+interface RecordingAgent extends MemoryToolContextAgent {
+  order: string[];
+  migrateCalls: unknown[][];
+  createCalls: unknown[][];
+  writeCalls: unknown[][];
+}
+
+function makeAgent(overrides?: {
+  createImpl?: (...args: unknown[]) => Promise<string>;
+  migrateImpl?: (...args: unknown[]) => Promise<unknown>;
+}): RecordingAgent {
+  const order: string[] = [];
+  const migrateCalls: unknown[][] = [];
+  const createCalls: unknown[][] = [];
+  const writeCalls: unknown[][] = [];
+  return {
+    order,
+    migrateCalls,
+    createCalls,
+    writeCalls,
+    query: async () => ({ bindings: [] }),
+    assertion: {
+      create: async (...args: unknown[]) => {
+        order.push('create');
+        createCalls.push(args);
+        if (overrides?.createImpl) return overrides.createImpl(...args);
+        return 'urn:test:assertion';
+      },
+      write: async (...args: unknown[]) => {
+        order.push('write');
+        writeCalls.push(args);
+        return undefined;
+      },
+      migrateLegacyRootScopedWorkingMemory: async (...args: unknown[]) => {
+        order.push('migrate');
+        migrateCalls.push(args);
+        if (overrides?.migrateImpl) return overrides.migrateImpl(...args);
+        return { status: 'not-needed', copiedPublic: 0, preservedPrivate: 0 };
+      },
+    },
+    createContextGraph: async () => undefined,
+    listContextGraphs: async () => [],
+  } as RecordingAgent;
+}
+
+const AGENT_OPTS = { agentAddress: '0xbb765f337e251c1f18dfbec1a45ca56001b15e54' };
+
+describe('buildMemoryToolContext — daemon chat-memory glue', () => {
+  it(
+    'createAssertion for agent-context/chat-turns migrates the legacy WM draft ' +
+      'FIRST and forwards the same resolved agentAddress to both operations',
+    async () => {
+      const agent = makeAgent();
+      const tools = buildMemoryToolContext(agent, () => {});
+
+      const result = await tools.createAssertion('agent-context', 'chat-turns', AGENT_OPTS);
+
+      expect(agent.order).toEqual(['migrate', 'create']);
+      expect(agent.migrateCalls).toEqual([[
+        'agent-context',
+        'chat-turns',
+        AGENT_OPTS,
+      ]]);
+      expect(agent.createCalls).toEqual([[
+        'agent-context',
+        'chat-turns',
+        { subGraphName: undefined, agentAddress: AGENT_OPTS.agentAddress },
+      ]]);
+      expect(result).toEqual({ assertionUri: 'urn:test:assertion', alreadyExists: false });
+    },
+  );
+
+  it('forwards subGraphName alongside agentAddress through the migration call', async () => {
+    const agent = makeAgent();
+    const tools = buildMemoryToolContext(agent, () => {});
+
+    await tools.createAssertion('agent-context', 'chat-turns', {
+      subGraphName: 'sub-a',
+      agentAddress: AGENT_OPTS.agentAddress,
+    });
+
+    expect(agent.migrateCalls[0]?.[2]).toEqual({
+      subGraphName: 'sub-a',
+      agentAddress: AGENT_OPTS.agentAddress,
+    });
+  });
+
+  it(
+    'createAssertion for any OTHER assertion never migrates — the legacy ' +
+      'migration is scoped to exactly the chat-turns WM draft (#2149)',
+    async () => {
+      const agent = makeAgent();
+      const tools = buildMemoryToolContext(agent, () => {});
+
+      await tools.createAssertion('agent-context', 'other-assertion', AGENT_OPTS);
+      await tools.createAssertion('other-graph', 'chat-turns', AGENT_OPTS);
+
+      expect(agent.migrateCalls).toHaveLength(0);
+      expect(agent.createCalls).toHaveLength(2);
+    },
+  );
+
+  it('maps "already exists" from create to alreadyExists (migration still ran)', async () => {
+    const agent = makeAgent({
+      createImpl: async () => {
+        throw new Error('assertion already exists');
+      },
+    });
+    const tools = buildMemoryToolContext(agent, () => {});
+
+    const result = await tools.createAssertion('agent-context', 'chat-turns', AGENT_OPTS);
+
+    expect(agent.order).toEqual(['migrate', 'create']);
+    expect(result).toEqual({ assertionUri: null, alreadyExists: true });
+  });
+
+  it(
+    'a migration failure whose message happens to contain "already exists" still ' +
+      'propagates — the idempotent-create catch must not absorb a failed migration',
+    async () => {
+      const agent = makeAgent({
+        migrateImpl: async () => {
+          throw new Error('legacy backup graph already exists');
+        },
+      });
+      const tools = buildMemoryToolContext(agent, () => {});
+
+      await expect(
+        tools.createAssertion('agent-context', 'chat-turns', AGENT_OPTS),
+      ).rejects.toThrow(/already exists/);
+      expect(agent.createCalls).toHaveLength(0);
+    },
+  );
+
+  it('propagates a coded migration refusal instead of swallowing it', async () => {
+    const refusal = Object.assign(
+      new Error('Legacy WM migration refused for agent-context/chat-turns: only an active, local created/WM draft is eligible'),
+      { code: 'KA_LEGACY_WM_MIGRATION_REFUSED' },
+    );
+    const agent = makeAgent({
+      migrateImpl: async () => {
+        throw refusal;
+      },
+    });
+    const tools = buildMemoryToolContext(agent, () => {});
+
+    await expect(
+      tools.createAssertion('agent-context', 'chat-turns', AGENT_OPTS),
+    ).rejects.toMatchObject({ code: 'KA_LEGACY_WM_MIGRATION_REFUSED' });
+    expect(agent.createCalls).toHaveLength(0);
+  });
+
+  it('writeAssertion forwards agentAddress and emits one wm memory-graph-changed event', async () => {
+    const agent = makeAgent();
+    const events: any[] = [];
+    const tools = buildMemoryToolContext(agent, (event) => events.push(event));
+
+    const result = await tools.writeAssertion(
+      'agent-context',
+      'chat-turns',
+      [{ subject: 'urn:s', predicate: 'urn:p', object: '"o"', graph: '' }],
+      AGENT_OPTS,
+    );
+
+    expect(agent.writeCalls).toEqual([[
+      'agent-context',
+      'chat-turns',
+      [{ subject: 'urn:s', predicate: 'urn:p', object: '"o"', graph: '' }],
+      { subGraphName: undefined, agentAddress: AGENT_OPTS.agentAddress },
+    ]]);
+    expect(result).toEqual({ written: 1 });
+    expect(events).toEqual([
+      expect.objectContaining({
+        contextGraphId: 'agent-context',
+        layers: ['wm'],
+        operation: 'assertion_written',
+        source: 'agent_tool',
+        counts: { triples: 1 },
+      }),
+    ]);
+  });
+});

--- a/packages/core/src/ka-ual-identity.ts
+++ b/packages/core/src/ka-ual-identity.ts
@@ -23,6 +23,25 @@ export const MAX_KA_ID_V1 = (1n << 256n) - 1n;
 const EVM_ADDRESS_ANY_CASE = /^0x[0-9a-fA-F]{40}$/;
 const CANONICAL_UNSIGNED_DECIMAL = /^(?:0|[1-9][0-9]*)$/;
 
+/**
+ * Can this author receive a graph-scoped KA number?
+ *
+ * The rootless KA id packs the author into its high 160 bits, so only a
+ * 20-byte EVM address can own a number — the allocator rejects anything else
+ * (`ethers.getAddress` throws). A node with no registered default agent falls
+ * back to its libp2p peerId, which fails here, and the caller then falls back
+ * to the legacy name-keyed WM graph instead of hard-failing.
+ *
+ * This is a policy-level rule, not formatting: it decides whether create and
+ * legacy-WM migration use graph-scoped identity or legacy storage, so the
+ * agent-side allocator resolver and the publisher's own self-allocation guard
+ * MUST agree. Same reasoning as this module's UAL rule — one home, so the two
+ * sides cannot drift.
+ */
+export function isAllocatableKaAuthorV1(author: string | undefined): boolean {
+  return typeof author === 'string' && EVM_ADDRESS_ANY_CASE.test(author);
+}
+
 export class KaUalIdentityError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);

--- a/packages/node-ui/src/chat-memory.ts
+++ b/packages/node-ui/src/chat-memory.ts
@@ -500,6 +500,23 @@ export class ChatMemoryManager {
   }
 
   /**
+   * The ONE route every chat-turn mutation takes. Target graph, assertion
+   * name, and the resolved-agent mutation options are owned here, so a new
+   * write path cannot silently land in a different graph or skip the
+   * agentAddress that reads resolve under (#277, #2149).
+   */
+  private async writeChatTurns(
+    quads: Array<{ subject: string; predicate: string; object: string; graph: string }>,
+  ): Promise<void> {
+    await this.tools.writeAssertion(
+      this.agentContextGraph,
+      this.chatTurnsAssertion,
+      quads,
+      this.wmMutationOpts(),
+    );
+  }
+
+  /**
    * Lazy creation of the chat-turn context graph + assertion. Runs on the
    * first `storeChatExchange` / `ensureInitialized` call and is idempotent
    * thereafter.
@@ -657,12 +674,7 @@ export class ChatMemoryManager {
       }
     }
 
-    await this.tools.writeAssertion(
-      this.agentContextGraph,
-      this.chatTurnsAssertion,
-      quads,
-      this.wmMutationOpts(),
-    );
+    await this.writeChatTurns(quads);
     this.knownSessions.add(sessionId);
 
     // Fire-and-forget: extract entity mentions and write them as separate triples
@@ -779,12 +791,7 @@ export class ChatMemoryManager {
         graph: '',
       });
     }
-    await this.tools.writeAssertion(
-      this.agentContextGraph,
-      this.chatTurnsAssertion,
-      quads,
-      this.wmMutationOpts(),
-    );
+    await this.writeChatTurns(quads);
   }
 
   private async extractAndWriteMentions(
@@ -832,12 +839,7 @@ export class ChatMemoryManager {
     }
 
     if (quads.length > 0) {
-      await this.tools.writeAssertion(
-        this.agentContextGraph,
-        this.chatTurnsAssertion,
-        quads,
-        this.wmMutationOpts(),
-      );
+      await this.writeChatTurns(quads);
     }
   }
 
@@ -912,12 +914,7 @@ export class ChatMemoryManager {
         { subject: memUri, predicate: `${SCHEMA}dateCreated`, object: `"${new Date().toISOString()}"^^<${XSD_DATETIME}>`, graph: '' },
       );
     }
-    await this.tools.writeAssertion(
-      this.agentContextGraph,
-      this.chatTurnsAssertion,
-      quads,
-      this.wmMutationOpts(),
-    );
+    await this.writeChatTurns(quads);
     return triples.length;
   }
 

--- a/packages/node-ui/src/chat-memory.ts
+++ b/packages/node-ui/src/chat-memory.ts
@@ -24,15 +24,24 @@ export interface MemoryToolContext {
   createAssertion: (
     contextGraphId: string,
     name: string,
-    opts?: { subGraphName?: string },
+    opts?: { subGraphName?: string; agentAddress?: string },
   ) => Promise<{ assertionUri: string | null; alreadyExists: boolean }>;
   /** Append quads into an existing Working Memory assertion graph. */
   writeAssertion: (
     contextGraphId: string,
     name: string,
     quads: any[],
-    opts?: { subGraphName?: string },
+    opts?: { subGraphName?: string; agentAddress?: string },
   ) => Promise<{ written: number }>;
+  /**
+   * Explicitly migrate one legacy, local-only WM assertion before mutation.
+   * Optional for embedders; the daemon supplies it for durable chat memory.
+   */
+  migrateLegacyAssertion?: (
+    contextGraphId: string,
+    name: string,
+    opts?: { subGraphName?: string; agentAddress?: string },
+  ) => Promise<{ status: string; copiedPublic: number; preservedPrivate: number }>;
   createContextGraph: (opts: { id: string; name: string; description?: string; private?: boolean }) => Promise<void>;
   listContextGraphs: () => Promise<any[]>;
 }
@@ -487,6 +496,10 @@ export class ChatMemoryManager {
     };
   }
 
+  private wmMutationOpts(): { agentAddress?: string } {
+    return { agentAddress: this.agentAddress };
+  }
+
   /**
    * Lazy creation of the chat-turn context graph + assertion. Runs on the
    * first `storeChatExchange` / `ensureInitialized` call and is idempotent
@@ -520,7 +533,20 @@ export class ChatMemoryManager {
     const assertionKey = `${this.agentContextGraph}::${this.chatTurnsAssertion}`;
     if (!this.assertionEnsured.has(assertionKey)) {
       try {
-        await this.tools.createAssertion(this.agentContextGraph, this.chatTurnsAssertion);
+        // Upgraded nodes can still hold the pre-graph-scope, name-keyed
+        // `agent-context/chat-turns` draft. The normal create/write APIs keep
+        // those legacy KAs read-only by design, so the daemon exposes one
+        // explicit, data-preserving migration for this local WM assertion.
+        await this.tools.migrateLegacyAssertion?.(
+          this.agentContextGraph,
+          this.chatTurnsAssertion,
+          this.wmMutationOpts(),
+        );
+        await this.tools.createAssertion(
+          this.agentContextGraph,
+          this.chatTurnsAssertion,
+          this.wmMutationOpts(),
+        );
         this.assertionEnsured.add(assertionKey);
       } catch (err: any) {
         if (err?.message?.includes('already exists')) {
@@ -641,7 +667,12 @@ export class ChatMemoryManager {
       }
     }
 
-    await this.tools.writeAssertion(this.agentContextGraph, this.chatTurnsAssertion, quads);
+    await this.tools.writeAssertion(
+      this.agentContextGraph,
+      this.chatTurnsAssertion,
+      quads,
+      this.wmMutationOpts(),
+    );
     this.knownSessions.add(sessionId);
 
     // Fire-and-forget: extract entity mentions and write them as separate triples
@@ -758,7 +789,12 @@ export class ChatMemoryManager {
         graph: '',
       });
     }
-    await this.tools.writeAssertion(this.agentContextGraph, this.chatTurnsAssertion, quads);
+    await this.tools.writeAssertion(
+      this.agentContextGraph,
+      this.chatTurnsAssertion,
+      quads,
+      this.wmMutationOpts(),
+    );
   }
 
   private async extractAndWriteMentions(
@@ -806,7 +842,12 @@ export class ChatMemoryManager {
     }
 
     if (quads.length > 0) {
-      await this.tools.writeAssertion(this.agentContextGraph, this.chatTurnsAssertion, quads);
+      await this.tools.writeAssertion(
+        this.agentContextGraph,
+        this.chatTurnsAssertion,
+        quads,
+        this.wmMutationOpts(),
+      );
     }
   }
 
@@ -881,7 +922,12 @@ export class ChatMemoryManager {
         { subject: memUri, predicate: `${SCHEMA}dateCreated`, object: `"${new Date().toISOString()}"^^<${XSD_DATETIME}>`, graph: '' },
       );
     }
-    await this.tools.writeAssertion(this.agentContextGraph, this.chatTurnsAssertion, quads);
+    await this.tools.writeAssertion(
+      this.agentContextGraph,
+      this.chatTurnsAssertion,
+      quads,
+      this.wmMutationOpts(),
+    );
     return triples.length;
   }
 

--- a/packages/node-ui/src/chat-memory.ts
+++ b/packages/node-ui/src/chat-memory.ts
@@ -18,8 +18,13 @@ export interface MemoryToolContext {
     },
   ) => Promise<any>;
   /**
-   * Create a per-agent Working Memory assertion graph. Idempotent: "already
-   * exists" is resolved quietly, any other error surfaces.
+   * ENSURE a per-agent Working Memory assertion graph exists and is
+   * writable. Idempotent: "already exists" is resolved quietly, any other
+   * error surfaces. The implementation owns whatever storage upgrades that
+   * takes — the daemon, for example, migrates a legacy root-scoped
+   * `agent-context/chat-turns` draft here before creating (#2149). The
+   * manager only describes the assertion it wants; it never orchestrates
+   * publisher storage concerns.
    */
   createAssertion: (
     contextGraphId: string,
@@ -33,15 +38,6 @@ export interface MemoryToolContext {
     quads: any[],
     opts?: { subGraphName?: string; agentAddress?: string },
   ) => Promise<{ written: number }>;
-  /**
-   * Explicitly migrate one legacy, local-only WM assertion before mutation.
-   * Optional for embedders; the daemon supplies it for durable chat memory.
-   */
-  migrateLegacyAssertion?: (
-    contextGraphId: string,
-    name: string,
-    opts?: { subGraphName?: string; agentAddress?: string },
-  ) => Promise<{ status: string; copiedPublic: number; preservedPrivate: number }>;
   createContextGraph: (opts: { id: string; name: string; description?: string; private?: boolean }) => Promise<void>;
   listContextGraphs: () => Promise<any[]>;
 }
@@ -163,8 +159,11 @@ export interface ImportResult {
  * extraction). v1 of the openclaw-dkg-primary-memory work intentionally
  * defers that migration; follow-up work tracks it.
  */
-const AGENT_CONTEXT_GRAPH = 'agent-context';
-const CHAT_TURNS_ASSERTION = 'chat-turns';
+// Exported so the daemon's MemoryToolContext implementation can key
+// chat-specific ensure behavior (the legacy-WM migration for exactly this
+// assertion, #2149) off the same identifiers the manager writes with.
+export const AGENT_CONTEXT_GRAPH = 'agent-context';
+export const CHAT_TURNS_ASSERTION = 'chat-turns';
 const OPENCLAW_LOCAL_SESSION_ID = 'openclaw:dkg-ui';
 
 const CHAT_NS = 'urn:dkg:chat:';
@@ -533,15 +532,6 @@ export class ChatMemoryManager {
     const assertionKey = `${this.agentContextGraph}::${this.chatTurnsAssertion}`;
     if (!this.assertionEnsured.has(assertionKey)) {
       try {
-        // Upgraded nodes can still hold the pre-graph-scope, name-keyed
-        // `agent-context/chat-turns` draft. The normal create/write APIs keep
-        // those legacy KAs read-only by design, so the daemon exposes one
-        // explicit, data-preserving migration for this local WM assertion.
-        await this.tools.migrateLegacyAssertion?.(
-          this.agentContextGraph,
-          this.chatTurnsAssertion,
-          this.wmMutationOpts(),
-        );
         await this.tools.createAssertion(
           this.agentContextGraph,
           this.chatTurnsAssertion,

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -64,7 +64,7 @@ export { LogPushWorker } from './gelf-push-worker.js';
 export type { LogPushWorkerOptions } from './gelf-push-worker.js';
 export { OtlpLogWorker } from './otlp-log-worker.js';
 export type { OtlpLogWorkerOptions } from './otlp-log-worker.js';
-export { ChatMemoryManager } from './chat-memory.js';
+export { ChatMemoryManager, AGENT_CONTEXT_GRAPH, CHAT_TURNS_ASSERTION } from './chat-memory.js';
 export type {
   MemoryToolContext,
   MemoryStats,

--- a/packages/node-ui/test/chat-memory.test.ts
+++ b/packages/node-ui/test/chat-memory.test.ts
@@ -157,7 +157,12 @@ describe('ChatMemoryManager', () => {
     mockQuery.returns.push({ bindings: [] });
     await manager.storeChatExchange('session-1', 'Hello', 'Hi there!');
 
-    expect(mockWriteAssertion.calls[0]).toEqual(['agent-context', 'chat-turns', expect.any(Array)]);
+    expect(mockWriteAssertion.calls[0]).toEqual([
+      'agent-context',
+      'chat-turns',
+      expect.any(Array),
+      { agentAddress: 'did:dkg:agent:test' },
+    ]);
     expect(mockShare.calls).toHaveLength(0);
     const quads = mockWriteAssertion.calls[0][2] as any[];
     expect(quads.length).toBeGreaterThanOrEqual(12);
@@ -913,6 +918,7 @@ describe('ChatMemoryManager WM write discipline', () => {
   let mockShare: TrackingFn;
   let mockCreateAssertion: TrackingFn;
   let mockWriteAssertion: TrackingFn;
+  let mockMigrateLegacyAssertion: TrackingFn;
   let mockCreateContextGraph: TrackingFn;
   let mockListContextGraphs: TrackingFn;
 
@@ -921,6 +927,11 @@ describe('ChatMemoryManager WM write discipline', () => {
     mockShare = trackFn({ shareOperationId: 'op-1' });
     mockCreateAssertion = trackFn({ assertionUri: 'urn:test:assertion', alreadyExists: false });
     mockWriteAssertion = trackFn({ written: 0 });
+    mockMigrateLegacyAssertion = trackFn({
+      status: 'not-needed',
+      copiedPublic: 0,
+      preservedPrivate: 0,
+    });
     mockCreateContextGraph = trackFn(undefined);
     mockListContextGraphs = trackFn([{ id: 'agent-context', name: 'Agent Context' }]);
   });
@@ -931,6 +942,7 @@ describe('ChatMemoryManager WM write discipline', () => {
         query: mockQuery,
         createAssertion: mockCreateAssertion,
         writeAssertion: mockWriteAssertion,
+        migrateLegacyAssertion: mockMigrateLegacyAssertion,
         createContextGraph: mockCreateContextGraph,
         listContextGraphs: mockListContextGraphs,
       },
@@ -948,6 +960,43 @@ describe('ChatMemoryManager WM write discipline', () => {
     expect(mockShare.calls).toHaveLength(0);
   });
 
+  it('migrates the exact agent-scoped chat-turns draft before creating or writing it', async () => {
+    const order: string[] = [];
+    const manager = new ChatMemoryManager(
+      {
+        query: mockQuery,
+        createAssertion: async (...args) => {
+          order.push('create');
+          return mockCreateAssertion(...args);
+        },
+        writeAssertion: async (...args) => {
+          order.push('write');
+          return mockWriteAssertion(...args);
+        },
+        migrateLegacyAssertion: async (...args) => {
+          order.push('migrate');
+          return mockMigrateLegacyAssertion(...args);
+        },
+        createContextGraph: mockCreateContextGraph,
+        listContextGraphs: mockListContextGraphs,
+      },
+      { apiKey: 'test' },
+      { agentAddress: 'did:dkg:agent:test' },
+    );
+    mockQuery.returns.push({ bindings: [] });
+
+    await manager.storeChatExchange('s-migrate', 'hello', 'reply');
+
+    expect(order.slice(0, 3)).toEqual(['migrate', 'create', 'write']);
+    expect(mockMigrateLegacyAssertion.calls).toEqual([[
+      'agent-context',
+      'chat-turns',
+      { agentAddress: 'did:dkg:agent:test' },
+    ]]);
+    expect(mockCreateAssertion.calls[0]?.[2]).toEqual({ agentAddress: 'did:dkg:agent:test' });
+    expect(mockWriteAssertion.calls[0]?.[3]).toEqual({ agentAddress: 'did:dkg:agent:test' });
+  });
+
   it('writeAssertion targets agent-context / chat-turns on every call', async () => {
     const manager = createManager();
     mockQuery.returns.push({ bindings: [] });
@@ -960,6 +1009,7 @@ describe('ChatMemoryManager WM write discipline', () => {
       expect(call[0]).toBe('agent-context');
       expect(call[1]).toBe('chat-turns');
       expect(Array.isArray(call[2])).toBe(true);
+      expect(call[3]).toEqual({ agentAddress: 'did:dkg:agent:test' });
     }
   });
 

--- a/packages/node-ui/test/chat-memory.test.ts
+++ b/packages/node-ui/test/chat-memory.test.ts
@@ -918,7 +918,6 @@ describe('ChatMemoryManager WM write discipline', () => {
   let mockShare: TrackingFn;
   let mockCreateAssertion: TrackingFn;
   let mockWriteAssertion: TrackingFn;
-  let mockMigrateLegacyAssertion: TrackingFn;
   let mockCreateContextGraph: TrackingFn;
   let mockListContextGraphs: TrackingFn;
 
@@ -927,11 +926,6 @@ describe('ChatMemoryManager WM write discipline', () => {
     mockShare = trackFn({ shareOperationId: 'op-1' });
     mockCreateAssertion = trackFn({ assertionUri: 'urn:test:assertion', alreadyExists: false });
     mockWriteAssertion = trackFn({ written: 0 });
-    mockMigrateLegacyAssertion = trackFn({
-      status: 'not-needed',
-      copiedPublic: 0,
-      preservedPrivate: 0,
-    });
     mockCreateContextGraph = trackFn(undefined);
     mockListContextGraphs = trackFn([{ id: 'agent-context', name: 'Agent Context' }]);
   });
@@ -942,7 +936,6 @@ describe('ChatMemoryManager WM write discipline', () => {
         query: mockQuery,
         createAssertion: mockCreateAssertion,
         writeAssertion: mockWriteAssertion,
-        migrateLegacyAssertion: mockMigrateLegacyAssertion,
         createContextGraph: mockCreateContextGraph,
         listContextGraphs: mockListContextGraphs,
       },
@@ -960,7 +953,7 @@ describe('ChatMemoryManager WM write discipline', () => {
     expect(mockShare.calls).toHaveLength(0);
   });
 
-  it('migrates the exact agent-scoped chat-turns draft before creating or writing it', async () => {
+  it('ensureInitialized creates the assertion with the manager agentAddress before first write', async () => {
     const order: string[] = [];
     const manager = new ChatMemoryManager(
       {
@@ -973,10 +966,6 @@ describe('ChatMemoryManager WM write discipline', () => {
           order.push('write');
           return mockWriteAssertion(...args);
         },
-        migrateLegacyAssertion: async (...args) => {
-          order.push('migrate');
-          return mockMigrateLegacyAssertion(...args);
-        },
         createContextGraph: mockCreateContextGraph,
         listContextGraphs: mockListContextGraphs,
       },
@@ -985,16 +974,71 @@ describe('ChatMemoryManager WM write discipline', () => {
     );
     mockQuery.returns.push({ bindings: [] });
 
-    await manager.storeChatExchange('s-migrate', 'hello', 'reply');
+    await manager.storeChatExchange('s-ensure', 'hello', 'reply');
 
-    expect(order.slice(0, 3)).toEqual(['migrate', 'create', 'write']);
-    expect(mockMigrateLegacyAssertion.calls).toEqual([[
+    // The daemon-side createAssertion owns any legacy chat-WM migration
+    // (#2149) — the manager's contract is only: ensure with the SAME agent
+    // address every mutation uses, before the first write.
+    expect(order.slice(0, 2)).toEqual(['create', 'write']);
+    expect(mockCreateAssertion.calls).toEqual([[
       'agent-context',
       'chat-turns',
       { agentAddress: 'did:dkg:agent:test' },
     ]]);
-    expect(mockCreateAssertion.calls[0]?.[2]).toEqual({ agentAddress: 'did:dkg:agent:test' });
     expect(mockWriteAssertion.calls[0]?.[3]).toEqual({ agentAddress: 'did:dkg:agent:test' });
+  });
+
+  it('recordChatTurnPersistenceTransition writes to chat-turns with the manager agentAddress', async () => {
+    const manager = createManager();
+    mockQuery.returns.push({ bindings: [] });
+
+    await manager.recordChatTurnPersistenceTransition('s-transition', 'turn-9', 'stored');
+
+    expect(mockWriteAssertion.calls).toHaveLength(1);
+    const call = mockWriteAssertion.calls[0]!;
+    expect(call[0]).toBe('agent-context');
+    expect(call[1]).toBe('chat-turns');
+    expect(Array.isArray(call[2])).toBe(true);
+    expect(call[3]).toEqual({ agentAddress: 'did:dkg:agent:test' });
+  });
+
+  it('mention-extraction writes to chat-turns with the manager agentAddress', async () => {
+    const manager = createManager();
+    (manager as any).callMentionExtraction = async () => [{ name: 'Alice', type: 'Person' }];
+
+    await (manager as any).extractAndWriteMentions(
+      'urn:dkg:chat:msg:u1',
+      'Alice asked about the DKG',
+      'urn:dkg:chat:msg:a1',
+      'Explained it to Alice',
+    );
+
+    expect(mockWriteAssertion.calls).toHaveLength(1);
+    const call = mockWriteAssertion.calls[0]!;
+    expect(call[0]).toBe('agent-context');
+    expect(call[1]).toBe('chat-turns');
+    expect(Array.isArray(call[2])).toBe(true);
+    expect(call[3]).toEqual({ agentAddress: 'did:dkg:agent:test' });
+  });
+
+  it('extractKnowledge writes to chat-turns with the manager agentAddress', async () => {
+    const manager = createManager();
+    (manager as any).llmClient = {
+      complete: async () => ({
+        message: { content: '<urn:test:s> <urn:test:p> <urn:test:o> .' },
+      }),
+    };
+    mockQuery.returns.push({ bindings: [] });
+
+    const written = await manager.extractKnowledge('s-extract', 'question', 'answer');
+
+    expect(written).toBe(1);
+    expect(mockWriteAssertion.calls).toHaveLength(1);
+    const call = mockWriteAssertion.calls[0]!;
+    expect(call[0]).toBe('agent-context');
+    expect(call[1]).toBe('chat-turns');
+    expect(Array.isArray(call[2])).toBe(true);
+    expect(call[3]).toEqual({ agentAddress: 'did:dkg:agent:test' });
   });
 
   it('writeAssertion targets agent-context / chat-turns on every call', async () => {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -54,7 +54,6 @@ import {
   VM_CURRENT_ASSERTION_PRED,
   SHARE_OPERATION_ID_PRED,
   PROMOTE_OPERATION_INTENT_PRED,
-  stripOptionalLiteral,
   toHex,
   buildScopedMinimalMeta,
   resolveUalByBatchId,
@@ -87,6 +86,7 @@ import {
   type CASCondition,
 } from './errors.js';
 import { isQuorumUnmetError } from './ack-errors.js';
+import { stripOptionalLiteral } from './sparql-binding-literal.js';
 import {
   runLegacyWorkingMemoryMigration,
   type LegacyWmMigrationHost,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -7357,6 +7357,337 @@ export class DKGPublisher implements Publisher {
     this.sharedMemoryOwnedEntities.delete(swmOwnershipKey);
   }
 
+  /**
+   * Explicit, opt-in migration for a legacy name-keyed Working Memory draft.
+   *
+   * The normal mutation APIs deliberately keep legacy/root-scoped KAs
+   * read-only. Local durable integrations such as `agent-context/chat-turns`,
+   * however, can predate graph-scoped KA storage and must survive an upgrade.
+   * This operation is therefore intentionally separate from `assertionCreate`:
+   * callers must select the exact local assertion they are willing to migrate.
+   *
+   * Safety properties:
+   * - only an active `created`/`WM` lifecycle with no SWM/VM/promote state is
+   *   eligible;
+   * - the legacy data graphs are retained as the durable backup;
+   * - the complete legacy lifecycle/event metadata is copied to a deterministic
+   *   backup graph before active metadata is changed;
+   * - a `prepared` marker makes every later step restart-idempotent;
+   * - public data is copied into a newly allocated graph-scoped WM graph while
+   *   private draft data stays intact under its stable lifecycle key.
+   */
+  async migrateLegacyRootScopedWorkingMemory(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+    opts?: { allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }> },
+  ): Promise<{
+    status: 'not-needed' | 'migrated' | 'resumed';
+    copiedPublic: number;
+    preservedPrivate: number;
+    sourceGraph: string;
+    targetGraph?: string;
+    backupGraph: string;
+  }> {
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      () => this.migrateLegacyRootScopedWorkingMemoryUnlocked(
+        contextGraphId,
+        name,
+        agentAddress,
+        subGraphName,
+        opts,
+      ),
+    );
+  }
+
+  private async migrateLegacyRootScopedWorkingMemoryUnlocked(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+    opts?: { allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }> },
+  ): Promise<{
+    status: 'not-needed' | 'migrated' | 'resumed';
+    copiedPublic: number;
+    preservedPrivate: number;
+    sourceGraph: string;
+    targetGraph?: string;
+    backupGraph: string;
+  }> {
+    DKGPublisher.validateOptionalSubGraph(subGraphName);
+    await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
+
+    const dkg = 'http://dkg.io/ontology/';
+    const lifecycle = assertSafeIri(
+      assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName),
+    );
+    const metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
+    const sourceGraph = assertSafeIri(
+      contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName),
+    );
+    const backupGraph = assertSafeIri(
+      `${metaGraph}/legacy-wm-backup/${encodeURIComponent(agentAddress.toLowerCase())}`
+      + `/${encodeURIComponent(name)}`
+      + (subGraphName ? `/${encodeURIComponent(subGraphName)}` : ''),
+    );
+    const markerSubject = sourceGraph;
+    const statePredicate = `${dkg}legacyWorkingMemoryMigrationState`;
+    const targetPredicate = `${dkg}legacyWorkingMemoryMigrationTarget`;
+    const copiedPredicate = `${dkg}legacyWorkingMemoryMigrationCopiedPublic`;
+    const privatePredicate = `${dkg}legacyWorkingMemoryMigrationPreservedPrivate`;
+    const appliedAtPredicate = `${dkg}legacyWorkingMemoryMigrationAppliedAt`;
+
+    const markerResult = await this.store.query(
+      `SELECT ?state ?target ?copied ?private WHERE { GRAPH <${backupGraph}> {
+        OPTIONAL { <${markerSubject}> <${statePredicate}> ?state }
+        OPTIONAL { <${markerSubject}> <${targetPredicate}> ?target }
+        OPTIONAL { <${markerSubject}> <${copiedPredicate}> ?copied }
+        OPTIONAL { <${markerSubject}> <${privatePredicate}> ?private }
+      } } LIMIT 4`,
+    );
+    const markerBinding = markerResult.type === 'bindings' ? markerResult.bindings[0] : undefined;
+    const markerState = stripOptionalLiteral(markerBinding?.['state']);
+    const markerTarget = markerBinding?.['target'];
+    const markerCopied = Number(stripOptionalLiteral(markerBinding?.['copied']) ?? 0);
+    const markerPrivate = Number(stripOptionalLiteral(markerBinding?.['private']) ?? 0);
+
+    const lifecycleResult = await this.store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${metaGraph}> {
+        ?s ?p ?o .
+        FILTER(STR(?s) = ${JSON.stringify(lifecycle)} || STRSTARTS(STR(?s), ${JSON.stringify(`${lifecycle}/`)}))
+      } } LIMIT 10001`,
+    );
+    const lifecycleRows = lifecycleResult.type === 'bindings'
+      ? lifecycleResult.bindings.filter((row) => row['s'] && row['p'] && row['o'] != null)
+      : [];
+    if (lifecycleRows.length > 10_000) {
+      throw Object.assign(
+        new Error(`Legacy WM migration refused: lifecycle metadata exceeds 10000 rows for ${name}`),
+        { code: 'KA_LEGACY_WM_MIGRATION_REFUSED' },
+      );
+    }
+
+    const activeLifecycleRows = lifecycleRows.filter((row) => row['s'] === lifecycle);
+    const scopeVersions = new Set(
+      activeLifecycleRows
+        .filter((row) => row['p'] === `${dkg}contentScopeVersion`)
+        .map((row) => stripOptionalLiteral(row['o']))
+        .filter((value): value is string => value !== undefined),
+    );
+    const isGraphScoped = scopeVersions.size === 1
+      && scopeVersions.has(String(GRAPH_KA_CONTENT_SCOPE_VERSION));
+
+    if (isGraphScoped && markerState !== 'prepared') {
+      return {
+        status: 'not-needed',
+        copiedPublic: Number.isFinite(markerCopied) ? markerCopied : 0,
+        preservedPrivate: Number.isFinite(markerPrivate) ? markerPrivate : 0,
+        sourceGraph,
+        ...(markerTarget ? { targetGraph: markerTarget } : {}),
+        backupGraph,
+      };
+    }
+    if (markerState !== undefined && markerState !== 'prepared' && markerState !== 'completed') {
+      throw Object.assign(
+        new Error(`Legacy WM migration refused: unsupported marker state ${markerState}`),
+        { code: 'KA_LEGACY_WM_MIGRATION_REFUSED' },
+      );
+    }
+    if (markerState === undefined && lifecycleRows.length === 0) {
+      return {
+        status: 'not-needed',
+        copiedPublic: 0,
+        preservedPrivate: 0,
+        sourceGraph,
+        backupGraph,
+      };
+    }
+
+    const publicQuads = await this.assertionScopedQuads(sourceGraph);
+    const privateQuads = await this.privateStore.getKnowledgeAssetPrivateDraftTriples(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
+    // Fail before touching active metadata if legacy content cannot enter the
+    // current graph-scoped assertion boundary.
+    rejectUserAuthoredProtocolMetadata(publicQuads);
+    rejectOversizedRdfLiterals(publicQuads, 'legacyWorkingMemoryMigration.publicQuads');
+    rejectOversizedRdfLiterals(privateQuads, 'legacyWorkingMemoryMigration.privateQuads');
+
+    const wasPrepared = markerState === 'prepared';
+    const canAllocateGraphIdentity = opts?.allocateKaNumber !== undefined
+      || (this.kaAllocator !== undefined && /^0x[a-fA-F0-9]{40}$/.test(agentAddress));
+    if (!wasPrepared) {
+      const stateValues = new Set(
+        activeLifecycleRows
+          .filter((row) => row['p'] === `${dkg}state`)
+          .map((row) => stripOptionalLiteral(row['o']))
+          .filter((value): value is string => value !== undefined),
+      );
+      const layerValues = new Set(
+        activeLifecycleRows
+          .filter((row) => row['p'] === `${dkg}memoryLayer`)
+          .map((row) => stripOptionalLiteral(row['o']))
+          .filter((value): value is string => value !== undefined),
+      );
+      const hasDurableOrInFlightState = activeLifecycleRows.some((row) =>
+        row['p'] === SWM_CURRENT_ASSERTION_PRED
+        || row['p'] === VM_CURRENT_ASSERTION_PRED
+        || row['p'] === SHARE_OPERATION_ID_PRED
+        || row['p'] === PROMOTE_OPERATION_INTENT_PRED,
+      );
+      const sealPredicates = [...new Set(Object.values(ASSERTION_SEAL_PREDICATES))]
+        .map((predicate) => `<${assertSafeIri(predicate)}>`)
+        .join(' ');
+      const sealResult = await this.store.query(
+        `ASK { GRAPH <${metaGraph}> { <${sourceGraph}> ?sealPredicate ?sealValue . VALUES ?sealPredicate { ${sealPredicates} } } }`,
+      );
+      const hasSeal = sealResult.type === 'boolean' && sealResult.value;
+      if (
+        scopeVersions.size > 1
+        || stateValues.size !== 1
+        || !stateValues.has('created')
+        || layerValues.size !== 1
+        || !layerValues.has(MemoryLayer.WorkingMemory)
+        || hasDurableOrInFlightState
+        || hasSeal
+      ) {
+        throw Object.assign(
+          new Error(
+            `Legacy WM migration refused for ${contextGraphId}/${name}: only an active, local created/WM draft is eligible`,
+          ),
+          { code: 'KA_LEGACY_WM_MIGRATION_REFUSED' },
+        );
+      }
+      if (!isGraphScoped && !canAllocateGraphIdentity) {
+        throw Object.assign(
+          new Error(
+            `Legacy WM migration requires a graph-scoped identity allocator for ${contextGraphId}/${name}`,
+          ),
+          { code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' },
+        );
+      }
+
+      await this.store.createGraph(backupGraph);
+      await this.store.insert([
+        ...lifecycleRows.map((row) => ({
+          subject: row['s']!,
+          predicate: row['p']!,
+          object: row['o']!,
+          graph: backupGraph,
+        })),
+        {
+          subject: markerSubject,
+          predicate: statePredicate,
+          object: '"prepared"',
+          graph: backupGraph,
+        },
+        {
+          subject: markerSubject,
+          predicate: copiedPredicate,
+          object: `"${publicQuads.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+          graph: backupGraph,
+        },
+        {
+          subject: markerSubject,
+          predicate: privatePredicate,
+          object: `"${privateQuads.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+          graph: backupGraph,
+        },
+      ]);
+    }
+
+    if (wasPrepared && !isGraphScoped && !canAllocateGraphIdentity) {
+      throw Object.assign(
+        new Error(
+          `Legacy WM migration requires a graph-scoped identity allocator for ${contextGraphId}/${name}`,
+        ),
+        { code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' },
+      );
+    }
+
+    if (!isGraphScoped) {
+      for (const subject of new Set(lifecycleRows.map((row) => row['s']!))) {
+        await this.store.deleteByPattern({ graph: metaGraph, subject });
+      }
+      await this.assertionCreateUnlocked(
+        contextGraphId,
+        name,
+        agentAddress,
+        subGraphName,
+        opts,
+      );
+    }
+
+    const targetGraph = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
+    if (targetGraph === sourceGraph) {
+      throw Object.assign(
+        new Error(
+          `Legacy WM migration requires a graph-scoped identity for ${contextGraphId}/${name}`,
+        ),
+        { code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' },
+      );
+    }
+    if (publicQuads.length > 0) {
+      await this.assertionWriteUnlocked(
+        contextGraphId,
+        name,
+        agentAddress,
+        publicQuads,
+        subGraphName,
+      );
+    }
+
+    await this.store.deleteByPattern({
+      graph: backupGraph,
+      subject: markerSubject,
+      predicate: statePredicate,
+    });
+    await this.store.insert([
+      {
+        subject: markerSubject,
+        predicate: statePredicate,
+        object: '"completed"',
+        graph: backupGraph,
+      },
+      {
+        subject: markerSubject,
+        predicate: targetPredicate,
+        object: targetGraph,
+        graph: backupGraph,
+      },
+      {
+        subject: markerSubject,
+        predicate: appliedAtPredicate,
+        object: `"${new Date().toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime>`,
+        graph: backupGraph,
+      },
+    ]);
+
+    this.log.info(
+      createOperationContext('system'),
+      `Migrated legacy WM ${contextGraphId}/${name} from ${sourceGraph} to ${targetGraph} `
+      + `(public=${publicQuads.length}, private-preserved=${privateQuads.length}, `
+      + `recovery=${wasPrepared ? 'resumed' : 'fresh'})`,
+    );
+
+    return {
+      status: wasPrepared ? 'resumed' : 'migrated',
+      copiedPublic: publicQuads.length,
+      preservedPrivate: privateQuads.length,
+      sourceGraph,
+      targetGraph,
+      backupGraph,
+    };
+  }
+
   async assertionCreate(
     contextGraphId: string,
     name: string,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -52,6 +52,9 @@ import {
   WM_CURRENT_ASSERTION_PRED,
   SWM_CURRENT_ASSERTION_PRED,
   VM_CURRENT_ASSERTION_PRED,
+  SHARE_OPERATION_ID_PRED,
+  PROMOTE_OPERATION_INTENT_PRED,
+  stripOptionalLiteral,
   toHex,
   buildScopedMinimalMeta,
   resolveUalByBatchId,
@@ -84,6 +87,11 @@ import {
   type CASCondition,
 } from './errors.js';
 import { isQuorumUnmetError } from './ack-errors.js';
+import {
+  runLegacyWorkingMemoryMigration,
+  type LegacyWmMigrationHost,
+  type LegacyWmMigrationResult,
+} from './legacy-wm-migration.js';
 import { PublishLifecycleLogger } from './publish-lifecycle-logger.js';
 import {
   PublisherPlanner,
@@ -112,8 +120,6 @@ export {
 // finalize(layer:"swm") so a subset share — which also stamps dkg:rootEntity
 // member rows — cannot be sealed-in-SWM and published as a partial asset.
 const SWM_SHARE_COMPLETE_PRED = 'http://dkg.io/ontology/swmShareComplete';
-const SHARE_OPERATION_ID_PRED = 'http://dkg.io/ontology/shareOperationId';
-const PROMOTE_OPERATION_INTENT_PRED = 'http://dkg.io/ontology/promoteOperationIntent';
 
 type PromoteOperationIntent = {
   version: 1;
@@ -854,19 +860,6 @@ function selectPublicStagingQuads(
     return undefined;
   }
   return publicNquadsBytes;
-}
-
-function stripOptionalLiteral(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  if (value.startsWith('"')) {
-    try {
-      return JSON.parse(value);
-    } catch {
-      const lastQuote = value.lastIndexOf('"');
-      return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
-    }
-  }
-  return value;
 }
 
 function parsePromoteOperationIntent(
@@ -7366,15 +7359,9 @@ export class DKGPublisher implements Publisher {
    * This operation is therefore intentionally separate from `assertionCreate`:
    * callers must select the exact local assertion they are willing to migrate.
    *
-   * Safety properties:
-   * - only an active `created`/`WM` lifecycle with no SWM/VM/promote state is
-   *   eligible;
-   * - the legacy data graphs are retained as the durable backup;
-   * - the complete legacy lifecycle/event metadata is copied to a deterministic
-   *   backup graph before active metadata is changed;
-   * - a `prepared` marker makes every later step restart-idempotent;
-   * - public data is copied into a newly allocated graph-scoped WM graph while
-   *   private draft data stays intact under its stable lifecycle key.
+   * The publisher only owns the lifecycle write lock and the primitive
+   * boundary; phase ordering, classification, and the safety properties live
+   * in `legacy-wm-migration.ts`.
    */
   async migrateLegacyRootScopedWorkingMemory(
     contextGraphId: string,
@@ -7382,309 +7369,56 @@ export class DKGPublisher implements Publisher {
     agentAddress: string,
     subGraphName?: string,
     opts?: { allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }> },
-  ): Promise<{
-    status: 'not-needed' | 'migrated' | 'resumed';
-    copiedPublic: number;
-    preservedPrivate: number;
-    sourceGraph: string;
-    targetGraph?: string;
-    backupGraph: string;
-  }> {
+  ): Promise<LegacyWmMigrationResult> {
     return this.withAssertionLifecycleWriteLock(
       contextGraphId,
       name,
       agentAddress,
       subGraphName,
-      () => this.migrateLegacyRootScopedWorkingMemoryUnlocked(
+      () => runLegacyWorkingMemoryMigration(this.legacyWmMigrationHost(), {
         contextGraphId,
         name,
         agentAddress,
         subGraphName,
-        opts,
-      ),
+        allocateKaNumber: opts?.allocateKaNumber,
+      }),
     );
   }
 
-  private async migrateLegacyRootScopedWorkingMemoryUnlocked(
-    contextGraphId: string,
-    name: string,
-    agentAddress: string,
-    subGraphName?: string,
-    opts?: { allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }> },
-  ): Promise<{
-    status: 'not-needed' | 'migrated' | 'resumed';
-    copiedPublic: number;
-    preservedPrivate: number;
-    sourceGraph: string;
-    targetGraph?: string;
-    backupGraph: string;
-  }> {
-    DKGPublisher.validateOptionalSubGraph(subGraphName);
-    await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
-
-    const dkg = 'http://dkg.io/ontology/';
-    const lifecycle = assertSafeIri(
-      assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName),
-    );
-    const metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
-    const sourceGraph = assertSafeIri(
-      contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName),
-    );
-    const backupGraph = assertSafeIri(
-      `${metaGraph}/legacy-wm-backup/${encodeURIComponent(agentAddress.toLowerCase())}`
-      + `/${encodeURIComponent(name)}`
-      + (subGraphName ? `/${encodeURIComponent(subGraphName)}` : ''),
-    );
-    const markerSubject = sourceGraph;
-    const statePredicate = `${dkg}legacyWorkingMemoryMigrationState`;
-    const targetPredicate = `${dkg}legacyWorkingMemoryMigrationTarget`;
-    const copiedPredicate = `${dkg}legacyWorkingMemoryMigrationCopiedPublic`;
-    const privatePredicate = `${dkg}legacyWorkingMemoryMigrationPreservedPrivate`;
-    const appliedAtPredicate = `${dkg}legacyWorkingMemoryMigrationAppliedAt`;
-
-    const markerResult = await this.store.query(
-      `SELECT ?state ?target ?copied ?private WHERE { GRAPH <${backupGraph}> {
-        OPTIONAL { <${markerSubject}> <${statePredicate}> ?state }
-        OPTIONAL { <${markerSubject}> <${targetPredicate}> ?target }
-        OPTIONAL { <${markerSubject}> <${copiedPredicate}> ?copied }
-        OPTIONAL { <${markerSubject}> <${privatePredicate}> ?private }
-      } } LIMIT 4`,
-    );
-    const markerBinding = markerResult.type === 'bindings' ? markerResult.bindings[0] : undefined;
-    const markerState = stripOptionalLiteral(markerBinding?.['state']);
-    const markerTarget = markerBinding?.['target'];
-    const markerCopied = Number(stripOptionalLiteral(markerBinding?.['copied']) ?? 0);
-    const markerPrivate = Number(stripOptionalLiteral(markerBinding?.['private']) ?? 0);
-
-    const lifecycleResult = await this.store.query(
-      `SELECT ?s ?p ?o WHERE { GRAPH <${metaGraph}> {
-        ?s ?p ?o .
-        FILTER(STR(?s) = ${JSON.stringify(lifecycle)} || STRSTARTS(STR(?s), ${JSON.stringify(`${lifecycle}/`)}))
-      } } LIMIT 10001`,
-    );
-    const lifecycleRows = lifecycleResult.type === 'bindings'
-      ? lifecycleResult.bindings.filter((row) => row['s'] && row['p'] && row['o'] != null)
-      : [];
-    if (lifecycleRows.length > 10_000) {
-      throw Object.assign(
-        new Error(`Legacy WM migration refused: lifecycle metadata exceeds 10000 rows for ${name}`),
-        { code: 'KA_LEGACY_WM_MIGRATION_REFUSED' },
-      );
-    }
-
-    const activeLifecycleRows = lifecycleRows.filter((row) => row['s'] === lifecycle);
-    const scopeVersions = new Set(
-      activeLifecycleRows
-        .filter((row) => row['p'] === `${dkg}contentScopeVersion`)
-        .map((row) => stripOptionalLiteral(row['o']))
-        .filter((value): value is string => value !== undefined),
-    );
-    const isGraphScoped = scopeVersions.size === 1
-      && scopeVersions.has(String(GRAPH_KA_CONTENT_SCOPE_VERSION));
-
-    if (isGraphScoped && markerState !== 'prepared') {
-      return {
-        status: 'not-needed',
-        copiedPublic: Number.isFinite(markerCopied) ? markerCopied : 0,
-        preservedPrivate: Number.isFinite(markerPrivate) ? markerPrivate : 0,
-        sourceGraph,
-        ...(markerTarget ? { targetGraph: markerTarget } : {}),
-        backupGraph,
-      };
-    }
-    if (markerState !== undefined && markerState !== 'prepared' && markerState !== 'completed') {
-      throw Object.assign(
-        new Error(`Legacy WM migration refused: unsupported marker state ${markerState}`),
-        { code: 'KA_LEGACY_WM_MIGRATION_REFUSED' },
-      );
-    }
-    if (markerState === undefined && lifecycleRows.length === 0) {
-      return {
-        status: 'not-needed',
-        copiedPublic: 0,
-        preservedPrivate: 0,
-        sourceGraph,
-        backupGraph,
-      };
-    }
-
-    const publicQuads = await this.assertionScopedQuads(sourceGraph);
-    const privateQuads = await this.privateStore.getKnowledgeAssetPrivateDraftTriples(
-      contextGraphId,
-      agentAddress,
-      name,
-      subGraphName,
-    );
-    // Fail before touching active metadata if legacy content cannot enter the
-    // current graph-scoped assertion boundary.
-    rejectUserAuthoredProtocolMetadata(publicQuads);
-    rejectOversizedRdfLiterals(publicQuads, 'legacyWorkingMemoryMigration.publicQuads');
-    rejectOversizedRdfLiterals(privateQuads, 'legacyWorkingMemoryMigration.privateQuads');
-
-    const wasPrepared = markerState === 'prepared';
-    const canAllocateGraphIdentity = opts?.allocateKaNumber !== undefined
-      || (this.kaAllocator !== undefined && /^0x[a-fA-F0-9]{40}$/.test(agentAddress));
-    if (!wasPrepared) {
-      const stateValues = new Set(
-        activeLifecycleRows
-          .filter((row) => row['p'] === `${dkg}state`)
-          .map((row) => stripOptionalLiteral(row['o']))
-          .filter((value): value is string => value !== undefined),
-      );
-      const layerValues = new Set(
-        activeLifecycleRows
-          .filter((row) => row['p'] === `${dkg}memoryLayer`)
-          .map((row) => stripOptionalLiteral(row['o']))
-          .filter((value): value is string => value !== undefined),
-      );
-      const hasDurableOrInFlightState = activeLifecycleRows.some((row) =>
-        row['p'] === SWM_CURRENT_ASSERTION_PRED
-        || row['p'] === VM_CURRENT_ASSERTION_PRED
-        || row['p'] === SHARE_OPERATION_ID_PRED
-        || row['p'] === PROMOTE_OPERATION_INTENT_PRED,
-      );
-      const sealPredicates = [...new Set(Object.values(ASSERTION_SEAL_PREDICATES))]
-        .map((predicate) => `<${assertSafeIri(predicate)}>`)
-        .join(' ');
-      const sealResult = await this.store.query(
-        `ASK { GRAPH <${metaGraph}> { <${sourceGraph}> ?sealPredicate ?sealValue . VALUES ?sealPredicate { ${sealPredicates} } } }`,
-      );
-      const hasSeal = sealResult.type === 'boolean' && sealResult.value;
-      if (
-        scopeVersions.size > 1
-        || stateValues.size !== 1
-        || !stateValues.has('created')
-        || layerValues.size !== 1
-        || !layerValues.has(MemoryLayer.WorkingMemory)
-        || hasDurableOrInFlightState
-        || hasSeal
-      ) {
-        throw Object.assign(
-          new Error(
-            `Legacy WM migration refused for ${contextGraphId}/${name}: only an active, local created/WM draft is eligible`,
-          ),
-          { code: 'KA_LEGACY_WM_MIGRATION_REFUSED' },
-        );
-      }
-      if (!isGraphScoped && !canAllocateGraphIdentity) {
-        throw Object.assign(
-          new Error(
-            `Legacy WM migration requires a graph-scoped identity allocator for ${contextGraphId}/${name}`,
-          ),
-          { code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' },
-        );
-      }
-
-      await this.store.createGraph(backupGraph);
-      await this.store.insert([
-        ...lifecycleRows.map((row) => ({
-          subject: row['s']!,
-          predicate: row['p']!,
-          object: row['o']!,
-          graph: backupGraph,
-        })),
-        {
-          subject: markerSubject,
-          predicate: statePredicate,
-          object: '"prepared"',
-          graph: backupGraph,
-        },
-        {
-          subject: markerSubject,
-          predicate: copiedPredicate,
-          object: `"${publicQuads.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
-          graph: backupGraph,
-        },
-        {
-          subject: markerSubject,
-          predicate: privatePredicate,
-          object: `"${privateQuads.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
-          graph: backupGraph,
-        },
-      ]);
-    }
-
-    if (wasPrepared && !isGraphScoped && !canAllocateGraphIdentity) {
-      throw Object.assign(
-        new Error(
-          `Legacy WM migration requires a graph-scoped identity allocator for ${contextGraphId}/${name}`,
-        ),
-        { code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' },
-      );
-    }
-
-    if (!isGraphScoped) {
-      for (const subject of new Set(lifecycleRows.map((row) => row['s']!))) {
-        await this.store.deleteByPattern({ graph: metaGraph, subject });
-      }
-      await this.assertionCreateUnlocked(
-        contextGraphId,
-        name,
-        agentAddress,
-        subGraphName,
-        opts,
-      );
-    }
-
-    const targetGraph = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
-    if (targetGraph === sourceGraph) {
-      throw Object.assign(
-        new Error(
-          `Legacy WM migration requires a graph-scoped identity for ${contextGraphId}/${name}`,
-        ),
-        { code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' },
-      );
-    }
-    if (publicQuads.length > 0) {
-      await this.assertionWriteUnlocked(
-        contextGraphId,
-        name,
-        agentAddress,
-        publicQuads,
-        subGraphName,
-      );
-    }
-
-    await this.store.deleteByPattern({
-      graph: backupGraph,
-      subject: markerSubject,
-      predicate: statePredicate,
-    });
-    await this.store.insert([
-      {
-        subject: markerSubject,
-        predicate: statePredicate,
-        object: '"completed"',
-        graph: backupGraph,
-      },
-      {
-        subject: markerSubject,
-        predicate: targetPredicate,
-        object: targetGraph,
-        graph: backupGraph,
-      },
-      {
-        subject: markerSubject,
-        predicate: appliedAtPredicate,
-        object: `"${new Date().toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime>`,
-        graph: backupGraph,
-      },
-    ]);
-
-    this.log.info(
-      createOperationContext('system'),
-      `Migrated legacy WM ${contextGraphId}/${name} from ${sourceGraph} to ${targetGraph} `
-      + `(public=${publicQuads.length}, private-preserved=${privateQuads.length}, `
-      + `recovery=${wasPrepared ? 'resumed' : 'fresh'})`,
-    );
-
+  /**
+   * The complete primitive surface the legacy-WM migration is allowed to
+   * touch. Everything here is a thin binding onto existing publisher
+   * internals — no migration policy.
+   */
+  private legacyWmMigrationHost(): LegacyWmMigrationHost {
     return {
-      status: wasPrepared ? 'resumed' : 'migrated',
-      copiedPublic: publicQuads.length,
-      preservedPrivate: privateQuads.length,
-      sourceGraph,
-      targetGraph,
-      backupGraph,
+      store: this.store,
+      validateOptionalSubGraph: (subGraphName) =>
+        DKGPublisher.validateOptionalSubGraph(subGraphName),
+      ensureSubGraphRegistered: (contextGraphId, subGraphName) =>
+        this.ensureSubGraphRegistered(contextGraphId, subGraphName),
+      loadAssertionScopedQuads: (graphUri) => this.assertionScopedQuads(graphUri),
+      loadPrivateDraftQuads: (contextGraphId, agentAddress, name, subGraphName) =>
+        this.privateStore.getKnowledgeAssetPrivateDraftTriples(
+          contextGraphId,
+          agentAddress,
+          name,
+          subGraphName,
+        ),
+      validateMigratableContent: (publicQuads, privateQuads) => {
+        rejectUserAuthoredProtocolMetadata(publicQuads);
+        rejectOversizedRdfLiterals(publicQuads, 'legacyWorkingMemoryMigration.publicQuads');
+        rejectOversizedRdfLiterals(privateQuads, 'legacyWorkingMemoryMigration.privateQuads');
+      },
+      canSelfAllocateGraphIdentity: (agentAddress) =>
+        this.kaAllocator !== undefined && /^0x[a-fA-F0-9]{40}$/.test(agentAddress),
+      createGraphScopedDraft: (contextGraphId, name, agentAddress, subGraphName, opts) =>
+        this.assertionCreateUnlocked(contextGraphId, name, agentAddress, subGraphName, opts),
+      writeGraphScopedDraft: (contextGraphId, name, agentAddress, quads, subGraphName) =>
+        this.assertionWriteUnlocked(contextGraphId, name, agentAddress, quads, subGraphName),
+      wmGraphUri: (contextGraphId, agentAddress, name, subGraphName) =>
+        this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName),
+      logInfo: (message) => this.log.info(createOperationContext('system'), message),
     };
   }
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3,7 +3,7 @@ import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams }
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, GraphKnowledgeAssetScope, OperationContext } from '@origintrail-official/dkg-core';
 import type { AssertionSeal } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphPrivateUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, contextGraphSubGraphPrivateUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphPrivateUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, contextGraphSubGraphPrivateUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, isAllocatableKaAuthorV1, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
 import { GraphManager, invalidateSwmMaterializationWitness, PrivateContentStore, loadSharedMemoryQuadsForScope, loadSelectedSharedMemoryQuads, resolveSharedMemoryScopeGraphs, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK, type V10ACKProviderParams, type V10ACKProviderObject, type LegacyV10ACKProvider } from './publisher.js';
 import { assertNoUserAuthoredKnowledgeAssetSkolemTerms, skolemizeByEntity, skolemizeKnowledgeAsset, skolemizeKnowledgeAssetParts } from './auto-partition.js';
@@ -7411,7 +7411,7 @@ export class DKGPublisher implements Publisher {
         rejectOversizedRdfLiterals(privateQuads, 'legacyWorkingMemoryMigration.privateQuads');
       },
       canSelfAllocateGraphIdentity: (agentAddress) =>
-        this.kaAllocator !== undefined && /^0x[a-fA-F0-9]{40}$/.test(agentAddress),
+        this.kaAllocator !== undefined && isAllocatableKaAuthorV1(agentAddress),
       createGraphScopedDraft: (contextGraphId, name, agentAddress, subGraphName, opts) =>
         this.assertionCreateUnlocked(contextGraphId, name, agentAddress, subGraphName, opts),
       writeGraphScopedDraft: (contextGraphId, name, agentAddress, quads, subGraphName) =>
@@ -7543,7 +7543,7 @@ export class DKGPublisher implements Publisher {
       if (m) kaNumber = BigInt(m[1]);
     } else if (opts?.allocateKaNumber) {
       ({ number: kaNumber, reservedUal } = await opts.allocateKaNumber());
-    } else if (this.kaAllocator && /^0x[a-fA-F0-9]{40}$/.test(agentAddress)) {
+    } else if (this.kaAllocator && isAllocatableKaAuthorV1(agentAddress)) {
       // Direct (non-agent-wrapper) callers still get a number from the SHARED allocator
       // (same instance the agent wrapper uses — no double-mint), so the per-KA graph is
       // the ONE layout. Without this, a direct create would fall back to a name-keyed

--- a/packages/publisher/src/legacy-wm-migration.ts
+++ b/packages/publisher/src/legacy-wm-migration.ts
@@ -1,0 +1,545 @@
+/**
+ * Legacy root-scoped Working Memory migration (issue #2149).
+ *
+ * Upgraded nodes can still hold a pre-graph-scope, name-keyed WM draft such
+ * as `agent-context/chat-turns`. The normal mutation APIs deliberately keep
+ * legacy/root-scoped KAs read-only, so this module implements the one
+ * explicit, opt-in migration for a caller-selected local assertion.
+ * `DKGPublisher.migrateLegacyRootScopedWorkingMemory` stays the lock-owning
+ * façade and supplies its store / private-store / create / write primitives
+ * through `LegacyWmMigrationHost`; this module owns phase ordering and
+ * classification:
+ *
+ *   load marker → load lifecycle → classify (plan) → load + validate content
+ *   → prepare backup → apply graph-scoped draft → complete marker
+ *
+ * The classification is a typed `LegacyWmMigrationPlan` — `not-needed`,
+ * `fresh-legacy-draft`, or `prepared-resume` — and refusals are coded errors
+ * (`KA_LEGACY_WM_MIGRATION_REFUSED`, `KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY`),
+ * so the restart states and allowed transitions are explicit rather than
+ * implicit in one long mutable procedure.
+ *
+ * Safety properties:
+ * - only an active `created`/`WM` lifecycle with no SWM/VM/promote state is
+ *   eligible;
+ * - the legacy data graphs are retained as the durable backup;
+ * - the complete legacy lifecycle/event metadata is copied to a deterministic
+ *   backup graph before active metadata is changed;
+ * - a `prepared` marker makes every later step restart-idempotent;
+ * - public data is copied into a newly allocated graph-scoped WM graph while
+ *   private draft data stays intact under its stable lifecycle key.
+ */
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  ASSERTION_SEAL_PREDICATES,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  assertSafeIri,
+  assertionLifecycleUri,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+} from '@origintrail-official/dkg-core';
+import {
+  PROMOTE_OPERATION_INTENT_PRED,
+  SHARE_OPERATION_ID_PRED,
+  SWM_CURRENT_ASSERTION_PRED,
+  VM_CURRENT_ASSERTION_PRED,
+  stripOptionalLiteral,
+} from './metadata.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const STATE_PRED = `${DKG}legacyWorkingMemoryMigrationState`;
+const TARGET_PRED = `${DKG}legacyWorkingMemoryMigrationTarget`;
+const COPIED_PUBLIC_PRED = `${DKG}legacyWorkingMemoryMigrationCopiedPublic`;
+const PRESERVED_PRIVATE_PRED = `${DKG}legacyWorkingMemoryMigrationPreservedPrivate`;
+const APPLIED_AT_PRED = `${DKG}legacyWorkingMemoryMigrationAppliedAt`;
+const MAX_LIFECYCLE_ROWS = 10_000;
+
+export interface LegacyWmMigrationRequest {
+  contextGraphId: string;
+  name: string;
+  agentAddress: string;
+  subGraphName?: string;
+  allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }>;
+}
+
+export interface LegacyWmMigrationResult {
+  status: 'not-needed' | 'migrated' | 'resumed';
+  copiedPublic: number;
+  preservedPrivate: number;
+  sourceGraph: string;
+  targetGraph?: string;
+  backupGraph: string;
+}
+
+/**
+ * Primitives the lock-owning `DKGPublisher` façade supplies. The migration
+ * never touches publisher internals directly, so the boundary that decides
+ * what a migration is ALLOWED to do stays reviewable in one interface.
+ */
+export interface LegacyWmMigrationHost {
+  store: Pick<TripleStore, 'query' | 'insert' | 'createGraph' | 'deleteByPattern'>;
+  validateOptionalSubGraph(subGraphName: string | undefined): void;
+  ensureSubGraphRegistered(contextGraphId: string, subGraphName: string | undefined): Promise<void>;
+  /** All quads reachable from the assertion-scoped graph family of `graphUri`. */
+  loadAssertionScopedQuads(graphUri: string): Promise<Quad[]>;
+  loadPrivateDraftQuads(
+    contextGraphId: string,
+    agentAddress: string,
+    name: string,
+    subGraphName: string | undefined,
+  ): Promise<Quad[]>;
+  /** Content gate: throws unless the legacy content may enter the graph-scoped boundary. */
+  validateMigratableContent(publicQuads: Quad[], privateQuads: Quad[]): void;
+  /** Whether the publisher can mint a KA number itself for this author. */
+  canSelfAllocateGraphIdentity(agentAddress: string): boolean;
+  createGraphScopedDraft(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName: string | undefined,
+    opts: { allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }> },
+  ): Promise<unknown>;
+  writeGraphScopedDraft(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    quads: Quad[],
+    subGraphName: string | undefined,
+  ): Promise<unknown>;
+  wmGraphUri(
+    contextGraphId: string,
+    agentAddress: string,
+    name: string,
+    subGraphName: string | undefined,
+  ): Promise<string>;
+  logInfo(message: string): void;
+}
+
+/**
+ * The typed migration phases a request can classify into. Refusals throw.
+ *
+ * The two `not-needed` reasons differ in what they may report: an
+ * already-migrated draft echoes its recorded marker counts/target, while a
+ * draft that never existed (or was since discarded) reports nothing — its
+ * marker rows, if any survived a crash, describe an assertion that is gone.
+ */
+export type LegacyWmMigrationPlan =
+  | { phase: 'not-needed'; reason: 'already-graph-scoped' | 'no-legacy-draft' }
+  | { phase: 'fresh-legacy-draft' }
+  | { phase: 'prepared-resume' };
+
+interface MigrationUris {
+  lifecycle: string;
+  metaGraph: string;
+  sourceGraph: string;
+  backupGraph: string;
+  /** Marker rows hang off the legacy source graph inside the backup graph. */
+  markerSubject: string;
+}
+
+interface MigrationMarker {
+  state: string | undefined;
+  targetGraph: string | undefined;
+  copiedPublic: number;
+  preservedPrivate: number;
+}
+
+type LifecycleRow = Record<string, string | undefined>;
+
+interface LifecycleScope {
+  activeRows: LifecycleRow[];
+  scopeVersions: Set<string>;
+  isGraphScoped: boolean;
+}
+
+function migrationRefused(message: string): Error {
+  return Object.assign(new Error(message), { code: 'KA_LEGACY_WM_MIGRATION_REFUSED' });
+}
+
+function identityAllocatorRequired(contextGraphId: string, name: string): Error {
+  return Object.assign(
+    new Error(
+      `Legacy WM migration requires a graph-scoped identity allocator for ${contextGraphId}/${name}`,
+    ),
+    { code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' },
+  );
+}
+
+function migrationUris(request: LegacyWmMigrationRequest): MigrationUris {
+  const { contextGraphId, name, agentAddress, subGraphName } = request;
+  // Derivation order is load-bearing: when more than one derived URI is
+  // unsafe the caller must keep seeing the lifecycle-flavored error first.
+  const lifecycle = assertSafeIri(
+    assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName),
+  );
+  const metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
+  const sourceGraph = assertSafeIri(
+    contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName),
+  );
+  return {
+    lifecycle,
+    metaGraph,
+    sourceGraph,
+    backupGraph: assertSafeIri(
+      `${metaGraph}/legacy-wm-backup/${encodeURIComponent(agentAddress.toLowerCase())}`
+      + `/${encodeURIComponent(name)}`
+      + (subGraphName ? `/${encodeURIComponent(subGraphName)}` : ''),
+    ),
+    markerSubject: sourceGraph,
+  };
+}
+
+/** Phase 1 — load the durable restart marker from the backup graph. */
+async function loadMigrationMarker(
+  store: LegacyWmMigrationHost['store'],
+  uris: MigrationUris,
+): Promise<MigrationMarker> {
+  const result = await store.query(
+    `SELECT ?state ?target ?copied ?private WHERE { GRAPH <${uris.backupGraph}> {
+      OPTIONAL { <${uris.markerSubject}> <${STATE_PRED}> ?state }
+      OPTIONAL { <${uris.markerSubject}> <${TARGET_PRED}> ?target }
+      OPTIONAL { <${uris.markerSubject}> <${COPIED_PUBLIC_PRED}> ?copied }
+      OPTIONAL { <${uris.markerSubject}> <${PRESERVED_PRIVATE_PRED}> ?private }
+    } } LIMIT 4`,
+  );
+  const binding = result.type === 'bindings' ? result.bindings[0] : undefined;
+  const copiedPublic = Number(stripOptionalLiteral(binding?.['copied']) ?? 0);
+  const preservedPrivate = Number(stripOptionalLiteral(binding?.['private']) ?? 0);
+  return {
+    state: stripOptionalLiteral(binding?.['state']),
+    targetGraph: binding?.['target'],
+    copiedPublic: Number.isFinite(copiedPublic) ? copiedPublic : 0,
+    preservedPrivate: Number.isFinite(preservedPrivate) ? preservedPrivate : 0,
+  };
+}
+
+/** Phase 2 — load the complete lifecycle/event row set for this assertion. */
+async function loadLifecycleRows(
+  store: LegacyWmMigrationHost['store'],
+  uris: MigrationUris,
+  name: string,
+): Promise<LifecycleRow[]> {
+  const result = await store.query(
+    `SELECT ?s ?p ?o WHERE { GRAPH <${uris.metaGraph}> {
+      ?s ?p ?o .
+      FILTER(STR(?s) = ${JSON.stringify(uris.lifecycle)} || STRSTARTS(STR(?s), ${JSON.stringify(`${uris.lifecycle}/`)}))
+    } } LIMIT ${MAX_LIFECYCLE_ROWS + 1}`,
+  );
+  const rows = result.type === 'bindings'
+    ? result.bindings.filter((row) => row['s'] && row['p'] && row['o'] != null)
+    : [];
+  if (rows.length > MAX_LIFECYCLE_ROWS) {
+    throw migrationRefused(
+      `Legacy WM migration refused: lifecycle metadata exceeds ${MAX_LIFECYCLE_ROWS} rows for ${name}`,
+    );
+  }
+  return rows;
+}
+
+/** Pure classifier — content-scope shape of the active lifecycle subject. */
+export function classifyLifecycleScope(
+  lifecycleRows: LifecycleRow[],
+  lifecycle: string,
+): LifecycleScope {
+  const activeRows = lifecycleRows.filter((row) => row['s'] === lifecycle);
+  const scopeVersions = new Set(
+    activeRows
+      .filter((row) => row['p'] === `${DKG}contentScopeVersion`)
+      .map((row) => stripOptionalLiteral(row['o']))
+      .filter((value): value is string => value !== undefined),
+  );
+  return {
+    activeRows,
+    scopeVersions,
+    isGraphScoped: scopeVersions.size === 1
+      && scopeVersions.has(String(GRAPH_KA_CONTENT_SCOPE_VERSION)),
+  };
+}
+
+/**
+ * Pure classifier — decide the migration phase from marker + lifecycle state.
+ * Ordering matters and is part of the durable contract: an already
+ * graph-scoped draft short-circuits to `not-needed` even under a stale or
+ * unsupported marker; only a non-graph-scoped draft with an unrecognized
+ * marker state refuses.
+ */
+export function planLegacyWmMigration(input: {
+  markerState: string | undefined;
+  isGraphScoped: boolean;
+  lifecycleRowCount: number;
+}): LegacyWmMigrationPlan {
+  if (input.isGraphScoped && input.markerState !== 'prepared') {
+    return { phase: 'not-needed', reason: 'already-graph-scoped' };
+  }
+  if (
+    input.markerState !== undefined
+    && input.markerState !== 'prepared'
+    && input.markerState !== 'completed'
+  ) {
+    throw migrationRefused(
+      `Legacy WM migration refused: unsupported marker state ${input.markerState}`,
+    );
+  }
+  if (input.markerState === undefined && input.lifecycleRowCount === 0) {
+    return { phase: 'not-needed', reason: 'no-legacy-draft' };
+  }
+  return input.markerState === 'prepared'
+    ? { phase: 'prepared-resume' }
+    : { phase: 'fresh-legacy-draft' };
+}
+
+/**
+ * Phase 4 (fresh drafts only) — eligibility gate, then durable preparation:
+ * copy every lifecycle/event row to the backup graph and stamp the
+ * `prepared` marker so a restart resumes instead of re-validating a
+ * half-migrated draft.
+ */
+async function prepareBackup(
+  host: LegacyWmMigrationHost,
+  request: LegacyWmMigrationRequest,
+  uris: MigrationUris,
+  lifecycleRows: LifecycleRow[],
+  scope: LifecycleScope,
+  canAllocateGraphIdentity: boolean,
+  counts: { publicQuads: number; privateQuads: number },
+): Promise<void> {
+  const stateValues = new Set(
+    scope.activeRows
+      .filter((row) => row['p'] === `${DKG}state`)
+      .map((row) => stripOptionalLiteral(row['o']))
+      .filter((value): value is string => value !== undefined),
+  );
+  const layerValues = new Set(
+    scope.activeRows
+      .filter((row) => row['p'] === `${DKG}memoryLayer`)
+      .map((row) => stripOptionalLiteral(row['o']))
+      .filter((value): value is string => value !== undefined),
+  );
+  const hasDurableOrInFlightState = scope.activeRows.some((row) =>
+    row['p'] === SWM_CURRENT_ASSERTION_PRED
+    || row['p'] === VM_CURRENT_ASSERTION_PRED
+    || row['p'] === SHARE_OPERATION_ID_PRED
+    || row['p'] === PROMOTE_OPERATION_INTENT_PRED,
+  );
+  const sealPredicates = [...new Set(Object.values(ASSERTION_SEAL_PREDICATES))]
+    .map((predicate) => `<${assertSafeIri(predicate)}>`)
+    .join(' ');
+  const sealResult = await host.store.query(
+    `ASK { GRAPH <${uris.metaGraph}> { <${uris.sourceGraph}> ?sealPredicate ?sealValue . VALUES ?sealPredicate { ${sealPredicates} } } }`,
+  );
+  const hasSeal = sealResult.type === 'boolean' && sealResult.value;
+  if (
+    scope.scopeVersions.size > 1
+    || stateValues.size !== 1
+    || !stateValues.has('created')
+    || layerValues.size !== 1
+    || !layerValues.has(MemoryLayer.WorkingMemory)
+    || hasDurableOrInFlightState
+    || hasSeal
+  ) {
+    throw migrationRefused(
+      `Legacy WM migration refused for ${request.contextGraphId}/${request.name}: only an active, local created/WM draft is eligible`,
+    );
+  }
+  if (!scope.isGraphScoped && !canAllocateGraphIdentity) {
+    throw identityAllocatorRequired(request.contextGraphId, request.name);
+  }
+
+  await host.store.createGraph(uris.backupGraph);
+  await host.store.insert([
+    ...lifecycleRows.map((row) => ({
+      subject: row['s']!,
+      predicate: row['p']!,
+      object: row['o']!,
+      graph: uris.backupGraph,
+    })),
+    {
+      subject: uris.markerSubject,
+      predicate: STATE_PRED,
+      object: '"prepared"',
+      graph: uris.backupGraph,
+    },
+    {
+      subject: uris.markerSubject,
+      predicate: COPIED_PUBLIC_PRED,
+      object: `"${counts.publicQuads}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+      graph: uris.backupGraph,
+    },
+    {
+      subject: uris.markerSubject,
+      predicate: PRESERVED_PRIVATE_PRED,
+      object: `"${counts.privateQuads}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+      graph: uris.backupGraph,
+    },
+  ]);
+}
+
+/**
+ * Phase 5 — replace the legacy active metadata with a graph-scoped draft and
+ * copy the public triples into the newly resolved WM graph. The legacy source
+ * graph itself is deliberately NOT deleted: it is the durable data backup.
+ */
+async function applyGraphScopedDraft(
+  host: LegacyWmMigrationHost,
+  request: LegacyWmMigrationRequest,
+  uris: MigrationUris,
+  lifecycleRows: LifecycleRow[],
+  isGraphScoped: boolean,
+  publicQuads: Quad[],
+): Promise<string> {
+  if (!isGraphScoped) {
+    for (const subject of new Set(lifecycleRows.map((row) => row['s']!))) {
+      await host.store.deleteByPattern({ graph: uris.metaGraph, subject });
+    }
+    await host.createGraphScopedDraft(
+      request.contextGraphId,
+      request.name,
+      request.agentAddress,
+      request.subGraphName,
+      { allocateKaNumber: request.allocateKaNumber },
+    );
+  }
+
+  const targetGraph = await host.wmGraphUri(
+    request.contextGraphId,
+    request.agentAddress,
+    request.name,
+    request.subGraphName,
+  );
+  if (targetGraph === uris.sourceGraph) {
+    throw Object.assign(
+      new Error(
+        `Legacy WM migration requires a graph-scoped identity for ${request.contextGraphId}/${request.name}`,
+      ),
+      { code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' },
+    );
+  }
+  if (publicQuads.length > 0) {
+    await host.writeGraphScopedDraft(
+      request.contextGraphId,
+      request.name,
+      request.agentAddress,
+      publicQuads,
+      request.subGraphName,
+    );
+  }
+  return targetGraph;
+}
+
+/** Phase 6 — flip the durable marker from `prepared` to `completed`. */
+async function completeMarker(
+  store: LegacyWmMigrationHost['store'],
+  uris: MigrationUris,
+  targetGraph: string,
+): Promise<void> {
+  await store.deleteByPattern({
+    graph: uris.backupGraph,
+    subject: uris.markerSubject,
+    predicate: STATE_PRED,
+  });
+  await store.insert([
+    {
+      subject: uris.markerSubject,
+      predicate: STATE_PRED,
+      object: '"completed"',
+      graph: uris.backupGraph,
+    },
+    {
+      subject: uris.markerSubject,
+      predicate: TARGET_PRED,
+      object: targetGraph,
+      graph: uris.backupGraph,
+    },
+    {
+      subject: uris.markerSubject,
+      predicate: APPLIED_AT_PRED,
+      object: `"${new Date().toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime>`,
+      graph: uris.backupGraph,
+    },
+  ]);
+}
+
+/**
+ * Run one legacy-WM migration to completion under the caller's lifecycle
+ * write lock. See the module doc comment for the phase model.
+ */
+export async function runLegacyWorkingMemoryMigration(
+  host: LegacyWmMigrationHost,
+  request: LegacyWmMigrationRequest,
+): Promise<LegacyWmMigrationResult> {
+  host.validateOptionalSubGraph(request.subGraphName);
+  await host.ensureSubGraphRegistered(request.contextGraphId, request.subGraphName);
+
+  const uris = migrationUris(request);
+  const marker = await loadMigrationMarker(host.store, uris);
+  const lifecycleRows = await loadLifecycleRows(host.store, uris, request.name);
+  const scope = classifyLifecycleScope(lifecycleRows, uris.lifecycle);
+  const plan = planLegacyWmMigration({
+    markerState: marker.state,
+    isGraphScoped: scope.isGraphScoped,
+    lifecycleRowCount: lifecycleRows.length,
+  });
+
+  if (plan.phase === 'not-needed') {
+    const migrated = plan.reason === 'already-graph-scoped';
+    return {
+      status: 'not-needed',
+      copiedPublic: migrated ? marker.copiedPublic : 0,
+      preservedPrivate: migrated ? marker.preservedPrivate : 0,
+      sourceGraph: uris.sourceGraph,
+      ...(migrated && marker.targetGraph ? { targetGraph: marker.targetGraph } : {}),
+      backupGraph: uris.backupGraph,
+    };
+  }
+
+  // Load and gate the content BEFORE any mutation: a draft whose legacy
+  // content cannot enter the graph-scoped assertion boundary must fail
+  // while its active metadata is still untouched.
+  const publicQuads = await host.loadAssertionScopedQuads(uris.sourceGraph);
+  const privateQuads = await host.loadPrivateDraftQuads(
+    request.contextGraphId,
+    request.agentAddress,
+    request.name,
+    request.subGraphName,
+  );
+  host.validateMigratableContent(publicQuads, privateQuads);
+
+  const canAllocateGraphIdentity = request.allocateKaNumber !== undefined
+    || host.canSelfAllocateGraphIdentity(request.agentAddress);
+
+  if (plan.phase === 'fresh-legacy-draft') {
+    await prepareBackup(host, request, uris, lifecycleRows, scope, canAllocateGraphIdentity, {
+      publicQuads: publicQuads.length,
+      privateQuads: privateQuads.length,
+    });
+  } else if (!scope.isGraphScoped && !canAllocateGraphIdentity) {
+    // A prepared resume still needs an identity lane before it may mutate.
+    throw identityAllocatorRequired(request.contextGraphId, request.name);
+  }
+
+  const targetGraph = await applyGraphScopedDraft(
+    host,
+    request,
+    uris,
+    lifecycleRows,
+    scope.isGraphScoped,
+    publicQuads,
+  );
+  await completeMarker(host.store, uris, targetGraph);
+
+  host.logInfo(
+    `Migrated legacy WM ${request.contextGraphId}/${request.name} from ${uris.sourceGraph} to ${targetGraph} `
+    + `(public=${publicQuads.length}, private-preserved=${privateQuads.length}, `
+    + `recovery=${plan.phase === 'prepared-resume' ? 'resumed' : 'fresh'})`,
+  );
+
+  return {
+    status: plan.phase === 'prepared-resume' ? 'resumed' : 'migrated',
+    copiedPublic: publicQuads.length,
+    preservedPrivate: privateQuads.length,
+    sourceGraph: uris.sourceGraph,
+    targetGraph,
+    backupGraph: uris.backupGraph,
+  };
+}

--- a/packages/publisher/src/legacy-wm-migration.ts
+++ b/packages/publisher/src/legacy-wm-migration.ts
@@ -44,8 +44,8 @@ import {
   SHARE_OPERATION_ID_PRED,
   SWM_CURRENT_ASSERTION_PRED,
   VM_CURRENT_ASSERTION_PRED,
-  stripOptionalLiteral,
 } from './metadata.js';
+import { stripOptionalLiteral } from './sparql-binding-literal.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const STATE_PRED = `${DKG}legacyWorkingMemoryMigrationState`;
@@ -145,7 +145,22 @@ interface MigrationMarker {
   preservedPrivate: number;
 }
 
-type LifecycleRow = Record<string, string | undefined>;
+/**
+ * A complete lifecycle/event metadata row. SPARQL binding optionality is
+ * resolved once, at the query boundary in `toLifecycleRow`, so every phase
+ * downstream operates on a strict model instead of re-asserting non-null.
+ */
+export interface LifecycleRow {
+  s: string;
+  p: string;
+  o: string;
+}
+
+/** Narrow one raw SPARQL binding to a complete row, or drop it. */
+export function toLifecycleRow(binding: Record<string, string | undefined>): LifecycleRow | null {
+  const { s, p, o } = binding;
+  return s && p && o != null ? { s, p, o } : null;
+}
 
 interface LifecycleScope {
   activeRows: LifecycleRow[];
@@ -227,7 +242,7 @@ async function loadLifecycleRows(
     } } LIMIT ${MAX_LIFECYCLE_ROWS + 1}`,
   );
   const rows = result.type === 'bindings'
-    ? result.bindings.filter((row) => row['s'] && row['p'] && row['o'] != null)
+    ? result.bindings.map(toLifecycleRow).filter((row): row is LifecycleRow => row !== null)
     : [];
   if (rows.length > MAX_LIFECYCLE_ROWS) {
     throw migrationRefused(
@@ -242,11 +257,11 @@ export function classifyLifecycleScope(
   lifecycleRows: LifecycleRow[],
   lifecycle: string,
 ): LifecycleScope {
-  const activeRows = lifecycleRows.filter((row) => row['s'] === lifecycle);
+  const activeRows = lifecycleRows.filter((row) => row.s === lifecycle);
   const scopeVersions = new Set(
     activeRows
-      .filter((row) => row['p'] === `${DKG}contentScopeVersion`)
-      .map((row) => stripOptionalLiteral(row['o']))
+      .filter((row) => row.p === `${DKG}contentScopeVersion`)
+      .map((row) => stripOptionalLiteral(row.o))
       .filter((value): value is string => value !== undefined),
   );
   return {
@@ -306,21 +321,21 @@ async function prepareBackup(
 ): Promise<void> {
   const stateValues = new Set(
     scope.activeRows
-      .filter((row) => row['p'] === `${DKG}state`)
-      .map((row) => stripOptionalLiteral(row['o']))
+      .filter((row) => row.p === `${DKG}state`)
+      .map((row) => stripOptionalLiteral(row.o))
       .filter((value): value is string => value !== undefined),
   );
   const layerValues = new Set(
     scope.activeRows
-      .filter((row) => row['p'] === `${DKG}memoryLayer`)
-      .map((row) => stripOptionalLiteral(row['o']))
+      .filter((row) => row.p === `${DKG}memoryLayer`)
+      .map((row) => stripOptionalLiteral(row.o))
       .filter((value): value is string => value !== undefined),
   );
   const hasDurableOrInFlightState = scope.activeRows.some((row) =>
-    row['p'] === SWM_CURRENT_ASSERTION_PRED
-    || row['p'] === VM_CURRENT_ASSERTION_PRED
-    || row['p'] === SHARE_OPERATION_ID_PRED
-    || row['p'] === PROMOTE_OPERATION_INTENT_PRED,
+    row.p === SWM_CURRENT_ASSERTION_PRED
+    || row.p === VM_CURRENT_ASSERTION_PRED
+    || row.p === SHARE_OPERATION_ID_PRED
+    || row.p === PROMOTE_OPERATION_INTENT_PRED,
   );
   const sealPredicates = [...new Set(Object.values(ASSERTION_SEAL_PREDICATES))]
     .map((predicate) => `<${assertSafeIri(predicate)}>`)
@@ -349,9 +364,9 @@ async function prepareBackup(
   await host.store.createGraph(uris.backupGraph);
   await host.store.insert([
     ...lifecycleRows.map((row) => ({
-      subject: row['s']!,
-      predicate: row['p']!,
-      object: row['o']!,
+      subject: row.s,
+      predicate: row.p,
+      object: row.o,
       graph: uris.backupGraph,
     })),
     {
@@ -389,7 +404,7 @@ async function applyGraphScopedDraft(
   publicQuads: Quad[],
 ): Promise<string> {
   if (!isGraphScoped) {
-    for (const subject of new Set(lifecycleRows.map((row) => row['s']!))) {
+    for (const subject of new Set(lifecycleRows.map((row) => row.s))) {
       await host.store.deleteByPattern({ graph: uris.metaGraph, subject });
     }
     await host.createGraphScopedDraft(

--- a/packages/publisher/src/legacy-wm-migration.ts
+++ b/packages/publisher/src/legacy-wm-migration.ts
@@ -10,14 +10,17 @@
  * through `LegacyWmMigrationHost`; this module owns phase ordering and
  * classification:
  *
- *   load marker → load lifecycle → classify (plan) → load + validate content
- *   → prepare backup → apply graph-scoped draft → complete marker
+ *   load marker → load lifecycle → summarize → classify → load + validate
+ *   content → prepare backup → apply graph-scoped draft → complete marker
  *
- * The classification is a typed `LegacyWmMigrationPlan` — `not-needed`,
- * `fresh-legacy-draft`, or `prepared-resume` — and refusals are coded errors
- * (`KA_LEGACY_WM_MIGRATION_REFUSED`, `KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY`),
- * so the restart states and allowed transitions are explicit rather than
- * implicit in one long mutable procedure.
+ * `classifyLegacyWmMigration` is the ONLY place a migration is decided: it
+ * takes the marker × lifecycle matrix and returns an exhaustive typed
+ * `LegacyWmMigrationPlan` — `not-needed` (already graph-scoped, or no legacy
+ * draft), `eligible-fresh`, or `prepared-resume` — or throws a coded refusal
+ * (`KA_LEGACY_WM_MIGRATION_REFUSED`, `KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY`).
+ * `eligible-fresh` genuinely means eligible; no later phase re-decides
+ * whether a draft may migrate, so the restart states and allowed transitions
+ * are explicit rather than implicit in one long mutable procedure.
  *
  * Safety properties:
  * - only an active `created`/`WM` lifecycle with no SWM/VM/promote state is
@@ -126,7 +129,7 @@ export interface LegacyWmMigrationHost {
  */
 export type LegacyWmMigrationPlan =
   | { phase: 'not-needed'; reason: 'already-graph-scoped' | 'no-legacy-draft' }
-  | { phase: 'fresh-legacy-draft' }
+  | { phase: 'eligible-fresh' }
   | { phase: 'prepared-resume' };
 
 interface MigrationUris {
@@ -162,10 +165,16 @@ export function toLifecycleRow(binding: Record<string, string | undefined>): Lif
   return s && p && o != null ? { s, p, o } : null;
 }
 
-interface LifecycleScope {
+/** The complete lifecycle picture the classifier decides from. */
+export interface LifecycleSummary {
+  rowCount: number;
   activeRows: LifecycleRow[];
   scopeVersions: Set<string>;
   isGraphScoped: boolean;
+  states: Set<string>;
+  layers: Set<string>;
+  /** Any SWM/VM pointer, share operation, or promote intent on the draft. */
+  hasDurableOrInFlightState: boolean;
 }
 
 function migrationRefused(message: string): Error {
@@ -252,115 +261,124 @@ async function loadLifecycleRows(
   return rows;
 }
 
-/** Pure classifier — content-scope shape of the active lifecycle subject. */
-export function classifyLifecycleScope(
+/**
+ * Pure classifier — everything the migration decision reads out of the
+ * lifecycle rows, computed once so no later phase re-derives it.
+ */
+export function summarizeLifecycle(
   lifecycleRows: LifecycleRow[],
   lifecycle: string,
-): LifecycleScope {
+): LifecycleSummary {
   const activeRows = lifecycleRows.filter((row) => row.s === lifecycle);
-  const scopeVersions = new Set(
+  const activeValues = (predicate: string): Set<string> => new Set(
     activeRows
-      .filter((row) => row.p === `${DKG}contentScopeVersion`)
+      .filter((row) => row.p === predicate)
       .map((row) => stripOptionalLiteral(row.o))
       .filter((value): value is string => value !== undefined),
   );
+  const scopeVersions = activeValues(`${DKG}contentScopeVersion`);
   return {
+    rowCount: lifecycleRows.length,
     activeRows,
     scopeVersions,
     isGraphScoped: scopeVersions.size === 1
       && scopeVersions.has(String(GRAPH_KA_CONTENT_SCOPE_VERSION)),
+    states: activeValues(`${DKG}state`),
+    layers: activeValues(`${DKG}memoryLayer`),
+    hasDurableOrInFlightState: activeRows.some((row) =>
+      row.p === SWM_CURRENT_ASSERTION_PRED
+      || row.p === VM_CURRENT_ASSERTION_PRED
+      || row.p === SHARE_OPERATION_ID_PRED
+      || row.p === PROMOTE_OPERATION_INTENT_PRED,
+    ),
   };
 }
 
 /**
- * Pure classifier — decide the migration phase from marker + lifecycle state.
- * Ordering matters and is part of the durable contract: an already
- * graph-scoped draft short-circuits to `not-needed` even under a stale or
- * unsupported marker; only a non-graph-scoped draft with an unrecognized
- * marker state refuses.
+ * The single classifier for the migration state machine: marker × lifecycle
+ * in, an exhaustive plan out, refusals thrown. `eligible-fresh` genuinely
+ * means eligible — nothing downstream re-decides whether a draft may migrate.
+ *
+ * Ordering is part of the durable contract:
+ * 1. an already graph-scoped draft is done, even under a stale marker;
+ * 2. an unrecognized marker state refuses rather than guessing;
+ * 3. a `prepared` marker resumes — preparation deliberately clears the legacy
+ *    rows, so zero rows there means "resume", not "nothing to do";
+ * 4. no active lifecycle at all means there is nothing to migrate, whether we
+ *    never saw a draft or a completed migration's assertion was since
+ *    discarded (that case must stay a no-op, or a later `createAssertion`
+ *    would be blocked forever by its own success marker);
+ * 5. otherwise the draft must pass the full local-draft eligibility gate.
+ *
+ * `loadSeal` is a thunk so the seal ASK is only issued for a draft that has
+ * actually reached the eligibility decision.
  */
-export function planLegacyWmMigration(input: {
-  markerState: string | undefined;
-  isGraphScoped: boolean;
-  lifecycleRowCount: number;
-}): LegacyWmMigrationPlan {
-  if (input.isGraphScoped && input.markerState !== 'prepared') {
+export async function classifyLegacyWmMigration(
+  input: {
+    markerState: string | undefined;
+    summary: LifecycleSummary;
+    contextGraphId: string;
+    name: string;
+  },
+  loadSeal: () => Promise<boolean>,
+): Promise<LegacyWmMigrationPlan> {
+  const { markerState, summary } = input;
+  if (summary.isGraphScoped && markerState !== 'prepared') {
     return { phase: 'not-needed', reason: 'already-graph-scoped' };
   }
-  if (
-    input.markerState !== undefined
-    && input.markerState !== 'prepared'
-    && input.markerState !== 'completed'
-  ) {
+  if (markerState !== undefined && markerState !== 'prepared' && markerState !== 'completed') {
     throw migrationRefused(
-      `Legacy WM migration refused: unsupported marker state ${input.markerState}`,
+      `Legacy WM migration refused: unsupported marker state ${markerState}`,
     );
   }
-  if (input.markerState === undefined && input.lifecycleRowCount === 0) {
+  if (markerState === 'prepared') {
+    return { phase: 'prepared-resume' };
+  }
+  if (summary.rowCount === 0) {
     return { phase: 'not-needed', reason: 'no-legacy-draft' };
   }
-  return input.markerState === 'prepared'
-    ? { phase: 'prepared-resume' }
-    : { phase: 'fresh-legacy-draft' };
+  if (
+    summary.scopeVersions.size > 1
+    || summary.states.size !== 1
+    || !summary.states.has('created')
+    || summary.layers.size !== 1
+    || !summary.layers.has(MemoryLayer.WorkingMemory)
+    || summary.hasDurableOrInFlightState
+    || await loadSeal()
+  ) {
+    throw migrationRefused(
+      `Legacy WM migration refused for ${input.contextGraphId}/${input.name}: only an active, local created/WM draft is eligible`,
+    );
+  }
+  return { phase: 'eligible-fresh' };
 }
 
-/**
- * Phase 4 (fresh drafts only) — eligibility gate, then durable preparation:
- * copy every lifecycle/event row to the backup graph and stamp the
- * `prepared` marker so a restart resumes instead of re-validating a
- * half-migrated draft.
- */
-async function prepareBackup(
+/** Is the legacy source graph carrying any assertion seal? */
+async function loadSealFlag(
   host: LegacyWmMigrationHost,
-  request: LegacyWmMigrationRequest,
   uris: MigrationUris,
-  lifecycleRows: LifecycleRow[],
-  scope: LifecycleScope,
-  canAllocateGraphIdentity: boolean,
-  counts: { publicQuads: number; privateQuads: number },
-): Promise<void> {
-  const stateValues = new Set(
-    scope.activeRows
-      .filter((row) => row.p === `${DKG}state`)
-      .map((row) => stripOptionalLiteral(row.o))
-      .filter((value): value is string => value !== undefined),
-  );
-  const layerValues = new Set(
-    scope.activeRows
-      .filter((row) => row.p === `${DKG}memoryLayer`)
-      .map((row) => stripOptionalLiteral(row.o))
-      .filter((value): value is string => value !== undefined),
-  );
-  const hasDurableOrInFlightState = scope.activeRows.some((row) =>
-    row.p === SWM_CURRENT_ASSERTION_PRED
-    || row.p === VM_CURRENT_ASSERTION_PRED
-    || row.p === SHARE_OPERATION_ID_PRED
-    || row.p === PROMOTE_OPERATION_INTENT_PRED,
-  );
+): Promise<boolean> {
   const sealPredicates = [...new Set(Object.values(ASSERTION_SEAL_PREDICATES))]
     .map((predicate) => `<${assertSafeIri(predicate)}>`)
     .join(' ');
   const sealResult = await host.store.query(
     `ASK { GRAPH <${uris.metaGraph}> { <${uris.sourceGraph}> ?sealPredicate ?sealValue . VALUES ?sealPredicate { ${sealPredicates} } } }`,
   );
-  const hasSeal = sealResult.type === 'boolean' && sealResult.value;
-  if (
-    scope.scopeVersions.size > 1
-    || stateValues.size !== 1
-    || !stateValues.has('created')
-    || layerValues.size !== 1
-    || !layerValues.has(MemoryLayer.WorkingMemory)
-    || hasDurableOrInFlightState
-    || hasSeal
-  ) {
-    throw migrationRefused(
-      `Legacy WM migration refused for ${request.contextGraphId}/${request.name}: only an active, local created/WM draft is eligible`,
-    );
-  }
-  if (!scope.isGraphScoped && !canAllocateGraphIdentity) {
-    throw identityAllocatorRequired(request.contextGraphId, request.name);
-  }
+  return sealResult.type === 'boolean' && sealResult.value;
+}
 
+/**
+ * Phase 4 (eligible fresh drafts only) — the durable write, and nothing else:
+ * copy every lifecycle/event row to the backup graph and stamp the `prepared`
+ * marker so a restart resumes instead of re-validating a half-migrated draft.
+ * Eligibility was already decided by `classifyLegacyWmMigration`.
+ */
+async function prepareBackup(
+  host: LegacyWmMigrationHost,
+  uris: MigrationUris,
+  lifecycleRows: LifecycleRow[],
+  counts: { publicQuads: number; privateQuads: number },
+): Promise<void> {
   await host.store.createGraph(uris.backupGraph);
   await host.store.insert([
     ...lifecycleRows.map((row) => ({
@@ -489,12 +507,16 @@ export async function runLegacyWorkingMemoryMigration(
   const uris = migrationUris(request);
   const marker = await loadMigrationMarker(host.store, uris);
   const lifecycleRows = await loadLifecycleRows(host.store, uris, request.name);
-  const scope = classifyLifecycleScope(lifecycleRows, uris.lifecycle);
-  const plan = planLegacyWmMigration({
-    markerState: marker.state,
-    isGraphScoped: scope.isGraphScoped,
-    lifecycleRowCount: lifecycleRows.length,
-  });
+  const summary = summarizeLifecycle(lifecycleRows, uris.lifecycle);
+  const plan = await classifyLegacyWmMigration(
+    {
+      markerState: marker.state,
+      summary,
+      contextGraphId: request.contextGraphId,
+      name: request.name,
+    },
+    () => loadSealFlag(host, uris),
+  );
 
   if (plan.phase === 'not-needed') {
     const migrated = plan.reason === 'already-graph-scoped';
@@ -520,17 +542,19 @@ export async function runLegacyWorkingMemoryMigration(
   );
   host.validateMigratableContent(publicQuads, privateQuads);
 
+  // Both remaining phases mutate, so both need a graph-scoped identity lane
+  // before anything is written.
   const canAllocateGraphIdentity = request.allocateKaNumber !== undefined
     || host.canSelfAllocateGraphIdentity(request.agentAddress);
+  if (!summary.isGraphScoped && !canAllocateGraphIdentity) {
+    throw identityAllocatorRequired(request.contextGraphId, request.name);
+  }
 
-  if (plan.phase === 'fresh-legacy-draft') {
-    await prepareBackup(host, request, uris, lifecycleRows, scope, canAllocateGraphIdentity, {
+  if (plan.phase === 'eligible-fresh') {
+    await prepareBackup(host, uris, lifecycleRows, {
       publicQuads: publicQuads.length,
       privateQuads: privateQuads.length,
     });
-  } else if (!scope.isGraphScoped && !canAllocateGraphIdentity) {
-    // A prepared resume still needs an identity lane before it may mutate.
-    throw identityAllocatorRequired(request.contextGraphId, request.name);
   }
 
   const targetGraph = await applyGraphScopedDraft(
@@ -538,7 +562,7 @@ export async function runLegacyWorkingMemoryMigration(
     request,
     uris,
     lifecycleRows,
-    scope.isGraphScoped,
+    summary.isGraphScoped,
     publicQuads,
   );
   await completeMarker(host.store, uris, targetGraph);

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -1900,6 +1900,30 @@ export const VM_CURRENT_ASSERTION_PRED = `${DKG}vmCurrentAssertion`;
 export const KA_ID_PRED = `${DKG}kaId`;
 export const RESERVED_UAL_PRED = `${DKG}reservedUal`;
 export const PROV_WAS_REVISION_OF = `${PROV}wasRevisionOf`;
+// In-flight lane markers stamped on the lifecycle URN while a share /
+// promote operation is outstanding. Their presence means the draft is NOT
+// purely local — the legacy-WM migration eligibility gate keys off them.
+export const SHARE_OPERATION_ID_PRED = `${DKG}shareOperationId`;
+export const PROMOTE_OPERATION_INTENT_PRED = `${DKG}promoteOperationIntent`;
+
+/**
+ * Strip the quoting from an optional SPARQL binding literal. Bindings come
+ * back either bare (IRIs) or as a `"…"`-quoted, JSON-escaped literal —
+ * possibly with a datatype/lang suffix the JSON parse rejects, in which case
+ * the raw inner body between the outer quotes is returned.
+ */
+export function stripOptionalLiteral(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.startsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      const lastQuote = value.lastIndexOf('"');
+      return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
+    }
+  }
+  return value;
+}
 
 /** OT-RFC-43 §10.5.4 per-layer / overall KA status enum (string-stable). */
 export type KaStatus = 'draft-open' | 'wm-sealed' | 'swm-shared' | 'vm-confirmed';

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -1906,25 +1906,6 @@ export const PROV_WAS_REVISION_OF = `${PROV}wasRevisionOf`;
 export const SHARE_OPERATION_ID_PRED = `${DKG}shareOperationId`;
 export const PROMOTE_OPERATION_INTENT_PRED = `${DKG}promoteOperationIntent`;
 
-/**
- * Strip the quoting from an optional SPARQL binding literal. Bindings come
- * back either bare (IRIs) or as a `"…"`-quoted, JSON-escaped literal —
- * possibly with a datatype/lang suffix the JSON parse rejects, in which case
- * the raw inner body between the outer quotes is returned.
- */
-export function stripOptionalLiteral(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  if (value.startsWith('"')) {
-    try {
-      return JSON.parse(value);
-    } catch {
-      const lastQuote = value.lastIndexOf('"');
-      return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
-    }
-  }
-  return value;
-}
-
 /** OT-RFC-43 §10.5.4 per-layer / overall KA status enum (string-stable). */
 export type KaStatus = 'draft-open' | 'wm-sealed' | 'swm-shared' | 'vm-confirmed';
 

--- a/packages/publisher/src/sparql-binding-literal.ts
+++ b/packages/publisher/src/sparql-binding-literal.ts
@@ -1,0 +1,35 @@
+/**
+ * Publisher-internal helper for reading SPARQL *binding* values.
+ *
+ * This is deliberately NOT a general RDF literal parser and is deliberately
+ * NOT part of any package's public API: `@origintrail-official/dkg-rdf-utils`
+ * owns that job (`parseRdfLiteralTerm` / `decodeRdfLiteralBody`), and it is
+ * the implementation to reach for when parsing user-facing or on-the-wire RDF.
+ *
+ * What this handles instead is the narrow shape the publisher's own lifecycle
+ * bookkeeping reads back out of the store: a binding that is either a bare IRI
+ * or a literal the publisher itself wrote (`"created"`, `"WM"`,
+ * `"2"^^<xsd:integer>`). It stays here, unexported from the package barrel, so
+ * the codebase does not grow a second literal decoder presented as shared API.
+ */
+
+/**
+ * Strip the quoting from an optional SPARQL binding value.
+ *
+ * Bare values (IRIs) pass through unchanged. Quoted values are JSON-decoded;
+ * when a datatype/language suffix makes that invalid JSON, the raw body
+ * between the outer quotes is returned. Lenient by design — a lifecycle read
+ * must not throw on an unexpected binding shape.
+ */
+export function stripOptionalLiteral(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.startsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      const lastQuote = value.lastIndexOf('"');
+      return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
+    }
+  }
+  return value;
+}

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -522,6 +522,146 @@ describe('Working Memory Assertion Lifecycle', () => {
     ]);
   });
 
+  it('a completed marker whose assertion was later discarded is a no-op, not a refusal', async () => {
+    // Regression: a successful migration leaves a `completed` marker behind
+    // forever. If the assertion is later discarded, the next chat-memory
+    // initialization runs migration BEFORE create — misclassifying that as a
+    // fresh legacy draft made it refuse, permanently blocking createAssertion.
+    const name = 'legacy-completed-then-discarded';
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const sourceGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+    const backupGraph = `${metaGraph}/legacy-wm-backup/${encodeURIComponent(AGENT.toLowerCase())}/${encodeURIComponent(name)}`;
+    await store.createGraph(backupGraph);
+    await store.insert([
+      {
+        subject: sourceGraph,
+        predicate: 'http://dkg.io/ontology/legacyWorkingMemoryMigrationState',
+        object: '"completed"',
+        graph: backupGraph,
+      },
+      {
+        subject: sourceGraph,
+        predicate: 'http://dkg.io/ontology/legacyWorkingMemoryMigrationCopiedPublic',
+        object: '"5"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: backupGraph,
+      },
+    ]);
+
+    const result = await publisher.migrateLegacyRootScopedWorkingMemory(CG_ID, name, AGENT);
+
+    expect(result.status).toBe('not-needed');
+    // The stale marker describes an assertion that no longer exists, so its
+    // recorded counts must not be echoed back as if data were preserved.
+    expect(result.copiedPublic).toBe(0);
+    expect(result.targetGraph).toBeUndefined();
+
+    // ...and the daemon's create-after-migrate path still works afterwards.
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+    await publisher.assertionWrite(CG_ID, name, AGENT, [
+      { subject: 'urn:test:fresh', predicate: 'http://schema.org/text', object: '"new"' },
+    ]);
+    expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:test:fresh' }),
+    ]);
+  });
+
+  // The eligibility gate refuses a created/WM draft that is not purely local.
+  // Each guard gets its own case so removing any one of them fails a test —
+  // the SWM case above cannot exercise these, since it differs in state/layer.
+  for (const [label, extraLifecycleQuad] of [
+    ['an in-flight share operation', {
+      predicate: 'http://dkg.io/ontology/shareOperationId',
+      object: '"op-in-flight"',
+    }],
+    ['a durable promote intent', {
+      predicate: 'http://dkg.io/ontology/promoteOperationIntent',
+      object: '"{\\"version\\":1}"',
+    }],
+    ['an SWM layer pointer', {
+      predicate: 'http://dkg.io/ontology/swmCurrentAssertion',
+      object: 'urn:test:swm:snapshot',
+    }],
+    ['a VM layer pointer', {
+      predicate: 'http://dkg.io/ontology/vmCurrentAssertion',
+      object: 'urn:test:vm:snapshot',
+    }],
+  ] as const) {
+    it(`refuses an otherwise-eligible created/WM draft carrying ${label}`, async () => {
+      const name = `legacy-guard-${label.replace(/[^a-z]+/gi, '-')}`;
+      const lifecycle = assertionLifecycleUri(CG_ID, AGENT, name);
+      const metaGraph = contextGraphMetaUri(CG_ID);
+      const sourceGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+      await store.insert([
+        {
+          subject: 'urn:test:guarded',
+          predicate: 'http://schema.org/text',
+          object: '"must remain"',
+          graph: sourceGraph,
+        },
+        { subject: lifecycle, predicate: 'http://dkg.io/ontology/state', object: '"created"', graph: metaGraph },
+        { subject: lifecycle, predicate: 'http://dkg.io/ontology/memoryLayer', object: '"WM"', graph: metaGraph },
+        { subject: lifecycle, predicate: extraLifecycleQuad.predicate, object: extraLifecycleQuad.object, graph: metaGraph },
+      ]);
+
+      await expect(
+        publisher.migrateLegacyRootScopedWorkingMemory(CG_ID, name, AGENT, undefined, {
+          allocateKaNumber: async () => ({
+            number: 99n,
+            reservedUal: `did:dkg:31337/${AGENT.toLowerCase()}/99`,
+          }),
+        }),
+      ).rejects.toMatchObject({ code: 'KA_LEGACY_WM_MIGRATION_REFUSED' });
+
+      // Refused before any mutation: metadata and source data both intact.
+      const stateIntact = await store.query(
+        `ASK { GRAPH <${metaGraph}> { <${lifecycle}> <http://dkg.io/ontology/state> "created" } }`,
+      );
+      expect(stateIntact.type === 'boolean' && stateIntact.value).toBe(true);
+      const dataIntact = await store.query(
+        `ASK { GRAPH <${sourceGraph}> { <urn:test:guarded> <http://schema.org/text> "must remain" } }`,
+      );
+      expect(dataIntact.type === 'boolean' && dataIntact.value).toBe(true);
+    });
+  }
+
+  it('refuses an otherwise-eligible created/WM draft whose source graph is sealed', async () => {
+    const name = 'legacy-guard-sealed';
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, name);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const sourceGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+    await store.insert([
+      {
+        subject: 'urn:test:sealed',
+        predicate: 'http://schema.org/text',
+        object: '"must remain"',
+        graph: sourceGraph,
+      },
+      { subject: lifecycle, predicate: 'http://dkg.io/ontology/state', object: '"created"', graph: metaGraph },
+      { subject: lifecycle, predicate: 'http://dkg.io/ontology/memoryLayer', object: '"WM"', graph: metaGraph },
+      // The seal hangs off the SOURCE GRAPH subject, not the lifecycle URN.
+      {
+        subject: sourceGraph,
+        predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT,
+        object: '"deadbeef"^^<http://www.w3.org/2001/XMLSchema#hexBinary>',
+        graph: metaGraph,
+      },
+    ]);
+
+    await expect(
+      publisher.migrateLegacyRootScopedWorkingMemory(CG_ID, name, AGENT, undefined, {
+        allocateKaNumber: async () => ({
+          number: 98n,
+          reservedUal: `did:dkg:31337/${AGENT.toLowerCase()}/98`,
+        }),
+      }),
+    ).rejects.toMatchObject({ code: 'KA_LEGACY_WM_MIGRATION_REFUSED' });
+
+    const dataIntact = await store.query(
+      `ASK { GRAPH <${sourceGraph}> { <urn:test:sealed> <http://schema.org/text> "must remain" } }`,
+    );
+    expect(dataIntact.type === 'boolean' && dataIntact.value).toBe(true);
+  });
+
   it('write inserts triples into the assertion graph', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -277,6 +277,251 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(q.length).toBeGreaterThan(0);
   });
 
+  it('migrates a legacy local WM draft without deleting its public or private backup', async () => {
+    const name = 'legacy-chat-turns';
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, name);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const sourceGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+    const targetGraph = contextGraphLayerUri(
+      CG_ID,
+      MemoryLayer.WorkingMemory,
+      AGENT,
+      42n,
+    );
+    const publicQuads = [
+      { subject: 'urn:test:chat:turn:1', predicate: 'http://schema.org/text', object: '"hello"' },
+      { subject: 'urn:test:chat:turn:2', predicate: 'http://schema.org/text', object: '"reply"' },
+    ];
+    const privateQuads = [
+      { subject: 'urn:test:chat:private:1', predicate: 'http://schema.org/text', object: '"secret"', graph: '' },
+    ];
+
+    // Build a valid draft first so its private partition uses the production
+    // private-store key, then replace only the lifecycle metadata with the
+    // legacy shape observed in #2149 (kaId=0, reservedUal ending in /1).
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+    await publisher.assertionWrite(CG_ID, name, AGENT, publicQuads);
+    await publisher.assertionWritePrivate(CG_ID, name, AGENT, privateQuads);
+    const lifecycleSubjects = await store.query(
+      `SELECT DISTINCT ?s WHERE { GRAPH <${metaGraph}> { ?s ?p ?o . `
+      + `FILTER(STR(?s) = "${lifecycle}" || STRSTARTS(STR(?s), "${lifecycle}/")) } }`,
+    );
+    if (lifecycleSubjects.type === 'bindings') {
+      for (const row of lifecycleSubjects.bindings) {
+        if (row['s']) await store.deleteByPattern({ graph: metaGraph, subject: row['s'] });
+      }
+    }
+    const oldEvent = `${lifecycle}/event/legacy`;
+    await store.insert([
+      { subject: lifecycle, predicate: 'http://dkg.io/ontology/state', object: '"created"', graph: metaGraph },
+      { subject: lifecycle, predicate: 'http://dkg.io/ontology/memoryLayer', object: '"WM"', graph: metaGraph },
+      {
+        subject: lifecycle,
+        predicate: 'http://dkg.io/ontology/contentScopeVersion',
+        object: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: metaGraph,
+      },
+      {
+        subject: lifecycle,
+        predicate: 'http://dkg.io/ontology/kaId',
+        object: '"0"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: metaGraph,
+      },
+      {
+        subject: lifecycle,
+        predicate: 'http://dkg.io/ontology/reservedUal',
+        object: `"did:dkg:31337/${AGENT.toLowerCase()}/1"`,
+        graph: metaGraph,
+      },
+      {
+        subject: oldEvent,
+        predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+        object: 'http://dkg.io/ontology/AssertionCreated',
+        graph: metaGraph,
+      },
+    ]);
+
+    const result = await publisher.migrateLegacyRootScopedWorkingMemory(
+      CG_ID,
+      name,
+      AGENT,
+      undefined,
+      {
+        allocateKaNumber: async () => ({
+          number: 42n,
+          reservedUal: `did:dkg:31337/${AGENT.toLowerCase()}/42`,
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: 'migrated',
+      copiedPublic: 2,
+      preservedPrivate: 1,
+      sourceGraph,
+      targetGraph,
+    });
+    expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toEqual(
+      expect.arrayContaining(publicQuads.map((quad) => expect.objectContaining(quad))),
+    );
+    expect(await publisher.assertionQueryPrivate(CG_ID, name, AGENT)).toEqual(privateQuads);
+
+    // The old name-keyed graph is deliberately retained as a data backup.
+    const sourceRows = await store.query(
+      `SELECT ?s WHERE { GRAPH <${sourceGraph}> { ?s ?p ?o } }`,
+    );
+    expect(sourceRows.type).toBe('bindings');
+    if (sourceRows.type === 'bindings') expect(sourceRows.bindings).toHaveLength(2);
+    const backupRows = await store.query(
+      `ASK { GRAPH <${result.backupGraph}> { <${oldEvent}> ?p ?o } }`,
+    );
+    expect(backupRows.type === 'boolean' && backupRows.value).toBe(true);
+
+    const identityRows = await store.query(
+      `SELECT ?scope ?id ?ual WHERE { GRAPH <${metaGraph}> { <${lifecycle}> `
+      + `<http://dkg.io/ontology/contentScopeVersion> ?scope ; `
+      + `<http://dkg.io/ontology/kaId> ?id ; `
+      + `<http://dkg.io/ontology/reservedUal> ?ual } }`,
+    );
+    expect(identityRows.type).toBe('bindings');
+    if (identityRows.type === 'bindings') {
+      expect(identityRows.bindings).toEqual([expect.objectContaining({
+        scope: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        id: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        ual: `"did:dkg:31337/${AGENT.toLowerCase()}/42"`,
+      })]);
+    }
+
+    // The normal graph-scoped write path works after migration, and a second
+    // migration call is a no-op rather than duplicating or replacing content.
+    await publisher.assertionWrite(CG_ID, name, AGENT, [{
+      subject: 'urn:test:chat:turn:3',
+      predicate: 'http://schema.org/text',
+      object: '"again"',
+    }]);
+    const second = await publisher.migrateLegacyRootScopedWorkingMemory(
+      CG_ID,
+      name,
+      AGENT,
+    );
+    expect(second.status).toBe('not-needed');
+    expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toHaveLength(3);
+  });
+
+  it('resumes a prepared legacy WM migration after active metadata was removed', async () => {
+    const name = 'legacy-chat-resume';
+    const sourceGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const backupGraph = `${metaGraph}/legacy-wm-backup/${encodeURIComponent(AGENT.toLowerCase())}/${encodeURIComponent(name)}`;
+    await store.createGraph(sourceGraph);
+    await store.createGraph(backupGraph);
+    await store.insert([
+      {
+        subject: 'urn:test:chat:resume',
+        predicate: 'http://schema.org/text',
+        object: '"recover me"',
+        graph: sourceGraph,
+      },
+      {
+        subject: sourceGraph,
+        predicate: 'http://dkg.io/ontology/legacyWorkingMemoryMigrationState',
+        object: '"prepared"',
+        graph: backupGraph,
+      },
+    ]);
+
+    const result = await publisher.migrateLegacyRootScopedWorkingMemory(
+      CG_ID,
+      name,
+      AGENT,
+      undefined,
+      {
+        allocateKaNumber: async () => ({
+          number: 43n,
+          reservedUal: `did:dkg:31337/${AGENT.toLowerCase()}/43`,
+        }),
+      },
+    );
+
+    expect(result.status).toBe('resumed');
+    expect(result.copiedPublic).toBe(1);
+    expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:test:chat:resume', object: '"recover me"' }),
+    ]);
+    const completed = await store.query(
+      `ASK { GRAPH <${backupGraph}> { <${sourceGraph}> `
+      + '<http://dkg.io/ontology/legacyWorkingMemoryMigrationState> "completed" } }',
+    );
+    expect(completed.type === 'boolean' && completed.value).toBe(true);
+  });
+
+  it('refuses to migrate a legacy SWM lifecycle and leaves it untouched', async () => {
+    const name = 'legacy-shared';
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, name);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const sourceGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+    await store.createGraph(sourceGraph);
+    await store.insert([
+      {
+        subject: 'urn:test:shared',
+        predicate: 'http://schema.org/text',
+        object: '"must remain"',
+        graph: sourceGraph,
+      },
+      { subject: lifecycle, predicate: 'http://dkg.io/ontology/state', object: '"shared"', graph: metaGraph },
+      { subject: lifecycle, predicate: 'http://dkg.io/ontology/memoryLayer', object: '"SWM"', graph: metaGraph },
+      {
+        subject: lifecycle,
+        predicate: 'http://dkg.io/ontology/swmCurrentAssertion',
+        object: 'urn:test:swm:snapshot',
+        graph: metaGraph,
+      },
+    ]);
+
+    await expect(
+      publisher.migrateLegacyRootScopedWorkingMemory(CG_ID, name, AGENT),
+    ).rejects.toMatchObject({ code: 'KA_LEGACY_WM_MIGRATION_REFUSED' });
+    const stillThere = await store.query(
+      `ASK { GRAPH <${sourceGraph}> { <urn:test:shared> <http://schema.org/text> "must remain" } }`,
+    );
+    expect(stillThere.type === 'boolean' && stillThere.value).toBe(true);
+    const state = await store.query(
+      `SELECT ?state WHERE { GRAPH <${metaGraph}> { <${lifecycle}> <http://dkg.io/ontology/state> ?state } }`,
+    );
+    expect(state.type).toBe('bindings');
+    if (state.type === 'bindings') expect(state.bindings[0]?.['state']).toBe('"shared"');
+  });
+
+  it('requires a numbered identity before changing eligible legacy WM metadata', async () => {
+    const name = 'legacy-without-allocator';
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, name);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const sourceGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+    await store.insert([
+      {
+        subject: 'urn:test:allocator-required',
+        predicate: 'http://schema.org/text',
+        object: '"must remain"',
+        graph: sourceGraph,
+      },
+      { subject: lifecycle, predicate: 'http://dkg.io/ontology/state', object: '"created"', graph: metaGraph },
+      { subject: lifecycle, predicate: 'http://dkg.io/ontology/memoryLayer', object: '"WM"', graph: metaGraph },
+    ]);
+
+    await expect(
+      publisher.migrateLegacyRootScopedWorkingMemory(CG_ID, name, AGENT),
+    ).rejects.toMatchObject({ code: 'KA_LEGACY_WM_MIGRATION_REQUIRES_IDENTITY' });
+
+    const unchanged = await store.query(
+      `ASK { GRAPH <${metaGraph}> { <${lifecycle}> `
+      + '<http://dkg.io/ontology/state> "created" } }',
+    );
+    expect(unchanged.type === 'boolean' && unchanged.value).toBe(true);
+    expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:test:allocator-required', object: '"must remain"' }),
+    ]);
+  });
+
   it('write inserts triples into the assertion graph', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);


### PR DESCRIPTION
## User impact

Upgraded nodes with a legacy root-scoped `agent-context/chat-turns` assertion can persist and reload Prime Agent chat again without deleting their existing local memory. Hermes and OpenClaw continue through the same durable chat-memory path.

On first chat-memory initialization, the daemon now detects this one legacy local WM draft, preserves its old public graph and private draft, backs up all lifecycle/event metadata, allocates a graph-scoped KA identity, copies the public triples, and resumes normal writes. General legacy Knowledge Assets remain read-only.

Fixes #2149.

## Before

```mermaid
sequenceDiagram
    participant Client as Prime / Hermes / OpenClaw
    participant Memory as ChatMemoryManager
    participant Agent as DKG Agent
    participant Store as Local store

    Client->>Memory: Persist chat turn
    Memory->>Agent: create/write agent-context/chat-turns
    Agent->>Store: Mutate legacy root-scoped KA
    Store-->>Agent: LegacyKnowledgeAssetReadOnlyError
    Agent-->>Client: Persistence and history reload fail
```

## After

```mermaid
sequenceDiagram
    participant Client as Prime / Hermes / OpenClaw
    participant Memory as ChatMemoryManager
    participant Agent as DKG Agent
    participant Store as Local store

    Client->>Memory: First persistence or history initialization
    Memory->>Agent: Migrate exact agent-context/chat-turns WM
    Agent->>Store: Validate created + WM + local-only state
    Agent->>Store: Back up lifecycle/events + write prepared marker
    Agent->>Store: Allocate numbered identity and create graph-scoped WM
    Agent->>Store: Copy public triples and retain legacy backup data
    Agent->>Store: Write completed marker
    Memory->>Agent: Create/write with the same resolved agent address
    Agent-->>Client: Turn persists and reloads normally
```

## Safety boundaries

- Migrates only an active `created` / `WM` draft with no SWM/VM pointer, promotion/share intent, or seal.
- Refuses migration before mutation if a numbered graph identity cannot be allocated.
- Retains the legacy public graph and stable private-draft key; copies lifecycle and event rows to a deterministic backup graph.
- Uses a durable `prepared` marker so a restart after preparation resumes idempotently.
- Threads the daemon-resolved memory agent address through migrate, create, and every write.
- Does not relax the normal legacy-KA read-only guard.

## Validation

- `pnpm run build:runtime:packages`
- Publisher lifecycle: 89 passed
- Prime persistence route: 18 passed
- Chat-memory focused: 46 passed
- Full Node UI: 158 files / 2,219 passed / 38 skipped
- `git diff --check`

Base: `testnet-canary` at `885ddeb2e` (includes #2147).
