### PR TITLE
fix(storage): consult managed ownership before serving warm read caches

### DIFF
--- a/.github/workflows/system-record-managed-ownership.yml
+++ b/.github/workflows/system-record-managed-ownership.yml
@@ -158,7 +158,8 @@ jobs:
             test/system-record-verified-replacement-v1.test.ts \
             test/managed-backend-ownership-dispatch-v1.test.ts \
             test/managed-terminal-read-through-index-v1.test.ts \
-            test/managed-warm-read-composition-v1.test.ts \n            test/managed-read-gate-decorator-coverage-v1.test.ts \
+            test/managed-warm-read-composition-v1.test.ts \
+            test/managed-read-gate-decorator-coverage-v1.test.ts \
             test/system-record-controller-disposal-v1.test.ts \
             test/system-record-capability-probe-errors-v1.test.ts \
             test/graph-set-index-store.test.ts \
@@ -177,7 +178,8 @@ jobs:
       - name: Agent facade conformance
         run: |
           pnpm --filter @origintrail-official/dkg-agent exec vitest run \
-            test/system-record-agent-facade-outcomes-v1.test.ts \n            test/managed-read-gate-through-agent-wrapper-v1.test.ts
+            test/system-record-agent-facade-outcomes-v1.test.ts \
+            test/managed-read-gate-through-agent-wrapper-v1.test.ts
 
       - name: CLI supervisor conformance
         run: |

--- a/.github/workflows/system-record-managed-ownership.yml
+++ b/.github/workflows/system-record-managed-ownership.yml
@@ -163,6 +163,8 @@ jobs:
             test/system-record-controller-disposal-v1.test.ts \
             test/system-record-capability-probe-errors-v1.test.ts \
             test/graph-set-index-store.test.ts \
+            test/changelog-store.test.ts \
+            test/graph-write-gen.test.ts \
             test/system-record-decorator-apply-outcomes-v1.test.ts \
             test/store-priority-scheduler.test.ts \
             test/store-scheduler-system-record-admission.test.ts \

--- a/.github/workflows/system-record-managed-ownership.yml
+++ b/.github/workflows/system-record-managed-ownership.yml
@@ -158,6 +158,7 @@ jobs:
             test/system-record-verified-replacement-v1.test.ts \
             test/managed-backend-ownership-dispatch-v1.test.ts \
             test/managed-terminal-read-through-index-v1.test.ts \
+            test/managed-warm-read-composition-v1.test.ts \n            test/managed-read-gate-decorator-coverage-v1.test.ts \
             test/system-record-controller-disposal-v1.test.ts \
             test/system-record-capability-probe-errors-v1.test.ts \
             test/graph-set-index-store.test.ts \
@@ -176,7 +177,7 @@ jobs:
       - name: Agent facade conformance
         run: |
           pnpm --filter @origintrail-official/dkg-agent exec vitest run \
-            test/system-record-agent-facade-outcomes-v1.test.ts
+            test/system-record-agent-facade-outcomes-v1.test.ts \n            test/managed-read-gate-through-agent-wrapper-v1.test.ts
 
       - name: CLI supervisor conformance
         run: |

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -110,7 +110,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions, type SystemRecordApplyOutcomeV1, type SystemRecordLaneActivationV1, type SystemRecordLaneControllerV1 } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, STORE_CHAIN_INNER, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions, type SystemRecordApplyOutcomeV1, type SystemRecordLaneActivationV1, type SystemRecordLaneControllerV1 } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -447,8 +447,16 @@ export function createListContextGraphsCacheInvalidatingStore(
   };
   let systemRecordLaneMemo: SystemRecordLaneControllerV1 | null | undefined;
   let systemRecordLaneInner: SystemRecordLaneControllerV1 | null | undefined;
-  const wrapper: TripleStore & { readonly innerStore: TripleStore } = {
+  const wrapper: TripleStore & {
+    readonly innerStore: TripleStore;
+    readonly [STORE_CHAIN_INNER]: TripleStore;
+  } = {
     innerStore,
+    // The canonical decorator-chain contract. This forwarder declares neither
+    // the changelog API nor the managed read gate, so EVERY capability a caller
+    // resolves through it depends on traversal working here — the sync-changelog
+    // responder lane and the write-generation source among them.
+    [STORE_CHAIN_INNER]: innerStore,
     get queryCancellation() {
       return innerStore.queryCancellation;
     },

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -110,7 +110,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, isExternalBackend, linkStoreChainV1, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions, type SystemRecordApplyOutcomeV1, type SystemRecordLaneActivationV1, type SystemRecordLaneControllerV1 } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions, type SystemRecordApplyOutcomeV1, type SystemRecordLaneActivationV1, type SystemRecordLaneControllerV1 } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -637,11 +637,10 @@ export function createListContextGraphsCacheInvalidatingStore(
       return innerStore.close();
     },
   };
-  // Register for capability discovery. This forwarder declares neither the
-  // changelog API nor the managed read gate, so EVERY capability resolved
-  // through it depends on traversal working here — the sync-changelog
-  // responder lane and the write-generation source among them.
-  linkStoreChainV1(wrapper, innerStore);
+  // Traversable via the public `innerStore` above — no registration needed.
+  // EVERY capability a caller resolves through this forwarder depends on that,
+  // since it declares neither the changelog API nor the cached-read gate:
+  // the sync-changelog responder lane and the write-generation source both.
   return wrapper;
 }
 

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -110,7 +110,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, STORE_CHAIN_INNER, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions, type SystemRecordApplyOutcomeV1, type SystemRecordLaneActivationV1, type SystemRecordLaneControllerV1 } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, isExternalBackend, linkStoreChainV1, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions, type SystemRecordApplyOutcomeV1, type SystemRecordLaneActivationV1, type SystemRecordLaneControllerV1 } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -447,16 +447,8 @@ export function createListContextGraphsCacheInvalidatingStore(
   };
   let systemRecordLaneMemo: SystemRecordLaneControllerV1 | null | undefined;
   let systemRecordLaneInner: SystemRecordLaneControllerV1 | null | undefined;
-  const wrapper: TripleStore & {
-    readonly innerStore: TripleStore;
-    readonly [STORE_CHAIN_INNER]: TripleStore;
-  } = {
+  const wrapper: TripleStore & { readonly innerStore: TripleStore } = {
     innerStore,
-    // The canonical decorator-chain contract. This forwarder declares neither
-    // the changelog API nor the managed read gate, so EVERY capability a caller
-    // resolves through it depends on traversal working here — the sync-changelog
-    // responder lane and the write-generation source among them.
-    [STORE_CHAIN_INNER]: innerStore,
     get queryCancellation() {
       return innerStore.queryCancellation;
     },
@@ -645,6 +637,11 @@ export function createListContextGraphsCacheInvalidatingStore(
       return innerStore.close();
     },
   };
+  // Register for capability discovery. This forwarder declares neither the
+  // changelog API nor the managed read gate, so EVERY capability resolved
+  // through it depends on traversal working here — the sync-changelog
+  // responder lane and the write-generation source among them.
+  linkStoreChainV1(wrapper, innerStore);
   return wrapper;
 }
 

--- a/packages/agent/test/managed-read-gate-through-agent-wrapper-v1.test.ts
+++ b/packages/agent/test/managed-read-gate-through-agent-wrapper-v1.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   GraphSetIndexStore,
   ManagedOxigraphBackendUnownedError,
+  attachManagedOxigraphLeaseV1,
+  createManagedOxigraphOwnershipControllerV1,
+  createTripleStore,
+  type ManagedOxigraphOwnershipControllerV1,
+  type ManagedOxigraphSupervisorHandoffV1,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
 
@@ -13,97 +18,107 @@ import { createListContextGraphsCacheInvalidatingStore } from '../src/dkg-agent-
  * drives an external read cache through its `invalidate()` callback — so reads
  * genuinely can be answered above it without delegating downward.
  *
- * A previous design made the managed read gate an optional method every wrapper
+ * An earlier design made the managed read gate an optional method every wrapper
  * had to re-declare; this one, in a different package, did not, so the gate
  * silently vanished here and warm reads went fail-open. A source-scanning test
  * inside packages/storage could never have seen it, which is why the coverage
  * lives here.
  *
- * This asserts the PRODUCTION property — a warm read refuses once ownership is
- * lost — rather than the resolver mechanism. The resolver is storage-internal
- * and deliberately not part of the published API, so testing it from here would
- * have meant widening that API for a test.
+ * Everything below uses the REAL managed adapter rather than a hand-built fake:
+ * the gate is symbol-keyed and storage-internal, so a fake would have to import
+ * that symbol, and widening the published API to make a test compile is the
+ * trade this PR already had to undo once.
  */
-const managedAdapter = () => {
-  const store = {
-    // The one thing only the managed adapter declares. Stands in for the real
-    // lease-snapshot check, which needs no I/O.
-    assertManagedBackendReadableV1: vi.fn(),
-    listGraphs: async () => ['urn:g:1'],
-    listGraphsByPrefix: async () => ['urn:g:1'],
-    query: async () => ({ type: 'boolean' as const, value: true }),
-    insert: async () => undefined,
-    delete: async () => undefined,
-    deleteByPattern: async () => 0,
-    deleteBySubjectPrefix: async () => 0,
-    hasGraph: async () => false,
-    createGraph: async () => undefined,
-    dropGraph: async () => undefined,
-    countQuads: async () => 0,
-    close: async () => undefined,
-  };
-  return store as unknown as TripleStore & {
-    assertManagedBackendReadableV1: ReturnType<typeof vi.fn>;
-  };
-};
+const QUERY_ENDPOINT = 'http://127.0.0.1:7941/query';
+const UPDATE_ENDPOINT = 'http://127.0.0.1:7941/update';
 
