### PR TITLE
refactor(storage): migrate exact managed mutations

### DIFF
--- a/packages/agent/src/curator-meta-refresh.ts
+++ b/packages/agent/src/curator-meta-refresh.ts
@@ -3,7 +3,6 @@
 import { randomUUID } from 'node:crypto';
 import { multiaddr } from '@multiformats/multiaddr';
 import {
-  assertSafeIri,
   contextGraphDataGraphUri,
   contextGraphMetaGraphUri,
   createOperationContext,
@@ -11,7 +10,7 @@ import {
   type OperationContext,
 } from '@origintrail-official/dkg-core';
 import {
-  tryUpdateWithTouchedGraphs,
+  tryReplaceProjectionFromGraphAtomically,
   type Quad,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
@@ -415,45 +414,6 @@ async function fetchAuthoritativeMetaSnapshot(
   return { checkpointKey: result.checkpointKey, quads: controlMetaQuads };
 }
 
-/**
- * Replace only the curator-replicated portion of a CG's root `_meta` graph.
- * `dkg:revokedAgent` is deliberately retained as a node-local tombstone.
- */
-function replaceCuratorMetaProjectionSparql(
-  contextGraphId: string,
-  metaGraph: string,
-  stagingGraph: string,
-): string {
-  const contextGraphUri = assertSafeIri(contextGraphDataGraphUri(contextGraphId));
-  const delegationPrefix = `did:dkg:agent-delegation:${contextGraphId}:`;
-  assertSafeIri(metaGraph);
-  assertSafeIri(stagingGraph);
-  return `DELETE {
-    GRAPH <${metaGraph}> { ?staleSubject ?stalePredicate ?staleObject . }
-  }
-  INSERT {
-    GRAPH <${metaGraph}> { ?freshSubject ?freshPredicate ?freshObject . }
-  }
-  WHERE {
-    {
-      GRAPH <${metaGraph}> {
-        ?staleSubject ?stalePredicate ?staleObject .
-        FILTER (
-          (
-            ?staleSubject = <${contextGraphUri}> &&
-            ?stalePredicate != <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}>
-          ) ||
-          STRSTARTS(STR(?staleSubject), ${JSON.stringify(delegationPrefix)})
-        )
-      }
-    }
-    UNION
-    {
-      GRAPH <${stagingGraph}> { ?freshSubject ?freshPredicate ?freshObject . }
-    }
-  }`;
-}
-
 async function atomicallyReplaceCuratorMetaSnapshot(
   agent: CuratorMetaRefreshAgent,
   contextGraphId: string,
@@ -488,10 +448,15 @@ async function atomicallyReplaceCuratorMetaSnapshot(
     invalidateTargetProjections();
     let replaced = false;
     try {
-      replaced = await tryUpdateWithTouchedGraphs(
+      replaced = await tryReplaceProjectionFromGraphAtomically(
         agent.store,
-        replaceCuratorMetaProjectionSparql(contextGraphId, metaGraph, stagingGraph),
-        [metaGraph],
+        {
+          targetGraphUri: metaGraph,
+          stagingGraphUri: stagingGraph,
+          targetSubject: contextGraphDataGraphUri(contextGraphId),
+          preservedTargetPredicates: [DKG_ONTOLOGY.DKG_REVOKED_AGENT],
+          targetSubjectPrefixes: [`did:dkg:agent-delegation:${contextGraphId}:`],
+        },
         { source: 'agent.metaRefresh.replace' },
       );
     } finally {

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -110,7 +110,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, TRIPLE_STORE_CAPABILITY_SUPPORT, createTripleStore, isExternalBackend, structuredMutationMightMutate, structuredMutationTouchedGraphs, supportsTripleStoreCapability, type TripleStore, type TripleStoreCapability, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -460,6 +460,9 @@ export function createListContextGraphsCacheInvalidatingStore(
   );
   const wrapper: TripleStore & { readonly innerStore: TripleStore } = {
     innerStore,
+    [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability) {
+      return supportsTripleStoreCapability(innerStore, capability);
+    },
     get queryCancellation() {
       return innerStore.queryCancellation;
     },
@@ -575,6 +578,19 @@ export function createListContextGraphsCacheInvalidatingStore(
             // non-CG graph (e.g. the control-plane graph), so no hot-path churn.
             () => markProjectionDirty?.(undefined, graphUri),
           )
+      : undefined,
+    structuredMutation: innerStore.structuredMutation
+      ? (mutation, options) => {
+          // Capture scope before the first await so caller-side mutation cannot
+          // redirect cache invalidation after the backend has committed.
+          const targetGraphs = [...structuredMutationTouchedGraphs(mutation)];
+          const mightMutate = structuredMutationMightMutate(mutation);
+          return invalidateAfterMutation(
+            () => innerStore.structuredMutation!(mutation, options),
+            () => mightMutate,
+            () => targetGraphs.forEach((graph) => markProjectionDirty?.(undefined, graph)),
+          );
+        }
       : undefined,
     listGraphs(options) {
       return innerStore.listGraphs(options);

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -110,7 +110,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, TRIPLE_STORE_CAPABILITY_SUPPORT, createTripleStore, isExternalBackend, structuredMutationMightMutate, structuredMutationTouchedGraphs, supportsTripleStoreCapability, type TripleStore, type TripleStoreCapability, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, createTripleStore, isExternalBackend, structuredMutationMightMutate, structuredMutationTouchedGraphs, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -460,9 +460,6 @@ export function createListContextGraphsCacheInvalidatingStore(
   );
   const wrapper: TripleStore & { readonly innerStore: TripleStore } = {
     innerStore,
-    [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability) {
-      return supportsTripleStoreCapability(innerStore, capability);
-    },
     get queryCancellation() {
       return innerStore.queryCancellation;
     },

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -95,7 +95,7 @@ import {
   pickNetworkTunables,
   assertRdfLiteralMutf8Safe,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -955,28 +955,12 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     const gm = new GraphManager(this.store);
 
-    const { subGraphDeregistrationSparql } = await import('@origintrail-official/dkg-publisher');
     const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
-    try {
-      const sparql = subGraphDeregistrationSparql(contextGraphId, subGraphName);
-      const updated = await tryUpdateWithTouchedGraphs(
-        this.store,
-        sparql,
-        [metaGraph],
-        {
-          source: 'agent.cg.removeSubGraph.registration',
-        },
-      );
-      if (!updated) {
-        await this.store.query(sparql, {
-          source: 'agent.cg.removeSubGraph.registrationFallback',
-        });
-      }
-    } catch {
-      // SPARQL DELETE WHERE may not be supported — delete quads manually
-      const subGraphUri = `did:dkg:context-graph:${contextGraphId}/${subGraphName}`;
-      await this.store.deleteByPattern({ graph: metaGraph, subject: subGraphUri });
-    }
+    const subGraphUri = `did:dkg:context-graph:${contextGraphId}/${subGraphName}`;
+    await this.store.deleteByPattern(
+      { graph: metaGraph, subject: subGraphUri },
+      { source: 'agent.cg.removeSubGraph.registration' },
+    );
 
     const dataUri = gm.subGraphUri(contextGraphId, subGraphName);
     const metaUri = gm.subGraphMetaUri(contextGraphId, subGraphName);

--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -96,7 +96,7 @@ import {
   OPEN_ENROLLMENT_MAX_APPROVALS_PER_HOUR,
   isBoundedOpenEnrollmentPolicy,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, tryReplaceSubjectAtomically, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -1189,28 +1189,15 @@ export class JoinRequestMethods extends DKGAgentBase {
       predicate: REQUESTER_JOIN_STATE_CURATOR,
       object: `"${escapeSparqlLiteral(curatorPeerId)}"`,
     }] : [])];
-    const curatorInsert = curatorPeerId
-      ? ` ;\n                        <${REQUESTER_JOIN_STATE_CURATOR}> "${escapeSparqlLiteral(curatorPeerId)}"`
-      : '';
     try {
-      const updatedAtomically = await tryUpdateWithTouchedGraphs(
+      const updatedAtomically = await tryReplaceSubjectAtomically(
         this.store,
-        `DELETE {
-          GRAPH <${REQUESTER_JOIN_STATE_GRAPH}> { <${subject}> ?p ?o . }
-        }
-        INSERT {
-          GRAPH <${REQUESTER_JOIN_STATE_GRAPH}> {
-            <${subject}> <${REQUESTER_JOIN_STATE_STATUS}> "${state.status}" ;
-                        <${REQUESTER_JOIN_STATE_GENERATION}> "${state.requestGeneration}"${curatorInsert} .
-          }
-        }
-        WHERE {
-          OPTIONAL { GRAPH <${REQUESTER_JOIN_STATE_GRAPH}> { <${subject}> ?p ?o . } }
-        }`,
-        [REQUESTER_JOIN_STATE_GRAPH],
+        REQUESTER_JOIN_STATE_GRAPH,
+        subject,
+        quads,
       );
       if (!updatedAtomically) {
-        // Compatibility fallback for custom stores without SPARQL UPDATE.
+        // Compatibility fallback for custom stores without atomic subject replacement.
         // Restore the prior row best-effort if the replacement insert fails.
         await this.store.deleteByPattern({ graph: REQUESTER_JOIN_STATE_GRAPH, subject });
         try {

--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -96,7 +96,7 @@ import {
   OPEN_ENROLLMENT_MAX_APPROVALS_PER_HOUR,
   isBoundedOpenEnrollmentPolicy,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, tryReplaceSubjectAtomically, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, supportsReplaceSubjectPredicatesAtomically, tryReplaceSubjectAtomically, tryReplaceSubjectPredicatesAtomically, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -389,13 +389,44 @@ import {
   type ContextGraphJoinAdmissionHost,
   type IncomingJoinRequestDecision,
 } from './context-graph-join-admission.js';
-import { pruneTerminalJoinRequestRecords } from './join-request-retention.js';
+import { tryPruneTerminalJoinRequestRecords } from './join-request-retention.js';
 
 const JOIN_REQUEST_INGRESS_WINDOW_MS = 60_000;
 const JOIN_REQUEST_INGRESS_PER_PEER = 20;
 const JOIN_REQUEST_INGRESS_PER_AGENT = 6;
 const JOIN_REQUEST_INGRESS_PER_CONTEXT_GRAPH = 100;
 const JOIN_REQUEST_INGRESS_MAX_QUEUE_DEPTH = 64;
+const JOIN_REQUEST_STATUS_PREDICATE = 'https://dkg.network/ontology#requestStatus';
+const JOIN_REQUEST_DECISION_TIMESTAMP_PREDICATE = 'https://dkg.network/ontology#decisionTimestamp';
+
+function joinRequestDecisionReplacement(
+  contextGraphId: string,
+  agentAddress: string,
+  status: 'approved' | 'rejected',
+  decidedAt = Date.now(),
+) {
+  const graphUri = contextGraphMetaGraphUri(contextGraphId);
+  const subject = `did:dkg:join-request:${contextGraphId}:${agentAddress.toLowerCase()}`;
+  return {
+    graphUri,
+    subject,
+    predicates: [JOIN_REQUEST_STATUS_PREDICATE, JOIN_REQUEST_DECISION_TIMESTAMP_PREDICATE],
+    replacementQuads: [
+      {
+        subject,
+        predicate: JOIN_REQUEST_STATUS_PREDICATE,
+        object: `"${status}"`,
+        graph: graphUri,
+      },
+      {
+        subject,
+        predicate: JOIN_REQUEST_DECISION_TIMESTAMP_PREDICATE,
+        object: `"${decidedAt}"`,
+        graph: graphUri,
+      },
+    ],
+  };
+}
 
 export interface ContextGraphJoinPolicyStatus {
   contextGraphId: string;
@@ -1957,12 +1988,11 @@ export class JoinRequestMethods extends DKGAgentBase {
       );
     }
 
-    // Every production adapter implements SPARQL UPDATE. Refuse to cross the
-    // membership boundary on a custom adapter that cannot atomically replace
-    // the moderation status.
-    if (typeof this.store.update !== 'function') {
+    // Refuse to cross the membership boundary on a custom adapter that cannot
+    // atomically replace the moderation predicates after the invite commits.
+    if (!supportsReplaceSubjectPredicatesAtomically(this.store)) {
       throw new Error(
-        'Join approval requires atomic SPARQL UPDATE support from the configured triple store.',
+        'Join approval requires atomic subject-predicate replacement support from the configured triple store.',
       );
     }
 
@@ -2009,44 +2039,23 @@ export class JoinRequestMethods extends DKGAgentBase {
 
   /** Complete the moderation side of an approval; safe to repeat after retry. */
   async markJoinRequestApproved(this: DKGAgent, contextGraphId: string, agentAddress: string): Promise<void> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const requestUri = `did:dkg:join-request:${contextGraphId}:${agentAddress.toLowerCase()}`;
-    const requestStatus = 'https://dkg.network/ontology#requestStatus';
-    const decisionTimestamp = 'https://dkg.network/ontology#decisionTimestamp';
-    const decidedAt = Date.now();
-    if (typeof this.store.update !== 'function') {
+    const replaced = await tryReplaceSubjectPredicatesAtomically(
+      this.store,
+      joinRequestDecisionReplacement(contextGraphId, agentAddress, 'approved'),
+      { source: 'join-approval-status' },
+    );
+    if (!replaced) {
       throw new Error(
-        'Join approval requires atomic SPARQL UPDATE support from the configured triple store.',
+        'Join approval requires atomic subject-predicate replacement support from the configured triple store.',
       );
     }
-    // Status and retention ordering must cross the terminal boundary together.
-    await this.store.update(`
-      DELETE { GRAPH <${cgMetaGraph}> {
-        <${requestUri}> <${requestStatus}> ?oldStatus .
-        <${requestUri}> <${decisionTimestamp}> ?oldDecisionTimestamp .
-      } }
-      INSERT { GRAPH <${cgMetaGraph}> {
-        <${requestUri}> <${requestStatus}> "approved" .
-        <${requestUri}> <${decisionTimestamp}> "${decidedAt}" .
-      } }
-      WHERE  {
-        OPTIONAL { GRAPH <${cgMetaGraph}> { <${requestUri}> <${requestStatus}> ?oldStatus . } }
-        OPTIONAL { GRAPH <${cgMetaGraph}> { <${requestUri}> <${decisionTimestamp}> ?oldDecisionTimestamp . } }
-      }
-    `, { touchedGraphs: [cgMetaGraph], source: 'join-approval-status' });
     await this.pruneTerminalJoinRequestHistory(contextGraphId);
   }
 
   /** Keep curator/requester moderation state bounded without risking the decision path. */
   async pruneTerminalJoinRequestHistory(this: DKGAgent, contextGraphId: string): Promise<void> {
     try {
-      const pruned = await pruneTerminalJoinRequestRecords(this.store, contextGraphId);
-      if (pruned > 0) {
-        this.log.info(
-          createOperationContext('system'),
-          `Pruned ${pruned} terminal join-request record(s) for "${contextGraphId}"`,
-        );
-      }
+      await tryPruneTerminalJoinRequestRecords(this.store, contextGraphId);
     } catch (error) {
       // Retention is resource hygiene, not part of the authorization commit.
       // Keep the terminal decision durable and retry pruning on the next one.
@@ -2256,55 +2265,27 @@ export class JoinRequestMethods extends DKGAgentBase {
     agentAddress: string,
     status: 'approved' | 'rejected',
   ): Promise<void> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const requestUri = `did:dkg:join-request:${contextGraphId}:${agentAddress.toLowerCase()}`;
-    const requestStatus = 'https://dkg.network/ontology#requestStatus';
-    const decisionTimestamp = 'https://dkg.network/ontology#decisionTimestamp';
-    const decidedAt = Date.now();
-
-    if (typeof this.store.update === 'function') {
-      await this.store.update(`
-        DELETE { GRAPH <${cgMetaGraph}> {
-          <${requestUri}> <${requestStatus}> ?oldStatus .
-          <${requestUri}> <${decisionTimestamp}> ?oldDecisionTimestamp .
-        } }
-        INSERT { GRAPH <${cgMetaGraph}> {
-          <${requestUri}> <${requestStatus}> "${status}" .
-          <${requestUri}> <${decisionTimestamp}> "${decidedAt}" .
-        } }
-        WHERE  {
-          OPTIONAL { GRAPH <${cgMetaGraph}> { <${requestUri}> <${requestStatus}> ?oldStatus . } }
-          OPTIONAL { GRAPH <${cgMetaGraph}> { <${requestUri}> <${decisionTimestamp}> ?oldDecisionTimestamp . } }
-        }
-      `, { touchedGraphs: [cgMetaGraph], source: `local-join-${status}-status` });
-    } else {
-      // Compatibility fallback for custom stores without SPARQL UPDATE.
+    const replacement = joinRequestDecisionReplacement(contextGraphId, agentAddress, status);
+    const replaced = await tryReplaceSubjectPredicatesAtomically(
+      this.store,
+      replacement,
+      { source: `local-join-${status}-status` },
+    );
+    if (!replaced) {
+      // Compatibility fallback for custom stores without atomic replacement.
       // The curator remains authoritative if a crash lands between these two
       // mutations, and an approval can be redelivered to repair local state.
       await this.store.deleteByPattern({
-        graph: cgMetaGraph,
-        subject: requestUri,
-        predicate: requestStatus,
+        graph: replacement.graphUri,
+        subject: replacement.subject,
+        predicate: JOIN_REQUEST_STATUS_PREDICATE,
       });
       await this.store.deleteByPattern({
-        graph: cgMetaGraph,
-        subject: requestUri,
-        predicate: decisionTimestamp,
+        graph: replacement.graphUri,
+        subject: replacement.subject,
+        predicate: JOIN_REQUEST_DECISION_TIMESTAMP_PREDICATE,
       });
-      await this.store.insert([
-        {
-          subject: requestUri,
-          predicate: requestStatus,
-          object: `"${status}"`,
-          graph: cgMetaGraph,
-        },
-        {
-          subject: requestUri,
-          predicate: decisionTimestamp,
-          object: `"${decidedAt}"`,
-          graph: cgMetaGraph,
-        },
-      ]);
+      await this.store.insert(replacement.replacementQuads);
     }
 
     await this.pruneTerminalJoinRequestHistory(contextGraphId);
@@ -2488,9 +2469,6 @@ export class JoinRequestMethods extends DKGAgentBase {
     // graph curator can …" (403 at the route) for a non-curator.
     await this.assertContextGraphOwner(contextGraphId, callerAgentAddress, 'manage join requests');
 
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const requestUri = `did:dkg:join-request:${contextGraphId}:${agentAddress.toLowerCase()}`;
-    const DKG = 'https://dkg.network/ontology#';
     const delegation = await this.loadPendingJoinDelegation(contextGraphId, agentAddress);
     if (!delegation) {
       throw new Error(`No pending join request found from ${agentAddress}`);
@@ -2506,28 +2484,16 @@ export class JoinRequestMethods extends DKGAgentBase {
     ) {
       throw new Error('Pending join request generation does not match its signed delegation');
     }
-    const requestStatus = `${DKG}requestStatus`;
-    const decisionTimestamp = `${DKG}decisionTimestamp`;
-    const decidedAt = Date.now();
-    if (typeof this.store.update !== 'function') {
+    const replaced = await tryReplaceSubjectPredicatesAtomically(
+      this.store,
+      joinRequestDecisionReplacement(contextGraphId, agentAddress, 'rejected'),
+      { source: 'join-rejected' },
+    );
+    if (!replaced) {
       throw new Error(
-        'Join rejection requires atomic SPARQL UPDATE support from the configured triple store.',
+        'Join rejection requires atomic subject-predicate replacement support from the configured triple store.',
       );
     }
-    await this.store.update(`
-      DELETE { GRAPH <${cgMetaGraph}> {
-        <${requestUri}> <${requestStatus}> ?oldStatus .
-        <${requestUri}> <${decisionTimestamp}> ?oldDecisionTimestamp .
-      } }
-      INSERT { GRAPH <${cgMetaGraph}> {
-        <${requestUri}> <${requestStatus}> "rejected" .
-        <${requestUri}> <${decisionTimestamp}> "${decidedAt}" .
-      } }
-      WHERE  {
-        OPTIONAL { GRAPH <${cgMetaGraph}> { <${requestUri}> <${requestStatus}> ?oldStatus . } }
-        OPTIONAL { GRAPH <${cgMetaGraph}> { <${requestUri}> <${decisionTimestamp}> ?oldDecisionTimestamp . } }
-      }
-    `, { touchedGraphs: [cgMetaGraph], source: 'join-rejected' });
     await this.pruneTerminalJoinRequestHistory(contextGraphId);
     this.upsertContextGraphMember({
       contextGraphId,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -95,7 +95,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, StoreSchedulerBusyError, asChangelogReader, asGraphWriteGenSource, createTripleStore, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type QueryOptions, type Quad, type LargeLiteralStorageConfig, type SelectResult } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, StoreSchedulerBusyError, asChangelogReader, asGraphWriteGenSource, chunkCopySubjectProjectionInput, createTripleStore, supportsCopySubjectProjection, supportsReplaceSubjectPredicatesAtomically, tryCopySubjectProjection, tryReplaceSubjectPredicatesAtomically, type TripleStore, type TripleStoreConfig, type QueryOptions, type Quad, type LargeLiteralStorageConfig, type SelectResult } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -323,6 +323,45 @@ function advanceRsHealCursor(
     if (oldest === undefined) break;
     cursorMap.delete(oldest);
   }
+}
+
+type RsHealCopyInput = Parameters<typeof tryCopySubjectProjection>[1];
+type RsHealPredicateReplacement = Parameters<typeof tryReplaceSubjectPredicatesAtomically>[1];
+
+interface RsHealMaterializationPlan {
+  dataCopy: RsHealCopyInput;
+  metadataCopy: RsHealCopyInput;
+  completionReset: RsHealPredicateReplacement;
+  completionStamp: RsHealPredicateReplacement;
+}
+
+/** Apply one fail-closed RS-heal projection transition after candidate discovery. */
+async function applyRsHealMaterialization(
+  plan: RsHealMaterializationPlan,
+  operations: {
+    canApply: () => boolean;
+    copyProjection: (input: RsHealCopyInput) => Promise<void>;
+    replacePredicates: (input: RsHealPredicateReplacement) => Promise<void>;
+  },
+): Promise<void> {
+  // Preflight the complete plan before crossing the first write boundary. An
+  // individually unrepresentable root must not clear an otherwise valid
+  // completion marker before failing.
+  const dataCopyChunks = chunkCopySubjectProjectionInput(plan.dataCopy);
+
+  // Clear completion before the first data chunk. A crash between chunks then
+  // remains retryable instead of exposing a partial projection as complete.
+  await operations.replacePredicates(plan.completionReset);
+  if (!operations.canApply()) return;
+
+  for (const chunk of dataCopyChunks) {
+    await operations.copyProjection(chunk);
+    if (!operations.canApply()) return;
+  }
+
+  await operations.copyProjection(plan.metadataCopy);
+  if (!operations.canApply()) return;
+  await operations.replacePredicates(plan.completionStamp);
 }
 
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
@@ -3303,7 +3342,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
    * the prover can find it, while leaving the label-graph view intact.
    *
    * CONTENT-BINDING RULE: the data/meta copies go through
-   * `this.store.update(INSERT…WHERE)` so the terms NEVER leave the store. A
+   * structured server-side copy so the terms NEVER leave the store. A
    * `query()`/CONSTRUCT → `insert(quads)` round-trip would double backslashes
    * in escape-bearing literals and change the leaf bytes the on-chain
    * `challengeRoot` was committed over, making the proof permanently
@@ -3330,25 +3369,34 @@ export class SwmHostModeMethods extends DKGAgentBase {
       if (!canApply() || !capturedOnChainId) {
         return { status: 'skipped', reason: 'not-current' };
       }
-      // Server-side byte-safe copy is the ONLY safe relocation mechanism; if the
-      // backend can't do SPARQL UPDATE we bail rather than risk a lossy JS round-trip.
-      if (typeof this.store.update !== 'function') {
+      if (
+        !supportsCopySubjectProjection(this.store)
+        || !supportsReplaceSubjectPredicatesAtomically(this.store)
+      ) {
         return { status: 'skipped', reason: 'unsupported-store' };
       }
-      // #1549: every server-side INSERT in this RS-heal path has a statically-known
-      // target graph, so `touchedGraphs` is REQUIRED — the index then maintains
-      // itself incrementally (a bounded `hasGraph`) instead of marking the whole
-      // index dirty and forcing a full store scan on the next enumeration. Requiring
-      // it (not optional) closes the escape hatch: a future `update(sparql)` here that
-      // forgot to declare its graph would silently fall back to dirtying the index.
-      const update = async (sparql: string, touchedGraphs: readonly string[]): Promise<void> => {
-        const updated = await tryUpdateWithTouchedGraphs(
+      // Server-side byte-safe copy is the ONLY safe relocation mechanism. The
+      // structured capabilities keep RDF terms inside the store while making
+      // source/target graph ownership and mutation scope explicit to decorators.
+      const copyProjection = async (
+        input: Parameters<typeof tryCopySubjectProjection>[1],
+      ): Promise<void> => {
+        const copied = await tryCopySubjectProjection(
           this.store,
-          sparql,
-          touchedGraphs,
-          rsHealStoreOptions('materialize', signal),
+          input,
+          rsHealStoreOptions('materialize.copy', signal),
         );
-        if (!updated) throw new Error('RS heal requires server-side update() support');
+        if (!copied) throw new Error('RS heal requires server-side subject projection copy support');
+      };
+      const replacePredicates = async (
+        input: Parameters<typeof tryReplaceSubjectPredicatesAtomically>[1],
+      ): Promise<void> => {
+        const replaced = await tryReplaceSubjectPredicatesAtomically(
+          this.store,
+          input,
+          rsHealStoreOptions('materialize.marker', signal),
+        );
+        if (!replaced) throw new Error('RS heal requires atomic subject-predicate replacement support');
       };
 
       const DKG = 'http://dkg.io/ontology/';
@@ -3514,69 +3562,49 @@ export class SwmHostModeMethods extends DKGAgentBase {
               if (!canApply() || present.type !== 'boolean' || !present.value) return;
             }
 
-            // DATA copy (per root) — MANDATORY server-side, byte-safe, read-both
+            // DATA copy — MANDATORY server-side, byte-safe, read-both
             // (legacy root data UNION per-KA VM graph). Skip the post-publish
             // trustLevel stamps in BOTH branches so the recomputed leaf set stays
-            // bit-identical with the on-chain merkleLeafCount.
-            for (const root of roots) {
-              if (!canApply()) return;
-              await update(
-                `INSERT { GRAPH <${scopedData}> { ?s ?p ?o } } WHERE {
-                   {
-                     GRAPH <${rootData}> {
-                       ?s ?p ?o .
-                       FILTER(?s = <${root}> || STRSTARTS(STR(?s), "${root}/.well-known/genid/"))
-                       FILTER(?p != <${TRUST_LEVEL_PREDICATE}> && ?p != <${LEGACY_TRUST_LEVEL_PREDICATE}>)
-                     }
-                   } UNION {
-                     GRAPH <${vmGraph}> {
-                       ?s ?p ?o .
-                       FILTER(?s = <${root}> || STRSTARTS(STR(?s), "${root}/.well-known/genid/"))
-                       FILTER(?p != <${TRUST_LEVEL_PREDICATE}> && ?p != <${LEGACY_TRUST_LEVEL_PREDICATE}>)
-                     }
-                   }
-                 }`,
-                [scopedData],
-              );
-              if (!canApply()) return;
-            }
-
-            // `update()` is not an atomic transaction on every supported HTTP
-            // store. Remove the completion marker first, copy metadata without
-            // that marker, and stamp completion only after the copy succeeds.
-            // Any partial copy therefore remains visible to the next heal.
-            if (!canApply()) return;
-            await update(
-              `DELETE WHERE {
-                 GRAPH <${scopedMeta}> {
-                   <${ual}> <${DKG}materializedVersion> ?oldVersion
-                 }
-               }`,
-              [scopedMeta],
-            );
-            if (!canApply()) return;
-            await update(
-              `INSERT {
-                 GRAPH <${scopedMeta}> { ?s ?p ?o }
-               }
-               WHERE {
-                 GRAPH <${legacyMeta}> {
-                   ?s ?p ?o .
-                   FILTER(?s = <${ual}> || STRSTARTS(STR(?s), "${ual}/"))
-                   FILTER(?p != <${DKG}materializedVersion>)
-                 }
-               }`,
-              [scopedMeta],
-            );
-            if (!canApply()) return;
-            await update(
-              `INSERT DATA {
-                 GRAPH <${scopedMeta}> {
-                   <${ual}> <${DKG}materializedVersion> "${version.blockNumber}:${version.txIndex}"
-                 }
-               }`,
-              [scopedMeta],
-            );
+            // bit-identical with the on-chain merkleLeafCount. Root order is
+            // preserved while large multi-root KCs are split below both 4 MiB
+            // structured-mutation limits.
+            await applyRsHealMaterialization({
+              dataCopy: {
+                sourceGraphUris: [rootData, vmGraph],
+                targetGraphUri: scopedData,
+                roots,
+                descendantSuffix: '/.well-known/genid/',
+                excludedPredicates: [TRUST_LEVEL_PREDICATE, LEGACY_TRUST_LEVEL_PREDICATE],
+              },
+              metadataCopy: {
+                sourceGraphUris: [legacyMeta],
+                targetGraphUri: scopedMeta,
+                roots: [ual],
+                descendantSuffix: '/',
+                excludedPredicates: [`${DKG}materializedVersion`],
+              },
+              completionReset: {
+                graphUri: scopedMeta,
+                subject: ual,
+                predicates: [`${DKG}materializedVersion`],
+                replacementQuads: [],
+              },
+              completionStamp: {
+                graphUri: scopedMeta,
+                subject: ual,
+                predicates: [`${DKG}materializedVersion`],
+                replacementQuads: [{
+                  subject: ual,
+                  predicate: `${DKG}materializedVersion`,
+                  object: `"${version.blockNumber}:${version.txIndex}"`,
+                  graph: scopedMeta,
+                }],
+              },
+            }, {
+              canApply,
+              copyProjection,
+              replacePredicates,
+            });
 
             if (canApply()) {
               this.log.info(

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -351,14 +351,15 @@ async function applyRsHealMaterialization(
 
   // Clear completion before the first data chunk. A crash between chunks then
   // remains retryable instead of exposing a partial projection as complete.
-  await operations.replacePredicates(plan.completionReset);
   if (!operations.canApply()) return;
+  await operations.replacePredicates(plan.completionReset);
 
   for (const chunk of dataCopyChunks) {
-    await operations.copyProjection(chunk);
     if (!operations.canApply()) return;
+    await operations.copyProjection(chunk);
   }
 
+  if (!operations.canApply()) return;
   await operations.copyProjection(plan.metadataCopy);
   if (!operations.canApply()) return;
   await operations.replacePredicates(plan.completionStamp);

--- a/packages/agent/src/join-request-retention.ts
+++ b/packages/agent/src/join-request-retention.ts
@@ -3,12 +3,24 @@ import {
   contextGraphMetaGraphUri,
   sparqlString,
 } from '@origintrail-official/dkg-core';
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  BOUNDED_MUTATION_MAX_PRUNE_DELETE,
+  tryPruneRankedSubjects,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 
 const JOIN_REQUEST_SUBJECT_PREFIX = 'did:dkg:join-request:';
 const REQUEST_STATUS = 'https://dkg.network/ontology#requestStatus';
 const REQUEST_TIMESTAMP = 'https://dkg.network/ontology#requestTimestamp';
 const DECISION_TIMESTAMP = 'https://dkg.network/ontology#decisionTimestamp';
+
+const TERMINAL_JOIN_REQUEST_RETENTION_POLICY = {
+  subjectPrefix: JOIN_REQUEST_SUBJECT_PREFIX,
+  eligibilityPredicate: REQUEST_STATUS,
+  eligibleObjects: ['approved', 'rejected'] as const,
+  primaryRankPredicate: DECISION_TIMESTAMP,
+  secondaryRankPredicate: REQUEST_TIMESTAMP,
+};
 
 /**
  * Terminal moderation resources are useful for curator diagnostics, but unlike
@@ -25,13 +37,19 @@ function bindingInteger(value: string | undefined): number {
 }
 
 function terminalJoinRequestWhere(metaGraph: string): string {
+  const policy = TERMINAL_JOIN_REQUEST_RETENTION_POLICY;
+  const eligibleStatuses = policy.eligibleObjects.map(sparqlString);
   return `
     GRAPH <${assertSafeIri(metaGraph)}> {
-      ?request <${REQUEST_STATUS}> ?status .
-      OPTIONAL { ?request <${REQUEST_TIMESTAMP}> ?requestTimestamp }
-      OPTIONAL { ?request <${DECISION_TIMESTAMP}> ?decisionTimestamp }
-      VALUES ?status { "approved" "rejected" }
-      FILTER(STRSTARTS(STR(?request), ${sparqlString(JOIN_REQUEST_SUBJECT_PREFIX)}))
+      ?request <${policy.eligibilityPredicate}> ?status .
+      OPTIONAL { ?request <${policy.secondaryRankPredicate}> ?requestTimestamp }
+      OPTIONAL { ?request <${policy.primaryRankPredicate}> ?decisionTimestamp }
+      VALUES ?status { ${eligibleStatuses.join(' ')} }
+      FILTER NOT EXISTS {
+        ?request <${policy.eligibilityPredicate}> ?nonTerminalStatus .
+        FILTER(?nonTerminalStatus NOT IN (${eligibleStatuses.join(', ')}))
+      }
+      FILTER(STRSTARTS(STR(?request), ${sparqlString(policy.subjectPrefix)}))
     }
   `;
 }
@@ -40,14 +58,16 @@ function terminalJoinRequestWhere(metaGraph: string): string {
  * Delete terminal join-request subjects beyond the newest `maxRecords`.
  *
  * Pending requests are never candidates. Production stores prune wholly in a
- * server-side SPARQL update; the compatibility fallback materializes only the
- * overflow subject IDs, never their full moderation payloads.
+ * server-side atomic operation that rechecks terminal state at commit time.
+ * Legacy stores without that capability skip this resource-hygiene pass: a
+ * select-then-delete fallback could erase a subject concurrently reused as a
+ * pending request.
  */
-export async function pruneTerminalJoinRequestRecords(
+export async function tryPruneTerminalJoinRequestRecords(
   store: TripleStore,
   contextGraphId: string,
   maxRecords = MAX_TERMINAL_JOIN_REQUEST_RECORDS_PER_CONTEXT_GRAPH,
-): Promise<number> {
+): Promise<void> {
   const cap = Math.max(0, Math.floor(maxRecords));
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const countResult = await store.query(`
@@ -59,53 +79,30 @@ export async function pruneTerminalJoinRequestRecords(
     ? bindingInteger(countResult.bindings[0]?.['count'])
     : 0;
   const overflow = Math.max(0, total - cap);
-  if (overflow === 0) return 0;
+  if (overflow === 0) return;
 
-  const overflowSelection = `
-    SELECT ?request
-           (MAX(?decisionTimestamp) AS ?latestDecisionTimestamp)
-           (MAX(?requestTimestamp) AS ?latestRequestTimestamp)
-    WHERE {
-      ${terminalJoinRequestWhere(metaGraph)}
-    }
-    GROUP BY ?request
-    ORDER BY DESC(COALESCE(
-      xsd:integer(STR(?latestDecisionTimestamp)),
-      xsd:integer(STR(?latestRequestTimestamp)),
-      0
-    )) DESC(STR(?request))
-    OFFSET ${cap}
-  `;
-
-  if (typeof store.update === 'function') {
-    await store.update(`
-      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-      DELETE { GRAPH <${assertSafeIri(metaGraph)}> { ?request ?predicate ?object } }
-      WHERE {
-        { ${overflowSelection} }
-        GRAPH <${assertSafeIri(metaGraph)}> { ?request ?predicate ?object }
-      }
-    `, {
-      touchedGraphs: [metaGraph],
-      priority: 'background',
-      source: 'join.moderationRetention.prune',
-    });
-    return overflow;
-  }
-
-  const result = await store.query(`
-    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-    ${overflowSelection}
-  `, { priority: 'background', source: 'join.moderationRetention.selectOverflow' });
-  if (result.type !== 'bindings') return 0;
-  const subjects = result.bindings
-    .map((row) => row['request'])
-    .filter((subject): subject is string => Boolean(subject));
-  for (const subject of subjects) {
-    await store.deleteByPattern(
-      { graph: metaGraph, subject },
-      { priority: 'background', source: 'join.moderationRetention.pruneFallback' },
+  // Drain the pre-counted overflow in independently scheduled batches. Each
+  // mutation rechecks terminal eligibility atomically, and releasing the store
+  // scheduler between batches prevents a large historical backlog from holding
+  // one unbounded mutation permit.
+  let remainingOverflow = overflow;
+  while (remainingOverflow > 0) {
+    const policy = TERMINAL_JOIN_REQUEST_RETENTION_POLICY;
+    const batchSize = Math.min(
+      remainingOverflow,
+      BOUNDED_MUTATION_MAX_PRUNE_DELETE,
     );
+    const supported = await tryPruneRankedSubjects(store, {
+      graphUri: metaGraph,
+      subjectPrefix: policy.subjectPrefix,
+      eligibilityPredicate: policy.eligibilityPredicate,
+      eligibleObjects: [...policy.eligibleObjects],
+      primaryRankPredicate: policy.primaryRankPredicate,
+      secondaryRankPredicate: policy.secondaryRankPredicate,
+      retainNewest: cap,
+      maxDelete: batchSize,
+    }, { priority: 'background', source: 'join.moderationRetention.prune' });
+    if (!supported) return;
+    remainingOverflow -= batchSize;
   }
-  return subjects.length;
 }

--- a/packages/agent/test/cg-resolve-refresh.test.ts
+++ b/packages/agent/test/cg-resolve-refresh.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { DKG_ONTOLOGY, contextGraphDataGraphUri, contextGraphMetaGraphUri, type OperationContext } from '@origintrail-official/dkg-core';
-import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  OxigraphStore,
+  type Quad,
+  type ReplaceProjectionFromGraphInput,
+  type StructuredMutation,
+} from '@origintrail-official/dkg-storage';
 import { ContextGraphResolveMethods } from '../src/dkg-agent-cg-resolve.js';
 import { SYNC_TOTAL_TIMEOUT_MS } from '../src/dkg-agent-constants.js';
 import {
@@ -15,6 +20,17 @@ const CURATOR_PEER_ID = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
 const RELAY_ADDR = '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
 
 function noop(): void {}
+
+function projectionMutation(
+  apply: (input: ReplaceProjectionFromGraphInput) => void | Promise<void>,
+): (mutation: StructuredMutation) => Promise<void> {
+  return async (mutation) => {
+    if (mutation.kind !== 'replace-projection-from-graph') {
+      throw new Error(`Unexpected structured mutation: ${mutation.kind}`);
+    }
+    await apply(mutation.input);
+  };
+}
 
 function operationContext(): OperationContext {
   return { kind: 'sync', id: 'cg-refresh-test', startedAt: Date.now() } as never;
@@ -371,7 +387,7 @@ describe('refreshMetaFromCurator', () => {
       }),
       store: {
         insert: async (quads: Quad[]) => { staged = quads; },
-        update: async () => undefined,
+        structuredMutation: projectionMutation(noop),
         dropGraph: async () => undefined,
       },
       oversizeTombstoneLog: { record: noop },
@@ -389,6 +405,61 @@ describe('refreshMetaFromCurator', () => {
 
     expect(refreshed).toBe(true);
     expect(staged).toHaveLength(2);
+  });
+
+  it('preserves curator projection replacement through an update-only store', async () => {
+    const contextGraphId = 'public/update-only-curator-snapshot';
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+    const snapshot: Quad[] = [{
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: metaGraph,
+    }, {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      object: '"public"',
+      graph: metaGraph,
+    }];
+    const update = vi.fn(async () => undefined);
+    const agent = {
+      metaRefreshTimestamps: new Map<string, number>(),
+      peerId: 'local-peer',
+      node: {
+        libp2p: {
+          getConnections: () => [{ remotePeer: { toString: () => CURATOR_PEER_ID } }],
+        },
+      },
+      discovery: {},
+      fetchSyncPages: async () => ({
+        quads: snapshot,
+        checkpointKey: 'update-only-authoritative-snapshot',
+        resumedFromOffset: 0,
+        completed: true,
+      }),
+      store: {
+        insert: async () => undefined,
+        update,
+        dropGraph: async () => undefined,
+      },
+      oversizeTombstoneLog: { record: noop },
+      invalidateListContextGraphsCache: noop,
+      contextGraphMetaProjection: { markDirty: noop },
+      syncCheckpoints: new Map<string, number>(),
+      log: { warn: noop, info: noop },
+    };
+
+    await expect(ContextGraphResolveMethods.prototype.refreshMetaFromCurator.call(
+      agent as never,
+      contextGraphId,
+      { trustedCuratorPeerId: CURATOR_PEER_ID, force: true },
+    )).resolves.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledWith(
+      expect.stringContaining(`GRAPH <${metaGraph}>`),
+      expect.objectContaining({ touchedGraphs: [metaGraph] }),
+    );
   });
 
   it('rejects a public-only snapshot when private member proof was required', async () => {
@@ -424,7 +495,7 @@ describe('refreshMetaFromCurator', () => {
       }),
       store: {
         insert: async () => { targetMutated = true; },
-        update: async () => { targetMutated = true; },
+        structuredMutation: projectionMutation(() => { targetMutated = true; }),
         dropGraph: async () => { targetMutated = true; },
       },
       oversizeTombstoneLog: { record: noop },
@@ -488,7 +559,7 @@ describe('refreshMetaFromCurator', () => {
     let fetchDeadline: number | undefined;
     let forceFreshSession: boolean | undefined;
     let staged: Quad[] = [];
-    let replacementUpdate = '';
+    let replacementInput: ReplaceProjectionFromGraphInput | undefined;
     const agent = {
       // A recent auth-driven refresh would suppress a normal call.
       metaRefreshTimestamps: new Map([[contextGraphId, Date.now()]]),
@@ -517,7 +588,9 @@ describe('refreshMetaFromCurator', () => {
       },
       store: {
         insert: async (quads: Quad[]) => { staged = quads; },
-        update: async (sparql: string) => { replacementUpdate = sparql; },
+        structuredMutation: projectionMutation((input) => {
+          replacementInput = input;
+        }),
         dropGraph: async () => undefined,
       },
       oversizeTombstoneLog: { record: noop },
@@ -551,8 +624,13 @@ describe('refreshMetaFromCurator', () => {
       object: inserted[0].object,
     });
     expect(staged[0].graph).toMatch(/^urn:dkg:curator-meta-refresh:/);
-    expect(replacementUpdate).toContain(`GRAPH <${metaGraph}>`);
-    expect(replacementUpdate).not.toContain(inserted[4].graph);
+    expect(replacementInput).toMatchObject({
+      targetGraphUri: metaGraph,
+      targetSubject: contextGraphDataGraphUri(contextGraphId),
+      preservedTargetPredicates: [DKG_ONTOLOGY.DKG_REVOKED_AGENT],
+      targetSubjectPrefixes: [`did:dkg:agent-delegation:${contextGraphId}:`],
+    });
+    expect(replacementInput?.stagingGraphUri).not.toBe(inserted[4].graph);
     expect(agent.syncCheckpoints.has('trusted-meta-checkpoint')).toBe(false);
   });
 
@@ -678,7 +756,7 @@ describe('refreshMetaFromCurator', () => {
         insert: async (quads: Quad[]) => {
           storedSnapshots.push(quads.map((quad) => ({ ...quad, graph: metaGraph })));
         },
-        update: async () => undefined,
+        structuredMutation: projectionMutation(noop),
         dropGraph: async () => undefined,
       },
       oversizeTombstoneLog: { record: noop },
@@ -739,7 +817,7 @@ describe('refreshMetaFromCurator', () => {
       }),
       store: {
         insert: async () => { targetMutated = true; },
-        update: async () => { targetMutated = true; },
+        structuredMutation: projectionMutation(() => { targetMutated = true; }),
         dropGraph: async () => { targetMutated = true; },
       },
       syncCheckpoints: new Map<string, number>(),
@@ -792,7 +870,7 @@ describe('refreshMetaFromCurator', () => {
       }),
       store: {
         insert: async () => undefined,
-        update: async () => { targetUpdates += 1; },
+        structuredMutation: projectionMutation(() => { targetUpdates += 1; }),
         dropGraph: async () => undefined,
       },
       oversizeTombstoneLog: {
@@ -970,12 +1048,12 @@ describe('refreshMetaFromCurator', () => {
       }),
       store: {
         insert: async () => undefined,
-        update: async () => {
-          // Model ChangelogStore.update: inner SPARQL committed, then the
+        structuredMutation: projectionMutation(() => {
+          // Model ChangelogStore: inner projection committed, then the
           // post-mutation marker append failed and surfaced an exception.
           targetCommitted = true;
           throw new Error('post-mutation marker append failed');
-        },
+        }),
         dropGraph: async () => {
           signalCleanupStarted();
           await cleanupGate;
@@ -1041,7 +1119,7 @@ describe('refreshMetaFromCurator', () => {
       },
       store: {
         insert: async () => undefined,
-        update: async () => { replacements += 1; },
+        structuredMutation: projectionMutation(() => { replacements += 1; }),
         dropGraph: async () => undefined,
       },
       oversizeTombstoneLog: { record: noop },
@@ -1115,7 +1193,7 @@ describe('refreshMetaFromCurator', () => {
       },
       store: {
         insert: async () => undefined,
-        update: async () => { replacements += 1; },
+        structuredMutation: projectionMutation(() => { replacements += 1; }),
         dropGraph: async () => undefined,
       },
       oversizeTombstoneLog: { record: noop },

--- a/packages/agent/test/context-graph-join-policy.test.ts
+++ b/packages/agent/test/context-graph-join-policy.test.ts
@@ -3,6 +3,11 @@ import { ethers } from 'ethers';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGEvent, PROTOCOL_JOIN_REQUEST } from '@origintrail-official/dkg-core';
 import {
+  GraphSetIndexStore,
+  TRIPLE_STORE_CAPABILITY_SUPPORT,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
   DKGAgent,
   signAgentDelegation,
   type ContextGraphJoinPolicyAuditEvent,
@@ -11,6 +16,7 @@ import {
 } from '../src/index.js';
 import { joinDelegationScope } from '../src/dkg-agent-helpers.js';
 import { ContextGraphJoinAdmissionLockManager } from '../src/context-graph-join-admission-lock.js';
+import { createListContextGraphsCacheInvalidatingStore } from '../src/dkg-agent-base.js';
 import { Messenger } from '../src/p2p/messenger.js';
 
 type JoinRequestHandler = (data: Uint8Array, peerId: string) => Promise<Uint8Array>;
@@ -287,9 +293,15 @@ describe('context graph open enrollment policy', () => {
     const store = (agent as any).store;
     const insertSpy = vi.spyOn(store, 'insert');
     const deleteSpy = vi.spyOn(store, 'deleteByPattern');
+    const structuredMutationSpy = vi.spyOn(store, 'structuredMutation');
     insertSpy.mockClear();
     deleteSpy.mockClear();
-    const mutationCounts = () => [insertSpy.mock.calls.length, deleteSpy.mock.calls.length];
+    structuredMutationSpy.mockClear();
+    const mutationCounts = () => [
+      insertSpy.mock.calls.length,
+      deleteSpy.mock.calls.length,
+      structuredMutationSpy.mock.calls.length,
+    ];
     const expectRejectedBeforeMutation = async (operation: () => Promise<unknown>) => {
       const before = mutationCounts();
       await expect(operation()).rejects.toThrow(/live admission-lock token/i);
@@ -688,6 +700,133 @@ describe('context graph open enrollment policy', () => {
     }
   }, 30_000);
 
+  it('approves through the structured predicate capability without raw update()', async () => {
+    const { agent, owner } = await boot();
+    const contextGraphId = 'private-policy-no-raw-update';
+    await createPrivateCg(agent, contextGraphId, owner.agentAddress);
+    await agent.setContextGraphJoinPolicy(contextGraphId, {
+      mode: 'open',
+      maxMembers: 10,
+      maxApprovalsPerHour: 5,
+      acknowledgeOpenEnrollment: true,
+    }, owner.agentAddress);
+    const joiner = await agent.registerAgent('no-raw-update-joiner', { framework: 'test' });
+    const delegation = await agent.signJoinRequest(contextGraphId, joiner.agentAddress);
+    const store = (agent as any).store as { update?: unknown };
+    const originalUpdate = store.update;
+    store.update = undefined;
+    try {
+      await expect(agent.processIncomingJoinRequest(
+        contextGraphId,
+        delegation,
+        joiner.name,
+        agent.peerId,
+      )).resolves.toMatchObject({ status: 'approved', autoApproved: true });
+      expect(await agent.getJoinRequestStatus(contextGraphId, joiner.agentAddress))
+        .toBe('approved');
+    } finally {
+      store.update = originalUpdate;
+    }
+  }, 30_000);
+
+  it('preserves approval through an update-only store wrapped by a decorator', async () => {
+    const { agent, owner } = await boot();
+    const contextGraphId = 'private-policy-decorated-update-only';
+    await createPrivateCg(agent, contextGraphId, owner.agentAddress);
+    const joiner = await agent.registerAgent('decorated-update-only-joiner', { framework: 'test' });
+    const delegation = await agent.signJoinRequest(contextGraphId, joiner.agentAddress);
+    const rejectedJoiner = await agent.registerAgent(
+      'decorated-update-only-rejected-joiner',
+      { framework: 'test' },
+    );
+    const rejectedDelegation = await agent.signJoinRequest(
+      contextGraphId,
+      rejectedJoiner.agentAddress,
+    );
+    await expect(agent.processIncomingJoinRequest(
+      contextGraphId,
+      delegation,
+      joiner.name,
+      agent.peerId,
+    )).resolves.toMatchObject({ status: 'pending' });
+    await expect(agent.processIncomingJoinRequest(
+      contextGraphId,
+      rejectedDelegation,
+      rejectedJoiner.name,
+      agent.peerId,
+    )).resolves.toMatchObject({ status: 'pending' });
+
+    const originalStore = (agent as any).store as TripleStore;
+    const updateOnlyStore = new Proxy(originalStore, {
+      get(target, property, receiver) {
+        if (property === TRIPLE_STORE_CAPABILITY_SUPPORT) return undefined;
+        if (property === 'structuredMutation') return undefined;
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    (agent as any).store = createListContextGraphsCacheInvalidatingStore(
+      new GraphSetIndexStore(updateOnlyStore, { enabled: false }),
+      () => undefined,
+    );
+
+    await expect(agent.approveJoinRequest(
+      contextGraphId,
+      joiner.agentAddress,
+      owner.agentAddress,
+    )).resolves.toBeUndefined();
+    expect(await agent.getJoinRequestStatus(contextGraphId, joiner.agentAddress)).toBe('approved');
+    expect((await agent.getContextGraphAllowedAgents(contextGraphId)).map((address) => address.toLowerCase()))
+      .toContain(joiner.agentAddress.toLowerCase());
+
+    await expect(agent.rejectJoinRequest(
+      contextGraphId,
+      rejectedJoiner.agentAddress,
+      owner.agentAddress,
+    )).resolves.toBeUndefined();
+    expect(await agent.getJoinRequestStatus(contextGraphId, rejectedJoiner.agentAddress))
+      .toBe('rejected');
+    expect((await agent.getContextGraphAllowedAgents(contextGraphId)).map((address) => address.toLowerCase()))
+      .not.toContain(rejectedJoiner.agentAddress.toLowerCase());
+  }, 30_000);
+
+  it('refuses approval before membership commit when a decorator wraps an incapable store', async () => {
+    const { agent, owner } = await boot();
+    const contextGraphId = 'private-policy-decorated-missing-structured-mutation';
+    await createPrivateCg(agent, contextGraphId, owner.agentAddress);
+    const joiner = await agent.registerAgent('decorated-incapable-joiner', { framework: 'test' });
+    const delegation = await agent.signJoinRequest(contextGraphId, joiner.agentAddress);
+    await expect(agent.processIncomingJoinRequest(
+      contextGraphId,
+      delegation,
+      joiner.name,
+      agent.peerId,
+    )).resolves.toMatchObject({ status: 'pending' });
+
+    const originalStore = (agent as any).store as TripleStore;
+    const legacyStore = new Proxy(originalStore, {
+      get(target, property, receiver) {
+        if (property === TRIPLE_STORE_CAPABILITY_SUPPORT) return undefined;
+        if (property === 'structuredMutation' || property === 'update') return undefined;
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    (agent as any).store = createListContextGraphsCacheInvalidatingStore(
+      new GraphSetIndexStore(legacyStore, { enabled: false }),
+      () => undefined,
+    );
+
+    await expect(agent.approveJoinRequest(
+      contextGraphId,
+      joiner.agentAddress,
+      owner.agentAddress,
+    )).rejects.toThrow(/requires atomic subject-predicate replacement support/i);
+    expect(await agent.getJoinRequestStatus(contextGraphId, joiner.agentAddress)).toBe('pending');
+    expect((await agent.getContextGraphAllowedAgents(contextGraphId)).map((address) => address.toLowerCase()))
+      .not.toContain(joiner.agentAddress.toLowerCase());
+  }, 30_000);
+
   it('repairs an interrupted approved-status write on a signed member retry', async () => {
     const { agent, owner, policyStore } = await boot();
     const contextGraphId = 'private-policy-status-repair';
@@ -700,11 +839,13 @@ describe('context graph open enrollment policy', () => {
     }, owner.agentAddress);
     const joiner = await agent.registerAgent('status-repair-joiner', { framework: 'test' });
     const delegation = await agent.signJoinRequest(contextGraphId, joiner.agentAddress);
-    const store = (agent as any).store as { update: (sparql: string, options?: unknown) => Promise<void> };
-    const originalUpdate = store.update.bind(store);
-    vi.spyOn(store, 'update')
+    const store = (agent as any).store as {
+      structuredMutation: (mutation: unknown, options?: unknown) => Promise<void>;
+    };
+    const originalReplace = store.structuredMutation.bind(store);
+    vi.spyOn(store, 'structuredMutation')
       .mockRejectedValueOnce(new Error('simulated atomic status update failure'))
-      .mockImplementation(originalUpdate);
+      .mockImplementation(originalReplace);
 
     // Make the initial admission consume the final verified-agent ingress slot.
     // The exact signed repair retry must bypass that just-consumed slot, while

--- a/packages/agent/test/context-graph-join-policy.test.ts
+++ b/packages/agent/test/context-graph-join-policy.test.ts
@@ -759,7 +759,9 @@ describe('context graph open enrollment policy', () => {
     const originalStore = (agent as any).store as TripleStore;
     const updateOnlyStore = new Proxy(originalStore, {
       get(target, property, receiver) {
-        if (property === TRIPLE_STORE_CAPABILITY_SUPPORT) return undefined;
+        if (property === TRIPLE_STORE_CAPABILITY_SUPPORT) {
+          return (capability: string) => capability === 'update';
+        }
         if (property === 'structuredMutation') return undefined;
         const value = Reflect.get(target, property, receiver) as unknown;
         return typeof value === 'function' ? value.bind(target) : value;
@@ -806,7 +808,7 @@ describe('context graph open enrollment policy', () => {
     const originalStore = (agent as any).store as TripleStore;
     const legacyStore = new Proxy(originalStore, {
       get(target, property, receiver) {
-        if (property === TRIPLE_STORE_CAPABILITY_SUPPORT) return undefined;
+        if (property === TRIPLE_STORE_CAPABILITY_SUPPORT) return () => false;
         if (property === 'structuredMutation' || property === 'update') return undefined;
         const value = Reflect.get(target, property, receiver) as unknown;
         return typeof value === 'function' ? value.bind(target) : value;

--- a/packages/agent/test/join-request-retention.test.ts
+++ b/packages/agent/test/join-request-retention.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
-import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import { pruneTerminalJoinRequestRecords } from '../src/join-request-retention.js';
+import {
+  BOUNDED_MUTATION_MAX_PRUNE_DELETE,
+  OxigraphStore,
+  type Quad,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import { tryPruneTerminalJoinRequestRecords } from '../src/join-request-retention.js';
 
 const CG = 'moderation-retention';
 const META = contextGraphMetaGraphUri(CG);
@@ -46,7 +51,7 @@ describe('terminal join-request retention', () => {
       ...requestQuads(6, 'pending'),
     ]);
 
-    await expect(pruneTerminalJoinRequestRecords(store, CG, 2)).resolves.toBe(3);
+    await expect(tryPruneTerminalJoinRequestRecords(store, CG, 2)).resolves.toBeUndefined();
 
     const result = await store.query(`
       SELECT ?request ?status WHERE {
@@ -77,7 +82,7 @@ describe('terminal join-request retention', () => {
       ...requestQuads(3, 'approved', { requestTimestamp: null, decisionTimestamp: 950 }),
     ]);
 
-    await expect(pruneTerminalJoinRequestRecords(store, CG, 2)).resolves.toBe(1);
+    await expect(tryPruneTerminalJoinRequestRecords(store, CG, 2)).resolves.toBeUndefined();
 
     const result = await store.query(`
       SELECT ?request WHERE {
@@ -93,4 +98,47 @@ describe('terminal join-request retention', () => {
     ]);
     await store.close();
   });
+
+  it('skips pruning when the store cannot atomically recheck terminal state', async () => {
+    const store = new OxigraphStore();
+    await store.insert([
+      ...requestQuads(1, 'approved'),
+      ...requestQuads(2, 'rejected'),
+    ]);
+    const legacyStore = {
+      query: store.query.bind(store),
+    } as unknown as TripleStore;
+
+    await expect(tryPruneTerminalJoinRequestRecords(legacyStore, CG, 1)).resolves.toBeUndefined();
+    expect((await rowsForStatus(store)).map((row) => row.request)).toHaveLength(2);
+    await store.close();
+  });
+
+  it('drains overflow larger than one bounded mutation batch', async () => {
+    const store = new OxigraphStore();
+    const terminalRecords = BOUNDED_MUTATION_MAX_PRUNE_DELETE + 5;
+    await store.insert(Array.from({ length: terminalRecords }, (_, index) => ({
+      graph: META,
+      subject: `did:dkg:join-request:${CG}:0x${(index + 1).toString(16).padStart(40, '0')}`,
+      predicate: STATUS,
+      object: '"approved"',
+    })));
+    const mutationSpy = vi.spyOn(store, 'structuredMutation');
+
+    await expect(tryPruneTerminalJoinRequestRecords(store, CG, 2)).resolves.toBeUndefined();
+
+    expect(mutationSpy).toHaveBeenCalledTimes(2);
+    expect((await rowsForStatus(store)).map((row) => row.request)).toHaveLength(2);
+    await store.close();
+  }, 30_000);
 });
+
+async function rowsForStatus(store: TripleStore): Promise<Array<Record<string, string>>> {
+  const result = await store.query(`
+    SELECT ?request WHERE {
+      GRAPH <${META}> { ?request <${STATUS}> ?status }
+    }
+    ORDER BY ?request
+  `);
+  return result.type === 'bindings' ? result.bindings : [];
+}

--- a/packages/agent/test/remove-sub-graph-index-hint.test.ts
+++ b/packages/agent/test/remove-sub-graph-index-hint.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   OxigraphStore,
   type TripleStore,
-  type UpdateOptions,
+  type QueryOptions,
 } from '@origintrail-official/dkg-storage';
 import { ContextGraphRegistryMethods } from '../src/dkg-agent-cg-registry.js';
 
@@ -20,75 +20,21 @@ async function removeTempSubGraph(store: TripleStore): Promise<void> {
 }
 
 describe('removeSubGraph graph-set maintenance', () => {
-  it('declares the context-graph meta graph on the server-side deregistration update', async () => {
+  it('deletes the exact registration subject through the structured mutation', async () => {
     const inner = new OxigraphStore();
-    const updateCalls: Array<{ sparql: string; options?: UpdateOptions }> = [];
+    const deleteCalls: Array<{
+      pattern: { graph?: string; subject?: string };
+      options?: QueryOptions;
+    }> = [];
     const store = new Proxy(inner, {
       get(target, prop, receiver) {
-        if (prop === 'update') {
-          return (sparql: string, options?: UpdateOptions) => {
-            updateCalls.push({ sparql, options });
-            return target.update(sparql, options);
-          };
-        }
-        const value = Reflect.get(target, prop, receiver);
-        return typeof value === 'function' ? value.bind(target) : value;
-      },
-    }) as TripleStore;
-
-    try {
-      await removeTempSubGraph(store);
-    } finally {
-      await store.close();
-    }
-
-    expect(updateCalls).toHaveLength(1);
-    expect(updateCalls[0].sparql).toContain('DELETE WHERE');
-    expect(updateCalls[0].options).toEqual({
-      source: 'agent.cg.removeSubGraph.registration',
-      touchedGraphs: ['did:dkg:context-graph:review-cg/_meta'],
-    });
-  });
-
-  it('falls back to query() when server-side update() is unavailable', async () => {
-    const inner = new OxigraphStore();
-    const queryCalls: string[] = [];
-    const store = new Proxy(inner, {
-      get(target, prop, receiver) {
-        if (prop === 'update') return undefined;
-        if (prop === 'query') {
-          return async (sparql: string) => {
-            queryCalls.push(sparql);
-            return { type: 'bindings' as const, bindings: [] };
-          };
-        }
-        const value = Reflect.get(target, prop, receiver);
-        return typeof value === 'function' ? value.bind(target) : value;
-      },
-    }) as TripleStore;
-
-    try {
-      await removeTempSubGraph(store);
-    } finally {
-      await store.close();
-    }
-
-    expect(queryCalls).toHaveLength(1);
-    expect(queryCalls[0]).toContain('DELETE WHERE');
-  });
-
-  it('falls back to deleteByPattern() when the SPARQL update fails', async () => {
-    const inner = new OxigraphStore();
-    const deletePatterns: Array<{ graph?: string; subject?: string }> = [];
-    const store = new Proxy(inner, {
-      get(target, prop, receiver) {
-        if (prop === 'update') {
-          return async () => { throw new Error('update unsupported'); };
-        }
         if (prop === 'deleteByPattern') {
-          return async (pattern: { graph?: string; subject?: string }) => {
-            deletePatterns.push(pattern);
-            return 0;
+          return (
+            pattern: { graph?: string; subject?: string },
+            options?: QueryOptions,
+          ) => {
+            deleteCalls.push({ pattern, options });
+            return target.deleteByPattern(pattern);
           };
         }
         const value = Reflect.get(target, prop, receiver);
@@ -102,9 +48,56 @@ describe('removeSubGraph graph-set maintenance', () => {
       await store.close();
     }
 
-    expect(deletePatterns).toEqual([{
-      graph: 'did:dkg:context-graph:review-cg/_meta',
-      subject: 'did:dkg:context-graph:review-cg/temp',
+    expect(deleteCalls).toEqual([{
+      pattern: {
+        graph: 'did:dkg:context-graph:review-cg/_meta',
+        subject: 'did:dkg:context-graph:review-cg/temp',
+      },
+      options: { source: 'agent.cg.removeSubGraph.registration' },
     }]);
+  });
+
+  it('never sends a mutation through query() or raw update()', async () => {
+    const inner = new OxigraphStore();
+    let rawMutationCalls = 0;
+    const store = new Proxy(inner, {
+      get(target, prop, receiver) {
+        if (prop === 'update' || prop === 'query') {
+          return async () => {
+            rawMutationCalls++;
+            throw new Error('raw mutation channel reached');
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+
+    try {
+      await removeTempSubGraph(store);
+    } finally {
+      await store.close();
+    }
+
+    expect(rawMutationCalls).toBe(0);
+  });
+
+  it('propagates a structured deletion failure', async () => {
+    const inner = new OxigraphStore();
+    const store = new Proxy(inner, {
+      get(target, prop, receiver) {
+        if (prop === 'deleteByPattern') {
+          return async () => { throw new Error('store unavailable'); };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+
+    try {
+      await expect(removeTempSubGraph(store)).rejects.toThrow('store unavailable');
+    } finally {
+      await store.close();
+    }
   });
 });

--- a/packages/agent/test/requester-join-state-structured-write.test.ts
+++ b/packages/agent/test/requester-join-state-structured-write.test.ts
@@ -1,0 +1,71 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  JoinRequestMethods,
+  type RequesterJoinRequestState,
+} from '../src/dkg-agent-join.js';
+
+const GRAPH = 'urn:dkg:local:requester-join-state';
+const STATUS = 'urn:dkg:local:requester-join-state:status';
+const GENERATION = 'urn:dkg:local:requester-join-state:generation';
+const CURATOR = 'urn:dkg:local:requester-join-state:curator-peer-id';
+
+describe('requester join-state structured persistence', () => {
+  it('uses the atomic subject capability without reaching raw update()', async () => {
+    const replaceSubject = vi.fn(async () => undefined);
+    const update = vi.fn(async () => {
+      throw new Error('raw update channel reached');
+    });
+    const flush = vi.fn(async () => undefined);
+    const store = {
+      replaceSubject,
+      update,
+      flush,
+    } as unknown as TripleStore;
+    const cache = new Map<string, RequesterJoinRequestState>();
+    const contextGraphId = 'private/structured-state';
+    const agentAddress = '0x1234567890123456789012345678901234567890';
+    const state: RequesterJoinRequestState = {
+      status: 'pending',
+      requestGeneration: `0x${'ab'.repeat(32)}`,
+      curatorPeerId: '12D3KooWCurator"Quoted',
+    };
+
+    await JoinRequestMethods.prototype.writeRequesterJoinRequestState.call(
+      {
+        store,
+        requesterJoinStateCache: () => cache,
+      } as never,
+      contextGraphId,
+      agentAddress,
+      state,
+    );
+
+    const subject = `urn:dkg:local:requester-join-state:${createHash('sha256')
+      .update(`${contextGraphId}\0${agentAddress.toLowerCase()}`)
+      .digest('hex')}`;
+    const expected: Quad[] = [{
+      graph: GRAPH,
+      subject,
+      predicate: STATUS,
+      object: '"pending"',
+    }, {
+      graph: GRAPH,
+      subject,
+      predicate: GENERATION,
+      object: `"${state.requestGeneration}"`,
+    }, {
+      graph: GRAPH,
+      subject,
+      predicate: CURATOR,
+      object: '"12D3KooWCurator\\"Quoted"',
+    }];
+
+    expect(replaceSubject).toHaveBeenCalledWith(GRAPH, subject, expected, {});
+    expect(update).not.toHaveBeenCalled();
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(cache.get(`${contextGraphId}\0${agentAddress.toLowerCase()}`)).toBe(state);
+  });
+});

--- a/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
@@ -595,6 +595,67 @@ describe('healStrandedScopedKCs — through the production store decorator stack
     expect(mutations).toEqual([]);
   });
 
+  it('does not copy metadata or stamp completion after becoming stale during data copy', async () => {
+    const cg = 'stale-after-data-copy';
+    const onChainId = '24';
+    const ual = 'did:dkg:hardhat:31337/0xstale-copy/42';
+    const root = 'urn:entity:stale-copy';
+    const mutations: StructuredMutation[] = [];
+    let isCurrent = true;
+    const scopedData = contextGraphDataUri(cg, onChainId);
+    const scopedMeta = contextGraphMetaUri(cg, onChainId);
+    const fakeStore = {
+      query: vi.fn(async (sparql: string) => {
+        if (sparql.includes('SELECT ?ual ?b')) {
+          return { type: 'bindings' as const, bindings: [{ ual, b: String(KA_ID) }] };
+        }
+        if (sparql.includes('SELECT ?root')) {
+          return { type: 'bindings' as const, bindings: [{ root }] };
+        }
+        if (sparql.includes('ASK')) return { type: 'boolean' as const, value: true };
+        return { type: 'bindings' as const, bindings: [] };
+      }),
+      structuredMutation: vi.fn(async (mutation: StructuredMutation) => {
+        mutations.push(mutation);
+        if (
+          mutation.kind === 'copy-subject-projection'
+          && mutation.input.targetGraphUri === scopedData
+        ) {
+          isCurrent = false;
+        }
+      }),
+    } as unknown as TripleStore;
+
+    await expect(SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      {
+        store: fakeStore,
+        rsHealCursorByCg: new Map<string, string>(),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      } as never,
+      cg,
+      { subscribed: true, synced: true, onChainId } as never,
+      () => isCurrent,
+    )).resolves.toEqual({ status: 'completed', inspected: 1 });
+
+    expect(mutations).toHaveLength(2);
+    expect(mutations[0]).toMatchObject({
+      kind: 'replace-subject-predicates',
+      input: { graphUri: scopedMeta, replacementQuads: [] },
+    });
+    expect(mutations[1]).toMatchObject({
+      kind: 'copy-subject-projection',
+      input: { targetGraphUri: scopedData },
+    });
+    expect(mutations.some((mutation) => (
+      mutation.kind === 'copy-subject-projection'
+      && mutation.input.targetGraphUri === scopedMeta
+    ))).toBe(false);
+    expect(mutations.some((mutation) => (
+      mutation.kind === 'replace-subject-predicates'
+      && mutation.input.replacementQuads.length > 0
+    ))).toBe(false);
+  });
+
   it('(#1549) RS-heal INSERTs declare touchedGraphs through the decorator stack', async () => {
     // Guard the #1549 warm-index behaviour at the call site: a regression reverting
     // either INSERT to a plain `store.update(sparql)` would still relocate the KC

--- a/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
@@ -2,16 +2,16 @@
  * RS-heal — runs through the PRODUCTION store decorator stack.
  *
  * Regression for the review finding: `healStrandedScopedKCs` bails unless
- * `this.store.update` is a function, but the agent's store is NOT a bare
+ * the structured copy capabilities are present, but the agent's store is NOT a bare
  * adapter. `createTripleStore` wraps it in `SharedMemoryLiteralBlobStore` /
  * `GraphSetIndexStore`, and `DKGAgent.create` wraps THAT in
  * `createListContextGraphsCacheInvalidatingStore`. If any layer fails to
- * forward the (optional) `update` method, `this.store.update` is `undefined`
+ * forward the optional methods, the capability is `undefined`
  * in every normal daemon config → the guard silently returns → the heal never
  * runs and RS stays stuck. The bare-adapter gate tests cannot see this.
  *
  * This builds the production decorator order around a counted adapter and
- * proves: (1) `update` propagates to the top of the stack; (2) the heal
+ * proves: (1) the capabilities propagate to the top of the stack; (2) the heal
  * actually RELOCATES through it (byte-exact root equality — if `update` were
  * dropped the guard would no-op and scoped would stay empty); (3) the wrapper's
  * cache invalidation fires and the GraphSetIndex touched-graph maintenance keeps
@@ -21,8 +21,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   GraphSetIndexStore,
   OxigraphStore,
+  supportsCopySubjectProjection,
+  supportsReplaceSubjectPredicatesAtomically,
+  supportsTripleStoreCapability,
   type QueryOptions,
   type Quad,
+  type StructuredMutation,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
 import { V10MerkleTree, contextGraphDataUri, contextGraphMetaUri, contextGraphLayerUri, MemoryLayer } from '@origintrail-official/dkg-core';
@@ -130,8 +134,109 @@ describe('healStrandedScopedKCs — through the production store decorator stack
     );
   }
 
-  it('exposes update() at the top of the decorator stack (capability propagation)', () => {
-    expect(typeof store.update).toBe('function');
+  it('exposes structured RS-heal capabilities at the top of the decorator stack', () => {
+    expect(typeof store.structuredMutation).toBe('function');
+    expect(supportsTripleStoreCapability(store, 'structuredMutation')).toBe(true);
+  });
+
+  it('preserves update-only RS-heal compatibility through the full decorator stack', async () => {
+    const adapter = new Proxy(new OxigraphStore(), {
+      get(target, prop, receiver) {
+        if (prop === 'structuredMutation') return undefined;
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    const wrapped = createListContextGraphsCacheInvalidatingStore(
+      new GraphSetIndexStore(adapter),
+      () => undefined,
+    );
+
+    expect(typeof wrapped.structuredMutation).toBe('function');
+    expect(supportsTripleStoreCapability(wrapped, 'structuredMutation')).toBe(false);
+    expect(supportsCopySubjectProjection(wrapped)).toBe(true);
+    expect(supportsReplaceSubjectPredicatesAtomically(wrapped)).toBe(true);
+
+    const legacyMeta = contextGraphMetaUri(TEST_CG);
+    await wrapped.insert([
+      {
+        subject: `did:dkg:context-graph:${TEST_CG}`,
+        predicate: CONTEXT_GRAPH_ON_CHAIN_ID,
+        object: `"${TEST_ONCHAIN}"`,
+        graph: ONTOLOGY_GRAPH,
+      },
+      ...metaQuads(TEST_UAL, legacyMeta),
+      ...publicTriples().map((triple) => ({ ...triple, graph: contextGraphDataUri(TEST_CG) })),
+    ]);
+    await writeMaterializedVersion(wrapped, legacyMeta, TEST_UAL, {
+      blockNumber: 100,
+      txIndex: 0,
+    });
+
+    await expect(SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      {
+        store: wrapped,
+        rsHealCursorByCg: new Map(),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      } as never,
+      TEST_CG,
+      { subscribed: true, synced: true, onChainId: TEST_ONCHAIN } as never,
+    )).resolves.toEqual({ status: 'completed', inspected: 1 });
+
+    const scopedData = contextGraphDataUri(TEST_CG, TEST_ONCHAIN);
+    const scopedMeta = contextGraphMetaUri(TEST_CG, TEST_ONCHAIN);
+    const dataPresent = await wrapped.query(
+      `ASK { GRAPH <${scopedData}> { <${ROOT}> <urn:p:name> "strand" } }`,
+    );
+    const metadataPresent = await wrapped.query(
+      `ASK { GRAPH <${scopedMeta}> { <${TEST_UAL}> <${DKG}batchId> "${KA_ID}"^^<${XSD}integer> } }`,
+    );
+    const completionPresent = await wrapped.query(
+      `ASK { GRAPH <${scopedMeta}> { <${TEST_UAL}> <${DKG}materializedVersion> ?version } }`,
+    );
+    expect(dataPresent).toEqual({ type: 'boolean', value: true });
+    expect(metadataPresent).toEqual({ type: 'boolean', value: true });
+    expect(completionPresent).toEqual({ type: 'boolean', value: true });
+
+    await wrapped.close();
+  });
+
+  it('snapshots structured-mutation cache bookkeeping before async dispatch', async () => {
+    let release!: () => void;
+    const structuredMutation = vi.fn(() => new Promise<void>((resolve) => {
+      release = resolve;
+    }));
+    const adapter = new Proxy(new OxigraphStore(), {
+      get(target, prop, receiver) {
+        if (prop === 'structuredMutation') return structuredMutation;
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    const dirtiedGraphs: string[] = [];
+    const wrapped = createListContextGraphsCacheInvalidatingStore(
+      adapter,
+      () => undefined,
+      (_quads, targetGraph) => {
+        if (targetGraph) dirtiedGraphs.push(targetGraph);
+      },
+    );
+    const input = {
+      sourceGraphUris: ['urn:test:source'],
+      targetGraphUri: 'urn:test:target',
+      roots: ['urn:test:root'],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    };
+
+    const pending = wrapped.structuredMutation!({ kind: 'copy-subject-projection', input });
+    input.targetGraphUri = 'urn:test:mutated-after-dispatch';
+    release();
+    await pending;
+
+    expect(structuredMutation).toHaveBeenCalledTimes(1);
+    expect(dirtiedGraphs).toEqual(['urn:test:target']);
+    await wrapped.close();
   });
 
   it('forwards atomic graph-and-subject replacement through the agent decorator', async () => {
@@ -294,14 +399,171 @@ describe('healStrandedScopedKCs — through the production store decorator stack
     expect(legacyStill.type === 'boolean' && legacyStill.value).toBe(true);
   });
 
+  it('relocates every root of a multi-root KC with byte-identical proof data', async () => {
+    const cg = 'multi-root-strand';
+    const onChainId = '19';
+    const controlCg = 'multi-root-control';
+    const controlOnChainId = '20';
+    const ual = 'did:dkg:hardhat:31337/0xmulti/42';
+    const controlUal = 'did:dkg:hardhat:31337/0xmulticontrol/42';
+    const roots = ['urn:entity:multi-a', 'urn:entity:multi-b'];
+    const data = roots.flatMap((root, index) => [
+      { subject: root, predicate: 'urn:p:value', object: `"${index}"` },
+      {
+        subject: `${root}/.well-known/genid/child`,
+        predicate: 'urn:p:child',
+        object: `"child-${index}"`,
+      },
+    ]);
+    const metadata = (subject: string, graph: string): Quad[] => [
+      { subject, predicate: `${RDF}type`, object: `${DKG}KnowledgeCollection`, graph },
+      { subject, predicate: `${DKG}batchId`, object: `"${KA_ID}"^^<${XSD}integer>`, graph },
+      ...roots.flatMap((root, index) => [
+        { subject: `${subject}/${index + 1}`, predicate: `${DKG}partOf`, object: subject, graph },
+        { subject: `${subject}/${index + 1}`, predicate: `${DKG}rootEntity`, object: root, graph },
+      ]),
+    ];
+    await store.insert([
+      {
+        subject: `did:dkg:context-graph:${cg}`,
+        predicate: CONTEXT_GRAPH_ON_CHAIN_ID,
+        object: `"${onChainId}"`,
+        graph: ONTOLOGY_GRAPH,
+      },
+      {
+        subject: `did:dkg:context-graph:${controlCg}`,
+        predicate: CONTEXT_GRAPH_ON_CHAIN_ID,
+        object: `"${controlOnChainId}"`,
+        graph: ONTOLOGY_GRAPH,
+      },
+      ...metadata(ual, contextGraphMetaUri(cg)),
+      ...data.map((quad) => ({ ...quad, graph: contextGraphDataUri(cg) })),
+      ...metadata(controlUal, contextGraphMetaUri(controlCg, controlOnChainId)),
+      ...data.map((quad) => ({ ...quad, graph: contextGraphDataUri(controlCg, controlOnChainId) })),
+    ]);
+    await writeMaterializedVersion(store, contextGraphMetaUri(cg), ual, {
+      blockNumber: 100,
+      txIndex: 0,
+    });
+
+    const control = await extractV10KCFromStore(store, BigInt(controlOnChainId), KA_ID);
+    await runHeal(cg, onChainId);
+    const healed = await extractV10KCFromStore(store, BigInt(onChainId), KA_ID);
+
+    expect(new V10MerkleTree(healed.leaves).root).toEqual(new V10MerkleTree(control.leaves).root);
+    for (const root of roots) {
+      const present = await store.query(
+        `ASK { GRAPH <${contextGraphDataUri(cg, onChainId)}> { <${root}> ?p ?o } }`,
+      );
+      expect(present.type === 'boolean' && present.value).toBe(true);
+    }
+  });
+
+  it('chunks an over-budget root set and stamps completion after every data chunk', async () => {
+    const cg = 'oversized-root-set';
+    const onChainId = '21';
+    const ual = 'did:dkg:hardhat:31337/0xoversized/42';
+    const roots = Array.from(
+      { length: 10 },
+      (_, index) => `urn:entity:oversized:${index}:${'x'.repeat(500_000)}`,
+    );
+    const mutations: StructuredMutation[] = [];
+    const fakeStore = {
+      query: vi.fn(async (sparql: string) => {
+        if (sparql.includes('SELECT ?ual ?b')) {
+          return { type: 'bindings' as const, bindings: [{ ual, b: String(KA_ID) }] };
+        }
+        if (sparql.includes('SELECT ?root')) {
+          return {
+            type: 'bindings' as const,
+            bindings: roots.map((root) => ({ root })),
+          };
+        }
+        if (sparql.includes('ASK')) return { type: 'boolean' as const, value: true };
+        return { type: 'bindings' as const, bindings: [] };
+      }),
+      structuredMutation: vi.fn(async (mutation: StructuredMutation) => {
+        mutations.push(mutation);
+      }),
+    } as unknown as TripleStore;
+
+    await expect(SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      {
+        store: fakeStore,
+        rsHealCursorByCg: new Map<string, string>(),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      } as never,
+      cg,
+      { subscribed: true, synced: true, onChainId } as never,
+    )).resolves.toEqual({ status: 'completed', inspected: 1 });
+
+    const scopedData = contextGraphDataUri(cg, onChainId);
+    const dataCopies = mutations.filter((mutation) => mutation.kind === 'copy-subject-projection'
+      && mutation.input.targetGraphUri === scopedData);
+    expect(dataCopies.length).toBeGreaterThan(1);
+    expect(dataCopies.flatMap((mutation) => mutation.kind === 'copy-subject-projection'
+      ? mutation.input.roots
+      : [])).toEqual(roots);
+
+    const firstDataIndex = mutations.indexOf(dataCopies[0]);
+    const lastDataIndex = mutations.indexOf(dataCopies[dataCopies.length - 1]);
+    const completionResetIndex = mutations.findIndex((mutation) => (
+      mutation.kind === 'replace-subject-predicates'
+      && mutation.input.replacementQuads.length === 0
+    ));
+    const completionStampIndex = mutations.findIndex((mutation) => (
+      mutation.kind === 'replace-subject-predicates'
+      && mutation.input.replacementQuads.some((quad) => quad.predicate === `${DKG}materializedVersion`)
+    ));
+    expect(completionResetIndex).toBeGreaterThanOrEqual(0);
+    expect(completionResetIndex).toBeLessThan(firstDataIndex);
+    expect(completionStampIndex).toBeGreaterThan(lastDataIndex);
+  });
+
+  it('rejects an individually over-budget root before clearing completion', async () => {
+    const cg = 'unrepresentable-root';
+    const onChainId = '22';
+    const ual = 'did:dkg:hardhat:31337/0xunrepresentable/42';
+    const root = `urn:entity:unrepresentable:${'x'.repeat(4 * 1024 * 1024)}`;
+    const mutations: StructuredMutation[] = [];
+    const fakeStore = {
+      query: vi.fn(async (sparql: string) => {
+        if (sparql.includes('SELECT ?ual ?b')) {
+          return { type: 'bindings' as const, bindings: [{ ual, b: String(KA_ID) }] };
+        }
+        if (sparql.includes('SELECT ?root')) {
+          return { type: 'bindings' as const, bindings: [{ root }] };
+        }
+        if (sparql.includes('ASK')) return { type: 'boolean' as const, value: true };
+        return { type: 'bindings' as const, bindings: [] };
+      }),
+      structuredMutation: vi.fn(async (mutation: StructuredMutation) => {
+        mutations.push(mutation);
+      }),
+    } as unknown as TripleStore;
+
+    await expect(SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      {
+        store: fakeStore,
+        rsHealCursorByCg: new Map<string, string>(),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      } as never,
+      cg,
+      { subscribed: true, synced: true, onChainId } as never,
+    )).resolves.toEqual({ status: 'completed', inspected: 1 });
+
+    expect(mutations).toEqual([]);
+  });
+
   it('(#1549) RS-heal INSERTs declare touchedGraphs through the decorator stack', async () => {
     // Guard the #1549 warm-index behaviour at the call site: a regression reverting
     // either INSERT to a plain `store.update(sparql)` would still relocate the KC
     // (the graphsAfter/merkle assertions above stay green) but would re-dirty the
-    // graph-set index and force a full rebuild scan. Capture the update() options the
-    // heal sends through the top of the production stack and assert each INSERT
-    // declares its scoped target graph + source tag.
-    const updateCalls: Array<{ sparql: string; options?: { source?: string; touchedGraphs?: readonly string[] } }> = [];
+    // graph-set index and force a full rebuild scan. Capture the structured
+    // operations the heal sends through the top of the production stack and
+    // assert each declares its scoped target graph + source tag.
+    const copyCalls: Array<{ targetGraphUri: string; options?: QueryOptions }> = [];
+    const replaceCalls: Array<{ graphUri: string; options?: QueryOptions }> = [];
     const operationOptions: Array<{ method: string; options?: QueryOptions }> = [];
     const capturing = new Proxy(store, {
       get(target, prop, receiver) {
@@ -326,12 +588,17 @@ describe('healStrandedScopedKCs — through the production store decorator stack
             return orig.call(target, pattern, options);
           };
         }
-        if (prop === 'update') {
-          const orig = Reflect.get(target, prop, receiver) as NonNullable<TripleStore['update']>;
-          return (sparql: string, options?: { source?: string; touchedGraphs?: readonly string[] }) => {
-            updateCalls.push({ sparql, options });
-            operationOptions.push({ method: 'update', options });
-            return orig.call(target, sparql, options);
+        if (prop === 'structuredMutation') {
+          const orig = Reflect.get(target, prop, receiver) as NonNullable<TripleStore['structuredMutation']>;
+          return (mutation: Parameters<NonNullable<TripleStore['structuredMutation']>>[0], options?: QueryOptions) => {
+            if (mutation.kind === 'copy-subject-projection') {
+              copyCalls.push({ targetGraphUri: mutation.input.targetGraphUri, options });
+            }
+            if (mutation.kind === 'replace-subject-predicates') {
+              replaceCalls.push({ graphUri: mutation.input.graphUri, options });
+            }
+            operationOptions.push({ method: `structuredMutation:${mutation.kind}`, options });
+            return orig.call(target, mutation, options);
           };
         }
         return Reflect.get(target, prop, receiver);
@@ -350,18 +617,17 @@ describe('healStrandedScopedKCs — through the production store decorator stack
 
     const scopedData = contextGraphDataUri(TEST_CG, TEST_ONCHAIN);
     const scopedMeta = contextGraphMetaUri(TEST_CG, TEST_ONCHAIN);
-    const dataInsert = updateCalls.find((c) => /INSERT/i.test(c.sparql) && c.sparql.includes(scopedData));
-    const metaInsert = updateCalls.find((c) => /INSERT/i.test(c.sparql) && c.sparql.includes(scopedMeta));
-    expect(dataInsert?.options).toMatchObject({
+    const dataCopy = copyCalls.find((call) => call.targetGraphUri === scopedData);
+    const metaCopy = copyCalls.find((call) => call.targetGraphUri === scopedMeta);
+    expect(dataCopy?.options).toMatchObject({
       priority: 'background',
-      source: 'agent.swm.rsHeal.materialize',
-      touchedGraphs: [scopedData],
+      source: 'agent.swm.rsHeal.materialize.copy',
     });
-    expect(metaInsert?.options).toMatchObject({
+    expect(metaCopy?.options).toMatchObject({
       priority: 'background',
-      source: 'agent.swm.rsHeal.materialize',
-      touchedGraphs: [scopedMeta],
+      source: 'agent.swm.rsHeal.materialize.copy',
     });
+    expect(replaceCalls.filter((call) => call.graphUri === scopedMeta)).toHaveLength(2);
     expect(operationOptions.length).toBeGreaterThan(0);
     expect(operationOptions.every(({ options }) => options?.priority === 'background')).toBe(true);
     expect(operationOptions.every(({ options }) => options?.source?.startsWith('agent.swm.rsHeal.'))).toBe(true);

--- a/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
@@ -555,6 +555,46 @@ describe('healStrandedScopedKCs — through the production store decorator stack
     expect(mutations).toEqual([]);
   });
 
+  it('does not clear completion when the heal stops being current before its first write', async () => {
+    const cg = 'stale-before-write';
+    const onChainId = '23';
+    const ual = 'did:dkg:hardhat:31337/0xstale/42';
+    const root = 'urn:entity:stale';
+    const mutations: StructuredMutation[] = [];
+    const fakeStore = {
+      query: vi.fn(async (sparql: string) => {
+        if (sparql.includes('SELECT ?ual ?b')) {
+          return { type: 'bindings' as const, bindings: [{ ual, b: String(KA_ID) }] };
+        }
+        if (sparql.includes('SELECT ?root')) {
+          return { type: 'bindings' as const, bindings: [{ root }] };
+        }
+        if (sparql.includes('ASK')) return { type: 'boolean' as const, value: true };
+        return { type: 'bindings' as const, bindings: [] };
+      }),
+      structuredMutation: vi.fn(async (mutation: StructuredMutation) => {
+        mutations.push(mutation);
+      }),
+    } as unknown as TripleStore;
+    let currentChecks = 0;
+
+    await expect(SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      {
+        store: fakeStore,
+        rsHealCursorByCg: new Map<string, string>(),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      } as never,
+      cg,
+      { subscribed: true, synced: true, onChainId } as never,
+      // Nine checks cover candidate discovery and root preflight. The tenth is
+      // the first materialization write boundary and must fail closed.
+      () => ++currentChecks <= 9,
+    )).resolves.toEqual({ status: 'completed', inspected: 1 });
+
+    expect(currentChecks).toBeGreaterThanOrEqual(10);
+    expect(mutations).toEqual([]);
+  });
+
   it('(#1549) RS-heal INSERTs declare touchedGraphs through the decorator stack', async () => {
     // Guard the #1549 warm-index behaviour at the call site: a regression reverting
     // either INSERT to a plain `store.update(sparql)` would still relocate the KC

--- a/packages/agent/test/rs-heal-stranded-kc.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc.test.ts
@@ -344,6 +344,7 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
     );
     const fakeStore = {
       update: async () => undefined,
+      structuredMutation: async () => undefined,
       query: async (_sparql: string, queryOptions?: QueryOptions) => {
         queryCalls += 1;
         options.push(queryOptions ?? {});
@@ -397,6 +398,7 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
     let legacyReadStarted = false;
     const fakeStore = {
       update: async () => undefined,
+      structuredMutation: async () => undefined,
       query: async (_sparql: string, options?: QueryOptions) => {
         if (options?.source === 'agent.swm.rsHeal.guard') {
           return { type: 'boolean', value: true } as const;
@@ -641,20 +643,21 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
       ...publicTriples().map((triple) => ({ ...triple, graph: contextGraphDataUri(cg) })),
     ]);
 
-    const originalUpdate = store.update.bind(store);
+    const originalMutation = store.structuredMutation.bind(store);
     const scopedMeta = contextGraphMetaUri(cg, onChainId);
     let failMetadataCopyOnce = true;
-    store.update = async (sparql, options) => {
+    store.structuredMutation = async (mutation, options) => {
       if (
         failMetadataCopyOnce
-        && sparql.includes(`FILTER(?p != <${DKG}materializedVersion>)`)
+        && mutation.kind === 'copy-subject-projection'
+        && mutation.input.targetGraphUri === scopedMeta
       ) {
         failMetadataCopyOnce = false;
-        await originalUpdate(sparql, options);
+        await originalMutation(mutation, options);
         // Model a non-transactional endpoint that applied only part of the
         // metadata INSERT before reporting failure. Completion must remain
         // unstamped so the next sweep repairs the missing child row.
-        await originalUpdate(
+        await store.update(
           `DELETE WHERE {
              GRAPH <${scopedMeta}> {
                <${ual}/1> <${RDF}type> ?type
@@ -664,7 +667,7 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
         );
         throw new Error('injected partial metadata copy failure');
       }
-      return originalUpdate(sparql, options);
+      return originalMutation(mutation, options);
     };
 
     await runHeal(store, cg, onChainId);

--- a/packages/publisher/src/agent-registry-meta-retention.ts
+++ b/packages/publisher/src/agent-registry-meta-retention.ts
@@ -1,4 +1,4 @@
-import { tryUpdateWithTouchedGraphs, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import { tryPruneLinkedRecordClosures, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
   isAgentRegistryContextGraph,
   sparqlIri,
@@ -15,17 +15,6 @@ const log = new Logger('AgentRegistryMetaRetention');
 // subjects (`<ual>/<n> dkg:partOf <ual>`). Used here to resolve a matched member
 // subject back to its record ROOT (the KC `<ual>`).
 const DKG_PART_OF = 'http://dkg.io/ontology/partOf';
-
-/**
- * Reject SPARQL-structure-breaking characters before a graph IRI is embedded in
- * a `GRAPH <...>` clause. Local copy of the guard in `metadata.ts` so this
- * module stays self-contained (metadata.ts is now pure quad generation).
- */
-function assertSafeGraphIriForSparql(graphIri: string): void {
-  if (/[<>"{}|^`\\\s]/.test(graphIri)) {
-    throw new Error(`Unsafe graph IRI for SPARQL query: "${graphIri}"`);
-  }
-}
 
 // Per-INDIVIDUAL-root serialization (#1533/#1534 review). Two concurrent
 // agents/_meta writes whose root sets INTERSECT each insert a fresh record and then
@@ -235,7 +224,7 @@ export async function pruneSupersededAgentRegistryMeta(opts: {
   const { store, contextGraphId, metaGraph, rootEntities, keepUal } = opts;
   if (!isAgentRegistryContextGraph(contextGraphId)) return;
 
-  // Build the `VALUES ?root { … }` list with the canonical `sparqlIri` guard,
+  // Validate the requested roots with the canonical `sparqlIri` guard,
   // which THROWS on an unsafe IRI. An unsafe root is therefore an explicit
   // boundary, not a silent drop: we collect it and WARN (naming it) rather than
   // degrade the retention invariant without any signal.
@@ -243,7 +232,8 @@ export async function pruneSupersededAgentRegistryMeta(opts: {
   const droppedRoots: string[] = [];
   for (const root of new Set(rootEntities)) {
     try {
-      rootIris.push(sparqlIri(root));
+      sparqlIri(root);
+      rootIris.push(root);
     } catch {
       droppedRoots.push(root);
     }
@@ -257,44 +247,27 @@ export async function pruneSupersededAgentRegistryMeta(opts: {
     );
   }
   if (rootIris.length === 0) return;
-  assertSafeGraphIriForSparql(metaGraph);
 
-  // COUNT-FREE by construction: ONE server-side SPARQL `DELETE … WHERE`, never a
+  // COUNT-FREE by construction: ONE bounded server-side prune, never a
   // per-record `deleteByPattern`/`deleteBySubjectPrefix` loop. On the production
   // Blazegraph/SparqlHttp backends those helpers bracket every delete with TWO
   // full-graph `countQuads` scans (blazegraph.ts deleteByPattern/
   // deleteBySubjectPrefix) — evicting an agent's backlog on the first heartbeat
   // would fan out into thousands of full-graph scans on the very cores this
   // change exists to relieve. A single UPDATE does the whole eviction inside the
-  // store with no client round-trips or counts. Same "bail if the backend can't
-  // do server-side UPDATE" contract as the RS heal (dkg-agent-swm-host.ts
-  // healStrandedScopedKCs); every production + test backend implements it.
-  if (typeof store.update !== 'function') {
-    // Pruning IS required here (agents CG + non-empty roots), but the store
-    // cannot run a server-side UPDATE. Do NOT silently skip — and do NOT throw
-    // (a defensive bound must never break the publish path). WARN loudly so the
-    // invariant violation is visible: every production + test backend implements
-    // update(), so this means a misconfigured store and agents/_meta will grow
-    // unbounded on it.
-    log.warn(
-      createOperationContext('system'),
-      `agents/_meta bound SKIPPED for context graph "${contextGraphId}": the triple store ` +
-        `lacks server-side update(); the agents-registry _meta graph will grow UNBOUNDED on ` +
-        `this backend (#1233). Every production/test backend implements update() — this ` +
-        `indicates a misconfigured store.`,
-    );
-    return;
-  }
-
+  // store with no client round-trips or counts. The structured capability owns
+  // escaping, admission, reserved-graph policy, changelog accounting, and
+  // graph-set maintenance; callers never assemble executable SPARQL.
+  //
   // `keepUal` protects a record (insert-first ordering). If it cannot be safely
   // embedded, pruning would delete the protected record, so SKIP the prune
   // (warn) rather than risk the loss. Absent `keepUal` ⇒ no protection (the
   // legacy prune-only contract).
-  let keepFilter = '';
+  let safeKeepUal: string | undefined;
   if (keepUal !== undefined) {
-    let keepIri: string;
     try {
-      keepIri = sparqlIri(keepUal);
+      sparqlIri(keepUal);
+      safeKeepUal = keepUal;
     } catch {
       log.warn(
         createOperationContext('system'),
@@ -303,7 +276,6 @@ export async function pruneSupersededAgentRegistryMeta(opts: {
       );
       return;
     }
-    keepFilter = `FILTER(?record != ${keepIri})`;
   }
 
   // Resolve each matched MEMBER subject to its record ROOT before deleting. The
@@ -315,26 +287,25 @@ export async function pruneSupersededAgentRegistryMeta(opts: {
   // the token subtree (the legacy-shape leak, PR #1526 #1). Collapsed records
   // have no `partOf` self-edge (metadata.ts) so COALESCE → member = `<ual>`.
   // Read-both on the member predicate (`dkg:rootEntity` ‖ `dkg:entity`).
-  const values = rootIris.join(' ');
-  const sparql = `DELETE { GRAPH <${metaGraph}> { ?s ?p ?o } }
-WHERE { GRAPH <${metaGraph}> {
-  VALUES ?root { ${values} }
-  { ?member <${DKG_ROOT_ENTITY_LEGACY}> ?root } UNION { ?member <${DKG_ENTITY}> ?root }
-  OPTIONAL { ?member <${DKG_PART_OF}> ?parent }
-  BIND(COALESCE(?parent, ?member) AS ?record)
-  ${keepFilter}
-  ?s ?p ?o .
-  FILTER(?s = ?record || STRSTARTS(STR(?s), CONCAT(STR(?record), "/")))
-} }`;
-  // #1549: the prune's DELETE only touches `metaGraph`, so declare it — the
-  // graph-set index then maintains itself incrementally (one `hasGraph`) instead
-  // of marking the whole index dirty and forcing a full store scan on the next
-  // enumeration. The agents-meta prune is one of only two recurring server-side
-  // UPDATE sources that dirtied the index on managed cores.
-  await tryUpdateWithTouchedGraphs(
+  const pruned = await tryPruneLinkedRecordClosures(
     store,
-    sparql,
-    [metaGraph],
+    {
+      graphUri: metaGraph,
+      matchObjectIris: rootIris,
+      linkPredicates: [DKG_ROOT_ENTITY_LEGACY, DKG_ENTITY],
+      recordParentPredicate: DKG_PART_OF,
+      protectedRecordIri: safeKeepUal,
+      descendantSeparator: '/',
+    },
     { source: 'agent-registry-meta.prune' },
   );
+  if (!pruned) {
+    log.warn(
+      createOperationContext('system'),
+      `agents/_meta bound SKIPPED for context graph "${contextGraphId}": the triple store ` +
+        `lacks structuredMutation() and update(); the agents-registry _meta graph will grow UNBOUNDED ` +
+        `on this backend (#1233). Managed production stores expose this capability; this ` +
+        `indicates a legacy or misconfigured store.`,
+    );
+  }
 }

--- a/packages/publisher/src/catalog-persistence.ts
+++ b/packages/publisher/src/catalog-persistence.ts
@@ -1,10 +1,9 @@
 import {
-  tryUpdateWithTouchedGraphs,
+  tryDeleteSubjects,
   type Quad,
   type QueryOptions,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
-import { sparqlIri } from '@origintrail-official/dkg-core';
 
 function catalogStoreOptions(operation: string, signal?: AbortSignal): QueryOptions {
   return {
@@ -18,11 +17,11 @@ function catalogStoreOptions(operation: string, signal?: AbortSignal): QueryOpti
  * Replace the touched subjects in a verified public catalog and make the
  * replacement durable.
  *
- * The fast path clears IRI subjects in one server-side UPDATE. Blank-node
+ * The fast path clears IRI subjects in one bounded server-side operation. Blank-node
  * labels are scoped to a single RDF operation and therefore cannot safely be
- * carried into a later UPDATE; catalogs containing one use the legacy
- * per-subject delete path. Stores with no real UPDATE capability use that same
- * compatibility path, while genuine UPDATE execution errors still propagate.
+ * carried into a later subject-set operation; catalogs containing one use the legacy
+ * per-subject delete path. Stores without the structured capability use that same
+ * compatibility path, while genuine execution errors still propagate.
  */
 export async function replaceCatalogQuads(
   store: TripleStore,
@@ -33,15 +32,10 @@ export async function replaceCatalogQuads(
   const catalogSubjects = [...new Set(parsedCatalog.map((quad) => quad.subject))];
   const canUseTargetedUpdate = catalogSubjects.length > 0 &&
     catalogSubjects.every((subject) => !subject.startsWith('_:'));
-  const usedTargetedUpdate = canUseTargetedUpdate && await tryUpdateWithTouchedGraphs(
+  const usedTargetedUpdate = canUseTargetedUpdate && await tryDeleteSubjects(
     store,
-    `DELETE { GRAPH ${sparqlIri(catalogGraph)} { ?s ?p ?o } }
-WHERE { GRAPH ${sparqlIri(catalogGraph)} {
-  VALUES ?s { ${catalogSubjects.map((subject) => sparqlIri(subject)).join(' ')} }
-  ?s ?p ?o
-} }`,
-    [catalogGraph],
-    catalogStoreOptions('update', signal),
+    { graphUri: catalogGraph, subjects: catalogSubjects },
+    catalogStoreOptions('deleteSubjects', signal),
   );
 
   if (!usedTargetedUpdate) {

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -1,5 +1,9 @@
 import type { Quad, QueryOptions, TripleStore } from '@origintrail-official/dkg-storage';
-import { GraphManager, LOCAL_TRUSTED_KA_CONTROLS_GRAPH } from '@origintrail-official/dkg-storage';
+import {
+  GraphManager,
+  LOCAL_TRUSTED_KA_CONTROLS_GRAPH,
+  tryReplaceSubjectPredicatesAtomically,
+} from '@origintrail-official/dkg-storage';
 import {
   validateSubGraphName,
   isSafeIri,
@@ -1149,27 +1153,29 @@ export async function updateMetaMerkleRoot(
   assertSafeGraphIriForSparql(ual);
 
   const rootLiteral = `"${toHex(newMerkleRoot)}"`;
+  const merkleRootPredicate = `${DKG}merkleRoot`;
+  const replaced = await tryReplaceSubjectPredicatesAtomically(store, {
+    graphUri: metaGraph,
+    subject: ual,
+    predicates: [merkleRootPredicate],
+    replacementQuads: [{
+      subject: ual,
+      predicate: merkleRootPredicate,
+      object: rootLiteral,
+      graph: metaGraph,
+    }],
+  }, { source: 'publisher.metadata.updateMerkleRoot' });
+  if (replaced) return;
 
-  // Prefer a single SPARQL DELETE/INSERT to avoid an intermediate
-  // state with no dkg:merkleRoot when update succeeds.
-  try {
-    await store.query(
-      `DELETE { GRAPH <${metaGraph}> { <${ual}> <${DKG}merkleRoot> ?oldRoot } }
-       INSERT { GRAPH <${metaGraph}> { <${ual}> <${DKG}merkleRoot> ${rootLiteral} } }
-       WHERE  { GRAPH <${metaGraph}> { OPTIONAL { <${ual}> <${DKG}merkleRoot> ?oldRoot } } }`,
-    );
-    return;
-  } catch {
-    // Some backends may not support SPARQL updates via query().
-    // Fallback preserves correctness by inserting first, then pruning old roots.
-  }
+  // Compatibility fallback for custom stores without predicate replacement.
+  // Preserve availability by inserting first, then pruning stale roots.
 
   const existing = await store.query(
     `SELECT ?root WHERE { GRAPH <${metaGraph}> { <${ual}> <${DKG}merkleRoot> ?root } }`,
   );
   await store.insert([{
     subject: ual,
-    predicate: `${DKG}merkleRoot`,
+    predicate: merkleRootPredicate,
     object: rootLiteral,
     graph: metaGraph,
   }]);
@@ -1180,7 +1186,7 @@ export async function updateMetaMerkleRoot(
     .filter((root): root is string => typeof root === 'string' && root.length > 0 && root !== rootLiteral)
     .map((root) => ({
       subject: ual,
-      predicate: `${DKG}merkleRoot`,
+      predicate: merkleRootPredicate,
       object: root,
       graph: metaGraph,
     }));

--- a/packages/publisher/src/update-handler.ts
+++ b/packages/publisher/src/update-handler.ts
@@ -1,5 +1,5 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
-import { GraphManager } from '@origintrail-official/dkg-storage';
+import { GraphManager, tryReplaceGraphAndSubjectAtomically } from '@origintrail-official/dkg-storage';
 import type {
   EventBus,
   KAUpdateRequestMsg,
@@ -18,8 +18,6 @@ import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   knowledgeAssetLayerGraphUri,
   validateSubGraphName,
-  assertSafeIri,
-  assertSafeRdfTerm,
 } from '@origintrail-official/dkg-core';
 import { decodeKAUpdateRequest } from '@origintrail-official/dkg-core';
 import { parseSimpleNQuads } from './publish-handler.js';
@@ -735,7 +733,7 @@ export class UpdateHandler {
         if (!replaced) {
           throw Object.assign(
             new Error(
-              'Graph-scoped KA update requires atomic cross-graph TripleStore.update() support',
+              'Graph-scoped KA update requires TripleStore.replaceGraphAndSubject() support',
             ),
             { code: 'KA_MATERIALIZATION_ATOMIC_UPDATE_UNSUPPORTED' },
           );
@@ -787,36 +785,28 @@ export class UpdateHandler {
     metadata: readonly Quad[];
     version: MaterializedVersion;
   }): Promise<boolean> {
-    if (typeof this.store.update !== 'function') return false;
-    const vmGraph = assertSafeIri(input.vmGraph);
-    const metaGraph = assertSafeIri(input.metaGraph);
-    const ual = assertSafeIri(input.ual);
-    const vmTriples = input.publicQuads
-      .map((quad) => formatSparqlTriple({ ...quad, graph: vmGraph }))
-      .join('\n');
+    const vmGraphQuads = input.publicQuads.map((quad) => ({
+      ...quad,
+      graph: input.vmGraph,
+    }));
     const metaRows: Quad[] = [
-      ...input.metadata.map((quad) => ({ ...quad, graph: metaGraph })),
+      ...input.metadata.map((quad) => ({ ...quad, graph: input.metaGraph })),
       {
-        subject: ual,
+        subject: input.ual,
         predicate: `${DKG_NS}materializedVersion`,
         object: `"${input.version.blockNumber}:${input.version.txIndex}"`,
-        graph: metaGraph,
+        graph: input.metaGraph,
       },
     ];
-    const metaTriples = metaRows.map(formatSparqlTriple).join('\n');
-    const update = [
-      `DROP SILENT GRAPH <${vmGraph}>`,
-      vmTriples.length > 0
-        ? `INSERT DATA { GRAPH <${vmGraph}> {\n${vmTriples}\n} }`
-        : '',
-      `DELETE WHERE { GRAPH <${metaGraph}> { <${ual}> ?p ?o } }`,
-      `INSERT DATA { GRAPH <${metaGraph}> {\n${metaTriples}\n} }`,
-    ].filter(Boolean).join(';\n');
-    await this.store.update(update, {
-      touchedGraphs: [vmGraph, metaGraph],
-      source: 'publisher.updateHandler.graphScopedMaterialization',
-    });
-    return true;
+    return tryReplaceGraphAndSubjectAtomically(
+      this.store,
+      input.vmGraph,
+      vmGraphQuads,
+      input.metaGraph,
+      input.ual,
+      metaRows,
+      { source: 'publisher.updateHandler.graphScopedMaterialization' },
+    );
   }
 
   private async readGraphScopedMetadata(
@@ -955,21 +945,4 @@ function stripRdfLiteral(value: string | undefined): string {
   if (languageIndex > 0) return value.slice(1, languageIndex);
   const lastQuote = value.lastIndexOf('"');
   return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
-}
-
-function formatSparqlTriple(quad: Quad): string {
-  const resource = (term: string): string => {
-    const unwrapped = term.startsWith('<') && term.endsWith('>')
-      ? term.slice(1, -1)
-      : term;
-    return `<${assertSafeIri(unwrapped)}>`;
-  };
-  let object: string;
-  if (quad.object.startsWith('"')) {
-    assertSafeRdfTerm(quad.object);
-    object = quad.object;
-  } else {
-    object = resource(quad.object);
-  }
-  return `${resource(quad.subject)} ${resource(quad.predicate)} ${object} .`;
 }

--- a/packages/publisher/test/agents-meta-bound.test.ts
+++ b/packages/publisher/test/agents-meta-bound.test.ts
@@ -104,12 +104,12 @@ async function ask(store: OxigraphStore, sparql: string): Promise<boolean> {
 }
 
 // A call-counting proxy over a real store. The prune MUST reach the store only
-// via a single server-side `update()` — never via `countQuads`/`deleteByPattern`/
+// via a single structured server-side prune — never via `countQuads`/`deleteByPattern`/
 // `deleteBySubjectPrefix`, each of which brackets its work with full-graph COUNT
 // scans on the production Blazegraph backend (the BLOCKER this rewrite fixes,
 // invisible to a plain Oxigraph assertion). The OxigraphStore backing the proxy
-// implements `update()`, so the real DELETE still runs.
-const COUNTED = ['update', 'countQuads', 'deleteByPattern', 'deleteBySubjectPrefix', 'query', 'insert', 'delete'] as const;
+// implements `structuredMutation()`, so the real DELETE still runs.
+const COUNTED = ['structuredMutation', 'update', 'countQuads', 'deleteByPattern', 'deleteBySubjectPrefix', 'query', 'insert', 'delete'] as const;
 type Counts = Record<(typeof COUNTED)[number], number>;
 
 function makeCountingStore(inner: OxigraphStore): { store: OxigraphStore; calls: Counts } {
@@ -210,7 +210,7 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
     expect(new Set(live).size, 'all N distinct UALs retained').toBe(N);
   });
 
-  it('is count-free: prune reaches the store only via update(), never countQuads/deleteByPattern/deleteBySubjectPrefix', async () => {
+  it('is count-free: prune reaches the store only via the bounded capability', async () => {
     const base = new OxigraphStore();
     const agent = agentDid(0xa1);
     const priorUal = mkUal('prior');
@@ -233,33 +233,70 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
       keepUal: mkUal('current'),
     });
 
-    // The count-free contract: the single server-side UPDATE, and ZERO of the
+    // The count-free contract: one structured server-side prune, and ZERO raw
+    // updates or
     // full-graph-COUNT-bracketed delete/count helpers (the production BLOCKER).
-    expect(calls.update, 'prune issues the single server-side UPDATE').toBeGreaterThanOrEqual(1);
+    expect(calls.structuredMutation, 'prune issues one bounded operation').toBe(1);
+    expect(calls.update, 'caller does not issue raw UPDATE').toBe(0);
     expect(calls.countQuads, 'no full-graph COUNT scans').toBe(0);
     expect(calls.deleteByPattern, 'no per-pattern delete (each does 2 COUNT scans on Blazegraph)').toBe(0);
     expect(calls.deleteBySubjectPrefix, 'no prefix delete (each does 2 COUNT scans on Blazegraph)').toBe(0);
     expect(calls.query, 'no separate SELECT round-trip — one UPDATE does it all').toBe(0);
 
-    // …and the UPDATE actually evicted the superseded prior record.
-    expect(await base.countQuads(metaOf(AGENTS)), 'the prior record was deleted by the UPDATE').toBe(0);
+    // …and the capability actually evicted the superseded prior record.
+    expect(await base.countQuads(metaOf(AGENTS)), 'the prior record was deleted').toBe(0);
   });
 
-  it('(#1549) the prune declares touchedGraphs=[metaGraph] on its server-side update (index stays warm)', async () => {
-    // Call-site guard: a regression reverting to `store.update(sparql)` (dropping the
-    // hint) would still delete the record and pass the count-free test above, but it
-    // would mark the graph-set index dirty and force a full rebuild scan on the next
-    // enumeration — exactly what #1549 avoids. Assert the hint is sent.
+  it('keeps count-free atomic pruning on an update-only store', async () => {
+    const base = new OxigraphStore();
+    const agent = agentDid(0xa1);
+    const priorUal = mkUal('update-only-prior');
+    const currentUal = mkUal('update-only-current');
+    await base.insert([
+      ...metaQuadsFor(AGENTS, agent, priorUal),
+      ...metaQuadsFor(AGENTS, agent, currentUal),
+    ]);
+
+    const { store: counted, calls } = makeCountingStore(base);
+    const updateOnly = new Proxy(counted, {
+      get(target, property, receiver) {
+        if (property === 'structuredMutation') return undefined;
+        return Reflect.get(target, property, receiver);
+      },
+    }) as unknown as OxigraphStore;
+
+    await pruneSupersededAgentRegistryMeta({
+      store: updateOnly,
+      contextGraphId: AGENTS,
+      metaGraph: metaOf(AGENTS),
+      rootEntities: [agent],
+      keepUal: currentUal,
+    });
+
+    expect(calls.structuredMutation).toBe(0);
+    expect(calls.update).toBe(1);
+    expect(calls.countQuads).toBe(0);
+    expect(calls.deleteByPattern).toBe(0);
+    expect(calls.deleteBySubjectPrefix).toBe(0);
+    expect(
+      await ask(base, `ASK { GRAPH <${metaOf(AGENTS)}> { <${priorUal}> ?p ?o } }`),
+    ).toBe(false);
+    expect(
+      await ask(base, `ASK { GRAPH <${metaOf(AGENTS)}> { <${currentUal}> ?p ?o } }`),
+    ).toBe(true);
+  });
+
+  it('declares the exact target graph and roots through the structured capability', async () => {
     const base = new OxigraphStore();
     const agent = agentDid(0xa1);
     await base.insert(metaQuadsFor(AGENTS, agent, mkUal('prior')));
-    const updateCalls: Array<{ sparql: string; options?: { touchedGraphs?: readonly string[] } }> = [];
+    const calls: Array<{ mutation: Parameters<NonNullable<OxigraphStore['structuredMutation']>>[0]; options?: { source?: string } }> = [];
     const capturing = new Proxy(base, {
       get(t, p, r) {
-        if (p === 'update') {
-          return (sparql: string, options?: { touchedGraphs?: readonly string[] }) => {
-            updateCalls.push({ sparql, options });
-            return base.update(sparql, options);
+        if (p === 'structuredMutation') {
+          return (mutation: Parameters<NonNullable<OxigraphStore['structuredMutation']>>[0], options?: { source?: string }) => {
+            calls.push({ mutation, options });
+            return base.structuredMutation(mutation);
           };
         }
         return Reflect.get(t, p, r);
@@ -274,9 +311,15 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
       keepUal: mkUal('prior'),
     });
 
-    const deleteUpdate = updateCalls.find((c) => /DELETE/i.test(c.sparql));
-    expect(deleteUpdate, 'the prune issues a server-side DELETE update').toBeDefined();
-    expect(deleteUpdate?.options?.touchedGraphs).toEqual([metaOf(AGENTS)]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      mutation: { kind: 'prune-linked-record-closures', input: {
+        graphUri: metaOf(AGENTS),
+        matchObjectIris: [agent],
+        protectedRecordIri: mkUal('prior'),
+      } },
+      options: { source: 'agent-registry-meta.prune' },
+    });
   });
 
   it('(B) evicts the WHOLE record for legacy/multi-root shape (member on <ual>/n with dkg:partOf)', async () => {
@@ -384,11 +427,11 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
     // the tentative publish (#1533). It must resolve + warn instead.
     const base = new OxigraphStore();
     const agent = agentDid(0xa1);
-    // insert() runs on the real base store (succeeds); update() throws — that is
-    // the engine the prune uses, so the prune fails AFTER a durable insert.
+    // insert() runs on the real base store (succeeds); the bounded prune throws,
+    // so the prune fails AFTER a durable insert.
     const pruneFailsStore = new Proxy(base, {
       get(t, p, r) {
-        if (p === 'update') return async () => { throw new Error('update boom'); };
+        if (p === 'structuredMutation') return async () => { throw new Error('prune boom'); };
         if (p === 'insert') return (quads: Quad[]) => base.insert(quads);
         return Reflect.get(t, p, r);
       },
@@ -462,7 +505,7 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
   it('(A) serializes concurrent same-agent heartbeats — collapses to exactly the newest record', async () => {
     // Two concurrent heartbeats for the SAME agent (fresh UAL each). Without the
     // per-root mutex both insert, then each prunes the OTHER's record → the agent
-    // ends with ZERO records. The store below defers every prune (`update`) past
+    // ends with ZERO records. The store below defers every bounded prune past
     // the microtask queue via setTimeout(0), so BOTH inserts deterministically
     // land before EITHER prune's DELETE — the exact interleaving that zeroes the
     // graph unserialized. The mutex serialises insert+prune, so the 2nd call (B)
@@ -476,9 +519,9 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
     const raceStore = new Proxy(base, {
       get(t, p, r) {
         if (p === 'insert') return (quads: Quad[]) => base.insert(quads);
-        if (p === 'update') return async (sparql: string) => {
+        if (p === 'structuredMutation') return async (mutation: Parameters<NonNullable<OxigraphStore['structuredMutation']>>[0]) => {
           await new Promise((res) => setTimeout(res, 0)); // defer the prune past both inserts
-          return base.update(sparql);
+          return base.structuredMutation(mutation);
         };
         return Reflect.get(t, p, r);
       },
@@ -517,9 +560,9 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
     const raceStore = new Proxy(base, {
       get(t, p, r) {
         if (p === 'insert') return (quads: Quad[]) => base.insert(quads);
-        if (p === 'update') return async (sparql: string) => {
+        if (p === 'structuredMutation') return async (mutation: Parameters<NonNullable<OxigraphStore['structuredMutation']>>[0]) => {
           await new Promise((res) => setTimeout(res, 0)); // defer the prune past both inserts
-          return base.update(sparql);
+          return base.structuredMutation(mutation);
         };
         return Reflect.get(t, p, r);
       },
@@ -623,12 +666,12 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
     // propagate, the ACK rejects and pendingPublishes/expireTentativePublish never
     // register → the tentative publish is orphaned (#1533).
     const base = new OxigraphStore();
-    // Every store method delegates to base EXCEPT update(), which throws — that is
-    // the engine the agents/_meta prune uses, so the prune fails AFTER a durable
+    // Every store method delegates to base EXCEPT the bounded prune, which throws,
+    // so the prune fails AFTER a durable
     // insert while the rest of handlePublish runs normally.
     const pruneFailsStore = new Proxy(base, {
       get(t, p, r) {
-        if (p === 'update') return async () => { throw new Error('update boom'); };
+        if (p === 'structuredMutation') return async () => { throw new Error('prune boom'); };
         const v = Reflect.get(t, p, r);
         return typeof v === 'function' ? v.bind(base) : v;
       },

--- a/packages/publisher/test/ka-graph-update-handler.test.ts
+++ b/packages/publisher/test/ka-graph-update-handler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
@@ -127,9 +127,13 @@ describe('UpdateHandler graph-scoped updates', () => {
     const privateQuads: Quad[] = [
       { subject: 'urn:secret', predicate: 'urn:p:value', object: '"hidden"', graph: '' },
     ];
+    const replaceGraphAndSubject = vi.spyOn(store, 'replaceGraphAndSubject');
+    const rawUpdate = vi.spyOn(store, 'update');
 
     await handler.handle(message(publicQuads, privateQuads), 'forwarding-peer');
 
+    expect(replaceGraphAndSubject).toHaveBeenCalledTimes(1);
+    expect(rawUpdate).not.toHaveBeenCalled();
     expect(await store.countQuads(vmGraph)).toBe(2);
     expect(await store.countQuads(swmGraph)).toBe(0);
     const state = await store.query(
@@ -306,15 +310,9 @@ describe('UpdateHandler graph-scoped updates', () => {
       subject: 'urn:new', predicate: 'urn:p:value', object: '"new"', graph: '',
     }];
     const encoded = message(update);
-    const realUpdate = store.update.bind(store);
-    let fail = true;
-    store.update = async (...args) => {
-      if (fail) {
-        fail = false;
-        throw new Error('injected atomic materialization failure');
-      }
-      return realUpdate(...args);
-    };
+    vi.spyOn(store, 'replaceGraphAndSubject').mockRejectedValueOnce(
+      new Error('injected atomic materialization failure'),
+    );
 
     await handler.handle(encoded, 'forwarding-peer');
     expect(await store.countQuads(vmGraph)).toBe(1);

--- a/packages/publisher/test/ka-graph-update-handler.test.ts
+++ b/packages/publisher/test/ka-graph-update-handler.test.ts
@@ -329,6 +329,47 @@ describe('UpdateHandler graph-scoped updates', () => {
     )).toMatchObject({ type: 'boolean', value: true });
   });
 
+  it('keeps prior state replayable when atomic graph replacement is unsupported', async () => {
+    await seedPriorMetadata();
+    await store.insert([
+      { subject: 'urn:stale', predicate: 'urn:p:value', object: '"old"', graph: vmGraph },
+      { subject: 'urn:new', predicate: 'urn:p:value', object: '"new"', graph: swmGraph },
+    ]);
+    const update: Quad[] = [{
+      subject: 'urn:new', predicate: 'urn:p:value', object: '"new"', graph: '',
+    }];
+    const encoded = message(update);
+    const replacement = store.replaceGraphAndSubject.bind(store);
+    Object.defineProperty(store, 'replaceGraphAndSubject', {
+      configurable: true,
+      value: undefined,
+    });
+
+    await handler.handle(encoded, 'forwarding-peer');
+
+    expect(await store.query(
+      `ASK { GRAPH <${vmGraph}> { <urn:stale> <urn:p:value> "old" } }`,
+    )).toMatchObject({ type: 'boolean', value: true });
+    expect(await store.query(
+      `ASK { GRAPH <${META}> { <${UAL}> <${DKG}assertionVersion> "1"^^<${XSD}integer> } }`,
+    )).toMatchObject({ type: 'boolean', value: true });
+    expect(await store.countQuads(swmGraph)).toBe(1);
+
+    Object.defineProperty(store, 'replaceGraphAndSubject', {
+      configurable: true,
+      value: replacement,
+    });
+    await handler.handle(encoded, 'forwarding-peer');
+
+    expect(await store.query(
+      `ASK { GRAPH <${vmGraph}> { <urn:new> <urn:p:value> "new" } }`,
+    )).toMatchObject({ type: 'boolean', value: true });
+    expect(await store.query(
+      `ASK { GRAPH <${META}> { <${UAL}> <${DKG}assertionVersion> "2"^^<${XSD}integer> } }`,
+    )).toMatchObject({ type: 'boolean', value: true });
+    expect(await store.countQuads(swmGraph)).toBe(0);
+  });
+
   it('rejects non-canonical receiver RDF before materialization', async () => {
     await seedPriorMetadata();
     const update: Quad[] = [{

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -40,12 +40,12 @@ function makeQuad(s: string, p: string, o: string, g = 'urn:test:swm'): Quad {
  * hitting the live store. Mirrors `storeWithFailingOps` in
  * storage-ack-core-unavailable.test.ts — the curated-catalog store-failure
  * regressions below need the SAME real-store-with-armed-failure model so
- * they exercise the actual persist path (parse → verify → targeted update →
+ * they exercise the actual persist path (parse → verify → targeted delete →
  * insert) up to the failing store call.
  */
 function storeWithFailingOps(
   base: OxigraphStore,
-  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern' | 'update' | 'flush')[],
+  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern' | 'structuredMutation' | 'update' | 'flush')[],
 ): TripleStore {
   return new Proxy(base as unknown as TripleStore, {
     get(target, prop, receiver) {
@@ -1037,7 +1037,7 @@ describe('StorageACKHandler', () => {
     }
 
     async function curatedHandlerWithFailingStore(
-      failingOps: readonly ('deleteByPattern' | 'update' | 'insert' | 'flush')[],
+      failingOps: readonly ('deleteByPattern' | 'structuredMutation' | 'insert' | 'flush')[],
       configOverrides: Partial<StorageACKHandlerConfig> = {},
     ) {
       const base = new OxigraphStore();
@@ -1047,7 +1047,7 @@ describe('StorageACKHandler', () => {
       );
     }
 
-    it('uses one targeted update with graph hints, avoids deleteByPattern counts, and preserves unrelated subjects', async () => {
+    it('uses one targeted subject-set delete, avoids deleteByPattern counts, and preserves unrelated subjects', async () => {
       const catalogGraph = `${cgDid}/_catalog`;
       const unrelatedSubject = 'urn:test:unrelated-catalog-subject';
       const stalePredicate = 'urn:test:stale-catalog-predicate';
@@ -1056,14 +1056,14 @@ describe('StorageACKHandler', () => {
         { subject: cgDid, predicate: stalePredicate, object: '"stale"', graph: catalogGraph },
         { subject: unrelatedSubject, predicate: 'urn:test:kept', object: '"yes"', graph: catalogGraph },
       ]);
-      const updates: Array<{ sparql: string; options?: { source?: string; priority?: string; touchedGraphs?: readonly string[] } }> = [];
+      const deletes: Array<{ input: { graphUri: string; subjects: readonly string[] }; options?: { source?: string; priority?: string } }> = [];
       let deleteByPatternCalls = 0;
       const store = new Proxy(base as unknown as TripleStore, {
         get(target, prop, receiver) {
-          if (prop === 'update') {
-            return async (sparql: string, options?: { source?: string; priority?: string; touchedGraphs?: readonly string[] }) => {
-              updates.push({ sparql, options });
-              return target.update!.call(target, sparql, options);
+          if (prop === 'structuredMutation') {
+            return async (mutation: Parameters<NonNullable<TripleStore['structuredMutation']>>[0], options?: { source?: string; priority?: string }) => {
+              if (mutation.kind === 'delete-subjects') deletes.push({ input: mutation.input, options });
+              return target.structuredMutation!.call(target, mutation, options);
             };
           }
           if (prop === 'deleteByPattern') {
@@ -1082,12 +1082,11 @@ describe('StorageACKHandler', () => {
 
       expect(isStorageACKDecline(decoded)).toBe(false);
       expect(deleteByPatternCalls).toBe(0);
-      expect(updates).toHaveLength(1);
-      expect(updates[0]?.sparql).toContain(`VALUES ?s { <${cgDid}> }`);
-      expect(updates[0]?.options).toMatchObject({
-        source: 'storage-ack.persistCatalog.update',
+      expect(deletes).toHaveLength(1);
+      expect(deletes[0]?.input).toEqual({ graphUri: catalogGraph, subjects: [cgDid] });
+      expect(deletes[0]?.options).toMatchObject({
+        source: 'storage-ack.persistCatalog.deleteSubjects',
         priority: 'ack',
-        touchedGraphs: [catalogGraph],
       });
       const stale = await base.query(`ASK { GRAPH <${catalogGraph}> { <${cgDid}> <${stalePredicate}> ?o } }`);
       expect(stale).toMatchObject({ type: 'boolean', value: false });
@@ -1095,12 +1094,12 @@ describe('StorageACKHandler', () => {
       expect(unrelated).toMatchObject({ type: 'boolean', value: true });
     });
 
-    it('falls back to per-subject deleteByPattern when update() is unavailable', async () => {
+    it('falls back to per-subject deleteByPattern when deleteSubjects() is unavailable', async () => {
       const base = new OxigraphStore();
       let deleteByPatternCalls = 0;
       const store = new Proxy(base as unknown as TripleStore, {
         get(target, prop, receiver) {
-          if (prop === 'update') return undefined;
+          if (prop === 'structuredMutation') return undefined;
           if (prop === 'deleteByPattern') {
             return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
               deleteByPatternCalls += 1;
@@ -1119,12 +1118,12 @@ describe('StorageACKHandler', () => {
       expect(deleteByPatternCalls).toBe(1);
     });
 
-    it('falls back through a decorator whose inner store does not support update()', async () => {
+    it('falls back through a decorator whose inner store lacks deleteSubjects()', async () => {
       const base = new OxigraphStore();
       let deleteByPatternCalls = 0;
       const innerWithoutUpdate = new Proxy(base as unknown as TripleStore, {
         get(target, prop, receiver) {
-          if (prop === 'update') return undefined;
+          if (prop === 'structuredMutation') return undefined;
           if (prop === 'deleteByPattern') {
             return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
               deleteByPatternCalls += 1;
@@ -1136,7 +1135,7 @@ describe('StorageACKHandler', () => {
         },
       });
       const decoratedStore = new GraphSetIndexStore(innerWithoutUpdate);
-      expect(typeof decoratedStore.update).toBe('function');
+      expect(typeof decoratedStore.structuredMutation).toBe('function');
       const handler = curatedHandlerWithStore(decoratedStore);
 
       const decoded = decodeStorageACK(await handler.handler(curatedIntent(), fakePeerId));
@@ -1156,14 +1155,14 @@ describe('StorageACKHandler', () => {
       const blankCatalogBytes = new TextEncoder().encode(blankCatalogNquads);
       const blankCatalogRoot = computeCatalogRoot(blankCatalogTriples);
       const base = new OxigraphStore();
-      let updateCalls = 0;
+      let targetedDeleteCalls = 0;
       const deletedPatterns: Array<Partial<Quad>> = [];
       const store = new Proxy(base as unknown as TripleStore, {
         get(target, prop, receiver) {
-          if (prop === 'update') {
-            return async (...args: Parameters<NonNullable<TripleStore['update']>>) => {
-              updateCalls += 1;
-              return target.update!.call(target, ...args);
+          if (prop === 'structuredMutation') {
+            return async (...args: Parameters<NonNullable<TripleStore['structuredMutation']>>) => {
+              if (args[0].kind === 'delete-subjects') targetedDeleteCalls += 1;
+              return target.structuredMutation!.call(target, ...args);
             };
           }
           if (prop === 'deleteByPattern') {
@@ -1191,7 +1190,7 @@ describe('StorageACKHandler', () => {
       }), fakePeerId));
 
       expect(isStorageACKDecline(decoded)).toBe(false);
-      expect(updateCalls).toBe(0);
+      expect(targetedDeleteCalls).toBe(0);
       expect(deletedPatterns).toEqual([{
         graph: `${cgDid}/_catalog`,
         subject: '_:catalog',
@@ -1199,13 +1198,13 @@ describe('StorageACKHandler', () => {
       await expect(base.countQuads(`${cgDid}/_catalog`)).resolves.toBe(1);
     });
 
-    it('curated catalog persist / targeted update throws → CORE_TEMPORARILY_UNAVAILABLE ("store unavailable"), NO signed ACK', async () => {
+    it('curated catalog persist / targeted delete throws → CORE_TEMPORARILY_UNAVAILABLE ("store unavailable"), NO signed ACK', async () => {
       // Dead-air regression: a curated encrypted publish with a VALID catalog
-      // root whose `<cg>/_catalog` targeted DELETE update hits a closed
+      // root whose `<cg>/_catalog` targeted subject delete hits a closed
       // store used to throw out of the handler → stream reset → publisher
       // no_response. It must instead reply with the transient decline.
       const onDecline = vi.fn();
-      const handler = await curatedHandlerWithFailingStore(['update'], { onDecline });
+      const handler = await curatedHandlerWithFailingStore(['structuredMutation'], { onDecline });
       const decoded = decodeStorageACK(await handler.handler(curatedIntent(), fakePeerId));
 
       expect(isStorageACKDecline(decoded)).toBe(true);

--- a/packages/publisher/test/ual-lookup-and-update-extra.test.ts
+++ b/packages/publisher/test/ual-lookup-and-update-extra.test.ts
@@ -28,7 +28,7 @@
  * pinned against the expected behavior; if the metadata resolver
  * regresses, the failures ARE the bug signal.
  */
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { resolveUalByBatchId, updateMetaMerkleRoot } from '../src/index.js';
 import { GraphManager } from '@origintrail-official/dkg-storage';
@@ -109,6 +109,48 @@ describe('P-18: resolveUalByBatchId uses a typed integer literal (batchId 1 ≠ 
   it('batchId=10 resolves to the "/10" UAL (no prefix collision with batchId=1)', async () => {
     const result = await resolveUalByBatchId(store, metaGraph, BATCH_10);
     expect(result).toBe(UAL_10);
+  });
+
+  it('updates the root through the predicate capability without a mutating query', async () => {
+    const DKG = 'http://dkg.io/ontology/';
+    await store.insert([{
+      subject: UAL_1,
+      predicate: `${DKG}merkleRoot`,
+      object: '"old-root"',
+      graph: metaGraph,
+    }]);
+    const originalQuery = store.query.bind(store);
+    const mutatingQueries: string[] = [];
+    vi.spyOn(store, 'query').mockImplementation(async (sparql, options) => {
+      if (/\b(?:INSERT|DELETE|DROP|CLEAR|COPY|MOVE|ADD|LOAD)\b/i.test(sparql)) {
+        mutatingQueries.push(sparql);
+        throw new Error('mutating query channel reached');
+      }
+      return originalQuery(sparql, options);
+    });
+    const replace = vi.spyOn(store, 'structuredMutation');
+    const newRoot = new Uint8Array(32).fill(0x5a);
+
+    await updateMetaMerkleRoot(store, new GraphManager(store), CG, BATCH_1, newRoot);
+
+    expect(mutatingQueries).toEqual([]);
+    expect(replace).toHaveBeenCalledWith({ kind: 'replace-subject-predicates', input: {
+      graphUri: metaGraph,
+      subject: UAL_1,
+      predicates: [`${DKG}merkleRoot`],
+      replacementQuads: [{
+        subject: UAL_1,
+        predicate: `${DKG}merkleRoot`,
+        object: `"${'5a'.repeat(32)}"`,
+        graph: metaGraph,
+      }],
+    } }, { source: 'publisher.metadata.updateMerkleRoot' });
+    const roots = await originalQuery(
+      `SELECT ?root WHERE { GRAPH <${metaGraph}> { <${UAL_1}> <${DKG}merkleRoot> ?root } }`,
+    );
+    expect(roots.type === 'bindings' ? roots.bindings : []).toEqual([
+      { root: `"${'5a'.repeat(32)}"` },
+    ]);
   });
 
   it('batchId that would substring-match a real row still returns undefined', async () => {

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -10,6 +10,7 @@ import type {
   SelectResult,
   ConstructResult,
   AskResult,
+  StructuredMutation,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { buildBlankNodeSafeDelete } from './sparql-http.js';
@@ -31,6 +32,11 @@ import {
   buildAtomicSubjectReplaceUpdate,
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
+import {
+  buildStructuredMutationUpdate,
+  normalizeStructuredMutation,
+  structuredMutationMightMutate,
+} from '../bounded-structured-mutation.js';
 import { quadToNQuad } from '../bounded-rdf.js';
 import { readResponseTextBounded } from '../http-response-limit.js';
 
@@ -403,6 +409,26 @@ export class BlazegraphStore implements TripleStore {
       buildAtomicSubjectReplaceUpdate(graphUri, subject, quads),
       { ...options, source: options?.source ?? 'blazegraph.replaceSubject' },
       'replaceSubject',
+    );
+  }
+
+  async structuredMutation(
+    mutation: StructuredMutation,
+    options?: QueryOptions,
+  ): Promise<void> {
+    const normalized = normalizeStructuredMutation(mutation);
+    if (normalized.kind === 'replace-subject-predicates') {
+      assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
+        maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
+        label: 'BlazegraphStore.structuredMutation',
+      });
+    }
+    const update = buildStructuredMutationUpdate(normalized);
+    if (!update || !structuredMutationMightMutate(normalized)) return;
+    await this.sparqlUpdate(
+      update,
+      { ...options, source: options?.source ?? 'blazegraph.structuredMutation' },
+      'structuredMutation',
     );
   }
 

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -2,9 +2,21 @@ import { Worker } from 'node:worker_threads';
 import { existsSync } from 'node:fs';
 import { sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { TripleStore, Quad, TripleStoreQueryOptions, QueryResult, UpdateOptions } from '../triple-store.js';
+import type {
+  TripleStore,
+  Quad,
+  TripleStoreQueryOptions,
+  QueryResult,
+  UpdateOptions,
+  StructuredMutation,
+} from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { GraphWriteGenTracker } from '../graph-write-gen.js';
+import {
+  normalizeStructuredMutation,
+  structuredMutationMightMutate,
+  structuredMutationTouchedGraphs,
+} from '../bounded-structured-mutation.js';
 
 /**
  * Default per-operation timeout for the embedded worker store. The worker is
@@ -678,6 +690,18 @@ export class OxigraphWorkerStore implements TripleStore {
     // single-message commit, same contract as insert/replaceGraph.
     await this.call('replaceSubject', graphUri, subject, quads);
     this.writeGen.recordGraphWrites([graphUri]);
+  }
+  async structuredMutation(
+    mutation: StructuredMutation,
+    // Mutations intentionally use the unbounded, non-cancellable worker lane:
+    // aborting the caller could report failure while the worker later commits.
+    _options?: TripleStoreQueryOptions,
+  ): Promise<void> {
+    const normalized = normalizeStructuredMutation(mutation);
+    await this.call('structuredMutation', normalized);
+    if (structuredMutationMightMutate(normalized)) {
+      this.writeGen.recordGraphWrites(structuredMutationTouchedGraphs(normalized));
+    }
   }
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     return this.callWithTimeout<QueryResult>(this.operationTimeoutMs, options?.signal, 'query', sparql);

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -12,6 +12,7 @@ import type {
   AskResult,
   TripleStoreQueryOptions,
   UpdateOptions,
+  StructuredMutation,
 } from '../triple-store.js';
 import {
   formatCanonicalRdfLiteralTerm,
@@ -25,6 +26,12 @@ import {
   buildAtomicSubjectReplaceUpdate,
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
+import {
+  buildStructuredMutationUpdate,
+  normalizeStructuredMutation,
+  structuredMutationMightMutate,
+  structuredMutationTouchedGraphs,
+} from '../bounded-structured-mutation.js';
 import { quadsToNQuads } from '../bounded-rdf.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 
@@ -405,6 +412,26 @@ export class OxigraphStore implements TripleStore {
     this.store.update(buildAtomicSubjectReplaceUpdate(graphUri, subject, quads));
     this.scheduleFlush();
     this.writeGen.recordGraphWrites([graphUri]);
+  }
+
+  async structuredMutation(
+    mutation: StructuredMutation,
+    // Embedded mutations are synchronous and cannot be safely cancelled after
+    // dispatch; source/priority are advisory only for scheduled HTTP stores.
+    _options?: TripleStoreQueryOptions,
+  ): Promise<void> {
+    const normalized = normalizeStructuredMutation(mutation);
+    if (normalized.kind === 'replace-subject-predicates') {
+      assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
+        maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
+        label: 'OxigraphStore.structuredMutation',
+      });
+    }
+    const update = buildStructuredMutationUpdate(normalized);
+    if (!update || !structuredMutationMightMutate(normalized)) return;
+    this.store.update(update);
+    this.scheduleFlush();
+    this.writeGen.recordGraphWrites(structuredMutationTouchedGraphs(normalized));
   }
 
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -31,6 +31,7 @@ import type {
   ConstructResult,
   AskResult,
   StorePressureSnapshot,
+  StructuredMutation,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { SPARQL_QUERY_CONTENT_TYPE, SPARQL_UPDATE_CONTENT_TYPE } from './sparql-content-types.js';
@@ -51,6 +52,13 @@ import {
   buildAtomicSubjectReplaceUpdate,
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
+import {
+  buildStructuredMutationUpdate,
+  normalizeStructuredMutation,
+  structuredMutationGuardedGraphs,
+  structuredMutationMightMutate,
+  structuredMutationTouchedGraphs,
+} from '../bounded-structured-mutation.js';
 import {
   assertNotReservedInternalGraphV1,
   isInternalGraphUriV1,
@@ -1243,6 +1251,40 @@ export class SparqlHttpStore implements TripleStore {
     }
     this.invalidateListGraphsCache();
     this.writeGen.recordGraphWrites([graphUri]);
+  }
+
+  async structuredMutation(
+    mutation: StructuredMutation,
+    options?: QueryOptions,
+  ): Promise<void> {
+    const normalized = normalizeStructuredMutation(mutation);
+    const touchedGraphs = structuredMutationTouchedGraphs(normalized);
+    this.assertGenericMutationScope(structuredMutationGuardedGraphs(normalized), 'structuredMutation');
+    if (normalized.kind === 'replace-subject-predicates') {
+      assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
+        maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
+        label: 'SparqlHttpStore.structuredMutation',
+      });
+    }
+    const update = buildStructuredMutationUpdate(normalized);
+    if (!update || !structuredMutationMightMutate(normalized)) return;
+    try {
+      await this.postUpdate(
+        update,
+        { ...options, source: options?.source ?? 'sparql-http.structuredMutation' },
+        'structuredMutation',
+        touchedGraphs,
+      );
+    } catch (error) {
+      // A remote endpoint may commit before its response is lost. Fail open for
+      // cache coherence: invalidate graph enumeration and advance each affected
+      // write generation even though the caller still receives the failure.
+      this.invalidateListGraphsCache();
+      this.writeGen.recordGraphWrites(touchedGraphs);
+      throw error;
+    }
+    this.invalidateListGraphsCache();
+    this.writeGen.recordGraphWrites(touchedGraphs);
   }
 
   async query(sparql: string, options?: SparqlHttpQueryOptions): Promise<QueryResult> {

--- a/packages/storage/src/atomic-graph-replace.ts
+++ b/packages/storage/src/atomic-graph-replace.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from 'node:crypto';
-import {
-  assertSafeIri,
-  assertSafeRdfTerm,
-} from '@origintrail-official/dkg-core';
+import { assertSafeIri } from '@origintrail-official/dkg-core';
 import type { Quad } from './triple-store.js';
+import {
+  formatRdfObjectTerm,
+  formatRdfResourceTerm,
+  unwrapIriTerm,
+} from './rdf-term-format.js';
 
 /** Never expose these operation-internal graphs through graph enumeration. */
 export const ATOMIC_GRAPH_REPLACE_STAGING_PREFIX =
@@ -47,7 +49,7 @@ export function buildAtomicGraphReplaceUpdate(
 
   const stagingGraph = `${ATOMIC_GRAPH_REPLACE_STAGING_PREFIX}${randomUUID()}`;
   const triples = quads
-    .map((quad) => `    ${formatResource(quad.subject, 'subject')} <${assertSafeIri(unwrapIri(quad.predicate))}> ${formatObject(quad.object)} .`)
+    .map((quad) => `    ${formatRdfResourceTerm(quad.subject, 'Atomic graph replacement subject')} <${assertSafeIri(unwrapIriTerm(quad.predicate))}> ${formatRdfObjectTerm(quad.object, 'Atomic graph replacement object')} .`)
     .join('\n');
   const cleanup = `DROP SILENT GRAPH <${stagingGraph}>`;
   return {
@@ -216,36 +218,7 @@ export function assertSubjectReplacementPayload(
 
 function formatGraphBlock(graphUri: string, quads: readonly Quad[]): string {
   const triples = quads
-    .map((quad) => `    ${formatResource(quad.subject, 'subject')} <${assertSafeIri(unwrapIri(quad.predicate))}> ${formatObject(quad.object)} .`)
+    .map((quad) => `    ${formatRdfResourceTerm(quad.subject, 'Atomic graph replacement subject')} <${assertSafeIri(unwrapIriTerm(quad.predicate))}> ${formatRdfObjectTerm(quad.object, 'Atomic graph replacement object')} .`)
     .join('\n');
   return `  GRAPH <${graphUri}> {\n${triples}\n  }`;
-}
-
-function formatResource(term: string, role: string): string {
-  if (term.startsWith('"')) {
-    throw new Error(`Atomic graph replacement ${role} must be an IRI`);
-  }
-  return `<${assertSafeIri(unwrapIri(term))}>`;
-}
-
-function formatObject(term: string): string {
-  if (term.startsWith('"')) {
-    const normalized = normalizeLiteralDatatype(term);
-    assertSafeRdfTerm(normalized);
-    return normalized;
-  }
-  return formatResource(term, 'object');
-}
-
-function normalizeLiteralDatatype(term: string): string {
-  const bareDatatype = term.match(/^("(?:[^"\\]|\\.)*")\^\^(?!<)(.+)$/);
-  return bareDatatype
-    ? `${bareDatatype[1]}^^<${assertSafeIri(unwrapIri(bareDatatype[2]))}>`
-    : term;
-}
-
-function unwrapIri(term: string): string {
-  return term.startsWith('<') && term.endsWith('>')
-    ? term.slice(1, -1)
-    : term;
 }

--- a/packages/storage/src/bounded-structured-mutation.ts
+++ b/packages/storage/src/bounded-structured-mutation.ts
@@ -1,0 +1,682 @@
+import {
+  isSafeIri,
+  sparqlInt,
+  sparqlString,
+} from '@origintrail-official/dkg-core';
+import type {
+  CopySubjectProjectionInput,
+  DeleteSubjectsInput,
+  PruneLinkedRecordClosuresInput,
+  PruneRankedSubjectsInput,
+  Quad,
+  ReplaceProjectionFromGraphInput,
+  ReplaceSubjectPredicatesInput,
+  StructuredMutation,
+} from './triple-store.js';
+import { formatRdfObjectTerm } from './rdf-term-format.js';
+
+export const BOUNDED_MUTATION_MAX_IRIS = 100_000;
+export const BOUNDED_MUTATION_MAX_PRUNE_DELETE = 10_000;
+export const BOUNDED_MUTATION_MAX_OPERAND_BYTES = 4 * 1024 * 1024;
+export const BOUNDED_MUTATION_MAX_UPDATE_BYTES = 4 * 1024 * 1024;
+export const BOUNDED_MUTATION_MAX_SOURCE_GRAPHS = 8;
+export const BOUNDED_MUTATION_MAX_PREDICATES = 64;
+export const BOUNDED_MUTATION_MAX_PREFIXES = 64;
+
+const UTF8 = new TextEncoder();
+
+class BoundedMutationBudgetError extends Error {}
+
+function unsupportedMutation(mutation: never): never {
+  throw new Error(`Unsupported structured mutation kind ${String((mutation as { kind?: unknown })?.kind)}`);
+}
+
+function boundedInteger(value: number, label: string, max: number): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > max) {
+    throw new Error(`${label} must be an integer in 0..${max}`);
+  }
+  return value;
+}
+
+function boundedString(value: string, label: string, maxBytes = 512): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (UTF8.encode(value).byteLength > maxBytes) {
+    throw new Error(`${label} exceeds ${maxBytes} UTF-8 bytes`);
+  }
+  return value;
+}
+
+function absoluteIri(value: string, label: string): string {
+  if (typeof value !== 'string' || !isSafeIri(value)) {
+    throw new Error(`${label} must be an absolute IRI`);
+  }
+  return value;
+}
+
+function normalizeStructuredRdfObject(value: string, label: string): string {
+  try {
+    return formatRdfObjectTerm(value, label, absoluteIri);
+  } catch {
+    throw new Error(`${label} must be a safe RDF literal or absolute IRI`);
+  }
+}
+
+function uniqueIris(
+  values: readonly string[],
+  label: string,
+  max = BOUNDED_MUTATION_MAX_IRIS,
+  allowEmpty = false,
+): string[] {
+  if (!Array.isArray(values) || (!allowEmpty && values.length === 0) || values.length > max) {
+    throw new Error(`${label} must contain ${allowEmpty ? '0' : '1'}..${max} IRIs`);
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (let index = 0; index < values.length; index++) {
+    if (!(index in values)) throw new Error(`${label} must be a dense array`);
+    const iri = absoluteIri(values[index], `${label}[${index}]`);
+    if (seen.has(iri)) throw new Error(`${label} contains duplicate IRI ${iri}`);
+    seen.add(iri);
+    result.push(iri);
+  }
+  return result;
+}
+
+function boundedUniqueStrings(
+  values: readonly string[],
+  label: string,
+  max: number,
+): string[] {
+  if (!Array.isArray(values) || values.length === 0 || values.length > max) {
+    throw new Error(`${label} must contain 1..${max} values`);
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (let index = 0; index < values.length; index++) {
+    if (!(index in values)) throw new Error(`${label} must be a dense array`);
+    const value = boundedString(values[index], `${label}[${index}]`);
+    if (seen.has(value)) throw new Error(`${label} contains duplicate value ${value}`);
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function assertOperandBudget(label: string, values: readonly string[]): void {
+  let bytes = 0;
+  for (const value of values) {
+    bytes += UTF8.encode(value).byteLength;
+    if (bytes > BOUNDED_MUTATION_MAX_OPERAND_BYTES) {
+      throw new BoundedMutationBudgetError(
+        `${label} exceeds ${BOUNDED_MUTATION_MAX_OPERAND_BYTES} operand bytes`,
+      );
+    }
+  }
+}
+
+export function assertBoundedStructuredUpdate(label: string, update: string): string {
+  const bytes = UTF8.encode(update).byteLength;
+  if (bytes > BOUNDED_MUTATION_MAX_UPDATE_BYTES) {
+    throw new BoundedMutationBudgetError(
+      `${label} serialized update exceeds ${BOUNDED_MUTATION_MAX_UPDATE_BYTES} UTF-8 bytes`,
+    );
+  }
+  return update;
+}
+
+export function normalizeDeleteSubjectsInput(input: DeleteSubjectsInput): DeleteSubjectsInput {
+  const graphUri = absoluteIri(input.graphUri, 'deleteSubjects.graphUri');
+  const subjects = uniqueIris(input.subjects, 'deleteSubjects.subjects', undefined, true);
+  assertOperandBudget('deleteSubjects', [graphUri, ...subjects]);
+  return { graphUri, subjects };
+}
+
+export function buildDeleteSubjectsUpdate(input: DeleteSubjectsInput): string | undefined {
+  const normalized = normalizeDeleteSubjectsInput(input);
+  if (normalized.subjects.length === 0) return undefined;
+  const values = normalized.subjects.map((subject) => `<${subject}>`).join(' ');
+  return assertBoundedStructuredUpdate('deleteSubjects', `DELETE { GRAPH <${normalized.graphUri}> { ?subject ?predicate ?object } }
+WHERE { GRAPH <${normalized.graphUri}> {
+  VALUES ?subject { ${values} }
+  ?subject ?predicate ?object
+} }`);
+}
+
+export function normalizePruneRankedSubjectsInput(
+  input: PruneRankedSubjectsInput,
+): PruneRankedSubjectsInput {
+  const graphUri = absoluteIri(input.graphUri, 'pruneRankedSubjects.graphUri');
+  const subjectPrefix = absoluteIri(input.subjectPrefix, 'pruneRankedSubjects.subjectPrefix');
+  const eligibilityPredicate = absoluteIri(
+    input.eligibilityPredicate,
+    'pruneRankedSubjects.eligibilityPredicate',
+  );
+  const primaryRankPredicate = absoluteIri(
+    input.primaryRankPredicate,
+    'pruneRankedSubjects.primaryRankPredicate',
+  );
+  const secondaryRankPredicate = absoluteIri(
+    input.secondaryRankPredicate,
+    'pruneRankedSubjects.secondaryRankPredicate',
+  );
+  const eligibleObjects = boundedUniqueStrings(
+    input.eligibleObjects,
+    'pruneRankedSubjects.eligibleObjects',
+    16,
+  );
+  const retainNewest = boundedInteger(
+    input.retainNewest,
+    'pruneRankedSubjects.retainNewest',
+    BOUNDED_MUTATION_MAX_IRIS,
+  );
+  const maxDelete = boundedInteger(
+    input.maxDelete,
+    'pruneRankedSubjects.maxDelete',
+    BOUNDED_MUTATION_MAX_PRUNE_DELETE,
+  );
+  if (maxDelete === 0) throw new Error('pruneRankedSubjects.maxDelete must be positive');
+  assertOperandBudget('pruneRankedSubjects', [
+    graphUri,
+    subjectPrefix,
+    eligibilityPredicate,
+    primaryRankPredicate,
+    secondaryRankPredicate,
+    ...eligibleObjects,
+  ]);
+  return {
+    graphUri,
+    subjectPrefix,
+    eligibilityPredicate,
+    eligibleObjects,
+    primaryRankPredicate,
+    secondaryRankPredicate,
+    retainNewest,
+    maxDelete,
+  };
+}
+
+export function buildPruneRankedSubjectsUpdate(input: PruneRankedSubjectsInput): string {
+  const normalized = normalizePruneRankedSubjectsInput(input);
+  const eligibleObjects = normalized.eligibleObjects.map(sparqlString).join(' ');
+  const eligibilityFilter = `VALUES ?eligibleObject { ${eligibleObjects} }
+      FILTER NOT EXISTS {
+        ?subject <${normalized.eligibilityPredicate}> ?ineligibleObject .
+        FILTER(?ineligibleObject NOT IN (${normalized.eligibleObjects.map(sparqlString).join(', ')}))
+      }`;
+  return assertBoundedStructuredUpdate('pruneRankedSubjects', `PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+DELETE { GRAPH <${normalized.graphUri}> { ?subject ?predicate ?object } }
+WHERE {
+  {
+    SELECT ?subject
+           (MAX(?primaryRank) AS ?latestPrimaryRank)
+           (MAX(?secondaryRank) AS ?latestSecondaryRank)
+    WHERE {
+      GRAPH <${normalized.graphUri}> {
+        ?subject <${normalized.eligibilityPredicate}> ?eligibleObject .
+        OPTIONAL { ?subject <${normalized.primaryRankPredicate}> ?primaryRank }
+        OPTIONAL { ?subject <${normalized.secondaryRankPredicate}> ?secondaryRank }
+        ${eligibilityFilter}
+        FILTER(STRSTARTS(STR(?subject), ${sparqlString(normalized.subjectPrefix)}))
+      }
+    }
+    # sparql-scan-allow: R3 -- one bounded retention prune; OFFSET <= 100000 and LIMIT <= 10000; never page-walked
+    GROUP BY ?subject
+    ORDER BY DESC(COALESCE(
+      xsd:integer(STR(?latestPrimaryRank)),
+      xsd:integer(STR(?latestSecondaryRank)),
+      0
+    )) DESC(STR(?subject))
+    OFFSET ${sparqlInt(normalized.retainNewest, { min: 0 })}
+    LIMIT ${sparqlInt(normalized.maxDelete, { min: 1 })}
+  }
+  GRAPH <${normalized.graphUri}> {
+    ?subject <${normalized.eligibilityPredicate}> ?eligibleObject ; ?predicate ?object .
+    ${eligibilityFilter}
+    FILTER(STRSTARTS(STR(?subject), ${sparqlString(normalized.subjectPrefix)}))
+  }
+}`);
+}
+
+export function normalizePruneLinkedRecordClosuresInput(
+  input: PruneLinkedRecordClosuresInput,
+): PruneLinkedRecordClosuresInput {
+  const graphUri = absoluteIri(input.graphUri, 'pruneLinkedRecordClosures.graphUri');
+  const matchObjectIris = uniqueIris(
+    input.matchObjectIris,
+    'pruneLinkedRecordClosures.matchObjectIris',
+  );
+  const linkPredicates = uniqueIris(
+    input.linkPredicates,
+    'pruneLinkedRecordClosures.linkPredicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+  );
+  const recordParentPredicate = absoluteIri(
+    input.recordParentPredicate,
+    'pruneLinkedRecordClosures.recordParentPredicate',
+  );
+  const protectedRecordIri = input.protectedRecordIri === undefined
+    ? undefined
+    : absoluteIri(input.protectedRecordIri, 'pruneLinkedRecordClosures.protectedRecordIri');
+  const descendantSeparator = boundedString(
+    input.descendantSeparator,
+    'pruneLinkedRecordClosures.descendantSeparator',
+    64,
+  );
+  assertOperandBudget('pruneLinkedRecordClosures', [
+    graphUri,
+    ...matchObjectIris,
+    ...linkPredicates,
+    recordParentPredicate,
+    descendantSeparator,
+    ...(protectedRecordIri ? [protectedRecordIri] : []),
+  ]);
+  return {
+    graphUri,
+    matchObjectIris,
+    linkPredicates,
+    recordParentPredicate,
+    protectedRecordIri,
+    descendantSeparator,
+  };
+}
+
+export function buildPruneLinkedRecordClosuresUpdate(input: PruneLinkedRecordClosuresInput): string {
+  const normalized = normalizePruneLinkedRecordClosuresInput(input);
+  const matchObjects = normalized.matchObjectIris.map((root) => `<${root}>`).join(' ');
+  const linkPredicates = normalized.linkPredicates
+    .map((predicate) => `<${predicate}>`)
+    .join(' ');
+  const keepFilter = normalized.protectedRecordIri
+    ? `FILTER(?record != <${normalized.protectedRecordIri}>)`
+    : '';
+  return assertBoundedStructuredUpdate('pruneLinkedRecordClosures', `DELETE { GRAPH <${normalized.graphUri}> { ?subject ?predicate ?object } }
+WHERE { GRAPH <${normalized.graphUri}> {
+  VALUES ?matchObject { ${matchObjects} }
+  VALUES ?linkPredicate { ${linkPredicates} }
+  ?member ?linkPredicate ?matchObject .
+  OPTIONAL { ?member <${normalized.recordParentPredicate}> ?parent }
+  BIND(COALESCE(?parent, ?member) AS ?record)
+  ${keepFilter}
+  ?subject ?predicate ?object .
+  FILTER(?subject = ?record || STRSTARTS(STR(?subject), CONCAT(STR(?record), ${sparqlString(normalized.descendantSeparator)})))
+} }`);
+}
+
+export function normalizeReplaceProjectionFromGraphInput(
+  input: ReplaceProjectionFromGraphInput,
+): ReplaceProjectionFromGraphInput {
+  const targetGraphUri = absoluteIri(
+    input.targetGraphUri,
+    'replaceProjectionFromGraph.targetGraphUri',
+  );
+  const stagingGraphUri = absoluteIri(
+    input.stagingGraphUri,
+    'replaceProjectionFromGraph.stagingGraphUri',
+  );
+  if (targetGraphUri === stagingGraphUri) {
+    throw new Error('replaceProjectionFromGraph requires distinct target and staging graphs');
+  }
+  const targetSubject = absoluteIri(
+    input.targetSubject,
+    'replaceProjectionFromGraph.targetSubject',
+  );
+  const preservedTargetPredicates = uniqueIris(
+    input.preservedTargetPredicates,
+    'replaceProjectionFromGraph.preservedTargetPredicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+    true,
+  );
+  const targetSubjectPrefixes = uniqueIris(
+    input.targetSubjectPrefixes,
+    'replaceProjectionFromGraph.targetSubjectPrefixes',
+    BOUNDED_MUTATION_MAX_PREFIXES,
+    true,
+  );
+  assertOperandBudget('replaceProjectionFromGraph', [
+    targetGraphUri,
+    stagingGraphUri,
+    targetSubject,
+    ...preservedTargetPredicates,
+    ...targetSubjectPrefixes,
+  ]);
+  return {
+    targetGraphUri,
+    stagingGraphUri,
+    targetSubject,
+    preservedTargetPredicates,
+    targetSubjectPrefixes,
+  };
+}
+
+function normalizeReplaceSubjectPredicatesInputInternal(
+  input: ReplaceSubjectPredicatesInput,
+  enforceOperandBudget: boolean,
+): ReplaceSubjectPredicatesInput {
+  const graphUri = absoluteIri(input.graphUri, 'replaceSubjectPredicates.graphUri');
+  const subject = absoluteIri(input.subject, 'replaceSubjectPredicates.subject');
+  const predicates = uniqueIris(
+    input.predicates,
+    'replaceSubjectPredicates.predicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+  );
+  if (!Array.isArray(input.replacementQuads)
+    || input.replacementQuads.length > BOUNDED_MUTATION_MAX_IRIS) {
+    throw new Error(
+      `replaceSubjectPredicates.replacementQuads must contain 0..${BOUNDED_MUTATION_MAX_IRIS} quads`,
+    );
+  }
+  for (let index = 0; index < input.replacementQuads.length; index++) {
+    if (!(index in input.replacementQuads)) {
+      throw new Error('replaceSubjectPredicates.replacementQuads must be a dense array');
+    }
+  }
+  const allowedPredicates = new Set(predicates);
+  const replacementQuads = input.replacementQuads.map((quad, index) => {
+    if (quad.graph !== graphUri || quad.subject !== subject) {
+      throw new Error(
+        `replaceSubjectPredicates quad ${index} must target subject ${subject} in graph ${graphUri}`,
+      );
+    }
+    const predicate = absoluteIri(
+      quad.predicate,
+      `replaceSubjectPredicates.replacementQuads[${index}].predicate`,
+    );
+    if (!allowedPredicates.has(predicate)) {
+      throw new Error(`replaceSubjectPredicates quad ${index} targets undeclared predicate ${predicate}`);
+    }
+    const object = normalizeStructuredRdfObject(
+      quad.object,
+      `replaceSubjectPredicates.replacementQuads[${index}].object`,
+    );
+    return { ...quad, predicate, object };
+  });
+  if (enforceOperandBudget) {
+    assertOperandBudget('replaceSubjectPredicates', [
+      graphUri,
+      subject,
+      ...predicates,
+      ...replacementQuads.flatMap((quad) => [
+        quad.subject,
+        quad.predicate,
+        quad.object,
+        quad.graph,
+      ]),
+    ]);
+  }
+  return { graphUri, subject, predicates, replacementQuads };
+}
+
+export function normalizeReplaceSubjectPredicatesInput(
+  input: ReplaceSubjectPredicatesInput,
+): ReplaceSubjectPredicatesInput {
+  return normalizeReplaceSubjectPredicatesInputInternal(input, true);
+}
+
+/**
+ * Validate and canonicalize a predicate replacement before a storage decorator
+ * rewrites its RDF objects. The final, rewritten mutation must still pass the
+ * normal bounded validator before it reaches an adapter.
+ */
+export function normalizeReplaceSubjectPredicatesInputForObjectRewrite(
+  input: ReplaceSubjectPredicatesInput,
+): ReplaceSubjectPredicatesInput {
+  return normalizeReplaceSubjectPredicatesInputInternal(input, false);
+}
+
+export function buildReplaceSubjectPredicatesUpdate(
+  input: ReplaceSubjectPredicatesInput,
+): string {
+  const normalized = normalizeReplaceSubjectPredicatesInput(input);
+  const predicateValues = normalized.predicates.map((predicate) => `<${predicate}>`).join(', ');
+  const insertion = normalized.replacementQuads.length > 0
+    ? `INSERT {
+  GRAPH <${normalized.graphUri}> {
+${normalized.replacementQuads.map((quad) => `    <${quad.subject}> <${quad.predicate}> ${quad.object} .`).join('\n')}
+  }
+}
+`
+    : '';
+  return assertBoundedStructuredUpdate('replaceSubjectPredicates', `DELETE {
+  GRAPH <${normalized.graphUri}> { <${normalized.subject}> ?predicate ?oldObject }
+}
+${insertion}WHERE {
+  OPTIONAL {
+    GRAPH <${normalized.graphUri}> {
+      <${normalized.subject}> ?predicate ?oldObject .
+      FILTER(?predicate IN (${predicateValues}))
+    }
+  }
+}`);
+}
+
+export function buildReplaceProjectionFromGraphUpdate(
+  input: ReplaceProjectionFromGraphInput,
+): string {
+  const normalized = normalizeReplaceProjectionFromGraphInput(input);
+  const preserved = normalized.preservedTargetPredicates.length > 0
+    ? ` && ?stalePredicate NOT IN (${normalized.preservedTargetPredicates.map((iri) => `<${iri}>`).join(', ')})`
+    : '';
+  const prefixes = normalized.targetSubjectPrefixes
+    .map((prefix) => `STRSTARTS(STR(?staleSubject), ${sparqlString(prefix)})`);
+  const staleScopes = [
+    `(?staleSubject = <${normalized.targetSubject}>${preserved})`,
+    ...prefixes,
+  ].join(' || ');
+  const freshScopes = [
+    `?freshSubject = <${normalized.targetSubject}>`,
+    ...normalized.targetSubjectPrefixes.map(
+      (prefix) => `STRSTARTS(STR(?freshSubject), ${sparqlString(prefix)})`,
+    ),
+  ].join(' || ');
+  return assertBoundedStructuredUpdate('replaceProjectionFromGraph', `DELETE {
+  GRAPH <${normalized.targetGraphUri}> { ?staleSubject ?stalePredicate ?staleObject }
+}
+INSERT {
+  GRAPH <${normalized.targetGraphUri}> { ?freshSubject ?freshPredicate ?freshObject }
+}
+WHERE {
+  {
+    GRAPH <${normalized.targetGraphUri}> {
+      ?staleSubject ?stalePredicate ?staleObject .
+      FILTER(${staleScopes})
+    }
+  }
+  UNION
+  {
+    GRAPH <${normalized.stagingGraphUri}> {
+      ?freshSubject ?freshPredicate ?freshObject .
+      FILTER(${freshScopes})
+    }
+  }
+}`);
+}
+
+export function normalizeCopySubjectProjectionInput(
+  input: CopySubjectProjectionInput,
+): CopySubjectProjectionInput {
+  const sourceGraphUris = uniqueIris(
+    input.sourceGraphUris,
+    'copySubjectProjection.sourceGraphUris',
+    BOUNDED_MUTATION_MAX_SOURCE_GRAPHS,
+  );
+  const targetGraphUri = absoluteIri(input.targetGraphUri, 'copySubjectProjection.targetGraphUri');
+  if (sourceGraphUris.includes(targetGraphUri)) {
+    throw new Error('copySubjectProjection target graph must not be a source graph');
+  }
+  const roots = uniqueIris(input.roots, 'copySubjectProjection.roots');
+  const descendantSuffix = boundedString(
+    input.descendantSuffix,
+    'copySubjectProjection.descendantSuffix',
+    256,
+  );
+  if (!descendantSuffix.startsWith('/')) {
+    throw new Error('copySubjectProjection.descendantSuffix must start with /');
+  }
+  const excludedPredicates = uniqueIris(
+    input.excludedPredicates,
+    'copySubjectProjection.excludedPredicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+    true,
+  );
+  assertOperandBudget('copySubjectProjection', [
+    ...sourceGraphUris,
+    targetGraphUri,
+    ...roots,
+    descendantSuffix,
+    ...excludedPredicates,
+  ]);
+  return {
+    sourceGraphUris,
+    targetGraphUri,
+    roots,
+    descendantSuffix,
+    excludedPredicates,
+  };
+}
+
+export function buildCopySubjectProjectionUpdate(input: CopySubjectProjectionInput): string {
+  const normalized = normalizeCopySubjectProjectionInput(input);
+  const sources = normalized.sourceGraphUris.map((graph) => `<${graph}>`).join(' ');
+  const roots = normalized.roots.map((root) => `<${root}>`).join(' ');
+  const excluded = normalized.excludedPredicates.length > 0
+    ? `FILTER(?predicate NOT IN (${normalized.excludedPredicates.map((iri) => `<${iri}>`).join(', ')}))`
+    : '';
+  return assertBoundedStructuredUpdate('copySubjectProjection', `INSERT { GRAPH <${normalized.targetGraphUri}> { ?subject ?predicate ?object } }
+WHERE {
+  VALUES ?sourceGraph { ${sources} }
+  VALUES ?root { ${roots} }
+  # sparql-scan-allow: R2 -- ?sourceGraph is VALUES-bound to at most 8 validated exact graph IRIs
+  GRAPH ?sourceGraph { ?subject ?predicate ?object }
+  FILTER(?subject = ?root || STRSTARTS(STR(?subject), CONCAT(STR(?root), ${sparqlString(normalized.descendantSuffix)})))
+  ${excluded}
+}`);
+}
+
+/**
+ * Split a subject-projection copy into the largest ordered root batches that
+ * fit both structured-mutation byte limits. Each returned descriptor is
+ * independently valid and preserves the caller's root order.
+ */
+export function chunkCopySubjectProjectionInput(
+  input: CopySubjectProjectionInput,
+): CopySubjectProjectionInput[] {
+  const roots = uniqueIris(input.roots, 'copySubjectProjection.roots');
+  const normalized = normalizeCopySubjectProjectionInput({ ...input, roots: [roots[0]] });
+  const chunks: CopySubjectProjectionInput[] = [];
+
+  for (let start = 0; start < roots.length;) {
+    let low = start + 1;
+    let high = roots.length;
+    let accepted: CopySubjectProjectionInput | undefined;
+
+    // Use the canonical normalizer and serializer as the only size model. A
+    // binary search keeps planning bounded for large root sets while still
+    // selecting the largest ordered prefix that fits both byte limits.
+    while (low <= high) {
+      const end = low + Math.floor((high - low) / 2);
+      const candidate = { ...normalized, roots: roots.slice(start, end) };
+      try {
+        buildCopySubjectProjectionUpdate(candidate);
+        accepted = candidate;
+        low = end + 1;
+      } catch (error) {
+        if (!(error instanceof BoundedMutationBudgetError)) throw error;
+        high = end - 1;
+      }
+    }
+
+    if (!accepted) {
+      // Surface the canonical limit error for an individually unrepresentable root.
+      buildCopySubjectProjectionUpdate({ ...normalized, roots: [roots[start]] });
+      throw new Error('copySubjectProjection root cannot fit the bounded mutation budget');
+    }
+    chunks.push(accepted);
+    start += accepted.roots.length;
+  }
+  return chunks;
+}
+
+export function normalizeStructuredMutation(mutation: StructuredMutation): StructuredMutation {
+  switch (mutation.kind) {
+    case 'delete-subjects':
+      return { kind: mutation.kind, input: normalizeDeleteSubjectsInput(mutation.input) };
+    case 'prune-ranked-subjects':
+      return { kind: mutation.kind, input: normalizePruneRankedSubjectsInput(mutation.input) };
+    case 'prune-linked-record-closures':
+      return { kind: mutation.kind, input: normalizePruneLinkedRecordClosuresInput(mutation.input) };
+    case 'replace-subject-predicates':
+      return { kind: mutation.kind, input: normalizeReplaceSubjectPredicatesInput(mutation.input) };
+    case 'replace-projection-from-graph':
+      return { kind: mutation.kind, input: normalizeReplaceProjectionFromGraphInput(mutation.input) };
+    case 'copy-subject-projection':
+      return { kind: mutation.kind, input: normalizeCopySubjectProjectionInput(mutation.input) };
+    default:
+      return unsupportedMutation(mutation);
+  }
+}
+
+/**
+ * Rewrite every caller-provided quad payload, then enforce the canonical
+ * mutation budget on the rewritten representation. The exhaustive switch keeps
+ * storage decorators from maintaining their own mutation-kind allowlists.
+ */
+export async function rewriteStructuredMutationQuads(
+  mutation: StructuredMutation,
+  rewriteQuad: (quad: Quad) => Quad | Promise<Quad>,
+): Promise<StructuredMutation> {
+  switch (mutation.kind) {
+    case 'replace-subject-predicates': {
+      const scoped = normalizeReplaceSubjectPredicatesInputForObjectRewrite(mutation.input);
+      const replacementQuads = await Promise.all(scoped.replacementQuads.map(rewriteQuad));
+      return normalizeStructuredMutation({
+        kind: mutation.kind,
+        input: { ...scoped, replacementQuads },
+      });
+    }
+    case 'delete-subjects':
+    case 'prune-ranked-subjects':
+    case 'prune-linked-record-closures':
+    case 'replace-projection-from-graph':
+    case 'copy-subject-projection':
+      return normalizeStructuredMutation(mutation);
+    default:
+      return unsupportedMutation(mutation);
+  }
+}
+
+export function buildStructuredMutationUpdate(mutation: StructuredMutation): string | undefined {
+  switch (mutation.kind) {
+    case 'delete-subjects': return buildDeleteSubjectsUpdate(mutation.input);
+    case 'prune-ranked-subjects': return buildPruneRankedSubjectsUpdate(mutation.input);
+    case 'prune-linked-record-closures': return buildPruneLinkedRecordClosuresUpdate(mutation.input);
+    case 'replace-subject-predicates': return buildReplaceSubjectPredicatesUpdate(mutation.input);
+    case 'replace-projection-from-graph': return buildReplaceProjectionFromGraphUpdate(mutation.input);
+    case 'copy-subject-projection': return buildCopySubjectProjectionUpdate(mutation.input);
+    default: return unsupportedMutation(mutation);
+  }
+}
+
+export function structuredMutationGuardedGraphs(mutation: StructuredMutation): readonly string[] {
+  switch (mutation.kind) {
+    case 'replace-projection-from-graph':
+      return [mutation.input.targetGraphUri, mutation.input.stagingGraphUri];
+    case 'copy-subject-projection':
+      return [...mutation.input.sourceGraphUris, mutation.input.targetGraphUri];
+    default:
+      return [mutation.input.graphUri];
+  }
+}
+
+export function structuredMutationTouchedGraphs(mutation: StructuredMutation): readonly string[] {
+  switch (mutation.kind) {
+    case 'replace-projection-from-graph': return [mutation.input.targetGraphUri];
+    case 'copy-subject-projection': return [mutation.input.targetGraphUri];
+    default: return [mutation.input.graphUri];
+  }
+}
+
+export function structuredMutationMightMutate(mutation: StructuredMutation): boolean {
+  return mutation.kind !== 'delete-subjects' || mutation.input.subjects.length > 0;
+}

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -10,14 +10,11 @@ import type {
   StructuredMutation,
 } from './triple-store.js';
 import {
-  TRIPLE_STORE_CAPABILITY_SUPPORT,
   UnsupportedTripleStoreCapabilityError,
-  supportsTripleStoreCapability,
   isReplaceGraphAndSubjectCapabilityRefusal,
   isReplaceGraphCapabilityRefusal,
   isReplaceSubjectCapabilityRefusal,
   isTripleStoreCapabilityRefusal,
-  type TripleStoreCapability,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { assertNotReservedInternalGraphV1 } from './internal-graph-policy.js';
@@ -254,10 +251,6 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
     this.reserved = reserved;
     this.onAppend = options.onAppend;
     this.eraGuard = options.eraGuard;
-  }
-
-  [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability): boolean {
-    return supportsTripleStoreCapability(this.inner, capability);
   }
 
   // ------------------------------------------------------------------

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -7,12 +7,17 @@ import type {
   TripleStore,
   UpdateOptions,
   StorePressureSnapshot,
+  StructuredMutation,
 } from './triple-store.js';
 import {
+  TRIPLE_STORE_CAPABILITY_SUPPORT,
   UnsupportedTripleStoreCapabilityError,
+  supportsTripleStoreCapability,
   isReplaceGraphAndSubjectCapabilityRefusal,
   isReplaceGraphCapabilityRefusal,
   isReplaceSubjectCapabilityRefusal,
+  isTripleStoreCapabilityRefusal,
+  type TripleStoreCapability,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { assertNotReservedInternalGraphV1 } from './internal-graph-policy.js';
@@ -21,6 +26,12 @@ import {
   resolveStoreChainCapabilityV1,
 } from './store-chain-capability.js';
 import type { SystemRecordLaneControllerV1 } from './system-record-materializer-v1.js';
+import {
+  normalizeStructuredMutation,
+  structuredMutationGuardedGraphs,
+  structuredMutationMightMutate,
+  structuredMutationTouchedGraphs,
+} from './bounded-structured-mutation.js';
 
 /**
  * ChangelogStore — an append-only per-node change log maintained on the write
@@ -245,6 +256,10 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
     this.eraGuard = options.eraGuard;
   }
 
+  [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability): boolean {
+    return supportsTripleStoreCapability(this.inner, capability);
+  }
+
   // ------------------------------------------------------------------
   // Mutations (marker-emitting)
   // ------------------------------------------------------------------
@@ -447,6 +462,31 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
         throw error;
       }
       await this.markPostMutation([graphUri], options);
+    });
+  }
+
+  async structuredMutation(mutation: StructuredMutation, options?: QueryOptions): Promise<void> {
+    const normalized = normalizeStructuredMutation(mutation);
+    const operation = this.inner.structuredMutation;
+    if (!operation) {
+      throw new UnsupportedTripleStoreCapabilityError('structuredMutation', 'ChangelogStore');
+    }
+    if (!this.enabled) return operation.call(this.inner, normalized, options);
+    for (const graph of structuredMutationGuardedGraphs(normalized)) {
+      this.assertNotReserved(graph, 'structuredMutation');
+    }
+    await this.runExclusive(async () => {
+      try {
+        await operation.call(this.inner, normalized, options);
+      } catch (error) {
+        if (!isTripleStoreCapabilityRefusal(error, 'structuredMutation')) {
+          this.flagReconcile('structuredMutation(indeterminate-failure)');
+        }
+        throw error;
+      }
+      if (structuredMutationMightMutate(normalized)) {
+        await this.markPostMutation(structuredMutationTouchedGraphs(normalized), options);
+      }
     });
   }
 

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -8,18 +8,28 @@ import type {
   StoreWorkPriority,
   TripleStore,
   UpdateOptions,
+  StructuredMutation,
 } from './triple-store.js';
 import { storeWorkPriorityRank } from './store-priority-scheduler.js';
 import { linkStoreChainV1 } from './store-chain-capability.js';
 import { SystemRecordLaneForwarderV1 } from './system-record-lane-forwarder-v1.js';
 import {
+  TRIPLE_STORE_CAPABILITY_SUPPORT,
   UnsupportedTripleStoreCapabilityError,
+  supportsTripleStoreCapability,
   isReplaceGraphAndSubjectCapabilityRefusal,
   isReplaceGraphCapabilityRefusal,
   isReplaceSubjectCapabilityRefusal,
+  isTripleStoreCapabilityRefusal,
+  type TripleStoreCapability,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { ManagedOxigraphBackendUnownedError } from './managed-oxigraph-ownership-v1-internal.js';
+import {
+  normalizeStructuredMutation,
+  structuredMutationMightMutate,
+  structuredMutationTouchedGraphs,
+} from './bounded-structured-mutation.js';
 import {
   CACHED_READ_GATE_V1,
   asCachedReadGateV1,
@@ -47,6 +57,7 @@ export type GraphSetMutationSource =
   | 'replaceGraph'
   | 'replaceGraphAndSubject'
   | 'replaceSubject'
+  | 'structuredMutation'
   | 'query'
   | 'update';
 
@@ -57,6 +68,7 @@ type TouchedGraphMutationSource =
   | 'replaceGraph'
   | 'replaceGraphAndSubject'
   | 'replaceSubject'
+  | 'structuredMutation'
   | 'update';
 /**
  * `system-record.*` (#2052 B2) are dirty-sources rather than touched-graph
@@ -520,6 +532,10 @@ export class GraphSetIndexStore implements TripleStore {
     );
   }
 
+  [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability): boolean {
+    return supportsTripleStoreCapability(this.inner, capability);
+  }
+
   async replaceSubject(
     graphUri: string,
     subject: string,
@@ -546,6 +562,29 @@ export class GraphSetIndexStore implements TripleStore {
     }
     this.bumpMutation();
     await this.maintainTouchedGraphs([graphUri], 'replaceSubject', options);
+  }
+
+  async structuredMutation(mutation: StructuredMutation, options?: QueryOptions): Promise<void> {
+    const normalized = normalizeStructuredMutation(mutation);
+    const operation = this.inner.structuredMutation;
+    if (!operation) {
+      throw new UnsupportedTripleStoreCapabilityError('structuredMutation', 'GraphSetIndexStore');
+    }
+    try {
+      await operation.call(this.inner, normalized, options);
+    } catch (error) {
+      if (!isTripleStoreCapabilityRefusal(error, 'structuredMutation')) {
+        this.scheduleFullRefresh('structuredMutation');
+      }
+      throw error;
+    }
+    if (!this.enabled || !structuredMutationMightMutate(normalized)) return;
+    this.bumpMutation();
+    await this.maintainTouchedGraphs(
+      [...structuredMutationTouchedGraphs(normalized)],
+      'structuredMutation',
+      options,
+    );
   }
 
   async listGraphs(options?: QueryOptions): Promise<string[]> {

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -14,14 +14,11 @@ import { storeWorkPriorityRank } from './store-priority-scheduler.js';
 import { linkStoreChainV1 } from './store-chain-capability.js';
 import { SystemRecordLaneForwarderV1 } from './system-record-lane-forwarder-v1.js';
 import {
-  TRIPLE_STORE_CAPABILITY_SUPPORT,
   UnsupportedTripleStoreCapabilityError,
-  supportsTripleStoreCapability,
   isReplaceGraphAndSubjectCapabilityRefusal,
   isReplaceGraphCapabilityRefusal,
   isReplaceSubjectCapabilityRefusal,
   isTripleStoreCapabilityRefusal,
-  type TripleStoreCapability,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { ManagedOxigraphBackendUnownedError } from './managed-oxigraph-ownership-v1-internal.js';
@@ -530,10 +527,6 @@ export class GraphSetIndexStore implements TripleStore {
       'replaceGraphAndSubject',
       options,
     );
-  }
-
-  [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability): boolean {
-    return supportsTripleStoreCapability(this.inner, capability);
   }
 
   async replaceSubject(

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -12,6 +12,13 @@ export {
   type TripleStoreBackend,
   type TripleStoreQueryOptions,
   type UpdateOptions,
+  type DeleteSubjectsInput,
+  type PruneRankedSubjectsInput,
+  type PruneLinkedRecordClosuresInput,
+  type ReplaceSubjectPredicatesInput,
+  type ReplaceProjectionFromGraphInput,
+  type CopySubjectProjectionInput,
+  type StructuredMutation,
   type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   createTripleStore,
@@ -19,6 +26,15 @@ export {
   tryReplaceGraphAtomically,
   tryReplaceGraphAndSubjectAtomically,
   tryReplaceSubjectAtomically,
+  tryDeleteSubjects,
+  tryStructuredMutation,
+  tryPruneRankedSubjects,
+  tryPruneLinkedRecordClosures,
+  supportsReplaceSubjectPredicatesAtomically,
+  tryReplaceSubjectPredicatesAtomically,
+  tryReplaceProjectionFromGraphAtomically,
+  supportsCopySubjectProjection,
+  tryCopySubjectProjection,
   isExternalBackend,
   getSparqlEndpoint,
   type SparqlEndpoint,
@@ -33,6 +49,12 @@ export {
   type AtomicGraphAndSubjectReplaceUpdate,
   type AtomicGraphReplaceUpdate,
 } from './atomic-graph-replace.js';
+export {
+  BOUNDED_MUTATION_MAX_PRUNE_DELETE,
+  chunkCopySubjectProjectionInput,
+  structuredMutationMightMutate,
+  structuredMutationTouchedGraphs,
+} from './bounded-structured-mutation.js';
 // System-record V1 (#2052 Stack B2). Default-unused: these modules perform no
 // I/O, scheduling, timer, or per-store lane work until the daemon supervisor
 // supplies a live ownership lease. Their fixed module-level registries remain
@@ -95,7 +117,10 @@ export {
   type SystemRecordLaneOutcomePolicyV1,
 } from './system-record-lane-forwarder-v1.js';
 export {
+  TRIPLE_STORE_CAPABILITY_SUPPORT,
   UnsupportedTripleStoreCapabilityError,
+  supportsTripleStoreCapability,
+  isTripleStoreCapabilityRefusal,
   isReplaceGraphAndSubjectCapabilityRefusal,
   isReplaceGraphCapabilityRefusal,
   isReplaceSubjectCapabilityRefusal,

--- a/packages/storage/src/rdf-term-format.ts
+++ b/packages/storage/src/rdf-term-format.ts
@@ -1,0 +1,41 @@
+import {
+  assertSafeIri,
+  assertSafeRdfTerm,
+} from '@origintrail-official/dkg-core';
+
+export function unwrapIriTerm(term: string): string {
+  return term.startsWith('<') && term.endsWith('>')
+    ? term.slice(1, -1)
+    : term;
+}
+
+export type RdfIriValidator = (value: string, label: string) => string;
+
+const safeIri: RdfIriValidator = (value) => assertSafeIri(value);
+
+export function formatRdfResourceTerm(
+  term: string,
+  label: string,
+  validateIri: RdfIriValidator = safeIri,
+): string {
+  if (term.startsWith('"')) {
+    throw new Error(`${label} must be an IRI`);
+  }
+  return `<${validateIri(unwrapIriTerm(term), label)}>`;
+}
+
+export function formatRdfObjectTerm(
+  term: string,
+  label: string,
+  validateIri: RdfIriValidator = safeIri,
+): string {
+  if (!term.startsWith('"')) {
+    return formatRdfResourceTerm(term, label, validateIri);
+  }
+  const bareDatatype = term.match(/^("(?:[^"\\]|\\.)*")\^\^(?!<)(.+)$/);
+  const normalized = bareDatatype
+    ? `${bareDatatype[1]}^^<${validateIri(unwrapIriTerm(bareDatatype[2]), `${label} datatype`)}>`
+    : term;
+  assertSafeRdfTerm(normalized);
+  return normalized;
+}

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -12,8 +12,17 @@ import type {
   SelectResult,
   StorePressureSnapshot,
   TripleStore,
+  StructuredMutation,
 } from './triple-store.js';
-import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
+import {
+  TRIPLE_STORE_CAPABILITY_SUPPORT,
+  UnsupportedTripleStoreCapabilityError,
+  supportsTripleStoreCapability,
+  type TripleStoreCapability,
+} from './unsupported-capability-error.js';
+import {
+  rewriteStructuredMutationQuads,
+} from './bounded-structured-mutation.js';
 
 export const EXTERNAL_LITERAL_REF_DATATYPE = 'http://dkg.io/ontology/externalLiteralRef';
 export const SHARED_MEMORY_GRAPH_SUFFIX = '/_shared_memory';
@@ -88,6 +97,10 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     linkStoreChainV1(this, inner);
     this.blobDir = options.blobDir;
     this.thresholdBytes = options.thresholdBytes;
+  }
+
+  [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability): boolean {
+    return supportsTripleStoreCapability(this.inner, capability);
   }
 
   async insert(quads: Quad[], options?: QueryOptions): Promise<void> {
@@ -180,6 +193,20 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
       quads.map((quad) => this.externalizeInsertQuad(quad)),
     );
     await this.inner.replaceSubject(graphUri, subject, externalized, options);
+  }
+
+  async structuredMutation(mutation: StructuredMutation, options?: QueryOptions): Promise<void> {
+    if (typeof this.inner.structuredMutation !== 'function') {
+      throw new UnsupportedTripleStoreCapabilityError(
+        'structuredMutation',
+        'SharedMemoryLiteralBlobStore',
+      );
+    }
+    const rewritten = await rewriteStructuredMutationQuads(
+      mutation,
+      (quad) => this.externalizeInsertQuad(quad),
+    );
+    await this.inner.structuredMutation(rewritten, options);
   }
 
   async update(sparql: string, options?: UpdateOptions): Promise<void> {

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -15,10 +15,7 @@ import type {
   StructuredMutation,
 } from './triple-store.js';
 import {
-  TRIPLE_STORE_CAPABILITY_SUPPORT,
   UnsupportedTripleStoreCapabilityError,
-  supportsTripleStoreCapability,
-  type TripleStoreCapability,
 } from './unsupported-capability-error.js';
 import {
   rewriteStructuredMutationQuads,
@@ -97,10 +94,6 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     linkStoreChainV1(this, inner);
     this.blobDir = options.blobDir;
     this.thresholdBytes = options.thresholdBytes;
-  }
-
-  [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability): boolean {
-    return supportsTripleStoreCapability(this.inner, capability);
   }
 
   async insert(quads: Quad[], options?: QueryOptions): Promise<void> {

--- a/packages/storage/src/store-chain-capability.ts
+++ b/packages/storage/src/store-chain-capability.ts
@@ -98,6 +98,22 @@ export function resolveStoreChainCapabilityV1<T>(
 }
 
 /**
+ * Return the innermost node reached by the canonical decorator-chain walk.
+ *
+ * Transparent decorators use this when an optional operation's availability is
+ * defined by the backend they forward to. A decorator that adds or constrains a
+ * capability should expose that decision explicitly instead of relying on the
+ * terminal method shape.
+ */
+export function resolveStoreChainTerminalV1(store: unknown): unknown | null {
+  return walk(
+    store,
+    (candidate): candidate is object => registeredOrPublic(candidate as object) == null,
+    registeredOrPublic,
+  );
+}
+
+/**
  * As {@link resolveStoreChainCapabilityV1}, but also follows a `inner` property.
  *
  * Compatibility only, for `asGraphWriteGenSource`, whose published contract

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -20,7 +20,18 @@ import {
   ChangelogStore,
   type ChangelogStoreOptions,
 } from './changelog-store.js';
-import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
+import {
+  TRIPLE_STORE_CAPABILITY_SUPPORT,
+  UnsupportedTripleStoreCapabilityError,
+  supportsTripleStoreCapability,
+  type TripleStoreCapability,
+} from './unsupported-capability-error.js';
+import {
+  buildCopySubjectProjectionUpdate,
+  buildPruneLinkedRecordClosuresUpdate,
+  buildReplaceProjectionFromGraphUpdate,
+  buildReplaceSubjectPredicatesUpdate,
+} from './bounded-structured-mutation.js';
 
 export interface Quad {
   subject: string;
@@ -105,7 +116,72 @@ export interface UpdateOptions extends QueryOptions {
   touchedGraphs?: readonly string[];
 }
 
+export interface DeleteSubjectsInput {
+  readonly graphUri: string;
+  readonly subjects: readonly string[];
+}
+
+export interface PruneRankedSubjectsInput {
+  readonly graphUri: string;
+  readonly subjectPrefix: string;
+  readonly eligibilityPredicate: string;
+  readonly eligibleObjects: readonly string[];
+  readonly primaryRankPredicate: string;
+  readonly secondaryRankPredicate: string;
+  readonly retainNewest: number;
+  readonly maxDelete: number;
+}
+
+export interface PruneLinkedRecordClosuresInput {
+  readonly graphUri: string;
+  readonly matchObjectIris: readonly string[];
+  readonly linkPredicates: readonly string[];
+  readonly recordParentPredicate: string;
+  readonly protectedRecordIri?: string;
+  readonly descendantSeparator: string;
+}
+
+export interface ReplaceSubjectPredicatesInput {
+  readonly graphUri: string;
+  readonly subject: string;
+  readonly predicates: readonly string[];
+  readonly replacementQuads: readonly Quad[];
+}
+
+export interface ReplaceProjectionFromGraphInput {
+  readonly targetGraphUri: string;
+  readonly stagingGraphUri: string;
+  readonly targetSubject: string;
+  readonly preservedTargetPredicates: readonly string[];
+  readonly targetSubjectPrefixes: readonly string[];
+}
+
+export interface CopySubjectProjectionInput {
+  readonly sourceGraphUris: readonly string[];
+  readonly targetGraphUri: string;
+  readonly roots: readonly string[];
+  readonly descendantSuffix: string;
+  readonly excludedPredicates: readonly string[];
+}
+
+/**
+ * Closed, validated server-side mutation vocabulary. A single capability keeps
+ * adapter/decorator forwarding stable while this bounded vocabulary evolves.
+ */
+export type StructuredMutation =
+  | { readonly kind: 'delete-subjects'; readonly input: DeleteSubjectsInput }
+  | { readonly kind: 'prune-ranked-subjects'; readonly input: PruneRankedSubjectsInput }
+  | { readonly kind: 'prune-linked-record-closures'; readonly input: PruneLinkedRecordClosuresInput }
+  | { readonly kind: 'replace-subject-predicates'; readonly input: ReplaceSubjectPredicatesInput }
+  | { readonly kind: 'replace-projection-from-graph'; readonly input: ReplaceProjectionFromGraphInput }
+  | { readonly kind: 'copy-subject-projection'; readonly input: CopySubjectProjectionInput };
+
 export interface TripleStore {
+  /**
+   * Truthful support probe for optional operations exposed by decorators.
+   * A wrapper whose method is always present must forward this to its backend.
+   */
+  [TRIPLE_STORE_CAPABILITY_SUPPORT]?(capability: TripleStoreCapability): boolean;
   /**
    * Whether `query(..., { signal })` can reject while a query is already in
    * flight (`interruptible`) or can only observe cancellation before dispatch
@@ -191,6 +267,8 @@ export interface TripleStore {
     quads: Quad[],
     options?: QueryOptions,
   ): Promise<void>;
+  /** Execute one validated, bounded server-side mutation in one commit. */
+  structuredMutation?(mutation: StructuredMutation, options?: QueryOptions): Promise<void>;
   listGraphs(options?: QueryOptions): Promise<string[]>;
   listGraphsByPrefix?(prefix: string, options?: QueryOptions): Promise<string[]>;
 
@@ -353,6 +431,151 @@ export async function tryReplaceSubjectAtomically(
     }
     throw error;
   }
+}
+
+async function tryOptionalStoreCapability(
+  capability: TripleStoreCapability,
+  operation: (() => Promise<void>) | undefined,
+): Promise<boolean> {
+  if (!operation) return false;
+  try {
+    await operation();
+    return true;
+  } catch (error) {
+    if (
+      error instanceof UnsupportedTripleStoreCapabilityError
+      && error.capability === capability
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export async function tryStructuredMutation(
+  store: TripleStore,
+  mutation: StructuredMutation,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  const operation = store.structuredMutation;
+  return tryOptionalStoreCapability(
+    'structuredMutation',
+    operation ? () => operation.call(store, mutation, options) : undefined,
+  );
+}
+
+export async function tryDeleteSubjects(
+  store: TripleStore,
+  input: DeleteSubjectsInput,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  return tryStructuredMutation(store, { kind: 'delete-subjects', input }, options);
+}
+
+export async function tryPruneRankedSubjects(
+  store: TripleStore,
+  input: PruneRankedSubjectsInput,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  return tryStructuredMutation(store, { kind: 'prune-ranked-subjects', input }, options);
+}
+
+export async function tryPruneLinkedRecordClosures(
+  store: TripleStore,
+  input: PruneLinkedRecordClosuresInput,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  if (await tryStructuredMutation(
+    store,
+    { kind: 'prune-linked-record-closures', input },
+    options,
+  )) {
+    return true;
+  }
+  return tryUpdateWithTouchedGraphs(
+    store,
+    buildPruneLinkedRecordClosuresUpdate(input),
+    [input.graphUri],
+    options,
+  );
+}
+
+/**
+ * Return whether the store can perform the atomic predicate transition used by
+ * {@link tryReplaceSubjectPredicatesAtomically}. The operation deliberately
+ * preserves the pre-capability `update()` contract for third-party stores, so
+ * callers should probe this operation rather than either transport primitive.
+ */
+export function supportsReplaceSubjectPredicatesAtomically(store: TripleStore): boolean {
+  return supportsTripleStoreCapability(store, 'structuredMutation')
+    || supportsTripleStoreCapability(store, 'update');
+}
+
+export async function tryReplaceSubjectPredicatesAtomically(
+  store: TripleStore,
+  input: ReplaceSubjectPredicatesInput,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  if (!supportsReplaceSubjectPredicatesAtomically(store)) return false;
+  if (await tryStructuredMutation(
+    store,
+    { kind: 'replace-subject-predicates', input },
+    options,
+  )) {
+    return true;
+  }
+
+  // Third-party stores cannot hold the daemon ownership lease and may still
+  // implement only the pre-capability atomic SPARQL Update contract. Keep that
+  // compatibility path inside storage so feature callers never author SPARQL.
+  return tryUpdateWithTouchedGraphs(
+    store,
+    buildReplaceSubjectPredicatesUpdate(input),
+    [input.graphUri],
+    options,
+  );
+}
+
+export async function tryReplaceProjectionFromGraphAtomically(
+  store: TripleStore,
+  input: ReplaceProjectionFromGraphInput,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  if (await tryStructuredMutation(
+    store,
+    { kind: 'replace-projection-from-graph', input },
+    options,
+  )) {
+    return true;
+  }
+  return tryUpdateWithTouchedGraphs(
+    store,
+    buildReplaceProjectionFromGraphUpdate(input),
+    [input.targetGraphUri],
+    options,
+  );
+}
+
+export function supportsCopySubjectProjection(store: TripleStore): boolean {
+  return supportsTripleStoreCapability(store, 'structuredMutation')
+    || supportsTripleStoreCapability(store, 'update');
+}
+
+export async function tryCopySubjectProjection(
+  store: TripleStore,
+  input: CopySubjectProjectionInput,
+  options: QueryOptions = {},
+): Promise<boolean> {
+  if (!supportsCopySubjectProjection(store)) return false;
+  if (await tryStructuredMutation(store, { kind: 'copy-subject-projection', input }, options)) {
+    return true;
+  }
+  return tryUpdateWithTouchedGraphs(
+    store,
+    buildCopySubjectProjectionUpdate(input),
+    [input.targetGraphUri],
+    options,
+  );
 }
 
 export type TripleStoreBackend = 'oxigraph' | 'oxigraph-persistent' | 'oxigraph-worker' | 'blazegraph' | 'sparql-http' | string;

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -177,10 +177,7 @@ export type StructuredMutation =
   | { readonly kind: 'copy-subject-projection'; readonly input: CopySubjectProjectionInput };
 
 export interface TripleStore {
-  /**
-   * Truthful support probe for optional operations exposed by decorators.
-   * A wrapper whose method is always present must forward this to its backend.
-   */
+  /** Explicit override for wrappers that add or constrain optional operations. */
   [TRIPLE_STORE_CAPABILITY_SUPPORT]?(capability: TripleStoreCapability): boolean;
   /**
    * Whether `query(..., { signal })` can reject while a query is already in

--- a/packages/storage/src/unsupported-capability-error.ts
+++ b/packages/storage/src/unsupported-capability-error.ts
@@ -1,3 +1,8 @@
+import {
+  resolveStoreChainCapabilityV1,
+  resolveStoreChainTerminalV1,
+} from './store-chain-capability.js';
+
 /**
  * Optional TripleStore operations that a decorator may expose even when its
  * wrapped backend cannot perform them.
@@ -28,12 +33,17 @@ export function supportsTripleStoreCapability(
   store: unknown,
   capability: TripleStoreCapability,
 ): boolean {
-  const support = (store as Partial<TripleStoreCapabilitySupport> | null | undefined)
-    ?.[TRIPLE_STORE_CAPABILITY_SUPPORT];
-  if (typeof support === 'function') {
-    return support.call(store, capability);
+  const reporter = resolveStoreChainCapabilityV1(
+    store,
+    (candidate): candidate is TripleStoreCapabilitySupport => typeof (
+      candidate as Partial<TripleStoreCapabilitySupport> | null | undefined
+    )?.[TRIPLE_STORE_CAPABILITY_SUPPORT] === 'function',
+  );
+  if (reporter) {
+    return reporter[TRIPLE_STORE_CAPABILITY_SUPPORT](capability);
   }
-  return typeof (store as Partial<Record<TripleStoreCapability, unknown>> | null | undefined)
+  const terminal = resolveStoreChainTerminalV1(store);
+  return typeof (terminal as Partial<Record<TripleStoreCapability, unknown>> | null | undefined)
     ?.[capability] === 'function';
 }
 

--- a/packages/storage/src/unsupported-capability-error.ts
+++ b/packages/storage/src/unsupported-capability-error.ts
@@ -14,12 +14,7 @@ export type TripleStoreCapability =
   | 'replaceSubject'
   | 'structuredMutation';
 
-/**
- * Decorators whose optional methods are always present use this non-mutating
- * probe to report the capability of the store they wrap. The symbol keeps the
- * forwarding contract explicit without adding another public method name to
- * every TripleStore implementation.
- */
+/** Explicit support override for decorators that add or constrain semantics. */
 export const TRIPLE_STORE_CAPABILITY_SUPPORT: unique symbol = Symbol(
   'dkg.tripleStoreCapabilitySupport',
 );

--- a/packages/storage/src/unsupported-capability-error.ts
+++ b/packages/storage/src/unsupported-capability-error.ts
@@ -6,7 +6,36 @@ export type TripleStoreCapability =
   | 'update'
   | 'replaceGraph'
   | 'replaceGraphAndSubject'
-  | 'replaceSubject';
+  | 'replaceSubject'
+  | 'structuredMutation';
+
+/**
+ * Decorators whose optional methods are always present use this non-mutating
+ * probe to report the capability of the store they wrap. The symbol keeps the
+ * forwarding contract explicit without adding another public method name to
+ * every TripleStore implementation.
+ */
+export const TRIPLE_STORE_CAPABILITY_SUPPORT: unique symbol = Symbol(
+  'dkg.tripleStoreCapabilitySupport',
+);
+
+interface TripleStoreCapabilitySupport {
+  [TRIPLE_STORE_CAPABILITY_SUPPORT](capability: TripleStoreCapability): boolean;
+}
+
+/** Return whether invoking an optional operation can reach a capable backend. */
+export function supportsTripleStoreCapability(
+  store: unknown,
+  capability: TripleStoreCapability,
+): boolean {
+  const support = (store as Partial<TripleStoreCapabilitySupport> | null | undefined)
+    ?.[TRIPLE_STORE_CAPABILITY_SUPPORT];
+  if (typeof support === 'function') {
+    return support.call(store, capability);
+  }
+  return typeof (store as Partial<Record<TripleStoreCapability, unknown>> | null | undefined)
+    ?.[capability] === 'function';
+}
 
 /**
  * Typed signal that an optional store capability is unavailable.
@@ -29,6 +58,14 @@ export class UnsupportedTripleStoreCapabilityError extends Error {
   }
 }
 
+export function isTripleStoreCapabilityRefusal(
+  error: unknown,
+  capability: TripleStoreCapability,
+): boolean {
+  return error instanceof UnsupportedTripleStoreCapabilityError
+    && error.capability === capability;
+}
+
 /**
  * A capability refusal is a clean preflight outcome — the contract requires it
  * to be raised before the operation starts — so decorators that treat a failed
@@ -36,22 +73,13 @@ export class UnsupportedTripleStoreCapabilityError extends Error {
  * it from cache-dirtying and reconcile flagging.
  */
 export function isReplaceGraphCapabilityRefusal(error: unknown): boolean {
-  return (
-    error instanceof UnsupportedTripleStoreCapabilityError &&
-    error.capability === 'replaceGraph'
-  );
+  return isTripleStoreCapabilityRefusal(error, 'replaceGraph');
 }
 
 export function isReplaceGraphAndSubjectCapabilityRefusal(error: unknown): boolean {
-  return (
-    error instanceof UnsupportedTripleStoreCapabilityError &&
-    error.capability === 'replaceGraphAndSubject'
-  );
+  return isTripleStoreCapabilityRefusal(error, 'replaceGraphAndSubject');
 }
 
 export function isReplaceSubjectCapabilityRefusal(error: unknown): boolean {
-  return (
-    error instanceof UnsupportedTripleStoreCapabilityError &&
-    error.capability === 'replaceSubject'
-  );
+  return isTripleStoreCapabilityRefusal(error, 'replaceSubject');
 }

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -662,6 +662,47 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     expect(body).not.toContain('atomic-graph-replace:');
   });
 
+  it('structuredMutation posts one bounded predicate replacement update', async () => {
+    const s = new BlazegraphStore(baseUrl);
+    await s.structuredMutation({ kind: 'replace-subject-predicates', input: {
+      graphUri: 'http://ex.org/g',
+      subject: 'http://ex.org/job',
+      predicates: ['http://ex.org/status'],
+      replacementQuads: [{
+        subject: 'http://ex.org/job',
+        predicate: 'http://ex.org/status',
+        object: '"approved"',
+        graph: 'http://ex.org/g',
+      }],
+    } });
+
+    expect(fetchCalls).toHaveLength(1);
+    const [, init] = fetchCalls[0];
+    const body = String(init?.body);
+    expect((init?.headers as Record<string, string>)['Content-Type'])
+      .toBe('application/sparql-update; charset=utf-8');
+    expect(body).toContain('DELETE {');
+    expect(body).toContain('INSERT {');
+    expect(body).toContain('GRAPH <http://ex.org/g>');
+    expect(body).toContain('<http://ex.org/job> <http://ex.org/status> "approved"');
+  });
+
+  it('structuredMutation rejects oversized replacement literals before fetch', async () => {
+    const s = new BlazegraphStore(baseUrl);
+    await expect(s.structuredMutation({ kind: 'replace-subject-predicates', input: {
+      graphUri: 'http://ex.org/g',
+      subject: 'http://ex.org/job',
+      predicates: ['http://ex.org/status'],
+      replacementQuads: [{
+        subject: 'http://ex.org/job',
+        predicate: 'http://ex.org/status',
+        object: `"${'x'.repeat(70_000)}"`,
+        graph: 'http://ex.org/g',
+      }],
+    } })).rejects.toMatchObject({ code: 'OVERSIZED_RDF_LITERAL' });
+    expect(fetchCalls).toHaveLength(0);
+  });
+
   it('update honors pre-aborted options before dispatch', async () => {
     const s = new BlazegraphStore(baseUrl);
     const controller = new AbortController();

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ChangelogStore,
+  GraphSetIndexStore,
+  SharedMemoryLiteralBlobStore,
+  OxigraphStore,
+  OxigraphWorkerStore,
+  UnsupportedTripleStoreCapabilityError,
+  supportsReplaceSubjectPredicatesAtomically,
+  supportsTripleStoreCapability,
+  tryCopySubjectProjection,
+  tryDeleteSubjects,
+  tryReplaceProjectionFromGraphAtomically,
+  type Quad,
+  type TripleStore,
+} from '../src/index.js';
+import {
+  BOUNDED_MUTATION_MAX_IRIS,
+  BOUNDED_MUTATION_MAX_UPDATE_BYTES,
+  buildCopySubjectProjectionUpdate,
+  buildDeleteSubjectsUpdate,
+  chunkCopySubjectProjectionInput,
+  normalizeCopySubjectProjectionInput,
+  normalizeDeleteSubjectsInput,
+  normalizeReplaceSubjectPredicatesInput,
+} from '../src/bounded-structured-mutation.js';
+
+const GRAPH = 'urn:test:bounded';
+const OTHER_GRAPH = 'urn:test:bounded:other';
+const P = 'urn:test:p';
+const STATUS = 'urn:test:status';
+const REQUESTED_AT = 'urn:test:requested-at';
+const DECIDED_AT = 'urn:test:decided-at';
+
+function quad(subject: string, predicate: string, object: string, graph = GRAPH): Quad {
+  return { subject, predicate, object, graph };
+}
+
+async function rows(store: TripleStore, graph: string): Promise<Array<Record<string, string>>> {
+  const result = await store.query(
+    `SELECT ?s ?p ?o WHERE { GRAPH <${graph}> { ?s ?p ?o } } ORDER BY ?s ?p ?o`,
+  );
+  return result.type === 'bindings' ? result.bindings : [];
+}
+
+describe('bounded structured mutation capabilities', () => {
+  it('deletes one explicit subject set and preserves co-located rows', async () => {
+    const store = new OxigraphStore();
+    await store.insert([
+      quad('urn:test:a', P, '"a"'),
+      quad('urn:test:b', P, '"b"'),
+      quad('urn:test:c', P, '"c"'),
+    ]);
+
+    await store.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: GRAPH, subjects: ['urn:test:a', 'urn:test:c'] },
+    });
+
+    expect(await rows(store, GRAPH)).toEqual([{ s: 'urn:test:b', p: P, o: '"b"' }]);
+  });
+
+  it('prunes only bounded terminal overflow and rechecks terminal state in the delete', async () => {
+    const store = new OxigraphStore();
+    await store.insert([
+      quad('urn:test:req:old', STATUS, '"approved"'),
+      quad('urn:test:req:old', DECIDED_AT, '"1"'),
+      quad('urn:test:req:new', STATUS, '"rejected"'),
+      quad('urn:test:req:new', DECIDED_AT, '"2"'),
+      // A reused record with one terminal and one non-terminal status must survive.
+      quad('urn:test:req:reused', STATUS, '"approved"'),
+      quad('urn:test:req:reused', STATUS, '"pending"'),
+      quad('urn:test:req:reused', REQUESTED_AT, '"0"'),
+    ]);
+
+    await store.structuredMutation({ kind: 'prune-ranked-subjects', input: {
+      graphUri: GRAPH,
+      subjectPrefix: 'urn:test:req:',
+      eligibilityPredicate: STATUS,
+      eligibleObjects: ['approved', 'rejected'],
+      primaryRankPredicate: DECIDED_AT,
+      secondaryRankPredicate: REQUESTED_AT,
+      retainNewest: 1,
+      maxDelete: 1,
+    } });
+
+    const remaining = await rows(store, GRAPH);
+    expect(remaining.some((row) => row.s === 'urn:test:req:old')).toBe(false);
+    expect(remaining.some((row) => row.s === 'urn:test:req:new')).toBe(true);
+    expect(remaining.some((row) => row.s === 'urn:test:req:reused')).toBe(true);
+  });
+
+  it('prunes complete record closures while preserving the protected root', async () => {
+    const store = new OxigraphStore();
+    const memberPredicate = 'urn:test:member';
+    const parentPredicate = 'urn:test:parent';
+    await store.insert([
+      quad('urn:test:record:old/1', memberPredicate, 'urn:test:agent'),
+      quad('urn:test:record:old/1', parentPredicate, 'urn:test:record:old'),
+      quad('urn:test:record:old', P, '"old"'),
+      quad('urn:test:record:keep', memberPredicate, 'urn:test:agent'),
+      quad('urn:test:record:keep', P, '"keep"'),
+      quad('urn:test:unrelated', P, '"unrelated"'),
+    ]);
+
+    await store.structuredMutation({ kind: 'prune-linked-record-closures', input: {
+      graphUri: GRAPH,
+      matchObjectIris: ['urn:test:agent'],
+      linkPredicates: [memberPredicate],
+      recordParentPredicate: parentPredicate,
+      protectedRecordIri: 'urn:test:record:keep',
+      descendantSeparator: '/',
+    } });
+
+    const remaining = await rows(store, GRAPH);
+    expect(remaining.some((row) => row.s.startsWith('urn:test:record:old'))).toBe(false);
+    expect(remaining.some((row) => row.s === 'urn:test:record:keep')).toBe(true);
+    expect(remaining.some((row) => row.s === 'urn:test:unrelated')).toBe(true);
+  });
+
+  it('atomically replaces only declared predicates on one subject', async () => {
+    const store = new OxigraphStore();
+    const subject = 'urn:test:request';
+    await store.insert([
+      quad(subject, STATUS, '"pending"'),
+      quad(subject, DECIDED_AT, '"1"'),
+      quad(subject, 'urn:test:signed-delegation', '"preserve"'),
+    ]);
+
+    await store.structuredMutation({ kind: 'replace-subject-predicates', input: {
+      graphUri: GRAPH,
+      subject,
+      predicates: [STATUS, DECIDED_AT],
+      replacementQuads: [
+        quad(subject, STATUS, '"approved"'),
+        quad(subject, DECIDED_AT, '"2"'),
+      ],
+    } });
+
+    expect(await rows(store, GRAPH)).toEqual([
+      { s: subject, p: DECIDED_AT, o: '"2"' },
+      { s: subject, p: 'urn:test:signed-delegation', o: '"preserve"' },
+      { s: subject, p: STATUS, o: '"approved"' },
+    ]);
+  });
+
+  it('replaces one staged projection while preserving local tombstones and unrelated subjects', async () => {
+    const store = new OxigraphStore();
+    const target = 'urn:test:meta';
+    const staging = 'urn:test:staging';
+    const subject = 'urn:test:cg';
+    const revoked = 'urn:test:revoked';
+    const delegationPrefix = 'urn:test:delegation:';
+    await store.insert([
+      quad(subject, P, '"stale"', target),
+      quad(subject, revoked, 'urn:test:agent:revoked', target),
+      quad(`${delegationPrefix}old`, P, '"stale"', target),
+      quad('urn:test:unrelated', P, '"keep"', target),
+      quad(subject, P, '"fresh"', staging),
+      quad(`${delegationPrefix}new`, P, '"fresh"', staging),
+      quad('urn:test:staging-unrelated', P, '"do-not-copy"', staging),
+    ]);
+
+    await store.structuredMutation({ kind: 'replace-projection-from-graph', input: {
+      targetGraphUri: target,
+      stagingGraphUri: staging,
+      targetSubject: subject,
+      preservedTargetPredicates: [revoked],
+      targetSubjectPrefixes: [delegationPrefix],
+    } });
+
+    expect(await rows(store, target)).toEqual([
+      { s: subject, p: P, o: '"fresh"' },
+      { s: subject, p: revoked, o: 'urn:test:agent:revoked' },
+      { s: `${delegationPrefix}new`, p: P, o: '"fresh"' },
+      { s: 'urn:test:unrelated', p: P, o: '"keep"' },
+    ]);
+  });
+
+  it('copies exact subject closures from bounded sources without RDF term round-tripping', async () => {
+    const store = new OxigraphStore();
+    const sourceA = 'urn:test:source:a';
+    const sourceB = 'urn:test:source:b';
+    const target = 'urn:test:target';
+    const root = 'urn:test:root';
+    const excluded = 'urn:test:excluded';
+    const escapeBearing = JSON.stringify('line1\\line2\n"quoted" µ');
+    await store.insert([
+      quad(root, P, escapeBearing, sourceA),
+      quad(`${root}/.well-known/genid/1`, P, '"child"', sourceB),
+      quad(root, excluded, '"skip"', sourceB),
+      quad('urn:test:other', P, '"other"', sourceA),
+      quad(root, P, '"wrong graph"', OTHER_GRAPH),
+    ]);
+
+    await store.structuredMutation({ kind: 'copy-subject-projection', input: {
+      sourceGraphUris: [sourceA, sourceB],
+      targetGraphUri: target,
+      roots: [root],
+      descendantSuffix: '/.well-known/genid/',
+      excludedPredicates: [excluded],
+    } });
+
+    expect(await rows(store, target)).toEqual([
+      { s: root, p: P, o: escapeBearing },
+      { s: `${root}/.well-known/genid/1`, p: P, o: '"child"' },
+    ]);
+  });
+
+  it('chunks oversized subject projection roots below the encoded update budget', () => {
+    const roots = Array.from(
+      { length: 10 },
+      (_, index) => `urn:test:large-root:${index}:${'x'.repeat(500_000)}`,
+    );
+    const input = {
+      sourceGraphUris: [GRAPH],
+      targetGraphUri: OTHER_GRAPH,
+      roots,
+      descendantSuffix: '/.well-known/genid/',
+      excludedPredicates: [P],
+    };
+
+    expect(() => buildCopySubjectProjectionUpdate(input)).toThrow(/exceeds/);
+    const chunks = chunkCopySubjectProjectionInput(input);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.flatMap((chunk) => chunk.roots)).toEqual(roots);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(buildCopySubjectProjectionUpdate(chunk), 'utf8'))
+        .toBeLessThanOrEqual(BOUNDED_MUTATION_MAX_UPDATE_BYTES);
+    }
+    for (let index = 0; index < chunks.length - 1; index++) {
+      expect(() => buildCopySubjectProjectionUpdate({
+        ...chunks[index],
+        roots: [...chunks[index].roots, chunks[index + 1].roots[0]],
+      })).toThrow(/exceeds/);
+    }
+  });
+
+  it('reports atomic predicate replacement support at the operation boundary', () => {
+    const updateOnly = new GraphSetIndexStore({ update: vi.fn() } as unknown as TripleStore);
+    const incapable = new GraphSetIndexStore({} as TripleStore);
+
+    expect(supportsTripleStoreCapability(updateOnly, 'structuredMutation')).toBe(false);
+    expect(supportsReplaceSubjectPredicatesAtomically(updateOnly)).toBe(true);
+    expect(supportsReplaceSubjectPredicatesAtomically(incapable)).toBe(false);
+  });
+
+  it('preserves bounded projection operations for update-only stores', async () => {
+    const update = vi.fn(async () => undefined);
+    const store = { update } as unknown as TripleStore;
+    const projection = {
+      targetGraphUri: OTHER_GRAPH,
+      stagingGraphUri: 'urn:test:staging',
+      targetSubject: 'urn:test:subject',
+      preservedTargetPredicates: [STATUS],
+      targetSubjectPrefixes: ['urn:test:prefix:'],
+    };
+    const copy = {
+      sourceGraphUris: [GRAPH],
+      targetGraphUri: OTHER_GRAPH,
+      roots: ['urn:test:root'],
+      descendantSuffix: '/.well-known/genid/',
+      excludedPredicates: [STATUS],
+    };
+
+    await expect(tryReplaceProjectionFromGraphAtomically(store, projection))
+      .resolves.toBe(true);
+    await expect(tryCopySubjectProjection(store, copy)).resolves.toBe(true);
+    expect(update).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(`GRAPH <${OTHER_GRAPH}>`),
+      { touchedGraphs: [OTHER_GRAPH] },
+    );
+    expect(update).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('VALUES ?root { <urn:test:root> }'),
+      { touchedGraphs: [OTHER_GRAPH] },
+    );
+  });
+
+  it('dispatches a max accepted subject set as one embedded update', async () => {
+    const store = new OxigraphStore();
+    const embedded = (store as unknown as { store: { update: (sparql: string) => void } }).store;
+    const update = vi.spyOn(embedded, 'update').mockImplementation(() => undefined);
+    const subjects = Array.from(
+      { length: BOUNDED_MUTATION_MAX_IRIS },
+      (_, index) => `urn:test:subject:${index}`,
+    );
+
+    await store.structuredMutation({ kind: 'delete-subjects', input: { graphUri: GRAPH, subjects } });
+
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects sparse, duplicate, oversized, and cross-scope descriptors before dispatch', () => {
+    const sparse = Array(2) as string[];
+    sparse[1] = 'urn:test:a';
+    expect(() => normalizeDeleteSubjectsInput({ graphUri: GRAPH, subjects: sparse }))
+      .toThrow(/dense array/);
+    expect(() => normalizeDeleteSubjectsInput({
+      graphUri: GRAPH,
+      subjects: ['urn:test:a', 'urn:test:a'],
+    })).toThrow(/duplicate/);
+    expect(() => normalizeDeleteSubjectsInput({
+      graphUri: GRAPH,
+      subjects: ['_:blank'],
+    })).toThrow(/absolute IRI/);
+    expect(() => normalizeDeleteSubjectsInput({
+      graphUri: 'relative-graph',
+      subjects: ['urn:test:a'],
+    })).toThrow(/absolute IRI/);
+    expect(() => normalizeDeleteSubjectsInput({
+      graphUri: GRAPH,
+      subjects: Array(BOUNDED_MUTATION_MAX_IRIS + 1).fill('urn:test:a'),
+    })).toThrow(/must contain/);
+
+    const sparseQuads = Array(2) as Quad[];
+    sparseQuads[1] = quad('urn:test:a', P, '"a"');
+    expect(() => normalizeReplaceSubjectPredicatesInput({
+      graphUri: GRAPH,
+      subject: 'urn:test:a',
+      predicates: [P],
+      replacementQuads: sparseQuads,
+    })).toThrow(/dense array/);
+    expect(() => normalizeReplaceSubjectPredicatesInput({
+      graphUri: GRAPH,
+      subject: 'urn:test:a',
+      predicates: [P],
+      replacementQuads: [quad('urn:test:a', P, 'relative-object')],
+    })).toThrow(/absolute IRI/);
+
+    expect(() => normalizeCopySubjectProjectionInput({
+      sourceGraphUris: [GRAPH],
+      targetGraphUri: GRAPH,
+      roots: ['urn:test:a'],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    })).toThrow(/must not be a source/);
+  });
+
+  it('rejects a generated request whose syntax overhead crosses the byte cap', () => {
+    const subjects = Array.from(
+      { length: 75_000 },
+      (_, index) => `urn:test:${index.toString().padStart(5, '0')}:${'x'.repeat(40)}`,
+    );
+    expect(() => buildDeleteSubjectsUpdate({ graphUri: GRAPH, subjects }))
+      .toThrow(/serialized update exceeds/);
+  });
+
+  it('reports only typed capability refusal as unsupported', async () => {
+    const missing = {} as TripleStore;
+    await expect(tryDeleteSubjects(missing, { graphUri: GRAPH, subjects: [] }))
+      .resolves.toBe(false);
+
+    const refusing = {
+      structuredMutation: async () => {
+        throw new UnsupportedTripleStoreCapabilityError('structuredMutation', 'test');
+      },
+    } as unknown as TripleStore;
+    await expect(tryDeleteSubjects(refusing, { graphUri: GRAPH, subjects: [] }))
+      .resolves.toBe(false);
+
+    const failing = {
+      structuredMutation: async () => { throw new Error('backend failed'); },
+    } as unknown as TripleStore;
+    await expect(tryDeleteSubjects(failing, { graphUri: GRAPH, subjects: [] }))
+      .rejects.toThrow('backend failed');
+  });
+
+  it('reports structured mutation support truthfully through every decorator', async () => {
+    const incapable = new ChangelogStore(new GraphSetIndexStore(
+      new SharedMemoryLiteralBlobStore({} as TripleStore, {
+        blobDir: '/tmp/dkg-structured-mutation-capability-test',
+        thresholdBytes: 1024,
+      }),
+    ));
+    expect(supportsTripleStoreCapability(incapable, 'structuredMutation')).toBe(false);
+
+    const capable = new ChangelogStore(new GraphSetIndexStore(
+      new SharedMemoryLiteralBlobStore(new OxigraphStore(), {
+        blobDir: '/tmp/dkg-structured-mutation-capability-test',
+        thresholdBytes: 1024,
+      }),
+    ));
+    expect(supportsTripleStoreCapability(capable, 'structuredMutation')).toBe(true);
+    await capable.close();
+  });
+
+  it('executes every mutation variant through the real worker RPC boundary', async () => {
+    const store = new OxigraphWorkerStore();
+    try {
+      const staging = 'urn:test:worker:staging';
+      const target = 'urn:test:worker:target';
+      const member = 'urn:test:worker:member';
+      const parent = 'urn:test:worker:parent';
+      await store.insert([
+        quad('urn:test:delete', P, '"delete"'),
+        quad('urn:test:req:old', STATUS, '"approved"'),
+        quad('urn:test:req:old', DECIDED_AT, '"1"'),
+        quad('urn:test:req:new', STATUS, '"approved"'),
+        quad('urn:test:req:new', DECIDED_AT, '"2"'),
+        quad('urn:test:record/1', member, 'urn:test:agent'),
+        quad('urn:test:record/1', parent, 'urn:test:record'),
+        quad('urn:test:record', P, '"record"'),
+        quad('urn:test:subject', STATUS, '"pending"'),
+        quad('urn:test:projection', P, '"fresh"', staging),
+      ]);
+
+      await store.structuredMutation({ kind: 'delete-subjects', input: {
+        graphUri: GRAPH, subjects: ['urn:test:delete'],
+      } });
+      await store.structuredMutation({ kind: 'prune-ranked-subjects', input: {
+        graphUri: GRAPH, subjectPrefix: 'urn:test:req:', eligibilityPredicate: STATUS,
+        eligibleObjects: ['approved'], primaryRankPredicate: DECIDED_AT,
+        secondaryRankPredicate: REQUESTED_AT, retainNewest: 1, maxDelete: 1,
+      } });
+      await store.structuredMutation({ kind: 'prune-linked-record-closures', input: {
+        graphUri: GRAPH, matchObjectIris: ['urn:test:agent'], linkPredicates: [member],
+        recordParentPredicate: parent, descendantSeparator: '/',
+      } });
+      await store.structuredMutation({ kind: 'replace-subject-predicates', input: {
+        graphUri: GRAPH, subject: 'urn:test:subject', predicates: [STATUS],
+        replacementQuads: [quad('urn:test:subject', STATUS, '"approved"')],
+      } });
+      await store.structuredMutation({ kind: 'replace-projection-from-graph', input: {
+        targetGraphUri: target, stagingGraphUri: staging, targetSubject: 'urn:test:projection',
+        preservedTargetPredicates: [], targetSubjectPrefixes: [],
+      } });
+      await store.structuredMutation({ kind: 'copy-subject-projection', input: {
+        sourceGraphUris: [target], targetGraphUri: OTHER_GRAPH, roots: ['urn:test:projection'],
+        descendantSuffix: '/', excludedPredicates: [],
+      } });
+
+      const sourceRows = await rows(store, GRAPH);
+      expect(sourceRows.some((row) => row.s === 'urn:test:delete')).toBe(false);
+      expect(sourceRows.some((row) => row.s === 'urn:test:req:old')).toBe(false);
+      expect(sourceRows.some((row) => row.s === 'urn:test:req:new')).toBe(true);
+      expect(sourceRows.some((row) => row.s === 'urn:test:record')).toBe(false);
+      expect(sourceRows.some((row) => row.s === 'urn:test:record/1')).toBe(false);
+      expect(sourceRows).toContainEqual({
+        s: 'urn:test:subject',
+        p: STATUS,
+        o: '"approved"',
+      });
+      expect(await rows(store, target)).toEqual([
+        { s: 'urn:test:projection', p: P, o: '"fresh"' },
+      ]);
+      expect(await rows(store, OTHER_GRAPH)).toEqual([
+        { s: 'urn:test:projection', p: P, o: '"fresh"' },
+      ]);
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -6,6 +6,7 @@ import {
   SharedMemoryLiteralBlobStore,
   OxigraphStore,
   OxigraphWorkerStore,
+  TRIPLE_STORE_CAPABILITY_SUPPORT,
   UnsupportedTripleStoreCapabilityError,
   supportsReplaceSubjectPredicatesAtomically,
   supportsTripleStoreCapability,
@@ -399,6 +400,13 @@ describe('bounded structured mutation capabilities', () => {
     const incapableWrapper = { structuredMutation: vi.fn() } as unknown as TripleStore;
     linkStoreChainV1(incapableWrapper, incapable);
     expect(supportsTripleStoreCapability(incapableWrapper, 'structuredMutation')).toBe(false);
+
+    const constrainingWrapper = {
+      structuredMutation: vi.fn(),
+      [TRIPLE_STORE_CAPABILITY_SUPPORT]: () => false,
+    } as unknown as TripleStore;
+    linkStoreChainV1(constrainingWrapper, capable);
+    expect(supportsTripleStoreCapability(constrainingWrapper, 'structuredMutation')).toBe(false);
   });
 
   it('executes every mutation variant through the real worker RPC boundary', async () => {

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -25,6 +25,7 @@ import {
   normalizeDeleteSubjectsInput,
   normalizeReplaceSubjectPredicatesInput,
 } from '../src/bounded-structured-mutation.js';
+import { linkStoreChainV1 } from '../src/store-chain-capability.js';
 
 const GRAPH = 'urn:test:bounded';
 const OTHER_GRAPH = 'urn:test:bounded:other';
@@ -386,6 +387,18 @@ describe('bounded structured mutation capabilities', () => {
     ));
     expect(supportsTripleStoreCapability(capable, 'structuredMutation')).toBe(true);
     await capable.close();
+  });
+
+  it('discovers optional operations through link-only transparent wrappers', () => {
+    const capable = { structuredMutation: vi.fn() } as unknown as TripleStore;
+    const capableWrapper = { structuredMutation: vi.fn() } as unknown as TripleStore;
+    linkStoreChainV1(capableWrapper, capable);
+    expect(supportsTripleStoreCapability(capableWrapper, 'structuredMutation')).toBe(true);
+
+    const incapable = {} as TripleStore;
+    const incapableWrapper = { structuredMutation: vi.fn() } as unknown as TripleStore;
+    linkStoreChainV1(incapableWrapper, incapable);
+    expect(supportsTripleStoreCapability(incapableWrapper, 'structuredMutation')).toBe(false);
   });
 
   it('executes every mutation variant through the real worker RPC boundary', async () => {

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -22,7 +22,8 @@ import { OxigraphStore } from '../src/adapters/oxigraph.js';
 import { BlazegraphStore } from '../src/adapters/blazegraph.js';
 import { ChangelogStore, CHANGELOG_GRAPH, asChangelogReader, type ChangelogEraGuard } from '../src/changelog-store.js';
 import { createTripleStore } from '../src/triple-store.js';
-import type { Quad, QueryOptions, QueryResult, TripleStore, UpdateOptions } from '../src/triple-store.js';
+import type { Quad, QueryOptions, QueryResult, StructuredMutation, TripleStore, UpdateOptions } from '../src/triple-store.js';
+import { UnsupportedTripleStoreCapabilityError } from '../src/unsupported-capability-error.js';
 
 const G1 = 'http://ex.org/g1';
 const G2 = 'http://ex.org/g2';
@@ -212,6 +213,79 @@ describe('ChangelogStore — restart reseed & reserved-graph hiding', () => {
 });
 
 describe('ChangelogStore — opaque update handling', () => {
+  it('attributes a structured projection copy only to its target graph', async () => {
+    const source = 'http://ex.org/projection-source';
+    const target = 'http://ex.org/projection-target';
+    const root = 'http://ex.org/projection-root';
+    const base = new OxigraphStore();
+    await base.insert([q(root, source)]);
+    const log = new ChangelogStore(base);
+
+    await log.structuredMutation({ kind: 'copy-subject-projection', input: {
+      sourceGraphUris: [source],
+      targetGraphUri: target,
+      roots: [root],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    } });
+
+    expect(await log.readChanges(0, 100)).toEqual([
+      { seq: 1, graph: target, op: 'upsert' },
+    ]);
+    expect(log.needsReconcile).toBe(false);
+    await base.close();
+  });
+
+  it('treats a typed structured-capability refusal as mutation-free preflight', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(new SpyStore(base));
+
+    await expect(log.structuredMutation({ kind: 'copy-subject-projection', input: {
+      sourceGraphUris: [G1],
+      targetGraphUri: G2,
+      roots: ['http://ex.org/root'],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    } })).rejects.toMatchObject<Partial<UnsupportedTripleStoreCapabilityError>>({
+      name: 'UnsupportedTripleStoreCapabilityError',
+      capability: 'structuredMutation',
+    });
+    expect(log.needsReconcile).toBe(false);
+    await base.close();
+  });
+
+  it('flags reconcile after an indeterminate structured mutation failure', async () => {
+    const source = 'http://ex.org/indeterminate-source';
+    const targetGraph = 'http://ex.org/indeterminate-target';
+    const root = 'http://ex.org/indeterminate-root';
+    const base = new OxigraphStore();
+    await base.insert([q(root, source)]);
+    const uncertain = new Proxy(base, {
+      get(target, property, receiver) {
+        if (property === 'structuredMutation') {
+          return async (mutation: StructuredMutation, options?: QueryOptions) => {
+            await target.structuredMutation(mutation, options);
+            throw new Error('lost structured mutation response');
+          };
+        }
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    const log = new ChangelogStore(uncertain);
+
+    await expect(log.structuredMutation({ kind: 'copy-subject-projection', input: {
+      sourceGraphUris: [source],
+      targetGraphUri: targetGraph,
+      roots: [root],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    } })).rejects.toThrow('lost structured mutation response');
+    expect(log.needsReconcile).toBe(true);
+    expect(await base.hasGraph(targetGraph)).toBe(true);
+    await base.close();
+  });
+
   it('an update() with touchedGraphs emits markers; without, it flags reconcile', async () => {
     const base = new OxigraphStore();
     const log = new ChangelogStore(base);

--- a/packages/storage/test/external-literal-store.test.ts
+++ b/packages/storage/test/external-literal-store.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   EXTERNAL_LITERAL_REF_DATATYPE,
   OxigraphStore,
@@ -11,8 +11,10 @@ import {
   type QueryOptions,
   type QueryResult,
   type Quad,
+  type StructuredMutation,
   type TripleStore,
 } from '../src/index.js';
+import { BOUNDED_MUTATION_MAX_OPERAND_BYTES } from '../src/bounded-structured-mutation.js';
 
 const SWM_GRAPH = 'did:dkg:context-graph:test/_shared_memory';
 const NON_SWM_GRAPH = 'did:dkg:context-graph:test';
@@ -305,6 +307,72 @@ describe('SharedMemoryLiteralBlobStore', () => {
       `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${subject}> <http://schema.org/value> ?o } }`,
     );
     expect(select.type === 'bindings' ? select.bindings : []).toEqual([{ o: largeLiteral }]);
+  });
+
+  it('externalizes a large literal in a predicate-only replacement', async () => {
+    const blobDir = await tempBlobDir();
+    const inner = new OxigraphStore();
+    const store = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 20 });
+    const subject = 'http://ex.org/predicate-replacement';
+    const largeLiteral = `"${'predicate-value'.repeat(8)}"`;
+
+    await store.structuredMutation({ kind: 'replace-subject-predicates', input: {
+      graphUri: SWM_GRAPH,
+      subject,
+      predicates: ['http://schema.org/value'],
+      replacementQuads: [quad(subject, largeLiteral, SWM_GRAPH)],
+    } });
+
+    const hash = sha256Term(largeLiteral);
+    expect(await readFile(blobPath(blobDir, hash), 'utf8')).toBe(largeLiteral);
+    const raw = await inner.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${subject}> <http://schema.org/value> ?o } }`,
+    );
+    expect(raw.type === 'bindings' ? raw.bindings : []).toEqual([{ o: externalRef(hash) }]);
+    const hydrated = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${subject}> <http://schema.org/value> ?o } }`,
+    );
+    expect(hydrated.type === 'bindings' ? hydrated.bindings : []).toEqual([{ o: largeLiteral }]);
+  });
+
+  it('externalizes an over-budget replacement literal before validating the rewritten mutation', async () => {
+    const blobDir = await tempBlobDir();
+    const inner = new OxigraphStore();
+    const mutationSpy = vi.spyOn(inner, 'structuredMutation');
+    const store = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 20 });
+    const subject = 'http://ex.org/over-budget-predicate-replacement';
+    const largeLiteral = `"${'x'.repeat(BOUNDED_MUTATION_MAX_OPERAND_BYTES + 1)}"`;
+
+    await store.structuredMutation({ kind: 'replace-subject-predicates', input: {
+      graphUri: SWM_GRAPH,
+      subject,
+      predicates: ['http://schema.org/value'],
+      replacementQuads: [quad(subject, largeLiteral, SWM_GRAPH)],
+    } });
+
+    expect(mutationSpy).toHaveBeenCalledTimes(1);
+    const forwarded = mutationSpy.mock.calls[0][0] as StructuredMutation;
+    expect(forwarded.kind).toBe('replace-subject-predicates');
+    if (forwarded.kind !== 'replace-subject-predicates') {
+      throw new Error(`unexpected forwarded mutation kind: ${forwarded.kind}`);
+    }
+    const hash = sha256Term(largeLiteral);
+    expect(forwarded.input.replacementQuads[0].object).toBe(externalRef(hash));
+    expect(await readFile(blobPath(blobDir, hash), 'utf8')).toBe(largeLiteral);
+
+    const hydrated = await store.query(
+      `CONSTRUCT { <${subject}> <http://schema.org/value> ?o }
+       WHERE { GRAPH <${SWM_GRAPH}> { <${subject}> <http://schema.org/value> ?o } }`,
+    );
+    expect(hydrated.type).toBe('quads');
+    if (hydrated.type === 'quads') {
+      expect(hydrated.quads).toEqual([{
+        subject,
+        predicate: 'http://schema.org/value',
+        object: largeLiteral,
+        graph: '',
+      }]);
+    }
   });
 });
 

--- a/packages/storage/test/graph-set-index-store-harness.ts
+++ b/packages/storage/test/graph-set-index-store-harness.ts
@@ -2,6 +2,7 @@ import {
   type Quad,
   type QueryOptions,
   type QueryResult,
+  type StructuredMutation,
   type TripleStore,
 } from '../src/index.js';
 
@@ -41,6 +42,9 @@ export class CountingStore implements TripleStore {
   dropGraph(graphUri: string, options?: QueryOptions): Promise<void> { return this.inner.dropGraph(graphUri, options); }
   deleteBySubjectPrefix(graphUri: string, prefix: string, options?: QueryOptions): Promise<number> {
     return this.inner.deleteBySubjectPrefix(graphUri, prefix, options);
+  }
+  structuredMutation(mutation: StructuredMutation, options?: QueryOptions): Promise<void> {
+    return this.inner.structuredMutation!(mutation, options);
   }
   countQuads(graphUri?: string, options?: QueryOptions): Promise<number> { return this.inner.countQuads(graphUri, options); }
   flush(options?: QueryOptions): Promise<void> { return this.inner.flush?.(options) ?? Promise.resolve(); }

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -11,6 +11,8 @@ import {
   registerTripleStoreAdapter,
   type GraphSetIndexStoreOptions,
   type GraphSetMutationEvent,
+  type CopySubjectProjectionInput,
+  type StructuredMutation,
   type QueryOptions,
   type StoreWorkPriority,
 } from '../src/index.js';
@@ -82,6 +84,109 @@ async function exhaustTouchedGraphProbeRetries(
 }
 
 describe('GraphSetIndexStore', () => {
+  it('keeps the graph index warm after a structured copy and attributes only the target', async () => {
+    const source = 'did:dkg:context-graph:projection-source';
+    const target = 'did:dkg:context-graph:projection-target';
+    const root = 'urn:projection-root';
+    const inner = new OxigraphStore();
+    await inner.insert([q(source, root)]);
+    const counting = new CountingStore(inner);
+    const events: GraphSetMutationEvent[] = [];
+    const store = new GraphSetIndexStore(counting, {
+      onMutation: (event) => events.push(event),
+    });
+
+    await expect(store.listGraphs()).resolves.toEqual([source]);
+    await store.structuredMutation({ kind: 'copy-subject-projection', input: {
+      sourceGraphUris: [source],
+      targetGraphUri: target,
+      roots: [root],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    } });
+
+    await expect(store.listGraphs()).resolves.toEqual(expect.arrayContaining([source, target]));
+    expect(counting.listGraphsCalls).toBe(1);
+    expect(events).toContainEqual({
+      type: 'graph-added',
+      graph: target,
+      source: 'structuredMutation',
+    });
+    expect(events).not.toContainEqual(expect.objectContaining({
+      graph: source,
+      source: 'structuredMutation',
+    }));
+    await inner.close();
+  });
+
+  it('defensively snapshots structured operands before asynchronous forwarding', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let observed: StructuredMutation | undefined;
+    const inner = new OxigraphStore();
+    const delayed = new (class extends CountingStore {
+      override async structuredMutation(mutation: StructuredMutation): Promise<void> {
+        await gate;
+        observed = mutation;
+      }
+    })(inner);
+    const store = new GraphSetIndexStore(delayed);
+    const input: CopySubjectProjectionInput = {
+      sourceGraphUris: ['did:dkg:context-graph:source-before'],
+      targetGraphUri: 'did:dkg:context-graph:target',
+      roots: ['urn:root-before'],
+      descendantSuffix: '/',
+      excludedPredicates: ['urn:predicate-before'],
+    };
+
+    const pending = store.structuredMutation({ kind: 'copy-subject-projection', input });
+    (input.sourceGraphUris as string[])[0] = 'did:dkg:context-graph:source-after';
+    (input.roots as string[])[0] = 'urn:root-after';
+    (input.excludedPredicates as string[])[0] = 'urn:predicate-after';
+    release();
+    await pending;
+
+    expect(observed).toEqual({ kind: 'copy-subject-projection', input: {
+      sourceGraphUris: ['did:dkg:context-graph:source-before'],
+      targetGraphUri: 'did:dkg:context-graph:target',
+      roots: ['urn:root-before'],
+      descendantSuffix: '/',
+      excludedPredicates: ['urn:predicate-before'],
+    } });
+    await inner.close();
+  });
+
+  it('rebuilds a warm graph index after an indeterminate structured mutation failure', async () => {
+    const source = 'did:dkg:context-graph:indeterminate-source';
+    const target = 'did:dkg:context-graph:indeterminate-target';
+    const root = 'urn:indeterminate-root';
+    const inner = new OxigraphStore();
+    await inner.insert([q(source, root)]);
+    const uncertain = new (class extends CountingStore {
+      override async structuredMutation(
+        mutation: StructuredMutation,
+        options?: QueryOptions,
+      ): Promise<void> {
+        await super.structuredMutation(mutation, options);
+        throw new Error('lost structured mutation response');
+      }
+    })(inner);
+    const store = new GraphSetIndexStore(uncertain);
+
+    await expect(store.listGraphs()).resolves.toEqual([source]);
+    await expect(store.structuredMutation({ kind: 'copy-subject-projection', input: {
+      sourceGraphUris: [source],
+      targetGraphUri: target,
+      roots: [root],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    } })).rejects.toThrow('lost structured mutation response');
+
+    await expect(store.listGraphs()).resolves.toEqual(expect.arrayContaining([source, target]));
+    expect(uncertain.listGraphsCalls).toBe(2);
+    await inner.close();
+  });
+
   it('seeds from one listGraphs scan and serves prefix lookups from memory', async () => {
     const inner = new OxigraphStore();
     await inner.insert([

--- a/packages/storage/test/reserved-internal-graph-mutation-guard.test.ts
+++ b/packages/storage/test/reserved-internal-graph-mutation-guard.test.ts
@@ -68,6 +68,61 @@ const mutations: ReadonlyArray<{
     run: (s, g) => s.replaceGraphAndSubject!('urn:data', [], g, 'urn:s', []),
   },
   { name: 'replaceSubject', run: (s, g) => s.replaceSubject!(g, 'urn:s', []) },
+  { name: 'deleteSubjects', run: (s, g) => s.structuredMutation!({
+    kind: 'delete-subjects', input: { graphUri: g, subjects: [] },
+  }) },
+  {
+    name: 'pruneTerminalSubjects',
+    run: (s, g) => s.structuredMutation!({ kind: 'prune-ranked-subjects', input: {
+      graphUri: g,
+      subjectPrefix: 'urn:request:',
+      eligibilityPredicate: 'urn:status',
+      eligibleObjects: ['done'],
+      primaryRankPredicate: 'urn:decided',
+      secondaryRankPredicate: 'urn:requested',
+      retainNewest: 1,
+      maxDelete: 1,
+    } }),
+  },
+  {
+    name: 'pruneRecordClosures',
+    run: (s, g) => s.structuredMutation!({ kind: 'prune-linked-record-closures', input: {
+      graphUri: g,
+      matchObjectIris: ['urn:root'],
+      linkPredicates: ['urn:member'],
+      recordParentPredicate: 'urn:parent',
+      descendantSeparator: '/',
+    } }),
+  },
+  {
+    name: 'replaceSubjectPredicates',
+    run: (s, g) => s.structuredMutation!({ kind: 'replace-subject-predicates', input: {
+      graphUri: g,
+      subject: 'urn:s',
+      predicates: ['urn:p'],
+      replacementQuads: [],
+    } }),
+  },
+  {
+    name: 'replaceProjectionFromGraph(target)',
+    run: (s, g) => s.structuredMutation!({ kind: 'replace-projection-from-graph', input: {
+      targetGraphUri: g,
+      stagingGraphUri: 'urn:staging',
+      targetSubject: 'urn:s',
+      preservedTargetPredicates: [],
+      targetSubjectPrefixes: [],
+    } }),
+  },
+  {
+    name: 'copySubjectProjection(target)',
+    run: (s, g) => s.structuredMutation!({ kind: 'copy-subject-projection', input: {
+      sourceGraphUris: ['urn:source'],
+      targetGraphUri: g,
+      roots: ['urn:s'],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    } }),
+  },
 ];
 
 describe('reserved internal graph mutation guard', () => {
@@ -108,6 +163,32 @@ describe('reserved internal graph mutation guard', () => {
         nonAtomic.replaceSubject!(SYSTEM_RECORD_V1_SHADOW_AGENTS_GRAPH, 'urn:s', []),
       ).rejects.toThrow(ReservedInternalGraphWriteError);
     });
+
+    for (const graph of RESERVED) {
+      it(`refuses replaceProjectionFromGraph source ${graph.split(':').pop()} before I/O`, async () => {
+        const fetchSpy = stubFetch();
+        await expect(newStore().structuredMutation!({ kind: 'replace-projection-from-graph', input: {
+          targetGraphUri: 'urn:target',
+          stagingGraphUri: graph,
+          targetSubject: 'urn:s',
+          preservedTargetPredicates: [],
+          targetSubjectPrefixes: [],
+        } })).rejects.toThrow(ReservedInternalGraphWriteError);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+
+      it(`refuses copySubjectProjection source ${graph.split(':').pop()} before I/O`, async () => {
+        const fetchSpy = stubFetch();
+        await expect(newStore().structuredMutation!({ kind: 'copy-subject-projection', input: {
+          sourceGraphUris: [graph],
+          targetGraphUri: 'urn:target',
+          roots: ['urn:s'],
+          descendantSuffix: '/',
+          excludedPredicates: [],
+        } })).rejects.toThrow(ReservedInternalGraphWriteError);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+    }
 
     describe('the opaque update() channel is a KNOWN-OPEN route, closed in Stack C', () => {
       /**

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -2,6 +2,7 @@ import { createServer, type Server, type ServerResponse } from 'node:http';
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import {
   SparqlHttpStore,
+  asGraphWriteGenSource,
   createTripleStore,
   getExternalStorePrioritySchedulerSnapshot,
   tryReplaceGraphAtomically,
@@ -844,6 +845,36 @@ describe('SparqlHttpStore (test server)', () => {
     expect(insertedQuads).toHaveLength(1);
   });
 
+  it('replaceSubjectPredicates uses one atomic DELETE/INSERT WHERE operation', async () => {
+    insertedQuads.length = 0;
+    await store.structuredMutation!({ kind: 'replace-subject-predicates', input: {
+      graphUri: 'http://ex.org/g1',
+      subject: 'http://ex.org/job',
+      predicates: ['http://ex.org/status', 'http://ex.org/decidedAt'],
+      replacementQuads: [
+        {
+          subject: 'http://ex.org/job',
+          predicate: 'http://ex.org/status',
+          object: '"approved"',
+          graph: 'http://ex.org/g1',
+        },
+        {
+          subject: 'http://ex.org/job',
+          predicate: 'http://ex.org/decidedAt',
+          object: '"2"',
+          graph: 'http://ex.org/g1',
+        },
+      ],
+    } });
+
+    expect(insertedQuads).toHaveLength(1);
+    expect(insertedQuads[0]).toContain('DELETE {');
+    expect(insertedQuads[0]).toContain('INSERT {');
+    expect(insertedQuads[0]).toContain('WHERE {');
+    expect(insertedQuads[0]).not.toContain('INSERT DATA');
+    expect(insertedQuads[0]).not.toContain(';');
+  });
+
   it('deleteByPattern sends DELETE WHERE to update endpoint', async () => {
     insertedQuads.length = 0;
     await store.deleteByPattern({ subject: 'http://ex.org/s', graph: 'http://ex.org/g' });
@@ -919,6 +950,31 @@ describe('SparqlHttpStore (test server)', () => {
         graph: 'http://ex.org/g2',
       }]);
       await expect(store.listGraphs()).resolves.toContain('http://ex.org/g1');
+      expect(listGraphsHits).toBe(2);
+    });
+
+    it('invalidates caches and write generations after an indeterminate structured mutation', async () => {
+      listGraphsHits = 0;
+      const store = new SparqlHttpStore({
+        queryEndpoint: queryUrl,
+        updateEndpoint: updateUrl.replace('/update', '/error-update'),
+        managedByDkg: true,
+      });
+      await store.listGraphs();
+      await store.listGraphs();
+      expect(listGraphsHits).toBe(1);
+      const writeGen = asGraphWriteGenSource(store);
+      expect(writeGen).not.toBeNull();
+      const graph = 'http://ex.org/g2';
+      const before = writeGen?.getWriteGen(graph) ?? 0;
+
+      await expect(store.structuredMutation({ kind: 'delete-subjects', input: {
+        graphUri: graph,
+        subjects: ['http://ex.org/stale'],
+      } })).rejects.toThrow(/SPARQL HTTP structuredMutation failed \(500\)/);
+
+      expect(writeGen?.getWriteGen(graph)).toBeGreaterThan(before);
+      await store.listGraphs();
       expect(listGraphsHits).toBe(2);
     });
 


### PR DESCRIPTION
## Summary

- Migrate the remaining exact managed-state writes for requester join state, graph-scoped KA materialization, and subgraph registration into bounded structured storage operations.
- Include the merged #2186 expansion: one closed `TripleStore.structuredMutation()` union, bounded validation and serialization, first-party adapter/decorator forwarding, and migrations for catalog, retention, curator refresh, RS repair, and KA metadata callers.
- Reuse the canonical store-chain traversal for capability discovery, so transparent wrappers participate through their existing chain link instead of maintaining a parallel forwarding protocol.
- Guard every RS-heal materialization write boundary with the current subscription/on-chain binding so a stale repair pass cannot clear a valid completion marker.
- Remove the subgraph deregistration fallback that sent a SPARQL mutation through `query()`, while preserving rolling-upgrade behavior through explicit capability checks.
- Keep raw-channel contraction separate in stacked PR #2187 so the ownership-lease security boundary can be reviewed independently.

## Related

- Related to #2162
- Part of #2052
- Includes merged #2186
- Stacked PR: #2187
- Follow-up: #2188

## Diagrams

### Managed-state mutation path

```mermaid
flowchart LR
    A[Domain caller] --> B[Structured mutation descriptor]
    B --> C{Validate scope and bounds}
    C -->|invalid| D[Typed refusal]
    C -->|valid| E[Decorators account for touched graphs]
    E --> F[Adapter-authored bounded SPARQL]
    F --> G[Storage backend]
```

### Stack boundary

```mermaid
flowchart TB
    P2186[PR 2186: bounded capability layer]
    P2185[PR 2185: migrate exact callers]
    P2187[PR 2187: close leased raw mutation channels]
    P2186 --> P2185
    P2185 --> P2187
```

## Files changed

| Area | What |
|------|------|
| `packages/storage/src/**` | Defines, validates, forwards, and implements the closed structured mutation capability across first-party stores and decorators. |
| `packages/agent/src/**` | Migrates join state, registration cleanup, retention, curator refresh, and RS repair away from caller-authored mutations; guards RS-heal writes against stale ownership. |
| `packages/publisher/src/**` | Migrates graph-scoped KA materialization, catalog cleanup, agents retention, and Merkle-root metadata. |
| `packages/{storage,agent,publisher}/test/**` | Covers bounds, atomicity, reserved scopes, decorator accounting, worker parity, retries, retention, rolling-upgrade behavior, and stale RS-heal cancellation. |

## Test plan

- [x] Post-rebase builds: core, storage, publisher, and agent
- [x] Canonical capability-chain regression: 30 focused storage tests, including link-only capable and incapable wrappers
- [x] Post-rebase Agent selected suites: 32 passed
- [x] Decorated RS-repair suite after the final review fix: 16 passed
- [x] Companion RS-repair suite after the final review fix: 15 passed
- [x] Post-rebase Publisher selected suites: 22 passed
- [x] Agent type and package-root checks
- [x] Merged #2186 storage suite evidence: 948 passed, 26 skipped integration tests
- [x] Merged #2186 changed Agent suite: 76 passed
- [x] Merged #2186 focused Publisher suite: 65 passed
- [x] Real worker-RPC coverage for all six structured mutation variants
- [x] Multi-root and over-budget RS repair coverage, including ordered chunks below the 4 MiB serialized-update cap
- [x] Stale-before-first-write and stale-after-data-copy RS-heal regressions proving later metadata/completion writes are not dispatched
- [x] Over-cap retention integration across multiple bounded mutations
- [x] Raw mutation inventory at the merged capability head: no Agent/Publisher `store.update()` or mutating `store.query()` caller remains
- [x] `git diff --check`; worktree clean after rebasing onto current `integration/2052-system-record-sync`