### PR TITLE
fix(agent): do not route a local-only publish into an on-chain update

### DIFF
--- a/packages/agent/src/profile-manager.ts
+++ b/packages/agent/src/profile-manager.ts
@@ -104,7 +104,11 @@ export class ProfileManager {
       quads: quads.map((quad) => ({ ...quad })),
     };
 
-    const result = this.currentKcId !== null
+    // A publish that never reached chain mints no knowledge-asset id and
+    // reports `0n`, so a republish has nothing on chain to update. Gate the
+    // routing decision rather than the stored id: `profileKcId` must keep
+    // mirroring what the publisher returned.
+    const result = this.currentKcId !== null && this.currentKcId > 0n
       ? await this.publisher.update(this.currentKcId, options)
       : await this.publisher.publish(options);
     this.currentKcId = result.kaId;

--- a/packages/agent/test/profile-manager-republish-v1.test.ts
+++ b/packages/agent/test/profile-manager-republish-v1.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PublishOptions, PublishResult, Publisher } from '@origintrail-official/dkg-publisher';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+
+import { ProfileManager } from '../src/profile-manager.js';
+
+/**
+ * A local/no-chain publish carries no minted knowledge-asset id. The publisher
+ * reports that as `kaId: 0n` (see the `?? 0n` fallback in dkg-agent-publish),
+ * so a republish has nothing on-chain to update and must publish again.
+ */
+const LOCAL_ONLY_KA_ID = 0n;
+
+function publishResult(kaId: bigint): PublishResult {
+  return {
+    kaId,
+    ual: `did:dkg:ka:${kaId.toString()}`,
+    merkleRoot: new Uint8Array(32),
+    kaManifest: [],
+    status: 'tentative',
+  } as unknown as PublishResult;
+}
+
+function stubStore(): TripleStore {
+  return {
+    query: async () => ({ type: 'bindings', bindings: [] }),
+    deleteBySubjectPrefix: async () => undefined,
+  } as unknown as TripleStore;
+}
+
+/** Mirrors the real update guard, which rejects before validating the id. */
+function stubPublisher(mintedKaId: bigint) {
+  const publish = vi.fn(async (_options: PublishOptions) => publishResult(mintedKaId));
+  const update = vi.fn(async (_kaId: bigint, _options: PublishOptions) => {
+    throw new Error(
+      'Update rejected: on-chain update requires precomputedUpdateAttestation. ' +
+        'Sign UpdateAuthorAttestation(kaId, newMerkleRoot, authorAddress) off-band ' +
+        'and pass the seal in this call.',
+    );
+  });
+  return { publisher: { publish, update } as unknown as Publisher, publish, update };
+}
+
+describe('ProfileManager republish routing', () => {
+  it('republishes rather than updating when the first publish minted no on-chain id', async () => {
+    const { publisher, publish, update } = stubPublisher(LOCAL_ONLY_KA_ID);
+    const manager = new ProfileManager(publisher, stubStore());
+    const config = { peerId: 'QmLocalOnly', name: 'LocalBot', skills: [] };
+
+    await manager.publishProfile(config);
+    await manager.publishProfile(config);
+
+    // 0n is "no knowledge asset yet", not an id to update. Routing it to
+    // update() trips the attestation guard, and the publisher never validates
+    // the id at all, so the failure names the attestation and nothing ever
+    // mentions the zero id that caused it.
+    expect(update).not.toHaveBeenCalled();
+    expect(publish).toHaveBeenCalledTimes(2);
+    // Gate the routing decision, not the stored id: profileKcId still mirrors
+    // what the publisher returned. A fix that nulls the field instead would
+    // pass the routing assertions above and silently break this one.
+    expect(manager.profileKcId).toBe(LOCAL_ONLY_KA_ID);
+  });
+
+  it('updates on republish once a real on-chain id has been minted', async () => {
+    const { publisher, publish, update } = stubPublisher(7n);
+    const manager = new ProfileManager(publisher, stubStore());
+    const config = { peerId: 'QmMinted', name: 'MintedBot', skills: [] };
+
+    await manager.publishProfile(config);
+    expect(manager.profileKcId).toBe(7n);
+
+    await expect(manager.publishProfile(config)).rejects.toThrow(
+      /requires precomputedUpdateAttestation/,
+    );
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0]?.[0]).toBe(7n);
+  });
+});

