### PR TITLE
feat(agent): add bounded exact record requester

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -34,6 +34,8 @@
     "./dist/system-records/artifact-v1.js": "./dist/system-records/artifact-v1.js",
     "./dist/system-records/in-memory-agent-profile-publication-store-v1.js": "./dist/system-records/in-memory-agent-profile-publication-store-v1.js",
     "./dist/system-records/provider-v1.js": "./dist/system-records/provider-v1.js",
+    "./dist/system-records/requester-api-v1.js": "./dist/system-records/requester-api-v1.js",
+    "./dist/system-records/requester-v1.js": "./dist/system-records/requester-v1.js",
     "./dist/system-records/transport-v1.js": "./dist/system-records/transport-v1.js",
     "./dist/system-records/*": null,
     "./dist/rfc64/control-envelope-signer-v1.js": null,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -34,7 +34,6 @@
     "./dist/system-records/artifact-v1.js": "./dist/system-records/artifact-v1.js",
     "./dist/system-records/in-memory-agent-profile-publication-store-v1.js": "./dist/system-records/in-memory-agent-profile-publication-store-v1.js",
     "./dist/system-records/provider-v1.js": "./dist/system-records/provider-v1.js",
-    "./dist/system-records/requester-api-v1.js": "./dist/system-records/requester-api-v1.js",
     "./dist/system-records/requester-v1.js": "./dist/system-records/requester-v1.js",
     "./dist/system-records/transport-v1.js": "./dist/system-records/transport-v1.js",
     "./dist/system-records/*": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -22,25 +22,25 @@ const expectedRfc64PolicyCells = [
   'private-open',
   'private-curated',
 ];
-const internalAgentProfilePhaseSpecifiers = [
+const internalAgentSpecifiers = [
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-api-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-artifacts-v1-internal.js',
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-preparation-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-signing-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-inventory-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-commit-v1.js',
+  '@origintrail-official/dkg-agent/dist/system-records/requester-api-v1.js',
 ];
 const publicSystemRecordSpecifiers = [
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/artifact-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/in-memory-agent-profile-publication-store-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/provider-v1.js',
-  '@origintrail-official/dkg-agent/dist/system-records/requester-api-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/requester-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/transport-v1.js',
 ];
 
-for (const specifier of internalAgentProfilePhaseSpecifiers) {
+for (const specifier of internalAgentSpecifiers) {
   let resolved = false;
   try {
     await import(specifier);
@@ -48,7 +48,7 @@ for (const specifier of internalAgentProfilePhaseSpecifiers) {
   } catch (error) {
     if (error?.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw error;
   }
-  if (resolved) throw new Error(`published package exposed internal phase ${specifier}`);
+  if (resolved) throw new Error(`published package exposed internal module ${specifier}`);
 }
 
 for (const specifier of publicSystemRecordSpecifiers) {

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -11,6 +11,9 @@ const publicCatalogActivation = await import(
 const agentProfileProducer = await import(
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-v1.js'
 );
+const systemRecordRequester = await import(
+  '@origintrail-official/dkg-agent/dist/system-records/requester-v1.js'
+);
 const require = createRequire(import.meta.url);
 const packageManifest = require('@origintrail-official/dkg-agent/package.json');
 const expectedRfc64PolicyCells = [
@@ -32,6 +35,8 @@ const publicSystemRecordSpecifiers = [
   '@origintrail-official/dkg-agent/dist/system-records/artifact-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/in-memory-agent-profile-publication-store-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/provider-v1.js',
+  '@origintrail-official/dkg-agent/dist/system-records/requester-api-v1.js',
+  '@origintrail-official/dkg-agent/dist/system-records/requester-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/transport-v1.js',
 ];
 
@@ -147,6 +152,9 @@ if (
 }
 if (typeof publicCatalogActivation.resolveRfc64PublicCatalogControlsV1 !== 'function') {
   throw new Error('public RFC-64 activation subpath did not expose catalog-control normalization');
+}
+if (typeof systemRecordRequester.createSystemRecordRequesterV1 !== 'function') {
+  throw new Error('published System Record requester subpath did not expose its factory');
 }
 
 const digestAuthor = '0x1111111111111111111111111111111111111111';

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -30,6 +30,7 @@ const internalAgentSpecifiers = [
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-inventory-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-commit-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/requester-api-v1.js',
+  '@origintrail-official/dkg-agent/dist/system-records/resource-admission-v1-internal.js',
 ];
 const publicSystemRecordSpecifiers = [
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-v1.js',

--- a/packages/agent/src/system-records/provider-v1.ts
+++ b/packages/agent/src/system-records/provider-v1.ts
@@ -25,14 +25,16 @@ import type {
   SystemRecordArtifactV1,
 } from './artifact-v1.js';
 import {
-  createSystemRecordProviderPermitGateV1,
   createSystemRecordProviderTokenBucketV1,
-  raceSystemRecordAbortV1,
   type SystemRecordProviderFrameAdmissionV1,
   type SystemRecordProviderFrameReservationV1,
   type SystemRecordProviderPermitGateV1,
   type SystemRecordProviderTokenBucketV1,
 } from './transport-v1.js';
+import {
+  createSystemRecordPermitGateV1,
+  raceSystemRecordAbortV1,
+} from './resource-admission-v1-internal.js';
 
 const EMPTY = new Uint8Array();
 
@@ -91,7 +93,7 @@ export function createSystemRecordProviderV1(
   options: CreateSystemRecordProviderOptionsV1,
 ): SystemRecordProviderV1 {
   const bucket = options.tokenBucket ?? createSystemRecordProviderTokenBucketV1();
-  const permits = options.permitGate ?? createSystemRecordProviderPermitGateV1();
+  const permits = options.permitGate ?? createSystemRecordPermitGateV1();
   const timeoutMs = positiveTimeout(
     options.timeoutMs ?? SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
   );

--- a/packages/agent/src/system-records/provider-v1.ts
+++ b/packages/agent/src/system-records/provider-v1.ts
@@ -27,6 +27,7 @@ import type {
 import {
   createSystemRecordProviderPermitGateV1,
   createSystemRecordProviderTokenBucketV1,
+  raceSystemRecordAbortV1,
   type SystemRecordProviderFrameAdmissionV1,
   type SystemRecordProviderFrameReservationV1,
   type SystemRecordProviderPermitGateV1,
@@ -135,7 +136,7 @@ export function createSystemRecordProviderV1(
       try {
         let request: SystemRecordRequestHeaderV1;
         try {
-          const requestFrame = await raceAbort(
+          const requestFrame = await raceSystemRecordAbortV1(
             exchange.readRequestFrame(controller.signal),
             controller.signal,
           );
@@ -166,7 +167,7 @@ export function createSystemRecordProviderV1(
         try {
           let artifact: SystemRecordArtifactV1 | null;
           try {
-            artifact = await raceAbort(
+            artifact = await raceSystemRecordAbortV1(
               options.repository.resolve(repositoryLookupV1(request), controller.signal),
               controller.signal,
             );
@@ -227,7 +228,7 @@ export function createSystemRecordProviderV1(
             responseTokens = bucket.tryReserveResponse(response.byteLength);
             if (responseTokens === null) return reset(exchange, 'response-rate');
             try {
-              await raceAbort(
+              await raceSystemRecordAbortV1(
                 exchange.writeResponseFrame(response, controller.signal),
                 controller.signal,
               );
@@ -326,13 +327,4 @@ function positiveTimeout(value: number): number {
     );
   }
   return value;
-}
-
-function raceAbort<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) return Promise.reject(signal.reason);
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(signal.reason);
-    signal.addEventListener('abort', onAbort, { once: true });
-    work.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
-  });
 }

--- a/packages/agent/src/system-records/requester-api-v1.ts
+++ b/packages/agent/src/system-records/requester-api-v1.ts
@@ -95,7 +95,6 @@ export interface SystemRecordRequesterStatsV1 {
 export interface SystemRecordRequesterV1 {
   fetch(
     lookup: SystemRecordExactArtifactLookupV1,
-    openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>,
     signal: AbortSignal,
   ): Promise<SystemRecordExactFetchResultV1>;
   stats(): SystemRecordRequesterStatsV1;
@@ -104,6 +103,8 @@ export interface SystemRecordRequesterV1 {
 
 export interface CreateSystemRecordRequesterOptionsV1 {
   readonly networkId: NetworkIdV1;
+  /** Lifecycle-owned provider selection and transport opening for a leader transfer. */
+  readonly openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>;
   readonly byteAdmission: SystemRecordRequesterByteAdmissionV1;
   readonly streamAdmission: SystemRecordRequesterAdmissionV1;
   readonly decodeAdmission: SystemRecordRequesterAdmissionV1;

--- a/packages/agent/src/system-records/requester-api-v1.ts
+++ b/packages/agent/src/system-records/requester-api-v1.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  Digest32V1,
+  NetworkIdV1,
+  SystemRecordObjectKindV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+
+import type {
+  SystemRecordArtifactLookupV1,
+  SystemRecordArtifactV1,
+} from './artifact-v1.js';
+
+type SystemRecordExactControlObjectKindV1 = Exclude<
+  SystemRecordObjectKindV1,
+  'root-descriptor' | 'inventory-internal' | 'inventory-leaf'
+>;
+
+export type SystemRecordExactArtifactLookupV1 =
+  | Extract<SystemRecordArtifactLookupV1, Readonly<{ type: 'inventory-object' }>>
+  | Readonly<{
+    type: 'object';
+    objectKind: SystemRecordExactControlObjectKindV1;
+    objectDigest: Digest32V1;
+  }>;
+
+export interface SystemRecordRequesterExchangeV1 {
+  writeRequestFrame(frame: Uint8Array, signal: AbortSignal): Promise<void>;
+  readResponseFrame(maxBytes: number, signal: AbortSignal): Promise<Uint8Array>;
+  reset(reason: SystemRecordRequesterResetReasonV1): void;
+}
+
+export type SystemRecordRequesterResetReasonV1 =
+  | 'deadline'
+  | 'invalid-response'
+  | 'transport'
+  | 'cancelled'
+  | 'closed';
+
+export interface SystemRecordRequesterByteReservationV1 {
+  shrinkTo(bytes: number): void;
+  release(): void;
+}
+
+/** Supplied by the one lifecycle-owned aggregate accountant; it never queues. */
+export interface SystemRecordRequesterByteAdmissionV1 {
+  tryReserve(bytes: number): SystemRecordRequesterByteReservationV1 | null;
+}
+
+export interface SystemRecordRequesterPermitV1 {
+  release(): void;
+}
+
+/** Shared process-wide, nonqueued requester or decoder admission. */
+export interface SystemRecordRequesterAdmissionV1 {
+  tryAcquire(): SystemRecordRequesterPermitV1 | null;
+}
+
+export interface SystemRecordExactFetchLeaseV1 {
+  readonly artifact: SystemRecordArtifactV1;
+  readonly wireBytes: number;
+  release(): void;
+}
+
+export type SystemRecordExactFetchResultV1 =
+  | Readonly<{ outcome: 'ok'; lease: SystemRecordExactFetchLeaseV1 }>
+  | Readonly<{
+    outcome:
+      | 'not-found'
+      | 'unsupported'
+      | 'remote-busy'
+      | 'remote-error'
+      | 'busy'
+      | 'capacity'
+      | 'waiter-limit'
+      | 'deadline'
+      | 'invalid-response'
+      | 'transport'
+      | 'closed';
+    wireBytes: number;
+  }>;
+
+export interface SystemRecordRequesterStatsV1 {
+  readonly started: number;
+  readonly joined: number;
+  readonly completed: number;
+  readonly pendingDigests: number;
+  readonly waitingCallers: number;
+  readonly activeLeases: number;
+  readonly activeStream: 0 | 1;
+  readonly peakActiveStream: 0 | 1;
+  readonly queuedStreams: 0;
+  readonly retainedPayloadBytes: number;
+  readonly closed: boolean;
+}
+
+export interface SystemRecordRequesterV1 {
+  fetch(
+    lookup: SystemRecordExactArtifactLookupV1,
+    openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>,
+    signal: AbortSignal,
+  ): Promise<SystemRecordExactFetchResultV1>;
+  stats(): SystemRecordRequesterStatsV1;
+  close(): void;
+}
+
+export interface CreateSystemRecordRequesterOptionsV1 {
+  readonly networkId: NetworkIdV1;
+  readonly byteAdmission: SystemRecordRequesterByteAdmissionV1;
+  readonly streamAdmission: SystemRecordRequesterAdmissionV1;
+  readonly decodeAdmission: SystemRecordRequesterAdmissionV1;
+  readonly requestId?: () => string;
+  readonly timeoutMs?: number;
+  /** Test seams may lower, never raise, the frozen protocol limits. */
+  readonly maxPendingDigests?: number;
+  readonly maxWaitersPerDigest?: number;
+}

--- a/packages/agent/src/system-records/requester-api-v1.ts
+++ b/packages/agent/src/system-records/requester-api-v1.ts
@@ -79,7 +79,8 @@ export interface SystemRecordRequesterStatsV1 {
   readonly started: number;
   readonly joined: number;
   readonly completed: number;
-  readonly pendingDigests: number;
+  /** Exact coordinates with an in-flight transfer or a retained source lease. */
+  readonly trackedDigests: number;
   readonly waitingCallers: number;
   readonly activeLeases: number;
   readonly activeStream: 0 | 1;
@@ -107,7 +108,7 @@ export interface CreateSystemRecordRequesterOptionsV1 {
   readonly decodeAdmission: SystemRecordRequesterAdmissionV1;
   readonly requestId?: () => string;
   readonly timeoutMs?: number;
-  /** Test seams may lower, never raise, the frozen protocol limits. */
-  readonly maxPendingDigests?: number;
+  /** Test-only cap across in-flight and retained exact coordinates; may only lower the protocol limit. */
+  readonly maxTrackedDigests?: number;
   readonly maxWaitersPerDigest?: number;
 }

--- a/packages/agent/src/system-records/requester-api-v1.ts
+++ b/packages/agent/src/system-records/requester-api-v1.ts
@@ -10,6 +10,10 @@ import type {
   SystemRecordArtifactLookupV1,
   SystemRecordArtifactV1,
 } from './artifact-v1.js';
+import type {
+  SystemRecordByteAdmissionV1,
+  SystemRecordByteReservationV1,
+} from './transport-v1.js';
 
 type SystemRecordExactControlObjectKindV1 = Exclude<
   SystemRecordObjectKindV1,
@@ -37,15 +41,9 @@ export type SystemRecordRequesterResetReasonV1 =
   | 'cancelled'
   | 'closed';
 
-export interface SystemRecordRequesterByteReservationV1 {
-  shrinkTo(bytes: number): void;
-  release(): void;
-}
-
 /** Supplied by the one lifecycle-owned aggregate accountant; it never queues. */
-export interface SystemRecordRequesterByteAdmissionV1 {
-  tryReserve(bytes: number): SystemRecordRequesterByteReservationV1 | null;
-}
+export type SystemRecordRequesterByteReservationV1 = SystemRecordByteReservationV1;
+export type SystemRecordRequesterByteAdmissionV1 = SystemRecordByteAdmissionV1;
 
 export interface SystemRecordRequesterPermitV1 {
   release(): void;

--- a/packages/agent/src/system-records/requester-api-v1.ts
+++ b/packages/agent/src/system-records/requester-api-v1.ts
@@ -13,6 +13,8 @@ import type {
 import type {
   SystemRecordByteAdmissionV1,
   SystemRecordByteReservationV1,
+  SystemRecordPermitAdmissionV1,
+  SystemRecordPermitV1,
 } from './transport-v1.js';
 
 type SystemRecordExactControlObjectKindV1 = Exclude<
@@ -45,14 +47,9 @@ export type SystemRecordRequesterResetReasonV1 =
 export type SystemRecordRequesterByteReservationV1 = SystemRecordByteReservationV1;
 export type SystemRecordRequesterByteAdmissionV1 = SystemRecordByteAdmissionV1;
 
-export interface SystemRecordRequesterPermitV1 {
-  release(): void;
-}
-
+export type SystemRecordRequesterPermitV1 = SystemRecordPermitV1;
 /** Shared process-wide, nonqueued requester or decoder admission. */
-export interface SystemRecordRequesterAdmissionV1 {
-  tryAcquire(): SystemRecordRequesterPermitV1 | null;
-}
+export type SystemRecordRequesterAdmissionV1 = SystemRecordPermitAdmissionV1;
 
 export interface SystemRecordExactFetchLeaseV1 {
   readonly artifact: SystemRecordArtifactV1;

--- a/packages/agent/src/system-records/requester-api-v1.ts
+++ b/packages/agent/src/system-records/requester-api-v1.ts
@@ -3,7 +3,7 @@
 import type {
   Digest32V1,
   NetworkIdV1,
-  SystemRecordObjectKindV1,
+  SystemRecordRequestHeaderV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
 
 import type {
@@ -17,16 +17,16 @@ import type {
   SystemRecordPermitV1,
 } from './resource-admission-v1-internal.js';
 
-type SystemRecordExactControlObjectKindV1 = Exclude<
-  SystemRecordObjectKindV1,
-  'root-descriptor' | 'inventory-internal' | 'inventory-leaf'
->;
+type SystemRecordExactObjectKindV1 = Extract<
+  SystemRecordRequestHeaderV1,
+  Readonly<{ operation: 'get-bundle' | 'get-control-object' }>
+>['objectKind'];
 
 export type SystemRecordExactArtifactLookupV1 =
   | Extract<SystemRecordArtifactLookupV1, Readonly<{ type: 'inventory-object' }>>
   | Readonly<{
     type: 'object';
-    objectKind: SystemRecordExactControlObjectKindV1;
+    objectKind: SystemRecordExactObjectKindV1;
     objectDigest: Digest32V1;
   }>;
 
@@ -99,6 +99,13 @@ export interface SystemRecordRequesterV1 {
   close(): void;
 }
 
+export interface SystemRecordRequesterLimitsV1 {
+  /** Exact coordinates retained or in flight; may only lower the protocol maximum. */
+  readonly maxTrackedDigests?: number;
+  /** Followers admitted behind one exact-coordinate leader; may only lower the protocol maximum. */
+  readonly maxWaitersPerDigest?: number;
+}
+
 export interface CreateSystemRecordRequesterOptionsV1 {
   readonly networkId: NetworkIdV1;
   /** Lifecycle-owned provider selection and transport opening for a leader transfer. */
@@ -108,7 +115,6 @@ export interface CreateSystemRecordRequesterOptionsV1 {
   readonly decodeAdmission: SystemRecordRequesterAdmissionV1;
   readonly requestId?: () => string;
   readonly timeoutMs?: number;
-  /** Test-only cap across in-flight and retained exact coordinates; may only lower the protocol limit. */
-  readonly maxTrackedDigests?: number;
-  readonly maxWaitersPerDigest?: number;
+  /** Lifecycle-owned immutable policy; omitted values use the protocol maxima. */
+  readonly limits?: Readonly<SystemRecordRequesterLimitsV1>;
 }

--- a/packages/agent/src/system-records/requester-api-v1.ts
+++ b/packages/agent/src/system-records/requester-api-v1.ts
@@ -15,7 +15,7 @@ import type {
   SystemRecordByteReservationV1,
   SystemRecordPermitAdmissionV1,
   SystemRecordPermitV1,
-} from './transport-v1.js';
+} from './resource-admission-v1-internal.js';
 
 type SystemRecordExactControlObjectKindV1 = Exclude<
   SystemRecordObjectKindV1,

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -48,6 +48,7 @@ export async function openSystemRecordRequesterExchangeV1(input: {
   readonly signal: AbortSignal;
   readonly resetReason: () => SystemRecordRequesterResetReasonV1;
 }): Promise<SystemRecordRequesterExchangeV1> {
+  input.signal.throwIfAborted();
   const opening = input.openExchange(input.signal);
   let accepted = false;
   void opening.then((lateExchange) => {

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -11,15 +11,16 @@ import {
 
 import type { SystemRecordArtifactV1 } from './artifact-v1.js';
 import type {
-  SystemRecordExactFetchLeaseV1,
-  SystemRecordExactFetchResultV1,
   SystemRecordRequesterAdmissionV1,
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterByteReservationV1,
   SystemRecordRequesterExchangeV1,
   SystemRecordRequesterPermitV1,
 } from './requester-api-v1.js';
-import { systemRecordExactResponseOutcomeV1 } from './requester-wire-v1-internal.js';
+import {
+  systemRecordExactResponseOutcomeV1,
+  type SystemRecordRemoteFetchOutcomeV1,
+} from './requester-wire-v1-internal.js';
 import { raceSystemRecordAbortV1 } from './transport-v1.js';
 
 export interface SystemRecordDecodedTransferV1 {
@@ -36,10 +37,10 @@ export interface SystemRecordRetainedSourceV1 {
 
 export type SystemRecordRetainTransferResultV1 =
   | Readonly<{ outcome: 'ok'; retained: SystemRecordRetainedSourceV1 }>
-  | Exclude<
-    SystemRecordExactFetchResultV1,
-    Readonly<{ outcome: 'ok'; lease: SystemRecordExactFetchLeaseV1 }>
-  >;
+  | Readonly<{
+    outcome: SystemRecordRemoteFetchOutcomeV1 | 'busy' | 'capacity';
+    wireBytes: number;
+  }>;
 
 export async function exchangeSystemRecordResponseV1(input: {
   readonly request: SystemRecordRequestHeaderV1;

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -24,7 +24,7 @@ import {
   systemRecordExactResponseOutcomeV1,
   type SystemRecordRemoteFetchOutcomeV1,
 } from './requester-wire-v1-internal.js';
-import { raceSystemRecordAbortV1 } from './transport-v1.js';
+import { raceSystemRecordAbortV1 } from './resource-admission-v1-internal.js';
 
 export interface SystemRecordDecodedTransferV1 {
   readonly decoded: SystemRecordDecodedResponseFrameV1;

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -81,12 +81,14 @@ export async function exchangeSystemRecordResponseV1(input: {
       input.exchange.readResponseFrame(SYSTEM_RECORD_MAX_FRAME_BYTES, input.signal),
       input.signal,
     );
-    if (!(responseFrame instanceof Uint8Array)
-      || responseFrame.byteLength < 1
-      || responseFrame.byteLength > SYSTEM_RECORD_MAX_FRAME_BYTES) {
+    if (!(responseFrame instanceof Uint8Array)) {
       throw new InvalidSystemRecordResponseError(wireBytes);
     }
     wireBytes += responseFrame.byteLength;
+    if (responseFrame.byteLength < 1
+      || responseFrame.byteLength > SYSTEM_RECORD_MAX_FRAME_BYTES) {
+      throw new InvalidSystemRecordResponseError(wireBytes);
+    }
     input.frameReservation.shrinkTo(responseFrame.byteLength);
     input.signal.throwIfAborted();
     let decoded: SystemRecordDecodedResponseFrameV1;

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -18,7 +18,6 @@ import type {
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterByteReservationV1,
   SystemRecordRequesterExchangeV1,
-  SystemRecordRequesterPermitV1,
 } from './requester-api-v1.js';
 import {
   systemRecordExactResponseOutcomeV1,
@@ -33,9 +32,8 @@ export interface SystemRecordDecodedTransferV1 {
 
 export interface SystemRecordRetainedSourceV1 {
   readonly artifact: SystemRecordArtifactV1;
-  readonly reservation: SystemRecordRequesterByteReservationV1;
-  readonly decodePermit: SystemRecordRequesterPermitV1;
   readonly wireBytes: number;
+  release(): void;
 }
 
 export type SystemRecordRetainTransferResultV1 =
@@ -127,13 +125,18 @@ export function retainVerifiedSystemRecordResponseV1(input: {
         objectDigest: decoded.header.objectDigest,
         canonicalBytes: decoded.payload,
       });
+      let released = false;
       return Object.freeze({
         outcome: 'ok',
         retained: Object.freeze({
           artifact,
-          reservation: payloadReservation,
-          decodePermit,
           wireBytes,
+          release(): void {
+            if (released) return;
+            released = true;
+            payloadReservation.release();
+            decodePermit.release();
+          },
         }),
       });
     } catch (error) {

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -9,7 +9,10 @@ import {
   type SystemRecordRequestHeaderV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
 
-import type { SystemRecordArtifactV1 } from './artifact-v1.js';
+import {
+  cloneSystemRecordArtifactV1,
+  type SystemRecordArtifactV1,
+} from './artifact-v1.js';
 import type {
   SystemRecordRequesterAdmissionV1,
   SystemRecordRequesterByteAdmissionV1,
@@ -119,15 +122,15 @@ export function retainVerifiedSystemRecordResponseV1(input: {
       return Object.freeze({ outcome: 'capacity', wireBytes });
     }
     try {
-      const canonicalBytes = Uint8Array.from(decoded.payload);
+      const artifact = cloneSystemRecordArtifactV1({
+        objectKind: decoded.header.objectKind,
+        objectDigest: decoded.header.objectDigest,
+        canonicalBytes: decoded.payload,
+      });
       return Object.freeze({
         outcome: 'ok',
         retained: Object.freeze({
-          artifact: Object.freeze({
-            objectKind: decoded.header.objectKind,
-            objectDigest: decoded.header.objectDigest,
-            canonicalBytes,
-          }),
+          artifact,
           reservation: payloadReservation,
           decodePermit,
           wireBytes,

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -18,6 +18,7 @@ import type {
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterByteReservationV1,
   SystemRecordRequesterExchangeV1,
+  SystemRecordRequesterResetReasonV1,
 } from './requester-api-v1.js';
 import {
   systemRecordExactResponseOutcomeV1,
@@ -42,6 +43,26 @@ export type SystemRecordRetainTransferResultV1 =
     outcome: SystemRecordRemoteFetchOutcomeV1 | 'busy' | 'capacity';
     wireBytes: number;
   }>;
+
+export async function openSystemRecordRequesterExchangeV1(input: {
+  readonly openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>;
+  readonly signal: AbortSignal;
+  readonly resetReason: () => SystemRecordRequesterResetReasonV1;
+}): Promise<SystemRecordRequesterExchangeV1> {
+  const opening = input.openExchange(input.signal);
+  let accepted = false;
+  void opening.then((lateExchange) => {
+    if (accepted || !input.signal.aborted) return;
+    try {
+      lateExchange.reset(input.resetReason());
+    } catch {
+      // A late transport owns no requester resources; reset remains best-effort.
+    }
+  }, () => undefined);
+  const exchange = await raceSystemRecordAbortV1(opening, input.signal);
+  accepted = true;
+  return exchange;
+}
 
 export async function exchangeSystemRecordResponseV1(input: {
   readonly request: SystemRecordRequestHeaderV1;

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -3,7 +3,6 @@
 import {
   SYSTEM_RECORD_MAX_FRAME_BYTES,
   decodeSystemRecordResponseFrameV1,
-  encodeSystemRecordRequestFrameV1,
   verifySystemRecordResponsePayloadV1,
   type SystemRecordDecodedResponseFrameV1,
   type SystemRecordRequestHeaderV1,
@@ -66,18 +65,18 @@ export async function openSystemRecordRequesterExchangeV1(input: {
 
 export async function exchangeSystemRecordResponseV1(input: {
   readonly request: SystemRecordRequestHeaderV1;
+  readonly requestFrame: Uint8Array;
   readonly exchange: SystemRecordRequesterExchangeV1;
   readonly frameReservation: SystemRecordRequesterByteReservationV1;
   readonly signal: AbortSignal;
 }): Promise<SystemRecordDecodedTransferV1> {
-  const requestFrame = encodeSystemRecordRequestFrameV1(input.request);
   let wireBytes = 0;
   try {
     await raceSystemRecordAbortV1(
-      input.exchange.writeRequestFrame(requestFrame, input.signal),
+      input.exchange.writeRequestFrame(input.requestFrame, input.signal),
       input.signal,
     );
-    wireBytes = requestFrame.byteLength;
+    wireBytes = input.requestFrame.byteLength;
     const responseFrame = await raceSystemRecordAbortV1(
       input.exchange.readResponseFrame(SYSTEM_RECORD_MAX_FRAME_BYTES, input.signal),
       input.signal,

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -88,6 +88,7 @@ export async function exchangeSystemRecordResponseV1(input: {
     }
     wireBytes += responseFrame.byteLength;
     input.frameReservation.shrinkTo(responseFrame.byteLength);
+    input.signal.throwIfAborted();
     let decoded: SystemRecordDecodedResponseFrameV1;
     try {
       decoded = decodeSystemRecordResponseFrameV1(responseFrame);
@@ -112,6 +113,7 @@ export function retainVerifiedSystemRecordResponseV1(input: {
   readonly transfer: SystemRecordDecodedTransferV1;
   readonly decodeAdmission: SystemRecordRequesterAdmissionV1;
   readonly byteAdmission: SystemRecordRequesterByteAdmissionV1;
+  readonly signal: AbortSignal;
 }): SystemRecordRetainTransferResultV1 {
   const { decoded, wireBytes } = input.transfer;
   if (decoded.header.status !== 'ok') {
@@ -127,8 +129,13 @@ export function retainVerifiedSystemRecordResponseV1(input: {
   }
 
   const decodePermit = input.decodeAdmission.tryAcquire();
-  if (decodePermit === null) return Object.freeze({ outcome: 'busy', wireBytes });
+  if (decodePermit === null) {
+    input.signal.throwIfAborted();
+    return Object.freeze({ outcome: 'busy', wireBytes });
+  }
+  let releaseDecode = true;
   try {
+    input.signal.throwIfAborted();
     try {
       verifySystemRecordResponsePayloadV1(input.request, decoded.header, decoded.payload);
     } catch (error) {
@@ -136,16 +143,20 @@ export function retainVerifiedSystemRecordResponseV1(input: {
     }
     const payloadReservation = input.byteAdmission.tryReserve(decoded.payload.byteLength);
     if (payloadReservation === null) {
-      decodePermit.release();
+      input.signal.throwIfAborted();
       return Object.freeze({ outcome: 'capacity', wireBytes });
     }
+    let releasePayload = true;
     try {
+      input.signal.throwIfAborted();
       const artifact = cloneSystemRecordArtifactV1({
         objectKind: decoded.header.objectKind,
         objectDigest: decoded.header.objectDigest,
         canonicalBytes: decoded.payload,
       });
       let released = false;
+      releaseDecode = false;
+      releasePayload = false;
       return Object.freeze({
         outcome: 'ok',
         retained: Object.freeze({
@@ -159,13 +170,11 @@ export function retainVerifiedSystemRecordResponseV1(input: {
           },
         }),
       });
-    } catch (error) {
-      payloadReservation.release();
-      throw error;
+    } finally {
+      if (releasePayload) payloadReservation.release();
     }
-  } catch (error) {
-    decodePermit.release();
-    throw error;
+  } finally {
+    if (releaseDecode) decodePermit.release();
   }
 }
 

--- a/packages/agent/src/system-records/requester-transfer-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-transfer-v1-internal.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  SYSTEM_RECORD_MAX_FRAME_BYTES,
+  decodeSystemRecordResponseFrameV1,
+  encodeSystemRecordRequestFrameV1,
+  verifySystemRecordResponsePayloadV1,
+  type SystemRecordDecodedResponseFrameV1,
+  type SystemRecordRequestHeaderV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+
+import type { SystemRecordArtifactV1 } from './artifact-v1.js';
+import type {
+  SystemRecordExactFetchLeaseV1,
+  SystemRecordExactFetchResultV1,
+  SystemRecordRequesterAdmissionV1,
+  SystemRecordRequesterByteAdmissionV1,
+  SystemRecordRequesterByteReservationV1,
+  SystemRecordRequesterExchangeV1,
+  SystemRecordRequesterPermitV1,
+} from './requester-api-v1.js';
+import { systemRecordExactResponseOutcomeV1 } from './requester-wire-v1-internal.js';
+import { raceSystemRecordAbortV1 } from './transport-v1.js';
+
+export interface SystemRecordDecodedTransferV1 {
+  readonly decoded: SystemRecordDecodedResponseFrameV1;
+  readonly wireBytes: number;
+}
+
+export interface SystemRecordRetainedSourceV1 {
+  readonly artifact: SystemRecordArtifactV1;
+  readonly reservation: SystemRecordRequesterByteReservationV1;
+  readonly decodePermit: SystemRecordRequesterPermitV1;
+  readonly wireBytes: number;
+}
+
+export type SystemRecordRetainTransferResultV1 =
+  | Readonly<{ outcome: 'ok'; retained: SystemRecordRetainedSourceV1 }>
+  | Exclude<
+    SystemRecordExactFetchResultV1,
+    Readonly<{ outcome: 'ok'; lease: SystemRecordExactFetchLeaseV1 }>
+  >;
+
+export async function exchangeSystemRecordResponseV1(input: {
+  readonly request: SystemRecordRequestHeaderV1;
+  readonly exchange: SystemRecordRequesterExchangeV1;
+  readonly frameReservation: SystemRecordRequesterByteReservationV1;
+  readonly signal: AbortSignal;
+}): Promise<SystemRecordDecodedTransferV1> {
+  const requestFrame = encodeSystemRecordRequestFrameV1(input.request);
+  let wireBytes = 0;
+  try {
+    await raceSystemRecordAbortV1(
+      input.exchange.writeRequestFrame(requestFrame, input.signal),
+      input.signal,
+    );
+    wireBytes = requestFrame.byteLength;
+    const responseFrame = await raceSystemRecordAbortV1(
+      input.exchange.readResponseFrame(SYSTEM_RECORD_MAX_FRAME_BYTES, input.signal),
+      input.signal,
+    );
+    if (!(responseFrame instanceof Uint8Array)
+      || responseFrame.byteLength < 1
+      || responseFrame.byteLength > SYSTEM_RECORD_MAX_FRAME_BYTES) {
+      throw new InvalidSystemRecordResponseError(wireBytes);
+    }
+    wireBytes += responseFrame.byteLength;
+    input.frameReservation.shrinkTo(responseFrame.byteLength);
+    let decoded: SystemRecordDecodedResponseFrameV1;
+    try {
+      decoded = decodeSystemRecordResponseFrameV1(responseFrame);
+    } catch (error) {
+      throw new InvalidSystemRecordResponseError(wireBytes, { cause: error });
+    }
+    return Object.freeze({
+      decoded,
+      wireBytes,
+    });
+  } catch (error) {
+    if (error instanceof InvalidSystemRecordResponseError) throw error;
+    if (wireBytes > 0) {
+      throw new SystemRecordRequesterTransferError(wireBytes, { cause: error });
+    }
+    throw error;
+  }
+}
+
+export function retainVerifiedSystemRecordResponseV1(input: {
+  readonly request: SystemRecordRequestHeaderV1;
+  readonly transfer: SystemRecordDecodedTransferV1;
+  readonly decodeAdmission: SystemRecordRequesterAdmissionV1;
+  readonly byteAdmission: SystemRecordRequesterByteAdmissionV1;
+}): SystemRecordRetainTransferResultV1 {
+  const { decoded, wireBytes } = input.transfer;
+  if (decoded.header.status !== 'ok') {
+    try {
+      verifySystemRecordResponsePayloadV1(input.request, decoded.header, decoded.payload);
+    } catch (error) {
+      throw new InvalidSystemRecordResponseError(wireBytes, { cause: error });
+    }
+    return Object.freeze({
+      outcome: systemRecordExactResponseOutcomeV1(decoded.header.status),
+      wireBytes,
+    });
+  }
+
+  const decodePermit = input.decodeAdmission.tryAcquire();
+  if (decodePermit === null) return Object.freeze({ outcome: 'busy', wireBytes });
+  try {
+    try {
+      verifySystemRecordResponsePayloadV1(input.request, decoded.header, decoded.payload);
+    } catch (error) {
+      throw new InvalidSystemRecordResponseError(wireBytes, { cause: error });
+    }
+    const payloadReservation = input.byteAdmission.tryReserve(decoded.payload.byteLength);
+    if (payloadReservation === null) {
+      decodePermit.release();
+      return Object.freeze({ outcome: 'capacity', wireBytes });
+    }
+    try {
+      const canonicalBytes = Uint8Array.from(decoded.payload);
+      return Object.freeze({
+        outcome: 'ok',
+        retained: Object.freeze({
+          artifact: Object.freeze({
+            objectKind: decoded.header.objectKind,
+            objectDigest: decoded.header.objectDigest,
+            canonicalBytes,
+          }),
+          reservation: payloadReservation,
+          decodePermit,
+          wireBytes,
+        }),
+      });
+    } catch (error) {
+      payloadReservation.release();
+      throw error;
+    }
+  } catch (error) {
+    decodePermit.release();
+    throw error;
+  }
+}
+
+export class SystemRecordRequesterTransferError extends Error {
+  constructor(
+    readonly wireBytes: number,
+    options?: ErrorOptions,
+  ) {
+    super('System Record transfer failed', options);
+  }
+}
+
+export class InvalidSystemRecordResponseError extends SystemRecordRequesterTransferError {
+  constructor(wireBytes: number, options?: ErrorOptions) {
+    super(wireBytes, options);
+    this.message = 'invalid System Record response';
+  }
+}

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -7,17 +7,12 @@ import {
   SYSTEM_RECORD_MAX_FRAME_BYTES,
   SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
   SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
-  decodeSystemRecordResponseFrameV1,
-  encodeSystemRecordRequestFrameV1,
-  verifySystemRecordResponsePayloadV1,
   type SystemRecordRequestHeaderV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
 
-import type { SystemRecordArtifactV1 } from './artifact-v1.js';
 import type {
   CreateSystemRecordRequesterOptionsV1,
   SystemRecordExactArtifactLookupV1,
-  SystemRecordExactFetchLeaseV1,
   SystemRecordExactFetchResultV1,
   SystemRecordRequesterByteReservationV1,
   SystemRecordRequesterExchangeV1,
@@ -27,37 +22,34 @@ import type {
   SystemRecordRequesterV1,
 } from './requester-api-v1.js';
 import {
+  InvalidSystemRecordResponseError,
+  SystemRecordRequesterTransferError,
+  exchangeSystemRecordResponseV1,
+  retainVerifiedSystemRecordResponseV1,
+  type SystemRecordRetainedSourceV1,
+  type SystemRecordRetainTransferResultV1,
+} from './requester-transfer-v1-internal.js';
+import {
   createSystemRecordExactRequestV1,
   systemRecordExactRequestKeyV1,
-  systemRecordExactResponseOutcomeV1,
 } from './requester-wire-v1-internal.js';
+import { raceSystemRecordAbortV1 } from './transport-v1.js';
 
-interface RetainedFetchV1 {
-  readonly artifact: SystemRecordArtifactV1;
-  readonly reservation: SystemRecordRequesterByteReservationV1;
-  readonly decodePermit: SystemRecordRequesterPermitV1;
-  readonly wireBytes: number;
-}
-
-type SharedFetchOutcomeV1 =
-  | Readonly<{ outcome: 'ok'; retained: RetainedFetchV1 }>
-  | Exclude<SystemRecordExactFetchResultV1, Readonly<{ outcome: 'ok'; lease: SystemRecordExactFetchLeaseV1 }>>;
-
-interface FetchSubscriberV1 {
+interface FetchWaiterV1 {
   readonly signal: AbortSignal;
   readonly resolve: (result: SystemRecordExactFetchResultV1) => void;
   readonly reject: (reason?: unknown) => void;
   readonly onAbort: () => void;
-  state: 'waiting' | 'leased' | 'done';
 }
 
 interface FetchEntryV1 {
   readonly key: string;
   readonly controller: AbortController;
-  readonly subscribers: Set<FetchSubscriberV1>;
+  readonly waiters: Set<FetchWaiterV1>;
+  leaseCount: number;
   abortReason?: SystemRecordRequesterResetReasonV1;
   settled: boolean;
-  retained?: RetainedFetchV1;
+  retained?: SystemRecordRetainedSourceV1;
 }
 
 /**
@@ -107,8 +99,8 @@ export function createSystemRecordRequesterV1(
     const key = systemRecordExactRequestKeyV1(request);
     let entry = entries.get(key);
     if (entry !== undefined) {
-      // The first subscriber owns the transfer; the frozen limit counts followers.
-      if (entry.subscribers.size >= maxWaitersPerDigest + 1) {
+      // The first observer owns the transfer; the frozen limit counts followers.
+      if (entry.waiters.size + entry.leaseCount >= maxWaitersPerDigest + 1) {
         return Object.freeze({ outcome: 'waiter-limit', wireBytes: 0 });
       }
       joined += 1;
@@ -127,7 +119,8 @@ export function createSystemRecordRequesterV1(
     entry = {
       key,
       controller: new AbortController(),
-      subscribers: new Set(),
+      waiters: new Set(),
+      leaseCount: 0,
       settled: false,
     };
     entries.set(key, entry);
@@ -143,28 +136,25 @@ export function createSystemRecordRequesterV1(
     signal: AbortSignal,
   ): Promise<SystemRecordExactFetchResultV1> {
     return new Promise<SystemRecordExactFetchResultV1>((resolve, reject) => {
-      const subscriber: FetchSubscriberV1 = {
+      const waiter: FetchWaiterV1 = {
         signal,
         resolve,
         reject,
-        state: 'waiting',
         onAbort: () => {
-          if (subscriber.state !== 'waiting') return;
-          subscriber.state = 'done';
-          entry.subscribers.delete(subscriber);
+          if (!entry.waiters.delete(waiter)) return;
           waitingCallers -= 1;
           reject(signal.reason);
           abortIfUnobserved(entry);
         },
       };
-      entry.subscribers.add(subscriber);
+      entry.waiters.add(waiter);
       waitingCallers += 1;
-      signal.addEventListener('abort', subscriber.onAbort, { once: true });
+      signal.addEventListener('abort', waiter.onAbort, { once: true });
       if (signal.aborted) {
-        subscriber.onAbort();
+        waiter.onAbort();
         return;
       }
-      if (entry.settled && entry.retained !== undefined) deliverLease(entry, subscriber);
+      if (entry.settled && entry.retained !== undefined) deliverLease(entry, waiter);
     });
   }
 
@@ -186,72 +176,33 @@ export function createSystemRecordRequesterV1(
       timeoutMs,
     );
     timeout.unref?.();
-    let shared: SharedFetchOutcomeV1;
+    let shared: SystemRecordRetainTransferResultV1;
     try {
-      const requestFrame = encodeSystemRecordRequestFrameV1(request);
-      exchange = await raceAbort(openExchange(entry.controller.signal), entry.controller.signal);
-      await raceAbort(
-        exchange.writeRequestFrame(requestFrame, entry.controller.signal),
+      exchange = await raceSystemRecordAbortV1(
+        openExchange(entry.controller.signal),
         entry.controller.signal,
       );
-      wireBytes += requestFrame.byteLength;
-      const responseFrame = await raceAbort(
-        exchange.readResponseFrame(SYSTEM_RECORD_MAX_FRAME_BYTES, entry.controller.signal),
-        entry.controller.signal,
-      );
-      if (responseFrame instanceof Uint8Array) wireBytes += responseFrame.byteLength;
-      if (!(responseFrame instanceof Uint8Array)
-        || responseFrame.byteLength < 1
-        || responseFrame.byteLength > SYSTEM_RECORD_MAX_FRAME_BYTES) {
-        throw new InvalidSystemRecordResponseError();
-      }
-      frameReservation.shrinkTo(responseFrame.byteLength);
-      let decoded: ReturnType<typeof decodeSystemRecordResponseFrameV1>;
-      try {
-        decoded = decodeSystemRecordResponseFrameV1(responseFrame);
-        verifySystemRecordResponsePayloadV1(request, decoded.header, decoded.payload);
-      } catch {
-        throw new InvalidSystemRecordResponseError();
-      }
-      if (decoded.header.status !== 'ok') {
-        shared = Object.freeze({
-          outcome: systemRecordExactResponseOutcomeV1(decoded.header.status),
-          wireBytes,
-        });
-      } else {
-        const decodePermit = options.decodeAdmission.tryAcquire();
-        if (decodePermit === null) {
-          shared = Object.freeze({ outcome: 'busy', wireBytes });
-        } else {
-          const payloadReservation = options.byteAdmission.tryReserve(decoded.payload.byteLength);
-          if (payloadReservation === null) {
-            decodePermit.release();
-            shared = Object.freeze({ outcome: 'capacity', wireBytes });
-          } else {
-            try {
-              const canonicalBytes = Uint8Array.from(decoded.payload);
-              const retained: RetainedFetchV1 = Object.freeze({
-                artifact: Object.freeze({
-                  objectKind: decoded.header.objectKind,
-                  objectDigest: decoded.header.objectDigest,
-                  canonicalBytes,
-                }),
-                reservation: payloadReservation,
-                decodePermit,
-                wireBytes,
-              });
-              entry.retained = retained;
-              retainedPayloadBytes += canonicalBytes.byteLength;
-              shared = Object.freeze({ outcome: 'ok', retained });
-            } catch (error) {
-              payloadReservation.release();
-              decodePermit.release();
-              throw error;
-            }
-          }
-        }
+      const transfer = await exchangeSystemRecordResponseV1({
+        request,
+        exchange,
+        frameReservation,
+        signal: entry.controller.signal,
+      });
+      wireBytes = transfer.wireBytes;
+      shared = retainVerifiedSystemRecordResponseV1({
+        request,
+        transfer,
+        decodeAdmission: options.decodeAdmission,
+        byteAdmission: options.byteAdmission,
+      });
+      if (shared.outcome === 'ok') {
+        entry.retained = shared.retained;
+        retainedPayloadBytes += shared.retained.artifact.canonicalBytes.byteLength;
       }
     } catch (error) {
+      if (error instanceof SystemRecordRequesterTransferError) {
+        wireBytes = error.wireBytes;
+      }
       const outcome = error instanceof InvalidSystemRecordResponseError
         ? 'invalid-response'
         : entry.controller.signal.aborted
@@ -281,43 +232,63 @@ export function createSystemRecordRequesterV1(
     settle(entry, shared);
   }
 
-  function settle(entry: FetchEntryV1, shared: SharedFetchOutcomeV1): void {
+  function settle(entry: FetchEntryV1, shared: SystemRecordRetainTransferResultV1): void {
     entry.settled = true;
     if (shared.outcome === 'ok') {
-      for (const subscriber of [...entry.subscribers]) deliverLease(entry, subscriber);
+      for (const waiter of [...entry.waiters]) deliverLease(entry, waiter);
       abortIfUnobserved(entry);
       return;
     }
     entries.delete(entry.key);
-    for (const subscriber of [...entry.subscribers]) {
-      if (subscriber.state !== 'waiting') continue;
-      subscriber.signal.removeEventListener('abort', subscriber.onAbort);
-      subscriber.state = 'done';
+    for (const waiter of [...entry.waiters]) {
+      if (!entry.waiters.delete(waiter)) continue;
+      waiter.signal.removeEventListener('abort', waiter.onAbort);
       waitingCallers -= 1;
-      entry.subscribers.delete(subscriber);
-      subscriber.resolve(shared);
+      waiter.resolve(shared);
     }
   }
 
-  function deliverLease(entry: FetchEntryV1, subscriber: FetchSubscriberV1): void {
-    if (subscriber.state !== 'waiting' || entry.retained === undefined) return;
-    subscriber.signal.removeEventListener('abort', subscriber.onAbort);
-    subscriber.state = 'leased';
-    waitingCallers -= 1;
-    activeLeases += 1;
-    let released = false;
+  function deliverLease(entry: FetchEntryV1, waiter: FetchWaiterV1): void {
     const retained = entry.retained;
-    subscriber.resolve(Object.freeze({
+    if (retained === undefined || !entry.waiters.delete(waiter)) return;
+    waiter.signal.removeEventListener('abort', waiter.onAbort);
+    waitingCallers -= 1;
+    const payloadBytes = retained.artifact.canonicalBytes.byteLength;
+    const reservation = options.byteAdmission.tryReserve(payloadBytes);
+    if (reservation === null) {
+      waiter.resolve(Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes }));
+      releaseRetainedIfUnobserved(entry);
+      return;
+    }
+    let canonicalBytes: Uint8Array;
+    try {
+      canonicalBytes = Uint8Array.from(retained.artifact.canonicalBytes);
+    } catch {
+      reservation.release();
+      waiter.resolve(Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes }));
+      releaseRetainedIfUnobserved(entry);
+      return;
+    }
+    entry.leaseCount += 1;
+    activeLeases += 1;
+    retainedPayloadBytes += payloadBytes;
+    let released = false;
+    waiter.resolve(Object.freeze({
       outcome: 'ok',
       lease: Object.freeze({
-        artifact: retained.artifact,
+        artifact: Object.freeze({
+          objectKind: retained.artifact.objectKind,
+          objectDigest: retained.artifact.objectDigest,
+          canonicalBytes,
+        }),
         wireBytes: retained.wireBytes,
         release(): void {
           if (released) return;
           released = true;
-          subscriber.state = 'done';
-          entry.subscribers.delete(subscriber);
+          entry.leaseCount -= 1;
           activeLeases -= 1;
+          retainedPayloadBytes -= payloadBytes;
+          reservation.release();
           releaseRetainedIfUnobserved(entry);
         },
       }),
@@ -325,7 +296,7 @@ export function createSystemRecordRequesterV1(
   }
 
   function abortIfUnobserved(entry: FetchEntryV1): void {
-    if (entry.subscribers.size !== 0) return;
+    if (entry.waiters.size !== 0 || entry.leaseCount !== 0) return;
     if (!entry.settled) {
       abortEntry(entry, 'cancelled', new Error('system-record requester has no callers'));
     }
@@ -333,7 +304,7 @@ export function createSystemRecordRequesterV1(
   }
 
   function releaseRetainedIfUnobserved(entry: FetchEntryV1): void {
-    if (entry.subscribers.size !== 0 || entry.retained === undefined) return;
+    if (entry.waiters.size !== 0 || entry.leaseCount !== 0 || entry.retained === undefined) return;
     entries.delete(entry.key);
     retainedPayloadBytes -= entry.retained.artifact.canonicalBytes.byteLength;
     entry.retained.reservation.release();
@@ -384,14 +355,3 @@ function boundedPositive(value: number, maximum: number, label: string): number 
   }
   return value;
 }
-
-function raceAbort<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) return Promise.reject(signal.reason);
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(signal.reason);
-    signal.addEventListener('abort', onAbort, { once: true });
-    work.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
-  });
-}
-
-class InvalidSystemRecordResponseError extends Error {}

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -18,6 +18,7 @@ import type {
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterByteReservationV1,
   SystemRecordRequesterExchangeV1,
+  SystemRecordRequesterLimitsV1,
   SystemRecordRequesterPermitV1,
   SystemRecordRequesterResetReasonV1,
   SystemRecordRequesterStatsV1,
@@ -45,6 +46,7 @@ export type {
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterByteReservationV1,
   SystemRecordRequesterExchangeV1,
+  SystemRecordRequesterLimitsV1,
   SystemRecordRequesterPermitV1,
   SystemRecordRequesterResetReasonV1,
   SystemRecordRequesterStatsV1,
@@ -328,18 +330,19 @@ export function createSystemRecordRequesterV1(
   const streamAdmission = options.streamAdmission;
   const decodeAdmission = options.decodeAdmission;
   const requestId = options.requestId ?? (() => randomBytes(16).toString('hex'));
+  const limits = options.limits;
   const timeoutMs = boundedPositive(
     options.timeoutMs ?? SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
     SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
     'requester timeoutMs',
   );
   const maxTrackedDigests = boundedPositive(
-    options.maxTrackedDigests ?? SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
+    limits?.maxTrackedDigests ?? SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
     SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
     'maxTrackedDigests',
   );
   const maxWaitersPerDigest = boundedPositive(
-    options.maxWaitersPerDigest ?? SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
+    limits?.maxWaitersPerDigest ?? SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
     SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
     'maxWaitersPerDigest',
   );

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -32,30 +32,22 @@ import {
 } from './requester-transfer-v1-internal.js';
 import {
   createSystemRecordExactRequestV1,
-  systemRecordExactRequestKeyV1,
 } from './requester-wire-v1-internal.js';
 import { raceSystemRecordAbortV1 } from './transport-v1.js';
-
-interface FetchWaiterV1 {
-  readonly signal: AbortSignal;
-  readonly resolve: (result: SystemRecordExactFetchResultV1) => void;
-  readonly reject: (reason?: unknown) => void;
-  readonly onAbort: () => void;
-}
-
-interface FetchEntryV1 {
-  readonly key: string;
-  readonly controller: AbortController;
-  readonly waiters: Set<FetchWaiterV1>;
-  leaseCount: number;
-  abortReason?: SystemRecordRequesterResetReasonV1;
-  settled: boolean;
-  retained?: SystemRecordRetainedSourceV1;
-}
 
 type SystemRecordRequesterSettlementV1 =
   | SystemRecordRetainTransferResultV1
   | Exclude<SystemRecordExactFetchResultV1, Readonly<{ outcome: 'ok' }>>;
+
+interface FetchEntryV1 {
+  readonly key: string;
+  readonly controller: AbortController;
+  readonly transfer: Promise<SystemRecordRequesterSettlementV1>;
+  observerCount: number;
+  leaseCount: number;
+  abortReason?: SystemRecordRequesterResetReasonV1;
+  retained?: SystemRecordRetainedSourceV1;
+}
 
 /**
  * One default-unused exact requester. Same-coordinate calls share one transfer,
@@ -100,15 +92,15 @@ export function createSystemRecordRequesterV1(
   ): Promise<SystemRecordExactFetchResultV1> {
     signal.throwIfAborted();
     if (closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
-    const request = createSystemRecordExactRequestV1(options.networkId, lookup, requestId());
-    const key = systemRecordExactRequestKeyV1(request);
+    const exact = createSystemRecordExactRequestV1(options.networkId, lookup, requestId());
+    const { key, request } = exact;
     let entry = entries.get(key);
     if (entry !== undefined) {
-      if (!entry.settled && entry.controller.signal.aborted) {
+      if (entry.controller.signal.aborted) {
         return Object.freeze({ outcome: 'busy', wireBytes: 0 });
       }
       // The first observer owns the transfer; the frozen limit counts followers.
-      if (entry.waiters.size + entry.leaseCount >= maxWaitersPerDigest + 1) {
+      if (entry.observerCount + entry.leaseCount >= maxWaitersPerDigest + 1) {
         return Object.freeze({ outcome: 'waiter-limit', wireBytes: 0 });
       }
       joined += 1;
@@ -124,46 +116,57 @@ export function createSystemRecordRequesterV1(
       streamPermit.release();
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
     }
+    let resolveTransfer!: (result: SystemRecordRequesterSettlementV1) => void;
+    let rejectTransfer!: (reason?: unknown) => void;
+    const transfer = new Promise<SystemRecordRequesterSettlementV1>((resolve, reject) => {
+      resolveTransfer = resolve;
+      rejectTransfer = reject;
+    });
     entry = {
       key,
       controller: new AbortController(),
-      waiters: new Set(),
+      transfer,
+      observerCount: 0,
       leaseCount: 0,
-      settled: false,
     };
     entries.set(key, entry);
     started += 1;
     activeStream = 1;
     peakActiveStream = 1;
-    void run(entry, request, openExchange, streamPermit, frameReservation);
+    void run(entry, request, openExchange, streamPermit, frameReservation).then(
+      resolveTransfer,
+      rejectTransfer,
+    );
     return subscribe(entry, signal);
   }
 
-  function subscribe(
+  async function subscribe(
     entry: FetchEntryV1,
     signal: AbortSignal,
   ): Promise<SystemRecordExactFetchResultV1> {
-    return new Promise<SystemRecordExactFetchResultV1>((resolve, reject) => {
-      const waiter: FetchWaiterV1 = {
-        signal,
-        resolve,
-        reject,
-        onAbort: () => {
-          if (!entry.waiters.delete(waiter)) return;
-          waitingCallers -= 1;
-          reject(signal.reason);
-          abortIfUnobserved(entry);
-        },
-      };
-      entry.waiters.add(waiter);
-      waitingCallers += 1;
-      signal.addEventListener('abort', waiter.onAbort, { once: true });
-      if (signal.aborted) {
-        waiter.onAbort();
-        return;
-      }
-      if (entry.settled && entry.retained !== undefined) deliverLease(entry, waiter);
-    });
+    signal.throwIfAborted();
+    entry.observerCount += 1;
+    waitingCallers += 1;
+    let observing = true;
+    const releaseObserver = () => {
+      if (!observing) return;
+      observing = false;
+      entry.observerCount -= 1;
+      waitingCallers -= 1;
+      abortIfUnobserved(entry);
+    };
+    signal.addEventListener('abort', releaseObserver, { once: true });
+    if (signal.aborted) {
+      releaseObserver();
+      signal.throwIfAborted();
+    }
+    try {
+      const shared = await raceSystemRecordAbortV1(entry.transfer, signal);
+      return shared.outcome === 'ok' ? deliverLease(entry, shared.retained) : shared;
+    } finally {
+      signal.removeEventListener('abort', releaseObserver);
+      releaseObserver();
+    }
   }
 
   async function run(
@@ -172,7 +175,7 @@ export function createSystemRecordRequesterV1(
     openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>,
     streamPermit: SystemRecordRequesterPermitV1,
     frameReservation: SystemRecordRequesterByteReservationV1,
-  ): Promise<void> {
+  ): Promise<SystemRecordRequesterSettlementV1> {
     let exchange: SystemRecordRequesterExchangeV1 | undefined;
     let wireBytes = 0;
     const timeout = setTimeout(
@@ -237,51 +240,31 @@ export function createSystemRecordRequesterV1(
       activeStream = 0;
       completed += 1;
     }
-    settle(entry, shared);
+    if (shared.outcome !== 'ok' && entries.get(entry.key) === entry) entries.delete(entry.key);
+    return shared;
   }
 
-  function settle(entry: FetchEntryV1, shared: SystemRecordRequesterSettlementV1): void {
-    entry.settled = true;
-    if (shared.outcome === 'ok') {
-      for (const waiter of [...entry.waiters]) deliverLease(entry, waiter);
-      abortIfUnobserved(entry);
-      return;
-    }
-    entries.delete(entry.key);
-    for (const waiter of [...entry.waiters]) {
-      if (!entry.waiters.delete(waiter)) continue;
-      waiter.signal.removeEventListener('abort', waiter.onAbort);
-      waitingCallers -= 1;
-      waiter.resolve(shared);
-    }
-  }
-
-  function deliverLease(entry: FetchEntryV1, waiter: FetchWaiterV1): void {
-    const retained = entry.retained;
-    if (retained === undefined || !entry.waiters.delete(waiter)) return;
-    waiter.signal.removeEventListener('abort', waiter.onAbort);
-    waitingCallers -= 1;
+  function deliverLease(
+    entry: FetchEntryV1,
+    retained: SystemRecordRetainedSourceV1,
+  ): SystemRecordExactFetchResultV1 {
     const payloadBytes = retained.artifact.canonicalBytes.byteLength;
     const reservation = options.byteAdmission.tryReserve(payloadBytes);
     if (reservation === null) {
-      waiter.resolve(Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes }));
-      releaseRetainedIfUnobserved(entry);
-      return;
+      return Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes });
     }
     let artifact: ReturnType<typeof cloneSystemRecordArtifactV1>;
     try {
       artifact = cloneSystemRecordArtifactV1(retained.artifact);
     } catch {
       reservation.release();
-      waiter.resolve(Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes }));
-      releaseRetainedIfUnobserved(entry);
-      return;
+      return Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes });
     }
     entry.leaseCount += 1;
     activeLeases += 1;
     retainedPayloadBytes += payloadBytes;
     let released = false;
-    waiter.resolve(Object.freeze({
+    return Object.freeze({
       outcome: 'ok',
       lease: Object.freeze({
         artifact,
@@ -296,20 +279,21 @@ export function createSystemRecordRequesterV1(
           releaseRetainedIfUnobserved(entry);
         },
       }),
-    }));
+    });
   }
 
   function abortIfUnobserved(entry: FetchEntryV1): void {
-    if (entry.waiters.size !== 0 || entry.leaseCount !== 0) return;
-    if (!entry.settled) {
+    if (entry.observerCount !== 0 || entry.leaseCount !== 0) return;
+    if (entries.get(entry.key) !== entry) return;
+    if (entry.retained === undefined) {
       abortEntry(entry, 'cancelled', new Error('system-record requester has no callers'));
     }
     releaseRetainedIfUnobserved(entry);
   }
 
   function releaseRetainedIfUnobserved(entry: FetchEntryV1): void {
-    if (entry.waiters.size !== 0 || entry.leaseCount !== 0 || entry.retained === undefined) return;
-    entries.delete(entry.key);
+    if (entry.observerCount !== 0 || entry.leaseCount !== 0 || entry.retained === undefined) return;
+    if (entries.get(entry.key) === entry) entries.delete(entry.key);
     retainedPayloadBytes -= entry.retained.artifact.canonicalBytes.byteLength;
     entry.retained.reservation.release();
     entry.retained.decodePermit.release();
@@ -336,7 +320,7 @@ export function createSystemRecordRequesterV1(
     if (closed) return;
     closed = true;
     for (const entry of entries.values()) {
-      if (!entry.settled) {
+      if (entry.retained === undefined) {
         abortEntry(entry, 'closed', new Error('system-record requester closed'));
       }
     }

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomBytes } from 'node:crypto';
+
+import {
+  SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
+  SYSTEM_RECORD_MAX_FRAME_BYTES,
+  SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
+  SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
+  decodeSystemRecordResponseFrameV1,
+  encodeSystemRecordRequestFrameV1,
+  verifySystemRecordResponsePayloadV1,
+  type SystemRecordRequestHeaderV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+
+import type { SystemRecordArtifactV1 } from './artifact-v1.js';
+import type {
+  CreateSystemRecordRequesterOptionsV1,
+  SystemRecordExactArtifactLookupV1,
+  SystemRecordExactFetchLeaseV1,
+  SystemRecordExactFetchResultV1,
+  SystemRecordRequesterByteReservationV1,
+  SystemRecordRequesterExchangeV1,
+  SystemRecordRequesterPermitV1,
+  SystemRecordRequesterResetReasonV1,
+  SystemRecordRequesterStatsV1,
+  SystemRecordRequesterV1,
+} from './requester-api-v1.js';
+import {
+  createSystemRecordExactRequestV1,
+  systemRecordExactRequestKeyV1,
+  systemRecordExactResponseOutcomeV1,
+} from './requester-wire-v1-internal.js';
+
+interface RetainedFetchV1 {
+  readonly artifact: SystemRecordArtifactV1;
+  readonly reservation: SystemRecordRequesterByteReservationV1;
+  readonly decodePermit: SystemRecordRequesterPermitV1;
+  readonly wireBytes: number;
+}
+
+type SharedFetchOutcomeV1 =
+  | Readonly<{ outcome: 'ok'; retained: RetainedFetchV1 }>
+  | Exclude<SystemRecordExactFetchResultV1, Readonly<{ outcome: 'ok'; lease: SystemRecordExactFetchLeaseV1 }>>;
+
+interface FetchSubscriberV1 {
+  readonly signal: AbortSignal;
+  readonly resolve: (result: SystemRecordExactFetchResultV1) => void;
+  readonly reject: (reason?: unknown) => void;
+  readonly onAbort: () => void;
+  state: 'waiting' | 'leased' | 'done';
+}
+
+interface FetchEntryV1 {
+  readonly key: string;
+  readonly controller: AbortController;
+  readonly subscribers: Set<FetchSubscriberV1>;
+  abortReason?: SystemRecordRequesterResetReasonV1;
+  settled: boolean;
+  retained?: RetainedFetchV1;
+}
+
+/**
+ * One default-unused exact requester. Same-coordinate calls share one transfer,
+ * while unrelated digests never wait behind the single process-wide stream.
+ */
+export function createSystemRecordRequesterV1(
+  options: CreateSystemRecordRequesterOptionsV1,
+): SystemRecordRequesterV1 {
+  const requestId = options.requestId ?? (() => randomBytes(16).toString('hex'));
+  const timeoutMs = boundedPositive(
+    options.timeoutMs ?? SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
+    SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
+    'requester timeoutMs',
+  );
+  const maxPendingDigests = boundedPositive(
+    options.maxPendingDigests ?? SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
+    SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
+    'maxPendingDigests',
+  );
+  const maxWaitersPerDigest = boundedPositive(
+    options.maxWaitersPerDigest ?? SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
+    SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
+    'maxWaitersPerDigest',
+  );
+  const entries = new Map<string, FetchEntryV1>();
+  let started = 0;
+  let joined = 0;
+  let completed = 0;
+  let waitingCallers = 0;
+  let activeLeases = 0;
+  let activeStream: 0 | 1 = 0;
+  let peakActiveStream: 0 | 1 = 0;
+  let retainedPayloadBytes = 0;
+  let closed = false;
+
+  return Object.freeze({ fetch, stats, close });
+
+  async function fetch(
+    lookup: SystemRecordExactArtifactLookupV1,
+    openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>,
+    signal: AbortSignal,
+  ): Promise<SystemRecordExactFetchResultV1> {
+    signal.throwIfAborted();
+    if (closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
+    const request = createSystemRecordExactRequestV1(options.networkId, lookup, requestId());
+    const key = systemRecordExactRequestKeyV1(request);
+    let entry = entries.get(key);
+    if (entry !== undefined) {
+      // The first subscriber owns the transfer; the frozen limit counts followers.
+      if (entry.subscribers.size >= maxWaitersPerDigest + 1) {
+        return Object.freeze({ outcome: 'waiter-limit', wireBytes: 0 });
+      }
+      joined += 1;
+      return subscribe(entry, signal);
+    }
+    if (entries.size >= maxPendingDigests) {
+      return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
+    }
+    const streamPermit = options.streamAdmission.tryAcquire();
+    if (streamPermit === null) return Object.freeze({ outcome: 'busy', wireBytes: 0 });
+    const frameReservation = options.byteAdmission.tryReserve(SYSTEM_RECORD_MAX_FRAME_BYTES);
+    if (frameReservation === null) {
+      streamPermit.release();
+      return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
+    }
+    entry = {
+      key,
+      controller: new AbortController(),
+      subscribers: new Set(),
+      settled: false,
+    };
+    entries.set(key, entry);
+    started += 1;
+    activeStream = 1;
+    peakActiveStream = 1;
+    void run(entry, request, openExchange, streamPermit, frameReservation);
+    return subscribe(entry, signal);
+  }
+
+  function subscribe(
+    entry: FetchEntryV1,
+    signal: AbortSignal,
+  ): Promise<SystemRecordExactFetchResultV1> {
+    return new Promise<SystemRecordExactFetchResultV1>((resolve, reject) => {
+      const subscriber: FetchSubscriberV1 = {
+        signal,
+        resolve,
+        reject,
+        state: 'waiting',
+        onAbort: () => {
+          if (subscriber.state !== 'waiting') return;
+          subscriber.state = 'done';
+          entry.subscribers.delete(subscriber);
+          waitingCallers -= 1;
+          reject(signal.reason);
+          abortIfUnobserved(entry);
+        },
+      };
+      entry.subscribers.add(subscriber);
+      waitingCallers += 1;
+      signal.addEventListener('abort', subscriber.onAbort, { once: true });
+      if (signal.aborted) {
+        subscriber.onAbort();
+        return;
+      }
+      if (entry.settled && entry.retained !== undefined) deliverLease(entry, subscriber);
+    });
+  }
+
+  async function run(
+    entry: FetchEntryV1,
+    request: SystemRecordRequestHeaderV1,
+    openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>,
+    streamPermit: SystemRecordRequesterPermitV1,
+    frameReservation: SystemRecordRequesterByteReservationV1,
+  ): Promise<void> {
+    let exchange: SystemRecordRequesterExchangeV1 | undefined;
+    let wireBytes = 0;
+    const timeout = setTimeout(
+      () => abortEntry(
+        entry,
+        'deadline',
+        new Error('system-record requester deadline exceeded'),
+      ),
+      timeoutMs,
+    );
+    timeout.unref?.();
+    let shared: SharedFetchOutcomeV1;
+    try {
+      const requestFrame = encodeSystemRecordRequestFrameV1(request);
+      exchange = await raceAbort(openExchange(entry.controller.signal), entry.controller.signal);
+      await raceAbort(
+        exchange.writeRequestFrame(requestFrame, entry.controller.signal),
+        entry.controller.signal,
+      );
+      wireBytes += requestFrame.byteLength;
+      const responseFrame = await raceAbort(
+        exchange.readResponseFrame(SYSTEM_RECORD_MAX_FRAME_BYTES, entry.controller.signal),
+        entry.controller.signal,
+      );
+      if (responseFrame instanceof Uint8Array) wireBytes += responseFrame.byteLength;
+      if (!(responseFrame instanceof Uint8Array)
+        || responseFrame.byteLength < 1
+        || responseFrame.byteLength > SYSTEM_RECORD_MAX_FRAME_BYTES) {
+        throw new InvalidSystemRecordResponseError();
+      }
+      frameReservation.shrinkTo(responseFrame.byteLength);
+      let decoded: ReturnType<typeof decodeSystemRecordResponseFrameV1>;
+      try {
+        decoded = decodeSystemRecordResponseFrameV1(responseFrame);
+        verifySystemRecordResponsePayloadV1(request, decoded.header, decoded.payload);
+      } catch {
+        throw new InvalidSystemRecordResponseError();
+      }
+      if (decoded.header.status !== 'ok') {
+        shared = Object.freeze({
+          outcome: systemRecordExactResponseOutcomeV1(decoded.header.status),
+          wireBytes,
+        });
+      } else {
+        const decodePermit = options.decodeAdmission.tryAcquire();
+        if (decodePermit === null) {
+          shared = Object.freeze({ outcome: 'busy', wireBytes });
+        } else {
+          const payloadReservation = options.byteAdmission.tryReserve(decoded.payload.byteLength);
+          if (payloadReservation === null) {
+            decodePermit.release();
+            shared = Object.freeze({ outcome: 'capacity', wireBytes });
+          } else {
+            try {
+              const canonicalBytes = Uint8Array.from(decoded.payload);
+              const retained: RetainedFetchV1 = Object.freeze({
+                artifact: Object.freeze({
+                  objectKind: decoded.header.objectKind,
+                  objectDigest: decoded.header.objectDigest,
+                  canonicalBytes,
+                }),
+                reservation: payloadReservation,
+                decodePermit,
+                wireBytes,
+              });
+              entry.retained = retained;
+              retainedPayloadBytes += canonicalBytes.byteLength;
+              shared = Object.freeze({ outcome: 'ok', retained });
+            } catch (error) {
+              payloadReservation.release();
+              decodePermit.release();
+              throw error;
+            }
+          }
+        }
+      }
+    } catch (error) {
+      const outcome = error instanceof InvalidSystemRecordResponseError
+        ? 'invalid-response'
+        : entry.controller.signal.aborted
+          ? entry.abortReason === 'closed'
+            ? 'closed'
+            : entry.abortReason === 'deadline'
+              ? 'deadline'
+              : 'transport'
+          : 'transport';
+      try {
+        exchange?.reset(
+          outcome === 'invalid-response'
+            ? 'invalid-response'
+            : entry.abortReason ?? outcome,
+        );
+      } catch {
+        // Reset is best-effort cleanup and cannot strand the single-flight entry.
+      }
+      shared = Object.freeze({ outcome, wireBytes });
+    } finally {
+      clearTimeout(timeout);
+      frameReservation.release();
+      streamPermit.release();
+      activeStream = 0;
+      completed += 1;
+    }
+    settle(entry, shared);
+  }
+
+  function settle(entry: FetchEntryV1, shared: SharedFetchOutcomeV1): void {
+    entry.settled = true;
+    if (shared.outcome === 'ok') {
+      for (const subscriber of [...entry.subscribers]) deliverLease(entry, subscriber);
+      abortIfUnobserved(entry);
+      return;
+    }
+    entries.delete(entry.key);
+    for (const subscriber of [...entry.subscribers]) {
+      if (subscriber.state !== 'waiting') continue;
+      subscriber.signal.removeEventListener('abort', subscriber.onAbort);
+      subscriber.state = 'done';
+      waitingCallers -= 1;
+      entry.subscribers.delete(subscriber);
+      subscriber.resolve(shared);
+    }
+  }
+
+  function deliverLease(entry: FetchEntryV1, subscriber: FetchSubscriberV1): void {
+    if (subscriber.state !== 'waiting' || entry.retained === undefined) return;
+    subscriber.signal.removeEventListener('abort', subscriber.onAbort);
+    subscriber.state = 'leased';
+    waitingCallers -= 1;
+    activeLeases += 1;
+    let released = false;
+    const retained = entry.retained;
+    subscriber.resolve(Object.freeze({
+      outcome: 'ok',
+      lease: Object.freeze({
+        artifact: retained.artifact,
+        wireBytes: retained.wireBytes,
+        release(): void {
+          if (released) return;
+          released = true;
+          subscriber.state = 'done';
+          entry.subscribers.delete(subscriber);
+          activeLeases -= 1;
+          releaseRetainedIfUnobserved(entry);
+        },
+      }),
+    }));
+  }
+
+  function abortIfUnobserved(entry: FetchEntryV1): void {
+    if (entry.subscribers.size !== 0) return;
+    if (!entry.settled) {
+      abortEntry(entry, 'cancelled', new Error('system-record requester has no callers'));
+    }
+    releaseRetainedIfUnobserved(entry);
+  }
+
+  function releaseRetainedIfUnobserved(entry: FetchEntryV1): void {
+    if (entry.subscribers.size !== 0 || entry.retained === undefined) return;
+    entries.delete(entry.key);
+    retainedPayloadBytes -= entry.retained.artifact.canonicalBytes.byteLength;
+    entry.retained.reservation.release();
+    entry.retained.decodePermit.release();
+    entry.retained = undefined;
+  }
+
+  function stats(): SystemRecordRequesterStatsV1 {
+    return Object.freeze({
+      started,
+      joined,
+      completed,
+      pendingDigests: entries.size,
+      waitingCallers,
+      activeLeases,
+      activeStream,
+      peakActiveStream,
+      queuedStreams: 0,
+      retainedPayloadBytes,
+      closed,
+    });
+  }
+
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    for (const entry of entries.values()) {
+      if (!entry.settled) {
+        abortEntry(entry, 'closed', new Error('system-record requester closed'));
+      }
+    }
+  }
+
+  function abortEntry(
+    entry: FetchEntryV1,
+    reason: SystemRecordRequesterResetReasonV1,
+    error: Error,
+  ): void {
+    if (entry.controller.signal.aborted) return;
+    entry.abortReason = reason;
+    entry.controller.abort(error);
+  }
+}
+
+function boundedPositive(value: number, maximum: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new TypeError(`${label} must be in 1..${maximum}`);
+  }
+  return value;
+}
+
+function raceAbort<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
+  });
+}
+
+class InvalidSystemRecordResponseError extends Error {}

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -15,6 +15,7 @@ import type {
   CreateSystemRecordRequesterOptionsV1,
   SystemRecordExactArtifactLookupV1,
   SystemRecordExactFetchResultV1,
+  SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterByteReservationV1,
   SystemRecordRequesterExchangeV1,
   SystemRecordRequesterPermitV1,
@@ -35,9 +36,14 @@ import {
 } from './requester-wire-v1-internal.js';
 import { raceSystemRecordAbortV1 } from './transport-v1.js';
 
+type SystemRecordRequesterFailureV1 = Exclude<
+  SystemRecordExactFetchResultV1,
+  Readonly<{ outcome: 'ok' }>
+>;
+
 type SystemRecordRequesterSettlementV1 =
-  | Readonly<{ outcome: 'ok'; wireBytes: number }>
-  | Exclude<SystemRecordExactFetchResultV1, Readonly<{ outcome: 'ok' }>>;
+  | Readonly<{ state: 'retained'; source: SystemRecordRetainedSourceV1 }>
+  | Readonly<{ state: 'failed'; result: SystemRecordRequesterFailureV1 }>;
 
 interface PendingFetchPhaseV1 {
   readonly state: 'pending';
@@ -51,11 +57,140 @@ interface RetainedFetchPhaseV1 {
   readonly source: SystemRecordRetainedSourceV1;
 }
 
-interface FetchEntryV1 {
+interface SettledFetchPhaseV1 {
+  readonly state: 'failed' | 'disposed';
+}
+
+type FetchPhaseV1 = PendingFetchPhaseV1 | RetainedFetchPhaseV1 | SettledFetchPhaseV1;
+
+interface FetchEntryAccountingV1 {
+  observerDelta(delta: 1 | -1): void;
+  leaseDelta(delta: 1 | -1): void;
+  retainedBytesDelta(delta: number): void;
+  remove(entry: FetchEntryV1): void;
+}
+
+class FetchEntryV1 {
   readonly key: string;
-  observerCount: number;
-  leaseCount: number;
-  phase: PendingFetchPhaseV1 | RetainedFetchPhaseV1;
+  #phase: FetchPhaseV1;
+  #observerCount = 0;
+  #leaseCount = 0;
+  readonly #accounting: FetchEntryAccountingV1;
+
+  constructor(
+    key: string,
+    pending: PendingFetchPhaseV1,
+    accounting: FetchEntryAccountingV1,
+  ) {
+    this.key = key;
+    this.#phase = pending;
+    this.#accounting = accounting;
+  }
+
+  get participantCount(): number {
+    return this.#observerCount + this.#leaseCount;
+  }
+
+  get pendingAborted(): boolean {
+    return this.#phase.state === 'pending' && this.#phase.controller.signal.aborted;
+  }
+
+  snapshot(): FetchPhaseV1 {
+    return this.#phase;
+  }
+
+  addObserver(): void {
+    this.#observerCount += 1;
+    this.#accounting.observerDelta(1);
+  }
+
+  releaseObserver(): void {
+    if (this.#observerCount < 1) throw new Error('System Record observer underflow');
+    this.#observerCount -= 1;
+    this.#accounting.observerDelta(-1);
+    this.#disposeIfIdle();
+  }
+
+  retainSource(source: SystemRecordRetainedSourceV1): void {
+    if (this.#phase.state !== 'pending') {
+      source.release();
+      throw new Error('System Record source retained outside the pending phase');
+    }
+    this.#phase = Object.freeze({ state: 'retained', source });
+    this.#accounting.retainedBytesDelta(source.artifact.canonicalBytes.byteLength);
+  }
+
+  settleFailure(): void {
+    if (this.#phase.state !== 'pending') return;
+    this.#phase = Object.freeze({ state: 'failed' });
+    this.#accounting.remove(this);
+  }
+
+  deliverLease(
+    source: SystemRecordRetainedSourceV1,
+    byteAdmission: SystemRecordRequesterByteAdmissionV1,
+  ): SystemRecordExactFetchResultV1 {
+    if (this.#phase.state !== 'retained' || this.#phase.source !== source) {
+      throw new Error('System Record lease source is not retained by its entry');
+    }
+    const payloadBytes = source.artifact.canonicalBytes.byteLength;
+    const reservation = byteAdmission.tryReserve(payloadBytes);
+    if (reservation === null) {
+      return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
+    }
+    let artifact: ReturnType<typeof cloneSystemRecordArtifactV1>;
+    try {
+      artifact = cloneSystemRecordArtifactV1(source.artifact);
+    } catch {
+      reservation.release();
+      return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
+    }
+    this.#leaseCount += 1;
+    this.#accounting.leaseDelta(1);
+    this.#accounting.retainedBytesDelta(payloadBytes);
+    let released = false;
+    return Object.freeze({
+      outcome: 'ok',
+      lease: Object.freeze({
+        artifact,
+        wireBytes: source.wireBytes,
+        release: () => {
+          if (released) return;
+          released = true;
+          this.#leaseCount -= 1;
+          this.#accounting.leaseDelta(-1);
+          this.#accounting.retainedBytesDelta(-payloadBytes);
+          reservation.release();
+          this.#disposeIfIdle();
+        },
+      }),
+    });
+  }
+
+  abort(reason: SystemRecordRequesterResetReasonV1, error: Error): void {
+    const phase = this.#phase;
+    if (phase.state !== 'pending' || phase.controller.signal.aborted) return;
+    phase.abortReason = reason;
+    phase.controller.abort(error);
+  }
+
+  close(): void {
+    this.abort('closed', new Error('system-record requester closed'));
+  }
+
+  #disposeIfIdle(): void {
+    if (this.#observerCount !== 0 || this.#leaseCount !== 0) return;
+    const phase = this.#phase;
+    if (phase.state === 'pending') {
+      this.abort('cancelled', new Error('system-record requester has no callers'));
+      return;
+    }
+    if (phase.state !== 'retained') return;
+    this.#phase = Object.freeze({ state: 'disposed' });
+    this.#accounting.remove(this);
+    this.#accounting.retainedBytesDelta(-phase.source.artifact.canonicalBytes.byteLength);
+    phase.source.release();
+  }
 }
 
 /**
@@ -91,6 +226,20 @@ export function createSystemRecordRequesterV1(
   let peakActiveStream: 0 | 1 = 0;
   let retainedPayloadBytes = 0;
   let closed = false;
+  const entryAccounting: FetchEntryAccountingV1 = {
+    observerDelta(delta) {
+      waitingCallers += delta;
+    },
+    leaseDelta(delta) {
+      activeLeases += delta;
+    },
+    retainedBytesDelta(delta) {
+      retainedPayloadBytes += delta;
+    },
+    remove(entry) {
+      if (entries.get(entry.key) === entry) entries.delete(entry.key);
+    },
+  };
 
   return Object.freeze({ fetch, stats, close });
 
@@ -104,11 +253,11 @@ export function createSystemRecordRequesterV1(
     const { key, request } = exact;
     let entry = entries.get(key);
     if (entry !== undefined) {
-      if (entry.phase.state === 'pending' && entry.phase.controller.signal.aborted) {
+      if (entry.pendingAborted) {
         return Object.freeze({ outcome: 'busy', wireBytes: 0 });
       }
       // The first observer owns the transfer; the frozen limit counts followers.
-      if (entry.observerCount + entry.leaseCount >= maxWaitersPerDigest + 1) {
+      if (entry.participantCount >= maxWaitersPerDigest + 1) {
         return Object.freeze({ outcome: 'waiter-limit', wireBytes: 0 });
       }
       joined += 1;
@@ -130,16 +279,15 @@ export function createSystemRecordRequesterV1(
       resolveTransfer = resolve;
       rejectTransfer = reject;
     });
-    entry = {
+    entry = new FetchEntryV1(
       key,
-      observerCount: 0,
-      leaseCount: 0,
-      phase: {
+      {
         state: 'pending',
         controller: new AbortController(),
         transfer,
       },
-    };
+      entryAccounting,
+    );
     entries.set(key, entry);
     started += 1;
     activeStream = 1;
@@ -155,15 +303,12 @@ export function createSystemRecordRequesterV1(
     entry: FetchEntryV1,
     signal: AbortSignal,
   ): Promise<SystemRecordExactFetchResultV1> {
-    entry.observerCount += 1;
-    waitingCallers += 1;
+    entry.addObserver();
     let observing = true;
     const releaseObserver = () => {
       if (!observing) return;
       observing = false;
-      entry.observerCount -= 1;
-      waitingCallers -= 1;
-      abortIfUnobserved(entry);
+      entry.releaseObserver();
     };
     signal.addEventListener('abort', releaseObserver, { once: true });
     if (signal.aborted) {
@@ -171,15 +316,17 @@ export function createSystemRecordRequesterV1(
       signal.throwIfAborted();
     }
     try {
-      const phase = entry.phase;
-      if (phase.state === 'retained') return deliverLease(entry, phase.source);
-      const shared = await raceSystemRecordAbortV1(phase.transfer, signal);
-      if (shared.outcome !== 'ok') return shared;
-      const retained = entry.phase;
-      if (retained.state !== 'retained') {
-        throw new Error('successful System Record transfer has no retained source');
+      const phase = entry.snapshot();
+      if (phase.state === 'retained') {
+        return entry.deliverLease(phase.source, options.byteAdmission);
       }
-      return deliverLease(entry, retained.source);
+      if (phase.state !== 'pending') {
+        return Object.freeze({ outcome: 'busy', wireBytes: 0 });
+      }
+      const shared = await raceSystemRecordAbortV1(phase.transfer, signal);
+      return shared.state === 'retained'
+        ? entry.deliverLease(shared.source, options.byteAdmission)
+        : shared.result;
     } finally {
       signal.removeEventListener('abort', releaseObserver);
       releaseObserver();
@@ -192,22 +339,21 @@ export function createSystemRecordRequesterV1(
     streamPermit: SystemRecordRequesterPermitV1,
     frameReservation: SystemRecordRequesterByteReservationV1,
   ): Promise<SystemRecordRequesterSettlementV1> {
-    const pending = entry.phase;
+    const pending = entry.snapshot();
     if (pending.state !== 'pending') {
       throw new Error('System Record transfer started outside the pending phase');
     }
     let exchange: SystemRecordRequesterExchangeV1 | undefined;
     let wireBytes = 0;
     const timeout = setTimeout(
-      () => abortEntry(
-        entry,
+      () => entry.abort(
         'deadline',
         new Error('system-record requester deadline exceeded'),
       ),
       timeoutMs,
     );
     timeout.unref?.();
-    let shared: SystemRecordRequesterSettlementV1;
+    let settlement: SystemRecordRequesterSettlementV1;
     try {
       exchange = await openSystemRecordRequesterExchangeV1({
         openExchange: options.openExchange,
@@ -228,11 +374,10 @@ export function createSystemRecordRequesterV1(
         byteAdmission: options.byteAdmission,
       });
       if (retained.outcome === 'ok') {
-        entry.phase = Object.freeze({ state: 'retained', source: retained.retained });
-        retainedPayloadBytes += retained.retained.artifact.canonicalBytes.byteLength;
-        shared = Object.freeze({ outcome: 'ok', wireBytes: retained.retained.wireBytes });
+        entry.retainSource(retained.retained);
+        settlement = Object.freeze({ state: 'retained', source: retained.retained });
       } else {
-        shared = retained;
+        settlement = Object.freeze({ state: 'failed', result: retained });
       }
     } catch (error) {
       if (error instanceof SystemRecordRequesterTransferError) {
@@ -256,7 +401,10 @@ export function createSystemRecordRequesterV1(
       } catch {
         // Reset is best-effort cleanup and cannot strand the single-flight entry.
       }
-      shared = Object.freeze({ outcome, wireBytes });
+      settlement = Object.freeze({
+        state: 'failed',
+        result: Object.freeze({ outcome, wireBytes }),
+      });
     } finally {
       clearTimeout(timeout);
       frameReservation.release();
@@ -264,64 +412,8 @@ export function createSystemRecordRequesterV1(
       activeStream = 0;
       completed += 1;
     }
-    if (shared.outcome !== 'ok' && entries.get(entry.key) === entry) entries.delete(entry.key);
-    return shared;
-  }
-
-  function deliverLease(
-    entry: FetchEntryV1,
-    retained: SystemRecordRetainedSourceV1,
-  ): SystemRecordExactFetchResultV1 {
-    const payloadBytes = retained.artifact.canonicalBytes.byteLength;
-    const reservation = options.byteAdmission.tryReserve(payloadBytes);
-    if (reservation === null) {
-      return Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes });
-    }
-    let artifact: ReturnType<typeof cloneSystemRecordArtifactV1>;
-    try {
-      artifact = cloneSystemRecordArtifactV1(retained.artifact);
-    } catch {
-      reservation.release();
-      return Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes });
-    }
-    entry.leaseCount += 1;
-    activeLeases += 1;
-    retainedPayloadBytes += payloadBytes;
-    let released = false;
-    return Object.freeze({
-      outcome: 'ok',
-      lease: Object.freeze({
-        artifact,
-        wireBytes: retained.wireBytes,
-        release(): void {
-          if (released) return;
-          released = true;
-          entry.leaseCount -= 1;
-          activeLeases -= 1;
-          retainedPayloadBytes -= payloadBytes;
-          reservation.release();
-          releaseRetainedIfUnobserved(entry);
-        },
-      }),
-    });
-  }
-
-  function abortIfUnobserved(entry: FetchEntryV1): void {
-    if (entry.observerCount !== 0 || entry.leaseCount !== 0) return;
-    if (entries.get(entry.key) !== entry) return;
-    if (entry.phase.state === 'pending') {
-      abortEntry(entry, 'cancelled', new Error('system-record requester has no callers'));
-    }
-    releaseRetainedIfUnobserved(entry);
-  }
-
-  function releaseRetainedIfUnobserved(entry: FetchEntryV1): void {
-    if (entry.observerCount !== 0 || entry.leaseCount !== 0) return;
-    const phase = entry.phase;
-    if (phase.state !== 'retained') return;
-    if (entries.get(entry.key) === entry) entries.delete(entry.key);
-    retainedPayloadBytes -= phase.source.artifact.canonicalBytes.byteLength;
-    phase.source.release();
+    if (settlement.state === 'failed') entry.settleFailure();
+    return settlement;
   }
 
   function stats(): SystemRecordRequesterStatsV1 {
@@ -344,21 +436,8 @@ export function createSystemRecordRequesterV1(
     if (closed) return;
     closed = true;
     for (const entry of entries.values()) {
-      if (entry.phase.state === 'pending') {
-        abortEntry(entry, 'closed', new Error('system-record requester closed'));
-      }
+      entry.close();
     }
-  }
-
-  function abortEntry(
-    entry: FetchEntryV1,
-    reason: SystemRecordRequesterResetReasonV1,
-    error: Error,
-  ): void {
-    const phase = entry.phase;
-    if (phase.state !== 'pending' || phase.controller.signal.aborted) return;
-    phase.abortReason = reason;
-    phase.controller.abort(error);
   }
 }
 

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -80,12 +80,9 @@ type FetchPhaseV1 = PendingFetchPhaseV1 | RetainedFetchPhaseV1 | SettledFetchPha
 
 interface FetchEntryV1 {
   readonly key: string;
-  readonly pendingSignal: AbortSignal;
   readonly participantCount: number;
   readonly pendingAborted: boolean;
   subscribe(signal: AbortSignal): Promise<SystemRecordExactFetchResultV1>;
-  completeRetained(source: SystemRecordRetainedSourceV1): SystemRecordRequesterSettlementV1;
-  completeFailure(result: SystemRecordRequesterFailureV1): SystemRecordRequesterSettlementV1;
   abort(reason: SystemRecordRequesterResetReasonV1, error: Error): void;
   resetReason(): SystemRecordRequesterResetReasonV1;
   close(): void;
@@ -113,8 +110,14 @@ class ExactFetchRegistryV1 {
     return this.#entries.get(key);
   }
 
-  create(key: string, pending: PendingFetchPhaseV1): FetchEntryV1 {
-    const entry = new ExactFetchEntryV1(key, pending, this.#byteAdmission, this);
+  create(
+    key: string,
+    start: (
+      entry: FetchEntryV1,
+      signal: AbortSignal,
+    ) => Promise<SystemRecordRequesterSettlementV1>,
+  ): FetchEntryV1 {
+    const entry = new ExactFetchEntryV1(key, this.#byteAdmission, this, start);
     this.#entries.set(key, entry);
     this.#tracked.add(entry);
     return entry;
@@ -163,20 +166,21 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
 
   constructor(
     key: string,
-    pending: PendingFetchPhaseV1,
     byteAdmission: SystemRecordRequesterByteAdmissionV1,
     registry: ExactFetchRegistryV1,
+    start: (
+      entry: FetchEntryV1,
+      signal: AbortSignal,
+    ) => Promise<SystemRecordRequesterSettlementV1>,
   ) {
     this.key = key;
-    this.#phase = pending;
     this.#byteAdmission = byteAdmission;
     this.#registry = registry;
-  }
-
-  get pendingSignal(): AbortSignal {
-    const phase = this.#phase;
-    if (phase.state !== 'pending') throw new Error('System Record entry is not pending');
-    return phase.controller.signal;
+    const controller = new AbortController();
+    const transfer = Promise.resolve()
+      .then(() => start(this, controller.signal))
+      .then((settlement) => this.#settle(settlement));
+    this.#phase = { state: 'pending', controller, transfer };
   }
 
   get participantCount(): number {
@@ -188,6 +192,7 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
   }
 
   async subscribe(signal: AbortSignal): Promise<SystemRecordExactFetchResultV1> {
+    signal.throwIfAborted();
     this.#observerCount += 1;
     let observing = true;
     const releaseObserver = () => {
@@ -197,11 +202,8 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
       this.#disposeIfIdle();
     };
     signal.addEventListener('abort', releaseObserver, { once: true });
-    if (signal.aborted) {
-      releaseObserver();
-      signal.throwIfAborted();
-    }
     try {
+      signal.throwIfAborted();
       const phase = this.#phase;
       if (phase.state === 'retained') return this.#deliverLease(phase.source);
       if (phase.state !== 'pending') {
@@ -215,26 +217,6 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
       signal.removeEventListener('abort', releaseObserver);
       releaseObserver();
     }
-  }
-
-  completeRetained(source: SystemRecordRetainedSourceV1): SystemRecordRequesterSettlementV1 {
-    if (this.#phase.state !== 'pending') {
-      source.release();
-      throw new Error('System Record source retained outside the pending phase');
-    }
-    this.#phase = Object.freeze({ state: 'retained', source });
-    this.#retainedPayloadBytes += source.artifact.canonicalBytes.byteLength;
-    return Object.freeze({ state: 'retained', source });
-  }
-
-  completeFailure(result: SystemRecordRequesterFailureV1): SystemRecordRequesterSettlementV1 {
-    if (this.#phase.state !== 'pending') {
-      throw new Error('System Record failure completed outside the pending phase');
-    }
-    this.#phase = Object.freeze({ state: 'failed' });
-    this.#registry.unpublish(this);
-    this.#disposeIfIdle();
-    return Object.freeze({ state: 'failed', result });
   }
 
   abort(reason: SystemRecordRequesterResetReasonV1, error: Error): void {
@@ -263,6 +245,22 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
       activeLeases: this.#leaseCount,
       retainedPayloadBytes: this.#retainedPayloadBytes,
     });
+  }
+
+  #settle(settlement: SystemRecordRequesterSettlementV1): SystemRecordRequesterSettlementV1 {
+    if (this.#phase.state !== 'pending') {
+      if (settlement.state === 'retained') settlement.source.release();
+      throw new Error('System Record task settled outside the pending phase');
+    }
+    if (settlement.state === 'retained') {
+      this.#phase = Object.freeze({ state: 'retained', source: settlement.source });
+      this.#retainedPayloadBytes += settlement.source.artifact.canonicalBytes.byteLength;
+      return settlement;
+    }
+    this.#phase = Object.freeze({ state: 'failed' });
+    this.#registry.unpublish(this);
+    this.#disposeIfIdle();
+    return settlement;
   }
 
   #deliverLease(source: SystemRecordRetainedSourceV1): SystemRecordExactFetchResultV1 {
@@ -332,10 +330,10 @@ export function createSystemRecordRequesterV1(
     SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
     'requester timeoutMs',
   );
-  const maxPendingDigests = boundedPositive(
-    options.maxPendingDigests ?? SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
+  const maxTrackedDigests = boundedPositive(
+    options.maxTrackedDigests ?? SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
     SYSTEM_RECORD_MAX_PENDING_EXACT_FETCHES,
-    'maxPendingDigests',
+    'maxTrackedDigests',
   );
   const maxWaitersPerDigest = boundedPositive(
     options.maxWaitersPerDigest ?? SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
@@ -372,7 +370,7 @@ export function createSystemRecordRequesterV1(
       joined += 1;
       return entry.subscribe(signal);
     }
-    if (registry.size >= maxPendingDigests) {
+    if (registry.size >= maxTrackedDigests) {
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
     }
     const streamPermit = options.streamAdmission.tryAcquire();
@@ -382,37 +380,29 @@ export function createSystemRecordRequesterV1(
       streamPermit.release();
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
     }
-    let resolveTransfer!: (result: SystemRecordRequesterSettlementV1) => void;
-    let rejectTransfer!: (reason?: unknown) => void;
-    const transfer = new Promise<SystemRecordRequesterSettlementV1>((resolve, reject) => {
-      resolveTransfer = resolve;
-      rejectTransfer = reject;
-    });
     entry = registry.create(
       key,
-      {
-        state: 'pending',
-        controller: new AbortController(),
-        transfer,
-      },
+      (createdEntry, pendingSignal) => run(
+        createdEntry,
+        request,
+        pendingSignal,
+        streamPermit,
+        frameReservation,
+      ),
     );
     started += 1;
     activeStream = 1;
     peakActiveStream = 1;
-    void run(entry, request, streamPermit, frameReservation).then(
-      resolveTransfer,
-      rejectTransfer,
-    );
     return entry.subscribe(signal);
   }
 
   async function run(
     entry: FetchEntryV1,
     request: SystemRecordRequestHeaderV1,
+    pendingSignal: AbortSignal,
     streamPermit: SystemRecordRequesterPermitV1,
     frameReservation: SystemRecordRequesterByteReservationV1,
   ): Promise<SystemRecordRequesterSettlementV1> {
-    const pendingSignal = entry.pendingSignal;
     let exchange: SystemRecordRequesterExchangeV1 | undefined;
     let wireBytes = 0;
     const timeout = setTimeout(
@@ -444,7 +434,7 @@ export function createSystemRecordRequesterV1(
         byteAdmission: options.byteAdmission,
       });
       if (retained.outcome === 'ok') {
-        settlement = entry.completeRetained(retained.retained);
+        settlement = Object.freeze({ state: 'retained', source: retained.retained });
       } else {
         settlement = Object.freeze({ state: 'failed', result: retained });
       }
@@ -481,9 +471,7 @@ export function createSystemRecordRequesterV1(
       activeStream = 0;
       completed += 1;
     }
-    return settlement.state === 'failed'
-      ? entry.completeFailure(settlement.result)
-      : settlement;
+    return settlement;
   }
 
   function stats(): SystemRecordRequesterStatsV1 {
@@ -492,7 +480,7 @@ export function createSystemRecordRequesterV1(
       started,
       joined,
       completed,
-      pendingDigests: registry.size,
+      trackedDigests: registry.size,
       waitingCallers: entryStats.waitingCallers,
       activeLeases: entryStats.activeLeases,
       activeStream,

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -10,6 +10,7 @@ import {
   type SystemRecordRequestHeaderV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
 
+import { cloneSystemRecordArtifactV1 } from './artifact-v1.js';
 import type {
   CreateSystemRecordRequesterOptionsV1,
   SystemRecordExactArtifactLookupV1,
@@ -103,6 +104,9 @@ export function createSystemRecordRequesterV1(
     const key = systemRecordExactRequestKeyV1(request);
     let entry = entries.get(key);
     if (entry !== undefined) {
+      if (!entry.settled && entry.controller.signal.aborted) {
+        return Object.freeze({ outcome: 'busy', wireBytes: 0 });
+      }
       // The first observer owns the transfer; the frozen limit counts followers.
       if (entry.waiters.size + entry.leaseCount >= maxWaitersPerDigest + 1) {
         return Object.freeze({ outcome: 'waiter-limit', wireBytes: 0 });
@@ -264,9 +268,9 @@ export function createSystemRecordRequesterV1(
       releaseRetainedIfUnobserved(entry);
       return;
     }
-    let canonicalBytes: Uint8Array;
+    let artifact: ReturnType<typeof cloneSystemRecordArtifactV1>;
     try {
-      canonicalBytes = Uint8Array.from(retained.artifact.canonicalBytes);
+      artifact = cloneSystemRecordArtifactV1(retained.artifact);
     } catch {
       reservation.release();
       waiter.resolve(Object.freeze({ outcome: 'capacity', wireBytes: retained.wireBytes }));
@@ -280,11 +284,7 @@ export function createSystemRecordRequesterV1(
     waiter.resolve(Object.freeze({
       outcome: 'ok',
       lease: Object.freeze({
-        artifact: Object.freeze({
-          objectKind: retained.artifact.objectKind,
-          objectDigest: retained.artifact.objectDigest,
-          canonicalBytes,
-        }),
+        artifact,
         wireBytes: retained.wireBytes,
         release(): void {
           if (released) return;

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -144,7 +144,6 @@ export function createSystemRecordRequesterV1(
     entry: FetchEntryV1,
     signal: AbortSignal,
   ): Promise<SystemRecordExactFetchResultV1> {
-    signal.throwIfAborted();
     entry.observerCount += 1;
     waitingCallers += 1;
     let observing = true;

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -52,6 +52,10 @@ interface FetchEntryV1 {
   retained?: SystemRecordRetainedSourceV1;
 }
 
+type SystemRecordRequesterSettlementV1 =
+  | SystemRecordRetainTransferResultV1
+  | Exclude<SystemRecordExactFetchResultV1, Readonly<{ outcome: 'ok' }>>;
+
 /**
  * One default-unused exact requester. Same-coordinate calls share one transfer,
  * while unrelated digests never wait behind the single process-wide stream.
@@ -176,7 +180,7 @@ export function createSystemRecordRequesterV1(
       timeoutMs,
     );
     timeout.unref?.();
-    let shared: SystemRecordRetainTransferResultV1;
+    let shared: SystemRecordRequesterSettlementV1;
     try {
       exchange = await raceSystemRecordAbortV1(
         openExchange(entry.controller.signal),
@@ -232,7 +236,7 @@ export function createSystemRecordRequesterV1(
     settle(entry, shared);
   }
 
-  function settle(entry: FetchEntryV1, shared: SystemRecordRetainTransferResultV1): void {
+  function settle(entry: FetchEntryV1, shared: SystemRecordRequesterSettlementV1): void {
     entry.settled = true;
     if (shared.outcome === 'ok') {
       for (const waiter of [...entry.waiters]) deliverLease(entry, waiter);

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -26,9 +26,9 @@ import {
   InvalidSystemRecordResponseError,
   SystemRecordRequesterTransferError,
   exchangeSystemRecordResponseV1,
+  openSystemRecordRequesterExchangeV1,
   retainVerifiedSystemRecordResponseV1,
   type SystemRecordRetainedSourceV1,
-  type SystemRecordRetainTransferResultV1,
 } from './requester-transfer-v1-internal.js';
 import {
   createSystemRecordExactRequestV1,
@@ -36,17 +36,26 @@ import {
 import { raceSystemRecordAbortV1 } from './transport-v1.js';
 
 type SystemRecordRequesterSettlementV1 =
-  | SystemRecordRetainTransferResultV1
+  | Readonly<{ outcome: 'ok'; wireBytes: number }>
   | Exclude<SystemRecordExactFetchResultV1, Readonly<{ outcome: 'ok' }>>;
+
+interface PendingFetchPhaseV1 {
+  readonly state: 'pending';
+  readonly controller: AbortController;
+  readonly transfer: Promise<SystemRecordRequesterSettlementV1>;
+  abortReason?: SystemRecordRequesterResetReasonV1;
+}
+
+interface RetainedFetchPhaseV1 {
+  readonly state: 'retained';
+  readonly source: SystemRecordRetainedSourceV1;
+}
 
 interface FetchEntryV1 {
   readonly key: string;
-  readonly controller: AbortController;
-  readonly transfer: Promise<SystemRecordRequesterSettlementV1>;
   observerCount: number;
   leaseCount: number;
-  abortReason?: SystemRecordRequesterResetReasonV1;
-  retained?: SystemRecordRetainedSourceV1;
+  phase: PendingFetchPhaseV1 | RetainedFetchPhaseV1;
 }
 
 /**
@@ -95,7 +104,7 @@ export function createSystemRecordRequesterV1(
     const { key, request } = exact;
     let entry = entries.get(key);
     if (entry !== undefined) {
-      if (entry.controller.signal.aborted) {
+      if (entry.phase.state === 'pending' && entry.phase.controller.signal.aborted) {
         return Object.freeze({ outcome: 'busy', wireBytes: 0 });
       }
       // The first observer owns the transfer; the frozen limit counts followers.
@@ -123,10 +132,13 @@ export function createSystemRecordRequesterV1(
     });
     entry = {
       key,
-      controller: new AbortController(),
-      transfer,
       observerCount: 0,
       leaseCount: 0,
+      phase: {
+        state: 'pending',
+        controller: new AbortController(),
+        transfer,
+      },
     };
     entries.set(key, entry);
     started += 1;
@@ -159,30 +171,19 @@ export function createSystemRecordRequesterV1(
       signal.throwIfAborted();
     }
     try {
-      const shared = await raceSystemRecordAbortV1(entry.transfer, signal);
-      return shared.outcome === 'ok' ? deliverLease(entry, shared.retained) : shared;
+      const phase = entry.phase;
+      if (phase.state === 'retained') return deliverLease(entry, phase.source);
+      const shared = await raceSystemRecordAbortV1(phase.transfer, signal);
+      if (shared.outcome !== 'ok') return shared;
+      const retained = entry.phase;
+      if (retained.state !== 'retained') {
+        throw new Error('successful System Record transfer has no retained source');
+      }
+      return deliverLease(entry, retained.source);
     } finally {
       signal.removeEventListener('abort', releaseObserver);
       releaseObserver();
     }
-  }
-
-  async function openRequesterExchangeV1(
-    entry: FetchEntryV1,
-  ): Promise<SystemRecordRequesterExchangeV1> {
-    const opening = options.openExchange(entry.controller.signal);
-    let accepted = false;
-    void opening.then((lateExchange) => {
-      if (accepted || !entry.controller.signal.aborted) return;
-      try {
-        lateExchange.reset(entry.abortReason ?? 'cancelled');
-      } catch {
-        // A late transport owns no requester resources; reset remains best-effort.
-      }
-    }, () => undefined);
-    const exchange = await raceSystemRecordAbortV1(opening, entry.controller.signal);
-    accepted = true;
-    return exchange;
   }
 
   async function run(
@@ -191,6 +192,10 @@ export function createSystemRecordRequesterV1(
     streamPermit: SystemRecordRequesterPermitV1,
     frameReservation: SystemRecordRequesterByteReservationV1,
   ): Promise<SystemRecordRequesterSettlementV1> {
+    const pending = entry.phase;
+    if (pending.state !== 'pending') {
+      throw new Error('System Record transfer started outside the pending phase');
+    }
     let exchange: SystemRecordRequesterExchangeV1 | undefined;
     let wireBytes = 0;
     const timeout = setTimeout(
@@ -204,23 +209,30 @@ export function createSystemRecordRequesterV1(
     timeout.unref?.();
     let shared: SystemRecordRequesterSettlementV1;
     try {
-      exchange = await openRequesterExchangeV1(entry);
+      exchange = await openSystemRecordRequesterExchangeV1({
+        openExchange: options.openExchange,
+        signal: pending.controller.signal,
+        resetReason: () => pending.abortReason ?? 'cancelled',
+      });
       const transfer = await exchangeSystemRecordResponseV1({
         request,
         exchange,
         frameReservation,
-        signal: entry.controller.signal,
+        signal: pending.controller.signal,
       });
       wireBytes = transfer.wireBytes;
-      shared = retainVerifiedSystemRecordResponseV1({
+      const retained = retainVerifiedSystemRecordResponseV1({
         request,
         transfer,
         decodeAdmission: options.decodeAdmission,
         byteAdmission: options.byteAdmission,
       });
-      if (shared.outcome === 'ok') {
-        entry.retained = shared.retained;
-        retainedPayloadBytes += shared.retained.artifact.canonicalBytes.byteLength;
+      if (retained.outcome === 'ok') {
+        entry.phase = Object.freeze({ state: 'retained', source: retained.retained });
+        retainedPayloadBytes += retained.retained.artifact.canonicalBytes.byteLength;
+        shared = Object.freeze({ outcome: 'ok', wireBytes: retained.retained.wireBytes });
+      } else {
+        shared = retained;
       }
     } catch (error) {
       if (error instanceof SystemRecordRequesterTransferError) {
@@ -228,10 +240,10 @@ export function createSystemRecordRequesterV1(
       }
       const outcome = error instanceof InvalidSystemRecordResponseError
         ? 'invalid-response'
-        : entry.controller.signal.aborted
-          ? entry.abortReason === 'closed'
+        : pending.controller.signal.aborted
+          ? pending.abortReason === 'closed'
             ? 'closed'
-            : entry.abortReason === 'deadline'
+            : pending.abortReason === 'deadline'
               ? 'deadline'
               : 'transport'
           : 'transport';
@@ -239,7 +251,7 @@ export function createSystemRecordRequesterV1(
         exchange?.reset(
           outcome === 'invalid-response'
             ? 'invalid-response'
-            : entry.abortReason ?? outcome,
+            : pending.abortReason ?? outcome,
         );
       } catch {
         // Reset is best-effort cleanup and cannot strand the single-flight entry.
@@ -297,18 +309,19 @@ export function createSystemRecordRequesterV1(
   function abortIfUnobserved(entry: FetchEntryV1): void {
     if (entry.observerCount !== 0 || entry.leaseCount !== 0) return;
     if (entries.get(entry.key) !== entry) return;
-    if (entry.retained === undefined) {
+    if (entry.phase.state === 'pending') {
       abortEntry(entry, 'cancelled', new Error('system-record requester has no callers'));
     }
     releaseRetainedIfUnobserved(entry);
   }
 
   function releaseRetainedIfUnobserved(entry: FetchEntryV1): void {
-    if (entry.observerCount !== 0 || entry.leaseCount !== 0 || entry.retained === undefined) return;
+    if (entry.observerCount !== 0 || entry.leaseCount !== 0) return;
+    const phase = entry.phase;
+    if (phase.state !== 'retained') return;
     if (entries.get(entry.key) === entry) entries.delete(entry.key);
-    retainedPayloadBytes -= entry.retained.artifact.canonicalBytes.byteLength;
-    entry.retained.release();
-    entry.retained = undefined;
+    retainedPayloadBytes -= phase.source.artifact.canonicalBytes.byteLength;
+    phase.source.release();
   }
 
   function stats(): SystemRecordRequesterStatsV1 {
@@ -331,7 +344,7 @@ export function createSystemRecordRequesterV1(
     if (closed) return;
     closed = true;
     for (const entry of entries.values()) {
-      if (entry.retained === undefined) {
+      if (entry.phase.state === 'pending') {
         abortEntry(entry, 'closed', new Error('system-record requester closed'));
       }
     }
@@ -342,9 +355,10 @@ export function createSystemRecordRequesterV1(
     reason: SystemRecordRequesterResetReasonV1,
     error: Error,
   ): void {
-    if (entry.controller.signal.aborted) return;
-    entry.abortReason = reason;
-    entry.controller.abort(error);
+    const phase = entry.phase;
+    if (phase.state !== 'pending' || phase.controller.signal.aborted) return;
+    phase.abortReason = reason;
+    phase.controller.abort(error);
   }
 }
 

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -64,7 +64,6 @@ interface PendingFetchPhaseV1 {
   readonly state: 'pending';
   readonly controller: AbortController;
   readonly transfer: Promise<SystemRecordRequesterSettlementV1>;
-  abortReason?: SystemRecordRequesterResetReasonV1;
 }
 
 interface RetainedFetchPhaseV1 {
@@ -222,7 +221,6 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
   abort(reason: SystemRecordRequesterResetReasonV1, error: Error): void {
     const phase = this.#phase;
     if (phase.state !== 'pending' || phase.controller.signal.aborted) return;
-    phase.abortReason = reason;
     this.#lastResetReason = reason;
     phase.controller.abort(error);
   }
@@ -324,6 +322,11 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
 export function createSystemRecordRequesterV1(
   options: CreateSystemRecordRequesterOptionsV1,
 ): SystemRecordRequesterV1 {
+  const networkId = options.networkId;
+  const openExchange = options.openExchange;
+  const byteAdmission = options.byteAdmission;
+  const streamAdmission = options.streamAdmission;
+  const decodeAdmission = options.decodeAdmission;
   const requestId = options.requestId ?? (() => randomBytes(16).toString('hex'));
   const timeoutMs = boundedPositive(
     options.timeoutMs ?? SYSTEM_RECORD_PROVIDER_EXCHANGE_TIMEOUT_MS,
@@ -340,7 +343,7 @@ export function createSystemRecordRequesterV1(
     SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
     'maxWaitersPerDigest',
   );
-  const registry = new ExactFetchRegistryV1(options.byteAdmission);
+  const registry = new ExactFetchRegistryV1(byteAdmission);
   let started = 0;
   let joined = 0;
   let completed = 0;
@@ -356,8 +359,8 @@ export function createSystemRecordRequesterV1(
   ): Promise<SystemRecordExactFetchResultV1> {
     signal.throwIfAborted();
     if (closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
-    const exact = createSystemRecordExactRequestV1(options.networkId, lookup, requestId());
-    const { key, request } = exact;
+    const exact = createSystemRecordExactRequestV1(networkId, lookup, requestId());
+    const { key, request, requestFrame } = exact;
     let entry = registry.get(key);
     if (entry !== undefined) {
       if (entry.pendingAborted) {
@@ -373,9 +376,9 @@ export function createSystemRecordRequesterV1(
     if (registry.size >= maxTrackedDigests) {
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
     }
-    const streamPermit = options.streamAdmission.tryAcquire();
+    const streamPermit = streamAdmission.tryAcquire();
     if (streamPermit === null) return Object.freeze({ outcome: 'busy', wireBytes: 0 });
-    const frameReservation = options.byteAdmission.tryReserve(SYSTEM_RECORD_MAX_FRAME_BYTES);
+    const frameReservation = byteAdmission.tryReserve(SYSTEM_RECORD_MAX_FRAME_BYTES);
     if (frameReservation === null) {
       streamPermit.release();
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
@@ -385,6 +388,7 @@ export function createSystemRecordRequesterV1(
       (createdEntry, pendingSignal) => run(
         createdEntry,
         request,
+        requestFrame,
         pendingSignal,
         streamPermit,
         frameReservation,
@@ -399,6 +403,7 @@ export function createSystemRecordRequesterV1(
   async function run(
     entry: FetchEntryV1,
     request: SystemRecordRequestHeaderV1,
+    requestFrame: Uint8Array,
     pendingSignal: AbortSignal,
     streamPermit: SystemRecordRequesterPermitV1,
     frameReservation: SystemRecordRequesterByteReservationV1,
@@ -416,12 +421,13 @@ export function createSystemRecordRequesterV1(
     let settlement: SystemRecordRequesterSettlementV1;
     try {
       exchange = await openSystemRecordRequesterExchangeV1({
-        openExchange: options.openExchange,
+        openExchange,
         signal: pendingSignal,
         resetReason: () => entry.resetReason(),
       });
       const transfer = await exchangeSystemRecordResponseV1({
         request,
+        requestFrame,
         exchange,
         frameReservation,
         signal: pendingSignal,
@@ -430,8 +436,8 @@ export function createSystemRecordRequesterV1(
       const retained = retainVerifiedSystemRecordResponseV1({
         request,
         transfer,
-        decodeAdmission: options.decodeAdmission,
-        byteAdmission: options.byteAdmission,
+        decodeAdmission,
+        byteAdmission,
       });
       if (retained.outcome === 'ok') {
         settlement = Object.freeze({ state: 'retained', source: retained.retained });

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -178,6 +178,7 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
   #phase: FetchPhaseV1;
   #observerCount = 0;
   #leaseCount = 0;
+  #leaseDeliveries = 0;
   #retainedPayloadBytes = 0;
   #lastResetReason: SystemRecordRequesterResetReasonV1 = 'cancelled';
 
@@ -287,51 +288,65 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
     if (this.#phase.state !== 'retained' || this.#phase.source !== source) {
       throw new Error('System Record lease source is not retained by its entry');
     }
-    if (this.#leaseCount >= SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS + 1) {
+    if (this.#leaseCount + this.#leaseDeliveries
+      >= SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS + 1) {
       return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
     }
-    const payloadBytes = source.artifact.canonicalBytes.byteLength;
-    const reservation = this.#byteAdmission.tryReserve(payloadBytes);
-    if (signal.aborted) {
-      reservation?.release();
-      signal.throwIfAborted();
-    }
-    if (this.#registry.closed) {
-      reservation?.release();
-      return Object.freeze({ outcome: 'closed', wireBytes: source.wireBytes });
-    }
-    if (reservation === null) {
-      return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
-    }
-    let artifact: ReturnType<typeof cloneSystemRecordArtifactV1>;
+    this.#leaseDeliveries += 1;
+    let deliveryOwned = true;
     try {
-      artifact = cloneSystemRecordArtifactV1(source.artifact);
-    } catch {
-      reservation.release();
-      return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
+      const payloadBytes = source.artifact.canonicalBytes.byteLength;
+      const reservation = this.#byteAdmission.tryReserve(payloadBytes);
+      if (signal.aborted) {
+        reservation?.release();
+        signal.throwIfAborted();
+      }
+      if (this.#registry.closed) {
+        reservation?.release();
+        return Object.freeze({ outcome: 'closed', wireBytes: source.wireBytes });
+      }
+      if (reservation === null) {
+        return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
+      }
+      let artifact: ReturnType<typeof cloneSystemRecordArtifactV1>;
+      try {
+        artifact = cloneSystemRecordArtifactV1(source.artifact);
+      } catch {
+        reservation.release();
+        return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
+      }
+      this.#leaseDeliveries -= 1;
+      deliveryOwned = false;
+      this.#leaseCount += 1;
+      this.#retainedPayloadBytes += payloadBytes;
+      let released = false;
+      return Object.freeze({
+        outcome: 'ok',
+        lease: Object.freeze({
+          artifact,
+          wireBytes: source.wireBytes,
+          release: () => {
+            if (released) return;
+            released = true;
+            this.#leaseCount -= 1;
+            this.#retainedPayloadBytes -= payloadBytes;
+            reservation.release();
+            this.#disposeIfIdle();
+          },
+        }),
+      });
+    } finally {
+      if (deliveryOwned) {
+        this.#leaseDeliveries -= 1;
+        this.#disposeIfIdle();
+      }
     }
-    this.#leaseCount += 1;
-    this.#retainedPayloadBytes += payloadBytes;
-    let released = false;
-    return Object.freeze({
-      outcome: 'ok',
-      lease: Object.freeze({
-        artifact,
-        wireBytes: source.wireBytes,
-        release: () => {
-          if (released) return;
-          released = true;
-          this.#leaseCount -= 1;
-          this.#retainedPayloadBytes -= payloadBytes;
-          reservation.release();
-          this.#disposeIfIdle();
-        },
-      }),
-    });
   }
 
   #disposeIfIdle(): void {
-    if (this.#observerCount !== 0 || this.#leaseCount !== 0) return;
+    if (this.#observerCount !== 0
+      || this.#leaseCount !== 0
+      || this.#leaseDeliveries !== 0) return;
     const phase = this.#phase;
     if (phase.state === 'pending') {
       this.abort('cancelled', new Error('system-record requester has no callers'));
@@ -339,9 +354,12 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
     }
     if (phase.state === 'retained') {
       this.#retainedPayloadBytes -= phase.source.artifact.canonicalBytes.byteLength;
+      this.#phase = Object.freeze({ state: 'disposed' });
+      this.#registry.dispose(this);
       phase.source.release();
+      return;
     }
-    if (phase.state === 'retained' || phase.state === 'failed') {
+    if (phase.state === 'failed') {
       this.#phase = Object.freeze({ state: 'disposed' });
       this.#registry.dispose(this);
     }
@@ -536,10 +554,10 @@ export function createSystemRecordRequesterV1(
       });
     } finally {
       clearTimeout(timeout);
-      frameReservation.release();
-      streamPermit.release();
       activeStream = 0;
       completed += 1;
+      frameReservation.release();
+      streamPermit.release();
     }
     if (pendingSignal.aborted) {
       if (settlement.state === 'retained') settlement.source.release();

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -34,7 +34,7 @@ import {
 import {
   createSystemRecordExactRequestV1,
 } from './requester-wire-v1-internal.js';
-import { raceSystemRecordAbortV1 } from './transport-v1.js';
+import { raceSystemRecordAbortV1 } from './resource-admission-v1-internal.js';
 
 export type {
   CreateSystemRecordRequesterOptionsV1,
@@ -80,17 +80,26 @@ type FetchPhaseV1 = PendingFetchPhaseV1 | RetainedFetchPhaseV1 | SettledFetchPha
 
 interface FetchEntryV1 {
   readonly key: string;
-  phase: FetchPhaseV1;
-  observerCount: number;
-  leaseCount: number;
+  readonly pendingSignal: AbortSignal;
+  readonly participantCount: number;
+  readonly pendingAborted: boolean;
+  subscribe(signal: AbortSignal): Promise<SystemRecordExactFetchResultV1>;
+  completeRetained(source: SystemRecordRetainedSourceV1): SystemRecordRequesterSettlementV1;
+  completeFailure(result: SystemRecordRequesterFailureV1): SystemRecordRequesterSettlementV1;
+  abort(reason: SystemRecordRequesterResetReasonV1, error: Error): void;
+  resetReason(): SystemRecordRequesterResetReasonV1;
+  close(): void;
+  accounting(): Readonly<{
+    waitingCallers: number;
+    activeLeases: number;
+    retainedPayloadBytes: number;
+  }>;
 }
 
 class ExactFetchRegistryV1 {
   readonly #entries = new Map<string, FetchEntryV1>();
+  readonly #tracked = new Set<FetchEntryV1>();
   readonly #byteAdmission: SystemRecordRequesterByteAdmissionV1;
-  #waitingCallers = 0;
-  #activeLeases = 0;
-  #retainedPayloadBytes = 0;
 
   constructor(byteAdmission: SystemRecordRequesterByteAdmissionV1) {
     this.#byteAdmission = byteAdmission;
@@ -100,72 +109,164 @@ class ExactFetchRegistryV1 {
     return this.#entries.size;
   }
 
-  get waitingCallers(): number {
-    return this.#waitingCallers;
-  }
-
-  get activeLeases(): number {
-    return this.#activeLeases;
-  }
-
-  get retainedPayloadBytes(): number {
-    return this.#retainedPayloadBytes;
-  }
-
   get(key: string): FetchEntryV1 | undefined {
     return this.#entries.get(key);
   }
 
   create(key: string, pending: PendingFetchPhaseV1): FetchEntryV1 {
-    const entry: FetchEntryV1 = { key, phase: pending, observerCount: 0, leaseCount: 0 };
+    const entry = new ExactFetchEntryV1(key, pending, this.#byteAdmission, this);
     this.#entries.set(key, entry);
+    this.#tracked.add(entry);
     return entry;
   }
 
-  snapshot(entry: FetchEntryV1): FetchPhaseV1 {
-    return entry.phase;
+  stats(): Readonly<{
+    waitingCallers: number;
+    activeLeases: number;
+    retainedPayloadBytes: number;
+  }> {
+    let waitingCallers = 0;
+    let activeLeases = 0;
+    let retainedPayloadBytes = 0;
+    for (const entry of this.#tracked) {
+      const accounting = entry.accounting();
+      waitingCallers += accounting.waitingCallers;
+      activeLeases += accounting.activeLeases;
+      retainedPayloadBytes += accounting.retainedPayloadBytes;
+    }
+    return Object.freeze({ waitingCallers, activeLeases, retainedPayloadBytes });
   }
 
-  pendingAborted(entry: FetchEntryV1): boolean {
-    return entry.phase.state === 'pending' && entry.phase.controller.signal.aborted;
+  close(): void {
+    for (const entry of this.#tracked) entry.close();
   }
 
-  participantCount(entry: FetchEntryV1): number {
-    return entry.observerCount + entry.leaseCount;
+  unpublish(entry: FetchEntryV1): void {
+    if (this.#entries.get(entry.key) === entry) this.#entries.delete(entry.key);
   }
 
-  addObserver(entry: FetchEntryV1): void {
-    entry.observerCount += 1;
-    this.#waitingCallers += 1;
+  dispose(entry: FetchEntryV1): void {
+    this.unpublish(entry);
+    this.#tracked.delete(entry);
+  }
+}
+
+class ExactFetchEntryV1 implements FetchEntryV1 {
+  readonly key: string;
+  readonly #byteAdmission: SystemRecordRequesterByteAdmissionV1;
+  readonly #registry: ExactFetchRegistryV1;
+  #phase: FetchPhaseV1;
+  #observerCount = 0;
+  #leaseCount = 0;
+  #retainedPayloadBytes = 0;
+  #lastResetReason: SystemRecordRequesterResetReasonV1 = 'cancelled';
+
+  constructor(
+    key: string,
+    pending: PendingFetchPhaseV1,
+    byteAdmission: SystemRecordRequesterByteAdmissionV1,
+    registry: ExactFetchRegistryV1,
+  ) {
+    this.key = key;
+    this.#phase = pending;
+    this.#byteAdmission = byteAdmission;
+    this.#registry = registry;
   }
 
-  releaseObserver(entry: FetchEntryV1): void {
-    if (entry.observerCount < 1) throw new Error('System Record observer underflow');
-    entry.observerCount -= 1;
-    this.#waitingCallers -= 1;
-    this.#disposeIfIdle(entry);
+  get pendingSignal(): AbortSignal {
+    const phase = this.#phase;
+    if (phase.state !== 'pending') throw new Error('System Record entry is not pending');
+    return phase.controller.signal;
   }
 
-  retainSource(entry: FetchEntryV1, source: SystemRecordRetainedSourceV1): void {
-    if (entry.phase.state !== 'pending') {
+  get participantCount(): number {
+    return this.#observerCount + this.#leaseCount;
+  }
+
+  get pendingAborted(): boolean {
+    return this.#phase.state === 'pending' && this.#phase.controller.signal.aborted;
+  }
+
+  async subscribe(signal: AbortSignal): Promise<SystemRecordExactFetchResultV1> {
+    this.#observerCount += 1;
+    let observing = true;
+    const releaseObserver = () => {
+      if (!observing) return;
+      observing = false;
+      this.#observerCount -= 1;
+      this.#disposeIfIdle();
+    };
+    signal.addEventListener('abort', releaseObserver, { once: true });
+    if (signal.aborted) {
+      releaseObserver();
+      signal.throwIfAborted();
+    }
+    try {
+      const phase = this.#phase;
+      if (phase.state === 'retained') return this.#deliverLease(phase.source);
+      if (phase.state !== 'pending') {
+        return Object.freeze({ outcome: 'busy', wireBytes: 0 });
+      }
+      const shared = await raceSystemRecordAbortV1(phase.transfer, signal);
+      return shared.state === 'retained'
+        ? this.#deliverLease(shared.source)
+        : shared.result;
+    } finally {
+      signal.removeEventListener('abort', releaseObserver);
+      releaseObserver();
+    }
+  }
+
+  completeRetained(source: SystemRecordRetainedSourceV1): SystemRecordRequesterSettlementV1 {
+    if (this.#phase.state !== 'pending') {
       source.release();
       throw new Error('System Record source retained outside the pending phase');
     }
-    entry.phase = Object.freeze({ state: 'retained', source });
+    this.#phase = Object.freeze({ state: 'retained', source });
     this.#retainedPayloadBytes += source.artifact.canonicalBytes.byteLength;
+    return Object.freeze({ state: 'retained', source });
   }
 
-  settleFailure(entry: FetchEntryV1): void {
-    if (entry.phase.state !== 'pending') return;
-    entry.phase = Object.freeze({ state: 'failed' });
-    this.#remove(entry);
+  completeFailure(result: SystemRecordRequesterFailureV1): SystemRecordRequesterSettlementV1 {
+    if (this.#phase.state !== 'pending') {
+      throw new Error('System Record failure completed outside the pending phase');
+    }
+    this.#phase = Object.freeze({ state: 'failed' });
+    this.#registry.unpublish(this);
+    this.#disposeIfIdle();
+    return Object.freeze({ state: 'failed', result });
   }
 
-  deliverLease(
-    entry: FetchEntryV1,
-    source: SystemRecordRetainedSourceV1,
-  ): SystemRecordExactFetchResultV1 {
-    if (entry.phase.state !== 'retained' || entry.phase.source !== source) {
+  abort(reason: SystemRecordRequesterResetReasonV1, error: Error): void {
+    const phase = this.#phase;
+    if (phase.state !== 'pending' || phase.controller.signal.aborted) return;
+    phase.abortReason = reason;
+    this.#lastResetReason = reason;
+    phase.controller.abort(error);
+  }
+
+  resetReason(): SystemRecordRequesterResetReasonV1 {
+    return this.#lastResetReason;
+  }
+
+  close(): void {
+    this.abort('closed', new Error('system-record requester closed'));
+  }
+
+  accounting(): Readonly<{
+    waitingCallers: number;
+    activeLeases: number;
+    retainedPayloadBytes: number;
+  }> {
+    return Object.freeze({
+      waitingCallers: this.#observerCount,
+      activeLeases: this.#leaseCount,
+      retainedPayloadBytes: this.#retainedPayloadBytes,
+    });
+  }
+
+  #deliverLease(source: SystemRecordRetainedSourceV1): SystemRecordExactFetchResultV1 {
+    if (this.#phase.state !== 'retained' || this.#phase.source !== source) {
       throw new Error('System Record lease source is not retained by its entry');
     }
     const payloadBytes = source.artifact.canonicalBytes.byteLength;
@@ -180,8 +281,7 @@ class ExactFetchRegistryV1 {
       reservation.release();
       return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
     }
-    entry.leaseCount += 1;
-    this.#activeLeases += 1;
+    this.#leaseCount += 1;
     this.#retainedPayloadBytes += payloadBytes;
     let released = false;
     return Object.freeze({
@@ -192,49 +292,30 @@ class ExactFetchRegistryV1 {
         release: () => {
           if (released) return;
           released = true;
-          entry.leaseCount -= 1;
-          this.#activeLeases -= 1;
+          this.#leaseCount -= 1;
           this.#retainedPayloadBytes -= payloadBytes;
           reservation.release();
-          this.#disposeIfIdle(entry);
+          this.#disposeIfIdle();
         },
       }),
     });
   }
 
-  abort(
-    entry: FetchEntryV1,
-    reason: SystemRecordRequesterResetReasonV1,
-    error: Error,
-  ): void {
-    const phase = entry.phase;
-    if (phase.state !== 'pending' || phase.controller.signal.aborted) return;
-    phase.abortReason = reason;
-    phase.controller.abort(error);
-  }
-
-  close(): void {
-    for (const entry of this.#entries.values()) {
-      this.abort(entry, 'closed', new Error('system-record requester closed'));
-    }
-  }
-
-  #disposeIfIdle(entry: FetchEntryV1): void {
-    if (entry.observerCount !== 0 || entry.leaseCount !== 0) return;
-    const phase = entry.phase;
+  #disposeIfIdle(): void {
+    if (this.#observerCount !== 0 || this.#leaseCount !== 0) return;
+    const phase = this.#phase;
     if (phase.state === 'pending') {
-      this.abort(entry, 'cancelled', new Error('system-record requester has no callers'));
+      this.abort('cancelled', new Error('system-record requester has no callers'));
       return;
     }
-    if (phase.state !== 'retained') return;
-    entry.phase = Object.freeze({ state: 'disposed' });
-    this.#remove(entry);
-    this.#retainedPayloadBytes -= phase.source.artifact.canonicalBytes.byteLength;
-    phase.source.release();
-  }
-
-  #remove(entry: FetchEntryV1): void {
-    if (this.#entries.get(entry.key) === entry) this.#entries.delete(entry.key);
+    if (phase.state === 'retained') {
+      this.#retainedPayloadBytes -= phase.source.artifact.canonicalBytes.byteLength;
+      phase.source.release();
+    }
+    if (phase.state === 'retained' || phase.state === 'failed') {
+      this.#phase = Object.freeze({ state: 'disposed' });
+      this.#registry.dispose(this);
+    }
   }
 }
 
@@ -281,15 +362,15 @@ export function createSystemRecordRequesterV1(
     const { key, request } = exact;
     let entry = registry.get(key);
     if (entry !== undefined) {
-      if (registry.pendingAborted(entry)) {
+      if (entry.pendingAborted) {
         return Object.freeze({ outcome: 'busy', wireBytes: 0 });
       }
       // The first observer owns the transfer; the frozen limit counts followers.
-      if (registry.participantCount(entry) >= maxWaitersPerDigest + 1) {
+      if (entry.participantCount >= maxWaitersPerDigest + 1) {
         return Object.freeze({ outcome: 'waiter-limit', wireBytes: 0 });
       }
       joined += 1;
-      return subscribe(entry, signal);
+      return entry.subscribe(signal);
     }
     if (registry.size >= maxPendingDigests) {
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
@@ -322,41 +403,7 @@ export function createSystemRecordRequesterV1(
       resolveTransfer,
       rejectTransfer,
     );
-    return subscribe(entry, signal);
-  }
-
-  async function subscribe(
-    entry: FetchEntryV1,
-    signal: AbortSignal,
-  ): Promise<SystemRecordExactFetchResultV1> {
-    registry.addObserver(entry);
-    let observing = true;
-    const releaseObserver = () => {
-      if (!observing) return;
-      observing = false;
-      registry.releaseObserver(entry);
-    };
-    signal.addEventListener('abort', releaseObserver, { once: true });
-    if (signal.aborted) {
-      releaseObserver();
-      signal.throwIfAborted();
-    }
-    try {
-      const phase = registry.snapshot(entry);
-      if (phase.state === 'retained') {
-        return registry.deliverLease(entry, phase.source);
-      }
-      if (phase.state !== 'pending') {
-        return Object.freeze({ outcome: 'busy', wireBytes: 0 });
-      }
-      const shared = await raceSystemRecordAbortV1(phase.transfer, signal);
-      return shared.state === 'retained'
-        ? registry.deliverLease(entry, shared.source)
-        : shared.result;
-    } finally {
-      signal.removeEventListener('abort', releaseObserver);
-      releaseObserver();
-    }
+    return entry.subscribe(signal);
   }
 
   async function run(
@@ -365,15 +412,11 @@ export function createSystemRecordRequesterV1(
     streamPermit: SystemRecordRequesterPermitV1,
     frameReservation: SystemRecordRequesterByteReservationV1,
   ): Promise<SystemRecordRequesterSettlementV1> {
-    const pending = registry.snapshot(entry);
-    if (pending.state !== 'pending') {
-      throw new Error('System Record transfer started outside the pending phase');
-    }
+    const pendingSignal = entry.pendingSignal;
     let exchange: SystemRecordRequesterExchangeV1 | undefined;
     let wireBytes = 0;
     const timeout = setTimeout(
-      () => registry.abort(
-        entry,
+      () => entry.abort(
         'deadline',
         new Error('system-record requester deadline exceeded'),
       ),
@@ -384,14 +427,14 @@ export function createSystemRecordRequesterV1(
     try {
       exchange = await openSystemRecordRequesterExchangeV1({
         openExchange: options.openExchange,
-        signal: pending.controller.signal,
-        resetReason: () => pending.abortReason ?? 'cancelled',
+        signal: pendingSignal,
+        resetReason: () => entry.resetReason(),
       });
       const transfer = await exchangeSystemRecordResponseV1({
         request,
         exchange,
         frameReservation,
-        signal: pending.controller.signal,
+        signal: pendingSignal,
       });
       wireBytes = transfer.wireBytes;
       const retained = retainVerifiedSystemRecordResponseV1({
@@ -401,8 +444,7 @@ export function createSystemRecordRequesterV1(
         byteAdmission: options.byteAdmission,
       });
       if (retained.outcome === 'ok') {
-        registry.retainSource(entry, retained.retained);
-        settlement = Object.freeze({ state: 'retained', source: retained.retained });
+        settlement = entry.completeRetained(retained.retained);
       } else {
         settlement = Object.freeze({ state: 'failed', result: retained });
       }
@@ -412,10 +454,10 @@ export function createSystemRecordRequesterV1(
       }
       const outcome = error instanceof InvalidSystemRecordResponseError
         ? 'invalid-response'
-        : pending.controller.signal.aborted
-          ? pending.abortReason === 'closed'
+        : pendingSignal.aborted
+          ? entry.resetReason() === 'closed'
             ? 'closed'
-            : pending.abortReason === 'deadline'
+            : entry.resetReason() === 'deadline'
               ? 'deadline'
               : 'transport'
           : 'transport';
@@ -423,7 +465,7 @@ export function createSystemRecordRequesterV1(
         exchange?.reset(
           outcome === 'invalid-response'
             ? 'invalid-response'
-            : pending.abortReason ?? outcome,
+            : pendingSignal.aborted ? entry.resetReason() : outcome,
         );
       } catch {
         // Reset is best-effort cleanup and cannot strand the single-flight entry.
@@ -439,22 +481,24 @@ export function createSystemRecordRequesterV1(
       activeStream = 0;
       completed += 1;
     }
-    if (settlement.state === 'failed') registry.settleFailure(entry);
-    return settlement;
+    return settlement.state === 'failed'
+      ? entry.completeFailure(settlement.result)
+      : settlement;
   }
 
   function stats(): SystemRecordRequesterStatsV1 {
+    const entryStats = registry.stats();
     return Object.freeze({
       started,
       joined,
       completed,
       pendingDigests: registry.size,
-      waitingCallers: registry.waitingCallers,
-      activeLeases: registry.activeLeases,
+      waitingCallers: entryStats.waitingCallers,
+      activeLeases: entryStats.activeLeases,
       activeStream,
       peakActiveStream,
       queuedStreams: 0,
-      retainedPayloadBytes: registry.retainedPayloadBytes,
+      retainedPayloadBytes: entryStats.retainedPayloadBytes,
       closed,
     });
   }

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -34,6 +34,7 @@ import {
 } from './requester-transfer-v1-internal.js';
 import {
   createSystemRecordExactRequestV1,
+  normalizeSystemRecordExactLookupV1,
 } from './requester-wire-v1-internal.js';
 import { raceSystemRecordAbortV1 } from './resource-admission-v1-internal.js';
 
@@ -89,7 +90,7 @@ type FetchPhaseV1 = PendingFetchPhaseV1 | RetainedFetchPhaseV1 | SettledFetchPha
 
 interface FetchEntryV1 {
   readonly key: string;
-  readonly participantCount: number;
+  readonly pendingParticipantCount: number;
   readonly pendingAborted: boolean;
   subscribe(signal: AbortSignal): Promise<SystemRecordExactFetchResultV1>;
   abort(reason: SystemRecordRequesterResetReasonV1, error: Error): void;
@@ -199,8 +200,8 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
     this.#phase = { state: 'pending', controller, transfer };
   }
 
-  get participantCount(): number {
-    return this.#observerCount + this.#leaseCount;
+  get pendingParticipantCount(): number {
+    return this.#phase.state === 'pending' ? this.#observerCount : 0;
   }
 
   get pendingAborted(): boolean {
@@ -285,6 +286,9 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
   ): SystemRecordExactFetchResultV1 {
     if (this.#phase.state !== 'retained' || this.#phase.source !== source) {
       throw new Error('System Record lease source is not retained by its entry');
+    }
+    if (this.#leaseCount >= SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS + 1) {
+      return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
     }
     const payloadBytes = source.artifact.canonicalBytes.byteLength;
     const reservation = this.#byteAdmission.tryReserve(payloadBytes);
@@ -388,17 +392,17 @@ export function createSystemRecordRequesterV1(
   ): Promise<SystemRecordExactFetchResultV1> {
     signal.throwIfAborted();
     if (registry.closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
-    const exact = createSystemRecordExactRequestV1(networkId, lookup, requestId());
+    const normalized = normalizeSystemRecordExactLookupV1(networkId, lookup);
     signal.throwIfAborted();
     if (registry.closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
-    const { key, request, requestFrame } = exact;
+    const { key } = normalized;
     let entry = registry.get(key);
     if (entry !== undefined) {
       if (entry.pendingAborted) {
         return Object.freeze({ outcome: 'busy', wireBytes: 0 });
       }
       // The first observer owns the transfer; the frozen limit counts followers.
-      if (entry.participantCount >= maxWaitersPerDigest + 1) {
+      if (entry.pendingParticipantCount >= maxWaitersPerDigest + 1) {
         return Object.freeze({ outcome: 'waiter-limit', wireBytes: 0 });
       }
       joined += 1;
@@ -407,6 +411,12 @@ export function createSystemRecordRequesterV1(
     if (registry.size >= maxTrackedDigests) {
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
     }
+    const { request, requestFrame } = createSystemRecordExactRequestV1(
+      normalized,
+      requestId(),
+    );
+    signal.throwIfAborted();
+    if (registry.closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
     const admission = admitLeader(signal);
     if (admission.state !== 'admitted') {
       return Object.freeze({ outcome: admission.state, wireBytes: 0 });

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -193,6 +193,7 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
   }
 
   async subscribe(signal: AbortSignal): Promise<SystemRecordExactFetchResultV1> {
+    if (signal.aborted) this.#disposeIfIdle();
     signal.throwIfAborted();
     this.#observerCount += 1;
     let observing = true;
@@ -451,27 +452,20 @@ export function createSystemRecordRequesterV1(
       if (error instanceof SystemRecordRequesterTransferError) {
         wireBytes = error.wireBytes;
       }
-      const outcome = error instanceof InvalidSystemRecordResponseError
-        ? 'invalid-response'
-        : pendingSignal.aborted
-          ? entry.resetReason() === 'closed'
-            ? 'closed'
-            : entry.resetReason() === 'deadline'
-              ? 'deadline'
-              : 'transport'
-          : 'transport';
+      const failure = classifyRequesterFailure(
+        error,
+        pendingSignal,
+        entry.resetReason(),
+        wireBytes,
+      );
       try {
-        exchange?.reset(
-          outcome === 'invalid-response'
-            ? 'invalid-response'
-            : pendingSignal.aborted ? entry.resetReason() : outcome,
-        );
+        exchange?.reset(failure.resetReason);
       } catch {
         // Reset is best-effort cleanup and cannot strand the single-flight entry.
       }
       settlement = Object.freeze({
         state: 'failed',
-        result: Object.freeze({ outcome, wireBytes }),
+        result: failure.result,
       });
     } finally {
       clearTimeout(timeout);
@@ -505,6 +499,38 @@ export function createSystemRecordRequesterV1(
     closed = true;
     registry.close();
   }
+}
+
+function classifyRequesterFailure(
+  error: unknown,
+  pendingSignal: AbortSignal,
+  resetReason: SystemRecordRequesterResetReasonV1,
+  wireBytes: number,
+): Readonly<{
+  result: SystemRecordRequesterFailureV1;
+  resetReason: SystemRecordRequesterResetReasonV1;
+}> {
+  if (error instanceof InvalidSystemRecordResponseError) {
+    return Object.freeze({
+      result: Object.freeze({ outcome: 'invalid-response', wireBytes }),
+      resetReason: 'invalid-response',
+    });
+  }
+  if (!pendingSignal.aborted) {
+    return Object.freeze({
+      result: Object.freeze({ outcome: 'transport', wireBytes }),
+      resetReason: 'transport',
+    });
+  }
+  const outcome = resetReason === 'closed'
+    ? 'closed'
+    : resetReason === 'deadline'
+      ? 'deadline'
+      : 'transport';
+  return Object.freeze({
+    result: Object.freeze({ outcome, wireBytes }),
+    resetReason,
+  });
 }
 
 function boundedPositive(value: number, maximum: number, label: string): number {

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -87,7 +87,6 @@ export function createSystemRecordRequesterV1(
 
   async function fetch(
     lookup: SystemRecordExactArtifactLookupV1,
-    openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>,
     signal: AbortSignal,
   ): Promise<SystemRecordExactFetchResultV1> {
     signal.throwIfAborted();
@@ -133,7 +132,7 @@ export function createSystemRecordRequesterV1(
     started += 1;
     activeStream = 1;
     peakActiveStream = 1;
-    void run(entry, request, openExchange, streamPermit, frameReservation).then(
+    void run(entry, request, streamPermit, frameReservation).then(
       resolveTransfer,
       rejectTransfer,
     );
@@ -168,10 +167,27 @@ export function createSystemRecordRequesterV1(
     }
   }
 
+  async function openRequesterExchangeV1(
+    entry: FetchEntryV1,
+  ): Promise<SystemRecordRequesterExchangeV1> {
+    const opening = options.openExchange(entry.controller.signal);
+    let accepted = false;
+    void opening.then((lateExchange) => {
+      if (accepted || !entry.controller.signal.aborted) return;
+      try {
+        lateExchange.reset(entry.abortReason ?? 'cancelled');
+      } catch {
+        // A late transport owns no requester resources; reset remains best-effort.
+      }
+    }, () => undefined);
+    const exchange = await raceSystemRecordAbortV1(opening, entry.controller.signal);
+    accepted = true;
+    return exchange;
+  }
+
   async function run(
     entry: FetchEntryV1,
     request: SystemRecordRequestHeaderV1,
-    openExchange: (signal: AbortSignal) => Promise<SystemRecordRequesterExchangeV1>,
     streamPermit: SystemRecordRequesterPermitV1,
     frameReservation: SystemRecordRequesterByteReservationV1,
   ): Promise<SystemRecordRequesterSettlementV1> {
@@ -188,10 +204,7 @@ export function createSystemRecordRequesterV1(
     timeout.unref?.();
     let shared: SystemRecordRequesterSettlementV1;
     try {
-      exchange = await raceSystemRecordAbortV1(
-        openExchange(entry.controller.signal),
-        entry.controller.signal,
-      );
+      exchange = await openRequesterExchangeV1(entry);
       const transfer = await exchangeSystemRecordResponseV1({
         request,
         exchange,
@@ -294,8 +307,7 @@ export function createSystemRecordRequesterV1(
     if (entry.observerCount !== 0 || entry.leaseCount !== 0 || entry.retained === undefined) return;
     if (entries.get(entry.key) === entry) entries.delete(entry.key);
     retainedPayloadBytes -= entry.retained.artifact.canonicalBytes.byteLength;
-    entry.retained.reservation.release();
-    entry.retained.decodePermit.release();
+    entry.retained.release();
     entry.retained = undefined;
   }
 

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -36,6 +36,21 @@ import {
 } from './requester-wire-v1-internal.js';
 import { raceSystemRecordAbortV1 } from './transport-v1.js';
 
+export type {
+  CreateSystemRecordRequesterOptionsV1,
+  SystemRecordExactArtifactLookupV1,
+  SystemRecordExactFetchLeaseV1,
+  SystemRecordExactFetchResultV1,
+  SystemRecordRequesterAdmissionV1,
+  SystemRecordRequesterByteAdmissionV1,
+  SystemRecordRequesterByteReservationV1,
+  SystemRecordRequesterExchangeV1,
+  SystemRecordRequesterPermitV1,
+  SystemRecordRequesterResetReasonV1,
+  SystemRecordRequesterStatsV1,
+  SystemRecordRequesterV1,
+} from './requester-api-v1.js';
+
 type SystemRecordRequesterFailureV1 = Exclude<
   SystemRecordExactFetchResultV1,
   Readonly<{ outcome: 'ok' }>
@@ -63,78 +78,98 @@ interface SettledFetchPhaseV1 {
 
 type FetchPhaseV1 = PendingFetchPhaseV1 | RetainedFetchPhaseV1 | SettledFetchPhaseV1;
 
-interface FetchEntryAccountingV1 {
-  observerDelta(delta: 1 | -1): void;
-  leaseDelta(delta: 1 | -1): void;
-  retainedBytesDelta(delta: number): void;
-  remove(entry: FetchEntryV1): void;
+interface FetchEntryV1 {
+  readonly key: string;
+  phase: FetchPhaseV1;
+  observerCount: number;
+  leaseCount: number;
 }
 
-class FetchEntryV1 {
-  readonly key: string;
-  #phase: FetchPhaseV1;
-  #observerCount = 0;
-  #leaseCount = 0;
-  readonly #accounting: FetchEntryAccountingV1;
+class ExactFetchRegistryV1 {
+  readonly #entries = new Map<string, FetchEntryV1>();
+  readonly #byteAdmission: SystemRecordRequesterByteAdmissionV1;
+  #waitingCallers = 0;
+  #activeLeases = 0;
+  #retainedPayloadBytes = 0;
 
-  constructor(
-    key: string,
-    pending: PendingFetchPhaseV1,
-    accounting: FetchEntryAccountingV1,
-  ) {
-    this.key = key;
-    this.#phase = pending;
-    this.#accounting = accounting;
+  constructor(byteAdmission: SystemRecordRequesterByteAdmissionV1) {
+    this.#byteAdmission = byteAdmission;
   }
 
-  get participantCount(): number {
-    return this.#observerCount + this.#leaseCount;
+  get size(): number {
+    return this.#entries.size;
   }
 
-  get pendingAborted(): boolean {
-    return this.#phase.state === 'pending' && this.#phase.controller.signal.aborted;
+  get waitingCallers(): number {
+    return this.#waitingCallers;
   }
 
-  snapshot(): FetchPhaseV1 {
-    return this.#phase;
+  get activeLeases(): number {
+    return this.#activeLeases;
   }
 
-  addObserver(): void {
-    this.#observerCount += 1;
-    this.#accounting.observerDelta(1);
+  get retainedPayloadBytes(): number {
+    return this.#retainedPayloadBytes;
   }
 
-  releaseObserver(): void {
-    if (this.#observerCount < 1) throw new Error('System Record observer underflow');
-    this.#observerCount -= 1;
-    this.#accounting.observerDelta(-1);
-    this.#disposeIfIdle();
+  get(key: string): FetchEntryV1 | undefined {
+    return this.#entries.get(key);
   }
 
-  retainSource(source: SystemRecordRetainedSourceV1): void {
-    if (this.#phase.state !== 'pending') {
+  create(key: string, pending: PendingFetchPhaseV1): FetchEntryV1 {
+    const entry: FetchEntryV1 = { key, phase: pending, observerCount: 0, leaseCount: 0 };
+    this.#entries.set(key, entry);
+    return entry;
+  }
+
+  snapshot(entry: FetchEntryV1): FetchPhaseV1 {
+    return entry.phase;
+  }
+
+  pendingAborted(entry: FetchEntryV1): boolean {
+    return entry.phase.state === 'pending' && entry.phase.controller.signal.aborted;
+  }
+
+  participantCount(entry: FetchEntryV1): number {
+    return entry.observerCount + entry.leaseCount;
+  }
+
+  addObserver(entry: FetchEntryV1): void {
+    entry.observerCount += 1;
+    this.#waitingCallers += 1;
+  }
+
+  releaseObserver(entry: FetchEntryV1): void {
+    if (entry.observerCount < 1) throw new Error('System Record observer underflow');
+    entry.observerCount -= 1;
+    this.#waitingCallers -= 1;
+    this.#disposeIfIdle(entry);
+  }
+
+  retainSource(entry: FetchEntryV1, source: SystemRecordRetainedSourceV1): void {
+    if (entry.phase.state !== 'pending') {
       source.release();
       throw new Error('System Record source retained outside the pending phase');
     }
-    this.#phase = Object.freeze({ state: 'retained', source });
-    this.#accounting.retainedBytesDelta(source.artifact.canonicalBytes.byteLength);
+    entry.phase = Object.freeze({ state: 'retained', source });
+    this.#retainedPayloadBytes += source.artifact.canonicalBytes.byteLength;
   }
 
-  settleFailure(): void {
-    if (this.#phase.state !== 'pending') return;
-    this.#phase = Object.freeze({ state: 'failed' });
-    this.#accounting.remove(this);
+  settleFailure(entry: FetchEntryV1): void {
+    if (entry.phase.state !== 'pending') return;
+    entry.phase = Object.freeze({ state: 'failed' });
+    this.#remove(entry);
   }
 
   deliverLease(
+    entry: FetchEntryV1,
     source: SystemRecordRetainedSourceV1,
-    byteAdmission: SystemRecordRequesterByteAdmissionV1,
   ): SystemRecordExactFetchResultV1 {
-    if (this.#phase.state !== 'retained' || this.#phase.source !== source) {
+    if (entry.phase.state !== 'retained' || entry.phase.source !== source) {
       throw new Error('System Record lease source is not retained by its entry');
     }
     const payloadBytes = source.artifact.canonicalBytes.byteLength;
-    const reservation = byteAdmission.tryReserve(payloadBytes);
+    const reservation = this.#byteAdmission.tryReserve(payloadBytes);
     if (reservation === null) {
       return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
     }
@@ -145,9 +180,9 @@ class FetchEntryV1 {
       reservation.release();
       return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
     }
-    this.#leaseCount += 1;
-    this.#accounting.leaseDelta(1);
-    this.#accounting.retainedBytesDelta(payloadBytes);
+    entry.leaseCount += 1;
+    this.#activeLeases += 1;
+    this.#retainedPayloadBytes += payloadBytes;
     let released = false;
     return Object.freeze({
       outcome: 'ok',
@@ -157,39 +192,49 @@ class FetchEntryV1 {
         release: () => {
           if (released) return;
           released = true;
-          this.#leaseCount -= 1;
-          this.#accounting.leaseDelta(-1);
-          this.#accounting.retainedBytesDelta(-payloadBytes);
+          entry.leaseCount -= 1;
+          this.#activeLeases -= 1;
+          this.#retainedPayloadBytes -= payloadBytes;
           reservation.release();
-          this.#disposeIfIdle();
+          this.#disposeIfIdle(entry);
         },
       }),
     });
   }
 
-  abort(reason: SystemRecordRequesterResetReasonV1, error: Error): void {
-    const phase = this.#phase;
+  abort(
+    entry: FetchEntryV1,
+    reason: SystemRecordRequesterResetReasonV1,
+    error: Error,
+  ): void {
+    const phase = entry.phase;
     if (phase.state !== 'pending' || phase.controller.signal.aborted) return;
     phase.abortReason = reason;
     phase.controller.abort(error);
   }
 
   close(): void {
-    this.abort('closed', new Error('system-record requester closed'));
+    for (const entry of this.#entries.values()) {
+      this.abort(entry, 'closed', new Error('system-record requester closed'));
+    }
   }
 
-  #disposeIfIdle(): void {
-    if (this.#observerCount !== 0 || this.#leaseCount !== 0) return;
-    const phase = this.#phase;
+  #disposeIfIdle(entry: FetchEntryV1): void {
+    if (entry.observerCount !== 0 || entry.leaseCount !== 0) return;
+    const phase = entry.phase;
     if (phase.state === 'pending') {
-      this.abort('cancelled', new Error('system-record requester has no callers'));
+      this.abort(entry, 'cancelled', new Error('system-record requester has no callers'));
       return;
     }
     if (phase.state !== 'retained') return;
-    this.#phase = Object.freeze({ state: 'disposed' });
-    this.#accounting.remove(this);
-    this.#accounting.retainedBytesDelta(-phase.source.artifact.canonicalBytes.byteLength);
+    entry.phase = Object.freeze({ state: 'disposed' });
+    this.#remove(entry);
+    this.#retainedPayloadBytes -= phase.source.artifact.canonicalBytes.byteLength;
     phase.source.release();
+  }
+
+  #remove(entry: FetchEntryV1): void {
+    if (this.#entries.get(entry.key) === entry) this.#entries.delete(entry.key);
   }
 }
 
@@ -216,30 +261,13 @@ export function createSystemRecordRequesterV1(
     SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
     'maxWaitersPerDigest',
   );
-  const entries = new Map<string, FetchEntryV1>();
+  const registry = new ExactFetchRegistryV1(options.byteAdmission);
   let started = 0;
   let joined = 0;
   let completed = 0;
-  let waitingCallers = 0;
-  let activeLeases = 0;
   let activeStream: 0 | 1 = 0;
   let peakActiveStream: 0 | 1 = 0;
-  let retainedPayloadBytes = 0;
   let closed = false;
-  const entryAccounting: FetchEntryAccountingV1 = {
-    observerDelta(delta) {
-      waitingCallers += delta;
-    },
-    leaseDelta(delta) {
-      activeLeases += delta;
-    },
-    retainedBytesDelta(delta) {
-      retainedPayloadBytes += delta;
-    },
-    remove(entry) {
-      if (entries.get(entry.key) === entry) entries.delete(entry.key);
-    },
-  };
 
   return Object.freeze({ fetch, stats, close });
 
@@ -251,19 +279,19 @@ export function createSystemRecordRequesterV1(
     if (closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
     const exact = createSystemRecordExactRequestV1(options.networkId, lookup, requestId());
     const { key, request } = exact;
-    let entry = entries.get(key);
+    let entry = registry.get(key);
     if (entry !== undefined) {
-      if (entry.pendingAborted) {
+      if (registry.pendingAborted(entry)) {
         return Object.freeze({ outcome: 'busy', wireBytes: 0 });
       }
       // The first observer owns the transfer; the frozen limit counts followers.
-      if (entry.participantCount >= maxWaitersPerDigest + 1) {
+      if (registry.participantCount(entry) >= maxWaitersPerDigest + 1) {
         return Object.freeze({ outcome: 'waiter-limit', wireBytes: 0 });
       }
       joined += 1;
       return subscribe(entry, signal);
     }
-    if (entries.size >= maxPendingDigests) {
+    if (registry.size >= maxPendingDigests) {
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
     }
     const streamPermit = options.streamAdmission.tryAcquire();
@@ -279,16 +307,14 @@ export function createSystemRecordRequesterV1(
       resolveTransfer = resolve;
       rejectTransfer = reject;
     });
-    entry = new FetchEntryV1(
+    entry = registry.create(
       key,
       {
         state: 'pending',
         controller: new AbortController(),
         transfer,
       },
-      entryAccounting,
     );
-    entries.set(key, entry);
     started += 1;
     activeStream = 1;
     peakActiveStream = 1;
@@ -303,12 +329,12 @@ export function createSystemRecordRequesterV1(
     entry: FetchEntryV1,
     signal: AbortSignal,
   ): Promise<SystemRecordExactFetchResultV1> {
-    entry.addObserver();
+    registry.addObserver(entry);
     let observing = true;
     const releaseObserver = () => {
       if (!observing) return;
       observing = false;
-      entry.releaseObserver();
+      registry.releaseObserver(entry);
     };
     signal.addEventListener('abort', releaseObserver, { once: true });
     if (signal.aborted) {
@@ -316,16 +342,16 @@ export function createSystemRecordRequesterV1(
       signal.throwIfAborted();
     }
     try {
-      const phase = entry.snapshot();
+      const phase = registry.snapshot(entry);
       if (phase.state === 'retained') {
-        return entry.deliverLease(phase.source, options.byteAdmission);
+        return registry.deliverLease(entry, phase.source);
       }
       if (phase.state !== 'pending') {
         return Object.freeze({ outcome: 'busy', wireBytes: 0 });
       }
       const shared = await raceSystemRecordAbortV1(phase.transfer, signal);
       return shared.state === 'retained'
-        ? entry.deliverLease(shared.source, options.byteAdmission)
+        ? registry.deliverLease(entry, shared.source)
         : shared.result;
     } finally {
       signal.removeEventListener('abort', releaseObserver);
@@ -339,14 +365,15 @@ export function createSystemRecordRequesterV1(
     streamPermit: SystemRecordRequesterPermitV1,
     frameReservation: SystemRecordRequesterByteReservationV1,
   ): Promise<SystemRecordRequesterSettlementV1> {
-    const pending = entry.snapshot();
+    const pending = registry.snapshot(entry);
     if (pending.state !== 'pending') {
       throw new Error('System Record transfer started outside the pending phase');
     }
     let exchange: SystemRecordRequesterExchangeV1 | undefined;
     let wireBytes = 0;
     const timeout = setTimeout(
-      () => entry.abort(
+      () => registry.abort(
+        entry,
         'deadline',
         new Error('system-record requester deadline exceeded'),
       ),
@@ -374,7 +401,7 @@ export function createSystemRecordRequesterV1(
         byteAdmission: options.byteAdmission,
       });
       if (retained.outcome === 'ok') {
-        entry.retainSource(retained.retained);
+        registry.retainSource(entry, retained.retained);
         settlement = Object.freeze({ state: 'retained', source: retained.retained });
       } else {
         settlement = Object.freeze({ state: 'failed', result: retained });
@@ -412,7 +439,7 @@ export function createSystemRecordRequesterV1(
       activeStream = 0;
       completed += 1;
     }
-    if (settlement.state === 'failed') entry.settleFailure();
+    if (settlement.state === 'failed') registry.settleFailure(entry);
     return settlement;
   }
 
@@ -421,13 +448,13 @@ export function createSystemRecordRequesterV1(
       started,
       joined,
       completed,
-      pendingDigests: entries.size,
-      waitingCallers,
-      activeLeases,
+      pendingDigests: registry.size,
+      waitingCallers: registry.waitingCallers,
+      activeLeases: registry.activeLeases,
       activeStream,
       peakActiveStream,
       queuedStreams: 0,
-      retainedPayloadBytes,
+      retainedPayloadBytes: registry.retainedPayloadBytes,
       closed,
     });
   }
@@ -435,9 +462,7 @@ export function createSystemRecordRequesterV1(
   function close(): void {
     if (closed) return;
     closed = true;
-    for (const entry of entries.values()) {
-      entry.close();
-    }
+    registry.close();
   }
 }
 

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -106,6 +106,7 @@ class ExactFetchRegistryV1 {
   readonly #entries = new Map<string, FetchEntryV1>();
   readonly #tracked = new Set<FetchEntryV1>();
   readonly #byteAdmission: SystemRecordRequesterByteAdmissionV1;
+  #closed = false;
 
   constructor(byteAdmission: SystemRecordRequesterByteAdmissionV1) {
     this.#byteAdmission = byteAdmission;
@@ -113,6 +114,10 @@ class ExactFetchRegistryV1 {
 
   get size(): number {
     return this.#entries.size;
+  }
+
+  get closed(): boolean {
+    return this.#closed;
   }
 
   get(key: string): FetchEntryV1 | undefined {
@@ -150,6 +155,8 @@ class ExactFetchRegistryV1 {
   }
 
   close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
     for (const entry of this.#tracked) entry.close();
   }
 
@@ -215,13 +222,13 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
     try {
       signal.throwIfAborted();
       const phase = this.#phase;
-      if (phase.state === 'retained') return this.#deliverLease(phase.source);
+      if (phase.state === 'retained') return this.#deliverLease(phase.source, signal);
       if (phase.state !== 'pending') {
         return Object.freeze({ outcome: 'busy', wireBytes: 0 });
       }
       const shared = await raceSystemRecordAbortV1(phase.transfer, signal);
       return shared.state === 'retained'
-        ? this.#deliverLease(shared.source)
+        ? this.#deliverLease(shared.source, signal)
         : shared.result;
     } finally {
       signal.removeEventListener('abort', releaseObserver);
@@ -272,12 +279,23 @@ class ExactFetchEntryV1 implements FetchEntryV1 {
     return settlement;
   }
 
-  #deliverLease(source: SystemRecordRetainedSourceV1): SystemRecordExactFetchResultV1 {
+  #deliverLease(
+    source: SystemRecordRetainedSourceV1,
+    signal: AbortSignal,
+  ): SystemRecordExactFetchResultV1 {
     if (this.#phase.state !== 'retained' || this.#phase.source !== source) {
       throw new Error('System Record lease source is not retained by its entry');
     }
     const payloadBytes = source.artifact.canonicalBytes.byteLength;
     const reservation = this.#byteAdmission.tryReserve(payloadBytes);
+    if (signal.aborted) {
+      reservation?.release();
+      signal.throwIfAborted();
+    }
+    if (this.#registry.closed) {
+      reservation?.release();
+      return Object.freeze({ outcome: 'closed', wireBytes: source.wireBytes });
+    }
     if (reservation === null) {
       return Object.freeze({ outcome: 'capacity', wireBytes: source.wireBytes });
     }
@@ -361,7 +379,6 @@ export function createSystemRecordRequesterV1(
   let completed = 0;
   let activeStream: 0 | 1 = 0;
   let peakActiveStream: 0 | 1 = 0;
-  let closed = false;
 
   return Object.freeze({ fetch, stats, close });
 
@@ -370,10 +387,10 @@ export function createSystemRecordRequesterV1(
     signal: AbortSignal,
   ): Promise<SystemRecordExactFetchResultV1> {
     signal.throwIfAborted();
-    if (closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
+    if (registry.closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
     const exact = createSystemRecordExactRequestV1(networkId, lookup, requestId());
     signal.throwIfAborted();
-    if (closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
+    if (registry.closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
     const { key, request, requestFrame } = exact;
     let entry = registry.get(key);
     if (entry !== undefined) {
@@ -417,21 +434,21 @@ export function createSystemRecordRequesterV1(
     const streamPermit = streamAdmission.tryAcquire();
     if (streamPermit === null) {
       signal.throwIfAborted();
-      return Object.freeze({ state: closed ? 'closed' : 'busy' });
+      return Object.freeze({ state: registry.closed ? 'closed' : 'busy' });
     }
     let releaseStream = true;
     try {
       signal.throwIfAborted();
-      if (closed) return Object.freeze({ state: 'closed' });
+      if (registry.closed) return Object.freeze({ state: 'closed' });
       const frameReservation = byteAdmission.tryReserve(SYSTEM_RECORD_MAX_FRAME_BYTES);
       if (frameReservation === null) {
         signal.throwIfAborted();
-        return Object.freeze({ state: closed ? 'closed' : 'capacity' });
+        return Object.freeze({ state: registry.closed ? 'closed' : 'capacity' });
       }
       let releaseFrame = true;
       try {
         signal.throwIfAborted();
-        if (closed) return Object.freeze({ state: 'closed' });
+        if (registry.closed) return Object.freeze({ state: 'closed' });
         releaseStream = false;
         releaseFrame = false;
         return Object.freeze({ state: 'admitted', streamPermit, frameReservation });
@@ -481,6 +498,7 @@ export function createSystemRecordRequesterV1(
         transfer,
         decodeAdmission,
         byteAdmission,
+        signal: pendingSignal,
       });
       if (retained.outcome === 'ok') {
         settlement = Object.freeze({ state: 'retained', source: retained.retained });
@@ -513,6 +531,18 @@ export function createSystemRecordRequesterV1(
       activeStream = 0;
       completed += 1;
     }
+    if (pendingSignal.aborted) {
+      if (settlement.state === 'retained') settlement.source.release();
+      return Object.freeze({
+        state: 'failed',
+        result: classifyRequesterFailure(
+          pendingSignal.reason,
+          pendingSignal,
+          entry.resetReason(),
+          wireBytes,
+        ).result,
+      });
+    }
     return settlement;
   }
 
@@ -529,13 +559,11 @@ export function createSystemRecordRequesterV1(
       peakActiveStream,
       queuedStreams: 0,
       retainedPayloadBytes: entryStats.retainedPayloadBytes,
-      closed,
+      closed: registry.closed,
     });
   }
 
   function close(): void {
-    if (closed) return;
-    closed = true;
     registry.close();
   }
 }

--- a/packages/agent/src/system-records/requester-v1.ts
+++ b/packages/agent/src/system-records/requester-v1.ts
@@ -62,6 +62,14 @@ type SystemRecordRequesterSettlementV1 =
   | Readonly<{ state: 'retained'; source: SystemRecordRetainedSourceV1 }>
   | Readonly<{ state: 'failed'; result: SystemRecordRequesterFailureV1 }>;
 
+type SystemRecordLeaderAdmissionV1 =
+  | Readonly<{
+    state: 'admitted';
+    streamPermit: SystemRecordRequesterPermitV1;
+    frameReservation: SystemRecordRequesterByteReservationV1;
+  }>
+  | Readonly<{ state: 'busy' | 'capacity' | 'closed' }>;
+
 interface PendingFetchPhaseV1 {
   readonly state: 'pending';
   readonly controller: AbortController;
@@ -364,6 +372,8 @@ export function createSystemRecordRequesterV1(
     signal.throwIfAborted();
     if (closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
     const exact = createSystemRecordExactRequestV1(networkId, lookup, requestId());
+    signal.throwIfAborted();
+    if (closed) return Object.freeze({ outcome: 'closed', wireBytes: 0 });
     const { key, request, requestFrame } = exact;
     let entry = registry.get(key);
     if (entry !== undefined) {
@@ -380,13 +390,11 @@ export function createSystemRecordRequesterV1(
     if (registry.size >= maxTrackedDigests) {
       return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
     }
-    const streamPermit = streamAdmission.tryAcquire();
-    if (streamPermit === null) return Object.freeze({ outcome: 'busy', wireBytes: 0 });
-    const frameReservation = byteAdmission.tryReserve(SYSTEM_RECORD_MAX_FRAME_BYTES);
-    if (frameReservation === null) {
-      streamPermit.release();
-      return Object.freeze({ outcome: 'capacity', wireBytes: 0 });
+    const admission = admitLeader(signal);
+    if (admission.state !== 'admitted') {
+      return Object.freeze({ outcome: admission.state, wireBytes: 0 });
     }
+    const { streamPermit, frameReservation } = admission;
     entry = registry.create(
       key,
       (createdEntry, pendingSignal) => run(
@@ -402,6 +410,37 @@ export function createSystemRecordRequesterV1(
     activeStream = 1;
     peakActiveStream = 1;
     return entry.subscribe(signal);
+  }
+
+  function admitLeader(signal: AbortSignal): SystemRecordLeaderAdmissionV1 {
+    signal.throwIfAborted();
+    const streamPermit = streamAdmission.tryAcquire();
+    if (streamPermit === null) {
+      signal.throwIfAborted();
+      return Object.freeze({ state: closed ? 'closed' : 'busy' });
+    }
+    let releaseStream = true;
+    try {
+      signal.throwIfAborted();
+      if (closed) return Object.freeze({ state: 'closed' });
+      const frameReservation = byteAdmission.tryReserve(SYSTEM_RECORD_MAX_FRAME_BYTES);
+      if (frameReservation === null) {
+        signal.throwIfAborted();
+        return Object.freeze({ state: closed ? 'closed' : 'capacity' });
+      }
+      let releaseFrame = true;
+      try {
+        signal.throwIfAborted();
+        if (closed) return Object.freeze({ state: 'closed' });
+        releaseStream = false;
+        releaseFrame = false;
+        return Object.freeze({ state: 'admitted', streamPermit, frameReservation });
+      } finally {
+        if (releaseFrame) frameReservation.release();
+      }
+    } finally {
+      if (releaseStream) streamPermit.release();
+    }
   }
 
   async function run(

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -31,6 +31,7 @@ export function createSystemRecordExactRequestV1(
   lookup: SystemRecordExactArtifactLookupV1,
   requestId: string,
 ): SystemRecordExactRequestV1 {
+  const normalized = snapshotSystemRecordExactLookupV1(lookup);
   const common = {
     wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
     requestId,
@@ -38,58 +39,53 @@ export function createSystemRecordExactRequestV1(
     networkId,
     payloadBytes: '0' as const,
   };
-  if (lookup.type === 'inventory-object') {
-    const path = Object.freeze([...lookup.path]);
-    return exactRequest(Object.freeze({
+  let request: SystemRecordExactRequestHeaderV1;
+  if (normalized.type === 'inventory-object') {
+    request = Object.freeze({
       ...common,
       operation: 'get-inventory-object',
-      rootDescriptorDigest: lookup.rootDescriptorDigest,
-      path,
-      objectKind: lookup.objectKind,
-      objectDigest: lookup.objectDigest,
-    }));
-  }
-  if (lookup.objectKind === 'profile-bundle') {
-    return exactRequest(Object.freeze({
+      rootDescriptorDigest: normalized.rootDescriptorDigest,
+      path: normalized.path,
+      objectKind: normalized.objectKind,
+      objectDigest: normalized.objectDigest,
+    });
+  } else if (normalized.objectKind === 'profile-bundle') {
+    request = Object.freeze({
       ...common,
       operation: 'get-bundle',
-      objectKind: lookup.objectKind,
-      objectDigest: lookup.objectDigest,
-    }));
+      objectKind: normalized.objectKind,
+      objectDigest: normalized.objectDigest,
+    });
+  } else {
+    request = Object.freeze({
+      ...common,
+      operation: 'get-control-object',
+      objectKind: normalized.objectKind,
+      objectDigest: normalized.objectDigest,
+    });
   }
-  return exactRequest(Object.freeze({
-    ...common,
-    operation: 'get-control-object',
-    objectKind: lookup.objectKind,
-    objectDigest: lookup.objectDigest,
-  }));
+  return Object.freeze({ request, key: systemRecordExactLookupKeyV1(normalized) });
 }
 
-function exactRequest(request: SystemRecordExactRequestHeaderV1): SystemRecordExactRequestV1 {
-  return Object.freeze({ request, key: systemRecordExactRequestKeyV1(request) });
+function snapshotSystemRecordExactLookupV1(
+  lookup: SystemRecordExactArtifactLookupV1,
+): SystemRecordExactArtifactLookupV1 {
+  return lookup.type === 'inventory-object'
+    ? Object.freeze({ ...lookup, path: Object.freeze([...lookup.path]) })
+    : Object.freeze({ ...lookup });
 }
 
-function systemRecordExactRequestKeyV1(request: SystemRecordExactRequestHeaderV1): string {
-  switch (request.operation) {
-    case 'get-inventory-object':
-      return JSON.stringify([
-        request.operation,
-        request.rootDescriptorDigest,
-        request.path,
-        request.objectKind,
-        request.objectDigest,
-      ]);
-    case 'get-bundle':
-    case 'get-control-object':
-      return JSON.stringify([
-        request.operation,
-        request.objectKind,
-        request.objectDigest,
-      ]);
+function systemRecordExactLookupKeyV1(lookup: SystemRecordExactArtifactLookupV1): string {
+  if (lookup.type === 'inventory-object') {
+    return JSON.stringify([
+      lookup.type,
+      lookup.rootDescriptorDigest,
+      lookup.path,
+      lookup.objectKind,
+      lookup.objectDigest,
+    ]);
   }
-  throw new Error(`unsupported exact System Record operation: ${String(
-    (request as SystemRecordRequestHeaderV1).operation,
-  )}`);
+  return JSON.stringify([lookup.type, lookup.objectKind, lookup.objectDigest]);
 }
 
 export function systemRecordExactResponseOutcomeV1(

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  SYSTEM_RECORD_KIND_V1,
+  SYSTEM_RECORD_WIRE_VERSION_V1,
+  decodeSystemRecordRequestFrameV1,
+  encodeSystemRecordRequestFrameV1,
+  type NetworkIdV1,
+  type SystemRecordRequestHeaderV1,
+  type SystemRecordResponseStatusV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+
+import type {
+  SystemRecordExactArtifactLookupV1,
+  SystemRecordExactFetchResultV1,
+} from './requester-api-v1.js';
+
+export function createSystemRecordExactRequestV1(
+  networkId: NetworkIdV1,
+  lookup: SystemRecordExactArtifactLookupV1,
+  requestId: string,
+): SystemRecordRequestHeaderV1 {
+  const common = {
+    wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
+    requestId,
+    kind: SYSTEM_RECORD_KIND_V1,
+    networkId,
+    payloadBytes: '0' as const,
+  };
+  const request: SystemRecordRequestHeaderV1 = lookup.type === 'inventory-object'
+    ? {
+      ...common,
+      operation: 'get-inventory-object',
+      rootDescriptorDigest: lookup.rootDescriptorDigest,
+      path: lookup.path,
+      objectKind: lookup.objectKind,
+      objectDigest: lookup.objectDigest,
+    }
+    : lookup.objectKind === 'profile-bundle'
+      ? {
+        ...common,
+        operation: 'get-bundle',
+        objectKind: lookup.objectKind,
+        objectDigest: lookup.objectDigest,
+      }
+      : {
+        ...common,
+        operation: 'get-control-object',
+        objectKind: lookup.objectKind,
+        objectDigest: lookup.objectDigest,
+      };
+  return decodeSystemRecordRequestFrameV1(encodeSystemRecordRequestFrameV1(request));
+}
+
+export function systemRecordExactRequestKeyV1(request: SystemRecordRequestHeaderV1): string {
+  if (request.operation === 'get-root') {
+    throw new Error('root discovery is not an exact-fetch coordinate');
+  }
+  const coordinate = request.operation === 'get-inventory-object'
+    ? [
+      request.operation,
+      request.rootDescriptorDigest,
+      request.path,
+      request.objectKind,
+      request.objectDigest,
+    ]
+    : [request.operation, request.objectKind, request.objectDigest];
+  return JSON.stringify(coordinate);
+}
+
+export function systemRecordExactResponseOutcomeV1(
+  status: Exclude<SystemRecordResponseStatusV1, 'ok'>,
+): Exclude<SystemRecordExactFetchResultV1, Readonly<{ outcome: 'ok' }>>['outcome'] {
+  switch (status) {
+    case 'not-found': return 'not-found';
+    case 'unsupported': return 'unsupported';
+    case 'busy': return 'remote-busy';
+    case 'invalid-request':
+    case 'internal': return 'remote-error';
+  }
+  throw new Error(`unsupported system-record response status: ${String(status)}`);
+}

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -16,9 +16,11 @@ export type SystemRecordRemoteFetchOutcomeV1 =
   | 'remote-busy'
   | 'remote-error';
 
-type SystemRecordExactRequestHeaderV1 = Exclude<
+type SystemRecordExactRequestHeaderV1 = Extract<
   SystemRecordRequestHeaderV1,
-  Readonly<{ operation: 'get-root' }>
+  Readonly<{
+    operation: 'get-bundle' | 'get-control-object' | 'get-inventory-object';
+  }>
 >;
 
 export interface SystemRecordExactRequestV1 {

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  SYSTEM_RECORD_MAX_INVENTORY_CHILD_INDEX,
+  SYSTEM_RECORD_MAX_INVENTORY_PATH_DEPTH,
   SYSTEM_RECORD_KIND_V1,
   SYSTEM_RECORD_WIRE_VERSION_V1,
+  assertCanonicalDigest,
+  assertNetworkIdV1,
+  encodeSystemRecordRequestFrameV1,
   type NetworkIdV1,
   type SystemRecordRequestHeaderV1,
   type SystemRecordResponseStatusV1,
@@ -25,6 +30,7 @@ type SystemRecordExactRequestHeaderV1 = Extract<
 
 export interface SystemRecordExactRequestV1 {
   readonly request: SystemRecordExactRequestHeaderV1;
+  readonly requestFrame: Uint8Array;
   readonly key: string;
 }
 
@@ -33,6 +39,7 @@ export function createSystemRecordExactRequestV1(
   lookup: SystemRecordExactArtifactLookupV1,
   requestId: string,
 ): SystemRecordExactRequestV1 {
+  assertNetworkIdV1(networkId);
   const normalized = snapshotSystemRecordExactLookupV1(lookup);
   const common = {
     wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
@@ -66,15 +73,69 @@ export function createSystemRecordExactRequestV1(
       objectDigest: normalized.objectDigest,
     });
   }
-  return Object.freeze({ request, key: systemRecordExactLookupKeyV1(normalized) });
+  const requestFrame = encodeSystemRecordRequestFrameV1(request);
+  return Object.freeze({
+    request,
+    requestFrame,
+    key: systemRecordExactLookupKeyV1(normalized),
+  });
 }
 
 function snapshotSystemRecordExactLookupV1(
   lookup: SystemRecordExactArtifactLookupV1,
 ): SystemRecordExactArtifactLookupV1 {
-  return lookup.type === 'inventory-object'
-    ? Object.freeze({ ...lookup, path: Object.freeze([...lookup.path]) })
-    : Object.freeze({ ...lookup });
+  if (typeof lookup !== 'object' || lookup === null) {
+    throw new TypeError('system-record exact lookup must be an object');
+  }
+  const candidate = lookup as unknown as Readonly<Record<string, unknown>>;
+  const type = candidate.type;
+  if (type === 'inventory-object') {
+    const rootDescriptorDigest = candidate.rootDescriptorDigest;
+    assertCanonicalDigest(rootDescriptorDigest, 'inventory root descriptor digest');
+    const pathValue = candidate.path;
+    if (!Array.isArray(pathValue)
+      || pathValue.length > SYSTEM_RECORD_MAX_INVENTORY_PATH_DEPTH) {
+      throw new Error(
+        `inventory traversal path must contain at most ${SYSTEM_RECORD_MAX_INVENTORY_PATH_DEPTH} indexes`,
+      );
+    }
+    const path: number[] = [];
+    for (let index = 0; index < pathValue.length; index += 1) {
+      const childIndex = pathValue[index];
+      if (!Number.isInteger(childIndex)
+        || (childIndex as number) < 0
+        || (childIndex as number) > SYSTEM_RECORD_MAX_INVENTORY_CHILD_INDEX) {
+        throw new Error('inventory traversal path must contain bounded child indexes');
+      }
+      path.push(childIndex as number);
+    }
+    const objectKind = candidate.objectKind;
+    if (objectKind !== 'inventory-internal' && objectKind !== 'inventory-leaf') {
+      throw new Error('inventory request object kind is invalid');
+    }
+    const objectDigest = candidate.objectDigest;
+    assertCanonicalDigest(objectDigest, 'inventory object digest');
+    return Object.freeze({
+      type,
+      rootDescriptorDigest,
+      path: Object.freeze(path),
+      objectKind,
+      objectDigest,
+    });
+  }
+  if (type !== 'object') throw new Error('system-record exact lookup type is invalid');
+  const objectKind = candidate.objectKind;
+  if (objectKind !== 'profile-bundle'
+    && objectKind !== 'agent-profile-head'
+    && objectKind !== 'authority-transition'
+    && objectKind !== 'fork-resolution'
+    && objectKind !== 'conflict-evidence'
+    && objectKind !== 'owned-subject-table') {
+    throw new Error('exact request object kind is invalid');
+  }
+  const objectDigest = candidate.objectDigest;
+  assertCanonicalDigest(objectDigest, 'exact object digest');
+  return Object.freeze({ type, objectKind, objectDigest });
 }
 
 function systemRecordExactLookupKeyV1(lookup: SystemRecordExactArtifactLookupV1): string {

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -33,6 +33,15 @@ type SystemRecordExactObjectKindV1 = Extract<
   Readonly<{ type: 'object' }>
 >['objectKind'];
 
+type SystemRecordExactOperationForObjectKindV1<
+  Kind extends SystemRecordExactObjectKindV1,
+> = Kind extends Extract<
+  SystemRecordExactRequestHeaderV1,
+  Readonly<{ operation: 'get-bundle' }>
+>['objectKind']
+  ? 'get-bundle'
+  : 'get-control-object';
+
 const SYSTEM_RECORD_EXACT_OPERATION_BY_OBJECT_KIND_V1 = Object.freeze({
   'profile-bundle': 'get-bundle',
   'agent-profile-head': 'get-control-object',
@@ -40,12 +49,9 @@ const SYSTEM_RECORD_EXACT_OPERATION_BY_OBJECT_KIND_V1 = Object.freeze({
   'fork-resolution': 'get-control-object',
   'conflict-evidence': 'get-control-object',
   'owned-subject-table': 'get-control-object',
-} satisfies Readonly<Record<
-  SystemRecordExactObjectKindV1,
-  Extract<SystemRecordExactRequestHeaderV1, Readonly<{
-    operation: 'get-bundle' | 'get-control-object';
-  }>>['operation']
->>);
+} satisfies Readonly<{
+  [Kind in SystemRecordExactObjectKindV1]: SystemRecordExactOperationForObjectKindV1<Kind>;
+}>);
 
 export interface SystemRecordExactRequestV1 {
   readonly request: SystemRecordExactRequestHeaderV1;
@@ -77,20 +83,8 @@ export function createSystemRecordExactRequestV1(
       objectKind: normalized.objectKind,
       objectDigest: normalized.objectDigest,
     });
-  } else if (normalized.objectKind === 'profile-bundle') {
-    request = Object.freeze({
-      ...common,
-      operation: 'get-bundle',
-      objectKind: normalized.objectKind,
-      objectDigest: normalized.objectDigest,
-    });
   } else {
-    request = Object.freeze({
-      ...common,
-      operation: 'get-control-object',
-      objectKind: normalized.objectKind,
-      objectDigest: normalized.objectDigest,
-    });
+    request = createSystemRecordExactObjectRequestV1(common, normalized);
   }
   const requestFrame = encodeSystemRecordRequestFrameV1(request);
   return Object.freeze({
@@ -98,6 +92,25 @@ export function createSystemRecordExactRequestV1(
     requestFrame,
     key: systemRecordExactLookupKeyV1(normalized),
   });
+}
+
+function createSystemRecordExactObjectRequestV1(
+  common: Readonly<{
+    wireVersion: typeof SYSTEM_RECORD_WIRE_VERSION_V1;
+    requestId: string;
+    kind: typeof SYSTEM_RECORD_KIND_V1;
+    networkId: NetworkIdV1;
+    payloadBytes: '0';
+  }>,
+  lookup: Extract<SystemRecordExactArtifactLookupV1, Readonly<{ type: 'object' }>>,
+): SystemRecordExactRequestHeaderV1 {
+  const operation = SYSTEM_RECORD_EXACT_OPERATION_BY_OBJECT_KIND_V1[lookup.objectKind];
+  return Object.freeze({
+    ...common,
+    operation,
+    objectKind: lookup.objectKind,
+    objectDigest: lookup.objectDigest,
+  }) as SystemRecordExactRequestHeaderV1;
 }
 
 function snapshotSystemRecordExactLookupV1(

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -56,42 +56,53 @@ const SYSTEM_RECORD_EXACT_OPERATION_BY_OBJECT_KIND_V1 = Object.freeze({
 export interface SystemRecordExactRequestV1 {
   readonly request: SystemRecordExactRequestHeaderV1;
   readonly requestFrame: Uint8Array;
+}
+
+export interface NormalizedSystemRecordExactLookupV1 {
+  readonly networkId: NetworkIdV1;
+  readonly lookup: SystemRecordExactArtifactLookupV1;
   readonly key: string;
 }
 
-export function createSystemRecordExactRequestV1(
+export function normalizeSystemRecordExactLookupV1(
   networkId: NetworkIdV1,
   lookup: SystemRecordExactArtifactLookupV1,
-  requestId: string,
-): SystemRecordExactRequestV1 {
+): NormalizedSystemRecordExactLookupV1 {
   assertNetworkIdV1(networkId);
   const normalized = snapshotSystemRecordExactLookupV1(lookup);
+  return Object.freeze({
+    networkId,
+    lookup: normalized,
+    key: systemRecordExactLookupKeyV1(normalized),
+  });
+}
+
+export function createSystemRecordExactRequestV1(
+  normalized: NormalizedSystemRecordExactLookupV1,
+  requestId: string,
+): SystemRecordExactRequestV1 {
   const common = {
     wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
     requestId,
     kind: SYSTEM_RECORD_KIND_V1,
-    networkId,
+    networkId: normalized.networkId,
     payloadBytes: '0' as const,
   };
   let request: SystemRecordExactRequestHeaderV1;
-  if (normalized.type === 'inventory-object') {
+  if (normalized.lookup.type === 'inventory-object') {
     request = Object.freeze({
       ...common,
       operation: 'get-inventory-object',
-      rootDescriptorDigest: normalized.rootDescriptorDigest,
-      path: normalized.path,
-      objectKind: normalized.objectKind,
-      objectDigest: normalized.objectDigest,
+      rootDescriptorDigest: normalized.lookup.rootDescriptorDigest,
+      path: normalized.lookup.path,
+      objectKind: normalized.lookup.objectKind,
+      objectDigest: normalized.lookup.objectDigest,
     });
   } else {
-    request = createSystemRecordExactObjectRequestV1(common, normalized);
+    request = createSystemRecordExactObjectRequestV1(common, normalized.lookup);
   }
   const requestFrame = encodeSystemRecordRequestFrameV1(request);
-  return Object.freeze({
-    request,
-    requestFrame,
-    key: systemRecordExactLookupKeyV1(normalized),
-  });
+  return Object.freeze({ request, requestFrame });
 }
 
 function createSystemRecordExactObjectRequestV1(

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -28,6 +28,25 @@ type SystemRecordExactRequestHeaderV1 = Extract<
   }>
 >;
 
+type SystemRecordExactObjectKindV1 = Extract<
+  SystemRecordExactArtifactLookupV1,
+  Readonly<{ type: 'object' }>
+>['objectKind'];
+
+const SYSTEM_RECORD_EXACT_OPERATION_BY_OBJECT_KIND_V1 = Object.freeze({
+  'profile-bundle': 'get-bundle',
+  'agent-profile-head': 'get-control-object',
+  'authority-transition': 'get-control-object',
+  'fork-resolution': 'get-control-object',
+  'conflict-evidence': 'get-control-object',
+  'owned-subject-table': 'get-control-object',
+} satisfies Readonly<Record<
+  SystemRecordExactObjectKindV1,
+  Extract<SystemRecordExactRequestHeaderV1, Readonly<{
+    operation: 'get-bundle' | 'get-control-object';
+  }>>['operation']
+>>);
+
 export interface SystemRecordExactRequestV1 {
   readonly request: SystemRecordExactRequestHeaderV1;
   readonly requestFrame: Uint8Array;
@@ -125,17 +144,16 @@ function snapshotSystemRecordExactLookupV1(
   }
   if (type !== 'object') throw new Error('system-record exact lookup type is invalid');
   const objectKind = candidate.objectKind;
-  if (objectKind !== 'profile-bundle'
-    && objectKind !== 'agent-profile-head'
-    && objectKind !== 'authority-transition'
-    && objectKind !== 'fork-resolution'
-    && objectKind !== 'conflict-evidence'
-    && objectKind !== 'owned-subject-table') {
+  if (typeof objectKind !== 'string'
+    || !Object.prototype.hasOwnProperty.call(
+      SYSTEM_RECORD_EXACT_OPERATION_BY_OBJECT_KIND_V1,
+      objectKind,
+    )) {
     throw new Error('exact request object kind is invalid');
   }
   const objectDigest = candidate.objectDigest;
   assertCanonicalDigest(objectDigest, 'exact object digest');
-  return Object.freeze({ type, objectKind, objectDigest });
+  return Object.freeze({ type, objectKind: objectKind as SystemRecordExactObjectKindV1, objectDigest });
 }
 
 function systemRecordExactLookupKeyV1(lookup: SystemRecordExactArtifactLookupV1): string {

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -16,11 +16,16 @@ export type SystemRecordRemoteFetchOutcomeV1 =
   | 'remote-busy'
   | 'remote-error';
 
+export interface SystemRecordExactRequestV1 {
+  readonly request: SystemRecordRequestHeaderV1;
+  readonly key: string;
+}
+
 export function createSystemRecordExactRequestV1(
   networkId: NetworkIdV1,
   lookup: SystemRecordExactArtifactLookupV1,
   requestId: string,
-): SystemRecordRequestHeaderV1 {
+): SystemRecordExactRequestV1 {
   const common = {
     wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
     requestId,
@@ -28,44 +33,46 @@ export function createSystemRecordExactRequestV1(
     networkId,
     payloadBytes: '0' as const,
   };
-  return lookup.type === 'inventory-object'
-    ? Object.freeze({
-      ...common,
-      operation: 'get-inventory-object',
-      rootDescriptorDigest: lookup.rootDescriptorDigest,
-      path: Object.freeze([...lookup.path]),
-      objectKind: lookup.objectKind,
-      objectDigest: lookup.objectDigest,
-    })
-    : lookup.objectKind === 'profile-bundle'
-      ? Object.freeze({
+  if (lookup.type === 'inventory-object') {
+    const path = Object.freeze([...lookup.path]);
+    return Object.freeze({
+      request: Object.freeze({
+        ...common,
+        operation: 'get-inventory-object',
+        rootDescriptorDigest: lookup.rootDescriptorDigest,
+        path,
+        objectKind: lookup.objectKind,
+        objectDigest: lookup.objectDigest,
+      }),
+      key: JSON.stringify([
+        'get-inventory-object',
+        lookup.rootDescriptorDigest,
+        path,
+        lookup.objectKind,
+        lookup.objectDigest,
+      ]),
+    });
+  }
+  if (lookup.objectKind === 'profile-bundle') {
+    return Object.freeze({
+      request: Object.freeze({
         ...common,
         operation: 'get-bundle',
         objectKind: lookup.objectKind,
         objectDigest: lookup.objectDigest,
-      })
-      : Object.freeze({
-        ...common,
-        operation: 'get-control-object',
-        objectKind: lookup.objectKind,
-        objectDigest: lookup.objectDigest,
-      });
-}
-
-export function systemRecordExactRequestKeyV1(request: SystemRecordRequestHeaderV1): string {
-  if (request.operation === 'get-root') {
-    throw new Error('root discovery is not an exact-fetch coordinate');
+      }),
+      key: JSON.stringify(['get-bundle', lookup.objectKind, lookup.objectDigest]),
+    });
   }
-  const coordinate = request.operation === 'get-inventory-object'
-    ? [
-      request.operation,
-      request.rootDescriptorDigest,
-      request.path,
-      request.objectKind,
-      request.objectDigest,
-    ]
-    : [request.operation, request.objectKind, request.objectDigest];
-  return JSON.stringify(coordinate);
+  return Object.freeze({
+    request: Object.freeze({
+      ...common,
+      operation: 'get-control-object',
+      objectKind: lookup.objectKind,
+      objectDigest: lookup.objectDigest,
+    }),
+    key: JSON.stringify(['get-control-object', lookup.objectKind, lookup.objectDigest]),
+  });
 }
 
 export function systemRecordExactResponseOutcomeV1(

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -3,17 +3,18 @@
 import {
   SYSTEM_RECORD_KIND_V1,
   SYSTEM_RECORD_WIRE_VERSION_V1,
-  decodeSystemRecordRequestFrameV1,
-  encodeSystemRecordRequestFrameV1,
   type NetworkIdV1,
   type SystemRecordRequestHeaderV1,
   type SystemRecordResponseStatusV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
 
-import type {
-  SystemRecordExactArtifactLookupV1,
-  SystemRecordExactFetchResultV1,
-} from './requester-api-v1.js';
+import type { SystemRecordExactArtifactLookupV1 } from './requester-api-v1.js';
+
+export type SystemRecordRemoteFetchOutcomeV1 =
+  | 'not-found'
+  | 'unsupported'
+  | 'remote-busy'
+  | 'remote-error';
 
 export function createSystemRecordExactRequestV1(
   networkId: NetworkIdV1,
@@ -27,29 +28,28 @@ export function createSystemRecordExactRequestV1(
     networkId,
     payloadBytes: '0' as const,
   };
-  const request: SystemRecordRequestHeaderV1 = lookup.type === 'inventory-object'
-    ? {
+  return lookup.type === 'inventory-object'
+    ? Object.freeze({
       ...common,
       operation: 'get-inventory-object',
       rootDescriptorDigest: lookup.rootDescriptorDigest,
-      path: lookup.path,
+      path: Object.freeze([...lookup.path]),
       objectKind: lookup.objectKind,
       objectDigest: lookup.objectDigest,
-    }
+    })
     : lookup.objectKind === 'profile-bundle'
-      ? {
+      ? Object.freeze({
         ...common,
         operation: 'get-bundle',
         objectKind: lookup.objectKind,
         objectDigest: lookup.objectDigest,
-      }
-      : {
+      })
+      : Object.freeze({
         ...common,
         operation: 'get-control-object',
         objectKind: lookup.objectKind,
         objectDigest: lookup.objectDigest,
-      };
-  return decodeSystemRecordRequestFrameV1(encodeSystemRecordRequestFrameV1(request));
+      });
 }
 
 export function systemRecordExactRequestKeyV1(request: SystemRecordRequestHeaderV1): string {
@@ -70,7 +70,7 @@ export function systemRecordExactRequestKeyV1(request: SystemRecordRequestHeader
 
 export function systemRecordExactResponseOutcomeV1(
   status: Exclude<SystemRecordResponseStatusV1, 'ok'>,
-): Exclude<SystemRecordExactFetchResultV1, Readonly<{ outcome: 'ok' }>>['outcome'] {
+): SystemRecordRemoteFetchOutcomeV1 {
   switch (status) {
     case 'not-found': return 'not-found';
     case 'unsupported': return 'unsupported';

--- a/packages/agent/src/system-records/requester-wire-v1-internal.ts
+++ b/packages/agent/src/system-records/requester-wire-v1-internal.ts
@@ -16,8 +16,13 @@ export type SystemRecordRemoteFetchOutcomeV1 =
   | 'remote-busy'
   | 'remote-error';
 
+type SystemRecordExactRequestHeaderV1 = Exclude<
+  SystemRecordRequestHeaderV1,
+  Readonly<{ operation: 'get-root' }>
+>;
+
 export interface SystemRecordExactRequestV1 {
-  readonly request: SystemRecordRequestHeaderV1;
+  readonly request: SystemRecordExactRequestHeaderV1;
   readonly key: string;
 }
 
@@ -35,44 +40,56 @@ export function createSystemRecordExactRequestV1(
   };
   if (lookup.type === 'inventory-object') {
     const path = Object.freeze([...lookup.path]);
-    return Object.freeze({
-      request: Object.freeze({
-        ...common,
-        operation: 'get-inventory-object',
-        rootDescriptorDigest: lookup.rootDescriptorDigest,
-        path,
-        objectKind: lookup.objectKind,
-        objectDigest: lookup.objectDigest,
-      }),
-      key: JSON.stringify([
-        'get-inventory-object',
-        lookup.rootDescriptorDigest,
-        path,
-        lookup.objectKind,
-        lookup.objectDigest,
-      ]),
-    });
-  }
-  if (lookup.objectKind === 'profile-bundle') {
-    return Object.freeze({
-      request: Object.freeze({
-        ...common,
-        operation: 'get-bundle',
-        objectKind: lookup.objectKind,
-        objectDigest: lookup.objectDigest,
-      }),
-      key: JSON.stringify(['get-bundle', lookup.objectKind, lookup.objectDigest]),
-    });
-  }
-  return Object.freeze({
-    request: Object.freeze({
+    return exactRequest(Object.freeze({
       ...common,
-      operation: 'get-control-object',
+      operation: 'get-inventory-object',
+      rootDescriptorDigest: lookup.rootDescriptorDigest,
+      path,
       objectKind: lookup.objectKind,
       objectDigest: lookup.objectDigest,
-    }),
-    key: JSON.stringify(['get-control-object', lookup.objectKind, lookup.objectDigest]),
-  });
+    }));
+  }
+  if (lookup.objectKind === 'profile-bundle') {
+    return exactRequest(Object.freeze({
+      ...common,
+      operation: 'get-bundle',
+      objectKind: lookup.objectKind,
+      objectDigest: lookup.objectDigest,
+    }));
+  }
+  return exactRequest(Object.freeze({
+    ...common,
+    operation: 'get-control-object',
+    objectKind: lookup.objectKind,
+    objectDigest: lookup.objectDigest,
+  }));
+}
+
+function exactRequest(request: SystemRecordExactRequestHeaderV1): SystemRecordExactRequestV1 {
+  return Object.freeze({ request, key: systemRecordExactRequestKeyV1(request) });
+}
+
+function systemRecordExactRequestKeyV1(request: SystemRecordExactRequestHeaderV1): string {
+  switch (request.operation) {
+    case 'get-inventory-object':
+      return JSON.stringify([
+        request.operation,
+        request.rootDescriptorDigest,
+        request.path,
+        request.objectKind,
+        request.objectDigest,
+      ]);
+    case 'get-bundle':
+    case 'get-control-object':
+      return JSON.stringify([
+        request.operation,
+        request.objectKind,
+        request.objectDigest,
+      ]);
+  }
+  throw new Error(`unsupported exact System Record operation: ${String(
+    (request as SystemRecordRequestHeaderV1).operation,
+  )}`);
 }
 
 export function systemRecordExactResponseOutcomeV1(

--- a/packages/agent/src/system-records/resource-admission-v1-internal.ts
+++ b/packages/agent/src/system-records/resource-admission-v1-internal.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface SystemRecordPermitV1 {
+  release(): void;
+}
+
+export interface SystemRecordPermitAdmissionV1 {
+  tryAcquire(): SystemRecordPermitV1 | null;
+}
+
+export interface SystemRecordPermitGateV1 extends SystemRecordPermitAdmissionV1 {
+  readonly active: 0 | 1;
+}
+
+/** One nonqueued permit. Absence is an immediate refusal, never a waiter. */
+export function createSystemRecordPermitGateV1(): SystemRecordPermitGateV1 {
+  let held = false;
+  return Object.freeze({
+    tryAcquire(): SystemRecordPermitV1 | null {
+      if (held) return null;
+      held = true;
+      let released = false;
+      return Object.freeze({
+        release(): void {
+          if (released) return;
+          released = true;
+          held = false;
+        },
+      });
+    },
+    get active(): 0 | 1 {
+      return held ? 1 : 0;
+    },
+  });
+}
+
+export interface SystemRecordByteReservationV1 {
+  /** Return unused capacity while preserving the exact retained bytes. */
+  shrinkTo(bytes: number): void;
+  release(): void;
+}
+
+/** Supplied by the one lifecycle-owned runtime accountant; it never queues. */
+export interface SystemRecordByteAdmissionV1 {
+  tryReserve(bytes: number): SystemRecordByteReservationV1 | null;
+}
+
+/** Shared abort race for bounded System Record requester/provider exchanges. */
+export function raceSystemRecordAbortV1<T>(
+  work: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
+  });
+}

--- a/packages/agent/src/system-records/transport-v1.ts
+++ b/packages/agent/src/system-records/transport-v1.ts
@@ -149,8 +149,8 @@ export function createSystemRecordProviderPermitGateV1(): SystemRecordProviderPe
   });
 }
 
-export interface SystemRecordProviderFrameReservationV1 {
-  /** Return unused capacity while preserving the exact retained frame bytes. */
+export interface SystemRecordByteReservationV1 {
+  /** Return unused capacity while preserving the exact retained bytes. */
   shrinkTo(bytes: number): void;
   release(): void;
 }
@@ -159,9 +159,12 @@ export interface SystemRecordProviderFrameReservationV1 {
  * Supplied by the one lifecycle-owned runtime accountant. This module never
  * constructs a private accountant or queues for capacity.
  */
-export interface SystemRecordProviderFrameAdmissionV1 {
-  tryReserve(bytes: number): SystemRecordProviderFrameReservationV1 | null;
+export interface SystemRecordByteAdmissionV1 {
+  tryReserve(bytes: number): SystemRecordByteReservationV1 | null;
 }
+
+export type SystemRecordProviderFrameReservationV1 = SystemRecordByteReservationV1;
+export type SystemRecordProviderFrameAdmissionV1 = SystemRecordByteAdmissionV1;
 
 /** Shared abort race for bounded System Record requester/provider exchanges. */
 export function raceSystemRecordAbortV1<T>(

--- a/packages/agent/src/system-records/transport-v1.ts
+++ b/packages/agent/src/system-records/transport-v1.ts
@@ -118,20 +118,23 @@ export function createSystemRecordProviderTokenBucketV1(
   });
 }
 
-export interface SystemRecordProviderPermitV1 {
+export interface SystemRecordPermitV1 {
   release(): void;
 }
 
-export interface SystemRecordProviderPermitGateV1 {
-  tryAcquire(): SystemRecordProviderPermitV1 | null;
+export interface SystemRecordPermitAdmissionV1 {
+  tryAcquire(): SystemRecordPermitV1 | null;
+}
+
+export interface SystemRecordPermitGateV1 extends SystemRecordPermitAdmissionV1 {
   readonly active: 0 | 1;
 }
 
-/** One nonqueued provider permit. Absence is an immediate reset, never a waiter. */
-export function createSystemRecordProviderPermitGateV1(): SystemRecordProviderPermitGateV1 {
+/** One nonqueued permit. Absence is an immediate refusal, never a waiter. */
+export function createSystemRecordPermitGateV1(): SystemRecordPermitGateV1 {
   let held = false;
   return Object.freeze({
-    tryAcquire(): SystemRecordProviderPermitV1 | null {
+    tryAcquire(): SystemRecordPermitV1 | null {
       if (held) return null;
       held = true;
       let released = false;
@@ -147,6 +150,14 @@ export function createSystemRecordProviderPermitGateV1(): SystemRecordProviderPe
       return held ? 1 : 0;
     },
   });
+}
+
+export type SystemRecordProviderPermitV1 = SystemRecordPermitV1;
+export type SystemRecordProviderPermitGateV1 = SystemRecordPermitGateV1;
+
+/** Compatibility facade for the canonical nonqueued System Record permit gate. */
+export function createSystemRecordProviderPermitGateV1(): SystemRecordProviderPermitGateV1 {
+  return createSystemRecordPermitGateV1();
 }
 
 export interface SystemRecordByteReservationV1 {

--- a/packages/agent/src/system-records/transport-v1.ts
+++ b/packages/agent/src/system-records/transport-v1.ts
@@ -8,6 +8,27 @@ import {
   SYSTEM_RECORD_PROVIDER_RESPONSE_TOKEN_REFILL_PER_MINUTE,
 } from '@origintrail-official/dkg-core/system-record-v1';
 
+import {
+  createSystemRecordPermitGateV1,
+  raceSystemRecordAbortV1,
+  type SystemRecordByteAdmissionV1,
+  type SystemRecordByteReservationV1,
+  type SystemRecordPermitGateV1,
+  type SystemRecordPermitV1,
+} from './resource-admission-v1-internal.js';
+
+export {
+  createSystemRecordPermitGateV1,
+  raceSystemRecordAbortV1,
+};
+export type {
+  SystemRecordByteAdmissionV1,
+  SystemRecordByteReservationV1,
+  SystemRecordPermitAdmissionV1,
+  SystemRecordPermitGateV1,
+  SystemRecordPermitV1,
+} from './resource-admission-v1-internal.js';
+
 export interface SystemRecordProviderTokenBucketSnapshotV1 {
   readonly requestTokens: number;
   readonly responseTokens: number;
@@ -118,40 +139,6 @@ export function createSystemRecordProviderTokenBucketV1(
   });
 }
 
-export interface SystemRecordPermitV1 {
-  release(): void;
-}
-
-export interface SystemRecordPermitAdmissionV1 {
-  tryAcquire(): SystemRecordPermitV1 | null;
-}
-
-export interface SystemRecordPermitGateV1 extends SystemRecordPermitAdmissionV1 {
-  readonly active: 0 | 1;
-}
-
-/** One nonqueued permit. Absence is an immediate refusal, never a waiter. */
-export function createSystemRecordPermitGateV1(): SystemRecordPermitGateV1 {
-  let held = false;
-  return Object.freeze({
-    tryAcquire(): SystemRecordPermitV1 | null {
-      if (held) return null;
-      held = true;
-      let released = false;
-      return Object.freeze({
-        release(): void {
-          if (released) return;
-          released = true;
-          held = false;
-        },
-      });
-    },
-    get active(): 0 | 1 {
-      return held ? 1 : 0;
-    },
-  });
-}
-
 export type SystemRecordProviderPermitV1 = SystemRecordPermitV1;
 export type SystemRecordProviderPermitGateV1 = SystemRecordPermitGateV1;
 
@@ -160,35 +147,8 @@ export function createSystemRecordProviderPermitGateV1(): SystemRecordProviderPe
   return createSystemRecordPermitGateV1();
 }
 
-export interface SystemRecordByteReservationV1 {
-  /** Return unused capacity while preserving the exact retained bytes. */
-  shrinkTo(bytes: number): void;
-  release(): void;
-}
-
-/**
- * Supplied by the one lifecycle-owned runtime accountant. This module never
- * constructs a private accountant or queues for capacity.
- */
-export interface SystemRecordByteAdmissionV1 {
-  tryReserve(bytes: number): SystemRecordByteReservationV1 | null;
-}
-
 export type SystemRecordProviderFrameReservationV1 = SystemRecordByteReservationV1;
 export type SystemRecordProviderFrameAdmissionV1 = SystemRecordByteAdmissionV1;
-
-/** Shared abort race for bounded System Record requester/provider exchanges. */
-export function raceSystemRecordAbortV1<T>(
-  work: Promise<T>,
-  signal: AbortSignal,
-): Promise<T> {
-  if (signal.aborted) return Promise.reject(signal.reason);
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(signal.reason);
-    signal.addEventListener('abort', onAbort, { once: true });
-    work.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
-  });
-}
 
 function positiveInteger(value: number, label: string): number {
   if (!Number.isSafeInteger(value) || value < 1) {

--- a/packages/agent/src/system-records/transport-v1.ts
+++ b/packages/agent/src/system-records/transport-v1.ts
@@ -163,6 +163,19 @@ export interface SystemRecordProviderFrameAdmissionV1 {
   tryReserve(bytes: number): SystemRecordProviderFrameReservationV1 | null;
 }
 
+/** Shared abort race for bounded System Record requester/provider exchanges. */
+export function raceSystemRecordAbortV1<T>(
+  work: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
+  });
+}
+
 function positiveInteger(value: number, label: string): number {
   if (!Number.isSafeInteger(value) || value < 1) {
     throw new TypeError(`${label} must be a positive safe integer`);

--- a/packages/agent/src/system-records/transport-v1.ts
+++ b/packages/agent/src/system-records/transport-v1.ts
@@ -10,23 +10,10 @@ import {
 
 import {
   createSystemRecordPermitGateV1,
-  raceSystemRecordAbortV1,
   type SystemRecordByteAdmissionV1,
   type SystemRecordByteReservationV1,
   type SystemRecordPermitGateV1,
   type SystemRecordPermitV1,
-} from './resource-admission-v1-internal.js';
-
-export {
-  createSystemRecordPermitGateV1,
-  raceSystemRecordAbortV1,
-};
-export type {
-  SystemRecordByteAdmissionV1,
-  SystemRecordByteReservationV1,
-  SystemRecordPermitAdmissionV1,
-  SystemRecordPermitGateV1,
-  SystemRecordPermitV1,
 } from './resource-admission-v1-internal.js';
 
 export interface SystemRecordProviderTokenBucketSnapshotV1 {

--- a/packages/agent/test/system-record-requester-public-api.typecheck.ts
+++ b/packages/agent/test/system-record-requester-public-api.typecheck.ts
@@ -1,0 +1,34 @@
+import type { Digest32V1 } from '@origintrail-official/dkg-core/system-record-v1';
+import type {
+  CreateSystemRecordRequesterOptionsV1,
+  SystemRecordExactFetchResultV1,
+  SystemRecordRequesterAdmissionV1,
+  SystemRecordRequesterByteAdmissionV1,
+  SystemRecordRequesterExchangeV1,
+  SystemRecordRequesterV1,
+} from '@origintrail-official/dkg-agent/dist/system-records/requester-api-v1.js';
+import { createSystemRecordRequesterV1 } from '@origintrail-official/dkg-agent/dist/system-records/requester-v1.js';
+
+declare const byteAdmission: SystemRecordRequesterByteAdmissionV1;
+declare const streamAdmission: SystemRecordRequesterAdmissionV1;
+declare const decodeAdmission: SystemRecordRequesterAdmissionV1;
+declare const exchange: SystemRecordRequesterExchangeV1;
+declare const digest: Digest32V1;
+declare const signal: AbortSignal;
+declare const networkId: CreateSystemRecordRequesterOptionsV1['networkId'];
+
+const options: CreateSystemRecordRequesterOptionsV1 = {
+  networkId,
+  openExchange: async (_signal) => exchange,
+  byteAdmission,
+  streamAdmission,
+  decodeAdmission,
+};
+const requester: SystemRecordRequesterV1 = createSystemRecordRequesterV1(options);
+const result: Promise<SystemRecordExactFetchResultV1> = requester.fetch({
+  type: 'object',
+  objectKind: 'profile-bundle',
+  objectDigest: digest,
+}, signal);
+
+void result;

--- a/packages/agent/test/system-record-requester-public-api.typecheck.ts
+++ b/packages/agent/test/system-record-requester-public-api.typecheck.ts
@@ -5,6 +5,7 @@ import type {
   SystemRecordRequesterAdmissionV1,
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterExchangeV1,
+  SystemRecordRequesterLimitsV1,
   SystemRecordRequesterV1,
 } from '@origintrail-official/dkg-agent/dist/system-records/requester-v1.js';
 import { createSystemRecordRequesterV1 } from '@origintrail-official/dkg-agent/dist/system-records/requester-v1.js';
@@ -16,6 +17,9 @@ declare const exchange: SystemRecordRequesterExchangeV1;
 declare const digest: Digest32V1;
 declare const signal: AbortSignal;
 declare const networkId: CreateSystemRecordRequesterOptionsV1['networkId'];
+const limits: Readonly<SystemRecordRequesterLimitsV1> = Object.freeze({
+  maxTrackedDigests: 1,
+});
 
 const options: CreateSystemRecordRequesterOptionsV1 = {
   networkId,
@@ -23,7 +27,7 @@ const options: CreateSystemRecordRequesterOptionsV1 = {
   byteAdmission,
   streamAdmission,
   decodeAdmission,
-  maxTrackedDigests: 1,
+  limits,
 };
 const requester: SystemRecordRequesterV1 = createSystemRecordRequesterV1(options);
 const trackedDigests: number = requester.stats().trackedDigests;

--- a/packages/agent/test/system-record-requester-public-api.typecheck.ts
+++ b/packages/agent/test/system-record-requester-public-api.typecheck.ts
@@ -23,8 +23,10 @@ const options: CreateSystemRecordRequesterOptionsV1 = {
   byteAdmission,
   streamAdmission,
   decodeAdmission,
+  maxTrackedDigests: 1,
 };
 const requester: SystemRecordRequesterV1 = createSystemRecordRequesterV1(options);
+const trackedDigests: number = requester.stats().trackedDigests;
 const result: Promise<SystemRecordExactFetchResultV1> = requester.fetch({
   type: 'object',
   objectKind: 'profile-bundle',
@@ -32,3 +34,4 @@ const result: Promise<SystemRecordExactFetchResultV1> = requester.fetch({
 }, signal);
 
 void result;
+void trackedDigests;

--- a/packages/agent/test/system-record-requester-public-api.typecheck.ts
+++ b/packages/agent/test/system-record-requester-public-api.typecheck.ts
@@ -6,7 +6,7 @@ import type {
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterExchangeV1,
   SystemRecordRequesterV1,
-} from '@origintrail-official/dkg-agent/dist/system-records/requester-api-v1.js';
+} from '@origintrail-official/dkg-agent/dist/system-records/requester-v1.js';
 import { createSystemRecordRequesterV1 } from '@origintrail-official/dkg-agent/dist/system-records/requester-v1.js';
 
 declare const byteAdmission: SystemRecordRequesterByteAdmissionV1;

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -353,6 +353,44 @@ describe('system-record requester V1', () => {
     });
   });
 
+  it('cancels a newly created entry when synchronous setup aborts its first caller', async () => {
+    const controller = new AbortController();
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const decode = permitAdmission();
+    const exchange = fixtureExchange();
+    const openExchange = vi.fn(async () => exchange.value);
+    const requester = createSystemRecordRequesterV1({
+      networkId: NETWORK,
+      openExchange,
+      byteAdmission: bytes,
+      streamAdmission: stream.value,
+      decodeAdmission: decode.value,
+      requestId: () => {
+        controller.abort(new Error('caller aborted during request setup'));
+        return '1'.repeat(32);
+      },
+    });
+
+    await expect(requester.fetch(LOOKUP, controller.signal)).rejects.toThrow(
+      'caller aborted during request setup',
+    );
+    await vi.waitFor(() => expect(requester.stats()).toMatchObject({
+      completed: 1,
+      trackedDigests: 0,
+      waitingCallers: 0,
+      activeLeases: 0,
+      activeStream: 0,
+      retainedPayloadBytes: 0,
+    }));
+    await vi.waitFor(() => expect(exchange.reset).toHaveBeenCalledWith('cancelled'));
+    expect(exchange.writeRequestFrame).not.toHaveBeenCalled();
+    expect(bytes.reservations).toHaveLength(1);
+    expect(bytes.reservations[0]?.released).toBe(true);
+    expect(stream.active()).toBe(false);
+    expect(decode.active()).toBe(false);
+  });
+
   it('caps followers per digest without opening another stream', async () => {
     const gate = Promise.withResolvers<void>();
     const exchange = fixtureExchange(async (request) => {
@@ -670,6 +708,36 @@ describe('system-record requester V1', () => {
     opening.resolve(late.value);
     await vi.waitFor(() => expect(late.reset).toHaveBeenCalledWith('deadline'));
     expect(late.writeRequestFrame).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['caller cancellation', 'cancelled'],
+    ['requester close', 'closed'],
+  ] as const)('resets an exchange that opens after %s', async (mode, resetReason) => {
+    const opening = Promise.withResolvers<SystemRecordRequesterExchangeV1>();
+    const controller = new AbortController();
+    const openExchange = vi.fn(async () => opening.promise);
+    const requester = createRequester({ openExchange });
+    const result = requester.fetch(LOOKUP, controller.signal);
+    await vi.waitFor(() => expect(openExchange).toHaveBeenCalledOnce());
+
+    if (mode === 'caller cancellation') {
+      controller.abort(new Error('caller cancelled late open'));
+      await expect(result).rejects.toThrow('caller cancelled late open');
+    } else {
+      requester.close();
+      await expect(result).resolves.toEqual({ outcome: 'closed', wireBytes: 0 });
+    }
+
+    const late = fixtureExchange();
+    opening.resolve(late.value);
+    await vi.waitFor(() => expect(late.reset).toHaveBeenCalledWith(resetReason));
+    expect(late.writeRequestFrame).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(requester.stats()).toMatchObject({
+      completed: 1,
+      trackedDigests: 0,
+      activeStream: 0,
+    }));
   });
 
   it('returns busy when the shared decoder is occupied and retains no payload', async () => {

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -1,0 +1,506 @@
+import {
+  SYSTEM_RECORD_DIGEST_DOMAINS_V1,
+  SYSTEM_RECORD_MAX_FRAME_BYTES,
+  SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES,
+  SYSTEM_RECORD_WIRE_VERSION_V1,
+  decodeSystemRecordRequestFrameV1,
+  digestSystemRecordBytesV1,
+  encodeSystemRecordResponseFrameV1,
+  type Digest32V1,
+  type SystemRecordRequestHeaderV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  SystemRecordRequesterAdmissionV1,
+  SystemRecordRequesterByteAdmissionV1,
+  SystemRecordRequesterExchangeV1,
+} from '../src/system-records/requester-api-v1.js';
+import {
+  createSystemRecordRequesterV1,
+} from '../src/system-records/requester-v1.js';
+
+const NETWORK = 'base:84532' as const;
+const PAYLOAD = Uint8Array.of(1, 2, 3);
+const DIGEST = digestSystemRecordBytesV1(
+  SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+  PAYLOAD,
+);
+const LOOKUP = Object.freeze({
+  type: 'object' as const,
+  objectKind: 'profile-bundle' as const,
+  objectDigest: DIGEST,
+});
+
+describe('system-record requester V1', () => {
+  it('coalesces one exact transfer and retains one accounted payload until all leases release', async () => {
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const decode = permitAdmission();
+    const response = Promise.withResolvers<Uint8Array>();
+    const exchange = fixtureExchange(async (request) => {
+      await response.promise;
+      return successResponse(request, PAYLOAD, DIGEST);
+    });
+    const openExchange = vi.fn(async () => exchange.value);
+    const requester = createRequester({ bytes, stream, decode });
+    const signal = new AbortController().signal;
+
+    const first = requester.fetch(LOOKUP, openExchange, signal);
+    await exchange.requestWritten.promise;
+    const second = requester.fetch(LOOKUP, openExchange, signal);
+    expect(requester.stats()).toMatchObject({
+      started: 1,
+      joined: 1,
+      pendingDigests: 1,
+      waitingCallers: 2,
+      activeStream: 1,
+      queuedStreams: 0,
+    });
+    response.resolve(Uint8Array.of());
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.outcome).toBe('ok');
+    expect(secondResult.outcome).toBe('ok');
+    if (firstResult.outcome !== 'ok' || secondResult.outcome !== 'ok') return;
+    expect(firstResult.lease.artifact).toBe(secondResult.lease.artifact);
+    expect(firstResult.lease.artifact).toMatchObject({
+      objectKind: 'profile-bundle',
+      objectDigest: DIGEST,
+    });
+    expect(firstResult.lease.artifact.canonicalBytes).toEqual(PAYLOAD);
+    expect(openExchange).toHaveBeenCalledTimes(1);
+    expect(exchange.writeRequestFrame).toHaveBeenCalledTimes(1);
+    expect(exchange.readResponseFrame).toHaveBeenCalledWith(
+      SYSTEM_RECORD_MAX_FRAME_BYTES,
+      expect.any(AbortSignal),
+    );
+    expect(bytes.reservations.map(({ requested }) => requested)).toEqual([
+      SYSTEM_RECORD_MAX_FRAME_BYTES,
+      PAYLOAD.byteLength,
+    ]);
+    expect(bytes.reservations[0]?.released).toBe(true);
+    expect(bytes.reservations[1]?.released).toBe(false);
+    expect(requester.stats()).toMatchObject({
+      completed: 1,
+      pendingDigests: 1,
+      activeLeases: 2,
+      retainedPayloadBytes: PAYLOAD.byteLength,
+      activeStream: 0,
+    });
+    expect(decode.active()).toBe(true);
+    firstResult.lease.release();
+    expect(bytes.reservations[1]?.released).toBe(false);
+    expect(decode.active()).toBe(true);
+    secondResult.lease.release();
+    expect(bytes.reservations[1]?.released).toBe(true);
+    expect(decode.active()).toBe(false);
+    expect(requester.stats()).toMatchObject({
+      pendingDigests: 0,
+      activeLeases: 0,
+      retainedPayloadBytes: 0,
+    });
+  });
+
+  it('never queues an unrelated digest behind the one requester stream', async () => {
+    const gate = Promise.withResolvers<void>();
+    const firstExchange = fixtureExchange(async (request) => {
+      await gate.promise;
+      return successResponse(request, PAYLOAD, DIGEST);
+    });
+    const requester = createRequester();
+    const first = requester.fetch(
+      LOOKUP,
+      async () => firstExchange.value,
+      new AbortController().signal,
+    );
+    await firstExchange.requestWritten.promise;
+    const otherPayload = Uint8Array.of(4, 5, 6);
+    const otherDigest = digestSystemRecordBytesV1(
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+      otherPayload,
+    );
+    const unopened = vi.fn(async () => fixtureExchange().value);
+    await expect(requester.fetch({
+      ...LOOKUP,
+      objectDigest: otherDigest,
+    }, unopened, new AbortController().signal)).resolves.toEqual({
+      outcome: 'busy',
+      wireBytes: 0,
+    });
+    expect(unopened).not.toHaveBeenCalled();
+    expect(requester.stats().queuedStreams).toBe(0);
+    gate.resolve();
+    const result = await first;
+    expect(result.outcome).toBe('ok');
+    if (result.outcome === 'ok') result.lease.release();
+  });
+
+  it('caps followers per digest without opening another stream', async () => {
+    const gate = Promise.withResolvers<void>();
+    const exchange = fixtureExchange(async (request) => {
+      await gate.promise;
+      return successResponse(request, PAYLOAD, DIGEST);
+    });
+    const openExchange = vi.fn(async () => exchange.value);
+    const requester = createRequester({ maxWaitersPerDigest: 1 });
+    const signal = new AbortController().signal;
+    const leader = requester.fetch(LOOKUP, openExchange, signal);
+    await exchange.requestWritten.promise;
+    const follower = requester.fetch(LOOKUP, openExchange, signal);
+    await expect(requester.fetch(LOOKUP, openExchange, signal)).resolves.toEqual({
+      outcome: 'waiter-limit',
+      wireBytes: 0,
+    });
+    gate.resolve();
+    const results = await Promise.all([leader, follower]);
+    for (const result of results) {
+      if (result.outcome === 'ok') result.lease.release();
+    }
+    expect(openExchange).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts retained successful entries against the global digest cap', async () => {
+    const firstExchange = fixtureExchange();
+    const requester = createRequester({ maxPendingDigests: 1 });
+    const first = await requester.fetch(
+      LOOKUP,
+      async () => firstExchange.value,
+      new AbortController().signal,
+    );
+    expect(first.outcome).toBe('ok');
+    const otherPayload = Uint8Array.of(7, 8, 9);
+    const otherDigest = digestSystemRecordBytesV1(
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+      otherPayload,
+    );
+    const unopened = vi.fn(async () => fixtureExchange().value);
+    await expect(requester.fetch({
+      ...LOOKUP,
+      objectDigest: otherDigest,
+    }, unopened, new AbortController().signal)).resolves.toEqual({
+      outcome: 'capacity',
+      wireBytes: 0,
+    });
+    expect(unopened).not.toHaveBeenCalled();
+    if (first.outcome === 'ok') first.lease.release();
+    expect(requester.stats().pendingDigests).toBe(0);
+  });
+
+  it('keeps a coalesced transfer alive when only one caller aborts', async () => {
+    const gate = Promise.withResolvers<void>();
+    const exchange = fixtureExchange(async (request) => {
+      await gate.promise;
+      return successResponse(request, PAYLOAD, DIGEST);
+    });
+    const requester = createRequester();
+    const leaderController = new AbortController();
+    const followerController = new AbortController();
+    const leader = requester.fetch(LOOKUP, async () => exchange.value, leaderController.signal);
+    await exchange.requestWritten.promise;
+    const follower = requester.fetch(LOOKUP, async () => exchange.value, followerController.signal);
+    leaderController.abort(new Error('leader cancelled'));
+    await expect(leader).rejects.toThrow('leader cancelled');
+    gate.resolve();
+    const result = await follower;
+    expect(result.outcome).toBe('ok');
+    if (result.outcome === 'ok') result.lease.release();
+    expect(exchange.reset).not.toHaveBeenCalled();
+  });
+
+  it('aborts and releases the shared transfer after its final caller leaves', async () => {
+    const bytes = byteAdmission();
+    const exchange = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
+    const requester = createRequester({ bytes });
+    const controller = new AbortController();
+    const result = requester.fetch(LOOKUP, async () => exchange.value, controller.signal);
+    await exchange.requestWritten.promise;
+    controller.abort(new Error('caller left'));
+    await expect(result).rejects.toThrow('caller left');
+    await vi.waitFor(() => {
+      expect(requester.stats()).toMatchObject({
+        completed: 1,
+        pendingDigests: 0,
+        waitingCallers: 0,
+        activeStream: 0,
+      });
+    });
+    expect(bytes.reservations).toHaveLength(1);
+    expect(bytes.reservations[0]?.released).toBe(true);
+    expect(exchange.reset).toHaveBeenCalledWith('cancelled');
+  });
+
+  it('maps remote errors and rejects invalid payload identity fail closed', async () => {
+    const notFound = fixtureExchange(async (request) => errorResponse(request, 'not-found'));
+    const requester = createRequester();
+    await expect(requester.fetch(
+      LOOKUP,
+      async () => notFound.value,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'not-found', wireBytes: expect.any(Number) });
+    expect(notFound.reset).not.toHaveBeenCalled();
+
+    const wrongPayload = Uint8Array.of(9, 9, 9);
+    const invalid = fixtureExchange(async (request) => successResponse(request, wrongPayload, DIGEST));
+    const invalidResult = await requester.fetch(
+      LOOKUP,
+      async () => invalid.value,
+      new AbortController().signal,
+    );
+    expect(invalidResult).toEqual(expect.objectContaining({
+      outcome: 'invalid-response',
+      wireBytes: expect.any(Number),
+    }));
+    expect(invalidResult.wireBytes).toBeGreaterThan(0);
+    expect(invalid.reset).toHaveBeenCalledWith('invalid-response');
+    expect(requester.stats()).toMatchObject({ pendingDigests: 0, activeStream: 0 });
+  });
+
+  it('reserves before network work and releases permits on capacity, deadline, and close', async () => {
+    const stream = permitAdmission();
+    const exhausted = createRequester({
+      bytes: { tryReserve: vi.fn(() => null) },
+      stream,
+    });
+    const unopened = vi.fn(async () => fixtureExchange().value);
+    await expect(exhausted.fetch(
+      LOOKUP,
+      unopened,
+      new AbortController().signal,
+    )).resolves.toEqual({ outcome: 'capacity', wireBytes: 0 });
+    expect(unopened).not.toHaveBeenCalled();
+    expect(stream.active()).toBe(false);
+
+    const slow = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
+    const timed = createRequester({ timeoutMs: 5 });
+    await expect(timed.fetch(
+      LOOKUP,
+      async () => slow.value,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'deadline', wireBytes: expect.any(Number) });
+    expect(slow.reset).toHaveBeenCalledWith('deadline');
+    expect(timed.stats()).toMatchObject({ pendingDigests: 0, activeStream: 0 });
+
+    const blocked = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
+    const closing = createRequester();
+    const result = closing.fetch(
+      LOOKUP,
+      async () => blocked.value,
+      new AbortController().signal,
+    );
+    await blocked.requestWritten.promise;
+    closing.close();
+    await expect(result).resolves.toMatchObject({ outcome: 'closed', wireBytes: expect.any(Number) });
+    expect(blocked.reset).toHaveBeenCalledWith('closed');
+    expect(closing.stats()).toMatchObject({ closed: true, pendingDigests: 0, activeStream: 0 });
+    await expect(closing.fetch(
+      LOOKUP,
+      unopened,
+      new AbortController().signal,
+    )).resolves.toEqual({ outcome: 'closed', wireBytes: 0 });
+  });
+
+  it('returns busy when the shared decoder is occupied and retains no payload', async () => {
+    const decode = permitAdmission();
+    const held = decode.value.tryAcquire();
+    expect(held).not.toBeNull();
+    const bytes = byteAdmission();
+    const exchange = fixtureExchange(async (request) => successResponse(request, PAYLOAD, DIGEST));
+    const requester = createRequester({ bytes, decode });
+    await expect(requester.fetch(
+      LOOKUP,
+      async () => exchange.value,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'busy', wireBytes: expect.any(Number) });
+    expect(bytes.reservations).toHaveLength(1);
+    expect(bytes.reservations[0]?.released).toBe(true);
+    expect(requester.stats().retainedPayloadBytes).toBe(0);
+    held?.release();
+  });
+
+  it('accepts the maximum legal bundle under encoded and decoded reservations', async () => {
+    const payload = new Uint8Array(SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES);
+    const digest = digestSystemRecordBytesV1(
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+      payload,
+    );
+    const bytes = byteAdmission();
+    const exchange = fixtureExchange(async (request) => successResponse(request, payload, digest));
+    const requester = createRequester({ bytes });
+    const result = await requester.fetch({
+      ...LOOKUP,
+      objectDigest: digest,
+    }, async () => exchange.value, new AbortController().signal);
+
+    expect(result.outcome).toBe('ok');
+    expect(bytes.reservations.map(({ requested }) => requested)).toEqual([
+      SYSTEM_RECORD_MAX_FRAME_BYTES,
+      SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES,
+    ]);
+    expect(bytes.reservations[0]?.shrunk).toBeLessThanOrEqual(SYSTEM_RECORD_MAX_FRAME_BYTES);
+    if (result.outcome === 'ok') {
+      expect(result.lease.artifact.canonicalBytes.byteLength).toBe(
+        SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES,
+      );
+      result.lease.release();
+    }
+    expect(bytes.reservations.every(({ released }) => released)).toBe(true);
+  });
+
+  it('closes new work without under-accounting an already delivered lease', async () => {
+    const bytes = byteAdmission();
+    const decode = permitAdmission();
+    const exchange = fixtureExchange();
+    const requester = createRequester({ bytes, decode });
+    const result = await requester.fetch(
+      LOOKUP,
+      async () => exchange.value,
+      new AbortController().signal,
+    );
+    expect(result.outcome).toBe('ok');
+    requester.close();
+    expect(requester.stats()).toMatchObject({
+      closed: true,
+      activeLeases: 1,
+      retainedPayloadBytes: PAYLOAD.byteLength,
+    });
+    expect(bytes.reservations[1]?.released).toBe(false);
+    expect(decode.active()).toBe(true);
+    if (result.outcome === 'ok') result.lease.release();
+    expect(requester.stats()).toMatchObject({ activeLeases: 0, retainedPayloadBytes: 0 });
+    expect(bytes.reservations[1]?.released).toBe(true);
+    expect(decode.active()).toBe(false);
+  });
+});
+
+function createRequester(overrides: {
+  bytes?: SystemRecordRequesterByteAdmissionV1;
+  stream?: ReturnType<typeof permitAdmission>;
+  decode?: ReturnType<typeof permitAdmission>;
+  timeoutMs?: number;
+  maxWaitersPerDigest?: number;
+  maxPendingDigests?: number;
+} = {}) {
+  const stream = overrides.stream ?? permitAdmission();
+  const decode = overrides.decode ?? permitAdmission();
+  return createSystemRecordRequesterV1({
+    networkId: NETWORK,
+    byteAdmission: overrides.bytes ?? byteAdmission(),
+    streamAdmission: stream.value,
+    decodeAdmission: decode.value,
+    requestId: () => '1'.repeat(32),
+    ...(overrides.timeoutMs === undefined ? {} : { timeoutMs: overrides.timeoutMs }),
+    ...(overrides.maxWaitersPerDigest === undefined
+      ? {}
+      : { maxWaitersPerDigest: overrides.maxWaitersPerDigest }),
+    ...(overrides.maxPendingDigests === undefined
+      ? {}
+      : { maxPendingDigests: overrides.maxPendingDigests }),
+  });
+}
+
+function fixtureExchange(
+  respond: (request: SystemRecordRequestHeaderV1) => Promise<Uint8Array> = async (request) => (
+    successResponse(request, PAYLOAD, DIGEST)
+  ),
+) {
+  let written: Uint8Array | undefined;
+  const requestWritten = Promise.withResolvers<void>();
+  const writeRequestFrame = vi.fn(async (frame: Uint8Array) => {
+    written = Uint8Array.from(frame);
+    requestWritten.resolve();
+  });
+  const readResponseFrame = vi.fn(async () => {
+    if (written === undefined) throw new Error('request was not written');
+    return respond(decodeSystemRecordRequestFrameV1(written));
+  });
+  const reset = vi.fn();
+  const value: SystemRecordRequesterExchangeV1 = {
+    writeRequestFrame,
+    readResponseFrame,
+    reset,
+  };
+  return { value, writeRequestFrame, readResponseFrame, reset, requestWritten };
+}
+
+function successResponse(
+  request: SystemRecordRequestHeaderV1,
+  payload: Uint8Array,
+  digest: Digest32V1,
+): Uint8Array {
+  return encodeSystemRecordResponseFrameV1({
+    wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
+    requestId: request.requestId,
+    status: 'ok',
+    objectKind: 'profile-bundle',
+    objectDigest: digest,
+    payloadBytes: payload.byteLength.toString(),
+  }, payload);
+}
+
+function errorResponse(
+  request: SystemRecordRequestHeaderV1,
+  status: 'not-found' | 'unsupported' | 'busy' | 'internal' | 'invalid-request',
+): Uint8Array {
+  const errorCode = status === 'not-found'
+    ? 'not_found'
+    : status === 'invalid-request'
+      ? 'invalid_request'
+      : status;
+  return encodeSystemRecordResponseFrameV1({
+    wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
+    requestId: request.requestId,
+    status,
+    payloadBytes: '0',
+    errorCode,
+  }, new Uint8Array());
+}
+
+function permitAdmission() {
+  let active = false;
+  const value: SystemRecordRequesterAdmissionV1 = {
+    tryAcquire() {
+      if (active) return null;
+      active = true;
+      let released = false;
+      return Object.freeze({
+        release() {
+          if (released) return;
+          released = true;
+          active = false;
+        },
+      });
+    },
+  };
+  return { value, active: () => active };
+}
+
+function byteAdmission() {
+  const reservations: Array<{
+    requested: number;
+    shrunk?: number;
+    released: boolean;
+  }> = [];
+  const value: SystemRecordRequesterByteAdmissionV1 = {
+    tryReserve(requested) {
+      const record: {
+        requested: number;
+        shrunk?: number;
+        released: boolean;
+      } = { requested, released: false };
+      reservations.push(record);
+      return {
+        shrinkTo(bytes) {
+          if (!Number.isSafeInteger(bytes) || bytes < 1 || bytes > requested) {
+            throw new Error('invalid reservation shrink');
+          }
+          record.shrunk = bytes;
+        },
+        release() {
+          record.released = true;
+        },
+      };
+    },
+  };
+  return { ...value, reservations };
+}

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -279,15 +279,40 @@ describe('system-record requester V1', () => {
     expect(exchange.reset).toHaveBeenCalledWith('cancelled');
   });
 
-  it('maps remote errors and rejects invalid payload identity fail closed', async () => {
-    const notFound = fixtureExchange(async (request) => errorResponse(request, 'not-found'));
+  it('does not attach an immediate retry to a cancelled single-flight', async () => {
+    const exchange = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
     const requester = createRequester();
-    await expect(requester.fetch(
-      LOOKUP,
-      async () => notFound.value,
-      new AbortController().signal,
-    )).resolves.toMatchObject({ outcome: 'not-found', wireBytes: expect.any(Number) });
-    expect(notFound.reset).not.toHaveBeenCalled();
+    const controller = new AbortController();
+    const first = requester.fetch(LOOKUP, async () => exchange.value, controller.signal);
+    await exchange.requestWritten.promise;
+    controller.abort(new Error('caller left'));
+
+    const unopened = vi.fn(async () => fixtureExchange().value);
+    const retry = requester.fetch(LOOKUP, unopened, new AbortController().signal);
+    await expect(retry).resolves.toEqual({ outcome: 'busy', wireBytes: 0 });
+    expect(unopened).not.toHaveBeenCalled();
+    await expect(first).rejects.toThrow('caller left');
+    await vi.waitFor(() => expect(requester.stats().pendingDigests).toBe(0));
+  });
+
+  it('maps every remote status and rejects invalid payload identity fail closed', async () => {
+    const requester = createRequester();
+    const statuses = [
+      ['not-found', 'not-found'],
+      ['unsupported', 'unsupported'],
+      ['busy', 'remote-busy'],
+      ['invalid-request', 'remote-error'],
+      ['internal', 'remote-error'],
+    ] as const;
+    for (const [remote, local] of statuses) {
+      const response = fixtureExchange(async (request) => errorResponse(request, remote));
+      await expect(requester.fetch(
+        LOOKUP,
+        async () => response.value,
+        new AbortController().signal,
+      )).resolves.toMatchObject({ outcome: local, wireBytes: expect.any(Number) });
+      expect(response.reset).not.toHaveBeenCalled();
+    }
 
     const wrongPayload = Uint8Array.of(9, 9, 9);
     const invalid = fixtureExchange(async (request) => successResponse(request, wrongPayload, DIGEST));

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -155,6 +155,212 @@ describe('system-record requester V1', () => {
     });
   });
 
+  it.each(['requester close', 'caller abort'] as const)(
+    'fences retained lease delivery after reentrant %s',
+    async (mode) => {
+      const bytes = byteAdmission();
+      const stream = permitAdmission();
+      const decode = permitAdmission();
+      const exchange = fixtureExchange();
+      const openExchange = vi.fn(async () => exchange.value);
+      const secondController = new AbortController();
+      let requester: ReturnType<typeof createSystemRecordRequesterV1>;
+      let reservationCount = 0;
+      const reentrantBytes: SystemRecordRequesterByteAdmissionV1 = {
+        tryReserve(requested) {
+          const reservation = bytes.tryReserve(requested);
+          reservationCount += 1;
+          if (reservationCount === 4) {
+            if (mode === 'requester close') {
+              requester.close();
+            } else {
+              secondController.abort(new Error('caller aborted during retained delivery'));
+            }
+          }
+          return reservation;
+        },
+      };
+      requester = createSystemRecordRequesterV1({
+        networkId: NETWORK,
+        openExchange,
+        byteAdmission: reentrantBytes,
+        streamAdmission: stream.value,
+        decodeAdmission: decode.value,
+        requestId: () => '1'.repeat(32),
+      });
+
+      const first = await requester.fetch(LOOKUP, new AbortController().signal);
+      expect(first.outcome).toBe('ok');
+      if (first.outcome !== 'ok') return;
+      expect(bytes.reservations).toHaveLength(3);
+
+      const second = requester.fetch(LOOKUP, secondController.signal);
+      if (mode === 'requester close') {
+        await expect(second).resolves.toEqual({
+          outcome: 'closed',
+          wireBytes: first.lease.wireBytes,
+        });
+      } else {
+        await expect(second).rejects.toThrow('caller aborted during retained delivery');
+      }
+
+      expect(openExchange).toHaveBeenCalledOnce();
+      expect(exchange.writeRequestFrame).toHaveBeenCalledOnce();
+      expect(exchange.readResponseFrame).toHaveBeenCalledOnce();
+      expect(exchange.reset).not.toHaveBeenCalled();
+      expect(bytes.reservations).toHaveLength(4);
+      expect(bytes.reservations[0]?.released).toBe(true);
+      expect(bytes.reservations[1]?.released).toBe(false);
+      expect(bytes.reservations[2]?.released).toBe(false);
+      expect(bytes.reservations[3]?.released).toBe(true);
+      expect(requester.stats()).toMatchObject({
+        joined: 1,
+        trackedDigests: 1,
+        activeLeases: 1,
+        retainedPayloadBytes: PAYLOAD.byteLength * 2,
+        activeStream: 0,
+        closed: mode === 'requester close',
+      });
+      expect(decode.active()).toBe(true);
+
+      first.lease.release();
+      expect(bytes.reservations.every(({ released }) => released)).toBe(true);
+      expect(decode.active()).toBe(false);
+      expect(requester.stats()).toMatchObject({
+        trackedDigests: 0,
+        activeLeases: 0,
+        retainedPayloadBytes: 0,
+      });
+    },
+  );
+
+  it.each([
+    ['decode admission', 'requester close'],
+    ['decode admission', 'caller abort'],
+    ['source byte admission', 'requester close'],
+    ['source byte admission', 'caller abort'],
+    ['frame shrink', 'requester close'],
+    ['frame shrink', 'caller abort'],
+    ['frame release', 'requester close'],
+    ['frame release', 'caller abort'],
+    ['stream release', 'requester close'],
+    ['stream release', 'caller abort'],
+  ] as const)(
+    'fences source retention after reentrant %s %s',
+    async (hook, mode) => {
+      const bytes = byteAdmission();
+      const stream = permitAdmission();
+      const decode = permitAdmission();
+      const exchange = fixtureExchange();
+      const openExchange = vi.fn(async () => exchange.value);
+      const controller = new AbortController();
+      let requester: ReturnType<typeof createSystemRecordRequesterV1>;
+      let triggered = false;
+      const trigger = () => {
+        if (triggered) return;
+        triggered = true;
+        if (mode === 'requester close') {
+          requester.close();
+        } else {
+          controller.abort(new Error(`caller aborted during ${hook}`));
+        }
+      };
+      const streamAdmission = {
+        tryAcquire() {
+          const permit = stream.value.tryAcquire();
+          if (permit === null || hook !== 'stream release') return permit;
+          let released = false;
+          return Object.freeze({
+            release() {
+              if (released) return;
+              released = true;
+              permit.release();
+              trigger();
+            },
+          });
+        },
+      };
+      const decodeAdmission = {
+        tryAcquire() {
+          const permit = decode.value.tryAcquire();
+          if (hook === 'decode admission') trigger();
+          return permit;
+        },
+      };
+      let reservationCount = 0;
+      const reentrantBytes: SystemRecordRequesterByteAdmissionV1 = {
+        tryReserve(requested) {
+          const reservation = bytes.tryReserve(requested);
+          reservationCount += 1;
+          if (reservationCount === 2 && hook === 'source byte admission') trigger();
+          if (reservationCount !== 1
+            || (hook !== 'frame shrink' && hook !== 'frame release')) {
+            return reservation;
+          }
+          let released = false;
+          return Object.freeze({
+            shrinkTo(retainedBytes: number) {
+              reservation.shrinkTo(retainedBytes);
+              if (hook === 'frame shrink') trigger();
+            },
+            release() {
+              if (released) return;
+              released = true;
+              reservation.release();
+              if (hook === 'frame release') trigger();
+            },
+          });
+        },
+      };
+      requester = createSystemRecordRequesterV1({
+        networkId: NETWORK,
+        openExchange,
+        byteAdmission: reentrantBytes,
+        streamAdmission,
+        decodeAdmission,
+        requestId: () => '1'.repeat(32),
+      });
+
+      const result = requester.fetch(LOOKUP, controller.signal);
+      if (mode === 'requester close') {
+        await expect(result).resolves.toMatchObject({
+          outcome: 'closed',
+          wireBytes: expect.any(Number),
+        });
+      } else {
+        await expect(result).rejects.toThrow(`caller aborted during ${hook}`);
+      }
+
+      expect(triggered).toBe(true);
+      expect(openExchange).toHaveBeenCalledOnce();
+      expect(exchange.writeRequestFrame).toHaveBeenCalledOnce();
+      expect(exchange.readResponseFrame).toHaveBeenCalledOnce();
+      const resetDuringTransfer = hook === 'decode admission'
+        || hook === 'source byte admission'
+        || hook === 'frame shrink';
+      if (resetDuringTransfer) {
+        expect(exchange.reset).toHaveBeenCalledWith(
+          mode === 'requester close' ? 'closed' : 'cancelled',
+        );
+      } else {
+        expect(exchange.reset).not.toHaveBeenCalled();
+      }
+      await vi.waitFor(() => expect(requester.stats()).toMatchObject({
+        started: 1,
+        completed: 1,
+        trackedDigests: 0,
+        waitingCallers: 0,
+        activeLeases: 0,
+        activeStream: 0,
+        retainedPayloadBytes: 0,
+        closed: mode === 'requester close',
+      }));
+      expect(bytes.reservations.every(({ released }) => released)).toBe(true);
+      expect(stream.active()).toBe(false);
+      expect(decode.active()).toBe(false);
+    },
+  );
+
   it('fetches and verifies an exact inventory object through the public requester', async () => {
     const leaf = { objectType: 'inventory-leaf', rows: [] } as const;
     const payload = canonicalizeSystemRecordInventoryLeafObjectV1(leaf, NETWORK, true);

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -1,5 +1,6 @@
 import {
   SYSTEM_RECORD_DIGEST_DOMAINS_V1,
+  SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS,
   SYSTEM_RECORD_MAX_FRAME_BYTES,
   SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES,
   SYSTEM_RECORD_MAX_INVENTORY_PATH_DEPTH,
@@ -707,7 +708,8 @@ describe('system-record requester V1', () => {
       return successResponse(request, PAYLOAD, DIGEST);
     });
     const openExchange = vi.fn(async () => exchange.value);
-    const requester = createRequester({ maxWaitersPerDigest: 1, openExchange });
+    const requestId = vi.fn(() => '1'.repeat(32));
+    const requester = createRequester({ maxWaitersPerDigest: 1, openExchange, requestId });
     const signal = new AbortController().signal;
     const leader = requester.fetch(LOOKUP, signal);
     await exchange.requestWritten.promise;
@@ -722,6 +724,49 @@ describe('system-record requester V1', () => {
       if (result.outcome === 'ok') result.lease.release();
     }
     expect(openExchange).toHaveBeenCalledTimes(1);
+    expect(requestId).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not apply the pending follower cap to late retained leases', async () => {
+    const requester = createRequester({ maxWaitersPerDigest: 1 });
+    const signal = new AbortController().signal;
+    const leases = [];
+
+    for (let index = 0; index < 4; index += 1) {
+      const result = await requester.fetch(LOOKUP, signal);
+      expect(result.outcome).toBe('ok');
+      if (result.outcome === 'ok') leases.push(result.lease);
+    }
+
+    expect(requester.stats()).toMatchObject({
+      started: 1,
+      joined: 3,
+      waitingCallers: 0,
+      activeLeases: 4,
+    });
+    for (const lease of leases) lease.release();
+    expect(requester.stats()).toMatchObject({ activeLeases: 0, trackedDigests: 0 });
+  });
+
+  it('bounds retained leases independently of the pending follower policy', async () => {
+    const requester = createRequester({ maxWaitersPerDigest: 1 });
+    const signal = new AbortController().signal;
+    const leases = [];
+    const leaseLimit = SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS + 1;
+
+    for (let index = 0; index < leaseLimit; index += 1) {
+      const result = await requester.fetch(LOOKUP, signal);
+      expect(result.outcome).toBe('ok');
+      if (result.outcome === 'ok') leases.push(result.lease);
+    }
+    await expect(requester.fetch(LOOKUP, signal)).resolves.toMatchObject({
+      outcome: 'capacity',
+      wireBytes: expect.any(Number),
+    });
+    expect(requester.stats()).toMatchObject({ activeLeases: leaseLimit });
+
+    for (const lease of leases) lease.release();
+    expect(requester.stats()).toMatchObject({ activeLeases: 0, trackedDigests: 0 });
   });
 
   it('counts retained successful entries against the tracked digest cap', async () => {
@@ -921,16 +966,32 @@ describe('system-record requester V1', () => {
     expect(stream.active()).toBe(false);
 
     const slow = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
-    const timed = createRequester({ timeoutMs: 5, openExchange: async () => slow.value });
+    const timedBytes = byteAdmission();
+    const timedStream = permitAdmission();
+    const timed = createRequester({
+      bytes: timedBytes,
+      stream: timedStream,
+      timeoutMs: 5,
+      openExchange: async () => slow.value,
+    });
     await expect(timed.fetch(
       LOOKUP,
       new AbortController().signal,
     )).resolves.toMatchObject({ outcome: 'deadline', wireBytes: expect.any(Number) });
     expect(slow.reset).toHaveBeenCalledWith('deadline');
     expect(timed.stats()).toMatchObject({ trackedDigests: 0, activeStream: 0 });
+    expect(timedStream.active()).toBe(false);
+    expect(timedBytes.reservations).toHaveLength(1);
+    expect(timedBytes.reservations[0]?.released).toBe(true);
 
     const blocked = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
-    const closing = createRequester({ openExchange: async () => blocked.value });
+    const closingBytes = byteAdmission();
+    const closingStream = permitAdmission();
+    const closing = createRequester({
+      bytes: closingBytes,
+      stream: closingStream,
+      openExchange: async () => blocked.value,
+    });
     const result = closing.fetch(
       LOOKUP,
       new AbortController().signal,
@@ -940,6 +1001,9 @@ describe('system-record requester V1', () => {
     await expect(result).resolves.toMatchObject({ outcome: 'closed', wireBytes: expect.any(Number) });
     expect(blocked.reset).toHaveBeenCalledWith('closed');
     expect(closing.stats()).toMatchObject({ closed: true, trackedDigests: 0, activeStream: 0 });
+    expect(closingStream.active()).toBe(false);
+    expect(closingBytes.reservations).toHaveLength(1);
+    expect(closingBytes.reservations[0]?.released).toBe(true);
     await expect(closing.fetch(
       LOOKUP,
       new AbortController().signal,
@@ -1217,6 +1281,7 @@ function createRequester(overrides: {
   decode?: ReturnType<typeof permitAdmission>;
   openExchange?: CreateSystemRecordRequesterOptionsV1['openExchange'];
   timeoutMs?: number;
+  requestId?: CreateSystemRecordRequesterOptionsV1['requestId'];
   maxWaitersPerDigest?: number;
   maxTrackedDigests?: number;
 } = {}) {
@@ -1228,7 +1293,7 @@ function createRequester(overrides: {
     byteAdmission: overrides.bytes ?? byteAdmission(),
     streamAdmission: stream.value,
     decodeAdmission: decode.value,
-    requestId: () => '1'.repeat(32),
+    requestId: overrides.requestId ?? (() => '1'.repeat(32)),
     ...(overrides.timeoutMs === undefined ? {} : { timeoutMs: overrides.timeoutMs }),
     ...(overrides.maxWaitersPerDigest === undefined
       && overrides.maxTrackedDigests === undefined

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -279,19 +279,46 @@ describe('system-record requester V1', () => {
     expect(exchange.reset).toHaveBeenCalledWith('cancelled');
   });
 
+  it('releases stream and frame ownership when the only caller leaves during open', async () => {
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const opening = Promise.withResolvers<void>();
+    const openExchange = vi.fn(async () => {
+      opening.resolve();
+      return new Promise<SystemRecordRequesterExchangeV1>(() => {});
+    });
+    const requester = createRequester({ bytes, stream });
+    const controller = new AbortController();
+    const result = requester.fetch(LOOKUP, openExchange, controller.signal);
+    await opening.promise;
+    controller.abort(new Error('caller left during open'));
+
+    await expect(result).rejects.toThrow('caller left during open');
+    await vi.waitFor(() => expect(requester.stats()).toMatchObject({
+      completed: 1,
+      pendingDigests: 0,
+      waitingCallers: 0,
+      activeStream: 0,
+    }));
+    expect(stream.active()).toBe(false);
+    expect(bytes.reservations).toHaveLength(1);
+    expect(bytes.reservations[0]?.released).toBe(true);
+  });
+
   it('does not attach an immediate retry to a cancelled single-flight', async () => {
     const exchange = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
     const requester = createRequester();
     const controller = new AbortController();
     const first = requester.fetch(LOOKUP, async () => exchange.value, controller.signal);
     await exchange.requestWritten.promise;
+    const firstRejection = expect(first).rejects.toThrow('caller left');
     controller.abort(new Error('caller left'));
 
     const unopened = vi.fn(async () => fixtureExchange().value);
     const retry = requester.fetch(LOOKUP, unopened, new AbortController().signal);
     await expect(retry).resolves.toEqual({ outcome: 'busy', wireBytes: 0 });
     expect(unopened).not.toHaveBeenCalled();
-    await expect(first).rejects.toThrow('caller left');
+    await firstRejection;
     await vi.waitFor(() => expect(requester.stats().pendingDigests).toBe(0));
   });
 

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type {
   CreateSystemRecordRequesterOptionsV1,
+  SystemRecordExactFetchResultV1,
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterExchangeV1,
 } from '../src/system-records/requester-api-v1.js';
@@ -235,6 +236,119 @@ describe('system-record requester V1', () => {
     },
   );
 
+  it('unpublishes a retained entry before releasing its reentrant source owner', async () => {
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const decode = permitAdmission();
+    const openExchange = vi.fn(async () => fixtureExchange().value);
+    let requester: ReturnType<typeof createSystemRecordRequesterV1>;
+    let nested: Promise<SystemRecordExactFetchResultV1> | undefined;
+    let triggerSourceRelease = false;
+    const reentrantBytes: SystemRecordRequesterByteAdmissionV1 = {
+      tryReserve(requested) {
+        const reservation = bytes.tryReserve(requested);
+        const reservationIndex = bytes.reservations.length - 1;
+        if (reservation === null) return null;
+        let released = false;
+        return Object.freeze({
+          shrinkTo: (retainedBytes: number) => reservation.shrinkTo(retainedBytes),
+          release() {
+            if (released) return;
+            released = true;
+            reservation.release();
+            if (triggerSourceRelease && reservationIndex === 1) {
+              triggerSourceRelease = false;
+              nested = requester.fetch(LOOKUP, new AbortController().signal);
+            }
+          },
+        });
+      },
+    };
+    requester = createSystemRecordRequesterV1({
+      networkId: NETWORK,
+      openExchange,
+      byteAdmission: reentrantBytes,
+      streamAdmission: stream.value,
+      decodeAdmission: decode.value,
+      requestId: () => '1'.repeat(32),
+    });
+
+    const first = await requester.fetch(LOOKUP, new AbortController().signal);
+    expect(first.outcome).toBe('ok');
+    if (first.outcome !== 'ok') return;
+    triggerSourceRelease = true;
+    first.lease.release();
+
+    expect(nested).toBeDefined();
+    const nestedResult = await nested!;
+    expect(nestedResult.outcome).toBe('ok');
+    expect(openExchange).toHaveBeenCalledTimes(2);
+    expect(requester.stats()).toMatchObject({
+      trackedDigests: 1,
+      activeLeases: 1,
+      retainedPayloadBytes: PAYLOAD.byteLength * 2,
+    });
+    if (nestedResult.outcome === 'ok') nestedResult.lease.release();
+    expect(requester.stats()).toMatchObject({
+      trackedDigests: 0,
+      activeLeases: 0,
+      retainedPayloadBytes: 0,
+    });
+    expect(bytes.reservations.every(({ released }) => released)).toBe(true);
+    expect(stream.active()).toBe(false);
+    expect(decode.active()).toBe(false);
+  });
+
+  it('reserves a retained lease slot before reentrant byte admission', async () => {
+    const bytes = byteAdmission();
+    let requester: ReturnType<typeof createSystemRecordRequesterV1>;
+    let nested: Promise<SystemRecordExactFetchResultV1> | undefined;
+    let triggerAdmission = false;
+    const reentrantBytes: SystemRecordRequesterByteAdmissionV1 = {
+      tryReserve(requested) {
+        const reservation = bytes.tryReserve(requested);
+        if (triggerAdmission) {
+          triggerAdmission = false;
+          nested = requester.fetch(LOOKUP, new AbortController().signal);
+        }
+        return reservation;
+      },
+    };
+    requester = createSystemRecordRequesterV1({
+      networkId: NETWORK,
+      openExchange: async () => fixtureExchange().value,
+      byteAdmission: reentrantBytes,
+      streamAdmission: permitAdmission().value,
+      decodeAdmission: permitAdmission().value,
+      requestId: () => '1'.repeat(32),
+    });
+    const leases = [];
+    for (let index = 0; index < SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS; index += 1) {
+      const result = await requester.fetch(LOOKUP, new AbortController().signal);
+      expect(result.outcome).toBe('ok');
+      if (result.outcome === 'ok') leases.push(result.lease);
+    }
+
+    triggerAdmission = true;
+    const outer = requester.fetch(LOOKUP, new AbortController().signal);
+    expect(nested).toBeDefined();
+    const [outerResult, nestedResult] = await Promise.all([outer, nested!]);
+    expect([outerResult.outcome, nestedResult.outcome].sort()).toEqual(['capacity', 'ok']);
+    if (outerResult.outcome === 'ok') leases.push(outerResult.lease);
+    if (nestedResult.outcome === 'ok') leases.push(nestedResult.lease);
+    expect(requester.stats().activeLeases).toBe(
+      SYSTEM_RECORD_MAX_EXACT_FETCH_WAITERS + 1,
+    );
+
+    for (const lease of leases) lease.release();
+    expect(requester.stats()).toMatchObject({
+      trackedDigests: 0,
+      activeLeases: 0,
+      retainedPayloadBytes: 0,
+    });
+    expect(bytes.reservations.every(({ released }) => released)).toBe(true);
+  });
+
   it.each([
     ['decode admission', 'requester close'],
     ['decode admission', 'caller abort'],
@@ -361,6 +475,87 @@ describe('system-record requester V1', () => {
       expect(decode.active()).toBe(false);
     },
   );
+
+  it('does not let an older stream release clear reentrant leader accounting', async () => {
+    const otherPayload = Uint8Array.of(7, 8, 9);
+    const otherDigest = digestSystemRecordBytesV1(
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+      otherPayload,
+    );
+    const otherLookup = Object.freeze({
+      type: 'object' as const,
+      objectKind: 'profile-bundle' as const,
+      objectDigest: otherDigest,
+    });
+    const firstExchange = fixtureExchange();
+    const secondGate = Promise.withResolvers<void>();
+    const secondExchange = fixtureExchange(async (request) => {
+      await secondGate.promise;
+      return successResponse(request, otherPayload, otherDigest);
+    });
+    let opened = 0;
+    const openExchange = vi.fn(async () => {
+      opened += 1;
+      return opened === 1 ? firstExchange.value : secondExchange.value;
+    });
+    const stream = permitAdmission();
+    let requester: ReturnType<typeof createSystemRecordRequesterV1>;
+    let second: Promise<SystemRecordExactFetchResultV1> | undefined;
+    let triggerNextLeader = true;
+    const reentrantStream = {
+      tryAcquire() {
+        const permit = stream.value.tryAcquire();
+        if (permit === null) return null;
+        let released = false;
+        return Object.freeze({
+          release() {
+            if (released) return;
+            released = true;
+            permit.release();
+            if (triggerNextLeader) {
+              triggerNextLeader = false;
+              second = requester.fetch(otherLookup, new AbortController().signal);
+            }
+          },
+        });
+      },
+    };
+    requester = createSystemRecordRequesterV1({
+      networkId: NETWORK,
+      openExchange,
+      byteAdmission: byteAdmission(),
+      streamAdmission: reentrantStream,
+      decodeAdmission: permitAdmission().value,
+      requestId: () => '1'.repeat(32),
+    });
+
+    const first = await requester.fetch(LOOKUP, new AbortController().signal);
+    expect(first.outcome).toBe('ok');
+    expect(second).toBeDefined();
+    await secondExchange.requestWritten.promise;
+    expect(stream.active()).toBe(true);
+    expect(requester.stats()).toMatchObject({
+      started: 2,
+      completed: 1,
+      activeStream: 1,
+      peakActiveStream: 1,
+    });
+
+    if (first.outcome === 'ok') first.lease.release();
+    secondGate.resolve();
+    const secondResult = await second!;
+    expect(secondResult.outcome).toBe('ok');
+    if (secondResult.outcome === 'ok') secondResult.lease.release();
+    expect(stream.active()).toBe(false);
+    expect(requester.stats()).toMatchObject({
+      started: 2,
+      completed: 2,
+      trackedDigests: 0,
+      activeLeases: 0,
+      activeStream: 0,
+      peakActiveStream: 1,
+    });
+  });
 
   it('fetches and verifies an exact inventory object through the public requester', async () => {
     const leaf = { objectType: 'inventory-leaf', rows: [] } as const;
@@ -948,6 +1143,33 @@ describe('system-record requester V1', () => {
       new AbortController().signal,
     )).resolves.toMatchObject({ outcome: 'invalid-response', wireBytes: expect.any(Number) });
     expect(malformed.reset).toHaveBeenCalledWith('invalid-response');
+  });
+
+  it('accounts every returned byte before rejecting an oversized response frame', async () => {
+    const oversized = new Uint8Array(SYSTEM_RECORD_MAX_FRAME_BYTES + 1);
+    const exchange = fixtureExchange(async () => oversized);
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const requester = createRequester({
+      bytes,
+      stream,
+      openExchange: async () => exchange.value,
+    });
+
+    const result = await requester.fetch(LOOKUP, new AbortController().signal);
+    expect(result.outcome).toBe('invalid-response');
+    const requestFrame = exchange.writeRequestFrame.mock.calls[0]?.[0];
+    expect(requestFrame).toBeInstanceOf(Uint8Array);
+    expect(result.wireBytes).toBe(requestFrame!.byteLength + oversized.byteLength);
+    expect(exchange.reset).toHaveBeenCalledWith('invalid-response');
+    expect(stream.active()).toBe(false);
+    expect(bytes.reservations).toHaveLength(1);
+    expect(bytes.reservations[0]?.released).toBe(true);
+    expect(requester.stats()).toMatchObject({
+      trackedDigests: 0,
+      activeStream: 0,
+      retainedPayloadBytes: 0,
+    });
   });
 
   it('reserves before network work and releases permits on capacity, deadline, and close', async () => {

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -15,13 +15,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type {
   CreateSystemRecordRequesterOptionsV1,
-  SystemRecordRequesterAdmissionV1,
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterExchangeV1,
 } from '../src/system-records/requester-api-v1.js';
 import {
   createSystemRecordRequesterV1,
 } from '../src/system-records/requester-v1.js';
+import { createSystemRecordPermitGateV1 } from '../src/system-records/transport-v1.js';
 
 const NETWORK = 'base:84532' as const;
 const PAYLOAD = Uint8Array.of(1, 2, 3);
@@ -770,22 +770,8 @@ function errorResponse(
 }
 
 function permitAdmission() {
-  let active = false;
-  const value: SystemRecordRequesterAdmissionV1 = {
-    tryAcquire() {
-      if (active) return null;
-      active = true;
-      let released = false;
-      return Object.freeze({
-        release() {
-          if (released) return;
-          released = true;
-          active = false;
-        },
-      });
-    },
-  };
-  return { value, active: () => active };
+  const value = createSystemRecordPermitGateV1();
+  return { value, active: () => value.active === 1 };
 }
 
 function byteAdmission() {

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -2,6 +2,7 @@ import {
   SYSTEM_RECORD_DIGEST_DOMAINS_V1,
   SYSTEM_RECORD_MAX_FRAME_BYTES,
   SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES,
+  SYSTEM_RECORD_MAX_INVENTORY_PATH_DEPTH,
   SYSTEM_RECORD_WIRE_VERSION_V1,
   canonicalizeSystemRecordInventoryLeafObjectV1,
   computeSystemRecordInventoryLeafDigestV1,
@@ -9,6 +10,7 @@ import {
   digestSystemRecordBytesV1,
   encodeSystemRecordResponseFrameV1,
   type Digest32V1,
+  type NetworkIdV1,
   type SystemRecordRequestHeaderV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
 import { describe, expect, it, vi } from 'vitest';
@@ -225,6 +227,130 @@ describe('system-record requester V1', () => {
     const result = await first;
     expect(result.outcome).toBe('ok');
     if (result.outcome === 'ok') result.lease.release();
+  });
+
+  it('snapshots every lifecycle dependency before unrelated fetches and awaits', async () => {
+    const originalBytes = byteAdmission();
+    const originalStream = permitAdmission();
+    const originalDecode = permitAdmission();
+    const replacementBytes = byteAdmission();
+    const replacementStream = permitAdmission();
+    const replacementDecode = permitAdmission();
+    const firstResponse = Promise.withResolvers<void>();
+    const seenRequests: SystemRecordRequestHeaderV1[] = [];
+    const firstExchange = fixtureExchange(async (request) => {
+      seenRequests.push(request);
+      await firstResponse.promise;
+      return successResponse(request, PAYLOAD, DIGEST);
+    });
+    const otherPayload = Uint8Array.of(4, 5, 6);
+    const otherDigest = digestSystemRecordBytesV1(
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+      otherPayload,
+    );
+    const secondExchange = fixtureExchange(async (request) => {
+      seenRequests.push(request);
+      return successResponse(request, otherPayload, otherDigest);
+    });
+    const originalOpen = vi.fn()
+      .mockResolvedValueOnce(firstExchange.value)
+      .mockResolvedValueOnce(secondExchange.value);
+    const replacementOpen = vi.fn(async () => fixtureExchange().value);
+    const options = {
+      networkId: NETWORK,
+      openExchange: originalOpen,
+      byteAdmission: originalBytes,
+      streamAdmission: originalStream.value,
+      decodeAdmission: originalDecode.value,
+      requestId: () => '1'.repeat(32),
+    } satisfies CreateSystemRecordRequesterOptionsV1;
+    const requester = createSystemRecordRequesterV1(options);
+
+    const first = requester.fetch(LOOKUP, new AbortController().signal);
+    await firstExchange.requestWritten.promise;
+    Object.assign(options as object, {
+      networkId: 'replacement:1' as NetworkIdV1,
+      openExchange: replacementOpen,
+      byteAdmission: replacementBytes,
+      streamAdmission: replacementStream.value,
+      decodeAdmission: replacementDecode.value,
+      requestId: () => '2'.repeat(32),
+    });
+
+    const otherLookup = Object.freeze({ ...LOOKUP, objectDigest: otherDigest });
+    await expect(requester.fetch(
+      otherLookup,
+      new AbortController().signal,
+    )).resolves.toEqual({ outcome: 'busy', wireBytes: 0 });
+    expect(originalStream.active()).toBe(true);
+    expect(replacementStream.active()).toBe(false);
+    expect(replacementOpen).not.toHaveBeenCalled();
+
+    firstResponse.resolve();
+    const firstResult = await first;
+    expect(firstResult.outcome).toBe('ok');
+    expect(originalDecode.active()).toBe(true);
+    expect(replacementDecode.active()).toBe(false);
+    if (firstResult.outcome === 'ok') firstResult.lease.release();
+
+    const secondResult = await requester.fetch(
+      otherLookup,
+      new AbortController().signal,
+    );
+    expect(secondResult.outcome).toBe('ok');
+    expect(originalOpen).toHaveBeenCalledTimes(2);
+    expect(replacementOpen).not.toHaveBeenCalled();
+    expect(seenRequests).toHaveLength(2);
+    expect(seenRequests.map(({ networkId }) => networkId)).toEqual([NETWORK, NETWORK]);
+    expect(seenRequests.map(({ requestId }) => requestId)).toEqual([
+      '1'.repeat(32),
+      '1'.repeat(32),
+    ]);
+    expect(replacementBytes.reservations).toHaveLength(0);
+    expect(replacementStream.active()).toBe(false);
+    expect(replacementDecode.active()).toBe(false);
+    if (secondResult.outcome === 'ok') secondResult.lease.release();
+    expect(originalBytes.reservations).toHaveLength(6);
+    expect(originalBytes.reservations.every(({ released }) => released)).toBe(true);
+  });
+
+  it('rejects invalid inventory paths before keying or resource admission', async () => {
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const decode = permitAdmission();
+    const exchange = fixtureExchange();
+    const openExchange = vi.fn(async () => exchange.value);
+    const requester = createRequester({ bytes, stream, decode, openExchange });
+    const overDepth = new Array<number>(SYSTEM_RECORD_MAX_INVENTORY_PATH_DEPTH + 1).fill(0);
+    const hugeSparsePath: number[] = [];
+    hugeSparsePath.length = 1_000_000_000;
+
+    for (const path of [overDepth, hugeSparsePath]) {
+      await expect(requester.fetch({
+        type: 'inventory-object',
+        rootDescriptorDigest: DIGEST,
+        path,
+        objectKind: 'inventory-leaf',
+        objectDigest: DIGEST,
+      }, new AbortController().signal)).rejects.toThrow(
+        `inventory traversal path must contain at most ${SYSTEM_RECORD_MAX_INVENTORY_PATH_DEPTH} indexes`,
+      );
+    }
+
+    expect(openExchange).not.toHaveBeenCalled();
+    expect(bytes.reservations).toHaveLength(0);
+    expect(stream.active()).toBe(false);
+    expect(decode.active()).toBe(false);
+    expect(exchange.writeRequestFrame).not.toHaveBeenCalled();
+    expect(exchange.readResponseFrame).not.toHaveBeenCalled();
+    expect(exchange.reset).not.toHaveBeenCalled();
+    expect(requester.stats()).toMatchObject({
+      started: 0,
+      joined: 0,
+      completed: 0,
+      trackedDigests: 0,
+      activeStream: 0,
+    });
   });
 
   it('caps followers per digest without opening another stream', async () => {

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -55,7 +55,7 @@ describe('system-record requester V1', () => {
     expect(requester.stats()).toMatchObject({
       started: 1,
       joined: 1,
-      pendingDigests: 1,
+      trackedDigests: 1,
       waitingCallers: 2,
       activeStream: 1,
       queuedStreams: 0,
@@ -93,7 +93,7 @@ describe('system-record requester V1', () => {
     expect(bytes.reservations[3]?.released).toBe(false);
     expect(requester.stats()).toMatchObject({
       completed: 1,
-      pendingDigests: 1,
+      trackedDigests: 1,
       activeLeases: 2,
       retainedPayloadBytes: PAYLOAD.byteLength * 3,
       activeStream: 0,
@@ -109,7 +109,7 @@ describe('system-record requester V1', () => {
     expect(bytes.reservations[3]?.released).toBe(true);
     expect(decode.active()).toBe(false);
     expect(requester.stats()).toMatchObject({
-      pendingDigests: 0,
+      trackedDigests: 0,
       activeLeases: 0,
       retainedPayloadBytes: 0,
     });
@@ -138,7 +138,7 @@ describe('system-record requester V1', () => {
     expect(requester.stats()).toMatchObject({
       started: 1,
       joined: 1,
-      pendingDigests: 1,
+      trackedDigests: 1,
       activeLeases: 2,
       retainedPayloadBytes: PAYLOAD.byteLength * 3,
     });
@@ -147,7 +147,7 @@ describe('system-record requester V1', () => {
     first.lease.release();
     expect(bytes.reservations.every(({ released }) => released)).toBe(true);
     expect(requester.stats()).toMatchObject({
-      pendingDigests: 0,
+      trackedDigests: 0,
       activeLeases: 0,
       retainedPayloadBytes: 0,
     });
@@ -251,10 +251,10 @@ describe('system-record requester V1', () => {
     expect(openExchange).toHaveBeenCalledTimes(1);
   });
 
-  it('counts retained successful entries against the global digest cap', async () => {
+  it('counts retained successful entries against the tracked digest cap', async () => {
     const firstExchange = fixtureExchange();
     const openExchange = vi.fn(async () => firstExchange.value);
-    const requester = createRequester({ maxPendingDigests: 1, openExchange });
+    const requester = createRequester({ maxTrackedDigests: 1, openExchange });
     const first = await requester.fetch(
       LOOKUP,
       new AbortController().signal,
@@ -274,7 +274,7 @@ describe('system-record requester V1', () => {
     });
     expect(openExchange).toHaveBeenCalledTimes(1);
     if (first.outcome === 'ok') first.lease.release();
-    expect(requester.stats().pendingDigests).toBe(0);
+    expect(requester.stats().trackedDigests).toBe(0);
   });
 
   it('keeps a coalesced transfer alive when only one caller aborts', async () => {
@@ -310,7 +310,7 @@ describe('system-record requester V1', () => {
     await vi.waitFor(() => {
       expect(requester.stats()).toMatchObject({
         completed: 1,
-        pendingDigests: 0,
+        trackedDigests: 0,
         waitingCallers: 0,
         activeStream: 0,
       });
@@ -337,7 +337,7 @@ describe('system-record requester V1', () => {
     await expect(result).rejects.toThrow('caller left during open');
     await vi.waitFor(() => expect(requester.stats()).toMatchObject({
       completed: 1,
-      pendingDigests: 0,
+      trackedDigests: 0,
       waitingCallers: 0,
       activeStream: 0,
     }));
@@ -350,6 +350,7 @@ describe('system-record requester V1', () => {
     const bytes = byteAdmission();
     const stream = permitAdmission();
     const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
     const openExchange = vi.fn(async () => {
       controller.abort(new Error('cancelled during open'));
       return new Promise<SystemRecordRequesterExchangeV1>(() => {});
@@ -360,13 +361,14 @@ describe('system-record requester V1', () => {
     await expect(result).rejects.toThrow('cancelled during open');
     await vi.waitFor(() => expect(requester.stats()).toMatchObject({
       completed: 1,
-      pendingDigests: 0,
+      trackedDigests: 0,
       waitingCallers: 0,
       activeStream: 0,
     }));
     expect(stream.active()).toBe(false);
     expect(bytes.reservations).toHaveLength(1);
     expect(bytes.reservations[0]?.released).toBe(true);
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
   });
 
   it('does not attach an immediate retry to a cancelled single-flight', async () => {
@@ -383,7 +385,7 @@ describe('system-record requester V1', () => {
     await expect(retry).resolves.toEqual({ outcome: 'busy', wireBytes: 0 });
     expect(openExchange).toHaveBeenCalledTimes(1);
     await firstRejection;
-    await vi.waitFor(() => expect(requester.stats().pendingDigests).toBe(0));
+    await vi.waitFor(() => expect(requester.stats().trackedDigests).toBe(0));
   });
 
   it('maps every remote status and rejects invalid payload identity fail closed', async () => {
@@ -419,7 +421,7 @@ describe('system-record requester V1', () => {
     }));
     expect(invalidResult.wireBytes).toBeGreaterThan(0);
     expect(invalid.reset).toHaveBeenCalledWith('invalid-response');
-    expect(requester.stats()).toMatchObject({ pendingDigests: 0, activeStream: 0 });
+    expect(requester.stats()).toMatchObject({ trackedDigests: 0, activeStream: 0 });
 
     const malformed = fixtureExchange(async () => Uint8Array.of(1));
     active = malformed;
@@ -452,7 +454,7 @@ describe('system-record requester V1', () => {
       new AbortController().signal,
     )).resolves.toMatchObject({ outcome: 'deadline', wireBytes: expect.any(Number) });
     expect(slow.reset).toHaveBeenCalledWith('deadline');
-    expect(timed.stats()).toMatchObject({ pendingDigests: 0, activeStream: 0 });
+    expect(timed.stats()).toMatchObject({ trackedDigests: 0, activeStream: 0 });
 
     const blocked = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
     const closing = createRequester({ openExchange: async () => blocked.value });
@@ -464,7 +466,7 @@ describe('system-record requester V1', () => {
     closing.close();
     await expect(result).resolves.toMatchObject({ outcome: 'closed', wireBytes: expect.any(Number) });
     expect(blocked.reset).toHaveBeenCalledWith('closed');
-    expect(closing.stats()).toMatchObject({ closed: true, pendingDigests: 0, activeStream: 0 });
+    expect(closing.stats()).toMatchObject({ closed: true, trackedDigests: 0, activeStream: 0 });
     await expect(closing.fetch(
       LOOKUP,
       new AbortController().signal,
@@ -486,6 +488,29 @@ describe('system-record requester V1', () => {
     expect(openStream.active()).toBe(false);
     expect(openBytes.reservations).toHaveLength(1);
     expect(openBytes.reservations[0]?.released).toBe(true);
+
+    const writeBytes = byteAdmission();
+    const writeStream = permitAdmission();
+    const writeFailure = fixtureExchange();
+    writeFailure.writeRequestFrame.mockRejectedValueOnce(new Error('write failed'));
+    const writeRequester = createRequester({
+      bytes: writeBytes,
+      stream: writeStream,
+      openExchange: async () => writeFailure.value,
+    });
+    await expect(writeRequester.fetch(
+      LOOKUP,
+      new AbortController().signal,
+    )).resolves.toEqual({ outcome: 'transport', wireBytes: 0 });
+    expect(writeFailure.reset).toHaveBeenCalledWith('transport');
+    expect(writeFailure.readResponseFrame).not.toHaveBeenCalled();
+    expect(writeStream.active()).toBe(false);
+    expect(writeBytes.reservations).toHaveLength(1);
+    expect(writeBytes.reservations[0]?.released).toBe(true);
+    expect(writeRequester.stats()).toMatchObject({
+      trackedDigests: 0,
+      activeStream: 0,
+    });
 
     const readBytes = byteAdmission();
     const readStream = permitAdmission();
@@ -585,7 +610,7 @@ describe('system-record requester V1', () => {
     expect(base.reservations.every(({ released }) => released)).toBe(true);
     expect(decode.active()).toBe(false);
     expect(requester.stats()).toMatchObject({
-      pendingDigests: 0,
+      trackedDigests: 0,
       activeLeases: 0,
       retainedPayloadBytes: 0,
     });
@@ -616,7 +641,7 @@ describe('system-record requester V1', () => {
     expect(base.reservations[0]?.released).toBe(true);
     expect(decode.active()).toBe(false);
     expect(requester.stats()).toMatchObject({
-      pendingDigests: 0,
+      trackedDigests: 0,
       activeLeases: 0,
       retainedPayloadBytes: 0,
     });
@@ -690,7 +715,7 @@ function createRequester(overrides: {
   openExchange?: CreateSystemRecordRequesterOptionsV1['openExchange'];
   timeoutMs?: number;
   maxWaitersPerDigest?: number;
-  maxPendingDigests?: number;
+  maxTrackedDigests?: number;
 } = {}) {
   const stream = overrides.stream ?? permitAdmission();
   const decode = overrides.decode ?? permitAdmission();
@@ -705,9 +730,9 @@ function createRequester(overrides: {
     ...(overrides.maxWaitersPerDigest === undefined
       ? {}
       : { maxWaitersPerDigest: overrides.maxWaitersPerDigest }),
-    ...(overrides.maxPendingDigests === undefined
+    ...(overrides.maxTrackedDigests === undefined
       ? {}
-      : { maxPendingDigests: overrides.maxPendingDigests }),
+      : { maxTrackedDigests: overrides.maxTrackedDigests }),
   });
 }
 

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -3,6 +3,8 @@ import {
   SYSTEM_RECORD_MAX_FRAME_BYTES,
   SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES,
   SYSTEM_RECORD_WIRE_VERSION_V1,
+  canonicalizeSystemRecordInventoryLeafObjectV1,
+  computeSystemRecordInventoryLeafDigestV1,
   decodeSystemRecordRequestFrameV1,
   digestSystemRecordBytesV1,
   encodeSystemRecordResponseFrameV1,
@@ -149,6 +151,47 @@ describe('system-record requester V1', () => {
       activeLeases: 0,
       retainedPayloadBytes: 0,
     });
+  });
+
+  it('fetches and verifies an exact inventory object through the public requester', async () => {
+    const leaf = { objectType: 'inventory-leaf', rows: [] } as const;
+    const payload = canonicalizeSystemRecordInventoryLeafObjectV1(leaf, NETWORK, true);
+    const digest = computeSystemRecordInventoryLeafDigestV1(leaf, NETWORK, true);
+    const bytes = byteAdmission();
+    let active = fixtureExchange(async (request) => (
+      successResponse(request, payload, digest, 'inventory-leaf')
+    ));
+    const requester = createRequester({
+      bytes,
+      openExchange: async () => active.value,
+    });
+    const lookup = Object.freeze({
+      type: 'inventory-object' as const,
+      rootDescriptorDigest: DIGEST,
+      path: Object.freeze([]),
+      objectKind: 'inventory-leaf' as const,
+      objectDigest: digest,
+    });
+
+    const result = await requester.fetch(lookup, new AbortController().signal);
+    expect(result.outcome).toBe('ok');
+    if (result.outcome !== 'ok') return;
+    expect(result.lease.artifact).toMatchObject({
+      objectKind: 'inventory-leaf',
+      objectDigest: digest,
+      canonicalBytes: payload,
+    });
+    result.lease.release();
+
+    active = fixtureExchange(async (request) => (
+      successResponse(request, payload, digest, 'inventory-internal')
+    ));
+    await expect(requester.fetch(
+      lookup,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'invalid-response' });
+    expect(active.reset).toHaveBeenCalledWith('invalid-response');
+    expect(bytes.reservations.every(({ released }) => released)).toBe(true);
   });
 
   it('never queues an unrelated digest behind the one requester stream', async () => {
@@ -696,12 +739,13 @@ function successResponse(
   request: SystemRecordRequestHeaderV1,
   payload: Uint8Array,
   digest: Digest32V1,
+  objectKind: 'profile-bundle' | 'inventory-internal' | 'inventory-leaf' = 'profile-bundle',
 ): Uint8Array {
   return encodeSystemRecordResponseFrameV1({
     wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
     requestId: request.requestId,
     status: 'ok',
-    objectKind: 'profile-bundle',
+    objectKind,
     objectDigest: digest,
     payloadBytes: payload.byteLength.toString(),
   }, payload);

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -33,7 +33,7 @@ const LOOKUP = Object.freeze({
 });
 
 describe('system-record requester V1', () => {
-  it('coalesces one exact transfer and retains one accounted payload until all leases release', async () => {
+  it('coalesces one exact transfer and accounts isolated caller leases', async () => {
     const bytes = byteAdmission();
     const stream = permitAdmission();
     const decode = permitAdmission();
@@ -63,7 +63,10 @@ describe('system-record requester V1', () => {
     expect(firstResult.outcome).toBe('ok');
     expect(secondResult.outcome).toBe('ok');
     if (firstResult.outcome !== 'ok' || secondResult.outcome !== 'ok') return;
-    expect(firstResult.lease.artifact).toBe(secondResult.lease.artifact);
+    expect(firstResult.lease.artifact).not.toBe(secondResult.lease.artifact);
+    expect(firstResult.lease.artifact.canonicalBytes).not.toBe(
+      secondResult.lease.artifact.canonicalBytes,
+    );
     expect(firstResult.lease.artifact).toMatchObject({
       objectKind: 'profile-bundle',
       objectDigest: DIGEST,
@@ -78,23 +81,69 @@ describe('system-record requester V1', () => {
     expect(bytes.reservations.map(({ requested }) => requested)).toEqual([
       SYSTEM_RECORD_MAX_FRAME_BYTES,
       PAYLOAD.byteLength,
+      PAYLOAD.byteLength,
+      PAYLOAD.byteLength,
     ]);
     expect(bytes.reservations[0]?.released).toBe(true);
     expect(bytes.reservations[1]?.released).toBe(false);
+    expect(bytes.reservations[2]?.released).toBe(false);
+    expect(bytes.reservations[3]?.released).toBe(false);
     expect(requester.stats()).toMatchObject({
       completed: 1,
       pendingDigests: 1,
       activeLeases: 2,
-      retainedPayloadBytes: PAYLOAD.byteLength,
+      retainedPayloadBytes: PAYLOAD.byteLength * 3,
       activeStream: 0,
     });
     expect(decode.active()).toBe(true);
     firstResult.lease.release();
     expect(bytes.reservations[1]?.released).toBe(false);
+    expect(bytes.reservations[2]?.released).toBe(true);
+    expect(bytes.reservations[3]?.released).toBe(false);
     expect(decode.active()).toBe(true);
     secondResult.lease.release();
     expect(bytes.reservations[1]?.released).toBe(true);
+    expect(bytes.reservations[3]?.released).toBe(true);
     expect(decode.active()).toBe(false);
+    expect(requester.stats()).toMatchObject({
+      pendingDigests: 0,
+      activeLeases: 0,
+      retainedPayloadBytes: 0,
+    });
+  });
+
+  it('serves a late subscriber from retained bytes without sharing mutable storage', async () => {
+    const bytes = byteAdmission();
+    const requester = createRequester({ bytes });
+    const exchange = fixtureExchange();
+    const first = await requester.fetch(
+      LOOKUP,
+      async () => exchange.value,
+      new AbortController().signal,
+    );
+    expect(first.outcome).toBe('ok');
+    if (first.outcome !== 'ok') return;
+
+    const unopened = vi.fn(async () => fixtureExchange().value);
+    const second = await requester.fetch(LOOKUP, unopened, new AbortController().signal);
+    expect(second.outcome).toBe('ok');
+    if (second.outcome !== 'ok') return;
+    expect(unopened).not.toHaveBeenCalled();
+    expect(second.lease.artifact.canonicalBytes).toEqual(PAYLOAD);
+
+    first.lease.artifact.canonicalBytes[0] = 99;
+    expect(second.lease.artifact.canonicalBytes).toEqual(PAYLOAD);
+    expect(requester.stats()).toMatchObject({
+      started: 1,
+      joined: 1,
+      pendingDigests: 1,
+      activeLeases: 2,
+      retainedPayloadBytes: PAYLOAD.byteLength * 3,
+    });
+
+    second.lease.release();
+    first.lease.release();
+    expect(bytes.reservations.every(({ released }) => released)).toBe(true);
     expect(requester.stats()).toMatchObject({
       pendingDigests: 0,
       activeLeases: 0,
@@ -254,6 +303,14 @@ describe('system-record requester V1', () => {
     expect(invalidResult.wireBytes).toBeGreaterThan(0);
     expect(invalid.reset).toHaveBeenCalledWith('invalid-response');
     expect(requester.stats()).toMatchObject({ pendingDigests: 0, activeStream: 0 });
+
+    const malformed = fixtureExchange(async () => Uint8Array.of(1));
+    await expect(requester.fetch(
+      LOOKUP,
+      async () => malformed.value,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'invalid-response', wireBytes: expect.any(Number) });
+    expect(malformed.reset).toHaveBeenCalledWith('invalid-response');
   });
 
   it('reserves before network work and releases permits on capacity, deadline, and close', async () => {
@@ -318,6 +375,52 @@ describe('system-record requester V1', () => {
     held?.release();
   });
 
+  it('acquires decoder admission before verifying a successful payload', async () => {
+    const decode = permitAdmission();
+    const held = decode.value.tryAcquire();
+    expect(held).not.toBeNull();
+    const invalid = fixtureExchange(async (request) => (
+      successResponse(request, Uint8Array.of(9, 9, 9), DIGEST)
+    ));
+    const requester = createRequester({ decode });
+
+    await expect(requester.fetch(
+      LOOKUP,
+      async () => invalid.value,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'busy', wireBytes: expect.any(Number) });
+    expect(invalid.reset).not.toHaveBeenCalled();
+    held?.release();
+  });
+
+  it('fails closed when an isolated lease copy cannot be reserved', async () => {
+    const base = byteAdmission();
+    let reservationAttempt = 0;
+    const bytes: SystemRecordRequesterByteAdmissionV1 = {
+      tryReserve(requested) {
+        reservationAttempt += 1;
+        if (reservationAttempt === 3) return null;
+        return base.tryReserve(requested);
+      },
+    };
+    const decode = permitAdmission();
+    const requester = createRequester({ bytes, decode });
+
+    await expect(requester.fetch(
+      LOOKUP,
+      async () => fixtureExchange().value,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'capacity', wireBytes: expect.any(Number) });
+    expect(base.reservations).toHaveLength(2);
+    expect(base.reservations.every(({ released }) => released)).toBe(true);
+    expect(decode.active()).toBe(false);
+    expect(requester.stats()).toMatchObject({
+      pendingDigests: 0,
+      activeLeases: 0,
+      retainedPayloadBytes: 0,
+    });
+  });
+
   it('accepts the maximum legal bundle under encoded and decoded reservations', async () => {
     const payload = new Uint8Array(SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES);
     const digest = digestSystemRecordBytesV1(
@@ -335,6 +438,7 @@ describe('system-record requester V1', () => {
     expect(result.outcome).toBe('ok');
     expect(bytes.reservations.map(({ requested }) => requested)).toEqual([
       SYSTEM_RECORD_MAX_FRAME_BYTES,
+      SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES,
       SYSTEM_RECORD_MAX_FRAME_PAYLOAD_BYTES,
     ]);
     expect(bytes.reservations[0]?.shrunk).toBeLessThanOrEqual(SYSTEM_RECORD_MAX_FRAME_BYTES);
@@ -362,13 +466,15 @@ describe('system-record requester V1', () => {
     expect(requester.stats()).toMatchObject({
       closed: true,
       activeLeases: 1,
-      retainedPayloadBytes: PAYLOAD.byteLength,
+      retainedPayloadBytes: PAYLOAD.byteLength * 2,
     });
     expect(bytes.reservations[1]?.released).toBe(false);
+    expect(bytes.reservations[2]?.released).toBe(false);
     expect(decode.active()).toBe(true);
     if (result.outcome === 'ok') result.lease.release();
     expect(requester.stats()).toMatchObject({ activeLeases: 0, retainedPayloadBytes: 0 });
     expect(bytes.reservations[1]?.released).toBe(true);
+    expect(bytes.reservations[2]?.released).toBe(true);
     expect(decode.active()).toBe(false);
   });
 });

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -353,42 +353,145 @@ describe('system-record requester V1', () => {
     });
   });
 
-  it('cancels a newly created entry when synchronous setup aborts its first caller', async () => {
+  it.each([
+    'request id creation',
+    'stream admission',
+    'byte admission',
+  ] as const)('rejects a synchronous setup abort from %s without retained work', async (hook) => {
     const controller = new AbortController();
     const bytes = byteAdmission();
     const stream = permitAdmission();
     const decode = permitAdmission();
     const exchange = fixtureExchange();
     const openExchange = vi.fn(async () => exchange.value);
+    const requestId = vi.fn(() => {
+      if (hook === 'request id creation') {
+        controller.abort(new Error('caller aborted during request setup'));
+      }
+      return '1'.repeat(32);
+    });
+    const streamAdmission = {
+      tryAcquire: vi.fn(() => {
+        if (hook === 'stream admission') {
+          controller.abort(new Error('caller aborted during request setup'));
+        }
+        return stream.value.tryAcquire();
+      }),
+    };
+    const reentrantBytes: SystemRecordRequesterByteAdmissionV1 = {
+      tryReserve: vi.fn((requested) => {
+        if (hook === 'byte admission') {
+          controller.abort(new Error('caller aborted during request setup'));
+        }
+        return bytes.tryReserve(requested);
+      }),
+    };
     const requester = createSystemRecordRequesterV1({
       networkId: NETWORK,
       openExchange,
-      byteAdmission: bytes,
-      streamAdmission: stream.value,
+      byteAdmission: reentrantBytes,
+      streamAdmission,
       decodeAdmission: decode.value,
-      requestId: () => {
-        controller.abort(new Error('caller aborted during request setup'));
-        return '1'.repeat(32);
-      },
+      requestId,
     });
 
     await expect(requester.fetch(LOOKUP, controller.signal)).rejects.toThrow(
       'caller aborted during request setup',
     );
     await vi.waitFor(() => expect(requester.stats()).toMatchObject({
-      completed: 1,
+      started: 0,
+      completed: 0,
       trackedDigests: 0,
       waitingCallers: 0,
       activeLeases: 0,
       activeStream: 0,
       retainedPayloadBytes: 0,
     }));
-    await vi.waitFor(() => expect(exchange.reset).toHaveBeenCalledWith('cancelled'));
+    expect(openExchange).not.toHaveBeenCalled();
+    expect(exchange.reset).not.toHaveBeenCalled();
     expect(exchange.writeRequestFrame).not.toHaveBeenCalled();
-    expect(bytes.reservations).toHaveLength(1);
-    expect(bytes.reservations[0]?.released).toBe(true);
+    expect(exchange.readResponseFrame).not.toHaveBeenCalled();
+    expect(requestId).toHaveBeenCalledOnce();
+    expect(streamAdmission.tryAcquire).toHaveBeenCalledTimes(
+      hook === 'request id creation' ? 0 : 1,
+    );
+    expect(reentrantBytes.tryReserve).toHaveBeenCalledTimes(
+      hook === 'byte admission' ? 1 : 0,
+    );
+    expect(bytes.reservations).toHaveLength(hook === 'byte admission' ? 1 : 0);
+    expect(bytes.reservations.every(({ released }) => released)).toBe(true);
     expect(stream.active()).toBe(false);
     expect(decode.active()).toBe(false);
+  });
+
+  it.each([
+    'request id creation',
+    'stream admission',
+    'byte admission',
+  ] as const)('fences requester close reentered from %s', async (hook) => {
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const decode = permitAdmission();
+    const exchange = fixtureExchange();
+    const openExchange = vi.fn(async () => exchange.value);
+    let requester: ReturnType<typeof createSystemRecordRequesterV1>;
+    const requestId = vi.fn(() => {
+      if (hook === 'request id creation') requester.close();
+      return '1'.repeat(32);
+    });
+    const streamAdmission = {
+      tryAcquire: vi.fn(() => {
+        if (hook === 'stream admission') requester.close();
+        return stream.value.tryAcquire();
+      }),
+    };
+    const reentrantBytes: SystemRecordRequesterByteAdmissionV1 = {
+      tryReserve: vi.fn((requested) => {
+        if (hook === 'byte admission') requester.close();
+        return bytes.tryReserve(requested);
+      }),
+    };
+    requester = createSystemRecordRequesterV1({
+      networkId: NETWORK,
+      openExchange,
+      byteAdmission: reentrantBytes,
+      streamAdmission,
+      decodeAdmission: decode.value,
+      requestId,
+    });
+
+    await expect(requester.fetch(
+      LOOKUP,
+      new AbortController().signal,
+    )).resolves.toEqual({ outcome: 'closed', wireBytes: 0 });
+    expect(requestId).toHaveBeenCalledOnce();
+    expect(streamAdmission.tryAcquire).toHaveBeenCalledTimes(
+      hook === 'request id creation' ? 0 : 1,
+    );
+    expect(reentrantBytes.tryReserve).toHaveBeenCalledTimes(
+      hook === 'byte admission' ? 1 : 0,
+    );
+    expect(bytes.reservations).toHaveLength(hook === 'byte admission' ? 1 : 0);
+    expect(bytes.reservations.every(({ released }) => released)).toBe(true);
+    expect(stream.active()).toBe(false);
+    expect(decode.active()).toBe(false);
+    expect(openExchange).not.toHaveBeenCalled();
+    expect(exchange.writeRequestFrame).not.toHaveBeenCalled();
+    expect(exchange.readResponseFrame).not.toHaveBeenCalled();
+    expect(exchange.reset).not.toHaveBeenCalled();
+    expect(requester.stats()).toEqual({
+      started: 0,
+      joined: 0,
+      completed: 0,
+      trackedDigests: 0,
+      waitingCallers: 0,
+      activeLeases: 0,
+      activeStream: 0,
+      peakActiveStream: 0,
+      queuedStreams: 0,
+      retainedPayloadBytes: 0,
+      closed: true,
+    });
   });
 
   it('caps followers per digest without opening another stream', async () => {

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -1033,6 +1033,30 @@ describe('system-record requester V1', () => {
     expect(exchange.reset).toHaveBeenCalledWith('cancelled');
   });
 
+  it('does not open a transport after the sole caller cancels before leader start', async () => {
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const openExchange = vi.fn(async () => fixtureExchange().value);
+    const requester = createRequester({ bytes, stream, openExchange });
+    const controller = new AbortController();
+
+    const result = requester.fetch(LOOKUP, controller.signal);
+    controller.abort(new Error('caller cancelled before leader start'));
+
+    await expect(result).rejects.toThrow('caller cancelled before leader start');
+    await vi.waitFor(() => expect(requester.stats()).toMatchObject({
+      started: 1,
+      completed: 1,
+      trackedDigests: 0,
+      waitingCallers: 0,
+      activeStream: 0,
+    }));
+    expect(openExchange).not.toHaveBeenCalled();
+    expect(stream.active()).toBe(false);
+    expect(bytes.reservations).toHaveLength(1);
+    expect(bytes.reservations[0]?.released).toBe(true);
+  });
+
   it('releases stream and frame ownership when the only caller leaves during open', async () => {
     const bytes = byteAdmission();
     const stream = permitAdmission();

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -12,6 +12,7 @@ import {
 import { describe, expect, it, vi } from 'vitest';
 
 import type {
+  CreateSystemRecordRequesterOptionsV1,
   SystemRecordRequesterAdmissionV1,
   SystemRecordRequesterByteAdmissionV1,
   SystemRecordRequesterExchangeV1,
@@ -43,12 +44,12 @@ describe('system-record requester V1', () => {
       return successResponse(request, PAYLOAD, DIGEST);
     });
     const openExchange = vi.fn(async () => exchange.value);
-    const requester = createRequester({ bytes, stream, decode });
+    const requester = createRequester({ bytes, stream, decode, openExchange });
     const signal = new AbortController().signal;
 
-    const first = requester.fetch(LOOKUP, openExchange, signal);
+    const first = requester.fetch(LOOKUP, signal);
     await exchange.requestWritten.promise;
-    const second = requester.fetch(LOOKUP, openExchange, signal);
+    const second = requester.fetch(LOOKUP, signal);
     expect(requester.stats()).toMatchObject({
       started: 1,
       joined: 1,
@@ -114,21 +115,20 @@ describe('system-record requester V1', () => {
 
   it('serves a late subscriber from retained bytes without sharing mutable storage', async () => {
     const bytes = byteAdmission();
-    const requester = createRequester({ bytes });
     const exchange = fixtureExchange();
+    const openExchange = vi.fn(async () => exchange.value);
+    const requester = createRequester({ bytes, openExchange });
     const first = await requester.fetch(
       LOOKUP,
-      async () => exchange.value,
       new AbortController().signal,
     );
     expect(first.outcome).toBe('ok');
     if (first.outcome !== 'ok') return;
 
-    const unopened = vi.fn(async () => fixtureExchange().value);
-    const second = await requester.fetch(LOOKUP, unopened, new AbortController().signal);
+    const second = await requester.fetch(LOOKUP, new AbortController().signal);
     expect(second.outcome).toBe('ok');
     if (second.outcome !== 'ok') return;
-    expect(unopened).not.toHaveBeenCalled();
+    expect(openExchange).toHaveBeenCalledTimes(1);
     expect(second.lease.artifact.canonicalBytes).toEqual(PAYLOAD);
 
     first.lease.artifact.canonicalBytes[0] = 99;
@@ -157,10 +157,10 @@ describe('system-record requester V1', () => {
       await gate.promise;
       return successResponse(request, PAYLOAD, DIGEST);
     });
-    const requester = createRequester();
+    const openExchange = vi.fn(async () => firstExchange.value);
+    const requester = createRequester({ openExchange });
     const first = requester.fetch(
       LOOKUP,
-      async () => firstExchange.value,
       new AbortController().signal,
     );
     await firstExchange.requestWritten.promise;
@@ -169,15 +169,14 @@ describe('system-record requester V1', () => {
       SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
       otherPayload,
     );
-    const unopened = vi.fn(async () => fixtureExchange().value);
     await expect(requester.fetch({
       ...LOOKUP,
       objectDigest: otherDigest,
-    }, unopened, new AbortController().signal)).resolves.toEqual({
+    }, new AbortController().signal)).resolves.toEqual({
       outcome: 'busy',
       wireBytes: 0,
     });
-    expect(unopened).not.toHaveBeenCalled();
+    expect(openExchange).toHaveBeenCalledTimes(1);
     expect(requester.stats().queuedStreams).toBe(0);
     gate.resolve();
     const result = await first;
@@ -192,12 +191,12 @@ describe('system-record requester V1', () => {
       return successResponse(request, PAYLOAD, DIGEST);
     });
     const openExchange = vi.fn(async () => exchange.value);
-    const requester = createRequester({ maxWaitersPerDigest: 1 });
+    const requester = createRequester({ maxWaitersPerDigest: 1, openExchange });
     const signal = new AbortController().signal;
-    const leader = requester.fetch(LOOKUP, openExchange, signal);
+    const leader = requester.fetch(LOOKUP, signal);
     await exchange.requestWritten.promise;
-    const follower = requester.fetch(LOOKUP, openExchange, signal);
-    await expect(requester.fetch(LOOKUP, openExchange, signal)).resolves.toEqual({
+    const follower = requester.fetch(LOOKUP, signal);
+    await expect(requester.fetch(LOOKUP, signal)).resolves.toEqual({
       outcome: 'waiter-limit',
       wireBytes: 0,
     });
@@ -211,10 +210,10 @@ describe('system-record requester V1', () => {
 
   it('counts retained successful entries against the global digest cap', async () => {
     const firstExchange = fixtureExchange();
-    const requester = createRequester({ maxPendingDigests: 1 });
+    const openExchange = vi.fn(async () => firstExchange.value);
+    const requester = createRequester({ maxPendingDigests: 1, openExchange });
     const first = await requester.fetch(
       LOOKUP,
-      async () => firstExchange.value,
       new AbortController().signal,
     );
     expect(first.outcome).toBe('ok');
@@ -223,15 +222,14 @@ describe('system-record requester V1', () => {
       SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
       otherPayload,
     );
-    const unopened = vi.fn(async () => fixtureExchange().value);
     await expect(requester.fetch({
       ...LOOKUP,
       objectDigest: otherDigest,
-    }, unopened, new AbortController().signal)).resolves.toEqual({
+    }, new AbortController().signal)).resolves.toEqual({
       outcome: 'capacity',
       wireBytes: 0,
     });
-    expect(unopened).not.toHaveBeenCalled();
+    expect(openExchange).toHaveBeenCalledTimes(1);
     if (first.outcome === 'ok') first.lease.release();
     expect(requester.stats().pendingDigests).toBe(0);
   });
@@ -242,12 +240,12 @@ describe('system-record requester V1', () => {
       await gate.promise;
       return successResponse(request, PAYLOAD, DIGEST);
     });
-    const requester = createRequester();
+    const requester = createRequester({ openExchange: async () => exchange.value });
     const leaderController = new AbortController();
     const followerController = new AbortController();
-    const leader = requester.fetch(LOOKUP, async () => exchange.value, leaderController.signal);
+    const leader = requester.fetch(LOOKUP, leaderController.signal);
     await exchange.requestWritten.promise;
-    const follower = requester.fetch(LOOKUP, async () => exchange.value, followerController.signal);
+    const follower = requester.fetch(LOOKUP, followerController.signal);
     leaderController.abort(new Error('leader cancelled'));
     await expect(leader).rejects.toThrow('leader cancelled');
     gate.resolve();
@@ -260,9 +258,9 @@ describe('system-record requester V1', () => {
   it('aborts and releases the shared transfer after its final caller leaves', async () => {
     const bytes = byteAdmission();
     const exchange = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
-    const requester = createRequester({ bytes });
+    const requester = createRequester({ bytes, openExchange: async () => exchange.value });
     const controller = new AbortController();
-    const result = requester.fetch(LOOKUP, async () => exchange.value, controller.signal);
+    const result = requester.fetch(LOOKUP, controller.signal);
     await exchange.requestWritten.promise;
     controller.abort(new Error('caller left'));
     await expect(result).rejects.toThrow('caller left');
@@ -287,9 +285,9 @@ describe('system-record requester V1', () => {
       opening.resolve();
       return new Promise<SystemRecordRequesterExchangeV1>(() => {});
     });
-    const requester = createRequester({ bytes, stream });
+    const requester = createRequester({ bytes, stream, openExchange });
     const controller = new AbortController();
-    const result = requester.fetch(LOOKUP, openExchange, controller.signal);
+    const result = requester.fetch(LOOKUP, controller.signal);
     await opening.promise;
     controller.abort(new Error('caller left during open'));
 
@@ -313,8 +311,8 @@ describe('system-record requester V1', () => {
       controller.abort(new Error('cancelled during open'));
       return new Promise<SystemRecordRequesterExchangeV1>(() => {});
     });
-    const requester = createRequester({ bytes, stream });
-    const result = requester.fetch(LOOKUP, openExchange, controller.signal);
+    const requester = createRequester({ bytes, stream, openExchange });
+    const result = requester.fetch(LOOKUP, controller.signal);
 
     await expect(result).rejects.toThrow('cancelled during open');
     await vi.waitFor(() => expect(requester.stats()).toMatchObject({
@@ -330,23 +328,24 @@ describe('system-record requester V1', () => {
 
   it('does not attach an immediate retry to a cancelled single-flight', async () => {
     const exchange = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
-    const requester = createRequester();
+    const openExchange = vi.fn(async () => exchange.value);
+    const requester = createRequester({ openExchange });
     const controller = new AbortController();
-    const first = requester.fetch(LOOKUP, async () => exchange.value, controller.signal);
+    const first = requester.fetch(LOOKUP, controller.signal);
     await exchange.requestWritten.promise;
     const firstRejection = expect(first).rejects.toThrow('caller left');
     controller.abort(new Error('caller left'));
 
-    const unopened = vi.fn(async () => fixtureExchange().value);
-    const retry = requester.fetch(LOOKUP, unopened, new AbortController().signal);
+    const retry = requester.fetch(LOOKUP, new AbortController().signal);
     await expect(retry).resolves.toEqual({ outcome: 'busy', wireBytes: 0 });
-    expect(unopened).not.toHaveBeenCalled();
+    expect(openExchange).toHaveBeenCalledTimes(1);
     await firstRejection;
     await vi.waitFor(() => expect(requester.stats().pendingDigests).toBe(0));
   });
 
   it('maps every remote status and rejects invalid payload identity fail closed', async () => {
-    const requester = createRequester();
+    let active = fixtureExchange();
+    const requester = createRequester({ openExchange: async () => active.value });
     const statuses = [
       ['not-found', 'not-found'],
       ['unsupported', 'unsupported'],
@@ -356,9 +355,9 @@ describe('system-record requester V1', () => {
     ] as const;
     for (const [remote, local] of statuses) {
       const response = fixtureExchange(async (request) => errorResponse(request, remote));
+      active = response;
       await expect(requester.fetch(
         LOOKUP,
-        async () => response.value,
         new AbortController().signal,
       )).resolves.toMatchObject({ outcome: local, wireBytes: expect.any(Number) });
       expect(response.reset).not.toHaveBeenCalled();
@@ -366,9 +365,9 @@ describe('system-record requester V1', () => {
 
     const wrongPayload = Uint8Array.of(9, 9, 9);
     const invalid = fixtureExchange(async (request) => successResponse(request, wrongPayload, DIGEST));
+    active = invalid;
     const invalidResult = await requester.fetch(
       LOOKUP,
-      async () => invalid.value,
       new AbortController().signal,
     );
     expect(invalidResult).toEqual(expect.objectContaining({
@@ -380,9 +379,9 @@ describe('system-record requester V1', () => {
     expect(requester.stats()).toMatchObject({ pendingDigests: 0, activeStream: 0 });
 
     const malformed = fixtureExchange(async () => Uint8Array.of(1));
+    active = malformed;
     await expect(requester.fetch(
       LOOKUP,
-      async () => malformed.value,
       new AbortController().signal,
     )).resolves.toMatchObject({ outcome: 'invalid-response', wireBytes: expect.any(Number) });
     expect(malformed.reset).toHaveBeenCalledWith('invalid-response');
@@ -390,34 +389,32 @@ describe('system-record requester V1', () => {
 
   it('reserves before network work and releases permits on capacity, deadline, and close', async () => {
     const stream = permitAdmission();
+    const unopened = vi.fn(async () => fixtureExchange().value);
     const exhausted = createRequester({
       bytes: { tryReserve: vi.fn(() => null) },
       stream,
+      openExchange: unopened,
     });
-    const unopened = vi.fn(async () => fixtureExchange().value);
     await expect(exhausted.fetch(
       LOOKUP,
-      unopened,
       new AbortController().signal,
     )).resolves.toEqual({ outcome: 'capacity', wireBytes: 0 });
     expect(unopened).not.toHaveBeenCalled();
     expect(stream.active()).toBe(false);
 
     const slow = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
-    const timed = createRequester({ timeoutMs: 5 });
+    const timed = createRequester({ timeoutMs: 5, openExchange: async () => slow.value });
     await expect(timed.fetch(
       LOOKUP,
-      async () => slow.value,
       new AbortController().signal,
     )).resolves.toMatchObject({ outcome: 'deadline', wireBytes: expect.any(Number) });
     expect(slow.reset).toHaveBeenCalledWith('deadline');
     expect(timed.stats()).toMatchObject({ pendingDigests: 0, activeStream: 0 });
 
     const blocked = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
-    const closing = createRequester();
+    const closing = createRequester({ openExchange: async () => blocked.value });
     const result = closing.fetch(
       LOOKUP,
-      async () => blocked.value,
       new AbortController().signal,
     );
     await blocked.requestWritten.promise;
@@ -427,9 +424,58 @@ describe('system-record requester V1', () => {
     expect(closing.stats()).toMatchObject({ closed: true, pendingDigests: 0, activeStream: 0 });
     await expect(closing.fetch(
       LOOKUP,
-      unopened,
       new AbortController().signal,
     )).resolves.toEqual({ outcome: 'closed', wireBytes: 0 });
+  });
+
+  it('maps ordinary open and read failures to transport with complete cleanup', async () => {
+    const openBytes = byteAdmission();
+    const openStream = permitAdmission();
+    const openFailure = createRequester({
+      bytes: openBytes,
+      stream: openStream,
+      openExchange: async () => { throw new Error('dial failed'); },
+    });
+    await expect(openFailure.fetch(
+      LOOKUP,
+      new AbortController().signal,
+    )).resolves.toEqual({ outcome: 'transport', wireBytes: 0 });
+    expect(openStream.active()).toBe(false);
+    expect(openBytes.reservations).toHaveLength(1);
+    expect(openBytes.reservations[0]?.released).toBe(true);
+
+    const readBytes = byteAdmission();
+    const readStream = permitAdmission();
+    const readFailure = fixtureExchange(async () => { throw new Error('read failed'); });
+    const readRequester = createRequester({
+      bytes: readBytes,
+      stream: readStream,
+      openExchange: async () => readFailure.value,
+    });
+    const result = await readRequester.fetch(LOOKUP, new AbortController().signal);
+    expect(result).toMatchObject({ outcome: 'transport', wireBytes: expect.any(Number) });
+    expect(result.wireBytes).toBeGreaterThan(0);
+    expect(readFailure.reset).toHaveBeenCalledWith('transport');
+    expect(readStream.active()).toBe(false);
+    expect(readBytes.reservations).toHaveLength(1);
+    expect(readBytes.reservations[0]?.released).toBe(true);
+  });
+
+  it('resets an exchange that opens after the requester deadline', async () => {
+    const opening = Promise.withResolvers<SystemRecordRequesterExchangeV1>();
+    const requester = createRequester({
+      timeoutMs: 5,
+      openExchange: async () => opening.promise,
+    });
+    await expect(requester.fetch(
+      LOOKUP,
+      new AbortController().signal,
+    )).resolves.toEqual({ outcome: 'deadline', wireBytes: 0 });
+
+    const late = fixtureExchange();
+    opening.resolve(late.value);
+    await vi.waitFor(() => expect(late.reset).toHaveBeenCalledWith('deadline'));
+    expect(late.writeRequestFrame).not.toHaveBeenCalled();
   });
 
   it('returns busy when the shared decoder is occupied and retains no payload', async () => {
@@ -438,10 +484,13 @@ describe('system-record requester V1', () => {
     expect(held).not.toBeNull();
     const bytes = byteAdmission();
     const exchange = fixtureExchange(async (request) => successResponse(request, PAYLOAD, DIGEST));
-    const requester = createRequester({ bytes, decode });
+    const requester = createRequester({
+      bytes,
+      decode,
+      openExchange: async () => exchange.value,
+    });
     await expect(requester.fetch(
       LOOKUP,
-      async () => exchange.value,
       new AbortController().signal,
     )).resolves.toMatchObject({ outcome: 'busy', wireBytes: expect.any(Number) });
     expect(bytes.reservations).toHaveLength(1);
@@ -457,11 +506,10 @@ describe('system-record requester V1', () => {
     const invalid = fixtureExchange(async (request) => (
       successResponse(request, Uint8Array.of(9, 9, 9), DIGEST)
     ));
-    const requester = createRequester({ decode });
+    const requester = createRequester({ decode, openExchange: async () => invalid.value });
 
     await expect(requester.fetch(
       LOOKUP,
-      async () => invalid.value,
       new AbortController().signal,
     )).resolves.toMatchObject({ outcome: 'busy', wireBytes: expect.any(Number) });
     expect(invalid.reset).not.toHaveBeenCalled();
@@ -479,15 +527,50 @@ describe('system-record requester V1', () => {
       },
     };
     const decode = permitAdmission();
-    const requester = createRequester({ bytes, decode });
+    const capacityExchange = fixtureExchange();
+    const requester = createRequester({
+      bytes,
+      decode,
+      openExchange: async () => capacityExchange.value,
+    });
 
     await expect(requester.fetch(
       LOOKUP,
-      async () => fixtureExchange().value,
       new AbortController().signal,
     )).resolves.toMatchObject({ outcome: 'capacity', wireBytes: expect.any(Number) });
     expect(base.reservations).toHaveLength(2);
     expect(base.reservations.every(({ released }) => released)).toBe(true);
+    expect(decode.active()).toBe(false);
+    expect(requester.stats()).toMatchObject({
+      pendingDigests: 0,
+      activeLeases: 0,
+      retainedPayloadBytes: 0,
+    });
+  });
+
+  it('releases decoder and frame ownership when verified payload retention is full', async () => {
+    const base = byteAdmission();
+    let reservationAttempt = 0;
+    const bytes: SystemRecordRequesterByteAdmissionV1 = {
+      tryReserve(requested) {
+        reservationAttempt += 1;
+        if (reservationAttempt === 2) return null;
+        return base.tryReserve(requested);
+      },
+    };
+    const decode = permitAdmission();
+    const exchange = fixtureExchange();
+    const requester = createRequester({
+      bytes,
+      decode,
+      openExchange: async () => exchange.value,
+    });
+
+    const result = await requester.fetch(LOOKUP, new AbortController().signal);
+    expect(result).toMatchObject({ outcome: 'capacity', wireBytes: expect.any(Number) });
+    expect(result.wireBytes).toBeGreaterThan(0);
+    expect(base.reservations).toHaveLength(1);
+    expect(base.reservations[0]?.released).toBe(true);
     expect(decode.active()).toBe(false);
     expect(requester.stats()).toMatchObject({
       pendingDigests: 0,
@@ -504,11 +587,11 @@ describe('system-record requester V1', () => {
     );
     const bytes = byteAdmission();
     const exchange = fixtureExchange(async (request) => successResponse(request, payload, digest));
-    const requester = createRequester({ bytes });
+    const requester = createRequester({ bytes, openExchange: async () => exchange.value });
     const result = await requester.fetch({
       ...LOOKUP,
       objectDigest: digest,
-    }, async () => exchange.value, new AbortController().signal);
+    }, new AbortController().signal);
 
     expect(result.outcome).toBe('ok');
     expect(bytes.reservations.map(({ requested }) => requested)).toEqual([
@@ -530,10 +613,13 @@ describe('system-record requester V1', () => {
     const bytes = byteAdmission();
     const decode = permitAdmission();
     const exchange = fixtureExchange();
-    const requester = createRequester({ bytes, decode });
+    const requester = createRequester({
+      bytes,
+      decode,
+      openExchange: async () => exchange.value,
+    });
     const result = await requester.fetch(
       LOOKUP,
-      async () => exchange.value,
       new AbortController().signal,
     );
     expect(result.outcome).toBe('ok');
@@ -558,6 +644,7 @@ function createRequester(overrides: {
   bytes?: SystemRecordRequesterByteAdmissionV1;
   stream?: ReturnType<typeof permitAdmission>;
   decode?: ReturnType<typeof permitAdmission>;
+  openExchange?: CreateSystemRecordRequesterOptionsV1['openExchange'];
   timeoutMs?: number;
   maxWaitersPerDigest?: number;
   maxPendingDigests?: number;
@@ -566,6 +653,7 @@ function createRequester(overrides: {
   const decode = overrides.decode ?? permitAdmission();
   return createSystemRecordRequesterV1({
     networkId: NETWORK,
+    openExchange: overrides.openExchange ?? (async () => fixtureExchange().value),
     byteAdmission: overrides.bytes ?? byteAdmission(),
     streamAdmission: stream.value,
     decodeAdmission: decode.value,

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -21,7 +21,7 @@ import type {
 import {
   createSystemRecordRequesterV1,
 } from '../src/system-records/requester-v1.js';
-import { createSystemRecordPermitGateV1 } from '../src/system-records/transport-v1.js';
+import { createSystemRecordPermitGateV1 } from '../src/system-records/resource-admission-v1-internal.js';
 
 const NETWORK = 'base:84532' as const;
 const PAYLOAD = Uint8Array.of(1, 2, 3);

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -854,11 +854,18 @@ function createRequester(overrides: {
     requestId: () => '1'.repeat(32),
     ...(overrides.timeoutMs === undefined ? {} : { timeoutMs: overrides.timeoutMs }),
     ...(overrides.maxWaitersPerDigest === undefined
+      && overrides.maxTrackedDigests === undefined
       ? {}
-      : { maxWaitersPerDigest: overrides.maxWaitersPerDigest }),
-    ...(overrides.maxTrackedDigests === undefined
-      ? {}
-      : { maxTrackedDigests: overrides.maxTrackedDigests }),
+      : {
+        limits: Object.freeze({
+          ...(overrides.maxWaitersPerDigest === undefined
+            ? {}
+            : { maxWaitersPerDigest: overrides.maxWaitersPerDigest }),
+          ...(overrides.maxTrackedDigests === undefined
+            ? {}
+            : { maxTrackedDigests: overrides.maxTrackedDigests }),
+        }),
+      }),
   });
 }
 

--- a/packages/agent/test/system-record-requester-v1.test.ts
+++ b/packages/agent/test/system-record-requester-v1.test.ts
@@ -305,6 +305,29 @@ describe('system-record requester V1', () => {
     expect(bytes.reservations[0]?.released).toBe(true);
   });
 
+  it('cleans up when the opener synchronously cancels the initiating caller', async () => {
+    const bytes = byteAdmission();
+    const stream = permitAdmission();
+    const controller = new AbortController();
+    const openExchange = vi.fn(async () => {
+      controller.abort(new Error('cancelled during open'));
+      return new Promise<SystemRecordRequesterExchangeV1>(() => {});
+    });
+    const requester = createRequester({ bytes, stream });
+    const result = requester.fetch(LOOKUP, openExchange, controller.signal);
+
+    await expect(result).rejects.toThrow('cancelled during open');
+    await vi.waitFor(() => expect(requester.stats()).toMatchObject({
+      completed: 1,
+      pendingDigests: 0,
+      waitingCallers: 0,
+      activeStream: 0,
+    }));
+    expect(stream.active()).toBe(false);
+    expect(bytes.reservations).toHaveLength(1);
+    expect(bytes.reservations[0]?.released).toBe(true);
+  });
+
   it('does not attach an immediate retry to a cancelled single-flight', async () => {
     const exchange = fixtureExchange(async () => new Promise<Uint8Array>(() => {}));
     const requester = createRequester();

--- a/packages/agent/test/system-record-requester-wire-v1.test.ts
+++ b/packages/agent/test/system-record-requester-wire-v1.test.ts
@@ -2,7 +2,6 @@ import {
   SYSTEM_RECORD_KIND_V1,
   SYSTEM_RECORD_WIRE_VERSION_V1,
   decodeSystemRecordRequestFrameV1,
-  encodeSystemRecordRequestFrameV1,
   type Digest32V1,
 } from '@origintrail-official/dkg-core/system-record-v1';
 import { describe, expect, it } from 'vitest';
@@ -103,9 +102,7 @@ describe('system-record exact requester wire mapping V1', () => {
 
 function writtenRequest(lookup: SystemRecordExactArtifactLookupV1) {
   const mapped = createSystemRecordExactRequestV1(NETWORK, lookup, REQUEST_ID);
-  const request = decodeSystemRecordRequestFrameV1(
-    encodeSystemRecordRequestFrameV1(mapped.request),
-  );
+  const request = decodeSystemRecordRequestFrameV1(mapped.requestFrame);
   expect(request).toMatchObject({
     wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
     requestId: REQUEST_ID,

--- a/packages/agent/test/system-record-requester-wire-v1.test.ts
+++ b/packages/agent/test/system-record-requester-wire-v1.test.ts
@@ -1,4 +1,6 @@
 import {
+  SYSTEM_RECORD_KIND_V1,
+  SYSTEM_RECORD_WIRE_VERSION_V1,
   decodeSystemRecordRequestFrameV1,
   encodeSystemRecordRequestFrameV1,
   type Digest32V1,
@@ -26,7 +28,7 @@ describe('system-record exact requester wire mapping V1', () => {
       objectKind: 'profile-bundle',
       objectDigest: DIGEST_A,
     });
-    expect(key).toBe(JSON.stringify(['get-bundle', 'profile-bundle', DIGEST_A]));
+    expect(key).toBe(JSON.stringify(['object', 'profile-bundle', DIGEST_A]));
   });
 
   it('writes non-bundle exact lookups as get-control-object requests', () => {
@@ -42,7 +44,7 @@ describe('system-record exact requester wire mapping V1', () => {
       objectDigest: DIGEST_A,
     });
     expect(key).toBe(JSON.stringify([
-      'get-control-object',
+      'object',
       'owned-subject-table',
       DIGEST_A,
     ]));
@@ -65,7 +67,7 @@ describe('system-record exact requester wire mapping V1', () => {
       objectDigest: DIGEST_B,
     });
     expect(key).toBe(JSON.stringify([
-      'get-inventory-object',
+      'inventory-object',
       DIGEST_A,
       [1, 7],
       'inventory-leaf',
@@ -75,7 +77,7 @@ describe('system-record exact requester wire mapping V1', () => {
 
   it('snapshots and freezes mutable inventory paths before asynchronous transfer', () => {
     const path = [1, 7];
-    const { request } = createSystemRecordExactRequestV1(NETWORK, {
+    const { key, request } = createSystemRecordExactRequestV1(NETWORK, {
       type: 'inventory-object',
       rootDescriptorDigest: DIGEST_A,
       path,
@@ -87,6 +89,13 @@ describe('system-record exact requester wire mapping V1', () => {
     expect(request.operation).toBe('get-inventory-object');
     if (request.operation !== 'get-inventory-object') return;
     expect(request.path).toEqual([1, 7]);
+    expect(key).toBe(JSON.stringify([
+      'inventory-object',
+      DIGEST_A,
+      [1, 7],
+      'inventory-leaf',
+      DIGEST_B,
+    ]));
     expect(Object.isFrozen(request.path)).toBe(true);
     expect(Object.isFrozen(request)).toBe(true);
   });
@@ -94,8 +103,18 @@ describe('system-record exact requester wire mapping V1', () => {
 
 function writtenRequest(lookup: SystemRecordExactArtifactLookupV1) {
   const mapped = createSystemRecordExactRequestV1(NETWORK, lookup, REQUEST_ID);
+  const request = decodeSystemRecordRequestFrameV1(
+    encodeSystemRecordRequestFrameV1(mapped.request),
+  );
+  expect(request).toMatchObject({
+    wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
+    requestId: REQUEST_ID,
+    kind: SYSTEM_RECORD_KIND_V1,
+    networkId: NETWORK,
+    payloadBytes: '0',
+  });
   return Object.freeze({
     key: mapped.key,
-    request: decodeSystemRecordRequestFrameV1(encodeSystemRecordRequestFrameV1(mapped.request)),
+    request,
   });
 }

--- a/packages/agent/test/system-record-requester-wire-v1.test.ts
+++ b/packages/agent/test/system-record-requester-wire-v1.test.ts
@@ -59,6 +59,24 @@ describe('system-record exact requester wire mapping V1', () => {
       objectDigest: DIGEST_B,
     });
   });
+
+  it('snapshots and freezes mutable inventory paths before asynchronous transfer', () => {
+    const path = [1, 7];
+    const request = createSystemRecordExactRequestV1(NETWORK, {
+      type: 'inventory-object',
+      rootDescriptorDigest: DIGEST_A,
+      path,
+      objectKind: 'inventory-leaf',
+      objectDigest: DIGEST_B,
+    }, REQUEST_ID);
+    path[0] = 0;
+
+    expect(request.operation).toBe('get-inventory-object');
+    if (request.operation !== 'get-inventory-object') return;
+    expect(request.path).toEqual([1, 7]);
+    expect(Object.isFrozen(request.path)).toBe(true);
+    expect(Object.isFrozen(request)).toBe(true);
+  });
 });
 
 function writtenRequest(lookup: SystemRecordExactArtifactLookupV1) {

--- a/packages/agent/test/system-record-requester-wire-v1.test.ts
+++ b/packages/agent/test/system-record-requester-wire-v1.test.ts
@@ -7,7 +7,10 @@ import {
 import { describe, expect, it } from 'vitest';
 
 import type { SystemRecordExactArtifactLookupV1 } from '../src/system-records/requester-api-v1.js';
-import { createSystemRecordExactRequestV1 } from '../src/system-records/requester-wire-v1-internal.js';
+import {
+  createSystemRecordExactRequestV1,
+  normalizeSystemRecordExactLookupV1,
+} from '../src/system-records/requester-wire-v1-internal.js';
 
 const NETWORK = 'base:84532' as const;
 const REQUEST_ID = '1'.repeat(32);
@@ -76,19 +79,20 @@ describe('system-record exact requester wire mapping V1', () => {
 
   it('snapshots and freezes mutable inventory paths before asynchronous transfer', () => {
     const path = [1, 7];
-    const { key, request } = createSystemRecordExactRequestV1(NETWORK, {
+    const normalized = normalizeSystemRecordExactLookupV1(NETWORK, {
       type: 'inventory-object',
       rootDescriptorDigest: DIGEST_A,
       path,
       objectKind: 'inventory-leaf',
       objectDigest: DIGEST_B,
-    }, REQUEST_ID);
+    });
+    const { request } = createSystemRecordExactRequestV1(normalized, REQUEST_ID);
     path[0] = 0;
 
     expect(request.operation).toBe('get-inventory-object');
     if (request.operation !== 'get-inventory-object') return;
     expect(request.path).toEqual([1, 7]);
-    expect(key).toBe(JSON.stringify([
+    expect(normalized.key).toBe(JSON.stringify([
       'inventory-object',
       DIGEST_A,
       [1, 7],
@@ -106,16 +110,16 @@ describe('system-record exact requester wire mapping V1', () => {
       objectDigest: DIGEST_A,
     } as unknown as SystemRecordExactArtifactLookupV1;
 
-    expect(() => createSystemRecordExactRequestV1(
+    expect(() => normalizeSystemRecordExactLookupV1(
       NETWORK,
       invalid,
-      REQUEST_ID,
     )).toThrow('exact request object kind is invalid');
   });
 });
 
 function writtenRequest(lookup: SystemRecordExactArtifactLookupV1) {
-  const mapped = createSystemRecordExactRequestV1(NETWORK, lookup, REQUEST_ID);
+  const normalized = normalizeSystemRecordExactLookupV1(NETWORK, lookup);
+  const mapped = createSystemRecordExactRequestV1(normalized, REQUEST_ID);
   const request = decodeSystemRecordRequestFrameV1(mapped.requestFrame);
   expect(request).toMatchObject({
     wireVersion: SYSTEM_RECORD_WIRE_VERSION_V1,
@@ -125,7 +129,7 @@ function writtenRequest(lookup: SystemRecordExactArtifactLookupV1) {
     payloadBytes: '0',
   });
   return Object.freeze({
-    key: mapped.key,
+    key: normalized.key,
     request,
   });
 }

--- a/packages/agent/test/system-record-requester-wire-v1.test.ts
+++ b/packages/agent/test/system-record-requester-wire-v1.test.ts
@@ -15,7 +15,7 @@ const DIGEST_B = `0x${'bb'.repeat(32)}` as Digest32V1;
 
 describe('system-record exact requester wire mapping V1', () => {
   it('writes profile bundle lookups as get-bundle requests', () => {
-    const request = writtenRequest({
+    const { key, request } = writtenRequest({
       type: 'object',
       objectKind: 'profile-bundle',
       objectDigest: DIGEST_A,
@@ -26,10 +26,11 @@ describe('system-record exact requester wire mapping V1', () => {
       objectKind: 'profile-bundle',
       objectDigest: DIGEST_A,
     });
+    expect(key).toBe(JSON.stringify(['get-bundle', 'profile-bundle', DIGEST_A]));
   });
 
   it('writes non-bundle exact lookups as get-control-object requests', () => {
-    const request = writtenRequest({
+    const { key, request } = writtenRequest({
       type: 'object',
       objectKind: 'owned-subject-table',
       objectDigest: DIGEST_A,
@@ -40,10 +41,15 @@ describe('system-record exact requester wire mapping V1', () => {
       objectKind: 'owned-subject-table',
       objectDigest: DIGEST_A,
     });
+    expect(key).toBe(JSON.stringify([
+      'get-control-object',
+      'owned-subject-table',
+      DIGEST_A,
+    ]));
   });
 
   it('preserves the complete coordinate in get-inventory-object requests', () => {
-    const request = writtenRequest({
+    const { key, request } = writtenRequest({
       type: 'inventory-object',
       rootDescriptorDigest: DIGEST_A,
       path: [1, 7],
@@ -58,11 +64,18 @@ describe('system-record exact requester wire mapping V1', () => {
       objectKind: 'inventory-leaf',
       objectDigest: DIGEST_B,
     });
+    expect(key).toBe(JSON.stringify([
+      'get-inventory-object',
+      DIGEST_A,
+      [1, 7],
+      'inventory-leaf',
+      DIGEST_B,
+    ]));
   });
 
   it('snapshots and freezes mutable inventory paths before asynchronous transfer', () => {
     const path = [1, 7];
-    const request = createSystemRecordExactRequestV1(NETWORK, {
+    const { request } = createSystemRecordExactRequestV1(NETWORK, {
       type: 'inventory-object',
       rootDescriptorDigest: DIGEST_A,
       path,
@@ -81,5 +94,8 @@ describe('system-record exact requester wire mapping V1', () => {
 
 function writtenRequest(lookup: SystemRecordExactArtifactLookupV1) {
   const mapped = createSystemRecordExactRequestV1(NETWORK, lookup, REQUEST_ID);
-  return decodeSystemRecordRequestFrameV1(encodeSystemRecordRequestFrameV1(mapped));
+  return Object.freeze({
+    key: mapped.key,
+    request: decodeSystemRecordRequestFrameV1(encodeSystemRecordRequestFrameV1(mapped.request)),
+  });
 }

--- a/packages/agent/test/system-record-requester-wire-v1.test.ts
+++ b/packages/agent/test/system-record-requester-wire-v1.test.ts
@@ -98,6 +98,20 @@ describe('system-record exact requester wire mapping V1', () => {
     expect(Object.isFrozen(request.path)).toBe(true);
     expect(Object.isFrozen(request)).toBe(true);
   });
+
+  it('rejects object kinds outside the Core exact-request taxonomy', () => {
+    const invalid = {
+      type: 'object',
+      objectKind: 'root-descriptor',
+      objectDigest: DIGEST_A,
+    } as unknown as SystemRecordExactArtifactLookupV1;
+
+    expect(() => createSystemRecordExactRequestV1(
+      NETWORK,
+      invalid,
+      REQUEST_ID,
+    )).toThrow('exact request object kind is invalid');
+  });
 });
 
 function writtenRequest(lookup: SystemRecordExactArtifactLookupV1) {

--- a/packages/agent/test/system-record-requester-wire-v1.test.ts
+++ b/packages/agent/test/system-record-requester-wire-v1.test.ts
@@ -1,0 +1,67 @@
+import {
+  decodeSystemRecordRequestFrameV1,
+  encodeSystemRecordRequestFrameV1,
+  type Digest32V1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+import { describe, expect, it } from 'vitest';
+
+import type { SystemRecordExactArtifactLookupV1 } from '../src/system-records/requester-api-v1.js';
+import { createSystemRecordExactRequestV1 } from '../src/system-records/requester-wire-v1-internal.js';
+
+const NETWORK = 'base:84532' as const;
+const REQUEST_ID = '1'.repeat(32);
+const DIGEST_A = `0x${'aa'.repeat(32)}` as Digest32V1;
+const DIGEST_B = `0x${'bb'.repeat(32)}` as Digest32V1;
+
+describe('system-record exact requester wire mapping V1', () => {
+  it('writes profile bundle lookups as get-bundle requests', () => {
+    const request = writtenRequest({
+      type: 'object',
+      objectKind: 'profile-bundle',
+      objectDigest: DIGEST_A,
+    });
+
+    expect(request).toMatchObject({
+      operation: 'get-bundle',
+      objectKind: 'profile-bundle',
+      objectDigest: DIGEST_A,
+    });
+  });
+
+  it('writes non-bundle exact lookups as get-control-object requests', () => {
+    const request = writtenRequest({
+      type: 'object',
+      objectKind: 'owned-subject-table',
+      objectDigest: DIGEST_A,
+    });
+
+    expect(request).toMatchObject({
+      operation: 'get-control-object',
+      objectKind: 'owned-subject-table',
+      objectDigest: DIGEST_A,
+    });
+  });
+
+  it('preserves the complete coordinate in get-inventory-object requests', () => {
+    const request = writtenRequest({
+      type: 'inventory-object',
+      rootDescriptorDigest: DIGEST_A,
+      path: [1, 7],
+      objectKind: 'inventory-leaf',
+      objectDigest: DIGEST_B,
+    });
+
+    expect(request).toMatchObject({
+      operation: 'get-inventory-object',
+      rootDescriptorDigest: DIGEST_A,
+      path: [1, 7],
+      objectKind: 'inventory-leaf',
+      objectDigest: DIGEST_B,
+    });
+  });
+});
+
+function writtenRequest(lookup: SystemRecordExactArtifactLookupV1) {
+  const mapped = createSystemRecordExactRequestV1(NETWORK, lookup, REQUEST_ID);
+  return decodeSystemRecordRequestFrameV1(encodeSystemRecordRequestFrameV1(mapped));
+}

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -105,6 +105,7 @@ export default defineConfig({
       "test/sync-on-connect-churn.test.ts",
       "test/system-context-graph-policy.test.ts",
       "test/system-record-requester-v1.test.ts",
+      "test/system-record-requester-wire-v1.test.ts",
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",
       "test/swm-fanout-peer-selection.test.ts",

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -104,6 +104,7 @@ export default defineConfig({
       "test/sync-on-connect-retry.test.ts",
       "test/sync-on-connect-churn.test.ts",
       "test/system-context-graph-policy.test.ts",
+      "test/system-record-requester-v1.test.ts",
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",
       "test/swm-fanout-peer-selection.test.ts",


### PR DESCRIPTION
## Summary

- Add a default-unused exact System Record requester that canonicalizes exact coordinates, globally coalesces duplicate callers, and bounds each digest to 16 followers.
- Bound requester pressure with one externally owned, nonqueued stream permit; one externally owned decode permit; at most 128 tracked coordinates; a three-second exchange deadline; exact frame/retained/caller-copy byte charging; and zero internal transport queue.
- Normalize and key exact coordinates before leader selection; only a new leader allocates a request ID or frame, and frame construction consumes the normalized coordinate network.
- Verify request/response identity, record kind, digest, payload length, and canonical object digest before exposing an isolated, explicitly released byte lease to each caller.
- Snapshot every lifecycle dependency, admission owner, and supported lowering policy at requester construction so caller mutation cannot split accounting or transport ownership across awaits.
- Derive the exact-object taxonomy and dispatch from the Core request union through one compile-checked operation table.
- Fence abort, close, and same-key reentrancy across request/frame creation, every admission hook, frame/decode/source retention, retained lease delivery, source disposal, and stream cleanup; ownership transitions happen before external callbacks and release exactly once.
- Classify public failure and transport reset from one pure mapping, including late-open deadline, cancellation, and close cleanup.
- Give each single-flight entry ownership of transfer, cancellation, settlement, retained-source lifetime, and caller leases, with pending followers capped by policy and retained leases independently capped at the protocol maximum.
- Keep production behavior unchanged: this PR registers no protocol or lifecycle hook, opens no runtime session, and adds no periodic task, worker, retry loop, or runtime requester registration.

## Related

- Relates to #2052.
- Targets `integration/2052-system-record-sync` at integration base `3877ff162eafe9e74ce89ef0ce246771ce3edfba`.
- Builds on the already integrated provider and shared resource-admission work from #2206 and #2217.
- Replayed only the requester range after boundary `03d87320d042c9c89a1d75afed39103c590f8de4`: all 13 commits are `range-diff` equivalent and the aggregate stable patch ID remains `a7b642762d796a4b01f08375a8e0ec0c7e9f31b5`.
- Follow-up work owns provider-scoped negative memoization, the reconciler adapter, lifecycle/config wiring, legacy gating, and activation/cutover.

## Diagrams

### Before

```mermaid
flowchart LR
    R[Future reconciler] -->|exact coordinate| G[Abstract inventory loader]
    G --> P[Provider]
    G -. no requester ownership contract .-> L[Receiver lifecycle]
```

### After

```mermaid
sequenceDiagram
    participant R as Future reconciler
    participant Q as Exact requester
    participant A as Shared admissions
    participant P as Provider
    R->>Q: fetch exact coordinate
    Q->>Q: join or create bounded single-flight
    Q->>A: reserve stream and maximum frame bytes
    Q->>P: canonical exact request
    P-->>Q: bounded response
    Q->>A: acquire decoder
    Q->>Q: verify identity, digest, length, and payload
    Q->>A: retain verified source bytes
    Q-->>R: isolated charged lease
    R->>Q: release lease
    Q->>A: release caller and retained ownership
```

## Files changed

| Area | What |
| --- | --- |
| `packages/agent/src/system-records/requester-api-v1.ts` | Internal exact-coordinate, exchange opener, admission, result, lease, and statistics contracts. |
| `packages/agent/src/system-records/requester-v1.ts` | Public requester facade and bounded single-flight registry/entry lifecycle. |
| `packages/agent/src/system-records/requester-transfer-v1-internal.ts` | Abort-safe exchange opening, decoder-admitted verification, and retained-source ownership. |
| `packages/agent/src/system-records/requester-wire-v1-internal.ts` | Snapshotted lookup, stable coalescing key, operation allowlist, wire request, and remote-status mapping. |
| `packages/agent/src/system-records/resource-admission-v1-internal.ts` | Shared permit, byte reservation, gate, and abort-race primitives used by requester/provider paths. |
| `packages/agent/src/system-records/transport-v1.ts` and `provider-v1.ts` | Reuse shared lifecycle admission primitives without changing provider behavior or API ownership. |
| Requester/wire/type/package-root tests and package metadata | Exercise requester ownership and expose only the supported requester facade. |

## Test plan

- [x] Node.js `22.22.0` for the final fix round (the rebased requester range was also validated on `22.21.1`).
- [x] `pnpm --filter @origintrail-official/dkg-core build`.
- [x] `pnpm --filter @origintrail-official/dkg-storage build` (refresh declarations required by the integrated base).
- [x] `pnpm --filter @origintrail-official/dkg-agent build` including TypeScript, public API typecheck, and package-root export checks.
- [x] Focused requester and wire tests on the final head: 55 passed (50 requester, 5 wire), including pre-start cancellation, pending-follower versus retained-lease boundaries, follower zero request-ID work, oversized wire accounting, and abort/close/same-key reentrancy at every identified ownership hook.
- [x] Provider compatibility tests: 18 passed.
- [x] Full Agent unit run on immediately preceding head `8e914c4c1`: 2,533 passed, 5 skipped across 176/176 files; the final one-line pre-open abort fence passes the complete focused runtime and Agent build/type/package-root gates.
- [x] `git diff --check` and clean worktree.
- [x] Rebase evidence: 13/13 commits `range-diff` equivalent; aggregate patch ID preserved.
- [ ] GitHub CI on the final pushed head.


