### PR TITLE
refactor(core): decompose System Record verification phases

### DIFF
--- a/packages/core/src/system-record-cache-accounting-v1-internal.ts
+++ b/packages/core/src/system-record-cache-accounting-v1-internal.ts
@@ -421,9 +421,8 @@ function accountCacheReferencesV1(
   return total;
 }
 
-function assertLiveCacheAccountingBoundsV1(
+function assertIncrementalCacheAccountingBoundsV1(
   accumulator: CacheAccountingAccumulatorV1,
-  totals?: CacheAccountingTotalsV1,
 ): void {
   if (
     accumulator.closurePhysical.size > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_OBJECTS ||
@@ -431,10 +430,20 @@ function assertLiveCacheAccountingBoundsV1(
     accumulator.metadataBytes > SYSTEM_RECORD_MAX_CLOSURE_SIDECAR_LIVE_METADATA_BYTES ||
     accumulator.sidecars > SYSTEM_RECORD_MAX_CONFLICT_SIDECARS ||
     accumulator.sidecarReferences > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_REFERENCES ||
-    accumulator.sidecarMetadataBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_METADATA_BYTES ||
-    (totals !== undefined &&
-      (totals.closurePhysicalBytes > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_BYTES ||
-        totals.sidecarPhysicalBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_AGGREGATE_BYTES))
+    accumulator.sidecarMetadataBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_METADATA_BYTES
+  ) {
+    fail('system-record-closure', 'aggregate cache accounting exceeds a live V1 bound');
+  }
+}
+
+function assertFinalLiveCacheAccountingBoundsV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  totals: CacheAccountingTotalsV1,
+): void {
+  assertIncrementalCacheAccountingBoundsV1(accumulator);
+  if (
+    totals.closurePhysicalBytes > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_BYTES ||
+    totals.sidecarPhysicalBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_AGGREGATE_BYTES
   ) {
     fail('system-record-closure', 'aggregate cache accounting exceeds a live V1 bound');
   }
@@ -511,7 +520,7 @@ export function preflightSystemRecordCacheAccountingV1(
   const accumulator = createCacheAccountingAccumulatorV1();
   for (const row of normalized.rows) {
     collectCacheAccountingRowV1(accumulator, row);
-    assertLiveCacheAccountingBoundsV1(accumulator);
+    assertIncrementalCacheAccountingBoundsV1(accumulator);
   }
   accountCacheReferencesV1(
     accumulator,
@@ -525,7 +534,7 @@ export function preflightSystemRecordCacheAccountingV1(
     fail('system-record-closure', 'activation inventory may contain only leaf objects');
   }
   const totals = computeCacheAccountingTotalsV1(accumulator);
-  assertLiveCacheAccountingBoundsV1(accumulator, totals);
+  assertFinalLiveCacheAccountingBoundsV1(accumulator, totals);
   assertActivationCacheAccountingBoundsV1(normalized, accumulator, totals);
   return projectCacheAccountingResultV1(normalized, accumulator, totals);
 }

--- a/packages/core/src/system-record-cache-accounting-v1-internal.ts
+++ b/packages/core/src/system-record-cache-accounting-v1-internal.ts
@@ -320,8 +320,8 @@ function collectCacheAccountingRowV1(
   const rowClosureBytes = accountCacheReferencesV1(
     accumulator,
     closure,
-    accumulator.closurePhysical,
     'closure',
+    accumulator.closurePhysical,
   );
   if (rowClosureBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
     fail('system-record-closure', 'row closure exceeds its byte bound');
@@ -347,8 +347,8 @@ function collectCacheAccountingRowV1(
     const rowSidecarBytes = accountCacheReferencesV1(
       accumulator,
       sidecar,
-      accumulator.sidecarPhysical,
       'sidecar',
+      accumulator.sidecarPhysical,
     );
     if (
       sidecar.filter((reference) => reference.objectKind === 'conflict-evidence').length !== 1 ||
@@ -387,8 +387,8 @@ function collectCacheAccountingRowV1(
 function accountCacheReferencesV1(
   accumulator: CacheAccountingAccumulatorV1,
   references: readonly SystemRecordCacheReferenceV1[],
-  category: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
   label: string,
+  category?: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
 ): number {
   let total = 0;
   const logical = new Set<string>();
@@ -401,24 +401,32 @@ function accountCacheReferencesV1(
       fail('system-record-closure', `${label} contains a duplicate semantic reference`);
     }
     logical.add(logicalKey);
-    const prior = accumulator.physical.get(reference.cacheDigest);
-    if (
-      prior !== undefined &&
-      (prior.reference.objectKind !== reference.objectKind ||
-        prior.reference.digest !== reference.digest ||
-        prior.facts.byteLength !== facts.byteLength ||
-        prior.facts.fingerprint !== facts.fingerprint)
-    ) {
-      fail('system-record-closure', 'one cache digest was reported with conflicting canonical bytes');
-    }
-    accumulator.physical.set(reference.cacheDigest, { reference, facts });
-    category.set(reference.cacheDigest, facts);
+    accountCachePhysicalReferenceV1(accumulator, reference, facts);
+    category?.set(reference.cacheDigest, facts);
     total += facts.byteLength;
     if (!Number.isSafeInteger(total)) {
       fail('system-record-closure', `${label} byte accounting overflow`);
     }
   }
   return total;
+}
+
+function accountCachePhysicalReferenceV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  reference: SystemRecordCacheReferenceV1,
+  facts: SystemRecordCacheReferenceFactsV1,
+): void {
+  const prior = accumulator.physical.get(reference.cacheDigest);
+  if (
+    prior !== undefined &&
+    (prior.reference.objectKind !== reference.objectKind ||
+      prior.reference.digest !== reference.digest ||
+      prior.facts.byteLength !== facts.byteLength ||
+      prior.facts.fingerprint !== facts.fingerprint)
+  ) {
+    fail('system-record-closure', 'one cache digest was reported with conflicting canonical bytes');
+  }
+  accumulator.physical.set(reference.cacheDigest, { reference, facts });
 }
 
 function assertIncrementalCacheAccountingBoundsV1(
@@ -525,7 +533,6 @@ export function preflightSystemRecordCacheAccountingV1(
   accountCacheReferencesV1(
     accumulator,
     normalized.inventoryLeaves,
-    new Map(),
     'activation inventory',
   );
   if (

--- a/packages/core/src/system-record-cache-accounting-v1-internal.ts
+++ b/packages/core/src/system-record-cache-accounting-v1-internal.ts
@@ -190,10 +190,43 @@ export interface SystemRecordCachePreflightInputV1 {
   readonly inventoryLeaves?: readonly SystemRecordCacheReferenceV1[];
 }
 
-/** Pure all-or-nothing aggregate preflight; shared physical digests are charged once. */
-export function preflightSystemRecordCacheAccountingV1(
+interface NormalizedCachePreflightInputV1 {
+  readonly mode: SystemRecordCachePreflightInputV1['mode'];
+  readonly rows: readonly SystemRecordCacheRowAccountingV1[];
+  readonly inventoryLeaves: readonly SystemRecordCacheReferenceV1[];
+}
+
+interface CacheAccountingAccumulatorV1 {
+  readonly physical: Map<
+    Digest32V1,
+    {
+      reference: SystemRecordCacheReferenceV1;
+      facts: SystemRecordCacheReferenceFactsV1;
+    }
+  >;
+  readonly closurePhysical: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>;
+  readonly sidecarPhysical: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>;
+  readonly bundlePhysical: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>;
+  closureReferences: number;
+  closureReferencedBytes: number;
+  sidecarReferences: number;
+  sidecars: number;
+  sidecarReferencedBytes: number;
+  metadataBytes: number;
+  sidecarMetadataBytes: number;
+}
+
+interface CacheAccountingTotalsV1 {
+  readonly physicalBytes: number;
+  readonly closurePhysicalBytes: number;
+  readonly sidecarPhysicalBytes: number;
+  readonly closureSidecarPhysicalBytes: number;
+  readonly activationBundleBytes: number;
+}
+
+function normalizeCachePreflightInputV1(
   input: SystemRecordCachePreflightInputV1,
-): SystemRecordCachePreflightResultV1 {
+): NormalizedCachePreflightInputV1 {
   const hasInventoryLeaves = hasOwnDataProperty(input, 'inventoryLeaves');
   const exact = snapshotExactDataRecord(
     input,
@@ -207,10 +240,9 @@ export function preflightSystemRecordCacheAccountingV1(
   let inventoryLeaves: readonly SystemRecordCacheReferenceV1[];
   try {
     rows = snapshotDataArray(exact.rows, 'cache rows', {
-      maxLength:
-        exact.mode === 'activation'
-          ? SYSTEM_RECORD_MAX_ACTIVATION_RECORDS
-          : SYSTEM_RECORD_MAX_INVENTORY_RECORDS,
+      maxLength: exact.mode === 'activation'
+        ? SYSTEM_RECORD_MAX_ACTIVATION_RECORDS
+        : SYSTEM_RECORD_MAX_INVENTORY_RECORDS,
     }) as readonly SystemRecordCacheRowAccountingV1[];
     inventoryLeaves = snapshotDataArray(
       hasInventoryLeaves ? exact.inventoryLeaves : [],
@@ -226,213 +258,276 @@ export function preflightSystemRecordCacheAccountingV1(
   if (inventoryLeaves.length > SYSTEM_RECORD_MAX_ACTIVATION_INVENTORY_LEAVES) {
     fail('system-record-closure', 'activation inventory exceeds its leaf bound');
   }
-  const physical = new Map<
-    Digest32V1,
-    {
-      reference: SystemRecordCacheReferenceV1;
-      facts: SystemRecordCacheReferenceFactsV1;
-    }
-  >();
-  const closurePhysical = new Map<Digest32V1, SystemRecordCacheReferenceFactsV1>();
-  const sidecarPhysical = new Map<Digest32V1, SystemRecordCacheReferenceFactsV1>();
-  const bundlePhysical = new Map<Digest32V1, SystemRecordCacheReferenceFactsV1>();
-  let closureReferences = 0;
-  let closureReferencedBytes = 0;
-  let sidecarReferences = 0;
-  let sidecars = 0;
-  let sidecarReferencedBytes = 0;
-  let metadataBytes = 0;
-  let sidecarMetadataBytes = 0;
-  for (const row of rows) {
-    const hasSidecar = hasOwnDataProperty(row, 'sidecar');
-    const hasSidecarMetadata = hasOwnDataProperty(row, 'sidecarMetadata');
-    const exactRow = snapshotExactDataRecord(
-      row,
-      [
-        'closure',
-        'metadata',
-        ...(hasSidecar ? ['sidecar'] : []),
-        ...(hasSidecarMetadata ? ['sidecarMetadata'] : []),
-      ],
-      'cache accounting row',
+  return Object.freeze({ mode: exact.mode, rows, inventoryLeaves });
+}
+
+function createCacheAccountingAccumulatorV1(): CacheAccountingAccumulatorV1 {
+  return {
+    physical: new Map(),
+    closurePhysical: new Map(),
+    sidecarPhysical: new Map(),
+    bundlePhysical: new Map(),
+    closureReferences: 0,
+    closureReferencedBytes: 0,
+    sidecarReferences: 0,
+    sidecars: 0,
+    sidecarReferencedBytes: 0,
+    metadataBytes: 0,
+    sidecarMetadataBytes: 0,
+  };
+}
+
+function collectCacheAccountingRowV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  row: SystemRecordCacheRowAccountingV1,
+): void {
+  const hasSidecar = hasOwnDataProperty(row, 'sidecar');
+  const hasSidecarMetadata = hasOwnDataProperty(row, 'sidecarMetadata');
+  const exactRow = snapshotExactDataRecord(
+    row,
+    [
+      'closure',
+      'metadata',
+      ...(hasSidecar ? ['sidecar'] : []),
+      ...(hasSidecarMetadata ? ['sidecarMetadata'] : []),
+    ],
+    'cache accounting row',
+  );
+  let closure: readonly SystemRecordCacheReferenceV1[];
+  let sidecar: readonly SystemRecordCacheReferenceV1[] | undefined;
+  try {
+    closure = snapshotDataArray(exactRow.closure, 'cache row closure', {
+      maxLength: SYSTEM_RECORD_MAX_CLOSURE_OBJECTS,
+    }) as readonly SystemRecordCacheReferenceV1[];
+    sidecar = hasSidecar
+      ? (snapshotDataArray(exactRow.sidecar, 'cache row sidecar', {
+          maxLength: SYSTEM_RECORD_MAX_SIDECAR_OBJECTS,
+        }) as readonly SystemRecordCacheReferenceV1[])
+      : undefined;
+  } catch (cause) {
+    fail('system-record-closure', 'cache row arrays exceed their closed bounds', cause);
+  }
+  const rowMetadataBytes = requireCacheMetadataBytes(exactRow.metadata, 'cache row metadata');
+  if (hasSidecar !== hasSidecarMetadata) {
+    fail(
+      'system-record-closure',
+      'cache row sidecar and sidecar metadata must be present together',
     );
-    let closure: readonly SystemRecordCacheReferenceV1[];
-    let sidecar: readonly SystemRecordCacheReferenceV1[] | undefined;
-    try {
-      closure = snapshotDataArray(exactRow.closure, 'cache row closure', {
-        maxLength: SYSTEM_RECORD_MAX_CLOSURE_OBJECTS,
-      }) as readonly SystemRecordCacheReferenceV1[];
-      sidecar = hasSidecar
-        ? (snapshotDataArray(exactRow.sidecar, 'cache row sidecar', {
-            maxLength: SYSTEM_RECORD_MAX_SIDECAR_OBJECTS,
-          }) as readonly SystemRecordCacheReferenceV1[])
-        : undefined;
-    } catch (cause) {
-      fail('system-record-closure', 'cache row arrays exceed their closed bounds', cause);
-    }
-    const rowMetadataBytes = requireCacheMetadataBytes(exactRow.metadata, 'cache row metadata');
-    if (hasSidecar !== hasSidecarMetadata) {
-      fail(
-        'system-record-closure',
-        'cache row sidecar and sidecar metadata must be present together',
+  }
+  const rowSidecarMetadataBytes = hasSidecarMetadata
+    ? requireCacheMetadataBytes(exactRow.sidecarMetadata, 'cache row sidecar metadata')
+    : 0;
+  const rowClosureBytes = accountCacheReferencesV1(
+    accumulator,
+    closure,
+    accumulator.closurePhysical,
+    'closure',
+  );
+  if (rowClosureBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
+    fail('system-record-closure', 'row closure exceeds its byte bound');
+  }
+  accumulator.closureReferences += closure.length;
+  accumulator.closureReferencedBytes += rowClosureBytes;
+  if (
+    !Number.isSafeInteger(accumulator.closureReferences) ||
+    !Number.isSafeInteger(accumulator.closureReferencedBytes)
+  ) {
+    fail('system-record-closure', 'aggregate closure accounting overflow');
+  }
+  for (const reference of closure) {
+    if (reference.objectKind === 'profile-bundle') {
+      accumulator.bundlePhysical.set(
+        reference.cacheDigest,
+        requireCacheReferenceFacts(reference, 'closure'),
       );
     }
-    const rowSidecarMetadataBytes = hasSidecarMetadata
-      ? requireCacheMetadataBytes(exactRow.sidecarMetadata, 'cache row sidecar metadata')
-      : 0;
-    const rowClosureBytes = accountReferences(closure, closurePhysical, 'closure');
-    if (rowClosureBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES) {
-      fail('system-record-closure', 'row closure exceeds its byte bound');
-    }
-    closureReferences += closure.length;
-    closureReferencedBytes += rowClosureBytes;
-    if (!Number.isSafeInteger(closureReferences) || !Number.isSafeInteger(closureReferencedBytes)) {
-      fail('system-record-closure', 'aggregate closure accounting overflow');
-    }
-    for (const reference of closure) {
-      if (reference.objectKind === 'profile-bundle') {
-        bundlePhysical.set(reference.cacheDigest, requireCacheReferenceFacts(reference, 'closure'));
-      }
-    }
-    if (sidecar !== undefined) {
-      sidecars += 1;
-      const rowSidecarBytes = accountReferences(sidecar, sidecarPhysical, 'sidecar');
-      if (
-        sidecar.filter((reference) => reference.objectKind === 'conflict-evidence').length !== 1 ||
-        sidecar.some(
-          (reference) =>
-            reference.objectKind !== 'conflict-evidence' &&
-            reference.objectKind !== 'agent-profile-head' &&
-            reference.objectKind !== 'authority-transition' &&
-            reference.objectKind !== 'fork-resolution',
-        )
-      ) {
-        fail(
-          'system-record-closure',
-          'row sidecar must contain one evidence object and only signed controls',
-        );
-      }
-      if (rowSidecarBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
-        fail('system-record-closure', 'row sidecar exceeds its byte bound');
-      }
-      sidecarReferences += sidecar.length;
-      sidecarReferencedBytes += rowSidecarBytes;
-      if (
-        !Number.isSafeInteger(sidecarReferences) ||
-        !Number.isSafeInteger(sidecarReferencedBytes)
-      ) {
-        fail('system-record-closure', 'aggregate sidecar accounting overflow');
-      }
-    }
-    metadataBytes += rowMetadataBytes + rowSidecarMetadataBytes;
-    sidecarMetadataBytes += rowSidecarMetadataBytes;
-    if (!Number.isSafeInteger(metadataBytes))
-      fail('system-record-closure', 'cache metadata accounting overflow');
+  }
+  if (sidecar !== undefined) {
+    accumulator.sidecars += 1;
+    const rowSidecarBytes = accountCacheReferencesV1(
+      accumulator,
+      sidecar,
+      accumulator.sidecarPhysical,
+      'sidecar',
+    );
     if (
-      closurePhysical.size > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_OBJECTS ||
-      closureReferences > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_REFERENCES ||
-      metadataBytes > SYSTEM_RECORD_MAX_CLOSURE_SIDECAR_LIVE_METADATA_BYTES ||
-      sidecars > SYSTEM_RECORD_MAX_CONFLICT_SIDECARS ||
-      sidecarReferences > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_REFERENCES ||
-      sidecarMetadataBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_METADATA_BYTES
+      sidecar.filter((reference) => reference.objectKind === 'conflict-evidence').length !== 1 ||
+      sidecar.some(
+        (reference) =>
+          reference.objectKind !== 'conflict-evidence' &&
+          reference.objectKind !== 'agent-profile-head' &&
+          reference.objectKind !== 'authority-transition' &&
+          reference.objectKind !== 'fork-resolution',
+      )
     ) {
-      fail('system-record-closure', 'aggregate cache accounting exceeds a live V1 bound');
+      fail(
+        'system-record-closure',
+        'row sidecar must contain one evidence object and only signed controls',
+      );
+    }
+    if (rowSidecarBytes > SYSTEM_RECORD_MAX_SIDECAR_BYTES) {
+      fail('system-record-closure', 'row sidecar exceeds its byte bound');
+    }
+    accumulator.sidecarReferences += sidecar.length;
+    accumulator.sidecarReferencedBytes += rowSidecarBytes;
+    if (
+      !Number.isSafeInteger(accumulator.sidecarReferences) ||
+      !Number.isSafeInteger(accumulator.sidecarReferencedBytes)
+    ) {
+      fail('system-record-closure', 'aggregate sidecar accounting overflow');
     }
   }
-  accountReferences(inventoryLeaves, new Map(), 'activation inventory');
-  if (inventoryLeaves.some((reference) => reference.objectKind !== 'inventory-leaf')) {
-    fail('system-record-closure', 'activation inventory may contain only leaf objects');
+  accumulator.metadataBytes += rowMetadataBytes + rowSidecarMetadataBytes;
+  accumulator.sidecarMetadataBytes += rowSidecarMetadataBytes;
+  if (!Number.isSafeInteger(accumulator.metadataBytes)) {
+    fail('system-record-closure', 'cache metadata accounting overflow');
   }
-  const physicalBytes = [...physical.values()].reduce(
-    (sum, entry) => sum + entry.facts.byteLength,
-    0,
-  );
-  const closurePhysicalBytes = sumPhysicalBytes(closurePhysical);
-  const sidecarPhysicalBytes = sumPhysicalBytes(sidecarPhysical);
-  const closureSidecarPhysicalBytes = sumPhysicalBytes(
-    new Map([...closurePhysical, ...sidecarPhysical]),
-  );
-  const activationBundleBytes = sumPhysicalBytes(bundlePhysical);
+}
+
+function accountCacheReferencesV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  references: readonly SystemRecordCacheReferenceV1[],
+  category: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
+  label: string,
+): number {
+  let total = 0;
+  const logical = new Set<string>();
+  for (const reference of references) {
+    const facts = requireCacheReferenceFacts(reference, label);
+    digest(reference.digest, `${label} digest`);
+    digest(reference.cacheDigest, `${label} cache digest`);
+    const logicalKey = `${reference.objectKind}:${reference.digest}`;
+    if (logical.has(logicalKey)) {
+      fail('system-record-closure', `${label} contains a duplicate semantic reference`);
+    }
+    logical.add(logicalKey);
+    const prior = accumulator.physical.get(reference.cacheDigest);
+    if (
+      prior !== undefined &&
+      (prior.reference.objectKind !== reference.objectKind ||
+        prior.reference.digest !== reference.digest ||
+        prior.facts.byteLength !== facts.byteLength ||
+        prior.facts.fingerprint !== facts.fingerprint)
+    ) {
+      fail('system-record-closure', 'one cache digest was reported with conflicting canonical bytes');
+    }
+    accumulator.physical.set(reference.cacheDigest, { reference, facts });
+    category.set(reference.cacheDigest, facts);
+    total += facts.byteLength;
+    if (!Number.isSafeInteger(total)) {
+      fail('system-record-closure', `${label} byte accounting overflow`);
+    }
+  }
+  return total;
+}
+
+function assertLiveCacheAccountingBoundsV1(
+  accumulator: CacheAccountingAccumulatorV1,
+  totals?: CacheAccountingTotalsV1,
+): void {
   if (
-    closurePhysical.size > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_OBJECTS ||
-    closurePhysicalBytes > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_BYTES ||
-    closureReferences > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_REFERENCES ||
-    metadataBytes > SYSTEM_RECORD_MAX_CLOSURE_SIDECAR_LIVE_METADATA_BYTES ||
-    sidecars > SYSTEM_RECORD_MAX_CONFLICT_SIDECARS ||
-    sidecarReferences > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_REFERENCES ||
-    sidecarPhysicalBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_AGGREGATE_BYTES ||
-    sidecarMetadataBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_METADATA_BYTES
+    accumulator.closurePhysical.size > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_OBJECTS ||
+    accumulator.closureReferences > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_REFERENCES ||
+    accumulator.metadataBytes > SYSTEM_RECORD_MAX_CLOSURE_SIDECAR_LIVE_METADATA_BYTES ||
+    accumulator.sidecars > SYSTEM_RECORD_MAX_CONFLICT_SIDECARS ||
+    accumulator.sidecarReferences > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_REFERENCES ||
+    accumulator.sidecarMetadataBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_METADATA_BYTES ||
+    (totals !== undefined &&
+      (totals.closurePhysicalBytes > SYSTEM_RECORD_MAX_ADVERTISED_CLOSURE_BYTES ||
+        totals.sidecarPhysicalBytes > SYSTEM_RECORD_MAX_CONFLICT_SIDECAR_AGGREGATE_BYTES))
   ) {
     fail('system-record-closure', 'aggregate cache accounting exceeds a live V1 bound');
   }
+}
+
+function sumCachePhysicalBytesV1(
+  references: ReadonlyMap<Digest32V1, SystemRecordCacheReferenceFactsV1>,
+): number {
+  return [...references.values()].reduce((sum, facts) => sum + facts.byteLength, 0);
+}
+
+function computeCacheAccountingTotalsV1(
+  accumulator: CacheAccountingAccumulatorV1,
+): CacheAccountingTotalsV1 {
+  return Object.freeze({
+    physicalBytes: [...accumulator.physical.values()].reduce(
+      (sum, entry) => sum + entry.facts.byteLength,
+      0,
+    ),
+    closurePhysicalBytes: sumCachePhysicalBytesV1(accumulator.closurePhysical),
+    sidecarPhysicalBytes: sumCachePhysicalBytesV1(accumulator.sidecarPhysical),
+    closureSidecarPhysicalBytes: sumCachePhysicalBytesV1(
+      new Map([...accumulator.closurePhysical, ...accumulator.sidecarPhysical]),
+    ),
+    activationBundleBytes: sumCachePhysicalBytesV1(accumulator.bundlePhysical),
+  });
+}
+
+function assertActivationCacheAccountingBoundsV1(
+  normalized: NormalizedCachePreflightInputV1,
+  accumulator: CacheAccountingAccumulatorV1,
+  totals: CacheAccountingTotalsV1,
+): void {
   if (
-    exact.mode === 'activation' &&
-    (activationBundleBytes > SYSTEM_RECORD_MAX_ACTIVATION_BUNDLE_BYTES ||
-      closureSidecarPhysicalBytes > SYSTEM_RECORD_MAX_ACTIVATION_CLOSURE_BYTES ||
-      closureReferences + sidecarReferences + inventoryLeaves.length >
+    normalized.mode === 'activation' &&
+    (totals.activationBundleBytes > SYSTEM_RECORD_MAX_ACTIVATION_BUNDLE_BYTES ||
+      totals.closureSidecarPhysicalBytes > SYSTEM_RECORD_MAX_ACTIVATION_CLOSURE_BYTES ||
+      accumulator.closureReferences +
+          accumulator.sidecarReferences +
+          normalized.inventoryLeaves.length >
         SYSTEM_RECORD_MAX_ACTIVATION_REFERENCES ||
-      metadataBytes > SYSTEM_RECORD_MAX_ACTIVATION_METADATA_BYTES)
+      accumulator.metadataBytes > SYSTEM_RECORD_MAX_ACTIVATION_METADATA_BYTES)
   ) {
     fail('system-record-closure', 'activation cache accounting exceeds its cohort bound');
   }
+}
+
+function projectCacheAccountingResultV1(
+  normalized: NormalizedCachePreflightInputV1,
+  accumulator: CacheAccountingAccumulatorV1,
+  totals: CacheAccountingTotalsV1,
+): SystemRecordCachePreflightResultV1 {
   return Object.freeze({
-    cohortPhysicalObjects: physical.size,
-    cohortPhysicalBytes: physicalBytes,
-    closureReferences,
-    closurePhysicalBytes,
-    closureReferencedBytes,
-    sidecarReferences,
-    sidecars,
-    sidecarPhysicalBytes,
-    sidecarReferencedBytes,
-    activationBundleBytes,
-    activationInventoryLeaves: inventoryLeaves.length,
-    metadataBytes,
+    cohortPhysicalObjects: accumulator.physical.size,
+    cohortPhysicalBytes: totals.physicalBytes,
+    closureReferences: accumulator.closureReferences,
+    closurePhysicalBytes: totals.closurePhysicalBytes,
+    closureReferencedBytes: accumulator.closureReferencedBytes,
+    sidecarReferences: accumulator.sidecarReferences,
+    sidecars: accumulator.sidecars,
+    sidecarPhysicalBytes: totals.sidecarPhysicalBytes,
+    sidecarReferencedBytes: accumulator.sidecarReferencedBytes,
+    activationBundleBytes: totals.activationBundleBytes,
+    activationInventoryLeaves: normalized.inventoryLeaves.length,
+    metadataBytes: accumulator.metadataBytes,
   });
+}
 
-  function accountReferences(
-    references: readonly SystemRecordCacheReferenceV1[],
-    category: Map<Digest32V1, SystemRecordCacheReferenceFactsV1>,
-    label: string,
-  ): number {
-    let total = 0;
-    const logical = new Set<string>();
-    for (const reference of references as readonly SystemRecordCacheReferenceV1[]) {
-      const facts = requireCacheReferenceFacts(reference, label);
-      digest(reference.digest, `${label} digest`);
-      digest(reference.cacheDigest, `${label} cache digest`);
-      const logicalKey = `${reference.objectKind}:${reference.digest}`;
-      if (logical.has(logicalKey)) {
-        fail('system-record-closure', `${label} contains a duplicate semantic reference`);
-      }
-      logical.add(logicalKey);
-      const prior = physical.get(reference.cacheDigest);
-      if (
-        prior !== undefined &&
-        (prior.reference.objectKind !== reference.objectKind ||
-          prior.reference.digest !== reference.digest ||
-          prior.facts.byteLength !== facts.byteLength ||
-          prior.facts.fingerprint !== facts.fingerprint)
-      ) {
-        fail(
-          'system-record-closure',
-          'one cache digest was reported with conflicting canonical bytes',
-        );
-      }
-      physical.set(reference.cacheDigest, { reference, facts });
-      category.set(reference.cacheDigest, facts);
-      total += facts.byteLength;
-      if (!Number.isSafeInteger(total))
-        fail('system-record-closure', `${label} byte accounting overflow`);
-    }
-    return total;
+/** Pure all-or-nothing aggregate preflight; shared physical digests are charged once. */
+export function preflightSystemRecordCacheAccountingV1(
+  input: SystemRecordCachePreflightInputV1,
+): SystemRecordCachePreflightResultV1 {
+  const normalized = normalizeCachePreflightInputV1(input);
+  const accumulator = createCacheAccountingAccumulatorV1();
+  for (const row of normalized.rows) {
+    collectCacheAccountingRowV1(accumulator, row);
+    assertLiveCacheAccountingBoundsV1(accumulator);
   }
-
-  function sumPhysicalBytes(
-    references: ReadonlyMap<Digest32V1, SystemRecordCacheReferenceFactsV1>,
-  ): number {
-    return [...references.values()].reduce((sum, facts) => sum + facts.byteLength, 0);
+  accountCacheReferencesV1(
+    accumulator,
+    normalized.inventoryLeaves,
+    new Map(),
+    'activation inventory',
+  );
+  if (
+    normalized.inventoryLeaves.some((reference) => reference.objectKind !== 'inventory-leaf')
+  ) {
+    fail('system-record-closure', 'activation inventory may contain only leaf objects');
   }
+  const totals = computeCacheAccountingTotalsV1(accumulator);
+  assertLiveCacheAccountingBoundsV1(accumulator, totals);
+  assertActivationCacheAccountingBoundsV1(normalized, accumulator, totals);
+  return projectCacheAccountingResultV1(normalized, accumulator, totals);
 }
 
 function requireCacheMetadataBytes(value: unknown, label: string): number {

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -179,7 +179,7 @@ interface ClosurePendingReferenceV1 {
   readonly referencedByHeadDigest?: Digest32V1;
 }
 
-interface ClosureCollectedStateV1 {
+interface ClosureTraversalStateV1 {
   readonly currentHeadDigest: Digest32V1;
   readonly pending: Map<string, ClosurePendingReferenceV1>;
   readonly artifacts: SystemRecordVerificationClosureObjectV1[];
@@ -191,6 +191,19 @@ interface ClosureCollectedStateV1 {
   canonicalBytes: number;
 }
 
+interface CollectedClosureV1 {
+  readonly currentHeadDigest: Digest32V1;
+  readonly artifacts: readonly SystemRecordVerificationClosureObjectV1[];
+  readonly parsedHeads: ReadonlyMap<Digest32V1, AgentProfileHeadObjectV1>;
+  readonly parsedTransitions: ReadonlyMap<
+    Digest32V1,
+    AgentProfileAuthorityTransitionV1
+  >;
+  readonly parsedResolutions: readonly AgentProfileForkResolutionV1[];
+  readonly rootClaimCount: number;
+  readonly canonicalBytes: number;
+}
+
 interface ClosureExecutionV1 {
   readonly nowMs: number;
   readonly resolve: AgentProfileClosureVerifierV1['resolve'];
@@ -198,9 +211,9 @@ interface ClosureExecutionV1 {
   readonly verifyCurrentBundle: AgentProfileClosureVerifierV1['verifyCurrentBundle'];
 }
 
-function createClosureCollectedStateV1(
+function createClosureTraversalStateV1(
   currentHeadDigest: Digest32V1,
-): ClosureCollectedStateV1 {
+): ClosureTraversalStateV1 {
   return {
     currentHeadDigest,
     pending: new Map(),
@@ -223,7 +236,7 @@ const CLOSURE_PURPOSE_PRIORITY_V1: Readonly<Record<ClosurePurposeV1, number>> = 
 });
 
 function enqueueClosureReferenceV1(
-  state: ClosureCollectedStateV1,
+  state: ClosureTraversalStateV1,
   objectKind: SystemRecordObjectKindV1,
   objectDigest: Digest32V1,
   purpose: ClosurePurposeV1,
@@ -265,7 +278,7 @@ type ClosureReferenceV1 = Pick<
 >;
 
 async function visitClosureObjectV1(
-  state: ClosureCollectedStateV1,
+  state: ClosureTraversalStateV1,
   context: ClosurePendingReferenceV1,
   canonicalBytes: Uint8Array,
   references: ClosureReferenceV1[],
@@ -428,13 +441,14 @@ async function visitClosureObjectV1(
 }
 
 async function collectVerificationClosureV1(
-  state: ClosureCollectedStateV1,
+  currentHeadDigest: Digest32V1,
   execution: ClosureExecutionV1,
-): Promise<void> {
+): Promise<CollectedClosureV1> {
+  const state = createClosureTraversalStateV1(currentHeadDigest);
   enqueueClosureReferenceV1(
     state,
     'agent-profile-head',
-    state.currentHeadDigest,
+    currentHeadDigest,
     'current',
   );
 
@@ -508,10 +522,20 @@ async function collectVerificationClosureV1(
       fail('system-record-closure', 'verification closure cannot fit before dependency fetch');
     }
   }
+
+  return Object.freeze({
+    currentHeadDigest,
+    artifacts: Object.freeze([...state.artifacts]),
+    parsedHeads: new Map(state.parsedHeads),
+    parsedTransitions: new Map(state.parsedTransitions),
+    parsedResolutions: Object.freeze([...state.parsedResolutions]),
+    rootClaimCount: state.rootClaims.size,
+    canonicalBytes: state.canonicalBytes,
+  });
 }
 
 function validateCollectedClosureAuthorityV1(
-  state: ClosureCollectedStateV1,
+  state: CollectedClosureV1,
   nowMs: number,
 ): void {
   for (const resolution of state.parsedResolutions) {
@@ -615,7 +639,7 @@ function validateCollectedClosureAuthorityV1(
 }
 
 function assertCompleteUniqueRootLineageV1(
-  state: ClosureCollectedStateV1,
+  state: CollectedClosureV1,
   headDigest: Digest32V1,
   head: AgentProfileHeadObjectV1,
 ): void {
@@ -654,21 +678,21 @@ function assertCompleteUniqueRootLineageV1(
 }
 
 function projectVerificationClosureV1(
-  state: ClosureCollectedStateV1,
+  state: CollectedClosureV1,
 ): SystemRecordVerificationClosureV1 {
   const authoritySummary = createVerifiedAuthoritySummaryV1(state);
-  state.artifacts.sort(compareClosureObjects);
+  const objects = Object.freeze([...state.artifacts].sort(compareClosureObjects));
   return Object.freeze({
-    objects: Object.freeze(state.artifacts),
+    objects,
     canonicalBytes: state.canonicalBytes,
-    rootClaims: state.rootClaims.size,
+    rootClaims: state.rootClaimCount,
     resolvedForkTuples: state.parsedResolutions.length,
     authoritySummary,
   });
 }
 
 function createVerifiedAuthoritySummaryV1(
-  state: ClosureCollectedStateV1,
+  state: CollectedClosureV1,
 ): AgentProfileVerifiedAuthoritySummaryV1 {
   const current = state.parsedHeads.get(state.currentHeadDigest);
   if (current === undefined) {
@@ -750,10 +774,9 @@ export async function buildAgentProfileVerificationClosureV1(
     verifyAuthorityEnvelope,
     verifyCurrentBundle,
   });
-  const state = createClosureCollectedStateV1(currentHeadDigest);
-  await collectVerificationClosureV1(state, execution);
-  validateCollectedClosureAuthorityV1(state, nowMs);
-  return projectVerificationClosureV1(state);
+  const collected = await collectVerificationClosureV1(currentHeadDigest, execution);
+  validateCollectedClosureAuthorityV1(collected, nowMs);
+  return projectVerificationClosureV1(collected);
 }
 
 function compareClosureObjects(

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -171,54 +171,280 @@ type ClosurePurposeV1 =
   | 'tombstone-predecessor'
   | 'deletion-predecessor';
 
-/**
- * Derive the row closure from canonical objects rather than trusting caller-supplied edges.
- * Authority and current-bundle verification stay injected because final chain/seal proofs
- * belong to later stacks, but a false/missing verifier result always fails closed.
- */
-export async function buildAgentProfileVerificationClosureV1(
-  currentHeadDigest: Digest32V1,
-  verifier: AgentProfileClosureVerifierV1,
-): Promise<SystemRecordVerificationClosureV1> {
-  digest(currentHeadDigest, 'currentHeadDigest');
-  const nowMs = verifier.nowMs;
-  const resolve = verifier.resolve;
-  const verifyAuthorityEnvelope = verifier.verifyAuthorityEnvelope;
-  const verifyCurrentBundle = verifier.verifyCurrentBundle;
-  if (!isSafeNow(nowMs)) fail('system-record-closure', 'closure verifier clock is invalid');
-  if (
-    typeof resolve !== 'function' ||
-    typeof verifyAuthorityEnvelope !== 'function' ||
-    typeof verifyCurrentBundle !== 'function'
-  ) {
-    fail('system-record-closure', 'closure verifier callbacks are invalid');
-  }
-  const pending = new Map<
-    string,
-    {
-      objectKind: SystemRecordObjectKindV1;
-      digest: Digest32V1;
-      purpose: ClosurePurposeV1;
-      rootSubject?: string;
-      referencedByHeadDigest?: Digest32V1;
-    }
-  >();
-  const artifacts: SystemRecordVerificationClosureObjectV1[] = [];
-  const parsedHeads = new Map<Digest32V1, AgentProfileHeadObjectV1>();
-  const parsedTransitions = new Map<Digest32V1, AgentProfileAuthorityTransitionV1>();
-  const parsedResolutions: AgentProfileForkResolutionV1[] = [];
-  const seen = new Map<Digest32V1, SystemRecordObjectKindV1>();
-  const rootClaims = new Set<string>();
-  let bytes = 0;
-  enqueue('agent-profile-head', currentHeadDigest, 'current');
+interface ClosurePendingReferenceV1 {
+  readonly objectKind: SystemRecordObjectKindV1;
+  readonly digest: Digest32V1;
+  readonly purpose: ClosurePurposeV1;
+  readonly rootSubject?: string;
+  readonly referencedByHeadDigest?: Digest32V1;
+}
 
-  while (pending.size > 0) {
+interface ClosureCollectedStateV1 {
+  readonly currentHeadDigest: Digest32V1;
+  readonly pending: Map<string, ClosurePendingReferenceV1>;
+  readonly artifacts: SystemRecordVerificationClosureObjectV1[];
+  readonly parsedHeads: Map<Digest32V1, AgentProfileHeadObjectV1>;
+  readonly parsedTransitions: Map<Digest32V1, AgentProfileAuthorityTransitionV1>;
+  readonly parsedResolutions: AgentProfileForkResolutionV1[];
+  readonly seen: Map<Digest32V1, SystemRecordObjectKindV1>;
+  readonly rootClaims: Set<string>;
+  canonicalBytes: number;
+}
+
+interface ClosureExecutionV1 {
+  readonly nowMs: number;
+  readonly resolve: AgentProfileClosureVerifierV1['resolve'];
+  readonly verifyAuthorityEnvelope: AgentProfileClosureVerifierV1['verifyAuthorityEnvelope'];
+  readonly verifyCurrentBundle: AgentProfileClosureVerifierV1['verifyCurrentBundle'];
+}
+
+function createClosureCollectedStateV1(
+  currentHeadDigest: Digest32V1,
+): ClosureCollectedStateV1 {
+  return {
+    currentHeadDigest,
+    pending: new Map(),
+    artifacts: [],
+    parsedHeads: new Map(),
+    parsedTransitions: new Map(),
+    parsedResolutions: [],
+    seen: new Map(),
+    rootClaims: new Set(),
+    canonicalBytes: 0,
+  };
+}
+
+const CLOSURE_PURPOSE_PRIORITY_V1: Readonly<Record<ClosurePurposeV1, number>> = Object.freeze({
+  history: 0,
+  'fork-evidence': 1,
+  'tombstone-predecessor': 2,
+  'deletion-predecessor': 3,
+  current: 4,
+});
+
+function enqueueClosureReferenceV1(
+  state: ClosureCollectedStateV1,
+  objectKind: SystemRecordObjectKindV1,
+  objectDigest: Digest32V1,
+  purpose: ClosurePurposeV1,
+  rootSubject?: string,
+  referencedByHeadDigest?: Digest32V1,
+): void {
+  digest(objectDigest, 'closure reference digest');
+  const seenKind = state.seen.get(objectDigest);
+  if (seenKind !== undefined) {
+    if (seenKind !== objectKind) {
+      fail(
+        'system-record-closure',
+        'one closure digest was referenced under different object kinds',
+      );
+    }
+    return;
+  }
+  const existing = state.pending.get(objectDigest);
+  if (existing !== undefined && existing.objectKind !== objectKind) {
+    fail('system-record-closure', 'one pending closure digest has conflicting object kinds');
+  }
+  if (
+    existing === undefined ||
+    CLOSURE_PURPOSE_PRIORITY_V1[purpose] > CLOSURE_PURPOSE_PRIORITY_V1[existing.purpose]
+  ) {
+    state.pending.set(objectDigest, {
+      objectKind,
+      digest: objectDigest,
+      purpose,
+      ...(rootSubject === undefined ? {} : { rootSubject }),
+      ...(referencedByHeadDigest === undefined ? {} : { referencedByHeadDigest }),
+    });
+  }
+}
+
+type ClosureReferenceV1 = Pick<
+  SystemRecordVerificationClosureObjectV1,
+  'objectKind' | 'digest'
+>;
+
+async function visitClosureObjectV1(
+  state: ClosureCollectedStateV1,
+  context: ClosurePendingReferenceV1,
+  canonicalBytes: Uint8Array,
+  references: ClosureReferenceV1[],
+  execution: ClosureExecutionV1,
+): Promise<void> {
+  const objectKind = context.objectKind;
+  const objectDigest = context.digest;
+  const add = (
+    referencedKind: SystemRecordObjectKindV1,
+    referencedDigest: Digest32V1,
+    purpose: ClosurePurposeV1,
+    rootSubject?: string,
+    referencedByHeadDigest?: Digest32V1,
+  ) => {
+    enqueueClosureReferenceV1(
+      state,
+      referencedKind,
+      referencedDigest,
+      purpose,
+      rootSubject,
+      referencedByHeadDigest,
+    );
+    references.push(Object.freeze({ objectKind: referencedKind, digest: referencedDigest }));
+  };
+
+  if (objectKind === 'agent-profile-head') {
+    const envelope = parseCanonicalSignedAgentProfileHeadEnvelopeV1(canonicalBytes);
+    if (
+      envelope.objectDigest !== objectDigest ||
+      (await execution.verifyAuthorityEnvelope(envelope)) !== true
+    ) {
+      fail('system-record-closure', 'head authority verification failed');
+    }
+    const head = envelope.object;
+    if (isIssuedTooFarInFuture(head.issuedAt, execution.nowMs)) {
+      fail('system-record-closure', 'head issuedAt exceeds the future clock-skew bound');
+    }
+    state.parsedHeads.set(objectDigest, head);
+    state.rootClaims.add(head.rootSubject);
+    if (head.acceptedTransitionDigest !== undefined) {
+      add(
+        'authority-transition',
+        head.acceptedTransitionDigest,
+        'history',
+        undefined,
+        objectDigest,
+      );
+    }
+    if (
+      objectDigest === state.currentHeadDigest &&
+      head.forkResolutionDigest !== undefined
+    ) {
+      add('fork-resolution', head.forkResolutionDigest, 'history', undefined, objectDigest);
+    }
+    if (context.purpose === 'current' && head.state === 'active') {
+      add('profile-bundle', head.bundleDigest, 'current');
+    }
+    if (head.state === 'tombstone') {
+      add(
+        'agent-profile-head',
+        head.previousHeadDigest,
+        context.purpose === 'current' ? 'deletion-predecessor' : 'tombstone-predecessor',
+      );
+    }
+    if (
+      context.purpose === 'deletion-predecessor' ||
+      context.purpose === 'tombstone-predecessor'
+    ) {
+      if (head.state !== 'active') {
+        fail('system-record-closure', 'tombstone predecessor must be active');
+      }
+      if (context.purpose === 'deletion-predecessor') {
+        add('owned-subject-table', head.ownedSubjectTableDigest, 'history', head.rootSubject);
+      }
+    }
+    return;
+  }
+
+  if (objectKind === 'authority-transition') {
+    const envelope = parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(canonicalBytes);
+    if (
+      envelope.objectDigest !== objectDigest ||
+      (await execution.verifyAuthorityEnvelope(envelope)) !== true
+    ) {
+      fail('system-record-closure', 'authority-transition verification failed');
+    }
+    state.parsedTransitions.set(objectDigest, envelope.object);
+    if (context.referencedByHeadDigest !== undefined) {
+      const referencingHead = state.parsedHeads.get(context.referencedByHeadDigest);
+      if (
+        referencingHead === undefined ||
+        !isAgentProfileHeadBoundToAcceptedTransitionV1(referencingHead, envelope.object)
+      ) {
+        fail('system-record-closure', 'head does not bind its accepted authority transition');
+      }
+    }
+    state.rootClaims.add(envelope.object.nextRoot);
+    add('agent-profile-head', envelope.object.priorHeadDigest, 'history');
+    return;
+  }
+
+  if (objectKind === 'fork-resolution') {
+    const envelope = parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(canonicalBytes);
+    if (
+      envelope.objectDigest !== objectDigest ||
+      (await execution.verifyAuthorityEnvelope(envelope)) !== true
+    ) {
+      fail('system-record-closure', 'fork-resolution verification failed');
+    }
+    state.parsedResolutions.push(envelope.object);
+    if (isIssuedTooFarInFuture(envelope.object.issuedAt, execution.nowMs)) {
+      fail('system-record-closure', 'fork resolution issuedAt exceeds the future clock-skew bound');
+    }
+    if (context.referencedByHeadDigest !== undefined) {
+      const referencingHead = state.parsedHeads.get(context.referencedByHeadDigest);
+      if (
+        referencingHead === undefined ||
+        !isDirectResolvingSuccessorV1(referencingHead, envelope.object)
+      ) {
+        fail(
+          'system-record-closure',
+          'current head is not the direct successor of its fork resolution',
+        );
+      }
+    }
+    for (const headDigest of envelope.object.evidenceHeadDigests) {
+      add('agent-profile-head', headDigest, 'fork-evidence');
+    }
+    if (envelope.object.forkBaseHeadDigest !== undefined) {
+      add('agent-profile-head', envelope.object.forkBaseHeadDigest, 'history');
+    }
+    return;
+  }
+
+  if (objectKind === 'profile-bundle') {
+    const current = state.parsedHeads.get(state.currentHeadDigest);
+    if (
+      current?.state !== 'active' ||
+      digestSystemRecordBytesV1(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle, canonicalBytes) !==
+        objectDigest ||
+      (await execution.verifyCurrentBundle(current, canonicalBytes.slice())) !== true
+    ) {
+      fail('system-record-closure', 'current profile bundle verification failed');
+    }
+    return;
+  }
+
+  if (objectKind === 'owned-subject-table') {
+    if (context.rootSubject === undefined) {
+      fail('system-record-closure', 'subject table lacks root context');
+    }
+    const table = parseCanonicalOwnedSubjectTableObjectV1(context.rootSubject, canonicalBytes);
+    if (computeOwnedSubjectTableDigestV1(context.rootSubject, table) !== objectDigest) {
+      fail('system-record-closure', 'owned-subject table digest mismatch');
+    }
+    return;
+  }
+
+  fail('system-record-closure', `${objectKind} is not part of an advertised row closure`);
+}
+
+async function collectVerificationClosureV1(
+  state: ClosureCollectedStateV1,
+  execution: ClosureExecutionV1,
+): Promise<void> {
+  enqueueClosureReferenceV1(
+    state,
+    'agent-profile-head',
+    state.currentHeadDigest,
+    'current',
+  );
+
+  while (state.pending.size > 0) {
     const context = Object.freeze({
-      ...[...pending.values()].sort(compareClosureObjects)[0],
+      ...[...state.pending.values()].sort(compareClosureObjects)[0],
     });
     const key = context.digest;
-    pending.delete(key);
-    const seenKind = seen.get(key);
+    state.pending.delete(key);
+    const seenKind = state.seen.get(key);
     if (seenKind !== undefined) {
       if (seenKind !== context.objectKind) {
         fail(
@@ -228,14 +454,15 @@ export async function buildAgentProfileVerificationClosureV1(
       }
       continue;
     }
-    const resolved = await resolve(
+    const resolved = await execution.resolve(
       Object.freeze({
         objectKind: context.objectKind,
         digest: context.digest,
       }),
     );
-    if (resolved === undefined)
+    if (resolved === undefined) {
       fail('system-record-closure', `verification closure is missing ${key}`);
+    }
     const artifact = snapshotExactDataRecord(
       resolved,
       ['objectKind', 'digest', 'canonicalBytes'],
@@ -256,150 +483,20 @@ export async function buildAgentProfileVerificationClosureV1(
     } catch (cause) {
       fail('system-record-closure', 'closure artifact exceeds its kind cap', cause);
     }
-    const references: Pick<SystemRecordVerificationClosureObjectV1, 'objectKind' | 'digest'>[] = [];
-    const add = (
-      objectKind: SystemRecordObjectKindV1,
-      objectDigest: Digest32V1,
-      purpose: ClosurePurposeV1,
-      rootSubject?: string,
-      referencedByHeadDigest?: Digest32V1,
-    ) => {
-      enqueue(objectKind, objectDigest, purpose, rootSubject, referencedByHeadDigest);
-      references.push(Object.freeze({ objectKind, digest: objectDigest }));
-    };
+    const references: ClosureReferenceV1[] = [];
+    await visitClosureObjectV1(state, context, canonicalBytes, references, execution);
 
-    if (objectKind === 'agent-profile-head') {
-      const envelope = parseCanonicalSignedAgentProfileHeadEnvelopeV1(canonicalBytes);
-      if (
-        envelope.objectDigest !== objectDigest ||
-        (await verifyAuthorityEnvelope(envelope)) !== true
-      ) {
-        fail('system-record-closure', 'head authority verification failed');
-      }
-      const head = envelope.object;
-      if (isIssuedTooFarInFuture(head.issuedAt, nowMs)) {
-        fail('system-record-closure', 'head issuedAt exceeds the future clock-skew bound');
-      }
-      parsedHeads.set(objectDigest, head);
-      rootClaims.add(head.rootSubject);
-      if (head.acceptedTransitionDigest !== undefined) {
-        add(
-          'authority-transition',
-          head.acceptedTransitionDigest,
-          'history',
-          undefined,
-          objectDigest,
-        );
-      }
-      if (objectDigest === currentHeadDigest && head.forkResolutionDigest !== undefined) {
-        add('fork-resolution', head.forkResolutionDigest, 'history', undefined, objectDigest);
-      }
-      if (context.purpose === 'current' && head.state === 'active') {
-        add('profile-bundle', head.bundleDigest, 'current');
-      }
-      if (head.state === 'tombstone') {
-        add(
-          'agent-profile-head',
-          head.previousHeadDigest,
-          context.purpose === 'current' ? 'deletion-predecessor' : 'tombstone-predecessor',
-        );
-      }
-      if (
-        context.purpose === 'deletion-predecessor' ||
-        context.purpose === 'tombstone-predecessor'
-      ) {
-        if (head.state !== 'active')
-          fail('system-record-closure', 'tombstone predecessor must be active');
-        if (context.purpose === 'deletion-predecessor') {
-          add('owned-subject-table', head.ownedSubjectTableDigest, 'history', head.rootSubject);
-        }
-      }
-    } else if (objectKind === 'authority-transition') {
-      const envelope =
-        parseCanonicalSignedAgentProfileAuthorityTransitionEnvelopeV1(canonicalBytes);
-      if (
-        envelope.objectDigest !== objectDigest ||
-        (await verifyAuthorityEnvelope(envelope)) !== true
-      ) {
-        fail('system-record-closure', 'authority-transition verification failed');
-      }
-      parsedTransitions.set(objectDigest, envelope.object);
-      if (context.referencedByHeadDigest !== undefined) {
-        const referencingHead = parsedHeads.get(context.referencedByHeadDigest);
-        if (
-          referencingHead === undefined ||
-          !isAgentProfileHeadBoundToAcceptedTransitionV1(referencingHead, envelope.object)
-        ) {
-          fail('system-record-closure', 'head does not bind its accepted authority transition');
-        }
-      }
-      rootClaims.add(envelope.object.nextRoot);
-      add('agent-profile-head', envelope.object.priorHeadDigest, 'history');
-    } else if (objectKind === 'fork-resolution') {
-      const envelope = parseCanonicalSignedAgentProfileForkResolutionEnvelopeV1(canonicalBytes);
-      if (
-        envelope.objectDigest !== objectDigest ||
-        (await verifyAuthorityEnvelope(envelope)) !== true
-      ) {
-        fail('system-record-closure', 'fork-resolution verification failed');
-      }
-      parsedResolutions.push(envelope.object);
-      if (isIssuedTooFarInFuture(envelope.object.issuedAt, nowMs)) {
-        fail(
-          'system-record-closure',
-          'fork resolution issuedAt exceeds the future clock-skew bound',
-        );
-      }
-      if (context.referencedByHeadDigest !== undefined) {
-        const referencingHead = parsedHeads.get(context.referencedByHeadDigest);
-        if (
-          referencingHead === undefined ||
-          !isDirectResolvingSuccessorV1(referencingHead, envelope.object)
-        ) {
-          fail(
-            'system-record-closure',
-            'current head is not the direct successor of its fork resolution',
-          );
-        }
-      }
-      for (const headDigest of envelope.object.evidenceHeadDigests) {
-        add('agent-profile-head', headDigest, 'fork-evidence');
-      }
-      if (envelope.object.forkBaseHeadDigest !== undefined) {
-        add('agent-profile-head', envelope.object.forkBaseHeadDigest, 'history');
-      }
-    } else if (objectKind === 'profile-bundle') {
-      const current = parsedHeads.get(currentHeadDigest);
-      if (
-        current?.state !== 'active' ||
-        digestSystemRecordBytesV1(SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle, canonicalBytes) !==
-          objectDigest ||
-        (await verifyCurrentBundle(current, canonicalBytes.slice())) !== true
-      ) {
-        fail('system-record-closure', 'current profile bundle verification failed');
-      }
-    } else if (objectKind === 'owned-subject-table') {
-      if (context.rootSubject === undefined)
-        fail('system-record-closure', 'subject table lacks root context');
-      const table = parseCanonicalOwnedSubjectTableObjectV1(context.rootSubject, canonicalBytes);
-      if (computeOwnedSubjectTableDigestV1(context.rootSubject, table) !== objectDigest) {
-        fail('system-record-closure', 'owned-subject table digest mismatch');
-      }
-    } else {
-      fail('system-record-closure', `${objectKind} is not part of an advertised row closure`);
-    }
-
-    bytes += canonicalBytes.byteLength;
+    state.canonicalBytes += canonicalBytes.byteLength;
     if (
-      artifacts.length + 1 > SYSTEM_RECORD_MAX_CLOSURE_OBJECTS ||
-      bytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES ||
-      rootClaims.size > SYSTEM_RECORD_MAX_ROOT_CLAIMS ||
-      parsedResolutions.length > SYSTEM_RECORD_MAX_RESOLVED_FORK_TUPLES
+      state.artifacts.length + 1 > SYSTEM_RECORD_MAX_CLOSURE_OBJECTS ||
+      state.canonicalBytes > SYSTEM_RECORD_MAX_CLOSURE_BYTES ||
+      state.rootClaims.size > SYSTEM_RECORD_MAX_ROOT_CLAIMS ||
+      state.parsedResolutions.length > SYSTEM_RECORD_MAX_RESOLVED_FORK_TUPLES
     ) {
       fail('system-record-closure', 'verification closure exceeds a V1 bound');
     }
-    seen.set(key, objectKind);
-    artifacts.push(
+    state.seen.set(key, objectKind);
+    state.artifacts.push(
       Object.freeze({
         objectKind,
         digest: objectDigest,
@@ -407,30 +504,35 @@ export async function buildAgentProfileVerificationClosureV1(
         references: Object.freeze(references.sort(compareClosureObjects)),
       }),
     );
-    if (seen.size + pending.size > SYSTEM_RECORD_MAX_CLOSURE_OBJECTS) {
+    if (state.seen.size + state.pending.size > SYSTEM_RECORD_MAX_CLOSURE_OBJECTS) {
       fail('system-record-closure', 'verification closure cannot fit before dependency fetch');
     }
   }
+}
 
-  for (const resolution of parsedResolutions) {
+function validateCollectedClosureAuthorityV1(
+  state: ClosureCollectedStateV1,
+  nowMs: number,
+): void {
+  for (const resolution of state.parsedResolutions) {
     const evidence = resolution.evidenceHeadDigests.map((headDigest) =>
-      parsedHeads.get(headDigest),
+      state.parsedHeads.get(headDigest),
     );
     if (evidence.some((head) => head === undefined)) {
       fail('system-record-closure', 'fork evidence is incomplete after traversal');
     }
-    const base =
-      resolution.forkBaseHeadDigest === undefined
-        ? undefined
-        : parsedHeads.get(resolution.forkBaseHeadDigest);
+    const base = resolution.forkBaseHeadDigest === undefined
+      ? undefined
+      : state.parsedHeads.get(resolution.forkBaseHeadDigest);
     assertAgentProfileForkResolutionEvidenceV1(
       resolution,
       evidence as AgentProfileHeadObjectV1[],
       base,
     );
-    const transitionDigest = (evidence as AgentProfileHeadObjectV1[])[0].acceptedTransitionDigest;
+    const transitionDigest = (evidence as AgentProfileHeadObjectV1[])[0]
+      .acceptedTransitionDigest;
     const resolutionDigest = computeAgentProfileForkResolutionDigestV1(resolution);
-    for (const head of parsedHeads.values()) {
+    for (const head of state.parsedHeads.values()) {
       if (
         head.forkResolutionDigest === resolutionDigest &&
         head.acceptedTransitionDigest !== transitionDigest
@@ -439,9 +541,10 @@ export async function buildAgentProfileVerificationClosureV1(
       }
     }
   }
+
   const transitionTupleDigests = new Map<string, Digest32V1>();
-  for (const [transitionDigest, transition] of parsedTransitions) {
-    const prior = parsedHeads.get(transition.priorHeadDigest);
+  for (const [transitionDigest, transition] of state.parsedTransitions) {
+    const prior = state.parsedHeads.get(transition.priorHeadDigest);
     if (
       prior === undefined ||
       evaluateAuthorityTransitionV1(transition, prior, nowMs).decision !== 'accept'
@@ -466,10 +569,11 @@ export async function buildAgentProfileVerificationClosureV1(
     }
     transitionTupleDigests.set(tuple, transitionDigest);
   }
-  for (const [headDigest, head] of parsedHeads) {
-    assertCompleteUniqueRootLineage(headDigest, head);
+
+  for (const [headDigest, head] of state.parsedHeads) {
+    assertCompleteUniqueRootLineageV1(state, headDigest, head);
     if (head.acceptedTransitionDigest !== undefined) {
-      const transition = parsedTransitions.get(head.acceptedTransitionDigest);
+      const transition = state.parsedTransitions.get(head.acceptedTransitionDigest);
       if (
         transition === undefined ||
         !isAgentProfileHeadBoundToAcceptedTransitionV1(head, transition)
@@ -477,8 +581,11 @@ export async function buildAgentProfileVerificationClosureV1(
         fail('system-record-closure', `head ${headDigest} does not bind its accepted transition`);
       }
     }
-    if (headDigest === currentHeadDigest && head.forkResolutionDigest !== undefined) {
-      const resolution = parsedResolutions.find(
+    if (
+      headDigest === state.currentHeadDigest &&
+      head.forkResolutionDigest !== undefined
+    ) {
+      const resolution = state.parsedResolutions.find(
         (candidate) =>
           computeAgentProfileForkResolutionDigestV1(candidate) === head.forkResolutionDigest,
       );
@@ -490,10 +597,14 @@ export async function buildAgentProfileVerificationClosureV1(
       }
     }
   }
-  for (const head of parsedHeads.values()) {
+
+  for (const head of state.parsedHeads.values()) {
     if (head.state === 'tombstone') {
-      const predecessor = parsedHeads.get(head.previousHeadDigest);
-      if (predecessor?.state !== 'active' || !isTombstoneBoundToPredecessorV1(head, predecessor)) {
+      const predecessor = state.parsedHeads.get(head.previousHeadDigest);
+      if (
+        predecessor?.state !== 'active' ||
+        !isTombstoneBoundToPredecessorV1(head, predecessor)
+      ) {
         fail(
           'system-record-closure',
           'tombstone predecessor is not the exact prior active authority state',
@@ -501,148 +612,148 @@ export async function buildAgentProfileVerificationClosureV1(
       }
     }
   }
-  const authoritySummary = createVerifiedAuthoritySummary();
-  artifacts.sort(compareClosureObjects);
+}
+
+function assertCompleteUniqueRootLineageV1(
+  state: ClosureCollectedStateV1,
+  headDigest: Digest32V1,
+  head: AgentProfileHeadObjectV1,
+): void {
+  let cursor = head;
+  let sequence = parseCanonicalDecimalU64(head.authoritySequence);
+  const roots = new Set<string>([head.rootSubject]);
+  for (let depth = 0; sequence > 0n; depth += 1) {
+    if (
+      depth >= Number(SYSTEM_RECORD_AUTHORITY_SEQUENCE_MAX) ||
+      cursor.acceptedTransitionDigest === undefined
+    ) {
+      fail('system-record-history', `head ${headDigest} has incomplete authority/root lineage`);
+    }
+    const transition = state.parsedTransitions.get(cursor.acceptedTransitionDigest);
+    const prior = transition === undefined
+      ? undefined
+      : state.parsedHeads.get(transition.priorHeadDigest);
+    if (
+      transition === undefined ||
+      prior === undefined ||
+      parseCanonicalDecimalU64(transition.nextAuthoritySequence) !== sequence ||
+      parseCanonicalDecimalU64(prior.authoritySequence) + 1n !== sequence
+    ) {
+      fail('system-record-history', `head ${headDigest} has incomplete authority/root lineage`);
+    }
+    if (roots.has(prior.rootSubject)) {
+      fail('system-record-history', `head ${headDigest} reuses a historical wallet root`);
+    }
+    roots.add(prior.rootSubject);
+    cursor = prior;
+    sequence -= 1n;
+  }
+  if (cursor.acceptedTransitionDigest !== undefined) {
+    fail('system-record-history', `head ${headDigest} has authority evidence below sequence zero`);
+  }
+}
+
+function projectVerificationClosureV1(
+  state: ClosureCollectedStateV1,
+): SystemRecordVerificationClosureV1 {
+  const authoritySummary = createVerifiedAuthoritySummaryV1(state);
+  state.artifacts.sort(compareClosureObjects);
   return Object.freeze({
-    objects: Object.freeze(artifacts),
-    canonicalBytes: bytes,
-    rootClaims: rootClaims.size,
-    resolvedForkTuples: parsedResolutions.length,
+    objects: Object.freeze(state.artifacts),
+    canonicalBytes: state.canonicalBytes,
+    rootClaims: state.rootClaims.size,
+    resolvedForkTuples: state.parsedResolutions.length,
     authoritySummary,
   });
+}
 
-  function enqueue(
-    objectKind: SystemRecordObjectKindV1,
-    objectDigest: Digest32V1,
-    purpose: ClosurePurposeV1,
-    rootSubject?: string,
-    referencedByHeadDigest?: Digest32V1,
-  ): void {
-    digest(objectDigest, 'closure reference digest');
-    const key = objectDigest;
-    const seenKind = seen.get(key);
-    if (seenKind !== undefined) {
-      if (seenKind !== objectKind) {
-        fail(
-          'system-record-closure',
-          'one closure digest was referenced under different object kinds',
-        );
-      }
-      return;
-    }
-    const existing = pending.get(key);
-    if (existing !== undefined && existing.objectKind !== objectKind) {
-      fail('system-record-closure', 'one pending closure digest has conflicting object kinds');
-    }
-    const priority: Record<ClosurePurposeV1, number> = {
-      history: 0,
-      'fork-evidence': 1,
-      'tombstone-predecessor': 2,
-      'deletion-predecessor': 3,
-      current: 4,
-    };
-    if (existing === undefined || priority[purpose] > priority[existing.purpose]) {
-      pending.set(key, {
-        objectKind,
-        digest: objectDigest,
-        purpose,
-        ...(rootSubject === undefined ? {} : { rootSubject }),
-        ...(referencedByHeadDigest === undefined ? {} : { referencedByHeadDigest }),
-      });
-    }
+function createVerifiedAuthoritySummaryV1(
+  state: ClosureCollectedStateV1,
+): AgentProfileVerifiedAuthoritySummaryV1 {
+  const current = state.parsedHeads.get(state.currentHeadDigest);
+  if (current === undefined) {
+    fail('system-record-closure', 'verified closure lost its current head');
   }
+  const reverseLineage: AgentProfileAppliedTransitionV1[] = [];
+  const reverseRoots: string[] = [];
+  let cursor = current;
+  let sequence = parseCanonicalDecimalU64(current.authoritySequence);
+  while (sequence > 0n) {
+    const transition = cursor.acceptedTransitionDigest === undefined
+      ? undefined
+      : state.parsedTransitions.get(cursor.acceptedTransitionDigest);
+    const prior = transition === undefined
+      ? undefined
+      : state.parsedHeads.get(transition.priorHeadDigest);
+    if (transition === undefined || prior === undefined) {
+      fail('system-record-history', 'verified closure lost its authority lineage');
+    }
+    reverseLineage.push(
+      Object.freeze({
+        priorAuthoritySequence: transition.priorAuthoritySequence,
+        nextAuthoritySequence: transition.nextAuthoritySequence,
+        transitionDigest: computeAgentProfileAuthorityTransitionDigestV1(transition),
+      }),
+    );
+    reverseRoots.push(prior.rootSubject);
+    cursor = prior;
+    sequence -= 1n;
+  }
+  const tombstonePredecessor = current.state === 'tombstone'
+    ? state.parsedHeads.get(current.previousHeadDigest)
+    : undefined;
+  if (tombstonePredecessor !== undefined && tombstonePredecessor.state !== 'active') {
+    fail('system-record-history', 'verified tombstone closure lost its active predecessor');
+  }
+  const latestTransition = current.acceptedTransitionDigest === undefined
+    ? undefined
+    : state.parsedTransitions.get(current.acceptedTransitionDigest);
+  if (current.authoritySequence !== '0' && latestTransition === undefined) {
+    fail('system-record-history', 'verified closure lost its latest authority transition');
+  }
+  return mintAgentProfileVerifiedAuthoritySummaryV1({
+    candidateHeadDigest: state.currentHeadDigest,
+    transitionLineage: Object.freeze(reverseLineage.reverse()),
+    historicalRoots: Object.freeze(reverseRoots.reverse()),
+    lastAuthorityTransitionPriorHeadDigest: latestTransition?.priorHeadDigest,
+    tombstonePredecessor:
+      tombstonePredecessor?.state === 'active' ? tombstonePredecessor : undefined,
+    deletionTableDigest: tombstonePredecessor?.ownedSubjectTableDigest,
+  });
+}
 
-  function assertCompleteUniqueRootLineage(
-    headDigest: Digest32V1,
-    head: AgentProfileHeadObjectV1,
-  ): void {
-    let cursor = head;
-    let sequence = parseCanonicalDecimalU64(head.authoritySequence);
-    const roots = new Set<string>([head.rootSubject]);
-    for (let depth = 0; sequence > 0n; depth += 1) {
-      if (
-        depth >= Number(SYSTEM_RECORD_AUTHORITY_SEQUENCE_MAX) ||
-        cursor.acceptedTransitionDigest === undefined
-      ) {
-        fail('system-record-history', `head ${headDigest} has incomplete authority/root lineage`);
-      }
-      const transition = parsedTransitions.get(cursor.acceptedTransitionDigest);
-      const prior =
-        transition === undefined ? undefined : parsedHeads.get(transition.priorHeadDigest);
-      if (
-        transition === undefined ||
-        prior === undefined ||
-        parseCanonicalDecimalU64(transition.nextAuthoritySequence) !== sequence ||
-        parseCanonicalDecimalU64(prior.authoritySequence) + 1n !== sequence
-      ) {
-        fail('system-record-history', `head ${headDigest} has incomplete authority/root lineage`);
-      }
-      if (roots.has(prior.rootSubject)) {
-        fail('system-record-history', `head ${headDigest} reuses a historical wallet root`);
-      }
-      roots.add(prior.rootSubject);
-      cursor = prior;
-      sequence -= 1n;
-    }
-    if (cursor.acceptedTransitionDigest !== undefined) {
-      fail(
-        'system-record-history',
-        `head ${headDigest} has authority evidence below sequence zero`,
-      );
-    }
+/**
+ * Derive the row closure from canonical objects rather than trusting caller-supplied edges.
+ * Authority and current-bundle verification stay injected because final chain/seal proofs
+ * belong to later stacks, but a false/missing verifier result always fails closed.
+ */
+export async function buildAgentProfileVerificationClosureV1(
+  currentHeadDigest: Digest32V1,
+  verifier: AgentProfileClosureVerifierV1,
+): Promise<SystemRecordVerificationClosureV1> {
+  digest(currentHeadDigest, 'currentHeadDigest');
+  const nowMs = verifier.nowMs;
+  const resolve = verifier.resolve;
+  const verifyAuthorityEnvelope = verifier.verifyAuthorityEnvelope;
+  const verifyCurrentBundle = verifier.verifyCurrentBundle;
+  if (!isSafeNow(nowMs)) fail('system-record-closure', 'closure verifier clock is invalid');
+  if (
+    typeof resolve !== 'function' ||
+    typeof verifyAuthorityEnvelope !== 'function' ||
+    typeof verifyCurrentBundle !== 'function'
+  ) {
+    fail('system-record-closure', 'closure verifier callbacks are invalid');
   }
-
-  function createVerifiedAuthoritySummary(): AgentProfileVerifiedAuthoritySummaryV1 {
-    const current = parsedHeads.get(currentHeadDigest);
-    if (current === undefined)
-      fail('system-record-closure', 'verified closure lost its current head');
-    const reverseLineage: AgentProfileAppliedTransitionV1[] = [];
-    const reverseRoots: string[] = [];
-    let cursor = current;
-    let sequence = parseCanonicalDecimalU64(current.authoritySequence);
-    while (sequence > 0n) {
-      const transition =
-        cursor.acceptedTransitionDigest === undefined
-          ? undefined
-          : parsedTransitions.get(cursor.acceptedTransitionDigest);
-      const prior =
-        transition === undefined ? undefined : parsedHeads.get(transition.priorHeadDigest);
-      if (transition === undefined || prior === undefined) {
-        fail('system-record-history', 'verified closure lost its authority lineage');
-      }
-      reverseLineage.push(
-        Object.freeze({
-          priorAuthoritySequence: transition.priorAuthoritySequence,
-          nextAuthoritySequence: transition.nextAuthoritySequence,
-          transitionDigest: computeAgentProfileAuthorityTransitionDigestV1(transition),
-        }),
-      );
-      reverseRoots.push(prior.rootSubject);
-      cursor = prior;
-      sequence -= 1n;
-    }
-    const tombstonePredecessor =
-      current.state === 'tombstone' ? parsedHeads.get(current.previousHeadDigest) : undefined;
-    if (tombstonePredecessor !== undefined && tombstonePredecessor.state !== 'active') {
-      fail('system-record-history', 'verified tombstone closure lost its active predecessor');
-    }
-    const latestTransition =
-      current.acceptedTransitionDigest === undefined
-        ? undefined
-        : parsedTransitions.get(current.acceptedTransitionDigest);
-    if (current.authoritySequence !== '0' && latestTransition === undefined) {
-      fail('system-record-history', 'verified closure lost its latest authority transition');
-    }
-    return mintAgentProfileVerifiedAuthoritySummaryV1({
-      candidateHeadDigest: currentHeadDigest,
-      transitionLineage: Object.freeze(reverseLineage.reverse()),
-      historicalRoots: Object.freeze(reverseRoots.reverse()),
-      lastAuthorityTransitionPriorHeadDigest: latestTransition?.priorHeadDigest,
-      tombstonePredecessor:
-        tombstonePredecessor?.state === 'active' ? tombstonePredecessor : undefined,
-      deletionTableDigest: tombstonePredecessor?.ownedSubjectTableDigest,
-    });
-  }
+  const execution: ClosureExecutionV1 = Object.freeze({
+    nowMs,
+    resolve,
+    verifyAuthorityEnvelope,
+    verifyCurrentBundle,
+  });
+  const state = createClosureCollectedStateV1(currentHeadDigest);
+  await collectVerificationClosureV1(state, execution);
+  validateCollectedClosureAuthorityV1(state, nowMs);
+  return projectVerificationClosureV1(state);
 }
 
 function compareClosureObjects(

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -54,17 +54,6 @@ function expectNoDependencyPath(name: string, forbidden: readonly string[]): voi
   for (const dependency of forbidden) expect(reachable).not.toContain(dependency);
 }
 
-function functionSource(name: string, functionName: string): string {
-  const text = source(name);
-  const parsed = ts.createSourceFile(name, text, ts.ScriptTarget.Latest, true);
-  const declaration = parsed.statements.find(
-    (statement): statement is ts.FunctionDeclaration =>
-      ts.isFunctionDeclaration(statement) && statement.name?.text === functionName,
-  );
-  if (declaration === undefined) throw new Error(`${functionName} is not a top-level function`);
-  return declaration.getText(parsed);
-}
-
 describe('System Record V1 module ownership', () => {
   it('keeps the supported object and inventory facades explicit', () => {
     for (const facade of ['system-record-objects-v1.ts', 'system-record-inventory-v1.ts']) {
@@ -224,23 +213,17 @@ describe('System Record V1 module ownership', () => {
     );
   });
 
-  it('keeps verification closure and cache preflight as named phase orchestrators', () => {
-    const closure = functionSource(
+  it('keeps closure and cache internals below durable code-health boundaries', () => {
+    expect(source('system-record-verification-closure-v1-internal.ts').split('\n').length)
+      .toBeLessThan(850);
+    expect(source('system-record-cache-accounting-v1-internal.ts').split('\n').length)
+      .toBeLessThan(650);
+    for (const unit of [
       'system-record-verification-closure-v1-internal.ts',
-      'buildAgentProfileVerificationClosureV1',
-    );
-    expect(closure).toMatch(
-      /collectVerificationClosureV1[\s\S]*validateCollectedClosureAuthorityV1[\s\S]*projectVerificationClosureV1/u,
-    );
-    expect(closure).not.toContain('mintAgentProfileVerifiedAuthoritySummaryV1');
-
-    const cache = functionSource(
       'system-record-cache-accounting-v1-internal.ts',
-      'preflightSystemRecordCacheAccountingV1',
-    );
-    expect(cache).toMatch(
-      /normalizeCachePreflightInputV1[\s\S]*collectCacheAccountingRowV1[\s\S]*assertLiveCacheAccountingBoundsV1[\s\S]*assertActivationCacheAccountingBoundsV1[\s\S]*projectCacheAccountingResultV1/u,
-    );
+    ]) {
+      expect(source(unit)).not.toMatch(/export\s+\*/u);
+    }
   });
 
   it('keeps wire and applied-state codecs off authority and closure implementations', () => {

--- a/packages/core/test/system-record-module-boundaries-v1.test.ts
+++ b/packages/core/test/system-record-module-boundaries-v1.test.ts
@@ -54,6 +54,17 @@ function expectNoDependencyPath(name: string, forbidden: readonly string[]): voi
   for (const dependency of forbidden) expect(reachable).not.toContain(dependency);
 }
 
+function functionSource(name: string, functionName: string): string {
+  const text = source(name);
+  const parsed = ts.createSourceFile(name, text, ts.ScriptTarget.Latest, true);
+  const declaration = parsed.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === functionName,
+  );
+  if (declaration === undefined) throw new Error(`${functionName} is not a top-level function`);
+  return declaration.getText(parsed);
+}
+
 describe('System Record V1 module ownership', () => {
   it('keeps the supported object and inventory facades explicit', () => {
     for (const facade of ['system-record-objects-v1.ts', 'system-record-inventory-v1.ts']) {
@@ -210,6 +221,25 @@ describe('System Record V1 module ownership', () => {
     );
     expect(source('system-record-verification-closure-v1-internal.ts')).toMatch(
       /function mintAgentProfileVerifiedAuthoritySummaryV1/u,
+    );
+  });
+
+  it('keeps verification closure and cache preflight as named phase orchestrators', () => {
+    const closure = functionSource(
+      'system-record-verification-closure-v1-internal.ts',
+      'buildAgentProfileVerificationClosureV1',
+    );
+    expect(closure).toMatch(
+      /collectVerificationClosureV1[\s\S]*validateCollectedClosureAuthorityV1[\s\S]*projectVerificationClosureV1/u,
+    );
+    expect(closure).not.toContain('mintAgentProfileVerifiedAuthoritySummaryV1');
+
+    const cache = functionSource(
+      'system-record-cache-accounting-v1-internal.ts',
+      'preflightSystemRecordCacheAccountingV1',
+    );
+    expect(cache).toMatch(
+      /normalizeCachePreflightInputV1[\s\S]*collectCacheAccountingRowV1[\s\S]*assertLiveCacheAccountingBoundsV1[\s\S]*assertActivationCacheAccountingBoundsV1[\s\S]*projectCacheAccountingResultV1/u,
     );
   });
 

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -1138,7 +1138,7 @@ describe('system-record owned subjects and verification closure', () => {
     })).toThrow(/aggregate cache accounting exceeds/);
   });
 
-  it('preserves shared physical accounting across closure, sidecar, and inventory paths', () => {
+  it('preserves shared physical accounting across closure, sidecar, and inventory paths', async () => {
     const metadata = createSystemRecordCacheMetadataV1(new Uint8Array());
     const reference = (
       objectKind: 'profile-bundle' | 'conflict-evidence' | 'inventory-leaf',
@@ -1159,6 +1159,14 @@ describe('system-record owned subjects and verification closure', () => {
       SYSTEM_RECORD_DIGEST_DOMAINS_V1.conflictEvidence,
       'shared-sidecar',
     );
+    const fixture = await authorityFixture();
+    const transition = authorityTransition(fixture, activeHead(fixture));
+    const transitionBytes = fakeEnvelopeBytes(transition);
+    const sharedControl = createSystemRecordCacheReferenceV1(
+      'authority-transition',
+      computeAgentProfileAuthorityTransitionDigestV1(transition),
+      transitionBytes,
+    );
     const inventoryLeaf = reference(
       'inventory-leaf',
       SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryLeaf,
@@ -1166,16 +1174,21 @@ describe('system-record owned subjects and verification closure', () => {
     );
     const result = preflightSystemRecordCacheAccountingV1({
       mode: 'activation',
-      rows: [0, 1].map(() => ({
-        closure: [sharedClosure],
-        sidecar: [sharedSidecar],
+      rows: [{
+        closure: [sharedClosure, sharedControl],
+        sidecar: [sharedControl, sharedSidecar],
         metadata,
         sidecarMetadata: metadata,
-      })),
+      }],
       inventoryLeaves: [inventoryLeaf],
     });
     expect(result).toMatchObject({
-      cohortPhysicalObjects: 3,
+      cohortPhysicalObjects: 4,
+      cohortPhysicalBytes:
+        new TextEncoder().encode('shared-closure').byteLength
+        + transitionBytes.byteLength
+        + new TextEncoder().encode('shared-sidecar').byteLength
+        + new TextEncoder().encode('activation-leaf').byteLength,
       closureReferences: 2,
       sidecarReferences: 2,
       activationInventoryLeaves: 1,

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -1138,6 +1138,60 @@ describe('system-record owned subjects and verification closure', () => {
     })).toThrow(/aggregate cache accounting exceeds/);
   });
 
+  it('preserves shared physical accounting across closure, sidecar, and inventory paths', () => {
+    const metadata = createSystemRecordCacheMetadataV1(new Uint8Array());
+    const reference = (
+      objectKind: 'profile-bundle' | 'conflict-evidence' | 'inventory-leaf',
+      domain: string,
+      label: string,
+    ) => {
+      const canonicalBytes = new TextEncoder().encode(label);
+      const digest = digestSystemRecordBytesV1(domain, canonicalBytes);
+      return createSystemRecordCacheReferenceV1(objectKind, digest, canonicalBytes);
+    };
+    const sharedClosure = reference(
+      'profile-bundle',
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+      'shared-closure',
+    );
+    const sharedSidecar = reference(
+      'conflict-evidence',
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.conflictEvidence,
+      'shared-sidecar',
+    );
+    const inventoryLeaf = reference(
+      'inventory-leaf',
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryLeaf,
+      'activation-leaf',
+    );
+    const result = preflightSystemRecordCacheAccountingV1({
+      mode: 'activation',
+      rows: [0, 1].map(() => ({
+        closure: [sharedClosure],
+        sidecar: [sharedSidecar],
+        metadata,
+        sidecarMetadata: metadata,
+      })),
+      inventoryLeaves: [inventoryLeaf],
+    });
+    expect(result).toMatchObject({
+      cohortPhysicalObjects: 3,
+      closureReferences: 2,
+      sidecarReferences: 2,
+      activationInventoryLeaves: 1,
+    });
+
+    expect(() => preflightSystemRecordCacheAccountingV1({
+      mode: 'activation',
+      rows: [],
+      inventoryLeaves: Array.from({ length: 5 }, (_, index) => reference(
+        'inventory-leaf',
+        SYSTEM_RECORD_DIGEST_DOMAINS_V1.inventoryLeaf,
+        `activation-leaf-${index}`,
+      )),
+    })).toThrow(/leaf bound|closed bounds/);
+  });
+
   it.runIf(process.env.DKG_SYSTEM_RECORD_EXHAUSTIVE === '1')(
     'accepts exactly 128 MiB of activation bundles and rejects one more MiB', () => {
     const reusable = new Uint8Array(SYSTEM_RECORD_MAX_ATOMIC_BUNDLE_BYTES);
@@ -1765,6 +1819,21 @@ describe('system-record owned subjects and verification closure', () => {
       deletionTableDigest: middle.ownedSubjectTableDigest,
       historicalRoots: [initial.rootSubject],
       lastAuthorityTransitionPriorHeadDigest: transition.priorHeadDigest,
+    });
+    expect(closure.objects.map(({ objectKind }) => objectKind).sort()).toEqual([
+      'agent-profile-head',
+      'agent-profile-head',
+      'agent-profile-head',
+      'authority-transition',
+      'owned-subject-table',
+    ]);
+    expect(closure.objects.find(
+      ({ objectKind, digest }) =>
+        objectKind === 'authority-transition' &&
+        digest === computeAgentProfileAuthorityTransitionDigestV1(transition),
+    )?.references).toContainEqual({
+      objectKind: 'agent-profile-head',
+      digest: transition.priorHeadDigest,
     });
   });
 


### PR DESCRIPTION
## Summary

- Decompose verification-closure traversal into explicit collection, per-kind visitation, authority validation, and immutable projection phases without changing protocol behavior.
- Replace the cache-preflight monolith with one typed accumulator plus separate normalization, live-bound, activation-bound, total, and projection phases.
- Separate cohort-wide physical de-duplication from optional closure/sidecar category totals, so inventory no longer allocates a throwaway category map.
- Preserve deterministic ordering, callback order, cache identity semantics, all bounds and failure messages, and the closure-owned private authority-summary mint.

## Related

- Fixes #2176
- Fixes #2181
- Follow-up to #2171
- Stacked on #2199
- Related to #2052

## Diagrams

### Verification closure

Before:

```mermaid
sequenceDiagram
    participant Caller
    participant Builder
    participant Resolver
    participant Verifier
    Caller->>Builder: Build closure
    loop Pending references
        Builder->>Resolver: Resolve canonical object
        Builder->>Verifier: Verify object and authority
        Builder->>Builder: Parse, discover, account, validate, project
    end
    Builder-->>Caller: Frozen closure and authority summary
```

After:

```mermaid
sequenceDiagram
    participant Caller
    participant Builder
    participant Resolver
    participant Verifier
    Caller->>Builder: Build closure
    Builder->>Builder: Create per-call collected state
    loop Deterministically ordered references
        Builder->>Resolver: Resolve canonical object
        Builder->>Verifier: Verify through focused visitor
        Builder->>Builder: Collect references and accounting
    end
    Builder->>Builder: Validate lineage and project private summary
    Builder-->>Caller: Behavior-identical frozen closure
```

### Cache accounting

Before:

```mermaid
sequenceDiagram
    participant Caller
    participant Preflight
    Caller->>Preflight: Rows and activation inventory
    Preflight->>Preflight: Mix logical, category, and physical accounting
    Preflight-->>Caller: Frozen result
```

After:

```mermaid
sequenceDiagram
    participant Caller
    participant Preflight
    participant Physical as Physical de-dup owner
    Caller->>Preflight: Rows and activation inventory
    Preflight->>Physical: Register each physical reference once
    Preflight->>Preflight: Opt closure and sidecar into category totals
    Preflight-->>Caller: Behavior-identical frozen result
```

## Files changed

| File | What |
|------|------|
| `packages/core/src/system-record-verification-closure-v1-internal.ts` | Split deterministic closure construction into collected-state, visitor, validation, and projection phases. |
| `packages/core/src/system-record-cache-accounting-v1-internal.ts` | Introduce one accumulator, separate live/activation policy checks, and a physical-reference owner that needs no fake category map. |
| `packages/core/test/system-record-module-boundaries-v1.test.ts` | Lock public entry points to named phases and protect private mint ownership. |
| `packages/core/test/system-record-objects-v1.test.ts` | Prove exact physical de-duplication across logical paths and preserve activation totals. |

## Test plan

- [x] Build RDF Utils and Core.
- [x] Run `test:system-record` (97 passed, 2 skipped).
- [x] Re-run the focused object/accounting suite after physical-accounting extraction (33 passed, 1 exhaustive case skipped).
- [x] Run `test:system-record-export` (269 exact symbols).
- [x] Run `test:baseline` (1,692 passed).
- [x] Run `test:system-record-exhaustive` (2/2).
- [x] Build the Agent dependency graph excluding EVM module.
- [x] Run `git diff --check`.

- [x] After rebasing onto #2199 head `f32664b4e`, rebuild Core and rerun all eight System Record suites (101 passed, 2 exhaustive-only skips) plus the 269-symbol export gate.
