### PR TITLE
test(adapter-prime-agent): wait on the observable effect, not on a fixed sleep

### DIFF
--- a/packages/adapter-prime-agent/test/bridge-contract.test.ts
+++ b/packages/adapter-prime-agent/test/bridge-contract.test.ts
@@ -305,7 +305,7 @@ describe('/send', () => {
       headers: authed(),
       body: JSON.stringify({ text: 'hello agent', correlationId: 'c-1' }),
     });
-    await new Promise((r) => setTimeout(r, 30));
+    await until(() => sent.length === 1);
     expect(sent.map(visiblePrompt)).toEqual(['hello agent']);
 
     startBridgeRun();
@@ -337,7 +337,7 @@ describe('/send', () => {
       headers: authed(),
       body: JSON.stringify({ text: 'one', correlationId: 'c-a' }),
     });
-    await new Promise((r) => setTimeout(r, 30));
+    await until(() => sent.length === 1);
     startBridgeRun();
     const second = await fetch(`${base}/send`, {
       method: 'POST',
@@ -582,7 +582,7 @@ describe('/send', () => {
       headers: authed(),
       body: JSON.stringify({ text: 'hung turn', correlationId: 'c-hard-timeout' }),
     });
-    await new Promise((r) => setTimeout(r, 10));
+    await until(() => sent.length === 1);
     startBridgeRun({
       sessionManager: { getSessionId: () => 'sess-hard-timeout' },
       abort: () => { abortCount += 1; },
@@ -597,7 +597,7 @@ describe('/send', () => {
     });
     expect(whileStillRunning.status).toBe(429);
 
-    await new Promise((r) => setTimeout(r, 70));
+    await until(() => abortCount === 1);
     expect(abortCount).toBe(1);
     // The hard timeout aborts but keeps admission closed until Prime confirms
     // the lifecycle boundary with agent_end.


### PR DESCRIPTION
## Summary

- Four cases in `bridge-contract.test.ts` slept a fixed number of milliseconds and then asserted an asynchronous step had already happened. That is load-dependent — the sleep elapses on schedule while the work it stands in for does not — so they fail intermittently under CI load, on PRs that have nothing to do with them.
- Replaced those four with the file's existing `until()` poll helper, which waits on the observable side effect instead of on the clock.
- Deliberately left the remaining fixed sleeps: they wait for time to *pass* rather than for work to *finish*, or they assert an absence, which cannot be polled for.

## Related

- Diagnosed while attributing a CI failure on #2233; the same pattern also fired on #2234 and #2235 within one hour.
- Not related to the change under review in any of those PRs — `adapter-prime-agent` has no module-graph path from the packages they touch.

## Diagrams

### `/send` turn admission

Before:

```mermaid
sequenceDiagram
    participant Test
    participant Bridge
    Test->>Bridge: POST /send (not awaited)
    Test->>Test: sleep 30ms
    Note over Test: under load the POST has not arrived yet
    Test->>Test: assert sent == ['hello agent']  ✗
```

After:

```mermaid
sequenceDiagram
    participant Test
    participant Bridge
    Test->>Bridge: POST /send (not awaited)
    loop until sent.length === 1 (2s cap)
        Test->>Test: poll observable effect
    end
    Test->>Test: assert sent == ['hello agent']  ✓
```

## Files changed

| File | What |
|------|------|
| `packages/adapter-prime-agent/test/bridge-contract.test.ts` | Four fixed sleeps replaced with `until()`; three waited for a POST to be received, one for the hard-timeout abort callback to fire |

## Test plan

- [x] `pnpm exec turbo build --filter=@origintrail-official/dkg-adapter-prime-agent` — 3/3, exit 0
- [x] `pnpm exec vitest run test/bridge-contract.test.ts` — **35/35 passed**
- [x] **Proved the change is load-bearing, not cosmetic.** Shortening the first sleep to `0ms` — the slow-CI condition — reproduces the observed CI failure verbatim:
  `AssertionError: expected [] to deeply equal [ 'hello agent' ]`
  Restoring `until()` turns the same case green. So the poll is doing real work rather than decorating a test that would pass either way.

## Why the other sleeps stay

`until()` already existed here, with a comment naming this exact hazard, and 22 sites already used it. The four fixed were the ones that had not adopted it.

The rule separating them: **a sleep that waits for time to pass is safe under load; a sleep that waits for work to complete is not.** A slow machine makes more time pass, so duration-based waits fail safe; completion-based waits fail exactly when the machine is slow. The remaining sleeps are a wall-clock gap so an ISO stamp is strictly newer, keepalive intervals, a scheduler yield, and two absence assertions — all in the safe class.
