### PR TITLE
fix(sync): balance selected recovery toward recent state

### DIFF
--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -115,6 +115,15 @@ export interface ChainReconcilerDeps {
   /** Maximum ordinal reconciliations allowed to run concurrently in one pass. */
   maxOrdinalConcurrency?: number;
   /**
+   * Number of slots in a bounded pass reserved for the newest outstanding
+   * ordinals. The remaining slots keep advancing the historical scan cursor.
+   *
+   * This is intentionally opt-in. Ordinary member/Core reconciliation keeps
+   * strict oldest-first behaviour, while an explicitly selected cold Edge can
+   * make the current head useful quickly without starving durable history.
+   */
+  recentOrdinalsPerPass?: number;
+  /**
    * Fetch one exact batch containing only locally-missing KAs, then re-run
    * local verification for those ordinals. Undefined preserves scan-only
    * behavior for callers/tests that do not provide network recovery.
@@ -220,8 +229,32 @@ export async function reconcileContextGraph(
     state.scanOrdinal = state.watermark;
     candidates = outstandingBefore;
   }
-  const ordinals = candidates.slice(0, passLimit);
+  const requestedRecent = Number.isFinite(deps.recentOrdinalsPerPass)
+    ? Math.max(0, Math.floor(deps.recentOrdinalsPerPass ?? 0))
+    : 0;
+  const recentCount = Number.isFinite(passLimit) && passLimit >= 2
+    ? Math.min(requestedRecent, passLimit - 1)
+    : 0;
+  let historicalOrdinals: number[];
+  let recentOrdinals: number[] = [];
+  if (recentCount > 0 && candidates.length > passLimit) {
+    const historicalCount = passLimit - recentCount;
+    historicalOrdinals = candidates.slice(0, historicalCount);
+    const historicalSet = new Set(historicalOrdinals);
+    recentOrdinals = candidates
+      .slice(-recentCount)
+      .filter((ordinal) => !historicalSet.has(ordinal));
+  } else {
+    historicalOrdinals = candidates.slice(0, passLimit);
+  }
+  // Cursor mutation and completion absorption stay ordinal-ordered even when
+  // the selected lane used both ends of the outstanding inventory.
+  const ordinals = [...historicalOrdinals, ...recentOrdinals]
+    .sort((a, b) => a - b);
   const hasUnvisitedCandidates = candidates.length > ordinals.length;
+  const historicalContinuationOrdinal = historicalOrdinals.length > 0
+    ? historicalOrdinals[historicalOrdinals.length - 1]! + 1
+    : state.watermark;
   if (headUnavailable) {
     state.scanOrdinal = state.watermark;
   } else {
@@ -271,12 +304,24 @@ export async function reconcileContextGraph(
     await Promise.all(Array.from({ length: workerCount }, () => runOrdinalWorker()));
     if (workerFailed) throw workerError;
 
+    const recentOrdinalSet = new Set(recentOrdinals);
     const recoveryTargets = ordinals
       .map((ordinal) => outcomes.get(ordinal))
       .filter((outcome): outcome is Extract<OrdinalOutcome, { status: 'pending' }> =>
         outcome?.status === 'pending' && outcome.recovery !== undefined,
       )
-      .map((outcome) => outcome.recovery!);
+      .map((outcome) => outcome.recovery!)
+      // The exact-recovery executor has a tighter physical peer/request budget
+      // than the ordinal scanner. Spend that scarce budget on the recent slots
+      // this selected pass deliberately reserved, then use any remainder for
+      // the historical side. Cursor completion is still merged below in
+      // ordinal order, so this changes latency rather than correctness.
+      .sort((left, right) => {
+        const leftRecent = recentOrdinalSet.has(left.ordinal);
+        const rightRecent = recentOrdinalSet.has(right.ordinal);
+        if (leftRecent !== rightRecent) return leftRecent ? -1 : 1;
+        return leftRecent ? right.ordinal - left.ordinal : left.ordinal - right.ordinal;
+      });
     if (!staleTarget && recoveryTargets.length > 0 && deps.recoverPendingOrdinals) {
       const recovery = await deps.recoverPendingOrdinals(
         localCgId,
@@ -331,7 +376,11 @@ export async function reconcileContextGraph(
   } else if (!hasUnvisitedCandidates) {
     state.scanOrdinal = state.watermark;
   } else if (ordinals.length > 0) {
-    state.scanOrdinal = ordinals[ordinals.length - 1]! + 1;
+    // A recent-priority ordinal is deliberately held in `ahead`; it must not
+    // jump the historical scan cursor to the chain head. Only the oldest-side
+    // slice advances that cursor, preserving eventual completeness under a
+    // continuously growing graph.
+    state.scanOrdinal = Math.max(state.watermark, historicalContinuationOrdinal);
   }
 
   const pending = ordinalsToReconcile(state, head).length;

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -158,6 +158,104 @@ export interface ReconcileResult {
   staleTarget: boolean;
 }
 
+interface OrdinalPassPlan {
+  /** Oldest outstanding ordinals that advance the durable scan cursor. */
+  historicalOrdinals: readonly number[];
+  /** Newest outstanding ordinals sampled only to reduce head latency. */
+  recentOrdinals: readonly number[];
+  /** Deterministic ordinal-ordered union used by the reconciliation workers. */
+  ordinals: readonly number[];
+  /** True when this pass deliberately sampled both ends of the inventory. */
+  usesRecentLane: boolean;
+  hasUnvisitedCandidates: boolean;
+  /** Next cursor derived exclusively from the oldest-side slice. */
+  historicalContinuationOrdinal: number;
+  /** Priority comparator for the bounded exact-recovery queue. */
+  compareRecoveryTargets: (left: OrdinalRecoveryTarget, right: OrdinalRecoveryTarget) => number;
+  /** Derive the next durable scan cursor without conflating recovery order. */
+  nextScanOrdinal: (input: {
+    watermark: number;
+    recoveryContinuationOrdinal: number | undefined;
+    recoveryAttempted: boolean;
+    recoveryCooldownOnly: boolean;
+  }) => number | undefined;
+}
+
+/**
+ * Build one bounded ordinal pass without mutating cursor state.
+ *
+ * The recent lane is a latency sample, not a second cursor. Keeping that
+ * distinction explicit prevents a continuation from the recent-first exact
+ * recovery queue from jumping the durable historical scan over older gaps.
+ */
+function planOrdinalPass(
+  candidates: readonly number[],
+  passLimit: number,
+  requestedRecent: number,
+  watermark: number,
+): OrdinalPassPlan {
+  const recentCount = Number.isFinite(passLimit) && passLimit >= 2
+    ? Math.min(requestedRecent, passLimit - 1)
+    : 0;
+  let historicalOrdinals: readonly number[];
+  let recentOrdinals: readonly number[] = [];
+  if (recentCount > 0 && candidates.length > passLimit) {
+    const historicalCount = passLimit - recentCount;
+    historicalOrdinals = candidates.slice(0, historicalCount);
+    const historicalSet = new Set(historicalOrdinals);
+    recentOrdinals = candidates
+      .slice(-recentCount)
+      .filter((ordinal) => !historicalSet.has(ordinal));
+  } else {
+    historicalOrdinals = candidates.slice(0, passLimit);
+  }
+  const ordinals = [...historicalOrdinals, ...recentOrdinals]
+    .sort((a, b) => a - b);
+  const recentOrdinalSet = new Set(recentOrdinals);
+  const usesRecentLane = recentOrdinals.length > 0;
+  const hasUnvisitedCandidates = candidates.length > ordinals.length;
+  const historicalContinuationOrdinal = historicalOrdinals.length > 0
+    ? historicalOrdinals[historicalOrdinals.length - 1]! + 1
+    : watermark;
+  return {
+    historicalOrdinals,
+    recentOrdinals,
+    ordinals,
+    usesRecentLane,
+    hasUnvisitedCandidates,
+    historicalContinuationOrdinal,
+    compareRecoveryTargets: (left, right) => {
+      const leftRecent = recentOrdinalSet.has(left.ordinal);
+      const rightRecent = recentOrdinalSet.has(right.ordinal);
+      if (leftRecent !== rightRecent) return leftRecent ? -1 : 1;
+      return leftRecent ? right.ordinal - left.ordinal : left.ordinal - right.ordinal;
+    },
+    nextScanOrdinal: ({
+      watermark: currentWatermark,
+      recoveryContinuationOrdinal,
+      recoveryAttempted,
+      recoveryCooldownOnly,
+    }) => {
+      if (usesRecentLane) {
+        return hasUnvisitedCandidates
+          ? Math.max(currentWatermark, historicalContinuationOrdinal)
+          : currentWatermark;
+      }
+      if (
+        recoveryContinuationOrdinal !== undefined
+        && (recoveryAttempted || recoveryCooldownOnly || !hasUnvisitedCandidates)
+      ) {
+        return Math.max(currentWatermark, recoveryContinuationOrdinal);
+      }
+      if (!hasUnvisitedCandidates) return currentWatermark;
+      if (ordinals.length > 0) {
+        return Math.max(currentWatermark, historicalContinuationOrdinal);
+      }
+      return undefined;
+    },
+  };
+}
+
 /**
  * One bounded sweep slice for a single CG: reconcile up to
  * `maxOrdinalsPerPass` ordinals in `[watermark, head)` (skipping ones already
@@ -232,29 +330,16 @@ export async function reconcileContextGraph(
   const requestedRecent = Number.isFinite(deps.recentOrdinalsPerPass)
     ? Math.max(0, Math.floor(deps.recentOrdinalsPerPass ?? 0))
     : 0;
-  const recentCount = Number.isFinite(passLimit) && passLimit >= 2
-    ? Math.min(requestedRecent, passLimit - 1)
-    : 0;
-  let historicalOrdinals: number[];
-  let recentOrdinals: number[] = [];
-  if (recentCount > 0 && candidates.length > passLimit) {
-    const historicalCount = passLimit - recentCount;
-    historicalOrdinals = candidates.slice(0, historicalCount);
-    const historicalSet = new Set(historicalOrdinals);
-    recentOrdinals = candidates
-      .slice(-recentCount)
-      .filter((ordinal) => !historicalSet.has(ordinal));
-  } else {
-    historicalOrdinals = candidates.slice(0, passLimit);
-  }
-  // Cursor mutation and completion absorption stay ordinal-ordered even when
-  // the selected lane used both ends of the outstanding inventory.
-  const ordinals = [...historicalOrdinals, ...recentOrdinals]
-    .sort((a, b) => a - b);
-  const hasUnvisitedCandidates = candidates.length > ordinals.length;
-  const historicalContinuationOrdinal = historicalOrdinals.length > 0
-    ? historicalOrdinals[historicalOrdinals.length - 1]! + 1
-    : state.watermark;
+  const passPlan = planOrdinalPass(
+    candidates,
+    passLimit,
+    requestedRecent,
+    state.watermark,
+  );
+  const {
+    ordinals,
+    hasUnvisitedCandidates,
+  } = passPlan;
   if (headUnavailable) {
     state.scanOrdinal = state.watermark;
   } else {
@@ -304,7 +389,6 @@ export async function reconcileContextGraph(
     await Promise.all(Array.from({ length: workerCount }, () => runOrdinalWorker()));
     if (workerFailed) throw workerError;
 
-    const recentOrdinalSet = new Set(recentOrdinals);
     const recoveryTargets = ordinals
       .map((ordinal) => outcomes.get(ordinal))
       .filter((outcome): outcome is Extract<OrdinalOutcome, { status: 'pending' }> =>
@@ -316,12 +400,7 @@ export async function reconcileContextGraph(
       // this selected pass deliberately reserved, then use any remainder for
       // the historical side. Cursor completion is still merged below in
       // ordinal order, so this changes latency rather than correctness.
-      .sort((left, right) => {
-        const leftRecent = recentOrdinalSet.has(left.ordinal);
-        const rightRecent = recentOrdinalSet.has(right.ordinal);
-        if (leftRecent !== rightRecent) return leftRecent ? -1 : 1;
-        return leftRecent ? right.ordinal - left.ordinal : left.ordinal - right.ordinal;
-      });
+      .sort(passPlan.compareRecoveryTargets);
     if (!staleTarget && recoveryTargets.length > 0 && deps.recoverPendingOrdinals) {
       const recovery = await deps.recoverPendingOrdinals(
         localCgId,
@@ -368,19 +447,21 @@ export async function reconcileContextGraph(
 
   if (staleTarget || headUnavailable) {
     state.scanOrdinal = state.watermark;
-  } else if (
-    recoveryContinuationOrdinal !== undefined
-    && (recoveryAttempted || recoveryCooldownOnly || !hasUnvisitedCandidates)
-  ) {
-    state.scanOrdinal = Math.max(state.watermark, recoveryContinuationOrdinal);
-  } else if (!hasUnvisitedCandidates) {
-    state.scanOrdinal = state.watermark;
-  } else if (ordinals.length > 0) {
-    // A recent-priority ordinal is deliberately held in `ahead`; it must not
-    // jump the historical scan cursor to the chain head. Only the oldest-side
-    // slice advances that cursor, preserving eventual completeness under a
-    // continuously growing graph.
-    state.scanOrdinal = Math.max(state.watermark, historicalContinuationOrdinal);
+  } else {
+    // The recovery executor consumes recent targets first and therefore its
+    // continuation is ordered by recovery priority, not by chain ordinal. It
+    // must never become the durable scan cursor: on a growing graph that would
+    // move the cursor near the head and starve the untouched historical gap.
+    // Advance only from the oldest-side slice. The recovery continuation still
+    // contributes to `hasMore` below, while pending outcomes remain in the
+    // inventory and are revisited on a later historical cycle.
+    const nextScanOrdinal = passPlan.nextScanOrdinal({
+      watermark: state.watermark,
+      recoveryContinuationOrdinal,
+      recoveryAttempted,
+      recoveryCooldownOnly,
+    });
+    if (nextScanOrdinal !== undefined) state.scanOrdinal = nextScanOrdinal;
   }
 
   const pending = ordinalsToReconcile(state, head).length;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -6460,6 +6460,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             }
             : undefined,
           metadataFetcher: selectedMetaFetcher?.strategy,
+          snapshotRecoveryOrder: selectedSwmEnabled ? 'recent-balanced' : 'manifest',
           ensureContextGraph: async (contextGraphId) => {
             const graphManager = new GraphManager(this.store);
             await graphManager.ensureContextGraph(contextGraphId);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3515,6 +3515,27 @@ export class SwmHostModeMethods extends DKGAgentBase {
         ),
       maxOrdinalsPerPass: DKGAgentBase.VM_RECONCILE_BATCH_SIZE,
       maxOrdinalConcurrency: DKGAgentBase.VM_RECONCILE_ORDINAL_CONCURRENCY,
+      // Selected-only Edges are often cold and explicitly ask for a useful
+      // current view. Reserve 75% of each bounded slice for the newest missing
+      // chain ordinals while the remaining 25% advances history. Member/Core
+      // targets retain strict oldest-first order.
+      // Both RFC-64 configuration-only targets and ordinary Edge
+      // subscriptions represent explicit user intent.  A durable Edge
+      // subscription must not silently fall back to the historical-first
+      // Core lane merely because it has a ContextGraphSub row (the public
+      // subscribe API creates exactly that row).  Keep Core reconciliation
+      // historical-first: Core nodes own whole-corpus completeness, while an
+      // Edge user first needs a useful current view without starving history.
+      recentOrdinalsPerPass: (
+        target.kind === 'rfc64-selected'
+        || (
+          (this.config.nodeRole ?? 'edge') === 'edge'
+          && target.kind === 'subscription'
+          && target.sub.subscribed
+        )
+      )
+        ? Math.max(1, Math.floor(DKGAgentBase.VM_RECONCILE_BATCH_SIZE * 0.75))
+        : 0,
       isTargetCurrent: () => isTargetCurrent(),
       persistWatermark: (lcg, watermark) => {
         if (!isTargetCurrent()) return;

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -280,6 +280,11 @@ interface SharedMemorySyncContext {
   };
   /** Optional metadata retrieval strategy; ordinary callers use page fetch. */
   metadataFetcher?: SharedMemoryMetadataFetcher;
