### PR TITLE
refactor(core): centralize System Record object identity

### DIFF
--- a/packages/core/src/system-record-cache-accounting-v1-internal.ts
+++ b/packages/core/src/system-record-cache-accounting-v1-internal.ts
@@ -224,6 +224,21 @@ interface CacheAccountingTotalsV1 {
   readonly activationBundleBytes: number;
 }
 
+interface CacheAccountingReferenceContributionV1 {
+  readonly entries: readonly Readonly<{
+    reference: SystemRecordCacheReferenceV1;
+    facts: SystemRecordCacheReferenceFactsV1;
+  }>[];
+  readonly referencedBytes: number;
+}
+
+interface CacheAccountingRowContributionV1 {
+  readonly closure: CacheAccountingReferenceContributionV1;
+  readonly sidecar?: CacheAccountingReferenceContributionV1;
+  readonly metadataBytes: number;
+  readonly sidecarMetadataBytes: number;
+}
+
 function normalizeCachePreflightInputV1(
   input: SystemRecordCachePreflightInputV1,
 ): NormalizedCachePreflightInputV1 {
@@ -278,9 +293,8 @@ function createCacheAccountingAccumulatorV1(): CacheAccountingAccumulatorV1 {
 }
 
 function collectCacheAccountingRowV1(
-  accumulator: CacheAccountingAccumulatorV1,
   row: SystemRecordCacheRowAccountingV1,
-): void {
+): CacheAccountingRowContributionV1 {
   const hasSidecar = hasOwnDataProperty(row, 'sidecar');
   const hasSidecarMetadata = hasOwnDataProperty(row, 'sidecarMetadata');
   const exactRow = snapshotExactDataRecord(
@@ -317,39 +331,13 @@ function collectCacheAccountingRowV1(
   const rowSidecarMetadataBytes = hasSidecarMetadata
     ? requireCacheMetadataBytes(exactRow.sidecarMetadata, 'cache row sidecar metadata')
     : 0;
-  const rowClosureBytes = accountCacheReferencesV1(
-    accumulator,
-    closure,
-    'closure',
-    accumulator.closurePhysical,
-  );
-  if (rowClosureBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
+  const closureContribution = collectCacheReferenceContributionV1(closure, 'closure');
+  if (closureContribution.referencedBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
     fail('system-record-closure', 'row closure exceeds its byte bound');
   }
-  accumulator.closureReferences += closure.length;
-  accumulator.closureReferencedBytes += rowClosureBytes;
-  if (
-    !Number.isSafeInteger(accumulator.closureReferences) ||
-    !Number.isSafeInteger(accumulator.closureReferencedBytes)
-  ) {
-    fail('system-record-closure', 'aggregate closure accounting overflow');
-  }
-  for (const reference of closure) {
-    if (reference.objectKind === 'profile-bundle') {
-      accumulator.bundlePhysical.set(
-        reference.cacheDigest,
-        requireCacheReferenceFacts(reference, 'closure'),
-      );
-    }
-  }
+  let sidecarContribution: CacheAccountingReferenceContributionV1 | undefined;
   if (sidecar !== undefined) {
-    accumulator.sidecars += 1;
-    const rowSidecarBytes = accountCacheReferencesV1(
-      accumulator,
-      sidecar,
-      'sidecar',
-      accumulator.sidecarPhysical,
-    );
+    sidecarContribution = collectCacheReferenceContributionV1(sidecar, 'sidecar');
     if (
       sidecar.filter((reference) => reference.objectKind === 'conflict-evidence').length !== 1 ||
       sidecar.some(
@@ -365,33 +353,28 @@ function collectCacheAccountingRowV1(
         'row sidecar must contain one evidence object and only signed controls',
       );
     }
-    if (rowSidecarBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
+    if (sidecarContribution.referencedBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
       fail('system-record-closure', 'row sidecar exceeds its byte bound');
     }
-    accumulator.sidecarReferences += sidecar.length;
-    accumulator.sidecarReferencedBytes += rowSidecarBytes;
-    if (
-      !Number.isSafeInteger(accumulator.sidecarReferences) ||
-      !Number.isSafeInteger(accumulator.sidecarReferencedBytes)
-    ) {
-      fail('system-record-closure', 'aggregate sidecar accounting overflow');
-    }
   }
-  accumulator.metadataBytes += rowMetadataBytes + rowSidecarMetadataBytes;
-  accumulator.sidecarMetadataBytes += rowSidecarMetadataBytes;
-  if (!Number.isSafeInteger(accumulator.metadataBytes)) {
-    fail('system-record-closure', 'cache metadata accounting overflow');
-  }
+  return Object.freeze({
+    closure: closureContribution,
+    ...(sidecarContribution === undefined ? {} : { sidecar: sidecarContribution }),
+    metadataBytes: rowMetadataBytes,
+    sidecarMetadataBytes: rowSidecarMetadataBytes,
+  });
 }
 
-function accountCacheReferencesV1(
-  accumulator: CacheAccountingAccumulatorV1,
+function collectCacheReferenceContributionV1(
   references: readonly SystemRecordCacheReferenceV1[],
   label: string,
-  category?: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
-): number {
+): CacheAccountingReferenceContributionV1 {
   let total = 0;
   const logical = new Set<string>();
+  const entries: Array<Readonly<{
+    reference: SystemRecordCacheReferenceV1;
+    facts: SystemRecordCacheReferenceFactsV1;
+  }>> = [];
   for (const reference of references) {
     const facts = requireCacheReferenceFacts(reference, label);
     digest(reference.digest, `${label} digest`);
@@ -401,14 +384,69 @@ function accountCacheReferencesV1(
       fail('system-record-closure', `${label} contains a duplicate semantic reference`);
     }
     logical.add(logicalKey);
-    accountCachePhysicalReferenceV1(accumulator, reference, facts);
-    category?.set(reference.cacheDigest, facts);
+    entries.push(Object.freeze({ reference, facts }));
     total += facts.byteLength;
     if (!Number.isSafeInteger(total)) {
       fail('system-record-closure', `${label} byte accounting overflow`);
     }
   }
-  return total;
+  return Object.freeze({ entries: Object.freeze(entries), referencedBytes: total });
+}
+
+function mergeCacheAccountingRowV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  contribution: CacheAccountingRowContributionV1,
+): void {
+  mergeCacheReferenceContributionV1(
+    accumulator,
+    contribution.closure,
+    accumulator.closurePhysical,
+  );
+  for (const { reference, facts } of contribution.closure.entries) {
+    if (reference.objectKind === 'profile-bundle') {
+      accumulator.bundlePhysical.set(reference.cacheDigest, facts);
+    }
+  }
+  accumulator.closureReferences += contribution.closure.entries.length;
+  accumulator.closureReferencedBytes += contribution.closure.referencedBytes;
+  if (contribution.sidecar !== undefined) {
+    mergeCacheReferenceContributionV1(
+      accumulator,
+      contribution.sidecar,
+      accumulator.sidecarPhysical,
+    );
+    accumulator.sidecars += 1;
+    accumulator.sidecarReferences += contribution.sidecar.entries.length;
+    accumulator.sidecarReferencedBytes += contribution.sidecar.referencedBytes;
+  }
+  accumulator.metadataBytes += contribution.metadataBytes + contribution.sidecarMetadataBytes;
+  accumulator.sidecarMetadataBytes += contribution.sidecarMetadataBytes;
+  if (
+    !Number.isSafeInteger(accumulator.closureReferences) ||
+    !Number.isSafeInteger(accumulator.closureReferencedBytes)
+  ) {
+    fail('system-record-closure', 'aggregate closure accounting overflow');
+  }
+  if (
+    !Number.isSafeInteger(accumulator.sidecarReferences) ||
+    !Number.isSafeInteger(accumulator.sidecarReferencedBytes)
+  ) {
+    fail('system-record-closure', 'aggregate sidecar accounting overflow');
+  }
+  if (!Number.isSafeInteger(accumulator.metadataBytes)) {
+    fail('system-record-closure', 'cache metadata accounting overflow');
+  }
+}
+
+function mergeCacheReferenceContributionV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  contribution: CacheAccountingReferenceContributionV1,
+  category?: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
+): void {
+  for (const { reference, facts } of contribution.entries) {
+    accountCachePhysicalReferenceV1(accumulator, reference, facts);
+    category?.set(reference.cacheDigest, facts);
+  }
 }
 
 function accountCachePhysicalReferenceV1(
@@ -527,13 +565,12 @@ export function preflightSystemRecordCacheAccountingV1(
   const normalized = normalizeCachePreflightInputV1(input);
   const accumulator = createCacheAccountingAccumulatorV1();
   for (const row of normalized.rows) {
-    collectCacheAccountingRowV1(accumulator, row);
+    mergeCacheAccountingRowV1(accumulator, collectCacheAccountingRowV1(row));
     assertIncrementalCacheAccountingBoundsV1(accumulator);
   }
-  accountCacheReferencesV1(
+  mergeCacheReferenceContributionV1(
     accumulator,
-    normalized.inventoryLeaves,
-    'activation inventory',
+    collectCacheReferenceContributionV1(normalized.inventoryLeaves, 'activation inventory'),
   );
   if (
     normalized.inventoryLeaves.some((reference) => reference.objectKind !== 'inventory-leaf')

--- a/packages/core/src/system-record-cache-accounting-v1-internal.ts
+++ b/packages/core/src/system-record-cache-accounting-v1-internal.ts
@@ -224,21 +224,6 @@ interface CacheAccountingTotalsV1 {
   readonly activationBundleBytes: number;
 }
 
-interface CacheAccountingReferenceContributionV1 {
-  readonly entries: readonly Readonly<{
-    reference: SystemRecordCacheReferenceV1;
-    facts: SystemRecordCacheReferenceFactsV1;
-  }>[];
-  readonly referencedBytes: number;
-}
-
-interface CacheAccountingRowContributionV1 {
-  readonly closure: CacheAccountingReferenceContributionV1;
-  readonly sidecar?: CacheAccountingReferenceContributionV1;
-  readonly metadataBytes: number;
-  readonly sidecarMetadataBytes: number;
-}
-
 function normalizeCachePreflightInputV1(
   input: SystemRecordCachePreflightInputV1,
 ): NormalizedCachePreflightInputV1 {
@@ -292,9 +277,10 @@ function createCacheAccountingAccumulatorV1(): CacheAccountingAccumulatorV1 {
   };
 }
 
-function collectCacheAccountingRowV1(
+function accountCacheAccountingRowV1(
+  accumulator: CacheAccountingAccumulatorV1,
   row: SystemRecordCacheRowAccountingV1,
-): CacheAccountingRowContributionV1 {
+): void {
   const hasSidecar = hasOwnDataProperty(row, 'sidecar');
   const hasSidecarMetadata = hasOwnDataProperty(row, 'sidecarMetadata');
   const exactRow = snapshotExactDataRecord(
@@ -331,13 +317,17 @@ function collectCacheAccountingRowV1(
   const rowSidecarMetadataBytes = hasSidecarMetadata
     ? requireCacheMetadataBytes(exactRow.sidecarMetadata, 'cache row sidecar metadata')
     : 0;
-  const closureContribution = collectCacheReferenceContributionV1(closure, 'closure');
-  if (closureContribution.referencedBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
+  const closureReferencedBytes = accountCacheReferenceSetV1(
+    accumulator,
+    closure,
+    'closure',
+    accumulator.closurePhysical,
+    true,
+  );
+  if (closureReferencedBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
     fail('system-record-closure', 'row closure exceeds its byte bound');
   }
-  let sidecarContribution: CacheAccountingReferenceContributionV1 | undefined;
   if (sidecar !== undefined) {
-    sidecarContribution = collectCacheReferenceContributionV1(sidecar, 'sidecar');
     if (
       sidecar.filter((reference) => reference.objectKind === 'conflict-evidence').length !== 1 ||
       sidecar.some(
@@ -353,74 +343,23 @@ function collectCacheAccountingRowV1(
         'row sidecar must contain one evidence object and only signed controls',
       );
     }
-    if (sidecarContribution.referencedBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
-      fail('system-record-closure', 'row sidecar exceeds its byte bound');
-    }
-  }
-  return Object.freeze({
-    closure: closureContribution,
-    ...(sidecarContribution === undefined ? {} : { sidecar: sidecarContribution }),
-    metadataBytes: rowMetadataBytes,
-    sidecarMetadataBytes: rowSidecarMetadataBytes,
-  });
-}
-
-function collectCacheReferenceContributionV1(
-  references: readonly SystemRecordCacheReferenceV1[],
-  label: string,
-): CacheAccountingReferenceContributionV1 {
-  let total = 0;
-  const logical = new Set<string>();
-  const entries: Array<Readonly<{
-    reference: SystemRecordCacheReferenceV1;
-    facts: SystemRecordCacheReferenceFactsV1;
-  }>> = [];
-  for (const reference of references) {
-    const facts = requireCacheReferenceFacts(reference, label);
-    digest(reference.digest, `${label} digest`);
-    digest(reference.cacheDigest, `${label} cache digest`);
-    const logicalKey = `${reference.objectKind}:${reference.digest}`;
-    if (logical.has(logicalKey)) {
-      fail('system-record-closure', `${label} contains a duplicate semantic reference`);
-    }
-    logical.add(logicalKey);
-    entries.push(Object.freeze({ reference, facts }));
-    total += facts.byteLength;
-    if (!Number.isSafeInteger(total)) {
-      fail('system-record-closure', `${label} byte accounting overflow`);
-    }
-  }
-  return Object.freeze({ entries: Object.freeze(entries), referencedBytes: total });
-}
-
-function mergeCacheAccountingRowV1(
-  accumulator: CacheAccountingAccumulatorV1,
-  contribution: CacheAccountingRowContributionV1,
-): void {
-  mergeCacheReferenceContributionV1(
-    accumulator,
-    contribution.closure,
-    accumulator.closurePhysical,
-  );
-  for (const { reference, facts } of contribution.closure.entries) {
-    if (reference.objectKind === 'profile-bundle') {
-      accumulator.bundlePhysical.set(reference.cacheDigest, facts);
-    }
-  }
-  accumulator.closureReferences += contribution.closure.entries.length;
-  accumulator.closureReferencedBytes += contribution.closure.referencedBytes;
-  if (contribution.sidecar !== undefined) {
-    mergeCacheReferenceContributionV1(
+    const sidecarReferencedBytes = accountCacheReferenceSetV1(
       accumulator,
-      contribution.sidecar,
+      sidecar,
+      'sidecar',
       accumulator.sidecarPhysical,
     );
+    if (sidecarReferencedBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
+      fail('system-record-closure', 'row sidecar exceeds its byte bound');
+    }
     accumulator.sidecars += 1;
-    accumulator.sidecarReferences += contribution.sidecar.entries.length;
-    accumulator.sidecarReferencedBytes += contribution.sidecar.referencedBytes;
+    accumulator.sidecarReferences += sidecar.length;
+    accumulator.sidecarReferencedBytes += sidecarReferencedBytes;
   }
-  accumulator.metadataBytes += contribution.metadataBytes + contribution.sidecarMetadataBytes;
-  accumulator.sidecarMetadataBytes += contribution.sidecarMetadataBytes;
+  accumulator.closureReferences += closure.length;
+  accumulator.closureReferencedBytes += closureReferencedBytes;
+  accumulator.metadataBytes += rowMetadataBytes + rowSidecarMetadataBytes;
+  accumulator.sidecarMetadataBytes += rowSidecarMetadataBytes;
   if (
     !Number.isSafeInteger(accumulator.closureReferences) ||
     !Number.isSafeInteger(accumulator.closureReferencedBytes)
@@ -438,15 +377,35 @@ function mergeCacheAccountingRowV1(
   }
 }
 
-function mergeCacheReferenceContributionV1(
+function accountCacheReferenceSetV1(
   accumulator: CacheAccountingAccumulatorV1,
-  contribution: CacheAccountingReferenceContributionV1,
+  references: readonly SystemRecordCacheReferenceV1[],
+  label: string,
   category?: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
-): void {
-  for (const { reference, facts } of contribution.entries) {
+  trackBundles = false,
+): number {
+  let referencedBytes = 0;
+  const logical = new Set<string>();
+  for (const reference of references) {
+    const facts = requireCacheReferenceFacts(reference, label);
+    digest(reference.digest, `${label} digest`);
+    digest(reference.cacheDigest, `${label} cache digest`);
+    const logicalKey = `${reference.objectKind}:${reference.digest}`;
+    if (logical.has(logicalKey)) {
+      fail('system-record-closure', `${label} contains a duplicate semantic reference`);
+    }
+    logical.add(logicalKey);
     accountCachePhysicalReferenceV1(accumulator, reference, facts);
     category?.set(reference.cacheDigest, facts);
+    if (trackBundles && reference.objectKind === 'profile-bundle') {
+      accumulator.bundlePhysical.set(reference.cacheDigest, facts);
+    }
+    referencedBytes += facts.byteLength;
+    if (!Number.isSafeInteger(referencedBytes)) {
+      fail('system-record-closure', `${label} byte accounting overflow`);
+    }
   }
+  return referencedBytes;
 }
 
 function accountCachePhysicalReferenceV1(
@@ -565,12 +524,13 @@ export function preflightSystemRecordCacheAccountingV1(
   const normalized = normalizeCachePreflightInputV1(input);
   const accumulator = createCacheAccountingAccumulatorV1();
   for (const row of normalized.rows) {
-    mergeCacheAccountingRowV1(accumulator, collectCacheAccountingRowV1(row));
+    accountCacheAccountingRowV1(accumulator, row);
     assertIncrementalCacheAccountingBoundsV1(accumulator);
   }
-  mergeCacheReferenceContributionV1(
+  accountCacheReferenceSetV1(
     accumulator,
-    collectCacheReferenceContributionV1(normalized.inventoryLeaves, 'activation inventory'),
+    normalized.inventoryLeaves,
+    'activation inventory',
   );
   if (
     normalized.inventoryLeaves.some((reference) => reference.objectKind !== 'inventory-leaf')

--- a/packages/core/src/system-record-cache-accounting-v1-internal.ts
+++ b/packages/core/src/system-record-cache-accounting-v1-internal.ts
@@ -190,10 +190,43 @@ export interface SystemRecordCachePreflightInputV1 {
   readonly inventoryLeaves?: readonly SystemRecordCacheReferenceV1[];
 }
 
-/** Pure all-or-nothing aggregate preflight; shared physical digests are charged once. */
-export function preflightSystemRecordCacheAccountingV1(
+interface NormalizedCachePreflightInputV1 {
+  readonly mode: SystemRecordCachePreflightInputV1['mode'];
+  readonly rows: readonly SystemRecordCacheRowAccountingV1[];
+  readonly inventoryLeaves: readonly SystemRecordCacheReferenceV1[];
+}
+
+interface CacheAccountingAccumulatorV1 {
+  readonly physical: Map<
+    Digest32V1,
+    {
+      reference: SystemRecordCacheReferenceV1;
+      facts: SystemRecordCacheReferenceFactsV1;
+    }
+  >;
+  readonly closurePhysical: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>;
+  readonly sidecarPhysical: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>;
+  readonly bundlePhysical: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>;
+  closureReferences: number;
+  closureReferencedBytes: number;
+  sidecarReferences: number;
+  sidecars: number;
+  sidecarReferencedBytes: number;
+  metadataBytes: number;
+  sidecarMetadataBytes: number;
+}
+
+interface CacheAccountingTotalsV1 {
+  readonly physicalBytes: number;
+  readonly closurePhysicalBytes: number;
+  readonly sidecarPhysicalBytes: number;
+  readonly closureSidecarPhysicalBytes: number;
+  readonly activationBundleBytes: number;
+}
+
+function normalizeCachePreflightInputV1(
   input: SystemRecordCachePreflightInputV1,
-): SystemRecordCachePreflightResultV1 {
+): NormalizedCachePreflightInputV1 {
   const hasInventoryLeaves = hasOwnDataProperty(input, 'inventoryLeaves');
   const exact = snapshotExactDataRecord(
     input,
@@ -207,10 +240,9 @@ export function preflightSystemRecordCacheAccountingV1(
   let inventoryLeaves: readonly SystemRecordCacheReferenceV1[];
   try {
     rows = snapshotDataArray(exact.rows, 'cache rows', {
-      maxLength:
-        exact.mode === 'activation'
-          ? SYSTEM_RECORD_MAX_ACTIVATION_RECORDS
-          : SYSTEM_RECORD_MAX_INVENTORY_RECORDS,
+      maxLength: exact.mode === 'activation'
+        ? SYSTEM_RECORD_MAX_ACTIVATION_RECORDS
+        : SYSTEM_RECORD_MAX_INVENTORY_RECORDS,
     }) as readonly SystemRecordCacheRowAccountingV1[];
     inventoryLeaves = snapshotDataArray(
       hasInventoryLeaves ? exact.inventoryLeaves : [],
@@ -226,213 +258,292 @@ export function preflightSystemRecordCacheAccountingV1(
   if (inventoryLeaves.length > SYSTEM_RECORD_MAX_ACTIVATION_INVENTORY_LEAVES) {
     fail('system-record-closure', 'activation inventory exceeds its leaf bound');
   }
-  const physical = new Map<
-    Digest32V1,
-    {
-      reference: SystemRecordCacheReferenceV1;
-      facts: SystemRecordCacheReferenceFactsV1;
-    }
-  >();
-  const closurePhysical = new Map<Digest32V1, SystemRecordCacheReferenceFactsV1>();
-  const sidecarPhysical = new Map<Digest32V1, SystemRecordCacheReferenceFactsV1>();
-  const bundlePhysical = new Map<Digest32V1, SystemRecordCacheReferenceFactsV1>();
-  let closureReferences = 0;
-  let closureReferencedBytes = 0;
-  let sidecarReferences = 0;
-  let sidecars = 0;
-  let sidecarReferencedBytes = 0;
-  let metadataBytes = 0;
-  let sidecarMetadataBytes = 0;
-  for (const row of rows) {
-    const hasSidecar = hasOwnDataProperty(row, 'sidecar');
-    const hasSidecarMetadata = hasOwnDataProperty(row, 'sidecarMetadata');
-    const exactRow = snapshotExactDataRecord(
-      row,
-      [
-        'closure',
-        'metadata',
-        ...(hasSidecar ? ['sidecar'] : []),
-        ...(hasSidecarMetadata ? ['sidecarMetadata'] : []),
-      ],
-      'cache accounting row',
+  return Object.freeze({ mode: exact.mode, rows, inventoryLeaves });
+}
+
+function createCacheAccountingAccumulatorV1(): CacheAccountingAccumulatorV1 {
+  return {
+    physical: new Map(),
+    closurePhysical: new Map(),
+    sidecarPhysical: new Map(),
+    bundlePhysical: new Map(),
+    closureReferences: 0,
+    closureReferencedBytes: 0,
+    sidecarReferences: 0,
+    sidecars: 0,
+    sidecarReferencedBytes: 0,
+    metadataBytes: 0,
+    sidecarMetadataBytes: 0,
+  };
+}
+
+function collectCacheAccountingRowV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  row: SystemRecordCacheRowAccountingV1,
+): void {
+  const hasSidecar = hasOwnDataProperty(row, 'sidecar');
+  const hasSidecarMetadata = hasOwnDataProperty(row, 'sidecarMetadata');
+  const exactRow = snapshotExactDataRecord(
+    row,
+    [
+      'closure',
+      'metadata',
+      ...(hasSidecar ? ['sidecar'] : []),
+      ...(hasSidecarMetadata ? ['sidecarMetadata'] : []),
+    ],
+    'cache accounting row',
+  );
+  let closure: readonly SystemRecordCacheReferenceV1[];
+  let sidecar: readonly SystemRecordCacheReferenceV1[] | undefined;
+  try {
+    closure = snapshotDataArray(exactRow.closure, 'cache row closure', {
+      maxLength: SYSTEM_RECORD_MAX_CLOSURE_OBJECTS,
+    }) as readonly SystemRecordCacheReferenceV1[];
+    sidecar = hasSidecar
+      ? (snapshotDataArray(exactRow.sidecar, 'cache row sidecar', {
+          maxLength: SYSTEM_RECORD_MAX_SIDECAR_OBJECTS,
+        }) as readonly SystemRecordCacheReferenceV1[])
+      : undefined;
+  } catch (cause) {
+    fail('system-record-closure', 'cache row arrays exceed their closed bounds', cause);
+  }
+  const rowMetadataBytes = requireCacheMetadataBytes(exactRow.metadata, 'cache row metadata');
+  if (hasSidecar !== hasSidecarMetadata) {
+    fail(
+      'system-record-closure',
+      'cache row sidecar and sidecar metadata must be present together',
     );
-    let closure: readonly SystemRecordCacheReferenceV1[];
-    let sidecar: readonly SystemRecordCacheReferenceV1[] | undefined;
-    try {
-      closure = snapshotDataArray(exactRow.closure, 'cache row closure', {
-        maxLength: SYSTEM_RECORD_MAX_CLOSURE_OBJECTS,
-      }) as readonly SystemRecordCacheReferenceV1[];
-      sidecar = hasSidecar
-        ? (snapshotDataArray(exactRow.sidecar, 'cache row sidecar', {
-            maxLength: SYSTEM_RECORD_MAX_SIDECAR_OBJECTS,
-          }) as readonly SystemRecordCacheReferenceV1[])
-        : undefined;
-    } catch (cause) {
-      fail('system-record-closure', 'cache row arrays exceed their closed bounds', cause);
-    }
-    const rowMetadataBytes = requireCacheMetadataBytes(exactRow.metadata, 'cache row metadata');
-    if (hasSidecar !== hasSidecarMetadata) {
-      fail(
-        'system-record-closure',
-        'cache row sidecar and sidecar metadata must be present together',
+  }
+  const rowSidecarMetadataBytes = hasSidecarMetadata
+    ? requireCacheMetadataBytes(exactRow.sidecarMetadata, 'cache row sidecar metadata')
+    : 0;
+  const rowClosureBytes = accountCacheReferencesV1(
+    accumulator,
+    closure,
+    'closure',
+    accumulator.closurePhysical,
+  );
+  if (rowClosureBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
+    fail('system-record-closure', 'row closure exceeds its byte bound');
+  }
+  accumulator.closureReferences += closure.length;
+  accumulator.closureReferencedBytes += rowClosureBytes;
+  if (
+    !Number.isSafeInteger(accumulator.closureReferences) ||
+    !Number.isSafeInteger(accumulator.closureReferencedBytes)
+  ) {
+    fail('system-record-closure', 'aggregate closure accounting overflow');
+  }
+  for (const reference of closure) {
+    if (reference.objectKind === 'profile-bundle') {
+      accumulator.bundlePhysical.set(
+        reference.cacheDigest,
+        requireCacheReferenceFacts(reference, 'closure'),
       );
     }
-    const rowSidecarMetadataBytes = hasSidecarMetadata
-      ? requireCacheMetadataBytes(exactRow.sidecarMetadata, 'cache row sidecar metadata')
-      : 0;
-    const rowClosureBytes = accountReferences(closure, closurePhysical, 'closure');
-    if (rowClosureBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
-      fail('system-record-closure', 'row closure exceeds its byte bound');
-    }
-    closureReferences += closure.length;
-    closureReferencedBytes += rowClosureBytes;
-    if (!Number.isSafeInteger(closureReferences) || !Number.isSafeInteger(closureReferencedBytes)) {
-      fail('system-record-closure', 'aggregate closure accounting overflow');
-    }
-    for (const reference of closure) {
-      if (reference.objectKind === 'profile-bundle') {
-        bundlePhysical.set(reference.cacheDigest, requireCacheReferenceFacts(reference, 'closure'));
-      }
-    }
-    if (sidecar !== undefined) {
-      sidecars += 1;
-      const rowSidecarBytes = accountReferences(sidecar, sidecarPhysical, 'sidecar');
-      if (
-        sidecar.filter((reference) => reference.objectKind === 'conflict-evidence').length !== 1 ||
-        sidecar.some(
-          (reference) =>
-            reference.objectKind !== 'conflict-evidence' &&
-            reference.objectKind !== 'agent-profile-head' &&
-            reference.objectKind !== 'authority-transition' &&
-            reference.objectKind !== 'fork-resolution',
-        )
-      ) {
-        fail(
-          'system-record-closure',
-          'row sidecar must contain one evidence object and only signed controls',
-        );
-      }
-      if (rowSidecarBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
-        fail('system-record-closure', 'row sidecar exceeds its byte bound');
-      }
-      sidecarReferences += sidecar.length;
-      sidecarReferencedBytes += rowSidecarBytes;
-      if (
-        !Number.isSafeInteger(sidecarReferences) ||
-        !Number.isSafeInteger(sidecarReferencedBytes)
-      ) {
-        fail('system-record-closure', 'aggregate sidecar accounting overflow');
-      }
-    }
-    metadataBytes += rowMetadataBytes + rowSidecarMetadataBytes;
-    sidecarMetadataBytes += rowSidecarMetadataBytes;
-    if (!Number.isSafeInteger(metadataBytes))
-      fail('system-record-closure', 'cache metadata accounting overflow');
+  }
+  if (sidecar !== undefined) {
+    accumulator.sidecars += 1;
+    const rowSidecarBytes = accountCacheReferencesV1(
+      accumulator,
+      sidecar,
+      'sidecar',
+      accumulator.sidecarPhysical,
+    );
     if (
-      closurePhysical.size > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_OBJECTS ||
-      closureReferences > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_REFERENCES ||
-      metadataBytes > SYSTEM_RECORD_MAX_CLOSURE_SIDECAR_LIVE_METADATA_BYTES ||
-      sidecars > SYSTEM_RECORD_MAX_CONFLICT_SIDECARS ||
-      sidecarReferences > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_REFERENCES ||
-      sidecarMetadataBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_METADATA_BYTES
+      sidecar.filter((reference) => reference.objectKind === 'conflict-evidence').length !== 1 ||
+      sidecar.some(
+        (reference) =>
+          reference.objectKind !== 'conflict-evidence' &&
+          reference.objectKind !== 'agent-profile-head' &&
+          reference.objectKind !== 'authority-transition' &&
+          reference.objectKind !== 'fork-resolution',
+      )
     ) {
-      fail('system-record-closure', 'aggregate cache accounting exceeds a live V1 bound');
+      fail(
+        'system-record-closure',
+        'row sidecar must contain one evidence object and only signed controls',
+      );
+    }
+    if (rowSidecarBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
+      fail('system-record-closure', 'row sidecar exceeds its byte bound');
+    }
+    accumulator.sidecarReferences += sidecar.length;
+    accumulator.sidecarReferencedBytes += rowSidecarBytes;
+    if (
+      !Number.isSafeInteger(accumulator.sidecarReferences) ||
+      !Number.isSafeInteger(accumulator.sidecarReferencedBytes)
+    ) {
+      fail('system-record-closure', 'aggregate sidecar accounting overflow');
     }
   }
-  accountReferences(inventoryLeaves, new Map(), 'activation inventory');
-  if (inventoryLeaves.some((reference) => reference.objectKind !== 'inventory-leaf')) {
-    fail('system-record-closure', 'activation inventory may contain only leaf objects');
+  accumulator.metadataBytes += rowMetadataBytes + rowSidecarMetadataBytes;
+  accumulator.sidecarMetadataBytes += rowSidecarMetadataBytes;
+  if (!Number.isSafeInteger(accumulator.metadataBytes)) {
+    fail('system-record-closure', 'cache metadata accounting overflow');
   }
-  const physicalBytes = [...physical.values()].reduce(
-    (sum, entry) => sum + entry.facts.byteLength,
-    0,
-  );
-  const closurePhysicalBytes = sumPhysicalBytes(closurePhysical);
-  const sidecarPhysicalBytes = sumPhysicalBytes(sidecarPhysical);
-  const closureSidecarPhysicalBytes = sumPhysicalBytes(
-    new Map([...closurePhysical, ...sidecarPhysical]),
-  );
-  const activationBundleBytes = sumPhysicalBytes(bundlePhysical);
+}
+
+function accountCacheReferencesV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  references: readonly SystemRecordCacheReferenceV1[],
+  label: string,
+  category?: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
+): number {
+  let total = 0;
+  const logical = new Set<string>();
+  for (const reference of references) {
+    const facts = requireCacheReferenceFacts(reference, label);
+    digest(reference.digest, `${label} digest`);
+    digest(reference.cacheDigest, `${label} cache digest`);
+    const logicalKey = `${reference.objectKind}:${reference.digest}`;
+    if (logical.has(logicalKey)) {
+      fail('system-record-closure', `${label} contains a duplicate semantic reference`);
+    }
+    logical.add(logicalKey);
+    accountCachePhysicalReferenceV1(accumulator, reference, facts);
+    category?.set(reference.cacheDigest, facts);
+    total += facts.byteLength;
+    if (!Number.isSafeInteger(total)) {
+      fail('system-record-closure', `${label} byte accounting overflow`);
+    }
+  }
+  return total;
+}
+
+function accountCachePhysicalReferenceV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  reference: SystemRecordCacheReferenceV1,
+  facts: SystemRecordCacheReferenceFactsV1,
+): void {
+  const prior = accumulator.physical.get(reference.cacheDigest);
   if (
-    closurePhysical.size > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_OBJECTS ||
-    closurePhysicalBytes > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_BYTES ||
-    closureReferences > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_REFERENCES ||
-    metadataBytes > SYSTEM_RECORD_MAX_CLOSURE_SIDECAR_LIVE_METADATA_BYTES ||
-    sidecars > SYSTEM_RECORD_MAX_CONFLICT_SIDECARS ||
-    sidecarReferences > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_REFERENCES ||
-    sidecarPhysicalBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_AGGREGATE_BYTES ||
-    sidecarMetadataBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_METADATA_BYTES
+    prior !== undefined &&
+    (prior.reference.objectKind !== reference.objectKind ||
+      prior.reference.digest !== reference.digest ||
+      prior.facts.byteLength !== facts.byteLength ||
+      prior.facts.fingerprint !== facts.fingerprint)
+  ) {
+    fail('system-record-closure', 'one cache digest was reported with conflicting canonical bytes');
+  }
+  accumulator.physical.set(reference.cacheDigest, { reference, facts });
+}
+
+function assertIncrementalCacheAccountingBoundsV1(
+  accumulator: CacheAccountingAccumulatorV1,
+): void {
+  if (
+    accumulator.closurePhysical.size > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_OBJECTS ||
+    accumulator.closureReferences > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_REFERENCES ||
+    accumulator.metadataBytes > SYSTEM_RECORD_MAX_CLOSURE_SIDECAR_LIVE_METADATA_BYTES ||
+    accumulator.sidecars > SYSTEM_RECORD_MAX_CONFLICT_SIDECARS ||
+    accumulator.sidecarReferences > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_REFERENCES ||
+    accumulator.sidecarMetadataBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_METADATA_BYTES
   ) {
     fail('system-record-closure', 'aggregate cache accounting exceeds a live V1 bound');
   }
+}
+
+function assertFinalLiveCacheAccountingBoundsV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  totals: CacheAccountingTotalsV1,
+): void {
+  assertIncrementalCacheAccountingBoundsV1(accumulator);
   if (
-    exact.mode === 'activation' &&
-    (activationBundleBytes > SYSTEM_RECORD_MAX_ACTIVATION_BUNDLE_BYTES ||
-      closureSidecarPhysicalBytes > SYSTEM_RECORD_MAX_ACTIVATION_CLOSURE_BYTES ||
-      closureReferences + sidecarReferences + inventoryLeaves.length >
+    totals.closurePhysicalBytes > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_BYTES ||
+    totals.sidecarPhysicalBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_AGGREGATE_BYTES
+  ) {
+    fail('system-record-closure', 'aggregate cache accounting exceeds a live V1 bound');
+  }
+}
+
+function sumCachePhysicalBytesV1(
+  references: ReadonlyMap<Digest32V1, SystemRecordCacheReferenceFactsV1>,
+): number {
+  return [...references.values()].reduce((sum, facts) => sum + facts.byteLength, 0);
+}
+
+function computeCacheAccountingTotalsV1(
+  accumulator: CacheAccountingAccumulatorV1,
+): CacheAccountingTotalsV1 {
+  return Object.freeze({
+    physicalBytes: [...accumulator.physical.values()].reduce(
+      (sum, entry) => sum + entry.facts.byteLength,
+      0,
+    ),
+    closurePhysicalBytes: sumCachePhysicalBytesV1(accumulator.closurePhysical),
+    sidecarPhysicalBytes: sumCachePhysicalBytesV1(accumulator.sidecarPhysical),
+    closureSidecarPhysicalBytes: sumCachePhysicalBytesV1(
+      new Map([...accumulator.closurePhysical, ...accumulator.sidecarPhysical]),
+    ),
+    activationBundleBytes: sumCachePhysicalBytesV1(accumulator.bundlePhysical),
+  });
+}
+
+function assertActivationCacheAccountingBoundsV1(
+  normalized: NormalizedCachePreflightInputV1,
+  accumulator: CacheAccountingAccumulatorV1,
+  totals: CacheAccountingTotalsV1,
+): void {
+  if (
+    normalized.mode === 'activation' &&
+    (totals.activationBundleBytes > SYSTEM_RECORD_MAX_ACTIVATION_BUNDLE_BYTES ||
+      totals.closureSidecarPhysicalBytes > SYSTEM_RECORD_MAX_ACTIVATION_CLOSURE_BYTES ||
+      accumulator.closureReferences +
+          accumulator.sidecarReferences +
+          normalized.inventoryLeaves.length >
         SYSTEM_RECORD_MAX_ACTIVATION_REFERENCES ||
-      metadataBytes > SYSTEM_RECORD_MAX_ACTIVATION_METADATA_BYTES)
+      accumulator.metadataBytes > SYSTEM_RECORD_MAX_ACTIVATION_METADATA_BYTES)
   ) {
     fail('system-record-closure', 'activation cache accounting exceeds its cohort bound');
   }
+}
+
+function projectCacheAccountingResultV1(
+  normalized: NormalizedCachePreflightInputV1,
+  accumulator: CacheAccountingAccumulatorV1,
+  totals: CacheAccountingTotalsV1,
+): SystemRecordCachePreflightResultV1 {
   return Object.freeze({
-    cohortPhysicalObjects: physical.size,
-    cohortPhysicalBytes: physicalBytes,
-    closureReferences,
-    closurePhysicalBytes,
-    closureReferencedBytes,
-    sidecarReferences,
-    sidecars,
-    sidecarPhysicalBytes,
-    sidecarReferencedBytes,
-    activationBundleBytes,
-    activationInventoryLeaves: inventoryLeaves.length,
-    metadataBytes,
+    cohortPhysicalObjects: accumulator.physical.size,
+    cohortPhysicalBytes: totals.physicalBytes,
+    closureReferences: accumulator.closureReferences,
+    closurePhysicalBytes: totals.closurePhysicalBytes,
+    closureReferencedBytes: accumulator.closureReferencedBytes,
+    sidecarReferences: accumulator.sidecarReferences,
+    sidecars: accumulator.sidecars,
+    sidecarPhysicalBytes: totals.sidecarPhysicalBytes,
+    sidecarReferencedBytes: accumulator.sidecarReferencedBytes,
+    activationBundleBytes: totals.activationBundleBytes,
+    activationInventoryLeaves: normalized.inventoryLeaves.length,
+    metadataBytes: accumulator.metadataBytes,
   });
+}
 
-  function accountReferences(
-    references: readonly SystemRecordCacheReferenceV1[],
-    category: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
-    label: string,
-  ): number {
-    let total = 0;
-    const logical = new Set<string>();
-    for (const reference of references as readonly SystemRecordCacheReferenceV1[]) {
-      const facts = requireCacheReferenceFacts(reference, label);
-      digest(reference.digest, `${label} digest`);
-      digest(reference.cacheDigest, `${label} cache digest`);
-      const logicalKey = `${reference.objectKind}:${reference.digest}`;
-      if (logical.has(logicalKey)) {
-        fail('system-record-closure', `${label} contains a duplicate semantic reference`);
-      }
-      logical.add(logicalKey);
-      const prior = physical.get(reference.cacheDigest);
-      if (
-        prior !== undefined &&
-        (prior.reference.objectKind !== reference.objectKind ||
-          prior.reference.digest !== reference.digest ||
-          prior.facts.byteLength !== facts.byteLength ||
-          prior.facts.fingerprint !== facts.fingerprint)
-      ) {
-        fail(
-          'system-record-closure',
-          'one cache digest was reported with conflicting canonical bytes',
-        );
-      }
-      physical.set(reference.cacheDigest, { reference, facts });
-      category.set(reference.cacheDigest, facts);
-      total += facts.byteLength;
-      if (!Number.isSafeInteger(total))
-        fail('system-record-closure', `${label} byte accounting overflow`);
-    }
-    return total;
+/** Pure all-or-nothing aggregate preflight; shared physical digests are charged once. */
+export function preflightSystemRecordCacheAccountingV1(
+  input: SystemRecordCachePreflightInputV1,
+): SystemRecordCachePreflightResultV1 {
+  const normalized = normalizeCachePreflightInputV1(input);
+  const accumulator = createCacheAccountingAccumulatorV1();
+  for (const row of normalized.rows) {
+    collectCacheAccountingRowV1(accumulator, row);
+    assertIncrementalCacheAccountingBoundsV1(accumulator);
   }
-
-  function sumPhysicalBytes(
-    references: ReadonlyMap<Digest32V1, SystemRecordCacheReferenceFactsV1>,
-  ): number {
-    return [...references.values()].reduce((sum, facts) => sum + facts.byteLength, 0);
+  accountCacheReferencesV1(
+    accumulator,
+    normalized.inventoryLeaves,
+    'activation inventory',
+  );
+  if (
+    normalized.inventoryLeaves.some((reference) => reference.objectKind !== 'inventory-leaf')
+  ) {
+    fail('system-record-closure', 'activation inventory may contain only leaf objects');
   }
+  const totals = computeCacheAccountingTotalsV1(accumulator);
+  assertFinalLiveCacheAccountingBoundsV1(accumulator, totals);
+  assertActivationCacheAccountingBoundsV1(normalized, accumulator, totals);
+  return projectCacheAccountingResultV1(normalized, accumulator, totals);
 }
 
 function requireCacheMetadataBytes(value: unknown, label: string): number {

--- a/packages/core/src/system-record-cache-accounting-v1-internal.ts
+++ b/packages/core/src/system-record-cache-accounting-v1-internal.ts
@@ -8,12 +8,9 @@ import {
 import { type Digest32V1 } from './sync-wire-scalars.js';
 import {
   copyBoundedSystemRecordBytesV1,
-  digestSystemRecordBytesV1,
   failSystemRecordObjectV1 as fail,
 } from './system-record-codec-primitives-v1.js';
-import { parseCanonicalSignedSystemRecordRootDescriptorEnvelopeV1 } from './system-record-inventory-codecs-v1-internal.js';
 import {
-  SYSTEM_RECORD_DIGEST_DOMAINS_V1,
   SYSTEM_RECORD_MAX_ACTIVATION_BUNDLE_BYTES,
   SYSTEM_RECORD_MAX_ACTIVATION_CLOSURE_BYTES,
   SYSTEM_RECORD_MAX_ACTIVATION_INVENTORY_LEAVES,
@@ -38,12 +35,7 @@ import {
 } from './system-record-limits-v1.js';
 
 import { digest } from './system-record-agent-profile-primitives-v1-internal.js';
-import {
-  computeSignedSystemRecordEnvelopeDigestV1,
-  parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
-  parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
-  parseCanonicalSignedAgentProfileHeadEnvelopeV1,
-} from './system-record-signatures-v1-internal.js';
+import { deriveSystemRecordArtifactIdentitiesV1 } from './system-record-object-identity-descriptors-v1-internal.js';
 
 interface SystemRecordCacheReferenceFactsV1 {
   readonly byteLength: number;
@@ -104,7 +96,7 @@ export function createSystemRecordCacheReferenceV1(
   }
   if (ownedBytes.byteLength < 1)
     fail('system-record-closure', 'cache reference bytes must not be empty');
-  const identities = deriveCacheReferenceArtifactIdentitiesV1(
+  const identities = deriveSystemRecordArtifactIdentitiesV1(
     objectKind,
     ownedBytes,
     'cache reference',
@@ -474,53 +466,4 @@ function requireCacheReferenceFacts(
     fail('system-record-closure', `${label} object kind is invalid`);
   }
   return facts;
-}
-
-function deriveCacheReferenceArtifactIdentitiesV1(
-  objectKind: SystemRecordObjectKindV1,
-  canonicalBytes: Uint8Array,
-  label: string,
-): Readonly<{ semanticDigest: Digest32V1; cacheDigest: Digest32V1 }> {
-  let semanticDigest: Digest32V1;
-  let cacheDigest: Digest32V1;
-  if (objectKind === 'agent-profile-head') {
-    const envelope = parseCanonicalSignedAgentProfileHeadEnvelopeV1(canonicalBytes);
-    semanticDigest = envelope.objectDigest;
-    cacheDigest = computeSignedSystemRecordEnvelopeDigestV1(envelope);
-  } else if (objectKind === 'authority-transition') {
-    const envelope = parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(canonicalBytes);
-    semanticDigest = envelope.objectDigest;
-    cacheDigest = computeSignedSystemRecordEnvelopeDigestV1(envelope);
-  } else if (objectKind === 'fork-resolution') {
-    const envelope = parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(canonicalBytes);
-    semanticDigest = envelope.objectDigest;
-    cacheDigest = computeSignedSystemRecordEnvelopeDigestV1(envelope);
-  } else if (objectKind === 'root-descriptor') {
-    const envelope = parseCanonicalSignedSystemRecordRootDescriptorEnvelopeV1(canonicalBytes);
-    semanticDigest = envelope.objectDigest;
-    cacheDigest = digestSystemRecordBytesV1(
-      SYSTEM_RECORD_DIGEST_DOMAINS_V1.signedRootDescriptorEnvelope,
-      canonicalBytes,
-    );
-  } else {
-    const domains: Record<
-      Exclude<
-        SystemRecordObjectKindV1,
-        'agent-profile-head' | 'authority-transition' | 'fork-resolution' | 'root-descriptor'
-      >,
-      string
-    > = {
-      'inventory-internal': SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryInternal,
-      'inventory-leaf': SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryLeaf,
-      'conflict-evidence': SYSTEM_RECORD_DIGEST_DOMAINS_V1.conflictEvidence,
-      'owned-subject-table': SYSTEM_RECORD_DIGEST_DOMAINS_V1.ownedSubjectTable,
-      'profile-bundle': SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
-    };
-    semanticDigest = digestSystemRecordBytesV1(domains[objectKind], canonicalBytes);
-    cacheDigest = semanticDigest;
-  }
-  if (semanticDigest.length !== 66 || cacheDigest.length !== 66) {
-    fail('system-record-closure', `${label} artifact identity is invalid`);
-  }
-  return Object.freeze({ semanticDigest, cacheDigest });
 }

--- a/packages/core/src/system-record-cache-accounting-v1-internal.ts
+++ b/packages/core/src/system-record-cache-accounting-v1-internal.ts
@@ -317,13 +317,7 @@ function accountCacheAccountingRowV1(
   const rowSidecarMetadataBytes = hasSidecarMetadata
     ? requireCacheMetadataBytes(exactRow.sidecarMetadata, 'cache row sidecar metadata')
     : 0;
-  const closureReferencedBytes = accountCacheReferenceSetV1(
-    accumulator,
-    closure,
-    'closure',
-    accumulator.closurePhysical,
-    true,
-  );
+  const closureReferencedBytes = accountClosureReferencesV1(accumulator, closure);
   if (closureReferencedBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
     fail('system-record-closure', 'row closure exceeds its byte bound');
   }
@@ -343,12 +337,7 @@ function accountCacheAccountingRowV1(
         'row sidecar must contain one evidence object and only signed controls',
       );
     }
-    const sidecarReferencedBytes = accountCacheReferenceSetV1(
-      accumulator,
-      sidecar,
-      'sidecar',
-      accumulator.sidecarPhysical,
-    );
+    const sidecarReferencedBytes = accountSidecarReferencesV1(accumulator, sidecar);
     if (sidecarReferencedBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
       fail('system-record-closure', 'row sidecar exceeds its byte bound');
     }
@@ -377,12 +366,51 @@ function accountCacheAccountingRowV1(
   }
 }
 
+function accountClosureReferencesV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  references: readonly SystemRecordCacheReferenceV1[],
+): number {
+  return accountCacheReferenceSetV1(
+    accumulator,
+    references,
+    'closure',
+    accumulator.closurePhysical,
+    true,
+  );
+}
+
+function accountSidecarReferencesV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  references: readonly SystemRecordCacheReferenceV1[],
+): number {
+  return accountCacheReferenceSetV1(
+    accumulator,
+    references,
+    'sidecar',
+    accumulator.sidecarPhysical,
+    false,
+  );
+}
+
+function accountInventoryLeavesV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  references: readonly SystemRecordCacheReferenceV1[],
+): number {
+  return accountCacheReferenceSetV1(
+    accumulator,
+    references,
+    'activation inventory',
+    undefined,
+    false,
+  );
+}
+
 function accountCacheReferenceSetV1(
   accumulator: CacheAccountingAccumulatorV1,
   references: readonly SystemRecordCacheReferenceV1[],
   label: string,
-  category?: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
-  trackBundles = false,
+  category: Map<Digest32V1, SystemRecordCacheReferenceFactsV1> | undefined,
+  trackBundles: boolean,
 ): number {
   let referencedBytes = 0;
   const logical = new Set<string>();
@@ -527,11 +555,7 @@ export function preflightSystemRecordCacheAccountingV1(
     accountCacheAccountingRowV1(accumulator, row);
     assertIncrementalCacheAccountingBoundsV1(accumulator);
   }
-  accountCacheReferenceSetV1(
-    accumulator,
-    normalized.inventoryLeaves,
-    'activation inventory',
-  );
+  accountInventoryLeavesV1(accumulator, normalized.inventoryLeaves);
   if (
     normalized.inventoryLeaves.some((reference) => reference.objectKind !== 'inventory-leaf')
   ) {

--- a/packages/core/src/system-record-codec-primitives-v1.ts
+++ b/packages/core/src/system-record-codec-primitives-v1.ts
@@ -104,6 +104,21 @@ export function copyBoundedSystemRecordBytesV1(
   return copy;
 }
 
+export function systemRecordHexToBytesV1(value: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(value.slice(2), 'hex'));
+}
+
+export function concatSystemRecordBytesV1(...values: readonly Uint8Array[]): Uint8Array {
+  const length = values.reduce((sum, value) => sum + value.byteLength, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const value of values) {
+    result.set(value, offset);
+    offset += value.byteLength;
+  }
+  return result;
+}
+
 function systemRecordByteLengthV1(value: unknown, label: string): number {
   if (!(value instanceof Uint8Array) || TYPED_ARRAY_BYTE_LENGTH === undefined) {
     failSystemRecordObjectV1('system-record-scalar', `${label} must be Uint8Array bytes`);

--- a/packages/core/src/system-record-codec-primitives-v1.ts
+++ b/packages/core/src/system-record-codec-primitives-v1.ts
@@ -104,10 +104,6 @@ export function copyBoundedSystemRecordBytesV1(
   return copy;
 }
 
-export function systemRecordHexToBytesV1(value: string): Uint8Array {
-  return Uint8Array.from(Buffer.from(value.slice(2), 'hex'));
-}
-
 export function concatSystemRecordBytesV1(...values: readonly Uint8Array[]): Uint8Array {
   const length = values.reduce((sum, value) => sum + value.byteLength, 0);
   const result = new Uint8Array(length);

--- a/packages/core/src/system-record-inventory-codecs-v1-internal.ts
+++ b/packages/core/src/system-record-inventory-codecs-v1-internal.ts
@@ -1,6 +1,3 @@
-import { publicKeyFromRaw } from '@libp2p/crypto/keys';
-import { peerIdFromPublicKey } from '@libp2p/peer-id';
-import { verifyAsync as verifyEd25519 } from '@noble/ed25519';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import {
@@ -27,12 +24,10 @@ import {
   copyBoundedSystemRecordBytesV1,
   decodeUnpaddedBase64UrlV1,
   digestSystemRecordBytesV1,
-  type SystemRecordPeerPublicKeyV1,
 } from './system-record-codec-primitives-v1.js';
 import {
   SYSTEM_RECORD_AUTHORITY_SEQUENCE_MAX,
   SYSTEM_RECORD_DIGEST_DOMAINS_V1,
-  SYSTEM_RECORD_ED25519_PUBLIC_KEY_BYTES,
   SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
   SYSTEM_RECORD_INTERNAL_MAX_ENTRIES,
   SYSTEM_RECORD_INTERNAL_MIN_ENTRIES,
@@ -51,7 +46,6 @@ import {
   SYSTEM_RECORD_OBJECT_CAPS_V1,
   SYSTEM_RECORD_ROOT_MAX_ENTRIES,
   SYSTEM_RECORD_ROOT_MIN_ENTRIES,
-  SYSTEM_RECORD_SIGNATURE_DOMAINS_V1,
 } from './system-record-limits-v1.js';
 
 const UTF8 = new TextEncoder();
@@ -591,55 +585,9 @@ export function parseCanonicalSignedSystemRecordRootDescriptorEnvelopeV1(
   );
 }
 
-export function buildSystemRecordProviderSignatureMessageV1(
-  descriptor: SystemRecordRootDescriptorObjectV1,
-  descriptorObjectDigest: Digest32V1,
-  providerPeerId: string,
-): Uint8Array {
-  const validatedDescriptor = validateRootDescriptor(descriptor);
-  assertCanonicalDigest(descriptorObjectDigest);
-  const tuple: CanonicalJsonValue = [
-    validatedDescriptor.kind,
-    validatedDescriptor.networkId,
-    providerPeerId,
-    descriptorObjectDigest,
-  ];
-  return concatBytes(
-    UTF8.encode(SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.provider),
-    canonicalizeJsonBytes(tuple),
-  );
-}
-
-export async function verifySignedSystemRecordRootDescriptorEnvelopeV1(
-  envelope: SignedSystemRecordRootDescriptorEnvelopeV1,
-  providerPeerPublicKey: SystemRecordPeerPublicKeyV1,
-): Promise<boolean> {
-  const validated = validateSignedRootDescriptor(envelope);
-  const keyBytes = decodeUnpaddedBase64UrlV1(
-    providerPeerPublicKey,
-    SYSTEM_RECORD_ED25519_PUBLIC_KEY_BYTES,
-    'providerPeerPublicKey',
-  );
-  if (peerIdFromPublicKey(publicKeyFromRaw(keyBytes)).toString() !== validated.providerPeerId) {
-    return false;
-  }
-  const signature = decodeUnpaddedBase64UrlV1(
-    validated.signature,
-    SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
-    'provider signature',
-  );
-  return verifyEd25519(
-    signature,
-    buildSystemRecordProviderSignatureMessageV1(
-      validated.object,
-      validated.objectDigest,
-      validated.providerPeerId,
-    ),
-    keyBytes,
-  );
-}
-
-function validateSignedRootDescriptor(value: unknown): SignedSystemRecordRootDescriptorEnvelopeV1 {
+export function validateSignedRootDescriptor(
+  value: unknown,
+): SignedSystemRecordRootDescriptorEnvelopeV1 {
   const envelope = snapshotExactDataRecord(
     value,
     ['object', 'objectDigest', 'providerPeerId', 'signatureSuite', 'signature'],
@@ -759,14 +707,4 @@ function hexDigestBytes(value: Digest32V1): Uint8Array {
 function bytesDigest(value: Uint8Array): Digest32V1 {
   if (value.byteLength !== 32) throw new Error('digest must be 32 bytes');
   return `0x${Buffer.from(value).toString('hex')}` as Digest32V1;
-}
-
-function concatBytes(...values: readonly Uint8Array[]): Uint8Array {
-  const output = new Uint8Array(values.reduce((sum, value) => sum + value.byteLength, 0));
-  let offset = 0;
-  for (const value of values) {
-    output.set(value, offset);
-    offset += value.byteLength;
-  }
-  return output;
 }

--- a/packages/core/src/system-record-inventory-signatures-v1-internal.ts
+++ b/packages/core/src/system-record-inventory-signatures-v1-internal.ts
@@ -7,6 +7,7 @@ import {
   type CanonicalJsonValue,
 } from './canonical-json.js';
 import {
+  concatSystemRecordBytesV1,
   decodeUnpaddedBase64UrlV1,
   type SystemRecordPeerPublicKeyV1,
 } from './system-record-codec-primitives-v1.js';
@@ -38,7 +39,7 @@ export function buildSystemRecordProviderSignatureMessageV1(
     providerPeerId,
     descriptorObjectDigest,
   ];
-  return concatBytes(
+  return concatSystemRecordBytesV1(
     UTF8.encode(SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.provider),
     canonicalizeJsonBytes(tuple),
   );
@@ -71,14 +72,4 @@ export async function verifySignedSystemRecordRootDescriptorEnvelopeV1(
     ),
     keyBytes,
   );
-}
-
-function concatBytes(...values: readonly Uint8Array[]): Uint8Array {
-  const output = new Uint8Array(values.reduce((sum, value) => sum + value.byteLength, 0));
-  let offset = 0;
-  for (const value of values) {
-    output.set(value, offset);
-    offset += value.byteLength;
-  }
-  return output;
 }

--- a/packages/core/src/system-record-inventory-signatures-v1-internal.ts
+++ b/packages/core/src/system-record-inventory-signatures-v1-internal.ts
@@ -1,0 +1,84 @@
+import { publicKeyFromRaw } from '@libp2p/crypto/keys';
+import { peerIdFromPublicKey } from '@libp2p/peer-id';
+import { verifyAsync as verifyEd25519 } from '@noble/ed25519';
+
+import {
+  canonicalizeJsonBytes,
+  type CanonicalJsonValue,
+} from './canonical-json.js';
+import {
+  decodeUnpaddedBase64UrlV1,
+  type SystemRecordPeerPublicKeyV1,
+} from './system-record-codec-primitives-v1.js';
+import {
+  SYSTEM_RECORD_ED25519_PUBLIC_KEY_BYTES,
+  SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
+  SYSTEM_RECORD_SIGNATURE_DOMAINS_V1,
+} from './system-record-limits-v1.js';
+import {
+  validateRootDescriptor,
+  validateSignedRootDescriptor,
+  type SignedSystemRecordRootDescriptorEnvelopeV1,
+  type SystemRecordRootDescriptorObjectV1,
+} from './system-record-inventory-codecs-v1-internal.js';
+import { type Digest32V1, assertCanonicalDigest } from './sync-wire-scalars.js';
+
+const UTF8 = new TextEncoder();
+
+export function buildSystemRecordProviderSignatureMessageV1(
+  descriptor: SystemRecordRootDescriptorObjectV1,
+  descriptorObjectDigest: Digest32V1,
+  providerPeerId: string,
+): Uint8Array {
+  const validatedDescriptor = validateRootDescriptor(descriptor);
+  assertCanonicalDigest(descriptorObjectDigest);
+  const tuple: CanonicalJsonValue = [
+    validatedDescriptor.kind,
+    validatedDescriptor.networkId,
+    providerPeerId,
+    descriptorObjectDigest,
+  ];
+  return concatBytes(
+    UTF8.encode(SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.provider),
+    canonicalizeJsonBytes(tuple),
+  );
+}
+
+export async function verifySignedSystemRecordRootDescriptorEnvelopeV1(
+  envelope: SignedSystemRecordRootDescriptorEnvelopeV1,
+  providerPeerPublicKey: SystemRecordPeerPublicKeyV1,
+): Promise<boolean> {
+  const validated = validateSignedRootDescriptor(envelope);
+  const keyBytes = decodeUnpaddedBase64UrlV1(
+    providerPeerPublicKey,
+    SYSTEM_RECORD_ED25519_PUBLIC_KEY_BYTES,
+    'providerPeerPublicKey',
+  );
+  if (peerIdFromPublicKey(publicKeyFromRaw(keyBytes)).toString() !== validated.providerPeerId) {
+    return false;
+  }
+  const signature = decodeUnpaddedBase64UrlV1(
+    validated.signature,
+    SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
+    'provider signature',
+  );
+  return verifyEd25519(
+    signature,
+    buildSystemRecordProviderSignatureMessageV1(
+      validated.object,
+      validated.objectDigest,
+      validated.providerPeerId,
+    ),
+    keyBytes,
+  );
+}
+
+function concatBytes(...values: readonly Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(values.reduce((sum, value) => sum + value.byteLength, 0));
+  let offset = 0;
+  for (const value of values) {
+    output.set(value, offset);
+    offset += value.byteLength;
+  }
+  return output;
+}

--- a/packages/core/src/system-record-inventory-v1.ts
+++ b/packages/core/src/system-record-inventory-v1.ts
@@ -10,7 +10,6 @@ export {
   assertSystemRecordInventoryInternalObjectV1,
   assertSystemRecordInventoryLeafObjectV1,
   assertSystemRecordRootDescriptorObjectV1,
-  buildSystemRecordProviderSignatureMessageV1,
   canonicalizeSignedSystemRecordRootDescriptorEnvelopeV1,
   canonicalizeSystemRecordInventoryInternalObjectV1,
   canonicalizeSystemRecordInventoryLeafObjectV1,
@@ -28,7 +27,6 @@ export {
   parseCanonicalSystemRecordInventoryLeafObjectV1,
   parseCanonicalSystemRecordRootDescriptorObjectV1,
   systemRecordInventoryRowMaxEncodedBytesV1,
-  verifySignedSystemRecordRootDescriptorEnvelopeV1,
   type SignedSystemRecordRootDescriptorEnvelopeV1,
   type SystemRecordInventoryInternalEntryV1,
   type SystemRecordInventoryInternalObjectV1,
@@ -37,6 +35,11 @@ export {
   type SystemRecordInventoryRowV1,
   type SystemRecordRootDescriptorObjectV1,
 } from './system-record-inventory-codecs-v1-internal.js';
+
+export {
+  buildSystemRecordProviderSignatureMessageV1,
+  verifySignedSystemRecordRootDescriptorEnvelopeV1,
+} from './system-record-inventory-signatures-v1-internal.js';
 
 export {
   createSystemRecordInventoryTraversalV1,

--- a/packages/core/src/system-record-object-identity-descriptors-v1-internal.ts
+++ b/packages/core/src/system-record-object-identity-descriptors-v1-internal.ts
@@ -12,7 +12,7 @@ import {
   parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
   parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
   parseCanonicalSignedAgentProfileHeadEnvelopeV1,
-} from './system-record-signatures-v1-internal.js';
+} from './system-record-signed-envelope-codecs-v1-internal.js';
 import {
   parseCanonicalSignedSystemRecordRootDescriptorEnvelopeV1,
 } from './system-record-inventory-codecs-v1-internal.js';
@@ -22,17 +22,15 @@ export interface SystemRecordArtifactIdentitiesV1 {
   readonly cacheDigest: Digest32V1;
 }
 
-interface SystemRecordObjectIdentityDescriptorV1 {
-  readonly derive: (canonicalBytes: Uint8Array) => SystemRecordArtifactIdentitiesV1;
-}
+type SystemRecordObjectIdentityDeriverV1 = (
+  canonicalBytes: Uint8Array,
+) => SystemRecordArtifactIdentitiesV1;
 
-function byteIdentity(domain: string): SystemRecordObjectIdentityDescriptorV1 {
-  return Object.freeze({
-    derive: (canonicalBytes: Uint8Array) => {
-      const digest = digestSystemRecordBytesV1(domain, canonicalBytes);
-      return Object.freeze({ semanticDigest: digest, cacheDigest: digest });
-    },
-  });
+function byteIdentity(domain: string): SystemRecordObjectIdentityDeriverV1 {
+  return (canonicalBytes: Uint8Array) => {
+    const digest = digestSystemRecordBytesV1(domain, canonicalBytes);
+    return Object.freeze({ semanticDigest: digest, cacheDigest: digest });
+  };
 }
 
 function signedEnvelopeIdentity<TEnvelope extends Readonly<{ objectDigest: Digest32V1 }>>(
@@ -41,19 +39,17 @@ function signedEnvelopeIdentity<TEnvelope extends Readonly<{ objectDigest: Diges
     envelope: TEnvelope,
     canonicalBytes: Uint8Array,
   ) => Digest32V1,
-): SystemRecordObjectIdentityDescriptorV1 {
-  return Object.freeze({
-    derive: (canonicalBytes: Uint8Array) => {
-      const envelope = parse(canonicalBytes);
-      return Object.freeze({
-        semanticDigest: envelope.objectDigest,
-        cacheDigest: cacheDigest(envelope, canonicalBytes),
-      });
-    },
-  });
+): SystemRecordObjectIdentityDeriverV1 {
+  return (canonicalBytes: Uint8Array) => {
+    const envelope = parse(canonicalBytes);
+    return Object.freeze({
+      semanticDigest: envelope.objectDigest,
+      cacheDigest: cacheDigest(envelope, canonicalBytes),
+    });
+  };
 }
 
-export const SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1 = Object.freeze({
+export const SYSTEM_RECORD_OBJECT_IDENTITY_DERIVERS_V1 = Object.freeze({
   'root-descriptor': signedEnvelopeIdentity(
     parseCanonicalSignedSystemRecordRootDescriptorEnvelopeV1,
     (_envelope, canonicalBytes) => digestSystemRecordBytesV1(
@@ -79,7 +75,7 @@ export const SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1 = Object.freeze({
   'owned-subject-table': byteIdentity(SYSTEM_RECORD_DIGEST_DOMAINS_V1.ownedSubjectTable),
   'profile-bundle': byteIdentity(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle),
 } satisfies Readonly<
-  Record<SystemRecordObjectKindV1, SystemRecordObjectIdentityDescriptorV1>
+  Record<SystemRecordObjectKindV1, SystemRecordObjectIdentityDeriverV1>
 >);
 
 export function deriveSystemRecordArtifactIdentitiesV1(
@@ -87,10 +83,10 @@ export function deriveSystemRecordArtifactIdentitiesV1(
   canonicalBytes: Uint8Array,
   label: string,
 ): SystemRecordArtifactIdentitiesV1 {
-  if (!Object.prototype.hasOwnProperty.call(SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1, objectKind)) {
+  if (!Object.prototype.hasOwnProperty.call(SYSTEM_RECORD_OBJECT_IDENTITY_DERIVERS_V1, objectKind)) {
     fail('system-record-closure', `${label} artifact identity is invalid`);
   }
-  const identities = SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1[objectKind].derive(canonicalBytes);
+  const identities = SYSTEM_RECORD_OBJECT_IDENTITY_DERIVERS_V1[objectKind](canonicalBytes);
   if (identities.semanticDigest.length !== 66 || identities.cacheDigest.length !== 66) {
     fail('system-record-closure', `${label} artifact identity is invalid`);
   }

--- a/packages/core/src/system-record-object-identity-descriptors-v1-internal.ts
+++ b/packages/core/src/system-record-object-identity-descriptors-v1-internal.ts
@@ -1,0 +1,98 @@
+import { type Digest32V1 } from './sync-wire-scalars.js';
+import {
+  digestSystemRecordBytesV1,
+  failSystemRecordObjectV1 as fail,
+} from './system-record-codec-primitives-v1.js';
+import {
+  SYSTEM_RECORD_DIGEST_DOMAINS_V1,
+  type SystemRecordObjectKindV1,
+} from './system-record-limits-v1.js';
+import {
+  computeSignedSystemRecordEnvelopeDigestV1,
+  parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
+  parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
+  parseCanonicalSignedAgentProfileHeadEnvelopeV1,
+} from './system-record-signatures-v1-internal.js';
+import {
+  parseCanonicalSignedSystemRecordRootDescriptorEnvelopeV1,
+} from './system-record-inventory-codecs-v1-internal.js';
+
+export interface SystemRecordArtifactIdentitiesV1 {
+  readonly semanticDigest: Digest32V1;
+  readonly cacheDigest: Digest32V1;
+}
+
+interface SystemRecordObjectIdentityDescriptorV1 {
+  readonly derive: (canonicalBytes: Uint8Array) => SystemRecordArtifactIdentitiesV1;
+}
+
+function byteIdentity(domain: string): SystemRecordObjectIdentityDescriptorV1 {
+  return Object.freeze({
+    derive: (canonicalBytes: Uint8Array) => {
+      const digest = digestSystemRecordBytesV1(domain, canonicalBytes);
+      return Object.freeze({ semanticDigest: digest, cacheDigest: digest });
+    },
+  });
+}
+
+function signedEnvelopeIdentity<TEnvelope extends Readonly<{ objectDigest: Digest32V1 }>>(
+  parse: (canonicalBytes: Uint8Array) => TEnvelope,
+  cacheDigest: (
+    envelope: TEnvelope,
+    canonicalBytes: Uint8Array,
+  ) => Digest32V1,
+): SystemRecordObjectIdentityDescriptorV1 {
+  return Object.freeze({
+    derive: (canonicalBytes: Uint8Array) => {
+      const envelope = parse(canonicalBytes);
+      return Object.freeze({
+        semanticDigest: envelope.objectDigest,
+        cacheDigest: cacheDigest(envelope, canonicalBytes),
+      });
+    },
+  });
+}
+
+export const SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1 = Object.freeze({
+  'root-descriptor': signedEnvelopeIdentity(
+    parseCanonicalSignedSystemRecordRootDescriptorEnvelopeV1,
+    (_envelope, canonicalBytes) => digestSystemRecordBytesV1(
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.signedRootDescriptorEnvelope,
+      canonicalBytes,
+    ),
+  ),
+  'inventory-internal': byteIdentity(SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryInternal),
+  'inventory-leaf': byteIdentity(SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryLeaf),
+  'agent-profile-head': signedEnvelopeIdentity(
+    parseCanonicalSignedAgentProfileHeadEnvelopeV1,
+    (envelope) => computeSignedSystemRecordEnvelopeDigestV1(envelope),
+  ),
+  'authority-transition': signedEnvelopeIdentity(
+    parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
+    (envelope) => computeSignedSystemRecordEnvelopeDigestV1(envelope),
+  ),
+  'fork-resolution': signedEnvelopeIdentity(
+    parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
+    (envelope) => computeSignedSystemRecordEnvelopeDigestV1(envelope),
+  ),
+  'conflict-evidence': byteIdentity(SYSTEM_RECORD_DIGEST_DOMAINS_V1.conflictEvidence),
+  'owned-subject-table': byteIdentity(SYSTEM_RECORD_DIGEST_DOMAINS_V1.ownedSubjectTable),
+  'profile-bundle': byteIdentity(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle),
+} satisfies Readonly<
+  Record<SystemRecordObjectKindV1, SystemRecordObjectIdentityDescriptorV1>
+>);
+
+export function deriveSystemRecordArtifactIdentitiesV1(
+  objectKind: SystemRecordObjectKindV1,
+  canonicalBytes: Uint8Array,
+  label: string,
+): SystemRecordArtifactIdentitiesV1 {
+  if (!Object.prototype.hasOwnProperty.call(SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1, objectKind)) {
+    fail('system-record-closure', `${label} artifact identity is invalid`);
+  }
+  const identities = SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1[objectKind].derive(canonicalBytes);
+  if (identities.semanticDigest.length !== 66 || identities.cacheDigest.length !== 66) {
+    fail('system-record-closure', `${label} artifact identity is invalid`);
+  }
+  return identities;
+}

--- a/packages/core/src/system-record-signable-object-policy-v1-internal.ts
+++ b/packages/core/src/system-record-signable-object-policy-v1-internal.ts
@@ -1,0 +1,218 @@
+import { type CanonicalJsonValue } from './canonical-json.js';
+import {
+  computeAgentProfileAuthorityTransitionDigestV1,
+  computeAgentProfileForkResolutionDigestV1,
+  validateAuthorityTransition,
+  validateForkResolution,
+  type AgentProfileAuthorityTransitionV1,
+  type AgentProfileForkResolutionV1,
+  type SystemRecordSignatureRoleV1,
+} from './system-record-agent-profile-control-codecs-v1-internal.js';
+import {
+  computeAgentProfileHeadObjectDigestV1,
+  validateAgentProfileHeadObjectV1,
+  type AgentProfileHeadObjectV1,
+} from './system-record-agent-profile-head-codec-v1-internal.js';
+import { snapshotSystemRecordDataRecord } from './system-record-agent-profile-primitives-v1-internal.js';
+import { failSystemRecordObjectV1 as fail } from './system-record-codec-primitives-v1.js';
+import {
+  SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
+  SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
+  type SystemRecordObjectKindV1,
+} from './system-record-limits-v1.js';
+import { type Digest32V1 } from './sync-wire-scalars.js';
+
+export type SignableSystemRecordObjectV1 =
+  | AgentProfileHeadObjectV1
+  | AgentProfileAuthorityTransitionV1
+  | AgentProfileForkResolutionV1;
+
+export type SignableSystemRecordKindV1 = 'head' | 'transition' | 'fork';
+
+interface SignableSystemRecordDescriptorV1<T extends SignableSystemRecordObjectV1> {
+  readonly kind: SignableSystemRecordKindV1;
+  readonly objectType: T['objectType'];
+  readonly objectKind: SystemRecordObjectKindV1;
+  readonly maxJsonDepth: number;
+  readonly validate: (value: unknown) => T;
+  readonly digest: (object: T) => Digest32V1;
+  readonly requiredRoles: (object: T) => readonly SystemRecordSignatureRoleV1[];
+  readonly issuerForRole: (
+    object: T,
+    role: Exclude<SystemRecordSignatureRoleV1, 'peer'>,
+  ) => string;
+  readonly signatureMessageTuple: (
+    object: T,
+    objectDigest: Digest32V1,
+    role: SystemRecordSignatureRoleV1,
+  ) => CanonicalJsonValue;
+}
+
+export interface BoundSignableSystemRecordPolicyV1 {
+  readonly kind: SignableSystemRecordKindV1;
+  readonly objectKind: SystemRecordObjectKindV1;
+  readonly maxJsonDepth: number;
+  readonly object: SignableSystemRecordObjectV1;
+  readonly objectDigest: Digest32V1;
+  readonly requiredRoles: readonly SystemRecordSignatureRoleV1[];
+  readonly issuerForRole: (
+    role: Exclude<SystemRecordSignatureRoleV1, 'peer'>,
+  ) => string;
+  readonly signatureMessageTuple: (
+    objectDigest: Digest32V1,
+    role: SystemRecordSignatureRoleV1,
+  ) => CanonicalJsonValue;
+}
+
+export interface SignableSystemRecordStaticPolicyV1 {
+  readonly kind: SignableSystemRecordKindV1;
+  readonly objectKind: SystemRecordObjectKindV1;
+  readonly maxJsonDepth: number;
+}
+
+const HEAD_ROLES = Object.freeze(['peer', 'current-evm'] as const);
+const TRANSITION_CO_SIGNED_ROLES = Object.freeze(['peer', 'prior-evm', 'next-evm'] as const);
+const TRANSITION_EXPIRED_ROLES = Object.freeze(['peer', 'next-evm'] as const);
+
+const SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1 = Object.freeze({
+  'agent-profile-head': defineDescriptor<AgentProfileHeadObjectV1>({
+    kind: 'head',
+    objectType: 'agent-profile-head',
+    objectKind: 'agent-profile-head',
+    maxJsonDepth: SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
+    validate: validateAgentProfileHeadObjectV1,
+    digest: computeAgentProfileHeadObjectDigestV1,
+    requiredRoles: () => HEAD_ROLES,
+    issuerForRole: (object, role) => {
+      if (role === 'current-evm') return object.evmIssuer;
+      return invalidRole(role, object.objectType);
+    },
+    signatureMessageTuple: (object, objectDigest, role) => {
+      if (role !== 'peer' && role !== 'current-evm') return invalidRole(role, object.objectType);
+      return [
+        object.objectType, objectDigest, object.networkId, recordKey(object),
+        object.authoritySequence, object.version,
+        ...(role === 'peer' ? [] : ['current-evm', object.evmIssuer]),
+      ];
+    },
+  }),
+  'authority-transition': defineDescriptor<AgentProfileAuthorityTransitionV1>({
+    kind: 'transition',
+    objectType: 'authority-transition',
+    objectKind: 'authority-transition',
+    maxJsonDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
+    validate: validateAuthorityTransition,
+    digest: computeAgentProfileAuthorityTransitionDigestV1,
+    requiredRoles: (object) => object.mode === 'co-signed'
+      ? TRANSITION_CO_SIGNED_ROLES
+      : TRANSITION_EXPIRED_ROLES,
+    issuerForRole: (object, role) => {
+      if (role === 'prior-evm') return object.priorEvmIssuer;
+      if (role === 'next-evm') return object.nextEvmIssuer;
+      return invalidRole(role, object.objectType);
+    },
+    signatureMessageTuple: (object, objectDigest, role) => {
+      if (role !== 'peer' && role !== 'prior-evm' && role !== 'next-evm') {
+        return invalidRole(role, object.objectType);
+      }
+      return [
+        object.objectType, objectDigest, object.networkId, recordKey(object),
+        object.priorAuthoritySequence, object.nextAuthoritySequence,
+        object.priorHeadDigest, role,
+        ...(role === 'peer' ? [] : [
+          role === 'prior-evm' ? object.priorEvmIssuer : object.nextEvmIssuer,
+        ]),
+      ];
+    },
+  }),
+  'fork-resolution': defineDescriptor<AgentProfileForkResolutionV1>({
+    kind: 'fork',
+    objectType: 'fork-resolution',
+    objectKind: 'fork-resolution',
+    maxJsonDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
+    validate: validateForkResolution,
+    digest: computeAgentProfileForkResolutionDigestV1,
+    requiredRoles: () => HEAD_ROLES,
+    issuerForRole: (object, role) => {
+      if (role === 'current-evm') return object.evmIssuer;
+      return invalidRole(role, object.objectType);
+    },
+    signatureMessageTuple: (object, objectDigest, role) => {
+      if (role !== 'peer' && role !== 'current-evm') return invalidRole(role, object.objectType);
+      return [
+        object.objectType, objectDigest, object.networkId, recordKey(object),
+        object.authoritySequence, object.forkedVersion, object.resolutionVersion, role,
+        ...(role === 'peer' ? [] : [object.evmIssuer]),
+      ];
+    },
+  }),
+});
+
+export function bindSignableSystemRecordPolicyV1(
+  value: unknown,
+): BoundSignableSystemRecordPolicyV1 {
+  const record = snapshotSystemRecordDataRecord(value, 'signed envelope object');
+  if (record.objectType === 'agent-profile-head') {
+    return bindDescriptor(SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['agent-profile-head'], record);
+  }
+  if (record.objectType === 'authority-transition') {
+    return bindDescriptor(SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['authority-transition'], record);
+  }
+  if (record.objectType === 'fork-resolution') {
+    return bindDescriptor(SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['fork-resolution'], record);
+  }
+  return fail('system-record-schema', 'signed envelope object type is unsupported');
+}
+
+export function signableSystemRecordStaticPolicyV1(
+  kind: SignableSystemRecordKindV1,
+): SignableSystemRecordStaticPolicyV1 {
+  const descriptor = kind === 'head'
+    ? SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['agent-profile-head']
+    : kind === 'transition'
+      ? SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['authority-transition']
+      : SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['fork-resolution'];
+  return Object.freeze({
+    kind: descriptor.kind,
+    objectKind: descriptor.objectKind,
+    maxJsonDepth: descriptor.maxJsonDepth,
+  });
+}
+
+function defineDescriptor<T extends SignableSystemRecordObjectV1>(
+  descriptor: SignableSystemRecordDescriptorV1<T>,
+): SignableSystemRecordDescriptorV1<T> {
+  return Object.freeze(descriptor);
+}
+
+function bindDescriptor<T extends SignableSystemRecordObjectV1>(
+  descriptor: SignableSystemRecordDescriptorV1<T>,
+  value: unknown,
+): BoundSignableSystemRecordPolicyV1 {
+  const object = descriptor.validate(value);
+  return Object.freeze({
+    kind: descriptor.kind,
+    objectKind: descriptor.objectKind,
+    maxJsonDepth: descriptor.maxJsonDepth,
+    object,
+    objectDigest: descriptor.digest(object),
+    requiredRoles: Object.freeze([...descriptor.requiredRoles(object)]),
+    issuerForRole: (role: Exclude<SystemRecordSignatureRoleV1, 'peer'>) =>
+      descriptor.issuerForRole(object, role),
+    signatureMessageTuple: (
+      objectDigest: Digest32V1,
+      role: SystemRecordSignatureRoleV1,
+    ) =>
+      descriptor.signatureMessageTuple(object, objectDigest, role),
+  });
+}
+
+function recordKey(
+  object: SignableSystemRecordObjectV1,
+): CanonicalJsonValue {
+  return [object.networkId, object.peerId];
+}
+
+function invalidRole(role: string, objectType: string): never {
+  fail('system-record-signature', `${role} is not valid for ${objectType}`);
+}

--- a/packages/core/src/system-record-signable-object-policy-v1-internal.ts
+++ b/packages/core/src/system-record-signable-object-policy-v1-internal.ts
@@ -28,8 +28,9 @@ export type SignableSystemRecordObjectV1 =
   | AgentProfileForkResolutionV1;
 
 export type SignableSystemRecordKindV1 = 'head' | 'transition' | 'fork';
+type SignableSystemRecordObjectTypeV1 = SignableSystemRecordObjectV1['objectType'];
 
-interface SignableSystemRecordDescriptorV1<T extends SignableSystemRecordObjectV1> {
+interface SignableSystemRecordDescriptorDefinitionV1<T extends SignableSystemRecordObjectV1> {
   readonly kind: SignableSystemRecordKindV1;
   readonly objectType: T['objectType'];
   readonly objectKind: SystemRecordObjectKindV1;
@@ -37,6 +38,14 @@ interface SignableSystemRecordDescriptorV1<T extends SignableSystemRecordObjectV
   readonly validate: (value: unknown) => T;
   readonly digest: (object: T) => Digest32V1;
   readonly bindRoles: (object: T) => readonly SignableSystemRecordRolePolicyV1[];
+}
+
+interface SignableSystemRecordDescriptorV1 {
+  readonly kind: SignableSystemRecordKindV1;
+  readonly objectType: SignableSystemRecordObjectTypeV1;
+  readonly objectKind: SystemRecordObjectKindV1;
+  readonly maxJsonDepth: number;
+  readonly bind: (value: unknown) => BoundSignableSystemRecordPolicyV1;
 }
 
 interface SignableSystemRecordRolePolicyV1 {
@@ -132,32 +141,32 @@ const SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1 = Object.freeze({
       ], object.evmIssuer),
     ]),
   }),
-});
+}) satisfies Readonly<
+  Record<SignableSystemRecordObjectTypeV1, SignableSystemRecordDescriptorV1>
+>;
+
+const SIGNABLE_SYSTEM_RECORD_DESCRIPTOR_BY_OBJECT_TYPE_V1 = indexSignableDescriptorsV1<string>(
+  (descriptor) => descriptor.objectType,
+);
+const SIGNABLE_SYSTEM_RECORD_DESCRIPTOR_BY_KIND_V1 =
+  indexSignableDescriptorsV1<SignableSystemRecordKindV1>((descriptor) => descriptor.kind);
 
 export function bindSignableSystemRecordPolicyV1(
   value: unknown,
 ): BoundSignableSystemRecordPolicyV1 {
   const record = snapshotSystemRecordDataRecord(value, 'signed envelope object');
-  if (record.objectType === 'agent-profile-head') {
-    return bindDescriptor(SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['agent-profile-head'], record);
-  }
-  if (record.objectType === 'authority-transition') {
-    return bindDescriptor(SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['authority-transition'], record);
-  }
-  if (record.objectType === 'fork-resolution') {
-    return bindDescriptor(SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['fork-resolution'], record);
-  }
-  return fail('system-record-schema', 'signed envelope object type is unsupported');
+  const descriptor = typeof record.objectType === 'string'
+    ? SIGNABLE_SYSTEM_RECORD_DESCRIPTOR_BY_OBJECT_TYPE_V1.get(record.objectType)
+    : undefined;
+  return descriptor?.bind(record)
+    ?? fail('system-record-schema', 'signed envelope object type is unsupported');
 }
 
 export function signableSystemRecordStaticPolicyV1(
   kind: SignableSystemRecordKindV1,
 ): SignableSystemRecordStaticPolicyV1 {
-  const descriptor = kind === 'head'
-    ? SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['agent-profile-head']
-    : kind === 'transition'
-      ? SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['authority-transition']
-      : SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1['fork-resolution'];
+  const descriptor = SIGNABLE_SYSTEM_RECORD_DESCRIPTOR_BY_KIND_V1.get(kind)
+    ?? fail('system-record-schema', 'signable object kind is unsupported');
   return Object.freeze({
     kind: descriptor.kind,
     objectKind: descriptor.objectKind,
@@ -166,13 +175,19 @@ export function signableSystemRecordStaticPolicyV1(
 }
 
 function defineDescriptor<T extends SignableSystemRecordObjectV1>(
-  descriptor: SignableSystemRecordDescriptorV1<T>,
-): SignableSystemRecordDescriptorV1<T> {
-  return Object.freeze(descriptor);
+  definition: SignableSystemRecordDescriptorDefinitionV1<T>,
+): SignableSystemRecordDescriptorV1 {
+  return Object.freeze({
+    kind: definition.kind,
+    objectType: definition.objectType,
+    objectKind: definition.objectKind,
+    maxJsonDepth: definition.maxJsonDepth,
+    bind: (value: unknown) => bindDescriptor(definition, value),
+  });
 }
 
 function bindDescriptor<T extends SignableSystemRecordObjectV1>(
-  descriptor: SignableSystemRecordDescriptorV1<T>,
+  descriptor: SignableSystemRecordDescriptorDefinitionV1<T>,
   value: unknown,
 ): BoundSignableSystemRecordPolicyV1 {
   const object = descriptor.validate(value);
@@ -193,6 +208,20 @@ function bindDescriptor<T extends SignableSystemRecordObjectV1>(
       role: SystemRecordSignatureRoleV1,
     ) => rolePolicy(rolePolicies, role, object.objectType).signatureMessageTuple(objectDigest),
   });
+}
+
+function indexSignableDescriptorsV1<K extends string>(
+  keyOf: (descriptor: SignableSystemRecordDescriptorV1) => K,
+): ReadonlyMap<K, SignableSystemRecordDescriptorV1> {
+  const index = new Map<K, SignableSystemRecordDescriptorV1>();
+  for (const descriptor of Object.values(SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1)) {
+    const key = keyOf(descriptor);
+    if (index.has(key)) {
+      fail('system-record-schema', `duplicate signable descriptor key ${key}`);
+    }
+    index.set(key, descriptor);
+  }
+  return index;
 }
 
 function defineRolePolicy(

--- a/packages/core/src/system-record-signable-object-policy-v1-internal.ts
+++ b/packages/core/src/system-record-signable-object-policy-v1-internal.ts
@@ -36,16 +36,13 @@ interface SignableSystemRecordDescriptorV1<T extends SignableSystemRecordObjectV
   readonly maxJsonDepth: number;
   readonly validate: (value: unknown) => T;
   readonly digest: (object: T) => Digest32V1;
-  readonly requiredRoles: (object: T) => readonly SystemRecordSignatureRoleV1[];
-  readonly issuerForRole: (
-    object: T,
-    role: Exclude<SystemRecordSignatureRoleV1, 'peer'>,
-  ) => string;
-  readonly signatureMessageTuple: (
-    object: T,
-    objectDigest: Digest32V1,
-    role: SystemRecordSignatureRoleV1,
-  ) => CanonicalJsonValue;
+  readonly bindRoles: (object: T) => readonly SignableSystemRecordRolePolicyV1[];
+}
+
+interface SignableSystemRecordRolePolicyV1 {
+  readonly role: SystemRecordSignatureRoleV1;
+  readonly issuer?: string;
+  readonly signatureMessageTuple: (objectDigest: Digest32V1) => CanonicalJsonValue;
 }
 
 export interface BoundSignableSystemRecordPolicyV1 {
@@ -70,10 +67,6 @@ export interface SignableSystemRecordStaticPolicyV1 {
   readonly maxJsonDepth: number;
 }
 
-const HEAD_ROLES = Object.freeze(['peer', 'current-evm'] as const);
-const TRANSITION_CO_SIGNED_ROLES = Object.freeze(['peer', 'prior-evm', 'next-evm'] as const);
-const TRANSITION_EXPIRED_ROLES = Object.freeze(['peer', 'next-evm'] as const);
-
 const SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1 = Object.freeze({
   'agent-profile-head': defineDescriptor<AgentProfileHeadObjectV1>({
     kind: 'head',
@@ -82,19 +75,16 @@ const SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1 = Object.freeze({
     maxJsonDepth: SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
     validate: validateAgentProfileHeadObjectV1,
     digest: computeAgentProfileHeadObjectDigestV1,
-    requiredRoles: () => HEAD_ROLES,
-    issuerForRole: (object, role) => {
-      if (role === 'current-evm') return object.evmIssuer;
-      return invalidRole(role, object.objectType);
-    },
-    signatureMessageTuple: (object, objectDigest, role) => {
-      if (role !== 'peer' && role !== 'current-evm') return invalidRole(role, object.objectType);
-      return [
+    bindRoles: (object) => Object.freeze([
+      defineRolePolicy('peer', (objectDigest) => [
         object.objectType, objectDigest, object.networkId, recordKey(object),
         object.authoritySequence, object.version,
-        ...(role === 'peer' ? [] : ['current-evm', object.evmIssuer]),
-      ];
-    },
+      ]),
+      defineRolePolicy('current-evm', (objectDigest) => [
+        object.objectType, objectDigest, object.networkId, recordKey(object),
+        object.authoritySequence, object.version, 'current-evm', object.evmIssuer,
+      ], object.evmIssuer),
+    ]),
   }),
   'authority-transition': defineDescriptor<AgentProfileAuthorityTransitionV1>({
     kind: 'transition',
@@ -103,27 +93,25 @@ const SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1 = Object.freeze({
     maxJsonDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
     validate: validateAuthorityTransition,
     digest: computeAgentProfileAuthorityTransitionDigestV1,
-    requiredRoles: (object) => object.mode === 'co-signed'
-      ? TRANSITION_CO_SIGNED_ROLES
-      : TRANSITION_EXPIRED_ROLES,
-    issuerForRole: (object, role) => {
-      if (role === 'prior-evm') return object.priorEvmIssuer;
-      if (role === 'next-evm') return object.nextEvmIssuer;
-      return invalidRole(role, object.objectType);
-    },
-    signatureMessageTuple: (object, objectDigest, role) => {
-      if (role !== 'peer' && role !== 'prior-evm' && role !== 'next-evm') {
-        return invalidRole(role, object.objectType);
-      }
-      return [
+    bindRoles: (object) => Object.freeze([
+      defineRolePolicy('peer', (objectDigest) => [
         object.objectType, objectDigest, object.networkId, recordKey(object),
         object.priorAuthoritySequence, object.nextAuthoritySequence,
-        object.priorHeadDigest, role,
-        ...(role === 'peer' ? [] : [
-          role === 'prior-evm' ? object.priorEvmIssuer : object.nextEvmIssuer,
-        ]),
-      ];
-    },
+        object.priorHeadDigest, 'peer',
+      ]),
+      ...(object.mode === 'co-signed' ? [
+        defineRolePolicy('prior-evm', (objectDigest) => [
+          object.objectType, objectDigest, object.networkId, recordKey(object),
+          object.priorAuthoritySequence, object.nextAuthoritySequence,
+          object.priorHeadDigest, 'prior-evm', object.priorEvmIssuer,
+        ], object.priorEvmIssuer),
+      ] : []),
+      defineRolePolicy('next-evm', (objectDigest) => [
+        object.objectType, objectDigest, object.networkId, recordKey(object),
+        object.priorAuthoritySequence, object.nextAuthoritySequence,
+        object.priorHeadDigest, 'next-evm', object.nextEvmIssuer,
+      ], object.nextEvmIssuer),
+    ]),
   }),
   'fork-resolution': defineDescriptor<AgentProfileForkResolutionV1>({
     kind: 'fork',
@@ -132,19 +120,17 @@ const SIGNABLE_SYSTEM_RECORD_DESCRIPTORS_V1 = Object.freeze({
     maxJsonDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
     validate: validateForkResolution,
     digest: computeAgentProfileForkResolutionDigestV1,
-    requiredRoles: () => HEAD_ROLES,
-    issuerForRole: (object, role) => {
-      if (role === 'current-evm') return object.evmIssuer;
-      return invalidRole(role, object.objectType);
-    },
-    signatureMessageTuple: (object, objectDigest, role) => {
-      if (role !== 'peer' && role !== 'current-evm') return invalidRole(role, object.objectType);
-      return [
+    bindRoles: (object) => Object.freeze([
+      defineRolePolicy('peer', (objectDigest) => [
         object.objectType, objectDigest, object.networkId, recordKey(object),
-        object.authoritySequence, object.forkedVersion, object.resolutionVersion, role,
-        ...(role === 'peer' ? [] : [object.evmIssuer]),
-      ];
-    },
+        object.authoritySequence, object.forkedVersion, object.resolutionVersion, 'peer',
+      ]),
+      defineRolePolicy('current-evm', (objectDigest) => [
+        object.objectType, objectDigest, object.networkId, recordKey(object),
+        object.authoritySequence, object.forkedVersion, object.resolutionVersion,
+        'current-evm', object.evmIssuer,
+      ], object.evmIssuer),
+    ]),
   }),
 });
 
@@ -190,21 +176,40 @@ function bindDescriptor<T extends SignableSystemRecordObjectV1>(
   value: unknown,
 ): BoundSignableSystemRecordPolicyV1 {
   const object = descriptor.validate(value);
+  const rolePolicies = Object.freeze([...descriptor.bindRoles(object)]);
   return Object.freeze({
     kind: descriptor.kind,
     objectKind: descriptor.objectKind,
     maxJsonDepth: descriptor.maxJsonDepth,
     object,
     objectDigest: descriptor.digest(object),
-    requiredRoles: Object.freeze([...descriptor.requiredRoles(object)]),
-    issuerForRole: (role: Exclude<SystemRecordSignatureRoleV1, 'peer'>) =>
-      descriptor.issuerForRole(object, role),
+    requiredRoles: Object.freeze(rolePolicies.map(({ role }) => role)),
+    issuerForRole: (role: Exclude<SystemRecordSignatureRoleV1, 'peer'>) => {
+      const issuer = rolePolicy(rolePolicies, role, object.objectType).issuer;
+      return issuer ?? invalidRole(role, object.objectType);
+    },
     signatureMessageTuple: (
       objectDigest: Digest32V1,
       role: SystemRecordSignatureRoleV1,
-    ) =>
-      descriptor.signatureMessageTuple(object, objectDigest, role),
+    ) => rolePolicy(rolePolicies, role, object.objectType).signatureMessageTuple(objectDigest),
   });
+}
+
+function defineRolePolicy(
+  role: SystemRecordSignatureRoleV1,
+  signatureMessageTuple: (objectDigest: Digest32V1) => CanonicalJsonValue,
+  issuer?: string,
+): SignableSystemRecordRolePolicyV1 {
+  return Object.freeze({ role, issuer, signatureMessageTuple });
+}
+
+function rolePolicy(
+  policies: readonly SignableSystemRecordRolePolicyV1[],
+  role: SystemRecordSignatureRoleV1,
+  objectType: string,
+): SignableSystemRecordRolePolicyV1 {
+  return policies.find((candidate) => candidate.role === role)
+    ?? invalidRole(role, objectType);
 }
 
 function recordKey(

--- a/packages/core/src/system-record-signature-policy-v1-internal.ts
+++ b/packages/core/src/system-record-signature-policy-v1-internal.ts
@@ -28,7 +28,6 @@ import {
   concatSystemRecordBytesV1,
   decodeUnpaddedBase64UrlV1,
   failSystemRecordObjectV1 as fail,
-  systemRecordHexToBytesV1,
 } from './system-record-codec-primitives-v1.js';
 import {
   SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
@@ -105,6 +104,10 @@ export function validateSystemRecordSignatureEntryV1(
 }
 
 export function assertCanonicalEip191SignatureV1(value: unknown): asserts value is string {
+  decodeCanonicalEip191SignatureV1(value);
+}
+
+export function decodeCanonicalEip191SignatureV1(value: unknown): Uint8Array {
   try {
     assertCanonicalHexBytes(
       value,
@@ -115,7 +118,7 @@ export function assertCanonicalEip191SignatureV1(value: unknown): asserts value 
   } catch (cause) {
     fail('system-record-signature', 'EIP-191 signature bytes are invalid', cause);
   }
-  const bytes = systemRecordHexToBytesV1(value as string);
+  const bytes = Uint8Array.from(Buffer.from((value as string).slice(2), 'hex'));
   const s = bytesToBigInt(bytes.subarray(32, 64));
   if (s === 0n || s > SYSTEM_RECORD_EIP191_MAX_S) {
     fail('system-record-signature', 'EIP-191 signature must use canonical low-s form');
@@ -128,6 +131,7 @@ export function assertCanonicalEip191SignatureV1(value: unknown): asserts value 
   if (bytes[64] !== 27 && bytes[64] !== 28) {
     fail('system-record-signature', 'EIP-191 recovery byte must be 27 or 28');
   }
+  return bytes;
 }
 
 export function buildSystemRecordSignatureMessageV1(

--- a/packages/core/src/system-record-signature-policy-v1-internal.ts
+++ b/packages/core/src/system-record-signature-policy-v1-internal.ts
@@ -1,0 +1,244 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+import {
+  canonicalizeJsonBytes,
+  type CanonicalJsonValue,
+} from './canonical-json.js';
+import { type NetworkIdV1 } from './sync-wire-identifiers.js';
+import { snapshotExactDataRecord } from './sync-wire-objects.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalDecimalU64,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertCanonicalHexBytes,
+  type Digest32V1,
+} from './sync-wire-scalars.js';
+import {
+  validateAuthorityTransition,
+  validateForkResolution,
+  type AgentProfileAuthorityTransitionV1,
+  type AgentProfileForkResolutionV1,
+  type SystemRecordEip1271EvidenceV1,
+  type SystemRecordNoSignatureEvidenceV1,
+  type SystemRecordSignatureEntryV1,
+  type SystemRecordSignatureRoleV1,
+} from './system-record-agent-profile-control-codecs-v1-internal.js';
+import {
+  validateAgentProfileHeadObjectV1,
+  type AgentProfileHeadObjectV1,
+} from './system-record-agent-profile-head-codec-v1-internal.js';
+import {
+  digest,
+  numericChainIdForNetworkV1,
+  snapshotSystemRecordDataRecord,
+} from './system-record-agent-profile-primitives-v1-internal.js';
+import {
+  concatSystemRecordBytesV1,
+  decodeUnpaddedBase64UrlV1,
+  failSystemRecordObjectV1 as fail,
+  systemRecordHexToBytesV1,
+} from './system-record-codec-primitives-v1.js';
+import {
+  SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
+  SYSTEM_RECORD_EIP191_MAX_S,
+  SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
+  SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
+  SYSTEM_RECORD_SIGNATURE_DOMAINS_V1,
+} from './system-record-limits-v1.js';
+
+const UTF8 = new TextEncoder();
+
+const SIGNATURE_ROLE_ORDER: Readonly<Record<SystemRecordSignatureRoleV1, number>> = {
+  peer: 0,
+  'prior-evm': 1,
+  'next-evm': 2,
+  'current-evm': 3,
+};
+
+type SignableSystemRecordObjectV1 =
+  | AgentProfileHeadObjectV1
+  | AgentProfileAuthorityTransitionV1
+  | AgentProfileForkResolutionV1;
+
+export function validateSystemRecordSignatureEntryV1(
+  value: unknown,
+  requiredRole: SystemRecordSignatureRoleV1,
+  object: SignableSystemRecordObjectV1,
+): SystemRecordSignatureEntryV1 {
+  const entry = snapshotExactDataRecord(
+    value,
+    ['role', 'suite', 'signer', 'evidence', 'signature'],
+    `signature entry ${requiredRole}`,
+  );
+  if (entry.role !== requiredRole || SIGNATURE_ROLE_ORDER[requiredRole] === undefined) {
+    fail('system-record-signature', 'signature roles are missing, extra, duplicated, or reordered');
+  }
+  const isPeer = requiredRole === 'peer';
+  let evidence: SystemRecordSignatureEntryV1['evidence'];
+  if (isPeer) {
+    if (entry.suite !== 'ed25519-v1' || entry.signer !== object.peerId) {
+      fail('system-record-signature', 'peer signature suite/signer is invalid');
+    }
+    evidence = exactNoneEvidence(entry.evidence);
+    decodeUnpaddedBase64UrlV1(
+      entry.signature,
+      SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
+      'Ed25519 signature',
+    );
+  } else {
+    const issuer = issuerForRole(object, requiredRole);
+    if (entry.signer !== issuer) {
+      fail('system-record-signature', `${requiredRole} signer does not match the object authority`);
+    }
+    if (entry.suite === 'eip191-personal-sign-digest-v1') {
+      evidence = exactNoneEvidence(entry.evidence);
+      assertCanonicalEip191SignatureV1(entry.signature);
+    } else if (entry.suite === 'eip1271-current-finalized-v1') {
+      evidence = validateEip1271Evidence(entry.evidence, issuer, object.networkId);
+      try {
+        assertCanonicalHexBytes(
+          entry.signature,
+          'EIP-1271 signature',
+          1,
+          SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
+        );
+      } catch (cause) {
+        fail('system-record-signature', 'EIP-1271 signature bytes are invalid', cause);
+      }
+    } else {
+      fail('system-record-signature', 'EVM signature suite is invalid');
+    }
+  }
+  return Object.freeze({ ...entry, evidence }) as unknown as SystemRecordSignatureEntryV1;
+}
+
+export function assertCanonicalEip191SignatureV1(value: unknown): asserts value is string {
+  try {
+    assertCanonicalHexBytes(
+      value,
+      'EIP-191 signature',
+      SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
+      SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
+    );
+  } catch (cause) {
+    fail('system-record-signature', 'EIP-191 signature bytes are invalid', cause);
+  }
+  const bytes = systemRecordHexToBytesV1(value as string);
+  const s = bytesToBigInt(bytes.subarray(32, 64));
+  if (s === 0n || s > SYSTEM_RECORD_EIP191_MAX_S) {
+    fail('system-record-signature', 'EIP-191 signature must use canonical low-s form');
+  }
+  try {
+    secp256k1.Signature.fromBytes(bytes.subarray(0, 64), 'compact');
+  } catch (cause) {
+    fail('system-record-signature', 'EIP-191 compact signature is not canonical', cause);
+  }
+  if (bytes[64] !== 27 && bytes[64] !== 28) {
+    fail('system-record-signature', 'EIP-191 recovery byte must be 27 or 28');
+  }
+}
+
+export function buildSystemRecordSignatureMessageV1(
+  object: SignableSystemRecordObjectV1,
+  objectDigest: Digest32V1,
+  role: SystemRecordSignatureRoleV1,
+): Uint8Array {
+  digest(objectDigest, 'objectDigest');
+  const validatedObject = validateSignableObject(object);
+  const recordKey: CanonicalJsonValue = [validatedObject.networkId, validatedObject.peerId];
+  let tuple: CanonicalJsonValue;
+  if (validatedObject.objectType === 'agent-profile-head') {
+    if (role !== 'peer' && role !== 'current-evm')
+      fail('system-record-signature', 'head role is invalid');
+    tuple = [
+      'agent-profile-head', objectDigest, validatedObject.networkId, recordKey,
+      validatedObject.authoritySequence, validatedObject.version,
+      ...(role === 'peer' ? [] : ['current-evm', validatedObject.evmIssuer]),
+    ];
+  } else if (validatedObject.objectType === 'authority-transition') {
+    if (role !== 'peer' && role !== 'prior-evm' && role !== 'next-evm') {
+      fail('system-record-signature', 'transition role is invalid');
+    }
+    tuple = [
+      'authority-transition', objectDigest, validatedObject.networkId, recordKey,
+      validatedObject.priorAuthoritySequence, validatedObject.nextAuthoritySequence,
+      validatedObject.priorHeadDigest, role,
+      ...(role === 'peer' ? [] : [issuerForRole(validatedObject, role)]),
+    ];
+  } else {
+    if (role !== 'peer' && role !== 'current-evm')
+      fail('system-record-signature', 'resolution role is invalid');
+    tuple = [
+      'fork-resolution', objectDigest, validatedObject.networkId, recordKey,
+      validatedObject.authoritySequence, validatedObject.forkedVersion,
+      validatedObject.resolutionVersion, role,
+      ...(role === 'peer' ? [] : [validatedObject.evmIssuer]),
+    ];
+  }
+  const domain = role === 'peer'
+    ? SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.peer
+    : SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.evm;
+  return concatSystemRecordBytesV1(UTF8.encode(domain), canonicalizeJsonBytes(tuple));
+}
+
+function validateSignableObject(object: SignableSystemRecordObjectV1): SignableSystemRecordObjectV1 {
+  const record = snapshotSystemRecordDataRecord(object, 'signed envelope object');
+  if (record.objectType === 'agent-profile-head') return validateAgentProfileHeadObjectV1(record);
+  if (record.objectType === 'authority-transition') return validateAuthorityTransition(record);
+  if (record.objectType === 'fork-resolution') return validateForkResolution(record);
+  fail('system-record-schema', 'signed envelope object type is unsupported');
+}
+
+function validateEip1271Evidence(
+  value: unknown,
+  issuer: string,
+  networkId: NetworkIdV1,
+): SystemRecordEip1271EvidenceV1 {
+  const evidence = snapshotExactDataRecord(
+    value,
+    ['kind', 'chainId', 'contractAddress', 'finalizedBlockNumber', 'finalizedBlockHash'],
+    'EIP-1271 evidence',
+  );
+  if (evidence.kind !== 'eip1271-current-finalized') {
+    fail('system-record-signature', 'EIP-1271 evidence kind is invalid');
+  }
+  try {
+    assertCanonicalChainId(evidence.chainId);
+    assertCanonicalEvmAddress(evidence.contractAddress);
+    assertCanonicalDecimalU64(evidence.finalizedBlockNumber);
+    assertCanonicalDigest(evidence.finalizedBlockHash);
+  } catch (cause) {
+    fail('system-record-signature', 'EIP-1271 finalized evidence is invalid', cause);
+  }
+  if (evidence.contractAddress !== issuer) {
+    fail('system-record-binding', 'EIP-1271 contract does not match signer');
+  }
+  if (evidence.chainId !== numericChainIdForNetworkV1(networkId)) {
+    fail('system-record-binding', 'EIP-1271 evidence chainId does not match the record network');
+  }
+  return Object.freeze({ ...evidence }) as unknown as SystemRecordEip1271EvidenceV1;
+}
+
+function exactNoneEvidence(value: unknown): SystemRecordNoSignatureEvidenceV1 {
+  const evidence = snapshotExactDataRecord(value, ['kind'], 'signature evidence');
+  if (evidence.kind !== 'none') fail('system-record-signature', 'signature evidence must be none');
+  return Object.freeze({ kind: 'none' });
+}
+
+function issuerForRole(
+  object: SignableSystemRecordObjectV1,
+  role: Exclude<SystemRecordSignatureRoleV1, 'peer'>,
+): string {
+  if (object.objectType === 'authority-transition') {
+    if (role === 'prior-evm') return object.priorEvmIssuer;
+    if (role === 'next-evm') return object.nextEvmIssuer;
+  } else if (role === 'current-evm') {
+    return object.evmIssuer;
+  }
+  fail('system-record-signature', `${role} is not valid for ${object.objectType}`);
+}
+
+function bytesToBigInt(value: Uint8Array): bigint {
+  return BigInt(`0x${Buffer.from(value).toString('hex')}`);
+}

--- a/packages/core/src/system-record-signature-policy-v1-internal.ts
+++ b/packages/core/src/system-record-signature-policy-v1-internal.ts
@@ -15,23 +15,14 @@ import {
   type Digest32V1,
 } from './sync-wire-scalars.js';
 import {
-  validateAuthorityTransition,
-  validateForkResolution,
-  type AgentProfileAuthorityTransitionV1,
-  type AgentProfileForkResolutionV1,
   type SystemRecordEip1271EvidenceV1,
   type SystemRecordNoSignatureEvidenceV1,
   type SystemRecordSignatureEntryV1,
   type SystemRecordSignatureRoleV1,
 } from './system-record-agent-profile-control-codecs-v1-internal.js';
 import {
-  validateAgentProfileHeadObjectV1,
-  type AgentProfileHeadObjectV1,
-} from './system-record-agent-profile-head-codec-v1-internal.js';
-import {
   digest,
   numericChainIdForNetworkV1,
-  snapshotSystemRecordDataRecord,
 } from './system-record-agent-profile-primitives-v1-internal.js';
 import {
   concatSystemRecordBytesV1,
@@ -46,6 +37,11 @@ import {
   SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
   SYSTEM_RECORD_SIGNATURE_DOMAINS_V1,
 } from './system-record-limits-v1.js';
+import {
+  bindSignableSystemRecordPolicyV1,
+  type BoundSignableSystemRecordPolicyV1,
+  type SignableSystemRecordObjectV1,
+} from './system-record-signable-object-policy-v1-internal.js';
 
 const UTF8 = new TextEncoder();
 
@@ -56,15 +52,10 @@ const SIGNATURE_ROLE_ORDER: Readonly<Record<SystemRecordSignatureRoleV1, number>
   'current-evm': 3,
 };
 
-type SignableSystemRecordObjectV1 =
-  | AgentProfileHeadObjectV1
-  | AgentProfileAuthorityTransitionV1
-  | AgentProfileForkResolutionV1;
-
 export function validateSystemRecordSignatureEntryV1(
   value: unknown,
   requiredRole: SystemRecordSignatureRoleV1,
-  object: SignableSystemRecordObjectV1,
+  policy: BoundSignableSystemRecordPolicyV1,
 ): SystemRecordSignatureEntryV1 {
   const entry = snapshotExactDataRecord(
     value,
@@ -77,7 +68,7 @@ export function validateSystemRecordSignatureEntryV1(
   const isPeer = requiredRole === 'peer';
   let evidence: SystemRecordSignatureEntryV1['evidence'];
   if (isPeer) {
-    if (entry.suite !== 'ed25519-v1' || entry.signer !== object.peerId) {
+    if (entry.suite !== 'ed25519-v1' || entry.signer !== policy.object.peerId) {
       fail('system-record-signature', 'peer signature suite/signer is invalid');
     }
     evidence = exactNoneEvidence(entry.evidence);
@@ -87,7 +78,7 @@ export function validateSystemRecordSignatureEntryV1(
       'Ed25519 signature',
     );
   } else {
-    const issuer = issuerForRole(object, requiredRole);
+    const issuer = policy.issuerForRole(requiredRole);
     if (entry.signer !== issuer) {
       fail('system-record-signature', `${requiredRole} signer does not match the object authority`);
     }
@@ -95,7 +86,7 @@ export function validateSystemRecordSignatureEntryV1(
       evidence = exactNoneEvidence(entry.evidence);
       assertCanonicalEip191SignatureV1(entry.signature);
     } else if (entry.suite === 'eip1271-current-finalized-v1') {
-      evidence = validateEip1271Evidence(entry.evidence, issuer, object.networkId);
+      evidence = validateEip1271Evidence(entry.evidence, issuer, policy.object.networkId);
       try {
         assertCanonicalHexBytes(
           entry.signature,
@@ -144,50 +135,24 @@ export function buildSystemRecordSignatureMessageV1(
   objectDigest: Digest32V1,
   role: SystemRecordSignatureRoleV1,
 ): Uint8Array {
+  return buildSystemRecordSignatureMessageFromPolicyV1(
+    bindSignableSystemRecordPolicyV1(object),
+    objectDigest,
+    role,
+  );
+}
+
+export function buildSystemRecordSignatureMessageFromPolicyV1(
+  policy: BoundSignableSystemRecordPolicyV1,
+  objectDigest: Digest32V1,
+  role: SystemRecordSignatureRoleV1,
+): Uint8Array {
   digest(objectDigest, 'objectDigest');
-  const validatedObject = validateSignableObject(object);
-  const recordKey: CanonicalJsonValue = [validatedObject.networkId, validatedObject.peerId];
-  let tuple: CanonicalJsonValue;
-  if (validatedObject.objectType === 'agent-profile-head') {
-    if (role !== 'peer' && role !== 'current-evm')
-      fail('system-record-signature', 'head role is invalid');
-    tuple = [
-      'agent-profile-head', objectDigest, validatedObject.networkId, recordKey,
-      validatedObject.authoritySequence, validatedObject.version,
-      ...(role === 'peer' ? [] : ['current-evm', validatedObject.evmIssuer]),
-    ];
-  } else if (validatedObject.objectType === 'authority-transition') {
-    if (role !== 'peer' && role !== 'prior-evm' && role !== 'next-evm') {
-      fail('system-record-signature', 'transition role is invalid');
-    }
-    tuple = [
-      'authority-transition', objectDigest, validatedObject.networkId, recordKey,
-      validatedObject.priorAuthoritySequence, validatedObject.nextAuthoritySequence,
-      validatedObject.priorHeadDigest, role,
-      ...(role === 'peer' ? [] : [issuerForRole(validatedObject, role)]),
-    ];
-  } else {
-    if (role !== 'peer' && role !== 'current-evm')
-      fail('system-record-signature', 'resolution role is invalid');
-    tuple = [
-      'fork-resolution', objectDigest, validatedObject.networkId, recordKey,
-      validatedObject.authoritySequence, validatedObject.forkedVersion,
-      validatedObject.resolutionVersion, role,
-      ...(role === 'peer' ? [] : [validatedObject.evmIssuer]),
-    ];
-  }
+  const tuple: CanonicalJsonValue = policy.signatureMessageTuple(objectDigest, role);
   const domain = role === 'peer'
     ? SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.peer
     : SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.evm;
   return concatSystemRecordBytesV1(UTF8.encode(domain), canonicalizeJsonBytes(tuple));
-}
-
-function validateSignableObject(object: SignableSystemRecordObjectV1): SignableSystemRecordObjectV1 {
-  const record = snapshotSystemRecordDataRecord(object, 'signed envelope object');
-  if (record.objectType === 'agent-profile-head') return validateAgentProfileHeadObjectV1(record);
-  if (record.objectType === 'authority-transition') return validateAuthorityTransition(record);
-  if (record.objectType === 'fork-resolution') return validateForkResolution(record);
-  fail('system-record-schema', 'signed envelope object type is unsupported');
 }
 
 function validateEip1271Evidence(
@@ -224,19 +189,6 @@ function exactNoneEvidence(value: unknown): SystemRecordNoSignatureEvidenceV1 {
   const evidence = snapshotExactDataRecord(value, ['kind'], 'signature evidence');
   if (evidence.kind !== 'none') fail('system-record-signature', 'signature evidence must be none');
   return Object.freeze({ kind: 'none' });
-}
-
-function issuerForRole(
-  object: SignableSystemRecordObjectV1,
-  role: Exclude<SystemRecordSignatureRoleV1, 'peer'>,
-): string {
-  if (object.objectType === 'authority-transition') {
-    if (role === 'prior-evm') return object.priorEvmIssuer;
-    if (role === 'next-evm') return object.nextEvmIssuer;
-  } else if (role === 'current-evm') {
-    return object.evmIssuer;
-  }
-  fail('system-record-signature', `${role} is not valid for ${object.objectType}`);
 }
 
 function bytesToBigInt(value: Uint8Array): bigint {

--- a/packages/core/src/system-record-signatures-v1-internal.ts
+++ b/packages/core/src/system-record-signatures-v1-internal.ts
@@ -10,9 +10,11 @@ import {
 } from './system-record-agent-profile-control-codecs-v1-internal.js';
 import { type AgentProfileHeadObjectV1 } from './system-record-agent-profile-head-codec-v1-internal.js';
 import {
+  concatSystemRecordBytesV1,
   copyBoundedSystemRecordBytesV1,
   decodeUnpaddedBase64UrlV1,
   failSystemRecordObjectV1 as fail,
+  systemRecordHexToBytesV1,
 } from './system-record-codec-primitives-v1.js';
 import {
   SYSTEM_RECORD_ED25519_PUBLIC_KEY_BYTES,
@@ -20,25 +22,27 @@ import {
   SYSTEM_RECORD_OBJECT_CAPS_V1,
 } from './system-record-limits-v1.js';
 import {
-  assertCanonicalEip191SignatureV1,
-  buildSystemRecordSignatureMessageV1,
-  concatSystemRecordBytesV1,
-  systemRecordHexToBytesV1,
   validateDispatchedSignedEnvelopeV1,
 } from './system-record-signed-envelope-codecs-v1-internal.js';
+import {
+  assertCanonicalEip191SignatureV1,
+  buildSystemRecordSignatureMessageV1,
+} from './system-record-signature-policy-v1-internal.js';
 
 export {
-  assertCanonicalEip191SignatureV1,
   assertSignedAgentProfileAuthorityTransitionEnvelopeV1,
   assertSignedAgentProfileForkResolutionEnvelopeV1,
   assertSignedAgentProfileHeadEnvelopeV1,
-  buildSystemRecordSignatureMessageV1,
   canonicalizeSignedSystemRecordEnvelopeV1,
   computeSignedSystemRecordEnvelopeDigestV1,
   parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
   parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
   parseCanonicalSignedAgentProfileHeadEnvelopeV1,
 } from './system-record-signed-envelope-codecs-v1-internal.js';
+export {
+  assertCanonicalEip191SignatureV1,
+  buildSystemRecordSignatureMessageV1,
+} from './system-record-signature-policy-v1-internal.js';
 
 const UTF8 = new TextEncoder();
 

--- a/packages/core/src/system-record-signatures-v1-internal.ts
+++ b/packages/core/src/system-record-signatures-v1-internal.ts
@@ -26,7 +26,7 @@ import {
 } from './system-record-signed-envelope-codecs-v1-internal.js';
 import {
   assertCanonicalEip191SignatureV1,
-  buildSystemRecordSignatureMessageV1,
+  buildSystemRecordSignatureMessageFromPolicyV1,
 } from './system-record-signature-policy-v1-internal.js';
 
 export {
@@ -65,17 +65,15 @@ export async function verifySignedSystemRecordEnvelopeV1<
 ): Promise<boolean> {
   const verifyEip1271 = options.verifyEip1271;
   if (verifyEip1271 !== undefined && typeof verifyEip1271 !== 'function') return false;
-  const { validated } = validateDispatchedSignedEnvelopeV1(envelope) as {
-    readonly validated: SignedSystemRecordEnvelopeV1<T>;
-  };
+  const { validated, policy } = validateDispatchedSignedEnvelopeV1(envelope);
   const publicKey = decodeUnpaddedBase64UrlV1(
     validated.object.peerPublicKey,
     SYSTEM_RECORD_ED25519_PUBLIC_KEY_BYTES,
     'peerPublicKey',
   );
   for (const entry of validated.signatures) {
-    const message = buildSystemRecordSignatureMessageV1(
-      validated.object,
+    const message = buildSystemRecordSignatureMessageFromPolicyV1(
+      policy,
       validated.objectDigest,
       entry.role,
     );

--- a/packages/core/src/system-record-signatures-v1-internal.ts
+++ b/packages/core/src/system-record-signatures-v1-internal.ts
@@ -1,354 +1,46 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { verifyAsync as verifyEd25519 } from '@noble/ed25519';
 
-import {
-  canonicalizeJsonBytes,
-  parseCanonicalJson,
-  type CanonicalJsonValue,
-} from './canonical-json.js';
 import { keccak256 } from './crypto/keccak.js';
-import { type NetworkIdV1 } from './sync-wire-identifiers.js';
-import { snapshotDataArray, snapshotExactDataRecord } from './sync-wire-objects.js';
 import {
-  assertCanonicalChainId,
-  assertCanonicalDecimalU64,
-  assertCanonicalDigest,
-  assertCanonicalEvmAddress,
-  assertCanonicalHexBytes,
-  type Digest32V1,
-} from './sync-wire-scalars.js';
-import {
-  computeAgentProfileAuthorityTransitionDigestV1,
-  computeAgentProfileForkResolutionDigestV1,
-  validateAuthorityTransition,
-  validateForkResolution,
   type AgentProfileAuthorityTransitionV1,
   type AgentProfileForkResolutionV1,
-  type SignedAgentProfileAuthorityTransitionEnvelopeV1,
-  type SignedAgentProfileForkResolutionEnvelopeV1,
-  type SignedAgentProfileHeadEnvelopeV1,
   type SignedSystemRecordEnvelopeV1,
-  type SystemRecordEip1271EvidenceV1,
-  type SystemRecordNoSignatureEvidenceV1,
   type SystemRecordSignatureEntryV1,
-  type SystemRecordSignatureRoleV1,
 } from './system-record-agent-profile-control-codecs-v1-internal.js';
-import {
-  computeAgentProfileHeadObjectDigestV1,
-  validateAgentProfileHeadObjectV1,
-  type AgentProfileHeadObjectV1,
-} from './system-record-agent-profile-head-codec-v1-internal.js';
-import {
-  digest,
-  numericChainIdForNetworkV1,
-  snapshotSystemRecordDataRecord,
-} from './system-record-agent-profile-primitives-v1-internal.js';
+import { type AgentProfileHeadObjectV1 } from './system-record-agent-profile-head-codec-v1-internal.js';
 import {
   copyBoundedSystemRecordBytesV1,
   decodeUnpaddedBase64UrlV1,
-  digestSystemRecordBytesV1,
   failSystemRecordObjectV1 as fail,
 } from './system-record-codec-primitives-v1.js';
 import {
-  SYSTEM_RECORD_DIGEST_DOMAINS_V1,
   SYSTEM_RECORD_ED25519_PUBLIC_KEY_BYTES,
   SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
-  SYSTEM_RECORD_EIP191_MAX_S,
-  SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
-  SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
-  SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
-  SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
   SYSTEM_RECORD_OBJECT_CAPS_V1,
-  SYSTEM_RECORD_SIGNATURE_DOMAINS_V1,
 } from './system-record-limits-v1.js';
+import {
+  assertCanonicalEip191SignatureV1,
+  buildSystemRecordSignatureMessageV1,
+  concatSystemRecordBytesV1,
+  systemRecordHexToBytesV1,
+  validateDispatchedSignedEnvelopeV1,
+} from './system-record-signed-envelope-codecs-v1-internal.js';
+
+export {
+  assertCanonicalEip191SignatureV1,
+  assertSignedAgentProfileAuthorityTransitionEnvelopeV1,
+  assertSignedAgentProfileForkResolutionEnvelopeV1,
+  assertSignedAgentProfileHeadEnvelopeV1,
+  buildSystemRecordSignatureMessageV1,
+  canonicalizeSignedSystemRecordEnvelopeV1,
+  computeSignedSystemRecordEnvelopeDigestV1,
+  parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
+  parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
+  parseCanonicalSignedAgentProfileHeadEnvelopeV1,
+} from './system-record-signed-envelope-codecs-v1-internal.js';
 
 const UTF8 = new TextEncoder();
-
-const SIGNATURE_ROLE_ORDER: Readonly<Record<SystemRecordSignatureRoleV1, number>> = {
-  peer: 0,
-  'prior-evm': 1,
-  'next-evm': 2,
-  'current-evm': 3,
-};
-
-export function assertSignedAgentProfileHeadEnvelopeV1(
-  value: unknown,
-): asserts value is SignedAgentProfileHeadEnvelopeV1 {
-  validateSignedEnvelope(value, 'head');
-}
-
-export function assertSignedAgentProfileAuthorityTransitionEnvelopeV1(
-  value: unknown,
-): asserts value is SignedAgentProfileAuthorityTransitionEnvelopeV1 {
-  validateSignedEnvelope(value, 'transition');
-}
-
-export function assertSignedAgentProfileForkResolutionEnvelopeV1(
-  value: unknown,
-): asserts value is SignedAgentProfileForkResolutionEnvelopeV1 {
-  validateSignedEnvelope(value, 'fork');
-}
-
-export function canonicalizeSignedSystemRecordEnvelopeV1<T>(
-  value: SignedSystemRecordEnvelopeV1<T>,
-): Uint8Array {
-  const { kind, validated } = validateDispatchedSignedEnvelope(value);
-  return canonicalizeJsonBytes(validated as unknown as CanonicalJsonValue, {
-    maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1[objectKindForEnvelope(kind)],
-  });
-}
-
-export function computeSignedSystemRecordEnvelopeDigestV1<T>(
-  value: SignedSystemRecordEnvelopeV1<T>,
-): Digest32V1 {
-  return digestSystemRecordBytesV1(
-    SYSTEM_RECORD_DIGEST_DOMAINS_V1.signedEnvelope,
-    canonicalizeSignedSystemRecordEnvelopeV1(value),
-  );
-}
-
-export function parseCanonicalSignedAgentProfileHeadEnvelopeV1(
-  input: string | Uint8Array,
-): SignedAgentProfileHeadEnvelopeV1 {
-  return validateSignedEnvelope(
-    parseCanonicalJson(input, {
-      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['agent-profile-head'],
-      maxDepth: SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
-    }),
-    'head',
-  ) as SignedAgentProfileHeadEnvelopeV1;
-}
-
-export function parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(
-  input: string | Uint8Array,
-): SignedAgentProfileAuthorityTransitionEnvelopeV1 {
-  return validateSignedEnvelope(
-    parseCanonicalJson(input, {
-      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['authority-transition'],
-      maxDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
-    }),
-    'transition',
-  ) as SignedAgentProfileAuthorityTransitionEnvelopeV1;
-}
-
-export function parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(
-  input: string | Uint8Array,
-): SignedAgentProfileForkResolutionEnvelopeV1 {
-  return validateSignedEnvelope(
-    parseCanonicalJson(input, {
-      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['fork-resolution'],
-      maxDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
-    }),
-    'fork',
-  ) as SignedAgentProfileForkResolutionEnvelopeV1;
-}
-
-function validateSignedEnvelope(
-  value: unknown,
-  kind: 'head' | 'transition' | 'fork',
-): SignedSystemRecordEnvelopeV1<unknown> {
-  const envelope = snapshotExactDataRecord(
-    value,
-    ['object', 'objectDigest', 'signatures'],
-    'signed system-record envelope',
-  );
-  const object =
-    kind === 'head'
-      ? validateAgentProfileHeadObjectV1(envelope.object)
-      : kind === 'transition'
-        ? validateAuthorityTransition(envelope.object)
-        : validateForkResolution(envelope.object);
-  const expectedDigest =
-    kind === 'head'
-      ? computeAgentProfileHeadObjectDigestV1(object as AgentProfileHeadObjectV1)
-      : kind === 'transition'
-        ? computeAgentProfileAuthorityTransitionDigestV1(
-            object as AgentProfileAuthorityTransitionV1,
-          )
-        : computeAgentProfileForkResolutionDigestV1(object as AgentProfileForkResolutionV1);
-  digest(envelope.objectDigest, 'objectDigest');
-  if (envelope.objectDigest !== expectedDigest) {
-    fail('system-record-binding', 'signed envelope objectDigest does not match the object');
-  }
-  const requiredRoles: readonly SystemRecordSignatureRoleV1[] =
-    kind === 'transition'
-      ? (object as AgentProfileAuthorityTransitionV1).mode === 'co-signed'
-        ? ['peer', 'prior-evm', 'next-evm']
-        : ['peer', 'next-evm']
-      : ['peer', 'current-evm'];
-  let signatureEntries: readonly unknown[];
-  try {
-    signatureEntries = snapshotDataArray(envelope.signatures, 'signed envelope signatures', {
-      minLength: requiredRoles.length,
-      maxLength: requiredRoles.length,
-    });
-  } catch (cause) {
-    fail(
-      'system-record-signature',
-      'signed envelope has the wrong closed signature cardinality',
-      cause,
-    );
-  }
-  const signatures = signatureEntries.map((entry, index) =>
-    validateSignatureEntry(entry, requiredRoles[index], object),
-  );
-  return Object.freeze({
-    object,
-    objectDigest: envelope.objectDigest,
-    signatures: Object.freeze(signatures),
-  });
-}
-
-function validateSignatureEntry(
-  value: unknown,
-  requiredRole: SystemRecordSignatureRoleV1,
-  object:
-    | AgentProfileHeadObjectV1
-    | AgentProfileAuthorityTransitionV1
-    | AgentProfileForkResolutionV1,
-): SystemRecordSignatureEntryV1 {
-  const entry = snapshotExactDataRecord(
-    value,
-    ['role', 'suite', 'signer', 'evidence', 'signature'],
-    `signature entry ${requiredRole}`,
-  );
-  if (entry.role !== requiredRole || SIGNATURE_ROLE_ORDER[requiredRole] === undefined) {
-    fail('system-record-signature', 'signature roles are missing, extra, duplicated, or reordered');
-  }
-  const isPeer = requiredRole === 'peer';
-  let evidence: SystemRecordSignatureEntryV1['evidence'];
-  if (isPeer) {
-    if (entry.suite !== 'ed25519-v1' || entry.signer !== object.peerId) {
-      fail('system-record-signature', 'peer signature suite/signer is invalid');
-    }
-    evidence = exactNoneEvidence(entry.evidence);
-    decodeUnpaddedBase64UrlV1(
-      entry.signature,
-      SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
-      'Ed25519 signature',
-    );
-  } else {
-    const issuer = issuerForRole(object, requiredRole);
-    if (entry.signer !== issuer) {
-      fail('system-record-signature', `${requiredRole} signer does not match the object authority`);
-    }
-    if (entry.suite === 'eip191-personal-sign-digest-v1') {
-      evidence = exactNoneEvidence(entry.evidence);
-      assertCanonicalEip191SignatureV1(entry.signature);
-    } else if (entry.suite === 'eip1271-current-finalized-v1') {
-      evidence = validateEip1271Evidence(entry.evidence, issuer, object.networkId);
-      try {
-        assertCanonicalHexBytes(
-          entry.signature,
-          'EIP-1271 signature',
-          1,
-          SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
-        );
-      } catch (cause) {
-        fail('system-record-signature', 'EIP-1271 signature bytes are invalid', cause);
-      }
-    } else {
-      fail('system-record-signature', 'EVM signature suite is invalid');
-    }
-  }
-  return Object.freeze({
-    ...entry,
-    evidence,
-  }) as unknown as SystemRecordSignatureEntryV1;
-}
-
-export function assertCanonicalEip191SignatureV1(value: unknown): asserts value is string {
-  try {
-    assertCanonicalHexBytes(
-      value,
-      'EIP-191 signature',
-      SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
-      SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
-    );
-  } catch (cause) {
-    fail('system-record-signature', 'EIP-191 signature bytes are invalid', cause);
-  }
-  const bytes = hexToBytes(value as string);
-  const s = bytesToBigInt(bytes.subarray(32, 64));
-  if (s === 0n || s > SYSTEM_RECORD_EIP191_MAX_S) {
-    fail('system-record-signature', 'EIP-191 signature must use canonical low-s form');
-  }
-  try {
-    secp256k1.Signature.fromBytes(bytes.subarray(0, 64), 'compact');
-  } catch (cause) {
-    fail('system-record-signature', 'EIP-191 compact signature is not canonical', cause);
-  }
-  if (bytes[64] !== 27 && bytes[64] !== 28) {
-    fail('system-record-signature', 'EIP-191 recovery byte must be 27 or 28');
-  }
-}
-
-export function buildSystemRecordSignatureMessageV1(
-  object:
-    | AgentProfileHeadObjectV1
-    | AgentProfileAuthorityTransitionV1
-    | AgentProfileForkResolutionV1,
-  objectDigest: Digest32V1,
-  role: SystemRecordSignatureRoleV1,
-): Uint8Array {
-  digest(objectDigest, 'objectDigest');
-  const kind = classifyEnvelopeObject(object);
-  const validatedObject =
-    kind === 'head'
-      ? validateAgentProfileHeadObjectV1(object)
-      : kind === 'transition'
-        ? validateAuthorityTransition(object)
-        : validateForkResolution(object);
-  const recordKey: CanonicalJsonValue = [validatedObject.networkId, validatedObject.peerId];
-  let tuple: CanonicalJsonValue;
-  if (validatedObject.objectType === 'agent-profile-head') {
-    if (role !== 'peer' && role !== 'current-evm')
-      fail('system-record-signature', 'head role is invalid');
-    tuple = [
-      'agent-profile-head',
-      objectDigest,
-      validatedObject.networkId,
-      recordKey,
-      validatedObject.authoritySequence,
-      validatedObject.version,
-      ...(role === 'peer' ? [] : ['current-evm', validatedObject.evmIssuer]),
-    ];
-  } else if (validatedObject.objectType === 'authority-transition') {
-    if (role !== 'peer' && role !== 'prior-evm' && role !== 'next-evm') {
-      fail('system-record-signature', 'transition role is invalid');
-    }
-    tuple = [
-      'authority-transition',
-      objectDigest,
-      validatedObject.networkId,
-      recordKey,
-      validatedObject.priorAuthoritySequence,
-      validatedObject.nextAuthoritySequence,
-      validatedObject.priorHeadDigest,
-      role,
-      ...(role === 'peer' ? [] : [issuerForRole(validatedObject, role)]),
-    ];
-  } else {
-    if (role !== 'peer' && role !== 'current-evm')
-      fail('system-record-signature', 'resolution role is invalid');
-    tuple = [
-      'fork-resolution',
-      objectDigest,
-      validatedObject.networkId,
-      recordKey,
-      validatedObject.authoritySequence,
-      validatedObject.forkedVersion,
-      validatedObject.resolutionVersion,
-      role,
-      ...(role === 'peer' ? [] : [validatedObject.evmIssuer]),
-    ];
-  }
-  const domain =
-    role === 'peer'
-      ? SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.peer
-      : SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.evm;
-  return concatBytes(UTF8.encode(domain), canonicalizeJsonBytes(tuple));
-}
 
 export interface VerifySystemRecordEnvelopeOptionsV1 {
   readonly verifyEip1271?: (
@@ -369,7 +61,7 @@ export async function verifySignedSystemRecordEnvelopeV1<
 ): Promise<boolean> {
   const verifyEip1271 = options.verifyEip1271;
   if (verifyEip1271 !== undefined && typeof verifyEip1271 !== 'function') return false;
-  const { validated } = validateDispatchedSignedEnvelope(envelope) as {
+  const { validated } = validateDispatchedSignedEnvelopeV1(envelope) as {
     readonly validated: SignedSystemRecordEnvelopeV1<T>;
   };
   const publicKey = decodeUnpaddedBase64UrlV1(
@@ -409,134 +101,30 @@ export function eip191PersonalMessageHashV1(message: Uint8Array): Uint8Array {
     'EIP-191 personal message',
   );
   const prefix = UTF8.encode(`\x19Ethereum Signed Message:\n${ownedMessage.byteLength}`);
-  return keccak256(concatBytes(prefix, ownedMessage));
+  return keccak256(concatSystemRecordBytesV1(prefix, ownedMessage));
 }
 
-export function recoverEip191SignerV1(signature: string, personalHash: Uint8Array): string {
+export function recoverEip191SignerV1(
+  signature: string,
+  personalHash: Uint8Array,
+): string {
   assertCanonicalEip191SignatureV1(signature);
   const ownedPersonalHash = copyBoundedSystemRecordBytesV1(
     personalHash,
     32,
     'EIP-191 personal message hash',
   );
-  if (ownedPersonalHash.byteLength !== 32)
+  if (ownedPersonalHash.byteLength !== 32) {
     fail('system-record-signature', 'personal message hash must be 32 bytes');
+  }
   try {
-    const bytes = hexToBytes(signature);
-    const compact = secp256k1.Signature.fromBytes(bytes.subarray(0, 64), 'compact').addRecoveryBit(
-      bytes[64] - 27,
-    );
+    const bytes = systemRecordHexToBytesV1(signature);
+    const compact = secp256k1.Signature
+      .fromBytes(bytes.subarray(0, 64), 'compact')
+      .addRecoveryBit(bytes[64] - 27);
     const publicKey = compact.recoverPublicKey(ownedPersonalHash).toBytes(false);
     return `0x${Buffer.from(keccak256(publicKey.subarray(1)).subarray(12)).toString('hex')}`;
   } catch (cause) {
     fail('system-record-signature', 'EIP-191 signature recovery failed', cause);
   }
-}
-
-function validateEip1271Evidence(
-  value: unknown,
-  issuer: string,
-  networkId: NetworkIdV1,
-): SystemRecordEip1271EvidenceV1 {
-  const evidence = snapshotExactDataRecord(
-    value,
-    ['kind', 'chainId', 'contractAddress', 'finalizedBlockNumber', 'finalizedBlockHash'],
-    'EIP-1271 evidence',
-  );
-  if (evidence.kind !== 'eip1271-current-finalized') {
-    fail('system-record-signature', 'EIP-1271 evidence kind is invalid');
-  }
-  try {
-    assertCanonicalChainId(evidence.chainId);
-    assertCanonicalEvmAddress(evidence.contractAddress);
-    assertCanonicalDecimalU64(evidence.finalizedBlockNumber);
-    assertCanonicalDigest(evidence.finalizedBlockHash);
-  } catch (cause) {
-    fail('system-record-signature', 'EIP-1271 finalized evidence is invalid', cause);
-  }
-  if (evidence.contractAddress !== issuer) {
-    fail('system-record-binding', 'EIP-1271 contract does not match signer');
-  }
-  const expectedChainId = numericChainIdForNetworkV1(networkId);
-  if (evidence.chainId !== expectedChainId) {
-    fail('system-record-binding', 'EIP-1271 evidence chainId does not match the record network');
-  }
-  return Object.freeze({
-    ...evidence,
-  }) as unknown as SystemRecordEip1271EvidenceV1;
-}
-
-function exactNoneEvidence(value: unknown): SystemRecordNoSignatureEvidenceV1 {
-  const evidence = snapshotExactDataRecord(value, ['kind'], 'signature evidence');
-  if (evidence.kind !== 'none') fail('system-record-signature', 'signature evidence must be none');
-  return Object.freeze({ kind: 'none' });
-}
-
-function issuerForRole(
-  object:
-    | AgentProfileHeadObjectV1
-    | AgentProfileAuthorityTransitionV1
-    | AgentProfileForkResolutionV1,
-  role: Exclude<SystemRecordSignatureRoleV1, 'peer'>,
-): string {
-  if (object.objectType === 'authority-transition') {
-    if (role === 'prior-evm') return object.priorEvmIssuer;
-    if (role === 'next-evm') return object.nextEvmIssuer;
-  } else if (role === 'current-evm') {
-    return object.evmIssuer;
-  }
-  fail('system-record-signature', `${role} is not valid for ${object.objectType}`);
-}
-
-function classifyEnvelopeObject(value: unknown): 'head' | 'transition' | 'fork' {
-  const record = snapshotSystemRecordDataRecord(value, 'signed envelope object');
-  if (record.objectType === 'agent-profile-head') return 'head';
-  if (record.objectType === 'authority-transition') return 'transition';
-  if (record.objectType === 'fork-resolution') return 'fork';
-  fail('system-record-schema', 'signed envelope object type is unsupported');
-}
-
-function validateDispatchedSignedEnvelope(value: unknown): {
-  readonly kind: 'head' | 'transition' | 'fork';
-  readonly validated: SignedSystemRecordEnvelopeV1<unknown>;
-} {
-  const envelope = snapshotExactDataRecord(
-    value,
-    ['object', 'objectDigest', 'signatures'],
-    'signed system-record envelope',
-  );
-  const kind = classifyEnvelopeObject(envelope.object);
-  return Object.freeze({
-    kind,
-    validated: validateSignedEnvelope(envelope, kind),
-  });
-}
-
-function objectKindForEnvelope(
-  value: 'head' | 'transition' | 'fork',
-): 'agent-profile-head' | 'authority-transition' | 'fork-resolution' {
-  return value === 'head'
-    ? 'agent-profile-head'
-    : value === 'transition'
-      ? 'authority-transition'
-      : 'fork-resolution';
-}
-
-function hexToBytes(value: string): Uint8Array {
-  return Uint8Array.from(Buffer.from(value.slice(2), 'hex'));
-}
-
-function bytesToBigInt(value: Uint8Array): bigint {
-  return BigInt(`0x${Buffer.from(value).toString('hex')}`);
-}
-
-function concatBytes(...values: readonly Uint8Array[]): Uint8Array {
-  const length = values.reduce((sum, value) => sum + value.byteLength, 0);
-  const result = new Uint8Array(length);
-  let offset = 0;
-  for (const value of values) {
-    result.set(value, offset);
-    offset += value.byteLength;
-  }
-  return result;
 }

--- a/packages/core/src/system-record-signatures-v1-internal.ts
+++ b/packages/core/src/system-record-signatures-v1-internal.ts
@@ -14,7 +14,6 @@ import {
   copyBoundedSystemRecordBytesV1,
   decodeUnpaddedBase64UrlV1,
   failSystemRecordObjectV1 as fail,
-  systemRecordHexToBytesV1,
 } from './system-record-codec-primitives-v1.js';
 import {
   SYSTEM_RECORD_ED25519_PUBLIC_KEY_BYTES,
@@ -27,6 +26,7 @@ import {
 import {
   assertCanonicalEip191SignatureV1,
   buildSystemRecordSignatureMessageFromPolicyV1,
+  decodeCanonicalEip191SignatureV1,
 } from './system-record-signature-policy-v1-internal.js';
 
 export {
@@ -110,7 +110,7 @@ export function recoverEip191SignerV1(
   signature: string,
   personalHash: Uint8Array,
 ): string {
-  assertCanonicalEip191SignatureV1(signature);
+  const bytes = decodeCanonicalEip191SignatureV1(signature);
   const ownedPersonalHash = copyBoundedSystemRecordBytesV1(
     personalHash,
     32,
@@ -120,7 +120,6 @@ export function recoverEip191SignerV1(
     fail('system-record-signature', 'personal message hash must be 32 bytes');
   }
   try {
-    const bytes = systemRecordHexToBytesV1(signature);
     const compact = secp256k1.Signature
       .fromBytes(bytes.subarray(0, 64), 'compact')
       .addRecoveryBit(bytes[64] - 27);

--- a/packages/core/src/system-record-signed-envelope-codecs-v1-internal.ts
+++ b/packages/core/src/system-record-signed-envelope-codecs-v1-internal.ts
@@ -1,20 +1,10 @@
-import { secp256k1 } from '@noble/curves/secp256k1.js';
-
 import {
   canonicalizeJsonBytes,
   parseCanonicalJson,
   type CanonicalJsonValue,
 } from './canonical-json.js';
-import { type NetworkIdV1 } from './sync-wire-identifiers.js';
 import { snapshotDataArray, snapshotExactDataRecord } from './sync-wire-objects.js';
-import {
-  assertCanonicalChainId,
-  assertCanonicalDecimalU64,
-  assertCanonicalDigest,
-  assertCanonicalEvmAddress,
-  assertCanonicalHexBytes,
-  type Digest32V1,
-} from './sync-wire-scalars.js';
+import { type Digest32V1 } from './sync-wire-scalars.js';
 import {
   computeAgentProfileAuthorityTransitionDigestV1,
   computeAgentProfileForkResolutionDigestV1,
@@ -26,9 +16,6 @@ import {
   type SignedAgentProfileForkResolutionEnvelopeV1,
   type SignedAgentProfileHeadEnvelopeV1,
   type SignedSystemRecordEnvelopeV1,
-  type SystemRecordEip1271EvidenceV1,
-  type SystemRecordNoSignatureEvidenceV1,
-  type SystemRecordSignatureEntryV1,
   type SystemRecordSignatureRoleV1,
 } from './system-record-agent-profile-control-codecs-v1-internal.js';
 import {
@@ -38,34 +25,19 @@ import {
 } from './system-record-agent-profile-head-codec-v1-internal.js';
 import {
   digest,
-  numericChainIdForNetworkV1,
   snapshotSystemRecordDataRecord,
 } from './system-record-agent-profile-primitives-v1-internal.js';
 import {
-  decodeUnpaddedBase64UrlV1,
   digestSystemRecordBytesV1,
   failSystemRecordObjectV1 as fail,
 } from './system-record-codec-primitives-v1.js';
 import {
   SYSTEM_RECORD_DIGEST_DOMAINS_V1,
-  SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
-  SYSTEM_RECORD_EIP191_MAX_S,
-  SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
-  SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
   SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
   SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
   SYSTEM_RECORD_OBJECT_CAPS_V1,
-  SYSTEM_RECORD_SIGNATURE_DOMAINS_V1,
 } from './system-record-limits-v1.js';
-
-const UTF8 = new TextEncoder();
-
-const SIGNATURE_ROLE_ORDER: Readonly<Record<SystemRecordSignatureRoleV1, number>> = {
-  peer: 0,
-  'prior-evm': 1,
-  'next-evm': 2,
-  'current-evm': 3,
-};
+import { validateSystemRecordSignatureEntryV1 } from './system-record-signature-policy-v1-internal.js';
 
 export function assertSignedAgentProfileHeadEnvelopeV1(
   value: unknown,
@@ -148,30 +120,27 @@ function validateSignedEnvelope(
     ['object', 'objectDigest', 'signatures'],
     'signed system-record envelope',
   );
-  const object =
-    kind === 'head'
-      ? validateAgentProfileHeadObjectV1(envelope.object)
-      : kind === 'transition'
-        ? validateAuthorityTransition(envelope.object)
-        : validateForkResolution(envelope.object);
-  const expectedDigest =
-    kind === 'head'
-      ? computeAgentProfileHeadObjectDigestV1(object as AgentProfileHeadObjectV1)
-      : kind === 'transition'
-        ? computeAgentProfileAuthorityTransitionDigestV1(
-            object as AgentProfileAuthorityTransitionV1,
-          )
-        : computeAgentProfileForkResolutionDigestV1(object as AgentProfileForkResolutionV1);
+  const object = kind === 'head'
+    ? validateAgentProfileHeadObjectV1(envelope.object)
+    : kind === 'transition'
+      ? validateAuthorityTransition(envelope.object)
+      : validateForkResolution(envelope.object);
+  const expectedDigest = kind === 'head'
+    ? computeAgentProfileHeadObjectDigestV1(object as AgentProfileHeadObjectV1)
+    : kind === 'transition'
+      ? computeAgentProfileAuthorityTransitionDigestV1(
+          object as AgentProfileAuthorityTransitionV1,
+        )
+      : computeAgentProfileForkResolutionDigestV1(object as AgentProfileForkResolutionV1);
   digest(envelope.objectDigest, 'objectDigest');
   if (envelope.objectDigest !== expectedDigest) {
     fail('system-record-binding', 'signed envelope objectDigest does not match the object');
   }
-  const requiredRoles: readonly SystemRecordSignatureRoleV1[] =
-    kind === 'transition'
-      ? (object as AgentProfileAuthorityTransitionV1).mode === 'co-signed'
-        ? ['peer', 'prior-evm', 'next-evm']
-        : ['peer', 'next-evm']
-      : ['peer', 'current-evm'];
+  const requiredRoles: readonly SystemRecordSignatureRoleV1[] = kind === 'transition'
+    ? (object as AgentProfileAuthorityTransitionV1).mode === 'co-signed'
+      ? ['peer', 'prior-evm', 'next-evm']
+      : ['peer', 'next-evm']
+    : ['peer', 'current-evm'];
   let signatureEntries: readonly unknown[];
   try {
     signatureEntries = snapshotDataArray(envelope.signatures, 'signed envelope signatures', {
@@ -186,219 +155,13 @@ function validateSignedEnvelope(
     );
   }
   const signatures = signatureEntries.map((entry, index) =>
-    validateSignatureEntry(entry, requiredRoles[index], object),
+    validateSystemRecordSignatureEntryV1(entry, requiredRoles[index], object),
   );
   return Object.freeze({
     object,
     objectDigest: envelope.objectDigest,
     signatures: Object.freeze(signatures),
   });
-}
-
-function validateSignatureEntry(
-  value: unknown,
-  requiredRole: SystemRecordSignatureRoleV1,
-  object:
-    | AgentProfileHeadObjectV1
-    | AgentProfileAuthorityTransitionV1
-    | AgentProfileForkResolutionV1,
-): SystemRecordSignatureEntryV1 {
-  const entry = snapshotExactDataRecord(
-    value,
-    ['role', 'suite', 'signer', 'evidence', 'signature'],
-    `signature entry ${requiredRole}`,
-  );
-  if (entry.role !== requiredRole || SIGNATURE_ROLE_ORDER[requiredRole] === undefined) {
-    fail('system-record-signature', 'signature roles are missing, extra, duplicated, or reordered');
-  }
-  const isPeer = requiredRole === 'peer';
-  let evidence: SystemRecordSignatureEntryV1['evidence'];
-  if (isPeer) {
-    if (entry.suite !== 'ed25519-v1' || entry.signer !== object.peerId) {
-      fail('system-record-signature', 'peer signature suite/signer is invalid');
-    }
-    evidence = exactNoneEvidence(entry.evidence);
-    decodeUnpaddedBase64UrlV1(
-      entry.signature,
-      SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
-      'Ed25519 signature',
-    );
-  } else {
-    const issuer = issuerForRole(object, requiredRole);
-    if (entry.signer !== issuer) {
-      fail('system-record-signature', `${requiredRole} signer does not match the object authority`);
-    }
-    if (entry.suite === 'eip191-personal-sign-digest-v1') {
-      evidence = exactNoneEvidence(entry.evidence);
-      assertCanonicalEip191SignatureV1(entry.signature);
-    } else if (entry.suite === 'eip1271-current-finalized-v1') {
-      evidence = validateEip1271Evidence(entry.evidence, issuer, object.networkId);
-      try {
-        assertCanonicalHexBytes(
-          entry.signature,
-          'EIP-1271 signature',
-          1,
-          SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
-        );
-      } catch (cause) {
-        fail('system-record-signature', 'EIP-1271 signature bytes are invalid', cause);
-      }
-    } else {
-      fail('system-record-signature', 'EVM signature suite is invalid');
-    }
-  }
-  return Object.freeze({
-    ...entry,
-    evidence,
-  }) as unknown as SystemRecordSignatureEntryV1;
-}
-
-export function assertCanonicalEip191SignatureV1(value: unknown): asserts value is string {
-  try {
-    assertCanonicalHexBytes(
-      value,
-      'EIP-191 signature',
-      SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
-      SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
-    );
-  } catch (cause) {
-    fail('system-record-signature', 'EIP-191 signature bytes are invalid', cause);
-  }
-  const bytes = systemRecordHexToBytesV1(value as string);
-  const s = bytesToBigInt(bytes.subarray(32, 64));
-  if (s === 0n || s > SYSTEM_RECORD_EIP191_MAX_S) {
-    fail('system-record-signature', 'EIP-191 signature must use canonical low-s form');
-  }
-  try {
-    secp256k1.Signature.fromBytes(bytes.subarray(0, 64), 'compact');
-  } catch (cause) {
-    fail('system-record-signature', 'EIP-191 compact signature is not canonical', cause);
-  }
-  if (bytes[64] !== 27 && bytes[64] !== 28) {
-    fail('system-record-signature', 'EIP-191 recovery byte must be 27 or 28');
-  }
-}
-
-export function buildSystemRecordSignatureMessageV1(
-  object:
-    | AgentProfileHeadObjectV1
-    | AgentProfileAuthorityTransitionV1
-    | AgentProfileForkResolutionV1,
-  objectDigest: Digest32V1,
-  role: SystemRecordSignatureRoleV1,
-): Uint8Array {
-  digest(objectDigest, 'objectDigest');
-  const kind = classifyEnvelopeObject(object);
-  const validatedObject =
-    kind === 'head'
-      ? validateAgentProfileHeadObjectV1(object)
-      : kind === 'transition'
-        ? validateAuthorityTransition(object)
-        : validateForkResolution(object);
-  const recordKey: CanonicalJsonValue = [validatedObject.networkId, validatedObject.peerId];
-  let tuple: CanonicalJsonValue;
-  if (validatedObject.objectType === 'agent-profile-head') {
-    if (role !== 'peer' && role !== 'current-evm')
-      fail('system-record-signature', 'head role is invalid');
-    tuple = [
-      'agent-profile-head',
-      objectDigest,
-      validatedObject.networkId,
-      recordKey,
-      validatedObject.authoritySequence,
-      validatedObject.version,
-      ...(role === 'peer' ? [] : ['current-evm', validatedObject.evmIssuer]),
-    ];
-  } else if (validatedObject.objectType === 'authority-transition') {
-    if (role !== 'peer' && role !== 'prior-evm' && role !== 'next-evm') {
-      fail('system-record-signature', 'transition role is invalid');
-    }
-    tuple = [
-      'authority-transition',
-      objectDigest,
-      validatedObject.networkId,
-      recordKey,
-      validatedObject.priorAuthoritySequence,
-      validatedObject.nextAuthoritySequence,
-      validatedObject.priorHeadDigest,
-      role,
-      ...(role === 'peer' ? [] : [issuerForRole(validatedObject, role)]),
-    ];
-  } else {
-    if (role !== 'peer' && role !== 'current-evm')
-      fail('system-record-signature', 'resolution role is invalid');
-    tuple = [
-      'fork-resolution',
-      objectDigest,
-      validatedObject.networkId,
-      recordKey,
-      validatedObject.authoritySequence,
-      validatedObject.forkedVersion,
-      validatedObject.resolutionVersion,
-      role,
-      ...(role === 'peer' ? [] : [validatedObject.evmIssuer]),
-    ];
-  }
-  const domain =
-    role === 'peer'
-      ? SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.peer
-      : SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.evm;
-  return concatSystemRecordBytesV1(UTF8.encode(domain), canonicalizeJsonBytes(tuple));
-}
-
-function validateEip1271Evidence(
-  value: unknown,
-  issuer: string,
-  networkId: NetworkIdV1,
-): SystemRecordEip1271EvidenceV1 {
-  const evidence = snapshotExactDataRecord(
-    value,
-    ['kind', 'chainId', 'contractAddress', 'finalizedBlockNumber', 'finalizedBlockHash'],
-    'EIP-1271 evidence',
-  );
-  if (evidence.kind !== 'eip1271-current-finalized') {
-    fail('system-record-signature', 'EIP-1271 evidence kind is invalid');
-  }
-  try {
-    assertCanonicalChainId(evidence.chainId);
-    assertCanonicalEvmAddress(evidence.contractAddress);
-    assertCanonicalDecimalU64(evidence.finalizedBlockNumber);
-    assertCanonicalDigest(evidence.finalizedBlockHash);
-  } catch (cause) {
-    fail('system-record-signature', 'EIP-1271 finalized evidence is invalid', cause);
-  }
-  if (evidence.contractAddress !== issuer) {
-    fail('system-record-binding', 'EIP-1271 contract does not match signer');
-  }
-  const expectedChainId = numericChainIdForNetworkV1(networkId);
-  if (evidence.chainId !== expectedChainId) {
-    fail('system-record-binding', 'EIP-1271 evidence chainId does not match the record network');
-  }
-  return Object.freeze({
-    ...evidence,
-  }) as unknown as SystemRecordEip1271EvidenceV1;
-}
-
-function exactNoneEvidence(value: unknown): SystemRecordNoSignatureEvidenceV1 {
-  const evidence = snapshotExactDataRecord(value, ['kind'], 'signature evidence');
-  if (evidence.kind !== 'none') fail('system-record-signature', 'signature evidence must be none');
-  return Object.freeze({ kind: 'none' });
-}
-
-function issuerForRole(
-  object:
-    | AgentProfileHeadObjectV1
-    | AgentProfileAuthorityTransitionV1
-    | AgentProfileForkResolutionV1,
-  role: Exclude<SystemRecordSignatureRoleV1, 'peer'>,
-): string {
-  if (object.objectType === 'authority-transition') {
-    if (role === 'prior-evm') return object.priorEvmIssuer;
-    if (role === 'next-evm') return object.nextEvmIssuer;
-  } else if (role === 'current-evm') {
-    return object.evmIssuer;
-  }
-  fail('system-record-signature', `${role} is not valid for ${object.objectType}`);
 }
 
 function classifyEnvelopeObject(value: unknown): 'head' | 'transition' | 'fork' {
@@ -419,10 +182,7 @@ export function validateDispatchedSignedEnvelopeV1(value: unknown): {
     'signed system-record envelope',
   );
   const kind = classifyEnvelopeObject(envelope.object);
-  return Object.freeze({
-    kind,
-    validated: validateSignedEnvelope(envelope, kind),
-  });
+  return Object.freeze({ kind, validated: validateSignedEnvelope(envelope, kind) });
 }
 
 function objectKindForEnvelope(
@@ -433,23 +193,4 @@ function objectKindForEnvelope(
     : value === 'transition'
       ? 'authority-transition'
       : 'fork-resolution';
-}
-
-export function systemRecordHexToBytesV1(value: string): Uint8Array {
-  return Uint8Array.from(Buffer.from(value.slice(2), 'hex'));
-}
-
-function bytesToBigInt(value: Uint8Array): bigint {
-  return BigInt(`0x${Buffer.from(value).toString('hex')}`);
-}
-
-export function concatSystemRecordBytesV1(...values: readonly Uint8Array[]): Uint8Array {
-  const length = values.reduce((sum, value) => sum + value.byteLength, 0);
-  const result = new Uint8Array(length);
-  let offset = 0;
-  for (const value of values) {
-    result.set(value, offset);
-    offset += value.byteLength;
-  }
-  return result;
 }

--- a/packages/core/src/system-record-signed-envelope-codecs-v1-internal.ts
+++ b/packages/core/src/system-record-signed-envelope-codecs-v1-internal.ts
@@ -6,37 +6,27 @@ import {
 import { snapshotDataArray, snapshotExactDataRecord } from './sync-wire-objects.js';
 import { type Digest32V1 } from './sync-wire-scalars.js';
 import {
-  computeAgentProfileAuthorityTransitionDigestV1,
-  computeAgentProfileForkResolutionDigestV1,
-  validateAuthorityTransition,
-  validateForkResolution,
-  type AgentProfileAuthorityTransitionV1,
-  type AgentProfileForkResolutionV1,
   type SignedAgentProfileAuthorityTransitionEnvelopeV1,
   type SignedAgentProfileForkResolutionEnvelopeV1,
   type SignedAgentProfileHeadEnvelopeV1,
   type SignedSystemRecordEnvelopeV1,
-  type SystemRecordSignatureRoleV1,
 } from './system-record-agent-profile-control-codecs-v1-internal.js';
-import {
-  computeAgentProfileHeadObjectDigestV1,
-  validateAgentProfileHeadObjectV1,
-  type AgentProfileHeadObjectV1,
-} from './system-record-agent-profile-head-codec-v1-internal.js';
-import {
-  digest,
-  snapshotSystemRecordDataRecord,
-} from './system-record-agent-profile-primitives-v1-internal.js';
+import { digest } from './system-record-agent-profile-primitives-v1-internal.js';
 import {
   digestSystemRecordBytesV1,
   failSystemRecordObjectV1 as fail,
 } from './system-record-codec-primitives-v1.js';
 import {
   SYSTEM_RECORD_DIGEST_DOMAINS_V1,
-  SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
-  SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
   SYSTEM_RECORD_OBJECT_CAPS_V1,
 } from './system-record-limits-v1.js';
+import {
+  bindSignableSystemRecordPolicyV1,
+  signableSystemRecordStaticPolicyV1,
+  type BoundSignableSystemRecordPolicyV1,
+  type SignableSystemRecordKindV1,
+  type SignableSystemRecordObjectV1,
+} from './system-record-signable-object-policy-v1-internal.js';
 import { validateSystemRecordSignatureEntryV1 } from './system-record-signature-policy-v1-internal.js';
 
 export function assertSignedAgentProfileHeadEnvelopeV1(
@@ -60,9 +50,9 @@ export function assertSignedAgentProfileForkResolutionEnvelopeV1(
 export function canonicalizeSignedSystemRecordEnvelopeV1<T>(
   value: SignedSystemRecordEnvelopeV1<T>,
 ): Uint8Array {
-  const { kind, validated } = validateDispatchedSignedEnvelopeV1(value);
+  const { objectKind, validated } = validateDispatchedSignedEnvelopeV1(value);
   return canonicalizeJsonBytes(validated as unknown as CanonicalJsonValue, {
-    maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1[objectKindForEnvelope(kind)],
+    maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1[objectKind],
   });
 }
 
@@ -78,74 +68,90 @@ export function computeSignedSystemRecordEnvelopeDigestV1<T>(
 export function parseCanonicalSignedAgentProfileHeadEnvelopeV1(
   input: string | Uint8Array,
 ): SignedAgentProfileHeadEnvelopeV1 {
+  const policy = signableSystemRecordStaticPolicyV1('head');
   return validateSignedEnvelope(
     parseCanonicalJson(input, {
-      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['agent-profile-head'],
-      maxDepth: SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
+      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1[policy.objectKind],
+      maxDepth: policy.maxJsonDepth,
     }),
     'head',
-  ) as SignedAgentProfileHeadEnvelopeV1;
+  );
 }
 
 export function parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(
   input: string | Uint8Array,
 ): SignedAgentProfileAuthorityTransitionEnvelopeV1 {
+  const policy = signableSystemRecordStaticPolicyV1('transition');
   return validateSignedEnvelope(
     parseCanonicalJson(input, {
-      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['authority-transition'],
-      maxDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
+      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1[policy.objectKind],
+      maxDepth: policy.maxJsonDepth,
     }),
     'transition',
-  ) as SignedAgentProfileAuthorityTransitionEnvelopeV1;
+  );
 }
 
 export function parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(
   input: string | Uint8Array,
 ): SignedAgentProfileForkResolutionEnvelopeV1 {
+  const policy = signableSystemRecordStaticPolicyV1('fork');
   return validateSignedEnvelope(
     parseCanonicalJson(input, {
-      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['fork-resolution'],
-      maxDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
+      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1[policy.objectKind],
+      maxDepth: policy.maxJsonDepth,
     }),
     'fork',
-  ) as SignedAgentProfileForkResolutionEnvelopeV1;
+  );
 }
 
 function validateSignedEnvelope(
   value: unknown,
-  kind: 'head' | 'transition' | 'fork',
-): SignedSystemRecordEnvelopeV1<unknown> {
+  kind: 'head',
+): SignedAgentProfileHeadEnvelopeV1;
+function validateSignedEnvelope(
+  value: unknown,
+  kind: 'transition',
+): SignedAgentProfileAuthorityTransitionEnvelopeV1;
+function validateSignedEnvelope(
+  value: unknown,
+  kind: 'fork',
+): SignedAgentProfileForkResolutionEnvelopeV1;
+function validateSignedEnvelope(
+  value: unknown,
+  expectedKind?: SignableSystemRecordKindV1,
+): SignedSystemRecordEnvelopeV1<SignableSystemRecordObjectV1>;
+function validateSignedEnvelope(
+  value: unknown,
+  expectedKind?: SignableSystemRecordKindV1,
+): SignedSystemRecordEnvelopeV1<SignableSystemRecordObjectV1> {
+  return validateSignedEnvelopeWithPolicy(value, expectedKind).validated;
+}
+
+function validateSignedEnvelopeWithPolicy(
+  value: unknown,
+  expectedKind?: SignableSystemRecordKindV1,
+): Readonly<{
+  validated: SignedSystemRecordEnvelopeV1<SignableSystemRecordObjectV1>;
+  policy: BoundSignableSystemRecordPolicyV1;
+}> {
   const envelope = snapshotExactDataRecord(
     value,
     ['object', 'objectDigest', 'signatures'],
     'signed system-record envelope',
   );
-  const object = kind === 'head'
-    ? validateAgentProfileHeadObjectV1(envelope.object)
-    : kind === 'transition'
-      ? validateAuthorityTransition(envelope.object)
-      : validateForkResolution(envelope.object);
-  const expectedDigest = kind === 'head'
-    ? computeAgentProfileHeadObjectDigestV1(object as AgentProfileHeadObjectV1)
-    : kind === 'transition'
-      ? computeAgentProfileAuthorityTransitionDigestV1(
-          object as AgentProfileAuthorityTransitionV1,
-        )
-      : computeAgentProfileForkResolutionDigestV1(object as AgentProfileForkResolutionV1);
+  const policy = bindSignableSystemRecordPolicyV1(envelope.object);
+  if (expectedKind !== undefined && policy.kind !== expectedKind) {
+    fail('system-record-schema', `signed envelope does not contain a ${expectedKind} object`);
+  }
   digest(envelope.objectDigest, 'objectDigest');
-  if (envelope.objectDigest !== expectedDigest) {
+  if (envelope.objectDigest !== policy.objectDigest) {
     fail('system-record-binding', 'signed envelope objectDigest does not match the object');
   }
-  const requiredRoles: readonly SystemRecordSignatureRoleV1[] = kind === 'transition'
-    ? (object as AgentProfileAuthorityTransitionV1).mode === 'co-signed'
-      ? ['peer', 'prior-evm', 'next-evm']
-      : ['peer', 'next-evm']
-    : ['peer', 'current-evm'];
   let signatureEntries: readonly unknown[];
   try {
     signatureEntries = snapshotDataArray(envelope.signatures, 'signed envelope signatures', {
-      minLength: requiredRoles.length,
-      maxLength: requiredRoles.length,
+      minLength: policy.requiredRoles.length,
+      maxLength: policy.requiredRoles.length,
     });
   } catch (cause) {
     fail(
@@ -155,42 +161,27 @@ function validateSignedEnvelope(
     );
   }
   const signatures = signatureEntries.map((entry, index) =>
-    validateSystemRecordSignatureEntryV1(entry, requiredRoles[index], object),
+    validateSystemRecordSignatureEntryV1(entry, policy.requiredRoles[index], policy),
   );
-  return Object.freeze({
-    object,
+  const validated = Object.freeze({
+    object: policy.object,
     objectDigest: envelope.objectDigest,
     signatures: Object.freeze(signatures),
   });
-}
-
-function classifyEnvelopeObject(value: unknown): 'head' | 'transition' | 'fork' {
-  const record = snapshotSystemRecordDataRecord(value, 'signed envelope object');
-  if (record.objectType === 'agent-profile-head') return 'head';
-  if (record.objectType === 'authority-transition') return 'transition';
-  if (record.objectType === 'fork-resolution') return 'fork';
-  fail('system-record-schema', 'signed envelope object type is unsupported');
+  return Object.freeze({ validated, policy });
 }
 
 export function validateDispatchedSignedEnvelopeV1(value: unknown): {
-  readonly kind: 'head' | 'transition' | 'fork';
-  readonly validated: SignedSystemRecordEnvelopeV1<unknown>;
+  readonly kind: SignableSystemRecordKindV1;
+  readonly objectKind: BoundSignableSystemRecordPolicyV1['objectKind'];
+  readonly validated: SignedSystemRecordEnvelopeV1<SignableSystemRecordObjectV1>;
+  readonly policy: BoundSignableSystemRecordPolicyV1;
 } {
-  const envelope = snapshotExactDataRecord(
-    value,
-    ['object', 'objectDigest', 'signatures'],
-    'signed system-record envelope',
-  );
-  const kind = classifyEnvelopeObject(envelope.object);
-  return Object.freeze({ kind, validated: validateSignedEnvelope(envelope, kind) });
-}
-
-function objectKindForEnvelope(
-  value: 'head' | 'transition' | 'fork',
-): 'agent-profile-head' | 'authority-transition' | 'fork-resolution' {
-  return value === 'head'
-    ? 'agent-profile-head'
-    : value === 'transition'
-      ? 'authority-transition'
-      : 'fork-resolution';
+  const { validated, policy } = validateSignedEnvelopeWithPolicy(value);
+  return Object.freeze({
+    kind: policy.kind,
+    objectKind: policy.objectKind,
+    validated,
+    policy,
+  });
 }

--- a/packages/core/src/system-record-signed-envelope-codecs-v1-internal.ts
+++ b/packages/core/src/system-record-signed-envelope-codecs-v1-internal.ts
@@ -1,0 +1,455 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+import {
+  canonicalizeJsonBytes,
+  parseCanonicalJson,
+  type CanonicalJsonValue,
+} from './canonical-json.js';
+import { type NetworkIdV1 } from './sync-wire-identifiers.js';
+import { snapshotDataArray, snapshotExactDataRecord } from './sync-wire-objects.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalDecimalU64,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertCanonicalHexBytes,
+  type Digest32V1,
+} from './sync-wire-scalars.js';
+import {
+  computeAgentProfileAuthorityTransitionDigestV1,
+  computeAgentProfileForkResolutionDigestV1,
+  validateAuthorityTransition,
+  validateForkResolution,
+  type AgentProfileAuthorityTransitionV1,
+  type AgentProfileForkResolutionV1,
+  type SignedAgentProfileAuthorityTransitionEnvelopeV1,
+  type SignedAgentProfileForkResolutionEnvelopeV1,
+  type SignedAgentProfileHeadEnvelopeV1,
+  type SignedSystemRecordEnvelopeV1,
+  type SystemRecordEip1271EvidenceV1,
+  type SystemRecordNoSignatureEvidenceV1,
+  type SystemRecordSignatureEntryV1,
+  type SystemRecordSignatureRoleV1,
+} from './system-record-agent-profile-control-codecs-v1-internal.js';
+import {
+  computeAgentProfileHeadObjectDigestV1,
+  validateAgentProfileHeadObjectV1,
+  type AgentProfileHeadObjectV1,
+} from './system-record-agent-profile-head-codec-v1-internal.js';
+import {
+  digest,
+  numericChainIdForNetworkV1,
+  snapshotSystemRecordDataRecord,
+} from './system-record-agent-profile-primitives-v1-internal.js';
+import {
+  decodeUnpaddedBase64UrlV1,
+  digestSystemRecordBytesV1,
+  failSystemRecordObjectV1 as fail,
+} from './system-record-codec-primitives-v1.js';
+import {
+  SYSTEM_RECORD_DIGEST_DOMAINS_V1,
+  SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
+  SYSTEM_RECORD_EIP191_MAX_S,
+  SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
+  SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
+  SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
+  SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
+  SYSTEM_RECORD_OBJECT_CAPS_V1,
+  SYSTEM_RECORD_SIGNATURE_DOMAINS_V1,
+} from './system-record-limits-v1.js';
+
+const UTF8 = new TextEncoder();
+
+const SIGNATURE_ROLE_ORDER: Readonly<Record<SystemRecordSignatureRoleV1, number>> = {
+  peer: 0,
+  'prior-evm': 1,
+  'next-evm': 2,
+  'current-evm': 3,
+};
+
+export function assertSignedAgentProfileHeadEnvelopeV1(
+  value: unknown,
+): asserts value is SignedAgentProfileHeadEnvelopeV1 {
+  validateSignedEnvelope(value, 'head');
+}
+
+export function assertSignedAgentProfileAuthorityTransitionEnvelopeV1(
+  value: unknown,
+): asserts value is SignedAgentProfileAuthorityTransitionEnvelopeV1 {
+  validateSignedEnvelope(value, 'transition');
+}
+
+export function assertSignedAgentProfileForkResolutionEnvelopeV1(
+  value: unknown,
+): asserts value is SignedAgentProfileForkResolutionEnvelopeV1 {
+  validateSignedEnvelope(value, 'fork');
+}
+
+export function canonicalizeSignedSystemRecordEnvelopeV1<T>(
+  value: SignedSystemRecordEnvelopeV1<T>,
+): Uint8Array {
+  const { kind, validated } = validateDispatchedSignedEnvelopeV1(value);
+  return canonicalizeJsonBytes(validated as unknown as CanonicalJsonValue, {
+    maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1[objectKindForEnvelope(kind)],
+  });
+}
+
+export function computeSignedSystemRecordEnvelopeDigestV1<T>(
+  value: SignedSystemRecordEnvelopeV1<T>,
+): Digest32V1 {
+  return digestSystemRecordBytesV1(
+    SYSTEM_RECORD_DIGEST_DOMAINS_V1.signedEnvelope,
+    canonicalizeSignedSystemRecordEnvelopeV1(value),
+  );
+}
+
+export function parseCanonicalSignedAgentProfileHeadEnvelopeV1(
+  input: string | Uint8Array,
+): SignedAgentProfileHeadEnvelopeV1 {
+  return validateSignedEnvelope(
+    parseCanonicalJson(input, {
+      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['agent-profile-head'],
+      maxDepth: SYSTEM_RECORD_MAX_SIGNED_HEAD_JSON_DEPTH,
+    }),
+    'head',
+  ) as SignedAgentProfileHeadEnvelopeV1;
+}
+
+export function parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(
+  input: string | Uint8Array,
+): SignedAgentProfileAuthorityTransitionEnvelopeV1 {
+  return validateSignedEnvelope(
+    parseCanonicalJson(input, {
+      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['authority-transition'],
+      maxDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
+    }),
+    'transition',
+  ) as SignedAgentProfileAuthorityTransitionEnvelopeV1;
+}
+
+export function parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(
+  input: string | Uint8Array,
+): SignedAgentProfileForkResolutionEnvelopeV1 {
+  return validateSignedEnvelope(
+    parseCanonicalJson(input, {
+      maxBytes: SYSTEM_RECORD_OBJECT_CAPS_V1['fork-resolution'],
+      maxDepth: SYSTEM_RECORD_MAX_SIGNED_CONTROL_JSON_DEPTH,
+    }),
+    'fork',
+  ) as SignedAgentProfileForkResolutionEnvelopeV1;
+}
+
+function validateSignedEnvelope(
+  value: unknown,
+  kind: 'head' | 'transition' | 'fork',
+): SignedSystemRecordEnvelopeV1<unknown> {
+  const envelope = snapshotExactDataRecord(
+    value,
+    ['object', 'objectDigest', 'signatures'],
+    'signed system-record envelope',
+  );
+  const object =
+    kind === 'head'
+      ? validateAgentProfileHeadObjectV1(envelope.object)
+      : kind === 'transition'
+        ? validateAuthorityTransition(envelope.object)
+        : validateForkResolution(envelope.object);
+  const expectedDigest =
+    kind === 'head'
+      ? computeAgentProfileHeadObjectDigestV1(object as AgentProfileHeadObjectV1)
+      : kind === 'transition'
+        ? computeAgentProfileAuthorityTransitionDigestV1(
+            object as AgentProfileAuthorityTransitionV1,
+          )
+        : computeAgentProfileForkResolutionDigestV1(object as AgentProfileForkResolutionV1);
+  digest(envelope.objectDigest, 'objectDigest');
+  if (envelope.objectDigest !== expectedDigest) {
+    fail('system-record-binding', 'signed envelope objectDigest does not match the object');
+  }
+  const requiredRoles: readonly SystemRecordSignatureRoleV1[] =
+    kind === 'transition'
+      ? (object as AgentProfileAuthorityTransitionV1).mode === 'co-signed'
+        ? ['peer', 'prior-evm', 'next-evm']
+        : ['peer', 'next-evm']
+      : ['peer', 'current-evm'];
+  let signatureEntries: readonly unknown[];
+  try {
+    signatureEntries = snapshotDataArray(envelope.signatures, 'signed envelope signatures', {
+      minLength: requiredRoles.length,
+      maxLength: requiredRoles.length,
+    });
+  } catch (cause) {
+    fail(
+      'system-record-signature',
+      'signed envelope has the wrong closed signature cardinality',
+      cause,
+    );
+  }
+  const signatures = signatureEntries.map((entry, index) =>
+    validateSignatureEntry(entry, requiredRoles[index], object),
+  );
+  return Object.freeze({
+    object,
+    objectDigest: envelope.objectDigest,
+    signatures: Object.freeze(signatures),
+  });
+}
+
+function validateSignatureEntry(
+  value: unknown,
+  requiredRole: SystemRecordSignatureRoleV1,
+  object:
+    | AgentProfileHeadObjectV1
+    | AgentProfileAuthorityTransitionV1
+    | AgentProfileForkResolutionV1,
+): SystemRecordSignatureEntryV1 {
+  const entry = snapshotExactDataRecord(
+    value,
+    ['role', 'suite', 'signer', 'evidence', 'signature'],
+    `signature entry ${requiredRole}`,
+  );
+  if (entry.role !== requiredRole || SIGNATURE_ROLE_ORDER[requiredRole] === undefined) {
+    fail('system-record-signature', 'signature roles are missing, extra, duplicated, or reordered');
+  }
+  const isPeer = requiredRole === 'peer';
+  let evidence: SystemRecordSignatureEntryV1['evidence'];
+  if (isPeer) {
+    if (entry.suite !== 'ed25519-v1' || entry.signer !== object.peerId) {
+      fail('system-record-signature', 'peer signature suite/signer is invalid');
+    }
+    evidence = exactNoneEvidence(entry.evidence);
+    decodeUnpaddedBase64UrlV1(
+      entry.signature,
+      SYSTEM_RECORD_ED25519_SIGNATURE_BYTES,
+      'Ed25519 signature',
+    );
+  } else {
+    const issuer = issuerForRole(object, requiredRole);
+    if (entry.signer !== issuer) {
+      fail('system-record-signature', `${requiredRole} signer does not match the object authority`);
+    }
+    if (entry.suite === 'eip191-personal-sign-digest-v1') {
+      evidence = exactNoneEvidence(entry.evidence);
+      assertCanonicalEip191SignatureV1(entry.signature);
+    } else if (entry.suite === 'eip1271-current-finalized-v1') {
+      evidence = validateEip1271Evidence(entry.evidence, issuer, object.networkId);
+      try {
+        assertCanonicalHexBytes(
+          entry.signature,
+          'EIP-1271 signature',
+          1,
+          SYSTEM_RECORD_MAX_EIP1271_SIGNATURE_BYTES,
+        );
+      } catch (cause) {
+        fail('system-record-signature', 'EIP-1271 signature bytes are invalid', cause);
+      }
+    } else {
+      fail('system-record-signature', 'EVM signature suite is invalid');
+    }
+  }
+  return Object.freeze({
+    ...entry,
+    evidence,
+  }) as unknown as SystemRecordSignatureEntryV1;
+}
+
+export function assertCanonicalEip191SignatureV1(value: unknown): asserts value is string {
+  try {
+    assertCanonicalHexBytes(
+      value,
+      'EIP-191 signature',
+      SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
+      SYSTEM_RECORD_EIP191_SIGNATURE_BYTES,
+    );
+  } catch (cause) {
+    fail('system-record-signature', 'EIP-191 signature bytes are invalid', cause);
+  }
+  const bytes = systemRecordHexToBytesV1(value as string);
+  const s = bytesToBigInt(bytes.subarray(32, 64));
+  if (s === 0n || s > SYSTEM_RECORD_EIP191_MAX_S) {
+    fail('system-record-signature', 'EIP-191 signature must use canonical low-s form');
+  }
+  try {
+    secp256k1.Signature.fromBytes(bytes.subarray(0, 64), 'compact');
+  } catch (cause) {
+    fail('system-record-signature', 'EIP-191 compact signature is not canonical', cause);
+  }
+  if (bytes[64] !== 27 && bytes[64] !== 28) {
+    fail('system-record-signature', 'EIP-191 recovery byte must be 27 or 28');
+  }
+}
+
+export function buildSystemRecordSignatureMessageV1(
+  object:
+    | AgentProfileHeadObjectV1
+    | AgentProfileAuthorityTransitionV1
+    | AgentProfileForkResolutionV1,
+  objectDigest: Digest32V1,
+  role: SystemRecordSignatureRoleV1,
+): Uint8Array {
+  digest(objectDigest, 'objectDigest');
+  const kind = classifyEnvelopeObject(object);
+  const validatedObject =
+    kind === 'head'
+      ? validateAgentProfileHeadObjectV1(object)
+      : kind === 'transition'
+        ? validateAuthorityTransition(object)
+        : validateForkResolution(object);
+  const recordKey: CanonicalJsonValue = [validatedObject.networkId, validatedObject.peerId];
+  let tuple: CanonicalJsonValue;
+  if (validatedObject.objectType === 'agent-profile-head') {
+    if (role !== 'peer' && role !== 'current-evm')
+      fail('system-record-signature', 'head role is invalid');
+    tuple = [
+      'agent-profile-head',
+      objectDigest,
+      validatedObject.networkId,
+      recordKey,
+      validatedObject.authoritySequence,
+      validatedObject.version,
+      ...(role === 'peer' ? [] : ['current-evm', validatedObject.evmIssuer]),
+    ];
+  } else if (validatedObject.objectType === 'authority-transition') {
+    if (role !== 'peer' && role !== 'prior-evm' && role !== 'next-evm') {
+      fail('system-record-signature', 'transition role is invalid');
+    }
+    tuple = [
+      'authority-transition',
+      objectDigest,
+      validatedObject.networkId,
+      recordKey,
+      validatedObject.priorAuthoritySequence,
+      validatedObject.nextAuthoritySequence,
+      validatedObject.priorHeadDigest,
+      role,
+      ...(role === 'peer' ? [] : [issuerForRole(validatedObject, role)]),
+    ];
+  } else {
+    if (role !== 'peer' && role !== 'current-evm')
+      fail('system-record-signature', 'resolution role is invalid');
+    tuple = [
+      'fork-resolution',
+      objectDigest,
+      validatedObject.networkId,
+      recordKey,
+      validatedObject.authoritySequence,
+      validatedObject.forkedVersion,
+      validatedObject.resolutionVersion,
+      role,
+      ...(role === 'peer' ? [] : [validatedObject.evmIssuer]),
+    ];
+  }
+  const domain =
+    role === 'peer'
+      ? SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.peer
+      : SYSTEM_RECORD_SIGNATURE_DOMAINS_V1.evm;
+  return concatSystemRecordBytesV1(UTF8.encode(domain), canonicalizeJsonBytes(tuple));
+}
+
+function validateEip1271Evidence(
+  value: unknown,
+  issuer: string,
+  networkId: NetworkIdV1,
+): SystemRecordEip1271EvidenceV1 {
+  const evidence = snapshotExactDataRecord(
+    value,
+    ['kind', 'chainId', 'contractAddress', 'finalizedBlockNumber', 'finalizedBlockHash'],
+    'EIP-1271 evidence',
+  );
+  if (evidence.kind !== 'eip1271-current-finalized') {
+    fail('system-record-signature', 'EIP-1271 evidence kind is invalid');
+  }
+  try {
+    assertCanonicalChainId(evidence.chainId);
+    assertCanonicalEvmAddress(evidence.contractAddress);
+    assertCanonicalDecimalU64(evidence.finalizedBlockNumber);
+    assertCanonicalDigest(evidence.finalizedBlockHash);
+  } catch (cause) {
+    fail('system-record-signature', 'EIP-1271 finalized evidence is invalid', cause);
+  }
+  if (evidence.contractAddress !== issuer) {
+    fail('system-record-binding', 'EIP-1271 contract does not match signer');
+  }
+  const expectedChainId = numericChainIdForNetworkV1(networkId);
+  if (evidence.chainId !== expectedChainId) {
+    fail('system-record-binding', 'EIP-1271 evidence chainId does not match the record network');
+  }
+  return Object.freeze({
+    ...evidence,
+  }) as unknown as SystemRecordEip1271EvidenceV1;
+}
+
+function exactNoneEvidence(value: unknown): SystemRecordNoSignatureEvidenceV1 {
+  const evidence = snapshotExactDataRecord(value, ['kind'], 'signature evidence');
+  if (evidence.kind !== 'none') fail('system-record-signature', 'signature evidence must be none');
+  return Object.freeze({ kind: 'none' });
+}
+
+function issuerForRole(
+  object:
+    | AgentProfileHeadObjectV1
+    | AgentProfileAuthorityTransitionV1
+    | AgentProfileForkResolutionV1,
+  role: Exclude<SystemRecordSignatureRoleV1, 'peer'>,
+): string {
+  if (object.objectType === 'authority-transition') {
+    if (role === 'prior-evm') return object.priorEvmIssuer;
+    if (role === 'next-evm') return object.nextEvmIssuer;
+  } else if (role === 'current-evm') {
+    return object.evmIssuer;
+  }
+  fail('system-record-signature', `${role} is not valid for ${object.objectType}`);
+}
+
+function classifyEnvelopeObject(value: unknown): 'head' | 'transition' | 'fork' {
+  const record = snapshotSystemRecordDataRecord(value, 'signed envelope object');
+  if (record.objectType === 'agent-profile-head') return 'head';
+  if (record.objectType === 'authority-transition') return 'transition';
+  if (record.objectType === 'fork-resolution') return 'fork';
+  fail('system-record-schema', 'signed envelope object type is unsupported');
+}
+
+export function validateDispatchedSignedEnvelopeV1(value: unknown): {
+  readonly kind: 'head' | 'transition' | 'fork';
+  readonly validated: SignedSystemRecordEnvelopeV1<unknown>;
+} {
+  const envelope = snapshotExactDataRecord(
+    value,
+    ['object', 'objectDigest', 'signatures'],
+    'signed system-record envelope',
+  );
+  const kind = classifyEnvelopeObject(envelope.object);
+  return Object.freeze({
+    kind,
+    validated: validateSignedEnvelope(envelope, kind),
+  });
+}
+
+function objectKindForEnvelope(
+  value: 'head' | 'transition' | 'fork',
+): 'agent-profile-head' | 'authority-transition' | 'fork-resolution' {
+  return value === 'head'
+    ? 'agent-profile-head'
+    : value === 'transition'
+      ? 'authority-transition'
+      : 'fork-resolution';
+}
+
+export function systemRecordHexToBytesV1(value: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(value.slice(2), 'hex'));
+}
+
+function bytesToBigInt(value: Uint8Array): bigint {
+  return BigInt(`0x${Buffer.from(value).toString('hex')}`);
+}
+
+export function concatSystemRecordBytesV1(...values: readonly Uint8Array[]): Uint8Array {
+  const length = values.reduce((sum, value) => sum + value.byteLength, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const value of values) {
+    result.set(value, offset);
+    offset += value.byteLength;
+  }
+  return result;
+}

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -171,54 +171,294 @@ type ClosurePurposeV1 =
   | 'tombstone-predecessor'
   | 'deletion-predecessor';
 
-/**
- * Derive the row closure from canonical objects rather than trusting caller-supplied edges.
- * Authority and current-bundle verification stay injected because final chain/seal proofs
- * belong to later stacks, but a false/missing verifier result always fails closed.
- */
-export async function buildAgentProfileVerificationClosureV1(
-  currentHeadDigest: Digest32V1,
-  verifier: AgentProfileClosureVerifierV1,
-): Promise<SystemRecordVerificationClosureV1> {
-  digest(currentHeadDigest, 'currentHeadDigest');
-  const nowMs = verifier.nowMs;
-  const resolve = verifier.resolve;
-  const verifyAuthorityEnvelope = verifier.verifyAuthorityEnvelope;
-  const verifyCurrentBundle = verifier.verifyCurrentBundle;
-  if (!isSafeNow(nowMs)) fail('system-record-closure', 'closure verifier clock is invalid');
-  if (
-    typeof resolve !== 'function' ||
-    typeof verifyAuthorityEnvelope !== 'function' ||
-    typeof verifyCurrentBundle !== 'function'
-  ) {
-    fail('system-record-closure', 'closure verifier callbacks are invalid');
-  }
-  const pending = new Map<
-    string,
-    {
-      objectKind: SystemRecordObjectKindV1;
-      digest: Digest32V1;
-      purpose: ClosurePurposeV1;
-      rootSubject?: string;
-      referencedByHeadDigest?: Digest32V1;
-    }
-  >();
-  const artifacts: SystemRecordVerificationClosureObjectV1[] = [];
-  const parsedHeads = new Map<Digest32V1, AgentProfileHeadObjectV1>();
-  const parsedTransitions = new Map<Digest32V1, AgentProfileAuthorityTransitionV1>();
-  const parsedResolutions: AgentProfileForkResolutionV1[] = [];
-  const seen = new Map<Digest32V1, SystemRecordObjectKindV1>();
-  const rootClaims = new Set<string>();
-  let bytes = 0;
-  enqueue('agent-profile-head', currentHeadDigest, 'current');
+interface ClosurePendingReferenceV1 {
+  readonly objectKind: SystemRecordObjectKindV1;
+  readonly digest: Digest32V1;
+  readonly purpose: ClosurePurposeV1;
+  readonly rootSubject?: string;
+  readonly referencedByHeadDigest?: Digest32V1;
+}
 
-  while (pending.size > 0) {
+interface ClosureTraversalStateV1 {
+  readonly currentHeadDigest: Digest32V1;
+  readonly pending: Map<string, ClosurePendingReferenceV1>;
+  readonly artifacts: SystemRecordVerificationClosureObjectV1[];
+  readonly parsedHeads: Map<Digest32V1, AgentProfileHeadObjectV1>;
+  readonly parsedTransitions: Map<Digest32V1, AgentProfileAuthorityTransitionV1>;
+  readonly parsedResolutions: AgentProfileForkResolutionV1[];
+  readonly seen: Map<Digest32V1, SystemRecordObjectKindV1>;
+  readonly rootClaims: Set<string>;
+  canonicalBytes: number;
+}
+
+interface CollectedClosureV1 {
+  readonly currentHeadDigest: Digest32V1;
+  readonly artifacts: readonly SystemRecordVerificationClosureObjectV1[];
+  readonly parsedHeads: ReadonlyMap<Digest32V1, AgentProfileHeadObjectV1>;
+  readonly parsedTransitions: ReadonlyMap<
+    Digest32V1,
+    AgentProfileAuthorityTransitionV1
+  >;
+  readonly parsedResolutions: readonly AgentProfileForkResolutionV1[];
+  readonly rootClaimCount: number;
+  readonly canonicalBytes: number;
+}
+
+interface ClosureExecutionV1 {
+  readonly nowMs: number;
+  readonly resolve: AgentProfileClosureVerifierV1['resolve'];
+  readonly verifyAuthorityEnvelope: AgentProfileClosureVerifierV1['verifyAuthorityEnvelope'];
+  readonly verifyCurrentBundle: AgentProfileClosureVerifierV1['verifyCurrentBundle'];
+}
+
+function createClosureTraversalStateV1(
+  currentHeadDigest: Digest32V1,
+): ClosureTraversalStateV1 {
+  return {
+    currentHeadDigest,
+    pending: new Map(),
+    artifacts: [],
+    parsedHeads: new Map(),
+    parsedTransitions: new Map(),
+    parsedResolutions: [],
+    seen: new Map(),
+    rootClaims: new Set(),
+    canonicalBytes: 0,
+  };
+}
+
+const CLOSURE_PURPOSE_PRIORITY_V1: Readonly<Record<ClosurePurposeV1, number>> = Object.freeze({
+  history: 0,
+  'fork-evidence': 1,
+  'tombstone-predecessor': 2,
+  'deletion-predecessor': 3,
+  current: 4,
+});
+
+function enqueueClosureReferenceV1(
+  state: ClosureTraversalStateV1,
+  objectKind: SystemRecordObjectKindV1,
+  objectDigest: Digest32V1,
+  purpose: ClosurePurposeV1,
+  rootSubject?: string,
+  referencedByHeadDigest?: Digest32V1,
+): void {
+  digest(objectDigest, 'closure reference digest');
+  const seenKind = state.seen.get(objectDigest);
+  if (seenKind !== undefined) {
+    if (seenKind !== objectKind) {
+      fail(
+        'system-record-closure',
+        'one closure digest was referenced under different object kinds',
+      );
+    }
+    return;
+  }
+  const existing = state.pending.get(objectDigest);
+  if (existing !== undefined && existing.objectKind !== objectKind) {
+    fail('system-record-closure', 'one pending closure digest has conflicting object kinds');
+  }
+  if (
+    existing === undefined ||
+    CLOSURE_PURPOSE_PRIORITY_V1[purpose] > CLOSURE_PURPOSE_PRIORITY_V1[existing.purpose]
+  ) {
+    state.pending.set(objectDigest, {
+      objectKind,
+      digest: objectDigest,
+      purpose,
+      ...(rootSubject === undefined ? {} : { rootSubject }),
+      ...(referencedByHeadDigest === undefined ? {} : { referencedByHeadDigest }),
+    });
+  }
+}
+
+type ClosureReferenceV1 = Pick<
+  SystemRecordVerificationClosureObjectV1,
+  'objectKind' | 'digest'
+>;
+
+async function visitClosureObjectV1(
+  state: ClosureTraversalStateV1,
+  context: ClosurePendingReferenceV1,
+  canonicalBytes: Uint8Array,
+  references: ClosureReferenceV1[],
+  execution: ClosureExecutionV1,
+): Promise<void> {
+  const objectKind = context.objectKind;
+  const objectDigest = context.digest;
+  const add = (
+    referencedKind: SystemRecordObjectKindV1,
+    referencedDigest: Digest32V1,
+    purpose: ClosurePurposeV1,
+    rootSubject?: string,
+    referencedByHeadDigest?: Digest32V1,
+  ) => {
+    enqueueClosureReferenceV1(
+      state,
+      referencedKind,
+      referencedDigest,
+      purpose,
+      rootSubject,
+      referencedByHeadDigest,
+    );
+    references.push(Object.freeze({ objectKind: referencedKind, digest: referencedDigest }));
+  };
+
+  if (objectKind === 'agent-profile-head') {
+    const envelope = parseCanonicalSignedAgentProfileHeadEnvelopeV1(canonicalBytes);
+    if (
+      envelope.objectDigest !== objectDigest ||
+      (await execution.verifyAuthorityEnvelope(envelope)) !== true
+    ) {
+      fail('system-record-closure', 'head authority verification failed');
+    }
+    const head = envelope.object;
+    if (isIssuedTooFarInFuture(head.issuedAt, execution.nowMs)) {
+      fail('system-record-closure', 'head issuedAt exceeds the future clock-skew bound');
+    }
+    state.parsedHeads.set(objectDigest, head);
+    state.rootClaims.add(head.rootSubject);
+    if (head.acceptedTransitionDigest !== undefined) {
+      add(
+        'authority-transition',
+        head.acceptedTransitionDigest,
+        'history',
+        undefined,
+        objectDigest,
+      );
+    }
+    if (
+      objectDigest === state.currentHeadDigest &&
+      head.forkResolutionDigest !== undefined
+    ) {
+      add('fork-resolution', head.forkResolutionDigest, 'history', undefined, objectDigest);
+    }
+    if (context.purpose === 'current' && head.state === 'active') {
+      add('profile-bundle', head.bundleDigest, 'current');
+    }
+    if (head.state === 'tombstone') {
+      add(
+        'agent-profile-head',
+        head.previousHeadDigest,
+        context.purpose === 'current' ? 'deletion-predecessor' : 'tombstone-predecessor',
+      );
+    }
+    if (
+      context.purpose === 'deletion-predecessor' ||
+      context.purpose === 'tombstone-predecessor'
+    ) {
+      if (head.state !== 'active') {
+        fail('system-record-closure', 'tombstone predecessor must be active');
+      }
+      if (context.purpose === 'deletion-predecessor') {
+        add('owned-subject-table', head.ownedSubjectTableDigest, 'history', head.rootSubject);
+      }
+    }
+    return;
+  }
+
+  if (objectKind === 'authority-transition') {
+    const envelope = parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(canonicalBytes);
+    if (
+      envelope.objectDigest !== objectDigest ||
+      (await execution.verifyAuthorityEnvelope(envelope)) !== true
+    ) {
+      fail('system-record-closure', 'authority-transition verification failed');
+    }
+    state.parsedTransitions.set(objectDigest, envelope.object);
+    if (context.referencedByHeadDigest !== undefined) {
+      const referencingHead = state.parsedHeads.get(context.referencedByHeadDigest);
+      if (
+        referencingHead === undefined ||
+        !isAgentProfileHeadBoundToAcceptedTransitionV1(referencingHead, envelope.object)
+      ) {
+        fail('system-record-closure', 'head does not bind its accepted authority transition');
+      }
+    }
+    state.rootClaims.add(envelope.object.nextRoot);
+    add('agent-profile-head', envelope.object.priorHeadDigest, 'history');
+    return;
+  }
+
+  if (objectKind === 'fork-resolution') {
+    const envelope = parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(canonicalBytes);
+    if (
+      envelope.objectDigest !== objectDigest ||
+      (await execution.verifyAuthorityEnvelope(envelope)) !== true
+    ) {
+      fail('system-record-closure', 'fork-resolution verification failed');
+    }
+    state.parsedResolutions.push(envelope.object);
+    if (isIssuedTooFarInFuture(envelope.object.issuedAt, execution.nowMs)) {
+      fail('system-record-closure', 'fork resolution issuedAt exceeds the future clock-skew bound');
+    }
+    if (context.referencedByHeadDigest !== undefined) {
+      const referencingHead = state.parsedHeads.get(context.referencedByHeadDigest);
+      if (
+        referencingHead === undefined ||
+        !isDirectResolvingSuccessorV1(referencingHead, envelope.object)
+      ) {
+        fail(
+          'system-record-closure',
+          'current head is not the direct successor of its fork resolution',
+        );
+      }
+    }
+    for (const headDigest of envelope.object.evidenceHeadDigests) {
+      add('agent-profile-head', headDigest, 'fork-evidence');
+    }
+    if (envelope.object.forkBaseHeadDigest !== undefined) {
+      add('agent-profile-head', envelope.object.forkBaseHeadDigest, 'history');
+    }
+    return;
+  }
+
+  if (objectKind === 'profile-bundle') {
+    const current = state.parsedHeads.get(state.currentHeadDigest);
+    if (
+      current?.state !== 'active' ||
+      digestSystemRecordBytesV1(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle, canonicalBytes) !==
+        objectDigest ||
+      (await execution.verifyCurrentBundle(current, canonicalBytes.slice())) !== true
+    ) {
+      fail('system-record-closure', 'current profile bundle verification failed');
+    }
+    return;
+  }
+
+  if (objectKind === 'owned-subject-table') {
+    if (context.rootSubject === undefined) {
+      fail('system-record-closure', 'subject table lacks root context');
+    }
+    const table = parseCanonicalOwnedSubjectTableObjectV1(context.rootSubject, canonicalBytes);
+    if (computeOwnedSubjectTableDigestV1(context.rootSubject, table) !== objectDigest) {
+      fail('system-record-closure', 'owned-subject table digest mismatch');
+    }
+    return;
+  }
+
+  fail('system-record-closure', `${objectKind} is not part of an advertised row closure`);
+}
+
+async function collectVerificationClosureV1(
+  currentHeadDigest: Digest32V1,
+  execution: ClosureExecutionV1,
+): Promise<CollectedClosureV1> {
+  const state = createClosureTraversalStateV1(currentHeadDigest);
+  enqueueClosureReferenceV1(
+    state,
+    'agent-profile-head',
+    currentHeadDigest,
+    'current',
+  );
+
+  while (state.pending.size > 0) {
     const context = Object.freeze({
-      ...[...pending.values()].sort(compareClosureObjects)[0],
+      ...[...state.pending.values()].sort(compareClosureObjects)[0],
     });
     const key = context.digest;
-    pending.delete(key);
-    const seenKind = seen.get(key);
+    state.pending.delete(key);
+    const seenKind = state.seen.get(key);
     if (seenKind !== undefined) {
       if (seenKind !== context.objectKind) {
         fail(
@@ -228,14 +468,15 @@ export async function buildAgentProfileVerificationClosureV1(
       }
       continue;
     }
-    const resolved = await resolve(
+    const resolved = await execution.resolve(
       Object.freeze({
         objectKind: context.objectKind,
         digest: context.digest,
       }),
     );
-    if (resolved === undefined)
+    if (resolved === undefined) {
       fail('system-record-closure', `verification closure is missing ${key}`);
+    }
     const artifact = snapshotExactDataRecord(
       resolved,
       ['objectKind', 'digest', 'canonicalBytes'],
@@ -256,150 +497,20 @@ export async function buildAgentProfileVerificationClosureV1(
     } catch (cause) {
       fail('system-record-closure', 'closure artifact exceeds its kind cap', cause);
     }
-    const references: Pick<SystemRecordVerificationClosureObjectV1, 'objectKind' | 'digest'>[] = [];
-    const add = (
-      objectKind: SystemRecordObjectKindV1,
-      objectDigest: Digest32V1,
-      purpose: ClosurePurposeV1,
-      rootSubject?: string,
-      referencedByHeadDigest?: Digest32V1,
-    ) => {
-      enqueue(objectKind, objectDigest, purpose, rootSubject, referencedByHeadDigest);
-      references.push(Object.freeze({ objectKind, digest: objectDigest }));
-    };
+    const references: ClosureReferenceV1[] = [];
+    await visitClosureObjectV1(state, context, canonicalBytes, references, execution);
 
-    if (objectKind === 'agent-profile-head') {
-      const envelope = parseCanonicalSignedAgentProfileHeadEnvelopeV1(canonicalBytes);
-      if (
-        envelope.objectDigest !== objectDigest ||
-        (await verifyAuthorityEnvelope(envelope)) !== true
-      ) {
-        fail('system-record-closure', 'head authority verification failed');
-      }
-      const head = envelope.object;
-      if (isIssuedTooFarInFuture(head.issuedAt, nowMs)) {
-        fail('system-record-closure', 'head issuedAt exceeds the future clock-skew bound');
-      }
-      parsedHeads.set(objectDigest, head);
-      rootClaims.add(head.rootSubject);
-      if (head.acceptedTransitionDigest !== undefined) {
-        add(
-          'authority-transition',
-          head.acceptedTransitionDigest,
-          'history',
-          undefined,
-          objectDigest,
-        );
-      }
-      if (objectDigest === currentHeadDigest && head.forkResolutionDigest !== undefined) {
-        add('fork-resolution', head.forkResolutionDigest, 'history', undefined, objectDigest);
-      }
-      if (context.purpose === 'current' && head.state === 'active') {
-        add('profile-bundle', head.bundleDigest, 'current');
-      }
-      if (head.state === 'tombstone') {
-        add(
-          'agent-profile-head',
-          head.previousHeadDigest,
-          context.purpose === 'current' ? 'deletion-predecessor' : 'tombstone-predecessor',
-        );
-      }
-      if (
-        context.purpose === 'deletion-predecessor' ||
-        context.purpose === 'tombstone-predecessor'
-      ) {
-        if (head.state !== 'active')
-          fail('system-record-closure', 'tombstone predecessor must be active');
-        if (context.purpose === 'deletion-predecessor') {
-          add('owned-subject-table', head.ownedSubjectTableDigest, 'history', head.rootSubject);
-        }
-      }
-    } else if (objectKind === 'authority-transition') {
-      const envelope =
-        parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(canonicalBytes);
-      if (
-        envelope.objectDigest !== objectDigest ||
-        (await verifyAuthorityEnvelope(envelope)) !== true
-      ) {
-        fail('system-record-closure', 'authority-transition verification failed');
-      }
-      parsedTransitions.set(objectDigest, envelope.object);
-      if (context.referencedByHeadDigest !== undefined) {
-        const referencingHead = parsedHeads.get(context.referencedByHeadDigest);
-        if (
-          referencingHead === undefined ||
-          !isAgentProfileHeadBoundToAcceptedTransitionV1(referencingHead, envelope.object)
-        ) {
-          fail('system-record-closure', 'head does not bind its accepted authority transition');
-        }
-      }
-      rootClaims.add(envelope.object.nextRoot);
-      add('agent-profile-head', envelope.object.priorHeadDigest, 'history');
-    } else if (objectKind === 'fork-resolution') {
-      const envelope = parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(canonicalBytes);
-      if (
-        envelope.objectDigest !== objectDigest ||
-        (await verifyAuthorityEnvelope(envelope)) !== true
-      ) {
-        fail('system-record-closure', 'fork-resolution verification failed');
-      }
-      parsedResolutions.push(envelope.object);
-      if (isIssuedTooFarInFuture(envelope.object.issuedAt, nowMs)) {
-        fail(
-          'system-record-closure',
-          'fork resolution issuedAt exceeds the future clock-skew bound',
-        );
-      }
-      if (context.referencedByHeadDigest !== undefined) {
-        const referencingHead = parsedHeads.get(context.referencedByHeadDigest);
-        if (
-          referencingHead === undefined ||
-          !isDirectResolvingSuccessorV1(referencingHead, envelope.object)
-        ) {
-          fail(
-            'system-record-closure',
-            'current head is not the direct successor of its fork resolution',
-          );
-        }
-      }
-      for (const headDigest of envelope.object.evidenceHeadDigests) {
-        add('agent-profile-head', headDigest, 'fork-evidence');
-      }
-      if (envelope.object.forkBaseHeadDigest !== undefined) {
-        add('agent-profile-head', envelope.object.forkBaseHeadDigest, 'history');
-      }
-    } else if (objectKind === 'profile-bundle') {
-      const current = parsedHeads.get(currentHeadDigest);
-      if (
-        current?.state !== 'active' ||
-        digestSystemRecordBytesV1(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle, canonicalBytes) !==
-          objectDigest ||
-        (await verifyCurrentBundle(current, canonicalBytes.slice())) !== true
-      ) {
-        fail('system-record-closure', 'current profile bundle verification failed');
-      }
-    } else if (objectKind === 'owned-subject-table') {
-      if (context.rootSubject === undefined)
-        fail('system-record-closure', 'subject table lacks root context');
-      const table = parseCanonicalOwnedSubjectTableObjectV1(context.rootSubject, canonicalBytes);
-      if (computeOwnedSubjectTableDigestV1(context.rootSubject, table) !== objectDigest) {
-        fail('system-record-closure', 'owned-subject table digest mismatch');
-      }
-    } else {
-      fail('system-record-closure', `${objectKind} is not part of an advertised row closure`);
-    }
-
-    bytes += canonicalBytes.byteLength;
+    state.canonicalBytes += canonicalBytes.byteLength;
     if (
-      artifacts.length + 1 > SYSTEM_RECORD_MAX_CLOSURE_OBJECTS ||
-      bytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES ||
-      rootClaims.size > SYSTEM_RECORD_MAX_ROOT_CLAIMS ||
-      parsedResolutions.length > SYSTEM_RECORD_MAX_RESOLVED_FORK_TUPLES
+      state.artifacts.length + 1 > SYSTEM_RECORD_MAX_CLOSURE_OBJECTS ||
+      state.canonicalBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES ||
+      state.rootClaims.size > SYSTEM_RECORD_MAX_ROOT_CLAIMS ||
+      state.parsedResolutions.length > SYSTEM_RECORD_MAX_RESOLVED_FORK_TUPLES
     ) {
       fail('system-record-closure', 'verification closure exceeds a V1 bound');
     }
-    seen.set(key, objectKind);
-    artifacts.push(
+    state.seen.set(key, objectKind);
+    state.artifacts.push(
       Object.freeze({
         objectKind,
         digest: objectDigest,
@@ -407,30 +518,45 @@ export async function buildAgentProfileVerificationClosureV1(
         references: Object.freeze(references.sort(compareClosureObjects)),
       }),
     );
-    if (seen.size + pending.size > SYSTEM_RECORD_MAX_CLOSURE_OBJECTS) {
+    if (state.seen.size + state.pending.size > SYSTEM_RECORD_MAX_CLOSURE_OBJECTS) {
       fail('system-record-closure', 'verification closure cannot fit before dependency fetch');
     }
   }
 
-  for (const resolution of parsedResolutions) {
+  return Object.freeze({
+    currentHeadDigest,
+    artifacts: Object.freeze([...state.artifacts]),
+    parsedHeads: new Map(state.parsedHeads),
+    parsedTransitions: new Map(state.parsedTransitions),
+    parsedResolutions: Object.freeze([...state.parsedResolutions]),
+    rootClaimCount: state.rootClaims.size,
+    canonicalBytes: state.canonicalBytes,
+  });
+}
+
+function validateCollectedClosureAuthorityV1(
+  state: CollectedClosureV1,
+  nowMs: number,
+): void {
+  for (const resolution of state.parsedResolutions) {
     const evidence = resolution.evidenceHeadDigests.map((headDigest) =>
-      parsedHeads.get(headDigest),
+      state.parsedHeads.get(headDigest),
     );
     if (evidence.some((head) => head === undefined)) {
       fail('system-record-closure', 'fork evidence is incomplete after traversal');
     }
-    const base =
-      resolution.forkBaseHeadDigest === undefined
-        ? undefined
-        : parsedHeads.get(resolution.forkBaseHeadDigest);
+    const base = resolution.forkBaseHeadDigest === undefined
+      ? undefined
+      : state.parsedHeads.get(resolution.forkBaseHeadDigest);
     assertAgentProfileForkResolutionEvidenceV1(
       resolution,
       evidence as AgentProfileHeadObjectV1[],
       base,
     );
-    const transitionDigest = (evidence as AgentProfileHeadObjectV1[])[0].acceptedTransitionDigest;
+    const transitionDigest = (evidence as AgentProfileHeadObjectV1[])[0]
+      .acceptedTransitionDigest;
     const resolutionDigest = computeAgentProfileForkResolutionDigestV1(resolution);
-    for (const head of parsedHeads.values()) {
+    for (const head of state.parsedHeads.values()) {
       if (
         head.forkResolutionDigest === resolutionDigest &&
         head.acceptedTransitionDigest !== transitionDigest
@@ -439,9 +565,10 @@ export async function buildAgentProfileVerificationClosureV1(
       }
     }
   }
+
   const transitionTupleDigests = new Map<string, Digest32V1>();
-  for (const [transitionDigest, transition] of parsedTransitions) {
-    const prior = parsedHeads.get(transition.priorHeadDigest);
+  for (const [transitionDigest, transition] of state.parsedTransitions) {
+    const prior = state.parsedHeads.get(transition.priorHeadDigest);
     if (
       prior === undefined ||
       evaluateAuthorityTransitionV1(transition, prior, nowMs).decision !== 'accept'
@@ -466,10 +593,11 @@ export async function buildAgentProfileVerificationClosureV1(
     }
     transitionTupleDigests.set(tuple, transitionDigest);
   }
-  for (const [headDigest, head] of parsedHeads) {
-    assertCompleteUniqueRootLineage(headDigest, head);
+
+  for (const [headDigest, head] of state.parsedHeads) {
+    assertCompleteUniqueRootLineageV1(state, headDigest, head);
     if (head.acceptedTransitionDigest !== undefined) {
-      const transition = parsedTransitions.get(head.acceptedTransitionDigest);
+      const transition = state.parsedTransitions.get(head.acceptedTransitionDigest);
       if (
         transition === undefined ||
         !isAgentProfileHeadBoundToAcceptedTransitionV1(head, transition)
@@ -477,8 +605,11 @@ export async function buildAgentProfileVerificationClosureV1(
         fail('system-record-closure', `head ${headDigest} does not bind its accepted transition`);
       }
     }
-    if (headDigest === currentHeadDigest && head.forkResolutionDigest !== undefined) {
-      const resolution = parsedResolutions.find(
+    if (
+      headDigest === state.currentHeadDigest &&
+      head.forkResolutionDigest !== undefined
+    ) {
+      const resolution = state.parsedResolutions.find(
         (candidate) =>
           computeAgentProfileForkResolutionDigestV1(candidate) === head.forkResolutionDigest,
       );
@@ -490,10 +621,14 @@ export async function buildAgentProfileVerificationClosureV1(
       }
     }
   }
-  for (const head of parsedHeads.values()) {
+
+  for (const head of state.parsedHeads.values()) {
     if (head.state === 'tombstone') {
-      const predecessor = parsedHeads.get(head.previousHeadDigest);
-      if (predecessor?.state !== 'active' || !isTombstoneBoundToPredecessorV1(head, predecessor)) {
+      const predecessor = state.parsedHeads.get(head.previousHeadDigest);
+      if (
+        predecessor?.state !== 'active' ||
+        !isTombstoneBoundToPredecessorV1(head, predecessor)
+      ) {
         fail(
           'system-record-closure',
           'tombstone predecessor is not the exact prior active authority state',
@@ -501,148 +636,147 @@ export async function buildAgentProfileVerificationClosureV1(
       }
     }
   }
-  const authoritySummary = createVerifiedAuthoritySummary();
-  artifacts.sort(compareClosureObjects);
+}
+
+function assertCompleteUniqueRootLineageV1(
+  state: CollectedClosureV1,
+  headDigest: Digest32V1,
+  head: AgentProfileHeadObjectV1,
+): void {
+  let cursor = head;
+  let sequence = parseCanonicalDecimalU64(head.authoritySequence);
+  const roots = new Set<string>([head.rootSubject]);
+  for (let depth = 0; sequence > 0n; depth += 1) {
+    if (
+      depth >= Number(SYSTEM_RECORD_AUTHORITY_SEQUENCE_MAX) ||
+      cursor.acceptedTransitionDigest === undefined
+    ) {
+      fail('system-record-history', `head ${headDigest} has incomplete authority/root lineage`);
+    }
+    const transition = state.parsedTransitions.get(cursor.acceptedTransitionDigest);
+    const prior = transition === undefined
+      ? undefined
+      : state.parsedHeads.get(transition.priorHeadDigest);
+    if (
+      transition === undefined ||
+      prior === undefined ||
+      parseCanonicalDecimalU64(transition.nextAuthoritySequence) !== sequence ||
+      parseCanonicalDecimalU64(prior.authoritySequence) + 1n !== sequence
+    ) {
+      fail('system-record-history', `head ${headDigest} has incomplete authority/root lineage`);
+    }
+    if (roots.has(prior.rootSubject)) {
+      fail('system-record-history', `head ${headDigest} reuses a historical wallet root`);
+    }
+    roots.add(prior.rootSubject);
+    cursor = prior;
+    sequence -= 1n;
+  }
+  if (cursor.acceptedTransitionDigest !== undefined) {
+    fail('system-record-history', `head ${headDigest} has authority evidence below sequence zero`);
+  }
+}
+
+function projectVerificationClosureV1(
+  state: CollectedClosureV1,
+): SystemRecordVerificationClosureV1 {
+  const authoritySummary = createVerifiedAuthoritySummaryV1(state);
+  const objects = Object.freeze([...state.artifacts].sort(compareClosureObjects));
   return Object.freeze({
-    objects: Object.freeze(artifacts),
-    canonicalBytes: bytes,
-    rootClaims: rootClaims.size,
-    resolvedForkTuples: parsedResolutions.length,
+    objects,
+    canonicalBytes: state.canonicalBytes,
+    rootClaims: state.rootClaimCount,
+    resolvedForkTuples: state.parsedResolutions.length,
     authoritySummary,
   });
+}
 
-  function enqueue(
-    objectKind: SystemRecordObjectKindV1,
-    objectDigest: Digest32V1,
-    purpose: ClosurePurposeV1,
-    rootSubject?: string,
-    referencedByHeadDigest?: Digest32V1,
-  ): void {
-    digest(objectDigest, 'closure reference digest');
-    const key = objectDigest;
-    const seenKind = seen.get(key);
-    if (seenKind !== undefined) {
-      if (seenKind !== objectKind) {
-        fail(
-          'system-record-closure',
-          'one closure digest was referenced under different object kinds',
-        );
-      }
-      return;
-    }
-    const existing = pending.get(key);
-    if (existing !== undefined && existing.objectKind !== objectKind) {
-      fail('system-record-closure', 'one pending closure digest has conflicting object kinds');
-    }
-    const priority: Record<ClosurePurposeV1, number> = {
-      history: 0,
-      'fork-evidence': 1,
-      'tombstone-predecessor': 2,
-      'deletion-predecessor': 3,
-      current: 4,
-    };
-    if (existing === undefined || priority[purpose] > priority[existing.purpose]) {
-      pending.set(key, {
-        objectKind,
-        digest: objectDigest,
-        purpose,
-        ...(rootSubject === undefined ? {} : { rootSubject }),
-        ...(referencedByHeadDigest === undefined ? {} : { referencedByHeadDigest }),
-      });
-    }
+function createVerifiedAuthoritySummaryV1(
+  state: CollectedClosureV1,
+): AgentProfileVerifiedAuthoritySummaryV1 {
+  const current = state.parsedHeads.get(state.currentHeadDigest);
+  if (current === undefined) {
+    fail('system-record-closure', 'verified closure lost its current head');
   }
+  const reverseLineage: AgentProfileAppliedTransitionV1[] = [];
+  const reverseRoots: string[] = [];
+  let cursor = current;
+  let sequence = parseCanonicalDecimalU64(current.authoritySequence);
+  while (sequence > 0n) {
+    const transition = cursor.acceptedTransitionDigest === undefined
+      ? undefined
+      : state.parsedTransitions.get(cursor.acceptedTransitionDigest);
+    const prior = transition === undefined
+      ? undefined
+      : state.parsedHeads.get(transition.priorHeadDigest);
+    if (transition === undefined || prior === undefined) {
+      fail('system-record-history', 'verified closure lost its authority lineage');
+    }
+    reverseLineage.push(
+      Object.freeze({
+        priorAuthoritySequence: transition.priorAuthoritySequence,
+        nextAuthoritySequence: transition.nextAuthoritySequence,
+        transitionDigest: computeAgentProfileAuthorityTransitionDigestV1(transition),
+      }),
+    );
+    reverseRoots.push(prior.rootSubject);
+    cursor = prior;
+    sequence -= 1n;
+  }
+  const tombstonePredecessor = current.state === 'tombstone'
+    ? state.parsedHeads.get(current.previousHeadDigest)
+    : undefined;
+  if (tombstonePredecessor !== undefined && tombstonePredecessor.state !== 'active') {
+    fail('system-record-history', 'verified tombstone closure lost its active predecessor');
+  }
+  const latestTransition = current.acceptedTransitionDigest === undefined
+    ? undefined
+    : state.parsedTransitions.get(current.acceptedTransitionDigest);
+  if (current.authoritySequence !== '0' && latestTransition === undefined) {
+    fail('system-record-history', 'verified closure lost its latest authority transition');
+  }
+  return mintAgentProfileVerifiedAuthoritySummaryV1({
+    candidateHeadDigest: state.currentHeadDigest,
+    transitionLineage: Object.freeze(reverseLineage.reverse()),
+    historicalRoots: Object.freeze(reverseRoots.reverse()),
+    lastAuthorityTransitionPriorHeadDigest: latestTransition?.priorHeadDigest,
+    tombstonePredecessor:
+      tombstonePredecessor?.state === 'active' ? tombstonePredecessor : undefined,
+    deletionTableDigest: tombstonePredecessor?.ownedSubjectTableDigest,
+  });
+}
 
-  function assertCompleteUniqueRootLineage(
-    headDigest: Digest32V1,
-    head: AgentProfileHeadObjectV1,
-  ): void {
-    let cursor = head;
-    let sequence = parseCanonicalDecimalU64(head.authoritySequence);
-    const roots = new Set<string>([head.rootSubject]);
-    for (let depth = 0; sequence > 0n; depth += 1) {
-      if (
-        depth >= Number(SYSTEM_RECORD_AUTHORITY_SEQUENCE_MAX) ||
-        cursor.acceptedTransitionDigest === undefined
-      ) {
-        fail('system-record-history', `head ${headDigest} has incomplete authority/root lineage`);
-      }
-      const transition = parsedTransitions.get(cursor.acceptedTransitionDigest);
-      const prior =
-        transition === undefined ? undefined : parsedHeads.get(transition.priorHeadDigest);
-      if (
-        transition === undefined ||
-        prior === undefined ||
-        parseCanonicalDecimalU64(transition.nextAuthoritySequence) !== sequence ||
-        parseCanonicalDecimalU64(prior.authoritySequence) + 1n !== sequence
-      ) {
-        fail('system-record-history', `head ${headDigest} has incomplete authority/root lineage`);
-      }
-      if (roots.has(prior.rootSubject)) {
-        fail('system-record-history', `head ${headDigest} reuses a historical wallet root`);
-      }
-      roots.add(prior.rootSubject);
-      cursor = prior;
-      sequence -= 1n;
-    }
-    if (cursor.acceptedTransitionDigest !== undefined) {
-      fail(
-        'system-record-history',
-        `head ${headDigest} has authority evidence below sequence zero`,
-      );
-    }
+/**
+ * Derive the row closure from canonical objects rather than trusting caller-supplied edges.
+ * Authority and current-bundle verification stay injected because final chain/seal proofs
+ * belong to later stacks, but a false/missing verifier result always fails closed.
+ */
+export async function buildAgentProfileVerificationClosureV1(
+  currentHeadDigest: Digest32V1,
+  verifier: AgentProfileClosureVerifierV1,
+): Promise<SystemRecordVerificationClosureV1> {
+  digest(currentHeadDigest, 'currentHeadDigest');
+  const nowMs = verifier.nowMs;
+  const resolve = verifier.resolve;
+  const verifyAuthorityEnvelope = verifier.verifyAuthorityEnvelope;
+  const verifyCurrentBundle = verifier.verifyCurrentBundle;
+  if (!isSafeNow(nowMs)) fail('system-record-closure', 'closure verifier clock is invalid');
+  if (
+    typeof resolve !== 'function' ||
+    typeof verifyAuthorityEnvelope !== 'function' ||
+    typeof verifyCurrentBundle !== 'function'
+  ) {
+    fail('system-record-closure', 'closure verifier callbacks are invalid');
   }
-
-  function createVerifiedAuthoritySummary(): AgentProfileVerifiedAuthoritySummaryV1 {
-    const current = parsedHeads.get(currentHeadDigest);
-    if (current === undefined)
-      fail('system-record-closure', 'verified closure lost its current head');
-    const reverseLineage: AgentProfileAppliedTransitionV1[] = [];
-    const reverseRoots: string[] = [];
-    let cursor = current;
-    let sequence = parseCanonicalDecimalU64(current.authoritySequence);
-    while (sequence > 0n) {
-      const transition =
-        cursor.acceptedTransitionDigest === undefined
-          ? undefined
-          : parsedTransitions.get(cursor.acceptedTransitionDigest);
-      const prior =
-        transition === undefined ? undefined : parsedHeads.get(transition.priorHeadDigest);
-      if (transition === undefined || prior === undefined) {
-        fail('system-record-history', 'verified closure lost its authority lineage');
-      }
-      reverseLineage.push(
-        Object.freeze({
-          priorAuthoritySequence: transition.priorAuthoritySequence,
-          nextAuthoritySequence: transition.nextAuthoritySequence,
-          transitionDigest: computeAgentProfileAuthorityTransitionDigestV1(transition),
-        }),
-      );
-      reverseRoots.push(prior.rootSubject);
-      cursor = prior;
-      sequence -= 1n;
-    }
-    const tombstonePredecessor =
-      current.state === 'tombstone' ? parsedHeads.get(current.previousHeadDigest) : undefined;
-    if (tombstonePredecessor !== undefined && tombstonePredecessor.state !== 'active') {
-      fail('system-record-history', 'verified tombstone closure lost its active predecessor');
-    }
-    const latestTransition =
-      current.acceptedTransitionDigest === undefined
-        ? undefined
-        : parsedTransitions.get(current.acceptedTransitionDigest);
-    if (current.authoritySequence !== '0' && latestTransition === undefined) {
-      fail('system-record-history', 'verified closure lost its latest authority transition');
-    }
-    return mintAgentProfileVerifiedAuthoritySummaryV1({
-      candidateHeadDigest: currentHeadDigest,
-      transitionLineage: Object.freeze(reverseLineage.reverse()),
-      historicalRoots: Object.freeze(reverseRoots.reverse()),
-      lastAuthorityTransitionPriorHeadDigest: latestTransition?.priorHeadDigest,
-      tombstonePredecessor:
-        tombstonePredecessor?.state === 'active' ? tombstonePredecessor : undefined,
-      deletionTableDigest: tombstonePredecessor?.ownedSubjectTableDigest,
-    });
-  }
+  const execution: ClosureExecutionV1 = Object.freeze({
+    nowMs,
+    resolve,
+    verifyAuthorityEnvelope,
+    verifyCurrentBundle,
+  });
+  const collected = await collectVerificationClosureV1(currentHeadDigest, execution);
+  validateCollectedClosureAuthorityV1(collected, nowMs);
+  return projectVerificationClosureV1(collected);
 }
 
 function compareClosureObjects(

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -296,14 +296,23 @@ async function visitClosureObjectV1(
       digest: reference.digest,
     }));
   }
-  if (effects.head !== undefined) {
-    state.parsedHeads.set(effects.head.digest, effects.head.object);
-  }
-  if (effects.transition !== undefined) {
-    state.parsedTransitions.set(effects.transition.digest, effects.transition.object);
-  }
-  if (effects.resolution !== undefined) {
-    state.parsedResolutions.push(effects.resolution);
+  switch (effects.objectKind) {
+    case 'agent-profile-head':
+      state.parsedHeads.set(effects.head.digest, effects.head.object);
+      break;
+    case 'authority-transition':
+      state.parsedTransitions.set(effects.transition.digest, effects.transition.object);
+      break;
+    case 'fork-resolution':
+      state.parsedResolutions.push(effects.resolution);
+      break;
+    case 'profile-bundle':
+    case 'owned-subject-table':
+      break;
+    default: {
+      const unreachable: never = effects;
+      fail('system-record-closure', `unsupported closure effect ${String(unreachable)}`);
+    }
   }
   for (const rootClaim of effects.rootClaims) state.rootClaims.add(rootClaim);
 }

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -2,12 +2,10 @@ import { snapshotExactDataRecord } from './sync-wire-objects.js';
 import { parseCanonicalDecimalU64, type Digest32V1 } from './sync-wire-scalars.js';
 import {
   copyBoundedSystemRecordBytesV1,
-  digestSystemRecordBytesV1,
   failSystemRecordObjectV1 as fail,
 } from './system-record-codec-primitives-v1.js';
 import {
   SYSTEM_RECORD_AUTHORITY_SEQUENCE_MAX,
-  SYSTEM_RECORD_DIGEST_DOMAINS_V1,
   SYSTEM_RECORD_MAX_CLOSURE_BYTES,
   SYSTEM_RECORD_MAX_CLOSURE_OBJECTS,
   SYSTEM_RECORD_MAX_CONFLICT_DIGESTS,
@@ -31,25 +29,19 @@ import type {
   AgentProfileHeadObjectV1,
 } from './system-record-agent-profile-head-codec-v1-internal.js';
 import { digest } from './system-record-agent-profile-primitives-v1-internal.js';
-import {
-  computeOwnedSubjectTableDigestV1,
-  parseCanonicalOwnedSubjectTableObjectV1,
-} from './system-record-owned-subject-codecs-v1-internal.js';
 import type { AgentProfileAppliedTransitionV1 } from './system-record-authority-types-v1-internal.js';
 import {
   assertAgentProfileForkResolutionEvidenceV1,
   evaluateAuthorityTransitionV1,
   isAgentProfileHeadBoundToAcceptedTransitionV1,
   isDirectResolvingSuccessorV1,
-  isIssuedTooFarInFuture,
   isSafeNow,
   isTombstoneBoundToPredecessorV1,
 } from './system-record-authority-verification-v1-internal.js';
 import {
-  parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
-  parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
-  parseCanonicalSignedAgentProfileHeadEnvelopeV1,
-} from './system-record-signatures-v1-internal.js';
+  interpretClosureObjectV1,
+  type ClosureVisitEffectsV1,
+} from './system-record-verification-closure-visitors-v1-internal.js';
 
 const MINT_AGENT_PROFILE_VERIFIED_AUTHORITY_SUMMARY_V1 = Symbol(
   'mint-agent-profile-verified-authority-summary-v1',
@@ -284,160 +276,39 @@ async function visitClosureObjectV1(
   references: ClosureReferenceV1[],
   execution: ClosureExecutionV1,
 ): Promise<void> {
-  const objectKind = context.objectKind;
-  const objectDigest = context.digest;
-  const add = (
-    referencedKind: SystemRecordObjectKindV1,
-    referencedDigest: Digest32V1,
-    purpose: ClosurePurposeV1,
-    rootSubject?: string,
-    referencedByHeadDigest?: Digest32V1,
-  ) => {
+  const effects: ClosureVisitEffectsV1 = await interpretClosureObjectV1(
+    Object.freeze({
+      currentHeadDigest: state.currentHeadDigest,
+      parsedHeads: state.parsedHeads,
+    }),
+    context,
+    canonicalBytes,
+    execution,
+  );
+  for (const reference of effects.references) {
     enqueueClosureReferenceV1(
       state,
-      referencedKind,
-      referencedDigest,
-      purpose,
-      rootSubject,
-      referencedByHeadDigest,
+      reference.objectKind,
+      reference.digest,
+      reference.purpose,
+      reference.rootSubject,
+      reference.referencedByHeadDigest,
     );
-    references.push(Object.freeze({ objectKind: referencedKind, digest: referencedDigest }));
-  };
-
-  if (objectKind === 'agent-profile-head') {
-    const envelope = parseCanonicalSignedAgentProfileHeadEnvelopeV1(canonicalBytes);
-    if (
-      envelope.objectDigest !== objectDigest ||
-      (await execution.verifyAuthorityEnvelope(envelope)) !== true
-    ) {
-      fail('system-record-closure', 'head authority verification failed');
-    }
-    const head = envelope.object;
-    if (isIssuedTooFarInFuture(head.issuedAt, execution.nowMs)) {
-      fail('system-record-closure', 'head issuedAt exceeds the future clock-skew bound');
-    }
-    state.parsedHeads.set(objectDigest, head);
-    state.rootClaims.add(head.rootSubject);
-    if (head.acceptedTransitionDigest !== undefined) {
-      add(
-        'authority-transition',
-        head.acceptedTransitionDigest,
-        'history',
-        undefined,
-        objectDigest,
-      );
-    }
-    if (
-      objectDigest === state.currentHeadDigest &&
-      head.forkResolutionDigest !== undefined
-    ) {
-      add('fork-resolution', head.forkResolutionDigest, 'history', undefined, objectDigest);
-    }
-    if (context.purpose === 'current' && head.state === 'active') {
-      add('profile-bundle', head.bundleDigest, 'current');
-    }
-    if (head.state === 'tombstone') {
-      add(
-        'agent-profile-head',
-        head.previousHeadDigest,
-        context.purpose === 'current' ? 'deletion-predecessor' : 'tombstone-predecessor',
-      );
-    }
-    if (
-      context.purpose === 'deletion-predecessor' ||
-      context.purpose === 'tombstone-predecessor'
-    ) {
-      if (head.state !== 'active') {
-        fail('system-record-closure', 'tombstone predecessor must be active');
-      }
-      if (context.purpose === 'deletion-predecessor') {
-        add('owned-subject-table', head.ownedSubjectTableDigest, 'history', head.rootSubject);
-      }
-    }
-    return;
+    references.push(Object.freeze({
+      objectKind: reference.objectKind,
+      digest: reference.digest,
+    }));
   }
-
-  if (objectKind === 'authority-transition') {
-    const envelope = parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(canonicalBytes);
-    if (
-      envelope.objectDigest !== objectDigest ||
-      (await execution.verifyAuthorityEnvelope(envelope)) !== true
-    ) {
-      fail('system-record-closure', 'authority-transition verification failed');
-    }
-    state.parsedTransitions.set(objectDigest, envelope.object);
-    if (context.referencedByHeadDigest !== undefined) {
-      const referencingHead = state.parsedHeads.get(context.referencedByHeadDigest);
-      if (
-        referencingHead === undefined ||
-        !isAgentProfileHeadBoundToAcceptedTransitionV1(referencingHead, envelope.object)
-      ) {
-        fail('system-record-closure', 'head does not bind its accepted authority transition');
-      }
-    }
-    state.rootClaims.add(envelope.object.nextRoot);
-    add('agent-profile-head', envelope.object.priorHeadDigest, 'history');
-    return;
+  if (effects.head !== undefined) {
+    state.parsedHeads.set(effects.head.digest, effects.head.object);
   }
-
-  if (objectKind === 'fork-resolution') {
-    const envelope = parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(canonicalBytes);
-    if (
-      envelope.objectDigest !== objectDigest ||
-      (await execution.verifyAuthorityEnvelope(envelope)) !== true
-    ) {
-      fail('system-record-closure', 'fork-resolution verification failed');
-    }
-    state.parsedResolutions.push(envelope.object);
-    if (isIssuedTooFarInFuture(envelope.object.issuedAt, execution.nowMs)) {
-      fail('system-record-closure', 'fork resolution issuedAt exceeds the future clock-skew bound');
-    }
-    if (context.referencedByHeadDigest !== undefined) {
-      const referencingHead = state.parsedHeads.get(context.referencedByHeadDigest);
-      if (
-        referencingHead === undefined ||
-        !isDirectResolvingSuccessorV1(referencingHead, envelope.object)
-      ) {
-        fail(
-          'system-record-closure',
-          'current head is not the direct successor of its fork resolution',
-        );
-      }
-    }
-    for (const headDigest of envelope.object.evidenceHeadDigests) {
-      add('agent-profile-head', headDigest, 'fork-evidence');
-    }
-    if (envelope.object.forkBaseHeadDigest !== undefined) {
-      add('agent-profile-head', envelope.object.forkBaseHeadDigest, 'history');
-    }
-    return;
+  if (effects.transition !== undefined) {
+    state.parsedTransitions.set(effects.transition.digest, effects.transition.object);
   }
-
-  if (objectKind === 'profile-bundle') {
-    const current = state.parsedHeads.get(state.currentHeadDigest);
-    if (
-      current?.state !== 'active' ||
-      digestSystemRecordBytesV1(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle, canonicalBytes) !==
-        objectDigest ||
-      (await execution.verifyCurrentBundle(current, canonicalBytes.slice())) !== true
-    ) {
-      fail('system-record-closure', 'current profile bundle verification failed');
-    }
-    return;
+  if (effects.resolution !== undefined) {
+    state.parsedResolutions.push(effects.resolution);
   }
-
-  if (objectKind === 'owned-subject-table') {
-    if (context.rootSubject === undefined) {
-      fail('system-record-closure', 'subject table lacks root context');
-    }
-    const table = parseCanonicalOwnedSubjectTableObjectV1(context.rootSubject, canonicalBytes);
-    if (computeOwnedSubjectTableDigestV1(context.rootSubject, table) !== objectDigest) {
-      fail('system-record-closure', 'owned-subject table digest mismatch');
-    }
-    return;
-  }
-
-  fail('system-record-closure', `${objectKind} is not part of an advertised row closure`);
+  for (const rootClaim of effects.rootClaims) state.rootClaims.add(rootClaim);
 }
 
 async function collectVerificationClosureV1(

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -168,7 +168,6 @@ interface ClosurePendingReferenceV1 {
   readonly digest: Digest32V1;
   readonly purpose: ClosurePurposeV1;
   readonly rootSubject?: string;
-  readonly referencedByHeadDigest?: Digest32V1;
 }
 
 interface ClosureTraversalStateV1 {
@@ -233,7 +232,6 @@ function enqueueClosureReferenceV1(
   objectDigest: Digest32V1,
   purpose: ClosurePurposeV1,
   rootSubject?: string,
-  referencedByHeadDigest?: Digest32V1,
 ): void {
   digest(objectDigest, 'closure reference digest');
   const seenKind = state.seen.get(objectDigest);
@@ -259,7 +257,6 @@ function enqueueClosureReferenceV1(
       digest: objectDigest,
       purpose,
       ...(rootSubject === undefined ? {} : { rootSubject }),
-      ...(referencedByHeadDigest === undefined ? {} : { referencedByHeadDigest }),
     });
   }
 }
@@ -276,10 +273,11 @@ async function visitClosureObjectV1(
   references: ClosureReferenceV1[],
   execution: ClosureExecutionV1,
 ): Promise<void> {
+  const currentHead = state.parsedHeads.get(state.currentHeadDigest);
   const effects: ClosureVisitEffectsV1 = await interpretClosureObjectV1(
     Object.freeze({
       currentHeadDigest: state.currentHeadDigest,
-      parsedHeads: state.parsedHeads,
+      ...(currentHead === undefined ? {} : { currentHead }),
     }),
     context,
     canonicalBytes,
@@ -292,7 +290,6 @@ async function visitClosureObjectV1(
       reference.digest,
       reference.purpose,
       reference.rootSubject,
-      reference.referencedByHeadDigest,
     );
     references.push(Object.freeze({
       objectKind: reference.objectKind,
@@ -473,7 +470,10 @@ function validateCollectedClosureAuthorityV1(
         transition === undefined ||
         !isAgentProfileHeadBoundToAcceptedTransitionV1(head, transition)
       ) {
-        fail('system-record-closure', `head ${headDigest} does not bind its accepted transition`);
+        fail(
+          'system-record-closure',
+          `head ${headDigest} does not bind its accepted authority transition`,
+        );
       }
     }
     if (

--- a/packages/core/src/system-record-verification-closure-visitors-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-visitors-v1-internal.ts
@@ -31,7 +31,7 @@ import {
   parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
   parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
   parseCanonicalSignedAgentProfileHeadEnvelopeV1,
-} from './system-record-signatures-v1-internal.js';
+} from './system-record-signed-envelope-codecs-v1-internal.js';
 
 export type ClosureVisitPurposeV1 =
   | 'current'

--- a/packages/core/src/system-record-verification-closure-visitors-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-visitors-v1-internal.ts
@@ -25,8 +25,6 @@ import {
   parseCanonicalOwnedSubjectTableObjectV1,
 } from './system-record-owned-subject-codecs-v1-internal.js';
 import {
-  isAgentProfileHeadBoundToAcceptedTransitionV1,
-  isDirectResolvingSuccessorV1,
   isIssuedTooFarInFuture,
 } from './system-record-authority-verification-v1-internal.js';
 import {
@@ -47,7 +45,6 @@ export interface ClosureVisitReferenceV1 {
   readonly digest: Digest32V1;
   readonly purpose: ClosureVisitPurposeV1;
   readonly rootSubject?: string;
-  readonly referencedByHeadDigest?: Digest32V1;
 }
 
 export interface ClosureVisitEffectsV1 {
@@ -65,7 +62,7 @@ export interface ClosureVisitContextV1 extends ClosureVisitReferenceV1 {}
 
 export interface ClosureVisitFactsV1 {
   readonly currentHeadDigest: Digest32V1;
-  readonly parsedHeads: ReadonlyMap<Digest32V1, AgentProfileHeadObjectV1>;
+  readonly currentHead?: AgentProfileHeadObjectV1;
 }
 
 export interface ClosureVisitExecutionV1 {
@@ -92,9 +89,9 @@ export async function interpretClosureObjectV1(
     case 'agent-profile-head':
       return visitClosureHeadV1(facts, context, canonicalBytes, execution);
     case 'authority-transition':
-      return visitClosureTransitionV1(facts, context, canonicalBytes, execution);
+      return visitClosureTransitionV1(context, canonicalBytes, execution);
     case 'fork-resolution':
-      return visitClosureResolutionV1(facts, context, canonicalBytes, execution);
+      return visitClosureResolutionV1(context, canonicalBytes, execution);
     case 'profile-bundle':
       return visitClosureBundleV1(facts, context, canonicalBytes, execution);
     case 'owned-subject-table':
@@ -127,12 +124,12 @@ async function visitClosureHeadV1(
   const references: ClosureVisitReferenceV1[] = [];
   if (head.acceptedTransitionDigest !== undefined) {
     references.push(closureReference(
-      'authority-transition', head.acceptedTransitionDigest, 'history', undefined, context.digest,
+      'authority-transition', head.acceptedTransitionDigest, 'history',
     ));
   }
   if (context.digest === facts.currentHeadDigest && head.forkResolutionDigest !== undefined) {
     references.push(closureReference(
-      'fork-resolution', head.forkResolutionDigest, 'history', undefined, context.digest,
+      'fork-resolution', head.forkResolutionDigest, 'history',
     ));
   }
   if (context.purpose === 'current' && head.state === 'active') {
@@ -166,7 +163,6 @@ async function visitClosureHeadV1(
 }
 
 async function visitClosureTransitionV1(
-  facts: ClosureVisitFactsV1,
   context: ClosureVisitContextV1,
   canonicalBytes: Uint8Array,
   execution: ClosureVisitExecutionV1,
@@ -178,15 +174,6 @@ async function visitClosureTransitionV1(
   ) {
     fail('system-record-closure', 'authority-transition verification failed');
   }
-  if (context.referencedByHeadDigest !== undefined) {
-    const referencingHead = facts.parsedHeads.get(context.referencedByHeadDigest);
-    if (
-      referencingHead === undefined ||
-      !isAgentProfileHeadBoundToAcceptedTransitionV1(referencingHead, envelope.object)
-    ) {
-      fail('system-record-closure', 'head does not bind its accepted authority transition');
-    }
-  }
   return Object.freeze({
     references: Object.freeze([
       closureReference('agent-profile-head', envelope.object.priorHeadDigest, 'history'),
@@ -197,7 +184,6 @@ async function visitClosureTransitionV1(
 }
 
 async function visitClosureResolutionV1(
-  facts: ClosureVisitFactsV1,
   context: ClosureVisitContextV1,
   canonicalBytes: Uint8Array,
   execution: ClosureVisitExecutionV1,
@@ -211,18 +197,6 @@ async function visitClosureResolutionV1(
   }
   if (isIssuedTooFarInFuture(envelope.object.issuedAt, execution.nowMs)) {
     fail('system-record-closure', 'fork resolution issuedAt exceeds the future clock-skew bound');
-  }
-  if (context.referencedByHeadDigest !== undefined) {
-    const referencingHead = facts.parsedHeads.get(context.referencedByHeadDigest);
-    if (
-      referencingHead === undefined ||
-      !isDirectResolvingSuccessorV1(referencingHead, envelope.object)
-    ) {
-      fail(
-        'system-record-closure',
-        'current head is not the direct successor of its fork resolution',
-      );
-    }
   }
   const references = envelope.object.evidenceHeadDigests.map((headDigest) =>
     closureReference('agent-profile-head', headDigest, 'fork-evidence'));
@@ -244,7 +218,7 @@ async function visitClosureBundleV1(
   canonicalBytes: Uint8Array,
   execution: ClosureVisitExecutionV1,
 ): Promise<ClosureVisitEffectsV1> {
-  const current = facts.parsedHeads.get(facts.currentHeadDigest);
+  const current = facts.currentHead;
   if (
     current?.state !== 'active' ||
     digestSystemRecordBytesV1(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle, canonicalBytes) !==
@@ -275,7 +249,6 @@ function closureReference(
   objectDigest: Digest32V1,
   purpose: ClosureVisitPurposeV1,
   rootSubject?: string,
-  referencedByHeadDigest?: Digest32V1,
 ): ClosureVisitReferenceV1 {
   digest(objectDigest, 'closure reference digest');
   return Object.freeze({
@@ -283,7 +256,6 @@ function closureReference(
     digest: objectDigest,
     purpose,
     ...(rootSubject === undefined ? {} : { rootSubject }),
-    ...(referencedByHeadDigest === undefined ? {} : { referencedByHeadDigest }),
   });
 }
 

--- a/packages/core/src/system-record-verification-closure-visitors-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-visitors-v1-internal.ts
@@ -1,0 +1,292 @@
+import {
+  digestSystemRecordBytesV1,
+  failSystemRecordObjectV1 as fail,
+} from './system-record-codec-primitives-v1.js';
+import {
+  SYSTEM_RECORD_DIGEST_DOMAINS_V1,
+  type SystemRecordObjectKindV1,
+} from './system-record-limits-v1.js';
+import type { Digest32V1 } from './sync-wire-scalars.js';
+
+import type {
+  AgentProfileAuthorityTransitionV1,
+  AgentProfileForkResolutionV1,
+  SignedAgentProfileAuthorityTransitionEnvelopeV1,
+  SignedAgentProfileForkResolutionEnvelopeV1,
+  SignedAgentProfileHeadEnvelopeV1,
+} from './system-record-agent-profile-control-codecs-v1-internal.js';
+import type {
+  AgentProfileActiveHeadObjectV1,
+  AgentProfileHeadObjectV1,
+} from './system-record-agent-profile-head-codec-v1-internal.js';
+import { digest } from './system-record-agent-profile-primitives-v1-internal.js';
+import {
+  computeOwnedSubjectTableDigestV1,
+  parseCanonicalOwnedSubjectTableObjectV1,
+} from './system-record-owned-subject-codecs-v1-internal.js';
+import {
+  isAgentProfileHeadBoundToAcceptedTransitionV1,
+  isDirectResolvingSuccessorV1,
+  isIssuedTooFarInFuture,
+} from './system-record-authority-verification-v1-internal.js';
+import {
+  parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1,
+  parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1,
+  parseCanonicalSignedAgentProfileHeadEnvelopeV1,
+} from './system-record-signatures-v1-internal.js';
+
+export type ClosureVisitPurposeV1 =
+  | 'current'
+  | 'history'
+  | 'fork-evidence'
+  | 'tombstone-predecessor'
+  | 'deletion-predecessor';
+
+export interface ClosureVisitReferenceV1 {
+  readonly objectKind: SystemRecordObjectKindV1;
+  readonly digest: Digest32V1;
+  readonly purpose: ClosureVisitPurposeV1;
+  readonly rootSubject?: string;
+  readonly referencedByHeadDigest?: Digest32V1;
+}
+
+export interface ClosureVisitEffectsV1 {
+  readonly references: readonly ClosureVisitReferenceV1[];
+  readonly head?: Readonly<{ digest: Digest32V1; object: AgentProfileHeadObjectV1 }>;
+  readonly transition?: Readonly<{
+    digest: Digest32V1;
+    object: AgentProfileAuthorityTransitionV1;
+  }>;
+  readonly resolution?: AgentProfileForkResolutionV1;
+  readonly rootClaims: readonly string[];
+}
+
+export interface ClosureVisitContextV1 extends ClosureVisitReferenceV1 {}
+
+export interface ClosureVisitFactsV1 {
+  readonly currentHeadDigest: Digest32V1;
+  readonly parsedHeads: ReadonlyMap<Digest32V1, AgentProfileHeadObjectV1>;
+}
+
+export interface ClosureVisitExecutionV1 {
+  readonly nowMs: number;
+  readonly verifyAuthorityEnvelope: (
+    envelope:
+      | SignedAgentProfileHeadEnvelopeV1
+      | SignedAgentProfileAuthorityTransitionEnvelopeV1
+      | SignedAgentProfileForkResolutionEnvelopeV1,
+  ) => boolean | Promise<boolean>;
+  readonly verifyCurrentBundle: (
+    head: AgentProfileActiveHeadObjectV1,
+    canonicalBundleBytes: Uint8Array,
+  ) => boolean | Promise<boolean>;
+}
+
+export async function interpretClosureObjectV1(
+  facts: ClosureVisitFactsV1,
+  context: ClosureVisitContextV1,
+  canonicalBytes: Uint8Array,
+  execution: ClosureVisitExecutionV1,
+): Promise<ClosureVisitEffectsV1> {
+  switch (context.objectKind) {
+    case 'agent-profile-head':
+      return visitClosureHeadV1(facts, context, canonicalBytes, execution);
+    case 'authority-transition':
+      return visitClosureTransitionV1(facts, context, canonicalBytes, execution);
+    case 'fork-resolution':
+      return visitClosureResolutionV1(facts, context, canonicalBytes, execution);
+    case 'profile-bundle':
+      return visitClosureBundleV1(facts, context, canonicalBytes, execution);
+    case 'owned-subject-table':
+      return visitClosureSubjectTableV1(context, canonicalBytes);
+    default:
+      fail(
+        'system-record-closure',
+        `${context.objectKind} is not part of an advertised row closure`,
+      );
+  }
+}
+
+async function visitClosureHeadV1(
+  facts: ClosureVisitFactsV1,
+  context: ClosureVisitContextV1,
+  canonicalBytes: Uint8Array,
+  execution: ClosureVisitExecutionV1,
+): Promise<ClosureVisitEffectsV1> {
+  const envelope = parseCanonicalSignedAgentProfileHeadEnvelopeV1(canonicalBytes);
+  if (
+    envelope.objectDigest !== context.digest ||
+    (await execution.verifyAuthorityEnvelope(envelope)) !== true
+  ) {
+    fail('system-record-closure', 'head authority verification failed');
+  }
+  const head = envelope.object;
+  if (isIssuedTooFarInFuture(head.issuedAt, execution.nowMs)) {
+    fail('system-record-closure', 'head issuedAt exceeds the future clock-skew bound');
+  }
+  const references: ClosureVisitReferenceV1[] = [];
+  if (head.acceptedTransitionDigest !== undefined) {
+    references.push(closureReference(
+      'authority-transition', head.acceptedTransitionDigest, 'history', undefined, context.digest,
+    ));
+  }
+  if (context.digest === facts.currentHeadDigest && head.forkResolutionDigest !== undefined) {
+    references.push(closureReference(
+      'fork-resolution', head.forkResolutionDigest, 'history', undefined, context.digest,
+    ));
+  }
+  if (context.purpose === 'current' && head.state === 'active') {
+    references.push(closureReference('profile-bundle', head.bundleDigest, 'current'));
+  }
+  if (head.state === 'tombstone') {
+    references.push(closureReference(
+      'agent-profile-head',
+      head.previousHeadDigest,
+      context.purpose === 'current' ? 'deletion-predecessor' : 'tombstone-predecessor',
+    ));
+  }
+  if (
+    context.purpose === 'deletion-predecessor' ||
+    context.purpose === 'tombstone-predecessor'
+  ) {
+    if (head.state !== 'active') {
+      fail('system-record-closure', 'tombstone predecessor must be active');
+    }
+    if (context.purpose === 'deletion-predecessor') {
+      references.push(closureReference(
+        'owned-subject-table', head.ownedSubjectTableDigest, 'history', head.rootSubject,
+      ));
+    }
+  }
+  return Object.freeze({
+    references: Object.freeze(references),
+    head: Object.freeze({ digest: context.digest, object: head }),
+    rootClaims: Object.freeze([head.rootSubject]),
+  });
+}
+
+async function visitClosureTransitionV1(
+  facts: ClosureVisitFactsV1,
+  context: ClosureVisitContextV1,
+  canonicalBytes: Uint8Array,
+  execution: ClosureVisitExecutionV1,
+): Promise<ClosureVisitEffectsV1> {
+  const envelope = parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(canonicalBytes);
+  if (
+    envelope.objectDigest !== context.digest ||
+    (await execution.verifyAuthorityEnvelope(envelope)) !== true
+  ) {
+    fail('system-record-closure', 'authority-transition verification failed');
+  }
+  if (context.referencedByHeadDigest !== undefined) {
+    const referencingHead = facts.parsedHeads.get(context.referencedByHeadDigest);
+    if (
+      referencingHead === undefined ||
+      !isAgentProfileHeadBoundToAcceptedTransitionV1(referencingHead, envelope.object)
+    ) {
+      fail('system-record-closure', 'head does not bind its accepted authority transition');
+    }
+  }
+  return Object.freeze({
+    references: Object.freeze([
+      closureReference('agent-profile-head', envelope.object.priorHeadDigest, 'history'),
+    ]),
+    transition: Object.freeze({ digest: context.digest, object: envelope.object }),
+    rootClaims: Object.freeze([envelope.object.nextRoot]),
+  });
+}
+
+async function visitClosureResolutionV1(
+  facts: ClosureVisitFactsV1,
+  context: ClosureVisitContextV1,
+  canonicalBytes: Uint8Array,
+  execution: ClosureVisitExecutionV1,
+): Promise<ClosureVisitEffectsV1> {
+  const envelope = parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(canonicalBytes);
+  if (
+    envelope.objectDigest !== context.digest ||
+    (await execution.verifyAuthorityEnvelope(envelope)) !== true
+  ) {
+    fail('system-record-closure', 'fork-resolution verification failed');
+  }
+  if (isIssuedTooFarInFuture(envelope.object.issuedAt, execution.nowMs)) {
+    fail('system-record-closure', 'fork resolution issuedAt exceeds the future clock-skew bound');
+  }
+  if (context.referencedByHeadDigest !== undefined) {
+    const referencingHead = facts.parsedHeads.get(context.referencedByHeadDigest);
+    if (
+      referencingHead === undefined ||
+      !isDirectResolvingSuccessorV1(referencingHead, envelope.object)
+    ) {
+      fail(
+        'system-record-closure',
+        'current head is not the direct successor of its fork resolution',
+      );
+    }
+  }
+  const references = envelope.object.evidenceHeadDigests.map((headDigest) =>
+    closureReference('agent-profile-head', headDigest, 'fork-evidence'));
+  if (envelope.object.forkBaseHeadDigest !== undefined) {
+    references.push(closureReference(
+      'agent-profile-head', envelope.object.forkBaseHeadDigest, 'history',
+    ));
+  }
+  return Object.freeze({
+    references: Object.freeze(references),
+    resolution: envelope.object,
+    rootClaims: Object.freeze([]),
+  });
+}
+
+async function visitClosureBundleV1(
+  facts: ClosureVisitFactsV1,
+  context: ClosureVisitContextV1,
+  canonicalBytes: Uint8Array,
+  execution: ClosureVisitExecutionV1,
+): Promise<ClosureVisitEffectsV1> {
+  const current = facts.parsedHeads.get(facts.currentHeadDigest);
+  if (
+    current?.state !== 'active' ||
+    digestSystemRecordBytesV1(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle, canonicalBytes) !==
+      context.digest ||
+    (await execution.verifyCurrentBundle(current, canonicalBytes.slice())) !== true
+  ) {
+    fail('system-record-closure', 'current profile bundle verification failed');
+  }
+  return emptyClosureVisitEffectsV1();
+}
+
+function visitClosureSubjectTableV1(
+  context: ClosureVisitContextV1,
+  canonicalBytes: Uint8Array,
+): ClosureVisitEffectsV1 {
+  if (context.rootSubject === undefined) {
+    fail('system-record-closure', 'subject table lacks root context');
+  }
+  const table = parseCanonicalOwnedSubjectTableObjectV1(context.rootSubject, canonicalBytes);
+  if (computeOwnedSubjectTableDigestV1(context.rootSubject, table) !== context.digest) {
+    fail('system-record-closure', 'owned-subject table digest mismatch');
+  }
+  return emptyClosureVisitEffectsV1();
+}
+
+function closureReference(
+  objectKind: SystemRecordObjectKindV1,
+  objectDigest: Digest32V1,
+  purpose: ClosureVisitPurposeV1,
+  rootSubject?: string,
+  referencedByHeadDigest?: Digest32V1,
+): ClosureVisitReferenceV1 {
+  digest(objectDigest, 'closure reference digest');
+  return Object.freeze({
+    objectKind,
+    digest: objectDigest,
+    purpose,
+    ...(rootSubject === undefined ? {} : { rootSubject }),
+    ...(referencedByHeadDigest === undefined ? {} : { referencedByHeadDigest }),
+  });
+}
+
+function emptyClosureVisitEffectsV1(): ClosureVisitEffectsV1 {
+  return Object.freeze({ references: Object.freeze([]), rootClaims: Object.freeze([]) });
+}

--- a/packages/core/src/system-record-verification-closure-visitors-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-visitors-v1-internal.ts
@@ -47,16 +47,30 @@ export interface ClosureVisitReferenceV1 {
   readonly rootSubject?: string;
 }
 
-export interface ClosureVisitEffectsV1 {
+interface ClosureVisitBaseEffectsV1 {
   readonly references: readonly ClosureVisitReferenceV1[];
-  readonly head?: Readonly<{ digest: Digest32V1; object: AgentProfileHeadObjectV1 }>;
-  readonly transition?: Readonly<{
-    digest: Digest32V1;
-    object: AgentProfileAuthorityTransitionV1;
-  }>;
-  readonly resolution?: AgentProfileForkResolutionV1;
   readonly rootClaims: readonly string[];
 }
+
+export type ClosureVisitEffectsV1 =
+  | Readonly<ClosureVisitBaseEffectsV1 & {
+    objectKind: 'agent-profile-head';
+    head: Readonly<{ digest: Digest32V1; object: AgentProfileHeadObjectV1 }>;
+  }>
+  | Readonly<ClosureVisitBaseEffectsV1 & {
+    objectKind: 'authority-transition';
+    transition: Readonly<{
+      digest: Digest32V1;
+      object: AgentProfileAuthorityTransitionV1;
+    }>;
+  }>
+  | Readonly<ClosureVisitBaseEffectsV1 & {
+    objectKind: 'fork-resolution';
+    resolution: AgentProfileForkResolutionV1;
+  }>
+  | Readonly<ClosureVisitBaseEffectsV1 & {
+    objectKind: 'profile-bundle' | 'owned-subject-table';
+  }>;
 
 export interface ClosureVisitContextV1 extends ClosureVisitReferenceV1 {}
 
@@ -156,6 +170,7 @@ async function visitClosureHeadV1(
     }
   }
   return Object.freeze({
+    objectKind: 'agent-profile-head',
     references: Object.freeze(references),
     head: Object.freeze({ digest: context.digest, object: head }),
     rootClaims: Object.freeze([head.rootSubject]),
@@ -175,6 +190,7 @@ async function visitClosureTransitionV1(
     fail('system-record-closure', 'authority-transition verification failed');
   }
   return Object.freeze({
+    objectKind: 'authority-transition',
     references: Object.freeze([
       closureReference('agent-profile-head', envelope.object.priorHeadDigest, 'history'),
     ]),
@@ -206,6 +222,7 @@ async function visitClosureResolutionV1(
     ));
   }
   return Object.freeze({
+    objectKind: 'fork-resolution',
     references: Object.freeze(references),
     resolution: envelope.object,
     rootClaims: Object.freeze([]),
@@ -227,7 +244,7 @@ async function visitClosureBundleV1(
   ) {
     fail('system-record-closure', 'current profile bundle verification failed');
   }
-  return emptyClosureVisitEffectsV1();
+  return emptyClosureVisitEffectsV1('profile-bundle');
 }
 
 function visitClosureSubjectTableV1(
@@ -241,7 +258,7 @@ function visitClosureSubjectTableV1(
   if (computeOwnedSubjectTableDigestV1(context.rootSubject, table) !== context.digest) {
     fail('system-record-closure', 'owned-subject table digest mismatch');
   }
-  return emptyClosureVisitEffectsV1();
+  return emptyClosureVisitEffectsV1('owned-subject-table');
 }
 
 function closureReference(
@@ -259,6 +276,12 @@ function closureReference(
   });
 }
 
-function emptyClosureVisitEffectsV1(): ClosureVisitEffectsV1 {
-  return Object.freeze({ references: Object.freeze([]), rootClaims: Object.freeze([]) });
+function emptyClosureVisitEffectsV1(
+  objectKind: 'profile-bundle' | 'owned-subject-table',
+): ClosureVisitEffectsV1 {
+  return Object.freeze({
+    objectKind,
+    references: Object.freeze([]),
+    rootClaims: Object.freeze([]),
+  });
 }

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -211,15 +211,24 @@ describe('System Record V1 module ownership', () => {
     expect(source('system-record-verification-closure-v1-internal.ts')).toMatch(
       /function mintAgentProfileVerifiedAuthoritySummaryV1/u,
     );
+    expect(directDependencies('system-record-verification-closure-v1-internal.ts')).toContain(
+      'system-record-verification-closure-visitors-v1-internal.ts',
+    );
+    expectNoDependencyPath('system-record-verification-closure-visitors-v1-internal.ts', [
+      'system-record-verification-closure-v1-internal.ts',
+    ]);
   });
 
   it('keeps closure and cache internals below durable code-health boundaries', () => {
     expect(source('system-record-verification-closure-v1-internal.ts').split('\n').length)
       .toBeLessThan(850);
+    expect(source('system-record-verification-closure-visitors-v1-internal.ts').split('\n').length)
+      .toBeLessThan(350);
     expect(source('system-record-cache-accounting-v1-internal.ts').split('\n').length)
       .toBeLessThan(650);
     for (const unit of [
       'system-record-verification-closure-v1-internal.ts',
+      'system-record-verification-closure-visitors-v1-internal.ts',
       'system-record-cache-accounting-v1-internal.ts',
     ]) {
       expect(source(unit)).not.toMatch(/export\s+\*/u);

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -214,8 +214,11 @@ describe('System Record V1 module ownership', () => {
     expect(directDependencies('system-record-verification-closure-v1-internal.ts')).toContain(
       'system-record-verification-closure-visitors-v1-internal.ts',
     );
+    expect(directDependencies('system-record-verification-closure-visitors-v1-internal.ts'))
+      .toContain('system-record-signed-envelope-codecs-v1-internal.ts');
     expectNoDependencyPath('system-record-verification-closure-visitors-v1-internal.ts', [
       'system-record-verification-closure-v1-internal.ts',
+      'system-record-signatures-v1-internal.ts',
     ]);
   });
 

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -213,6 +213,19 @@ describe('System Record V1 module ownership', () => {
     );
   });
 
+  it('keeps closure and cache internals below durable code-health boundaries', () => {
+    expect(source('system-record-verification-closure-v1-internal.ts').split('\n').length)
+      .toBeLessThan(850);
+    expect(source('system-record-cache-accounting-v1-internal.ts').split('\n').length)
+      .toBeLessThan(650);
+    for (const unit of [
+      'system-record-verification-closure-v1-internal.ts',
+      'system-record-cache-accounting-v1-internal.ts',
+    ]) {
+      expect(source(unit)).not.toMatch(/export\s+\*/u);
+    }
+  });
+
   it('keeps wire and applied-state codecs off authority and closure implementations', () => {
     for (const unit of ['system-record-wire-v1.ts', 'system-record-applied-state-v1.ts']) {
       expectNoDependencyPath(unit, [

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -3,6 +3,10 @@ import { readdirSync, readFileSync } from 'node:fs';
 import * as ts from 'typescript';
 
 import { describe, expect, it } from 'vitest';
+import { SYSTEM_RECORD_OBJECT_CAPS_V1 } from '../src/system-record-limits-v1.js';
+import {
+  SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1,
+} from '../src/system-record-object-identity-descriptors-v1-internal.js';
 
 const source = (name: string): string =>
   readFileSync(new URL(`../src/${name}`, import.meta.url), 'utf8');
@@ -84,7 +88,9 @@ describe('System Record V1 module ownership', () => {
       'system-record-authority-v1-internal.ts',
       'system-record-verification-closure-v1-internal.ts',
       'system-record-cache-accounting-v1-internal.ts',
+      'system-record-object-identity-descriptors-v1-internal.ts',
       'system-record-inventory-codecs-v1-internal.ts',
+      'system-record-inventory-signatures-v1-internal.ts',
       'system-record-inventory-traversal-v1-internal.ts',
       'system-record-inventory-cow-build-v1-internal.ts',
       'system-record-inventory-cow-context-v1-internal.ts',
@@ -111,6 +117,28 @@ describe('System Record V1 module ownership', () => {
         'system-record-cache-accounting-v1-internal.ts',
       ]);
     }
+  });
+
+  it('keeps inventory data codecs below provider signature verification', () => {
+    expectNoDependencyPath('system-record-inventory-codecs-v1-internal.ts', [
+      'system-record-inventory-signatures-v1-internal.ts',
+    ]);
+    expect(directDependencies('system-record-inventory-signatures-v1-internal.ts')).toContain(
+      'system-record-inventory-codecs-v1-internal.ts',
+    );
+    expect(source('system-record-inventory-codecs-v1-internal.ts'))
+      .not.toMatch(/@libp2p\/|@noble\/ed25519/u);
+  });
+
+  it('owns one exhaustive internal identity descriptor for every object kind', () => {
+    expect(Object.keys(SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1).sort())
+      .toEqual(Object.keys(SYSTEM_RECORD_OBJECT_CAPS_V1).sort());
+    expect(Object.isFrozen(SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1)).toBe(true);
+    for (const descriptor of Object.values(SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1)) {
+      expect(Object.isFrozen(descriptor)).toBe(true);
+    }
+    expect(source('system-record-inventory-v1.ts'))
+      .not.toContain('system-record-object-identity-descriptors-v1-internal');
   });
 
   it('keeps COW implementation units acyclic and below the file-health boundary', () => {

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -84,6 +84,7 @@ describe('System Record V1 module ownership', () => {
       'system-record-agent-profile-evidence-codecs-v1-internal.ts',
       'system-record-owned-subject-codecs-v1-internal.ts',
       'system-record-signed-envelope-codecs-v1-internal.ts',
+      'system-record-signature-policy-v1-internal.ts',
       'system-record-signatures-v1-internal.ts',
       'system-record-authority-verification-v1-internal.ts',
       'system-record-authority-v1-internal.ts',
@@ -184,8 +185,17 @@ describe('System Record V1 module ownership', () => {
       .toContain('system-record-signed-envelope-codecs-v1-internal.ts');
     expect(directDependencies('system-record-signatures-v1-internal.ts'))
       .toContain('system-record-signed-envelope-codecs-v1-internal.ts');
+    expect(directDependencies('system-record-signed-envelope-codecs-v1-internal.ts'))
+      .toContain('system-record-signature-policy-v1-internal.ts');
+    expect(directDependencies('system-record-signatures-v1-internal.ts'))
+      .toContain('system-record-signature-policy-v1-internal.ts');
     expect(source('system-record-signed-envelope-codecs-v1-internal.ts'))
-      .not.toMatch(/@noble\/ed25519/u);
+      .not.toMatch(/@noble\/|Signature\.fromBytes|signature message/u);
+    expect(source('system-record-signature-policy-v1-internal.ts'))
+      .not.toMatch(/@noble\/ed25519|verifyEd25519/u);
+    expect(source('system-record-signatures-v1-internal.ts')).toMatch(/@noble\/ed25519/u);
+    expect(source('system-record-signed-envelope-codecs-v1-internal.ts'))
+      .not.toMatch(/concatSystemRecordBytesV1|systemRecordHexToBytesV1/u);
   });
 
   it('keeps closure verification below authority policy and summary minting private', () => {

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -219,13 +219,7 @@ describe('System Record V1 module ownership', () => {
     ]);
   });
 
-  it('keeps closure and cache internals below durable code-health boundaries', () => {
-    expect(source('system-record-verification-closure-v1-internal.ts').split('\n').length)
-      .toBeLessThan(850);
-    expect(source('system-record-verification-closure-visitors-v1-internal.ts').split('\n').length)
-      .toBeLessThan(350);
-    expect(source('system-record-cache-accounting-v1-internal.ts').split('\n').length)
-      .toBeLessThan(650);
+  it('keeps closure and cache internal exports explicit', () => {
     for (const unit of [
       'system-record-verification-closure-v1-internal.ts',
       'system-record-verification-closure-visitors-v1-internal.ts',

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -5,7 +5,7 @@ import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import { SYSTEM_RECORD_OBJECT_CAPS_V1 } from '../src/system-record-limits-v1.js';
 import {
-  SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1,
+  SYSTEM_RECORD_OBJECT_IDENTITY_DERIVERS_V1,
 } from '../src/system-record-object-identity-descriptors-v1-internal.js';
 
 const source = (name: string): string =>
@@ -83,6 +83,7 @@ describe('System Record V1 module ownership', () => {
       'system-record-agent-profile-control-codecs-v1-internal.ts',
       'system-record-agent-profile-evidence-codecs-v1-internal.ts',
       'system-record-owned-subject-codecs-v1-internal.ts',
+      'system-record-signed-envelope-codecs-v1-internal.ts',
       'system-record-signatures-v1-internal.ts',
       'system-record-authority-verification-v1-internal.ts',
       'system-record-authority-v1-internal.ts',
@@ -130,12 +131,12 @@ describe('System Record V1 module ownership', () => {
       .not.toMatch(/@libp2p\/|@noble\/ed25519/u);
   });
 
-  it('owns one exhaustive internal identity descriptor for every object kind', () => {
-    expect(Object.keys(SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1).sort())
+  it('owns one exhaustive internal identity deriver for every object kind', () => {
+    expect(Object.keys(SYSTEM_RECORD_OBJECT_IDENTITY_DERIVERS_V1).sort())
       .toEqual(Object.keys(SYSTEM_RECORD_OBJECT_CAPS_V1).sort());
-    expect(Object.isFrozen(SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1)).toBe(true);
-    for (const descriptor of Object.values(SYSTEM_RECORD_OBJECT_IDENTITY_DESCRIPTORS_V1)) {
-      expect(Object.isFrozen(descriptor)).toBe(true);
+    expect(Object.isFrozen(SYSTEM_RECORD_OBJECT_IDENTITY_DERIVERS_V1)).toBe(true);
+    for (const derive of Object.values(SYSTEM_RECORD_OBJECT_IDENTITY_DERIVERS_V1)) {
+      expect(derive).toBeTypeOf('function');
     }
     expect(source('system-record-inventory-v1.ts'))
       .not.toContain('system-record-object-identity-descriptors-v1-internal');
@@ -173,6 +174,18 @@ describe('System Record V1 module ownership', () => {
     ]) {
       expectNoDependencyPath(unit, ['system-record-signatures-v1-internal.ts']);
     }
+  });
+
+  it('keeps cache identity below profile signature verification', () => {
+    expectNoDependencyPath('system-record-object-identity-descriptors-v1-internal.ts', [
+      'system-record-signatures-v1-internal.ts',
+    ]);
+    expect(directDependencies('system-record-object-identity-descriptors-v1-internal.ts'))
+      .toContain('system-record-signed-envelope-codecs-v1-internal.ts');
+    expect(directDependencies('system-record-signatures-v1-internal.ts'))
+      .toContain('system-record-signed-envelope-codecs-v1-internal.ts');
+    expect(source('system-record-signed-envelope-codecs-v1-internal.ts'))
+      .not.toMatch(/@noble\/ed25519/u);
   });
 
   it('keeps closure verification below authority policy and summary minting private', () => {

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -1138,6 +1138,73 @@ describe('system-record owned subjects and verification closure', () => {
     })).toThrow(/aggregate cache accounting exceeds/);
   });
 
+  it('preserves shared physical accounting across closure, sidecar, and inventory paths', async () => {
+    const metadata = createSystemRecordCacheMetadataV1(new Uint8Array());
+    const reference = (
+      objectKind: 'profile-bundle' | 'conflict-evidence' | 'inventory-leaf',
+      domain: string,
+      label: string,
+    ) => {
+      const canonicalBytes = new TextEncoder().encode(label);
+      const digest = digestSystemRecordBytesV1(domain, canonicalBytes);
+      return createSystemRecordCacheReferenceV1(objectKind, digest, canonicalBytes);
+    };
+    const sharedClosure = reference(
+      'profile-bundle',
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+      'shared-closure',
+    );
+    const sharedSidecar = reference(
+      'conflict-evidence',
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.conflictEvidence,
+      'shared-sidecar',
+    );
+    const fixture = await authorityFixture();
+    const transition = authorityTransition(fixture, activeHead(fixture));
+    const transitionBytes = fakeEnvelopeBytes(transition);
+    const sharedControl = createSystemRecordCacheReferenceV1(
+      'authority-transition',
+      computeAgentProfileAuthorityTransitionDigestV1(transition),
+      transitionBytes,
+    );
+    const inventoryLeaf = reference(
+      'inventory-leaf',
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryLeaf,
+      'activation-leaf',
+    );
+    const result = preflightSystemRecordCacheAccountingV1({
+      mode: 'activation',
+      rows: [{
+        closure: [sharedClosure, sharedControl],
+        sidecar: [sharedControl, sharedSidecar],
+        metadata,
+        sidecarMetadata: metadata,
+      }],
+      inventoryLeaves: [inventoryLeaf],
+    });
+    expect(result).toMatchObject({
+      cohortPhysicalObjects: 4,
+      cohortPhysicalBytes:
+        new TextEncoder().encode('shared-closure').byteLength
+        + transitionBytes.byteLength
+        + new TextEncoder().encode('shared-sidecar').byteLength
+        + new TextEncoder().encode('activation-leaf').byteLength,
+      closureReferences: 2,
+      sidecarReferences: 2,
+      activationInventoryLeaves: 1,
+    });
+
+    expect(() => preflightSystemRecordCacheAccountingV1({
+      mode: 'activation',
+      rows: [],
+      inventoryLeaves: Array.from({ length: 5 }, (_, index) => reference(
+        'inventory-leaf',
+        SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryLeaf,
+        `activation-leaf-${index}`,
+      )),
+    })).toThrow(/leaf bound|closed bounds/);
+  });
+
   it.runIf(process.env.DKG_SYSTEM_RECORD_EXHAUSTIVE === '1')(
     'accepts exactly 128 MiB of activation bundles and rejects one more MiB', () => {
     const reusable = new Uint8Array(SYSTEM_RECORD_MAX_ATOMIC_BUNDLE_BYTES);
@@ -1765,6 +1832,21 @@ describe('system-record owned subjects and verification closure', () => {
       deletionTableDigest: middle.ownedSubjectTableDigest,
       historicalRoots: [initial.rootSubject],
       lastAuthorityTransitionPriorHeadDigest: transition.priorHeadDigest,
+    });
+    expect(closure.objects.map(({ objectKind }) => objectKind).sort()).toEqual([
+      'agent-profile-head',
+      'agent-profile-head',
+      'agent-profile-head',
+      'authority-transition',
+      'owned-subject-table',
+    ]);
+    expect(closure.objects.find(
+      ({ objectKind, digest }) =>
+        objectKind === 'authority-transition' &&
+        digest === computeAgentProfileAuthorityTransitionDigestV1(transition),
+    )?.references).toContainEqual({
+      objectKind: 'agent-profile-head',
+      digest: transition.priorHeadDigest,
     });
   });
 

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -1224,6 +1224,84 @@ describe('system-record owned subjects and verification closure', () => {
     expect(descriptorReference.cacheDigest).not.toBe(descriptorReference.digest);
   });
 
+  it('derives the established semantic and cache identity for every object kind', async () => {
+    const fixture = await authorityFixture();
+    const head = activeHead(fixture);
+    const transition = authorityTransition(fixture, head);
+    const resolution = forkResolution(fixture, head);
+    const signedCases = [
+      {
+        objectKind: 'agent-profile-head' as const,
+        semanticDigest: computeAgentProfileHeadObjectDigestV1(head),
+        canonicalBytes: fakeEnvelopeBytes(head),
+      },
+      {
+        objectKind: 'authority-transition' as const,
+        semanticDigest: computeAgentProfileAuthorityTransitionDigestV1(transition),
+        canonicalBytes: fakeEnvelopeBytes(transition),
+      },
+      {
+        objectKind: 'fork-resolution' as const,
+        semanticDigest: computeAgentProfileForkResolutionDigestV1(resolution),
+        canonicalBytes: fakeEnvelopeBytes(resolution),
+      },
+    ];
+    for (const artifact of signedCases) {
+      const reference = createSystemRecordCacheReferenceV1(
+        artifact.objectKind,
+        artifact.semanticDigest,
+        artifact.canonicalBytes,
+      );
+      expect(reference.digest).toBe(artifact.semanticDigest);
+      expect(reference.cacheDigest).toBe(digestSystemRecordBytesV1(
+        SYSTEM_RECORD_DIGEST_DOMAINS_V1.signedEnvelope,
+        artifact.canonicalBytes,
+      ));
+    }
+
+    const descriptor = {
+      objectType: 'root-descriptor', kind: 'agents', networkId: NETWORK,
+      epoch: '0', version: '0', treeRootDigest: DIGEST_A, totalRows: '0',
+    } as const;
+    const descriptorDigest = computeSystemRecordRootDescriptorDigestV1(descriptor);
+    const descriptorBytes = canonicalizeSignedSystemRecordRootDescriptorEnvelopeV1({
+      object: descriptor,
+      objectDigest: descriptorDigest,
+      providerPeerId: fixture.peerId,
+      signatureSuite: 'ed25519-v1',
+      signature: Buffer.alloc(64).toString('base64url'),
+    });
+    const descriptorReference = createSystemRecordCacheReferenceV1(
+      'root-descriptor',
+      descriptorDigest,
+      descriptorBytes,
+    );
+    expect(descriptorReference).toMatchObject({
+      digest: descriptorDigest,
+      cacheDigest: digestSystemRecordBytesV1(
+        SYSTEM_RECORD_DIGEST_DOMAINS_V1.signedRootDescriptorEnvelope,
+        descriptorBytes,
+      ),
+    });
+
+    const byteCases = [
+      ['inventory-internal', SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryInternal],
+      ['inventory-leaf', SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryLeaf],
+      ['conflict-evidence', SYSTEM_RECORD_DIGEST_DOMAINS_V1.conflictEvidence],
+      ['owned-subject-table', SYSTEM_RECORD_DIGEST_DOMAINS_V1.ownedSubjectTable],
+      ['profile-bundle', SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle],
+    ] as const;
+    for (const [objectKind, domain] of byteCases) {
+      const canonicalBytes = new TextEncoder().encode(`identity-${objectKind}`);
+      const digest = digestSystemRecordBytesV1(domain, canonicalBytes);
+      expect(createSystemRecordCacheReferenceV1(
+        objectKind,
+        digest,
+        canonicalBytes,
+      )).toMatchObject({ digest, cacheDigest: digest });
+    }
+  });
+
   it('derives a complete raw-artifact closure and fails closed on a missing dependency', async () => {
     const fixture = await authorityFixture();
     const bundle = new TextEncoder().encode('canonical-profile-bundle');

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -1190,7 +1190,16 @@ describe('system-record owned subjects and verification closure', () => {
         + new TextEncoder().encode('shared-sidecar').byteLength
         + new TextEncoder().encode('activation-leaf').byteLength,
       closureReferences: 2,
+      closurePhysicalBytes:
+        new TextEncoder().encode('shared-closure').byteLength + transitionBytes.byteLength,
+      closureReferencedBytes:
+        new TextEncoder().encode('shared-closure').byteLength + transitionBytes.byteLength,
       sidecarReferences: 2,
+      sidecarPhysicalBytes:
+        transitionBytes.byteLength + new TextEncoder().encode('shared-sidecar').byteLength,
+      sidecarReferencedBytes:
+        transitionBytes.byteLength + new TextEncoder().encode('shared-sidecar').byteLength,
+      activationBundleBytes: new TextEncoder().encode('shared-closure').byteLength,
       activationInventoryLeaves: 1,
     });
 


### PR DESCRIPTION
## Summary

- Replace parallel System Record object-kind switches and digest tables with one exhaustive internal identity descriptor owner for all nine object kinds.
- Centralize signable validation, digest, parse limits, roles, issuers, and message tuples in one typed registry; codecs and cryptographic verification reuse one bound policy.
- Decompose verification closure traversal into typed phases/visitors with localized effects and direct cache-accounting ownership, while keeping public bytes, digests, limits, and exports unchanged.
- Keep inventory codecs below signature construction/verification so pure parsing does not import the heavier signature facade.

## Related

- Fixes #2176
- Fixes #2177
- Fixes #2180
- Fixes #2181
- Includes the exact reviewed changes from #2200
- Follow-up to #2171
- Part of #2052
- Execution plan: `agent-docs/plans/2026-08-09-system-record-followup-refactors.md`

## Diagrams

### Object identity ownership

Before:

```mermaid
sequenceDiagram
    participant Cache
    participant Identity as Identity owner
    participant Codec
    participant Policy
    Cache->>Cache: Switch on every object kind
    Cache->>Codec: Parse signed envelopes
    Cache->>Policy: Select local digest/role tables
    Cache-->>Identity: Reconstruct semantic/cache identity
```

After:

```mermaid
sequenceDiagram
    participant Cache
    participant Identity as Identity owner
    participant Codec
    participant Policy
    Cache->>Identity: Kind and canonical bytes
    Identity->>Codec: Parse canonical object
    Codec->>Policy: Apply bound validation/digest roles
    Identity-->>Cache: Semantic and cache identities
```

### Verification closure ownership

Before:

```mermaid
sequenceDiagram
    participant Verify
    participant Closure
    participant Visitor
    participant Cache
    Verify->>Closure: Verify inventory closure
    Closure->>Closure: Parse, traverse, account, and mutate effects
    Closure->>Cache: Apply parallel accounting dispatch
    Visitor-->>Closure: Implicit mutable traversal state
```

After:

```mermaid
sequenceDiagram
    participant Verify
    participant Closure
    participant Visitor
    participant Cache
    Verify->>Closure: Verify inventory closure
    Closure->>Visitor: Visit typed closure phase
    Visitor->>Cache: Return explicit localized accounting effects
    Cache-->>Closure: Exhaustive descriptor-owned result
```

## Files changed

| File | What |
|------|------|
| `packages/core/src/system-record-object-identity-descriptors-v1-internal.ts` | Own exhaustive object parsing and semantic/cache identity. |
| `packages/core/src/system-record-cache-accounting-v1-internal.ts` | Consume canonical descriptors and fold accounting directly. |
| `packages/core/src/system-record-signable-object-policy-v1-internal.ts` | Own typed signable validation, digest, roles, and issuers. |
| `packages/core/src/system-record-signed-envelope-codecs-v1-internal.ts` | Consume bound policy for canonical envelope parsing and identity. |
| `packages/core/src/system-record-signature-policy-v1-internal.ts` | Own suites/evidence, EIP-191 policy, and role-bound messages. |
| `packages/core/src/system-record-signatures-v1-internal.ts` | Reuse bound policy during verification orchestration. |
| `packages/core/src/system-record-codec-primitives-v1.ts` | Own bounded byte, hex, and concatenation primitives. |
| `packages/core/src/system-record-inventory-codecs-v1-internal.ts` | Keep pure inventory parsing below signature construction. |
| `packages/core/src/system-record-inventory-signatures-v1-internal.ts` | Reuse shared primitives for provider signatures. |
| `packages/core/src/system-record-verification-closure-v1-internal.ts` | Orchestrate explicit closure phases. |
| `packages/core/src/system-record-verification-closure-visitors-v1-internal.ts` | Own typed visitors and localized effects. |
| `packages/core/test/system-record-module-boundaries-v1.test.ts` | Enforce descriptor exhaustiveness, dependency direction, and facade privacy. |
| `packages/core/test/system-record-objects-v1.test.ts` | Cover identity and closure behavior after decomposition. |

## Test plan

- [x] Build `@origintrail-official/dkg-core` after rebasing onto integration head `c49cb3126`.
- [x] Run the full System Record Core suite (101 passed, 2 exhaustive-only tests skipped).
- [x] Run package export/runtime/type verification (269 exact symbols).
- [x] Run golden signature and canonical-byte vectors unchanged as part of the full suite.
- [x] Build Storage, then build the complete Agent dependency graph including type and package-root checks.
- [x] Prove the rebase is patch-identical with `git range-diff` (14/14 commits unchanged).
- [x] Run `git diff --check`.