--- a/packages/agent/test/profile-manager-republish-v1.test.ts
+++ b/packages/agent/test/profile-manager-republish-v1.test.ts
@@ -6,9 +6,11 @@ import type { TripleStore } from '@origintrail-official/dkg-storage';
 import { ProfileManager } from '../src/profile-manager.js';
 
 /**
- * A local/no-chain publish carries no minted knowledge-asset id. The publisher
- * reports that as `kaId: 0n` (see the `?? 0n` fallback in dkg-agent-publish),
- * so a republish has nothing on-chain to update and must publish again.
+ * A local/no-chain publish carries no minted knowledge-asset id, so a republish
+ * has nothing on chain to update and must publish again. Observed in the agent
+ * suite as "No positive on-chain context graph id resolved from 'agents' —
+ * skipping on-chain publish", then "Storing N triples in local store (no
+ * on-chain CG id)"; the resulting PublishResult carries `kaId: 0n`.
  */
 const LOCAL_ONLY_KA_ID = 0n;
 

--- a/packages/agent/test/profile-preparation-v1.test.ts
+++ b/packages/agent/test/profile-preparation-v1.test.ts
@@ -112,7 +112,15 @@ describe('prepared agent profile V1', () => {
     expect(publishedQuads).not.toBe(expected.publicationQuads);
   });
 
