### PR TITLE
fix(agent): partition sync admission to prevent background starvation

### DIFF
--- a/packages/agent/src/curator-meta-refresh.ts
+++ b/packages/agent/src/curator-meta-refresh.ts
@@ -27,7 +27,6 @@ import { hasAuthoritativePublicMetaDefinition } from './context-graph-public-met
 import { getSyncCheckpointKey, type SyncCheckpointStore } from './sync/checkpoint/state.js';
 import {
   hasSyncAdmissionSource,
-  withSyncAdmissionSource,
 } from './sync/attempt-telemetry.js';
 import { insertWithOversizeGuard, type OversizeDrop } from './sync/oversize-filter.js';
 import type {
@@ -103,6 +102,17 @@ interface CuratorMetaRefreshAgent {
     deadline: number,
     options?: SyncPageFetchOptions,
   ): Promise<SyncPageResult>;
+  runContextGraphSyncWithBackpressure<T>(
+    ctx: OperationContext,
+    contextGraphId: string,
+    lane: 'durable',
+    label: string,
+    work: () => Promise<T>,
+    admission: {
+      operationSignal?: AbortSignal;
+      source: 'control-plane';
+    },
+  ): Promise<T>;
   bindSubscriptionOnChainId?(
     localCgId: string,
     sub: CuratorBoundSubscription,
@@ -369,9 +379,24 @@ async function fetchAuthoritativeMetaSnapshot(
       forceFreshSession: true,
     },
   );
+  // A standalone control-plane refresh is real outbound sync work. Admit it
+  // through the node-wide scheduler so partitioned mode can route it to fast
+  // capacity and the global cap still bounds it. Nested refreshes deliberately
+  // stay inside their enclosing admission: acquiring twice could deadlock a
+  // saturated partition, and the enclosing trigger remains the honest source.
   const result = await (hasSyncAdmissionSource()
     ? runFetch()
-    : withSyncAdmissionSource('control-plane', runFetch));
+    : agent.runContextGraphSyncWithBackpressure(
+      ctx,
+      contextGraphId,
+      'durable',
+      'durable:control-plane',
+      runFetch,
+      {
+        operationSignal: options.signal,
+        source: 'control-plane',
+      },
+    ));
   throwIfCuratorMetaRefreshAborted(options.signal);
 
   // The shared N-Quads parser admits any graph under the CG prefix. This

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2963,14 +2963,25 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       (message) => this.log.warn(ctx, message),
     );
     const syncGlobalPolicy = resolveAgentSyncGlobalBackpressure(this.config);
+    const syncPartitions = 'partitions' in syncGlobalPolicy
+      ? syncGlobalPolicy.partitions
+      : undefined;
     const configuredPriorityCounts = countSyncPriorityClasses(this.config.syncContextGraphPriorities);
     this.log.info(ctx, `Resolved sync policy ${JSON.stringify({
+      syncAdmissionMode: syncPartitions ? 'partitioned' : 'shared',
       snapshotGlobalRows: snapshotPolicy.budget.maxRows,
       snapshotGlobalBytesEstimate: snapshotPolicy.budget.maxBytesEstimate,
       snapshotLocalRows: snapshotPolicy.budget.maxSnapshotRows,
       snapshotLocalBytesEstimate: snapshotPolicy.budget.maxSnapshotBytesEstimate,
       syncGlobalInflightLimit: syncGlobalPolicy.limit ?? 0,
       syncGlobalQueueLimit: syncGlobalPolicy.queueLimit ?? 0,
+      syncFastInflightLimit: syncPartitions?.fast.maxInflight,
+      syncFastQueueLimit: syncPartitions?.fast.queueLimit,
+      syncSlowInflightLimit: syncPartitions?.slow.maxInflight,
+      syncSlowForegroundReserved: syncPartitions?.slow.foregroundReserved,
+      syncSlowForegroundQueueLimit: syncPartitions?.slow.foregroundQueueLimit,
+      syncSlowBackgroundInflightLimit: syncPartitions?.slow.backgroundMaxInflight,
+      syncSlowBackgroundQueueLimit: syncPartitions?.slow.backgroundQueueLimit,
       configuredPriorities: configuredPriorityCounts,
       snapshotLocalClamped: snapshotPolicy.localRowsClamped || snapshotPolicy.localBytesEstimateClamped,
     })}`);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -269,6 +269,7 @@ import {
 import {
   createContextGraphSyncDeadline,
   createDurableSyncBudget,
+  createDurableSyncFetchTimeoutMs,
   EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS,
   normalizeDurableSyncTimeoutMs,
 } from './sync/requester/durable-sync-budget.js';
@@ -5195,9 +5196,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       signal: options?.signal,
     });
     const authenticationTimeoutMs = normalizeDurableSyncTimeoutMs(options?.totalTimeoutMs);
-    const fetchTimeoutMs = exactAssetUals && options?.totalTimeoutMs === undefined
-      ? EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS
-      : authenticationTimeoutMs;
+    const fetchTimeoutMs = createDurableSyncFetchTimeoutMs({
+      totalTimeoutMs: options?.totalTimeoutMs,
+      exactRecovery: exactAssetUals !== undefined,
+    });
     const orderedContextGraphIds = orderContextGraphIdsByPriority(
       contextGraphIds,
       this.config.syncContextGraphPriorities,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2963,12 +2963,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       (message) => this.log.warn(ctx, message),
     );
     const syncGlobalPolicy = resolveAgentSyncGlobalBackpressure(this.config);
