### PR TITLE
test(storage): enforce first-party store-chain participation

### DIFF
--- a/.github/workflows/system-record-managed-ownership.yml
+++ b/.github/workflows/system-record-managed-ownership.yml
@@ -160,6 +160,7 @@ jobs:
             test/managed-terminal-read-through-index-v1.test.ts \
             test/managed-warm-read-composition-v1.test.ts \
             test/managed-read-gate-decorator-coverage-v1.test.ts \
+            test/store-chain-participation-source-v1.test.ts \
             test/system-record-controller-disposal-v1.test.ts \
             test/system-record-capability-probe-errors-v1.test.ts \
             test/graph-set-index-store.test.ts \

--- a/packages/storage/test/store-chain-participation-source-v1.test.ts
+++ b/packages/storage/test/store-chain-participation-source-v1.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from 'node:fs';
-import { basename, join, relative, sep } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as ts from 'typescript';
@@ -17,10 +17,6 @@ interface DecoratorEvidence {
 }
 
 const STORAGE_SOURCE_ROOT = fileURLToPath(new URL('../src/', import.meta.url));
-const AGENT_WRAPPER_PATH = fileURLToPath(
-  new URL('../../agent/src/dkg-agent-base.ts', import.meta.url),
-);
-const AGENT_WRAPPER_NAME = 'createListContextGraphsCacheInvalidatingStore';
 
 const EXPECTED_STORAGE_DECORATORS: Readonly<Record<string, ParticipationMode>> = Object.freeze({
   'changelog-store.ts#ChangelogStore': 'registered',
@@ -176,74 +172,6 @@ function normalizedRelativePath(root: string, path: string): string {
   return relative(root, path).split(sep).join('/');
 }
 
-function objectLiteralHasInnerStore(
-  sourceText: string,
-  fileName: string,
-  functionName: string,
-): boolean {
-  const sourceFile = ts.createSourceFile(
-    fileName,
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-  let foundFunction = false;
-  let exposesInner = false;
-
-  const visit = (node: ts.Node): void => {
-    if (ts.isFunctionDeclaration(node) && node.name?.text === functionName) {
-      foundFunction = true;
-      const innerParameter = node.parameters.find(
-        (parameter) => ts.isIdentifier(parameter.name)
-          && parameter.name.text === 'innerStore'
-          && typeNamesTripleStore(parameter.type, sourceFile),
-      );
-      if (innerParameter === undefined || node.body === undefined) return;
-      const returnedNames = new Set<string>();
-      const returnedObjects: ts.ObjectLiteralExpression[] = [];
-      const collectReturns = (candidate: ts.Node): void => {
-        if (candidate !== node.body && ts.isFunctionLike(candidate)) return;
-        if (ts.isReturnStatement(candidate)) {
-          if (candidate.expression !== undefined && ts.isIdentifier(candidate.expression)) {
-            returnedNames.add(candidate.expression.text);
-          } else if (candidate.expression !== undefined
-            && ts.isObjectLiteralExpression(candidate.expression)) {
-            returnedObjects.push(candidate.expression);
-          }
-        }
-        ts.forEachChild(candidate, collectReturns);
-      };
-      collectReturns(node.body);
-      const collectReturnedDeclarations = (candidate: ts.Node): void => {
-        if (candidate !== node.body && ts.isFunctionLike(candidate)) return;
-        if (ts.isVariableDeclaration(candidate)
-          && ts.isIdentifier(candidate.name)
-          && returnedNames.has(candidate.name.text)
-          && candidate.initializer !== undefined
-          && ts.isObjectLiteralExpression(candidate.initializer)) {
-          returnedObjects.push(candidate.initializer);
-        }
-        ts.forEachChild(candidate, collectReturnedDeclarations);
-      };
-      collectReturnedDeclarations(node.body);
-      exposesInner = returnedObjects.some((object) => object.properties.some((property) => {
-        if (ts.isShorthandPropertyAssignment(property)) {
-          return property.name.text === 'innerStore';
-        }
-        return ts.isPropertyAssignment(property)
-          && propertyNameText(property.name) === 'innerStore'
-          && ts.isIdentifier(property.initializer)
-          && property.initializer.text === 'innerStore';
-      }));
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  if (!foundFunction) throw new Error(`${fileName}: missing ${functionName}`);
-  return exposesInner;
-}
-
 describe('first-party store-chain participation source contract', () => {
   it('classifies every Storage decorator and verifies its traversal evidence', () => {
     const discovered = listTypeScriptSources(STORAGE_SOURCE_ROOT)
@@ -307,25 +235,4 @@ describe('first-party store-chain participation source contract', () => {
     expect(participationViolation(publicParameter, 'public-inner')).toBeNull();
   });
 
-  it('keeps the Agent object-literal forwarder traversable', () => {
-    expect(objectLiteralHasInnerStore(
-      readFileSync(AGENT_WRAPPER_PATH, 'utf8'),
-      basename(AGENT_WRAPPER_PATH),
-      AGENT_WRAPPER_NAME,
-    )).toBe(true);
-  });
-
-  it('rejects an Agent-style object-literal forwarder without innerStore', () => {
-    const broken = `
-      function ${AGENT_WRAPPER_NAME}(innerStore: TripleStore): TripleStore {
-        const unrelated = { innerStore };
-        void unrelated;
-        const wrapper: TripleStore = {
-          listGraphs: () => innerStore.listGraphs(),
-        };
-        return wrapper;
-      }
-    `;
-    expect(objectLiteralHasInnerStore(broken, 'fixture-agent.ts', AGENT_WRAPPER_NAME)).toBe(false);
-  });
 });

--- a/packages/storage/test/store-chain-participation-source-v1.test.ts
+++ b/packages/storage/test/store-chain-participation-source-v1.test.ts
@@ -1,0 +1,331 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { basename, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+type ParticipationMode = 'registered' | 'public-inner';
+
+interface DecoratorEvidence {
+  readonly key: string;
+  readonly location: string;
+  readonly className: string;
+  readonly innerParameter: string;
+  readonly registered: boolean;
+  readonly publicInner: boolean;
+}
+
+const STORAGE_SOURCE_ROOT = fileURLToPath(new URL('../src/', import.meta.url));
+const AGENT_WRAPPER_PATH = fileURLToPath(
+  new URL('../../agent/src/dkg-agent-base.ts', import.meta.url),
+);
+const AGENT_WRAPPER_NAME = 'createListContextGraphsCacheInvalidatingStore';
+
+const EXPECTED_STORAGE_DECORATORS: Readonly<Record<string, ParticipationMode>> = Object.freeze({
+  'changelog-store.ts#ChangelogStore': 'registered',
+  'graph-set-index-store.ts#GraphSetIndexStore': 'registered',
+  'shared-memory-literal-blob-store.ts#SharedMemoryLiteralBlobStore': 'registered',
+});
+
+function propertyNameText(name: ts.PropertyName | undefined): string | null {
+  if (name === undefined) return null;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+function typeNamesTripleStore(type: ts.TypeNode | undefined, sourceFile: ts.SourceFile): boolean {
+  return type !== undefined && /(?:^|\W)TripleStore(?:\W|$)/.test(type.getText(sourceFile));
+}
+
+function classImplementsTripleStore(node: ts.ClassDeclaration, sourceFile: ts.SourceFile): boolean {
+  return node.heritageClauses?.some(
+    (clause) => clause.token === ts.SyntaxKind.ImplementsKeyword
+      && clause.types.some((type) => typeNamesTripleStore(type, sourceFile)),
+  ) ?? false;
+}
+
+function constructorLinkCall(
+  constructor: ts.ConstructorDeclaration,
+  innerParameter: string,
+): boolean {
+  return constructor.body?.statements.some((statement) => {
+    if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)) {
+      return false;
+    }
+    const call = statement.expression;
+    return ts.isIdentifier(call.expression)
+      && call.expression.text === 'linkStoreChainV1'
+      && call.arguments.length >= 2
+      && call.arguments[0]?.kind === ts.SyntaxKind.ThisKeyword
+      && ts.isIdentifier(call.arguments[1]!)
+      && call.arguments[1]!.text === innerParameter;
+  }) ?? false;
+}
+
+function constructorAssignsPublicInner(
+  node: ts.ClassDeclaration,
+  constructor: ts.ConstructorDeclaration,
+  innerParameter: string,
+): boolean {
+  const publicParameterProperty = constructor.parameters.some((parameter) =>
+    ts.isIdentifier(parameter.name)
+    && parameter.name.text === 'innerStore'
+    && innerParameter === 'innerStore'
+    && parameter.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.PublicKeyword
+        || modifier.kind === ts.SyntaxKind.ReadonlyKeyword,
+    ) === true
+    && !parameter.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.PrivateKeyword
+        || modifier.kind === ts.SyntaxKind.ProtectedKeyword,
+    ));
+  if (publicParameterProperty) return true;
+
+  const declaredPublicInner = node.members.some((member) => {
+    if (!ts.isPropertyDeclaration(member) || propertyNameText(member.name) !== 'innerStore') {
+      return false;
+    }
+    return !member.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.PrivateKeyword
+        || modifier.kind === ts.SyntaxKind.ProtectedKeyword,
+    );
+  });
+  if (!declaredPublicInner) return false;
+
+  return constructor.body?.statements.some((statement) => {
+    if (!ts.isExpressionStatement(statement) || !ts.isBinaryExpression(statement.expression)) {
+      return false;
+    }
+    const assignment = statement.expression;
+    return assignment.operatorToken.kind === ts.SyntaxKind.EqualsToken
+      && ts.isPropertyAccessExpression(assignment.left)
+      && assignment.left.expression.kind === ts.SyntaxKind.ThisKeyword
+      && assignment.left.name.text === 'innerStore'
+      && ts.isIdentifier(assignment.right)
+      && assignment.right.text === innerParameter;
+  }) ?? false;
+}
+
+function discoverStorageDecorators(sourceText: string, fileName: string): DecoratorEvidence[] {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const decorators: DecoratorEvidence[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node) && node.name !== undefined
+      && classImplementsTripleStore(node, sourceFile)) {
+      const constructor = node.members.find(ts.isConstructorDeclaration);
+      const inner = constructor?.parameters.find(
+        (parameter) => ts.isIdentifier(parameter.name)
+          && typeNamesTripleStore(parameter.type, sourceFile),
+      );
+      if (constructor !== undefined && inner !== undefined && ts.isIdentifier(inner.name)) {
+        const innerParameter = inner.name.text;
+        const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+        decorators.push({
+          key: `${fileName}#${node.name.text}`,
+          location: `${fileName}:${line}`,
+          className: node.name.text,
+          innerParameter,
+          registered: constructorLinkCall(constructor, innerParameter),
+          publicInner: constructorAssignsPublicInner(node, constructor, innerParameter),
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return decorators;
+}
+
+function participationViolation(
+  evidence: DecoratorEvidence,
+  mode: ParticipationMode,
+): string | null {
+  if (mode === 'registered' && !evidence.registered) {
+    return `${evidence.location} ${evidence.className}: missing linkStoreChainV1(this, ${evidence.innerParameter})`;
+  }
+  if (mode === 'public-inner' && !evidence.publicInner) {
+    return `${evidence.location} ${evidence.className}: missing public innerStore assignment from ${evidence.innerParameter}`;
+  }
+  return null;
+}
+
+function listTypeScriptSources(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listTypeScriptSources(path));
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function normalizedRelativePath(root: string, path: string): string {
+  return relative(root, path).split(sep).join('/');
+}
+
+function objectLiteralHasInnerStore(
+  sourceText: string,
+  fileName: string,
+  functionName: string,
+): boolean {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  let foundFunction = false;
+  let exposesInner = false;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === functionName) {
+      foundFunction = true;
+      const innerParameter = node.parameters.find(
+        (parameter) => ts.isIdentifier(parameter.name)
+          && parameter.name.text === 'innerStore'
+          && typeNamesTripleStore(parameter.type, sourceFile),
+      );
+      if (innerParameter === undefined || node.body === undefined) return;
+      const returnedNames = new Set<string>();
+      const returnedObjects: ts.ObjectLiteralExpression[] = [];
+      const collectReturns = (candidate: ts.Node): void => {
+        if (candidate !== node.body && ts.isFunctionLike(candidate)) return;
+        if (ts.isReturnStatement(candidate)) {
+          if (candidate.expression !== undefined && ts.isIdentifier(candidate.expression)) {
+            returnedNames.add(candidate.expression.text);
+          } else if (candidate.expression !== undefined
+            && ts.isObjectLiteralExpression(candidate.expression)) {
+            returnedObjects.push(candidate.expression);
+          }
+        }
+        ts.forEachChild(candidate, collectReturns);
+      };
+      collectReturns(node.body);
+      const collectReturnedDeclarations = (candidate: ts.Node): void => {
+        if (candidate !== node.body && ts.isFunctionLike(candidate)) return;
+        if (ts.isVariableDeclaration(candidate)
+          && ts.isIdentifier(candidate.name)
+          && returnedNames.has(candidate.name.text)
+          && candidate.initializer !== undefined
+          && ts.isObjectLiteralExpression(candidate.initializer)) {
+          returnedObjects.push(candidate.initializer);
+        }
+        ts.forEachChild(candidate, collectReturnedDeclarations);
+      };
+      collectReturnedDeclarations(node.body);
+      exposesInner = returnedObjects.some((object) => object.properties.some((property) => {
+        if (ts.isShorthandPropertyAssignment(property)) {
+          return property.name.text === 'innerStore';
+        }
+        return ts.isPropertyAssignment(property)
+          && propertyNameText(property.name) === 'innerStore'
+          && ts.isIdentifier(property.initializer)
+          && property.initializer.text === 'innerStore';
+      }));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!foundFunction) throw new Error(`${fileName}: missing ${functionName}`);
+  return exposesInner;
+}
+
+describe('first-party store-chain participation source contract', () => {
+  it('classifies every Storage decorator and verifies its traversal evidence', () => {
+    const discovered = listTypeScriptSources(STORAGE_SOURCE_ROOT)
+      .flatMap((path) => discoverStorageDecorators(
+        readFileSync(path, 'utf8'),
+        normalizedRelativePath(STORAGE_SOURCE_ROOT, path),
+      ))
+      .sort((left, right) => left.key.localeCompare(right.key));
+
+    expect(discovered.map(({ key }) => key)).toEqual(
+      Object.keys(EXPECTED_STORAGE_DECORATORS).sort(),
+    );
+    expect(discovered.flatMap((evidence) => {
+      const mode = EXPECTED_STORAGE_DECORATORS[evidence.key];
+      if (mode === undefined) return [`${evidence.location} ${evidence.className}: unclassified`];
+      const violation = participationViolation(evidence, mode);
+      return violation === null ? [] : [violation];
+    })).toEqual([]);
+  });
+
+  it('mechanically rejects a non-exported decorator that forgets participation', () => {
+    const [evidence] = discoverStorageDecorators(`
+      class ForgetfulDecoratorStore implements TripleStore {
+        constructor(private readonly inner: TripleStore) {
+          const neverCalled = () => linkStoreChainV1(this, inner);
+          void neverCalled;
+        }
+      }
+    `, 'fixture.ts');
+
+    expect(evidence).toBeDefined();
+    expect(participationViolation(evidence!, 'registered')).toBe(
+      'fixture.ts:2 ForgetfulDecoratorStore: missing linkStoreChainV1(this, inner)',
+    );
+  });
+
+  it('accepts both supported first-party participation modes', () => {
+    const registered = discoverStorageDecorators(`
+      class RegisteredStore implements TripleStore {
+        constructor(private readonly inner: TripleStore) {
+          linkStoreChainV1(this, inner);
+        }
+      }
+    `, 'registered.ts')[0]!;
+    const publicInner = discoverStorageDecorators(`
+      class PublicInnerStore implements TripleStore {
+        readonly innerStore: TripleStore;
+        constructor(inner: TripleStore) {
+          this.innerStore = inner;
+        }
+      }
+    `, 'public-inner.ts')[0]!;
+    const publicParameter = discoverStorageDecorators(`
+      class PublicParameterStore implements TripleStore {
+        constructor(readonly innerStore: TripleStore) {}
+      }
+    `, 'public-parameter.ts')[0]!;
+
+    expect(participationViolation(registered, 'registered')).toBeNull();
+    expect(participationViolation(publicInner, 'public-inner')).toBeNull();
+    expect(participationViolation(publicParameter, 'public-inner')).toBeNull();
+  });
+
+  it('keeps the Agent object-literal forwarder traversable', () => {
+    expect(objectLiteralHasInnerStore(
+      readFileSync(AGENT_WRAPPER_PATH, 'utf8'),
+      basename(AGENT_WRAPPER_PATH),
+      AGENT_WRAPPER_NAME,
+    )).toBe(true);
+  });
+
+  it('rejects an Agent-style object-literal forwarder without innerStore', () => {
+    const broken = `
+      function ${AGENT_WRAPPER_NAME}(innerStore: TripleStore): TripleStore {
+        const unrelated = { innerStore };
+        void unrelated;
+        const wrapper: TripleStore = {
+          listGraphs: () => innerStore.listGraphs(),
+        };
+        return wrapper;
+      }
+    `;
+    expect(objectLiteralHasInnerStore(broken, 'fixture-agent.ts', AGENT_WRAPPER_NAME)).toBe(false);
+  });
+});

--- a/packages/storage/test/store-chain-participation-source-v1.test.ts
+++ b/packages/storage/test/store-chain-participation-source-v1.test.ts
@@ -5,45 +5,26 @@ import { fileURLToPath } from 'node:url';
 import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-type ParticipationMode = 'registered' | 'public-inner';
-
-interface DecoratorEvidence {
+interface DecoratorSource {
   readonly key: string;
   readonly location: string;
   readonly className: string;
   readonly innerParameter: string;
-  readonly registered: boolean;
-  readonly publicInner: boolean;
+  readonly directlyRegistered: boolean;
 }
 
 const STORAGE_SOURCE_ROOT = fileURLToPath(new URL('../src/', import.meta.url));
-
-const EXPECTED_STORAGE_DECORATORS: Readonly<Record<string, ParticipationMode>> = Object.freeze({
-  'changelog-store.ts#ChangelogStore': 'registered',
-  'graph-set-index-store.ts#GraphSetIndexStore': 'registered',
-  'shared-memory-literal-blob-store.ts#SharedMemoryLiteralBlobStore': 'registered',
-});
-
-function propertyNameText(name: ts.PropertyName | undefined): string | null {
-  if (name === undefined) return null;
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
-    return name.text;
-  }
-  return null;
-}
+const EXPECTED_STORAGE_DECORATORS = Object.freeze([
+  'changelog-store.ts#ChangelogStore',
+  'graph-set-index-store.ts#GraphSetIndexStore',
+  'shared-memory-literal-blob-store.ts#SharedMemoryLiteralBlobStore',
+]);
 
 function typeNamesTripleStore(type: ts.TypeNode | undefined, sourceFile: ts.SourceFile): boolean {
   return type !== undefined && /(?:^|\W)TripleStore(?:\W|$)/.test(type.getText(sourceFile));
 }
 
-function classImplementsTripleStore(node: ts.ClassDeclaration, sourceFile: ts.SourceFile): boolean {
-  return node.heritageClauses?.some(
-    (clause) => clause.token === ts.SyntaxKind.ImplementsKeyword
-      && clause.types.some((type) => typeNamesTripleStore(type, sourceFile)),
-  ) ?? false;
-}
-
-function constructorLinkCall(
+function directlyRegisters(
   constructor: ts.ConstructorDeclaration,
   innerParameter: string,
 ): boolean {
@@ -61,51 +42,7 @@ function constructorLinkCall(
   }) ?? false;
 }
 
-function constructorAssignsPublicInner(
-  node: ts.ClassDeclaration,
-  constructor: ts.ConstructorDeclaration,
-  innerParameter: string,
-): boolean {
-  const publicParameterProperty = constructor.parameters.some((parameter) =>
-    ts.isIdentifier(parameter.name)
-    && parameter.name.text === 'innerStore'
-    && innerParameter === 'innerStore'
-    && parameter.modifiers?.some(
-      (modifier) => modifier.kind === ts.SyntaxKind.PublicKeyword
-        || modifier.kind === ts.SyntaxKind.ReadonlyKeyword,
-    ) === true
-    && !parameter.modifiers?.some(
-      (modifier) => modifier.kind === ts.SyntaxKind.PrivateKeyword
-        || modifier.kind === ts.SyntaxKind.ProtectedKeyword,
-    ));
-  if (publicParameterProperty) return true;
-
-  const declaredPublicInner = node.members.some((member) => {
-    if (!ts.isPropertyDeclaration(member) || propertyNameText(member.name) !== 'innerStore') {
-      return false;
-    }
-    return !member.modifiers?.some(
-      (modifier) => modifier.kind === ts.SyntaxKind.PrivateKeyword
-        || modifier.kind === ts.SyntaxKind.ProtectedKeyword,
-    );
-  });
-  if (!declaredPublicInner) return false;
-
-  return constructor.body?.statements.some((statement) => {
-    if (!ts.isExpressionStatement(statement) || !ts.isBinaryExpression(statement.expression)) {
-      return false;
-    }
-    const assignment = statement.expression;
-    return assignment.operatorToken.kind === ts.SyntaxKind.EqualsToken
-      && ts.isPropertyAccessExpression(assignment.left)
-      && assignment.left.expression.kind === ts.SyntaxKind.ThisKeyword
-      && assignment.left.name.text === 'innerStore'
-      && ts.isIdentifier(assignment.right)
-      && assignment.right.text === innerParameter;
-  }) ?? false;
-}
-
-function discoverStorageDecorators(sourceText: string, fileName: string): DecoratorEvidence[] {
+function discoverDecorators(sourceText: string, fileName: string): DecoratorSource[] {
   const sourceFile = ts.createSourceFile(
     fileName,
     sourceText,
@@ -113,87 +50,73 @@ function discoverStorageDecorators(sourceText: string, fileName: string): Decora
     true,
     ts.ScriptKind.TS,
   );
-  const decorators: DecoratorEvidence[] = [];
-
+  const found: DecoratorSource[] = [];
   const visit = (node: ts.Node): void => {
     if (ts.isClassDeclaration(node) && node.name !== undefined
-      && classImplementsTripleStore(node, sourceFile)) {
+      && node.heritageClauses?.some(
+        (clause) => clause.token === ts.SyntaxKind.ImplementsKeyword
+          && clause.types.some((type) => typeNamesTripleStore(type, sourceFile)),
+      )) {
       const constructor = node.members.find(ts.isConstructorDeclaration);
       const inner = constructor?.parameters.find(
         (parameter) => ts.isIdentifier(parameter.name)
           && typeNamesTripleStore(parameter.type, sourceFile),
       );
       if (constructor !== undefined && inner !== undefined && ts.isIdentifier(inner.name)) {
-        const innerParameter = inner.name.text;
         const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
-        decorators.push({
+        found.push({
           key: `${fileName}#${node.name.text}`,
           location: `${fileName}:${line}`,
           className: node.name.text,
-          innerParameter,
-          registered: constructorLinkCall(constructor, innerParameter),
-          publicInner: constructorAssignsPublicInner(node, constructor, innerParameter),
+          innerParameter: inner.name.text,
+          directlyRegistered: directlyRegisters(constructor, inner.name.text),
         });
       }
     }
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);
-  return decorators;
-}
-
-function participationViolation(
-  evidence: DecoratorEvidence,
-  mode: ParticipationMode,
-): string | null {
-  if (mode === 'registered' && !evidence.registered) {
-    return `${evidence.location} ${evidence.className}: missing linkStoreChainV1(this, ${evidence.innerParameter})`;
-  }
-  if (mode === 'public-inner' && !evidence.publicInner) {
-    return `${evidence.location} ${evidence.className}: missing public innerStore assignment from ${evidence.innerParameter}`;
-  }
-  return null;
+  return found;
 }
 
 function listTypeScriptSources(directory: string): string[] {
-  const files: string[] = [];
-  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = join(directory, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...listTypeScriptSources(path));
-    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
-      files.push(path);
-    }
-  }
-  return files;
+    if (entry.isDirectory()) return listTypeScriptSources(path);
+    return entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')
+      ? [path]
+      : [];
+  });
 }
 
-function normalizedRelativePath(root: string, path: string): string {
-  return relative(root, path).split(sep).join('/');
+function relativeSourcePath(path: string): string {
+  return relative(STORAGE_SOURCE_ROOT, path).split(sep).join('/');
+}
+
+function registrationViolation(decorator: DecoratorSource): string | null {
+  return decorator.directlyRegistered
+    ? null
+    : `${decorator.location} ${decorator.className}: missing linkStoreChainV1(this, ${decorator.innerParameter})`;
 }
 
 describe('first-party store-chain participation source contract', () => {
-  it('classifies every Storage decorator and verifies its traversal evidence', () => {
+  it('requires direct registration from every Storage-owned decorator', () => {
     const discovered = listTypeScriptSources(STORAGE_SOURCE_ROOT)
-      .flatMap((path) => discoverStorageDecorators(
+      .flatMap((path) => discoverDecorators(
         readFileSync(path, 'utf8'),
-        normalizedRelativePath(STORAGE_SOURCE_ROOT, path),
+        relativeSourcePath(path),
       ))
       .sort((left, right) => left.key.localeCompare(right.key));
 
-    expect(discovered.map(({ key }) => key)).toEqual(
-      Object.keys(EXPECTED_STORAGE_DECORATORS).sort(),
-    );
-    expect(discovered.flatMap((evidence) => {
-      const mode = EXPECTED_STORAGE_DECORATORS[evidence.key];
-      if (mode === undefined) return [`${evidence.location} ${evidence.className}: unclassified`];
-      const violation = participationViolation(evidence, mode);
+    expect(discovered.map(({ key }) => key)).toEqual(EXPECTED_STORAGE_DECORATORS);
+    expect(discovered.flatMap((decorator) => {
+      const violation = registrationViolation(decorator);
       return violation === null ? [] : [violation];
     })).toEqual([]);
   });
 
-  it('mechanically rejects a non-exported decorator that forgets participation', () => {
-    const [evidence] = discoverStorageDecorators(`
+  it('rejects a non-exported decorator whose registration is not executed', () => {
+    const [decorator] = discoverDecorators(`
       class ForgetfulDecoratorStore implements TripleStore {
         constructor(private readonly inner: TripleStore) {
           const neverCalled = () => linkStoreChainV1(this, inner);
@@ -202,37 +125,9 @@ describe('first-party store-chain participation source contract', () => {
       }
     `, 'fixture.ts');
 
-    expect(evidence).toBeDefined();
-    expect(participationViolation(evidence!, 'registered')).toBe(
+    expect(decorator).toBeDefined();
+    expect(registrationViolation(decorator!)).toBe(
       'fixture.ts:2 ForgetfulDecoratorStore: missing linkStoreChainV1(this, inner)',
     );
   });
-
-  it('accepts both supported first-party participation modes', () => {
-    const registered = discoverStorageDecorators(`
-      class RegisteredStore implements TripleStore {
-        constructor(private readonly inner: TripleStore) {
-          linkStoreChainV1(this, inner);
-        }
-      }
-    `, 'registered.ts')[0]!;
-    const publicInner = discoverStorageDecorators(`
-      class PublicInnerStore implements TripleStore {
-        readonly innerStore: TripleStore;
-        constructor(inner: TripleStore) {
-          this.innerStore = inner;
-        }
-      }
-    `, 'public-inner.ts')[0]!;
-    const publicParameter = discoverStorageDecorators(`
-      class PublicParameterStore implements TripleStore {
-        constructor(readonly innerStore: TripleStore) {}
-      }
-    `, 'public-parameter.ts')[0]!;
-
-    expect(participationViolation(registered, 'registered')).toBeNull();
-    expect(participationViolation(publicInner, 'public-inner')).toBeNull();
-    expect(participationViolation(publicParameter, 'public-inner')).toBeNull();
-  });
-
 });

--- a/packages/storage/test/store-chain-participation-source-v1.test.ts
+++ b/packages/storage/test/store-chain-participation-source-v1.test.ts
@@ -20,8 +20,22 @@ const EXPECTED_STORAGE_DECORATORS = Object.freeze([
   'shared-memory-literal-blob-store.ts#SharedMemoryLiteralBlobStore',
 ]);
 
-function typeNamesTripleStore(type: ts.TypeNode | undefined, sourceFile: ts.SourceFile): boolean {
-  return type !== undefined && /(?:^|\W)TripleStore(?:\W|$)/.test(type.getText(sourceFile));
+function entityNamesTripleStore(name: ts.EntityName): boolean {
+  return ts.isIdentifier(name)
+    ? name.text === 'TripleStore'
+    : name.right.text === 'TripleStore';
+}
+
+function expressionNamesTripleStore(expression: ts.Expression): boolean {
+  return ts.isIdentifier(expression)
+    ? expression.text === 'TripleStore'
+    : ts.isPropertyAccessExpression(expression) && expression.name.text === 'TripleStore';
+}
+
+function typeNamesTripleStore(type: ts.TypeNode | undefined): boolean {
+  return type !== undefined
+    && ts.isTypeReferenceNode(type)
+    && entityNamesTripleStore(type.typeName);
 }
 
 function directlyRegisters(
@@ -55,12 +69,12 @@ function discoverDecorators(sourceText: string, fileName: string): DecoratorSour
     if (ts.isClassDeclaration(node) && node.name !== undefined
       && node.heritageClauses?.some(
         (clause) => clause.token === ts.SyntaxKind.ImplementsKeyword
-          && clause.types.some((type) => typeNamesTripleStore(type, sourceFile)),
+          && clause.types.some((type) => expressionNamesTripleStore(type.expression)),
       )) {
       const constructor = node.members.find(ts.isConstructorDeclaration);
       const inner = constructor?.parameters.find(
         (parameter) => ts.isIdentifier(parameter.name)
-          && typeNamesTripleStore(parameter.type, sourceFile),
+          && typeNamesTripleStore(parameter.type),
       );
       if (constructor !== undefined && inner !== undefined && ts.isIdentifier(inner.name)) {
         const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
@@ -129,5 +143,20 @@ describe('first-party store-chain participation source contract', () => {
     expect(registrationViolation(decorator!)).toBe(
       'fixture.ts:2 ForgetfulDecoratorStore: missing linkStoreChainV1(this, inner)',
     );
+  });
+
+  it('accepts namespace-qualified TripleStore references', () => {
+    const [decorator] = discoverDecorators(`
+      class QualifiedDecoratorStore implements storage.TripleStore {
+        constructor(private readonly inner: storage.TripleStore) {
+          linkStoreChainV1(this, inner);
+        }
+      }
+    `, 'qualified-fixture.ts');
+
+    expect(decorator).toMatchObject({
+      key: 'qualified-fixture.ts#QualifiedDecoratorStore',
+      directlyRegistered: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Makes the remaining first-party store-chain participation gap in #2168 mechanically fail CI: a non-exported Storage-owned `TripleStore` decorator that accepts an inner store but omits the canonical direct registration call is discovered and named.
- Keeps package ownership clean: the new AST contract inspects only Storage decorators, while the existing Agent package runtime suite proves its object-literal forwarder reaches the real managed read gate.
- Adds no production registry, traversal, declaration, scheduler, allocation, or public API work. Existing runtime resolution remains unchanged; this is a repository-source contract for established first-party TypeScript patterns, not a claim about arbitrary external JavaScript wrappers.

## Related

- Fixes #2168
- Follow-up to #2157 and #2170
- Related to #2166
- Part of #2052

## Diagrams

### First-party decorator participation gate

Before:

```mermaid
sequenceDiagram
    participant Developer
    participant FactoryTest as Factory runtime test
    participant Resolver as Capability resolver
    Developer->>FactoryTest: Add non-exported decorator outside current composition
    FactoryTest-->>Developer: Existing factory composition still passes
    Note over Resolver: Forgotten private inner edge can terminate a future walk as null
```

After:

```mermaid
sequenceDiagram
    participant Developer
    participant ASTGate as AST conformance gate
    participant FactoryTest as Factory runtime test
    participant Resolver as Capability resolver
    Developer->>ASTGate: Add any first-party TripleStore decorator
    ASTGate->>ASTGate: Discover and require classification
    ASTGate->>ASTGate: Verify direct linkStoreChainV1 registration
    alt Participation omitted
        ASTGate-->>Developer: Fail with file and class name
    else Participation proven
        ASTGate->>FactoryTest: Existing runtime composition remains green
        FactoryTest->>Resolver: Resolve through real wrapper chain
    end
```

## Files changed

| File | What |
|------|------|
| `packages/storage/test/store-chain-participation-source-v1.test.ts` | Inventories non-exported Storage decorators using explicit AST type predicates, requires direct constructor registration, and proves an uncalled nested registration does not pass. |
| `.github/workflows/system-record-managed-ownership.yml` | Runs the new contract in the existing Storage ownership lane. |

## Test plan

- [x] Baseline: `managed-read-gate-decorator-coverage-v1.test.ts` passes 11/11.
- [x] Baseline: `managed-read-gate-through-agent-wrapper-v1.test.ts` passes 4/4.
- [x] Focused Storage: new source contract plus runtime decorator coverage pass 14/14.
- [x] Exact managed-ownership Storage lane passes 31 files / 530 tests.
- [x] Agent facade conformance passes 2 files / 13 tests.
- [x] `pnpm --filter @origintrail-official/dkg-storage build` passes.
- [x] `pnpm --filter @origintrail-official/dkg-agent build` passes, including type and package-root gates.
- [x] Mutation proof: an unexported decorator with registration hidden in an uncalled callback still fails with `missing linkStoreChainV1(this, inner)`; namespace-qualified `TripleStore` references are accepted.
- [x] `git diff --check` passes; no generated deployments, local plans, secrets, or unrelated files are included.