### PR TITLE
fix(agent): reuse proven VM recovery providers

### DIFF
--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -4322,6 +4322,47 @@ export class SwmHostModeMethods extends DKGAgentBase {
     ].filter((peerId) => !record.attemptedPeerIds.has(peerId));
   }
 
+  /**
+   * Select one physical peer for an exact-VM target. A peer that returned an
+   * exact hit in this slice is preferred and may be reused sequentially; all
+   * other peers remain one-use-per-slice. Unavailable peers and the global
+   * considered-peer cap remain authoritative for both classes.
+   */
+  selectVmReconcileExactCandidate(
+    this: DKGAgent,
+    record: VmReconcileRotationRecord | undefined,
+    fallbackCandidatePeerIds: readonly string[],
+    policy: {
+      provenHolderPeerIds: ReadonlySet<string>;
+      usedPeerIds: ReadonlySet<string>;
+      unavailablePeerIds: ReadonlySet<string>;
+      consideredPeerIds: Set<string>;
+    },
+  ): string | undefined {
+    const uncreditedCandidateOrder = record
+      ? this.vmReconcileUncreditedCandidateOrder(record)
+      : [...fallbackCandidatePeerIds];
+    const candidateOrder = [
+      ...uncreditedCandidateOrder.filter((peerId) =>
+        policy.provenHolderPeerIds.has(peerId)),
+      ...uncreditedCandidateOrder.filter((peerId) =>
+        !policy.provenHolderPeerIds.has(peerId)),
+    ];
+    for (const peerId of candidateOrder) {
+      if (
+        (policy.usedPeerIds.has(peerId) && !policy.provenHolderPeerIds.has(peerId))
+        || policy.unavailablePeerIds.has(peerId)
+      ) continue;
+      if (
+        !policy.consideredPeerIds.has(peerId)
+        && policy.consideredPeerIds.size >= DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX
+      ) return undefined;
+      policy.consideredPeerIds.add(peerId);
+      return peerId;
+    }
+    return undefined;
+  }
+
   findVmReconcileRotationReplacement(
     this: DKGAgent,
     requestingCgId?: string,
@@ -5014,25 +5055,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // uncredited, but consume this target's turn so another missing KA gets
       // the next physical peer slot in the same bounded pass.
       let peerId: string | undefined;
-      const uncreditedCandidateOrder = installedRecord
-        ? this.vmReconcileUncreditedCandidateOrder(installedRecord)
-        : orderedPeerIds;
-      const candidateOrder = [
-        ...uncreditedCandidateOrder.filter((candidatePeerId) =>
-          provenHolderPeerIds.has(candidatePeerId)),
-        ...uncreditedCandidateOrder.filter((candidatePeerId) =>
-          !provenHolderPeerIds.has(candidatePeerId)),
-      ];
-      for (const candidatePeerId of candidateOrder) {
-        if (
-          (usedPeerIds.has(candidatePeerId) && !provenHolderPeerIds.has(candidatePeerId))
-          || unavailablePeerIds.has(candidatePeerId)
-        ) continue;
-        if (
-          !consideredPeerIds.has(candidatePeerId)
-          && consideredPeerIds.size >= DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX
-        ) break;
-        consideredPeerIds.add(candidatePeerId);
+      const candidatePeerId = this.selectVmReconcileExactCandidate(
+        installedRecord,
+        orderedPeerIds,
+        { provenHolderPeerIds, usedPeerIds, unavailablePeerIds, consideredPeerIds },
+      );
+      if (candidatePeerId) {
         attemptedOrdinals.add(target.ordinal);
         if (installedRecord) {
           installedRecord.lastAttemptedPeerId = candidatePeerId;
@@ -5065,24 +5093,20 @@ export class SwmHostModeMethods extends DKGAgentBase {
         if (!isRecoveryCurrent()) return noRecovery();
         if (!connectedPeer || !protocolReady) {
           unavailablePeerIds.add(candidatePeerId);
-          break;
+        } else {
+          // Network boundary: a merely-connected peer is not necessarily
+          // admitted to this DKG network. Never send an authenticated exact
+          // request to an unverified or rejected peer.
+          const peerAdmitted = await this.ensurePeerAdmittedForRecovery(
+            candidatePeerId,
+            ctx,
+            'VM exact fetch',
+            signal,
+          );
+          if (!isRecoveryCurrent()) return noRecovery();
+          if (!peerAdmitted) unavailablePeerIds.add(candidatePeerId);
+          else peerId = candidatePeerId;
         }
-        // Network boundary: a merely-connected peer is not necessarily
-        // admitted to this DKG network. Never send an authenticated exact
-        // request to an unverified or rejected peer.
-        const peerAdmitted = await this.ensurePeerAdmittedForRecovery(
-          candidatePeerId,
-          ctx,
-          'VM exact fetch',
-          signal,
-        );
-        if (!isRecoveryCurrent()) return noRecovery();
-        if (!peerAdmitted) {
-          unavailablePeerIds.add(candidatePeerId);
-          break;
-        }
-        peerId = candidatePeerId;
-        break;
       }
       if (!peerId) {
         if (installedRecord) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -4984,6 +4984,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const outcomes = new Map<number, OrdinalOutcome>();
     const attemptedOrdinals = new Set<number>();
     const usedPeerIds = new Set<string>();
+    // A clean exact hit proves only that this peer held the requested asset,
+    // not the whole CG. It is nevertheless the best bounded candidate for the
+    // next untouched target in this same slice. Reuse it sequentially while it
+    // keeps returning exact hits; one clean absence or incomplete response
+    // removes the hint immediately. This preserves the one-frame-per-request
+    // memory bound and peer-roster proof semantics while avoiding the former
+    // one-asset-per-provider-per-sweep throughput ceiling.
+    const provenHolderPeerIds = new Set<string>();
     const consideredPeerIds = new Set<string>();
     const unavailablePeerIds = new Set<string>();
     let recoveryWorkRan = false;
@@ -5006,11 +5014,20 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // uncredited, but consume this target's turn so another missing KA gets
       // the next physical peer slot in the same bounded pass.
       let peerId: string | undefined;
-      const candidateOrder = installedRecord
+      const uncreditedCandidateOrder = installedRecord
         ? this.vmReconcileUncreditedCandidateOrder(installedRecord)
         : orderedPeerIds;
+      const candidateOrder = [
+        ...uncreditedCandidateOrder.filter((candidatePeerId) =>
+          provenHolderPeerIds.has(candidatePeerId)),
+        ...uncreditedCandidateOrder.filter((candidatePeerId) =>
+          !provenHolderPeerIds.has(candidatePeerId)),
+      ];
       for (const candidatePeerId of candidateOrder) {
-        if (usedPeerIds.has(candidatePeerId) || unavailablePeerIds.has(candidatePeerId)) continue;
+        if (
+          (usedPeerIds.has(candidatePeerId) && !provenHolderPeerIds.has(candidatePeerId))
+          || unavailablePeerIds.has(candidatePeerId)
+        ) continue;
         if (
           !consideredPeerIds.has(candidatePeerId)
           && consideredPeerIds.size >= DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX
@@ -5125,6 +5142,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
           `VM exact fetch for "${localCgId}" from ${peerId.slice(-8)} failed: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
+      if (disposition === 'found') provenHolderPeerIds.add(peerId);
+      else provenHolderPeerIds.delete(peerId);
 
       // The exact request may have completed after unsubscribe, rebind, or
       // shutdown. Its authenticated materialization is already fail-closed,

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2708,6 +2708,139 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(result.continuationOrdinal).toBe(2);
   });
 
+  it('reuses a proven holder sequentially across the bounded recovery slice', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmProvenHolderBurst', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const holder = '12D3KooWExactProvenAHolder';
+    const fallback = '12D3KooWExactProvenZFallback';
+    const localCgId = '0x0000000000000000000000000000000000000001/proven-holder';
+    const connected = [holder, fallback].map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWExactProvenLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [holder, fallback], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const fetches: Array<{ peerId: string; ordinal: number }> = [];
+    const recovered = new Set<number>();
+    let activeFetches = 0;
+    let maxActiveFetches = 0;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
+      peerId: string,
+      _cg: string,
+      uals: string[],
+    ) => {
+      activeFetches += 1;
+      maxActiveFetches = Math.max(maxActiveFetches, activeFetches);
+      const ordinal = Number(uals[0]!.split('/').at(-1));
+      fetches.push({ peerId, ordinal });
+      if (peerId === holder) recovered.add(ordinal);
+      activeFetches -= 1;
+      return {
+        result: {
+          fetchedDataTriples: peerId === holder ? 1 : 0,
+          fetchedMetaTriples: peerId === holder ? 8 : 0,
+          insertedTriples: peerId === holder ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: peerId === holder ? 'found' as const : 'clean-absent' as const,
+      };
+    };
+    const targets = Array.from({ length: 4 }, (_, ordinal) =>
+      vmRecoveryTarget(localCgId, ordinal, String(ordinal)));
+    (internals as any).reconcileChainOrdinal = async (
+      _lcg: string, _ocg: bigint, ordinal: number,
+    ) => recovered.has(ordinal)
+      ? { status: 'reconciled', blockNumber: 100 }
+      : { status: 'pending', recovery: targets[ordinal] };
+
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, targets, 100, () => true,
+    );
+
+    expect(fetches).toEqual(targets.map((target) => ({
+      peerId: holder,
+      ordinal: target.ordinal,
+    })));
+    expect(maxActiveFetches).toBe(1);
+    expect(result.attemptedOrdinals).toEqual(targets.map((target) => target.ordinal));
+    expect([...result.outcomes.values()]).toEqual(
+      targets.map(() => ({ status: 'reconciled', blockNumber: 100 })),
+    );
+    expect(result.continuationOrdinal).toBeUndefined();
+  });
+
+  it('stops reusing a proven holder after a clean absence', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmProvenHolderRevocation', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const holder = '12D3KooWExactRevocationAHolder';
+    const fallback = '12D3KooWExactRevocationZFallback';
+    const localCgId = '0x0000000000000000000000000000000000000001/revoke-holder';
+    const connected = [holder, fallback].map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWExactRevocationLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [holder, fallback], curatorIsLocal: false, legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const fetches: Array<{ peerId: string; ordinal: number }> = [];
+    const recovered = new Set<number>();
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
+      peerId: string,
+      _cg: string,
+      uals: string[],
+    ) => {
+      const ordinal = Number(uals[0]!.split('/').at(-1));
+      fetches.push({ peerId, ordinal });
+      const found = (peerId === holder && ordinal === 0)
+        || (peerId === fallback && ordinal === 2);
+      if (found) recovered.add(ordinal);
+      return {
+        result: {
+          fetchedDataTriples: found ? 1 : 0,
+          fetchedMetaTriples: found ? 8 : 0,
+          insertedTriples: found ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: found ? 'found' as const : 'clean-absent' as const,
+      };
+    };
+    const targets = Array.from({ length: 3 }, (_, ordinal) =>
+      vmRecoveryTarget(localCgId, ordinal, String(ordinal)));
+    (internals as any).reconcileChainOrdinal = async (
+      _lcg: string, _ocg: bigint, ordinal: number,
+    ) => recovered.has(ordinal)
+      ? { status: 'reconciled', blockNumber: 100 }
+      : { status: 'pending', recovery: targets[ordinal] };
+
+    const result = await internals.recoverVmReconcileBatch(
+      localCgId, 1n, targets, 100, () => true,
+    );
+
+    expect(fetches).toEqual([
+      { peerId: holder, ordinal: 0 },
+      { peerId: holder, ordinal: 1 },
+      { peerId: fallback, ordinal: 2 },
+    ]);
+    expect(result.attemptedOrdinals).toEqual([0, 1, 2]);
+    expect(result.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+    expect(result.outcomes.get(1)?.status).toBe('pending');
+    expect(result.outcomes.get(2)).toEqual({ status: 'reconciled', blockNumber: 100 });
+    expect(result.continuationOrdinal).toBeUndefined();
+  });
+
   it('spreads unavailable-peer probes across targets within the global peer budget', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmUnavailableFairness', chainAdapter: chain });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2051,6 +2051,90 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     }
   });
 
+  async function createExactVmRecoveryHarness(options: {
+    name: string;
+    localCgId: string;
+    peers: string[];
+    targetCount: number;
+    found: (peerId: string, ordinal: number) => boolean;
+  }) {
+    const created = await DKGAgent.create({
+      name: options.name,
+      chainAdapter: new MockChainAdapter(),
+    });
+    const internals = created as unknown as AgentInternals;
+    const connected = options.peers.map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: `12D3KooW${options.name}Local`,
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: options.peers,
+      curatorIsLocal: false,
+      legacyTripleResolved: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (
+      peers: Array<{ toString(): string }>,
+    ) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+
+    const fetches: Array<{ peerId: string; ordinal: number }> = [];
+    const recovered = new Set<number>();
+    let activeFetches = 0;
+    let maxActiveFetches = 0;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
+      peerId: string,
+      _cg: string,
+      uals: string[],
+    ) => {
+      activeFetches += 1;
+      maxActiveFetches = Math.max(maxActiveFetches, activeFetches);
+      const ordinal = Number(uals[0]!.split('/').at(-1));
+      fetches.push({ peerId, ordinal });
+      const wasFound = options.found(peerId, ordinal);
+      if (wasFound) recovered.add(ordinal);
+      activeFetches -= 1;
+      return {
+        result: {
+          fetchedDataTriples: wasFound ? 1 : 0,
+          fetchedMetaTriples: wasFound ? 8 : 0,
+          insertedTriples: wasFound ? 9 : 0,
+          failedPeers: 0,
+          failedPhases: 0,
+          deferredBackpressure: 0,
+        },
+        disposition: wasFound ? 'found' as const : 'clean-absent' as const,
+      };
+    };
+    const targets = Array.from({ length: options.targetCount }, (_, ordinal) =>
+      vmRecoveryTarget(options.localCgId, ordinal, String(ordinal)));
+    (internals as any).reconcileChainOrdinal = async (
+      _localCgId: string,
+      _onChainCgId: bigint,
+      ordinal: number,
+    ) => recovered.has(ordinal)
+      ? { status: 'reconciled', blockNumber: 100 }
+      : { status: 'pending', recovery: targets[ordinal] };
+
+    return {
+      agent: created,
+      internals,
+      targets,
+      fetches,
+      recovered,
+      maxActiveFetches: () => maxActiveFetches,
+      run: () => internals.recoverVmReconcileBatch(
+        options.localCgId,
+        1n,
+        targets,
+        100,
+        () => true,
+      ),
+    };
+  }
+
   it('sweep triggers a reconcile for a core-hosted CG with NO member subscription', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'CoreFillSweep', chainAdapter: chain });
@@ -2709,127 +2793,49 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
   });
 
   it('reuses a proven holder sequentially across the bounded recovery slice', async () => {
-    const chain = new MockChainAdapter();
-    agent = await DKGAgent.create({ name: 'ExactVmProvenHolderBurst', chainAdapter: chain });
-    const internals = agent as unknown as AgentInternals;
     const holder = '12D3KooWExactProvenAHolder';
     const fallback = '12D3KooWExactProvenZFallback';
     const localCgId = '0x0000000000000000000000000000000000000001/proven-holder';
-    const connected = [holder, fallback].map((peerId) => ({ toString: () => peerId }));
-    (internals as any).node = {
-      peerId: '12D3KooWExactProvenLocal',
-      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
-    };
-    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
-      peerIds: [holder, fallback], curatorIsLocal: false, legacyTripleResolved: false,
+    const harness = await createExactVmRecoveryHarness({
+      name: 'ExactVmProvenHolderBurst',
+      localCgId,
+      peers: [holder, fallback],
+      targetCount: 4,
+      found: (peerId) => peerId === holder,
     });
-    (internals as any).ensurePeerConnected = async () => undefined;
-    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
-    (internals as any).waitForSyncProtocol = async () => true;
-    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
-    const fetches: Array<{ peerId: string; ordinal: number }> = [];
-    const recovered = new Set<number>();
-    let activeFetches = 0;
-    let maxActiveFetches = 0;
-    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
-      peerId: string,
-      _cg: string,
-      uals: string[],
-    ) => {
-      activeFetches += 1;
-      maxActiveFetches = Math.max(maxActiveFetches, activeFetches);
-      const ordinal = Number(uals[0]!.split('/').at(-1));
-      fetches.push({ peerId, ordinal });
-      if (peerId === holder) recovered.add(ordinal);
-      activeFetches -= 1;
-      return {
-        result: {
-          fetchedDataTriples: peerId === holder ? 1 : 0,
-          fetchedMetaTriples: peerId === holder ? 8 : 0,
-          insertedTriples: peerId === holder ? 9 : 0,
-          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
-        },
-        disposition: peerId === holder ? 'found' as const : 'clean-absent' as const,
-      };
-    };
-    const targets = Array.from({ length: 4 }, (_, ordinal) =>
-      vmRecoveryTarget(localCgId, ordinal, String(ordinal)));
-    (internals as any).reconcileChainOrdinal = async (
-      _lcg: string, _ocg: bigint, ordinal: number,
-    ) => recovered.has(ordinal)
-      ? { status: 'reconciled', blockNumber: 100 }
-      : { status: 'pending', recovery: targets[ordinal] };
+    agent = harness.agent;
+    const result = await harness.run();
 
-    const result = await internals.recoverVmReconcileBatch(
-      localCgId, 1n, targets, 100, () => true,
-    );
-
-    expect(fetches).toEqual(targets.map((target) => ({
+    expect(harness.fetches).toEqual(harness.targets.map((target) => ({
       peerId: holder,
       ordinal: target.ordinal,
     })));
-    expect(maxActiveFetches).toBe(1);
-    expect(result.attemptedOrdinals).toEqual(targets.map((target) => target.ordinal));
+    expect(harness.maxActiveFetches()).toBe(1);
+    expect(result.attemptedOrdinals).toEqual(
+      harness.targets.map((target) => target.ordinal),
+    );
     expect([...result.outcomes.values()]).toEqual(
-      targets.map(() => ({ status: 'reconciled', blockNumber: 100 })),
+      harness.targets.map(() => ({ status: 'reconciled', blockNumber: 100 })),
     );
     expect(result.continuationOrdinal).toBeUndefined();
   });
 
   it('stops reusing a proven holder after a clean absence', async () => {
-    const chain = new MockChainAdapter();
-    agent = await DKGAgent.create({ name: 'ExactVmProvenHolderRevocation', chainAdapter: chain });
-    const internals = agent as unknown as AgentInternals;
     const holder = '12D3KooWExactRevocationAHolder';
     const fallback = '12D3KooWExactRevocationZFallback';
     const localCgId = '0x0000000000000000000000000000000000000001/revoke-holder';
-    const connected = [holder, fallback].map((peerId) => ({ toString: () => peerId }));
-    (internals as any).node = {
-      peerId: '12D3KooWExactRevocationLocal',
-      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
-    };
-    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
-      peerIds: [holder, fallback], curatorIsLocal: false, legacyTripleResolved: false,
+    const harness = await createExactVmRecoveryHarness({
+      name: 'ExactVmProvenHolderRevocation',
+      localCgId,
+      peers: [holder, fallback],
+      targetCount: 3,
+      found: (peerId, ordinal) => (peerId === holder && ordinal === 0)
+        || (peerId === fallback && ordinal === 2),
     });
-    (internals as any).ensurePeerConnected = async () => undefined;
-    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
-    (internals as any).waitForSyncProtocol = async () => true;
-    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
-    const fetches: Array<{ peerId: string; ordinal: number }> = [];
-    const recovered = new Set<number>();
-    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (
-      peerId: string,
-      _cg: string,
-      uals: string[],
-    ) => {
-      const ordinal = Number(uals[0]!.split('/').at(-1));
-      fetches.push({ peerId, ordinal });
-      const found = (peerId === holder && ordinal === 0)
-        || (peerId === fallback && ordinal === 2);
-      if (found) recovered.add(ordinal);
-      return {
-        result: {
-          fetchedDataTriples: found ? 1 : 0,
-          fetchedMetaTriples: found ? 8 : 0,
-          insertedTriples: found ? 9 : 0,
-          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
-        },
-        disposition: found ? 'found' as const : 'clean-absent' as const,
-      };
-    };
-    const targets = Array.from({ length: 3 }, (_, ordinal) =>
-      vmRecoveryTarget(localCgId, ordinal, String(ordinal)));
-    (internals as any).reconcileChainOrdinal = async (
-      _lcg: string, _ocg: bigint, ordinal: number,
-    ) => recovered.has(ordinal)
-      ? { status: 'reconciled', blockNumber: 100 }
-      : { status: 'pending', recovery: targets[ordinal] };
+    agent = harness.agent;
+    const result = await harness.run();
 
-    const result = await internals.recoverVmReconcileBatch(
-      localCgId, 1n, targets, 100, () => true,
-    );
-
-    expect(fetches).toEqual([
+    expect(harness.fetches).toEqual([
       { peerId: holder, ordinal: 0 },
       { peerId: holder, ordinal: 1 },
       { peerId: fallback, ordinal: 2 },


### PR DESCRIPTION
## Impact

Cold VM recovery no longer stalls at roughly one asset per recovery sweep when only one reachable peer actually holds the CG corpus. After an exact authenticated hit, the receiver may reuse that proven holder sequentially for the remaining assets in the same bounded slice.

The change does not increase request concurrency or frame-memory pressure: every request still contains one asset, requests remain sequential, and the existing VM reconciliation batch cap remains authoritative. A clean absence or incomplete response immediately revokes the preference.

## Before

```mermaid
sequenceDiagram
    participant Receiver
    participant Holder
    participant EmptyPeer
    loop Each recovery sweep
        Receiver->>Holder: Fetch one exact VM asset
        Holder-->>Receiver: Exact asset found
        Receiver->>EmptyPeer: Fetch next exact VM asset
        EmptyPeer-->>Receiver: Clean absence
        Note over Receiver: Remaining assets wait for another sweep
    end
```

## After

```mermaid
sequenceDiagram
    participant Receiver
    participant Holder
    participant Fallback
    loop Bounded recovery slice
        Receiver->>Holder: Fetch one exact VM asset
        Holder-->>Receiver: Exact asset found
        Note over Receiver: Mark holder proven for this slice
        Receiver->>Holder: Fetch next exact VM asset sequentially
        alt Holder continues returning exact assets
            Holder-->>Receiver: Exact asset found
        else Holder returns absence or incomplete
            Holder-->>Receiver: No exact asset
            Note over Receiver: Revoke proven-holder preference
            Receiver->>Fallback: Continue with next eligible peer
        end
    end
```

## Verification

- `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/core-fills-gap.test.ts --silent` — 125 passed
- `pnpm --filter @origintrail-official/dkg-agent build` — passed, including type and package-root checks
- Added coverage proving sequential requests, bounded concurrency, reuse after exact hits, and immediate revocation after clean absence.

## Live evidence motivating this change

In the automatic-only Testnet baseline, both receivers discover the on-chain VM inventory, but exact recovery repeatedly finds one productive holder while other peers report absence. The existing per-sweep peer de-duplication limits the productive holder to one asset per sweep even though the configured recovery slice is larger. This PR removes that scheduling ceiling without weakening verification or expanding concurrency.
