### PR TITLE
feat(storage): materialize terminal and quarantine agent profiles

### DIFF
--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -31,6 +31,8 @@ const internalAgentSpecifiers = [
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-commit-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/requester-api-v1.js',
   '@origintrail-official/dkg-agent/dist/system-records/resource-admission-v1-internal.js',
+  '@origintrail-official/dkg-agent/dist/system-records/agent-profile-materializer-bridge-v1-internal.js',
+  '@origintrail-official/dkg-agent/dist/system-records/receiver-v1.js',
 ];
 const publicSystemRecordSpecifiers = [
   '@origintrail-official/dkg-agent/dist/system-records/agent-profile-producer-v1.js',

--- a/packages/agent/src/system-records/agent-profile-materializer-bridge-v1-internal.ts
+++ b/packages/agent/src/system-records/agent-profile-materializer-bridge-v1-internal.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  SYSTEM_RECORD_REQUIRED_DISPATCH_BUDGET_MS,
+  SYSTEM_RECORD_SLICE_TIMEOUT_MS,
+} from '@origintrail-official/dkg-core/system-record-v1';
+import type {
+  SystemRecordApplyOutcomeV1,
+  SystemRecordLaneSessionV1,
+} from '@origintrail-official/dkg-storage';
+
+import type {
+  AgentProfileAdmittedSliceContextV1,
+  AgentProfileAdmittedSliceSnapshotV1,
+} from './admitted-slice-context-v1.js';
+import {
+  assertAuthenticAgentProfileReceiverCandidateV1,
+  type AgentProfileReceiverCandidateV1,
+  type CreateAgentProfileReceiverOptionsV1,
+} from './receiver-v1.js';
+
+export interface AgentProfileMaterializerBridgeDepsV1 {
+  /** Captured from the single authentic managed ownership runtime; never caller supplied. */
+  readonly runtime: AgentProfileMaterializerProofRuntimeV1;
+  /** Exact facade returned by the currently open lifecycle activation. */
+  readonly session: SystemRecordLaneSessionV1;
+  /** Authenticate the original nonrenewable reconciliation context. */
+  readonly inspectAdmittedContext: (
+    context: AgentProfileAdmittedSliceContextV1,
+  ) => AgentProfileAdmittedSliceSnapshotV1;
+  /** Resolve the private session/generation/epoch binding synchronously. */
+  readonly resolveBinding: (
+    context: AgentProfileAdmittedSliceContextV1,
+  ) => AgentProfileMaterializerLaneBindingV1 | null;
+}
+
+/** Private structural port implemented by Storage's non-exported proof registry. */
+export interface AgentProfileMaterializerProofRuntimeV1 {
+  readonly issuer: Readonly<{
+    issueCandidate(input: AgentProfileMaterializerCandidateIssueV1): unknown;
+  }>;
+  readonly consumer: Readonly<{
+    discardProof(proof: unknown): void;
+  }>;
+}
+
+/** Private structural port implemented by the activation-owned lane binding. */
+export interface AgentProfileMaterializerLaneBindingV1 {
+  readonly networkId: AgentProfileReceiverCandidateV1['head']['networkId'];
+  readonly kind: 'agents';
+  readonly mode: 'shadow' | 'authoritative';
+  readonly sessionIdentity: object;
+  readonly activationGeneration: string;
+  readonly childGeneration: string;
+  readonly materializationEpoch: string;
+}
+
+type ActiveCandidateV1 = Extract<
+  AgentProfileReceiverCandidateV1,
+  { readonly operation: 'active' }
+>;
+type TombstoneCandidateV1 = Extract<
+  AgentProfileReceiverCandidateV1,
+  { readonly operation: 'tombstone' }
+>;
+type QuarantineCandidateV1 = Extract<
+  AgentProfileReceiverCandidateV1,
+  { readonly operation: 'quarantine' }
+>;
+
+interface AgentProfileMaterializerIssueCommonV1 {
+  readonly networkId: AgentProfileReceiverCandidateV1['head']['networkId'];
+  readonly kind: 'agents';
+  readonly mode: 'shadow' | 'authoritative';
+  readonly sessionIdentity: object;
+  readonly activationGeneration: string;
+  readonly childGeneration: string;
+  readonly materializationEpoch: string;
+  readonly admittedDeadlineMs: number;
+}
+
+/** Exact private issue shape consumed structurally by Storage's internal issuer. */
+export type AgentProfileMaterializerCandidateIssueV1 =
+  | Readonly<AgentProfileMaterializerIssueCommonV1 & {
+      readonly operation: 'active';
+      readonly head: ActiveCandidateV1['head'];
+      readonly verifiedAuthoritySummary: ActiveCandidateV1['verifiedAuthoritySummary'];
+      readonly canonicalProjectionBytes: ActiveCandidateV1['canonicalProjectionBytes'];
+      readonly projectionQuads: ActiveCandidateV1['projectionQuads'];
+      readonly ownedSubjectTable: ActiveCandidateV1['ownedSubjectTable'];
+    }>
+  | Readonly<AgentProfileMaterializerIssueCommonV1 & {
+      readonly operation: 'tombstone';
+      readonly head: TombstoneCandidateV1['head'];
+      readonly verifiedAuthoritySummary: TombstoneCandidateV1['verifiedAuthoritySummary'];
+      readonly deletionOwnedSubjectTable: TombstoneCandidateV1['deletionOwnedSubjectTable'];
+    }>
+  | Readonly<AgentProfileMaterializerIssueCommonV1 & {
+      readonly operation: 'quarantine';
+      readonly head: QuarantineCandidateV1['head'];
+      readonly verifiedAuthoritySummary: QuarantineCandidateV1['verifiedAuthoritySummary'];
+      readonly canonicalProjectionBytes: QuarantineCandidateV1['canonicalProjectionBytes'];
+      readonly projectionQuads: QuarantineCandidateV1['projectionQuads'];
+      readonly ownedSubjectTable: QuarantineCandidateV1['ownedSubjectTable'];
+      readonly conflictEvidenceDigest: QuarantineCandidateV1['conflictEvidenceDigest'];
+      readonly canonicalConflictEvidenceBytes:
+        QuarantineCandidateV1['canonicalConflictEvidenceBytes'];
+      readonly terminalTransitionConflict: QuarantineCandidateV1['terminalTransitionConflict'];
+    }>;
+
+/**
+ * Default-unused receiver-to-storage preparation. D7 owns production composition;
+ * this module only guarantees that proof authority is created at dispatch and
+ * immediately transferred to the captured lane session.
+ */
+export function createAgentProfileMaterializerPrepareBridgeV1(
+  deps: AgentProfileMaterializerBridgeDepsV1,
+): CreateAgentProfileReceiverOptionsV1['prepareCandidateApply'] {
+  const { runtime, session, inspectAdmittedContext, resolveBinding } = deps;
+  return (candidate, admittedContext, signal) => {
+    assertAuthenticAgentProfileReceiverCandidateV1(candidate);
+    signal.throwIfAborted();
+    const preparedContext = snapshotAdmittedContext(
+      inspectAdmittedContext(admittedContext),
+    );
+    const preparedRemainingMs = preparedContext.admittedDeadlineMs - preparedContext.nowMs;
+    if (preparedRemainingMs > SYSTEM_RECORD_SLICE_TIMEOUT_MS) {
+      throw new Error('agent-profile admitted deadline exceeds its physical slice bound');
+    }
+    const preparedBinding = matchingBinding(
+      resolveBinding(admittedContext),
+      candidate,
+      session,
+    );
+    let invoked = false;
+    return Object.freeze({
+      existingMonotonicDeadlineMs: preparedContext.admittedDeadlineMs,
+      monotonicNowMs: preparedContext.nowMs,
+      apply(admittedDeadlineMs: number) {
+        if (invoked) throw new Error('agent-profile materializer bridge was already invoked');
+        invoked = true;
+        const currentContext = snapshotAdmittedContext(
+          inspectAdmittedContext(admittedContext),
+        );
+        if (currentContext.admittedDeadlineMs !== preparedContext.admittedDeadlineMs) {
+          throw new Error('agent-profile admitted deadline changed before proof issuance');
+        }
+        if (!Number.isSafeInteger(admittedDeadlineMs)
+            || admittedDeadlineMs < 0
+            || admittedDeadlineMs > preparedContext.admittedDeadlineMs) {
+          throw new Error('agent-profile receiver selected an invalid apply deadline');
+        }
+        if (admittedDeadlineMs - currentContext.nowMs
+            < SYSTEM_RECORD_REQUIRED_DISPATCH_BUDGET_MS) {
+          return deferred('insufficient-apply-budget');
+        }
+        if (preparedBinding === null) return deferred('generation-changed');
+        const currentBinding = matchingBinding(
+          resolveBinding(admittedContext),
+          candidate,
+          session,
+        );
+        if (currentBinding === null
+            || !sameBinding(currentBinding, preparedBinding)) {
+          return deferred('generation-changed');
+        }
+        if (session.state === 'shutdown'
+            || session.state === 'unavailable'
+            || session.state === 'detached') {
+          return Object.freeze({ outcome: 'capability-lost' as const });
+        }
+        if (session.state !== 'enabled') return deferred('generation-changed');
+        signal.throwIfAborted();
+        const proof = runtime.issuer.issueCandidate(candidateIssue(
+          candidate,
+          currentBinding,
+          admittedDeadlineMs,
+        ));
+        try {
+          // Invocation transfers ownership. Do not await or recheck cancellation
+          // between issue and this call, and never return the proof to the receiver.
+          return session.applyVerified(proof);
+        } catch (error) {
+          runtime.consumer.discardProof(proof);
+          throw error;
+        }
+      },
+    });
+  };
+}
+
+function matchingBinding(
+  binding: AgentProfileMaterializerLaneBindingV1 | null,
+  candidate: AgentProfileReceiverCandidateV1,
+  session: SystemRecordLaneSessionV1,
+): AgentProfileMaterializerLaneBindingV1 | null {
+  return binding !== null
+    && binding.networkId === candidate.head.networkId
+    && binding.kind === 'agents'
+    && binding.activationGeneration === session.activationGeneration
+    ? binding
+    : null;
+}
+
+function sameBinding(
+  current: AgentProfileMaterializerLaneBindingV1,
+  prepared: AgentProfileMaterializerLaneBindingV1,
+): boolean {
+  return current.networkId === prepared.networkId
+    && current.kind === prepared.kind
+    && current.mode === prepared.mode
+    && current.sessionIdentity === prepared.sessionIdentity
+    && current.activationGeneration === prepared.activationGeneration
+    && current.childGeneration === prepared.childGeneration
+    && current.materializationEpoch === prepared.materializationEpoch;
+}
+
+function deferred(
+  reason: Extract<SystemRecordApplyOutcomeV1, { outcome: 'deferred' }>['reason'],
+): SystemRecordApplyOutcomeV1 {
+  return Object.freeze({ outcome: 'deferred', reason });
+}
+
+function candidateIssue(
+  candidate: AgentProfileReceiverCandidateV1,
+  binding: AgentProfileMaterializerLaneBindingV1,
+  admittedDeadlineMs: number,
+): AgentProfileMaterializerCandidateIssueV1 {
+  const common = Object.freeze({
+    networkId: candidate.head.networkId,
+    kind: binding.kind,
+    mode: binding.mode,
+    sessionIdentity: binding.sessionIdentity,
+    activationGeneration: binding.activationGeneration,
+    childGeneration: binding.childGeneration,
+    materializationEpoch: binding.materializationEpoch,
+    admittedDeadlineMs,
+  });
+  if (candidate.operation === 'tombstone') {
+    return Object.freeze({
+      operation: 'tombstone',
+      ...common,
+      head: candidate.head,
+      verifiedAuthoritySummary: candidate.verifiedAuthoritySummary,
+      deletionOwnedSubjectTable: candidate.deletionOwnedSubjectTable,
+    });
+  }
+  const active = {
+    ...common,
+    head: candidate.head,
+    verifiedAuthoritySummary: candidate.verifiedAuthoritySummary,
+    canonicalProjectionBytes: candidate.canonicalProjectionBytes,
+    projectionQuads: candidate.projectionQuads,
+    ownedSubjectTable: candidate.ownedSubjectTable,
+  } as const;
+  if (candidate.operation === 'active') {
+    return Object.freeze({ operation: 'active', ...active });
+  }
+  return Object.freeze({
+    operation: 'quarantine',
+    ...active,
+    conflictEvidenceDigest: candidate.conflictEvidenceDigest,
+    canonicalConflictEvidenceBytes: candidate.canonicalConflictEvidenceBytes,
+    terminalTransitionConflict: candidate.terminalTransitionConflict,
+  });
+}
+
+function snapshotAdmittedContext(
+  value: AgentProfileAdmittedSliceSnapshotV1,
+): AgentProfileAdmittedSliceSnapshotV1 {
+  if (value === null || typeof value !== 'object'
+      || !Number.isSafeInteger(value.nowMs) || value.nowMs < 0
+      || !Number.isSafeInteger(value.admittedDeadlineMs) || value.admittedDeadlineMs < 0) {
+    throw new Error('agent-profile admission returned an invalid context snapshot');
+  }
+  return Object.freeze({
+    nowMs: value.nowMs,
+    admittedDeadlineMs: value.admittedDeadlineMs,
+  });
+}

