### PR TITLE
test(core): cover System Record V1 public policy helpers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "build": "tsc",
     "test": "pnpm run test:baseline && pnpm run test:system-record",
     "test:baseline": "vitest run --exclude 'test/system-record-*.test.ts' --maxWorkers=4",
-    "test:system-record": "vitest run --exclude 'test/**/!(system-record-*).test.ts' --maxWorkers=1 --no-file-parallelism",
+    "test:system-record": "vitest run --config vitest.system-record.config.ts --maxWorkers=1 --no-file-parallelism",
     "test:system-record-export": "node test/system-record-package-export-v1.mjs",
     "test:system-record-exhaustive": "DKG_SYSTEM_RECORD_EXHAUSTIVE=1 vitest run test/system-record-inventory-v1.test.ts test/system-record-objects-v1.test.ts -t \"complete height-three|exactly 128 MiB\" --maxWorkers=1 --no-file-parallelism",
     "test:coverage": "vitest run --coverage",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "build": "tsc",
     "test": "pnpm run test:baseline && pnpm run test:system-record",
     "test:baseline": "vitest run --exclude 'test/system-record-*.test.ts' --maxWorkers=4",
-    "test:system-record": "vitest run test/system-record-applied-state-v1.test.ts test/system-record-golden-v1.test.ts test/system-record-inventory-v1.test.ts test/system-record-limits-v1.test.ts test/system-record-objects-v1.test.ts test/system-record-policy-helpers-v1.test.ts test/system-record-wire-v1.test.ts --maxWorkers=1 --no-file-parallelism",
+    "test:system-record": "vitest run --config vitest.system-record.config.ts --maxWorkers=1 --no-file-parallelism",
     "test:system-record-export": "node test/system-record-package-export-v1.mjs",
     "test:system-record-exhaustive": "DKG_SYSTEM_RECORD_EXHAUSTIVE=1 vitest run test/system-record-inventory-v1.test.ts test/system-record-objects-v1.test.ts -t \"complete height-three|exactly 128 MiB\" --maxWorkers=1 --no-file-parallelism",
     "test:coverage": "vitest run --coverage",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "build": "tsc",
     "test": "pnpm run test:baseline && pnpm run test:system-record",
     "test:baseline": "vitest run --exclude 'test/system-record-*.test.ts' --maxWorkers=4",
-    "test:system-record": "vitest run test/system-record-applied-state-v1.test.ts test/system-record-golden-v1.test.ts test/system-record-inventory-v1.test.ts test/system-record-limits-v1.test.ts test/system-record-objects-v1.test.ts test/system-record-wire-v1.test.ts --maxWorkers=1 --no-file-parallelism",
+    "test:system-record": "vitest run test/system-record-applied-state-v1.test.ts test/system-record-golden-v1.test.ts test/system-record-inventory-v1.test.ts test/system-record-limits-v1.test.ts test/system-record-objects-v1.test.ts test/system-record-policy-helpers-v1.test.ts test/system-record-wire-v1.test.ts --maxWorkers=1 --no-file-parallelism",
     "test:system-record-export": "node test/system-record-package-export-v1.mjs",
     "test:system-record-exhaustive": "DKG_SYSTEM_RECORD_EXHAUSTIVE=1 vitest run test/system-record-inventory-v1.test.ts test/system-record-objects-v1.test.ts -t \"complete height-three|exactly 128 MiB\" --maxWorkers=1 --no-file-parallelism",
     "test:coverage": "vitest run --coverage",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "build": "tsc",
     "test": "pnpm run test:baseline && pnpm run test:system-record",
     "test:baseline": "vitest run --exclude 'test/system-record-*.test.ts' --maxWorkers=4",
-    "test:system-record": "vitest run --config vitest.system-record.config.ts --maxWorkers=1 --no-file-parallelism",
+    "test:system-record": "vitest run --exclude 'test/**/!(system-record-*).test.ts' --maxWorkers=1 --no-file-parallelism",
     "test:system-record-export": "node test/system-record-package-export-v1.mjs",
     "test:system-record-exhaustive": "DKG_SYSTEM_RECORD_EXHAUSTIVE=1 vitest run test/system-record-inventory-v1.test.ts test/system-record-objects-v1.test.ts -t \"complete height-three|exactly 128 MiB\" --maxWorkers=1 --no-file-parallelism",
     "test:coverage": "vitest run --coverage",

