### PR TITLE
fix(chain): tolerate recovered RPC minority during CG binding

### DIFF
--- a/packages/chain/src/evm-context-graph-name-hash-fence.ts
+++ b/packages/chain/src/evm-context-graph-name-hash-fence.ts
@@ -338,19 +338,19 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
     await this.assertScopeCurrent(requestScope, 'current-slot refresh');
 
     let state = previous;
+    let nextState: ContextGraphNameHashSlotState | undefined;
     if (rebuild || staged.length > 0) {
       const idsByHash = rebuild
         ? new Map<string, bigint[]>()
         : cloneIdsByHash(previous?.idsByHash);
       appendSlots(idsByHash, staged, firstId, latestId);
-      state = {
+      nextState = {
         scope: copyScope(requestScope.scope),
         highWater: latestId,
         anchor: nextAnchor,
         idsByHash,
       };
-      this.currentSlotState = state;
-      this.currentSlotGeneration += 1;
+      state = nextState;
     }
 
     const ids = state?.idsByHash.get(normalizedNameHash) ?? [];
@@ -363,6 +363,10 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
     const id = ids[0] ?? null;
 
     const verification = await this.loadProviderHighWaters();
+    this.assertCompleteProviderHighWaterBoundary(
+      verification,
+      'current-slot resolution',
+    );
     if (verification.latestId !== latestId) {
       throw new Error(
         `resolveContextGraphIdByNameHash: Context Graph registry advanced from ` +
@@ -374,8 +378,7 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
       const currentHash = await this.readCurrentNameHash(
         id,
         undefined,
-        verification.providerHighWaters,
-        verification.unavailableProviderCount,
+        verification,
       );
       if (currentHash !== normalizedNameHash) {
         throw new Error(
@@ -387,6 +390,10 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
     }
 
     await this.assertScopeCurrent(requestScope, 'current-slot resolution');
+    if (nextState !== undefined) {
+      this.currentSlotState = nextState;
+      this.currentSlotGeneration += 1;
+    }
     return { mode: 'current', id, highWater: latestId };
   }
 
@@ -410,8 +417,7 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
           const currentHash = await this.readCurrentNameHash(
             contextGraphId,
             scanController.signal,
-            highWaterSnapshot.providerHighWaters,
-            highWaterSnapshot.unavailableProviderCount,
+            highWaterSnapshot,
           );
           slots.push({ id: contextGraphId, nameHash: currentHash });
         } catch (cause) {
@@ -522,6 +528,27 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
   }
 
   /**
+   * A reverse lookup cannot return a positive or negative result while any
+   * configured backend's registry boundary is unknown. Such a backend may
+   * commit a higher numeric id (including a duplicate name hash) than every
+   * responder. Incomplete snapshots may stage bounded slot reads, but only a
+   * complete follow-up boundary may authorize a result or cache commit.
+   */
+  private assertCompleteProviderHighWaterBoundary(
+    snapshot: ContextGraphNameHashProviderHighWaters,
+    lane: 'current-slot resolution' | 'historical scan',
+  ): void {
+    if (snapshot.unavailableProviderCount === 0) return;
+    const providerCount =
+      snapshot.providerHighWaters.size + snapshot.unavailableProviderCount;
+    throw new Error(
+      `resolveContextGraphIdByNameHash: incomplete registry high-water ` +
+      `coverage during ${lane}; ${snapshot.providerHighWaters.size} of ` +
+      `${providerCount} RPC backends responded`,
+    );
+  }
+
+  /**
    * Require a strict majority of providers at or above the slot to respond,
    * while every response agrees (including null). A transiently unavailable
    * backend is not conflicting chain evidence; a deterministic failure is.
@@ -529,18 +556,15 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
   async readCurrentNameHash(
     contextGraphId: bigint,
     signal?: AbortSignal,
-    providerHighWaters?: ReadonlyMap<JsonRpcProvider, bigint>,
-    capturedUnavailableProviderCount = 0,
+    capturedHighWaterSnapshot?: ContextGraphNameHashProviderHighWaters,
   ): Promise<string | null> {
     await this.dependencies.initialize();
     const cgs = this.dependencies.requireContextGraphStorage();
-    const highWaterSnapshot = providerHighWaters === undefined
+    const highWaterSnapshot = capturedHighWaterSnapshot === undefined
       ? await this.loadProviderHighWaters()
-      : undefined;
-    const highWaters = providerHighWaters ?? highWaterSnapshot!.providerHighWaters;
-    const unavailableProviderCount = providerHighWaters === undefined
-      ? highWaterSnapshot!.unavailableProviderCount
-      : capturedUnavailableProviderCount;
+      : capturedHighWaterSnapshot;
+    const highWaters = highWaterSnapshot.providerHighWaters;
+    const { unavailableProviderCount } = highWaterSnapshot;
     const coveringProviders = [...highWaters].filter(
       ([, highWater]) => highWater >= contextGraphId,
     );
@@ -611,6 +635,10 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
     );
     const assertHistoricalRegistryCurrent = async (): Promise<void> => {
       const currentBoundary = await this.loadProviderHighWaters();
+      this.assertCompleteProviderHighWaterBoundary(
+        currentBoundary,
+        'historical scan',
+      );
       if (currentBoundary.latestId !== scannedRegistryHighWater) {
         throw new Error(
           `resolveContextGraphIdByNameHash: registry high-water changed from ` +

--- a/packages/chain/src/evm-context-graph-name-hash-fence.ts
+++ b/packages/chain/src/evm-context-graph-name-hash-fence.ts
@@ -13,6 +13,7 @@ import {
   RPC_READ_STALL_TIMEOUT_MS,
 } from './evm-adapter-constants.js';
 import { withTimeout } from './evm-adapter-rpc.js';
+import { isContractViewRetryable } from './rpc-failover-client.js';
 import { withRpcRequestAbortSignal } from './rpc-request-transport.js';
 
 /**
@@ -98,6 +99,8 @@ export interface EvmContextGraphNameHashFenceDependencies {
 export interface ContextGraphNameHashProviderHighWaters {
   readonly latestId: bigint;
   readonly providerHighWaters: ReadonlyMap<JsonRpcProvider, bigint>;
+  /** Providers whose transient high-water failure leaves slot coverage unknown. */
+  readonly unavailableProviderCount: number;
 }
 
 export interface ContextGraphNameHashScopeToken {
@@ -372,6 +375,7 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
         id,
         undefined,
         verification.providerHighWaters,
+        verification.unavailableProviderCount,
       );
       if (currentHash !== normalizedNameHash) {
         throw new Error(
@@ -407,6 +411,7 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
             contextGraphId,
             scanController.signal,
             highWaterSnapshot.providerHighWaters,
+            highWaterSnapshot.unavailableProviderCount,
           );
           slots.push({ id: contextGraphId, nameHash: currentHash });
         } catch (cause) {
@@ -489,6 +494,17 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
     const failures = reads.filter(
       (result): result is PromiseRejectedResult => result.status === 'rejected',
     );
+    const nonRetryableFailures = failures.filter(
+      (failure) => !isContractViewRetryable(failure.reason),
+    );
+    if (nonRetryableFailures.length > 0) {
+      throw new Error(
+        `resolveContextGraphIdByNameHash: ${nonRetryableFailures.length} of ` +
+        `${providers.length} RPC backends returned a non-retryable registry ` +
+        'high-water failure',
+        { cause: nonRetryableFailures[0]!.reason },
+      );
+    }
     if (providerHighWaters.size === 0) {
       throw failures[0]?.reason ?? new Error(
         'resolveContextGraphIdByNameHash: no RPC backend returned a current registry high-water',
@@ -498,19 +514,33 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
       (maximum, value) => value > maximum ? value : maximum,
       0n,
     );
-    return { latestId, providerHighWaters };
+    return {
+      latestId,
+      providerHighWaters,
+      unavailableProviderCount: failures.length,
+    };
   }
 
-  /** Require every provider at or above the slot to agree, including null. */
+  /**
+   * Require a strict majority of providers at or above the slot to respond,
+   * while every response agrees (including null). A transiently unavailable
+   * backend is not conflicting chain evidence; a deterministic failure is.
+   */
   async readCurrentNameHash(
     contextGraphId: bigint,
     signal?: AbortSignal,
     providerHighWaters?: ReadonlyMap<JsonRpcProvider, bigint>,
+    capturedUnavailableProviderCount = 0,
   ): Promise<string | null> {
     await this.dependencies.initialize();
     const cgs = this.dependencies.requireContextGraphStorage();
-    const highWaters = providerHighWaters
-      ?? (await this.loadProviderHighWaters()).providerHighWaters;
+    const highWaterSnapshot = providerHighWaters === undefined
+      ? await this.loadProviderHighWaters()
+      : undefined;
+    const highWaters = providerHighWaters ?? highWaterSnapshot!.providerHighWaters;
+    const unavailableProviderCount = providerHighWaters === undefined
+      ? highWaterSnapshot!.unavailableProviderCount
+      : capturedUnavailableProviderCount;
     const coveringProviders = [...highWaters].filter(
       ([, highWater]) => highWater >= contextGraphId,
     );
@@ -524,18 +554,27 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
     const failures = reads.filter(
       (result): result is PromiseRejectedResult => result.status === 'rejected',
     );
-    if (failures.length > 0) {
+    const nonRetryableFailures = failures.filter(
+      (failure) => !isContractViewRetryable(failure.reason),
+    );
+    if (nonRetryableFailures.length > 0) {
       throw new Error(
-        `resolveContextGraphIdByNameHash: ${failures.length} of ` +
-        `${coveringProviders.length} covering RPC backends failed to read current slot ` +
-        `${contextGraphId.toString()}`,
-        { cause: failures[0]!.reason },
+        `resolveContextGraphIdByNameHash: ${nonRetryableFailures.length} of ` +
+        `${coveringProviders.length} covering RPC backends returned a non-retryable ` +
+        `failure for current slot ${contextGraphId.toString()}`,
+        { cause: nonRetryableFailures[0]!.reason },
       );
     }
-    if (observed.size === 0) {
+    const fulfilledCount = reads.length - failures.length;
+    const capturedCoveringProviderCount =
+      coveringProviders.length + unavailableProviderCount;
+    const requiredQuorum = Math.floor(capturedCoveringProviderCount / 2) + 1;
+    if (fulfilledCount < requiredQuorum) {
       throw new Error(
-        `resolveContextGraphIdByNameHash: no RPC backend could read slot ` +
-        contextGraphId.toString(),
+        `resolveContextGraphIdByNameHash: insufficient covering RPC quorum for ` +
+        `current slot ${contextGraphId.toString()}; ${fulfilledCount} of ` +
+        `${capturedCoveringProviderCount} backends responded, need ${requiredQuorum}`,
+        { cause: failures[0]?.reason },
       );
     }
     if (observed.size !== 1) {

--- a/packages/chain/test/context-graph-name-hash-cache-invalidation.unit.test.ts
+++ b/packages/chain/test/context-graph-name-hash-cache-invalidation.unit.test.ts
@@ -185,12 +185,14 @@ describe('Context Graph name-hash cache and index invalidation', () => {
     ) => {
       if (method === 'getLatestContextGraphId') return 2n;
       const id = BigInt(args[0] as bigint);
-      if (id === 2n && failDelta) throw new Error('delta RPC failed');
+      if (id === 2n && failDelta) {
+        throw Object.assign(new Error('delta RPC timed out'), { code: 'RPC_TIMEOUT' });
+      }
       return hashes.get(id) ?? ethers.ZeroHash;
     });
 
     await expect(adapter.resolveContextGraphIdByNameHash(OTHER_HASH)).rejects.toThrow(
-      /1 of 1 covering RPC backends failed to read current slot 2/i,
+      /insufficient covering RPC quorum.*0 of 1 backends responded, need 1/i,
     );
     failDelta = false;
     await expect(adapter.resolveContextGraphIdByNameHash(OTHER_HASH)).resolves.toBe(2n);
@@ -270,6 +272,7 @@ describe('Context Graph name-hash cache and index invalidation', () => {
       return {
         latestId: 2n,
         providerHighWaters: new Map([[scenario.adapter.providers[0], 2n]]),
+        unavailableProviderCount: 0,
       };
     });
 

--- a/packages/chain/test/context-graph-name-hash-current-slot.unit.test.ts
+++ b/packages/chain/test/context-graph-name-hash-current-slot.unit.test.ts
@@ -12,6 +12,8 @@ import {
   minimalConfig,
   NAME_HASH,
   OTHER_HASH,
+  providerHighWaterSnapshot,
+  providerQuorumFixture,
   resolverInternals,
 } from './context-graph-name-hash-reverse-resolution.fixtures.js';
 
@@ -50,17 +52,19 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     const { adapter, fence } = fixture([null, NAME_HASH]);
     const enumerationHighWaters = new Map([[{} as any, 2n]]);
     const verificationHighWaters = new Map([[{} as any, 2n]]);
+    const enumerationSnapshot = {
+      latestId: 2n,
+      providerHighWaters: enumerationHighWaters,
+      unavailableProviderCount: 0,
+    };
+    const verificationSnapshot = {
+      latestId: 2n,
+      providerHighWaters: verificationHighWaters,
+      unavailableProviderCount: 0,
+    };
     vi.spyOn(fence, 'loadProviderHighWaters')
-      .mockResolvedValueOnce({
-        latestId: 2n,
-        providerHighWaters: enumerationHighWaters,
-        unavailableProviderCount: 0,
-      })
-      .mockResolvedValueOnce({
-        latestId: 2n,
-        providerHighWaters: verificationHighWaters,
-        unavailableProviderCount: 0,
-      });
+      .mockResolvedValueOnce(enumerationSnapshot)
+      .mockResolvedValueOnce(verificationSnapshot);
     const slotReader = vi.spyOn(fence, 'readCurrentNameHash').mockImplementation(
       async (id) => id === 2n ? NAME_HASH : null,
     );
@@ -71,9 +75,9 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
       (call) => call[1] instanceof AbortSignal,
     );
     expect(rangeReads).toHaveLength(2);
-    expect(rangeReads.every((call) => call[2] === enumerationHighWaters)).toBe(true);
+    expect(rangeReads.every((call) => call[2] === enumerationSnapshot)).toBe(true);
     const exactRead = slotReader.mock.calls.find((call) => call[1] === undefined);
-    expect(exactRead?.[2]).toBe(verificationHighWaters);
+    expect(exactRead?.[2]).toBe(verificationSnapshot);
   });
 
   it('normalizes an uppercase bytes32 input before current-slot comparison', async () => {
@@ -125,74 +129,59 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     expect(callsForMethod(readContractWithOptions, 'getLatestContextGraphId')).toHaveLength(4);
     expect(callsForMethod(readContractWithOptions, 'getNameHash').map(
       (call) => BigInt(call[3][0]),
-    )).toEqual([1n, 2n, 2n]);
+    )).toEqual([1n, 1n, 2n, 2n]);
   });
 
   it('does not let a lower-high-water RPC hide a slot from a current backend', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
     const primary = { id: 'lagging' };
     const backup = { id: 'current' };
-    const storage = { getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6') };
-    adapter.contracts = { contextGraphStorage: storage };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getNameHash: vi.fn(async () => provider === primary ? ethers.ZeroHash : NAME_HASH),
-    }));
-    const { fence } = resolverInternals(adapter);
+    const { adapter, fence } = providerQuorumFixture({
+      providers: [primary, backup],
+      readNameHash: async (provider) => provider === primary ? ethers.ZeroHash : NAME_HASH,
+    });
 
     await expect(fence.readCurrentNameHash(
       1n,
       undefined,
-      new Map([[primary, 0n], [backup, 1n]]),
+      providerHighWaterSnapshot([[primary, 0n], [backup, 1n]]),
     )).resolves.toBe(NAME_HASH);
     expect(adapter.rebindContract).toHaveBeenCalledTimes(1);
   });
 
   it('fails closed when same-high-water RPCs disagree on a current slot', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
     const primary = { id: 'fork-a' };
     const backup = { id: 'fork-b' };
-    const storage = { getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6') };
-    adapter.contracts = { contextGraphStorage: storage };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getNameHash: vi.fn(async () => provider === primary ? ethers.ZeroHash : NAME_HASH),
-    }));
-    const { fence } = resolverInternals(adapter);
+    const { fence } = providerQuorumFixture({
+      providers: [primary, backup],
+      readNameHash: async (provider) => provider === primary ? ethers.ZeroHash : NAME_HASH,
+    });
 
     await expect(fence.readCurrentNameHash(
       1n,
       undefined,
-      new Map([[primary, 1n], [backup, 1n]]),
+      providerHighWaterSnapshot([[primary, 1n], [backup, 1n]]),
     )).rejects.toThrow(
       /RPC backends disagree on current slot 1/i,
     );
   });
 
   it('fails closed when one of two covering RPCs is transiently unavailable', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
     const failing = { id: 'failing' };
     const responding = { id: 'responding' };
-    const storage = { getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6') };
-    adapter.contracts = { contextGraphStorage: storage };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getNameHash: vi.fn(async () => {
+    const { adapter, fence } = providerQuorumFixture({
+      providers: [failing, responding],
+      readNameHash: async (provider) => {
         if (provider === failing) {
           throw Object.assign(new Error('slot read timed out'), { code: 'RPC_TIMEOUT' });
         }
         return ethers.ZeroHash;
-      }),
-    }));
-    const { fence } = resolverInternals(adapter);
+      },
+    });
 
     await expect(fence.readCurrentNameHash(
       2n,
       undefined,
-      new Map([[failing, 2n], [responding, 2n]]),
+      providerHighWaterSnapshot([[failing, 2n], [responding, 2n]]),
     )).rejects.toThrow(
       /insufficient covering RPC quorum.*1 of 2 backends responded, need 2/i,
     );
