### PR TITLE
fix(agent): seed selected SWM recovery on cold bootstrap

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -26,6 +26,7 @@ import { Rfc64PublicCatalogReconciliationFailureRegistryV1 } from './rfc64/publi
 import { resolveVmReconcileStartupMaxDelayMs } from './startup-jitter.js';
 import { ContextGraphMembershipPersistScheduler } from './context-graph-membership-persist-scheduler.js';
 import { ContextGraphBindingState } from './context-graph-binding-state.js';
+import { SelectedSwmBootstrapAdmission } from './sync/selected-swm-bootstrap-admission.js';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -1607,21 +1608,8 @@ export class DKGAgentBase {
    * so denied peers must remain eligible on the next reconciler cadence.
    */
   protected readonly lastSyncProgressAt = new Map<string, number>();
-  /**
-   * Complete RFC-64 SWM providers whose most recent selected transfer did not
-   * prove every selected Context Graph complete. The catalog bootstrap may
-   * bypass the generic clean-success freshness gate only while this marker is
-   * present; the ordinary per-peer queue cooldown and reconciler backoff still
-   * bound retries.
-   */
-  protected readonly selectedSwmRetryRequiredPeers = new Set<string>();
-  /**
-   * Complete RFC-64 SWM providers whose one cold-start seed has already been
-   * admitted during this node lifecycle. The lifecycle scheduler owns this
-   * alongside the retry-required marker so bootstrap never has to coordinate
-   * two halves of the same state transition.
-   */
-  protected readonly selectedSwmBootstrapSeededPeers = new Set<string>();
+  /** Peer + selected-CG scoped seed/retry/terminal state for RFC-64 SWM. */
+  protected readonly selectedSwmBootstrapAdmission = new SelectedSwmBootstrapAdmission();
   /**
    * Per-peer sync-reconciler backoff. `failures` is the count of
    * consecutive reconciler attempts that did NOT produce a successful

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1616,6 +1616,13 @@ export class DKGAgentBase {
    */
   protected readonly selectedSwmRetryRequiredPeers = new Set<string>();
   /**
+   * Complete RFC-64 SWM providers whose one cold-start seed has already been
+   * admitted during this node lifecycle. The lifecycle scheduler owns this
+   * alongside the retry-required marker so bootstrap never has to coordinate
+   * two halves of the same state transition.
+   */
+  protected readonly selectedSwmBootstrapSeededPeers = new Set<string>();
+  /**
    * Per-peer sync-reconciler backoff. `failures` is the count of
    * consecutive reconciler attempts that did NOT produce a successful
    * sync; `nextRetryAt` is the epoch-ms before which the reconciler

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4018,6 +4018,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.lastSuccessfulSyncAt.delete(remotePeer);
     this.lastSyncProgressAt.delete(remotePeer);
     this.selectedSwmRetryRequiredPeers.delete(remotePeer);
+    this.selectedSwmBootstrapSeededPeers.delete(remotePeer);
     this.syncReconcilerBackoff.delete(remotePeer);
     this.warmedCores.delete(remotePeer);
     this.warmCoreFailedUnpins.delete(remotePeer);
@@ -4029,12 +4030,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     handleSyncError: (remotePeer: string, err: unknown) => void,
     delayMs = 3000,
   ): boolean {
-    // The same marker represents both an RFC-64-selected provider's first
-    // bounded pull and any continuation required after incomplete coverage.
-    // Establish it before entering the generic scheduler: selected recovery
-    // is independently enabled and must be able to start when broad
-    // sync-on-connect is disabled. Completion clears the marker; cooldown and
-    // reconciler backoff retain it so a later bootstrap pass can resume.
+    const alreadySeeded = this.selectedSwmBootstrapSeededPeers.has(remotePeer);
+    const retryRequired = this.selectedSwmRetryRequiredPeers.has(remotePeer);
+    // This API owns the selected provider's small admission state machine:
+    // seed once per node lifecycle, resume only while exact coverage remains
+    // incomplete, and become a no-op after plane proof clears the retry
+    // marker. Bootstrap therefore never reads or mutates scheduler internals.
+    if (alreadySeeded && !retryRequired) return false;
+    this.selectedSwmBootstrapSeededPeers.add(remotePeer);
     this.selectedSwmRetryRequiredPeers.add(remotePeer);
     return this.queueSyncFromPeerOnConnect(
       remotePeer,
@@ -4379,6 +4382,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       createOperationContext('sync'),
       { requireCompleteProviderMatch: true },
     );
+    if (sharedMemorySyncPlan.publicContextGraphIds.length === 0) {
+      // A provider pin without a matching selected CG is a clean no-work
+      // terminal state, not an incomplete recovery. Clear the retry marker so
+      // periodic bootstrap refreshes do not manufacture an endless loop; the
+      // per-lifecycle seed still prevents immediate reseeding.
+      this.selectedSwmRetryRequiredPeers.delete(remotePeer);
+      return 'not-started';
+    }
     return runSelectedSharedMemoryRetry({
       remotePeer,
       syncingPeers: this.syncingPeers,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -598,7 +598,10 @@ import { VmReconcileShutdownTimeoutError } from './vm-reconcile-service.js';
 import { ContextGraphMembershipPersistShutdownTimeoutError } from './context-graph-membership-persist-scheduler.js';
 import type { DKGAgent } from './dkg-agent.js';
 import { deterministicStartupJitterMs, scheduleAfterStartupJitter } from './startup-jitter.js';
-import { resolveRfc64SelectedRecoveryContextGraphIdsV1 } from './dkg-agent-rfc64-catalog-bootstrap.js';
+import {
+  resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1,
+  resolveRfc64SelectedRecoveryContextGraphIdsV1,
+} from './dkg-agent-rfc64-catalog-bootstrap.js';
 
 const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
 const RFC64_SELECTED_SWM_ADMISSION_PRIORITY = 2_000;
@@ -4017,8 +4020,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.lastSyncDisconnectedAt.delete(remotePeer);
     this.lastSuccessfulSyncAt.delete(remotePeer);
     this.lastSyncProgressAt.delete(remotePeer);
-    this.selectedSwmRetryRequiredPeers.delete(remotePeer);
-    this.selectedSwmBootstrapSeededPeers.delete(remotePeer);
+    this.selectedSwmBootstrapAdmission.clear(remotePeer);
     this.syncReconcilerBackoff.delete(remotePeer);
     this.warmedCores.delete(remotePeer);
     this.warmCoreFailedUnpins.delete(remotePeer);
@@ -4030,21 +4032,30 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     handleSyncError: (remotePeer: string, err: unknown) => void,
     delayMs = 3000,
   ): boolean {
-    const alreadySeeded = this.selectedSwmBootstrapSeededPeers.has(remotePeer);
-    const retryRequired = this.selectedSwmRetryRequiredPeers.has(remotePeer);
-    // This API owns the selected provider's small admission state machine:
-    // seed once per node lifecycle, resume only while exact coverage remains
-    // incomplete, and become a no-op after plane proof clears the retry
-    // marker. Bootstrap therefore never reads or mutates scheduler internals.
-    if (alreadySeeded && !retryRequired) return false;
-    this.selectedSwmBootstrapSeededPeers.add(remotePeer);
-    this.selectedSwmRetryRequiredPeers.add(remotePeer);
+    const selectedContextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(remotePeer);
+    // One graph-scoped owner decides whether this exact peer/scope pair is a
+    // first seed, an incomplete retry, or already terminal. A changed runtime
+    // subscription scope is a new bounded admission.
+    if (!this.selectedSwmBootstrapAdmission.request(remotePeer, selectedContextGraphIds)) {
+      return false;
+    }
     return this.queueSyncFromPeerOnConnect(
       remotePeer,
       handleSyncError,
       delayMs,
       { selectedSwmRetry: true },
     );
+  }
+
+  selectedSwmBootstrapContextGraphIdsForPeer(
+    this: DKGAgent,
+    remotePeer: string,
+  ): readonly string[] {
+    const selected = new Set(this.config.syncContextGraphs ?? []);
+    return resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1(
+      this.config.rfc64PublicCatalogBootstrap,
+      remotePeer,
+    ).filter((contextGraphId) => selected.has(contextGraphId));
   }
 
   queueSyncFromPeerOnConnect(
@@ -4055,7 +4066,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     options: { selectedSwmRetry?: boolean } = {},
   ): boolean {
     const selectedSwmRetryRequired = options.selectedSwmRetry === true
-      && this.selectedSwmRetryRequiredPeers.has(remotePeer);
+      && this.selectedSwmBootstrapAdmission.isRetryRequired(remotePeer);
     // RFC-64 bootstrap is an independently enabled, graph-scoped recovery
     // authority. Its selected provider must be able to resume an incomplete
     // bounded walk even when the operator disabled broad peer-on-connect sync.
@@ -4125,7 +4136,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeer: string,
     handleSyncError: (remotePeer: string, err: unknown) => void,
   ): Promise<void> {
-    if (!this.selectedSwmRetryRequiredPeers.has(remotePeer)) return;
+    if (!this.selectedSwmBootstrapAdmission.isRetryRequired(remotePeer)) return;
     const now = Date.now();
     const backoff = this.syncReconcilerBackoff.get(remotePeer);
     if (backoff && now < backoff.nextRetryAt) return;
@@ -4162,7 +4173,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     probe: SyncReconcilerProbe,
     source: SyncAdmissionSource = 'on-connect',
   ): Promise<SyncReconcilerAttemptOutcome> {
-    if (!this.selectedSwmRetryRequiredPeers.has(remotePeer)) return 'not-started';
+    if (!this.selectedSwmBootstrapAdmission.isRetryRequired(remotePeer)) return 'not-started';
     return this.accountSyncAttemptWithReconciler(
       remotePeer,
       probe,
@@ -4370,10 +4381,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     onSyncAccounting?: (outcome: SyncOnConnectPeerOutcome) => void,
     source: SyncAdmissionSource = 'on-connect',
   ): Promise<SyncOnConnectOutcome | 'not-started'> {
-    if (!this.started || !this.selectedSwmRetryRequiredPeers.has(remotePeer)) {
+    if (!this.started || !this.selectedSwmBootstrapAdmission.isRetryRequired(remotePeer)) {
       return 'not-started';
     }
     if (!this.networkAdmissionCoordinator.isAcceptedPeer(remotePeer)) {
+      return 'not-started';
+    }
+    const requestedContextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(remotePeer);
+    if (requestedContextGraphIds.length === 0) {
+      this.selectedSwmBootstrapAdmission.request(remotePeer, requestedContextGraphIds);
       return 'not-started';
     }
     const sharedMemorySyncPlan = await this.planSharedMemorySyncContextGraphs(
@@ -4383,11 +4399,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       { requireCompleteProviderMatch: true },
     );
     if (sharedMemorySyncPlan.publicContextGraphIds.length === 0) {
-      // A provider pin without a matching selected CG is a clean no-work
-      // terminal state, not an incomplete recovery. Clear the retry marker so
-      // periodic bootstrap refreshes do not manufacture an endless loop; the
-      // per-lifecycle seed still prevents immediate reseeding.
-      this.selectedSwmRetryRequiredPeers.delete(remotePeer);
+      // A configured scope that cannot yet be planned remains retryable. RPC,
+      // binding, or policy evidence may become available on a later bounded
+      // bootstrap pass; only an actually empty operator scope is terminal.
       return 'not-started';
     }
     return runSelectedSharedMemoryRetry({
@@ -6496,6 +6510,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const selectedSwmEnabled = Boolean(
       options?.selectedSwmPriority && publicContextGraphIds.length > 0,
     );
+    const selectedBootstrapOwner = selectedSwmEnabled
+      ? this.selectedSwmBootstrapAdmission.beginTransfer(
+        remotePeerId,
+        publicContextGraphIds,
+      )
+      : null;
     const selectedMetaRetentionBudget = selectedSwmEnabled
       ? (() => {
         const budget = resolveSyncResponderSnapshotPolicy(
@@ -6883,7 +6903,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         === expectedSelectedContextGraphs.size
         && continuationExecution.incompleteContextGraphIds.length === 0;
       if (selectedScopeComplete) {
-        this.selectedSwmRetryRequiredPeers.delete(remotePeerId);
+        this.selectedSwmBootstrapAdmission.markTransferTerminal(selectedBootstrapOwner!);
       }
       // Preserve the raw historical yield/failure counters for diagnostics;
       // the canonical freshness helper bounds the selected continuation's
@@ -6902,13 +6922,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         ? this.getSelectedSwmMetaTransfers().run(
           remotePeerId,
           createSelectedMetaFetcher,
-          (selectedMetaFetcher) => {
-            // Different selected calls for one peer serialize behind this
-            // owner. Mark after ownership begins so an earlier complete call
-            // cannot clear a later queued call's retry requirement.
-            this.selectedSwmRetryRequiredPeers.add(remotePeerId);
-            return runSync(selectedMetaFetcher);
-          },
+          (selectedMetaFetcher) => runSync(selectedMetaFetcher),
         )
         : runSync()
     ), {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4023,6 +4023,27 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.warmCoreFailedUnpins.delete(remotePeer);
   }
 
+  queueSelectedSwmFromPeerOnConnect(
+    this: DKGAgent,
+    remotePeer: string,
+    handleSyncError: (remotePeer: string, err: unknown) => void,
+    delayMs = 3000,
+  ): boolean {
+    // The same marker represents both an RFC-64-selected provider's first
+    // bounded pull and any continuation required after incomplete coverage.
+    // Establish it before entering the generic scheduler: selected recovery
+    // is independently enabled and must be able to start when broad
+    // sync-on-connect is disabled. Completion clears the marker; cooldown and
+    // reconciler backoff retain it so a later bootstrap pass can resume.
+    this.selectedSwmRetryRequiredPeers.add(remotePeer);
+    return this.queueSyncFromPeerOnConnect(
+      remotePeer,
+      handleSyncError,
+      delayMs,
+      { selectedSwmRetry: true },
+    );
+  }
+
   queueSyncFromPeerOnConnect(
     this: DKGAgent,
     remotePeer: string,

--- a/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
@@ -69,8 +69,6 @@ interface BootstrapStateV1 {
   readonly config: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
   readonly targets: MutableTargetStatusV1[];
   readonly ctx: OperationContext;
-  /** Providers whose cold-start selected pull has already been seeded. */
-  readonly seededCompleteSwmProviders: Set<string>;
   closed: boolean;
   running: boolean;
   pass: number;
@@ -156,7 +154,6 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
         updatedAtMs: null,
       })),
       ctx,
