### PR TITLE
fix(sync): reserve Edge capacity for selected graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,26 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [10.0.14] - 2026-08-10
 
-A selected-public convergence release. An Edge node can opt a bounded set of publicly readable Context Graphs into RFC-64: signed catalogs drive complete Shared Memory recovery, while Verifiable Memory remains independently derived from finalized blockchain inventory. Both lanes continue across partial progress and provider gaps, and VM recovery batches assets by bounded byte/quad footprint instead of treating an arbitrarily large graph as one transfer. RFC-64 remains opt-in and public-only; private encrypted live sharing is unchanged, and private catalog-based cold join is not part of this release. **No smart-contract changes or deployments are required.**
+A selected-public convergence release. An Edge node can opt a bounded set of publicly readable Context Graphs into RFC-64: an operator-approved graph-complete provider drives bounded native Shared Memory recovery, while Verifiable Memory remains independently derived from finalized blockchain inventory. Both lanes continue across partial progress and provider gaps, and VM recovery batches assets by bounded byte/quad footprint instead of treating an arbitrarily large graph as one transfer. Signed SWM inventory remains shadow evidence in this release and does not drive receiver synchronization. RFC-64 remains opt-in and public-only; private encrypted live sharing is unchanged, and private catalog-based cold join is not part of this release. **No smart-contract changes or deployments are required.**
 
 ### Upgrading from 10.0.13
 
 | Change | Impact | Action |
 | --- | --- | --- |
-| Selected public RFC-64 convergence is usable end to end | For an explicitly selected public CG, signed RFC-64 catalogs recover SWM-only assets and finalized chain inventory recovers VM assets. Empty or disabled configuration remains dormant | Configure `rfc64PublicCatalog` only for public CGs the Edge should maintain; leave it absent to retain 10.0.13 behavior |
+| Selected public RFC-64 convergence is usable end to end | For an explicitly selected public CG, a configured graph-complete provider recovers SWM-only assets through native durable sync and finalized chain inventory recovers VM assets. Empty or disabled configuration remains dormant | Configure `rfc64PublicCatalog` only for public CGs the Edge should maintain, and list a `completeSwmProviders` peer only after establishing that graph-wide property; leave the block absent to retain 10.0.13 behavior |
 | Selected VM recovery uses bounded footprint-aware batches | Multiple small assets can share one recovery request, while byte, quad and heap estimates keep large transfers bounded | No action; the scheduler derives safe batches from authoritative or conservative size evidence |
 | Persisted user subscriptions rehydrate on daemon startup | An operator-selected graph resumes automatically after restart instead of remaining a dormant database row | Set `DKG_CONTEXT_GRAPH_SUBSCRIPTION_REHYDRATION_ENABLED=false` only as an emergency kill-switch |
 | Dashboard SQLite schema 32 → 33 | Selected-VM cursors are fenced by deployment identity; v32 optimization cursors are discarded so a redeploy cannot reuse another chain deployment's numeric IDs or watermark | No action; the graph data is retained and selected VM reconciliation safely resumes from chain inventory |
 
 ### Added
 