@@ -212,28 +201,21 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     _failureKind,
     createFailure,
   ) => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
     const unavailable = { id: 'unavailable' };
     const respondingA = { id: 'responding-a' };
     const respondingB = { id: 'responding-b' };
-    const storage = {
-      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-    };
-    adapter.contracts = { contextGraphStorage: storage };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getNameHash: vi.fn(async () => {
+    const { fence } = providerQuorumFixture({
+      providers: [unavailable, respondingA, respondingB],
+      readNameHash: async (provider) => {
         if (provider === unavailable) throw createFailure();
         return NAME_HASH;
-      }),
-    }));
-    const { fence } = resolverInternals(adapter);
+      },
+    });
 
     await expect(fence.readCurrentNameHash(
       2n,
       undefined,
-      new Map([
+      providerHighWaterSnapshot([
         [unavailable, 2n],
         [respondingA, 2n],
         [respondingB, 2n],
@@ -242,30 +224,23 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
   });
 
   it('fails closed when two of three covering RPCs are transiently unavailable', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
     const unavailableA = { id: 'unavailable-a' };
     const unavailableB = { id: 'unavailable-b' };
     const responding = { id: 'responding' };
-    const storage = {
-      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-    };
-    adapter.contracts = { contextGraphStorage: storage };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getNameHash: vi.fn(async () => {
+    const { fence } = providerQuorumFixture({
+      providers: [unavailableA, unavailableB, responding],
+      readNameHash: async (provider) => {
         if (provider !== responding) {
           throw Object.assign(new Error('slot read timed out'), { code: 'RPC_TIMEOUT' });
         }
         return NAME_HASH;
-      }),
-    }));
-    const { fence } = resolverInternals(adapter);
+      },
+    });
 
     await expect(fence.readCurrentNameHash(
       2n,
       undefined,
-      new Map([
+      providerHighWaterSnapshot([
         [unavailableA, 2n],
         [unavailableB, 2n],
         [responding, 2n],
@@ -275,65 +250,30 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     );
   });
 
-  it('fails closed on a non-retryable provider error despite an agreeing majority', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
+  it.each([
+    ['CALL_EXCEPTION', 'execution reverted'],
+    ['BAD_DATA', 'could not decode result data'],
+  ])('fails closed on non-retryable slot %s despite an agreeing majority', async (
+    code,
+    message,
+  ) => {
     const invalid = { id: 'invalid' };
     const respondingA = { id: 'responding-a' };
     const respondingB = { id: 'responding-b' };
-    const storage = {
-      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-    };
-    adapter.contracts = { contextGraphStorage: storage };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getNameHash: vi.fn(async () => {
+    const { fence } = providerQuorumFixture({
+      providers: [invalid, respondingA, respondingB],
+      readNameHash: async (provider) => {
         if (provider === invalid) {
-          throw Object.assign(new Error('execution reverted'), { code: 'CALL_EXCEPTION' });
+          throw Object.assign(new Error(message), { code });
         }
         return NAME_HASH;
-      }),
-    }));
-    const { fence } = resolverInternals(adapter);
+      },
+    });
 
     await expect(fence.readCurrentNameHash(
       2n,
       undefined,
-      new Map([
-        [invalid, 2n],
-        [respondingA, 2n],
-        [respondingB, 2n],
-      ]),
-    )).rejects.toThrow(
-      /non-retryable failure for current slot 2/i,
-    );
-  });
-
-  it('fails closed on slot BAD_DATA despite a two-of-three agreeing majority', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
-    const invalid = { id: 'bad-data' };
-    const respondingA = { id: 'responding-a' };
-    const respondingB = { id: 'responding-b' };
-    const storage = {
-      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-    };
-    adapter.contracts = { contextGraphStorage: storage };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getNameHash: vi.fn(async () => {
-        if (provider === invalid) {
-          throw Object.assign(new Error('could not decode result data'), { code: 'BAD_DATA' });
-        }
-        return NAME_HASH;
-      }),
-    }));
-    const { fence } = resolverInternals(adapter);
-
-    await expect(fence.readCurrentNameHash(
-      2n,
-      undefined,
-      new Map([
+      providerHighWaterSnapshot([
         [invalid, 2n],
         [respondingA, 2n],
         [respondingB, 2n],
@@ -344,30 +284,23 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
   });
 
   it('fails closed when fulfilled RPCs disagree despite reaching quorum', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
     const unavailable = { id: 'unavailable' };
     const forkA = { id: 'fork-a' };
     const forkB = { id: 'fork-b' };
-    const storage = {
-      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-    };
-    adapter.contracts = { contextGraphStorage: storage };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getNameHash: vi.fn(async () => {
+    const { fence } = providerQuorumFixture({
+      providers: [unavailable, forkA, forkB],
+      readNameHash: async (provider) => {
         if (provider === unavailable) {
           throw Object.assign(new Error('slot read timed out'), { code: 'RPC_TIMEOUT' });
         }
         return provider === forkA ? NAME_HASH : OTHER_HASH;
-      }),
-    }));
-    const { fence } = resolverInternals(adapter);
+      },
+    });
 
     await expect(fence.readCurrentNameHash(
       2n,
       undefined,
-      new Map([
+      providerHighWaterSnapshot([
         [unavailable, 2n],
         [forkA, 2n],
         [forkB, 2n],
@@ -396,7 +329,7 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     const read = fence.readCurrentNameHash(
       1n,
       controller.signal,
-      new Map([[provider, 1n]]),
+      providerHighWaterSnapshot([[provider, 1n]]),
     );
     await started.promise;
     controller.abort(new Error('sibling slot failed'));
@@ -404,84 +337,90 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     await expect(read).rejects.toThrow('sibling slot failed');
   });
 
-  it('keeps one transient high-water failure in a three-provider quorum', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
+  it('accepts a transient initial high-water failure after complete verification', async () => {
     const unavailable = { id: 'unavailable' };
     const respondingA = { id: 'responding-a' };
     const respondingB = { id: 'responding-b' };
-    adapter.providers = [unavailable, respondingA, respondingB];
-    adapter.rpcUrls = [
-      'http://unavailable.invalid',
-      'http://responding-a.invalid',
-      'http://responding-b.invalid',
-    ];
-    adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
-    adapter.contracts = {
-      contextGraphStorage: {
-        getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-      },
-    };
-    const getLatestContextGraphId = vi.fn(async (provider: unknown) => {
-      if (provider === unavailable) {
-        throw Object.assign(new Error('high-water timed out'), { code: 'RPC_TIMEOUT' });
-      }
-      return 1n;
-    });
-    const getNameHash = vi.fn(async () => NAME_HASH);
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getLatestContextGraphId: () => getLatestContextGraphId(provider),
+    let unavailableReads = 0;
+    const {
+      adapter,
+      getLatestContextGraphId,
       getNameHash,
-    }));
-    const anchorHash = `0x${'11'.repeat(32)}`;
-    const { fence } = resolverInternals(adapter);
-    vi.spyOn(fence, 'captureAnchor').mockResolvedValue({
-      blockNumber: 100,
-      blockHash: anchorHash,
+    } = providerQuorumFixture({
+      providers: [unavailable, respondingA, respondingB],
+      readHighWater: async (provider) => {
+        if (provider === unavailable && unavailableReads++ === 0) {
+          throw Object.assign(new Error('high-water timed out'), { code: 'RPC_TIMEOUT' });
+        }
+        return 1n;
+      },
+      readNameHash: async () => NAME_HASH,
     });
-    vi.spyOn(fence, 'loadAnchorHash').mockResolvedValue(anchorHash);
 
     await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBe(1n);
     expect(getLatestContextGraphId).toHaveBeenCalledTimes(6);
-    expect(getNameHash).toHaveBeenCalledTimes(4);
+    expect(getNameHash).toHaveBeenCalledTimes(5);
+  });
+
+  it.each([
+    ['zero observed ids', 0n, ethers.ZeroHash],
+    ['a stale null result', 1n, ethers.ZeroHash],
+    ['a stale positive result', 1n, NAME_HASH],
+  ])('fails closed before returning %s while a current backend high-water is unknown', async (
+    _scenario,
+    respondingHighWater,
+    slotHash,
+  ) => {
+    const unavailable = { id: 'unavailable-current-backend' };
+    const laggingA = { id: 'lagging-a' };
+    const laggingB = { id: 'lagging-b' };
+    const { adapter, fence } = providerQuorumFixture({
+      providers: [unavailable, laggingA, laggingB],
+      readHighWater: async (provider) => {
+        if (provider === unavailable) {
+          throw Object.assign(new Error('high-water timed out'), { code: 'RPC_TIMEOUT' });
+        }
+        return respondingHighWater;
+      },
+      readNameHash: async () => slotHash,
+    });
+
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      /incomplete registry high-water coverage during current-slot resolution; 2 of 3/i,
+    );
+    expect(fence.currentSlotRevision).toBe(0);
+  });
+
+  it('keeps the unavailable-provider count attached to the typed high-water snapshot', async () => {
+    const responding = { id: 'responding' };
+    const { fence } = providerQuorumFixture({
+      providers: [responding],
+      readNameHash: async () => NAME_HASH,
+    });
+
+    await expect(fence.readCurrentNameHash(
+      2n,
+      undefined,
+      providerHighWaterSnapshot([[responding, 2n]], 2),
+    )).rejects.toThrow(
+      /insufficient covering RPC quorum.*1 of 3 backends responded, need 2/i,
+    );
   });
 
   it('does not collapse two transient high-water failures into an unsafe one-of-one', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
     const unavailableA = { id: 'unavailable-a' };
     const unavailableB = { id: 'unavailable-b' };
     const responding = { id: 'responding' };
-    adapter.providers = [unavailableA, unavailableB, responding];
-    adapter.rpcUrls = [
-      'http://unavailable-a.invalid',
-      'http://unavailable-b.invalid',
-      'http://responding.invalid',
-    ];
-    adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
-    adapter.contracts = {
-      contextGraphStorage: {
-        getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-      },
-    };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getLatestContextGraphId: async () => {
+    const { adapter, fence } = providerQuorumFixture({
+      providers: [unavailableA, unavailableB, responding],
+      readHighWater: async (provider) => {
         if (provider !== responding) {
           throw Object.assign(new Error('high-water timed out'), { code: 'RPC_TIMEOUT' });
         }
         return 1n;
       },
-      getNameHash: async () => NAME_HASH,
-    }));
-    const anchorHash = `0x${'11'.repeat(32)}`;
-    const { fence } = resolverInternals(adapter);
-    vi.spyOn(fence, 'captureAnchor').mockResolvedValue({
-      blockNumber: 100,
-      blockHash: anchorHash,
+      readNameHash: async () => NAME_HASH,
     });
-    vi.spyOn(fence, 'loadAnchorHash').mockResolvedValue(anchorHash);
 
     await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
       /insufficient covering RPC quorum.*1 of 3 backends responded, need 2/i,
@@ -489,70 +428,26 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     expect(fence.currentSlotRevision).toBe(0);
   });
 
-  it('fails closed on a non-retryable high-water error', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
+  it.each([
+    ['CALL_EXCEPTION', 'execution reverted'],
+    ['BAD_DATA', 'could not decode result data'],
+  ])('fails closed on non-retryable high-water %s despite two agreeing providers', async (
+    code,
+    message,
+  ) => {
     const invalid = { id: 'invalid' };
     const respondingA = { id: 'responding-a' };
     const respondingB = { id: 'responding-b' };
-    adapter.providers = [invalid, respondingA, respondingB];
-    adapter.rpcUrls = [
-      'http://invalid.invalid',
-      'http://responding-a.invalid',
-      'http://responding-b.invalid',
-    ];
-    adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
-    adapter.contracts = {
-      contextGraphStorage: {
-        getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-      },
-    };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getLatestContextGraphId: async () => {
+    const { adapter, fence } = providerQuorumFixture({
+      providers: [invalid, respondingA, respondingB],
+      readHighWater: async (provider) => {
         if (provider === invalid) {
-          throw Object.assign(new Error('execution reverted'), { code: 'CALL_EXCEPTION' });
+          throw Object.assign(new Error(message), { code });
         }
         return 1n;
       },
-    }));
-    const { fence } = resolverInternals(adapter);
-
-    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
-      /non-retryable registry high-water failure/i,
-    );
-    expect(fence.currentSlotRevision).toBe(0);
-  });
-
-  it('fails closed on high-water BAD_DATA despite two agreeing providers', async () => {
-    const adapter: any = new EVMChainAdapter(minimalConfig());
-    adapter.initialized = true;
-    adapter.init = vi.fn(async () => {});
-    const invalid = { id: 'bad-data' };
-    const respondingA = { id: 'responding-a' };
-    const respondingB = { id: 'responding-b' };
-    adapter.providers = [invalid, respondingA, respondingB];
-    adapter.rpcUrls = [
-      'http://invalid.invalid',
-      'http://responding-a.invalid',
-      'http://responding-b.invalid',
-    ];
-    adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
-    adapter.contracts = {
-      contextGraphStorage: {
-        getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
-      },
-    };
-    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
-      getLatestContextGraphId: async () => {
-        if (provider === invalid) {
-          throw Object.assign(new Error('could not decode result data'), { code: 'BAD_DATA' });
-        }
-        return 1n;
-      },
-      getNameHash: async () => NAME_HASH,
-    }));
-    const { fence } = resolverInternals(adapter);
+      readNameHash: async () => NAME_HASH,
+    });
 
     await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
       /non-retryable registry high-water failure/i,
@@ -597,7 +492,7 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     highWaterRelease.resolve(undefined);
     const snapshot = await highWaters;
 
-    const slot = fence.readCurrentNameHash(1n, undefined, snapshot.providerHighWaters);
+    const slot = fence.readCurrentNameHash(1n, undefined, snapshot);
     await vi.waitFor(() => expect(activeSlots).toBe(2));
     slotRelease.resolve(undefined);
     await expect(slot).resolves.toBeNull();

--- a/packages/chain/test/context-graph-name-hash-current-slot.unit.test.ts
+++ b/packages/chain/test/context-graph-name-hash-current-slot.unit.test.ts
@@ -51,8 +51,16 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     const enumerationHighWaters = new Map([[{} as any, 2n]]);
     const verificationHighWaters = new Map([[{} as any, 2n]]);
     vi.spyOn(fence, 'loadProviderHighWaters')
-      .mockResolvedValueOnce({ latestId: 2n, providerHighWaters: enumerationHighWaters })
-      .mockResolvedValueOnce({ latestId: 2n, providerHighWaters: verificationHighWaters });
+      .mockResolvedValueOnce({
+        latestId: 2n,
+        providerHighWaters: enumerationHighWaters,
+        unavailableProviderCount: 0,
+      })
+      .mockResolvedValueOnce({
+        latestId: 2n,
+        providerHighWaters: verificationHighWaters,
+        unavailableProviderCount: 0,
+      });
     const slotReader = vi.spyOn(fence, 'readCurrentNameHash').mockImplementation(
       async (id) => id === 2n ? NAME_HASH : null,
     );
@@ -163,7 +171,7 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     );
   });
 