+  /**
+   * Selected cold-join recovery may interleave recent snapshots with the
+   * oldest outstanding history. Ordinary sync preserves manifest order.
+   */
+  snapshotRecoveryOrder?: 'manifest' | 'recent-balanced';
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number) => void;
   ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
@@ -320,6 +325,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     stopOnBackoffWorthyFailure = false,
     snapshotEvidencePolicy,
     metadataFetcher,
+    snapshotRecoveryOrder = 'manifest',
     deleteCheckpoint,
     setCheckpoint,
     ensureOwnedMap,
@@ -910,6 +916,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         contextGraphId: pid,
         deadline,
         metaQuads: processed.verifiedMeta,
+        recoveryOrder: snapshotRecoveryOrder,
         publicSnapshotStore,
         fetchSyncPages,
         deleteCheckpoint,
@@ -1202,6 +1209,7 @@ export async function syncPublicSnapshotsForMeta(params: {
   contextGraphId: string;
   deadline: number;
   metaQuads: readonly Quad[];
+  recoveryOrder?: 'manifest' | 'recent-balanced';
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   fetchSyncPages: SharedMemorySyncContext['fetchSyncPages'];
   deleteCheckpoint: (key: string) => void;
@@ -1241,7 +1249,10 @@ export async function syncPublicSnapshotsForMeta(params: {
    */
   yieldedAtDeadline: boolean;
 }> {
-  const snapshots = collectPublicSnapshotMetadata(params.metaQuads);
+  const manifestSnapshots = collectPublicSnapshotMetadata(params.metaQuads);
+  const snapshots = params.recoveryOrder === 'recent-balanced'
+    ? orderPublicSnapshotsForBalancedRecency(manifestSnapshots, params.metaQuads)
+    : manifestSnapshots;
   if (snapshots.length === 0) {
     return {
       bytesReceived: 0,
@@ -1465,6 +1476,113 @@ export function collectPublicSnapshotMetadata(metaQuads: readonly Quad[]): Publi
     byRef.set(ref, metadata);
   }
   return [...byRef.values()];
+}
+
+interface PublicSnapshotRecency {
+  publishedAtMs?: number;
+  ualOrdinal?: bigint;
+}
+
+/**
+ * Build a deterministic 3:1 recent/history walk from verified metadata.
+ *
+ * `publishedAt` and the UAL suffix affect scheduling only; digest/count remain
+ * the integrity boundary. Missing or malformed recency hints fall back to the
+ * manifest index, and a manifest with no usable hints keeps its original order.
+ */
+export function orderPublicSnapshotsForBalancedRecency(
+  snapshots: readonly PublicSnapshotMetadata[],
+  metaQuads: readonly Quad[],
+): PublicSnapshotMetadata[] {
+  const bySubject = new Map<string, {
+    ref?: string;
+    digest?: string;
+    hasSnapshotGraph?: boolean;
+    publishedAtMs?: number;
+    ualOrdinal?: bigint;
+  }>();
+  for (const quad of metaQuads) {
+    if (
+      quad.predicate !== `${DKG}publicSnapshotRef`
+      && quad.predicate !== `${DKG}publicSnapshotGraph`
+      && quad.predicate !== `${DKG}publicQuadsDigest`
+      && quad.predicate !== `${DKG}publishedAt`
+      && quad.predicate !== `${DKG}kaUal`
+    ) continue;
+    const entry = bySubject.get(quad.subject) ?? {};
+    const value = stripLiteral(quad.object)?.trim();
+    if (quad.predicate === `${DKG}publicSnapshotRef`) entry.ref = value;
+    if (quad.predicate === `${DKG}publicSnapshotGraph`) entry.hasSnapshotGraph = true;
+    if (quad.predicate === `${DKG}publicQuadsDigest`) entry.digest = value;
+    if (quad.predicate === `${DKG}publishedAt` && value) {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) entry.publishedAtMs = parsed;
+    }
+    if (quad.predicate === `${DKG}kaUal` && value) {
+      const match = value.match(/\/(\d+)$/);
+      if (match) {
+        try { entry.ualOrdinal = BigInt(match[1]!); } catch { /* scheduling hint only */ }
+      }
+    }
+    bySubject.set(quad.subject, entry);
+  }
+
+  const recencyByRef = new Map<string, PublicSnapshotRecency>();
+  const newer = (a: PublicSnapshotRecency, b: PublicSnapshotRecency): PublicSnapshotRecency => {
+    if ((b.publishedAtMs ?? -1) !== (a.publishedAtMs ?? -1)) {
+      return (b.publishedAtMs ?? -1) > (a.publishedAtMs ?? -1) ? b : a;
+    }
+    return (b.ualOrdinal ?? -1n) > (a.ualOrdinal ?? -1n) ? b : a;
+  };
+  for (const entry of bySubject.values()) {
+    if (entry.hasSnapshotGraph) continue;
+    const ref = entry.ref ?? entry.digest;
+    if (!ref) continue;
+    const recency: PublicSnapshotRecency = {
+      ...(entry.publishedAtMs !== undefined ? { publishedAtMs: entry.publishedAtMs } : {}),
+      ...(entry.ualOrdinal !== undefined ? { ualOrdinal: entry.ualOrdinal } : {}),
+    };
+    if (recency.publishedAtMs === undefined && recency.ualOrdinal === undefined) continue;
+    const current = recencyByRef.get(ref);
+    recencyByRef.set(ref, current ? newer(current, recency) : recency);
+  }
+  if (recencyByRef.size === 0 || snapshots.length < 2) return [...snapshots];
+
+  const manifestIndex = new Map(snapshots.map((snapshot, index) => [snapshot.ref, index]));
+  const ranked = [...snapshots].sort((a, b) => {
+    const aKey = recencyByRef.get(a.ref);
+    const bKey = recencyByRef.get(b.ref);
+    const aTime = aKey?.publishedAtMs;
+    const bTime = bKey?.publishedAtMs;
+    if (aTime !== undefined || bTime !== undefined) {
+      if (aTime === undefined) return -1;
+      if (bTime === undefined) return 1;
+      if (aTime !== bTime) return aTime - bTime;
+    }
+    const aOrdinal = aKey?.ualOrdinal;
+    const bOrdinal = bKey?.ualOrdinal;
+    if (aOrdinal !== undefined || bOrdinal !== undefined) {
+      if (aOrdinal === undefined) return -1;
+      if (bOrdinal === undefined) return 1;
+      if (aOrdinal !== bOrdinal) return aOrdinal < bOrdinal ? -1 : 1;
+    }
+    return (manifestIndex.get(a.ref) ?? 0) - (manifestIndex.get(b.ref) ?? 0);
+  });
+
+  const ordered: PublicSnapshotMetadata[] = [];
+  let oldest = 0;
+  let newest = ranked.length - 1;
+  while (oldest <= newest) {
+    for (let recent = 0; recent < 3 && oldest <= newest; recent += 1) {
+      ordered.push(ranked[newest]!);
+      newest -= 1;
+    }
+    if (oldest <= newest) {
+      ordered.push(ranked[oldest]!);
+      oldest += 1;
+    }
+  }
+  return ordered;
 }
 
 /**

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -1201,6 +1201,10 @@ export interface PublicSnapshotMetadata {
   ref: string;
   digest: string;
   count: number;
+  /** Optional, non-authoritative scheduling hint parsed with the manifest. */
+  publishedAtMs?: number;
+  /** Optional UAL suffix used only as a deterministic recency fallback. */
+  ualOrdinal?: bigint;
 }
 
 export async function syncPublicSnapshotsForMeta(params: {
@@ -1251,7 +1255,7 @@ export async function syncPublicSnapshotsForMeta(params: {
 }> {
   const manifestSnapshots = collectPublicSnapshotMetadata(params.metaQuads);
   const snapshots = params.recoveryOrder === 'recent-balanced'
-    ? orderPublicSnapshotsForBalancedRecency(manifestSnapshots, params.metaQuads)
+    ? orderPublicSnapshotsForBalancedRecency(manifestSnapshots)
     : manifestSnapshots;
   if (snapshots.length === 0) {
     return {
@@ -1429,21 +1433,41 @@ export async function syncPublicSnapshotsForMeta(params: {
 }
 
 export function collectPublicSnapshotMetadata(metaQuads: readonly Quad[]): PublicSnapshotMetadata[] {
-  const bySubject = new Map<string, { ref?: string; digest?: string; count?: number; hasSnapshotGraph?: boolean }>();
+  const bySubject = new Map<string, {
+    ref?: string;
+    digest?: string;
+    count?: number;
+    hasSnapshotGraph?: boolean;
+    publishedAtMs?: number;
+    ualOrdinal?: bigint;
+  }>();
   for (const quad of metaQuads) {
     if (
       quad.predicate !== `${DKG}publicSnapshotRef` &&
       quad.predicate !== `${DKG}publicSnapshotGraph` &&
       quad.predicate !== `${DKG}publicQuadsDigest` &&
-      quad.predicate !== `${DKG}publicQuadsCount`
+      quad.predicate !== `${DKG}publicQuadsCount` &&
+      quad.predicate !== `${DKG}publishedAt` &&
+      quad.predicate !== `${DKG}kaUal`
     ) {
       continue;
     }
     const entry = bySubject.get(quad.subject) ?? {};
-    if (quad.predicate === `${DKG}publicSnapshotRef`) entry.ref = stripLiteral(quad.object)?.trim();
+    const value = stripLiteral(quad.object)?.trim();
+    if (quad.predicate === `${DKG}publicSnapshotRef`) entry.ref = value;
     if (quad.predicate === `${DKG}publicSnapshotGraph`) entry.hasSnapshotGraph = true;
-    if (quad.predicate === `${DKG}publicQuadsDigest`) entry.digest = stripLiteral(quad.object)?.trim();
+    if (quad.predicate === `${DKG}publicQuadsDigest`) entry.digest = value;
     if (quad.predicate === `${DKG}publicQuadsCount`) entry.count = parseIntegerLiteral(quad.object);
+    if (quad.predicate === `${DKG}publishedAt` && value) {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) entry.publishedAtMs = parsed;
+    }
+    if (quad.predicate === `${DKG}kaUal` && value) {
+      const match = value.match(/\/(\d+)$/);
+      if (match) {
+        try { entry.ualOrdinal = BigInt(match[1]!); } catch { /* scheduling hint only */ }
+      }
+    }
     bySubject.set(quad.subject, entry);
   }
 
@@ -1469,18 +1493,38 @@ export function collectPublicSnapshotMetadata(metaQuads: readonly Quad[]): Publi
       throw new Error(`Shared-memory public snapshot metadata for ${subject} is missing digest/count`);
     }
     const existing = byRef.get(ref);
-    const metadata = { ref, digest: entry.digest, count: entry.count! };
+    const metadata: PublicSnapshotMetadata = {
+      ref,
+      digest: entry.digest,
+      count: entry.count!,
+      ...(entry.publishedAtMs !== undefined ? { publishedAtMs: entry.publishedAtMs } : {}),
+      ...(entry.ualOrdinal !== undefined ? { ualOrdinal: entry.ualOrdinal } : {}),
+    };
     if (existing && (existing.digest !== metadata.digest || existing.count !== metadata.count)) {
       throw new Error(`Conflicting shared-memory public snapshot metadata for ${ref}`);
     }
-    byRef.set(ref, metadata);
+    if (!existing) {
+      byRef.set(ref, metadata);
+      continue;
+    }
+    const newerHints = newerPublicSnapshotRecency(existing, metadata);
+    byRef.set(ref, {
+      ...existing,
+      ...(newerHints.publishedAtMs !== undefined ? { publishedAtMs: newerHints.publishedAtMs } : {}),
+      ...(newerHints.ualOrdinal !== undefined ? { ualOrdinal: newerHints.ualOrdinal } : {}),
+    });
   }
   return [...byRef.values()];
 }
 
-interface PublicSnapshotRecency {
-  publishedAtMs?: number;
-  ualOrdinal?: bigint;
+function newerPublicSnapshotRecency(
+  left: Pick<PublicSnapshotMetadata, 'publishedAtMs' | 'ualOrdinal'>,
+  right: Pick<PublicSnapshotMetadata, 'publishedAtMs' | 'ualOrdinal'>,
+): Pick<PublicSnapshotMetadata, 'publishedAtMs' | 'ualOrdinal'> {
+  if ((right.publishedAtMs ?? -1) !== (left.publishedAtMs ?? -1)) {
+    return (right.publishedAtMs ?? -1) > (left.publishedAtMs ?? -1) ? right : left;
+  }
+  return (right.ualOrdinal ?? -1n) > (left.ualOrdinal ?? -1n) ? right : left;
 }
 
 /**
@@ -1492,75 +1536,25 @@ interface PublicSnapshotRecency {
  */
 export function orderPublicSnapshotsForBalancedRecency(
   snapshots: readonly PublicSnapshotMetadata[],
-  metaQuads: readonly Quad[],
 ): PublicSnapshotMetadata[] {
-  const bySubject = new Map<string, {
-    ref?: string;
-    digest?: string;
-    hasSnapshotGraph?: boolean;
-    publishedAtMs?: number;
-    ualOrdinal?: bigint;
-  }>();
-  for (const quad of metaQuads) {
-    if (
-      quad.predicate !== `${DKG}publicSnapshotRef`
-      && quad.predicate !== `${DKG}publicSnapshotGraph`
-      && quad.predicate !== `${DKG}publicQuadsDigest`
-      && quad.predicate !== `${DKG}publishedAt`
-      && quad.predicate !== `${DKG}kaUal`
-    ) continue;
-    const entry = bySubject.get(quad.subject) ?? {};
-    const value = stripLiteral(quad.object)?.trim();
-    if (quad.predicate === `${DKG}publicSnapshotRef`) entry.ref = value;
-    if (quad.predicate === `${DKG}publicSnapshotGraph`) entry.hasSnapshotGraph = true;
-    if (quad.predicate === `${DKG}publicQuadsDigest`) entry.digest = value;
-    if (quad.predicate === `${DKG}publishedAt` && value) {
-      const parsed = Date.parse(value);
-      if (Number.isFinite(parsed)) entry.publishedAtMs = parsed;
-    }
-    if (quad.predicate === `${DKG}kaUal` && value) {
-      const match = value.match(/\/(\d+)$/);
-      if (match) {
-        try { entry.ualOrdinal = BigInt(match[1]!); } catch { /* scheduling hint only */ }
-      }
-    }
-    bySubject.set(quad.subject, entry);
-  }
-
-  const recencyByRef = new Map<string, PublicSnapshotRecency>();
-  const newer = (a: PublicSnapshotRecency, b: PublicSnapshotRecency): PublicSnapshotRecency => {
-    if ((b.publishedAtMs ?? -1) !== (a.publishedAtMs ?? -1)) {
-      return (b.publishedAtMs ?? -1) > (a.publishedAtMs ?? -1) ? b : a;
-    }
-    return (b.ualOrdinal ?? -1n) > (a.ualOrdinal ?? -1n) ? b : a;
-  };
-  for (const entry of bySubject.values()) {
-    if (entry.hasSnapshotGraph) continue;
-    const ref = entry.ref ?? entry.digest;
-    if (!ref) continue;
-    const recency: PublicSnapshotRecency = {
-      ...(entry.publishedAtMs !== undefined ? { publishedAtMs: entry.publishedAtMs } : {}),
-      ...(entry.ualOrdinal !== undefined ? { ualOrdinal: entry.ualOrdinal } : {}),
-    };
-    if (recency.publishedAtMs === undefined && recency.ualOrdinal === undefined) continue;
-    const current = recencyByRef.get(ref);
-    recencyByRef.set(ref, current ? newer(current, recency) : recency);
-  }
-  if (recencyByRef.size === 0 || snapshots.length < 2) return [...snapshots];
+  if (
+    snapshots.length < 2
+    || !snapshots.some((snapshot) => (
+      snapshot.publishedAtMs !== undefined || snapshot.ualOrdinal !== undefined
+    ))
+  ) return [...snapshots];
 
   const manifestIndex = new Map(snapshots.map((snapshot, index) => [snapshot.ref, index]));
   const ranked = [...snapshots].sort((a, b) => {
-    const aKey = recencyByRef.get(a.ref);
-    const bKey = recencyByRef.get(b.ref);
-    const aTime = aKey?.publishedAtMs;
-    const bTime = bKey?.publishedAtMs;
+    const aTime = a.publishedAtMs;
+    const bTime = b.publishedAtMs;
     if (aTime !== undefined || bTime !== undefined) {
       if (aTime === undefined) return -1;
       if (bTime === undefined) return 1;
       if (aTime !== bTime) return aTime - bTime;
     }
-    const aOrdinal = aKey?.ualOrdinal;
-    const bOrdinal = bKey?.ualOrdinal;
+    const aOrdinal = a.ualOrdinal;
+    const bOrdinal = b.ualOrdinal;
     if (aOrdinal !== undefined || bOrdinal !== undefined) {
       if (aOrdinal === undefined) return -1;
       if (bOrdinal === undefined) return 1;

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -279,6 +279,66 @@ describe('reconcileContextGraph — sweep', () => {
     ]]);
   });
 
+  it('never lets recent recovery continuation starve history while the head grows', async () => {
+    let head = 30;
+    let pass = 0;
+    const attempts: number[][] = [[], [], []];
+    const recoveryCalls: number[][] = [];
+    const { deps } = makeDeps({
+      getKCCount: async () => head,
+      maxOrdinalsPerPass: 10,
+      recentOrdinalsPerPass: 7,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => {
+        attempts[pass]!.push(ordinal);
+        if (ordinal < head - 7) {
+          return { status: 'reconciled', blockNumber: 0 };
+        }
+        return {
+          status: 'pending',
+          recovery: recoveryTarget(ordinal),
+        };
+      },
+      recoverPendingOrdinals: async (_cg, _onchain, targets) => {
+        const ordinals = targets.map(({ ordinal }) => ordinal);
+        recoveryCalls.push(ordinals);
+        const attempted = targets[0]!;
+        return {
+          outcomes: new Map([[
+            attempted.ordinal,
+            { status: 'pending', recovery: attempted } as OrdinalOutcome,
+          ]]),
+          attemptedOrdinals: [attempted.ordinal],
+          continuationOrdinal: targets[1]?.ordinal,
+          hasImmediateRecoveryWork: false,
+        };
+      },
+    });
+    const state = createCursorState(0);
+
+    const first = await reconcileContextGraph(deps, state, 'cg', 1n);
+    expect(first.watermark).toBe(3);
+    expect(state.scanOrdinal).toBe(3);
+
+    head = 35;
+    pass += 1;
+    const second = await reconcileContextGraph(deps, state, 'cg', 1n);
+    expect(second.watermark).toBe(6);
+    expect(state.scanOrdinal).toBe(6);
+
+    head = 40;
+    pass += 1;
+    const third = await reconcileContextGraph(deps, state, 'cg', 1n);
+    expect(third.watermark).toBe(9);
+    expect(state.scanOrdinal).toBe(9);
+
+    expect(attempts).toEqual([
+      [0, 1, 2, 23, 24, 25, 26, 27, 28, 29],
+      [3, 4, 5, 28, 29, 30, 31, 32, 33, 34],
+      [6, 7, 8, 33, 34, 35, 36, 37, 38, 39],
+    ]);
+    expect(recoveryCalls.map((ordinals) => ordinals[0])).toEqual([29, 34, 39]);
+  });
+
   it('runs each bounded slice with capped ordinal concurrency', async () => {
     let active = 0;
     let maxActive = 0;

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -220,6 +220,65 @@ describe('reconcileContextGraph — sweep', () => {
     expect(state.scanOrdinal).toBe(0);
   });
 
+  it('makes the recent head useful while preserving bounded historical progress', async () => {
+    const attempts: number[][] = [[], [], []];
+    let pass = 0;
+    const { deps } = makeDeps({
+      getKCCount: async () => 30,
+      maxOrdinalsPerPass: 10,
+      recentOrdinalsPerPass: 7,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => {
+        attempts[pass]!.push(ordinal);
+        return { status: 'reconciled', blockNumber: 0 };
+      },
+    });
+    const state = createCursorState(0);
+
+    const first = await reconcileContextGraph(deps, state, 'cg', 1n);
+    pass += 1;
+    const second = await reconcileContextGraph(deps, state, 'cg', 1n);
+    pass += 1;
+    const third = await reconcileContextGraph(deps, state, 'cg', 1n);
+
+    expect(attempts).toEqual([
+      [0, 1, 2, 23, 24, 25, 26, 27, 28, 29],
+      [3, 4, 5, 16, 17, 18, 19, 20, 21, 22],
+      [6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    ]);
+    expect([first.hasMore, second.hasMore, third.hasMore]).toEqual([true, true, false]);
+    expect([first.watermark, second.watermark, third.watermark]).toEqual([3, 6, 30]);
+    expect(state.scanOrdinal).toBe(30);
+  });
+
+  it('spends selected exact-recovery budget on recent ordinals before history', async () => {
+    const recoveryCalls: number[][] = [];
+    const { deps } = makeDeps({
+      getKCCount: async () => 30,
+      maxOrdinalsPerPass: 10,
+      recentOrdinalsPerPass: 7,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => ({
+        status: 'pending',
+        recovery: recoveryTarget(ordinal),
+      }),
+      recoverPendingOrdinals: async (_cg, _onchain, targets) => {
+        recoveryCalls.push(targets.map(({ ordinal }) => ordinal));
+        return {
+          outcomes: new Map(),
+          attemptedOrdinals: [targets[0]!.ordinal],
+          continuationOrdinal: targets[1]!.ordinal,
+          hasImmediateRecoveryWork: false,
+        };
+      },
+    });
+
+    await reconcileContextGraph(deps, createCursorState(0), 'cg', 1n);
+
+    expect(recoveryCalls).toEqual([[
+      29, 28, 27, 26, 25, 24, 23,
+      0, 1, 2,
+    ]]);
+  });
+
   it('runs each bounded slice with capped ordinal concurrency', async () => {
     let active = 0;
     let maxActive = 0;

--- a/packages/agent/test/rs-heal-stranded-kc.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc.test.ts
@@ -109,6 +109,9 @@ async function seedOntology(store: OxigraphStore, localCgId: string, onChainId: 
 function makeAgentLike(store: OxigraphStore): unknown {
   return Object.assign(Object.create(DKGAgent.prototype), {
     store,
+    // createVmReconcileDeps now distinguishes explicit Edge subscriptions
+    // from Core-owned historical reconciliation when planning recent slots.
+    config: { nodeRole: 'edge' },
     contextGraphBindingState: new ContextGraphBindingState(),
     rsHealCursorByCg: new Map<string, string>(),
     log: { info: () => undefined, warn: () => undefined, error: () => undefined },

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -5,7 +5,9 @@ import { classifySharedMemoryFreshness } from '../src/sync/shared-memory-freshne
 import { runSyncOnConnect } from '../src/sync/on-connect/sync-on-connect.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../src/sync/durable-session.js';
 import {
+  DKG,
   PEER,
+  callSyncSharedMemoryFromPeerDetailed,
   callSelectedSharedMemoryFromPeerDetailed,
   callSelectedSharedMemorySummary,
   callTrySyncFromPeer,
@@ -18,6 +20,82 @@ import {
 } from './selected-swm-test-helpers.js';
 
 describe('selected RFC-64 SWM lifecycle wiring', () => {
+  it('uses balanced recency only through the selected production lifecycle', async () => {
+    const publicCg = 'selected-balanced-recency';
+    const createManifest = () => {
+      const manifest = snapshotManifest(publicCg, 8);
+      const metaGraph = manifest.meta[0]!.graph;
+      for (let index = 0; index < 8; index += 1) {
+        const subject = `urn:selected-swm-manifest:${index}`;
+        manifest.meta.push(
+          {
+            subject,
+            predicate: `${DKG}publishedAt`,
+            object: `"2026-08-10T22:00:${index.toString().padStart(2, '0')}.000Z"`,
+            graph: metaGraph,
+          },
+          {
+            subject,
+            predicate: `${DKG}kaUal`,
+            object: `"did:dkg:base:84532/0x0000000000000000000000000000000000000001/${100 + index}"`,
+            graph: metaGraph,
+          },
+        );
+      }
+      return manifest;
+    };
+    const selectedManifest = createManifest();
+    const selectedRefs = [...selectedManifest.payloadByRef.keys()];
+    const selectedReads: string[] = [];
+    const selectedHarness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest: selectedManifest,
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+      onSnapshotRead: ({ ref }) => selectedReads.push(ref),
+    });
+
+    const ordinaryManifest = createManifest();
+    const ordinaryRefs = [...ordinaryManifest.payloadByRef.keys()];
+    const ordinaryReads: string[] = [];
+    const ordinaryHarness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest: ordinaryManifest,
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+      onSnapshotRead: ({ ref }) => ordinaryReads.push(ref),
+    });
+
+    const plan = {
+      publicContextGraphIds: [publicCg],
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: [publicCg],
+    };
+    try {
+      await callSelectedSharedMemoryFromPeerDetailed(
+        selectedHarness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: plan,
+        },
+      );
+      await callSyncSharedMemoryFromPeerDetailed(
+        ordinaryHarness.agent,
+        [publicCg],
+        { sharedMemorySyncPlan: plan },
+      );
+
+      expect(selectedReads).toEqual([
+        selectedRefs[7], selectedRefs[6], selectedRefs[5], selectedRefs[0],
+        selectedRefs[4], selectedRefs[3], selectedRefs[2], selectedRefs[1],
+      ]);
+      expect(ordinaryReads).toEqual(ordinaryRefs);
+    } finally {
+      await selectedHarness.close();
+      await ordinaryHarness.close();
+    }
+  });
+
   it('treats a clean selected graph with zero snapshot refs as explicit complete 0/0 coverage', async () => {
     const publicCg = 'selected-empty-snapshot-plane';
     const harness = createSelectedSwmLifecycleHarness({

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -20,7 +20,11 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
-import { syncPublicSnapshotsForMeta } from '../src/sync/requester/shared-memory-sync.js';
+import {
+  orderPublicSnapshotsForBalancedRecency,
+  syncPublicSnapshotsForMeta,
+  type PublicSnapshotMetadata,
+} from '../src/sync/requester/shared-memory-sync.js';
 import {
   recoverContextGraphSwm,
   recoverContextGraphSwmWithProgressRetries,
@@ -160,6 +164,42 @@ describe('recoverContextGraphSwmWithProgressRetries', () => {
 });
 
 describe('syncPublicSnapshotsForMeta', () => {
+  it('prioritizes three recent snapshots for every historical snapshot', () => {
+    const snapshots: PublicSnapshotMetadata[] = Array.from({ length: 8 }, (_, index) => ({
+      ref: `sha256:${index.toString(16).padStart(64, '0')}`,
+      digest: `sha256:${index.toString(16).padStart(64, '0')}`,
+      count: 1,
+    }));
+    const metaQuads: Quad[] = snapshots.flatMap((snapshot, index) => {
+      const subject = `urn:dkg:share:balanced-${index}`;
+      return [
+        { subject, predicate: `${DKG}publicQuadsDigest`, object: `"${snapshot.digest}"`, graph: WS_META },
+        { subject, predicate: `${DKG}publishedAt`, object: `"2026-08-10T22:00:${index.toString().padStart(2, '0')}.000Z"`, graph: WS_META },
+        { subject, predicate: `${DKG}kaUal`, object: `"did:dkg:base:84532/0x0000000000000000000000000000000000000001/${100 + index}"`, graph: WS_META },
+      ];
+    });
+
+    expect(orderPublicSnapshotsForBalancedRecency(snapshots, metaQuads).map(({ ref }) => ref))
+      .toEqual([
+        snapshots[7]!.ref,
+        snapshots[6]!.ref,
+        snapshots[5]!.ref,
+        snapshots[0]!.ref,
+        snapshots[4]!.ref,
+        snapshots[3]!.ref,
+        snapshots[2]!.ref,
+        snapshots[1]!.ref,
+      ]);
+  });
+
+  it('preserves manifest order when no recency evidence exists', () => {
+    const snapshots: PublicSnapshotMetadata[] = [
+      { ref: 'ref-b', digest: 'digest-b', count: 1 },
+      { ref: 'ref-a', digest: 'digest-a', count: 1 },
+    ];
+    expect(orderPublicSnapshotsForBalancedRecency(snapshots, [])).toEqual(snapshots);
+  });
+
   it('retries a cleanly-closed short snapshot response without caching its prefix', async () => {
     const expected: Quad[] = [
       { subject: 'urn:snapshot:a', predicate: STATUS, object: '"one"', graph: '' },

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -21,6 +21,7 @@ import {
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import {
+  collectPublicSnapshotMetadata,
   orderPublicSnapshotsForBalancedRecency,
   syncPublicSnapshotsForMeta,
   type PublicSnapshotMetadata,
@@ -174,12 +175,14 @@ describe('syncPublicSnapshotsForMeta', () => {
       const subject = `urn:dkg:share:balanced-${index}`;
       return [
         { subject, predicate: `${DKG}publicQuadsDigest`, object: `"${snapshot.digest}"`, graph: WS_META },
+        { subject, predicate: `${DKG}publicQuadsCount`, object: '"1"', graph: WS_META },
         { subject, predicate: `${DKG}publishedAt`, object: `"2026-08-10T22:00:${index.toString().padStart(2, '0')}.000Z"`, graph: WS_META },
         { subject, predicate: `${DKG}kaUal`, object: `"did:dkg:base:84532/0x0000000000000000000000000000000000000001/${100 + index}"`, graph: WS_META },
       ];
     });
 
-    expect(orderPublicSnapshotsForBalancedRecency(snapshots, metaQuads).map(({ ref }) => ref))
+    const parsed = collectPublicSnapshotMetadata(metaQuads);
+    expect(orderPublicSnapshotsForBalancedRecency(parsed).map(({ ref }) => ref))
       .toEqual([
         snapshots[7]!.ref,
         snapshots[6]!.ref,
@@ -197,7 +200,7 @@ describe('syncPublicSnapshotsForMeta', () => {
       { ref: 'ref-b', digest: 'digest-b', count: 1 },
       { ref: 'ref-a', digest: 'digest-a', count: 1 },
     ];
-    expect(orderPublicSnapshotsForBalancedRecency(snapshots, [])).toEqual(snapshots);
+    expect(orderPublicSnapshotsForBalancedRecency(snapshots)).toEqual(snapshots);
   });
 
   it('retries a cleanly-closed short snapshot response without caching its prefix', async () => {

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -1872,7 +1872,12 @@ describe('public SWM snapshot coverage (#2050)', () => {
     // 1` below would be measuring something else), and NOTHING may be
     // described (or this row would silently become a second copy of the mixed
     // row above, travelling the described path it is meant to avoid).
-    expect(collectPublicSnapshotMetadata(meta)).toEqual([{ ref: digest, digest, count: payload.length }]);
+    expect(collectPublicSnapshotMetadata(meta)).toEqual([{
+      ref: digest,
+      digest,
+      count: payload.length,
+      publishedAtMs: 0,
+    }]);
     expect(parseGraphScopedSwmRecoveryDescriptors({ contextGraphId: COVERAGE_CG, metaQuads: meta })).toEqual([]);
 
     // The blob is already cached: the state of a node whose earlier pass

--- a/packages/agent/test/vm-reconcile-self-prime.test.ts
+++ b/packages/agent/test/vm-reconcile-self-prime.test.ts
@@ -240,6 +240,57 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     expect(internals.subscribedContextGraphs.size).toBe(0);
   });
 
+  it('gives explicit Edge subscriptions balanced recent VM slots without changing Core ordering', async () => {
+    const target = {
+      kind: 'subscription',
+      sub: {
+        syncMode: 'always-on',
+        subscribed: true,
+        synced: true,
+        onChainId: '298',
+      },
+      onChainId: '298',
+      onChainCgId: 298n,
+      cursor: { watermark: 0, scanOrdinal: 0, ahead: new Map() },
+      watermarkBefore: 0,
+      bindingGeneration: 0,
+      bindingKind: 'authoritative',
+    };
+
+    const edgeChain = new MockChainAdapter();
+    agent = await DKGAgent.create({
+      name: 'Rfc64EdgeSubscribedVmPriority',
+      chainAdapter: edgeChain,
+      nodeRole: 'edge',
+    });
+    stubNode(agent);
+    let deps = (agent as any).createVmReconcileDeps(
+      'edge-selected-cg',
+      (agent as any).vmReconcileLifecycleGeneration,
+      target,
+    );
+    expect(deps.recentOrdinalsPerPass).toBeGreaterThan(0);
+
+    await agent.stop();
+    agent = null;
+    const coreChain = new MockChainAdapter();
+    agent = await DKGAgent.create({
+      name: 'Rfc64CoreHostedVmHistory',
+      chainAdapter: coreChain,
+      nodeRole: 'core',
+    });
+    stubNode(agent);
+    deps = (agent as any).createVmReconcileDeps(
+      'core-hosted-cg',
+      (agent as any).vmReconcileLifecycleGeneration,
+      {
+        ...target,
+        sub: { ...target.sub, coreHosted: true },
+      },
+    );
+    expect(deps.recentOrdinalsPerPass).toBe(0);
+  });
+
   it('preserves selected-only chain binding safety failures without creating cursor state', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'Rfc64SelectedVmAmbiguousBinding', chainAdapter: chain });


### PR DESCRIPTION
## Impact

Cold Edge nodes currently recover a large selected Context Graph strictly from the oldest missing item. That preserves completeness, but it can keep the newest user-visible SWM and VM state unavailable for a long time.

This change gives explicitly selected or subscribed Edge graphs a balanced recovery order:

- SWM walks three recent immutable snapshots for every one historical snapshot.
- VM reserves 75% of each bounded pass for recent missing ordinals and 25% for historical progress.
- Core nodes and ordinary non-selected reconciliation remain oldest-first.
- Digest, count, chain, confirmation-depth, and contiguous-watermark checks are unchanged.

The result is lower time-to-useful-current-state without sacrificing eventual whole-history convergence.

## Before

```mermaid
sequenceDiagram
    participant User as Edge user
    participant Edge as Cold Edge node
    participant History as Historical inventory
    participant Current as Current state

    User->>Edge: Subscribe to a large public graph
    Edge->>History: Recover oldest SWM snapshots first
    Edge->>History: Reconcile oldest VM ordinals first
    History-->>Edge: Long historical prefix
    Edge-->>User: Current state remains unavailable
    Edge->>Current: Reach recent items after the prefix
```

## After

```mermaid
sequenceDiagram
    participant User as Edge user
    participant Edge as Cold Edge node
    participant Recent as Recent inventory
    participant History as Historical inventory
    participant Verify as Integrity checks

    User->>Edge: Subscribe to a large public graph
    loop Bounded recovery pass
        Edge->>Recent: Recover recent SWM snapshots and VM ordinals
        Edge->>History: Advance historical snapshots and ordinals
        Recent-->>Verify: Digest count and chain evidence
        History-->>Verify: Digest count and chain evidence
        Verify-->>Edge: Admit verified material only
    end
    Edge-->>User: Current state becomes useful while history continues
```

## Validation

- Focused chain reconciler, SWM recovery, and selected VM reconciliation tests.
- Full Agent unit lane passed on the combined stack: 191 files, 2,753 tests passed, 5 skipped, 0 failed.
- Live Testnet cold receiver reached 50/50 SWM and 50/50 VM while historical recovery continued.

## Stack

1. This PR: balanced recent and historical recovery.
2. Next: size-aware exact VM microbatches.
3. Final: selected recovery capacity and ordering.