--- a/packages/core/test/system-record-policy-helpers-v1.test.ts
+++ b/packages/core/test/system-record-policy-helpers-v1.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../src/system-record-v1.js';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 const SCHEMA = 'https://schema.org/';
 const DKG = 'https://dkg.network/ontology#';
 const ERC8004 = 'https://eips.ethereum.org/erc-8004#';
@@ -61,6 +62,14 @@ const EXPECTED_ALLOWED_PROFILE_PREDICATES_V1 = {
 const PROFILE_PREDICATE_UNIVERSE_V1 = [
   ...new Set(Object.values(EXPECTED_ALLOWED_PROFILE_PREDICATES_V1).flat()),
 ];
+const UNLISTED_SAME_NAMESPACE_PREDICATES_V1 = [
+  `${RDF}value`,
+  `${SCHEMA}url`,
+  `${DKG}privateKey`,
+  `${ERC8004}agentRegistry`,
+  `${PROV}used`,
+  `${SKILL}endpoint`,
+] as const;
 const PROFILE_SUBJECT_KINDS_V1 = Object.keys(
   EXPECTED_ALLOWED_PROFILE_PREDICATES_V1,
 ) as AgentProfileOwnedSubjectKindV1[];
@@ -134,8 +143,10 @@ describe('system-record V1 public policy helpers', () => {
         expect(isAllowedAgentProfilePredicateV1(kind, predicate), `${kind}: ${predicate}`)
           .toBe(allowed.has(predicate));
       }
-      expect(isAllowedAgentProfilePredicateV1(kind, 'https://example.org/not-in-v1'), kind)
-        .toBe(false);
+      for (const predicate of UNLISTED_SAME_NAMESPACE_PREDICATES_V1) {
+        expect(isAllowedAgentProfilePredicateV1(kind, predicate), `${kind}: ${predicate}`)
+          .toBe(false);
+      }
     }
   });
 

--- a/packages/core/test/system-record-policy-helpers-v1.test.ts
+++ b/packages/core/test/system-record-policy-helpers-v1.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_PROFILE_LINK_PREDICATES_V1,
+  evaluateAuthorityTransitionConflictV1,
+  isAllowedAgentProfilePredicateV1,
+  type AgentProfileAuthorityTransitionV1,
+  type AgentProfileOwnedSubjectKindV1,
+} from '../src/system-record-v1.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const SCHEMA = 'https://schema.org/';
+const DKG = 'https://dkg.network/ontology#';
+const PROV = 'http://www.w3.org/ns/prov#';
+const SKILL = 'https://dkg.origintrail.io/skill#';
+
+const TRANSITION: AgentProfileAuthorityTransitionV1 = {
+  objectType: 'authority-transition',
+  kind: 'agents',
+  mode: 'co-signed',
+  networkId: 'otp:20430',
+  peerId: '12D3KooWJ1TsijH7H5F74hfAD5XishQz3sxrmAtVY37GtNd9CqYf',
+  peerPublicKey: 'ebVWLo_mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ',
+  priorAuthoritySequence: '0',
+  nextAuthoritySequence: '1',
+  priorHeadDigest: `0x${'55'.repeat(32)}`,
+  priorEvmIssuer: '0x677bb7270e0b03f0a2993a697654fb8ecb6dee91',
+  nextEvmIssuer: '0x73a4cde3017cf8d642ae6e637f5321ae5f43c985',
+  nextRoot: 'did:dkg:agent:0x73a4cde3017cf8d642ae6e637f5321ae5f43c985',
+  issuedAt: '2026-08-07T12:00:00Z',
+};
+
+describe('system-record V1 public policy helpers', () => {
+  it('classifies identical, equivocated, and different authority-transition tuples', () => {
+    expect(evaluateAuthorityTransitionConflictV1(TRANSITION, { ...TRANSITION }))
+      .toEqual({ decision: 'stale' });
+
+    expect(evaluateAuthorityTransitionConflictV1(TRANSITION, {
+      ...TRANSITION,
+      issuedAt: '2026-08-07T12:00:01Z',
+    })).toEqual({ decision: 'quarantine', reason: 'transition-equivocation' });
+
+    expect(evaluateAuthorityTransitionConflictV1(TRANSITION, {
+      ...TRANSITION,
+      priorAuthoritySequence: '1',
+      nextAuthoritySequence: '2',
+    })).toEqual({
+      decision: 'reject',
+      reason: 'transitions do not target the same authority tuple',
+    });
+  });
+
+  it('pins allowed and forbidden predicates for every owned-subject kind', () => {
+    const cases: readonly Readonly<{
+      kind: AgentProfileOwnedSubjectKindV1;
+      allowed: string;
+      forbidden: string;
+    }>[] = [
+      { kind: 'root', allowed: `${SCHEMA}name`, forbidden: `${PROV}atTime` },
+      { kind: 'capability', allowed: RDF_TYPE, forbidden: `${SKILL}skill` },
+      { kind: 'offering', allowed: `${SKILL}skill`, forbidden: `${PROV}atTime` },
+      { kind: 'registration', allowed: `${PROV}atTime`, forbidden: `${SCHEMA}name` },
+      { kind: 'hosting', allowed: `${SKILL}contextGraphsServed`, forbidden: `${SKILL}pricePerCall` },
+      { kind: 'x25519', allowed: `${DKG}revokedAt`, forbidden: RDF_TYPE },
+    ];
+
+    for (const { kind, allowed, forbidden } of cases) {
+      expect(isAllowedAgentProfilePredicateV1(kind, allowed), `${kind} allowed predicate`).toBe(true);
+      expect(isAllowedAgentProfilePredicateV1(kind, forbidden), `${kind} forbidden predicate`).toBe(false);
+    }
+  });
+
+  it('allows every exported profile link only on the root subject', () => {
+    const derivedKinds: readonly AgentProfileOwnedSubjectKindV1[] = [
+      'capability',
+      'offering',
+      'registration',
+      'hosting',
+      'x25519',
+    ];
+
+    for (const predicate of Object.values(AGENT_PROFILE_LINK_PREDICATES_V1)) {
+      expect(isAllowedAgentProfilePredicateV1('root', predicate), predicate).toBe(true);
+      for (const kind of derivedKinds) {
+        expect(isAllowedAgentProfilePredicateV1(kind, predicate), `${kind}: ${predicate}`).toBe(false);
+      }
+    }
+  });
+});

