### PR TITLE
fix(storage): retain writer ownership through recovery handoff

### DIFF
--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -168,7 +168,9 @@ export interface SystemRecordTransactionExecutorV1 {
   /**
    * B3 transaction boundary. Mutation settlement is explicit and an uncertain
    * write transfers ownership through `registerRecovery` while the executor's
-   * exclusive scheduler permit is still live.
+   * exclusive scheduler permit is still live. The executor must pass the exact
+   * binding object it received, invoke the registrar synchronously at most once,
+   * and must not retain that invocation-scoped capability after settlement.
    */
   applyVerifiedSettlementBound?(
     proof: unknown,
@@ -549,6 +551,13 @@ class SystemRecordLaneSession {
   /** In-flight transition, so same-intent callers coalesce instead of racing. */
   private transition: SystemRecordLaneTransitionV1 | null = null;
   private recoverySequence = 0n;
+  /** Already-admitted executor calls that may still transfer recovery ownership. */
+  private admittedApplyCount = 0;
+  /** Allocated only when detach actually has to wait for admitted work. */
+  private admittedApplyDrain: Promise<void> | null = null;
+  private resolveAdmittedApplyDrain: (() => void) | null = null;
+  /** Concurrent disposal callers join one ownership decision. */
+  private detachSettlement: Promise<void> | null = null;
 
   /**
    * The controller this session backs, so shutdown can release the
@@ -758,7 +767,12 @@ class SystemRecordLaneSession {
       // The joined open may have ended terminal, or a shutdown may have latched
       // while we waited. Re-read rather than acting on stale state.
       const after = this.readState();
-      if (after === 'shutdown' || after === 'disabled' || after === 'unavailable') return;
+      if (
+        after === 'shutdown' ||
+        after === 'detached' ||
+        after === 'disabled' ||
+        after === 'unavailable'
+      ) return;
       // Another disable that joined the SAME open may have resumed first and
       // already installed itself. `current` is then `disabling`, which none of
       // the three states above excludes, so installing anyway opened a SECOND
@@ -857,7 +871,10 @@ class SystemRecordLaneSession {
         throw error;
       } finally {
         entry.reportedSettled = true;
-        if (entry.physicalWork === null) this.release(entry);
+        if (
+          entry.physicalWork === null &&
+          (entry.recovery === null || entry.recovery.settled)
+        ) this.release(entry);
       }
     })();
 
@@ -1162,71 +1179,92 @@ class SystemRecordLaneSession {
       childGeneration: boundGeneration,
       materializationEpoch: facade.materializationEpoch,
     });
-    if (this.deps.executor.applyVerifiedSettlementBound) {
-      const settlement = await this.deps.executor.applyVerifiedSettlementBound(
-        proof,
-        executionBinding,
-        this.registerRecovery,
-      );
-      // The internal carrier is authoritative. In particular, a public
-      // `root-collision` may eventually include a settled quarantine mutation,
-      // while an `applied` result has already been exact-postread. Neither fact
-      // may be reconstructed from the public outcome spelling here.
-      return settlement.outcome;
-    }
-
-    const result = this.deps.executor.applyVerifiedBound
-      ? await this.deps.executor.applyVerifiedBound(proof, executionBinding)
-      : await this.deps.executor.applyVerified(proof, boundGeneration);
-
-    // Derive the FINAL outcome first, then seal on it.
-    //
-    // The previous order sealed only on the executor's own `indeterminate` and
-    // then synthesized a second one below without sealing — so a success whose
-    // generation changed under the dispatch returned `indeterminate` to the
-    // caller while leaving the lane `enabled`, and the very next apply was
-    // admitted. Reproduced: two dispatches, both returning `indeterminate`,
-    // state `enabled` throughout. The second must never have been admitted.
-    //
-    // Attribution is checked on the WHOLE ownership snapshot, not just the
-    // generation string: a lease that has gone not-ready or terminal under the
-    // dispatch is equally unable to attribute the response, and reading only
-    // `childGeneration` would miss both.
-    const after = readManagedOxigraphOwnershipSnapshotV1(this.deps.lease);
-    const attributable =
-      after !== null &&
-      !after.terminal &&
-      after.ready &&
-      after.childGeneration === boundGeneration &&
-      this.current === 'enabled' &&
-      this.descriptor === facade.descriptor &&
-      this.activation.toString(10) === facade.activationGeneration &&
-      this.activeSessionIdentity === facade.sessionIdentity &&
-      this.activeChildGeneration === facade.childGeneration &&
-      this.activeMaterializationEpoch === facade.materializationEpoch;
-
-    // Compatibility-only B2 fallback. Production B3 composition uses the
-    // explicit settlement carrier above; an older injected executor can only
-    // mutate on these two success outcomes. Do not extend this inference to a
-    // future mutating outcome such as quarantine.
-    const final: SystemRecordApplyOutcomeV1 =
-      !attributable && (result.outcome === 'applied' || result.outcome === 'already-applied')
-        ? {
-            outcome: 'indeterminate',
-            recoveryGeneration: after?.childGeneration ?? boundGeneration,
+    this.admittedApplyCount += 1;
+    try {
+      if (this.deps.executor.applyVerifiedSettlementBound) {
+        let registrarOpen = true;
+        let registrationAttempted = false;
+        const registerForInvocation: SystemRecordAtomicRecoveryRegistrarV1 = (request) => {
+          if (!registrarOpen || registrationAttempted) {
+            throw new Error(
+              'system-record recovery registrar is no longer live for this apply invocation',
+            );
           }
-        : result;
+          registrationAttempted = true;
+          return this.registerRecoveryForInvocation(request, executionBinding);
+        };
+        try {
+          const settlement = await this.deps.executor.applyVerifiedSettlementBound(
+            proof,
+            executionBinding,
+            registerForInvocation,
+          );
+          // The internal carrier is authoritative. In particular, a public
+          // `root-collision` may eventually include a settled quarantine mutation,
+          // while an `applied` result has already been exact-postread. Neither fact
+          // may be reconstructed from the public outcome spelling here.
+          return settlement.outcome;
+        } finally {
+          // A retained callback cannot borrow a later invocation's detach window.
+          registrarOpen = false;
+        }
+      }
 
-    // One seal, on the final outcome, however it was reached. The lane must not
-    // accept further work against a generation whose last write may or may not
-    // have committed.
-    // `commitState`, not a raw write: this is the fourth writer of `current` and
-    // the only one that never touches `this.transition`, so no amount of
-    // pointer discipline can reach it. A dispatch parked in the executor across
-    // a COMPLETED shutdown resumed here and wrote `reconciling` over the
-    // terminal state, after which the lane reopened and dispatched again.
-    if (final.outcome === 'indeterminate') this.commitState('reconciling');
-    return final;
+      const result = this.deps.executor.applyVerifiedBound
+        ? await this.deps.executor.applyVerifiedBound(proof, executionBinding)
+        : await this.deps.executor.applyVerified(proof, boundGeneration);
+
+      // Derive the FINAL outcome first, then seal on it.
+      //
+      // The previous order sealed only on the executor's own `indeterminate` and
+      // then synthesized a second one below without sealing — so a success whose
+      // generation changed under the dispatch returned `indeterminate` to the
+      // caller while leaving the lane `enabled`, and the very next apply was
+      // admitted. Reproduced: two dispatches, both returning `indeterminate`,
+      // state `enabled` throughout. The second must never have been admitted.
+      //
+      // Attribution is checked on the WHOLE ownership snapshot, not just the
+      // generation string: a lease that has gone not-ready or terminal under the
+      // dispatch is equally unable to attribute the response, and reading only
+      // `childGeneration` would miss both.
+      const after = readManagedOxigraphOwnershipSnapshotV1(this.deps.lease);
+      const attributable =
+        after !== null &&
+        !after.terminal &&
+        after.ready &&
+        after.childGeneration === boundGeneration &&
+        this.current === 'enabled' &&
+        this.descriptor === facade.descriptor &&
+        this.activation.toString(10) === facade.activationGeneration &&
+        this.activeSessionIdentity === facade.sessionIdentity &&
+        this.activeChildGeneration === facade.childGeneration &&
+        this.activeMaterializationEpoch === facade.materializationEpoch;
+
+      // Compatibility-only B2 fallback. Production B3 composition uses the
+      // explicit settlement carrier above; an older injected executor can only
+      // mutate on these two success outcomes. Do not extend this inference to a
+      // future mutating outcome such as quarantine.
+      const final: SystemRecordApplyOutcomeV1 =
+        !attributable && (result.outcome === 'applied' || result.outcome === 'already-applied')
+          ? {
+              outcome: 'indeterminate',
+              recoveryGeneration: after?.childGeneration ?? boundGeneration,
+            }
+          : result;
+
+      // One seal, on the final outcome, however it was reached. The lane must not
+      // accept further work against a generation whose last write may or may not
+      // have committed.
+      // `commitState`, not a raw write: this is the fourth writer of `current` and
+      // the only one that never touches `this.transition`, so no amount of
+      // pointer discipline can reach it. A dispatch parked in the executor across
+      // a COMPLETED shutdown resumed here and wrote `reconciling` over the
+      // terminal state, after which the lane reopened and dispatched again.
+      if (final.outcome === 'indeterminate') this.commitState('reconciling');
+      return final;
+    } finally {
+      this.releaseAdmittedApply();
+    }
   }
 
   private refuseVerifiedBeforeDispatch(
@@ -1246,14 +1284,16 @@ class SystemRecordLaneSession {
   /**
    * Transfer one ambiguous write to lifecycle recovery.
    *
-   * This is an arrow property deliberately: the executor receives it as a
-   * capability and invokes it synchronously from inside its exclusive permit.
-   * Calling `barrier` below synchronously installs the scheduler seal before
-   * this method returns, even though the transition itself cannot begin until
-   * that permit drains.
+   * The executor receives a separate wrapper for each invocation and calls it
+   * synchronously from inside its exclusive permit. Calling `barrier` below
+   * synchronously installs the scheduler seal before this method returns, even
+   * though the transition itself cannot begin until that permit drains.
    */
-  private readonly registerRecovery: SystemRecordAtomicRecoveryRegistrarV1 = (request) => {
-    this.assertRecoveryRequestBound(request);
+  private registerRecoveryForInvocation(
+    request: SystemRecordAtomicRecoveryRequestV1,
+    executionBinding: SystemRecordLaneExecutionBindingV1,
+  ): ReturnType<SystemRecordAtomicRecoveryRegistrarV1> {
+    this.assertRecoveryRequestBound(request, executionBinding);
     this.recoverySequence += 1n;
 
     let resolve!: (resolution: SystemRecordAtomicRecoveryResolutionV1) => void;
@@ -1281,7 +1321,12 @@ class SystemRecordLaneSession {
       if (active !== null) {
         throw new Error(`system-record ${active.kind} transition cannot accept recovery ownership`);
       }
-      if (!this.commitState('reconciling')) {
+      const state = this.readState();
+      if (
+        state !== 'detached' &&
+        state !== 'unavailable' &&
+        !this.commitState('reconciling')
+      ) {
         throw new Error('system-record terminal lane cannot enqueue recovery');
       }
       const entry: Extract<SystemRecordLaneTransitionV1, { kind: 'recovery' }> = {
@@ -1307,7 +1352,7 @@ class SystemRecordLaneSession {
       recoveryGeneration: recovery.recoveryGeneration,
       completion,
     });
-  };
+  }
 
   private async runRecovery(
     entry: Extract<SystemRecordLaneTransitionV1, { kind: 'recovery' }>,
@@ -1575,23 +1620,19 @@ class SystemRecordLaneSession {
     recovery.resolve(Object.freeze(resolution));
   }
 
-  private assertRecoveryRequestBound(request: SystemRecordAtomicRecoveryRequestV1): void {
-    const binding = request.binding;
+  private assertRecoveryRequestBound(
+    request: SystemRecordAtomicRecoveryRequestV1,
+    executionBinding: SystemRecordLaneExecutionBindingV1,
+  ): void {
     if (
       request === null ||
       typeof request !== 'object' ||
       request.ownership === null ||
       typeof request.ownership !== 'object' ||
       typeof request.reconcile !== 'function' ||
-      binding.activationGeneration !== this.activation.toString(10) ||
-      binding.networkId !== this.activeNetworkId ||
-      binding.kind !== 'agents' ||
-      this.descriptor !== `${binding.networkId}|${binding.kind}|${binding.mode}` ||
-      binding.sessionIdentity !== this.activeSessionIdentity ||
-      binding.childGeneration !== this.activeChildGeneration ||
-      binding.materializationEpoch !== this.activeMaterializationEpoch
+      request.binding !== executionBinding
     ) {
-      throw new Error('system-record recovery request is not bound to the active lane');
+      throw new Error('system-record recovery request is not bound to the admitted apply invocation');
     }
   }
 
@@ -1649,28 +1690,68 @@ class SystemRecordLaneSession {
    * the committed state is `detached` and not `shutdown`. Only `shutdown`
    * claims the child was proven dead, and a detach cannot make that claim.
    *
-   * It does not join an ordinary open. It does join a transition that already
-   * owns uncertain-write recovery, because releasing the process-global writer
-   * slot before that recovery physically settles would admit a second writer
-   * over the same managed child.
+   * It joins every transition that can still manipulate the managed child, and
+   * follows a successor installed by a continuation that was already suspended
+   * when detach latched. Releasing the process-global writer slot before those
+   * transitions physically settle would admit a second writer over that child.
    */
   detach(): Promise<void> {
     // A completed or in-flight shutdown made the STRONGER claim; overwriting it
     // with `detached` would downgrade the record of what was established.
     if (this.readState() !== 'shutdown') this.current = 'detached';
-    this.descriptor = null;
-    const transition = this.transition;
-    const recovery = this.recoveryOf(transition);
-    if (transition === null || recovery === null || recovery.settled) {
-      return Promise.resolve();
-    }
-    return this.transitionSettlement(transition).then(() => {
-      if (!recovery.settled) {
+    if (this.detachSettlement) return this.detachSettlement;
+    this.detachSettlement = this.finishDetach();
+    // A caller can abandon disposal after a sibling failure. Keep the shared
+    // settlement observed without changing what present or later callers join.
+    void this.detachSettlement.catch(() => undefined);
+    return this.detachSettlement;
+  }
+
+  private async finishDetach(): Promise<void> {
+    await this.waitForAdmittedApplies();
+
+    // Recovery registration is synchronous inside the executor permit, so the
+    // transition visible after the admitted cohort drains is the complete
+    // ownership handoff. Join every transition kind: an open/disable/shutdown
+    // can manipulate the same child even when it carries no recovery token.
+    let transition = this.transition;
+    while (transition !== null) {
+      await this.transitionSettlement(transition);
+      const recovery = this.recoveryOf(transition);
+      if (recovery !== null && !recovery.settled) {
         throw new Error(
           'system-record controller detach could not prove uncertain-write recovery settled',
         );
       }
-    });
+      const successor = this.transition;
+      if (successor === transition) break;
+      transition = successor;
+    }
+
+    this.descriptor = null;
+    this.clearActiveBinding();
+  }
+
+  private waitForAdmittedApplies(): Promise<void> {
+    if (this.admittedApplyCount === 0) return Promise.resolve();
+    if (this.admittedApplyDrain === null) {
+      this.admittedApplyDrain = new Promise<void>((resolve) => {
+        this.resolveAdmittedApplyDrain = resolve;
+      });
+    }
+    return this.admittedApplyDrain;
+  }
+
+  private releaseAdmittedApply(): void {
+    if (this.admittedApplyCount <= 0) {
+      throw new Error('system-record admitted apply count underflow');
+    }
+    this.admittedApplyCount -= 1;
+    if (this.admittedApplyCount !== 0) return;
+    const resolve = this.resolveAdmittedApplyDrain;
+    this.admittedApplyDrain = null;
+    this.resolveAdmittedApplyDrain = null;
+    resolve?.();
   }
 
   /**
@@ -1712,7 +1793,11 @@ class SystemRecordLaneSession {
    * reintroduces exactly the await-placement audit that has been wrong twice.
    */
   private commitState(next: SystemRecordLaneStateV1): boolean {
-    if (this.readState() === 'shutdown' || this.readState() === 'detached') return false;
+    if (
+      this.readState() === 'shutdown' ||
+      this.readState() === 'unavailable' ||
+      this.readState() === 'detached'
+    ) return false;
     this.current = next;
     if (next === 'enabling') this.deps.setAdmissionActive?.(true);
     if (next === 'disabled' || next === 'unavailable') {

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -169,8 +169,10 @@ export interface SystemRecordTransactionExecutorV1 {
    * B3 transaction boundary. Mutation settlement is explicit and an uncertain
    * write transfers ownership through `registerRecovery` while the executor's
    * exclusive scheduler permit is still live. The executor must pass the exact
-   * binding object it received, invoke the registrar synchronously at most once,
-   * and must not retain that invocation-scoped capability after settlement.
+   * binding object it received, invoke the registrar at most once before its
+   * returned promise settles, and must not retain that invocation-scoped
+   * capability afterward. The registrar call synchronously installs recovery
+   * ownership; the executor itself may have awaited inspection and dispatch.
    */
   applyVerifiedSettlementBound?(
     proof: unknown,

--- a/packages/storage/test/system-record-controller-disposal-v1.test.ts
+++ b/packages/storage/test/system-record-controller-disposal-v1.test.ts
@@ -245,9 +245,12 @@ describe('system-record controller disposal', () => {
     const opening = lane!.open(ACTIVATION).then(() => 'resolved', () => 'rejected');
     await started;
 
-    await a.close();
-
+    let closed = false;
+    const closing = a.close().then(() => { closed = true; });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(closed).toBe(false);
     release();
+    await closing;
     expect(await opening).toBe('rejected');
 
     // The replacement can register, and the superseded lane never reopened.

--- a/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
+++ b/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
@@ -268,6 +268,78 @@ class AtomicRecoveryExecutor extends StubExecutor {
   }
 }
 
+class CapturingSettlementExecutor extends StubExecutor {
+  registrar: SystemRecordAtomicRecoveryRegistrarV1 | null = null;
+  binding: SystemRecordLaneExecutionBindingV1 | null = null;
+
+  async applyVerifiedSettlementBound(
+    _proof: unknown,
+    binding: SystemRecordLaneExecutionBindingV1,
+    registerRecovery: SystemRecordAtomicRecoveryRegistrarV1,
+  ): Promise<SystemRecordAtomicApplySettlementV1> {
+    this.calls.push(binding);
+    this.binding = binding;
+    this.registrar = registerRecovery;
+    return Object.freeze({
+      settlement: 'no-mutation',
+      outcome: Object.freeze({ outcome: 'stale' }),
+    });
+  }
+}
+
+class MismatchedBindingExecutor extends StubExecutor {
+  registrationError: unknown = null;
+
+  async applyVerifiedSettlementBound(
+    _proof: unknown,
+    binding: SystemRecordLaneExecutionBindingV1,
+    registerRecovery: SystemRecordAtomicRecoveryRegistrarV1,
+  ): Promise<SystemRecordAtomicApplySettlementV1> {
+    this.calls.push(binding);
+    try {
+      registerRecovery(Object.freeze({
+        ownership: Object.freeze(Object.create(null) as object),
+        binding: Object.freeze({ ...binding }),
+        reconcile: async () => Object.freeze({ resolution: 'unavailable' as const }),
+      }));
+    } catch (error) {
+      this.registrationError = error;
+    }
+    return Object.freeze({
+      settlement: 'no-mutation',
+      outcome: Object.freeze({ outcome: 'stale' }),
+    });
+  }
+}
+
+class RejectingSettlementExecutor extends StubExecutor {
+  registration: SystemRecordAtomicRecoveryRegistrationV1 | null = null;
+
+  constructor(private readonly registerBeforeReject: boolean) {
+    super();
+  }
+
+  async applyVerifiedSettlementBound(
+    _proof: unknown,
+    binding: SystemRecordLaneExecutionBindingV1,
+    registerRecovery: SystemRecordAtomicRecoveryRegistrarV1,
+  ): Promise<SystemRecordAtomicApplySettlementV1> {
+    this.calls.push(binding);
+    if (this.registerBeforeReject) {
+      this.registration = registerRecovery(Object.freeze({
+        ownership: Object.freeze(Object.create(null) as object),
+        binding,
+        reconcile: async () => Object.freeze({
+          resolution: 'applied' as const,
+          stateRevision: '2',
+          appliedStateDigest: `0x${'2'.repeat(64)}`,
+        }),
+      }));
+    }
+    throw new Error('settlement executor rejected');
+  }
+}
+
 class RecoveryHandoff extends RecordingHandoff {
   private epoch = 0;
   readonly recoveryDeadlines: Array<{ phase: string; value: number | undefined }> = [];
@@ -376,6 +448,31 @@ class GateBarrier extends RecordingBarrier {
 
 }
 
+/** Parks after a transition callback settles but before its barrier releases. */
+class SettlementTailGateBarrier extends RecordingBarrier {
+  private releaseTail!: () => void;
+  private readonly tail = new Promise<void>((resolve) => { this.releaseTail = resolve; });
+  private reachedTail!: () => void;
+  readonly tailReached = new Promise<void>((resolve) => { this.reachedTail = resolve; });
+
+  constructor(private readonly gatedPurpose: string) {
+    super();
+    const recordAndRun = this.run;
+    this.run = async <T>(purpose: string, transition: () => Promise<T>): Promise<T> => {
+      const result = await recordAndRun(purpose, transition);
+      if (purpose === this.gatedPurpose) {
+        this.reachedTail();
+        await this.tail;
+      }
+      return result;
+    };
+  }
+
+  release(): void {
+    this.releaseTail();
+  }
+}
+
 /**
  * Scheduler-faithful transition-timeout model.
  *
@@ -415,17 +512,38 @@ class TransitionTimeoutBarrier extends RecordingBarrier {
   }
 }
 
-/** Models the scheduler rejecting before the shutdown callback is admitted. */
+/** Models the scheduler rejecting before a selected callback is admitted. */
 class WaitPhaseTimeoutBarrier extends RecordingBarrier {
-  constructor() {
+  constructor(private readonly rejectedPurpose = 'system-record.shutdown') {
     super();
     const recordAndRun = this.run;
     this.run = <T>(purpose: string, transition: () => Promise<T>): Promise<T> => {
-      if (purpose === 'system-record.shutdown') {
+      if (purpose === this.rejectedPurpose) {
         return Promise.reject(new Error('STORE_CONTROL_BARRIER_WAIT_TIMEOUT'));
       }
       return recordAndRun(purpose, transition);
     };
+  }
+}
+
+/** Holds the wait phase so recovery can attach before the timeout is reported. */
+class ControlledWaitPhaseTimeoutBarrier extends RecordingBarrier {
+  private rejectWait!: (reason: unknown) => void;
+  private reachedWait!: () => void;
+  readonly waitReached = new Promise<void>((resolve) => { this.reachedWait = resolve; });
+
+  constructor(private readonly rejectedPurpose: string) {
+    super();
+    const recordAndRun = this.run;
+    this.run = <T>(purpose: string, transition: () => Promise<T>): Promise<T> => {
+      if (purpose !== this.rejectedPurpose) return recordAndRun(purpose, transition);
+      this.reachedWait();
+      return new Promise<T>((_resolve, reject) => { this.rejectWait = reject; });
+    };
+  }
+
+  timeout(): void {
+    this.rejectWait(new Error('STORE_CONTROL_BARRIER_WAIT_TIMEOUT'));
   }
 }
 
@@ -1938,6 +2056,372 @@ describe('system-record lane session lifecycle V1', () => {
         executor: new StubExecutor(),
         barrier: barrier.run,
       });
+      await releaseSystemRecordLaneControllerV1(replacement);
+    });
+
+    it('retains the single-writer registration when release wins before recovery registration', async () => {
+      const gatedBarrier = new GateBarrier();
+      gatedBarrier.gate('system-record.recovery');
+      const { controller, recoveryExecutor } = buildRecovery(gatedBarrier);
+      const session = await controller.open(ACTIVATION);
+      recoveryExecutor.parkBeforeRegistration();
+
+      const apply = session.applyVerified({});
+      await recoveryExecutor.registrationReached;
+
+      let released = false;
+      const release = releaseSystemRecordLaneControllerV1(controller).then(() => {
+        released = true;
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+      const releasedBeforeRegistration = released;
+
+      recoveryExecutor.releaseRegistration();
+      const applyResult = await apply.then(
+        (value) => ({ status: 'fulfilled' as const, value }),
+        (reason: unknown) => ({ status: 'rejected' as const, reason }),
+      );
+      let releasedBeforePhysicalSettlement = released;
+      if (applyResult.status === 'fulfilled') {
+        await gatedBarrier.reached('system-record.recovery');
+        await new Promise((resolve) => setImmediate(resolve));
+        releasedBeforePhysicalSettlement = released;
+      }
+
+      gatedBarrier.release('system-record.recovery');
+      await release;
+
+      expect(releasedBeforeRegistration).toBe(false);
+      expect(releasedBeforePhysicalSettlement).toBe(false);
+      expect(applyResult).toEqual({
+        status: 'fulfilled',
+        value: { outcome: 'indeterminate', recoveryGeneration: '1' },
+      });
+
+      const replacement = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff: new RecordingHandoff(),
+        executor: new StubExecutor(),
+        barrier: barrier.run,
+      });
+      await releaseSystemRecordLaneControllerV1(replacement);
+    });
+
+    it('waits for every admitted compatibility call and coalesces concurrent release', async () => {
+      const controller = build();
+      const session = await controller.open(ACTIVATION);
+      executor.park();
+
+      const first = session.applyVerified({ call: 1 });
+      const second = session.applyVerified({ call: 2 });
+      await executor.dispatched;
+      expect(executor.calls).toHaveLength(2);
+
+      let releases = 0;
+      const releaseA = releaseSystemRecordLaneControllerV1(controller).then(() => {
+        releases += 1;
+      });
+      const releaseB = releaseSystemRecordLaneControllerV1(controller).then(() => {
+        releases += 1;
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(releases).toBe(0);
+      await expect(session.applyVerified({ call: 3 })).resolves.toEqual({
+        outcome: 'capability-lost',
+      });
+      expect(executor.calls).toHaveLength(2);
+      expect(() => build()).toThrow(SystemRecordControllerRegistrationError);
+
+      executor.release();
+      await Promise.all([first, second, releaseA, releaseB]);
+      expect(releases).toBe(2);
+
+      const replacement = build();
+      await releaseSystemRecordLaneControllerV1(replacement);
+    });
+
+    it('rejects a recovery registrar retained after its apply invocation settled', async () => {
+      const recoveryHandoff = new RecoveryHandoff(ownership);
+      const capturingExecutor = new CapturingSettlementExecutor();
+      const controller = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff: recoveryHandoff,
+        executor: capturingExecutor,
+        barrier: barrier.run,
+      });
+      const session = await controller.open(ACTIVATION);
+
+      await expect(session.applyVerified({})).resolves.toEqual({ outcome: 'stale' });
+      const binding = capturingExecutor.binding;
+      const registrar = capturingExecutor.registrar;
+      expect(binding).not.toBeNull();
+      expect(registrar).not.toBeNull();
+      expect(() => registrar?.(Object.freeze({
+        ownership: Object.freeze(Object.create(null) as object),
+        binding: binding!,
+        reconcile: async () => Object.freeze({ resolution: 'unavailable' as const }),
+      }))).toThrow(/no longer live for this apply invocation/);
+
+      await releaseSystemRecordLaneControllerV1(controller);
+    });
+
+    it('rejects a copied binding from the live invocation registrar', async () => {
+      const recoveryHandoff = new RecoveryHandoff(ownership);
+      const mismatchedExecutor = new MismatchedBindingExecutor();
+      const controller = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff: recoveryHandoff,
+        executor: mismatchedExecutor,
+        barrier: barrier.run,
+      });
+      const session = await controller.open(ACTIVATION);
+
+      await expect(session.applyVerified({})).resolves.toEqual({ outcome: 'stale' });
+      expect(mismatchedExecutor.registrationError).toEqual(expect.objectContaining({
+        message: expect.stringMatching(/not bound to the admitted apply invocation/),
+      }));
+      await releaseSystemRecordLaneControllerV1(controller);
+    });
+
+    it.each([
+      ['before recovery registration', false],
+      ['after recovery registration', true],
+    ] as const)('drains an executor rejection %s', async (_label, registerBeforeReject) => {
+      const recoveryHandoff = new RecoveryHandoff(ownership);
+      const rejectingExecutor = new RejectingSettlementExecutor(registerBeforeReject);
+      const controller = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff: recoveryHandoff,
+        executor: rejectingExecutor,
+        barrier: barrier.run,
+      });
+      const session = await controller.open(ACTIVATION);
+
+      await expect(session.applyVerified({})).rejects.toThrow(/settlement executor rejected/);
+      if (registerBeforeReject) {
+        await expect(rejectingExecutor.registration?.completion).resolves.toEqual({
+          resolution: 'applied',
+          stateRevision: '2',
+          appliedStateDigest: `0x${'2'.repeat(64)}`,
+        });
+      }
+      await expect(releaseSystemRecordLaneControllerV1(controller)).resolves.toBeUndefined();
+
+      const replacement = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff: new RecordingHandoff(),
+        executor: new StubExecutor(),
+        barrier: barrier.run,
+      });
+      await releaseSystemRecordLaneControllerV1(replacement);
+    });
+
+    it('waits for the recovery barrier tail after the recovery token settles', async () => {
+      const tailBarrier = new SettlementTailGateBarrier('system-record.recovery');
+      const { controller, recoveryExecutor } = buildRecovery(tailBarrier);
+      const session = await controller.open(ACTIVATION);
+
+      await expect(session.applyVerified({})).resolves.toEqual({
+        outcome: 'indeterminate',
+        recoveryGeneration: '1',
+      });
+      await expect(recoveryExecutor.registration?.completion).resolves.toEqual({
+        resolution: 'applied',
+        stateRevision: '2',
+        appliedStateDigest: `0x${'2'.repeat(64)}`,
+      });
+      await tailBarrier.tailReached;
+
+      let released = false;
+      const release = releaseSystemRecordLaneControllerV1(controller).then(() => {
+        released = true;
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(released).toBe(false);
+      expect(() =>
+        createSystemRecordLaneControllerV1({
+          lease: ownership.lease,
+          handoff: new RecordingHandoff(),
+          executor: new StubExecutor(),
+          barrier: barrier.run,
+        }),
+      ).toThrow(SystemRecordControllerRegistrationError);
+
+      tailBarrier.release();
+      await release;
+      const replacement = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff: new RecordingHandoff(),
+        executor: new StubExecutor(),
+        barrier: barrier.run,
+      });
+      await releaseSystemRecordLaneControllerV1(replacement);
+    });
+
+    it('accepts late bound recovery after a disable wait timeout clears the active binding', async () => {
+      const waitTimeout = new WaitPhaseTimeoutBarrier('system-record.disable');
+      const { controller, recoveryExecutor } = buildRecovery(waitTimeout);
+      const session = await controller.open(ACTIVATION);
+      recoveryExecutor.parkBeforeRegistration();
+
+      const apply = session.applyVerified({});
+      await recoveryExecutor.registrationReached;
+      const disable = session.close('disable');
+      let released = false;
+      const release = releaseSystemRecordLaneControllerV1(controller).then(() => {
+        released = true;
+      });
+      await expect(disable).rejects.toThrow(/WAIT_TIMEOUT/);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(released).toBe(false);
+
+      recoveryExecutor.releaseRegistration();
+      await expect(apply).resolves.toEqual({
+        outcome: 'indeterminate',
+        recoveryGeneration: '1',
+      });
+      await release;
+      expect(released).toBe(true);
+
+      const replacement = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff: new RecordingHandoff(),
+        executor: new StubExecutor(),
+        barrier: barrier.run,
+      });
+      await releaseSystemRecordLaneControllerV1(replacement);
+    });
+
+    it('keeps unavailable terminal when recovery registers after a disable wait timeout', async () => {
+      const waitTimeout = new WaitPhaseTimeoutBarrier('system-record.disable');
+      const { controller, recoveryExecutor } = buildRecovery(waitTimeout);
+      const session = await controller.open(ACTIVATION);
+      recoveryExecutor.parkBeforeRegistration();
+
+      const apply = session.applyVerified({});
+      await recoveryExecutor.registrationReached;
+      await expect(session.close('disable')).rejects.toThrow(/WAIT_TIMEOUT/);
+      expect(session.state).toBe('unavailable');
+
+      recoveryExecutor.releaseRegistration();
+      await expect(apply).resolves.toEqual({
+        outcome: 'indeterminate',
+        recoveryGeneration: '1',
+      });
+      await expect(recoveryExecutor.registration?.completion).resolves.toEqual({
+        resolution: 'applied',
+        stateRevision: '2',
+        appliedStateDigest: `0x${'2'.repeat(64)}`,
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(session.state).toBe('unavailable');
+      await expect(controller.open(ACTIVATION)).rejects.toThrow(/terminal \(unavailable\)/);
+    });
+
+    it('retains recovery attached before a disable wait timeout reports', async () => {
+      const waitTimeout = new ControlledWaitPhaseTimeoutBarrier('system-record.disable');
+      const { controller, recoveryExecutor } = buildRecovery(waitTimeout);
+      const session = await controller.open(ACTIVATION);
+      recoveryExecutor.parkBeforeRegistration();
+
+      const apply = session.applyVerified({});
+      await recoveryExecutor.registrationReached;
+      const disable = session.close('disable');
+      await waitTimeout.waitReached;
+
+      recoveryExecutor.releaseRegistration();
+      await expect(apply).resolves.toEqual({
+        outcome: 'indeterminate',
+        recoveryGeneration: '1',
+      });
+      const release = releaseSystemRecordLaneControllerV1(controller);
+      waitTimeout.timeout();
+
+      await expect(disable).rejects.toThrow(/WAIT_TIMEOUT/);
+      await expect(release).rejects.toThrow(/WAIT_TIMEOUT/);
+      expect(() =>
+        createSystemRecordLaneControllerV1({
+          lease: ownership.lease,
+          handoff: new RecordingHandoff(),
+          executor: new StubExecutor(),
+          barrier: barrier.run,
+        }),
+      ).toThrow(SystemRecordControllerRegistrationError);
+      let recoverySettled = false;
+      void recoveryExecutor.registration?.completion.then(() => { recoverySettled = true; });
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(recoverySettled).toBe(false);
+    });
+
+    it('blocks a disable successor that was waiting behind recovery when detach latches', async () => {
+      const { controller, recoveryHandoff, recoveryExecutor } = buildRecovery();
+      const session = await controller.open(ACTIVATION);
+      recoveryHandoff.calls.length = 0;
+      recoveryExecutor.parkReconcile();
+
+      await expect(session.applyVerified({})).resolves.toEqual({
+        outcome: 'indeterminate',
+        recoveryGeneration: '1',
+      });
+      await recoveryExecutor.reconcileReached;
+      const disable = session.close('disable');
+      const release = releaseSystemRecordLaneControllerV1(controller);
+
+      recoveryExecutor.releaseReconcile();
+      await Promise.all([disable, release]);
+      expect(recoveryHandoff.calls).not.toContain('rotateMaterializationEpoch');
+      expect(session.state).toBe('detached');
+
+      const replacement = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff: new RecordingHandoff(),
+        executor: new StubExecutor(),
+        barrier: barrier.run,
+      });
+      await releaseSystemRecordLaneControllerV1(replacement);
+    });
+
+    it('keeps a failed shutdown and late recovery globally claimed', async () => {
+      const waitTimeout = new WaitPhaseTimeoutBarrier();
+      const { controller, recoveryExecutor } = buildRecovery(waitTimeout);
+      const session = await controller.open(ACTIVATION);
+      recoveryExecutor.parkBeforeRegistration();
+
+      const apply = session.applyVerified({});
+      await recoveryExecutor.registrationReached;
+      const shutdown = session.close('shutdown');
+      const release = releaseSystemRecordLaneControllerV1(controller);
+      await expect(shutdown).rejects.toThrow(/WAIT_TIMEOUT/);
+
+      recoveryExecutor.releaseRegistration();
+      await expect(apply).resolves.toEqual({
+        outcome: 'indeterminate',
+        recoveryGeneration: '1',
+      });
+      await expect(release).rejects.toThrow(/WAIT_TIMEOUT/);
+      expect(session.state).toBe('shutdown');
+      expect(() =>
+        createSystemRecordLaneControllerV1({
+          lease: ownership.lease,
+          handoff: new RecordingHandoff(),
+          executor: new StubExecutor(),
+          barrier: barrier.run,
+        }),
+      ).toThrow(SystemRecordControllerRegistrationError);
+    });
+
+    it('retries owner quiescence without rerunning the detach decision', async () => {
+      const controller = build();
+      await controller.open(ACTIVATION);
+
+      await expect(releaseSystemRecordLaneControllerV1(
+        controller,
+        () => Promise.reject(new Error('owner quiescence failed')),
+      )).rejects.toThrow(/owner quiescence failed/);
+      expect(() => build()).toThrow(SystemRecordControllerRegistrationError);
+
+      await releaseSystemRecordLaneControllerV1(controller);
+      const replacement = build();
       await releaseSystemRecordLaneControllerV1(replacement);
     });
 

--- a/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
+++ b/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
@@ -289,6 +289,7 @@ class CapturingSettlementExecutor extends StubExecutor {
 
 class MismatchedBindingExecutor extends StubExecutor {
   registrationError: unknown = null;
+  retryError: unknown = null;
 
   async applyVerifiedSettlementBound(
     _proof: unknown,
@@ -304,6 +305,15 @@ class MismatchedBindingExecutor extends StubExecutor {
       }));
     } catch (error) {
       this.registrationError = error;
+    }
+    try {
+      registerRecovery(Object.freeze({
+        ownership: Object.freeze(Object.create(null) as object),
+        binding,
+        reconcile: async () => Object.freeze({ resolution: 'unavailable' as const }),
+      }));
+    } catch (error) {
+      this.retryError = error;
     }
     return Object.freeze({
       settlement: 'no-mutation',
@@ -2179,6 +2189,9 @@ describe('system-record lane session lifecycle V1', () => {
       await expect(session.applyVerified({})).resolves.toEqual({ outcome: 'stale' });
       expect(mismatchedExecutor.registrationError).toEqual(expect.objectContaining({
         message: expect.stringMatching(/not bound to the admitted apply invocation/),
+      }));
+      expect(mismatchedExecutor.retryError).toEqual(expect.objectContaining({
+        message: expect.stringMatching(/no longer live for this apply invocation/),
       }));
       await releaseSystemRecordLaneControllerV1(controller);
     });


### PR DESCRIPTION
## Summary

- Keep the process-global managed writer claimed while any already-admitted apply can still transfer an uncertain write to recovery. Release now latches detach synchronously, drains the admitted cohort, and joins the complete lifecycle transition before freeing ownership.
- Replace the session-wide recovery callback with an invocation-scoped, exact-once registrar bound to the exact frozen execution binding. Late recovery remains valid after detach or timeout cleanup, while stale, copied, repeated, and post-settlement capabilities fail closed.
- Preserve terminal `unavailable` and `shutdown` states, retain timeout-attached recovery, and follow successor transitions without adding queues, timers, polling, workers, unbounded collections, or ordinary-path promise allocation.

## Related

- Fixes #2159
- Follow-up to #2124
- Continues #2052 without activating the default-unused system-record lane
- Broader lifecycle decomposition remains tracked by #2155

## Diagrams

### Release before recovery registration

Before:

```mermaid
sequenceDiagram
    participant Apply
    participant Lane
    participant Release
    participant Registry
    Apply->>Lane: Admitted atomic apply
    Release->>Lane: Detach sees no recovery
    Lane->>Registry: Free writer slot
    Registry-->>Release: Replacement admitted
    Apply->>Lane: Register uncertain recovery
    Lane-->>Apply: Reject cleared binding
```

After:

```mermaid
sequenceDiagram
    participant Apply
    participant Lane
    participant Release
    participant Registry
    Apply->>Lane: Increment admitted count
    Release->>Lane: Latch detach and wait
    Apply->>Lane: Exact invocation recovery handoff
    Lane->>Lane: Join transition and barrier tail
    Lane->>Registry: Free writer slot
    Registry-->>Release: Replacement admitted safely
```

### Timeout and successor ownership

Before:

```mermaid
sequenceDiagram
    participant Apply
    participant Disable
    participant Lane
    participant Release
    Apply->>Lane: Admitted before registrar
    Disable->>Lane: Wait or join transition
    Lane-->>Disable: Timeout clears mutable binding
    Lane-->>Release: Snapshot old transition only
    Apply->>Lane: Recovery orphaned or rejected
```

After:

```mermaid
sequenceDiagram
    participant Apply
    participant Disable
    participant Lane
    participant Release
    Apply->>Lane: Invocation bound registrar
    Disable->>Lane: Wait or join transition
    Lane-->>Disable: Timeout retains recovery owner
    Release->>Lane: Drain cohort and follow successors
    Lane-->>Release: Resolve only after stable settlement
```

## Files changed

| File | What |
|------|------|
| `packages/storage/src/system-record-materializer-v1.ts` | Add bounded admitted-apply draining, invocation-scoped recovery authority, terminal-state preservation, timeout ownership retention, and successor-aware detach settlement. |
| `packages/storage/test/system-record-materializer-lifecycle-v1.test.ts` | Cover release-before-registration, concurrent drains, registrar misuse, timeout interleavings, terminal recovery, transition successors, barrier tails, exceptions, and release retry behavior. |
| `packages/storage/test/system-record-controller-disposal-v1.test.ts` | Update disposal evidence to prove close waits for an in-flight enable while latching the session terminal synchronously. |

## Test plan

- [x] Reproduced the base defect: release resolved before recovery registration and replacement admission became possible.
- [x] `pnpm --filter @origintrail-official/dkg-storage... build`
- [x] Focused lifecycle and ownership matrix: 156 passed across 5 files.
- [x] Full storage suite: 859 passed, 26 skipped; 3 unrelated Oxigraph worker timing cases exceeded 5 seconds under full parallel load.
- [x] Reran the affected worker timing files serially: 21 passed, 0 failed.
- [x] `git diff --check`
- [x] Two independent post-fix reviews found no remaining concurrency, ownership, resource-strain, API-contract, or evidence blocker.

The PR remains default-unused infrastructure. It changes no activation flag, wire format, RDF schema, scheduler policy, dependency, or public recovery entry point.