--- a/packages/agent/src/system-records/agent-profile-materializer-bridge-v1-internal.ts
+++ b/packages/agent/src/system-records/agent-profile-materializer-bridge-v1-internal.ts
@@ -15,8 +15,8 @@ import type {
 } from './admitted-slice-context-v1.js';
 import {
   assertAuthenticAgentProfileReceiverCandidateV1,
-  type AgentProfileReceiverCandidateV1,
-  type CreateAgentProfileReceiverOptionsV1,
+  type AgentProfileReceiverAnyCandidateV1,
+  type CreateAgentProfileCandidateReceiverOptionsV1,
 } from './receiver-v1.js';
 
 export interface AgentProfileMaterializerBridgeDepsV1 {
@@ -46,7 +46,7 @@ export interface AgentProfileMaterializerProofRuntimeV1 {
 
 /** Private structural port implemented by the activation-owned lane binding. */
 export interface AgentProfileMaterializerLaneBindingV1 {
-  readonly networkId: AgentProfileReceiverCandidateV1['head']['networkId'];
+  readonly networkId: AgentProfileReceiverAnyCandidateV1['head']['networkId'];
   readonly kind: 'agents';
   readonly mode: 'shadow' | 'authoritative';
   readonly sessionIdentity: object;
@@ -56,20 +56,20 @@ export interface AgentProfileMaterializerLaneBindingV1 {
 }
 
 type ActiveCandidateV1 = Extract<
-  AgentProfileReceiverCandidateV1,
+  AgentProfileReceiverAnyCandidateV1,
   { readonly operation: 'active' }
 >;
 type TombstoneCandidateV1 = Extract<
-  AgentProfileReceiverCandidateV1,
+  AgentProfileReceiverAnyCandidateV1,
   { readonly operation: 'tombstone' }
 >;
 type QuarantineCandidateV1 = Extract<
-  AgentProfileReceiverCandidateV1,
+  AgentProfileReceiverAnyCandidateV1,
   { readonly operation: 'quarantine' }
 >;
 
 interface AgentProfileMaterializerIssueCommonV1 {
-  readonly networkId: AgentProfileReceiverCandidateV1['head']['networkId'];
+  readonly networkId: AgentProfileReceiverAnyCandidateV1['head']['networkId'];
   readonly kind: 'agents';
   readonly mode: 'shadow' | 'authoritative';
   readonly sessionIdentity: object;
@@ -115,7 +115,7 @@ export type AgentProfileMaterializerCandidateIssueV1 =
  */
 export function createAgentProfileMaterializerPrepareBridgeV1(
   deps: AgentProfileMaterializerBridgeDepsV1,
-): CreateAgentProfileReceiverOptionsV1['prepareCandidateApply'] {
+): CreateAgentProfileCandidateReceiverOptionsV1['prepareCandidateApply'] {
   const { runtime, session, inspectAdmittedContext, resolveBinding } = deps;
   return (candidate, admittedContext, signal) => {
     assertAuthenticAgentProfileReceiverCandidateV1(candidate);
@@ -191,7 +191,7 @@ export function createAgentProfileMaterializerPrepareBridgeV1(
 
 function matchingBinding(
   binding: AgentProfileMaterializerLaneBindingV1 | null,
-  candidate: AgentProfileReceiverCandidateV1,
+  candidate: AgentProfileReceiverAnyCandidateV1,
   session: SystemRecordLaneSessionV1,
 ): AgentProfileMaterializerLaneBindingV1 | null {
   return binding !== null
@@ -222,7 +222,7 @@ function deferred(
 }
 
 function candidateIssue(
-  candidate: AgentProfileReceiverCandidateV1,
+  candidate: AgentProfileReceiverAnyCandidateV1,
   binding: AgentProfileMaterializerLaneBindingV1,
   admittedDeadlineMs: number,
 ): AgentProfileMaterializerCandidateIssueV1 {

--- a/packages/agent/src/system-records/receiver-v1.ts
+++ b/packages/agent/src/system-records/receiver-v1.ts
@@ -115,6 +115,18 @@ export type AgentProfileArtifactInputV1 =
   | SystemRecordArtifactRepositoryV1
   | AgentProfileArtifactSourcesV1;
 
+const AUTHENTIC_AGENT_PROFILE_RECEIVER_CANDIDATES_V1 = new WeakSet<object>();
+
+/** Internal bridge guard: structural candidates never become materializer authority. */
+export function assertAuthenticAgentProfileReceiverCandidateV1(
+  value: unknown,
+): asserts value is AgentProfileReceiverCandidateV1 {
+  if (value === null || typeof value !== 'object'
+      || !AUTHENTIC_AGENT_PROFILE_RECEIVER_CANDIDATES_V1.has(value)) {
+    throw new Error('agent-profile candidate was not produced by the verified receiver');
+  }
+}
+
 interface CreateAgentProfileReceiverCommonOptionsV1 {
   readonly networkId: NetworkIdV1;
   readonly artifacts: AgentProfileArtifactInputV1;
@@ -496,6 +508,7 @@ function createAgentProfileCandidateReceiverInternalV1(
       verifyAuthorityEnvelope: verifyForCall,
       verifyCurrentBundle,
     });
+    AUTHENTIC_AGENT_PROFILE_RECEIVER_CANDIDATES_V1.add(candidate);
     signal.throwIfAborted();
     let dispatchPrepared = false;
     return Object.freeze({

--- a/packages/agent/src/system-records/receiver-v1.ts
+++ b/packages/agent/src/system-records/receiver-v1.ts
@@ -120,7 +120,7 @@ const AUTHENTIC_AGENT_PROFILE_RECEIVER_CANDIDATES_V1 = new WeakSet<object>();
 /** Internal bridge guard: structural candidates never become materializer authority. */
 export function assertAuthenticAgentProfileReceiverCandidateV1(
   value: unknown,
-): asserts value is AgentProfileReceiverCandidateV1 {
+): asserts value is AgentProfileReceiverAnyCandidateV1 {
   if (value === null || typeof value !== 'object'
       || !AUTHENTIC_AGENT_PROFILE_RECEIVER_CANDIDATES_V1.has(value)) {
     throw new Error('agent-profile candidate was not produced by the verified receiver');

--- a/packages/agent/test/system-record-agent-profile-materializer-bridge-v1.test.ts
+++ b/packages/agent/test/system-record-agent-profile-materializer-bridge-v1.test.ts
@@ -180,6 +180,62 @@ describe('agent-profile private materializer prepare bridge', () => {
       change: (harness: MaterializerBridgeHarness) => harness.rotateChildGeneration(),
       expected: { outcome: 'deferred', reason: 'generation-changed' },
     },
+    // The bridge is a proof-authority boundary, so every binding coordinate it
+    // compares needs a negative case: a guard deleted or wired to the wrong field
+    // would otherwise leave this suite green.
+    //
+    // What each row pins was MEASURED by neutralising one comparison at a time
+    // (replacing it with `true`) and re-running this file. Three of the five
+    // coordinates have a single comparison and so have a sole detector:
+    //   mode -> 'the lane mode changes'
+    //   sessionIdentity -> 'the session identity changes'
+    //   materializationEpoch -> 'the materialization epoch changes'
+    // (childGeneration was already pinned by 'binding generation changes'.)
+    //
+    // networkId and activationGeneration are different, and the difference is
+    // worth stating because it looks like dead code and is not. Each is compared
+    // TWICE -- in matchingBinding against the candidate head / the session, and
+    // again in sameBinding between prepared and current. Neutralising either copy
+    // alone leaves this file green, because the twin still refuses. That is
+    // redundancy, not inertness: neutralising BOTH copies of a coordinate turns
+    // exactly its row red, which is what the last two rows below are for. Read a
+    // green single-copy mutant here as "not isolated", never as "the guard is
+    // dead".
+    //
+    // kind is compared twice as well, and neither copy is testable at all: the
+    // field is typed `'agents'`, so a differing kind is unrepresentable without a
+    // cast. Both copies survive even when neutralised together. It is left
+    // untested deliberately rather than pinned through a cast that would assert
+    // about a state the type forbids.
+    {
+      label: 'the binding leaves the candidate network',
+      change: (harness: MaterializerBridgeHarness) => harness.rebind({
+        networkId: 'base:8453' as AgentProfileMaterializerLaneBindingV1['networkId'],
+      }),
+      expected: { outcome: 'deferred', reason: 'generation-changed' },
+    },
+    {
+      label: 'the binding leaves the session activation',
+      change: (harness: MaterializerBridgeHarness) => harness.rebind({ activationGeneration: '2' }),
+      expected: { outcome: 'deferred', reason: 'generation-changed' },
+    },
+    {
+      label: 'the lane mode changes',
+      change: (harness: MaterializerBridgeHarness) => harness.rebind({ mode: 'shadow' }),
+      expected: { outcome: 'deferred', reason: 'generation-changed' },
+    },
+    {
+      label: 'the session identity changes',
+      change: (harness: MaterializerBridgeHarness) => harness.rebind({
+        sessionIdentity: Object.freeze(Object.create(null) as object),
+      }),
+      expected: { outcome: 'deferred', reason: 'generation-changed' },
+    },
+    {
+      label: 'the materialization epoch changes',
+      change: (harness: MaterializerBridgeHarness) => harness.rebind({ materializationEpoch: '4' }),
+      expected: { outcome: 'deferred', reason: 'generation-changed' },
+    },
     {
       label: 'session capability is lost',
       change: (harness: MaterializerBridgeHarness) => harness.setSessionState('shutdown'),
@@ -250,6 +306,7 @@ interface MaterializerBridgeHarness {
   readonly discardProof: ReturnType<typeof vi.fn>;
   readonly applyVerified: ReturnType<typeof vi.fn>;
   readonly issues: AgentProfileMaterializerCandidateIssueV1[];
+  rebind(patch: Partial<AgentProfileMaterializerLaneBindingV1>): void;
   rotateChildGeneration(): void;
   setSessionState(state: SystemRecordLaneStateV1): void;
 }
@@ -332,6 +389,9 @@ function materializerBridgeHarness(options: Readonly<{
     discardProof,
     applyVerified,
     issues,
+    rebind(patch) {
+      binding = Object.freeze({ ...binding, ...patch });
+    },
     rotateChildGeneration() {
       binding = Object.freeze({
         ...binding,

--- a/packages/agent/test/system-record-agent-profile-materializer-bridge-v1.test.ts
+++ b/packages/agent/test/system-record-agent-profile-materializer-bridge-v1.test.ts
@@ -22,8 +22,9 @@ import type {
   SystemRecordArtifactRepositoryV1,
 } from '../src/system-records/artifact-v1.js';
 import {
-  createAgentProfileReceiverV1,
-  type AgentProfileReceiverCandidateV1,
+  assertAuthenticAgentProfileReceiverCandidateV1,
+  createAgentProfileCandidateReceiverV1,
+  type AgentProfileReceiverAnyCandidateV1,
 } from '../src/system-records/receiver-v1.js';
 import { agentProfileArtifactSources } from './support/agent-profile-artifact-sources-v1-fixture.js';
 import {
@@ -44,7 +45,7 @@ describe('agent-profile private materializer prepare bridge', () => {
     const harness = materializerBridgeHarness();
 
     expect(() => harness.prepareCandidateApply(
-      Object.freeze({ operation: 'active' }) as AgentProfileReceiverCandidateV1,
+      Object.freeze({ operation: 'active' }) as AgentProfileReceiverAnyCandidateV1,
       harness.context,
       new AbortController().signal,
     )).toThrow(/not produced by the verified receiver/);
@@ -115,6 +116,41 @@ describe('agent-profile private materializer prepare bridge', () => {
       terminalTransitionConflict: false,
     });
     expect(harness.issues[0]?.admittedDeadlineMs).toBe(harness.originalDeadlineMs);
+  });
+
+  it.each([
+    { label: 'tombstone' as const, makeFixture: tombstoneFixture },
+    { label: 'quarantine' as const, makeFixture: quarantineFixture },
+  ])('marks a $label candidate authentic at the shared candidate factory', async ({
+    label,
+    makeFixture,
+  }) => {
+    const harness = materializerBridgeHarness();
+    const fixture = await makeFixture();
+    const captured: unknown[] = [];
+    const receiver = createAgentProfileCandidateReceiverV1({
+      networkId: NETWORK,
+      artifacts: agentProfileArtifactSources(fixture.artifacts),
+      nowMs: () => PRODUCER_FIXTURE_NOW_MS,
+      verifyCurrentBundle: () => true,
+      prepareCandidateApply: (candidate, admittedContext, signal) => {
+        captured.push(candidate);
+        return harness.prepareCandidateApply(candidate, admittedContext, signal);
+      },
+    });
+
+    await expect(receiver.receiveCandidate(
+      fixture.row,
+      harness.context,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'applied' });
+
+    // The marker is added in the shared candidate factory, not the active-only
+    // facade, so terminal candidates must pass the authenticity guard.
+    expect(captured).toHaveLength(1);
+    expect(() => assertAuthenticAgentProfileReceiverCandidateV1(captured[0])).not.toThrow();
+    expect((captured[0] as AgentProfileReceiverAnyCandidateV1).operation).toBe(label);
+    expect(harness.issues[0]).toMatchObject({ operation: label });
   });
 
   it.each([
@@ -292,7 +328,7 @@ function createReceiver(
   harness: MaterializerBridgeHarness,
   nowMs: () => number = () => PRODUCER_FIXTURE_NOW_MS,
 ) {
-  return createAgentProfileReceiverV1({
+  return createAgentProfileCandidateReceiverV1({
     networkId: NETWORK,
     artifacts: agentProfileArtifactSources(artifacts),
     nowMs,

--- a/packages/agent/test/system-record-agent-profile-materializer-bridge-v1.test.ts
+++ b/packages/agent/test/system-record-agent-profile-materializer-bridge-v1.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1,
+  type AgentProfileTombstoneHeadObjectV1,
+  type SystemRecordInventoryRowV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+import type {
+  SystemRecordApplyOutcomeV1,
+  SystemRecordLaneSessionV1,
+  SystemRecordLaneStateV1,
+} from '@origintrail-official/dkg-storage';
+import {
+  createAgentProfileAdmittedSliceContextAuthorityV1,
+} from '../src/system-records/admitted-slice-context-v1.js';
+import {
+  createAgentProfileMaterializerPrepareBridgeV1,
+  type AgentProfileMaterializerCandidateIssueV1,
+  type AgentProfileMaterializerLaneBindingV1,
+} from '../src/system-records/agent-profile-materializer-bridge-v1-internal.js';
+import type {
+  SystemRecordArtifactRepositoryV1,
+} from '../src/system-records/artifact-v1.js';
+import {
+  createAgentProfileReceiverV1,
+  type AgentProfileReceiverCandidateV1,
+} from '../src/system-records/receiver-v1.js';
+import { agentProfileArtifactSources } from './support/agent-profile-artifact-sources-v1-fixture.js';
+import {
+  envelopeArtifact,
+  NETWORK,
+  PRODUCER_FIXTURE_NOW_MS,
+  signHeadEnvelope,
+} from './support/agent-profile-producer-v1-fixture.js';
+import {
+  publishedReceiverFixture as publishedFixture,
+} from './support/agent-profile-receiver-v1-fixture.js';
+import {
+  quarantineFixture,
+} from './support/agent-profile-receiver-conflict-v1-fixture.js';
+
+describe('agent-profile private materializer prepare bridge', () => {
+  it('rejects a structural candidate before proof preparation', () => {
+    const harness = materializerBridgeHarness();
+
+    expect(() => harness.prepareCandidateApply(
+      Object.freeze({ operation: 'active' }) as AgentProfileReceiverCandidateV1,
+      harness.context,
+      new AbortController().signal,
+    )).toThrow(/not produced by the verified receiver/);
+    expect(harness.issueCandidate).not.toHaveBeenCalled();
+    expect(harness.applyVerified).not.toHaveBeenCalled();
+  });
+
+  it('issues an active proof with the receiver-clamped monotonic deadline', async () => {
+    const harness = materializerBridgeHarness();
+    const fixture = await publishedFixture();
+    const remainingWallMs = 2_000;
+    const receiver = createReceiver(
+      fixture.store,
+      harness,
+      () => Date.parse(fixture.envelope.object.validUntil) - remainingWallMs,
+    );
+
+    await expect(receiver.receiveActive(
+      fixture.row,
+      harness.context,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'applied' });
+
+    const selectedDeadline = harness.monotonicNowMs + remainingWallMs;
+    expect(harness.issueCandidate).toHaveBeenCalledTimes(1);
+    expect(harness.issueCandidate.mock.calls[0]?.[0]).toMatchObject({
+      operation: 'active',
+      admittedDeadlineMs: selectedDeadline,
+    });
+    expect(harness.issues[0]?.admittedDeadlineMs).toBe(selectedDeadline);
+  });
+
+  it('keeps the original admitted deadline for a tombstone', async () => {
+    const harness = materializerBridgeHarness();
+    const fixture = await tombstoneFixture();
+    const receiver = createReceiver(fixture.artifacts, harness);
+
+    await expect(receiver.receiveCandidate(
+      fixture.row,
+      harness.context,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'applied' });
+
+    expect(harness.issueCandidate).toHaveBeenCalledTimes(1);
+    expect(harness.issueCandidate.mock.calls[0]?.[0]).toMatchObject({
+      operation: 'tombstone',
+      admittedDeadlineMs: harness.originalDeadlineMs,
+    });
+    expect(harness.issues[0]?.admittedDeadlineMs).toBe(harness.originalDeadlineMs);
+  });
+
+  it('maps a quarantine proof without shortening its terminal deadline', async () => {
+    const harness = materializerBridgeHarness();
+    const fixture = await quarantineFixture();
+    const receiver = createReceiver(fixture.artifacts, harness);
+
+    await expect(receiver.receiveCandidate(
+      fixture.row,
+      harness.context,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'applied' });
+
+    expect(harness.issueCandidate).toHaveBeenCalledTimes(1);
+    expect(harness.issueCandidate.mock.calls[0]?.[0]).toMatchObject({
+      operation: 'quarantine',
+      admittedDeadlineMs: harness.originalDeadlineMs,
+      conflictEvidenceDigest: fixture.evidenceDigest,
+      terminalTransitionConflict: false,
+    });
+    expect(harness.issues[0]?.admittedDeadlineMs).toBe(harness.originalDeadlineMs);
+  });
+
+  it.each([
+    {
+      label: 'binding generation changes',
+      change: (harness: MaterializerBridgeHarness) => harness.rotateChildGeneration(),
+      expected: { outcome: 'deferred', reason: 'generation-changed' },
+    },
+    {
+      label: 'session capability is lost',
+      change: (harness: MaterializerBridgeHarness) => harness.setSessionState('shutdown'),
+      expected: { outcome: 'capability-lost' },
+    },
+  ])('issues no proof when $label after preparation', async ({ change, expected }) => {
+    const harness = materializerBridgeHarness();
+    const fixture = await publishedFixture();
+    const receiver = createReceiver(fixture.store, harness);
+    const signal = new AbortController().signal;
+    const prepared = await receiver.prepareActive(fixture.row, signal);
+    const dispatch = await prepared.prepareDispatch(harness.context, signal);
+
+    change(harness);
+
+    await expect(dispatch.dispatch()).resolves.toEqual(expected);
+    expect(harness.issueCandidate).not.toHaveBeenCalled();
+    expect(harness.applyVerified).not.toHaveBeenCalled();
+  });
+
+  it('returns a typed deferral without issuing when direct dispatch lacks budget', async () => {
+    const harness = materializerBridgeHarness({ remainingMs: 1_499 });
+    const fixture = await publishedFixture();
+    const receiver = createReceiver(fixture.store, harness);
+
+    await expect(receiver.receiveActive(
+      fixture.row,
+      harness.context,
+      new AbortController().signal,
+    )).resolves.toEqual({
+      outcome: 'deferred',
+      reason: 'insufficient-apply-budget',
+    });
+    expect(harness.issueCandidate).not.toHaveBeenCalled();
+    expect(harness.applyVerified).not.toHaveBeenCalled();
+  });
+
+  it('discards only a proof whose session transfer throws synchronously', async () => {
+    const synchronous = materializerBridgeHarness({ failure: 'synchronous' });
+    const fixture = await publishedFixture();
+    await expect(createReceiver(fixture.store, synchronous).receiveActive(
+      fixture.row,
+      synchronous.context,
+      new AbortController().signal,
+    )).rejects.toThrow(/synchronous dispatch failure/);
+    expect(synchronous.discardProof).toHaveBeenCalledTimes(1);
+
+    const asynchronous = materializerBridgeHarness({ failure: 'asynchronous' });
+    await expect(createReceiver(fixture.store, asynchronous).receiveActive(
+      fixture.row,
+      asynchronous.context,
+      new AbortController().signal,
+    )).rejects.toThrow(/asynchronous settlement failure/);
+    expect(asynchronous.discardProof).not.toHaveBeenCalled();
+  });
+});
+
+interface MaterializerBridgeHarness {
+  readonly prepareCandidateApply: ReturnType<
+    typeof createAgentProfileMaterializerPrepareBridgeV1
+  >;
+  readonly context: ReturnType<
+    ReturnType<typeof createAgentProfileAdmittedSliceContextAuthorityV1>['mint']
+  >;
+  readonly monotonicNowMs: number;
+  readonly originalDeadlineMs: number;
+  readonly issueCandidate: ReturnType<typeof vi.fn>;
+  readonly discardProof: ReturnType<typeof vi.fn>;
+  readonly applyVerified: ReturnType<typeof vi.fn>;
+  readonly issues: AgentProfileMaterializerCandidateIssueV1[];
+  rotateChildGeneration(): void;
+  setSessionState(state: SystemRecordLaneStateV1): void;
+}
+
+function materializerBridgeHarness(options: Readonly<{
+  remainingMs?: number;
+  failure?: 'synchronous' | 'asynchronous';
+}> = {}): MaterializerBridgeHarness {
+  const proofs = new WeakMap<object, AgentProfileMaterializerCandidateIssueV1>();
+  const issueCandidate = vi.fn((input: AgentProfileMaterializerCandidateIssueV1) => {
+    const proof = Object.freeze(Object.create(null) as object);
+    proofs.set(proof, input);
+    return proof;
+  });
+  const discardProof = vi.fn((proof: unknown) => {
+    if (proof === null || typeof proof !== 'object' || !proofs.delete(proof)) {
+      throw new Error('test bridge attempted to discard an unknown proof');
+    }
+  });
+  const runtime = Object.freeze({
+    issuer: Object.freeze({ issueCandidate }),
+    consumer: Object.freeze({ discardProof }),
+  });
+  const sessionIdentity = Object.freeze(Object.create(null) as object);
+  let binding: AgentProfileMaterializerLaneBindingV1 = Object.freeze({
+    activationGeneration: '1',
+    networkId: NETWORK,
+    kind: 'agents',
+    mode: 'authoritative',
+    sessionIdentity,
+    childGeneration: '2',
+    materializationEpoch: '3',
+  });
+  const issues: AgentProfileMaterializerCandidateIssueV1[] = [];
+  let sessionState: SystemRecordLaneStateV1 = 'enabled';
+  const applyVerified = vi.fn((proof: unknown): Promise<SystemRecordApplyOutcomeV1> => {
+    if (options.failure === 'synchronous') {
+      throw new Error('synchronous dispatch failure');
+    }
+    if (proof === null || typeof proof !== 'object') {
+      throw new Error('test session received a non-object proof');
+    }
+    const issue = proofs.get(proof);
+    if (issue === undefined) throw new Error('test session received an unknown proof');
+    proofs.delete(proof);
+    issues.push(issue);
+    if (options.failure === 'asynchronous') {
+      return Promise.reject(new Error('asynchronous settlement failure'));
+    }
+    return Promise.resolve(Object.freeze({
+      outcome: 'applied',
+      stateRevision: '1',
+      appliedStateDigest: `0x${'a'.repeat(64)}`,
+    }));
+  });
+  const session: SystemRecordLaneSessionV1 = Object.freeze({
+    get state() { return sessionState; },
+    activationGeneration: binding.activationGeneration,
+    applyVerified,
+    close: async () => undefined,
+  });
+  const monotonicNowMs = 10_000;
+  const originalDeadlineMs = monotonicNowMs + (options.remainingMs ?? 2_500);
+  const authority = createAgentProfileAdmittedSliceContextAuthorityV1(
+    () => monotonicNowMs,
+  );
+  const context = authority.mint(originalDeadlineMs);
+  const prepareCandidateApply = createAgentProfileMaterializerPrepareBridgeV1({
+    runtime,
+    session,
+    inspectAdmittedContext: authority.inspect,
+    resolveBinding: () => binding,
+  });
+  return {
+    prepareCandidateApply,
+    context,
+    monotonicNowMs,
+    originalDeadlineMs,
+    issueCandidate,
+    discardProof,
+    applyVerified,
+    issues,
+    rotateChildGeneration() {
+      binding = Object.freeze({
+        ...binding,
+        childGeneration: String(BigInt(binding.childGeneration) + 1n),
+      });
+    },
+    setSessionState(state) {
+      sessionState = state;
+    },
+  };
+}
+
+function createReceiver(
+  artifacts: SystemRecordArtifactRepositoryV1,
+  harness: MaterializerBridgeHarness,
+  nowMs: () => number = () => PRODUCER_FIXTURE_NOW_MS,
+) {
+  return createAgentProfileReceiverV1({
+    networkId: NETWORK,
+    artifacts: agentProfileArtifactSources(artifacts),
+    nowMs,
+    verifyCurrentBundle: () => true,
+    prepareCandidateApply: harness.prepareCandidateApply,
+  });
+}
+
+async function tombstoneFixture() {
+  const fixture = await publishedFixture(true);
+  const predecessor = fixture.envelope.object;
+  const tombstone: AgentProfileTombstoneHeadObjectV1 = Object.freeze({
+    objectType: 'agent-profile-head',
+    kind: 'agents',
+    state: 'tombstone',
+    networkId: predecessor.networkId,
+    peerId: predecessor.peerId,
+    peerPublicKey: predecessor.peerPublicKey,
+    authoritySequence: predecessor.authoritySequence,
+    version: String(BigInt(predecessor.version) + 1n),
+    ...(predecessor.acceptedTransitionDigest === undefined ? {} : {
+      acceptedTransitionDigest: predecessor.acceptedTransitionDigest,
+    }),
+    previousHeadDigest: fixture.envelope.objectDigest,
+    evmIssuer: predecessor.evmIssuer,
+    rootSubject: predecessor.rootSubject,
+    projectionSchemaDigest: predecessor.projectionSchemaDigest,
+    issuedAt: '2026-08-07T12:10:00Z',
+    ownedSubjectTableDigest: EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1,
+    ownedSubjectCount: '0',
+    projectionBytes: '0',
+    projectionQuads: '0',
+  });
+  const envelope = await signHeadEnvelope(
+    tombstone,
+    fixture.peerSigner,
+    fixture.evmSigner,
+  );
+  const artifact = envelopeArtifact('agent-profile-head', envelope);
+  const artifacts: SystemRecordArtifactRepositoryV1 = Object.freeze({
+    async resolve(lookup, signal) {
+      signal.throwIfAborted();
+      if (lookup.type === 'object'
+          && lookup.objectKind === artifact.objectKind
+          && lookup.objectDigest === artifact.objectDigest) return artifact;
+      return fixture.store.resolve(lookup, signal);
+    },
+  });
+  const row: SystemRecordInventoryRowV1 = Object.freeze({
+    stableKeyHash: fixture.row.stableKeyHash,
+    peerId: fixture.row.peerId,
+    authoritySequence: tombstone.authoritySequence,
+    version: tombstone.version,
+    headDigest: envelope.objectDigest,
+    tombstone: true,
+    quarantined: false,
+  });
+  return Object.freeze({ row, artifacts });
+}

--- a/packages/agent/test/system-record-agent-profile-materializer-bridge-v1.test.ts
+++ b/packages/agent/test/system-record-agent-profile-materializer-bridge-v1.test.ts
@@ -38,6 +38,7 @@ import {
 } from './support/agent-profile-receiver-v1-fixture.js';
 import {
   quarantineFixture,
+  transitionQuarantineFixture,
 } from './support/agent-profile-receiver-conflict-v1-fixture.js';
 
 describe('agent-profile private materializer prepare bridge', () => {
@@ -116,6 +117,26 @@ describe('agent-profile private materializer prepare bridge', () => {
       terminalTransitionConflict: false,
     });
     expect(harness.issues[0]?.admittedDeadlineMs).toBe(harness.originalDeadlineMs);
+  });
+
+  it('maps a terminal transition conflict through to the issued quarantine', async () => {
+    const harness = materializerBridgeHarness();
+    const fixture = await transitionQuarantineFixture();
+    const receiver = createReceiver(fixture.artifacts, harness);
+
+    await expect(receiver.receiveCandidate(
+      fixture.row,
+      harness.context,
+      new AbortController().signal,
+    )).resolves.toMatchObject({ outcome: 'applied' });
+
+    expect(harness.issueCandidate).toHaveBeenCalledTimes(1);
+    expect(harness.issueCandidate.mock.calls[0]?.[0]).toMatchObject({
+      operation: 'quarantine',
+      admittedDeadlineMs: harness.originalDeadlineMs,
+      conflictEvidenceDigest: fixture.evidenceDigest,
+      terminalTransitionConflict: true,
+    });
   });
 
   it.each([

--- a/packages/agent/test/system-record-reconcile-closure-continuation-v1.test.ts
+++ b/packages/agent/test/system-record-reconcile-closure-continuation-v1.test.ts
@@ -34,6 +34,76 @@ import {
 import { agentProfileArtifactSources } from './support/agent-profile-artifact-sources-v1-fixture.js';
 
 describe('agent-profile closure continuation V1', () => {
+  it('releases receiver preparation before bridge preflight and apply settlement', async () => {
+    const fixture = await maximumAuthorityClosureFixtureV1();
+    let preparationReleased = false;
+    let releasedAtPreflight: boolean | undefined;
+    let releasedAtSettlement: boolean | undefined;
+    const transport = createAgentProfileReconcileTransportV1({
+      networkId: NETWORK,
+      listProviderIds: () => ['provider-a'],
+      fetchExact: async (_providerId, lookup, signal) => {
+        const artifact = await fixture.repository.resolve(lookup, signal);
+        if (artifact === null) {
+          return Object.freeze({ outcome: 'not-found' as const, wireBytes: 1 });
+        }
+        return Object.freeze({
+          outcome: 'ok' as const,
+          lease: Object.freeze({
+            artifact,
+            wireBytes: 128 + artifact.canonicalBytes.byteLength,
+            release: vi.fn(),
+          }),
+        });
+      },
+      controlAdmission: trackingByteAdmission(),
+    });
+    // Inverted successor of the dropped D5b test, which pinned the forbidden
+    // polarity by asserting the preparation was still live during apply.
+    const receiver = Object.freeze({
+      openPreparation() {
+        return Object.freeze({
+          prepare: async () => Object.freeze({
+            prepareDispatch: async () => {
+              releasedAtPreflight = preparationReleased;
+              return Object.freeze({
+                dispatch: async () => {
+                  releasedAtSettlement = preparationReleased;
+                  return appliedOutcome('01');
+                },
+              });
+            },
+          }),
+          release() {
+            preparationReleased = true;
+          },
+        });
+      },
+      prepareActive: async () => { throw new Error('test uses stateful preparation'); },
+      receiveActive: async () => { throw new Error('test uses stateful preparation'); },
+      prepareCandidate: async () => { throw new Error('test uses stateful preparation'); },
+      receiveCandidate: async () => { throw new Error('test uses stateful preparation'); },
+    }) as unknown as AgentProfileCandidateContinuationReceiverV1;
+    const reconciler = await createAgentProfileReconcilerV1({
+      networkId: NETWORK,
+      rootEnvelope: fixture.rootEnvelope,
+      providerPeerPublicKey: fixture.peerSigner.publicKey,
+      admission: admissionGate(),
+      transport,
+      receiver,
+    });
+
+    let last;
+    for (let advance = 0; advance < SYSTEM_RECORD_MAX_SLICE_REQUESTS; advance += 1) {
+      last = await reconciler.advance(new AbortController().signal);
+      if (last.status !== 'paused') break;
+    }
+    expect(last).toMatchObject({ status: 'complete', processedRows: 1 });
+    expect(releasedAtPreflight).toBe(true);
+    expect(releasedAtSettlement).toBe(true);
+    expect(preparationReleased).toBe(true);
+  });
+
   it('completes a 31-artifact authority closure over three bounded physical slices', async () => {
     const fixture = await maximumAuthorityClosureFixtureV1();
     expect(fixture.artifacts.size).toBe(31);

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -110,6 +110,8 @@ export default defineConfig({
       "test/system-record-reconcile-transport-integration-v1.test.ts",
       "test/system-record-reconcile-closure-continuation-v1.test.ts",
       "test/profile-manager-republish-v1.test.ts",
+      "test/system-record-receiver-v1.test.ts",
+      "test/system-record-agent-profile-materializer-bridge-v1.test.ts",
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",
       "test/swm-fanout-peer-selection.test.ts",

--- a/packages/core/src/system-record-applied-state-v1.ts
+++ b/packages/core/src/system-record-applied-state-v1.ts
@@ -65,6 +65,16 @@ export interface SystemRecordAppliedStatePresentV1 {
   readonly headDigest: Digest32V1;
   readonly transitionLineage: readonly AgentProfileAppliedTransitionV1[];
   readonly conflictEvidenceDigest?: Digest32V1;
+  /**
+   * The quarantined head's own predecessor, captured at quarantine-install.
+   *
+   * A fork resolution names the common base its conflicting heads descend
+   * from. Only the holder of the quarantine knows which base *its* head
+   * descends from, so without this the receiver cannot tell a resolution of
+   * its own fork from a resolution of a different fork at the same sequence
+   * and version. Absent for a version-zero head, which has no predecessor.
+   */
+  readonly conflictForkBaseHeadDigest?: Digest32V1;
   readonly projectionDigest: Digest32V1;
   readonly projectionBytes: DecimalU64V1;
   readonly projectionQuads: DecimalU64V1;
@@ -178,7 +188,7 @@ function validateAppliedState(value: unknown): SystemRecordAppliedStateV1 {
     return ABSENT;
   }
   const optional = [
-    'conflictEvidenceDigest',
+    'conflictEvidenceDigest', 'conflictForkBaseHeadDigest',
     'conflictSidecarIntentOperation', 'conflictSidecarIntentEvidenceDigest',
     'conflictSidecarIntentStateRevision',
     'pendingDeletionTableDigest', 'pendingDeletionSubjectCount', 'pendingDeletionTableBytes',
@@ -217,6 +227,9 @@ function validateAppliedState(value: unknown): SystemRecordAppliedStateV1 {
   const transitionLineage = validateTransitionLineage(state.transitionLineage);
   if (hasOwnDataProperty(state, 'conflictEvidenceDigest')) {
     assertCanonicalDigest(state.conflictEvidenceDigest);
+  }
+  if (hasOwnDataProperty(state, 'conflictForkBaseHeadDigest')) {
+    assertCanonicalDigest(state.conflictForkBaseHeadDigest);
   }
   assertCanonicalDigest(state.projectionDigest);
   const projectionBytes = boundedU64(state.projectionBytes, SYSTEM_RECORD_MAX_PROJECTION_BYTES, 'projectionBytes');

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -873,6 +873,54 @@ describe('system-record V1 object codecs', () => {
     )).toEqual({ decision: 'quarantine', reason: 'transition-equivocation' });
   });
 
+  // Pins the weld between a resolution's authority sequence and its fork base's.
+  // A consumer matching a resolution against its own recorded quarantine leans on
+  // it: because the two are welded, a resolution disagreeing on sequence must name
+  // a base at that other sequence -- a different digest -- so comparing base
+  // digests carries the sequence property too, and a separate sequence conjunct
+  // downstream would be a re-check of this one.
+  //
+  // Both arms come from one construction with the base's sequence as the only free
+  // coordinate, so the refusal cannot be an incidental malformation of a hand-built
+  // head. Every sibling disjunct is falsified deliberately: the base stays active,
+  // its digest is the one the resolution names, network/peer/issuer are untouched,
+  // and its version stays below the forked version. The accepted-transition digest
+  // is asserted equal across the arms because that is the trap here -- a base at
+  // another sequence would ordinarily carry another lineage digest and be refused
+  // further down, which would leave this conjunct's removal undetected.
+  it('welds a fork resolution to a base at its own authority sequence', async () => {
+    const rotated = await rotatedForkResolutionCase();
+    const withBaseSequence = (authoritySequence: string) => {
+      const base = { ...rotated.base, authoritySequence };
+      const forkBaseHeadDigest = computeAgentProfileHeadObjectDigestV1(base);
+      const evidenceHeads = [rotated.left, rotated.right].map((head) => {
+        return { ...head, previousHeadDigest: forkBaseHeadDigest };
+      });
+      return {
+        base,
+        evidenceHeads,
+        resolution: {
+          ...rotated.resolution,
+          forkBaseHeadDigest,
+          evidenceHeadDigests: evidenceHeads.map(computeAgentProfileHeadObjectDigestV1).sort(),
+        },
+      };
+    };
+
+    const matched = withBaseSequence(rotated.resolution.authoritySequence);
+    expect(matched.base.authoritySequence).toBe('2');
+    expect(() => assertAgentProfileForkResolutionEvidenceV1(
+      matched.resolution, matched.evidenceHeads, matched.base,
+    )).not.toThrow();
+
+    const mismatched = withBaseSequence('1');
+    expect(mismatched.base.acceptedTransitionDigest)
+      .toBe(matched.base.acceptedTransitionDigest);
+    expect(() => assertAgentProfileForkResolutionEvidenceV1(
+      mismatched.resolution, mismatched.evidenceHeads, mismatched.base,
+    )).toThrow(/lower same-authority head/);
+  });
+
   it('enforces the exact five-minute future boundary and discards historical resolutions', async () => {
     const fixture = await authorityFixture();
     const now = Date.parse('2026-08-05T12:00:00Z');

--- a/packages/core/test/system-record-objects-v1.test.ts
+++ b/packages/core/test/system-record-objects-v1.test.ts
@@ -1961,13 +1961,19 @@ describe('system-record owned subjects and verification closure', () => {
     await expect(buildClosure(current, artifacts)).rejects.toThrow(/reuses a historical wallet root/);
   });
 
-  // A consumer comparing the summary against a recorded quarantine matches the
-  // resolution's authority sequence against its own applied lineage length. That
-  // equality is an inference from how the closure walks the lineage, not a
-  // declared invariant, so pin it directly -- if it ever goes off by one, the
-  // consumer's fork-resolution gate silently never fires. Two sequences, because
-  // a sequence-zero case alone is satisfied by a constant as well as by the
-  // real derivation.
+  // Pins this closure's own construction invariant: the lineage it walks is
+  // exactly as long as the head's authority sequence. Worth pinning because the
+  // traversal that builds the lineage is being reshaped, and an off-by-one
+  // there would otherwise go unnoticed.
+  //
+  // It is NOT the pin for a consumer matching a resolution against a recorded
+  // quarantine. Read against the summary that equality is forced -- the
+  // directness check already requires a resolution and its successor to share an
+  // authority sequence -- so a consumer-side conjunct phrased against the summary
+  // could never fail. A consumer has to compare against its OWN persisted
+  // lineage, and owes its own removal test there. Two sequences, because a
+  // sequence-zero case alone is satisfied by a constant as well as by the real
+  // derivation.
   it('mints a resolution authority sequence equal to the lineage length', async () => {
     const genesis = await genesisForkResolutionCase();
     const genesisSummary = (await buildClosure(genesis.successor, genesis.artifacts)).authoritySummary;

--- a/packages/storage/src/system-record-apply-command-v1-internal.ts
+++ b/packages/storage/src/system-record-apply-command-v1-internal.ts
@@ -92,8 +92,13 @@ export function buildSystemRecordConditionalApplyUpdateV1(
   const plan = raw.plan;
   const priorSubjects = plan.prior.ownedSubjectTable;
   const nextSubjects = plan.next.ownedSubjectTable;
-  const subjectUnion = mergeSystemRecordOwnedSubjectsV1(priorSubjects, nextSubjects);
-  if (subjectUnion.length < 1) throw new Error('active materialization requires an owned subject');
+  const replacementUnion = mergeSystemRecordOwnedSubjectsV1(priorSubjects, nextSubjects);
+  const subjectUnion = plan.projectionDeletionTable === undefined
+    ? replacementUnion
+    : mergeSystemRecordOwnedSubjectsV1(replacementUnion, plan.projectionDeletionTable);
+  if (subjectUnion.length < 1) {
+    throw new Error('system-record materialization requires a bounded projection subject scope');
+  }
   const oldReserved = plan.prior.reservedQuads;
   const nextReserved = plan.next.reservedQuads;
   const absent = plan.prior.requiredAbsentReservedSubjects;

--- a/packages/storage/src/system-record-atomic-apply-executor-v1-internal.ts
+++ b/packages/storage/src/system-record-atomic-apply-executor-v1-internal.ts
@@ -51,7 +51,7 @@ import {
 } from './system-record-state-snapshot-v1-internal.js';
 import {
   assertAuthenticSystemRecordActiveReplacementCompleteV1,
-  deriveSystemRecordActiveReplacementV1,
+  deriveSystemRecordReplacementV1,
   type SystemRecordActiveReplacementCompleteV1,
   type SystemRecordActiveReplacementReadyV1,
 } from './system-record-next-state-v1-internal.js';
@@ -405,9 +405,9 @@ class SystemRecordAtomicApplyAttemptV1 {
     inspectionDeadlineMs: number,
     inspection: SystemRecordPriorInspectionPhaseV1,
   ): Promise<SystemRecordDispatchPreparationPhaseV1> {
-    let derived: ReturnType<typeof deriveSystemRecordActiveReplacementV1>;
+    let derived: ReturnType<typeof deriveSystemRecordReplacementV1>;
     try {
-      derived = deriveSystemRecordActiveReplacementV1(Object.freeze({
+      derived = deriveSystemRecordReplacementV1(Object.freeze({
         facts: this.facts,
         snapshot: inspection.snapshot,
         observedRootClaimQuads: inspection.rootClaimQuads,
@@ -496,6 +496,7 @@ class SystemRecordAtomicApplyAttemptV1 {
         inspection.snapshot,
         exactPrior.projectionQuads,
         this.binding.mode,
+        derived,
       )) {
         return this.completePreparation(
           noMutation({ outcome: 'deferred', reason: 'validation-mismatch' }),
@@ -1190,6 +1191,7 @@ function matchesProjectionSnapshot(
   snapshot: SystemRecordAppliedSnapshotV1,
   projectionQuads: readonly Readonly<Quad>[],
   mode: SystemRecordLaneExecutionBindingV1['mode'],
+  prepared: SystemRecordActiveReplacementCompleteV1,
 ): boolean {
   const observed = fingerprintSystemRecordProjectionV1(projectionQuads);
   // No applied state owns authoritative projection subjects yet, so bounded
@@ -1197,6 +1199,10 @@ function matchesProjectionSnapshot(
   // atomic transaction must replace. Shadow storage is protocol-owned from
   // inception and therefore remains strict-empty when its state is absent.
   if (snapshot.state === 'absent' && mode === 'authoritative') return true;
+  if (snapshot.state === 'present'
+      && snapshot.appliedState.status === 'dirty'
+      && mode === 'authoritative'
+      && prepared.plan.projectionDeletionTable !== undefined) return true;
   const expected = snapshot.state === 'present'
     ? snapshot.appliedState
     : Object.freeze({
@@ -1257,7 +1263,7 @@ function classifyInspectionFailure(
 
 function mapZeroWrite(
   prepared: Exclude<
-    ReturnType<typeof deriveSystemRecordActiveReplacementV1>,
+    ReturnType<typeof deriveSystemRecordReplacementV1>,
     SystemRecordActiveReplacementCompleteV1
   >,
 ): Exclude<SystemRecordApplyOutcomeV1, { outcome: 'applied' | 'already-applied' | 'indeterminate' }> {

--- a/packages/storage/src/system-record-atomic-apply-executor-v1-internal.ts
+++ b/packages/storage/src/system-record-atomic-apply-executor-v1-internal.ts
@@ -1199,6 +1199,18 @@ function matchesProjectionSnapshot(
   // atomic transaction must replace. Shadow storage is protocol-owned from
   // inception and therefore remains strict-empty when its state is absent.
   if (snapshot.state === 'absent' && mode === 'authoritative') return true;
+  // A shadow tombstone writes status 'dirty' and its deletion scope to the
+  // single shared reserved row while emptying only the shadow projection, so the
+  // legacy authoritative projection is still in place. The authoritative cutover
+  // reads that same row, sees the empty projection the shadow pass recorded, and
+  // must DELETE the legacy content rather than match against it -- the skip is the
+  // cutover mechanism, not an exemption from it. Bounded on both sides: the
+  // observed projection is read over the exact next-subject union and the delete
+  // is bound by that same union, and the reserved-state precondition is untouched.
+  // Pinned by 'cuts a dirty shadow tombstone over to authoritative against a
+  // legacy projection'; remove this and the transition defers on
+  // validation-mismatch forever, because the row's recorded projection can never
+  // match the legacy rows still in the store.
   if (snapshot.state === 'present'
       && snapshot.appliedState.status === 'dirty'
       && mode === 'authoritative'

--- a/packages/storage/src/system-record-materializer-v1.ts
+++ b/packages/storage/src/system-record-materializer-v1.ts
@@ -161,9 +161,36 @@ export interface SystemRecordChildHandoffV1 {
   ): SystemRecordAtomicRecoveryRuntimeV1;
 }
 
+/**
+ * Executor half of the proof consume-or-discard contract.
+ *
+ * A verified proof holds the single-slot, registry-wide transient reservation,
+ * so exactly one party must always end up releasing it. The split is:
+ *
+ * - The lane owns the proof until an apply entry point accepts it. Every path
+ *   that refuses or throws before that point discards, including throws from
+ *   the ownership-snapshot read, the execution binding, and the admission
+ *   barrier.
+ * - The executor owns the proof from the moment one of the apply entry points
+ *   below is invoked. Having accepted it, the executor must consume it, discard
+ *   it, or transfer it to recovery ownership, on every outcome including its own
+ *   rejections. An entry point that rejects *without* having taken ownership
+ *   leaves the proof with the lane, which discards it.
+ *
+ * The lane's discard is tolerant of failure because it deliberately also runs on
+ * paths where the executor already took ownership; it must never convert a
+ * dispatch failure into a reservation error. Neither half may assume the other
+ * released the proof, and neither may release one it does not own -- a
+ * reservation transferred to recovery is owned by recovery until settlement.
+ */
 export interface SystemRecordTransactionExecutorV1 {
   applyVerified(proof: unknown, childGeneration: string): Promise<SystemRecordApplyOutcomeV1>;
-  /** Release an authentic proof that lifecycle admission refused before dispatch. */
+  /**
+   * Release an authentic proof the lane never handed to an apply entry point:
+   * lifecycle admission refused it, or the dispatch threw before ownership
+   * transferred. Implementations must tolerate being called for a proof that is
+   * already consumed, already released, or recovery-owned.
+   */
   discardVerified?(proof: unknown): void;
   /**
    * Preferred activation-bound entry point.
@@ -1268,6 +1295,25 @@ class SystemRecordLaneSession {
     proof: unknown,
     facade: SystemRecordLaneFacadeBindingV1,
   ): Promise<SystemRecordApplyOutcomeV1> {
+    try {
+      return await this.dispatchVerifiedForBinding(proof, facade);
+    } catch (error) {
+      // The refusal paths below discard before returning, and the executor owns
+      // the proof from the moment it accepts one. A throw escaping anywhere else
+      // -- the ownership-snapshot read, the execution-binding construction, the
+      // admission barrier, or an executor that rejected before consuming --
+      // would otherwise strand the proof's transient reservation. That gate is
+      // single-slot and registry-wide, so one stranded proof fails every later
+      // apply in the process with "reservation is already live" until restart.
+      this.discardVerifiedAfterFailedDispatch(proof);
+      throw error;
+    }
+  }
+
+  private async dispatchVerifiedForBinding(
+    proof: unknown,
+    facade: SystemRecordLaneFacadeBindingV1,
+  ): Promise<SystemRecordApplyOutcomeV1> {
     if (
       this.current === 'shutdown' ||
       this.current === 'unavailable' ||
@@ -1404,6 +1450,26 @@ class SystemRecordLaneSession {
       // into an exception or admit the proof to an executor path.
     }
     return outcome;
+  }
+
+  /**
+   * Release a proof whose dispatch threw before the executor took ownership.
+   *
+   * The tolerance here is load-bearing, not defensive habit. `discardProof`
+   * throws once the proof is consumed or its reservation already released, and
+   * a reservation transferred to recovery ownership is deliberately not
+   * releasable. So this runs on paths where the discard is expected to fail:
+   * rethrowing from it would replace the real dispatch failure with a
+   * misleading reservation error, and releasing a recovery-owned reservation
+   * would be worse still. Swallow, and let the original error propagate.
+   */
+  private discardVerifiedAfterFailedDispatch(proof: unknown): void {
+    try {
+      this.deps.executor.discardVerified?.(proof);
+    } catch {
+      // See above: an already-consumed, already-released, or recovery-owned
+      // proof throws here by design and must not mask the dispatch failure.
+    }
   }
 
   /**

--- a/packages/storage/src/system-record-next-state-v1-internal.ts
+++ b/packages/storage/src/system-record-next-state-v1-internal.ts
@@ -10,6 +10,7 @@ import {
 import {
   assertAgentProfileHeadObjectV1,
   assertAgentProfileVerifiedAuthoritySummaryV1,
+  type AgentProfileVerifiedAuthoritySummaryV1,
   canonicalizeOwnedSubjectTableObjectV1,
   canonicalizeSystemRecordAppliedStateV1,
   canonicalizeSystemRecordCapacityStateV1,
@@ -465,6 +466,12 @@ function quarantineSystemRecordDerivationV1(
     ...withoutConflictSaga(derived.plan.next.appliedState),
     status: 'quarantined',
     conflictEvidenceDigest: facts.conflictEvidenceDigest,
+    // Captured here because this is the only moment the receiver still knows
+    // which head it is quarantining; a later resolution names a fork base, and
+    // without our own base the two cannot be compared.
+    ...(facts.head.previousHeadDigest === undefined
+      ? {}
+      : { conflictForkBaseHeadDigest: facts.head.previousHeadDigest }),
     conflictDigestSlots,
     conflictOverflow,
   });
@@ -1019,6 +1026,60 @@ function persistedStateMatchesVerifiedTombstone(
         && sameStrings(snapshot.pendingDeletionTable, pendingDeletionTable));
 }
 
+/**
+ * Decide whether a fork resolution adjudicates *this* quarantine.
+ *
+ * A head advertising some resolution is not enough. A peer that equivocated at
+ * one point can hold a perfectly valid resolution of a different fork of its
+ * own history, and presenting that would otherwise walk the quarantine off
+ * without the original equivocation ever being adjudicated. Each conjunct pins
+ * one coordinate of the fork event against state the candidate does not own.
+ *
+ * P-forkedVersion / P-authoritySeq / P-forkBase name the fork event: the
+ * version it happened at, the authority sequence it happened under, and the
+ * base its branches descend from. P-resolutionDigest binds the summary to the
+ * head in hand. P-absentRefusal refuses a head that advertises a resolution the
+ * summary does not carry -- load-bearing because summary validation is identity
+ * only, so a summary minted on a traversal that never ran the directness check
+ * is indistinguishable here from one that did.
+ *
+ * P-authoritySeq deliberately compares against OUR persisted lineage rather
+ * than the summary's. Core forces a resolution's authority sequence to equal
+ * its successor's, so the summary form could never fail. The consequence is
+ * intended: a resolution issued after the peer rotated authority is refused,
+ * because resolving at the next sequence moves past the equivocation instead of
+ * adjudicating it. The supported order is resolve, clear, then rotate.
+ *
+ * Do not drop the sequence conjunct for looking untested. Deleting it alone
+ * changes no test, and that is structural rather than a coverage hole: a
+ * resolution cannot disagree with us on sequence ALONE, because the evidence
+ * check welds a resolution's sequence to its fork base's, so any sequence
+ * mismatch drags a base mismatch along and the base conjunct decides first.
+ * What the tests do catch is either comparison being wired to the other's
+ * operand, which is the mistake this shape actually invites.
+ */
+function resolutionAdjudicatesThisQuarantineV1(
+  current: SystemRecordAppliedStatePresentV1,
+  headVersion: string,
+  advertisedResolutionDigest: Digest32V1,
+  summary: AgentProfileVerifiedAuthoritySummaryV1,
+): boolean {
+  const resolution = summary.forkResolution;
+  // P-absentRefusal. Not removable: every conjunct below reads `resolution`, so
+  // deleting this line fails to compile rather than admitting anything -- the
+  // type carries the refusal. It never fires today, and the precondition that
+  // keeps it silent is pinned by 'carries verified fork-resolution facts on the
+  // fork-resolving successor': a summary minted through the closure for a head
+  // advertising a resolution always carries the facts. It exists for a summary
+  // minted on a traversal that never ran the directness check, which the
+  // identity-only validator cannot tell apart from one that did.
+  if (resolution === undefined) return false;
+  return resolution.forkedVersion === headVersion
+    && resolution.authoritySequence === String(current.transitionLineage.length)
+    && resolution.resolutionDigest === advertisedResolutionDigest
+    && resolution.forkBaseHeadDigest === current.conflictForkBaseHeadDigest;
+}
+
 type AuthorityAdvance =
   | Readonly<{
       readonly outcome: 'advance';
@@ -1040,7 +1101,13 @@ function classifyAuthorityAdvance(
       if (current.conflictDigestSlots.length > 0 || current.conflictOverflow
           || facts.head.forkResolutionDigest === undefined
           || parseCanonicalDecimalU64(facts.head.version)
-            <= parseCanonicalDecimalU64(snapshot.headVersion)) {
+            <= parseCanonicalDecimalU64(snapshot.headVersion)
+          || !resolutionAdjudicatesThisQuarantineV1(
+            current,
+            snapshot.headVersion,
+            facts.head.forkResolutionDigest,
+            facts.verifiedAuthoritySummary,
+          )) {
         return Object.freeze({ outcome: 'deferred', reason: 'non-active-state' });
       }
     } else if (facts.operation !== 'quarantine') {

--- a/packages/storage/src/system-record-next-state-v1-internal.ts
+++ b/packages/storage/src/system-record-next-state-v1-internal.ts
@@ -22,6 +22,7 @@ import {
   computeSystemRecordMaterializationReceiptDigestV1,
   computeSystemRecordRootClaimSetDigestV1,
   computeSystemRecordStableKeyHashV1,
+  EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1,
   parseCanonicalOwnedSubjectTableObjectV1,
   parseCanonicalSystemRecordAppliedStateV1,
   parseCanonicalSystemRecordCapacityStateV1,
@@ -30,8 +31,10 @@ import {
   SYSTEM_RECORD_MAX_APPLIED_AGGREGATE_BYTES,
   SYSTEM_RECORD_MAX_APPLIED_AGGREGATE_QUADS,
   SYSTEM_RECORD_MAX_APPLIED_STATE_BYTES,
+  SYSTEM_RECORD_MAX_CONFLICT_DIGESTS,
   SYSTEM_RECORD_MAX_INVENTORY_RECORDS,
   SYSTEM_RECORD_MAX_OWNED_SUBJECTS,
+  SYSTEM_RECORD_EMPTY_PROJECTION_DIGEST_V1,
   type AgentProfileAppliedTransitionV1,
   type OwnedSubjectTableObjectV1,
   type SystemRecordAppliedStatePresentV1,
@@ -56,7 +59,9 @@ import {
 } from './system-record-state-snapshot-v1-internal.js';
 import {
   assertAuthenticSystemRecordVerifiedReplacementFactsV1,
+  type SystemRecordVerifiedQuarantineReplacementFactsV1,
   type SystemRecordVerifiedReplacementFactsV1,
+  type SystemRecordVerifiedTombstoneReplacementFactsV1,
 } from './system-record-verified-replacement-v1-internal.js';
 
 export type SystemRecordActiveDerivationDeferredReasonV1 =
@@ -79,6 +84,7 @@ export interface SystemRecordPriorMaterializationV1 {
   readonly capacityState: SystemRecordCapacityStateV1;
   readonly materializationEpoch: string;
   readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
+  readonly pendingDeletionTable?: OwnedSubjectTableObjectV1;
   readonly rootClaimSet?: SystemRecordRootClaimSetV1;
   readonly receipt?: SystemRecordMaterializationReceiptV1;
   readonly rootClaimQuads: readonly Readonly<Quad>[];
@@ -93,6 +99,7 @@ export interface SystemRecordNextMaterializationV1 {
   readonly capacityState: SystemRecordCapacityStateV1;
   readonly materializationEpoch: string;
   readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
+  readonly pendingDeletionTable?: OwnedSubjectTableObjectV1;
   readonly rootClaimSet: SystemRecordRootClaimSetV1;
   readonly receipt: SystemRecordMaterializationReceiptV1;
   readonly receiptDigest: Digest32V1;
@@ -109,6 +116,8 @@ export interface SystemRecordRootClaimGuardV1 {
 export interface SystemRecordMaterializationPlanV1 {
   readonly stableKeyHash: Digest32V1;
   readonly projectionGraph: string;
+  /** Extra verified subjects that must be deleted but never become next projection. */
+  readonly projectionDeletionTable?: OwnedSubjectTableObjectV1;
   readonly prior: SystemRecordPriorMaterializationV1;
   readonly next: SystemRecordNextMaterializationV1;
   readonly rootClaimGuards: readonly SystemRecordRootClaimGuardV1[];
@@ -148,6 +157,28 @@ export type SystemRecordActiveReplacementDerivationV1 =
       readonly outcome: 'capacity-exhausted';
       readonly reason: SystemRecordActiveDerivationCapacityReasonV1;
     }>;
+
+export type SystemRecordReplacementDerivationV1 = SystemRecordActiveReplacementDerivationV1;
+
+/** Closed verified candidate transition; every complete variant uses the same CAS plan. */
+export function deriveSystemRecordReplacementV1(input: {
+  readonly facts: SystemRecordVerifiedReplacementFactsV1;
+  readonly snapshot: SystemRecordAppliedSnapshotV1;
+  readonly observedRootClaimQuads: readonly Readonly<Quad>[];
+}): SystemRecordReplacementDerivationV1 {
+  assertAuthenticSystemRecordVerifiedReplacementFactsV1(input.facts);
+  if (input.facts.operation === 'tombstone') {
+    return deriveSystemRecordTombstoneReplacementV1({
+      facts: input.facts,
+      snapshot: input.snapshot,
+      observedRootClaimQuads: input.observedRootClaimQuads,
+    });
+  }
+  const active = deriveSystemRecordActiveReplacementV1(input);
+  return input.facts.operation === 'quarantine'
+    ? quarantineSystemRecordDerivationV1(active, input.facts)
+    : active;
+}
 
 /**
  * Pure active-only state transition. Its `ready` variant is complete: callers
@@ -407,6 +438,340 @@ export function deriveSystemRecordActiveReplacementV1(input: {
   }));
 }
 
+function quarantineSystemRecordDerivationV1(
+  derived: SystemRecordActiveReplacementDerivationV1,
+  facts: SystemRecordVerifiedQuarantineReplacementFactsV1,
+): SystemRecordActiveReplacementDerivationV1 {
+  if (derived.outcome !== 'ready' && derived.outcome !== 'already-applied') return derived;
+  if (derived.outcome === 'already-applied'
+      && derived.plan.next.appliedState.status === 'quarantined'
+      && derived.plan.next.appliedState.conflictEvidenceDigest === facts.conflictEvidenceDigest) {
+    return derived;
+  }
+  if (derived.outcome !== 'ready') {
+    return Object.freeze({ outcome: 'deferred', reason: 'verified-state-mismatch' });
+  }
+
+  const currentSlots = derived.plan.next.appliedState.conflictDigestSlots;
+  const terminalDigests = facts.terminalTransitionConflict
+    ? facts.conflictEvidence.entries.flatMap((entry) =>
+        entry.type === 'transition' ? [...entry.objectDigests] : [])
+    : [];
+  const allSlots = canonicalDigests([...currentSlots, ...terminalDigests]);
+  const conflictOverflow = derived.plan.next.appliedState.conflictOverflow
+    || allSlots.length > SYSTEM_RECORD_MAX_CONFLICT_DIGESTS;
+  const conflictDigestSlots = Object.freeze(allSlots.slice(0, SYSTEM_RECORD_MAX_CONFLICT_DIGESTS));
+  const appliedState = canonicalAppliedState({
+    ...withoutConflictSaga(derived.plan.next.appliedState),
+    status: 'quarantined',
+    conflictEvidenceDigest: facts.conflictEvidenceDigest,
+    conflictDigestSlots,
+    conflictOverflow,
+  });
+  const appliedStateDigest = computeSystemRecordAppliedStateDigestV1(appliedState);
+  const receipt = canonicalReceipt({
+    ...derived.plan.next.receipt,
+    appliedStateDigest,
+    headDigest: appliedState.headDigest,
+  });
+  const reserved = buildSystemRecordReservedStateQuadsV1({
+    appliedState,
+    headVersion: derived.plan.next.headVersion,
+    ownedSubjectTable: derived.plan.next.ownedSubjectTable,
+    rootClaimSet: derived.plan.next.rootClaimSet,
+    capacityState: derived.plan.next.capacityState,
+    receipt,
+  });
+  const next = Object.freeze({
+    ...derived.plan.next,
+    appliedState,
+    appliedStateDigest,
+    receipt,
+    receiptDigest: computeSystemRecordMaterializationReceiptDigestV1(receipt),
+    reservedQuads: Object.freeze([
+      ...reserved.record,
+      ...reserved.capacity,
+      ...reserved.epoch,
+      ...reserved.receipt,
+      ...reserved.rootClaims,
+    ]),
+  });
+  return markComplete(Object.freeze({
+    outcome: 'ready',
+    plan: Object.freeze({
+      ...derived.plan,
+      next,
+      success: Object.freeze({
+        stateRevision: appliedState.stateRevision,
+        appliedStateDigest,
+      }),
+    }),
+  }));
+}
+
+function deriveSystemRecordTombstoneReplacementV1(input: {
+  readonly facts: SystemRecordVerifiedTombstoneReplacementFactsV1;
+  readonly snapshot: SystemRecordAppliedSnapshotV1;
+  readonly observedRootClaimQuads: readonly Readonly<Quad>[];
+}): SystemRecordActiveReplacementDerivationV1 {
+  const { facts, snapshot } = input;
+  assertAuthenticSystemRecordAppliedSnapshotV1(snapshot);
+  assertTrustedTombstoneReplacement(facts, snapshot);
+  const { head, verifiedAuthoritySummary: summary } = facts;
+  const headDigest = computeAgentProfileHeadObjectDigestV1(head);
+  const stableKeyHash = computeSystemRecordStableKeyHashV1(head.networkId, head.peerId);
+  const authority = classifyTombstoneAdvance(snapshot, facts, headDigest);
+  if (authority.outcome !== 'advance') return authority;
+
+  const rootClaimSet = canonicalRootClaimSet({
+    objectType: 'system-record-root-claim-set',
+    kind: 'agents',
+    networkId: head.networkId,
+    stableKeyHash,
+    currentRoot: head.rootSubject,
+    historicalRoots: summary.historicalRoots,
+  });
+  const recordSubject = systemRecordRecordSubjectV1(head.networkId, stableKeyHash);
+  const priorRootQuads = snapshot.state === 'present'
+    ? snapshot.expectedRootClaimQuads
+    : Object.freeze([]);
+  const priorRootSubjects = new Set(priorRootQuads.map((quad) => quad.subject));
+  const nextRootSubjects = [rootClaimSet.currentRoot, ...rootClaimSet.historicalRoots]
+    .map((root) => systemRecordRootClaimSubjectV1(head.networkId, root));
+  const requiredAbsentRootSubjects = canonicalSubjects(
+    nextRootSubjects.filter((subject) => !priorRootSubjects.has(subject)),
+  );
+  const rootSnapshot = classifyRootSnapshot(
+    input.observedRootClaimQuads,
+    priorRootQuads,
+    requiredAbsentRootSubjects,
+    facts.networkId,
+    recordSubject,
+  );
+  if (rootSnapshot.outcome !== 'match') return rootSnapshot;
+
+  const emptyTable = Object.freeze([]) as unknown as OwnedSubjectTableObjectV1;
+  const priorTable = snapshot.state === 'present'
+    ? snapshot.ownedSubjectTable
+    : emptyTable;
+  const pendingDeletionTable = facts.mode === 'shadow'
+    ? facts.deletionOwnedSubjectTable
+    : undefined;
+  const pendingTableBytes = pendingDeletionTable === undefined
+    ? 0
+    : canonicalizeOwnedSubjectTableObjectV1(
+        head.rootSubject,
+        pendingDeletionTable,
+      ).byteLength;
+  const rootClaimSetDigest = computeSystemRecordRootClaimSetDigestV1(rootClaimSet);
+
+  if (snapshot.state === 'present'
+      && persistedStateMatchesVerifiedTombstone(
+        snapshot,
+        facts,
+        rootClaimSetDigest,
+        pendingDeletionTable,
+      )) {
+    const appliedStateDigest = computeSystemRecordAppliedStateDigestV1(snapshot.appliedState);
+    const reservedQuads = Object.freeze([
+      ...snapshot.previousReservedQuads,
+      ...priorRootQuads,
+    ]);
+    const requiredAbsentReservedSubjects = canonicalSubjects([
+      ...snapshot.requiredAbsentReservedSubjects,
+      ...requiredAbsentRootSubjects,
+    ]);
+    const prior = Object.freeze({
+      appliedState: snapshot.appliedState,
+      headVersion: snapshot.headVersion,
+      capacityState: snapshot.capacityState,
+      materializationEpoch: snapshot.materializationEpoch,
+      ownedSubjectTable: priorTable,
+      ...(snapshot.pendingDeletionTable === undefined
+        ? {}
+        : { pendingDeletionTable: snapshot.pendingDeletionTable }),
+      rootClaimSet: snapshot.rootClaimSet,
+      receipt: snapshot.receipt,
+      rootClaimQuads: priorRootQuads,
+      reservedQuads,
+      requiredAbsentReservedSubjects,
+    });
+    const next = Object.freeze({
+      appliedState: snapshot.appliedState,
+      headVersion: snapshot.headVersion,
+      appliedStateDigest,
+      capacityState: snapshot.capacityState,
+      materializationEpoch: snapshot.materializationEpoch,
+      ownedSubjectTable: emptyTable,
+      ...(snapshot.pendingDeletionTable === undefined
+        ? {}
+        : { pendingDeletionTable: snapshot.pendingDeletionTable }),
+      rootClaimSet: snapshot.rootClaimSet,
+      receipt: snapshot.receipt,
+      receiptDigest: computeSystemRecordMaterializationReceiptDigestV1(snapshot.receipt),
+      rootClaimQuads: priorRootQuads,
+      reservedQuads,
+      projectionQuads: Object.freeze([]),
+    });
+    return markComplete(Object.freeze({
+      outcome: 'already-applied',
+      plan: Object.freeze({
+        stableKeyHash,
+        projectionGraph: systemRecordProjectionGraphV1(facts.mode),
+        projectionDeletionTable: facts.deletionOwnedSubjectTable,
+        prior,
+        next,
+        rootClaimGuards: rootGuards(nextRootSubjects, recordSubject),
+        success: Object.freeze({
+          stateRevision: snapshot.appliedState.stateRevision,
+          appliedStateDigest,
+        }),
+      }),
+    }));
+  }
+
+  if (mergedSubjectCount(
+    priorTable,
+    facts.deletionOwnedSubjectTable,
+  ) > SYSTEM_RECORD_MAX_OWNED_SUBJECTS) {
+    return Object.freeze({ outcome: 'capacity-exhausted', reason: 'subject-union-cap' });
+  }
+  const nextStateRevision = incrementU64(
+    snapshot.state === 'present' ? snapshot.appliedState.stateRevision : '0',
+  );
+  if (nextStateRevision === null) {
+    return Object.freeze({ outcome: 'capacity-exhausted', reason: 'state-revision-overflow' });
+  }
+  const capacityRevision = incrementU64(snapshot.capacityState.revision);
+  if (capacityRevision === null) {
+    return Object.freeze({ outcome: 'capacity-exhausted', reason: 'capacity-revision-overflow' });
+  }
+  const deletionTableDigest = computeOwnedSubjectTableDigestV1(
+    head.rootSubject,
+    facts.deletionOwnedSubjectTable,
+  );
+  const appliedState = canonicalAppliedState({
+    objectType: 'system-record-applied-state',
+    state: 'present',
+    kind: 'agents',
+    networkId: head.networkId,
+    stableKeyHash,
+    peerId: head.peerId,
+    stateRevision: nextStateRevision,
+    status: facts.mode === 'shadow' ? 'dirty' : 'tombstone',
+    headDigest,
+    transitionLineage: summary.transitionLineage,
+    projectionDigest: SYSTEM_RECORD_EMPTY_PROJECTION_DIGEST_V1,
+    projectionBytes: '0',
+    projectionQuads: '0',
+    ownedSubjectTableDigest: EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1,
+    ownedSubjectCount: '0',
+    ownedSubjectTableBytes: '0',
+    ...(pendingDeletionTable === undefined ? {} : {
+      pendingDeletionTableDigest: deletionTableDigest,
+      pendingDeletionSubjectCount: String(pendingDeletionTable.length),
+      pendingDeletionTableBytes: String(pendingTableBytes),
+    }),
+    currentRoot: head.rootSubject,
+    historicalRoots: summary.historicalRoots,
+    conflictDigestSlots: snapshot.state === 'present'
+      ? snapshot.appliedState.conflictDigestSlots
+      : Object.freeze([]),
+    conflictOverflow: snapshot.state === 'present'
+      ? snapshot.appliedState.conflictOverflow
+      : false,
+    materializationEpoch: facts.materializationEpoch,
+    rootClaimSetDigest,
+    accountedBytes: computeSystemRecordAccountedBytesV1(0, 0, pendingTableBytes).toString(),
+  });
+  const nextCapacity = deriveCapacity(
+    snapshot,
+    appliedState,
+    0,
+    capacityRevision,
+    pendingTableBytes,
+  );
+  if (nextCapacity.outcome !== 'capacity') return nextCapacity;
+  const appliedStateDigest = computeSystemRecordAppliedStateDigestV1(appliedState);
+  const receipt = canonicalReceipt({
+    objectType: 'system-record-materialization-receipt',
+    kind: 'agents',
+    networkId: head.networkId,
+    stableKeyHash,
+    stateRevision: nextStateRevision,
+    appliedStateDigest,
+    headDigest,
+    materializationEpoch: facts.materializationEpoch,
+  });
+  const nextReserved = buildSystemRecordReservedStateQuadsV1({
+    appliedState,
+    headVersion: head.version,
+    ownedSubjectTable: emptyTable,
+    ...(pendingDeletionTable === undefined ? {} : { pendingDeletionTable }),
+    rootClaimSet,
+    capacityState: nextCapacity.state,
+    receipt,
+  });
+  const priorReservedQuads = Object.freeze([
+    ...snapshot.previousReservedQuads,
+    ...priorRootQuads,
+  ]);
+  const requiredAbsentReservedSubjects = canonicalSubjects([
+    ...snapshot.requiredAbsentReservedSubjects,
+    ...requiredAbsentRootSubjects,
+  ]);
+  const prior = Object.freeze({
+    appliedState: snapshot.appliedState,
+    ...(snapshot.state === 'present' ? { headVersion: snapshot.headVersion } : {}),
+    capacityState: snapshot.capacityState,
+    materializationEpoch: snapshot.materializationEpoch,
+    ownedSubjectTable: priorTable,
+    ...(snapshot.state === 'present' && snapshot.pendingDeletionTable !== undefined
+      ? { pendingDeletionTable: snapshot.pendingDeletionTable }
+      : {}),
+    ...(snapshot.state === 'present' ? {
+      rootClaimSet: snapshot.rootClaimSet,
+      receipt: snapshot.receipt,
+    } : {}),
+    rootClaimQuads: priorRootQuads,
+    reservedQuads: priorReservedQuads,
+    requiredAbsentReservedSubjects,
+  });
+  const next = Object.freeze({
+    appliedState,
+    headVersion: head.version,
+    appliedStateDigest,
+    capacityState: nextCapacity.state,
+    materializationEpoch: facts.materializationEpoch,
+    ownedSubjectTable: emptyTable,
+    ...(pendingDeletionTable === undefined ? {} : { pendingDeletionTable }),
+    rootClaimSet,
+    receipt,
+    receiptDigest: computeSystemRecordMaterializationReceiptDigestV1(receipt),
+    rootClaimQuads: nextReserved.rootClaims,
+    reservedQuads: Object.freeze([
+      ...nextReserved.record,
+      ...nextReserved.capacity,
+      ...nextReserved.epoch,
+      ...nextReserved.receipt,
+      ...nextReserved.rootClaims,
+    ]),
+    projectionQuads: Object.freeze([]),
+  });
+  return markComplete(Object.freeze({
+    outcome: 'ready',
+    plan: Object.freeze({
+      stableKeyHash,
+      projectionGraph: systemRecordProjectionGraphV1(facts.mode),
+      projectionDeletionTable: facts.deletionOwnedSubjectTable,
+      prior,
+      next,
+      rootClaimGuards: rootGuards(nextRootSubjects, recordSubject),
+      success: Object.freeze({ stateRevision: nextStateRevision, appliedStateDigest }),
+    }),
+  }));
+}
+
 /** Equal digest is necessary but not sufficient for an already-applied result. */
 function persistedStateMatchesVerifiedHead(
   snapshot: Extract<SystemRecordAppliedSnapshotV1, { readonly state: 'present' }>,
@@ -421,7 +786,18 @@ function persistedStateMatchesVerifiedHead(
     table,
   ).byteLength;
   const rootClaimSetDigest = computeSystemRecordRootClaimSetDigestV1(rootClaimSet);
-  return state.status === 'active'
+  const eligibleStatus = state.status === 'active'
+    || (facts.operation === 'quarantine'
+      && state.status === 'quarantined'
+      && state.conflictEvidenceDigest === facts.conflictEvidenceDigest);
+  const terminalEvidenceRetained = facts.operation !== 'quarantine'
+    || !facts.terminalTransitionConflict
+    || state.conflictOverflow
+    || facts.conflictEvidence.entries.every((entry) => entry.type !== 'transition'
+      || entry.objectDigests.every((digest) => state.conflictDigestSlots.includes(digest)));
+  return eligibleStatus
+    && terminalEvidenceRetained
+    && state.conflictSidecarIntentOperation === undefined
     && state.headDigest === headDigest
     && String(state.transitionLineage.length) === facts.head.authoritySequence
     && snapshot.headVersion === facts.head.version
@@ -455,6 +831,7 @@ function assertTrustedReplacement(
   assertAgentProfileHeadObjectV1(facts.head);
   assertAgentProfileVerifiedAuthoritySummaryV1(facts.verifiedAuthoritySummary);
   if (facts.head.state !== 'active'
+      || (facts.operation !== 'active' && facts.operation !== 'quarantine')
       || facts.kind !== 'agents'
       || facts.networkId !== facts.head.networkId
       || facts.materializationEpoch !== snapshot.materializationEpoch
@@ -493,6 +870,115 @@ function assertTrustedReplacement(
   }
 }
 
+function assertTrustedTombstoneReplacement(
+  facts: SystemRecordVerifiedTombstoneReplacementFactsV1,
+  snapshot: SystemRecordAppliedSnapshotV1,
+): void {
+  assertAuthenticSystemRecordVerifiedReplacementFactsV1(facts);
+  assertAgentProfileHeadObjectV1(facts.head);
+  assertAgentProfileVerifiedAuthoritySummaryV1(facts.verifiedAuthoritySummary);
+  const summary = facts.verifiedAuthoritySummary;
+  const predecessor = summary.tombstonePredecessor;
+  if (facts.operation !== 'tombstone'
+      || facts.head.state !== 'tombstone'
+      || facts.networkId !== facts.head.networkId
+      || facts.materializationEpoch !== snapshot.materializationEpoch
+      || predecessor === undefined
+      || summary.candidateHeadDigest !== computeAgentProfileHeadObjectDigestV1(facts.head)
+      || summary.deletionTableDigest !== predecessor.ownedSubjectTableDigest
+      || facts.head.previousHeadDigest !== computeAgentProfileHeadObjectDigestV1(predecessor)
+      || facts.head.peerId !== predecessor.peerId
+      || facts.head.authoritySequence !== predecessor.authoritySequence
+      || facts.head.rootSubject !== predecessor.rootSubject
+      || computeOwnedSubjectTableDigestV1(
+        predecessor.rootSubject,
+        facts.deletionOwnedSubjectTable,
+      ) !== predecessor.ownedSubjectTableDigest
+      || BigInt(facts.deletionOwnedSubjectTable.length)
+        !== BigInt(predecessor.ownedSubjectCount)) {
+    throw new Error('verified tombstone replacement facts no longer bind their predecessor');
+  }
+}
+
+type TombstoneAdvance =
+  | Readonly<{ readonly outcome: 'advance' }>
+  | Exclude<SystemRecordActiveReplacementDerivationV1, SystemRecordActiveReplacementReadyV1>;
+
+function classifyTombstoneAdvance(
+  snapshot: SystemRecordAppliedSnapshotV1,
+  facts: SystemRecordVerifiedTombstoneReplacementFactsV1,
+  headDigest: Digest32V1,
+): TombstoneAdvance {
+  if (snapshot.state === 'absent') return Object.freeze({ outcome: 'advance' });
+  const current = snapshot.appliedState;
+  if (current.headDigest === headDigest) return Object.freeze({ outcome: 'advance' });
+  const predecessor = facts.verifiedAuthoritySummary.tombstonePredecessor;
+  if (predecessor === undefined) {
+    return Object.freeze({ outcome: 'deferred', reason: 'verified-state-mismatch' });
+  }
+  if (current.headDigest === computeAgentProfileHeadObjectDigestV1(predecessor)
+      && snapshot.headVersion === predecessor.version
+      && current.peerId === predecessor.peerId
+      && current.currentRoot === predecessor.rootSubject
+      && sameTransitions(
+        current.transitionLineage,
+        facts.verifiedAuthoritySummary.transitionLineage,
+      )
+      && sameStrings(
+        current.historicalRoots,
+        facts.verifiedAuthoritySummary.historicalRoots,
+      )) {
+    return Object.freeze({ outcome: 'advance' });
+  }
+  if (BigInt(facts.head.authoritySequence) < BigInt(current.transitionLineage.length)
+      || (facts.head.authoritySequence === String(current.transitionLineage.length)
+        && BigInt(facts.head.version) < BigInt(snapshot.headVersion))) {
+    return Object.freeze({ outcome: 'stale' });
+  }
+  return Object.freeze({ outcome: 'deferred', reason: 'authority-history-mismatch' });
+}
+
+function persistedStateMatchesVerifiedTombstone(
+  snapshot: Extract<SystemRecordAppliedSnapshotV1, { readonly state: 'present' }>,
+  facts: SystemRecordVerifiedTombstoneReplacementFactsV1,
+  rootClaimSetDigest: Digest32V1,
+  pendingDeletionTable: OwnedSubjectTableObjectV1 | undefined,
+): boolean {
+  const state = snapshot.appliedState;
+  const expectedStatus = facts.mode === 'shadow' ? 'dirty' : 'tombstone';
+  const pendingBytes = pendingDeletionTable === undefined
+    ? undefined
+    : canonicalizeOwnedSubjectTableObjectV1(
+        facts.head.rootSubject,
+        pendingDeletionTable,
+      ).byteLength;
+  return snapshot.appliedTupleEpoch === snapshot.materializationEpoch
+    && state.status === expectedStatus
+    && state.headDigest === computeAgentProfileHeadObjectDigestV1(facts.head)
+    && snapshot.headVersion === facts.head.version
+    && state.projectionDigest === SYSTEM_RECORD_EMPTY_PROJECTION_DIGEST_V1
+    && state.projectionBytes === '0'
+    && state.projectionQuads === '0'
+    && state.ownedSubjectTableDigest === EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1
+    && state.ownedSubjectCount === '0'
+    && state.ownedSubjectTableBytes === '0'
+    && snapshot.ownedSubjectTable.length === 0
+    && state.rootClaimSetDigest === rootClaimSetDigest
+    && state.conflictSidecarIntentOperation === undefined
+    && state.conflictEvidenceDigest === undefined
+    && (pendingDeletionTable === undefined
+      ? state.pendingDeletionTableDigest === undefined
+        && snapshot.pendingDeletionTable === undefined
+      : state.pendingDeletionTableDigest === computeOwnedSubjectTableDigestV1(
+          facts.head.rootSubject,
+          pendingDeletionTable,
+        )
+        && state.pendingDeletionSubjectCount === String(pendingDeletionTable.length)
+        && state.pendingDeletionTableBytes === String(pendingBytes)
+        && snapshot.pendingDeletionTable !== undefined
+        && sameStrings(snapshot.pendingDeletionTable, pendingDeletionTable));
+}
+
 type AuthorityAdvance =
   | Readonly<{
       readonly outcome: 'advance';
@@ -509,7 +995,18 @@ function classifyAuthorityAdvance(
     return Object.freeze({ outcome: 'advance', materialization: 'rematerialize' });
   }
   const current = snapshot.appliedState;
-  if (current.status !== 'active') {
+  if (current.status === 'quarantined') {
+    if (facts.operation === 'active') {
+      if (current.conflictDigestSlots.length > 0 || current.conflictOverflow
+          || facts.head.forkResolutionDigest === undefined
+          || parseCanonicalDecimalU64(facts.head.version)
+            <= parseCanonicalDecimalU64(snapshot.headVersion)) {
+        return Object.freeze({ outcome: 'deferred', reason: 'non-active-state' });
+      }
+    } else if (facts.operation !== 'quarantine') {
+      return Object.freeze({ outcome: 'deferred', reason: 'non-active-state' });
+    }
+  } else if (current.status !== 'active') {
     return Object.freeze({ outcome: 'deferred', reason: 'non-active-state' });
   }
   const candidate = facts.head;
@@ -536,6 +1033,9 @@ function classifyAuthorityAdvance(
         ? Object.freeze({
             outcome: 'advance',
             materialization: requiresSystemRecordSnapshotRematerializationV1(snapshot)
+              || (facts.operation === 'quarantine'
+                && (current.status !== 'quarantined'
+                  || current.conflictEvidenceDigest !== facts.conflictEvidenceDigest))
               ? 'rematerialize'
               : 'reuse',
           })
@@ -632,6 +1132,7 @@ function deriveCapacity(
   next: SystemRecordAppliedStatePresentV1,
   nextTableBytes: number,
   revision: string,
+  nextPendingTableBytes = 0,
 ): CapacityDerivation {
   const current = snapshot.capacityState;
   const wasPresent = snapshot.state === 'present';
@@ -654,7 +1155,11 @@ function deriveCapacity(
       prior.stateBytes,
       BigInt(SYSTEM_RECORD_MAX_APPLIED_STATE_BYTES),
     ),
-    tableBytes: replaceContribution(current.tableBytes, prior.tableBytes, BigInt(nextTableBytes)),
+    tableBytes: replaceContribution(
+      current.tableBytes,
+      prior.tableBytes,
+      BigInt(nextTableBytes) + BigInt(nextPendingTableBytes),
+    ),
     projectionBytes: replaceContribution(
       current.projectionBytes,
       prior.projectionBytes,
@@ -805,6 +1310,29 @@ function sameTransitions(
 
 function sameStrings(left: readonly string[], right: readonly string[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function canonicalDigests(values: readonly Digest32V1[]): readonly Digest32V1[] {
+  const unique = [...new Set(values)];
+  unique.sort(compareUtf8);
+  return Object.freeze(unique);
+}
+
+function withoutConflictSaga(
+  state: SystemRecordAppliedStatePresentV1,
+): Omit<SystemRecordAppliedStatePresentV1,
+  | 'conflictEvidenceDigest'
+  | 'conflictSidecarIntentOperation'
+  | 'conflictSidecarIntentEvidenceDigest'
+  | 'conflictSidecarIntentStateRevision'> {
+  const {
+    conflictEvidenceDigest: _evidence,
+    conflictSidecarIntentOperation: _operation,
+    conflictSidecarIntentEvidenceDigest: _intentEvidence,
+    conflictSidecarIntentStateRevision: _intentRevision,
+    ...rest
+  } = state;
+  return rest;
 }
 
 function compareUtf8(left: string, right: string): number {

--- a/packages/storage/src/system-record-next-state-v1-internal.ts
+++ b/packages/storage/src/system-record-next-state-v1-internal.ts
@@ -932,6 +932,26 @@ function classifyTombstoneAdvance(
   if (snapshot.state === 'absent') return Object.freeze({ outcome: 'advance' });
   const current = snapshot.appliedState;
   if (current.headDigest === headDigest) return Object.freeze({ outcome: 'advance' });
+  // A tombstone must never advance over a fork quarantine. The quarantined row
+  // persists the quarantined ACTIVE head's digest, version, peer, root and
+  // lineage, so a tombstone naming that head as its predecessor satisfies every
+  // conjunct below -- it would delete the row, resolving the equivocation by
+  // omission and taking the evidence with it, on nothing more than the peer
+  // declining to advertise the competing branch. Only a verified direct
+  // fork-resolving successor clears a quarantine, and that path is the active
+  // classifier's, not this one. Checked after the equal-head return, so that if
+  // a tombstone row ever carries conflict slots forward its replay stays
+  // idempotent. No reachable row does today: slots populate only on a terminal
+  // transition conflict, which can never clear (unquarantine defers while slots
+  // are non-empty) and, with this gate, can never be tombstoned either. The
+  // ordering is a cheap default, not a defended state -- do not read it as
+  // evidence that such a row exists.
+  if (current.status === 'quarantined'
+      || current.conflictEvidenceDigest !== undefined
+      || current.conflictDigestSlots.length > 0
+      || current.conflictOverflow) {
+    return Object.freeze({ outcome: 'deferred', reason: 'non-active-state' });
+  }
   const predecessor = facts.verifiedAuthoritySummary.tombstonePredecessor;
   if (predecessor === undefined) {
     return Object.freeze({ outcome: 'deferred', reason: 'verified-state-mismatch' });

--- a/packages/storage/src/system-record-next-state-v1-internal.ts
+++ b/packages/storage/src/system-record-next-state-v1-internal.ts
@@ -565,6 +565,17 @@ function deriveSystemRecordTombstoneReplacementV1(input: {
       ).byteLength;
   const rootClaimSetDigest = computeSystemRecordRootClaimSetDigestV1(rootClaimSet);
 
+  // The dirty cutover plans its deletion from the incoming candidate's table
+  // while the durably recorded scope is read only for the CAS and capacity, so
+  // the two being the same scope is what makes the cutover bounded. Two
+  // fail-closed points already force it, which is why there is no third check
+  // here: a row can never persist a pending table that disagrees with its own
+  // applied-state binding, refused when written by buildSystemRecordReservedStateQuadsV1
+  // and again when read by decodeSystemRecordAppliedSnapshotV1 (both pinned --
+  // see 'refuses to encode a pending deletion table' and 'round-trips the exact
+  // pending deletion table'), and classifyTombstoneAdvance only advances a
+  // candidate whose head digest matches the persisted one -- same head, same
+  // predecessor, same table.
   if (snapshot.state === 'present'
       && persistedStateMatchesVerifiedTombstone(
         snapshot,
@@ -870,6 +881,15 @@ function assertTrustedReplacement(
   }
 }
 
+/**
+ * No `kind` clause here on purpose, and its absence is not an oversight to
+ * "restore parity" with the active twin. Only registry-minted facts reach this
+ * assert, and both binding snapshots refuse a non-agents kind at mint
+ * (system-record-verified-replacement-v1-internal.ts:343 and :361, each pinning
+ * kind to 'agents'), a precondition covered by
+ * system-record-verified-replacement-v1.test.ts:541. Re-checking it here would
+ * be a guard nothing can make fail.
+ */
 function assertTrustedTombstoneReplacement(
   facts: SystemRecordVerifiedTombstoneReplacementFactsV1,
   snapshot: SystemRecordAppliedSnapshotV1,

--- a/packages/storage/src/system-record-next-state-v1-internal.ts
+++ b/packages/storage/src/system-record-next-state-v1-internal.ts
@@ -1035,28 +1035,26 @@ function persistedStateMatchesVerifiedTombstone(
  * without the original equivocation ever being adjudicated. Each conjunct pins
  * one coordinate of the fork event against state the candidate does not own.
  *
- * P-forkedVersion / P-authoritySeq / P-forkBase name the fork event: the
- * version it happened at, the authority sequence it happened under, and the
- * base its branches descend from. P-resolutionDigest binds the summary to the
- * head in hand. P-absentRefusal refuses a head that advertises a resolution the
- * summary does not carry -- load-bearing because summary validation is identity
- * only, so a summary minted on a traversal that never ran the directness check
- * is indistinguishable here from one that did.
+ * P-forkedVersion and P-forkBase name the fork event: the version it happened
+ * at and the base its branches descend from. P-resolutionDigest binds the
+ * summary to the head in hand. P-absentRefusal refuses a head that advertises a
+ * resolution the summary does not carry -- load-bearing because summary
+ * validation is identity only, so a summary minted on a traversal that never ran
+ * the directness check is indistinguishable here from one that did.
  *
- * P-authoritySeq deliberately compares against OUR persisted lineage rather
- * than the summary's. Core forces a resolution's authority sequence to equal
- * its successor's, so the summary form could never fail. The consequence is
- * intended: a resolution issued after the peer rotated authority is refused,
- * because resolving at the next sequence moves past the equivocation instead of
- * adjudicating it. The supported order is resolve, clear, then rotate.
+ * There is deliberately NO authority-sequence conjunct, and adding one back
+ * would be a re-check rather than a restored guard. Core welds a resolution's
+ * authority sequence to its fork base's, so a resolution disagreeing with us on
+ * sequence must name a base sitting at that other sequence -- a different digest
+ * -- and P-forkBase refuses it on the same candidate. The weld is pinned in core
+ * by 'welds a fork resolution to a base at its own authority sequence'; if that
+ * test is ever removed, the sequence coordinate stops being covered here.
  *
- * Do not drop the sequence conjunct for looking untested. Deleting it alone
- * changes no test, and that is structural rather than a coverage hole: a
- * resolution cannot disagree with us on sequence ALONE, because the evidence
- * check welds a resolution's sequence to its fork base's, so any sequence
- * mismatch drags a base mismatch along and the base conjunct decides first.
- * What the tests do catch is either comparison being wired to the other's
- * operand, which is the mistake this shape actually invites.
+ * One consequence is intended and is the reason the coordinate matters: a
+ * resolution issued only after the peer rotated authority is refused, because
+ * resolving at the next sequence moves past the equivocation instead of
+ * adjudicating it. The supported order is resolve, clear, then rotate. That case
+ * is held by 'refuses a resolution issued only after the peer rotated authority'.
  */
 function resolutionAdjudicatesThisQuarantineV1(
   current: SystemRecordAppliedStatePresentV1,
@@ -1075,7 +1073,6 @@ function resolutionAdjudicatesThisQuarantineV1(
   // identity-only validator cannot tell apart from one that did.
   if (resolution === undefined) return false;
   return resolution.forkedVersion === headVersion
-    && resolution.authoritySequence === String(current.transitionLineage.length)
     && resolution.resolutionDigest === advertisedResolutionDigest
     && resolution.forkBaseHeadDigest === current.conflictForkBaseHeadDigest;
 }

--- a/packages/storage/src/system-record-rdf-schema-v1-internal.ts
+++ b/packages/storage/src/system-record-rdf-schema-v1-internal.ts
@@ -58,6 +58,8 @@ export const SYSTEM_RECORD_V1_PREDICATES = Object.freeze({
   headVersion: `${NS}head-version`,
   ownedSubjectTable: `${NS}owned-subject-table`,
   ownedSubjectTableDigest: `${NS}owned-subject-table-digest`,
+  pendingDeletionTable: `${NS}pending-deletion-table`,
+  pendingDeletionTableDigest: `${NS}pending-deletion-table-digest`,
   rootClaimSet: `${NS}root-claim-set`,
   rootClaimSetDigest: `${NS}root-claim-set-digest`,
   capacityState: `${NS}capacity-state`,
@@ -132,6 +134,7 @@ export function buildSystemRecordReservedStateQuadsV1(input: {
   readonly appliedState: SystemRecordAppliedStatePresentV1;
   readonly headVersion: string;
   readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
+  readonly pendingDeletionTable?: OwnedSubjectTableObjectV1;
   readonly rootClaimSet: SystemRecordRootClaimSetV1;
   readonly capacityState: SystemRecordCapacityStateV1;
   readonly receipt: SystemRecordMaterializationReceiptV1;
@@ -154,6 +157,18 @@ export function buildSystemRecordReservedStateQuadsV1(input: {
     appliedState.currentRoot,
     tableBytes,
   );
+  const pendingDeletionTableBytes = outer.pendingDeletionTable === undefined
+    ? undefined
+    : canonicalizeOwnedSubjectTableObjectV1(
+        appliedState.currentRoot,
+        outer.pendingDeletionTable,
+      );
+  const pendingDeletionTable = pendingDeletionTableBytes === undefined
+    ? undefined
+    : parseCanonicalOwnedSubjectTableObjectV1(
+        appliedState.currentRoot,
+        pendingDeletionTableBytes,
+      );
   const claimsBytes = canonicalizeSystemRecordRootClaimSetV1(outer.rootClaimSet);
   const rootClaimSet = parseCanonicalSystemRecordRootClaimSetV1(claimsBytes);
   const capacityBytes = canonicalizeSystemRecordCapacityStateV1(outer.capacityState);
@@ -168,6 +183,18 @@ export function buildSystemRecordReservedStateQuadsV1(input: {
   if (computeOwnedSubjectTableDigestV1(appliedState.currentRoot, ownedSubjectTable)
       !== appliedState.ownedSubjectTableDigest) {
     throw new Error('owned-subject table does not bind the applied state');
+  }
+  const expectedPendingDigest = appliedState.pendingDeletionTableDigest;
+  if ((expectedPendingDigest === undefined) !== (pendingDeletionTable === undefined)) {
+    throw new Error('pending deletion table presence does not bind the applied state');
+  }
+  if (pendingDeletionTable !== undefined && pendingDeletionTableBytes !== undefined
+      && (computeOwnedSubjectTableDigestV1(appliedState.currentRoot, pendingDeletionTable)
+          !== expectedPendingDigest
+        || String(pendingDeletionTable.length) !== appliedState.pendingDeletionSubjectCount
+        || String(pendingDeletionTableBytes.byteLength)
+          !== appliedState.pendingDeletionTableBytes)) {
+    throw new Error('pending deletion table does not bind the applied state');
   }
   if (computeSystemRecordRootClaimSetDigestV1(rootClaimSet)
       !== appliedState.rootClaimSetDigest) {
@@ -213,6 +240,25 @@ export function buildSystemRecordReservedStateQuadsV1(input: {
         stringLiteral(appliedState.ownedSubjectTableDigest),
         graph,
       ),
+      ...(pendingDeletionTableBytes === undefined || pendingDeletionTable === undefined
+        ? []
+        : [
+          quad(
+            record,
+            SYSTEM_RECORD_V1_PREDICATES.pendingDeletionTable,
+            jsonLiteral(pendingDeletionTableBytes),
+            graph,
+          ),
+          quad(
+            record,
+            SYSTEM_RECORD_V1_PREDICATES.pendingDeletionTableDigest,
+            stringLiteral(computeOwnedSubjectTableDigestV1(
+              appliedState.currentRoot,
+              pendingDeletionTable,
+            )),
+            graph,
+          ),
+        ]),
       quad(record, SYSTEM_RECORD_V1_PREDICATES.rootClaimSet, jsonLiteral(claimsBytes), graph),
       quad(
         record,
@@ -263,6 +309,7 @@ function snapshotBuildInput(input: unknown): {
   readonly appliedState: SystemRecordAppliedStatePresentV1;
   readonly headVersion: string;
   readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
+  readonly pendingDeletionTable?: OwnedSubjectTableObjectV1;
   readonly rootClaimSet: SystemRecordRootClaimSetV1;
   readonly capacityState: SystemRecordCapacityStateV1;
   readonly receipt: SystemRecordMaterializationReceiptV1;
@@ -272,15 +319,20 @@ function snapshotBuildInput(input: unknown): {
       || ![Object.prototype, null].includes(Object.getPrototypeOf(input))) {
     throw new Error('reserved-state build input must be a plain data object');
   }
-  const expected = [
+  const hasPendingDeletionTable = Object.prototype.hasOwnProperty.call(
+    input,
+    'pendingDeletionTable',
+  );
+  const expected: readonly string[] = [
     'appliedState', 'headVersion', 'ownedSubjectTable', 'rootClaimSet', 'capacityState', 'receipt',
-  ] as const;
+    ...(hasPendingDeletionTable ? ['pendingDeletionTable'] as const : []),
+  ];
   const keys = Reflect.ownKeys(input);
   if (keys.length !== expected.length
-      || keys.some((key) => typeof key !== 'string' || !expected.includes(key as typeof expected[number]))) {
+      || keys.some((key) => typeof key !== 'string' || !expected.includes(key))) {
     throw new Error('reserved-state build input has unknown or missing fields');
   }
-  const read = (key: typeof expected[number]): unknown => {
+  const read = (key: string): unknown => {
     const descriptor = Object.getOwnPropertyDescriptor(input, key);
     if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
       throw new Error('reserved-state build input fields must be enumerable data properties');
@@ -291,6 +343,9 @@ function snapshotBuildInput(input: unknown): {
     appliedState: read('appliedState') as SystemRecordAppliedStatePresentV1,
     headVersion: read('headVersion') as string,
     ownedSubjectTable: read('ownedSubjectTable') as OwnedSubjectTableObjectV1,
+    ...(hasPendingDeletionTable ? {
+      pendingDeletionTable: read('pendingDeletionTable') as OwnedSubjectTableObjectV1,
+    } : {}),
     rootClaimSet: read('rootClaimSet') as SystemRecordRootClaimSetV1,
     capacityState: read('capacityState') as SystemRecordCapacityStateV1,
     receipt: read('receipt') as SystemRecordMaterializationReceiptV1,

--- a/packages/storage/src/system-record-state-snapshot-v1-internal.ts
+++ b/packages/storage/src/system-record-state-snapshot-v1-internal.ts
@@ -9,6 +9,7 @@ import {
 import {
   assertNetworkIdV1,
   canonicalizeOwnedSubjectTableObjectV1,
+  computeOwnedSubjectTableDigestV1,
   computeSystemRecordAppliedStateDigestV1,
   computeSystemRecordCapacityStateDigestV1,
   computeSystemRecordMaterializationReceiptDigestV1,
@@ -59,6 +60,7 @@ export interface SystemRecordPresentSnapshotV1 {
   /** Storage-local frontier kept outside the frozen B1 applied-state object. */
   readonly headVersion: string;
   readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
+  readonly pendingDeletionTable?: OwnedSubjectTableObjectV1;
   readonly rootClaimSet: SystemRecordRootClaimSetV1;
   readonly capacityState: SystemRecordCapacityStateV1;
   readonly receipt: SystemRecordMaterializationReceiptV1;
@@ -159,6 +161,16 @@ export function decodeSystemRecordAppliedSnapshotV1(input: {
     appliedState.currentRoot,
     exactJsonValue(recordRows, SYSTEM_RECORD_V1_PREDICATES.ownedSubjectTable, 'owned table'),
   );
+  const pendingTable = appliedState.pendingDeletionTableDigest === undefined
+    ? undefined
+    : parseCanonicalOwnedSubjectTableObjectV1(
+        appliedState.currentRoot,
+        exactJsonValue(
+          recordRows,
+          SYSTEM_RECORD_V1_PREDICATES.pendingDeletionTable,
+          'pending deletion table',
+        ),
+      );
   const claims = parseCanonicalSystemRecordRootClaimSetV1(exactJsonValue(
     recordRows,
     SYSTEM_RECORD_V1_PREDICATES.rootClaimSet,
@@ -192,6 +204,14 @@ export function decodeSystemRecordAppliedSnapshotV1(input: {
       throw new Error(`${label} does not match its canonical object`);
     }
   }
+  if (pendingTable !== undefined
+      && exactPlainValue(
+        recordRows,
+        SYSTEM_RECORD_V1_PREDICATES.pendingDeletionTableDigest,
+        'pending deletion table digest',
+      ) !== appliedState.pendingDeletionTableDigest) {
+    throw new Error('pending deletion table digest does not match its applied state');
+  }
   if (appliedState.networkId !== networkId || appliedState.stableKeyHash !== stableKeyHash
       || claims.networkId !== networkId || claims.stableKeyHash !== stableKeyHash
       || capacity.networkId !== networkId || receipt.networkId !== networkId
@@ -217,6 +237,18 @@ export function decodeSystemRecordAppliedSnapshotV1(input: {
   const pendingTableBytes = 'pendingDeletionTableBytes' in appliedState
     ? BigInt(appliedState.pendingDeletionTableBytes as string)
     : 0n;
+  if (pendingTable !== undefined) {
+    const canonicalPendingBytes = canonicalizeOwnedSubjectTableObjectV1(
+      appliedState.currentRoot,
+      pendingTable,
+    );
+    if (computeOwnedSubjectTableDigestV1(appliedState.currentRoot, pendingTable)
+          !== appliedState.pendingDeletionTableDigest
+        || String(pendingTable.length) !== appliedState.pendingDeletionSubjectCount
+        || BigInt(canonicalPendingBytes.byteLength) !== pendingTableBytes) {
+      throw new Error('pending deletion table does not match its count or byte binding');
+    }
+  }
   if (BigInt(capacity.liveRecordCount) < 1n
       || BigInt(capacity.stateBytes) < BigInt(SYSTEM_RECORD_MAX_APPLIED_STATE_BYTES)
       || BigInt(capacity.tableBytes) < persistedTableBytes + pendingTableBytes
@@ -229,6 +261,7 @@ export function decodeSystemRecordAppliedSnapshotV1(input: {
     appliedState,
     headVersion,
     ownedSubjectTable: table,
+    ...(pendingTable === undefined ? {} : { pendingDeletionTable: pendingTable }),
     rootClaimSet: claims,
     capacityState: capacity,
     receipt,
@@ -245,6 +278,7 @@ export function decodeSystemRecordAppliedSnapshotV1(input: {
     appliedState,
     headVersion,
     ownedSubjectTable: table,
+    ...(pendingTable === undefined ? {} : { pendingDeletionTable: pendingTable }),
     rootClaimSet: claims,
     capacityState: capacity,
     receipt,

--- a/packages/storage/src/system-record-verified-replacement-v1-internal.ts
+++ b/packages/storage/src/system-record-verified-replacement-v1-internal.ts
@@ -805,7 +805,13 @@ export function createSystemRecordVerifiedReplacementRegistryForRuntimeV1(
           });
           AUTHENTIC_VERIFIED_REPLACEMENT_FACTS.add(facts);
           FACT_RESERVATIONS.set(facts, registered.reservation);
+          // The active facts this promotion supersedes must stop being authentic
+          // at the same moment, or one reservation backs two facts objects that
+          // both pass the authenticity check.
+          const superseded = registered.facts;
           registered.facts = facts;
+          AUTHENTIC_VERIFIED_REPLACEMENT_FACTS.delete(superseded);
+          FACT_RESERVATIONS.delete(superseded);
           return handle;
         } catch (error) {
           if (registered.reservation.phase !== 'released') releaseReservation(registered.reservation);

--- a/packages/storage/src/system-record-verified-replacement-v1-internal.ts
+++ b/packages/storage/src/system-record-verified-replacement-v1-internal.ts
@@ -15,20 +15,29 @@ import {
   assertAgentProfileProjectionIdentityV1,
   assertAgentProfileProjectionSchemaV1,
   assertAgentProfileVerifiedAuthoritySummaryV1,
+  canonicalizeAgentProfileConflictEvidenceV1,
   assertNetworkIdV1,
   canonicalizeAgentProfileHeadObjectV1,
   canonicalizeOwnedSubjectTableObjectV1,
   classifyAgentProfileOwnedSubjectV1,
   copyBoundedSystemRecordBytesV1,
+  computeAgentProfileConflictEvidenceDigestV1,
   computeAgentProfileHeadObjectDigestV1,
   computeOwnedSubjectTableDigestV1,
   isAllowedAgentProfilePredicateV1,
+  parseCanonicalAgentProfileConflictEvidenceV1,
   parseCanonicalAgentProfileHeadObjectV1,
   parseCanonicalOwnedSubjectTableObjectV1,
+  SYSTEM_RECORD_EMPTY_PROJECTION_DIGEST_V1,
   SYSTEM_RECORD_MAX_ATOMIC_TRANSIENT_BYTES,
   SYSTEM_RECORD_MAX_PROJECTION_BYTES,
+  SYSTEM_RECORD_OBJECT_CAPS_V1,
   type AgentProfileActiveHeadObjectV1,
+  type AgentProfileConflictEvidenceV1,
+  type AgentProfileHeadObjectV1,
+  type AgentProfileTombstoneHeadObjectV1,
   type AgentProfileVerifiedAuthoritySummaryV1,
+  type Digest32V1,
   type NetworkIdV1,
   type OwnedSubjectTableObjectV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
@@ -87,8 +96,28 @@ export interface SystemRecordActiveReplacementIssueV1
   readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
 }
 
+export interface SystemRecordTombstoneReplacementIssueV1
+  extends SystemRecordVerifiedReplacementBindingsV1 {
+  readonly head: AgentProfileTombstoneHeadObjectV1;
+  readonly verifiedAuthoritySummary: AgentProfileVerifiedAuthoritySummaryV1;
+  /** Exact deletion-only table authenticated by the predecessor closure. */
+  readonly deletionOwnedSubjectTable: OwnedSubjectTableObjectV1;
+}
+
+export interface SystemRecordQuarantineReplacementIssueV1
+  extends SystemRecordActiveReplacementIssueV1 {
+  readonly conflictEvidenceDigest: Digest32V1;
+  readonly canonicalConflictEvidenceBytes: Uint8Array;
+  readonly terminalTransitionConflict: boolean;
+}
+
+export type SystemRecordVerifiedCandidateIssueV1 =
+  | Readonly<{ readonly operation: 'active' } & SystemRecordActiveReplacementIssueV1>
+  | Readonly<{ readonly operation: 'tombstone' } & SystemRecordTombstoneReplacementIssueV1>
+  | Readonly<{ readonly operation: 'quarantine' } & SystemRecordQuarantineReplacementIssueV1>;
+
 /** Deep-owned immutable facts returned once to the storage-side consumer. */
-export interface SystemRecordVerifiedReplacementFactsV1 {
+interface SystemRecordVerifiedReplacementCommonFactsV1 {
   readonly networkId: NetworkIdV1;
   readonly kind: 'agents';
   readonly mode: SystemRecordMaterializationModeV1;
@@ -98,6 +127,11 @@ export interface SystemRecordVerifiedReplacementFactsV1 {
   readonly admittedDeadlineMs: number;
   /** Opaque accountant capability; it carries no mutable or inspectable data. */
   readonly reservationIdentity: object;
+}
+
+export interface SystemRecordVerifiedActiveReplacementFactsV1
+  extends SystemRecordVerifiedReplacementCommonFactsV1 {
+  readonly operation: 'active';
   readonly head: AgentProfileActiveHeadObjectV1;
   readonly verifiedAuthoritySummary: AgentProfileVerifiedAuthoritySummaryV1;
   readonly projectionDigest: ReturnType<typeof computeKaBundleProjectionDigestV1>;
@@ -106,8 +140,38 @@ export interface SystemRecordVerifiedReplacementFactsV1 {
   readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
 }
 
+export interface SystemRecordVerifiedTombstoneReplacementFactsV1
+  extends SystemRecordVerifiedReplacementCommonFactsV1 {
+  readonly operation: 'tombstone';
+  readonly head: AgentProfileTombstoneHeadObjectV1;
+  readonly verifiedAuthoritySummary: AgentProfileVerifiedAuthoritySummaryV1;
+  readonly projectionDigest: typeof SYSTEM_RECORD_EMPTY_PROJECTION_DIGEST_V1;
+  readonly projectionQuads: readonly Readonly<Quad>[];
+  readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
+  readonly deletionOwnedSubjectTable: OwnedSubjectTableObjectV1;
+}
+
+export interface SystemRecordVerifiedQuarantineReplacementFactsV1
+  extends SystemRecordVerifiedReplacementCommonFactsV1 {
+  readonly operation: 'quarantine';
+  readonly head: AgentProfileActiveHeadObjectV1;
+  readonly verifiedAuthoritySummary: AgentProfileVerifiedAuthoritySummaryV1;
+  readonly projectionDigest: ReturnType<typeof computeKaBundleProjectionDigestV1>;
+  readonly projectionQuads: readonly Readonly<Quad>[];
+  readonly ownedSubjectTable: OwnedSubjectTableObjectV1;
+  readonly conflictEvidence: AgentProfileConflictEvidenceV1;
+  readonly conflictEvidenceDigest: Digest32V1;
+  readonly terminalTransitionConflict: boolean;
+}
+
+export type SystemRecordVerifiedReplacementFactsV1 =
+  | SystemRecordVerifiedActiveReplacementFactsV1
+  | SystemRecordVerifiedTombstoneReplacementFactsV1
+  | SystemRecordVerifiedQuarantineReplacementFactsV1;
+
 export interface SystemRecordVerifiedReplacementIssuerV1 {
   issueActive(input: SystemRecordActiveReplacementIssueV1): SystemRecordVerifiedReplacementHandleV1;
+  issueCandidate(input: SystemRecordVerifiedCandidateIssueV1): SystemRecordVerifiedReplacementHandleV1;
 }
 
 export interface SystemRecordVerifiedReplacementConsumerV1 {
@@ -152,7 +216,7 @@ export interface SystemRecordVerifiedReplacementRegistryV1 {
 interface RegisteredReplacementV1 {
   readonly registryIdentity: object;
   readonly bindings: SystemRecordVerifiedReplacementBindingsV1;
-  readonly facts: SystemRecordVerifiedReplacementFactsV1;
+  facts: SystemRecordVerifiedReplacementFactsV1;
   readonly reservation: RuntimeReservationV1;
   used: boolean;
 }
@@ -210,6 +274,29 @@ const ISSUE_KEYS = [
   'canonicalProjectionBytes',
   'projectionQuads',
   'ownedSubjectTable',
+] as const;
+
+const TAGGED_ACTIVE_ISSUE_KEYS = ['operation', ...ISSUE_KEYS] as const;
+const TOMBSTONE_ISSUE_KEYS = [
+  'operation',
+  'networkId',
+  'kind',
+  'mode',
+  'sessionIdentity',
+  'activationGeneration',
+  'childGeneration',
+  'materializationEpoch',
+  'admittedDeadlineMs',
+  'head',
+  'verifiedAuthoritySummary',
+  'deletionOwnedSubjectTable',
+] as const;
+const QUARANTINE_ISSUE_KEYS = [
+  'operation',
+  ...ISSUE_KEYS,
+  'conflictEvidenceDigest',
+  'canonicalConflictEvidenceBytes',
+  'terminalTransitionConflict',
 ] as const;
 
 const BINDING_KEYS = [
@@ -420,6 +507,43 @@ function bindingsEqual(
     && actual.materializationEpoch === expected.materializationEpoch;
 }
 
+function candidateIssueKeys(value: unknown): readonly string[] {
+  if (value === null || typeof value !== 'object' || utilTypes.isProxy(value)) {
+    throw new Error('verified replacement candidate must be a non-Proxy data object');
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(value, 'operation');
+  if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+    throw new Error('verified replacement candidate operation must be an enumerable data property');
+  }
+  if (descriptor.value === 'active') return TAGGED_ACTIVE_ISSUE_KEYS;
+  if (descriptor.value === 'tombstone') return TOMBSTONE_ISSUE_KEYS;
+  if (descriptor.value === 'quarantine') return QUARANTINE_ISSUE_KEYS;
+  throw new Error('verified replacement candidate operation is invalid');
+}
+
+function stripOperation(
+  value: Readonly<Record<string, unknown>>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  return Object.fromEntries(keys.map((key) => [key, value[key]]));
+}
+
+function tombstoneBindsPredecessor(
+  tombstone: AgentProfileTombstoneHeadObjectV1,
+  predecessor: AgentProfileActiveHeadObjectV1,
+): boolean {
+  return tombstone.previousHeadDigest === computeAgentProfileHeadObjectDigestV1(predecessor)
+    && tombstone.networkId === predecessor.networkId
+    && tombstone.peerId === predecessor.peerId
+    && tombstone.peerPublicKey === predecessor.peerPublicKey
+    && tombstone.authoritySequence === predecessor.authoritySequence
+    && tombstone.acceptedTransitionDigest === predecessor.acceptedTransitionDigest
+    && tombstone.evmIssuer === predecessor.evmIssuer
+    && tombstone.rootSubject === predecessor.rootSubject
+    && tombstone.projectionSchemaDigest === predecessor.projectionSchemaDigest
+    && BigInt(tombstone.version) > BigInt(predecessor.version);
+}
+
 /**
  * Create one non-interchangeable issuer/consumer pair. Only the consumer half belongs
  * in the storage executor; only the issuer half belongs in the verifier closure.
@@ -581,6 +705,7 @@ export function createSystemRecordVerifiedReplacementRegistryForRuntimeV1(
       reservation.charges.decoded = decodedBytes;
 
       const facts: SystemRecordVerifiedReplacementFactsV1 = Object.freeze({
+        operation: 'active',
         networkId: bindings.networkId,
         kind: bindings.kind,
         mode: bindings.mode,
@@ -608,6 +733,167 @@ export function createSystemRecordVerifiedReplacementRegistryForRuntimeV1(
         used: false,
       });
       return handle;
+      } catch (error) {
+        if (reservation.phase !== 'released') releaseReservation(reservation);
+        throw error;
+      }
+    },
+    issueCandidate(value: SystemRecordVerifiedCandidateIssueV1): SystemRecordVerifiedReplacementHandleV1 {
+      const tagged = exactRecord(
+        value,
+        candidateIssueKeys(value),
+        'verified replacement candidate',
+      );
+      if (tagged.operation === 'active') {
+        return issuer.issueActive(
+          stripOperation(tagged, ISSUE_KEYS) as unknown as SystemRecordActiveReplacementIssueV1,
+        );
+      }
+      if (tagged.operation === 'quarantine') {
+        const activeInput = stripOperation(
+          tagged,
+          ISSUE_KEYS,
+        ) as unknown as SystemRecordActiveReplacementIssueV1;
+        const handle = issuer.issueActive(activeInput);
+        const registered = registeredHandle(handle);
+        try {
+          const canonicalEvidenceBytes = copyBoundedSystemRecordBytesV1(
+            tagged.canonicalConflictEvidenceBytes,
+            SYSTEM_RECORD_OBJECT_CAPS_V1['conflict-evidence'],
+            'canonical conflict evidence',
+          );
+          const evidence = parseCanonicalAgentProfileConflictEvidenceV1(canonicalEvidenceBytes);
+          const canonicalEvidence = canonicalizeAgentProfileConflictEvidenceV1(evidence);
+          if (!Buffer.from(canonicalEvidence).equals(Buffer.from(canonicalEvidenceBytes))) {
+            throw new Error('conflict evidence bytes are not the canonical evidence object');
+          }
+          const evidenceDigest = computeAgentProfileConflictEvidenceDigestV1(evidence);
+          if (evidenceDigest !== tagged.conflictEvidenceDigest
+              || evidence.networkId !== registered.facts.networkId
+              || evidence.peerId !== registered.facts.head.peerId) {
+            throw new Error('conflict evidence does not bind the verified active candidate');
+          }
+          const terminalTransitionConflict = evidence.entries.some((entry) =>
+            entry.type === 'transition');
+          if (tagged.terminalTransitionConflict !== terminalTransitionConflict) {
+            throw new Error('conflict evidence terminal classification is inconsistent');
+          }
+          const headDigest = computeAgentProfileHeadObjectDigestV1(registered.facts.head);
+          for (const entry of evidence.entries) {
+            if (entry.type === 'fork'
+                && (entry.authoritySequence !== registered.facts.head.authoritySequence
+                  || entry.version !== registered.facts.head.version
+                  || !entry.objectDigests.includes(headDigest))) {
+              throw new Error('fork evidence does not bind the verified active candidate frontier');
+            }
+          }
+          if (registered.facts.operation !== 'active') {
+            throw new Error('quarantine candidate did not produce active verified facts');
+          }
+          const decodedBytes = registered.reservation.charges.decoded
+            + retainedVerifiedConflictEvidenceBytes(evidence);
+          if (decodedBytes > registered.reservation.bytes) {
+            throw new Error('verified replacement decoded state exceeds its transient lease');
+          }
+          registered.reservation.charges.decoded = decodedBytes;
+          const facts: SystemRecordVerifiedQuarantineReplacementFactsV1 = Object.freeze({
+            ...registered.facts,
+            operation: 'quarantine',
+            conflictEvidence: evidence,
+            conflictEvidenceDigest: evidenceDigest,
+            terminalTransitionConflict,
+          });
+          AUTHENTIC_VERIFIED_REPLACEMENT_FACTS.add(facts);
+          FACT_RESERVATIONS.set(facts, registered.reservation);
+          registered.facts = facts;
+          return handle;
+        } catch (error) {
+          if (registered.reservation.phase !== 'released') releaseReservation(registered.reservation);
+          throw error;
+        }
+      }
+
+      const bindings = snapshotBindings(stripOperation(tagged, BINDING_KEYS));
+      const reservation = reserveAtomic(bindings.admittedDeadlineMs, 0);
+      try {
+        if (tagged.head !== null && typeof tagged.head === 'object' && utilTypes.isProxy(tagged.head)) {
+          throw new Error('verified replacement head must not be a Proxy');
+        }
+        assertAgentProfileHeadObjectV1(tagged.head);
+        const parsedHead = parseCanonicalAgentProfileHeadObjectV1(
+          canonicalizeAgentProfileHeadObjectV1(tagged.head as AgentProfileHeadObjectV1),
+        );
+        if (parsedHead.state !== 'tombstone') {
+          throw new Error('verified tombstone replacement head must be tombstone');
+        }
+        if (parsedHead.networkId !== bindings.networkId) {
+          throw new Error('verified tombstone replacement head does not bind networkId');
+        }
+        assertAgentProfileVerifiedAuthoritySummaryV1(tagged.verifiedAuthoritySummary);
+        const authority = tagged.verifiedAuthoritySummary;
+        const predecessor = authority.tombstonePredecessor;
+        if (authority.candidateHeadDigest !== computeAgentProfileHeadObjectDigestV1(parsedHead)
+            || predecessor === undefined
+            || authority.deletionTableDigest !== predecessor.ownedSubjectTableDigest
+            || !tombstoneBindsPredecessor(parsedHead, predecessor)) {
+          throw new Error('verified tombstone authority summary lacks its exact predecessor');
+        }
+        if (utilTypes.isProxy(tagged.deletionOwnedSubjectTable)) {
+          throw new Error('tombstone deletion table must not be a Proxy');
+        }
+        const deletionTable = parseCanonicalOwnedSubjectTableObjectV1(
+          predecessor.rootSubject,
+          canonicalizeOwnedSubjectTableObjectV1(
+            predecessor.rootSubject,
+            tagged.deletionOwnedSubjectTable as OwnedSubjectTableObjectV1,
+          ),
+        );
+        if (computeOwnedSubjectTableDigestV1(predecessor.rootSubject, deletionTable)
+              !== predecessor.ownedSubjectTableDigest
+            || BigInt(deletionTable.length) !== BigInt(predecessor.ownedSubjectCount)) {
+          throw new Error('tombstone deletion table does not bind the verified predecessor');
+        }
+        const emptyTable = Object.freeze([]) as unknown as OwnedSubjectTableObjectV1;
+        const emptyProjection = Object.freeze([]) as readonly Readonly<Quad>[];
+        const decodedBytes = retainedVerifiedTerminalFactsBytes(
+          parsedHead,
+          authority,
+          deletionTable,
+        );
+        if (decodedBytes > reservation.bytes) {
+          throw new Error('verified replacement decoded state exceeds its transient lease');
+        }
+        reservation.charges.decoded = decodedBytes;
+        const facts: SystemRecordVerifiedTombstoneReplacementFactsV1 = Object.freeze({
+          operation: 'tombstone',
+          networkId: bindings.networkId,
+          kind: bindings.kind,
+          mode: bindings.mode,
+          activationGeneration: bindings.activationGeneration,
+          childGeneration: bindings.childGeneration,
+          materializationEpoch: bindings.materializationEpoch,
+          admittedDeadlineMs: bindings.admittedDeadlineMs,
+          reservationIdentity: reservation.identity,
+          head: parsedHead,
+          verifiedAuthoritySummary: authority,
+          projectionDigest: SYSTEM_RECORD_EMPTY_PROJECTION_DIGEST_V1,
+          projectionQuads: emptyProjection,
+          ownedSubjectTable: emptyTable,
+          deletionOwnedSubjectTable: deletionTable,
+        });
+        AUTHENTIC_VERIFIED_REPLACEMENT_FACTS.add(facts);
+        FACT_RESERVATIONS.set(facts, reservation);
+        const handle = Object.freeze(
+          Object.create(null) as object,
+        ) as SystemRecordVerifiedReplacementHandleV1;
+        REGISTERED_REPLACEMENTS.set(handle, {
+          registryIdentity,
+          bindings,
+          facts,
+          reservation,
+          used: false,
+        });
+        return handle;
       } catch (error) {
         if (reservation.phase !== 'released') releaseReservation(reservation);
         throw error;
@@ -761,4 +1047,22 @@ function retainedVerifiedFactsBytes(
     if (!Number.isSafeInteger(bytes)) return Number.MAX_SAFE_INTEGER;
   }
   return bytes;
+}
+
+function retainedVerifiedTerminalFactsBytes(
+  head: AgentProfileTombstoneHeadObjectV1,
+  authority: AgentProfileVerifiedAuthoritySummaryV1,
+  deletionTable: OwnedSubjectTableObjectV1,
+): number {
+  return 2 * (
+    Buffer.byteLength(JSON.stringify(head), 'utf8')
+    + Buffer.byteLength(JSON.stringify(authority), 'utf8')
+    + Buffer.byteLength(JSON.stringify(deletionTable), 'utf8')
+  );
+}
+
+function retainedVerifiedConflictEvidenceBytes(
+  evidence: AgentProfileConflictEvidenceV1,
+): number {
+  return 2 * Buffer.byteLength(JSON.stringify(evidence), 'utf8');
 }

--- a/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
+++ b/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
@@ -8,13 +8,19 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   buildAgentProfileVerificationClosureV1,
+  canonicalizeAgentProfileConflictEvidenceV1,
   canonicalizeSignedSystemRecordEnvelopeV1,
+  computeAgentProfileAuthorityTransitionDigestV1,
+  computeAgentProfileConflictEvidenceDigestV1,
   computeAgentProfileForkResolutionDigestV1,
   computeAgentProfileHeadObjectDigestV1,
+  computeOwnedSubjectTableDigestV1,
   computeSystemRecordStableKeyHashV1,
   digestSystemRecordBytesV1,
   SYSTEM_RECORD_DIGEST_DOMAINS_V1,
   type AgentProfileActiveHeadObjectV1,
+  type AgentProfileAuthorityTransitionV1,
+  type AgentProfileConflictEvidenceV1,
   type AgentProfileForkResolutionV1,
   type AgentProfileVerifiedAuthoritySummaryV1,
   type Digest32V1,
@@ -35,6 +41,7 @@ import { decodeSystemRecordAppliedSnapshotV1 } from '../../src/system-record-sta
 import {
   createSystemRecordVerifiedReplacementRegistryV1,
   type SystemRecordActiveReplacementIssueV1,
+  type SystemRecordQuarantineReplacementIssueV1,
 } from '../../src/system-record-verified-replacement-v1-internal.js';
 import type { SystemRecordLaneExecutionBindingV1 } from '../../src/system-record-materializer-v1.js';
 import type { Quad } from '../../src/triple-store.js';
@@ -148,95 +155,306 @@ export function makeSystemRecordActiveReplacementIssueV1(
 }
 
 const SIBLING_BUNDLE_DIGEST = `0x${'c7'.repeat(32)}` as Digest32V1;
+const ALTERNATE_BASE_ISSUED_AT = '2026-08-05T11:59:00Z';
+const ROTATION_ISSUERS = [
+  '0x5555555555555555555555555555555555555555',
+  '0x6666666666666666666666666666666666666666',
+] as const;
 
-export interface ForkResolvingSuccessorFixtureV1 {
-  readonly resolution: AgentProfileForkResolutionV1;
-  readonly head: AgentProfileActiveHeadObjectV1;
-  readonly issue: SystemRecordActiveReplacementIssueV1;
+/**
+ * Rotate authority to a new issuer, rebuilding the projection the rotation
+ * invalidates: a rotation moves the root subject, and a head commits to a
+ * digest of the projection over that root.
+ */
+function rotatedActiveHead(
+  source: AgentProfileActiveHeadObjectV1,
+  issuer: string,
+  authoritySequence: string,
+  version: string,
+  history: Readonly<{ previousHeadDigest?: Digest32V1; acceptedTransitionDigest?: Digest32V1 }>,
+): AgentProfileActiveHeadObjectV1 {
+  const rootSubject = `did:dkg:agent:${issuer}`;
+  const draft = {
+    ...source,
+    authoritySequence,
+    version,
+    ...history,
+    evmIssuer: issuer,
+    rootSubject,
+    ownedSubjectTableDigest: computeOwnedSubjectTableDigestV1(rootSubject, [rootSubject]),
+  } as AgentProfileActiveHeadObjectV1;
+  const quads = projectionFor(draft);
+  const contentDigest = contentDigestFor(quads);
+  return {
+    ...draft,
+    projectionBytes: String(canonicalBytesFor(quads).byteLength),
+    projectionQuads: String(quads.length),
+    contentDigest,
+    graphScopedAuthorSeal: {
+      ...source.graphScopedAuthorSeal,
+      authorAddress: issuer,
+      kaUal: `did:dkg:otp:20430/${issuer}/7`,
+      reservedKaId: ((BigInt(issuer) << 96n) | 7n).toString(),
+      assertionMerkleRoot: contentDigest,
+      publicTripleCount: String(quads.length),
+    },
+  } as AgentProfileActiveHeadObjectV1;
 }
 
 /**
- * A version-zero fork resolved by a successor descending from neither sibling,
- * so the resolution names no common base. The closure is the real one, so the
- * minted summary carries verified fork-resolution facts rather than a stub.
+ * Two real authority rotations, so a head derived from the result carries a
+ * transition lineage of length two. That is what lets the persisted row's
+ * lineage length differ from the forked version, which is the only way a
+ * predicate comparing the wrong one of the two can be caught.
+ */
+function twiceRotatedChain() {
+  const initial = structuredClone(verified.head);
+  const first = rotationTransition(initial, '1', ROTATION_ISSUERS[0]);
+  const middle = rotatedActiveHead(initial, ROTATION_ISSUERS[0], '1', '0', {
+    acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(first),
+  });
+  const second = rotationTransition(middle, '2', ROTATION_ISSUERS[1]);
+  const base = rotatedActiveHead(middle, ROTATION_ISSUERS[1], '2', '0', {
+    acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(second),
+  });
+  return { initial, middle, base, transitions: [first, second] as const };
+}
+
+function rotationTransition(
+  prior: AgentProfileActiveHeadObjectV1,
+  nextAuthoritySequence: string,
+  nextEvmIssuer: string,
+): AgentProfileAuthorityTransitionV1 {
+  return {
+    objectType: 'authority-transition',
+    kind: 'agents',
+    mode: 'co-signed',
+    networkId: prior.networkId,
+    peerId: prior.peerId,
+    peerPublicKey: prior.peerPublicKey,
+    priorAuthoritySequence: prior.authoritySequence,
+    nextAuthoritySequence,
+    priorHeadDigest: computeAgentProfileHeadObjectDigestV1(prior),
+    priorEvmIssuer: prior.evmIssuer,
+    nextEvmIssuer,
+    nextRoot: `did:dkg:agent:${nextEvmIssuer}`,
+    issuedAt: '2026-08-05T12:02:00Z',
+  } as AgentProfileAuthorityTransitionV1;
+}
+
+export interface ForkResolvingSuccessorFixtureV1 {
+  readonly resolution: AgentProfileForkResolutionV1;
+  /** The resolving successor. */
+  readonly head: AgentProfileActiveHeadObjectV1;
+  readonly issue: SystemRecordActiveReplacementIssueV1;
+  /** Our branch of the fork -- the head a receiver applies and then quarantines. */
+  readonly forkedIssue: SystemRecordActiveReplacementIssueV1;
+  /** Quarantines our branch on evidence naming both branches of the same fork. */
+  readonly quarantineIssue: SystemRecordQuarantineReplacementIssueV1;
+  readonly forkBaseHeadDigest?: Digest32V1;
+}
+
+/**
+ * A fork and the successor that resolves it, built through the real closure so
+ * the minted summary carries facts core actually produces.
+ *
+ * `genesis` forks at version zero, so the resolution names no common base and
+ * the successor descends from nothing. `based` forks at version one off a
+ * version-zero base, which is the shape that discriminates: its authority
+ * sequence, forked version, resolution version and successor version are four
+ * distinct numbers, so a predicate comparing the wrong pair cannot pass by
+ * coincidence. Use `based` for anything asserting on individual conjuncts.
  */
 export async function makeForkResolvingSuccessorFixtureV1(
   binding: SystemRecordLaneExecutionBindingV1,
+  shape: 'genesis' | 'based' | 'other-version' | 'other-base' | 'rotated' = 'genesis',
+  terminalTransitionConflict = false,
 ): Promise<ForkResolvingSuccessorFixtureV1> {
-  const forked = structuredClone(verified.head);
+  const genesis = shape === 'genesis';
+  const chain = shape === 'rotated' ? twiceRotatedChain() : undefined;
+  const origin = chain?.base ?? structuredClone(verified.head);
+  // A second version-zero head of the same authority: a different common base,
+  // which is what distinguishes two fork events that agree on every other
+  // coordinate. It differs by issue time rather than by bundle, so it keeps the
+  // one bundle this fixture can resolve while still hashing differently.
+  const base = shape === 'other-base'
+    ? { ...origin, issuedAt: ALTERNATE_BASE_ISSUED_AT } as AgentProfileActiveHeadObjectV1
+    : origin;
+  const baseDigest = computeAgentProfileHeadObjectDigestV1(base);
+  const forkedVersion = genesis ? '0' : shape === 'other-version' ? '2' : '1';
+  const forked = genesis
+    ? base
+    : { ...base, version: forkedVersion, previousHeadDigest: baseDigest } as AgentProfileActiveHeadObjectV1;
   const sibling = { ...forked, bundleDigest: SIBLING_BUNDLE_DIGEST };
   const resolution = Object.freeze({
     objectType: 'fork-resolution',
     kind: 'agents',
-    networkId: forked.networkId,
-    peerId: forked.peerId,
-    peerPublicKey: forked.peerPublicKey,
-    evmIssuer: forked.evmIssuer,
-    authoritySequence: forked.authoritySequence,
-    forkedVersion: forked.version,
-    resolutionVersion: '2',
+    networkId: origin.networkId,
+    peerId: origin.peerId,
+    peerPublicKey: origin.peerPublicKey,
+    evmIssuer: origin.evmIssuer,
+    authoritySequence: origin.authoritySequence,
+    forkedVersion,
+    resolutionVersion: genesis ? '2' : '3',
+    ...(genesis ? {} : { forkBaseHeadDigest: baseDigest }),
     evidenceHeadDigests: Object.freeze(
       [forked, sibling].map(computeAgentProfileHeadObjectDigestV1).sort(),
     ),
     issuedAt: '2026-08-05T12:05:00Z',
   }) as AgentProfileForkResolutionV1;
   const head = {
-    ...forked,
-    version: '3',
+    ...origin,
+    version: genesis ? '3' : shape === 'other-version' ? '5' : '4',
+    ...(genesis ? {} : { previousHeadDigest: baseDigest }),
     forkResolutionDigest: computeAgentProfileForkResolutionDigestV1(resolution),
   } as AgentProfileActiveHeadObjectV1;
-  const headDigest = computeAgentProfileHeadObjectDigestV1(head);
-  const artifacts = new Map<string, {
-    objectKind: 'agent-profile-head' | 'fork-resolution' | 'profile-bundle';
-    digest: Digest32V1;
-    canonicalBytes: Uint8Array;
-  }>([
-    envelopeArtifact('agent-profile-head', head),
-    envelopeArtifact('agent-profile-head', forked),
-    envelopeArtifact('agent-profile-head', sibling),
-    envelopeArtifact('fork-resolution', resolution),
-    [`profile-bundle:${head.bundleDigest}`, {
-      objectKind: 'profile-bundle',
-      digest: head.bundleDigest,
-      canonicalBytes: verified.bundle,
-    }],
-  ]);
-  const closure = await buildAgentProfileVerificationClosureV1(headDigest, {
-    nowMs: Date.parse('2026-08-05T12:10:00Z'),
-    resolve: async (reference) => artifacts.get(`${reference.objectKind}:${reference.digest}`),
-    verifyAuthorityEnvelope: () => true,
-    verifyCurrentBundle: (_head, bytes) =>
-      Buffer.from(bytes).equals(Buffer.from(verified.bundle)),
-  });
+  const artifacts = closureArtifactsFor(
+    [head, forked, sibling, base, ...(chain === undefined ? [] : [chain.middle, chain.initial])],
+    resolution,
+    chain?.transitions ?? [],
+  );
+  const closure = await buildAgentProfileVerificationClosureV1(
+    computeAgentProfileHeadObjectDigestV1(head),
+    closureOptions(),
+  );
+  const forkedClosure = genesis
+    ? undefined
+    : await buildAgentProfileVerificationClosureV1(
+      computeAgentProfileHeadObjectDigestV1(forked),
+      closureOptions(),
+    );
+  // A rotation moves the root subject, so the issue must carry the projection
+  // over the NEW root -- the derivation recomputes the head's committed digests
+  // from exactly these quads and refuses a mismatch.
+  const projected = chain === undefined ? {} : (() => {
+    const quads = projectionFor(forked);
+    return {
+      canonicalProjectionBytes: canonicalBytesFor(quads),
+      projectionQuads: quads,
+      ownedSubjectTable: [forked.rootSubject],
+    };
+  })();
+  const issue = { ...makeSystemRecordActiveReplacementIssueV1(binding), ...projected };
+  const forkedIssue = forkedClosure === undefined
+    ? issue
+    : { ...issue, head: forked, verifiedAuthoritySummary: forkedClosure.authoritySummary };
+  const branchDigests = Object.freeze(
+    [forked, sibling].map(computeAgentProfileHeadObjectDigestV1).sort(),
+  ) as readonly Digest32V1[];
+  // A transition-typed entry is what makes a quarantine terminal, and it is the
+  // only thing that fills the conflict digest slots: fork-only evidence leaves
+  // them empty. A pin needing a slots-carrying row therefore has to come through
+  // here rather than assigning the array.
+  const evidence = Object.freeze({
+    objectType: 'conflict-evidence',
+    kind: 'agents',
+    networkId: base.networkId,
+    peerId: base.peerId,
+    entries: Object.freeze([Object.freeze(terminalTransitionConflict
+      ? {
+        type: 'transition',
+        priorAuthoritySequence: forked.authoritySequence,
+        nextAuthoritySequence: String(BigInt(forked.authoritySequence) + 1n),
+        objectDigests: branchDigests,
+      }
+      : {
+        type: 'fork',
+        authoritySequence: forked.authoritySequence,
+        version: forked.version,
+        objectDigests: branchDigests,
+      })]),
+  }) as AgentProfileConflictEvidenceV1;
   return Object.freeze({
     resolution,
     head,
-    issue: {
-      ...makeSystemRecordActiveReplacementIssueV1(binding),
-      head,
-      verifiedAuthoritySummary: closure.authoritySummary,
+    issue: { ...issue, head, verifiedAuthoritySummary: closure.authoritySummary },
+    forkedIssue,
+    quarantineIssue: {
+      ...forkedIssue,
+      conflictEvidenceDigest: computeAgentProfileConflictEvidenceDigestV1(evidence),
+      canonicalConflictEvidenceBytes: canonicalizeAgentProfileConflictEvidenceV1(evidence),
+      terminalTransitionConflict,
     },
+    ...(genesis ? {} : { forkBaseHeadDigest: baseDigest }),
   });
+
+  function closureOptions() {
+    return {
+      nowMs: Date.parse('2026-08-05T12:10:00Z'),
+      resolve: async (reference: { objectKind: string; digest: string }) =>
+        artifacts.get(`${reference.objectKind}:${reference.digest}`),
+      verifyAuthorityEnvelope: () => true,
+      verifyCurrentBundle: (_head: unknown, bytes: Uint8Array) =>
+        Buffer.from(bytes).equals(Buffer.from(verified.bundle)),
+    };
+  }
+}
+
+function closureArtifactsFor(
+  heads: readonly AgentProfileActiveHeadObjectV1[],
+  resolution: AgentProfileForkResolutionV1,
+  transitions: readonly AgentProfileAuthorityTransitionV1[] = [],
+) {
+  const artifacts = new Map<string, {
+    objectKind: 'agent-profile-head' | 'fork-resolution' | 'profile-bundle'
+      | 'authority-transition';
+    digest: Digest32V1;
+    canonicalBytes: Uint8Array;
+  }>([
+    ...heads.map((head) => envelopeArtifact('agent-profile-head', head)),
+    ...transitions.map((transition) => envelopeArtifact('authority-transition', transition)),
+    envelopeArtifact('fork-resolution', resolution),
+  ]);
+  artifacts.set(`profile-bundle:${verified.head.bundleDigest}`, {
+    objectKind: 'profile-bundle',
+    digest: verified.head.bundleDigest,
+    canonicalBytes: verified.bundle,
+  });
+  return artifacts;
 }
 
 function envelopeArtifact(
-  objectKind: 'agent-profile-head' | 'fork-resolution',
-  object: AgentProfileActiveHeadObjectV1 | AgentProfileForkResolutionV1,
+  objectKind: 'agent-profile-head' | 'fork-resolution' | 'authority-transition',
+  object: AgentProfileActiveHeadObjectV1 | AgentProfileForkResolutionV1
+    | AgentProfileAuthorityTransitionV1,
 ): [string, {
-  objectKind: 'agent-profile-head' | 'fork-resolution';
+  objectKind: 'agent-profile-head' | 'fork-resolution' | 'authority-transition';
   digest: Digest32V1;
   canonicalBytes: Uint8Array;
 }] {
   const digest = object.objectType === 'agent-profile-head'
     ? computeAgentProfileHeadObjectDigestV1(object)
-    : computeAgentProfileForkResolutionDigestV1(object);
+    : object.objectType === 'authority-transition'
+      ? computeAgentProfileAuthorityTransitionDigestV1(object)
+      : computeAgentProfileForkResolutionDigestV1(object);
+  // Signers are rebuilt per role rather than reused from the vector envelope: a
+  // rotation changes the object's issuer, and the envelope check rejects a
+  // current-evm signature that still names the previous one.
+  const template = structuredClone(vectors.signed.activeEip191.envelope);
+  const peerEntry = template.signatures.find((entry) => entry.role === 'peer');
+  const evmEntry = template.signatures.find((entry) => entry.role !== 'peer');
+  const roles = object.objectType === 'authority-transition'
+    ? [
+      { role: 'peer', signer: object.peerId },
+      { role: 'prior-evm', signer: object.priorEvmIssuer },
+      { role: 'next-evm', signer: object.nextEvmIssuer },
+    ]
+    : [
+      { role: 'peer', signer: object.peerId },
+      { role: 'current-evm', signer: object.evmIssuer },
+    ];
   return [`${objectKind}:${digest}`, {
     objectKind,
     digest,
     canonicalBytes: canonicalizeSignedSystemRecordEnvelopeV1({
-      ...structuredClone(vectors.signed.activeEip191.envelope),
+      ...template,
       object,
       objectDigest: digest,
+      signatures: roles.map(({ role, signer }) => ({
+        ...(role === 'peer' ? peerEntry : evmEntry),
+        role,
+        signer,
+      })),
     } as SignedAgentProfileHeadEnvelopeV1),
   }];
 }

--- a/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
+++ b/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
@@ -9,12 +9,15 @@ import {
 import {
   buildAgentProfileVerificationClosureV1,
   canonicalizeSignedSystemRecordEnvelopeV1,
+  computeAgentProfileForkResolutionDigestV1,
   computeAgentProfileHeadObjectDigestV1,
   computeSystemRecordStableKeyHashV1,
   digestSystemRecordBytesV1,
   SYSTEM_RECORD_DIGEST_DOMAINS_V1,
   type AgentProfileActiveHeadObjectV1,
+  type AgentProfileForkResolutionV1,
   type AgentProfileVerifiedAuthoritySummaryV1,
+  type Digest32V1,
   type NetworkIdV1,
   type SignedAgentProfileHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
@@ -71,6 +74,7 @@ const verified = await (async () => {
   return Object.freeze({
     head,
     authority: await mintAuthority(head, bundle),
+    bundle,
     projectionQuads,
     canonicalProjectionBytes,
   });
@@ -141,6 +145,100 @@ export function makeSystemRecordActiveReplacementIssueV1(
     projectionQuads: structuredClone(verified.projectionQuads),
     ownedSubjectTable: [verified.head.rootSubject],
   };
+}
+
+const SIBLING_BUNDLE_DIGEST = `0x${'c7'.repeat(32)}` as Digest32V1;
+
+export interface ForkResolvingSuccessorFixtureV1 {
+  readonly resolution: AgentProfileForkResolutionV1;
+  readonly head: AgentProfileActiveHeadObjectV1;
+  readonly issue: SystemRecordActiveReplacementIssueV1;
+}
+
+/**
+ * A version-zero fork resolved by a successor descending from neither sibling,
+ * so the resolution names no common base. The closure is the real one, so the
+ * minted summary carries verified fork-resolution facts rather than a stub.
+ */
+export async function makeForkResolvingSuccessorFixtureV1(
+  binding: SystemRecordLaneExecutionBindingV1,
+): Promise<ForkResolvingSuccessorFixtureV1> {
+  const forked = structuredClone(verified.head);
+  const sibling = { ...forked, bundleDigest: SIBLING_BUNDLE_DIGEST };
+  const resolution = Object.freeze({
+    objectType: 'fork-resolution',
+    kind: 'agents',
+    networkId: forked.networkId,
+    peerId: forked.peerId,
+    peerPublicKey: forked.peerPublicKey,
+    evmIssuer: forked.evmIssuer,
+    authoritySequence: forked.authoritySequence,
+    forkedVersion: forked.version,
+    resolutionVersion: '2',
+    evidenceHeadDigests: Object.freeze(
+      [forked, sibling].map(computeAgentProfileHeadObjectDigestV1).sort(),
+    ),
+    issuedAt: '2026-08-05T12:05:00Z',
+  }) as AgentProfileForkResolutionV1;
+  const head = {
+    ...forked,
+    version: '3',
+    forkResolutionDigest: computeAgentProfileForkResolutionDigestV1(resolution),
+  } as AgentProfileActiveHeadObjectV1;
+  const headDigest = computeAgentProfileHeadObjectDigestV1(head);
+  const artifacts = new Map<string, {
+    objectKind: 'agent-profile-head' | 'fork-resolution' | 'profile-bundle';
+    digest: Digest32V1;
+    canonicalBytes: Uint8Array;
+  }>([
+    envelopeArtifact('agent-profile-head', head),
+    envelopeArtifact('agent-profile-head', forked),
+    envelopeArtifact('agent-profile-head', sibling),
+    envelopeArtifact('fork-resolution', resolution),
+    [`profile-bundle:${head.bundleDigest}`, {
+      objectKind: 'profile-bundle',
+      digest: head.bundleDigest,
+      canonicalBytes: verified.bundle,
+    }],
+  ]);
+  const closure = await buildAgentProfileVerificationClosureV1(headDigest, {
+    nowMs: Date.parse('2026-08-05T12:10:00Z'),
+    resolve: async (reference) => artifacts.get(`${reference.objectKind}:${reference.digest}`),
+    verifyAuthorityEnvelope: () => true,
+    verifyCurrentBundle: (_head, bytes) =>
+      Buffer.from(bytes).equals(Buffer.from(verified.bundle)),
+  });
+  return Object.freeze({
+    resolution,
+    head,
+    issue: {
+      ...makeSystemRecordActiveReplacementIssueV1(binding),
+      head,
+      verifiedAuthoritySummary: closure.authoritySummary,
+    },
+  });
+}
+
+function envelopeArtifact(
+  objectKind: 'agent-profile-head' | 'fork-resolution',
+  object: AgentProfileActiveHeadObjectV1 | AgentProfileForkResolutionV1,
+): [string, {
+  objectKind: 'agent-profile-head' | 'fork-resolution';
+  digest: Digest32V1;
+  canonicalBytes: Uint8Array;
+}] {
+  const digest = object.objectType === 'agent-profile-head'
+    ? computeAgentProfileHeadObjectDigestV1(object)
+    : computeAgentProfileForkResolutionDigestV1(object);
+  return [`${objectKind}:${digest}`, {
+    objectKind,
+    digest,
+    canonicalBytes: canonicalizeSignedSystemRecordEnvelopeV1({
+      ...structuredClone(vectors.signed.activeEip191.envelope),
+      object,
+      objectDigest: digest,
+    } as SignedAgentProfileHeadEnvelopeV1),
+  }];
 }
 
 function projectionFor(head: Pick<AgentProfileActiveHeadObjectV1,

--- a/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
+++ b/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
@@ -105,7 +105,7 @@ export function makeAuthenticActiveReplacementFixtureV1(
   });
   const registry = createSystemRecordVerifiedReplacementRegistryV1();
   const facts = registry.consumer.consume(
-    registry.issuer.issueActive(issue(binding)),
+    registry.issuer.issueActive(makeSystemRecordActiveReplacementIssueV1(binding)),
     binding,
   );
   const snapshot = decodeSystemRecordAppliedSnapshotV1({
@@ -128,7 +128,9 @@ export function makeAuthenticActiveReplacementFixtureV1(
   return Object.freeze({ binding, epochQuad, ready: derivation });
 }
 
-function issue(binding: SystemRecordLaneExecutionBindingV1): SystemRecordActiveReplacementIssueV1 {
+export function makeSystemRecordActiveReplacementIssueV1(
+  binding: SystemRecordLaneExecutionBindingV1,
+): SystemRecordActiveReplacementIssueV1 {
   return {
     ...binding,
     networkId: SYSTEM_RECORD_FIXTURE_NETWORK,

--- a/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
+++ b/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
@@ -217,7 +217,29 @@ function twiceRotatedChain() {
   const base = rotatedActiveHead(middle, ROTATION_ISSUERS[1], '2', '0', {
     acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(second),
   });
-  return { initial, middle, base, transitions: [first, second] as const };
+  return {
+    base,
+    ancestors: [middle, initial] as readonly AgentProfileActiveHeadObjectV1[],
+    transitions: [first, second] as readonly AgentProfileAuthorityTransitionV1[],
+  };
+}
+
+/**
+ * One real authority rotation. A resolution built on the result is internally
+ * valid at the NEXT authority sequence, which is what a peer offers when it
+ * rotates instead of adjudicating the fork it created.
+ */
+function onceRotatedChain() {
+  const initial = structuredClone(verified.head);
+  const first = rotationTransition(initial, '1', ROTATION_ISSUERS[0]);
+  const base = rotatedActiveHead(initial, ROTATION_ISSUERS[0], '1', '0', {
+    acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(first),
+  });
+  return {
+    base,
+    ancestors: [initial] as readonly AgentProfileActiveHeadObjectV1[],
+    transitions: [first] as readonly AgentProfileAuthorityTransitionV1[],
+  };
 }
 
 function rotationTransition(
@@ -264,14 +286,22 @@ export interface ForkResolvingSuccessorFixtureV1 {
  * sequence, forked version, resolution version and successor version are four
  * distinct numbers, so a predicate comparing the wrong pair cannot pass by
  * coincidence. Use `based` for anything asserting on individual conjuncts.
+ *
+ * `after-rotate` forks at the same version as `based` but off a base one
+ * authority rotation later, so its resolution is valid on its own terms while
+ * naming a fork event that is not the one a receiver quarantined at the earlier
+ * sequence.
  */
 export async function makeForkResolvingSuccessorFixtureV1(
   binding: SystemRecordLaneExecutionBindingV1,
-  shape: 'genesis' | 'based' | 'other-version' | 'other-base' | 'rotated' = 'genesis',
+  shape: 'genesis' | 'based' | 'other-version' | 'other-base' | 'rotated' | 'after-rotate'
+    = 'genesis',
   terminalTransitionConflict = false,
 ): Promise<ForkResolvingSuccessorFixtureV1> {
   const genesis = shape === 'genesis';
-  const chain = shape === 'rotated' ? twiceRotatedChain() : undefined;
+  const chain = shape === 'rotated'
+    ? twiceRotatedChain()
+    : shape === 'after-rotate' ? onceRotatedChain() : undefined;
   const origin = chain?.base ?? structuredClone(verified.head);
   // A second version-zero head of the same authority: a different common base,
   // which is what distinguishes two fork events that agree on every other
@@ -309,7 +339,7 @@ export async function makeForkResolvingSuccessorFixtureV1(
     forkResolutionDigest: computeAgentProfileForkResolutionDigestV1(resolution),
   } as AgentProfileActiveHeadObjectV1;
   const artifacts = closureArtifactsFor(
-    [head, forked, sibling, base, ...(chain === undefined ? [] : [chain.middle, chain.initial])],
+    [head, forked, sibling, base, ...(chain?.ancestors ?? [])],
     resolution,
     chain?.transitions ?? [],
   );

--- a/packages/storage/test/helpers/system-record-runtime-issue-input-v1.ts
+++ b/packages/storage/test/helpers/system-record-runtime-issue-input-v1.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs';
+
+import {
+  keccak256,
+  SENTINEL_NO_PRIVATE_V10,
+  tripleContentV10,
+  V10MerkleTree,
+} from '@origintrail-official/dkg-core';
+import {
+  buildAgentProfileVerificationClosureV1,
+  canonicalizeSignedSystemRecordEnvelopeV1,
+  computeAgentProfileHeadObjectDigestV1,
+  digestSystemRecordBytesV1,
+  SYSTEM_RECORD_DIGEST_DOMAINS_V1,
+  type AgentProfileActiveHeadObjectV1,
+  type AgentProfileVerifiedAuthoritySummaryV1,
+  type NetworkIdV1,
+  type SignedAgentProfileHeadEnvelopeV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+
+import type { SystemRecordActiveReplacementIssueV1 } from '../../src/system-record-verified-replacement-v1-internal.js';
+import { agentProfileIdentityProjectionV1 } from './agent-profile-identity-projection-v1.js';
+
+/**
+ * Standalone authentic issue input.
+ *
+ * Deliberately does not reuse `system-record-active-replacement-fixture.ts`:
+ * that fixture mints and immediately consumes its proof inside its own
+ * registry, so it can never hand back a live one, and reservation-release
+ * tests need a proof that is still holding the single transient slot.
+ */
+interface Vectors {
+  readonly variants: { readonly active: { readonly object: AgentProfileActiveHeadObjectV1 } };
+  readonly signed: { readonly activeEip191: { readonly envelope: SignedAgentProfileHeadEnvelopeV1 } };
+}
+
+const vectors = JSON.parse(readFileSync(new URL(
+  '../../../core/test/fixtures/system-record-v1/vectors.json',
+  import.meta.url,
+), 'utf8')) as Vectors;
+
+const verified = await (async () => {
+  const source = structuredClone(vectors.variants.active.object);
+  const projectionQuads = projectionFor(source);
+  const canonicalProjectionBytes = canonicalBytesFor(projectionQuads);
+  const contentDigest = contentDigestFor(projectionQuads);
+  const bundle = new TextEncoder().encode('verified-profile-bundle');
+  const head = {
+    ...source,
+    projectionBytes: String(canonicalProjectionBytes.byteLength),
+    projectionQuads: String(projectionQuads.length),
+    contentDigest,
+    graphScopedAuthorSeal: {
+      ...source.graphScopedAuthorSeal,
+      assertionMerkleRoot: contentDigest,
+      publicTripleCount: String(projectionQuads.length),
+    },
+    bundleDigest: digestSystemRecordBytesV1(
+      SYSTEM_RECORD_DIGEST_DOMAINS_V1.profileBundle,
+      bundle,
+    ),
+  } as AgentProfileActiveHeadObjectV1;
+  return Object.freeze({
+    head,
+    authority: await mintAuthority(head, bundle),
+    projectionQuads,
+    canonicalProjectionBytes,
+  });
+})();
+
+export const SYSTEM_RECORD_RUNTIME_FIXTURE_NETWORK = verified.head.networkId as NetworkIdV1;
+
+/** A fresh authentic issue input; each call yields independent owned copies. */
+export function makeRuntimeActiveIssueInputV1(): SystemRecordActiveReplacementIssueV1 {
+  return {
+    networkId: SYSTEM_RECORD_RUNTIME_FIXTURE_NETWORK,
+    kind: 'agents',
+    mode: 'shadow',
+    sessionIdentity: Object.freeze(Object.create(null) as object),
+    activationGeneration: '1',
+    childGeneration: '2',
+    materializationEpoch: '2',
+    admittedDeadlineMs: 10_000,
+    head: structuredClone(verified.head),
+    verifiedAuthoritySummary: verified.authority,
+    canonicalProjectionBytes: new Uint8Array(verified.canonicalProjectionBytes),
+    projectionQuads: structuredClone(verified.projectionQuads),
+    ownedSubjectTable: [verified.head.rootSubject],
+  } as SystemRecordActiveReplacementIssueV1;
+}
+
+function projectionFor(head: Pick<AgentProfileActiveHeadObjectV1,
+  'rootSubject' | 'peerId' | 'peerPublicKey' | 'evmIssuer'>) {
+  return [
+    {
+      subject: head.rootSubject,
+      predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+      object: 'https://dkg.network/ontology#Agent',
+      graph: '',
+    },
+    ...agentProfileIdentityProjectionV1(head),
+    { subject: head.rootSubject, predicate: 'https://schema.org/description', object: '"b"', graph: '' },
+    { subject: head.rootSubject, predicate: 'https://schema.org/name', object: '"a"', graph: '' },
+  ].sort((left, right) => Buffer.compare(
+    tripleContentV10(left.subject, left.predicate, left.object),
+    tripleContentV10(right.subject, right.predicate, right.object),
+  ));
+}
+
+function canonicalBytesFor(
+  quads: readonly Readonly<{ subject: string; predicate: string; object: string }>[],
+) {
+  return new TextEncoder().encode(quads.map((quad) =>
+    `${new TextDecoder().decode(tripleContentV10(quad.subject, quad.predicate, quad.object))}\n`)
+    .join(''));
+}
+
+function contentDigestFor(
+  quads: readonly Readonly<{ subject: string; predicate: string; object: string }>[],
+) {
+  const leaves = quads.map((quad) =>
+    keccak256(tripleContentV10(quad.subject, quad.predicate, quad.object)));
+  return `0x${Buffer.from(V10MerkleTree.computeKARoot(
+    new V10MerkleTree(leaves).root,
+    SENTINEL_NO_PRIVATE_V10,
+  )).toString('hex')}` as const;
+}
+
+async function mintAuthority(
+  head: AgentProfileActiveHeadObjectV1,
+  bundle: Uint8Array,
+): Promise<AgentProfileVerifiedAuthoritySummaryV1> {
+  const envelope = {
+    ...structuredClone(vectors.signed.activeEip191.envelope),
+    object: head,
+    objectDigest: computeAgentProfileHeadObjectDigestV1(head),
+  } as SignedAgentProfileHeadEnvelopeV1;
+  const artifacts = new Map([
+    [`agent-profile-head:${envelope.objectDigest}`, {
+      objectKind: 'agent-profile-head' as const,
+      digest: envelope.objectDigest,
+      canonicalBytes: canonicalizeSignedSystemRecordEnvelopeV1(envelope),
+    }],
+    [`profile-bundle:${head.bundleDigest}`, {
+      objectKind: 'profile-bundle' as const,
+      digest: head.bundleDigest,
+      canonicalBytes: bundle,
+    }],
+  ]);
+  const closure = await buildAgentProfileVerificationClosureV1(envelope.objectDigest, {
+    nowMs: Date.parse('2026-08-05T12:10:00Z'),
+    resolve: async (reference) => artifacts.get(`${reference.objectKind}:${reference.digest}`),
+    verifyAuthorityEnvelope: () => true,
+    verifyCurrentBundle: (_head, bytes) => Buffer.from(bytes).equals(Buffer.from(bundle)),
+  });
+  return closure.authoritySummary;
+}

--- a/packages/storage/test/helpers/system-record-terminal-replacement-fixture.ts
+++ b/packages/storage/test/helpers/system-record-terminal-replacement-fixture.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from 'node:fs';
+
+import {
+  buildAgentProfileVerificationClosureV1,
+  canonicalizeAgentProfileConflictEvidenceV1,
+  canonicalizeOwnedSubjectTableObjectV1,
+  canonicalizeSignedSystemRecordEnvelopeV1,
+  computeAgentProfileConflictEvidenceDigestV1,
+  computeAgentProfileHeadObjectDigestV1,
+  EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1,
+  type AgentProfileConflictEvidenceV1,
+  type AgentProfileTombstoneHeadObjectV1,
+  type Digest32V1,
+  type SignedAgentProfileHeadEnvelopeV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
+
+import type { SystemRecordLaneExecutionBindingV1 } from '../../src/system-record-materializer-v1.js';
+import type {
+  SystemRecordActiveReplacementIssueV1,
+  SystemRecordQuarantineReplacementIssueV1,
+  SystemRecordTombstoneReplacementIssueV1,
+} from '../../src/system-record-verified-replacement-v1-internal.js';
+import {
+  makeAuthenticActiveReplacementFixtureV1,
+  makeSystemRecordActiveReplacementIssueV1,
+} from './system-record-active-replacement-fixture.js';
+
+interface Vectors {
+  readonly signed: { readonly activeEip191: { readonly envelope: SignedAgentProfileHeadEnvelopeV1 } };
+}
+
+const vectors = JSON.parse(readFileSync(new URL(
+  '../../../core/test/fixtures/system-record-v1/vectors.json',
+  import.meta.url,
+), 'utf8')) as Vectors;
+
+export interface AuthenticTerminalReplacementFixtureV1 {
+  readonly binding: SystemRecordLaneExecutionBindingV1;
+  readonly epochQuad: ReturnType<typeof makeAuthenticActiveReplacementFixtureV1>['epochQuad'];
+  readonly active: SystemRecordActiveReplacementIssueV1;
+  readonly tombstone: SystemRecordTombstoneReplacementIssueV1;
+  readonly quarantine: SystemRecordQuarantineReplacementIssueV1;
+}
+
+export async function makeAuthenticTerminalReplacementFixtureV1(
+  mode: 'shadow' | 'authoritative' = 'authoritative',
+): Promise<AuthenticTerminalReplacementFixtureV1> {
+  const activeFixture = makeAuthenticActiveReplacementFixtureV1(mode);
+  const binding = activeFixture.binding;
+  const active = makeSystemRecordActiveReplacementIssueV1(binding);
+  const predecessorDigest = computeAgentProfileHeadObjectDigestV1(active.head);
+  const tombstoneHead: AgentProfileTombstoneHeadObjectV1 = Object.freeze({
+    objectType: 'agent-profile-head',
+    kind: 'agents',
+    state: 'tombstone',
+    networkId: active.head.networkId,
+    peerId: active.head.peerId,
+    peerPublicKey: active.head.peerPublicKey,
+    authoritySequence: active.head.authoritySequence,
+    version: String(BigInt(active.head.version) + 1n),
+    previousHeadDigest: predecessorDigest,
+    ...(active.head.acceptedTransitionDigest === undefined ? {} : {
+      acceptedTransitionDigest: active.head.acceptedTransitionDigest,
+    }),
+    evmIssuer: active.head.evmIssuer,
+    rootSubject: active.head.rootSubject,
+    projectionSchemaDigest: active.head.projectionSchemaDigest,
+    issuedAt: '2026-08-05T12:11:00Z',
+    ownedSubjectTableDigest: EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1,
+    ownedSubjectCount: '0',
+    projectionBytes: '0',
+    projectionQuads: '0',
+  });
+  const tombstoneDigest = computeAgentProfileHeadObjectDigestV1(tombstoneHead);
+  const activeEnvelope: SignedAgentProfileHeadEnvelopeV1 = {
+    ...structuredClone(vectors.signed.activeEip191.envelope),
+    object: active.head,
+    objectDigest: predecessorDigest,
+  };
+  const tombstoneEnvelope: SignedAgentProfileHeadEnvelopeV1 = {
+    ...structuredClone(vectors.signed.activeEip191.envelope),
+    object: tombstoneHead,
+    objectDigest: tombstoneDigest,
+  };
+  const tableBytes = canonicalizeOwnedSubjectTableObjectV1(
+    active.head.rootSubject,
+    active.ownedSubjectTable,
+  );
+  const artifacts = new Map([
+    [`agent-profile-head:${predecessorDigest}`, {
+      objectKind: 'agent-profile-head' as const,
+      digest: predecessorDigest,
+      canonicalBytes: canonicalizeSignedSystemRecordEnvelopeV1(activeEnvelope),
+    }],
+    [`agent-profile-head:${tombstoneDigest}`, {
+      objectKind: 'agent-profile-head' as const,
+      digest: tombstoneDigest,
+      canonicalBytes: canonicalizeSignedSystemRecordEnvelopeV1(tombstoneEnvelope),
+    }],
+    [`owned-subject-table:${active.head.ownedSubjectTableDigest}`, {
+      objectKind: 'owned-subject-table' as const,
+      digest: active.head.ownedSubjectTableDigest,
+      canonicalBytes: tableBytes,
+    }],
+  ]);
+  const closure = await buildAgentProfileVerificationClosureV1(tombstoneDigest, {
+    nowMs: Date.parse('2026-08-05T12:12:00Z'),
+    resolve: async (reference) => artifacts.get(`${reference.objectKind}:${reference.digest}`),
+    verifyAuthorityEnvelope: () => true,
+    verifyCurrentBundle: () => {
+      throw new Error('tombstone closure must not request a predecessor projection');
+    },
+  });
+
+  const alternateDigest = `0x${'de'.repeat(32)}` as Digest32V1;
+  const evidence: AgentProfileConflictEvidenceV1 = Object.freeze({
+    objectType: 'conflict-evidence',
+    kind: 'agents',
+    networkId: active.head.networkId,
+    peerId: active.head.peerId,
+    entries: Object.freeze([Object.freeze({
+      type: 'fork',
+      authoritySequence: active.head.authoritySequence,
+      version: active.head.version,
+      objectDigests: Object.freeze([
+        predecessorDigest,
+        alternateDigest,
+      ].sort()) as readonly Digest32V1[],
+    })]),
+  });
+  const canonicalConflictEvidenceBytes = canonicalizeAgentProfileConflictEvidenceV1(evidence);
+  const conflictEvidenceDigest = computeAgentProfileConflictEvidenceDigestV1(evidence);
+
+  return Object.freeze({
+    binding,
+    epochQuad: activeFixture.epochQuad,
+    active,
+    tombstone: Object.freeze({
+      ...binding,
+      admittedDeadlineMs: active.admittedDeadlineMs,
+      head: tombstoneHead,
+      verifiedAuthoritySummary: closure.authoritySummary,
+      deletionOwnedSubjectTable: active.ownedSubjectTable,
+    }),
+    quarantine: Object.freeze({
+      ...active,
+      conflictEvidenceDigest,
+      canonicalConflictEvidenceBytes,
+      terminalTransitionConflict: false,
+    }),
+  });
+}

--- a/packages/storage/test/managed-oxigraph-ownership-v1.test.ts
+++ b/packages/storage/test/managed-oxigraph-ownership-v1.test.ts
@@ -307,6 +307,72 @@ describe('managed Oxigraph ownership lease V1', () => {
       });
     });
 
+    // Pins the totality invariant that makes window 1 of the proof-discard fix
+    // unreachable. The lane reads this before its first refusal check, so a
+    // throwing read would strand a verified proof's transient reservation and
+    // wedge every later apply in the process. Because the read is total, a
+    // hostile lease yields null and the caller reaches its refusal path, which
+    // already discards. If this goes red, re-examine the proof-discard window
+    // list: window 1 would have become reachable.
+    it('never throws for a hostile lease, so a caller always reaches its refusal path', () => {
+      const throwOnAnyAccess = new Proxy({}, {
+        get() { throw new Error('lease property read must never be reached'); },
+        has() { throw new Error('lease property probe must never be reached'); },
+        getOwnPropertyDescriptor() { throw new Error('lease descriptor read must never be reached'); },
+      });
+      const hostile: readonly unknown[] = [
+        throwOnAnyAccess,
+        Object.create(null),
+        { childGeneration: '1', ready: true, terminal: false },
+        null,
+        undefined,
+        'lease',
+        42,
+      ];
+      for (const candidate of hostile) {
+        expect(() => readManagedOxigraphOwnershipSnapshotV1(candidate)).not.toThrow();
+        expect(readManagedOxigraphOwnershipSnapshotV1(candidate)).toBeNull();
+      }
+    });
+
+    // Second arm of the same invariant. The hostile-input arm never reaches the
+    // snapshot projection at all -- every non-lease is rejected by the
+    // membership guard first -- so alone it pins only the cheap half and leaves
+    // the field reads that actually build a snapshot unexercised. Drive a
+    // registered lease through every state branch instead.
+    it('never throws while projecting a registered lease in any state', () => {
+      for (const withEndpoints of [true, false]) {
+        for (const reason of [
+          undefined,
+          'child-exit',
+          'stop',
+          'listener-ownership-lost',
+          'shutdown',
+          'port-release-unproven',
+        ] as const) {
+          for (const bindFirst of [true, false]) {
+            const controller = withEndpoints
+              ? createManagedOxigraphOwnershipControllerV1(QUERY_ENDPOINT, UPDATE_ENDPOINT)
+              : createManagedOxigraphOwnershipControllerV1();
+            if (bindFirst) controller.bindReadyGeneration();
+            if (reason !== undefined) controller.invalidate(reason);
+
+            expect(() => readManagedOxigraphOwnershipSnapshotV1(controller.lease)).not.toThrow();
+            const snapshot = readManagedOxigraphOwnershipSnapshotV1(controller.lease);
+            expect(snapshot).not.toBeNull();
+            // The lane branches on exactly these fields, so a projection that
+            // silently dropped one would send a live lease down the refusal path.
+            expect(typeof snapshot?.childGeneration).toBe('string');
+            expect(snapshot?.ready).toBe(bindFirst && reason === undefined);
+            expect(snapshot?.terminal)
+              .toBe(reason === 'shutdown' || reason === 'port-release-unproven');
+            expect(snapshot?.queryEndpoint).toBe(withEndpoints ? QUERY_ENDPOINT : undefined);
+            expect(snapshot?.lastInvalidation).toBe(reason);
+          }
+        }
+      }
+    });
+
     it('isolates leases from different supervisors', () => {
       const a = createOwnership();
       const b = createOwnership();

--- a/packages/storage/test/system-record-atomic-apply-executor-v1.test.ts
+++ b/packages/storage/test/system-record-atomic-apply-executor-v1.test.ts
@@ -44,7 +44,7 @@ import {
   type SystemRecordActiveReplacementIssueV1,
   type SystemRecordVerifiedCandidateIssueV1,
 } from '../src/system-record-verified-replacement-v1-internal.js';
-import { SYSTEM_RECORD_V1_PREDICATES, systemRecordEpochSubjectV1 } from '../src/system-record-rdf-schema-v1-internal.js';
+import { buildSystemRecordReservedStateQuadsV1, SYSTEM_RECORD_V1_PREDICATES, systemRecordEpochSubjectV1 } from '../src/system-record-rdf-schema-v1-internal.js';
 import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../src/internal-graph-policy.js';
 import type { SystemRecordLaneExecutionBindingV1 } from '../src/system-record-materializer-v1.js';
 import type { Quad } from '../src/triple-store.js';
@@ -478,6 +478,95 @@ describe('bounded system-record atomic apply executor V1', () => {
     expect(fixture.issueAgain()).toBeDefined();
   });
 
+  // The shadow tombstone writes status 'dirty' with its deletion scope to the
+  // single shared reserved row and empties only the shadow projection; the
+  // legacy authoritative projection is still present. The authoritative cutover
+  // reads that same row, sees 'dirty', and must delete the legacy projection --
+  // which means it must NOT compare the observed projection against the row's
+  // recorded (empty) one. That skip is the cutover mechanism, so pin it: remove
+  // it and this transition can no longer happen.
+  it('cuts a dirty shadow tombstone over to authoritative against a legacy projection', async () => {
+    const shadow = await makeAuthenticTerminalReplacementFixtureV1('shadow');
+    const shadowRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const shadowFacts = shadowRegistry.consumer.consume(
+      shadowRegistry.issuer.issueCandidate({ operation: 'tombstone', ...shadow.tombstone }),
+      shadow.binding,
+    );
+    const shadowReady = deriveSystemRecordReplacementV1({
+      facts: shadowFacts,
+      snapshot: decodeSystemRecordAppliedSnapshotV1({
+        networkId: shadowFacts.networkId,
+        stableKeyHash: computeSystemRecordStableKeyHashV1(
+          shadowFacts.networkId,
+          shadowFacts.head.peerId,
+        ),
+        materializationEpoch: shadowFacts.materializationEpoch,
+        quads: [shadow.epochQuad],
+      }),
+      observedRootClaimQuads: [],
+    });
+    if (shadowReady.outcome !== 'ready') {
+      throw new Error(`shadow tombstone derivation was ${shadowReady.outcome}`);
+    }
+    expect(shadowReady.plan.next.appliedState.status).toBe('dirty');
+    const tuple = buildSystemRecordReservedStateQuadsV1({
+      appliedState: shadowReady.plan.next.appliedState,
+      headVersion: shadowReady.plan.next.headVersion,
+      ownedSubjectTable: shadowReady.plan.next.ownedSubjectTable,
+      pendingDeletionTable: shadowReady.plan.next.pendingDeletionTable!,
+      rootClaimSet: shadowReady.plan.next.rootClaimSet,
+      capacityState: shadowReady.plan.next.capacityState,
+      receipt: shadowReady.plan.next.receipt,
+    });
+    const reservedQuads = [
+      ...tuple.record,
+      ...tuple.capacity,
+      ...tuple.epoch,
+      ...tuple.receipt,
+    ];
+    const dirty = decodeSystemRecordAppliedSnapshotV1({
+      networkId: shadowFacts.networkId,
+      stableKeyHash: shadowReady.plan.stableKeyHash,
+      materializationEpoch: shadowFacts.materializationEpoch,
+      quads: reservedQuads,
+    });
+    shadowRegistry.consumer.release(shadowFacts);
+
+    const authoritative = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const fixture = makeFixture({
+      candidate: {
+        binding: authoritative.binding,
+        epochQuad: authoritative.epochQuad,
+        issue: { operation: 'tombstone', ...authoritative.tombstone },
+      },
+      postState: 'next',
+      prior: {
+        snapshot: dirty,
+        reservedQuads,
+        rootClaimQuads: shadowReady.plan.next.rootClaimQuads,
+        // Legacy content the shadow pass deliberately left behind. It cannot
+        // match the dirty row's recorded projection, which a tombstone empties.
+        projection: authoritative.active.projectionQuads.map((quad) => ({
+          ...quad,
+          graph: 'did:dkg:context-graph:agents',
+        })),
+      },
+    });
+    const result = await fixture.executor.execute(
+      fixture.proof,
+      fixture.binding,
+      fixture.registerRecovery,
+    );
+    expect(result).toMatchObject({ settlement: 'settled', outcome: { outcome: 'applied' } });
+    const update = fixture.client.calls.find((call) =>
+      call.contentType.startsWith('application/sparql-update'));
+    // Bounded: the cutover deletes the recorded scope and inserts no projection.
+    expect(update?.body).not.toContain('VALUES (?insertProjectionSubject');
+    for (const subject of shadowReady.plan.next.pendingDeletionTable!) {
+      expect(update?.body).toContain(subject);
+    }
+  });
+
   it('exact-recovers a cold tombstone and releases its reservation after settlement', async () => {
     const terminal = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
     let settleRecovery!: () => void;
@@ -798,6 +887,13 @@ function makeFixture(options: Readonly<{
     projection: readonly Readonly<Quad>[],
   ) => readonly Readonly<Quad>[];
   observedRootState?: 'foreign-collision';
+  /** Drive the executor against a pre-existing row instead of an absent one. */
+  prior?: Readonly<{
+    snapshot: Parameters<typeof deriveSystemRecordReplacementV1>[0]['snapshot'];
+    reservedQuads: readonly Readonly<Quad>[];
+    rootClaimQuads: readonly Readonly<Quad>[];
+    projection: readonly Readonly<Quad>[];
+  }>;
 }> = {}) {
   const verified = options.verified ?? VERIFIED;
   const order = options.order ?? [];
@@ -839,17 +935,21 @@ function makeFixture(options: Readonly<{
   });
   const ready = deriveSystemRecordReplacementV1({
     facts: expectedFacts,
-    snapshot: absentSnapshot,
-    observedRootClaimQuads: [],
+    snapshot: options.prior?.snapshot ?? absentSnapshot,
+    observedRootClaimQuads: options.prior?.rootClaimQuads ?? [],
   });
   if (ready.outcome !== 'ready') throw new Error(`fixture derivation was ${ready.outcome}`);
 
   const localNext = options.localState === 'next';
   const nextRootSubjects = new Set(ready.plan.next.rootClaimQuads.map((quad) => quad.subject));
-  const initialReserved = localNext
-    ? ready.plan.next.reservedQuads.filter((quad) => !nextRootSubjects.has(quad.subject))
-    : [epochQuad];
-  const initialRoots = options.observedRootState === 'foreign-collision'
+  const initialReserved = options.prior !== undefined
+    ? options.prior.reservedQuads
+    : localNext
+      ? ready.plan.next.reservedQuads.filter((quad) => !nextRootSubjects.has(quad.subject))
+      : [epochQuad];
+  const initialRoots = options.prior !== undefined
+    ? options.prior.rootClaimQuads
+    : options.observedRootState === 'foreign-collision'
     ? ready.plan.next.rootClaimQuads.map((quad) =>
       quad.predicate === SYSTEM_RECORD_V1_PREDICATES.claimedBy
         ? { ...quad, object: 'urn:test:foreign-record' }
@@ -858,7 +958,8 @@ function makeFixture(options: Readonly<{
   const faithfulInitialProjection = localNext
     ? ready.plan.next.projectionQuads.map((quad) => ({ ...quad, graph: ready.plan.projectionGraph }))
     : [];
-  const initialProjection = options.priorProjection?.(faithfulInitialProjection)
+  const initialProjection = options.prior?.projection
+    ?? options.priorProjection?.(faithfulInitialProjection)
     ?? faithfulInitialProjection;
   const responses: Array<Readonly<{ status: number; body: string }>> = [
     { status: 200, body: selectJson(initialReserved) },

--- a/packages/storage/test/system-record-atomic-apply-executor-v1.test.ts
+++ b/packages/storage/test/system-record-atomic-apply-executor-v1.test.ts
@@ -33,7 +33,7 @@ import {
   type SystemRecordAtomicRecoveryRequestV1,
 } from '../src/system-record-atomic-apply-executor-v1-internal.js';
 import {
-  deriveSystemRecordActiveReplacementV1,
+  deriveSystemRecordReplacementV1,
 } from '../src/system-record-next-state-v1-internal.js';
 import { parseSystemRecordInspectionResponseV1 } from '../src/system-record-inspection-v1-internal.js';
 import {
@@ -42,12 +42,14 @@ import {
 import {
   createSystemRecordVerifiedReplacementRegistryV1,
   type SystemRecordActiveReplacementIssueV1,
+  type SystemRecordVerifiedCandidateIssueV1,
 } from '../src/system-record-verified-replacement-v1-internal.js';
 import { SYSTEM_RECORD_V1_PREDICATES, systemRecordEpochSubjectV1 } from '../src/system-record-rdf-schema-v1-internal.js';
 import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../src/internal-graph-policy.js';
 import type { SystemRecordLaneExecutionBindingV1 } from '../src/system-record-materializer-v1.js';
 import type { Quad } from '../src/triple-store.js';
 import { agentProfileIdentityProjectionV1 } from './helpers/agent-profile-identity-projection-v1.js';
+import { makeAuthenticTerminalReplacementFixtureV1 } from './helpers/system-record-terminal-replacement-fixture.js';
 
 interface Vectors {
   readonly variants: { readonly active: { readonly object: AgentProfileActiveHeadObjectV1 } };
@@ -448,6 +450,101 @@ describe('bounded system-record atomic apply executor V1', () => {
     expect(fixture.client.updateCalls).toBe(1);
   });
 
+  it('cold-applies one authoritative tombstone without inserting predecessor projection', async () => {
+    const terminal = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const fixture = makeFixture({
+      candidate: {
+        binding: terminal.binding,
+        epochQuad: terminal.epochQuad,
+        issue: { operation: 'tombstone', ...terminal.tombstone },
+      },
+      postState: 'next',
+      priorProjection: () => terminal.active.projectionQuads.map((quad) => ({
+        ...quad,
+        graph: 'did:dkg:context-graph:agents',
+      })),
+    });
+    expect(fixture.exactNextProjection).toEqual([]);
+    const result = await fixture.executor.execute(
+      fixture.proof,
+      fixture.binding,
+      fixture.registerRecovery,
+    );
+    expect(result).toMatchObject({ settlement: 'settled', outcome: { outcome: 'applied' } });
+    expect(fixture.client.updateCalls).toBe(1);
+    const update = fixture.client.calls.find((call) =>
+      call.contentType.startsWith('application/sparql-update'));
+    expect(update?.body).not.toContain('VALUES (?insertProjectionSubject');
+    expect(fixture.issueAgain()).toBeDefined();
+  });
+
+  it('exact-recovers a cold tombstone and releases its reservation after settlement', async () => {
+    const terminal = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    let settleRecovery!: () => void;
+    const recoveryCompletion = new Promise<{
+      readonly resolution: 'unavailable';
+    }>((resolve) => {
+      settleRecovery = () => resolve(Object.freeze({ resolution: 'unavailable' as const }));
+    });
+    const fixture = makeFixture({
+      candidate: {
+        binding: terminal.binding,
+        epochQuad: terminal.epochQuad,
+        issue: { operation: 'tombstone', ...terminal.tombstone },
+      },
+      postState: 'malformed',
+      recoveryCompletion,
+    });
+    const result = await fixture.executor.execute(
+      fixture.proof,
+      fixture.binding,
+      fixture.registerRecovery,
+    );
+    expect(result).toMatchObject({ settlement: 'recovery-owned' });
+    expect(() => fixture.issueAgain()).toThrow(/reservation is already live/);
+
+    const responses = [
+      { status: 200, body: selectJson(fixture.exactNextReserved) },
+      { status: 200, body: selectJson([]) },
+    ];
+    const recoveryClient: SystemRecordAtomicApplyHttpClientV1 = {
+      childGeneration: '3',
+      isDestroyed: false,
+      post: async () => responses.shift() ?? (() => { throw new Error('unexpected recovery read'); })(),
+    };
+    await expect(fixture.registeredRequest()!.reconcile({
+      client: recoveryClient,
+      queryEndpoint: 'http://127.0.0.1:7878/query',
+      absoluteDeadlineMs: performance.now() + 30_000,
+      signal: new AbortController().signal,
+      assertAttributable: () => true,
+    })).resolves.toMatchObject({ resolution: 'applied' });
+    settleRecovery();
+    await recoveryCompletion;
+    await Promise.resolve();
+    expect(fixture.issueAgain()).toBeDefined();
+  });
+
+  it('atomically persists verified quarantine evidence through the same executor', async () => {
+    const terminal = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const fixture = makeFixture({
+      candidate: {
+        binding: terminal.binding,
+        epochQuad: terminal.epochQuad,
+        issue: { operation: 'quarantine', ...terminal.quarantine },
+      },
+      postState: 'next',
+    });
+    const result = await fixture.executor.execute(
+      fixture.proof,
+      fixture.binding,
+      fixture.registerRecovery,
+    );
+    expect(result).toMatchObject({ settlement: 'settled', outcome: { outcome: 'applied' } });
+    expect(fixture.exactNextReserved.some((quad) =>
+      quad.object.includes(terminal.quarantine.conflictEvidenceDigest))).toBe(true);
+  });
+
   it('exact-recovers a derived-subject projection in a replacement generation', async () => {
     const recoveryCompletion = new Promise<{ readonly resolution: 'unavailable' }>(() => undefined);
     const fixture = makeFixture({
@@ -680,6 +777,11 @@ describe('bounded system-record atomic apply executor V1', () => {
 
 function makeFixture(options: Readonly<{
   verified?: typeof VERIFIED;
+  candidate?: Readonly<{
+    binding: SystemRecordLaneExecutionBindingV1;
+    epochQuad: Readonly<Quad>;
+    issue: SystemRecordVerifiedCandidateIssueV1;
+  }>;
   admittedDeadlineMs?: number;
   localState?: 'absent' | 'next';
   mode?: SystemRecordLaneExecutionBindingV1['mode'];
@@ -701,7 +803,7 @@ function makeFixture(options: Readonly<{
   const order = options.order ?? [];
   const accountingEvents: string[] = [];
   const admittedDeadlineMs = options.admittedDeadlineMs ?? 10_000;
-  const binding = Object.freeze({
+  const binding = options.candidate?.binding ?? Object.freeze({
     activationGeneration: '1',
     networkId: NETWORK,
     kind: 'agents',
@@ -716,17 +818,26 @@ function makeFixture(options: Readonly<{
   // one-shot handle from the same verifier fixture.
   const expectedRegistry = createSystemRecordVerifiedReplacementRegistryV1();
   const expectedIssue = issue(binding, admittedDeadlineMs, verified);
+  const expectedProof = options.candidate === undefined
+    ? expectedRegistry.issuer.issueActive(expectedIssue)
+    : expectedRegistry.issuer.issueCandidate(options.candidate.issue);
   const expectedFacts = expectedRegistry.consumer.consume(
-    expectedRegistry.issuer.issueActive(expectedIssue),
+    expectedProof,
     binding,
   );
+  const networkId = expectedFacts.networkId;
+  const stableKeyHash = computeSystemRecordStableKeyHashV1(
+    networkId,
+    expectedFacts.head.peerId,
+  );
+  const epochQuad = options.candidate?.epochQuad ?? EPOCH;
   const absentSnapshot = decodeSystemRecordAppliedSnapshotV1({
-    networkId: NETWORK,
-    stableKeyHash: computeStableKey(),
-    materializationEpoch: '2',
-    quads: [EPOCH],
+    networkId,
+    stableKeyHash,
+    materializationEpoch: binding.materializationEpoch,
+    quads: [epochQuad],
   });
-  const ready = deriveSystemRecordActiveReplacementV1({
+  const ready = deriveSystemRecordReplacementV1({
     facts: expectedFacts,
     snapshot: absentSnapshot,
     observedRootClaimQuads: [],
@@ -737,7 +848,7 @@ function makeFixture(options: Readonly<{
   const nextRootSubjects = new Set(ready.plan.next.rootClaimQuads.map((quad) => quad.subject));
   const initialReserved = localNext
     ? ready.plan.next.reservedQuads.filter((quad) => !nextRootSubjects.has(quad.subject))
-    : [EPOCH];
+    : [epochQuad];
   const initialRoots = options.observedRootState === 'foreign-collision'
     ? ready.plan.next.rootClaimQuads.map((quad) =>
       quad.predicate === SYSTEM_RECORD_V1_PREDICATES.claimedBy
@@ -760,7 +871,7 @@ function makeFixture(options: Readonly<{
       responses.push({ status: 200, body: '{' });
     } else if (options.postState === 'prior') {
       responses.push(
-        { status: 200, body: selectJson([EPOCH]) },
+        { status: 200, body: selectJson([epochQuad]) },
         { status: 200, body: selectJson([]) },
       );
     } else {
@@ -786,7 +897,9 @@ function makeFixture(options: Readonly<{
     options.updateFailure,
   );
   const registry = createSystemRecordVerifiedReplacementRegistryV1();
-  const proof = registry.issuer.issueActive(issue(binding, admittedDeadlineMs, verified));
+  const proof = options.candidate === undefined
+    ? registry.issuer.issueActive(issue(binding, admittedDeadlineMs, verified))
+    : registry.issuer.issueCandidate(options.candidate.issue);
   const accountedConsumer: typeof registry.consumer = Object.freeze({
     ...registry.consumer,
     replaceCharge: (facts, category, bytes) => {
@@ -845,7 +958,9 @@ function makeFixture(options: Readonly<{
     inspectProof: () => registry.consumer.inspectDeadline(proof, binding),
     consumeProof: () => registry.consumer.consume(proof, binding),
     releaseFacts: (facts: unknown) => registry.consumer.release(facts),
-    issueAgain: () => registry.issuer.issueActive(issue(binding, admittedDeadlineMs, verified)),
+    issueAgain: () => options.candidate === undefined
+      ? registry.issuer.issueActive(issue(binding, admittedDeadlineMs, verified))
+      : registry.issuer.issueCandidate(options.candidate.issue),
   };
 }
 

--- a/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
+++ b/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
@@ -1942,6 +1942,36 @@ describe('system-record lane session lifecycle V1', () => {
       expect(Object.isFrozen(executor.calls[0])).toBe(true);
     });
 
+    it('discards a proof whose dispatch threw before the executor consumed it', async () => {
+      const session = await build().open(ACTIVATION);
+      const dispatchFailure = new Error('admission barrier closed under dispatch');
+      executor.onDispatch = () => { throw dispatchFailure; };
+      const strandedProof = Object.freeze({ proof: 'never-consumed' });
+
+      await expect(session.applyVerified(strandedProof)).rejects.toBe(dispatchFailure);
+      // The reservation gate is single-slot and registry-wide, so a proof left
+      // undiscarded here fails every later apply in the process, not just this
+      // lane. Releasing it is what keeps the next dispatch admissible.
+      expect(executor.discarded).toEqual([strandedProof]);
+
+      executor.onDispatch = undefined;
+      expect((await session.applyVerified({})).outcome).toBe('applied');
+    });
+
+    it('propagates the dispatch failure even when discarding that proof also throws', async () => {
+      const session = await build().open(ACTIVATION);
+      const dispatchFailure = new Error('admission barrier closed under dispatch');
+      const discardFailure = new Error('verified replacement proof is no longer live and unconsumed');
+      executor.onDispatch = () => { throw dispatchFailure; };
+      executor.discardVerified = () => { throw discardFailure; };
+
+      // A real discard throws whenever the proof was already consumed, already
+      // released, or transferred to recovery ownership. If that throw escaped it
+      // would replace the actual dispatch failure with a misleading reservation
+      // error, and the operator would debug the wrong thing.
+      await expect(session.applyVerified({})).rejects.toBe(dispatchFailure);
+    });
+
     it('keeps an explicit child-generation fallback for the current adapter', async () => {
       const legacyCalls: string[] = [];
       const controller = createSystemRecordLaneControllerV1({

--- a/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
+++ b/packages/storage/test/system-record-materializer-lifecycle-v1.test.ts
@@ -30,6 +30,8 @@ import {
   releaseReplacementSystemRecordControllerV1,
   trackSystemRecordControllerReleaseV1,
 } from './helpers/system-record-lifecycle-race-v1.js';
+import { createSystemRecordVerifiedReplacementRegistryV1 } from '../src/system-record-verified-replacement-v1-internal.js';
+import { makeRuntimeActiveIssueInputV1 } from './helpers/system-record-runtime-issue-input-v1.js';
 
 const ACTIVATION: SystemRecordLaneActivationV1 = {
   networkId: 'testnet',
@@ -1956,6 +1958,32 @@ describe('system-record lane session lifecycle V1', () => {
 
       executor.onDispatch = undefined;
       expect((await session.applyVerified({})).outcome).toBe('applied');
+    });
+
+    it('frees the real transient reservation when dispatch throws, so the next issuance succeeds', async () => {
+      // The guarantee lives at the real single-slot gate, so the proof has to be
+      // a real one: a stubbed executor holds no reservation and would report
+      // success no matter what the lane did with it.
+      const registry = createSystemRecordVerifiedReplacementRegistryV1();
+      const liveProof = registry.issuer.issueActive(makeRuntimeActiveIssueInputV1());
+      const dispatchFailure = new Error('admission barrier closed under dispatch');
+      const controller = createSystemRecordLaneControllerV1({
+        lease: ownership.lease,
+        handoff,
+        executor: {
+          applyVerified: async () => { throw dispatchFailure; },
+          discardVerified: (proof) => { registry.consumer.discardProof(proof); },
+        },
+        barrier: barrier.run,
+      });
+
+      const session = await controller.open(ACTIVATION);
+      await expect(session.applyVerified(liveProof)).rejects.toBe(dispatchFailure);
+
+      // The assertion that actually proves release. The gate is single-slot, so
+      // a stranded proof makes this throw "reservation is already live" and
+      // every later apply in the process fails the same way until restart.
+      expect(() => registry.issuer.issueActive(makeRuntimeActiveIssueInputV1())).not.toThrow();
     });
 
     it('propagates the dispatch failure even when discarding that proof also throws', async () => {

--- a/packages/storage/test/system-record-next-state-v1.test.ts
+++ b/packages/storage/test/system-record-next-state-v1.test.ts
@@ -776,6 +776,34 @@ describe('system-record terminal and quarantine next-state derivation', () => {
     expect(cleared.plan.next.appliedState.status).toBe('active');
   });
 
+  // The absent-base arm of the fork-base conjunct. A version-zero head has no
+  // predecessor, so the quarantine records no fork base; a genesis resolution is
+  // forbidden from naming one, so both sides are absent and the row must still
+  // clear. The two absences cannot drift apart: only a genesis resolution reaches
+  // the base comparison at all, because the version conjunct first demands the
+  // resolution's forked version equal our head version of zero.
+  //
+  // Without this case the conjunct can be narrowed to reject an absent base and
+  // nothing goes red -- which would strand every genesis quarantine permanently.
+  it('clears a genesis fork quarantine that recorded no fork base', async () => {
+    const fork = await quarantinedForkFixtureV1('genesis');
+    if (fork.quarantinedSnapshot.state !== 'present') throw new Error('expected a present row');
+    expect(fork.quarantinedSnapshot.headVersion).toBe('0');
+    expect(fork.quarantinedSnapshot.appliedState.conflictForkBaseHeadDigest).toBeUndefined();
+    expect(fork.forkBaseHeadDigest).toBeUndefined();
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const cleared = expectReady(deriveSystemRecordReplacementV1({
+      facts: registry.consumer.consume(
+        registry.issuer.issueActive(fork.successorIssue),
+        fork.binding,
+      ),
+      snapshot: fork.quarantinedSnapshot,
+      observedRootClaimQuads: fork.observedRootClaimQuads,
+    }));
+    expect(cleared.plan.next.appliedState.status).toBe('active');
+    expect(cleared.plan.next.appliedState.conflictForkBaseHeadDigest).toBeUndefined();
+  });
+
   it('clears a fork quarantine for the successor resolving that exact fork', async () => {
     const fork = await quarantinedForkFixtureV1();
     const registry = createSystemRecordVerifiedReplacementRegistryV1();
@@ -1580,9 +1608,9 @@ function compareUtf8(left: string, right: string): number {
 
 /** Apply our branch of a fork, then quarantine it, and hand back that row. */
 async function quarantinedForkFixtureV1(
-  shape: 'based' | 'rotated' = 'based',
+  shape: 'based' | 'rotated' | 'genesis' = 'based',
   terminalTransitionConflict = false,
-  expectedHeadVersion = '1',
+  expectedHeadVersion = shape === 'genesis' ? '0' : '1',
   expectedLineageLength = shape === 'rotated' ? 2 : 0,
 ) {
   const { binding, epochQuad } = makeAuthenticActiveReplacementFixtureV1('authoritative');

--- a/packages/storage/test/system-record-next-state-v1.test.ts
+++ b/packages/storage/test/system-record-next-state-v1.test.ts
@@ -606,6 +606,46 @@ describe('system-record terminal and quarantine next-state derivation', () => {
     authoritativeRegistry.consumer.release(authoritativeFacts);
   });
 
+  // The tombstone cutover plans its deletion from the incoming candidate's table
+  // and never compares it with the scope the row recorded. It does not need to,
+  // because a row cannot persist a pending table that disagrees with its own
+  // applied-state binding -- refused here on the way in, and again by the
+  // decoder on the way out. Pin the write half; the read half is pinned in
+  // system-record-state-snapshot-v1.test.ts.
+  it('refuses to encode a pending deletion table that does not bind the applied state', async () => {
+    const fixture = await makeAuthenticTerminalReplacementFixtureV1('shadow');
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const facts = registry.consumer.consume(
+      registry.issuer.issueCandidate({ operation: 'tombstone', ...fixture.tombstone }),
+      fixture.binding,
+    );
+    const ready = expectReady(deriveSystemRecordReplacementV1({
+      facts,
+      snapshot: decodeSystemRecordAppliedSnapshotV1({
+        networkId: facts.networkId,
+        stableKeyHash: computeSystemRecordStableKeyHashV1(facts.networkId, facts.head.peerId),
+        materializationEpoch: facts.materializationEpoch,
+        quads: [fixture.epochQuad],
+      }),
+      observedRootClaimQuads: [],
+    }));
+    const recorded = ready.plan.next.pendingDeletionTable!;
+    const widened = Object.freeze([
+      ...recorded,
+      `${ready.plan.next.appliedState.currentRoot}/.well-known/genid/cap1`,
+    ]) as unknown as typeof recorded;
+    expect(() => buildSystemRecordReservedStateQuadsV1({
+      appliedState: ready.plan.next.appliedState,
+      headVersion: ready.plan.next.headVersion,
+      ownedSubjectTable: ready.plan.next.ownedSubjectTable,
+      pendingDeletionTable: widened,
+      rootClaimSet: ready.plan.next.rootClaimSet,
+      capacityState: ready.plan.next.capacityState,
+      receipt: ready.plan.next.receipt,
+    })).toThrow(/does not bind the applied state/);
+    registry.consumer.release(facts);
+  });
+
   it('persists quarantine evidence without a sidecar intent and blocks ordinary unquarantine', async () => {
     const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
     const initialRegistry = createSystemRecordVerifiedReplacementRegistryV1();

--- a/packages/storage/test/system-record-next-state-v1.test.ts
+++ b/packages/storage/test/system-record-next-state-v1.test.ts
@@ -734,6 +734,111 @@ describe('system-record terminal and quarantine next-state derivation', () => {
     activeRegistry.consumer.release(activeFacts);
   });
 
+  // The tombstone classifier is a parallel path to the active one and had no
+  // quarantine gate, so a peer that equivocated could delete the quarantined row
+  // -- and the evidence of its own equivocation -- by publishing a tombstone for
+  // the head it had quarantined. Every conjunct of the advance matches here,
+  // which is the point: without the gate this fixture advances and plans a
+  // deletion.
+  it('never lets a tombstone advance over a fork-quarantined row', async () => {
+    const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const initialRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const initialFacts = initialRegistry.consumer.consume(
+      initialRegistry.issuer.issueActive(fixture.active),
+      fixture.binding,
+    );
+    const active = expectReady(deriveSystemRecordReplacementV1({
+      facts: initialFacts,
+      snapshot: decodeSystemRecordAppliedSnapshotV1({
+        networkId: initialFacts.networkId,
+        stableKeyHash: computeSystemRecordStableKeyHashV1(
+          initialFacts.networkId,
+          initialFacts.head.peerId,
+        ),
+        materializationEpoch: initialFacts.materializationEpoch,
+        quads: [fixture.epochQuad],
+      }),
+      observedRootClaimQuads: [],
+    }));
+    const activeTuple = buildSystemRecordReservedStateQuadsV1({
+      appliedState: active.plan.next.appliedState,
+      headVersion: active.plan.next.headVersion,
+      ownedSubjectTable: active.plan.next.ownedSubjectTable,
+      rootClaimSet: active.plan.next.rootClaimSet,
+      capacityState: active.plan.next.capacityState,
+      receipt: active.plan.next.receipt,
+    });
+    const activeSnapshot = decodeSystemRecordAppliedSnapshotV1({
+      networkId: initialFacts.networkId,
+      stableKeyHash: active.plan.stableKeyHash,
+      materializationEpoch: initialFacts.materializationEpoch,
+      quads: [
+        ...activeTuple.record,
+        ...activeTuple.capacity,
+        ...activeTuple.epoch,
+        ...activeTuple.receipt,
+      ],
+    });
+    initialRegistry.consumer.release(initialFacts);
+
+    const quarantineRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const quarantineFacts = quarantineRegistry.consumer.consume(
+      quarantineRegistry.issuer.issueCandidate({ operation: 'quarantine', ...fixture.quarantine }),
+      fixture.binding,
+    );
+    const quarantined = expectReady(deriveSystemRecordReplacementV1({
+      facts: quarantineFacts,
+      snapshot: activeSnapshot,
+      observedRootClaimQuads: active.plan.next.rootClaimQuads,
+    }));
+    expect(quarantined.plan.next.appliedState.status).toBe('quarantined');
+    const quarantineTuple = buildSystemRecordReservedStateQuadsV1({
+      appliedState: quarantined.plan.next.appliedState,
+      headVersion: quarantined.plan.next.headVersion,
+      ownedSubjectTable: quarantined.plan.next.ownedSubjectTable,
+      rootClaimSet: quarantined.plan.next.rootClaimSet,
+      capacityState: quarantined.plan.next.capacityState,
+      receipt: quarantined.plan.next.receipt,
+    });
+    const quarantinedSnapshot = decodeSystemRecordAppliedSnapshotV1({
+      networkId: quarantineFacts.networkId,
+      stableKeyHash: quarantined.plan.stableKeyHash,
+      materializationEpoch: quarantineFacts.materializationEpoch,
+      quads: [
+        ...quarantineTuple.record,
+        ...quarantineTuple.capacity,
+        ...quarantineTuple.epoch,
+        ...quarantineTuple.receipt,
+      ],
+    });
+    quarantineRegistry.consumer.release(quarantineFacts);
+    if (quarantinedSnapshot.state !== 'present') throw new Error('expected a quarantined row');
+
+    // The tombstone names exactly the head the row quarantined, so nothing but
+    // the status gate stands between it and a deletion.
+    const tombstoneRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const tombstoneFacts = tombstoneRegistry.consumer.consume(
+      tombstoneRegistry.issuer.issueCandidate({ operation: 'tombstone', ...fixture.tombstone }),
+      fixture.binding,
+    );
+    expect(tombstoneFacts.verifiedAuthoritySummary.tombstonePredecessor)
+      .toBeDefined();
+    expect(quarantinedSnapshot.appliedState.headDigest).toBe(
+      computeAgentProfileHeadObjectDigestV1(
+        tombstoneFacts.verifiedAuthoritySummary.tombstonePredecessor!,
+      ),
+    );
+    expect(quarantinedSnapshot.headVersion).toBe(
+      tombstoneFacts.verifiedAuthoritySummary.tombstonePredecessor!.version,
+    );
+    expect(deriveSystemRecordReplacementV1({
+      facts: tombstoneFacts,
+      snapshot: quarantinedSnapshot,
+      observedRootClaimQuads: quarantined.plan.next.rootClaimQuads,
+    })).toEqual({ outcome: 'deferred', reason: 'non-active-state' });
+    tombstoneRegistry.consumer.release(tombstoneFacts);
+  });
+
   it('persists terminal transition object digests in the bounded quarantine slots', async () => {
     const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
     const transitionDigests = Object.freeze([

--- a/packages/storage/test/system-record-next-state-v1.test.ts
+++ b/packages/storage/test/system-record-next-state-v1.test.ts
@@ -8,8 +8,10 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   buildAgentProfileVerificationClosureV1,
+  canonicalizeAgentProfileConflictEvidenceV1,
   canonicalizeOwnedSubjectTableObjectV1,
   canonicalizeSignedSystemRecordEnvelopeV1,
+  computeAgentProfileConflictEvidenceDigestV1,
   computeAgentProfileAuthorityTransitionDigestV1,
   computeAgentProfileHeadObjectDigestV1,
   computeOwnedSubjectTableDigestV1,
@@ -25,6 +27,8 @@ import {
   SYSTEM_RECORD_MAX_APPLIED_AGGREGATE_BYTES,
   type AgentProfileActiveHeadObjectV1,
   type AgentProfileAuthorityTransitionV1,
+  type AgentProfileConflictEvidenceV1,
+  type Digest32V1,
   type NetworkIdV1,
   type SignedAgentProfileAuthorityTransitionEnvelopeV1,
   type SignedAgentProfileHeadEnvelopeV1,
@@ -40,6 +44,7 @@ import {
 import {
   assertAuthenticSystemRecordActiveReplacementCompleteV1,
   deriveSystemRecordActiveReplacementV1,
+  deriveSystemRecordReplacementV1,
   type SystemRecordActiveReplacementCompleteV1,
   type SystemRecordActiveReplacementReadyV1,
 } from '../src/system-record-next-state-v1-internal.js';
@@ -59,6 +64,7 @@ import {
 } from '../src/system-record-verified-replacement-v1-internal.js';
 import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../src/internal-graph-policy.js';
 import { agentProfileIdentityProjectionV1 } from './helpers/agent-profile-identity-projection-v1.js';
+import { makeAuthenticTerminalReplacementFixtureV1 } from './helpers/system-record-terminal-replacement-fixture.js';
 
 interface Vectors {
   readonly variants: {
@@ -413,6 +419,329 @@ describe('system-record active next-state derivation', () => {
         observedRootClaimQuads: cold.plan.next.rootClaimQuads,
       })).toEqual({ outcome: 'deferred', reason: 'non-active-state' });
     }
+  });
+});
+
+describe('system-record terminal and quarantine next-state derivation', () => {
+  it('cold-applies an authoritative tombstone with deletion scope and zero transient projection', async () => {
+    const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const facts = registry.consumer.consume(registry.issuer.issueCandidate({
+      operation: 'tombstone',
+      ...fixture.tombstone,
+    }), fixture.binding);
+    const snapshot = decodeSystemRecordAppliedSnapshotV1({
+      networkId: facts.networkId,
+      stableKeyHash: computeSystemRecordStableKeyHashV1(facts.networkId, facts.head.peerId),
+      materializationEpoch: facts.materializationEpoch,
+      quads: [fixture.epochQuad],
+    });
+    const ready = expectReady(deriveSystemRecordReplacementV1({
+      facts,
+      snapshot,
+      observedRootClaimQuads: [],
+    }));
+    const update = buildSystemRecordConditionalApplyUpdateV1(ready);
+
+    expect(ready.plan.next.appliedState).toMatchObject({
+      status: 'tombstone',
+      projectionBytes: '0',
+      projectionQuads: '0',
+      ownedSubjectCount: '0',
+      ownedSubjectTableBytes: '0',
+    });
+    expect(ready.plan.next.projectionQuads).toEqual([]);
+    expect(ready.plan.projectionDeletionTable).toEqual(
+      fixture.tombstone.deletionOwnedSubjectTable,
+    );
+    expect(update.subjectUnion).toEqual(fixture.tombstone.deletionOwnedSubjectTable);
+    expect(update.sparql).not.toContain('VALUES (?insertProjectionSubject');
+    expect(ready.plan.next.appliedState).not.toHaveProperty('conflictSidecarIntentOperation');
+    registry.consumer.release(facts);
+  });
+
+  it('tombstones an active row by freeing only that row projection/table contribution', async () => {
+    const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const activeRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const activeFacts = activeRegistry.consumer.consume(
+      activeRegistry.issuer.issueActive(fixture.active),
+      fixture.binding,
+    );
+    const cold = expectReady(deriveSystemRecordReplacementV1({
+      facts: activeFacts,
+      snapshot: decodeSystemRecordAppliedSnapshotV1({
+        networkId: activeFacts.networkId,
+        stableKeyHash: computeSystemRecordStableKeyHashV1(
+          activeFacts.networkId,
+          activeFacts.head.peerId,
+        ),
+        materializationEpoch: activeFacts.materializationEpoch,
+        quads: [fixture.epochQuad],
+      }),
+      observedRootClaimQuads: [],
+    }));
+    const activeTuple = buildSystemRecordReservedStateQuadsV1({
+      appliedState: cold.plan.next.appliedState,
+      headVersion: cold.plan.next.headVersion,
+      ownedSubjectTable: cold.plan.next.ownedSubjectTable,
+      rootClaimSet: cold.plan.next.rootClaimSet,
+      capacityState: cold.plan.next.capacityState,
+      receipt: cold.plan.next.receipt,
+    });
+    const activeSnapshot = decodeSystemRecordAppliedSnapshotV1({
+      networkId: activeFacts.networkId,
+      stableKeyHash: cold.plan.stableKeyHash,
+      materializationEpoch: activeFacts.materializationEpoch,
+      quads: [
+        ...activeTuple.record,
+        ...activeTuple.capacity,
+        ...activeTuple.epoch,
+        ...activeTuple.receipt,
+      ],
+    });
+    activeRegistry.consumer.release(activeFacts);
+
+    const terminalRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const terminalFacts = terminalRegistry.consumer.consume(
+      terminalRegistry.issuer.issueCandidate({
+        operation: 'tombstone',
+        ...fixture.tombstone,
+      }),
+      fixture.binding,
+    );
+    const ready = expectReady(deriveSystemRecordReplacementV1({
+      facts: terminalFacts,
+      snapshot: activeSnapshot,
+      observedRootClaimQuads: cold.plan.next.rootClaimQuads,
+    }));
+    expect(ready.plan.next.capacityState.liveRecordCount).toBe(
+      cold.plan.next.capacityState.liveRecordCount,
+    );
+    expect(BigInt(ready.plan.next.capacityState.stateBytes)).toBe(
+      BigInt(cold.plan.next.capacityState.stateBytes),
+    );
+    expect(BigInt(cold.plan.next.capacityState.tableBytes)
+      - BigInt(ready.plan.next.capacityState.tableBytes)).toBe(
+      BigInt(cold.plan.next.appliedState.ownedSubjectTableBytes),
+    );
+    expect(BigInt(cold.plan.next.capacityState.projectionBytes)
+      - BigInt(ready.plan.next.capacityState.projectionBytes)).toBe(
+      BigInt(cold.plan.next.appliedState.projectionBytes),
+    );
+    terminalRegistry.consumer.release(terminalFacts);
+  });
+
+  it('persists a shadow deletion table across restart and clears it at authoritative cutover', async () => {
+    const shadowFixture = await makeAuthenticTerminalReplacementFixtureV1('shadow');
+    const shadowRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const shadowFacts = shadowRegistry.consumer.consume(
+      shadowRegistry.issuer.issueCandidate({
+        operation: 'tombstone',
+        ...shadowFixture.tombstone,
+      }),
+      shadowFixture.binding,
+    );
+    const shadowReady = expectReady(deriveSystemRecordReplacementV1({
+      facts: shadowFacts,
+      snapshot: decodeSystemRecordAppliedSnapshotV1({
+        networkId: shadowFacts.networkId,
+        stableKeyHash: computeSystemRecordStableKeyHashV1(
+          shadowFacts.networkId,
+          shadowFacts.head.peerId,
+        ),
+        materializationEpoch: shadowFacts.materializationEpoch,
+        quads: [shadowFixture.epochQuad],
+      }),
+      observedRootClaimQuads: [],
+    }));
+    expect(shadowReady.plan.next.appliedState.status).toBe('dirty');
+    expect(shadowReady.plan.next.pendingDeletionTable).toEqual(
+      shadowFixture.tombstone.deletionOwnedSubjectTable,
+    );
+    const shadowTuple = buildSystemRecordReservedStateQuadsV1({
+      appliedState: shadowReady.plan.next.appliedState,
+      headVersion: shadowReady.plan.next.headVersion,
+      ownedSubjectTable: shadowReady.plan.next.ownedSubjectTable,
+      pendingDeletionTable: shadowReady.plan.next.pendingDeletionTable!,
+      rootClaimSet: shadowReady.plan.next.rootClaimSet,
+      capacityState: shadowReady.plan.next.capacityState,
+      receipt: shadowReady.plan.next.receipt,
+    });
+    const restarted = decodeSystemRecordAppliedSnapshotV1({
+      networkId: shadowFacts.networkId,
+      stableKeyHash: shadowReady.plan.stableKeyHash,
+      materializationEpoch: shadowFacts.materializationEpoch,
+      quads: [
+        ...shadowTuple.record,
+        ...shadowTuple.capacity,
+        ...shadowTuple.epoch,
+        ...shadowTuple.receipt,
+      ],
+    });
+    expect(restarted.state).toBe('present');
+    if (restarted.state !== 'present') throw new Error('expected restarted dirty state');
+    expect(restarted.pendingDeletionTable).toEqual(
+      shadowFixture.tombstone.deletionOwnedSubjectTable,
+    );
+    shadowRegistry.consumer.release(shadowFacts);
+
+    const authoritativeFixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const authoritativeRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const authoritativeFacts = authoritativeRegistry.consumer.consume(
+      authoritativeRegistry.issuer.issueCandidate({
+        operation: 'tombstone',
+        ...authoritativeFixture.tombstone,
+      }),
+      authoritativeFixture.binding,
+    );
+    const cutover = expectReady(deriveSystemRecordReplacementV1({
+      facts: authoritativeFacts,
+      snapshot: restarted,
+      observedRootClaimQuads: shadowReady.plan.next.rootClaimQuads,
+    }));
+    expect(cutover.plan.next.appliedState.status).toBe('tombstone');
+    expect(cutover.plan.next).not.toHaveProperty('pendingDeletionTable');
+    expect(cutover.plan.next.appliedState).not.toHaveProperty('pendingDeletionTableDigest');
+    expect(cutover.plan.next.appliedState).not.toHaveProperty('conflictSidecarIntentOperation');
+    authoritativeRegistry.consumer.release(authoritativeFacts);
+  });
+
+  it('persists quarantine evidence without a sidecar intent and blocks ordinary unquarantine', async () => {
+    const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const initialRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const initialFacts = initialRegistry.consumer.consume(
+      initialRegistry.issuer.issueActive(fixture.active),
+      fixture.binding,
+    );
+    const active = expectReady(deriveSystemRecordReplacementV1({
+      facts: initialFacts,
+      snapshot: decodeSystemRecordAppliedSnapshotV1({
+        networkId: initialFacts.networkId,
+        stableKeyHash: computeSystemRecordStableKeyHashV1(
+          initialFacts.networkId,
+          initialFacts.head.peerId,
+        ),
+        materializationEpoch: initialFacts.materializationEpoch,
+        quads: [fixture.epochQuad],
+      }),
+      observedRootClaimQuads: [],
+    }));
+    const activeTuple = buildSystemRecordReservedStateQuadsV1({
+      appliedState: active.plan.next.appliedState,
+      headVersion: active.plan.next.headVersion,
+      ownedSubjectTable: active.plan.next.ownedSubjectTable,
+      rootClaimSet: active.plan.next.rootClaimSet,
+      capacityState: active.plan.next.capacityState,
+      receipt: active.plan.next.receipt,
+    });
+    const activeSnapshot = decodeSystemRecordAppliedSnapshotV1({
+      networkId: initialFacts.networkId,
+      stableKeyHash: active.plan.stableKeyHash,
+      materializationEpoch: initialFacts.materializationEpoch,
+      quads: [
+        ...activeTuple.record,
+        ...activeTuple.capacity,
+        ...activeTuple.epoch,
+        ...activeTuple.receipt,
+      ],
+    });
+    initialRegistry.consumer.release(initialFacts);
+
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const quarantineFacts = registry.consumer.consume(
+      registry.issuer.issueCandidate({ operation: 'quarantine', ...fixture.quarantine }),
+      fixture.binding,
+    );
+    const quarantined = expectReady(deriveSystemRecordReplacementV1({
+      facts: quarantineFacts,
+      snapshot: activeSnapshot,
+      observedRootClaimQuads: active.plan.next.rootClaimQuads,
+    }));
+    expect(quarantined.plan.next.appliedState).toMatchObject({
+      status: 'quarantined',
+      stateRevision: '2',
+      conflictEvidenceDigest: fixture.quarantine.conflictEvidenceDigest,
+    });
+    expect(quarantined.plan.next.appliedState).not.toHaveProperty(
+      'conflictSidecarIntentOperation',
+    );
+    const tuple = buildSystemRecordReservedStateQuadsV1({
+      appliedState: quarantined.plan.next.appliedState,
+      headVersion: quarantined.plan.next.headVersion,
+      ownedSubjectTable: quarantined.plan.next.ownedSubjectTable,
+      rootClaimSet: quarantined.plan.next.rootClaimSet,
+      capacityState: quarantined.plan.next.capacityState,
+      receipt: quarantined.plan.next.receipt,
+    });
+    const snapshot = decodeSystemRecordAppliedSnapshotV1({
+      networkId: quarantineFacts.networkId,
+      stableKeyHash: quarantined.plan.stableKeyHash,
+      materializationEpoch: quarantineFacts.materializationEpoch,
+      quads: [...tuple.record, ...tuple.capacity, ...tuple.epoch, ...tuple.receipt],
+    });
+    registry.consumer.release(quarantineFacts);
+
+    const activeRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const activeFacts = activeRegistry.consumer.consume(
+      activeRegistry.issuer.issueActive(fixture.active),
+      fixture.binding,
+    );
+    expect(deriveSystemRecordReplacementV1({
+      facts: activeFacts,
+      snapshot,
+      observedRootClaimQuads: quarantined.plan.next.rootClaimQuads,
+    })).toEqual({ outcome: 'deferred', reason: 'non-active-state' });
+    activeRegistry.consumer.release(activeFacts);
+  });
+
+  it('persists terminal transition object digests in the bounded quarantine slots', async () => {
+    const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const transitionDigests = Object.freeze([
+      `0x${'bc'.repeat(32)}`,
+      `0x${'de'.repeat(32)}`,
+    ].sort()) as readonly Digest32V1[];
+    const evidence: AgentProfileConflictEvidenceV1 = Object.freeze({
+      objectType: 'conflict-evidence',
+      kind: 'agents',
+      networkId: fixture.active.head.networkId,
+      peerId: fixture.active.head.peerId,
+      entries: Object.freeze([Object.freeze({
+        type: 'transition',
+        priorAuthoritySequence: fixture.active.head.authoritySequence,
+        nextAuthoritySequence: String(BigInt(fixture.active.head.authoritySequence) + 1n),
+        objectDigests: transitionDigests,
+      })]),
+    });
+    const canonicalConflictEvidenceBytes = canonicalizeAgentProfileConflictEvidenceV1(evidence);
+    const conflictEvidenceDigest = computeAgentProfileConflictEvidenceDigestV1(evidence);
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const facts = registry.consumer.consume(registry.issuer.issueCandidate({
+      operation: 'quarantine',
+      ...fixture.active,
+      conflictEvidenceDigest,
+      canonicalConflictEvidenceBytes,
+      terminalTransitionConflict: true,
+    }), fixture.binding);
+    const ready = expectReady(deriveSystemRecordReplacementV1({
+      facts,
+      snapshot: decodeSystemRecordAppliedSnapshotV1({
+        networkId: facts.networkId,
+        stableKeyHash: computeSystemRecordStableKeyHashV1(
+          facts.networkId,
+          facts.head.peerId,
+        ),
+        materializationEpoch: facts.materializationEpoch,
+        quads: [fixture.epochQuad],
+      }),
+      observedRootClaimQuads: [],
+    }));
+
+    expect(ready.plan.next.appliedState.conflictDigestSlots).toEqual(transitionDigests);
+    expect(ready.plan.next.appliedState.conflictOverflow).toBe(false);
+    expect(ready.plan.next.appliedState).not.toHaveProperty(
+      'conflictSidecarIntentOperation',
+    );
+    registry.consumer.release(facts);
   });
 });
 

--- a/packages/storage/test/system-record-next-state-v1.test.ts
+++ b/packages/storage/test/system-record-next-state-v1.test.ts
@@ -738,12 +738,11 @@ describe('system-record terminal and quarantine next-state derivation', () => {
     activeRegistry.consumer.release(activeFacts);
   });
 
-  // The tombstone classifier is a parallel path to the active one and had no
-  // quarantine gate, so a peer that equivocated could delete the quarantined row
-  // -- and the evidence of its own equivocation -- by publishing a tombstone for
-  // the head it had quarantined. Every conjunct of the advance matches here,
-  // which is the point: without the gate this fixture advances and plans a
-  // deletion.
+  // Pins the precondition that makes the absent-resolution refusal unreachable
+  // today: a summary minted through the closure for a head advertising a
+  // resolution always carries the facts. The refusal guards a summary minted on
+  // some other traversal, which cannot be built here -- so the precondition is
+  // pinned instead of faking a removal test for it.
   it('carries verified fork-resolution facts on the fork-resolving successor', async () => {
     const { binding } = makeAuthenticActiveReplacementFixtureV1('authoritative');
     const fork = await makeForkResolvingSuccessorFixtureV1(binding);
@@ -755,6 +754,130 @@ describe('system-record terminal and quarantine next-state derivation', () => {
     });
     expect(fork.head.version).toBe('3');
   });
+
+  // Two real authority rotations before the fork, so the persisted row's lineage
+  // length (2) differs from the forked version (1). Without that the two
+  // comparisons read the same number and a predicate matching the resolution's
+  // sequence against the wrong operand still passes.
+  it('clears a fork quarantine on a row whose lineage outruns its version', async () => {
+    const fork = await quarantinedForkFixtureV1('rotated');
+    if (fork.quarantinedSnapshot.state !== 'present') throw new Error('expected a present row');
+    expect(fork.quarantinedSnapshot.headVersion).toBe('1');
+    expect(fork.quarantinedSnapshot.appliedState.transitionLineage).toHaveLength(2);
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const cleared = expectReady(deriveSystemRecordReplacementV1({
+      facts: registry.consumer.consume(
+        registry.issuer.issueActive(fork.successorIssue),
+        fork.binding,
+      ),
+      snapshot: fork.quarantinedSnapshot,
+      observedRootClaimQuads: fork.observedRootClaimQuads,
+    }));
+    expect(cleared.plan.next.appliedState.status).toBe('active');
+  });
+
+  it('clears a fork quarantine for the successor resolving that exact fork', async () => {
+    const fork = await quarantinedForkFixtureV1();
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const cleared = expectReady(deriveSystemRecordReplacementV1({
+      facts: registry.consumer.consume(
+        registry.issuer.issueActive(fork.successorIssue),
+        fork.binding,
+      ),
+      snapshot: fork.quarantinedSnapshot,
+      observedRootClaimQuads: fork.observedRootClaimQuads,
+    }));
+    expect(cleared.plan.next.appliedState.status).toBe('active');
+  });
+
+  // The precondition every unreachable conjunct in this file rests on: an active
+  // row carries no conflict saga, so a later reader can treat empty slots and an
+  // absent fork base as facts rather than hopes. It holds because the active
+  // state is built as a fresh literal (:324-332) rather than by spreading the
+  // persisted row -- turn that into a spread and this goes red.
+  //
+  // The pin has two arms because a single one cannot exist: a row carrying slots
+  // is terminal and never unquarantines, so "unquarantine a slots-carrying row
+  // and find it clean" is unbuildable. Arm one is what makes an active row's
+  // slots always empty -- a genuinely slots-carrying row, derived through
+  // terminal transition evidence rather than assigned, is refused even though
+  // every other clause of the advance passes.
+  //
+  // That isolation is measured, not assumed: the slots disjunct is the only true
+  // one here, and disabling it turns this test and only this test red. Anyone
+  // re-proving that must mutate the clause inside classifyAuthorityAdvance
+  // specifically -- the tombstone gate carries a textually identical slots
+  // clause, and disabling that one instead leaves the whole suite green, which
+  // reads as though this pin were inert.
+  it('refuses to unquarantine a row whose conflict slots are occupied', async () => {
+    const fork = await quarantinedForkFixtureV1('based', true);
+    if (fork.quarantinedSnapshot.state !== 'present') throw new Error('expected a present row');
+    expect(fork.quarantinedSnapshot.appliedState.conflictDigestSlots.length)
+      .toBeGreaterThan(0);
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    expect(deriveSystemRecordReplacementV1({
+      facts: registry.consumer.consume(
+        registry.issuer.issueActive(fork.successorIssue),
+        fork.binding,
+      ),
+      snapshot: fork.quarantinedSnapshot,
+      observedRootClaimQuads: fork.observedRootClaimQuads,
+    })).toEqual({ outcome: 'deferred', reason: 'non-active-state' });
+  });
+
+  // Arm two: what a row that DOES clear looks like afterwards.
+  it('unquarantines to an active row carrying no conflict saga at all', async () => {
+    const fork = await quarantinedForkFixtureV1();
+    if (fork.quarantinedSnapshot.state !== 'present') throw new Error('expected a present row');
+    const quarantined = fork.quarantinedSnapshot.appliedState;
+    expect(fork.forkBaseHeadDigest).toBeDefined();
+    expect(quarantined.conflictForkBaseHeadDigest).toBe(fork.forkBaseHeadDigest);
+    expect(quarantined.conflictEvidenceDigest).toBeDefined();
+
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const cleared = expectReady(deriveSystemRecordReplacementV1({
+      facts: registry.consumer.consume(
+        registry.issuer.issueActive(fork.successorIssue),
+        fork.binding,
+      ),
+      snapshot: fork.quarantinedSnapshot,
+      observedRootClaimQuads: fork.observedRootClaimQuads,
+    }));
+    expect(cleared.plan.next.appliedState.status).toBe('active');
+    expect(cleared.plan.next.appliedState.conflictForkBaseHeadDigest).toBeUndefined();
+    expect(cleared.plan.next.appliedState.conflictEvidenceDigest).toBeUndefined();
+    expect(cleared.plan.next.appliedState.conflictDigestSlots).toEqual([]);
+    expect(cleared.plan.next.appliedState.conflictOverflow).toBe(false);
+  });
+
+  // Three resolutions that all verify on their own terms, each disagreeing with
+  // our quarantine on exactly one coordinate of the fork event. One conjunct
+  // decides each case, so removing that conjunct turns that case -- and only
+  // that case -- green.
+  it.each([
+    ['a different fork of the same history', 'genesis'],
+    ['a fork at a different version off our base', 'other-version'],
+    ['a fork at our version off a different base', 'other-base'],
+  ] as const)('refuses a resolution of %s', async (_label, shape) => {
+    const fork = await quarantinedForkFixtureV1();
+    const other = await makeForkResolvingSuccessorFixtureV1(fork.binding, shape);
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    expect(deriveSystemRecordReplacementV1({
+      facts: registry.consumer.consume(
+        registry.issuer.issueActive(other.issue),
+        fork.binding,
+      ),
+      snapshot: fork.quarantinedSnapshot,
+      observedRootClaimQuads: fork.observedRootClaimQuads,
+    })).toEqual({ outcome: 'deferred', reason: 'non-active-state' });
+  });
+
+  // The tombstone classifier is a parallel path to the active one and had no
+  // quarantine gate, so a peer that equivocated could delete the quarantined row
+  // -- and the evidence of its own equivocation -- by publishing a tombstone for
+  // the head it had quarantined. Every conjunct of the advance matches here,
+  // which is the point: without the gate this fixture advances and plans a
+  // deletion.
 
   it('never lets a tombstone advance over a fork-quarantined row', async () => {
     const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
@@ -1426,4 +1549,92 @@ function quadKey(quad: Readonly<{ subject: string; predicate: string; object: st
 
 function compareUtf8(left: string, right: string): number {
   return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
+}
+
+/** Apply our branch of a fork, then quarantine it, and hand back that row. */
+async function quarantinedForkFixtureV1(
+  shape: 'based' | 'rotated' = 'based',
+  terminalTransitionConflict = false,
+  expectedHeadVersion = '1',
+  expectedLineageLength = shape === 'rotated' ? 2 : 0,
+) {
+  const { binding, epochQuad } = makeAuthenticActiveReplacementFixtureV1('authoritative');
+  const fork = await makeForkResolvingSuccessorFixtureV1(
+    binding,
+    shape,
+    terminalTransitionConflict,
+  );
+  const activeRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+  const activeFacts = activeRegistry.consumer.consume(
+    activeRegistry.issuer.issueActive(fork.forkedIssue),
+    binding,
+  );
+  const active = expectReady(deriveSystemRecordReplacementV1({
+    facts: activeFacts,
+    snapshot: decodeSystemRecordAppliedSnapshotV1({
+      networkId: activeFacts.networkId,
+      stableKeyHash: computeStableKey(activeFacts.head as AgentProfileActiveHeadObjectV1),
+      materializationEpoch: activeFacts.materializationEpoch,
+      quads: [epochQuad],
+    }),
+    observedRootClaimQuads: [],
+  }));
+  activeRegistry.consumer.release(activeFacts);
+
+  const quarantineRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+  const quarantineFacts = quarantineRegistry.consumer.consume(
+    quarantineRegistry.issuer.issueCandidate({
+      operation: 'quarantine',
+      ...fork.quarantineIssue,
+    }),
+    binding,
+  );
+  const quarantined = expectReady(deriveSystemRecordReplacementV1({
+    facts: quarantineFacts,
+    snapshot: replayedSnapshot(activeFacts.networkId, active),
+    observedRootClaimQuads: active.plan.next.rootClaimQuads,
+  }));
+  quarantineRegistry.consumer.release(quarantineFacts);
+  const quarantinedSnapshot = replayedSnapshot(quarantineFacts.networkId, quarantined);
+  // The numbers the predicate tests turn on live on the summary side. They only
+  // constrain the comparison if the persisted row genuinely took those values by
+  // derivation, so assert the row before any test reads it. Without this a
+  // fixture change could quietly align the two sides again and every predicate
+  // test would keep passing for the wrong reason.
+  if (quarantinedSnapshot.state !== 'present'
+    || quarantinedSnapshot.appliedState.status !== 'quarantined'
+    || quarantinedSnapshot.headVersion !== expectedHeadVersion
+    || quarantinedSnapshot.appliedState.transitionLineage.length !== expectedLineageLength) {
+    throw new Error(
+      `fork fixture derived version ${quarantinedSnapshot.state === 'present'
+        ? quarantinedSnapshot.headVersion : 'absent'} rather than the intended row`,
+    );
+  }
+  return {
+    binding,
+    forkBaseHeadDigest: fork.forkBaseHeadDigest,
+    successorIssue: fork.issue,
+    observedRootClaimQuads: quarantined.plan.next.rootClaimQuads,
+    quarantinedSnapshot,
+  };
+}
+
+function replayedSnapshot(
+  networkId: NetworkIdV1,
+  ready: SystemRecordActiveReplacementReadyV1,
+) {
+  const tuple = buildSystemRecordReservedStateQuadsV1({
+    appliedState: ready.plan.next.appliedState,
+    headVersion: ready.plan.next.headVersion,
+    ownedSubjectTable: ready.plan.next.ownedSubjectTable,
+    rootClaimSet: ready.plan.next.rootClaimSet,
+    capacityState: ready.plan.next.capacityState,
+    receipt: ready.plan.next.receipt,
+  });
+  return decodeSystemRecordAppliedSnapshotV1({
+    networkId,
+    stableKeyHash: ready.plan.stableKeyHash,
+    materializationEpoch: ready.plan.next.appliedState.materializationEpoch,
+    quads: [...tuple.record, ...tuple.capacity, ...tuple.epoch, ...tuple.receipt],
+  });
 }

--- a/packages/storage/test/system-record-next-state-v1.test.ts
+++ b/packages/storage/test/system-record-next-state-v1.test.ts
@@ -872,6 +872,33 @@ describe('system-record terminal and quarantine next-state derivation', () => {
     })).toEqual({ outcome: 'deferred', reason: 'non-active-state' });
   });
 
+  // Resolve-after-rotate, which no longer has a conjunct of its own. A peer forks
+  // at our sequence, rotates authority, then offers a resolution issued at the NEW
+  // sequence. That has not adjudicated the equivocation, it has moved past it --
+  // the AC-5 move -- so it must still be refused. Core welds a resolution's
+  // authority sequence to its fork base's, so a rotated resolution necessarily
+  // names a base in the rotated lineage, and the fork-base conjunct is what
+  // refuses it. The assertions before the act are what make that specific: the
+  // forked version still equals ours, so the version conjunct cannot be deciding.
+  it('refuses a resolution issued only after the peer rotated authority', async () => {
+    const fork = await quarantinedForkFixtureV1();
+    if (fork.quarantinedSnapshot.state !== 'present') throw new Error('expected a present row');
+    const rotated = await makeForkResolvingSuccessorFixtureV1(fork.binding, 'after-rotate');
+    expect(rotated.resolution.forkedVersion).toBe(fork.quarantinedSnapshot.headVersion);
+    expect(rotated.resolution.authoritySequence)
+      .toBe(String(fork.quarantinedSnapshot.appliedState.transitionLineage.length + 1));
+    expect(rotated.forkBaseHeadDigest).not.toBe(fork.forkBaseHeadDigest);
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    expect(deriveSystemRecordReplacementV1({
+      facts: registry.consumer.consume(
+        registry.issuer.issueActive(rotated.issue),
+        fork.binding,
+      ),
+      snapshot: fork.quarantinedSnapshot,
+      observedRootClaimQuads: fork.observedRootClaimQuads,
+    })).toEqual({ outcome: 'deferred', reason: 'non-active-state' });
+  });
+
   // The tombstone classifier is a parallel path to the active one and had no
   // quarantine gate, so a peer that equivocated could delete the quarantined row
   // -- and the evidence of its own equivocation -- by publishing a tombstone for

--- a/packages/storage/test/system-record-next-state-v1.test.ts
+++ b/packages/storage/test/system-record-next-state-v1.test.ts
@@ -64,6 +64,10 @@ import {
 } from '../src/system-record-verified-replacement-v1-internal.js';
 import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../src/internal-graph-policy.js';
 import { agentProfileIdentityProjectionV1 } from './helpers/agent-profile-identity-projection-v1.js';
+import {
+  makeAuthenticActiveReplacementFixtureV1,
+  makeForkResolvingSuccessorFixtureV1,
+} from './helpers/system-record-active-replacement-fixture.js';
 import { makeAuthenticTerminalReplacementFixtureV1 } from './helpers/system-record-terminal-replacement-fixture.js';
 
 interface Vectors {
@@ -740,6 +744,18 @@ describe('system-record terminal and quarantine next-state derivation', () => {
   // the head it had quarantined. Every conjunct of the advance matches here,
   // which is the point: without the gate this fixture advances and plans a
   // deletion.
+  it('carries verified fork-resolution facts on the fork-resolving successor', async () => {
+    const { binding } = makeAuthenticActiveReplacementFixtureV1('authoritative');
+    const fork = await makeForkResolvingSuccessorFixtureV1(binding);
+    expect(fork.issue.verifiedAuthoritySummary.forkResolution).toEqual({
+      resolutionDigest: fork.head.forkResolutionDigest,
+      authoritySequence: '0',
+      forkedVersion: '0',
+      resolutionVersion: '2',
+    });
+    expect(fork.head.version).toBe('3');
+  });
+
   it('never lets a tombstone advance over a fork-quarantined row', async () => {
     const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
     const initialRegistry = createSystemRecordVerifiedReplacementRegistryV1();

--- a/packages/storage/test/system-record-state-snapshot-v1.test.ts
+++ b/packages/storage/test/system-record-state-snapshot-v1.test.ts
@@ -10,6 +10,8 @@ import {
   computeSystemRecordMaterializationReceiptDigestV1,
   computeSystemRecordRootClaimSetDigestV1,
   computeSystemRecordStableKeyHashV1,
+  EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1,
+  SYSTEM_RECORD_EMPTY_PROJECTION_DIGEST_V1,
   SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES,
   type OwnedSubjectTableObjectV1,
   type SystemRecordAppliedStatePresentV1,
@@ -94,6 +96,50 @@ describe('system-record reserved-state snapshot decoder', () => {
     expect(Object.isFrozen(decoded)).toBe(true);
     expect(() => assertAuthenticSystemRecordAppliedSnapshotV1(decoded)).not.toThrow();
     expect(() => assertAuthenticSystemRecordAppliedSnapshotV1({ ...decoded })).toThrow(/exact decoder/);
+  });
+
+  it('round-trips the exact pending deletion table and rejects metadata-only restart state', () => {
+    const pendingBytes = canonicalizeOwnedSubjectTableObjectV1(ROOT, TABLE).byteLength;
+    const dirty = state({
+      status: 'dirty',
+      projectionDigest: SYSTEM_RECORD_EMPTY_PROJECTION_DIGEST_V1,
+      projectionBytes: '0',
+      projectionQuads: '0',
+      ownedSubjectTableDigest: EMPTY_OWNED_SUBJECT_TABLE_DIGEST_V1,
+      ownedSubjectCount: '0',
+      ownedSubjectTableBytes: '0',
+      pendingDeletionTableDigest: computeOwnedSubjectTableDigestV1(ROOT, TABLE),
+      pendingDeletionSubjectCount: '1',
+      pendingDeletionTableBytes: String(pendingBytes),
+      accountedBytes: computeSystemRecordAccountedBytesV1(0, 0, pendingBytes).toString(),
+    });
+    const canonical = tuple({
+      appliedState: dirty,
+      ownedSubjectTable: Object.freeze([]) as OwnedSubjectTableObjectV1,
+      pendingDeletionTable: TABLE,
+      capacityState: {
+        objectType: 'system-record-capacity-state',
+        kind: 'agents',
+        networkId: NETWORK,
+        revision: '8',
+        liveRecordCount: '1',
+        stateBytes: '65536',
+        tableBytes: String(pendingBytes),
+        projectionBytes: '0',
+        projectionQuads: '0',
+      },
+    });
+    const decoded = decodeTuple(canonical);
+    expect(decoded.state).toBe('present');
+    if (decoded.state !== 'present') throw new Error('expected dirty present state');
+    expect(decoded.pendingDeletionTable).toEqual(TABLE);
+    expect(Object.isFrozen(decoded.pendingDeletionTable)).toBe(true);
+
+    expect(() => decodeTuple({
+      ...canonical,
+      record: canonical.record.filter((quad) =>
+        quad.predicate !== SYSTEM_RECORD_V1_PREDICATES.pendingDeletionTable),
+    })).toThrow(/pending deletion table/);
   });
 
   it('decodes an exact prior-epoch tuple against the current durable epoch', () => {
@@ -402,6 +448,8 @@ function decodeTuple(value: ReturnType<typeof tuple>) {
 
 function tuple(overrides: {
   readonly appliedState?: SystemRecordAppliedStatePresentV1;
+  readonly ownedSubjectTable?: OwnedSubjectTableObjectV1;
+  readonly pendingDeletionTable?: OwnedSubjectTableObjectV1;
   readonly rootClaimSet?: Parameters<typeof buildSystemRecordReservedStateQuadsV1>[0]['rootClaimSet'];
   readonly capacityState?: SystemRecordCapacityStateV1;
 } = {}) {
@@ -420,7 +468,10 @@ function tuple(overrides: {
   return buildSystemRecordReservedStateQuadsV1({
     appliedState,
     headVersion: '0',
-    ownedSubjectTable: TABLE,
+    ownedSubjectTable: overrides.ownedSubjectTable ?? TABLE,
+    ...(overrides.pendingDeletionTable === undefined
+      ? {}
+      : { pendingDeletionTable: overrides.pendingDeletionTable }),
     rootClaimSet,
     capacityState: overrides.capacityState ?? {
       objectType: 'system-record-capacity-state',

--- a/packages/storage/test/system-record-verified-replacement-v1.test.ts
+++ b/packages/storage/test/system-record-verified-replacement-v1.test.ts
@@ -293,6 +293,54 @@ describe('system-record verified replacement V1', () => {
     }
   });
 
+  // The tagged bridge is the entry point the agent-side receiver dispatches
+  // through, but every storage test reached active facts via issueActive instead:
+  // 17 issueCandidate call sites in this package and not one passed
+  // operation: 'active'. So the active arm had no storage-side coverage, and it
+  // can regress on its own. candidateIssueKeys hands exactRecord
+  // TAGGED_ACTIVE_ISSUE_KEYS, then stripOperation re-picks ISSUE_KEYS to drop the
+  // tag before delegating; the two sets must stay exactly one key apart. Drop
+  // 'operation' from the tagged set and exactRecord rejects the tag it was just
+  // handed. Widen the strip to the tagged set and issueActive receives a key its
+  // own exact shape refuses. Either way this test goes red and no other one does.
+  it('accepts a tagged active candidate through the generic bridge, not only issueActive', () => {
+    const legacyRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const legacy = fixture();
+    const legacyFacts = legacyRegistry.consumer.consume(
+      legacyRegistry.issuer.issueActive(legacy.input),
+      legacy.bindings,
+    );
+    const expected = {
+      keys: Object.keys(legacyFacts).sort(),
+      head: legacyFacts.head,
+      projectionDigest: legacyFacts.projectionDigest,
+      projectionQuads: legacyFacts.projectionQuads,
+      ownedSubjectTable: legacyFacts.ownedSubjectTable,
+      summary: legacyFacts.verifiedAuthoritySummary,
+    };
+    // Released before the second issue so this measures dispatch equivalence
+    // rather than whether two leases can be held at once.
+    legacyRegistry.consumer.release(legacyFacts);
+
+    const taggedRegistry = createSystemRecordVerifiedReplacementRegistryV1();
+    const tagged = fixture();
+    const taggedFacts = taggedRegistry.consumer.consume(
+      taggedRegistry.issuer.issueCandidate({ operation: 'active', ...tagged.input }),
+      tagged.bindings,
+    );
+
+    expect(taggedFacts.operation).toBe('active');
+    // The tag is consumed by dispatch and must not survive into the facts; an
+    // extra key here is what a widened strip would produce.
+    expect(Object.keys(taggedFacts).sort()).toEqual(expected.keys);
+    expect(taggedFacts.head).toEqual(expected.head);
+    expect(taggedFacts.projectionDigest).toBe(expected.projectionDigest);
+    expect(taggedFacts.projectionQuads).toEqual(expected.projectionQuads);
+    expect(taggedFacts.ownedSubjectTable).toEqual(expected.ownedSubjectTable);
+    expect(taggedFacts.verifiedAuthoritySummary).toBe(expected.summary);
+    taggedRegistry.consumer.release(taggedFacts);
+  });
+
   it('issues an empty frozen handle and returns one deep-owned immutable snapshot', () => {
     const registry = createSystemRecordVerifiedReplacementRegistryV1();
     const { input, bindings } = fixture();

--- a/packages/storage/test/system-record-verified-replacement-v1.test.ts
+++ b/packages/storage/test/system-record-verified-replacement-v1.test.ts
@@ -32,6 +32,7 @@ import {
 } from '../src/system-record-verified-replacement-v1-internal.js';
 import { resolveOwnedSystemRecordRuntimeV1 } from '../src/system-record-runtime-v1-internal.js';
 import { agentProfileIdentityProjectionV1 } from './helpers/agent-profile-identity-projection-v1.js';
+import { makeAuthenticTerminalReplacementFixtureV1 } from './helpers/system-record-terminal-replacement-fixture.js';
 
 interface Vectors {
   readonly variants: {
@@ -227,6 +228,65 @@ async function replacementFor(
 }
 
 describe('system-record verified replacement V1', () => {
+  it('issues exact tombstone facts without retaining a predecessor projection', async () => {
+    const fixture = await makeAuthenticTerminalReplacementFixtureV1('authoritative');
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const source = [...fixture.tombstone.deletionOwnedSubjectTable];
+    const handle = registry.issuer.issueCandidate({
+      operation: 'tombstone',
+      ...fixture.tombstone,
+      deletionOwnedSubjectTable: source,
+    });
+    source[0] = 'urn:test:mutated';
+    const facts = registry.consumer.consume(handle, fixture.binding);
+
+    expect(facts.operation).toBe('tombstone');
+    if (facts.operation !== 'tombstone') throw new Error('expected tombstone facts');
+    expect(facts.deletionOwnedSubjectTable).toEqual(
+      fixture.tombstone.deletionOwnedSubjectTable,
+    );
+    expect(facts.projectionQuads).toEqual([]);
+    expect(facts.ownedSubjectTable).toEqual([]);
+    expect(Object.isFrozen(facts.deletionOwnedSubjectTable)).toBe(true);
+    registry.consumer.release(facts);
+  });
+
+  it('recanonicalizes quarantine evidence and releases failed issue reservations', async () => {
+    const fixture = await makeAuthenticTerminalReplacementFixtureV1();
+    const valid = { operation: 'quarantine' as const, ...fixture.quarantine };
+    const registry = createSystemRecordVerifiedReplacementRegistryV1();
+    const facts = registry.consumer.consume(
+      registry.issuer.issueCandidate(valid),
+      fixture.binding,
+    );
+    expect(facts.operation).toBe('quarantine');
+    if (facts.operation !== 'quarantine') throw new Error('expected quarantine facts');
+    expect(facts.conflictEvidenceDigest).toBe(fixture.quarantine.conflictEvidenceDigest);
+    expect(facts.terminalTransitionConflict).toBe(false);
+    registry.consumer.release(facts);
+
+    const {
+      conflictEvidenceDigest: _digest,
+      canonicalConflictEvidenceBytes: _bytes,
+      terminalTransitionConflict: _terminal,
+      ...active
+    } = fixture.quarantine;
+
+    for (const invalid of [
+      { ...valid, conflictEvidenceDigest: `0x${'00'.repeat(32)}` },
+      { ...valid, terminalTransitionConflict: true },
+      {
+        ...valid,
+        canonicalConflictEvidenceBytes: new Uint8Array((16 * 1024) + 1),
+      },
+    ]) {
+      const isolated = createSystemRecordVerifiedReplacementRegistryV1();
+      expect(() => isolated.issuer.issueCandidate(invalid as typeof valid)).toThrow();
+      const next = isolated.issuer.issueActive(active);
+      isolated.consumer.release(next);
+    }
+  });
+
   it('issues an empty frozen handle and returns one deep-owned immutable snapshot', () => {
     const registry = createSystemRecordVerifiedReplacementRegistryV1();
     const { input, bindings } = fixture();

--- a/packages/storage/test/system-record-verified-replacement-v1.test.ts
+++ b/packages/storage/test/system-record-verified-replacement-v1.test.ts
@@ -272,6 +272,12 @@ describe('system-record verified replacement V1', () => {
       ...active
     } = fixture.quarantine;
 
+    // This loop is what keeps the terminal-transition flag re-derived rather than
+    // trusted. The accepting case cannot do it: with the comparison deleted the
+    // flag would be taken on faith, slots would still populate, and every accept
+    // test would stay green. The same classification also lives in the receiver,
+    // so if storage's copy is ever deleted as redundant, their agreement stops
+    // being checked anywhere -- and this is the test that would go red.
     for (const invalid of [
       { ...valid, conflictEvidenceDigest: `0x${'00'.repeat(32)}` },
       { ...valid, terminalTransitionConflict: true },


### PR DESCRIPTION
## Summary

D5b completes the System Record materializer for **terminal and quarantine** agent profiles. Storage could previously mint and execute only *active* replacement proofs; this extends the existing private registry, snapshot decoder, next-state derivation, conditional SPARQL command, and post-read/recovery executor into one closed tagged pipeline covering `active | tombstone | quarantine`, plus a **default-unused** private receiver→storage bridge.

Every mutation remains one generation- and epoch-bound full-state CAS. Nothing here activates a lane: D7 owns production composition.

Riding on the same branch, each as its own labelled commit: **S1** (refuse a tombstone advancing over a fork quarantine), **S2** (bind a fork resolution to the quarantine it clears), **S3/S5** (registry facts aliasing; a dropped re-check with its precondition pinned), **S4** (pin the dirty→authoritative cutover bypass), and **R4** (discard a verified proof when dispatch throws before consumption — a pre-existing single-slot reservation wedge).

## Related

- Issue #2052, Stack D5b. Builds on #2202, #2206, #2209, #2214, #2228, #2231.
- Depends on **#2234** (core fork-resolution identity on the authority summary) and **#2233** (ProfileManager local-only publish routing), both merged into this base.
- Carries the work tracked as S1/S2 (#35), S3/S4/S5 (#36), and R4 (#38).

## Commit shape

Eighteen commits over the integration head `2b269b0b0`: three D5b commits, six cherry-picked storage fixes, five S2 commits, and **four added in response to review** (see below). Equivalently **fifteen over the original D5b tip** and **nine over `2428057d2`**.

The branch is **fast-forwarded, never squashed**, and that is load-bearing — see the note on the sequence conjunct below.

### Added in review (`c0de92f6d`, `a4cd3ca8f`, `c67e848ce`, `a8b196009`)

Two coverage gaps and one missing invariant, all found by review on this PR. Both tests carry a fail-before proof at a recorded site, because a new test that has never been seen to fail proves nothing:

- **`c0de92f6d`** — covers the absent-fork-base arm of the fork-base conjunct. A version-zero head records no fork base and a genesis resolution is forbidden from naming one, so both sides of the comparison are absent and the row must still clear; every prior clearing test compared a *defined* base against a defined one. The gap was live: narrowing the conjunct with `resolution.forkBaseHeadDigest !== undefined` **passed the whole storage suite unchanged** while permanently stranding every genesis quarantine. With the test, that mutant kills exactly one test.
- **`a4cd3ca8f`** — covers the tagged active `issueCandidate` dispatch arm, which no storage test exercised: all 17 call sites used `tombstone` or `quarantine`, so a regression in `TAGGED_ACTIVE_ISSUE_KEYS` or `stripOperation` would have left the suite green. Mutant at `:279` kills exactly one test in 1109.
- **`c67e848ce`** — records at the site why the dirty→authoritative cutover skips the projection precondition. Behaviour unchanged; the justification previously lived only in a test comment in another file.

- **`a8b196009`** — pins the materializer bridge's binding mismatch guards. The bridge re-resolves the lane binding after preparation and refuses to issue if it moved; ten comparisons implement that and only one had a negative test. Coverage is measured: neutralising each comparison individually gives sole detectors for `mode`, `sessionIdentity`, `materializationEpoch` and `childGeneration`. `networkId` and `activationGeneration` are each compared twice, so either copy alone survives while neutralising **both** turns exactly its row red — redundancy, not dead code, and the site comment says so, because the default inference from that green is to delete a live guard.

Six review findings were declined or deferred with reasons on their threads, and filed as #2244, #2245, #2246, #2247, #2249, #2250.

## Diagrams

### Terminal apply path

Before:

```mermaid
sequenceDiagram
    participant Receiver
    participant Storage
    Receiver->>Storage: active candidate only
    Note over Storage: tombstone / quarantine<br/>cannot be minted
```

After:

```mermaid
sequenceDiagram
    participant Receiver
    participant Bridge
    participant Storage
    Receiver->>Bridge: candidate (active | tombstone | quarantine)
    Bridge->>Bridge: authenticate candidate, context, lane, generation, epoch
    Bridge-->>Receiver: prepared apply (deadlines only, no proof)
    Receiver->>Bridge: apply(admittedDeadlineMs)
    Bridge->>Storage: issue proof, then applyVerified (no await between)
    Storage-->>Receiver: settled outcome
```

## Three things a reviewer will reasonably challenge

These are answered here so the round is a footnote rather than a cycle. Each is a recorded ruling, not a preference.

### 1. The sequence conjunct is added and then dropped two commits later

That ordering is required, not churn. `4154ecaec` adds an authority-sequence conjunct; `1db4bc36b` removes it; **`36874c605`, the core weld pin, sits between them**. The conjunct could not be dropped until the core property it relies on was pinned, or the invariant would have gone from redundantly guarded to unguarded. Because the branch is fast-forwarded rather than squashed, **no commit in history has the property unguarded**.

The drop itself is a relocation. Core **welds** a resolution's authority sequence to its fork base's, so a resolution disagreeing on sequence must name a base at a different sequence — a different digest — and `P-forkBase` refuses it on the same candidate. The weld is pinned by `welds a fork resolution to a base at its own authority sequence`; **if that test is removed, the sequence coordinate stops being covered here**, and the code comment says so. The intended consequence — a resolution issued only *after* the peer rotated authority is refused, because resolving at the next sequence moves past the equivocation instead of adjudicating it — is held by `refuses a resolution issued only after the peer rotated authority`.

Strongest evidence for the drop is structural rather than textual: **the mutant "remove the sequence conjunct" can no longer be constructed, because there is no conjunct to remove**, and the remaining mutants behave exactly as a four-conjunct predicate must.

### 2. `assertTrustedTombstoneReplacement` lacks the `kind` clause its active twin has

Deliberate, per protocol ruling. The precondition is stable and already pinned: both binding snapshots reject a non-agents kind at mint, and `system-record-verified-replacement-v1.test.ts:541` drives `['kind','not-agents']` and expects a throw. Re-checking it downstream would be a permanent check that cannot fail. The code carries a citation comment naming both enforcement sites and the pinning test, so the asymmetry does not read as an oversight. **Do not "restore parity"** — if both twins' clauses are unreachable, parity argues for removing both, not for keeping a second dead one. The active twin is deliberately untouched and out of scope.

### 3. `P-absentRefusal` looks like a guard with no solo-removal test

It cannot have one, and does not need one: every conjunct below it reads `resolution`, so **deleting the line fails to compile** rather than admitting anything. The type carries the refusal. It never fires today, and the precondition keeping it silent is pinned by `carries verified fork-resolution facts on the fork-resolving successor`. It exists for a summary minted on a traversal that never ran the directness check — which the identity-only validator cannot distinguish from one that did.

## Coverage basis — read this before the numbers

`packages/storage` and `packages/core` both set `include: ['src']`, so **no `tsc` lane covers their test files**, and vitest runs through esbuild, which strips types without checking them. Every coverage claim in this series therefore rests on an **executing test plus a mutant**, never on compilation. A green build here does not imply type-level enforcement of test contracts. Tracked as #48/#50.

For R4 specifically, the honest coverage statement:

> Tests prove the property through the one reachable window (4, an executor that throws before consuming). Windows 1–3 are covered by the whole-body wrap by construction, not by test: window 1 is unreachable and now pinned as such, window 2 is frozen-field reads with no throwing path, window 3 (`admissions.run`) is a private tracker with no injection seam. That is precisely why the whole-body wrap earns its keep over a scoped region — it protects windows a future refactor could make reachable.

## Test plan

Measured by QA at the frozen head, Node 22:

| Gate | Result |
|---|---|
| `turbo build`, storage **package-plus-dependents closure filter** (not a 3-package build) | 18/18, exit 0 |
| storage serial (`--fileParallelism=false`) | 70 files / 1107 tests — reproduced twice; **1109 after the two review tests** |
| core serial (`--fileParallelism=false`) | 115 files / 1813 tests |
| core export gate | 273 exact symbols |
| agent full suite | 335 files / 4198 tests |

**The per-file base A/B is stronger than any green total**, so it is the number to read. Against `2b269b0b0`: **+28 storage tests, distributed across exactly the six touched files; +1 core (the weld pin); and zero movement in untouched files across all three lanes.** A green total can hide a file that stopped being collected; a per-file delta of zero everywhere else cannot.

Reconcile **file counts** before reading any pass number — `vitest.unit.config.ts` is an allow-list that CLI file arguments silently intersect with, so a dropped entry yields zero collected tests and a green run.

## How to read this PR's CI

The base-red ledger is pinned at `4e1215dd7`, and integration is now `2b269b0b0` with **no CI run at that base before this PR**. This PR's first run *was* the first one there, so it establishes the new baseline rather than being judged against an existing one. That first run, at `1db4bc36b`, came back **58 pass / 0 fail / 3 skipped-by-design** — and neither pre-characterized failure below reproduced.

Concretely: **an early green is not ledger-clean, and an early red is not automatically a regression.** QA re-pins the reds and the expected-skip set from this run's checkout-log-measured base.

Two pre-existing local failures were characterized before this PR opened and may appear: a `graph-set-index-store` timeout (one occurrence, never reproduced) and an `x25519` randomized round-trip (one red followed by seven greens). They are named here so a reviewer seeing either does not read it as new — **not** so it can be waved through. Neither is auto-excused: any red is still attributed per instance by mechanism, and either of these reproducing consistently would be a finding rather than noise.

## Note for anyone running the storage lane locally

**Build `core` first, or you will see eight failures that are not real.** This stack adds `conflictForkBaseHeadDigest` to core's applied-state codec, and storage executes core's **`dist`**. Against a stale `core/dist` the old validator's exact-key allowlist rejects the new field, and eight quarantine tests in `system-record-next-state-v1.test.ts` fail deterministically with `present applied state has unknown or missing fields`.

It is worth knowing the shape because it is convincingly disguised: **the stack trace points at `core/src` with real line numbers**, via sourcemaps, so it reads as a source defect rather than a stale artifact. Confirm with a grep — zero occurrences of the field in `core/dist/system-record-applied-state-v1.js` against four in `core/src` — and fix with `pnpm exec turbo build --filter=@origintrail-official/dkg-storage...`. CI builds fresh and is unaffected.

## Note for anyone running the agent lane locally

The agent full suite rewrites `packages/evm-module/deployments/localhost_contracts.json` in-process (identity metadata only). The file **will** be modified afterward. Restore with `git checkout --` before any staging, and never `git add -A`.


