### PR TITLE
fix(agent): resume selected SWM metadata monotonically

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -160,6 +160,7 @@ import {
   type SignedAgentDelegation,
 } from './auth/agent-delegation.js';
 import { SyncVerifyWorker } from './sync-verify-worker.js';
+import { SelectedSwmMetaTransferCoordinator } from './sync/selected-swm-meta-fetcher.js';
 import { bindRandomSampling, type RandomSamplingDisabledReason, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
@@ -1611,6 +1612,22 @@ export class DKGAgentBase {
   protected syncCheckpoints: SyncCheckpointStore = new MemorySyncCheckpointStore();
   protected changelogCursors: ChangelogCursorStore = new MemoryChangelogCursorStore();
   protected syncVerifyWorker?: SyncVerifyWorker;
+  /** Agent-owned retained selected-SWM transfers, created lazily and drained before store close. */
+  protected selectedSwmMetaTransfers?: SelectedSwmMetaTransferCoordinator;
+
+  protected getSelectedSwmMetaTransfers(): SelectedSwmMetaTransferCoordinator {
+    this.selectedSwmMetaTransfers ??= new SelectedSwmMetaTransferCoordinator();
+    return this.selectedSwmMetaTransfers;
+  }
+
+  protected async closeSelectedSwmMetaTransfers(): Promise<void> {
+    const transfers = this.selectedSwmMetaTransfers;
+    if (!transfers) return;
+    await transfers.close();
+    if (this.selectedSwmMetaTransfers === transfers) {
+      this.selectedSwmMetaTransfers = undefined;
+    }
+  }
 
   /** Registered agents on this node: agentAddress → AgentKeyRecord */
   protected readonly localAgents = new Map<string, AgentKeyRecord>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -160,7 +160,7 @@ import {
   type SignedAgentDelegation,
 } from './auth/agent-delegation.js';
 import { SyncVerifyWorker } from './sync-verify-worker.js';
-import { SelectedSwmMetaTransferCoordinator } from './sync/selected-swm-meta-fetcher.js';
+import { SelectedSwmMetaTransferCoordinator } from './sync/selected-swm-meta-transfer-coordinator.js';
 import { bindRandomSampling, type RandomSamplingDisabledReason, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -295,7 +295,6 @@ import {
 } from './sync/requester/shared-memory-sync.js';
 import {
   createSelectedSwmMetaFetcher,
-  SelectedSwmMetaTransferCoordinator,
   type SelectedSwmMetaFetcher,
 } from './sync/selected-swm-meta-fetcher.js';
 import { createSharedMemorySnapshotMaterializer } from './sync/requester/swm-snapshot-materializer.js';
@@ -967,30 +966,6 @@ const selectedSwmMetaRetentionBudgets = new WeakMap<
   object,
   { signature: string; budget: SelectedSwmMetaRetentionBudget }
 >();
-
-const selectedSwmMetaTransferCoordinators = new WeakMap<
-  object,
-  SelectedSwmMetaTransferCoordinator
->();
-
-function selectedSwmMetaTransferCoordinatorFor(
-  owner: object,
-): SelectedSwmMetaTransferCoordinator {
-  let coordinator = selectedSwmMetaTransferCoordinators.get(owner);
-  if (!coordinator) {
-    coordinator = new SelectedSwmMetaTransferCoordinator();
-    selectedSwmMetaTransferCoordinators.set(owner, coordinator);
-  }
-  return coordinator;
-}
-
-/** Release every retained selected-SWM prefix before agent storage teardown. */
-export async function closeSelectedSwmMetaTransfers(owner: object): Promise<void> {
-  const coordinator = selectedSwmMetaTransferCoordinators.get(owner);
-  if (!coordinator) return;
-  selectedSwmMetaTransferCoordinators.delete(owner);
-  await coordinator.close();
-}
 
 function selectedSwmMetaRetentionBudgetFor(
   owner: object,
@@ -6667,7 +6642,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
     return runSyncSingleFlight(this, singleFlightKey, () => (
       selectedSwmEnabled
-        ? selectedSwmMetaTransferCoordinatorFor(this).run(
+        ? this.getSelectedSwmMetaTransfers().run(
           remotePeerId,
           createSelectedMetaFetcher,
           runSync,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -263,6 +263,7 @@ import {
 import { insertWithOversizeGuard, type OversizeGuardHooks } from './sync/oversize-filter.js';
 import { runOversizeSweep } from './sync/oversize-sweep.js';
 import {
+  type SelectedSwmMetaRetentionScope,
   type SyncCheckpointScope,
 } from './sync/checkpoint/state.js';
 import {
@@ -292,7 +293,11 @@ import {
   selectSwmSnapshotCoverage,
   sharedMemoryOwnershipKeyFromGraph,
 } from './sync/requester/shared-memory-sync.js';
-import { createSelectedSwmMetaFetcher } from './sync/selected-swm-meta-fetcher.js';
+import {
+  createSelectedSwmMetaFetcher,
+  SelectedSwmMetaTransferCoordinator,
+  type SelectedSwmMetaFetcher,
+} from './sync/selected-swm-meta-fetcher.js';
 import { createSharedMemorySnapshotMaterializer } from './sync/requester/swm-snapshot-materializer.js';
 import {
   runOrderedContextGraphSyncs,
@@ -963,6 +968,30 @@ const selectedSwmMetaRetentionBudgets = new WeakMap<
   { signature: string; budget: SelectedSwmMetaRetentionBudget }
 >();
 
+const selectedSwmMetaTransferCoordinators = new WeakMap<
+  object,
+  SelectedSwmMetaTransferCoordinator
+>();
+
+function selectedSwmMetaTransferCoordinatorFor(
+  owner: object,
+): SelectedSwmMetaTransferCoordinator {
+  let coordinator = selectedSwmMetaTransferCoordinators.get(owner);
+  if (!coordinator) {
+    coordinator = new SelectedSwmMetaTransferCoordinator();
+    selectedSwmMetaTransferCoordinators.set(owner, coordinator);
+  }
+  return coordinator;
+}
+
+/** Release every retained selected-SWM prefix before agent storage teardown. */
+export async function closeSelectedSwmMetaTransfers(owner: object): Promise<void> {
+  const coordinator = selectedSwmMetaTransferCoordinators.get(owner);
+  if (!coordinator) return;
+  selectedSwmMetaTransferCoordinators.delete(owner);
+  await coordinator.close();
+}
+
 function selectedSwmMetaRetentionBudgetFor(
   owner: object,
   limits: SelectedSwmMetaRetentionLimits,
@@ -975,9 +1004,9 @@ function selectedSwmMetaRetentionBudgetFor(
   return budget;
 }
 
-function nextSelectedSwmMetaRequesterScope(): SyncCheckpointScope {
+function nextSelectedSwmMetaRequesterScope(): SelectedSwmMetaRetentionScope {
   selectedSwmMetaInvocationSequence += 1;
-  return `selected-swm-meta:${selectedSwmMetaInvocationSequence}`;
+  return `selected-swm-meta:retained:${selectedSwmMetaInvocationSequence}`;
 }
 
 function asSyncFetchAbortError(reason: unknown): Error {
@@ -6265,12 +6294,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const selectedSwmEnabled = Boolean(
       options?.selectedSwmPriority && publicContextGraphIds.length > 0,
     );
-    // This scope is unique even when two selected calls overlap on the same
-    // peer/CG through different top-level single-flight keys. Their in-memory
-    // prefixes must never share a responder cursor or pooled fetch session.
-    const selectedMetaRequesterScope = selectedSwmEnabled
-      ? nextSelectedSwmMetaRequesterScope()
-      : undefined;
     const selectedMetaRetentionBudget = selectedSwmEnabled
       ? (() => {
         const budget = resolveSyncResponderSnapshotPolicy(
@@ -6285,10 +6308,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         });
       })()
       : undefined;
-    const selectedMetaFetcher = selectedSwmEnabled
-      ? createSelectedSwmMetaFetcher({
+    const createSelectedMetaFetcher = (): SelectedSwmMetaFetcher => {
+      const requesterScope = nextSelectedSwmMetaRequesterScope();
+      return createSelectedSwmMetaFetcher({
         remotePeerId,
-        requesterScope: selectedMetaRequesterScope!,
+        requesterScope,
         retentionBudget: selectedMetaRetentionBudget!,
         deleteCheckpoint: (key) => deleteSyncPageCheckpoint(this.syncCheckpoints, key),
         fetchPage: (request) => this.fetchSyncPages(
@@ -6305,8 +6329,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             maxAcceptedHeapBytesEstimate: request.maxAcceptedHeapBytesEstimate,
           },
         ),
-      })
-      : undefined;
+      });
+    };
     const singleFlightKey = sharedMemorySyncSingleFlightKey({
       remotePeerId,
       contextGraphIds,
@@ -6317,7 +6341,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       selectedSwm: selectedSwmEnabled,
     });
 
-    const runSync = async (): Promise<SharedMemorySyncResult> => {
+    const runSync = async (
+      selectedMetaFetcher?: SelectedSwmMetaFetcher,
+    ): Promise<SharedMemorySyncResult> => {
       const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
       const getSubGraphAdmission = (contextGraphId: string) => {
         let admission = subGraphAdmissionByContextGraph.get(contextGraphId);
@@ -6639,13 +6665,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       );
     };
 
-    return runSyncSingleFlight(this, singleFlightKey, runSync, {
+    return runSyncSingleFlight(this, singleFlightKey, () => (
+      selectedSwmEnabled
+        ? selectedSwmMetaTransferCoordinatorFor(this).run(
+          remotePeerId,
+          createSelectedMetaFetcher,
+          runSync,
+        )
+        : runSync()
+    ), {
       scope: 'shared-memory',
       source: options?.source,
-    }).finally(() => {
-      // Never leave a non-zero persisted cursor after its in-memory prefix has
-      // gone out of scope. A later invocation must start at offset zero.
-      selectedMetaFetcher?.cleanup();
     });
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -739,6 +739,7 @@ function syncPageFetchCoalescingKey(params: {
   recovery?: boolean;
   forceFreshSession?: boolean;
   assetUals?: readonly string[];
+  returnAcceptedPrefixOnRetryableTransportFailure?: boolean;
   requesterScope?: SyncCheckpointScope;
   maxAcceptedQuads?: number;
   maxAcceptedHeapBytesEstimate?: number;
@@ -754,6 +755,7 @@ function syncPageFetchCoalescingKey(params: {
     params.recovery === true,
     params.forceFreshSession === true,
     params.assetUals === undefined ? null : exactAssetFilterKey(params.assetUals),
+    params.returnAcceptedPrefixOnRetryableTransportFailure === true,
     params.requesterScope ?? null,
     params.maxAcceptedQuads ?? null,
     params.maxAcceptedHeapBytesEstimate ?? null,
@@ -5858,6 +5860,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // Exact VM recovery filter. Included in checkpoint, coalescing, wire and
       // responder-session identities so offsets never cross asset batches.
       assetUals,
+      returnAcceptedPrefixOnRetryableTransportFailure,
       // Internal namespace for state whose retained prefix is unavailable to
       // ordinary coalesced callers.
       requesterScope,
@@ -5883,6 +5886,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         recovery,
         forceFreshSession,
         assetUals,
+        returnAcceptedPrefixOnRetryableTransportFailure,
         requesterScope,
         maxAcceptedQuads,
         maxAcceptedHeapBytesEstimate,
@@ -5933,6 +5937,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       snapshotRef,
       sinceBatchId,
       assetUals,
+      returnAcceptedPrefixOnRetryableTransportFailure,
       requesterScope,
       maxAcceptedBytes: exactAccumulationLimits?.maxBytes,
       maxAcceptedQuads: exactAccumulationLimits?.maxQuads === undefined
@@ -6299,6 +6304,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           request.graphUri,
           request.deadline,
           {
+            returnAcceptedPrefixOnRetryableTransportFailure:
+              request.returnAcceptedPrefixOnRetryableTransportFailure,
             requesterScope: request.requesterScope,
             maxAcceptedQuads: request.maxAcceptedQuads,
             maxAcceptedHeapBytesEstimate: request.maxAcceptedHeapBytesEstimate,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -425,7 +425,10 @@ import { SwmSubstrateMethods } from './dkg-agent-swm-substrate.js';
 import { QueryMethods } from './dkg-agent-query.js';
 import { AgentRegistryMethods } from './dkg-agent-registry.js';
 import { WorkspaceCryptoMethods } from './dkg-agent-crypto.js';
-import { LifecycleSyncMethods } from './dkg-agent-lifecycle.js';
+import {
+  closeSelectedSwmMetaTransfers,
+  LifecycleSyncMethods,
+} from './dkg-agent-lifecycle.js';
 import {
   PublishMethods,
   SEAL_CAPABILITY_GAP_CODE,
@@ -1917,6 +1920,10 @@ export class DKGAgent extends DKGAgentBase {
       await this.node.stop();
     } finally {
       this.finalizationRuntime.markStopped();
+      // Node stop aborts active transport first; now drain the peer-serial
+      // owners and release every retained selected-SWM prefix/checkpoint before
+      // the backing store closes.
+      await closeSelectedSwmMetaTransfers(this);
     }
     if (this.syncVerifyWorker) {
       await this.syncVerifyWorker.close();

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -425,10 +425,7 @@ import { SwmSubstrateMethods } from './dkg-agent-swm-substrate.js';
 import { QueryMethods } from './dkg-agent-query.js';
 import { AgentRegistryMethods } from './dkg-agent-registry.js';
 import { WorkspaceCryptoMethods } from './dkg-agent-crypto.js';
-import {
-  closeSelectedSwmMetaTransfers,
-  LifecycleSyncMethods,
-} from './dkg-agent-lifecycle.js';
+import { LifecycleSyncMethods } from './dkg-agent-lifecycle.js';
 import {
   PublishMethods,
   SEAL_CAPABILITY_GAP_CODE,
@@ -1923,7 +1920,7 @@ export class DKGAgent extends DKGAgentBase {
       // Node stop aborts active transport first; now drain the peer-serial
       // owners and release every retained selected-SWM prefix/checkpoint before
       // the backing store closes.
-      await closeSelectedSwmMetaTransfers(this);
+      await this.closeSelectedSwmMetaTransfers();
     }
     if (this.syncVerifyWorker) {
       await this.syncVerifyWorker.close();

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -161,8 +161,7 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
           // A request factory may perform chain reads and signing. Preserve
           // that local boundary so a generic timeout message cannot later be
           // mistaken for an untagged libp2p/router interruption.
-          markSyncLocalRequestFailure(error);
-          throw error;
+          throw markSyncLocalRequestFailure(error);
         }
         throwIfAborted(params.signal);
         const messageId = randomUUID();
@@ -179,14 +178,13 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
             params.signal,
           );
         } catch (error) {
-          markSyncTransportFailure(error);
           // Classified by TERMINAL STATE, never by message text: a deadline
           // `TimeoutError` and a caller cancel reach here as the same
           // `AbortError` shape, and `PooledStreamResetError('request timeout')`
           // is the same class as 'pool closed'. The caller's own signal is the
           // only non-textual evidence of caller cancellation that exists.
           outcome = params.signal?.aborted === true ? 'cancelled' : 'transport_error';
-          throw error;
+          throw markSyncTransportFailure(error);
         }
         responded = true;
         responseByteLength = responseBytes.byteLength;
@@ -196,10 +194,10 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
         try {
           await params.validateResponse?.(responseBytes);
         } catch (error) {
-          // Tag, never replace — the original error's message drives peer
-          // backoff and `failedPhases` accounting downstream.
-          markSyncValidationRejection(error);
-          throw error;
+          // Preserve object identity; primitive throws are normalized once
+          // with the same message/cause so downstream classification can carry
+          // the response boundary without weakening backoff accounting.
+          throw markSyncValidationRejection(error);
         }
         throwIfAborted(params.signal);
         outcome = 'response';

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { withRetry, withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import {
+  markSyncLocalRequestFailure,
   markSyncTransportFailure,
   markSyncValidationRejection,
   isSyncValidationRejection,
@@ -153,7 +154,16 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
       let outcome: SyncAttemptOutcome | undefined;
       try {
         throwIfAborted(params.signal);
-        const requestBytes = await params.requestFactory();
+        let requestBytes: Uint8Array;
+        try {
+          requestBytes = await params.requestFactory();
+        } catch (error) {
+          // A request factory may perform chain reads and signing. Preserve
+          // that local boundary so a generic timeout message cannot later be
+          // mistaken for an untagged libp2p/router interruption.
+          markSyncLocalRequestFailure(error);
+          throw error;
+        }
         throwIfAborted(params.signal);
         const messageId = randomUUID();
         let responseBytes: Uint8Array;

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { withRetry, withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import {
-  markSyncLocalRequestFailure,
-  markSyncTransportFailure,
-  markSyncValidationRejection,
+  toSyncLocalRequestFailureError,
+  toSyncTransportFailureError,
+  toSyncValidationRejectionError,
   isSyncValidationRejection,
 } from '../sync/error-tags.js';
 import {
@@ -161,7 +161,7 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
           // A request factory may perform chain reads and signing. Preserve
           // that local boundary so a generic timeout message cannot later be
           // mistaken for an untagged libp2p/router interruption.
-          throw markSyncLocalRequestFailure(error);
+          throw toSyncLocalRequestFailureError(error);
         }
         throwIfAborted(params.signal);
         const messageId = randomUUID();
@@ -184,7 +184,7 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
           // is the same class as 'pool closed'. The caller's own signal is the
           // only non-textual evidence of caller cancellation that exists.
           outcome = params.signal?.aborted === true ? 'cancelled' : 'transport_error';
-          throw markSyncTransportFailure(error);
+          throw toSyncTransportFailureError(error);
         }
         responded = true;
         responseByteLength = responseBytes.byteLength;
@@ -197,7 +197,7 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
           // Preserve object identity; primitive throws are normalized once
           // with the same message/cause so downstream classification can carry
           // the response boundary without weakening backoff accounting.
-          throw markSyncValidationRejection(error);
+          throw toSyncValidationRejectionError(error);
         }
         throwIfAborted(params.signal);
         outcome = 'response';

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -1,14 +1,24 @@
 import type { SyncPhase } from '../auth/request-build.js';
 
 /**
- * Requester-only namespace for one selected-SWM invocation.
+ * Requester-only namespace for one selected-SWM transfer owner.
  *
- * The suffix is deliberately invocation-unique: overlapping selected calls can
- * cover the same peer and Context Graph while retaining different in-memory
- * prefixes, so sharing a cursor/session between them would make either prefix
- * unsafe to resume.
+ * The suffix is deliberately owner-unique. One agent-local peer coordinator
+ * serializes overlapping selected calls and may retain that owner's exact
+ * prefix across bounded outer reconciler invocations; unrelated owners can
+ * never share its cursor/session.
  */
 export type SyncCheckpointScope = `selected-swm-meta:${string}`;
+
+/** Runtime-distinct namespace owned only by retained selected-SWM metadata. */
+export type SelectedSwmMetaRetentionScope = `selected-swm-meta:retained:${string}`;
+
+export function isSelectedSwmMetaRetentionScope(
+  value: unknown,
+): value is SelectedSwmMetaRetentionScope {
+  return typeof value === 'string'
+    && /^selected-swm-meta:retained:[1-9]\d*$/.test(value);
+}
 
 export const DEFAULT_SYNC_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1000;
 

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -13,13 +13,6 @@ export type SyncCheckpointScope = `selected-swm-meta:${string}`;
 /** Runtime-distinct namespace owned only by retained selected-SWM metadata. */
 export type SelectedSwmMetaRetentionScope = `selected-swm-meta:retained:${string}`;
 
-export function isSelectedSwmMetaRetentionScope(
-  value: unknown,
-): value is SelectedSwmMetaRetentionScope {
-  return typeof value === 'string'
-    && /^selected-swm-meta:retained:[1-9]\d*$/.test(value);
-}
-
 export const DEFAULT_SYNC_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1000;
 
 export interface SyncCheckpointEntry {

--- a/packages/agent/src/sync/error-tags.ts
+++ b/packages/agent/src/sync/error-tags.ts
@@ -1,4 +1,7 @@
-import { isOversizedRdfLiteralError } from '@origintrail-official/dkg-core';
+import {
+  isOversizedRdfLiteralError,
+  isRecoverableSendError,
+} from '@origintrail-official/dkg-core';
 import { isChainRpcTransportError } from '@origintrail-official/dkg-chain';
 
 type SyncErrorTag =
@@ -110,31 +113,14 @@ function syncErrorMessage(error: unknown): string {
     : String(error).toLowerCase();
 }
 
-function hasKnownRetryableSyncTransportMessage(error: unknown): boolean {
-  const message = syncErrorMessage(error);
-  return (
-    message.includes('peer-closed-stream') ||
-    message.includes('all multiaddr dials failed') ||
-    message.includes('stream reset') ||
-    message.includes('stream has been reset') ||
-    message.includes('remote closed connection during opening') ||
-    message.includes('connection reset') ||
-    message.includes('econnreset') ||
-    message.includes('etimedout') ||
-    message.includes('send timeout') ||
-    message.includes('operation timed out') ||
-    message.includes('operation was aborted due to timeout')
-  );
-}
-
 /**
  * A retryable interruption of the DKG peer transport itself.
  *
- * The explicit tag is authoritative while the message fallback covers the
- * small set of libp2p/router errors whose Error can be recreated across a
- * retry/span boundary. Negative evidence wins: a response-side rejection,
- * chain RPC/local request construction failure, or caller abort must never be
- * reclassified merely because its message also contains "timed out".
+ * The explicit tag is authoritative. Untagged errors delegate to Core's
+ * canonical recoverable-send classifier so Messenger, ProtocolRouter and sync
+ * cannot drift onto separate libp2p/router message lists. Negative evidence
+ * wins: a response-side rejection, chain RPC/local request construction
+ * failure, or caller abort must never be reclassified by message.
  */
 export function isKnownRetryableSyncTransportInterruption(error: unknown): boolean {
   if (
@@ -153,7 +139,7 @@ export function isKnownRetryableSyncTransportInterruption(error: unknown): boole
   // used for caller cancellation and transport deadlines.
   if (error instanceof Error && error.name === 'AbortError') return false;
 
-  return hasKnownRetryableSyncTransportMessage(error);
+  return isRecoverableSendError(error);
 }
 
 /**
@@ -171,7 +157,11 @@ export function isSyncPermanentRejection(error: unknown): boolean {
 }
 
 export function isSyncBackoffWorthyError(error: unknown): boolean {
-  if (isSyncTransportFailure(error) || isChainRpcTransportError(error)) return true;
+  if (
+    isSyncTransportFailure(error)
+    || isChainRpcTransportError(error)
+    || isRecoverableSendError(error)
+  ) return true;
 
   const message = syncErrorMessage(error);
 
@@ -182,13 +172,6 @@ export function isSyncBackoffWorthyError(error: unknown): boolean {
       message.includes('queue wait exceeded') ||
       message.includes('snapshot limit exceeded') ||
       message.includes('busy')
-    )) ||
-    // These libp2p/router surfaces are transport interruptions too, but an
-    // outer retry/span boundary can occasionally recreate the Error and lose
-    // our non-enumerable syncTransportFailure tag. Keep the message fallback
-    // aligned with Messenger's recoverable dial classifier so a successfully
-    // received durable prefix is not discarded merely because the final page
-    // lost its relay stream.
-    hasKnownRetryableSyncTransportMessage(error)
+    ))
   );
 }

--- a/packages/agent/src/sync/error-tags.ts
+++ b/packages/agent/src/sync/error-tags.ts
@@ -7,70 +7,101 @@ type SyncErrorTag =
   | 'syncValidationRejected'
   | 'syncLocalRequestFailure';
 
-function markSyncError(error: unknown, tag: SyncErrorTag): void {
-  if (!error || (typeof error !== 'object' && typeof error !== 'function')) return;
+const syncErrorTagSideChannels: Record<SyncErrorTag, WeakSet<object>> = {
+  syncPeerResponded: new WeakSet(),
+  syncTransportFailure: new WeakSet(),
+  syncValidationRejected: new WeakSet(),
+  syncLocalRequestFailure: new WeakSet(),
+};
+
+function isTaggableThrowable(error: unknown): error is object {
+  return error !== null && (typeof error === 'object' || typeof error === 'function');
+}
+
+function markSyncError(error: unknown, tag: SyncErrorTag): unknown {
+  // JavaScript permits throwing primitives. Normalize only those values so a
+  // catch-and-rethrow boundary can carry authoritative classification without
+  // changing the identity, class or stack of ordinary Error/object throwables.
+  const taggedError = isTaggableThrowable(error)
+    ? error
+    : new Error(String(error), { cause: error });
+  syncErrorTagSideChannels[tag].add(taggedError);
   try {
-    Object.defineProperty(error, tag, {
+    Object.defineProperty(taggedError, tag, {
       configurable: true,
       enumerable: false,
       value: true,
     });
   } catch {
     try {
-      (error as Record<string, unknown>)[tag] = true;
+      (taggedError as Record<string, unknown>)[tag] = true;
     } catch {
-      // Best-effort tagging only; never replace the original sync failure.
+      // Frozen/non-extensible values remain tagged by the WeakSet side-channel.
     }
+  }
+  return taggedError;
+}
+
+function hasSyncErrorTag(error: unknown, tag: SyncErrorTag): boolean {
+  if (!isTaggableThrowable(error)) return false;
+  if (syncErrorTagSideChannels[tag].has(error)) return true;
+  try {
+    return Boolean((error as Record<string, unknown>)[tag]);
+  } catch {
+    return false;
   }
 }
 
-export function markSyncPeerResponded(error: unknown): void {
-  markSyncError(error, 'syncPeerResponded');
+export function markSyncPeerResponded(error: unknown): unknown {
+  return markSyncError(error, 'syncPeerResponded');
 }
 
-export function markSyncTransportFailure(error: unknown): void {
-  markSyncError(error, 'syncTransportFailure');
+export function markSyncTransportFailure(error: unknown): unknown {
+  return markSyncError(error, 'syncTransportFailure');
 }
 
-export function markSyncLocalRequestFailure(error: unknown): void {
-  markSyncError(error, 'syncLocalRequestFailure');
+export function markSyncLocalRequestFailure(error: unknown): unknown {
+  return markSyncError(error, 'syncLocalRequestFailure');
 }
 
 /**
  * The peer's response ARRIVED and the in-transport validator then rejected it
  * (W1 attempt outcome `validation_rejected`, whose received bytes still count).
  *
- * Tagging, never replacing: `makeLegacySyncBusyError`'s message is matched by
- * {@link isSyncBackoffWorthyError}, so minting a substitute error would silently
- * change peer backoff, the durable-data verifiable-prefix return and
- * `failedPhases` accounting — a behaviour change dressed as telemetry. The tag
- * is non-enumerable and best-effort, exactly like the two above.
+ * Object throwables are tagged without replacement: `makeLegacySyncBusyError`'s
+ * message is matched by {@link isSyncBackoffWorthyError}, so minting a substitute
+ * error would silently change peer backoff, the durable-data verifiable-prefix
+ * return and `failedPhases` accounting — a behaviour change dressed as
+ * telemetry. Primitive throwables are normalized once at the catch/rethrow
+ * boundary because they cannot carry either a property or WeakSet identity.
  *
  * There is no message fallback for this marker. A rejection that reaches the
  * record site untagged is classified by its terminal state, never guessed from
  * text: the deadline/cancel/reset surfaces are indistinguishable by message.
  */
-export function markSyncValidationRejection(error: unknown): void {
-  markSyncError(error, 'syncValidationRejected');
+export function markSyncValidationRejection(error: unknown): unknown {
+  return markSyncError(error, 'syncValidationRejected');
 }
 
 export function isSyncValidationRejection(error: unknown): boolean {
-  return Boolean(error && typeof error === 'object' && (error as { syncValidationRejected?: boolean }).syncValidationRejected);
+  return hasSyncErrorTag(error, 'syncValidationRejected');
 }
 
 export function didSyncPeerRespond(error: unknown): boolean {
-  return Boolean(error && typeof error === 'object' && (
-    (error as { syncPeerResponded?: boolean }).syncPeerResponded ||
-    (error as { syncDenied?: boolean }).syncDenied
-  ));
+  if (hasSyncErrorTag(error, 'syncPeerResponded')) return true;
+  try {
+    return Boolean(isTaggableThrowable(error) && (error as { syncDenied?: boolean }).syncDenied);
+  } catch {
+    return false;
+  }
 }
 
 export function isSyncTransportFailure(error: unknown): boolean {
-  return Boolean(error && typeof error === 'object' && (error as { syncTransportFailure?: boolean }).syncTransportFailure);
+  return hasSyncErrorTag(error, 'syncTransportFailure');
 }
 
 function isSyncLocalRequestFailure(error: unknown): boolean {
-  return Boolean(error && typeof error === 'object' && (error as { syncLocalRequestFailure?: boolean }).syncLocalRequestFailure);
+  return hasSyncErrorTag(error, 'syncLocalRequestFailure');
 }
 
 function syncErrorMessage(error: unknown): string {

--- a/packages/agent/src/sync/error-tags.ts
+++ b/packages/agent/src/sync/error-tags.ts
@@ -1,7 +1,11 @@
 import { isOversizedRdfLiteralError } from '@origintrail-official/dkg-core';
 import { isChainRpcTransportError } from '@origintrail-official/dkg-chain';
 
-type SyncErrorTag = 'syncPeerResponded' | 'syncTransportFailure' | 'syncValidationRejected';
+type SyncErrorTag =
+  | 'syncPeerResponded'
+  | 'syncTransportFailure'
+  | 'syncValidationRejected'
+  | 'syncLocalRequestFailure';
 
 function markSyncError(error: unknown, tag: SyncErrorTag): void {
   if (!error || (typeof error !== 'object' && typeof error !== 'function')) return;
@@ -26,6 +30,10 @@ export function markSyncPeerResponded(error: unknown): void {
 
 export function markSyncTransportFailure(error: unknown): void {
   markSyncError(error, 'syncTransportFailure');
+}
+
+export function markSyncLocalRequestFailure(error: unknown): void {
+  markSyncError(error, 'syncLocalRequestFailure');
 }
 
 /**
@@ -61,6 +69,54 @@ export function isSyncTransportFailure(error: unknown): boolean {
   return Boolean(error && typeof error === 'object' && (error as { syncTransportFailure?: boolean }).syncTransportFailure);
 }
 
+function isSyncLocalRequestFailure(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && (error as { syncLocalRequestFailure?: boolean }).syncLocalRequestFailure);
+}
+
+function syncErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message.toLowerCase()
+    : String(error).toLowerCase();
+}
+
+function hasKnownRetryableSyncTransportMessage(error: unknown): boolean {
+  const message = syncErrorMessage(error);
+  return (
+    message.includes('peer-closed-stream') ||
+    message.includes('all multiaddr dials failed') ||
+    message.includes('stream reset') ||
+    message.includes('stream has been reset') ||
+    message.includes('remote closed connection during opening') ||
+    message.includes('connection reset') ||
+    message.includes('econnreset') ||
+    message.includes('etimedout') ||
+    message.includes('send timeout') ||
+    message.includes('operation timed out') ||
+    message.includes('operation was aborted due to timeout')
+  );
+}
+
+/**
+ * A retryable interruption of the DKG peer transport itself.
+ *
+ * The explicit tag is authoritative while the message fallback covers the
+ * small set of libp2p/router errors whose Error can be recreated across a
+ * retry/span boundary. Negative evidence wins: a response-side rejection,
+ * chain RPC/local request construction failure, or caller abort must never be
+ * reclassified merely because its message also contains "timed out".
+ */
+export function isKnownRetryableSyncTransportInterruption(error: unknown): boolean {
+  if (
+    (error instanceof Error && error.name === 'AbortError')
+    || isSyncValidationRejection(error)
+    || didSyncPeerRespond(error)
+    || isChainRpcTransportError(error)
+    || isSyncLocalRequestFailure(error)
+  ) return false;
+
+  return isSyncTransportFailure(error) || hasKnownRetryableSyncTransportMessage(error);
+}
+
 /**
  * PERMANENT ingest rejection (OT-RFC-56): retrying can never succeed — the
  * content itself violates a protocol invariant (today: the RDF-literal size
@@ -78,9 +134,7 @@ export function isSyncPermanentRejection(error: unknown): boolean {
 export function isSyncBackoffWorthyError(error: unknown): boolean {
   if (isSyncTransportFailure(error) || isChainRpcTransportError(error)) return true;
 
-  const message = error instanceof Error
-    ? error.message.toLowerCase()
-    : String(error).toLowerCase();
+  const message = syncErrorMessage(error);
 
   return (
     message.includes('too many active durable data sync session snapshots') ||
@@ -96,14 +150,6 @@ export function isSyncBackoffWorthyError(error: unknown): boolean {
     // aligned with Messenger's recoverable dial classifier so a successfully
     // received durable prefix is not discarded merely because the final page
     // lost its relay stream.
-    message.includes('peer-closed-stream') ||
-    message.includes('all multiaddr dials failed') ||
-    message.includes('stream reset') ||
-    message.includes('connection reset') ||
-    message.includes('econnreset') ||
-    message.includes('etimedout') ||
-    message.includes('send timeout') ||
-    message.includes('operation timed out') ||
-    message.includes('operation was aborted due to timeout')
+    hasKnownRetryableSyncTransportMessage(error)
   );
 }

--- a/packages/agent/src/sync/error-tags.ts
+++ b/packages/agent/src/sync/error-tags.ts
@@ -107,14 +107,22 @@ function hasKnownRetryableSyncTransportMessage(error: unknown): boolean {
  */
 export function isKnownRetryableSyncTransportInterruption(error: unknown): boolean {
   if (
-    (error instanceof Error && error.name === 'AbortError')
-    || isSyncValidationRejection(error)
+    isSyncValidationRejection(error)
     || didSyncPeerRespond(error)
     || isChainRpcTransportError(error)
     || isSyncLocalRequestFailure(error)
   ) return false;
 
-  return isSyncTransportFailure(error) || hasKnownRetryableSyncTransportMessage(error);
+  // The transport boundary is authoritative even when its deadline surfaces
+  // as AbortError. Caller/node cancellation is rejected separately by the
+  // requester's live signal before this classifier is consulted.
+  if (isSyncTransportFailure(error)) return true;
+
+  // Never infer an untagged AbortError from message text: the same shape is
+  // used for caller cancellation and transport deadlines.
+  if (error instanceof Error && error.name === 'AbortError') return false;
+
+  return hasKnownRetryableSyncTransportMessage(error);
 }
 
 /**

--- a/packages/agent/src/sync/error-tags.ts
+++ b/packages/agent/src/sync/error-tags.ts
@@ -10,6 +10,8 @@ type SyncErrorTag =
   | 'syncValidationRejected'
   | 'syncLocalRequestFailure';
 
+type TaggedSyncThrowable = object;
+
 const syncErrorTagSideChannels: Record<SyncErrorTag, WeakSet<object>> = {
   syncPeerResponded: new WeakSet(),
   syncTransportFailure: new WeakSet(),
@@ -21,7 +23,7 @@ function isTaggableThrowable(error: unknown): error is object {
   return error !== null && (typeof error === 'object' || typeof error === 'function');
 }
 
-function markSyncError(error: unknown, tag: SyncErrorTag): unknown {
+function toTaggedSyncError(error: unknown, tag: SyncErrorTag): TaggedSyncThrowable {
   // JavaScript permits throwing primitives. Normalize only those values so a
   // catch-and-rethrow boundary can carry authoritative classification without
   // changing the identity, class or stack of ordinary Error/object throwables.
@@ -55,16 +57,22 @@ function hasSyncErrorTag(error: unknown, tag: SyncErrorTag): boolean {
   }
 }
 
-export function markSyncPeerResponded(error: unknown): unknown {
-  return markSyncError(error, 'syncPeerResponded');
+export function toSyncPeerRespondedError<T extends object>(error: T): T;
+export function toSyncPeerRespondedError(error: unknown): TaggedSyncThrowable;
+export function toSyncPeerRespondedError(error: unknown): TaggedSyncThrowable {
+  return toTaggedSyncError(error, 'syncPeerResponded');
 }
 
-export function markSyncTransportFailure(error: unknown): unknown {
-  return markSyncError(error, 'syncTransportFailure');
+export function toSyncTransportFailureError<T extends object>(error: T): T;
+export function toSyncTransportFailureError(error: unknown): TaggedSyncThrowable;
+export function toSyncTransportFailureError(error: unknown): TaggedSyncThrowable {
+  return toTaggedSyncError(error, 'syncTransportFailure');
 }
 
-export function markSyncLocalRequestFailure(error: unknown): unknown {
-  return markSyncError(error, 'syncLocalRequestFailure');
+export function toSyncLocalRequestFailureError<T extends object>(error: T): T;
+export function toSyncLocalRequestFailureError(error: unknown): TaggedSyncThrowable;
+export function toSyncLocalRequestFailureError(error: unknown): TaggedSyncThrowable {
+  return toTaggedSyncError(error, 'syncLocalRequestFailure');
 }
 
 /**
@@ -82,8 +90,10 @@ export function markSyncLocalRequestFailure(error: unknown): unknown {
  * record site untagged is classified by its terminal state, never guessed from
  * text: the deadline/cancel/reset surfaces are indistinguishable by message.
  */
-export function markSyncValidationRejection(error: unknown): unknown {
-  return markSyncError(error, 'syncValidationRejected');
+export function toSyncValidationRejectionError<T extends object>(error: T): T;
+export function toSyncValidationRejectionError(error: unknown): TaggedSyncThrowable;
+export function toSyncValidationRejectionError(error: unknown): TaggedSyncThrowable {
+  return toTaggedSyncError(error, 'syncValidationRejected');
 }
 
 export function isSyncValidationRejection(error: unknown): boolean {

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -16,6 +16,7 @@ import type { SyncPhase } from '../auth/request-build.js';
 import { exactAssetFilterKey } from '../exact-assets.js';
 import {
   getSyncCheckpointKey,
+  isSelectedSwmMetaRetentionScope,
   type SyncCheckpointScope,
   type SyncCheckpointStore,
 } from '../checkpoint/state.js';
@@ -846,6 +847,44 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       logWarn(
         ctx,
         `Durable data transport interrupted after ${allQuads.length} accepted triples for "${contextGraphId}"; returning a verifiable prefix at raw offset ${offset}`,
+      );
+      phaseTelemetry.finish('timed_out', allQuads.length);
+      return {
+        quads: allQuads,
+        bytesReceived,
+        resumedFromOffset,
+        responderSessionStartedFresh,
+        nextOffset: offset,
+        checkpointKey,
+        completed: false,
+        timedOut: true,
+      };
+    }
+
+    // Selected RFC-64 SWM metadata has a stricter all-or-nothing activation
+    // boundary than its transfer boundary. Once at least one page from this
+    // exact scoped responder session has passed decode/parse/accumulation
+    // checks, a later retryable TRANSPORT exhaustion may return that validated
+    // prefix to its single in-memory owner. The owner retains it with this
+    // checkpoint/session and never exposes it to Blazegraph until the metadata
+    // response completes and the ordinary SWM verification path runs.
+    //
+    // Keep this narrower than `isSyncBackoffWorthyError`: responder denials,
+    // validation/integrity rejection, local request construction/signing, and
+    // caller/node aborts all throw and force the owner to discard its prefix.
+    if (
+      includeSharedMemory
+      && phase === 'meta'
+      && isSelectedSwmMetaRetentionScope(requesterScope)
+      && responsePages > 0
+      && allQuads.length > 0
+      && signal?.aborted !== true
+      && isSyncTransportFailure(err)
+      && isSyncBackoffWorthyError(err)
+    ) {
+      logWarn(
+        ctx,
+        `Selected SWM metadata transport interrupted after ${allQuads.length} accepted triples for "${contextGraphId}"; retaining a private prefix at raw offset ${offset}`,
       );
       phaseTelemetry.finish('timed_out', allQuads.length);
       return {

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -9,7 +9,7 @@ import {
   isSyncBackoffWorthyError,
   isSyncTransportFailure,
   isSyncValidationRejection,
-  markSyncPeerResponded,
+  toSyncPeerRespondedError,
 } from '../error-tags.js';
 import { syncPlaneFor } from '../attempt-telemetry.js';
 import { appendInPlace } from '../append-in-place.js';
@@ -691,7 +691,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
           nextBytesReceived,
           maxAcceptedBytes,
         );
-        throw markSyncPeerResponded(error);
+        throw toSyncPeerRespondedError(error);
       }
 
       let parsed: { quads: Quad[]; totalQuads: number };
@@ -743,7 +743,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         }
         acceptedHeapBytesEstimate = nextAcceptedHeapBytesEstimate;
       } catch (error) {
-        throw markSyncPeerResponded(error);
+        throw toSyncPeerRespondedError(error);
       }
 
       const stepDurationMs = transportDurationMs + decodeDurationMs + parseDurationMs;

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -5,6 +5,7 @@ import {
   type SingleUseSyncSender,
 } from '../../p2p/sync-transport.js';
 import {
+  isKnownRetryableSyncTransportInterruption,
   isSyncBackoffWorthyError,
   isSyncTransportFailure,
   isSyncValidationRejection,
@@ -903,8 +904,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       && responsePages > 0
       && allQuads.length > 0
       && signal?.aborted !== true
-      && isSyncTransportFailure(err)
-      && isSyncBackoffWorthyError(err)
+      && isKnownRetryableSyncTransportInterruption(err)
     ) {
       logWarn(
         ctx,

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -691,8 +691,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
           nextBytesReceived,
           maxAcceptedBytes,
         );
-        markSyncPeerResponded(error);
-        throw error;
+        throw markSyncPeerResponded(error);
       }
 
       let parsed: { quads: Quad[]; totalQuads: number };
@@ -744,8 +743,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         }
         acceptedHeapBytesEstimate = nextAcceptedHeapBytesEstimate;
       } catch (error) {
-        markSyncPeerResponded(error);
-        throw error;
+        throw markSyncPeerResponded(error);
       }
 
       const stepDurationMs = transportDurationMs + decodeDurationMs + parseDurationMs;

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -16,7 +16,6 @@ import type { SyncPhase } from '../auth/request-build.js';
 import { exactAssetFilterKey } from '../exact-assets.js';
 import {
   getSyncCheckpointKey,
-  isSelectedSwmMetaRetentionScope,
   type SyncCheckpointScope,
   type SyncCheckpointStore,
 } from '../checkpoint/state.js';
@@ -149,6 +148,16 @@ export interface SyncPageResult {
   checkpointKey: string;
   completed: boolean;
   timedOut: boolean;
+}
+
+function acceptedIncompletePrefixResult(
+  result: Omit<SyncPageResult, 'completed' | 'timedOut'>,
+): SyncPageResult {
+  return {
+    ...result,
+    completed: false,
+    timedOut: true,
+  };
 }
 
 /**
@@ -324,6 +333,12 @@ export interface SyncPageFetchOptions {
   readonly recovery?: boolean;
   readonly forceFreshSession?: boolean;
   readonly assetUals?: string[];
+  /**
+   * Permit the selected-SWM transfer owner to retain a validated metadata
+   * prefix after a retryable transport interruption. Checkpoint identity is
+   * intentionally independent of this transfer policy.
+   */
+  readonly returnAcceptedPrefixOnRetryableTransportFailure?: boolean;
   readonly requesterScope?: SyncCheckpointScope;
   readonly maxAcceptedQuads?: number;
   readonly maxAcceptedHeapBytesEstimate?: number;
@@ -399,6 +414,8 @@ interface FetchSyncPagesParams {
   sinceBatchId?: string;
   /** Exact KAs requested by VM recovery. Undefined retains ordinary full sync. */
   assetUals?: string[];
+  /** Selected-SWM-only policy for returning a validated incomplete prefix. */
+  returnAcceptedPrefixOnRetryableTransportFailure?: boolean;
   /** Isolates an internal requester whose retained prefix is not shareable. */
   requesterScope?: SyncCheckpointScope;
   /** Optional cumulative ceilings for proof-sensitive narrow fetches. */
@@ -495,6 +512,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     buildSyncRequest,
     sinceBatchId,
     assetUals,
+    returnAcceptedPrefixOnRetryableTransportFailure,
     requesterScope,
     maxAcceptedBytes,
     maxAcceptedQuads,
@@ -849,16 +867,14 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         `Durable data transport interrupted after ${allQuads.length} accepted triples for "${contextGraphId}"; returning a verifiable prefix at raw offset ${offset}`,
       );
       phaseTelemetry.finish('timed_out', allQuads.length);
-      return {
+      return acceptedIncompletePrefixResult({
         quads: allQuads,
         bytesReceived,
         resumedFromOffset,
         responderSessionStartedFresh,
         nextOffset: offset,
         checkpointKey,
-        completed: false,
-        timedOut: true,
-      };
+      });
     }
 
     // Selected RFC-64 SWM metadata has a stricter all-or-nothing activation
@@ -875,7 +891,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     if (
       includeSharedMemory
       && phase === 'meta'
-      && isSelectedSwmMetaRetentionScope(requesterScope)
+      && returnAcceptedPrefixOnRetryableTransportFailure === true
       && responsePages > 0
       && allQuads.length > 0
       && signal?.aborted !== true
@@ -887,16 +903,22 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         `Selected SWM metadata transport interrupted after ${allQuads.length} accepted triples for "${contextGraphId}"; retaining a private prefix at raw offset ${offset}`,
       );
       phaseTelemetry.finish('timed_out', allQuads.length);
-      return {
+      return acceptedIncompletePrefixResult({
         quads: allQuads,
         bytesReceived,
         resumedFromOffset,
         responderSessionStartedFresh,
         nextOffset: offset,
         checkpointKey,
-        completed: false,
-        timedOut: true,
-      };
+      });
+    }
+
+    if (returnAcceptedPrefixOnRetryableTransportFailure === true) {
+      // The selected transfer owner can retain only an explicitly returned
+      // validated prefix. Every thrown boundary invalidates both pieces of its
+      // resume tuple so aborts, denials and local/validation/integrity failures
+      // cannot strand a session without its byte-identical in-memory prefix.
+      deleteSyncPageCheckpoint(checkpointStore, checkpointKey);
     }
 
     phaseTelemetry.finish('error', allQuads.length);

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -4,7 +4,7 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
   getSyncCheckpointKey,
-  type SyncCheckpointScope,
+  type SelectedSwmMetaRetentionScope,
 } from './checkpoint/state.js';
 import { estimateQuadHeapBytes } from './memory-telemetry.js';
 import {
@@ -16,24 +16,39 @@ import type {
   SharedMemoryMetadataFetcher,
 } from './requester/shared-memory-sync.js';
 import type { SelectedSwmMetaRetentionLease } from './selected-swm-meta-budget.js';
+import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from './durable-session.js';
 
-/** Exact prefix retained only for one selected-provider invocation. */
+/** Exact prefix retained only by one selected-provider transfer owner. */
 interface SelectedSwmMetaContinuationState {
   quads: Quad[];
   bytesEstimate: number;
   nextOffset: number;
   checkpointKey: string;
-  requesterScope: SyncCheckpointScope;
+  requesterScope: SelectedSwmMetaRetentionScope;
   /** Incremented whenever the responder restarts this prefix from offset zero. */
   generation: number;
   completed: boolean;
+  expiresAtMs: number;
   retentionLease: SelectedSwmMetaRetentionLease;
 }
 
 export interface SelectedSwmMetaFetcher {
   readonly strategy: SharedMemoryMetadataFetcher;
   continuation(contextGraphId: string): SelectedSwmMetaContinuation;
+  /**
+   * Drop terminal/empty state at an outer reconciler boundary and describe the
+   * useful incomplete prefix that remains eligible for a later invocation.
+   */
+  settleOuterInvocation(): SelectedSwmMetaRetentionState;
   cleanup(): void;
+}
+
+export interface SelectedSwmMetaRetentionState {
+  readonly retained: boolean;
+  /** Changes only when a retained generation or exact prefix changes. */
+  readonly progressToken: string;
+  /** Earliest independent Context Graph prefix expiry. */
+  readonly nextExpiryAtMs: number | undefined;
 }
 
 /** Immutable continuation evidence captured immediately after one SWM round. */
@@ -43,13 +58,154 @@ export interface SelectedSwmMetaContinuation {
   readonly completed: boolean;
 }
 
+interface SelectedSwmMetaTransferEntry {
+  fetcher: SelectedSwmMetaFetcher | undefined;
+  tail: Promise<void>;
+  expiryTimer: ReturnType<typeof setTimeout> | undefined;
+}
+
+/**
+ * Agent-local, peer-serial ownership for selected-SWM metadata prefixes.
+ *
+ * A responder offset is meaningful only together with the byte-identical
+ * validated prefix and responder session that produced it. This coordinator
+ * keeps that tuple alive across bounded reconciler invocations, while allowing
+ * exactly one invocation for a peer to mutate it at a time. It is deliberately
+ * not a generic SWM cache: ordinary/private SWM retain their existing behavior.
+ */
+export class SelectedSwmMetaTransferCoordinator {
+  readonly #entries = new Map<string, SelectedSwmMetaTransferEntry>();
+
+  readonly #now: () => number;
+
+  #closed = false;
+
+  constructor(options: {
+    readonly now?: () => number;
+  } = {}) {
+    this.#now = options.now ?? (() => Date.now());
+  }
+
+  run<T>(
+    remotePeerId: string,
+    createFetcher: () => SelectedSwmMetaFetcher,
+    operation: (fetcher: SelectedSwmMetaFetcher) => Promise<T>,
+  ): Promise<T> {
+    if (this.#closed) return Promise.reject(this.#closedError());
+    let entry = this.#entries.get(remotePeerId);
+    if (!entry) {
+      entry = {
+        fetcher: undefined,
+        tail: Promise.resolve(),
+        expiryTimer: undefined,
+      };
+      this.#entries.set(remotePeerId, entry);
+    }
+
+    const execute = entry.tail.then(async () => {
+      if (this.#closed) throw this.#closedError();
+      this.#clearExpiryTimer(entry!);
+      const retainedBeforeRun = entry!.fetcher?.settleOuterInvocation();
+      if (entry!.fetcher && !retainedBeforeRun?.retained) {
+        entry!.fetcher.cleanup();
+        entry!.fetcher = undefined;
+      }
+      const fetcher = entry!.fetcher ?? createFetcher();
+      entry!.fetcher = fetcher;
+      let succeeded = false;
+      try {
+        const result = await operation(fetcher);
+        succeeded = true;
+        return result;
+      } finally {
+        if (!succeeded) {
+          // An escaping abort, validation/integrity failure, or local build
+          // failure must never leave a cursor whose owner already unwound.
+          fetcher.cleanup();
+          entry!.fetcher = undefined;
+        } else {
+          const retention = fetcher.settleOuterInvocation();
+          if (!retention.retained) {
+            fetcher.cleanup();
+            entry!.fetcher = undefined;
+          } else {
+            this.#scheduleExpiry(remotePeerId, entry!, retention.nextExpiryAtMs);
+          }
+        }
+      }
+    });
+    const settled = execute.then(() => undefined, () => undefined);
+    entry.tail = settled;
+    void settled.then(() => {
+      if (
+        this.#entries.get(remotePeerId) === entry
+        && entry!.tail === settled
+        && !entry!.fetcher
+      ) {
+        this.#entries.delete(remotePeerId);
+      }
+    });
+    return execute;
+  }
+
+  async close(): Promise<void> {
+    this.#closed = true;
+    const entries = [...this.#entries.values()];
+    for (const entry of entries) this.#clearExpiryTimer(entry);
+    await Promise.all(entries.map((entry) => entry.tail));
+    for (const entry of entries) {
+      entry.fetcher?.cleanup();
+      entry.fetcher = undefined;
+    }
+    this.#entries.clear();
+  }
+
+  #clearExpiryTimer(entry: SelectedSwmMetaTransferEntry): void {
+    if (entry.expiryTimer) clearTimeout(entry.expiryTimer);
+    entry.expiryTimer = undefined;
+  }
+
+  #scheduleExpiry(
+    remotePeerId: string,
+    entry: SelectedSwmMetaTransferEntry,
+    nextExpiryAtMs: number | undefined,
+  ): void {
+    this.#clearExpiryTimer(entry);
+    if (nextExpiryAtMs === undefined || this.#closed) return;
+    const delayMs = Math.max(1, nextExpiryAtMs - this.#now());
+    entry.expiryTimer = setTimeout(() => {
+      entry.expiryTimer = undefined;
+      if (this.#closed || this.#entries.get(remotePeerId) !== entry) return;
+      const expire = entry.tail.then(() => {
+        if (this.#closed || this.#entries.get(remotePeerId) !== entry) return;
+        const retention = entry.fetcher?.settleOuterInvocation();
+        if (!retention?.retained) {
+          entry.fetcher?.cleanup();
+          entry.fetcher = undefined;
+          this.#entries.delete(remotePeerId);
+          return;
+        }
+        this.#scheduleExpiry(remotePeerId, entry, retention.nextExpiryAtMs);
+      });
+      entry.tail = expire.then(() => undefined, () => undefined);
+    }, delayMs);
+    entry.expiryTimer.unref?.();
+  }
+
+  #closedError(): Error {
+    const error = new Error('Selected SWM metadata transfer coordinator is closed');
+    error.name = 'AbortError';
+    return error;
+  }
+}
+
 interface SelectedMetaPageFetchRequest {
   readonly ctx: OperationContext;
   readonly remotePeerId: string;
   readonly contextGraphId: string;
   readonly graphUri: string;
   readonly deadline: number;
-  readonly requesterScope: SyncCheckpointScope;
+  readonly requesterScope: SelectedSwmMetaRetentionScope;
   readonly maxAcceptedQuads: number;
   readonly maxAcceptedHeapBytesEstimate: number;
 }
@@ -63,13 +219,20 @@ interface SelectedMetaPageFetchRequest {
  */
 export function createSelectedSwmMetaFetcher(options: {
   readonly remotePeerId: string;
-  readonly requesterScope: SyncCheckpointScope;
+  readonly requesterScope: SelectedSwmMetaRetentionScope;
   readonly retentionBudget: { lease(): SelectedSwmMetaRetentionLease };
   readonly fetchPage: (request: SelectedMetaPageFetchRequest) => Promise<SyncPageResult>;
   readonly deleteCheckpoint: (checkpointKey: string) => void;
+  readonly now?: () => number;
+  readonly retentionTtlMs?: number;
 }): SelectedSwmMetaFetcher {
   const states = new Map<string, SelectedSwmMetaContinuationState>();
   const completedContextGraphs = new Set<string>();
+  const now = options.now ?? (() => Date.now());
+  const retentionTtlMs = options.retentionTtlMs ?? DURABLE_DATA_SYNC_SESSION_TTL_MS;
+  if (!Number.isSafeInteger(retentionTtlMs) || retentionTtlMs <= 0) {
+    throw new Error(`Invalid selected SWM metadata retention TTL: ${retentionTtlMs}`);
+  }
 
   const release = (
     contextGraphId: string,
@@ -96,7 +259,7 @@ export function createSelectedSwmMetaFetcher(options: {
       undefined,
       options.requesterScope,
     );
-    // A prefix is invocation-local. A checkpoint without that byte-identical
+    // A prefix is coordinator-local. A checkpoint without that byte-identical
     // prefix cannot be resumed, even if a previous process left it behind.
     options.deleteCheckpoint(checkpointKey);
     const state: SelectedSwmMetaContinuationState = {
@@ -107,6 +270,7 @@ export function createSelectedSwmMetaFetcher(options: {
       requesterScope: options.requesterScope,
       generation: 0,
       completed: false,
+      expiresAtMs: 0,
       retentionLease: options.retentionBudget.lease(),
     };
     states.set(contextGraphId, state);
@@ -130,6 +294,9 @@ export function createSelectedSwmMetaFetcher(options: {
       });
       const resumesPrefix = fetched.resumedFromOffset === state.nextOffset;
       const restartedFromZero = fetched.resumedFromOffset === 0;
+      const previousGeneration = state.generation;
+      const previousOffset = state.nextOffset;
+      const previousRows = state.quads.length;
       if (!resumesPrefix && !restartedFromZero) {
         options.deleteCheckpoint(fetched.checkpointKey);
         completedContextGraphs.delete(request.contextGraphId);
@@ -160,6 +327,20 @@ export function createSelectedSwmMetaFetcher(options: {
       state.nextOffset = fetched.nextOffset;
       state.checkpointKey = fetched.checkpointKey;
       state.completed = fetched.completed;
+      if (
+        !state.completed
+        && state.nextOffset > 0
+        && state.quads.length > 0
+        && (
+          state.generation !== previousGeneration
+          || state.nextOffset > previousOffset
+          || state.quads.length > previousRows
+        )
+      ) {
+        // Each Context Graph owns an independent sliding expiry. Progress on a
+        // sibling CG cannot keep an abandoned prefix resident.
+        state.expiresAtMs = now() + retentionTtlMs;
+      }
       if (state.completed) completedContextGraphs.add(request.contextGraphId);
       return { ...fetched, quads: state.quads };
     } catch (error) {
@@ -178,10 +359,15 @@ export function createSelectedSwmMetaFetcher(options: {
         state.bytesEstimate = 0;
         state.nextOffset = 0;
         state.completed = false;
+        state.expiresAtMs = 0;
         state.generation += 1;
         completedContextGraphs.delete(request.contextGraphId);
         return fetchRetained(request, state, false);
       }
+      // Only an incomplete result returned by the page fetcher is resumable.
+      // Every thrown boundary is fail-closed: discard the prefix and its exact
+      // responder cursor before propagating the original error unchanged.
+      release(request.contextGraphId, state);
       throw error;
     }
   };
@@ -217,6 +403,39 @@ export function createSelectedSwmMetaFetcher(options: {
         progress: state?.nextOffset,
         generation: state?.generation ?? 0,
         completed: completedContextGraphs.has(contextGraphId),
+      };
+    },
+    settleOuterInvocation() {
+      for (const [contextGraphId, state] of states) {
+        // Completed manifests may be reused by continuation passes in the same
+        // outer invocation, but never become a cross-invocation cache. Empty
+        // state has no validated prefix to justify a non-zero cursor lifetime.
+        if (
+          state.completed
+          || state.nextOffset <= 0
+          || state.quads.length === 0
+          || state.expiresAtMs <= now()
+        ) {
+          release(contextGraphId, state);
+          completedContextGraphs.delete(contextGraphId);
+        }
+      }
+      const retained = [...states.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([contextGraphId, state]) => [
+          contextGraphId,
+          state.requesterScope,
+          state.generation,
+          state.nextOffset,
+          state.quads.length,
+          state.checkpointKey,
+        ]);
+      return {
+        retained: retained.length > 0,
+        progressToken: JSON.stringify(retained),
+        nextExpiryAtMs: retained.length > 0
+          ? Math.min(...[...states.values()].map((state) => state.expiresAtMs))
+          : undefined,
       };
     },
     cleanup() {

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -35,6 +35,8 @@ interface SelectedSwmMetaContinuationState {
 export interface SelectedSwmMetaFetcher {
   readonly strategy: SharedMemoryMetadataFetcher;
   continuation(contextGraphId: string): SelectedSwmMetaContinuation;
+  /** Release expired inactive prefixes while an outer peer operation is live. */
+  pruneExpiredPrefixes(): SelectedSwmMetaRetentionState;
   /**
    * Drop terminal/empty state at an outer reconciler boundary and describe the
    * useful incomplete prefix that remains eligible for a later invocation.
@@ -62,6 +64,7 @@ interface SelectedSwmMetaTransferEntry {
   fetcher: SelectedSwmMetaFetcher | undefined;
   tail: Promise<void>;
   expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  active: boolean;
 }
 
 /**
@@ -98,40 +101,45 @@ export class SelectedSwmMetaTransferCoordinator {
         fetcher: undefined,
         tail: Promise.resolve(),
         expiryTimer: undefined,
+        active: false,
       };
       this.#entries.set(remotePeerId, entry);
     }
 
     const execute = entry.tail.then(async () => {
       if (this.#closed) throw this.#closedError();
-      this.#clearExpiryTimer(entry!);
-      const retainedBeforeRun = entry!.fetcher?.settleOuterInvocation();
-      if (entry!.fetcher && !retainedBeforeRun?.retained) {
-        entry!.fetcher.cleanup();
-        entry!.fetcher = undefined;
-      }
-      const fetcher = entry!.fetcher ?? createFetcher();
-      entry!.fetcher = fetcher;
-      let succeeded = false;
+      entry!.active = true;
       try {
-        const result = await operation(fetcher);
-        succeeded = true;
-        return result;
-      } finally {
-        if (!succeeded) {
-          // An escaping abort, validation/integrity failure, or local build
-          // failure must never leave a cursor whose owner already unwound.
-          fetcher.cleanup();
+        const retainedBeforeRun = entry!.fetcher?.settleOuterInvocation();
+        if (entry!.fetcher && !retainedBeforeRun?.retained) {
+          entry!.fetcher.cleanup();
           entry!.fetcher = undefined;
-        } else {
-          const retention = fetcher.settleOuterInvocation();
-          if (!retention.retained) {
+        }
+        const fetcher = entry!.fetcher ?? createFetcher();
+        entry!.fetcher = fetcher;
+        let succeeded = false;
+        try {
+          const result = await operation(fetcher);
+          succeeded = true;
+          return result;
+        } finally {
+          if (!succeeded) {
+            // An escaping abort, validation/integrity failure, or local build
+            // failure must never leave a cursor whose owner already unwound.
             fetcher.cleanup();
             entry!.fetcher = undefined;
           } else {
-            this.#scheduleExpiry(remotePeerId, entry!, retention.nextExpiryAtMs);
+            const retention = fetcher.settleOuterInvocation();
+            if (!retention.retained) {
+              fetcher.cleanup();
+              entry!.fetcher = undefined;
+            } else {
+              this.#scheduleExpiry(remotePeerId, entry!, retention.nextExpiryAtMs);
+            }
           }
         }
+      } finally {
+        entry!.active = false;
       }
     });
     const settled = execute.then(() => undefined, () => undefined);
@@ -176,18 +184,20 @@ export class SelectedSwmMetaTransferCoordinator {
     entry.expiryTimer = setTimeout(() => {
       entry.expiryTimer = undefined;
       if (this.#closed || this.#entries.get(remotePeerId) !== entry) return;
-      const expire = entry.tail.then(() => {
-        if (this.#closed || this.#entries.get(remotePeerId) !== entry) return;
-        const retention = entry.fetcher?.settleOuterInvocation();
-        if (!retention?.retained) {
+      // Expiry is process-global capacity enforcement, not peer-local work.
+      // Prune inactive CG states immediately even while this peer owns a long
+      // outer operation, otherwise an expired lease can starve another peer.
+      // The fetcher tracks its active CG and never mutates that state here.
+      const retention = entry.fetcher?.pruneExpiredPrefixes();
+      if (!retention?.retained) {
+        if (!entry.active) {
           entry.fetcher?.cleanup();
           entry.fetcher = undefined;
           this.#entries.delete(remotePeerId);
-          return;
         }
-        this.#scheduleExpiry(remotePeerId, entry, retention.nextExpiryAtMs);
-      });
-      entry.tail = expire.then(() => undefined, () => undefined);
+        return;
+      }
+      this.#scheduleExpiry(remotePeerId, entry, retention.nextExpiryAtMs);
     }, delayMs);
     entry.expiryTimer.unref?.();
   }
@@ -229,6 +239,7 @@ export function createSelectedSwmMetaFetcher(options: {
 }): SelectedSwmMetaFetcher {
   const states = new Map<string, SelectedSwmMetaContinuationState>();
   const completedContextGraphs = new Set<string>();
+  const activeContextGraphs = new Set<string>();
   const now = options.now ?? (() => Date.now());
   const retentionTtlMs = options.retentionTtlMs ?? DURABLE_DATA_SYNC_SESSION_TTL_MS;
   if (!Number.isSafeInteger(retentionTtlMs) || retentionTtlMs <= 0) {
@@ -281,12 +292,12 @@ export function createSelectedSwmMetaFetcher(options: {
   const pruneExpiredStates = (): void => {
     for (const [contextGraphId, state] of states) {
       // This fetcher owns multiple Context Graphs for one peer. The
-      // coordinator's idle timer is intentionally peer-wide and is suspended
-      // while an outer operation runs, so enforce each CG's independent TTL
-      // again at every serialized fetch boundary. Completed/empty state keeps
-      // its existing outer-invocation lifecycle below.
+      // coordinator's timer is intentionally peer-wide, so enforce each CG's
+      // independent TTL at every serialized fetch boundary and timer tick.
+      // Completed/empty state keeps its existing outer-invocation lifecycle.
       if (
-        !state.completed
+        !activeContextGraphs.has(contextGraphId)
+        && !state.completed
         && state.nextOffset > 0
         && state.quads.length > 0
         && state.expiresAtMs <= now()
@@ -295,6 +306,33 @@ export function createSelectedSwmMetaFetcher(options: {
         completedContextGraphs.delete(contextGraphId);
       }
     }
+  };
+
+  const retentionState = (): SelectedSwmMetaRetentionState => {
+    const retained = [...states.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([contextGraphId, state]) => [
+        contextGraphId,
+        state.requesterScope,
+        state.generation,
+        state.nextOffset,
+        state.quads.length,
+        state.checkpointKey,
+      ]);
+    const expiringInactiveStates = [...states.entries()]
+      .filter(([contextGraphId, state]) => (
+        !activeContextGraphs.has(contextGraphId)
+        && !state.completed
+        && state.nextOffset > 0
+        && state.quads.length > 0
+      ));
+    return {
+      retained: retained.length > 0,
+      progressToken: JSON.stringify(retained),
+      nextExpiryAtMs: expiringInactiveStates.length > 0
+        ? Math.min(...expiringInactiveStates.map(([, state]) => state.expiresAtMs))
+        : undefined,
+    };
   };
 
   const fetchRetained = async (
@@ -397,23 +435,28 @@ export function createSelectedSwmMetaFetcher(options: {
     async fetch(request) {
       pruneExpiredStates();
       const state = ensureState(request.contextGraphId);
-      if (state.completed) {
-        return {
-          result: {
-            quads: state.quads,
-            bytesReceived: 0,
-            resumedFromOffset: state.nextOffset,
-            nextOffset: state.nextOffset,
-            checkpointKey: state.checkpointKey,
-            completed: true,
-            timedOut: false,
-          },
-          continuationYielded: false,
-        };
+      activeContextGraphs.add(request.contextGraphId);
+      try {
+        if (state.completed) {
+          return {
+            result: {
+              quads: state.quads,
+              bytesReceived: 0,
+              resumedFromOffset: state.nextOffset,
+              nextOffset: state.nextOffset,
+              checkpointKey: state.checkpointKey,
+              completed: true,
+              timedOut: false,
+            },
+            continuationYielded: false,
+          };
+        }
+        const result = await fetchRetained(request, state, true);
+        return { result, continuationYielded: !state.completed };
+      } finally {
+        activeContextGraphs.delete(request.contextGraphId);
+        pruneExpiredStates();
       }
-      const result = await fetchRetained(request, state, true);
-      pruneExpiredStates();
-      return { result, continuationYielded: !state.completed };
     },
     release,
   };
@@ -427,6 +470,10 @@ export function createSelectedSwmMetaFetcher(options: {
         generation: state?.generation ?? 0,
         completed: completedContextGraphs.has(contextGraphId),
       };
+    },
+    pruneExpiredPrefixes() {
+      pruneExpiredStates();
+      return retentionState();
     },
     settleOuterInvocation() {
       pruneExpiredStates();
@@ -443,23 +490,7 @@ export function createSelectedSwmMetaFetcher(options: {
           completedContextGraphs.delete(contextGraphId);
         }
       }
-      const retained = [...states.entries()]
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([contextGraphId, state]) => [
-          contextGraphId,
-          state.requesterScope,
-          state.generation,
-          state.nextOffset,
-          state.quads.length,
-          state.checkpointKey,
-        ]);
-      return {
-        retained: retained.length > 0,
-        progressToken: JSON.stringify(retained),
-        nextExpiryAtMs: retained.length > 0
-          ? Math.min(...[...states.values()].map((state) => state.expiresAtMs))
-          : undefined,
-      };
+      return retentionState();
     },
     cleanup() {
       for (const [contextGraphId, state] of states) release(contextGraphId, state);

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -47,8 +47,6 @@ export interface SelectedSwmMetaFetcher {
 
 export interface SelectedSwmMetaRetentionState {
   readonly retained: boolean;
-  /** Changes only when a retained generation or exact prefix changes. */
-  readonly progressToken: string;
   /** Earliest independent Context Graph prefix expiry. */
   readonly nextExpiryAtMs: number | undefined;
 }
@@ -58,155 +56,6 @@ export interface SelectedSwmMetaContinuation {
   readonly progress: number | undefined;
   readonly generation: number;
   readonly completed: boolean;
-}
-
-interface SelectedSwmMetaTransferEntry {
-  fetcher: SelectedSwmMetaFetcher | undefined;
-  tail: Promise<void>;
-  expiryTimer: ReturnType<typeof setTimeout> | undefined;
-  active: boolean;
-}
-
-/**
- * Agent-local, peer-serial ownership for selected-SWM metadata prefixes.
- *
- * A responder offset is meaningful only together with the byte-identical
- * validated prefix and responder session that produced it. This coordinator
- * keeps that tuple alive across bounded reconciler invocations, while allowing
- * exactly one invocation for a peer to mutate it at a time. It is deliberately
- * not a generic SWM cache: ordinary/private SWM retain their existing behavior.
- */
-export class SelectedSwmMetaTransferCoordinator {
-  readonly #entries = new Map<string, SelectedSwmMetaTransferEntry>();
-
-  readonly #now: () => number;
-
-  #closed = false;
-
-  constructor(options: {
-    readonly now?: () => number;
-  } = {}) {
-    this.#now = options.now ?? (() => Date.now());
-  }
-
-  run<T>(
-    remotePeerId: string,
-    createFetcher: () => SelectedSwmMetaFetcher,
-    operation: (fetcher: SelectedSwmMetaFetcher) => Promise<T>,
-  ): Promise<T> {
-    if (this.#closed) return Promise.reject(this.#closedError());
-    let entry = this.#entries.get(remotePeerId);
-    if (!entry) {
-      entry = {
-        fetcher: undefined,
-        tail: Promise.resolve(),
-        expiryTimer: undefined,
-        active: false,
-      };
-      this.#entries.set(remotePeerId, entry);
-    }
-
-    const execute = entry.tail.then(async () => {
-      if (this.#closed) throw this.#closedError();
-      entry!.active = true;
-      try {
-        const retainedBeforeRun = entry!.fetcher?.settleOuterInvocation();
-        if (entry!.fetcher && !retainedBeforeRun?.retained) {
-          entry!.fetcher.cleanup();
-          entry!.fetcher = undefined;
-        }
-        const fetcher = entry!.fetcher ?? createFetcher();
-        entry!.fetcher = fetcher;
-        let succeeded = false;
-        try {
-          const result = await operation(fetcher);
-          succeeded = true;
-          return result;
-        } finally {
-          if (!succeeded) {
-            // An escaping abort, validation/integrity failure, or local build
-            // failure must never leave a cursor whose owner already unwound.
-            fetcher.cleanup();
-            entry!.fetcher = undefined;
-          } else {
-            const retention = fetcher.settleOuterInvocation();
-            if (!retention.retained) {
-              fetcher.cleanup();
-              entry!.fetcher = undefined;
-            } else {
-              this.#scheduleExpiry(remotePeerId, entry!, retention.nextExpiryAtMs);
-            }
-          }
-        }
-      } finally {
-        entry!.active = false;
-      }
-    });
-    const settled = execute.then(() => undefined, () => undefined);
-    entry.tail = settled;
-    void settled.then(() => {
-      if (
-        this.#entries.get(remotePeerId) === entry
-        && entry!.tail === settled
-        && !entry!.fetcher
-      ) {
-        this.#entries.delete(remotePeerId);
-      }
-    });
-    return execute;
-  }
-
-  async close(): Promise<void> {
-    this.#closed = true;
-    const entries = [...this.#entries.values()];
-    for (const entry of entries) this.#clearExpiryTimer(entry);
-    await Promise.all(entries.map((entry) => entry.tail));
-    for (const entry of entries) {
-      entry.fetcher?.cleanup();
-      entry.fetcher = undefined;
-    }
-    this.#entries.clear();
-  }
-
-  #clearExpiryTimer(entry: SelectedSwmMetaTransferEntry): void {
-    if (entry.expiryTimer) clearTimeout(entry.expiryTimer);
-    entry.expiryTimer = undefined;
-  }
-
-  #scheduleExpiry(
-    remotePeerId: string,
-    entry: SelectedSwmMetaTransferEntry,
-    nextExpiryAtMs: number | undefined,
-  ): void {
-    this.#clearExpiryTimer(entry);
-    if (nextExpiryAtMs === undefined || this.#closed) return;
-    const delayMs = Math.max(1, nextExpiryAtMs - this.#now());
-    entry.expiryTimer = setTimeout(() => {
-      entry.expiryTimer = undefined;
-      if (this.#closed || this.#entries.get(remotePeerId) !== entry) return;
-      // Expiry is process-global capacity enforcement, not peer-local work.
-      // Prune inactive CG states immediately even while this peer owns a long
-      // outer operation, otherwise an expired lease can starve another peer.
-      // The fetcher tracks its active CG and never mutates that state here.
-      const retention = entry.fetcher?.pruneExpiredPrefixes();
-      if (!retention?.retained) {
-        if (!entry.active) {
-          entry.fetcher?.cleanup();
-          entry.fetcher = undefined;
-          this.#entries.delete(remotePeerId);
-        }
-        return;
-      }
-      this.#scheduleExpiry(remotePeerId, entry, retention.nextExpiryAtMs);
-    }, delayMs);
-    entry.expiryTimer.unref?.();
-  }
-
-  #closedError(): Error {
-    const error = new Error('Selected SWM metadata transfer coordinator is closed');
-    error.name = 'AbortError';
-    return error;
-  }
 }
 
 interface SelectedMetaPageFetchRequest {
@@ -309,16 +158,6 @@ export function createSelectedSwmMetaFetcher(options: {
   };
 
   const retentionState = (): SelectedSwmMetaRetentionState => {
-    const retained = [...states.entries()]
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([contextGraphId, state]) => [
-        contextGraphId,
-        state.requesterScope,
-        state.generation,
-        state.nextOffset,
-        state.quads.length,
-        state.checkpointKey,
-      ]);
     const expiringInactiveStates = [...states.entries()]
       .filter(([contextGraphId, state]) => (
         !activeContextGraphs.has(contextGraphId)
@@ -327,8 +166,7 @@ export function createSelectedSwmMetaFetcher(options: {
         && state.quads.length > 0
       ));
     return {
-      retained: retained.length > 0,
-      progressToken: JSON.stringify(retained),
+      retained: states.size > 0,
       nextExpiryAtMs: expiringInactiveStates.length > 0
         ? Math.min(...expiringInactiveStates.map(([, state]) => state.expiresAtMs))
         : undefined,

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -278,6 +278,25 @@ export function createSelectedSwmMetaFetcher(options: {
     return state;
   };
 
+  const pruneExpiredStates = (): void => {
+    for (const [contextGraphId, state] of states) {
+      // This fetcher owns multiple Context Graphs for one peer. The
+      // coordinator's idle timer is intentionally peer-wide and is suspended
+      // while an outer operation runs, so enforce each CG's independent TTL
+      // again at every serialized fetch boundary. Completed/empty state keeps
+      // its existing outer-invocation lifecycle below.
+      if (
+        !state.completed
+        && state.nextOffset > 0
+        && state.quads.length > 0
+        && state.expiresAtMs <= now()
+      ) {
+        release(contextGraphId, state);
+        completedContextGraphs.delete(contextGraphId);
+      }
+    }
+  };
+
   const fetchRetained = async (
     request: SharedMemoryMetadataFetchRequest,
     state: SelectedSwmMetaContinuationState,
@@ -376,6 +395,7 @@ export function createSelectedSwmMetaFetcher(options: {
 
   const strategy: SharedMemoryMetadataFetcher = {
     async fetch(request) {
+      pruneExpiredStates();
       const state = ensureState(request.contextGraphId);
       if (state.completed) {
         return {
@@ -392,6 +412,7 @@ export function createSelectedSwmMetaFetcher(options: {
         };
       }
       const result = await fetchRetained(request, state, true);
+      pruneExpiredStates();
       return { result, continuationYielded: !state.completed };
     },
     release,
@@ -408,6 +429,7 @@ export function createSelectedSwmMetaFetcher(options: {
       };
     },
     settleOuterInvocation() {
+      pruneExpiredStates();
       for (const [contextGraphId, state] of states) {
         // Completed manifests may be reused by continuation passes in the same
         // outer invocation, but never become a cross-invocation cache. Empty
@@ -416,7 +438,6 @@ export function createSelectedSwmMetaFetcher(options: {
           state.completed
           || state.nextOffset <= 0
           || state.quads.length === 0
-          || state.expiresAtMs <= now()
         ) {
           release(contextGraphId, state);
           completedContextGraphs.delete(contextGraphId);

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -35,6 +35,15 @@ interface SelectedSwmMetaContinuationState {
 export interface SelectedSwmMetaFetcher {
   readonly strategy: SharedMemoryMetadataFetcher;
   continuation(contextGraphId: string): SelectedSwmMetaContinuation;
+}
+
+interface SelectedSwmMetaRetentionState {
+  readonly retained: boolean;
+  /** Earliest independent Context Graph prefix expiry. */
+  readonly nextExpiryAtMs: number | undefined;
+}
+
+interface SelectedSwmMetaFetcherLifecycle {
   /** Release expired inactive prefixes while an outer peer operation is live. */
   pruneExpiredPrefixes(): SelectedSwmMetaRetentionState;
   /**
@@ -45,10 +54,155 @@ export interface SelectedSwmMetaFetcher {
   cleanup(): void;
 }
 
-export interface SelectedSwmMetaRetentionState {
-  readonly retained: boolean;
-  /** Earliest independent Context Graph prefix expiry. */
-  readonly nextExpiryAtMs: number | undefined;
+const selectedSwmMetaFetcherLifecycles = new WeakMap<
+SelectedSwmMetaFetcher,
+SelectedSwmMetaFetcherLifecycle
+>();
+
+/**
+ * One peer's complete retained-prefix lifecycle.
+ *
+ * The coordinator only registers these owners by peer. Serialization, outer
+ * invocation boundaries, independent prefix expiry, failure cleanup, and
+ * shutdown drain all remain behind this single API.
+ */
+export class SelectedSwmMetaTransferOwner {
+  readonly #now: () => number;
+
+  readonly #onIdle: (() => void) | undefined;
+
+  #fetcher: SelectedSwmMetaFetcher | undefined;
+
+  #tail: Promise<void> = Promise.resolve();
+
+  #expiryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  #active = false;
+
+  #pendingRuns = 0;
+
+  #closed = false;
+
+  constructor(options: {
+    readonly now?: () => number;
+    readonly onIdle?: () => void;
+  } = {}) {
+    this.#now = options.now ?? (() => Date.now());
+    this.#onIdle = options.onIdle;
+  }
+
+  run<T>(
+    createFetcher: () => SelectedSwmMetaFetcher,
+    operation: (fetcher: SelectedSwmMetaFetcher) => Promise<T>,
+  ): Promise<T> {
+    if (this.#closed) return Promise.reject(this.#closedError());
+    this.#pendingRuns += 1;
+    const execute = this.#tail.then(async () => {
+      if (this.#closed) throw this.#closedError();
+      this.#active = true;
+      try {
+        const retainedBeforeRun = this.#fetcher
+          ? this.#lifecycle(this.#fetcher).settleOuterInvocation()
+          : undefined;
+        if (this.#fetcher && !retainedBeforeRun?.retained) {
+          this.#releaseFetcher();
+        }
+        const fetcher = this.#fetcher ?? createFetcher();
+        // Resolve the private lifecycle before retaining a newly-created
+        // fetcher, so an invalid factory cannot become owner state.
+        this.#lifecycle(fetcher);
+        this.#fetcher = fetcher;
+        let succeeded = false;
+        try {
+          const result = await operation(fetcher);
+          succeeded = true;
+          return result;
+        } finally {
+          if (!succeeded) {
+            this.#releaseFetcher();
+          } else {
+            const retention = this.#lifecycle(fetcher).settleOuterInvocation();
+            if (!retention.retained) {
+              this.#releaseFetcher();
+            } else {
+              this.#scheduleExpiry(retention.nextExpiryAtMs);
+            }
+          }
+        }
+      } finally {
+        this.#active = false;
+      }
+    });
+    const settled = execute.then(() => undefined, () => undefined);
+    this.#tail = settled;
+    void settled.then(() => {
+      this.#pendingRuns -= 1;
+      this.#notifyIdle();
+    });
+    return execute;
+  }
+
+  isIdle(): boolean {
+    return this.#pendingRuns === 0 && !this.#fetcher;
+  }
+
+  async close(): Promise<void> {
+    this.#closed = true;
+    this.#clearExpiryTimer();
+    await this.#tail;
+    this.#releaseFetcher();
+  }
+
+  #lifecycle(fetcher: SelectedSwmMetaFetcher): SelectedSwmMetaFetcherLifecycle {
+    const lifecycle = selectedSwmMetaFetcherLifecycles.get(fetcher);
+    if (!lifecycle) {
+      throw new Error('Selected SWM metadata owner received an unowned fetcher');
+    }
+    return lifecycle;
+  }
+
+  #releaseFetcher(): void {
+    if (this.#fetcher) this.#lifecycle(this.#fetcher).cleanup();
+    this.#fetcher = undefined;
+    this.#clearExpiryTimer();
+  }
+
+  #clearExpiryTimer(): void {
+    if (this.#expiryTimer) clearTimeout(this.#expiryTimer);
+    this.#expiryTimer = undefined;
+  }
+
+  #scheduleExpiry(nextExpiryAtMs: number | undefined): void {
+    this.#clearExpiryTimer();
+    if (nextExpiryAtMs === undefined || this.#closed) return;
+    const delayMs = Math.max(1, nextExpiryAtMs - this.#now());
+    this.#expiryTimer = setTimeout(() => {
+      this.#expiryTimer = undefined;
+      if (this.#closed || !this.#fetcher) return;
+      // The fetcher protects active CGs, allowing this peer owner to reclaim
+      // expired siblings even while another CG's operation is in flight.
+      const retention = this.#lifecycle(this.#fetcher).pruneExpiredPrefixes();
+      if (!retention.retained) {
+        if (!this.#active) {
+          this.#releaseFetcher();
+          this.#notifyIdle();
+        }
+        return;
+      }
+      this.#scheduleExpiry(retention.nextExpiryAtMs);
+    }, delayMs);
+    this.#expiryTimer.unref?.();
+  }
+
+  #closedError(): Error {
+    const error = new Error('Selected SWM metadata transfer owner is closed');
+    error.name = 'AbortError';
+    return error;
+  }
+
+  #notifyIdle(): void {
+    if (this.isIdle()) this.#onIdle?.();
+  }
 }
 
 /** Immutable continuation evidence captured immediately after one SWM round. */
@@ -299,7 +453,7 @@ export function createSelectedSwmMetaFetcher(options: {
     release,
   };
 
-  return {
+  const fetcher: SelectedSwmMetaFetcher = {
     strategy,
     continuation: (contextGraphId) => {
       const state = states.get(contextGraphId);
@@ -309,6 +463,8 @@ export function createSelectedSwmMetaFetcher(options: {
         completed: completedContextGraphs.has(contextGraphId),
       };
     },
+  };
+  selectedSwmMetaFetcherLifecycles.set(fetcher, {
     pruneExpiredPrefixes() {
       pruneExpiredStates();
       return retentionState();
@@ -334,5 +490,6 @@ export function createSelectedSwmMetaFetcher(options: {
       for (const [contextGraphId, state] of states) release(contextGraphId, state);
       completedContextGraphs.clear();
     },
-  };
+  });
+  return fetcher;
 }

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -205,6 +205,7 @@ interface SelectedMetaPageFetchRequest {
   readonly contextGraphId: string;
   readonly graphUri: string;
   readonly deadline: number;
+  readonly returnAcceptedPrefixOnRetryableTransportFailure: true;
   readonly requesterScope: SelectedSwmMetaRetentionScope;
   readonly maxAcceptedQuads: number;
   readonly maxAcceptedHeapBytesEstimate: number;
@@ -288,6 +289,7 @@ export function createSelectedSwmMetaFetcher(options: {
     try {
       const fetched = await options.fetchPage({
         ...request,
+        returnAcceptedPrefixOnRetryableTransportFailure: true,
         requesterScope: state.requesterScope,
         maxAcceptedQuads: reservation.maxRows,
         maxAcceptedHeapBytesEstimate: reservation.maxBytesEstimate,

--- a/packages/agent/src/sync/selected-swm-meta-transfer-coordinator.ts
+++ b/packages/agent/src/sync/selected-swm-meta-transfer-coordinator.ts
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SelectedSwmMetaFetcher } from './selected-swm-meta-fetcher.js';
+import {
+  SelectedSwmMetaTransferOwner,
+  type SelectedSwmMetaFetcher,
+} from './selected-swm-meta-fetcher.js';
 
-interface SelectedSwmMetaTransferEntry {
-  fetcher: SelectedSwmMetaFetcher | undefined;
-  tail: Promise<void>;
-  expiryTimer: ReturnType<typeof setTimeout> | undefined;
-  active: boolean;
-}
-
-/** Agent-owned peer serialization, expiry, and shutdown for retained metadata prefixes. */
+/** Agent-owned registry and shutdown boundary for per-peer metadata transfer owners. */
 export class SelectedSwmMetaTransferCoordinator {
-  readonly #entries = new Map<string, SelectedSwmMetaTransferEntry>();
+  readonly #owners = new Map<string, SelectedSwmMetaTransferOwner>();
 
   readonly #now: () => number;
 
@@ -27,107 +23,32 @@ export class SelectedSwmMetaTransferCoordinator {
     operation: (fetcher: SelectedSwmMetaFetcher) => Promise<T>,
   ): Promise<T> {
     if (this.#closed) return Promise.reject(this.#closedError());
-    let entry = this.#entries.get(remotePeerId);
-    if (!entry) {
-      entry = {
-        fetcher: undefined,
-        tail: Promise.resolve(),
-        expiryTimer: undefined,
-        active: false,
-      };
-      this.#entries.set(remotePeerId, entry);
-    }
-
-    const execute = entry.tail.then(async () => {
-      if (this.#closed) throw this.#closedError();
-      entry!.active = true;
-      try {
-        const retainedBeforeRun = entry!.fetcher?.settleOuterInvocation();
-        if (entry!.fetcher && !retainedBeforeRun?.retained) {
-          entry!.fetcher.cleanup();
-          entry!.fetcher = undefined;
-        }
-        const fetcher = entry!.fetcher ?? createFetcher();
-        entry!.fetcher = fetcher;
-        let succeeded = false;
-        try {
-          const result = await operation(fetcher);
-          succeeded = true;
-          return result;
-        } finally {
-          if (!succeeded) {
-            fetcher.cleanup();
-            entry!.fetcher = undefined;
-          } else {
-            const retention = fetcher.settleOuterInvocation();
-            if (!retention.retained) {
-              fetcher.cleanup();
-              entry!.fetcher = undefined;
-            } else {
-              this.#scheduleExpiry(remotePeerId, entry!, retention.nextExpiryAtMs);
-            }
+    let owner = this.#owners.get(remotePeerId);
+    if (!owner) {
+      let registeredOwner: SelectedSwmMetaTransferOwner;
+      registeredOwner = new SelectedSwmMetaTransferOwner({
+        now: this.#now,
+        onIdle: () => {
+          if (
+            this.#owners.get(remotePeerId) === registeredOwner
+            && registeredOwner.isIdle()
+          ) {
+            this.#owners.delete(remotePeerId);
           }
-        }
-      } finally {
-        entry!.active = false;
-      }
-    });
-    const settled = execute.then(() => undefined, () => undefined);
-    entry.tail = settled;
-    void settled.then(() => {
-      if (
-        this.#entries.get(remotePeerId) === entry
-        && entry!.tail === settled
-        && !entry!.fetcher
-      ) {
-        this.#entries.delete(remotePeerId);
-      }
-    });
+        },
+      });
+      owner = registeredOwner;
+      this.#owners.set(remotePeerId, owner);
+    }
+    const execute = owner.run(createFetcher, operation);
     return execute;
   }
 
   async close(): Promise<void> {
     this.#closed = true;
-    const entries = [...this.#entries.values()];
-    for (const entry of entries) this.#clearExpiryTimer(entry);
-    await Promise.all(entries.map((entry) => entry.tail));
-    for (const entry of entries) {
-      entry.fetcher?.cleanup();
-      entry.fetcher = undefined;
-    }
-    this.#entries.clear();
-  }
-
-  #clearExpiryTimer(entry: SelectedSwmMetaTransferEntry): void {
-    if (entry.expiryTimer) clearTimeout(entry.expiryTimer);
-    entry.expiryTimer = undefined;
-  }
-
-  #scheduleExpiry(
-    remotePeerId: string,
-    entry: SelectedSwmMetaTransferEntry,
-    nextExpiryAtMs: number | undefined,
-  ): void {
-    this.#clearExpiryTimer(entry);
-    if (nextExpiryAtMs === undefined || this.#closed) return;
-    const delayMs = Math.max(1, nextExpiryAtMs - this.#now());
-    entry.expiryTimer = setTimeout(() => {
-      entry.expiryTimer = undefined;
-      if (this.#closed || this.#entries.get(remotePeerId) !== entry) return;
-      // Expiry enforces a process-global budget. Prune inactive CG states even
-      // while this peer owns another operation; the fetcher protects active CGs.
-      const retention = entry.fetcher?.pruneExpiredPrefixes();
-      if (!retention?.retained) {
-        if (!entry.active) {
-          entry.fetcher?.cleanup();
-          entry.fetcher = undefined;
-          this.#entries.delete(remotePeerId);
-        }
-        return;
-      }
-      this.#scheduleExpiry(remotePeerId, entry, retention.nextExpiryAtMs);
-    }, delayMs);
-    entry.expiryTimer.unref?.();
+    const owners = [...this.#owners.values()];
+    await Promise.all(owners.map((owner) => owner.close()));
+    this.#owners.clear();
   }
 
   #closedError(): Error {

--- a/packages/agent/src/sync/selected-swm-meta-transfer-coordinator.ts
+++ b/packages/agent/src/sync/selected-swm-meta-transfer-coordinator.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SelectedSwmMetaFetcher } from './selected-swm-meta-fetcher.js';
+
+interface SelectedSwmMetaTransferEntry {
+  fetcher: SelectedSwmMetaFetcher | undefined;
+  tail: Promise<void>;
+  expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  active: boolean;
+}
+
+/** Agent-owned peer serialization, expiry, and shutdown for retained metadata prefixes. */
+export class SelectedSwmMetaTransferCoordinator {
+  readonly #entries = new Map<string, SelectedSwmMetaTransferEntry>();
+
+  readonly #now: () => number;
+
+  #closed = false;
+
+  constructor(options: { readonly now?: () => number } = {}) {
+    this.#now = options.now ?? (() => Date.now());
+  }
+
+  run<T>(
+    remotePeerId: string,
+    createFetcher: () => SelectedSwmMetaFetcher,
+    operation: (fetcher: SelectedSwmMetaFetcher) => Promise<T>,
+  ): Promise<T> {
+    if (this.#closed) return Promise.reject(this.#closedError());
+    let entry = this.#entries.get(remotePeerId);
+    if (!entry) {
+      entry = {
+        fetcher: undefined,
+        tail: Promise.resolve(),
+        expiryTimer: undefined,
+        active: false,
+      };
+      this.#entries.set(remotePeerId, entry);
+    }
+
+    const execute = entry.tail.then(async () => {
+      if (this.#closed) throw this.#closedError();
+      entry!.active = true;
+      try {
+        const retainedBeforeRun = entry!.fetcher?.settleOuterInvocation();
+        if (entry!.fetcher && !retainedBeforeRun?.retained) {
+          entry!.fetcher.cleanup();
+          entry!.fetcher = undefined;
+        }
+        const fetcher = entry!.fetcher ?? createFetcher();
+        entry!.fetcher = fetcher;
+        let succeeded = false;
+        try {
+          const result = await operation(fetcher);
+          succeeded = true;
+          return result;
+        } finally {
+          if (!succeeded) {
+            fetcher.cleanup();
+            entry!.fetcher = undefined;
+          } else {
+            const retention = fetcher.settleOuterInvocation();
+            if (!retention.retained) {
+              fetcher.cleanup();
+              entry!.fetcher = undefined;
+            } else {
+              this.#scheduleExpiry(remotePeerId, entry!, retention.nextExpiryAtMs);
+            }
+          }
+        }
+      } finally {
+        entry!.active = false;
+      }
+    });
+    const settled = execute.then(() => undefined, () => undefined);
+    entry.tail = settled;
+    void settled.then(() => {
+      if (
+        this.#entries.get(remotePeerId) === entry
+        && entry!.tail === settled
+        && !entry!.fetcher
+      ) {
+        this.#entries.delete(remotePeerId);
+      }
+    });
+    return execute;
+  }
+
+  async close(): Promise<void> {
+    this.#closed = true;
+    const entries = [...this.#entries.values()];
+    for (const entry of entries) this.#clearExpiryTimer(entry);
+    await Promise.all(entries.map((entry) => entry.tail));
+    for (const entry of entries) {
+      entry.fetcher?.cleanup();
+      entry.fetcher = undefined;
+    }
+    this.#entries.clear();
+  }
+
+  #clearExpiryTimer(entry: SelectedSwmMetaTransferEntry): void {
+    if (entry.expiryTimer) clearTimeout(entry.expiryTimer);
+    entry.expiryTimer = undefined;
+  }
+
+  #scheduleExpiry(
+    remotePeerId: string,
+    entry: SelectedSwmMetaTransferEntry,
+    nextExpiryAtMs: number | undefined,
+  ): void {
+    this.#clearExpiryTimer(entry);
+    if (nextExpiryAtMs === undefined || this.#closed) return;
+    const delayMs = Math.max(1, nextExpiryAtMs - this.#now());
+    entry.expiryTimer = setTimeout(() => {
+      entry.expiryTimer = undefined;
+      if (this.#closed || this.#entries.get(remotePeerId) !== entry) return;
+      // Expiry enforces a process-global budget. Prune inactive CG states even
+      // while this peer owns another operation; the fetcher protects active CGs.
+      const retention = entry.fetcher?.pruneExpiredPrefixes();
+      if (!retention?.retained) {
+        if (!entry.active) {
+          entry.fetcher?.cleanup();
+          entry.fetcher = undefined;
+          this.#entries.delete(remotePeerId);
+        }
+        return;
+      }
+      this.#scheduleExpiry(remotePeerId, entry, retention.nextExpiryAtMs);
+    }, delayMs);
+    entry.expiryTimer.unref?.();
+  }
+
+  #closedError(): Error {
+    const error = new Error('Selected SWM metadata transfer coordinator is closed');
+    error.name = 'AbortError';
+    return error;
+  }
+}

--- a/packages/agent/test/outbox-shutdown-lifecycle.test.ts
+++ b/packages/agent/test/outbox-shutdown-lifecycle.test.ts
@@ -13,8 +13,8 @@ import {
 } from '../src/vm-reconcile-service.js';
 import {
   createSelectedSwmMetaFetcher,
-  SelectedSwmMetaTransferCoordinator,
 } from '../src/sync/selected-swm-meta-fetcher.js';
+import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-meta-transfer-coordinator.js';
 import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
 
 describe('DKGAgent outbox shutdown lifecycle', () => {

--- a/packages/agent/test/outbox-shutdown-lifecycle.test.ts
+++ b/packages/agent/test/outbox-shutdown-lifecycle.test.ts
@@ -18,12 +18,18 @@ import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-met
 import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
 
 describe('DKGAgent outbox shutdown lifecycle', () => {
-  it('drains retained selected-SWM prefixes after network stop and before store close', async () => {
+  it('drains an in-flight selected-SWM owner after network stop and before store close', async () => {
     const events: string[] = [];
     const transfers = new SelectedSwmMetaTransferCoordinator();
     const deleteCheckpoint = vi.fn(() => events.push('prefix-cleaned'));
     const peerId = 'peer-stop-order';
-    await transfers.run(
+    let releaseTransfer!: () => void;
+    const transferGate = new Promise<void>((resolve) => { releaseTransfer = resolve; });
+    let signalTransferStarted!: () => void;
+    const transferStarted = new Promise<void>((resolve) => {
+      signalTransferStarted = resolve;
+    });
+    const transfer = transfers.run(
       peerId,
       () => createSelectedSwmMetaFetcher({
         remotePeerId: peerId,
@@ -35,15 +41,19 @@ describe('DKGAgent outbox shutdown lifecycle', () => {
           maxPrefixBytesEstimate: 1024,
         }),
         deleteCheckpoint,
-        fetchPage: async () => ({
-          quads: [{ subject: 'urn:s', predicate: 'urn:p', object: '"o"', graph: 'urn:g' }],
-          bytesReceived: 1,
-          resumedFromOffset: 0,
-          nextOffset: 1,
-          checkpointKey: 'retained-stop-checkpoint',
-          completed: false,
-          timedOut: true,
-        }),
+        fetchPage: async () => {
+          signalTransferStarted();
+          await transferGate;
+          return {
+            quads: [{ subject: 'urn:s', predicate: 'urn:p', object: '"o"', graph: 'urn:g' }],
+            bytesReceived: 1,
+            resumedFromOffset: 0,
+            nextOffset: 1,
+            checkpointKey: 'retained-stop-checkpoint',
+            completed: false,
+            timedOut: true,
+          };
+        },
       }),
       (fetcher) => fetcher.strategy.fetch({
         ctx: { operationId: 'stop-order', operationName: 'sync' } as never,
@@ -53,6 +63,7 @@ describe('DKGAgent outbox shutdown lifecycle', () => {
         deadline: Date.now() + 1_000,
       }),
     );
+    await transferStarted;
     // Initial ownership deliberately clears any orphaned cursor for this fresh
     // scope; observe only the later shutdown release.
     deleteCheckpoint.mockClear();
@@ -84,7 +95,14 @@ describe('DKGAgent outbox shutdown lifecycle', () => {
       log: { warn: vi.fn() },
     });
 
-    await expect(agent.stop()).resolves.toBeUndefined();
+    const stopping = agent.stop();
+    await vi.waitFor(() => expect(agent.node.stop).toHaveBeenCalledOnce());
+    expect(agent.store.close).not.toHaveBeenCalled();
+    expect(deleteCheckpoint).not.toHaveBeenCalled();
+    expect(agent.selectedSwmMetaTransfers).toBe(transfers);
+
+    releaseTransfer();
+    await Promise.all([transfer, stopping]);
     expect(events).toEqual(['node-stop', 'prefix-cleaned', 'store-close']);
   });
 

--- a/packages/agent/test/outbox-shutdown-lifecycle.test.ts
+++ b/packages/agent/test/outbox-shutdown-lifecycle.test.ts
@@ -11,8 +11,83 @@ import {
   VmReconcileQueueClosedError,
   VmReconcileShutdownTimeoutError,
 } from '../src/vm-reconcile-service.js';
+import {
+  createSelectedSwmMetaFetcher,
+  SelectedSwmMetaTransferCoordinator,
+} from '../src/sync/selected-swm-meta-fetcher.js';
+import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
 
 describe('DKGAgent outbox shutdown lifecycle', () => {
+  it('drains retained selected-SWM prefixes after network stop and before store close', async () => {
+    const events: string[] = [];
+    const transfers = new SelectedSwmMetaTransferCoordinator();
+    const deleteCheckpoint = vi.fn(() => events.push('prefix-cleaned'));
+    const peerId = 'peer-stop-order';
+    await transfers.run(
+      peerId,
+      () => createSelectedSwmMetaFetcher({
+        remotePeerId: peerId,
+        requesterScope: 'selected-swm-meta:retained:1',
+        retentionBudget: createSelectedSwmMetaRetentionBudget({
+          maxRows: 10,
+          maxBytesEstimate: 1024,
+          maxPrefixRows: 10,
+          maxPrefixBytesEstimate: 1024,
+        }),
+        deleteCheckpoint,
+        fetchPage: async () => ({
+          quads: [{ subject: 'urn:s', predicate: 'urn:p', object: '"o"', graph: 'urn:g' }],
+          bytesReceived: 1,
+          resumedFromOffset: 0,
+          nextOffset: 1,
+          checkpointKey: 'retained-stop-checkpoint',
+          completed: false,
+          timedOut: true,
+        }),
+      }),
+      (fetcher) => fetcher.strategy.fetch({
+        ctx: { operationId: 'stop-order', operationName: 'sync' } as never,
+        remotePeerId: peerId,
+        contextGraphId: 'cg-stop-order',
+        graphUri: 'urn:g',
+        deadline: Date.now() + 1_000,
+      }),
+    );
+    // Initial ownership deliberately clears any orphaned cursor for this fresh
+    // scope; observe only the later shutdown release.
+    deleteCheckpoint.mockClear();
+    events.length = 0;
+
+    const agent = Object.create(DKGAgent.prototype) as any;
+    Object.assign(agent, {
+      started: true,
+      chainPoller: null,
+      selectedSwmMetaTransfers: transfers,
+      coreHostRecordingsClosed: false,
+      drainCoreHostRecordings: vi.fn(async () => {}),
+      messenger: { stopOutboxDrain: vi.fn(async () => {}) },
+      clearRandomSamplingBindRetry: vi.fn(),
+      clearStorageACKRegistrationRetry: vi.fn(),
+      storageACKRegistrationRetryInFlight: false,
+      randomSamplingHandle: null,
+      inFlightSubstrateFanOutCount: () => 0,
+      router: { closePooling: vi.fn(async () => {}) },
+      node: { stop: vi.fn(async () => { events.push('node-stop'); }) },
+      finalizationRuntime: new FinalizationRuntime(),
+      store: {
+        close: vi.fn(async () => {
+          expect(deleteCheckpoint).toHaveBeenCalledWith('retained-stop-checkpoint');
+          expect(agent.selectedSwmMetaTransfers).toBeUndefined();
+          events.push('store-close');
+        }),
+      },
+      log: { warn: vi.fn() },
+    });
+
+    await expect(agent.stop()).resolves.toBeUndefined();
+    expect(events).toEqual(['node-stop', 'prefix-cleaned', 'store-close']);
+  });
+
   it('closes and drains membership persistence before network and store teardown', async () => {
     const membershipPersistence = new ContextGraphMembershipPersistScheduler();
     let releaseWrite!: () => void;

--- a/packages/agent/test/selected-swm-continuation.test.ts
+++ b/packages/agent/test/selected-swm-continuation.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   contextGraphWorkspaceMetaGraphUri,
   PROTOCOL_SYNC,
-  type OperationContext,
 } from '@origintrail-official/dkg-core';
 import { workspacePublicQuadsDigest } from '@origintrail-official/dkg-publisher';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
@@ -10,15 +9,11 @@ import type {
   SharedMemorySyncResult,
   SwmSnapshotCoverage,
 } from '../src/dkg-agent-types.js';
-import {
-  closeSelectedSwmMetaTransfers,
-  LifecycleSyncMethods,
-} from '../src/dkg-agent-lifecycle.js';
+import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 import {
   runSelectedSwmContinuations,
 } from '../src/sync/selected-swm-continuation.js';
 import {
-  createSelectedSwmMetaFetcher,
   SelectedSwmMetaTransferCoordinator,
   type SelectedSwmMetaContinuation,
 } from '../src/sync/selected-swm-meta-fetcher.js';
@@ -34,7 +29,6 @@ import {
 } from '../src/sync/requester/page-fetch.js';
 import { estimateQuadHeapBytes } from '../src/sync/memory-telemetry.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../src/sync/durable-session.js';
-import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
 
 const PEER = '12D3KooWSelectedCompleteSwmProvider';
 
@@ -73,20 +67,6 @@ function snapshotManifest(contextGraphId: string, count: number): {
     payloadByRef.set(digest, payload);
   }
   return { meta, payloadByRef };
-}
-
-const selectedMetaTestContext = {
-  operationId: 'selected-meta-owner-test',
-  operationName: 'sync',
-} as OperationContext;
-
-function selectedMetaRetentionBudget() {
-  return createSelectedSwmMetaRetentionBudget({
-    maxRows: 100,
-    maxBytesEstimate: 1024 * 1024,
-    maxPrefixRows: 100,
-    maxPrefixBytesEstimate: 1024 * 1024,
-  });
 }
 
 function cleanDurableResult(): SharedMemorySyncResult {
@@ -241,6 +221,8 @@ interface SelectedProviderSelectionAgent {
     options?: { selectedSwmPriority?: boolean },
   ) => Promise<SharedMemorySyncResult>;
   log: { info: () => void; warn: () => void; debug: () => void };
+  getSelectedSwmMetaTransfers: () => SelectedSwmMetaTransferCoordinator;
+  closeSelectedSwmMetaTransfers: () => Promise<void>;
 }
 
 const callTrySyncFromPeer = LifecycleSyncMethods.prototype.trySyncFromPeer as unknown as (
@@ -413,6 +395,7 @@ function createSelectedSwmLifecycleHarness(
   const metaSinceBatchIds: Array<string | undefined> = [];
   const processedMetaBatches: Quad[][] = [];
   const dateNow = vi.spyOn(Date, 'now').mockImplementation(options.clock.now);
+  let selectedSwmMetaTransfers: SelectedSwmMetaTransferCoordinator | undefined;
 
   const agent: SelectedSwmLifecycleAgentFixture = {
     config: {
@@ -583,6 +566,16 @@ function createSelectedSwmLifecycleHarness(
     contextGraphMetaProjection: { markDirtyFromQuads: () => {} },
     oversizeTombstoneLog: { record: () => {} },
     log: { info: () => {}, warn: () => {}, debug: () => {} },
+    getSelectedSwmMetaTransfers: () => {
+      selectedSwmMetaTransfers ??= new SelectedSwmMetaTransferCoordinator();
+      return selectedSwmMetaTransfers;
+    },
+    closeSelectedSwmMetaTransfers: async () => {
+      const transfers = selectedSwmMetaTransfers;
+      if (!transfers) return;
+      await transfers.close();
+      if (selectedSwmMetaTransfers === transfers) selectedSwmMetaTransfers = undefined;
+    },
   };
 
   return {
@@ -601,162 +594,11 @@ function createSelectedSwmLifecycleHarness(
     },
     close: async () => {
       dateNow.mockRestore();
-      await closeSelectedSwmMetaTransfers(agent);
+      await agent.closeSelectedSwmMetaTransfers();
       await store.close();
     },
   };
 }
-
-describe('selected SWM metadata transfer ownership', () => {
-  it('eagerly releases an expired prefix without requiring another reconciler invocation', async () => {
-    const peerId = 'peer-expiry';
-    const contextGraphId = 'cg-expiry';
-    const baseNow = Date.now();
-    let elapsedMs = 0;
-    const clock = () => baseNow + elapsedMs;
-    const deleteCheckpoint = vi.fn();
-    let ownedFetcher: ReturnType<typeof createSelectedSwmMetaFetcher> | undefined;
-    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
-
-    const createFetcher = () => {
-      ownedFetcher = createSelectedSwmMetaFetcher({
-        remotePeerId: peerId,
-        requesterScope: 'selected-swm-meta:retained:eager-expiry',
-        retentionBudget: selectedMetaRetentionBudget(),
-        deleteCheckpoint,
-        now: clock,
-        retentionTtlMs: 20,
-        fetchPage: async () => ({
-          quads: [{ subject: 'urn:expiry', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
-          bytesReceived: 1,
-          resumedFromOffset: 0,
-          nextOffset: 1,
-          checkpointKey: 'expiry-checkpoint',
-          completed: false,
-          timedOut: true,
-        }),
-      });
-      return ownedFetcher;
-    };
-
-    try {
-      await coordinator.run(peerId, createFetcher, (fetcher) => fetcher.strategy.fetch({
-        ctx: selectedMetaTestContext,
-        remotePeerId: peerId,
-        contextGraphId,
-        graphUri: 'urn:meta',
-        deadline: clock() + 1_000,
-      }));
-      expect(ownedFetcher?.continuation(contextGraphId).progress).toBe(1);
-
-      elapsedMs = 21;
-      await vi.waitFor(
-        () => expect(ownedFetcher?.continuation(contextGraphId).progress).toBeUndefined(),
-        { timeout: 250 },
-      );
-      expect(deleteCheckpoint).toHaveBeenCalledWith('expiry-checkpoint');
-    } finally {
-      await coordinator.close();
-    }
-  });
-
-  it('expires Context Graph prefixes independently inside one peer owner', async () => {
-    const peerId = 'peer-multi-cg';
-    const baseNow = Date.now();
-    let elapsedMs = 0;
-    const clock = () => baseNow + elapsedMs;
-    let ownedFetcher: ReturnType<typeof createSelectedSwmMetaFetcher> | undefined;
-    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
-    const createFetcher = () => {
-      ownedFetcher = createSelectedSwmMetaFetcher({
-        remotePeerId: peerId,
-        requesterScope: 'selected-swm-meta:retained:multi-cg',
-        retentionBudget: selectedMetaRetentionBudget(),
-        deleteCheckpoint: () => {},
-        now: clock,
-        retentionTtlMs: 30,
-        fetchPage: async ({ contextGraphId }) => ({
-          quads: [{
-            subject: `urn:${contextGraphId}`,
-            predicate: 'urn:p',
-            object: '"o"',
-            graph: 'urn:meta',
-          }],
-          bytesReceived: 1,
-          resumedFromOffset: 0,
-          nextOffset: 1,
-          checkpointKey: `${contextGraphId}:checkpoint`,
-          completed: false,
-          timedOut: true,
-        }),
-      });
-      return ownedFetcher;
-    };
-    const fetch = (contextGraphId: string) => coordinator.run(
-      peerId,
-      createFetcher,
-      (fetcher) => fetcher.strategy.fetch({
-        ctx: selectedMetaTestContext,
-        remotePeerId: peerId,
-        contextGraphId,
-        graphUri: 'urn:meta',
-        deadline: clock() + 1_000,
-      }),
-    );
-
-    try {
-      const first = await fetch('cg-a');
-      expect(first.result.quads.map((quad) => quad.subject)).toEqual(['urn:cg-a']);
-      elapsedMs = 20;
-      const second = await fetch('cg-b');
-      expect(second.result.quads.map((quad) => quad.subject)).toEqual(['urn:cg-b']);
-
-      elapsedMs = 31;
-      await vi.waitFor(
-        () => expect(ownedFetcher?.continuation('cg-a').progress).toBeUndefined(),
-        { timeout: 250 },
-      );
-      expect(ownedFetcher?.continuation('cg-b').progress).toBe(1);
-    } finally {
-      await coordinator.close();
-    }
-  });
-
-  it('does not serialize independent peers behind one transfer owner', async () => {
-    const coordinator = new SelectedSwmMetaTransferCoordinator();
-    let releasePeerA!: () => void;
-    const peerARelease = new Promise<void>((resolve) => { releasePeerA = resolve; });
-    let signalPeerAStarted!: () => void;
-    const peerAStarted = new Promise<void>((resolve) => { signalPeerAStarted = resolve; });
-    const createEmptyFetcher = (peerId: string) => createSelectedSwmMetaFetcher({
-      remotePeerId: peerId,
-      requesterScope: `selected-swm-meta:retained:${peerId}`,
-      retentionBudget: selectedMetaRetentionBudget(),
-      deleteCheckpoint: () => {},
-      fetchPage: async () => {
-        throw new Error('unused');
-      },
-    });
-
-    try {
-      const peerA = coordinator.run('peer-a', () => createEmptyFetcher('peer-a'), async () => {
-        signalPeerAStarted();
-        await peerARelease;
-      });
-      await peerAStarted;
-      let peerBStarted = false;
-      await coordinator.run('peer-b', () => createEmptyFetcher('peer-b'), async () => {
-        peerBStarted = true;
-      });
-      expect(peerBStarted).toBe(true);
-      releasePeerA();
-      await peerA;
-    } finally {
-      releasePeerA();
-      await coordinator.close();
-    }
-  });
-});
 
 describe('shared-memory freshness classification', () => {
   it('owns producer recovery, bounding, and final classification as one invariant', () => {
@@ -1727,7 +1569,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         selectedSwmPriority: true,
         sharedMemorySyncPlan: plan,
       });
-      await closeSelectedSwmMetaTransfers(harness.agent);
+      await harness.agent.closeSelectedSwmMetaTransfers();
       await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
         selectedSwmPriority: true,
         sharedMemorySyncPlan: plan,

--- a/packages/agent/test/selected-swm-continuation.test.ts
+++ b/packages/agent/test/selected-swm-continuation.test.ts
@@ -14,9 +14,9 @@ import {
   runSelectedSwmContinuations,
 } from '../src/sync/selected-swm-continuation.js';
 import {
-  SelectedSwmMetaTransferCoordinator,
   type SelectedSwmMetaContinuation,
 } from '../src/sync/selected-swm-meta-fetcher.js';
+import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-meta-transfer-coordinator.js';
 import {
   applySelectedSwmFreshnessResolution,
   classifySelectedSwmRoundFreshness,

--- a/packages/agent/test/selected-swm-continuation.test.ts
+++ b/packages/agent/test/selected-swm-continuation.test.ts
@@ -356,6 +356,7 @@ interface SelectedSwmLifecycleHarness {
     readonly dataFetches: () => number;
     readonly metaRequesterScopes: readonly (string | undefined)[];
     readonly metaSinceBatchIds: readonly (string | undefined)[];
+    readonly metaReturnAcceptedPrefixOnRetryableTransportFailure: readonly boolean[];
     readonly maxActiveAdmissions: () => number;
   };
   readonly close: () => Promise<void>;
@@ -393,6 +394,7 @@ function createSelectedSwmLifecycleHarness(
   let dataFetches = 0;
   const metaRequesterScopes: Array<string | undefined> = [];
   const metaSinceBatchIds: Array<string | undefined> = [];
+  const metaReturnAcceptedPrefixOnRetryableTransportFailure: boolean[] = [];
   const processedMetaBatches: Quad[][] = [];
   const dateNow = vi.spyOn(Date, 'now').mockImplementation(options.clock.now);
   let selectedSwmMetaTransfers: SelectedSwmMetaTransferCoordinator | undefined;
@@ -448,6 +450,7 @@ function createSelectedSwmLifecycleHarness(
         requesterScope,
         maxAcceptedQuads,
         maxAcceptedHeapBytesEstimate,
+        returnAcceptedPrefixOnRetryableTransportFailure,
       } = fetchOptions;
       if (phase === 'snapshot') {
         snapshotFetches.push(snapshotRef ?? 'missing-ref');
@@ -457,6 +460,9 @@ function createSelectedSwmLifecycleHarness(
         metaFetches += 1;
         metaRequesterScopes.push(requesterScope);
         metaSinceBatchIds.push(sinceBatchId);
+        metaReturnAcceptedPrefixOnRetryableTransportFailure.push(
+          returnAcceptedPrefixOnRetryableTransportFailure === true,
+        );
         await options.onMetaFetch?.({
           fetch: metaFetches,
           requesterScope,
@@ -590,6 +596,7 @@ function createSelectedSwmLifecycleHarness(
       dataFetches: () => dataFetches,
       metaRequesterScopes,
       metaSinceBatchIds,
+      metaReturnAcceptedPrefixOnRetryableTransportFailure,
       maxActiveAdmissions: () => maxActiveAdmissions,
     },
     close: async () => {
@@ -1325,6 +1332,9 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(harness.probes.metaRequesterScopes[1]).toBe(
         harness.probes.metaRequesterScopes[0],
       );
+      expect(
+        harness.probes.metaReturnAcceptedPrefixOnRetryableTransportFailure,
+      ).toEqual([true, true]);
       expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
     } finally {
       if (previousBudget === undefined) {

--- a/packages/agent/test/selected-swm-continuation.test.ts
+++ b/packages/agent/test/selected-swm-continuation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   contextGraphWorkspaceMetaGraphUri,
   PROTOCOL_SYNC,
+  type OperationContext,
 } from '@origintrail-official/dkg-core';
 import { workspacePublicQuadsDigest } from '@origintrail-official/dkg-publisher';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
@@ -9,11 +10,18 @@ import type {
   SharedMemorySyncResult,
   SwmSnapshotCoverage,
 } from '../src/dkg-agent-types.js';
-import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
+import {
+  closeSelectedSwmMetaTransfers,
+  LifecycleSyncMethods,
+} from '../src/dkg-agent-lifecycle.js';
 import {
   runSelectedSwmContinuations,
 } from '../src/sync/selected-swm-continuation.js';
-import type { SelectedSwmMetaContinuation } from '../src/sync/selected-swm-meta-fetcher.js';
+import {
+  createSelectedSwmMetaFetcher,
+  SelectedSwmMetaTransferCoordinator,
+  type SelectedSwmMetaContinuation,
+} from '../src/sync/selected-swm-meta-fetcher.js';
 import {
   applySelectedSwmFreshnessResolution,
   classifySelectedSwmRoundFreshness,
@@ -25,6 +33,8 @@ import {
   type SyncPageFetchOptions,
 } from '../src/sync/requester/page-fetch.js';
 import { estimateQuadHeapBytes } from '../src/sync/memory-telemetry.js';
+import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../src/sync/durable-session.js';
+import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
 
 const PEER = '12D3KooWSelectedCompleteSwmProvider';
 
@@ -63,6 +73,20 @@ function snapshotManifest(contextGraphId: string, count: number): {
     payloadByRef.set(digest, payload);
   }
   return { meta, payloadByRef };
+}
+
+const selectedMetaTestContext = {
+  operationId: 'selected-meta-owner-test',
+  operationName: 'sync',
+} as OperationContext;
+
+function selectedMetaRetentionBudget() {
+  return createSelectedSwmMetaRetentionBudget({
+    maxRows: 100,
+    maxBytesEstimate: 1024 * 1024,
+    maxPrefixRows: 100,
+    maxPrefixBytesEstimate: 1024 * 1024,
+  });
 }
 
 function cleanDurableResult(): SharedMemorySyncResult {
@@ -577,10 +601,162 @@ function createSelectedSwmLifecycleHarness(
     },
     close: async () => {
       dateNow.mockRestore();
+      await closeSelectedSwmMetaTransfers(agent);
       await store.close();
     },
   };
 }
+
+describe('selected SWM metadata transfer ownership', () => {
+  it('eagerly releases an expired prefix without requiring another reconciler invocation', async () => {
+    const peerId = 'peer-expiry';
+    const contextGraphId = 'cg-expiry';
+    const baseNow = Date.now();
+    let elapsedMs = 0;
+    const clock = () => baseNow + elapsedMs;
+    const deleteCheckpoint = vi.fn();
+    let ownedFetcher: ReturnType<typeof createSelectedSwmMetaFetcher> | undefined;
+    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
+
+    const createFetcher = () => {
+      ownedFetcher = createSelectedSwmMetaFetcher({
+        remotePeerId: peerId,
+        requesterScope: 'selected-swm-meta:retained:eager-expiry',
+        retentionBudget: selectedMetaRetentionBudget(),
+        deleteCheckpoint,
+        now: clock,
+        retentionTtlMs: 20,
+        fetchPage: async () => ({
+          quads: [{ subject: 'urn:expiry', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+          bytesReceived: 1,
+          resumedFromOffset: 0,
+          nextOffset: 1,
+          checkpointKey: 'expiry-checkpoint',
+          completed: false,
+          timedOut: true,
+        }),
+      });
+      return ownedFetcher;
+    };
+
+    try {
+      await coordinator.run(peerId, createFetcher, (fetcher) => fetcher.strategy.fetch({
+        ctx: selectedMetaTestContext,
+        remotePeerId: peerId,
+        contextGraphId,
+        graphUri: 'urn:meta',
+        deadline: clock() + 1_000,
+      }));
+      expect(ownedFetcher?.continuation(contextGraphId).progress).toBe(1);
+
+      elapsedMs = 21;
+      await vi.waitFor(
+        () => expect(ownedFetcher?.continuation(contextGraphId).progress).toBeUndefined(),
+        { timeout: 250 },
+      );
+      expect(deleteCheckpoint).toHaveBeenCalledWith('expiry-checkpoint');
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  it('expires Context Graph prefixes independently inside one peer owner', async () => {
+    const peerId = 'peer-multi-cg';
+    const baseNow = Date.now();
+    let elapsedMs = 0;
+    const clock = () => baseNow + elapsedMs;
+    let ownedFetcher: ReturnType<typeof createSelectedSwmMetaFetcher> | undefined;
+    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
+    const createFetcher = () => {
+      ownedFetcher = createSelectedSwmMetaFetcher({
+        remotePeerId: peerId,
+        requesterScope: 'selected-swm-meta:retained:multi-cg',
+        retentionBudget: selectedMetaRetentionBudget(),
+        deleteCheckpoint: () => {},
+        now: clock,
+        retentionTtlMs: 30,
+        fetchPage: async ({ contextGraphId }) => ({
+          quads: [{
+            subject: `urn:${contextGraphId}`,
+            predicate: 'urn:p',
+            object: '"o"',
+            graph: 'urn:meta',
+          }],
+          bytesReceived: 1,
+          resumedFromOffset: 0,
+          nextOffset: 1,
+          checkpointKey: `${contextGraphId}:checkpoint`,
+          completed: false,
+          timedOut: true,
+        }),
+      });
+      return ownedFetcher;
+    };
+    const fetch = (contextGraphId: string) => coordinator.run(
+      peerId,
+      createFetcher,
+      (fetcher) => fetcher.strategy.fetch({
+        ctx: selectedMetaTestContext,
+        remotePeerId: peerId,
+        contextGraphId,
+        graphUri: 'urn:meta',
+        deadline: clock() + 1_000,
+      }),
+    );
+
+    try {
+      const first = await fetch('cg-a');
+      expect(first.result.quads.map((quad) => quad.subject)).toEqual(['urn:cg-a']);
+      elapsedMs = 20;
+      const second = await fetch('cg-b');
+      expect(second.result.quads.map((quad) => quad.subject)).toEqual(['urn:cg-b']);
+
+      elapsedMs = 31;
+      await vi.waitFor(
+        () => expect(ownedFetcher?.continuation('cg-a').progress).toBeUndefined(),
+        { timeout: 250 },
+      );
+      expect(ownedFetcher?.continuation('cg-b').progress).toBe(1);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  it('does not serialize independent peers behind one transfer owner', async () => {
+    const coordinator = new SelectedSwmMetaTransferCoordinator();
+    let releasePeerA!: () => void;
+    const peerARelease = new Promise<void>((resolve) => { releasePeerA = resolve; });
+    let signalPeerAStarted!: () => void;
+    const peerAStarted = new Promise<void>((resolve) => { signalPeerAStarted = resolve; });
+    const createEmptyFetcher = (peerId: string) => createSelectedSwmMetaFetcher({
+      remotePeerId: peerId,
+      requesterScope: `selected-swm-meta:retained:${peerId}`,
+      retentionBudget: selectedMetaRetentionBudget(),
+      deleteCheckpoint: () => {},
+      fetchPage: async () => {
+        throw new Error('unused');
+      },
+    });
+
+    try {
+      const peerA = coordinator.run('peer-a', () => createEmptyFetcher('peer-a'), async () => {
+        signalPeerAStarted();
+        await peerARelease;
+      });
+      await peerAStarted;
+      let peerBStarted = false;
+      await coordinator.run('peer-b', () => createEmptyFetcher('peer-b'), async () => {
+        peerBStarted = true;
+      });
+      expect(peerBStarted).toBe(true);
+      releasePeerA();
+      await peerA;
+    } finally {
+      releasePeerA();
+      await coordinator.close();
+    }
+  });
+});
 
 describe('shared-memory freshness classification', () => {
   it('owns producer recovery, bounding, and final classification as one invariant', () => {
@@ -1228,7 +1404,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
 
       expect(harness.probes.metaFetches()).toBe(2);
       expect(harness.probes.metaRequesterScopes).toHaveLength(2);
-      expect(harness.probes.metaRequesterScopes[0]).toMatch(/^selected-swm-meta:\d+$/);
+      expect(harness.probes.metaRequesterScopes[0]).toMatch(/^selected-swm-meta:retained:\d+$/);
       expect(harness.probes.metaRequesterScopes[1]).toBe(
         harness.probes.metaRequesterScopes[0],
       );
@@ -1248,6 +1424,326 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       });
       expect(harness.agent.syncCheckpoints.size).toBe(0);
     } finally {
+      await harness.close();
+    }
+  });
+
+  it('resumes one exact metadata prefix across outer reconciler invocations without partial activation', async () => {
+    const publicCg = 'selected-cross-outer-metadata';
+    const manifest = snapshotManifest(publicCg, 3);
+    const firstPrefix = manifest.meta.slice(0, 4);
+    const finalSuffix = manifest.meta.slice(4);
+    const previousBudget = process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+    process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = '0';
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 1_001 },
+      metaPages: [
+        {
+          quads: firstPrefix,
+          resumedFromOffset: 0,
+          nextOffset: firstPrefix.length,
+          completed: false,
+          timedOut: true,
+        },
+        {
+          quads: finalSuffix,
+          resumedFromOffset: firstPrefix.length,
+          nextOffset: manifest.meta.length,
+          completed: true,
+          timedOut: false,
+        },
+      ],
+    });
+    const plan = {
+      publicContextGraphIds: [publicCg],
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: [publicCg],
+    };
+
+    try {
+      const first = await callSyncSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        { selectedSwmPriority: true, priority: 2_000, sharedMemorySyncPlan: plan },
+      );
+
+      expect(first.metadataContinuationYields).toBe(1);
+      expect(harness.probes.processedMetaBatches).toEqual([]);
+
+      const second = await callSyncSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        { selectedSwmPriority: true, priority: 2_000, sharedMemorySyncPlan: plan },
+      );
+
+      expect(second.failedPhases).toBe(0);
+      expect(harness.probes.metaRequesterScopes).toHaveLength(2);
+      expect(harness.probes.metaRequesterScopes[1]).toBe(
+        harness.probes.metaRequesterScopes[0],
+      );
+      expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
+    } finally {
+      if (previousBudget === undefined) {
+        delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+      } else {
+        process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = previousBudget;
+      }
+      await harness.close();
+    }
+  });
+
+  it('expires a cross-invocation prefix and starts a fresh responder scope', async () => {
+    const publicCg = 'selected-cross-outer-expiry';
+    const manifest = snapshotManifest(publicCg, 2);
+    let wallNow = 1_000;
+    const previousBudget = process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+    process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = '0';
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => wallNow, deadline: () => wallNow + 1 },
+      metaPages: [
+        {
+          quads: manifest.meta.slice(0, 2),
+          resumedFromOffset: 0,
+          nextOffset: 2,
+          completed: false,
+          timedOut: true,
+        },
+        {
+          quads: manifest.meta,
+          resumedFromOffset: 0,
+          nextOffset: manifest.meta.length,
+          completed: true,
+          timedOut: false,
+        },
+      ],
+    });
+    const plan = {
+      publicContextGraphIds: [publicCg],
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: [publicCg],
+    };
+
+    try {
+      await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+      wallNow += DURABLE_DATA_SYNC_SESSION_TTL_MS + 1;
+      await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+
+      expect(harness.probes.metaRequesterScopes).toHaveLength(2);
+      expect(harness.probes.metaRequesterScopes[1]).not.toBe(
+        harness.probes.metaRequesterScopes[0],
+      );
+      expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
+    } finally {
+      if (previousBudget === undefined) {
+        delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+      } else {
+        process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = previousBudget;
+      }
+      await harness.close();
+    }
+  });
+
+  it('drops an old cross-invocation prefix when the responder replaces its session', async () => {
+    const publicCg = 'selected-cross-outer-session-replacement';
+    const manifest = snapshotManifest(publicCg, 2);
+    const previousBudget = process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+    process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = '0';
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 1_001 },
+      metaPages: [
+        {
+          quads: manifest.meta.slice(0, 2),
+          resumedFromOffset: 0,
+          nextOffset: 14_000,
+          completed: false,
+          timedOut: true,
+        },
+        {
+          quads: manifest.meta,
+          resumedFromOffset: 0,
+          nextOffset: manifest.meta.length,
+          completed: true,
+          timedOut: false,
+        },
+      ],
+    });
+    const plan = {
+      publicContextGraphIds: [publicCg],
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: [publicCg],
+    };
+
+    try {
+      await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+      await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+
+      expect(harness.probes.metaRequesterScopes[1]).toBe(
+        harness.probes.metaRequesterScopes[0],
+      );
+      expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
+    } finally {
+      if (previousBudget === undefined) {
+        delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+      } else {
+        process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = previousBudget;
+      }
+      await harness.close();
+    }
+  });
+
+  it.each([
+    ['caller abort', Object.assign(new Error('caller cancelled'), { name: 'AbortError' })],
+    ['integrity rejection', new Error('metadata integrity rejected')],
+    ['local request build failure', new Error('wallet signing failed')],
+  ])('discards retained state after a cross-invocation %s', async (_label, failure) => {
+    const publicCg = `selected-cross-outer-failure-${_label.replaceAll(' ', '-')}`;
+    const manifest = snapshotManifest(publicCg, 2);
+    const previousBudget = process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+    process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = '0';
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 1_001 },
+      metaPages: [
+        {
+          quads: manifest.meta.slice(0, 2),
+          resumedFromOffset: 0,
+          nextOffset: 2,
+          completed: false,
+          timedOut: true,
+        },
+        // Fetch two throws from onMetaFetch. Fetch three must therefore begin
+        // a new owner at offset zero and may accept this full replacement.
+        {
+          quads: [],
+          resumedFromOffset: 0,
+          nextOffset: 0,
+          completed: false,
+          timedOut: false,
+        },
+        {
+          quads: manifest.meta,
+          resumedFromOffset: 0,
+          nextOffset: manifest.meta.length,
+          completed: true,
+          timedOut: false,
+        },
+      ],
+      onMetaFetch: ({ fetch }) => {
+        if (fetch === 2) throw failure;
+      },
+    });
+    const plan = {
+      publicContextGraphIds: [publicCg],
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: [publicCg],
+    };
+
+    try {
+      await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+      const failed = await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+      expect(failed.failedPhases + failed.failedPeers).toBeGreaterThan(0);
+      await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+
+      expect(harness.probes.metaRequesterScopes).toHaveLength(3);
+      expect(harness.probes.metaRequesterScopes[1]).toBe(
+        harness.probes.metaRequesterScopes[0],
+      );
+      expect(harness.probes.metaRequesterScopes[2]).not.toBe(
+        harness.probes.metaRequesterScopes[0],
+      );
+      expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
+    } finally {
+      if (previousBudget === undefined) {
+        delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+      } else {
+        process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = previousBudget;
+      }
+      await harness.close();
+    }
+  });
+
+  it('releases retained prefixes on node-lifecycle cleanup', async () => {
+    const publicCg = 'selected-cross-outer-node-close';
+    const manifest = snapshotManifest(publicCg, 2);
+    const previousBudget = process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+    process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = '0';
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 1_001 },
+      metaPages: [
+        {
+          quads: manifest.meta.slice(0, 2),
+          resumedFromOffset: 0,
+          nextOffset: 2,
+          completed: false,
+          timedOut: true,
+        },
+        {
+          quads: manifest.meta,
+          resumedFromOffset: 0,
+          nextOffset: manifest.meta.length,
+          completed: true,
+          timedOut: false,
+        },
+      ],
+    });
+    const plan = {
+      publicContextGraphIds: [publicCg],
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: [publicCg],
+    };
+
+    try {
+      await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+      await closeSelectedSwmMetaTransfers(harness.agent);
+      await callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        sharedMemorySyncPlan: plan,
+      });
+
+      expect(harness.probes.metaRequesterScopes).toHaveLength(2);
+      expect(harness.probes.metaRequesterScopes[1]).not.toBe(
+        harness.probes.metaRequesterScopes[0],
+      );
+      expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
+    } finally {
+      if (previousBudget === undefined) {
+        delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+      } else {
+        process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = previousBudget;
+      }
       await harness.close();
     }
   });
@@ -1521,18 +2017,42 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
     }
   });
 
-  it('isolates overlapping selected invocations with unique requester scopes', async () => {
+  it('serializes overlapping selected invocations behind one retained-prefix owner', async () => {
     const publicCg = 'selected-overlap-isolation';
-    const manifest = snapshotManifest(publicCg, 0);
-    let releaseBoth!: () => void;
-    const bothStarted = new Promise<void>((resolve) => { releaseBoth = resolve; });
+    const manifest = snapshotManifest(publicCg, 2);
+    const firstPrefix = manifest.meta.slice(0, 2);
+    const finalSuffix = manifest.meta.slice(2);
+    const previousBudget = process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+    process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = '0';
+    let signalFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => { signalFirstStarted = resolve; });
+    let releaseFirst!: () => void;
+    const firstRelease = new Promise<void>((resolve) => { releaseFirst = resolve; });
     const harness = createSelectedSwmLifecycleHarness({
       contextGraphs: { public: publicCg },
       manifest,
       clock: { now: () => 1_000, deadline: () => 61_000 },
-      onMetaFetch: ({ fetch }) => {
-        if (fetch === 2) releaseBoth();
-        return bothStarted;
+      metaPages: [
+        {
+          quads: firstPrefix,
+          resumedFromOffset: 0,
+          nextOffset: firstPrefix.length,
+          completed: false,
+          timedOut: true,
+        },
+        {
+          quads: finalSuffix,
+          resumedFromOffset: firstPrefix.length,
+          nextOffset: manifest.meta.length,
+          completed: true,
+          timedOut: false,
+        },
+      ],
+      onMetaFetch: async ({ fetch }) => {
+        if (fetch === 1) {
+          signalFirstStarted();
+          await firstRelease;
+        }
       },
     });
     const plan = {
@@ -1542,24 +2062,35 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
     };
 
     try {
-      await Promise.all([
-        callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
-          selectedSwmPriority: true,
-          priority: 2_000,
-          sharedMemorySyncPlan: plan,
-        }),
-        callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
-          selectedSwmPriority: true,
-          priority: 2_001,
-          sharedMemorySyncPlan: plan,
-        }),
-      ]);
+      const first = callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        priority: 2_000,
+        sharedMemorySyncPlan: plan,
+      });
+      await firstStarted;
+      const second = callSyncSharedMemoryFromPeerDetailed(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        priority: 2_001,
+        sharedMemorySyncPlan: plan,
+      });
+      await Promise.resolve();
+      expect(harness.probes.metaFetches()).toBe(1);
+      releaseFirst();
+      await Promise.all([first, second]);
 
       expect(harness.probes.metaRequesterScopes).toHaveLength(2);
-      expect(new Set(harness.probes.metaRequesterScopes).size).toBe(2);
+      expect(new Set(harness.probes.metaRequesterScopes).size).toBe(1);
       expect(harness.probes.metaSinceBatchIds).toEqual([undefined, undefined]);
+      expect(harness.probes.maxActiveAdmissions()).toBe(1);
+      expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
       expect(harness.agent.syncCheckpoints.size).toBe(0);
     } finally {
+      releaseFirst();
+      if (previousBudget === undefined) {
+        delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;
+      } else {
+        process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS = previousBudget;
+      }
       await harness.close();
     }
   });
@@ -1638,7 +2169,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(ordinarySummary).not.toBe(selectedSummary);
       expect(harness.probes.metaFetches()).toBe(3);
       expect(harness.probes.metaRequesterScopes[0]).toBeUndefined();
-      expect(harness.probes.metaRequesterScopes[1]).toMatch(/^selected-swm-meta:\d+$/);
+      expect(harness.probes.metaRequesterScopes[1]).toMatch(/^selected-swm-meta:retained:\d+$/);
       expect(harness.probes.metaRequesterScopes[2]).toBe(
         harness.probes.metaRequesterScopes[1],
       );
@@ -1660,13 +2191,13 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
     }
   });
 
-  it('shares one metadata retention budget across overlapping selected lifecycles', async () => {
+  it('releases the shared metadata budget before the next serialized owner generation', async () => {
     const publicCg = 'selected-overlap-shared-retention-budget';
     const manifest = snapshotManifest(publicCg, 2);
     let firstFetchStarted!: () => void;
     const firstStarted = new Promise<void>((resolve) => { firstFetchStarted = resolve; });
-    let secondFetchStarted!: () => void;
-    const secondStarted = new Promise<void>((resolve) => { secondFetchStarted = resolve; });
+    let releaseFirst!: () => void;
+    const firstRelease = new Promise<void>((resolve) => { releaseFirst = resolve; });
     const acceptedRows: Array<number | undefined> = [];
     const harness = createSelectedSwmLifecycleHarness({
       contextGraphs: { public: publicCg },
@@ -1698,9 +2229,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         acceptedRows.push(maxAcceptedQuads);
         if (fetch === 1) {
           firstFetchStarted();
-          await secondStarted;
-        } else if (fetch === 2) {
-          secondFetchStarted();
+          await firstRelease;
         }
       },
     });
@@ -1722,16 +2251,20 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         priority: 2_001,
         sharedMemorySyncPlan: plan,
       });
+      await Promise.resolve();
+      expect(harness.probes.metaFetches()).toBe(1);
+      releaseFirst();
 
       const [firstSummary, secondSummary] = await Promise.all([first, second]);
 
-      expect(acceptedRows).toEqual([manifest.meta.length, 0]);
+      expect(acceptedRows).toEqual([manifest.meta.length, manifest.meta.length]);
       expect(harness.probes.metaFetches()).toBe(2);
-      expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
+      expect(harness.probes.processedMetaBatches).toEqual([manifest.meta, manifest.meta]);
       expect(firstSummary.failedPhases).toBe(0);
-      expect(secondSummary.failedPhases).toBe(1);
+      expect(secondSummary.failedPhases).toBe(0);
       expect(harness.agent.syncCheckpoints.size).toBe(0);
     } finally {
+      releaseFirst();
       await harness.close();
     }
   });

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import {
   createSelectedSwmMetaFetcher,
-  SelectedSwmMetaTransferCoordinator,
 } from '../src/sync/selected-swm-meta-fetcher.js';
+import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-meta-transfer-coordinator.js';
 import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
 
 const testContext = {
@@ -246,43 +246,56 @@ describe('selected SWM metadata transfer ownership', () => {
     const clock = () => baseNow + elapsedMs;
     const deleteCheckpoint = vi.fn();
     const budget = createSelectedSwmMetaRetentionBudget({
-      maxRows: 1,
+      maxRows: 2,
       maxBytesEstimate: 1024 * 1024,
       maxPrefixRows: 1,
       maxPrefixBytesEstimate: 1024 * 1024,
     });
     const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
-    let releasePeerA!: () => void;
-    const peerAGate = new Promise<void>((resolve) => { releasePeerA = resolve; });
-    let signalPeerAStarted!: () => void;
-    const peerAStarted = new Promise<void>((resolve) => { signalPeerAStarted = resolve; });
+    let releasePeerAActiveFetch!: () => void;
+    const peerAActiveFetchGate = new Promise<void>((resolve) => {
+      releasePeerAActiveFetch = resolve;
+    });
+    let signalPeerAActiveFetchStarted!: (availableRows: number) => void;
+    const peerAActiveFetchStarted = new Promise<number>((resolve) => {
+      signalPeerAActiveFetchStarted = resolve;
+    });
     let peerACompleted = false;
     let peerBAvailableRows: number | undefined;
-    const createFetcher = (peerId: string) => createSelectedSwmMetaFetcher({
-      remotePeerId: peerId,
-      requesterScope: `selected-swm-meta:retained:${peerId}`,
-      retentionBudget: budget,
-      deleteCheckpoint,
-      now: clock,
-      retentionTtlMs: 20,
-      fetchPage: async (request) => {
-        if (peerId === 'peer-b') peerBAvailableRows = request.maxAcceptedQuads;
-        return {
-          quads: [{
-            subject: `urn:${peerId}:${request.contextGraphId}`,
-            predicate: 'urn:p',
-            object: '"o"',
-            graph: 'urn:meta',
-          }],
-          bytesReceived: 1,
-          resumedFromOffset: 0,
-          nextOffset: 1,
-          checkpointKey: `${peerId}:${request.contextGraphId}:checkpoint`,
-          completed: false,
-          timedOut: true,
-        };
-      },
-    });
+    let peerAFetcher: ReturnType<typeof createSelectedSwmMetaFetcher> | undefined;
+    const createFetcher = (peerId: string) => {
+      const fetcher = createSelectedSwmMetaFetcher({
+        remotePeerId: peerId,
+        requesterScope: `selected-swm-meta:retained:${peerId}`,
+        retentionBudget: budget,
+        deleteCheckpoint,
+        now: clock,
+        retentionTtlMs: 20,
+        fetchPage: async (request) => {
+          if (peerId === 'peer-a' && request.contextGraphId === 'cg-active') {
+            signalPeerAActiveFetchStarted(request.maxAcceptedQuads);
+            await peerAActiveFetchGate;
+          }
+          if (peerId === 'peer-b') peerBAvailableRows = request.maxAcceptedQuads;
+          return {
+            quads: [{
+              subject: `urn:${peerId}:${request.contextGraphId}`,
+              predicate: 'urn:p',
+              object: '"o"',
+              graph: 'urn:meta',
+            }],
+            bytesReceived: 1,
+            resumedFromOffset: 0,
+            nextOffset: 1,
+            checkpointKey: `${peerId}:${request.contextGraphId}:checkpoint`,
+            completed: false,
+            timedOut: true,
+          };
+        },
+      });
+      if (peerId === 'peer-a') peerAFetcher = fetcher;
+      return fetcher;
+    };
     const request = (peerId: string, contextGraphId: string) => ({
       ctx: testContext,
       remotePeerId: peerId,
@@ -295,29 +308,27 @@ describe('selected SWM metadata transfer ownership', () => {
       await coordinator.run(
         'peer-a',
         () => createFetcher('peer-a'),
-        (fetcher) => fetcher.strategy.fetch(request('peer-a', 'cg-a')),
+        (fetcher) => fetcher.strategy.fetch(request('peer-a', 'cg-old')),
       );
 
       const activePeerA = coordinator.run(
         'peer-a',
         () => createFetcher('peer-a'),
-        async () => {
-          signalPeerAStarted();
-          await peerAGate;
-        },
+        (fetcher) => fetcher.strategy.fetch(request('peer-a', 'cg-active')),
       );
       void activePeerA.then(() => { peerACompleted = true; });
-      await peerAStarted;
+      expect(await peerAActiveFetchStarted).toBe(1);
       elapsedMs = 21;
 
-      // A's timer must release its expired process-wide lease without waiting
-      // for A's unrelated outer operation. Otherwise concurrent peer B sees a
-      // zero-row reservation even though A has exceeded its independent TTL.
+      // A's timer must release the old prefix without touching the active CG's
+      // in-flight reservation. Otherwise B sees zero rows, or A loses its
+      // active continuation, after the shared process-wide budget is reclaimed.
       await vi.waitFor(
-        () => expect(deleteCheckpoint).toHaveBeenCalledWith('peer-a:cg-a:checkpoint'),
+        () => expect(deleteCheckpoint).toHaveBeenCalledWith('peer-a:cg-old:checkpoint'),
         { timeout: 250 },
       );
       expect(peerACompleted).toBe(false);
+      expect(deleteCheckpoint).not.toHaveBeenCalledWith('peer-a:cg-active:checkpoint');
 
       await coordinator.run(
         'peer-b',
@@ -327,10 +338,12 @@ describe('selected SWM metadata transfer ownership', () => {
       expect(peerBAvailableRows).toBe(1);
       expect(peerACompleted).toBe(false);
 
-      releasePeerA();
+      releasePeerAActiveFetch();
       await activePeerA;
+      expect(peerAFetcher?.continuation('cg-active').progress).toBe(1);
+      expect(deleteCheckpoint).not.toHaveBeenCalledWith('peer-a:cg-active:checkpoint');
     } finally {
-      releasePeerA();
+      releasePeerAActiveFetch();
       await coordinator.close();
     }
   });

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import {
   createSelectedSwmMetaFetcher,
+  SelectedSwmMetaTransferOwner,
 } from '../src/sync/selected-swm-meta-fetcher.js';
 import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-meta-transfer-coordinator.js';
 import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
@@ -21,6 +22,68 @@ function retentionBudget() {
 }
 
 describe('selected SWM metadata transfer ownership', () => {
+  it('keeps retained-prefix lifecycle controls private to the per-peer owner', async () => {
+    const coordinator = new SelectedSwmMetaTransferCoordinator();
+    const fetcher = createSelectedSwmMetaFetcher({
+      remotePeerId: 'peer-private-owner',
+      requesterScope: 'selected-swm-meta:retained:private-owner',
+      retentionBudget: retentionBudget(),
+      deleteCheckpoint: () => {},
+      fetchPage: async () => {
+        throw new Error('unused');
+      },
+    });
+
+    expect(fetcher).not.toHaveProperty('settleOuterInvocation');
+    expect(fetcher).not.toHaveProperty('pruneExpiredPrefixes');
+    expect(fetcher).not.toHaveProperty('cleanup');
+    await coordinator.run('peer-private-owner', () => fetcher, async () => {});
+    await coordinator.close();
+  });
+
+  it('notifies its registry after timer-driven final-prefix expiry', async () => {
+    const baseNow = Date.now();
+    let elapsedMs = 0;
+    const clock = () => baseNow + elapsedMs;
+    const onIdle = vi.fn();
+    const owner = new SelectedSwmMetaTransferOwner({ now: clock, onIdle });
+    const fetcher = createSelectedSwmMetaFetcher({
+      remotePeerId: 'peer-owner-idle',
+      requesterScope: 'selected-swm-meta:retained:owner-idle',
+      retentionBudget: retentionBudget(),
+      deleteCheckpoint: () => {},
+      now: clock,
+      retentionTtlMs: 20,
+      fetchPage: async () => ({
+        quads: [{ subject: 'urn:idle', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+        bytesReceived: 1,
+        resumedFromOffset: 0,
+        nextOffset: 1,
+        checkpointKey: 'owner-idle-checkpoint',
+        completed: false,
+        timedOut: true,
+      }),
+    });
+
+    try {
+      await owner.run(() => fetcher, (selectedFetcher) => selectedFetcher.strategy.fetch({
+        ctx: testContext,
+        remotePeerId: 'peer-owner-idle',
+        contextGraphId: 'cg-owner-idle',
+        graphUri: 'urn:meta',
+        deadline: clock() + 1_000,
+      }));
+      expect(owner.isIdle()).toBe(false);
+      expect(onIdle).not.toHaveBeenCalled();
+
+      elapsedMs = 21;
+      await vi.waitFor(() => expect(onIdle).toHaveBeenCalledOnce(), { timeout: 250 });
+      expect(owner.isIdle()).toBe(true);
+    } finally {
+      await owner.close();
+    }
+  });
+
   it('eagerly releases an expired prefix without requiring another reconciler invocation', async () => {
     const peerId = 'peer-expiry';
     const contextGraphId = 'cg-expiry';

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -135,6 +135,111 @@ describe('selected SWM metadata transfer ownership', () => {
     }
   });
 
+  it('releases an expired sibling prefix and its budget before a gated same-peer fetch completes', async () => {
+    const peerId = 'peer-active-expiry';
+    const baseNow = Date.now();
+    let elapsedMs = 0;
+    const clock = () => baseNow + elapsedMs;
+    const deleteCheckpoint = vi.fn();
+    const budget = createSelectedSwmMetaRetentionBudget({
+      maxRows: 1,
+      maxBytesEstimate: 1024 * 1024,
+      maxPrefixRows: 1,
+      maxPrefixBytesEstimate: 1024 * 1024,
+    });
+    let ownedFetcher: ReturnType<typeof createSelectedSwmMetaFetcher> | undefined;
+    let releaseSecondOperation!: () => void;
+    const secondOperationGate = new Promise<void>((resolve) => {
+      releaseSecondOperation = resolve;
+    });
+    let signalSecondOperationStarted!: () => void;
+    const secondOperationStarted = new Promise<void>((resolve) => {
+      signalSecondOperationStarted = resolve;
+    });
+    let releaseSecondFetch!: () => void;
+    const secondFetchGate = new Promise<void>((resolve) => {
+      releaseSecondFetch = resolve;
+    });
+    let signalSecondFetchStarted!: (availableRows: number) => void;
+    const secondFetchStarted = new Promise<number>((resolve) => {
+      signalSecondFetchStarted = resolve;
+    });
+    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
+    const createFetcher = () => {
+      ownedFetcher = createSelectedSwmMetaFetcher({
+        remotePeerId: peerId,
+        requesterScope: 'selected-swm-meta:retained:active-expiry',
+        retentionBudget: budget,
+        deleteCheckpoint,
+        now: clock,
+        retentionTtlMs: 20,
+        fetchPage: async (request) => {
+          if (request.contextGraphId === 'cg-b') {
+            signalSecondFetchStarted(request.maxAcceptedQuads);
+            await secondFetchGate;
+          }
+          return {
+            quads: [{
+              subject: `urn:${request.contextGraphId}`,
+              predicate: 'urn:p',
+              object: '"o"',
+              graph: 'urn:meta',
+            }],
+            bytesReceived: 1,
+            resumedFromOffset: 0,
+            nextOffset: 1,
+            checkpointKey: `${request.contextGraphId}:checkpoint`,
+            completed: false,
+            timedOut: true,
+          };
+        },
+      });
+      return ownedFetcher;
+    };
+    const request = (contextGraphId: string) => ({
+      ctx: testContext,
+      remotePeerId: peerId,
+      contextGraphId,
+      graphUri: 'urn:meta',
+      deadline: clock() + 1_000,
+    });
+
+    try {
+      await coordinator.run(
+        peerId,
+        createFetcher,
+        (fetcher) => fetcher.strategy.fetch(request('cg-a')),
+      );
+      expect(ownedFetcher?.continuation('cg-a').progress).toBe(1);
+
+      let secondCompleted = false;
+      const second = coordinator.run(peerId, createFetcher, async (fetcher) => {
+        signalSecondOperationStarted();
+        await secondOperationGate;
+        return fetcher.strategy.fetch(request('cg-b'));
+      });
+      void second.then(() => { secondCompleted = true; });
+      await secondOperationStarted;
+
+      // The peer-wide idle timer is suspended by the active outer operation.
+      // Crossing A's independent TTL before B reaches its fetch boundary must
+      // still release A's checkpoint and make its global row available to B.
+      elapsedMs = 21;
+      releaseSecondOperation();
+      expect(await secondFetchStarted).toBe(1);
+      expect(secondCompleted).toBe(false);
+      expect(deleteCheckpoint).toHaveBeenCalledWith('cg-a:checkpoint');
+      expect(ownedFetcher?.continuation('cg-a').progress).toBeUndefined();
+
+      releaseSecondFetch();
+      await second;
+    } finally {
+      releaseSecondOperation();
+      releaseSecondFetch();
+      await coordinator.close();
+    }
+  });
+
   it('does not serialize independent peers behind one transfer owner', async () => {
     const coordinator = new SelectedSwmMetaTransferCoordinator();
     let releasePeerA!: () => void;

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { OperationContext } from '@origintrail-official/dkg-core';
+import {
+  createSelectedSwmMetaFetcher,
+  SelectedSwmMetaTransferCoordinator,
+} from '../src/sync/selected-swm-meta-fetcher.js';
+import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
+
+const testContext = {
+  operationId: 'selected-meta-owner-test',
+  operationName: 'sync',
+} as OperationContext;
+
+function retentionBudget() {
+  return createSelectedSwmMetaRetentionBudget({
+    maxRows: 100,
+    maxBytesEstimate: 1024 * 1024,
+    maxPrefixRows: 100,
+    maxPrefixBytesEstimate: 1024 * 1024,
+  });
+}
+
+describe('selected SWM metadata transfer ownership', () => {
+  it('eagerly releases an expired prefix without requiring another reconciler invocation', async () => {
+    const peerId = 'peer-expiry';
+    const contextGraphId = 'cg-expiry';
+    const baseNow = Date.now();
+    let elapsedMs = 0;
+    const clock = () => baseNow + elapsedMs;
+    const deleteCheckpoint = vi.fn();
+    let ownedFetcher: ReturnType<typeof createSelectedSwmMetaFetcher> | undefined;
+    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
+
+    const createFetcher = () => {
+      ownedFetcher = createSelectedSwmMetaFetcher({
+        remotePeerId: peerId,
+        requesterScope: 'selected-swm-meta:retained:eager-expiry',
+        retentionBudget: retentionBudget(),
+        deleteCheckpoint,
+        now: clock,
+        retentionTtlMs: 20,
+        fetchPage: async () => ({
+          quads: [{ subject: 'urn:expiry', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+          bytesReceived: 1,
+          resumedFromOffset: 0,
+          nextOffset: 1,
+          checkpointKey: 'expiry-checkpoint',
+          completed: false,
+          timedOut: true,
+        }),
+      });
+      return ownedFetcher;
+    };
+
+    try {
+      await coordinator.run(peerId, createFetcher, (fetcher) => fetcher.strategy.fetch({
+        ctx: testContext,
+        remotePeerId: peerId,
+        contextGraphId,
+        graphUri: 'urn:meta',
+        deadline: clock() + 1_000,
+      }));
+      expect(ownedFetcher?.continuation(contextGraphId).progress).toBe(1);
+
+      elapsedMs = 21;
+      await vi.waitFor(
+        () => expect(ownedFetcher?.continuation(contextGraphId).progress).toBeUndefined(),
+        { timeout: 250 },
+      );
+      expect(deleteCheckpoint).toHaveBeenCalledWith('expiry-checkpoint');
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  it('expires Context Graph prefixes independently inside one peer owner', async () => {
+    const peerId = 'peer-multi-cg';
+    const baseNow = Date.now();
+    let elapsedMs = 0;
+    const clock = () => baseNow + elapsedMs;
+    let ownedFetcher: ReturnType<typeof createSelectedSwmMetaFetcher> | undefined;
+    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
+    const createFetcher = () => {
+      ownedFetcher = createSelectedSwmMetaFetcher({
+        remotePeerId: peerId,
+        requesterScope: 'selected-swm-meta:retained:multi-cg',
+        retentionBudget: retentionBudget(),
+        deleteCheckpoint: () => {},
+        now: clock,
+        retentionTtlMs: 30,
+        fetchPage: async ({ contextGraphId }) => ({
+          quads: [{
+            subject: `urn:${contextGraphId}`,
+            predicate: 'urn:p',
+            object: '"o"',
+            graph: 'urn:meta',
+          }],
+          bytesReceived: 1,
+          resumedFromOffset: 0,
+          nextOffset: 1,
+          checkpointKey: `${contextGraphId}:checkpoint`,
+          completed: false,
+          timedOut: true,
+        }),
+      });
+      return ownedFetcher;
+    };
+    const fetch = (contextGraphId: string) => coordinator.run(
+      peerId,
+      createFetcher,
+      (fetcher) => fetcher.strategy.fetch({
+        ctx: testContext,
+        remotePeerId: peerId,
+        contextGraphId,
+        graphUri: 'urn:meta',
+        deadline: clock() + 1_000,
+      }),
+    );
+
+    try {
+      const first = await fetch('cg-a');
+      expect(first.result.quads.map((quad) => quad.subject)).toEqual(['urn:cg-a']);
+      elapsedMs = 20;
+      const second = await fetch('cg-b');
+      expect(second.result.quads.map((quad) => quad.subject)).toEqual(['urn:cg-b']);
+
+      elapsedMs = 31;
+      await vi.waitFor(
+        () => expect(ownedFetcher?.continuation('cg-a').progress).toBeUndefined(),
+        { timeout: 250 },
+      );
+      expect(ownedFetcher?.continuation('cg-b').progress).toBe(1);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  it('does not serialize independent peers behind one transfer owner', async () => {
+    const coordinator = new SelectedSwmMetaTransferCoordinator();
+    let releasePeerA!: () => void;
+    const peerARelease = new Promise<void>((resolve) => { releasePeerA = resolve; });
+    let signalPeerAStarted!: () => void;
+    const peerAStarted = new Promise<void>((resolve) => { signalPeerAStarted = resolve; });
+    const createEmptyFetcher = (peerId: string) => createSelectedSwmMetaFetcher({
+      remotePeerId: peerId,
+      requesterScope: `selected-swm-meta:retained:${peerId}`,
+      retentionBudget: retentionBudget(),
+      deleteCheckpoint: () => {},
+      fetchPage: async () => {
+        throw new Error('unused');
+      },
+    });
+
+    try {
+      const peerA = coordinator.run('peer-a', () => createEmptyFetcher('peer-a'), async () => {
+        signalPeerAStarted();
+        await peerARelease;
+      });
+      await peerAStarted;
+      let peerBStarted = false;
+      await coordinator.run('peer-b', () => createEmptyFetcher('peer-b'), async () => {
+        peerBStarted = true;
+      });
+      expect(peerBStarted).toBe(true);
+      releasePeerA();
+      await peerA;
+    } finally {
+      releasePeerA();
+      await coordinator.close();
+    }
+  });
+});

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -240,6 +240,101 @@ describe('selected SWM metadata transfer ownership', () => {
     }
   });
 
+  it('releases an expired prefix globally while its peer has another active operation', async () => {
+    const baseNow = Date.now();
+    let elapsedMs = 0;
+    const clock = () => baseNow + elapsedMs;
+    const deleteCheckpoint = vi.fn();
+    const budget = createSelectedSwmMetaRetentionBudget({
+      maxRows: 1,
+      maxBytesEstimate: 1024 * 1024,
+      maxPrefixRows: 1,
+      maxPrefixBytesEstimate: 1024 * 1024,
+    });
+    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
+    let releasePeerA!: () => void;
+    const peerAGate = new Promise<void>((resolve) => { releasePeerA = resolve; });
+    let signalPeerAStarted!: () => void;
+    const peerAStarted = new Promise<void>((resolve) => { signalPeerAStarted = resolve; });
+    let peerACompleted = false;
+    let peerBAvailableRows: number | undefined;
+    const createFetcher = (peerId: string) => createSelectedSwmMetaFetcher({
+      remotePeerId: peerId,
+      requesterScope: `selected-swm-meta:retained:${peerId}`,
+      retentionBudget: budget,
+      deleteCheckpoint,
+      now: clock,
+      retentionTtlMs: 20,
+      fetchPage: async (request) => {
+        if (peerId === 'peer-b') peerBAvailableRows = request.maxAcceptedQuads;
+        return {
+          quads: [{
+            subject: `urn:${peerId}:${request.contextGraphId}`,
+            predicate: 'urn:p',
+            object: '"o"',
+            graph: 'urn:meta',
+          }],
+          bytesReceived: 1,
+          resumedFromOffset: 0,
+          nextOffset: 1,
+          checkpointKey: `${peerId}:${request.contextGraphId}:checkpoint`,
+          completed: false,
+          timedOut: true,
+        };
+      },
+    });
+    const request = (peerId: string, contextGraphId: string) => ({
+      ctx: testContext,
+      remotePeerId: peerId,
+      contextGraphId,
+      graphUri: 'urn:meta',
+      deadline: clock() + 1_000,
+    });
+
+    try {
+      await coordinator.run(
+        'peer-a',
+        () => createFetcher('peer-a'),
+        (fetcher) => fetcher.strategy.fetch(request('peer-a', 'cg-a')),
+      );
+
+      const activePeerA = coordinator.run(
+        'peer-a',
+        () => createFetcher('peer-a'),
+        async () => {
+          signalPeerAStarted();
+          await peerAGate;
+        },
+      );
+      void activePeerA.then(() => { peerACompleted = true; });
+      await peerAStarted;
+      elapsedMs = 21;
+
+      // A's timer must release its expired process-wide lease without waiting
+      // for A's unrelated outer operation. Otherwise concurrent peer B sees a
+      // zero-row reservation even though A has exceeded its independent TTL.
+      await vi.waitFor(
+        () => expect(deleteCheckpoint).toHaveBeenCalledWith('peer-a:cg-a:checkpoint'),
+        { timeout: 250 },
+      );
+      expect(peerACompleted).toBe(false);
+
+      await coordinator.run(
+        'peer-b',
+        () => createFetcher('peer-b'),
+        (fetcher) => fetcher.strategy.fetch(request('peer-b', 'cg-b')),
+      );
+      expect(peerBAvailableRows).toBe(1);
+      expect(peerACompleted).toBe(false);
+
+      releasePeerA();
+      await activePeerA;
+    } finally {
+      releasePeerA();
+      await coordinator.close();
+    }
+  });
+
   it('does not serialize independent peers behind one transfer owner', async () => {
     const coordinator = new SelectedSwmMetaTransferCoordinator();
     let releasePeerA!: () => void;

--- a/packages/agent/test/sync-exact-accumulation.test.ts
+++ b/packages/agent/test/sync-exact-accumulation.test.ts
@@ -52,7 +52,12 @@ function fetchParams(overrides: Partial<FetchParams> = {}): FetchParams {
 }
 
 describe('exact sync accumulation limits', () => {
-  it('returns a validated selected-SWM metadata prefix on retryable transport exhaustion only', async () => {
+  it.each([
+    'peer-closed-stream',
+    'The stream has been reset',
+    'Remote closed connection during opening',
+    'operation timed out',
+  ])('returns a validated selected-SWM metadata prefix on untagged %s transport exhaustion', async (message) => {
     const requesterScope = 'selected-swm-meta:explicit-policy' as const;
     const checkpointStore = new MemorySyncCheckpointStore();
     let sends = 0;
@@ -76,9 +81,7 @@ describe('exact sync accumulation limits', () => {
       send: async () => {
         sends += 1;
         if (sends === 1) return encoder.encode('valid-page');
-        const error = new Error('operation timed out');
-        markSyncTransportFailure(error);
-        throw error;
+        throw new Error(message);
       },
     }));
 
@@ -146,9 +149,31 @@ describe('exact sync accumulation limits', () => {
       },
     },
     {
+      name: 'validation rejection with transport-like text',
+      scopeId: 7,
+      fail: (_controller: AbortController) => {
+        const error = new Error('operation timed out');
+        markSyncValidationRejection(error);
+        return error;
+      },
+    },
+    {
       name: 'local request build failure',
       scopeId: 6,
       fail: (_controller: AbortController) => new Error('wallet signing failed'),
+    },
+    {
+      name: 'local request timeout with transport-like text',
+      scopeId: 8,
+      fail: (_controller: AbortController) => new Error('operation timed out'),
+    },
+    {
+      name: 'chain RPC timeout with transport-like text',
+      scopeId: 9,
+      fail: (_controller: AbortController) => Object.assign(
+        new Error('operation timed out'),
+        { code: 'RPC_TIMEOUT' },
+      ),
     },
   ])('discards a selected metadata prefix on $name', async ({ name, scopeId, fail }) => {
     const requesterScope = `selected-swm-meta:retained:${scopeId}` as const;
@@ -180,13 +205,22 @@ describe('exact sync accumulation limits', () => {
       signal: controller.signal,
       buildSyncRequest: async () => {
         builds += 1;
-        if (name === 'local request build failure' && builds === 2) throw fail(controller);
+        if (
+          (
+            name === 'local request build failure'
+            || name === 'local request timeout with transport-like text'
+            || name === 'chain RPC timeout with transport-like text'
+          )
+          && builds === 2
+        ) throw fail(controller);
         return encoder.encode('request');
       },
       parseAndFilter: async () => {
         parses += 1;
         if (
-          (name === 'integrity rejection' || name === 'validation rejection')
+          (name === 'integrity rejection'
+            || name === 'validation rejection'
+            || name === 'validation rejection with transport-like text')
           && parses === 2
         ) {
           throw fail(controller);
@@ -200,7 +234,11 @@ describe('exact sync accumulation limits', () => {
         sends += 1;
         if (sends === 1) return encoder.encode('valid-page');
         if (name === 'denial') return encoder.encode('denied');
-        if (name === 'integrity rejection' || name === 'validation rejection') {
+        if (
+          name === 'integrity rejection'
+          || name === 'validation rejection'
+          || name === 'validation rejection with transport-like text'
+        ) {
           return encoder.encode('invalid-page');
         }
         throw fail(controller);

--- a/packages/agent/test/sync-exact-accumulation.test.ts
+++ b/packages/agent/test/sync-exact-accumulation.test.ts
@@ -53,7 +53,7 @@ function fetchParams(overrides: Partial<FetchParams> = {}): FetchParams {
 
 describe('exact sync accumulation limits', () => {
   it('returns a validated selected-SWM metadata prefix on retryable transport exhaustion only', async () => {
-    const requesterScope = 'selected-swm-meta:retained:1' as const;
+    const requesterScope = 'selected-swm-meta:explicit-policy' as const;
     const checkpointStore = new MemorySyncCheckpointStore();
     let sends = 0;
     const acceptedQuad = {
@@ -69,6 +69,7 @@ describe('exact sync accumulation limits', () => {
       phase: 'meta',
       graphUri: 'urn:meta',
       requesterScope,
+      returnAcceptedPrefixOnRetryableTransportFailure: true,
       assetUals: undefined,
       maxAcceptedBytes: undefined,
       parseAndFilter: async () => ({ quads: [acceptedQuad], totalQuads: 1 }),
@@ -91,13 +92,13 @@ describe('exact sync accumulation limits', () => {
     expect(checkpointStore.get(result.checkpointKey)?.responderSessionId).toBeTruthy();
   });
 
-  it('does not expose transport prefixes to a non-retained custom SWM metadata scope', async () => {
+  it('does not infer selected metadata retention policy from checkpoint scope', async () => {
     let sends = 0;
     await expect(fetchSyncPages(fetchParams({
       includeSharedMemory: true,
       phase: 'meta',
       graphUri: 'urn:meta',
-      requesterScope: 'selected-swm-meta:ordinary-custom',
+      requesterScope: 'selected-swm-meta:retained:1',
       assetUals: undefined,
       maxAcceptedBytes: undefined,
       parseAndFilter: async () => ({
@@ -117,6 +118,7 @@ describe('exact sync accumulation limits', () => {
   it.each([
     {
       name: 'caller abort',
+      scopeId: 2,
       fail: (controller: AbortController) => {
         controller.abort(new Error('caller cancelled'));
         const error = new Error('operation timed out');
@@ -125,7 +127,18 @@ describe('exact sync accumulation limits', () => {
       },
     },
     {
+      name: 'denial',
+      scopeId: 3,
+      fail: (_controller: AbortController) => new Error('Sync denied by legacy-peer'),
+    },
+    {
+      name: 'integrity rejection',
+      scopeId: 4,
+      fail: (_controller: AbortController) => new Error('metadata integrity rejected'),
+    },
+    {
       name: 'validation rejection',
+      scopeId: 5,
       fail: (_controller: AbortController) => {
         const error = new Error('invalid signed response');
         markSyncValidationRejection(error);
@@ -134,10 +147,23 @@ describe('exact sync accumulation limits', () => {
     },
     {
       name: 'local request build failure',
+      scopeId: 6,
       fail: (_controller: AbortController) => new Error('wallet signing failed'),
     },
-  ])('discards a selected metadata prefix on $name', async ({ name, fail }) => {
-    const requesterScope = `selected-swm-meta:retained:${name.replaceAll(' ', '-')}` as const;
+  ])('discards a selected metadata prefix on $name', async ({ name, scopeId, fail }) => {
+    const requesterScope = `selected-swm-meta:retained:${scopeId}` as const;
+    const checkpointStore = new MemorySyncCheckpointStore();
+    const checkpointKey = getSyncCheckpointKey(
+      'legacy-peer',
+      'large-legacy-cg',
+      true,
+      'meta',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      requesterScope,
+    );
     const controller = new AbortController();
     let builds = 0;
     let sends = 0;
@@ -146,7 +172,9 @@ describe('exact sync accumulation limits', () => {
       includeSharedMemory: true,
       phase: 'meta',
       graphUri: 'urn:meta',
+      checkpointStore,
       requesterScope,
+      returnAcceptedPrefixOnRetryableTransportFailure: true,
       assetUals: undefined,
       maxAcceptedBytes: undefined,
       signal: controller.signal,
@@ -157,7 +185,12 @@ describe('exact sync accumulation limits', () => {
       },
       parseAndFilter: async () => {
         parses += 1;
-        if (name === 'validation rejection' && parses === 2) throw fail(controller);
+        if (
+          (name === 'integrity rejection' || name === 'validation rejection')
+          && parses === 2
+        ) {
+          throw fail(controller);
+        }
         return {
           quads: [{ subject: 'urn:accepted', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
           totalQuads: 1,
@@ -166,12 +199,33 @@ describe('exact sync accumulation limits', () => {
       send: async () => {
         sends += 1;
         if (sends === 1) return encoder.encode('valid-page');
-        if (name === 'validation rejection') return encoder.encode('invalid-page');
+        if (name === 'denial') return encoder.encode('denied');
+        if (name === 'integrity rejection' || name === 'validation rejection') {
+          return encoder.encode('invalid-page');
+        }
         throw fail(controller);
       },
     });
 
     await expect(fetchSyncPages(params)).rejects.toBeInstanceOf(Error);
+    expect(checkpointStore.get(checkpointKey)).toBeUndefined();
+
+    // Recreate only an offset. A leaked process-local responder token would
+    // incorrectly make this look resumable instead of rotating to offset zero.
+    checkpointStore.set(checkpointKey, 7);
+    const retry = await fetchSyncPages(fetchParams({
+      checkpointStore,
+      includeSharedMemory: true,
+      phase: 'meta',
+      graphUri: 'urn:meta',
+      requesterScope,
+      assetUals: undefined,
+      maxAcceptedBytes: undefined,
+      send: async () => new Uint8Array(),
+    }));
+    expect(retry.resumedFromOffset).toBe(0);
+    expect(retry.responderSessionStartedFresh).toBe(true);
+    deleteSyncPageCheckpoint(checkpointStore, checkpointKey);
   });
 
   it('rejects excess wire bytes before parsing and clears resumable state', async () => {

--- a/packages/agent/test/sync-exact-accumulation.test.ts
+++ b/packages/agent/test/sync-exact-accumulation.test.ts
@@ -12,6 +12,10 @@ import {
   fetchSyncPages,
 } from '../src/sync/requester/page-fetch.js';
 import { estimateQuadHeapBytes } from '../src/sync/memory-telemetry.js';
+import {
+  markSyncTransportFailure,
+  markSyncValidationRejection,
+} from '../src/sync/error-tags.js';
 
 const EXACT_UAL = 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7';
 const encoder = new TextEncoder();
@@ -48,6 +52,128 @@ function fetchParams(overrides: Partial<FetchParams> = {}): FetchParams {
 }
 
 describe('exact sync accumulation limits', () => {
+  it('returns a validated selected-SWM metadata prefix on retryable transport exhaustion only', async () => {
+    const requesterScope = 'selected-swm-meta:retained:1' as const;
+    const checkpointStore = new MemorySyncCheckpointStore();
+    let sends = 0;
+    const acceptedQuad = {
+      subject: 'urn:selected:accepted',
+      predicate: 'urn:p',
+      object: '"o"',
+      graph: 'urn:meta',
+    };
+
+    const result = await fetchSyncPages(fetchParams({
+      checkpointStore,
+      includeSharedMemory: true,
+      phase: 'meta',
+      graphUri: 'urn:meta',
+      requesterScope,
+      assetUals: undefined,
+      maxAcceptedBytes: undefined,
+      parseAndFilter: async () => ({ quads: [acceptedQuad], totalQuads: 1 }),
+      send: async () => {
+        sends += 1;
+        if (sends === 1) return encoder.encode('valid-page');
+        const error = new Error('operation timed out');
+        markSyncTransportFailure(error);
+        throw error;
+      },
+    }));
+
+    expect(result).toMatchObject({
+      quads: [acceptedQuad],
+      resumedFromOffset: 0,
+      nextOffset: 1,
+      completed: false,
+      timedOut: true,
+    });
+    expect(checkpointStore.get(result.checkpointKey)?.responderSessionId).toBeTruthy();
+  });
+
+  it('does not expose transport prefixes to a non-retained custom SWM metadata scope', async () => {
+    let sends = 0;
+    await expect(fetchSyncPages(fetchParams({
+      includeSharedMemory: true,
+      phase: 'meta',
+      graphUri: 'urn:meta',
+      requesterScope: 'selected-swm-meta:ordinary-custom',
+      assetUals: undefined,
+      maxAcceptedBytes: undefined,
+      parseAndFilter: async () => ({
+        quads: [{ subject: 'urn:ordinary', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+        totalQuads: 1,
+      }),
+      send: async () => {
+        sends += 1;
+        if (sends === 1) return encoder.encode('valid-page');
+        const error = new Error('operation timed out');
+        markSyncTransportFailure(error);
+        throw error;
+      },
+    }))).rejects.toThrow('operation timed out');
+  });
+
+  it.each([
+    {
+      name: 'caller abort',
+      fail: (controller: AbortController) => {
+        controller.abort(new Error('caller cancelled'));
+        const error = new Error('operation timed out');
+        markSyncTransportFailure(error);
+        return error;
+      },
+    },
+    {
+      name: 'validation rejection',
+      fail: (_controller: AbortController) => {
+        const error = new Error('invalid signed response');
+        markSyncValidationRejection(error);
+        return error;
+      },
+    },
+    {
+      name: 'local request build failure',
+      fail: (_controller: AbortController) => new Error('wallet signing failed'),
+    },
+  ])('discards a selected metadata prefix on $name', async ({ name, fail }) => {
+    const requesterScope = `selected-swm-meta:retained:${name.replaceAll(' ', '-')}` as const;
+    const controller = new AbortController();
+    let builds = 0;
+    let sends = 0;
+    let parses = 0;
+    const params = fetchParams({
+      includeSharedMemory: true,
+      phase: 'meta',
+      graphUri: 'urn:meta',
+      requesterScope,
+      assetUals: undefined,
+      maxAcceptedBytes: undefined,
+      signal: controller.signal,
+      buildSyncRequest: async () => {
+        builds += 1;
+        if (name === 'local request build failure' && builds === 2) throw fail(controller);
+        return encoder.encode('request');
+      },
+      parseAndFilter: async () => {
+        parses += 1;
+        if (name === 'validation rejection' && parses === 2) throw fail(controller);
+        return {
+          quads: [{ subject: 'urn:accepted', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+          totalQuads: 1,
+        };
+      },
+      send: async () => {
+        sends += 1;
+        if (sends === 1) return encoder.encode('valid-page');
+        if (name === 'validation rejection') return encoder.encode('invalid-page');
+        throw fail(controller);
+      },
+    });
+
+    await expect(fetchSyncPages(params)).rejects.toBeInstanceOf(Error);
+  });
+
   it('rejects excess wire bytes before parsing and clears resumable state', async () => {
     const firstPage = encoder.encode('page-one');
     const secondPage = encoder.encode('page-two');
@@ -141,7 +267,7 @@ describe('exact sync accumulation limits', () => {
   });
 
   it('tags a fresh scoped metadata accumulation error at the real requester boundary', async () => {
-    const requesterScope = 'selected-swm-meta:fresh-limit-contract' as const;
+    const requesterScope = 'selected-swm-meta:retained:fresh-limit-contract' as const;
     let sends = 0;
     let parses = 0;
 
@@ -181,7 +307,7 @@ describe('exact sync accumulation limits', () => {
 
   it('deletes the process-local responder token for a completed scoped requester', async () => {
     const checkpointStore = new MemorySyncCheckpointStore();
-    const requesterScope = 'selected-swm-meta:cleanup-test' as const;
+    const requesterScope = 'selected-swm-meta:retained:cleanup-test' as const;
     const checkpointKey = getSyncCheckpointKey(
       'legacy-peer',
       'large-legacy-cg',

--- a/packages/agent/test/sync-exact-accumulation.test.ts
+++ b/packages/agent/test/sync-exact-accumulation.test.ts
@@ -13,8 +13,8 @@ import {
 } from '../src/sync/requester/page-fetch.js';
 import { estimateQuadHeapBytes } from '../src/sync/memory-telemetry.js';
 import {
-  markSyncTransportFailure,
-  markSyncValidationRejection,
+  toSyncTransportFailureError,
+  toSyncValidationRejectionError,
 } from '../src/sync/error-tags.js';
 
 const EXACT_UAL = 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7';
@@ -123,8 +123,7 @@ describe('exact sync accumulation limits', () => {
         const error = new Error('request timeout');
         error.name = 'AbortError';
         Object.freeze(error);
-        markSyncTransportFailure(error);
-        throw error;
+        throw toSyncTransportFailureError(error);
       },
     }));
 
@@ -160,8 +159,7 @@ describe('exact sync accumulation limits', () => {
         sends += 1;
         if (sends === 1) return encoder.encode('valid-page');
         const error = new Error('operation timed out');
-        markSyncTransportFailure(error);
-        throw error;
+        throw toSyncTransportFailureError(error);
       },
     }))).rejects.toThrow('operation timed out');
   });
@@ -174,8 +172,7 @@ describe('exact sync accumulation limits', () => {
         controller.abort(new Error('caller cancelled'));
         const error = new Error('operation timed out');
         error.name = 'AbortError';
-        markSyncTransportFailure(error);
-        return error;
+        return toSyncTransportFailureError(error);
       },
     },
     {
@@ -193,8 +190,7 @@ describe('exact sync accumulation limits', () => {
       scopeId: 5,
       fail: (_controller: AbortController) => {
         const error = new Error('invalid signed response');
-        markSyncValidationRejection(error);
-        return error;
+        return toSyncValidationRejectionError(error);
       },
     },
     {
@@ -202,8 +198,7 @@ describe('exact sync accumulation limits', () => {
       scopeId: 7,
       fail: (_controller: AbortController) => {
         const error = new Error('operation timed out');
-        markSyncValidationRejection(error);
-        return error;
+        return toSyncValidationRejectionError(error);
       },
     },
     {

--- a/packages/agent/test/sync-exact-accumulation.test.ts
+++ b/packages/agent/test/sync-exact-accumulation.test.ts
@@ -95,6 +95,53 @@ describe('exact sync accumulation limits', () => {
     expect(checkpointStore.get(result.checkpointKey)?.responderSessionId).toBeTruthy();
   });
 
+  it('retains selected metadata when a tagged transport deadline has AbortError shape', async () => {
+    const requesterScope = 'selected-swm-meta:tagged-abort-deadline' as const;
+    const checkpointStore = new MemorySyncCheckpointStore();
+    let sends = 0;
+    const acceptedQuad = {
+      subject: 'urn:selected:tagged-abort',
+      predicate: 'urn:p',
+      object: '"o"',
+      graph: 'urn:meta',
+    };
+
+    const result = await fetchSyncPages(fetchParams({
+      checkpointStore,
+      includeSharedMemory: true,
+      phase: 'meta',
+      graphUri: 'urn:meta',
+      requesterScope,
+      returnAcceptedPrefixOnRetryableTransportFailure: true,
+      assetUals: undefined,
+      maxAcceptedBytes: undefined,
+      signal: new AbortController().signal,
+      parseAndFilter: async () => ({ quads: [acceptedQuad], totalQuads: 1 }),
+      send: async () => {
+        sends += 1;
+        if (sends === 1) return encoder.encode('valid-page');
+        const error = new Error('request timeout');
+        error.name = 'AbortError';
+        markSyncTransportFailure(error);
+        throw error;
+      },
+    }));
+
+    expect(result).toMatchObject({
+      quads: [acceptedQuad],
+      resumedFromOffset: 0,
+      nextOffset: 1,
+      completed: false,
+      timedOut: true,
+    });
+    expect(checkpointStore.get(result.checkpointKey)).toMatchObject({
+      // The selected owner, not the generic page fetcher, owns advancement to
+      // result.nextOffset after it has retained this exact private prefix.
+      offset: 0,
+      responderSessionId: expect.any(String),
+    });
+  });
+
   it('does not infer selected metadata retention policy from checkpoint scope', async () => {
     let sends = 0;
     await expect(fetchSyncPages(fetchParams({
@@ -125,6 +172,7 @@ describe('exact sync accumulation limits', () => {
       fail: (controller: AbortController) => {
         controller.abort(new Error('caller cancelled'));
         const error = new Error('operation timed out');
+        error.name = 'AbortError';
         markSyncTransportFailure(error);
         return error;
       },

--- a/packages/agent/test/sync-exact-accumulation.test.ts
+++ b/packages/agent/test/sync-exact-accumulation.test.ts
@@ -122,6 +122,7 @@ describe('exact sync accumulation limits', () => {
         if (sends === 1) return encoder.encode('valid-page');
         const error = new Error('request timeout');
         error.name = 'AbortError';
+        Object.freeze(error);
         markSyncTransportFailure(error);
         throw error;
       },
@@ -216,6 +217,21 @@ describe('exact sync accumulation limits', () => {
       fail: (_controller: AbortController) => new Error('operation timed out'),
     },
     {
+      name: 'frozen local request timeout with transport-like text',
+      scopeId: 10,
+      fail: (_controller: AbortController) => Object.freeze(new Error('operation timed out')),
+    },
+    {
+      name: 'frozen response parse timeout with transport-like text',
+      scopeId: 11,
+      fail: (_controller: AbortController) => Object.freeze(new Error('operation timed out')),
+    },
+    {
+      name: 'primitive response parse timeout with transport-like text',
+      scopeId: 12,
+      fail: (_controller: AbortController) => 'operation timed out',
+    },
+    {
       name: 'chain RPC timeout with transport-like text',
       scopeId: 9,
       fail: (_controller: AbortController) => Object.assign(
@@ -257,6 +273,7 @@ describe('exact sync accumulation limits', () => {
           (
             name === 'local request build failure'
             || name === 'local request timeout with transport-like text'
+            || name === 'frozen local request timeout with transport-like text'
             || name === 'chain RPC timeout with transport-like text'
           )
           && builds === 2
@@ -268,7 +285,9 @@ describe('exact sync accumulation limits', () => {
         if (
           (name === 'integrity rejection'
             || name === 'validation rejection'
-            || name === 'validation rejection with transport-like text')
+            || name === 'validation rejection with transport-like text'
+            || name === 'frozen response parse timeout with transport-like text'
+            || name === 'primitive response parse timeout with transport-like text')
           && parses === 2
         ) {
           throw fail(controller);
@@ -286,6 +305,8 @@ describe('exact sync accumulation limits', () => {
           name === 'integrity rejection'
           || name === 'validation rejection'
           || name === 'validation rejection with transport-like text'
+          || name === 'frozen response parse timeout with transport-like text'
+          || name === 'primitive response parse timeout with transport-like text'
         ) {
           return encoder.encode('invalid-page');
         }
@@ -293,7 +314,19 @@ describe('exact sync accumulation limits', () => {
       },
     });
 
-    await expect(fetchSyncPages(params)).rejects.toBeInstanceOf(Error);
+    let rejected: unknown;
+    try {
+      await fetchSyncPages(params);
+    } catch (error) {
+      rejected = error;
+    }
+    expect(rejected).toBeInstanceOf(Error);
+    if (name === 'primitive response parse timeout with transport-like text') {
+      expect(rejected).toMatchObject({
+        message: 'operation timed out',
+        cause: 'operation timed out',
+      });
+    }
     expect(checkpointStore.get(checkpointKey)).toBeUndefined();
 
     // Recreate only an offset. A leaked process-local responder token would

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -36,6 +36,7 @@ type FetchArgs = {
   signal?: AbortSignal;
   recovery?: boolean;
   assetUals?: string[];
+  returnAcceptedPrefixOnRetryableTransportFailure?: boolean;
   requesterScope?: SyncCheckpointScope;
   maxAcceptedQuads?: number;
   maxAcceptedHeapBytesEstimate?: number;
@@ -249,6 +250,8 @@ function fetchPages(agent: DKGAgent, args: FetchArgs = {}): Promise<SyncPageResu
       signal: args.signal,
       recovery: args.recovery,
       assetUals: args.assetUals,
+      returnAcceptedPrefixOnRetryableTransportFailure:
+        args.returnAcceptedPrefixOnRetryableTransportFailure,
       requesterScope: args.requesterScope,
       maxAcceptedQuads: args.maxAcceptedQuads,
       maxAcceptedHeapBytesEstimate: args.maxAcceptedHeapBytesEstimate,
@@ -339,6 +342,11 @@ describe('DKGAgent sync fetch coalescing', () => {
       // sequence, and an exact batch must never join a full sync.
       { name: 'assetUals', base: { assetUals: [EXACT_UAL_7] }, variant: { assetUals: [EXACT_UAL_8] } },
       { name: 'assetUals-vs-full', base: {}, variant: { assetUals: [EXACT_UAL_7] } },
+      {
+        name: 'returnAcceptedPrefixOnRetryableTransportFailure',
+        base: {},
+        variant: { returnAcceptedPrefixOnRetryableTransportFailure: true },
+      },
       { name: 'requesterScope', base: {}, variant: { requesterScope: 'selected-swm-meta:test' } },
       { name: 'maxAcceptedQuads', base: {}, variant: { maxAcceptedQuads: 10 } },
       { name: 'maxAcceptedHeapBytesEstimate', base: {}, variant: { maxAcceptedHeapBytesEstimate: 4096 } },

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../src/sync/requester/ordered-sync.js';
 import { SyncBackpressureBusyError } from '../src/sync/backpressure.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
-import { markSyncTransportFailure } from '../src/sync/error-tags.js';
+import { toSyncTransportFailureError } from '../src/sync/error-tags.js';
 import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 
 const ctx = { kind: 'system', id: 'test', startedAt: 0 } as OperationContext;
@@ -47,8 +47,7 @@ function pageResult(
 
 function transportError(message: string): Error {
   const err = new Error(message);
-  markSyncTransportFailure(err);
-  return err;
+  return toSyncTransportFailureError(err);
 }
 
 function deniedError(): Error & { syncDenied: boolean } {

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -25,7 +25,7 @@ import {
   SyncPageAccumulationLimitError,
   type SyncPageResult,
 } from '../src/sync/requester/page-fetch.js';
-import { markSyncTransportFailure } from '../src/sync/error-tags.js';
+import { toSyncTransportFailureError } from '../src/sync/error-tags.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -69,8 +69,7 @@ function deniedError(): Error & { syncDenied: boolean } {
 
 function transportError(message: string): Error {
   const err = new Error(message);
-  markSyncTransportFailure(err);
-  return err;
+  return toSyncTransportFailureError(err);
 }
 
 function quad(subject: string): Quad {

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -92,7 +92,9 @@ export default defineConfig({
       // #2050 — the stop rule for the bounded repeat of the public SWM peer walk.
       "test/catchup-pass-policy.test.ts",
       "test/selected-swm-continuation.test.ts",
+      "test/selected-swm-meta-transfer-coordinator.test.ts",
       "test/selected-swm-meta-budget.test.ts",
+      "test/outbox-shutdown-lifecycle.test.ts",
       "test/sync-checkpoint-key.test.ts",
       "test/map-with-concurrency.test.ts",
       "test/peer-selection.test.ts",

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -29,6 +29,9 @@ export function isRecoverableSendError(err: unknown): boolean {
     msg.includes('stream returned in closed state') ||
     msg.includes('econnreset') ||
     msg.includes('etimedout') ||
+    msg.includes('send timeout') ||
+    msg.includes('operation timed out') ||
+    msg.includes('operation was aborted due to timeout') ||
     msg.includes('econnrefused') ||
     msg.includes('epipe') ||
     msg.includes('aborted') ||

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -29,6 +29,12 @@ describe('ProtocolRouter', () => {
       expect(isRecoverableSendError(new Error('ECONNREFUSED'))).toBe(true);
       expect(isRecoverableSendError(new Error('EPIPE'))).toBe(true);
       expect(isRecoverableSendError(new Error('The operation was aborted'))).toBe(true);
+      expect(isRecoverableSendError(new Error('send timeout'))).toBe(true);
+      expect(isRecoverableSendError(new Error('operation timed out'))).toBe(true);
+      expect(isRecoverableSendError(new Error('operation was aborted due to timeout'))).toBe(true);
+      expect(isRecoverableSendError(new Error('peer-closed-stream'))).toBe(true);
+      expect(isRecoverableSendError(new Error('The stream has been reset'))).toBe(true);
+      expect(isRecoverableSendError(new Error('Remote closed connection during opening'))).toBe(true);
       expect(isRecoverableSendError(new Error('no valid addresses'))).toBe(true);
       expect(isRecoverableSendError(new Error('NO_RESERVATION'))).toBe(true);
       expect(isRecoverableSendError(new Error('no reservation for relay'))).toBe(true);


### PR DESCRIPTION
## Outcome

A selected public SWM receiver no longer throws away thousands of already validated catalog rows when the final page attempt ends in a retryable relay or transport interruption. The exact prefix, responder session, and raw offset remain privately owned and bounded across reconciler invocations, so the next automatic pass resumes monotonically instead of restarting at zero.

Incomplete metadata is never verified as a manifest and never reaches Blazegraph. Abort, denial, validation/integrity failure, local request construction failure, responder-session replacement, expiry, close, and budget rejection all discard the prefix and checkpoint fail-closed.

## Before

```mermaid
sequenceDiagram
    participant Receiver as Selected SWM receiver
    participant Provider as Catalog provider
    participant Memory as Private transfer state
    participant Store as Local store
    Receiver->>Provider: Fetch metadata pages from offset 0
    Provider-->>Receiver: 7472 validated rows
    Provider--xReceiver: Final retryable relay timeout
    Receiver->>Memory: Delete prefix and checkpoint
    Note over Store: No partial activation
    Receiver->>Provider: Next reconciler restarts at offset 0
```

## After

```mermaid
sequenceDiagram
    participant Receiver as Selected SWM receiver
    participant Provider as Catalog provider
    participant Memory as Bounded private transfer owner
    participant Store as Local store
    Receiver->>Provider: Fetch metadata pages from offset 0
    Provider-->>Receiver: Validated prefix and responder session
    Provider--xReceiver: Retryable transport exhaustion
    Receiver->>Memory: Retain prefix plus session plus raw offset
    Note over Store: Still no partial activation
    Receiver->>Provider: Next automatic pass resumes at exact offset
    Provider-->>Receiver: Complete manifest
    Receiver->>Receiver: Verify completeness and policy
    Receiver->>Store: Materialize atomically
```

## Safety boundaries

- Runtime-distinct requester scope limits salvage to selected public SWM metadata.
- Same-peer owners serialize; different peers remain concurrent.
- Each CG has an independent active TTL; sibling progress cannot keep an abandoned prefix alive.
- Existing local and global retention budgets bound rows and heap estimates.
- Completion, replacement, expiry, close, abort, denial, validation/integrity, and local-build failure clean up state and checkpoints.

## Validation

- Selected continuation and exact accumulation: 48/48 passed.
- Adjacent sync coalescing: 27/27 passed.
- Exact combined candidate focused gate: 6 files, 161/161 passed.
- Agent build, type tests, and package-root tests passed.
- Independent P0-P2 review: clean.

## Stack

Targets #2219 so reviewers see only the selected-SWM resumability delta. #2220 is an independent sibling hardening PR. The final candidate combines both and will be certified on a fresh Testnet receiver against the sealed CG298 corpus: SWM 901/901, VM 400/400, then restart parity with recovery disabled.