### PR TITLE
refactor(storage): own structured mutation commit effects

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -581,8 +581,8 @@ export function createListContextGraphsCacheInvalidatingStore(
           const effects = captureStructuredMutationEffects(mutation);
           return invalidateAfterMutation(
             () => innerStore.structuredMutation!(mutation, options),
-            () => effects.mightMutate,
-            () => effects.touchedGraphs.forEach(
+            () => effects !== undefined,
+            () => effects?.touchedGraphs.forEach(
               (graph) => markProjectionDirty?.(undefined, graph),
             ),
           );

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -110,7 +110,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, createTripleStore, isExternalBackend, structuredMutationMightMutate, structuredMutationTouchedGraphs, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, createTripleStore, isExternalBackend, runStructuredMutationWithCommittedEffects, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -577,17 +577,15 @@ export function createListContextGraphsCacheInvalidatingStore(
           )
       : undefined,
     structuredMutation: innerStore.structuredMutation
-      ? (mutation, options) => {
-          // Capture scope before the first await so caller-side mutation cannot
-          // redirect cache invalidation after the backend has committed.
-          const targetGraphs = [...structuredMutationTouchedGraphs(mutation)];
-          const mightMutate = structuredMutationMightMutate(mutation);
-          return invalidateAfterMutation(
-            () => innerStore.structuredMutation!(mutation, options),
-            () => mightMutate,
-            () => targetGraphs.forEach((graph) => markProjectionDirty?.(undefined, graph)),
-          );
-        }
+      ? (mutation, options) => runStructuredMutationWithCommittedEffects(
+          innerStore,
+          mutation,
+          options,
+          ({ touchedGraphs }) => {
+            invalidate();
+            touchedGraphs.forEach((graph) => markProjectionDirty?.(undefined, graph));
+          },
+        )
       : undefined,
     listGraphs(options) {
       return innerStore.listGraphs(options);

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -110,7 +110,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, createTripleStore, isExternalBackend, runStructuredMutationWithCommittedEffects, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, captureStructuredMutationEffects, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -577,15 +577,16 @@ export function createListContextGraphsCacheInvalidatingStore(
           )
       : undefined,
     structuredMutation: innerStore.structuredMutation
-      ? (mutation, options) => runStructuredMutationWithCommittedEffects(
-          innerStore,
-          mutation,
-          options,
-          ({ touchedGraphs }) => {
-            invalidate();
-            touchedGraphs.forEach((graph) => markProjectionDirty?.(undefined, graph));
-          },
-        )
+      ? (mutation, options) => {
+          const effects = captureStructuredMutationEffects(mutation);
+          return invalidateAfterMutation(
+            () => innerStore.structuredMutation!(mutation, options),
+            () => effects.mightMutate,
+            () => effects.touchedGraphs.forEach(
+              (graph) => markProjectionDirty?.(undefined, graph),
+            ),
+          );
+        }
       : undefined,
     listGraphs(options) {
       return innerStore.listGraphs(options);

--- a/packages/agent/test/replace-subject-agent-wrapper.test.ts
+++ b/packages/agent/test/replace-subject-agent-wrapper.test.ts
@@ -154,9 +154,18 @@ describe('#1863 replaceSubject through the agent store wrapper', () => {
   it('invalidates structured mutation effects after success without decoding them in Agent', async () => {
     let release!: () => void;
     const inFlight = new Promise<void>((resolve) => { release = resolve; });
-    const inner = {
-      structuredMutation: vi.fn(async () => inFlight),
-    } as unknown as TripleStore;
+    const options = { source: 'agent.test.structured-mutation-effects' };
+    let inner!: TripleStore;
+    const structuredMutation = vi.fn(function (
+      this: TripleStore,
+      _mutation: unknown,
+      receivedOptions: unknown,
+    ) {
+      expect(this).toBe(inner);
+      expect(receivedOptions).toBe(options);
+      return inFlight;
+    });
+    inner = { structuredMutation } as unknown as TripleStore;
     const invalidate = vi.fn();
     const markProjectionDirty = vi.fn();
     const store = createListContextGraphsCacheInvalidatingStore(
@@ -175,7 +184,7 @@ describe('#1863 replaceSubject through the agent store wrapper', () => {
       },
     };
 
-    const pending = store.structuredMutation!(mutation);
+    const pending = store.structuredMutation!(mutation, options);
     mutation.input.targetGraphUri = 'urn:test:redirected';
     expect(invalidate).not.toHaveBeenCalled();
     release();

--- a/packages/agent/test/replace-subject-agent-wrapper.test.ts
+++ b/packages/agent/test/replace-subject-agent-wrapper.test.ts
@@ -15,7 +15,7 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   CHANGELOG_GRAPH,
   OxigraphStore,
@@ -149,5 +149,68 @@ describe('#1863 replaceSubject through the agent store wrapper', () => {
     // entry created, no whole-cache churn on the hot job-write path.
     proj.markDirtyForGraph('urn:dkg:publisher:control-plane');
     expect(entries.has('urn:dkg:publisher:control-plane')).toBe(false);
+  });
+
+  it('invalidates structured mutation effects after success without decoding them in Agent', async () => {
+    let release!: () => void;
+    const inFlight = new Promise<void>((resolve) => { release = resolve; });
+    const inner = {
+      structuredMutation: vi.fn(async () => inFlight),
+    } as unknown as TripleStore;
+    const invalidate = vi.fn();
+    const markProjectionDirty = vi.fn();
+    const store = createListContextGraphsCacheInvalidatingStore(
+      inner,
+      invalidate,
+      markProjectionDirty,
+    );
+    const mutation = {
+      kind: 'copy-subject-projection' as const,
+      input: {
+        sourceGraphUris: ['urn:test:source'],
+        targetGraphUri: 'urn:test:target',
+        roots: ['urn:test:root'],
+        descendantSuffix: '/',
+        excludedPredicates: [],
+      },
+    };
+
+    const pending = store.structuredMutation!(mutation);
+    mutation.input.targetGraphUri = 'urn:test:redirected';
+    expect(invalidate).not.toHaveBeenCalled();
+    release();
+    await pending;
+
+    expect(invalidate).toHaveBeenCalledOnce();
+    expect(markProjectionDirty).toHaveBeenCalledOnce();
+    expect(markProjectionDirty).toHaveBeenCalledWith(undefined, 'urn:test:target');
+  });
+
+  it('does not invalidate structured mutation failures or structural no-ops', async () => {
+    const invalidate = vi.fn();
+    const markProjectionDirty = vi.fn();
+    const inner = {
+      structuredMutation: vi.fn(async () => undefined),
+    } as unknown as TripleStore;
+    const store = createListContextGraphsCacheInvalidatingStore(
+      inner,
+      invalidate,
+      markProjectionDirty,
+    );
+
+    await store.structuredMutation!({
+      kind: 'delete-subjects',
+      input: { graphUri: 'urn:test:target', subjects: [] },
+    });
+    expect(invalidate).not.toHaveBeenCalled();
+    expect(markProjectionDirty).not.toHaveBeenCalled();
+
+    inner.structuredMutation = vi.fn(async () => { throw new Error('commit failed'); });
+    await expect(store.structuredMutation!({
+      kind: 'delete-subjects',
+      input: { graphUri: 'urn:test:target', subjects: ['urn:test:subject'] },
+    })).rejects.toThrow('commit failed');
+    expect(invalidate).not.toHaveBeenCalled();
+    expect(markProjectionDirty).not.toHaveBeenCalled();
   });
 });

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -34,8 +34,8 @@ import {
 } from '../atomic-graph-replace.js';
 import {
   buildStructuredMutationUpdate,
+  captureStructuredMutationEffects,
   normalizeStructuredMutation,
-  structuredMutationMightMutate,
 } from '../bounded-structured-mutation.js';
 import { quadToNQuad } from '../bounded-rdf.js';
 import { readResponseTextBounded } from '../http-response-limit.js';
@@ -417,6 +417,7 @@ export class BlazegraphStore implements TripleStore {
     options?: QueryOptions,
   ): Promise<void> {
     const normalized = normalizeStructuredMutation(mutation);
+    const effects = captureStructuredMutationEffects(normalized);
     if (normalized.kind === 'replace-subject-predicates') {
       assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
         maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
@@ -424,7 +425,7 @@ export class BlazegraphStore implements TripleStore {
       });
     }
     const update = buildStructuredMutationUpdate(normalized);
-    if (!update || !structuredMutationMightMutate(normalized)) return;
+    if (!update || !effects) return;
     await this.sparqlUpdate(
       update,
       { ...options, source: options?.source ?? 'blazegraph.structuredMutation' },

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -13,9 +13,8 @@ import type {
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { GraphWriteGenTracker } from '../graph-write-gen.js';
 import {
+  captureStructuredMutationEffects,
   normalizeStructuredMutation,
-  structuredMutationMightMutate,
-  structuredMutationTouchedGraphs,
 } from '../bounded-structured-mutation.js';
 
 /**
@@ -698,10 +697,9 @@ export class OxigraphWorkerStore implements TripleStore {
     _options?: TripleStoreQueryOptions,
   ): Promise<void> {
     const normalized = normalizeStructuredMutation(mutation);
+    const effects = captureStructuredMutationEffects(normalized);
     await this.call('structuredMutation', normalized);
-    if (structuredMutationMightMutate(normalized)) {
-      this.writeGen.recordGraphWrites(structuredMutationTouchedGraphs(normalized));
-    }
+    if (effects) this.writeGen.recordGraphWrites(effects.touchedGraphs);
   }
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     return this.callWithTimeout<QueryResult>(this.operationTimeoutMs, options?.signal, 'query', sparql);

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -28,9 +28,8 @@ import {
 } from '../atomic-graph-replace.js';
 import {
   buildStructuredMutationUpdate,
+  captureStructuredMutationEffects,
   normalizeStructuredMutation,
-  structuredMutationMightMutate,
-  structuredMutationTouchedGraphs,
 } from '../bounded-structured-mutation.js';
 import { quadsToNQuads } from '../bounded-rdf.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
@@ -421,6 +420,7 @@ export class OxigraphStore implements TripleStore {
     _options?: TripleStoreQueryOptions,
   ): Promise<void> {
     const normalized = normalizeStructuredMutation(mutation);
+    const effects = captureStructuredMutationEffects(normalized);
     if (normalized.kind === 'replace-subject-predicates') {
       assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
         maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
@@ -428,10 +428,10 @@ export class OxigraphStore implements TripleStore {
       });
     }
     const update = buildStructuredMutationUpdate(normalized);
-    if (!update || !structuredMutationMightMutate(normalized)) return;
+    if (!update || !effects) return;
     this.store.update(update);
     this.scheduleFlush();
-    this.writeGen.recordGraphWrites(structuredMutationTouchedGraphs(normalized));
+    this.writeGen.recordGraphWrites(effects.touchedGraphs);
   }
 
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -54,10 +54,9 @@ import {
 } from '../atomic-graph-replace.js';
 import {
   buildStructuredMutationUpdate,
+  captureStructuredMutationEffects,
   normalizeStructuredMutation,
   structuredMutationGuardedGraphs,
-  structuredMutationMightMutate,
-  structuredMutationTouchedGraphs,
 } from '../bounded-structured-mutation.js';
 import {
   assertNotReservedInternalGraphV1,
@@ -1299,7 +1298,7 @@ export class SparqlHttpStore implements TripleStore {
     options?: QueryOptions,
   ): Promise<void> {
     const normalized = normalizeStructuredMutation(mutation);
-    const touchedGraphs = structuredMutationTouchedGraphs(normalized);
+    const effects = captureStructuredMutationEffects(normalized);
     this.assertGenericMutationScope(structuredMutationGuardedGraphs(normalized), 'structuredMutation');
     if (normalized.kind === 'replace-subject-predicates') {
       assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
@@ -1308,24 +1307,24 @@ export class SparqlHttpStore implements TripleStore {
       });
     }
     const update = buildStructuredMutationUpdate(normalized);
-    if (!update || !structuredMutationMightMutate(normalized)) return;
+    if (!update || !effects) return;
     try {
       await this.postUpdate(
         update,
         { ...options, source: options?.source ?? 'sparql-http.structuredMutation' },
         'structuredMutation',
-        touchedGraphs,
+        effects.touchedGraphs,
       );
     } catch (error) {
       // A remote endpoint may commit before its response is lost. Fail open for
       // cache coherence: invalidate graph enumeration and advance each affected
       // write generation even though the caller still receives the failure.
       this.invalidateListGraphsCache();
-      this.writeGen.recordGraphWrites(touchedGraphs);
+      this.writeGen.recordGraphWrites(effects.touchedGraphs);
       throw error;
     }
     this.invalidateListGraphsCache();
-    this.writeGen.recordGraphWrites(touchedGraphs);
+    this.writeGen.recordGraphWrites(effects.touchedGraphs);
   }
 
   async query(sparql: string, options?: SparqlHttpQueryOptions): Promise<QueryResult> {

--- a/packages/storage/src/bounded-structured-mutation.ts
+++ b/packages/storage/src/bounded-structured-mutation.ts
@@ -12,11 +12,8 @@ import type {
   ReplaceProjectionFromGraphInput,
   ReplaceSubjectPredicatesInput,
   StructuredMutation,
-  TripleStore,
-  QueryOptions,
 } from './triple-store.js';
 import { formatRdfObjectTerm } from './rdf-term-format.js';
-import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 export const BOUNDED_MUTATION_MAX_IRIS = 100_000;
 export const BOUNDED_MUTATION_MAX_PRUNE_DELETE = 10_000;
@@ -684,33 +681,19 @@ export function structuredMutationMightMutate(mutation: StructuredMutation): boo
   return mutation.kind !== 'delete-subjects' || mutation.input.subjects.length > 0;
 }
 
-/** Graph-scoped effects reported only after a structured mutation commits successfully. */
-export interface CommittedStructuredMutationEffects {
+/** Immutable graph-scoped effects captured before a structured mutation is dispatched. */
+export interface StructuredMutationEffects {
+  readonly mightMutate: boolean;
   readonly touchedGraphs: readonly string[];
 }
 
-/**
- * Execute one structured mutation and report its canonical graph effects after success.
- *
- * Effect scope is captured before the first await so a caller cannot redirect cache
- * invalidation by mutating an input object while the backend operation is in flight.
- * Structurally empty operations do not report a commit effect.
- */
-export async function runStructuredMutationWithCommittedEffects(
-  store: Pick<TripleStore, 'structuredMutation'>,
+/** Capture canonical effects without executing or probing a store capability. */
+export function captureStructuredMutationEffects(
   mutation: StructuredMutation,
-  options: QueryOptions | undefined,
-  onCommitted: (effects: CommittedStructuredMutationEffects) => void,
-): Promise<void> {
-  const execute = store.structuredMutation;
-  if (typeof execute !== 'function') {
-    throw new UnsupportedTripleStoreCapabilityError(
-      'structuredMutation',
-      'runStructuredMutationWithCommittedEffects',
-    );
-  }
-  const mightMutate = structuredMutationMightMutate(mutation);
+): StructuredMutationEffects {
   const touchedGraphs = Object.freeze([...structuredMutationTouchedGraphs(mutation)]);
-  await execute.call(store, mutation, options);
-  if (mightMutate) onCommitted(Object.freeze({ touchedGraphs }));
+  return Object.freeze({
+    mightMutate: structuredMutationMightMutate(mutation),
+    touchedGraphs,
+  });
 }

--- a/packages/storage/src/bounded-structured-mutation.ts
+++ b/packages/storage/src/bounded-structured-mutation.ts
@@ -683,17 +683,14 @@ export function structuredMutationMightMutate(mutation: StructuredMutation): boo
 
 /** Immutable graph-scoped effects captured before a structured mutation is dispatched. */
 export interface StructuredMutationEffects {
-  readonly mightMutate: boolean;
   readonly touchedGraphs: readonly string[];
 }
 
 /** Capture canonical effects without executing or probing a store capability. */
 export function captureStructuredMutationEffects(
   mutation: StructuredMutation,
-): StructuredMutationEffects {
+): StructuredMutationEffects | undefined {
+  if (!structuredMutationMightMutate(mutation)) return undefined;
   const touchedGraphs = Object.freeze([...structuredMutationTouchedGraphs(mutation)]);
-  return Object.freeze({
-    mightMutate: structuredMutationMightMutate(mutation),
-    touchedGraphs,
-  });
+  return Object.freeze({ touchedGraphs });
 }

--- a/packages/storage/src/bounded-structured-mutation.ts
+++ b/packages/storage/src/bounded-structured-mutation.ts
@@ -12,8 +12,11 @@ import type {
   ReplaceProjectionFromGraphInput,
   ReplaceSubjectPredicatesInput,
   StructuredMutation,
+  TripleStore,
+  QueryOptions,
 } from './triple-store.js';
 import { formatRdfObjectTerm } from './rdf-term-format.js';
+import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 export const BOUNDED_MUTATION_MAX_IRIS = 100_000;
 export const BOUNDED_MUTATION_MAX_PRUNE_DELETE = 10_000;
@@ -679,4 +682,35 @@ export function structuredMutationTouchedGraphs(mutation: StructuredMutation): r
 
 export function structuredMutationMightMutate(mutation: StructuredMutation): boolean {
   return mutation.kind !== 'delete-subjects' || mutation.input.subjects.length > 0;
+}
+
+/** Graph-scoped effects reported only after a structured mutation commits successfully. */
+export interface CommittedStructuredMutationEffects {
+  readonly touchedGraphs: readonly string[];
+}
+
+/**
+ * Execute one structured mutation and report its canonical graph effects after success.
+ *
+ * Effect scope is captured before the first await so a caller cannot redirect cache
+ * invalidation by mutating an input object while the backend operation is in flight.
+ * Structurally empty operations do not report a commit effect.
+ */
+export async function runStructuredMutationWithCommittedEffects(
+  store: Pick<TripleStore, 'structuredMutation'>,
+  mutation: StructuredMutation,
+  options: QueryOptions | undefined,
+  onCommitted: (effects: CommittedStructuredMutationEffects) => void,
+): Promise<void> {
+  const execute = store.structuredMutation;
+  if (typeof execute !== 'function') {
+    throw new UnsupportedTripleStoreCapabilityError(
+      'structuredMutation',
+      'runStructuredMutationWithCommittedEffects',
+    );
+  }
+  const mightMutate = structuredMutationMightMutate(mutation);
+  const touchedGraphs = Object.freeze([...structuredMutationTouchedGraphs(mutation)]);
+  await execute.call(store, mutation, options);
+  if (mightMutate) onCommitted(Object.freeze({ touchedGraphs }));
 }

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -24,10 +24,9 @@ import {
 } from './store-chain-capability.js';
 import type { SystemRecordLaneControllerV1 } from './system-record-materializer-v1.js';
 import {
+  captureStructuredMutationEffects,
   normalizeStructuredMutation,
   structuredMutationGuardedGraphs,
-  structuredMutationMightMutate,
-  structuredMutationTouchedGraphs,
 } from './bounded-structured-mutation.js';
 
 /**
@@ -460,6 +459,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
 
   async structuredMutation(mutation: StructuredMutation, options?: QueryOptions): Promise<void> {
     const normalized = normalizeStructuredMutation(mutation);
+    const effects = captureStructuredMutationEffects(normalized);
     const operation = this.inner.structuredMutation;
     if (!operation) {
       throw new UnsupportedTripleStoreCapabilityError('structuredMutation', 'ChangelogStore');
@@ -477,8 +477,8 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
         }
         throw error;
       }
-      if (structuredMutationMightMutate(normalized)) {
-        await this.markPostMutation(structuredMutationTouchedGraphs(normalized), options);
+      if (effects) {
+        await this.markPostMutation(effects.touchedGraphs, options);
       }
     });
   }

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -23,9 +23,8 @@ import {
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { ManagedOxigraphBackendUnownedError } from './managed-oxigraph-ownership-v1-internal.js';
 import {
+  captureStructuredMutationEffects,
   normalizeStructuredMutation,
-  structuredMutationMightMutate,
-  structuredMutationTouchedGraphs,
 } from './bounded-structured-mutation.js';
 import {
   CACHED_READ_GATE_V1,
@@ -559,6 +558,7 @@ export class GraphSetIndexStore implements TripleStore {
 
   async structuredMutation(mutation: StructuredMutation, options?: QueryOptions): Promise<void> {
     const normalized = normalizeStructuredMutation(mutation);
+    const effects = captureStructuredMutationEffects(normalized);
     const operation = this.inner.structuredMutation;
     if (!operation) {
       throw new UnsupportedTripleStoreCapabilityError('structuredMutation', 'GraphSetIndexStore');
@@ -571,10 +571,10 @@ export class GraphSetIndexStore implements TripleStore {
       }
       throw error;
     }
-    if (!this.enabled || !structuredMutationMightMutate(normalized)) return;
+    if (!this.enabled || !effects) return;
     this.bumpMutation();
     await this.maintainTouchedGraphs(
-      [...structuredMutationTouchedGraphs(normalized)],
+      [...effects.touchedGraphs],
       'structuredMutation',
       options,
     );

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -52,8 +52,10 @@ export {
 export {
   BOUNDED_MUTATION_MAX_PRUNE_DELETE,
   chunkCopySubjectProjectionInput,
+  runStructuredMutationWithCommittedEffects,
   structuredMutationMightMutate,
   structuredMutationTouchedGraphs,
+  type CommittedStructuredMutationEffects,
 } from './bounded-structured-mutation.js';
 // System-record V1 (#2052 Stack B2). Default-unused: these modules perform no
 // I/O, scheduling, timer, or per-store lane work until the daemon supervisor

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -51,11 +51,11 @@ export {
 } from './atomic-graph-replace.js';
 export {
   BOUNDED_MUTATION_MAX_PRUNE_DELETE,
+  captureStructuredMutationEffects,
   chunkCopySubjectProjectionInput,
-  runStructuredMutationWithCommittedEffects,
   structuredMutationMightMutate,
   structuredMutationTouchedGraphs,
-  type CommittedStructuredMutationEffects,
+  type StructuredMutationEffects,
 } from './bounded-structured-mutation.js';
 // System-record V1 (#2052 Stack B2). Default-unused: these modules perform no
 // I/O, scheduling, timer, or per-store lane work until the daemon supervisor

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -8,9 +8,9 @@ import {
   OxigraphWorkerStore,
   TRIPLE_STORE_CAPABILITY_SUPPORT,
   UnsupportedTripleStoreCapabilityError,
+  captureStructuredMutationEffects,
   supportsReplaceSubjectPredicatesAtomically,
   supportsTripleStoreCapability,
-  runStructuredMutationWithCommittedEffects,
   tryCopySubjectProjection,
   tryDeleteSubjects,
   tryReplaceProjectionFromGraphAtomically,
@@ -49,12 +49,7 @@ async function rows(store: TripleStore, graph: string): Promise<Array<Record<str
 }
 
 describe('bounded structured mutation capabilities', () => {
-  it('reports immutable graph effects only after a potentially mutating commit', async () => {
-    let release!: () => void;
-    const inFlight = new Promise<void>((resolve) => { release = resolve; });
-    const structuredMutation = vi.fn(async () => inFlight);
-    const store = { structuredMutation } as unknown as TripleStore;
-    const onCommitted = vi.fn();
+  it('captures immutable graph effects before dispatch', () => {
     const mutation = {
       kind: 'copy-subject-projection' as const,
       input: {
@@ -66,41 +61,22 @@ describe('bounded structured mutation capabilities', () => {
       },
     };
 
-    const pending = runStructuredMutationWithCommittedEffects(
-      store,
-      mutation,
-      undefined,
-      onCommitted,
-    );
+    const effects = captureStructuredMutationEffects(mutation);
     mutation.input.targetGraphUri = 'urn:test:redirected';
-    expect(onCommitted).not.toHaveBeenCalled();
-    release();
-    await pending;
-
-    expect(onCommitted).toHaveBeenCalledOnce();
-    const effects = onCommitted.mock.calls[0]![0];
-    expect(effects).toEqual({ touchedGraphs: [OTHER_GRAPH] });
+    expect(effects).toEqual({ mightMutate: true, touchedGraphs: [OTHER_GRAPH] });
     expect(Object.isFrozen(effects)).toBe(true);
     expect(Object.isFrozen(effects.touchedGraphs)).toBe(true);
   });
 
-  it('does not report effects for structural no-ops or failed mutations', async () => {
-    const onCommitted = vi.fn();
-    const successful = { structuredMutation: vi.fn(async () => undefined) } as unknown as TripleStore;
-    await runStructuredMutationWithCommittedEffects(successful, {
+  it('classifies structural no-ops without store orchestration', () => {
+    expect(captureStructuredMutationEffects({
       kind: 'delete-subjects',
       input: { graphUri: GRAPH, subjects: [] },
-    }, undefined, onCommitted);
-    expect(onCommitted).not.toHaveBeenCalled();
-
-    const failed = {
-      structuredMutation: vi.fn(async () => { throw new Error('commit failed'); }),
-    } as unknown as TripleStore;
-    await expect(runStructuredMutationWithCommittedEffects(failed, {
+    })).toEqual({ mightMutate: false, touchedGraphs: [GRAPH] });
+    expect(captureStructuredMutationEffects({
       kind: 'delete-subjects',
       input: { graphUri: GRAPH, subjects: ['urn:test:a'] },
-    }, undefined, onCommitted)).rejects.toThrow('commit failed');
-    expect(onCommitted).not.toHaveBeenCalled();
+    })).toEqual({ mightMutate: true, touchedGraphs: [GRAPH] });
   });
 
   it('reports the canonical target graph for every structured mutation kind', async () => {
@@ -131,12 +107,11 @@ describe('bounded structured mutation capabilities', () => {
         roots: ['urn:test:a'], descendantSuffix: '/', excludedPredicates: [],
       } }, OTHER_GRAPH],
     ];
-    const store = { structuredMutation: vi.fn(async () => undefined) } as unknown as TripleStore;
-
     for (const [mutation, expectedGraph] of mutations) {
-      const onCommitted = vi.fn();
-      await runStructuredMutationWithCommittedEffects(store, mutation, undefined, onCommitted);
-      expect(onCommitted).toHaveBeenCalledWith({ touchedGraphs: [expectedGraph] });
+      expect(captureStructuredMutationEffects(mutation)).toEqual({
+        mightMutate: true,
+        touchedGraphs: [expectedGraph],
+      });
     }
   });
 

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -10,10 +10,12 @@ import {
   UnsupportedTripleStoreCapabilityError,
   supportsReplaceSubjectPredicatesAtomically,
   supportsTripleStoreCapability,
+  runStructuredMutationWithCommittedEffects,
   tryCopySubjectProjection,
   tryDeleteSubjects,
   tryReplaceProjectionFromGraphAtomically,
   type Quad,
+  type StructuredMutation,
   type TripleStore,
 } from '../src/index.js';
 import {
@@ -47,6 +49,97 @@ async function rows(store: TripleStore, graph: string): Promise<Array<Record<str
 }
 
 describe('bounded structured mutation capabilities', () => {
+  it('reports immutable graph effects only after a potentially mutating commit', async () => {
+    let release!: () => void;
+    const inFlight = new Promise<void>((resolve) => { release = resolve; });
+    const structuredMutation = vi.fn(async () => inFlight);
+    const store = { structuredMutation } as unknown as TripleStore;
+    const onCommitted = vi.fn();
+    const mutation = {
+      kind: 'copy-subject-projection' as const,
+      input: {
+        sourceGraphUris: [GRAPH],
+        targetGraphUri: OTHER_GRAPH,
+        roots: ['urn:test:a'],
+        descendantSuffix: '/',
+        excludedPredicates: [],
+      },
+    };
+
+    const pending = runStructuredMutationWithCommittedEffects(
+      store,
+      mutation,
+      undefined,
+      onCommitted,
+    );
+    mutation.input.targetGraphUri = 'urn:test:redirected';
+    expect(onCommitted).not.toHaveBeenCalled();
+    release();
+    await pending;
+
+    expect(onCommitted).toHaveBeenCalledOnce();
+    const effects = onCommitted.mock.calls[0]![0];
+    expect(effects).toEqual({ touchedGraphs: [OTHER_GRAPH] });
+    expect(Object.isFrozen(effects)).toBe(true);
+    expect(Object.isFrozen(effects.touchedGraphs)).toBe(true);
+  });
+
+  it('does not report effects for structural no-ops or failed mutations', async () => {
+    const onCommitted = vi.fn();
+    const successful = { structuredMutation: vi.fn(async () => undefined) } as unknown as TripleStore;
+    await runStructuredMutationWithCommittedEffects(successful, {
+      kind: 'delete-subjects',
+      input: { graphUri: GRAPH, subjects: [] },
+    }, undefined, onCommitted);
+    expect(onCommitted).not.toHaveBeenCalled();
+
+    const failed = {
+      structuredMutation: vi.fn(async () => { throw new Error('commit failed'); }),
+    } as unknown as TripleStore;
+    await expect(runStructuredMutationWithCommittedEffects(failed, {
+      kind: 'delete-subjects',
+      input: { graphUri: GRAPH, subjects: ['urn:test:a'] },
+    }, undefined, onCommitted)).rejects.toThrow('commit failed');
+    expect(onCommitted).not.toHaveBeenCalled();
+  });
+
+  it('reports the canonical target graph for every structured mutation kind', async () => {
+    const mutations: Array<readonly [StructuredMutation, string]> = [
+      [{ kind: 'delete-subjects', input: {
+        graphUri: GRAPH, subjects: ['urn:test:a'],
+      } }, GRAPH],
+      [{ kind: 'prune-ranked-subjects', input: {
+        graphUri: GRAPH, subjectPrefix: 'urn:test:req:', eligibilityPredicate: STATUS,
+        eligibleObjects: ['approved'], primaryRankPredicate: DECIDED_AT,
+        secondaryRankPredicate: REQUESTED_AT, retainNewest: 1, maxDelete: 1,
+      } }, GRAPH],
+      [{ kind: 'prune-linked-record-closures', input: {
+        graphUri: GRAPH, matchObjectIris: ['urn:test:agent'], linkPredicates: [P],
+        recordParentPredicate: STATUS, descendantSeparator: '/',
+      } }, GRAPH],
+      [{ kind: 'replace-subject-predicates', input: {
+        graphUri: GRAPH, subject: 'urn:test:a', predicates: [P],
+        replacementQuads: [quad('urn:test:a', P, '"replacement"')],
+      } }, GRAPH],
+      [{ kind: 'replace-projection-from-graph', input: {
+        targetGraphUri: GRAPH, stagingGraphUri: 'urn:test:staging',
+        targetSubject: 'urn:test:a', preservedTargetPredicates: [],
+        targetSubjectPrefixes: [],
+      } }, GRAPH],
+      [{ kind: 'copy-subject-projection', input: {
+        sourceGraphUris: [GRAPH], targetGraphUri: OTHER_GRAPH,
+        roots: ['urn:test:a'], descendantSuffix: '/', excludedPredicates: [],
+      } }, OTHER_GRAPH],
+    ];
+    const store = { structuredMutation: vi.fn(async () => undefined) } as unknown as TripleStore;
+
+    for (const [mutation, expectedGraph] of mutations) {
+      const onCommitted = vi.fn();
+      await runStructuredMutationWithCommittedEffects(store, mutation, undefined, onCommitted);
+      expect(onCommitted).toHaveBeenCalledWith({ touchedGraphs: [expectedGraph] });
+    }
+  });
+
   it('deletes one explicit subject set and preserves co-located rows', async () => {
     const store = new OxigraphStore();
     await store.insert([

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -63,7 +63,7 @@ describe('bounded structured mutation capabilities', () => {
 
     const effects = captureStructuredMutationEffects(mutation);
     mutation.input.targetGraphUri = 'urn:test:redirected';
-    expect(effects).toEqual({ mightMutate: true, touchedGraphs: [OTHER_GRAPH] });
+    expect(effects).toEqual({ touchedGraphs: [OTHER_GRAPH] });
     expect(Object.isFrozen(effects)).toBe(true);
     expect(Object.isFrozen(effects.touchedGraphs)).toBe(true);
   });
@@ -72,11 +72,11 @@ describe('bounded structured mutation capabilities', () => {
     expect(captureStructuredMutationEffects({
       kind: 'delete-subjects',
       input: { graphUri: GRAPH, subjects: [] },
-    })).toEqual({ mightMutate: false, touchedGraphs: [GRAPH] });
+    })).toBeUndefined();
     expect(captureStructuredMutationEffects({
       kind: 'delete-subjects',
       input: { graphUri: GRAPH, subjects: ['urn:test:a'] },
-    })).toEqual({ mightMutate: true, touchedGraphs: [GRAPH] });
+    })).toEqual({ touchedGraphs: [GRAPH] });
   });
 
   it('reports the canonical target graph for every structured mutation kind', async () => {
@@ -109,7 +109,6 @@ describe('bounded structured mutation capabilities', () => {
     ];
     for (const [mutation, expectedGraph] of mutations) {
       expect(captureStructuredMutationEffects(mutation)).toEqual({
-        mightMutate: true,
         touchedGraphs: [expectedGraph],
       });
     }


### PR DESCRIPTION
## Summary

- Move structured-mutation graph-effect interpretation behind one pure Storage-owned effect snapshot.
- Capture the canonical touched graph set and structural no-op classification before the first await, so caller mutation cannot redirect cache invalidation after a backend commit.
- Keep execution in the existing Agent invalidation wrapper and apply effects only after successful potentially-mutating operations; structural no-ops and failures do not churn the Context Graph projection cache.
- Keep the existing `structuredMutation` capability and public helper exports intact; this adds no callback runner, capability protocol, wrapper layer, scheduler work, or background component.

## Related Work

- Fixes #2188
- Part of #2052
- Stacked on #2187
- Depends on #2185
- Execution plan: `agent-docs/plans/2026-08-09-system-record-followup-refactors.md`

## Data Flow

```mermaid
sequenceDiagram
    participant A as Agent cache wrapper
    participant S as Pure Storage effect model
    participant B as Structured mutation backend
    A->>S: capture effects from mutation
    S-->>A: frozen scope and no-op classification
    A->>B: execute original mutation with original receiver/options
    alt commit succeeds and may mutate
        B-->>A: success
        A->>A: invalidate list and touched projections
    else structural no-op or failure
        B-->>A: no-op success or error
        A->>A: no cache effect
    end
```

## Files Changed

| Area | Change |
| --- | --- |
| `packages/storage/src/bounded-structured-mutation.ts` | Adds the pure immutable effect snapshot and its contract. |
| `packages/storage/src/index.ts` | Exports the Storage-owned snapshot while retaining existing public helpers. |
| `packages/agent/src/dkg-agent-base.ts` | Consumes the snapshot without decoding the mutation vocabulary and retains execution ownership. |
| `packages/storage/test/bounded-structured-mutation.test.ts` | Covers all six mutation kinds, structural no-op classification, immutability, and caller mutation after capture. |
| `packages/agent/test/replace-subject-agent-wrapper.test.ts` | Proves success-only invalidation, original graph scope, exact options forwarding, and bound receiver semantics. |

## Test Plan

- [x] Dependency-aware Agent build, including Core, Storage, Query, Chain, Publisher, Random Sampling, Agent type tests, and package-root checks
- [x] Storage and Agent builds after the review simplification
- [x] `bounded-structured-mutation.test.ts`: 19 passed
- [x] `replace-subject-agent-wrapper.test.ts`: 4 passed
- [x] All six structured mutation variants capture the same target graph as before
- [x] Structural no-op and failed mutation paths produce no cache invalidation
- [x] Caller mutation after dispatch cannot redirect the captured effect
- [x] Agent forwards the exact options object and invokes the inner method with its store receiver
- [x] `git diff --check`; generated EVM deployment output restored before commit