### PR TITLE
fix(publisher): keep workspace head writes in ACK lane

### DIFF
--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -943,6 +943,10 @@ export class StorageACKHandler {
         metadata,
         ackStoreOptions('storage-ack.persistGraphScoped.insertOperationMeta', signal),
       );
+      // The current-head pointer is a delete/insert pair. Once that commit tail
+      // starts it must finish (including flush), even if the ACK deadline has
+      // already returned a decline; aborting between the two loses the last
+      // complete pointer. It remains isolated in the reserved ACK lane.
       await storeKnowledgeAssetWorkspaceHead({
         store: this.store,
         graphManager: this.graphManager,
@@ -951,13 +955,10 @@ export class StorageACKHandler {
         assertionVersion: graphPublish.scope.assertionVersion,
         shareOperationId: operationId,
         subGraphName: graphPublish.subGraphName,
-        queryOptions: ackStoreOptions(
-          'storage-ack.persistGraphScoped.workspaceHead',
-          signal,
-        ),
+        queryOptions: ackStoreOptions('storage-ack.persistGraphScoped.workspaceHead'),
       });
       await this.store.flush?.(
-        ackStoreOptions('storage-ack.persistGraphScoped.flush', signal),
+        ackStoreOptions('storage-ack.persistGraphScoped.flush'),
       );
     }, signal);
     return result.ok ? { ok: true } : result;

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -951,6 +951,10 @@ export class StorageACKHandler {
         assertionVersion: graphPublish.scope.assertionVersion,
         shareOperationId: operationId,
         subGraphName: graphPublish.subGraphName,
+        queryOptions: ackStoreOptions(
+          'storage-ack.persistGraphScoped.workspaceHead',
+          signal,
+        ),
       });
       await this.store.flush?.(
         ackStoreOptions('storage-ack.persistGraphScoped.flush', signal),

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -1,4 +1,4 @@
-import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import type { Quad, QueryOptions, TripleStore } from '@origintrail-official/dkg-storage';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -318,6 +318,7 @@ export async function storeKnowledgeAssetWorkspaceHead(params: {
   assertionVersion: string | number | bigint;
   shareOperationId: string;
   subGraphName?: string;
+  queryOptions?: QueryOptions;
 }): Promise<void> {
   const scope = createGraphKnowledgeAssetScope(params.kaUal, params.assertionVersion);
   const subGraphName = normalizeOptionalSubGraphName(params.subGraphName);
@@ -332,7 +333,7 @@ export async function storeKnowledgeAssetWorkspaceHead(params: {
     scope,
     subGraphName,
   );
-  await params.store.deleteByPattern({ graph: metaGraph, subject });
+  await params.store.deleteByPattern({ graph: metaGraph, subject }, params.queryOptions);
   const rows: Quad[] = [
     { subject, predicate: `${DKG}contentScopeVersion`, object: intLit(GRAPH_KA_CONTENT_SCOPE_VERSION), graph: metaGraph },
     { subject, predicate: `${DKG}kaUal`, object: scope.ual, graph: metaGraph },
@@ -340,7 +341,7 @@ export async function storeKnowledgeAssetWorkspaceHead(params: {
     { subject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: metaGraph },
     { subject, predicate: `${DKG}shareOperationId`, object: lit(params.shareOperationId), graph: metaGraph },
   ];
-  await params.store.insert(rows);
+  await params.store.insert(rows, params.queryOptions);
 }
 
 export async function resolveWorkspaceSelection(params: {

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -25,6 +25,17 @@ const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
 const XSD = 'http://www.w3.org/2001/XMLSchema#';
 
+function workspaceHeadStoreOptions(
+  options: QueryOptions | undefined,
+  operation: 'deleteByPattern' | 'insert',
+): QueryOptions | undefined {
+  if (!options) return undefined;
+  return {
+    ...options,
+    ...(options.source ? { source: `${options.source}.${operation}` } : {}),
+  };
+}
+
 export type WorkspaceSelection = 'all' | { rootEntities: readonly string[] };
 
 export interface ResolvedWorkspaceOperation {
@@ -333,7 +344,10 @@ export async function storeKnowledgeAssetWorkspaceHead(params: {
     scope,
     subGraphName,
   );
-  await params.store.deleteByPattern({ graph: metaGraph, subject }, params.queryOptions);
+  await params.store.deleteByPattern(
+    { graph: metaGraph, subject },
+    workspaceHeadStoreOptions(params.queryOptions, 'deleteByPattern'),
+  );
   const rows: Quad[] = [
     { subject, predicate: `${DKG}contentScopeVersion`, object: intLit(GRAPH_KA_CONTENT_SCOPE_VERSION), graph: metaGraph },
     { subject, predicate: `${DKG}kaUal`, object: scope.ual, graph: metaGraph },
@@ -341,7 +355,10 @@ export async function storeKnowledgeAssetWorkspaceHead(params: {
     { subject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: metaGraph },
     { subject, predicate: `${DKG}shareOperationId`, object: lit(params.shareOperationId), graph: metaGraph },
   ];
-  await params.store.insert(rows, params.queryOptions);
+  await params.store.insert(
+    rows,
+    workspaceHeadStoreOptions(params.queryOptions, 'insert'),
+  );
 }
 
 export async function resolveWorkspaceSelection(params: {

--- a/packages/publisher/test/storage-ack-priority-lane.test.ts
+++ b/packages/publisher/test/storage-ack-priority-lane.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ethers } from 'ethers';
 import {
   decodeStorageACK,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
   isStorageACKDecline,
   STORAGE_ACK_DECLINE_CODES,
   TypedEventBus,
@@ -71,6 +72,27 @@ function inlineStagingPublishIntent(): Uint8Array {
     tokenAmountStr: '1000',
     merkleLeafCount: swmMerkleLeafCount,
     stagingQuads,
+  });
+}
+
+function graphScopedPublishIntent(): Uint8Array {
+  return encodePublishIntent({
+    merkleRoot,
+    contextGraphId,
+    publisherPeerId: 'publisher-0',
+    publicByteSize: 300,
+    isPrivate: false,
+    kaCount: 1,
+    rootEntities: [],
+    epochs: 1,
+    tokenAmountStr: '1000',
+    merkleLeafCount: swmMerkleLeafCount,
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7',
+    assertionVersion: '1',
+    publicTripleCount: swmQuads.length,
+    privateTripleCount: 0,
+    accessPolicy: 'public',
   });
 }
 
@@ -278,5 +300,28 @@ describe('StorageACKHandler priority store lane', () => {
     expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
     expect(new Set(signals).size).toBe(1);
     expect(signals[0]?.aborted).toBe(false);
+  });
+
+  it('keeps graph-scoped workspace-head persistence in the ACK lane', async () => {
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
+    const events: string[] = [];
+    const store = new PriorityLaneStore(scheduler, events);
+    const handler = createHandler(store, { ackHandlerDeadlineMs: 1_000 });
+
+    const response = await handler.handler(graphScopedPublishIntent(), fakePeerId);
+    const decoded = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(decoded)).toBe(false);
+    expect(store.writeCalls.map((call) => call.source)).toEqual([
+      'storage-ack.persistGraphScoped.deleteOperationMeta',
+      'storage-ack.persistGraphScoped.insertOperationMeta',
+      'storage-ack.persistGraphScoped.workspaceHead',
+      'storage-ack.persistGraphScoped.workspaceHead',
+      'storage-ack.persistGraphScoped.flush',
+    ]);
+    expect(store.writeCalls.every((call) => call.priority === 'ack')).toBe(true);
+    const signals = store.writeCalls.map((call) => call.signal);
+    expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
+    expect(new Set(signals).size).toBe(1);
   });
 });

--- a/packages/publisher/test/storage-ack-priority-lane.test.ts
+++ b/packages/publisher/test/storage-ack-priority-lane.test.ts
@@ -25,6 +25,7 @@ const swmGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
 const coreWallet = ethers.Wallet.createRandom();
 const fakePeerId = { toString: () => 'publisher-peer' } as any;
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 function makeQuad(s: string, p: string, o: string, g = swmGraph): Quad {
   return { subject: s, predicate: p, object: o, graph: g };
@@ -115,7 +116,10 @@ class PriorityLaneStore implements TripleStore {
   constructor(
     private readonly scheduler: StorePriorityScheduler,
     private readonly events: string[],
-    private readonly options: { hangAck?: boolean } = {},
+    private readonly options: {
+      hangAck?: boolean;
+      workspaceHeadDeleteDelayMs?: number;
+    } = {},
   ) {}
 
   releaseBackgroundWork(): void {
@@ -175,6 +179,12 @@ class PriorityLaneStore implements TripleStore {
   async deleteByPattern(_pattern: Partial<Quad>, options?: QueryOptions): Promise<number> {
     return this.scheduler.run(options?.priority, options?.source ?? 'test.deleteByPattern', async () => {
       this.recordWrite('deleteByPattern', options);
+      if (
+        options?.source?.endsWith('workspaceHead.deleteByPattern')
+        && this.options.workspaceHeadDeleteDelayMs
+      ) {
+        await wait(this.options.workspaceHeadDeleteDelayMs);
+      }
       return 0;
     }, options?.signal);
   }
@@ -320,8 +330,36 @@ describe('StorageACKHandler priority store lane', () => {
       'storage-ack.persistGraphScoped.flush',
     ]);
     expect(store.writeCalls.every((call) => call.priority === 'ack')).toBe(true);
-    const signals = store.writeCalls.map((call) => call.signal);
-    expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
-    expect(new Set(signals).size).toBe(1);
+    const abortableSignals = store.writeCalls.slice(0, 2).map((call) => call.signal);
+    expect(abortableSignals.every((signal) => signal instanceof AbortSignal)).toBe(true);
+    expect(new Set(abortableSignals).size).toBe(1);
+    expect(store.writeCalls.slice(2).every((call) => call.signal === undefined)).toBe(true);
+  });
+
+  it('finishes the workspace-head commit tail after the ACK deadline fires', async () => {
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
+    const events: string[] = [];
+    const store = new PriorityLaneStore(scheduler, events, {
+      workspaceHeadDeleteDelayMs: 75,
+    });
+    const handler = createHandler(store, { ackHandlerDeadlineMs: 25 });
+
+    const response = await handler.handler(graphScopedPublishIntent(), fakePeerId);
+    const decoded = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CORE_TEMPORARILY_UNAVAILABLE);
+    await wait(125);
+
+    const commitTail = store.writeCalls.filter((call) =>
+      call.source?.includes('persistGraphScoped.workspaceHead')
+      || call.source === 'storage-ack.persistGraphScoped.flush');
+    expect(commitTail.map((call) => call.source)).toEqual([
+      'storage-ack.persistGraphScoped.workspaceHead.deleteByPattern',
+      'storage-ack.persistGraphScoped.workspaceHead.insert',
+      'storage-ack.persistGraphScoped.flush',
+    ]);
+    expect(commitTail.every((call) => call.priority === 'ack')).toBe(true);
+    expect(commitTail.every((call) => call.signal === undefined)).toBe(true);
   });
 });

--- a/packages/publisher/test/storage-ack-priority-lane.test.ts
+++ b/packages/publisher/test/storage-ack-priority-lane.test.ts
@@ -315,8 +315,8 @@ describe('StorageACKHandler priority store lane', () => {
     expect(store.writeCalls.map((call) => call.source)).toEqual([
       'storage-ack.persistGraphScoped.deleteOperationMeta',
       'storage-ack.persistGraphScoped.insertOperationMeta',
-      'storage-ack.persistGraphScoped.workspaceHead',
-      'storage-ack.persistGraphScoped.workspaceHead',
+      'storage-ack.persistGraphScoped.workspaceHead.deleteByPattern',
+      'storage-ack.persistGraphScoped.workspaceHead.insert',
       'storage-ack.persistGraphScoped.flush',
     ]);
     expect(store.writeCalls.every((call) => call.priority === 'ack')).toBe(true);

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
       'test/ack-collector.test.ts',
       'test/publish-lifecycle-logger.test.ts',
       'test/storage-ack-handler.test.ts',
+      'test/storage-ack-priority-lane.test.ts',
       'test/swm-slice-ack-unbounded.test.ts',
       'test/workspace-snapshot-store.test.ts',
     ],


### PR DESCRIPTION
## Impact

Storage-ACK handling already uses the dedicated `ack` store-scheduler lane, but the workspace-head delete/insert performed during the same handler silently fell back to ordinary priority. Under store pressure this could make a Core node miss its ACK deadline even when the ACK lane itself was idle.

This change threads the handler's ACK priority and abort signal through workspace-head persistence. It does not increase concurrency or bypass backpressure; it keeps all persistence for one ACK in the bounded lane that was already reserved for that work.

### Before

```mermaid
sequenceDiagram
    participant Publisher
    participant AckHandler as Storage ACK handler
    participant Store as Store scheduler
    Publisher->>AckHandler: Request storage ACK
    AckHandler->>Store: Persist asset with ACK priority
    Store-->>AckHandler: Asset persisted
    AckHandler->>Store: Update workspace head with ordinary priority
    Note over Store: Competes with sync and recovery backlog
    Store--xAckHandler: Deadline can expire
    AckHandler-->>Publisher: CORE_TEMPORARILY_UNAVAILABLE
```

### After

```mermaid
sequenceDiagram
    participant Publisher
    participant AckHandler as Storage ACK handler
    participant Store as Store scheduler
    Publisher->>AckHandler: Request storage ACK
    AckHandler->>Store: Persist asset with ACK priority and signal
    Store-->>AckHandler: Asset persisted
    AckHandler->>Store: Update workspace head with ACK priority and signal
    Store-->>AckHandler: Workspace head persisted
    AckHandler-->>Publisher: Signed storage ACK
```

## Validation

- Focused priority regression suite: 5/5 passed.
- Surrounding storage-ACK and graph suites: 56/56 passed after review follow-up.
- Deadline-race mutation verified: reintroducing the abort signal left only the head delete recorded; the test failed because the required insert and flush never ran.
- Publisher TypeScript build passed.
- Live Testnet proof on two patched Core nodes: a previously stalled VM publication collected 3/3 storage ACKs, finalized on-chain, and promoted 125 triples to VM. The ACK quorum consisted of the existing healthy Core plus both patched Cores.
- `git diff --check` passed.

## Scope

- No configuration change.
- No concurrency increase.
- No changes to ACK quorum or verification.
- Targets `testnet-canary`; this PR must not be merged automatically.
