### PR TITLE
fix(agent): preserve profile receiver compatibility

### DIFF
--- a/packages/agent/src/system-records/receiver-v1.ts
+++ b/packages/agent/src/system-records/receiver-v1.ts
@@ -266,6 +266,13 @@ function normalizeAgentProfileArtifactSourcesV1(
     throw new TypeError('agent-profile artifact input must be a repository or source pair');
   }
   const candidate = input as unknown as Record<PropertyKey, unknown>;
+  if (typeof candidate.resolve === 'function') {
+    const repository = bindAgentProfileArtifactRepositoryV1(input, 'artifacts');
+    return Object.freeze({
+      closureArtifacts: repository,
+      securitySidecarArtifacts: repository,
+    });
+  }
   const hasClosureArtifacts = 'closureArtifacts' in candidate;
   const hasSecuritySidecarArtifacts = 'securitySidecarArtifacts' in candidate;
   if (hasClosureArtifacts || hasSecuritySidecarArtifacts) {
@@ -283,11 +290,7 @@ function normalizeAgentProfileArtifactSourcesV1(
       ),
     });
   }
-  const repository = bindAgentProfileArtifactRepositoryV1(input, 'artifacts');
-  return Object.freeze({
-    closureArtifacts: repository,
-    securitySidecarArtifacts: repository,
-  });
+  throw new TypeError('agent-profile artifact input must provide a repository resolver');
 }
 
 function bindAgentProfileArtifactRepositoryV1(

--- a/packages/agent/src/system-records/receiver-v1.ts
+++ b/packages/agent/src/system-records/receiver-v1.ts
@@ -266,17 +266,17 @@ function normalizeAgentProfileArtifactSourcesV1(
     throw new TypeError('agent-profile artifact input must be a repository or source pair');
   }
   const candidate = input as unknown as Record<PropertyKey, unknown>;
-  if (typeof candidate.resolve === 'function') {
+  const inputKind = classifyAgentProfileArtifactInputV1(candidate);
+  if (inputKind === 'legacy-repository') {
     const repository = bindAgentProfileArtifactRepositoryV1(input, 'artifacts');
     return Object.freeze({
       closureArtifacts: repository,
       securitySidecarArtifacts: repository,
     });
   }
-  const hasClosureArtifacts = 'closureArtifacts' in candidate;
-  const hasSecuritySidecarArtifacts = 'securitySidecarArtifacts' in candidate;
-  if (hasClosureArtifacts || hasSecuritySidecarArtifacts) {
-    if (!hasClosureArtifacts || !hasSecuritySidecarArtifacts) {
+  if (inputKind === 'source-pair') {
+    if (!('closureArtifacts' in candidate)
+        || !('securitySidecarArtifacts' in candidate)) {
       throw new TypeError('agent-profile artifact source pair must provide both repositories');
     }
     return Object.freeze({
@@ -291,6 +291,18 @@ function normalizeAgentProfileArtifactSourcesV1(
     });
   }
   throw new TypeError('agent-profile artifact input must provide a repository resolver');
+}
+
+function classifyAgentProfileArtifactInputV1(
+  candidate: Record<PropertyKey, unknown>,
+): 'legacy-repository' | 'source-pair' | 'invalid' {
+  // The V1 compatibility contract is repository-first: extra structural
+  // properties cannot turn an existing repository into a different input mode.
+  if (typeof candidate.resolve === 'function') return 'legacy-repository';
+  if ('closureArtifacts' in candidate || 'securitySidecarArtifacts' in candidate) {
+    return 'source-pair';
+  }
+  return 'invalid';
 }
 
 function bindAgentProfileArtifactRepositoryV1(

--- a/packages/agent/src/system-records/reconcile-v1.ts
+++ b/packages/agent/src/system-records/reconcile-v1.ts
@@ -113,6 +113,7 @@ export type AgentProfileReconcileBlockReasonV1 =
   | 'inventory-busy'
   | 'inventory-transport'
   | 'activation-leaf-limit'
+  | 'unsupported-row-state'
   | 'receiver-verification-failed'
   | 'apply-root-collision'
   | 'apply-capacity-exhausted'
@@ -328,9 +329,7 @@ function normalizeAgentProfileReceiverForReconcileV1(
   return Object.freeze({
     prepare(row: SystemRecordInventoryRowV1, signal: AbortSignal) {
       if (row.tombstone || row.quarantined) {
-        throw new Error(
-          'active-only agent-profile receiver rejected a non-active inventory row',
-        );
+        throw new AgentProfileUnsupportedRowStateErrorV1();
       }
       return receiver.prepareActive(row, signal);
     },
@@ -344,12 +343,17 @@ function normalizeAgentProfileContinuationForReconcileV1(
   if (isAgentProfileCandidateReceiverV1(receiver)) return openPreparation;
   return (row: SystemRecordInventoryRowV1) => {
     if (row.tombstone || row.quarantined) {
-      throw new Error(
-        'active-only agent-profile continuation rejected a non-active inventory row',
-      );
+      throw new AgentProfileUnsupportedRowStateErrorV1();
     }
     return openPreparation(row);
   };
+}
+
+class AgentProfileUnsupportedRowStateErrorV1 extends Error {
+  constructor() {
+    super('active-only agent-profile receiver rejected a non-active inventory row');
+    this.name = 'AgentProfileUnsupportedRowStateErrorV1';
+  }
 }
 
 function isAgentProfileCandidateReceiverV1(
@@ -740,7 +744,9 @@ export async function createAgentProfileReconcilerV1(
           0,
           0,
           outcomes,
-          'receiver-verification-failed',
+          error instanceof AgentProfileUnsupportedRowStateErrorV1
+            ? 'unsupported-row-state'
+            : 'receiver-verification-failed',
         ),
       });
     }

--- a/packages/agent/src/system-records/reconcile-v1.ts
+++ b/packages/agent/src/system-records/reconcile-v1.ts
@@ -82,10 +82,16 @@ interface CreateAgentProfileReconcilerCommonOptionsV1 {
 }
 
 interface AgentProfileReconcileReceiverAdapterV1 {
+  supportsRow(row: SystemRecordInventoryRowV1): boolean;
   prepare(
     row: SystemRecordInventoryRowV1,
     signal: AbortSignal,
   ): Promise<AgentProfilePreparedCandidateV1>;
+}
+
+interface AgentProfileReconcileContinuationAdapterV1 {
+  supportsRow(row: SystemRecordInventoryRowV1): boolean;
+  openPreparation: AgentProfileContinuationReceiverV1['openPreparation'];
 }
 
 export type CreateAgentProfileReconcilerOptionsV1 =
@@ -201,6 +207,7 @@ interface AgentProfileSliceSourceOpenInputV1 {
 }
 
 interface AgentProfileSliceSourceFactoryV1 {
+  supportsRow(row: SystemRecordInventoryRowV1): boolean;
   tryOpen(input: AgentProfileSliceSourceOpenInputV1): AgentProfileSliceSourceOpenResultV1;
   clearPreparation(): void;
   retainedStats(): Readonly<{
@@ -216,7 +223,7 @@ function createSliceSourceFactoryV1(
   options: CreateAgentProfileReconcilerOptionsV1,
 ): AgentProfileSliceSourceFactoryV1 {
   const networkId = options.networkId;
-  const openPreparation = options.transport === undefined
+  const continuationReceiver = options.transport === undefined
     ? undefined
     : normalizeAgentProfileContinuationForReconcileV1(options.receiver);
   let preparation: AgentProfilePreparationV1 | undefined;
@@ -241,11 +248,11 @@ function createSliceSourceFactoryV1(
     signal: AbortSignal,
   ): Promise<AgentProfilePreparedCandidateV1> => {
     if (closed) throw new Error('agent-profile slice source factory is closed');
-    if (openPreparation === undefined) {
+    if (continuationReceiver === undefined) {
       throw new Error('agent-profile transport receiver does not support continuation');
     }
     selectRow(row);
-    preparation ??= openPreparation(row);
+    preparation ??= continuationReceiver.openPreparation(row);
     return preparation.prepare(artifacts, signal);
   };
   const retainedStats = () => {
@@ -263,11 +270,15 @@ function createSliceSourceFactoryV1(
     clearPreparation();
   };
   if (options.transport !== undefined) {
+    if (continuationReceiver === undefined) {
+      throw new Error('agent-profile transport receiver does not support continuation');
+    }
     const openTransportSlice = options.transport.openSlice.bind(options.transport);
     const openArtifactContinuation = options.transport.openArtifactContinuation.bind(
       options.transport,
     );
     return Object.freeze({
+      supportsRow: continuationReceiver.supportsRow,
       tryOpen(input: AgentProfileSliceSourceOpenInputV1): AgentProfileSliceSourceOpenResultV1 {
         const transportSlice = openTransportSlice(input);
         if (transportSlice === null) return Object.freeze({ status: 'deferred' });
@@ -301,6 +312,7 @@ function createSliceSourceFactoryV1(
   const loadInventoryObject = options.loadInventoryObject;
   const receiver = normalizeAgentProfileReceiverForReconcileV1(options.receiver);
   return Object.freeze({
+    supportsRow: receiver.supportsRow,
     tryOpen(): AgentProfileSliceSourceOpenResultV1 {
       return Object.freeze({
         status: 'opened',
@@ -323,37 +335,30 @@ function normalizeAgentProfileReceiverForReconcileV1(
 ): AgentProfileReconcileReceiverAdapterV1 {
   if (isAgentProfileCandidateReceiverV1(receiver)) {
     return Object.freeze({
+      supportsRow: () => true,
       prepare: receiver.prepareCandidate.bind(receiver),
     });
   }
   return Object.freeze({
-    prepare(row: SystemRecordInventoryRowV1, signal: AbortSignal) {
-      if (row.tombstone || row.quarantined) {
-        throw new AgentProfileUnsupportedRowStateErrorV1();
-      }
-      return receiver.prepareActive(row, signal);
-    },
+    supportsRow: isOrdinaryActiveInventoryRowV1,
+    prepare: receiver.prepareActive.bind(receiver),
   });
 }
 
 function normalizeAgentProfileContinuationForReconcileV1(
   receiver: AgentProfileContinuationReceiverV1,
-): AgentProfileContinuationReceiverV1['openPreparation'] {
+): AgentProfileReconcileContinuationAdapterV1 {
   const openPreparation = receiver.openPreparation.bind(receiver);
-  if (isAgentProfileCandidateReceiverV1(receiver)) return openPreparation;
-  return (row: SystemRecordInventoryRowV1) => {
-    if (row.tombstone || row.quarantined) {
-      throw new AgentProfileUnsupportedRowStateErrorV1();
-    }
-    return openPreparation(row);
-  };
+  return Object.freeze({
+    supportsRow: isAgentProfileCandidateReceiverV1(receiver)
+      ? () => true
+      : isOrdinaryActiveInventoryRowV1,
+    openPreparation,
+  });
 }
 
-class AgentProfileUnsupportedRowStateErrorV1 extends Error {
-  constructor() {
-    super('active-only agent-profile receiver rejected a non-active inventory row');
-    this.name = 'AgentProfileUnsupportedRowStateErrorV1';
-  }
+function isOrdinaryActiveInventoryRowV1(row: SystemRecordInventoryRowV1): boolean {
+  return !row.tombstone && !row.quarantined;
 }
 
 function isAgentProfileCandidateReceiverV1(
@@ -660,6 +665,10 @@ export async function createAgentProfileReconcilerV1(
         return result('blocked', 'records', 0, 0, outcomes, 'continuation-limit');
       }
       const row = pendingRows[0]!;
+      if (!sourceFactory.supportsRow(row)) {
+        sourceFactory.clearPreparation();
+        return result('blocked', 'records', 0, 0, outcomes, 'unsupported-row-state');
+      }
       if (predispatchBudgetUnavailable(runtime)) {
         sourceFactory.clearPreparation();
         return runtime.stop('records', outcomes);
@@ -744,9 +753,7 @@ export async function createAgentProfileReconcilerV1(
           0,
           0,
           outcomes,
-          error instanceof AgentProfileUnsupportedRowStateErrorV1
-            ? 'unsupported-row-state'
-            : 'receiver-verification-failed',
+          'receiver-verification-failed',
         ),
       });
     }

--- a/packages/agent/test/support/agent-profile-receiver-conflict-v1-fixture.ts
+++ b/packages/agent/test/support/agent-profile-receiver-conflict-v1-fixture.ts
@@ -244,6 +244,7 @@ export async function transitionQuarantineFixture(
   reverseDelivery = false,
   withTombstoneFork = false,
   unrelatedTransitionEvidence = false,
+  invalidCompetingPredecessor = false,
 ) {
   const prior = await publishedFixture();
   const nextSigner = createEvmPersonalMessageSignerV1({
@@ -313,6 +314,9 @@ export async function transitionQuarantineFixture(
   });
   const competingTransition: AgentProfileAuthorityTransitionV1 = Object.freeze({
     ...transitionBase,
+    ...(invalidCompetingPredecessor
+      ? { priorHeadDigest: nextSeedEnvelope.objectDigest }
+      : {}),
     nextEvmIssuer: alternateSigner.address.toLowerCase(),
     nextRoot: `did:dkg:agent:${alternateSigner.address.toLowerCase()}`,
   });

--- a/packages/agent/test/support/agent-profile-receiver-conflict-v1-fixture.ts
+++ b/packages/agent/test/support/agent-profile-receiver-conflict-v1-fixture.ts
@@ -240,12 +240,22 @@ export async function activeTombstoneConflictFixture() {
   };
 }
 
+export interface TransitionQuarantineFixtureOptions {
+  readonly reverseDelivery?: boolean;
+  readonly withTombstoneFork?: boolean;
+  readonly unrelatedTransitionEvidence?: boolean;
+  readonly invalidCompetingPredecessor?: boolean;
+}
+
 export async function transitionQuarantineFixture(
-  reverseDelivery = false,
-  withTombstoneFork = false,
-  unrelatedTransitionEvidence = false,
-  invalidCompetingPredecessor = false,
+  options: TransitionQuarantineFixtureOptions = {},
 ) {
+  const {
+    reverseDelivery = false,
+    withTombstoneFork = false,
+    unrelatedTransitionEvidence = false,
+    invalidCompetingPredecessor = false,
+  } = options;
   const prior = await publishedFixture();
   const nextSigner = createEvmPersonalMessageSignerV1({
     mode: 'custodial',

--- a/packages/agent/test/system-record-receiver-v1.test.ts
+++ b/packages/agent/test/system-record-receiver-v1.test.ts
@@ -145,14 +145,19 @@ describe('agent-profile system-record receiver', () => {
     expect(prepareCandidateApply.mock.calls[0]).toHaveLength(3);
   });
 
-  it('accepts the legacy artifact repository at constructor and preparation boundaries', async () => {
+  it('accepts a structural legacy repository with a reserved extra field', async () => {
     const fixture = await publishedFixture();
     const signal = new AbortController().signal;
+    const resolve = vi.fn(fixture.store.resolve.bind(fixture.store));
+    const legacyRepository = Object.freeze({
+      resolve,
+      closureArtifacts: Object.freeze({ kind: 'legacy-cache' }),
+    });
     const verifyCurrentBundle = vi.fn(() => true);
     const prepareCandidateApply = vi.fn(() => preparedFixtureApply('1', 'a'));
     const receiver = createReceiverWithArtifactSources({
       networkId: NETWORK,
-      artifacts: fixture.store,
+      artifacts: legacyRepository,
       nowMs: () => PRODUCER_FIXTURE_NOW_MS,
       verifyCurrentBundle,
       prepareCandidateApply,
@@ -163,7 +168,7 @@ describe('agent-profile system-record receiver', () => {
 
     const preparation = receiver.openPreparation(fixture.row);
     try {
-      const prepared = await preparation.prepare(fixture.store, signal);
+      const prepared = await preparation.prepare(legacyRepository, signal);
       const dispatch = await prepared.prepareDispatch(ADMITTED_CONTEXT, signal);
       await expect(dispatch.dispatch()).resolves.toMatchObject({ outcome: 'applied' });
     } finally {
@@ -172,6 +177,7 @@ describe('agent-profile system-record receiver', () => {
 
     expect(verifyCurrentBundle).toHaveBeenCalledTimes(2);
     expect(prepareCandidateApply).toHaveBeenCalledTimes(2);
+    expect(resolve).toHaveBeenCalled();
   });
 
   it('rejects malformed split artifact sources instead of treating them as legacy', async () => {
@@ -1329,6 +1335,27 @@ describe('agent-profile system-record receiver', () => {
       ADMITTED_CONTEXT,
       new AbortController().signal,
     )).rejects.toThrow(/unrelated to the retained authority lineage/);
+    expect(verifyCurrentBundle).not.toHaveBeenCalled();
+    expect(prepareCandidateApply).not.toHaveBeenCalled();
+  });
+
+  it('rejects terminal transition evidence without its exact accepted predecessor', async () => {
+    const fixture = await transitionQuarantineFixture(false, false, false, true);
+    const verifyCurrentBundle = vi.fn(() => true);
+    const prepareCandidateApply = vi.fn();
+    const receiver = createAgentProfileCandidateReceiverV1({
+      networkId: NETWORK,
+      artifacts: fixture.artifacts,
+      nowMs: () => PRODUCER_FIXTURE_NOW_MS,
+      verifyCurrentBundle,
+      prepareCandidateApply,
+    });
+
+    await expect(receiver.receiveCandidate(
+      fixture.row,
+      ADMITTED_CONTEXT,
+      new AbortController().signal,
+    )).rejects.toThrow(/transition conflict lacks its exact accepted predecessor/);
     expect(verifyCurrentBundle).not.toHaveBeenCalled();
     expect(prepareCandidateApply).not.toHaveBeenCalled();
   });

--- a/packages/agent/test/system-record-receiver-v1.test.ts
+++ b/packages/agent/test/system-record-receiver-v1.test.ts
@@ -152,6 +152,7 @@ describe('agent-profile system-record receiver', () => {
     const legacyRepository = Object.freeze({
       resolve,
       closureArtifacts: Object.freeze({ kind: 'legacy-cache' }),
+      securitySidecarArtifacts: Object.freeze({ kind: 'legacy-sidecar-cache' }),
     });
     const verifyCurrentBundle = vi.fn(() => true);
     const prepareCandidateApply = vi.fn(() => preparedFixtureApply('1', 'a'));
@@ -1319,7 +1320,9 @@ describe('agent-profile system-record receiver', () => {
   });
 
   it('rejects terminal transition evidence unrelated to the retained authority lineage', async () => {
-    const fixture = await transitionQuarantineFixture(false, false, true);
+    const fixture = await transitionQuarantineFixture({
+      unrelatedTransitionEvidence: true,
+    });
     const verifyCurrentBundle = vi.fn(() => true);
     const prepareCandidateApply = vi.fn();
     const receiver = createAgentProfileCandidateReceiverV1({
@@ -1340,7 +1343,9 @@ describe('agent-profile system-record receiver', () => {
   });
 
   it('rejects terminal transition evidence without its exact accepted predecessor', async () => {
-    const fixture = await transitionQuarantineFixture(false, false, false, true);
+    const fixture = await transitionQuarantineFixture({
+      invalidCompetingPredecessor: true,
+    });
     const verifyCurrentBundle = vi.fn(() => true);
     const prepareCandidateApply = vi.fn();
     const receiver = createAgentProfileCandidateReceiverV1({
@@ -1394,7 +1399,7 @@ describe('agent-profile system-record receiver', () => {
   });
 
   it('keeps transition equivocation terminal when the sidecar also advertises a tombstone', async () => {
-    const fixture = await transitionQuarantineFixture(false, true);
+    const fixture = await transitionQuarantineFixture({ withTombstoneFork: true });
     const prepareCandidateApply = vi.fn((
       _candidate: AgentProfileReceiverAnyCandidateV1,
     ) => preparedFixtureApply('10', 'a'));

--- a/packages/agent/test/system-record-reconcile-transport-integration-v1.test.ts
+++ b/packages/agent/test/system-record-reconcile-transport-integration-v1.test.ts
@@ -9,6 +9,7 @@ import {
 import type {
   AgentProfileArtifactSourcesV1,
   AgentProfileCandidateContinuationReceiverV1,
+  AgentProfileContinuationReceiverV1,
   AgentProfileReceiverAnyCandidateV1,
 } from '../src/system-records/receiver-v1.js';
 import { createAgentProfileCandidateReceiverV1 } from '../src/system-records/receiver-v1.js';
@@ -29,6 +30,76 @@ import { NETWORK } from './support/agent-profile-producer-v1-fixture.js';
 import { agentProfileArtifactSources } from './support/agent-profile-artifact-sources-v1-fixture.js';
 
 describe('agent-profile reconciler exact transport integration V1', () => {
+  it('reports unsupported non-active rows before transport receiver preparation', async () => {
+    const fixture = await conflictReconcileFixture('active');
+    const fetchExact = vi.fn(async (
+      _providerId: string,
+      lookup: SystemRecordExactArtifactLookupV1,
+      signal: AbortSignal,
+    ): Promise<SystemRecordExactFetchResultV1> => {
+      const artifact = await fixture.repository.resolve(lookup, signal);
+      if (artifact === null) return Object.freeze({ outcome: 'not-found', wireBytes: 1 });
+      return Object.freeze({
+        outcome: 'ok',
+        lease: Object.freeze({
+          artifact,
+          wireBytes: 4 + 128 + artifact.canonicalBytes.byteLength,
+          release: vi.fn(),
+        }),
+      });
+    });
+    const transport = createAgentProfileReconcileTransportV1({
+      networkId: NETWORK,
+      listProviderIds: () => ['provider-a'],
+      fetchExact,
+      controlAdmission: byteAdmission(),
+    });
+    const openPreparation = vi.fn();
+    const prepareActive = vi.fn(async () => {
+      throw new Error('active-only receiver must not prepare a quarantined row');
+    });
+    const receiveActive = vi.fn(async () => {
+      throw new Error('active-only receiver must not receive a quarantined row');
+    });
+    const activeOnlyReceiver: AgentProfileContinuationReceiverV1 = Object.freeze({
+      openPreparation(row) {
+        openPreparation(row);
+        throw new Error('active-only continuation must not open a quarantined row');
+      },
+      prepareActive,
+      receiveActive,
+    });
+    const reconciler = await createAgentProfileReconcilerV1({
+      networkId: NETWORK,
+      rootEnvelope: fixture.rootEnvelope,
+      providerPeerPublicKey: fixture.peerSigner.publicKey,
+      admission: admissionGate(),
+      transport,
+      receiver: activeOnlyReceiver,
+    });
+
+    await expect(reconciler.advance(new AbortController().signal)).resolves.toMatchObject({
+      status: 'paused',
+      phase: 'records',
+      pendingRows: 1,
+    });
+    const requestsAfterInventory = fetchExact.mock.calls.length;
+    await expect(reconciler.advance(new AbortController().signal)).resolves.toMatchObject({
+      status: 'blocked',
+      phase: 'records',
+      reason: 'unsupported-row-state',
+      pendingRows: 1,
+    });
+    expect(fetchExact).toHaveBeenCalledTimes(requestsAfterInventory);
+    expect(openPreparation).not.toHaveBeenCalled();
+    expect(prepareActive).not.toHaveBeenCalled();
+    expect(receiveActive).not.toHaveBeenCalled();
+    expect(reconciler.stats()).toMatchObject({
+      retainedClosureArtifacts: 0,
+      retainedSidecarArtifacts: 0,
+    });
+  });
+
   it('routes inventory and receiver closure fetches through one admitted transport slice', async () => {
     const fixture = await publishedFixture();
     const released: ReturnType<typeof vi.fn>[] = [];

--- a/packages/agent/test/system-record-reconcile-v1.test.ts
+++ b/packages/agent/test/system-record-reconcile-v1.test.ts
@@ -378,7 +378,7 @@ describe('agent-profile System Record reconciler V1', () => {
       .resolves.toMatchObject({
         status: 'blocked',
         phase: 'records',
-        reason: 'receiver-verification-failed',
+        reason: 'unsupported-row-state',
         processedRows: 0,
         pendingRows: 1,
       });


### PR DESCRIPTION
## Summary

- Preserve the advertised legacy artifact-repository contract when a structurally valid repository also carries a reserved split-source property.
- Restore the exported `unsupported-row-state` reconciliation outcome through an explicit direct/continuation row-support policy while keeping candidate-capable verification failures distinct.
- Add a security regression proving terminal transition evidence is rejected when a signed transition does not bind its exact accepted predecessor.

## Related

- Follow-up to #2228
- Structural decomposition remains tracked in #2216 and #2229

## Diagrams

### Artifact source selection

Before:

```mermaid
sequenceDiagram
    participant Caller
    participant Receiver
    participant Repository
    Caller->>Receiver: Legacy { resolve, closureArtifacts: cache }
    Receiver-->>Caller: Reject as incomplete split pair
```

After:

```mermaid
sequenceDiagram
    participant Caller
    participant Receiver
    participant Repository
    Caller->>Receiver: Legacy { resolve, closureArtifacts: cache }
    Receiver->>Repository: Bind resolve for both artifact domains
    Repository-->>Receiver: Exact artifacts
```

### Active-only unsupported row classification

Before:

```mermaid
sequenceDiagram
    participant Inventory
    participant Reconciler
    participant ActiveReceiver
    Inventory->>Reconciler: Tombstone or quarantine row
    Reconciler-->>Inventory: receiver-verification-failed
```

After:

```mermaid
sequenceDiagram
    participant Inventory
    participant Reconciler
    participant ActiveReceiver
    Inventory->>Reconciler: Tombstone or quarantine row
    Reconciler-->>Inventory: unsupported-row-state
```

## Files changed

| File | What |
|------|------|
| `packages/agent/src/system-records/receiver-v1.ts` | Classify artifact inputs through a named, documented repository-first boundary. |
| `packages/agent/src/system-records/reconcile-v1.ts` | Restore the stable unsupported-row reason through an explicit row-support policy. |
| `packages/agent/test/system-record-reconcile-v1.test.ts` | Prove active-only unsupported rows retain their distinct result. |
| `packages/agent/test/system-record-reconcile-transport-integration-v1.test.ts` | Prove the transport continuation blocks unsupported rows before preparation or artifact fetch. |
| `packages/agent/test/system-record-receiver-v1.test.ts` | Cover reserved legacy fields and invalid transition predecessors. |
| `packages/agent/test/support/agent-profile-receiver-conflict-v1-fixture.ts` | Produce a signed transition whose advertised predecessor cannot accept it. |

## Test plan

- [x] `pnpm -r --filter @origintrail-official/dkg-agent... --filter '!@origintrail-official/dkg-evm-module' run build`
- [x] `CI=1 pnpm --filter @origintrail-official/dkg-agent exec vitest run --reporter=dot test/system-record-receiver-v1.test.ts test/system-record-reconcile-v1.test.ts test/system-record-reconcile-transport-integration-v1.test.ts` (98/98)
- [x] `git diff --check`
- [x] Confirm generated localhost deployment output is excluded from the commit
