### PR TITLE
docs(release): scope 10.0.14 to proven SWM recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,26 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [10.0.14] - 2026-08-10
 
-A selected-public convergence release. An Edge node can opt a bounded set of publicly readable Context Graphs into RFC-64: signed catalogs drive complete Shared Memory recovery, while Verifiable Memory remains independently derived from finalized blockchain inventory. Both lanes continue across partial progress and provider gaps, and VM recovery batches assets by bounded byte/quad footprint instead of treating an arbitrarily large graph as one transfer. RFC-64 remains opt-in and public-only; private encrypted live sharing is unchanged, and private catalog-based cold join is not part of this release. **No smart-contract changes or deployments are required.**
+A selected-public convergence release. An Edge node can opt a bounded set of publicly readable Context Graphs into RFC-64: an operator-approved graph-complete provider drives bounded native Shared Memory recovery, while Verifiable Memory remains independently derived from finalized blockchain inventory. Both lanes continue across partial progress and provider gaps, and VM recovery batches assets by bounded byte/quad footprint instead of treating an arbitrarily large graph as one transfer. Signed SWM inventory remains shadow evidence in this release and does not drive receiver synchronization. RFC-64 remains opt-in and public-only; private encrypted live sharing is unchanged, and private catalog-based cold join is not part of this release. **No smart-contract changes or deployments are required.**
 
 ### Upgrading from 10.0.13
 
 | Change | Impact | Action |
 | --- | --- | --- |
-| Selected public RFC-64 convergence is usable end to end | For an explicitly selected public CG, signed RFC-64 catalogs recover SWM-only assets and finalized chain inventory recovers VM assets. Empty or disabled configuration remains dormant | Configure `rfc64PublicCatalog` only for public CGs the Edge should maintain; leave it absent to retain 10.0.13 behavior |
+| Selected public RFC-64 convergence is usable end to end | For an explicitly selected public CG, a configured graph-complete provider recovers SWM-only assets through native durable sync and finalized chain inventory recovers VM assets. Empty or disabled configuration remains dormant | Configure `rfc64PublicCatalog` only for public CGs the Edge should maintain, and list a `completeSwmProviders` peer only after establishing that graph-wide property; leave the block absent to retain 10.0.13 behavior |
 | Selected VM recovery uses bounded footprint-aware batches | Multiple small assets can share one recovery request, while byte, quad and heap estimates keep large transfers bounded | No action; the scheduler derives safe batches from authoritative or conservative size evidence |
 | Persisted user subscriptions rehydrate on daemon startup | An operator-selected graph resumes automatically after restart instead of remaining a dormant database row | Set `DKG_CONTEXT_GRAPH_SUBSCRIPTION_REHYDRATION_ENABLED=false` only as an emergency kill-switch |
 | Dashboard SQLite schema 32 → 33 | Selected-VM cursors are fenced by deployment identity; v32 optimization cursors are discarded so a redeploy cannot reuse another chain deployment's numeric IDs or watermark | No action; the graph data is retained and selected VM reconciliation safely resumes from chain inventory |
 
 ### Added
 
