### PR TITLE
fix(sync): route explicit selected catch-up through RFC-64 lane

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -78,6 +78,11 @@ export {
 } from './chain-reconciler.js';
 export { resolveSyncReconcilerEnabled } from './sync/backpressure.js';
 export {
+  classifySharedMemoryFreshness,
+  type SelectedSharedMemorySyncResult,
+  type SharedMemoryFreshnessSummary,
+} from './sync/shared-memory-freshness.js';
+export {
   ContextGraphOnChainIdUnresolvedError,
   VmReconcileQueueClosedError,
   VmReconcileQueueFullError,

--- a/packages/agent/src/sync/shared-memory-freshness.ts
+++ b/packages/agent/src/sync/shared-memory-freshness.ts
@@ -25,9 +25,8 @@ export interface SharedMemoryFreshnessSummary extends DurableProgressSummary {
  */
 export interface SelectedSharedMemorySyncResult {
   readonly kind: 'selected-shared-memory';
-  readonly shared: SharedMemoryFreshnessSummary & {
-    readonly insertedTriples: number;
-  };
+  /** Full diagnostics stay available even though completion is lane-specific. */
+  readonly shared: SharedMemorySyncResult;
   readonly selectedScopeComplete: boolean;
 }
 

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -5,6 +5,7 @@ import {
   SwmCatchupPassTracker,
   catchupPassNowMs,
   catchupWaveSizes,
+  classifySharedMemoryFreshness,
   createFailedPeerDurableSyncResult,
   mapWithConcurrency,
   resolveSwmCatchupPassConfig,
@@ -14,6 +15,7 @@ import {
   type CatchupPlaneContext,
   type DurableSyncResult,
   type SharedMemorySyncResult,
+  type SelectedSharedMemorySyncResult,
   type SwmSnapshotCoverage,
 } from '@origintrail-official/dkg-agent';
 import {
@@ -77,8 +79,36 @@ parentPort!.on('message', async (message: any) => {
  */
 type CatchupDurableResult = DurableSyncResult & { verifiedPrivateOnlyResponses: number };
 
-/** One peer's shared-memory plane, as returned across the Worker RPC. */
-type CatchupSharedMemoryResult = SharedMemorySyncResult;
+/**
+ * One peer's shared-memory plane, as returned across the Worker RPC.
+ *
+ * Ordinary fan-out keeps the historical raw result. An RFC-64 selected
+ * provider returns its discriminated terminal verdict as well, so the Worker
+ * never has to infer completion from diagnostic counters that deliberately
+ * retain resolved voluntary yields.
+ */
+type CatchupSelectedSharedMemoryResult = SelectedSharedMemorySyncResult & {
+  /** Projected for the generic catch-up admission retry policy. */
+  readonly deferredBackpressure?: number;
+};
+
+type CatchupSharedMemoryResult = SharedMemorySyncResult | CatchupSelectedSharedMemoryResult;
+
+function selectedSharedMemoryResult(
+  result: CatchupSharedMemoryResult | null | undefined,
+): SelectedSharedMemorySyncResult | undefined {
+  return result && 'kind' in result && result.kind === 'selected-shared-memory'
+    ? result
+    : undefined;
+}
+
+function sharedMemoryPayload(
+  result: CatchupSharedMemoryResult | null | undefined,
+): SharedMemorySyncResult | null {
+  if (!result) return null;
+  const selected = selectedSharedMemoryResult(result);
+  return selected ? selected.shared : result as SharedMemorySyncResult;
+}
 
 /**
  * One peer's sync round. A plane is `null` when the walk deliberately skipped
@@ -390,14 +420,22 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       { priority, source }: CatchupPlaneContext,
     ): Promise<CatchupSharedMemoryResult> =>
       invoke<CatchupSharedMemoryResult>(
-        authoritativeSharedMemoryPeerIds.has(peerId)
-          ? 'syncSelectedSharedMemory'
-          : 'syncSharedMemory',
+        'syncSharedMemory',
         peerId,
         request.contextGraphId,
         priority,
         source,
+        authoritativeSharedMemoryPeerIds.has(peerId),
       )
+        .then((result) => {
+          const selected = selectedSharedMemoryResult(result);
+          return selected
+            ? {
+              ...selected,
+              deferredBackpressure: selected.shared.deferredBackpressure,
+            }
+            : result;
+        })
         .catch(() => emptyShared());
 
     // Narrow each fallback peer to the planes the AUTHORITY has not already
@@ -461,18 +499,27 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     {
       peerId,
       durable,
-      shared,
+      shared: sharedResult,
       fromDurableAuthority,
       fromSharedMemoryAuthority,
     }: PeerRound,
     isContinuationRound = false,
   ): void => {
     let peerDenied = false;
+    const selectedShared = selectedSharedMemoryResult(sharedResult);
+    const shared = sharedMemoryPayload(sharedResult);
+    const sharedCompletedWithoutFailure = shared
+      ? selectedShared
+        ? classifySharedMemoryFreshness(shared, {
+          complete: selectedShared.selectedScopeComplete,
+        }).completedWithoutFailure
+        : catchupPlaneCompletedWithoutFailure(shared)
+      : false;
     if (shared) {
       passTracker.recordPeerRound(
         peerId,
         shared.swmCoverage,
-        catchupPlaneCompletedWithoutFailure(shared),
+        sharedCompletedWithoutFailure,
       );
     }
     if (durable) {
@@ -576,13 +623,14 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       // Shared memory carries no verified-private-only signal, so the shared
       // evidence only ever has data/empty set — the same reducer still applies.
       const sharedEvidence = catchupPeerPlaneEvidence(shared, {
+        completedWithoutFailure: sharedCompletedWithoutFailure,
         fromAuthority: fromSharedMemoryAuthority,
         plane: 'shared-memory',
       });
       addCatchupPlaneEvidence(cleanPlaneCompletions.sharedMemory, sharedEvidence);
       if (fromSharedMemoryAuthority) {
         addCatchupPlaneEvidence(authorityEvidence.sharedMemory, sharedEvidence);
-        if (catchupPlaneCompletedWithoutFailure(shared)) {
+        if (sharedCompletedWithoutFailure) {
           authorityAnswered.sharedMemory = true;
         }
       }
@@ -601,7 +649,13 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     // completed with no timeout. Mirrors the inline
     // `syncContextGraphFromConnectedPeers` path so both runners report the
     // same shape.
-    if (catchupPeerSucceeded(durable, shared, peerDenied, durable?.complete)) {
+    if (catchupPeerSucceeded(
+      durable,
+      shared,
+      peerDenied,
+      durable?.complete,
+      selectedShared?.selectedScopeComplete,
+    )) {
       peersSucceeded.add(peerId);
     }
   };

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -5,6 +5,7 @@ import {
   SwmCatchupPassTracker,
   catchupPassNowMs,
   catchupWaveSizes,
+  classifyDurableProgress,
   classifySharedMemoryFreshness,
   createFailedPeerDurableSyncResult,
   mapWithConcurrency,
@@ -13,6 +14,7 @@ import {
   runCatchupPlanesWithPolicy,
   selectSwmSnapshotCoverage,
   type CatchupPlaneContext,
+  type DurableProgressClassification,
   type DurableSyncResult,
   type SharedMemorySyncResult,
   type SelectedSharedMemorySyncResult,
@@ -29,6 +31,7 @@ import {
   catchupPlaneCompletedWithoutFailure,
   catchupPlaneProvenByAuthorityHostedEmpty,
   catchupPlaneProvenByData,
+  catchupPlaneProvenBySelectedScope,
   type CatchupJobResult,
   type CatchupPlaneCompletionEvidence,
   type CatchupRunRequest,
@@ -87,27 +90,55 @@ type CatchupDurableResult = DurableSyncResult & { verifiedPrivateOnlyResponses: 
  * never has to infer completion from diagnostic counters that deliberately
  * retain resolved voluntary yields.
  */
-type CatchupSelectedSharedMemoryResult = SelectedSharedMemorySyncResult & {
-  /** Projected for the generic catch-up admission retry policy. */
-  readonly deferredBackpressure?: number;
-};
-
-type CatchupSharedMemoryResult = SharedMemorySyncResult | CatchupSelectedSharedMemoryResult;
+type CatchupSharedMemoryRpcResult = SharedMemorySyncResult | SelectedSharedMemorySyncResult;
 
 function selectedSharedMemoryResult(
-  result: CatchupSharedMemoryResult | null | undefined,
+  result: CatchupSharedMemoryRpcResult | null | undefined,
 ): SelectedSharedMemorySyncResult | undefined {
   return result && 'kind' in result && result.kind === 'selected-shared-memory'
     ? result
     : undefined;
 }
 
-function sharedMemoryPayload(
-  result: CatchupSharedMemoryResult | null | undefined,
-): SharedMemorySyncResult | null {
-  if (!result) return null;
+/**
+ * Normalized worker boundary for one shared-memory RPC.
+ *
+ * The raw/discriminated wire union ends here. Every reducer below receives the
+ * same payload plus an explicit completion policy, so flattening `.shared`
+ * cannot silently discard an RFC-64 terminal verdict.
+ */
+interface CatchupSharedMemoryPlane {
+  readonly payload: SharedMemorySyncResult;
+  readonly progress: DurableProgressClassification;
+  readonly terminalBoundaryRequired: boolean;
+  readonly selectedScopeProven: boolean;
+  /** Projected for the generic catch-up admission retry policy. */
+  readonly deferredBackpressure?: number;
+}
+
+function normalizeCatchupSharedMemoryResult(
+  result: CatchupSharedMemoryRpcResult,
+  selectedRequested: boolean,
+): CatchupSharedMemoryPlane {
   const selected = selectedSharedMemoryResult(result);
-  return selected ? selected.shared : result as SharedMemorySyncResult;
+  const payload = selected?.shared ?? result as SharedMemorySyncResult;
+  // A selected request that receives an older/raw host response is incomplete,
+  // not ordinary success. That makes rolling upgrades fail closed at the one
+  // boundary where the requested lane is still known.
+  const progress = selectedRequested
+    ? classifySharedMemoryFreshness(payload, {
+      complete: selected?.selectedScopeComplete ?? false,
+    })
+    : classifyDurableProgress(payload);
+  return {
+    payload,
+    progress,
+    terminalBoundaryRequired: selectedRequested,
+    selectedScopeProven: selectedRequested
+      && selected?.selectedScopeComplete === true
+      && progress.completedWithoutFailure,
+    deferredBackpressure: payload.deferredBackpressure,
+  };
 }
 
 /**
@@ -122,7 +153,7 @@ interface PeerRound {
   /** An operator-pinned RFC-64 graph-complete SWM provider produced this round. */
   fromSharedMemoryAuthority: boolean;
   durable: CatchupDurableResult | null;
-  shared: CatchupSharedMemoryResult | null;
+  shared: CatchupSharedMemoryPlane | null;
 }
 
 /** What distinguishes one pass of the peer walk from the next. */
@@ -161,7 +192,7 @@ function describeCoverage(coverage: SwmSnapshotCoverage | undefined): string {
     + `...${coverage.peerIdSuffix}${manifest}`;
 }
 
-function emptyShared(): CatchupSharedMemoryResult {
+function emptyShared(): SharedMemorySyncResult {
   return {
     insertedTriples: 0,
     fetchedMetaTriples: 0,
@@ -350,6 +381,7 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
   const authoritySettles = (
     plane: 'durable' | 'sharedMemory',
   ): boolean => catchupPlaneProvenByData(authorityEvidence[plane])
+    || catchupPlaneProvenBySelectedScope(authorityEvidence[plane])
     || catchupPlaneProvenByAuthorityHostedEmpty(
       authorityEvidence[plane],
       diagnostics[plane],
@@ -418,25 +450,19 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
         }));
     const syncSharedMemory = (
       { priority, source }: CatchupPlaneContext,
-    ): Promise<CatchupSharedMemoryResult> =>
-      invoke<CatchupSharedMemoryResult>(
+    ): Promise<CatchupSharedMemoryPlane> => {
+      const selectedRequested = authoritativeSharedMemoryPeerIds.has(peerId);
+      return invoke<CatchupSharedMemoryRpcResult>(
         'syncSharedMemory',
         peerId,
         request.contextGraphId,
         priority,
         source,
-        authoritativeSharedMemoryPeerIds.has(peerId),
+        selectedRequested,
       )
-        .then((result) => {
-          const selected = selectedSharedMemoryResult(result);
-          return selected
-            ? {
-              ...selected,
-              deferredBackpressure: selected.shared.deferredBackpressure,
-            }
-            : result;
-        })
-        .catch(() => emptyShared());
+        .then((result) => normalizeCatchupSharedMemoryResult(result, selectedRequested))
+        .catch(() => normalizeCatchupSharedMemoryResult(emptyShared(), selectedRequested));
+    };
 
     // Narrow each fallback peer to the planes the AUTHORITY has not already
     // settled. One plane is often settled long before the other — a Context
@@ -506,15 +532,8 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     isContinuationRound = false,
   ): void => {
     let peerDenied = false;
-    const selectedShared = selectedSharedMemoryResult(sharedResult);
-    const shared = sharedMemoryPayload(sharedResult);
-    const sharedCompletedWithoutFailure = shared
-      ? selectedShared
-        ? classifySharedMemoryFreshness(shared, {
-          complete: selectedShared.selectedScopeComplete,
-        }).completedWithoutFailure
-        : catchupPlaneCompletedWithoutFailure(shared)
-      : false;
+    const shared = sharedResult?.payload ?? null;
+    const sharedCompletedWithoutFailure = sharedResult?.progress.completedWithoutFailure ?? false;
     if (shared) {
       passTracker.recordPeerRound(
         peerId,
@@ -627,6 +646,9 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
         fromAuthority: fromSharedMemoryAuthority,
         plane: 'shared-memory',
       });
+      if (sharedResult?.selectedScopeProven) {
+        sharedEvidence.selectedScopeCompletePeers = 1;
+      }
       addCatchupPlaneEvidence(cleanPlaneCompletions.sharedMemory, sharedEvidence);
       if (fromSharedMemoryAuthority) {
         addCatchupPlaneEvidence(authorityEvidence.sharedMemory, sharedEvidence);
@@ -654,7 +676,12 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       shared,
       peerDenied,
       durable?.complete,
-      selectedShared?.selectedScopeComplete,
+      sharedResult
+        ? {
+          progress: sharedResult.progress,
+          terminalBoundaryRequired: sharedResult.terminalBoundaryRequired,
+        }
+        : undefined,
     )) {
       peersSucceeded.add(peerId);
     }

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -389,7 +389,15 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     const syncSharedMemory = (
       { priority, source }: CatchupPlaneContext,
     ): Promise<CatchupSharedMemoryResult> =>
-      invoke<CatchupSharedMemoryResult>('syncSharedMemory', peerId, request.contextGraphId, priority, source)
+      invoke<CatchupSharedMemoryResult>(
+        authoritativeSharedMemoryPeerIds.has(peerId)
+          ? 'syncSelectedSharedMemory'
+          : 'syncSharedMemory',
+        peerId,
+        request.contextGraphId,
+        priority,
+        source,
+      )
         .catch(() => emptyShared());
 
     // Narrow each fallback peer to the planes the AUTHORITY has not already

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -1164,6 +1164,27 @@ class WorkerCatchupRunner implements CatchupRunner {
           },
         );
       }
+      case 'syncSelectedSharedMemory': {
+        const [peerId, contextGraphId, priority, source] = args as [
+          string, string, number | undefined, unknown,
+        ];
+        const selected = await agent.syncSelectedSharedMemoryFromPeerDetailed(
+          peerId,
+          [contextGraphId],
+          {
+            ...(priority === undefined ? {} : { priority }),
+            source: normalizeSyncAdmissionSource(
+              typeof source === 'string' ? source : undefined,
+            ),
+            selectedSwmPriority: true,
+          },
+        );
+        // The worker already owns the authority verdict and attaches
+        // `fromAuthority` to the returned coverage. Keep the RPC payload on the
+        // historical SharedMemorySyncResult shape while selecting the typed
+        // RFC-64 producer here, at the in-process agent boundary.
+        return selected.shared;
+      }
       case 'logCatchupPass': {
         // The pass loop runs inside the Worker, which has no logger of its own,
         // so the line is FORMATTED there — where the coverage records live — and

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import {
   authoritativeSyncPeerId,
   classifyDurableProgress,
+  classifySharedMemoryFreshness,
   normalizeDurableSyncResult,
   normalizeSyncAdmissionSource,
   type DKGAgent,
@@ -620,8 +621,15 @@ export function catchupPeerPlaneEvidence(
      * mistake here settles a plane nobody proved.
      */
     plane: 'durable' | 'shared-memory';
-    /** Durable-only lifecycle state; the shared plane has no `complete` concept. */
+    /** Durable lifecycle state; selected SWM supplies its own typed equivalent. */
     complete?: boolean;
+    /**
+     * Lane-specific clean-completion verdict when raw diagnostics deliberately
+     * retain superseded failures. Selected SWM is the current producer: its
+     * freshness classifier resolves bounded historical yields while preserving
+     * those counters for telemetry.
+     */
+    completedWithoutFailure?: boolean;
     fromAuthority?: boolean;
   },
 ): CatchupPlaneCompletionEvidence {
@@ -632,7 +640,8 @@ export function catchupPeerPlaneEvidence(
     authorityEmptyPeers: 0,
   };
   if (!plane) return none;
-  if (!catchupPlaneCompletedWithoutFailure(plane, options.complete)) {
+  if (!(options.completedWithoutFailure
+    ?? catchupPlaneCompletedWithoutFailure(plane, options.complete))) {
     // The peer answered and its round was not clean. A pure transport failure is
     // NOT that: we never heard from it, it is already counted in `failedPeers`,
     // and treating unreachable strangers as unresolved evidence would stop a
@@ -889,9 +898,14 @@ export function catchupPeerSucceeded(
   shared: CatchupPhaseProgress | null | undefined,
   peerDenied: boolean,
   durableComplete?: boolean,
+  selectedSharedComplete?: boolean,
 ): boolean {
   const durableProgress = classifyDurableProgress(durable, { complete: durableComplete });
-  const sharedProgress = shared ? classifyDurableProgress(shared) : null;
+  const sharedProgress = shared
+    ? selectedSharedComplete === undefined
+      ? classifyDurableProgress(shared)
+      : classifySharedMemoryFreshness(shared, { complete: selectedSharedComplete })
+    : null;
   if (
     !catchupPeerResponded(durable, shared)
     || peerDenied
@@ -1150,40 +1164,30 @@ class WorkerCatchupRunner implements CatchupRunner {
         );
       }
       case 'syncSharedMemory': {
-        const [peerId, contextGraphId, priority, source] = args as [
-          string, string, number | undefined, unknown,
+        const [peerId, contextGraphId, priority, source, selected] = args as [
+          string, string, number | undefined, unknown, unknown,
         ];
+        const admission = {
+          ...(priority === undefined ? {} : { priority }),
+          source: normalizeSyncAdmissionSource(
+            typeof source === 'string' ? source : undefined,
+          ),
+        };
+        // One bridge operation owns producer selection. The Worker supplies a
+        // closed boolean, and only literal `true` may enter the selected lane;
+        // malformed structured-clone values retain ordinary behavior.
+        if (selected === true) {
+          return agent.syncSelectedSharedMemoryFromPeerDetailed(
+            peerId,
+            [contextGraphId],
+            { ...admission, selectedSwmPriority: true },
+          );
+        }
         return agent.syncSharedMemoryFromPeerDetailed(
           peerId,
           [contextGraphId],
-          {
-            ...(priority === undefined ? {} : { priority }),
-            source: normalizeSyncAdmissionSource(
-              typeof source === 'string' ? source : undefined,
-            ),
-          },
+          admission,
         );
-      }
-      case 'syncSelectedSharedMemory': {
-        const [peerId, contextGraphId, priority, source] = args as [
-          string, string, number | undefined, unknown,
-        ];
-        const selected = await agent.syncSelectedSharedMemoryFromPeerDetailed(
-          peerId,
-          [contextGraphId],
-          {
-            ...(priority === undefined ? {} : { priority }),
-            source: normalizeSyncAdmissionSource(
-              typeof source === 'string' ? source : undefined,
-            ),
-            selectedSwmPriority: true,
-          },
-        );
-        // The worker already owns the authority verdict and attaches
-        // `fromAuthority` to the returned coverage. Keep the RPC payload on the
-        // historical SharedMemorySyncResult shape while selecting the typed
-        // RFC-64 producer here, at the in-process agent boundary.
-        return selected.shared;
       }
       case 'logCatchupPass': {
         // The pass loop runs inside the Worker, which has no logger of its own,

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -4,12 +4,12 @@ import { fileURLToPath } from 'node:url';
 import {
   authoritativeSyncPeerId,
   classifyDurableProgress,
-  classifySharedMemoryFreshness,
   normalizeDurableSyncResult,
   normalizeSyncAdmissionSource,
   type DKGAgent,
   type CatchupPassDecisionReason,
   type DurableProgressSummary,
+  type DurableProgressClassification,
   type DurableSyncDiagnostics,
   type DurableSyncResult,
   type SwmSnapshotCoverage,
@@ -544,6 +544,12 @@ export interface CatchupPlaneCompletionEvidence {
   verifiedDataPeers: number;
   /** Peers that cleanly verified one or more V2 KAs with no public triples. */
   verifiedPrivateOnlyPeers?: number;
+  /**
+   * RFC-64 providers whose selected public-SWM scope reached its explicit
+   * terminal boundary. Unlike an ordinary peer's empty response, this is a
+   * graph-complete proof tied to the accepted provider policy.
+   */
+  selectedScopeCompletePeers?: number;
   emptyPeers: number;
   /**
    * The metadata-resolved curator cleanly completed this plane while hosting
@@ -699,6 +705,10 @@ export function addCatchupPlaneEvidence(
     total.verifiedPrivateOnlyPeers = (total.verifiedPrivateOnlyPeers ?? 0)
       + peer.verifiedPrivateOnlyPeers;
   }
+  if (peer.selectedScopeCompletePeers) {
+    total.selectedScopeCompletePeers = (total.selectedScopeCompletePeers ?? 0)
+      + peer.selectedScopeCompletePeers;
+  }
   total.emptyPeers += peer.emptyPeers;
   if (peer.authorityEmptyPeers) {
     total.authorityEmptyPeers = (total.authorityEmptyPeers ?? 0) + peer.authorityEmptyPeers;
@@ -719,6 +729,20 @@ export function catchupPlaneProvenByData(
 ): boolean {
   return (completion?.verifiedDataPeers ?? 0) > 0
     || (completion?.verifiedPrivateOnlyPeers ?? 0) > 0;
+}
+
+/**
+ * Positive RFC-64 proof: an explicitly selected graph-complete SWM provider
+ * reached the terminal boundary of the accepted public scope.
+ *
+ * This stays separate from `verifiedDataPeers`: a repeat run may prove the
+ * exact same already-materialized scope while inserting zero new triples, and
+ * calling that "verified data received" would corrupt the transfer telemetry.
+ */
+export function catchupPlaneProvenBySelectedScope(
+  completion: CatchupPlaneCompletionEvidence | undefined,
+): boolean {
+  return (completion?.selectedScopeCompletePeers ?? 0) > 0;
 }
 
 /**
@@ -889,6 +913,7 @@ export function catchupPlaneReady(
   options: { isPrivate: boolean },
 ): boolean {
   return catchupPlaneProvenByData(completion)
+    || catchupPlaneProvenBySelectedScope(completion)
     || catchupPlaneProvenByAuthorityHostedEmpty(completion, diagnostics, options)
     || catchupPlaneProvenByUnanimousEmpty(completion, diagnostics, options);
 }
@@ -898,13 +923,15 @@ export function catchupPeerSucceeded(
   shared: CatchupPhaseProgress | null | undefined,
   peerDenied: boolean,
   durableComplete?: boolean,
-  selectedSharedComplete?: boolean,
+  sharedCompletion?: {
+    progress: DurableProgressClassification;
+    /** This lane requires an explicit terminal boundary, not just clean I/O. */
+    terminalBoundaryRequired: boolean;
+  },
 ): boolean {
   const durableProgress = classifyDurableProgress(durable, { complete: durableComplete });
   const sharedProgress = shared
-    ? selectedSharedComplete === undefined
-      ? classifyDurableProgress(shared)
-      : classifySharedMemoryFreshness(shared, { complete: selectedSharedComplete })
+    ? sharedCompletion?.progress ?? classifyDurableProgress(shared)
     : null;
   if (
     !catchupPeerResponded(durable, shared)
@@ -918,6 +945,8 @@ export function catchupPeerSucceeded(
   const peerPhaseFailed = durableProgress.phaseFailed || Boolean(sharedProgress?.phaseFailed);
   if (peerPhaseFailed) return false;
   if (durableProgress.integrityRejected || sharedProgress?.integrityRejected) return false;
+  if (sharedCompletion?.terminalBoundaryRequired
+    && !sharedCompletion.progress.completedWithoutFailure) return false;
   const peerMadeProgress = durableProgress.madeReadinessProgress
     || Boolean(sharedProgress?.madeReadinessProgress);
   const peerMetadataOnly = !peerMadeProgress

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -12,6 +12,7 @@ import {
   catchupPlaneCompletedWithoutFailure,
   catchupPlaneProvenByAuthorityHostedEmpty,
   catchupPlaneProvenByData,
+  catchupPlaneProvenBySelectedScope,
   catchupPlaneProvenByUnanimousEmpty,
   catchupPlaneReady,
   type CatchupJobResult,
@@ -357,6 +358,7 @@ function cleanCompletionHasResponse(
 ): boolean {
   return (completion?.verifiedDataPeers ?? 0) > 0 ||
     (completion?.verifiedPrivateOnlyPeers ?? 0) > 0 ||
+    (completion?.selectedScopeCompletePeers ?? 0) > 0 ||
     (completion?.emptyPeers ?? 0) > 0 ||
     (completion?.authorityEmptyPeers ?? 0) > 0;
 }
@@ -435,6 +437,7 @@ function catchupPlaneReadinessThisRun(input: {
   const fullyAccounted = (diagnostics?.failedPeers ?? 0) === 0;
   if (completion) {
     const provenPositively = catchupPlaneProvenByData(completion)
+      || catchupPlaneProvenBySelectedScope(completion)
       || catchupPlaneProvenByAuthorityHostedEmpty(completion, diagnostics, options);
     const unanimousEmpty = catchupPlaneProvenByUnanimousEmpty(completion, diagnostics, options);
     return {

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -176,9 +176,17 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
               kind: 'selected-shared-memory',
               shared: {
                 ...shared,
+                insertedTriples: 0,
+                fetchedDataTriples: 0,
+                insertedDataTriples: 0,
+                bytesReceived: 0,
+                emptyResponses: 1,
                 failedPhases: 1,
                 snapshotPlaneIncomplete: 1,
                 resolvedSnapshotPlaneIncomplete: 1,
+                timedOutPhases: 1,
+                metadataContinuationYields: 1,
+                resolvedMetadataContinuationYields: 1,
               },
               selectedScopeComplete: true,
             };
@@ -197,8 +205,62 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
     expect(result.peersNotAttempted).toBe(2);
     expect(result.diagnostics?.durable.authorityUnanswered).toBe(false);
     expect(result.diagnostics?.sharedMemory.authorityUnanswered).toBe(false);
-    expect(result.cleanPlaneCompletions?.sharedMemory.verifiedDataPeers).toBe(1);
+    // The selected provider proved the exact graph-complete scope without
+    // transferring anything new. Raw historical yield counters remain visible,
+    // but the typed terminal verdict is the positive readiness proof.
+    expect(result.sharedMemorySynced).toBe(0);
+    expect(result.diagnostics?.sharedMemory.failedPhases).toBe(1);
+    expect(result.diagnostics?.sharedMemory.timedOutPhases).toBe(1);
+    expect(result.cleanPlaneCompletions?.sharedMemory.verifiedDataPeers).toBe(0);
+    expect(result.cleanPlaneCompletions?.sharedMemory.selectedScopeCompletePeers).toBe(1);
     expect(result.peersSucceeded).toBe(2);
+  });
+
+  it('fails selected SWM closed when its explicit scope is incomplete', async () => {
+    const peerIds = ['peer-swm', 'peer-curator'];
+    const selectedCalls: string[] = [];
+
+    const result = await runWorkerCatchup(
+      { contextGraphId: 'cg-selected-incomplete', includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return {
+              preferredPeerId: 'peer-curator',
+              authoritativePeerId: 'peer-curator',
+              authoritativeSharedMemoryPeerIds: ['peer-swm'],
+              isPrivateContextGraph: false,
+              peerIds,
+              connectedPeers: peerIds.length,
+            };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory':
+            expect(args[4]).toBe(true);
+            selectedCalls.push(String(args[0]));
+            return {
+              kind: 'selected-shared-memory',
+              shared: sharedResult(),
+              selectedScopeComplete: false,
+            };
+          case 'finalizeCatchup':
+            return null;
+          default:
+            throw new Error(`unexpected invoke: ${method}`);
+        }
+      },
+    );
+
+    expect(selectedCalls).toEqual(['peer-swm']);
+    expect(result.cleanPlaneCompletions?.sharedMemory.verifiedDataPeers).toBe(0);
+    expect(result.cleanPlaneCompletions?.sharedMemory.selectedScopeCompletePeers ?? 0).toBe(0);
+    expect(result.cleanPlaneCompletions?.sharedMemory.incompleteResponders).toBe(1);
+    expect(result.diagnostics?.sharedMemory.authorityUnanswered).toBe(true);
+    // Only the durable curator succeeded. Clean-looking selected payload
+    // counters cannot promote an explicitly incomplete terminal boundary.
+    expect(result.peersSucceeded).toBe(1);
   });
 
   it('escalates waves and still caps in-flight peer syncs when no peer proves the plane', async () => {

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -166,11 +166,23 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
           case 'syncDurable':
             durableCalls.push(args[0] as string);
             return durableResult();
-          case 'syncSelectedSharedMemory':
+          case 'syncSharedMemory': {
+            if (args[4] !== true) {
+              throw new Error('complete SWM provider must select the RFC-64 lane');
+            }
             sharedCalls.push(args[0] as string);
-            return sharedResult();
-          case 'syncSharedMemory':
-            throw new Error('complete SWM provider must use the selected RFC-64 lane');
+            const shared = sharedResult();
+            return {
+              kind: 'selected-shared-memory',
+              shared: {
+                ...shared,
+                failedPhases: 1,
+                snapshotPlaneIncomplete: 1,
+                resolvedSnapshotPlaneIncomplete: 1,
+              },
+              selectedScopeComplete: true,
+            };
+          }
           case 'finalizeCatchup':
             return null;
           default:
@@ -185,6 +197,8 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
     expect(result.peersNotAttempted).toBe(2);
     expect(result.diagnostics?.durable.authorityUnanswered).toBe(false);
     expect(result.diagnostics?.sharedMemory.authorityUnanswered).toBe(false);
+    expect(result.cleanPlaneCompletions?.sharedMemory.verifiedDataPeers).toBe(1);
+    expect(result.peersSucceeded).toBe(2);
   });
 
   it('escalates waves and still caps in-flight peer syncs when no peer proves the plane', async () => {

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -166,9 +166,11 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
           case 'syncDurable':
             durableCalls.push(args[0] as string);
             return durableResult();
-          case 'syncSharedMemory':
+          case 'syncSelectedSharedMemory':
             sharedCalls.push(args[0] as string);
             return sharedResult();
+          case 'syncSharedMemory':
+            throw new Error('complete SWM provider must use the selected RFC-64 lane');
           case 'finalizeCatchup':
             return null;
           default:

--- a/packages/cli/test/catchup-runner-worker-lifecycle.test.ts
+++ b/packages/cli/test/catchup-runner-worker-lifecycle.test.ts
@@ -170,7 +170,7 @@ describe('WorkerCatchupRunner lifecycle', () => {
  */
 describe('WorkerCatchupRunner agent bridge', () => {
   function bridgeAgent(overrides: Record<string, unknown> = {}) {
-    const calls: Record<string, unknown[][]> = { durable: [], shared: [] };
+    const calls: Record<string, unknown[][]> = { durable: [], shared: [], selectedShared: [] };
     let resolutionCalls = 0;
     const agent = {
       isPrivateContextGraph: async () => false,
@@ -189,6 +189,10 @@ describe('WorkerCatchupRunner agent bridge', () => {
       syncSharedMemoryFromPeerDetailed: async (...args: unknown[]) => {
         calls.shared.push(args);
         return {};
+      },
+      syncSelectedSharedMemoryFromPeerDetailed: async (...args: unknown[]) => {
+        calls.selectedShared.push(args);
+        return { kind: 'selected-shared-memory', shared: {}, selectedScopeComplete: true };
       },
       ...overrides,
     };
@@ -383,6 +387,34 @@ describe('WorkerCatchupRunner agent bridge', () => {
       priority: 2000,
       source: 'catchup-foreground',
     });
+  });
+
+  it('routes an RFC-64 complete provider through the typed selected SWM lane', async () => {
+    const { agent, calls } = bridgeAgent({
+      syncSelectedSharedMemoryFromPeerDetailed: async (...args: unknown[]) => {
+        calls.selectedShared.push(args);
+        return {
+          kind: 'selected-shared-memory',
+          shared: { insertedDataTriples: 7 },
+          selectedScopeComplete: true,
+        };
+      },
+    });
+
+    const posted = await invokeThroughBridge(
+      agent,
+      'syncSelectedSharedMemory',
+      ['peer-swm', 'cg-x', 2000, 'catchup-foreground'],
+    );
+
+    expect(calls.shared).toEqual([]);
+    expect(calls.selectedShared).toHaveLength(1);
+    expect(calls.selectedShared[0]!.at(-1)).toMatchObject({
+      priority: 2000,
+      source: 'catchup-foreground',
+      selectedSwmPriority: true,
+    });
+    expect(posted.result).toEqual({ insertedDataTriples: 7 });
   });
 
   it('emits worker pass diagnostics through the parent logger bridge', async () => {

--- a/packages/cli/test/catchup-runner-worker-lifecycle.test.ts
+++ b/packages/cli/test/catchup-runner-worker-lifecycle.test.ts
@@ -267,9 +267,18 @@ describe('WorkerCatchupRunner agent bridge', () => {
 
     await invokeThroughBridge(agent, 'syncDurable', ['peer-a', 'cg-x', 2000, 'durable:urn:cg:private:abc']);
     await invokeThroughBridge(agent, 'syncSharedMemory', ['peer-a', 'cg-x', 2000, { not: 'a string' }]);
+    await invokeThroughBridge(
+      agent,
+      'syncSharedMemory',
+      ['peer-swm', 'cg-x', 2000, 'durable:urn:cg:private:abc', true],
+    );
 
     expect(calls.durable[0]!.at(-1)).toMatchObject({ source: 'unspecified' });
     expect(calls.shared[0]!.at(-1)).toMatchObject({ source: 'unspecified' });
+    expect(calls.selectedShared[0]!.at(-1)).toMatchObject({
+      source: 'unspecified',
+      selectedSwmPriority: true,
+    });
   });
 
   it('hands the resolved peer into selection and returns an authority-ranked list', async () => {
@@ -403,8 +412,8 @@ describe('WorkerCatchupRunner agent bridge', () => {
 
     const posted = await invokeThroughBridge(
       agent,
-      'syncSelectedSharedMemory',
-      ['peer-swm', 'cg-x', 2000, 'catchup-foreground'],
+      'syncSharedMemory',
+      ['peer-swm', 'cg-x', 2000, 'catchup-foreground', true],
     );
 
     expect(calls.shared).toEqual([]);
@@ -414,7 +423,11 @@ describe('WorkerCatchupRunner agent bridge', () => {
       source: 'catchup-foreground',
       selectedSwmPriority: true,
     });
-    expect(posted.result).toEqual({ insertedDataTriples: 7 });
+    expect(posted.result).toEqual({
+      kind: 'selected-shared-memory',
+      shared: { insertedDataTriples: 7 },
+      selectedScopeComplete: true,
+    });
   });
 
   it('emits worker pass diagnostics through the parent logger bridge', async () => {

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -254,6 +254,43 @@ describe('context graph catch-up readiness classification', () => {
     expect(classification.error).toContain('incomplete plane remains unready');
   });
 
+  it('accepts an explicit selected-SWM terminal proof with no new inserts', () => {
+    const result = mixedPeerResult(1);
+    result.denied = false;
+    result.deniedPeers = 0;
+    result.sharedMemorySynced = 0;
+    result.cleanPlaneCompletions!.sharedMemory.selectedScopeCompletePeers = 1;
+    // These remain raw telemetry from voluntary yields that the selected lane
+    // resolved before producing its terminal verdict. They must not be erased,
+    // and they must not override the stronger typed proof either.
+    result.diagnostics!.sharedMemory.failedPhases = 1;
+    result.diagnostics!.sharedMemory.timedOutPhases = 1;
+    result.diagnostics!.sharedMemory.emptyResponses = 1;
+
+    const classification = classifyContextGraphCatchupReadiness({
+      result,
+      includeSharedMemory: true,
+      hasConfirmedMeta: true,
+      isPrivate: false,
+      readinessBeforeCatchup,
+    });
+
+    expect(classification).toMatchObject({
+      jobStatus: 'done',
+      statePatch: {
+        synced: true,
+        sharedMemorySynced: true,
+      },
+      readinessPatch: {
+        durableVerified: true,
+        sharedMemoryVerified: true,
+      },
+      eventPayload: {
+        sharedMemorySynced: 0,
+      },
+    });
+  });
+
   it('does not let previously verified shared memory mask a later durable-only request', () => {
     const result = durableMetaOnlyResult();
 


### PR DESCRIPTION
## Impact

An Edge node that explicitly subscribes to a selected public context graph now uses the RFC-64 selected-SWM completion lane for operators declared as complete SWM providers. Other peers continue through the existing ordinary catch-up path.

Previously, the subscribe worker correctly resolved and ranked complete providers, but discarded that authority classification when it crossed the worker/daemon RPC boundary. The receiver therefore used generic SWM sync and could not produce authority-bound coverage or selected-lane completion evidence.

## Before

```mermaid
sequenceDiagram
    participant Edge as Edge subscriber
    participant Worker as Catch-up worker
    participant Daemon as DKG daemon
    participant Provider as Complete SWM provider

    Edge->>Worker: Subscribe with SWM enabled
    Worker->>Worker: Resolve and rank complete provider
    Worker->>Daemon: syncSharedMemory
    Daemon->>Provider: Generic SWM sync
    Provider-->>Daemon: Data without selected-lane result
    Daemon-->>Worker: Generic result
```

## After

```mermaid
sequenceDiagram
    participant Edge as Edge subscriber
    participant Worker as Catch-up worker
    participant Daemon as DKG daemon
    participant Provider as Complete SWM provider

    Edge->>Worker: Subscribe with SWM enabled
    Worker->>Worker: Resolve and rank complete provider
    Worker->>Daemon: syncSelectedSharedMemory
    Daemon->>Provider: RFC-64 selected SWM sync
    Provider-->>Daemon: Data plus authoritative coverage
    Daemon-->>Worker: Historical shared result shape
```

## Implementation

- Route only peers in `authoritativeSharedMemoryPeerIds` through a new worker RPC method.
- Bridge that RPC to `syncSelectedSharedMemoryFromPeerDetailed` with foreground priority and selected-SWM admission.
- Unwrap the typed selected result at the bridge so the worker protocol remains backward-compatible.
- Preserve the generic sync method for fallback and non-authoritative peers.

## Validation

### Local tests and builds

- `catchup-runner-worker-impl.test.ts`
- `catchup-runner-worker-lifecycle.test.ts`
- 59/59 focused tests passed.
- Agent build, type/package-root checks, and CLI build passed.
- `git diff --check` passed.

### Testnet hotfix validation

Exact source commit: `67a3ada66fbc888e0b995ff437c84aacf6bc3077`.

A fresh disposable Testnet Edge receiver explicitly subscribed to registered public CG `bb-open-20260806-a7190`. Automatic on-connect, reconciler, and generic shared-memory-on-connect recovery were disabled. The configured complete provider was the existing publisher Edge peer.

- Publisher SWM: 32 assets, 9,868 triples.
- Cold receiver SWM: 32 assets, 9,868 triples.
- Exact content digest on both nodes: `sha256:5d6fc2ed4cf90d53eb32834380fcf2f8e325f06483e69d81921a3251987aadaf`.
- Coverage: 32/32, `manifestComplete=true`, `descriptorsAuthoritative=true`, `materializationFailures=0`, `fromAuthority=true`.
- Selected continuation stopped `plane-proven` after one pass.
- Transport was ordinary DKG relay; no Tailscale data path was used.

The aggregate catch-up job ended `unreachable` because this corpus has no VM content and the durable responder classified one metadata-only response as incomplete. That is recorded as a separate VM/aggregate-status follow-up; the SWM plane itself completed with exact parity and authoritative terminal evidence.

## Risk

The behavior change is narrow and opt-in: it applies only when RFC-64 activation declares a peer as a complete SWM provider for the selected CG. Fallback peers and graphs without this configuration retain the existing path.