-  it('fails closed when any covering RPC cannot read the current slot', async () => {
+  it('fails closed when one of two covering RPCs is transiently unavailable', async () => {
     const adapter: any = new EVMChainAdapter(minimalConfig());
     adapter.initialized = true;
     adapter.init = vi.fn(async () => {});
@@ -173,7 +181,9 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     adapter.contracts = { contextGraphStorage: storage };
     adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
       getNameHash: vi.fn(async () => {
-        if (provider === failing) throw new Error('slot read timed out');
+        if (provider === failing) {
+          throw Object.assign(new Error('slot read timed out'), { code: 'RPC_TIMEOUT' });
+        }
         return ethers.ZeroHash;
       }),
     }));
@@ -184,9 +194,187 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
       undefined,
       new Map([[failing, 2n], [responding, 2n]]),
     )).rejects.toThrow(
-      /1 of 2 covering RPC backends failed to read current slot 2/i,
+      /insufficient covering RPC quorum.*1 of 2 backends responded, need 2/i,
     );
     expect(adapter.rebindContract).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [
+      'timeout',
+      () => Object.assign(new Error('slot read timed out'), { code: 'RPC_TIMEOUT' }),
+    ],
+    [
+      'HTTP 429',
+      () => Object.assign(new Error('too many requests'), { status: 429 }),
+    ],
+  ])('accepts a two-of-three agreeing quorum when one RPC has a retryable %s', async (
+    _failureKind,
+    createFailure,
+  ) => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const unavailable = { id: 'unavailable' };
+    const respondingA = { id: 'responding-a' };
+    const respondingB = { id: 'responding-b' };
+    const storage = {
+      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+    };
+    adapter.contracts = { contextGraphStorage: storage };
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getNameHash: vi.fn(async () => {
+        if (provider === unavailable) throw createFailure();
+        return NAME_HASH;
+      }),
+    }));
+    const { fence } = resolverInternals(adapter);
+
+    await expect(fence.readCurrentNameHash(
+      2n,
+      undefined,
+      new Map([
+        [unavailable, 2n],
+        [respondingA, 2n],
+        [respondingB, 2n],
+      ]),
+    )).resolves.toBe(NAME_HASH);
+  });
+
+  it('fails closed when two of three covering RPCs are transiently unavailable', async () => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const unavailableA = { id: 'unavailable-a' };
+    const unavailableB = { id: 'unavailable-b' };
+    const responding = { id: 'responding' };
+    const storage = {
+      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+    };
+    adapter.contracts = { contextGraphStorage: storage };
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getNameHash: vi.fn(async () => {
+        if (provider !== responding) {
+          throw Object.assign(new Error('slot read timed out'), { code: 'RPC_TIMEOUT' });
+        }
+        return NAME_HASH;
+      }),
+    }));
+    const { fence } = resolverInternals(adapter);
+
+    await expect(fence.readCurrentNameHash(
+      2n,
+      undefined,
+      new Map([
+        [unavailableA, 2n],
+        [unavailableB, 2n],
+        [responding, 2n],
+      ]),
+    )).rejects.toThrow(
+      /insufficient covering RPC quorum.*1 of 3 backends responded, need 2/i,
+    );
+  });
+
+  it('fails closed on a non-retryable provider error despite an agreeing majority', async () => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const invalid = { id: 'invalid' };
+    const respondingA = { id: 'responding-a' };
+    const respondingB = { id: 'responding-b' };
+    const storage = {
+      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+    };
+    adapter.contracts = { contextGraphStorage: storage };
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getNameHash: vi.fn(async () => {
+        if (provider === invalid) {
+          throw Object.assign(new Error('execution reverted'), { code: 'CALL_EXCEPTION' });
+        }
+        return NAME_HASH;
+      }),
+    }));
+    const { fence } = resolverInternals(adapter);
+
+    await expect(fence.readCurrentNameHash(
+      2n,
+      undefined,
+      new Map([
+        [invalid, 2n],
+        [respondingA, 2n],
+        [respondingB, 2n],
+      ]),
+    )).rejects.toThrow(
+      /non-retryable failure for current slot 2/i,
+    );
+  });
+
+  it('fails closed on slot BAD_DATA despite a two-of-three agreeing majority', async () => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const invalid = { id: 'bad-data' };
+    const respondingA = { id: 'responding-a' };
+    const respondingB = { id: 'responding-b' };
+    const storage = {
+      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+    };
+    adapter.contracts = { contextGraphStorage: storage };
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getNameHash: vi.fn(async () => {
+        if (provider === invalid) {
+          throw Object.assign(new Error('could not decode result data'), { code: 'BAD_DATA' });
+        }
+        return NAME_HASH;
+      }),
+    }));
+    const { fence } = resolverInternals(adapter);
+
+    await expect(fence.readCurrentNameHash(
+      2n,
+      undefined,
+      new Map([
+        [invalid, 2n],
+        [respondingA, 2n],
+        [respondingB, 2n],
+      ]),
+    )).rejects.toThrow(
+      /non-retryable failure for current slot 2/i,
+    );
+  });
+
+  it('fails closed when fulfilled RPCs disagree despite reaching quorum', async () => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const unavailable = { id: 'unavailable' };
+    const forkA = { id: 'fork-a' };
+    const forkB = { id: 'fork-b' };
+    const storage = {
+      getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+    };
+    adapter.contracts = { contextGraphStorage: storage };
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getNameHash: vi.fn(async () => {
+        if (provider === unavailable) {
+          throw Object.assign(new Error('slot read timed out'), { code: 'RPC_TIMEOUT' });
+        }
+        return provider === forkA ? NAME_HASH : OTHER_HASH;
+      }),
+    }));
+    const { fence } = resolverInternals(adapter);
+
+    await expect(fence.readCurrentNameHash(
+      2n,
+      undefined,
+      new Map([
+        [unavailable, 2n],
+        [forkA, 2n],
+        [forkB, 2n],
+      ]),
+    )).rejects.toThrow(
+      /RPC backends disagree on current slot 2/i,
+    );
   });
 
   it('aborts an in-flight provider slot read instead of waiting for its stall timeout', async () => {
@@ -214,6 +402,162 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     controller.abort(new Error('sibling slot failed'));
 
     await expect(read).rejects.toThrow('sibling slot failed');
+  });
+
+  it('keeps one transient high-water failure in a three-provider quorum', async () => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const unavailable = { id: 'unavailable' };
+    const respondingA = { id: 'responding-a' };
+    const respondingB = { id: 'responding-b' };
+    adapter.providers = [unavailable, respondingA, respondingB];
+    adapter.rpcUrls = [
+      'http://unavailable.invalid',
+      'http://responding-a.invalid',
+      'http://responding-b.invalid',
+    ];
+    adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
+    adapter.contracts = {
+      contextGraphStorage: {
+        getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+      },
+    };
+    const getLatestContextGraphId = vi.fn(async (provider: unknown) => {
+      if (provider === unavailable) {
+        throw Object.assign(new Error('high-water timed out'), { code: 'RPC_TIMEOUT' });
+      }
+      return 1n;
+    });
+    const getNameHash = vi.fn(async () => NAME_HASH);
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getLatestContextGraphId: () => getLatestContextGraphId(provider),
+      getNameHash,
+    }));
+    const anchorHash = `0x${'11'.repeat(32)}`;
+    const { fence } = resolverInternals(adapter);
+    vi.spyOn(fence, 'captureAnchor').mockResolvedValue({
+      blockNumber: 100,
+      blockHash: anchorHash,
+    });
+    vi.spyOn(fence, 'loadAnchorHash').mockResolvedValue(anchorHash);
+
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).resolves.toBe(1n);
+    expect(getLatestContextGraphId).toHaveBeenCalledTimes(6);
+    expect(getNameHash).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not collapse two transient high-water failures into an unsafe one-of-one', async () => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const unavailableA = { id: 'unavailable-a' };
+    const unavailableB = { id: 'unavailable-b' };
+    const responding = { id: 'responding' };
+    adapter.providers = [unavailableA, unavailableB, responding];
+    adapter.rpcUrls = [
+      'http://unavailable-a.invalid',
+      'http://unavailable-b.invalid',
+      'http://responding.invalid',
+    ];
+    adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
+    adapter.contracts = {
+      contextGraphStorage: {
+        getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+      },
+    };
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getLatestContextGraphId: async () => {
+        if (provider !== responding) {
+          throw Object.assign(new Error('high-water timed out'), { code: 'RPC_TIMEOUT' });
+        }
+        return 1n;
+      },
+      getNameHash: async () => NAME_HASH,
+    }));
+    const anchorHash = `0x${'11'.repeat(32)}`;
+    const { fence } = resolverInternals(adapter);
+    vi.spyOn(fence, 'captureAnchor').mockResolvedValue({
+      blockNumber: 100,
+      blockHash: anchorHash,
+    });
+    vi.spyOn(fence, 'loadAnchorHash').mockResolvedValue(anchorHash);
+
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      /insufficient covering RPC quorum.*1 of 3 backends responded, need 2/i,
+    );
+    expect(fence.currentSlotRevision).toBe(0);
+  });
+
+  it('fails closed on a non-retryable high-water error', async () => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const invalid = { id: 'invalid' };
+    const respondingA = { id: 'responding-a' };
+    const respondingB = { id: 'responding-b' };
+    adapter.providers = [invalid, respondingA, respondingB];
+    adapter.rpcUrls = [
+      'http://invalid.invalid',
+      'http://responding-a.invalid',
+      'http://responding-b.invalid',
+    ];
+    adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
+    adapter.contracts = {
+      contextGraphStorage: {
+        getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+      },
+    };
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getLatestContextGraphId: async () => {
+        if (provider === invalid) {
+          throw Object.assign(new Error('execution reverted'), { code: 'CALL_EXCEPTION' });
+        }
+        return 1n;
+      },
+    }));
+    const { fence } = resolverInternals(adapter);
+
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      /non-retryable registry high-water failure/i,
+    );
+    expect(fence.currentSlotRevision).toBe(0);
+  });
+
+  it('fails closed on high-water BAD_DATA despite two agreeing providers', async () => {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = vi.fn(async () => {});
+    const invalid = { id: 'bad-data' };
+    const respondingA = { id: 'responding-a' };
+    const respondingB = { id: 'responding-b' };
+    adapter.providers = [invalid, respondingA, respondingB];
+    adapter.rpcUrls = [
+      'http://invalid.invalid',
+      'http://responding-a.invalid',
+      'http://responding-b.invalid',
+    ];
+    adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
+    adapter.contracts = {
+      contextGraphStorage: {
+        getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+      },
+    };
+    adapter.rebindContract = vi.fn((_contract: unknown, provider: unknown) => ({
+      getLatestContextGraphId: async () => {
+        if (provider === invalid) {
+          throw Object.assign(new Error('could not decode result data'), { code: 'BAD_DATA' });
+        }
+        return 1n;
+      },
+      getNameHash: async () => NAME_HASH,
+    }));
+    const { fence } = resolverInternals(adapter);
+
+    await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      /non-retryable registry high-water failure/i,
+    );
+    expect(fence.currentSlotRevision).toBe(0);
   });
 
   it('fans out provider high-water and covering-slot reads concurrently', async () => {
@@ -346,9 +690,12 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     expect(callsForMethod(readContractWithOptions, 'getNameHash')).toHaveLength(13);
   });
 