-  it('treats a zero-valued KA id as an existing publication on the next call', async () => {
+  // Inverted from 'treats a zero-valued KA id as an existing publication on the
+  // next call', which pinned update(0n) as the intended behaviour. That semantics
+  // is unreachable against the real publisher: ProfileManager supplies no
+  // precomputedUpdateAttestation, and DKGPublisher.update rejects without one
+  // before it inspects the id. The original passed only because this stub's
+  // update() resolves where the real one throws -- four agent e2e lanes failed on
+  // the real publisher with "Update rejected: on-chain update requires
+  // precomputedUpdateAttestation".
+  it('republishes when the prior publish minted no KA id, because zero is not an id', async () => {
     const publisher = {
       publish: vi.fn(async () => publishResult(0n)),
       update: vi.fn(async () => publishResult(1n)),
@@ -129,8 +137,8 @@ describe('prepared agent profile V1', () => {
 
     await manager.publishProfile(config);
     await manager.publishProfile(config);
-    expect(publisher.publish).toHaveBeenCalledTimes(1);
-    expect(publisher.update).toHaveBeenCalledWith(0n, expect.anything());
+    expect(publisher.publish).toHaveBeenCalledTimes(2);
+    expect(publisher.update).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
       "test/system-record-reconcile-transport-v1.test.ts",
       "test/system-record-reconcile-transport-integration-v1.test.ts",
       "test/system-record-reconcile-closure-continuation-v1.test.ts",
+      "test/profile-manager-republish-v1.test.ts",
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",
       "test/swm-fanout-peer-selection.test.ts",


### PR DESCRIPTION
# fix(agent): treat a local-only publish as having no knowledge-asset id

Fixes the four ProfileManager republish failures on `integration/2052-system-record-sync`
(CI run 31411355851). Not related to D5b — this is a pre-existing regression on the
integration head, fixed on its own branch so the D5b PR does not inherit it.

**Introduced by `d7e7b08f5` ("feat(agent): add bounded profile record provider").**

## Symptom

Four failures, one root cause:

```
Update rejected: on-chain update requires precomputedUpdateAttestation.
```

in `e2e-network` (1/178), `e2e-agents` (1/469), and `agent.part-03` (2/454).
`testnet-canary` ran the same lanes green 35 minutes earlier, and
`packages/agent/src/profile-manager.ts` was modified only on the integration side.

## Root cause

A publish that never reaches chain mints no knowledge-asset id and reports `kaId: 0n`.
This is established by experiment, not by reading. The publisher says so itself in the run log:

```
[DKGPublisher] No positive on-chain context graph id resolved from "agents" - skipping on-chain publish [WARN]
[DKGPublisher] Storing 10 triples in local store (no on-chain CG id)
```

The agent-registry context graph has no on-chain id in these tests, so the publish never reaches
chain and the result carries `kaId: 0n`. Instrumenting the assignment site at `42db47007` confirms
the value and its runtime type directly - five calls, `kaId=0 typeof=bigint` every time, so the
declared `bigint` is honest and this is not an `undefined` masquerading as a falsy id.

The branch-point A/B closes the attribution: the affected tests pass 5/5 at `5d5919767` (old
truthiness guard) and fail 2 at `42db47007` with the exact CI errors. Pass-then-fail.

`ProfileManager` stored that value verbatim, and `d7e7b08f5` changed the republish guard
from a truthiness test to an explicit null check:

```diff
-    if (this.currentKcId) {
-      const result = await this.publisher.update(this.currentKcId, options);
+    const result = this.currentKcId !== null
+      ? await this.publisher.update(this.currentKcId, options)
+      : await this.publisher.publish(options);
```

Over `bigint | null` those two forms diverge at exactly one value: `0n`. The truthiness
form treated it as "no asset yet" and republished, which is correct because nothing
exists on chain to update. The null check routes it into `update()`.

## Why the error names the wrong thing

The failing call site is the publisher's `update()`, `packages/publisher/src/dkg-publisher.ts:5124`,
which rejects a missing `precomputedUpdateAttestation` before doing anything else — and that
file **never validates the id at all**. So a zero id produces an attestation failure and no
diagnostic anywhere mentions the id that caused it.

(The agent-side `update()` in `dkg-agent-publish.ts` does validate `kaId <= 0n`, but only
*after* its own attestation check at `:1955` — so that path mis-orders the checks rather than
omitting one. These tests do not use it.) Both shapes are filed as **#44**; this PR changes
neither.

## Fix

```ts
const result = this.currentKcId !== null && this.currentKcId > 0n
  ? await this.publisher.update(this.currentKcId, options)
  : await this.publisher.publish(options);
this.currentKcId = result.kaId;   // unchanged
```

Gate the routing decision, not the stored value. An earlier draft normalized the stored id to
`null` instead; that fixes the routing but breaks `publishes a profile as a KC via the
Publisher`, which asserts `manager.profileKcId === result.kaId` (`agent.part-03.test.ts:43`).
`currentKcId` mirroring the publisher's result is an existing contract with a test on it, so
the fix belongs in routing — which is where the defect is — rather than in storage, which was
never wrong. The explicit null check is kept.

## Scope: this changes nothing on real chains

`ProfileManager` never passes `precomputedUpdateAttestation` — its options are
`{ contextGraphId, quads }` and nothing else. So **every** `update()` call it makes throws,
for any id, and that was equally true under the old truthiness guard (`profile-manager.ts:104`
at the merge base also called `update()` whenever the id was truthy).

Republish against a real minted id has therefore always required an off-band attestation,
which the error text describes as deliberate design. This PR restores the `0n` behaviour and
changes nothing about that path. The second regression test pins it explicitly rather than
leaving it implicit, so the pre-existing requirement is documented rather than rediscovered
as a hole this fix "left open". Out of scope here.

## Tests

`packages/agent/test/profile-manager-republish-v1.test.ts`, registered in the fast unit lane.
No Hardhat, no chain, no global setup — a stub publisher and a stub store implementing only
the two methods `publishProfile` touches. Runs in ~9ms.

- **`republishes rather than updating when the first publish minted no on-chain id`** —
  fails on the unfixed code with the exact CI error string, stack at `profile-manager.ts:108`;
  passes after.
- **`updates on republish once a real on-chain id has been minted`** — publishes with `7n`
  and asserts the republish *does* route to `update()` with that id. Without this case the
  first would pass against a version that simply never updates, which would be a worse bug.
  It also pins the pre-existing real-chain behaviour described below, by assertion rather
  than by prose.

The first case asserts the routing **and** `profileKcId === result.kaId` together. That
second assertion is what discriminates between the two candidate fix shapes: verified by
re-applying the rejected normalize-at-assignment shape, which turns it red with
`expected null to be 0n`. A routing-only test passes under both and would let the invariant
break silently.

Verified against three distinct states, not just "before and after":

| State of `profile-manager.ts` | Regression test |
| --- | --- |
| The shipped broken shape — bare `this.currentKcId !== null` as at `42db47007` | **red**, with the exact CI error string, stack at the `update()` call |
| The rejected alternative fix — normalize the stored id to `null` | **red** on `expected null to be 0n`, i.e. the invariant assertion |
| This fix | green |

The middle row is the point: the test discriminates between the two candidate fixes rather
than merely detecting the absence of one. In both red cases the companion `7n` test still
passes, so the failures are specific rather than blanket.

Also green on this commit: `turbo build` 9/9 exit 0; the fast unit lane 2/2; and the full
`ProfileManager` block in `agent.part-03.test.ts` (Hardhat-backed) 5/5, run independently in
two separate worktrees.


## The defect was intended, and the intent cannot work

`d7e7b08f5` did not only change the guard — in the same commit it added a test asserting the
new behaviour was correct (`profile-preparation-v1.test.ts`):

```js
it('treats a zero-valued KA id as an existing publication on the next call', ...)
  expect(publisher.publish).toHaveBeenCalledTimes(1);
  expect(publisher.update).toHaveBeenCalledWith(0n, expect.anything());
```

So this is a deliberate semantics change, not a slip — which is the strongest evidence for the
attribution above.

The intent cannot hold. `ProfileManager` supplies no `precomputedUpdateAttestation`, and
`DKGPublisher.update` rejects a missing one **before** it inspects the id, so `update(0n, …)`
always throws against the real publisher. That test passed only because its stub's `update()`
resolves where the real one throws — and four agent e2e lanes failed on the real publisher with
exactly that rejection.

This PR **inverts** that test rather than deleting it: same fixtures, same stub, asserting the
corrected semantics, with the reason recorded in place so the next reader finds an explanation
rather than an unexplained deletion.

### Why this test was overturned and a different colliding test was not

This fix collided with two existing tests and treated them oppositely. That looks inconsistent
in a diff, so here is the rule, and it is mechanically checkable rather than a judgement call:
**a test that predates the defect is a contract; a test that arrived with the defect never
described intended behaviour.**

```
git log --diff-filter=A --oneline -- packages/agent/test/profile-preparation-v1.test.ts
  d7e7b08f5 feat(agent): add bounded profile record provider     <- the defect commit itself

git log --diff-filter=A --oneline -- packages/agent/test/agent.part-03.test.ts
  9f39c1cc4 test(agent): split agent test suite (#1030)
git merge-base --is-ancestor 9f39c1cc4 d7e7b08f5   ->  true      <- predates the defect
```

- `profileKcId === result.kaId` (`agent.part-03.test.ts:43`) **predates** the defect. It is a
  real contract, so when the first attempted fix broke it, the **fix** was wrong and was
  changed — that is why this PR gates the routing decision instead of normalising the stored id.
- `expect(update).toHaveBeenCalledWith(0n, …)` **arrived in the same commit as the defect**. It
  is a characterization test written from observed behaviour, not intended behaviour, so the
  **test** is wrong and is overturned here.

The provenance is the justification. Without it, "the fix contradicts a test, so change the
test" is the shape that lets a fix bulldoze a genuine contract — which is exactly what the
first row prevented.

### How this survived seven merged PRs

Both of the defect's detectors were neutralised at once. `agent.part-03.test.ts` would have
caught it, but `ci.yml` did not run on `integration/**` branches until #2232, so it never
executed on any of the stack's PRs. `profile-preparation-v1.test.ts` did run — and asserted the
defect was correct. One detector was silenced and the other was inverted at birth, so the
routing change merged behind a green board seven times.

## Validation set was derived, not recalled

Three earlier validation rounds (two of mine, one QA's) each named "the affected file" from
memory and all three missed `profile-preparation-v1.test.ts`. The set below is the output of a
query, so it cannot omit a consumer by forgetting one:

```
git grep -l 'publishProfile\|currentKcId\|prepareAgentProfileV1\|profileKcId' -- 'packages/agent/test/'
```

All 9 resulting test files run green: 2 via the unit allow-list (14 tests) and 7 via the default
config (86 tests), 100 tests total.

One trap worth naming, because it bit this very run: `vitest.unit.config.ts` is an explicit
allow-list and CLI file arguments **silently intersect** with it. Passing all 9 files to that
config ran only 2 — including dropping `profile-preparation-v1.test.ts`, the one file this PR
changes. A green result there would have meant nothing. The non-allow-listed files must go
through the default config.

## Notes for review

- `d7e7b08f5` introduced both this guard change **and** the `prepareAgentProfileV1` +
  shallow-copy change, so a commit-level bisect cannot distinguish the two candidate
  mechanisms. The attribution above rests on the mechanism argument plus the A/B, not on a
  bisect.
- A canonicalisation change cannot produce this error: it would have to get past a guard
  `ProfileManager` can never satisfy, and would surface as a merkle-root mismatch instead.
- Build must go through turbo. A bare `pnpm --filter` build races the dependency graph and
  emits spurious `TS2307 Cannot find module` errors — an invocation artifact, not a finding.