-      seededCompleteSwmProviders: new Set(),
       closed: false,
       running: false,
       pass: 0,
@@ -261,27 +258,20 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
             await this.connectToPeerId(providerPeerId, {
               timeoutMs: COMPLETE_SWM_PROVIDER_DIAL_TIMEOUT_MS_V1,
             });
-            // A pre-existing connection has no new connection:open event. Seed
-            // exactly one selected pull per node lifecycle, then only re-admit
-            // it while the selected lane retains its incomplete marker. A
-            // successful plane-proven pass clears that marker, so periodic
-            // catalog refreshes cannot manufacture a new full SWM walk.
-            if (
-              !state.seededCompleteSwmProviders.has(providerPeerId)
-              || this.selectedSwmRetryRequiredPeers.has(providerPeerId)
-            ) {
-              state.seededCompleteSwmProviders.add(providerPeerId);
-              this.queueSelectedSwmFromPeerOnConnect(
-                providerPeerId,
-                (_peerId, error) => {
-                  this.log.warn(
-                    state.ctx,
-                    `RFC-64 complete SWM provider sync failed for ${providerPeerId.slice(-8)}: ${errorMessageV1(error)}`,
-                  );
-                },
-                0,
-              );
-            }
+            // A pre-existing connection has no new connection:open event. Ask
+            // the lifecycle scheduler to seed or resume the selected lane; it
+            // owns the seed/incomplete/complete state transition and becomes a
+            // no-op after exact plane proof.
+            this.queueSelectedSwmFromPeerOnConnect(
+              providerPeerId,
+              (_peerId, error) => {
+                this.log.warn(
+                  state.ctx,
+                  `RFC-64 complete SWM provider sync failed for ${providerPeerId.slice(-8)}: ${errorMessageV1(error)}`,
+                );
+              },
+              0,
+            );
           } catch (error) {
             this.log.warn(
               state.ctx,

--- a/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
@@ -69,6 +69,8 @@ interface BootstrapStateV1 {
   readonly config: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
   readonly targets: MutableTargetStatusV1[];
   readonly ctx: OperationContext;
+  /** Providers whose cold-start selected pull has already been seeded. */
+  readonly seededCompleteSwmProviders: Set<string>;
   closed: boolean;
   running: boolean;
   pass: number;
@@ -154,6 +156,7 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
         updatedAtMs: null,
       })),
       ctx,
