### PR TITLE
D-13: route the agents system CG out of the changelog lane

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5253,6 +5253,30 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const legacyCgs: string[] = [];
     const work = [];
     for (const contextGraphId of contextGraphIds) {
+      // #2052 D-13 — the `agents` system CG never rides the changelog lane.
+      //
+      // `isPrivateContextGraph` returns FALSE for system CGs, so without this
+      // `agents` is carried down applyPage by any peer advertising the
+      // changelog protocol. That matters because the merkle bypass is on BOTH
+      // doors — `acceptUnverified` is computed from system-CG membership here
+      // (:5324) and identically in the legacy runner (durable-sync.ts:338) —
+      // and it does more than skip a precondition: it ADMITS mismatched
+      // content as verified. So the fix is routing, not a second gate; a gate
+      // would sit downstream of a selector that already accepted the quads.
+      //
+      // Withholding at applyPage is unsafe here rather than merely harder:
+      // planPageApply advances a contiguous-prefix cursor with two record
+      // dispositions, so a withhold-but-advance third shape makes the withhold
+      // PERMANENT past a passed sequence. Excluding the CG means no changelog
+      // cursor is ever established for it, which is the only shape that stays
+      // reversible.
+      //
+      // Fails closed: anything uncertain stays on legacy, the lane that has
+      // always carried this graph.
+      if (contextGraphId === SYSTEM_CONTEXT_GRAPHS.AGENTS) {
+        legacyCgs.push(contextGraphId);
+        continue;
+      }
       if (await this.isPrivateContextGraph(contextGraphId)) {
         legacyCgs.push(contextGraphId);
         continue;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -34,7 +34,7 @@ import {
   decodeGossipEnvelope, type GossipEnvelopeMsg,
   decodeEncryptedWorkspacePayload, ENCRYPTED_WORKSPACE_ENVELOPE_TYPE,
   decodeSwmSenderKeyMessage, SWM_SENDER_KEY_MESSAGE_TYPE,
-  getGenesisQuads, computeNetworkId, SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY,
+  getGenesisQuads, computeNetworkId, SYSTEM_CONTEXT_GRAPHS, isAgentRegistryContextGraph, DKG_ONTOLOGY,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   validateSubGraphName,
   Logger, createOperationContext, isKaPublishLifecycleDebugLoggingEnabled, isStorageACKDecline, sparqlString, escapeSparqlLiteral, isSafeIri, assertSafeIri,
@@ -5258,11 +5258,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // `isPrivateContextGraph` returns FALSE for system CGs, so without this
       // `agents` is carried down applyPage by any peer advertising the
       // changelog protocol. That matters because the merkle bypass is on BOTH
-      // doors — `acceptUnverified` is computed from system-CG membership here
-      // (:5324) and identically in the legacy runner (durable-sync.ts:338) —
-      // and it does more than skip a precondition: it ADMITS mismatched
-      // content as verified. So the fix is routing, not a second gate; a gate
-      // would sit downstream of a selector that already accepted the quads.
+      // doors — `acceptUnverified` is computed from system-CG membership in
+      // `runChangelogSyncForCg` below, and the legacy runner computes the
+      // identical predicate under a DIFFERENT NAME (`isSystemContextGraph` in
+      // `sync/requester/durable-sync.ts`), so grepping either name alone finds
+      // only one of the two doors — and it does more than skip a precondition:
+      // it ADMITS mismatched content as verified. So the fix is routing, not a
+      // second gate; a gate would sit downstream of a selector that had already
+      // accepted the quads.
       //
       // Withholding at applyPage is unsafe here rather than merely harder:
       // planPageApply advances a contiguous-prefix cursor with two record
@@ -5272,8 +5275,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // reversible.
       //
       // Fails closed: anything uncertain stays on legacy, the lane that has
-      // always carried this graph.
-      if (contextGraphId === SYSTEM_CONTEXT_GRAPHS.AGENTS) {
+      // always carried this graph. The predicate is core's canonical one rather
+      // than an inline comparison, so this site cannot drift from the other
+      // agent-registry call sites; the test pins the CONSTANT, so a predicate
+      // that stopped matching it would fail rather than silently agree.
+      if (isAgentRegistryContextGraph(contextGraphId)) {
         legacyCgs.push(contextGraphId);
         continue;
       }

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -22,7 +22,7 @@ vi.mock('../src/sync/requester/graph-scoped-materialization.js', async (importOr
   };
 });
 
-import { PROTOCOL_SYNC_CHANGELOG } from '@origintrail-official/dkg-core';
+import { PROTOCOL_SYNC_CHANGELOG, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import { createDurableSyncAccumulator } from '../src/sync/durable-progress.js';
 import { DKGAgent } from '../src/dkg-agent.js';
 import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
@@ -467,6 +467,49 @@ describe('durable sync lifecycle chain binding', () => {
       priorityOverride: 2_000,
       source: 'catchup-foreground',
     });
+  });
+
+  it('routes the agents system CG to legacy even on a changelog-capable peer (#2052 D-13)', async () => {
+    // `isPrivateContextGraph` returns FALSE for system Context Graphs, so before
+    // D-13 the `agents` graph was carried down the changelog lane by any peer
+    // advertising the protocol. The fixture below pins that exact condition —
+    // changelog-capable peer, nothing private — which is the only state where
+    // the routing decision is observable at all.
+    //
+    // Both assertions are load-bearing and neither implies the other: the
+    // returned list proves `agents` is HANDED to legacy, and the admission list
+    // proves it never ENTERED the changelog lane. A routing bug that admitted
+    // the graph and also reported it as remaining would satisfy the first alone.
+    const admissions: unknown[][] = [];
+    const agentLike = {
+      config: {},
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+      getPeerProtocols: async () => [PROTOCOL_SYNC_CHANGELOG],
+      isPrivateContextGraph: async () => false,
+      runContextGraphSyncWithBackpressure: async (...args: unknown[]) => {
+        admissions.push(args);
+        return createDurableSyncAccumulator();
+      },
+    };
+
+    const { remainingLegacyCgs } = await LifecycleSyncMethods.prototype.runChangelogLane.call(
+      agentLike as never,
+      ctx,
+      '12D3KooWChangelogPeer',
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, 'public-cg'],
+    );
+
+    // `agents` goes back to the legacy lane...
+    expect(remainingLegacyCgs).toContain(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    // ...and the ordinary public CG is NOT diverted with it, so this pins the
+    // exclusion rather than a lane that stopped working.
+    expect(remainingLegacyCgs).not.toContain('public-cg');
+
+    // The changelog lane admitted exactly one graph, and not the agents one.
+    expect(admissions).toHaveLength(1);
+    expect((admissions[0] as unknown[])[1]).toBe('public-cg');
+    const admittedGraphs = admissions.map((args) => args[1]);
+    expect(admittedGraphs).not.toContain(SYSTEM_CONTEXT_GRAPHS.AGENTS);
   });
 
   it('labels standalone SWM recovery admissions at the call site', async () => {


### PR DESCRIPTION
## What this is

D-13 of the #2052 Stack D remainder. **The `agents` system Context Graph no longer rides the RFC-59 changelog lane.** One condition at the existing divert site, failing closed.

The diff is four lines of routing plus a test. The reasoning behind why it is *routing* and not a gate is the part worth reading.

## The defect

`isPrivateContextGraph` returns **false** for system Context Graphs — they are not private — and the changelog divert only sends private graphs to legacy. So `agents` was carried down `applyPage` by any peer advertising `PROTOCOL_SYNC_CHANGELOG`, on a lane whose verification posture is described below.

The seam is live rather than merely reachable: `syncFromPeerDetailed` defaults its `contextGraphIds` to `[SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...syncContextGraphs]`, so `agents` is in the list on the default path.

## Why routing, not a second gate

The obvious shape — withhold `agents` quads at `applyPage`, mirroring the D-8 legacy gate — is wrong here, for two measured reasons.

**1. The merkle bypass is on both doors, and it does more than skip a check.**

`acceptUnverified` is computed from system-CG membership in the changelog lane (the `acceptUnverified` local in `runChangelogSyncForCg`) and *identically* in the legacy runner (`sync/requester/durable-sync.ts:338`, passed at `:484` under the name `isSystemContextGraph`). Both feed the same selector, `selectVerifiedDurableSyncQuads`. The differing argument names are the trap on this seam: grepping either name alone finds only one of the two doors.

And it is not merely two early returns. `acceptUnverified` **admits mismatched content as verified**: `admittedMetadataUals.add(ual)` (`durable-integrity.ts:702`), `verifiedKcUals.add(kcUal)` (`:845`, `:900`), with log levels downgraded from `warn` to `debug` throughout `:598`-`:929` and messages that read "(system context graph, accepted)". A gate placed downstream would sit *after* a selector that had already accepted the quads.

**2. Withholding at `applyPage` is unsafe here, not merely harder.**

`planPageApply` advances a contiguous-prefix cursor with two record dispositions. A withhold-but-advance third shape makes the withhold **permanent past a passed sequence** — the graph could never be recovered by replay. Excluding the CG means no changelog cursor is ever established for it, which is the only shape that stays reversible.

## The implementer question, answered

The spec asked why `acceptUnverified` exists for system CGs at all — deliberate, or oversight? **Deliberate, and specifically for genesis-seeding.** Three independent pieces of evidence:

1. The rationale is written at the helper's declaration (`dkg-agent-utils.ts`, `verifySyncedData`): "Normal context graphs fail closed when data has no Merkle-bound KA descriptor; **system/genesis callers must opt into the explicit `acceptUnverified` override**." The word *genesis* is the source's, not an inference.
2. Provenance: introduced in `93a089dab` (2026-07-11), "OT-RFC-59 SC4-6 — changelog responder + durable verified requester lane (#1608)" — the same commit that built the changelog lane, so it is part of that design rather than an accretion.
3. `SYSTEM_CONTEXT_GRAPHS`' own declaration corroborates it: "The agent registry (`agents`) system context graph is **genesis-seeded and never registered on-chain**."

**So no legacy-side follow-up is owed for the bypass existing.** It is a designed affordance for content that legitimately has no merkle-bound descriptor.

**One question it does raise, which is D-12's and not this slice's:** `agents` is the one system CG that Stack D gives an authenticated replay path. Once that lands, keeping `agents` in the `acceptUnverified` set means signed system records ride a lane that accepts mismatches. Whether `agents` *leaves* that set at cutover is a different question from why the set exists, and it has been routed to protocol as a candidate D-12 activation precondition.

## The recorded design cost

Stated as a decision rather than left silent: **the agents plane loses O(delta) changelog sync and reverts to legacy full-scan.**

Acceptable because that is already the behaviour whenever a peer does not advertise the changelog protocol, the changelog store is default-off, and Stack D exists precisely to give the agents plane its own authenticated replay path.

**No cursor cleanup is owed.** Excluding the CG strands any changelog cursor a node had already established, but that is dormant state, not a hazard: the request carries the cursor's `era`, and on era-mismatch, rollback or first contact the responder returns `resync`, which bootstraps through the legacy lane and only jumps the cursor when the resync completed fully. Any future re-entry therefore either resumes correctly from its sequence or is forced through a full legacy resync — no gap can open.

## Review round 1

Two non-behavioural changes at `f8fad6fd0`, in response to review:

**The exclusion now calls core's canonical predicate** rather than comparing inline. `isAgentRegistryContextGraph` (`core/src/genesis.ts:229`) is *literally* `return contextGraphId === SYSTEM_CONTEXT_GRAPHS.AGENTS` — byte-identical to the comparison it replaces, so the swap is provably zero-behaviour rather than believed to be. It is already the gate at `gossip-publish-handler.ts:752`, `sync/agents-meta-policy.ts:79`, `dkg-publisher.ts:3563`/`:3590` and `agent-registry-meta-retention.ts:133`/`:225`, so this site can no longer drift from the other agent-registry call sites.

The test deliberately still pins the **constant** while the source uses the **predicate** — independent expressions of the same fact, so a predicate that stopped matching the constant fails the test instead of silently agreeing with it.

**A citation this PR itself broke is fixed.** The decision comment cited the merkle-bypass site by line number, but the comment's own inserted lines had already pushed `acceptUnverified` past it, so the citation pointed at unrelated code. Same-file line citations rot by construction; the references are now symbol-based.

## Verification

Base `0da3b0e71`, Node v22.22.0.

- `pnpm exec turbo build --filter=@origintrail-official/dkg-agent...` — **18/18 tasks, exit 0**, with the agent package running `tsc && test:types && test:package-root`.
- The four test files that touch this seam (`durable-sync-lifecycle-binding`, `changelog-requester`, `sync-requester-priority`, `sync-operation-telemetry`) — **116/116 green**.

**Fail-before proof**, because a routing condition that was never exercised would look identical to one that works. Re-run against the round-1 predicate rather than inherited, since the refactor changed the expression under test:

| State | Result |
|---|---|
| clean | 28 passed |
| exclusion removed (private-CG divert left intact as a control) | **1 failed / 27 passed** — the failure is this slice's test, by name, asserting `expected [] to include 'agents'` |
| restored | 28 passed |

The mutation removes only the four-line exclusion, so the failure cannot be the lane breaking wholesale — the control confirms the private divert is still in place, and no other test moves, so the branch is not shadowing existing coverage.

The test pins **both halves, and neither implies the other**: `agents` is handed to the legacy lane, *and* it never enters the changelog lane. A routing bug that admitted the graph while also reporting it as remaining would satisfy the first assertion alone.

Routing is verified past the test's return value: `remainingLegacyCgs` feeds `legacyContextGraphIds`, which is what `runLegacyDurableSync` is called with.

## Scope

**AGENTS only.** `ONTOLOGY`'s changelog disposition belongs to Stack E (flagged in #30). Quad-level withholding for the legacy seam is #53's, not this slice's — this PR routes the graph, it does not gate its contents.

Refs #2052.
