### PR TITLE
fix(agent): normalize durable sync shutdown aborts

### DIFF
--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -59,8 +59,8 @@ export type { LegacyDurableSyncContext } from './durable-sync-compat.js';
 export { filterExactAssetDurablePayload } from './exact-durable-fetch.js';
 export type { ExactDurableFetchDisposition } from './exact-durable-fetch.js';
 
-/** @internal Normalize arbitrary AbortSignal reasons without mutating caller-owned errors. */
-export function normalizeDurableSyncAbortReason(reason: unknown): Error {
+/** Normalize arbitrary AbortSignal reasons without mutating caller-owned errors. */
+function normalizeDurableSyncAbortReason(reason: unknown): Error {
   if (reason instanceof Error && reason.name === 'AbortError') return reason;
 
   const error = new Error(

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -59,6 +59,24 @@ export type { LegacyDurableSyncContext } from './durable-sync-compat.js';
 export { filterExactAssetDurablePayload } from './exact-durable-fetch.js';
 export type { ExactDurableFetchDisposition } from './exact-durable-fetch.js';
 
+/** @internal Normalize arbitrary AbortSignal reasons without mutating caller-owned errors. */
+export function normalizeDurableSyncAbortReason(reason: unknown): Error {
+  if (reason instanceof Error && reason.name === 'AbortError') return reason;
+
+  const error = new Error(
+    reason instanceof Error
+      ? reason.message || 'Durable sync aborted'
+      : typeof reason === 'string'
+        ? reason
+        : 'Durable sync aborted',
+  );
+  error.name = 'AbortError';
+  if (reason !== undefined) {
+    (error as Error & { cause?: unknown }).cause = reason;
+  }
+  return error;
+}
+
 export interface DetailedDurableSyncResult {
   readonly result: InitializedDurableSyncResult;
   /** Present only when this physical run used an exact-asset filter. */
@@ -257,11 +275,7 @@ async function runDurableSyncWithBudget(
 
   const throwIfOperationAborted = () => {
     if (!signal?.aborted) return;
-    const error = signal.reason instanceof Error
-      ? signal.reason
-      : new Error(typeof signal.reason === 'string' ? signal.reason : 'Durable sync aborted');
-    error.name = 'AbortError';
-    throw error;
+    throw normalizeDurableSyncAbortReason(signal.reason);
   };
   const fetchContext = (deadline: number): DurableSyncFetchContext => ({
     deadline,
@@ -655,7 +669,7 @@ async function runDurableSyncWithBudget(
         } else if (outcome === 'stale') {
           logDebug(ctx, `Skipped stale graph-scoped durable assertion ${asset.ual} v${asset.assertionVersion}`);
         } else {
-          logWarn(ctx, `Quarantined oversized graph-scoped durable assertion ${asset.ual} v${asset.assertionVersion}`);
+          logWarn(ctx, `Quarantined graph-scoped durable assertion ${asset.ual} v${asset.assertionVersion}`);
         }
       }
       if (partitioned.remainingData.length > 0) {

--- a/packages/agent/test/durable-sync-budget.test.ts
+++ b/packages/agent/test/durable-sync-budget.test.ts
@@ -12,7 +12,6 @@ import {
   type DurableSyncBudget,
 } from '../src/sync/requester/durable-sync-budget.js';
 import {
-  normalizeDurableSyncAbortReason,
   runDurableSync,
   type DurableSyncContext,
   type DurableSyncFetchContext,
@@ -726,18 +725,35 @@ describe('durable sync deadline budget', () => {
     expect(warnings.some((message) => message.includes('only a getter'))).toBe(false);
   });
 
-  it('wraps an immutable non-abort Error reason without mutating it', () => {
+  it('handles an immutable non-abort Error reason without mutating it', async () => {
+    const controller = new AbortController();
     const reason = Object.freeze(new Error('shutdown lifecycle fence'));
+    const logWarn = vi.fn<DurableSyncContext['logWarn']>();
+    const storeInsert = vi.fn(async (_request: DurableSyncStoreInsertRequest) => {});
 
-    const normalized = normalizeDurableSyncAbortReason(reason);
-
-    expect(normalized).not.toBe(reason);
-    expect(normalized).toMatchObject({
-      name: 'AbortError',
-      message: 'shutdown lifecycle fence',
-      cause: reason,
+    const result = await runRequesterBudgetHarness({
+      durableSyncBudget: requesterBudget(() => Date.now() + 60_000),
+      signal: controller.signal,
+      graphScoped: false,
+      onVerify: () => controller.abort(reason),
+      storeInsert,
+      storeGraphScopedAsset: async () => 'applied',
+      logWarn,
     });
+
+    expect(result).toMatchObject({
+      insertedTriples: 0,
+      complete: false,
+      failedPhases: 1,
+    });
+    expect(controller.signal.reason).toBe(reason);
     expect(reason.name).toBe('Error');
+    expect(storeInsert).not.toHaveBeenCalled();
+    const warnings = logWarn.mock.calls.map(([, message]) => message);
+    expect(warnings.some((message) => message.includes('shutdown lifecycle fence'))).toBe(true);
+    expect(warnings.some((message) => message.includes('read only'))).toBe(false);
+    expect(warnings.some((message) => message.includes('read-only'))).toBe(false);
+    expect(warnings.some((message) => message.includes('only a getter'))).toBe(false);
   });
 });
 

--- a/packages/agent/test/durable-sync-budget.test.ts
+++ b/packages/agent/test/durable-sync-budget.test.ts
@@ -12,6 +12,7 @@ import {
   type DurableSyncBudget,
 } from '../src/sync/requester/durable-sync-budget.js';
 import {
+  normalizeDurableSyncAbortReason,
   runDurableSync,
   type DurableSyncContext,
   type DurableSyncFetchContext,
@@ -85,6 +86,7 @@ function requesterBudgetContext(options: {
   mapFetchResult?: (phase: 'data' | 'meta', page: SyncPageResult) => SyncPageResult;
   onVerify?: () => void;
   onVerifiedFullSnapshot?: DurableSyncContext['onVerifiedFullSnapshot'];
+  logWarn?: DurableSyncContext['logWarn'];
   emptyResponses?: number;
   storeInsert?: (request: DurableSyncStoreInsertRequest) => Promise<void>;
   storeGraphScopedAsset: (
@@ -139,7 +141,7 @@ function requesterBudgetContext(options: {
     deleteCheckpoint: () => {},
     setCheckpoint: () => {},
     logInfo: () => {},
-    logWarn: () => {},
+    logWarn: options.logWarn ?? (() => {}),
     logDebug: () => {},
   };
 }
@@ -693,6 +695,49 @@ describe('durable sync deadline budget', () => {
       failedPhases: 1,
     });
     expect(storeInsert).not.toHaveBeenCalled();
+  });
+
+  it('handles a default DOMException abort after a quarantined atomic store outcome', async () => {
+    const controller = new AbortController();
+    const logWarn = vi.fn<DurableSyncContext['logWarn']>();
+
+    const result = await runRequesterBudgetHarness({
+      durableSyncBudget: requesterBudget(() => Date.now() + 60_000),
+      signal: controller.signal,
+      storeGraphScopedAsset: async () => {
+        controller.abort();
+        return 'quarantined';
+      },
+      logWarn,
+    });
+
+    expect(controller.signal.reason).toBeInstanceOf(DOMException);
+    expect((controller.signal.reason as Error).name).toBe('AbortError');
+    expect(result).toMatchObject({
+      insertedTriples: 0,
+      complete: false,
+      failedPhases: 1,
+    });
+    const warnings = logWarn.mock.calls.map(([, message]) => message);
+    expect(warnings).toContain(
+      'Quarantined graph-scoped durable assertion did:dkg:otp:2043/0x1111111111111111111111111111111111111111/1 v1',
+    );
+    expect(warnings.some((message) => message.includes('oversized'))).toBe(false);
+    expect(warnings.some((message) => message.includes('only a getter'))).toBe(false);
+  });
+
+  it('wraps an immutable non-abort Error reason without mutating it', () => {
+    const reason = Object.freeze(new Error('shutdown lifecycle fence'));
+
+    const normalized = normalizeDurableSyncAbortReason(reason);
+
+    expect(normalized).not.toBe(reason);
+    expect(normalized).toMatchObject({
+      name: 'AbortError',
+      message: 'shutdown lifecycle fence',
+      cause: reason,
+    });
+    expect(reason.name).toBe('Error');
   });
 });
 

--- a/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
+++ b/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
@@ -1573,7 +1573,7 @@ describe('durable graph-scoped KA materialization', () => {
     expect(await values(store, 'assertionVersion')).toEqual(['"1"']);
   });
 
-  it('does not pass a lifecycle abort signal into an entered atomic replacement', async () => {
+  it('finishes an entered atomic replacement before applying the lifecycle fence', async () => {
     const store = new OxigraphStore();
     const controller = new AbortController();
     let releaseReplace!: () => void;
@@ -1620,6 +1620,8 @@ describe('durable graph-scoped KA materialization', () => {
     current = false;
     controller.abort();
     await Promise.resolve();
+    expect(controller.signal.reason).toBeInstanceOf(DOMException);
+    expect((controller.signal.reason as Error).name).toBe('AbortError');
     expect(settled).toBe(false);
     expect(observedCommitSignal).toBeUndefined();
 


### PR DESCRIPTION
## Outcome

A node shutting down during an entered atomic VM materialization now preserves the original abort semantics instead of trying to mutate Node DOMException.name and throwing a secondary TypeError. Quarantine logs also describe the actual lifecycle/binding quarantine rather than incorrectly classifying every case as oversized.

This is a bounded shutdown-hardening increment. It changes no wire format, checkpoint identity, catalog policy, or store-commit semantics.

## Before

```mermaid
sequenceDiagram
    participant Stop as Node shutdown
    participant Sync as In-flight VM sync
    participant Store as Local store
    Stop->>Sync: Abort lifecycle
    Sync->>Store: Finish entered atomic replacement
    Store-->>Sync: Quarantined by lifecycle fence
    Sync->>Sync: Mutate caller-owned AbortError.name
    Sync-->>Stop: TypeError and misleading oversized warning
```

## After

```mermaid
sequenceDiagram
    participant Stop as Node shutdown
    participant Sync as In-flight VM sync
    participant Store as Local store
    Stop->>Sync: Abort lifecycle
    Sync->>Store: Finish entered atomic replacement
    Store-->>Sync: Quarantined by lifecycle fence
    Sync->>Sync: Normalize abort reason without mutation
    Sync-->>Stop: Clean AbortError and truthful quarantine log
```

## Validation

- Focused durable-sync budget and graph-scoped materialization: 63/63 passed on the exact stacked head.
- Agent full unit lane on the implementation commit: 180 files, 2,546 passed, 5 skipped, 0 failed.
- Agent build, type tests, and package-root tests passed.
- Independent P0-P2 review: clean.

## Stack

Targets #2219 so reviewers see only the shutdown-specific 3-file delta. Do not merge before the parent stack is accepted.