-- **Selected public SWM convergence** (#2182, #2210): a verified graph-complete RFC-64 provider receives reserved scheduler priority, partial progress immediately schedules another bounded pass, and completion requires the selected catalog inventory rather than an empty or metadata-only response.
+- **Selected public SWM convergence** (#2182, #2210): an operator-approved graph-complete provider receives reserved scheduler priority, partial progress immediately schedules another bounded pass, and completion requires typed whole-scope snapshot coverage rather than an empty or metadata-only response.
 - **Chain-authoritative selected VM convergence** (#2145, #2146, #2184): the receiver resolves the selected CG against a pinned deployment, enumerates finalized Knowledge Assets from chain truth, persists a deployment-scoped cursor, and continues through bounded provider recovery until the VM inventory is complete.
 - **Footprint-aware VM microbatching** (#2203, #2204): recovery groups as many exact assets as fit the byte, quad and heap budgets, with bounded sizing reads and conservative fallback when evidence is unavailable.
 
 ### Changed
 
-- **RFC-64 catalogs describe SWM only** (#2147): VM is never accepted from a catalog as authority; finalized blockchain inventory remains the VM catalog for both discovery and completeness.
+- **RFC-64 catalogs describe SWM only** (#2147): VM is never accepted from a catalog as authority; finalized blockchain inventory remains the VM catalog for both discovery and completeness. Automatic signed-catalog production from ordinary publication is not enabled by this release.
 - **Cold selected CG bindings resolve directly from chain state** (#2205): a fresh receiver can map the configured public graph to its numeric on-chain identity without relying on pre-existing ontology/store metadata, and ambiguous or stale bindings fail closed.
 - **Publisher workspace-head writes remain on the StorageACK lane** (#2178), preventing unrelated normal-lane store work from delaying acknowledgement-critical state.
 - **Prime Agent legacy chat memory migrates to numbered, graph-scoped working memory** (#2151, #2153) without mistaking orphan lifecycle rows for legacy drafts.
@@ -44,6 +44,7 @@ A selected-public convergence release. An Edge node can opt a bounded set of pub
 ### Known limitations
 
 - RFC-64 catalog convergence is limited to publicly readable CGs in 10.0.14. Private CGs retain existing encrypted live sharing, membership and publication behavior, but an authorized cold receiver does not yet have the analogous private, catalog-based historical SWM recovery lane.
+- Signed SWM author inventory remains shadow/audit evidence. Ordinary KA publication does not automatically author the signed catalog consumed by catalog targets, so 10.0.14 completeness claims are scoped to the configured graph-complete-provider native recovery lane plus chain-authoritative VM recovery.
 
 ## [10.0.13] - 2026-08-07
 

--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -7,10 +7,11 @@ not advance catalogs after ordinary KA publication.
 
 This activation is intentionally selective. The operator supplies a bounded
 manifest of independently verified, finalized public-CG policy envelopes. The
-CG IDs in that manifest are the single source for both:
+CG IDs in that manifest are the single source for:
 
-- durable graph subscriptions; and
-- the optional post-publication catalog producer hook.
+- durable graph subscriptions;
+- explicit signed-catalog targets; and
+- optional graph-complete-provider native SWM recovery.
 
 There is no `sync all public CGs` mode in this release. Existing `contextGraphs`
 selection continues to work normally, and CGs outside the RFC-64 manifest stay
@@ -92,11 +93,12 @@ coverage, while VM remains chain/curator driven. Omit this field unless that
 graph-wide property has been established; ordinary per-author catalog providers
 do not imply it.
 
-`autoPublish` is optional. Configure it on a publisher that should maintain the
-selected public graph's SWM inventory after durable public sharing. A receiver
-can omit `autoPublish` and keep only the bootstrap controls. Inventory work is
-fail-open: an RFC-64 error is logged but does not rewrite an already-committed
-user operation into a failure.
+`autoPublish` is optional and arms the explicit low-level catalog-authoring
+capability. It does **not** make ordinary KA publication author or advance a
+signed catalog in 10.0.14. Ordinary publication only updates the signed SWM
+inventory shadow, which remains audit evidence and does not drive receiver
+synchronization. A receiver can omit `autoPublish` and keep only the bootstrap
+controls.
 
 `deploymentProfile` is also optional on a normal chain-connected node. When it
 is omitted, the agent resolves the chain ID and Knowledge Assets Lifecycle
@@ -134,16 +136,21 @@ Restart the daemon and inspect `GET /api/status`:
 }
 ```
 
-For a release gate, `enabled: true` is not sufficient. Every intended target
-must report `outcome: "applied"`, a non-null `appliedHeadDigest`, and the
-expected `inventoryRowCount`. Validate the same evidence again after receiver
-restart and during provider failover. A `not-found` or `failed` target is a
-failed completeness gate even if the ordinary durable-sync job reports done.
+For a signed-catalog target gate, `enabled: true` is not sufficient. Every
+intended target must report `outcome: "applied"`, a non-null
+`appliedHeadDigest`, and the expected `inventoryRowCount`. A `not-found` or
+`failed` target is a failed catalog gate even if ordinary durable sync reports
+done. For a configuration that uses only `completeSwmProviders`, `targets` may
+be empty; gate that lane by exact SWM asset/byte coverage before and after
+receiver restart, plus exact chain-derived VM coverage. In either mode, test
+provider loss/failover explicitly.
 
 ## Current boundary
 
-This release activates the already-built public RFC-64 catalog data plane for
-an explicit operator-selected set. Provider peer IDs and finalized policy
-envelopes are still pinned inputs. Automatic provider discovery and automatic
-chain-to-policy control-plane generation are later work; this activation does
-not claim either capability.
+This release exposes the already-built public RFC-64 catalog receiver data
+plane for explicit targets and the selected native SWM recovery lane for
+operator-approved graph-complete providers. Provider peer IDs and finalized
+policy envelopes are still pinned inputs. Signed catalog authoring is explicit;
+the ordinary-publication SWM inventory shadow is not connected to receiver
+convergence. Automatic catalog production, automatic provider discovery, and
+automatic chain-to-policy control-plane generation are later work.

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -607,11 +607,26 @@ const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
 const RFC64_SELECTED_SWM_ADMISSION_PRIORITY = 2_000;
 
 function resolveAgentSyncGlobalBackpressure(config: DKGAgentConfig) {
+  // `trackSyncContextGraph()` mutates this list when an Edge explicitly
+  // subscribes or starts a foreground catch-up. Those operator-selected graphs
+  // need the same admission guarantee as an RFC-64 pinned scope: otherwise a
+  // mature Edge can fill every global slot with unrelated background VM
+  // recovery and repeatedly reject the graph the user just selected.
+  //
+  // Keep this Edge-only. Core nodes intentionally host the public corpus and
+  // grow `syncContextGraphs` through discovery; treating that all-CG inventory
+  // as one selected scope would permanently reduce Core background throughput.
+  const edgeSelectedContextGraphIds = config.nodeRole === 'edge'
+    ? config.syncContextGraphs ?? []
+    : [];
   return resolveSyncGlobalBackpressure({
     ...config,
-    selectedRecoveryContextGraphIds: resolveRfc64SelectedRecoveryContextGraphIdsV1(
-      config.rfc64PublicCatalogBootstrap,
-    ),
+    selectedRecoveryContextGraphIds: [...new Set([
+      ...resolveRfc64SelectedRecoveryContextGraphIdsV1(
+        config.rfc64PublicCatalogBootstrap,
+      ),
+      ...edgeSelectedContextGraphIds,
+    ])],
   });
 }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -616,7 +616,7 @@ function resolveAgentSyncGlobalBackpressure(config: DKGAgentConfig) {
   // Keep this Edge-only. Core nodes intentionally host the public corpus and
   // grow `syncContextGraphs` through discovery; treating that all-CG inventory
   // as one selected scope would permanently reduce Core background throughput.
-  const edgeSelectedContextGraphIds = config.nodeRole === 'edge'
+  const edgeSelectedContextGraphIds = (config.nodeRole ?? 'edge') === 'edge'
     ? config.syncContextGraphs ?? []
     : [];
   return resolveSyncGlobalBackpressure({

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -1717,11 +1717,14 @@ describe('sync global backpressure', () => {
     ]);
   });
 
-  it('reserves Edge capacity for a runtime-selected Context Graph', async () => {
+  it.each([
+    { label: 'explicit Edge', nodeRole: 'edge' as const },
+    { label: 'default Edge', nodeRole: undefined },
+  ])('reserves $label capacity for a runtime-selected Context Graph', async ({ nodeRole }) => {
     const selectedCg = 'urn:cg:edge-selected';
     const agentLike = {
       config: {
-        nodeRole: 'edge',
+        ...(nodeRole === undefined ? {} : { nodeRole }),
         syncContextGraphs: [selectedCg],
         syncGlobalMaxInflight: 2,
         syncGlobalQueueLimit: 6,

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -1717,6 +1717,120 @@ describe('sync global backpressure', () => {
     ]);
   });
 
+  it('reserves Edge capacity for a runtime-selected Context Graph', async () => {
+    const selectedCg = 'urn:cg:edge-selected';
+    const agentLike = {
+      config: {
+        nodeRole: 'edge',
+        syncContextGraphs: [selectedCg],
+        syncGlobalMaxInflight: 2,
+        syncGlobalQueueLimit: 6,
+      },
+      node: { stopSignal: undefined },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+    const events: string[] = [];
+    let releaseSelected!: () => void;
+    let releaseRecovery!: () => void;
+
+    const run = (
+      contextGraphId: string,
+      label: string,
+      source: 'catchup-foreground' | 'vm-recovery',
+      work: () => Promise<void>,
+    ) => LifecycleSyncMethods.prototype.runContextGraphSyncWithBackpressure.call(
+      agentLike as never,
+      createOperationContext('sync'),
+      contextGraphId,
+      'durable' as never,
+      label,
+      work,
+      { source },
+    );
+
+    const selected = run(
+      selectedCg,
+      'durable:selected-catchup',
+      'catchup-foreground',
+      async () => new Promise<void>((resolve) => {
+        events.push('selected-start');
+        releaseSelected = resolve;
+      }),
+    );
+    await tick();
+    const unrelatedRecovery = run(
+      'urn:cg:unrelated',
+      'durable:unrelated-recovery',
+      'vm-recovery',
+      async () => { events.push('unrelated-recovery-start'); },
+    );
+    await tick();
+    expect(events).toEqual(['selected-start']);
+
+    const selectedRecovery = run(
+      selectedCg,
+      'durable:selected-recovery',
+      'vm-recovery',
+      async () => new Promise<void>((resolve) => {
+        events.push('selected-recovery-start');
+        releaseRecovery = resolve;
+      }),
+    );
+    await tick();
+    expect(events).toEqual(['selected-start', 'selected-recovery-start']);
+
+    releaseRecovery();
+    await selectedRecovery;
+    expect(events).toEqual(['selected-start', 'selected-recovery-start']);
+    releaseSelected();
+    await Promise.all([selected, unrelatedRecovery]);
+    expect(events).toEqual([
+      'selected-start',
+      'selected-recovery-start',
+      'unrelated-recovery-start',
+    ]);
+  });
+
+  it('does not reserve Core capacity for its all-CG sync inventory', async () => {
+    const trackedCg = 'urn:cg:core-hosted';
+    const agentLike = {
+      config: {
+        nodeRole: 'core',
+        syncContextGraphs: [trackedCg],
+        syncGlobalMaxInflight: 2,
+        syncGlobalQueueLimit: 4,
+      },
+      node: { stopSignal: undefined },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const run = (label: string, capture: (release: () => void) => void) => (
+      LifecycleSyncMethods.prototype.runContextGraphSyncWithBackpressure.call(
+        agentLike as never,
+        createOperationContext('sync'),
+        trackedCg,
+        'durable' as never,
+        label,
+        () => new Promise<void>((resolve) => {
+          events.push(label);
+          capture(resolve);
+        }),
+        { source: 'catchup-foreground' },
+      )
+    );
+
+    const first = run('first', (release) => { releaseFirst = release; });
+    await tick();
+    const second = run('second', (release) => { releaseSecond = release; });
+    await tick();
+    expect(events).toEqual(['first', 'second']);
+    releaseFirst();
+    releaseSecond();
+    await Promise.all([first, second]);
+  });
+
   it('does not derive a reservation from an RFC-64 policy without complete providers', async () => {
     const contextGraphId = 'urn:cg:rfc64-no-complete-provider';
     const agentLike = {


### PR DESCRIPTION
## Outcome

An Edge node now keeps one global sync slot available for Context Graphs that the operator explicitly selected. Background recovery for unrelated graphs can no longer occupy every slot and indefinitely crowd out the graph the user asked the node to synchronize.

Core scheduling is unchanged: Core nodes still use their full configured concurrency for the public corpus.

## User impact

- An Edge user can select a Context Graph and expect its foreground catch-up and follow-up recovery to keep making progress under background load.
- Existing RFC-64 selected scopes retain the same admission guarantee.
- Core nodes do not lose background throughput merely because their discovered all-CG inventory is tracked in `syncContextGraphs`.
- No configuration change is required.

## Before

```mermaid
sequenceDiagram
    participant User
    participant Edge
    participant Scheduler
    participant Background
    User->>Edge: Select Context Graph A
    Background->>Scheduler: Start unrelated VM recovery 1
    Background->>Scheduler: Start unrelated VM recovery 2
    Edge->>Scheduler: Continue sync for Graph A
    Scheduler-->>Edge: Reject or queue because all slots are occupied
```

## After

```mermaid
sequenceDiagram
    participant User
    participant Edge
    participant Scheduler
    participant Background
    User->>Edge: Select Context Graph A
    Edge->>Scheduler: Register Graph A as operator selected
    Background->>Scheduler: Start unrelated recovery
    Background->>Scheduler: Request another unrelated recovery
    Scheduler-->>Background: Keep selected capacity reserved
    Edge->>Scheduler: Continue Graph A recovery
    Scheduler-->>Edge: Admit work through reserved capacity
```

## Test evidence

- `pnpm --filter @origintrail-official/dkg-agent build`
- 204 focused and adjacent scheduler, catch-up, and Core-gap tests passed
- New regressions prove Edge reservation and unchanged Core concurrency
- `git diff --check`

## Testnet evidence motivating this change

In the strict five-receiver 10.0.14 candidate run, publishing completed 100/100 and four receivers reached the exact 50 SWM plus 50 VM inventory. One mature Edge stopped at 35/50 SWM and 35/50 VM while its two global slots were occupied by background VM recovery and selected follow-up work accumulated queue-full/displacement rejections. This PR addresses that bounded scheduling defect; an exact-head multi-node rerun remains required before release certification.