-  it('fails closed on any slot read error and aborts sibling failover reads', async () => {
+  it('does not commit a partial index when slot quorum fails and aborts sibling reads', async () => {
     const { adapter, fence, readContractWithOptions } = fixture([null, null, NAME_HASH, null]);
-    const failure = new Error('all RPC endpoints failed getNameHash(2)');
+    const failure = Object.assign(
+      new Error('all RPC endpoints failed getNameHash(2)'),
+      { code: 'RPC_TIMEOUT' },
+    );
     const slotReader = vi.spyOn(fence, 'readCurrentNameHash');
     readContractWithOptions.mockImplementation(async (
       _contract: unknown,
@@ -364,8 +711,9 @@ describe('current-slot Context Graph name-hash reverse resolution', () => {
     });
 
     await expect(adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
-      /1 of 1 covering RPC backends failed to read current slot 2/i,
+      /insufficient covering RPC quorum.*0 of 1 backends responded, need 1/i,
     );
+    expect(fence.currentSlotRevision).toBe(0);
     const observedSignals = slotReader.mock.calls
       .map((call) => call[1])
       .filter((signal): signal is AbortSignal => signal instanceof AbortSignal);

--- a/packages/chain/test/context-graph-name-hash-historical-log.unit.test.ts
+++ b/packages/chain/test/context-graph-name-hash-historical-log.unit.test.ts
@@ -215,6 +215,41 @@ describe('historical Context Graph name-hash reverse resolution', () => {
     );
   });
 
+  it('fails closed when historical slot verification has only one known high-water backend', async () => {
+    const scenario = historicalFixture([[42n]]);
+    const current = { id: 'current' };
+    const unavailableA = { id: 'unavailable-a' };
+    const unavailableB = { id: 'unavailable-b' };
+    const retryableFailure = () => Object.assign(
+      new Error('current high-water timed out'),
+      { code: 'RPC_TIMEOUT' },
+    );
+    scenario.adapter.providers = [current, unavailableA, unavailableB];
+    scenario.adapter.rpcUrls = [
+      'http://current.invalid',
+      'http://unavailable-a.invalid',
+      'http://unavailable-b.invalid',
+    ];
+    scenario.adapter.rebindContract.mockImplementation(
+      (_contract: unknown, provider: unknown) => ({
+        getLatestContextGraphId: async (options?: { blockTag?: number }) => {
+          if (options?.blockTag !== undefined) {
+            return CONTEXT_GRAPH_NAME_HASH_FAST_ENUMERATION_MAX_IDS + 1n;
+          }
+          if (provider !== current) throw retryableFailure();
+          return CONTEXT_GRAPH_NAME_HASH_FAST_ENUMERATION_MAX_IDS + 1n;
+        },
+        getNameHash: scenario.getNameHash,
+      }),
+    );
+
+    await expect(scenario.adapter.resolveContextGraphIdByNameHash(NAME_HASH)).rejects.toThrow(
+      /insufficient covering RPC quorum.*1 of 3 backends responded, need 2/i,
+    );
+    expect(scenario.getNameHash).toHaveBeenCalledTimes(1);
+    expect(scenario.getNameHash).toHaveBeenCalledWith(42n);
+  });
+
   it('discards a historical result when the adapter binding rotates mid-scan', async () => {
     const fixture = historicalFixture([[42n]]);
     fixture.queryEventLogsPage.mockImplementationOnce(async () => {

--- a/packages/chain/test/context-graph-name-hash-reverse-resolution.fixtures.ts
+++ b/packages/chain/test/context-graph-name-hash-reverse-resolution.fixtures.ts
@@ -1,10 +1,13 @@
-import { ethers } from 'ethers';
+import { ethers, type JsonRpcProvider } from 'ethers';
 import { expect, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import {
   CONTEXT_GRAPH_NAME_HASH_FAST_ENUMERATION_MAX_IDS,
 } from '../src/evm-context-graph-name-hash-fence.js';
-import type { EvmContextGraphNameHashFence } from '../src/evm-context-graph-name-hash-fence.js';
+import type {
+  ContextGraphNameHashProviderHighWaters,
+  EvmContextGraphNameHashFence,
+} from '../src/evm-context-graph-name-hash-fence.js';
 
 const PRIVATE_KEY =
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -37,6 +40,74 @@ export function resolverInternals(adapter: any) {
   return {
     resolver,
     fence: resolver.source as EvmContextGraphNameHashFence,
+  };
+}
+
+export function providerHighWaterSnapshot(
+  entries: ReadonlyArray<readonly [object, bigint]>,
+  unavailableProviderCount = 0,
+): ContextGraphNameHashProviderHighWaters {
+  const providerHighWaters = new Map(
+    entries as ReadonlyArray<readonly [JsonRpcProvider, bigint]>,
+  );
+  return {
+    latestId: [...providerHighWaters.values()].reduce(
+      (maximum, value) => value > maximum ? value : maximum,
+      0n,
+    ),
+    providerHighWaters,
+    unavailableProviderCount,
+  };
+}
+
+export function providerQuorumFixture(options: {
+  readonly providers: readonly object[];
+  readonly readHighWater?: (provider: object) => bigint | Promise<bigint>;
+  readonly readNameHash?: (
+    provider: object,
+    contextGraphId: bigint,
+  ) => string | Promise<string>;
+}) {
+  const adapter: any = new EVMChainAdapter(minimalConfig());
+  adapter.initialized = true;
+  adapter.init = vi.fn(async () => {});
+  adapter.providers = [...options.providers];
+  adapter.rpcUrls = options.providers.map(
+    (_provider, index) => `http://provider-${index}.invalid`,
+  );
+  adapter.ensureConfiguredStaticChainIdValidated = vi.fn(async () => 31337n);
+  const storage = {
+    getAddress: vi.fn(async () => '0x00000000000000000000000000000000000000c6'),
+  };
+  adapter.contracts = { contextGraphStorage: storage };
+  const getLatestContextGraphId = vi.fn(async (provider: object) => {
+    if (options.readHighWater === undefined) {
+      throw new Error('Unexpected getLatestContextGraphId read');
+    }
+    return options.readHighWater(provider);
+  });
+  const getNameHash = vi.fn(async (provider: object, contextGraphId: bigint) => {
+    if (options.readNameHash === undefined) {
+      throw new Error('Unexpected getNameHash read');
+    }
+    return options.readNameHash(provider, contextGraphId);
+  });
+  adapter.rebindContract = vi.fn((_contract: unknown, provider: object) => ({
+    getLatestContextGraphId: () => getLatestContextGraphId(provider),
+    getNameHash: (contextGraphId: bigint) => getNameHash(provider, contextGraphId),
+  }));
+  const { fence } = resolverInternals(adapter);
+  const anchorHash = `0x${'11'.repeat(32)}`;
+  vi.spyOn(fence, 'captureAnchor').mockResolvedValue({
+    blockNumber: 100,
+    blockHash: anchorHash,
+  });
+  vi.spyOn(fence, 'loadAnchorHash').mockResolvedValue(anchorHash);
+  return {
+    adapter,
+    fence,
+    getLatestContextGraphId,
+    getNameHash,
   };
 }
 


### PR DESCRIPTION
## Stack dependency

This PR is stacked on #2184 because `testnet-canary` does not yet contain the finalized Context Graph name-hash resolver.

After #2184 merges, retarget this PR to `testnet-canary` before merging. Do not merge the stacked PR independently of #2184.

## User impact

Cold VM / Context Graph name-hash resolution no longer restarts the complete `O(slots × providers)` refresh merely because a minority of public RPC backends times out, disconnects, or returns HTTP 429.

The 2-of-3 rule applies only to per-slot reads. A positive/null resolution and index/cache commit still require every configured backend to answer the final registry high-water fence; persistent minority unavailability remains retryable and fails closed.

For a three-provider configuration, two agreeing covering providers may stage slot work while the third has a retryable transport failure. The refresh does not return a positive/null resolution or commit its index/cache until final high-water verification confirms the complete provider boundary. If the third provider remains unavailable at that boundary, the refresh fails closed and stays retryable. Safety remains fail-closed:

- a strict majority of the captured covering provider set must fulfill the slot read;
- every fulfilled provider must return the same value;
- deterministic contract-view failures such as ethers `BAD_DATA` are non-retryable;
- non-retryable failures, disagreement, or loss of quorum abort the refresh;
- known lagging providers remain excluded for slots they cannot cover;
- providers with a retryable high-water failure remain in the quorum denominator as potentially covering, preventing an unsafe three-to-one provider collapse;
- the existing anchor, scope, abort, and all-or-nothing index/cache commit fences remain intact.

## Before

```mermaid
sequenceDiagram
    participant Agent as DKG Agent
    participant RPC1 as RPC A
    participant RPC2 as RPC B
    participant RPC3 as RPC C
    Agent->>RPC1: Read registry high-water and slot
    Agent->>RPC2: Read registry high-water and slot
    Agent->>RPC3: Read registry high-water and slot
    RPC1-->>Agent: Matching value
    RPC2-->>Agent: Matching value
    RPC3--xAgent: Timeout or HTTP 429
    Agent-->>Agent: Abort the complete refresh
```

## After

```mermaid
sequenceDiagram
    participant Agent as DKG Agent
    participant RPC1 as RPC A
    participant RPC2 as RPC B
    participant RPC3 as RPC C
    Agent->>RPC1: Read registry high-water and slot
    Agent->>RPC2: Read registry high-water and slot
    Agent->>RPC3: Read registry high-water and slot
    RPC1-->>Agent: Matching slot value
    RPC2-->>Agent: Matching slot value
    RPC3--xAgent: Retryable slot timeout or HTTP 429
    Agent->>Agent: Stage the strict-majority slot result
    Agent->>RPC1: Verify final registry high-water
    Agent->>RPC2: Verify final registry high-water
    Agent->>RPC3: Verify final registry high-water
    alt Every configured backend answers consistently
        RPC1-->>Agent: Final high-water
        RPC2-->>Agent: Final high-water
        RPC3-->>Agent: Final high-water
        Agent-->>Agent: Commit the fully fenced refresh
    else Any backend remains unavailable or disagrees
        RPC3--xAgent: Unavailable or inconsistent
        Agent-->>Agent: Fail closed without index/cache commit
    end
```

## Validation

- `pnpm --filter @origintrail-official/dkg-chain build`
- focused resolver/fence tests: 3 files, 56 passed, 0 failed
- full chain unit lane: 49 files, 950 passed, 1 skipped, 0 failed
- `git diff --check`