-/** The production shape: index over the agent forwarder over the managed adapter. */
-const composed = (adapter: TripleStore) =>
-  new GraphSetIndexStore(
-    createListContextGraphsCacheInvalidatingStore(adapter, () => undefined),
-  );
+const EMPTY_SELECT = JSON.stringify({ head: { vars: [] }, results: { bindings: [] } });
+const originalFetch = globalThis.fetch;
 
 describe('managed read gate survives the agent store wrapper', () => {
-  it('refuses a WARM listGraphs once ownership is lost', async () => {
-    const adapter = managedAdapter();
-    const index = composed(adapter);
+  let ownership: ManagedOxigraphOwnershipControllerV1;
 
-    await index.listGraphs(); // warm the index
+  const supervisor: ManagedOxigraphSupervisorHandoffV1 = {
+    stopAndProveOwnedChildDead: async () => undefined,
+    startAndProveCleanGeneration: async () => undefined,
+  };
 
-    adapter.assertManagedBackendReadableV1.mockImplementation(() => {
-      throw new ManagedOxigraphBackendUnownedError('probe', true, 'port-release-unproven');
+  beforeEach(() => {
+    ownership = createManagedOxigraphOwnershipControllerV1(QUERY_ENDPOINT, UPDATE_ENDPOINT);
+    ownership.bindReadyGeneration();
+    globalThis.fetch = (async (_input: unknown, init?: { body?: unknown }) => {
+      const body = String(init?.body ?? '');
+      const payload = /^\s*ASK/i.test(body) ? JSON.stringify({ boolean: false }) : EMPTY_SELECT;
+      return new Response(payload, {
+        status: 200,
+        headers: { 'Content-Type': 'application/sparql-results+json' },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  /** index -> agent forwarder -> real managed adapter. */
+  const composed = async (managed: boolean): Promise<TripleStore> => {
+    const adapter = await createTripleStore({
+      backend: 'sparql-http',
+      options: managed
+        ? (attachManagedOxigraphLeaseV1(
+            { queryEndpoint: QUERY_ENDPOINT, updateEndpoint: UPDATE_ENDPOINT, managedByDkg: true },
+            ownership.lease,
+            supervisor,
+          ) as unknown as Record<string, unknown>)
+        : { queryEndpoint: QUERY_ENDPOINT, updateEndpoint: UPDATE_ENDPOINT },
+      graphSetIndex: false,
     });
 
+    return new GraphSetIndexStore(
+      createListContextGraphsCacheInvalidatingStore(adapter, () => undefined),
+    );
+  };
+
+  it('refuses a WARM listGraphs once ownership is lost', async () => {
+    const index = await composed(true);
+    await index.listGraphs(); // warm the index
+
+    ownership.invalidate('port-release-unproven');
+
     await expect(index.listGraphs()).rejects.toThrow(ManagedOxigraphBackendUnownedError);
+    await index.close().catch(() => undefined);
   });
 
   it('refuses a WARM listGraphsByPrefix once ownership is lost', async () => {
-    const adapter = managedAdapter();
-    const index = composed(adapter);
-
+    const index = await composed(true);
     await index.listGraphs();
 
-    adapter.assertManagedBackendReadableV1.mockImplementation(() => {
-      throw new ManagedOxigraphBackendUnownedError('probe', true, 'port-release-unproven');
-    });
+    ownership.invalidate('port-release-unproven');
 
     await expect(index.listGraphsByPrefix('urn:')).rejects.toThrow(
       ManagedOxigraphBackendUnownedError,
     );
+    await index.close().catch(() => undefined);
   });
 
   it('still serves a warm read while ownership is live', async () => {
     // Positive control: without it, "always refuse" would satisfy both cases
     // above and the wrapper could be breaking reads rather than gating them.
-    const adapter = managedAdapter();
-    const index = composed(adapter);
+    const index = await composed(true);
 
     await index.listGraphs();
-    await expect(index.listGraphs()).resolves.toEqual(['urn:g:1']);
-    expect(adapter.assertManagedBackendReadableV1).toHaveBeenCalled();
+    await expect(index.listGraphs()).resolves.toEqual([]);
+
+    await index.close().catch(() => undefined);
   });
 
   it('leaves an unleased store behind the same wrapper untouched', async () => {
     // No managed backend anywhere in the chain must mean no refusal invented.
-    const bare = {
-      listGraphs: async () => ['urn:g:1'],
-      query: async () => ({ type: 'boolean' as const, value: true }),
-      close: async () => undefined,
-    } as unknown as TripleStore;
-
-    const index = composed(bare);
+    const index = await composed(false);
 
     await index.listGraphs();
-    await expect(index.listGraphs()).resolves.toEqual(['urn:g:1']);
+    await expect(index.listGraphs()).resolves.toEqual([]);
+
+    await index.close().catch(() => undefined);
   });
 });

--- a/packages/agent/test/managed-read-gate-through-agent-wrapper-v1.test.ts
+++ b/packages/agent/test/managed-read-gate-through-agent-wrapper-v1.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  asManagedReadGateV1,
+  GraphSetIndexStore,
+  ManagedOxigraphBackendUnownedError,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
 
@@ -12,21 +13,24 @@ import { createListContextGraphsCacheInvalidatingStore } from '../src/dkg-agent-
  * drives an external read cache through its `invalidate()` callback — so reads
  * genuinely can be answered above it without delegating downward.
  *
- * Under the previous design the managed read gate was an optional method every
- * wrapper had to re-declare, and this one (in a different package) did not. A
- * cache-owning layer above it would have called `assertManagedBackendReadableV1?.()`,
- * found nothing, and treated the absence as permission — the exact fail-open
- * shape the gate exists to prevent. A source-scanning test in packages/storage
- * could never have seen it.
+ * A previous design made the managed read gate an optional method every wrapper
+ * had to re-declare; this one, in a different package, did not, so the gate
+ * silently vanished here and warm reads went fail-open. A source-scanning test
+ * inside packages/storage could never have seen it, which is why the coverage
+ * lives here.
  *
- * Resolution walks `.innerStore`, which this wrapper already exposes, so it is
- * transparent without knowing the capability exists.
+ * This asserts the PRODUCTION property — a warm read refuses once ownership is
+ * lost — rather than the resolver mechanism. The resolver is storage-internal
+ * and deliberately not part of the published API, so testing it from here would
+ * have meant widening that API for a test.
  */
 const managedAdapter = () => {
   const store = {
+    // The one thing only the managed adapter declares. Stands in for the real
+    // lease-snapshot check, which needs no I/O.
     assertManagedBackendReadableV1: vi.fn(),
-    listGraphs: async () => [],
-    listGraphsByPrefix: async () => [],
+    listGraphs: async () => ['urn:g:1'],
+    listGraphsByPrefix: async () => ['urn:g:1'],
     query: async () => ({ type: 'boolean' as const, value: true }),
     insert: async () => undefined,
     delete: async () => undefined,
@@ -43,39 +47,63 @@ const managedAdapter = () => {
   };
 };
 
-describe('managed read gate resolves through the agent store wrapper', () => {
-  it('is transparent: the gate resolves to the adapter beneath it', () => {
+/** The production shape: index over the agent forwarder over the managed adapter. */
+const composed = (adapter: TripleStore) =>
+  new GraphSetIndexStore(
+    createListContextGraphsCacheInvalidatingStore(adapter, () => undefined),
+  );
+
+describe('managed read gate survives the agent store wrapper', () => {
+  it('refuses a WARM listGraphs once ownership is lost', async () => {
     const adapter = managedAdapter();
-    const wrapped = createListContextGraphsCacheInvalidatingStore(adapter, () => undefined);
+    const index = composed(adapter);
 
-    expect(asManagedReadGateV1(wrapped)).toBe(adapter);
-  });
-
-  it('a resolved gate on the wrapper refuses exactly when the adapter refuses', () => {
-    const adapter = managedAdapter();
-    const wrapped = createListContextGraphsCacheInvalidatingStore(adapter, () => undefined);
-    const gate = asManagedReadGateV1(wrapped);
-
-    // Live: no refusal.
-    expect(() => gate?.assertManagedBackendReadableV1('probe')).not.toThrow();
+    await index.listGraphs(); // warm the index
 
     adapter.assertManagedBackendReadableV1.mockImplementation(() => {
-      throw new Error('managed backend is not the proven ready listener');
+      throw new ManagedOxigraphBackendUnownedError('probe', true, 'port-release-unproven');
     });
-    expect(() => gate?.assertManagedBackendReadableV1('probe')).toThrow(
-      /not the proven ready listener/,
+
+    await expect(index.listGraphs()).rejects.toThrow(ManagedOxigraphBackendUnownedError);
+  });
+
+  it('refuses a WARM listGraphsByPrefix once ownership is lost', async () => {
+    const adapter = managedAdapter();
+    const index = composed(adapter);
+
+    await index.listGraphs();
+
+    adapter.assertManagedBackendReadableV1.mockImplementation(() => {
+      throw new ManagedOxigraphBackendUnownedError('probe', true, 'port-release-unproven');
+    });
+
+    await expect(index.listGraphsByPrefix('urn:')).rejects.toThrow(
+      ManagedOxigraphBackendUnownedError,
     );
   });
 
-  it('stays null for an unleased store behind the same wrapper', () => {
-    // Forwarding must not invent a gate where there is no managed backend.
+  it('still serves a warm read while ownership is live', async () => {
+    // Positive control: without it, "always refuse" would satisfy both cases
+    // above and the wrapper could be breaking reads rather than gating them.
+    const adapter = managedAdapter();
+    const index = composed(adapter);
+
+    await index.listGraphs();
+    await expect(index.listGraphs()).resolves.toEqual(['urn:g:1']);
+    expect(adapter.assertManagedBackendReadableV1).toHaveBeenCalled();
+  });
+
+  it('leaves an unleased store behind the same wrapper untouched', async () => {
+    // No managed backend anywhere in the chain must mean no refusal invented.
     const bare = {
-      listGraphs: async () => [],
+      listGraphs: async () => ['urn:g:1'],
+      query: async () => ({ type: 'boolean' as const, value: true }),
       close: async () => undefined,
     } as unknown as TripleStore;
 
-    expect(
-      asManagedReadGateV1(createListContextGraphsCacheInvalidatingStore(bare, () => undefined)),
-    ).toBeNull();
+    const index = composed(bare);
+
+    await index.listGraphs();
+    await expect(index.listGraphs()).resolves.toEqual(['urn:g:1']);
   });
 });

--- a/packages/agent/test/managed-read-gate-through-agent-wrapper-v1.test.ts
+++ b/packages/agent/test/managed-read-gate-through-agent-wrapper-v1.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  asManagedReadGateV1,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+
+import { createListContextGraphsCacheInvalidatingStore } from '../src/dkg-agent-base.js';
+
+/**
+ * The daemon's store is wrapped by this hand-rolled forwarder, and the forwarder
+ * drives an external read cache through its `invalidate()` callback — so reads
+ * genuinely can be answered above it without delegating downward.
+ *
+ * Under the previous design the managed read gate was an optional method every
+ * wrapper had to re-declare, and this one (in a different package) did not. A
+ * cache-owning layer above it would have called `assertManagedBackendReadableV1?.()`,
+ * found nothing, and treated the absence as permission — the exact fail-open
+ * shape the gate exists to prevent. A source-scanning test in packages/storage
+ * could never have seen it.
+ *
+ * Resolution walks `.innerStore`, which this wrapper already exposes, so it is
+ * transparent without knowing the capability exists.
+ */
+const managedAdapter = () => {
+  const store = {
+    assertManagedBackendReadableV1: vi.fn(),
+    listGraphs: async () => [],
+    listGraphsByPrefix: async () => [],
+    query: async () => ({ type: 'boolean' as const, value: true }),
+    insert: async () => undefined,
+    delete: async () => undefined,
+    deleteByPattern: async () => 0,
+    deleteBySubjectPrefix: async () => 0,
+    hasGraph: async () => false,
+    createGraph: async () => undefined,
+    dropGraph: async () => undefined,
+    countQuads: async () => 0,
+    close: async () => undefined,
+  };
+  return store as unknown as TripleStore & {
+    assertManagedBackendReadableV1: ReturnType<typeof vi.fn>;
+  };
+};
+
+describe('managed read gate resolves through the agent store wrapper', () => {
+  it('is transparent: the gate resolves to the adapter beneath it', () => {
+    const adapter = managedAdapter();
+    const wrapped = createListContextGraphsCacheInvalidatingStore(adapter, () => undefined);
+
+    expect(asManagedReadGateV1(wrapped)).toBe(adapter);
+  });
+
+  it('a resolved gate on the wrapper refuses exactly when the adapter refuses', () => {
+    const adapter = managedAdapter();
+    const wrapped = createListContextGraphsCacheInvalidatingStore(adapter, () => undefined);
+    const gate = asManagedReadGateV1(wrapped);
+
+    // Live: no refusal.
+    expect(() => gate?.assertManagedBackendReadableV1('probe')).not.toThrow();
+
+    adapter.assertManagedBackendReadableV1.mockImplementation(() => {
+      throw new Error('managed backend is not the proven ready listener');
+    });
+    expect(() => gate?.assertManagedBackendReadableV1('probe')).toThrow(
+      /not the proven ready listener/,
+    );
+  });
+
+  it('stays null for an unleased store behind the same wrapper', () => {
+    // Forwarding must not invent a gate where there is no managed backend.
+    const bare = {
+      listGraphs: async () => [],
+      close: async () => undefined,
+    } as unknown as TripleStore;
+
+    expect(
+      asManagedReadGateV1(createListContextGraphsCacheInvalidatingStore(bare, () => undefined)),
+    ).toBeNull();
+  });
+});

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -569,6 +569,25 @@ export class SparqlHttpStore implements TripleStore {
     return releaseSystemRecordLaneControllerV1(controller, quiesceOwner);
   }
 
+  /**
+   * Public so a caching decorator can fail closed WITHOUT a round trip.
+   *
+   * `GraphSetIndexStore` answers `listGraphs()` from a warm set for up to its
+   * revalidation interval, and this adapter answers from `listGraphsCache` for
+   * up to 30 s. Neither path touches the endpoint, so neither reaches the
+   * ownership checks on `query`/`update` — a lost lease kept serving
+   * enumeration for a whole cache window. A decorator that holds cached state
+   * derived from this store needs to ask, cheaply, whether that state is still
+   * attributable to a backend we own. This is a lease-snapshot read: no I/O.
+   *
+   * Named `…V1` and optional on `TripleStore` because only the managed adapter
+   * can answer it; stores without a lease are always readable and simply do not
+   * implement it.
+   */
+  assertManagedBackendReadableV1(operation: string): void {
+    this.assertManagedBackendReadable(operation);
+  }
+
   private assertManagedBackendReadable(operation: string): void {
     if (!this.ownershipLease) return;
     const snapshot = readManagedOxigraphOwnershipSnapshotV1(this.ownershipLease);
@@ -1327,6 +1346,11 @@ export class SparqlHttpStore implements TripleStore {
       return this.listGraphsDirect(options);
     }
     throwIfAborted(options?.signal);
+    // BEFORE the cache, not after. The warm branch below returns without
+    // touching the endpoint, so it never reaches the ownership check on
+    // `query` — a lost lease kept answering enumeration from this cache for up
+    // to MANAGED_LIST_GRAPHS_CACHE_MS.
+    this.assertManagedBackendReadable(options?.source ?? 'listGraphs');
     if (
       this.listGraphsCache &&
       this.now() - this.listGraphsCachedAt < MANAGED_LIST_GRAPHS_CACHE_MS

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -56,6 +56,7 @@ import {
   isInternalGraphUriV1,
 } from '../internal-graph-policy.js';
 import {
+  MANAGED_READ_GATE_V1,
   ManagedOxigraphBackendUnownedError,
   extractManagedOxigraphHandoffV1,
   extractManagedOxigraphLeaseV1,
@@ -570,21 +571,25 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   /**
-   * Public so a caching decorator can fail closed WITHOUT a round trip.
+   * The managed read gate, so a caching decorator can fail closed WITHOUT a
+   * round trip.
    *
    * `GraphSetIndexStore` answers `listGraphs()` from a warm set for up to its
    * revalidation interval, and this adapter answers from `listGraphsCache` for
    * up to 30 s. Neither path touches the endpoint, so neither reaches the
    * ownership checks on `query`/`update` — a lost lease kept serving
-   * enumeration for a whole cache window. A decorator that holds cached state
+   * enumeration for a whole cache window. A decorator holding cached state
    * derived from this store needs to ask, cheaply, whether that state is still
    * attributable to a backend we own. This is a lease-snapshot read: no I/O.
    *
-   * Named `…V1` and optional on `TripleStore` because only the managed adapter
-   * can answer it; stores without a lease are always readable and simply do not
-   * implement it.
+   * SYMBOL-keyed, not a named method. This class is a general SPARQL-over-HTTP
+   * adapter, and a string-named `assertManagedBackendReadableV1` on it both
+   * advertised a managed-Oxigraph lease concern to every consumer of the
+   * exported class and made discovery a structural match on a magic name — so
+   * any unrelated store declaring the same name would have been treated as a
+   * managed backend.
    */
-  assertManagedBackendReadableV1(operation: string): void {
+  [MANAGED_READ_GATE_V1](operation: string): void {
     this.assertManagedBackendReadable(operation);
   }
 

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -55,8 +55,8 @@ import {
   assertNotReservedInternalGraphV1,
   isInternalGraphUriV1,
 } from '../internal-graph-policy.js';
+import { CACHED_READ_GATE_V1 } from '../cached-read-gate-v1.js';
 import {
-  MANAGED_READ_GATE_V1,
   ManagedOxigraphBackendUnownedError,
   extractManagedOxigraphHandoffV1,
   extractManagedOxigraphLeaseV1,
@@ -589,7 +589,7 @@ export class SparqlHttpStore implements TripleStore {
    * any unrelated store declaring the same name would have been treated as a
    * managed backend.
    */
-  [MANAGED_READ_GATE_V1](operation: string): void {
+  [CACHED_READ_GATE_V1](operation: string): void {
     this.assertManagedBackendReadable(operation);
   }
 

--- a/packages/storage/src/cached-read-gate-v1.ts
+++ b/packages/storage/src/cached-read-gate-v1.ts
@@ -1,0 +1,64 @@
+/**
+ * "May I still serve a read from cached state?" — backend-neutral.
+ *
+ * A decorator that answers a read from warm state never delegates downward, so
+ * it never reaches whatever validity checks the backing store performs on a
+ * real request. Whether that cached answer is still attributable to the store it
+ * came from is a question only the backing store can answer, and it must be
+ * answerable WITHOUT I/O or the cache stops being a cache.
+ *
+ * This interface is deliberately about cache coherence, not about any one
+ * backend's ownership model. `GraphSetIndexStore` is a reusable index over any
+ * store; coupling it to a managed-Oxigraph lease meant a second backend needing
+ * the same guarantee would either have to grow a parallel symbol beside it or
+ * pretend to be a managed Oxigraph. Both leak backend policy into a generic
+ * layer.
+ *
+ * The managed-Oxigraph adapter implements this by consulting its ownership
+ * lease — see `adapters/sparql-http.ts`. That policy stays entirely in the
+ * adapter; the index only asks the neutral question.
+ *
+ * Stores with no cache-validity precondition simply do not implement it, and
+ * `asCachedReadGateV1` resolves to `null`, which means "no store in this chain
+ * constrains cached reads".
+ */
+
+import { resolveStoreChainCapabilityV1 } from './store-chain-capability.js';
+
+/**
+ * Symbol-keyed so discovery is an identity check rather than a structural match
+ * on a method name — an unrelated store that happens to declare a same-named
+ * method must not be mistaken for a gate that governs whether reads may be
+ * served. Not exported from the package barrel.
+ */
+export const CACHED_READ_GATE_V1: unique symbol = Symbol('dkg.cachedReadGate.v1');
+
+export interface CachedReadGateHostV1 {
+  /**
+   * Throw if cached state derived from this store may no longer be served.
+   *
+   * MUST NOT perform I/O: callers invoke this on the warm path, where the whole
+   * point is that no request is made. `operation` is for diagnostics only.
+   */
+  [CACHED_READ_GATE_V1](operation: string): void;
+}
+
+/**
+ * Recover the cached-read gate from anywhere in a decorator chain.
+ *
+ * Resolving rather than forwarding is what stops a wrapper silently erasing the
+ * gate: an earlier revision called the gate on the immediate inner store with
+ * optional chaining, and optional chaining treats an absent method as
+ * PERMISSION — so one intervening decorator turned a fail-closed read into a
+ * fail-open one.
+ *
+ * `null` means no store in the chain constrains cached reads, which is the
+ * ordinary case for an operator-configured store.
+ */
+export function asCachedReadGateV1(store: unknown): CachedReadGateHostV1 | null {
+  return resolveStoreChainCapabilityV1(store, isCachedReadGateHostV1);
+}
+
+function isCachedReadGateHostV1(candidate: unknown): candidate is CachedReadGateHostV1 {
+  return typeof (candidate as Partial<CachedReadGateHostV1>)?.[CACHED_READ_GATE_V1] === 'function';
+}

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -624,22 +624,6 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
     return this.inner.getSystemRecordLaneControllerV1?.();
   }
 
-  /**
-   * Pass-through for the managed read gate (#2052) — unconditionally, unlike
-   * the lane above.
-   *
-   * The lane getter DENIES when enabled, because handing out a mutation
-   * capability past this decorator would let a CAS bypass the changelog. This
-   * is the opposite kind of thing: a refusal, and suppressing a refusal is
-   * never the safe direction. An enabled changelog that swallowed it would let
-   * a cache-owning wrapper above serve reads attributed to a backend the node
-   * no longer owns — the caller uses optional chaining, so absence reads as
-   * permission.
-   */
-  assertManagedBackendReadableV1(operation: string): void {
-    this.inner.assertManagedBackendReadableV1?.(operation);
-  }
-
   async flush(options?: QueryOptions): Promise<void> {
     // Drain queued mutations (data + their markers) before flushing the inner
     // store, so a durability flush cannot return while a write is still queued.

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -624,6 +624,22 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
     return this.inner.getSystemRecordLaneControllerV1?.();
   }
 
+  /**
+   * Pass-through for the managed read gate (#2052) — unconditionally, unlike
+   * the lane above.
+   *
+   * The lane getter DENIES when enabled, because handing out a mutation
+   * capability past this decorator would let a CAS bypass the changelog. This
+   * is the opposite kind of thing: a refusal, and suppressing a refusal is
+   * never the safe direction. An enabled changelog that swallowed it would let
+   * a cache-owning wrapper above serve reads attributed to a backend the node
+   * no longer owns — the caller uses optional chaining, so absence reads as
+   * permission.
+   */
+  assertManagedBackendReadableV1(operation: string): void {
+    this.inner.assertManagedBackendReadableV1?.(operation);
+  }
+
   async flush(options?: QueryOptions): Promise<void> {
     // Drain queued mutations (data + their markers) before flushing the inner
     // store, so a durability flush cannot return while a write is still queued.

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -16,6 +16,7 @@ import {
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { assertNotReservedInternalGraphV1 } from './internal-graph-policy.js';
+import { resolveStoreChainCapabilityV1 } from './store-chain-capability.js';
 import type { SystemRecordLaneControllerV1 } from './system-record-materializer-v1.js';
 
 /**
@@ -205,6 +206,13 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
   }
 
   private readonly inner: TripleStore;
+  /**
+   * Public alias of {@link inner}, the decorator-chain convention.
+   *
+   * Capability resolution walks `innerStore`; exposing it means that walk no
+   * longer has to reach a TypeScript-private field to traverse this class.
+   */
+  readonly innerStore: TripleStore;
   private readonly enabled: boolean;
   private readonly reserved: ReadonlySet<string>;
   private readonly onAppend?: (record: ChangeRecord) => void;
@@ -229,6 +237,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
 
   constructor(inner: TripleStore, options: ChangelogStoreOptions = {}) {
     this.inner = inner;
+    this.innerStore = inner;
     this.enabled = options.enabled !== false;
     const reserved = new Set<string>([CHANGELOG_GRAPH]);
     for (const g of options.reservedGraphs ?? []) reserved.add(g);
@@ -993,24 +1002,24 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
  * no `instanceof`/cast/decorator-order assumption at the call site.
  */
 export function asChangelogReader(store: unknown): ChangelogReader | null {
-  // Follow `.innerStore` so a wrapper AROUND the ChangelogStore still resolves.
-  // The daemon's store is `createListContextGraphsCacheInvalidatingStore(...)`
-  // (dkg-agent-base.ts), a hand-rolled forwarder that exposes `.innerStore` but
-  // does NOT forward the changelog API — so a direct check misses it even when
-  // the changelog is enabled. The depth bound guards a pathological/cyclic chain.
-  let s = store as (Partial<ChangelogReader> & { innerStore?: unknown }) | null | undefined;
-  for (let depth = 0; s && depth < 8; depth++) {
-    if (s instanceof ChangelogStore) return s;
-    if (
-      typeof s.changelogHead === 'function' &&
-      typeof s.readChanges === 'function' &&
-      typeof s.headSeq === 'function' &&
-      typeof s.clearReconcileFlag === 'function' &&
-      typeof s.needsReconcile === 'boolean'
-    ) {
-      return s as ChangelogReader;
-    }
-    s = s.innerStore as typeof s;
-  }
-  return null;
+  // The walk itself is shared — see `resolveStoreChainCapabilityV1`. This copy
+  // followed ONLY `.innerStore`, while the write-gen and read-gate walkers also
+  // followed `.inner`; consolidating removes that divergence, which could only
+  // ever surface as a silent `null` ("no changelog") rather than an error.
+  //
+  // Resolution matters here because the daemon's store is
+  // `createListContextGraphsCacheInvalidatingStore(...)` (dkg-agent-base.ts), a
+  // hand-rolled forwarder that exposes `.innerStore` but does NOT forward the
+  // changelog API — so a direct check misses it even when the changelog is on.
+  return resolveStoreChainCapabilityV1<ChangelogReader>(store, (candidate) => {
+    if (candidate instanceof ChangelogStore) return true;
+    const c = candidate as Partial<ChangelogReader>;
+    return (
+      typeof c.changelogHead === 'function' &&
+      typeof c.readChanges === 'function' &&
+      typeof c.headSeq === 'function' &&
+      typeof c.clearReconcileFlag === 'function' &&
+      typeof c.needsReconcile === 'boolean'
+    );
+  });
 }

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -16,7 +16,10 @@ import {
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { assertNotReservedInternalGraphV1 } from './internal-graph-policy.js';
-import { resolveStoreChainCapabilityV1 } from './store-chain-capability.js';
+import {
+  STORE_CHAIN_INNER,
+  resolveStoreChainCapabilityV1,
+} from './store-chain-capability.js';
 import type { SystemRecordLaneControllerV1 } from './system-record-materializer-v1.js';
 
 /**
@@ -206,13 +209,17 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
   }
 
   private readonly inner: TripleStore;
+
   /**
-   * Public alias of {@link inner}, the decorator-chain convention.
+   * Lets capability discovery pass through WITHOUT publishing the wrapped store.
    *
-   * Capability resolution walks `innerStore`; exposing it means that walk no
-   * longer has to reach a TypeScript-private field to traverse this class.
+   * A public `innerStore` here would be an escape hatch: `store.innerStore
+   * .insert(...)` bypasses the change-marker recording this class exists to
+   * enforce, which is the one invariant that makes the log complete.
    */
-  readonly innerStore: TripleStore;
+  get [STORE_CHAIN_INNER](): TripleStore {
+    return this.inner;
+  }
   private readonly enabled: boolean;
   private readonly reserved: ReadonlySet<string>;
   private readonly onAppend?: (record: ChangeRecord) => void;
@@ -237,7 +244,6 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
 
   constructor(inner: TripleStore, options: ChangelogStoreOptions = {}) {
     this.inner = inner;
-    this.innerStore = inner;
     this.enabled = options.enabled !== false;
     const reserved = new Set<string>([CHANGELOG_GRAPH]);
     for (const g of options.reservedGraphs ?? []) reserved.add(g);

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -1011,15 +1011,17 @@ export function asChangelogReader(store: unknown): ChangelogReader | null {
   // `createListContextGraphsCacheInvalidatingStore(...)` (dkg-agent-base.ts), a
   // hand-rolled forwarder that exposes `.innerStore` but does NOT forward the
   // changelog API — so a direct check misses it even when the changelog is on.
-  return resolveStoreChainCapabilityV1<ChangelogReader>(store, (candidate) => {
-    if (candidate instanceof ChangelogStore) return true;
-    const c = candidate as Partial<ChangelogReader>;
-    return (
-      typeof c.changelogHead === 'function' &&
-      typeof c.readChanges === 'function' &&
-      typeof c.headSeq === 'function' &&
-      typeof c.clearReconcileFlag === 'function' &&
-      typeof c.needsReconcile === 'boolean'
-    );
-  });
+  return resolveStoreChainCapabilityV1(store, isChangelogReader);
+}
+
+function isChangelogReader(candidate: unknown): candidate is ChangelogReader {
+  if (candidate instanceof ChangelogStore) return true;
+  const c = candidate as Partial<ChangelogReader> | null | undefined;
+  return (
+    typeof c?.changelogHead === 'function' &&
+    typeof c.readChanges === 'function' &&
+    typeof c.headSeq === 'function' &&
+    typeof c.clearReconcileFlag === 'function' &&
+    typeof c.needsReconcile === 'boolean'
+  );
 }

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -17,7 +17,7 @@ import {
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { assertNotReservedInternalGraphV1 } from './internal-graph-policy.js';
 import {
-  STORE_CHAIN_INNER,
+  linkStoreChainV1,
   resolveStoreChainCapabilityV1,
 } from './store-chain-capability.js';
 import type { SystemRecordLaneControllerV1 } from './system-record-materializer-v1.js';
@@ -210,16 +210,6 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
 
   private readonly inner: TripleStore;
 
-  /**
-   * Lets capability discovery pass through WITHOUT publishing the wrapped store.
-   *
-   * A public `innerStore` here would be an escape hatch: `store.innerStore
-   * .insert(...)` bypasses the change-marker recording this class exists to
-   * enforce, which is the one invariant that makes the log complete.
-   */
-  get [STORE_CHAIN_INNER](): TripleStore {
-    return this.inner;
-  }
   private readonly enabled: boolean;
   private readonly reserved: ReadonlySet<string>;
   private readonly onAppend?: (record: ChangeRecord) => void;
@@ -244,6 +234,9 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
 
   constructor(inner: TripleStore, options: ChangelogStoreOptions = {}) {
     this.inner = inner;
+    // Registration, not a public handle: reaching past this decorator would
+    // skip the change-marker recording that makes the log complete.
+    linkStoreChainV1(this, inner);
     this.enabled = options.enabled !== false;
     const reserved = new Set<string>([CHANGELOG_GRAPH]);
     for (const g of options.reservedGraphs ?? []) reserved.add(g);

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -302,6 +302,14 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   private readonly inner: TripleStore;
+  /**
+   * Public alias of {@link inner}, the decorator-chain convention.
+   *
+   * Capability resolution (`asChangelogReader`, `asGraphWriteGenSource`,
+   * `asManagedReadGateV1`) walks `innerStore`. Exposing it here means that walk
+   * no longer has to reach a TypeScript-private field to traverse this class.
+   */
+  readonly innerStore: TripleStore;
   private systemRecordLaneMemo: SystemRecordLaneControllerV1 | null | undefined;
   /** The inner controller the memo wraps, so a replacement is not masked. */
   private systemRecordLaneInner: SystemRecordLaneControllerV1 | null | undefined;
@@ -340,6 +348,7 @@ export class GraphSetIndexStore implements TripleStore {
 
   constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
     this.inner = inner;
+    this.innerStore = inner;
     this.managedReadGate = asManagedReadGateV1(inner);
     this.enabled = options.enabled !== false;
     this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -10,7 +10,7 @@ import type {
   UpdateOptions,
 } from './triple-store.js';
 import { storeWorkPriorityRank } from './store-priority-scheduler.js';
-import { STORE_CHAIN_INNER } from './store-chain-capability.js';
+import { linkStoreChainV1 } from './store-chain-capability.js';
 import {
   UnsupportedTripleStoreCapabilityError,
   isReplaceGraphAndSubjectCapabilityRefusal,
@@ -305,17 +305,6 @@ export class GraphSetIndexStore implements TripleStore {
 
   private readonly inner: TripleStore;
 
-  /**
-   * Lets capability discovery pass through WITHOUT publishing the wrapped store.
-   *
-   * A public `innerStore` here would be an escape hatch: `store.innerStore
-   * .insert(...)` bypasses the index maintenance this class exists to enforce.
-   * The symbol keeps traversal working while keeping that bypass off the
-   * observable API.
-   */
-  get [STORE_CHAIN_INNER](): TripleStore {
-    return this.inner;
-  }
   private systemRecordLaneMemo: SystemRecordLaneControllerV1 | null | undefined;
   /** The inner controller the memo wraps, so a replacement is not masked. */
   private systemRecordLaneInner: SystemRecordLaneControllerV1 | null | undefined;
@@ -354,6 +343,10 @@ export class GraphSetIndexStore implements TripleStore {
 
   constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
     this.inner = inner;
+    // Traversable for capability discovery WITHOUT publishing the wrapped store.
+    // A public handle — named or symbol-keyed — would let a caller reach past
+    // this decorator and skip the index maintenance it exists to enforce.
+    linkStoreChainV1(this, inner);
     this.managedReadGate = asManagedReadGateV1(inner);
     this.enabled = options.enabled !== false;
     this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -618,6 +618,13 @@ export class GraphSetIndexStore implements TripleStore {
       this.revalidateMs > 0 &&
       this.now() < this.nextRevalidateAt
     ) {
+      // The warm path returns WITHOUT touching the inner store, so the
+      // ownership refusal that `refreshIndex` rethrows is unreachable here.
+      // Serving this set after the lease is lost attributes stale enumeration
+      // to a backend the node may no longer own — for up to `revalidateMs`
+      // (30 s in production), which is the window a foreign listener needs.
+      // Cheap: a lease-snapshot read, no I/O.
+      this.inner.assertManagedBackendReadableV1?.('graph-set-index.warm');
       return this.graphs;
     }
     return raceAgainstAbort(

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -17,7 +17,11 @@ import {
   isReplaceSubjectCapabilityRefusal,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
-import { ManagedOxigraphBackendUnownedError } from './managed-oxigraph-ownership-v1-internal.js';
+import {
+  ManagedOxigraphBackendUnownedError,
+  asManagedReadGateV1,
+  type ManagedReadGateHostV1,
+} from './managed-oxigraph-ownership-v1-internal.js';
 import type {
   SystemRecordApplyOutcomeV1,
   SystemRecordLaneActivationV1,
@@ -216,24 +220,6 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   /**
-   * Pass-through for the managed read gate (#2052).
-   *
-   * This class is the main CONSUMER of the gate — see the warm branch in
-   * `ensureGraphSet` — but it must also RE-EXPOSE it, which is easy to miss.
-   * `createTripleStore` can put a `ChangelogStore` outside this one, so a
-   * cache-owning wrapper above would call this method on the index; without a
-   * declaration here the optional call evaporates and reads go fail-open again,
-   * one layer higher than the bug this was written to fix.
-   *
-   * Consuming a capability is not the same as forwarding it. Grepping for the
-   * NAME is what hides this: the call site above matches, the declaration does
-   * not exist.
-   */
-  assertManagedBackendReadableV1(operation: string): void {
-    this.inner.assertManagedBackendReadableV1?.(operation);
-  }
-
-  /**
    * Memoized outcome-mapping facade for the system-record V1 lane (#2052 B2).
    *
    * The lane writes reserved graphs that this index deliberately never lists,
@@ -339,8 +325,22 @@ export class GraphSetIndexStore implements TripleStore {
    */
   private pendingFullRefresh: PendingFullRefreshSource | null = null;
 
+  /**
+   * The managed read gate, resolved ONCE through the whole inner chain.
+   *
+   * Resolved rather than probed per call: `this.inner.assert…?.()` asked only
+   * the immediate wrapper, and optional chaining treats an absent method as
+   * PERMISSION — so a single intervening decorator turned this fail-closed read
+   * into a fail-open one. `asManagedReadGateV1` walks to the adapter that
+   * actually holds the lease, so no wrapper can erase it by omission.
+   *
+   * `null` for every store with no managed backend: those are always readable.
+   */
+  private readonly managedReadGate: ManagedReadGateHostV1 | null;
+
   constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
     this.inner = inner;
+    this.managedReadGate = asManagedReadGateV1(inner);
     this.enabled = options.enabled !== false;
     this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);
     this.revalidateFailureBackoffMs = positiveFiniteMs(
@@ -642,7 +642,7 @@ export class GraphSetIndexStore implements TripleStore {
       // to a backend the node may no longer own — for up to `revalidateMs`
       // (30 s in production), which is the window a foreign listener needs.
       // Cheap: a lease-snapshot read, no I/O.
-      this.inner.assertManagedBackendReadableV1?.('graph-set-index.warm');
+      this.managedReadGate?.assertManagedBackendReadableV1('graph-set-index.warm');
       return this.graphs;
     }
     return raceAgainstAbort(

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -216,6 +216,24 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   /**
+   * Pass-through for the managed read gate (#2052).
+   *
+   * This class is the main CONSUMER of the gate — see the warm branch in
+   * `ensureGraphSet` — but it must also RE-EXPOSE it, which is easy to miss.
+   * `createTripleStore` can put a `ChangelogStore` outside this one, so a
+   * cache-owning wrapper above would call this method on the index; without a
+   * declaration here the optional call evaporates and reads go fail-open again,
+   * one layer higher than the bug this was written to fix.
+   *
+   * Consuming a capability is not the same as forwarding it. Grepping for the
+   * NAME is what hides this: the call site above matches, the declaration does
+   * not exist.
+   */
+  assertManagedBackendReadableV1(operation: string): void {
+    this.inner.assertManagedBackendReadableV1?.(operation);
+  }
+
+  /**
    * Memoized outcome-mapping facade for the system-record V1 lane (#2052 B2).
    *
    * The lane writes reserved graphs that this index deliberately never lists,

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -18,12 +18,12 @@ import {
   isReplaceSubjectCapabilityRefusal,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
+import { ManagedOxigraphBackendUnownedError } from './managed-oxigraph-ownership-v1-internal.js';
 import {
-  MANAGED_READ_GATE_V1,
-  ManagedOxigraphBackendUnownedError,
-  asManagedReadGateV1,
-  type ManagedReadGateHostV1,
-} from './managed-oxigraph-ownership-v1-internal.js';
+  CACHED_READ_GATE_V1,
+  asCachedReadGateV1,
+  type CachedReadGateHostV1,
+} from './cached-read-gate-v1.js';
 import type {
   SystemRecordApplyOutcomeV1,
   SystemRecordLaneActivationV1,
@@ -339,7 +339,7 @@ export class GraphSetIndexStore implements TripleStore {
    *
    * `null` for every store with no managed backend: those are always readable.
    */
-  private readonly managedReadGate: ManagedReadGateHostV1 | null;
+  private readonly cachedReadGate: CachedReadGateHostV1 | null;
 
   constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
     this.inner = inner;
@@ -347,7 +347,7 @@ export class GraphSetIndexStore implements TripleStore {
     // A public handle — named or symbol-keyed — would let a caller reach past
     // this decorator and skip the index maintenance it exists to enforce.
     linkStoreChainV1(this, inner);
-    this.managedReadGate = asManagedReadGateV1(inner);
+    this.cachedReadGate = asCachedReadGateV1(inner);
     this.enabled = options.enabled !== false;
     this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);
     this.revalidateFailureBackoffMs = positiveFiniteMs(
@@ -649,7 +649,7 @@ export class GraphSetIndexStore implements TripleStore {
       // to a backend the node may no longer own — for up to `revalidateMs`
       // (30 s in production), which is the window a foreign listener needs.
       // Cheap: a lease-snapshot read, no I/O.
-      this.managedReadGate?.[MANAGED_READ_GATE_V1]('graph-set-index.warm');
+      this.cachedReadGate?.[CACHED_READ_GATE_V1]('graph-set-index.warm');
       return this.graphs;
     }
     return raceAgainstAbort(

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -334,7 +334,7 @@ export class GraphSetIndexStore implements TripleStore {
    * Resolved rather than probed per call: `this.inner.assert…?.()` asked only
    * the immediate wrapper, and optional chaining treats an absent method as
    * PERMISSION — so a single intervening decorator turned this fail-closed read
-   * into a fail-open one. `asManagedReadGateV1` walks to the adapter that
+   * into a fail-open one. `asCachedReadGateV1` walks to the store that
    * actually holds the lease, so no wrapper can erase it by omission.
    *
    * `null` for every store with no managed backend: those are always readable.

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -19,6 +19,7 @@ import {
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import {
+  MANAGED_READ_GATE_V1,
   ManagedOxigraphBackendUnownedError,
   asManagedReadGateV1,
   type ManagedReadGateHostV1,
@@ -655,7 +656,7 @@ export class GraphSetIndexStore implements TripleStore {
       // to a backend the node may no longer own — for up to `revalidateMs`
       // (30 s in production), which is the window a foreign listener needs.
       // Cheap: a lease-snapshot read, no I/O.
-      this.managedReadGate?.assertManagedBackendReadableV1('graph-set-index.warm');
+      this.managedReadGate?.[MANAGED_READ_GATE_V1]('graph-set-index.warm');
       return this.graphs;
     }
     return raceAgainstAbort(

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -10,6 +10,7 @@ import type {
   UpdateOptions,
 } from './triple-store.js';
 import { storeWorkPriorityRank } from './store-priority-scheduler.js';
+import { STORE_CHAIN_INNER } from './store-chain-capability.js';
 import {
   UnsupportedTripleStoreCapabilityError,
   isReplaceGraphAndSubjectCapabilityRefusal,
@@ -302,14 +303,18 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   private readonly inner: TripleStore;
+
   /**
-   * Public alias of {@link inner}, the decorator-chain convention.
+   * Lets capability discovery pass through WITHOUT publishing the wrapped store.
    *
-   * Capability resolution (`asChangelogReader`, `asGraphWriteGenSource`,
-   * `asManagedReadGateV1`) walks `innerStore`. Exposing it here means that walk
-   * no longer has to reach a TypeScript-private field to traverse this class.
+   * A public `innerStore` here would be an escape hatch: `store.innerStore
+   * .insert(...)` bypasses the index maintenance this class exists to enforce.
+   * The symbol keeps traversal working while keeping that bypass off the
+   * observable API.
    */
-  readonly innerStore: TripleStore;
+  get [STORE_CHAIN_INNER](): TripleStore {
+    return this.inner;
+  }
   private systemRecordLaneMemo: SystemRecordLaneControllerV1 | null | undefined;
   /** The inner controller the memo wraps, so a replacement is not masked. */
   private systemRecordLaneInner: SystemRecordLaneControllerV1 | null | undefined;
@@ -348,7 +353,6 @@ export class GraphSetIndexStore implements TripleStore {
 
   constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
     this.inner = inner;
-    this.innerStore = inner;
     this.managedReadGate = asManagedReadGateV1(inner);
     this.enabled = options.enabled !== false;
     this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);

--- a/packages/storage/src/graph-write-gen.ts
+++ b/packages/storage/src/graph-write-gen.ts
@@ -21,7 +21,7 @@
  * shared oxigraph-server) are invisible here; the memo's TTL bounds that
  * hole, and a restart clears the memo entirely (the counter is in-memory).
  */
-import { resolveStoreChainCapabilityV1 } from './store-chain-capability.js';
+import { resolveStoreChainCapabilityLegacyV1 } from './store-chain-capability.js';
 
 export interface GraphWriteGenSource {
   /**
@@ -85,7 +85,9 @@ export class GraphWriteGenTracker implements GraphWriteGenSource {
 export function asGraphWriteGenSource(store: unknown): GraphWriteGenSource | null {
   // Traversal is shared — see `resolveStoreChainCapabilityV1`. This carried its
   // own copy of the walk, which had already drifted from `asChangelogReader`'s.
-  return resolveStoreChainCapabilityV1(store, isGraphWriteGenSource);
+  // The LEGACY resolver: this is the one capability whose checked-in contract
+  // asserts a TS-private `.inner` reach. New capabilities must not use it.
+  return resolveStoreChainCapabilityLegacyV1(store, isGraphWriteGenSource);
 }
 
 function isGraphWriteGenSource(candidate: unknown): candidate is GraphWriteGenSource {

--- a/packages/storage/src/graph-write-gen.ts
+++ b/packages/storage/src/graph-write-gen.ts
@@ -85,8 +85,9 @@ export class GraphWriteGenTracker implements GraphWriteGenSource {
 export function asGraphWriteGenSource(store: unknown): GraphWriteGenSource | null {
   // Traversal is shared — see `resolveStoreChainCapabilityV1`. This carried its
   // own copy of the walk, which had already drifted from `asChangelogReader`'s.
-  return resolveStoreChainCapabilityV1<GraphWriteGenSource>(
-    store,
-    (candidate) => typeof (candidate as Partial<GraphWriteGenSource>).getWriteGen === 'function',
-  );
+  return resolveStoreChainCapabilityV1(store, isGraphWriteGenSource);
+}
+
+function isGraphWriteGenSource(candidate: unknown): candidate is GraphWriteGenSource {
+  return typeof (candidate as Partial<GraphWriteGenSource>)?.getWriteGen === 'function';
 }

--- a/packages/storage/src/graph-write-gen.ts
+++ b/packages/storage/src/graph-write-gen.ts
@@ -21,6 +21,8 @@
  * shared oxigraph-server) are invisible here; the memo's TTL bounds that
  * hole, and a restart clears the memo entirely (the counter is in-memory).
  */
+import { resolveStoreChainCapabilityV1 } from './store-chain-capability.js';
+
 export interface GraphWriteGenSource {
   /**
    * Monotonic generation for "any local write that may have touched a graph
@@ -81,18 +83,10 @@ export class GraphWriteGenTracker implements GraphWriteGenSource {
  * MUST fail open (always scan) on `null`.
  */
 export function asGraphWriteGenSource(store: unknown): GraphWriteGenSource | null {
-  // Follow `.innerStore` (hand-rolled forwarders like the daemon's
-  // listContextGraphs-cache invalidator) and `.inner` (ChangelogStore,
-  // GraphSetIndexStore, SharedMemoryLiteralBlobStore) so the capability
-  // resolves through any decorator order — mirrors `asChangelogReader`.
-  // The depth bound guards a pathological/cyclic chain.
-  let s = store as
-    | { getWriteGen?: unknown; innerStore?: unknown; inner?: unknown }
-    | null
-    | undefined;
-  for (let depth = 0; s && depth < 8; depth++) {
-    if (typeof s.getWriteGen === 'function') return s as GraphWriteGenSource;
-    s = (s.innerStore ?? s.inner) as typeof s;
-  }
-  return null;
+  // Traversal is shared — see `resolveStoreChainCapabilityV1`. This carried its
+  // own copy of the walk, which had already drifted from `asChangelogReader`'s.
+  return resolveStoreChainCapabilityV1<GraphWriteGenSource>(
+    store,
+    (candidate) => typeof (candidate as Partial<GraphWriteGenSource>).getWriteGen === 'function',
+  );
 }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -206,8 +206,10 @@ import './adapters/oxigraph.js';
 import './adapters/oxigraph-worker.js';
 import './adapters/blazegraph.js';
 import './adapters/sparql-http.js';
+// Registration only — grants no ability to READ any wrapped store, so it
+// cannot become an invariant bypass the way a public handle would.
 export {
-  STORE_CHAIN_INNER,
   StoreChainCycleError,
+  linkStoreChainV1,
   type StoreChainNodeV1,
 } from './store-chain-capability.js';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -206,3 +206,8 @@ import './adapters/oxigraph.js';
 import './adapters/oxigraph-worker.js';
 import './adapters/blazegraph.js';
 import './adapters/sparql-http.js';
+export {
+  STORE_CHAIN_INNER,
+  StoreChainCycleError,
+  type StoreChainNodeV1,
+} from './store-chain-capability.js';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -54,7 +54,6 @@ export {
   ManagedOxigraphBackendUnownedError,
   attachManagedOxigraphLeaseV1,
   createManagedOxigraphOwnershipControllerV1,
-  asManagedReadGateV1,
   extractManagedOxigraphHandoffV1,
   extractManagedOxigraphLeaseV1,
   isManagedOxigraphOwnershipLeaseV1,
@@ -64,7 +63,6 @@ export {
   type ManagedOxigraphOwnershipInvalidationV1,
   type ManagedOxigraphOwnershipLeaseV1,
   type ManagedOxigraphOwnershipSnapshotV1,
-  type ManagedReadGateHostV1,
   type ManagedOxigraphSupervisorHandoffV1,
 } from './managed-oxigraph-ownership-v1-internal.js';
 export {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -206,10 +206,9 @@ import './adapters/oxigraph.js';
 import './adapters/oxigraph-worker.js';
 import './adapters/blazegraph.js';
 import './adapters/sparql-http.js';
-// Registration only — grants no ability to READ any wrapped store, so it
-// cannot become an invariant bypass the way a public handle would.
-export {
-  StoreChainCycleError,
-  linkStoreChainV1,
-  type StoreChainNodeV1,
-} from './store-chain-capability.js';
+// `linkStoreChainV1` is deliberately NOT exported: it is an internal
+// composition detail of this package's own decorators. A wrapper outside
+// storage is traversable through its public `innerStore`, so publishing the
+// registry would add a second traversal source for the same object without
+// changing discovery.
+export { StoreChainCycleError, type StoreChainNodeV1 } from './store-chain-capability.js';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -54,6 +54,7 @@ export {
   ManagedOxigraphBackendUnownedError,
   attachManagedOxigraphLeaseV1,
   createManagedOxigraphOwnershipControllerV1,
+  asManagedReadGateV1,
   extractManagedOxigraphHandoffV1,
   extractManagedOxigraphLeaseV1,
   isManagedOxigraphOwnershipLeaseV1,
@@ -63,6 +64,7 @@ export {
   type ManagedOxigraphOwnershipInvalidationV1,
   type ManagedOxigraphOwnershipLeaseV1,
   type ManagedOxigraphOwnershipSnapshotV1,
+  type ManagedReadGateHostV1,
   type ManagedOxigraphSupervisorHandoffV1,
 } from './managed-oxigraph-ownership-v1-internal.js';
 export {

--- a/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
+++ b/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
@@ -35,8 +35,6 @@
  * obtains the lease still cannot extend or revive it, failing (3).
  */
 
-import { resolveStoreChainCapabilityV1 } from './store-chain-capability.js';
-
 /** Opaque, non-inspectable lease handle. Compare by identity only. */
 declare const MANAGED_OXIGRAPH_LEASE_BRAND: unique symbol;
 export type ManagedOxigraphOwnershipLeaseV1 = {
@@ -416,50 +414,4 @@ export function readManagedOxigraphOwnershipSnapshotV1(
   return snapshotLeaseState(current);
 }
 
-/**
- * The managed read gate, keyed by symbol rather than by method name.
- *
- * Symbol-keyed for two reasons the review drew out. It keeps a managed-Oxigraph
- * lease concern OFF the public surface of `SparqlHttpStore`, which is a general
- * SPARQL-over-HTTP adapter and has no business advertising one; and it makes
- * discovery an identity check rather than a structural match on a magic string,
- * so an unrelated store that happens to declare a same-named method is not
- * mistaken for a managed backend.
- *
- * Deliberately NOT a member of `TripleStore` either: putting it on the
- * vendor-neutral interface made it a cross-cutting obligation that every present
- * and future wrapper had to remember, policed by nothing.
- */
-export const MANAGED_READ_GATE_V1: unique symbol = Symbol('dkg.managedReadGate.v1');
 
-export interface ManagedReadGateHostV1 {
-  [MANAGED_READ_GATE_V1](operation: string): void;
-}
-
-/**
- * Recover the managed read gate from anywhere in a decorator chain.
- *
- * The point of resolving rather than forwarding: a wrapper CANNOT silently
- * erase the gate by failing to re-declare it. The previous shape called
- * `store.assertManagedBackendReadableV1?.(…)` on the immediate inner store, and
- * optional chaining treats an absent method as PERMISSION — so one intervening
- * decorator turned a fail-closed read into a fail-open one, and keeping that
- * safe meant every wrapper in every package had to opt in forever.
- *
- * Traversal itself lives in `resolveStoreChainCapabilityV1`, shared with
- * `asGraphWriteGenSource` and `asChangelogReader`. Reusing that convention is
- * the point: wrappers already have to expose their inner store for those two to
- * resolve, so this adds no new obligation on any wrapper.
- *
- * `null` means no managed backend anywhere in the chain, which is the ordinary
- * case for an operator-configured store: such a store is always readable.
- */
-export function asManagedReadGateV1(store: unknown): ManagedReadGateHostV1 | null {
-  return resolveStoreChainCapabilityV1(store, isManagedReadGateHostV1);
-}
-
-function isManagedReadGateHostV1(candidate: unknown): candidate is ManagedReadGateHostV1 {
-  return (
-    typeof (candidate as Partial<ManagedReadGateHostV1>)?.[MANAGED_READ_GATE_V1] === 'function'
-  );
-}

--- a/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
+++ b/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
@@ -417,15 +417,23 @@ export function readManagedOxigraphOwnershipSnapshotV1(
 }
 
 /**
- * A store that can answer "is my backend still proven owned?" without I/O.
+ * The managed read gate, keyed by symbol rather than by method name.
  *
- * Declared by the managed adapter only. This is deliberately NOT a member of
- * `TripleStore`: the read gate is a managed-Oxigraph concern, and putting it on
- * the vendor-neutral interface made it a cross-cutting obligation every present
+ * Symbol-keyed for two reasons the review drew out. It keeps a managed-Oxigraph
+ * lease concern OFF the public surface of `SparqlHttpStore`, which is a general
+ * SPARQL-over-HTTP adapter and has no business advertising one; and it makes
+ * discovery an identity check rather than a structural match on a magic string,
+ * so an unrelated store that happens to declare a same-named method is not
+ * mistaken for a managed backend.
+ *
+ * Deliberately NOT a member of `TripleStore` either: putting it on the
+ * vendor-neutral interface made it a cross-cutting obligation that every present
  * and future wrapper had to remember, policed by nothing.
  */
+export const MANAGED_READ_GATE_V1: unique symbol = Symbol('dkg.managedReadGate.v1');
+
 export interface ManagedReadGateHostV1 {
-  assertManagedBackendReadableV1(operation: string): void;
+  [MANAGED_READ_GATE_V1](operation: string): void;
 }
 
 /**
@@ -452,7 +460,6 @@ export function asManagedReadGateV1(store: unknown): ManagedReadGateHostV1 | nul
 
 function isManagedReadGateHostV1(candidate: unknown): candidate is ManagedReadGateHostV1 {
   return (
-    typeof (candidate as Partial<ManagedReadGateHostV1>)?.assertManagedBackendReadableV1 ===
-    'function'
+    typeof (candidate as Partial<ManagedReadGateHostV1>)?.[MANAGED_READ_GATE_V1] === 'function'
   );
 }

--- a/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
+++ b/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
@@ -35,6 +35,8 @@
  * obtains the lease still cannot extend or revive it, failing (3).
  */
 
+import { resolveStoreChainCapabilityV1 } from './store-chain-capability.js';
+
 /** Opaque, non-inspectable lease handle. Compare by identity only. */
 declare const MANAGED_OXIGRAPH_LEASE_BRAND: unique symbol;
 export type ManagedOxigraphOwnershipLeaseV1 = {
@@ -436,24 +438,19 @@ export interface ManagedReadGateHostV1 {
  * decorator turned a fail-closed read into a fail-open one, and keeping that
  * safe meant every wrapper in every package had to opt in forever.
  *
- * Mirrors `asGraphWriteGenSource` / `asChangelogReader` exactly, including the
- * `.innerStore ?? .inner` walk — `inner` is TypeScript-private on the storage
- * decorators but present at runtime — and the depth bound against a cyclic
- * chain. Reusing that convention is the point: wrappers already have to expose
- * their inner store for the changelog and write-gen capabilities to resolve, so
- * this adds no new obligation.
+ * Traversal itself lives in `resolveStoreChainCapabilityV1`, shared with
+ * `asGraphWriteGenSource` and `asChangelogReader`. Reusing that convention is
+ * the point: wrappers already have to expose their inner store for those two to
+ * resolve, so this adds no new obligation on any wrapper.
  *
  * `null` means no managed backend anywhere in the chain, which is the ordinary
  * case for an operator-configured store: such a store is always readable.
  */
 export function asManagedReadGateV1(store: unknown): ManagedReadGateHostV1 | null {
-  let s = store as
-    | { assertManagedBackendReadableV1?: unknown; innerStore?: unknown; inner?: unknown }
-    | null
-    | undefined;
-  for (let depth = 0; s && depth < 8; depth++) {
-    if (typeof s.assertManagedBackendReadableV1 === 'function') return s as ManagedReadGateHostV1;
-    s = (s.innerStore ?? s.inner) as typeof s;
-  }
-  return null;
+  return resolveStoreChainCapabilityV1<ManagedReadGateHostV1>(
+    store,
+    (candidate) =>
+      typeof (candidate as Partial<ManagedReadGateHostV1>).assertManagedBackendReadableV1 ===
+      'function',
+  );
 }

--- a/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
+++ b/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
@@ -447,10 +447,12 @@ export interface ManagedReadGateHostV1 {
  * case for an operator-configured store: such a store is always readable.
  */
 export function asManagedReadGateV1(store: unknown): ManagedReadGateHostV1 | null {
-  return resolveStoreChainCapabilityV1<ManagedReadGateHostV1>(
-    store,
-    (candidate) =>
-      typeof (candidate as Partial<ManagedReadGateHostV1>).assertManagedBackendReadableV1 ===
-      'function',
+  return resolveStoreChainCapabilityV1(store, isManagedReadGateHostV1);
+}
+
+function isManagedReadGateHostV1(candidate: unknown): candidate is ManagedReadGateHostV1 {
+  return (
+    typeof (candidate as Partial<ManagedReadGateHostV1>)?.assertManagedBackendReadableV1 ===
+    'function'
   );
 }

--- a/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
+++ b/packages/storage/src/managed-oxigraph-ownership-v1-internal.ts
@@ -413,3 +413,47 @@ export function readManagedOxigraphOwnershipSnapshotV1(
   if (!current) return null;
   return snapshotLeaseState(current);
 }
+
+/**
+ * A store that can answer "is my backend still proven owned?" without I/O.
+ *
+ * Declared by the managed adapter only. This is deliberately NOT a member of
+ * `TripleStore`: the read gate is a managed-Oxigraph concern, and putting it on
+ * the vendor-neutral interface made it a cross-cutting obligation every present
+ * and future wrapper had to remember, policed by nothing.
+ */
+export interface ManagedReadGateHostV1 {
+  assertManagedBackendReadableV1(operation: string): void;
+}
+
+/**
+ * Recover the managed read gate from anywhere in a decorator chain.
+ *
+ * The point of resolving rather than forwarding: a wrapper CANNOT silently
+ * erase the gate by failing to re-declare it. The previous shape called
+ * `store.assertManagedBackendReadableV1?.(…)` on the immediate inner store, and
+ * optional chaining treats an absent method as PERMISSION — so one intervening
+ * decorator turned a fail-closed read into a fail-open one, and keeping that
+ * safe meant every wrapper in every package had to opt in forever.
+ *
+ * Mirrors `asGraphWriteGenSource` / `asChangelogReader` exactly, including the
+ * `.innerStore ?? .inner` walk — `inner` is TypeScript-private on the storage
+ * decorators but present at runtime — and the depth bound against a cyclic
+ * chain. Reusing that convention is the point: wrappers already have to expose
+ * their inner store for the changelog and write-gen capabilities to resolve, so
+ * this adds no new obligation.
+ *
+ * `null` means no managed backend anywhere in the chain, which is the ordinary
+ * case for an operator-configured store: such a store is always readable.
+ */
+export function asManagedReadGateV1(store: unknown): ManagedReadGateHostV1 | null {
+  let s = store as
+    | { assertManagedBackendReadableV1?: unknown; innerStore?: unknown; inner?: unknown }
+    | null
+    | undefined;
+  for (let depth = 0; s && depth < 8; depth++) {
+    if (typeof s.assertManagedBackendReadableV1 === 'function') return s as ManagedReadGateHostV1;
+    s = (s.innerStore ?? s.inner) as typeof s;
+  }
+  return null;
+}

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { STORE_CHAIN_INNER } from './store-chain-capability.js';
 import type { SystemRecordLaneControllerV1 } from './system-record-materializer-v1.js';
 import type {
   ConstructResult,
@@ -62,7 +63,18 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return this.inner.getSystemRecordLaneControllerV1?.();
   }
 
+  /**
+   * Pre-existing public handle, kept because callers already use it. New
+   * wrappers should declare {@link STORE_CHAIN_INNER} instead — that is how a
+   * decorator opts into capability discovery without publishing its inner store.
+   */
   readonly innerStore: TripleStore;
+
+  /** The canonical traversal contract — see `store-chain-capability.ts`. */
+  get [STORE_CHAIN_INNER](): TripleStore {
+    return this.inner;
+  }
+
   private readonly inner: TripleStore;
   private readonly blobDir: string;
   private readonly thresholdBytes: number;

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -62,6 +62,20 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return this.inner.getSystemRecordLaneControllerV1?.();
   }
 
+  /**
+   * Pass-through for the managed read gate (#2052).
+   *
+   * This decorator owns no cached read state, so it has nothing of its own to
+   * refuse — but it MUST forward, because the caller above it uses optional
+   * chaining and optional chaining treats an absent method as PERMISSION. With
+   * this missing, `GraphSetIndexStore(SharedMemoryLiteralBlobStore(adapter))`
+   * served its warm graph set for the whole revalidation window after the lease
+   * was lost: the guard evaporated here, one layer short of the snapshot.
+   */
+  assertManagedBackendReadableV1(operation: string): void {
+    this.inner.assertManagedBackendReadableV1?.(operation);
+  }
+
   readonly innerStore: TripleStore;
   private readonly inner: TripleStore;
   private readonly blobDir: string;

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -62,20 +62,6 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return this.inner.getSystemRecordLaneControllerV1?.();
   }
 
-  /**
-   * Pass-through for the managed read gate (#2052).
-   *
-   * This decorator owns no cached read state, so it has nothing of its own to
-   * refuse — but it MUST forward, because the caller above it uses optional
-   * chaining and optional chaining treats an absent method as PERMISSION. With
-   * this missing, `GraphSetIndexStore(SharedMemoryLiteralBlobStore(adapter))`
-   * served its warm graph set for the whole revalidation window after the lease
-   * was lost: the guard evaporated here, one layer short of the snapshot.
-   */
-  assertManagedBackendReadableV1(operation: string): void {
-    this.inner.assertManagedBackendReadableV1?.(operation);
-  }
-
   readonly innerStore: TripleStore;
   private readonly inner: TripleStore;
   private readonly blobDir: string;

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { STORE_CHAIN_INNER } from './store-chain-capability.js';
+import { linkStoreChainV1 } from './store-chain-capability.js';
 import type { SystemRecordLaneControllerV1 } from './system-record-materializer-v1.js';
 import type {
   ConstructResult,
@@ -65,15 +65,11 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
 
   /**
    * Pre-existing public handle, kept because callers already use it. New
-   * wrappers should declare {@link STORE_CHAIN_INNER} instead — that is how a
-   * decorator opts into capability discovery without publishing its inner store.
+   * wrappers should register with {@link linkStoreChainV1} instead — that is how
+   * a decorator opts into capability discovery without publishing its inner store.
    */
   readonly innerStore: TripleStore;
 
-  /** The canonical traversal contract — see `store-chain-capability.ts`. */
-  get [STORE_CHAIN_INNER](): TripleStore {
-    return this.inner;
-  }
 
   private readonly inner: TripleStore;
   private readonly blobDir: string;
@@ -89,6 +85,7 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     }
     this.inner = inner;
     this.innerStore = inner;
+    linkStoreChainV1(this, inner);
     this.blobDir = options.blobDir;
     this.thresholdBytes = options.thresholdBytes;
   }

--- a/packages/storage/src/store-chain-capability.ts
+++ b/packages/storage/src/store-chain-capability.ts
@@ -11,45 +11,47 @@
  *
  * ## How a decorator becomes traversable
  *
- * In preference order:
+ * It REGISTERS, via {@link linkStoreChainV1}. The link lives in a module-private
+ * `WeakMap` keyed by wrapper identity, mirroring how the ownership lease in
+ * `managed-oxigraph-ownership-v1-internal.ts` keeps its authority table: the
+ * registration function grants the caller nothing: it writes a link, it does not
+ * read one, and nothing exported from this module can retrieve the wrapped store.
  *
- * 1. `[STORE_CHAIN_INNER]` — the intentional mechanism. A symbol-keyed getter,
- *    so a decorator declares "capability discovery may pass through me" WITHOUT
- *    publishing its wrapped store. That distinction is the point: a public
- *    `innerStore` on an index or changelog decorator is an architectural escape
- *    hatch, because `store.innerStore.insert(...)` bypasses the very index
- *    maintenance and change-marker recording the wrapper exists to enforce.
- *    The symbol is not exported from the package barrel.
+ * That is the whole reason it is not a symbol-keyed getter. An earlier revision
+ * used one and exported the symbol so first-party wrappers in other packages
+ * could declare it — which made the getter public API and handed every consumer
+ * an invariant bypass: `store[STORE_CHAIN_INNER].insert(...)` skips changelog
+ * markers and graph-set index maintenance exactly as `store.innerStore.insert(...)`
+ * would. Publishing a hidden handle is still publishing the handle.
  *
- * 2. `.innerStore` — the pre-existing public convention, honoured because
- *    wrappers already rely on it: `SharedMemoryLiteralBlobStore` and the
- *    agent's hand-rolled forwarder both expose it, and `asChangelogReader` has
- *    always walked it.
+ * `.innerStore` remains honoured because it is a genuine pre-existing PUBLIC
+ * property on `SharedMemoryLiteralBlobStore` and the agent's forwarder, and
+ * removing it from the walk would silently break capability discovery for any
+ * out-of-repo wrapper built on it. First-party wrappers no longer depend on it —
+ * a test resolves the whole storage chain through the registry alone.
  *
- * 3. `.inner` — LEGACY COMPATIBILITY, not a convention to build on. It reaches
- *    a TypeScript-private field at runtime. An earlier revision of this module
- *    dropped it as unnecessary; that was wrong, and the test that proved it
- *    wrong (`graph-write-gen.test.ts`, `asGraphWriteGenSource({ innerStore: {
- *    inner: store } })`) was not in the workflow lane used to check the change.
- *    `asGraphWriteGenSource` has followed `.inner` since it was written, and
- *    removing it silently returns `null`, which its callers treat as "no
- *    write-generation support" and fall back to expensive full scans. New code
- *    should use the symbol.
+ * `.inner` is NOT walked here. Reaching a TypeScript-private field made any
+ * wrapper with an incidentally-named property an accidental opt-in to capability
+ * discovery. It survives only in {@link resolveStoreChainCapabilityLegacyV1},
+ * used by the single capability whose checked-in contract asserts it.
  */
+
+/** wrapper -> wrapped store. Module-private: registration is write-only to callers. */
+const CHAIN_LINKS = new WeakMap<object, unknown>();
 
 /**
- * Symbol-keyed accessor for the wrapped store.
+ * Declare that capability discovery may pass through `wrapper` to `inner`.
  *
- * Deliberately not on `TripleStore` and not exported from the barrel: this is
- * how a decorator opts into traversal without widening its public surface.
+ * Call once, from a decorator's constructor. Grants the caller no ability to
+ * read any wrapped store, including its own — this is the whole point.
  */
-export const STORE_CHAIN_INNER: unique symbol = Symbol('dkg.storeChainInner.v1');
+export function linkStoreChainV1(wrapper: object, inner: unknown): void {
+  CHAIN_LINKS.set(wrapper, inner);
+}
 
 export interface StoreChainNodeV1 {
-  readonly [STORE_CHAIN_INNER]?: unknown;
+  /** Pre-existing public convention. Prefer {@link linkStoreChainV1}. */
   readonly innerStore?: unknown;
-  /** @deprecated Legacy shape; declare {@link STORE_CHAIN_INNER} instead. */
-  readonly inner?: unknown;
 }
 
 /** A store chain that loops — a broken object graph, never a normal absence. */
@@ -62,8 +64,30 @@ export class StoreChainCycleError extends Error {
   }
 }
 
-const nextInChain = (node: StoreChainNodeV1): unknown =>
-  node[STORE_CHAIN_INNER] ?? node.innerStore ?? node.inner;
+type NextInChain = (node: object) => unknown;
+
+const registeredOrPublic: NextInChain = (node) =>
+  CHAIN_LINKS.get(node) ?? (node as StoreChainNodeV1).innerStore;
+
+/** Adds the TS-private `.inner` reach. Quarantined — see the module doc. */
+const registeredOrPublicOrLegacyInner: NextInChain = (node) =>
+  registeredOrPublic(node) ?? (node as { inner?: unknown }).inner;
+
+function walk<T>(
+  store: unknown,
+  isCapable: (candidate: unknown) => candidate is T,
+  next: NextInChain,
+): T | null {
+  const seen = new Set<unknown>();
+  let node = store as object | null | undefined;
+  while (node !== null && node !== undefined) {
+    if (isCapable(node)) return node;
+    if (seen.has(node)) throw new StoreChainCycleError();
+    seen.add(node);
+    node = next(node) as object | null | undefined;
+  }
+  return null;
+}
 
 /**
  * Walk `store` and its inner stores, returning the first node for which
@@ -71,29 +95,38 @@ const nextInChain = (node: StoreChainNodeV1): unknown =>
  *
  * `isCapable` is a TYPE PREDICATE, not a boolean: the helper returns the node
  * as-is with no cast, so the narrowing a caller gets is exactly the one its own
- * guard proved. An earlier draft took `(candidate: object) => boolean` and cast
- * to a caller-chosen `T`, which let a partial check mint a fully typed
- * capability.
+ * guard proved.
  *
  * `null` means ONE thing: the chain ended and no node had the capability. It
  * does not also mean "traversal gave up". An earlier draft used a depth cap of
  * 8, which silently returned `null` for a legitimately deeper chain — and for
- * the managed read gate that reads as "unleased store", i.e. fail-OPEN, which
- * is the exact failure this whole change exists to prevent. Termination is now
- * by object identity, so depth is unbounded and the only non-terminating shape
- * — a genuine cycle — THROWS rather than being reported as absence.
+ * the managed read gate that reads as "unleased store", i.e. fail-OPEN, which is
+ * the exact failure this change exists to prevent. Termination is by object
+ * identity, so depth is unbounded and the only non-terminating shape — a genuine
+ * cycle — THROWS rather than being reported as absence.
  */
 export function resolveStoreChainCapabilityV1<T>(
   store: unknown,
   isCapable: (candidate: unknown) => candidate is T,
 ): T | null {
-  const seen = new Set<unknown>();
-  let node = store as StoreChainNodeV1 | null | undefined;
-  while (node !== null && node !== undefined) {
-    if (isCapable(node)) return node;
-    if (seen.has(node)) throw new StoreChainCycleError();
-    seen.add(node);
-    node = nextInChain(node) as StoreChainNodeV1 | null | undefined;
-  }
-  return null;
+  return walk(store, isCapable, registeredOrPublic);
+}
+
+/**
+ * As {@link resolveStoreChainCapabilityV1}, but also follows a TS-private
+ * `.inner`.
+ *
+ * COMPATIBILITY ONLY, for `asGraphWriteGenSource`, whose checked-in contract
+ * asserts `asGraphWriteGenSource({ innerStore: { inner: store } })` resolves
+ * (`graph-write-gen.test.ts`). Removing that reach once already regressed it
+ * silently: its callers fail open on `null` and fall back to expensive full
+ * scans, so nothing announces the loss.
+ *
+ * Do not use for new capabilities. Register with {@link linkStoreChainV1}.
+ */
+export function resolveStoreChainCapabilityLegacyV1<T>(
+  store: unknown,
+  isCapable: (candidate: unknown) => candidate is T,
+): T | null {
+  return walk(store, isCapable, registeredOrPublicOrLegacyInner);
 }

--- a/packages/storage/src/store-chain-capability.ts
+++ b/packages/storage/src/store-chain-capability.ts
@@ -5,51 +5,58 @@
  * the changelog reader, the write-generation source, and the managed read gate
  * — and each had grown its own copy of the traversal. The copies had already
  * DIVERGED: `asChangelogReader` followed only `.innerStore`, while the other
- * two also followed `.inner`. A capability that could not be found through a
- * given wrapper simply resolved to `null`, which every caller treats as "this
- * store does not have it" — so a traversal gap is silent by construction.
+ * two also followed a TypeScript-private `.inner`. A capability that cannot be
+ * found through a given wrapper simply resolves to `null`, and every caller
+ * reads `null` as "this store does not have it" — so a traversal gap is silent
+ * by construction.
  *
- * Consolidating means wrapper shape, the legacy field fallback and the cycle
- * bound are decided once, and a new capability inherits all of it.
- *
- * ## The convention
+ * ## The contract
  *
  * A decorator exposes its inner store as a PUBLIC `readonly innerStore`. That
- * is the contract; every decorator in this package and the agent's hand-rolled
- * forwarder now satisfy it.
+ * is the whole contract, and every decorator in this package plus the agent's
+ * hand-rolled forwarder satisfies it.
  *
- * `.inner` remains a fallback only because it is what two of these walkers
- * already relied on, and dropping it would silently narrow discovery for any
- * wrapper outside this repo that copied the older shape. It reaches a
- * TypeScript-private field — legal at runtime, but not something new code
- * should depend on. Prefer `innerStore`.
+ * The `.inner` fallback the two older walkers carried is deliberately NOT here.
+ * It only ever worked by reaching a TypeScript-private field at runtime, it was
+ * never a documented convention, and it made any object with an incidental
+ * `inner` property part of capability discovery. It is also now unnecessary:
+ * `GraphSetIndexStore` and `ChangelogStore` expose `innerStore`, which is
+ * exactly the set of wrappers `.inner` existed to cross. Verified rather than
+ * assumed — the full storage lane passes with `innerStore` alone.
  */
 
 /** Bound against a pathological or cyclic chain. */
 const MAX_STORE_CHAIN_DEPTH = 8;
 
-interface StoreChainNode {
+/** The one field a decorator must expose to be transparent to capability discovery. */
+export interface StoreChainNodeV1 {
   readonly innerStore?: unknown;
-  readonly inner?: unknown;
 }
 
 /**
- * Walk `store` and its inner stores, returning the first node satisfying
- * `isCapable`, or `null` when the chain ends without one.
+ * Walk `store` and its inner stores, returning the first node for which
+ * `isCapable` holds, or `null` when the chain ends without one.
  *
- * `null` means "no store in this chain has the capability". Callers must decide
- * what that implies: for the managed read gate it means there is no managed
- * backend and reads are unrestricted; for the write-gen source it means callers
- * must fail open and always scan.
+ * `isCapable` is a TYPE PREDICATE, not a boolean: the helper returns the node
+ * as-is with no cast, so the narrowing a caller gets is exactly the one its own
+ * guard proved. An earlier draft took `(candidate: object) => boolean` and cast
+ * the result to a caller-chosen `T`, which let a partial check mint a fully
+ * typed capability — the wrong shape for a primitive whose entire purpose is
+ * making decorator-chain capabilities safer.
+ *
+ * `null` means "no store in this chain has the capability", and callers must
+ * decide what that implies: for the managed read gate it means there is no
+ * managed backend, so reads are unrestricted; for the write-gen source it means
+ * callers must fail open and always scan.
  */
 export function resolveStoreChainCapabilityV1<T>(
   store: unknown,
-  isCapable: (candidate: object) => boolean,
+  isCapable: (candidate: unknown) => candidate is T,
 ): T | null {
-  let node = store as StoreChainNode | null | undefined;
+  let node = store as StoreChainNodeV1 | null | undefined;
   for (let depth = 0; node && depth < MAX_STORE_CHAIN_DEPTH; depth++) {
-    if (typeof node === 'object' && isCapable(node)) return node as T;
-    node = (node.innerStore ?? node.inner) as StoreChainNode | null | undefined;
+    if (isCapable(node)) return node;
+    node = node.innerStore as StoreChainNodeV1 | null | undefined;
   }
   return null;
 }

--- a/packages/storage/src/store-chain-capability.ts
+++ b/packages/storage/src/store-chain-capability.ts
@@ -1,56 +1,52 @@
 /**
- * One canonical walk over a `TripleStore` decorator chain.
+ * One walk over a `TripleStore` decorator chain, shared by every capability
+ * that must find the store actually implementing it.
  *
- * Three capabilities need to find the store that actually implements them —
- * the changelog reader, the write-generation source, and the managed read gate
- * — and each had grown its own copy of the traversal. The copies had already
- * DIVERGED: `asChangelogReader` followed only `.innerStore`, while the other
- * two also followed `.inner`. A capability that cannot be found through a given
- * wrapper resolves to `null`, and every caller reads `null` as "this store does
- * not have it" — so a traversal gap is silent by construction.
+ * ## Traversal
  *
- * ## How a decorator becomes traversable
+ * From the outermost store inward, taking the first node that satisfies the
+ * caller's guard. A node's inner store is found by, in order:
  *
- * It REGISTERS, via {@link linkStoreChainV1}. The link lives in a module-private
- * `WeakMap` keyed by wrapper identity, mirroring how the ownership lease in
- * `managed-oxigraph-ownership-v1-internal.ts` keeps its authority table: the
- * registration function grants the caller nothing: it writes a link, it does not
- * read one, and nothing exported from this module can retrieve the wrapped store.
+ * 1. a link recorded via {@link linkStoreChainV1} — how this package's own
+ *    decorators opt in, without exposing the store they wrap;
+ * 2. a public `innerStore` property — the convention wrappers outside this
+ *    package use;
+ * 3. a `inner` property — {@link resolveStoreChainCapabilityLegacyV1} only.
  *
- * That is the whole reason it is not a symbol-keyed getter. An earlier revision
- * used one and exported the symbol so first-party wrappers in other packages
- * could declare it — which made the getter public API and handed every consumer
- * an invariant bypass: `store[STORE_CHAIN_INNER].insert(...)` skips changelog
- * markers and graph-set index maintenance exactly as `store.innerStore.insert(...)`
- * would. Publishing a hidden handle is still publishing the handle.
+ * ## What the result means
  *
- * `.innerStore` remains honoured because it is a genuine pre-existing PUBLIC
- * property on `SharedMemoryLiteralBlobStore` and the agent's forwarder, and
- * removing it from the walk would silently break capability discovery for any
- * out-of-repo wrapper built on it. First-party wrappers no longer depend on it —
- * a test resolves the whole storage chain through the registry alone.
+ * `null` means the chain ended with no node holding the capability. It never
+ * means traversal gave up: there is no depth limit, and the one shape that
+ * cannot terminate — a cycle — throws {@link StoreChainCycleError}.
  *
- * `.inner` is NOT walked here. Reaching a TypeScript-private field made any
- * wrapper with an incidentally-named property an accidental opt-in to capability
- * discovery. It survives only in {@link resolveStoreChainCapabilityLegacyV1},
- * used by the single capability whose checked-in contract asserts it.
+ * That distinction is load-bearing. Callers treat `null` as "no such
+ * capability", and for a safety capability such as the cached-read gate that
+ * reads as "unconstrained" — so a traversal failure reported as `null` would
+ * fail OPEN.
+ *
+ * ## Adding a capability
+ *
+ * Use {@link resolveStoreChainCapabilityV1} with a type predicate. Prefer a
+ * symbol-keyed member so discovery is an identity check rather than a
+ * structural match on a method name.
  */
 
-/** wrapper -> wrapped store. Module-private: registration is write-only to callers. */
+/** wrapper -> wrapped store. Module-private, so registration cannot be read back. */
 const CHAIN_LINKS = new WeakMap<object, unknown>();
 
 /**
- * Declare that capability discovery may pass through `wrapper` to `inner`.
+ * Record that capability discovery may pass through `wrapper` to `inner`.
  *
- * Call once, from a decorator's constructor. Grants the caller no ability to
- * read any wrapped store, including its own — this is the whole point.
+ * Call once from a decorator's constructor. Deliberately write-only: it exposes
+ * no way to read a wrapped store, so it cannot become a route around the
+ * decorator's own invariants the way a public `innerStore` can.
  */
 export function linkStoreChainV1(wrapper: object, inner: unknown): void {
   CHAIN_LINKS.set(wrapper, inner);
 }
 
 export interface StoreChainNodeV1 {
-  /** Pre-existing public convention. Prefer {@link linkStoreChainV1}. */
+  /** Public convention for wrappers outside this package. */
   readonly innerStore?: unknown;
 }
 
@@ -69,7 +65,6 @@ type NextInChain = (node: object) => unknown;
 const registeredOrPublic: NextInChain = (node) =>
   CHAIN_LINKS.get(node) ?? (node as StoreChainNodeV1).innerStore;
 
-/** Adds the TS-private `.inner` reach. Quarantined — see the module doc. */
 const registeredOrPublicOrLegacyInner: NextInChain = (node) =>
   registeredOrPublic(node) ?? (node as { inner?: unknown }).inner;
 
@@ -90,20 +85,10 @@ function walk<T>(
 }
 
 /**
- * Walk `store` and its inner stores, returning the first node for which
- * `isCapable` holds, or `null` when the chain ends without one.
+ * Find the first store in `store`'s chain satisfying `isCapable`, or `null`.
  *
- * `isCapable` is a TYPE PREDICATE, not a boolean: the helper returns the node
- * as-is with no cast, so the narrowing a caller gets is exactly the one its own
- * guard proved.
- *
- * `null` means ONE thing: the chain ended and no node had the capability. It
- * does not also mean "traversal gave up". An earlier draft used a depth cap of
- * 8, which silently returned `null` for a legitimately deeper chain — and for
- * the managed read gate that reads as "unleased store", i.e. fail-OPEN, which is
- * the exact failure this change exists to prevent. Termination is by object
- * identity, so depth is unbounded and the only non-terminating shape — a genuine
- * cycle — THROWS rather than being reported as absence.
+ * `isCapable` is a type predicate and the node is returned unchanged, so the
+ * narrowing a caller gets is exactly the one its own guard proved.
  */
 export function resolveStoreChainCapabilityV1<T>(
   store: unknown,
@@ -113,16 +98,12 @@ export function resolveStoreChainCapabilityV1<T>(
 }
 
 /**
- * As {@link resolveStoreChainCapabilityV1}, but also follows a TS-private
- * `.inner`.
+ * As {@link resolveStoreChainCapabilityV1}, but also follows a `inner` property.
  *
- * COMPATIBILITY ONLY, for `asGraphWriteGenSource`, whose checked-in contract
- * asserts `asGraphWriteGenSource({ innerStore: { inner: store } })` resolves
- * (`graph-write-gen.test.ts`). Removing that reach once already regressed it
- * silently: its callers fail open on `null` and fall back to expensive full
- * scans, so nothing announces the loss.
- *
- * Do not use for new capabilities. Register with {@link linkStoreChainV1}.
+ * Compatibility only, for `asGraphWriteGenSource`, whose published contract
+ * covers wrappers exposing `inner` alone. Not for new capabilities: reaching an
+ * arbitrarily-named property makes any object with that field an accidental
+ * participant in discovery.
  */
 export function resolveStoreChainCapabilityLegacyV1<T>(
   store: unknown,

--- a/packages/storage/src/store-chain-capability.ts
+++ b/packages/storage/src/store-chain-capability.ts
@@ -1,0 +1,55 @@
+/**
+ * One canonical walk over a `TripleStore` decorator chain.
+ *
+ * Three capabilities need to find the store that actually implements them —
+ * the changelog reader, the write-generation source, and the managed read gate
+ * — and each had grown its own copy of the traversal. The copies had already
+ * DIVERGED: `asChangelogReader` followed only `.innerStore`, while the other
+ * two also followed `.inner`. A capability that could not be found through a
+ * given wrapper simply resolved to `null`, which every caller treats as "this
+ * store does not have it" — so a traversal gap is silent by construction.
+ *
+ * Consolidating means wrapper shape, the legacy field fallback and the cycle
+ * bound are decided once, and a new capability inherits all of it.
+ *
+ * ## The convention
+ *
+ * A decorator exposes its inner store as a PUBLIC `readonly innerStore`. That
+ * is the contract; every decorator in this package and the agent's hand-rolled
+ * forwarder now satisfy it.
+ *
+ * `.inner` remains a fallback only because it is what two of these walkers
+ * already relied on, and dropping it would silently narrow discovery for any
+ * wrapper outside this repo that copied the older shape. It reaches a
+ * TypeScript-private field — legal at runtime, but not something new code
+ * should depend on. Prefer `innerStore`.
+ */
+
+/** Bound against a pathological or cyclic chain. */
+const MAX_STORE_CHAIN_DEPTH = 8;
+
+interface StoreChainNode {
+  readonly innerStore?: unknown;
+  readonly inner?: unknown;
+}
+
+/**
+ * Walk `store` and its inner stores, returning the first node satisfying
+ * `isCapable`, or `null` when the chain ends without one.
+ *
+ * `null` means "no store in this chain has the capability". Callers must decide
+ * what that implies: for the managed read gate it means there is no managed
+ * backend and reads are unrestricted; for the write-gen source it means callers
+ * must fail open and always scan.
+ */
+export function resolveStoreChainCapabilityV1<T>(
+  store: unknown,
+  isCapable: (candidate: object) => boolean,
+): T | null {
+  let node = store as StoreChainNode | null | undefined;
+  for (let depth = 0; node && depth < MAX_STORE_CHAIN_DEPTH; depth++) {
+    if (typeof node === 'object' && isCapable(node)) return node as T;
+    node = (node.innerStore ?? node.inner) as StoreChainNode | null | undefined;
+  }
+  return null;
+}

--- a/packages/storage/src/store-chain-capability.ts
+++ b/packages/storage/src/store-chain-capability.ts
@@ -5,33 +5,65 @@
  * the changelog reader, the write-generation source, and the managed read gate
  * — and each had grown its own copy of the traversal. The copies had already
  * DIVERGED: `asChangelogReader` followed only `.innerStore`, while the other
- * two also followed a TypeScript-private `.inner`. A capability that cannot be
- * found through a given wrapper simply resolves to `null`, and every caller
- * reads `null` as "this store does not have it" — so a traversal gap is silent
- * by construction.
+ * two also followed `.inner`. A capability that cannot be found through a given
+ * wrapper resolves to `null`, and every caller reads `null` as "this store does
+ * not have it" — so a traversal gap is silent by construction.
  *
- * ## The contract
+ * ## How a decorator becomes traversable
  *
- * A decorator exposes its inner store as a PUBLIC `readonly innerStore`. That
- * is the whole contract, and every decorator in this package plus the agent's
- * hand-rolled forwarder satisfies it.
+ * In preference order:
  *
- * The `.inner` fallback the two older walkers carried is deliberately NOT here.
- * It only ever worked by reaching a TypeScript-private field at runtime, it was
- * never a documented convention, and it made any object with an incidental
- * `inner` property part of capability discovery. It is also now unnecessary:
- * `GraphSetIndexStore` and `ChangelogStore` expose `innerStore`, which is
- * exactly the set of wrappers `.inner` existed to cross. Verified rather than
- * assumed — the full storage lane passes with `innerStore` alone.
+ * 1. `[STORE_CHAIN_INNER]` — the intentional mechanism. A symbol-keyed getter,
+ *    so a decorator declares "capability discovery may pass through me" WITHOUT
+ *    publishing its wrapped store. That distinction is the point: a public
+ *    `innerStore` on an index or changelog decorator is an architectural escape
+ *    hatch, because `store.innerStore.insert(...)` bypasses the very index
+ *    maintenance and change-marker recording the wrapper exists to enforce.
+ *    The symbol is not exported from the package barrel.
+ *
+ * 2. `.innerStore` — the pre-existing public convention, honoured because
+ *    wrappers already rely on it: `SharedMemoryLiteralBlobStore` and the
+ *    agent's hand-rolled forwarder both expose it, and `asChangelogReader` has
+ *    always walked it.
+ *
+ * 3. `.inner` — LEGACY COMPATIBILITY, not a convention to build on. It reaches
+ *    a TypeScript-private field at runtime. An earlier revision of this module
+ *    dropped it as unnecessary; that was wrong, and the test that proved it
+ *    wrong (`graph-write-gen.test.ts`, `asGraphWriteGenSource({ innerStore: {
+ *    inner: store } })`) was not in the workflow lane used to check the change.
+ *    `asGraphWriteGenSource` has followed `.inner` since it was written, and
+ *    removing it silently returns `null`, which its callers treat as "no
+ *    write-generation support" and fall back to expensive full scans. New code
+ *    should use the symbol.
  */
 
-/** Bound against a pathological or cyclic chain. */
-const MAX_STORE_CHAIN_DEPTH = 8;
+/**
+ * Symbol-keyed accessor for the wrapped store.
+ *
+ * Deliberately not on `TripleStore` and not exported from the barrel: this is
+ * how a decorator opts into traversal without widening its public surface.
+ */
+export const STORE_CHAIN_INNER: unique symbol = Symbol('dkg.storeChainInner.v1');
 
-/** The one field a decorator must expose to be transparent to capability discovery. */
 export interface StoreChainNodeV1 {
+  readonly [STORE_CHAIN_INNER]?: unknown;
   readonly innerStore?: unknown;
+  /** @deprecated Legacy shape; declare {@link STORE_CHAIN_INNER} instead. */
+  readonly inner?: unknown;
 }
+
+/** A store chain that loops — a broken object graph, never a normal absence. */
+export class StoreChainCycleError extends Error {
+  readonly code = 'STORE_CHAIN_CYCLE' as const;
+
+  constructor() {
+    super('TripleStore decorator chain contains a cycle; capability discovery cannot complete');
+    this.name = 'StoreChainCycleError';
+  }
+}
+
+const nextInChain = (node: StoreChainNodeV1): unknown =>
+  node[STORE_CHAIN_INNER] ?? node.innerStore ?? node.inner;
 
 /**
  * Walk `store` and its inner stores, returning the first node for which
@@ -40,23 +72,28 @@ export interface StoreChainNodeV1 {
  * `isCapable` is a TYPE PREDICATE, not a boolean: the helper returns the node
  * as-is with no cast, so the narrowing a caller gets is exactly the one its own
  * guard proved. An earlier draft took `(candidate: object) => boolean` and cast
- * the result to a caller-chosen `T`, which let a partial check mint a fully
- * typed capability — the wrong shape for a primitive whose entire purpose is
- * making decorator-chain capabilities safer.
+ * to a caller-chosen `T`, which let a partial check mint a fully typed
+ * capability.
  *
- * `null` means "no store in this chain has the capability", and callers must
- * decide what that implies: for the managed read gate it means there is no
- * managed backend, so reads are unrestricted; for the write-gen source it means
- * callers must fail open and always scan.
+ * `null` means ONE thing: the chain ended and no node had the capability. It
+ * does not also mean "traversal gave up". An earlier draft used a depth cap of
+ * 8, which silently returned `null` for a legitimately deeper chain — and for
+ * the managed read gate that reads as "unleased store", i.e. fail-OPEN, which
+ * is the exact failure this whole change exists to prevent. Termination is now
+ * by object identity, so depth is unbounded and the only non-terminating shape
+ * — a genuine cycle — THROWS rather than being reported as absence.
  */
 export function resolveStoreChainCapabilityV1<T>(
   store: unknown,
   isCapable: (candidate: unknown) => candidate is T,
 ): T | null {
+  const seen = new Set<unknown>();
   let node = store as StoreChainNodeV1 | null | undefined;
-  for (let depth = 0; node && depth < MAX_STORE_CHAIN_DEPTH; depth++) {
+  while (node !== null && node !== undefined) {
     if (isCapable(node)) return node;
-    node = node.innerStore as StoreChainNodeV1 | null | undefined;
+    if (seen.has(node)) throw new StoreChainCycleError();
+    seen.add(node);
+    node = nextInChain(node) as StoreChainNodeV1 | null | undefined;
   }
   return null;
 }

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -137,6 +137,20 @@ export interface TripleStore {
    */
   getSystemRecordLaneControllerV1?(): SystemRecordLaneControllerV1 | undefined;
 
+  /**
+   * Throw `ManagedOxigraphBackendUnownedError` if this store's backend is no
+   * longer proven owned. No I/O — a lease-snapshot read.
+   *
+   * Exists for CACHING decorators. A decorator that answers a read from warm
+   * state never reaches the ownership checks on `query`/`update`, so without
+   * this it keeps serving data attributed to a backend the node may no longer
+   * own — for a whole cache window. Any wrapper that can return a read without
+   * delegating downward must call this first; see `GraphSetIndexStore`.
+   *
+   * Absent on stores with no ownership lease, which are always readable.
+   */
+  assertManagedBackendReadableV1?(operation: string): void;
+
   insert(quads: Quad[], options?: QueryOptions): Promise<void>;
   delete(quads: Quad[], options?: QueryOptions): Promise<void>;
   deleteByPattern(pattern: Partial<Quad>, options?: QueryOptions): Promise<number>;

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -137,20 +137,6 @@ export interface TripleStore {
    */
   getSystemRecordLaneControllerV1?(): SystemRecordLaneControllerV1 | undefined;
 
-  /**
-   * Throw `ManagedOxigraphBackendUnownedError` if this store's backend is no
-   * longer proven owned. No I/O — a lease-snapshot read.
-   *
-   * Exists for CACHING decorators. A decorator that answers a read from warm
-   * state never reaches the ownership checks on `query`/`update`, so without
-   * this it keeps serving data attributed to a backend the node may no longer
-   * own — for a whole cache window. Any wrapper that can return a read without
-   * delegating downward must call this first; see `GraphSetIndexStore`.
-   *
-   * Absent on stores with no ownership lease, which are always readable.
-   */
-  assertManagedBackendReadableV1?(operation: string): void;
-
   insert(quads: Quad[], options?: QueryOptions): Promise<void>;
   delete(quads: Quad[], options?: QueryOptions): Promise<void>;
   deleteByPattern(pattern: Partial<Quad>, options?: QueryOptions): Promise<number>;

--- a/packages/storage/test/managed-backend-ownership-dispatch-v1.test.ts
+++ b/packages/storage/test/managed-backend-ownership-dispatch-v1.test.ts
@@ -202,6 +202,29 @@ describe('managed backend ownership at mutation dispatch', () => {
     await store.close().catch(() => undefined);
   });
 
+  it('refuses listGraphs from the adapter cache after ownership is lost', async () => {
+    // The adapter keeps its OWN warm list for MANAGED_LIST_GRAPHS_CACHE_MS
+    // (30 s), served without touching the endpoint — so it never reached the
+    // read check on `query`, and a lost lease kept answering enumeration from
+    // it for the whole window. Same defect the graph-set decorator had; found
+    // by sweeping the class rather than only the reported instance.
+    const store = await managedStore();
+
+    await store.listGraphs(); // warm it
+    const afterWarm = requests.length;
+    expect(afterWarm).toBeGreaterThan(0);
+
+    ownership.invalidate('port-release-unproven');
+
+    await expect(store.listGraphs()).rejects.toThrow(/not the proven ready listener/);
+    // A cached read would have produced no I/O either, so the refusal is the
+    // load-bearing assertion here; the request count guards against the fix
+    // "working" by accidentally forcing a refresh.
+    expect(requests.length).toBe(afterWarm);
+
+    await store.close().catch(() => undefined);
+  });
+
   it('hides reserved internal graphs from adapter-level hasGraph', async () => {
     // The policy module claims reserved state never enumerates and that "no
     // legitimate iterate-and-drop loop can reach one". That held only for the

--- a/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
+++ b/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
@@ -10,6 +10,7 @@ import {
   ManagedOxigraphBackendUnownedError,
 } from '../src/managed-oxigraph-ownership-v1-internal.js';
 import { SharedMemoryLiteralBlobStore } from '../src/shared-memory-literal-blob-store.js';
+import { StoreChainCycleError } from '../src/store-chain-capability.js';
 import type { TripleStore } from '../src/triple-store.js';
 
 /**
@@ -76,9 +77,11 @@ describe('managed read gate resolves through any wrapper chain', () => {
     expect(asManagedReadGateV1(bare)).toBeNull();
   });
 
-  it('resolves through every storage decorator via public innerStore', () => {
-    // All four wrappers expose a public `readonly innerStore`; traversal no
-    // longer reaches any TypeScript-private field.
+  it('resolves through every storage decorator', () => {
+    // Three different opt-in shapes in one chain: `ChangelogStore` and
+    // `GraphSetIndexStore` expose the symbol accessor (traversable without
+    // publishing their wrapped store), `SharedMemoryLiteralBlobStore` has a
+    // pre-existing public `innerStore`.
     const adapter = managedAdapter();
     const chain = new ChangelogStore(
       new GraphSetIndexStore(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS)),
@@ -137,10 +140,26 @@ describe('managed read gate resolves through any wrapper chain', () => {
     expect(asGraphWriteGenSource(chain)).toBe(adapter);
   });
 
-  it('terminates on a cyclic chain instead of hanging', () => {
+  it('THROWS on a cyclic chain rather than reporting absence', () => {
+    // A cycle is a broken object graph, not "this store has no gate". Reporting
+    // it as `null` would read as an unleased store — fail-OPEN, the exact
+    // failure this whole change exists to prevent. Termination is by object
+    // identity, so there is no depth cap to silently convert a legitimately
+    // deep chain into a false absence either.
     const cyclic: { innerStore?: unknown } = {};
     cyclic.innerStore = cyclic;
-    expect(asManagedReadGateV1(cyclic)).toBeNull();
+
+    expect(() => asManagedReadGateV1(cyclic)).toThrow(StoreChainCycleError);
+  });
+
+  it('resolves through a chain far deeper than any previous depth cap', () => {
+    // The old implementation capped at 8 and returned `null` beyond it. Twenty
+    // transparent forwarders must still resolve.
+    const adapter = managedAdapter();
+    let chain: TripleStore = adapter;
+    for (let i = 0; i < 20; i++) chain = opaqueForwarder(chain);
+
+    expect(asManagedReadGateV1(chain)).toBe(adapter);
   });
 
   it('refuses a WARM read through an opaque forwarder — the end-to-end property', async () => {

--- a/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
+++ b/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
@@ -6,11 +6,15 @@ import { ChangelogStore, asChangelogReader } from '../src/changelog-store.js';
 import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
 import { asGraphWriteGenSource } from '../src/graph-write-gen.js';
 import {
+  MANAGED_READ_GATE_V1,
   asManagedReadGateV1,
   ManagedOxigraphBackendUnownedError,
 } from '../src/managed-oxigraph-ownership-v1-internal.js';
 import { SharedMemoryLiteralBlobStore } from '../src/shared-memory-literal-blob-store.js';
-import { StoreChainCycleError } from '../src/store-chain-capability.js';
+import {
+  STORE_CHAIN_INNER,
+  StoreChainCycleError,
+} from '../src/store-chain-capability.js';
 import type { TripleStore } from '../src/triple-store.js';
 
 /**
@@ -36,7 +40,7 @@ const BLOB_OPTIONS = {
 /** Stands in for the managed adapter: the only thing that declares the gate. */
 const managedAdapter = () => {
   const store = {
-    assertManagedBackendReadableV1: vi.fn(),
+    [MANAGED_READ_GATE_V1]: vi.fn(),
     listGraphs: async () => [],
     query: async () => ({ type: 'boolean' as const, value: true }),
     insert: async () => undefined,
@@ -44,7 +48,7 @@ const managedAdapter = () => {
     close: async () => undefined,
   };
   return store as unknown as TripleStore & {
-    assertManagedBackendReadableV1: ReturnType<typeof vi.fn>;
+    [MANAGED_READ_GATE_V1]: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -140,6 +144,33 @@ describe('managed read gate resolves through any wrapper chain', () => {
     expect(asGraphWriteGenSource(chain)).toBe(adapter);
   });
 
+  it('every first-party storage wrapper is traversable by the SYMBOL alone', () => {
+    // This is the claim that makes STORE_CHAIN_INNER "the" contract rather than
+    // one of three. `innerStore` and `.inner` remain honoured as legacy shapes,
+    // so a wrapper that only had those would still resolve and the ordinary
+    // tests could not tell the difference. Resolving against a walker that
+    // follows ONLY the symbol is what proves first-party code no longer depends
+    // on the legacy paths.
+    const symbolOnly = (store: unknown): unknown => {
+      let node = store as { [STORE_CHAIN_INNER]?: unknown } | null | undefined;
+      for (let depth = 0; node && depth < 32; depth++) {
+        if (typeof (node as Record<symbol, unknown>)[MANAGED_READ_GATE_V1] === 'function') {
+          return node;
+        }
+        node = node[STORE_CHAIN_INNER] as typeof node;
+      }
+      return null;
+    };
+
+    const adapter = managedAdapter();
+    const chain = new ChangelogStore(
+      new GraphSetIndexStore(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS)),
+      { enabled: true },
+    );
+
+    expect(symbolOnly(chain)).toBe(adapter);
+  });
+
   it('THROWS on a cyclic chain rather than reporting absence', () => {
     // A cycle is a broken object graph, not "this store has no gate". Reporting
     // it as `null` would read as an unleased store — fail-OPEN, the exact
@@ -173,7 +204,7 @@ describe('managed read gate resolves through any wrapper chain', () => {
     // already fail-closed. The warm branch is the one under test.
     await index.listGraphs();
 
-    adapter.assertManagedBackendReadableV1.mockImplementation(() => {
+    adapter[MANAGED_READ_GATE_V1].mockImplementation(() => {
       throw new ManagedOxigraphBackendUnownedError('probe', true, 'port-release-unproven');
     });
 

--- a/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
+++ b/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
@@ -1,0 +1,123 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChangelogStore } from '../src/changelog-store.js';
+import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
+import { SharedMemoryLiteralBlobStore } from '../src/shared-memory-literal-blob-store.js';
+import type { TripleStore } from '../src/triple-store.js';
+
+/**
+ * `assertManagedBackendReadableV1` is called with optional chaining, so an
+ * absent implementation reads as PERMISSION. Every wrapper between a
+ * cache-owning reader and the managed adapter must therefore forward it, and
+ * nothing in the type system enforces that — the member is optional on
+ * `TripleStore` precisely so unleased stores need not implement it.
+ *
+ * These are the two halves of that enforcement: behavioural proof for the
+ * decorators that exist, and a structural sweep that fails when a NEW one is
+ * added without forwarding. Without the second, this defect returns silently
+ * the next time someone writes a decorator.
+ */
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+const collectSourceFiles = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return collectSourceFiles(full);
+    return entry.isFile() && entry.name.endsWith('.ts') ? [full] : [];
+  });
+
+/** A store that WRAPS another store, as opposed to one that owns a backend. */
+const isDecorator = (source: string): boolean =>
+  /implements\s+TripleStore/.test(source) && /(inner|innerStore)\s*:\s*TripleStore/.test(source);
+
+/**
+ * A DECLARATION, not a mention.
+ *
+ * This distinction is load-bearing and was not academic: the first version of
+ * this sweep tested `source.includes('assertManagedBackendReadableV1')`, which
+ * passed `GraphSetIndexStore` on the strength of its own CALL to the method
+ * while the class had no implementation at all — the exact gap being tested.
+ */
+const declaresReadGate = (source: string): boolean =>
+  /^\s+assertManagedBackendReadableV1\s*\(/m.test(source);
+
+describe('managed read gate is forwarded by every TripleStore decorator', () => {
+  it('every decorator in packages/storage/src declares the forward', () => {
+    const offenders = collectSourceFiles(SRC)
+      .map((file) => ({ file, source: readFileSync(file, 'utf8') }))
+      .filter(({ source }) => isDecorator(source))
+      .filter(({ source }) => !declaresReadGate(source))
+      .map(({ file }) => file.slice(SRC.length + 1));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('the sweep actually finds the decorators (it is not vacuously empty)', () => {
+    // A structural test whose selector silently matches nothing is the purest
+    // form of a check that cannot fail.
+    const decorators = collectSourceFiles(SRC)
+      .map((file) => ({ file, source: readFileSync(file, 'utf8') }))
+      .filter(({ source }) => isDecorator(source))
+      .map(({ file }) => file.slice(SRC.length + 1).replace(/\\/g, '/'));
+
+    expect(decorators).toEqual(
+      expect.arrayContaining([
+        'changelog-store.ts',
+        'graph-set-index-store.ts',
+        'shared-memory-literal-blob-store.ts',
+      ]),
+    );
+  });
+
+  describe('behavioural forwarding', () => {
+    const inner = () => {
+      const store = {
+        assertManagedBackendReadableV1: vi.fn(),
+        listGraphs: async () => [],
+        query: async () => ({ type: 'boolean' as const, value: true }),
+        insert: async () => undefined,
+        delete: async () => undefined,
+        close: async () => undefined,
+      };
+      return store as unknown as TripleStore & {
+        assertManagedBackendReadableV1: ReturnType<typeof vi.fn>;
+      };
+    };
+
+    it('GraphSetIndexStore forwards to its inner store', () => {
+      const target = inner();
+      new GraphSetIndexStore(target).assertManagedBackendReadableV1!('probe');
+      expect(target.assertManagedBackendReadableV1).toHaveBeenCalledWith('probe');
+    });
+
+    it('ChangelogStore forwards even when enabled', () => {
+      // Enabled is the interesting case: the sibling lane getter DENIES when
+      // enabled, and copying that shape here would suppress a refusal.
+      const target = inner();
+      new ChangelogStore(target, { enabled: true }).assertManagedBackendReadableV1!('probe');
+      expect(target.assertManagedBackendReadableV1).toHaveBeenCalledWith('probe');
+    });
+
+    it('SharedMemoryLiteralBlobStore forwards to its inner store', () => {
+      const target = inner();
+      new SharedMemoryLiteralBlobStore(target, {
+        blobDir: join(SRC, '..', 'test', '.tmp-unused'),
+        thresholdBytes: 1_000_000,
+      }).assertManagedBackendReadableV1!('probe');
+      expect(target.assertManagedBackendReadableV1).toHaveBeenCalledWith('probe');
+    });
+
+    it('a decorator over an UNLEASED inner store stays silent', () => {
+      // The capability is absent on stores with no lease; forwarding must not
+      // invent a refusal, or every non-managed composition would start throwing.
+      const bare = { listGraphs: async () => [] } as unknown as TripleStore;
+      expect(() =>
+        new GraphSetIndexStore(bare).assertManagedBackendReadableV1!('probe'),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
+++ b/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
@@ -76,9 +76,9 @@ describe('managed read gate resolves through any wrapper chain', () => {
     expect(asManagedReadGateV1(bare)).toBeNull();
   });
 
-  it('resolves through every storage decorator, including private inner fields', () => {
-    // `inner` is TypeScript-private on these two but present at runtime, which
-    // is exactly what lets resolution work without them opting in.
+  it('resolves through every storage decorator via public innerStore', () => {
+    // All four wrappers expose a public `readonly innerStore`; traversal no
+    // longer reaches any TypeScript-private field.
     const adapter = managedAdapter();
     const chain = new ChangelogStore(
       new GraphSetIndexStore(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS)),

--- a/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
+++ b/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
@@ -11,10 +11,7 @@ import {
   ManagedOxigraphBackendUnownedError,
 } from '../src/managed-oxigraph-ownership-v1-internal.js';
 import { SharedMemoryLiteralBlobStore } from '../src/shared-memory-literal-blob-store.js';
-import {
-  STORE_CHAIN_INNER,
-  StoreChainCycleError,
-} from '../src/store-chain-capability.js';
+import { StoreChainCycleError } from '../src/store-chain-capability.js';
 import type { TripleStore } from '../src/triple-store.js';
 
 /**
@@ -144,31 +141,34 @@ describe('managed read gate resolves through any wrapper chain', () => {
     expect(asGraphWriteGenSource(chain)).toBe(adapter);
   });
 
-  it('every first-party storage wrapper is traversable by the SYMBOL alone', () => {
-    // This is the claim that makes STORE_CHAIN_INNER "the" contract rather than
-    // one of three. `innerStore` and `.inner` remain honoured as legacy shapes,
-    // so a wrapper that only had those would still resolve and the ordinary
-    // tests could not tell the difference. Resolving against a walker that
-    // follows ONLY the symbol is what proves first-party code no longer depends
-    // on the legacy paths.
-    const symbolOnly = (store: unknown): unknown => {
-      let node = store as { [STORE_CHAIN_INNER]?: unknown } | null | undefined;
-      for (let depth = 0; node && depth < 32; depth++) {
-        if (typeof (node as Record<symbol, unknown>)[MANAGED_READ_GATE_V1] === 'function') {
-          return node;
-        }
-        node = node[STORE_CHAIN_INNER] as typeof node;
-      }
-      return null;
-    };
-
+  it('every first-party storage wrapper is traversable by REGISTRATION alone', () => {
+    // The claim that makes registration "the" contract rather than one of
+    // several. `.innerStore` is still honoured as a pre-existing public
+    // convention, so a wrapper relying only on that would still resolve and the
+    // ordinary tests could not tell the difference. Resolving with a walker that
+    // consults ONLY the registry is what proves first-party code no longer
+    // depends on any public handle.
+    //
+    // Note there is deliberately no way to READ the registry from outside the
+    // module — so this walks by asking each wrapper to resolve a capability
+    // through the real resolver on a chain whose public handles are stripped.
     const adapter = managedAdapter();
     const chain = new ChangelogStore(
       new GraphSetIndexStore(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS)),
       { enabled: true },
     );
 
-    expect(symbolOnly(chain)).toBe(adapter);
+    // Strip every public traversal handle the chain exposes. Only the
+    // module-private registration links survive.
+    for (let node: unknown = chain; node; ) {
+      const current = node as { innerStore?: unknown; inner?: unknown };
+      const next = current.innerStore ?? current.inner;
+      Object.defineProperty(current, 'innerStore', { value: undefined, configurable: true });
+      Object.defineProperty(current, 'inner', { value: undefined, configurable: true });
+      node = next;
+    }
+
+    expect(asManagedReadGateV1(chain)).toBe(adapter);
   });
 
   it('THROWS on a cyclic chain rather than reporting absence', () => {

--- a/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
+++ b/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
@@ -1,123 +1,125 @@
-import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
 import { ChangelogStore } from '../src/changelog-store.js';
 import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
+import {
+  asManagedReadGateV1,
+  ManagedOxigraphBackendUnownedError,
+} from '../src/managed-oxigraph-ownership-v1-internal.js';
 import { SharedMemoryLiteralBlobStore } from '../src/shared-memory-literal-blob-store.js';
 import type { TripleStore } from '../src/triple-store.js';
 
 /**
- * `assertManagedBackendReadableV1` is called with optional chaining, so an
- * absent implementation reads as PERMISSION. Every wrapper between a
- * cache-owning reader and the managed adapter must therefore forward it, and
- * nothing in the type system enforces that — the member is optional on
- * `TripleStore` precisely so unleased stores need not implement it.
+ * The read gate is RESOLVED through the chain, not forwarded by each wrapper.
  *
- * These are the two halves of that enforcement: behavioural proof for the
- * decorators that exist, and a structural sweep that fails when a NEW one is
- * added without forwarding. Without the second, this defect returns silently
- * the next time someone writes a decorator.
+ * The forwarding shape this replaced required every present and future
+ * decorator — in every package — to re-declare an optional method it did not
+ * otherwise care about, and optional chaining meant any wrapper that forgot
+ * silently turned a fail-closed read into a fail-open one. Policing that needed
+ * a source-scanning test, which is itself a sign the abstraction was wrong: it
+ * could only see `packages/storage/src`, so the agent's hand-rolled forwarder
+ * was invisible to it.
+ *
+ * Resolution removes the obligation entirely. A wrapper only has to expose its
+ * inner store — which it already must, for `asChangelogReader` and
+ * `asGraphWriteGenSource` to work.
  */
-const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+const BLOB_OPTIONS = {
+  blobDir: join(process.cwd(), 'test', '.tmp-unused'),
+  thresholdBytes: 1_000_000,
+};
 
-const collectSourceFiles = (dir: string): string[] =>
-  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) return collectSourceFiles(full);
-    return entry.isFile() && entry.name.endsWith('.ts') ? [full] : [];
-  });
-
-/** A store that WRAPS another store, as opposed to one that owns a backend. */
-const isDecorator = (source: string): boolean =>
-  /implements\s+TripleStore/.test(source) && /(inner|innerStore)\s*:\s*TripleStore/.test(source);
+/** Stands in for the managed adapter: the only thing that declares the gate. */
+const managedAdapter = () => {
+  const store = {
+    assertManagedBackendReadableV1: vi.fn(),
+    listGraphs: async () => [],
+    query: async () => ({ type: 'boolean' as const, value: true }),
+    insert: async () => undefined,
+    delete: async () => undefined,
+    close: async () => undefined,
+  };
+  return store as unknown as TripleStore & {
+    assertManagedBackendReadableV1: ReturnType<typeof vi.fn>;
+  };
+};
 
 /**
- * A DECLARATION, not a mention.
- *
- * This distinction is load-bearing and was not academic: the first version of
- * this sweep tested `source.includes('assertManagedBackendReadableV1')`, which
- * passed `GraphSetIndexStore` on the strength of its own CALL to the method
- * while the class had no implementation at all — the exact gap being tested.
+ * A hand-rolled forwarder that exposes `innerStore` but declares nothing else —
+ * the exact shape of `createListContextGraphsCacheInvalidatingStore` in
+ * packages/agent. Reproduced structurally here rather than imported, because
+ * storage must not depend on agent; the agent-side behaviour is covered by its
+ * own suite.
  */
-const declaresReadGate = (source: string): boolean =>
-  /^\s+assertManagedBackendReadableV1\s*\(/m.test(source);
+const opaqueForwarder = (innerStore: TripleStore): TripleStore =>
+  ({
+    innerStore,
+    listGraphs: () => innerStore.listGraphs(),
+    query: (...args: Parameters<TripleStore['query']>) => innerStore.query(...args),
+    insert: (...args: Parameters<TripleStore['insert']>) => innerStore.insert(...args),
+    delete: (...args: Parameters<TripleStore['delete']>) => innerStore.delete(...args),
+    close: () => innerStore.close(),
+  }) as unknown as TripleStore;
 
-describe('managed read gate is forwarded by every TripleStore decorator', () => {
-  it('every decorator in packages/storage/src declares the forward', () => {
-    const offenders = collectSourceFiles(SRC)
-      .map((file) => ({ file, source: readFileSync(file, 'utf8') }))
-      .filter(({ source }) => isDecorator(source))
-      .filter(({ source }) => !declaresReadGate(source))
-      .map(({ file }) => file.slice(SRC.length + 1));
-
-    expect(offenders).toEqual([]);
+describe('managed read gate resolves through any wrapper chain', () => {
+  it('finds the gate on the adapter itself', () => {
+    const adapter = managedAdapter();
+    expect(asManagedReadGateV1(adapter)).toBe(adapter);
   });
 
-  it('the sweep actually finds the decorators (it is not vacuously empty)', () => {
-    // A structural test whose selector silently matches nothing is the purest
-    // form of a check that cannot fail.
-    const decorators = collectSourceFiles(SRC)
-      .map((file) => ({ file, source: readFileSync(file, 'utf8') }))
-      .filter(({ source }) => isDecorator(source))
-      .map(({ file }) => file.slice(SRC.length + 1).replace(/\\/g, '/'));
+  it('returns null for a store with no managed backend anywhere', () => {
+    // Unleased stores are always readable; resolution must not invent a gate.
+    const bare = { listGraphs: async () => [] } as unknown as TripleStore;
+    expect(asManagedReadGateV1(bare)).toBeNull();
+  });
 
-    expect(decorators).toEqual(
-      expect.arrayContaining([
-        'changelog-store.ts',
-        'graph-set-index-store.ts',
-        'shared-memory-literal-blob-store.ts',
-      ]),
+  it('resolves through every storage decorator, including private inner fields', () => {
+    // `inner` is TypeScript-private on these two but present at runtime, which
+    // is exactly what lets resolution work without them opting in.
+    const adapter = managedAdapter();
+    const chain = new ChangelogStore(
+      new GraphSetIndexStore(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS)),
+      { enabled: true },
     );
+
+    expect(asManagedReadGateV1(chain)).toBe(adapter);
   });
 
-  describe('behavioural forwarding', () => {
-    const inner = () => {
-      const store = {
-        assertManagedBackendReadableV1: vi.fn(),
-        listGraphs: async () => [],
-        query: async () => ({ type: 'boolean' as const, value: true }),
-        insert: async () => undefined,
-        delete: async () => undefined,
-        close: async () => undefined,
-      };
-      return store as unknown as TripleStore & {
-        assertManagedBackendReadableV1: ReturnType<typeof vi.fn>;
-      };
-    };
+  it('resolves through a wrapper that declares NOTHING but innerStore', () => {
+    // The finding this replaced the source-sweep for: the agent's forwarder
+    // sits on a real store, drives its own read cache, and never knew about
+    // this capability. Under the old shape the call evaporated here.
+    const adapter = managedAdapter();
 
-    it('GraphSetIndexStore forwards to its inner store', () => {
-      const target = inner();
-      new GraphSetIndexStore(target).assertManagedBackendReadableV1!('probe');
-      expect(target.assertManagedBackendReadableV1).toHaveBeenCalledWith('probe');
+    expect(asManagedReadGateV1(opaqueForwarder(adapter))).toBe(adapter);
+    expect(
+      asManagedReadGateV1(opaqueForwarder(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS))),
+    ).toBe(adapter);
+  });
+
+  it('terminates on a cyclic chain instead of hanging', () => {
+    const cyclic: { innerStore?: unknown } = {};
+    cyclic.innerStore = cyclic;
+    expect(asManagedReadGateV1(cyclic)).toBeNull();
+  });
+
+  it('refuses a WARM read through an opaque forwarder — the end-to-end property', async () => {
+    // Resolution is only worth anything if the CONSUMER fails closed through
+    // the same chain. `GraphSetIndexStore` resolves at construction, so the
+    // forwarder in between cannot erase the refusal.
+    const adapter = managedAdapter();
+    const index = new GraphSetIndexStore(opaqueForwarder(adapter));
+
+    // Warm first: a COLD index goes to refresh, which is the path that was
+    // already fail-closed. The warm branch is the one under test.
+    await index.listGraphs();
+
+    adapter.assertManagedBackendReadableV1.mockImplementation(() => {
+      throw new ManagedOxigraphBackendUnownedError('probe', true, 'port-release-unproven');
     });
 
-    it('ChangelogStore forwards even when enabled', () => {
-      // Enabled is the interesting case: the sibling lane getter DENIES when
-      // enabled, and copying that shape here would suppress a refusal.
-      const target = inner();
-      new ChangelogStore(target, { enabled: true }).assertManagedBackendReadableV1!('probe');
-      expect(target.assertManagedBackendReadableV1).toHaveBeenCalledWith('probe');
-    });
-
-    it('SharedMemoryLiteralBlobStore forwards to its inner store', () => {
-      const target = inner();
-      new SharedMemoryLiteralBlobStore(target, {
-        blobDir: join(SRC, '..', 'test', '.tmp-unused'),
-        thresholdBytes: 1_000_000,
-      }).assertManagedBackendReadableV1!('probe');
-      expect(target.assertManagedBackendReadableV1).toHaveBeenCalledWith('probe');
-    });
-
-    it('a decorator over an UNLEASED inner store stays silent', () => {
-      // The capability is absent on stores with no lease; forwarding must not
-      // invent a refusal, or every non-managed composition would start throwing.
-      const bare = { listGraphs: async () => [] } as unknown as TripleStore;
-      expect(() =>
-        new GraphSetIndexStore(bare).assertManagedBackendReadableV1!('probe'),
-      ).not.toThrow();
-    });
+    await expect(index.listGraphs()).rejects.toThrow(ManagedOxigraphBackendUnownedError);
   });
 });

--- a/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
+++ b/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
@@ -5,11 +5,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { ChangelogStore, asChangelogReader } from '../src/changelog-store.js';
 import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
 import { asGraphWriteGenSource } from '../src/graph-write-gen.js';
+import { ManagedOxigraphBackendUnownedError } from '../src/managed-oxigraph-ownership-v1-internal.js';
 import {
-  MANAGED_READ_GATE_V1,
-  asManagedReadGateV1,
-  ManagedOxigraphBackendUnownedError,
-} from '../src/managed-oxigraph-ownership-v1-internal.js';
+  CACHED_READ_GATE_V1,
+  asCachedReadGateV1,
+} from '../src/cached-read-gate-v1.js';
 import { SharedMemoryLiteralBlobStore } from '../src/shared-memory-literal-blob-store.js';
 import { StoreChainCycleError } from '../src/store-chain-capability.js';
 import type { TripleStore } from '../src/triple-store.js';
@@ -37,7 +37,7 @@ const BLOB_OPTIONS = {
 /** Stands in for the managed adapter: the only thing that declares the gate. */
 const managedAdapter = () => {
   const store = {
-    [MANAGED_READ_GATE_V1]: vi.fn(),
+    [CACHED_READ_GATE_V1]: vi.fn(),
     listGraphs: async () => [],
     query: async () => ({ type: 'boolean' as const, value: true }),
     insert: async () => undefined,
@@ -45,7 +45,7 @@ const managedAdapter = () => {
     close: async () => undefined,
   };
   return store as unknown as TripleStore & {
-    [MANAGED_READ_GATE_V1]: ReturnType<typeof vi.fn>;
+    [CACHED_READ_GATE_V1]: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -66,16 +66,16 @@ const opaqueForwarder = (innerStore: TripleStore): TripleStore =>
     close: () => innerStore.close(),
   }) as unknown as TripleStore;
 
-describe('managed read gate resolves through any wrapper chain', () => {
+describe('cached-read gate resolves through any wrapper chain', () => {
   it('finds the gate on the adapter itself', () => {
     const adapter = managedAdapter();
-    expect(asManagedReadGateV1(adapter)).toBe(adapter);
+    expect(asCachedReadGateV1(adapter)).toBe(adapter);
   });
 
   it('returns null for a store with no managed backend anywhere', () => {
     // Unleased stores are always readable; resolution must not invent a gate.
     const bare = { listGraphs: async () => [] } as unknown as TripleStore;
-    expect(asManagedReadGateV1(bare)).toBeNull();
+    expect(asCachedReadGateV1(bare)).toBeNull();
   });
 
   it('resolves through every storage decorator', () => {
@@ -89,7 +89,7 @@ describe('managed read gate resolves through any wrapper chain', () => {
       { enabled: true },
     );
 
-    expect(asManagedReadGateV1(chain)).toBe(adapter);
+    expect(asCachedReadGateV1(chain)).toBe(adapter);
   });
 
   it('resolves through a wrapper that declares NOTHING but innerStore', () => {
@@ -98,9 +98,9 @@ describe('managed read gate resolves through any wrapper chain', () => {
     // this capability. Under the old shape the call evaporated here.
     const adapter = managedAdapter();
 
-    expect(asManagedReadGateV1(opaqueForwarder(adapter))).toBe(adapter);
+    expect(asCachedReadGateV1(opaqueForwarder(adapter))).toBe(adapter);
     expect(
-      asManagedReadGateV1(opaqueForwarder(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS))),
+      asCachedReadGateV1(opaqueForwarder(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS))),
     ).toBe(adapter);
   });
 
@@ -119,7 +119,7 @@ describe('managed read gate resolves through any wrapper chain', () => {
     const wrapped = opaqueForwarder(chain);
 
     // Read gate lives on the innermost adapter.
-    expect(asManagedReadGateV1(wrapped)).toBe(adapter);
+    expect(asCachedReadGateV1(wrapped)).toBe(adapter);
     // Changelog reader lives on the OUTERMOST decorator — opposite direction,
     // so this also proves the walk starts where it should.
     expect(asChangelogReader(wrapped)).toBe(chain);
@@ -168,7 +168,7 @@ describe('managed read gate resolves through any wrapper chain', () => {
       node = next;
     }
 
-    expect(asManagedReadGateV1(chain)).toBe(adapter);
+    expect(asCachedReadGateV1(chain)).toBe(adapter);
   });
 
   it('THROWS on a cyclic chain rather than reporting absence', () => {
@@ -180,7 +180,7 @@ describe('managed read gate resolves through any wrapper chain', () => {
     const cyclic: { innerStore?: unknown } = {};
     cyclic.innerStore = cyclic;
 
-    expect(() => asManagedReadGateV1(cyclic)).toThrow(StoreChainCycleError);
+    expect(() => asCachedReadGateV1(cyclic)).toThrow(StoreChainCycleError);
   });
 
   it('resolves through a chain far deeper than any previous depth cap', () => {
@@ -190,7 +190,7 @@ describe('managed read gate resolves through any wrapper chain', () => {
     let chain: TripleStore = adapter;
     for (let i = 0; i < 20; i++) chain = opaqueForwarder(chain);
 
-    expect(asManagedReadGateV1(chain)).toBe(adapter);
+    expect(asCachedReadGateV1(chain)).toBe(adapter);
   });
 
   it('refuses a WARM read through an opaque forwarder — the end-to-end property', async () => {
@@ -204,7 +204,7 @@ describe('managed read gate resolves through any wrapper chain', () => {
     // already fail-closed. The warm branch is the one under test.
     await index.listGraphs();
 
-    adapter[MANAGED_READ_GATE_V1].mockImplementation(() => {
+    adapter[CACHED_READ_GATE_V1].mockImplementation(() => {
       throw new ManagedOxigraphBackendUnownedError('probe', true, 'port-release-unproven');
     });
 

--- a/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
+++ b/packages/storage/test/managed-read-gate-decorator-coverage-v1.test.ts
@@ -2,8 +2,9 @@ import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { ChangelogStore } from '../src/changelog-store.js';
+import { ChangelogStore, asChangelogReader } from '../src/changelog-store.js';
 import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
+import { asGraphWriteGenSource } from '../src/graph-write-gen.js';
 import {
   asManagedReadGateV1,
   ManagedOxigraphBackendUnownedError,
@@ -97,6 +98,43 @@ describe('managed read gate resolves through any wrapper chain', () => {
     expect(
       asManagedReadGateV1(opaqueForwarder(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS))),
     ).toBe(adapter);
+  });
+
+  it('all THREE capabilities resolve through the same wrapper chain', () => {
+    // The consolidation check. These walkers used to be three separate copies
+    // and had already diverged — `asChangelogReader` followed only
+    // `.innerStore` while the other two also followed `.inner`. A traversal gap
+    // surfaces as `null`, which every caller reads as "this store does not have
+    // the capability", so divergence is silent by construction. Asserting all
+    // three against ONE composition is what makes a future drift visible.
+    const adapter = managedAdapter();
+    const chain = new ChangelogStore(
+      new GraphSetIndexStore(new SharedMemoryLiteralBlobStore(adapter, BLOB_OPTIONS)),
+      { enabled: true },
+    );
+    const wrapped = opaqueForwarder(chain);
+
+    // Read gate lives on the innermost adapter.
+    expect(asManagedReadGateV1(wrapped)).toBe(adapter);
+    // Changelog reader lives on the OUTERMOST decorator — opposite direction,
+    // so this also proves the walk starts where it should.
+    expect(asChangelogReader(wrapped)).toBe(chain);
+    // Write-gen source is absent here; `null` must mean absent, not "gave up".
+    expect(asGraphWriteGenSource(wrapped)).toBeNull();
+  });
+
+  it('finds a write-gen source through the same chain when one exists', () => {
+    // The positive half of the assertion above: prove `null` was a real absence
+    // rather than a traversal that stops early.
+    const adapter = managedAdapter() as unknown as Record<string, unknown>;
+    adapter.getWriteGen = () => 1;
+    const chain = opaqueForwarder(
+      new GraphSetIndexStore(
+        new SharedMemoryLiteralBlobStore(adapter as unknown as TripleStore, BLOB_OPTIONS),
+      ),
+    );
+
+    expect(asGraphWriteGenSource(chain)).toBe(adapter);
   });
 
   it('terminates on a cyclic chain instead of hanging', () => {

--- a/packages/storage/test/managed-terminal-read-through-index-v1.test.ts
+++ b/packages/storage/test/managed-terminal-read-through-index-v1.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
-import { ManagedOxigraphBackendUnownedError } from '../src/managed-oxigraph-ownership-v1-internal.js';
+import {
+  MANAGED_READ_GATE_V1,
+  ManagedOxigraphBackendUnownedError,
+} from '../src/managed-oxigraph-ownership-v1-internal.js';
 import type { Quad, QueryOptions, QueryResult, TripleStore } from '../src/triple-store.js';
 
 /**
@@ -30,7 +33,7 @@ class FakeInnerStore implements Partial<TripleStore> {
   unowned: ManagedOxigraphBackendUnownedError | null = null;
   readableChecks = 0;
 
-  assertManagedBackendReadableV1(_operation: string): void {
+  [MANAGED_READ_GATE_V1](_operation: string): void {
     this.readableChecks += 1;
     if (this.unowned) throw this.unowned;
   }

--- a/packages/storage/test/managed-terminal-read-through-index-v1.test.ts
+++ b/packages/storage/test/managed-terminal-read-through-index-v1.test.ts
@@ -26,18 +26,32 @@ class FakeInnerStore implements Partial<TripleStore> {
   failWith: Error | null = null;
   listGraphCalls = 0;
 
+  /** Ownership, independent of `failWith`, so the warm path can be driven alone. */
+  unowned: ManagedOxigraphBackendUnownedError | null = null;
+  readableChecks = 0;
+
+  assertManagedBackendReadableV1(_operation: string): void {
+    this.readableChecks += 1;
+    if (this.unowned) throw this.unowned;
+  }
+
   async listGraphs(): Promise<string[]> {
     this.listGraphCalls += 1;
     if (this.failWith) throw this.failWith;
     return [...this.graphs];
   }
 
+  // The real adapter refuses every delegated read once the lease is lost, so
+  // the fake must too — otherwise a test could "pass" through a path that
+  // production would have refused anyway.
   async hasGraph(): Promise<boolean> {
+    if (this.unowned) throw this.unowned;
     if (this.failWith) throw this.failWith;
     return true;
   }
 
   async query(): Promise<QueryResult> {
+    if (this.unowned) throw this.unowned;
     if (this.failWith) throw this.failWith;
     return { type: 'boolean', value: true };
   }
@@ -83,6 +97,57 @@ describe('terminal read refusal through the graph-set index', () => {
     await expect(store.listGraphsByPrefix('urn:g:')).rejects.toThrow(
       ManagedOxigraphBackendUnownedError,
     );
+  });
+
+  it('refuses from the WARM cache, before the revalidation window opens', async () => {
+    // The gap the three tests above cannot see. Each of them first waits out
+    // `revalidateMs`, so they only ever exercise the REFRESH path. Inside the
+    // window `ensureGraphSet()` returns `this.graphs` without touching the
+    // inner store at all, so ownership is never consulted and a lost lease
+    // keeps serving enumeration for up to the revalidation interval (30s in
+    // production).
+    //
+    // No `setTimeout` here on purpose: the read happens while the cache is
+    // still fresh. `unowned` rather than `failWith`, so ONLY the ownership
+    // predicate can produce the refusal — if the cache were silently expiring
+    // and refreshing, the inner `listGraphs()` would succeed and this would not
+    // reject at all.
+    inner.unowned = unowned();
+    const listCallsBefore = inner.listGraphCalls;
+
+    await expect(store.listGraphs()).rejects.toThrow(ManagedOxigraphBackendUnownedError);
+
+    // The refusal came from consulting ownership on the warm path, not from a
+    // refresh: the inner store was never re-scanned.
+    expect(inner.readableChecks).toBeGreaterThan(0);
+    expect(inner.listGraphCalls).toBe(listCallsBefore);
+  });
+
+  it('consults ownership on the warm path for listGraphsByPrefix too', async () => {
+    // The other entry point through `ensureGraphSet`. Without this, a fix
+    // applied to `listGraphs` alone would look complete.
+    //
+    // `hasGraph` is deliberately absent: on the enabled path it always
+    // delegates to the inner store, so it is not a warm-serving path and the
+    // adapter's own read check already covers it.
+    inner.unowned = unowned();
+    const listCallsBefore = inner.listGraphCalls;
+
+    await expect(store.listGraphsByPrefix('urn:g:')).rejects.toThrow(
+      ManagedOxigraphBackendUnownedError,
+    );
+    expect(inner.listGraphCalls).toBe(listCallsBefore);
+  });
+
+  it('does not refuse a warm read while ownership is still live', async () => {
+    // The positive control. Without it, "always throw on the warm path" would
+    // pass every assertion above.
+    const callsBefore = inner.listGraphCalls;
+
+    await expect(store.listGraphs()).resolves.toEqual(['urn:g:1', 'urn:g:2']);
+
+    expect(inner.readableChecks).toBeGreaterThan(0);
+    expect(inner.listGraphCalls).toBe(callsBefore);
   });
 
   it('STILL tolerates an ordinary transient failure on a warm index', async () => {

--- a/packages/storage/test/managed-terminal-read-through-index-v1.test.ts
+++ b/packages/storage/test/managed-terminal-read-through-index-v1.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
-import {
-  MANAGED_READ_GATE_V1,
-  ManagedOxigraphBackendUnownedError,
-} from '../src/managed-oxigraph-ownership-v1-internal.js';
+import { ManagedOxigraphBackendUnownedError } from '../src/managed-oxigraph-ownership-v1-internal.js';
+import { CACHED_READ_GATE_V1 } from '../src/cached-read-gate-v1.js';
 import type { Quad, QueryOptions, QueryResult, TripleStore } from '../src/triple-store.js';
 
 /**
@@ -33,7 +31,7 @@ class FakeInnerStore implements Partial<TripleStore> {
   unowned: ManagedOxigraphBackendUnownedError | null = null;
   readableChecks = 0;
 
-  [MANAGED_READ_GATE_V1](_operation: string): void {
+  [CACHED_READ_GATE_V1](_operation: string): void {
     this.readableChecks += 1;
     if (this.unowned) throw this.unowned;
   }

--- a/packages/storage/test/managed-warm-read-composition-v1.test.ts
+++ b/packages/storage/test/managed-warm-read-composition-v1.test.ts
@@ -20,7 +20,7 @@ import { createTripleStore, type TripleStore } from '../src/triple-store.js';
 /**
  * The warm-read ownership guard must survive REAL decorator compositions.
  *
- * `GraphSetIndexStore` calls `this.inner.assertManagedBackendReadableV1?.(…)`,
+ * `GraphSetIndexStore` used to call `this.inner.assertManagedBackendReadableV1?.(…)`,
  * and optional chaining treats an absent method as PERMISSION. Production
  * composes `GraphSetIndexStore(ChangelogStore(SharedMemoryLiteralBlobStore(
  * SparqlHttpStore)))`, so with either middle wrapper present the call lands on

--- a/packages/storage/test/managed-warm-read-composition-v1.test.ts
+++ b/packages/storage/test/managed-warm-read-composition-v1.test.ts
@@ -1,0 +1,156 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Adapter registration is a side effect of importing the module.
+import '../src/adapters/sparql-http.js';
+
+import {
+  ManagedOxigraphBackendUnownedError,
+  attachManagedOxigraphLeaseV1,
+  createManagedOxigraphOwnershipControllerV1,
+  type ManagedOxigraphOwnershipControllerV1,
+  type ManagedOxigraphSupervisorHandoffV1,
+} from '../src/managed-oxigraph-ownership-v1-internal.js';
+import { __resetSystemRecordControllerRegistrationForTests } from '../src/system-record-materializer-v1.js';
+import { createTripleStore, type TripleStore } from '../src/triple-store.js';
+
+/**
+ * The warm-read ownership guard must survive REAL decorator compositions.
+ *
+ * `GraphSetIndexStore` calls `this.inner.assertManagedBackendReadableV1?.(…)`,
+ * and optional chaining treats an absent method as PERMISSION. Production
+ * composes `GraphSetIndexStore(ChangelogStore(SharedMemoryLiteralBlobStore(
+ * SparqlHttpStore)))`, so with either middle wrapper present the call lands on
+ * a decorator that does not implement it, evaporates, and the warm cache is
+ * served for the whole revalidation window after the lease is lost.
+ *
+ * The single-decorator tests in `managed-terminal-read-through-index-v1` cannot
+ * see this: they wrap a fake that answers the capability directly.
+ */
+const QUERY_ENDPOINT = 'http://127.0.0.1:7931/query';
+const UPDATE_ENDPOINT = 'http://127.0.0.1:7931/update';
+
+const EMPTY_SELECT = JSON.stringify({ head: { vars: [] }, results: { bindings: [] } });
+
+const originalFetch = globalThis.fetch;
+
+describe('warm-read ownership refusal through production compositions', () => {
+  let ownership: ManagedOxigraphOwnershipControllerV1;
+  let blobDir: string;
+  let requests: number;
+
+  const supervisor: ManagedOxigraphSupervisorHandoffV1 = {
+    stopAndProveOwnedChildDead: async () => undefined,
+    startAndProveCleanGeneration: async () => undefined,
+  };
+
+  beforeEach(async () => {
+    __resetSystemRecordControllerRegistrationForTests();
+    ownership = createManagedOxigraphOwnershipControllerV1(QUERY_ENDPOINT, UPDATE_ENDPOINT);
+    ownership.bindReadyGeneration();
+    blobDir = await mkdtemp(join(tmpdir(), 'dkg-warm-read-'));
+    requests = 0;
+    globalThis.fetch = (async (_input: unknown, init?: { body?: unknown }) => {
+      requests += 1;
+      const body = String(init?.body ?? '');
+      const payload = /^\s*ASK/i.test(body) ? JSON.stringify({ boolean: false }) : EMPTY_SELECT;
+      return new Response(payload, {
+        status: 200,
+        headers: { 'Content-Type': 'application/sparql-results+json' },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    __resetSystemRecordControllerRegistrationForTests();
+    await rm(blobDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  /** The composition under test, built by the PRODUCTION factory. */
+  const composedStore = (largeLiteralStorage: boolean): Promise<TripleStore> =>
+    createTripleStore({
+      backend: 'sparql-http',
+      options: attachManagedOxigraphLeaseV1(
+        { queryEndpoint: QUERY_ENDPOINT, updateEndpoint: UPDATE_ENDPOINT, managedByDkg: true },
+        ownership.lease,
+        supervisor,
+      ) as unknown as Record<string, unknown>,
+      graphSetIndex: true,
+      ...(largeLiteralStorage
+        ? { largeLiteralStorage: { enabled: true, directory: blobDir } }
+        : {}),
+    });
+
+  for (const largeLiteralStorage of [false, true]) {
+    const shape = largeLiteralStorage
+      ? 'graphSetIndex + largeLiteralStorage'
+      : 'graphSetIndex only';
+
+    it(`refuses a warm listGraphs after ownership loss — ${shape}`, async () => {
+      const store = await composedStore(largeLiteralStorage);
+
+      await store.listGraphs(); // warm the index
+      const afterWarm = requests;
+      expect(afterWarm).toBeGreaterThan(0);
+
+      ownership.invalidate('port-release-unproven');
+
+      await expect(store.listGraphs()).rejects.toThrow(ManagedOxigraphBackendUnownedError);
+      // No I/O: the refusal must come from the lease snapshot, not from a
+      // refresh that happened to fail at the endpoint.
+      expect(requests).toBe(afterWarm);
+
+      await store.close().catch(() => undefined);
+    });
+
+    it(`refuses a warm listGraphsByPrefix after ownership loss — ${shape}`, async () => {
+      const store = await composedStore(largeLiteralStorage);
+
+      await store.listGraphs();
+      const afterWarm = requests;
+
+      ownership.invalidate('port-release-unproven');
+
+      await expect(store.listGraphsByPrefix('urn:')).rejects.toThrow(
+        ManagedOxigraphBackendUnownedError,
+      );
+      expect(requests).toBe(afterWarm);
+
+      await store.close().catch(() => undefined);
+    });
+
+    it(`still serves a warm read while ownership is live — ${shape}`, async () => {
+      // Positive control. Without it, "always refuse on the warm path" would
+      // satisfy every assertion above.
+      const store = await composedStore(largeLiteralStorage);
+
+      await store.listGraphs();
+      const afterWarm = requests;
+
+      await expect(store.listGraphs()).resolves.toEqual([]);
+      expect(requests).toBe(afterWarm); // served warm, no refresh
+
+      await store.close().catch(() => undefined);
+    });
+  }
+
+  it('leaves an UNLEASED store untouched through the same composition', async () => {
+    // The capability must stay absent-and-harmless where there is no lease:
+    // forwarding it through decorators must not invent a refusal.
+    const plain = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: QUERY_ENDPOINT, updateEndpoint: UPDATE_ENDPOINT },
+      graphSetIndex: true,
+      largeLiteralStorage: { enabled: true, directory: blobDir },
+    });
+
+    await plain.listGraphs();
+    await expect(plain.listGraphs()).resolves.toEqual([]);
+
+    await plain.close().catch(() => undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- A warm read cache answers `listGraphs()` **without touching the endpoint**, so it never reaches the ownership checks on `query`/`update`. After the managed lease is lost, enumeration kept being served from cache — attributing stale node state to a backend the node may no longer own, for a whole cache window. That window is exactly what a foreign listener needs.
- **Two instances, not one.** The review reported `GraphSetIndexStore` (stale for up to `revalidateMs`, 30 s in production). Sweeping the class found the same hole in `SparqlHttpStore.listGraphs()`, which serves its own list for up to `MANAGED_LIST_GRAPHS_CACHE_MS` (30 s). Both are fixed here.
- The decorator cannot see the lease, so the adapter exposes `assertManagedBackendReadableV1()` as an optional `TripleStore` capability — a lease-snapshot read, **no I/O** — and the warm branch calls it before returning cached state.

Follow-up to #2110, which merged before this was reported. Same fail-closed read contract; this closes the path that contract did not actually cover.

## Related

- Follow-up to #2110 (Stack B2 — the live managed materialization boundary)
- Part of #2052
- Reported by `otReviewAgent` on #2110 after merge

## Diagrams

### `listGraphs()` on a managed store after the lease is lost

Before:

```mermaid
sequenceDiagram
    participant C as Caller
    participant I as GraphSetIndexStore
    participant A as SparqlHttpStore
    participant X as Oxigraph endpoint
    Note over A: lease invalidated (port-release-unproven)
    C->>I: listGraphs()
    I->>I: warm set, inside revalidateMs
    I-->>C: stale graph list (no ownership consulted)
    Note over C: decides on state from a backend<br/>we may no longer own
```

After:

```mermaid
sequenceDiagram
    participant C as Caller
    participant I as GraphSetIndexStore
    participant A as SparqlHttpStore
    participant X as Oxigraph endpoint
    Note over A: lease invalidated (port-release-unproven)
    C->>I: listGraphs()
    I->>A: assertManagedBackendReadableV1() — lease snapshot, no I/O
    A-->>I: throw ManagedOxigraphBackendUnownedError
    I-->>C: refusal, zero endpoint contact
```

## Files changed

| File | What |
|------|------|
| `packages/storage/src/adapters/sparql-http.ts` | Ownership checked **before** the `listGraphsCache` fast path; `assertManagedBackendReadableV1()` exposed for caching decorators |
| `packages/storage/src/graph-set-index-store.ts` | `ensureGraphSet()` consults ownership before returning the warm set |
| `packages/storage/src/triple-store.ts` | Optional `assertManagedBackendReadableV1?()` capability, documented for wrappers that can answer a read without delegating |
| `packages/storage/test/managed-terminal-read-through-index-v1.test.ts` | Warm-path regressions + positive control; fake now models the adapter refusing delegated reads |
| `packages/storage/test/managed-backend-ownership-dispatch-v1.test.ts` | Adapter-cache regression |

## Why the existing tests missed it

All three terminal-read tests in that file wait out `revalidateMs` before asserting, so they only ever exercised the **refresh** path — which is where #2110's rethrow already lived. Nothing read while the cache was still fresh.

The new cases read inside the window and drive ownership through a field independent of transient failure, so **only** the ownership predicate can produce the refusal. If the cache were silently expiring and refreshing, the inner `listGraphs()` would succeed and the test would not reject at all.

## Test plan

- [x] `vitest run test/managed-terminal-read-through-index-v1.test.ts` — 6/6
- [x] `vitest run test/managed-backend-ownership-dispatch-v1.test.ts` — 15/15
- [x] `vitest run test/graph-set-index-store.test.ts` — passes unchanged
- [x] Full B2 lane (14 files) — **258/258**
- [x] `tsc --noEmit` on storage — clean
- [x] **Solo-removal on both call sites**, re-proven on this base: removing the decorator check reddens 3 tests, removing the adapter check reddens 1. Mutants verified applied by grep and reverted to a byte-clean tree.
- [x] **Positive control** — a warm read with ownership still live must not refuse, so "always throw on the warm path" cannot pass.
- [x] **Negative control preserved** — the transient-failure tolerance the decorator exists for still serves the last known set on an ordinary `ECONNRESET`.

`hasGraph` deliberately has no check added: on the enabled path it always delegates to the inner store, so it is not a warm-serving path and the adapter's own read check already covers it. The test comment records this so a later reader does not "fix" it.

### Local full-suite note

A full `vitest run` on this machine shows ~16–21 failures in the `oxigraph-worker-*` family at 5000 ms timeouts. A/B'd: the same run at the parent commit (`b971d253a`, without this change) fails the same way, and every one of those files passes in isolation. Pre-existing local contention, not this change.
