### PR TITLE
refactor(storage): unify structured mutation preparation

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -110,7 +110,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, captureStructuredMutationEffects, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, SystemRecordLaneForwarderV1, captureStructuredMutationSnapshot, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -577,12 +577,12 @@ export function createListContextGraphsCacheInvalidatingStore(
           )
       : undefined,
     structuredMutation: innerStore.structuredMutation
-      ? (mutation, options) => {
-          const effects = captureStructuredMutationEffects(mutation);
-          return invalidateAfterMutation(
-            () => innerStore.structuredMutation!(mutation, options),
-            () => effects !== undefined,
-            () => effects?.touchedGraphs.forEach(
+      ? async (mutation, options) => {
+          const snapshot = captureStructuredMutationSnapshot(mutation);
+          await invalidateAfterMutation(
+            () => innerStore.structuredMutation!(snapshot.mutation, options),
+            () => snapshot.outcome !== 'noop',
+            () => snapshot.effects?.touchedGraphs.forEach(
               (graph) => markProjectionDirty?.(undefined, graph),
             ),
           );

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -582,9 +582,12 @@ export function createListContextGraphsCacheInvalidatingStore(
           await invalidateAfterMutation(
             () => innerStore.structuredMutation!(snapshot.mutation, options),
             () => snapshot.outcome !== 'noop',
-            () => snapshot.effects?.touchedGraphs.forEach(
-              (graph) => markProjectionDirty?.(undefined, graph),
-            ),
+            () => {
+              if (snapshot.outcome === 'noop') return;
+              snapshot.effects.touchedGraphs.forEach(
+                (graph) => markProjectionDirty?.(undefined, graph),
+              );
+            },
           );
         }
       : undefined,

--- a/packages/agent/test/replace-subject-agent-wrapper.test.ts
+++ b/packages/agent/test/replace-subject-agent-wrapper.test.ts
@@ -156,13 +156,15 @@ describe('#1863 replaceSubject through the agent store wrapper', () => {
     const inFlight = new Promise<void>((resolve) => { release = resolve; });
     const options = { source: 'agent.test.structured-mutation-effects' };
     let inner!: TripleStore;
+    let observedMutation: unknown;
     const structuredMutation = vi.fn(function (
       this: TripleStore,
-      _mutation: unknown,
+      receivedMutation: unknown,
       receivedOptions: unknown,
     ) {
       expect(this).toBe(inner);
       expect(receivedOptions).toBe(options);
+      observedMutation = receivedMutation;
       return inFlight;
     });
     inner = { structuredMutation } as unknown as TripleStore;
@@ -193,6 +195,17 @@ describe('#1863 replaceSubject through the agent store wrapper', () => {
     expect(invalidate).toHaveBeenCalledOnce();
     expect(markProjectionDirty).toHaveBeenCalledOnce();
     expect(markProjectionDirty).toHaveBeenCalledWith(undefined, 'urn:test:target');
+    expect(observedMutation).toEqual({
+      kind: 'copy-subject-projection',
+      input: {
+        sourceGraphUris: ['urn:test:source'],
+        targetGraphUri: 'urn:test:target',
+        roots: ['urn:test:root'],
+        descendantSuffix: '/',
+        excludedPredicates: [],
+      },
+    });
+    expect(Object.isFrozen(observedMutation)).toBe(true);
   });
 
   it('does not invalidate structured mutation failures or structural no-ops', async () => {
@@ -211,6 +224,8 @@ describe('#1863 replaceSubject through the agent store wrapper', () => {
       kind: 'delete-subjects',
       input: { graphUri: 'urn:test:target', subjects: [] },
     });
+    expect(inner.structuredMutation).toHaveBeenCalledOnce();
+    expect(Object.isFrozen(inner.structuredMutation.mock.calls[0][0])).toBe(true);
     expect(invalidate).not.toHaveBeenCalled();
     expect(markProjectionDirty).not.toHaveBeenCalled();
 
@@ -221,5 +236,22 @@ describe('#1863 replaceSubject through the agent store wrapper', () => {
     })).rejects.toThrow('commit failed');
     expect(invalidate).not.toHaveBeenCalled();
     expect(markProjectionDirty).not.toHaveBeenCalled();
+  });
+
+  it('converts synchronous snapshot validation failures into rejected Promises', async () => {
+    const inner = {
+      structuredMutation: vi.fn(async () => undefined),
+    } as unknown as TripleStore;
+    const store = createListContextGraphsCacheInvalidatingStore(inner, vi.fn(), vi.fn());
+    let result!: Promise<void>;
+
+    expect(() => {
+      result = store.structuredMutation!({
+        kind: 'delete-subjects',
+        input: { graphUri: 'relative', subjects: [] },
+      });
+    }).not.toThrow();
+    await expect(result).rejects.toThrow(/absolute IRI/);
+    expect(inner.structuredMutation).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/test/replace-subject-agent-wrapper.test.ts
+++ b/packages/agent/test/replace-subject-agent-wrapper.test.ts
@@ -22,6 +22,7 @@ import {
   createTripleStore,
   tryReplaceSubjectAtomically,
   type Quad,
+  type StructuredMutation,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
 import { contextGraphCatalogUri, contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
@@ -206,6 +207,81 @@ describe('#1863 replaceSubject through the agent store wrapper', () => {
       },
     });
     expect(Object.isFrozen(observedMutation)).toBe(true);
+  });
+
+  it('forwards every structured mutation kind with exact scoped effects', async () => {
+    const structuredMutation = vi.fn(async () => undefined);
+    const inner = { structuredMutation } as unknown as TripleStore;
+    const invalidate = vi.fn();
+    const markProjectionDirty = vi.fn();
+    const store = createListContextGraphsCacheInvalidatingStore(
+      inner,
+      invalidate,
+      markProjectionDirty,
+    );
+    const options = { source: 'agent.test.all-structured-mutations' };
+    const graph = 'urn:test:agent:graph';
+    const target = 'urn:test:agent:target';
+    const predicate = 'urn:test:agent:predicate';
+    const fixtures: Array<{ mutation: StructuredMutation; touched: string }> = [
+      { mutation: { kind: 'delete-subjects', input: {
+        graphUri: graph, subjects: ['urn:test:agent:subject'],
+      } }, touched: graph },
+      { mutation: { kind: 'prune-ranked-subjects', input: {
+        graphUri: graph,
+        subjectPrefix: 'urn:test:agent:ranked:',
+        eligibilityPredicate: predicate,
+        eligibleObjects: ['approved'],
+        primaryRankPredicate: 'urn:test:agent:rank:primary',
+        secondaryRankPredicate: 'urn:test:agent:rank:secondary',
+        retainNewest: 1,
+        maxDelete: 1,
+      } }, touched: graph },
+      { mutation: { kind: 'prune-linked-record-closures', input: {
+        graphUri: graph,
+        matchObjectIris: ['urn:test:agent:member'],
+        linkPredicates: [predicate],
+        recordParentPredicate: 'urn:test:agent:parent',
+        descendantSeparator: '/',
+      } }, touched: graph },
+      { mutation: { kind: 'replace-subject-predicates', input: {
+        graphUri: graph,
+        subject: 'urn:test:agent:subject',
+        predicates: [predicate],
+        replacementQuads: [{
+          graph,
+          subject: 'urn:test:agent:subject',
+          predicate,
+          object: '"value"',
+        }],
+      } }, touched: graph },
+      { mutation: { kind: 'replace-projection-from-graph', input: {
+        targetGraphUri: target,
+        stagingGraphUri: 'urn:test:agent:staging',
+        targetSubject: 'urn:test:agent:subject',
+        preservedTargetPredicates: [predicate],
+        targetSubjectPrefixes: [],
+      } }, touched: target },
+      { mutation: { kind: 'copy-subject-projection', input: {
+        sourceGraphUris: [graph],
+        targetGraphUri: target,
+        roots: ['urn:test:agent:root'],
+        descendantSuffix: '/',
+        excludedPredicates: [],
+      } }, touched: target },
+    ];
+
+    for (const [index, fixture] of fixtures.entries()) {
+      await store.structuredMutation!(fixture.mutation, options);
+      expect(structuredMutation.mock.calls[index][1]).toBe(options);
+      expect(Object.isFrozen(structuredMutation.mock.calls[index][0])).toBe(true);
+      expect(markProjectionDirty).toHaveBeenNthCalledWith(
+        index + 1,
+        undefined,
+        fixture.touched,
+      );
+    }
+    expect(invalidate).toHaveBeenCalledTimes(fixtures.length);
   });
 
   it('does not invalidate structured mutation failures or structural no-ops', async () => {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -18,6 +18,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "benchmark:structured-mutation": "node scripts/benchmark-structured-mutation.mjs",
     "build": "tsc",
     "test": "vitest run",
     "test:package-exports": "node scripts/verify-pack-exports.mjs",

--- a/packages/storage/scripts/benchmark-structured-mutation.mjs
+++ b/packages/storage/scripts/benchmark-structured-mutation.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { cpus } from 'node:os';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const WARMUPS = 10;
+const TRIALS = 30;
+const REPETITIONS = 3;
+const REGRESSION_LIMIT_PERCENT = 10;
+
+const fixture = Object.freeze({
+  kind: 'delete-subjects',
+  input: Object.freeze({
+    graphUri: 'urn:benchmark:structured-mutation',
+    subjects: Object.freeze(Array.from(
+      { length: 100_000 },
+      (_, index) => `urn:benchmark:subject:${index.toString().padStart(6, '0')}`,
+    )),
+  }),
+});
+const fixtureDigest = createHash('sha256')
+  .update(JSON.stringify(fixture))
+  .digest('hex');
+
+if (process.argv.includes('--child')) {
+  await runChild();
+} else {
+  runParent();
+}
+
+async function runChild() {
+  if (typeof globalThis.gc !== 'function') {
+    throw new Error('benchmark child requires --expose-gc');
+  }
+  const bounded = await import('../dist/bounded-structured-mutation.js');
+  const root = await import('../dist/index.js');
+  let prepare;
+  if (typeof root.captureStructuredMutationSnapshot === 'function') {
+    const materialization = await import('../dist/structured-mutation-materialization-internal.js');
+    prepare = () => materialization.materializeStructuredMutation(
+      root.captureStructuredMutationSnapshot(fixture),
+    );
+  } else {
+    prepare = () => {
+      const normalized = bounded.normalizeStructuredMutation(fixture);
+      bounded.captureStructuredMutationEffects(normalized);
+      return bounded.buildStructuredMutationUpdate(normalized);
+    };
+  }
+
+  for (let index = 0; index < WARMUPS; index += 1) prepare();
+  globalThis.gc();
+  const heapBefore = process.memoryUsage().heapUsed;
+  const cpuBefore = process.cpuUsage();
+  let witness = 0;
+  for (let index = 0; index < TRIALS; index += 1) {
+    const result = prepare();
+    witness += typeof result === 'string'
+      ? result.length
+      : result.outcome === 'execute' ? result.update.length : 0;
+  }
+  const cpu = process.cpuUsage(cpuBefore);
+  globalThis.gc();
+  const heapAfter = process.memoryUsage().heapUsed;
+  const maxRss = process.resourceUsage().maxRSS;
+  process.stdout.write(`${JSON.stringify({
+    cpuMicros: cpu.user + cpu.system,
+    retainedHeapBytes: Math.max(0, heapAfter - heapBefore),
+    maxRssBytes: process.platform === 'darwin' ? maxRss : maxRss * 1024,
+    witness,
+  })}\n`);
+}
+
+function runParent() {
+  const options = parseArgs(process.argv.slice(2));
+  assertNode22();
+  if (existsSync(options.output)) {
+    throw new Error(`refusing to overwrite benchmark output ${options.output}`);
+  }
+  const repetitions = Array.from({ length: REPETITIONS }, () => runFreshChild());
+  const metrics = Object.freeze({
+    cpuMicros: median(repetitions.map(({ cpuMicros }) => cpuMicros)),
+    retainedHeapBytes: median(repetitions.map(({ retainedHeapBytes }) => retainedHeapBytes)),
+    maxRssBytes: median(repetitions.map(({ maxRssBytes }) => maxRssBytes)),
+  });
+  const metadata = environmentMetadata();
+  let comparison;
+  if (options.mode === 'compare') {
+    const baseline = readBenchmark(options.baseline);
+    assertComparable(baseline, metadata);
+    comparison = Object.freeze({
+      baseline: options.baseline,
+      cpuPercent: percentage(metrics.cpuMicros, baseline.metrics.cpuMicros),
+      retainedHeapPercent: percentage(
+        metrics.retainedHeapBytes,
+        baseline.metrics.retainedHeapBytes,
+      ),
+      maxRssPercent: percentage(metrics.maxRssBytes, baseline.metrics.maxRssBytes),
+    });
+  }
+  const result = Object.freeze({
+    schemaVersion: 1,
+    mode: options.mode,
+    metadata,
+    fixture: Object.freeze({
+      digest: fixtureDigest,
+      mutationKind: fixture.kind,
+      subjects: fixture.input.subjects.length,
+      warmups: WARMUPS,
+      trials: TRIALS,
+      repetitions: REPETITIONS,
+    }),
+    metrics,
+    repetitions,
+    ...(comparison === undefined ? {} : { comparison }),
+  });
+  mkdirSync(dirname(options.output), { recursive: true });
+  writeFileSync(options.output, `${JSON.stringify(result, null, 2)}\n`, { flag: 'wx' });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (comparison !== undefined && Object.entries(comparison).some(
+    ([key, value]) => key.endsWith('Percent') && value > REGRESSION_LIMIT_PERCENT,
+  )) {
+    process.exitCode = 2;
+  }
+}
+
+function parseArgs(args) {
+  let mode;
+  let output;
+  let baseline;
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (flag === '--') continue;
+    if (flag === '--mode') mode = value;
+    else if (flag === '--output') output = value;
+    else if (flag === '--baseline') baseline = value;
+    else throw new Error(`unknown benchmark argument ${flag}`);
+    index += 1;
+  }
+  if (mode !== 'baseline' && mode !== 'compare') {
+    throw new Error('--mode must be baseline or compare');
+  }
+  if (typeof output !== 'string' || output.length === 0) {
+    throw new Error('--output is required');
+  }
+  if (mode === 'compare' && (typeof baseline !== 'string' || baseline.length === 0)) {
+    throw new Error('--baseline is required in compare mode');
+  }
+  return Object.freeze({ mode, output, baseline });
+}
+
+function runFreshChild() {
+  const result = spawnSync(
+    process.execPath,
+    ['--expose-gc', fileURLToPath(import.meta.url), '--child'],
+    { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(`benchmark child failed: ${result.stderr || result.stdout}`);
+  }
+  return Object.freeze(JSON.parse(result.stdout));
+}
+
+function environmentMetadata() {
+  return Object.freeze({
+    node: process.version,
+    architecture: process.arch,
+    platform: process.platform,
+    cpuModel: cpus()[0]?.model ?? 'unknown',
+    cpuCount: cpus().length,
+    gitSha: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+    gitDirty: execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).length > 0,
+  });
+}
+
+function readBenchmark(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function assertComparable(baseline, metadata) {
+  if (baseline.mode !== 'baseline') throw new Error('comparison input is not a baseline result');
+  if (baseline.metadata?.node !== metadata.node) throw new Error('benchmark Node version mismatch');
+  if (baseline.metadata?.architecture !== metadata.architecture) {
+    throw new Error('benchmark architecture mismatch');
+  }
+  if (baseline.fixture?.digest !== fixtureDigest) throw new Error('benchmark fixture mismatch');
+}
+
+function assertNode22() {
+  if (Number(process.versions.node.split('.')[0]) !== 22) {
+    throw new Error(`benchmark requires Node.js 22, received ${process.version}`);
+  }
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function percentage(candidate, baseline) {
+  if (baseline === 0) return candidate === 0 ? 0 : Number.POSITIVE_INFINITY;
+  return ((candidate - baseline) / baseline) * 100;
+}

--- a/packages/storage/scripts/benchmark-structured-mutation.mjs
+++ b/packages/storage/scripts/benchmark-structured-mutation.mjs
@@ -42,9 +42,14 @@ async function runChild() {
   let prepare;
   if (typeof root.captureStructuredMutationSnapshot === 'function') {
     const materialization = await import('../dist/structured-mutation-materialization-internal.js');
-    prepare = () => materialization.materializeStructuredMutation(
-      root.captureStructuredMutationSnapshot(fixture),
-    );
+    prepare = () => {
+      const result = materialization.materializeStructuredMutation(
+        root.captureStructuredMutationSnapshot(fixture),
+      );
+      // Match the pre-change path's returned lifetime: retain only the generated
+      // update, not the new API's diagnostic reference back to its input snapshot.
+      return result.outcome === 'execute' ? result.update : undefined;
+    };
   } else {
     prepare = () => {
       const normalized = bounded.normalizeStructuredMutation(fixture);
@@ -60,9 +65,7 @@ async function runChild() {
   let witness = 0;
   for (let index = 0; index < TRIALS; index += 1) {
     const result = prepare();
-    witness += typeof result === 'string'
-      ? result.length
-      : result.outcome === 'execute' ? result.update.length : 0;
+    witness += typeof result === 'string' ? result.length : 0;
   }
   const cpu = process.cpuUsage(cpuBefore);
   globalThis.gc();

--- a/packages/storage/scripts/pack-gate/barrel-value-exports.json
+++ b/packages/storage/scripts/pack-gate/barrel-value-exports.json
@@ -49,6 +49,7 @@
   "buildAtomicSubjectReplaceUpdate",
   "canonicalSharedMemoryScopeWriteGraph",
   "captureStructuredMutationEffects",
+  "captureStructuredMutationSnapshot",
   "changelogSchemaQuad",
   "chunkCopySubjectProjectionInput",
   "createStoreControlBarrierKeyV1",

--- a/packages/storage/scripts/pack-gate/type-fixture.ts
+++ b/packages/storage/scripts/pack-gate/type-fixture.ts
@@ -4,8 +4,14 @@
 // error; a forbidden symbol returning to the barrel turns its suppression
 // into an unused directive (TS2578). The directive token must never begin a
 // wrapped comment line — tsc parses such a comment as a real directive.
-import { ManagedOxigraphBackendUnownedError } from '@origintrail-official/dkg-storage';
+import {
+  ManagedOxigraphBackendUnownedError,
+  captureStructuredMutationSnapshot,
+  type StructuredMutationSnapshot,
+} from '@origintrail-official/dkg-storage';
 import type { ManagedOxigraphSupervisorHandoffV1 } from '@origintrail-official/dkg-storage/internal/managed-oxigraph-ownership-v1';
+// @ts-expect-error — final mutation materialization has no supported package subpath
+import { materializeStructuredMutation } from '@origintrail-official/dkg-storage/structured-mutation-materialization-internal';
 // @ts-expect-error — the ownership mint is not on the public barrel
 import { createManagedOxigraphOwnershipControllerV1 } from '@origintrail-official/dkg-storage';
 // Every removed ownership type is pinned individually — runtime namespace
@@ -25,4 +31,10 @@ const witness: [typeof ManagedOxigraphBackendUnownedError, ManagedOxigraphSuperv
   ManagedOxigraphBackendUnownedError,
   null,
 ];
+const snapshotWitness: StructuredMutationSnapshot = captureStructuredMutationSnapshot({
+  kind: 'delete-subjects',
+  input: { graphUri: 'urn:test:pack-gate', subjects: [] },
+});
+void materializeStructuredMutation;
+void snapshotWitness;
 export default witness;

--- a/packages/storage/scripts/verify-pack-exports.mjs
+++ b/packages/storage/scripts/verify-pack-exports.mjs
@@ -53,6 +53,8 @@ const GATE = Object.freeze({
     ['@origintrail-official/dkg-storage/package.json', true],
     ['@origintrail-official/dkg-storage/dist/internal/managed-oxigraph-ownership-v1.js', false],
     ['@origintrail-official/dkg-storage/dist/store-priority-scheduler.js', false],
+    ['@origintrail-official/dkg-storage/structured-mutation-materialization-internal', false],
+    ['@origintrail-official/dkg-storage/dist/structured-mutation-materialization-internal.js', false],
     ['@origintrail-official/dkg-storage/dist/index.js', false],
   ],
 });

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -33,10 +33,9 @@ import {
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
 import {
-  buildStructuredMutationUpdate,
-  captureStructuredMutationEffects,
-  normalizeStructuredMutation,
+  captureStructuredMutationSnapshot,
 } from '../bounded-structured-mutation.js';
+import { materializeStructuredMutation } from '../structured-mutation-materialization-internal.js';
 import { quadToNQuad } from '../bounded-rdf.js';
 import { readResponseTextBounded } from '../http-response-limit.js';
 
@@ -416,18 +415,17 @@ export class BlazegraphStore implements TripleStore {
     mutation: StructuredMutation,
     options?: QueryOptions,
   ): Promise<void> {
-    const normalized = normalizeStructuredMutation(mutation);
-    const effects = captureStructuredMutationEffects(normalized);
-    if (normalized.kind === 'replace-subject-predicates') {
-      assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
+    const snapshot = captureStructuredMutationSnapshot(mutation);
+    if (snapshot.mutation.kind === 'replace-subject-predicates') {
+      assertQuadLiteralsMutf8Safe(snapshot.mutation.input.replacementQuads, {
         maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
         label: 'BlazegraphStore.structuredMutation',
       });
     }
-    const update = buildStructuredMutationUpdate(normalized);
-    if (!update || !effects) return;
+    const materialized = materializeStructuredMutation(snapshot);
+    if (materialized.outcome === 'noop') return;
     await this.sparqlUpdate(
-      update,
+      materialized.update,
       { ...options, source: options?.source ?? 'blazegraph.structuredMutation' },
       'structuredMutation',
     );

--- a/packages/storage/src/adapters/oxigraph-worker-impl.ts
+++ b/packages/storage/src/adapters/oxigraph-worker-impl.ts
@@ -1,5 +1,6 @@
 import { parentPort, workerData } from 'node:worker_threads';
 import { OxigraphStore } from './oxigraph.js';
+import { structuredMutationPreDispatchRefusalCode } from '../structured-mutation/refusal-internal.js';
 
 const store = new OxigraphStore(workerData?.persistPath);
 
@@ -7,12 +8,19 @@ parentPort!.on('message', async (msg: { id: number; method: string; args: unknow
   try {
     const fn = (store as any)[msg.method];
     if (typeof fn !== 'function') {
-      parentPort!.postMessage({ id: msg.id, error: `Unknown method: ${msg.method}` });
+      parentPort!.postMessage({ id: msg.id, error: { message: `Unknown method: ${msg.method}` } });
       return;
     }
     const result = await fn.apply(store, msg.args);
     parentPort!.postMessage({ id: msg.id, result });
   } catch (err) {
-    parentPort!.postMessage({ id: msg.id, error: err instanceof Error ? err.message : String(err) });
+    const code = structuredMutationPreDispatchRefusalCode(err);
+    parentPort!.postMessage({
+      id: msg.id,
+      error: {
+        message: err instanceof Error ? err.message : String(err),
+        ...(code === undefined ? {} : { code }),
+      },
+    });
   }
 });

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -728,6 +728,7 @@ export class OxigraphWorkerStore implements TripleStore {
     _options?: TripleStoreQueryOptions,
   ): Promise<void> {
     const snapshot = captureStructuredMutationSnapshot(mutation);
+    assertStructuredMutationSnapshotMaterializable(snapshot);
     if (snapshot.outcome === 'noop') {
       await this.preflightNoop('structuredMutation');
       return;
@@ -738,7 +739,6 @@ export class OxigraphWorkerStore implements TripleStore {
         label: 'OxigraphWorkerStore.structuredMutation',
       });
     }
-    assertStructuredMutationSnapshotMaterializable(snapshot);
     await this.call('structuredMutation', snapshot.mutation);
     this.writeGen.recordGraphWrites(snapshot.effects.touchedGraphs);
   }

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -15,6 +15,7 @@ import { GraphWriteGenTracker } from '../graph-write-gen.js';
 import { captureStructuredMutationSnapshot } from '../bounded-structured-mutation.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 import { assertStructuredMutationSnapshotMaterializable } from '../structured-mutation-materialization-internal.js';
+import { STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE } from '../structured-mutation/refusal-internal.js';
 
 /**
  * Default per-operation timeout for the embedded worker store. The worker is
@@ -117,6 +118,23 @@ export interface OxigraphWorkerTimeoutError extends Error {
   method: string;
   /** The bound that was exceeded. */
   timeoutMs: number;
+}
+
+interface WorkerErrorPayload {
+  readonly message: string;
+  readonly code?: string;
+}
+
+function deserializeWorkerError(payload: string | WorkerErrorPayload): Error {
+  if (typeof payload === 'string') return new Error(payload);
+  const error = new Error(payload.message);
+  if (payload.code === STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE) {
+    Object.defineProperty(error, 'code', {
+      value: STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE,
+      enumerable: true,
+    });
+  }
+  return error;
 }
 
 /**
@@ -335,7 +353,11 @@ export class OxigraphWorkerStore implements TripleStore {
     // this: a spawn only happens in the constructor or within respawn(), which
     // bails the moment a close() is seen.
     this.markSpawnedLive();
-    worker.on('message', (msg: { id: number; result?: unknown; error?: string }) => {
+    worker.on('message', (msg: {
+      id: number;
+      result?: unknown;
+      error?: string | WorkerErrorPayload;
+    }) => {
       if (this.worker !== worker) return;
       // Any successful reply proves this worker is healthy, which ends the
       // crash-loop accounting window (see MAX_CONSECUTIVE_RESPAWNS).
@@ -343,7 +365,7 @@ export class OxigraphWorkerStore implements TripleStore {
       const p = this.pending.get(msg.id);
       if (!p) return;
       this.pending.delete(msg.id);
-      if (msg.error) p.reject(new Error(msg.error));
+      if (msg.error) p.reject(deserializeWorkerError(msg.error));
       else p.resolve(msg.result);
     });
     worker.on('error', (err) => {
@@ -718,7 +740,7 @@ export class OxigraphWorkerStore implements TripleStore {
     }
     assertStructuredMutationSnapshotMaterializable(snapshot);
     await this.call('structuredMutation', snapshot.mutation);
-    this.writeGen.recordGraphWrites(snapshot.effects!.touchedGraphs);
+    this.writeGen.recordGraphWrites(snapshot.effects.touchedGraphs);
   }
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     return this.callWithTimeout<QueryResult>(this.operationTimeoutMs, options?.signal, 'query', sparql);

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -15,7 +15,10 @@ import { GraphWriteGenTracker } from '../graph-write-gen.js';
 import { captureStructuredMutationSnapshot } from '../bounded-structured-mutation.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 import { assertStructuredMutationSnapshotMaterializable } from '../structured-mutation-materialization-internal.js';
-import { STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE } from '../structured-mutation/refusal-internal.js';
+import {
+  STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE,
+  reconstructStructuredMutationPreDispatchRefusal,
+} from '../structured-mutation/refusal-internal.js';
 
 /**
  * Default per-operation timeout for the embedded worker store. The worker is
@@ -127,14 +130,10 @@ interface WorkerErrorPayload {
 
 function deserializeWorkerError(payload: string | WorkerErrorPayload): Error {
   if (typeof payload === 'string') return new Error(payload);
-  const error = new Error(payload.message);
   if (payload.code === STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE) {
-    Object.defineProperty(error, 'code', {
-      value: STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE,
-      enumerable: true,
-    });
+    return reconstructStructuredMutationPreDispatchRefusal(payload.message);
   }
-  return error;
+  return new Error(payload.message);
 }
 
 /**

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -12,10 +12,9 @@ import type {
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { GraphWriteGenTracker } from '../graph-write-gen.js';
-import {
-  captureStructuredMutationEffects,
-  normalizeStructuredMutation,
-} from '../bounded-structured-mutation.js';
+import { captureStructuredMutationSnapshot } from '../bounded-structured-mutation.js';
+import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
+import { assertStructuredMutationSnapshotMaterializable } from '../structured-mutation-materialization-internal.js';
 
 /**
  * Default per-operation timeout for the embedded worker store. The worker is
@@ -540,6 +539,30 @@ export class OxigraphWorkerStore implements TripleStore {
     return this.postToWorker<T>(timeoutMs, signal, method, args);
   }
 
+  /** Share call()'s lifecycle linearization without allocating a worker message. */
+  private async preflightNoop(method: string): Promise<void> {
+    while (this.respawnPromise) await this.respawnPromise;
+    if (this.lifecycle === 'live' && !this.workerExited) return;
+    throw this.workerUnavailableError(method);
+  }
+
+  private workerUnavailableError(method: string): Error {
+    if (this.lifecycle === 'in_memory_lost') {
+      return new Error(
+        `oxigraph-worker: cannot run "${method}" — the IN-MEMORY store's worker crashed and its data was ` +
+          'lost. An in-memory store cannot be recovered from a worker crash; every request now fails ' +
+          'fast. Use a disk-persisted store (store.path) or restart the node to start from empty.',
+      );
+    }
+    return new Error(
+      `oxigraph-worker: cannot run "${method}" — the store is closed.` +
+        (this.lifecycle === 'gave_up'
+          ? ' (The worker crashed repeatedly and automatic respawn gave up — restart the node and ' +
+            'investigate the [oxigraph-worker] crash logs.)'
+          : ''),
+    );
+  }
+
   private postToWorker<T>(
     timeoutMs: number,
     signal: AbortSignal | undefined,
@@ -558,21 +581,7 @@ export class OxigraphWorkerStore implements TripleStore {
       //   • gave_up — closed + the crash-loop guidance.
       //   • otherwise — a plain operator close.
       if (this.workerExited) {
-        if (this.lifecycle === 'in_memory_lost') {
-          reject(new Error(
-            `oxigraph-worker: cannot run "${method}" — the IN-MEMORY store's worker crashed and its data was ` +
-              'lost. An in-memory store cannot be recovered from a worker crash; every request now fails ' +
-              'fast. Use a disk-persisted store (store.path) or restart the node to start from empty.',
-          ));
-          return;
-        }
-        reject(new Error(
-          `oxigraph-worker: cannot run "${method}" — the store is closed.` +
-            (this.lifecycle === 'gave_up'
-              ? ' (The worker crashed repeatedly and automatic respawn gave up — restart the node and ' +
-                'investigate the [oxigraph-worker] crash logs.)'
-              : ''),
-        ));
+        reject(this.workerUnavailableError(method));
         return;
       }
       if (signal?.aborted) {
@@ -696,10 +705,20 @@ export class OxigraphWorkerStore implements TripleStore {
     // aborting the caller could report failure while the worker later commits.
     _options?: TripleStoreQueryOptions,
   ): Promise<void> {
-    const normalized = normalizeStructuredMutation(mutation);
-    const effects = captureStructuredMutationEffects(normalized);
-    await this.call('structuredMutation', normalized);
-    if (effects) this.writeGen.recordGraphWrites(effects.touchedGraphs);
+    const snapshot = captureStructuredMutationSnapshot(mutation);
+    if (snapshot.outcome === 'noop') {
+      await this.preflightNoop('structuredMutation');
+      return;
+    }
+    if (snapshot.mutation.kind === 'replace-subject-predicates') {
+      assertQuadLiteralsMutf8Safe(snapshot.mutation.input.replacementQuads, {
+        maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
+        label: 'OxigraphWorkerStore.structuredMutation',
+      });
+    }
+    assertStructuredMutationSnapshotMaterializable(snapshot);
+    await this.call('structuredMutation', snapshot.mutation);
+    this.writeGen.recordGraphWrites(snapshot.effects!.touchedGraphs);
   }
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     return this.callWithTimeout<QueryResult>(this.operationTimeoutMs, options?.signal, 'query', sparql);

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -429,7 +429,7 @@ export class OxigraphStore implements TripleStore {
     if (materialized.outcome === 'noop') return;
     this.store.update(materialized.update);
     this.scheduleFlush();
-    this.writeGen.recordGraphWrites(snapshot.effects!.touchedGraphs);
+    this.writeGen.recordGraphWrites(materialized.snapshot.effects.touchedGraphs);
   }
 
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -27,10 +27,9 @@ import {
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
 import {
-  buildStructuredMutationUpdate,
-  captureStructuredMutationEffects,
-  normalizeStructuredMutation,
+  captureStructuredMutationSnapshot,
 } from '../bounded-structured-mutation.js';
+import { materializeStructuredMutation } from '../structured-mutation-materialization-internal.js';
 import { quadsToNQuads } from '../bounded-rdf.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 
@@ -419,19 +418,18 @@ export class OxigraphStore implements TripleStore {
     // dispatch; source/priority are advisory only for scheduled HTTP stores.
     _options?: TripleStoreQueryOptions,
   ): Promise<void> {
-    const normalized = normalizeStructuredMutation(mutation);
-    const effects = captureStructuredMutationEffects(normalized);
-    if (normalized.kind === 'replace-subject-predicates') {
-      assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
+    const snapshot = captureStructuredMutationSnapshot(mutation);
+    if (snapshot.mutation.kind === 'replace-subject-predicates') {
+      assertQuadLiteralsMutf8Safe(snapshot.mutation.input.replacementQuads, {
         maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
         label: 'OxigraphStore.structuredMutation',
       });
     }
-    const update = buildStructuredMutationUpdate(normalized);
-    if (!update || !effects) return;
-    this.store.update(update);
+    const materialized = materializeStructuredMutation(snapshot);
+    if (materialized.outcome === 'noop') return;
+    this.store.update(materialized.update);
     this.scheduleFlush();
-    this.writeGen.recordGraphWrites(effects.touchedGraphs);
+    this.writeGen.recordGraphWrites(snapshot.effects!.touchedGraphs);
   }
 
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -53,11 +53,9 @@ import {
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
 import {
-  buildStructuredMutationUpdate,
-  captureStructuredMutationEffects,
-  normalizeStructuredMutation,
-  structuredMutationGuardedGraphs,
+  captureStructuredMutationSnapshot,
 } from '../bounded-structured-mutation.js';
+import { materializeStructuredMutation } from '../structured-mutation-materialization-internal.js';
 import {
   assertNotReservedInternalGraphV1,
   isInternalGraphUriV1,
@@ -1288,20 +1286,20 @@ export class SparqlHttpStore implements TripleStore {
     mutation: StructuredMutation,
     options?: QueryOptions,
   ): Promise<void> {
-    const normalized = normalizeStructuredMutation(mutation);
-    const effects = captureStructuredMutationEffects(normalized);
-    this.assertGenericMutationScope(structuredMutationGuardedGraphs(normalized), 'structuredMutation');
-    if (normalized.kind === 'replace-subject-predicates') {
-      assertQuadLiteralsMutf8Safe([...normalized.input.replacementQuads], {
+    const snapshot = captureStructuredMutationSnapshot(mutation);
+    this.assertGenericMutationScope(snapshot.guardedGraphs, 'structuredMutation');
+    if (snapshot.mutation.kind === 'replace-subject-predicates') {
+      assertQuadLiteralsMutf8Safe(snapshot.mutation.input.replacementQuads, {
         maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
         label: 'SparqlHttpStore.structuredMutation',
       });
     }
-    const update = buildStructuredMutationUpdate(normalized);
-    if (!update || !effects) return;
+    const materialized = materializeStructuredMutation(snapshot);
+    if (materialized.outcome === 'noop') return;
+    const effects = snapshot.effects!;
     try {
       await this.postUpdate(
-        update,
+        materialized.update,
         { ...options, source: options?.source ?? 'sparql-http.structuredMutation' },
         'structuredMutation',
         effects.touchedGraphs,

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -1296,7 +1296,7 @@ export class SparqlHttpStore implements TripleStore {
     }
     const materialized = materializeStructuredMutation(snapshot);
     if (materialized.outcome === 'noop') return;
-    const effects = snapshot.effects!;
+    const effects = materialized.snapshot.effects;
     try {
       await this.postUpdate(
         materialized.update,

--- a/packages/storage/src/bounded-structured-mutation.ts
+++ b/packages/storage/src/bounded-structured-mutation.ts
@@ -10,7 +10,11 @@ import {
   BOUNDED_MUTATION_MAX_PRUNE_DELETE,
   BOUNDED_MUTATION_MAX_SOURCE_GRAPHS,
   BOUNDED_MUTATION_MAX_UPDATE_BYTES,
+  absoluteIri,
   assertBoundedStructuredUpdate,
+  boundedInteger,
+  boundedString,
+  normalizeStructuredRdfObject,
 } from './structured-mutation/primitives.js';
 import {
   buildDeleteSubjectsUpdate,
@@ -61,6 +65,458 @@ export {
   normalizeReplaceSubjectPredicatesInput,
   normalizeReplaceSubjectPredicatesInputForObjectRewrite,
 };
+
+export interface ReadonlyStructuredMutationQuad {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+  readonly graph: string;
+}
+
+export type ReadonlyStructuredMutation =
+  | Readonly<{
+    kind: 'delete-subjects';
+    input: Readonly<{ graphUri: string; subjects: readonly string[] }>;
+  }>
+  | Readonly<{
+    kind: 'prune-ranked-subjects';
+    input: Readonly<{
+      graphUri: string;
+      subjectPrefix: string;
+      eligibilityPredicate: string;
+      eligibleObjects: readonly string[];
+      primaryRankPredicate: string;
+      secondaryRankPredicate: string;
+      retainNewest: number;
+      maxDelete: number;
+    }>;
+  }>
+  | Readonly<{
+    kind: 'prune-linked-record-closures';
+    input: Readonly<{
+      graphUri: string;
+      matchObjectIris: readonly string[];
+      linkPredicates: readonly string[];
+      recordParentPredicate: string;
+      protectedRecordIri?: string;
+      descendantSeparator: string;
+    }>;
+  }>
+  | Readonly<{
+    kind: 'replace-subject-predicates';
+    input: Readonly<{
+      graphUri: string;
+      subject: string;
+      predicates: readonly string[];
+      replacementQuads: readonly ReadonlyStructuredMutationQuad[];
+    }>;
+  }>
+  | Readonly<{
+    kind: 'replace-projection-from-graph';
+    input: Readonly<{
+      targetGraphUri: string;
+      stagingGraphUri: string;
+      targetSubject: string;
+      preservedTargetPredicates: readonly string[];
+      targetSubjectPrefixes: readonly string[];
+    }>;
+  }>
+  | Readonly<{
+    kind: 'copy-subject-projection';
+    input: Readonly<{
+      sourceGraphUris: readonly string[];
+      targetGraphUri: string;
+      roots: readonly string[];
+      descendantSuffix: string;
+      excludedPredicates: readonly string[];
+    }>;
+  }>;
+
+export interface StructuredMutationSnapshot {
+  readonly mutation: ReadonlyStructuredMutation;
+  readonly guardedGraphs: readonly string[];
+  readonly effects: StructuredMutationEffects | undefined;
+  readonly outcome: 'noop' | 'candidate';
+}
+
+const STRUCTURED_MUTATION_SNAPSHOT_BRAND = Symbol('structured-mutation-snapshot');
+const STRUCTURED_MUTATION_SNAPSHOTS = new WeakMap<object, StructuredMutationSnapshot>();
+
+/** Capture one immutable, caller-independent structured mutation observation. */
+export function captureStructuredMutationSnapshot(
+  mutation: StructuredMutation,
+): StructuredMutationSnapshot {
+  if (typeof mutation === 'object' && mutation !== null) {
+    const trusted = STRUCTURED_MUTATION_SNAPSHOTS.get(mutation);
+    if (trusted !== undefined) return trusted;
+  }
+  const descriptor = mutation as unknown as Record<string, unknown>;
+  const kind = descriptor?.kind;
+  const input = descriptor?.input;
+  let captured: ReadonlyStructuredMutation;
+  switch (kind) {
+    case 'delete-subjects':
+      captured = brandMutation(kind, captureDeleteSubjectsInput(input));
+      break;
+    case 'prune-ranked-subjects':
+      captured = brandMutation(kind, capturePruneRankedSubjectsInput(input));
+      break;
+    case 'prune-linked-record-closures':
+      captured = brandMutation(kind, capturePruneLinkedRecordClosuresInput(input));
+      break;
+    case 'replace-subject-predicates':
+      captured = brandMutation(kind, captureReplaceSubjectPredicatesInput(input));
+      break;
+    case 'replace-projection-from-graph':
+      captured = brandMutation(kind, captureReplaceProjectionFromGraphInput(input));
+      break;
+    case 'copy-subject-projection':
+      captured = brandMutation(kind, captureCopySubjectProjectionInput(input));
+      break;
+    default:
+      throw new Error(`Unsupported structured mutation kind ${String(kind)}`);
+  }
+  const guardedGraphs = Object.freeze([...structuredMutationGuardedGraphs(captured)]);
+  const mightMutate = structuredMutationMightMutate(captured);
+  const effects = mightMutate
+    ? Object.freeze({
+        touchedGraphs: Object.freeze([...structuredMutationTouchedGraphs(captured)]),
+      })
+    : undefined;
+  const snapshot: StructuredMutationSnapshot = Object.freeze({
+    mutation: captured,
+    guardedGraphs,
+    effects,
+    outcome: mightMutate ? 'candidate' : 'noop',
+  });
+  STRUCTURED_MUTATION_SNAPSHOTS.set(captured, snapshot);
+  return snapshot;
+}
+
+/** Storage-internal trust check used by final materialization. */
+export function assertTrustedStructuredMutationSnapshot(
+  snapshot: StructuredMutationSnapshot,
+): void {
+  if (typeof snapshot !== 'object'
+      || snapshot === null
+      || typeof snapshot.mutation !== 'object'
+      || snapshot.mutation === null
+      || STRUCTURED_MUTATION_SNAPSHOTS.get(snapshot.mutation) !== snapshot) {
+    throw new Error('structured mutation snapshot is not trusted');
+  }
+}
+
+function brandMutation<K extends ReadonlyStructuredMutation['kind']>(
+  kind: K,
+  input: Extract<ReadonlyStructuredMutation, { kind: K }>['input'],
+): Extract<ReadonlyStructuredMutation, { kind: K }> {
+  const mutation = { kind, input } as Extract<ReadonlyStructuredMutation, { kind: K }>;
+  Object.defineProperty(mutation, STRUCTURED_MUTATION_SNAPSHOT_BRAND, { value: true });
+  Object.freeze(mutation);
+  return mutation;
+}
+
+function captureDeleteSubjectsInput(input: unknown): Extract<
+  ReadonlyStructuredMutation,
+  { kind: 'delete-subjects' }
+>['input'] {
+  const value = inputRecord(input, 'deleteSubjects');
+  const graphUri = absoluteIri(value.graphUri as string, 'deleteSubjects.graphUri');
+  const subjects = captureUniqueIris(
+    value.subjects,
+    'deleteSubjects.subjects',
+    BOUNDED_MUTATION_MAX_IRIS,
+    true,
+  );
+  return Object.freeze({ graphUri, subjects });
+}
+
+function capturePruneRankedSubjectsInput(input: unknown): Extract<
+  ReadonlyStructuredMutation,
+  { kind: 'prune-ranked-subjects' }
+>['input'] {
+  const value = inputRecord(input, 'pruneRankedSubjects');
+  const graphUri = absoluteIri(value.graphUri as string, 'pruneRankedSubjects.graphUri');
+  const subjectPrefix = absoluteIri(
+    value.subjectPrefix as string,
+    'pruneRankedSubjects.subjectPrefix',
+  );
+  const eligibilityPredicate = absoluteIri(
+    value.eligibilityPredicate as string,
+    'pruneRankedSubjects.eligibilityPredicate',
+  );
+  const eligibleObjects = captureUniqueStrings(
+    value.eligibleObjects,
+    'pruneRankedSubjects.eligibleObjects',
+    16,
+  );
+  const primaryRankPredicate = absoluteIri(
+    value.primaryRankPredicate as string,
+    'pruneRankedSubjects.primaryRankPredicate',
+  );
+  const secondaryRankPredicate = absoluteIri(
+    value.secondaryRankPredicate as string,
+    'pruneRankedSubjects.secondaryRankPredicate',
+  );
+  const retainNewest = boundedInteger(
+    value.retainNewest as number,
+    'pruneRankedSubjects.retainNewest',
+    BOUNDED_MUTATION_MAX_IRIS,
+  );
+  const maxDelete = boundedInteger(
+    value.maxDelete as number,
+    'pruneRankedSubjects.maxDelete',
+    BOUNDED_MUTATION_MAX_PRUNE_DELETE,
+  );
+  if (maxDelete === 0) throw new Error('pruneRankedSubjects.maxDelete must be positive');
+  return Object.freeze({
+    graphUri,
+    subjectPrefix,
+    eligibilityPredicate,
+    eligibleObjects,
+    primaryRankPredicate,
+    secondaryRankPredicate,
+    retainNewest,
+    maxDelete,
+  });
+}
+
+function capturePruneLinkedRecordClosuresInput(input: unknown): Extract<
+  ReadonlyStructuredMutation,
+  { kind: 'prune-linked-record-closures' }
+>['input'] {
+  const value = inputRecord(input, 'pruneLinkedRecordClosures');
+  const graphUri = absoluteIri(value.graphUri as string, 'pruneLinkedRecordClosures.graphUri');
+  const matchObjectIris = captureUniqueIris(
+    value.matchObjectIris,
+    'pruneLinkedRecordClosures.matchObjectIris',
+    BOUNDED_MUTATION_MAX_IRIS,
+    false,
+  );
+  const linkPredicates = captureUniqueIris(
+    value.linkPredicates,
+    'pruneLinkedRecordClosures.linkPredicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+    false,
+  );
+  const recordParentPredicate = absoluteIri(
+    value.recordParentPredicate as string,
+    'pruneLinkedRecordClosures.recordParentPredicate',
+  );
+  const rawProtectedRecordIri = value.protectedRecordIri;
+  const protectedRecordIri = rawProtectedRecordIri === undefined
+    ? undefined
+    : absoluteIri(
+        rawProtectedRecordIri as string,
+        'pruneLinkedRecordClosures.protectedRecordIri',
+      );
+  const descendantSeparator = boundedString(
+    value.descendantSeparator as string,
+    'pruneLinkedRecordClosures.descendantSeparator',
+    64,
+  );
+  return Object.freeze({
+    graphUri,
+    matchObjectIris,
+    linkPredicates,
+    recordParentPredicate,
+    protectedRecordIri,
+    descendantSeparator,
+  });
+}
+
+function captureReplaceSubjectPredicatesInput(input: unknown): Extract<
+  ReadonlyStructuredMutation,
+  { kind: 'replace-subject-predicates' }
+>['input'] {
+  const value = inputRecord(input, 'replaceSubjectPredicates');
+  const graphUri = absoluteIri(value.graphUri as string, 'replaceSubjectPredicates.graphUri');
+  const subject = absoluteIri(value.subject as string, 'replaceSubjectPredicates.subject');
+  const predicates = captureUniqueIris(
+    value.predicates,
+    'replaceSubjectPredicates.predicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+    false,
+  );
+  const allowedPredicates = new Set(predicates);
+  const replacementQuads = captureArray(
+    value.replacementQuads,
+    'replaceSubjectPredicates.replacementQuads',
+    0,
+    BOUNDED_MUTATION_MAX_IRIS,
+    (candidate, index) => {
+      const quad = inputRecord(candidate, `replaceSubjectPredicates.replacementQuads[${index}]`);
+      const quadSubject = quad.subject;
+      const quadPredicate = quad.predicate;
+      const quadObject = quad.object;
+      const quadGraph = quad.graph;
+      if (quadGraph !== graphUri || quadSubject !== subject) {
+        throw new Error(
+          `replaceSubjectPredicates quad ${index} must target subject ${subject} in graph ${graphUri}`,
+        );
+      }
+      const predicate = absoluteIri(
+        quadPredicate as string,
+        `replaceSubjectPredicates.replacementQuads[${index}].predicate`,
+      );
+      if (!allowedPredicates.has(predicate)) {
+        throw new Error(
+          `replaceSubjectPredicates quad ${index} targets undeclared predicate ${predicate}`,
+        );
+      }
+      const object = normalizeStructuredRdfObject(
+        quadObject as string,
+        `replaceSubjectPredicates.replacementQuads[${index}].object`,
+      );
+      return Object.freeze({ subject, predicate, object, graph: graphUri });
+    },
+  );
+  return Object.freeze({ graphUri, subject, predicates, replacementQuads });
+}
+
+function captureReplaceProjectionFromGraphInput(input: unknown): Extract<
+  ReadonlyStructuredMutation,
+  { kind: 'replace-projection-from-graph' }
+>['input'] {
+  const value = inputRecord(input, 'replaceProjectionFromGraph');
+  const targetGraphUri = absoluteIri(
+    value.targetGraphUri as string,
+    'replaceProjectionFromGraph.targetGraphUri',
+  );
+  const stagingGraphUri = absoluteIri(
+    value.stagingGraphUri as string,
+    'replaceProjectionFromGraph.stagingGraphUri',
+  );
+  if (targetGraphUri === stagingGraphUri) {
+    throw new Error('replaceProjectionFromGraph requires distinct target and staging graphs');
+  }
+  const targetSubject = absoluteIri(
+    value.targetSubject as string,
+    'replaceProjectionFromGraph.targetSubject',
+  );
+  const preservedTargetPredicates = captureUniqueIris(
+    value.preservedTargetPredicates,
+    'replaceProjectionFromGraph.preservedTargetPredicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+    true,
+  );
+  const targetSubjectPrefixes = captureUniqueIris(
+    value.targetSubjectPrefixes,
+    'replaceProjectionFromGraph.targetSubjectPrefixes',
+    BOUNDED_MUTATION_MAX_PREFIXES,
+    true,
+  );
+  return Object.freeze({
+    targetGraphUri,
+    stagingGraphUri,
+    targetSubject,
+    preservedTargetPredicates,
+    targetSubjectPrefixes,
+  });
+}
+
+function captureCopySubjectProjectionInput(input: unknown): Extract<
+  ReadonlyStructuredMutation,
+  { kind: 'copy-subject-projection' }
+>['input'] {
+  const value = inputRecord(input, 'copySubjectProjection');
+  const sourceGraphUris = captureUniqueIris(
+    value.sourceGraphUris,
+    'copySubjectProjection.sourceGraphUris',
+    BOUNDED_MUTATION_MAX_SOURCE_GRAPHS,
+    false,
+  );
+  const targetGraphUri = absoluteIri(
+    value.targetGraphUri as string,
+    'copySubjectProjection.targetGraphUri',
+  );
+  if (sourceGraphUris.includes(targetGraphUri)) {
+    throw new Error('copySubjectProjection target graph must not be a source graph');
+  }
+  const roots = captureUniqueIris(
+    value.roots,
+    'copySubjectProjection.roots',
+    BOUNDED_MUTATION_MAX_IRIS,
+    false,
+  );
+  const descendantSuffix = boundedString(
+    value.descendantSuffix as string,
+    'copySubjectProjection.descendantSuffix',
+    256,
+  );
+  if (!descendantSuffix.startsWith('/')) {
+    throw new Error('copySubjectProjection.descendantSuffix must start with /');
+  }
+  const excludedPredicates = captureUniqueIris(
+    value.excludedPredicates,
+    'copySubjectProjection.excludedPredicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+    true,
+  );
+  return Object.freeze({
+    sourceGraphUris,
+    targetGraphUri,
+    roots,
+    descendantSuffix,
+    excludedPredicates,
+  });
+}
+
+function inputRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function captureUniqueIris(
+  value: unknown,
+  label: string,
+  max: number,
+  allowEmpty: boolean,
+): readonly string[] {
+  const seen = new Set<string>();
+  return captureArray(value, label, allowEmpty ? 0 : 1, max, (candidate, index) => {
+    const iri = absoluteIri(candidate as string, `${label}[${index}]`);
+    if (seen.has(iri)) throw new Error(`${label} contains duplicate IRI ${iri}`);
+    seen.add(iri);
+    return iri;
+  });
+}
+
+function captureUniqueStrings(
+  value: unknown,
+  label: string,
+  max: number,
+): readonly string[] {
+  const seen = new Set<string>();
+  return captureArray(value, label, 1, max, (candidate, index) => {
+    const captured = boundedString(candidate as string, `${label}[${index}]`);
+    if (seen.has(captured)) throw new Error(`${label} contains duplicate value ${captured}`);
+    seen.add(captured);
+    return captured;
+  });
+}
+
+function captureArray<T>(
+  value: unknown,
+  label: string,
+  min: number,
+  max: number,
+  capture: (candidate: unknown, index: number) => T,
+): readonly T[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  const length = value.length;
+  if (length < min || length > max) {
+    throw new Error(`${label} must contain ${min}..${max} values`);
+  }
+  const result = new Array<T>(length);
+  for (let index = 0; index < length; index += 1) {
+    if (!(index in value)) throw new Error(`${label} must be a dense array`);
+    result[index] = capture(value[index], index);
+  }
+  return Object.freeze(result);
+}
 
 function unsupportedMutation(mutation: never): never {
   throw new Error(

--- a/packages/storage/src/bounded-structured-mutation.ts
+++ b/packages/storage/src/bounded-structured-mutation.ts
@@ -10,36 +10,45 @@ import {
   BOUNDED_MUTATION_MAX_PRUNE_DELETE,
   BOUNDED_MUTATION_MAX_SOURCE_GRAPHS,
   BOUNDED_MUTATION_MAX_UPDATE_BYTES,
-  absoluteIri,
   assertBoundedStructuredUpdate,
-  boundedInteger,
-  boundedString,
-  normalizeStructuredRdfObject,
 } from './structured-mutation/primitives.js';
 import {
   buildDeleteSubjectsUpdate,
+  captureDeleteSubjectsInput,
+  deleteSubjectsSemantics,
   normalizeDeleteSubjectsInput,
 } from './structured-mutation/delete-subjects.js';
 import {
   buildPruneLinkedRecordClosuresUpdate,
   buildPruneRankedSubjectsUpdate,
+  capturePruneLinkedRecordClosuresInput,
+  capturePruneRankedSubjectsInput,
   normalizePruneLinkedRecordClosuresInput,
   normalizePruneRankedSubjectsInput,
+  pruneLinkedRecordClosuresSemantics,
+  pruneRankedSubjectsSemantics,
 } from './structured-mutation/retention.js';
 import {
   buildReplaceSubjectPredicatesUpdate,
+  captureReplaceSubjectPredicatesInput,
   normalizeReplaceSubjectPredicatesInput,
   normalizeReplaceSubjectPredicatesInputForObjectRewrite,
+  replaceSubjectPredicatesSemantics,
 } from './structured-mutation/replace-subject-predicates.js';
 import {
   buildReplaceProjectionFromGraphUpdate,
+  captureReplaceProjectionFromGraphInput,
   normalizeReplaceProjectionFromGraphInput,
+  replaceProjectionFromGraphSemantics,
 } from './structured-mutation/replace-projection-from-graph.js';
 import {
   buildCopySubjectProjectionUpdate,
+  captureCopySubjectProjectionInput,
   chunkCopySubjectProjectionInput,
+  copySubjectProjectionSemantics,
   normalizeCopySubjectProjectionInput,
 } from './structured-mutation/copy-subject-projection.js';
+import type { StructuredMutationSemantics } from './structured-mutation/capture-internal.js';
 
 export {
   BOUNDED_MUTATION_MAX_IRIS,
@@ -154,33 +163,52 @@ export function captureStructuredMutationSnapshot(
   const kind = descriptor?.kind;
   const input = descriptor?.input;
   let captured: ReadonlyStructuredMutation;
+  let semantics: StructuredMutationSemantics;
   switch (kind) {
-    case 'delete-subjects':
-      captured = brandMutation(kind, captureDeleteSubjectsInput(input));
+    case 'delete-subjects': {
+      const capturedInput = captureDeleteSubjectsInput(input);
+      captured = brandMutation(kind, capturedInput);
+      semantics = deleteSubjectsSemantics(capturedInput);
       break;
-    case 'prune-ranked-subjects':
-      captured = brandMutation(kind, capturePruneRankedSubjectsInput(input));
+    }
+    case 'prune-ranked-subjects': {
+      const capturedInput = capturePruneRankedSubjectsInput(input);
+      captured = brandMutation(kind, capturedInput);
+      semantics = pruneRankedSubjectsSemantics(capturedInput);
       break;
-    case 'prune-linked-record-closures':
-      captured = brandMutation(kind, capturePruneLinkedRecordClosuresInput(input));
+    }
+    case 'prune-linked-record-closures': {
+      const capturedInput = capturePruneLinkedRecordClosuresInput(input);
+      captured = brandMutation(kind, capturedInput);
+      semantics = pruneLinkedRecordClosuresSemantics(capturedInput);
       break;
-    case 'replace-subject-predicates':
-      captured = brandMutation(kind, captureReplaceSubjectPredicatesInput(input));
+    }
+    case 'replace-subject-predicates': {
+      const capturedInput = captureReplaceSubjectPredicatesInput(input);
+      captured = brandMutation(kind, capturedInput);
+      semantics = replaceSubjectPredicatesSemantics(capturedInput);
       break;
-    case 'replace-projection-from-graph':
-      captured = brandMutation(kind, captureReplaceProjectionFromGraphInput(input));
+    }
+    case 'replace-projection-from-graph': {
+      const capturedInput = captureReplaceProjectionFromGraphInput(input);
+      captured = brandMutation(kind, capturedInput);
+      semantics = replaceProjectionFromGraphSemantics(capturedInput);
       break;
-    case 'copy-subject-projection':
-      captured = brandMutation(kind, captureCopySubjectProjectionInput(input));
+    }
+    case 'copy-subject-projection': {
+      const capturedInput = captureCopySubjectProjectionInput(input);
+      captured = brandMutation(kind, capturedInput);
+      semantics = copySubjectProjectionSemantics(capturedInput);
       break;
+    }
     default:
       throw new Error(`Unsupported structured mutation kind ${String(kind)}`);
   }
-  const guardedGraphs = Object.freeze([...structuredMutationGuardedGraphs(captured)]);
-  const mightMutate = structuredMutationMightMutate(captured);
+  const guardedGraphs = Object.freeze([...semantics.guardedGraphs]);
+  const mightMutate = semantics.mightMutate;
   const effects = mightMutate
     ? Object.freeze({
-        touchedGraphs: Object.freeze([...structuredMutationTouchedGraphs(captured)]),
+        touchedGraphs: Object.freeze([...semantics.touchedGraphs]),
       })
     : undefined;
   const snapshot: StructuredMutationSnapshot = Object.freeze({
@@ -214,308 +242,6 @@ function brandMutation<K extends ReadonlyStructuredMutation['kind']>(
   Object.defineProperty(mutation, STRUCTURED_MUTATION_SNAPSHOT_BRAND, { value: true });
   Object.freeze(mutation);
   return mutation;
-}
-
-function captureDeleteSubjectsInput(input: unknown): Extract<
-  ReadonlyStructuredMutation,
-  { kind: 'delete-subjects' }
->['input'] {
-  const value = inputRecord(input, 'deleteSubjects');
-  const graphUri = absoluteIri(value.graphUri as string, 'deleteSubjects.graphUri');
-  const subjects = captureUniqueIris(
-    value.subjects,
-    'deleteSubjects.subjects',
-    BOUNDED_MUTATION_MAX_IRIS,
-    true,
-  );
-  return Object.freeze({ graphUri, subjects });
-}
-
-function capturePruneRankedSubjectsInput(input: unknown): Extract<
-  ReadonlyStructuredMutation,
-  { kind: 'prune-ranked-subjects' }
->['input'] {
-  const value = inputRecord(input, 'pruneRankedSubjects');
-  const graphUri = absoluteIri(value.graphUri as string, 'pruneRankedSubjects.graphUri');
-  const subjectPrefix = absoluteIri(
-    value.subjectPrefix as string,
-    'pruneRankedSubjects.subjectPrefix',
-  );
-  const eligibilityPredicate = absoluteIri(
-    value.eligibilityPredicate as string,
-    'pruneRankedSubjects.eligibilityPredicate',
-  );
-  const eligibleObjects = captureUniqueStrings(
-    value.eligibleObjects,
-    'pruneRankedSubjects.eligibleObjects',
-    16,
-  );
-  const primaryRankPredicate = absoluteIri(
-    value.primaryRankPredicate as string,
-    'pruneRankedSubjects.primaryRankPredicate',
-  );
-  const secondaryRankPredicate = absoluteIri(
-    value.secondaryRankPredicate as string,
-    'pruneRankedSubjects.secondaryRankPredicate',
-  );
-  const retainNewest = boundedInteger(
-    value.retainNewest as number,
-    'pruneRankedSubjects.retainNewest',
-    BOUNDED_MUTATION_MAX_IRIS,
-  );
-  const maxDelete = boundedInteger(
-    value.maxDelete as number,
-    'pruneRankedSubjects.maxDelete',
-    BOUNDED_MUTATION_MAX_PRUNE_DELETE,
-  );
-  if (maxDelete === 0) throw new Error('pruneRankedSubjects.maxDelete must be positive');
-  return Object.freeze({
-    graphUri,
-    subjectPrefix,
-    eligibilityPredicate,
-    eligibleObjects,
-    primaryRankPredicate,
-    secondaryRankPredicate,
-    retainNewest,
-    maxDelete,
-  });
-}
-
-function capturePruneLinkedRecordClosuresInput(input: unknown): Extract<
-  ReadonlyStructuredMutation,
-  { kind: 'prune-linked-record-closures' }
->['input'] {
-  const value = inputRecord(input, 'pruneLinkedRecordClosures');
-  const graphUri = absoluteIri(value.graphUri as string, 'pruneLinkedRecordClosures.graphUri');
-  const matchObjectIris = captureUniqueIris(
-    value.matchObjectIris,
-    'pruneLinkedRecordClosures.matchObjectIris',
-    BOUNDED_MUTATION_MAX_IRIS,
-    false,
-  );
-  const linkPredicates = captureUniqueIris(
-    value.linkPredicates,
-    'pruneLinkedRecordClosures.linkPredicates',
-    BOUNDED_MUTATION_MAX_PREDICATES,
-    false,
-  );
-  const recordParentPredicate = absoluteIri(
-    value.recordParentPredicate as string,
-    'pruneLinkedRecordClosures.recordParentPredicate',
-  );
-  const rawProtectedRecordIri = value.protectedRecordIri;
-  const protectedRecordIri = rawProtectedRecordIri === undefined
-    ? undefined
-    : absoluteIri(
-        rawProtectedRecordIri as string,
-        'pruneLinkedRecordClosures.protectedRecordIri',
-      );
-  const descendantSeparator = boundedString(
-    value.descendantSeparator as string,
-    'pruneLinkedRecordClosures.descendantSeparator',
-    64,
-  );
-  return Object.freeze({
-    graphUri,
-    matchObjectIris,
-    linkPredicates,
-    recordParentPredicate,
-    protectedRecordIri,
-    descendantSeparator,
-  });
-}
-
-function captureReplaceSubjectPredicatesInput(input: unknown): Extract<
-  ReadonlyStructuredMutation,
-  { kind: 'replace-subject-predicates' }
->['input'] {
-  const value = inputRecord(input, 'replaceSubjectPredicates');
-  const graphUri = absoluteIri(value.graphUri as string, 'replaceSubjectPredicates.graphUri');
-  const subject = absoluteIri(value.subject as string, 'replaceSubjectPredicates.subject');
-  const predicates = captureUniqueIris(
-    value.predicates,
-    'replaceSubjectPredicates.predicates',
-    BOUNDED_MUTATION_MAX_PREDICATES,
-    false,
-  );
-  const allowedPredicates = new Set(predicates);
-  const replacementQuads = captureArray(
-    value.replacementQuads,
-    'replaceSubjectPredicates.replacementQuads',
-    0,
-    BOUNDED_MUTATION_MAX_IRIS,
-    (candidate, index) => {
-      const quad = inputRecord(candidate, `replaceSubjectPredicates.replacementQuads[${index}]`);
-      const quadSubject = quad.subject;
-      const quadPredicate = quad.predicate;
-      const quadObject = quad.object;
-      const quadGraph = quad.graph;
-      if (quadGraph !== graphUri || quadSubject !== subject) {
-        throw new Error(
-          `replaceSubjectPredicates quad ${index} must target subject ${subject} in graph ${graphUri}`,
-        );
-      }
-      const predicate = absoluteIri(
-        quadPredicate as string,
-        `replaceSubjectPredicates.replacementQuads[${index}].predicate`,
-      );
-      if (!allowedPredicates.has(predicate)) {
-        throw new Error(
-          `replaceSubjectPredicates quad ${index} targets undeclared predicate ${predicate}`,
-        );
-      }
-      const object = normalizeStructuredRdfObject(
-        quadObject as string,
-        `replaceSubjectPredicates.replacementQuads[${index}].object`,
-      );
-      return Object.freeze({ subject, predicate, object, graph: graphUri });
-    },
-  );
-  return Object.freeze({ graphUri, subject, predicates, replacementQuads });
-}
-
-function captureReplaceProjectionFromGraphInput(input: unknown): Extract<
-  ReadonlyStructuredMutation,
-  { kind: 'replace-projection-from-graph' }
->['input'] {
-  const value = inputRecord(input, 'replaceProjectionFromGraph');
-  const targetGraphUri = absoluteIri(
-    value.targetGraphUri as string,
-    'replaceProjectionFromGraph.targetGraphUri',
-  );
-  const stagingGraphUri = absoluteIri(
-    value.stagingGraphUri as string,
-    'replaceProjectionFromGraph.stagingGraphUri',
-  );
-  if (targetGraphUri === stagingGraphUri) {
-    throw new Error('replaceProjectionFromGraph requires distinct target and staging graphs');
-  }
-  const targetSubject = absoluteIri(
-    value.targetSubject as string,
-    'replaceProjectionFromGraph.targetSubject',
-  );
-  const preservedTargetPredicates = captureUniqueIris(
-    value.preservedTargetPredicates,
-    'replaceProjectionFromGraph.preservedTargetPredicates',
-    BOUNDED_MUTATION_MAX_PREDICATES,
-    true,
-  );
-  const targetSubjectPrefixes = captureUniqueIris(
-    value.targetSubjectPrefixes,
-    'replaceProjectionFromGraph.targetSubjectPrefixes',
-    BOUNDED_MUTATION_MAX_PREFIXES,
-    true,
-  );
-  return Object.freeze({
-    targetGraphUri,
-    stagingGraphUri,
-    targetSubject,
-    preservedTargetPredicates,
-    targetSubjectPrefixes,
-  });
-}
-
-function captureCopySubjectProjectionInput(input: unknown): Extract<
-  ReadonlyStructuredMutation,
-  { kind: 'copy-subject-projection' }
->['input'] {
-  const value = inputRecord(input, 'copySubjectProjection');
-  const sourceGraphUris = captureUniqueIris(
-    value.sourceGraphUris,
-    'copySubjectProjection.sourceGraphUris',
-    BOUNDED_MUTATION_MAX_SOURCE_GRAPHS,
-    false,
-  );
-  const targetGraphUri = absoluteIri(
-    value.targetGraphUri as string,
-    'copySubjectProjection.targetGraphUri',
-  );
-  if (sourceGraphUris.includes(targetGraphUri)) {
-    throw new Error('copySubjectProjection target graph must not be a source graph');
-  }
-  const roots = captureUniqueIris(
-    value.roots,
-    'copySubjectProjection.roots',
-    BOUNDED_MUTATION_MAX_IRIS,
-    false,
-  );
-  const descendantSuffix = boundedString(
-    value.descendantSuffix as string,
-    'copySubjectProjection.descendantSuffix',
-    256,
-  );
-  if (!descendantSuffix.startsWith('/')) {
-    throw new Error('copySubjectProjection.descendantSuffix must start with /');
-  }
-  const excludedPredicates = captureUniqueIris(
-    value.excludedPredicates,
-    'copySubjectProjection.excludedPredicates',
-    BOUNDED_MUTATION_MAX_PREDICATES,
-    true,
-  );
-  return Object.freeze({
-    sourceGraphUris,
-    targetGraphUri,
-    roots,
-    descendantSuffix,
-    excludedPredicates,
-  });
-}
-
-function inputRecord(value: unknown, label: string): Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function captureUniqueIris(
-  value: unknown,
-  label: string,
-  max: number,
-  allowEmpty: boolean,
-): readonly string[] {
-  const seen = new Set<string>();
-  return captureArray(value, label, allowEmpty ? 0 : 1, max, (candidate, index) => {
-    const iri = absoluteIri(candidate as string, `${label}[${index}]`);
-    if (seen.has(iri)) throw new Error(`${label} contains duplicate IRI ${iri}`);
-    seen.add(iri);
-    return iri;
-  });
-}
-
-function captureUniqueStrings(
-  value: unknown,
-  label: string,
-  max: number,
-): readonly string[] {
-  const seen = new Set<string>();
-  return captureArray(value, label, 1, max, (candidate, index) => {
-    const captured = boundedString(candidate as string, `${label}[${index}]`);
-    if (seen.has(captured)) throw new Error(`${label} contains duplicate value ${captured}`);
-    seen.add(captured);
-    return captured;
-  });
-}
-
-function captureArray<T>(
-  value: unknown,
-  label: string,
-  min: number,
-  max: number,
-  capture: (candidate: unknown, index: number) => T,
-): readonly T[] {
-  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
-  const length = value.length;
-  if (length < min || length > max) {
-    throw new Error(`${label} must contain ${min}..${max} values`);
-  }
-  const result = new Array<T>(length);
-  for (let index = 0; index < length; index += 1) {
-    if (!(index in value)) throw new Error(`${label} must be a dense array`);
-    result[index] = capture(value[index], index);
-  }
-  return Object.freeze(result);
 }
 
 function unsupportedMutation(mutation: never): never {
@@ -581,26 +307,29 @@ export function buildStructuredMutationUpdate(mutation: StructuredMutation): str
 }
 
 export function structuredMutationGuardedGraphs(mutation: StructuredMutation): readonly string[] {
-  switch (mutation.kind) {
-    case 'replace-projection-from-graph':
-      return [mutation.input.targetGraphUri, mutation.input.stagingGraphUri];
-    case 'copy-subject-projection':
-      return [...mutation.input.sourceGraphUris, mutation.input.targetGraphUri];
-    default:
-      return [mutation.input.graphUri];
-  }
+  return structuredMutationSemantics(mutation).guardedGraphs;
 }
 
 export function structuredMutationTouchedGraphs(mutation: StructuredMutation): readonly string[] {
-  switch (mutation.kind) {
-    case 'replace-projection-from-graph': return [mutation.input.targetGraphUri];
-    case 'copy-subject-projection': return [mutation.input.targetGraphUri];
-    default: return [mutation.input.graphUri];
-  }
+  return structuredMutationSemantics(mutation).touchedGraphs;
 }
 
 export function structuredMutationMightMutate(mutation: StructuredMutation): boolean {
-  return mutation.kind !== 'delete-subjects' || mutation.input.subjects.length > 0;
+  return structuredMutationSemantics(mutation).mightMutate;
+}
+
+function structuredMutationSemantics(
+  mutation: StructuredMutation,
+): StructuredMutationSemantics {
+  switch (mutation.kind) {
+    case 'delete-subjects': return deleteSubjectsSemantics(mutation.input);
+    case 'prune-ranked-subjects': return pruneRankedSubjectsSemantics(mutation.input);
+    case 'prune-linked-record-closures': return pruneLinkedRecordClosuresSemantics(mutation.input);
+    case 'replace-subject-predicates': return replaceSubjectPredicatesSemantics(mutation.input);
+    case 'replace-projection-from-graph': return replaceProjectionFromGraphSemantics(mutation.input);
+    case 'copy-subject-projection': return copySubjectProjectionSemantics(mutation.input);
+    default: return unsupportedMutation(mutation);
+  }
 }
 
 /** Immutable graph-scoped effects captured before a structured mutation is dispatched. */

--- a/packages/storage/src/bounded-structured-mutation.ts
+++ b/packages/storage/src/bounded-structured-mutation.ts
@@ -141,12 +141,20 @@ export type ReadonlyStructuredMutation =
     }>;
   }>;
 
-export interface StructuredMutationSnapshot {
+interface StructuredMutationSnapshotBase {
   readonly mutation: ReadonlyStructuredMutation;
   readonly guardedGraphs: readonly string[];
-  readonly effects: StructuredMutationEffects | undefined;
-  readonly outcome: 'noop' | 'candidate';
 }
+
+export type StructuredMutationSnapshot =
+  | Readonly<StructuredMutationSnapshotBase & {
+    outcome: 'noop';
+    effects: undefined;
+  }>
+  | Readonly<StructuredMutationSnapshotBase & {
+    outcome: 'candidate';
+    effects: StructuredMutationEffects;
+  }>;
 
 const STRUCTURED_MUTATION_SNAPSHOT_BRAND = Symbol('structured-mutation-snapshot');
 const STRUCTURED_MUTATION_SNAPSHOTS = new WeakMap<object, StructuredMutationSnapshot>();
@@ -205,18 +213,21 @@ export function captureStructuredMutationSnapshot(
       throw new Error(`Unsupported structured mutation kind ${String(kind)}`);
   }
   const guardedGraphs = Object.freeze([...semantics.guardedGraphs]);
-  const mightMutate = semantics.mightMutate;
-  const effects = mightMutate
+  const snapshot: StructuredMutationSnapshot = semantics.mightMutate
     ? Object.freeze({
+      mutation: captured,
+      guardedGraphs,
+      outcome: 'candidate' as const,
+      effects: Object.freeze({
         touchedGraphs: Object.freeze([...semantics.touchedGraphs]),
-      })
-    : undefined;
-  const snapshot: StructuredMutationSnapshot = Object.freeze({
-    mutation: captured,
-    guardedGraphs,
-    effects,
-    outcome: mightMutate ? 'candidate' : 'noop',
-  });
+      }),
+    })
+    : Object.freeze({
+      mutation: captured,
+      guardedGraphs,
+      outcome: 'noop' as const,
+      effects: undefined,
+    });
   STRUCTURED_MUTATION_SNAPSHOTS.set(captured, snapshot);
   return snapshot;
 }

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -24,9 +24,7 @@ import {
 } from './store-chain-capability.js';
 import type { SystemRecordLaneControllerV1 } from './system-record-materializer-v1.js';
 import {
-  captureStructuredMutationEffects,
-  normalizeStructuredMutation,
-  structuredMutationGuardedGraphs,
+  captureStructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
 
 /**
@@ -458,27 +456,29 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
   }
 
   async structuredMutation(mutation: StructuredMutation, options?: QueryOptions): Promise<void> {
-    const normalized = normalizeStructuredMutation(mutation);
-    const effects = captureStructuredMutationEffects(normalized);
+    const snapshot = captureStructuredMutationSnapshot(mutation);
     const operation = this.inner.structuredMutation;
     if (!operation) {
       throw new UnsupportedTripleStoreCapabilityError('structuredMutation', 'ChangelogStore');
     }
-    if (!this.enabled) return operation.call(this.inner, normalized, options);
-    for (const graph of structuredMutationGuardedGraphs(normalized)) {
+    if (!this.enabled) return operation.call(this.inner, snapshot.mutation, options);
+    for (const graph of snapshot.guardedGraphs) {
       this.assertNotReserved(graph, 'structuredMutation');
     }
     await this.runExclusive(async () => {
       try {
-        await operation.call(this.inner, normalized, options);
+        await operation.call(this.inner, snapshot.mutation, options);
       } catch (error) {
-        if (!isTripleStoreCapabilityRefusal(error, 'structuredMutation')) {
+        if (
+          snapshot.outcome !== 'noop' &&
+          !isTripleStoreCapabilityRefusal(error, 'structuredMutation')
+        ) {
           this.flagReconcile('structuredMutation(indeterminate-failure)');
         }
         throw error;
       }
-      if (effects) {
-        await this.markPostMutation(effects.touchedGraphs, options);
+      if (snapshot.outcome !== 'noop') {
+        await this.markPostMutation(snapshot.effects!.touchedGraphs, options);
       }
     });
   }

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -26,6 +26,7 @@ import type { SystemRecordLaneControllerV1 } from './system-record-materializer-
 import {
   captureStructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
+import { isBoundedMutationBudgetError } from './structured-mutation/primitives.js';
 
 /**
  * ChangelogStore — an append-only per-node change log maintained on the write
@@ -471,7 +472,8 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
       } catch (error) {
         if (
           snapshot.outcome !== 'noop' &&
-          !isTripleStoreCapabilityRefusal(error, 'structuredMutation')
+          !isTripleStoreCapabilityRefusal(error, 'structuredMutation') &&
+          !isBoundedMutationBudgetError(error)
         ) {
           this.flagReconcile('structuredMutation(indeterminate-failure)');
         }

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -26,7 +26,7 @@ import type { SystemRecordLaneControllerV1 } from './system-record-materializer-
 import {
   captureStructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
-import { isBoundedMutationBudgetError } from './structured-mutation/primitives.js';
+import { isStructuredMutationPreDispatchRefusal } from './structured-mutation/refusal-internal.js';
 
 /**
  * ChangelogStore — an append-only per-node change log maintained on the write
@@ -473,14 +473,14 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
         if (
           snapshot.outcome !== 'noop' &&
           !isTripleStoreCapabilityRefusal(error, 'structuredMutation') &&
-          !isBoundedMutationBudgetError(error)
+          !isStructuredMutationPreDispatchRefusal(error)
         ) {
           this.flagReconcile('structuredMutation(indeterminate-failure)');
         }
         throw error;
       }
       if (snapshot.outcome !== 'noop') {
-        await this.markPostMutation(snapshot.effects!.touchedGraphs, options);
+        await this.markPostMutation(snapshot.effects.touchedGraphs, options);
       }
     });
   }

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -471,7 +471,6 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
         await operation.call(this.inner, snapshot.mutation, options);
       } catch (error) {
         if (
-          snapshot.outcome !== 'noop' &&
           !isTripleStoreCapabilityRefusal(error, 'structuredMutation') &&
           !isStructuredMutationPreDispatchRefusal(error)
         ) {

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -25,7 +25,7 @@ import { ManagedOxigraphBackendUnownedError } from './managed-oxigraph-backend-u
 import {
   captureStructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
-import { isBoundedMutationBudgetError } from './structured-mutation/primitives.js';
+import { isStructuredMutationPreDispatchRefusal } from './structured-mutation/refusal-internal.js';
 import {
   CACHED_READ_GATE_V1,
   asCachedReadGateV1,
@@ -568,7 +568,7 @@ export class GraphSetIndexStore implements TripleStore {
       if (
         snapshot.outcome !== 'noop' &&
         !isTripleStoreCapabilityRefusal(error, 'structuredMutation') &&
-        !isBoundedMutationBudgetError(error)
+        !isStructuredMutationPreDispatchRefusal(error)
       ) {
         this.scheduleFullRefresh('structuredMutation');
       }
@@ -577,7 +577,7 @@ export class GraphSetIndexStore implements TripleStore {
     if (!this.enabled || snapshot.outcome === 'noop') return;
     this.bumpMutation();
     await this.maintainTouchedGraphs(
-      [...snapshot.effects!.touchedGraphs],
+      [...snapshot.effects.touchedGraphs],
       'structuredMutation',
       options,
     );

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -25,6 +25,7 @@ import { ManagedOxigraphBackendUnownedError } from './managed-oxigraph-backend-u
 import {
   captureStructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
+import { isBoundedMutationBudgetError } from './structured-mutation/primitives.js';
 import {
   CACHED_READ_GATE_V1,
   asCachedReadGateV1,
@@ -566,7 +567,8 @@ export class GraphSetIndexStore implements TripleStore {
     } catch (error) {
       if (
         snapshot.outcome !== 'noop' &&
-        !isTripleStoreCapabilityRefusal(error, 'structuredMutation')
+        !isTripleStoreCapabilityRefusal(error, 'structuredMutation') &&
+        !isBoundedMutationBudgetError(error)
       ) {
         this.scheduleFullRefresh('structuredMutation');
       }

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -566,7 +566,6 @@ export class GraphSetIndexStore implements TripleStore {
       await operation.call(this.inner, snapshot.mutation, options);
     } catch (error) {
       if (
-        snapshot.outcome !== 'noop' &&
         !isTripleStoreCapabilityRefusal(error, 'structuredMutation') &&
         !isStructuredMutationPreDispatchRefusal(error)
       ) {

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -23,8 +23,7 @@ import {
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
 import { ManagedOxigraphBackendUnownedError } from './managed-oxigraph-backend-unowned-error.js';
 import {
-  captureStructuredMutationEffects,
-  normalizeStructuredMutation,
+  captureStructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
 import {
   CACHED_READ_GATE_V1,
@@ -557,24 +556,26 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   async structuredMutation(mutation: StructuredMutation, options?: QueryOptions): Promise<void> {
-    const normalized = normalizeStructuredMutation(mutation);
-    const effects = captureStructuredMutationEffects(normalized);
+    const snapshot = captureStructuredMutationSnapshot(mutation);
     const operation = this.inner.structuredMutation;
     if (!operation) {
       throw new UnsupportedTripleStoreCapabilityError('structuredMutation', 'GraphSetIndexStore');
     }
     try {
-      await operation.call(this.inner, normalized, options);
+      await operation.call(this.inner, snapshot.mutation, options);
     } catch (error) {
-      if (!isTripleStoreCapabilityRefusal(error, 'structuredMutation')) {
+      if (
+        snapshot.outcome !== 'noop' &&
+        !isTripleStoreCapabilityRefusal(error, 'structuredMutation')
+      ) {
         this.scheduleFullRefresh('structuredMutation');
       }
       throw error;
     }
-    if (!this.enabled || !effects) return;
+    if (!this.enabled || snapshot.outcome === 'noop') return;
     this.bumpMutation();
     await this.maintainTouchedGraphs(
-      [...effects.touchedGraphs],
+      [...snapshot.effects!.touchedGraphs],
       'structuredMutation',
       options,
     );

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -52,10 +52,14 @@ export {
 export {
   BOUNDED_MUTATION_MAX_PRUNE_DELETE,
   captureStructuredMutationEffects,
+  captureStructuredMutationSnapshot,
   chunkCopySubjectProjectionInput,
   structuredMutationMightMutate,
   structuredMutationTouchedGraphs,
+  type ReadonlyStructuredMutation,
+  type ReadonlyStructuredMutationQuad,
   type StructuredMutationEffects,
+  type StructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
 // System-record V1 (#2052 Stack B2). Default-unused: these modules perform no
 // I/O, scheduling, timer, or per-store lane work until the daemon supervisor

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -18,7 +18,7 @@ import {
   UnsupportedTripleStoreCapabilityError,
 } from './unsupported-capability-error.js';
 import {
-  rewriteStructuredMutationQuads,
+  captureStructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
 
 export const EXTERNAL_LITERAL_REF_DATATYPE = 'http://dkg.io/ontology/externalLiteralRef';
@@ -195,11 +195,19 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
         'SharedMemoryLiteralBlobStore',
       );
     }
-    const rewritten = await rewriteStructuredMutationQuads(
-      mutation,
-      (quad) => this.externalizeInsertQuad(quad),
+    const snapshot = captureStructuredMutationSnapshot(mutation);
+    if (snapshot.outcome === 'noop' || snapshot.mutation.kind !== 'replace-subject-predicates') {
+      await this.inner.structuredMutation(snapshot.mutation, options);
+      return;
+    }
+    const replacementQuads = await Promise.all(
+      snapshot.mutation.input.replacementQuads.map((quad) => this.externalizeInsertQuad(quad)),
     );
-    await this.inner.structuredMutation(rewritten, options);
+    const rewritten = captureStructuredMutationSnapshot({
+      kind: snapshot.mutation.kind,
+      input: { ...snapshot.mutation.input, replacementQuads },
+    });
+    await this.inner.structuredMutation(rewritten.mutation, options);
   }
 
   async update(sparql: string, options?: UpdateOptions): Promise<void> {

--- a/packages/storage/src/structured-mutation-materialization-internal.ts
+++ b/packages/storage/src/structured-mutation-materialization-internal.ts
@@ -13,10 +13,13 @@ import {
 } from './structured-mutation/retention.js';
 
 export type MaterializedStructuredMutation =
-  | Readonly<{ outcome: 'noop'; snapshot: StructuredMutationSnapshot }>
+  | Readonly<{
+    outcome: 'noop';
+    snapshot: Extract<StructuredMutationSnapshot, { outcome: 'noop' }>;
+  }>
   | Readonly<{
     outcome: 'execute';
-    snapshot: StructuredMutationSnapshot;
+    snapshot: Extract<StructuredMutationSnapshot, { outcome: 'candidate' }>;
     update: string;
   }>;
 

--- a/packages/storage/src/structured-mutation-materialization-internal.ts
+++ b/packages/storage/src/structured-mutation-materialization-internal.ts
@@ -25,9 +25,8 @@ export type MaterializedStructuredMutation =
 export function materializeStructuredMutation(
   snapshot: StructuredMutationSnapshot,
 ): MaterializedStructuredMutation {
-  assertTrustedStructuredMutationSnapshot(snapshot);
+  assertStructuredMutationSnapshotMaterializable(snapshot);
   const mutation = snapshot.mutation;
-  assertMutationOperandBudget(mutation);
   const update = buildSnapshotUpdate(mutation);
   if (update === undefined) {
     if (snapshot.outcome !== 'noop') {
@@ -39,6 +38,14 @@ export function materializeStructuredMutation(
     throw new Error('structured mutation no-op unexpectedly materialized an update');
   }
   return Object.freeze({ outcome: 'execute', snapshot, update });
+}
+
+/** Validate a worker-bound snapshot before structured clone without building backend text. */
+export function assertStructuredMutationSnapshotMaterializable(
+  snapshot: StructuredMutationSnapshot,
+): void {
+  assertTrustedStructuredMutationSnapshot(snapshot);
+  assertMutationOperandBudget(snapshot.mutation);
 }
 
 function buildSnapshotUpdate(mutation: ReadonlyStructuredMutation): string | undefined {

--- a/packages/storage/src/structured-mutation-materialization-internal.ts
+++ b/packages/storage/src/structured-mutation-materialization-internal.ts
@@ -1,0 +1,153 @@
+import {
+  assertTrustedStructuredMutationSnapshot,
+  type ReadonlyStructuredMutation,
+  type StructuredMutationSnapshot,
+} from './bounded-structured-mutation.js';
+import { buildCopySubjectProjectionUpdateFromNormalized } from './structured-mutation/copy-subject-projection.js';
+import { buildDeleteSubjectsUpdateFromNormalized } from './structured-mutation/delete-subjects.js';
+import { assertOperandBudget } from './structured-mutation/primitives.js';
+import { buildReplaceProjectionFromGraphUpdateFromNormalized } from './structured-mutation/replace-projection-from-graph.js';
+import { buildReplaceSubjectPredicatesUpdateFromNormalized } from './structured-mutation/replace-subject-predicates.js';
+import {
+  buildPruneLinkedRecordClosuresUpdateFromNormalized,
+  buildPruneRankedSubjectsUpdateFromNormalized,
+} from './structured-mutation/retention.js';
+
+export type MaterializedStructuredMutation =
+  | Readonly<{ outcome: 'noop'; snapshot: StructuredMutationSnapshot }>
+  | Readonly<{
+    outcome: 'execute';
+    snapshot: StructuredMutationSnapshot;
+    update: string;
+  }>;
+
+/** Validate deferred budgets and build one executable update from a trusted snapshot. */
+export function materializeStructuredMutation(
+  snapshot: StructuredMutationSnapshot,
+): MaterializedStructuredMutation {
+  assertTrustedStructuredMutationSnapshot(snapshot);
+  const mutation = snapshot.mutation;
+  assertMutationOperandBudget(mutation);
+  const update = buildSnapshotUpdate(mutation);
+  if (update === undefined) {
+    if (snapshot.outcome !== 'noop') {
+      throw new Error('structured mutation candidate unexpectedly materialized as a no-op');
+    }
+    return Object.freeze({ outcome: 'noop', snapshot });
+  }
+  if (snapshot.outcome !== 'candidate') {
+    throw new Error('structured mutation no-op unexpectedly materialized an update');
+  }
+  return Object.freeze({ outcome: 'execute', snapshot, update });
+}
+
+function buildSnapshotUpdate(mutation: ReadonlyStructuredMutation): string | undefined {
+  switch (mutation.kind) {
+    case 'delete-subjects':
+      return buildDeleteSubjectsUpdateFromNormalized(mutation.input);
+    case 'prune-ranked-subjects':
+      return buildPruneRankedSubjectsUpdateFromNormalized(mutation.input);
+    case 'prune-linked-record-closures':
+      return buildPruneLinkedRecordClosuresUpdateFromNormalized(mutation.input);
+    case 'replace-subject-predicates':
+      return buildReplaceSubjectPredicatesUpdateFromNormalized(mutation.input);
+    case 'replace-projection-from-graph':
+      return buildReplaceProjectionFromGraphUpdateFromNormalized(mutation.input);
+    case 'copy-subject-projection':
+      return buildCopySubjectProjectionUpdateFromNormalized(mutation.input);
+  }
+}
+
+function assertMutationOperandBudget(mutation: ReadonlyStructuredMutation): void {
+  switch (mutation.kind) {
+    case 'delete-subjects':
+      assertOperandBudget('deleteSubjects', deleteSubjectOperands(mutation.input));
+      return;
+    case 'prune-ranked-subjects':
+      assertOperandBudget('pruneRankedSubjects', pruneRankedOperands(mutation.input));
+      return;
+    case 'prune-linked-record-closures':
+      assertOperandBudget(
+        'pruneLinkedRecordClosures',
+        pruneLinkedRecordOperands(mutation.input),
+      );
+      return;
+    case 'replace-subject-predicates':
+      assertOperandBudget(
+        'replaceSubjectPredicates',
+        replaceSubjectPredicatesOperands(mutation.input),
+      );
+      return;
+    case 'replace-projection-from-graph':
+      assertOperandBudget(
+        'replaceProjectionFromGraph',
+        replaceProjectionOperands(mutation.input),
+      );
+      return;
+    case 'copy-subject-projection':
+      assertOperandBudget('copySubjectProjection', copyProjectionOperands(mutation.input));
+  }
+}
+
+function* deleteSubjectOperands(
+  input: Extract<ReadonlyStructuredMutation, { kind: 'delete-subjects' }>['input'],
+): Iterable<string> {
+  yield input.graphUri;
+  yield* input.subjects;
+}
+
+function* pruneRankedOperands(
+  input: Extract<ReadonlyStructuredMutation, { kind: 'prune-ranked-subjects' }>['input'],
+): Iterable<string> {
+  yield input.graphUri;
+  yield input.subjectPrefix;
+  yield input.eligibilityPredicate;
+  yield input.primaryRankPredicate;
+  yield input.secondaryRankPredicate;
+  yield* input.eligibleObjects;
+}
+
+function* pruneLinkedRecordOperands(
+  input: Extract<ReadonlyStructuredMutation, { kind: 'prune-linked-record-closures' }>['input'],
+): Iterable<string> {
+  yield input.graphUri;
+  yield* input.matchObjectIris;
+  yield* input.linkPredicates;
+  yield input.recordParentPredicate;
+  yield input.descendantSeparator;
+  if (input.protectedRecordIri !== undefined) yield input.protectedRecordIri;
+}
+
+function* replaceSubjectPredicatesOperands(
+  input: Extract<ReadonlyStructuredMutation, { kind: 'replace-subject-predicates' }>['input'],
+): Iterable<string> {
+  yield input.graphUri;
+  yield input.subject;
+  yield* input.predicates;
+  for (const quad of input.replacementQuads) {
+    yield quad.subject;
+    yield quad.predicate;
+    yield quad.object;
+    yield quad.graph;
+  }
+}
+
+function* replaceProjectionOperands(
+  input: Extract<ReadonlyStructuredMutation, { kind: 'replace-projection-from-graph' }>['input'],
+): Iterable<string> {
+  yield input.targetGraphUri;
+  yield input.stagingGraphUri;
+  yield input.targetSubject;
+  yield* input.preservedTargetPredicates;
+  yield* input.targetSubjectPrefixes;
+}
+
+function* copyProjectionOperands(
+  input: Extract<ReadonlyStructuredMutation, { kind: 'copy-subject-projection' }>['input'],
+): Iterable<string> {
+  yield* input.sourceGraphUris;
+  yield input.targetGraphUri;
+  yield* input.roots;
+  yield input.descendantSuffix;
+  yield* input.excludedPredicates;
+}

--- a/packages/storage/src/structured-mutation-materialization-internal.ts
+++ b/packages/storage/src/structured-mutation-materialization-internal.ts
@@ -3,13 +3,27 @@ import {
   type ReadonlyStructuredMutation,
   type StructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
-import { materializeCopySubjectProjectionInput } from './structured-mutation/copy-subject-projection.js';
-import { materializeDeleteSubjectsInput } from './structured-mutation/delete-subjects.js';
-import { materializeReplaceProjectionFromGraphInput } from './structured-mutation/replace-projection-from-graph.js';
-import { materializeReplaceSubjectPredicatesInput } from './structured-mutation/replace-subject-predicates.js';
 import {
-  materializePruneLinkedRecordClosuresInput,
-  materializePruneRankedSubjectsInput,
+  assertCopySubjectProjectionInputMaterializable,
+  buildCopySubjectProjectionUpdateFromNormalized,
+} from './structured-mutation/copy-subject-projection.js';
+import {
+  assertDeleteSubjectsInputMaterializable,
+  buildDeleteSubjectsUpdateFromNormalized,
+} from './structured-mutation/delete-subjects.js';
+import {
+  assertReplaceProjectionFromGraphInputMaterializable,
+  buildReplaceProjectionFromGraphUpdateFromNormalized,
+} from './structured-mutation/replace-projection-from-graph.js';
+import {
+  assertReplaceSubjectPredicatesInputMaterializable,
+  buildReplaceSubjectPredicatesUpdateFromNormalized,
+} from './structured-mutation/replace-subject-predicates.js';
+import {
+  assertPruneLinkedRecordClosuresInputMaterializable,
+  assertPruneRankedSubjectsInputMaterializable,
+  buildPruneLinkedRecordClosuresUpdateFromNormalized,
+  buildPruneRankedSubjectsUpdateFromNormalized,
 } from './structured-mutation/retention.js';
 
 export type MaterializedStructuredMutation =
@@ -29,7 +43,8 @@ export function materializeStructuredMutation(
 ): MaterializedStructuredMutation {
   assertTrustedStructuredMutationSnapshot(snapshot);
   const mutation = snapshot.mutation;
-  const update = materializeSnapshotUpdate(mutation);
+  assertSnapshotMaterializable(mutation);
+  const update = buildSnapshotUpdate(mutation);
   if (update === undefined) {
     if (snapshot.outcome !== 'noop') {
       throw new Error('structured mutation candidate unexpectedly materialized as a no-op');
@@ -47,25 +62,44 @@ export function assertStructuredMutationSnapshotMaterializable(
   snapshot: StructuredMutationSnapshot,
 ): void {
   assertTrustedStructuredMutationSnapshot(snapshot);
-  materializeSnapshotUpdate(snapshot.mutation, false);
+  assertSnapshotMaterializable(snapshot.mutation);
 }
 
-function materializeSnapshotUpdate(
-  mutation: ReadonlyStructuredMutation,
-  buildUpdate = true,
-): string | undefined {
+function assertSnapshotMaterializable(mutation: ReadonlyStructuredMutation): void {
   switch (mutation.kind) {
     case 'delete-subjects':
-      return materializeDeleteSubjectsInput(mutation.input, buildUpdate);
+      assertDeleteSubjectsInputMaterializable(mutation.input);
+      return;
     case 'prune-ranked-subjects':
-      return materializePruneRankedSubjectsInput(mutation.input, buildUpdate);
+      assertPruneRankedSubjectsInputMaterializable(mutation.input);
+      return;
     case 'prune-linked-record-closures':
-      return materializePruneLinkedRecordClosuresInput(mutation.input, buildUpdate);
+      assertPruneLinkedRecordClosuresInputMaterializable(mutation.input);
+      return;
     case 'replace-subject-predicates':
-      return materializeReplaceSubjectPredicatesInput(mutation.input, buildUpdate);
+      assertReplaceSubjectPredicatesInputMaterializable(mutation.input);
+      return;
     case 'replace-projection-from-graph':
-      return materializeReplaceProjectionFromGraphInput(mutation.input, buildUpdate);
+      assertReplaceProjectionFromGraphInputMaterializable(mutation.input);
+      return;
     case 'copy-subject-projection':
-      return materializeCopySubjectProjectionInput(mutation.input, buildUpdate);
+      assertCopySubjectProjectionInputMaterializable(mutation.input);
+  }
+}
+
+function buildSnapshotUpdate(mutation: ReadonlyStructuredMutation): string | undefined {
+  switch (mutation.kind) {
+    case 'delete-subjects':
+      return buildDeleteSubjectsUpdateFromNormalized(mutation.input);
+    case 'prune-ranked-subjects':
+      return buildPruneRankedSubjectsUpdateFromNormalized(mutation.input);
+    case 'prune-linked-record-closures':
+      return buildPruneLinkedRecordClosuresUpdateFromNormalized(mutation.input);
+    case 'replace-subject-predicates':
+      return buildReplaceSubjectPredicatesUpdateFromNormalized(mutation.input);
+    case 'replace-projection-from-graph':
+      return buildReplaceProjectionFromGraphUpdateFromNormalized(mutation.input);
+    case 'copy-subject-projection':
+      return buildCopySubjectProjectionUpdateFromNormalized(mutation.input);
   }
 }

--- a/packages/storage/src/structured-mutation-materialization-internal.ts
+++ b/packages/storage/src/structured-mutation-materialization-internal.ts
@@ -3,14 +3,13 @@ import {
   type ReadonlyStructuredMutation,
   type StructuredMutationSnapshot,
 } from './bounded-structured-mutation.js';
-import { buildCopySubjectProjectionUpdateFromNormalized } from './structured-mutation/copy-subject-projection.js';
-import { buildDeleteSubjectsUpdateFromNormalized } from './structured-mutation/delete-subjects.js';
-import { assertOperandBudget } from './structured-mutation/primitives.js';
-import { buildReplaceProjectionFromGraphUpdateFromNormalized } from './structured-mutation/replace-projection-from-graph.js';
-import { buildReplaceSubjectPredicatesUpdateFromNormalized } from './structured-mutation/replace-subject-predicates.js';
+import { materializeCopySubjectProjectionInput } from './structured-mutation/copy-subject-projection.js';
+import { materializeDeleteSubjectsInput } from './structured-mutation/delete-subjects.js';
+import { materializeReplaceProjectionFromGraphInput } from './structured-mutation/replace-projection-from-graph.js';
+import { materializeReplaceSubjectPredicatesInput } from './structured-mutation/replace-subject-predicates.js';
 import {
-  buildPruneLinkedRecordClosuresUpdateFromNormalized,
-  buildPruneRankedSubjectsUpdateFromNormalized,
+  materializePruneLinkedRecordClosuresInput,
+  materializePruneRankedSubjectsInput,
 } from './structured-mutation/retention.js';
 
 export type MaterializedStructuredMutation =
@@ -25,9 +24,9 @@ export type MaterializedStructuredMutation =
 export function materializeStructuredMutation(
   snapshot: StructuredMutationSnapshot,
 ): MaterializedStructuredMutation {
-  assertStructuredMutationSnapshotMaterializable(snapshot);
+  assertTrustedStructuredMutationSnapshot(snapshot);
   const mutation = snapshot.mutation;
-  const update = buildSnapshotUpdate(mutation);
+  const update = materializeSnapshotUpdate(mutation);
   if (update === undefined) {
     if (snapshot.outcome !== 'noop') {
       throw new Error('structured mutation candidate unexpectedly materialized as a no-op');
@@ -45,116 +44,25 @@ export function assertStructuredMutationSnapshotMaterializable(
   snapshot: StructuredMutationSnapshot,
 ): void {
   assertTrustedStructuredMutationSnapshot(snapshot);
-  assertMutationOperandBudget(snapshot.mutation);
+  materializeSnapshotUpdate(snapshot.mutation, false);
 }
 
-function buildSnapshotUpdate(mutation: ReadonlyStructuredMutation): string | undefined {
+function materializeSnapshotUpdate(
+  mutation: ReadonlyStructuredMutation,
+  buildUpdate = true,
+): string | undefined {
   switch (mutation.kind) {
     case 'delete-subjects':
-      return buildDeleteSubjectsUpdateFromNormalized(mutation.input);
+      return materializeDeleteSubjectsInput(mutation.input, buildUpdate);
     case 'prune-ranked-subjects':
-      return buildPruneRankedSubjectsUpdateFromNormalized(mutation.input);
+      return materializePruneRankedSubjectsInput(mutation.input, buildUpdate);
     case 'prune-linked-record-closures':
-      return buildPruneLinkedRecordClosuresUpdateFromNormalized(mutation.input);
+      return materializePruneLinkedRecordClosuresInput(mutation.input, buildUpdate);
     case 'replace-subject-predicates':
-      return buildReplaceSubjectPredicatesUpdateFromNormalized(mutation.input);
+      return materializeReplaceSubjectPredicatesInput(mutation.input, buildUpdate);
     case 'replace-projection-from-graph':
-      return buildReplaceProjectionFromGraphUpdateFromNormalized(mutation.input);
+      return materializeReplaceProjectionFromGraphInput(mutation.input, buildUpdate);
     case 'copy-subject-projection':
-      return buildCopySubjectProjectionUpdateFromNormalized(mutation.input);
+      return materializeCopySubjectProjectionInput(mutation.input, buildUpdate);
   }
-}
-
-function assertMutationOperandBudget(mutation: ReadonlyStructuredMutation): void {
-  switch (mutation.kind) {
-    case 'delete-subjects':
-      assertOperandBudget('deleteSubjects', deleteSubjectOperands(mutation.input));
-      return;
-    case 'prune-ranked-subjects':
-      assertOperandBudget('pruneRankedSubjects', pruneRankedOperands(mutation.input));
-      return;
-    case 'prune-linked-record-closures':
-      assertOperandBudget(
-        'pruneLinkedRecordClosures',
-        pruneLinkedRecordOperands(mutation.input),
-      );
-      return;
-    case 'replace-subject-predicates':
-      assertOperandBudget(
-        'replaceSubjectPredicates',
-        replaceSubjectPredicatesOperands(mutation.input),
-      );
-      return;
-    case 'replace-projection-from-graph':
-      assertOperandBudget(
-        'replaceProjectionFromGraph',
-        replaceProjectionOperands(mutation.input),
-      );
-      return;
-    case 'copy-subject-projection':
-      assertOperandBudget('copySubjectProjection', copyProjectionOperands(mutation.input));
-  }
-}
-
-function* deleteSubjectOperands(
-  input: Extract<ReadonlyStructuredMutation, { kind: 'delete-subjects' }>['input'],
-): Iterable<string> {
-  yield input.graphUri;
-  yield* input.subjects;
-}
-
-function* pruneRankedOperands(
-  input: Extract<ReadonlyStructuredMutation, { kind: 'prune-ranked-subjects' }>['input'],
-): Iterable<string> {
-  yield input.graphUri;
-  yield input.subjectPrefix;
-  yield input.eligibilityPredicate;
-  yield input.primaryRankPredicate;
-  yield input.secondaryRankPredicate;
-  yield* input.eligibleObjects;
-}
-
-function* pruneLinkedRecordOperands(
-  input: Extract<ReadonlyStructuredMutation, { kind: 'prune-linked-record-closures' }>['input'],
-): Iterable<string> {
-  yield input.graphUri;
-  yield* input.matchObjectIris;
-  yield* input.linkPredicates;
-  yield input.recordParentPredicate;
-  yield input.descendantSeparator;
-  if (input.protectedRecordIri !== undefined) yield input.protectedRecordIri;
-}
-
-function* replaceSubjectPredicatesOperands(
-  input: Extract<ReadonlyStructuredMutation, { kind: 'replace-subject-predicates' }>['input'],
-): Iterable<string> {
-  yield input.graphUri;
-  yield input.subject;
-  yield* input.predicates;
-  for (const quad of input.replacementQuads) {
-    yield quad.subject;
-    yield quad.predicate;
-    yield quad.object;
-    yield quad.graph;
-  }
-}
-
-function* replaceProjectionOperands(
-  input: Extract<ReadonlyStructuredMutation, { kind: 'replace-projection-from-graph' }>['input'],
-): Iterable<string> {
-  yield input.targetGraphUri;
-  yield input.stagingGraphUri;
-  yield input.targetSubject;
-  yield* input.preservedTargetPredicates;
-  yield* input.targetSubjectPrefixes;
-}
-
-function* copyProjectionOperands(
-  input: Extract<ReadonlyStructuredMutation, { kind: 'copy-subject-projection' }>['input'],
-): Iterable<string> {
-  yield* input.sourceGraphUris;
-  yield input.targetGraphUri;
-  yield* input.roots;
-  yield input.descendantSuffix;
-  yield* input.excludedPredicates;
 }

--- a/packages/storage/src/structured-mutation-materialization-internal.ts
+++ b/packages/storage/src/structured-mutation-materialization-internal.ts
@@ -25,6 +25,7 @@ import {
   buildPruneLinkedRecordClosuresUpdateFromNormalized,
   buildPruneRankedSubjectsUpdateFromNormalized,
 } from './structured-mutation/retention.js';
+import { markStructuredMutationPreDispatchRefusal } from './structured-mutation/refusal-internal.js';
 
 export type MaterializedStructuredMutation =
   | Readonly<{
@@ -42,19 +43,24 @@ export function materializeStructuredMutation(
   snapshot: StructuredMutationSnapshot,
 ): MaterializedStructuredMutation {
   assertTrustedStructuredMutationSnapshot(snapshot);
-  const mutation = snapshot.mutation;
-  assertSnapshotMaterializable(mutation);
-  const update = buildSnapshotUpdate(mutation);
-  if (update === undefined) {
-    if (snapshot.outcome !== 'noop') {
-      throw new Error('structured mutation candidate unexpectedly materialized as a no-op');
+  try {
+    const mutation = snapshot.mutation;
+    assertSnapshotMaterializable(mutation);
+    const update = buildSnapshotUpdate(mutation);
+    if (update === undefined) {
+      if (snapshot.outcome !== 'noop') {
+        throw new Error('structured mutation candidate unexpectedly materialized as a no-op');
+      }
+      return Object.freeze({ outcome: 'noop', snapshot });
     }
-    return Object.freeze({ outcome: 'noop', snapshot });
+    if (snapshot.outcome !== 'candidate') {
+      throw new Error('structured mutation no-op unexpectedly materialized an update');
+    }
+    return Object.freeze({ outcome: 'execute', snapshot, update });
+  } catch (error) {
+    markStructuredMutationPreDispatchRefusal(error);
+    throw error;
   }
-  if (snapshot.outcome !== 'candidate') {
-    throw new Error('structured mutation no-op unexpectedly materialized an update');
-  }
-  return Object.freeze({ outcome: 'execute', snapshot, update });
 }
 
 /** Validate a worker-bound snapshot before structured clone without building backend text. */
@@ -62,7 +68,12 @@ export function assertStructuredMutationSnapshotMaterializable(
   snapshot: StructuredMutationSnapshot,
 ): void {
   assertTrustedStructuredMutationSnapshot(snapshot);
-  assertSnapshotMaterializable(snapshot.mutation);
+  try {
+    assertSnapshotMaterializable(snapshot.mutation);
+  } catch (error) {
+    markStructuredMutationPreDispatchRefusal(error);
+    throw error;
+  }
 }
 
 function assertSnapshotMaterializable(mutation: ReadonlyStructuredMutation): void {

--- a/packages/storage/src/structured-mutation/capture-internal.ts
+++ b/packages/storage/src/structured-mutation/capture-internal.ts
@@ -1,0 +1,66 @@
+import {
+  absoluteIri,
+  boundedString,
+} from './primitives.js';
+
+export interface StructuredMutationSemantics {
+  readonly guardedGraphs: readonly string[];
+  readonly touchedGraphs: readonly string[];
+  readonly mightMutate: boolean;
+}
+
+export function captureInputRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function captureUniqueIris(
+  value: unknown,
+  label: string,
+  max: number,
+  allowEmpty: boolean,
+): readonly string[] {
+  const seen = new Set<string>();
+  return captureArray(value, label, allowEmpty ? 0 : 1, max, (candidate, index) => {
+    const iri = absoluteIri(candidate as string, `${label}[${index}]`);
+    if (seen.has(iri)) throw new Error(`${label} contains duplicate IRI ${iri}`);
+    seen.add(iri);
+    return iri;
+  });
+}
+
+export function captureUniqueStrings(
+  value: unknown,
+  label: string,
+  max: number,
+): readonly string[] {
+  const seen = new Set<string>();
+  return captureArray(value, label, 1, max, (candidate, index) => {
+    const captured = boundedString(candidate as string, `${label}[${index}]`);
+    if (seen.has(captured)) throw new Error(`${label} contains duplicate value ${captured}`);
+    seen.add(captured);
+    return captured;
+  });
+}
+
+export function captureArray<T>(
+  value: unknown,
+  label: string,
+  min: number,
+  max: number,
+  capture: (candidate: unknown, index: number) => T,
+): readonly T[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  const length = value.length;
+  if (length < min || length > max) {
+    throw new Error(`${label} must contain ${min}..${max} values`);
+  }
+  const result = new Array<T>(length);
+  for (let index = 0; index < length; index += 1) {
+    if (!(index in value)) throw new Error(`${label} must be a dense array`);
+    result[index] = capture(value[index], index);
+  }
+  return Object.freeze(result);
+}

--- a/packages/storage/src/structured-mutation/copy-subject-projection.ts
+++ b/packages/storage/src/structured-mutation/copy-subject-projection.ts
@@ -56,18 +56,24 @@ export function normalizeCopySubjectProjectionInput(
 
 export function buildCopySubjectProjectionUpdate(input: CopySubjectProjectionInput): string {
   const normalized = normalizeCopySubjectProjectionInput(input);
-  const sources = normalized.sourceGraphUris.map((graph) => `<${graph}>`).join(' ');
-  const roots = normalized.roots.map((root) => `<${root}>`).join(' ');
-  const excluded = normalized.excludedPredicates.length > 0
-    ? `FILTER(?predicate NOT IN (${normalized.excludedPredicates.map((iri) => `<${iri}>`).join(', ')}))`
+  return buildCopySubjectProjectionUpdateFromNormalized(normalized);
+}
+
+export function buildCopySubjectProjectionUpdateFromNormalized(
+  input: CopySubjectProjectionInput,
+): string {
+  const sources = input.sourceGraphUris.map((graph) => `<${graph}>`).join(' ');
+  const roots = input.roots.map((root) => `<${root}>`).join(' ');
+  const excluded = input.excludedPredicates.length > 0
+    ? `FILTER(?predicate NOT IN (${input.excludedPredicates.map((iri) => `<${iri}>`).join(', ')}))`
     : '';
-  return assertBoundedStructuredUpdate('copySubjectProjection', `INSERT { GRAPH <${normalized.targetGraphUri}> { ?subject ?predicate ?object } }
+  return assertBoundedStructuredUpdate('copySubjectProjection', `INSERT { GRAPH <${input.targetGraphUri}> { ?subject ?predicate ?object } }
 WHERE {
   VALUES ?sourceGraph { ${sources} }
   VALUES ?root { ${roots} }
   # sparql-scan-allow: R2 -- ?sourceGraph is VALUES-bound to at most 8 validated exact graph IRIs
   GRAPH ?sourceGraph { ?subject ?predicate ?object }
-  FILTER(?subject = ?root || STRSTARTS(STR(?subject), CONCAT(STR(?root), ${sparqlString(normalized.descendantSuffix)})))
+  FILTER(?subject = ?root || STRSTARTS(STR(?subject), CONCAT(STR(?root), ${sparqlString(input.descendantSuffix)})))
   ${excluded}
 }`);
 }

--- a/packages/storage/src/structured-mutation/copy-subject-projection.ts
+++ b/packages/storage/src/structured-mutation/copy-subject-projection.ts
@@ -1,6 +1,7 @@
 import { sparqlString } from '@origintrail-official/dkg-core';
 import type { CopySubjectProjectionInput } from '../triple-store.js';
 import {
+  BOUNDED_MUTATION_MAX_IRIS,
   BOUNDED_MUTATION_MAX_PREDICATES,
   BOUNDED_MUTATION_MAX_SOURCE_GRAPHS,
   BoundedMutationBudgetError,
@@ -8,50 +9,87 @@ import {
   assertBoundedStructuredUpdate,
   assertOperandBudget,
   boundedString,
-  uniqueIris,
 } from './primitives.js';
+import {
+  captureInputRecord,
+  captureUniqueIris,
+  type StructuredMutationSemantics,
+} from './capture-internal.js';
 
-export function normalizeCopySubjectProjectionInput(
-  input: CopySubjectProjectionInput,
-): CopySubjectProjectionInput {
-  const sourceGraphUris = uniqueIris(
-    input.sourceGraphUris,
+export function captureCopySubjectProjectionInput(input: unknown): CopySubjectProjectionInput {
+  const value = captureInputRecord(input, 'copySubjectProjection');
+  const sourceGraphUris = captureUniqueIris(
+    value.sourceGraphUris,
     'copySubjectProjection.sourceGraphUris',
     BOUNDED_MUTATION_MAX_SOURCE_GRAPHS,
+    false,
   );
-  const targetGraphUri = absoluteIri(input.targetGraphUri, 'copySubjectProjection.targetGraphUri');
+  const targetGraphUri = absoluteIri(
+    value.targetGraphUri as string,
+    'copySubjectProjection.targetGraphUri',
+  );
   if (sourceGraphUris.includes(targetGraphUri)) {
     throw new Error('copySubjectProjection target graph must not be a source graph');
   }
-  const roots = uniqueIris(input.roots, 'copySubjectProjection.roots');
+  const roots = captureUniqueIris(
+    value.roots,
+    'copySubjectProjection.roots',
+    BOUNDED_MUTATION_MAX_IRIS,
+    false,
+  );
   const descendantSuffix = boundedString(
-    input.descendantSuffix,
+    value.descendantSuffix as string,
     'copySubjectProjection.descendantSuffix',
     256,
   );
   if (!descendantSuffix.startsWith('/')) {
     throw new Error('copySubjectProjection.descendantSuffix must start with /');
   }
-  const excludedPredicates = uniqueIris(
-    input.excludedPredicates,
+  const excludedPredicates = captureUniqueIris(
+    value.excludedPredicates,
     'copySubjectProjection.excludedPredicates',
     BOUNDED_MUTATION_MAX_PREDICATES,
     true,
   );
-  assertOperandBudget('copySubjectProjection', [
-    ...sourceGraphUris,
-    targetGraphUri,
-    ...roots,
-    descendantSuffix,
-    ...excludedPredicates,
-  ]);
-  return {
+  return Object.freeze({
     sourceGraphUris,
     targetGraphUri,
     roots,
     descendantSuffix,
     excludedPredicates,
+  });
+}
+
+export function copySubjectProjectionSemantics(
+  input: CopySubjectProjectionInput,
+): StructuredMutationSemantics {
+  return {
+    guardedGraphs: [...input.sourceGraphUris, input.targetGraphUri],
+    touchedGraphs: [input.targetGraphUri],
+    mightMutate: true,
   };
+}
+
+export function materializeCopySubjectProjectionInput(
+  input: CopySubjectProjectionInput,
+  buildUpdate = true,
+): string | undefined {
+  assertOperandBudget('copySubjectProjection', [
+    ...input.sourceGraphUris,
+    input.targetGraphUri,
+    ...input.roots,
+    input.descendantSuffix,
+    ...input.excludedPredicates,
+  ]);
+  return buildUpdate ? buildCopySubjectProjectionUpdateFromNormalized(input) : undefined;
+}
+
+export function normalizeCopySubjectProjectionInput(
+  input: CopySubjectProjectionInput,
+): CopySubjectProjectionInput {
+  const captured = captureCopySubjectProjectionInput(input);
+  materializeCopySubjectProjectionInput(captured, false);
+  return captured;
 }
 
 export function buildCopySubjectProjectionUpdate(input: CopySubjectProjectionInput): string {
@@ -82,7 +120,12 @@ WHERE {
 export function chunkCopySubjectProjectionInput(
   input: CopySubjectProjectionInput,
 ): CopySubjectProjectionInput[] {
-  const roots = uniqueIris(input.roots, 'copySubjectProjection.roots');
+  const roots = captureUniqueIris(
+    input.roots,
+    'copySubjectProjection.roots',
+    BOUNDED_MUTATION_MAX_IRIS,
+    false,
+  );
   const normalized = normalizeCopySubjectProjectionInput({ ...input, roots: [roots[0]] });
   const chunks: CopySubjectProjectionInput[] = [];
 

--- a/packages/storage/src/structured-mutation/copy-subject-projection.ts
+++ b/packages/storage/src/structured-mutation/copy-subject-projection.ts
@@ -70,10 +70,9 @@ export function copySubjectProjectionSemantics(
   };
 }
 
-export function materializeCopySubjectProjectionInput(
+export function assertCopySubjectProjectionInputMaterializable(
   input: CopySubjectProjectionInput,
-  buildUpdate = true,
-): string | undefined {
+): void {
   assertOperandBudget('copySubjectProjection', [
     ...input.sourceGraphUris,
     input.targetGraphUri,
@@ -81,14 +80,13 @@ export function materializeCopySubjectProjectionInput(
     input.descendantSuffix,
     ...input.excludedPredicates,
   ]);
-  return buildUpdate ? buildCopySubjectProjectionUpdateFromNormalized(input) : undefined;
 }
 
 export function normalizeCopySubjectProjectionInput(
   input: CopySubjectProjectionInput,
 ): CopySubjectProjectionInput {
   const captured = captureCopySubjectProjectionInput(input);
-  materializeCopySubjectProjectionInput(captured, false);
+  assertCopySubjectProjectionInputMaterializable(captured);
   return captured;
 }
 

--- a/packages/storage/src/structured-mutation/delete-subjects.ts
+++ b/packages/storage/src/structured-mutation/delete-subjects.ts
@@ -1,16 +1,50 @@
 import type { DeleteSubjectsInput } from '../triple-store.js';
 import {
+  BOUNDED_MUTATION_MAX_IRIS,
   absoluteIri,
   assertBoundedStructuredUpdate,
   assertOperandBudget,
-  uniqueIris,
 } from './primitives.js';
+import {
+  captureInputRecord,
+  captureUniqueIris,
+  type StructuredMutationSemantics,
+} from './capture-internal.js';
+
+export function captureDeleteSubjectsInput(input: unknown): DeleteSubjectsInput {
+  const value = captureInputRecord(input, 'deleteSubjects');
+  const graphUri = absoluteIri(value.graphUri as string, 'deleteSubjects.graphUri');
+  const subjects = captureUniqueIris(
+    value.subjects,
+    'deleteSubjects.subjects',
+    BOUNDED_MUTATION_MAX_IRIS,
+    true,
+  );
+  return Object.freeze({ graphUri, subjects });
+}
+
+export function deleteSubjectsSemantics(
+  input: DeleteSubjectsInput,
+): StructuredMutationSemantics {
+  return {
+    guardedGraphs: [input.graphUri],
+    touchedGraphs: [input.graphUri],
+    mightMutate: input.subjects.length > 0,
+  };
+}
+
+export function materializeDeleteSubjectsInput(
+  input: DeleteSubjectsInput,
+  buildUpdate = true,
+): string | undefined {
+  assertOperandBudget('deleteSubjects', [input.graphUri, ...input.subjects]);
+  return buildUpdate ? buildDeleteSubjectsUpdateFromNormalized(input) : undefined;
+}
 
 export function normalizeDeleteSubjectsInput(input: DeleteSubjectsInput): DeleteSubjectsInput {
-  const graphUri = absoluteIri(input.graphUri, 'deleteSubjects.graphUri');
-  const subjects = uniqueIris(input.subjects, 'deleteSubjects.subjects', undefined, true);
-  assertOperandBudget('deleteSubjects', [graphUri, ...subjects]);
-  return { graphUri, subjects };
+  const captured = captureDeleteSubjectsInput(input);
+  materializeDeleteSubjectsInput(captured, false);
+  return captured;
 }
 
 export function buildDeleteSubjectsUpdate(input: DeleteSubjectsInput): string | undefined {

--- a/packages/storage/src/structured-mutation/delete-subjects.ts
+++ b/packages/storage/src/structured-mutation/delete-subjects.ts
@@ -15,10 +15,16 @@ export function normalizeDeleteSubjectsInput(input: DeleteSubjectsInput): Delete
 
 export function buildDeleteSubjectsUpdate(input: DeleteSubjectsInput): string | undefined {
   const normalized = normalizeDeleteSubjectsInput(input);
-  if (normalized.subjects.length === 0) return undefined;
-  const values = normalized.subjects.map((subject) => `<${subject}>`).join(' ');
-  return assertBoundedStructuredUpdate('deleteSubjects', `DELETE { GRAPH <${normalized.graphUri}> { ?subject ?predicate ?object } }
-WHERE { GRAPH <${normalized.graphUri}> {
+  return buildDeleteSubjectsUpdateFromNormalized(normalized);
+}
+
+export function buildDeleteSubjectsUpdateFromNormalized(
+  input: DeleteSubjectsInput,
+): string | undefined {
+  if (input.subjects.length === 0) return undefined;
+  const values = input.subjects.map((subject) => `<${subject}>`).join(' ');
+  return assertBoundedStructuredUpdate('deleteSubjects', `DELETE { GRAPH <${input.graphUri}> { ?subject ?predicate ?object } }
+WHERE { GRAPH <${input.graphUri}> {
   VALUES ?subject { ${values} }
   ?subject ?predicate ?object
 } }`);

--- a/packages/storage/src/structured-mutation/delete-subjects.ts
+++ b/packages/storage/src/structured-mutation/delete-subjects.ts
@@ -33,17 +33,13 @@ export function deleteSubjectsSemantics(
   };
 }
 
-export function materializeDeleteSubjectsInput(
-  input: DeleteSubjectsInput,
-  buildUpdate = true,
-): string | undefined {
+export function assertDeleteSubjectsInputMaterializable(input: DeleteSubjectsInput): void {
   assertOperandBudget('deleteSubjects', [input.graphUri, ...input.subjects]);
-  return buildUpdate ? buildDeleteSubjectsUpdateFromNormalized(input) : undefined;
 }
 
 export function normalizeDeleteSubjectsInput(input: DeleteSubjectsInput): DeleteSubjectsInput {
   const captured = captureDeleteSubjectsInput(input);
-  materializeDeleteSubjectsInput(captured, false);
+  assertDeleteSubjectsInputMaterializable(captured);
   return captured;
 }
 

--- a/packages/storage/src/structured-mutation/primitives.ts
+++ b/packages/storage/src/structured-mutation/primitives.ts
@@ -13,6 +13,12 @@ const UTF8 = new TextEncoder();
 
 export class BoundedMutationBudgetError extends Error {}
 
+export function isBoundedMutationBudgetError(
+  error: unknown,
+): error is BoundedMutationBudgetError {
+  return error instanceof BoundedMutationBudgetError;
+}
+
 export function boundedInteger(value: number, label: string, max: number): number {
   if (!Number.isSafeInteger(value) || value < 0 || value > max) {
     throw new Error(`${label} must be an integer in 0..${max}`);

--- a/packages/storage/src/structured-mutation/primitives.ts
+++ b/packages/storage/src/structured-mutation/primitives.ts
@@ -86,7 +86,7 @@ export function boundedUniqueStrings(
   return result;
 }
 
-export function assertOperandBudget(label: string, values: readonly string[]): void {
+export function assertOperandBudget(label: string, values: Iterable<string>): void {
   let bytes = 0;
   for (const value of values) {
     bytes += UTF8.encode(value).byteLength;

--- a/packages/storage/src/structured-mutation/refusal-internal.ts
+++ b/packages/storage/src/structured-mutation/refusal-internal.ts
@@ -3,13 +3,26 @@ import { isBoundedMutationBudgetError } from './primitives.js';
 export const STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE =
   'STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL';
 
+const TRUSTED_STRUCTURED_MUTATION_REFUSALS = new WeakSet<object>();
+
 export function isStructuredMutationPreDispatchRefusal(
   error: unknown,
 ): boolean {
   return isBoundedMutationBudgetError(error)
     || (typeof error === 'object'
       && error !== null
-      && (error as { code?: unknown }).code === STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE);
+      && TRUSTED_STRUCTURED_MUTATION_REFUSALS.has(error));
+}
+
+/** Reconstruct the private refusal identity after a trusted worker reports it. */
+export function reconstructStructuredMutationPreDispatchRefusal(message: string): Error {
+  const error = new Error(message);
+  Object.defineProperty(error, 'code', {
+    value: STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE,
+    enumerable: true,
+  });
+  TRUSTED_STRUCTURED_MUTATION_REFUSALS.add(error);
+  return error;
 }
 
 export function structuredMutationPreDispatchRefusalCode(

--- a/packages/storage/src/structured-mutation/refusal-internal.ts
+++ b/packages/storage/src/structured-mutation/refusal-internal.ts
@@ -8,10 +8,16 @@ const TRUSTED_STRUCTURED_MUTATION_REFUSALS = new WeakSet<object>();
 export function isStructuredMutationPreDispatchRefusal(
   error: unknown,
 ): boolean {
-  return isBoundedMutationBudgetError(error)
-    || (typeof error === 'object'
-      && error !== null
-      && TRUSTED_STRUCTURED_MUTATION_REFUSALS.has(error));
+  return typeof error === 'object'
+    && error !== null
+    && TRUSTED_STRUCTURED_MUTATION_REFUSALS.has(error);
+}
+
+/** Mark a budget error only while still inside the explicit pre-dispatch boundary. */
+export function markStructuredMutationPreDispatchRefusal(error: unknown): void {
+  if (isBoundedMutationBudgetError(error)) {
+    TRUSTED_STRUCTURED_MUTATION_REFUSALS.add(error);
+  }
 }
 
 /** Reconstruct the private refusal identity after a trusted worker reports it. */

--- a/packages/storage/src/structured-mutation/refusal-internal.ts
+++ b/packages/storage/src/structured-mutation/refusal-internal.ts
@@ -1,0 +1,21 @@
+import { isBoundedMutationBudgetError } from './primitives.js';
+
+export const STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE =
+  'STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL';
+
+export function isStructuredMutationPreDispatchRefusal(
+  error: unknown,
+): boolean {
+  return isBoundedMutationBudgetError(error)
+    || (typeof error === 'object'
+      && error !== null
+      && (error as { code?: unknown }).code === STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE);
+}
+
+export function structuredMutationPreDispatchRefusalCode(
+  error: unknown,
+): typeof STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE | undefined {
+  return isStructuredMutationPreDispatchRefusal(error)
+    ? STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL_CODE
+    : undefined;
+}

--- a/packages/storage/src/structured-mutation/replace-projection-from-graph.ts
+++ b/packages/storage/src/structured-mutation/replace-projection-from-graph.ts
@@ -63,10 +63,9 @@ export function replaceProjectionFromGraphSemantics(
   };
 }
 
-export function materializeReplaceProjectionFromGraphInput(
+export function assertReplaceProjectionFromGraphInputMaterializable(
   input: ReplaceProjectionFromGraphInput,
-  buildUpdate = true,
-): string | undefined {
+): void {
   assertOperandBudget('replaceProjectionFromGraph', [
     input.targetGraphUri,
     input.stagingGraphUri,
@@ -74,14 +73,13 @@ export function materializeReplaceProjectionFromGraphInput(
     ...input.preservedTargetPredicates,
     ...input.targetSubjectPrefixes,
   ]);
-  return buildUpdate ? buildReplaceProjectionFromGraphUpdateFromNormalized(input) : undefined;
 }
 
 export function normalizeReplaceProjectionFromGraphInput(
   input: ReplaceProjectionFromGraphInput,
 ): ReplaceProjectionFromGraphInput {
   const captured = captureReplaceProjectionFromGraphInput(input);
-  materializeReplaceProjectionFromGraphInput(captured, false);
+  assertReplaceProjectionFromGraphInputMaterializable(captured);
   return captured;
 }
 

--- a/packages/storage/src/structured-mutation/replace-projection-from-graph.ts
+++ b/packages/storage/src/structured-mutation/replace-projection-from-graph.ts
@@ -6,53 +6,83 @@ import {
   absoluteIri,
   assertBoundedStructuredUpdate,
   assertOperandBudget,
-  uniqueIris,
 } from './primitives.js';
+import {
+  captureInputRecord,
+  captureUniqueIris,
+  type StructuredMutationSemantics,
+} from './capture-internal.js';
 
-export function normalizeReplaceProjectionFromGraphInput(
-  input: ReplaceProjectionFromGraphInput,
+export function captureReplaceProjectionFromGraphInput(
+  input: unknown,
 ): ReplaceProjectionFromGraphInput {
+  const value = captureInputRecord(input, 'replaceProjectionFromGraph');
   const targetGraphUri = absoluteIri(
-    input.targetGraphUri,
+    value.targetGraphUri as string,
     'replaceProjectionFromGraph.targetGraphUri',
   );
   const stagingGraphUri = absoluteIri(
-    input.stagingGraphUri,
+    value.stagingGraphUri as string,
     'replaceProjectionFromGraph.stagingGraphUri',
   );
   if (targetGraphUri === stagingGraphUri) {
     throw new Error('replaceProjectionFromGraph requires distinct target and staging graphs');
   }
   const targetSubject = absoluteIri(
-    input.targetSubject,
+    value.targetSubject as string,
     'replaceProjectionFromGraph.targetSubject',
   );
-  const preservedTargetPredicates = uniqueIris(
-    input.preservedTargetPredicates,
+  const preservedTargetPredicates = captureUniqueIris(
+    value.preservedTargetPredicates,
     'replaceProjectionFromGraph.preservedTargetPredicates',
     BOUNDED_MUTATION_MAX_PREDICATES,
     true,
   );
-  const targetSubjectPrefixes = uniqueIris(
-    input.targetSubjectPrefixes,
+  const targetSubjectPrefixes = captureUniqueIris(
+    value.targetSubjectPrefixes,
     'replaceProjectionFromGraph.targetSubjectPrefixes',
     BOUNDED_MUTATION_MAX_PREFIXES,
     true,
   );
-  assertOperandBudget('replaceProjectionFromGraph', [
-    targetGraphUri,
-    stagingGraphUri,
-    targetSubject,
-    ...preservedTargetPredicates,
-    ...targetSubjectPrefixes,
-  ]);
-  return {
+  return Object.freeze({
     targetGraphUri,
     stagingGraphUri,
     targetSubject,
     preservedTargetPredicates,
     targetSubjectPrefixes,
+  });
+}
+
+export function replaceProjectionFromGraphSemantics(
+  input: ReplaceProjectionFromGraphInput,
+): StructuredMutationSemantics {
+  return {
+    guardedGraphs: [input.targetGraphUri, input.stagingGraphUri],
+    touchedGraphs: [input.targetGraphUri],
+    mightMutate: true,
   };
+}
+
+export function materializeReplaceProjectionFromGraphInput(
+  input: ReplaceProjectionFromGraphInput,
+  buildUpdate = true,
+): string | undefined {
+  assertOperandBudget('replaceProjectionFromGraph', [
+    input.targetGraphUri,
+    input.stagingGraphUri,
+    input.targetSubject,
+    ...input.preservedTargetPredicates,
+    ...input.targetSubjectPrefixes,
+  ]);
+  return buildUpdate ? buildReplaceProjectionFromGraphUpdateFromNormalized(input) : undefined;
+}
+
+export function normalizeReplaceProjectionFromGraphInput(
+  input: ReplaceProjectionFromGraphInput,
+): ReplaceProjectionFromGraphInput {
+  const captured = captureReplaceProjectionFromGraphInput(input);
+  materializeReplaceProjectionFromGraphInput(captured, false);
+  return captured;
 }
 
 export function buildReplaceProjectionFromGraphUpdate(

--- a/packages/storage/src/structured-mutation/replace-projection-from-graph.ts
+++ b/packages/storage/src/structured-mutation/replace-projection-from-graph.ts
@@ -59,37 +59,43 @@ export function buildReplaceProjectionFromGraphUpdate(
   input: ReplaceProjectionFromGraphInput,
 ): string {
   const normalized = normalizeReplaceProjectionFromGraphInput(input);
-  const preserved = normalized.preservedTargetPredicates.length > 0
-    ? ` && ?stalePredicate NOT IN (${normalized.preservedTargetPredicates.map((iri) => `<${iri}>`).join(', ')})`
+  return buildReplaceProjectionFromGraphUpdateFromNormalized(normalized);
+}
+
+export function buildReplaceProjectionFromGraphUpdateFromNormalized(
+  input: ReplaceProjectionFromGraphInput,
+): string {
+  const preserved = input.preservedTargetPredicates.length > 0
+    ? ` && ?stalePredicate NOT IN (${input.preservedTargetPredicates.map((iri) => `<${iri}>`).join(', ')})`
     : '';
-  const prefixes = normalized.targetSubjectPrefixes
+  const prefixes = input.targetSubjectPrefixes
     .map((prefix) => `STRSTARTS(STR(?staleSubject), ${sparqlString(prefix)})`);
   const staleScopes = [
-    `(?staleSubject = <${normalized.targetSubject}>${preserved})`,
+    `(?staleSubject = <${input.targetSubject}>${preserved})`,
     ...prefixes,
   ].join(' || ');
   const freshScopes = [
-    `?freshSubject = <${normalized.targetSubject}>`,
-    ...normalized.targetSubjectPrefixes.map(
+    `?freshSubject = <${input.targetSubject}>`,
+    ...input.targetSubjectPrefixes.map(
       (prefix) => `STRSTARTS(STR(?freshSubject), ${sparqlString(prefix)})`,
     ),
   ].join(' || ');
   return assertBoundedStructuredUpdate('replaceProjectionFromGraph', `DELETE {
-  GRAPH <${normalized.targetGraphUri}> { ?staleSubject ?stalePredicate ?staleObject }
+  GRAPH <${input.targetGraphUri}> { ?staleSubject ?stalePredicate ?staleObject }
 }
 INSERT {
-  GRAPH <${normalized.targetGraphUri}> { ?freshSubject ?freshPredicate ?freshObject }
+  GRAPH <${input.targetGraphUri}> { ?freshSubject ?freshPredicate ?freshObject }
 }
 WHERE {
   {
-    GRAPH <${normalized.targetGraphUri}> {
+    GRAPH <${input.targetGraphUri}> {
       ?staleSubject ?stalePredicate ?staleObject .
       FILTER(${staleScopes})
     }
   }
   UNION
   {
-    GRAPH <${normalized.stagingGraphUri}> {
+    GRAPH <${input.stagingGraphUri}> {
       ?freshSubject ?freshPredicate ?freshObject .
       FILTER(${freshScopes})
     }

--- a/packages/storage/src/structured-mutation/replace-subject-predicates.ts
+++ b/packages/storage/src/structured-mutation/replace-subject-predicates.ts
@@ -71,12 +71,10 @@ export function replaceSubjectPredicatesSemantics(
   return { guardedGraphs: [input.graphUri], touchedGraphs: [input.graphUri], mightMutate: true };
 }
 
-export function materializeReplaceSubjectPredicatesInput(
+export function assertReplaceSubjectPredicatesInputMaterializable(
   input: ReplaceSubjectPredicatesInput,
-  buildUpdate = true,
-): string | undefined {
+): void {
   assertOperandBudget('replaceSubjectPredicates', replaceSubjectPredicatesOperands(input));
-  return buildUpdate ? buildReplaceSubjectPredicatesUpdateFromNormalized(input) : undefined;
 }
 
 function* replaceSubjectPredicatesOperands(
@@ -97,7 +95,7 @@ export function normalizeReplaceSubjectPredicatesInput(
   input: ReplaceSubjectPredicatesInput,
 ): ReplaceSubjectPredicatesInput {
   const captured = captureReplaceSubjectPredicatesInput(input);
-  materializeReplaceSubjectPredicatesInput(captured, false);
+  assertReplaceSubjectPredicatesInputMaterializable(captured);
   return captured;
 }
 

--- a/packages/storage/src/structured-mutation/replace-subject-predicates.ts
+++ b/packages/storage/src/structured-mutation/replace-subject-predicates.ts
@@ -6,78 +6,106 @@ import {
   assertBoundedStructuredUpdate,
   assertOperandBudget,
   normalizeStructuredRdfObject,
-  uniqueIris,
 } from './primitives.js';
+import {
+  captureArray,
+  captureInputRecord,
+  captureUniqueIris,
+  type StructuredMutationSemantics,
+} from './capture-internal.js';
 
-function normalizeReplaceSubjectPredicatesInputInternal(
-  input: ReplaceSubjectPredicatesInput,
-  enforceOperandBudget: boolean,
+export function captureReplaceSubjectPredicatesInput(
+  input: unknown,
 ): ReplaceSubjectPredicatesInput {
-  const graphUri = absoluteIri(input.graphUri, 'replaceSubjectPredicates.graphUri');
-  const subject = absoluteIri(input.subject, 'replaceSubjectPredicates.subject');
-  const predicates = uniqueIris(
-    input.predicates,
+  const value = captureInputRecord(input, 'replaceSubjectPredicates');
+  const graphUri = absoluteIri(value.graphUri as string, 'replaceSubjectPredicates.graphUri');
+  const subject = absoluteIri(value.subject as string, 'replaceSubjectPredicates.subject');
+  const predicates = captureUniqueIris(
+    value.predicates,
     'replaceSubjectPredicates.predicates',
     BOUNDED_MUTATION_MAX_PREDICATES,
+    false,
   );
-  if (!Array.isArray(input.replacementQuads)
-    || input.replacementQuads.length > BOUNDED_MUTATION_MAX_IRIS) {
-    throw new Error(
-      `replaceSubjectPredicates.replacementQuads must contain 0..${BOUNDED_MUTATION_MAX_IRIS} quads`,
-    );
-  }
-  for (let index = 0; index < input.replacementQuads.length; index++) {
-    if (!(index in input.replacementQuads)) {
-      throw new Error('replaceSubjectPredicates.replacementQuads must be a dense array');
-    }
-  }
   const allowedPredicates = new Set(predicates);
-  const replacementQuads = input.replacementQuads.map((quad, index) => {
-    if (quad.graph !== graphUri || quad.subject !== subject) {
-      throw new Error(
-        `replaceSubjectPredicates quad ${index} must target subject ${subject} in graph ${graphUri}`,
+  const replacementQuads = captureArray(
+    value.replacementQuads,
+    'replaceSubjectPredicates.replacementQuads',
+    0,
+    BOUNDED_MUTATION_MAX_IRIS,
+    (candidate, index) => {
+      const quad = captureInputRecord(
+        candidate,
+        `replaceSubjectPredicates.replacementQuads[${index}]`,
       );
-    }
-    const predicate = absoluteIri(
-      quad.predicate,
-      `replaceSubjectPredicates.replacementQuads[${index}].predicate`,
-    );
-    if (!allowedPredicates.has(predicate)) {
-      throw new Error(`replaceSubjectPredicates quad ${index} targets undeclared predicate ${predicate}`);
-    }
-    const object = normalizeStructuredRdfObject(
-      quad.object,
-      `replaceSubjectPredicates.replacementQuads[${index}].object`,
-    );
-    return { ...quad, predicate, object };
-  });
-  if (enforceOperandBudget) {
-    assertOperandBudget('replaceSubjectPredicates', [
-      graphUri,
-      subject,
-      ...predicates,
-      ...replacementQuads.flatMap((quad) => [
-        quad.subject,
-        quad.predicate,
-        quad.object,
-        quad.graph,
-      ]),
-    ]);
+      const quadSubject = quad.subject;
+      const quadPredicate = quad.predicate;
+      const quadObject = quad.object;
+      const quadGraph = quad.graph;
+      if (quadGraph !== graphUri || quadSubject !== subject) {
+        throw new Error(
+          `replaceSubjectPredicates quad ${index} must target subject ${subject} in graph ${graphUri}`,
+        );
+      }
+      const predicate = absoluteIri(
+        quadPredicate as string,
+        `replaceSubjectPredicates.replacementQuads[${index}].predicate`,
+      );
+      if (!allowedPredicates.has(predicate)) {
+        throw new Error(
+          `replaceSubjectPredicates quad ${index} targets undeclared predicate ${predicate}`,
+        );
+      }
+      const object = normalizeStructuredRdfObject(
+        quadObject as string,
+        `replaceSubjectPredicates.replacementQuads[${index}].object`,
+      );
+      return Object.freeze({ subject, predicate, object, graph: graphUri });
+    },
+  );
+  return Object.freeze({ graphUri, subject, predicates, replacementQuads });
+}
+
+export function replaceSubjectPredicatesSemantics(
+  input: ReplaceSubjectPredicatesInput,
+): StructuredMutationSemantics {
+  return { guardedGraphs: [input.graphUri], touchedGraphs: [input.graphUri], mightMutate: true };
+}
+
+export function materializeReplaceSubjectPredicatesInput(
+  input: ReplaceSubjectPredicatesInput,
+  buildUpdate = true,
+): string | undefined {
+  assertOperandBudget('replaceSubjectPredicates', replaceSubjectPredicatesOperands(input));
+  return buildUpdate ? buildReplaceSubjectPredicatesUpdateFromNormalized(input) : undefined;
+}
+
+function* replaceSubjectPredicatesOperands(
+  input: ReplaceSubjectPredicatesInput,
+): Iterable<string> {
+  yield input.graphUri;
+  yield input.subject;
+  yield* input.predicates;
+  for (const quad of input.replacementQuads) {
+    yield quad.subject;
+    yield quad.predicate;
+    yield quad.object;
+    yield quad.graph;
   }
-  return { graphUri, subject, predicates, replacementQuads };
 }
 
 export function normalizeReplaceSubjectPredicatesInput(
   input: ReplaceSubjectPredicatesInput,
 ): ReplaceSubjectPredicatesInput {
-  return normalizeReplaceSubjectPredicatesInputInternal(input, true);
+  const captured = captureReplaceSubjectPredicatesInput(input);
+  materializeReplaceSubjectPredicatesInput(captured, false);
+  return captured;
 }
 
 /** Validate before a storage decorator rewrites RDF objects. */
 export function normalizeReplaceSubjectPredicatesInputForObjectRewrite(
   input: ReplaceSubjectPredicatesInput,
 ): ReplaceSubjectPredicatesInput {
-  return normalizeReplaceSubjectPredicatesInputInternal(input, false);
+  return captureReplaceSubjectPredicatesInput(input);
 }
 
 export function buildReplaceSubjectPredicatesUpdate(

--- a/packages/storage/src/structured-mutation/replace-subject-predicates.ts
+++ b/packages/storage/src/structured-mutation/replace-subject-predicates.ts
@@ -84,22 +84,28 @@ export function buildReplaceSubjectPredicatesUpdate(
   input: ReplaceSubjectPredicatesInput,
 ): string {
   const normalized = normalizeReplaceSubjectPredicatesInput(input);
-  const predicateValues = normalized.predicates.map((predicate) => `<${predicate}>`).join(', ');
-  const insertion = normalized.replacementQuads.length > 0
+  return buildReplaceSubjectPredicatesUpdateFromNormalized(normalized);
+}
+
+export function buildReplaceSubjectPredicatesUpdateFromNormalized(
+  input: ReplaceSubjectPredicatesInput,
+): string {
+  const predicateValues = input.predicates.map((predicate) => `<${predicate}>`).join(', ');
+  const insertion = input.replacementQuads.length > 0
     ? `INSERT {
-  GRAPH <${normalized.graphUri}> {
-${normalized.replacementQuads.map((quad) => `    <${quad.subject}> <${quad.predicate}> ${quad.object} .`).join('\n')}
+  GRAPH <${input.graphUri}> {
+${input.replacementQuads.map((quad) => `    <${quad.subject}> <${quad.predicate}> ${quad.object} .`).join('\n')}
   }
 }
 `
     : '';
   return assertBoundedStructuredUpdate('replaceSubjectPredicates', `DELETE {
-  GRAPH <${normalized.graphUri}> { <${normalized.subject}> ?predicate ?oldObject }
+  GRAPH <${input.graphUri}> { <${input.subject}> ?predicate ?oldObject }
 }
 ${insertion}WHERE {
   OPTIONAL {
-    GRAPH <${normalized.graphUri}> {
-      <${normalized.subject}> ?predicate ?oldObject .
+    GRAPH <${input.graphUri}> {
+      <${input.subject}> ?predicate ?oldObject .
       FILTER(?predicate IN (${predicateValues}))
     }
   }

--- a/packages/storage/src/structured-mutation/retention.ts
+++ b/packages/storage/src/structured-mutation/retention.ts
@@ -71,26 +71,32 @@ export function normalizePruneRankedSubjectsInput(
 
 export function buildPruneRankedSubjectsUpdate(input: PruneRankedSubjectsInput): string {
   const normalized = normalizePruneRankedSubjectsInput(input);
-  const eligibleObjects = normalized.eligibleObjects.map(sparqlString).join(' ');
+  return buildPruneRankedSubjectsUpdateFromNormalized(normalized);
+}
+
+export function buildPruneRankedSubjectsUpdateFromNormalized(
+  input: PruneRankedSubjectsInput,
+): string {
+  const eligibleObjects = input.eligibleObjects.map(sparqlString).join(' ');
   const eligibilityFilter = `VALUES ?eligibleObject { ${eligibleObjects} }
       FILTER NOT EXISTS {
-        ?subject <${normalized.eligibilityPredicate}> ?ineligibleObject .
-        FILTER(?ineligibleObject NOT IN (${normalized.eligibleObjects.map(sparqlString).join(', ')}))
+        ?subject <${input.eligibilityPredicate}> ?ineligibleObject .
+        FILTER(?ineligibleObject NOT IN (${input.eligibleObjects.map(sparqlString).join(', ')}))
       }`;
   return assertBoundedStructuredUpdate('pruneRankedSubjects', `PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-DELETE { GRAPH <${normalized.graphUri}> { ?subject ?predicate ?object } }
+DELETE { GRAPH <${input.graphUri}> { ?subject ?predicate ?object } }
 WHERE {
   {
     SELECT ?subject
            (MAX(?primaryRank) AS ?latestPrimaryRank)
            (MAX(?secondaryRank) AS ?latestSecondaryRank)
     WHERE {
-      GRAPH <${normalized.graphUri}> {
-        ?subject <${normalized.eligibilityPredicate}> ?eligibleObject .
-        OPTIONAL { ?subject <${normalized.primaryRankPredicate}> ?primaryRank }
-        OPTIONAL { ?subject <${normalized.secondaryRankPredicate}> ?secondaryRank }
+      GRAPH <${input.graphUri}> {
+        ?subject <${input.eligibilityPredicate}> ?eligibleObject .
+        OPTIONAL { ?subject <${input.primaryRankPredicate}> ?primaryRank }
+        OPTIONAL { ?subject <${input.secondaryRankPredicate}> ?secondaryRank }
         ${eligibilityFilter}
-        FILTER(STRSTARTS(STR(?subject), ${sparqlString(normalized.subjectPrefix)}))
+        FILTER(STRSTARTS(STR(?subject), ${sparqlString(input.subjectPrefix)}))
       }
     }
     # sparql-scan-allow: R3 -- one bounded retention prune; OFFSET <= 100000 and LIMIT <= 10000; never page-walked
@@ -100,13 +106,13 @@ WHERE {
       xsd:integer(STR(?latestSecondaryRank)),
       0
     )) DESC(STR(?subject))
-    OFFSET ${sparqlInt(normalized.retainNewest, { min: 0 })}
-    LIMIT ${sparqlInt(normalized.maxDelete, { min: 1 })}
+    OFFSET ${sparqlInt(input.retainNewest, { min: 0 })}
+    LIMIT ${sparqlInt(input.maxDelete, { min: 1 })}
   }
-  GRAPH <${normalized.graphUri}> {
-    ?subject <${normalized.eligibilityPredicate}> ?eligibleObject ; ?predicate ?object .
+  GRAPH <${input.graphUri}> {
+    ?subject <${input.eligibilityPredicate}> ?eligibleObject ; ?predicate ?object .
     ${eligibilityFilter}
-    FILTER(STRSTARTS(STR(?subject), ${sparqlString(normalized.subjectPrefix)}))
+    FILTER(STRSTARTS(STR(?subject), ${sparqlString(input.subjectPrefix)}))
   }
 }`);
 }
@@ -156,22 +162,28 @@ export function normalizePruneLinkedRecordClosuresInput(
 
 export function buildPruneLinkedRecordClosuresUpdate(input: PruneLinkedRecordClosuresInput): string {
   const normalized = normalizePruneLinkedRecordClosuresInput(input);
-  const matchObjects = normalized.matchObjectIris.map((root) => `<${root}>`).join(' ');
-  const linkPredicates = normalized.linkPredicates
+  return buildPruneLinkedRecordClosuresUpdateFromNormalized(normalized);
+}
+
+export function buildPruneLinkedRecordClosuresUpdateFromNormalized(
+  input: PruneLinkedRecordClosuresInput,
+): string {
+  const matchObjects = input.matchObjectIris.map((root) => `<${root}>`).join(' ');
+  const linkPredicates = input.linkPredicates
     .map((predicate) => `<${predicate}>`)
     .join(' ');
-  const keepFilter = normalized.protectedRecordIri
-    ? `FILTER(?record != <${normalized.protectedRecordIri}>)`
+  const keepFilter = input.protectedRecordIri
+    ? `FILTER(?record != <${input.protectedRecordIri}>)`
     : '';
-  return assertBoundedStructuredUpdate('pruneLinkedRecordClosures', `DELETE { GRAPH <${normalized.graphUri}> { ?subject ?predicate ?object } }
-WHERE { GRAPH <${normalized.graphUri}> {
+  return assertBoundedStructuredUpdate('pruneLinkedRecordClosures', `DELETE { GRAPH <${input.graphUri}> { ?subject ?predicate ?object } }
+WHERE { GRAPH <${input.graphUri}> {
   VALUES ?matchObject { ${matchObjects} }
   VALUES ?linkPredicate { ${linkPredicates} }
   ?member ?linkPredicate ?matchObject .
-  OPTIONAL { ?member <${normalized.recordParentPredicate}> ?parent }
+  OPTIONAL { ?member <${input.recordParentPredicate}> ?parent }
   BIND(COALESCE(?parent, ?member) AS ?record)
   ${keepFilter}
   ?subject ?predicate ?object .
-  FILTER(?subject = ?record || STRSTARTS(STR(?subject), CONCAT(STR(?record), ${sparqlString(normalized.descendantSeparator)})))
+  FILTER(?subject = ?record || STRSTARTS(STR(?subject), CONCAT(STR(?record), ${sparqlString(input.descendantSeparator)})))
 } }`);
 }

--- a/packages/storage/src/structured-mutation/retention.ts
+++ b/packages/storage/src/structured-mutation/retention.ts
@@ -73,10 +73,9 @@ export function pruneRankedSubjectsSemantics(
   return { guardedGraphs: [input.graphUri], touchedGraphs: [input.graphUri], mightMutate: true };
 }
 
-export function materializePruneRankedSubjectsInput(
+export function assertPruneRankedSubjectsInputMaterializable(
   input: PruneRankedSubjectsInput,
-  buildUpdate = true,
-): string | undefined {
+): void {
   assertOperandBudget('pruneRankedSubjects', [
     input.graphUri,
     input.subjectPrefix,
@@ -85,7 +84,6 @@ export function materializePruneRankedSubjectsInput(
     input.secondaryRankPredicate,
     ...input.eligibleObjects,
   ]);
-  return buildUpdate ? buildPruneRankedSubjectsUpdateFromNormalized(input) : undefined;
 }
 
 export function capturePruneLinkedRecordClosuresInput(
@@ -137,10 +135,9 @@ export function pruneLinkedRecordClosuresSemantics(
   return { guardedGraphs: [input.graphUri], touchedGraphs: [input.graphUri], mightMutate: true };
 }
 
-export function materializePruneLinkedRecordClosuresInput(
+export function assertPruneLinkedRecordClosuresInputMaterializable(
   input: PruneLinkedRecordClosuresInput,
-  buildUpdate = true,
-): string | undefined {
+): void {
   assertOperandBudget('pruneLinkedRecordClosures', [
     input.graphUri,
     ...input.matchObjectIris,
@@ -149,14 +146,13 @@ export function materializePruneLinkedRecordClosuresInput(
     input.descendantSeparator,
     ...(input.protectedRecordIri ? [input.protectedRecordIri] : []),
   ]);
-  return buildUpdate ? buildPruneLinkedRecordClosuresUpdateFromNormalized(input) : undefined;
 }
 
 export function normalizePruneRankedSubjectsInput(
   input: PruneRankedSubjectsInput,
 ): PruneRankedSubjectsInput {
   const captured = capturePruneRankedSubjectsInput(input);
-  materializePruneRankedSubjectsInput(captured, false);
+  assertPruneRankedSubjectsInputMaterializable(captured);
   return captured;
 }
 
@@ -212,7 +208,7 @@ export function normalizePruneLinkedRecordClosuresInput(
   input: PruneLinkedRecordClosuresInput,
 ): PruneLinkedRecordClosuresInput {
   const captured = capturePruneLinkedRecordClosuresInput(input);
-  materializePruneLinkedRecordClosuresInput(captured, false);
+  assertPruneLinkedRecordClosuresInputMaterializable(captured);
   return captured;
 }
 

--- a/packages/storage/src/structured-mutation/retention.ts
+++ b/packages/storage/src/structured-mutation/retention.ts
@@ -12,52 +12,50 @@ import {
   assertOperandBudget,
   boundedInteger,
   boundedString,
-  boundedUniqueStrings,
-  uniqueIris,
 } from './primitives.js';
+import {
+  captureInputRecord,
+  captureUniqueIris,
+  captureUniqueStrings,
+  type StructuredMutationSemantics,
+} from './capture-internal.js';
 
-export function normalizePruneRankedSubjectsInput(
-  input: PruneRankedSubjectsInput,
-): PruneRankedSubjectsInput {
-  const graphUri = absoluteIri(input.graphUri, 'pruneRankedSubjects.graphUri');
-  const subjectPrefix = absoluteIri(input.subjectPrefix, 'pruneRankedSubjects.subjectPrefix');
+export function capturePruneRankedSubjectsInput(input: unknown): PruneRankedSubjectsInput {
+  const value = captureInputRecord(input, 'pruneRankedSubjects');
+  const graphUri = absoluteIri(value.graphUri as string, 'pruneRankedSubjects.graphUri');
+  const subjectPrefix = absoluteIri(
+    value.subjectPrefix as string,
+    'pruneRankedSubjects.subjectPrefix',
+  );
   const eligibilityPredicate = absoluteIri(
-    input.eligibilityPredicate,
+    value.eligibilityPredicate as string,
     'pruneRankedSubjects.eligibilityPredicate',
   );
-  const primaryRankPredicate = absoluteIri(
-    input.primaryRankPredicate,
-    'pruneRankedSubjects.primaryRankPredicate',
-  );
-  const secondaryRankPredicate = absoluteIri(
-    input.secondaryRankPredicate,
-    'pruneRankedSubjects.secondaryRankPredicate',
-  );
-  const eligibleObjects = boundedUniqueStrings(
-    input.eligibleObjects,
+  const eligibleObjects = captureUniqueStrings(
+    value.eligibleObjects,
     'pruneRankedSubjects.eligibleObjects',
     16,
   );
+  const primaryRankPredicate = absoluteIri(
+    value.primaryRankPredicate as string,
+    'pruneRankedSubjects.primaryRankPredicate',
+  );
+  const secondaryRankPredicate = absoluteIri(
+    value.secondaryRankPredicate as string,
+    'pruneRankedSubjects.secondaryRankPredicate',
+  );
   const retainNewest = boundedInteger(
-    input.retainNewest,
+    value.retainNewest as number,
     'pruneRankedSubjects.retainNewest',
     BOUNDED_MUTATION_MAX_IRIS,
   );
   const maxDelete = boundedInteger(
-    input.maxDelete,
+    value.maxDelete as number,
     'pruneRankedSubjects.maxDelete',
     BOUNDED_MUTATION_MAX_PRUNE_DELETE,
   );
   if (maxDelete === 0) throw new Error('pruneRankedSubjects.maxDelete must be positive');
-  assertOperandBudget('pruneRankedSubjects', [
-    graphUri,
-    subjectPrefix,
-    eligibilityPredicate,
-    primaryRankPredicate,
-    secondaryRankPredicate,
-    ...eligibleObjects,
-  ]);
-  return {
+  return Object.freeze({
     graphUri,
     subjectPrefix,
     eligibilityPredicate,
@@ -66,7 +64,100 @@ export function normalizePruneRankedSubjectsInput(
     secondaryRankPredicate,
     retainNewest,
     maxDelete,
-  };
+  });
+}
+
+export function pruneRankedSubjectsSemantics(
+  input: PruneRankedSubjectsInput,
+): StructuredMutationSemantics {
+  return { guardedGraphs: [input.graphUri], touchedGraphs: [input.graphUri], mightMutate: true };
+}
+
+export function materializePruneRankedSubjectsInput(
+  input: PruneRankedSubjectsInput,
+  buildUpdate = true,
+): string | undefined {
+  assertOperandBudget('pruneRankedSubjects', [
+    input.graphUri,
+    input.subjectPrefix,
+    input.eligibilityPredicate,
+    input.primaryRankPredicate,
+    input.secondaryRankPredicate,
+    ...input.eligibleObjects,
+  ]);
+  return buildUpdate ? buildPruneRankedSubjectsUpdateFromNormalized(input) : undefined;
+}
+
+export function capturePruneLinkedRecordClosuresInput(
+  input: unknown,
+): PruneLinkedRecordClosuresInput {
+  const value = captureInputRecord(input, 'pruneLinkedRecordClosures');
+  const graphUri = absoluteIri(value.graphUri as string, 'pruneLinkedRecordClosures.graphUri');
+  const matchObjectIris = captureUniqueIris(
+    value.matchObjectIris,
+    'pruneLinkedRecordClosures.matchObjectIris',
+    BOUNDED_MUTATION_MAX_IRIS,
+    false,
+  );
+  const linkPredicates = captureUniqueIris(
+    value.linkPredicates,
+    'pruneLinkedRecordClosures.linkPredicates',
+    BOUNDED_MUTATION_MAX_PREDICATES,
+    false,
+  );
+  const recordParentPredicate = absoluteIri(
+    value.recordParentPredicate as string,
+    'pruneLinkedRecordClosures.recordParentPredicate',
+  );
+  const rawProtectedRecordIri = value.protectedRecordIri;
+  const protectedRecordIri = rawProtectedRecordIri === undefined
+    ? undefined
+    : absoluteIri(
+        rawProtectedRecordIri as string,
+        'pruneLinkedRecordClosures.protectedRecordIri',
+      );
+  const descendantSeparator = boundedString(
+    value.descendantSeparator as string,
+    'pruneLinkedRecordClosures.descendantSeparator',
+    64,
+  );
+  return Object.freeze({
+    graphUri,
+    matchObjectIris,
+    linkPredicates,
+    recordParentPredicate,
+    protectedRecordIri,
+    descendantSeparator,
+  });
+}
+
+export function pruneLinkedRecordClosuresSemantics(
+  input: PruneLinkedRecordClosuresInput,
+): StructuredMutationSemantics {
+  return { guardedGraphs: [input.graphUri], touchedGraphs: [input.graphUri], mightMutate: true };
+}
+
+export function materializePruneLinkedRecordClosuresInput(
+  input: PruneLinkedRecordClosuresInput,
+  buildUpdate = true,
+): string | undefined {
+  assertOperandBudget('pruneLinkedRecordClosures', [
+    input.graphUri,
+    ...input.matchObjectIris,
+    ...input.linkPredicates,
+    input.recordParentPredicate,
+    input.descendantSeparator,
+    ...(input.protectedRecordIri ? [input.protectedRecordIri] : []),
+  ]);
+  return buildUpdate ? buildPruneLinkedRecordClosuresUpdateFromNormalized(input) : undefined;
+}
+
+export function normalizePruneRankedSubjectsInput(
+  input: PruneRankedSubjectsInput,
+): PruneRankedSubjectsInput {
+  const captured = capturePruneRankedSubjectsInput(input);
+  materializePruneRankedSubjectsInput(captured, false);
+  return captured;
 }
 
 export function buildPruneRankedSubjectsUpdate(input: PruneRankedSubjectsInput): string {
@@ -120,44 +211,9 @@ WHERE {
 export function normalizePruneLinkedRecordClosuresInput(
   input: PruneLinkedRecordClosuresInput,
 ): PruneLinkedRecordClosuresInput {
-  const graphUri = absoluteIri(input.graphUri, 'pruneLinkedRecordClosures.graphUri');
-  const matchObjectIris = uniqueIris(
-    input.matchObjectIris,
-    'pruneLinkedRecordClosures.matchObjectIris',
-  );
-  const linkPredicates = uniqueIris(
-    input.linkPredicates,
-    'pruneLinkedRecordClosures.linkPredicates',
-    BOUNDED_MUTATION_MAX_PREDICATES,
-  );
-  const recordParentPredicate = absoluteIri(
-    input.recordParentPredicate,
-    'pruneLinkedRecordClosures.recordParentPredicate',
-  );
-  const protectedRecordIri = input.protectedRecordIri === undefined
-    ? undefined
-    : absoluteIri(input.protectedRecordIri, 'pruneLinkedRecordClosures.protectedRecordIri');
-  const descendantSeparator = boundedString(
-    input.descendantSeparator,
-    'pruneLinkedRecordClosures.descendantSeparator',
-    64,
-  );
-  assertOperandBudget('pruneLinkedRecordClosures', [
-    graphUri,
-    ...matchObjectIris,
-    ...linkPredicates,
-    recordParentPredicate,
-    descendantSeparator,
-    ...(protectedRecordIri ? [protectedRecordIri] : []),
-  ]);
-  return {
-    graphUri,
-    matchObjectIris,
-    linkPredicates,
-    recordParentPredicate,
-    protectedRecordIri,
-    descendantSeparator,
-  };
+  const captured = capturePruneLinkedRecordClosuresInput(input);
+  materializePruneLinkedRecordClosuresInput(captured, false);
+  return captured;
 }
 
 export function buildPruneLinkedRecordClosuresUpdate(input: PruneLinkedRecordClosuresInput): string {

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -687,6 +687,17 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     expect(body).toContain('<http://ex.org/job> <http://ex.org/status> "approved"');
   });
 
+  it('structuredMutation sends no request for a valid empty delete', async () => {
+    const s = new BlazegraphStore(baseUrl);
+
+    await s.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: 'http://ex.org/g', subjects: [] },
+    });
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+
   it('structuredMutation rejects oversized replacement literals before fetch', async () => {
     const s = new BlazegraphStore(baseUrl);
     await expect(s.structuredMutation({ kind: 'replace-subject-predicates', input: {

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../src/index.js';
 import {
   BOUNDED_MUTATION_MAX_IRIS,
+  BOUNDED_MUTATION_MAX_OPERAND_BYTES,
   BOUNDED_MUTATION_MAX_UPDATE_BYTES,
   buildCopySubjectProjectionUpdate,
   buildDeleteSubjectsUpdate,
@@ -440,7 +441,7 @@ describe('bounded structured mutation capabilities', () => {
     expect(update).toHaveBeenCalledTimes(1);
   });
 
-  it('suppresses embedded and live-worker I/O for a valid empty delete', async () => {
+  it('keeps valid empty deletes I/O-free and rejects oversized worker no-ops before posting', async () => {
     const embedded = new OxigraphStore();
     const embeddedStore = (embedded as unknown as {
       store: { update: (sparql: string) => void };
@@ -469,6 +470,14 @@ describe('bounded structured mutation capabilities', () => {
 
       expect(workerInternals.nextId).toBe(nextId);
       expect(worker.getWriteGen(GRAPH)).toBe(workerGeneration);
+
+      const oversizedGraph = `urn:test:${'x'.repeat(BOUNDED_MUTATION_MAX_OPERAND_BYTES + 1)}`;
+      await expect(worker.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: oversizedGraph, subjects: [] },
+      })).rejects.toThrow(/operand bytes/);
+      expect(workerInternals.nextId).toBe(nextId);
+      expect(worker.getWriteGen(oversizedGraph)).toBe(0);
     } finally {
       await worker.close();
     }

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -440,6 +440,71 @@ describe('bounded structured mutation capabilities', () => {
     expect(update).toHaveBeenCalledTimes(1);
   });
 
+  it('suppresses embedded and live-worker I/O for a valid empty delete', async () => {
+    const embedded = new OxigraphStore();
+    const embeddedStore = (embedded as unknown as {
+      store: { update: (sparql: string) => void };
+    }).store;
+    const update = vi.spyOn(embeddedStore, 'update');
+    const embeddedGeneration = embedded.getWriteGen(GRAPH);
+
+    await embedded.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: GRAPH, subjects: [] },
+    });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(embedded.getWriteGen(GRAPH)).toBe(embeddedGeneration);
+
+    const worker = new OxigraphWorkerStore();
+    const workerInternals = worker as unknown as { nextId: number };
+    try {
+      const nextId = workerInternals.nextId;
+      const workerGeneration = worker.getWriteGen(GRAPH);
+
+      await worker.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: GRAPH, subjects: [] },
+      });
+
+      expect(workerInternals.nextId).toBe(nextId);
+      expect(worker.getWriteGen(GRAPH)).toBe(workerGeneration);
+    } finally {
+      await worker.close();
+    }
+  });
+
+  it('rejects final worker-bound encoding and operand budgets before posting', async () => {
+    const worker = new OxigraphWorkerStore();
+    const workerInternals = worker as unknown as { nextId: number };
+    try {
+      const beforeMutf8 = workerInternals.nextId;
+      await expect(worker.structuredMutation({
+        kind: 'replace-subject-predicates',
+        input: {
+          graphUri: GRAPH,
+          subject: 'urn:test:subject',
+          predicates: [P],
+          replacementQuads: [quad('urn:test:subject', P, `"${'x'.repeat(70_000)}"`)],
+        },
+      })).rejects.toMatchObject({ code: 'OVERSIZED_RDF_LITERAL' });
+      expect(workerInternals.nextId).toBe(beforeMutf8);
+
+      const subjects = Array.from(
+        { length: 65_000 },
+        (_, index) => `urn:test:operand:${index}:${'x'.repeat(55)}`,
+      );
+      const beforeBudget = workerInternals.nextId;
+      await expect(worker.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: GRAPH, subjects },
+      })).rejects.toThrow(/operand bytes/);
+      expect(workerInternals.nextId).toBe(beforeBudget);
+    } finally {
+      await worker.close();
+    }
+  });
+
   it('rejects sparse, duplicate, oversized, and cross-scope descriptors before dispatch', () => {
     const sparse = Array(2) as string[];
     sparse[1] = 'urn:test:a';

--- a/packages/storage/test/bounded-structured-mutation.test.ts
+++ b/packages/storage/test/bounded-structured-mutation.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -23,6 +25,7 @@ import {
   BOUNDED_MUTATION_MAX_UPDATE_BYTES,
   buildCopySubjectProjectionUpdate,
   buildDeleteSubjectsUpdate,
+  buildStructuredMutationUpdate,
   chunkCopySubjectProjectionInput,
   normalizeCopySubjectProjectionInput,
   normalizeDeleteSubjectsInput,
@@ -49,6 +52,80 @@ async function rows(store: TripleStore, graph: string): Promise<Array<Record<str
 }
 
 describe('bounded structured mutation capabilities', () => {
+  it('preserves the canonical update bytes for every mutation kind and the no-op shape', () => {
+    const fixtures: ReadonlyArray<readonly [string, StructuredMutation, number, string]> = [
+      ['delete-subjects', {
+        kind: 'delete-subjects',
+        input: { graphUri: GRAPH, subjects: ['urn:test:a', 'urn:test:b'] },
+      }, 184, '1816e8bb2a177b1a5abc7b66b0d716b9ecfa39caccbc57280add47bc25b7f775'],
+      ['prune-ranked-subjects', {
+        kind: 'prune-ranked-subjects',
+        input: {
+          graphUri: GRAPH,
+          subjectPrefix: 'urn:test:req:',
+          eligibilityPredicate: STATUS,
+          eligibleObjects: ['approved', 'rejected'],
+          primaryRankPredicate: DECIDED_AT,
+          secondaryRankPredicate: REQUESTED_AT,
+          retainNewest: 5,
+          maxDelete: 10,
+        },
+      }, 1_460, 'a4383f845f8eaa592d6e48932c9d1a37623d933e7c550970fea711d040a9f491'],
+      ['prune-linked-record-closures', {
+        kind: 'prune-linked-record-closures',
+        input: {
+          graphUri: GRAPH,
+          matchObjectIris: ['urn:test:agent'],
+          linkPredicates: [P],
+          recordParentPredicate: STATUS,
+          protectedRecordIri: 'urn:test:keep',
+          descendantSeparator: '/',
+        },
+      }, 478, 'a5b262cba67f38f7467316f2e39f917c9c51a96593a10d55c8f1e589a1df9a1f'],
+      ['replace-subject-predicates', {
+        kind: 'replace-subject-predicates',
+        input: {
+          graphUri: GRAPH,
+          subject: 'urn:test:a',
+          predicates: [P],
+          replacementQuads: [quad('urn:test:a', P, '"value"')],
+        },
+      }, 310, '63257772a038004b2043e8946de4f8da682e90e7bcf6156807520966e3f256b8'],
+      ['replace-projection-from-graph', {
+        kind: 'replace-projection-from-graph',
+        input: {
+          targetGraphUri: GRAPH,
+          stagingGraphUri: OTHER_GRAPH,
+          targetSubject: 'urn:test:a',
+          preservedTargetPredicates: [P],
+          targetSubjectPrefixes: ['urn:test:child:'],
+        },
+      }, 618, '1f15cafd7c386ee0f32f742d9188bb53d04e8b026c0aa984302603a2b615fe21'],
+      ['copy-subject-projection', {
+        kind: 'copy-subject-projection',
+        input: {
+          sourceGraphUris: [GRAPH],
+          targetGraphUri: OTHER_GRAPH,
+          roots: ['urn:test:a'],
+          descendantSuffix: '/',
+          excludedPredicates: [P],
+        },
+      }, 434, '16d90e11bc91e1aaa049a5f56b4f55ec03e27090205010fb3a76e64508685ec1'],
+      ['delete-subjects/noop', {
+        kind: 'delete-subjects',
+        input: { graphUri: GRAPH, subjects: [] },
+      }, 0, 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+    ];
+
+    for (const [label, mutation, expectedBytes, expectedHash] of fixtures) {
+      const update = buildStructuredMutationUpdate(mutation);
+      const bytes = update === undefined ? Buffer.alloc(0) : Buffer.from(update, 'utf8');
+      expect(bytes.byteLength, label).toBe(expectedBytes);
+      expect(createHash('sha256').update(bytes).digest('hex'), label).toBe(expectedHash);
+      expect(update === undefined, label).toBe(label.endsWith('/noop'));
+    }
+  });
+
   it('captures immutable graph effects before dispatch', () => {
     const mutation = {
       kind: 'copy-subject-projection' as const,

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -288,12 +288,12 @@ describe('ChangelogStore — opaque update handling', () => {
     await base.close();
   });
 
-  it('does not flag reconcile when a known no-op fails during inner preflight', async () => {
+  it('flags reconcile when a no-op fails because the inner store lost data', async () => {
     const base = new OxigraphStore();
     const failing = new Proxy(base, {
       get(target, property, receiver) {
         if (property === 'structuredMutation') {
-          return async () => { throw new Error('no-op preflight failed'); };
+          return async () => { throw new Error('in-memory worker data was lost'); };
         }
         const value = Reflect.get(target, property, receiver) as unknown;
         return typeof value === 'function' ? value.bind(target) : value;
@@ -304,9 +304,9 @@ describe('ChangelogStore — opaque update handling', () => {
     await expect(log.structuredMutation({
       kind: 'delete-subjects',
       input: { graphUri: G1, subjects: [] },
-    })).rejects.toThrow('no-op preflight failed');
+    })).rejects.toThrow('in-memory worker data was lost');
 
-    expect(log.needsReconcile).toBe(false);
+    expect(log.needsReconcile).toBe(true);
     await base.close();
   });
 

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -286,6 +286,88 @@ describe('ChangelogStore — opaque update handling', () => {
     await base.close();
   });
 
+  it('does not flag reconcile when a known no-op fails during inner preflight', async () => {
+    const base = new OxigraphStore();
+    const failing = new Proxy(base, {
+      get(target, property, receiver) {
+        if (property === 'structuredMutation') {
+          return async () => { throw new Error('no-op preflight failed'); };
+        }
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    const log = new ChangelogStore(failing);
+
+    await expect(log.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: G1, subjects: [] },
+    })).rejects.toThrow('no-op preflight failed');
+
+    expect(log.needsReconcile).toBe(false);
+    await base.close();
+  });
+
+  it('keeps an enabled no-op inside the write tail while close drains it', async () => {
+    const base = new OxigraphStore();
+    await base.insert([q('http://ex.org/delete-me', G1)]);
+    let release!: () => void;
+    let started!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const firstStarted = new Promise<void>((resolve) => { started = resolve; });
+    const calls: Array<{ mutation: StructuredMutation; options?: QueryOptions }> = [];
+    const gated = new Proxy(base, {
+      get(target, property, receiver) {
+        if (property === 'structuredMutation') {
+          return async (mutation: StructuredMutation, options?: QueryOptions) => {
+            calls.push({ mutation, options });
+            if (calls.length === 1) {
+              started();
+              await gate;
+            }
+            await target.structuredMutation(mutation, options);
+          };
+        }
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    const appended: unknown[] = [];
+    const log = new ChangelogStore(gated, { onAppend: (record) => appended.push(record) });
+    const options = { source: 'changelog.noop' };
+
+    const mutation = log.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: G1, subjects: ['http://ex.org/delete-me'] },
+    });
+    await firstStarted;
+    const noop = log.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: G1, subjects: [] },
+    }, options);
+    const close = log.close();
+
+    await expect(Promise.race([
+      noop.then(() => 'settled'),
+      new Promise<string>((resolve) => setTimeout(() => resolve('pending'), 25)),
+    ])).resolves.toBe('pending');
+    await expect(log.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: G1, subjects: [] },
+    })).rejects.toThrow(/store is closing/);
+
+    release();
+    await mutation;
+    await noop;
+    await close;
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].options).toBe(options);
+    expect(Object.isFrozen(calls[1].mutation)).toBe(true);
+    expect(appended).toHaveLength(1);
+    expect(log.needsReconcile).toBe(false);
+  });
+
   it('an update() with touchedGraphs emits markers; without, it flags reconcile', async () => {
     const base = new OxigraphStore();
     const log = new ChangelogStore(base);

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -24,6 +24,8 @@ import { ChangelogStore, CHANGELOG_GRAPH, asChangelogReader, type ChangelogEraGu
 import { createTripleStore } from '../src/triple-store.js';
 import type { Quad, QueryOptions, QueryResult, StructuredMutation, TripleStore, UpdateOptions } from '../src/triple-store.js';
 import { UnsupportedTripleStoreCapabilityError } from '../src/unsupported-capability-error.js';
+import { captureStructuredMutationSnapshot } from '../src/bounded-structured-mutation.js';
+import { materializeStructuredMutation } from '../src/structured-mutation-materialization-internal.js';
 
 const G1 = 'http://ex.org/g1';
 const G2 = 'http://ex.org/g2';
@@ -308,6 +310,36 @@ describe('ChangelogStore — opaque update handling', () => {
     await base.close();
   });
 
+  it('does not flag reconcile after a deferred-budget refusal before backend I/O', async () => {
+    const base = new OxigraphStore();
+    let backendUpdates = 0;
+    const validatingLeaf = new Proxy(base, {
+      get(target, property, receiver) {
+        if (property === 'structuredMutation') {
+          return async (mutation: StructuredMutation, options?: QueryOptions) => {
+            const materialized = materializeStructuredMutation(
+              captureStructuredMutationSnapshot(mutation),
+            );
+            if (materialized.outcome === 'noop') return;
+            backendUpdates += 1;
+            await target.structuredMutation(mutation, options);
+          };
+        }
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    const log = new ChangelogStore(validatingLeaf);
+
+    await expect(log.structuredMutation(overBudgetDeleteMutation(G1)))
+      .rejects.toThrow(/operand bytes/);
+
+    expect(backendUpdates).toBe(0);
+    expect(log.needsReconcile).toBe(false);
+    expect(await log.readChanges(0, 100)).toEqual([]);
+    await base.close();
+  });
+
   it('keeps an enabled no-op inside the write tail while close drains it', async () => {
     const base = new OxigraphStore();
     await base.insert([q('http://ex.org/delete-me', G1)]);
@@ -410,6 +442,19 @@ describe('ChangelogStore — opaque update handling', () => {
     await base.close();
   });
 });
+
+function overBudgetDeleteMutation(graphUri: string): StructuredMutation {
+  return {
+    kind: 'delete-subjects',
+    input: {
+      graphUri,
+      subjects: Array.from(
+        { length: 65_000 },
+        (_, index) => `urn:test:operand:${index}:${'x'.repeat(55)}`,
+      ),
+    },
+  };
+}
 
 describe('ChangelogStore over Blazegraph — single-request atomicity', () => {
   let server: Server;

--- a/packages/storage/test/external-literal-store.test.ts
+++ b/packages/storage/test/external-literal-store.test.ts
@@ -335,6 +335,28 @@ describe('SharedMemoryLiteralBlobStore', () => {
     expect(hydrated.type === 'bindings' ? hydrated.bindings : []).toEqual([{ o: largeLiteral }]);
   });
 
+  it('forwards a structural no-op without externalization and preserves options identity', async () => {
+    const blobDir = await tempBlobDir();
+    const inner = new OxigraphStore();
+    const mutationSpy = vi.spyOn(inner, 'structuredMutation');
+    const store = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 20 });
+    const externalize = vi.spyOn(
+      store as unknown as { externalizeInsertQuad: (quad: Quad) => Promise<Quad> },
+      'externalizeInsertQuad',
+    );
+    const options = { source: 'literal-blob.noop' };
+
+    await store.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: SWM_GRAPH, subjects: [] },
+    }, options);
+
+    expect(externalize).not.toHaveBeenCalled();
+    expect(mutationSpy).toHaveBeenCalledOnce();
+    expect(mutationSpy.mock.calls[0][1]).toBe(options);
+    expect(Object.isFrozen(mutationSpy.mock.calls[0][0])).toBe(true);
+  });
+
   it('externalizes an over-budget replacement literal before validating the rewritten mutation', async () => {
     const blobDir = await tempBlobDir();
     const inner = new OxigraphStore();

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -158,7 +158,7 @@ describe('GraphSetIndexStore', () => {
     await inner.close();
   });
 
-  it('forwards a known no-op without maintenance and never schedules recovery for its failure', async () => {
+  it('invalidates a warm index when a no-op fails because the inner store lost data', async () => {
     const graph = 'did:dkg:context-graph:noop';
     const inner = new OxigraphStore();
     await inner.insert([q(graph)]);
@@ -171,7 +171,8 @@ describe('GraphSetIndexStore', () => {
       ): Promise<void> {
         observed = mutation;
         observedOptions = options;
-        throw new Error('no-op preflight failed');
+        this.failListGraphs = true;
+        throw new Error('in-memory worker data was lost');
       }
     })(inner);
     const events: GraphSetMutationEvent[] = [];
@@ -185,7 +186,7 @@ describe('GraphSetIndexStore', () => {
     await expect(store.structuredMutation({
       kind: 'delete-subjects',
       input: { graphUri: graph, subjects: [] },
-    }, options)).rejects.toThrow('no-op preflight failed');
+    }, options)).rejects.toThrow('in-memory worker data was lost');
 
     expect(observedOptions).toBe(options);
     expect(observed).toEqual({
@@ -194,8 +195,8 @@ describe('GraphSetIndexStore', () => {
     });
     expect(Object.isFrozen(observed)).toBe(true);
     expect(events).toEqual([]);
-    await expect(store.listGraphs()).resolves.toEqual([graph]);
-    expect(failing.listGraphsCalls).toBe(1);
+    await expect(store.listGraphs()).rejects.toThrow('listGraphs failed');
+    expect(failing.listGraphsCalls).toBe(2);
     await inner.close();
   });
 

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -15,7 +15,9 @@ import {
   type StructuredMutation,
   type QueryOptions,
   type StoreWorkPriority,
+  captureStructuredMutationSnapshot,
 } from '../src/index.js';
+import { materializeStructuredMutation } from '../src/structured-mutation-materialization-internal.js';
 import {
   ControlledProbeStore,
   CountingStore,
@@ -194,6 +196,36 @@ describe('GraphSetIndexStore', () => {
     expect(events).toEqual([]);
     await expect(store.listGraphs()).resolves.toEqual([graph]);
     expect(failing.listGraphsCalls).toBe(1);
+    await inner.close();
+  });
+
+  it('does not rebuild after a deterministic deferred-budget refusal before backend I/O', async () => {
+    const graph = 'did:dkg:context-graph:budget-refusal';
+    const inner = new OxigraphStore();
+    await inner.insert([q(graph)]);
+    let backendUpdates = 0;
+    const validatingLeaf = new (class extends CountingStore {
+      override async structuredMutation(
+        mutation: StructuredMutation,
+        options?: QueryOptions,
+      ): Promise<void> {
+        const materialized = materializeStructuredMutation(
+          captureStructuredMutationSnapshot(mutation),
+        );
+        if (materialized.outcome === 'noop') return;
+        backendUpdates += 1;
+        await super.structuredMutation(mutation, options);
+      }
+    })(inner);
+    const store = new GraphSetIndexStore(validatingLeaf);
+
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+    await expect(store.structuredMutation(overBudgetDeleteMutation(graph)))
+      .rejects.toThrow(/operand bytes/);
+
+    expect(backendUpdates).toBe(0);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+    expect(validatingLeaf.listGraphsCalls).toBe(1);
     await inner.close();
   });
 
@@ -1401,3 +1433,16 @@ describe('GraphSetIndexStore', () => {
     await optedInStore.close();
   });
 });
+
+function overBudgetDeleteMutation(graphUri: string): StructuredMutation {
+  return {
+    kind: 'delete-subjects',
+    input: {
+      graphUri,
+      subjects: Array.from(
+        { length: 65_000 },
+        (_, index) => `urn:test:operand:${index}:${'x'.repeat(55)}`,
+      ),
+    },
+  };
+}

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -156,6 +156,47 @@ describe('GraphSetIndexStore', () => {
     await inner.close();
   });
 
+  it('forwards a known no-op without maintenance and never schedules recovery for its failure', async () => {
+    const graph = 'did:dkg:context-graph:noop';
+    const inner = new OxigraphStore();
+    await inner.insert([q(graph)]);
+    let observed: StructuredMutation | undefined;
+    let observedOptions: QueryOptions | undefined;
+    const failing = new (class extends CountingStore {
+      override async structuredMutation(
+        mutation: StructuredMutation,
+        options?: QueryOptions,
+      ): Promise<void> {
+        observed = mutation;
+        observedOptions = options;
+        throw new Error('no-op preflight failed');
+      }
+    })(inner);
+    const events: GraphSetMutationEvent[] = [];
+    const store = new GraphSetIndexStore(failing, {
+      onMutation: (event) => events.push(event),
+    });
+    const options = { source: 'graph-set.noop' };
+
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+    events.length = 0;
+    await expect(store.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: graph, subjects: [] },
+    }, options)).rejects.toThrow('no-op preflight failed');
+
+    expect(observedOptions).toBe(options);
+    expect(observed).toEqual({
+      kind: 'delete-subjects',
+      input: { graphUri: graph, subjects: [] },
+    });
+    expect(Object.isFrozen(observed)).toBe(true);
+    expect(events).toEqual([]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+    expect(failing.listGraphsCalls).toBe(1);
+    await inner.close();
+  });
+
   it('rebuilds a warm graph index after an indeterminate structured mutation failure', async () => {
     const source = 'did:dkg:context-graph:indeterminate-source';
     const target = 'did:dkg:context-graph:indeterminate-target';

--- a/packages/storage/test/managed-backend-ownership-dispatch-v1.test.ts
+++ b/packages/storage/test/managed-backend-ownership-dispatch-v1.test.ts
@@ -117,6 +117,19 @@ describe('managed backend ownership at mutation dispatch', () => {
     await store.close().catch(() => undefined);
   });
 
+  it('completes a valid structured no-op before managed admission and I/O', async () => {
+    const store = await managedStore();
+    ownership.invalidate('port-release-unproven');
+
+    await expect(store.structuredMutation!({
+      kind: 'delete-subjects',
+      input: { graphUri: 'urn:dkg:test:g', subjects: [] },
+    })).resolves.toBeUndefined();
+    expect(requests).toEqual([]);
+
+    await store.close().catch(() => undefined);
+  });
+
   it('refuses a mutation with ZERO I/O after a failed clean-generation start', async () => {
     // The reviewer's second named regression. Here the lease is NOT terminal —
     // the supervisor invalidated with `stop` and will revive — so a check keyed

--- a/packages/storage/test/oxigraph-worker-respawn.test.ts
+++ b/packages/storage/test/oxigraph-worker-respawn.test.ts
@@ -51,6 +51,7 @@ function internals(store: OxigraphWorkerStore): {
   closePromise: Promise<void> | null;
   respawnPromise: Promise<void> | null;
   consecutiveRespawnFailures: number;
+  nextId: number;
 } {
   return store as unknown as {
     worker: Worker;
@@ -58,6 +59,7 @@ function internals(store: OxigraphWorkerStore): {
     closePromise: Promise<void> | null;
     respawnPromise: Promise<void> | null;
     consecutiveRespawnFailures: number;
+    nextId: number;
   };
 }
 
@@ -168,6 +170,32 @@ describe('OxigraphWorkerStore respawn after unexpected worker exit', () => {
     }
   }, 15_000);
 
+  it('parks a no-op through respawn without posting or advancing generations', async () => {
+    const store = makeStore(path);
+    try {
+      await killWorker(store);
+      await killWorker(store);
+      expect(internals(store).lifecycle).toBe('respawning');
+      expect(internals(store).respawnPromise).not.toBeNull();
+
+      const nextId = internals(store).nextId;
+      const generation = store.getWriteGen('urn:test:g');
+      const noop = store.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: 'urn:test:g', subjects: [] },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(internals(store).nextId).toBe(nextId);
+
+      await expect(noop).resolves.toBeUndefined();
+      expect(internals(store).lifecycle).toBe('live');
+      expect(internals(store).nextId).toBe(nextId);
+      expect(store.getWriteGen('urn:test:g')).toBe(generation);
+    } finally {
+      await store.close().catch(() => {});
+    }
+  }, 15_000);
+
   it('a successful op resets the crash-loop counter', async () => {
     const store = makeStore(path);
     try {
@@ -200,6 +228,27 @@ describe('OxigraphWorkerStore respawn after unexpected worker exit', () => {
     // Post-close ops fail exactly as before this fix — fast and permanent.
     await expect(store.countQuads('urn:test:g')).rejects.toThrow(/store is closed/);
     await expect(store.insert(quads(1))).rejects.toThrow(/store is closed/);
+    const nextId = internals(store).nextId;
+    await expect(store.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: 'urn:test:g', subjects: [] },
+    })).rejects.toThrow(/store is closed/);
+    expect(internals(store).nextId).toBe(nextId);
+  });
+
+  it('rejects a no-op while close is draining without posting another message', async () => {
+    const store = makeStore(path);
+    const close = store.close();
+    expect(internals(store).lifecycle).toBe('closing');
+    const nextId = internals(store).nextId;
+
+    await expect(store.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: 'urn:test:g', subjects: [] },
+    })).rejects.toThrow(/store is closed/);
+    expect(internals(store).nextId).toBe(nextId);
+
+    await close;
   });
 
   it('gives up after MAX consecutive dead-on-arrival respawns and latches closed with guidance', async () => {
@@ -224,6 +273,12 @@ describe('OxigraphWorkerStore respawn after unexpected worker exit', () => {
       // The give-up verdict is now the single, explicit terminal state — no
       // cluster of booleans that could disagree with the fail-fast error above.
       expect(internals(store).lifecycle).toBe('gave_up');
+      const nextId = internals(store).nextId;
+      await expect(store.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: 'urn:test:g', subjects: [] },
+      })).rejects.toThrow(/respawn gave up/);
+      expect(internals(store).nextId).toBe(nextId);
     } finally {
       // close() on a latched store must still resolve (idempotent teardown).
       await expect(store.close()).resolves.toBeUndefined();
@@ -245,6 +300,12 @@ describe('OxigraphWorkerStore respawn after unexpected worker exit', () => {
     // Wait out the backoff so a buggy respawn would have fired by now.
     await new Promise((r) => setTimeout(r, 1_500));
     await expect(store.countQuads('urn:test:g')).rejects.toThrow(/store is closed/);
+    const nextId = internals(store).nextId;
+    await expect(store.structuredMutation({
+      kind: 'delete-subjects',
+      input: { graphUri: 'urn:test:g', subjects: [] },
+    })).rejects.toThrow(/store is closed/);
+    expect(internals(store).nextId).toBe(nextId);
   }, 15_000);
 });
 
@@ -289,6 +350,12 @@ describe('OxigraphWorkerStore in-memory fail-closed on unexpected worker exit', 
 
       // Writes fail closed the same way — the store is unusable, not read-only.
       await expect(store.insert(quads(1))).rejects.toThrow(/IN-MEMORY store's worker crashed/);
+      const nextId = internals(store).nextId;
+      await expect(store.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: 'urn:test:g', subjects: [] },
+      })).rejects.toThrow(/IN-MEMORY store's worker crashed/);
+      expect(internals(store).nextId).toBe(nextId);
     } finally {
       // close() on a data-lost store must still resolve (idempotent teardown)
       // and must not resurrect it.

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -875,6 +875,17 @@ describe('SparqlHttpStore (test server)', () => {
     expect(insertedQuads[0]).not.toContain(';');
   });
 
+  it('structuredMutation sends no request for a valid empty delete', async () => {
+    insertedQuads.length = 0;
+
+    await store.structuredMutation!({
+      kind: 'delete-subjects',
+      input: { graphUri: 'http://ex.org/g1', subjects: [] },
+    });
+
+    expect(insertedQuads).toHaveLength(0);
+  });
+
   it('deleteByPattern sends DELETE WHERE to update endpoint', async () => {
     insertedQuads.length = 0;
     await store.deleteByPattern({ subject: 'http://ex.org/s', graph: 'http://ex.org/g' });

--- a/packages/storage/test/structured-mutation-composition.test.ts
+++ b/packages/storage/test/structured-mutation-composition.test.ts
@@ -22,6 +22,7 @@ import {
   BOUNDED_MUTATION_MAX_OPERAND_BYTES,
   buildStructuredMutationUpdate,
 } from '../src/bounded-structured-mutation.js';
+import { BoundedMutationBudgetError } from '../src/structured-mutation/primitives.js';
 
 const GRAPH = 'urn:test:composition';
 const TARGET = 'urn:test:composition:target';
@@ -262,56 +263,65 @@ describe('structured mutation composition', () => {
     }
   });
 
-  it('does not trust a forged refusal code after the inner store commits', async () => {
-    const source = 'urn:test:composition:forged-source';
-    const target = 'urn:test:composition:forged-target';
-    const root = 'urn:test:composition:forged-root';
-    const leaf = new (class extends OxigraphStore {
-      override async structuredMutation(
-        mutation: StructuredMutation,
-        options?: QueryOptions,
-      ): Promise<void> {
-        await super.structuredMutation(mutation, options);
-        const error = new Error('committed then forged a clean refusal') as Error & {
-          code: string;
-        };
-        error.code = 'STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL';
-        throw error;
+  it('does not trust forged or bare low-level refusals after the inner store commits', async () => {
+    const failures: ReadonlyArray<readonly [string, () => Error]> = [
+      ['forged-code', () => Object.assign(
+        new Error('committed then forged a clean refusal'),
+        { code: 'STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL' },
+      )],
+      ['bare-budget', () => new BoundedMutationBudgetError(
+        'committed then threw a bare budget error',
+      )],
+    ];
+
+    for (const [suffix, createFailure] of failures) {
+      const source = `urn:test:composition:${suffix}:source`;
+      const target = `urn:test:composition:${suffix}:target`;
+      const root = `urn:test:composition:${suffix}:root`;
+      const failure = createFailure();
+      const leaf = new (class extends OxigraphStore {
+        override async structuredMutation(
+          mutation: StructuredMutation,
+          options?: QueryOptions,
+        ): Promise<void> {
+          await super.structuredMutation(mutation, options);
+          throw failure;
+        }
+      })();
+      const listGraphs = vi.spyOn(leaf, 'listGraphs');
+      const graphSet = new GraphSetIndexStore(leaf);
+      const changelog = new ChangelogStore(graphSet);
+
+      try {
+        await leaf.insert([{
+          subject: root,
+          predicate: PREDICATE,
+          object: '"source"',
+          graph: source,
+        }]);
+        await expect(changelog.listGraphs()).resolves.toEqual([source]);
+        expect(listGraphs).toHaveBeenCalledOnce();
+
+        const received = await changelog.structuredMutation({
+          kind: 'copy-subject-projection',
+          input: {
+            sourceGraphUris: [source],
+            targetGraphUri: target,
+            roots: [root],
+            descendantSuffix: '/',
+            excludedPredicates: [],
+          },
+        }).then(() => undefined, (error: unknown) => error);
+        expect(received).toBe(failure);
+
+        expect(changelog.needsReconcile).toBe(true);
+        expect(await leaf.hasGraph(target)).toBe(true);
+        await expect(changelog.listGraphs())
+          .resolves.toEqual(expect.arrayContaining([source, target]));
+        expect(listGraphs).toHaveBeenCalledTimes(2);
+      } finally {
+        await changelog.close();
       }
-    })();
-    const listGraphs = vi.spyOn(leaf, 'listGraphs');
-    const graphSet = new GraphSetIndexStore(leaf);
-    const changelog = new ChangelogStore(graphSet);
-
-    try {
-      await leaf.insert([{
-        subject: root,
-        predicate: PREDICATE,
-        object: '"source"',
-        graph: source,
-      }]);
-      await expect(changelog.listGraphs()).resolves.toEqual([source]);
-      expect(listGraphs).toHaveBeenCalledOnce();
-
-      await expect(changelog.structuredMutation({
-        kind: 'copy-subject-projection',
-        input: {
-          sourceGraphUris: [source],
-          targetGraphUri: target,
-          roots: [root],
-          descendantSuffix: '/',
-          excludedPredicates: [],
-        },
-      })).rejects.toMatchObject({
-        code: 'STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL',
-      });
-
-      expect(changelog.needsReconcile).toBe(true);
-      expect(await leaf.hasGraph(target)).toBe(true);
-      await expect(changelog.listGraphs()).resolves.toEqual(expect.arrayContaining([source, target]));
-      expect(listGraphs).toHaveBeenCalledTimes(2);
-    } finally {
-      await changelog.close();
     }
   });
 

--- a/packages/storage/test/structured-mutation-composition.test.ts
+++ b/packages/storage/test/structured-mutation-composition.test.ts
@@ -262,6 +262,59 @@ describe('structured mutation composition', () => {
     }
   });
 
+  it('does not trust a forged refusal code after the inner store commits', async () => {
+    const source = 'urn:test:composition:forged-source';
+    const target = 'urn:test:composition:forged-target';
+    const root = 'urn:test:composition:forged-root';
+    const leaf = new (class extends OxigraphStore {
+      override async structuredMutation(
+        mutation: StructuredMutation,
+        options?: QueryOptions,
+      ): Promise<void> {
+        await super.structuredMutation(mutation, options);
+        const error = new Error('committed then forged a clean refusal') as Error & {
+          code: string;
+        };
+        error.code = 'STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL';
+        throw error;
+      }
+    })();
+    const listGraphs = vi.spyOn(leaf, 'listGraphs');
+    const graphSet = new GraphSetIndexStore(leaf);
+    const changelog = new ChangelogStore(graphSet);
+
+    try {
+      await leaf.insert([{
+        subject: root,
+        predicate: PREDICATE,
+        object: '"source"',
+        graph: source,
+      }]);
+      await expect(changelog.listGraphs()).resolves.toEqual([source]);
+      expect(listGraphs).toHaveBeenCalledOnce();
+
+      await expect(changelog.structuredMutation({
+        kind: 'copy-subject-projection',
+        input: {
+          sourceGraphUris: [source],
+          targetGraphUri: target,
+          roots: [root],
+          descendantSuffix: '/',
+          excludedPredicates: [],
+        },
+      })).rejects.toMatchObject({
+        code: 'STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL',
+      });
+
+      expect(changelog.needsReconcile).toBe(true);
+      expect(await leaf.hasGraph(target)).toBe(true);
+      await expect(changelog.listGraphs()).resolves.toEqual(expect.arrayContaining([source, target]));
+      expect(listGraphs).toHaveBeenCalledTimes(2);
+    } finally {
+      await changelog.close();
+    }
+  });
+
   it('preserves worker-side serialized-budget refusals as mutation-free', async () => {
     const leaf = new OxigraphWorkerStore();
     const graphSet = new GraphSetIndexStore(leaf);

--- a/packages/storage/test/structured-mutation-composition.test.ts
+++ b/packages/storage/test/structured-mutation-composition.test.ts
@@ -11,13 +11,17 @@ import {
   EXTERNAL_LITERAL_REF_DATATYPE,
   GraphSetIndexStore,
   OxigraphStore,
+  OxigraphWorkerStore,
   SharedMemoryLiteralBlobStore,
   captureStructuredMutationSnapshot,
   type GraphSetMutationEvent,
   type QueryOptions,
   type StructuredMutation,
 } from '../src/index.js';
-import { BOUNDED_MUTATION_MAX_OPERAND_BYTES } from '../src/bounded-structured-mutation.js';
+import {
+  BOUNDED_MUTATION_MAX_OPERAND_BYTES,
+  buildStructuredMutationUpdate,
+} from '../src/bounded-structured-mutation.js';
 
 const GRAPH = 'urn:test:composition';
 const TARGET = 'urn:test:composition:target';
@@ -253,6 +257,51 @@ describe('structured mutation composition', () => {
       );
       expect(await leaf.hasGraph(SWM_GRAPH)).toBe(true);
       expect(changelog.needsReconcile).toBe(false);
+    } finally {
+      await changelog.close();
+    }
+  });
+
+  it('preserves worker-side serialized-budget refusals as mutation-free', async () => {
+    const leaf = new OxigraphWorkerStore();
+    const graphSet = new GraphSetIndexStore(leaf);
+    const changelog = new ChangelogStore(graphSet);
+    const listGraphs = vi.spyOn(leaf, 'listGraphs');
+    const mutation: StructuredMutation = {
+      kind: 'delete-subjects',
+      input: {
+        graphUri: GRAPH,
+        subjects: Array.from(
+          { length: 75_000 },
+          (_, index) => `urn:test:${index.toString().padStart(5, '0')}:${'x'.repeat(40)}`,
+        ),
+      },
+    };
+
+    try {
+      await leaf.insert([{
+        subject: 'urn:test:composition:retained',
+        predicate: PREDICATE,
+        object: '"retained"',
+        graph: GRAPH,
+      }]);
+      await expect(changelog.listGraphs()).resolves.toEqual([GRAPH]);
+      expect(listGraphs).toHaveBeenCalledOnce();
+      const generation = leaf.getWriteGen(GRAPH);
+      expect(() => buildStructuredMutationUpdate(mutation))
+        .toThrow(/serialized update exceeds/);
+
+      await expect(changelog.structuredMutation(mutation))
+        .rejects.toMatchObject({
+          code: 'STRUCTURED_MUTATION_PRE_DISPATCH_REFUSAL',
+          message: expect.stringMatching(/serialized update exceeds/),
+        });
+
+      expect(changelog.needsReconcile).toBe(false);
+      expect(leaf.getWriteGen(GRAPH)).toBe(generation);
+      expect(await leaf.countQuads(GRAPH)).toBe(1);
+      await expect(changelog.listGraphs()).resolves.toEqual([GRAPH]);
+      expect(listGraphs).toHaveBeenCalledOnce();
     } finally {
       await changelog.close();
     }

--- a/packages/storage/test/structured-mutation-composition.test.ts
+++ b/packages/storage/test/structured-mutation-composition.test.ts
@@ -1,0 +1,260 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CHANGELOG_GRAPH,
+  ChangelogStore,
+  EXTERNAL_LITERAL_REF_DATATYPE,
+  GraphSetIndexStore,
+  OxigraphStore,
+  SharedMemoryLiteralBlobStore,
+  captureStructuredMutationSnapshot,
+  type GraphSetMutationEvent,
+  type QueryOptions,
+  type StructuredMutation,
+} from '../src/index.js';
+import { BOUNDED_MUTATION_MAX_OPERAND_BYTES } from '../src/bounded-structured-mutation.js';
+
+const GRAPH = 'urn:test:composition';
+const TARGET = 'urn:test:composition:target';
+const PREDICATE = 'urn:test:composition:predicate';
+const SWM_GRAPH = 'did:dkg:context-graph:composition/_shared_memory';
+
+function mutationFixtures(): StructuredMutation[] {
+  return [
+    { kind: 'delete-subjects', input: {
+      graphUri: GRAPH,
+      subjects: ['urn:test:composition:delete'],
+    } },
+    { kind: 'prune-ranked-subjects', input: {
+      graphUri: GRAPH,
+      subjectPrefix: 'urn:test:composition:ranked:',
+      eligibilityPredicate: PREDICATE,
+      eligibleObjects: ['approved'],
+      primaryRankPredicate: 'urn:test:composition:rank:primary',
+      secondaryRankPredicate: 'urn:test:composition:rank:secondary',
+      retainNewest: 1,
+      maxDelete: 1,
+    } },
+    { kind: 'prune-linked-record-closures', input: {
+      graphUri: GRAPH,
+      matchObjectIris: ['urn:test:composition:agent'],
+      linkPredicates: [PREDICATE],
+      recordParentPredicate: 'urn:test:composition:parent',
+      descendantSeparator: '/',
+    } },
+    { kind: 'replace-subject-predicates', input: {
+      graphUri: GRAPH,
+      subject: 'urn:test:composition:subject',
+      predicates: [PREDICATE],
+      replacementQuads: [{
+        subject: 'urn:test:composition:subject',
+        predicate: PREDICATE,
+        object: '"value"',
+        graph: GRAPH,
+      }],
+    } },
+    { kind: 'replace-projection-from-graph', input: {
+      targetGraphUri: TARGET,
+      stagingGraphUri: 'urn:test:composition:staging',
+      targetSubject: 'urn:test:composition:subject',
+      preservedTargetPredicates: [PREDICATE],
+      targetSubjectPrefixes: ['urn:test:composition:prefix:'],
+    } },
+    { kind: 'copy-subject-projection', input: {
+      sourceGraphUris: [GRAPH],
+      targetGraphUri: TARGET,
+      roots: ['urn:test:composition:root'],
+      descendantSuffix: '/',
+      excludedPredicates: [PREDICATE],
+    } },
+  ];
+}
+
+function redirectCallerMutation(mutation: StructuredMutation): void {
+  const input = mutation.input as unknown as Record<string, unknown>;
+  if ('graphUri' in input) input.graphUri = 'urn:test:redirected';
+  if ('targetGraphUri' in input) input.targetGraphUri = 'urn:test:redirected';
+  for (const key of [
+    'subjects',
+    'eligibleObjects',
+    'matchObjectIris',
+    'predicates',
+    'preservedTargetPredicates',
+    'roots',
+  ]) {
+    const values = input[key];
+    if (Array.isArray(values) && values.length > 0) values[0] = 'urn:test:redirected';
+  }
+  if (mutation.kind === 'replace-subject-predicates') {
+    (mutation.input.replacementQuads[0] as { object: string }).object = '"redirected"';
+  }
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+describe('structured mutation composition', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('reuses one snapshot through unchanged wrappers for every mutation kind', async () => {
+    const blobDir = await mkdtemp(join(tmpdir(), 'structured-mutation-composition-'));
+    tempDirs.push(blobDir);
+    const leaf = new OxigraphStore();
+    const literal = new SharedMemoryLiteralBlobStore(leaf, {
+      blobDir,
+      thresholdBytes: 1_024,
+    });
+    const graphSet = new GraphSetIndexStore(literal);
+    const changelog = new ChangelogStore(graphSet);
+    const graphSetMutation = vi.spyOn(graphSet, 'structuredMutation');
+    const literalMutation = vi.spyOn(literal, 'structuredMutation');
+    const leafMutation = vi.spyOn(leaf, 'structuredMutation');
+    const options: QueryOptions = { source: 'composition.identity' };
+
+    try {
+      for (const mutation of mutationFixtures()) {
+        const expected = JSON.parse(JSON.stringify(mutation)) as StructuredMutation;
+        const graphSetCalls = graphSetMutation.mock.calls.length;
+        const literalCalls = literalMutation.mock.calls.length;
+        const leafCalls = leafMutation.mock.calls.length;
+
+        const pending = changelog.structuredMutation(mutation, options);
+        redirectCallerMutation(mutation);
+        await pending;
+
+        const graphSetCall = graphSetMutation.mock.calls[graphSetCalls];
+        const literalCall = literalMutation.mock.calls[literalCalls];
+        const leafCall = leafMutation.mock.calls[leafCalls];
+        expect(graphSetCall[0]).toEqual(expected);
+        expect(literalCall[0]).toEqual(expected);
+        expect(leafCall[0]).toEqual(expected);
+        expect(graphSetCall[0]).toBe(literalCall[0]);
+        expect(captureStructuredMutationSnapshot(graphSetCall[0]))
+          .toBe(captureStructuredMutationSnapshot(literalCall[0]));
+        if (expected.kind === 'replace-subject-predicates') {
+          expect(leafCall[0]).not.toBe(literalCall[0]);
+          expect(captureStructuredMutationSnapshot(leafCall[0]))
+            .not.toBe(captureStructuredMutationSnapshot(literalCall[0]));
+        } else {
+          expect(leafCall[0]).toBe(literalCall[0]);
+          expect(captureStructuredMutationSnapshot(leafCall[0]))
+            .toBe(captureStructuredMutationSnapshot(literalCall[0]));
+        }
+        expect(Object.isFrozen(graphSetCall[0])).toBe(true);
+        expect(Object.isFrozen(leafCall[0])).toBe(true);
+        expect(graphSetCall[1]).toBe(options);
+        expect(literalCall[1]).toBe(options);
+        expect(leafCall[1]).toBe(options);
+      }
+    } finally {
+      await changelog.close();
+    }
+  });
+
+  it('runs no-op policy preflight but performs no I/O, maintenance, or generation advance', async () => {
+    const blobDir = await mkdtemp(join(tmpdir(), 'structured-mutation-noop-'));
+    tempDirs.push(blobDir);
+    const leaf = new OxigraphStore();
+    const embedded = (leaf as unknown as { store: { update: (sparql: string) => void } }).store;
+    const update = vi.spyOn(embedded, 'update');
+    const leafMutation = vi.spyOn(leaf, 'structuredMutation');
+    const query = vi.spyOn(leaf, 'query');
+    const hasGraph = vi.spyOn(leaf, 'hasGraph');
+    const graphEvents: GraphSetMutationEvent[] = [];
+    const changelogEvents: unknown[] = [];
+    const literal = new SharedMemoryLiteralBlobStore(leaf, { blobDir, thresholdBytes: 20 });
+    const graphSet = new GraphSetIndexStore(literal, {
+      onMutation: (event) => graphEvents.push(event),
+    });
+    const changelog = new ChangelogStore(graphSet, {
+      onAppend: (event) => changelogEvents.push(event),
+    });
+    const options = { source: 'composition.noop' };
+    const generation = leaf.getWriteGen(GRAPH);
+
+    try {
+      await changelog.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: GRAPH, subjects: [] },
+      }, options);
+
+      expect(leafMutation).toHaveBeenCalledOnce();
+      expect(leafMutation.mock.calls[0][1]).toBe(options);
+      expect(update).not.toHaveBeenCalled();
+      expect(query).not.toHaveBeenCalled();
+      expect(hasGraph).not.toHaveBeenCalled();
+      expect(graphEvents).toEqual([]);
+      expect(changelogEvents).toEqual([]);
+      expect(leaf.getWriteGen(GRAPH)).toBe(generation);
+
+      leafMutation.mockClear();
+      await expect(changelog.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: CHANGELOG_GRAPH, subjects: [] },
+      })).rejects.toThrow(/reserved changelog plane/);
+      expect(leafMutation).not.toHaveBeenCalled();
+
+      const neutral = new GraphSetIndexStore(literal);
+      await expect(neutral.structuredMutation({
+        kind: 'delete-subjects',
+        input: { graphUri: CHANGELOG_GRAPH, subjects: [] },
+      })).resolves.toBeUndefined();
+      expect(leafMutation).toHaveBeenCalledOnce();
+      expect(update).not.toHaveBeenCalled();
+    } finally {
+      await changelog.close();
+    }
+  });
+
+  it('externalizes an over-budget literal before final validation through the full stack', async () => {
+    const blobDir = await mkdtemp(join(tmpdir(), 'structured-mutation-large-composition-'));
+    tempDirs.push(blobDir);
+    const leaf = new OxigraphStore();
+    const leafMutation = vi.spyOn(leaf, 'structuredMutation');
+    const literal = new SharedMemoryLiteralBlobStore(leaf, { blobDir, thresholdBytes: 20 });
+    const graphSet = new GraphSetIndexStore(literal);
+    const changelog = new ChangelogStore(graphSet);
+    const subject = 'urn:test:composition:large-subject';
+    const largeLiteral = `"${'x'.repeat(BOUNDED_MUTATION_MAX_OPERAND_BYTES + 1)}"`;
+
+    try {
+      await changelog.structuredMutation({
+        kind: 'replace-subject-predicates',
+        input: {
+          graphUri: SWM_GRAPH,
+          subject,
+          predicates: [PREDICATE],
+          replacementQuads: [{
+            subject,
+            predicate: PREDICATE,
+            object: largeLiteral,
+            graph: SWM_GRAPH,
+          }],
+        },
+      });
+
+      expect(leafMutation).toHaveBeenCalledOnce();
+      const forwarded = leafMutation.mock.calls[0][0];
+      expect(forwarded.kind).toBe('replace-subject-predicates');
+      if (forwarded.kind !== 'replace-subject-predicates') return;
+      expect(forwarded.input.replacementQuads[0].object).toBe(
+        `"sha256:${sha256(largeLiteral)}"^^<${EXTERNAL_LITERAL_REF_DATATYPE}>`,
+      );
+      expect(await leaf.hasGraph(SWM_GRAPH)).toBe(true);
+      expect(changelog.needsReconcile).toBe(false);
+    } finally {
+      await changelog.close();
+    }
+  });
+});

--- a/packages/storage/test/structured-mutation-preparation.test.ts
+++ b/packages/storage/test/structured-mutation-preparation.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildStructuredMutationUpdate,
+  captureStructuredMutationEffects,
+  captureStructuredMutationSnapshot,
+  type StructuredMutationSnapshot,
+} from '../src/bounded-structured-mutation.js';
+import { materializeStructuredMutation } from '../src/structured-mutation-materialization-internal.js';
+import type { StructuredMutation } from '../src/triple-store.js';
+
+const GRAPH = 'urn:test:preparation';
+const TARGET = 'urn:test:preparation:target';
+const PREDICATE = 'urn:test:preparation:predicate';
+
+function deleteMutation(subjects: readonly string[] = ['urn:test:subject']): StructuredMutation {
+  return { kind: 'delete-subjects', input: { graphUri: GRAPH, subjects } };
+}
+
+describe('structured mutation preparation', () => {
+  it('captures one deeply frozen caller-independent snapshot and reuses its identity', () => {
+    const subjects = ['urn:test:subject'];
+    const mutation = deleteMutation(subjects);
+    const snapshot = captureStructuredMutationSnapshot(mutation);
+
+    subjects[0] = 'urn:test:redirected';
+    expect(snapshot.mutation).toEqual({
+      kind: 'delete-subjects',
+      input: { graphUri: GRAPH, subjects: ['urn:test:subject'] },
+    });
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.mutation)).toBe(true);
+    expect(Object.isFrozen(snapshot.mutation.input)).toBe(true);
+    expect(snapshot.mutation.kind === 'delete-subjects'
+      && Object.isFrozen(snapshot.mutation.input.subjects)).toBe(true);
+    expect(captureStructuredMutationSnapshot(snapshot.mutation)).toBe(snapshot);
+    expect(captureStructuredMutationSnapshot({ ...snapshot.mutation })).not.toBe(snapshot);
+    expect(() => {
+      (snapshot.mutation.input as { graphUri: string }).graphUri = TARGET;
+    }).toThrow(TypeError);
+  });
+
+  it('keeps final backend materialization off the package-root surface', async () => {
+    const storage = await import('../src/index.js');
+    expect('materializeStructuredMutation' in storage).toBe(false);
+  });
+
+  it('reads accessor-backed descriptors and proxy-array entries exactly once', () => {
+    const reads = new Map<string, number>();
+    const read = <T>(key: string, value: T): T => {
+      reads.set(key, (reads.get(key) ?? 0) + 1);
+      return value;
+    };
+    const subjects = new Proxy(['urn:test:subject'], {
+      get(target, property, receiver) {
+        if (property === 'length' || property === '0') read(`subjects.${String(property)}`, null);
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const input = Object.defineProperties({}, {
+      graphUri: { enumerable: true, get: () => read('graphUri', GRAPH) },
+      subjects: { enumerable: true, get: () => read('subjects', subjects) },
+    });
+    const mutation = Object.defineProperties({}, {
+      kind: { enumerable: true, get: () => read('kind', 'delete-subjects') },
+      input: { enumerable: true, get: () => read('input', input) },
+    }) as StructuredMutation;
+
+    const snapshot = captureStructuredMutationSnapshot(mutation);
+
+    expect(snapshot.mutation).toEqual(deleteMutation());
+    expect(Object.fromEntries(reads)).toEqual({
+      kind: 1,
+      input: 1,
+      graphUri: 1,
+      subjects: 1,
+      'subjects.length': 1,
+      'subjects.0': 1,
+    });
+  });
+
+  it('copies exact quad fields and cannot be redirected after capture', () => {
+    const quad = {
+      subject: 'urn:test:subject',
+      predicate: PREDICATE,
+      object: '"before"',
+      graph: GRAPH,
+      ignored: 'caller-only',
+    };
+    const snapshot = captureStructuredMutationSnapshot({
+      kind: 'replace-subject-predicates',
+      input: {
+        graphUri: GRAPH,
+        subject: quad.subject,
+        predicates: [PREDICATE],
+        replacementQuads: [quad],
+      },
+    });
+    quad.object = '"after"';
+    quad.graph = TARGET;
+
+    expect(snapshot.mutation.kind).toBe('replace-subject-predicates');
+    if (snapshot.mutation.kind !== 'replace-subject-predicates') return;
+    expect(snapshot.mutation.input.replacementQuads).toEqual([{
+      subject: 'urn:test:subject',
+      predicate: PREDICATE,
+      object: '"before"',
+      graph: GRAPH,
+    }]);
+    expect(Object.isFrozen(snapshot.mutation.input.replacementQuads[0])).toBe(true);
+    expect('ignored' in snapshot.mutation.input.replacementQuads[0]).toBe(false);
+  });
+
+  it('materializes every trusted snapshot without replacing its operands', () => {
+    const mutations: StructuredMutation[] = [
+      deleteMutation(),
+      { kind: 'prune-ranked-subjects', input: {
+        graphUri: GRAPH,
+        subjectPrefix: 'urn:test:ranked:',
+        eligibilityPredicate: PREDICATE,
+        eligibleObjects: ['approved'],
+        primaryRankPredicate: 'urn:test:rank:primary',
+        secondaryRankPredicate: 'urn:test:rank:secondary',
+        retainNewest: 1,
+        maxDelete: 1,
+      } },
+      { kind: 'prune-linked-record-closures', input: {
+        graphUri: GRAPH,
+        matchObjectIris: ['urn:test:agent'],
+        linkPredicates: [PREDICATE],
+        recordParentPredicate: 'urn:test:parent',
+        descendantSeparator: '/',
+      } },
+      { kind: 'replace-subject-predicates', input: {
+        graphUri: GRAPH,
+        subject: 'urn:test:subject',
+        predicates: [PREDICATE],
+        replacementQuads: [{
+          subject: 'urn:test:subject', predicate: PREDICATE, object: '"value"', graph: GRAPH,
+        }],
+      } },
+      { kind: 'replace-projection-from-graph', input: {
+        targetGraphUri: TARGET,
+        stagingGraphUri: 'urn:test:preparation:staging',
+        targetSubject: 'urn:test:subject',
+        preservedTargetPredicates: [PREDICATE],
+        targetSubjectPrefixes: [],
+      } },
+      { kind: 'copy-subject-projection', input: {
+        sourceGraphUris: [GRAPH],
+        targetGraphUri: TARGET,
+        roots: ['urn:test:subject'],
+        descendantSuffix: '/',
+        excludedPredicates: [],
+      } },
+    ];
+
+    for (const mutation of mutations) {
+      const snapshot = captureStructuredMutationSnapshot(mutation);
+      const capturedInput = snapshot.mutation.input;
+      const materialized = materializeStructuredMutation(snapshot);
+      expect(materialized.outcome).toBe('execute');
+      if (materialized.outcome !== 'execute') continue;
+      expect(materialized.snapshot).toBe(snapshot);
+      expect(materialized.snapshot.mutation.input).toBe(capturedInput);
+      expect(materialized.update).toBe(buildStructuredMutationUpdate(mutation));
+    }
+  });
+
+  it('classifies no-op only after trusted deferred validation', () => {
+    const snapshot = captureStructuredMutationSnapshot(deleteMutation([]));
+    expect(snapshot.outcome).toBe('noop');
+    expect(snapshot.effects).toBeUndefined();
+    expect(materializeStructuredMutation(snapshot)).toEqual({ outcome: 'noop', snapshot });
+  });
+
+  it('rejects copied or forged snapshots at the internal materialization boundary', () => {
+    const snapshot = captureStructuredMutationSnapshot(deleteMutation());
+    const copied = { ...snapshot } as StructuredMutationSnapshot;
+    const forged = {
+      ...snapshot,
+      mutation: { ...snapshot.mutation },
+    } as StructuredMutationSnapshot;
+
+    expect(() => materializeStructuredMutation(copied)).toThrow(/not trusted/);
+    expect(() => materializeStructuredMutation(forged)).toThrow(/not trusted/);
+  });
+
+  it('defers the aggregate replacement budget until after snapshot capture', () => {
+    const object = JSON.stringify('x'.repeat(4 * 1024 * 1024));
+    const snapshot = captureStructuredMutationSnapshot({
+      kind: 'replace-subject-predicates',
+      input: {
+        graphUri: GRAPH,
+        subject: 'urn:test:subject',
+        predicates: [PREDICATE],
+        replacementQuads: [{
+          subject: 'urn:test:subject', predicate: PREDICATE, object, graph: GRAPH,
+        }],
+      },
+    });
+
+    expect(snapshot.outcome).toBe('candidate');
+    expect(() => materializeStructuredMutation(snapshot)).toThrow(/operand bytes/);
+  });
+
+  it('preserves the non-validating synchronous effects compatibility helper', () => {
+    const malformed = {
+      kind: 'delete-subjects',
+      input: { graphUri: 'relative', subjects: [] },
+    } as StructuredMutation;
+    expect(captureStructuredMutationEffects(malformed)).toBeUndefined();
+    expect(() => captureStructuredMutationSnapshot(malformed)).toThrow(/absolute IRI/);
+  });
+});

--- a/packages/storage/test/structured-mutation-preparation.test.ts
+++ b/packages/storage/test/structured-mutation-preparation.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
+  BOUNDED_MUTATION_MAX_SOURCE_GRAPHS,
   buildStructuredMutationUpdate,
   captureStructuredMutationEffects,
   captureStructuredMutationSnapshot,
   type StructuredMutationSnapshot,
 } from '../src/bounded-structured-mutation.js';
+import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
 import { materializeStructuredMutation } from '../src/structured-mutation-materialization-internal.js';
-import type { StructuredMutation } from '../src/triple-store.js';
+import type { StructuredMutation, TripleStore } from '../src/triple-store.js';
 
 const GRAPH = 'urn:test:preparation';
 const TARGET = 'urn:test:preparation:target';
@@ -212,4 +214,100 @@ describe('structured mutation preparation', () => {
     expect(captureStructuredMutationEffects(malformed)).toBeUndefined();
     expect(() => captureStructuredMutationSnapshot(malformed)).toThrow(/absolute IRI/);
   });
+
+  it.each(invalidSnapshotDescriptors())(
+    'rejects the $name descriptor through snapshot capture',
+    ({ mutation, expected }) => {
+      expect(() => captureStructuredMutationSnapshot(mutation)).toThrow(expected);
+    },
+  );
+
+  it('rejects an invalid descriptor in a decorator before inner I/O', async () => {
+    const operation = vi.fn(async () => {});
+    const store = new GraphSetIndexStore({
+      structuredMutation: operation,
+    } as unknown as TripleStore);
+
+    await expect(store.structuredMutation({
+      kind: 'copy-subject-projection',
+      input: {
+        sourceGraphUris: [GRAPH],
+        targetGraphUri: GRAPH,
+        roots: ['urn:test:subject'],
+        descendantSuffix: '/',
+        excludedPredicates: [],
+      },
+    })).rejects.toThrow(/must not be a source/);
+    expect(operation).not.toHaveBeenCalled();
+  });
 });
+
+function invalidSnapshotDescriptors(): Array<{
+  name: string;
+  mutation: StructuredMutation;
+  expected: RegExp;
+}> {
+  const sparseSubjects = Array(2) as string[];
+  sparseSubjects[1] = 'urn:test:subject';
+  return [
+    {
+      name: 'sparse',
+      mutation: deleteMutation(sparseSubjects),
+      expected: /dense array/,
+    },
+    {
+      name: 'duplicate',
+      mutation: deleteMutation(['urn:test:subject', 'urn:test:subject']),
+      expected: /duplicate/,
+    },
+    {
+      name: 'oversized',
+      mutation: {
+        kind: 'copy-subject-projection',
+        input: {
+          sourceGraphUris: Array.from(
+            { length: BOUNDED_MUTATION_MAX_SOURCE_GRAPHS + 1 },
+            (_, index) => `urn:test:source:${index}`,
+          ),
+          targetGraphUri: TARGET,
+          roots: ['urn:test:subject'],
+          descendantSuffix: '/',
+          excludedPredicates: [],
+        },
+      },
+      expected: /must contain/,
+    },
+    {
+      name: 'cross-scope',
+      mutation: {
+        kind: 'replace-subject-predicates',
+        input: {
+          graphUri: GRAPH,
+          subject: 'urn:test:subject',
+          predicates: [PREDICATE],
+          replacementQuads: [{
+            subject: 'urn:test:subject',
+            predicate: PREDICATE,
+            object: '"value"',
+            graph: TARGET,
+          }],
+        },
+      },
+      expected: /must target subject/,
+    },
+    {
+      name: 'same source and target',
+      mutation: {
+        kind: 'copy-subject-projection',
+        input: {
+          sourceGraphUris: [GRAPH],
+          targetGraphUri: GRAPH,
+          roots: ['urn:test:subject'],
+          descendantSuffix: '/',
+          excludedPredicates: [],
+        },
+      },
+      expected: /must not be a source/,
+    },
+  ];
+}

--- a/packages/storage/test/structured-mutation-preparation.test.ts
+++ b/packages/storage/test/structured-mutation-preparation.test.ts
@@ -8,6 +8,7 @@ import {
   type StructuredMutationSnapshot,
 } from '../src/bounded-structured-mutation.js';
 import { GraphSetIndexStore } from '../src/graph-set-index-store.js';
+import { CHANGELOG_GRAPH, ChangelogStore } from '../src/changelog-store.js';
 import { materializeStructuredMutation } from '../src/structured-mutation-materialization-internal.js';
 import type { StructuredMutation, TripleStore } from '../src/triple-store.js';
 
@@ -238,6 +239,69 @@ describe('structured mutation preparation', () => {
         excludedPredicates: [],
       },
     })).rejects.toThrow(/must not be a source/);
+    expect(operation).not.toHaveBeenCalled();
+  });
+
+  it('separates multi-graph guarded scopes from target-only effects', () => {
+    const copy = captureStructuredMutationSnapshot({
+      kind: 'copy-subject-projection',
+      input: {
+        sourceGraphUris: [GRAPH, 'urn:test:preparation:source-2'],
+        targetGraphUri: TARGET,
+        roots: ['urn:test:subject'],
+        descendantSuffix: '/',
+        excludedPredicates: [],
+      },
+    });
+    expect(copy.guardedGraphs).toEqual([GRAPH, 'urn:test:preparation:source-2', TARGET]);
+    expect(copy.outcome).toBe('candidate');
+    if (copy.outcome === 'candidate') {
+      expect(copy.effects.touchedGraphs).toEqual([TARGET]);
+    }
+
+    const replacement = captureStructuredMutationSnapshot({
+      kind: 'replace-projection-from-graph',
+      input: {
+        targetGraphUri: TARGET,
+        stagingGraphUri: GRAPH,
+        targetSubject: 'urn:test:subject',
+        preservedTargetPredicates: [],
+        targetSubjectPrefixes: [],
+      },
+    });
+    expect(replacement.guardedGraphs).toEqual([TARGET, GRAPH]);
+    expect(replacement.outcome).toBe('candidate');
+    if (replacement.outcome === 'candidate') {
+      expect(replacement.effects.touchedGraphs).toEqual([TARGET]);
+    }
+  });
+
+  it('rejects reserved multi-graph sources and staging graphs before inner I/O', async () => {
+    const operation = vi.fn(async () => {});
+    const store = new ChangelogStore({
+      structuredMutation: operation,
+    } as unknown as TripleStore);
+
+    await expect(store.structuredMutation({
+      kind: 'copy-subject-projection',
+      input: {
+        sourceGraphUris: [CHANGELOG_GRAPH],
+        targetGraphUri: TARGET,
+        roots: ['urn:test:subject'],
+        descendantSuffix: '/',
+        excludedPredicates: [],
+      },
+    })).rejects.toThrow(/reserved changelog plane/);
+    await expect(store.structuredMutation({
+      kind: 'replace-projection-from-graph',
+      input: {
+        targetGraphUri: TARGET,
+        stagingGraphUri: CHANGELOG_GRAPH,
+        targetSubject: 'urn:test:subject',
+        preservedTargetPredicates: [],
+        targetSubjectPrefixes: [],
+      },
+    })).rejects.toThrow(/reserved changelog plane/);
     expect(operation).not.toHaveBeenCalled();
   });
 });

--- a/packages/storage/test/structured-mutation-snapshot.typetest.ts
+++ b/packages/storage/test/structured-mutation-snapshot.typetest.ts
@@ -15,6 +15,14 @@ const snapshot = captureStructuredMutationSnapshot({
   },
 });
 
+if (snapshot.outcome === 'noop') {
+  const effects: undefined = snapshot.effects;
+  void effects;
+} else {
+  const touchedGraphs: readonly string[] = snapshot.effects.touchedGraphs;
+  void touchedGraphs;
+}
+
 if (snapshot.mutation.kind === 'replace-subject-predicates') {
   // @ts-expect-error snapshot input fields are immutable
   snapshot.mutation.input.graphUri = 'urn:test:redirected';

--- a/packages/storage/test/structured-mutation-snapshot.typetest.ts
+++ b/packages/storage/test/structured-mutation-snapshot.typetest.ts
@@ -1,0 +1,35 @@
+import { captureStructuredMutationSnapshot } from '../src/index.js';
+
+const snapshot = captureStructuredMutationSnapshot({
+  kind: 'replace-subject-predicates',
+  input: {
+    graphUri: 'urn:test:graph',
+    subject: 'urn:test:subject',
+    predicates: ['urn:test:predicate'],
+    replacementQuads: [{
+      subject: 'urn:test:subject',
+      predicate: 'urn:test:predicate',
+      object: '"value"',
+      graph: 'urn:test:graph',
+    }],
+  },
+});
+
+if (snapshot.mutation.kind === 'replace-subject-predicates') {
+  // @ts-expect-error snapshot input fields are immutable
+  snapshot.mutation.input.graphUri = 'urn:test:redirected';
+  // @ts-expect-error snapshot arrays are immutable
+  snapshot.mutation.input.predicates[0] = 'urn:test:redirected';
+  // @ts-expect-error snapshot quad fields are immutable
+  snapshot.mutation.input.replacementQuads[0].object = '"redirected"';
+  // @ts-expect-error snapshot arrays cannot be extended
+  snapshot.mutation.input.replacementQuads.push({
+    subject: 'urn:test:subject',
+    predicate: 'urn:test:predicate',
+    object: '"extra"',
+    graph: 'urn:test:graph',
+  });
+}
+
+// @ts-expect-error snapshot mutation tags are immutable
+snapshot.mutation.kind = 'delete-subjects';

--- a/packages/storage/tsconfig.typetests.json
+++ b/packages/storage/tsconfig.typetests.json
@@ -7,7 +7,8 @@
   "include": [
     "src",
     "test/store-control-barrier-contract-v1.test.ts",
-    "test/store-control-barrier-contract-v1.typetest.ts"
+    "test/store-control-barrier-contract-v1.typetest.ts",
+    "test/structured-mutation-snapshot.typetest.ts"
   ],
   "references": [{ "path": "../core" }, { "path": "../rdf-utils" }]
 }


### PR DESCRIPTION
## Summary

- Introduce a deeply immutable, privately trusted structured-mutation snapshot that owns caller isolation, guarded/touched graph effects, and no-op classification while allowing unchanged in-process wrappers to reuse one identity.
- Move deferred operand-budget validation and backend update generation into a Storage-internal materializer, with non-normalizing builders so leaf adapters construct update text once without a second O(N) operand copy.
- Migrate Agent, GraphSet, Changelog, literal-blob, HTTP, Blazegraph, embedded Oxigraph, and worker-backed paths while preserving each owner's capability, reserved-graph, close/drain, lifecycle, and failure-recovery semantics.
- Validate deferred operand budgets for candidates and no-ops before suppressing valid backend/HTTP/worker work, and externalize oversized SWM literals before final bounded materialization.
- Trust only nominal local/worker pre-dispatch refusals; operational no-op failures and forged refusal codes still trigger Changelog reconciliation and GraphSet refresh.
- Add golden-byte, API-boundary, type-contract, full-composition, worker-lifecycle, request-count, and reproducible Node 22 resource gates.

## Related

- Fixes #2208
- Follow-up to #2194 and #2196
- Rebased onto #2206 integration head `dd078f0aa41c7c973b3fa1504050e1caff61db01`
- Found during #2207 review
- Related to #2052

## Diagrams

### Structured mutation preparation

Before:

```mermaid
sequenceDiagram
    participant Caller
    participant Agent
    participant Decorators
    participant Leaf
    participant Backend
    Caller->>Agent: mutable descriptor
    Agent->>Agent: derive effects
    Agent->>Decorators: original descriptor
    Decorators->>Decorators: normalize and derive effects again
    Decorators->>Leaf: copied descriptor
    Leaf->>Leaf: normalize, validate, build update
    Leaf->>Backend: dispatch update or no-op request
```

After:

```mermaid
sequenceDiagram
    participant Caller
    participant Agent
    participant Decorators
    participant Leaf
    participant Backend
    Caller->>Agent: mutable descriptor
    Agent->>Agent: capture immutable snapshot once
    Agent->>Decorators: trusted snapshot mutation
    Decorators->>Decorators: reuse snapshot identity
    Decorators->>Decorators: optional literal rewrite and recapture
    Decorators->>Leaf: prepared mutation
    Leaf->>Leaf: deferred validation and one materialization
    alt executable
        Leaf->>Backend: dispatch one update
    else valid no-op
        Leaf-->>Caller: complete after policy/lifecycle preflight
    end
```

## Files changed

| File | What |
|------|------|
| `packages/storage/src/bounded-structured-mutation.ts` | Add deep-readonly capture, exact single-read copying, effects/no-op observation, private trust, and identity reuse. |
| `packages/storage/src/structured-mutation-materialization-internal.ts` | Add the Storage-internal deferred validation and executable update boundary. |
| `packages/storage/src/structured-mutation/*.ts` | Co-locate canonical capture/normalization, graph semantics, deferred operands, non-normalizing builders, and private refusal identity. |
| `packages/storage/src/adapters/*.ts` | Materialize only at HTTP, Blazegraph, embedded Oxigraph, and worker leaves; preserve policy and lifecycle ordering. |
| `packages/storage/src/{graph-set-index-store,changelog-store,shared-memory-literal-blob-store}.ts` | Reuse prepared mutations and preserve owner-specific maintenance/failure behavior. |
| `packages/agent/src/dkg-agent-base.ts` | Capture before forwarding and consume prepared effects for success-only cache invalidation. |
| `packages/storage/src/index.ts` and pack-gate fixtures | Export only the read-only capture contract and prove materialization is unreachable from supported package subpaths. |
| `packages/storage/scripts/benchmark-structured-mutation.mjs` | Add immutable baseline/compare modes with fresh Node 22 child processes and 10% CPU/heap/RSS gates. |
| `packages/storage/test/*structured-mutation*` and owner tests | Pin golden bytes, trust/type boundaries, caller races, all-kind composition, no-op I/O, literal ordering, and worker terminal states. |
| `packages/agent/test/replace-subject-agent-wrapper.test.ts` | Cover all six kinds, exact options/effects, caller isolation, no-op behavior, and Promise rejection semantics. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core build`
- [x] `pnpm --filter @origintrail-official/dkg-storage build`
- [x] `pnpm --filter @origintrail-official/dkg-storage typecheck:type-contracts`
- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] `pnpm --filter @origintrail-official/dkg-storage test:package-exports` (all properties held; all mutants killed)
- [x] Named Storage matrix excluding separately serialized worker files: 10 files, 318 tests passed
- [x] `test/oxigraph-worker-resilience.test.ts`: 11 tests passed
- [x] `test/oxigraph-worker-respawn.test.ts`: 12 tests passed
- [x] Focused structured-mutation, worker, and recovery matrix: 7 files / 157 tests passed when serialized; worker resilience 11/11 and respawn 12/12 pass in isolation
- [x] Full serialized Storage suite under concurrent host load (`--testTimeout=15000`): 67 files / 1,053 tests passed; 26 configured integration/oracle tests skipped
- [x] Named Agent matrix: 2 files / 22 tests passed
- [x] `pnpm exec tsx scripts/check-managed-store-raw-channels.mjs` (287 reviewed dynamic sites; no raw update or statically mutating query calls)
- [x] `git diff --check`
- [x] Node `v22.22.0`, x64, fixture digest `94aeae872655f5489f105a15c2d88c43912adfdcbb55fa3401e94d453fc850f3`, 100,000 subjects, 10 warmups, 30 trials, 3 fresh processes
- [x] Benchmark Storage-identical base `dd078f0aa41c7c973b3fa1504050e1caff61db01` (same `packages/storage` tree as the `a5c04c257` baseline artifact) -> `f7cbf464c250f30d48888d9b4ca16c094b80a239`: CPU `-53.37%`, retained heap `+0.18%`, max RSS `-6.29%`

The repository's literal `node scripts/check-managed-store-raw-channels.mjs` command cannot map the source module's `.js` specifier to `sparql-lexer.ts` under Node's built-in type stripping; the same checked-in script passes through the repository's installed `tsx` loader as recorded above.
