### PR TITLE
D-10: the four default-off system-record config controls, with a boundary-survival proof

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1405,6 +1405,21 @@ export interface DKGAgentConfig {
   /** Emergency switch for durable/SWM sync execution. Env DKG_DURABLE_SYNC_ENABLED wins. */
   durableSyncEnabled?: boolean;
   /**
+   * #2052 Stack D system-record lane controls (plan :1436). Independent and
+   * DEFAULT-OFF — note the opposite polarity to the emergency switches above,
+   * which default ON. Resolve them through
+   * `system-records/config-controls-v1.ts`, never by reading the raw field, so
+   * the default and the env override stay in one place.
+   * Env DKG_SYSTEM_RECORD_PRODUCER_TRACKING_ENABLED wins.
+   */
+  systemRecordProducerTrackingEnabled?: boolean;
+  /** Advertise the system-record provider protocol. Default OFF. Env DKG_SYSTEM_RECORD_PROVIDER_ADVERTISEMENT_ENABLED wins. */
+  systemRecordProviderAdvertisementEnabled?: boolean;
+  /** Run the system-record requester lane. Default OFF. Env DKG_SYSTEM_RECORD_REQUESTER_LANE_ENABLED wins. */
+  systemRecordRequesterLaneEnabled?: boolean;
+  /** Let legacy sync prefer system-record-capable peers. Default OFF. Env DKG_SYSTEM_RECORD_LEGACY_CAPABLE_PEER_SELECTION_ENABLED wins. */
+  systemRecordLegacyCapablePeerSelectionEnabled?: boolean;
+  /**
    * Global cap for concurrent sync jobs. Defaults to 2; set 0 to disable.
    * Env DKG_SYNC_GLOBAL_MAX_INFLIGHT wins.
    */

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -402,3 +402,14 @@ export { selectSwmSnapshotCoverage } from './sync/requester/shared-memory-sync.j
 // exported. The serve-side resolver `shouldWithholdAgentsDurableMeta` stays
 // internal; only the in-agent lifecycle (at its env boundary) + tests use it.
 export { resolveSyncAgentsMeta, parseBooleanEnv } from './sync/agents-meta-policy.js';
+// #2052 Stack D config controls (plan :1436). The pick helper is exported
+// because the CLI forwarding hop consumes it; the four resolvers are exported
+// for the later slices that will read each control.
+export {
+  pickSystemRecordConfigControlsV1,
+  systemRecordLegacyCapablePeerSelectionEnabledV1,
+  systemRecordProducerTrackingEnabledV1,
+  systemRecordProviderAdvertisementEnabledV1,
+  systemRecordRequesterLaneEnabledV1,
+  type SystemRecordConfigControlsV1,
+} from './system-records/config-controls-v1.js';

--- a/packages/agent/src/system-records/config-controls-v1.ts
+++ b/packages/agent/src/system-records/config-controls-v1.ts
@@ -1,0 +1,111 @@
+/**
+ * Stack D config controls for the system-record lane (plan `:1436`).
+ *
+ * Four INDEPENDENT, DEFAULT-OFF switches: producer tracking, provider
+ * advertisement, requester lane, and legacy capable-peer selection. Independent
+ * means exactly that — no flag gates another, and none is nested under a parent
+ * whose own value could silently disable its children.
+ *
+ * POLARITY, because the neighbours read the other way: `syncReconcilerEnabled`
+ * and its siblings are EMERGENCY OFF switches for behaviour that is on by
+ * default, so they resolve with `true`. These four are the opposite — enable
+ * switches for a lane that does not run yet — so they resolve with `false`.
+ * Copying the neighbouring default would silently activate an unactivated lane.
+ *
+ * FORWARDING, and why this file owns a pick helper rather than open-coding the
+ * hop: `DkgConfig` → `DKGAgentConfig` is a hand-written per-field mapping in
+ * `cli/src/daemon/lifecycle.ts`, so a flag that is declared and documented but
+ * missing from that list typechecks, is settable by an operator, and does
+ * nothing. `pickSystemRecordConfigControlsV1` is the single chokepoint the hop
+ * travels through, and its pinned return type makes a typo at any caller a
+ * compile error. Same construction, and same reason, as core's
+ * `pickNetworkTunables` (`core/src/node.ts:290`).
+ *
+ * These flags gate no production behaviour yet — the lanes they will govern are
+ * default-unused, and each consumer arrives in a later slice. See the PR body
+ * for the per-flag consumer mapping.
+ */
+
+import { resolveBooleanSwitch } from '../sync/backpressure.js';
+
+/**
+ * The exact field set forwarded across the `DkgConfig` → `DKGAgentConfig` hop.
+ * Centralising it as one named type is what makes the forwarding hop
+ * drift-proof; see `pickSystemRecordConfigControlsV1` below.
+ */
+export interface SystemRecordConfigControlsV1 {
+  /** Track locally published agent profiles as signed system records. */
+  systemRecordProducerTrackingEnabled?: boolean;
+  /** Advertise the system-record provider protocol to peers. */
+  systemRecordProviderAdvertisementEnabled?: boolean;
+  /** Run the system-record requester lane. */
+  systemRecordRequesterLaneEnabled?: boolean;
+  /** Let legacy sync prefer system-record-capable peers. */
+  systemRecordLegacyCapablePeerSelectionEnabled?: boolean;
+}
+
+/**
+ * Forward exactly the four controls, field by field.
+ *
+ * The explicit assignment is deliberate rather than a spread: the pinned
+ * `SystemRecordConfigControlsV1` return type turns a typo at any caller into a
+ * compile error, and the one-hot forwarding test catches the failure a type
+ * cannot — a copy-paste-cross that wires one flag's slot from another flag's
+ * source. Four booleans share only two values, so a fixture that sets them all
+ * true would pass while cross-wired; the test rotates a single `true` instead.
+ */
+export function pickSystemRecordConfigControlsV1(
+  source: Partial<SystemRecordConfigControlsV1>,
+): SystemRecordConfigControlsV1 {
+  return {
+    systemRecordProducerTrackingEnabled: source.systemRecordProducerTrackingEnabled,
+    systemRecordProviderAdvertisementEnabled: source.systemRecordProviderAdvertisementEnabled,
+    systemRecordRequesterLaneEnabled: source.systemRecordRequesterLaneEnabled,
+    systemRecordLegacyCapablePeerSelectionEnabled:
+      source.systemRecordLegacyCapablePeerSelectionEnabled,
+  };
+}
+
+/** Resolved value of the producer-tracking control. Default OFF. */
+export function systemRecordProducerTrackingEnabledV1(
+  config: Partial<SystemRecordConfigControlsV1>,
+): boolean {
+  return resolveBooleanSwitch(
+    config.systemRecordProducerTrackingEnabled,
+    'DKG_SYSTEM_RECORD_PRODUCER_TRACKING_ENABLED',
+    false,
+  );
+}
+
+/** Resolved value of the provider-advertisement control. Default OFF. */
+export function systemRecordProviderAdvertisementEnabledV1(
+  config: Partial<SystemRecordConfigControlsV1>,
+): boolean {
+  return resolveBooleanSwitch(
+    config.systemRecordProviderAdvertisementEnabled,
+    'DKG_SYSTEM_RECORD_PROVIDER_ADVERTISEMENT_ENABLED',
+    false,
+  );
+}
+
+/** Resolved value of the requester-lane control. Default OFF. */
+export function systemRecordRequesterLaneEnabledV1(
+  config: Partial<SystemRecordConfigControlsV1>,
+): boolean {
+  return resolveBooleanSwitch(
+    config.systemRecordRequesterLaneEnabled,
+    'DKG_SYSTEM_RECORD_REQUESTER_LANE_ENABLED',
+    false,
+  );
+}
+
+/** Resolved value of the legacy capable-peer-selection control. Default OFF. */
+export function systemRecordLegacyCapablePeerSelectionEnabledV1(
+  config: Partial<SystemRecordConfigControlsV1>,
+): boolean {
+  return resolveBooleanSwitch(
+    config.systemRecordLegacyCapablePeerSelectionEnabled,
+    'DKG_SYSTEM_RECORD_LEGACY_CAPABLE_PEER_SELECTION_ENABLED',
+    false,
+  );
+}

--- a/packages/agent/test/system-record-config-controls-coverage.typecheck.ts
+++ b/packages/agent/test/system-record-config-controls-coverage.typecheck.ts
@@ -1,0 +1,49 @@
+/**
+ * Type-level pin: the forwarding chokepoint must cover EVERY system-record
+ * control declared on the agent config, in both directions.
+ *
+ * Why this exists (review of PR #2255). `pickSystemRecordConfigControlsV1`
+ * forwards exactly the fields named in `SystemRecordConfigControlsV1`. That
+ * closes the silent-drop hazard for the fields IN that interface — but it does
+ * nothing about a FIFTH control added to `DKGAgentConfig` and forgotten here:
+ * the picker would simply not forward it, and it would be documented,
+ * operator-settable and inert. That is the same defect class the chokepoint was
+ * built to prevent, one level up, and neither the pinned return type nor the
+ * CLI wiring test catches it (the type sees no error, and the wiring test
+ * iterates the four names it knows).
+ *
+ * The pin runs in `pnpm run test:types`, which `build` invokes, so it fails the
+ * build rather than a lane someone might not run.
+ *
+ * KNOWN LIMIT, stated rather than implied: this keys on the `systemRecord`
+ * NAME PREFIX, which is a convention, not a contract. A fifth control named
+ * outside that convention escapes the pin. The prefix is what every control in
+ * the ratified `:1436` inventory uses, so the pin holds for the shape the plan
+ * actually describes — but it is a convention pinned by a naming habit, and a
+ * reviewer should know that rather than read this as total.
+ */
+import type { DKGAgentConfig } from '../src/dkg-agent-types.js';
+import type { SystemRecordConfigControlsV1 } from '../src/system-records/config-controls-v1.js';
+
+/** Fails to compile unless `T` is exactly `true`. */
+type Expect<T extends true> = T;
+
+/**
+ * `[X] extends [never]` rather than `X extends never`: the naked form
+ * distributes over unions and silently evaluates to `never` for an empty one,
+ * which would make this pin pass no matter what. The tuple wrapper blocks
+ * distribution, so an empty difference is genuinely `true` and a non-empty one
+ * is genuinely `false`.
+ */
+type IsEmpty<T> = [T] extends [never] ? true : false;
+
+type ControlKeysOnAgentConfig = Extract<keyof DKGAgentConfig, `systemRecord${string}`>;
+
+/** A control the agent config declares but the chokepoint would not forward. */
+type NotForwarded = Exclude<ControlKeysOnAgentConfig, keyof SystemRecordConfigControlsV1>;
+
+/** A control the chokepoint forwards that the agent config does not declare. */
+type NotDeclared = Exclude<keyof SystemRecordConfigControlsV1, ControlKeysOnAgentConfig>;
+
+export type _EveryAgentControlIsForwarded = Expect<IsEmpty<NotForwarded>>;
+export type _EveryForwardedControlIsDeclared = Expect<IsEmpty<NotDeclared>>;

--- a/packages/agent/test/system-record-config-controls-v1.test.ts
+++ b/packages/agent/test/system-record-config-controls-v1.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Contract tests for the Stack D system-record config controls (plan `:1436`).
+ *
+ * Two properties carry this slice, and each has a fixture shape that would hide
+ * a real defect if chosen carelessly:
+ *
+ *  - DEFAULT-OFF. Asserting the declared field is optional proves nothing; the
+ *    claim is about the RESOLVED value with nothing set. The neighbouring
+ *    switches resolve with `true`, so a copied default is a live hazard rather
+ *    than a hypothetical one.
+ *  - INDEPENDENCE / no cross-wiring. Four booleans share only two values, so a
+ *    fixture setting all four `true` and asserting all four `true` passes even
+ *    if two slots are wired from each other's source. Every forwarding case
+ *    below rotates a single `true` instead.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  pickSystemRecordConfigControlsV1,
+  systemRecordLegacyCapablePeerSelectionEnabledV1,
+  systemRecordProducerTrackingEnabledV1,
+  systemRecordProviderAdvertisementEnabledV1,
+  systemRecordRequesterLaneEnabledV1,
+  type SystemRecordConfigControlsV1,
+} from '../src/system-records/config-controls-v1.js';
+
+/** The four controls, each paired with its resolver and env override. */
+const CONTROLS = [
+  {
+    field: 'systemRecordProducerTrackingEnabled',
+    env: 'DKG_SYSTEM_RECORD_PRODUCER_TRACKING_ENABLED',
+    resolve: systemRecordProducerTrackingEnabledV1,
+  },
+  {
+    field: 'systemRecordProviderAdvertisementEnabled',
+    env: 'DKG_SYSTEM_RECORD_PROVIDER_ADVERTISEMENT_ENABLED',
+    resolve: systemRecordProviderAdvertisementEnabledV1,
+  },
+  {
+    field: 'systemRecordRequesterLaneEnabled',
+    env: 'DKG_SYSTEM_RECORD_REQUESTER_LANE_ENABLED',
+    resolve: systemRecordRequesterLaneEnabledV1,
+  },
+  {
+    field: 'systemRecordLegacyCapablePeerSelectionEnabled',
+    env: 'DKG_SYSTEM_RECORD_LEGACY_CAPABLE_PEER_SELECTION_ENABLED',
+    resolve: systemRecordLegacyCapablePeerSelectionEnabledV1,
+  },
+] as const satisfies readonly {
+  field: keyof SystemRecordConfigControlsV1;
+  env: string;
+  resolve: (config: Partial<SystemRecordConfigControlsV1>) => boolean;
+}[];
+
+const ENV_NAMES = CONTROLS.map((control) => control.env);
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const name of ENV_NAMES) {
+    savedEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+});
+
+afterEach(() => {
+  for (const name of ENV_NAMES) {
+    const previous = savedEnv[name];
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
+});
+
+describe('system-record config controls — default OFF (:1436)', () => {
+  it('resolves false for every control when nothing is configured', () => {
+    for (const control of CONTROLS) {
+      expect(control.resolve({}), `${control.field} must default OFF`).toBe(false);
+    }
+  });
+
+  it('resolves false when the field is explicitly undefined', () => {
+    for (const control of CONTROLS) {
+      expect(control.resolve({ [control.field]: undefined })).toBe(false);
+    }
+  });
+
+  it('resolves true only when explicitly enabled', () => {
+    for (const control of CONTROLS) {
+      expect(control.resolve({ [control.field]: true })).toBe(true);
+      expect(control.resolve({ [control.field]: false })).toBe(false);
+    }
+  });
+});
+
+describe('system-record config controls — independence (:1436)', () => {
+  // One-hot: enabling exactly one control must leave the other three OFF. A
+  // fixture enabling all four could not distinguish independence from four
+  // slots reading one shared source.
+  it('enabling one control leaves the other three resolving false', () => {
+    for (const enabled of CONTROLS) {
+      const config: Partial<SystemRecordConfigControlsV1> = { [enabled.field]: true };
+      for (const other of CONTROLS) {
+        const expected = other.field === enabled.field;
+        expect(
+          other.resolve(config),
+          `enabling ${enabled.field} must not change ${other.field}`,
+        ).toBe(expected);
+      }
+    }
+  });
+
+  it('no control is gated by any other being enabled first', () => {
+    // The inverse direction: with the other three explicitly OFF, each control
+    // must still be able to turn on by itself. This is what "independent"
+    // forbids a nested/parent-gated shape from doing.
+    for (const enabled of CONTROLS) {
+      const config = Object.fromEntries(
+        CONTROLS.map((control) => [control.field, control.field === enabled.field]),
+      ) as Partial<SystemRecordConfigControlsV1>;
+      expect(enabled.resolve(config)).toBe(true);
+    }
+  });
+});
+
+describe('system-record config controls — env override', () => {
+  it('lets the env variable win over the configured value, per control', () => {
+    for (const control of CONTROLS) {
+      process.env[control.env] = 'false';
+      expect(control.resolve({ [control.field]: true })).toBe(false);
+      process.env[control.env] = 'true';
+      expect(control.resolve({ [control.field]: false })).toBe(true);
+      delete process.env[control.env];
+    }
+  });
+
+  it('scopes each env variable to its own control', () => {
+    // Setting one env must not enable a different control — the env-name
+    // equivalent of the cross-wiring check below.
+    for (const enabled of CONTROLS) {
+      process.env[enabled.env] = 'true';
+      for (const other of CONTROLS) {
+        expect(other.resolve({}), `${enabled.env} must only affect ${enabled.field}`)
+          .toBe(other.field === enabled.field);
+      }
+      delete process.env[enabled.env];
+    }
+  });
+});
+
+describe('pickSystemRecordConfigControlsV1 — the CLI forwarding chokepoint', () => {
+  it('returns all four keys when the source is empty', () => {
+    // Every key present (even undefined) so the spread at the call site keeps
+    // the property names greppable in the resulting agent config.
+    expect(pickSystemRecordConfigControlsV1({})).toEqual({
+      systemRecordProducerTrackingEnabled: undefined,
+      systemRecordProviderAdvertisementEnabled: undefined,
+      systemRecordRequesterLaneEnabled: undefined,
+      systemRecordLegacyCapablePeerSelectionEnabled: undefined,
+    });
+  });
+
+  // This is the test that would have caught the failure the whole chokepoint
+  // exists to prevent: a control declared and documented but dropped on the
+  // hop typechecks, is operator-settable, and does nothing.
+  it('forwards each control to the SAME-named slot (no copy-paste-cross)', () => {
+    for (const enabled of CONTROLS) {
+      const picked = pickSystemRecordConfigControlsV1({ [enabled.field]: true });
+      for (const other of CONTROLS) {
+        expect(
+          picked[other.field],
+          `${enabled.field} must not land in ${other.field}`,
+        ).toBe(other.field === enabled.field ? true : undefined);
+      }
+    }
+  });
+
+  it('preserves an explicit false rather than dropping it to undefined', () => {
+    // `false` and `undefined` resolve the same today, but they are different
+    // operator intents; dropping one would silently rewrite the config.
+    for (const control of CONTROLS) {
+      expect(pickSystemRecordConfigControlsV1({ [control.field]: false })[control.field])
+        .toBe(false);
+    }
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -104,6 +104,7 @@ export default defineConfig({
       "test/sync-on-connect-retry.test.ts",
       "test/sync-on-connect-churn.test.ts",
       "test/system-context-graph-policy.test.ts",
+      "test/system-record-config-controls-v1.test.ts",
       "test/system-record-requester-v1.test.ts",
       "test/system-record-requester-wire-v1.test.ts",
       "test/system-record-reconcile-transport-v1.test.ts",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -647,6 +647,20 @@ export interface DkgConfig {
   /** Emergency switch for durable/SWM sync execution. Env DKG_DURABLE_SYNC_ENABLED wins. */
   durableSyncEnabled?: boolean;
   /**
+   * #2052 Stack D system-record lane controls (plan :1436). Independent and
+   * DEFAULT-OFF — the opposite polarity to the emergency switches above, which
+   * default ON. They reach the agent through
+   * `pickSystemRecordConfigControlsV1`, the single forwarding chokepoint.
+   * Env DKG_SYSTEM_RECORD_PRODUCER_TRACKING_ENABLED wins.
+   */
+  systemRecordProducerTrackingEnabled?: boolean;
+  /** Advertise the system-record provider protocol. Default OFF. Env DKG_SYSTEM_RECORD_PROVIDER_ADVERTISEMENT_ENABLED wins. */
+  systemRecordProviderAdvertisementEnabled?: boolean;
+  /** Run the system-record requester lane. Default OFF. Env DKG_SYSTEM_RECORD_REQUESTER_LANE_ENABLED wins. */
+  systemRecordRequesterLaneEnabled?: boolean;
+  /** Let legacy sync prefer system-record-capable peers. Default OFF. Env DKG_SYSTEM_RECORD_LEGACY_CAPABLE_PEER_SELECTION_ENABLED wins. */
+  systemRecordLegacyCapablePeerSelectionEnabled?: boolean;
+  /**
    * Global cap for concurrent sync jobs. Defaults to 2; set 0 to disable.
    * Env DKG_SYNC_GLOBAL_MAX_INFLIGHT wins.
    */

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -68,7 +68,7 @@ import {
   MockChainAdapter,
   mergeRpcUsageWindows,
 } from '@origintrail-official/dkg-chain';
-import { DKGAgent, loadOpWallets, KaNumberAllocator, resolveSyncAgentsMeta } from '@origintrail-official/dkg-agent';
+import { DKGAgent, loadOpWallets, KaNumberAllocator, pickSystemRecordConfigControlsV1, resolveSyncAgentsMeta } from '@origintrail-official/dkg-agent';
 import { isExternalBackend } from '@origintrail-official/dkg-storage';
 import { BackpressureMonitor, computeNetworkId, createOperationContext, createLogRedactor, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables, isKaPublishLifecycleDebugLoggingEnabled, setKaPublishLifecycleDebugLoggingEnabled, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import {
@@ -1791,6 +1791,11 @@ export async function runDaemonInner(
     syncOnConnectEnabled: config.syncOnConnectEnabled,
     syncSystemContextGraphsOnConnect: config.syncSystemContextGraphsOnConnect,
     durableSyncEnabled: config.durableSyncEnabled,
+    // #2052 Stack D. Routed through the one pick helper rather than four more
+    // hand-written lines: this mapping is explicit per field, so a control that
+    // is declared and documented but omitted here would typecheck, be settable
+    // by an operator, and silently do nothing.
+    ...pickSystemRecordConfigControlsV1(config),
     syncGlobalMaxInflight: config.syncGlobalMaxInflight,
     syncGlobalLimit: config.syncGlobalLimit,
     syncGlobalQueueLimit: config.syncGlobalQueueLimit,

--- a/packages/cli/test/daemon-system-record-config-controls-wiring.test.ts
+++ b/packages/cli/test/daemon-system-record-config-controls-wiring.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Boundary-survival guard for the #2052 Stack D config controls (plan `:1436`).
+//
+// The agent-package tests prove what the four resolvers and the pick helper DO.
+// They cannot prove the controls SURVIVE the trip, because the trip happens
+// here: `runDaemonInner` builds `DKGAgent.create({...})` from a hand-written
+// per-field mapping, so a control that is declared on `DkgConfig`, documented,
+// and settable by an operator still reaches the agent only if this call site
+// forwards it. Deleting `...pickSystemRecordConfigControlsV1(config)` from
+// `packages/cli/src/daemon/lifecycle.ts` compiles cleanly — every field is
+// optional — and leaves the agent-side suite green. It fails HERE.
+//
+// One-hot on purpose. Four booleans share only two values, so a fixture that
+// sets all four `true` and asserts all four `true` passes even when two slots
+// are wired from each other's source; each case below rotates a single `true`
+// and pins the other three as absent.
+//
+// Pattern mirrors daemon-sync-agents-meta-wiring.test.ts: mock
+// `DKGAgent.create` to capture its options object and reject immediately, so
+// `runDaemonInner` unwinds before the heavy post-create boot (HTTP server,
+// libp2p). No hardhat, no real chain/network.
+
+const mocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  loadOpWallets: vi.fn(),
+  loadNetworkConfig: vi.fn(),
+}));
+
+vi.mock('@origintrail-official/dkg-agent', async importOriginal => {
+  const actual = await importOriginal<typeof import('@origintrail-official/dkg-agent')>();
+  return {
+    ...actual, // keeps the REAL pickSystemRecordConfigControlsV1 that lifecycle.ts calls
+    DKGAgent: { create: mocks.agentCreate },
+    loadOpWallets: mocks.loadOpWallets,
+    KaNumberAllocator: class KaNumberAllocator {},
+  };
+});
+
+vi.mock('../src/config.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/config.js')>();
+  return {
+    ...actual,
+    loadNetworkConfig: mocks.loadNetworkConfig,
+  };
+});
+
+const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
+
+/** The four controls, in the order plan `:1436` names them. */
+const CONTROL_FIELDS = [
+  'systemRecordProducerTrackingEnabled',
+  'systemRecordProviderAdvertisementEnabled',
+  'systemRecordRequesterLaneEnabled',
+  'systemRecordLegacyCapablePeerSelectionEnabled',
+] as const;
+
+function closeDashboardDbFromAgentCreateArg(createArg: any): void {
+  const db =
+    createArg?.chainEventCursorStore?.cursors?.db ??
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+  db?.close?.();
+}
+
+describe('runDaemonInner forwards the system-record config controls (:1436)', () => {
+  let tempHome: string | undefined;
+  let originalDkgHome: string | undefined;
+  let stdoutWrite: typeof process.stdout.write = process.stdout.write;
+  let stderrWrite: typeof process.stderr.write = process.stderr.write;
+  let uncaughtExceptionListeners: NodeJS.UncaughtExceptionListener[] = [];
+  let unhandledRejectionListeners: NodeJS.UnhandledRejectionListener[] = [];
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-system-record-controls-wiring-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    // The resolvers let an env var win over config, so a stray one in the
+    // ambient environment could mask a dropped field. Clear all four.
+    for (const name of [
+      'DKG_SYSTEM_RECORD_PRODUCER_TRACKING_ENABLED',
+      'DKG_SYSTEM_RECORD_PROVIDER_ADVERTISEMENT_ENABLED',
+      'DKG_SYSTEM_RECORD_REQUESTER_LANE_ENABLED',
+      'DKG_SYSTEM_RECORD_LEGACY_CAPABLE_PEER_SELECTION_ENABLED',
+    ]) {
+      savedEnv[name] = process.env[name];
+      delete process.env[name];
+    }
+    stdoutWrite = process.stdout.write;
+    stderrWrite = process.stderr.write;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+
+    mocks.loadNetworkConfig.mockResolvedValue({
+      networkName: 'DKG V10 Gnosis Mainnet',
+      genesisId: 'gnosis-mainnet',
+      genesisVersion: 1,
+      relays: ['/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M'],
+      defaultNodeRole: 'core',
+    });
+    mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
+    mocks.agentCreate.mockRejectedValue(new Error('after-agent-create'));
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    process.stdout.write = stdoutWrite;
+    process.stderr.write = stderrWrite;
+    process.removeAllListeners('uncaughtException');
+    for (const listener of uncaughtExceptionListeners) process.on('uncaughtException', listener);
+    process.removeAllListeners('unhandledRejection');
+    for (const listener of unhandledRejectionListeners) process.on('unhandledRejection', listener);
+    if (originalDkgHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = originalDkgHome;
+    for (const [name, previous] of Object.entries(savedEnv)) {
+      if (previous === undefined) delete process.env[name];
+      else process.env[name] = previous;
+    }
+    if (tempHome) await rm(tempHome, { recursive: true, force: true });
+    tempHome = undefined;
+  });
+
+  async function captureCreateArg(configOverrides: Record<string, unknown> = {}): Promise<any> {
+    await expect(runDaemonInner(true, {
+      name: 'system-record-controls-wiring-test',
+      networkConfig: 'mainnet-gnosis',
+      listenPort: 0,
+      nodeRole: 'core',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
+      ...configOverrides,
+    } as any, Date.now())).rejects.toThrow('after-agent-create');
+
+    expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
+    const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
+    closeDashboardDbFromAgentCreateArg(createArg);
+    return createArg;
+  }
+
+  for (const field of CONTROL_FIELDS) {
+    it(`carries ${field} across the CLI→agent boundary, alone`, async () => {
+      const createArg = await captureCreateArg({ [field]: true });
+
+      // Survival: the operator's value reached the agent.
+      expect(createArg[field], `${field} was dropped on the CLI→agent hop`).toBe(true);
+
+      // Independence in transit: no sibling slot picked it up.
+      for (const other of CONTROL_FIELDS) {
+        if (other === field) continue;
+        expect(createArg[other], `${field} must not land in ${other}`).toBeUndefined();
+      }
+    });
+  }
+
+  it('carries an explicit false rather than dropping it', async () => {
+    // `false` and `undefined` resolve alike today, but they are different
+    // operator intents and the hop must not rewrite one into the other.
+    const createArg = await captureCreateArg({ systemRecordRequesterLaneEnabled: false });
+    expect(createArg.systemRecordRequesterLaneEnabled).toBe(false);
+  });
+
+  it('leaves every control undefined when the operator sets none', async () => {
+    const createArg = await captureCreateArg();
+    for (const field of CONTROL_FIELDS) {
+      expect(createArg[field], `${field} must not be invented by the hop`).toBeUndefined();
+    }
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -179,6 +179,9 @@ export default defineConfig({
           'test/daemon-context-graph-bootstrap.test.ts',
           'test/daemon-sync-agents-meta-wiring.test.ts',
           'test/daemon-storage-ack-timing-wiring.test.ts',
+          // #2052 D-10 — the same guard for the four system-record config
+          // controls: set at the CLI, asserted on the DKGAgent.create options.
+          'test/daemon-system-record-config-controls-wiring.test.ts',
         ],
     testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
     globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],


### PR DESCRIPTION
## What this is

D-10 of the #2052 Stack D remainder: the four operator-facing config controls the frozen plan names at `:1436` — **producer tracking**, **provider advertisement**, **requester lane**, and **legacy capable-peer selection** — "independent and default-off".

**These flags gate nothing today, and that is the design, not an oversight.** Every lane they will govern is still default-unused; each consumer arrives in a later slice. This PR ships the control surface and its proofs, so that the slice which wires the first consumer has a switch to wire it to, rather than inventing one under time pressure at activation.

## The flag inventory is user-ratified, because the plan disagrees with itself

Three places in the frozen plan name three different flag sets. `:1435` says "responder/requester/cache"; `:1436` says the four above; `:1621-1628` describe a rollout over coarser groupings ("producer/cache", advertisement, requester). Only "requester" appears in all of them, and "legacy capable-peer selection" appears nowhere but `:1436`.

This was raised rather than absorbed — the flag inventory is the slice's public surface (config keys operators set) and getting it wrong is a config-compatibility break, not a refactor. **The USER ratified `:1436`'s four as governing**: `:1435` is loose implementation prose, `:1621-1628` are rollout ORDER over coarser groupings. This PR implements exactly those four.

## Polarity is deliberately inverted from the neighbouring switches

`syncReconcilerEnabled`, `syncOnConnectEnabled` and `durableSyncEnabled` all resolve `resolveBooleanSwitch(..., true)` and are documented "Emergency switch for …" — they are kill switches for behaviour that is ON by default.

These four are the opposite: **enable switches for a lane that does not run yet**, so they resolve with `false`. Copying the neighbouring idiom faithfully would have silently activated an unactivated lane while looking perfectly idiomatic in review. The reason is recorded at the declaration site, not just here, because the declaration is where the next person will copy from.

## The forwarding chokepoint, and the two different failure modes it answers

`DkgConfig` → `DKGAgentConfig` is a **hand-written per-field mapping** inside `runDaemonInner`. There is no `...config` spread. So a control can be declared, typed, documented, operator-settable — and silently do nothing, because someone added two of the three coordinated edits.

That hazard is not hypothetical for these four; it is already live for the flags shipped before them. **Zero of the 231 test files in `packages/cli/test` mention `syncReconcilerEnabled`, `syncOnConnectEnabled` or `durableSyncEnabled`** — so nothing anywhere tests that those three survive the hop. (Five test files in `packages/agent` do exercise them, but they sit on the far side of the boundary and cannot see the CLI mapping at all.) That pre-existing gap is filed separately as #55; this PR does not widen it, and the pattern below is what closing it would look like.

The four therefore travel through ONE named chokepoint — `SystemRecordConfigControlsV1` plus `pickSystemRecordConfigControlsV1`, with a pinned return type. This is not a new invention: it is the construction core already uses for `pickNetworkTunables` (`core/src/node.ts:290`), created for exactly this failure, whose own comment says "a typo at any caller would fail to compile".

**Two failure modes, and the type only catches one:**

1. *A typo inside the helper's shape* — caught at compile time by the pinned return type. The CLI package building IS this half of the proof.
2. *Deletion of the CALL itself* — the type cannot catch it, because every field is optional, so dropping the spread compiles cleanly and leaves the agent-side suite green.

Failure mode 2 is what the CLI wiring test owns, and it is the load-bearing one.

## Tests: boundary survival, not declaration

The agent-package tests prove what the resolvers and the pick helper DO. They cannot prove the controls SURVIVE the trip, because the trip happens in the CLI. So there are two layers:

- `packages/agent/test/system-record-config-controls-v1.test.ts` — defaults, env override, and helper behaviour at the declaration.
- `packages/cli/test/daemon-system-record-config-controls-wiring.test.ts` — **set at the CLI, assert on the object handed to `DKGAgent.create`**. This is the layer the guarantee actually lives at. It follows the existing pattern of `daemon-sync-agents-meta-wiring.test.ts` and its two siblings.
- `packages/agent/test/system-record-config-controls-coverage.typecheck.ts` — added in review (see below). A type-level pin that the chokepoint covers every system-record control declared on the agent config, both directions. It runs in `test:types`, which `build` invokes, so it fails the build rather than a lane someone might not run.

**Every fixture rotates a single `true` (one-hot), at both layers.** Four booleans share only two values, so a fixture that sets all four `true` and asserts all four `true` passes *while cross-wired* — it cannot distinguish independence from four slots reading one shared source. The one-hot rotation is what makes the independence claim falsifiable, and it applies at the boundary identically to the declaration.

## Mutation evidence

Nine mutants, run serially on Node v22.22.0. Every mutation is pinned by LINE NUMBER and proven applied by reading that line back — the eight agent-side targets are textually near-identical, so "the string changed" would not say which site moved. Each run's COLLECTED FILE COUNT is checked, not just its exit code; a green on zero collected files looks identical to a real green. Unmutated baselines are green at both ends of the campaign.

### M9 — the call site, measured BEFORE and AFTER the fix

Blank `...pickSystemRecordConfigControlsV1(config)` at `cli/src/daemon/lifecycle.ts:1798`. Applied-proof is site-anchored: occurrences of the symbol in that file drop 2 → 1, the survivor being the import at `:71`.

| | observer set | baseline | under the mutant |
|---|---|---|---|
| **before** the wiring test | all 11 CLI test files that call `runDaemonInner` (derived by grep, collection reconciled: 11 collected) | 11 files / 57 tests green | 11 files / 57 tests green → **SURVIVED** |
| **after** the wiring test | the new wiring test | 1 file / 6 tests green | 5 failed, 1 passed → **KILLED** |

The before-half is what makes the after-half evidence rather than assumption: the fix is proven load-bearing against a demonstrated survivor, not assumed necessary. The single case that correctly still passes under the mutant is `leaves every control undefined when the operator sets none` — it asserts absence, so a dropped field cannot fail it.

Failure messages under the mutant name the defect directly, e.g. `systemRecordProducerTrackingEnabled was dropped on the CLI→agent hop: expected undefined to be true`.

### D1-D4, X1-X4 — the eight agent-side predicates

All eight KILLED, each `applied=true restored=true`, every run collecting 1 file, with green baselines before (10 tests) and after the campaign.

| Mutant | Line | Mutation | Verdict |
|---|---|---|---|
| D1 default-producer | `:76` | `false,` → `true,` | KILLED |
| D2 default-provider | `:87` | `false,` → `true,` | KILLED |
| D3 default-requester | `:98` | `false,` → `true,` | KILLED |
| D4 default-legacy-capable | `:109` | `false,` → `true,` | KILLED |
| X1 cross-producer | `:61` | producer slot ← provider source | KILLED |
| X2 cross-provider | `:62` | provider slot ← producer source | KILLED |
| X3 cross-requester | `:63` | requester slot ← legacy-capable source | KILLED |
| X4 cross-legacy-capable | `:65` | legacy-capable slot ← requester source | KILLED |

A kill can prove the wrong property, so one representative of each family was re-run with its failing test names read back rather than inferred from a substring match:

- **D1** fails `resolves false for every control when nothing is configured` (plus three siblings) — 4 failed / 6 passed of 10.
- **X1** fails `forwards each control to the SAME-named slot (no copy-paste-cross)` (plus `preserves an explicit false`) — 2 failed / 8 passed of 10.

Both are the intended targets, and both runs collected all 10 tests.

## What is deliberately NOT in this PR

- **The rollout ORDER is not encoded as runtime validation.** The plan makes the sequence normative (`:1621-1623` producer/cache → advertisement → requester, rollback the exact reverse at `:1628`), and it is deployment doctrine — documented, not enforced in code. Encoding it would destroy the independence the same plan line requires: a flag that refuses to enable until another is on is not independent. Pairwise-independence tests here must NOT be read as licensing arbitrary production enable orders; the sequence is fixed, the mechanism is not what fixes it.
- **Epoch rotation on disable/flip belongs to D-11**, not here. `:1436`'s second sentence ("turning all off unregisters protocols, aborts/drains slices, clears caches…") is the all-off teardown, a separate slice with its own `:1628` rotation-on-flip semantics. These flags gate nothing yet, so there is nothing for a rotation to respond to.
- **No consumer wiring.** Naming a consumer is not wiring one; see the mapping below.
- **The control contract is not restructured into a canonical descriptor** that `DkgConfig` and `DKGAgentConfig` extend. Review raised this, and its factual core is right — a fifth control would need edits in both config interfaces, the chokepoint interface, the picker, a resolver, and the test arrays. It is declined on a measurement rather than a preference: **the repo's own solved instance of this exact problem does the same thing this PR does.** `NetworkTunables` is not reused by either config — `DkgConfig.network` declares its fields inline and `DKGAgentConfig` declares `peerStoreMaxAddressAgeMs` independently at `:1517` — and that shape was deliberate, surviving three rounds of review on PR #698 with the pinned-return-type-plus-value-preserving-test pair as the chosen mitigation. Adopting a different model for these four alone would leave two idioms for one problem while the sibling tunables keep the first, and would make a CLI config type structurally depend on an agent-package interface the precedent avoided.

  What review *did* surface, and what is now fixed: the chokepoint forwards exactly the fields named in the interface, so a **fifth control added to `DKGAgentConfig` and forgotten there** would be documented, settable and inert — the silent-drop class one level up, invisible to both the type and the wiring test. The coverage typecheck pin closes that, proven by mutant: clean green, a fifth control on the agent config alone fails `test:types` with TS2344, restored green. Its limit is stated at the site — it keys on the `systemRecord` name prefix, a convention rather than a contract.

## Per-flag consumer mapping

Factory names below are verified by grep against this tree, not recalled. "Production callers today" is the measured count of non-test call sites.

| Control | Consumer it will gate | Production callers today | Wiring slice |
|---|---|---|---|
| `systemRecordProducerTrackingEnabled` | `createAgentProfileProducerV1` (`agent/src/system-records/agent-profile-producer-v1.ts:29`) | **0** — every call site is a test or test fixture | not assigned in the record |
| `systemRecordProviderAdvertisementEnabled` | `createSystemRecordProviderV1` (`agent/src/system-records/provider-v1.ts:92`) | **0** — same | not assigned in the record |
| `systemRecordRequesterLaneEnabled` | `createSystemRecordRequesterV1` (`agent/src/system-records/requester-v1.ts:373`) | **0** — same | not assigned in the record |
| `systemRecordLegacyCapablePeerSelectionEnabled` | the legacy catch-up capable-peer probe (`agent/src/dkg-agent-lifecycle.ts:6565-6618`) | **live production code today** | not assigned in the record |

Two things worth a reviewer's attention rather than a quiet assumption:

1. **The wiring slice per flag is genuinely unrecorded, so this PR does not invent one.** The only textual link in the durable record is issue #53's description, which lists "the D-10 config flag" among the things the D-8 residual wiring needs — but it names no specific flag, and by the ratified `:1436` inventory none of the four IS the legacy profile gate. The nearest by name, legacy capable-peer selection, governs peer *preference* inside catch-up sync — a different mechanism from the legacy ingest *gate*. Whoever picks up #53 will go looking for "the D-10 config flag" and find four, none of which fits. That should be resolved by the slice owner, on the record, not by me here.
2. **The fourth control is categorically different from the other three.** Three of them will activate dormant machinery that currently has no production caller at all. The fourth will modify a code path that runs in production today. "Independent and default-off" makes them uniform as a config surface, but their activation risk is not uniform, and the rollout order in the plan already reflects that by putting the requester last.

## Activation context (D-12)

D-12 (cutover) is sequenced LAST precisely because it makes everything simultaneously reachable, and it carries two preconditions that this slice is a prerequisite for rather than a satisfier of: both seam gates landed (D-8 legacy AND D-13 changelog — activation fails with either door open), and rotation-on-flip existing and proven before any lane enables in production. Nothing here activates anything; it makes activation *expressible*.

## Verification

All on Node v22.22.0, base `203310f82` (re-fetched immediately before opening; the integration head had not moved).

- `pnpm exec turbo build --filter=@origintrail-official/dkg-agent --filter=@origintrail-official/dkg` — **18/18 tasks, exit 0**. The CLI compiling is the compile-time half of the chokepoint proof, so this is a contract check, not a formality.
- Agent lane: `system-record-config-controls-v1.test.ts` — **1 file, 10 tests**, green.
- CLI lane: `daemon-system-record-config-controls-wiring.test.ts` — **1 file, 6 tests**, green.
- CLI observer lane (the 11 files constructing the agent config) — **11 files, 57 tests**, green.

Both test files were added to their package's `vitest.unit.config.ts` allowlist. Neither was listed before, so both fast lanes silently skipped them. **CI was never affected** — the agent shard planner (`packages/agent/scripts/ci-shard-agent.mjs`) and the CLI planner (`scripts/ci/plan-vitest-shard.mjs`) both discover by filesystem walk, which I read rather than assumed. The allowlist entries are a local-lane fix, and they take the agent lane from a hardhat boot per run to about two seconds.

**A note for whoever reviews the red, if there is one:** this branch's target has no push CI (the workflows' `push:` filters do not include `integration/**`, only their `pull_request:` filters do), so a failure appearing at PR-open is as likely to come from the previous merge as from this diff. The baseline to attribute against, with its SHA: the 11-file CLI observer lane was green at **`5c0726501`** — this branch before my commit, base `203310f82` — at 11 files / 57 tests, and it was still 11 files / 57 tests green after. That lane is where a CLI-side regression from this diff would land.

Refs #2052.
