### PR TITLE
D-10 follow-up: keep the four control resolvers off the package root

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -402,14 +402,13 @@ export { selectSwmSnapshotCoverage } from './sync/requester/shared-memory-sync.j
 // exported. The serve-side resolver `shouldWithholdAgentsDurableMeta` stays
 // internal; only the in-agent lifecycle (at its env boundary) + tests use it.
 export { resolveSyncAgentsMeta, parseBooleanEnv } from './sync/agents-meta-policy.js';
-// #2052 Stack D config controls (plan :1436). The pick helper is exported
-// because the CLI forwarding hop consumes it; the four resolvers are exported
-// for the later slices that will read each control.
+// #2052 Stack D config controls (plan :1436). Only the pick helper and its
+// return type are exported, because only the CLI forwarding hop consumes them.
+// The four per-control resolvers stay INTERNAL: they have no production caller
+// yet, and publishing them from the package root would let external code depend
+// on resolver names and shapes before the consuming lanes have shown what the
+// right boundary is. Export each one when its lane arrives.
 export {
   pickSystemRecordConfigControlsV1,
-  systemRecordLegacyCapablePeerSelectionEnabledV1,
-  systemRecordProducerTrackingEnabledV1,
-  systemRecordProviderAdvertisementEnabledV1,
-  systemRecordRequesterLaneEnabledV1,
   type SystemRecordConfigControlsV1,
 } from './system-records/config-controls-v1.js';


### PR DESCRIPTION
## What this is

A one-file follow-up to #2255 (D-10 config controls), which merged as `b3e85484a` while I was committing this change. The review finding it answers arrived on #2255 about ten minutes before the merge, so it missed the boat by timing rather than by judgement.

## The finding

#2255's barrel published all four per-control resolvers, with a comment saying they were exported "for the later slices that will read each control." Review pointed out that this makes internal feature-flag plumbing into root-level package API before it has real call sites. It is right, and the measurement backs it:

**Repo-wide, the only references to the four resolvers are their own definitions, the barrel, and the unit test — which imports them from the source module, not the package root.** Zero production callers. That is the exported-tested-zero-callers shape: a surface that looks load-bearing because it is exported and covered, while nothing consumes it.

`packages/agent/package.json` exports `.` via `dist/index.js`, so the package root is public API. Publishing the four now lets external code depend on resolver names and shapes before the consuming lanes have shown what the right boundary is — compatibility pressure bought with nothing.

## What changes

Only `pickSystemRecordConfigControlsV1` and its return type stay exported, because the CLI forwarding hop genuinely consumes them. Each resolver gets exported when its lane arrives and can show why that shape is worth committing to. Nothing else moves — same fields, same defaults, same env precedence, same forwarding.

## Verification

Base `b3e85484a`, Node v22.22.0. The base moved between #2255's measurements and this branch, so everything below was re-run here rather than carried over.

- `pnpm exec turbo build --filter=@origintrail-official/dkg-agent --filter=@origintrail-official/dkg` — 18/18, exit 0.
- Agent lane `system-record-config-controls-v1.test.ts` — 1 file, 10 tests, green. It imports the resolvers from the source module, so it is unaffected by the barrel change; that is what makes this trim safe.
- CLI boundary lane `daemon-system-record-config-controls-wiring.test.ts` — 1 file, 6 tests, green. This is the one that would break if the picker's export were disturbed, and it is not.

**Artifact-level proof, not just source.** A barrel change is exactly the case where a cached or stale build hides the result, and turbo did report a cache hit here (legitimately — the content is byte-identical to a tree I built minutes earlier). So I grepped the built output rather than trusting the source diff:

- `dist/index.js` — 0 occurrences of the four resolver names.
- `dist/index.d.ts` — 0 occurrences.
- `pickSystemRecordConfigControlsV1` — still present in both.

## Not in scope

The same review round raised two other things, both answered on #2255 and neither actioned here: restructuring the four controls behind a generated descriptor table (declined on a precedent measurement — core's `pickNetworkTunables` does not reuse its canonical interface either, deliberately, through three review rounds; if the doctrine argument wins it should move both idiom instances together as its own slice), and removing plan anchors from durable config comments (declined — citing plan and issue anchors in durable comments is pervasive repo convention, and the protocol reviewer specifically endorsed the chokepoint comment stating its hazard where it will be read).

Refs #2052.