+      seededCompleteSwmProviders: new Set(),
       closed: false,
       running: false,
       pass: 0,
@@ -258,20 +261,27 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
             await this.connectToPeerId(providerPeerId, {
               timeoutMs: COMPLETE_SWM_PROVIDER_DIAL_TIMEOUT_MS_V1,
             });
-            // A pre-existing connection has no new connection:open event. Feed
-            // it through the normal cooldown/backoff-aware automatic scheduler
-            // so a selected provider is actionable after every cold start.
-            this.queueSyncFromPeerOnConnect(
-              providerPeerId,
-              (_peerId, error) => {
-                this.log.warn(
-                  state.ctx,
-                  `RFC-64 complete SWM provider sync failed for ${providerPeerId.slice(-8)}: ${errorMessageV1(error)}`,
-                );
-              },
-              0,
-              { selectedSwmRetry: true },
-            );
+            // A pre-existing connection has no new connection:open event. Seed
+            // exactly one selected pull per node lifecycle, then only re-admit
+            // it while the selected lane retains its incomplete marker. A
+            // successful plane-proven pass clears that marker, so periodic
+            // catalog refreshes cannot manufacture a new full SWM walk.
+            if (
+              !state.seededCompleteSwmProviders.has(providerPeerId)
+              || this.selectedSwmRetryRequiredPeers.has(providerPeerId)
+            ) {
+              state.seededCompleteSwmProviders.add(providerPeerId);
+              this.queueSelectedSwmFromPeerOnConnect(
+                providerPeerId,
+                (_peerId, error) => {
+                  this.log.warn(
+                    state.ctx,
+                    `RFC-64 complete SWM provider sync failed for ${providerPeerId.slice(-8)}: ${errorMessageV1(error)}`,
+                  );
+                },
+                0,
+              );
+            }
           } catch (error) {
             this.log.warn(
               state.ctx,

--- a/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
@@ -95,6 +95,17 @@ export function resolveRfc64SelectedRecoveryContextGraphIdsV1(
     .map(({ policyEnvelope }) => policyEnvelope.payload.contextGraphId));
 }
 
+/** Selected recovery scopes for which one peer is explicitly graph-complete. */
+export function resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1(
+  config: Readonly<Rfc64PublicCatalogBootstrapConfigV1> | undefined,
+  providerPeerId: string,
+): readonly string[] {
+  if (config === undefined) return Object.freeze([]);
+  return Object.freeze(config.acceptedPublicPolicies
+    .filter(({ completeSwmProviders = [] }) => completeSwmProviders.includes(providerPeerId))
+    .map(({ policyEnvelope }) => policyEnvelope.payload.contextGraphId));
+}
+
 export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
   /**
    * Exact operator-pinned graph-complete SWM providers for one accepted policy.

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1953,8 +1953,7 @@ export class DKGAgent extends DKGAgentBase {
       try {
         await this.closeSelectedSwmMetaTransfers();
       } finally {
-        this.selectedSwmRetryRequiredPeers.clear();
-        this.selectedSwmBootstrapSeededPeers.clear();
+        this.selectedSwmBootstrapAdmission.clearAll();
       }
     }
     if (this.syncVerifyWorker) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1954,6 +1954,7 @@ export class DKGAgent extends DKGAgentBase {
         await this.closeSelectedSwmMetaTransfers();
       } finally {
         this.selectedSwmRetryRequiredPeers.clear();
+        this.selectedSwmBootstrapSeededPeers.clear();
       }
     }
     if (this.syncVerifyWorker) {

--- a/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
+++ b/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type SelectedSwmBootstrapPhase = 'retry-required' | 'terminal';
+
+export interface SelectedSwmBootstrapAdmissionSnapshot {
+  readonly contextGraphIds: readonly string[];
+  readonly phase: SelectedSwmBootstrapPhase;
+}
+
+export interface SelectedSwmBootstrapTransferOwner {
+  readonly remotePeer: string;
+  readonly contextGraphIds: readonly string[];
+  readonly generation: number;
+}
+
+interface SelectedSwmBootstrapAdmissionState extends SelectedSwmBootstrapAdmissionSnapshot {
+  readonly generation: number;
+}
+
+function canonicalScope(contextGraphIds: readonly string[]): readonly string[] {
+  return Object.freeze([...new Set(contextGraphIds)].sort());
+}
+
+function sameScope(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length
+    && left.every((contextGraphId, index) => contextGraphId === right[index]);
+}
+
+/**
+ * One explicit owner for selected-SWM bootstrap admission state.
+ *
+ * State is peer + graph-scope keyed: completing one scope suppresses duplicate
+ * refreshes for that exact scope, while adding or removing an operator-selected
+ * graph creates a new scope and therefore a new bounded admission.
+ */
+export class SelectedSwmBootstrapAdmission {
+  readonly #byPeer = new Map<string, SelectedSwmBootstrapAdmissionState>();
+  #nextGeneration = 0;
+
+  #replace(
+    remotePeer: string,
+    contextGraphIds: readonly string[],
+    phase: SelectedSwmBootstrapPhase,
+  ): SelectedSwmBootstrapAdmissionState {
+    const state = Object.freeze({
+      contextGraphIds: canonicalScope(contextGraphIds),
+      phase,
+      generation: this.#nextGeneration += 1,
+    });
+    this.#byPeer.set(remotePeer, state);
+    return state;
+  }
+
+  request(remotePeer: string, contextGraphIds: readonly string[]): boolean {
+    const scope = canonicalScope(contextGraphIds);
+    const current = this.#byPeer.get(remotePeer);
+    if (scope.length === 0) {
+      this.#replace(remotePeer, scope, 'terminal');
+      return false;
+    }
+    if (
+      current !== undefined
+      && current.phase === 'terminal'
+      && sameScope(current.contextGraphIds, scope)
+    ) return false;
+    if (current?.phase !== 'retry-required' || !sameScope(current.contextGraphIds, scope)) {
+      this.#replace(remotePeer, scope, 'retry-required');
+    }
+    return true;
+  }
+
+  /**
+   * Claim one concrete transfer generation before it enters peer single-flight.
+   * A later queued transfer or operator scope change supersedes this owner, so
+   * its older completion cannot clear the newer retry requirement.
+   */
+  beginTransfer(
+    remotePeer: string,
+    contextGraphIds: readonly string[],
+  ): SelectedSwmBootstrapTransferOwner {
+    const scope = canonicalScope(contextGraphIds);
+    if (scope.length === 0) {
+      throw new Error('selected SWM transfer requires a non-empty Context Graph scope');
+    }
+    const state = this.#replace(remotePeer, scope, 'retry-required');
+    return Object.freeze({
+      remotePeer,
+      contextGraphIds: state.contextGraphIds,
+      generation: state.generation,
+    });
+  }
+
+  markTransferTerminal(owner: SelectedSwmBootstrapTransferOwner): boolean {
+    const current = this.#byPeer.get(owner.remotePeer);
+    if (
+      current === undefined
+      || current.generation !== owner.generation
+      || !sameScope(current.contextGraphIds, owner.contextGraphIds)
+    ) return false;
+    this.#byPeer.set(owner.remotePeer, Object.freeze({
+      ...current,
+      phase: 'terminal',
+    }));
+    return true;
+  }
+
+  isRetryRequired(remotePeer: string): boolean {
+    return this.#byPeer.get(remotePeer)?.phase === 'retry-required';
+  }
+
+  snapshot(remotePeer: string): SelectedSwmBootstrapAdmissionSnapshot | null {
+    const state = this.#byPeer.get(remotePeer);
+    if (state === undefined) return null;
+    return Object.freeze({
+      contextGraphIds: state.contextGraphIds,
+      phase: state.phase,
+    });
+  }
+
+  clear(remotePeer: string): void {
+    this.#byPeer.delete(remotePeer);
+  }
+
+  clearAll(): void {
+    this.#byPeer.clear();
+  }
+
+  get size(): number {
+    return this.#byPeer.size;
+  }
+}