-    const syncPartitions = 'partitions' in syncGlobalPolicy
+    const syncPartitions = syncGlobalPolicy.mode === 'partitioned'
+      && syncGlobalPolicy.limit !== undefined
       ? syncGlobalPolicy.partitions
       : undefined;
     const configuredPriorityCounts = countSyncPriorityClasses(this.config.syncContextGraphPriorities);
     this.log.info(ctx, `Resolved sync policy ${JSON.stringify({
-      syncAdmissionMode: syncPartitions ? 'partitioned' : 'shared',
+      syncAdmissionMode: syncGlobalPolicy.mode,
       snapshotGlobalRows: snapshotPolicy.budget.maxRows,
       snapshotGlobalBytesEstimate: snapshotPolicy.budget.maxBytesEstimate,
       snapshotLocalRows: snapshotPolicy.budget.maxSnapshotRows,

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -63,6 +63,7 @@ import type {
   ResolvedRfc64PublicCatalogAutoPublishPolicyV1,
 } from './rfc64/public-catalog-activation-config-v1.js';
 import type {
+  SyncAdmissionConfig,
   SyncContextGraphPriorityConfig,
   SyncResponderSnapshotLimitsConfig,
 } from './sync/policy.js';
@@ -1480,6 +1481,8 @@ export interface DKGAgentConfig {
   syncGlobalLimit?: number;
   /** Max sync jobs waiting behind the global cap. Defaults to 2x the inflight cap. */
   syncGlobalQueueLimit?: number;
+  /** Optional partitioned fast/slow sync admission. Omit for the legacy shared limiter. */
+  syncAdmission?: SyncAdmissionConfig;
   /** Daemon-local retained responder snapshot row/estimated-byte policy. */
   syncResponderSnapshotLimits?: SyncResponderSnapshotLimitsConfig;
   /**

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1473,13 +1473,13 @@ export interface DKGAgentConfig {
   /** Emergency switch for durable/SWM sync execution. Env DKG_DURABLE_SYNC_ENABLED wins. */
   durableSyncEnabled?: boolean;
   /**
-   * Global cap for concurrent sync jobs. Defaults to 2; set 0 to disable.
+   * Global cap for concurrent sync jobs. Defaults to 10; set 0 to disable.
    * Env DKG_SYNC_GLOBAL_MAX_INFLIGHT wins.
    */
   syncGlobalMaxInflight?: number;
   /** Backwards-compatible alias for syncGlobalMaxInflight. Env DKG_SYNC_GLOBAL_LIMIT wins. */
   syncGlobalLimit?: number;
-  /** Max sync jobs waiting behind the global cap. Defaults to 2x the inflight cap. */
+  /** Hard cap for queued sync jobs. Shared mode defaults to 2x the inflight cap. */
   syncGlobalQueueLimit?: number;
   /** Optional partitioned fast/slow sync admission. Omit for the legacy shared limiter. */
   syncAdmission?: SyncAdmissionConfig;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -154,6 +154,7 @@ export {
   syncPriorityClass,
   validateSyncResponderSnapshotLimitsConfig,
   type SyncAdmissionSource,
+  type SyncAdmissionConfig,
   type SyncContextGraphPriorityConfig,
   type SyncPriorityClass,
   type SyncResponderSnapshotLimitsConfig,

--- a/packages/agent/src/sync/attempt-telemetry.ts
+++ b/packages/agent/src/sync/attempt-telemetry.ts
@@ -104,6 +104,7 @@ export type SyncOperationOutcome = (typeof SYNC_OPERATION_OUTCOMES)[number];
 
 export const SYNC_OPERATION_REJECTION_REASONS = [
   'queue_full',
+  'queue_timeout',
   'displaced',
   'aborted_before_start',
 ] as const;

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -1,5 +1,9 @@
 import { performance } from 'node:perf_hooks';
-import { getMetrics, type OperationContext } from '@origintrail-official/dkg-core';
+import {
+  getMetrics,
+  type OperationContext,
+  type SchedulerPressureCapacity,
+} from '@origintrail-official/dkg-core';
 import {
   normalizeSyncAdmissionSource,
   type SyncAdmissionConfig,
@@ -32,22 +36,31 @@ export interface SyncGlobalBackpressureConfig {
 
 declare const syncGlobalBackpressurePolicyBrand: unique symbol;
 
+type SyncAdmissionPartitions = Readonly<{
+  fast: Readonly<{ maxInflight: number; queueLimit: number; queueTimeoutMs: number }>;
+  slow: Readonly<{
+    maxInflight: number;
+    foregroundReserved: number;
+    foregroundQueueLimit: number;
+    backgroundMaxInflight: number;
+    backgroundQueueLimit: number;
+  }>;
+}>;
+
 export type SyncGlobalBackpressurePolicy = Readonly<(
   | {
+    mode: 'shared';
     limit: number;
     queueLimit: number;
-    partitions?: Readonly<{
-      fast: Readonly<{ maxInflight: number; queueLimit: number; queueTimeoutMs: number }>;
-      slow: Readonly<{
-        maxInflight: number;
-        foregroundReserved: number;
-        foregroundQueueLimit: number;
-        backgroundMaxInflight: number;
-        backgroundQueueLimit: number;
-      }>;
-    }>;
+    partitions?: never;
   }
-  | { limit: undefined; queueLimit: undefined }
+  | {
+    mode: 'partitioned';
+    limit: number;
+    queueLimit: number;
+    partitions: SyncAdmissionPartitions;
+  }
+  | { mode: 'shared' | 'partitioned'; limit: undefined; queueLimit: undefined; partitions?: never }
 ) & { [syncGlobalBackpressurePolicyBrand]: true }>;
 
 export type SyncAdmissionClass = 'fast' | 'slow_foreground' | 'slow_background';
@@ -76,7 +89,7 @@ type SyncCapacityClaim =
     readonly contextGraphId: string;
   };
 
-export const DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT = 2;
+export const DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT = 10;
 export const DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER = 2;
 export const DEFAULT_SYNC_PRIORITY_AGING_MS = 30_000;
 export const DEFAULT_SYNC_PARTITIONED_GLOBAL_MAX_INFLIGHT = 10;
@@ -325,32 +338,6 @@ const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
     // source, before node-wide diagnostics/logging.
     operation: (entry) => syncAdmissionOperation(entry.payload),
     inflightLimit: (entry) => entry.payload.limit,
-    capacity: (entry, options) => {
-      const { policy } = entry.payload;
-      if (!isPartitionedPolicy(policy)) {
-        return {
-          queueLimit: options.queueLimit,
-          inflightLimit: policy.limit,
-          capacityModel: 'shared',
-        };
-      }
-      return {
-        queueLimit: policy.queueLimit,
-        inflightLimit: policy.limit,
-        capacityModel: 'partitioned',
-        lanes: {
-          fast: {
-            queueLimit: policy.partitions.fast.queueLimit,
-            inflightLimit: policy.partitions.fast.maxInflight,
-          },
-          slow: {
-            queueLimit: policy.partitions.slow.foregroundQueueLimit
-              + policy.partitions.slow.backgroundQueueLimit,
-            inflightLimit: policy.partitions.slow.maxInflight,
-          },
-        },
-      };
-    },
     thresholds: {
       degradedQueueAgeMs: DEFAULT_SYNC_PRIORITY_AGING_MS / 2,
       stalledActiveAgeMs: 120_000,
@@ -358,6 +345,55 @@ const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
     register: true,
   },
 });
+
+function syncGlobalPressureCapacity(
+  policy: SyncGlobalBackpressurePolicy,
+): SchedulerPressureCapacity {
+  if (policy.limit === undefined) {
+    if (policy.mode === 'shared') {
+      return { capacityModel: 'shared', queueLimit: 0, inflightLimit: 0 };
+    }
+    return {
+      capacityModel: 'partitioned',
+      queueLimit: 0,
+      inflightLimit: 0,
+      lanes: {
+        fast: { queueLimit: 0, inflightLimit: 0 },
+        slow: { queueLimit: 0, inflightLimit: 0 },
+      },
+    };
+  }
+  if (!isPartitionedPolicy(policy)) {
+    return {
+      capacityModel: 'shared',
+      queueLimit: policy.queueLimit,
+      inflightLimit: policy.limit,
+    };
+  }
+  return {
+    capacityModel: 'partitioned',
+    queueLimit: policy.queueLimit,
+    inflightLimit: policy.limit,
+    lanes: {
+      fast: {
+        queueLimit: policy.partitions.fast.queueLimit,
+        inflightLimit: policy.partitions.fast.maxInflight,
+      },
+      slow: {
+        queueLimit: policy.partitions.slow.foregroundQueueLimit
+          + policy.partitions.slow.backgroundQueueLimit,
+        inflightLimit: policy.partitions.slow.maxInflight,
+      },
+    },
+  };
+}
+
+function configureResolvedSyncGlobalPolicy(
+  policy: SyncGlobalBackpressurePolicy,
+): SyncGlobalBackpressurePolicy {
+  queue.configureObservabilityCapacity(syncGlobalPressureCapacity(policy));
+  return policy;
+}
 const automaticBackgroundLimits = new WeakMap<object, number>();
 const selectedRecoveryScopeIds = new WeakMap<object, ReadonlySet<string>>();
 
@@ -544,7 +580,9 @@ export function resolveSyncGlobalBackpressure(
     ) ?? [],
   );
   if (config.syncAdmission !== undefined && config.syncAdmission.mode !== 'shared') {
-    return resolvePartitionedSyncGlobalBackpressure(config.syncAdmission, selectedRecoveryIds);
+    return configureResolvedSyncGlobalPolicy(
+      resolvePartitionedSyncGlobalBackpressure(config, selectedRecoveryIds),
+    );
   }
   const limit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_MAX_INFLIGHT'))
     ?? nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_LIMIT'))
@@ -552,16 +590,18 @@ export function resolveSyncGlobalBackpressure(
     ?? nonNegativeInteger(config.syncGlobalLimit)
     ?? DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT;
   if (limit === 0) {
-    return Object.freeze({
+    return configureResolvedSyncGlobalPolicy(Object.freeze({
+      mode: 'shared',
       limit: undefined,
       queueLimit: undefined,
-    }) as SyncGlobalBackpressurePolicy;
+    }) as SyncGlobalBackpressurePolicy);
   }
 
   const queueLimit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_QUEUE_LIMIT'))
     ?? nonNegativeInteger(config.syncGlobalQueueLimit)
     ?? limit * DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER;
   const policy = Object.freeze({
+    mode: 'shared',
     limit,
     queueLimit,
   }) as SyncGlobalBackpressurePolicy;
@@ -573,7 +613,7 @@ export function resolveSyncGlobalBackpressure(
   // consuming that slot before exact VM or selected-SWM recovery arrives.
   automaticBackgroundLimits.set(policy, selectedRecoveryIds.size > 0 && limit > 1 ? limit - 1 : limit);
   selectedRecoveryScopeIds.set(policy, selectedRecoveryIds);
-  return policy;
+  return configureResolvedSyncGlobalPolicy(policy);
 }
 
 function validateSyncAdmissionConfig(config: SyncAdmissionConfig | undefined): void {
@@ -609,12 +649,18 @@ function resolvedPartitionValue(
 }
 
 function resolvePartitionedSyncGlobalBackpressure(
-  config: SyncAdmissionConfig,
+  globalConfig: SyncGlobalBackpressureConfig,
   selectedRecoveryIds: ReadonlySet<string>,
 ): SyncGlobalBackpressurePolicy {
+  const config = globalConfig.syncAdmission;
+  if (config === undefined) {
+    throw new TypeError('Invalid syncAdmission: partitioned mode requires a config object');
+  }
   const envLimit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_MAX_INFLIGHT'))
     ?? nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_LIMIT'));
   const limit = envLimit
+    ?? nonNegativeInteger(globalConfig.syncGlobalMaxInflight)
+    ?? nonNegativeInteger(globalConfig.syncGlobalLimit)
     ?? resolvedPartitionValue(
       config.globalMaxInflight,
       DEFAULT_SYNC_PARTITIONED_GLOBAL_MAX_INFLIGHT,
@@ -622,6 +668,7 @@ function resolvePartitionedSyncGlobalBackpressure(
     );
   if (limit === 0) {
     return Object.freeze({
+      mode: 'partitioned',
       limit: undefined,
       queueLimit: undefined,
     }) as SyncGlobalBackpressurePolicy;
@@ -689,11 +736,25 @@ function resolvePartitionedSyncGlobalBackpressure(
       'Invalid syncAdmission.slow.backgroundMaxInflight: must leave foregroundReserved slow slots',
     );
   }
+  if (slow.foregroundQueueLimit > 0 && slow.maxInflight === 0) {
+    throw new TypeError(
+      'Invalid syncAdmission.slow.foregroundQueueLimit: retained foreground work requires slow.maxInflight > 0',
+    );
+  }
+  if (slow.backgroundQueueLimit > 0 && slow.backgroundMaxInflight === 0) {
+    throw new TypeError(
+      'Invalid syncAdmission.slow.backgroundQueueLimit: retained background work requires backgroundMaxInflight > 0',
+    );
+  }
 
-  const queueLimit = fast.queueLimit
+  const partitionQueueLimit = fast.queueLimit
     + slow.foregroundQueueLimit
     + slow.backgroundQueueLimit;
+  const queueLimit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_QUEUE_LIMIT'))
+    ?? nonNegativeInteger(globalConfig.syncGlobalQueueLimit)
+    ?? partitionQueueLimit;
   const policy = Object.freeze({
+    mode: 'partitioned',
     limit,
     queueLimit,
     partitions: Object.freeze({ fast, slow }),

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -2,6 +2,7 @@ import { performance } from 'node:perf_hooks';
 import { getMetrics, type OperationContext } from '@origintrail-official/dkg-core';
 import {
   normalizeSyncAdmissionSource,
+  type SyncAdmissionConfig,
   type SyncAdmissionSource,
   type SyncPriorityClass,
   type SyncSchedulerLane,
@@ -26,16 +27,34 @@ export interface SyncGlobalBackpressureConfig {
   syncGlobalQueueLimit?: number;
   /** Scheduler-native scopes whose exact recovery must retain one slot. */
   selectedRecoveryContextGraphIds?: readonly string[];
+  syncAdmission?: SyncAdmissionConfig;
 }
 
 declare const syncGlobalBackpressurePolicyBrand: unique symbol;
 
 export type SyncGlobalBackpressurePolicy = Readonly<(
-  | { limit: number; queueLimit: number }
+  | {
+    limit: number;
+    queueLimit: number;
+    partitions?: Readonly<{
+      fast: Readonly<{ maxInflight: number; queueLimit: number; queueTimeoutMs: number }>;
+      slow: Readonly<{
+        maxInflight: number;
+        foregroundReserved: number;
+        foregroundQueueLimit: number;
+        backgroundMaxInflight: number;
+        backgroundQueueLimit: number;
+      }>;
+    }>;
+  }
   | { limit: undefined; queueLimit: undefined }
 ) & { [syncGlobalBackpressurePolicyBrand]: true }>;
 
+export type SyncAdmissionClass = 'fast' | 'slow_foreground' | 'slow_background';
+
 interface GlobalQueuePayload {
+  policy: SyncGlobalBackpressurePolicy & { limit: number; queueLimit: number };
+  admissionClass: SyncAdmissionClass;
   limit: number;
   automaticBackgroundLimit: number;
   label: string;
@@ -60,6 +79,14 @@ type SyncCapacityClaim =
 export const DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT = 2;
 export const DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER = 2;
 export const DEFAULT_SYNC_PRIORITY_AGING_MS = 30_000;
+export const DEFAULT_SYNC_PARTITIONED_GLOBAL_MAX_INFLIGHT = 10;
+export const DEFAULT_SYNC_FAST_MAX_INFLIGHT = 8;
+export const DEFAULT_SYNC_FAST_QUEUE_LIMIT = 64;
+export const DEFAULT_SYNC_FAST_QUEUE_TIMEOUT_MS = 5_000;
+export const DEFAULT_SYNC_SLOW_MAX_INFLIGHT = 2;
+export const DEFAULT_SYNC_SLOW_FOREGROUND_RESERVED = 1;
+export const DEFAULT_SYNC_SLOW_FOREGROUND_QUEUE_LIMIT = 8;
+export const DEFAULT_SYNC_SLOW_BACKGROUND_QUEUE_LIMIT = 0;
 
 function syncOperationClass(label: string): string {
   const operation = label.split(':', 1)[0];
@@ -87,12 +114,38 @@ function syncAdmissionOperation(payload: GlobalQueuePayload): string {
   return `${syncOperationClass(payload.label)}:${normalizeSyncAdmissionSource(payload.source)}`;
 }
 
+function isPartitionedPolicy(
+  policy: SyncGlobalBackpressurePolicy,
+): policy is SyncGlobalBackpressurePolicy & {
+  limit: number;
+  queueLimit: number;
+  partitions: NonNullable<GlobalQueuePayload['policy']['partitions']>;
+} {
+  return policy.limit !== undefined && policy.partitions !== undefined;
+}
+
+/** Map bounded trigger/work labels and selected-scope claims onto physical partitions. */
+export function syncAdmissionClass(
+  lane: SyncSchedulerLane,
+  source: SyncAdmissionSource,
+  selectedRecovery = false,
+): SyncAdmissionClass {
+  if (lane === 'changelog' || source === 'control-plane') return 'fast';
+  if (source === 'catchup-foreground' || selectedRecovery) return 'slow_foreground';
+  return 'slow_background';
+}
+
 class SyncCapacityTracker {
   private inflight = 0;
   private automaticBackgroundInflight = 0;
   private selectedRecoveryInflight = 0;
   private ordinarySelectedScopeInflightTotal = 0;
   private readonly ordinarySelectedScopeInflight = new Map<string, number>();
+  private readonly inflightByAdmissionClass: Record<SyncAdmissionClass, number> = {
+    fast: 0,
+    slow_foreground: 0,
+    slow_background: 0,
+  };
 
   get inflightCount(): number {
     return this.inflight;
@@ -130,17 +183,37 @@ class SyncCapacityTracker {
     return automaticBackground ? { kind: 'automatic-background' } : { kind: 'unrestricted' };
   }
 
-  canRun(claim: SyncCapacityClaim, limit: number, automaticBackgroundLimit: number): boolean {
-    if (this.inflight >= limit) return false;
+  canRun(
+    claim: SyncCapacityClaim,
+    admissionClass: SyncAdmissionClass,
+    policy: SyncGlobalBackpressurePolicy & { limit: number; queueLimit: number },
+    automaticBackgroundLimit: number,
+  ): boolean {
+    if (this.inflight >= policy.limit) return false;
     if (
       this.isAutomaticBackground(claim)
       && this.automaticBackgroundInflight >= automaticBackgroundLimit
     ) return false;
     if (
-      limit > 1
+      policy.limit > 1
       && claim.kind === 'ordinary-selected-scope'
-      && (this.ordinarySelectedScopeInflight.get(claim.contextGraphId) ?? 0) >= limit - 1
+      && (this.ordinarySelectedScopeInflight.get(claim.contextGraphId) ?? 0) >= policy.limit - 1
     ) return false;
+
+    if (isPartitionedPolicy(policy)) {
+      if (admissionClass === 'fast') {
+        if (this.inflightByAdmissionClass.fast >= policy.partitions.fast.maxInflight) return false;
+      } else {
+        const slowInflight = this.inflightByAdmissionClass.slow_foreground
+          + this.inflightByAdmissionClass.slow_background;
+        if (slowInflight >= policy.partitions.slow.maxInflight) return false;
+        if (
+          admissionClass === 'slow_background'
+          && this.inflightByAdmissionClass.slow_background
+            >= policy.partitions.slow.backgroundMaxInflight
+        ) return false;
+      }
+    }
 
     // As soon as selected-scope fallback is active (or asks to become active),
     // every non-selected claim shares only limit - 1 slots. This keeps the last
@@ -151,25 +224,25 @@ class SyncCapacityTracker {
       || claim.kind === 'ordinary-selected-scope';
     const nonSelectedInflight = this.inflight - this.selectedRecoveryInflight;
     return !(
-      limit > 1
+      policy.limit > 1
       && selectedReservationActive
       && claim.kind !== 'selected-recovery'
-      && nonSelectedInflight >= limit - 1
+      && nonSelectedInflight >= policy.limit - 1
     );
   }
 
-  start(claim: SyncCapacityClaim): () => void {
-    this.increment(claim);
+  start(claim: SyncCapacityClaim, admissionClass: SyncAdmissionClass): () => void {
+    this.increment(claim, admissionClass);
     let released = false;
     return () => {
       if (released) return;
       released = true;
-      this.decrement(claim);
+      this.decrement(claim, admissionClass);
     };
   }
 
-  rollback(claim: SyncCapacityClaim): void {
-    this.decrement(claim);
+  rollback(claim: SyncCapacityClaim, admissionClass: SyncAdmissionClass): void {
+    this.decrement(claim, admissionClass);
   }
 
   private isAutomaticBackground(claim: SyncCapacityClaim): boolean {
@@ -177,8 +250,9 @@ class SyncCapacityTracker {
       || (claim.kind === 'ordinary-selected-scope' && claim.automaticBackground);
   }
 
-  private increment(claim: SyncCapacityClaim): void {
+  private increment(claim: SyncCapacityClaim, admissionClass: SyncAdmissionClass): void {
     this.inflight += 1;
+    this.inflightByAdmissionClass[admissionClass] += 1;
     if (this.isAutomaticBackground(claim)) this.automaticBackgroundInflight += 1;
     if (claim.kind === 'selected-recovery') this.selectedRecoveryInflight += 1;
     if (claim.kind === 'ordinary-selected-scope') {
@@ -190,8 +264,12 @@ class SyncCapacityTracker {
     }
   }
 
-  private decrement(claim: SyncCapacityClaim): void {
+  private decrement(claim: SyncCapacityClaim, admissionClass: SyncAdmissionClass): void {
     this.inflight = Math.max(0, this.inflight - 1);
+    this.inflightByAdmissionClass[admissionClass] = Math.max(
+      0,
+      this.inflightByAdmissionClass[admissionClass] - 1,
+    );
     if (this.isAutomaticBackground(claim)) {
       this.automaticBackgroundInflight = Math.max(0, this.automaticBackgroundInflight - 1);
     }
@@ -216,16 +294,18 @@ class SyncCapacityTracker {
 const capacityTracker = new SyncCapacityTracker();
 let lastLimit: number | null = null;
 let lastQueueLimit: number | null = null;
+
 const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
   now: () => performance.now(),
   canRun: (entry) => capacityTracker.canRun(
     entry.payload.capacityClaim,
-    entry.payload.limit,
+    entry.payload.admissionClass,
+    entry.payload.policy,
     entry.payload.automaticBackgroundLimit,
   ),
   onStart: (entry) => {
-    const { capacityClaim } = entry.payload;
-    const releaseCapacity = capacityTracker.start(capacityClaim);
+    const { capacityClaim, admissionClass } = entry.payload;
+    const releaseCapacity = capacityTracker.start(capacityClaim, admissionClass);
     lastLimit = entry.payload.limit;
     getMetrics().syncGlobalInflight.record(capacityTracker.inflightCount);
     return () => {
@@ -234,7 +314,7 @@ const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
     };
   },
   onStartFailureRollback: (entry) => {
-    capacityTracker.rollback(entry.payload.capacityClaim);
+    capacityTracker.rollback(entry.payload.capacityClaim, entry.payload.admissionClass);
     getMetrics().syncGlobalInflight.record(capacityTracker.inflightCount);
   },
   onDepthChange: (depth) => getMetrics().syncBackgroundQueueDepth.record(depth),
@@ -245,6 +325,32 @@ const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
     // source, before node-wide diagnostics/logging.
     operation: (entry) => syncAdmissionOperation(entry.payload),
     inflightLimit: (entry) => entry.payload.limit,
+    capacity: (entry, options) => {
+      const { policy } = entry.payload;
+      if (!isPartitionedPolicy(policy)) {
+        return {
+          queueLimit: options.queueLimit,
+          inflightLimit: policy.limit,
+          capacityModel: 'shared',
+        };
+      }
+      return {
+        queueLimit: policy.queueLimit,
+        inflightLimit: policy.limit,
+        capacityModel: 'partitioned',
+        lanes: {
+          fast: {
+            queueLimit: policy.partitions.fast.queueLimit,
+            inflightLimit: policy.partitions.fast.maxInflight,
+          },
+          slow: {
+            queueLimit: policy.partitions.slow.foregroundQueueLimit
+              + policy.partitions.slow.backgroundQueueLimit,
+            inflightLimit: policy.partitions.slow.maxInflight,
+          },
+        },
+      };
+    },
     thresholds: {
       degradedQueueAgeMs: DEFAULT_SYNC_PRIORITY_AGING_MS / 2,
       stalledActiveAgeMs: 120_000,
@@ -255,7 +361,7 @@ const queue = new PriorityAdmissionQueue<GlobalQueuePayload>({
 const automaticBackgroundLimits = new WeakMap<object, number>();
 const selectedRecoveryScopeIds = new WeakMap<object, ReadonlySet<string>>();
 
-export type SyncBackpressureBusyReason = 'queue_full' | 'displaced';
+export type SyncBackpressureBusyReason = 'queue_full' | 'queue_timeout' | 'displaced';
 
 export class SyncBackpressureBusyError extends Error {
   readonly reason: SyncBackpressureBusyReason;
@@ -298,30 +404,59 @@ function acquire(
   const { limit } = policy;
   if (limit === undefined) throw new Error('disabled sync backpressure policy cannot acquire');
   const { queueLimit } = policy;
+  const normalizedSource = normalizeSyncAdmissionSource(options.source);
+  const selectedRecoveryScope = options.contextGraphId !== undefined
+    && (selectedRecoveryScopeIds.get(policy)?.has(options.contextGraphId) ?? false);
+  const capacityClaim = capacityTracker.classify({
+    contextGraphId: options.contextGraphId,
+    source: normalizedSource,
+    selectedSwmPriority: options.selectedSwmPriority,
+    selectedRecoveryScope,
+  });
+  const admissionClass = isPartitionedPolicy(policy)
+    ? syncAdmissionClass(
+      options.lane,
+      normalizedSource,
+      capacityClaim.kind === 'selected-recovery',
+    )
+    : 'slow_background';
+  const schedulerLane: SyncSchedulerLane = isPartitionedPolicy(policy)
+    ? admissionClass === 'fast' ? 'fast' : 'slow'
+    : options.lane;
+  const ownerKey = !isPartitionedPolicy(policy)
+    ? 'global'
+    : admissionClass;
+  const ownerQueueLimit = !isPartitionedPolicy(policy)
+    ? undefined
+    : admissionClass === 'fast'
+      ? policy.partitions.fast.queueLimit
+      : admissionClass === 'slow_foreground'
+        ? policy.partitions.slow.foregroundQueueLimit
+        : policy.partitions.slow.backgroundQueueLimit;
+  const queueTimeoutMs = isPartitionedPolicy(policy) && admissionClass === 'fast'
+    ? policy.partitions.fast.queueTimeoutMs
+    : undefined;
   lastLimit = limit;
   lastQueueLimit = queueLimit;
   const queuedBefore = queue.length;
-  const selectedRecoveryScope = options.contextGraphId !== undefined
-    && (selectedRecoveryScopeIds.get(policy)?.has(options.contextGraphId) ?? false);
   return queue.acquire({
     payload: {
+      policy: policy as GlobalQueuePayload['policy'],
+      admissionClass,
       limit,
       automaticBackgroundLimit: automaticBackgroundLimits.get(policy) ?? limit,
       label: options.label,
       contextGraphId: options.contextGraphId,
-      source: options.source,
-      capacityClaim: capacityTracker.classify({
-        contextGraphId: options.contextGraphId,
-        source: options.source,
-        selectedSwmPriority: options.selectedSwmPriority,
-        selectedRecoveryScope,
-      }),
+      source: normalizedSource,
+      capacityClaim,
     },
-    ownerKey: 'global',
-    lane: options.lane,
+    ownerKey,
+    ownerQueueLimit,
+    lane: schedulerLane,
     priority: options.priority,
     priorityClass: options.priorityClass,
     signal: options.signal,
+    timeoutMs: queueTimeoutMs,
     agingThresholdMs: options.agingThresholdMs,
     queueLimit,
     createBusyError: () => new SyncBackpressureBusyError(
@@ -332,6 +467,10 @@ function acquire(
         `Sync backpressure displaced ${victim.payload.contextGraphId ?? 'queued work'} for higher-priority ${options.label}`,
         'displaced',
       ),
+    createTimeoutError: () => new SyncBackpressureBusyError(
+      `Sync backpressure timed out ${options.label} waiting for the fast partition`,
+      'queue_timeout',
+    ),
   });
 }
 
@@ -398,6 +537,15 @@ export function resolveNonNegativeIntegerSwitch(
 export function resolveSyncGlobalBackpressure(
   config: SyncGlobalBackpressureConfig,
 ): SyncGlobalBackpressurePolicy {
+  validateSyncAdmissionConfig(config.syncAdmission);
+  const selectedRecoveryIds = new Set(
+    config.selectedRecoveryContextGraphIds?.filter(
+      (contextGraphId) => typeof contextGraphId === 'string' && contextGraphId.length > 0,
+    ) ?? [],
+  );
+  if (config.syncAdmission !== undefined && config.syncAdmission.mode !== 'shared') {
+    return resolvePartitionedSyncGlobalBackpressure(config.syncAdmission, selectedRecoveryIds);
+  }
   const limit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_MAX_INFLIGHT'))
     ?? nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_LIMIT'))
     ?? nonNegativeInteger(config.syncGlobalMaxInflight)
@@ -413,11 +561,6 @@ export function resolveSyncGlobalBackpressure(
   const queueLimit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_QUEUE_LIMIT'))
     ?? nonNegativeInteger(config.syncGlobalQueueLimit)
     ?? limit * DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER;
-  const selectedRecoveryIds = new Set(
-    config.selectedRecoveryContextGraphIds?.filter(
-      (contextGraphId) => typeof contextGraphId === 'string' && contextGraphId.length > 0,
-    ) ?? [],
-  );
   const policy = Object.freeze({
     limit,
     queueLimit,
@@ -428,6 +571,133 @@ export function resolveSyncGlobalBackpressure(
   // selected Edge provider becomes dialable. For the selected CG itself, the
   // scope-aware guard above also prevents explicit fallback fanout from
   // consuming that slot before exact VM or selected-SWM recovery arrives.
+  automaticBackgroundLimits.set(policy, selectedRecoveryIds.size > 0 && limit > 1 ? limit - 1 : limit);
+  selectedRecoveryScopeIds.set(policy, selectedRecoveryIds);
+  return policy;
+}
+
+function validateSyncAdmissionConfig(config: SyncAdmissionConfig | undefined): void {
+  if (config === undefined) return;
+  if (config === null || typeof config !== 'object' || Array.isArray(config)) {
+    throw new TypeError('Invalid syncAdmission: expected an object');
+  }
+  if (config.mode !== undefined && config.mode !== 'shared' && config.mode !== 'partitioned') {
+    throw new TypeError('Invalid syncAdmission.mode: expected shared or partitioned');
+  }
+  for (const key of ['fast', 'slow'] as const) {
+    const value = config[key];
+    if (value !== undefined && (
+      value === null
+      || typeof value !== 'object'
+      || Array.isArray(value)
+    )) {
+      throw new TypeError(`Invalid syncAdmission.${key}: expected an object`);
+    }
+  }
+}
+
+function resolvedPartitionValue(
+  value: number | undefined,
+  fallback: number,
+  path: string,
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 0) {
+    throw new TypeError(`Invalid ${path}: expected a non-negative safe integer`);
+  }
+  return resolved;
+}
+
+function resolvePartitionedSyncGlobalBackpressure(
+  config: SyncAdmissionConfig,
+  selectedRecoveryIds: ReadonlySet<string>,
+): SyncGlobalBackpressurePolicy {
+  const envLimit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_MAX_INFLIGHT'))
+    ?? nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_LIMIT'));
+  const limit = envLimit
+    ?? resolvedPartitionValue(
+      config.globalMaxInflight,
+      DEFAULT_SYNC_PARTITIONED_GLOBAL_MAX_INFLIGHT,
+      'syncAdmission.globalMaxInflight',
+    );
+  if (limit === 0) {
+    return Object.freeze({
+      limit: undefined,
+      queueLimit: undefined,
+    }) as SyncGlobalBackpressurePolicy;
+  }
+
+  const fast = Object.freeze({
+    maxInflight: resolvedPartitionValue(
+      config.fast?.maxInflight,
+      DEFAULT_SYNC_FAST_MAX_INFLIGHT,
+      'syncAdmission.fast.maxInflight',
+    ),
+    queueLimit: resolvedPartitionValue(
+      config.fast?.queueLimit,
+      DEFAULT_SYNC_FAST_QUEUE_LIMIT,
+      'syncAdmission.fast.queueLimit',
+    ),
+    queueTimeoutMs: resolvedPartitionValue(
+      config.fast?.queueTimeoutMs,
+      DEFAULT_SYNC_FAST_QUEUE_TIMEOUT_MS,
+      'syncAdmission.fast.queueTimeoutMs',
+    ),
+  });
+  const slowMaxInflight = resolvedPartitionValue(
+    config.slow?.maxInflight,
+    DEFAULT_SYNC_SLOW_MAX_INFLIGHT,
+    'syncAdmission.slow.maxInflight',
+  );
+  const foregroundReserved = resolvedPartitionValue(
+    config.slow?.foregroundReserved,
+    DEFAULT_SYNC_SLOW_FOREGROUND_RESERVED,
+    'syncAdmission.slow.foregroundReserved',
+  );
+  const slow = Object.freeze({
+    maxInflight: slowMaxInflight,
+    foregroundReserved,
+    foregroundQueueLimit: resolvedPartitionValue(
+      config.slow?.foregroundQueueLimit,
+      DEFAULT_SYNC_SLOW_FOREGROUND_QUEUE_LIMIT,
+      'syncAdmission.slow.foregroundQueueLimit',
+    ),
+    backgroundMaxInflight: resolvedPartitionValue(
+      config.slow?.backgroundMaxInflight,
+      Math.max(0, slowMaxInflight - foregroundReserved),
+      'syncAdmission.slow.backgroundMaxInflight',
+    ),
+    backgroundQueueLimit: resolvedPartitionValue(
+      config.slow?.backgroundQueueLimit,
+      DEFAULT_SYNC_SLOW_BACKGROUND_QUEUE_LIMIT,
+      'syncAdmission.slow.backgroundQueueLimit',
+    ),
+  });
+
+  if (fast.maxInflight + slow.maxInflight > limit) {
+    throw new TypeError(
+      'Invalid syncAdmission: fast.maxInflight + slow.maxInflight must not exceed globalMaxInflight',
+    );
+  }
+  if (slow.foregroundReserved > slow.maxInflight) {
+    throw new TypeError(
+      'Invalid syncAdmission.slow.foregroundReserved: must not exceed slow.maxInflight',
+    );
+  }
+  if (slow.backgroundMaxInflight > slow.maxInflight - slow.foregroundReserved) {
+    throw new TypeError(
+      'Invalid syncAdmission.slow.backgroundMaxInflight: must leave foregroundReserved slow slots',
+    );
+  }
+
+  const queueLimit = fast.queueLimit
+    + slow.foregroundQueueLimit
+    + slow.backgroundQueueLimit;
+  const policy = Object.freeze({
+    limit,
+    queueLimit,
+    partitions: Object.freeze({ fast, slow }),
+  }) as SyncGlobalBackpressurePolicy;
   automaticBackgroundLimits.set(policy, selectedRecoveryIds.size > 0 && limit > 1 ? limit - 1 : limit);
   selectedRecoveryScopeIds.set(policy, selectedRecoveryIds);
   return policy;

--- a/packages/agent/src/sync/policy.ts
+++ b/packages/agent/src/sync/policy.ts
@@ -24,7 +24,36 @@ export type SyncSchedulerLane =
   | 'shared_memory'
   | 'swm_recovery'
   | 'pre_authorization'
-  | 'responder';
+  | 'responder'
+  | 'fast'
+  | 'slow';
+
+/**
+ * Optional node-wide sync admission partitions. Omitting this block preserves
+ * the legacy shared limiter (`syncGlobalMaxInflight` / `syncGlobalQueueLimit`).
+ *
+ * A partitioned scheduler protects short changelog/control-plane work from
+ * snapshot transfers, and reserves part of the slow partition for explicit
+ * foreground recovery. Automatic work is non-queueing by default: the
+ * on-connect/reconcile drivers already retry it, so retaining duplicate bulk
+ * jobs here can convert transient pressure into a permanent backlog.
+ */
+export interface SyncAdmissionConfig {
+  mode?: 'shared' | 'partitioned';
+  globalMaxInflight?: number;
+  fast?: {
+    maxInflight?: number;
+    queueLimit?: number;
+    queueTimeoutMs?: number;
+  };
+  slow?: {
+    maxInflight?: number;
+    foregroundReserved?: number;
+    foregroundQueueLimit?: number;
+    backgroundMaxInflight?: number;
+    backgroundQueueLimit?: number;
+  };
+}
 
 /**
  * Which trigger enqueued a `sync-global` admission.

--- a/packages/agent/src/sync/policy.ts
+++ b/packages/agent/src/sync/policy.ts
@@ -40,6 +40,7 @@ export type SyncSchedulerLane =
  */
 export interface SyncAdmissionConfig {
   mode?: 'shared' | 'partitioned';
+  /** Partitioned fallback; explicit legacy global config/env caps remain authoritative. */
   globalMaxInflight?: number;
   fast?: {
     maxInflight?: number;
@@ -49,8 +50,10 @@ export interface SyncAdmissionConfig {
   slow?: {
     maxInflight?: number;
     foregroundReserved?: number;
+    /** Retained foreground work requires maxInflight > 0. */
     foregroundQueueLimit?: number;
     backgroundMaxInflight?: number;
+    /** Retained background work requires backgroundMaxInflight > 0. */
     backgroundQueueLimit?: number;
   };
 }

--- a/packages/agent/src/sync/priority-admission-queue.ts
+++ b/packages/agent/src/sync/priority-admission-queue.ts
@@ -62,11 +62,8 @@ export interface PriorityAdmissionQueueHooks<Payload> {
     scheduler: string;
     operation: (entry: PriorityAdmissionEntry<Payload>) => string;
     inflightLimit?: (entry: PriorityAdmissionEntry<Payload>) => number | null;
-    /** Override the default shared-pool description for a true partitioned scheduler. */
-    capacity?: (
-      entry: PriorityAdmissionEntry<Payload>,
-      options: Pick<PriorityAdmissionAcquireOptions<Payload>, 'queueLimit'>,
-    ) => SchedulerPressureCapacity;
+    /** Static scheduler capacity. Omit only when acquire options define a shared pool. */
+    capacity?: SchedulerPressureCapacity;
     thresholds?: SchedulerPressureThresholds;
     register?: boolean;
   };
@@ -116,6 +113,7 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
   private readonly pressureTickets = new WeakMap<PriorityAdmissionEntry<Payload>, SchedulerPressureTicket>();
   private readonly hooks: PriorityAdmissionQueueHooks<Payload>;
   private readonly now: () => number;
+  private hasStaticObservabilityCapacity: boolean;
   private nextSequence = 0;
   private agedTurnOwed = false;
 
@@ -125,17 +123,19 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       scheduler: hooks.observability?.scheduler ?? 'priority-admission',
       thresholds: hooks.observability?.thresholds,
       now,
-      // Registration happens here, but capacity is only published on the first
-      // acquire — so without this a freshly booted daemon advertises
-      // `partitioned` on the field documented as authoritative, permanently so
-      // when sync admission is disabled and no acquire ever runs. The limits
-      // themselves still arrive with the first acquire; this declares only the
-      // model, which is a property of this queue rather than of a call.
-      capacity: { capacityModel: 'shared' },
+      capacity: hooks.observability?.capacity ?? { capacityModel: 'shared' },
     });
     this.hooks = hooks;
     this.now = now;
+    this.hasStaticObservabilityCapacity = hooks.observability?.capacity !== undefined;
     if (hooks.observability?.register) backpressureRegistry.register(this);
+  }
+
+  /** Configure one scheduler-wide capacity model before any admission. */
+  configureObservabilityCapacity(capacity: SchedulerPressureCapacity): void {
+    if (!this.hooks.observability) return;
+    this.hasStaticObservabilityCapacity = true;
+    this.updatePressureCapacity(capacity);
   }
 
   get length(): number {
@@ -186,13 +186,13 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       enqueuedAt: this.now(),
       agingThresholdMs: options.agingThresholdMs,
     };
-    if (this.hooks.observability) {
-      this.updatePressureCapacity(this.hooks.observability.capacity?.(base, options) ?? {
+    if (this.hooks.observability && !this.hasStaticObservabilityCapacity) {
+      this.updatePressureCapacity({
         queueLimit: options.queueLimit,
         inflightLimit: this.hooks.observability.inflightLimit?.(base) ?? null,
         // Lanes here normally order one pool by priority, they do not
         // partition it. A caller with private allocations must opt in through
-        // `capacity` above so diagnostics never infer partitions from labels.
+        // static `capacity` so diagnostics never infer partitions from labels.
         capacityModel: 'shared',
       });
     }

--- a/packages/agent/src/sync/priority-admission-queue.ts
+++ b/packages/agent/src/sync/priority-admission-queue.ts
@@ -3,6 +3,7 @@ import {
   backpressureRegistry,
   getMetrics,
   ObservableScheduler,
+  type SchedulerPressureCapacity,
   type SchedulerPressureThresholds,
   type SchedulerPressureTicket,
 } from '@origintrail-official/dkg-core';
@@ -61,6 +62,11 @@ export interface PriorityAdmissionQueueHooks<Payload> {
     scheduler: string;
     operation: (entry: PriorityAdmissionEntry<Payload>) => string;
     inflightLimit?: (entry: PriorityAdmissionEntry<Payload>) => number | null;
+    /** Override the default shared-pool description for a true partitioned scheduler. */
+    capacity?: (
+      entry: PriorityAdmissionEntry<Payload>,
+      options: Pick<PriorityAdmissionAcquireOptions<Payload>, 'queueLimit'>,
+    ) => SchedulerPressureCapacity;
     thresholds?: SchedulerPressureThresholds;
     register?: boolean;
   };
@@ -181,16 +187,12 @@ export class PriorityAdmissionQueue<Payload> extends ObservableScheduler {
       agingThresholdMs: options.agingThresholdMs,
     };
     if (this.hooks.observability) {
-      this.updatePressureCapacity({
+      this.updatePressureCapacity(this.hooks.observability.capacity?.(base, options) ?? {
         queueLimit: options.queueLimit,
         inflightLimit: this.hooks.observability.inflightLimit?.(base) ?? null,
-        // Lanes here order one pool by priority, they do not partition it:
-        // `queueLimit` bounds the whole queue (`globalFull` below) and `canRun`
-        // bounds total inflight, so no lane has a private allocation to
-        // publish. Declaring the model is what makes lane `state` classifiable
-        // from queue depth at all — without it the depth branches see a null
-        // ceiling, and only queue age or an already-taken rejection can move a
-        // lane off `healthy`.
+        // Lanes here normally order one pool by priority, they do not
+        // partition it. A caller with private allocations must opt in through
+        // `capacity` above so diagnostics never infer partitions from labels.
         capacityModel: 'shared',
       });
     }

--- a/packages/agent/src/sync/requester/durable-sync-budget.ts
+++ b/packages/agent/src/sync/requester/durable-sync-budget.ts
@@ -4,6 +4,12 @@ import {
 } from '../../dkg-agent-constants.js';
 
 export const MAX_DURABLE_SYNC_TOTAL_TIMEOUT_MS = 300_000;
+// Explicit operation timeouts also bound verification, storage, and durable
+// checkpoint settlement. Stop network fetches before that hard boundary so a
+// large, already-received prefix is not discarded when the outer signal fires
+// during local settlement. Callers without an explicit operation boundary keep
+// their historical fetch-only budgets.
+export const DURABLE_SYNC_SETTLEMENT_HEADROOM_MS = 60_000;
 // A maximum-size valid KA is 10,000 triples. Field measurements on the slowest
 // observed canary path project roughly 425 seconds for its byte-paged transfer,
 // so exact VM repair gets a separate hard 10-minute transfer ceiling.
@@ -70,6 +76,31 @@ export function normalizeDurableSyncTimeoutMs(
   return Math.min(
     maximumMs,
     Math.max(SYNC_MIN_GRAPH_BUDGET_MS, Math.floor(value)),
+  );
+}
+
+/**
+ * Resolve the soft fetch budget inside a durable-sync operation.
+ *
+ * An explicit `totalTimeoutMs` owns the whole operation, not just transport,
+ * so reserve bounded headroom for verification, storage, and checkpointing.
+ * Exact recovery keeps its wider fetch-only ceiling when no outer operation
+ * timeout exists.
+ */
+export function createDurableSyncFetchTimeoutMs(options: {
+  totalTimeoutMs?: number;
+  exactRecovery?: boolean;
+} = {}): number {
+  if (options.totalTimeoutMs === undefined) {
+    return options.exactRecovery
+      ? EXACT_RECOVERY_DURABLE_TRANSFER_TIMEOUT_MS
+      : normalizeDurableSyncTimeoutMs(undefined);
+  }
+
+  const operationTimeoutMs = normalizeDurableSyncTimeoutMs(options.totalTimeoutMs);
+  return Math.max(
+    SYNC_MIN_GRAPH_BUDGET_MS,
+    operationTimeoutMs - DURABLE_SYNC_SETTLEMENT_HEADROOM_MS,
   );
 }
 

--- a/packages/agent/test/cg-resolve-refresh.test.ts
+++ b/packages/agent/test/cg-resolve-refresh.test.ts
@@ -23,6 +23,16 @@ function operationContext(): OperationContext {
   return { kind: 'sync', id: 'cg-refresh-test', startedAt: Date.now() } as never;
 }
 
+async function runDirectlyWithBackpressure<T>(
+  _ctx: OperationContext,
+  _contextGraphId: string,
+  _lane: 'durable',
+  _label: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  return work();
+}
+
 function authoritativePrivateMetaQuads(contextGraphId: string): Quad[] {
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
@@ -303,6 +313,7 @@ describe('refreshMetaFromCurator', () => {
 
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       resolveCuratorPeerId: async () => CURATOR_PEER_ID,
       node: {
@@ -359,6 +370,7 @@ describe('refreshMetaFromCurator', () => {
     let staged: Quad[] = [];
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {
@@ -412,6 +424,7 @@ describe('refreshMetaFromCurator', () => {
     let targetMutated = false;
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {
@@ -495,6 +508,7 @@ describe('refreshMetaFromCurator', () => {
     const agent = {
       // A recent auth-driven refresh would suppress a normal call.
       metaRefreshTimestamps: new Map([[contextGraphId, Date.now()]]),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       resolveCuratorPeerId: async () => {
         resolved = true;
@@ -570,6 +584,7 @@ describe('refreshMetaFromCurator', () => {
     let stored = false;
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {
@@ -651,6 +666,7 @@ describe('refreshMetaFromCurator', () => {
     const storedSnapshots: unknown[] = [];
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {
@@ -727,6 +743,7 @@ describe('refreshMetaFromCurator', () => {
     let targetMutated = false;
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {
@@ -780,6 +797,7 @@ describe('refreshMetaFromCurator', () => {
     let recordedDrops = 0;
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {
@@ -861,6 +879,7 @@ describe('refreshMetaFromCurator', () => {
       };
       const agent = {
         metaRefreshTimestamps: new Map<string, number>(),
+        runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
         peerId: 'local-peer',
         node: {
           libp2p: {
@@ -958,6 +977,7 @@ describe('refreshMetaFromCurator', () => {
     const cleanupGate = new Promise<void>((resolve) => { releaseCleanup = resolve; });
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {
@@ -1025,6 +1045,7 @@ describe('refreshMetaFromCurator', () => {
     let replacements = 0;
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {
@@ -1089,6 +1110,7 @@ describe('refreshMetaFromCurator', () => {
     let replacements = 0;
     const agent = {
       metaRefreshTimestamps: new Map<string, number>(),
+      runContextGraphSyncWithBackpressure: runDirectlyWithBackpressure,
       peerId: 'local-peer',
       node: {
         libp2p: {

--- a/packages/agent/test/durable-sync-budget.test.ts
+++ b/packages/agent/test/durable-sync-budget.test.ts
@@ -6,7 +6,9 @@ import {
   createContextGraphSyncDeadline,
   createDurableMetaPhaseFetchDeadline,
   createDurableSyncBudget,
+  createDurableSyncFetchTimeoutMs,
   createGraphScopedAuthenticationDeadline,
+  DURABLE_SYNC_SETTLEMENT_HEADROOM_MS,
   DURABLE_DATA_PHASE_MIN_BUDGET_MS,
   DURABLE_META_PHASE_BUDGET_FRACTION,
   type DurableSyncBudget,
@@ -196,6 +198,21 @@ describe('durable sync deadline budget', () => {
     expect(
       createContextGraphSyncDeadline({ remainingContextGraphs: 1 }),
     ).toBe(1_120_000);
+  });
+
+  it('reserves settlement headroom inside an explicit operation timeout', () => {
+    expect(createDurableSyncFetchTimeoutMs({ totalTimeoutMs: 299_000 }))
+      .toBe(299_000 - DURABLE_SYNC_SETTLEMENT_HEADROOM_MS);
+  });
+
+  it('keeps historical fetch-only budgets without an outer operation timeout', () => {
+    expect(createDurableSyncFetchTimeoutMs()).toBe(120_000);
+    expect(createDurableSyncFetchTimeoutMs({ exactRecovery: true })).toBe(600_000);
+  });
+
+  it('never removes the minimum usable fetch window from short operations', () => {
+    expect(createDurableSyncFetchTimeoutMs({ totalTimeoutMs: 30_000 }))
+      .toBe(10_000);
   });
 
   it('uses a caller-supplied bounded graph-scoped authentication budget', () => {

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -190,7 +190,7 @@ describe('durable sync lifecycle chain binding', () => {
       .toBe(1_800_000_299_000);
   });
 
-  it('keeps totalTimeoutMs as one outer operation boundary without a caller signal', async () => {
+  it('stops fetching before the outer totalTimeoutMs boundary without a caller signal', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_800_000_000_000);
     const agentLike: any = {
@@ -224,7 +224,7 @@ describe('durable sync lifecycle chain binding', () => {
         undefined,
         undefined,
         undefined,
-        { totalTimeoutMs: 30_000 },
+        { totalTimeoutMs: 299_000 },
       );
       await vi.advanceTimersByTimeAsync(0);
 
@@ -234,14 +234,17 @@ describe('durable sync lifecycle chain binding', () => {
         contextGraphId,
         remainingContextGraphs: 1,
       });
-      expect(contextGraphBudget.fetchDeadline).toBe(1_800_000_030_000);
+      expect(contextGraphBudget.fetchDeadline).toBe(1_800_000_239_000);
 
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(239_000);
+      expect(capturedContext?.signal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(60_000);
       await sync;
 
       expect(capturedContext?.signal?.aborted).toBe(true);
       expect(contextGraphBudget.createGraphScopedAuthenticationDeadline())
-        .toBe(1_800_000_030_000);
+        .toBe(1_800_000_299_000);
     } finally {
       vi.useRealTimers();
     }
@@ -497,7 +500,7 @@ describe('durable sync lifecycle chain binding', () => {
     expect(admission).toEqual({ source: 'swm-recovery' });
   });
 
-  it('honors an explicit exact-asset timeout while internal VM recovery keeps 600 seconds', async () => {
+  it('reserves settlement time inside an explicit exact-asset timeout while internal VM recovery keeps 600 seconds', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
     const exactUal = 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/1';
     const agentLike: any = {
@@ -531,7 +534,7 @@ describe('durable sync lifecycle chain binding', () => {
       mockedRunDurableSyncDetailed.mock.calls[0]![0].durableSyncBudget
         .createContextGraphBudget({ contextGraphId, remainingContextGraphs: 1 })
         .fetchDeadline,
-    ).toBe(1_800_000_030_000);
+    ).toBe(1_800_000_010_000);
 
     mockedRunDurableSyncDetailed.mockClear();
     agentLike.runLegacyDurableSyncDetailed = LifecycleSyncMethods.prototype.runLegacyDurableSyncDetailed;

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -1126,6 +1126,85 @@ describe('sync global backpressure', () => {
     }
   });
 
+  it('resolves the safe partitioned policy when syncAdmission is present', () => {
+    const oldMaxInflight = process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+    const oldLegacyLimit = process.env.DKG_SYNC_GLOBAL_LIMIT;
+    try {
+      delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+      delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+
+      expect(resolveSyncGlobalBackpressure({ syncAdmission: {} })).toEqual({
+        limit: 10,
+        queueLimit: 72,
+        partitions: {
+          fast: { maxInflight: 8, queueLimit: 64, queueTimeoutMs: 5_000 },
+          slow: {
+            maxInflight: 2,
+            foregroundReserved: 1,
+            foregroundQueueLimit: 8,
+            backgroundMaxInflight: 1,
+            backgroundQueueLimit: 0,
+          },
+        },
+      });
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: 1,
+        syncGlobalQueueLimit: 0,
+        syncAdmission: {
+          globalMaxInflight: 5,
+          fast: { maxInflight: 3, queueLimit: 4, queueTimeoutMs: 25 },
+          slow: {
+            maxInflight: 2,
+            foregroundReserved: 1,
+            foregroundQueueLimit: 2,
+            backgroundMaxInflight: 1,
+            backgroundQueueLimit: 0,
+          },
+        },
+      })).toEqual({
+        limit: 5,
+        queueLimit: 6,
+        partitions: {
+          fast: { maxInflight: 3, queueLimit: 4, queueTimeoutMs: 25 },
+          slow: {
+            maxInflight: 2,
+            foregroundReserved: 1,
+            foregroundQueueLimit: 2,
+            backgroundMaxInflight: 1,
+            backgroundQueueLimit: 0,
+          },
+        },
+      });
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: 3,
+        syncGlobalQueueLimit: 1,
+        syncAdmission: { mode: 'shared' },
+      })).toEqual({ limit: 3, queueLimit: 1 });
+    } finally {
+      if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+      else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;
+      if (oldLegacyLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+      else process.env.DKG_SYNC_GLOBAL_LIMIT = oldLegacyLimit;
+    }
+  });
+
+  it('rejects partition settings that consume the reserved foreground capacity', () => {
+    expect(() => resolveSyncGlobalBackpressure({
+      syncAdmission: {
+        globalMaxInflight: 4,
+        fast: { maxInflight: 2 },
+        slow: {
+          maxInflight: 2,
+          foregroundReserved: 1,
+          backgroundMaxInflight: 2,
+        },
+      },
+    })).toThrow('must leave foregroundReserved slow slots');
+    expect(() => resolveSyncGlobalBackpressure({
+      syncAdmission: { mode: 'invalid' } as never,
+    })).toThrow('Invalid syncAdmission.mode');
+  });
+
   it('disables the complete policy when the inflight limit is zero', () => {
     const oldMaxInflight = process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
     const oldLegacyLimit = process.env.DKG_SYNC_GLOBAL_LIMIT;
@@ -1910,5 +1989,224 @@ describe('sync global backpressure', () => {
     releaseA();
     releaseB();
     await Promise.all([first, second]);
+  });
+
+  it('keeps fast capacity and one slow foreground slot available while background sync is active', async () => {
+    const ctx = createOperationContext('sync');
+    const policy = resolveSyncGlobalBackpressure({
+      syncAdmission: {
+        globalMaxInflight: 3,
+        fast: { maxInflight: 1, queueLimit: 2, queueTimeoutMs: 100 },
+        slow: {
+          maxInflight: 2,
+          foregroundReserved: 1,
+          foregroundQueueLimit: 2,
+          backgroundMaxInflight: 1,
+          backgroundQueueLimit: 0,
+        },
+      },
+    });
+    const events: string[] = [];
+    let releaseBackground: (() => void) | undefined;
+    let releaseForeground: (() => void) | undefined;
+    let releaseFast: (() => void) | undefined;
+
+    const background = withGlobalSyncBackpressure({
+      policy, ctx, label: 'durable:background', lane: 'durable', source: 'on-connect',
+    }, async () => {
+      events.push('background-start');
+      await new Promise<void>((resolve) => { releaseBackground = resolve; });
+    });
+    await tick();
+
+    await expect(withGlobalSyncBackpressure({
+      policy, ctx, label: 'durable:background-duplicate', lane: 'durable', source: 'reconcile',
+    }, async () => { events.push('background-duplicate-start'); }))
+      .rejects.toMatchObject({ reason: 'queue_full' });
+
+    const foreground = withGlobalSyncBackpressure({
+      policy, ctx, label: 'durable:foreground', lane: 'durable', source: 'catchup-foreground',
+    }, async () => {
+      events.push('foreground-start');
+      await new Promise<void>((resolve) => { releaseForeground = resolve; });
+    });
+    const fast = withGlobalSyncBackpressure({
+      policy, ctx, label: 'changelog:delta', lane: 'changelog', source: 'reconcile',
+    }, async () => {
+      events.push('fast-start');
+      await new Promise<void>((resolve) => { releaseFast = resolve; });
+    });
+    await tick();
+
+    try {
+      expect(events).toEqual(['background-start', 'foreground-start', 'fast-start']);
+      expect(getSyncBackpressureSnapshot(policy)).toMatchObject({
+        inflight: 3,
+        queued: 0,
+        limit: 3,
+        queueLimit: 4,
+      });
+    } finally {
+      releaseBackground?.();
+      releaseForeground?.();
+      releaseFast?.();
+      await Promise.all([background, foreground, fast]);
+    }
+  });
+
+  it('keeps selected recovery reserved inside the partitioned slow lane', async () => {
+    const ctx = createOperationContext('sync');
+    const selectedCg = 'urn:cg:partitioned-selected';
+    const policy = resolveSyncGlobalBackpressure({
+      selectedRecoveryContextGraphIds: [selectedCg],
+      syncAdmission: {
+        globalMaxInflight: 3,
+        fast: { maxInflight: 1, queueLimit: 2, queueTimeoutMs: 100 },
+        slow: {
+          maxInflight: 2,
+          foregroundReserved: 1,
+          foregroundQueueLimit: 2,
+          backgroundMaxInflight: 1,
+          backgroundQueueLimit: 0,
+        },
+      },
+    });
+    const events: string[] = [];
+    let releaseBackground!: () => void;
+    let releaseSelected!: () => void;
+    let releaseFast!: () => void;
+
+    const background = withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      contextGraphId: 'urn:cg:unrelated',
+      label: 'durable:unrelated-vm-recovery',
+      lane: 'durable',
+      source: 'vm-recovery',
+    }, async () => new Promise<void>((resolve) => {
+      events.push('background-start');
+      releaseBackground = resolve;
+    }));
+    await tick();
+
+    await expect(withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      contextGraphId: 'urn:cg:another-unrelated',
+      label: 'swm-recovery:unrelated',
+      lane: 'swm_recovery',
+      source: 'swm-recovery',
+    }, async () => { events.push('second-background-start'); }))
+      .rejects.toMatchObject({ reason: 'queue_full' });
+
+    const selected = withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      contextGraphId: selectedCg,
+      label: 'durable:selected-vm-recovery',
+      lane: 'durable',
+      source: 'vm-recovery',
+    }, async () => new Promise<void>((resolve) => {
+      events.push('selected-start');
+      releaseSelected = resolve;
+    }));
+    const fast = withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      label: 'changelog:selected-delta',
+      lane: 'changelog',
+      source: 'reconcile',
+    }, async () => new Promise<void>((resolve) => {
+      events.push('fast-start');
+      releaseFast = resolve;
+    }));
+    await tick();
+
+    try {
+      expect(events).toEqual(['background-start', 'selected-start', 'fast-start']);
+      expect(getSyncBackpressureSnapshot(policy)).toMatchObject({
+        inflight: 3,
+        queued: 0,
+        limit: 3,
+      });
+    } finally {
+      releaseBackground();
+      releaseSelected();
+      releaseFast();
+      await Promise.all([background, selected, fast]);
+    }
+  });
+
+  it('bounds fast queue wait with the configured timeout', async () => {
+    const ctx = createOperationContext('sync');
+    const policy = resolveSyncGlobalBackpressure({
+      syncAdmission: {
+        globalMaxInflight: 2,
+        fast: { maxInflight: 1, queueLimit: 1, queueTimeoutMs: 10 },
+        slow: {
+          maxInflight: 1,
+          foregroundReserved: 1,
+          foregroundQueueLimit: 0,
+          backgroundMaxInflight: 0,
+          backgroundQueueLimit: 0,
+        },
+      },
+    });
+    let releaseRunning!: () => void;
+    const running = withGlobalSyncBackpressure({
+      policy, ctx, label: 'changelog:running', lane: 'changelog', source: 'reconcile',
+    }, async () => new Promise<void>((resolve) => { releaseRunning = resolve; }));
+    await tick();
+
+    try {
+      await expect(withGlobalSyncBackpressure({
+        policy, ctx, label: 'changelog:queued', lane: 'changelog', source: 'reconcile',
+      }, async () => {})).rejects.toMatchObject({ reason: 'queue_timeout' });
+    } finally {
+      releaseRunning();
+      await running;
+    }
+  });
+
+  it('publishes real fast/slow partitions from the production sync-global queue', async () => {
+    const ctx = createOperationContext('sync');
+    const policy = resolveSyncGlobalBackpressure({ syncAdmission: {} });
+    let releaseFast!: () => void;
+    let releaseSlow!: () => void;
+    const fastWork = withGlobalSyncBackpressure(
+      { policy, ctx, label: 'changelog:delta', lane: 'changelog', source: 'reconcile' },
+      async () => new Promise<void>((resolve) => { releaseFast = resolve; }),
+    );
+    const slowWork = withGlobalSyncBackpressure(
+      { policy, ctx, label: 'durable:snapshot', lane: 'durable', source: 'on-connect' },
+      async () => new Promise<void>((resolve) => { releaseSlow = resolve; }),
+    );
+    await tick();
+
+    try {
+      const snapshot = backpressureRegistry.capture().schedulers.find(
+        (scheduler) => scheduler.scheduler === 'sync-global',
+      );
+      expect(snapshot).toMatchObject({
+        capacityModel: 'partitioned',
+        totals: { queueLimit: 72, inflightLimit: 10, inflight: 2 },
+      });
+      expect(snapshot!.lanes.find((lane) => lane.lane === 'fast')).toMatchObject({
+        capacityModel: 'partitioned',
+        queueLimit: 64,
+        inflightLimit: 8,
+        inflight: 1,
+      });
+      expect(snapshot!.lanes.find((lane) => lane.lane === 'slow')).toMatchObject({
+        capacityModel: 'partitioned',
+        queueLimit: 8,
+        inflightLimit: 2,
+        inflight: 1,
+      });
+    } finally {
+      releaseFast();
+      releaseSlow();
+      await Promise.all([fastWork, slowWork]);
+    }
   });
 });

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -1084,8 +1084,9 @@ describe('sync global backpressure', () => {
       delete process.env.DKG_SYNC_GLOBAL_LIMIT;
       delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
 
-      expect(resolveSyncGlobalBackpressure({})).toEqual({ limit: 2, queueLimit: 4 });
+      expect(resolveSyncGlobalBackpressure({})).toEqual({ mode: 'shared', limit: 10, queueLimit: 20 });
       expect(resolveSyncGlobalBackpressure({ syncGlobalMaxInflight: 3 })).toEqual({
+        mode: 'shared',
         limit: 3,
         queueLimit: 6,
       });
@@ -1093,20 +1094,23 @@ describe('sync global backpressure', () => {
         syncGlobalMaxInflight: 3,
         syncGlobalLimit: 4,
         syncGlobalQueueLimit: 7,
-      })).toEqual({ limit: 3, queueLimit: 7 });
+      })).toEqual({ mode: 'shared', limit: 3, queueLimit: 7 });
       expect(resolveSyncGlobalBackpressure({ syncGlobalLimit: 4 })).toEqual({
+        mode: 'shared',
         limit: 4,
         queueLimit: 8,
       });
 
       process.env.DKG_SYNC_GLOBAL_LIMIT = '5';
       expect(resolveSyncGlobalBackpressure({ syncGlobalMaxInflight: 3 })).toEqual({
+        mode: 'shared',
         limit: 5,
         queueLimit: 10,
       });
 
       process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = '6';
       expect(resolveSyncGlobalBackpressure({ syncGlobalMaxInflight: 3, syncGlobalLimit: 4 })).toEqual({
+        mode: 'shared',
         limit: 6,
         queueLimit: 12,
       });
@@ -1115,7 +1119,7 @@ describe('sync global backpressure', () => {
       expect(resolveSyncGlobalBackpressure({
         syncGlobalMaxInflight: 3,
         syncGlobalQueueLimit: 8,
-      })).toEqual({ limit: 6, queueLimit: 0 });
+      })).toEqual({ mode: 'shared', limit: 6, queueLimit: 0 });
     } finally {
       if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
       else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;
@@ -1129,11 +1133,14 @@ describe('sync global backpressure', () => {
   it('resolves the safe partitioned policy when syncAdmission is present', () => {
     const oldMaxInflight = process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
     const oldLegacyLimit = process.env.DKG_SYNC_GLOBAL_LIMIT;
+    const oldQueueLimit = process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
     try {
       delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
       delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+      delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
 
       expect(resolveSyncGlobalBackpressure({ syncAdmission: {} })).toEqual({
+        mode: 'partitioned',
         limit: 10,
         queueLimit: 72,
         partitions: {
@@ -1148,8 +1155,6 @@ describe('sync global backpressure', () => {
         },
       });
       expect(resolveSyncGlobalBackpressure({
-        syncGlobalMaxInflight: 1,
-        syncGlobalQueueLimit: 0,
         syncAdmission: {
           globalMaxInflight: 5,
           fast: { maxInflight: 3, queueLimit: 4, queueTimeoutMs: 25 },
@@ -1162,6 +1167,7 @@ describe('sync global backpressure', () => {
           },
         },
       })).toEqual({
+        mode: 'partitioned',
         limit: 5,
         queueLimit: 6,
         partitions: {
@@ -1176,15 +1182,39 @@ describe('sync global backpressure', () => {
         },
       });
       expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: 5,
+        syncGlobalQueueLimit: 0,
+        syncAdmission: {
+          globalMaxInflight: 9,
+          fast: { maxInflight: 3, queueLimit: 4, queueTimeoutMs: 25 },
+          slow: {
+            maxInflight: 2,
+            foregroundReserved: 1,
+            foregroundQueueLimit: 2,
+            backgroundMaxInflight: 1,
+            backgroundQueueLimit: 0,
+          },
+        },
+      })).toMatchObject({ limit: 5, queueLimit: 0 });
+
+      process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = '0';
+      expect(resolveSyncGlobalBackpressure({ syncAdmission: {} })).toMatchObject({
+        limit: 10,
+        queueLimit: 0,
+      });
+      delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+      expect(resolveSyncGlobalBackpressure({
         syncGlobalMaxInflight: 3,
         syncGlobalQueueLimit: 1,
         syncAdmission: { mode: 'shared' },
-      })).toEqual({ limit: 3, queueLimit: 1 });
+      })).toEqual({ mode: 'shared', limit: 3, queueLimit: 1 });
     } finally {
       if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
       else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;
       if (oldLegacyLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_LIMIT;
       else process.env.DKG_SYNC_GLOBAL_LIMIT = oldLegacyLimit;
+      if (oldQueueLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+      else process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = oldQueueLimit;
     }
   });
 
@@ -1205,6 +1235,93 @@ describe('sync global backpressure', () => {
     })).toThrow('Invalid syncAdmission.mode');
   });
 
+  it('rejects slow queues that can retain work with no execution capacity', () => {
+    expect(() => resolveSyncGlobalBackpressure({
+      syncAdmission: {
+        globalMaxInflight: 1,
+        fast: { maxInflight: 1, queueLimit: 0 },
+        slow: {
+          maxInflight: 0,
+          foregroundReserved: 0,
+          foregroundQueueLimit: 1,
+          backgroundMaxInflight: 0,
+          backgroundQueueLimit: 0,
+        },
+      },
+    })).toThrow('retained foreground work requires slow.maxInflight > 0');
+
+    expect(() => resolveSyncGlobalBackpressure({
+      syncAdmission: {
+        globalMaxInflight: 2,
+        fast: { maxInflight: 1, queueLimit: 0 },
+        slow: {
+          maxInflight: 1,
+          foregroundReserved: 1,
+          foregroundQueueLimit: 0,
+          backgroundMaxInflight: 0,
+          backgroundQueueLimit: 1,
+        },
+      },
+    })).toThrow('retained background work requires backgroundMaxInflight > 0');
+
+    expect(resolveSyncGlobalBackpressure({
+      syncAdmission: {
+        globalMaxInflight: 1,
+        fast: { maxInflight: 1, queueLimit: 0 },
+        slow: {
+          maxInflight: 0,
+          foregroundReserved: 0,
+          foregroundQueueLimit: 0,
+          backgroundMaxInflight: 0,
+          backgroundQueueLimit: 0,
+        },
+      },
+    })).toMatchObject({ mode: 'partitioned', limit: 1, queueLimit: 0 });
+  });
+
+  it('keeps legacy global inflight and queue caps hard in partitioned mode', async () => {
+    const ctx = createOperationContext('sync');
+    const policy = resolveSyncGlobalBackpressure({
+      syncGlobalMaxInflight: 1,
+      syncGlobalQueueLimit: 0,
+      syncAdmission: {
+        globalMaxInflight: 10,
+        fast: { maxInflight: 1, queueLimit: 8, queueTimeoutMs: 100 },
+        slow: {
+          maxInflight: 0,
+          foregroundReserved: 0,
+          foregroundQueueLimit: 0,
+          backgroundMaxInflight: 0,
+          backgroundQueueLimit: 0,
+        },
+      },
+    });
+    let release!: () => void;
+    const running = withGlobalSyncBackpressure({
+      policy,
+      ctx,
+      label: 'changelog:running',
+      lane: 'changelog',
+      source: 'reconcile',
+    }, async () => new Promise<void>((resolve) => { release = resolve; }));
+    await tick();
+
+    try {
+      expect(policy).toMatchObject({ limit: 1, queueLimit: 0 });
+      await expect(withGlobalSyncBackpressure({
+        policy,
+        ctx,
+        label: 'changelog:rejected',
+        lane: 'changelog',
+        source: 'reconcile',
+      }, async () => {})).rejects.toMatchObject({ reason: 'queue_full' });
+      expect(getSyncBackpressureSnapshot(policy).queued).toBe(0);
+    } finally {
+      release();
+      await running;
+    }
+  });
+
   it('disables the complete policy when the inflight limit is zero', () => {
     const oldMaxInflight = process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
     const oldLegacyLimit = process.env.DKG_SYNC_GLOBAL_LIMIT;
@@ -1217,14 +1334,14 @@ describe('sync global backpressure', () => {
       expect(resolveSyncGlobalBackpressure({
         syncGlobalMaxInflight: 0,
         syncGlobalQueueLimit: 8,
-      })).toEqual({ limit: undefined, queueLimit: undefined });
+      })).toEqual({ mode: 'shared', limit: undefined, queueLimit: undefined });
 
       process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = '0';
       process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = '9';
       expect(resolveSyncGlobalBackpressure({
         syncGlobalMaxInflight: 3,
         syncGlobalQueueLimit: 8,
-      })).toEqual({ limit: undefined, queueLimit: undefined });
+      })).toEqual({ mode: 'shared', limit: undefined, queueLimit: undefined });
     } finally {
       if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
       else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;
@@ -1248,12 +1365,12 @@ describe('sync global backpressure', () => {
         syncGlobalMaxInflight: Number.NaN,
         syncGlobalLimit: 3,
         syncGlobalQueueLimit: 1.5,
-      })).toEqual({ limit: 3, queueLimit: 6 });
+      })).toEqual({ mode: 'shared', limit: 3, queueLimit: 6 });
       expect(resolveSyncGlobalBackpressure({
         syncGlobalMaxInflight: -1,
         syncGlobalLimit: 4,
         syncGlobalQueueLimit: -2,
-      })).toEqual({ limit: 4, queueLimit: 8 });
+      })).toEqual({ mode: 'shared', limit: 4, queueLimit: 8 });
 
       process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = '1.5';
       process.env.DKG_SYNC_GLOBAL_LIMIT = '5';
@@ -1261,7 +1378,7 @@ describe('sync global backpressure', () => {
       expect(resolveSyncGlobalBackpressure({
         syncGlobalMaxInflight: 3,
         syncGlobalQueueLimit: 7,
-      })).toEqual({ limit: 5, queueLimit: 7 });
+      })).toEqual({ mode: 'shared', limit: 5, queueLimit: 7 });
     } finally {
       if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
       else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;
@@ -1457,6 +1574,81 @@ describe('sync global backpressure', () => {
       // …and no ceiling is fabricated ahead of the first acquire, which is what
       // actually carries the limits.
       totals: { queueLimit: null, inflightLimit: null },
+    });
+  });
+
+  it('keeps an explicitly disabled partitioned scheduler healthy while idle', () => {
+    const queue = new PriorityAdmissionQueue<string>({
+      canRun: () => false,
+      onStart: () => () => {},
+      observability: {
+        scheduler: 'test-disabled-partitioned',
+        operation: (entry) => entry.payload,
+        capacity: {
+          capacityModel: 'partitioned',
+          queueLimit: 0,
+          inflightLimit: 0,
+          lanes: {
+            fast: { queueLimit: 0, inflightLimit: 0 },
+            slow: { queueLimit: 0, inflightLimit: 0 },
+          },
+        },
+      },
+    });
+
+    expect(queue.getBackpressureSnapshot()).toMatchObject({
+      state: 'healthy',
+      capacityModel: 'partitioned',
+      totals: { queueLimit: 0, inflightLimit: 0, queued: 0, inflight: 0 },
+    });
+  });
+
+  it('publishes the resolved partitioned policy before its first admission', () => {
+    resolveSyncGlobalBackpressure({ syncAdmission: {} });
+
+    const snapshot = backpressureRegistry.capture().schedulers.find(
+      (scheduler) => scheduler.scheduler === 'sync-global',
+    );
+    expect(snapshot).toMatchObject({
+      capacityModel: 'partitioned',
+      totals: { queueLimit: 72, inflightLimit: 10, inflight: 0 },
+    });
+    expect(snapshot!.lanes.find((lane) => lane.lane === 'fast')).toMatchObject({
+      capacityModel: 'partitioned',
+      queueLimit: 64,
+      inflightLimit: 8,
+    });
+    expect(snapshot!.lanes.find((lane) => lane.lane === 'slow')).toMatchObject({
+      capacityModel: 'partitioned',
+      queueLimit: 8,
+      inflightLimit: 2,
+    });
+  });
+
+  it('preserves partitioned diagnostics when global admission is disabled', () => {
+    const policy = resolveSyncGlobalBackpressure({
+      syncAdmission: { globalMaxInflight: 0 },
+    });
+
+    expect(policy).toEqual({
+      mode: 'partitioned',
+      limit: undefined,
+      queueLimit: undefined,
+    });
+    const snapshot = backpressureRegistry.capture().schedulers.find(
+      (scheduler) => scheduler.scheduler === 'sync-global',
+    );
+    expect(snapshot).toMatchObject({
+      capacityModel: 'partitioned',
+      totals: { queueLimit: 0, inflightLimit: 0, inflight: 0 },
+    });
+    expect(snapshot!.lanes.find((lane) => lane.lane === 'fast')).toMatchObject({
+      queueLimit: 0,
+      inflightLimit: 0,
+    });
+    expect(snapshot!.lanes.find((lane) => lane.lane === 'slow')).toMatchObject({
+      queueLimit: 0,
+      inflightLimit: 0,
     });
   });
 

--- a/packages/agent/test/sync-operation-telemetry.test.ts
+++ b/packages/agent/test/sync-operation-telemetry.test.ts
@@ -11,7 +11,11 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { createOperationContext } from '@origintrail-official/dkg-core';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 
-import { DKGAgent, runCatchupPlaneWithPolicy } from '../src/index.js';
+import {
+  DKGAgent,
+  runCatchupPlaneWithPolicy,
+  type SyncAdmissionConfig,
+} from '../src/index.js';
 import { getSyncBackpressureSnapshot } from '../src/sync/backpressure.js';
 import { ethers } from 'ethers';
 
@@ -92,6 +96,7 @@ async function createAgent(options: {
   sendToPeer?: (...args: unknown[]) => Promise<Uint8Array>;
   syncGlobalMaxInflight?: number;
   syncGlobalQueueLimit?: number;
+  syncAdmission?: SyncAdmissionConfig;
 } = {}): Promise<DKGAgent> {
   const agent = await DKGAgent.create({
     name: 'W1OperationTelemetry',
@@ -99,6 +104,7 @@ async function createAgent(options: {
     chainAdapter: new MockChainAdapter(),
     syncGlobalMaxInflight: options.syncGlobalMaxInflight ?? 2,
     syncGlobalQueueLimit: options.syncGlobalQueueLimit ?? 2,
+    syncAdmission: options.syncAdmission,
   });
   liveAgents.push(agent);
   (agent as any).messenger = { sendToPeer: options.sendToPeer ?? (async () => new Uint8Array(0)) };
@@ -198,6 +204,47 @@ describe('W1 I4/I5 — the operation denominator and its rejections', () => {
     // M10 emits a 0 ms duration sample here; the denominator must not grow.
     const samples = await harness.histogram(I4);
     expect(samples.filter((point) => point.attributes.source === 'reconcile')).toEqual([]);
+
+    blocker.resolve();
+    await blocking;
+  });
+
+  it('records a fast queue timeout in I5 without starting or emitting I4', async () => {
+    harness.install();
+    const agent = await createAgent({
+      syncAdmission: {
+        globalMaxInflight: 2,
+        fast: { maxInflight: 1, queueLimit: 1, queueTimeoutMs: 10 },
+        slow: {
+          maxInflight: 1,
+          foregroundReserved: 1,
+          foregroundQueueLimit: 0,
+          backgroundMaxInflight: 0,
+          backgroundQueueLimit: 0,
+        },
+      },
+    });
+    const blocker = blockingDeferred();
+    const blocking = admit(
+      agent,
+      { lane: 'changelog', source: 'on-connect', label: 'fast-blocker' },
+      () => blocker.promise,
+    );
+    await waitFor(() => getSyncBackpressureSnapshot().inflight === 1);
+
+    let started = false;
+    await expect(admit(
+      agent,
+      { lane: 'changelog', source: 'reconcile', label: 'fast-timeout' },
+      async () => { started = true; },
+    )).rejects.toMatchObject({ reason: 'queue_timeout' });
+    expect(started).toBe(false);
+    expect(await harness.matching(I5, {
+      lane: 'changelog', source: 'reconcile', reason: 'queue_timeout',
+    })).toHaveLength(1);
+    expect(await harness.matching(I4, {
+      lane: 'changelog', source: 'reconcile',
+    })).toEqual([]);
 
     blocker.resolve();
     await blocking;
@@ -908,6 +955,7 @@ describe('W1 §5.5 — `control-plane` is the trigger base case, not a catch-all
   async function createRefreshAgent(
     /** Omitted ⇒ an empty successful page. Supply one to inject a wire failure. */
     onSend?: () => Promise<Uint8Array>,
+    syncAdmission?: SyncAdmissionConfig,
   ): Promise<{ agent: DKGAgent; sends: () => number }> {
     let sends = 0;
     const agent = await createAgent({
@@ -915,6 +963,7 @@ describe('W1 §5.5 — `control-plane` is the trigger base case, not a catch-all
         sends += 1;
         return onSend ? onSend() : new Uint8Array(0);
       },
+      syncAdmission,
     });
     (agent as any).node = {
       ...(agent as any).node,
@@ -943,6 +992,39 @@ describe('W1 §5.5 — `control-plane` is the trigger base case, not a catch-all
     expect((await harness.matching(I1, { source: 'control-plane', phase: 'meta' })).length)
       .toBeGreaterThanOrEqual(1);
     expect(await harness.matching(I1, { source: 'unspecified' })).toEqual([]);
+  });
+
+  it('1b: a standalone control-plane refresh uses fast capacity while slow background is full', async () => {
+    harness.install();
+    const { agent, sends } = await createRefreshAgent(undefined, {
+      globalMaxInflight: 2,
+      fast: { maxInflight: 1, queueLimit: 0, queueTimeoutMs: 100 },
+      slow: {
+        maxInflight: 1,
+        foregroundReserved: 0,
+        foregroundQueueLimit: 0,
+        backgroundMaxInflight: 1,
+        backgroundQueueLimit: 0,
+      },
+    });
+    const blocker = blockingDeferred();
+    const background = admit(
+      agent,
+      { source: 'on-connect', lane: 'durable', label: 'slow-background-blocker' },
+      () => blocker.promise,
+    );
+    await waitFor(() => getSyncBackpressureSnapshot().inflight === 1);
+
+    try {
+      expect(await refresh(agent)).toBe(false);
+      expect(sends()).toBeGreaterThanOrEqual(1);
+      expect(await harness.matching(I4, {
+        lane: 'durable', source: 'control-plane', outcome: 'resolved',
+      })).toHaveLength(1);
+    } finally {
+      blocker.resolve();
+      await background;
+    }
   });
 
   it('2: a refresh NESTED in an admitted operation keeps the ENCLOSING source', async () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 import type {
   DKGAgentConfig,
+  SyncAdmissionConfig,
   SyncContextGraphPriorityConfig,
   SyncResponderSnapshotLimitsConfig,
 } from '@origintrail-official/dkg-agent';
@@ -662,6 +663,8 @@ export interface DkgConfig {
   syncGlobalLimit?: number;
   /** Max sync jobs waiting behind the global cap. Defaults to 2x the inflight cap. */
   syncGlobalQueueLimit?: number;
+  /** Optional partitioned fast/slow sync admission. Omit for the legacy shared limiter. */
+  syncAdmission?: SyncAdmissionConfig;
   /** Retained sync responder snapshot limits (rows and estimated bytes). */
   syncResponderSnapshotLimits?: SyncResponderSnapshotLimitsConfig;
   /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -655,13 +655,13 @@ export interface DkgConfig {
   /** Emergency switch for durable/SWM sync execution. Env DKG_DURABLE_SYNC_ENABLED wins. */
   durableSyncEnabled?: boolean;
   /**
-   * Global cap for concurrent sync jobs. Defaults to 2; set 0 to disable.
+   * Global cap for concurrent sync jobs. Defaults to 10; set 0 to disable.
    * Env DKG_SYNC_GLOBAL_MAX_INFLIGHT wins.
    */
   syncGlobalMaxInflight?: number;
   /** Backwards-compatible alias for syncGlobalMaxInflight. Env DKG_SYNC_GLOBAL_LIMIT wins. */
   syncGlobalLimit?: number;
-  /** Max sync jobs waiting behind the global cap. Defaults to 2x the inflight cap. */
+  /** Hard cap for queued sync jobs. Shared mode defaults to 2x the inflight cap. */
   syncGlobalQueueLimit?: number;
   /** Optional partitioned fast/slow sync admission. Omit for the legacy shared limiter. */
   syncAdmission?: SyncAdmissionConfig;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1802,6 +1802,7 @@ export async function runDaemonInner(
     syncGlobalMaxInflight: config.syncGlobalMaxInflight,
     syncGlobalLimit: config.syncGlobalLimit,
     syncGlobalQueueLimit: config.syncGlobalQueueLimit,
+    syncAdmission: config.syncAdmission,
     syncResponderSnapshotLimits: config.syncResponderSnapshotLimits,
     syncContextGraphPriorities: config.syncContextGraphPriorities,
     storageAckHandlerDeadlineMs: config.storageAckHandlerDeadlineMs,

--- a/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
+++ b/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
@@ -162,6 +162,23 @@ describe('runDaemonInner wires sync options into DKGAgent.create', () => {
     expect(createArg.syncGlobalQueueLimit).toBe(0);
   });
 
+  it('passes partitioned sync admission through unchanged', async () => {
+    const syncAdmission = {
+      globalMaxInflight: 10,
+      fast: { maxInflight: 8, queueLimit: 64, queueTimeoutMs: 5_000 },
+      slow: {
+        maxInflight: 2,
+        foregroundReserved: 1,
+        foregroundQueueLimit: 8,
+        backgroundMaxInflight: 1,
+        backgroundQueueLimit: 0,
+      },
+    } as const;
+    const createArg = await captureCreateArg({ syncAdmission });
+
+    expect(createArg.syncAdmission).toEqual(syncAdmission);
+  });
+
   it('passes the automatic system Context Graph sync override through unchanged', async () => {
     const createArg = await captureCreateArg({
       syncSystemContextGraphsOnConnect: false,

--- a/packages/core/src/telemetry-api.ts
+++ b/packages/core/src/telemetry-api.ts
@@ -329,7 +329,8 @@ export interface DkgMetrics {
    *  source, outcome={resolved|error|cancelled}. */
   syncOperationDurationMs: Histogram;
   /** I5 — operations rejected *before starting*, so they are never a 0 ms I4
-   *  sample. lane, source, reason={queue_full|displaced|aborted_before_start}. */
+   *  sample. lane, source,
+   *  reason={queue_full|queue_timeout|displaced|aborted_before_start}. */
   syncOperationRejectedTotal: Counter;
   /** I6 — single-flight/coalescing joins, recorded at map-hit time (before any
    *  bytes move). scope={context-graph|durable|shared-memory|page},


### PR DESCRIPTION
## Summary

This PR adds an opt-in, node-wide **partitioned sync admission policy** on top of the selected-recovery reservation introduced by #2251.

It separates short, latency-sensitive work from long snapshot transfers while retaining one global safety ceiling:

- **fast**: changelog and standalone control-plane metadata sync
- **slow foreground**: explicit foreground catch-up and VM/SWM recovery selected by #2251
- **slow background**: automatic on-connect, reconcile, and unrelated bulk recovery

It also raises the default node-wide shared concurrency from **2 to 10**, keeps the default shared queue bounded at **20**, preserves legacy global settings as hard caps, rejects non-live zero-capacity configurations, and makes diagnostics accurate before the first request is admitted.

## Stack relationship

This PR is intentionally based on **#2251**.

- #2251 decides which recovery scope is selected and therefore deserves reserved progress.
- #2248 decides which physical capacity partition each admitted operation uses.
- Shared mode keeps #2251's selection-aware reservation without enabling physical partitions.

```mermaid
flowchart LR
    P2251["PR #2251<br/>Resolve selected recovery scope"] --> Classify["Classify each sync request"]
    Classify --> Fast["Fast partition<br/>changelog + control plane"]
    Classify --> SlowFG["Slow foreground<br/>selected recovery"]
    Classify --> SlowBG["Slow background<br/>automatic bulk work"]
    Global["Node-wide hard cap"] -. "bounds all partitions" .-> Fast
    Global -. "bounds all partitions" .-> SlowFG
    Global -. "bounds all partitions" .-> SlowBG
```

## Problem

The previous scheduler exposed multiple logical priority lanes, but every lane still consumed the same small global pool. Priority controlled which queued request ran next; it did not reserve capacity.

A permanently active on-connect or reconcile transfer could therefore occupy the pool and block a small changelog or control-plane request. Increasing only the shared queue retained more blocked work without providing isolation.

There were also four correctness/operability gaps:

1. standalone curator metadata refreshes could bypass the node-wide admission path;
2. a configured queue with zero runnable capacity could retain work forever;
3. pressure diagnostics learned the partition shape only from an acquire call, so startup/pre-admission state could be misleading;
4. lifecycle telemetry did not prove that a fast-lane queue timeout emitted I5 without starting work or emitting I4.

## Admission model

Partitioned mode is enabled by a present `syncAdmission` block unless `mode: shared` is selected.

Default partitioned capacity:

| Class | Examples | Inflight | Queue | Queue timeout |
| --- | --- | ---: | ---: | ---: |
| Fast | changelog, standalone control-plane metadata | 8 | 64 | 5,000 ms |
| Slow foreground | explicit catch-up, selected VM/SWM recovery | up to 2 total slow slots | 8 | none |
| Slow background | on-connect, reconcile, unrelated VM/SWM recovery | 1 | 0 | not applicable |
| Global | all classes combined | 10 | 72 | n/a |

The slow partition has two slots. Background work may use at most one, leaving one slot unavailable to automatic background transfers and therefore available to foreground recovery.

```mermaid
flowchart TD
    Request["Sync admission request"] --> Route{"Lane/source classification"}
    Route -->|"changelog or control-plane"| Fast["Fast class"]
    Route -->|"catchup-foreground or selected VM/SWM recovery"| SlowFG["Slow foreground"]
    Route -->|"on-connect, reconcile, or unrelated bulk recovery"| SlowBG["Slow background"]

    Fast --> FastGate["Fast: 8 inflight<br/>queue 64<br/>5 s wait limit"]
    SlowFG --> SlowGate["Slow: 2 inflight total"]
    SlowBG --> BgGate["Background: 1 inflight<br/>queue 0"]
    BgGate --> SlowGate

    HardCap["Global: 10 inflight<br/>queue 72"] -. "hard ceiling" .-> FastGate
    HardCap -. "hard ceiling" .-> SlowGate
```

## Runtime sequences

### Fast work is isolated from persistent bulk work

```mermaid
sequenceDiagram
    autonumber
    participant Driver as "On-connect/reconcile driver"
    participant Admission as "Admission classifier"
    participant Slow as "Slow partition"
    participant Delta as "Changelog/control-plane request"
    participant Fast as "Fast partition"
    participant Recovery as "Selected recovery"

    Driver->>Admission: "Acquire automatic snapshot"
    Admission->>Slow: "slow_background"
    Slow-->>Driver: "Start in background slot"

    par "Fast work progresses independently"
        Delta->>Admission: "Acquire short operation"
        Admission->>Fast: "fast"
        Fast-->>Delta: "Start"
    and "Selected recovery retains progress"
        Recovery->>Admission: "Acquire selected VM/SWM recovery"
        Admission->>Slow: "slow_foreground"
        Slow-->>Recovery: "Start in protected slow capacity"
    end

    Note over Admission,Slow: "Active work is not preempted; isolation happens before admission"
```

### Standalone control-plane refresh uses real admission

```mermaid
sequenceDiagram
    autonumber
    participant Caller as "Curator metadata caller"
    participant Refresh as "Curator metadata refresh"
    participant Global as "Node-wide scheduler"
    participant Fast as "Fast partition"
    participant Peer as "Remote peer"

    Caller->>Refresh: "Refresh root _meta graph"
    alt "No enclosing sync admission"
        Refresh->>Global: "Acquire durable:control-plane"
        Global->>Fast: "Classify as fast"
        Fast-->>Refresh: "Admission granted"
        Refresh->>Peer: "Fetch bounded metadata"
        Refresh-->>Global: "Release"
    else "Already inside admitted sync work"
        Refresh->>Refresh: "Reuse enclosing admission and source"
        Refresh->>Peer: "Fetch bounded metadata"
    end

    Note over Refresh,Global: "Nested refreshes do not double-acquire or relabel their trigger"
```

### Automatic background work is retried by its driver

```mermaid
sequenceDiagram
    autonumber
    participant Driver as "Automatic sync driver"
    participant Admission as "Slow-background admission"
    participant Worker as "Snapshot worker"
    participant Retry as "Existing cooldown/backoff"

    Driver->>Admission: "Acquire bulk job"
    alt "Background slot is free"
        Admission-->>Worker: "Start"
        Worker-->>Admission: "Release on completion/failure"
    else "Background slot is occupied"
        Admission-->>Driver: "Reject queue_full"
        Driver->>Retry: "Schedule later attempt"
    end

    Note over Admission,Retry: "The admission queue does not retain duplicate long-lived automatic jobs"
```

### Fast queue timeout is terminal before work starts

```mermaid
sequenceDiagram
    autonumber
    participant Request as "Queued fast request"
    participant Queue as "Fast admission queue"
    participant Telemetry as "Operation telemetry"
    participant Work as "Sync body"

    Request->>Queue: "Wait for fast capacity"
    Queue-->>Request: "queue_timeout after configured deadline"
    Request->>Telemetry: "Emit I5 reason=queue_timeout"
    Note over Work: "Work never starts"
    Note over Telemetry: "No I4 completion is emitted"
```

## Configuration and precedence

Safe opt-in defaults:

```yaml
syncAdmission: {}
```

Equivalent explicit configuration:

```yaml
syncAdmission:
  mode: partitioned
  globalMaxInflight: 10
  fast:
    maxInflight: 8
    queueLimit: 64
    queueTimeoutMs: 5000
  slow:
    maxInflight: 2
    foregroundReserved: 1
    foregroundQueueLimit: 8
    backgroundMaxInflight: 1
    backgroundQueueLimit: 0
```

Global limits remain hard caps in both modes.

Inflight precedence:

1. `DKG_SYNC_GLOBAL_MAX_INFLIGHT`
2. legacy `DKG_SYNC_GLOBAL_LIMIT`
3. `syncGlobalMaxInflight`
4. legacy `syncGlobalLimit`
5. partitioned `syncAdmission.globalMaxInflight`
6. default `10`

Queue precedence:

1. `DKG_SYNC_GLOBAL_QUEUE_LIMIT`
2. `syncGlobalQueueLimit`
3. partition queue sum in partitioned mode, or `2 × inflight` in shared mode

Resolving the global inflight limit to `0` disables node-wide admission while retaining the configured mode in diagnostics.

```mermaid
flowchart TD
    Input["Config + environment"] --> Mode{"syncAdmission present and mode != shared?"}
    Mode -->|"No"| Shared["Resolve shared policy<br/>default 10 inflight / 20 queued"]
    Mode -->|"Yes"| Partitioned["Resolve partition defaults<br/>10 global, 8 fast, 2 slow"]
    Shared --> Caps["Apply legacy env/config hard caps"]
    Partitioned --> Caps
    Caps --> Validate{"Resolved global inflight == 0?"}
    Validate -->|"Yes"| Disabled["Disabled policy<br/>mode retained<br/>zero capacity reported"]
    Validate -->|"No"| Live["Validate runnable capacity and limits"]
    Live --> Publish["Configure static scheduler capacity<br/>before first acquire"]
```

## Validation and invariants

Startup rejects configurations that violate any of these invariants:

1. `fast.maxInflight + slow.maxInflight <= globalMaxInflight`
2. `slow.foregroundReserved <= slow.maxInflight`
3. `slow.backgroundMaxInflight <= slow.maxInflight - slow.foregroundReserved`
4. a positive foreground queue requires `slow.maxInflight > 0`
5. a positive background queue requires `slow.backgroundMaxInflight > 0`
6. every configured limit and timeout is a non-negative safe integer
7. every admitted request satisfies both the global ceiling and its class/partition limit
8. release decrements the matching counters once and pumps the next runnable entry

The production scheduler now receives a static capacity description when policy resolution completes. Before any admission, diagnostics report the real model:

- enabled partitioned defaults: global `10/72`, fast `8/64`, slow `2/8`
- disabled partitioned policy: mode `partitioned`, zero capacity, healthy idle state

Validation run for the final patch:

- `pnpm --filter @origintrail-official/dkg-agent exec tsc --noEmit`
- `pnpm --filter @origintrail-official/dkg-agent run build`
- `pnpm --filter @origintrail-official/dkg exec tsc --noEmit`
- focused agent suites: **105 tests passed**
- policy + attempt telemetry suites: **49 tests passed**
- core backpressure observability suite: **17 tests passed**
- final sync-backpressure suite: **55 tests passed**
- fresh-process proof for enabled and disabled pre-admission diagnostics
- `git diff --check`

## Observability

The resolved startup log and `sync-global` pressure snapshot now expose:

- selected mode: `shared` or `partitioned`
- aggregate inflight and queue limits
- static fast/slow capacity before the first acquire
- current fast/slow inflight and queued counts
- `queue_full`, `queue_timeout`, displacement, and abort-before-start outcomes
- trigger source without laundering nested work into `control-plane`

## Rollout and rollback

1. Enable `syncAdmission: {}` on one canary.
2. Confirm startup reports partitioned mode and global `10`, fast `8`, slow `2`.
3. Confirm automatic work is rejected/retried when its single background slot is occupied.
4. Confirm changelog/control-plane work starts through fast capacity.
5. Confirm selected recovery can enter the protected slow capacity.
6. Expand only after queue depth and timeout telemetry remain healthy.

Rollback is configuration-only: set `syncAdmission.mode: shared` or remove the block, then restart the node.

## Deliberate non-goals

- no cancellation or preemption of active transfers
- no time-slicing of partial transfers
- no duplicate retry ownership inside admission
- no broad lane-type or routing refactor beyond the correctness changes above
