### PR TITLE
refactor(agent): extract RS-heal materialization

### DIFF
--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -95,7 +95,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, StoreSchedulerBusyError, asChangelogReader, asGraphWriteGenSource, createTripleStore, type TripleStore, type TripleStoreConfig, type QueryOptions, type Quad, type LargeLiteralStorageConfig, type SelectResult } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, StoreSchedulerBusyError, asChangelogReader, asGraphWriteGenSource, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type SelectResult } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -254,14 +254,7 @@ import {
   applyRsHealMaterialization,
   supportsRsHealMaterialization,
 } from './rs-heal-materialization.js';
-
-function rsHealStoreOptions(operation: string, signal?: AbortSignal): QueryOptions {
-  return {
-    priority: 'background',
-    source: `agent.swm.rsHeal.${operation}`,
-    ...(signal ? { signal } : {}),
-  };
-}
+import { rsHealStoreOptions } from './rs-heal-store-options.js';
 
 function isStoreSchedulerBusyError(err: unknown): boolean {
   return err instanceof StoreSchedulerBusyError || (
@@ -3508,37 +3501,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
             // preserved while large multi-root KCs are split below both 4 MiB
             // structured-mutation limits.
             await applyRsHealMaterialization(this.store, {
-              dataCopy: {
-                sourceGraphUris: [rootData, vmGraph],
-                targetGraphUri: scopedData,
-                roots,
-                descendantSuffix: '/.well-known/genid/',
-                excludedPredicates: [TRUST_LEVEL_PREDICATE, LEGACY_TRUST_LEVEL_PREDICATE],
-              },
-              metadataCopy: {
-                sourceGraphUris: [legacyMeta],
-                targetGraphUri: scopedMeta,
-                roots: [ual],
-                descendantSuffix: '/',
-                excludedPredicates: [`${DKG}materializedVersion`],
-              },
-              completionReset: {
-                graphUri: scopedMeta,
-                subject: ual,
-                predicates: [`${DKG}materializedVersion`],
-                replacementQuads: [],
-              },
-              completionStamp: {
-                graphUri: scopedMeta,
-                subject: ual,
-                predicates: [`${DKG}materializedVersion`],
-                replacementQuads: [{
-                  subject: ual,
-                  predicate: `${DKG}materializedVersion`,
-                  object: `"${version.blockNumber}:${version.txIndex}"`,
-                  graph: scopedMeta,
-                }],
-              },
+              sourceDataGraphUris: [rootData, vmGraph],
+              targetDataGraphUri: scopedData,
+              sourceMetadataGraphUri: legacyMeta,
+              targetMetadataGraphUri: scopedMeta,
+              ual,
+              roots,
+              version,
+              materializedVersionPredicate: `${DKG}materializedVersion`,
+              dataExcludedPredicates: [TRUST_LEVEL_PREDICATE, LEGACY_TRUST_LEVEL_PREDICATE],
             }, canApply, signal);
 
             if (canApply()) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -95,7 +95,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, StoreSchedulerBusyError, asChangelogReader, asGraphWriteGenSource, chunkCopySubjectProjectionInput, createTripleStore, supportsCopySubjectProjection, supportsReplaceSubjectPredicatesAtomically, tryCopySubjectProjection, tryReplaceSubjectPredicatesAtomically, type TripleStore, type TripleStoreConfig, type QueryOptions, type Quad, type LargeLiteralStorageConfig, type SelectResult } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, StoreSchedulerBusyError, asChangelogReader, asGraphWriteGenSource, createTripleStore, type TripleStore, type TripleStoreConfig, type QueryOptions, type Quad, type LargeLiteralStorageConfig, type SelectResult } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -250,6 +250,10 @@ import {
   type VmReconcileSource,
 } from './vm-reconcile-service.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