--- a/packages/agent/test/outbox-shutdown-lifecycle.test.ts
+++ b/packages/agent/test/outbox-shutdown-lifecycle.test.ts
@@ -16,11 +16,11 @@ import {
 } from '../src/sync/selected-swm-meta-fetcher.js';
 import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-meta-transfer-coordinator.js';
 import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
+import { SelectedSwmBootstrapAdmission } from '../src/sync/selected-swm-bootstrap-admission.js';
 
 function syntheticShutdownAgent(): any {
   const agent = Object.create(DKGAgent.prototype) as any;
-  agent.selectedSwmRetryRequiredPeers = new Set<string>();
-  agent.selectedSwmBootstrapSeededPeers = new Set<string>();
+  agent.selectedSwmBootstrapAdmission = new SelectedSwmBootstrapAdmission();
   return agent;
 }
 

--- a/packages/agent/test/outbox-shutdown-lifecycle.test.ts
+++ b/packages/agent/test/outbox-shutdown-lifecycle.test.ts
@@ -20,6 +20,7 @@ import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-m
 function syntheticShutdownAgent(): any {
   const agent = Object.create(DKGAgent.prototype) as any;
   agent.selectedSwmRetryRequiredPeers = new Set<string>();
+  agent.selectedSwmBootstrapSeededPeers = new Set<string>();
   return agent;
 }
 

--- a/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
@@ -31,6 +31,7 @@ import { getRfc64PersistenceRootOwnershipForInventoryV1 } from '../src/rfc64/per
 import {
   RFC64_PERSISTENCE_ROOT_RELATIVE_PATH_V1,
 } from '../src/rfc64/persistence-layout-v1.js';
+import { SelectedSwmBootstrapAdmission } from '../src/sync/selected-swm-bootstrap-admission.js';
 
 const temporaryDirectories: string[] = [];
 const childProcesses = new Set<ChildProcessWithoutNullStreams>();
@@ -53,8 +54,7 @@ function syntheticAgent(dataDirectory?: string): any {
     contextGraphMembershipPersistence: new ContextGraphMembershipPersistScheduler(),
     finalizationRuntime: new FinalizationRuntime(),
     rfc64PersistenceV1: undefined,
-    selectedSwmRetryRequiredPeers: new Set<string>(),
-    selectedSwmBootstrapSeededPeers: new Set<string>(),
+    selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
   });
   return agent;
 }

--- a/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
@@ -54,6 +54,7 @@ function syntheticAgent(dataDirectory?: string): any {
     finalizationRuntime: new FinalizationRuntime(),
     rfc64PersistenceV1: undefined,
     selectedSwmRetryRequiredPeers: new Set<string>(),
+    selectedSwmBootstrapSeededPeers: new Set<string>(),
   });
   return agent;
 }

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -991,8 +991,13 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect(queue).toHaveBeenCalledTimes(1);
     expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(true);
 
-    // The selected producer clears this marker only after exact plane proof.
-    (receiver as any).selectedSwmRetryRequiredPeers.delete(providerPeerId);
+    // No configured selected Context Graph is eligible for this provider. The
+    // production selected retry path must classify that as clean no-work and
+    // clear its marker before the next bootstrap pass.
+    (receiver as any).networkAdmissionCoordinator.isAcceptedPeer = () => true;
+    await expect((receiver as any).trySelectedSwmRetryFromPeer(providerPeerId))
+      .resolves.toBe('not-started');
+    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(false);
     await vi.waitFor(() => {
       expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.pass).toBeGreaterThanOrEqual(2);
     }, { timeout: 2_500, interval: 25 });
@@ -1000,6 +1005,53 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
 
     expect(queue).toHaveBeenCalledTimes(1);
     expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(false);
+  });
+
+  it('re-admits an incomplete selected SWM provider on periodic bootstrap refresh', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-rfc64-incomplete-provider-refresh-'));
+    tempDirs.push(dataDir);
+    const providerPeerId = '12D3KooWIncompleteSwmProvider';
+    const receiver = await DKGAgent.create({
+      name: 'incomplete-provider-refresh-receiver',
+      dataDir,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      bootstrapPeers: [],
+      store: new OxigraphStore(),
+      syncOnConnectEnabled: false,
+      syncReconcilerEnabled: false,
+      agentProfileHeartbeatMs: 0,
+      rfc64CatalogDeploymentProfile: NATIVE_DEPLOYMENT,
+      rfc64PublicCatalogBootstrap: {
+        retryIntervalMs: 1_000,
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [],
+          completeSwmProviders: [providerPeerId],
+        }],
+      },
+    });
+    agents.push(receiver);
+    vi.spyOn(receiver, 'connectToPeerId').mockResolvedValue();
+    const queue = vi.spyOn(receiver, 'queueSyncFromPeerOnConnect').mockReturnValue(true);
+
+    await receiver.start();
+    await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
+    expect(queue).toHaveBeenCalledTimes(1);
+    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.pass).toBeGreaterThanOrEqual(2);
+    }, { timeout: 2_500, interval: 25 });
+    await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
+
+    expect(queue).toHaveBeenCalledTimes(2);
+    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(true);
   });
 
   it('rejects bootstrap without persistence before node startup', async () => {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -924,7 +924,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       listenPort: 0,
       bootstrapPeers: [],
       store: new OxigraphStore(),
-      syncOnConnectEnabled: true,
+      syncOnConnectEnabled: false,
       syncReconcilerEnabled: false,
       agentProfileHeartbeatMs: 0,
       rfc64CatalogDeploymentProfile: NATIVE_DEPLOYMENT,
@@ -938,7 +938,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     });
     agents.push(receiver);
     const connect = vi.spyOn(receiver, 'connectToPeerId').mockResolvedValue();
-    const queue = vi.spyOn(receiver, 'queueSyncFromPeerOnConnect').mockReturnValue(true);
+    const queue = vi.spyOn(receiver, 'queueSelectedSwmFromPeerOnConnect').mockReturnValue(true);
 
     await receiver.start();
     await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
@@ -950,8 +950,56 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       '12D3KooWCompleteSwmProvider',
       expect.any(Function),
       0,
-      { selectedSwmRetry: true },
     );
