### PR TITLE
fix(cli): redact RPC endpoints from node info

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -404,6 +404,13 @@ When the daemon is running, it exposes a local HTTP API (default: `http://localh
 - `GET /api/diagnostics/backpressure` — node-admin scheduler pressure snapshot
 - `GET /api/events` — Server-Sent Events stream for real-time notifications
 
+`GET /api/info` retains its legacy `chain.rpcUrl`, `chain.rpcUrls`, and
+`chain.hubAddress` keys for response-shape compatibility. RPC endpoint values
+are never returned (`rpcUrl` is `null`, `rpcUrls` is empty, and
+`rpcEndpointsRedacted` is `true`) because configured URLs can contain provider
+credentials. The public Hub contract address remains available, while
+`rpcEndpointCount` reports the number of configured endpoints.
+
 > The V9 `GET /api/apps` endpoint (and the `/apps/*` iframe host) was retired in
 > V10 along with the installable apps framework — the daemon now returns
 > `410 Gone` on those paths. See [Extending the Node](#extending-the-node) below.

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -859,6 +859,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     const allConns = agent.node.libp2p.getConnections();
     const uniquePeers = new Set(allConns.map((c) => c.remotePeer.toString()));
     const chainConf = resolveChainConfig(config, network);
+    const rpcEndpointCount = chainConf?.rpcUrl
+      ? resolveRpcUrls(chainConf.rpcUrl, chainConf.rpcUrls).length
+      : 0;
     const now = Date.now();
 
     return jsonResponse(res, 200, {
@@ -874,9 +877,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       chain: chainConf
         ? {
             chainId: chainConf.chainId ?? null,
-            rpcUrl: chainConf.rpcUrl,
-            rpcUrls: chainConf.rpcUrls ?? [],
-            hubAddress: chainConf.hubAddress,
+            configured: Boolean(chainConf.rpcUrl && chainConf.hubAddress),
+            rpcEndpointCount,
+            hubConfigured: Boolean(chainConf.hubAddress),
           }
         : null,
       peers: uniquePeers.size,

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -85,6 +85,7 @@ import {
   ensureDkgDir,
   TELEMETRY_ENDPOINTS,
   type DkgConfig,
+  type ResolvedChainConfig,
   type AutoUpdateConfig,
   type LocalAgentIntegrationCapabilities,
   type LocalAgentIntegrationConfig,
@@ -387,6 +388,32 @@ async function probeRpcEndpoint(rpcUrl: string, index: number): Promise<{
   }
 }
 
+interface PublicChainSummary {
+  chainId: string | null;
+  configured: boolean;
+  rpcEndpointCount: number;
+  hubConfigured: boolean;
+}
+
+/**
+ * Project effective chain configuration onto the non-secret HTTP status shape.
+ * Keeping this boundary shared prevents either status route from accidentally
+ * serializing credential-bearing RPC URLs or raw contract addresses.
+ */
+function buildPublicChainSummary(
+  chainConf: ResolvedChainConfig | undefined,
+): PublicChainSummary | null {
+  if (!chainConf) return null;
+  return {
+    chainId: chainConf.chainId ?? null,
+    configured: Boolean(chainConf.rpcUrl && chainConf.hubAddress),
+    rpcEndpointCount: chainConf.rpcUrl
+      ? resolveRpcUrls(chainConf.rpcUrl, chainConf.rpcUrls).length
+      : 0,
+    hubConfigured: Boolean(chainConf.hubAddress),
+  };
+}
+
 function createRouteEvmProvider(rpcUrl: string, rpcUrls?: string[]): ethers.JsonRpcProvider | ethers.FallbackProvider {
   const providers = resolveRpcUrls(rpcUrl, rpcUrls)
     .map((url) => new ethers.JsonRpcProvider(url, undefined, { cacheTimeout: -1 }));
@@ -646,9 +673,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     );
     const networkId = network?.networkId ?? await computeNetworkId(network?.genesisId);
     const chainConf = resolveChainConfig(config, network);
-    const rpcEndpointCount = chainConf?.rpcUrl
-      ? resolveRpcUrls(chainConf.rpcUrl, chainConf.rpcUrls).length
-      : 0;
+    const publicChainSummary = buildPublicChainSummary(chainConf);
     // Process-wide multi-RPC write-failover counters (host-only; no URLs).
     // Reflects WRITE failover/exhaustion across all chain adapters in this
     // daemon process; read-path failover is internal to the FallbackProvider.
@@ -823,12 +848,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       localAgentIntegrations,
       connectedLocalAgentIds: localAgentIntegrations.filter((integration) => integration.enabled).map((integration) => integration.id),
       autoUpdate: resolveAutoUpdateEnabled(config),
-      chain: chainConf
+      chain: publicChainSummary
         ? {
-            chainId: chainConf.chainId ?? null,
-            configured: Boolean(chainConf.rpcUrl && chainConf.hubAddress),
-            rpcEndpointCount,
-            hubConfigured: Boolean(chainConf.hubAddress),
+            ...publicChainSummary,
             // Multi-RPC failover observability (counts only — no RPC URLs).
             rpcFailovers: rpcFailoverStats.failovers,
             rpcExhaustions: rpcFailoverStats.exhaustions,
@@ -859,9 +881,6 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     const allConns = agent.node.libp2p.getConnections();
     const uniquePeers = new Set(allConns.map((c) => c.remotePeer.toString()));
     const chainConf = resolveChainConfig(config, network);
-    const rpcEndpointCount = chainConf?.rpcUrl
-      ? resolveRpcUrls(chainConf.rpcUrl, chainConf.rpcUrls).length
-      : 0;
     const now = Date.now();
 
     return jsonResponse(res, 200, {
@@ -874,14 +893,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       startedAt: new Date(startedAt).toISOString(),
       uptimeSeconds: Math.floor((now - startedAt) / 1000),
       timestamp: new Date(now).toISOString(),
-      chain: chainConf
-        ? {
-            chainId: chainConf.chainId ?? null,
-            configured: Boolean(chainConf.rpcUrl && chainConf.hubAddress),
-            rpcEndpointCount,
-            hubConfigured: Boolean(chainConf.hubAddress),
-          }
-        : null,
+      chain: buildPublicChainSummary(chainConf),
       peers: uniquePeers.size,
       contextGraphs: resolveContextGraphs(config).length,
       telemetry: config.telemetry?.enabled ?? false,

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -395,6 +395,18 @@ interface PublicChainSummary {
   hubConfigured: boolean;
 }
 
+interface PublicInfoChainSummary extends PublicChainSummary {
+  /**
+   * Compatibility fields retained from the original `/api/info` contract.
+   * RPC endpoint values are deliberately unavailable on every response: the
+   * configured URLs may carry userinfo, provider keys, or path/query tokens.
+   */
+  rpcUrl: null;
+  rpcUrls: [];
+  hubAddress: string | null;
+  rpcEndpointsRedacted: true;
+}
+
 /**
  * Project effective chain configuration onto the non-secret HTTP status shape.
  * Keeping this boundary shared prevents either status route from accidentally
@@ -411,6 +423,26 @@ function buildPublicChainSummary(
       ? resolveRpcUrls(chainConf.rpcUrl, chainConf.rpcUrls).length
       : 0,
     hubConfigured: Boolean(chainConf.hubAddress),
+  };
+}
+
+/**
+ * Keep the established `/api/info.chain` keys without returning credentials.
+ * The Hub contract address is public chain metadata, so it remains usable;
+ * endpoint fields fail closed and the additive marker makes that intentional
+ * contract visible to clients instead of silently changing the object shape.
+ */
+function buildPublicInfoChainSummary(
+  chainConf: ResolvedChainConfig | undefined,
+): PublicInfoChainSummary | null {
+  const summary = buildPublicChainSummary(chainConf);
+  if (!summary || !chainConf) return null;
+  return {
+    ...summary,
+    rpcUrl: null,
+    rpcUrls: [],
+    hubAddress: chainConf.hubAddress ?? null,
+    rpcEndpointsRedacted: true,
   };
 }
 
@@ -893,7 +925,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       startedAt: new Date(startedAt).toISOString(),
       uptimeSeconds: Math.floor((now - startedAt) / 1000),
       timestamp: new Date(now).toISOString(),
-      chain: buildPublicChainSummary(chainConf),
+      chain: buildPublicInfoChainSummary(chainConf),
       peers: uniquePeers.size,
       contextGraphs: resolveContextGraphs(config).length,
       telemetry: config.telemetry?.enabled ?? false,

--- a/packages/cli/test/auth.test.ts
+++ b/packages/cli/test/auth.test.ts
@@ -232,6 +232,12 @@ describe('httpAuthGuard', () => {
     expect(body.error).toContain('Unauthorized');
   });
 
+  it('rejects /api/info without token', async () => {
+    const res = await fetch(`${baseUrl}/api/info`);
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toBe('Bearer realm="dkg-node"');
+  });
+
   it('rejects Hermes provider persistence without token', async () => {
     const res = await fetch(`${baseUrl}/api/hermes-channel/persist-turn`, { method: 'POST' });
     expect(res.status).toBe(401);

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -220,11 +220,40 @@ describe('/api/info chain sanitization', () => {
       configured: true,
       rpcEndpointCount: 2,
       hubConfigured: true,
+      rpcUrl: null,
+      rpcUrls: [],
+      hubAddress: `0x${'11'.repeat(20)}`,
+      rpcEndpointsRedacted: true,
     });
-    expect(response.body.chain).not.toHaveProperty('rpcUrl');
-    expect(response.body.chain).not.toHaveProperty('rpcUrls');
     expect(JSON.stringify(response.body)).not.toContain(credentialSentinel);
     expect(JSON.stringify(response.body.chain)).not.toContain('://');
+  });
+
+  it('retains the legacy chain keys while making endpoint redaction explicit', async () => {
+    const response = await requestStatusWithAgent(
+      {},
+      {
+        auth: { enabled: true },
+        chain: {
+          type: 'evm',
+          rpcUrl: 'https://primary.invalid/operator-secret',
+          rpcUrls: ['https://backup.invalid/operator-secret'],
+          hubAddress: `0x${'22'.repeat(20)}`,
+          chainId: 'base:84532',
+        },
+      },
+      '/api/info',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.chain).toMatchObject({
+      rpcUrl: null,
+      rpcUrls: [],
+      hubAddress: `0x${'22'.repeat(20)}`,
+      rpcEndpointsRedacted: true,
+      rpcEndpointCount: 2,
+    });
+    expect(JSON.stringify(response.body)).not.toContain('operator-secret');
   });
 });
 

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -62,6 +62,7 @@ const DISABLED_RFC64_PUBLIC_CATALOG: RequestContext['rfc64PublicCatalog'] = {
 async function requestStatusWithAgent(
   agentOverrides: Record<string, unknown>,
   configOverrides: Record<string, unknown> = {},
+  requestPath = '/api/status',
 ): Promise<{ status: number; body: any }> {
   const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
@@ -103,7 +104,7 @@ async function requestStatusWithAgent(
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   try {
     const address = server.address() as AddressInfo;
-    const response = await fetch(`http://127.0.0.1:${address.port}/api/status`);
+    const response = await fetch(`http://127.0.0.1:${address.port}${requestPath}`);
     return { status: response.status, body: await response.json() };
   } finally {
     await new Promise<void>((resolve, reject) => {
@@ -191,6 +192,39 @@ describe('/api/status + /api/chain/rpc-health (real daemon, real chain)', () => 
     for (const probe of body.rpcs) {
       expect(probe).not.toHaveProperty('rpcUrl');
     }
+  });
+});
+
+describe('/api/info chain sanitization', () => {
+  it('never serializes configured RPC endpoint credentials when API auth is disabled', async () => {
+    const credentialSentinel = 'UNIT_TEST_RPC_CREDENTIAL_MUST_NOT_LEAK';
+    const response = await requestStatusWithAgent(
+      {},
+      {
+        auth: { enabled: false },
+        chain: {
+          type: 'evm',
+          rpcUrl: `https://tenant:${credentialSentinel}@primary.invalid/v1/${credentialSentinel}`,
+          rpcUrls: [`https://backup.invalid/rpc?token=${credentialSentinel}`],
+          hubAddress: `0x${'11'.repeat(20)}`,
+          chainId: 'base:84532',
+        },
+      },
+      '/api/info',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.auth).toBe(false);
+    expect(response.body.chain).toEqual({
+      chainId: 'base:84532',
+      configured: true,
+      rpcEndpointCount: 2,
+      hubConfigured: true,
+    });
+    expect(response.body.chain).not.toHaveProperty('rpcUrl');
+    expect(response.body.chain).not.toHaveProperty('rpcUrls');
+    expect(JSON.stringify(response.body)).not.toContain(credentialSentinel);
+    expect(JSON.stringify(response.body.chain)).not.toContain('://');
   });
 });
 


### PR DESCRIPTION
## Impact

`GET /api/info` no longer serializes configured RPC endpoint URLs. This prevents embedded userinfo, path tokens, or query credentials from being disclosed when an operator disables API authentication or shares the diagnostic response.

The endpoint keeps the established `chain` response keys while making redaction explicit:

- `chainId`
- `rpcUrl: null`
- `rpcUrls: []`
- `hubAddress` (public contract metadata)
- `rpcEndpointsRedacted: true`
- `configured`
- `rpcEndpointCount`
- `hubConfigured`

Authentication behavior is unchanged: `/api/info` remains protected by bearer authentication whenever API auth is enabled. No live node configuration or runtime is changed by this PR.

## Before

```mermaid
sequenceDiagram
    participant Caller as API caller
    participant API as DKG HTTP API
    participant Config as Chain configuration

    Caller->>API: GET /api/info
    API->>Config: Resolve effective chain configuration
    Config-->>API: Full RPC endpoint strings
    API-->>Caller: rpcUrl and rpcUrls with embedded credentials
```

## After

```mermaid
sequenceDiagram
    participant Caller as API caller
    participant API as DKG HTTP API
    participant Config as Chain configuration

    Caller->>API: GET /api/info
    API->>Config: Resolve effective chain configuration
    Config-->>API: Chain readiness, endpoint count, public Hub address
    API-->>Caller: Legacy keys with RPC values redacted explicitly
```

## Verification

- Synthetic credential-sentinel regressions prove both auth-enabled and auth-disabled `/api/info` responses retain the legacy chain keys without endpoint text.
- Explicit auth regression proves tokenless `/api/info` remains `401` when authentication is enabled.
- `pnpm exec vitest run --config vitest.unit.config.ts test/status-route-rpc.test.ts test/auth.test.ts -t '/api/info'` — 3 passed.
- `pnpm exec vitest run --config vitest.unit.config.ts test/auth.test.ts` — 38 passed.
- `DKG_SKIP_EVM_BUILD=1 pnpm --filter @origintrail-official/dkg... run build` — passed, including CLI TypeScript build and runtime asset copy.
- `git diff --check` — passed.

## Compatibility

The original `/api/info.chain` keys remain present. RPC endpoint fields fail closed (`null` and `[]`) because their prior usable values could carry credentials; `rpcEndpointsRedacted: true` makes that intentional contract machine-readable. The public Hub contract address remains unchanged. The additive summary fields let clients inspect readiness and endpoint count without parsing secrets.
