### PR TITLE
refactor(storage): retire result-bearing coalesced control barriers from first-party composition

### DIFF
--- a/.github/workflows/system-record-managed-ownership.yml
+++ b/.github/workflows/system-record-managed-ownership.yml
@@ -137,11 +137,12 @@ jobs:
         run: pnpm typecheck:live:system-record-managed-ownership
 
       - name: Typecheck barrier type contracts (issue 2179)
-        # The type-level pins in store-control-barrier-contract-v1.test.ts
-        # (expectTypeOf + @ts-expect-error) only PROVE anything under a
-        # compiler. The package tsconfig includes only src/ and vitest does
-        # not typecheck, so without this lane every type assertion in that
-        # file is decorative — a check that cannot fail.
+        # Compiles the runtime spec's expectTypeOf assertions
+        # (store-control-barrier-contract-v1.test.ts) and the compile-only
+        # negative contracts (store-control-barrier-contract-v1.typetest.ts,
+        # which vitest never executes). Type assertions only PROVE anything
+        # under a compiler: the package tsconfig includes only src/ and vitest
+        # does not typecheck, so without this lane they are decorative.
         run: pnpm --filter @origintrail-official/dkg-storage run typecheck:type-contracts
 
       - name: Storage unit conformance

--- a/.github/workflows/system-record-managed-ownership.yml
+++ b/.github/workflows/system-record-managed-ownership.yml
@@ -136,6 +136,14 @@ jobs:
       - name: Typecheck the ownership gate harness
         run: pnpm typecheck:live:system-record-managed-ownership
 
+      - name: Typecheck barrier type contracts (issue 2179)
+        # The type-level pins in store-control-barrier-contract-v1.test.ts
+        # (expectTypeOf + @ts-expect-error) only PROVE anything under a
+        # compiler. The package tsconfig includes only src/ and vitest does
+        # not typecheck, so without this lane every type assertion in that
+        # file is decorative — a check that cannot fail.
+        run: pnpm --filter @origintrail-official/dkg-storage run typecheck:type-contracts
+
       - name: Storage unit conformance
         run: |
           pnpm --filter @origintrail-official/dkg-storage exec vitest run \

--- a/.github/workflows/system-record-managed-ownership.yml
+++ b/.github/workflows/system-record-managed-ownership.yml
@@ -176,6 +176,7 @@ jobs:
             test/changelog-store.test.ts \
             test/graph-write-gen.test.ts \
             test/system-record-decorator-apply-outcomes-v1.test.ts \
+            test/system-record-managed-coordinator-v1.test.ts \
             test/store-control-barrier-contract-v1.test.ts \
             test/store-priority-scheduler.test.ts \
             test/store-scheduler-system-record-admission.test.ts \

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "typecheck:type-contracts": "tsc --noEmit -p tsconfig.typetests.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -783,13 +783,8 @@ export class SparqlHttpStore implements TripleStore {
           // when the controller was BUILT would seal a generation that has since
           // been replaced.
           //