+  });
+
+  it('does not reseed a plane-proven SWM provider on periodic bootstrap refresh', async () => {
+    const policy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-rfc64-complete-provider-refresh-'));
+    tempDirs.push(dataDir);
+    const providerPeerId = '12D3KooWCompleteSwmProvider';
+    const receiver = await DKGAgent.create({
+      name: 'complete-provider-refresh-receiver',
+      dataDir,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      bootstrapPeers: [],
+      store: new OxigraphStore(),
+      syncOnConnectEnabled: false,
+      syncReconcilerEnabled: false,
+      agentProfileHeartbeatMs: 0,
+      rfc64CatalogDeploymentProfile: NATIVE_DEPLOYMENT,
+      rfc64PublicCatalogBootstrap: {
+        retryIntervalMs: 1_000,
+        acceptedPublicPolicies: [{
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [],
+          completeSwmProviders: [providerPeerId],
+        }],
+      },
+    });
+    agents.push(receiver);
+    vi.spyOn(receiver, 'connectToPeerId').mockResolvedValue();
+    const queue = vi.spyOn(receiver, 'queueSyncFromPeerOnConnect').mockReturnValue(true);
+
+    await receiver.start();
+    await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
+    expect(queue).toHaveBeenCalledTimes(1);
+    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(true);
+
+    // The selected producer clears this marker only after exact plane proof.
+    (receiver as any).selectedSwmRetryRequiredPeers.delete(providerPeerId);
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.pass).toBeGreaterThanOrEqual(2);
+    }, { timeout: 2_500, interval: 25 });
+    await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
+
+    expect(queue).toHaveBeenCalledTimes(1);
+    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(false);
   });
 
   it('rejects bootstrap without persistence before node startup', async () => {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -926,6 +926,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       store: new OxigraphStore(),
       syncOnConnectEnabled: false,
       syncReconcilerEnabled: false,
+      syncContextGraphs: [CONTEXT_GRAPH_ID],
       agentProfileHeartbeatMs: 0,
       rfc64CatalogDeploymentProfile: NATIVE_DEPLOYMENT,
       rfc64PublicCatalogBootstrap: {
@@ -971,6 +972,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       store: new OxigraphStore(),
       syncOnConnectEnabled: false,
       syncReconcilerEnabled: false,
+      syncContextGraphs: [CONTEXT_GRAPH_ID],
       agentProfileHeartbeatMs: 0,
       rfc64CatalogDeploymentProfile: NATIVE_DEPLOYMENT,
       rfc64PublicCatalogBootstrap: {
@@ -989,22 +991,25 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     await receiver.start();
     await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
     expect(queue).toHaveBeenCalledTimes(1);
-    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(true);
+    expect((receiver as any).selectedSwmBootstrapAdmission.isRetryRequired(providerPeerId))
+      .toBe(true);
 
-    // No configured selected Context Graph is eligible for this provider. The
-    // production selected retry path must classify that as clean no-work and
-    // clear its marker before the next bootstrap pass.
-    (receiver as any).networkAdmissionCoordinator.isAcceptedPeer = () => true;
-    await expect((receiver as any).trySelectedSwmRetryFromPeer(providerPeerId))
-      .resolves.toBe('not-started');
-    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(false);
+    // Exact plane proof terminates only this peer + selected-graph scope.
+    const completeOwner = (receiver as any).selectedSwmBootstrapAdmission.beginTransfer(
+      providerPeerId,
+      [CONTEXT_GRAPH_ID],
+    );
+    (receiver as any).selectedSwmBootstrapAdmission.markTransferTerminal(completeOwner);
+    expect((receiver as any).selectedSwmBootstrapAdmission.isRetryRequired(providerPeerId))
+      .toBe(false);
     await vi.waitFor(() => {
       expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.pass).toBeGreaterThanOrEqual(2);
     }, { timeout: 2_500, interval: 25 });
     await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
 
     expect(queue).toHaveBeenCalledTimes(1);
-    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(false);
+    expect((receiver as any).selectedSwmBootstrapAdmission.isRetryRequired(providerPeerId))
+      .toBe(false);
   });
 
   it('re-admits an incomplete selected SWM provider on periodic bootstrap refresh', async () => {
@@ -1025,6 +1030,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       store: new OxigraphStore(),
       syncOnConnectEnabled: false,
       syncReconcilerEnabled: false,
+      syncContextGraphs: [CONTEXT_GRAPH_ID],
       agentProfileHeartbeatMs: 0,
       rfc64CatalogDeploymentProfile: NATIVE_DEPLOYMENT,
       rfc64PublicCatalogBootstrap: {
@@ -1043,7 +1049,8 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     await receiver.start();
     await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
     expect(queue).toHaveBeenCalledTimes(1);
-    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(true);
+    expect((receiver as any).selectedSwmBootstrapAdmission.isRetryRequired(providerPeerId))
+      .toBe(true);
 
     await vi.waitFor(() => {
       expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.pass).toBeGreaterThanOrEqual(2);
@@ -1051,7 +1058,72 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
 
     expect(queue).toHaveBeenCalledTimes(2);
-    expect((receiver as any).selectedSwmRetryRequiredPeers.has(providerPeerId)).toBe(true);
+    expect((receiver as any).selectedSwmBootstrapAdmission.isRetryRequired(providerPeerId))
+      .toBe(true);
+  });
+
+  it('re-admits the same provider when a selected Context Graph is added later', async () => {
+    const secondContextGraphId = (
+      '0x2222222222222222222222222222222222222222/selected-later'
+    ) as ContextGraphIdV1;
+    const firstPolicy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const secondPolicy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: secondContextGraphId,
+      ownerAddress: AUTHOR,
+    });
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-rfc64-provider-scope-growth-'));
+    tempDirs.push(dataDir);
+    const providerPeerId = '12D3KooWScopeAwareCompleteSwmProvider';
+    const receiver = await DKGAgent.create({
+      name: 'complete-provider-scope-growth-receiver',
+      dataDir,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      bootstrapPeers: [],
+      store: new OxigraphStore(),
+      syncOnConnectEnabled: false,
+      syncReconcilerEnabled: false,
+      syncContextGraphs: [CONTEXT_GRAPH_ID],
+      agentProfileHeartbeatMs: 0,
+      rfc64CatalogDeploymentProfile: NATIVE_DEPLOYMENT,
+      rfc64PublicCatalogBootstrap: {
+        retryIntervalMs: 1_000,
+        acceptedPublicPolicies: [firstPolicy, secondPolicy].map((policy) => ({
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(policy),
+          targets: [],
+          completeSwmProviders: [providerPeerId],
+        })),
+      },
+    });
+    agents.push(receiver);
+    vi.spyOn(receiver, 'connectToPeerId').mockResolvedValue();
+    const queue = vi.spyOn(receiver, 'queueSyncFromPeerOnConnect').mockReturnValue(true);
+
+    await receiver.start();
+    await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
+    expect(queue).toHaveBeenCalledTimes(1);
+    const firstScopeOwner = (receiver as any).selectedSwmBootstrapAdmission.beginTransfer(
+      providerPeerId,
+      [CONTEXT_GRAPH_ID],
+    );
+    (receiver as any).selectedSwmBootstrapAdmission.markTransferTerminal(firstScopeOwner);
+
+    expect(receiver.trackSyncContextGraph(secondContextGraphId)).toBe(true);
+    await vi.waitFor(() => {
+      expect(receiver.readRfc64PublicCatalogBootstrapStatusV1()?.pass).toBeGreaterThanOrEqual(2);
+    }, { timeout: 2_500, interval: 25 });
+    await receiver.whenRfc64PublicCatalogBootstrapIdleV1();
+
+    expect(queue).toHaveBeenCalledTimes(2);
+    expect((receiver as any).selectedSwmBootstrapAdmission.snapshot(providerPeerId)).toEqual({
+      contextGraphIds: [CONTEXT_GRAPH_ID, secondContextGraphId].sort(),
+      phase: 'retry-required',
+    });
   });
 
   it('rejects bootstrap without persistence before node startup', async () => {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -51,6 +51,9 @@ import {
   snapshotRfc64PublicCatalogBootstrapConfigV1,
 } from '../src/dkg-agent-rfc64-catalog.js';
 import {
+  resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1,
+} from '../src/dkg-agent-rfc64-catalog-bootstrap.js';
+import {
   buildOpenOwnerContextGraphPolicyV1,
   unsignedOpenContextGraphPolicyEnvelopeV1,
 } from '../src/rfc64/open-catalog-policy-v1.js';
@@ -907,6 +910,49 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         policyDigest: `0x${'11'.repeat(32)}`,
       }],
     } as unknown as Rfc64PublicCatalogBootstrapConfigV1)).toThrow(/unknown or missing fields/u);
