### PR TITLE
feat(agent): gate legacy agent-profile quads against applied signed records

### DIFF
--- a/packages/agent/src/system-records/legacy-profile-gate-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-v1.ts
@@ -1,0 +1,285 @@
+/**
+ * `LegacyAgentProfileGateV1` — the inbound legacy `agents` duplicate/conflict gate.
+ *
+ * Legacy aggregate sync replays whole `agents` pages. Once a root carries an applied
+ * signed record, those pages are redundant at best and contradictory at worst, so this
+ * gate partitions incoming quads by the canonical root/subject index before any store
+ * insertion:
+ *
+ *   - a quad already present in the applied record's exact projection is DISCARDED;
+ *   - a quad that is additional or different for a covered root is WITHHELD, and its root
+ *     is counted as conflicted;
+ *   - a quad whose root has no applied record — including an unknown subject shape —
+ *     falls through to ordinary legacy insertion, unchanged.
+ *
+ * The invariant is that unsigned legacy bytes never reach the store for a covered root,
+ * so applied signed state cannot be overwritten by legacy insertion.
+ *
+ * Comparison is streaming per quad, never page equality. A page that omits quads the
+ * record holds carries no deletion or conflict meaning: absence is not evidence. Pages
+ * split across root, nested and key subjects are expected and are classified
+ * independently.
+ *
+ * Plan lines 924-930. At :924 "quarantined" takes quads as its object, in parallel with
+ * "discarded" — the quads are held aside. The record-level marker is :925's "dirties ...
+ * it", and the plan's record vocabulary is consistently dirty (:923, :927, AC-4).
+ *
+ * This module decides; it does not write. Marking a contaminated record is deferred: the
+ * record-dirty mechanism does not exist yet and is shared with :927, so it lands where
+ * both consumers reach it. Withholding alone holds the invariant for this seam.
+ *
+ * Scope is the legacy durable-sync seam only. `agents` also reaches the store through the
+ * RFC-59 changelog lane, which is a separate slice (D-13) because its page shape differs
+ * and :926's two-request budget does not transfer to it. Activation is gated on both.
+ */
+
+import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  classifyAgentProfileOwnedSubjectV1,
+  SYSTEM_RECORD_MAX_OWNED_SUBJECTS,
+  SYSTEM_RECORD_MAX_PROJECTION_QUADS,
+} from '@origintrail-official/dkg-core/system-record-v1';
+
+/**
+ * Derived roots resolved by one batched lookup for one legacy page.
+ *
+ * The plan fixes this at 256 and it has no existing limits-v1 constant: the neighbouring
+ * 256s there are byte caps and B+tree fanouts, not a per-page root budget.
+ */
+export const LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 = 256;
+
+/** One applied signed record, as resolved by the first batched lookup. */
+export interface LegacyAgentProfileAppliedRootV1 {
+  readonly root: string;
+  /** The record's exact owned-subject table. */
+  readonly ownedSubjects: readonly string[];
+}
+
+/**
+ * The two bounded store reads this gate is allowed for one legacy page.
+ *
+ * Implementations own the batching; the gate guarantees it calls each at most once per
+ * page and never per root or per quad.
+ */
+export interface LegacyAgentProfileGateLookupV1 {
+  /** Request one: which of these derived roots carry an applied signed record. */
+  lookupAppliedRoots(
+    roots: readonly string[],
+    signal?: AbortSignal,
+  ): Promise<readonly LegacyAgentProfileAppliedRootV1[]>;
+  /** Request two: the exact projection triples owned by these subjects. */
+  lookupProjectionMembership(
+    subjects: readonly string[],
+    signal?: AbortSignal,
+  ): Promise<readonly Quad[]>;
+}
+
+/** Why a root's quads were withheld rather than classified. Deliberately not exported. */
+type LegacyAgentProfileWithholdReasonV1 = 'conflict' | 'unclassified';
+
+export interface LegacyAgentProfileGateResultV1 {
+  /** Quads cleared for ordinary legacy insertion, in arrival order. */
+  readonly insert: readonly Quad[];
+  /** Quads never offered to the store: a conflict, or a root left unclassified by a cap. */
+  readonly withheld: readonly Quad[];
+  /** Exact duplicates dropped before insertion. */
+  readonly discardedDuplicates: number;
+  /** Covered roots that saw at least one conflicting quad. */
+  readonly conflictedRoots: number;
+  /** Roots a batch cap left unclassified, so their quads were withheld unverified. */
+  readonly unclassifiedRoots: number;
+  /** Physical store reads performed. Never exceeds two. */
+  readonly storeRequests: number;
+}
+
+/**
+ * Derive the canonical record root for an arbitrary inbound subject.
+ *
+ * Exact `did:dkg:agent:<address>` subjects are their own root; a `/.well-known/`
+ * descendant and a validated `#x25519-<32 lowercase hex>` fragment strip back to it.
+ * Every candidate is confirmed by core's owned-subject classifier rather than by
+ * restating its string rules here, so this can never admit a shape core rejects.
+ * Unknown shapes stay uncovered and take the legacy path.
+ */
+export function deriveLegacyAgentProfileRootV1(subject: string): string | null {
+  if (typeof subject !== 'string' || subject.length === 0) return null;
+  if (classifyAgentProfileOwnedSubjectV1(subject, subject) !== null) return subject;
+  const wellKnown = subject.indexOf('/.well-known/');
+  if (wellKnown > 0) {
+    const root = subject.slice(0, wellKnown);
+    if (classifyAgentProfileOwnedSubjectV1(root, subject) !== null) return root;
+  }
+  const fragment = subject.indexOf('#');
+  if (fragment > 0) {
+    const root = subject.slice(0, fragment);
+    if (classifyAgentProfileOwnedSubjectV1(root, subject) !== null) return root;
+  }
+  return null;
+}
+
+/** Graphless identity. Projection membership is a triple property; the page's graph is not. */
+function tripleKeyV1(quad: Quad): string {
+  return JSON.stringify([quad.subject, quad.predicate, quad.object]);
+}
+
+export interface LegacyAgentProfileGateV1 {
+  /**
+   * Classify one legacy page. Performs at most two bounded store reads, and none at all
+   * when the page derives no covered-candidate root.
+   */
+  filterPage(quads: readonly Quad[], signal?: AbortSignal): Promise<LegacyAgentProfileGateResultV1>;
+}
+
+export function createLegacyAgentProfileGateV1(
+  lookup: LegacyAgentProfileGateLookupV1,
+): LegacyAgentProfileGateV1 {
+  return Object.freeze({
+    async filterPage(
+      quads: readonly Quad[],
+      signal?: AbortSignal,
+    ): Promise<LegacyAgentProfileGateResultV1> {
+      // Partition first: one pass, one derivation per quad, no query.
+      const byRoot = new Map<string, Quad[]>();
+      const uncovered: Quad[] = [];
+      for (const quad of quads) {
+        const root = deriveLegacyAgentProfileRootV1(quad.subject);
+        if (root === null) {
+          uncovered.push(quad);
+          continue;
+        }
+        const existing = byRoot.get(root);
+        if (existing === undefined) byRoot.set(root, [quad]);
+        else existing.push(quad);
+      }
+
+      if (byRoot.size === 0) {
+        return frozenResult({
+          insert: uncovered,
+          withheld: [],
+          discardedDuplicates: 0,
+          conflictedRoots: 0,
+          unclassifiedRoots: 0,
+          storeRequests: 0,
+        });
+      }
+
+      // A page may derive more roots than one batch may carry. Selection is sorted so the
+      // same page always selects the same roots, and the remainder is withheld rather than
+      // inserted on an unverified assumption that it is uncovered — absence of a lookup is
+      // not absence of a record.
+      const derivedRoots = [...byRoot.keys()].sort();
+      const selected = derivedRoots.slice(0, LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1);
+      const deferred = derivedRoots.slice(LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1);
+
+      const withheld: Quad[] = [];
+      const recovery = new Map<string, LegacyAgentProfileWithholdReasonV1>();
+      for (const root of deferred) {
+        withheld.push(...(byRoot.get(root) ?? []));
+        recovery.set(root, 'unclassified');
+      }
+
+      const applied = await lookup.lookupAppliedRoots(selected, signal);
+      let storeRequests = 1;
+
+      const appliedByRoot = new Map<string, LegacyAgentProfileAppliedRootV1>();
+      for (const record of applied) {
+        if (byRoot.has(record.root)) appliedByRoot.set(record.root, record);
+      }
+
+      // Only covered roots need a membership read, and only for subjects the page touched.
+      const subjects = new Set<string>();
+      for (const [root, record] of appliedByRoot) {
+        const owned = new Set(record.ownedSubjects);
+        for (const quad of byRoot.get(root) ?? []) {
+          if (owned.has(quad.subject)) subjects.add(quad.subject);
+        }
+      }
+
+      // A covered root whose page subjects overflow the membership batch cannot be
+      // classified exactly, so it is withheld whole rather than partly compared.
+      const membershipSubjects: string[] = [];
+      const overflowed = new Set<string>();
+      if (subjects.size > SYSTEM_RECORD_MAX_OWNED_SUBJECTS) {
+        for (const [root] of appliedByRoot) {
+          withheld.push(...(byRoot.get(root) ?? []));
+          recovery.set(root, 'unclassified');
+          overflowed.add(root);
+        }
+      } else {
+        membershipSubjects.push(...[...subjects].sort());
+      }
+
+      const projection = new Set<string>();
+      if (membershipSubjects.length > 0) {
+        const rows = await lookup.lookupProjectionMembership(membershipSubjects, signal);
+        storeRequests += 1;
+        if (rows.length > SYSTEM_RECORD_MAX_PROJECTION_QUADS) {
+          // An over-cap response cannot be trusted as the exact applied set, so every
+          // covered root falls back to withhold-and-recover rather than being compared
+          // against a truncated projection.
+          for (const [root] of appliedByRoot) {
+            if (overflowed.has(root)) continue;
+            withheld.push(...(byRoot.get(root) ?? []));
+            recovery.set(root, 'unclassified');
+            overflowed.add(root);
+          }
+        } else {
+          for (const row of rows) projection.add(tripleKeyV1(row));
+        }
+      }
+
+      const insert: Quad[] = [...uncovered];
+      let discardedDuplicates = 0;
+      const conflicted = new Set<string>();
+      for (const root of selected) {
+        const pageQuads = byRoot.get(root) ?? [];
+        const record = appliedByRoot.get(root);
+        if (record === undefined) {
+          // No applied signed record: ordinary legacy behaviour, untouched.
+          insert.push(...pageQuads);
+          continue;
+        }
+        if (overflowed.has(root)) continue;
+        for (const quad of pageQuads) {
+          if (projection.has(tripleKeyV1(quad))) {
+            discardedDuplicates += 1;
+            continue;
+          }
+          // Additional or different for a covered root: never inserted.
+          withheld.push(quad);
+          conflicted.add(root);
+        }
+      }
+      for (const root of conflicted) recovery.set(root, 'conflict');
+
+      // The roots owing exact signed recovery stay inside this module and surface only as
+      // counts. The record-dirty mechanism that would consume them does not exist yet, and
+      // it is shared with plan :927 ("generic deletes/updates ... must use the record
+      // capability or atomically dirty that record"), so it belongs where both consumers
+      // reach it rather than as an interface here with nothing on the other end.
+      // Withholding alone already holds :1505 for this seam.
+      let unclassifiedRoots = 0;
+      for (const reason of recovery.values()) if (reason === 'unclassified') unclassifiedRoots += 1;
+
+      return frozenResult({
+        insert,
+        withheld,
+        discardedDuplicates,
+        conflictedRoots: conflicted.size,
+        unclassifiedRoots,
+        storeRequests,
+      });
+    },
+  });
+}
+
+function frozenResult(result: LegacyAgentProfileGateResultV1): LegacyAgentProfileGateResultV1 {
+  return Object.freeze({
+    insert: Object.freeze([...result.insert]),
+    withheld: Object.freeze([...result.withheld]),
+    discardedDuplicates: result.discardedDuplicates,
+    conflictedRoots: result.conflictedRoots,
+    unclassifiedRoots: result.unclassifiedRoots,
+    storeRequests: result.storeRequests,
+  }) as LegacyAgentProfileGateResultV1;
+}

