### PR TITLE
fix(storage): reject noncanonical materialization epoch rows

### DIFF
--- a/packages/storage/src/system-record-rdf-schema-v1-internal.ts
+++ b/packages/storage/src/system-record-rdf-schema-v1-internal.ts
@@ -100,6 +100,25 @@ export function systemRecordEpochSubjectV1(networkId: string): string {
   return fixedSubject(networkId, 'epoch');
 }
 
+export function buildSystemRecordMaterializationEpochQuadsV1(
+  networkId: string,
+  materializationEpoch: string,
+): readonly Quad[] {
+  assertNetworkIdV1(networkId);
+  const canonicalEpoch = parseCanonicalDecimalU64(materializationEpoch).toString();
+  if (canonicalEpoch !== materializationEpoch) {
+    throw new Error('system-record materialization epoch must be canonical');
+  }
+  return freezeQuads([
+    quad(
+      systemRecordEpochSubjectV1(networkId),
+      SYSTEM_RECORD_V1_PREDICATES.materializationEpoch,
+      stringLiteral(canonicalEpoch),
+      SYSTEM_RECORD_V1_STATE_GRAPH,
+    ),
+  ]);
+}
+
 export function systemRecordReceiptSubjectV1(networkId: string, stableKeyHash: string): string {
   return fixedSubject(networkId, `receipt:${digestToken(stableKeyHash)}`);
 }
@@ -171,7 +190,6 @@ export function buildSystemRecordReservedStateQuadsV1(input: {
     appliedState.stableKeyHash,
   );
   const capacity = systemRecordCapacitySubjectV1(appliedState.networkId);
-  const epoch = systemRecordEpochSubjectV1(appliedState.networkId);
   const receipt = systemRecordReceiptSubjectV1(
     appliedState.networkId,
     appliedState.stableKeyHash,
@@ -212,14 +230,10 @@ export function buildSystemRecordReservedStateQuadsV1(input: {
         graph,
       ),
     ]),
-    epoch: freezeQuads([
-      quad(
-        epoch,
-        SYSTEM_RECORD_V1_PREDICATES.materializationEpoch,
-        stringLiteral(appliedState.materializationEpoch),
-        graph,
-      ),
-    ]),
+    epoch: buildSystemRecordMaterializationEpochQuadsV1(
+      appliedState.networkId,
+      appliedState.materializationEpoch,
+    ),
     receipt: freezeQuads([
       quad(receipt, SYSTEM_RECORD_V1_PREDICATES.receipt, jsonLiteral(receiptBytes), graph),
       quad(

--- a/packages/storage/src/system-record-state-snapshot-v1-internal.ts
+++ b/packages/storage/src/system-record-state-snapshot-v1-internal.ts
@@ -33,6 +33,7 @@ import {
 
 import type { Quad } from './triple-store.js';
 import {
+  buildSystemRecordMaterializationEpochQuadsV1,
   buildSystemRecordReservedStateQuadsV1,
   systemRecordCapacitySubjectV1,
   systemRecordEpochSubjectV1,
@@ -113,9 +114,7 @@ export function decodeSystemRecordAppliedSnapshotV1(input: {
   if (epoch !== owned.materializationEpoch) {
     throw new Error('system-record materialization epoch changed during inspection');
   }
-  const canonicalEpochRows = epochRows.filter((quad) => (
-    quad.predicate === SYSTEM_RECORD_V1_PREDICATES.materializationEpoch
-  ));
+  const canonicalEpochRows = buildSystemRecordMaterializationEpochQuadsV1(networkId, epoch);
 
   const decodedCapacity = decodeCapacityState(networkId, capacityRows);
 

--- a/packages/storage/test/system-record-state-snapshot-v1.test.ts
+++ b/packages/storage/test/system-record-state-snapshot-v1.test.ts
@@ -220,6 +220,19 @@ describe('system-record reserved-state snapshot decoder', () => {
       predicate: SYSTEM_RECORD_V1_PREDICATES.root,
       object: ROOT,
     }])).toThrow(/fixed canonical RDF schema/);
+    const escapedEpoch = {
+      ...canonical.epoch[0],
+      object: '"\\u0032"',
+    };
+    expect(() => decode(all.map((quad) => (
+      quad === canonical.epoch[0] ? escapedEpoch : quad
+    )))).toThrow(/fixed canonical RDF schema/);
+    expect(() => decodeSystemRecordAppliedSnapshotV1({
+      networkId: NETWORK,
+      stableKeyHash: STABLE_KEY,
+      materializationEpoch: '2',
+      quads: [escapedEpoch],
+    })).toThrow(/fixed canonical RDF schema/);
     expect(() => decode(all.map((quad) => quad === canonical.record[0]
       ? { ...quad, object: '"not-json"^^<urn:dkg:system-record-v1:canonical-json>' }
       : quad))).toThrow();


### PR DESCRIPTION
## Summary

- Rebuild the durable materialization-epoch row from its validated value before exact reserved-state comparison.
- Reject alternate RDF lexical encodings, such as `"\\u0032"`, instead of accepting and retaining the observed row as its own canonical evidence.
- Apply the same canonical comparison to absent and present snapshots.

## Related

- Follow-up to #2140
- Addresses [the missed red review finding](https://github.com/OriginTrail/dkg/pull/2140#discussion_r3736208172)
- Related to #2052

## Diagrams

### Reserved-state epoch validation

Before:

```mermaid
sequenceDiagram
    participant Store
    participant Decoder
    participant Validator
    Store->>Decoder: Observed epoch row
    Decoder->>Validator: Decode lexical value
    Validator-->>Decoder: Canonical numeric value
    Decoder->>Decoder: Reuse observed row as expected row
    Decoder-->>Store: Accept alternate lexical encoding
```

After:

```mermaid
sequenceDiagram
    participant Store
    participant Decoder
    participant Validator
    Store->>Decoder: Observed epoch row
    Decoder->>Validator: Decode lexical value
    Validator-->>Decoder: Canonical numeric value
    Decoder->>Decoder: Rebuild canonical expected row
    Decoder-->>Store: Reject lexical mismatch
```

## Files changed

| File | What |
|------|------|
| `packages/storage/src/system-record-rdf-schema-v1-internal.ts` | Adds one canonical materialization-epoch quad builder and reuses it for reserved-state construction. |
| `packages/storage/src/system-record-state-snapshot-v1-internal.ts` | Compares observed epoch rows against the rebuilt canonical row. |
| `packages/storage/test/system-record-state-snapshot-v1.test.ts` | Covers escaped numeric epoch literals in present and absent snapshots. |

## Test plan

- [x] Run `pnpm --filter '@origintrail-official/dkg-storage...' build`
- [x] Run `pnpm exec vitest run test/system-record-state-snapshot-v1.test.ts test/system-record-rdf-schema-v1.test.ts`
- [x] Verify canonical snapshots remain accepted.
- [x] Verify `"\\u0032"` is rejected for both present and absent reserved state.
- [x] Run `git diff --check`
