### PR TITLE
test(publisher): restore the store-unavailable ACK guard

### DIFF
--- a/packages/publisher/src/catalog-persistence.ts
+++ b/packages/publisher/src/catalog-persistence.ts
@@ -6,21 +6,26 @@ import {
 } from '@origintrail-official/dkg-storage';
 
 /**
- * The catalog-persist steps, as a closed set. Failure-injection tests target a
- * step by name, so a renamed step must be a compile error at every call site
- * rather than a string that silently stops matching.
+ * The canonical `QueryOptions.source` tag for each catalog-persist step.
+ *
+ * These strings are an observable contract: storage-side diagnostics and the
+ * ACK dead-air guards select store calls by this exact tag. They are literals
+ * here, in one place, rather than a template built from the step name — so
+ * renaming a step cannot silently change the externally visible tag.
  */
-export type CatalogPersistStep = 'deleteSubjects' | 'deleteByPattern' | 'insert' | 'flush';
+export const CATALOG_PERSIST_SOURCES = {
+  deleteSubjects: 'storage-ack.persistCatalog.deleteSubjects',
+  deleteByPattern: 'storage-ack.persistCatalog.deleteByPattern',
+  insert: 'storage-ack.persistCatalog.insert',
+  flush: 'storage-ack.persistCatalog.flush',
+} as const;
 
-/** The canonical `QueryOptions.source` tag for one catalog-persist step. */
-export function catalogPersistSource(step: CatalogPersistStep): string {
-  return `storage-ack.persistCatalog.${step}`;
-}
+export type CatalogPersistStep = keyof typeof CATALOG_PERSIST_SOURCES;
 
 function catalogStoreOptions(step: CatalogPersistStep, signal?: AbortSignal): QueryOptions {
   return {
     priority: 'ack',
-    source: catalogPersistSource(step),
+    source: CATALOG_PERSIST_SOURCES[step],
     ...(signal ? { signal } : {}),
   };
 }