--- a/packages/core/test/system-record-policy-helpers-v1.test.ts
+++ b/packages/core/test/system-record-policy-helpers-v1.test.ts
@@ -14,6 +14,11 @@ const DKG = 'https://dkg.network/ontology#';
 const PROV = 'http://www.w3.org/ns/prov#';
 const SKILL = 'https://dkg.origintrail.io/skill#';
 
+const FOREIGN_PEER = {
+  peerId: '12D3KooWHwCJEQ7p5idnD7iQAWyCJHEW7rngKQiXCnEfGef69SV4',
+  peerPublicKey: 'eJ1mZqeYaQKe779cgMrFD5sgUFYZzToKnNFEqVA43-8',
+} as const;
+
 const TRANSITION: AgentProfileAuthorityTransitionV1 = {
   objectType: 'authority-transition',
   kind: 'agents',
@@ -40,33 +45,109 @@ describe('system-record V1 public policy helpers', () => {
       issuedAt: '2026-08-07T12:00:01Z',
     })).toEqual({ decision: 'quarantine', reason: 'transition-equivocation' });
 
-    expect(evaluateAuthorityTransitionConflictV1(TRANSITION, {
-      ...TRANSITION,
-      priorAuthoritySequence: '1',
-      nextAuthoritySequence: '2',
-    })).toEqual({
-      decision: 'reject',
-      reason: 'transitions do not target the same authority tuple',
-    });
+    const foreignTuples: readonly Readonly<{
+      field: string;
+      transition: AgentProfileAuthorityTransitionV1;
+    }>[] = [
+      { field: 'networkId', transition: { ...TRANSITION, networkId: 'otp:20431' } },
+      { field: 'peerId', transition: { ...TRANSITION, ...FOREIGN_PEER } },
+      {
+        field: 'authority sequence',
+        transition: {
+          ...TRANSITION,
+          priorAuthoritySequence: '1',
+          nextAuthoritySequence: '2',
+        },
+      },
+    ];
+    for (const { field, transition } of foreignTuples) {
+      expect(evaluateAuthorityTransitionConflictV1(TRANSITION, transition), field).toEqual({
+        decision: 'reject',
+        reason: 'transitions do not target the same authority tuple',
+      });
+    }
+
+    for (const malformed of [
+      { ...TRANSITION, priorAuthoritySequence: '1' },
+      { ...TRANSITION, nextAuthoritySequence: '2' },
+    ] as const) {
+      expect(() => evaluateAuthorityTransitionConflictV1(TRANSITION, malformed))
+        .toThrow(/must increment/);
+    }
   });
 
