### PR TITLE
feat(sync): prioritize selected RFC-64 SWM convergence

### DIFF
--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -63,6 +63,7 @@ Add the following shape to `~/.dkg/config.json`:
             "signatureEvidence": { "kind": "none" },
             "signatureSuite": "eip191-personal-sign-digest-v1"
           },
+          "completeSwmProviders": ["12D3Koo...complete-swm-provider"],
           "targets": [
             {
               "authorAddress": "0x...catalog-author",
@@ -83,11 +84,19 @@ network transport starts and rejects non-public policies, duplicate selections,
 unknown fields, non-canonical identifiers, oversized manifests, and any policy
 whose `networkId` differs from the daemon's effective `chain.chainId`.
 
-`autoPublish` is optional. Configure it on a publisher that should advance its
-catalog after a confirmed public KA mint. A receiver can omit `autoPublish` and
-keep only the bootstrap targets. Catalog work after a confirmed mint is
-fail-open: a catalog error is logged but does not rewrite the already-confirmed
-KA result into a publication failure.
+`completeSwmProviders` is optional and stronger than a target's `providers`.
+Each listed peer is an operator assertion that the peer serves the complete
+public SWM snapshot for this exact accepted policy generation. Catch-up then
+contacts that peer for SWM first and may stop the SWM fan-out after verified
+coverage, while VM remains chain/curator driven. Omit this field unless that
+graph-wide property has been established; ordinary per-author catalog providers
+do not imply it.
+
+`autoPublish` is optional. Configure it on a publisher that should maintain the
+selected public graph's SWM inventory after durable public sharing. A receiver
+can omit `autoPublish` and keep only the bootstrap controls. Inventory work is
+fail-open: an RFC-64 error is logged but does not rewrite an already-committed
+user operation into a failure.
 
 `deploymentProfile` is also optional on a normal chain-connected node. When it
 is omitted, the agent resolves the chain ID and Knowledge Assets Lifecycle

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -567,6 +567,7 @@ import {
 import { deterministicStartupJitterMs, scheduleAfterStartupJitter } from './startup-jitter.js';
 
 const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
+const RFC64_SELECTED_SWM_ADMISSION_PRIORITY = 2_000;
 type InFlightSyncPageFetch = {
   promise: Promise<SyncPageResult>;
   controller: AbortController;
@@ -1337,6 +1338,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
        * bypassed is worth more than one that merely type-checks.
        */
       source?: SyncAdmissionSource;
+      /** Admit the selected graph-complete RFC-64 SWM transfer into its reserved slot. */
+      selectedSwmPriority?: boolean;
     } = {},
     /**
      * Nothing may follow `admission`. Typed `never[]` so a TypeScript caller passing
@@ -1367,12 +1370,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       || typeof (admission as { aborted?: unknown }).aborted === 'boolean') {
       throw new TypeError(
         'runContextGraphSyncWithBackpressure takes a single `admission` object '
-        + '({ priorityOverride, operationSignal, source }). The positional '
+        + '({ priorityOverride, operationSignal, source, selectedSwmPriority }). The positional '
         + 'priority/signal arguments used before issue #2006 are no longer accepted, '
         + 'because ignoring them would silently drop the caller\'s cancellation.',
       );
     }
-    const { priorityOverride, operationSignal } = admission;
+    const { priorityOverride, operationSignal, selectedSwmPriority } = admission;
     const source = normalizeSyncAdmissionSource(admission.source);
     const priority = priorityOverride
       ?? contextGraphPriority(this.config.syncContextGraphPriorities, contextGraphId);
@@ -1450,6 +1453,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           priority,
           priorityClass: syncPriorityClass(priority),
           source,
+          selectedSwmPriority,
           signal: admissionBoundary.signal,
           logInfo: (opCtx, message) => this.log.info(opCtx, message),
         },
@@ -3985,6 +3989,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return 'not-started';
     }
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
+    const prioritySharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
+    const automaticPeerSweep = source === 'on-connect' || source === 'reconcile';
+    const remotePeerIsCompleteSwmProvider = this.config.rfc64PublicCatalogBootstrap
+      ?.acceptedPublicPolicies.some(
+        ({ completeSwmProviders = [] }) => completeSwmProviders.includes(remotePeer),
+      ) ?? false;
     const getSharedMemorySyncPlan = (peerId: string): Promise<SharedMemorySyncContextGraphPlan> => {
       let plan = sharedMemorySyncPlans.get(peerId);
       if (!plan) {
@@ -3992,8 +4002,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           peerId,
           this.config.syncContextGraphs ?? [],
           createOperationContext('sync'),
+          { completeProviderOnly: automaticPeerSweep },
         );
         sharedMemorySyncPlans.set(peerId, plan);
+      }
+      return plan;
+    };
+    const getPrioritySharedMemorySyncPlan = (
+      peerId: string,
+    ): Promise<SharedMemorySyncContextGraphPlan> => {
+      let plan = prioritySharedMemorySyncPlans.get(peerId);
+      if (!plan) {
+        plan = this.planSharedMemorySyncContextGraphs(
+          peerId,
+          this.config.syncContextGraphs ?? [],
+          createOperationContext('sync'),
+          { requireCompleteProviderMatch: true },
+        );
+        prioritySharedMemorySyncPlans.set(peerId, plan);
       }
       return plan;
     };
@@ -4011,8 +4037,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           configValue: this.config.syncSystemContextGraphsOnConnect,
           envValue: process.env.DKG_SYNC_SYSTEM_CONTEXT_GRAPHS_ON_CONNECT,
         },
-      ),
+      ).filter((contextGraphId) => {
+        const completeSwmProviders = this.resolveRfc64CompleteSwmProviderPeerIdsV1(
+          contextGraphId,
+        );
+        // For an RFC-64 selected public CG, VM/durable inventory is chain/core
+        // territory. An Edge that was pinned as the complete SWM source must
+        // not start a duplicate durable pull before its useful SWM transfer;
+        // unrelated Edge peers should do neither plane in the automatic sweep.
+        return completeSwmProviders.length === 0 || this.knownCorePeerIds.has(remotePeer);
+      }),
       getSharedMemorySyncContextGraphs: async (peerId) => (await getSharedMemorySyncPlan(peerId)).eligibleContextGraphIds,
+      ...(automaticPeerSweep && remotePeerIsCompleteSwmProvider
+        ? {
+          getPrioritySharedMemorySyncContextGraphs: async (peerId: string) => (
+            await getPrioritySharedMemorySyncPlan(peerId)
+          ).eligibleContextGraphIds,
+        }
+        : {}),
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
         peerId,
         contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...(this.config.syncContextGraphs ?? [])],
@@ -4023,10 +4065,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ),
       refreshMetaSyncedFlags: (contextGraphIds) => this.refreshMetaSyncedFlags(contextGraphIds),
       discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
-      syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, {
+      syncSharedMemoryFromPeer: async (peerId, contextGraphIds, syncOptions) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, {
         stopOnBackoffWorthyFailure: true,
         source,
         sharedMemorySyncPlan: await getSharedMemorySyncPlan(peerId),
+        ...(syncOptions?.selectedPriority
+          ? {
+            priority: RFC64_SELECTED_SWM_ADMISSION_PRIORITY,
+            selectedSwmPriority: true,
+          }
+          : {}),
       }),
       syncSharedMemoryOnConnect: syncOnConnectEnabled(this.config) && (this.config.syncSharedMemoryOnConnect ?? true),
       logInfo: (ctx, message) => this.log.info(ctx, message),
@@ -4055,6 +4103,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeerId: string | undefined,
     contextGraphIds: readonly string[],
     ctx: OperationContext,
+    options: {
+      completeProviderOnly?: boolean;
+      requireCompleteProviderMatch?: boolean;
+    } = {},
   ): Promise<SharedMemorySyncContextGraphPlan> {
     // M2 (curator-leader convergence): a PRIVATE CG converges by REPLACE-recovering the
     // current state from its CURATOR (the authoritative SWM replica), never the
@@ -4096,7 +4148,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
 
     for (const contextGraphId of contextGraphIds) {
-      if (!(await this.canUseSharedMemoryForContextGraph(contextGraphId))) {
+      const completeSwmProviders = this.resolveRfc64CompleteSwmProviderPeerIdsV1(
+        contextGraphId,
+      );
+      if (
+        completeSwmProviders.length === 0
+        && !(await this.canUseSharedMemoryForContextGraph(contextGraphId))
+      ) {
         this.log.warn(ctx, `Skipping SWM sync for unauthorized or unconfirmed context graph "${contextGraphId}"`);
         continue;
       }
@@ -4163,6 +4221,27 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           privateRecoverFromCurator.push(contextGraphId);
           eligibleContextGraphIds.push(contextGraphId);
         }
+        continue;
+      }
+      if (
+        options.requireCompleteProviderMatch
+        && (
+          remotePeerId === undefined
+          || !completeSwmProviders.includes(remotePeerId)
+        )
+      ) {
+        continue;
+      }
+      if (
+        options.completeProviderOnly
+        && remotePeerId !== undefined
+        && completeSwmProviders.length > 0
+        && !completeSwmProviders.includes(remotePeerId)
+      ) {
+        this.log.debug(
+          ctx,
+          `SWM sync: skipping "${contextGraphId}" from ${remotePeerId.slice(-8)} — RFC-64 complete provider selected`,
+        );
         continue;
       }
       publicContextGraphIds.push(contextGraphId);
@@ -5939,6 +6018,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
        * and it clamps in the CLI bridge, while `acquire` re-clamps regardless.
        */
       source?: SyncAdmissionSource;
+      /** Internal marker for the selected graph-complete RFC-64 SWM admission. */
+      selectedSwmPriority?: boolean;
     },
   ): Promise<SharedMemorySyncResult> {
     const ctx = createOperationContext('sync');
@@ -6163,7 +6244,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           item.lane,
           item.operationId,
           run,
-          { priorityOverride: options?.priority, source: options?.source },
+          {
+            priorityOverride: options?.priority,
+            source: options?.source,
+            selectedSwmPriority: options?.selectedSwmPriority,
+          },
         ),
         merge: mergeSharedMemorySyncResults,
         markDeferred: (summary) => ({

--- a/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
@@ -21,6 +21,7 @@ import { mapWithConcurrency } from './map-with-concurrency.js';
 
 const MAX_STATUS_ERROR_BYTES_V1 = 1024;
 const MAX_CONCURRENT_TARGETS_V1 = 4;
+const COMPLETE_SWM_PROVIDER_DIAL_TIMEOUT_MS_V1 = 10_000;
 const UTF8 = new TextEncoder();
 
 export type Rfc64PublicCatalogBootstrapOutcomeV1 =
@@ -81,6 +82,23 @@ interface BootstrapStateV1 {
 const STATES = new WeakMap<DKGAgent, BootstrapStateV1>();
 
 export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
+  /**
+   * Exact operator-pinned graph-complete SWM providers for one accepted policy.
+   * These are deliberately separate from per-author catalog providers: only
+   * this explicit graph-wide assertion may let one peer end the SWM walk.
+   */
+  resolveRfc64CompleteSwmProviderPeerIdsV1(
+    this: DKGAgent,
+    contextGraphId: string,
+  ): readonly string[] {
+    const config = this.config.rfc64PublicCatalogBootstrap;
+    if (config === undefined) return Object.freeze([]);
+    const policy = config.acceptedPublicPolicies.find(
+      ({ policyEnvelope }) => policyEnvelope.payload.contextGraphId === contextGraphId,
+    );
+    return policy?.completeSwmProviders ?? Object.freeze([]);
+  }
+
   /** Accept pinned policies and start the first bounded provider pass. */
   startRfc64PublicCatalogBootstrapV1(this: DKGAgent, ctx: OperationContext): void {
     const config = this.config.rfc64PublicCatalogBootstrap;
@@ -212,6 +230,41 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
     const abortController = new AbortController();
     state.abortController = abortController;
     try {
+      const completeSwmProviders = [...new Set(
+        state.config.acceptedPublicPolicies.flatMap(
+          ({ completeSwmProviders: providers = [] }) => providers,
+        ),
+      )];
+      await mapWithConcurrency(
+        completeSwmProviders,
+        MAX_CONCURRENT_TARGETS_V1,
+        async (providerPeerId) => {
+          if (state.closed || abortController.signal.aborted) return;
+          try {
+            await this.connectToPeerId(providerPeerId, {
+              timeoutMs: COMPLETE_SWM_PROVIDER_DIAL_TIMEOUT_MS_V1,
+            });
+            // A pre-existing connection has no new connection:open event. Feed
+            // it through the normal cooldown/backoff-aware automatic scheduler
+            // so a selected provider is actionable after every cold start.
+            this.queueSyncFromPeerOnConnect(
+              providerPeerId,
+              (_peerId, error) => {
+                this.log.warn(
+                  state.ctx,
+                  `RFC-64 complete SWM provider sync failed for ${providerPeerId.slice(-8)}: ${errorMessageV1(error)}`,
+                );
+              },
+              0,
+            );
+          } catch (error) {
+            this.log.warn(
+              state.ctx,
+              `RFC-64 complete SWM provider ${providerPeerId.slice(-8)} is not dialable: ${errorMessageV1(error)}`,
+            );
+          }
+        },
+      );
       await mapWithConcurrency(
         state.targets,
         MAX_CONCURRENT_TARGETS_V1,

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1271,6 +1271,13 @@ export interface Rfc64PublicCatalogBootstrapPolicyV1 {
   readonly policyEnvelope: UnsignedContextGraphPolicyEnvelopeV1;
   /** Author catalogs under the policy graph/era. */
   readonly targets: readonly Rfc64PublicCatalogBootstrapTargetV1[];
+  /**
+   * Operator-pinned peers that each serve a complete public-SWM snapshot for
+   * this exact accepted policy generation.  Unlike a catalog target provider,
+   * one of these peers may settle the graph-wide SWM catch-up plane by itself.
+   * Omission preserves the ordinary multi-provider union walk.
+   */
+  readonly completeSwmProviders?: readonly string[];
 }
 
 /**

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -180,7 +180,7 @@ export function snapshotRfc64PublicCatalogBootstrapConfigV1(
     assertPlainExactObject(
       entry,
       `rfc64PublicCatalogBootstrap.acceptedPublicPolicies[${index}]`,
-      ['policyEnvelope', 'targets'],
+      ['completeSwmProviders', 'policyEnvelope', 'targets'],
       ['policyEnvelope', 'targets'],
     );
     const candidate = entry as unknown as {
@@ -188,6 +188,7 @@ export function snapshotRfc64PublicCatalogBootstrapConfigV1(
         'acceptedPublicPolicies'
       ][number]['policyEnvelope'];
       readonly targets: readonly Rfc64PublicCatalogBootstrapTargetV1[];
+      readonly completeSwmProviders?: readonly string[];
     };
     const policyEnvelope = parseCanonicalUnsignedContextGraphPolicyEnvelopeV1(
       canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1(candidate.policyEnvelope),
@@ -225,7 +226,10 @@ export function snapshotRfc64PublicCatalogBootstrapConfigV1(
       if (targetCandidate.authorAddress === `0x${'0'.repeat(40)}`) {
         throw new TypeError('rfc64PublicCatalogBootstrap authorAddress must be nonzero');
       }
-      const providers = snapshotBootstrapProviders(targetCandidate.providers, targetIndex);
+      const providers = snapshotBootstrapProviders(
+        targetCandidate.providers,
+        `targets[${targetIndex}].providers`,
+      );
       const targetKey = `${key}\n${targetCandidate.authorAddress}\n${policy.era}`;
       if (targetKeys.has(targetKey)) {
         throw new TypeError('rfc64PublicCatalogBootstrap targets must be unique by author scope');
@@ -233,9 +237,16 @@ export function snapshotRfc64PublicCatalogBootstrapConfigV1(
       targetKeys.add(targetKey);
       return Object.freeze({ authorAddress: targetCandidate.authorAddress, providers });
     });
+    const completeSwmProviders = candidate.completeSwmProviders === undefined
+      ? undefined
+      : snapshotBootstrapProviders(
+        candidate.completeSwmProviders,
+        `acceptedPublicPolicies[${index}].completeSwmProviders`,
+      );
     return Object.freeze({
       policyEnvelope: deepFreezePlain(policyEnvelope),
       targets: Object.freeze(targets),
+      ...(completeSwmProviders === undefined ? {} : { completeSwmProviders }),
     });
   });
 
@@ -267,14 +278,14 @@ function snapshotTimestamp(value: unknown, label: string): TimestampMsV1 {
   return value as TimestampMsV1;
 }
 
-function snapshotBootstrapProviders(input: readonly string[], targetIndex: number): readonly string[] {
+function snapshotBootstrapProviders(input: readonly string[], label: string): readonly string[] {
   const providers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input);
   if (
     providers.length === 0
     || providers.length > MAX_RFC64_BOOTSTRAP_PROVIDERS_V1
   ) {
     throw new TypeError(
-      `rfc64PublicCatalogBootstrap.targets[${targetIndex}].providers must contain 1..`
+      `rfc64PublicCatalogBootstrap.${label} must contain 1..`
       + `${MAX_RFC64_BOOTSTRAP_PROVIDERS_V1} peers`,
     );
   }

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -24,6 +24,11 @@ export interface SyncGlobalBackpressureConfig {
   syncGlobalMaxInflight?: number;
   syncGlobalLimit?: number;
   syncGlobalQueueLimit?: number;
+  rfc64PublicCatalogBootstrap?: {
+    acceptedPublicPolicies?: readonly {
+      completeSwmProviders?: readonly string[];
+    }[];
+  };
 }
 
 declare const syncGlobalBackpressurePolicyBrand: unique symbol;
@@ -35,9 +40,11 @@ export type SyncGlobalBackpressurePolicy = Readonly<(
 
 interface GlobalQueuePayload {
   limit: number;
+  automaticBackgroundLimit: number;
   label: string;
   contextGraphId?: string;
   source: SyncAdmissionSource;
+  selectedSwmPriority: boolean;
 }
 
 export const DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT = 2;
@@ -71,22 +78,37 @@ function syncAdmissionOperation(payload: GlobalQueuePayload): string {
 }
 
 let inflight = 0;
+let automaticBackgroundInflight = 0;
 let lastLimit: number | null = null;
 let lastQueueLimit: number | null = null;
 const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
   now: () => performance.now(),
-  canRun: (entry) => inflight < entry.payload.limit,
+  canRun: (entry) => (
+    inflight < entry.payload.limit
+    && (
+      !isAutomaticBackgroundSync(entry)
+      || automaticBackgroundInflight < entry.payload.automaticBackgroundLimit
+    )
+  ),
   onStart: (entry) => {
     inflight += 1;
+    const automaticBackground = isAutomaticBackgroundSync(entry);
+    if (automaticBackground) automaticBackgroundInflight += 1;
     lastLimit = entry.payload.limit;
     getMetrics().syncGlobalInflight.record(inflight);
     return () => {
       inflight = Math.max(0, inflight - 1);
+      if (automaticBackground) {
+        automaticBackgroundInflight = Math.max(0, automaticBackgroundInflight - 1);
+      }
       getMetrics().syncGlobalInflight.record(inflight);
     };
   },
-  onStartFailureRollback: () => {
+  onStartFailureRollback: (entry) => {
     inflight = Math.max(0, inflight - 1);
+    if (isAutomaticBackgroundSync(entry)) {
+      automaticBackgroundInflight = Math.max(0, automaticBackgroundInflight - 1);
+    }
     getMetrics().syncGlobalInflight.record(inflight);
   },
   onDepthChange: (depth) => getMetrics().syncBackgroundQueueDepth.record(depth),
@@ -104,6 +126,16 @@ const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
     register: true,
   },
 });
+const automaticBackgroundLimits = new WeakMap<object, number>();
+
+function isAutomaticBackgroundSync(entry: { payload: GlobalQueuePayload }): boolean {
+  if (entry.payload.selectedSwmPriority) return false;
+  return entry.payload.source === 'on-connect'
+    || entry.payload.source === 'reconcile'
+    || entry.payload.source === 'vm-recovery'
+    || entry.payload.source === 'swm-recovery'
+    || entry.payload.source === 'catchup-background';
+}
 
 export type SyncBackpressureBusyReason = 'queue_full' | 'displaced';
 
@@ -140,6 +172,7 @@ function acquire(
     priority: number;
     priorityClass: SyncPriorityClass;
     source: SyncAdmissionSource;
+    selectedSwmPriority: boolean;
     signal?: AbortSignal;
     agingThresholdMs: number;
   },
@@ -153,9 +186,11 @@ function acquire(
   return queue.acquire({
     payload: {
       limit,
+      automaticBackgroundLimit: automaticBackgroundLimits.get(policy) ?? limit,
       label: options.label,
       contextGraphId: options.contextGraphId,
       source: options.source,
+      selectedSwmPriority: options.selectedSwmPriority,
     },
     ownerKey: 'global',
     lane: options.lane,
@@ -242,10 +277,19 @@ export function resolveSyncGlobalBackpressure(
   const queueLimit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_QUEUE_LIMIT'))
     ?? nonNegativeInteger(config.syncGlobalQueueLimit)
     ?? limit * DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER;
-  return Object.freeze({
+  const hasCompleteSwmProvider = config.rfc64PublicCatalogBootstrap?.acceptedPublicPolicies
+    ?.some((acceptedPolicy) => (acceptedPolicy.completeSwmProviders?.length ?? 0) > 0) ?? false;
+  const policy = Object.freeze({
     limit,
     queueLimit,
   }) as SyncGlobalBackpressurePolicy;
+  // A selected complete SWM provider is useful only if its transfer can enter
+  // the scheduler. Keep one slot out of every automatic background source,
+  // including VM/SWM recovery, because those sources can start during daemon
+  // bootstrap before the selected Edge provider becomes dialable. Explicit
+  // foreground catch-up retains the full cap.
+  automaticBackgroundLimits.set(policy, hasCompleteSwmProvider && limit > 1 ? limit - 1 : limit);
+  return policy;
 }
 
 export function getSyncBackpressureSnapshot(
@@ -284,6 +328,8 @@ export async function withGlobalSyncBackpressure<T>(
      * `unspecified`.
      */
     source?: SyncAdmissionSource;
+    /** The selected graph-complete RFC-64 SWM transfer may use the reserved slot. */
+    selectedSwmPriority?: boolean;
     signal?: AbortSignal;
     agingThresholdMs?: number;
     logInfo?: (ctx: OperationContext, message: string) => void;
@@ -313,6 +359,7 @@ export async function withGlobalSyncBackpressure<T>(
       priority,
       priorityClass,
       source: normalizeSyncAdmissionSource(options.source),
+      selectedSwmPriority: options.selectedSwmPriority === true,
       signal: options.signal,
       agingThresholdMs: options.agingThresholdMs ?? DEFAULT_SYNC_PRIORITY_AGING_MS,
     });

--- a/packages/agent/src/sync/graph-scoped-swm-recovery.ts
+++ b/packages/agent/src/sync/graph-scoped-swm-recovery.ts
@@ -138,20 +138,17 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
       );
     }
 
-    const shareOperationId = requireLiteral(headRows, SHARE_OPERATION_ID, 'shareOperationId').trim();
-    if (!shareOperationId) throw new Error(`Graph-scoped SWM head ${headSubject} has an empty shareOperationId`);
-    const operationSubject = `urn:dkg:share:${params.contextGraphId}:${shareOperationId}`;
-    const operationRows = byGraphAndSubject.get(`${metaGraph}\u0000${operationSubject}`) ?? [];
-    validateOperationRows({
-      rows: operationRows,
+    const operation = resolveEquivalentHeadOperation({
+      headRows,
+      byGraphAndSubject,
       contextGraphId: params.contextGraphId,
       metaGraph,
-      operationSubject,
-      shareOperationId,
+      headSubject,
       kaUal: scope.ual,
       assertionVersion: scope.assertionVersion,
       subGraphName,
     });
+    const { shareOperationId, operationSubject, operationRows } = operation;
 
     const publicQuadsDigest = requireLiteral(
       operationRows,
@@ -236,7 +233,11 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
       ...(publicSnapshotGraph ? { publicSnapshotGraph } : {}),
       publisherPeerId,
       ...(subGraphName ? { subGraphName } : {}),
-      metadataQuads: [...headRows, ...operationRows],
+      metadataQuads: [
+        ...headRows.filter((row) => row.predicate !== SHARE_OPERATION_ID),
+        operation.headShareOperationRow,
+        ...operationRows,
+      ],
     });
   }
 
@@ -249,6 +250,115 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
     assertionOwners.set(descriptor.assertionGraph, descriptor.kaUal);
   }
   return descriptors;
+}
+
+/**
+ * Collapse only the current-head pointer rows covered by parsed descriptors.
+ * Superseded operation subjects may remain as immutable history, but a head
+ * itself must name exactly one operation or LIMIT-1 readers become arbitrary.
+ */
+export function canonicalizeGraphScopedSwmHeadRows(params: {
+  readonly metaQuads: readonly Quad[];
+  readonly descriptors: readonly GraphScopedSwmRecoveryDescriptor[];
+}): Quad[] {
+  const selectedByHead = new Map(
+    params.descriptors.map((descriptor) => [
+      `${descriptor.metaGraph}\u0000${descriptor.headSubject}`,
+      descriptor.shareOperationId,
+    ]),
+  );
+  return params.metaQuads.filter((row) => {
+    if (row.predicate !== SHARE_OPERATION_ID) return true;
+    const selected = selectedByHead.get(`${row.graph}\u0000${row.subject}`);
+    return selected === undefined || stripLiteral(row.object).trim() === selected;
+  });
+}
+
+interface ResolvedHeadOperation {
+  readonly shareOperationId: string;
+  readonly operationSubject: string;
+  readonly operationRows: readonly Quad[];
+  readonly headShareOperationRow: Quad;
+}
+
+/**
+ * Storage-ACK persistence and originator persistence can legitimately produce
+ * two operation ids for the same exact assertion. Accept that residue only
+ * when every recovery-relevant operation row is byte-equivalent (apart from
+ * operation id and timestamp), then choose the newest operation
+ * deterministically. Any content or policy disagreement remains fail-closed.
+ */
+function resolveEquivalentHeadOperation(params: {
+  readonly headRows: readonly Quad[];
+  readonly byGraphAndSubject: ReadonlyMap<string, readonly Quad[]>;
+  readonly contextGraphId: string;
+  readonly metaGraph: string;
+  readonly headSubject: string;
+  readonly kaUal: string;
+  readonly assertionVersion: string;
+  readonly subGraphName?: string;
+}): ResolvedHeadOperation {
+  const shareOperationIds = [...new Set(
+    distinctObjects(params.headRows, SHARE_OPERATION_ID)
+      .map(stripLiteral)
+      .map((value) => value.trim()),
+  )];
+  if (shareOperationIds.length === 0) {
+    throw new Error(`Graph-scoped SWM head ${params.headSubject} is missing shareOperationId`);
+  }
+  if (shareOperationIds.some((value) => value.length === 0)) {
+    throw new Error(`Graph-scoped SWM head ${params.headSubject} has an empty shareOperationId`);
+  }
+
+  const candidates = shareOperationIds.map((shareOperationId) => {
+    const operationSubject = `urn:dkg:share:${params.contextGraphId}:${shareOperationId}`;
+    const operationRows = params.byGraphAndSubject.get(
+      `${params.metaGraph}\u0000${operationSubject}`,
+    ) ?? [];
+    validateOperationRows({
+      rows: operationRows,
+      contextGraphId: params.contextGraphId,
+      metaGraph: params.metaGraph,
+      operationSubject,
+      shareOperationId,
+      kaUal: params.kaUal,
+      assertionVersion: params.assertionVersion,
+      subGraphName: params.subGraphName,
+    });
+    const publishedAt = stripLiteral(requireSingle(operationRows, PUBLISHED_AT, 'publishedAt'));
+    const publishedAtMs = Date.parse(publishedAt);
+    if (!Number.isFinite(publishedAtMs)) {
+      throw new Error(`Graph-scoped SWM operation ${operationSubject} has an invalid publishedAt`);
+    }
+    const equivalenceKey = operationRows
+      .filter((row) => row.predicate !== SHARE_OPERATION_ID && row.predicate !== PUBLISHED_AT)
+      .map((row) => `${row.predicate}\u0000${row.object}\u0000${row.graph}`)
+      .sort()
+      .join('\u0001');
+    const headShareOperationRow = params.headRows
+      .filter((row) => row.predicate === SHARE_OPERATION_ID)
+      .filter((row) => stripLiteral(row.object).trim() === shareOperationId)
+      .sort((left, right) => left.object.localeCompare(right.object))[0];
+    if (!headShareOperationRow) {
+      throw new Error(`Graph-scoped SWM head ${params.headSubject} is missing shareOperationId`);
+    }
+    return {
+      shareOperationId,
+      operationSubject,
+      operationRows,
+      headShareOperationRow,
+      publishedAtMs,
+      equivalenceKey,
+    };
+  });
+
+  if (new Set(candidates.map((candidate) => candidate.equivalenceKey)).size > 1) {
+    throw new Error(`ambiguous shareOperationId`);
+  }
+  candidates.sort((left, right) =>
+    right.publishedAtMs - left.publishedAtMs
+    || right.shareOperationId.localeCompare(left.shareOperationId));
+  return candidates[0]!;
 }
 
 /** Load and re-verify one immutable snapshot, then stamp its exact SWM graph. */

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -23,10 +23,16 @@ interface SyncOnConnectContext {
   /** Exact durable scope for this automatic run; explicit catch-up bypasses it. */
   getDurableSyncContextGraphs?: () => string[];
   getSharedMemorySyncContextGraphs?: (remotePeerId: string) => string[] | Promise<string[]>;
+  /** Selected graph-complete SWM scope that must run before unrelated history. */
+  getPrioritySharedMemorySyncContextGraphs?: (remotePeerId: string) => string[] | Promise<string[]>;
   syncFromPeer: (peerId: string, contextGraphIds?: string[]) => Promise<SyncFromPeerResult>;
   refreshMetaSyncedFlags: (contextGraphIds: Iterable<string>) => Promise<void>;
   discoverContextGraphsFromStore: () => Promise<number>;
-  syncSharedMemoryFromPeer: (peerId: string, contextGraphIds: string[]) => Promise<SyncFromPeerResult>;
+  syncSharedMemoryFromPeer: (
+    peerId: string,
+    contextGraphIds: string[],
+    options?: { selectedPriority?: boolean },
+  ) => Promise<SyncFromPeerResult>;
   syncSharedMemoryOnConnect?: boolean;
   logInfo: (ctx: OperationContext, message: string) => void;
   /**
@@ -139,6 +145,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     getSyncContextGraphs,
     getDurableSyncContextGraphs,
     getSharedMemorySyncContextGraphs,
+    getPrioritySharedMemorySyncContextGraphs,
     syncFromPeer,
     refreshMetaSyncedFlags,
     discoverContextGraphsFromStore,
@@ -245,6 +252,36 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       return 'skipped-no-sync';
     }
 
+    const prioritySharedMemoryContextGraphIds = syncSharedMemoryOnConnect
+      && getPrioritySharedMemorySyncContextGraphs
+        ? [...new Set(await runNonTransportStep(() => Promise.resolve(
+          getPrioritySharedMemorySyncContextGraphs(remotePeer),
+        )))]
+        : [];
+    if (prioritySharedMemoryContextGraphIds.length > 0) {
+      logInfo(
+        ctx,
+        `Prioritizing ${prioritySharedMemoryContextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
+      );
+      const priorityWsSynced = await syncSharedMemoryFromPeer(
+        remotePeer,
+        prioritySharedMemoryContextGraphIds,
+        { selectedPriority: true },
+      );
+      const prioritySharedAccounting = recordSyncAccounting(priorityWsSynced, 'shared');
+      logInfo(
+        ctx,
+        `Synced ${prioritySharedAccounting.insertedTriples} priority shared memory triples from peer ${shortPeer}`,
+      );
+      if (prioritySharedAccounting.deferredByBackpressure) {
+        logInfo(
+          ctx,
+          `Priority shared-memory sync from peer ${shortPeer} deferred by local admission pressure`,
+        );
+        return finishSyncAccounting();
+      }
+    }
+
     const durableContextGraphIds = getDurableSyncContextGraphs?.() ?? [
       SYSTEM_CONTEXT_GRAPHS.AGENTS,
       SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
@@ -311,9 +348,13 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     }
 
     durableSyncCompleted = true;
-    const wsContextGraphIds = getSharedMemorySyncContextGraphs
+    const allWsContextGraphIds = getSharedMemorySyncContextGraphs
       ? await runNonTransportStep(() => Promise.resolve(getSharedMemorySyncContextGraphs(remotePeer)))
       : getSyncContextGraphs() ?? [];
+    const prioritySharedMemoryContextGraphIdSet = new Set(prioritySharedMemoryContextGraphIds);
+    const wsContextGraphIds = allWsContextGraphIds.filter(
+      (contextGraphId) => !prioritySharedMemoryContextGraphIdSet.has(contextGraphId),
+    );
     if (syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
       const wsSynced = await syncSharedMemoryFromPeer(remotePeer, wsContextGraphIds);
       const sharedAccounting = recordSyncAccounting(wsSynced, 'shared');

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -8,6 +8,7 @@ import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection,
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import type { SyncPageResult } from './page-fetch.js';
 import {
+  canonicalizeGraphScopedSwmHeadRows,
   materializeGraphScopedSwmRecoveryAsset,
   parseGraphScopedSwmRecoveryDescriptors,
   type GraphScopedSwmRecoveryDescriptor,
@@ -487,6 +488,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // otherwise abort the whole CG fanout. A parse failure here must degrade to
       // "no materialization this round" — never take down the sync.
       const snapshotDescriptorsByRef = new Map<string, GraphScopedSwmRecoveryDescriptor[]>();
+      let verifiedMetaForInsert = processed.verifiedMeta;
       // Whether the descriptor map is an AUTHORITATIVE statement about this
       // round's metadata, i.e. whether "this ref has no descriptor" may be read
       // as "this ref has nothing to materialize".
@@ -501,7 +503,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       let descriptorsAuthoritative = true;
       if (snapshotMaterializer && publicSnapshotStore && wsMetaResult.completed) {
         try {
-          for (const descriptor of parseGraphScopedSwmRecoveryDescriptors({
+          const descriptors = parseGraphScopedSwmRecoveryDescriptors({
             contextGraphId: pid,
             metaQuads: processed.verifiedMeta,
             // Without the subgraph admission context every KA under a
@@ -511,7 +513,12 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
             // graph — not just for the subgraph KA that triggered it.
             ...(registeredSubGraphNames ? { registeredSubGraphNames } : {}),
             ...(excludedSubGraphNames ? { excludedSubGraphNames } : {}),
-          })) {
+          });
+          verifiedMetaForInsert = canonicalizeGraphScopedSwmHeadRows({
+            metaQuads: processed.verifiedMeta,
+            descriptors,
+          });
+          for (const descriptor of descriptors) {
             const ref = descriptor.publicSnapshotRef;
             if (!ref) continue; // no immutable snapshot for this KA
             const list = snapshotDescriptorsByRef.get(ref) ?? [];
@@ -935,7 +942,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         summary.insertedTriples += validWsQuads.length;
         summary.insertedDataTriples += validWsQuads.length;
       }
-      if (processed.verifiedMeta.length > 0) {
+      if (verifiedMetaForInsert.length > 0) {
         // Still written in full — an RDF store is a set, so rewriting the rows
         // the per-KA path already wrote is a no-op, and the rows for KAs that
         // were NOT materialized still have to land.
@@ -960,8 +967,8 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // insert is the plausible source): a re-filter drops both copies and
         // undercounts by one. Valid because every per-KA row is filtered through
         // `verifiedMetaKeys`, so the ledger is always a subset of these keys.
-        await storeInsert(processed.verifiedMeta);
-        const newlyCountedMeta = processed.verifiedMeta.length - perKaInsertedMetaKeys.size;
+        await storeInsert(verifiedMetaForInsert);
+        const newlyCountedMeta = verifiedMetaForInsert.length - perKaInsertedMetaKeys.size;
         summary.insertedTriples += newlyCountedMeta;
         summary.insertedMetaTriples += newlyCountedMeta;
       }
@@ -974,7 +981,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       hydrateOwnership();
       const storeDurationMs = Date.now() - storeStartedAt;
 
-      logInfo(ctx, `SWM sync for "${pid}": ${validWsQuads.length} data + ${processed.verifiedMeta.length} meta triples`);
+      logInfo(ctx, `SWM sync for "${pid}": ${validWsQuads.length} data + ${verifiedMetaForInsert.length} meta triples`);
       if (fetchDurationMs + verifyDurationMs + snapshotDurationMs + storeDurationMs > 100) {
         logDebug(
           ctx,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -2314,6 +2314,9 @@ async function readCachedRowsPage(
   const rows = await cache.memo.get(cache.key, loadRows, {
     refresh: cache.refresh,
     refreshGeneration: cache.refreshGeneration,
+    // No prefix has been consumed at offset zero, so an entry evicted under
+    // responder memory pressure can be rebuilt without mixing snapshots.
+    refreshExpired: safeOffset === 0,
     requireExisting: safeOffset > 0,
     signal,
   });

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -64,6 +64,8 @@ export interface SyncRowListMemo {
        * the retained-entry set.
        */
       refreshGeneration?: string;
+      /** Offset-zero retry may rebuild an evicted/expired snapshot safely. */
+      refreshExpired?: boolean;
       requireExisting?: boolean;
       signal?: AbortSignal;
     },
@@ -363,6 +365,7 @@ export function createResponderSyncRowListMemo(
       if (priorExpiry) {
         if (
           options?.refresh ||
+          options?.refreshExpired ||
           (requestedGeneration !== undefined &&
             priorExpiry.refreshGeneration !== requestedGeneration)
         ) deleteExpired(key);

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -867,30 +867,90 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     });
     const policyEnvelope = unsignedOpenContextGraphPolicyEnvelopeV1(policy);
     const providers = ['12D3KooPrimary'];
+    const completeSwmProviders = ['12D3KooCompleteSwm'];
     const callerOwned: Rfc64PublicCatalogBootstrapConfigV1 = {
       acceptedPublicPolicies: [{
         policyEnvelope,
         targets: [{ authorAddress: AUTHOR, providers }],
+        completeSwmProviders,
       }],
       retryIntervalMs: 1_000,
     };
     const snapshot = snapshotRfc64PublicCatalogBootstrapConfigV1(callerOwned)!;
     providers.push('12D3KooLateMutation');
+    completeSwmProviders.push('12D3KooLateSwmMutation');
 
     expect(snapshot.acceptedPublicPolicies[0]?.targets[0]?.providers)
       .toEqual(['12D3KooPrimary']);
+    expect(snapshot.acceptedPublicPolicies[0]?.completeSwmProviders)
+      .toEqual(['12D3KooCompleteSwm']);
     expect(snapshot.acceptedPublicPolicies[0]?.policyEnvelope.payload).toEqual(policy);
     expect(Object.isFrozen(snapshot)).toBe(true);
     expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.targets)).toBe(true);
     expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.targets[0]?.providers)).toBe(true);