--- a/packages/publisher/src/catalog-persistence.ts
+++ b/packages/publisher/src/catalog-persistence.ts
@@ -5,10 +5,22 @@ import {
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
 
-function catalogStoreOptions(operation: string, signal?: AbortSignal): QueryOptions {
+/**
+ * The catalog-persist steps, as a closed set. Failure-injection tests target a
+ * step by name, so a renamed step must be a compile error at every call site
+ * rather than a string that silently stops matching.
+ */
+export type CatalogPersistStep = 'deleteSubjects' | 'deleteByPattern' | 'insert' | 'flush';
+
+/** The canonical `QueryOptions.source` tag for one catalog-persist step. */
+export function catalogPersistSource(step: CatalogPersistStep): string {
+  return `storage-ack.persistCatalog.${step}`;
+}
+
+function catalogStoreOptions(step: CatalogPersistStep, signal?: AbortSignal): QueryOptions {
   return {
     priority: 'ack',
-    source: `storage-ack.persistCatalog.${operation}`,
+    source: catalogPersistSource(step),
     ...(signal ? { signal } : {}),
   };
 }

--- a/packages/publisher/test/catalog-persist-source.test.ts
+++ b/packages/publisher/test/catalog-persist-source.test.ts
@@ -9,9 +9,14 @@ import { CATALOG_PERSIST_SOURCES } from '../src/catalog-persistence.js';
  *
  * Driven by the production map at RUNTIME, not by the type. The publisher
  * package typechecks only `src`, so a type-level exhaustiveness check here would
- * never execute — a step added to the union would slip through green. Iterating
- * the map itself means a new step is covered automatically, and the expected-key
- * assertion is what fails if one is added without a decision.
+ * never execute — a step added to the union would slip through green. Pinning the
+ * whole map means a new step is covered automatically.
+ *
+ * Deliberately NOT asserted: that a tag is derived from its step key. The map
+ * exists so the observable tag and the internal step name can move apart — a key
+ * rename that intentionally preserves the public tag must stay expressible, and a
+ * derived-prefix check would fail it, pushing the maintainer to change the tag
+ * instead of the key.
  */
 describe('catalog-persist source tags', () => {
   it('pins the exact tag for every step in the production map', () => {
@@ -23,12 +28,9 @@ describe('catalog-persist source tags', () => {
     });
   });
 
-  it('gives every step a distinct, correctly-prefixed tag', () => {
-    const entries = Object.entries(CATALOG_PERSIST_SOURCES);
-    expect(entries.length).toBeGreaterThan(0);
-    for (const [step, source] of entries) {
-      expect(source).toBe(`storage-ack.persistCatalog.${step}`);
-    }
-    expect(new Set(entries.map(([, source]) => source)).size).toBe(entries.length);
+  it('gives every step a distinct tag', () => {
+    const sources = Object.values(CATALOG_PERSIST_SOURCES);
+    expect(sources.length).toBeGreaterThan(0);
+    expect(new Set(sources).size).toBe(sources.length);
   });
 });

--- a/packages/publisher/test/catalog-persist-source.test.ts
+++ b/packages/publisher/test/catalog-persist-source.test.ts
@@ -1,40 +1,34 @@
 import { describe, expect, it } from 'vitest';
 
-import { catalogPersistSource, type CatalogPersistStep } from '../src/catalog-persistence.js';
+import { CATALOG_PERSIST_SOURCES } from '../src/catalog-persistence.js';
 
 /**
  * `QueryOptions.source` is an observable diagnostic and failure-injection
- * contract: storage-side tooling and the ACK dead-air guards select calls by
- * this exact tag. Pin the literal strings here, independently of the builder.
+ * contract: storage-side tooling and the ACK dead-air guards select store calls
+ * by these exact tags.
  *
- * Every other assertion in the suite now compares against `catalogPersistSource(step)`,
- * which proves the WIRING (production and test agree) but cannot prove the FORMAT —
- * a changed prefix would move both sides together and stay green. These literals are
- * the half that fails when the externally visible tag changes.
+ * Driven by the production map at RUNTIME, not by the type. The publisher
+ * package typechecks only `src`, so a type-level exhaustiveness check here would
+ * never execute — a step added to the union would slip through green. Iterating
+ * the map itself means a new step is covered automatically, and the expected-key
+ * assertion is what fails if one is added without a decision.
  */
 describe('catalog-persist source tags', () => {
-  it('pins the canonical source string for every step', () => {
-    expect(catalogPersistSource('deleteSubjects')).toBe('storage-ack.persistCatalog.deleteSubjects');
-    expect(catalogPersistSource('deleteByPattern')).toBe('storage-ack.persistCatalog.deleteByPattern');
-    expect(catalogPersistSource('insert')).toBe('storage-ack.persistCatalog.insert');
-    expect(catalogPersistSource('flush')).toBe('storage-ack.persistCatalog.flush');
+  it('pins the exact tag for every step in the production map', () => {
+    expect(CATALOG_PERSIST_SOURCES).toEqual({
+      deleteSubjects: 'storage-ack.persistCatalog.deleteSubjects',
+      deleteByPattern: 'storage-ack.persistCatalog.deleteByPattern',
+      insert: 'storage-ack.persistCatalog.insert',
+      flush: 'storage-ack.persistCatalog.flush',
+    });
   });
 
-  it('covers every member of the step union', () => {
-    const steps: readonly CatalogPersistStep[] = [
-      'deleteSubjects', 'deleteByPattern', 'insert', 'flush',
-    ];
-    // A step added to the union without a literal above would leave this list
-    // stale; the exhaustive switch makes that a compile error rather than a gap.
-    for (const step of steps) {
-      const covered: boolean = ((s: CatalogPersistStep): boolean => {
-        switch (s) {
-          case 'deleteSubjects': case 'deleteByPattern': case 'insert': case 'flush': return true;
-          default: { const never: never = s; return never; }
-        }
-      })(step);
-      expect(covered).toBe(true);
-      expect(catalogPersistSource(step)).toBe(`storage-ack.persistCatalog.${step}`);
+  it('gives every step a distinct, correctly-prefixed tag', () => {
+    const entries = Object.entries(CATALOG_PERSIST_SOURCES);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [step, source] of entries) {
+      expect(source).toBe(`storage-ack.persistCatalog.${step}`);
     }
+    expect(new Set(entries.map(([, source]) => source)).size).toBe(entries.length);
   });
 });

--- a/packages/publisher/test/catalog-persist-source.test.ts
+++ b/packages/publisher/test/catalog-persist-source.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { catalogPersistSource, type CatalogPersistStep } from '../src/catalog-persistence.js';
+
+/**
+ * `QueryOptions.source` is an observable diagnostic and failure-injection
+ * contract: storage-side tooling and the ACK dead-air guards select calls by
+ * this exact tag. Pin the literal strings here, independently of the builder.
+ *
+ * Every other assertion in the suite now compares against `catalogPersistSource(step)`,
+ * which proves the WIRING (production and test agree) but cannot prove the FORMAT —
+ * a changed prefix would move both sides together and stay green. These literals are
+ * the half that fails when the externally visible tag changes.
+ */
+describe('catalog-persist source tags', () => {
+  it('pins the canonical source string for every step', () => {
+    expect(catalogPersistSource('deleteSubjects')).toBe('storage-ack.persistCatalog.deleteSubjects');
+    expect(catalogPersistSource('deleteByPattern')).toBe('storage-ack.persistCatalog.deleteByPattern');
+    expect(catalogPersistSource('insert')).toBe('storage-ack.persistCatalog.insert');
+    expect(catalogPersistSource('flush')).toBe('storage-ack.persistCatalog.flush');
+  });
+
+  it('covers every member of the step union', () => {
+    const steps: readonly CatalogPersistStep[] = [
+      'deleteSubjects', 'deleteByPattern', 'insert', 'flush',
+    ];
+    // A step added to the union without a literal above would leave this list
+    // stale; the exhaustive switch makes that a compile error rather than a gap.
+    for (const step of steps) {
+      const covered: boolean = ((s: CatalogPersistStep): boolean => {
+        switch (s) {
+          case 'deleteSubjects': case 'deleteByPattern': case 'insert': case 'flush': return true;
+          default: { const never: never = s; return never; }
+        }
+      })(step);
+      expect(covered).toBe(true);
+      expect(catalogPersistSource(step)).toBe(`storage-ack.persistCatalog.${step}`);
+    }
+  });
+});

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { StorageACKHandler, type StorageACKHandlerConfig } from '../src/storage-ack-handler.js';
+import { catalogPersistSource } from '../src/catalog-persistence.js';
 import { createStorageAckLifecycleObserver } from '../src/storage-ack-lifecycle-observer.js';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
@@ -1085,7 +1086,7 @@ describe('StorageACKHandler', () => {
       expect(deletes).toHaveLength(1);
       expect(deletes[0]?.input).toEqual({ graphUri: catalogGraph, subjects: [cgDid] });
       expect(deletes[0]?.options).toMatchObject({
-        source: 'storage-ack.persistCatalog.deleteSubjects',
+        source: catalogPersistSource('deleteSubjects'),
         priority: 'ack',
       });
       const stale = await base.query(`ASK { GRAPH <${catalogGraph}> { <${cgDid}> <${stalePredicate}> ?o } }`);

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { StorageACKHandler, type StorageACKHandlerConfig } from '../src/storage-ack-handler.js';
-import { catalogPersistSource } from '../src/catalog-persistence.js';
+import { CATALOG_PERSIST_SOURCES } from '../src/catalog-persistence.js';
 import { createStorageAckLifecycleObserver } from '../src/storage-ack-lifecycle-observer.js';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
@@ -1086,7 +1086,7 @@ describe('StorageACKHandler', () => {
       expect(deletes).toHaveLength(1);
       expect(deletes[0]?.input).toEqual({ graphUri: catalogGraph, subjects: [cgDid] });
       expect(deletes[0]?.options).toMatchObject({
-        source: catalogPersistSource('deleteSubjects'),
+        source: CATALOG_PERSIST_SOURCES.deleteSubjects,
         priority: 'ack',
       });
       const stale = await base.query(`ASK { GRAPH <${catalogGraph}> { <${cgDid}> <${stalePredicate}> ?o } }`);

--- a/packages/publisher/test/storage-update-ack.test.ts
+++ b/packages/publisher/test/storage-update-ack.test.ts
@@ -27,26 +27,33 @@ function makeQuad(s: string, p: string, o: string, g = 'urn:test:swm'): Quad {
 }
 
 /**
- * Wrap a REAL OxigraphStore so only the named ops throw the classic mid-
- * worker-restart oxigraph failure ('store is closed'); everything else keeps
- * hitting the live store. Mirrors `storeWithFailingOps` in
- * storage-ack-core-unavailable.test.ts — the curated-catalog UPDATE store-
- * failure regression below drives the real persist path (parse → verify →
- * targeted update → insert) up to the armed failure.
+ * Wrap a REAL OxigraphStore so one CATALOG-PERSIST STEP fails with the classic
+ * mid-worker-restart oxigraph failure ('store is closed'); everything else keeps
+ * hitting the live store.
+ *
+ * Keyed on the semantic step, not the storage method that implements it.
+ * `catalogStoreOptions` tags every catalog call with
+ * `source: 'storage-ack.persistCatalog.<step>'`, so this injection survives the
+ * storage layer swapping primitives underneath it. The previous version named
+ * methods instead: #2185 moved the targeted delete from `update()` to
+ * `structuredMutation()`, the arming string went stale, the failure stopped being
+ * injected, and this dead-air guard was inert until CI caught it. Naming more
+ * methods would only have moved the next silent break one refactor further out.
  */
-function storeWithFailingOps(
-  base: OxigraphStore,
-  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern' | 'structuredMutation' | 'replaceGraphAndSubject' | 'update' | 'flush')[],
-): TripleStore {
+function storeFailingCatalogPersistStep(base: OxigraphStore, step: string): TripleStore {
+  const source = `storage-ack.persistCatalog.${step}`;
+  const targetsStep = (args: readonly unknown[]): boolean => args.some(
+    (arg) => typeof arg === 'object' && arg !== null
+      && (arg as { source?: unknown }).source === source,
+  );
   return new Proxy(base as unknown as TripleStore, {
     get(target, prop, receiver) {
-      if (typeof prop === 'string' && (failingOps as readonly string[]).includes(prop)) {
-        return async () => {
-          throw new Error('store is closed');
-        };
-      }
       const value = Reflect.get(target, prop, receiver);
-      return typeof value === 'function' ? value.bind(target) : value;
+      if (typeof value !== 'function') return value;
+      return (...args: unknown[]) => {
+        if (targetsStep(args)) throw new Error('store is closed');
+        return (value as (...a: unknown[]) => unknown).apply(target, args);
+      };
     },
   });
 }
@@ -251,15 +258,7 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
       // hits a closed store used to throw out of the handler → stream reset →
       // publisher no_response. It must instead reply with the transient decline.
       const onDecline = vi.fn();
-      // Arm every mutation seam the targeted update could travel, not just the
-      // one it uses today: #2185 migrated this path from `update()` to
-      // `structuredMutation()` and this injection kept naming `update`, so the
-      // failure stopped being injected and the guard went inert. Naming all of
-      // them keeps the guard alive across the next migration too.
-      const store = storeWithFailingOps(
-        new OxigraphStore(),
-        ['structuredMutation', 'replaceGraphAndSubject', 'update'],
-      );
+      const store = storeFailingCatalogPersistStep(new OxigraphStore(), 'deleteSubjects');
       const handler = new StorageACKHandler(
         store as any,
         makeConfig(ethers.Wallet.createRandom(), 42n, { onDecline }),
@@ -287,7 +286,7 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
     it('curated catalog persist / insert throws → CORE_TEMPORARILY_UNAVAILABLE ("store unavailable"), NO signed ACK', async () => {
       // Same durability invariant, second store call: deletes succeed but the
       // catalog INSERT hits the closed store. Still a transient decline.
-      const store = storeWithFailingOps(new OxigraphStore(), ['insert']);
+      const store = storeFailingCatalogPersistStep(new OxigraphStore(), 'insert');
       const handler = makeHandler(ethers.Wallet.createRandom(), store as any);
       const ack = decodeStorageACK(await handler.updateHandler(curatedUpdateIntent(), fakePeerId));
 

--- a/packages/publisher/test/storage-update-ack.test.ts
+++ b/packages/publisher/test/storage-update-ack.test.ts
@@ -16,6 +16,7 @@ import {
   TypedEventBus,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { catalogPersistSource, type CatalogPersistStep } from '../src/catalog-persistence.js';
 import { ethers } from 'ethers';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 
@@ -40,8 +41,8 @@ function makeQuad(s: string, p: string, o: string, g = 'urn:test:swm'): Quad {
  * injected, and this dead-air guard was inert until CI caught it. Naming more
  * methods would only have moved the next silent break one refactor further out.
  */
-function storeFailingCatalogPersistStep(base: OxigraphStore, step: string): TripleStore {
-  const source = `storage-ack.persistCatalog.${step}`;
+function storeFailingCatalogPersistStep(base: OxigraphStore, step: CatalogPersistStep): TripleStore {
+  const source = catalogPersistSource(step);
   const targetsStep = (args: readonly unknown[]): boolean => args.some(
     (arg) => typeof arg === 'object' && arg !== null
       && (arg as { source?: unknown }).source === source,

--- a/packages/publisher/test/storage-update-ack.test.ts
+++ b/packages/publisher/test/storage-update-ack.test.ts
@@ -16,7 +16,7 @@ import {
   TypedEventBus,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
-import { catalogPersistSource, type CatalogPersistStep } from '../src/catalog-persistence.js';
+import { CATALOG_PERSIST_SOURCES, type CatalogPersistStep } from '../src/catalog-persistence.js';
 import { ethers } from 'ethers';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 
@@ -42,11 +42,16 @@ function makeQuad(s: string, p: string, o: string, g = 'urn:test:swm'): Quad {
  * methods would only have moved the next silent break one refactor further out.
  */
 function storeFailingCatalogPersistStep(base: OxigraphStore, step: CatalogPersistStep): TripleStore {
-  const source = catalogPersistSource(step);
-  const targetsStep = (args: readonly unknown[]): boolean => args.some(
-    (arg) => typeof arg === 'object' && arg !== null
-      && (arg as { source?: unknown }).source === source,
-  );
+  const source = CATALOG_PERSIST_SOURCES[step];
+  // Inspect the QueryOptions argument specifically rather than scanning every
+  // argument: a mutation payload that legitimately carried a `source` field
+  // would otherwise trip the injection before we ever reached the options.
+  // Every TripleStore method takes QueryOptions last.
+  const targetsStep = (args: readonly unknown[]): boolean => {
+    const options = args.at(-1);
+    return typeof options === 'object' && options !== null
+      && (options as { source?: unknown }).source === source;
+  };
   return new Proxy(base as unknown as TripleStore, {
     get(target, prop, receiver) {
       const value = Reflect.get(target, prop, receiver);

--- a/packages/publisher/test/storage-update-ack.test.ts
+++ b/packages/publisher/test/storage-update-ack.test.ts
@@ -36,7 +36,7 @@ function makeQuad(s: string, p: string, o: string, g = 'urn:test:swm'): Quad {
  */
 function storeWithFailingOps(
   base: OxigraphStore,
-  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern' | 'update')[],
+  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern' | 'structuredMutation' | 'replaceGraphAndSubject' | 'update' | 'flush')[],
 ): TripleStore {
   return new Proxy(base as unknown as TripleStore, {
     get(target, prop, receiver) {
@@ -251,7 +251,15 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
       // hits a closed store used to throw out of the handler → stream reset →
       // publisher no_response. It must instead reply with the transient decline.
       const onDecline = vi.fn();
-      const store = storeWithFailingOps(new OxigraphStore(), ['update']);
+      // Arm every mutation seam the targeted update could travel, not just the
+      // one it uses today: #2185 migrated this path from `update()` to
+      // `structuredMutation()` and this injection kept naming `update`, so the
+      // failure stopped being injected and the guard went inert. Naming all of
+      // them keeps the guard alive across the next migration too.
+      const store = storeWithFailingOps(
+        new OxigraphStore(),
+        ['structuredMutation', 'replaceGraphAndSubject', 'update'],
+      );
       const handler = new StorageACKHandler(
         store as any,
         makeConfig(ethers.Wallet.createRandom(), 42n, { onDecline }),


### PR DESCRIPTION
## Summary

The curated-catalog dead-air guard in `storage-update-ack.test.ts` stopped injecting its failure and had been inert since #2185.

That commit migrated the targeted update off `TripleStore.update()` — the path now calls `structuredMutation()` — but this file's fault-injection proxy still armed `update`. The proxy matched **by method name**, so the armed failure never fired, the update succeeded, a genuine signed ACK came back, and the assertion that a decline was returned failed.

The same helper is duplicated in `storage-ack-handler.test.ts`, which #2185 *did* migrate (its union gained `structuredMutation` and `flush`). This copy was missed.

## Why this matters more than a red lane

The test is a named dead-air regression guard — its own comment cites otReviewAgent #1408:650: a closed store throwing out of the handler caused a stream reset and a publisher `no_response`. While the seam was stale, **that protection did not exist on the targeted-update path**. It is a check that could not fail for the reason it exists.

We were lucky in the failure mode: because the migrated call now *succeeds*, the test went red and we noticed. A differently-shaped drift would have left it green and defenceless, which is how this class normally presents.

## What ships

Failure injection is keyed on the **semantic catalog-persist step**, not on storage method names, and the step tags are canonical production data:

```ts
export const CATALOG_PERSIST_SOURCES = {
  deleteSubjects: 'storage-ack.persistCatalog.deleteSubjects',
  deleteByPattern: 'storage-ack.persistCatalog.deleteByPattern',
  insert: 'storage-ack.persistCatalog.insert',
  flush: 'storage-ack.persistCatalog.flush',
} as const;

export type CatalogPersistStep = keyof typeof CATALOG_PERSIST_SOURCES;
```

`catalogStoreOptions` indexes that map. The test proxy fails any store call whose **`QueryOptions` argument** carries the target `source`, so it is independent of which primitive implements the step — and cannot be tripped by a mutation payload that happens to carry a `source` field.

Renaming a step can no longer change the externally visible tag as a side effect, because the tag is data sitting beside the step rather than derived from its name.

## Scope, characterized precisely

This began test-only and no longer is:

- **`packages/publisher/src/catalog-persistence.ts`** gains an exported const map and a derived type; `catalogStoreOptions` takes the union instead of an arbitrary string. Protocol's scope review confirmed **no behavioural change** — byte-identical `source` output for every step, no branch, validation, or side-effect delta.
- **`packages/publisher` has no `exports` field**, so every file is deep-importable and these symbols are externally reachable. Not a finding — the package's posture was already open — but the "not in the barrel, therefore package-internal" reasoning that applies to `packages/agent` (which has a `"./dist/*": null` map) does **not** transfer here.

## The enforcement split runs opposite to intuition

Worth stating so nobody later replaces the map with a template believing the type pins it:

- **Mechanically enforced:** the ESM import. `packages/publisher` has no test typecheck lane (`tsconfig.json` covers `src` only; no `test:types` script), but the tests import `CATALOG_PERSIST_SOURCES` — removing or renaming it fails at module load, so the suites go red.
- **Editor-only:** the type union. It produces a real `TS2345` for a bogus step, but no gate runs that check on test files.

The types are the *weaker* half here. The literal pin is deliberately driven by the production map **at runtime** for exactly this reason — a type-level exhaustiveness check would never execute. Filed as a separate follow-up (publisher test typecheck lane), deliberately not expanded into this PR.

## Test plan

Every claim below was measured, not asserted.

**The restored guard**

| State | Result |
| --- | --- |
| armed correctly | **17/17 pass** — the decline fires again |
| armed with **nothing** | **RED** — proves it observes the injected failure rather than passing vacuously |
| armed with **only the old `update` seam** | **RED** — reproduces exactly the regression being restored |
| pointed at a different valid step | **RED** — each injection is separately live |

**The source-tag contract**

| Mutant | Result |
| --- | --- |
| change a tag's value | **RED** — the literal pin fires |
| add a fifth step, leave the test alone | **RED** — runtime-driven, so no typecheck lane needed |
| rename an internal key while keeping the public tag | **GREEN** — the decoupling refactor stays expressible |

That last row is deliberate: an earlier revision asserted `source === prefix + step`, which would have failed a correct refactor and pushed the maintainer to change the observable tag instead of the key. Its absence is recorded in a comment so it is not "restored" later.

Full suites: **58 passed across 3 files**; publisher builds clean. Run with `pnpm --filter @origintrail-official/dkg-publisher exec vitest run` (Node 22; the publisher vitest config carries the Hardhat global setup).

## Repo-wide sweep

Every by-method-name fault-injection proxy was audited, not just this helper. 30 test files use `new Proxy`; 7 key off a string list of method names. **Exactly one — this file — armed an abandoned seam.** The rest either arm live methods or are not fault injection at all (`async-lift-broadcast-durability.test.ts` is a hostile-input probe for a classifier). A single missed copy in one migration, not systemic rot.

## Related

- Task #43. Diagnosed during the first full CI run ever executed on `integration/2052-system-record-sync` ([run 31411355851](https://github.com/OriginTrail/dkg/actions/runs/31411355851)), enabled by #2232.
- Severity **category (ii)** — stale detection, not a false witness. Confirmed by reading `tryReplaceGraphAndSubjectAtomically`: it swallows only `UnsupportedTripleStoreCapabilityError` for that exact capability and rethrows everything else, so a genuinely unavailable store still propagates out of the handler.
- Introduced by `88559e5fc` (#2185/#2186), which predates the D5b system-record stack.

## A note on how the seam was found

Two confident static predictions were wrong first — `update`, then `replaceGraphAndSubject`, both read off `update-handler.ts`. Instrumenting the proxy to log what the path actually touches gave `structuredMutation`. Reading a call site tells you which *function* is invoked, not which *store method* survives to the injection boundary. Seam identification for fault injection is a measurement.