+import {
+  applyRsHealMaterialization,
+  supportsRsHealMaterialization,
+} from './rs-heal-materialization.js';
 
 function rsHealStoreOptions(operation: string, signal?: AbortSignal): QueryOptions {
   return {
@@ -323,46 +327,6 @@ function advanceRsHealCursor(
     if (oldest === undefined) break;
     cursorMap.delete(oldest);
   }
-}
-
-type RsHealCopyInput = Parameters<typeof tryCopySubjectProjection>[1];
-type RsHealPredicateReplacement = Parameters<typeof tryReplaceSubjectPredicatesAtomically>[1];
-
-interface RsHealMaterializationPlan {
-  dataCopy: RsHealCopyInput;
-  metadataCopy: RsHealCopyInput;
-  completionReset: RsHealPredicateReplacement;
-  completionStamp: RsHealPredicateReplacement;
-}
-
-/** Apply one fail-closed RS-heal projection transition after candidate discovery. */
-async function applyRsHealMaterialization(
-  plan: RsHealMaterializationPlan,
-  operations: {
-    canApply: () => boolean;
-    copyProjection: (input: RsHealCopyInput) => Promise<void>;
-    replacePredicates: (input: RsHealPredicateReplacement) => Promise<void>;
-  },
-): Promise<void> {
-  // Preflight the complete plan before crossing the first write boundary. An
-  // individually unrepresentable root must not clear an otherwise valid
-  // completion marker before failing.
-  const dataCopyChunks = chunkCopySubjectProjectionInput(plan.dataCopy);
-
-  // Clear completion before the first data chunk. A crash between chunks then
-  // remains retryable instead of exposing a partial projection as complete.
-  if (!operations.canApply()) return;
-  await operations.replacePredicates(plan.completionReset);
-
-  for (const chunk of dataCopyChunks) {
-    if (!operations.canApply()) return;
-    await operations.copyProjection(chunk);
-  }
-
-  if (!operations.canApply()) return;
-  await operations.copyProjection(plan.metadataCopy);
-  if (!operations.canApply()) return;
-  await operations.replacePredicates(plan.completionStamp);
 }
 
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
@@ -3370,35 +3334,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
       if (!canApply() || !capturedOnChainId) {
         return { status: 'skipped', reason: 'not-current' };
       }
-      if (
-        !supportsCopySubjectProjection(this.store)
-        || !supportsReplaceSubjectPredicatesAtomically(this.store)
-      ) {
+      if (!supportsRsHealMaterialization(this.store)) {
         return { status: 'skipped', reason: 'unsupported-store' };
       }
-      // Server-side byte-safe copy is the ONLY safe relocation mechanism. The
-      // structured capabilities keep RDF terms inside the store while making
-      // source/target graph ownership and mutation scope explicit to decorators.
-      const copyProjection = async (
-        input: Parameters<typeof tryCopySubjectProjection>[1],
-      ): Promise<void> => {
-        const copied = await tryCopySubjectProjection(
-          this.store,
-          input,
-          rsHealStoreOptions('materialize.copy', signal),
-        );
-        if (!copied) throw new Error('RS heal requires server-side subject projection copy support');
-      };
-      const replacePredicates = async (
-        input: Parameters<typeof tryReplaceSubjectPredicatesAtomically>[1],
-      ): Promise<void> => {
-        const replaced = await tryReplaceSubjectPredicatesAtomically(
-          this.store,
-          input,
-          rsHealStoreOptions('materialize.marker', signal),
-        );
-        if (!replaced) throw new Error('RS heal requires atomic subject-predicate replacement support');
-      };
 
       const DKG = 'http://dkg.io/ontology/';
       const legacyMeta = contextGraphMetaUri(localCgId);
@@ -3569,7 +3507,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
             // bit-identical with the on-chain merkleLeafCount. Root order is
             // preserved while large multi-root KCs are split below both 4 MiB
             // structured-mutation limits.
-            await applyRsHealMaterialization({
+            await applyRsHealMaterialization(this.store, {
               dataCopy: {
                 sourceGraphUris: [rootData, vmGraph],
                 targetGraphUri: scopedData,
@@ -3601,11 +3539,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
                   graph: scopedMeta,
                 }],
               },
-            }, {
-              canApply,
-              copyProjection,
-              replacePredicates,
-            });
+            }, canApply, signal);
 
             if (canApply()) {
               this.log.info(

--- a/packages/agent/src/rs-heal-materialization.ts
+++ b/packages/agent/src/rs-heal-materialization.ts
@@ -1,0 +1,83 @@
+import {
+  chunkCopySubjectProjectionInput,
+  supportsCopySubjectProjection,
+  supportsReplaceSubjectPredicatesAtomically,
+  tryCopySubjectProjection,
+  tryReplaceSubjectPredicatesAtomically,
+  type QueryOptions,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+
+type RsHealCopyInput = Parameters<typeof tryCopySubjectProjection>[1];
+type RsHealPredicateReplacement = Parameters<typeof tryReplaceSubjectPredicatesAtomically>[1];
+
+export interface RsHealMaterializationPlan {
+  readonly dataCopy: RsHealCopyInput;
+  readonly metadataCopy: RsHealCopyInput;
+  readonly completionReset: RsHealPredicateReplacement;
+  readonly completionStamp: RsHealPredicateReplacement;
+}
+
+function storeOptions(operation: 'copy' | 'marker', signal?: AbortSignal): QueryOptions {
+  return {
+    priority: 'background',
+    source: `agent.swm.rsHeal.materialize.${operation}`,
+    ...(signal ? { signal } : {}),
+  };
+}
+
+export function supportsRsHealMaterialization(store: TripleStore): boolean {
+  return supportsCopySubjectProjection(store)
+    && supportsReplaceSubjectPredicatesAtomically(store);
+}
+
+async function copyProjection(
+  store: TripleStore,
+  input: RsHealCopyInput,
+  signal?: AbortSignal,
+): Promise<void> {
+  const copied = await tryCopySubjectProjection(store, input, storeOptions('copy', signal));
+  if (!copied) {
+    throw new Error('RS heal requires server-side subject projection copy support');
+  }
+}
+
+async function replacePredicates(
+  store: TripleStore,
+  input: RsHealPredicateReplacement,
+  signal?: AbortSignal,
+): Promise<void> {
+  const replaced = await tryReplaceSubjectPredicatesAtomically(
+    store,
+    input,
+    storeOptions('marker', signal),
+  );
+  if (!replaced) {
+    throw new Error('RS heal requires atomic subject-predicate replacement support');
+  }
+}
+
+/** Execute one fail-closed RS-heal transition after candidate discovery. */
+export async function applyRsHealMaterialization(
+  store: TripleStore,
+  plan: RsHealMaterializationPlan,
+  canApply: () => boolean,
+  signal?: AbortSignal,
+): Promise<void> {
+  // Validate and chunk the complete data plan before crossing the first write
+  // boundary. An unrepresentable root must not clear a valid completion marker.
+  const dataCopyChunks = chunkCopySubjectProjectionInput(plan.dataCopy);
+
+  if (!canApply()) return;
+  await replacePredicates(store, plan.completionReset, signal);
+
+  for (const chunk of dataCopyChunks) {
+    if (!canApply()) return;
+    await copyProjection(store, chunk, signal);
+  }
+
+  if (!canApply()) return;
+  await copyProjection(store, plan.metadataCopy, signal);
+  if (!canApply()) return;
+  await replacePredicates(store, plan.completionStamp, signal);
+}

--- a/packages/agent/src/rs-heal-materialization.ts
+++ b/packages/agent/src/rs-heal-materialization.ts
@@ -4,25 +4,68 @@ import {
   supportsReplaceSubjectPredicatesAtomically,
   tryCopySubjectProjection,
   tryReplaceSubjectPredicatesAtomically,
-  type QueryOptions,
+  type CopySubjectProjectionInput,
+  type ReplaceSubjectPredicatesInput,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
+import type { MaterializedVersion } from '@origintrail-official/dkg-publisher';
+import { rsHealStoreOptions } from './rs-heal-store-options.js';
 
-type RsHealCopyInput = Parameters<typeof tryCopySubjectProjection>[1];
-type RsHealPredicateReplacement = Parameters<typeof tryReplaceSubjectPredicatesAtomically>[1];
-
-export interface RsHealMaterializationPlan {
-  readonly dataCopy: RsHealCopyInput;
-  readonly metadataCopy: RsHealCopyInput;
-  readonly completionReset: RsHealPredicateReplacement;
-  readonly completionStamp: RsHealPredicateReplacement;
+export interface RsHealMaterializationInput {
+  readonly sourceDataGraphUris: readonly string[];
+  readonly targetDataGraphUri: string;
+  readonly sourceMetadataGraphUri: string;
+  readonly targetMetadataGraphUri: string;
+  readonly ual: string;
+  readonly roots: readonly string[];
+  readonly version: MaterializedVersion;
+  readonly materializedVersionPredicate: string;
+  readonly dataExcludedPredicates: readonly string[];
 }
 
-function storeOptions(operation: 'copy' | 'marker', signal?: AbortSignal): QueryOptions {
+interface RsHealMaterializationPlan {
+  readonly dataCopy: CopySubjectProjectionInput;
+  readonly metadataCopy: CopySubjectProjectionInput;
+  readonly completionReset: ReplaceSubjectPredicatesInput;
+  readonly completionStamp: ReplaceSubjectPredicatesInput;
+}
+
+function buildRsHealMaterializationPlan(
+  input: RsHealMaterializationInput,
+): RsHealMaterializationPlan {
+  const completion = {
+    graphUri: input.targetMetadataGraphUri,
+    subject: input.ual,
+    predicates: [input.materializedVersionPredicate],
+  };
   return {
-    priority: 'background',
-    source: `agent.swm.rsHeal.materialize.${operation}`,
-    ...(signal ? { signal } : {}),
+    dataCopy: {
+      sourceGraphUris: [...input.sourceDataGraphUris],
+      targetGraphUri: input.targetDataGraphUri,
+      roots: [...input.roots],
+      descendantSuffix: '/.well-known/genid/',
+      excludedPredicates: [...input.dataExcludedPredicates],
+    },
+    metadataCopy: {
+      sourceGraphUris: [input.sourceMetadataGraphUri],
+      targetGraphUri: input.targetMetadataGraphUri,
+      roots: [input.ual],
+      descendantSuffix: '/',
+      excludedPredicates: [input.materializedVersionPredicate],
+    },
+    completionReset: {
+      ...completion,
+      replacementQuads: [],
+    },
+    completionStamp: {
+      ...completion,
+      replacementQuads: [{
+        graph: input.targetMetadataGraphUri,
+        subject: input.ual,
+        predicate: input.materializedVersionPredicate,
+        object: `"${input.version.blockNumber}:${input.version.txIndex}"`,
+      }],
+    },
   };
 }
 
@@ -33,10 +76,14 @@ export function supportsRsHealMaterialization(store: TripleStore): boolean {
 
 async function copyProjection(
   store: TripleStore,
-  input: RsHealCopyInput,
+  input: CopySubjectProjectionInput,
   signal?: AbortSignal,
 ): Promise<void> {
-  const copied = await tryCopySubjectProjection(store, input, storeOptions('copy', signal));
+  const copied = await tryCopySubjectProjection(
+    store,
+    input,
+    rsHealStoreOptions('materialize.copy', signal),
+  );
   if (!copied) {
     throw new Error('RS heal requires server-side subject projection copy support');
   }
@@ -44,13 +91,13 @@ async function copyProjection(
 
 async function replacePredicates(
   store: TripleStore,
-  input: RsHealPredicateReplacement,
+  input: ReplaceSubjectPredicatesInput,
   signal?: AbortSignal,
 ): Promise<void> {
   const replaced = await tryReplaceSubjectPredicatesAtomically(
     store,
     input,
-    storeOptions('marker', signal),
+    rsHealStoreOptions('materialize.marker', signal),
   );
   if (!replaced) {
     throw new Error('RS heal requires atomic subject-predicate replacement support');
@@ -60,10 +107,11 @@ async function replacePredicates(
 /** Execute one fail-closed RS-heal transition after candidate discovery. */
 export async function applyRsHealMaterialization(
   store: TripleStore,
-  plan: RsHealMaterializationPlan,
+  input: RsHealMaterializationInput,
   canApply: () => boolean,
   signal?: AbortSignal,
 ): Promise<void> {
+  const plan = buildRsHealMaterializationPlan(input);
   // Validate and chunk the complete data plan before crossing the first write
   // boundary. An unrepresentable root must not clear a valid completion marker.
   const dataCopyChunks = chunkCopySubjectProjectionInput(plan.dataCopy);

--- a/packages/agent/src/rs-heal-store-options.ts
+++ b/packages/agent/src/rs-heal-store-options.ts
@@ -1,0 +1,10 @@
+import type { QueryOptions } from '@origintrail-official/dkg-storage';
+
+/** One scheduler and tracing policy for every RS-heal store operation. */
+export function rsHealStoreOptions(operation: string, signal?: AbortSignal): QueryOptions {
+  return {
+    priority: 'background',
+    source: `agent.swm.rsHeal.${operation}`,
+    ...(signal ? { signal } : {}),
+  };
+}

--- a/packages/agent/test/rs-heal-materialization.test.ts
+++ b/packages/agent/test/rs-heal-materialization.test.ts
@@ -33,9 +33,10 @@ describe('RS-heal materialization executor', () => {
         seen.push({ mutation, options });
       }),
     } as unknown as TripleStore;
+    const signal = new AbortController().signal;
 
     expect(supportsRsHealMaterialization(store)).toBe(true);
-    await applyRsHealMaterialization(store, input(), () => true);
+    await applyRsHealMaterialization(store, input(), () => true, signal);
 
     expect(seen.map(({ mutation }) => mutation.kind)).toEqual([
       'replace-subject-predicates',
@@ -51,6 +52,8 @@ describe('RS-heal materialization executor', () => {
     ]);
     expect(seen.map(({ options }) => (options as { priority: string }).priority))
       .toEqual(['background', 'background', 'background', 'background']);
+    expect(seen.map(({ options }) => (options as { signal?: AbortSignal }).signal))
+      .toEqual([signal, signal, signal, signal]);
     expect(seen.map(({ mutation }) => mutation)).toEqual([
       {
         kind: 'replace-subject-predicates',

--- a/packages/agent/test/rs-heal-materialization.test.ts
+++ b/packages/agent/test/rs-heal-materialization.test.ts
@@ -121,4 +121,17 @@ describe('RS-heal materialization executor', () => {
     await applyRsHealMaterialization(store, input(), () => false);
     expect(structuredMutation).not.toHaveBeenCalled();
   });
+
+  it('preflights an unchunkable data plan before clearing completion', async () => {
+    const structuredMutation = vi.fn(async () => undefined);
+    const store = { structuredMutation } as unknown as TripleStore;
+    const oversizedRoot = `urn:test:rs-heal:${'a'.repeat(4 * 1024 * 1024)}`;
+
+    await expect(applyRsHealMaterialization(
+      store,
+      { ...input(), roots: [oversizedRoot] },
+      () => true,
+    )).rejects.toThrow(/copySubjectProjection exceeds .* operand bytes/);
+    expect(structuredMutation).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent/test/rs-heal-materialization.test.ts
+++ b/packages/agent/test/rs-heal-materialization.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StructuredMutation, TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  applyRsHealMaterialization,
+  supportsRsHealMaterialization,
+  type RsHealMaterializationPlan,
+} from '../src/rs-heal-materialization.js';
+
+const SOURCE = 'urn:test:rs-heal:source';
+const TARGET = 'urn:test:rs-heal:target';
+const META = 'urn:test:rs-heal:meta';
+const UAL = 'urn:test:rs-heal:ual';
+
+function plan(): RsHealMaterializationPlan {
+  return {
+    dataCopy: {
+      sourceGraphUris: [SOURCE],
+      targetGraphUri: TARGET,
+      roots: ['urn:test:rs-heal:root'],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    },
+    metadataCopy: {
+      sourceGraphUris: [SOURCE],
+      targetGraphUri: META,
+      roots: [UAL],
+      descendantSuffix: '/',
+      excludedPredicates: [],
+    },
+    completionReset: {
+      graphUri: META,
+      subject: UAL,
+      predicates: ['urn:test:rs-heal:version'],
+      replacementQuads: [],
+    },
+    completionStamp: {
+      graphUri: META,
+      subject: UAL,
+      predicates: ['urn:test:rs-heal:version'],
+      replacementQuads: [{
+        graph: META,
+        subject: UAL,
+        predicate: 'urn:test:rs-heal:version',
+        object: '"1:0"',
+      }],
+    },
+  };
+}
+
+describe('RS-heal materialization executor', () => {
+  it('preserves reset, data, metadata, stamp order and store options', async () => {
+    const seen: Array<{ mutation: StructuredMutation; options: unknown }> = [];
+    const store = {
+      structuredMutation: vi.fn(async (mutation: StructuredMutation, options: unknown) => {
+        seen.push({ mutation, options });
+      }),
+    } as unknown as TripleStore;
+
+    expect(supportsRsHealMaterialization(store)).toBe(true);
+    await applyRsHealMaterialization(store, plan(), () => true);
+
+    expect(seen.map(({ mutation }) => mutation.kind)).toEqual([
+      'replace-subject-predicates',
+      'copy-subject-projection',
+      'copy-subject-projection',
+      'replace-subject-predicates',
+    ]);
+    expect(seen.map(({ options }) => (options as { source: string }).source)).toEqual([
+      'agent.swm.rsHeal.materialize.marker',
+      'agent.swm.rsHeal.materialize.copy',
+      'agent.swm.rsHeal.materialize.copy',
+      'agent.swm.rsHeal.materialize.marker',
+    ]);
+  });
+
+  it('stops before metadata and completion after currentness changes', async () => {
+    let current = true;
+    const seen: StructuredMutation[] = [];
+    const store = {
+      structuredMutation: vi.fn(async (mutation: StructuredMutation) => {
+        seen.push(mutation);
+        if (mutation.kind === 'copy-subject-projection') current = false;
+      }),
+    } as unknown as TripleStore;
+
+    await applyRsHealMaterialization(store, plan(), () => current);
+    expect(seen.map(({ kind }) => kind)).toEqual([
+      'replace-subject-predicates',
+      'copy-subject-projection',
+    ]);
+  });
+
+  it('performs no writes when stale before the first boundary', async () => {
+    const structuredMutation = vi.fn(async () => undefined);
+    const store = { structuredMutation } as unknown as TripleStore;
+    await applyRsHealMaterialization(store, plan(), () => false);
+    expect(structuredMutation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/test/rs-heal-materialization.test.ts
+++ b/packages/agent/test/rs-heal-materialization.test.ts
@@ -3,7 +3,7 @@ import type { StructuredMutation, TripleStore } from '@origintrail-official/dkg-
 import {
   applyRsHealMaterialization,
   supportsRsHealMaterialization,
-  type RsHealMaterializationPlan,
+  type RsHealMaterializationInput,
 } from '../src/rs-heal-materialization.js';
 
 const SOURCE = 'urn:test:rs-heal:source';
@@ -11,39 +11,17 @@ const TARGET = 'urn:test:rs-heal:target';
 const META = 'urn:test:rs-heal:meta';
 const UAL = 'urn:test:rs-heal:ual';
 
-function plan(): RsHealMaterializationPlan {
+function input(): RsHealMaterializationInput {
   return {
-    dataCopy: {
-      sourceGraphUris: [SOURCE],
-      targetGraphUri: TARGET,
-      roots: ['urn:test:rs-heal:root'],
-      descendantSuffix: '/',
-      excludedPredicates: [],
-    },
-    metadataCopy: {
-      sourceGraphUris: [SOURCE],
-      targetGraphUri: META,
-      roots: [UAL],
-      descendantSuffix: '/',
-      excludedPredicates: [],
-    },
-    completionReset: {
-      graphUri: META,
-      subject: UAL,
-      predicates: ['urn:test:rs-heal:version'],
-      replacementQuads: [],
-    },
-    completionStamp: {
-      graphUri: META,
-      subject: UAL,
-      predicates: ['urn:test:rs-heal:version'],
-      replacementQuads: [{
-        graph: META,
-        subject: UAL,
-        predicate: 'urn:test:rs-heal:version',
-        object: '"1:0"',
-      }],
-    },
+    sourceDataGraphUris: [SOURCE],
+    targetDataGraphUri: TARGET,
+    sourceMetadataGraphUri: SOURCE,
+    targetMetadataGraphUri: META,
+    ual: UAL,
+    roots: ['urn:test:rs-heal:root'],
+    version: { blockNumber: 1, txIndex: 0 },
+    materializedVersionPredicate: 'urn:test:rs-heal:version',
+    dataExcludedPredicates: [],
   };
 }
 
@@ -57,7 +35,7 @@ describe('RS-heal materialization executor', () => {
     } as unknown as TripleStore;
 
     expect(supportsRsHealMaterialization(store)).toBe(true);
-    await applyRsHealMaterialization(store, plan(), () => true);
+    await applyRsHealMaterialization(store, input(), () => true);
 
     expect(seen.map(({ mutation }) => mutation.kind)).toEqual([
       'replace-subject-predicates',
@@ -71,6 +49,53 @@ describe('RS-heal materialization executor', () => {
       'agent.swm.rsHeal.materialize.copy',
       'agent.swm.rsHeal.materialize.marker',
     ]);
+    expect(seen.map(({ options }) => (options as { priority: string }).priority))
+      .toEqual(['background', 'background', 'background', 'background']);
+    expect(seen.map(({ mutation }) => mutation)).toEqual([
+      {
+        kind: 'replace-subject-predicates',
+        input: {
+          graphUri: META,
+          subject: UAL,
+          predicates: ['urn:test:rs-heal:version'],
+          replacementQuads: [],
+        },
+      },
+      {
+        kind: 'copy-subject-projection',
+        input: {
+          sourceGraphUris: [SOURCE],
+          targetGraphUri: TARGET,
+          roots: ['urn:test:rs-heal:root'],
+          descendantSuffix: '/.well-known/genid/',
+          excludedPredicates: [],
+        },
+      },
+      {
+        kind: 'copy-subject-projection',
+        input: {
+          sourceGraphUris: [SOURCE],
+          targetGraphUri: META,
+          roots: [UAL],
+          descendantSuffix: '/',
+          excludedPredicates: ['urn:test:rs-heal:version'],
+        },
+      },
+      {
+        kind: 'replace-subject-predicates',
+        input: {
+          graphUri: META,
+          subject: UAL,
+          predicates: ['urn:test:rs-heal:version'],
+          replacementQuads: [{
+            graph: META,
+            subject: UAL,
+            predicate: 'urn:test:rs-heal:version',
+            object: '"1:0"',
+          }],
+        },
+      },
+    ]);
   });
 
   it('stops before metadata and completion after currentness changes', async () => {
@@ -83,7 +108,7 @@ describe('RS-heal materialization executor', () => {
       }),
     } as unknown as TripleStore;
 
-    await applyRsHealMaterialization(store, plan(), () => current);
+    await applyRsHealMaterialization(store, input(), () => current);
     expect(seen.map(({ kind }) => kind)).toEqual([
       'replace-subject-predicates',
       'copy-subject-projection',
@@ -93,7 +118,7 @@ describe('RS-heal materialization executor', () => {
   it('performs no writes when stale before the first boundary', async () => {
     const structuredMutation = vi.fn(async () => undefined);
     const store = { structuredMutation } as unknown as TripleStore;
-    await applyRsHealMaterialization(store, plan(), () => false);
+    await applyRsHealMaterialization(store, input(), () => false);
     expect(structuredMutation).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Extract RS-heal capability proof, bounded chunk preflight, and reset/copy/metadata/stamp execution from the SWM host into one focused materialization owner.
- Keep candidate discovery, per-CG cursors, exact VM graph derivation, root-presence checks, materialization locking, and logging in `healStrandedScopedKCs`.
- Accept RS-heal domain inputs at the module boundary and privately construct the structured mutations, so storage mechanics no longer leak into host orchestration.
- Share one background scheduler/tracing option factory across RS-heal discovery and materialization while preserving every source label, currentness check, and caller AbortSignal.

## Related

- Fixes #2191
- Part of #2052
- Stacked on #2196 / fixes #2190
- Builds on #2194, #2187, and #2185
- Execution plan: `agent-docs/plans/2026-08-09-system-record-followup-refactors.md`

## Diagrams

### RS-heal materialization ownership

Before:

```mermaid
sequenceDiagram
    participant H as SWM host
    participant M as Materializer
    participant S as Structured store
    H->>H: Build reset, copy, metadata, and stamp mutations
    H->>M: Pass storage mutation plan
    M->>S: Execute plan with private option policy
```

After:

```mermaid
sequenceDiagram
    participant H as SWM host
    participant M as Materializer
    participant S as Structured store
    H->>M: Pass graphs, UAL, roots, version, predicates
    M->>M: Build and preflight private mutation plan
    M->>S: Reset marker using shared RS-heal options
    loop each bounded data chunk while current
        M->>S: Copy exact subject projection
    end
    M->>S: Copy metadata while current
    M->>S: Stamp completion while current
```

## Files changed

| File | What |
|------|------|
| `packages/agent/src/rs-heal-materialization.ts` | Own the domain input, private mutation construction, capability proof, preflight, and fail-closed executor. |
| `packages/agent/src/rs-heal-store-options.ts` | Define one RS-heal scheduler and tracing option policy. |
| `packages/agent/src/dkg-agent-swm-host.ts` | Retain discovery/orchestration and delegate domain inputs instead of storage mutations. |
| `packages/agent/test/rs-heal-materialization.test.ts` | Pin generated mutations, exact order/options (including signal identity), and stale boundaries. |

## Test plan

- [x] Run dependency-aware Agent build, including type and package-root checks.
- [x] Run `rs-heal-materialization.test.ts` (4/4).
- [x] Run decorated RS-heal suite (16/16).
- [x] Run companion RS-heal suite (15/15).
- [x] Run HTTP RS-heal suite (3/3).
- [x] Confirm stale after the first data copy performs no metadata copy or completion stamp.
- [x] Confirm stale before the first boundary performs zero writes.
- [x] Confirm exact source labels, background priority, AbortSignal propagation, generated mutations, and reset/data/metadata/stamp order.
- [x] Run `git diff --check`; restore generated EVM deployment output before commit.