--- a/packages/agent/src/system-records/legacy-profile-gate-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-v1.ts
@@ -20,6 +20,13 @@
  * split across root, nested and key subjects are expected and are classified
  * independently.
  *
+ * Structure: the lookup phases only assign a DISPOSITION to each derived root; a single
+ * final pass then walks the original page and materializes the result from those
+ * dispositions. That keeps `insert` and `withheld` in arrival order — "uncovered roots use
+ * legacy insertion" means unchanged, and reordering a passthrough page is a change — and
+ * keeps the classification invariant readable in one place rather than spread across
+ * mutations in each lookup branch.
+ *
  * Plan lines 924-930. At :924 "quarantined" takes quads as its object, in parallel with
  * "discarded" — the quads are held aside. The record-level marker is :925's "dirties ...
  * it", and the plan's record vocabulary is consistently dirty (:923, :927, AC-4).
@@ -33,6 +40,7 @@
  * and :926's two-request budget does not transfer to it. Activation is gated on both.
  */
 
+import { tripleContentV10 } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
   classifyAgentProfileOwnedSubjectV1,
@@ -74,13 +82,10 @@ export interface LegacyAgentProfileGateLookupV1 {
   ): Promise<readonly Quad[]>;
 }
 
-/** Why a root's quads were withheld rather than classified. Deliberately not exported. */
-type LegacyAgentProfileWithholdReasonV1 = 'conflict' | 'unclassified';
-
 export interface LegacyAgentProfileGateResultV1 {
-  /** Quads cleared for ordinary legacy insertion, in arrival order. */
+  /** Quads cleared for ordinary legacy insertion, in the page's arrival order. */
   readonly insert: readonly Quad[];
-  /** Quads never offered to the store: a conflict, or a root left unclassified by a cap. */
+  /** Quads never offered to the store, in arrival order. */
   readonly withheld: readonly Quad[];
   /** Exact duplicates dropped before insertion. */
   readonly discardedDuplicates: number;
@@ -93,6 +98,18 @@ export interface LegacyAgentProfileGateResultV1 {
 }
 
 /**
+ * What one derived root's quads are to do. Assigned by the lookup phases, consumed once
+ * by the final pass. Deliberately not exported: it is this module's internal plan.
+ */
+type RootDispositionV1 =
+  /** No applied signed record: ordinary legacy behaviour, untouched. */
+  | { readonly kind: 'uncovered' }
+  /** A batch cap stopped us classifying it, so nothing may be inserted unverified. */
+  | { readonly kind: 'unclassified' }
+  /** Covered by an applied record; each quad is compared against its exact projection. */
+  | { readonly kind: 'covered' };
+
+/**
  * Derive the canonical record root for an arbitrary inbound subject.
  *
  * Exact `did:dkg:agent:<address>` subjects are their own root; a `/.well-known/`
@@ -100,6 +117,11 @@ export interface LegacyAgentProfileGateResultV1 {
  * Every candidate is confirmed by core's owned-subject classifier rather than by
  * restating its string rules here, so this can never admit a shape core rejects.
  * Unknown shapes stay uncovered and take the legacy path.
+ *
+ * Known gap, filed rather than papered over: the separators tried here are fixed, while
+ * the authoritative shape set is core's module-private policy table. A future owned-subject
+ * shape using a new separator would derive to null and be treated as uncovered. Core is
+ * the only place that can see the full set, which is why reverse derivation belongs there.
  */
 export function deriveLegacyAgentProfileRootV1(subject: string): string | null {
   if (typeof subject !== 'string' || subject.length === 0) return null;
@@ -117,9 +139,14 @@ export function deriveLegacyAgentProfileRootV1(subject: string): string | null {
   return null;
 }
 
-/** Graphless identity. Projection membership is a triple property; the page's graph is not. */
-function tripleKeyV1(quad: Quad): string {
-  return JSON.stringify([quad.subject, quad.predicate, quad.object]);
+/**
+ * Projection membership identity: the canonical graphless N-Triples line, the same
+ * encoding storage's projection inspection uses. Graph is deliberately excluded — the
+ * applied projection lives in its own graph while the legacy page carries the aggregate
+ * `agents` graph, so a graph-sensitive key would call every real duplicate a conflict.
+ */
+function projectionKeyV1(quad: Quad): string {
+  return new TextDecoder().decode(tripleContentV10(quad.subject, quad.predicate, quad.object));
 }
 
 export interface LegacyAgentProfileGateV1 {
@@ -138,148 +165,112 @@ export function createLegacyAgentProfileGateV1(
       quads: readonly Quad[],
       signal?: AbortSignal,
     ): Promise<LegacyAgentProfileGateResultV1> {
-      // Partition first: one pass, one derivation per quad, no query.
-      const byRoot = new Map<string, Quad[]>();
-      const uncovered: Quad[] = [];
-      for (const quad of quads) {
+      // Phase 1 — derive once per quad, keeping the result positionally so the final pass
+      // never re-derives. No query.
+      const rootByIndex: (string | null)[] = new Array(quads.length);
+      const roots = new Set<string>();
+      for (const [index, quad] of quads.entries()) {
         const root = deriveLegacyAgentProfileRootV1(quad.subject);
-        if (root === null) {
-          uncovered.push(quad);
-          continue;
-        }
-        const existing = byRoot.get(root);
-        if (existing === undefined) byRoot.set(root, [quad]);
-        else existing.push(quad);
+        rootByIndex[index] = root;
+        if (root !== null) roots.add(root);
       }
 
-      if (byRoot.size === 0) {
-        return frozenResult({
-          insert: uncovered,
-          withheld: [],
-          discardedDuplicates: 0,
-          conflictedRoots: 0,
-          unclassifiedRoots: 0,
-          storeRequests: 0,
-        });
-      }
-
-      // A page may derive more roots than one batch may carry. Selection is sorted so the
-      // same page always selects the same roots, and the remainder is withheld rather than
-      // inserted on an unverified assumption that it is uncovered — absence of a lookup is
-      // not absence of a record.
-      const derivedRoots = [...byRoot.keys()].sort();
-      const selected = derivedRoots.slice(0, LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1);
-      const deferred = derivedRoots.slice(LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1);
-
-      const withheld: Quad[] = [];
-      const recovery = new Map<string, LegacyAgentProfileWithholdReasonV1>();
-      for (const root of deferred) {
-        withheld.push(...(byRoot.get(root) ?? []));
-        recovery.set(root, 'unclassified');
-      }
-
-      const applied = await lookup.lookupAppliedRoots(selected, signal);
-      let storeRequests = 1;
-
-      const appliedByRoot = new Map<string, LegacyAgentProfileAppliedRootV1>();
-      for (const record of applied) {
-        if (byRoot.has(record.root)) appliedByRoot.set(record.root, record);
-      }
-
-      // Only covered roots need a membership read, and only for subjects the page touched.
-      const subjects = new Set<string>();
-      for (const [root, record] of appliedByRoot) {
-        const owned = new Set(record.ownedSubjects);
-        for (const quad of byRoot.get(root) ?? []) {
-          if (owned.has(quad.subject)) subjects.add(quad.subject);
-        }
-      }
-
-      // A covered root whose page subjects overflow the membership batch cannot be
-      // classified exactly, so it is withheld whole rather than partly compared.
-      const membershipSubjects: string[] = [];
-      const overflowed = new Set<string>();
-      if (subjects.size > SYSTEM_RECORD_MAX_OWNED_SUBJECTS) {
-        for (const [root] of appliedByRoot) {
-          withheld.push(...(byRoot.get(root) ?? []));
-          recovery.set(root, 'unclassified');
-          overflowed.add(root);
-        }
-      } else {
-        membershipSubjects.push(...[...subjects].sort());
-      }
-
+      const disposition = new Map<string, RootDispositionV1>();
+      let storeRequests = 0;
       const projection = new Set<string>();
-      if (membershipSubjects.length > 0) {
-        const rows = await lookup.lookupProjectionMembership(membershipSubjects, signal);
+
+      if (roots.size > 0) {
+        // Phase 2 — a page may derive more roots than one batch may carry. Selection is
+        // sorted so the same page always selects the same roots; the remainder is withheld
+        // rather than inserted on an unverified assumption that it is uncovered, because
+        // absence of a lookup is not absence of a record.
+        const derivedRoots = [...roots].sort();
+        const selected = derivedRoots.slice(0, LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1);
+        for (const root of derivedRoots.slice(LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1)) {
+          disposition.set(root, { kind: 'unclassified' });
+        }
+
+        // Phase 3 — one batched read maps the selected roots to applied records.
+        const applied = await lookup.lookupAppliedRoots(selected, signal);
         storeRequests += 1;
-        if (rows.length > SYSTEM_RECORD_MAX_PROJECTION_QUADS) {
-          // An over-cap response cannot be trusted as the exact applied set, so every
-          // covered root falls back to withhold-and-recover rather than being compared
-          // against a truncated projection.
-          for (const [root] of appliedByRoot) {
-            if (overflowed.has(root)) continue;
-            withheld.push(...(byRoot.get(root) ?? []));
-            recovery.set(root, 'unclassified');
-            overflowed.add(root);
+        const appliedByRoot = new Map<string, LegacyAgentProfileAppliedRootV1>();
+        for (const record of applied) {
+          if (roots.has(record.root)) appliedByRoot.set(record.root, record);
+        }
+        for (const root of selected) {
+          disposition.set(root, appliedByRoot.has(root) ? { kind: 'covered' } : { kind: 'uncovered' });
+        }
+
+        // Phase 4 — one batched membership read, for covered roots only and only for the
+        // subjects this page actually touched.
+        const subjects = new Set<string>();
+        for (const [root, record] of appliedByRoot) {
+          const owned = new Set(record.ownedSubjects);
+          for (const [index, quad] of quads.entries()) {
+            if (rootByIndex[index] === root && owned.has(quad.subject)) subjects.add(quad.subject);
           }
-        } else {
-          for (const row of rows) projection.add(tripleKeyV1(row));
+        }
+
+        // A covered root whose page subjects overflow the membership batch cannot be
+        // classified exactly, so it is withheld whole rather than partly compared.
+        if (subjects.size > SYSTEM_RECORD_MAX_OWNED_SUBJECTS) {
+          for (const root of appliedByRoot.keys()) disposition.set(root, { kind: 'unclassified' });
+        } else if (subjects.size > 0) {
+          const rows = await lookup.lookupProjectionMembership([...subjects].sort(), signal);
+          storeRequests += 1;
+          if (rows.length > SYSTEM_RECORD_MAX_PROJECTION_QUADS) {
+            // An over-cap response cannot be trusted as the exact applied set, so every
+            // covered root falls back to withhold rather than being compared against a
+            // truncated projection.
+            for (const root of appliedByRoot.keys()) disposition.set(root, { kind: 'unclassified' });
+          } else {
+            for (const row of rows) projection.add(projectionKeyV1(row));
+          }
         }
       }
 
-      const insert: Quad[] = [...uncovered];
-      let discardedDuplicates = 0;
+      // Phase 5 — one materialization pass over the page, in arrival order.
+      const insert: Quad[] = [];
+      const withheld: Quad[] = [];
       const conflicted = new Set<string>();
-      for (const root of selected) {
-        const pageQuads = byRoot.get(root) ?? [];
-        const record = appliedByRoot.get(root);
-        if (record === undefined) {
-          // No applied signed record: ordinary legacy behaviour, untouched.
-          insert.push(...pageQuads);
+      let discardedDuplicates = 0;
+      let unclassifiedRoots = 0;
+      for (const [index, quad] of quads.entries()) {
+        const root = rootByIndex[index];
+        const plan = root === null ? undefined : disposition.get(root);
+        if (root === null || plan === undefined || plan.kind === 'uncovered') {
+          insert.push(quad);
           continue;
         }
-        if (overflowed.has(root)) continue;
-        for (const quad of pageQuads) {
-          if (projection.has(tripleKeyV1(quad))) {
-            discardedDuplicates += 1;
-            continue;
-          }
-          // Additional or different for a covered root: never inserted.
+        if (plan.kind === 'unclassified') {
           withheld.push(quad);
-          conflicted.add(root);
+          continue;
         }
+        if (projection.has(projectionKeyV1(quad))) {
+          discardedDuplicates += 1;
+          continue;
+        }
+        // Additional or different for a covered root: never inserted.
+        withheld.push(quad);
+        conflicted.add(root);
       }
-      for (const root of conflicted) recovery.set(root, 'conflict');
+      for (const plan of disposition.values()) {
+        if (plan.kind === 'unclassified') unclassifiedRoots += 1;
+      }
 
       // The roots owing exact signed recovery stay inside this module and surface only as
       // counts. The record-dirty mechanism that would consume them does not exist yet, and
       // it is shared with plan :927 ("generic deletes/updates ... must use the record
       // capability or atomically dirty that record"), so it belongs where both consumers
       // reach it rather than as an interface here with nothing on the other end.
-      // Withholding alone already holds :1505 for this seam.
-      let unclassifiedRoots = 0;
-      for (const reason of recovery.values()) if (reason === 'unclassified') unclassifiedRoots += 1;
-
-      return frozenResult({
-        insert,
-        withheld,
+      return Object.freeze({
+        insert: Object.freeze(insert),
+        withheld: Object.freeze(withheld),
         discardedDuplicates,
         conflictedRoots: conflicted.size,
         unclassifiedRoots,
         storeRequests,
-      });
+      }) as LegacyAgentProfileGateResultV1;
     },
   });
-}
-
-function frozenResult(result: LegacyAgentProfileGateResultV1): LegacyAgentProfileGateResultV1 {
-  return Object.freeze({
-    insert: Object.freeze([...result.insert]),
-    withheld: Object.freeze([...result.withheld]),
-    discardedDuplicates: result.discardedDuplicates,
-    conflictedRoots: result.conflictedRoots,
-    unclassifiedRoots: result.unclassifiedRoots,
-    storeRequests: result.storeRequests,
-  }) as LegacyAgentProfileGateResultV1;
 }

--- a/packages/agent/src/system-records/legacy-profile-gate-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-v1.ts
@@ -70,7 +70,15 @@ export interface LegacyAgentProfileAppliedRootV1 {
  * page and never per root or per quad.
  */
 export interface LegacyAgentProfileGateLookupV1 {
-  /** Request one: which of these derived roots carry an applied signed record. */
+  /**
+   * Request one: which of these derived roots carry an applied signed record.
+   *
+   * :926 puts the owned-subject lists in this response and caps it at 1 MiB. That byte
+   * cap belongs to the implementation, because by the time the gate holds the result the
+   * bytes have already been transferred — the gate can only refuse to trust an oversized
+   * answer, which it does per record below. An implementation that cannot honour the cap
+   * must return fewer roots rather than a larger response.
+   */
   lookupAppliedRoots(
     roots: readonly string[],
     signal?: AbortSignal,
@@ -139,14 +147,14 @@ export function deriveLegacyAgentProfileRootV1(subject: string): string | null {
   return null;
 }
 
+const PROJECTION_KEY_DECODER_V1 = new TextDecoder();
+
 /**
  * Projection membership identity: the canonical graphless N-Triples line, the same
  * encoding storage's projection inspection uses. Graph is deliberately excluded — the
  * applied projection lives in its own graph while the legacy page carries the aggregate
  * `agents` graph, so a graph-sensitive key would call every real duplicate a conflict.
  */
-const PROJECTION_KEY_DECODER_V1 = new TextDecoder();
-
 function projectionKeyV1(quad: Quad): string {
   // The decoder is module-scope on purpose: this runs once per projection row and again
   // per page quad, so a per-call decoder would allocate up to 10,000 of them on a
@@ -201,10 +209,24 @@ export function createLegacyAgentProfileGateV1(
         const applied = await lookup.lookupAppliedRoots(selected, signal);
         storeRequests += 1;
         const appliedByRoot = new Map<string, LegacyAgentProfileAppliedRootV1>();
+        const untrusted = new Set<string>();
         for (const record of applied) {
-          if (roots.has(record.root)) appliedByRoot.set(record.root, record);
+          if (!roots.has(record.root)) continue;
+          // Fail closed on data crossing the injected lookup boundary. A well-formed
+          // record cannot exceed the owned-subject cap, so an over-cap table means this
+          // response is not the exact applied set and its root must not be classified
+          // against it — withholding is the safe answer, insertion is not.
+          if (record.ownedSubjects.length > SYSTEM_RECORD_MAX_OWNED_SUBJECTS) {
+            untrusted.add(record.root);
+            continue;
+          }
+          appliedByRoot.set(record.root, record);
         }
         for (const root of selected) {
+          if (untrusted.has(root)) {
+            disposition.set(root, { kind: 'unclassified' });
+            continue;
+          }
           disposition.set(root, appliedByRoot.has(root) ? { kind: 'covered' } : { kind: 'uncovered' });
         }
 

--- a/packages/agent/src/system-records/legacy-profile-gate-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-v1.ts
@@ -145,8 +145,15 @@ export function deriveLegacyAgentProfileRootV1(subject: string): string | null {
  * applied projection lives in its own graph while the legacy page carries the aggregate
  * `agents` graph, so a graph-sensitive key would call every real duplicate a conflict.
  */
+const PROJECTION_KEY_DECODER_V1 = new TextDecoder();
+
 function projectionKeyV1(quad: Quad): string {
-  return new TextDecoder().decode(tripleContentV10(quad.subject, quad.predicate, quad.object));
+  // The decoder is module-scope on purpose: this runs once per projection row and again
+  // per page quad, so a per-call decoder would allocate up to 10,000 of them on a
+  // maximum-size page — and :926 exists to bound exactly that per-page cost.
+  return PROJECTION_KEY_DECODER_V1.decode(
+    tripleContentV10(quad.subject, quad.predicate, quad.object),
+  );
 }
 
 export interface LegacyAgentProfileGateV1 {
@@ -254,6 +261,11 @@ export function createLegacyAgentProfileGateV1(
         withheld.push(quad);
         conflicted.add(root);
       }
+      // These two counts are disjoint today — a root is either withheld whole by a cap or
+      // classified and possibly conflicted, never both — but they derive asymmetrically:
+      // one from a set built in the pass above, one from a scan of the dispositions. If a
+      // third withhold reason is ever added, derive BOTH from `disposition`, or the scan
+      // will adapt and the set silently will not.
       for (const plan of disposition.values()) {
         if (plan.kind === 'unclassified') unclassifiedRoots += 1;
       }

--- a/packages/agent/test/system-record-legacy-gate-v1.test.ts
+++ b/packages/agent/test/system-record-legacy-gate-v1.test.ts
@@ -363,20 +363,52 @@ describe('LegacyAgentProfileGateV1 — bounded store requests (:926)', () => {
   });
 
   it('withholds covered roots whose page subjects exceed the membership batch', async () => {
-    const owned = Array.from(
+    // TWO records, each with a VALID owned-subject table, whose combined page subjects
+    // exceed the membership cap. Deliberately kept under the per-record cap so this
+    // exercises the aggregate guard and not the untrusted-response guard below — without
+    // that separation, one guard would silently take credit for the other's kill.
+    const each = Math.floor(SYSTEM_RECORD_MAX_OWNED_SUBJECTS / 2) + 100;
+    const ownedFor = (root: string) => Array.from(
+      { length: each },
+      (_, i) => deriveAgentProfileOwnedSubjectV1(root, 'capability', i + 1),
+    );
+    const first = ownedFor(ROOT);
+    const second = ownedFor(OTHER_ROOT);
+    const applied = [
+      { root: ROOT, ownedSubjects: first },
+      { root: OTHER_ROOT, ownedSubjects: second },
+    ];
+    const { lookup, lookupProjectionMembership } = fakeLookup(applied, []);
+    const page = [...first, ...second].map((subject) => quad(subject, 'p', 'o'));
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(page);
+
+    expect(each).toBeLessThanOrEqual(SYSTEM_RECORD_MAX_OWNED_SUBJECTS);
+    expect(first.length + second.length).toBeGreaterThan(SYSTEM_RECORD_MAX_OWNED_SUBJECTS);
+    expect(result.insert).toEqual([]);
+    expect(result.withheld).toHaveLength(page.length);
+    expect(result.unclassifiedRoots).toBe(2);
+    // The over-cap membership read is never issued.
+    expect(lookupProjectionMembership).not.toHaveBeenCalled();
+    expect(result.storeRequests).toBe(1);
+  });
+
+  // The lookup port is an injected boundary, so its answer is incoming input. A
+  // well-formed record cannot exceed the owned-subject cap, so an over-cap table means
+  // the response is not the exact applied set; withholding is the only safe reading.
+  it('refuses an applied record whose owned-subject table exceeds the cap', async () => {
+    const oversized = Array.from(
       { length: SYSTEM_RECORD_MAX_OWNED_SUBJECTS + 1 },
       (_, i) => deriveAgentProfileOwnedSubjectV1(ROOT, 'capability', i + 1),
     );
-    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: owned };
+    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: oversized };
     const { lookup, lookupProjectionMembership } = fakeLookup([applied], []);
 
-    const result = await createLegacyAgentProfileGateV1(lookup)
-      .filterPage(owned.map((subject) => quad(subject, 'p', 'o')));
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([quad(ROOT, 'p', 'o')]);
 
     expect(result.insert).toEqual([]);
-    expect(result.withheld).toHaveLength(owned.length);
+    expect(result.withheld).toHaveLength(1);
     expect(result.unclassifiedRoots).toBe(1);
-    // The over-cap membership read is never issued.
     expect(lookupProjectionMembership).not.toHaveBeenCalled();
     expect(result.storeRequests).toBe(1);
   });

--- a/packages/agent/test/system-record-legacy-gate-v1.test.ts
+++ b/packages/agent/test/system-record-legacy-gate-v1.test.ts
@@ -4,6 +4,11 @@
  * Both the module and this file are greenfield, so every assertion here is a contract
  * from day one rather than a characterization of observed behaviour. Each block cites the
  * plan sentence it pins.
+ *
+ * Fixture discipline that matters for the key contract: the applied projection is modelled
+ * GRAPHLESS while the inbound legacy page carries the aggregate `agents` graph, because
+ * that is how they really differ. Using one graph for both would let a regression that
+ * started comparing `graph` pass every duplicate test while withholding real duplicates.
  */
 import { describe, expect, it, vi } from 'vitest';
 
@@ -32,8 +37,14 @@ const ROOT = rootAt(1);
 const OTHER_ROOT = rootAt(2);
 const X25519_SUFFIX = 'a'.repeat(32);
 
+/** An inbound legacy quad: carries the aggregate agents graph. */
 function quad(subject: string, predicate: string, object: string): Quad {
   return { subject, predicate, object, graph: AGENTS_GRAPH };
+}
+
+/** An applied-projection row as the store really holds it: graphless. */
+function projectionRow(subject: string, predicate: string, object: string): Quad {
+  return { subject, predicate, object, graph: '' };
 }
 
 /**
@@ -57,9 +68,15 @@ describe('deriveLegacyAgentProfileRootV1 (:926 root derivation)', () => {
     expect(deriveLegacyAgentProfileRootV1(ROOT)).toBe(ROOT);
   });
 
-  it('strips a /.well-known/ descendant back to its root', () => {
+  it('round-trips every owned-subject shape core can derive', () => {
+    // If core changes an existing shape, this fails. It cannot detect a NEW shape with a
+    // new separator — core's policy table is module-private — which is why reverse
+    // derivation belongs in core; recorded on the PR rather than silently accepted.
     expect(deriveLegacyAgentProfileRootV1(deriveAgentProfileOwnedSubjectV1(ROOT, 'hosting'))).toBe(ROOT);
+    expect(deriveLegacyAgentProfileRootV1(deriveAgentProfileOwnedSubjectV1(ROOT, 'registration'))).toBe(ROOT);
     expect(deriveLegacyAgentProfileRootV1(deriveAgentProfileOwnedSubjectV1(ROOT, 'capability', 7))).toBe(ROOT);
+    expect(deriveLegacyAgentProfileRootV1(deriveAgentProfileOwnedSubjectV1(ROOT, 'offering', 3))).toBe(ROOT);
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}#x25519-${X25519_SUFFIX}`)).toBe(ROOT);
   });
 
   it('strips only a validated x25519 fragment', () => {
@@ -76,6 +93,8 @@ describe('deriveLegacyAgentProfileRootV1 (:926 root derivation)', () => {
     expect(deriveLegacyAgentProfileRootV1('https://example.com/agent')).toBeNull();
     expect(deriveLegacyAgentProfileRootV1(`${ROOT}/other`)).toBeNull();
     expect(deriveLegacyAgentProfileRootV1(`${ROOT}/.well-known/genid/unknown`)).toBeNull();
+    // Strips at `/.well-known/` but core's genid prefix is narrower, so this falls out.
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}/.well-known/other/thing`)).toBeNull();
     expect(deriveLegacyAgentProfileRootV1(`did:dkg:agent:0x${'A'.repeat(40)}`)).toBeNull();
     expect(deriveLegacyAgentProfileRootV1('')).toBeNull();
   });
@@ -116,13 +135,29 @@ describe('LegacyAgentProfileGateV1 — uncovered roots keep legacy behaviour (:9
     expect(lookupProjectionMembership).not.toHaveBeenCalled();
     expect(result.storeRequests).toBe(1);
   });
+
+  // A passthrough page must come out in the order it went in: "unchanged" includes order,
+  // and root selection is sorted for batching, which must not leak into emission.
+  it('preserves arrival order across interleaved unknown-shape and derived-root quads', async () => {
+    const { lookup } = fakeLookup([], []);
+    const quads = [
+      quad(OTHER_ROOT, 'p', 'o'),
+      quad('urn:x', 'p', 'o'),
+      quad(ROOT, 'p', 'o'),
+      quad('https://example.com/a', 'p', 'o'),
+    ];
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(quads);
+
+    expect(result.insert).toEqual(quads);
+  });
 });
 
 // :924 — exact duplicates discarded before store insertion; conflicting quads held aside.
 // :925 — streaming per quad, never page equality.
 describe('LegacyAgentProfileGateV1 — covered roots (:924, :925)', () => {
   const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: [ROOT] };
-  const projection = [quad(ROOT, 'p', 'o1'), quad(ROOT, 'p', 'o2')];
+  const projection = [projectionRow(ROOT, 'p', 'o1'), projectionRow(ROOT, 'p', 'o2')];
 
   it('discards exact duplicates before insertion', async () => {
     const { lookup } = fakeLookup([applied], projection);
@@ -137,6 +172,19 @@ describe('LegacyAgentProfileGateV1 — covered roots (:924, :925)', () => {
     expect(result.withheld).toEqual([]);
     expect(result.conflictedRoots).toBe(0);
     expect(result.storeRequests).toBe(2);
+  });
+
+  // The applied projection is graphless and the legacy page carries the agents graph, so
+  // this fails the moment membership identity starts including `graph`.
+  it('matches duplicates across differing graphs', async () => {
+    const { lookup } = fakeLookup([applied], projection);
+
+    const result = await createLegacyAgentProfileGateV1(lookup)
+      .filterPage([{ subject: ROOT, predicate: 'p', object: 'o1', graph: AGENTS_GRAPH }]);
+
+    expect(result.discardedDuplicates).toBe(1);
+    expect(result.withheld).toEqual([]);
+    expect(result.conflictedRoots).toBe(0);
   });
 
   it('withholds a conflicting quad and counts the root as conflicted', async () => {
@@ -199,14 +247,14 @@ describe('LegacyAgentProfileGateV1 — covered roots (:924, :925)', () => {
 // :1505 — "signed state cannot be overwritten".
 describe('LegacyAgentProfileGateV1 — signed state cannot be overwritten (:1505)', () => {
   it('never offers a quad of a covered root for insertion, under any page shape', async () => {
-    const owned = [ROOT, deriveAgentProfileOwnedSubjectV1(ROOT, 'hosting')];
-    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: owned };
-    const projection = [quad(ROOT, 'p', 'o1'), quad(owned[1] as string, 'p', 'o2')];
+    const hosting = deriveAgentProfileOwnedSubjectV1(ROOT, 'hosting');
+    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: [ROOT, hosting] };
+    const projection = [projectionRow(ROOT, 'p', 'o1'), projectionRow(hosting, 'p', 'o2')];
 
     const pages: Quad[][] = [
       [quad(ROOT, 'p', 'o1')],
       [quad(ROOT, 'p', 'rewritten')],
-      [quad(owned[1] as string, 'p', 'o2'), quad(owned[1] as string, 'p', 'extra')],
+      [quad(hosting, 'p', 'o2'), quad(hosting, 'p', 'extra')],
       [quad(`${ROOT}#x25519-${X25519_SUFFIX}`, 'p', 'o')],
       [quad(ROOT, 'p', 'o1'), quad(ROOT, 'p', 'rewritten'), quad(OTHER_ROOT, 'p', 'o')],
     ];
@@ -228,7 +276,7 @@ describe('LegacyAgentProfileGateV1 — a profile split across conflicting legacy
   it('classifies each page independently and only the conflicting page reports a conflict', async () => {
     const hosting = deriveAgentProfileOwnedSubjectV1(ROOT, 'hosting');
     const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: [ROOT, hosting] };
-    const projection = [quad(ROOT, 'p', 'o1'), quad(hosting, 'p', 'o2')];
+    const projection = [projectionRow(ROOT, 'p', 'o1'), projectionRow(hosting, 'p', 'o2')];
 
     const first = fakeLookup([applied], projection);
     const clean = await createLegacyAgentProfileGateV1(first.lookup).filterPage([quad(ROOT, 'p', 'o1')]);
@@ -254,10 +302,11 @@ describe('LegacyAgentProfileGateV1 — bounded store requests (:926)', () => {
   it('classifies a cold page spanning 256 signed roots with exactly two store requests', async () => {
     const roots = Array.from({ length: LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 }, (_, i) => rootAt(i + 1));
     const applied = roots.map((root) => ({ root, ownedSubjects: [root] }));
-    const projection = roots.map((root) => quad(root, 'p', 'o'));
+    const projection = roots.map((root) => projectionRow(root, 'p', 'o'));
+    const page = roots.map((root) => quad(root, 'p', 'o'));
     const { lookup, lookupAppliedRoots, lookupProjectionMembership } = fakeLookup(applied, projection);
 
-    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(projection.map((row) => ({ ...row })));
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(page);
 
     expect(result.discardedDuplicates).toBe(LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1);
     expect(result.insert).toEqual([]);
@@ -272,10 +321,11 @@ describe('LegacyAgentProfileGateV1 — bounded store requests (:926)', () => {
     const total = LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 + 2;
     const roots = Array.from({ length: total }, (_, i) => rootAt(i + 1));
     const applied = roots.map((root) => ({ root, ownedSubjects: [root] }));
-    const projection = roots.map((root) => quad(root, 'p', 'o'));
+    const projection = roots.map((root) => projectionRow(root, 'p', 'o'));
+    const page = roots.map((root) => quad(root, 'p', 'o'));
     const { lookup, lookupAppliedRoots, lookupProjectionMembership } = fakeLookup(applied, projection);
 
-    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(projection.map((row) => ({ ...row })));
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(page);
 
     expect(result.withheld).toHaveLength(2);
     expect(result.unclassifiedRoots).toBe(2);
@@ -290,10 +340,9 @@ describe('LegacyAgentProfileGateV1 — bounded store requests (:926)', () => {
   // classification of the quads that DID fit in the batch.
   it('still classifies in-batch quads exactly while withholding the out-of-batch remainder', async () => {
     const total = LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 + 1;
-    // Sorted selection takes the numerically-lowest roots; index 1 and 2 are in-batch.
     const roots = Array.from({ length: total }, (_, i) => rootAt(i + 1));
     const applied = roots.map((root) => ({ root, ownedSubjects: [root] }));
-    const projection = roots.map((root) => quad(root, 'p', 'o'));
+    const projection = roots.map((root) => projectionRow(root, 'p', 'o'));
     const { lookup } = fakeLookup(applied, projection);
 
     // The page itself must derive more than one batch of roots — the cap is on roots the
@@ -336,7 +385,7 @@ describe('LegacyAgentProfileGateV1 — bounded store requests (:926)', () => {
     const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: [ROOT] };
     const oversized = Array.from(
       { length: SYSTEM_RECORD_MAX_PROJECTION_QUADS + 1 },
-      (_, i) => quad(ROOT, 'p', `o${i}`),
+      (_, i) => projectionRow(ROOT, 'p', `o${i}`),
     );
     const { lookup } = fakeLookup([applied], oversized);
 

--- a/packages/agent/test/system-record-legacy-gate-v1.test.ts
+++ b/packages/agent/test/system-record-legacy-gate-v1.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Contract tests for `LegacyAgentProfileGateV1`, plan lines 924-930.
+ *
+ * Both the module and this file are greenfield, so every assertion here is a contract
+ * from day one rather than a characterization of observed behaviour. Each block cites the
+ * plan sentence it pins.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  deriveAgentProfileOwnedSubjectV1,
+  SYSTEM_RECORD_MAX_OWNED_SUBJECTS,
+  SYSTEM_RECORD_MAX_PROJECTION_QUADS,
+} from '@origintrail-official/dkg-core/system-record-v1';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+import {
+  createLegacyAgentProfileGateV1,
+  deriveLegacyAgentProfileRootV1,
+  LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1,
+  type LegacyAgentProfileAppliedRootV1,
+  type LegacyAgentProfileGateLookupV1,
+} from '../src/system-records/legacy-profile-gate-v1.js';
+
+const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+
+function rootAt(index: number): string {
+  return `did:dkg:agent:0x${index.toString(16).padStart(40, '0')}`;
+}
+
+const ROOT = rootAt(1);
+const OTHER_ROOT = rootAt(2);
+const X25519_SUFFIX = 'a'.repeat(32);
+
+function quad(subject: string, predicate: string, object: string): Quad {
+  return { subject, predicate, object, graph: AGENTS_GRAPH };
+}
+
+/**
+ * A lookup that answers from an explicit applied set and records its call shape, so every
+ * assertion about the store budget is made against calls that actually happened.
+ */
+function fakeLookup(records: readonly LegacyAgentProfileAppliedRootV1[], projection: readonly Quad[]) {
+  const lookupAppliedRoots = vi.fn(async (roots: readonly string[]) =>
+    records.filter((record) => roots.includes(record.root)));
+  const lookupProjectionMembership = vi.fn(async (subjects: readonly string[]) =>
+    projection.filter((row) => subjects.includes(row.subject)));
+  const lookup: LegacyAgentProfileGateLookupV1 = { lookupAppliedRoots, lookupProjectionMembership };
+  return { lookup, lookupAppliedRoots, lookupProjectionMembership };
+}
+
+// :926 — exact `did:dkg:agent:<address>` roots; strip `/.well-known/` from allowed
+// descendants; strip only a validated `#x25519-<32 lowercase hex>` fragment; unknown
+// shapes remain uncovered.
+describe('deriveLegacyAgentProfileRootV1 (:926 root derivation)', () => {
+  it('accepts an exact agent root as its own root', () => {
+    expect(deriveLegacyAgentProfileRootV1(ROOT)).toBe(ROOT);
+  });
+
+  it('strips a /.well-known/ descendant back to its root', () => {
+    expect(deriveLegacyAgentProfileRootV1(deriveAgentProfileOwnedSubjectV1(ROOT, 'hosting'))).toBe(ROOT);
+    expect(deriveLegacyAgentProfileRootV1(deriveAgentProfileOwnedSubjectV1(ROOT, 'capability', 7))).toBe(ROOT);
+  });
+
+  it('strips only a validated x25519 fragment', () => {
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}#x25519-${X25519_SUFFIX}`)).toBe(ROOT);
+    // One hex digit short, one too long, uppercase, and a non-x25519 fragment must all
+    // stay uncovered rather than being stripped to a root that would then be gated.
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}#x25519-${'a'.repeat(31)}`)).toBeNull();
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}#x25519-${'a'.repeat(33)}`)).toBeNull();
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}#x25519-${'A'.repeat(32)}`)).toBeNull();
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}#other`)).toBeNull();
+  });
+
+  it('leaves unknown shapes uncovered', () => {
+    expect(deriveLegacyAgentProfileRootV1('https://example.com/agent')).toBeNull();
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}/other`)).toBeNull();
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}/.well-known/genid/unknown`)).toBeNull();
+    expect(deriveLegacyAgentProfileRootV1(`did:dkg:agent:0x${'A'.repeat(40)}`)).toBeNull();
+    expect(deriveLegacyAgentProfileRootV1('')).toBeNull();
+  });
+
+  it('does not strip a fragment sitting on a non-root path', () => {
+    expect(deriveLegacyAgentProfileRootV1(`${ROOT}/.well-known/genid/hosting#x25519-${X25519_SUFFIX}`))
+      .toBeNull();
+  });
+});
+
+// :924 — "Uncovered roots use legacy insertion." :78 — "Uncovered roots keep current
+// legacy behavior."
+describe('LegacyAgentProfileGateV1 — uncovered roots keep legacy behaviour (:924, :78)', () => {
+  it('inserts every quad and performs no store read when nothing derives a root', async () => {
+    const { lookup, lookupAppliedRoots, lookupProjectionMembership } = fakeLookup([], []);
+    const quads = [quad('https://example.com/a', 'p', 'o'), quad('urn:x', 'p', 'o')];
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(quads);
+
+    expect(result.insert).toEqual(quads);
+    expect(result.withheld).toEqual([]);
+    expect(result.conflictedRoots).toBe(0);
+    expect(result.unclassifiedRoots).toBe(0);
+    expect(result.storeRequests).toBe(0);
+    expect(lookupAppliedRoots).not.toHaveBeenCalled();
+    expect(lookupProjectionMembership).not.toHaveBeenCalled();
+  });
+
+  it('inserts quads for a derived root that carries no applied record', async () => {
+    const { lookup, lookupProjectionMembership } = fakeLookup([], []);
+    const quads = [quad(ROOT, 'p', 'o')];
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(quads);
+
+    expect(result.insert).toEqual(quads);
+    expect(result.conflictedRoots).toBe(0);
+    // The root resolved to no record, so no membership read is owed.
+    expect(lookupProjectionMembership).not.toHaveBeenCalled();
+    expect(result.storeRequests).toBe(1);
+  });
+});
+
+// :924 — exact duplicates discarded before store insertion; conflicting quads held aside.
+// :925 — streaming per quad, never page equality.
+describe('LegacyAgentProfileGateV1 — covered roots (:924, :925)', () => {
+  const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: [ROOT] };
+  const projection = [quad(ROOT, 'p', 'o1'), quad(ROOT, 'p', 'o2')];
+
+  it('discards exact duplicates before insertion', async () => {
+    const { lookup } = fakeLookup([applied], projection);
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([
+      quad(ROOT, 'p', 'o1'),
+      quad(ROOT, 'p', 'o2'),
+    ]);
+
+    expect(result.discardedDuplicates).toBe(2);
+    expect(result.insert).toEqual([]);
+    expect(result.withheld).toEqual([]);
+    expect(result.conflictedRoots).toBe(0);
+    expect(result.storeRequests).toBe(2);
+  });
+
+  it('withholds a conflicting quad and counts the root as conflicted', async () => {
+    const { lookup } = fakeLookup([applied], projection);
+    const conflicting = quad(ROOT, 'p', 'different');
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([
+      quad(ROOT, 'p', 'o1'),
+      conflicting,
+    ]);
+
+    expect(result.discardedDuplicates).toBe(1);
+    expect(result.withheld).toEqual([conflicting]);
+    expect(result.conflictedRoots).toBe(1);
+    expect(result.unclassifiedRoots).toBe(0);
+    expect(result.insert).toEqual([]);
+  });
+
+  it('treats a quad on an unowned subject of a covered root as a conflict', async () => {
+    const { lookup } = fakeLookup([applied], projection);
+    // Derives to a covered root but is absent from the record's owned-subject table.
+    const foreign = quad(deriveAgentProfileOwnedSubjectV1(ROOT, 'hosting'), 'p', 'o');
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([foreign]);
+
+    expect(result.withheld).toEqual([foreign]);
+    expect(result.insert).toEqual([]);
+    expect(result.conflictedRoots).toBe(1);
+  });
+
+  // :925 — "a page that omits other record quads has no deletion/conflict meaning".
+  it('reads omission as neither deletion nor conflict', async () => {
+    const { lookup } = fakeLookup([applied], projection);
+
+    // The page carries a strict subset of the applied projection.
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([quad(ROOT, 'p', 'o1')]);
+
+    expect(result.discardedDuplicates).toBe(1);
+    expect(result.withheld).toEqual([]);
+    expect(result.conflictedRoots).toBe(0);
+    expect(result.unclassifiedRoots).toBe(0);
+  });
+
+  it('classifies a covered and an uncovered root independently in one page', async () => {
+    const { lookup } = fakeLookup([applied], projection);
+    const uncoveredQuad = quad(OTHER_ROOT, 'p', 'o');
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([
+      quad(ROOT, 'p', 'o1'),
+      uncoveredQuad,
+      quad(ROOT, 'p', 'conflict'),
+    ]);
+
+    expect(result.insert).toEqual([uncoveredQuad]);
+    expect(result.discardedDuplicates).toBe(1);
+    expect(result.conflictedRoots).toBe(1);
+  });
+});
+
+// :1505 — "signed state cannot be overwritten".
+describe('LegacyAgentProfileGateV1 — signed state cannot be overwritten (:1505)', () => {
+  it('never offers a quad of a covered root for insertion, under any page shape', async () => {
+    const owned = [ROOT, deriveAgentProfileOwnedSubjectV1(ROOT, 'hosting')];
+    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: owned };
+    const projection = [quad(ROOT, 'p', 'o1'), quad(owned[1] as string, 'p', 'o2')];
+
+    const pages: Quad[][] = [
+      [quad(ROOT, 'p', 'o1')],
+      [quad(ROOT, 'p', 'rewritten')],
+      [quad(owned[1] as string, 'p', 'o2'), quad(owned[1] as string, 'p', 'extra')],
+      [quad(`${ROOT}#x25519-${X25519_SUFFIX}`, 'p', 'o')],
+      [quad(ROOT, 'p', 'o1'), quad(ROOT, 'p', 'rewritten'), quad(OTHER_ROOT, 'p', 'o')],
+    ];
+
+    for (const page of pages) {
+      const { lookup } = fakeLookup([applied], projection);
+      const result = await createLegacyAgentProfileGateV1(lookup).filterPage(page);
+      // Leakage is detected with an independent literal prefix rather than by calling the
+      // production deriver: an assertion routed through the code under test would pass
+      // vacuously the moment that deriver regressed to returning null.
+      const leaked = result.insert.filter((row) => row.subject.startsWith(ROOT));
+      expect(leaked).toEqual([]);
+    }
+  });
+});
+
+// :925 — "Page splits across root, nested, and key subjects are expected."
+describe('LegacyAgentProfileGateV1 — a profile split across conflicting legacy pages (:925)', () => {
+  it('classifies each page independently and only the conflicting page reports a conflict', async () => {
+    const hosting = deriveAgentProfileOwnedSubjectV1(ROOT, 'hosting');
+    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: [ROOT, hosting] };
+    const projection = [quad(ROOT, 'p', 'o1'), quad(hosting, 'p', 'o2')];
+
+    const first = fakeLookup([applied], projection);
+    const clean = await createLegacyAgentProfileGateV1(first.lookup).filterPage([quad(ROOT, 'p', 'o1')]);
+
+    const second = fakeLookup([applied], projection);
+    const dirty = await createLegacyAgentProfileGateV1(second.lookup)
+      .filterPage([quad(hosting, 'p', 'rewritten')]);
+
+    expect(clean.discardedDuplicates).toBe(1);
+    expect(clean.conflictedRoots).toBe(0);
+    expect(dirty.withheld).toHaveLength(1);
+    expect(dirty.conflictedRoots).toBe(1);
+    // Neither page inserted anything for the covered root.
+    expect(clean.insert).toEqual([]);
+    expect(dirty.insert).toEqual([]);
+  });
+});
+
+// :926 — at most two physical store requests for one legacy page; cap exceeded means the
+// unclassified signed-root quads are withheld, and "absence never conflicts, so received
+// quads in the batch are classified independently against the exact applied set".
+describe('LegacyAgentProfileGateV1 — bounded store requests (:926)', () => {
+  it('classifies a cold page spanning 256 signed roots with exactly two store requests', async () => {
+    const roots = Array.from({ length: LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 }, (_, i) => rootAt(i + 1));
+    const applied = roots.map((root) => ({ root, ownedSubjects: [root] }));
+    const projection = roots.map((root) => quad(root, 'p', 'o'));
+    const { lookup, lookupAppliedRoots, lookupProjectionMembership } = fakeLookup(applied, projection);
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(projection.map((row) => ({ ...row })));
+
+    expect(result.discardedDuplicates).toBe(LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1);
+    expect(result.insert).toEqual([]);
+    expect(result.conflictedRoots).toBe(0);
+    expect(result.storeRequests).toBe(2);
+    expect(lookupAppliedRoots).toHaveBeenCalledTimes(1);
+    expect(lookupProjectionMembership).toHaveBeenCalledTimes(1);
+    expect(lookupAppliedRoots.mock.calls[0]?.[0]).toHaveLength(LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1);
+  });
+
+  it('withholds roots beyond the batch instead of inserting them unclassified', async () => {
+    const total = LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 + 2;
+    const roots = Array.from({ length: total }, (_, i) => rootAt(i + 1));
+    const applied = roots.map((root) => ({ root, ownedSubjects: [root] }));
+    const projection = roots.map((root) => quad(root, 'p', 'o'));
+    const { lookup, lookupAppliedRoots, lookupProjectionMembership } = fakeLookup(applied, projection);
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(projection.map((row) => ({ ...row })));
+
+    expect(result.withheld).toHaveLength(2);
+    expect(result.unclassifiedRoots).toBe(2);
+    expect(result.insert).toEqual([]);
+    // Still at most two physical reads, however many roots the page derived.
+    expect(result.storeRequests).toBe(2);
+    expect(lookupAppliedRoots).toHaveBeenCalledTimes(1);
+    expect(lookupProjectionMembership).toHaveBeenCalledTimes(1);
+  });
+
+  // The composition of the two rules: exceeding the root cap must not degrade the
+  // classification of the quads that DID fit in the batch.
+  it('still classifies in-batch quads exactly while withholding the out-of-batch remainder', async () => {
+    const total = LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 + 1;
+    // Sorted selection takes the numerically-lowest roots; index 1 and 2 are in-batch.
+    const roots = Array.from({ length: total }, (_, i) => rootAt(i + 1));
+    const applied = roots.map((root) => ({ root, ownedSubjects: [root] }));
+    const projection = roots.map((root) => quad(root, 'p', 'o'));
+    const { lookup } = fakeLookup(applied, projection);
+
+    // The page itself must derive more than one batch of roots — the cap is on roots the
+    // PAGE derives, not on records that exist. Root index 1 carries a conflicting object;
+    // every other in-batch root repeats its applied quad exactly.
+    const page: Quad[] = roots.map((root, index) =>
+      quad(root, 'p', index === 1 ? 'rewritten' : 'o'));
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(page);
+
+    // 256 selected roots: one conflicts, the other 255 are exact duplicates. The single
+    // out-of-batch root is withheld unverified without being called a conflict.
+    expect(result.discardedDuplicates).toBe(LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 - 1);
+    expect(result.conflictedRoots).toBe(1);
+    expect(result.unclassifiedRoots).toBe(1);
+    expect(result.withheld).toHaveLength(2);
+    expect(result.insert).toEqual([]);
+    expect(result.storeRequests).toBe(2);
+  });
+
+  it('withholds covered roots whose page subjects exceed the membership batch', async () => {
+    const owned = Array.from(
+      { length: SYSTEM_RECORD_MAX_OWNED_SUBJECTS + 1 },
+      (_, i) => deriveAgentProfileOwnedSubjectV1(ROOT, 'capability', i + 1),
+    );
+    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: owned };
+    const { lookup, lookupProjectionMembership } = fakeLookup([applied], []);
+
+    const result = await createLegacyAgentProfileGateV1(lookup)
+      .filterPage(owned.map((subject) => quad(subject, 'p', 'o')));
+
+    expect(result.insert).toEqual([]);
+    expect(result.withheld).toHaveLength(owned.length);
+    expect(result.unclassifiedRoots).toBe(1);
+    // The over-cap membership read is never issued.
+    expect(lookupProjectionMembership).not.toHaveBeenCalled();
+    expect(result.storeRequests).toBe(1);
+  });
+
+  it('withholds covered roots when the membership response exceeds the projection cap', async () => {
+    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: [ROOT] };
+    const oversized = Array.from(
+      { length: SYSTEM_RECORD_MAX_PROJECTION_QUADS + 1 },
+      (_, i) => quad(ROOT, 'p', `o${i}`),
+    );
+    const { lookup } = fakeLookup([applied], oversized);
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([quad(ROOT, 'p', 'o0')]);
+
+    expect(result.insert).toEqual([]);
+    expect(result.withheld).toHaveLength(1);
+    expect(result.unclassifiedRoots).toBe(1);
+    expect(result.discardedDuplicates).toBe(0);
+    expect(result.storeRequests).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `LegacyAgentProfileGateV1` (issue #2052, Stack D slice D-8) — the inbound gate that stops replayed legacy `agents` RDF from contradicting an applied signed record.

Legacy aggregate sync replays whole `agents` pages on every reconnect. Once a root carries an applied signed record those pages are redundant at best and contradictory at worst, so this gate partitions incoming quads by the canonical root/subject index **before** any store insertion:

- a quad already present in the applied record's exact projection is **discarded**;
- a quad that is additional or different for a covered root is **withheld** and never offered to the store;
- a quad whose root has no applied record — including an unknown subject shape — falls through to **ordinary legacy insertion, unchanged**.

The invariant is that unsigned legacy bytes never reach the store for a covered root, so applied signed state cannot be overwritten by legacy insertion (plan line 1505).

## Plan conformance — the block is `:924-930`

Implemented against **`:924-930`** (terminator: the `### Numeric resource envelope` heading at `:932`) plus `:78` and `:1505`. The full range matters because `:925-926` carry the operative algorithm, and reading only `:924` would license a per-quad query loop that satisfies every stated criterion while blowing the plan's I/O budget:

- **`:925`** — comparison is *streaming per quad, never page equality*; a page that omits quads the record holds carries no deletion or conflict meaning; page splits across root, nested and key subjects are expected.
- **`:926`** — root derivation is exact (`did:dkg:agent:<address>`; strip `/.well-known/` from allowed descendants; strip only a validated `#x25519-<32 lowercase hex>` fragment; unknown shapes stay uncovered), and one legacy page costs **at most two physical store requests** — one batched roots→heads/owned-subjects read capped at 256 roots, one batched projection-membership read capped at 2,048 subjects / 10,000 quads.

Root derivation does not restate those string rules. It proposes a candidate root by stripping, then confirms it through core's existing `classifyAgentProfileOwnedSubjectV1`, so core stays the single authority and the gate **structurally cannot admit a shape core rejects**. "Strip *only a validated* fragment" falls out for free: 31-hex, 33-hex, uppercase and non-x25519 fragments are simply not stripped.

### Cap behaviour, stated exactly (it differs across the three caps)

`:926`'s "quads in the batch are classified independently" guarantee is implemented **for the root cap only**, and that asymmetry is deliberate:

- **Root cap** — the first 256 sorted roots are selected and classified normally; only the remainder is withheld. Bounded selection, exactly as written.
- **Subject cap and projection-response cap** — the covered set is withheld **whole**, without a bounded re-selection. No in-batch quad is classified independently on those paths.

The second behaviour is *more* conservative than the plan requires. Over-withholding cannot violate `:1505` (it only delays legacy availability), and a bounded re-selection there would add real complexity for availability alone. Flagged explicitly so a future reader diffing the code against `:926` reads deliberate conservatism rather than a defect to "fix".

There is a third, fail-closed guard at the **lookup boundary itself**. `:926` places the owned-subject lists in request one under a 1-MiB response cap; that byte cap belongs to the implementation, since by the time the gate holds the result the bytes have transferred. What the gate can do — and now does — is refuse to trust an oversized answer: a record whose owned-subject table exceeds `SYSTEM_RECORD_MAX_OWNED_SUBJECTS` cannot be well-formed, so its root is marked unclassified and its quads withheld rather than classified against untrustworthy data. The port contract records the byte-cap obligation, and enforcing it in the real batched query belongs to **#53**.

### How `:924`'s "quarantined" is read

At `:924` the verbs are parallel and both take **quads** as their object — "exact duplicate quads are **discarded** … conflicting quads are **quarantined**" — so the quads are held aside. This matches the plan's own idiom at `:926` ("quads … are **withheld**"). The record-level marker is `:925`'s "dirties … **it**", and the plan's record vocabulary is consistently *dirty* (`:923`, `:927`, AC-4).

This reading was confirmed against the code rather than assumed: a record-level `'quarantined'` status is **structurally unreachable** from the ingest path. `system-record-verified-replacement-v1-internal.ts:790-791` throws `'quarantine candidate did not produce active verified facts'` unless the facts are already verified **active**, and `:782-788` requires fork evidence binding that candidate's own head digest; the wire codec (`system-record-inventory-codecs-v1-internal.ts:660-664`) and core's applied-state validator (`:272-276`) mirror the refusal. A legacy quad is unsigned and yields no second signed head, so the quad reading is the only implementable one.

### `:927-930` — scope split

**None of the three lands in this PR's code**, for structural reasons rather than preference:

1. *"Generic deletes/updates … must use the record capability or atomically dirty that record."* — **Not this gate**; it performs no delete or update, it filters an insert. It is the **second consumer of the same record-dirty mechanism**, which is why the marking half defers rather than being minted here.
2. *"Unknown-scope operations rotate `materializationEpoch` before mutation."* — **Not this gate**; it performs no mutation, and its scope is precisely known per derived root/subject, so it is not an unknown-scope operation by construction.
3. *"Activation fails if the audited opaque call sites or measured epoch rotation/revalidation rate can erase the pressure reduction."* — an **activation gate (D-12)**, but D-8 has a stake worth stating: this gate adds **zero opaque call sites** (no store write path whatsoever; two reads through an injected port) and it *reduces* attempted insertions, which is the pressure reduction the clause protects.

## Seam scope — read this before treating D-8 as closing the invariant

**This PR gates the legacy durable-sync seam only.** `agents` also reaches the store through the **RFC-59 changelog lane** (`dkg-agent-lifecycle.ts:5554`): only *private* context graphs divert to the legacy lane (`:5255-5259`) and every system CG is non-private (`dkg-agent-cg-resolve.ts:1952-1954`), so a peer advertising changelog support carries `agents` down the other path.

That second door is slice **D-13** — `:926`'s two-request budget does not transfer to it, since `applyPage` is a different insertion context needing its own measured bound. **The `:1505` invariant is therefore not fully held until both seam gates land, and the coupling is enforced at D-12: activation fails with either door open.** Stating this rather than letting "D-8 done" imply a complete invariant.

## What is deliberately not here

**No production caller, and no exported obligation.** The gate decides and withholds; it does not write, and it exposes no per-root recovery interface. Contaminated roots are tracked internally and surface only as **counts**, because the record-dirty mechanism that would consume them does not exist yet and is shared with `:927` — an exported interface with nothing on the other end is the exported-tested-zero-callers shape, and it is not needed to deliver the safety property. Withholding alone holds `:1505` for this seam. (Measured: there is no logging idiom in any sibling `system-records` module, so "counted" is what is available without inventing a dependency; emission lands with the consumer.)

Three independent blockers to wiring, all measured: storage exports none of the applied-state read path and its `package.json` has three export keys with **no `./dist/*` wildcard**; the D-10 config flag does not exist and the lane is default-off by design; and the record-dirty capability is unavailable — the only producer of applied status `'dirty'` is the shadow-mode tombstone derivation (`next-state:679`), the issue union has exactly three members, and `:927`'s other route ("record capability") has zero src hits.

Consumer filed as **#53**; the core-side reverse-derivation follow-up as **#54**. The gate is intentionally **not** added to any barrel or export map, matching its unexported siblings `receiver-v1` and `reconcile-v1`.

> Trap for reviewers and for whoever picks up the deferred half: **`markDirty` (38 src hits) is not this.** Every hit is `contextGraphMetaProjection.markDirty`, a projection *cache* flag. Wiring to it would compile, run, leave applied status untouched, and hold nothing.

## Files changed

- `packages/agent/src/system-records/legacy-profile-gate-v1.ts` (new) — named by the plan's own file list at `:1430`.
- `packages/agent/test/system-record-legacy-gate-v1.test.ts` (new) — named by the plan's regression command block at `:1440`.

## Test plan

`pnpm --filter @origintrail-official/dkg-agent exec vitest run test/system-record-legacy-gate-v1.test.ts` — **1 file collected, 22/22 passing**. Build via `pnpm exec turbo build --filter=@origintrail-official/dkg-agent` is clean (exit 0), including the package's `test:types` and `test:package-root` gates. Node v22.22.0 per `.nvmrc`.

Both files are greenfield, so every assertion is a **contract from day one** rather than a characterization of observed behaviour; each block cites the plan sentence it pins. Fixture discipline worth noting: the applied projection is modelled **graphless** while the inbound page carries the `agents` graph, because that is how they really differ — using one graph for both would let a regression that started comparing `graph` pass every duplicate test while withholding real duplicates.

| Acceptance | Test |
| --- | --- |
| (a) partition by canonical root/subject index | the `deriveLegacyAgentProfileRootV1` block, incl. a round-trip over all five shapes core can derive |
| (b) exact duplicates discarded before insertion | "discards exact duplicates before insertion", "matches duplicates across differing graphs" |
| (c) conflicting quads held aside | "withholds a conflicting quad…", "treats a quad on an unowned subject…" |
| (d) uncovered roots unchanged | "inserts every quad and performs no store read…", "…carries no applied record", "preserves arrival order across interleaved unknown-shape and derived-root quads" |
| (e) signed state cannot be overwritten | "never offers a quad of a covered root for insertion, under any page shape" — five page shapes |
| `:925` omission rule | "reads omission as neither deletion nor conflict" |
| `:926` two-request budget | "classifies a cold page spanning 256 signed roots with exactly two store requests" |
| `:926` cap-exceeded withhold | three tests: root batch, subject batch, projection response |
| `:926` composition | "still classifies in-batch quads exactly while withholding the out-of-batch remainder" |

Both devnet-matrix constructions named for this slice are present: *a signed apply then a profile split across conflicting legacy pages*, and *a cold-cache legacy page spanning 256 signed roots with at most two store requests*.

### Solo-removal proofs

Every load-bearing predicate was mutated **serially**, applied by exact line number and proven applied by re-reading that line — site-anchored rather than by grep, because several lines share a substring and a bare grep could not say which occurrence moved. The baseline is **committed** before mutating so restoration is provable by content.

Control rows, which are what makes the table mean anything: the **unmutated baseline is GREEN** under the same invocation (without it, a lane red for environmental reasons would report a perfect score).

| Mutant | Site | Mutation | Result |
| --- | --- | --- | --- |
| M1 fragment-validation | `legacy-profile-gate-v1.ts:145` | drop the classifier confirmation | **KILLED** — "strips only a validated x25519 fragment" |
| M2 wellknown-validation | `:140` | same text, well-known branch | **KILLED** — "leaves unknown shapes uncovered" |
| M3 duplicate-discard-guard | `:278` | `if (projection.has(…))` → `if (true)` | **KILLED** — "withholds a conflicting quad…" |
| M4 conflict-withhold | `:283` | `withheld.push` → `insert.push` | **KILLED** — the `:1505` invariant test |
| M12 unclassified-withhold | `:275` | `withheld.push` → `insert.push` | **KILLED** — "withholds roots beyond the batch" |
| M5 deferred-root-disposition | `:205` | `unclassified` → `uncovered` | **KILLED** — "withholds roots beyond the batch" |
| M6 subject-cap | `:245` | → `if (false)` | **KILLED** — "exceed the membership batch" |
| M7 projection-cap | `:250` | → `if (false)` | **KILLED** — "exceeds the projection cap" |
| M13 untrusted-record-refusal | `:219` | → `if (false)` | **KILLED** — "owned-subject table exceeds the cap" |
| M8 uncovered-disposition | `:230` | always `covered` | **KILLED** — "carries no applied record" |
| M9 unclassified-counter | `:292` | drop the reason filter | **KILLED** — "withholds a conflicting quad…" |
| M10 graphless-membership-identity | `:163` | canonical line → JSON tuple **including `graph`** | **KILLED** — "matches duplicates across differing graphs" |
| M11 arrival-order-materialization | `:267` | materialize in sorted order | **KILLED** — "preserves arrival order…" |

Every row records `applied=True` (verified by reading that line back, not by a bare grep) and `restored=True`, and every kill named its own target test. **Line-anchoring is doing real work here, on three separate collisions**: M1/M2 sit on textually identical lines; `withheld.push(quad);` occurs at both `:275` (unclassified) and `:283` (conflict), so M12 and M4 are mutated separately rather than one crediting the other; and M11's loop header appears three times (`187` / `238` / `267`). A substring-matched mutation could have landed on the wrong site in any of the three, and a grep-based applied-proof could not have told.

**M10 is the row that proves a fixture fix rather than asserting one.** Under the previous same-graph fixtures that identical mutant would have **survived** — the suite could not observe graph-sensitivity at all. Measured before/after, not a claim.

*Anomaly status:* an earlier run's post-restore baseline returned red once, and the harness discarded that run's output so it could not be diagnosed. It has **not recurred** — this run's post-restore baseline is green — and the harness now retains the output of any post-restore red and of any mutant that survives or kills without naming its target, so a recurrence will arrive with evidence instead of a bare exit code.