-          // Typed-only, structurally (#2179): the managed coordinator's
-          // options carry NO string-barrier member, so first-party
-          // composition cannot fall back onto the deprecated purpose-string
-          // contract by any edit short of changing that internal interface —
-          // the loudest possible place for such a change. External composers
-          // with string barriers use the public
-          // `createSystemRecordLaneControllerV1` compatibility adapter.
+          // The only barrier managed composition has (#2179) — rationale on
+          // SystemRecordLaneControllerTypedDepsV1.
           typedBarrier: (kind, transition) =>
             runTypedBarrier(SYSTEM_RECORD_BARRIER_KEYS_V1[kind], transition),
           setAdmissionActive: (active) => { this.systemRecordAdmissionActive = active; },

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -783,17 +783,28 @@ export class SparqlHttpStore implements TripleStore {
           // when the controller was BUILT would seal a generation that has since
           // been replaced.
           //
-          // Keep the published string callback intact for external/legacy
-          // coordinator composition. Production lifecycle calls use the
-          // domain-owned typed methods below, which translate to scheduler keys
-          // only at this adapter boundary.
-          barrier: (purpose, transition) =>
-            externalStorePriorityScheduler.runControlBarrier(
-              this,
-              purpose,
-              transition,
-              barrierGeneration(),
-            ),
+          // The string barrier is POISONED in managed composition, not
+          // supplied (#2179). Every production lifecycle call goes through
+          // `typedBarrier` below, so this callback is reachable only through
+          // the controller's legacy fallback — i.e. only if a future edit
+          // removes `typedBarrier` from these deps or reorders the fallback.
+          // Supplying the real string barrier here would make that edit
+          // SILENT: transitions would keep working while quietly moving onto
+          // the deprecated purpose-string contract with its unsound result
+          // cast. A loud throw turns the same edit into an immediate, named
+          // failure. The member itself stays required on the deps interface —
+          // required-ness is the compile-time guard that already caught a
+          // barrier shipping with zero callers once in this stack's history —
+          // and external composers keep supplying real string barriers until
+          // the deprecated contract is removed at a breaking version.
+          barrier: () => {
+            throw new Error(
+              'system-record managed composition retired the purpose-string barrier (#2179): ' +
+                'lifecycle transitions must run through typedBarrier and the scheduler\'s ' +
+                'runTypedControlBarrier. Reaching this throw means the typed path was ' +
+                'removed or bypassed in sparql-http\'s controller deps.',
+            );
+          },
           typedBarrier: (kind, transition) =>
             runTypedBarrier(SYSTEM_RECORD_BARRIER_KEYS_V1[kind], transition),
           setAdmissionActive: (active) => { this.systemRecordAdmissionActive = active; },

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -783,28 +783,13 @@ export class SparqlHttpStore implements TripleStore {
           // when the controller was BUILT would seal a generation that has since
           // been replaced.
           //
-          // The string barrier is POISONED in managed composition, not
-          // supplied (#2179). Every production lifecycle call goes through
-          // `typedBarrier` below, so this callback is reachable only through
-          // the controller's legacy fallback — i.e. only if a future edit
-          // removes `typedBarrier` from these deps or reorders the fallback.
-          // Supplying the real string barrier here would make that edit
-          // SILENT: transitions would keep working while quietly moving onto
-          // the deprecated purpose-string contract with its unsound result
-          // cast. A loud throw turns the same edit into an immediate, named
-          // failure. The member itself stays required on the deps interface —
-          // required-ness is the compile-time guard that already caught a
-          // barrier shipping with zero callers once in this stack's history —
-          // and external composers keep supplying real string barriers until
-          // the deprecated contract is removed at a breaking version.
-          barrier: () => {
-            throw new Error(
-              'system-record managed composition retired the purpose-string barrier (#2179): ' +
-                'lifecycle transitions must run through typedBarrier and the scheduler\'s ' +
-                'runTypedControlBarrier. Reaching this throw means the typed path was ' +
-                'removed or bypassed in sparql-http\'s controller deps.',
-            );
-          },
+          // Typed-only, structurally (#2179): the managed coordinator's
+          // options carry NO string-barrier member, so first-party
+          // composition cannot fall back onto the deprecated purpose-string
+          // contract by any edit short of changing that internal interface —
+          // the loudest possible place for such a change. External composers
+          // with string barriers use the public
+          // `createSystemRecordLaneControllerV1` compatibility adapter.
           typedBarrier: (kind, transition) =>
             runTypedBarrier(SYSTEM_RECORD_BARRIER_KEYS_V1[kind], transition),
           setAdmissionActive: (active) => { this.systemRecordAdmissionActive = active; },

--- a/packages/storage/src/adapters/system-record-managed-coordinator-v1-internal.ts
+++ b/packages/storage/src/adapters/system-record-managed-coordinator-v1-internal.ts
@@ -4,7 +4,7 @@ import {
   type SystemRecordAtomicApplyHttpClientV1,
 } from '../system-record-atomic-apply-executor-v1-internal.js';
 import {
-  createSystemRecordLaneControllerTypedV1,
+  createSystemRecordLaneControllerV1,
   type SystemRecordApplyOutcomeV1,
   type SystemRecordChildHandoffV1,
   type SystemRecordLaneControllerTypedDepsV1,
@@ -47,7 +47,11 @@ export function createManagedSystemRecordCoordinatorV1(
     updateEndpoint: options.updateEndpoint,
     resolveClient: options.resolveClient,
   });
-  return createSystemRecordLaneControllerTypedV1({
+  // The deps literal is typed as the typed-only shape, so the managed path
+  // resolves the single factory's typed overload: no string member exists
+  // here to fall back to, and adding one is a type error pinned in the
+  // typecheck lane.
+  const typedDeps: SystemRecordLaneControllerTypedDepsV1 = {
     lease: options.lease,
     handoff: options.handoff,
     executor: {
@@ -58,5 +62,6 @@ export function createManagedSystemRecordCoordinatorV1(
     },
     typedBarrier: options.typedBarrier,
     setAdmissionActive: options.setAdmissionActive,
-  });
+  };
+  return createSystemRecordLaneControllerV1(typedDeps);
 }

--- a/packages/storage/src/adapters/system-record-managed-coordinator-v1-internal.ts
+++ b/packages/storage/src/adapters/system-record-managed-coordinator-v1-internal.ts
@@ -4,10 +4,9 @@ import {
   type SystemRecordAtomicApplyHttpClientV1,
 } from '../system-record-atomic-apply-executor-v1-internal.js';
 import {
-  createSystemRecordLaneControllerV1,
+  createSystemRecordLaneControllerTypedV1,
   type SystemRecordApplyOutcomeV1,
   type SystemRecordChildHandoffV1,
-  type SystemRecordLaneBarrierV1,
   type SystemRecordLaneControllerV1,
   type SystemRecordLaneExecutionBindingV1,
   type SystemRecordLaneTypedBarrierV1,
@@ -27,7 +26,15 @@ export interface ManagedSystemRecordCoordinatorOptionsV1 {
     proof: unknown,
     childGeneration: string,
   ) => Promise<SystemRecordApplyOutcomeV1>;
-  readonly barrier: SystemRecordLaneBarrierV1;
+  /**
+   * The ONLY barrier the managed path accepts. There is deliberately no
+   * string-barrier member on these options: the purpose-string contract is
+   * retired for first-party composition (#2179), and its absence here is
+   * structural — a future edit cannot fall back onto it without changing
+   * this interface, which is the loudest possible place for that change.
+   * External composers with string barriers use the public
+   * `createSystemRecordLaneControllerV1` compatibility adapter instead.
+   */
   readonly typedBarrier: SystemRecordLaneTypedBarrierV1;
   readonly setAdmissionActive: (active: boolean) => void;
 }
@@ -44,7 +51,7 @@ export function createManagedSystemRecordCoordinatorV1(
     updateEndpoint: options.updateEndpoint,
     resolveClient: options.resolveClient,
   });
-  return createSystemRecordLaneControllerV1({
+  return createSystemRecordLaneControllerTypedV1({
     lease: options.lease,
     handoff: options.handoff,
     executor: {
@@ -53,7 +60,6 @@ export function createManagedSystemRecordCoordinatorV1(
       applyVerifiedSettlementBound: (proof, binding, registerRecovery) =>
         atomicExecutor.execute(proof, binding, registerRecovery),
     },
-    barrier: options.barrier,
     typedBarrier: options.typedBarrier,
     setAdmissionActive: options.setAdmissionActive,
   });

--- a/packages/storage/src/adapters/system-record-managed-coordinator-v1-internal.ts
+++ b/packages/storage/src/adapters/system-record-managed-coordinator-v1-internal.ts
@@ -7,6 +7,7 @@ import {
   createSystemRecordLaneControllerTypedV1,
   type SystemRecordApplyOutcomeV1,
   type SystemRecordChildHandoffV1,
+  type SystemRecordLaneControllerTypedDepsV1,
   type SystemRecordLaneControllerV1,
   type SystemRecordLaneExecutionBindingV1,
   type SystemRecordLaneTypedBarrierV1,
@@ -27,13 +28,8 @@ export interface ManagedSystemRecordCoordinatorOptionsV1 {
     childGeneration: string,
   ) => Promise<SystemRecordApplyOutcomeV1>;
   /**
-   * The ONLY barrier the managed path accepts. There is deliberately no
-   * string-barrier member on these options: the purpose-string contract is
-   * retired for first-party composition (#2179), and its absence here is
-   * structural — a future edit cannot fall back onto it without changing
-   * this interface, which is the loudest possible place for that change.
-   * External composers with string barriers use the public
-   * `createSystemRecordLaneControllerV1` compatibility adapter instead.
+   * The ONLY barrier the managed path accepts — no string member exists here
+   * by design; rationale on {@link SystemRecordLaneControllerTypedDepsV1}.
    */
   readonly typedBarrier: SystemRecordLaneTypedBarrierV1;
   readonly setAdmissionActive: (active: boolean) => void;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -75,6 +75,8 @@ export {
   type SystemRecordDeferralReasonV1,
   type SystemRecordLaneActivationV1,
   type SystemRecordLaneControllerDepsV1,
+  type SystemRecordLaneControllerSharedDepsV1,
+  type SystemRecordLaneControllerTypedDepsV1,
   type SystemRecordLaneControllerV1,
   type SystemRecordLaneSessionV1,
   type SystemRecordLaneStateV1,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -75,7 +75,9 @@ export {
   type SystemRecordDeferralReasonV1,
   type SystemRecordLaneActivationV1,
   type SystemRecordLaneControllerDepsV1,
-  type SystemRecordLaneControllerSharedDepsV1,
+  // The shared deps base is deliberately NOT published: it is a factoring
+  // device, not a valid factory input (no barrier of either kind), and a
+  // public name for an incomplete shape is compatibility burden without use.
   type SystemRecordLaneControllerTypedDepsV1,
   type SystemRecordLaneControllerV1,
   type SystemRecordLaneSessionV1,

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -1092,12 +1092,12 @@ export class StorePriorityScheduler extends ObservableScheduler {
    * @deprecated Use {@link runTypedControlBarrier} with a key created by
    * `createStoreControlBarrierKeyV1` — one key per transition, created once at
    * module scope, binds every coalescing caller to that key's result type.
-   * First-party code no longer calls this method (managed composition poisons
-   * its string-barrier fallback so the path cannot silently re-animate); it is
-   * removed, together with the `'control-barrier'` `run()` admission mode, at
-   * the next allowed breaking version boundary. Until then behavior is
-   * unchanged: both entry points share the coordinator, so coalescing,
-   * timeout, sealing, quiescence and metrics are identical.
+   * First-party code no longer calls this method: managed composition
+   * structurally omits the string barrier (its deps shape has no such
+   * member). It is removed, together with the `'control-barrier'` `run()`
+   * admission mode, at the next allowed breaking version boundary. Until
+   * then behavior is unchanged: both entry points share the coordinator, so
+   * coalescing, timeout, sealing, quiescence and metrics are identical.
    * @param timeoutMs Overrides the default bound for this transition.
    */
   runControlBarrier<T>(

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -140,6 +140,16 @@ export type StoreQueuedAdmissionV1 = StoreAdmissionV1 & {
   readonly mode: Exclude<StoreAdmissionMode, 'control-barrier'>;
 };
 
+/**
+ * @deprecated The `run()` control-barrier admission is the same unsound
+ * purpose-string contract as {@link StorePriorityScheduler.runControlBarrier}:
+ * the run() generic `T` is chosen by each caller while coalescing is keyed by
+ * `(storeId, purpose-string)`, so a coalesced caller receives the first
+ * transition's value under its own `T`. Use
+ * {@link StorePriorityScheduler.runTypedControlBarrier} with a key from
+ * `createStoreControlBarrierKeyV1`. Removed, together with `runControlBarrier`,
+ * at the next allowed breaking version boundary.
+ */
 export type StoreControlBarrierAdmissionV1 = StoreAdmissionV1 & {
   readonly mode: 'control-barrier';
 };
@@ -1080,7 +1090,14 @@ export class StorePriorityScheduler extends ObservableScheduler {
    * callers that already use the historical free-form string contract.
    *
    * @deprecated Use {@link runTypedControlBarrier} with a key created by
-   * `createStoreControlBarrierKeyV1`.
+   * `createStoreControlBarrierKeyV1` — one key per transition, created once at
+   * module scope, binds every coalescing caller to that key's result type.
+   * First-party code no longer calls this method (managed composition poisons
+   * its string-barrier fallback so the path cannot silently re-animate); it is
+   * removed, together with the `'control-barrier'` `run()` admission mode, at
+   * the next allowed breaking version boundary. Until then behavior is
+   * unchanged: both entry points share the coordinator, so coalescing,
+   * timeout, sealing, quiescence and metrics are identical.
    * @param timeoutMs Overrides the default bound for this transition.
    */
   runControlBarrier<T>(

--- a/packages/storage/src/system-record-lane-controller-contract-v1.ts
+++ b/packages/storage/src/system-record-lane-controller-contract-v1.ts
@@ -1,0 +1,133 @@
+/**
+ * The system-record lane controller-barrier CONTRACT (#2179): the barrier
+ * vocabulary, the controller deps shapes, and the typed/legacy normalizer.
+ * Separated from the materializer so the compatibility boundary can be read
+ * without navigating lane-session mechanics; the materializer re-exports
+ * everything here, so its public surface is unchanged.
+ */
+import type { ManagedOxigraphOwnershipLeaseV1 } from './managed-oxigraph-ownership-v1-internal.js';
+import type { SystemRecordMaterializationEpochRotationV1 } from './system-record-materialization-epoch-contract-v1.js';
+// Type-only, deliberately: the value-import graph stays acyclic (the
+// materializer imports the normalizer VALUE from this module; this module
+// imports only TYPES back).
+import type {
+  SystemRecordChildHandoffV1,
+  SystemRecordTransactionExecutorV1,
+} from './system-record-materializer-v1.js';
+
+/**
+ * Run a lifecycle transition as an exclusive section over the whole store.
+ *
+ * Every transition here can invalidate the client or the child, so ordinary
+ * store traffic must be sealed and drained around it — otherwise a request that
+ * was already in flight is cut off mid-exchange when the child is stopped, and
+ * turns into a transport failure or an ambiguous write rather than
+ * backpressure. The adapter backs this with the scheduler's control barrier;
+ * tests supply a recording pass-through.
+ *
+ * The transition MUST NOT re-enter the store scheduler: it owns the store
+ * exclusively for the duration, so scheduled work issued from inside it waits
+ * for a barrier that cannot commit until the work drains. That is why the
+ * handoff steps are limited to supervisor calls, owned-client drains and
+ * synchronous cache invalidation.
+ */
+export type SystemRecordLaneBarrierV1 = <T>(
+  purpose: string,
+  transition: () => Promise<T>,
+) => Promise<T>;
+
+export interface SystemRecordLaneBarrierResultsV1 {
+  readonly enable: void | SystemRecordMaterializationEpochRotationV1;
+  readonly disable: void;
+  readonly shutdown: void;
+  readonly recovery: void;
+}
+
+export type SystemRecordLaneBarrierKindV1 = keyof SystemRecordLaneBarrierResultsV1;
+
+/** Additive typed lifecycle path; adapters may translate kinds to scheduler keys. */
+export type SystemRecordLaneTypedBarrierV1 = <K extends SystemRecordLaneBarrierKindV1>(
+  kind: K,
+  transition: () => Promise<SystemRecordLaneBarrierResultsV1[K]>,
+) => Promise<SystemRecordLaneBarrierResultsV1[K]>;
+
+/**
+ * Dependencies shared by every controller composition route. The legacy and
+ * typed entry points differ ONLY in how the barrier is supplied; everything
+ * else lives here exactly once, so a future shared dependency (a tracing
+ * hook, a lifecycle signal) is added in one place and reaches both routes or
+ * neither.
+ */
+export interface SystemRecordLaneControllerSharedDepsV1 {
+  /** The supervisor-issued live ownership lease. Captured, never accepted per-call. */
+  readonly lease: ManagedOxigraphOwnershipLeaseV1;
+  readonly handoff: SystemRecordChildHandoffV1;
+  readonly executor: SystemRecordTransactionExecutorV1;
+  /**
+   * Adapter-owned admission latch, driven by the lifecycle's physical state.
+   * `true` is published synchronously before enable can enqueue its barrier;
+   * `false` is published only after disable physically commits or the lane is
+   * terminally unavailable. Merely constructing the controller never calls it.
+   */
+  readonly setAdmissionActive?: (active: boolean) => void;
+}
+
+export interface SystemRecordLaneControllerDepsV1 extends SystemRecordLaneControllerSharedDepsV1 {
+  /**
+   * Required, not optional. An optional barrier is one that gets forgotten:
+   * this capability shipped once with a barrier implemented, exported and
+   * tested but with zero production callers, so the enable path stopped the
+   * child while ordinary requests were still in flight. Required-ness is the
+   * compile-time guard against that recurring, which is why retiring the
+   * string contract does NOT make this member optional before the break.
+   *
+   * @deprecated The purpose-string contract cannot carry a sound result type:
+   * coalescing is keyed by a runtime string while each caller picks a static
+   * `T`, so a later same-purpose caller receives the first promise under its
+   * own `T`. Supply {@link typedBarrier}; migrate string barriers to
+   * `runTypedControlBarrier` with keys from `createStoreControlBarrierKeyV1`.
+   * First-party composition no longer passes through this interface at all —
+   * the managed coordinator calls the factory's typed overload with
+   * {@link SystemRecordLaneControllerTypedDepsV1}, which has no string member
+   * to fall back to. This member is removed at the next allowed breaking
+   * version boundary, not before: the removal is source-incompatible for
+   * external composers.
+   */
+  readonly barrier: SystemRecordLaneBarrierV1;
+  /**
+   * When supplied it is ALWAYS used and the string callback above is never
+   * invoked; the fallback exists only for external composers that predate
+   * typed keys.
+   */
+  readonly typedBarrier?: SystemRecordLaneTypedBarrierV1;
+}
+
+/**
+ * Typed-only controller deps — the CANONICAL home of the #2179 rationale;
+ * everywhere else carries at most a one-line pointer here.
+ *
+ * The purpose-string barrier contract is unsound: coalescing is keyed by a
+ * runtime string while each caller picks a static result type, so a later
+ * same-purpose caller receives the first promise under its own type. This
+ * shape therefore has NO string `barrier` member — structurally absent, not
+ * deprecated — so first-party composition cannot regress onto that contract
+ * without editing this interface, and a type-contract pin fails the
+ * typecheck lane if a string member is ever re-added. `typedBarrier` being
+ * required is the same can't-forget guard that `barrier`'s required-ness
+ * gives external composers on the legacy shape, which keeps the string
+ * contract alive only until its breaking-version removal.
+ */
+export interface SystemRecordLaneControllerTypedDepsV1
+  extends SystemRecordLaneControllerSharedDepsV1 {
+  readonly typedBarrier: SystemRecordLaneTypedBarrierV1;
+}
+
+/** Typed deps pass through; legacy deps wrap `barrier`. Proven by `in`-narrowing, no cast. */
+export function normalizeControllerBarrierV1(
+  deps: SystemRecordLaneControllerDepsV1 | SystemRecordLaneControllerTypedDepsV1,
+): SystemRecordLaneTypedBarrierV1 {
+  if (!('barrier' in deps)) return deps.typedBarrier;
+  return deps.typedBarrier ??
+    ((kind, transition) => deps.barrier(`system-record.${kind}`, transition));
+}
+

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -390,9 +390,43 @@ export async function releaseSystemRecordLaneControllerV1(
 }
 
 /**
- * The one controller constructor: accepts the typed-only or the
+ * The typed-only CORE: builds the session from already-normalized deps and
+ * knows nothing about the legacy string-barrier shape. MODULE-PRIVATE by
+ * design — one review round rejected a second exported constructor (a second
+ * deep-importable construction surface), a later one asked that the canonical
+ * layer not reason about both input models; a private core satisfies both.
+ * Assumes the caller has already run the duplicate-registration guard.
+ */
+function buildSystemRecordLaneControllerFromTypedV1(
+  deps: SystemRecordLaneControllerTypedDepsV1,
+): SystemRecordLaneControllerV1 {
+  const session = new SystemRecordLaneSession({
+    lease: deps.lease,
+    handoff: deps.handoff,
+    executor: deps.executor,
+    setAdmissionActive: deps.setAdmissionActive,
+    runEnableBarrier: async (transition) =>
+      snapshotSystemRecordMaterializationEpochRotationV1(
+        await deps.typedBarrier('enable', transition),
+      ),
+    runVoidBarrier: (kind, transition) => deps.typedBarrier(kind, transition),
+  });
+  const controller: SystemRecordLaneControllerV1 = Object.freeze({
+    open: (activation: SystemRecordLaneActivationV1) => session.open(activation),
+  });
+  session.owner = controller;
+  CONTROLLER_SESSIONS.set(controller, session);
+  registeredController = controller;
+  return controller;
+}
+
+/**
+ * The one EXPORTED controller constructor — a thin adapter: guard, normalize,
+ * delegate to the typed-only core. Accepts the typed-only or the
  * legacy-capable deps shape (see {@link SystemRecordLaneControllerTypedDepsV1}
- * for why the shapes differ) and normalizes the barrier internally.
+ * for why the shapes differ); the legacy shape exists only until its
+ * breaking-version removal, and no construction code below this function's
+ * body reasons about it.
  *
  * The duplicate-registration guard runs before ANY caller-supplied dependency
  * property is read: deps may carry accessors, and a second registration must
@@ -410,25 +444,13 @@ export function createSystemRecordLaneControllerV1(
 ): SystemRecordLaneControllerV1 {
   if (registeredController) throw new SystemRecordControllerRegistrationError();
 
-  const typedBarrier = normalizeControllerBarrierV1(deps);
-  const session = new SystemRecordLaneSession({
+  return buildSystemRecordLaneControllerFromTypedV1({
     lease: deps.lease,
     handoff: deps.handoff,
     executor: deps.executor,
+    typedBarrier: normalizeControllerBarrierV1(deps),
     setAdmissionActive: deps.setAdmissionActive,
-    runEnableBarrier: async (transition) =>
-      snapshotSystemRecordMaterializationEpochRotationV1(
-        await typedBarrier('enable', transition),
-      ),
-    runVoidBarrier: (kind, transition) => typedBarrier(kind, transition),
   });
-  const controller: SystemRecordLaneControllerV1 = Object.freeze({
-    open: (activation: SystemRecordLaneActivationV1) => session.open(activation),
-  });
-  session.owner = controller;
-  CONTROLLER_SESSIONS.set(controller, session);
-  registeredController = controller;
-  return controller;
 }
 
 /* ------------------------------------------------------------------ *

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -275,11 +275,11 @@ export interface SystemRecordLaneControllerDepsV1 extends SystemRecordLaneContro
    * own `T`. Supply {@link typedBarrier}; migrate string barriers to
    * `runTypedControlBarrier` with keys from `createStoreControlBarrierKeyV1`.
    * First-party composition no longer passes through this interface at all —
-   * the managed coordinator builds on the typed-only
-   * `createSystemRecordLaneControllerTypedV1`, whose deps have no string
-   * member to fall back to. This member is removed at the next allowed
-   * breaking version boundary, not before: the removal is
-   * source-incompatible for external composers.
+   * the managed coordinator calls the factory's typed overload with
+   * {@link SystemRecordLaneControllerTypedDepsV1}, which has no string member
+   * to fall back to. This member is removed at the next allowed breaking
+   * version boundary, not before: the removal is source-incompatible for
+   * external composers.
    */
   readonly barrier: SystemRecordLaneBarrierV1;
   /**
@@ -473,15 +473,37 @@ export interface SystemRecordLaneControllerTypedDepsV1
 }
 
 /**
- * The typed-only core builder. Managed composition calls this directly;
- * {@link createSystemRecordLaneControllerV1} is the compatibility adapter
- * that normalizes the public legacy-capable deps down to this shape.
+ * The ONE controller constructor. Accepts either the typed-only deps (the
+ * managed path — no string member exists on that shape) or the legacy-capable
+ * public deps, and normalizes the difference internally: a supplied
+ * `typedBarrier` is used as-is; otherwise the string `barrier` is wrapped,
+ * preserving the purpose-string contract for external composers until its
+ * breaking-version removal. One entry point, one singleton lifecycle — the
+ * shape split lives in the TYPES, not in parallel factories.
+ *
+ * ORDER MATTERS on the duplicate-registration guard: it runs before ANY
+ * caller-supplied dependency property is read. Deps come from composers and
+ * may carry accessors; a second registration must be refused with
+ * {@link SystemRecordControllerRegistrationError} before composer code gets a
+ * chance to run (or throw something else) from a property read.
  */
-export function createSystemRecordLaneControllerTypedV1(
+export function createSystemRecordLaneControllerV1(
   deps: SystemRecordLaneControllerTypedDepsV1,
+): SystemRecordLaneControllerV1;
+export function createSystemRecordLaneControllerV1(
+  deps: SystemRecordLaneControllerDepsV1,
+): SystemRecordLaneControllerV1;
+export function createSystemRecordLaneControllerV1(
+  deps: SystemRecordLaneControllerDepsV1 | SystemRecordLaneControllerTypedDepsV1,
 ): SystemRecordLaneControllerV1 {
   if (registeredController) throw new SystemRecordControllerRegistrationError();
 
+  const typedBarrier: SystemRecordLaneTypedBarrierV1 = deps.typedBarrier ??
+    ((kind, transition) =>
+      (deps as SystemRecordLaneControllerDepsV1).barrier(
+        `system-record.${kind}`,
+        transition,
+      ));
   const session = new SystemRecordLaneSession({
     lease: deps.lease,
     handoff: deps.handoff,
@@ -489,9 +511,9 @@ export function createSystemRecordLaneControllerTypedV1(
     setAdmissionActive: deps.setAdmissionActive,
     runEnableBarrier: async (transition) =>
       snapshotSystemRecordMaterializationEpochRotationV1(
-        await deps.typedBarrier('enable', transition),
+        await typedBarrier('enable', transition),
       ),
-    runVoidBarrier: (kind, transition) => deps.typedBarrier(kind, transition),
+    runVoidBarrier: (kind, transition) => typedBarrier(kind, transition),
   });
   const controller: SystemRecordLaneControllerV1 = Object.freeze({
     open: (activation: SystemRecordLaneActivationV1) => session.open(activation),
@@ -500,26 +522,6 @@ export function createSystemRecordLaneControllerTypedV1(
   CONTROLLER_SESSIONS.set(controller, session);
   registeredController = controller;
   return controller;
-}
-
-/**
- * Public compatibility entry point. Normalizes the legacy-capable deps to the
- * typed core: a supplied `typedBarrier` is used as-is; otherwise the string
- * `barrier` is wrapped, preserving the purpose-string contract for external
- * composers until its removal at a breaking version boundary.
- */
-export function createSystemRecordLaneControllerV1(
-  deps: SystemRecordLaneControllerDepsV1,
-): SystemRecordLaneControllerV1 {
-  const typedBarrier: SystemRecordLaneTypedBarrierV1 = deps.typedBarrier ??
-    ((kind, transition) => deps.barrier(`system-record.${kind}`, transition));
-  return createSystemRecordLaneControllerTypedV1({
-    lease: deps.lease,
-    handoff: deps.handoff,
-    executor: deps.executor,
-    typedBarrier,
-    setAdmissionActive: deps.setAdmissionActive,
-  });
 }
 
 /* ------------------------------------------------------------------ *

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -248,13 +248,28 @@ export interface SystemRecordLaneControllerDepsV1 {
    * Required, not optional. An optional barrier is one that gets forgotten:
    * this capability shipped once with a barrier implemented, exported and
    * tested but with zero production callers, so the enable path stopped the
-   * child while ordinary requests were still in flight.
+   * child while ordinary requests were still in flight. Required-ness is the
+   * compile-time guard against that recurring, which is why retiring the
+   * string contract does NOT make this member optional before the break.
    *
-   * @deprecated Managed composition uses `typedBarrier`. Retained so existing
-   * external controller integrations keep their purpose-string contract.
+   * @deprecated The purpose-string contract cannot carry a sound result type:
+   * coalescing is keyed by a runtime string while each caller picks a static
+   * `T`, so a later same-purpose caller receives the first promise under its
+   * own `T`. Supply {@link typedBarrier}; migrate string barriers to
+   * `runTypedControlBarrier` with keys from `createStoreControlBarrierKeyV1`.
+   * Managed composition already supplies a POISONED callback here (throws on
+   * use) so the retired path cannot silently re-animate. Removal of this
+   * member — and the required/optional flip that makes `typedBarrier` the
+   * mandatory one — happens together at the next allowed breaking version
+   * boundary, not before: both are source-incompatible for external
+   * composers.
    */
   readonly barrier: SystemRecordLaneBarrierV1;
-  /** Optional typed path; the string callback above remains the compatibility contract. */
+  /**
+   * The production lifecycle path. When supplied it is ALWAYS used and the
+   * string callback above is never invoked; the fallback exists only for
+   * external composers that predate typed keys.
+   */
   readonly typedBarrier?: SystemRecordLaneTypedBarrierV1;
   /**
    * Adapter-owned admission latch, driven by the lifecycle's physical state.

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -239,11 +239,28 @@ export type SystemRecordLaneTypedBarrierV1 = <K extends SystemRecordLaneBarrierK
   transition: () => Promise<SystemRecordLaneBarrierResultsV1[K]>,
 ) => Promise<SystemRecordLaneBarrierResultsV1[K]>;
 
-export interface SystemRecordLaneControllerDepsV1 {
+/**
+ * Dependencies shared by every controller composition route. The legacy and
+ * typed entry points differ ONLY in how the barrier is supplied; everything
+ * else lives here exactly once, so a future shared dependency (a tracing
+ * hook, a lifecycle signal) is added in one place and reaches both routes or
+ * neither.
+ */
+export interface SystemRecordLaneControllerSharedDepsV1 {
   /** The supervisor-issued live ownership lease. Captured, never accepted per-call. */
   readonly lease: ManagedOxigraphOwnershipLeaseV1;
   readonly handoff: SystemRecordChildHandoffV1;
   readonly executor: SystemRecordTransactionExecutorV1;
+  /**
+   * Adapter-owned admission latch, driven by the lifecycle's physical state.
+   * `true` is published synchronously before enable can enqueue its barrier;
+   * `false` is published only after disable physically commits or the lane is
+   * terminally unavailable. Merely constructing the controller never calls it.
+   */
+  readonly setAdmissionActive?: (active: boolean) => void;
+}
+
+export interface SystemRecordLaneControllerDepsV1 extends SystemRecordLaneControllerSharedDepsV1 {
   /**
    * Required, not optional. An optional barrier is one that gets forgotten:
    * this capability shipped once with a barrier implemented, exported and
@@ -271,19 +288,9 @@ export interface SystemRecordLaneControllerDepsV1 {
    * typed keys.
    */
   readonly typedBarrier?: SystemRecordLaneTypedBarrierV1;
-  /**
-   * Adapter-owned admission latch, driven by the lifecycle's physical state.
-   * `true` is published synchronously before enable can enqueue its barrier;
-   * `false` is published only after disable physically commits or the lane is
-   * terminally unavailable. Merely constructing the controller never calls it.
-   */
-  readonly setAdmissionActive?: (active: boolean) => void;
 }
 
-type SystemRecordLaneSessionDepsV1 = Pick<
-  SystemRecordLaneControllerDepsV1,
-  'lease' | 'handoff' | 'executor' | 'setAdmissionActive'
-> & {
+type SystemRecordLaneSessionDepsV1 = SystemRecordLaneControllerSharedDepsV1 & {
   readonly runEnableBarrier: (
     transition: () => Promise<SystemRecordLaneBarrierResultsV1['enable']>,
   ) => Promise<SystemRecordMaterializationEpochRotationSnapshotV1>;
@@ -444,19 +451,25 @@ export async function releaseSystemRecordLaneControllerV1(
 }
 
 /**
- * Typed-only controller deps: the managed path's shape. There is NO string
- * `barrier` member — not deprecated, not optional, structurally absent — so
- * first-party composition cannot regress onto the purpose-string contract by
- * any edit short of changing this interface. The compile-time can't-forget
- * guard that `SystemRecordLaneControllerDepsV1.barrier` provides for external
- * composers is provided here by `typedBarrier` being required.
+ * Typed-only controller deps: the managed path's shape, and the CANONICAL
+ * home of the typed-barrier rationale (call sites carry one-line pointers
+ * here, not copies).
+ *
+ * There is NO string `barrier` member — not deprecated, not optional,
+ * structurally absent — so first-party composition cannot regress onto the
+ * purpose-string contract by any edit short of changing this interface,
+ * which is the loudest possible place for that change. The string contract
+ * is unsound for coalescing (a runtime purpose string cannot bind the result
+ * type shared by coalesced callers) and survives only on the public
+ * compatibility entry point until its breaking-version removal. The
+ * compile-time can't-forget guard that `SystemRecordLaneControllerDepsV1.
+ * barrier` provides for external composers is provided here by `typedBarrier`
+ * being required. A type-contract pin fails the typecheck lane if a string
+ * member is ever re-added to a typed-only shape.
  */
-export interface SystemRecordLaneControllerTypedDepsV1 {
-  readonly lease: ManagedOxigraphOwnershipLeaseV1;
-  readonly handoff: SystemRecordChildHandoffV1;
-  readonly executor: SystemRecordTransactionExecutorV1;
+export interface SystemRecordLaneControllerTypedDepsV1
+  extends SystemRecordLaneControllerSharedDepsV1 {
   readonly typedBarrier: SystemRecordLaneTypedBarrierV1;
-  readonly setAdmissionActive?: (active: boolean) => void;
 }
 
 /**

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -451,60 +451,44 @@ export async function releaseSystemRecordLaneControllerV1(
 }
 
 /**
- * Typed-only controller deps: the managed path's shape, and the CANONICAL
- * home of the typed-barrier rationale (call sites carry one-line pointers
- * here, not copies).
+ * Typed-only controller deps — the CANONICAL home of the #2179 rationale;
+ * everywhere else carries at most a one-line pointer here.
  *
- * There is NO string `barrier` member — not deprecated, not optional,
- * structurally absent — so first-party composition cannot regress onto the
- * purpose-string contract by any edit short of changing this interface,
- * which is the loudest possible place for that change. The string contract
- * is unsound for coalescing (a runtime purpose string cannot bind the result
- * type shared by coalesced callers) and survives only on the public
- * compatibility entry point until its breaking-version removal. The
- * compile-time can't-forget guard that `SystemRecordLaneControllerDepsV1.
- * barrier` provides for external composers is provided here by `typedBarrier`
- * being required. A type-contract pin fails the typecheck lane if a string
- * member is ever re-added to a typed-only shape.
+ * The purpose-string barrier contract is unsound: coalescing is keyed by a
+ * runtime string while each caller picks a static result type, so a later
+ * same-purpose caller receives the first promise under its own type. This
+ * shape therefore has NO string `barrier` member — structurally absent, not
+ * deprecated — so first-party composition cannot regress onto that contract
+ * without editing this interface, and a type-contract pin fails the
+ * typecheck lane if a string member is ever re-added. `typedBarrier` being
+ * required is the same can't-forget guard that `barrier`'s required-ness
+ * gives external composers on the legacy shape, which keeps the string
+ * contract alive only until its breaking-version removal.
  */
 export interface SystemRecordLaneControllerTypedDepsV1
   extends SystemRecordLaneControllerSharedDepsV1 {
   readonly typedBarrier: SystemRecordLaneTypedBarrierV1;
 }
 
-/**
- * The ONE controller constructor. Accepts either the typed-only deps (the
- * managed path — no string member exists on that shape) or the legacy-capable
- * public deps, and normalizes the difference internally: a supplied
- * `typedBarrier` is used as-is; otherwise the string `barrier` is wrapped,
- * preserving the purpose-string contract for external composers until its
- * breaking-version removal. One entry point, one singleton lifecycle — the
- * shape split lives in the TYPES, not in parallel factories.
- *
- * ORDER MATTERS on the duplicate-registration guard: it runs before ANY
- * caller-supplied dependency property is read. Deps come from composers and
- * may carry accessors; a second registration must be refused with
- * {@link SystemRecordControllerRegistrationError} before composer code gets a
- * chance to run (or throw something else) from a property read.
- */
-/**
- * The barrier-mode split, stated once and PROVEN by narrowing rather than
- * asserted by a cast: `'barrier' in deps` discriminates the union, so the
- * compiler itself proves the legacy branch has a string `barrier` to wrap
- * and the typed-only branch has a required `typedBarrier`. A future deps
- * change that breaks either premise fails to typecheck here instead of
- * surviving inside an `as`.
- */
+/** Typed deps pass through; legacy deps wrap `barrier`. Proven by `in`-narrowing, no cast. */
 function normalizeControllerBarrierV1(
   deps: SystemRecordLaneControllerDepsV1 | SystemRecordLaneControllerTypedDepsV1,
 ): SystemRecordLaneTypedBarrierV1 {
   if (!('barrier' in deps)) return deps.typedBarrier;
-  // Legacy-capable shape: a supplied typed member always wins; the string
-  // barrier is wrapped only when it is all the composer has.
   return deps.typedBarrier ??
     ((kind, transition) => deps.barrier(`system-record.${kind}`, transition));
 }
 
+/**
+ * The one controller constructor: accepts the typed-only or the
+ * legacy-capable deps shape (see {@link SystemRecordLaneControllerTypedDepsV1}
+ * for why the shapes differ) and normalizes the barrier internally.
+ *
+ * The duplicate-registration guard runs before ANY caller-supplied dependency
+ * property is read: deps may carry accessors, and a second registration must
+ * be refused with {@link SystemRecordControllerRegistrationError} before
+ * composer code can run from a property read.
+ */
 export function createSystemRecordLaneControllerV1(
   deps: SystemRecordLaneControllerTypedDepsV1,
 ): SystemRecordLaneControllerV1;
@@ -514,9 +498,6 @@ export function createSystemRecordLaneControllerV1(
 export function createSystemRecordLaneControllerV1(
   deps: SystemRecordLaneControllerDepsV1 | SystemRecordLaneControllerTypedDepsV1,
 ): SystemRecordLaneControllerV1 {
-  // Guard FIRST, before the normalizer or any other deps read — deps come
-  // from composers and may carry accessors; see the registration-invariant
-  // tests.
   if (registeredController) throw new SystemRecordControllerRegistrationError();
 
   const typedBarrier = normalizeControllerBarrierV1(deps);

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -206,13 +206,16 @@ export interface SystemRecordLaneExecutionBindingV1 {
 // The controller-barrier contract (barrier vocabulary, deps shapes, and the
 // typed/legacy normalizer) lives in its own focused module; re-exported here
 // so the materializer's public surface is unchanged.
+// Re-exported: the contract types with real consumers (the barrel and the
+// coordinator). The normalizer and the shared deps base are deliberately NOT
+// re-exported — the normalizer is constructor plumbing and the shared base is
+// not a valid factory input; both stay reachable only through the contract
+// module itself, which the package barrel does not publish.
 export {
-  normalizeControllerBarrierV1,
   type SystemRecordLaneBarrierKindV1,
   type SystemRecordLaneBarrierResultsV1,
   type SystemRecordLaneBarrierV1,
   type SystemRecordLaneControllerDepsV1,
-  type SystemRecordLaneControllerSharedDepsV1,
   type SystemRecordLaneControllerTypedDepsV1,
   type SystemRecordLaneTypedBarrierV1,
 } from './system-record-lane-controller-contract-v1.js';

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -203,92 +203,28 @@ export interface SystemRecordLaneExecutionBindingV1 {
   readonly materializationEpoch: string;
 }
 
-/**
- * Run a lifecycle transition as an exclusive section over the whole store.
- *
- * Every transition here can invalidate the client or the child, so ordinary
- * store traffic must be sealed and drained around it — otherwise a request that
- * was already in flight is cut off mid-exchange when the child is stopped, and
- * turns into a transport failure or an ambiguous write rather than
- * backpressure. The adapter backs this with the scheduler's control barrier;
- * tests supply a recording pass-through.
- *
- * The transition MUST NOT re-enter the store scheduler: it owns the store
- * exclusively for the duration, so scheduled work issued from inside it waits
- * for a barrier that cannot commit until the work drains. That is why the
- * handoff steps are limited to supervisor calls, owned-client drains and
- * synchronous cache invalidation.
- */
-export type SystemRecordLaneBarrierV1 = <T>(
-  purpose: string,
-  transition: () => Promise<T>,
-) => Promise<T>;
-
-export interface SystemRecordLaneBarrierResultsV1 {
-  readonly enable: void | SystemRecordMaterializationEpochRotationV1;
-  readonly disable: void;
-  readonly shutdown: void;
-  readonly recovery: void;
-}
-
-export type SystemRecordLaneBarrierKindV1 = keyof SystemRecordLaneBarrierResultsV1;
-
-/** Additive typed lifecycle path; adapters may translate kinds to scheduler keys. */
-export type SystemRecordLaneTypedBarrierV1 = <K extends SystemRecordLaneBarrierKindV1>(
-  kind: K,
-  transition: () => Promise<SystemRecordLaneBarrierResultsV1[K]>,
-) => Promise<SystemRecordLaneBarrierResultsV1[K]>;
-
-/**
- * Dependencies shared by every controller composition route. The legacy and
- * typed entry points differ ONLY in how the barrier is supplied; everything
- * else lives here exactly once, so a future shared dependency (a tracing
- * hook, a lifecycle signal) is added in one place and reaches both routes or
- * neither.
- */
-export interface SystemRecordLaneControllerSharedDepsV1 {
-  /** The supervisor-issued live ownership lease. Captured, never accepted per-call. */
-  readonly lease: ManagedOxigraphOwnershipLeaseV1;
-  readonly handoff: SystemRecordChildHandoffV1;
-  readonly executor: SystemRecordTransactionExecutorV1;
-  /**
-   * Adapter-owned admission latch, driven by the lifecycle's physical state.
-   * `true` is published synchronously before enable can enqueue its barrier;
-   * `false` is published only after disable physically commits or the lane is
-   * terminally unavailable. Merely constructing the controller never calls it.
-   */
-  readonly setAdmissionActive?: (active: boolean) => void;
-}
-
-export interface SystemRecordLaneControllerDepsV1 extends SystemRecordLaneControllerSharedDepsV1 {
-  /**
-   * Required, not optional. An optional barrier is one that gets forgotten:
-   * this capability shipped once with a barrier implemented, exported and
-   * tested but with zero production callers, so the enable path stopped the
-   * child while ordinary requests were still in flight. Required-ness is the
-   * compile-time guard against that recurring, which is why retiring the
-   * string contract does NOT make this member optional before the break.
-   *
-   * @deprecated The purpose-string contract cannot carry a sound result type:
-   * coalescing is keyed by a runtime string while each caller picks a static
-   * `T`, so a later same-purpose caller receives the first promise under its
-   * own `T`. Supply {@link typedBarrier}; migrate string barriers to
-   * `runTypedControlBarrier` with keys from `createStoreControlBarrierKeyV1`.
-   * First-party composition no longer passes through this interface at all —
-   * the managed coordinator calls the factory's typed overload with
-   * {@link SystemRecordLaneControllerTypedDepsV1}, which has no string member
-   * to fall back to. This member is removed at the next allowed breaking
-   * version boundary, not before: the removal is source-incompatible for
-   * external composers.
-   */
-  readonly barrier: SystemRecordLaneBarrierV1;
-  /**
-   * When supplied it is ALWAYS used and the string callback above is never
-   * invoked; the fallback exists only for external composers that predate
-   * typed keys.
-   */
-  readonly typedBarrier?: SystemRecordLaneTypedBarrierV1;
-}
+// The controller-barrier contract (barrier vocabulary, deps shapes, and the
+// typed/legacy normalizer) lives in its own focused module; re-exported here
+// so the materializer's public surface is unchanged.
+export {
+  normalizeControllerBarrierV1,
+  type SystemRecordLaneBarrierKindV1,
+  type SystemRecordLaneBarrierResultsV1,
+  type SystemRecordLaneBarrierV1,
+  type SystemRecordLaneControllerDepsV1,
+  type SystemRecordLaneControllerSharedDepsV1,
+  type SystemRecordLaneControllerTypedDepsV1,
+  type SystemRecordLaneTypedBarrierV1,
+} from './system-record-lane-controller-contract-v1.js';
+import {
+  normalizeControllerBarrierV1,
+  type SystemRecordLaneBarrierKindV1,
+  type SystemRecordLaneBarrierResultsV1,
+  type SystemRecordLaneControllerDepsV1,
+  type SystemRecordLaneControllerSharedDepsV1,
+  type SystemRecordLaneControllerTypedDepsV1,
+  type SystemRecordLaneTypedBarrierV1,
+} from './system-record-lane-controller-contract-v1.js';
 
 type SystemRecordLaneSessionDepsV1 = SystemRecordLaneControllerSharedDepsV1 & {
   readonly runEnableBarrier: (
@@ -448,35 +384,6 @@ export async function releaseSystemRecordLaneControllerV1(
   await Promise.all([quiesceOwner(), recoverySettlement]);
   if (registeredController === controller) registeredController = null;
   CONTROLLER_SESSIONS.delete(controller);
-}
-
-/**
- * Typed-only controller deps — the CANONICAL home of the #2179 rationale;
- * everywhere else carries at most a one-line pointer here.
- *
- * The purpose-string barrier contract is unsound: coalescing is keyed by a
- * runtime string while each caller picks a static result type, so a later
- * same-purpose caller receives the first promise under its own type. This
- * shape therefore has NO string `barrier` member — structurally absent, not
- * deprecated — so first-party composition cannot regress onto that contract
- * without editing this interface, and a type-contract pin fails the
- * typecheck lane if a string member is ever re-added. `typedBarrier` being
- * required is the same can't-forget guard that `barrier`'s required-ness
- * gives external composers on the legacy shape, which keeps the string
- * contract alive only until its breaking-version removal.
- */
-export interface SystemRecordLaneControllerTypedDepsV1
-  extends SystemRecordLaneControllerSharedDepsV1 {
-  readonly typedBarrier: SystemRecordLaneTypedBarrierV1;
-}
-
-/** Typed deps pass through; legacy deps wrap `barrier`. Proven by `in`-narrowing, no cast. */
-function normalizeControllerBarrierV1(
-  deps: SystemRecordLaneControllerDepsV1 | SystemRecordLaneControllerTypedDepsV1,
-): SystemRecordLaneTypedBarrierV1 {
-  if (!('barrier' in deps)) return deps.typedBarrier;
-  return deps.typedBarrier ??
-    ((kind, transition) => deps.barrier(`system-record.${kind}`, transition));
 }
 
 /**

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -487,6 +487,24 @@ export interface SystemRecordLaneControllerTypedDepsV1
  * {@link SystemRecordControllerRegistrationError} before composer code gets a
  * chance to run (or throw something else) from a property read.
  */
+/**
+ * The barrier-mode split, stated once and PROVEN by narrowing rather than
+ * asserted by a cast: `'barrier' in deps` discriminates the union, so the
+ * compiler itself proves the legacy branch has a string `barrier` to wrap
+ * and the typed-only branch has a required `typedBarrier`. A future deps
+ * change that breaks either premise fails to typecheck here instead of
+ * surviving inside an `as`.
+ */
+function normalizeControllerBarrierV1(
+  deps: SystemRecordLaneControllerDepsV1 | SystemRecordLaneControllerTypedDepsV1,
+): SystemRecordLaneTypedBarrierV1 {
+  if (!('barrier' in deps)) return deps.typedBarrier;
+  // Legacy-capable shape: a supplied typed member always wins; the string
+  // barrier is wrapped only when it is all the composer has.
+  return deps.typedBarrier ??
+    ((kind, transition) => deps.barrier(`system-record.${kind}`, transition));
+}
+
 export function createSystemRecordLaneControllerV1(
   deps: SystemRecordLaneControllerTypedDepsV1,
 ): SystemRecordLaneControllerV1;
@@ -496,14 +514,12 @@ export function createSystemRecordLaneControllerV1(
 export function createSystemRecordLaneControllerV1(
   deps: SystemRecordLaneControllerDepsV1 | SystemRecordLaneControllerTypedDepsV1,
 ): SystemRecordLaneControllerV1 {
+  // Guard FIRST, before the normalizer or any other deps read — deps come
+  // from composers and may carry accessors; see the registration-invariant
+  // tests.
   if (registeredController) throw new SystemRecordControllerRegistrationError();
 
-  const typedBarrier: SystemRecordLaneTypedBarrierV1 = deps.typedBarrier ??
-    ((kind, transition) =>
-      (deps as SystemRecordLaneControllerDepsV1).barrier(
-        `system-record.${kind}`,
-        transition,
-      ));
+  const typedBarrier = normalizeControllerBarrierV1(deps);
   const session = new SystemRecordLaneSession({
     lease: deps.lease,
     handoff: deps.handoff,

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -257,18 +257,18 @@ export interface SystemRecordLaneControllerDepsV1 {
    * `T`, so a later same-purpose caller receives the first promise under its
    * own `T`. Supply {@link typedBarrier}; migrate string barriers to
    * `runTypedControlBarrier` with keys from `createStoreControlBarrierKeyV1`.
-   * Managed composition already supplies a POISONED callback here (throws on
-   * use) so the retired path cannot silently re-animate. Removal of this
-   * member — and the required/optional flip that makes `typedBarrier` the
-   * mandatory one — happens together at the next allowed breaking version
-   * boundary, not before: both are source-incompatible for external
-   * composers.
+   * First-party composition no longer passes through this interface at all —
+   * the managed coordinator builds on the typed-only
+   * `createSystemRecordLaneControllerTypedV1`, whose deps have no string
+   * member to fall back to. This member is removed at the next allowed
+   * breaking version boundary, not before: the removal is
+   * source-incompatible for external composers.
    */
   readonly barrier: SystemRecordLaneBarrierV1;
   /**
-   * The production lifecycle path. When supplied it is ALWAYS used and the
-   * string callback above is never invoked; the fallback exists only for
-   * external composers that predate typed keys.
+   * When supplied it is ALWAYS used and the string callback above is never
+   * invoked; the fallback exists only for external composers that predate
+   * typed keys.
    */
   readonly typedBarrier?: SystemRecordLaneTypedBarrierV1;
   /**
@@ -443,13 +443,32 @@ export async function releaseSystemRecordLaneControllerV1(
   CONTROLLER_SESSIONS.delete(controller);
 }
 
-export function createSystemRecordLaneControllerV1(
-  deps: SystemRecordLaneControllerDepsV1,
+/**
+ * Typed-only controller deps: the managed path's shape. There is NO string
+ * `barrier` member — not deprecated, not optional, structurally absent — so
+ * first-party composition cannot regress onto the purpose-string contract by
+ * any edit short of changing this interface. The compile-time can't-forget
+ * guard that `SystemRecordLaneControllerDepsV1.barrier` provides for external
+ * composers is provided here by `typedBarrier` being required.
+ */
+export interface SystemRecordLaneControllerTypedDepsV1 {
+  readonly lease: ManagedOxigraphOwnershipLeaseV1;
+  readonly handoff: SystemRecordChildHandoffV1;
+  readonly executor: SystemRecordTransactionExecutorV1;
+  readonly typedBarrier: SystemRecordLaneTypedBarrierV1;
+  readonly setAdmissionActive?: (active: boolean) => void;
+}
+
+/**
+ * The typed-only core builder. Managed composition calls this directly;
+ * {@link createSystemRecordLaneControllerV1} is the compatibility adapter
+ * that normalizes the public legacy-capable deps down to this shape.
+ */
+export function createSystemRecordLaneControllerTypedV1(
+  deps: SystemRecordLaneControllerTypedDepsV1,
 ): SystemRecordLaneControllerV1 {
   if (registeredController) throw new SystemRecordControllerRegistrationError();
 
-  const publicBarrier: SystemRecordLaneTypedBarrierV1 = deps.typedBarrier ??
-    ((kind, transition) => deps.barrier(`system-record.${kind}`, transition));
   const session = new SystemRecordLaneSession({
     lease: deps.lease,
     handoff: deps.handoff,
@@ -457,9 +476,9 @@ export function createSystemRecordLaneControllerV1(
     setAdmissionActive: deps.setAdmissionActive,
     runEnableBarrier: async (transition) =>
       snapshotSystemRecordMaterializationEpochRotationV1(
-        await publicBarrier('enable', transition),
+        await deps.typedBarrier('enable', transition),
       ),
-    runVoidBarrier: (kind, transition) => publicBarrier(kind, transition),
+    runVoidBarrier: (kind, transition) => deps.typedBarrier(kind, transition),
   });
   const controller: SystemRecordLaneControllerV1 = Object.freeze({
     open: (activation: SystemRecordLaneActivationV1) => session.open(activation),
@@ -468,6 +487,26 @@ export function createSystemRecordLaneControllerV1(
   CONTROLLER_SESSIONS.set(controller, session);
   registeredController = controller;
   return controller;
+}
+
+/**
+ * Public compatibility entry point. Normalizes the legacy-capable deps to the
+ * typed core: a supplied `typedBarrier` is used as-is; otherwise the string
+ * `barrier` is wrapped, preserving the purpose-string contract for external
+ * composers until its removal at a breaking version boundary.
+ */
+export function createSystemRecordLaneControllerV1(
+  deps: SystemRecordLaneControllerDepsV1,
+): SystemRecordLaneControllerV1 {
+  const typedBarrier: SystemRecordLaneTypedBarrierV1 = deps.typedBarrier ??
+    ((kind, transition) => deps.barrier(`system-record.${kind}`, transition));
+  return createSystemRecordLaneControllerTypedV1({
+    lease: deps.lease,
+    handoff: deps.handoff,
+    executor: deps.executor,
+    typedBarrier,
+    setAdmissionActive: deps.setAdmissionActive,
+  });
 }
 
 /* ------------------------------------------------------------------ *

--- a/packages/storage/test/store-control-barrier-contract-v1.test.ts
+++ b/packages/storage/test/store-control-barrier-contract-v1.test.ts
@@ -266,3 +266,39 @@ describe('control barrier contract survives the coordinator extraction', () => {
     expect(ran).toBe(true);
   });
 });
+
+describe('typed barrier keys close the generic result channel (#2179)', () => {
+  // The retired contract's defect was that `T` was chosen per CALL while
+  // coalescing was keyed per runtime STRING, so the type system had no say in
+  // which caller's `T` a coalesced promise satisfied. These are type-level
+  // pins that the replacement actually closes that channel: `T` is chosen per
+  // KEY, once, and no call site can renegotiate it.
+  it('binds the result type to the key, not the call site', async () => {
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 1 });
+    const epochKey = createStoreControlBarrierKeyV1<{ epoch: string }>('typed.epoch');
+    const effectKey = createStoreControlBarrierKeyV1<void>('typed.effect');
+
+    const typed = scheduler.runTypedControlBarrier({}, epochKey, async () => ({ epoch: '1' }));
+    expectTypeOf(typed).toEqualTypeOf<Promise<{ epoch: string }>>();
+    expect(await typed).toEqual({ epoch: '1' });
+
+    // A void key is an effect barrier BY TYPE: its promise carries no data, so
+    // it cannot be used as a typed side channel between coalescing callers.
+    const effect = scheduler.runTypedControlBarrier({}, effectKey, async () => {});
+    expectTypeOf(effect).toEqualTypeOf<Promise<void>>();
+    await effect;
+
+    // A transition cannot smuggle a different result type past its key.
+    // @ts-expect-error — the epoch key demands { epoch: string }, not number
+    void scheduler.runTypedControlBarrier({}, epochKey, async () => 7);
+
+    // A key cannot be forged from a plain literal: the module-private brand is
+    // a required member no caller outside the factory can produce.
+    // @ts-expect-error — structural literal lacks the private brand
+    void scheduler.runTypedControlBarrier({}, { purpose: 'forged' }, async () => 7);
+  });
+
+  it('rejects an empty purpose at key creation', () => {
+    expect(() => createStoreControlBarrierKeyV1('')).toThrow(/must not be empty/);
+  });
+});

--- a/packages/storage/test/store-control-barrier-contract-v1.test.ts
+++ b/packages/storage/test/store-control-barrier-contract-v1.test.ts
@@ -4,7 +4,11 @@ import {
   StorePriorityScheduler,
   type StoreQueuedAdmissionV1,
 } from '../src/store-priority-scheduler.js';
-import { createStoreControlBarrierKeyV1 } from '../src/store-control-barrier-key-v1.js';
+import {
+  createStoreControlBarrierKeyV1,
+  type StoreControlBarrierKeyV1,
+} from '../src/store-control-barrier-key-v1.js';
+import type { ManagedSystemRecordCoordinatorOptionsV1 } from '../src/adapters/system-record-managed-coordinator-v1-internal.js';
 
 /**
  * The scheduler/coordinator boundary, asserted through the PUBLIC scheduler.
@@ -288,6 +292,17 @@ describe('typed barrier keys close the generic result channel (#2179)', () => {
     expectTypeOf(effect).toEqualTypeOf<Promise<void>>();
     await effect;
 
+  });
+
+  // Compile-time-only negatives, in a function that is DELIBERATELY never
+  // invoked: the typecheck lane compiles the body (each @ts-expect-error is
+  // verified live — fixing the suppressed error away yields TS2578), while
+  // the vitest run never executes an intentionally-invalid call, so no
+  // real barrier is enqueued and no promise floats.
+  const negativeTypeContracts = (
+    scheduler: StorePriorityScheduler,
+    epochKey: StoreControlBarrierKeyV1<{ epoch: string }>,
+  ) => {
     // A transition cannot smuggle a different result type past its key.
     // @ts-expect-error — the epoch key demands { epoch: string }, not number
     void scheduler.runTypedControlBarrier({}, epochKey, async () => 7);
@@ -296,7 +311,33 @@ describe('typed barrier keys close the generic result channel (#2179)', () => {
     // a required member no caller outside the factory can produce.
     // @ts-expect-error — structural literal lacks the private brand
     void scheduler.runTypedControlBarrier({}, { purpose: 'forged' }, async () => 7);
-  });
+
+    // The managed coordinator is typed-only STRUCTURALLY: its options carry no
+    // string-barrier member, so first-party composition cannot regress onto
+    // the purpose-string contract without editing that interface. The literal
+    // below is COMPLETE apart from `barrier`, deliberately: with every
+    // required member present, the excess `barrier` property is the ONLY
+    // error, so re-adding the member to the interface turns this suppression
+    // into an unused @ts-expect-error and fails the typecheck lane. (An
+    // incomplete literal could not discriminate — missing-member errors would
+    // keep the suppression alive either way.)
+    const typedOnly = (options: ManagedSystemRecordCoordinatorOptionsV1) => options;
+    void typedOnly({
+      lease: null as never,
+      handoff: null as never,
+      storeId: {},
+      queryEndpoint: '',
+      updateEndpoint: '',
+      resolveClient: () => null,
+      applyLegacy: null as never,
+      typedBarrier: null as never,
+      setAdmissionActive: () => {},
+      // @ts-expect-error — a string `barrier` member does not exist on the
+      // managed coordinator's options
+      barrier: null as never,
+    });
+  };
+  void negativeTypeContracts;
 
   it('rejects an empty purpose at key creation', () => {
     expect(() => createStoreControlBarrierKeyV1('')).toThrow(/must not be empty/);

--- a/packages/storage/test/store-control-barrier-contract-v1.test.ts
+++ b/packages/storage/test/store-control-barrier-contract-v1.test.ts
@@ -4,11 +4,7 @@ import {
   StorePriorityScheduler,
   type StoreQueuedAdmissionV1,
 } from '../src/store-priority-scheduler.js';
-import {
-  createStoreControlBarrierKeyV1,
-  type StoreControlBarrierKeyV1,
-} from '../src/store-control-barrier-key-v1.js';
-import type { ManagedSystemRecordCoordinatorOptionsV1 } from '../src/adapters/system-record-managed-coordinator-v1-internal.js';
+import { createStoreControlBarrierKeyV1 } from '../src/store-control-barrier-key-v1.js';
 
 /**
  * The scheduler/coordinator boundary, asserted through the PUBLIC scheduler.
@@ -294,50 +290,11 @@ describe('typed barrier keys close the generic result channel (#2179)', () => {
 
   });
 
-  // Compile-time-only negatives, in a function that is DELIBERATELY never
-  // invoked: the typecheck lane compiles the body (each @ts-expect-error is
-  // verified live — fixing the suppressed error away yields TS2578), while
-  // the vitest run never executes an intentionally-invalid call, so no
-  // real barrier is enqueued and no promise floats.
-  const negativeTypeContracts = (
-    scheduler: StorePriorityScheduler,
-    epochKey: StoreControlBarrierKeyV1<{ epoch: string }>,
-  ) => {
-    // A transition cannot smuggle a different result type past its key.
-    // @ts-expect-error — the epoch key demands { epoch: string }, not number
-    void scheduler.runTypedControlBarrier({}, epochKey, async () => 7);
-
-    // A key cannot be forged from a plain literal: the module-private brand is
-    // a required member no caller outside the factory can produce.
-    // @ts-expect-error — structural literal lacks the private brand
-    void scheduler.runTypedControlBarrier({}, { purpose: 'forged' }, async () => 7);
-
-    // The managed coordinator is typed-only STRUCTURALLY: its options carry no
-    // string-barrier member, so first-party composition cannot regress onto
-    // the purpose-string contract without editing that interface. The literal
-    // below is COMPLETE apart from `barrier`, deliberately: with every
-    // required member present, the excess `barrier` property is the ONLY
-    // error, so re-adding the member to the interface turns this suppression
-    // into an unused @ts-expect-error and fails the typecheck lane. (An
-    // incomplete literal could not discriminate — missing-member errors would
-    // keep the suppression alive either way.)
-    const typedOnly = (options: ManagedSystemRecordCoordinatorOptionsV1) => options;
-    void typedOnly({
-      lease: null as never,
-      handoff: null as never,
-      storeId: {},
-      queryEndpoint: '',
-      updateEndpoint: '',
-      resolveClient: () => null,
-      applyLegacy: null as never,
-      typedBarrier: null as never,
-      setAdmissionActive: () => {},
-      // @ts-expect-error — a string `barrier` member does not exist on the
-      // managed coordinator's options
-      barrier: null as never,
-    });
-  };
-  void negativeTypeContracts;
+  // The compile-only NEGATIVE contracts (smuggled result types, forged keys,
+  // the coordinator's structural no-string-member pin) live in
+  // store-control-barrier-contract-v1.typetest.ts, compiled by the
+  // typecheck:type-contracts lane and never executed — this file stays
+  // runtime-only.
 
   it('rejects an empty purpose at key creation', () => {
     expect(() => createStoreControlBarrierKeyV1('')).toThrow(/must not be empty/);

--- a/packages/storage/test/store-control-barrier-contract-v1.typetest.ts
+++ b/packages/storage/test/store-control-barrier-contract-v1.typetest.ts
@@ -1,0 +1,57 @@
+/**
+ * Compile-only negative type contracts for typed control-barrier keys (#2179).
+ *
+ * NEVER EXECUTED: this file is compiled by `typecheck:type-contracts`
+ * (tsconfig.typetests.json) and is not matched by the vitest include glob, so
+ * intentionally-invalid expressions prove type-level properties without
+ * enqueueing real barriers or floating promises. Each `@ts-expect-error` here
+ * is a live assertion — if the error it suppresses stops existing, the lane
+ * fails with TS2578 (unused directive). All values are `declare`d: there is
+ * no runtime, only shapes.
+ */
+import type { ManagedSystemRecordCoordinatorOptionsV1 } from '../src/adapters/system-record-managed-coordinator-v1-internal.js';
+import type { StoreControlBarrierKeyV1 } from '../src/store-control-barrier-key-v1.js';
+import type { StorePriorityScheduler } from '../src/store-priority-scheduler.js';
+
+declare const scheduler: StorePriorityScheduler;
+declare const epochKey: StoreControlBarrierKeyV1<{ epoch: string }>;
+declare const takeOptions: (options: ManagedSystemRecordCoordinatorOptionsV1) => void;
+
+// A transition cannot smuggle a different result type past its key.
+// @ts-expect-error — the epoch key demands { epoch: string }, not number
+void scheduler.runTypedControlBarrier({}, epochKey, async () => 7);
+
+// A key cannot be forged from a plain literal: the module-private brand is a
+// required member no caller outside the factory can produce.
+// @ts-expect-error — structural literal lacks the private brand
+void scheduler.runTypedControlBarrier({}, { purpose: 'forged' }, async () => 7);
+
+// The managed coordinator is typed-only STRUCTURALLY: its options carry no
+// string-barrier member, so first-party composition cannot regress onto the
+// purpose-string contract without editing that interface. The literal below is
+// COMPLETE apart from `barrier`, deliberately: with every required member
+// present, the excess `barrier` property is the ONLY error, so re-adding the
+// member to the interface turns the suppression below into an unused
+// directive (TS2578) and fails the typecheck lane. (An incomplete literal
+// could not discriminate — missing-member errors would keep the suppression
+// alive either way.) NOTE: never let the directive token itself start a
+// wrapped comment line here — tsc parses any comment line beginning with the
+// expect-error token as a REAL directive, and a phantom directive on a prose
+// line reads as unused and fails this lane. That exact wrap bug shipped in
+// this file's first version.
+void takeOptions({
+  lease: null as never,
+  handoff: null as never,
+  storeId: {},
+  queryEndpoint: '',
+  updateEndpoint: '',
+  resolveClient: () => null,
+  applyLegacy: null as never,
+  typedBarrier: null as never,
+  setAdmissionActive: () => {},
+  // @ts-expect-error — a string `barrier` member does not exist on the
+  // managed coordinator's options
+  barrier: null as never,
+});
+
+export {};

--- a/packages/storage/test/store-control-barrier-contract-v1.typetest.ts
+++ b/packages/storage/test/store-control-barrier-contract-v1.typetest.ts
@@ -10,6 +10,7 @@
  * no runtime, only shapes.
  */
 import type { ManagedSystemRecordCoordinatorOptionsV1 } from '../src/adapters/system-record-managed-coordinator-v1-internal.js';
+import type { SystemRecordLaneControllerTypedDepsV1 } from '../src/system-record-lane-controller-contract-v1.js';
 import type { StoreControlBarrierKeyV1 } from '../src/store-control-barrier-key-v1.js';
 import type { StorePriorityScheduler } from '../src/store-priority-scheduler.js';
 
@@ -51,6 +52,23 @@ void takeOptions({
   setAdmissionActive: () => {},
   // @ts-expect-error — a string `barrier` member does not exist on the
   // managed coordinator's options
+  barrier: null as never,
+});
+
+
+// The EXPORTED typed-only factory input carries the same structural pin as
+// the coordinator options: a complete literal, excess `barrier` as the only
+// error. If SystemRecordLaneControllerTypedDepsV1 ever grows a string
+// `barrier` member (even optional), the suppression below turns into an
+// unused directive (TS2578) and this lane fails.
+declare const takeTypedDeps: (deps: SystemRecordLaneControllerTypedDepsV1) => void;
+void takeTypedDeps({
+  lease: null as never,
+  handoff: null as never,
+  executor: null as never,
+  typedBarrier: null as never,
+  setAdmissionActive: () => {},
+  // @ts-expect-error — no string `barrier` member exists on the typed-only deps
   barrier: null as never,
 });
 

--- a/packages/storage/test/system-record-capability-probe-errors-v1.test.ts
+++ b/packages/storage/test/system-record-capability-probe-errors-v1.test.ts
@@ -23,16 +23,12 @@ vi.mock('../src/system-record-materializer-v1.js', async (importOriginal) => {
   >();
   return {
     ...actual,
-    // The managed path builds on the TYPED-ONLY entry point (#2179): the
-    // coordinator imports createSystemRecordLaneControllerTypedV1 directly,
-    // so the injection must sit there to reach production composition. Note
-    // the scope honestly: the public compatibility adapter reaches the typed
-    // builder through a module-internal call, which a module mock cannot
-    // intercept — this injection covers the coordinator's imported route,
-    // which is the route production takes.
-    createSystemRecordLaneControllerTypedV1: (deps: never) => {
+    // There is ONE controller constructor (#2179 round 3): both the managed
+    // coordinator and any legacy composer go through it, so this single
+    // injection point covers every construction route.
+    createSystemRecordLaneControllerV1: (deps: never) => {
       if (injected.error) throw injected.error;
-      return actual.createSystemRecordLaneControllerTypedV1(deps);
+      return actual.createSystemRecordLaneControllerV1(deps);
     },
   };
 });

--- a/packages/storage/test/system-record-capability-probe-errors-v1.test.ts
+++ b/packages/storage/test/system-record-capability-probe-errors-v1.test.ts
@@ -23,9 +23,16 @@ vi.mock('../src/system-record-materializer-v1.js', async (importOriginal) => {
   >();
   return {
     ...actual,
-    createSystemRecordLaneControllerV1: (deps: never) => {
+    // The managed path builds on the TYPED-ONLY entry point (#2179): the
+    // coordinator imports createSystemRecordLaneControllerTypedV1 directly,
+    // so the injection must sit there to reach production composition. Note
+    // the scope honestly: the public compatibility adapter reaches the typed
+    // builder through a module-internal call, which a module mock cannot
+    // intercept — this injection covers the coordinator's imported route,
+    // which is the route production takes.
+    createSystemRecordLaneControllerTypedV1: (deps: never) => {
       if (injected.error) throw injected.error;
-      return actual.createSystemRecordLaneControllerV1(deps);
+      return actual.createSystemRecordLaneControllerTypedV1(deps);
     },
   };
 });

--- a/packages/storage/test/system-record-managed-coordinator-v1.test.ts
+++ b/packages/storage/test/system-record-managed-coordinator-v1.test.ts
@@ -13,12 +13,13 @@ vi.mock('../src/system-record-atomic-apply-executor-v1-internal.js', () => ({
   createSystemRecordAtomicApplyExecutorV1: probes.atomicFactory,
 }));
 
-// The coordinator builds on the TYPED-ONLY factory (#2179). Mocking only that
-// export is deliberate: if the coordinator ever reaches for the legacy
-// createSystemRecordLaneControllerV1 again, its import resolves to undefined
-// here and this test fails at the call, not silently.
+// One controller constructor (#2179 round 3): the coordinator calls the
+// single factory with its typed-only deps shape. The structural invariant is
+// asserted below on the DEPS VALUE the factory receives — no 'barrier' key —
+// rather than on which of two factories was called, because there is only
+// one.
 vi.mock('../src/system-record-materializer-v1.js', () => ({
-  createSystemRecordLaneControllerTypedV1: probes.laneFactory,
+  createSystemRecordLaneControllerV1: probes.laneFactory,
 }));
 
 vi.mock('../src/system-record-runtime-v1-internal.js', () => ({

--- a/packages/storage/test/system-record-managed-coordinator-v1.test.ts
+++ b/packages/storage/test/system-record-managed-coordinator-v1.test.ts
@@ -13,8 +13,12 @@ vi.mock('../src/system-record-atomic-apply-executor-v1-internal.js', () => ({
   createSystemRecordAtomicApplyExecutorV1: probes.atomicFactory,
 }));
 
+// The coordinator builds on the TYPED-ONLY factory (#2179). Mocking only that
+// export is deliberate: if the coordinator ever reaches for the legacy
+// createSystemRecordLaneControllerV1 again, its import resolves to undefined
+// here and this test fails at the call, not silently.
 vi.mock('../src/system-record-materializer-v1.js', () => ({
-  createSystemRecordLaneControllerV1: probes.laneFactory,
+  createSystemRecordLaneControllerTypedV1: probes.laneFactory,
 }));
 
 vi.mock('../src/system-record-runtime-v1-internal.js', () => ({
@@ -37,7 +41,6 @@ describe('managed system-record coordinator composition', () => {
     const storeId = Object.freeze({ store: true });
     const resolveClient = vi.fn();
     const applyLegacy = vi.fn().mockResolvedValue({ outcome: 'stale' });
-    const barrier = vi.fn();
     const typedBarrier = vi.fn();
     const setAdmissionActive = vi.fn();
     const controller = createManagedSystemRecordCoordinatorV1({
@@ -48,7 +51,6 @@ describe('managed system-record coordinator composition', () => {
       updateEndpoint: 'http://127.0.0.1:1/update',
       resolveClient,
       applyLegacy,
-      barrier,
       typedBarrier,
       setAdmissionActive,
     } as never);
@@ -66,7 +68,6 @@ describe('managed system-record coordinator composition', () => {
     const laneDeps = probes.laneFactory.mock.calls[0][0] as {
       lease: unknown;
       handoff: unknown;
-      barrier: unknown;
       typedBarrier: unknown;
       setAdmissionActive: unknown;
       executor: {
@@ -82,10 +83,13 @@ describe('managed system-record coordinator composition', () => {
     expect(laneDeps).toMatchObject({
       lease,
       handoff,
-      barrier,
       typedBarrier,
       setAdmissionActive,
     });
+    // The typed factory receives NO string barrier — not undefined-valued,
+    // structurally absent. This is the managed path's #2179 invariant at the
+    // composition boundary, asserted on the deps object production passes.
+    expect('barrier' in laneDeps).toBe(false);
 
     const proof = Object.freeze({ proof: true });
     const binding = Object.freeze({ binding: true });

--- a/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
+++ b/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
@@ -2915,4 +2915,40 @@ describe('system-record lane session lifecycle V1', () => {
       expect(session.state).toBe('shutdown');
     });
   });
+
+  describe('poisoned string barrier under the legacy fallback (#2179)', () => {
+    // Managed composition routes every lifecycle call through `typedBarrier`
+    // and supplies a string barrier that THROWS. The controller's fallback
+    // reaches that string barrier only when `typedBarrier` is absent — i.e.
+    // only if a future edit removes it from the production deps. This pins
+    // what such an edit produces: an immediate, NAMED failure, instead of the
+    // silent alternative where transitions keep working while quietly moving
+    // onto the deprecated purpose-string contract and its unsound result cast.
+    it('a lane composed with only a poisoned barrier fails enable loudly, named, and closed', async () => {
+      const controller = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff,
+        executor,
+        // The same shape sparql-http supplies in managed composition.
+        barrier: () => {
+          throw new Error(
+            'system-record managed composition retired the purpose-string barrier (#2179)',
+          );
+        },
+      });
+
+      await expect(controller.open(ACTIVATION)).rejects.toThrow(/#2179/);
+
+      // Closed, not just loud, in one assertion: the ONLY handoff interaction
+      // is the fail-closed order. The poison threw at the barrier boundary, so
+      // no physical step ran — the child was never stopped, destroyed, or
+      // replaced under an enable that could not settle.
+      expect(handoff.calls).toEqual([
+        'failManagedMutationsClosed:enable transition did not physically settle',
+      ]);
+      // The lane is terminally unavailable, matching every other failed-enable
+      // path in this file.
+      await expect(controller.open(ACTIVATION)).rejects.toThrow(/terminal/);
+    });
+  });
 });

--- a/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
+++ b/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
@@ -2916,33 +2916,29 @@ describe('system-record lane session lifecycle V1', () => {
     });
   });
 
-  describe('poisoned string barrier under the legacy fallback (#2179)', () => {
-    // Managed composition routes every lifecycle call through `typedBarrier`
-    // and supplies a string barrier that THROWS. The controller's fallback
-    // reaches that string barrier only when `typedBarrier` is absent — i.e.
-    // only if a future edit removes it from the production deps. This pins
-    // what such an edit produces: an immediate, NAMED failure, instead of the
-    // silent alternative where transitions keep working while quietly moving
-    // onto the deprecated purpose-string contract and its unsound result cast.
-    it('a lane composed with only a poisoned barrier fails enable loudly, named, and closed', async () => {
+  describe('compatibility adapter with a failing string barrier (#2179)', () => {
+    // First-party composition is typed-only and structurally cannot reach the
+    // string path (the managed coordinator's deps have no string member).
+    // External composers still enter through this public adapter with string
+    // barriers, so the compat path's failure shape is pinned here: a barrier
+    // that throws at the boundary must fail CLOSED, not leave a half-enabled
+    // lane over a child nobody stopped.
+    it('a string barrier that throws at the boundary fails enable loudly and closed', async () => {
       const controller = createSystemRecordLaneControllerV1({
         lease: ownership.lease,
         handoff,
         executor,
-        // The same shape sparql-http supplies in managed composition.
         barrier: () => {
-          throw new Error(
-            'system-record managed composition retired the purpose-string barrier (#2179)',
-          );
+          throw new Error('external barrier infrastructure refused the transition');
         },
       });
 
-      await expect(controller.open(ACTIVATION)).rejects.toThrow(/#2179/);
+      await expect(controller.open(ACTIVATION)).rejects.toThrow(/refused the transition/);
 
       // Closed, not just loud, in one assertion: the ONLY handoff interaction
-      // is the fail-closed order. The poison threw at the barrier boundary, so
-      // no physical step ran — the child was never stopped, destroyed, or
-      // replaced under an enable that could not settle.
+      // is the fail-closed order. The barrier threw before the transition ran,
+      // so no physical step happened — the child was never stopped, destroyed,
+      // or replaced under an enable that could not settle.
       expect(handoff.calls).toEqual([
         'failManagedMutationsClosed:enable transition did not physically settle',
       ]);

--- a/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
+++ b/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
@@ -901,6 +901,23 @@ describe('system-record lane session lifecycle V1', () => {
       build();
       expect(() => build()).toThrow(SystemRecordControllerRegistrationError);
     });
+
+    it('refuses a second registration BEFORE reading composer-supplied deps', () => {
+      // Deps come from composers and may carry accessors. The duplicate guard
+      // must run before ANY dependency property is read — otherwise a second
+      // registration surfaces whatever a composer accessor throws (or runs
+      // its side effects) instead of the typed refusal. Every property access
+      // on this deps object throws, so the assertion below discriminates: the
+      // typed error can only surface if nothing was read first.
+      build();
+      const boobyTrapped = new Proxy({}, {
+        get() {
+          throw new Error('composer accessor ran before the registration guard');
+        },
+      });
+      expect(() => createSystemRecordLaneControllerV1(boobyTrapped as never))
+        .toThrow(SystemRecordControllerRegistrationError);
+    });
   });
 
   describe('transition precedence', () => {

--- a/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
+++ b/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
@@ -914,6 +914,12 @@ describe('system-record lane session lifecycle V1', () => {
         get() {
           throw new Error('composer accessor ran before the registration guard');
         },
+        // `in` narrowing triggers `has`, not `get` — trap both so ANY deps
+        // inspection before the guard trips this, including the normalizer's
+        // discriminating `'barrier' in deps` check.
+        has() {
+          throw new Error('composer deps were inspected before the registration guard');
+        },
       });
       expect(() => createSystemRecordLaneControllerV1(boobyTrapped as never))
         .toThrow(SystemRecordControllerRegistrationError);

--- a/packages/storage/tsconfig.typetests.json
+++ b/packages/storage/tsconfig.typetests.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "test/store-control-barrier-contract-v1.test.ts"
+  ],
+  "references": [{ "path": "../core" }, { "path": "../rdf-utils" }]
+}

--- a/packages/storage/tsconfig.typetests.json
+++ b/packages/storage/tsconfig.typetests.json
@@ -6,7 +6,8 @@
   },
   "include": [
     "src",
-    "test/store-control-barrier-contract-v1.test.ts"
+    "test/store-control-barrier-contract-v1.test.ts",
+    "test/store-control-barrier-contract-v1.typetest.ts"
   ],
   "references": [{ "path": "../core" }, { "path": "../rdf-utils" }]
 }


### PR DESCRIPTION
## Summary

- Retire the purpose-string control-barrier contract from first-party composition. The unsoundness (#2179): coalescing is keyed by a runtime `(storeId, purpose-string)` while each caller picks a static `T`, so a later same-purpose caller receives the first transition's promise under its own `T`. The typed-key path (`runTypedControlBarrier` + `createStoreControlBarrierKeyV1`, landed in #2169) binds `T` to the key once; this PR finishes the migration so **no first-party code calls the string API at all**.
- The managed lane is typed-only **structurally** (design refined across review rounds 1–3, replacing an earlier poisoned-callback approach and then a second exported factory): `createSystemRecordLaneControllerV1` remains the **only** controller constructor, with overloads accepting either `SystemRecordLaneControllerTypedDepsV1` (no string-barrier member at all) or the legacy-capable public deps, normalizing internally. The managed coordinator's options forbid the string member and it passes a typed-deps literal, so first-party composition cannot regress onto the purpose-string contract by any edit short of changing an internal interface. A complete-literal `@ts-expect-error` pin keeps that structural absence honest — re-adding the member fails the typecheck lane with TS2578 (verified live). The duplicate-registration guard runs before **any** caller-supplied deps property is read, pinned by a throw-on-every-access Proxy test and mutation-checked.
- Deprecate `runControlBarrier` and the `run()` `'control-barrier'` admission with the migration path and the removal boundary stated: both are removed **together at the next allowed breaking version**, not before — both removals are source-incompatible for external callers. Until then externals keep working unchanged; the lifecycle suite (string-only barriers throughout) is the compat pin. Coalescing, timeout, sealing, quiescence and metrics behavior are untouched — both entry points share the coordinator.
- Make the type contracts **provable instead of decorative**: nothing typechecked storage test files (package tsconfig includes only `src/`; vitest does not typecheck), so every `expectTypeOf` in the suite was inert. A narrow `tsconfig.typetests.json` lane compiles the barrier contract file in CI. The suite-wide gap is flagged as follow-up, not absorbed here.

## Related

- Closes #2179
- Follow-up to #2169 (typed keys; review threads r3742018911, r3742135534)
- Part of #2052
- Note: `.github/workflows/system-record-managed-ownership.yml` is also touched by open PR #2189 (different hunks; whichever merges second rebases trivially)

## Diagrams

### Lifecycle transition under the barrier

Before:

```mermaid
sequenceDiagram
    participant Lane as system-record lane
    participant Deps as controller deps
    participant Sched as StorePriorityScheduler
    Lane->>Deps: typedBarrier('enable', transition)
    Deps->>Sched: runTypedControlBarrier(storeId, key, transition)
    Note over Deps,Sched: if typedBarrier were ever removed:
    Lane->>Deps: barrier('system-record.enable', transition)
    Deps->>Sched: runControlBarrier(storeId, purpose, transition)
    Note over Sched: silent fallback onto the unsound<br/>string contract — as Promise#60;T#62;
```

After:

```mermaid
sequenceDiagram
    participant Lane as system-record lane
    participant Deps as controller deps
    participant Sched as StorePriorityScheduler
    Lane->>Deps: typedBarrier('enable', transition)
    Deps->>Sched: runTypedControlBarrier(storeId, key, transition)
    Note over Deps,Sched: the coordinator's deps have NO string member —<br/>falling back is a type error, pinned by<br/>an #64;ts-expect-error tripwire in the typecheck lane
```

## Files changed

| File | What |
|------|------|
| `packages/storage/src/adapters/sparql-http.ts` | Supplies only `typedBarrier`; no string barrier exists in managed composition |
| `packages/storage/src/adapters/system-record-managed-coordinator-v1-internal.ts` | Options drop the string member; calls the typed-only builder |
| `packages/storage/src/system-record-materializer-v1.ts` | One factory with typed/legacy overloads; shared deps base (`SystemRecordLaneControllerSharedDepsV1`); guard-before-deps-read ordering; deprecation docs with removal boundary |
| `packages/storage/src/store-priority-scheduler.ts` | `runControlBarrier` + `StoreControlBarrierAdmissionV1` deprecations: migration path, removal boundary, behavior-parity statement |
| `packages/storage/test/system-record-materializer-lifecycle-v1.test.ts` | Compat-path pin: an external string barrier that throws at the boundary fails enable loudly and closed |
| `packages/storage/test/system-record-capability-probe-errors-v1.test.ts` | Injection follows the composition: mock sits on the typed builder (the route production takes) |
| `packages/storage/test/store-control-barrier-contract-v1.test.ts` | Type contracts: result type bound to the key; void key = effect barrier by type; `@ts-expect-error` pins (no smuggled result type, no forged key) |
| `packages/storage/tsconfig.typetests.json`, `packages/storage/package.json` | `typecheck:type-contracts` lane so the type assertions are compiled, not decorative |
| `.github/workflows/system-record-managed-ownership.yml` | CI step running the type-contract lane |

## Test plan

- [x] Storage curated CI lane: 33 files / 564 tests green
- [x] Affected suites: 176 tests green across contract, lifecycle, epoch-adapter, scheduler, admission, barrier-integration
- [x] `typecheck:type-contracts` lane green; both `@ts-expect-error` pins proven live (fixing the suppressed error away yields TS2578)
- [x] Structural mutant: re-adding a string `barrier` member to the coordinator options turns the `@ts-expect-error` pin into an unused suppression — typecheck lane fails with TS2578 (verified live)
- [x] Negative type assertions live in a never-invoked function: compiled by the typecheck lane, never executed by vitest (no real barriers enqueued, no floating promises)
- [x] First-party caller sweep: zero `runControlBarrier(` call sites outside the scheduler's own deprecated method
- [x] String-only compat pin: the lifecycle suite supplies string barriers throughout and stays green