+  });
+
+  it('keeps mixed graph-complete provider scopes isolated', () => {
+    const peerA = '12D3KooWMixedCompleteProviderA';
+    const peerB = '12D3KooWMixedCompleteProviderB';
+    const contextGraphA = CONTEXT_GRAPH_ID;
+    const contextGraphB =
+      '0x2222222222222222222222222222222222222222/mixed-provider' as ContextGraphIdV1;
+    const config = snapshotRfc64PublicCatalogBootstrapConfigV1({
+      acceptedPublicPolicies: [
+        {
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(
+            buildOpenOwnerContextGraphPolicyV1({
+              networkId: NETWORK_ID,
+              contextGraphId: contextGraphA,
+              ownerAddress: AUTHOR,
+            }),
+          ),
+          targets: [],
+          completeSwmProviders: [peerA],
+        },
+        {
+          policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(
+            buildOpenOwnerContextGraphPolicyV1({
+              networkId: NETWORK_ID,
+              contextGraphId: contextGraphB,
+              ownerAddress: AUTHOR,
+            }),
+          ),
+          targets: [],
+          completeSwmProviders: [peerB],
+        },
+      ],
+    });
+
+    expect(resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1(config, peerA))
+      .toEqual([contextGraphA]);
+    expect(resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1(config, peerB))
+      .toEqual([contextGraphB]);
+    expect(resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1(
+      config,
+      '12D3KooWUnconfiguredProvider',
+    )).toEqual([]);
   });
 
   it('dials and schedules every graph-complete SWM provider during bootstrap', async () => {

--- a/packages/agent/test/selected-swm-bootstrap-admission.test.ts
+++ b/packages/agent/test/selected-swm-bootstrap-admission.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { SelectedSwmBootstrapAdmission } from '../src/sync/selected-swm-bootstrap-admission.js';
+
+const PEER = '12D3KooWScopeAwareSelectedSwmProvider';
+
+function completeScope(
+  admission: SelectedSwmBootstrapAdmission,
+  contextGraphIds: readonly string[],
+): void {
+  const owner = admission.beginTransfer(PEER, contextGraphIds);
+  expect(admission.markTransferTerminal(owner)).toBe(true);
+}
+
+describe('SelectedSwmBootstrapAdmission', () => {
+  it('suppresses only an exact terminal peer and graph scope', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+
+    expect(admission.request(PEER, ['cg-b', 'cg-a', 'cg-a'])).toBe(true);
+    completeScope(admission, ['cg-a', 'cg-b']);
+
+    expect(admission.request(PEER, ['cg-b', 'cg-a'])).toBe(false);
+    expect(admission.snapshot(PEER)).toEqual({
+      contextGraphIds: ['cg-a', 'cg-b'],
+      phase: 'terminal',
+    });
+  });
+
+  it('admits a provider again when the selected graph scope grows', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+
+    expect(admission.request(PEER, ['cg-a'])).toBe(true);
+    completeScope(admission, ['cg-a']);
+    expect(admission.request(PEER, ['cg-a', 'cg-b'])).toBe(true);
+
+    expect(admission.snapshot(PEER)).toEqual({
+      contextGraphIds: ['cg-a', 'cg-b'],
+      phase: 'retry-required',
+    });
+  });
+
+  it('does not let an older in-flight completion suppress a newer scope', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+
+    const first = admission.beginTransfer(PEER, ['cg-a']);
+    expect(admission.request(PEER, ['cg-a', 'cg-b'])).toBe(true);
+    expect(admission.markTransferTerminal(first)).toBe(false);
+
+    expect(admission.snapshot(PEER)).toEqual({
+      contextGraphIds: ['cg-a', 'cg-b'],
+      phase: 'retry-required',
+    });
+  });
+
+  it('lets only the newest queued transfer mark one unchanged scope terminal', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+    const first = admission.beginTransfer(PEER, ['cg-a']);
+    const second = admission.beginTransfer(PEER, ['cg-a']);
+
+    expect(admission.markTransferTerminal(first)).toBe(false);
+    expect(admission.isRetryRequired(PEER)).toBe(true);
+    expect(admission.markTransferTerminal(second)).toBe(true);
+    expect(admission.isRetryRequired(PEER)).toBe(false);
+  });
+
+  it('treats an empty selected scope as terminal no-work', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+
+    expect(admission.request(PEER, [])).toBe(false);
+    expect(admission.snapshot(PEER)).toEqual({
+      contextGraphIds: [],
+      phase: 'terminal',
+    });
+  });
+});

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -4,6 +4,7 @@ import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 import { classifySharedMemoryFreshness } from '../src/sync/shared-memory-freshness.js';
 import { runSyncOnConnect } from '../src/sync/on-connect/sync-on-connect.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../src/sync/durable-session.js';
+import { SelectedSwmBootstrapAdmission } from '../src/sync/selected-swm-bootstrap-admission.js';
 import {
   DKG,
   PEER,
@@ -135,7 +136,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(selected.selectedScopeComplete).toBe(true);
       expect(summary.continuationPasses).toBe(0);
       expect(harness.probes.publicAdmissions()).toBe(1);
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(false);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
     } finally {
       await harness.close();
     }
@@ -169,7 +170,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(selected.shared.failedPhases).toBeGreaterThan(0);
       expect(selected.shared.swmCoverage).toBeUndefined();
       expect(selected.selectedScopeComplete).toBe(false);
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     } finally {
       await harness.close();
     }
@@ -212,7 +213,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(selected.shared.insertedMetaTriples).toBe(0);
       expect(selected.shared.failedPhases).toBeGreaterThan(0);
       expect(selected.selectedScopeComplete).toBe(false);
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     } finally {
       await harness.close();
     }
@@ -250,7 +251,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(selected.shared.swmCoverage).toBeUndefined();
       expect(selected.shared.timedOutPhases).toBeGreaterThan(0);
       expect(selected.selectedScopeComplete).toBe(false);
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     } finally {
       await harness.close();
     }
@@ -286,7 +287,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       lastSuccessfulSyncAt: new Map<string, number>(),
       lastSyncProgressAt: new Map<string, number>(),
       syncReconcilerBackoff: new Map<string, unknown>(),
