### PR TITLE
ci: run PR gates on integration/** branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
   push:
     branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
   pull_request:
-    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip, 'integration/**']
     types: [opened, synchronize, reopened, labeled, unlabeled]
   # When merge queue is enabled, this is the pre-merge full-CI safety net.
   # It validates the exact candidate that will land, without introducing a

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
   pull_request:
-    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip, 'integration/**']
     types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [main, testnet-canary, rc17-vm-wip]
   pull_request:
-    branches: [main, testnet-canary, rc17-vm-wip]
+    branches: [main, testnet-canary, rc17-vm-wip, 'integration/**']
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -26,7 +26,7 @@ name: Supply chain scan
 
 on:
   pull_request:
-    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip]
+    branches: [main, testnet-canary, release/rc.12, rc17-vm-wip, 'integration/**']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'


### PR DESCRIPTION
## Summary

PRs into long-lived `integration/**` branches were running only the workflows that carry no `pull_request.branches` filter. Everything gated by that filter — the sharded vitest lanes, EVM integration, Knip, and the supply-chain scan — never executed for them.

Concretely: **all seven PRs merged into `integration/2052-system-record-sync` landed without a single package test suite running in CI.** Their only checks were four path-filtered gates (SQLite lifecycle Windows, SPARQL scalability lint, managed Oxigraph ownership, protocol evidence).

This adds the `integration/**` glob to the `pull_request` filter in the four workflows that have one.

## Why this is not theoretical

A `workflow_dispatch` of `ci.yml` against `integration/2052-system-record-sync` — the first time these suites have ever run on that branch — immediately surfaced a real regression that the seven merged PRs had hidden: four tests failing across `e2e-network`, `e2e-agents`, and `agent.part-03` with `Update rejected: on-chain update requires precomputedUpdateAttestation`. The same lanes are green on `testnet-canary`. That regression is being triaged separately; it is the evidence for this change, not part of it.

Run: https://github.com/OriginTrail/dkg/actions/runs/31411355851

## Files changed

Four workflows, one line each — `ci.yml`, `evm-integration.yml`, `knip.yml`, `supply-chain-scan.yml`. The other seven workflow files have no branch filter and already cover the branch. All eleven re-parse as valid YAML.

## Deliberate scope decision

**Only `pull_request` filters are changed. `push` filters are left alone**, though three of these four also list branches on `push`. PR coverage is what gates a merge; adding post-merge push runs would re-run the whole suite for a signal we already have. Recorded in the commit message so it does not read as an oversight later.

## Two things reviewers should know

1. **This PR demonstrates its own fix.** For `pull_request` events GitHub evaluates the workflow definitions from the merge of head into base, so the new filter applies to this PR itself. It is running **26 checks** across all four modified workflows — `CI`, `EVM Integration Tests`, `Knip`, and `Supply chain scan` — where the seven PRs merged into this branch before it received four or five. That difference *is* the change working.

   (An earlier revision of this description claimed the opposite — that `pull_request` filters are read from the base branch, so the new lanes could not apply here. That was wrong, and the check list on this PR disproves it. Corrected rather than left standing.)
2. **The line flows into `testnet-canary` at final integration.** Whether to keep or drop it there is a decision for that merge, not this one.

## Test plan

- All 11 workflow files parsed as YAML after the edit.
- Trigger surface audited across every workflow: 4 carry a `pull_request.branches` filter excluding `integration/**` (changed here); 7 carry none (already covered).
- Effect is verifiable only after merge, by observing the check set on the next PR into an `integration/**` branch.