+    expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.completeSwmProviders)).toBe(true);
     expect(Object.isFrozen(snapshot.acceptedPublicPolicies[0]?.policyEnvelope.payload.source))
       .toBe(true);
+    const providerResolver = DKGAgent.prototype.resolveRfc64CompleteSwmProviderPeerIdsV1;
+    const resolverAgent = {
+      config: { rfc64PublicCatalogBootstrap: snapshot },
+    } as unknown as DKGAgent;
+    expect(providerResolver.call(resolverAgent, CONTEXT_GRAPH_ID))
+      .toEqual(['12D3KooCompleteSwm']);
+    expect(providerResolver.call(
+      resolverAgent,
+      '0x2222222222222222222222222222222222222222/other' as ContextGraphIdV1,
+    )).toEqual([]);
     expect(() => snapshotRfc64PublicCatalogBootstrapConfigV1({
       acceptedPublicPolicies: [{
         ...callerOwned.acceptedPublicPolicies[0]!,
         policyDigest: `0x${'11'.repeat(32)}`,
       }],
     } as unknown as Rfc64PublicCatalogBootstrapConfigV1)).toThrow(/unknown or missing fields/u);
+  });
+
+  it('dials and schedules every graph-complete SWM provider during bootstrap', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-rfc64-complete-provider-bootstrap-'));
+    tempDirs.push(dataDir);
+    const receiver = await DKGAgent.create({
+      name: 'complete-provider-bootstrap-receiver',
+      dataDir,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      bootstrapPeers: [],
+      store: new OxigraphStore(),
+      syncOnConnectEnabled: true,
+      syncReconcilerEnabled: false,
+      agentProfileHeartbeatMs: 0,
+      rfc64CatalogDeploymentProfile: NATIVE_DEPLOYMENT,
+      rfc64PublicCatalogBootstrap: {
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [],
+          completeSwmProviders: ['12D3KooWCompleteSwmProvider'],
+        }],
+      },
+    });
+    agents.push(receiver);
+    const connect = vi.spyOn(receiver, 'connectToPeerId').mockResolvedValue();
+    const queue = vi.spyOn(receiver, 'queueSyncFromPeerOnConnect').mockReturnValue(true);
+
+    await receiver.start();
+    await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
+
+    expect(connect).toHaveBeenCalledWith('12D3KooWCompleteSwmProvider', {
+      timeoutMs: 10_000,
+    });
+    expect(queue).toHaveBeenCalledWith(
+      '12D3KooWCompleteSwmProvider',
+      expect.any(Function),
+      0,
+    );
   });
 
   it('rejects bootstrap without persistence before node startup', async () => {

--- a/packages/agent/test/swm-curator-recovery-plan.test.ts
+++ b/packages/agent/test/swm-curator-recovery-plan.test.ts
@@ -72,6 +72,77 @@ describe('private SWM curator recovery planning', () => {
     expect(plan.eligibleContextGraphIds).toEqual([]);
   });
 
+  it('limits automatic public SWM sweeps to an RFC-64 graph-complete provider', async () => {
+    const contextGraphId = `${ethers.Wallet.createRandom().address}/selected-public`;
+    const completeProvider = '12D3KooWCompleteSwmProvider';
+    const agent = await createAgent('CompletePublicSwmProviderPlan');
+    const internals = agent as any;
+    internals.canUseSharedMemoryForContextGraph = async () => true;
+    internals.isPrivateContextGraph = async () => false;
+    internals.resolveRfc64CompleteSwmProviderPeerIdsV1 = () => [completeProvider];
+
+    await expect(agent.planSharedMemorySyncContextGraphs(
+      '12D3KooWUnrelatedEdge',
+      [contextGraphId],
+      createOperationContext('sync'),
+      { completeProviderOnly: true },
+    )).resolves.toMatchObject({
+      publicContextGraphIds: [],
+      eligibleContextGraphIds: [],
+    });
+
+    await expect(agent.planSharedMemorySyncContextGraphs(
+      completeProvider,
+      [contextGraphId],
+      createOperationContext('sync'),
+      { completeProviderOnly: true },
+    )).resolves.toMatchObject({
+      publicContextGraphIds: [contextGraphId],
+      eligibleContextGraphIds: [contextGraphId],
+    });
+  });
+
+  it('uses an accepted public policy as cold-start authorization for its exact complete provider', async () => {
+    const contextGraphId = `${ethers.Wallet.createRandom().address}/selected-public-cold`;
+    const ordinaryContextGraphId = `${ethers.Wallet.createRandom().address}/ordinary-public-cold`;
+    const completeProvider = '12D3KooWCompleteSwmProvider';
+    const agent = await createAgent('CompletePublicSwmColdStartPlan');
+    const internals = agent as any;
+    internals.canUseSharedMemoryForContextGraph = async () => false;
+    internals.isPrivateContextGraph = async () => false;
+    internals.resolveRfc64CompleteSwmProviderPeerIdsV1 = (candidate: string) => (
+      candidate === contextGraphId ? [completeProvider] : []
+    );
+
+    await expect(agent.planSharedMemorySyncContextGraphs(
+      completeProvider,
+      [ordinaryContextGraphId, contextGraphId],
+      createOperationContext('sync'),
+      { requireCompleteProviderMatch: true },
+    )).resolves.toMatchObject({
+      publicContextGraphIds: [contextGraphId],
+      eligibleContextGraphIds: [contextGraphId],
+    });
+  });
+
+  it('retains union fallback for explicit catch-up even when RFC-64 providers are configured', async () => {
+    const contextGraphId = `${ethers.Wallet.createRandom().address}/selected-public-fallback`;
+    const agent = await createAgent('ExplicitPublicSwmFallbackPlan');
+    const internals = agent as any;
+    internals.canUseSharedMemoryForContextGraph = async () => true;
+    internals.isPrivateContextGraph = async () => false;
+    internals.resolveRfc64CompleteSwmProviderPeerIdsV1 = () => ['12D3KooWCompleteSwmProvider'];
+
+    await expect(agent.planSharedMemorySyncContextGraphs(
+      '12D3KooWFallbackPeer',
+      [contextGraphId],
+      createOperationContext('sync'),
+    )).resolves.toMatchObject({
+      publicContextGraphIds: [contextGraphId],
+      eligibleContextGraphIds: [contextGraphId],
+    });
+  });
+
   it('does not treat an empty registry after a failed metadata refresh as authoritative', async () => {
     const curator = ethers.Wallet.createRandom().address.toLowerCase();
     const contextGraphId = `${curator}/refresh-failed-plan`;

--- a/packages/agent/test/swm-snapshot-materializer.test.ts
+++ b/packages/agent/test/swm-snapshot-materializer.test.ts
@@ -241,7 +241,7 @@ describe('createSharedMemorySnapshotMaterializer against a real OxigraphStore', 
   });
 
   describe('end-to-end catch-up with the real materializer', () => {
-    function realHarness(store: TripleStore, served: typeof v1) {
+    function realHarness(store: TripleStore, served: typeof v1, servedMeta: Quad[] = served.meta) {
       const snapshotStore = new MemorySnapshotStore();
       const { materializer } = materializerFor(store);
       let replaceCalls = 0;
@@ -253,10 +253,10 @@ describe('createSharedMemorySnapshotMaterializer against a real OxigraphStore', 
           contextGraphIds: [CG],
           createContextGraphSyncDeadline: () => Number.MAX_SAFE_INTEGER,
           fetchSyncPages: async (_c, _p, _cg, _inc, phase): Promise<SyncPageResult> => ({
-            quads: phase === 'meta' ? [...served.meta] : [],
+            quads: phase === 'meta' ? [...servedMeta] : [],
             bytesReceived: 0,
             resumedFromOffset: 0,
-            nextOffset: phase === 'meta' ? served.meta.length : 0,
+            nextOffset: phase === 'meta' ? servedMeta.length : 0,
             checkpointKey: 'k',
             completed: true,
             timedOut: false,
@@ -349,6 +349,56 @@ describe('createSharedMemorySnapshotMaterializer against a real OxigraphStore', 
       const again = await h.run();
       expect(again.failedPhases).toBe(0);
       expect(h.replaceCalls()).toBe(1);
+    });
+
+    it('recovers equivalent originator and storage-ACK heads and stores one current pointer', async () => {
+      // A later StorageACK can persist the exact same assertion under its own
+      // deterministic operation id while an older originator head is replayed
+      // by durable metadata sync. This is the production residue observed in
+      // the 400/400 canary run: two operation pointers, identical content and
+      // policy, different timestamps. It is recoverable, not corrupt.
+      const storageAck = share(1, 'storage-ack-equivalent', 'version-one');
+      const storageAckMeta = storageAck.meta.map((row) =>
+        row.subject === storageAck.operationSubject && row.predicate === `${DKG}publishedAt`
+          ? { ...row, object: '"1970-01-01T00:00:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>' }
+          : row);
+      const servedMeta = [
+        ...v1.meta,
+        ...storageAckMeta.filter((row) => row.subject === storageAck.operationSubject),
+        ...storageAckMeta.filter((row) =>
+          row.subject === storageAck.headSubject && row.predicate === `${DKG}shareOperationId`),
+      ];
+
+      const parsed = parseGraphScopedSwmRecoveryDescriptors({
+        contextGraphId: CG,
+        metaQuads: servedMeta,
+      });
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]?.shareOperationId).toBe('storage-ack-equivalent');
+      expect(parsed[0]?.metadataQuads.filter((row) =>
+        row.subject === storageAck.headSubject && row.predicate === `${DKG}shareOperationId`))
+        .toEqual([expect.objectContaining({ object: '"storage-ack-equivalent"' })]);
+
+      const store = new OxigraphStore();
+      const h = realHarness(store, storageAck, servedMeta);
+      const summary = await h.run();
+      expect(summary.failedPhases).toBe(0);
+      expect(await distinctObjects(store, WS_META, storageAck.headSubject, `${DKG}shareOperationId`))
+        .toEqual(['"storage-ack-equivalent"']);
+    });
+
+    it('still fails closed when two head operations disagree on content', () => {
+      const conflicting = share(1, 'op-conflicting', 'different-content');
+      const poisonedMeta = [
+        ...v1.meta,
+        ...conflicting.meta.filter((row) => row.subject === conflicting.operationSubject),
+        ...conflicting.meta.filter((row) =>
+          row.subject === conflicting.headSubject && row.predicate === `${DKG}shareOperationId`),
+      ];
+      expect(() => parseGraphScopedSwmRecoveryDescriptors({
+        contextGraphId: CG,
+        metaQuads: poisonedMeta,
+      })).toThrow(/ambiguous shareOperationId/);
     });
   });
 });

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -1431,4 +1431,77 @@ describe('sync global backpressure', () => {
       await running;
     }
   });
+
+  it('reserves one selected-provider slot from every automatic background source', async () => {
+    const ctx = createOperationContext('sync');
+    const policy = resolveSyncGlobalBackpressure({
+      syncGlobalMaxInflight: 2,
+      syncGlobalQueueLimit: 4,
+      rfc64PublicCatalogBootstrap: {
+        acceptedPublicPolicies: [{ completeSwmProviders: ['12D3KooWCompleteSwmProvider'] }],
+      },
+    });
+    const events: string[] = [];
+    let releaseRoutine!: () => void;
+    let releaseShared!: () => void;
+
+    const changelogA = withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      label: 'changelog:core-a',
+      lane: 'changelog',
+      source: 'on-connect',
+    }, async () => new Promise<void>((resolve) => {
+      events.push('changelog-a-start');
+      releaseRoutine = resolve;
+    }));
+    await tick();
+    const vmRecovery = withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      label: 'durable:vm-recovery',
+      lane: 'durable',
+      priority: 1_000,
+      source: 'vm-recovery',
+    }, async () => {
+      events.push('vm-recovery-start');
+    });
+    await tick();
+    const ordinaryShared = withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      label: 'shared-memory:ordinary-provider',
+      lane: 'shared_memory',
+      source: 'on-connect',
+    }, async () => {
+      events.push('ordinary-shared-start');
+    });
+    await tick();
+    const shared = withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      label: 'shared-memory:selected-provider',
+      lane: 'shared_memory',
+      priority: 2_000,
+      source: 'on-connect',
+      selectedSwmPriority: true,
+    }, async () => new Promise<void>((resolve) => {
+      events.push('shared-start');
+      releaseShared = resolve;
+    }));
+    await tick();
+
+    expect(events).toEqual(['changelog-a-start', 'shared-start']);
+    releaseShared();
+    await shared;
+    expect(events).toEqual(['changelog-a-start', 'shared-start']);
+    releaseRoutine();
+    await Promise.all([changelogA, vmRecovery, ordinaryShared]);
+    expect(events).toEqual([
+      'changelog-a-start',
+      'shared-start',
+      'vm-recovery-start',
+      'ordinary-shared-start',
+    ]);
+  });
 });

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -98,6 +98,43 @@ function allowAllNetworkAdmission(agent: DKGAgent): void {
 }
 
 describe('runSyncOnConnect callbacks', () => {
+  it('runs selected-provider shared memory before unrelated durable and ordinary SWM history', async () => {
+    const remotePeer = freshPeerIdString();
+    const order: string[] = [];
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['selected', 'ordinary'],
+      getDurableSyncContextGraphs: () => ['ordinary'],
+      getPrioritySharedMemorySyncContextGraphs: async () => ['selected'],
+      getSharedMemorySyncContextGraphs: async () => ['selected', 'ordinary'],
+      syncFromPeer: async (_peerId, contextGraphIds) => {
+        order.push(`durable:${contextGraphIds?.join(',') ?? 'all'}`);
+        return 0;
+      },
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async (_peerId, contextGraphIds, options) => {
+        order.push(
+          `shared:${contextGraphIds.join(',')}:`
+            + (options?.selectedPriority === true ? 'selected' : 'ordinary'),
+        );
+        return 0;
+      },
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(order).toEqual([
+      'shared:selected:selected',
+      'durable:ordinary',
+      'shared:ordinary:ordinary',
+    ]);
+  });
+
   it('returns deferred-backpressure without marking a zero-progress peer successful', async () => {
     const remotePeer = freshPeerIdString();
     const synced: SyncOnConnectPeerOutcome[] = [];

--- a/packages/agent/test/sync-responder-snapshot-cache.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-cache.test.ts
@@ -385,6 +385,31 @@ describe('sync responder snapshot cache and budget', () => {
     expect(loads).toBe(1);
   });
 
+  it('rebuilds an expired snapshot when the same session safely retries offset zero', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    const memo = createResponderSyncRowListMemo(10);
+    let loads = 0;
+    const loadRows = async () => [{
+      s: 'urn:memo:row',
+      p: `${DKG_NS}label`,
+      o: `"snapshot-${++loads}"`,
+      g: 'urn:memo:graph',
+    }];
+
+    await expect(memo.get('durable', loadRows, {
+      refreshGeneration: 'same-session',
+    })).resolves.toMatchObject([{ o: '"snapshot-1"' }]);
+
+    vi.setSystemTime(11);
+    await expect(memo.get('durable', loadRows, {
+      refreshGeneration: 'same-session',
+      refreshExpired: true,
+    })).resolves.toMatchObject([{ o: '"snapshot-2"' }]);
+    expect(loads).toBe(2);
+  });
+
   it('does not retain empty durable row snapshots against the active cap', async () => {
     const memo = createResponderSyncRowListMemo(10_000, 1);
     let emptyLoads = 0;

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -106,6 +106,7 @@ export default defineConfig({
       "test/system-context-graph-policy.test.ts",
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",
+      "test/swm-curator-recovery-plan.test.ts",
       "test/swm-fanout-peer-selection.test.ts",
       "test/publish-literal-size.test.ts",
       "test/verify-batch.test.ts",

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -84,8 +84,10 @@ type CatchupSharedMemoryResult = SharedMemorySyncResult;
  */
 interface PeerRound {
   peerId: string;
-  /** The resolved curator for this Context Graph produced this round. */
-  fromAuthority: boolean;
+  /** The metadata-resolved curator produced this round. */
+  fromDurableAuthority: boolean;
+  /** An operator-pinned RFC-64 graph-complete SWM provider produced this round. */
+  fromSharedMemoryAuthority: boolean;
   durable: CatchupDurableResult | null;
   shared: CatchupSharedMemoryResult | null;
 }
@@ -164,10 +166,15 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
      * without this, so it orders the walk but can never end it.
      */
     authoritativePeerId?: string;
+    /** Operator-pinned RFC-64 providers that each carry the complete public SWM graph. */
+    authoritativeSharedMemoryPeerIds?: string[];
     isPrivateContextGraph: boolean;
     peerIds: string[];
     connectedPeers: number;
-  }>('prepareCatchup', request.contextGraphId);
+  }>('prepareCatchup', request.contextGraphId, request.includeSharedMemory);
+  const authoritativeSharedMemoryPeerIds = new Set(
+    prepared.authoritativeSharedMemoryPeerIds ?? [],
+  );
 
   let syncCapablePeers = 0;
   // DISTINCT peers, not peer-passes. Once the walk can repeat, `+= 1` per round
@@ -267,20 +274,18 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   }
   syncCapablePeers = syncCapable.length;
 
-  // Only the resolved curator's snapshot is a reference for the WHOLE graph: a
-  // peer's `complete` flag proves it served its own manifest, so a
-  // non-authoritative peer carrying a subset would otherwise be able to cut the
-  // walk short and strand another peer's Knowledge Assets. Both optimisations
-  // below — skipping remaining peers, and skipping an already-proven plane on
-  // the peers we do contact — are therefore gated on AUTHORITY proof. With no
-  // resolvable curator the walk degrades to the previous full bounded fan-out
-  // and keeps unioning every peer's data.
+  // Only a plane-specific authority may let one snapshot stand for the WHOLE
+  // graph: metadata resolves the durable/VM authority, while an explicit
+  // RFC-64 manifest may separately pin a graph-complete SWM provider. A peer's
+  // `complete` flag otherwise proves only its own manifest. Both optimisations
+  // below — skipping remaining peers and skipping an already-proven plane —
+  // are therefore gated on the corresponding authority proof.
   const authorityProven = { durable: false, sharedMemory: false };
   const authorityProvedEverything = (): boolean => authorityProven.durable
     && (!request.includeSharedMemory || authorityProven.sharedMemory);
 
   /**
-   * The CURATOR's own evidence, kept apart from the round total.
+   * Each plane authority's own evidence, kept apart from the round total.
    *
    * The round total mixes in every peer, and only the curator may end the walk —
    * so proof-by-data has to be read from this, not from
@@ -292,7 +297,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   };
 
   /**
-   * Whether the curator's round settles a plane well enough to stop walking.
+   * Whether the corresponding authority settles a plane well enough to stop walking.
    *
    * Verified content from the curator always does. Its EMPTINESS is weaker: it
    * is exactly `catchupPlaneProvenByAuthorityHostedEmpty`, the same predicate
@@ -319,7 +324,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     );
 
   /**
-   * Did the curator cleanly answer this plane at all?
+   * Did the corresponding authority cleanly answer this plane at all?
    *
    * Separate from `authorityProven`: a curator that answered with data proves the
    * plane, and one that answered content-free may or may not, but BOTH count as
@@ -344,8 +349,11 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   // Isolate per-peer failures: if one peer's sync steps throw, aggregate what we
   // can from the other peers instead of failing the entire subscribe/catch-up.
   const syncPeer = async (peerId: string, pass: CatchupPassContext): Promise<PeerRound> => {
-    const fromAuthorityPeer = prepared.authoritativePeerId !== undefined
+    const fromDurableAuthority = prepared.authoritativePeerId !== undefined
       && peerId === prepared.authoritativePeerId;
+    const fromSharedMemoryAuthority = authoritativeSharedMemoryPeerIds.size > 0
+      ? authoritativeSharedMemoryPeerIds.has(peerId)
+      : fromDurableAuthority;
     // A deferred plane can burn up to CATCHUP_BACKPRESSURE_MAX_WAIT_MS (180 s)
     // inside a single admission, so a continuation pass can go past its budget
     // between one peer and the next. Decline to START another peer rather than
@@ -357,7 +365,13 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     // the REPEAT, not the original: a zero budget would otherwise expire before
     // the first peer and turn the kill switch into "fetch nothing".
     if (pass.deadlineMs !== undefined && catchupPassNowMs() >= pass.deadlineMs) {
-      return { peerId, fromAuthority: fromAuthorityPeer, durable: null, shared: null };
+      return {
+        peerId,
+        fromDurableAuthority,
+        fromSharedMemoryAuthority,
+        durable: null,
+        shared: null,
+      };
     }
     peersTried.add(peerId);
     const syncDurable = (
@@ -389,18 +403,39 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     // accepted cost of repeating the walk is per-pass replay. Pass 1's durable
     // evidence is already in `cleanPlaneCompletions`; a later pass producing none
     // cannot take it away.
-    const needDurable = !pass.sharedMemoryOnly && (!optimize || !authorityProven.durable);
+    const hasDedicatedDurableAuthority = prepared.authoritativePeerId !== undefined;
+    const hasDedicatedSharedMemoryAuthority = authoritativeSharedMemoryPeerIds.size > 0;
+    const needDurable = !pass.sharedMemoryOnly
+      && (!optimize || !authorityProven.durable)
+      && (
+        !optimize
+        || !hasDedicatedDurableAuthority
+        || fromDurableAuthority
+        || !fromSharedMemoryAuthority
+      );
     // A policy-selected continuation peer is here precisely because its latest
     // complete manifest still names unresolved snapshots. Authority proof may
     // optimize pass 1, but it must never turn that selected retry into a no-op.
     const needSharedMemory = request.includeSharedMemory
-      && (pass.sharedMemoryOnly || !optimize || !authorityProven.sharedMemory);
-    const fromAuthority = fromAuthorityPeer;
+      && (pass.sharedMemoryOnly || !optimize || !authorityProven.sharedMemory)
+      && (
+        pass.sharedMemoryOnly
+        || !optimize
+        || !hasDedicatedSharedMemoryAuthority
+        || fromSharedMemoryAuthority
+        || !fromDurableAuthority
+      );
     if (!needDurable) {
       const shared = needSharedMemory
         ? await runCatchupPlaneWithPolicy('foreground', syncSharedMemory)
         : null;
-      return { peerId, fromAuthority, durable: null, shared };
+      return {
+        peerId,
+        fromDurableAuthority,
+        fromSharedMemoryAuthority,
+        durable: null,
+        shared,
+      };
     }
     const round = await runCatchupPlanesWithPolicy({
       mode: 'foreground',
@@ -408,11 +443,17 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       syncDurable,
       syncSharedMemory,
     });
-    return { peerId, fromAuthority, ...round };
+    return { peerId, fromDurableAuthority, fromSharedMemoryAuthority, ...round };
   };
 
   const accumulate = (
-    { peerId, durable, shared, fromAuthority }: PeerRound,
+    {
+      peerId,
+      durable,
+      shared,
+      fromDurableAuthority,
+      fromSharedMemoryAuthority,
+    }: PeerRound,
     isContinuationRound = false,
   ): void => {
     let peerDenied = false;
@@ -450,11 +491,11 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
 
       const durableEvidence = catchupPeerPlaneEvidence(durable, {
         complete: durable.complete,
-        fromAuthority,
+        fromAuthority: fromDurableAuthority,
         plane: 'durable',
       });
       addCatchupPlaneEvidence(cleanPlaneCompletions.durable, durableEvidence);
-      if (fromAuthority) {
+      if (fromDurableAuthority) {
         addCatchupPlaneEvidence(authorityEvidence.durable, durableEvidence);
         if (catchupPlaneCompletedWithoutFailure(durable, durable.complete)) {
           authorityAnswered.durable = true;
@@ -514,7 +555,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       if (shared.swmCoverage) {
         diagnostics.sharedMemory.swmCoverage = selectSwmSnapshotCoverage(
           diagnostics.sharedMemory.swmCoverage,
-          { ...shared.swmCoverage, fromAuthority },
+          { ...shared.swmCoverage, fromAuthority: fromSharedMemoryAuthority },
         );
       }
       diagnostics.sharedMemory.deniedPhases =
@@ -523,9 +564,12 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
 
       // Shared memory carries no verified-private-only signal, so the shared
       // evidence only ever has data/empty set — the same reducer still applies.
-      const sharedEvidence = catchupPeerPlaneEvidence(shared, { fromAuthority, plane: 'shared-memory' });
+      const sharedEvidence = catchupPeerPlaneEvidence(shared, {
+        fromAuthority: fromSharedMemoryAuthority,
+        plane: 'shared-memory',
+      });
       addCatchupPlaneEvidence(cleanPlaneCompletions.sharedMemory, sharedEvidence);
-      if (fromAuthority) {
+      if (fromSharedMemoryAuthority) {
         addCatchupPlaneEvidence(authorityEvidence.sharedMemory, sharedEvidence);
         if (catchupPlaneCompletedWithoutFailure(shared)) {
           authorityAnswered.sharedMemory = true;
@@ -551,19 +595,17 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     }
   };
 
-  // Progressive peer walk (issue #2006). The peer list arrives ranked
-  // authority-first (preferred/curator, then known cores, then the rest), but
+  // Progressive peer walk (issue #2006). The peer list arrives ranked with
+  // RFC-64 SWM providers and the metadata curator first, then known cores and the rest, but
   // that ordering used never to become *selection*: every sync-capable peer got
   // a full durable+SWM pull, so a 14-peer testnet downloaded the same graph 5-6
   // times (147,246 fetched triples for a 24,541-triple graph, ~278MB) and the
   // node-wide sync-global queue (2 inflight / 4 queued) saturated against
   // itself.
   //
-  // Instead, walk escalating waves and stop as soon as the AUTHORITY has proven
-  // every requested plane with verified data — see `authorityProven` above for
-  // why only the curator's snapshot may cut the walk short. Wave 1 is that
-  // curator when one is resolvable, so the happy path transfers exactly one
-  // payload; with no resolvable curator nothing is ever authority-proven and
+  // Instead, walk escalating waves and stop as soon as each requested plane's
+  // authority has proven it with verified data. Distinct VM and SWM authorities
+  // share the opening wave and each runs only its own plane. With no authority,
   // this degrades to the previous full bounded fan-out.
   //
   // The stop condition is also deliberately POSITIVE-only: an empty round proves
@@ -571,14 +613,14 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   // on the wire), so emptiness stays a whole-round verdict evaluated by
   // `catchupPlaneProvenByUnanimousEmpty` after every peer has been walked.
   //
-  // Tradeoff, stated deliberately: even the curator's `complete` flag proves it
-  // served its own manifest, not that the manifest was network-complete.
-  // Foreground catch-up therefore optimises for one fast authoritative payload;
-  // breadth and eventual convergence remain the background reconcile lane's job.
+  // Tradeoff, stated deliberately: metadata authority alone still proves only
+  // the curator's hosted view. An RFC-64 `completeSwmProviders` entry is a
+  // stronger operator assertion scoped to one accepted public policy; omitting
+  // it retains the ordinary union walk and background convergence.
   // DKG_CATCHUP_STOP_ON_PROOF=0 restores the previous full fan-out.
   //
-  // The single-peer opening wave is spent on the authority, so it is only taken
-  // when there IS one: if no curator resolved (or it is not sync-capable), the
+  // The opening wave is spent on the reachable plane authorities, so it is only
+  // narrowed when at least one heads the ranked list. If none is sync-capable, the
   // head of the ranked list has no special claim and serialising it would just
   // add a round-trip to the front of every round, with no early stop to earn it
   // back. In that case the walk opens at the full concurrency cap — the previous
@@ -592,19 +634,32 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   // actually decides: narrow the opening wave only when the authority IS the
   // peer that wave would contact.
   const runWalk = async (walkPeers: string[], pass: CatchupPassContext): Promise<void> => {
-  const authorityFirst = prepared.authoritativePeerId !== undefined
-    && walkPeers[0] === prepared.authoritativePeerId;
+  const isPlaneAuthority = (peerId: string): boolean => (
+    peerId === prepared.authoritativePeerId
+    || authoritativeSharedMemoryPeerIds.has(peerId)
+  );
+  let openingAuthorityCount = 0;
+  while (
+    openingAuthorityCount < walkPeers.length
+    && openingAuthorityCount < CATCHUP_MAX_CONCURRENT_PEER_SYNCS
+    && isPlaneAuthority(walkPeers[openingAuthorityCount]!)
+  ) openingAuthorityCount += 1;
   // Waves exist ONLY so an authority can cut the walk short. With no authority
   // resolvable nothing can ever break the loop, so splitting the peer set into
   // waves cannot save a single fetch — it only adds a barrier between them,
   // making the round SLOWER than the single bounded pass it replaced. Fall back
   // to that pass rather than paying for a stop that cannot happen.
-  const canStopEarly = CATCHUP_STOP_ON_PROOF && prepared.authoritativePeerId !== undefined;
+  const canStopEarly = CATCHUP_STOP_ON_PROOF && (
+    prepared.authoritativePeerId !== undefined
+    || authoritativeSharedMemoryPeerIds.size > 0
+  );
   const waveSizes = canStopEarly
     ? catchupWaveSizes(
       walkPeers.length,
       CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
-      authorityFirst ? 1 : CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
+      openingAuthorityCount > 0
+        ? openingAuthorityCount
+        : CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
     )
     : [walkPeers.length];
   let cursor = 0;
@@ -701,9 +756,15 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   // one and fail the other.
   if (prepared.authoritativePeerId !== undefined) {
     diagnostics.durable.authorityUnanswered = !authorityAnswered.durable;
-    if (request.includeSharedMemory) {
-      diagnostics.sharedMemory.authorityUnanswered = !authorityAnswered.sharedMemory;
-    }
+  }
+  if (
+    request.includeSharedMemory
+    && (
+      prepared.authoritativePeerId !== undefined
+      || authoritativeSharedMemoryPeerIds.size > 0
+    )
+  ) {
+    diagnostics.sharedMemory.authorityUnanswered = !authorityAnswered.sharedMemory;
   }
 
   diagnostics.noProtocolPeers = noProtocolPeers;

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -1054,7 +1054,7 @@ class WorkerCatchupRunner implements CatchupRunner {
     const agent = this.agent as any;
     switch (method) {
       case 'prepareCatchup': {
-        const [contextGraphId] = args as [string];
+        const [contextGraphId, includeSharedMemory = true] = args as [string, boolean?];
         const isPrivateContextGraph = await agent.isPrivateContextGraph(contextGraphId);
         // ONE resolution, two notions. Ranking uses whatever peer is available;
         // letting one peer's answer stand for the whole graph requires the
@@ -1078,22 +1078,43 @@ class WorkerCatchupRunner implements CatchupRunner {
         // of it: a renamed or added provenance value has to break here rather
         // than silently downgrade every curator to non-authoritative.
         const authoritativePeerId = authoritativeSyncPeerId(resolution);
+        const authoritativeSharedMemoryPeerIds: readonly string[] =
+          includeSharedMemory
+          && typeof agent.resolveRfc64CompleteSwmProviderPeerIdsV1 === 'function'
+            ? agent.resolveRfc64CompleteSwmProviderPeerIdsV1(contextGraphId)
+            : [];
         if (preferredPeerId) {
           await agent.ensurePeerConnected(preferredPeerId);
         }
+        await Promise.allSettled(
+          authoritativeSharedMemoryPeerIds.map(
+            (peerId) => agent.ensurePeerConnected(peerId),
+          ),
+        );
         await agent.primeCatchupConnections();
 
-        const peerIds = agent.selectCatchupPeers(
+        const selectedPeerIds = agent.selectCatchupPeers(
           [...new Map(
             agent.node.libp2p.getConnections().map((connection: any) => [connection.remotePeer.toString(), connection.remotePeer]),
           ).values()],
           preferredPeerId,
           isPrivateContextGraph,
         ).map((peer: { toString(): string }) => peer.toString());
+        const prioritizedPeerIds = [...new Set([
+          ...authoritativeSharedMemoryPeerIds,
+          ...(preferredPeerId === undefined ? [] : [preferredPeerId]),
+        ])];
+        const selectedPeerIdSet = new Set(selectedPeerIds);
+        const prioritizedPeerIdSet = new Set(prioritizedPeerIds);
+        const peerIds = [
+          ...prioritizedPeerIds.filter((peerId) => selectedPeerIdSet.has(peerId)),
+          ...selectedPeerIds.filter((peerId: string) => !prioritizedPeerIdSet.has(peerId)),
+        ];
 
         return {
           preferredPeerId,
           authoritativePeerId,
+          authoritativeSharedMemoryPeerIds,
           isPrivateContextGraph,
           peerIds,
           connectedPeers: peerIds.length,

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -703,6 +703,14 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       && typeof agent.readRfc64PublicCatalogBootstrapStatusV1 === 'function'
         ? agent.readRfc64PublicCatalogBootstrapStatusV1()
         : null;
+    const rfc64CompleteSwmProviders = rfc64PublicCatalogActivation.enabled
+      ? (rfc64PublicCatalogActivation.bootstrap?.acceptedPublicPolicies ?? [])
+        .filter((accepted) => (accepted.completeSwmProviders?.length ?? 0) > 0)
+        .map((accepted) => ({
+          contextGraphId: accepted.policyEnvelope.payload.contextGraphId,
+          providers: accepted.completeSwmProviders,
+        }))
+      : [];
     const unavailableFinalizationRecovery = (reason: string) => ({
       available: false,
       closed: false,
@@ -807,6 +815,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         enabled: rfc64PublicCatalogActivation.enabled,
         selectedContextGraphs: rfc64PublicCatalogActivation.selectedContextGraphs,
         autoPublishEnabled: rfc64PublicCatalogActivation.autoPublish !== undefined,
+        completeSwmProviders: rfc64CompleteSwmProviders,
         service: rfc64PublicCatalogService,
         bootstrap: rfc64PublicCatalogBootstrap,
       },

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -57,19 +57,18 @@ const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 /**
  * SCOPE OF THESE TESTS — read before trusting a green run.
  *
- * Every case below hands the worker an `authoritativePeerId` through the stubbed
- * `prepareCatchup` boundary. **No production resolver route currently produces
- * one.** `resolveCuratorSyncPeer` was changed in `e7f46dca2` so that nothing
- * earns `metadata` provenance, because a curator-to-peer binding read out of
- * accumulated `<cg>/_meta` identifies the graph that HOLDS the rows, not the
- * writer that SUPPLIED them — and ordinary durable-meta catch-up lets a
- * contacted peer write those very rows.
+ * Most older cases below hand the worker an `authoritativePeerId` through the
+ * stubbed `prepareCatchup` boundary. No production metadata resolver currently
+ * produces that durable/VM authority: `resolveCuratorSyncPeer` was changed in
+ * `e7f46dca2` because a curator-to-peer binding read out of accumulated
+ * `<cg>/_meta` identifies the graph that HOLDS the rows, not the writer that
+ * SUPPLIED them. RFC-64 now has a separate production route for explicit,
+ * operator-pinned graph-complete SWM providers; the focused test below covers
+ * that resolver-to-worker bridge and keeps its authority separate from VM.
  *
- * So these tests verify that the worker HANDLES an authority correctly IF it is
- * given one. They do NOT verify that the early stop or the per-plane narrowing
- * happens in the shipped build — it cannot, and byte volume is at the pre-fix
- * level until #2018 lands a trusted binding. Read as end-to-end evidence for the
- * fan-out reduction they would be claiming something untrue.
+ * Therefore the injected metadata-authority cases remain worker-contract tests,
+ * while the RFC-64 SWM case is production-wiring evidence for SWM selection.
+ * Do not read the former as proof that VM authority resolution is already live.
  *
  * They are kept rather than deleted because #2018 re-enables exactly this
  * machinery, and deleting them would remove the contract it has to satisfy. When
@@ -142,6 +141,48 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
     expect(result.sharedMemorySynced).toBe(1);
     expect(result.denied).toBe(false);
     expect(finalizeCalls).toEqual([['cg-one-payload', 1, 1]]);
+  });
+
+  it('uses distinct RFC-64 SWM and metadata VM authorities without fallback fan-out', async () => {
+    const peerIds = ['peer-swm', 'peer-curator', 'peer-a', 'peer-b'];
+    const durableCalls: string[] = [];
+    const sharedCalls: string[] = [];
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: 'cg-plane-authorities', includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return {
+              preferredPeerId: 'peer-curator',
+              authoritativePeerId: 'peer-curator',
+              authoritativeSharedMemoryPeerIds: ['peer-swm'],
+              isPrivateContextGraph: false,
+              peerIds,
+              connectedPeers: peerIds.length,
+            };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            durableCalls.push(args[0] as string);
+            return durableResult();
+          case 'syncSharedMemory':
+            sharedCalls.push(args[0] as string);
+            return sharedResult();
+          case 'finalizeCatchup':
+            return null;
+          default:
+            throw new Error(`unexpected invoke: ${method}`);
+        }
+      },
+    );
+
+    expect(durableCalls).toEqual(['peer-curator']);
+    expect(sharedCalls).toEqual(['peer-swm']);
+    expect(result.peersTried).toBe(2);
+    expect(result.peersNotAttempted).toBe(2);
+    expect(result.diagnostics?.durable.authorityUnanswered).toBe(false);
+    expect(result.diagnostics?.sharedMemory.authorityUnanswered).toBe(false);
   });
 
   it('escalates waves and still caps in-flight peer syncs when no peer proves the plane', async () => {

--- a/packages/cli/test/catchup-runner-worker-lifecycle.test.ts
+++ b/packages/cli/test/catchup-runner-worker-lifecycle.test.ts
@@ -314,6 +314,59 @@ describe('WorkerCatchupRunner agent bridge', () => {
     expect(posted.result.connectedPeers).toBe(3);
   });
 
+  it('ranks an RFC-64 complete-SWM provider ahead of fallback peers', async () => {
+    const ensured: string[] = [];
+    const { agent } = bridgeAgent({
+      resolveSyncPeerWithProvenance: async () => ({
+        peerId: 'peer-curator',
+        provenance: 'metadata',
+      }),
+      resolveRfc64CompleteSwmProviderPeerIdsV1: () => ['peer-swm'],
+      ensurePeerConnected: async (peerId: string) => { ensured.push(peerId); },
+      node: {
+        libp2p: {
+          getConnections: () => ['peer-a', 'peer-curator', 'peer-swm'].map(
+            (id) => ({ remotePeer: { toString: () => id } }),
+          ),
+        },
+      },
+      selectCatchupPeers: (peers: Array<{ toString(): string }>) => peers,
+    });
+
+    const posted = await invokeThroughBridge(agent, 'prepareCatchup', ['cg-rfc64-swm', true]);
+
+    expect(ensured).toEqual(['peer-curator', 'peer-swm']);
+    expect(posted.result.authoritativePeerId).toBe('peer-curator');
+    expect(posted.result.authoritativeSharedMemoryPeerIds).toEqual(['peer-swm']);
+    expect(posted.result.peerIds).toEqual(['peer-swm', 'peer-curator', 'peer-a']);
+  });
+
+  it('does not prioritize an RFC-64 SWM provider for a VM-only catch-up', async () => {
+    const ensured: string[] = [];
+    const { agent } = bridgeAgent({
+      resolveSyncPeerWithProvenance: async () => ({
+        peerId: 'peer-curator',
+        provenance: 'metadata',
+      }),
+      resolveRfc64CompleteSwmProviderPeerIdsV1: () => ['peer-swm'],
+      ensurePeerConnected: async (peerId: string) => { ensured.push(peerId); },
+      node: {
+        libp2p: {
+          getConnections: () => ['peer-a', 'peer-curator', 'peer-swm'].map(
+            (id) => ({ remotePeer: { toString: () => id } }),
+          ),
+        },
+      },
+      selectCatchupPeers: (peers: Array<{ toString(): string }>) => peers,
+    });
+
+    const posted = await invokeThroughBridge(agent, 'prepareCatchup', ['cg-rfc64-swm', false]);
+
+    expect(ensured).toEqual(['peer-curator']);
+    expect(posted.result.authoritativeSharedMemoryPeerIds).toEqual([]);
+    expect(posted.result.peerIds).toEqual(['peer-curator', 'peer-a', 'peer-swm']);
+  });
+
   it('forwards the admission source into both detailed sync calls', async () => {
     const { agent, calls } = bridgeAgent();
 

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -255,6 +255,7 @@ describe('/api/status RFC-64 selected-public activation', () => {
       enabled: false,
       selectedContextGraphs: [],
       autoPublishEnabled: false,
+      completeSwmProviders: [],
       service: null,
       bootstrap: null,
     });
@@ -292,7 +293,10 @@ describe('/api/status RFC-64 selected-public activation', () => {
             catalogIssuerDelegationExpiresAt: '1893456000000',
           },
           bootstrap: {
-            acceptedPublicPolicies: [rfc64PublicCatalogPolicy('selected-public-cg')],
+            acceptedPublicPolicies: [{
+              ...rfc64PublicCatalogPolicy('selected-public-cg'),
+              completeSwmProviders: ['12D3KooCompleteSwm'],
+            }],
           },
         },
       },
@@ -303,6 +307,10 @@ describe('/api/status RFC-64 selected-public activation', () => {
       enabled: true,
       selectedContextGraphs: ['selected-public-cg'],
       autoPublishEnabled: true,
+      completeSwmProviders: [{
+        contextGraphId: 'selected-public-cg',
+        providers: ['12D3KooCompleteSwm'],
+      }],
       service,
       bootstrap,
     });
@@ -335,6 +343,7 @@ describe('/api/status RFC-64 selected-public activation', () => {
       enabled: true,
       selectedContextGraphs: ['receiver-only-cg'],
       autoPublishEnabled: false,
+      completeSwmProviders: [],
       bootstrap,
     });
   });


### PR DESCRIPTION
## User impact

An Edge operator can select specific public context graphs and pin an independently established graph-complete SWM provider. Those selected graphs receive a bounded priority path so live or cold recovery is not starved by unrelated background synchronization. VM and durable recovery remain chain and curator driven.

This does **not** introduce sync-all-public-CGs behavior. It is dormant when RFC-64 is disabled, and existing behavior remains unchanged when `completeSwmProviders` is omitted.

## What changes

- Treat `completeSwmProviders` as plane-specific authority for public SWM only.
- Contact selected SWM authorities before the general peer walk while keeping VM and durable authority separate.
- Reserve one global admission slot from automatic background work when selected RFC-64 SWM convergence is configured.
- Avoid duplicate durable pulls from unrelated Edge peers for the selected graph.
- Preserve retry, failover, restart, and cancellation behavior.
- Expose the effective graph-to-provider selection through `/api/status`.

## Before

```mermaid
sequenceDiagram
    participant Edge
    participant Peers
    participant Queue as Global sync queue

    Edge->>Peers: Start automatic peer walk
    loop Every sync-capable peer
        Edge->>Peers: Request durable and SWM planes
        Peers-->>Queue: Return overlapping snapshots
        Queue-->>Edge: Admit with background synchronization
    end
    Queue-->>Edge: Selected SWM may be deferred by unrelated work
```

## After

```mermaid
sequenceDiagram
    participant Operator
    participant Edge
    participant SWM as Complete SWM provider
    participant VM as Chain and curator authority
    participant Queue as Global sync queue

    Operator->>Edge: Select public CG and complete SWM provider
    par SWM plane
        Edge->>SWM: Request selected graph SWM
        SWM-->>Queue: Return graph-complete SWM snapshot
        Queue-->>Edge: Admit through reserved selected-SWM capacity
    and VM and durable planes
        Edge->>VM: Reconcile chain-backed inventory
        VM-->>Edge: Return durable and finalized VM state
    end
    Edge-->>Operator: Report selected providers and convergence status
```

## Safety boundaries

- No new all-public graph discovery or subscription mode.
- No RFC-64 VM catalog authority; VM remains chain-backed.
- No effect unless RFC-64 is enabled for an explicit accepted public policy.
- A normal catalog provider is not treated as graph-complete; only the explicit `completeSwmProviders` assertion enables early proof.
- Failure remains fail-open for an already committed user operation.

## Validation

- Agent focused suite: 6 files, 181 tests passed.
- Agent build: TypeScript, type tests, and package-root test passed.
- CLI worker suites: 2 files, 58 tests passed.
- CLI TypeScript check passed.
- Diff whitespace check passed.
- Combined candidate-stack Testnet gate on fresh public CG 298:
  - 400 SWM and 400 VM assets, 100-500 triples per publication.
  - Selected receiver reached exact SWM 400/400.
  - After the chain-inventory VM recovery fix, exact VM reached 400/400 and 15,428,882 bytes.
  - Restart preserved exact 400/400 VM state with no manual catch-up.

## Scope

- Targets `testnet-canary`.
- No protocol-wire change.
- This PR is ready for independent review; it is not merged by the PR author.