-      selectedSwmRetryRequiredPeers: new Set<string>(),
+      selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
       getPeerProtocols: async () => [PROTOCOL_SYNC],
       planSharedMemorySyncContextGraphs: async () => mixedPlan,
       resolveRfc64CompleteSwmProviderPeerIdsV1: (contextGraphId: string) => (
@@ -351,7 +352,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       lastSuccessfulSyncAt: new Map<string, number>(),
       lastSyncProgressAt: new Map<string, number>(),
       syncReconcilerBackoff: new Map<string, unknown>(),
-      selectedSwmRetryRequiredPeers: new Set<string>(),
+      selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
       getPeerProtocols: async () => [PROTOCOL_SYNC],
       planSharedMemorySyncContextGraphs: async () => ({
         publicContextGraphIds: [publicCg],
@@ -378,7 +379,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
 
     await callTrySyncFromPeer.call(agent, PEER, (outcome) => accounting.push(outcome));
 
-    expect(agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(false);
+    expect(agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
     expect(agent.lastSuccessfulSyncAt.has(PEER)).toBe(false);
     // No freshness/progress callback means the reconciler wrapper classifies
     // this explicit incomplete result as a failed attempt and grows backoff.
@@ -432,7 +433,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(summary.resolvedSnapshotPlaneIncomplete).toBe(1);
       expect(summary.timedOutPhases).toBe(0);
       expect(summary.backoffWorthyFailures).toBe(0);
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(false);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
       expect(initialSnapshotReads).toBe(672);
       expect(harness.probes.snapshotFetches).toEqual([]);
       expect(harness.probes.maxActiveAdmissions()).toBe(1);
@@ -500,7 +501,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         },
       );
       expect(selected.selectedScopeComplete).toBe(false);
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     } finally {
       await harness.close();
     }
@@ -620,7 +621,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(first.metadataContinuationYields).toBe(1);
       expect(firstSelected.selectedScopeComplete).toBe(false);
       expect(harness.probes.processedMetaBatches).toEqual([]);
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
 
       const queuedPeers: string[] = [];
       const queueAgent = harness.agent as SelectedSwmLifecycleAgentFixture & Record<string, any>;
@@ -661,7 +662,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         harness.probes.metaReturnAcceptedPrefixOnRetryableTransportFailure,
       ).toEqual([true, true]);
       expect(harness.probes.processedMetaBatches).toEqual([manifest.meta]);
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(false);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
     } finally {
       if (previousBudget === undefined) {
         delete process.env.DKG_SWM_CATCHUP_PASS_BUDGET_MS;

--- a/packages/agent/test/selected-swm-lifecycle-queue.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-queue.test.ts
@@ -151,7 +151,7 @@ describe('selected RFC-64 SWM lifecycle queue and budgets', () => {
         snapshotsResolved: 1,
         snapshotsTotal: 2,
       });
-      expect(harness.agent.selectedSwmRetryRequiredPeers.has(PEER)).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     } finally {
       releaseFirst();
       await harness.close();

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -20,6 +20,7 @@ import {
   type SelectedSwmMetaContinuation,
 } from '../src/sync/selected-swm-meta-fetcher.js';
 import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-meta-transfer-coordinator.js';
+import { SelectedSwmBootstrapAdmission } from '../src/sync/selected-swm-bootstrap-admission.js';
 import {
   SyncPageAccumulationLimitError,
   type SyncPageFetchOptions,
@@ -270,7 +271,7 @@ export interface SelectedProviderSelectionAgent {
   lastSuccessfulSyncAt: Map<string, number>;
   lastSyncProgressAt: Map<string, number>;
   syncReconcilerBackoff: Map<string, unknown>;
-  selectedSwmRetryRequiredPeers: Set<string>;
+  selectedSwmBootstrapAdmission: SelectedSwmBootstrapAdmission;
   getPeerProtocols: () => Promise<string[]>;
   planSharedMemorySyncContextGraphs: () => Promise<{
     publicContextGraphIds: string[];
@@ -373,7 +374,7 @@ export interface SelectedSwmLifecycleAgentFixture {
       local?: { rows?: number; bytesEstimate?: number };
     };
   };
-  selectedSwmRetryRequiredPeers: Set<string>;
+  selectedSwmBootstrapAdmission: SelectedSwmBootstrapAdmission;
   store: OxigraphStore;
   writeLocks: Map<string, Promise<void>>;
   publicSnapshotStore: {
@@ -542,7 +543,7 @@ export function createSelectedSwmLifecycleHarness(
         }
         : {}),
     },
-    selectedSwmRetryRequiredPeers: new Set(),
+    selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
     store,
     writeLocks: new Map(),
     publicSnapshotStore: {

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -221,7 +221,7 @@ describe('sync-on-connect churn gates', () => {
       { selectedSwmRetry: true },
     )).toBe(false);
 
-    (agent as any).selectedSwmRetryRequiredPeers.add(PEER_A);
+    (agent as any).selectedSwmBootstrapAdmission.request(PEER_A, ['selected-cg']);
     // A normal connection-open event never inherits the catalog bootstrap's
     // selected retry authority, even while the scheduling marker is present.
     expect((agent as any).queueSyncFromPeerOnConnect(
@@ -258,7 +258,11 @@ describe('sync-on-connect churn gates', () => {
 
     // A later exact completion clears the marker. Even after the short queue
     // cooldown expires, the still-fresh generic success prevents another run.
-    (agent as any).selectedSwmRetryRequiredPeers.delete(PEER_A);
+    const completedOwner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
+      PEER_A,
+      ['selected-cg'],
+    );
+    (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(completedOwner);
     (agent as any).catchupOnConnectAt.set(
       PEER_A,
       Date.now() - CATCHUP_ON_CONNECT_COOLDOWN_MS - 1,
@@ -283,6 +287,7 @@ describe('sync-on-connect churn gates', () => {
     (agent as any).config.rfc64PublicCatalogBootstrap = {
       acceptedPublicPolicies: [{ completeSwmProviders: [PEER_A] }],
     };
+    (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = () => ['selected-cg'];
     (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
     (agent as any).planSharedMemorySyncContextGraphs = async () => ({
       publicContextGraphIds: ['selected-cg'],
@@ -310,7 +315,7 @@ describe('sync-on-connect churn gates', () => {
       errors.push(error);
     };
     (agent as any).lastSuccessfulSyncAt.set(PEER_A, Date.now());
-    expect((agent as any).selectedSwmRetryRequiredPeers.has(PEER_A)).toBe(false);
+    expect((agent as any).selectedSwmBootstrapAdmission.isRetryRequired(PEER_A)).toBe(false);
 
     expect((agent as any).queueSyncFromPeerOnConnect(
       PEER_A,
@@ -322,7 +327,7 @@ describe('sync-on-connect churn gates', () => {
       handleSyncError,
       0,
     )).toBe(true);
-    expect((agent as any).selectedSwmRetryRequiredPeers.has(PEER_A)).toBe(true);
+    expect((agent as any).selectedSwmBootstrapAdmission.isRetryRequired(PEER_A)).toBe(true);
 
     await flushTimers();
     expect(errors).toEqual([]);
@@ -337,13 +342,11 @@ describe('sync-on-connect churn gates', () => {
 
   it('clears selected SWM retry state when network admission rejects a peer', async () => {
     const agent = await createUnstartedAgent('SelectedSwmRetryRejectedPeerCleanup');
-    (agent as any).selectedSwmRetryRequiredPeers.add(PEER_A);
-    (agent as any).selectedSwmBootstrapSeededPeers.add(PEER_A);
+    (agent as any).selectedSwmBootstrapAdmission.request(PEER_A, ['selected-cg']);
 
     (agent as any).clearNetworkRejectedPeerState(PEER_A);
 
-    expect((agent as any).selectedSwmRetryRequiredPeers.has(PEER_A)).toBe(false);
-    expect((agent as any).selectedSwmBootstrapSeededPeers.has(PEER_A)).toBe(false);
+    expect((agent as any).selectedSwmBootstrapAdmission.snapshot(PEER_A)).toBeNull();
   });
 
   it('clears selected SWM retry state after stop drains transfer owners', async () => {
@@ -356,13 +359,11 @@ describe('sync-on-connect churn gates', () => {
     });
     try {
       await agent.start();
-      (agent as any).selectedSwmRetryRequiredPeers.add(PEER_A);
-      (agent as any).selectedSwmBootstrapSeededPeers.add(PEER_A);
+      (agent as any).selectedSwmBootstrapAdmission.request(PEER_A, ['selected-cg']);
 
       await agent.stop();
 
-      expect((agent as any).selectedSwmRetryRequiredPeers.size).toBe(0);
-      expect((agent as any).selectedSwmBootstrapSeededPeers.size).toBe(0);
+      expect((agent as any).selectedSwmBootstrapAdmission.size).toBe(0);
     } finally {
       if ((agent as any).started) await agent.stop().catch(() => undefined);
     }
@@ -466,7 +467,7 @@ describe('sync-on-connect churn gates', () => {
       getPeers: () => [{ toString: () => PEER_A }],
       getConnections: () => [],
     };
-    (agent as any).selectedSwmRetryRequiredPeers.add(PEER_A);
+    (agent as any).selectedSwmBootstrapAdmission.request(PEER_A, ['selected-cg']);
     (agent as any).trySelectedSwmRetryFromPeer = async (
       _peerId: string,
       onSyncAccounting?: (outcome: { fresh: boolean; progress?: boolean }) => void,
@@ -528,7 +529,8 @@ describe('sync-on-connect churn gates', () => {
       }),
       selectedScopeComplete: false,
     });
-    (agent as any).selectedSwmRetryRequiredPeers.add(PEER_A);
+    (agent as any).selectedSwmBootstrapAdmission.request(PEER_A, ['selected-cg']);
+    (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = () => ['selected-cg'];
     (agent as any).syncReconcilerBackoff.set(PEER_A, {
       failures: 1,
       nextRetryAt: Date.now() + 60_000,

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -338,10 +338,12 @@ describe('sync-on-connect churn gates', () => {
   it('clears selected SWM retry state when network admission rejects a peer', async () => {
     const agent = await createUnstartedAgent('SelectedSwmRetryRejectedPeerCleanup');
     (agent as any).selectedSwmRetryRequiredPeers.add(PEER_A);
+    (agent as any).selectedSwmBootstrapSeededPeers.add(PEER_A);
 
     (agent as any).clearNetworkRejectedPeerState(PEER_A);
 
     expect((agent as any).selectedSwmRetryRequiredPeers.has(PEER_A)).toBe(false);
+    expect((agent as any).selectedSwmBootstrapSeededPeers.has(PEER_A)).toBe(false);
   });
 
   it('clears selected SWM retry state after stop drains transfer owners', async () => {
@@ -355,10 +357,12 @@ describe('sync-on-connect churn gates', () => {
     try {
       await agent.start();
       (agent as any).selectedSwmRetryRequiredPeers.add(PEER_A);
+      (agent as any).selectedSwmBootstrapSeededPeers.add(PEER_A);
 
       await agent.stop();
 
       expect((agent as any).selectedSwmRetryRequiredPeers.size).toBe(0);
+      expect((agent as any).selectedSwmBootstrapSeededPeers.size).toBe(0);
     } finally {
       if ((agent as any).started) await agent.stop().catch(() => undefined);
     }

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -273,7 +273,7 @@ describe('sync-on-connect churn gates', () => {
     expect(calls).toEqual([PEER_A]);
   });
 
-  it('resumes RFC-64 selected SWM when broad sync-on-connect is disabled', async () => {
+  it('starts RFC-64 selected SWM cold when broad sync-on-connect is disabled', async () => {
     const agent = await createUnstartedAgent('SelectedSwmRetryIndependentSwitch');
     allowAllNetworkAdmission(agent);
     (agent as any).started = true;
@@ -310,19 +310,19 @@ describe('sync-on-connect churn gates', () => {
       errors.push(error);
     };
     (agent as any).lastSuccessfulSyncAt.set(PEER_A, Date.now());
-    (agent as any).selectedSwmRetryRequiredPeers.add(PEER_A);
+    expect((agent as any).selectedSwmRetryRequiredPeers.has(PEER_A)).toBe(false);
 
     expect((agent as any).queueSyncFromPeerOnConnect(
       PEER_A,
       handleSyncError,
       0,
     )).toBe(false);
-    expect((agent as any).queueSyncFromPeerOnConnect(
+    expect((agent as any).queueSelectedSwmFromPeerOnConnect(
       PEER_A,
       handleSyncError,
       0,
-      { selectedSwmRetry: true },
     )).toBe(true);
+    expect((agent as any).selectedSwmRetryRequiredPeers.has(PEER_A)).toBe(true);
 
     await flushTimers();
     expect(errors).toEqual([]);

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -93,6 +93,7 @@ export default defineConfig({
       "test/catchup-pass-policy.test.ts",
       "test/selected-swm-continuation.test.ts",
       "test/selected-swm-freshness.test.ts",
+      "test/selected-swm-bootstrap-admission.test.ts",
       "test/selected-swm-lifecycle-core.test.ts",
       "test/selected-swm-lifecycle-session.test.ts",
       "test/selected-swm-lifecycle-queue.test.ts",


### PR DESCRIPTION
## Outcome

An RFC-64-selected public Context Graph now starts native SWM recovery on a cold Edge even when broad `syncOnConnect` is disabled. A dedicated admission owner tracks provider plus the canonical selected-CG scope and a monotonic transfer generation. Incomplete scopes remain retryable, exact terminal scopes stop periodic reseeding, runtime scope growth is re-admitted, and an older in-flight completion cannot erase newer selected work.

This is stacked on #2215 and changes only the selected RFC-64 bootstrap lane. Ordinary sync-on-connect behavior remains unchanged.

## Before

```mermaid
sequenceDiagram
    participant Edge as Cold Edge
    participant Bootstrap as RFC-64 bootstrap
    participant Scheduler as Sync scheduler
    participant Provider as Selected SWM provider

    Bootstrap->>Provider: Connect pinned provider
    Bootstrap->>Scheduler: Queue selected retry
    Scheduler->>Scheduler: Retry marker is absent
    Scheduler-->>Bootstrap: Reject admission
    Note over Edge: Broad sync is disabled, so selected SWM stays empty
```

## After

```mermaid
sequenceDiagram
    participant Edge as Cold Edge
    participant Bootstrap as RFC-64 bootstrap
    participant Admission as Selected SWM admission
    participant Scheduler as Sync scheduler
    participant Provider as Selected SWM provider

    Bootstrap->>Provider: Connect pinned provider
    Bootstrap->>Admission: Request provider and selected CG scope
    Admission->>Scheduler: Admit first or incomplete scope
    Scheduler->>Provider: Pull selected SWM scope
    Provider-->>Edge: Verified metadata and snapshot pages
    Scheduler->>Admission: Mark exact generation terminal
    Bootstrap->>Admission: Request same terminal scope later
    Admission-->>Bootstrap: Suppress duplicate pull
    Note over Admission: Expanded scope is admitted as new work
```

## Verification

- Exact head: `48d2797ea7083f576b9e5fb45e7001dd8315e24e`
- Full agent unit suite: 194 files; 2,773 passed; 5 skipped; 0 failed
- Broad focused lane: 7 files; 123 passed; 0 failed
- Selected bootstrap lifecycle subset: 68 passed
- Native production regression subset: 3 passed
- Agent build, type tests, package-root test, and CLI build: passed
- `git diff --check`: clean

The focused regressions cover first admission, incomplete re-admission, exact-terminal suppression, clean no-work, runtime `trackSyncContextGraph` scope growth for the same provider, and stale in-flight completion ownership.

### Live DKG Testnet

Validated exact head `48d2797e` on public CG 302 through the actual DKG Testnet transport with generic sync-on-connect, shared-memory-on-connect, and system-graph sync disabled:

- Exact corpus score before restart: SWM 50/50 and VM 50/50 in 403 ms.
- Three 30-second bootstrap intervals produced one selected transfer and no duplicate walk.
- Store and global sync schedulers stayed healthy with zero rejected sync jobs.
- Graceful restart preserved the same store and peer identity.
- Exact corpus score after restart: SWM 50/50 and VM 50/50 in 373 ms.
- Restart revalidation transferred 900 metadata triples and 0 data triples, then returned to an empty, healthy sync queue.

The complete release gate still requires the separate strict remote-laptop participant run; this PR's bounded single-receiver Testnet gate is green.