-  it('pins allowed and forbidden predicates for every owned-subject kind', () => {
+  it('pins the complete allowed predicate set for every owned-subject kind', () => {
     const cases: readonly Readonly<{
       kind: AgentProfileOwnedSubjectKindV1;
-      allowed: string;
+      allowed: readonly string[];
       forbidden: string;
     }>[] = [
-      { kind: 'root', allowed: `${SCHEMA}name`, forbidden: `${PROV}atTime` },
-      { kind: 'capability', allowed: RDF_TYPE, forbidden: `${SKILL}skill` },
-      { kind: 'offering', allowed: `${SKILL}skill`, forbidden: `${PROV}atTime` },
-      { kind: 'registration', allowed: `${PROV}atTime`, forbidden: `${SCHEMA}name` },
-      { kind: 'hosting', allowed: `${SKILL}contextGraphsServed`, forbidden: `${SKILL}pricePerCall` },
-      { kind: 'x25519', allowed: `${DKG}revokedAt`, forbidden: RDF_TYPE },
+      {
+        kind: 'root',
+        allowed: [
+          RDF_TYPE,
+          `${SCHEMA}name`,
+          `${SCHEMA}description`,
+          `${DKG}peerId`,
+          `${DKG}nodeRole`,
+          `${DKG}publicKey`,
+          `${DKG}relayAddress`,
+          `${DKG}agentAddress`,
+          `${DKG}multiaddr`,
+          `${DKG}lastSeen`,
+          `${DKG}publicEncryptionKey`,
+          `${DKG}encryptionKeyAlgorithm`,
+          `${DKG}encryptionKeyProof`,
+          `${SKILL}framework`,
+          ...Object.values(AGENT_PROFILE_LINK_PREDICATES_V1),
+        ],
+        forbidden: `${PROV}atTime`,
+      },
+      {
+        kind: 'capability',
+        allowed: [RDF_TYPE, `${SCHEMA}name`],
+        forbidden: `${SKILL}skill`,
+      },
+      {
+        kind: 'offering',
+        allowed: [
+          RDF_TYPE,
+          `${SKILL}skill`,
+          `${SKILL}pricePerCall`,
+          `${SKILL}currency`,
+          `${SKILL}successRate`,
+          `${SKILL}pricing`,
+        ],
+        forbidden: `${PROV}atTime`,
+      },
+      {
+        kind: 'registration',
+        allowed: [RDF_TYPE, `${PROV}atTime`],
+        forbidden: `${SCHEMA}name`,
+      },
+      {
+        kind: 'hosting',
+        allowed: [RDF_TYPE, `${SKILL}contextGraphsServed`, `${SKILL}paranetsServed`],
+        forbidden: `${SKILL}pricePerCall`,
+      },
+      {
+        kind: 'x25519',
+        allowed: [
+          `${DKG}revokedAt`,
+          `${DKG}revokedBy`,
+          `${DKG}encryptionKeyRevocationProof`,
+        ],
+        forbidden: RDF_TYPE,
+      },
     ];
 
     for (const { kind, allowed, forbidden } of cases) {
-      expect(isAllowedAgentProfilePredicateV1(kind, allowed), `${kind} allowed predicate`).toBe(true);
-      expect(isAllowedAgentProfilePredicateV1(kind, forbidden), `${kind} forbidden predicate`).toBe(false);
+      for (const predicate of allowed) {
+        expect(isAllowedAgentProfilePredicateV1(kind, predicate), `${kind}: ${predicate}`)
+          .toBe(true);
+      }
+      expect(isAllowedAgentProfilePredicateV1(kind, forbidden), `${kind} forbidden predicate`)
+        .toBe(false);
     }
   });
 

--- a/packages/core/test/system-record-policy-helpers-v1.test.ts
+++ b/packages/core/test/system-record-policy-helpers-v1.test.ts
@@ -11,8 +11,59 @@ import {
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const SCHEMA = 'https://schema.org/';
 const DKG = 'https://dkg.network/ontology#';
+const ERC8004 = 'https://eips.ethereum.org/erc-8004#';
 const PROV = 'http://www.w3.org/ns/prov#';
 const SKILL = 'https://dkg.origintrail.io/skill#';
+
+const EXPECTED_AGENT_PROFILE_LINK_PREDICATES_V1 = {
+  capability: `${ERC8004}capabilities`,
+  offering: `${SKILL}offersSkill`,
+  registration: `${PROV}wasGeneratedBy`,
+  hosting: `${SKILL}hostingProfile`,
+} as const;
+
+const EXPECTED_ALLOWED_PROFILE_PREDICATES_V1 = {
+  root: [
+    RDF_TYPE,
+    `${SCHEMA}name`,
+    `${SCHEMA}description`,
+    `${DKG}peerId`,
+    `${DKG}nodeRole`,
+    `${DKG}publicKey`,
+    `${DKG}relayAddress`,
+    `${DKG}agentAddress`,
+    `${DKG}multiaddr`,
+    `${DKG}lastSeen`,
+    `${DKG}publicEncryptionKey`,
+    `${DKG}encryptionKeyAlgorithm`,
+    `${DKG}encryptionKeyProof`,
+    `${SKILL}framework`,
+    ...Object.values(EXPECTED_AGENT_PROFILE_LINK_PREDICATES_V1),
+  ],
+  capability: [RDF_TYPE, `${SCHEMA}name`],
+  offering: [
+    RDF_TYPE,
+    `${SKILL}skill`,
+    `${SKILL}pricePerCall`,
+    `${SKILL}currency`,
+    `${SKILL}successRate`,
+    `${SKILL}pricing`,
+  ],
+  registration: [RDF_TYPE, `${PROV}atTime`],
+  hosting: [RDF_TYPE, `${SKILL}contextGraphsServed`, `${SKILL}paranetsServed`],
+  x25519: [
+    `${DKG}revokedAt`,
+    `${DKG}revokedBy`,
+    `${DKG}encryptionKeyRevocationProof`,
+  ],
+} as const satisfies Readonly<Record<AgentProfileOwnedSubjectKindV1, readonly string[]>>;
+
+const PROFILE_PREDICATE_UNIVERSE_V1 = [
+  ...new Set(Object.values(EXPECTED_ALLOWED_PROFILE_PREDICATES_V1).flat()),
+];
+const PROFILE_SUBJECT_KINDS_V1 = Object.keys(
+  EXPECTED_ALLOWED_PROFILE_PREDICATES_V1,
+) as AgentProfileOwnedSubjectKindV1[];
 
 const FOREIGN_PEER = {
   peerId: '12D3KooWHwCJEQ7p5idnD7iQAWyCJHEW7rngKQiXCnEfGef69SV4',
@@ -76,95 +127,20 @@ describe('system-record V1 public policy helpers', () => {
     }
   });
 
-  it('pins the complete allowed predicate set for every owned-subject kind', () => {
-    const cases: readonly Readonly<{
-      kind: AgentProfileOwnedSubjectKindV1;
-      allowed: readonly string[];
-      forbidden: string;
-    }>[] = [
-      {
-        kind: 'root',
-        allowed: [
-          RDF_TYPE,
-          `${SCHEMA}name`,
-          `${SCHEMA}description`,
-          `${DKG}peerId`,
-          `${DKG}nodeRole`,
-          `${DKG}publicKey`,
-          `${DKG}relayAddress`,
-          `${DKG}agentAddress`,
-          `${DKG}multiaddr`,
-          `${DKG}lastSeen`,
-          `${DKG}publicEncryptionKey`,
-          `${DKG}encryptionKeyAlgorithm`,
-          `${DKG}encryptionKeyProof`,
-          `${SKILL}framework`,
-          ...Object.values(AGENT_PROFILE_LINK_PREDICATES_V1),
-        ],
-        forbidden: `${PROV}atTime`,
-      },
-      {
-        kind: 'capability',
-        allowed: [RDF_TYPE, `${SCHEMA}name`],
-        forbidden: `${SKILL}skill`,
-      },
-      {
-        kind: 'offering',
-        allowed: [
-          RDF_TYPE,
-          `${SKILL}skill`,
-          `${SKILL}pricePerCall`,
-          `${SKILL}currency`,
-          `${SKILL}successRate`,
-          `${SKILL}pricing`,
-        ],
-        forbidden: `${PROV}atTime`,
-      },
-      {
-        kind: 'registration',
-        allowed: [RDF_TYPE, `${PROV}atTime`],
-        forbidden: `${SCHEMA}name`,
-      },
-      {
-        kind: 'hosting',
-        allowed: [RDF_TYPE, `${SKILL}contextGraphsServed`, `${SKILL}paranetsServed`],
-        forbidden: `${SKILL}pricePerCall`,
-      },
-      {
-        kind: 'x25519',
-        allowed: [
-          `${DKG}revokedAt`,
-          `${DKG}revokedBy`,
-          `${DKG}encryptionKeyRevocationProof`,
-        ],
-        forbidden: RDF_TYPE,
-      },
-    ];
-
-    for (const { kind, allowed, forbidden } of cases) {
-      for (const predicate of allowed) {
+  it('pins the exact predicate matrix for every owned-subject kind', () => {
+    for (const kind of PROFILE_SUBJECT_KINDS_V1) {
+      const allowed = new Set(EXPECTED_ALLOWED_PROFILE_PREDICATES_V1[kind]);
+      for (const predicate of PROFILE_PREDICATE_UNIVERSE_V1) {
         expect(isAllowedAgentProfilePredicateV1(kind, predicate), `${kind}: ${predicate}`)
-          .toBe(true);
+          .toBe(allowed.has(predicate));
       }
-      expect(isAllowedAgentProfilePredicateV1(kind, forbidden), `${kind} forbidden predicate`)
+      expect(isAllowedAgentProfilePredicateV1(kind, 'https://example.org/not-in-v1'), kind)
         .toBe(false);
     }
   });
 
-  it('allows every exported profile link only on the root subject', () => {
-    const derivedKinds: readonly AgentProfileOwnedSubjectKindV1[] = [
-      'capability',
-      'offering',
-      'registration',
-      'hosting',
-      'x25519',
-    ];
-
-    for (const predicate of Object.values(AGENT_PROFILE_LINK_PREDICATES_V1)) {
-      expect(isAllowedAgentProfilePredicateV1('root', predicate), predicate).toBe(true);
-      for (const kind of derivedKinds) {
-        expect(isAllowedAgentProfilePredicateV1(kind, predicate), `${kind}: ${predicate}`).toBe(false);
-      }
-    }
+  it('pins the exported profile link mapping independently', () => {
+    expect(AGENT_PROFILE_LINK_PREDICATES_V1)
+      .toEqual(EXPECTED_AGENT_PROFILE_LINK_PREDICATES_V1);
   });
 });

--- a/packages/core/vitest.system-record.config.ts
+++ b/packages/core/vitest.system-record.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config';
-
-export default defineConfig({
-  test: {
-    include: ['test/system-record-*.test.ts'],
-  },
-});

--- a/packages/core/vitest.system-record.config.ts
+++ b/packages/core/vitest.system-record.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+import coreConfig from './vitest.config.js';
+
+export default defineConfig({
+  ...coreConfig,
+  test: {
+    ...coreConfig.test,
+    include: ['test/system-record-*.test.ts'],
+  },
+});

--- a/packages/core/vitest.system-record.config.ts
+++ b/packages/core/vitest.system-record.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/system-record-*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- add direct contract coverage for identical, equivocated, and different-tuple authority transitions
- pin the exact allowed predicate matrix for every Agent Profile owned-subject kind using test-owned literals
- reject plausible unlisted predicates from every governed RDF vocabulary and pin the exported root-link mapping independently
- keep all matching System Record specs in a positive, serialized test suite that extends the canonical Core Vitest configuration
- make no runtime, protocol, codec, wire-format, or exported-signature changes

## Related

- Fixes #2148
- Follow-up to #2103
- Related to #2052

## Diagrams

- No flow changes. This is a test-only contract-coverage PR.

## Files changed

| File | What |
|------|------|
| `packages/core/test/system-record-policy-helpers-v1.test.ts` | Adds independent, table-driven coverage for both public policy helpers. |
| `packages/core/vitest.system-record.config.ts` | Extends the canonical Core config with the positive System Record suite boundary. |
| `packages/core/package.json` | Runs the complete System Record suite serially through the focused config. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core exec vitest run --config vitest.config.ts test/system-record-policy-helpers-v1.test.ts --maxWorkers=1 --no-file-parallelism` (3 passed)
- [x] `pnpm --filter @origintrail-official/dkg-core... build`
- [x] `pnpm --filter @origintrail-official/dkg-core test:system-record` (84 passed, 2 exhaustive tests skipped)
- [x] `pnpm --filter @origintrail-official/dkg-core test:system-record-export`
- [x] `pnpm --filter @origintrail-official/dkg-core test` (1,692 baseline tests passed; 84 System Record tests passed, 2 exhaustive tests skipped)
- [x] `git diff --check`
