### PR TITLE
fix(core): carry the verified fork-resolution identity on the authority summary

### DIFF
--- a/packages/core/src/system-record-objects-v1.ts
+++ b/packages/core/src/system-record-objects-v1.ts
@@ -121,6 +121,7 @@ export type { AgentProfileAppliedTransitionV1 } from './system-record-authority-
 export {
   assertAgentProfileVerifiedAuthoritySummaryV1,
   type AgentProfileVerifiedAuthoritySummaryV1,
+  type AgentProfileVerifiedForkResolutionFactsV1,
 } from './system-record-verification-closure-v1-internal.js';
 
 export {

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -50,6 +50,29 @@ const MINT_AGENT_PROFILE_VERIFIED_AUTHORITY_SUMMARY_V1 = Symbol(
 );
 const MINTED_AGENT_PROFILE_VERIFIED_AUTHORITY_SUMMARIES_V1 = new WeakSet<object>();
 
+/**
+ * Identity of the fork this candidate resolves, as verified by the closure.
+ *
+ * Present only when the closure actually ran the direct-successor check for the
+ * current head. Consumers hold local state the closure cannot see -- a recorded
+ * quarantine -- and need these to decide whether the resolution adjudicates
+ * *their* fork rather than some other fork of the same peer. `forkedVersion`
+ * plus `authoritySequence` name the fork event; `forkBaseHeadDigest` names the
+ * common base, which is what distinguishes two fork events that share a
+ * sequence and version but descend from different predecessors.
+ *
+ * Deliberately carries no evidence-head list: the plan makes that list a
+ * verified subset rather than a completeness claim, so a consumer must not
+ * reject a resolution for omitting a conflict it happens to know about.
+ */
+export interface AgentProfileVerifiedForkResolutionFactsV1 {
+  readonly resolutionDigest: Digest32V1;
+  readonly authoritySequence: string;
+  readonly forkedVersion: string;
+  readonly resolutionVersion: string;
+  readonly forkBaseHeadDigest?: Digest32V1;
+}
+
 class AgentProfileVerifiedAuthoritySummaryValueV1 {
   declare private readonly __opaqueAgentProfileVerifiedAuthoritySummaryV1: void;
 
@@ -61,6 +84,7 @@ class AgentProfileVerifiedAuthoritySummaryValueV1 {
     public readonly lastAuthorityTransitionPriorHeadDigest?: Digest32V1,
     public readonly tombstonePredecessor?: AgentProfileActiveHeadObjectV1,
     public readonly deletionTableDigest?: Digest32V1,
+    public readonly forkResolution?: AgentProfileVerifiedForkResolutionFactsV1,
   ) {
     if (token !== MINT_AGENT_PROFILE_VERIFIED_AUTHORITY_SUMMARY_V1) {
       fail('system-record-closure', 'verified authority summary is factory-only');
@@ -104,6 +128,7 @@ function mintAgentProfileVerifiedAuthoritySummaryV1(
     lastAuthorityTransitionPriorHeadDigest?: Digest32V1;
     tombstonePredecessor?: AgentProfileActiveHeadObjectV1;
     deletionTableDigest?: Digest32V1;
+    forkResolution?: AgentProfileVerifiedForkResolutionFactsV1;
   }>,
 ): AgentProfileVerifiedAuthoritySummaryV1 {
   return new AgentProfileVerifiedAuthoritySummaryValueV1(
@@ -114,6 +139,7 @@ function mintAgentProfileVerifiedAuthoritySummaryV1(
     input.lastAuthorityTransitionPriorHeadDigest,
     input.tombstonePredecessor,
     input.deletionTableDigest,
+    input.forkResolution,
   );
 }
 
@@ -635,6 +661,37 @@ function createVerifiedAuthoritySummaryV1(
     tombstonePredecessor:
       tombstonePredecessor?.state === 'active' ? tombstonePredecessor : undefined,
     deletionTableDigest: tombstonePredecessor?.ownedSubjectTableDigest,
+    forkResolution: verifiedForkResolutionFactsV1(state, current),
+  });
+}
+
+/**
+ * Only mint these facts on the path that already proved direct succession.
+ *
+ * A head carrying a resolution digest has been through `isDirectResolvingSuccessorV1`
+ * above, so reaching here without the resolution object means the traversal
+ * diverged from that check and the summary must not claim a verified resolution.
+ * Failing closed keeps a consumer from ever seeing a head whose
+ * `forkResolutionDigest` is set while the summary is silent about it.
+ */
+function verifiedForkResolutionFactsV1(
+  state: CollectedClosureV1,
+  current: AgentProfileHeadObjectV1,
+): AgentProfileVerifiedForkResolutionFactsV1 | undefined {
+  if (current.forkResolutionDigest === undefined) return undefined;
+  const resolution = state.parsedResolutions.find((candidate) =>
+    computeAgentProfileForkResolutionDigestV1(candidate) === current.forkResolutionDigest);
+  if (resolution === undefined) {
+    fail('system-record-closure', 'verified closure lost its current fork resolution');
+  }
+  return Object.freeze({
+    resolutionDigest: current.forkResolutionDigest,
+    authoritySequence: resolution.authoritySequence,
+    forkedVersion: resolution.forkedVersion,
+    resolutionVersion: resolution.resolutionVersion,
+    ...(resolution.forkBaseHeadDigest === undefined
+      ? {}
+      : { forkBaseHeadDigest: resolution.forkBaseHeadDigest }),
   });
 }
 

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -458,10 +458,17 @@ async function collectVerificationClosureV1(
  * the only way to obtain this value is to return from the validator.
  *
  * It carries the verified FACTS rather than the resolution they came from, so
- * projection cannot reach the rest of the control object. That matters beyond
+ * the summary is built without naming the control object. That matters beyond
  * tidiness: the raw resolution carries `evidenceHeadDigests`, a verified subset
- * that no consumer may treat as a completeness claim, and this boundary makes
- * it structurally unreachable from the summary rather than merely unused.
+ * no consumer may treat as a completeness claim, and the mint site now has no
+ * expression for it.
+ *
+ * Not an inaccessibility claim -- `collected` is right here, and its
+ * `parsedResolutions` with it. The property is narrower and worth stating
+ * exactly, because a reader who finds that field after being told otherwise
+ * will reasonably conclude the comment lied and reopen a settled question: the
+ * summary reads only `currentForkResolutionFacts`, and the helper that builds
+ * those facts takes only a resolution, so neither can express the mistake.
  */
 interface ValidatedClosureV1 {
   readonly collected: CollectedClosureV1;

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -1,5 +1,9 @@
 import { snapshotExactDataRecord } from './sync-wire-objects.js';
-import { parseCanonicalDecimalU64, type Digest32V1 } from './sync-wire-scalars.js';
+import {
+  parseCanonicalDecimalU64,
+  type DecimalU64V1,
+  type Digest32V1,
+} from './sync-wire-scalars.js';
 import {
   copyBoundedSystemRecordBytesV1,
   failSystemRecordObjectV1 as fail,
@@ -67,9 +71,9 @@ const MINTED_AGENT_PROFILE_VERIFIED_AUTHORITY_SUMMARIES_V1 = new WeakSet<object>
  */
 export interface AgentProfileVerifiedForkResolutionFactsV1 {
   readonly resolutionDigest: Digest32V1;
-  readonly authoritySequence: string;
-  readonly forkedVersion: string;
-  readonly resolutionVersion: string;
+  readonly authoritySequence: DecimalU64V1;
+  readonly forkedVersion: DecimalU64V1;
+  readonly resolutionVersion: DecimalU64V1;
   readonly forkBaseHeadDigest?: Digest32V1;
 }
 
@@ -457,6 +461,14 @@ async function collectVerificationClosureV1(
  * run" is not a third case to guard against -- it is unrepresentable, because
  * the only way to obtain this value is to return from the validator.
  *
+ * The brand is what makes "only the validator produces this" a fact about the
+ * type rather than a convention about this file. Without it a new function here
+ * could write `{ collected }` and typecheck, and the guarantee the summary rests
+ * on would hold only for as long as nobody did. A deliberate cast still defeats
+ * it -- that is the intended strength: this value never leaves the module, so
+ * the risk is an honest mistake during a refactor, not a forgery, and a cast is
+ * visible in review where a plain literal is not.
+ *
  * It carries the verified FACTS rather than the resolution they came from, so
  * the summary is built without naming the control object. That matters beyond
  * tidiness: the raw resolution carries `evidenceHeadDigests`, a verified subset
@@ -470,7 +482,10 @@ async function collectVerificationClosureV1(
  * summary reads only `currentForkResolutionFacts`, and the helper that builds
  * those facts takes only a resolution, so neither can express the mistake.
  */
+declare const VALIDATED_CLOSURE_V1_BRAND: unique symbol;
+
 interface ValidatedClosureV1 {
+  readonly [VALIDATED_CLOSURE_V1_BRAND]: true;
   readonly collected: CollectedClosureV1;
   readonly currentForkResolutionFacts?: AgentProfileVerifiedForkResolutionFactsV1;
 }
@@ -583,10 +598,11 @@ function validateCollectedClosureAuthorityV1(
     }
   }
 
+  // The one sanctioned construction site, cast where the proof happens.
   return Object.freeze({
     collected: state,
     ...(currentForkResolutionFacts === undefined ? {} : { currentForkResolutionFacts }),
-  });
+  }) as ValidatedClosureV1;
 }
 
 function assertCompleteUniqueRootLineageV1(

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -453,15 +453,19 @@ async function collectVerificationClosureV1(
  * The closure after authority validation, carrying what validation actually
  * verified so projection cannot rediscover it.
  *
- * `currentForkResolution` is `null` when the current head advertises none --
- * which is a different fact from "validation did not run", and that second
- * state is unrepresentable here because the only way to obtain this value is to
- * return from the validator. Projection therefore cannot mint a resolution
- * nobody verified: it has no other source, rather than checking and refusing.
+ * Absent means the current head advertises no resolution. "Validation did not
+ * run" is not a third case to guard against -- it is unrepresentable, because
+ * the only way to obtain this value is to return from the validator.
+ *
+ * It carries the verified FACTS rather than the resolution they came from, so
+ * projection cannot reach the rest of the control object. That matters beyond
+ * tidiness: the raw resolution carries `evidenceHeadDigests`, a verified subset
+ * that no consumer may treat as a completeness claim, and this boundary makes
+ * it structurally unreachable from the summary rather than merely unused.
  */
 interface ValidatedClosureV1 {
   readonly collected: CollectedClosureV1;
-  readonly currentForkResolution: AgentProfileForkResolutionV1 | null;
+  readonly currentForkResolutionFacts?: AgentProfileVerifiedForkResolutionFactsV1;
 }
 
 function validateCollectedClosureAuthorityV1(
@@ -524,7 +528,7 @@ function validateCollectedClosureAuthorityV1(
     transitionTupleDigests.set(tuple, transitionDigest);
   }
 
-  let currentForkResolution: AgentProfileForkResolutionV1 | null = null;
+  let currentForkResolutionFacts: AgentProfileVerifiedForkResolutionFactsV1 | undefined;
   for (const [headDigest, head] of state.parsedHeads) {
     assertCompleteUniqueRootLineageV1(state, headDigest, head);
     if (head.acceptedTransitionDigest !== undefined) {
@@ -553,7 +557,7 @@ function validateCollectedClosureAuthorityV1(
           `head ${headDigest} does not directly bind its fork resolution`,
         );
       }
-      currentForkResolution = resolution;
+      currentForkResolutionFacts = verifiedForkResolutionFactsV1(resolution);
     }
   }
 
@@ -572,7 +576,10 @@ function validateCollectedClosureAuthorityV1(
     }
   }
 
-  return Object.freeze({ collected: state, currentForkResolution });
+  return Object.freeze({
+    collected: state,
+    ...(currentForkResolutionFacts === undefined ? {} : { currentForkResolutionFacts }),
+  });
 }
 
 function assertCompleteUniqueRootLineageV1(
@@ -682,19 +689,16 @@ function createVerifiedAuthoritySummaryV1(
     tombstonePredecessor:
       tombstonePredecessor?.state === 'active' ? tombstonePredecessor : undefined,
     deletionTableDigest: tombstonePredecessor?.ownedSubjectTableDigest,
-    forkResolution: validated.currentForkResolution === null
-      ? undefined
-      : verifiedForkResolutionFactsV1(validated.currentForkResolution),
+    forkResolution: validated.currentForkResolutionFacts,
   });
 }
 
 /**
- * Project the resolution validation already verified for this head.
+ * Mint the facts at the point of proof.
  *
- * No lookup here by design: the only way to reach this function is to hand it a
- * resolution that came back from `validateCollectedClosureAuthorityV1`, the site
- * that proved direct succession. A head advertising a resolution the traversal
- * never collected fails there, so no summary can be silent about one.
+ * Called only where `isDirectResolvingSuccessorV1` has just succeeded, so the
+ * verified subset is fixed where it is verified rather than re-derived later
+ * from an object that also carries unverified-by-this-check fields.
  */
 function verifiedForkResolutionFactsV1(
   resolution: AgentProfileForkResolutionV1,

--- a/packages/core/src/system-record-verification-closure-v1-internal.ts
+++ b/packages/core/src/system-record-verification-closure-v1-internal.ts
@@ -449,10 +449,25 @@ async function collectVerificationClosureV1(
   });
 }
 
+/**
+ * The closure after authority validation, carrying what validation actually
+ * verified so projection cannot rediscover it.
+ *
+ * `currentForkResolution` is `null` when the current head advertises none --
+ * which is a different fact from "validation did not run", and that second
+ * state is unrepresentable here because the only way to obtain this value is to
+ * return from the validator. Projection therefore cannot mint a resolution
+ * nobody verified: it has no other source, rather than checking and refusing.
+ */
+interface ValidatedClosureV1 {
+  readonly collected: CollectedClosureV1;
+  readonly currentForkResolution: AgentProfileForkResolutionV1 | null;
+}
+
 function validateCollectedClosureAuthorityV1(
   state: CollectedClosureV1,
   nowMs: number,
-): void {
+): ValidatedClosureV1 {
   for (const resolution of state.parsedResolutions) {
     const evidence = resolution.evidenceHeadDigests.map((headDigest) =>
       state.parsedHeads.get(headDigest),
@@ -509,6 +524,7 @@ function validateCollectedClosureAuthorityV1(
     transitionTupleDigests.set(tuple, transitionDigest);
   }
 
+  let currentForkResolution: AgentProfileForkResolutionV1 | null = null;
   for (const [headDigest, head] of state.parsedHeads) {
     assertCompleteUniqueRootLineageV1(state, headDigest, head);
     if (head.acceptedTransitionDigest !== undefined) {
@@ -537,6 +553,7 @@ function validateCollectedClosureAuthorityV1(
           `head ${headDigest} does not directly bind its fork resolution`,
         );
       }
+      currentForkResolution = resolution;
     }
   }
 
@@ -554,6 +571,8 @@ function validateCollectedClosureAuthorityV1(
       }
     }
   }
+
+  return Object.freeze({ collected: state, currentForkResolution });
 }
 
 function assertCompleteUniqueRootLineageV1(
@@ -596,9 +615,10 @@ function assertCompleteUniqueRootLineageV1(
 }
 
 function projectVerificationClosureV1(
-  state: CollectedClosureV1,
+  validated: ValidatedClosureV1,
 ): SystemRecordVerificationClosureV1 {
-  const authoritySummary = createVerifiedAuthoritySummaryV1(state);
+  const state = validated.collected;
+  const authoritySummary = createVerifiedAuthoritySummaryV1(validated);
   const objects = Object.freeze([...state.artifacts].sort(compareClosureObjects));
   return Object.freeze({
     objects,
@@ -610,8 +630,9 @@ function projectVerificationClosureV1(
 }
 
 function createVerifiedAuthoritySummaryV1(
-  state: CollectedClosureV1,
+  validated: ValidatedClosureV1,
 ): AgentProfileVerifiedAuthoritySummaryV1 {
+  const state = validated.collected;
   const current = state.parsedHeads.get(state.currentHeadDigest);
   if (current === undefined) {
     fail('system-record-closure', 'verified closure lost its current head');
@@ -661,31 +682,25 @@ function createVerifiedAuthoritySummaryV1(
     tombstonePredecessor:
       tombstonePredecessor?.state === 'active' ? tombstonePredecessor : undefined,
     deletionTableDigest: tombstonePredecessor?.ownedSubjectTableDigest,
-    forkResolution: verifiedForkResolutionFactsV1(state, current),
+    forkResolution: validated.currentForkResolution === null
+      ? undefined
+      : verifiedForkResolutionFactsV1(validated.currentForkResolution),
   });
 }
 
 /**
- * Only mint these facts on the path that already proved direct succession.
+ * Project the resolution validation already verified for this head.
  *
- * A head carrying a resolution digest has been through `isDirectResolvingSuccessorV1`
- * above, so reaching here without the resolution object means the traversal
- * diverged from that check and the summary must not claim a verified resolution.
- * Failing closed keeps a consumer from ever seeing a head whose
- * `forkResolutionDigest` is set while the summary is silent about it.
+ * No lookup here by design: the only way to reach this function is to hand it a
+ * resolution that came back from `validateCollectedClosureAuthorityV1`, the site
+ * that proved direct succession. A head advertising a resolution the traversal
+ * never collected fails there, so no summary can be silent about one.
  */
 function verifiedForkResolutionFactsV1(
-  state: CollectedClosureV1,
-  current: AgentProfileHeadObjectV1,
-): AgentProfileVerifiedForkResolutionFactsV1 | undefined {
-  if (current.forkResolutionDigest === undefined) return undefined;
-  const resolution = state.parsedResolutions.find((candidate) =>
-    computeAgentProfileForkResolutionDigestV1(candidate) === current.forkResolutionDigest);
-  if (resolution === undefined) {
-    fail('system-record-closure', 'verified closure lost its current fork resolution');
-  }
+  resolution: AgentProfileForkResolutionV1,
+): AgentProfileVerifiedForkResolutionFactsV1 {
   return Object.freeze({
-    resolutionDigest: current.forkResolutionDigest,
+    resolutionDigest: computeAgentProfileForkResolutionDigestV1(resolution),
     authoritySequence: resolution.authoritySequence,
     forkedVersion: resolution.forkedVersion,
     resolutionVersion: resolution.resolutionVersion,
@@ -744,8 +759,9 @@ async function buildAgentProfileVerificationClosureForPurposeV1(
     currentHeadDigest,
     collection,
   );
-  validateCollectedClosureAuthorityV1(collected, nowMs);
-  return projectVerificationClosureV1(collected);
+  return projectVerificationClosureV1(
+    validateCollectedClosureAuthorityV1(collected, nowMs),
+  );
 }
 
 function createMaterializationClosureExecutionV1(

--- a/packages/core/test/system-record-limits-v1.test.ts
+++ b/packages/core/test/system-record-limits-v1.test.ts
@@ -67,4 +67,12 @@ describe('frozen system-record V1 limits', () => {
     expect(limits.SYSTEM_RECORD_MAX_CACHE_LIVE_METADATA_BYTES).toBe(32 * 1024 * 1024);
     expect(limits.SYSTEM_RECORD_MAX_CACHE_RESERVE_METADATA_BYTES).toBe(32 * 1024 * 1024);
   });
+
+  it('pins the owned-subject, conflict-slot, and sidecar-envelope ceilings', () => {
+    expect(limits.SYSTEM_RECORD_MAX_OWNED_SUBJECTS).toBe(2_048);
+    expect(limits.SYSTEM_RECORD_MAX_CONFLICT_DIGESTS).toBe(16);
+    expect(limits.SYSTEM_RECORD_MAX_CONFLICT_ENTRIES).toBe(8);
+    expect(limits.SYSTEM_RECORD_MAX_SIDECAR_OBJECTS).toBe(17);
+    expect(limits.SYSTEM_RECORD_MAX_SIDECAR_BYTES).toBe(1_064_960);
+  });
 });

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -1960,6 +1960,100 @@ describe('system-record owned subjects and verification closure', () => {
     await expect(buildClosure(current, artifacts)).rejects.toThrow(/reuses a historical wallet root/);
   });
 
+  // A consumer comparing the summary against a recorded quarantine matches the
+  // resolution's authority sequence against its own applied lineage length. That
+  // equality is an inference from how the closure walks the lineage, not a
+  // declared invariant, so pin it directly -- if it ever goes off by one, the
+  // consumer's fork-resolution gate silently never fires. Two sequences, because
+  // a sequence-zero case alone is satisfied by a constant as well as by the
+  // real derivation.
+  it('mints a resolution authority sequence equal to the lineage length', async () => {
+    const genesis = await genesisForkResolutionCase();
+    const genesisSummary = (await buildClosure(genesis.successor, genesis.artifacts)).authoritySummary;
+    expect(genesisSummary.transitionLineage).toHaveLength(0);
+    expect(genesisSummary.forkResolution).toEqual({
+      resolutionDigest: computeAgentProfileForkResolutionDigestV1(genesis.resolution),
+      authoritySequence: '0',
+      forkedVersion: '0',
+      resolutionVersion: '2',
+    });
+    expect(genesisSummary.forkResolution?.authoritySequence)
+      .toBe(String(genesisSummary.transitionLineage.length));
+
+    const rotated = await rotatedForkResolutionCase();
+    const rotatedSummary = (await buildClosure(rotated.successor, rotated.artifacts)).authoritySummary;
+    expect(rotatedSummary.transitionLineage).toHaveLength(2);
+    expect(rotatedSummary.forkResolution).toEqual({
+      resolutionDigest: computeAgentProfileForkResolutionDigestV1(rotated.resolution),
+      authoritySequence: '2',
+      forkedVersion: '1',
+      resolutionVersion: '3',
+      forkBaseHeadDigest: computeAgentProfileHeadObjectDigestV1(rotated.base),
+    });
+    expect(rotatedSummary.forkResolution?.authoritySequence)
+      .toBe(String(rotatedSummary.transitionLineage.length));
+  });
+
+  it('mints no fork-resolution facts for a head that advertises no resolution', async () => {
+    const fixture = await authorityFixture();
+    const current = { ...activeHead(fixture), bundleDigest: CLOSURE_BUNDLE_DIGEST };
+    expect(current.forkResolutionDigest).toBeUndefined();
+    const closure = await buildClosure(current, closureArtifacts(current, [], []));
+    expect(closure.authoritySummary.forkResolution).toBeUndefined();
+  });
+
+  // The summary's fork-resolution minting fails closed when a head advertises a
+  // resolution the traversal did not collect. That branch has no removal test
+  // because it is unreachable through either entry point, and the reason is a
+  // precondition worth pinning instead: the traversal enqueues the current
+  // head's advertised resolution whatever the root purpose, so an uncollected
+  // resolution is already a closure failure. If this goes red the branch has
+  // become reachable and owes a removal test of its own.
+  it('always collects the resolution its current head advertises, or fails closed', async () => {
+    const rotated = await rotatedForkResolutionCase();
+    const requestedKinds: string[] = [];
+    const closure = await buildAgentProfileVerificationClosureV1(
+      computeAgentProfileHeadObjectDigestV1(rotated.successor),
+      {
+        nowMs: Date.parse('2026-08-08T00:00:00Z'),
+        resolve: async (reference) => {
+          requestedKinds.push(reference.objectKind);
+          return rotated.artifacts.get(`${reference.objectKind}:${reference.digest}`);
+        },
+        verifyAuthorityEnvelope: () => true,
+        verifyCurrentBundle: (_head, bytes) => Buffer.from(bytes).equals(Buffer.from(CLOSURE_BUNDLE)),
+      },
+    );
+    expect(requestedKinds).toContain('fork-resolution');
+    expect(closure.authoritySummary.forkResolution).toBeDefined();
+
+    const withheld = new Map(rotated.artifacts);
+    withheld.delete(
+      `fork-resolution:${computeAgentProfileForkResolutionDigestV1(rotated.resolution)}`,
+    );
+    await expect(buildClosure(rotated.successor, withheld)).rejects.toThrow(/missing/);
+  });
+
+  // The authority-only traversal is the path most likely to mint a summary
+  // without the resolution facts, so demonstrate rather than assume that it
+  // mints the same ones.
+  it('mints identical fork-resolution facts through the authority-only closure', async () => {
+    const rotated = await rotatedForkResolutionCase();
+    const materialization = await buildClosure(rotated.successor, rotated.artifacts);
+    const authorityOnly = await buildAgentProfileForkEvidenceAuthorityClosureV1(
+      computeAgentProfileHeadObjectDigestV1(rotated.successor),
+      {
+        nowMs: Date.parse('2026-08-08T00:00:00Z'),
+        resolve: async (reference) =>
+          rotated.artifacts.get(`${reference.objectKind}:${reference.digest}`),
+        verifyAuthorityEnvelope: () => true,
+      },
+    );
+    expect(materialization.authoritySummary.forkResolution).toBeDefined();
+    expect(authorityOnly.authoritySummary.forkResolution)
+      .toEqual(materialization.authoritySummary.forkResolution);
+  });
+
   it('pins the authority/fork closure edge equations', () => {
     expect(assertSystemRecordClosureAlgebraV1(14n, 'active')).toBe(30);
     expect(assertSystemRecordClosureAlgebraV1(14n, 'tombstone')).toBe(31);
@@ -2215,6 +2309,75 @@ function forkResolution(
     resolutionVersion: '2', evidenceHeadDigests,
     issuedAt: '2026-08-05T12:05:00Z',
   };
+}
+
+/** Version-zero fork: no common base, so the successor descends from nothing. */
+async function genesisForkResolutionCase() {
+  const fixture = await authorityFixture();
+  const initial = activeHead(fixture);
+  const conflicting = { ...initial, bundleDigest: DIGEST_C };
+  const resolution = forkResolution(fixture, initial, [initial, conflicting]);
+  const successor = {
+    ...initial,
+    version: '3' as const,
+    forkResolutionDigest: computeAgentProfileForkResolutionDigestV1(resolution),
+    bundleDigest: CLOSURE_BUNDLE_DIGEST,
+  };
+  return {
+    resolution,
+    successor,
+    artifacts: closureArtifacts(successor, [initial, conflicting], [], [resolution]),
+  } as const;
+}
+
+/**
+ * Rotated authority forking above version zero, so the resolution names a base.
+ * Authority sequence, forked version, resolution version and successor version
+ * are deliberately four distinct numbers, so an assertion over the minted facts
+ * cannot pass while two of the fields are transposed.
+ */
+async function rotatedForkResolutionCase() {
+  const secondIssuer = '0x5555555555555555555555555555555555555555';
+  const thirdIssuer = '0x6666666666666666666666666666666666666666';
+  const fixture = await authorityFixture();
+  const initial = activeHead(fixture);
+  const firstTransition = authorityTransition(fixture, initial);
+  const middle = activeForIssuer(initial, secondIssuer, '1', '0', {
+    acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(firstTransition),
+  });
+  const secondTransition = transitionFrom(fixture, middle, '2', thirdIssuer);
+  const base = activeForIssuer(middle, thirdIssuer, '2', '0', {
+    acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(secondTransition),
+  });
+  const baseDigest = computeAgentProfileHeadObjectDigestV1(base);
+  const left = { ...base, version: '1' as const, previousHeadDigest: baseDigest };
+  const right = { ...left, bundleDigest: DIGEST_C };
+  const resolution: AgentProfileForkResolutionV1 = {
+    objectType: 'fork-resolution', kind: 'agents', networkId: NETWORK,
+    peerId: fixture.peerId, peerPublicKey: fixture.peerPublicKey,
+    evmIssuer: thirdIssuer, authoritySequence: '2',
+    forkedVersion: '1', resolutionVersion: '3', forkBaseHeadDigest: baseDigest,
+    evidenceHeadDigests: [left, right].map(computeAgentProfileHeadObjectDigestV1).sort(),
+    issuedAt: '2026-08-07T12:05:00Z',
+  };
+  const successor = {
+    ...base,
+    version: '4' as const,
+    previousHeadDigest: baseDigest,
+    forkResolutionDigest: computeAgentProfileForkResolutionDigestV1(resolution),
+    bundleDigest: CLOSURE_BUNDLE_DIGEST,
+  };
+  return {
+    base,
+    resolution,
+    successor,
+    artifacts: closureArtifacts(
+      successor,
+      [base, left, right, middle, initial],
+      [secondTransition, firstTransition],
+      [resolution],
+    ),
+  } as const;
 }
 
 function signEip191(message: Uint8Array, privateKey: Uint8Array): string {

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -38,6 +38,7 @@ import {
   evaluateAuthorityTransitionV1,
   evaluateAuthorityTransitionAgainstAcceptedStateV1,
   evaluateAgentProfileHeadAdvanceV1,
+  isDirectResolvingSuccessorV1,
   preflightSystemRecordCacheAccountingV1,
   recoverEip191SignerV1,
   parseCanonicalAgentProfileAuthorityTransitionV1,
@@ -2054,6 +2055,31 @@ describe('system-record owned subjects and verification closure', () => {
       .toEqual(materialization.authoritySummary.forkResolution);
   });
 
+  // The direct-successor predicate never inspects `state`, and
+  // `forkResolutionDigest` lives on the common head shape, so on those two facts
+  // alone a tombstone looks like it could be summarized as a resolving successor
+  // -- while the authority decision path rejects the same candidate for not
+  // being active. It cannot, and this is the reason: the head codec refuses the
+  // input shape outright, so such a head never parses, never enters a closure,
+  // and never reaches the minting site. That refusal is what makes the state
+  // check redundant at every later layer; if it ever goes, they stop being
+  // redundant and the minting site needs its own gate.
+  it('refuses a tombstone that advertises a fork resolution', async () => {
+    const rotated = await rotatedForkResolutionCase();
+    const terminal = {
+      ...tombstoneHead(rotated.base),
+      version: '4' as const,
+      previousHeadDigest: computeAgentProfileHeadObjectDigestV1(rotated.base),
+      forkResolutionDigest: computeAgentProfileForkResolutionDigestV1(rotated.resolution),
+    };
+    expect(() => computeAgentProfileHeadObjectDigestV1(terminal as AgentProfileHeadObjectV1))
+      .toThrow(/no direct terminal fork-resolution tombstone/);
+    expect(() => isDirectResolvingSuccessorV1(
+      terminal as AgentProfileHeadObjectV1,
+      rotated.resolution,
+    )).toThrow(/no direct terminal fork-resolution tombstone/);
+  });
+
   it('pins the authority/fork closure edge equations', () => {
     expect(assertSystemRecordClosureAlgebraV1(14n, 'active')).toBe(30);
     expect(assertSystemRecordClosureAlgebraV1(14n, 'tombstone')).toBe(31);
@@ -2369,6 +2395,12 @@ async function rotatedForkResolutionCase() {
   };
   return {
     base,
+    left,
+    right,
+    middle,
+    initial,
+    firstTransition,
+    secondTransition,
     resolution,
     successor,
     artifacts: closureArtifacts(

--- a/packages/core/test/system-record-package-export-v1.types.ts
+++ b/packages/core/test/system-record-package-export-v1.types.ts
@@ -139,7 +139,9 @@ void rowTraversalSubpathContract;
 type ForkResolutionScalarsAreStrings =
   AgentProfileVerifiedForkResolutionFactsV1['forkedVersion'] extends string
     ? AgentProfileVerifiedForkResolutionFactsV1['authoritySequence'] extends string
-      ? true
+      ? AgentProfileVerifiedForkResolutionFactsV1['resolutionVersion'] extends string
+        ? true
+        : never
       : never
     : never;
 const forkResolutionScalarsAreStrings: ForkResolutionScalarsAreStrings = true;

--- a/packages/core/test/system-record-package-export-v1.types.ts
+++ b/packages/core/test/system-record-package-export-v1.types.ts
@@ -22,6 +22,7 @@ import type {
   AgentProfileTombstoneHeadObjectV1,
   AgentProfileTransitionConflictEntryV1,
   AgentProfileVerifiedAuthoritySummaryV1,
+  AgentProfileVerifiedForkResolutionFactsV1,
   CanonicalRfc3339SecondsV1,
   Digest32V1,
   NetworkIdV1,

--- a/packages/core/test/system-record-package-export-v1.types.ts
+++ b/packages/core/test/system-record-package-export-v1.types.ts
@@ -131,4 +131,18 @@ void forgedCacheMetadata;
 void forkEvidenceClosureVerifier;
 void rowTraversalSubpathContract;
 
+// The storage quarantine-exit predicate compares these fork-resolution scalars
+// directly against a persisted head version typed plain `string`. Both sides must
+// stay strings at runtime: a branded string qualifies and is preferred, but a
+// `bigint` on either side would make every comparison false, refusing every
+// legitimate unquarantine while looking fail-closed.
+type ForkResolutionScalarsAreStrings =
+  AgentProfileVerifiedForkResolutionFactsV1['forkedVersion'] extends string
+    ? AgentProfileVerifiedForkResolutionFactsV1['authoritySequence'] extends string
+      ? true
+      : never
+    : never;
+const forkResolutionScalarsAreStrings: ForkResolutionScalarsAreStrings = true;
+void forkResolutionScalarsAreStrings;
+
 export {};


### PR DESCRIPTION
## Summary

A peer that equivocates can currently clear a quarantine it never resolved.

When a node quarantines a peer's record at version 5, the only thing storage can observe about a later resolving successor is that `forkResolutionDigest` is *set*. That proves a valid fork resolution exists somewhere in the candidate's history — not that it adjudicates **this node's** fork. So a peer that forks at v5, is quarantined, then forks again at v9 and issues a perfectly valid v9 resolution produces a successor that clears the v5 quarantine. The v5 equivocation is never adjudicated; the quarantine is rolled back by authority that had nothing to do with it.

Storage cannot close this today because the contract gives it nothing to compare against. `isDirectResolvingSuccessorV1` binds network, peer, key, issuer, sequence, the digest and a strict version advance, but **never compares `forkedVersion`**. The only `forkedVersion` check lives in `evaluateForkResolutionSuccessorV1`, a separate evaluator whose `current` is not the node's persisted state and whose verdict never reaches storage. And the minted `AgentProfileVerifiedAuthoritySummaryV1` carried no fork-resolution data at all.

This PR carries the fork identity the closure has already parsed and verified, so the storage-side predicate becomes expressible. **This PR is the capability; it adds no predicate.** The storage conjuncts land in D5b as task #35's S2 half, which is why nothing here changes behaviour.

Internal capability change, not a wire-format change: the summary is a factory-minted opaque value passed by reference, and the receiver threads it without inspecting fields.

## Related

- Issue #2052 — System Record sync.
- Master plan acceptance criterion **AC-5**: "a dishonest peer cannot … resolve an equivocation." The v5/v9 case is a direct violation, which is why this is not discretionary hardening.
- Task #35 (S2 half) consumes these facts in storage. **D5b must not merge while this is open.**
- Conjunct 6 (evidence-subset coverage) was proposed and then **withdrawn** — see "Deliberately not built".

## Before / after

**Before** — everything storage could observe about a resolving successor:

```
facts.head.forkResolutionDigest !== undefined
```

A presence check. True for a resolution of *any* fork by that peer.

**After** — the summary carries the verified fork identity:

```ts
export interface AgentProfileVerifiedForkResolutionFactsV1 {
  readonly resolutionDigest: Digest32V1;
  readonly authoritySequence: DecimalU64V1;
  readonly forkedVersion: DecimalU64V1;
  readonly resolutionVersion: DecimalU64V1;
  readonly forkBaseHeadDigest?: Digest32V1;
}
```

`forkedVersion` plus `authoritySequence` name the fork event; `forkBaseHeadDigest` names the common base, which distinguishes two fork events sharing a sequence and version but descending from different predecessors. The scalars keep their canonical branded type rather than widening to `string` — see the test plan for the contract that keeps them string-assignable.

Three properties of the minting are load-bearing:

1. **Minted where succession is proved.** Validation mints the facts at the point `isDirectResolvingSuccessorV1` succeeds. They are not re-parsed or re-derived downstream.
2. **The validated closure is branded.** `ValidatedClosureV1` carries a unique-symbol brand, so `{ collected }` does not typecheck and only the validator's single construction site produces one. Previously that guarantee held by module privacy plus a single producer — a convention. A deliberate cast still defeats the brand; that is the intended strength, since this value never leaves the module, so the hazard is an honest refactor mistake rather than a forge, and a cast is visible in review where a plain literal is not.
3. **Fails closed when a head advertises a resolution the traversal did not collect.** Not defensive padding — the structural answer to a future traversal split (#2216) minting a summary without running the directness check. Softening it to a silent `undefined` would reopen exactly the hole this PR closes.

## Deliberately not built

**No `evidenceHeadDigests`, and no evidence-coverage predicate.** Proposed as a sixth conjunct and withdrawn against the frozen plan text: the 2–16 conflict list is "a **verified subset** of conflicting heads at the forked version and … **evidence, not a receiver-local completeness claim**" (lines 362-364), and a verifier "must not reject it merely because that receiver knows an omitted conflict" (lines 214-215). Line 203 makes the "{C,D} clears {A,B}" shape designed behaviour. A coverage conjunct would reject precisely the resolutions the plan requires us to accept.

Downstream consequences, so the dependencies are not built either: `conflictDigestSlots` must **not** be populated for ordinary fork quarantines, and no explicit terminality boolean is added — inferring terminality from slot occupancy stays correct exactly as long as only `terminalTransitionConflict` populates slots.

**No state gate on the minting site.** A review round raised that a tombstone could be summarized as a resolving successor, since the direct-successor predicate never inspects `state` and `forkResolutionDigest` lives on the common head shape. Both facts are true; the conclusion does not follow. The head codec refuses that shape outright (`system-record-agent-profile-head-codec-v1-internal.ts:271-272`), so such a head never parses, never enters a closure, and never reaches minting. Adding a gate would be a check for an unconstructible state. What was missing was a test on the existing refusal, which `1a0172685` adds.

## Review rounds

Four rounds; the design above is the post-review shape.

1. **Key the verified resolution instead of rediscovering it** (`4b8cfe7ca`). Validation returns what it verified. The `find` it replaced was fail-closed, so the refusal was replaced by structure rather than dropped: "advertises none" stays distinct from "validation did not run", and the second is unrepresentable.
2. **Carry the verified facts, not the raw resolution** (`8b0c93dc4`), plus exporting the facts type. The raw resolution carries `evidenceHeadDigests` — the list this PR deliberately does not surface — so while projection held the object, that list was one property access from the summary.
3. **Tombstone minting** (`1a0172685`) — refuted at construction, pin added instead. See "Deliberately not built".
4. **Brand the validated closure and keep the scalars canonical** (`1cea0551c`, `e8868a773`). The brand repairs a guarantee that was previously a convention; the canonical scalars restore precision at the boundary whose purpose is publishing verified facts.

`37bde1bdd` narrows an overstatement from rounds 1–2: the collected closure remains reachable via `validated.collected`; the real property is that neither the summary nor the facts helper can express an unverified lookup. The two earlier commit messages keep the stronger wording; the tree is the corrected copy.

## Files

| File | Change |
| --- | --- |
| `packages/core/src/system-record-verification-closure-v1-internal.ts` | The facts type, the branded validated closure, minting at the point of proof (+114/-7) |
| `packages/core/src/system-record-objects-v1.ts` | Re-exports the facts type on the public boundary (+1) |
| `packages/core/test/system-record-objects-v1.test.ts` | Five tests and two closure fixtures (+195) |
| `packages/core/test/system-record-package-export-v1.types.ts` | Type pin plus the scalar string contract (+17) |
| `packages/core/test/system-record-limits-v1.test.ts` | Value-pins five AC-cited caps (qa-ci's rider) (+8) |

Nine commits: `5049caa4f` (cap pins) · `45c5bad6c` (capability) · `fe17d185e` (tests) · `4b8cfe7ca` · `8b0c93dc4` · `37bde1bdd` · `1a0172685` · `1cea0551c` · `e8868a773`.

**The cap-pin rider** exists because five AC-cited bounds were name-exported but never value-pinned: `SYSTEM_RECORD_MAX_OWNED_SUBJECTS=2_048`, `MAX_CONFLICT_DIGESTS=16`, `MAX_CONFLICT_ENTRIES=8`, `MAX_SIDECAR_OBJECTS=17`, `MAX_SIDECAR_BYTES=1_064_960`. D5b's 2,049-refusal test imports the constant, so raising the cap to 4,096 would have left that test green while the bound moved.

## Test plan

The complete core gate is three runs, not one — worth stating precisely, because the vitest figure alone is the one that reads like "everything":

- `vitest run --fileParallelism=false`: **115 files, 1810 passed, 2 skipped** (1805 before this PR).
- `pnpm run test:system-record-export`: clean, **273 exact symbols**, plus the type-pin compile. **Not in the vitest number** — `vitest.config.ts` includes only `test/**/*.test.ts`, so the runtime symbol check and the type pin run only from this script.
- `turbo build`: clean, 18/18.

Scope statement: this PR touches `packages/core` only, so no storage or agent lane was run here — cross-package coverage is the integration branch's own CI.

Every guard added here has a mutant of the right shape. All were verified **applied** before their result was read, run **serially**, with a restore and a green re-verification between each.

| Test | Mutant |
| --- | --- |
| authority sequence equals lineage length | Mint `authoritySequence` from `forkedVersion` → kills **only** this test. Duplicate a lineage entry → kills this plus 2 pre-existing, proving the *other* side of the equality is load-bearing |
| no facts when the head advertises none | Fabricate facts for a head with no resolution → kills **only** this test |
| always collects the advertised resolution, or fails closed | Never enqueue the advertised resolution → kills this plus 4 |
| identical facts through the authority-only closure | Enqueue only when `purpose === 'current'` → kills **only** this test |
| refuses a tombstone that advertises a fork resolution | Disable the codec refusal → kills **only** this test |

Both closure mutants were re-run after each refactor rather than assumed to survive; a refactor preserving behaviour usually preserves mutant kills, and *usually* is not evidence.

**Two proofs that needed the build, not the source.** The brand: a plain `{ collected }` literal fails with `TS2741: Property '[VALIDATED_CLOSURE_V1_BRAND]' is missing` — probe added, observed, removed, since the type is module-private and has no test surface. The scalar contract: it imports via the package specifier, so it reads *built declarations*; mutating `forkedVersion` to `bigint` and **rebuilding** turns the export gate red at the pin's own line. Without the rebuild the gate passes against stale `dist/`, which looks exactly like a pin that cannot fail.

**Why that contract exists.** The storage predicate compares these scalars against a persisted head version typed plain `string`. A `bigint` on either side would make every comparison false — refusing every legitimate unquarantine while looking fail-closed. A branded string satisfies the requirement and is preferred; the pin now enforces it at compile time rather than leaving it to a comment.

**Fixture note.** The rotated fork case uses four distinct numbers (sequence 2, forked 1, resolution 3, successor version 4) so an assertion over the minted facts cannot pass while two fields are transposed. An earlier draft had `authoritySequence === forkedVersion === 1`, under which the field-swap mutant *survives*. Two rotations are forced, because a head above version 0 requires `previousHeadDigest`, so the fork base must sit at version 0.