-- **Selected public SWM convergence** (#2182, #2210): a verified graph-complete RFC-64 provider receives reserved scheduler priority, partial progress immediately schedules another bounded pass, and completion requires the selected catalog inventory rather than an empty or metadata-only response.
+- **Selected public SWM convergence** (#2182, #2210): an operator-approved graph-complete provider receives reserved scheduler priority, partial progress immediately schedules another bounded pass, and completion requires typed whole-scope snapshot coverage rather than an empty or metadata-only response.
 - **Chain-authoritative selected VM convergence** (#2145, #2146, #2184): the receiver resolves the selected CG against a pinned deployment, enumerates finalized Knowledge Assets from chain truth, persists a deployment-scoped cursor, and continues through bounded provider recovery until the VM inventory is complete.
 - **Footprint-aware VM microbatching** (#2203, #2204): recovery groups as many exact assets as fit the byte, quad and heap budgets, with bounded sizing reads and conservative fallback when evidence is unavailable.
 
 ### Changed
 
-- **RFC-64 catalogs describe SWM only** (#2147): VM is never accepted from a catalog as authority; finalized blockchain inventory remains the VM catalog for both discovery and completeness.
+- **RFC-64 catalogs describe SWM only** (#2147): VM is never accepted from a catalog as authority; finalized blockchain inventory remains the VM catalog for both discovery and completeness. Automatic signed-catalog production from ordinary publication is not enabled by this release.
 - **Cold selected CG bindings resolve directly from chain state** (#2205): a fresh receiver can map the configured public graph to its numeric on-chain identity without relying on pre-existing ontology/store metadata, and ambiguous or stale bindings fail closed.
 - **Publisher workspace-head writes remain on the StorageACK lane** (#2178), preventing unrelated normal-lane store work from delaying acknowledgement-critical state.
 - **Prime Agent legacy chat memory migrates to numbered, graph-scoped working memory** (#2151, #2153) without mistaking orphan lifecycle rows for legacy drafts.
@@ -44,6 +44,7 @@ A selected-public convergence release. An Edge node can opt a bounded set of pub
 ### Known limitations
 
 - RFC-64 catalog convergence is limited to publicly readable CGs in 10.0.14. Private CGs retain existing encrypted live sharing, membership and publication behavior, but an authorized cold receiver does not yet have the analogous private, catalog-based historical SWM recovery lane.
+- Signed SWM author inventory remains shadow/audit evidence. Ordinary KA publication does not automatically author the signed catalog consumed by catalog targets, so 10.0.14 completeness claims are scoped to the configured graph-complete-provider native recovery lane plus chain-authoritative VM recovery.
 
 ## [10.0.13] - 2026-08-07
 

--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -7,10 +7,11 @@ not advance catalogs after ordinary KA publication.
 
 This activation is intentionally selective. The operator supplies a bounded
 manifest of independently verified, finalized public-CG policy envelopes. The
-CG IDs in that manifest are the single source for both:
+CG IDs in that manifest are the single source for:
 
-- durable graph subscriptions; and
-- the optional post-publication catalog producer hook.
+- durable graph subscriptions;
+- explicit signed-catalog targets; and
+- optional graph-complete-provider native SWM recovery.
 
 There is no `sync all public CGs` mode in this release. Existing `contextGraphs`
 selection continues to work normally, and CGs outside the RFC-64 manifest stay
@@ -92,11 +93,12 @@ coverage, while VM remains chain/curator driven. Omit this field unless that
 graph-wide property has been established; ordinary per-author catalog providers
 do not imply it.
 
-`autoPublish` is optional. Configure it on a publisher that should maintain the
-selected public graph's SWM inventory after durable public sharing. A receiver
-can omit `autoPublish` and keep only the bootstrap controls. Inventory work is
-fail-open: an RFC-64 error is logged but does not rewrite an already-committed
-user operation into a failure.
+`autoPublish` is optional and arms the explicit low-level catalog-authoring
+capability. It does **not** make ordinary KA publication author or advance a
+signed catalog in 10.0.14. Ordinary publication only updates the signed SWM
+inventory shadow, which remains audit evidence and does not drive receiver
+synchronization. A receiver can omit `autoPublish` and keep only the bootstrap
+controls.
 
 `deploymentProfile` is also optional on a normal chain-connected node. When it
 is omitted, the agent resolves the chain ID and Knowledge Assets Lifecycle
@@ -134,16 +136,21 @@ Restart the daemon and inspect `GET /api/status`:
 }
 ```
 
-For a release gate, `enabled: true` is not sufficient. Every intended target
-must report `outcome: "applied"`, a non-null `appliedHeadDigest`, and the
-expected `inventoryRowCount`. Validate the same evidence again after receiver
-restart and during provider failover. A `not-found` or `failed` target is a
-failed completeness gate even if the ordinary durable-sync job reports done.
+For a signed-catalog target gate, `enabled: true` is not sufficient. Every
+intended target must report `outcome: "applied"`, a non-null
+`appliedHeadDigest`, and the expected `inventoryRowCount`. A `not-found` or
+`failed` target is a failed catalog gate even if ordinary durable sync reports
+done. For a configuration that uses only `completeSwmProviders`, `targets` may
+be empty; gate that lane by exact SWM asset/byte coverage before and after
+receiver restart, plus exact chain-derived VM coverage. In either mode, test
+provider loss/failover explicitly.
 
 ## Current boundary
 
-This release activates the already-built public RFC-64 catalog data plane for
-an explicit operator-selected set. Provider peer IDs and finalized policy
-envelopes are still pinned inputs. Automatic provider discovery and automatic
-chain-to-policy control-plane generation are later work; this activation does
-not claim either capability.
+This release exposes the already-built public RFC-64 catalog receiver data
+plane for explicit targets and the selected native SWM recovery lane for
+operator-approved graph-complete providers. Provider peer IDs and finalized
+policy envelopes are still pinned inputs. Signed catalog authoring is explicit;
+the ordinary-publication SWM inventory shadow is not connected to receiver
+convergence. Automatic catalog production, automatic provider discovery, and
+automatic chain-to-policy control-plane generation are later work.


### PR DESCRIPTION
## Outcome

The 10.0.14 release contract now matches the runtime that we have actually proven on Testnet:

- selected public SWM converges through native durable sync from an operator-approved graph-complete provider;
- selected public VM converges from finalized blockchain inventory;
- signed SWM inventory remains shadow/audit evidence and does not drive receiver synchronization yet.

This is a documentation-only PR stacked on #2241. It does not weaken or disable the signed-catalog receiver data plane; it removes the incorrect claim that ordinary KA publication automatically authors the signed catalog.

## Before

```mermaid
sequenceDiagram
    participant Publisher
    participant Catalog as Signed SWM catalog
    participant Receiver
    participant Chain
    Publisher->>Catalog: Ordinary publication automatically advances catalog
    Catalog->>Receiver: Catalog drives complete SWM recovery
    Chain->>Receiver: Finalized inventory drives VM recovery
    Note over Publisher,Catalog: This automatic producer wiring is not present in 10.0.14
```

## After

```mermaid
sequenceDiagram
    participant Operator
    participant Provider as Graph-complete SWM provider
    participant Receiver
    participant Chain
    Operator->>Receiver: Select public CG and approve complete provider
    Receiver->>Provider: Run bounded native SWM recovery
    Provider-->>Receiver: Verified snapshot coverage
    Receiver->>Provider: Continue while whole scope is incomplete
    Chain->>Receiver: Finalized inventory drives VM recovery
    Note over Receiver: Signed inventory remains shadow evidence
```

## Verification

- Confirmed there is no production call site from ordinary publication into `recordRfc64PublicCatalogAssetV1`.
- Confirmed the signed SWM inventory lifecycle is documented and implemented as shadow/audit-only.
- Confirmed the selected native lane uses `completeSwmProviders` and typed whole-scope snapshot coverage.
- `git diff --check`: clean.

## Review scope

Please verify release accuracy and operator expectations. There is no runtime or protocol change in this PR.
