### PR TITLE
fix(agent): retain and generation-bind durable sync progress

### DIFF
--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -50,10 +50,23 @@ export const SYNC_REQUEST_SAFE_PAGE_SIZE = Math.max(
 export const SYNC_BYTE_BUDGET_PAGE_MODE = 'byte-budget-v1' as const;
 /** Maximum rows a responder may materialize for one byte-budgeted durable page. */
 export const SYNC_BYTE_BUDGET_MAX_ROWS = 8_192;
+/**
+ * Conservative first request for a previously unseen peer/path.
+ *
+ * The 8,192-row byte-budget ceiling remains available after the requester has
+ * observed sustained success, but opening at that ceiling amplifies cold
+ * relay and responder-queue churn: one reset throws away a much larger page
+ * and occupies a scarce durable lane while the transport retries. 512 stays
+ * above the legacy 500-row cap (so byte-budget EOF semantics remain active)
+ * while bounding the first response.
+ */
+export const SYNC_REQUEST_INITIAL_PAGE_SIZE = 512;
 /** Target serialized body. Six MiB of the 10 MiB router cap remains as headroom. */
 export const SYNC_BYTE_BUDGET_RESPONSE_BYTES = DEFAULT_MAX_READ_BYTES - SYNC_RESPONSE_FRAME_HEADROOM_BYTES;
-/** Throughput-oriented requested row hint; the signed legacy limit remains 500. */
+/** Maximum throughput-oriented row hint; the signed legacy limit remains 500. */
 export const SYNC_REQUEST_PAGE_SIZE = SYNC_BYTE_BUDGET_MAX_ROWS;
+/** Successful pages required before the requester doubles its learned size. */
+export const SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD = 8;
 export const SYNC_PAGE_RETRY_ATTEMPTS = 3;
 export const SYNC_TOTAL_TIMEOUT_MS = 120_000;
 /** Per-page timeout for sync when we have budget (relay links can be slow). */

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5508,6 +5508,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         snapshotRef,
         sinceBatchId,
         manifestDigest,
+        manifestPrefixDigestAtOffset,
         forceFreshSession,
         fetchContext,
       }) => {
@@ -5526,6 +5527,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             forceFreshSession: forceFreshSession
               || onVerifiedFullSnapshot !== undefined,
             manifestDigest,
+            manifestPrefixDigestAtOffset,
             assetUals: exactAssetUals,
           },
         );
@@ -5668,10 +5670,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       },
       onVerifiedFullSnapshot,
       deleteCheckpoint: (key) => deleteSyncPageCheckpoint(this.syncCheckpoints, key),
-      setCheckpoint: (key, offset, manifestDigest) => {
+      setCheckpoint: (key, offset, manifestDigest, manifestPrefixDigest) => {
         if (manifestDigest) {
           if (this.syncCheckpoints.setManifestBoundOffset) {
-            this.syncCheckpoints.setManifestBoundOffset(key, offset, manifestDigest);
+            this.syncCheckpoints.setManifestBoundOffset(
+              key,
+              offset,
+              manifestDigest,
+              Date.now(),
+              manifestPrefixDigest,
+            );
           } else {
             // Rolling/custom stores that cannot persist the binding must not
             // retain an offset whose generation identity would be lost.
@@ -6115,6 +6123,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // an unfinished offset-zero requester session remains cached.
       forceFreshSession,
       manifestDigest,
+      manifestPrefixDigestAtOffset,
       // Exact VM recovery filter. Included in checkpoint, coalescing, wire and
       // responder-session identities so offsets never cross asset batches.
       assetUals,
@@ -6231,6 +6240,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       checkpointStore: this.syncCheckpoints,
       forceFreshSession,
       manifestDigest,
+      manifestPrefixDigestAtOffset,
       buildSyncRequest: this.buildSyncRequest.bind(this),
       parseAndFilter: (nquadsText, targetGraphUri, targetContextGraphId) => {
         if (phase === 'snapshot') {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -801,6 +801,7 @@ function syncPageFetchCoalescingKey(params: {
   sinceBatchId?: string;
   recovery?: boolean;
   forceFreshSession?: boolean;
+  manifestDigest?: SyncPageFetchOptions['manifestDigest'];
   assetUals?: readonly string[];
   returnAcceptedPrefixOnRetryableTransportFailure?: boolean;
   requesterScope?: SyncCheckpointScope;
@@ -817,6 +818,7 @@ function syncPageFetchCoalescingKey(params: {
     params.sinceBatchId ?? null,
     params.recovery === true,
     params.forceFreshSession === true,
+    params.manifestDigest ?? null,
     params.assetUals === undefined ? null : exactAssetFilterKey(params.assetUals),
     params.returnAcceptedPrefixOnRetryableTransportFailure === true,
     params.requesterScope ?? null,
@@ -5505,6 +5507,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         graphUri,
         snapshotRef,
         sinceBatchId,
+        manifestDigest,
+        forceFreshSession,
         fetchContext,
       }) => {
         return this.fetchSyncPages(
@@ -5519,7 +5523,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             snapshotRef,
             sinceBatchId,
             signal: fetchContext.signal,
-            forceFreshSession: onVerifiedFullSnapshot !== undefined,
+            forceFreshSession: forceFreshSession
+              || onVerifiedFullSnapshot !== undefined,
+            manifestDigest,
             assetUals: exactAssetUals,
           },
         );
@@ -5661,8 +5667,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         });
       },
       onVerifiedFullSnapshot,
-      deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
-      setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
+      deleteCheckpoint: (key) => deleteSyncPageCheckpoint(this.syncCheckpoints, key),
+      setCheckpoint: (key, offset, manifestDigest) => {
+        if (manifestDigest) {
+          if (this.syncCheckpoints.setManifestBoundOffset) {
+            this.syncCheckpoints.setManifestBoundOffset(key, offset, manifestDigest);
+          } else {
+            // Rolling/custom stores that cannot persist the binding must not
+            // retain an offset whose generation identity would be lost.
+            deleteSyncPageCheckpoint(this.syncCheckpoints, key);
+          }
+        } else {
+          this.syncCheckpoints.set(key, offset);
+        }
+      },
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),
       logDebug: (opCtx, message) => this.log.debug(opCtx, message),
@@ -6096,6 +6114,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // Authoritative snapshot callers rotate the responder session even when
       // an unfinished offset-zero requester session remains cached.
       forceFreshSession,
+      manifestDigest,
       // Exact VM recovery filter. Included in checkpoint, coalescing, wire and
       // responder-session identities so offsets never cross asset batches.
       assetUals,
@@ -6124,6 +6143,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         sinceBatchId,
         recovery,
         forceFreshSession,
+        manifestDigest,
         assetUals,
         returnAcceptedPrefixOnRetryableTransportFailure,
         requesterScope,
@@ -6210,6 +6230,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       protocolSync: PROTOCOL_SYNC,
       checkpointStore: this.syncCheckpoints,
       forceFreshSession,
+      manifestDigest,
       buildSyncRequest: this.buildSyncRequest.bind(this),
       parseAndFilter: (nquadsText, targetGraphUri, targetContextGraphId) => {
         if (phase === 'snapshot') {

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -16,6 +16,7 @@ export type SelectedSwmMetaRetentionScope = `selected-swm-meta:retained:${string
 export const DEFAULT_SYNC_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1000;
 
 export type DurableManifestDigest = `sha256:${string}`;
+export type DurableManifestPrefixDigest = `sha256:${string}`;
 
 export interface SyncCheckpointEntry {
   offset: number;
@@ -23,6 +24,8 @@ export interface SyncCheckpointEntry {
   expiresAtMs: number;
   /** Canonical META generation that gives this DATA offset/session meaning. */
   manifestDigest?: DurableManifestDigest;
+  /** Canonical descriptor prefix already verified through `offset`. */
+  manifestPrefixDigest?: DurableManifestPrefixDigest;
   /**
    * Opaque responder snapshot token paired with this offset. OFFSET is only
    * meaningful while the responder still owns the same immutable row list;
@@ -46,6 +49,7 @@ export interface SyncCheckpointStore {
     value: number,
     manifestDigest: DurableManifestDigest,
     nowMs?: number,
+    manifestPrefixDigest?: DurableManifestPrefixDigest,
   ): void;
   /** Persist the responder snapshot token without advancing the verified offset. */
   setResponderSession?(
@@ -54,6 +58,7 @@ export interface SyncCheckpointStore {
     expiresAtMs: number,
     nowMs?: number,
     manifestDigest?: DurableManifestDigest,
+    manifestPrefixDigest?: DurableManifestPrefixDigest,
   ): void;
   /** Forget only the snapshot token while retaining the verified offset. */
   clearResponderSession?(key: string): void;
@@ -87,6 +92,9 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
         updatedAtMs: entry.updatedAtMs,
         expiresAtMs: entry.expiresAtMs,
         ...(entry.manifestDigest ? { manifestDigest: entry.manifestDigest } : {}),
+        ...(entry.manifestPrefixDigest
+          ? { manifestPrefixDigest: entry.manifestPrefixDigest }
+          : {}),
       };
       this.entries.set(key, withoutExpiredSession);
       return withoutExpiredSession;
@@ -119,12 +127,19 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
     value: number,
     manifestDigest: DurableManifestDigest,
     nowMs = this.clock(),
+    manifestPrefixDigest?: DurableManifestPrefixDigest,
   ): void {
     if (!Number.isSafeInteger(value) || value < 0) {
       throw new Error(`Invalid sync checkpoint offset for ${key}: ${value}`);
     }
     if (!/^sha256:[0-9a-f]{64}$/.test(manifestDigest)) {
       throw new Error(`Invalid sync manifest digest for ${key}`);
+    }
+    if (
+      manifestPrefixDigest !== undefined
+      && !/^sha256:[0-9a-f]{64}$/.test(manifestPrefixDigest)
+    ) {
+      throw new Error(`Invalid sync manifest prefix digest for ${key}`);
     }
     const existing = this.entries.get(key);
     const bindingMatches = existing?.manifestDigest === manifestDigest;
@@ -133,6 +148,7 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
       updatedAtMs: nowMs,
       expiresAtMs: nowMs + this.ttlMs,
       manifestDigest,
+      ...(manifestPrefixDigest ? { manifestPrefixDigest } : {}),
       ...(bindingMatches
         && existing?.responderSessionId
         && (existing.responderSessionExpiresAtMs ?? 0) > nowMs
@@ -150,6 +166,7 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
     expiresAtMs: number,
     nowMs = this.clock(),
     manifestDigest?: DurableManifestDigest,
+    manifestPrefixDigest?: DurableManifestPrefixDigest,
   ): void {
     if (!sessionId || !Number.isSafeInteger(expiresAtMs)) {
       throw new Error(`Invalid sync responder session for ${key}`);
@@ -165,6 +182,11 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
       updatedAtMs: bindingMatches ? existing?.updatedAtMs ?? nowMs : nowMs,
       expiresAtMs: bindingMatches ? existing?.expiresAtMs ?? nowMs + this.ttlMs : nowMs + this.ttlMs,
       ...(manifestDigest ? { manifestDigest } : {}),
+      ...(manifestPrefixDigest
+        ? { manifestPrefixDigest }
+        : bindingMatches && existing?.manifestPrefixDigest
+          ? { manifestPrefixDigest: existing.manifestPrefixDigest }
+          : {}),
       responderSessionId: sessionId,
       responderSessionExpiresAtMs: expiresAtMs,
     });
@@ -178,6 +200,9 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
       updatedAtMs: existing.updatedAtMs,
       expiresAtMs: existing.expiresAtMs,
       ...(existing.manifestDigest ? { manifestDigest: existing.manifestDigest } : {}),
+      ...(existing.manifestPrefixDigest
+        ? { manifestPrefixDigest: existing.manifestPrefixDigest }
+        : {}),
     });
   }
 

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -15,10 +15,14 @@ export type SelectedSwmMetaRetentionScope = `selected-swm-meta:retained:${string
 
 export const DEFAULT_SYNC_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1000;
 
+export type DurableManifestDigest = `sha256:${string}`;
+
 export interface SyncCheckpointEntry {
   offset: number;
   updatedAtMs: number;
   expiresAtMs: number;
+  /** Canonical META generation that gives this DATA offset/session meaning. */
+  manifestDigest?: DurableManifestDigest;
   /**
    * Opaque responder snapshot token paired with this offset. OFFSET is only
    * meaningful while the responder still owns the same immutable row list;
@@ -36,8 +40,21 @@ export interface SyncCheckpointStore {
    */
   get(key: string, nowMs?: number): SyncCheckpointEntry | undefined;
   set(key: string, value: number, nowMs?: number): void;
+  /** Advance a verified DATA offset without detaching it from its META generation. */
+  setManifestBoundOffset?(
+    key: string,
+    value: number,
+    manifestDigest: DurableManifestDigest,
+    nowMs?: number,
+  ): void;
   /** Persist the responder snapshot token without advancing the verified offset. */
-  setResponderSession?(key: string, sessionId: string, expiresAtMs: number, nowMs?: number): void;
+  setResponderSession?(
+    key: string,
+    sessionId: string,
+    expiresAtMs: number,
+    nowMs?: number,
+    manifestDigest?: DurableManifestDigest,
+  ): void;
   /** Forget only the snapshot token while retaining the verified offset. */
   clearResponderSession?(key: string): void;
   delete(key: string): void;
@@ -69,6 +86,7 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
         offset: entry.offset,
         updatedAtMs: entry.updatedAtMs,
         expiresAtMs: entry.expiresAtMs,
+        ...(entry.manifestDigest ? { manifestDigest: entry.manifestDigest } : {}),
       };
       this.entries.set(key, withoutExpiredSession);
       return withoutExpiredSession;
@@ -85,7 +103,38 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
       offset: value,
       updatedAtMs: nowMs,
       expiresAtMs: nowMs + this.ttlMs,
-      ...(existing?.responderSessionId
+      ...(existing?.manifestDigest === undefined
+        && existing?.responderSessionId
+        && (existing.responderSessionExpiresAtMs ?? 0) > nowMs
+        ? {
+            responderSessionId: existing.responderSessionId,
+            responderSessionExpiresAtMs: existing.responderSessionExpiresAtMs,
+          }
+        : {}),
+    });
+  }
+
+  setManifestBoundOffset(
+    key: string,
+    value: number,
+    manifestDigest: DurableManifestDigest,
+    nowMs = this.clock(),
+  ): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`Invalid sync checkpoint offset for ${key}: ${value}`);
+    }
+    if (!/^sha256:[0-9a-f]{64}$/.test(manifestDigest)) {
+      throw new Error(`Invalid sync manifest digest for ${key}`);
+    }
+    const existing = this.entries.get(key);
+    const bindingMatches = existing?.manifestDigest === manifestDigest;
+    this.entries.set(key, {
+      offset: value,
+      updatedAtMs: nowMs,
+      expiresAtMs: nowMs + this.ttlMs,
+      manifestDigest,
+      ...(bindingMatches
+        && existing?.responderSessionId
         && (existing.responderSessionExpiresAtMs ?? 0) > nowMs
         ? {
             responderSessionId: existing.responderSessionId,
@@ -100,6 +149,7 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
     sessionId: string,
     expiresAtMs: number,
     nowMs = this.clock(),
+    manifestDigest?: DurableManifestDigest,
   ): void {
     if (!sessionId || !Number.isSafeInteger(expiresAtMs)) {
       throw new Error(`Invalid sync responder session for ${key}`);
@@ -109,10 +159,12 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
       return;
     }
     const existing = this.entries.get(key);
+    const bindingMatches = existing?.manifestDigest === manifestDigest;
     this.entries.set(key, {
-      offset: existing?.offset ?? 0,
-      updatedAtMs: existing?.updatedAtMs ?? nowMs,
-      expiresAtMs: existing?.expiresAtMs ?? nowMs + this.ttlMs,
+      offset: bindingMatches ? existing?.offset ?? 0 : 0,
+      updatedAtMs: bindingMatches ? existing?.updatedAtMs ?? nowMs : nowMs,
+      expiresAtMs: bindingMatches ? existing?.expiresAtMs ?? nowMs + this.ttlMs : nowMs + this.ttlMs,
+      ...(manifestDigest ? { manifestDigest } : {}),
       responderSessionId: sessionId,
       responderSessionExpiresAtMs: expiresAtMs,
     });
@@ -125,6 +177,7 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
       offset: existing.offset,
       updatedAtMs: existing.updatedAtMs,
       expiresAtMs: existing.expiresAtMs,
+      ...(existing.manifestDigest ? { manifestDigest: existing.manifestDigest } : {}),
     });
   }
 

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
@@ -184,17 +185,116 @@ function readOrderedGraphScopedDescriptors(
   return descriptorByGraph.size === descriptors.length ? descriptors : null;
 }
 
+export const DURABLE_MANIFEST_DIGEST_DOMAIN = 'origintrail.dkg.durable-data-manifest';
+export const DURABLE_MANIFEST_DIGEST_VERSION = 1;
+
+export interface GraphScopedDurableManifestPlan {
+  readonly contextGraphId: string;
+  readonly manifestDigest: `sha256:${string}`;
+  readonly descriptors: readonly GraphScopedDescriptor[];
+  readonly manifestRowCount: number;
+}
+
+/**
+ * Encode the exact graph-scoped DATA plan without depending on RDF row order.
+ *
+ * Every scalar is length-prefixed independently. This makes embedded
+ * separators and empty optional values unambiguous while the explicit domain
+ * and version prevent the bytes from being reused as another protocol hash.
+ */
+export function encodeGraphScopedDurableManifest(
+  contextGraphId: string,
+  descriptors: readonly GraphScopedDescriptor[],
+  domain = DURABLE_MANIFEST_DIGEST_DOMAIN,
+  version = DURABLE_MANIFEST_DIGEST_VERSION,
+): Uint8Array {
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  const append = (value: string): void => {
+    const bytes = encoder.encode(value);
+    const length = new Uint8Array(4);
+    new DataView(length.buffer).setUint32(0, bytes.byteLength, false);
+    chunks.push(length, bytes);
+    byteLength += length.byteLength + bytes.byteLength;
+  };
+
+  append(domain);
+  append(String(version));
+  append(contextGraphId);
+  append(String(descriptors.length));
+  for (const descriptor of descriptors) {
+    append(descriptor.ual);
+    append(descriptor.contentScopeVersion);
+    append(descriptor.assertionVersion);
+    append(descriptor.contextGraphId);
+    append(descriptor.subGraphName ?? '');
+    append(descriptor.assertionGraph);
+    append(String(descriptor.publicTripleCount));
+    append(descriptor.claimedRootHex);
+    append(String(descriptor.privateTripleCount));
+    append(descriptor.privateRootHex ?? '');
+  }
+
+  const encoded = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    encoded.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return encoded;
+}
+
+/**
+ * Parse, validate, order and bind the complete V2 manifest that defines a
+ * rootless durable DATA plan. `null` means the metadata is incomplete,
+ * malformed, mixed legacy/V2, or belongs to another Context Graph and cannot
+ * authorize a nonzero continuation.
+ */
+export function createGraphScopedDurableManifestPlan(
+  metaQuads: readonly Quad[],
+  contextGraphId: string,
+): GraphScopedDurableManifestPlan | null {
+  const descriptors = readOrderedGraphScopedDescriptors([], metaQuads);
+  if (
+    !descriptors
+    || descriptors.some((descriptor) => descriptor.contextGraphId !== contextGraphId)
+  ) return null;
+
+  let manifestRowCount = 0;
+  for (const descriptor of descriptors) {
+    manifestRowCount += descriptor.publicTripleCount;
+    if (!Number.isSafeInteger(manifestRowCount)) return null;
+  }
+  const canonical = encodeGraphScopedDurableManifest(contextGraphId, descriptors);
+  const manifestDigest = `sha256:${createHash('sha256').update(canonical).digest('hex')}` as const;
+  return {
+    contextGraphId,
+    manifestDigest,
+    descriptors,
+    manifestRowCount,
+  };
+}
+
+function isGraphScopedDurableManifestPlan(
+  value: readonly Quad[] | GraphScopedDurableManifestPlan,
+): value is GraphScopedDurableManifestPlan {
+  return !Array.isArray(value);
+}
+
 /**
  * Check whether a persisted OFFSET is an exact graph boundary in the current
  * rootless manifest. `null` means the metadata is not a pure, structurally
  * valid graph-scoped manifest and therefore cannot justify boundary repair.
  */
 export function isGraphScopedDurableManifestBoundary(
-  metaQuads: readonly Quad[],
+  manifestOrMeta: readonly Quad[] | GraphScopedDurableManifestPlan,
   offset: number,
 ): boolean | null {
   if (!Number.isSafeInteger(offset) || offset < 0) return false;
-  const descriptors = readOrderedGraphScopedDescriptors([], metaQuads);
+  const descriptors = isGraphScopedDurableManifestPlan(manifestOrMeta)
+    ? manifestOrMeta.descriptors
+    : readOrderedGraphScopedDescriptors([], manifestOrMeta);
   if (!descriptors) return null;
   if (offset === 0) return true;
 
@@ -221,7 +321,7 @@ export function isGraphScopedDurableManifestBoundary(
  */
 export function planBoundedGraphScopedDurableBatch(
   dataQuads: readonly Quad[],
-  metaQuads: readonly Quad[],
+  manifestOrMeta: readonly Quad[] | GraphScopedDurableManifestPlan,
   resumedFromOffset: number,
   rawNextOffset: number,
   phaseCompleted: boolean,
@@ -231,7 +331,7 @@ export function planBoundedGraphScopedDurableBatch(
     || resumedFromOffset < 0
     || !Number.isSafeInteger(rawNextOffset)
     || rawNextOffset < resumedFromOffset
-    || metaQuads.length === 0
+    || (!isGraphScopedDurableManifestPlan(manifestOrMeta) && manifestOrMeta.length === 0)
   ) return null;
 
   // Do not require the responder cursor delta to equal the number of received
@@ -243,7 +343,9 @@ export function planBoundedGraphScopedDurableBatch(
   // Requiring cursor/row equality here discarded that independently verifiable
   // prefix and recreated the all-or-nothing retry loop this planner prevents.
 
-  const descriptors = readOrderedGraphScopedDescriptors(dataQuads, metaQuads);
+  const descriptors = isGraphScopedDurableManifestPlan(manifestOrMeta)
+    ? manifestOrMeta.descriptors
+    : readOrderedGraphScopedDescriptors(dataQuads, manifestOrMeta);
   if (!descriptors) return null;
   const descriptorByGraph = new Map(
     descriptors.map((descriptor) => [descriptor.assertionGraph, descriptor] as const),
@@ -339,11 +441,17 @@ export function planBoundedGraphScopedDurableBatch(
   };
 }
 
-interface GraphScopedDescriptor {
+export interface GraphScopedDescriptor {
   ual: string;
+  contentScopeVersion: string;
+  assertionVersion: string;
+  contextGraphId: string;
+  subGraphName?: string;
   assertionGraph: string;
   publicTripleCount: number;
+  privateTripleCount: number;
   privateRoot?: Uint8Array;
+  privateRootHex?: string;
   claimedRootHex: string;
 }
 
@@ -1427,6 +1535,10 @@ function parseGraphScopedDescriptor(ual: string, rows: readonly Quad[]): GraphSc
 
   const metadataUal = requireSingle(KA_UAL, 'kaUal');
   if (metadataUal !== ual) throw new Error(`kaUal mismatch: found ${metadataUal}`);
+  const contentScopeVersion = parseInteger(
+    requireSingle(CONTENT_SCOPE_VERSION, 'contentScopeVersion'),
+    'contentScopeVersion',
+  );
   const assertionVersion = parseInteger(
     requireSingle(ASSERTION_VERSION, 'assertionVersion'),
     'assertionVersion',
@@ -1487,14 +1599,25 @@ function parseGraphScopedDescriptor(ual: string, rows: readonly Quad[]): GraphSc
   if (privateTripleCount === 0 && privateRootValues.length > 0) {
     throw new Error('privateMerkleRoot present without private content');
   }
+  const privateRootHex = privateRootValues[0]
+    ? normalizeHex32(privateRootValues[0], 'privateMerkleRoot')
+    : undefined;
 
   return {
     ual,
+    contentScopeVersion: contentScopeVersion.toString(),
+    assertionVersion: assertionVersion.toString(),
+    contextGraphId,
+    ...(subGraphName === undefined ? {} : { subGraphName }),
     assertionGraph,
     publicTripleCount,
-    privateRoot: privateRootValues[0]
-      ? hexToBytes(normalizeHex32(privateRootValues[0], 'privateMerkleRoot'))
-      : undefined,
+    privateTripleCount,
+    ...(privateRootHex
+      ? {
+          privateRoot: hexToBytes(privateRootHex),
+          privateRootHex,
+        }
+      : {}),
     claimedRootHex: normalizeHex32(requireSingle(MERKLE_ROOT, 'merkleRoot'), 'merkleRoot'),
   };
 }

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -162,10 +162,12 @@ function compareUnicodeCodePoints(leftValue: string, rightValue: string): number
  * Project an incomplete/resumed full snapshot onto a safe V2 graph prefix.
  *
  * This mirrors the responder's `buildExactGraphPagePlan` ordering. The raw
- * offset must start on a manifest boundary and the received rows must be a
- * contiguous prefix of the remaining exact graphs. Any ambiguity fails closed
- * by returning `null`, so callers cannot advance a cursor on attacker-shaped
- * metadata or a mixed legacy/V2 snapshot.
+ * offset must start on a manifest boundary. The checkpointed projection must
+ * be a contiguous prefix of the remaining exact graphs, but an interrupted
+ * partitioned fetch may also contain rows beyond its first incomplete graph;
+ * those non-contiguous tail rows are discarded for replay. Ownership or resume
+ * ambiguity still fails closed by returning `null`, so callers cannot advance
+ * a cursor on attacker-shaped metadata or a mixed legacy/V2 snapshot.
  */
 export function planBoundedGraphScopedDurableBatch(
   dataQuads: readonly Quad[],
@@ -246,7 +248,14 @@ export function planBoundedGraphScopedDurableBatch(
 
     const observed = observedCounts.get(descriptor.assertionGraph) ?? 0;
     if (stoppedAtIncompleteGraph) {
-      if (observed !== 0) return null;
+      // The responder can fetch exact graphs through independent partitions.
+      // An interrupted round may therefore contain rows for later graphs even
+      // though an earlier graph is short. Those rows are not part of the
+      // contiguous checkpointable prefix, but their presence does not make the
+      // already-complete leading graphs ambiguous: graph-scoped metadata still
+      // gives every row an exact owner and the verifier authenticates each
+      // selected graph before storage. Drop the non-contiguous tail and replay
+      // it from the first incomplete boundary on the next round.
       continue;
     }
     if (observed === expected) {

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -187,12 +187,19 @@ function readOrderedGraphScopedDescriptors(
 
 export const DURABLE_MANIFEST_DIGEST_DOMAIN = 'origintrail.dkg.durable-data-manifest';
 export const DURABLE_MANIFEST_DIGEST_VERSION = 1;
+export const DURABLE_MANIFEST_PREFIX_DIGEST_DOMAIN = 'origintrail.dkg.durable-data-manifest-prefix';
 
 export interface GraphScopedDurableManifestPlan {
   readonly contextGraphId: string;
   readonly manifestDigest: `sha256:${string}`;
   readonly descriptors: readonly GraphScopedDescriptor[];
   readonly manifestRowCount: number;
+}
+
+export interface GraphScopedDurableManifestPrefix {
+  readonly offset: number;
+  readonly descriptorCount: number;
+  readonly prefixDigest: `sha256:${string}`;
 }
 
 /**
@@ -273,6 +280,64 @@ export function createGraphScopedDurableManifestPlan(
     manifestDigest,
     descriptors,
     manifestRowCount,
+  };
+}
+
+/**
+ * Bind one verified DATA checkpoint boundary to the canonical descriptor
+ * prefix that gives that offset meaning.
+ *
+ * Zero-width descriptors immediately following a positive-width graph are
+ * included at that boundary. This makes inserting/removing a private-only or
+ * empty asset before the next DATA row observable even though the numeric
+ * offset does not move.
+ */
+export function graphScopedDurableManifestPrefixAtOffset(
+  manifest: GraphScopedDurableManifestPlan,
+  offset: number,
+): GraphScopedDurableManifestPrefix | null {
+  if (!Number.isSafeInteger(offset) || offset < 0) return null;
+
+  let rowCount = 0;
+  let descriptorCount = 0;
+  if (offset === 0) {
+    while (
+      descriptorCount < manifest.descriptors.length
+      && manifest.descriptors[descriptorCount]!.publicTripleCount === 0
+    ) {
+      descriptorCount += 1;
+    }
+  }
+  for (const descriptor of manifest.descriptors) {
+    if (offset === 0) break;
+    const nextRowCount = rowCount + descriptor.publicTripleCount;
+    if (!Number.isSafeInteger(nextRowCount)) return null;
+    if (nextRowCount > offset) return null;
+    rowCount = nextRowCount;
+    descriptorCount += 1;
+
+    if (rowCount === offset) {
+      while (
+        descriptorCount < manifest.descriptors.length
+        && manifest.descriptors[descriptorCount]!.publicTripleCount === 0
+      ) {
+        descriptorCount += 1;
+      }
+      break;
+    }
+  }
+
+  if (rowCount !== offset) return null;
+  const canonical = encodeGraphScopedDurableManifest(
+    manifest.contextGraphId,
+    manifest.descriptors.slice(0, descriptorCount),
+    DURABLE_MANIFEST_PREFIX_DIGEST_DOMAIN,
+    DURABLE_MANIFEST_DIGEST_VERSION,
+  );
+  return {
+    offset,
+    descriptorCount,
+    prefixDigest: `sha256:${createHash('sha256').update(canonical).digest('hex')}`,
   };
 }
 

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -158,6 +158,56 @@ function compareUnicodeCodePoints(leftValue: string, rightValue: string): number
   return left.length - right.length;
 }
 
+function readOrderedGraphScopedDescriptors(
+  dataQuads: readonly Quad[],
+  metaQuads: readonly Quad[],
+): GraphScopedDescriptor[] | null {
+  // #1921 — verification must never see non-IRI `_meta` subjects: a peer's
+  // `_:bad dkg:partOf "<valid-ual>"` row would otherwise be scanned by
+  // readIntegrityMetadata and falsely invalidate that valid graph-scoped UAL.
+  const iriMetaQuads = metaQuads.filter((quad) => isIriMetaSubject(quad.subject));
+  const metadata = indexIntegrityMetadata(dataQuads, iriMetaQuads);
+  const parsed = readIntegrityMetadata(metadata, false);
+  if (
+    parsed.fatalUnscopedFailure
+    || parsed.invalidKcUals.size > 0
+    || parsed.candidates.length === 0
+    || parsed.candidates.some((candidate) => candidate.kind !== 'graph-scoped')
+  ) return null;
+
+  const descriptors = (parsed.candidates as GraphScopedCandidate[])
+    .map((candidate) => candidate.descriptor)
+    .sort((left, right) => compareUnicodeCodePoints(left.assertionGraph, right.assertionGraph));
+  const descriptorByGraph = new Map(
+    descriptors.map((descriptor) => [descriptor.assertionGraph, descriptor] as const),
+  );
+  return descriptorByGraph.size === descriptors.length ? descriptors : null;
+}
+
+/**
+ * Check whether a persisted OFFSET is an exact graph boundary in the current
+ * rootless manifest. `null` means the metadata is not a pure, structurally
+ * valid graph-scoped manifest and therefore cannot justify boundary repair.
+ */
+export function isGraphScopedDurableManifestBoundary(
+  metaQuads: readonly Quad[],
+  offset: number,
+): boolean | null {
+  if (!Number.isSafeInteger(offset) || offset < 0) return false;
+  const descriptors = readOrderedGraphScopedDescriptors([], metaQuads);
+  if (!descriptors) return null;
+  if (offset === 0) return true;
+
+  let boundary = 0;
+  for (const descriptor of descriptors) {
+    boundary += descriptor.publicTripleCount;
+    if (!Number.isSafeInteger(boundary)) return false;
+    if (offset === boundary) return true;
+    if (offset < boundary) return false;
+  }
+  return false;
+}
+
 /**
  * Project an incomplete/resumed full snapshot onto a safe V2 graph prefix.
  *
@@ -185,28 +235,11 @@ export function planBoundedGraphScopedDurableBatch(
     || metaQuads.length === 0
   ) return null;
 
-  // #1921 — verification must never see non-IRI `_meta` subjects: a peer's
-  // `_:bad dkg:partOf "<valid-ual>"` row would otherwise be scanned by
-  // readIntegrityMetadata and falsely invalidate the valid graph-scoped UAL.
-  // Sanitize before indexing. The bounded planner returns only data offsets,
-  // so dropping non-IRI meta rows here is loss-free.
-  const iriMetaQuads = metaQuads.filter((quad) => isIriMetaSubject(quad.subject));
-  const metadata = indexIntegrityMetadata(dataQuads, iriMetaQuads);
-  const parsed = readIntegrityMetadata(metadata, false);
-  if (
-    parsed.fatalUnscopedFailure
-    || parsed.invalidKcUals.size > 0
-    || parsed.candidates.length === 0
-    || parsed.candidates.some((candidate) => candidate.kind !== 'graph-scoped')
-  ) return null;
-
-  const descriptors = (parsed.candidates as GraphScopedCandidate[])
-    .map((candidate) => candidate.descriptor)
-    .sort((left, right) => compareUnicodeCodePoints(left.assertionGraph, right.assertionGraph));
+  const descriptors = readOrderedGraphScopedDescriptors(dataQuads, metaQuads);
+  if (!descriptors) return null;
   const descriptorByGraph = new Map(
     descriptors.map((descriptor) => [descriptor.assertionGraph, descriptor] as const),
   );
-  if (descriptorByGraph.size !== descriptors.length) return null;
 
   const observedCounts = new Map<string, number>();
   for (const quad of dataQuads) {

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -231,9 +231,17 @@ export function planBoundedGraphScopedDurableBatch(
     || resumedFromOffset < 0
     || !Number.isSafeInteger(rawNextOffset)
     || rawNextOffset < resumedFromOffset
-    || rawNextOffset - resumedFromOffset !== dataQuads.length
     || metaQuads.length === 0
   ) return null;
+
+  // Do not require the responder cursor delta to equal the number of received
+  // rows. Older responders can advance their session cursor past a short
+  // exact-graph read before the requester observes the transport deadline.
+  // Graph ownership, exact descriptor counts, and Merkle verification below
+  // still make only the complete leading graphs checkpointable: a skipped row
+  // makes its graph incomplete and drops that graph plus every later graph.
+  // Requiring cursor/row equality here discarded that independently verifiable
+  // prefix and recreated the all-or-nothing retry loop this planner prevents.
 
   const descriptors = readOrderedGraphScopedDescriptors(dataQuads, metaQuads);
   if (!descriptors) return null;

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -13,8 +13,10 @@ import {
 import type { DurableBatchVerificationMode } from '../../sync-verify-worker.js';
 import { packKnowledgeAssetIdFromIdentity } from '../../ka-identity.js';
 import {
+  createGraphScopedDurableManifestPlan,
   isGraphScopedDurableManifestBoundary,
   planBoundedGraphScopedDurableBatch,
+  type GraphScopedDurableManifestPlan,
 } from '../durable-integrity.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import {
@@ -24,7 +26,10 @@ import {
   recordDurableSyncDiagnostics,
   type InitializedDurableSyncResult,
 } from '../durable-progress.js';
-import { getSyncCheckpointKey } from '../checkpoint/state.js';
+import {
+  getSyncCheckpointKey,
+  type DurableManifestDigest,
+} from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
 import type {
   GraphScopedMaterializationOutcome,
@@ -142,6 +147,10 @@ export interface DurableSyncFetchRequest {
   readonly snapshotRef?: string;
   readonly sinceBatchId?: string;
   readonly exactAssetUals?: string[];
+  /** Canonical META generation that authorizes this DATA continuation. */
+  readonly manifestDigest?: DurableManifestDigest;
+  /** Identity is unprovable; rotate any saved DATA continuation before fetch. */
+  readonly forceFreshSession?: boolean;
   readonly fetchContext: DurableSyncFetchContext;
 }
 
@@ -219,7 +228,7 @@ export interface DurableSyncContext {
   /** Runs after verified snapshot writes and before phase checkpoints advance. */
   onVerifiedFullSnapshot?: (snapshot: VerifiedFullSnapshot) => Promise<void>;
   deleteCheckpoint: (key: string) => void;
-  setCheckpoint: (key: string, offset: number) => void;
+  setCheckpoint: (key: string, offset: number, manifestDigest?: DurableManifestDigest) => void;
   logInfo: (ctx: OperationContext, message: string) => void;
   logWarn: (ctx: OperationContext, message: string) => void;
   logDebug: (ctx: OperationContext, message: string) => void;
@@ -294,6 +303,7 @@ async function runDurableSyncWithBudget(
       updateCheckpoint: boolean;
       countProgress?: boolean;
       emptyPhase?: boolean;
+      manifestDigest?: DurableManifestDigest;
     },
   ) => {
     const countProgress = options.countProgress ?? true;
@@ -324,7 +334,7 @@ async function runDurableSyncWithBudget(
     if (!options.updateCheckpoint) return;
     if (result.completed) deleteCheckpoint(result.checkpointKey);
     else if (result.nextOffset > 0 || result.resumedFromOffset > 0) {
-      setCheckpoint(result.checkpointKey, result.nextOffset);
+      setCheckpoint(result.checkpointKey, result.nextOffset, options.manifestDigest);
     }
   };
 
@@ -387,6 +397,8 @@ async function runDurableSyncWithBudget(
         phase: 'data' | 'meta',
         graphUri: string,
         sinceBatchId?: string,
+        manifestDigest?: DurableManifestDigest,
+        forceFreshSession?: boolean,
       ): Promise<SyncPageResult> => fetchSyncPages({
         ctx,
         remotePeerId,
@@ -395,6 +407,8 @@ async function runDurableSyncWithBudget(
         graphUri,
         sinceBatchId,
         exactAssetUals,
+        manifestDigest,
+        forceFreshSession,
         fetchContext: fetchContext(phase === 'meta' ? metaFetchDeadline : deadline),
       });
       const metaResult: SyncPageResult = skipAgentsMeta
@@ -415,7 +429,42 @@ async function runDurableSyncWithBudget(
       // next context graph when stopOnBackoffWorthyFailure is enabled.
       throwIfOperationAborted();
       const sinceBatchId = sinceBatchIdFor?.(pid);
-      const rawDataResult = await fetchPhase('data', dataGraph, sinceBatchId);
+      let graphScopedManifest: GraphScopedDurableManifestPlan | null = null;
+      let forceFreshUnboundDataSession = false;
+      if (sinceBatchId === undefined && !isSystemContextGraph) {
+        if (
+          !metaResult.completed
+          || metaResult.timedOut
+          || metaResult.resumedFromOffset !== 0
+        ) {
+          // A suffix or incomplete META phase is not a manifest. It cannot
+          // identify the generation of a saved DATA OFFSET/session, so do not
+          // fetch or advance DATA under it. A legacy resumed META checkpoint
+          // is discarded so the next round can obtain the complete manifest.
+          if (metaResult.resumedFromOffset !== 0) {
+            deleteCheckpoint(metaResult.checkpointKey);
+          }
+          throw Object.assign(
+            new Error(
+              `Cannot authorize durable DATA continuation for "${pid}": `
+              + 'META did not complete from offset zero',
+            ),
+            { code: 'SYNC_DATA_MANIFEST_INCOMPLETE' },
+          );
+        }
+        graphScopedManifest = createGraphScopedDurableManifestPlan(metaResult.quads, pid);
+        // Legacy/mixed/malformed metadata has no canonical generation identity.
+        // It may still complete safely in one round, but never by trusting a
+        // saved nonzero offset or responder token.
+        forceFreshUnboundDataSession = graphScopedManifest === null;
+      }
+      const rawDataResult = await fetchPhase(
+        'data',
+        dataGraph,
+        sinceBatchId,
+        graphScopedManifest?.manifestDigest,
+        forceFreshUnboundDataSession,
+      );
       throwIfOperationAborted();
       peerRespondedForContextGraph = true;
       endPhase();
@@ -462,9 +511,23 @@ async function runDurableSyncWithBudget(
         sinceBatchId === undefined
         && !isSystemContextGraph
       ) {
+        if (
+          graphScopedManifest
+          && dataResult.resumedFromOffset > 0
+          && dataResult.manifestDigest !== graphScopedManifest.manifestDigest
+        ) {
+          deleteCheckpoint(dataResult.checkpointKey);
+          throw Object.assign(
+            new Error(
+              `Discarding rootless durable response for "${pid}": resumed DATA `
+              + 'continuation is not bound to the completed META generation',
+            ),
+            { code: 'SYNC_DATA_MANIFEST_UNBOUND' },
+          );
+        }
         const resumeIsManifestBoundary = dataResult.resumedFromOffset > 0
           ? isGraphScopedDurableManifestBoundary(
-            effectiveMetaResult.quads,
+            graphScopedManifest ?? effectiveMetaResult.quads,
             dataResult.resumedFromOffset,
           )
           : true;
@@ -495,7 +558,7 @@ async function runDurableSyncWithBudget(
         }
         const bounded = planBoundedGraphScopedDurableBatch(
           dataResult.quads,
-          effectiveMetaResult.quads,
+          graphScopedManifest ?? effectiveMetaResult.quads,
           dataResult.resumedFromOffset,
           dataResult.nextOffset,
           dataResult.completed,
@@ -525,13 +588,19 @@ async function runDurableSyncWithBudget(
 
       startPhase('verify');
       const verifyStartedAt = Date.now();
-      const processed = await processDurableBatchInWorker(
-        dataForVerification,
-        effectiveMetaResult.quads,
-        ctx,
-        isSystemContextGraph,
-        verificationMode,
-      );
+      let processed: Awaited<ReturnType<DurableSyncContext['processDurableBatchInWorker']>>;
+      try {
+        processed = await processDurableBatchInWorker(
+          dataForVerification,
+          effectiveMetaResult.quads,
+          ctx,
+          isSystemContextGraph,
+          verificationMode,
+        );
+      } catch (error) {
+        if (graphScopedManifest) deleteCheckpoint(rawDataResult.checkpointKey);
+        throw error;
+      }
       throwIfOperationAborted();
       endPhase();
       const verifyDurationMs = Date.now() - verifyStartedAt;
@@ -554,11 +623,15 @@ async function runDurableSyncWithBudget(
       // instead of silently skipping it.
       const batchVerifiedCleanly = processed.rejectedKcs === 0;
       if (!batchVerifiedCleanly) {
+        if (graphScopedManifest) deleteCheckpoint(rawDataResult.checkpointKey);
         logWarn(
           ctx,
           `Rejected ${processed.rejectedKcs} KCs that failed durable integrity verification from ${remotePeerId}`,
         );
         recordDurableSyncDiagnostics(accumulator, { rejectedKcs: processed.rejectedKcs });
+      }
+      if (graphScopedManifest && processed.dataRejectedMissingMeta !== 0) {
+        deleteCheckpoint(rawDataResult.checkpointKey);
       }
 
       const notifyVerifiedFullSnapshot = async (): Promise<void> => {
@@ -654,6 +727,7 @@ async function runDurableSyncWithBudget(
         recordPhaseOutcome(effectiveDataResult, {
           updateCheckpoint: updateDataCheckpoint,
           emptyPhase,
+          manifestDigest: graphScopedManifest?.manifestDigest,
         });
         markDurableTerminalBoundary(accumulator, reachedContextGraphTerminalBoundary);
         if (exactFetchDispositionIndex !== undefined) {
@@ -735,7 +809,10 @@ async function runDurableSyncWithBudget(
       await notifyVerifiedFullSnapshot();
       throwIfOperationAborted();
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
-      recordPhaseOutcome(effectiveDataResult, { updateCheckpoint: updateDataCheckpoint });
+      recordPhaseOutcome(effectiveDataResult, {
+        updateCheckpoint: updateDataCheckpoint,
+        manifestDigest: graphScopedManifest?.manifestDigest,
+      });
       markDurableTerminalBoundary(accumulator, reachedContextGraphTerminalBoundary);
       if (exactFetchDispositionIndex !== undefined) {
         exactFetchDispositions[exactFetchDispositionIndex] = settledExactDisposition();

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -14,6 +14,7 @@ import type { DurableBatchVerificationMode } from '../../sync-verify-worker.js';
 import { packKnowledgeAssetIdFromIdentity } from '../../ka-identity.js';
 import {
   createGraphScopedDurableManifestPlan,
+  graphScopedDurableManifestPrefixAtOffset,
   isGraphScopedDurableManifestBoundary,
   planBoundedGraphScopedDurableBatch,
   type GraphScopedDurableManifestPlan,
@@ -29,6 +30,7 @@ import {
 import {
   getSyncCheckpointKey,
   type DurableManifestDigest,
+  type DurableManifestPrefixDigest,
 } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
 import type {
@@ -149,6 +151,10 @@ export interface DurableSyncFetchRequest {
   readonly exactAssetUals?: string[];
   /** Canonical META generation that authorizes this DATA continuation. */
   readonly manifestDigest?: DurableManifestDigest;
+  /** Canonical descriptor-prefix proof for safe cross-generation reuse. */
+  readonly manifestPrefixDigestAtOffset?: (
+    offset: number,
+  ) => DurableManifestPrefixDigest | undefined;
   /** Identity is unprovable; rotate any saved DATA continuation before fetch. */
   readonly forceFreshSession?: boolean;
   readonly fetchContext: DurableSyncFetchContext;
@@ -228,7 +234,12 @@ export interface DurableSyncContext {
   /** Runs after verified snapshot writes and before phase checkpoints advance. */
   onVerifiedFullSnapshot?: (snapshot: VerifiedFullSnapshot) => Promise<void>;
   deleteCheckpoint: (key: string) => void;
-  setCheckpoint: (key: string, offset: number, manifestDigest?: DurableManifestDigest) => void;
+  setCheckpoint: (
+    key: string,
+    offset: number,
+    manifestDigest?: DurableManifestDigest,
+    manifestPrefixDigest?: DurableManifestPrefixDigest,
+  ) => void;
   logInfo: (ctx: OperationContext, message: string) => void;
   logWarn: (ctx: OperationContext, message: string) => void;
   logDebug: (ctx: OperationContext, message: string) => void;
@@ -303,7 +314,7 @@ async function runDurableSyncWithBudget(
       updateCheckpoint: boolean;
       countProgress?: boolean;
       emptyPhase?: boolean;
-      manifestDigest?: DurableManifestDigest;
+      manifestPlan?: GraphScopedDurableManifestPlan;
     },
   ) => {
     const countProgress = options.countProgress ?? true;
@@ -334,7 +345,27 @@ async function runDurableSyncWithBudget(
     if (!options.updateCheckpoint) return;
     if (result.completed) deleteCheckpoint(result.checkpointKey);
     else if (result.nextOffset > 0 || result.resumedFromOffset > 0) {
-      setCheckpoint(result.checkpointKey, result.nextOffset, options.manifestDigest);
+      if (options.manifestPlan) {
+        const prefix = graphScopedDurableManifestPrefixAtOffset(
+          options.manifestPlan,
+          result.nextOffset,
+        );
+        if (!prefix) {
+          deleteCheckpoint(result.checkpointKey);
+          throw new Error(
+            `Refusing to checkpoint durable DATA offset ${result.nextOffset}: `
+            + 'the completed META manifest has no matching graph boundary',
+          );
+        }
+        setCheckpoint(
+          result.checkpointKey,
+          result.nextOffset,
+          options.manifestPlan.manifestDigest,
+          prefix.prefixDigest,
+        );
+      } else {
+        setCheckpoint(result.checkpointKey, result.nextOffset);
+      }
     }
   };
 
@@ -398,6 +429,9 @@ async function runDurableSyncWithBudget(
         graphUri: string,
         sinceBatchId?: string,
         manifestDigest?: DurableManifestDigest,
+        manifestPrefixDigestAtOffset?: (
+          offset: number,
+        ) => DurableManifestPrefixDigest | undefined,
         forceFreshSession?: boolean,
       ): Promise<SyncPageResult> => fetchSyncPages({
         ctx,
@@ -408,6 +442,7 @@ async function runDurableSyncWithBudget(
         sinceBatchId,
         exactAssetUals,
         manifestDigest,
+        manifestPrefixDigestAtOffset,
         forceFreshSession,
         fetchContext: fetchContext(phase === 'meta' ? metaFetchDeadline : deadline),
       });
@@ -429,6 +464,21 @@ async function runDurableSyncWithBudget(
       // next context graph when stopOnBackoffWorthyFailure is enabled.
       throwIfOperationAborted();
       const sinceBatchId = sinceBatchIdFor?.(pid);
+      let effectiveMetaResult = metaResult;
+      let exactAssetDescriptorCoverageComplete = true;
+      if (exactAssetUals !== undefined) {
+        // Scope META before it defines the DATA generation. Older responders
+        // can ignore the exact-asset wire filter and over-return descriptors;
+        // those unrelated assets must not enter the continuation digest or
+        // bounded DATA plan for the requested subset.
+        const exactMeta = filterExactAssetDurablePayload(
+          [],
+          metaResult.quads,
+          exactAssetUals,
+        );
+        effectiveMetaResult = { ...metaResult, quads: exactMeta.metaQuads };
+        exactAssetDescriptorCoverageComplete = exactMeta.descriptorCoverageComplete;
+      }
       let graphScopedManifest: GraphScopedDurableManifestPlan | null = null;
       let forceFreshUnboundDataSession = false;
       if (sinceBatchId === undefined && !isSystemContextGraph) {
@@ -452,7 +502,10 @@ async function runDurableSyncWithBudget(
             { code: 'SYNC_DATA_MANIFEST_INCOMPLETE' },
           );
         }
-        graphScopedManifest = createGraphScopedDurableManifestPlan(metaResult.quads, pid);
+        graphScopedManifest = createGraphScopedDurableManifestPlan(
+          effectiveMetaResult.quads,
+          pid,
+        );
         // Legacy/mixed/malformed metadata has no canonical generation identity.
         // It may still complete safely in one round, but never by trusting a
         // saved nonzero offset or responder token.
@@ -463,15 +516,19 @@ async function runDurableSyncWithBudget(
         dataGraph,
         sinceBatchId,
         graphScopedManifest?.manifestDigest,
+        graphScopedManifest
+          ? (offset) => graphScopedDurableManifestPrefixAtOffset(
+            graphScopedManifest!,
+            offset,
+          )?.prefixDigest
+          : undefined,
         forceFreshUnboundDataSession,
       );
       throwIfOperationAborted();
       peerRespondedForContextGraph = true;
       endPhase();
       const fetchDurationMs = Date.now() - fetchStartedAt;
-      let effectiveMetaResult = metaResult;
       let dataResult = rawDataResult;
-      let exactAssetDescriptorCoverageComplete = true;
       if (exactAssetUals !== undefined) {
         const exact = filterExactAssetDurablePayload(
           rawDataResult.quads,
@@ -727,7 +784,7 @@ async function runDurableSyncWithBudget(
         recordPhaseOutcome(effectiveDataResult, {
           updateCheckpoint: updateDataCheckpoint,
           emptyPhase,
-          manifestDigest: graphScopedManifest?.manifestDigest,
+          manifestPlan: graphScopedManifest ?? undefined,
         });
         markDurableTerminalBoundary(accumulator, reachedContextGraphTerminalBoundary);
         if (exactFetchDispositionIndex !== undefined) {
@@ -811,7 +868,7 @@ async function runDurableSyncWithBudget(
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
       recordPhaseOutcome(effectiveDataResult, {
         updateCheckpoint: updateDataCheckpoint,
-        manifestDigest: graphScopedManifest?.manifestDigest,
+        manifestPlan: graphScopedManifest ?? undefined,
       });
       markDurableTerminalBoundary(accumulator, reachedContextGraphTerminalBoundary);
       if (exactFetchDispositionIndex !== undefined) {

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -12,7 +12,10 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { DurableBatchVerificationMode } from '../../sync-verify-worker.js';
 import { packKnowledgeAssetIdFromIdentity } from '../../ka-identity.js';
-import { planBoundedGraphScopedDurableBatch } from '../durable-integrity.js';
+import {
+  isGraphScopedDurableManifestBoundary,
+  planBoundedGraphScopedDurableBatch,
+} from '../durable-integrity.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import {
   createDurableSyncAccumulator,
@@ -459,6 +462,28 @@ async function runDurableSyncWithBudget(
         sinceBatchId === undefined
         && !isSystemContextGraph
       ) {
+        const resumeIsManifestBoundary = dataResult.resumedFromOffset > 0
+          ? isGraphScopedDurableManifestBoundary(
+            effectiveMetaResult.quads,
+            dataResult.resumedFromOffset,
+          )
+          : true;
+        if (resumeIsManifestBoundary === false) {
+          // An OFFSET inside an exact assertion graph can never produce a
+          // complete first graph in this round. Keeping it creates a permanent
+          // N-1 verification loop (for example 9,999/10,000 rows). Delete the
+          // paired responder session/checkpoint and retry from offset zero on
+          // the next bounded sync; never store this non-contiguous suffix.
+          deleteCheckpoint(dataResult.checkpointKey);
+          throw Object.assign(
+            new Error(
+              `Discarding rootless durable response for "${pid}": resumed offset `
+              + `${dataResult.resumedFromOffset} is inside an assertion graph; `
+              + 'resetting the data checkpoint to a manifest boundary',
+            ),
+            { code: 'SYNC_GRAPH_CHECKPOINT_MISALIGNED' },
+          );
+        }
         const bounded = planBoundedGraphScopedDurableBatch(
           dataResult.quads,
           effectiveMetaResult.quads,

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -484,6 +484,15 @@ async function runDurableSyncWithBudget(
             { code: 'SYNC_GRAPH_CHECKPOINT_MISALIGNED' },
           );
         }
+        const responderCursorDelta = dataResult.nextOffset - dataResult.resumedFromOffset;
+        if (responderCursorDelta !== dataResult.quads.length) {
+          logWarn(
+            ctx,
+            `Rootless durable cursor drift for "${pid}": responder advanced `
+              + `${responderCursorDelta} row(s) but delivered ${dataResult.quads.length}; `
+              + 'projecting only the verified complete-graph prefix',
+          );
+        }
         const bounded = planBoundedGraphScopedDurableBatch(
           dataResult.quads,
           effectiveMetaResult.quads,

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -31,6 +31,8 @@ import {
 } from '../memory-telemetry.js';
 import {
   SYNC_PAGE_SIZE,
+  SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD,
+  SYNC_REQUEST_INITIAL_PAGE_SIZE,
   SYNC_REQUEST_SAFE_PAGE_SIZE,
 } from '../../dkg-agent-constants.js';
 
@@ -262,9 +264,10 @@ class AdaptiveSyncPageSizer {
     private readonly rememberPreferredPageSize?: (pageSize: number) => void,
   ) {
     this.safePageSize = Math.min(syncPageSize, SYNC_REQUEST_SAFE_PAGE_SIZE);
+    const initialPageSize = Math.min(syncPageSize, SYNC_REQUEST_INITIAL_PAGE_SIZE);
     this.activePageSize = Number.isSafeInteger(preferredPageSize)
       ? Math.max(this.safePageSize, Math.min(syncPageSize, preferredPageSize!))
-      : syncPageSize;
+      : Math.max(this.safePageSize, initialPageSize);
   }
 
   current(): number {
@@ -303,7 +306,7 @@ class AdaptiveSyncPageSizer {
     this.rememberCurrentPageSize();
     if (this.usesByteBudgetPagination && this.activePageSize < this.syncPageSize) {
       this.consecutiveSuccessfulPages += 1;
-      if (this.consecutiveSuccessfulPages >= 3) {
+      if (this.consecutiveSuccessfulPages >= SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD) {
         this.activePageSize = Math.min(
           this.syncPageSize,
           this.activePageSize * 2,
@@ -579,8 +582,10 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   let acceptedHeapBytesEstimate = 0;
   let responsePages = 0;
   let timedOut = false;
-  // Start with the throughput-oriented page size, but reduce it within the
-  // existing bounded retry budget if a response cannot traverse the wire.
+  // Start an unknown peer/path at the conservative initial page size, then
+  // grow toward the throughput ceiling only after sustained success. Reduce
+  // within the existing bounded retry budget if a response cannot traverse
+  // the wire.
   // ProtocolRouter may surface an oversized response as a generic stream reset,
   // so the reduction intentionally applies to any retryable transport failure.
   // A transient failure merely makes the remainder of this phase conservative;
@@ -588,11 +593,11 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   // Byte-budget pagination: a SHORT page is NOT EOF — only an empty response is
   // (see the loop's EOF checks). This is a REQUESTER-SIDE default derived from
   // `syncPageSize > SYNC_PAGE_SIZE` (the fetch wrapper passes
-  // SYNC_REQUEST_PAGE_SIZE=8192 for every phase), NOT a wire-negotiated
+  // a ceiling above SYNC_PAGE_SIZE for every phase), NOT a wire-negotiated
   // capability. Durable meta relies on it: since #1916 the responder byte-caps
   // durable-meta pages, so a page can be short for byte reasons; a requester
   // that treated "short = EOF" for meta could end the phase early. Every
-  // testnet-canary+ requester uses 8192 here, so short≠EOF holds for meta and
+  // testnet-canary+ requester uses a byte-budget ceiling here, so short≠EOF holds for meta and
   // data alike; a pre-canary requester using the 500-row cap is the only one
   // that would regress, and only on an oversized (>4 MiB) meta subject.
   const usesByteBudgetPagination = syncPageSize > SYNC_PAGE_SIZE;
@@ -610,7 +615,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       ? (pageSize) => pageSizeProfileCache.remember(pageSizeProfileScope, pageSize)
       : undefined,
   );
-  let successfulPageSize = syncPageSize;
+  let successfulPageSize = adaptivePageSizer.current();
   const syncSessionId = usesPageSession
     ? (savedResponderSession?.syncSessionId ?? createResponderSessionId(includeSharedMemory, phase))
     : undefined;

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -18,6 +18,7 @@ import { exactAssetFilterKey } from '../exact-assets.js';
 import {
   getSyncCheckpointKey,
   type DurableManifestDigest,
+  type DurableManifestPrefixDigest,
   type SyncCheckpointScope,
   type SyncCheckpointStore,
 } from '../checkpoint/state.js';
@@ -93,6 +94,7 @@ function persistUnfinishedSyncResponderSession(
   checkpointKey: string,
   session: UnfinishedSyncResponderSession,
   manifestDigest: DurableManifestDigest | undefined,
+  manifestPrefixDigest: DurableManifestPrefixDigest | undefined,
   now = Date.now(),
 ): void {
   rememberUnfinishedSyncResponderSession(checkpointKey, {
@@ -105,6 +107,7 @@ function persistUnfinishedSyncResponderSession(
     session.expiresAt,
     now,
     manifestDigest,
+    manifestPrefixDigest,
   );
 }
 
@@ -359,6 +362,10 @@ export interface SyncPageFetchOptions {
   readonly forceFreshSession?: boolean;
   /** Completed canonical META generation that defines a durable DATA plan. */
   readonly manifestDigest?: DurableManifestDigest;
+  /** Canonical prefix proof for any candidate checkpoint offset. */
+  readonly manifestPrefixDigestAtOffset?: (
+    offset: number,
+  ) => DurableManifestPrefixDigest | undefined;
   readonly assetUals?: string[];
   /**
    * Permit the selected-SWM transfer owner to retain a validated metadata
@@ -425,6 +432,10 @@ interface FetchSyncPagesParams {
   forceFreshSession?: boolean;
   /** Enforces generation identity for durable DATA continuation state. */
   manifestDigest?: DurableManifestDigest;
+  /** Allows a changed generation to retain a cryptographically identical prefix. */
+  manifestPrefixDigestAtOffset?: (
+    offset: number,
+  ) => DurableManifestPrefixDigest | undefined;
   /**
    * R9/R10 — member SWM recovery marker. Forks BOTH the checkpoint namespace
    * (R10: distinct `|recovery` cursor + responder-session scope so it never
@@ -538,6 +549,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     checkpointStore,
     forceFreshSession,
     manifestDigest,
+    manifestPrefixDigestAtOffset,
     recovery,
     buildSyncRequest,
     sinceBatchId,
@@ -578,12 +590,75 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     unfinishedSyncResponderSessions.delete(checkpointKey);
   }
   let checkpoint = checkpointStore.get(checkpointKey);
-  if (manifestDigest && checkpoint?.manifestDigest !== manifestDigest) {
-    // OFFSET has meaning only inside the exact META generation that produced
-    // the responder DATA plan. A legacy/missing binding is just as unprovable
-    // as a mismatch, so rotate the token and restart from zero as one action.
-    deleteSyncPageCheckpoint(checkpointStore, checkpointKey);
-    checkpoint = undefined;
+  let responderSessionNeedsPriming = false;
+  if (manifestDigest && checkpoint) {
+    const currentPrefixDigest = manifestPrefixDigestAtOffset?.(checkpoint.offset);
+    const fullGenerationMatches = checkpoint.manifestDigest === manifestDigest;
+    const savedPrefixMatches = checkpoint.manifestPrefixDigest !== undefined
+      && checkpoint.manifestPrefixDigest === currentPrefixDigest;
+    const offsetHasCurrentBoundaryProof = checkpoint.offset === 0
+      || currentPrefixDigest !== undefined;
+
+    if (!fullGenerationMatches) {
+      if (
+        assetUals === undefined
+        && checkpoint.offset > 0
+        && savedPrefixMatches
+        && checkpointStore.setManifestBoundOffset
+      ) {
+        // The suffix changed, but every descriptor through the verified graph
+        // boundary is byte-identical. Rebind that prefix to the fresh META
+        // generation and rotate only the responder snapshot. The new token is
+        // primed at offset zero below before it is allowed to jump to this
+        // boundary, so raw responder cursor semantics remain generation-local.
+        checkpointStore.setManifestBoundOffset(
+          checkpointKey,
+          checkpoint.offset,
+          manifestDigest,
+          Date.now(),
+          currentPrefixDigest,
+        );
+        unfinishedSyncResponderSessions.delete(checkpointKey);
+        checkpoint = checkpointStore.get(checkpointKey);
+        responderSessionNeedsPriming = true;
+        logInfo(
+          ctx,
+          `Reusing verified durable prefix for "${contextGraphId}" through offset ${checkpoint?.offset ?? 0} after META generation change`,
+        );
+      } else {
+        // OFFSET has meaning only inside the exact META generation that
+        // produced it. Missing legacy prefix proof, a changed prefix, or a
+        // custom store that cannot atomically rebind the tuple all restart.
+        deleteSyncPageCheckpoint(checkpointStore, checkpointKey);
+        checkpoint = undefined;
+      }
+    } else if (!offsetHasCurrentBoundaryProof) {
+      deleteSyncPageCheckpoint(checkpointStore, checkpointKey);
+      checkpoint = undefined;
+    } else if (
+      checkpoint.offset > 0
+      && checkpoint.manifestPrefixDigest !== undefined
+      && !savedPrefixMatches
+    ) {
+      deleteSyncPageCheckpoint(checkpointStore, checkpointKey);
+      checkpoint = undefined;
+    } else if (
+      checkpoint.offset > 0
+      && currentPrefixDigest !== undefined
+      && checkpoint.manifestPrefixDigest === undefined
+      && checkpointStore.setManifestBoundOffset
+    ) {
+      // Upgrade an otherwise generation-bound checkpoint so a later suffix
+      // change or responder restart can reuse its verified prefix safely.
+      checkpointStore.setManifestBoundOffset(
+        checkpointKey,
+        checkpoint.offset,
+        manifestDigest,
+        Date.now(),
+        currentPrefixDigest,
+      );
+      checkpoint = checkpointStore.get(checkpointKey);
+    }
   }
   let offset = checkpoint?.offset ?? 0;
   const usesPageSession = usesResponderSession(includeSharedMemory, phase);
@@ -602,10 +677,37 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     : undefined;
   const responderSessionStartedFresh = savedResponderSession === undefined;
   if (usesPageSession && offset > 0 && !savedResponderSession) {
-    checkpointStore.delete(checkpointKey);
-    offset = 0;
+    const currentPrefixDigest = manifestPrefixDigestAtOffset?.(offset);
+    if (
+      assetUals === undefined
+      && manifestDigest
+      && checkpoint?.manifestDigest === manifestDigest
+      && checkpoint?.manifestPrefixDigest === currentPrefixDigest
+      && currentPrefixDigest !== undefined
+    ) {
+      // The local verified prefix remains proven, but the responder token was
+      // evicted/restarted. Prime a new immutable responder generation instead
+      // of throwing away the local prefix.
+      responderSessionNeedsPriming = true;
+    } else {
+      checkpointStore.delete(checkpointKey);
+      offset = 0;
+    }
   }
   const resumedFromOffset = offset;
+  const verifiedResumePrefixDigest = resumedFromOffset > 0
+    ? manifestPrefixDigestAtOffset?.(resumedFromOffset)
+    : undefined;
+  const canRotateResponderAtVerifiedPrefix = Boolean(
+    usesPageSession
+    && assetUals === undefined
+    && resumedFromOffset > 0
+    && manifestDigest
+    && checkpoint?.manifestDigest === manifestDigest
+    && verifiedResumePrefixDigest !== undefined
+    && checkpoint?.manifestPrefixDigest === verifiedResumePrefixDigest
+    && checkpointStore.clearResponderSession,
+  );
   let bytesReceived = 0;
   let acceptedHeapBytesEstimate = 0;
   let responsePages = 0;
@@ -656,6 +758,96 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     : undefined;
 
   try {
+    if (
+      responderSessionNeedsPriming
+      && responderSession
+      && resumedFromOffset > 0
+    ) {
+      // A responder session owns an immutable raw-row coordinate system and
+      // refuses an unseen token at offset>0. Seed the new generation with one
+      // ordinary offset-zero page, discard those already-verified rows, then
+      // jump to the cryptographically identical manifest boundary. This costs
+      // one bounded page instead of replaying the entire verified prefix.
+      const primePageSize = Math.min(
+        syncPageSize,
+        Math.max(adaptivePageSizer.current(), SYNC_PAGE_SIZE + 1),
+      );
+      successfulPageSize = primePageSize;
+      const primeBytes = await sendSyncRequest({
+        remotePeerId,
+        timeoutMs: Math.min(
+          syncPageTimeoutMs,
+          Math.max(2000, Math.floor(Math.max(0, deadline - Date.now()) / syncRouterAttempts)),
+        ),
+        retryAttempts: syncPageRetryAttempts,
+        signal,
+        contextGraphId,
+        offset: 0,
+        protocolId: protocolSync,
+        plane: syncPlaneFor(includeSharedMemory),
+        phase,
+        requestFactory: async () => buildSyncRequest(
+          contextGraphId,
+          0,
+          primePageSize,
+          includeSharedMemory,
+          remotePeerId,
+          phase,
+          snapshotRef,
+          sinceBatchId,
+          syncSessionId,
+          recovery,
+          assetUals,
+        ),
+        send,
+        validateResponse: (responseBytes) => {
+          if (decodeSyncResponse(responseBytes) === LEGACY_SYNC_BUSY_RESPONSE) {
+            throw makeLegacySyncBusyError(remotePeerId, contextGraphId, phase);
+          }
+        },
+        onRetry: (attempt, delay, err) => {
+          logWarn(
+            ctx,
+            `Sync generation-prime retry ${attempt}/${syncPageRetryAttempts} for offset 0 `
+            + `(delay ${Math.round(delay)}ms): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        },
+      });
+      throwIfAborted(signal);
+      const primeBody = decodeSyncResponse(primeBytes);
+      if (
+        primeBody === syncDeniedResponse
+        || (extraDeniedResponses && extraDeniedResponses.includes(primeBody))
+      ) {
+        const error = new Error(
+          `Sync denied by ${remotePeerId} while priming the new responder generation for "${contextGraphId}" (${phase})`,
+        );
+        (error as Error & { syncDenied?: boolean }).syncDenied = true;
+        throw error;
+      }
+      if (!primeBody) {
+        throw new Error(
+          `Durable sync session returned an empty generation-prime page for nonzero offset ${resumedFromOffset}`,
+        );
+      }
+      const nextBytesReceived = bytesReceived + primeBytes.byteLength;
+      if (maxAcceptedBytes !== undefined && nextBytesReceived > maxAcceptedBytes) {
+        throw toSyncPeerRespondedError(new SyncPageAccumulationLimitError(
+          'bytes',
+          nextBytesReceived,
+          maxAcceptedBytes,
+        ));
+      }
+      bytesReceived = nextBytesReceived;
+      responsePages += 1;
+      phaseTelemetry.recordPage();
+      adaptivePageSizer.onPageSuccess();
+      logInfo(
+        ctx,
+        `Primed fresh durable responder generation for "${contextGraphId}" before reusing verified offset ${resumedFromOffset}`,
+      );
+    }
+
     while (true) {
       throwIfAborted(signal);
       if (Date.now() > deadline) {
@@ -832,8 +1024,16 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       // terminal token until its requester-side TTL elapses. Some transports
       // still destroy a responder's text and expose a generic reset, which is
       // why the zero-accepted-page fallback below remains necessary.
-      unfinishedSyncResponderSessions.delete(checkpointKey);
-      checkpointStore.delete(checkpointKey);
+      if (canRotateResponderAtVerifiedPrefix) {
+        // The token is invalid, not the already verified local graph prefix.
+        // Keep its generation-bound boundary, forget only the token, and let
+        // the next bounded round prime a fresh responder generation at zero
+        // before jumping back to this cryptographically proven offset.
+        forgetUnfinishedSyncResponderSession(checkpointStore, checkpointKey);
+      } else {
+        unfinishedSyncResponderSessions.delete(checkpointKey);
+        checkpointStore.delete(checkpointKey);
+      }
     } else if (usesPageSession && responderSession && !recovery && !denied) {
       if (resumedFromOffset > 0 && responsePages === 0) {
         // R1 fix (2026-07-07 sync storm). This round RESUMED a saved session at
@@ -845,12 +1045,12 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         // drop. Re-saving is a trap in BOTH readings: the retry resumes at
         // offset>0 with a session id the responder won't honour (offset>0 +
         // non-active token => it supersedes AGAIN), looping for the full
-        // session TTL (~10 min) while peer backoff compounds. Drop BOTH the
-        // session and the checkpoint (exactly as the in-process superseded
-        // branch above does) so the retry mints a fresh id and sends offset 0
-        // => the responder refreshes its row list and serves from the start —
-        // real progress instead of a stuck loop, and the loop-kill stops the
-        // backoff from compounding. A FRESH round (resumedFromOffset === 0)
+        // session TTL (~10 min) while peer backoff compounds. When the offset
+        // is bound to a canonical verified-prefix digest, drop only the token:
+        // the next retry mints a fresh id, primes it at offset zero, then jumps
+        // back to the proven boundary. Legacy/custom stores without that proof
+        // still drop both halves and restart at zero. A FRESH round
+        // (resumedFromOffset === 0)
         // that merely advanced then blipped is NOT dropped: its resume is
         // likely valid, and a supersede there just costs one wasted resume
         // attempt before this branch catches it next round. Precise
@@ -862,8 +1062,12 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         // previously certified checkpoint. At worst, a concurrent supersession
         // after that accepted page costs one extra retry: its zero-page failure
         // reaches this branch and then rotates the session safely.
-        unfinishedSyncResponderSessions.delete(checkpointKey);
-        checkpointStore.delete(checkpointKey);
+        if (canRotateResponderAtVerifiedPrefix) {
+          forgetUnfinishedSyncResponderSession(checkpointStore, checkpointKey);
+        } else {
+          unfinishedSyncResponderSessions.delete(checkpointKey);
+          checkpointStore.delete(checkpointKey);
+        }
       } else {
         // Fresh round, or a resumed round that demonstrably delivered at least
         // one page with this token: keep the session so a retry can resume from
@@ -884,6 +1088,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
           checkpointKey,
           refreshedResponderSession,
           manifestDigest,
+          manifestPrefixDigestAtOffset?.(resumedFromOffset),
         );
       }
     }
@@ -996,6 +1201,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         checkpointKey,
         refreshedResponderSession,
         manifestDigest,
+        manifestPrefixDigestAtOffset?.(resumedFromOffset),
       );
     } else {
       forgetUnfinishedSyncResponderSession(checkpointStore, checkpointKey);

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -17,6 +17,7 @@ import type { SyncPhase } from '../auth/request-build.js';
 import { exactAssetFilterKey } from '../exact-assets.js';
 import {
   getSyncCheckpointKey,
+  type DurableManifestDigest,
   type SyncCheckpointScope,
   type SyncCheckpointStore,
 } from '../checkpoint/state.js';
@@ -40,14 +41,19 @@ const MAX_UNFINISHED_SYNC_RESPONDER_SESSIONS = 4096;
 type UnfinishedSyncResponderSession = {
   syncSessionId: string;
   expiresAt: number;
+  manifestDigest?: DurableManifestDigest;
 };
 
 const unfinishedSyncResponderSessions = new Map<string, UnfinishedSyncResponderSession>();
 
-function getUnfinishedSyncResponderSession(checkpointKey: string, now = Date.now()): UnfinishedSyncResponderSession | undefined {
+function getUnfinishedSyncResponderSession(
+  checkpointKey: string,
+  manifestDigest: DurableManifestDigest | undefined,
+  now = Date.now(),
+): UnfinishedSyncResponderSession | undefined {
   const session = unfinishedSyncResponderSessions.get(checkpointKey);
   if (!session) return undefined;
-  if (session.expiresAt > now) return session;
+  if (session.expiresAt > now && session.manifestDigest === manifestDigest) return session;
   unfinishedSyncResponderSessions.delete(checkpointKey);
   return undefined;
 }
@@ -66,16 +72,19 @@ function rememberUnfinishedSyncResponderSession(checkpointKey: string, session: 
 
 function getPersistedSyncResponderSession(
   checkpoint: ReturnType<SyncCheckpointStore['get']>,
+  manifestDigest: DurableManifestDigest | undefined,
   now = Date.now(),
 ): UnfinishedSyncResponderSession | undefined {
   if (
     !checkpoint?.responderSessionId
+    || checkpoint.manifestDigest !== manifestDigest
     || !Number.isSafeInteger(checkpoint.responderSessionExpiresAtMs)
     || (checkpoint.responderSessionExpiresAtMs ?? 0) <= now
   ) return undefined;
   return {
     syncSessionId: checkpoint.responderSessionId,
     expiresAt: checkpoint.responderSessionExpiresAtMs!,
+    ...(checkpoint.manifestDigest ? { manifestDigest: checkpoint.manifestDigest } : {}),
   };
 }
 
@@ -83,14 +92,19 @@ function persistUnfinishedSyncResponderSession(
   checkpointStore: SyncCheckpointStore,
   checkpointKey: string,
   session: UnfinishedSyncResponderSession,
+  manifestDigest: DurableManifestDigest | undefined,
   now = Date.now(),
 ): void {
-  rememberUnfinishedSyncResponderSession(checkpointKey, session, now);
+  rememberUnfinishedSyncResponderSession(checkpointKey, {
+    ...session,
+    ...(manifestDigest ? { manifestDigest } : {}),
+  }, now);
   checkpointStore.setResponderSession?.(
     checkpointKey,
     session.syncSessionId,
     session.expiresAt,
     now,
+    manifestDigest,
   );
 }
 
@@ -147,6 +161,8 @@ export interface SyncPageResult {
    * proof-sensitive callers must treat an omitted value as unknown.
    */
   responderSessionStartedFresh?: boolean;
+  /** META generation actually used to authorize this DATA continuation. */
+  manifestDigest?: DurableManifestDigest;
   nextOffset: number;
   checkpointKey: string;
   completed: boolean;
@@ -341,6 +357,8 @@ export interface SyncPageFetchOptions {
   readonly signal?: AbortSignal;
   readonly recovery?: boolean;
   readonly forceFreshSession?: boolean;
+  /** Completed canonical META generation that defines a durable DATA plan. */
+  readonly manifestDigest?: DurableManifestDigest;
   readonly assetUals?: string[];
   /**
    * Permit the selected-SWM transfer owner to retain a validated metadata
@@ -405,6 +423,8 @@ interface FetchSyncPagesParams {
    * an unfinished session's stale offset-zero view.
    */
   forceFreshSession?: boolean;
+  /** Enforces generation identity for durable DATA continuation state. */
+  manifestDigest?: DurableManifestDigest;
   /**
    * R9/R10 — member SWM recovery marker. Forks BOTH the checkpoint namespace
    * (R10: distinct `|recovery` cursor + responder-session scope so it never
@@ -517,6 +537,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     protocolSync,
     checkpointStore,
     forceFreshSession,
+    manifestDigest,
     recovery,
     buildSyncRequest,
     sinceBatchId,
@@ -556,7 +577,14 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     checkpointStore.delete(checkpointKey);
     unfinishedSyncResponderSessions.delete(checkpointKey);
   }
-  const checkpoint = checkpointStore.get(checkpointKey);
+  let checkpoint = checkpointStore.get(checkpointKey);
+  if (manifestDigest && checkpoint?.manifestDigest !== manifestDigest) {
+    // OFFSET has meaning only inside the exact META generation that produced
+    // the responder DATA plan. A legacy/missing binding is just as unprovable
+    // as a mismatch, so rotate the token and restart from zero as one action.
+    deleteSyncPageCheckpoint(checkpointStore, checkpointKey);
+    checkpoint = undefined;
+  }
   let offset = checkpoint?.offset ?? 0;
   const usesPageSession = usesResponderSession(includeSharedMemory, phase);
   const sessionStartedAt = Date.now();
@@ -567,9 +595,9 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   const savedResponderSession = usesPageSession
     ? (
         (checkpoint
-          ? getUnfinishedSyncResponderSession(checkpointKey, sessionStartedAt)
+          ? getUnfinishedSyncResponderSession(checkpointKey, manifestDigest, sessionStartedAt)
           : undefined)
-        ?? getPersistedSyncResponderSession(checkpoint, sessionStartedAt)
+        ?? getPersistedSyncResponderSession(checkpoint, manifestDigest, sessionStartedAt)
       )
     : undefined;
   const responderSessionStartedFresh = savedResponderSession === undefined;
@@ -623,6 +651,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     ? {
       syncSessionId,
       expiresAt: savedResponderSession?.expiresAt ?? sessionStartedAt + DURABLE_DATA_SYNC_SESSION_TTL_MS,
+      ...(manifestDigest ? { manifestDigest } : {}),
     }
     : undefined;
 
@@ -854,6 +883,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
           checkpointStore,
           checkpointKey,
           refreshedResponderSession,
+          manifestDigest,
         );
       }
     }
@@ -884,6 +914,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         bytesReceived,
         resumedFromOffset,
         responderSessionStartedFresh,
+        ...(manifestDigest ? { manifestDigest } : {}),
         nextOffset: offset,
         checkpointKey,
       });
@@ -919,6 +950,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         bytesReceived,
         resumedFromOffset,
         responderSessionStartedFresh,
+        ...(manifestDigest ? { manifestDigest } : {}),
         nextOffset: offset,
         checkpointKey,
       });
@@ -963,6 +995,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         checkpointStore,
         checkpointKey,
         refreshedResponderSession,
+        manifestDigest,
       );
     } else {
       forgetUnfinishedSyncResponderSession(checkpointStore, checkpointKey);
@@ -984,6 +1017,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     bytesReceived,
     resumedFromOffset,
     responderSessionStartedFresh,
+    ...(manifestDigest ? { manifestDigest } : {}),
     nextOffset: offset,
     checkpointKey,
     completed: !timedOut,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -2035,13 +2035,14 @@ async function readRowsPageFromExactGraphPlan(
       rows.push(...page);
       added = page.length;
     } else {
+      const isFinalGraphPage = entryOffset + expectedRows === entry.rowCount;
       const result = await store.query(`
         SELECT ?s ?p ?o WHERE {
           GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
         }
         ORDER BY ?s ?p ?o
         OFFSET ${entryOffset}
-        LIMIT ${expectedRows}
+        LIMIT ${expectedRows + (isFinalGraphPage ? 1 : 0)}
       `, {
         ...syncResponderStoreOptions(signal, 'sync.responder.readExactGraphRowsPage'),
         maxResponseBytes: snapshotResponseByteLimit(snapshotLimits.maxBytesEstimate),
@@ -2056,6 +2057,12 @@ async function readRowsPageFromExactGraphPlan(
             added += 1;
           }
         }
+      }
+      if (isFinalGraphPage && added > expectedRows) {
+        throw new Error(
+          `Sync exact-graph plan changed while paging ${entry.graph}: `
+          + `expected ${entry.rowCount} total rows but found a surplus row`,
+        );
       }
     }
     // Exact-asset metadata is a commitment to the number of rows in each

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -2020,6 +2020,8 @@ async function readRowsPageFromExactGraphPlan(
       skip -= entry.rowCount;
       continue;
     }
+    const entryOffset = skip;
+    const expectedRows = Math.min(entry.rowCount - entryOffset, remaining);
     let added = 0;
     const graphRows = await loadExactGraphRowsSnapshot(
       store,
@@ -2029,7 +2031,7 @@ async function readRowsPageFromExactGraphPlan(
       signal,
     );
     if (graphRows) {
-      const page = graphRows.slice(skip, skip + remaining);
+      const page = graphRows.slice(entryOffset, entryOffset + expectedRows);
       rows.push(...page);
       added = page.length;
     } else {
@@ -2038,8 +2040,8 @@ async function readRowsPageFromExactGraphPlan(
           GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
         }
         ORDER BY ?s ?p ?o
-        OFFSET ${skip}
-        LIMIT ${remaining}
+        OFFSET ${entryOffset}
+        LIMIT ${expectedRows}
       `, {
         ...syncResponderStoreOptions(signal, 'sync.responder.readExactGraphRowsPage'),
         maxResponseBytes: snapshotResponseByteLimit(snapshotLimits.maxBytesEstimate),
@@ -2055,6 +2057,16 @@ async function readRowsPageFromExactGraphPlan(
           }
         }
       }
+    }
+    // Exact-asset metadata is a commitment to the number of rows in each
+    // assertion graph. Do not let a short graph borrow rows from the next
+    // graph in the plan: that produces a full-looking response whose graph
+    // boundaries no longer match the manifest and hides the damaged source.
+    if (added !== expectedRows) {
+      throw new Error(
+        `Sync exact-graph plan changed while paging ${entry.graph}: ` +
+        `expected ${expectedRows} rows at offset ${entryOffset}, found ${added}`,
+      );
     }
     remaining -= added;
     if (remaining <= 0) break;

--- a/packages/agent/test/durable-manifest-continuation.test.ts
+++ b/packages/agent/test/durable-manifest-continuation.test.ts
@@ -1,0 +1,402 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  type OperationContext,
+} from '@origintrail-official/dkg-core';
+import {
+  computeFlatKCRootV10,
+  generateGraphKnowledgeAssetMetadata,
+} from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { SYNC_PAGE_SIZE } from '../src/dkg-agent-constants.js';
+import {
+  createGraphScopedDurableManifestPlan,
+} from '../src/sync/durable-integrity.js';
+import {
+  getSyncCheckpointKey,
+  MemorySyncCheckpointStore,
+  type DurableManifestDigest,
+} from '../src/sync/checkpoint/state.js';
+import {
+  deleteSyncPageCheckpoint,
+  fetchSyncPages,
+  type SyncPageResult,
+} from '../src/sync/requester/page-fetch.js';
+import {
+  runDurableSync,
+  type DurableSyncFetchRequest,
+  type DurableSyncGraphScopedStoreRequest,
+} from '../src/sync/requester/durable-sync.js';
+import { processDurableBatchForWire } from '../src/sync-verify-worker-impl.js';
+import type { DurableBatchVerificationMode } from '../src/sync-verify-worker.js';
+import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
+
+const ctx = { operationId: 'manifest-continuation', operationName: 'sync' } as OperationContext;
+let scenarioSequence = 0;
+
+interface AssetFixture {
+  ual: string;
+  graph: string;
+  payload: Quad[];
+  meta: Quad[];
+}
+
+function asset(
+  contextGraphId: string,
+  kaNumber: number,
+  options: {
+    tripleCount?: number;
+    valuePrefix?: string;
+    subGraphName?: string;
+  } = {},
+): AssetFixture {
+  const tripleCount = options.tripleCount ?? 4;
+  const ual = `did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ef/${kaNumber}`;
+  const scope = createGraphKnowledgeAssetScope(ual, '1');
+  const graph = knowledgeAssetLayerGraphUri(
+    contextGraphId,
+    MemoryLayer.VerifiableMemory,
+    scope,
+    options.subGraphName,
+  );
+  const payload = Array.from({ length: tripleCount }, (_, index): Quad => ({
+    subject: `urn:continuation:${kaNumber}:${index}`,
+    predicate: 'urn:continuation:value',
+    object: `"${options.valuePrefix ?? 'value'}-${index}"`,
+    graph,
+  }));
+  const meta = generateGraphKnowledgeAssetMetadata({
+    ual,
+    contextGraphId,
+    merkleRoot: computeFlatKCRootV10(payload, []),
+    publisherPeerId: 'publisher-peer',
+    accessPolicy: 'public',
+    timestamp: new Date(0),
+    assertionVersion: '1',
+    publicTripleCount: payload.length,
+    privateTripleCount: 0,
+    assertionGraph: graph,
+    ...(options.subGraphName ? { subGraphName: options.subGraphName } : {}),
+  }, { status: 'tentative' });
+  return { ual, graph, payload, meta };
+}
+
+function ordered(fixtures: readonly AssetFixture[]): AssetFixture[] {
+  return [...fixtures].sort((left, right) => left.graph.localeCompare(right.graph));
+}
+
+function processBatch(
+  dataQuads: Quad[],
+  metaQuads: Quad[],
+  _ctx: OperationContext,
+  acceptUnverified: boolean,
+  mode: DurableBatchVerificationMode,
+) {
+  const wire = processDurableBatchForWire(dataQuads, metaQuads, acceptUnverified, mode);
+  return {
+    verifiedData: wire.verifiedDataIndexes.map((index) => dataQuads[index]!),
+    verifiedMeta: wire.verifiedMetaIndexes.map((index) => metaQuads[index]!),
+    verifiedGraphScopedDataGraphs: wire.verifiedGraphScopedDataGraphs,
+    consumedUnpersistedMetaTriples: wire.consumedUnpersistedMetaTriples,
+    verifiedPrivateOnlyResponses: wire.verifiedPrivateOnlyResponses,
+    totalFetchedDataQuads: wire.totalFetchedDataQuads,
+    totalFetchedMetaQuads: wire.totalFetchedMetaQuads,
+    rejectedKcs: wire.rejectedKcs,
+    emptyResponses: wire.emptyResponses,
+    metaOnlyResponses: wire.metaOnlyResponses,
+    dataRejectedMissingMeta: wire.dataRejectedMissingMeta,
+  };
+}
+
+interface Round {
+  readonly meta: Quad[];
+  readonly dataPage: (offset: number) => Quad[];
+}
+
+interface DataRequestEvidence {
+  readonly offset: number;
+  readonly syncSessionId: string | undefined;
+  readonly manifestDigest: DurableManifestDigest | undefined;
+}
+
+function createTwoRoundHarness(
+  contextGraphId: string,
+  remotePeerId: string,
+  checkpointStore = new MemorySyncCheckpointStore(),
+) {
+  let currentRound: Round;
+  let pendingRequest: {
+    phase: 'data' | 'meta';
+    offset: number;
+    syncSessionId: string | undefined;
+    manifestDigest: DurableManifestDigest | undefined;
+  } | undefined;
+  let responseSequence = 0;
+  const parsedResponses = new Map<string, Quad[]>();
+  const dataRequests: DataRequestEvidence[] = [];
+
+  const fetch = async (request: DurableSyncFetchRequest): Promise<SyncPageResult> => fetchSyncPages({
+    ctx: request.ctx,
+    remotePeerId: request.remotePeerId,
+    contextGraphId: request.contextGraphId,
+    includeSharedMemory: false,
+    phase: request.phase,
+    graphUri: request.graphUri,
+    deadline: request.fetchContext.deadline,
+    syncPageTimeoutMs: 5_000,
+    syncRouterAttempts: 1,
+    syncPageRetryAttempts: 1,
+    syncPageSize: SYNC_PAGE_SIZE,
+    syncDeniedResponse: '#DENIED',
+    debugSyncProgress: false,
+    protocolSync: '/test/durable-manifest-continuation',
+    checkpointStore,
+    forceFreshSession: request.forceFreshSession,
+    manifestDigest: request.manifestDigest,
+    buildSyncRequest: async (
+      _contextGraphId,
+      offset,
+      _limit,
+      _includeSharedMemory,
+      _remotePeerId,
+      phase,
+      _snapshotRef,
+      _sinceBatchId,
+      syncSessionId,
+    ) => {
+      pendingRequest = {
+        phase: phase as 'data' | 'meta',
+        offset,
+        syncSessionId,
+        manifestDigest: request.manifestDigest,
+      };
+      if (phase === 'data') {
+        dataRequests.push({ offset, syncSessionId, manifestDigest: request.manifestDigest });
+      }
+      return new TextEncoder().encode('request');
+    },
+    send: async () => {
+      const pending = pendingRequest!;
+      const quads = pending.phase === 'meta'
+        ? currentRound.meta
+        : currentRound.dataPage(pending.offset);
+      if (quads.length === 0) return new Uint8Array();
+      const responseId = `response-${responseSequence++}`;
+      parsedResponses.set(responseId, quads);
+      return new TextEncoder().encode(responseId);
+    },
+    parseAndFilter: async (body) => {
+      const quads = parsedResponses.get(body) ?? [];
+      return { quads, totalQuads: quads.length };
+    },
+    logWarn: () => {},
+    logInfo: () => {},
+    logDebug: () => {},
+  });
+
+  const run = async (round: Round) => {
+    currentRound = round;
+    return runDurableSync({
+      ctx,
+      remotePeerId,
+      contextGraphIds: [contextGraphId],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: fetch,
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async (_request: DurableSyncGraphScopedStoreRequest) => 'applied',
+      deleteCheckpoint: (key) => deleteSyncPageCheckpoint(checkpointStore, key),
+      setCheckpoint: (key, offset, manifestDigest) => {
+        if (manifestDigest) checkpointStore.setManifestBoundOffset(key, offset, manifestDigest);
+        else checkpointStore.set(key, offset);
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+  };
+
+  return { checkpointStore, dataRequests, run };
+}
+
+function makeScenario(
+  name: string,
+  makeGenerations: (contextGraphId: string) => { x: AssetFixture[]; y: AssetFixture[] },
+) {
+  const contextGraphId = `manifest-${name}-${scenarioSequence++}`;
+  const remotePeerId = `peer-${name}-${scenarioSequence}`;
+  const generations = makeGenerations(contextGraphId);
+  return { contextGraphId, remotePeerId, ...generations };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('manifest-bound durable DATA continuation', () => {
+  it('resumes the same responder session for an unchanged manifest and completes', async () => {
+    const { contextGraphId, remotePeerId, x } = makeScenario('unchanged', (cg) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3), asset(cg, 5)]),
+      y: [],
+    }));
+    const harness = createTwoRoundHarness(contextGraphId, remotePeerId);
+    const meta = x.flatMap((entry) => entry.meta);
+    const firstPrefix = x[0]!.payload;
+
+    const first = await harness.run({ meta, dataPage: () => firstPrefix });
+    const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, false, 'data');
+    const established = harness.checkpointStore.get(checkpointKey);
+    expect(first.complete).toBe(false);
+    expect(established).toMatchObject({
+      offset: firstPrefix.length,
+      manifestDigest: createGraphScopedDurableManifestPlan(meta, contextGraphId)!.manifestDigest,
+      responderSessionId: expect.any(String),
+    });
+
+    harness.dataRequests.length = 0;
+    const second = await harness.run({
+      meta: [...meta].reverse(),
+      dataPage: (offset) => offset === firstPrefix.length
+        ? x.slice(1).flatMap((entry) => entry.payload)
+        : [],
+    });
+
+    expect(harness.dataRequests[0]).toMatchObject({
+      offset: firstPrefix.length,
+      syncSessionId: established?.responderSessionId,
+      manifestDigest: established?.manifestDigest,
+    });
+    expect(second.complete).toBe(true);
+    expect(harness.checkpointStore.get(checkpointKey)).toBeUndefined();
+  });
+
+  it.each([
+    ['equal-width replacement', (cg: string) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3), asset(cg, 5)]),
+      y: ordered([asset(cg, 1), asset(cg, 2), asset(cg, 5)]),
+    })],
+    ['append', (cg: string) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3)]),
+      y: ordered([asset(cg, 1), asset(cg, 3), asset(cg, 5)]),
+    })],
+    ['insertion', (cg: string) => ({
+      x: ordered([asset(cg, 1), asset(cg, 5)]),
+      y: ordered([asset(cg, 1), asset(cg, 3), asset(cg, 5)]),
+    })],
+    ['deletion', (cg: string) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3), asset(cg, 5)]),
+      y: ordered([asset(cg, 1), asset(cg, 5)]),
+    })],
+    ['DATA-plan graph/order change', (cg: string) => ({
+      x: ordered([asset(cg, 1, { subGraphName: 'a' }), asset(cg, 3, { subGraphName: 'z' })]),
+      y: ordered([asset(cg, 1, { subGraphName: 'z' }), asset(cg, 3, { subGraphName: 'a' })]),
+    })],
+    ['public count change', (cg: string) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3)]),
+      y: ordered([asset(cg, 1, { tripleCount: 5 }), asset(cg, 3)]),
+    })],
+    ['Merkle-root/content change', (cg: string) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3)]),
+      y: ordered([
+        asset(cg, 1, { valuePrefix: 'replacement' }),
+        asset(cg, 3),
+      ]),
+    })],
+  ] as const)('resets offset and token on %s', async (name, generationsFor) => {
+    const { contextGraphId, remotePeerId, x, y } = makeScenario(name.replaceAll(' ', '-'), generationsFor);
+    const harness = createTwoRoundHarness(contextGraphId, remotePeerId);
+    const xMeta = x.flatMap((entry) => entry.meta);
+    const yMeta = y.flatMap((entry) => entry.meta);
+    const firstPrefix = x[0]!.payload;
+
+    await harness.run({ meta: xMeta, dataPage: () => firstPrefix });
+    const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, false, 'data');
+    const established = harness.checkpointStore.get(checkpointKey);
+    expect(established?.offset).toBe(firstPrefix.length);
+    expect(createGraphScopedDurableManifestPlan(yMeta, contextGraphId)?.manifestDigest)
+      .not.toBe(established?.manifestDigest);
+
+    harness.dataRequests.length = 0;
+    const second = await harness.run({ meta: yMeta, dataPage: () => y[0]!.payload });
+
+    expect(harness.dataRequests[0]?.offset).toBe(0);
+    expect(harness.dataRequests[0]?.syncSessionId).not.toBe(established?.responderSessionId);
+    expect(harness.dataRequests[0]?.manifestDigest)
+      .toBe(createGraphScopedDurableManifestPlan(yMeta, contextGraphId)?.manifestDigest);
+    expect(second.complete).toBe(false);
+  });
+
+  it.each([
+    ['legacy checkpoint without digest', (store: MemorySyncCheckpointStore, key: string, offset: number, session: string) => {
+      deleteSyncPageCheckpoint(store, key);
+      store.set(key, offset);
+      store.setResponderSession(key, session, Date.now() + 60_000);
+    }],
+    ['responder restart without the paired session', (store: MemorySyncCheckpointStore, key: string, offset: number, _session: string, digest: DurableManifestDigest) => {
+      deleteSyncPageCheckpoint(store, key);
+      store.setManifestBoundOffset(key, offset, digest);
+    }],
+  ] as const)('fails safe for %s', async (_name, damageContinuation) => {
+    const { contextGraphId, remotePeerId, x } = makeScenario('legacy-or-restart', (cg) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3)]),
+      y: [],
+    }));
+    const harness = createTwoRoundHarness(contextGraphId, remotePeerId);
+    const meta = x.flatMap((entry) => entry.meta);
+    const prefix = x[0]!.payload;
+
+    await harness.run({ meta, dataPage: () => prefix });
+    const key = getSyncCheckpointKey(remotePeerId, contextGraphId, false, 'data');
+    const established = harness.checkpointStore.get(key)!;
+    damageContinuation(
+      harness.checkpointStore,
+      key,
+      established.offset,
+      established.responderSessionId!,
+      established.manifestDigest!,
+    );
+
+    harness.dataRequests.length = 0;
+    const second = await harness.run({ meta, dataPage: () => prefix });
+
+    expect(harness.dataRequests[0]?.offset).toBe(0);
+    expect(harness.dataRequests[0]?.syncSessionId).not.toBe(established.responderSessionId);
+    expect(second.complete).toBe(false);
+  });
+
+  it('does not issue DATA or complete when META transport is incomplete', async () => {
+    const contextGraphId = `manifest-incomplete-meta-${scenarioSequence++}`;
+    let dataFetches = 0;
+    const result = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-incomplete-meta',
+      contextGraphIds: [contextGraphId],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase }) => {
+        if (phase === 'data') dataFetches += 1;
+        return {
+          quads: [],
+          bytesReceived: 0,
+          resumedFromOffset: 0,
+          nextOffset: 1,
+          checkpointKey: `${contextGraphId}:${phase}`,
+          completed: phase === 'data',
+          timedOut: phase === 'meta',
+        };
+      },
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(dataFetches).toBe(0);
+    expect(result.complete).toBe(false);
+    expect(result.failedPhases).toBe(1);
+  });
+});

--- a/packages/agent/test/durable-manifest-continuation.test.ts
+++ b/packages/agent/test/durable-manifest-continuation.test.ts
@@ -19,6 +19,7 @@ import {
   MemorySyncCheckpointStore,
   type DurableManifestDigest,
 } from '../src/sync/checkpoint/state.js';
+import { exactAssetFilterKey } from '../src/sync/exact-assets.js';
 import {
   deleteSyncPageCheckpoint,
   fetchSyncPages,
@@ -112,7 +113,7 @@ function processBatch(
 
 interface Round {
   readonly meta: Quad[];
-  readonly dataPage: (offset: number) => Quad[];
+  readonly dataPage: (offset: number) => Quad[] | Error;
 }
 
 interface DataRequestEvidence {
@@ -125,6 +126,7 @@ function createTwoRoundHarness(
   contextGraphId: string,
   remotePeerId: string,
   checkpointStore = new MemorySyncCheckpointStore(),
+  exactAssetUals?: string[],
 ) {
   let currentRound: Round;
   let pendingRequest: {
@@ -136,6 +138,7 @@ function createTwoRoundHarness(
   let responseSequence = 0;
   const parsedResponses = new Map<string, Quad[]>();
   const dataRequests: DataRequestEvidence[] = [];
+  const storedAssetUals: string[] = [];
 
   const fetch = async (request: DurableSyncFetchRequest): Promise<SyncPageResult> => fetchSyncPages({
     ctx: request.ctx,
@@ -155,6 +158,8 @@ function createTwoRoundHarness(
     checkpointStore,
     forceFreshSession: request.forceFreshSession,
     manifestDigest: request.manifestDigest,
+    manifestPrefixDigestAtOffset: request.manifestPrefixDigestAtOffset,
+    assetUals: request.exactAssetUals,
     buildSyncRequest: async (
       _contextGraphId,
       offset,
@@ -179,9 +184,11 @@ function createTwoRoundHarness(
     },
     send: async () => {
       const pending = pendingRequest!;
-      const quads = pending.phase === 'meta'
+      const page = pending.phase === 'meta'
         ? currentRound.meta
         : currentRound.dataPage(pending.offset);
+      if (page instanceof Error) throw page;
+      const quads = page;
       if (quads.length === 0) return new Uint8Array();
       const responseId = `response-${responseSequence++}`;
       parsedResponses.set(responseId, quads);
@@ -204,12 +211,24 @@ function createTwoRoundHarness(
       contextGraphIds: [contextGraphId],
       durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
       fetchSyncPages: fetch,
+      exactAssetUalsFor: exactAssetUals ? () => exactAssetUals : undefined,
       processDurableBatchInWorker: processBatch,
       storeInsert: async () => {},
-      storeGraphScopedAsset: async (_request: DurableSyncGraphScopedStoreRequest) => 'applied',
+      storeGraphScopedAsset: async (request: DurableSyncGraphScopedStoreRequest) => {
+        storedAssetUals.push(request.asset.ual);
+        return 'applied';
+      },
       deleteCheckpoint: (key) => deleteSyncPageCheckpoint(checkpointStore, key),
-      setCheckpoint: (key, offset, manifestDigest) => {
-        if (manifestDigest) checkpointStore.setManifestBoundOffset(key, offset, manifestDigest);
+      setCheckpoint: (key, offset, manifestDigest, manifestPrefixDigest) => {
+        if (manifestDigest) {
+          checkpointStore.setManifestBoundOffset(
+            key,
+            offset,
+            manifestDigest,
+            Date.now(),
+            manifestPrefixDigest,
+          );
+        }
         else checkpointStore.set(key, offset);
       },
       logInfo: () => {},
@@ -218,7 +237,7 @@ function createTwoRoundHarness(
     });
   };
 
-  return { checkpointStore, dataRequests, run };
+  return { checkpointStore, dataRequests, storedAssetUals, run };
 }
 
 function makeScenario(
@@ -289,6 +308,53 @@ describe('manifest-bound durable DATA continuation', () => {
       x: ordered([asset(cg, 1), asset(cg, 3), asset(cg, 5)]),
       y: ordered([asset(cg, 1), asset(cg, 5)]),
     })],
+  ] as const)('reuses the verified prefix and primes a fresh session on suffix %s', async (name, generationsFor) => {
+    const { contextGraphId, remotePeerId, x, y } = makeScenario(name.replaceAll(' ', '-'), generationsFor);
+    const harness = createTwoRoundHarness(contextGraphId, remotePeerId);
+    const xMeta = x.flatMap((entry) => entry.meta);
+    const yMeta = y.flatMap((entry) => entry.meta);
+    const firstPrefix = x[0]!.payload;
+
+    await harness.run({ meta: xMeta, dataPage: () => firstPrefix });
+    const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, false, 'data');
+    const established = harness.checkpointStore.get(checkpointKey)!;
+    expect(established).toMatchObject({
+      offset: firstPrefix.length,
+      manifestPrefixDigest: expect.stringMatching(/^sha256:/),
+      responderSessionId: expect.any(String),
+    });
+
+    harness.dataRequests.length = 0;
+    const second = await harness.run({
+      meta: yMeta,
+      dataPage: (offset) => offset === 0
+        ? y[0]!.payload
+        : offset === firstPrefix.length
+          ? y.slice(1).flatMap((entry) => entry.payload)
+          : [],
+    });
+
+    expect(harness.dataRequests.map(({ offset }) => offset).slice(0, 2))
+      .toEqual([0, firstPrefix.length]);
+    expect(harness.dataRequests[0]?.syncSessionId)
+      .not.toBe(established.responderSessionId);
+    expect(harness.dataRequests[1]?.syncSessionId)
+      .toBe(harness.dataRequests[0]?.syncSessionId);
+    expect(harness.dataRequests[1]?.manifestDigest)
+      .toBe(createGraphScopedDurableManifestPlan(yMeta, contextGraphId)?.manifestDigest);
+    expect(second.complete).toBe(true);
+    expect(harness.checkpointStore.get(checkpointKey)).toBeUndefined();
+  });
+
+  it.each([
+    ['insertion before the prefix', (cg: string) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3)]),
+      y: ordered([asset(cg, 0), asset(cg, 1), asset(cg, 3)]),
+    })],
+    ['deletion inside the prefix', (cg: string) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3)]),
+      y: ordered([asset(cg, 3), asset(cg, 5)]),
+    })],
     ['DATA-plan graph/order change', (cg: string) => ({
       x: ordered([asset(cg, 1, { subGraphName: 'a' }), asset(cg, 3, { subGraphName: 'z' })]),
       y: ordered([asset(cg, 1, { subGraphName: 'z' }), asset(cg, 3, { subGraphName: 'a' })]),
@@ -304,7 +370,7 @@ describe('manifest-bound durable DATA continuation', () => {
         asset(cg, 3),
       ]),
     })],
-  ] as const)('resets offset and token on %s', async (name, generationsFor) => {
+  ] as const)('resets offset and token when %s changes the verified prefix', async (name, generationsFor) => {
     const { contextGraphId, remotePeerId, x, y } = makeScenario(name.replaceAll(' ', '-'), generationsFor);
     const harness = createTwoRoundHarness(contextGraphId, remotePeerId);
     const xMeta = x.flatMap((entry) => entry.meta);
@@ -328,17 +394,7 @@ describe('manifest-bound durable DATA continuation', () => {
     expect(second.complete).toBe(false);
   });
 
-  it.each([
-    ['legacy checkpoint without digest', (store: MemorySyncCheckpointStore, key: string, offset: number, session: string) => {
-      deleteSyncPageCheckpoint(store, key);
-      store.set(key, offset);
-      store.setResponderSession(key, session, Date.now() + 60_000);
-    }],
-    ['responder restart without the paired session', (store: MemorySyncCheckpointStore, key: string, offset: number, _session: string, digest: DurableManifestDigest) => {
-      deleteSyncPageCheckpoint(store, key);
-      store.setManifestBoundOffset(key, offset, digest);
-    }],
-  ] as const)('fails safe for %s', async (_name, damageContinuation) => {
+  it('fails safe for a legacy checkpoint without a digest', async () => {
     const { contextGraphId, remotePeerId, x } = makeScenario('legacy-or-restart', (cg) => ({
       x: ordered([asset(cg, 1), asset(cg, 3)]),
       y: [],
@@ -350,12 +406,12 @@ describe('manifest-bound durable DATA continuation', () => {
     await harness.run({ meta, dataPage: () => prefix });
     const key = getSyncCheckpointKey(remotePeerId, contextGraphId, false, 'data');
     const established = harness.checkpointStore.get(key)!;
-    damageContinuation(
-      harness.checkpointStore,
+    deleteSyncPageCheckpoint(harness.checkpointStore, key);
+    harness.checkpointStore.set(key, established.offset);
+    harness.checkpointStore.setResponderSession(
       key,
-      established.offset,
       established.responderSessionId!,
-      established.manifestDigest!,
+      Date.now() + 60_000,
     );
 
     harness.dataRequests.length = 0;
@@ -364,6 +420,176 @@ describe('manifest-bound durable DATA continuation', () => {
     expect(harness.dataRequests[0]?.offset).toBe(0);
     expect(harness.dataRequests[0]?.syncSessionId).not.toBe(established.responderSessionId);
     expect(second.complete).toBe(false);
+  });
+
+  it('reuses a proven prefix after the responder forgets its session', async () => {
+    const { contextGraphId, remotePeerId, x } = makeScenario('responder-restart', (cg) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3)]),
+      y: [],
+    }));
+    const harness = createTwoRoundHarness(contextGraphId, remotePeerId);
+    const meta = x.flatMap((entry) => entry.meta);
+    const prefix = x[0]!.payload;
+
+    await harness.run({ meta, dataPage: () => prefix });
+    const key = getSyncCheckpointKey(remotePeerId, contextGraphId, false, 'data');
+    const established = harness.checkpointStore.get(key)!;
+    deleteSyncPageCheckpoint(harness.checkpointStore, key);
+    harness.checkpointStore.setManifestBoundOffset(
+      key,
+      established.offset,
+      established.manifestDigest!,
+      Date.now(),
+      established.manifestPrefixDigest,
+    );
+
+    harness.dataRequests.length = 0;
+    const second = await harness.run({
+      meta,
+      dataPage: (offset) => offset === 0
+        ? prefix
+        : offset === prefix.length
+          ? x[1]!.payload
+          : [],
+    });
+
+    expect(harness.dataRequests.map(({ offset }) => offset).slice(0, 2))
+      .toEqual([0, prefix.length]);
+    expect(harness.dataRequests[0]?.syncSessionId)
+      .not.toBe(established.responderSessionId);
+    expect(harness.dataRequests[1]?.syncSessionId)
+      .toBe(harness.dataRequests[0]?.syncSessionId);
+    expect(second.complete).toBe(true);
+  });
+
+  it.each([
+    ['declared session expiry', 'sync session expired'],
+    ['opaque transport reset before any resumed page', 'stream reset'],
+  ])('retains a proven prefix after %s', async (_name, failureMessage) => {
+    const { contextGraphId, remotePeerId, x } = makeScenario('responder-expired', (cg) => ({
+      x: ordered([asset(cg, 1), asset(cg, 3)]),
+      y: [],
+    }));
+    const harness = createTwoRoundHarness(contextGraphId, remotePeerId);
+    const meta = x.flatMap((entry) => entry.meta);
+    const prefix = x[0]!.payload;
+
+    await harness.run({ meta, dataPage: () => prefix });
+    const key = getSyncCheckpointKey(remotePeerId, contextGraphId, false, 'data');
+    const established = harness.checkpointStore.get(key)!;
+    expect(established).toMatchObject({
+      offset: prefix.length,
+      responderSessionId: expect.any(String),
+      manifestPrefixDigest: expect.stringMatching(/^sha256:/),
+    });
+
+    await harness.run({
+      meta,
+      dataPage: () => new Error(failureMessage),
+    });
+    expect(harness.checkpointStore.get(key)).toMatchObject({
+      offset: prefix.length,
+      manifestDigest: established.manifestDigest,
+      manifestPrefixDigest: established.manifestPrefixDigest,
+    });
+    expect(harness.checkpointStore.get(key)?.responderSessionId).toBeUndefined();
+
+    harness.dataRequests.length = 0;
+    const recovered = await harness.run({
+      meta,
+      dataPage: (offset) => offset === 0
+        ? prefix
+        : offset === prefix.length
+          ? x[1]!.payload
+          : [],
+    });
+
+    expect(harness.dataRequests.map(({ offset }) => offset).slice(0, 2))
+      .toEqual([0, prefix.length]);
+    expect(harness.dataRequests[0]?.syncSessionId)
+      .not.toBe(established.responderSessionId);
+    expect(recovered.complete).toBe(true);
+  });
+
+  it('scopes the manifest before exact recovery when an old responder over-returns', async () => {
+    const contextGraphId = `manifest-exact-over-return-${scenarioSequence++}`;
+    const remotePeerId = 'peer-exact-over-return';
+    const [unrequested, requested] = ordered([
+      asset(contextGraphId, 1),
+      asset(contextGraphId, 3),
+    ]);
+    const fullMeta = [...unrequested!.meta, ...requested!.meta];
+    const fullData = [...unrequested!.payload, ...requested!.payload];
+    const requestedPlan = createGraphScopedDurableManifestPlan(
+      requested!.meta,
+      contextGraphId,
+    )!;
+    const harness = createTwoRoundHarness(
+      contextGraphId,
+      remotePeerId,
+      new MemorySyncCheckpointStore(),
+      [requested!.ual],
+    );
+
+    const result = await harness.run({
+      meta: fullMeta,
+      // Simulate a rolling responder that ignores assetUals and returns the
+      // complete Context Graph in its legacy order.
+      dataPage: (offset) => offset === 0 ? fullData : [],
+    });
+
+    expect(harness.dataRequests[0]?.manifestDigest).toBe(requestedPlan.manifestDigest);
+    expect(harness.storedAssetUals).toEqual([requested!.ual]);
+    expect(result.complete).toBe(true);
+  });
+
+  it('restarts exact recovery at zero after its page-only responder session is rejected', async () => {
+    const contextGraphId = `manifest-exact-session-loss-${scenarioSequence++}`;
+    const remotePeerId = 'peer-exact-session-loss';
+    const requested = ordered([
+      asset(contextGraphId, 7),
+      asset(contextGraphId, 9),
+    ]);
+    const requestedUals = requested.map(({ ual }) => ual);
+    const meta = requested.flatMap(({ meta: assetMeta }) => assetMeta);
+    const harness = createTwoRoundHarness(
+      contextGraphId,
+      remotePeerId,
+      new MemorySyncCheckpointStore(),
+      requestedUals,
+    );
+
+    await harness.run({ meta, dataPage: () => requested[0]!.payload });
+    const key = getSyncCheckpointKey(
+      remotePeerId,
+      contextGraphId,
+      false,
+      'data',
+      undefined,
+      undefined,
+      undefined,
+      exactAssetFilterKey(requestedUals),
+    );
+    const established = harness.checkpointStore.get(key)!;
+    expect(established.offset).toBe(requested[0]!.payload.length);
+    await harness.run({
+      meta,
+      dataPage: () => new Error('sync session expired'),
+    });
+    expect(harness.checkpointStore.get(key)).toBeUndefined();
+
+    harness.dataRequests.length = 0;
+    const result = await harness.run({
+      meta,
+      dataPage: (offset) => offset === 0
+        ? requested.flatMap(({ payload }) => payload)
+        : [],
+    });
+
+    expect(harness.dataRequests[0]?.offset).toBe(0);
+    expect(harness.dataRequests[0]?.syncSessionId)
+      .not.toBe(established.responderSessionId);
+    expect(result.complete).toBe(true);
   });
 
   it('does not issue DATA or complete when META transport is incomplete', async () => {
@@ -398,5 +624,83 @@ describe('manifest-bound durable DATA continuation', () => {
     expect(dataFetches).toBe(0);
     expect(result.complete).toBe(false);
     expect(result.failedPhases).toBe(1);
+  });
+
+  it('deletes a resumed META suffix checkpoint before refusing DATA', async () => {
+    const contextGraphId = `manifest-resumed-meta-${scenarioSequence++}`;
+    const deleteCheckpoint = vi.fn();
+    let dataFetches = 0;
+    const result = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-resumed-meta',
+      contextGraphIds: [contextGraphId],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase }) => {
+        if (phase === 'data') dataFetches += 1;
+        return {
+          quads: [],
+          bytesReceived: 0,
+          resumedFromOffset: phase === 'meta' ? 10 : 0,
+          nextOffset: phase === 'meta' ? 20 : 0,
+          checkpointKey: `${contextGraphId}:${phase}`,
+          completed: true,
+          timedOut: false,
+        };
+      },
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      deleteCheckpoint,
+      setCheckpoint: () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(deleteCheckpoint).toHaveBeenCalledWith(`${contextGraphId}:meta`);
+    expect(dataFetches).toBe(0);
+    expect(result.complete).toBe(false);
+  });
+
+  it('deletes a manifest-bound DATA checkpoint when verification rejects a graph', async () => {
+    const contextGraphId = `manifest-rejected-data-${scenarioSequence++}`;
+    const remotePeerId = 'peer-rejected-data';
+    const fixture = asset(contextGraphId, 1);
+    const checkpointKey = getSyncCheckpointKey(
+      remotePeerId,
+      contextGraphId,
+      false,
+      'data',
+    );
+    const deleteCheckpoint = vi.fn();
+    const result = await runDurableSync({
+      ctx,
+      remotePeerId,
+      contextGraphIds: [contextGraphId],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase, manifestDigest }) => ({
+        quads: phase === 'meta' ? fixture.meta : fixture.payload,
+        bytesReceived: 1,
+        resumedFromOffset: 0,
+        ...(phase === 'data' && manifestDigest ? { manifestDigest } : {}),
+        nextOffset: phase === 'meta' ? fixture.meta.length : fixture.payload.length,
+        checkpointKey: phase === 'data' ? checkpointKey : `${contextGraphId}:meta`,
+        completed: true,
+        timedOut: false,
+      }),
+      processDurableBatchInWorker: async (...args) => ({
+        ...processBatch(...args),
+        rejectedKcs: 1,
+      }),
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async () => 'applied',
+      deleteCheckpoint,
+      setCheckpoint: () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(deleteCheckpoint).toHaveBeenCalledWith(checkpointKey);
+    expect(result.complete).toBe(false);
   });
 });

--- a/packages/agent/test/durable-manifest-digest.test.ts
+++ b/packages/agent/test/durable-manifest-digest.test.ts
@@ -1,0 +1,182 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import {
+  computeFlatKCRootV10,
+  computePrivateRootV10,
+  generateGraphKnowledgeAssetMetadata,
+} from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  createGraphScopedDurableManifestPlan,
+  DURABLE_MANIFEST_DIGEST_DOMAIN,
+  DURABLE_MANIFEST_DIGEST_VERSION,
+  encodeGraphScopedDurableManifest,
+  type GraphScopedDescriptor,
+} from '../src/sync/durable-integrity.js';
+
+const CONTEXT_GRAPH_ID = 'manifest-digest-test';
+
+function asset(
+  kaNumber: number,
+  options: { tripleCount?: number; valuePrefix?: string; subGraphName?: string } = {},
+): { payload: Quad[]; meta: Quad[] } {
+  const tripleCount = options.tripleCount ?? 2;
+  const ual = `did:dkg:hardhat:31337/0x00000000000000000000000000000000000000dd/${kaNumber}`;
+  const scope = createGraphKnowledgeAssetScope(ual, '1');
+  const graph = knowledgeAssetLayerGraphUri(
+    CONTEXT_GRAPH_ID,
+    MemoryLayer.VerifiableMemory,
+    scope,
+    options.subGraphName,
+  );
+  const payload = Array.from({ length: tripleCount }, (_, index): Quad => ({
+    subject: `urn:manifest:${kaNumber}:${index}`,
+    predicate: 'urn:manifest:value',
+    object: `"${options.valuePrefix ?? 'value'}-${index}"`,
+    graph,
+  }));
+  const privateQuads: Quad[] = [];
+  const privateMerkleRoot = computePrivateRootV10(privateQuads);
+  return {
+    payload,
+    meta: generateGraphKnowledgeAssetMetadata({
+      ual,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      merkleRoot: computeFlatKCRootV10(
+        payload,
+        privateMerkleRoot ? [privateMerkleRoot] : [],
+      ),
+      publisherPeerId: 'publisher-peer',
+      accessPolicy: 'public',
+      timestamp: new Date(0),
+      assertionVersion: '1',
+      publicTripleCount: payload.length,
+      privateTripleCount: 0,
+      assertionGraph: graph,
+      ...(options.subGraphName ? { subGraphName: options.subGraphName } : {}),
+    }, { status: 'tentative' }),
+  };
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function descriptor(overrides: Partial<GraphScopedDescriptor> = {}): GraphScopedDescriptor {
+  return {
+    ual: 'did:dkg:test/asset',
+    contentScopeVersion: '2',
+    assertionVersion: '1',
+    contextGraphId: CONTEXT_GRAPH_ID,
+    assertionGraph: 'did:dkg:context-graph:test/_verifiable_memory/a',
+    publicTripleCount: 2,
+    privateTripleCount: 0,
+    claimedRootHex: '11'.repeat(32),
+    ...overrides,
+  };
+}
+
+describe('canonical durable manifest digest', () => {
+  it('is deterministic and independent of raw META RDF row order', () => {
+    const meta = [asset(1), asset(2), asset(3)].flatMap((entry) => entry.meta);
+    const forward = createGraphScopedDurableManifestPlan(meta, CONTEXT_GRAPH_ID);
+    const reordered = createGraphScopedDurableManifestPlan([...meta].reverse(), CONTEXT_GRAPH_ID);
+
+    expect(forward).not.toBeNull();
+    expect(reordered?.manifestDigest).toBe(forward?.manifestDigest);
+    expect(reordered?.descriptors).toEqual(forward?.descriptors);
+  });
+
+  it('changes for equal-width replacement and append generations', () => {
+    const x = createGraphScopedDurableManifestPlan(
+      [asset(1), asset(3), asset(5)].flatMap((entry) => entry.meta),
+      CONTEXT_GRAPH_ID,
+    );
+    const replacement = createGraphScopedDurableManifestPlan(
+      [asset(1), asset(2), asset(5)].flatMap((entry) => entry.meta),
+      CONTEXT_GRAPH_ID,
+    );
+    const appended = createGraphScopedDurableManifestPlan(
+      [asset(1), asset(3), asset(5), asset(7)].flatMap((entry) => entry.meta),
+      CONTEXT_GRAPH_ID,
+    );
+
+    expect(replacement?.manifestRowCount).toBe(x?.manifestRowCount);
+    expect(replacement?.manifestDigest).not.toBe(x?.manifestDigest);
+    expect(appended?.manifestDigest).not.toBe(x?.manifestDigest);
+  });
+
+  it('uses unambiguous length-prefixed fields', () => {
+    const left = encodeGraphScopedDurableManifest(CONTEXT_GRAPH_ID, [descriptor({
+      ual: 'a|b',
+      assertionGraph: 'c',
+    })]);
+    const right = encodeGraphScopedDurableManifest(CONTEXT_GRAPH_ID, [descriptor({
+      ual: 'a',
+      assertionGraph: 'b|c',
+    })]);
+
+    expect(left).not.toEqual(right);
+    expect(sha256(left)).not.toBe(sha256(right));
+  });
+
+  it('is sensitive to every DATA-plan and integrity field', () => {
+    const base = descriptor();
+    const baseDigest = sha256(encodeGraphScopedDurableManifest(CONTEXT_GRAPH_ID, [base]));
+    const mutations: GraphScopedDescriptor[] = [
+      descriptor({ ual: `${base.ual}:other` }),
+      descriptor({ contentScopeVersion: '3' }),
+      descriptor({ assertionVersion: '2' }),
+      descriptor({ contextGraphId: `${CONTEXT_GRAPH_ID}:other` }),
+      descriptor({ subGraphName: 'private' }),
+      descriptor({ assertionGraph: `${base.assertionGraph}:other` }),
+      descriptor({ publicTripleCount: 3 }),
+      descriptor({ claimedRootHex: '22'.repeat(32) }),
+      descriptor({ privateTripleCount: 1, privateRootHex: '33'.repeat(32) }),
+    ];
+
+    for (const mutation of mutations) {
+      expect(sha256(encodeGraphScopedDurableManifest(CONTEXT_GRAPH_ID, [mutation])))
+        .not.toBe(baseDigest);
+    }
+  });
+
+  it('is order-sensitive using the same ordered descriptors as the DATA plan', () => {
+    const first = descriptor({ ual: 'first', assertionGraph: 'graph:a' });
+    const second = descriptor({ ual: 'second', assertionGraph: 'graph:b' });
+    const forward = sha256(encodeGraphScopedDurableManifest(CONTEXT_GRAPH_ID, [first, second]));
+    const reversed = sha256(encodeGraphScopedDurableManifest(CONTEXT_GRAPH_ID, [second, first]));
+
+    expect(reversed).not.toBe(forward);
+  });
+
+  it('separates the digest domain and encoding version', () => {
+    const fields = [descriptor()];
+    const current = sha256(encodeGraphScopedDurableManifest(
+      CONTEXT_GRAPH_ID,
+      fields,
+      DURABLE_MANIFEST_DIGEST_DOMAIN,
+      DURABLE_MANIFEST_DIGEST_VERSION,
+    ));
+    const otherDomain = sha256(encodeGraphScopedDurableManifest(
+      CONTEXT_GRAPH_ID,
+      fields,
+      `${DURABLE_MANIFEST_DIGEST_DOMAIN}.other`,
+      DURABLE_MANIFEST_DIGEST_VERSION,
+    ));
+    const otherVersion = sha256(encodeGraphScopedDurableManifest(
+      CONTEXT_GRAPH_ID,
+      fields,
+      DURABLE_MANIFEST_DIGEST_DOMAIN,
+      DURABLE_MANIFEST_DIGEST_VERSION + 1,
+    ));
+
+    expect(otherDomain).not.toBe(current);
+    expect(otherVersion).not.toBe(current);
+  });
+});

--- a/packages/agent/test/durable-manifest-digest.test.ts
+++ b/packages/agent/test/durable-manifest-digest.test.ts
@@ -16,6 +16,7 @@ import {
   DURABLE_MANIFEST_DIGEST_DOMAIN,
   DURABLE_MANIFEST_DIGEST_VERSION,
   encodeGraphScopedDurableManifest,
+  graphScopedDurableManifestPrefixAtOffset,
   type GraphScopedDescriptor,
 } from '../src/sync/durable-integrity.js';
 
@@ -178,5 +179,31 @@ describe('canonical durable manifest digest', () => {
 
     expect(otherDomain).not.toBe(current);
     expect(otherVersion).not.toBe(current);
+  });
+
+  it('reuses only an unchanged canonical graph prefix across generations', () => {
+    const original = createGraphScopedDurableManifestPlan(
+      [asset(1), asset(3)].flatMap((entry) => entry.meta),
+      CONTEXT_GRAPH_ID,
+    )!;
+    const appended = createGraphScopedDurableManifestPlan(
+      [asset(1), asset(3), asset(5)].flatMap((entry) => entry.meta),
+      CONTEXT_GRAPH_ID,
+    )!;
+    const changedPrefix = createGraphScopedDurableManifestPlan(
+      [asset(1, { valuePrefix: 'changed' }), asset(3), asset(5)]
+        .flatMap((entry) => entry.meta),
+      CONTEXT_GRAPH_ID,
+    )!;
+
+    const boundary = original.descriptors[0]!.publicTripleCount;
+    const originalPrefix = graphScopedDurableManifestPrefixAtOffset(original, boundary);
+    const appendedPrefix = graphScopedDurableManifestPrefixAtOffset(appended, boundary);
+    const changed = graphScopedDurableManifestPrefixAtOffset(changedPrefix, boundary);
+
+    expect(appended.manifestDigest).not.toBe(original.manifestDigest);
+    expect(appendedPrefix?.prefixDigest).toBe(originalPrefix?.prefixDigest);
+    expect(changed?.prefixDigest).not.toBe(originalPrefix?.prefixDigest);
+    expect(graphScopedDurableManifestPrefixAtOffset(appended, boundary - 1)).toBeNull();
   });
 });

--- a/packages/agent/test/exact-asset-wire-parse.test.ts
+++ b/packages/agent/test/exact-asset-wire-parse.test.ts
@@ -325,6 +325,67 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
     await store.close();
   }, 60_000);
 
+  it('fails at the first short graph instead of borrowing rows from the next graph', async () => {
+    const contextGraphId = 'short-public-exact';
+    const store = new OxigraphStore();
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const declaredRows = 4;
+    const assetUals = [
+      `did:dkg:base:84532/${AUTHOR}/201`,
+      `did:dkg:base:84532/${AUTHOR}/202`,
+    ];
+    const payloadGraphs = assetUals.map((ual) => knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(ual, 1),
+    ));
+    const manifestQuads: Quad[] = [];
+    for (const [index, ual] of assetUals.entries()) {
+      const graph = payloadGraphs[index]!;
+      manifestQuads.push(
+        { graph: metaGraph, subject: ual, predicate: `${DKG}contentScopeVersion`, object: integer(GRAPH_KA_CONTENT_SCOPE_VERSION) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}kaUal`, object: ual },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}assertionVersion`, object: integer(1) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}assertionGraph`, object: graph },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}contextGraph`, object: contextGraphDataGraphUri(contextGraphId) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}publicTripleCount`, object: integer(declaredRows) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}privateTripleCount`, object: integer(0) },
+        { graph: metaGraph, subject: ual, predicate: `${DKG}status`, object: '"confirmed"' },
+      );
+    }
+    await store.insert([
+      ...manifestQuads,
+      ...Array.from({ length: declaredRows - 1 }, (_, index) => ({
+        graph: payloadGraphs[0]!,
+        subject: `urn:short-graph:${index}`,
+        predicate: 'urn:predicate',
+        object: `"value-${index}"`,
+      })),
+      ...Array.from({ length: declaredRows }, (_, index) => ({
+        graph: payloadGraphs[1]!,
+        subject: `urn:complete-next-graph:${index}`,
+        predicate: 'urn:predicate',
+        object: `"value-${index}"`,
+      })),
+    ]);
+
+    await expect(readDurableDataPage({
+      store,
+      graphList: payloadGraphs,
+      contextGraphId,
+      sinceBatchId: null,
+      offset: 0,
+      limit: declaredRows * assetUals.length,
+      assetUals,
+      exactGraphReadMode: 'page-only',
+    })).rejects.toThrow(
+      `Sync exact-graph plan changed while paging ${payloadGraphs[0]}: ` +
+      `expected ${declaredRows} rows at offset 0, found ${declaredRows - 1}`,
+    );
+
+    await store.close();
+  });
+
   it('keeps fake signature fields on the 64-row page-only exact-fetch policy', async () => {
     const contextGraphId = 'fake-signature-public-exact';
     const store = new OxigraphStore();

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
+  createGraphScopedDurableManifestPlan,
   isGraphScopedDurableManifestBoundary,
   planBoundedGraphScopedDurableBatch,
 } from '../src/sync/durable-integrity.js';
@@ -558,6 +559,7 @@ describe('bounded rootless durable progress', () => {
     const fixtures = orderedAssets();
     const meta = fixtures.flatMap((entry) => entry.meta);
     const suffix = fixtures[2]!.payload;
+    const manifestDigest = createGraphScopedDurableManifestPlan(meta, CONTEXT_GRAPH_ID)!.manifestDigest;
     const inserted: Quad[][] = [];
     const materialized: Array<{ dataQuads: Quad[] }> = [];
     const deleted: string[] = [];
@@ -578,6 +580,7 @@ describe('bounded rootless durable progress', () => {
           quads: suffix,
           resumedFromOffset: 8,
           nextOffset: 12,
+          manifestDigest,
           completed: true,
           timedOut: false,
         }),
@@ -611,6 +614,7 @@ describe('bounded rootless durable progress', () => {
   it('resets a checkpoint that resumes inside an exact assertion graph', async () => {
     const fixtures = orderedAssets();
     const meta = fixtures.flatMap((entry) => entry.meta);
+    const manifestDigest = createGraphScopedDurableManifestPlan(meta, CONTEXT_GRAPH_ID)!.manifestDigest;
     const misalignedOffset = 1;
     const suffix = [
       ...fixtures[0]!.payload.slice(misalignedOffset),
@@ -639,6 +643,7 @@ describe('bounded rootless durable progress', () => {
           quads: suffix,
           resumedFromOffset: misalignedOffset,
           nextOffset: misalignedOffset + suffix.length,
+          manifestDigest,
           completed: false,
           timedOut: true,
         }),

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
+  isGraphScopedDurableManifestBoundary,
   planBoundedGraphScopedDurableBatch,
 } from '../src/sync/durable-integrity.js';
 import {
@@ -581,6 +582,68 @@ describe('bounded rootless durable progress', () => {
     expect(deleted).toContain(`${CONTEXT_GRAPH_ID}:data`);
     expect(materialized.flatMap((entry) => entry.dataQuads)).toEqual(suffix);
     expect(inserted.flat().some((quad) => quad.graph === fixtures[2]!.graph)).toBe(false);
+  });
+
+  it('resets a checkpoint that resumes inside an exact assertion graph', async () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const misalignedOffset = 1;
+    const suffix = [
+      ...fixtures[0]!.payload.slice(misalignedOffset),
+      ...fixtures[1]!.payload,
+    ];
+    const deleted: string[] = [];
+    const materialized: string[] = [];
+    const warnings: string[] = [];
+    let verificationCalls = 0;
+
+    expect(isGraphScopedDurableManifestBoundary(meta, 0)).toBe(true);
+    expect(isGraphScopedDurableManifestBoundary(meta, 4)).toBe(true);
+    expect(isGraphScopedDurableManifestBoundary(meta, misalignedOffset)).toBe(false);
+    expect(isGraphScopedDurableManifestBoundary(meta, 13)).toBe(false);
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-misaligned-resume',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({
+        phase,
+      }: DurableSyncFetchRequest) => phase === 'meta'
+        ? pageResult('meta', { quads: meta, nextOffset: meta.length })
+        : pageResult('data', {
+          quads: suffix,
+          resumedFromOffset: misalignedOffset,
+          nextOffset: misalignedOffset + suffix.length,
+          completed: false,
+          timedOut: true,
+        }),
+      processDurableBatchInWorker: (...args) => {
+        verificationCalls += 1;
+        return processBatch(...args);
+      },
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async ({
+        asset,
+      }: DurableSyncGraphScopedStoreRequest) => {
+        materialized.push(asset.ual);
+        return 'applied';
+      },
+      deleteCheckpoint: (key) => { deleted.push(key); },
+      setCheckpoint: () => {},
+      logInfo: () => {},
+      logWarn: (_ctx, message) => { warnings.push(message); },
+      logDebug: () => {},
+    });
+
+    expect(summary.insertedTriples).toBe(0);
+    expect(summary.failedPhases).toBe(1);
+    expect(verificationCalls).toBe(0);
+    expect(materialized).toEqual([]);
+    expect(deleted).toContain(`${CONTEXT_GRAPH_ID}:data`);
+    expect(warnings.some((message) => message.includes(
+      'resumed offset 1 is inside an assertion graph',
+    ))).toBe(true);
   });
 
   it('fails closed for mixed legacy and graph-scoped metadata', () => {

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -180,6 +180,30 @@ describe('bounded rootless durable progress', () => {
     expect(plan?.dataQuads).toEqual(fixtures[0]!.payload);
   });
 
+  it('preserves the safe prefix when an older responder cursor advances past missing rows', () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const rawData = [
+      ...fixtures[0]!.payload,
+      ...fixtures[1]!.payload.slice(0, 2),
+      ...fixtures[2]!.payload,
+    ];
+
+    const plan = planBoundedGraphScopedDurableBatch(
+      rawData,
+      meta,
+      0,
+      rawData.length + 63,
+      false,
+    );
+
+    expect(plan).not.toBeNull();
+    expect(plan?.safeNextOffset).toBe(4);
+    expect(plan?.completedGraphCount).toBe(1);
+    expect(plan?.changedDataGraphs).toEqual([fixtures[0]!.graph]);
+    expect(plan?.dataQuads).toEqual(fixtures[0]!.payload);
+  });
+
   it('does not checkpoint a corrupt leading graph while dropping a non-contiguous tail', async () => {
     const fixtures = orderedAssets();
     const meta = fixtures.flatMap((entry) => entry.meta);

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -154,6 +154,81 @@ describe('bounded rootless durable progress', () => {
     ]);
   });
 
+  it('drops rows after the first incomplete graph and preserves the safe leading prefix', () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const rawData = [
+      ...fixtures[0]!.payload,
+      ...fixtures[1]!.payload.slice(0, 2),
+      ...fixtures[2]!.payload,
+    ];
+
+    const plan = planBoundedGraphScopedDurableBatch(
+      rawData,
+      meta,
+      0,
+      rawData.length,
+      false,
+    );
+
+    expect(plan).not.toBeNull();
+    expect(plan?.safeNextOffset).toBe(4);
+    expect(plan?.manifestRowCount).toBe(12);
+    expect(plan?.completedGraphCount).toBe(1);
+    expect(plan?.changedDataGraphs).toEqual([fixtures[0]!.graph]);
+    expect(plan?.dataQuads).toEqual(fixtures[0]!.payload);
+  });
+
+  it('does not checkpoint a corrupt leading graph while dropping a non-contiguous tail', async () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const corruptLeading = fixtures[0]!.payload.map((quad, index) => index === 0
+      ? { ...quad, object: '"tampered"' }
+      : quad);
+    const rawData = [
+      ...corruptLeading,
+      ...fixtures[1]!.payload.slice(0, 2),
+      ...fixtures[2]!.payload,
+    ];
+    const materialized: string[] = [];
+    const checkpoints: Array<[string, number]> = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-non-contiguous',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({
+        phase,
+      }: DurableSyncFetchRequest) => phase === 'meta'
+        ? pageResult('meta', { quads: meta, nextOffset: meta.length })
+        : pageResult('data', {
+          quads: rawData,
+          nextOffset: rawData.length,
+          completed: false,
+          timedOut: true,
+        }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async ({
+        asset,
+      }: DurableSyncGraphScopedStoreRequest) => {
+        materialized.push(asset.ual);
+        return 'applied';
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: (key, offset) => { checkpoints.push([key, offset]); },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.rejectedKcs).toBe(1);
+    expect(summary.insertedDataTriples).toBe(0);
+    expect(materialized).toEqual([]);
+    expect(checkpoints).toEqual([]);
+  });
+
   it('ignores a non-IRI dkg:partOf poison row and still projects the valid boundary (#1921)', () => {
     // A peer can attach `_:bad dkg:partOf "<valid-ual>"` to a valid graph-scoped
     // manifest. Without the bounded planner's #1921 verification-input sanitize,

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -9,7 +9,9 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_BYTE_BUDGET_RESPONSE_BYTES,
+  SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD,
   SYNC_PAGE_SIZE,
+  SYNC_REQUEST_INITIAL_PAGE_SIZE,
   SYNC_REQUEST_PAGE_SIZE,
   SYNC_REQUEST_SAFE_PAGE_SIZE,
 } from '../src/dkg-agent-constants.js';
@@ -226,8 +228,8 @@ describe('byte-budget sync pagination', () => {
     });
 
     expect(requested).toEqual([
-      { offset: 0, limit: SYNC_REQUEST_PAGE_SIZE },
-      { offset: SYNC_PAGE_SIZE, limit: SYNC_REQUEST_PAGE_SIZE },
+      { offset: 0, limit: SYNC_REQUEST_INITIAL_PAGE_SIZE },
+      { offset: SYNC_PAGE_SIZE, limit: SYNC_REQUEST_INITIAL_PAGE_SIZE },
     ]);
     expect(result.nextOffset).toBe(SYNC_PAGE_SIZE);
     expect(result.completed).toBe(true);
@@ -249,17 +251,18 @@ describe('byte-budget sync pagination', () => {
       send: async () => {
         sends += 1;
         if (sends === 1) throw new Error('relay stream reset');
-        return sends <= 4
+        return sends <= SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD + 1
           ? new TextEncoder().encode('<urn:s> <urn:p> <urn:o> <urn:g> .')
           : new Uint8Array();
       },
     }));
 
     expect(requestedSizes).toEqual([
-      SYNC_REQUEST_PAGE_SIZE,
-      SYNC_REQUEST_SAFE_PAGE_SIZE,
-      SYNC_REQUEST_SAFE_PAGE_SIZE,
-      SYNC_REQUEST_SAFE_PAGE_SIZE,
+      SYNC_REQUEST_INITIAL_PAGE_SIZE,
+      ...Array.from(
+        { length: SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD },
+        () => SYNC_REQUEST_SAFE_PAGE_SIZE,
+      ),
       SYNC_REQUEST_SAFE_PAGE_SIZE * 2,
     ]);
     expect(result.completed).toBe(true);
@@ -288,7 +291,7 @@ describe('byte-budget sync pagination', () => {
 
     await expect(run()).rejects.toThrow('sync responder queue wait exceeded');
     expect(requestedSizes).toEqual([
-      SYNC_REQUEST_PAGE_SIZE,
+      SYNC_REQUEST_INITIAL_PAGE_SIZE,
       SYNC_REQUEST_SAFE_PAGE_SIZE,
       SYNC_REQUEST_SAFE_PAGE_SIZE,
     ]);
@@ -321,13 +324,13 @@ describe('byte-budget sync pagination', () => {
     }));
 
     await expect(run()).rejects.toThrow('terminal relay stream reset');
-    expect(requestedSizes).toEqual([SYNC_REQUEST_PAGE_SIZE]);
+    expect(requestedSizes).toEqual([SYNC_REQUEST_INITIAL_PAGE_SIZE]);
     expect(pageSizeProfileCache.preferred(scope)).toBe(SYNC_REQUEST_SAFE_PAGE_SIZE);
 
     failTransport = false;
     await expect(run()).resolves.toMatchObject({ completed: true, nextOffset: 0 });
     expect(requestedSizes).toEqual([
-      SYNC_REQUEST_PAGE_SIZE,
+      SYNC_REQUEST_INITIAL_PAGE_SIZE,
       SYNC_REQUEST_SAFE_PAGE_SIZE,
     ]);
   });

--- a/packages/agent/test/sync-checkpoint-key.test.ts
+++ b/packages/agent/test/sync-checkpoint-key.test.ts
@@ -100,6 +100,7 @@ describe('getSyncCheckpointKey', () => {
 describe('manifest-bound sync continuation', () => {
   const digestA = `sha256:${'aa'.repeat(32)}` as const;
   const digestB = `sha256:${'bb'.repeat(32)}` as const;
+  const prefixDigest = `sha256:${'cc'.repeat(32)}` as const;
 
   it('stores offset, responder session and digest as one logical tuple', () => {
     const store = new MemorySyncCheckpointStore({ clock: () => 1_000 });
@@ -148,5 +149,19 @@ describe('manifest-bound sync continuation', () => {
       manifestDigest: digestA,
     });
     expect(store.get('data', 2_001)?.responderSessionId).toBeUndefined();
+  });
+
+  it('atomically rebinds a proven prefix while dropping the old generation token', () => {
+    const store = new MemorySyncCheckpointStore({ clock: () => 1_000 });
+    store.setResponderSession('data', 'session-a', 10_000, 1_000, digestA);
+    store.setManifestBoundOffset('data', 512, digestA, 1_001, prefixDigest);
+    store.setManifestBoundOffset('data', 512, digestB, 1_002, prefixDigest);
+
+    expect(store.get('data', 1_003)).toMatchObject({
+      offset: 512,
+      manifestDigest: digestB,
+      manifestPrefixDigest: prefixDigest,
+    });
+    expect(store.get('data', 1_003)?.responderSessionId).toBeUndefined();
   });
 });

--- a/packages/agent/test/sync-checkpoint-key.test.ts
+++ b/packages/agent/test/sync-checkpoint-key.test.ts
@@ -96,3 +96,57 @@ describe('getSyncCheckpointKey', () => {
     expect(store.get(recoveryKey)).toBeUndefined();
   });
 });
+
+describe('manifest-bound sync continuation', () => {
+  const digestA = `sha256:${'aa'.repeat(32)}` as const;
+  const digestB = `sha256:${'bb'.repeat(32)}` as const;
+
+  it('stores offset, responder session and digest as one logical tuple', () => {
+    const store = new MemorySyncCheckpointStore({ clock: () => 1_000 });
+    store.setResponderSession('data', 'session-a', 10_000, 1_000, digestA);
+    store.setManifestBoundOffset('data', 512, digestA, 1_001);
+
+    expect(store.get('data', 1_002)).toMatchObject({
+      offset: 512,
+      manifestDigest: digestA,
+      responderSessionId: 'session-a',
+      responderSessionExpiresAtMs: 10_000,
+    });
+  });
+
+  it('never carries a responder token across a manifest change', () => {
+    const store = new MemorySyncCheckpointStore({ clock: () => 1_000 });
+    store.setResponderSession('data', 'session-a', 10_000, 1_000, digestA);
+    store.setManifestBoundOffset('data', 512, digestA, 1_001);
+    store.setManifestBoundOffset('data', 0, digestB, 1_002);
+
+    expect(store.get('data', 1_003)).toMatchObject({
+      offset: 0,
+      manifestDigest: digestB,
+    });
+    expect(store.get('data', 1_003)?.responderSessionId).toBeUndefined();
+  });
+
+  it('does not let an unbound offset update inherit a bound token or digest', () => {
+    const store = new MemorySyncCheckpointStore({ clock: () => 1_000 });
+    store.setResponderSession('data', 'session-a', 10_000, 1_000, digestA);
+    store.setManifestBoundOffset('data', 512, digestA, 1_001);
+    store.set('data', 768, 1_002);
+
+    expect(store.get('data', 1_003)).toMatchObject({ offset: 768 });
+    expect(store.get('data', 1_003)?.manifestDigest).toBeUndefined();
+    expect(store.get('data', 1_003)?.responderSessionId).toBeUndefined();
+  });
+
+  it('preserves the digest when the responder session expires or is cleared', () => {
+    const store = new MemorySyncCheckpointStore({ clock: () => 1_000 });
+    store.setResponderSession('data', 'session-a', 2_000, 1_000, digestA);
+    store.setManifestBoundOffset('data', 512, digestA, 1_001);
+
+    expect(store.get('data', 2_001)).toMatchObject({
+      offset: 512,
+      manifestDigest: digestA,
+    });
+    expect(store.get('data', 2_001)?.responderSessionId).toBeUndefined();
+  });
+});

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -9,7 +9,12 @@ import {
   FOREGROUND_CATCHUP_SYNC_PRIORITY,
 } from '../src/index.js';
 import type { ContextGraphMembershipStore, SwmSnapshotCoverage } from '../src/dkg-agent-types.js';
-import { resolveSyncGlobalBackpressure, SyncBackpressureBusyError, withGlobalSyncBackpressure } from '../src/sync/backpressure.js';
+import {
+  getSyncBackpressureSnapshot,
+  resolveSyncGlobalBackpressure,
+  SyncBackpressureBusyError,
+  withGlobalSyncBackpressure,
+} from '../src/sync/backpressure.js';
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
 import type { SyncCheckpointScope } from '../src/sync/checkpoint/state.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
@@ -744,8 +749,10 @@ describe('DKGAgent sync fetch coalescing', () => {
       );
       await waitFor(() => fetchCalls === 1);
       // Different budgets remain separate operations, but the second physical
-      // stream must wait instead of racing/superseding the first session.
+      // stream must wait outside admission instead of racing/superseding the
+      // first session or occupying a second scarce slow-lane slot.
       expect(fetchCalls).toBe(1);
+      expect(getSyncBackpressureSnapshot()).toMatchObject({ inflight: 1, queued: 0 });
 
       firstMetaFetch.resolve(emptySyncPage('meta'));
       const [automaticResult, recoveryResult] = await Promise.all([automatic, recovery]);

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -40,6 +40,7 @@ type FetchArgs = {
   sinceBatchId?: string;
   signal?: AbortSignal;
   recovery?: boolean;
+  manifestDigest?: `sha256:${string}`;
   assetUals?: string[];
   returnAcceptedPrefixOnRetryableTransportFailure?: boolean;
   requesterScope?: SyncCheckpointScope;
@@ -254,6 +255,7 @@ function fetchPages(agent: DKGAgent, args: FetchArgs = {}): Promise<SyncPageResu
       sinceBatchId: args.sinceBatchId,
       signal: args.signal,
       recovery: args.recovery,
+      manifestDigest: args.manifestDigest,
       assetUals: args.assetUals,
       returnAcceptedPrefixOnRetryableTransportFailure:
         args.returnAcceptedPrefixOnRetryableTransportFailure,
@@ -343,6 +345,11 @@ describe('DKGAgent sync fetch coalescing', () => {
       },
       { name: 'sinceBatchId', base: { sinceBatchId: '10' }, variant: { sinceBatchId: '11' } },
       { name: 'recovery', base: { includeSharedMemory: true, recovery: false }, variant: { includeSharedMemory: true, recovery: true } },
+      {
+        name: 'manifestDigest',
+        base: { manifestDigest: `sha256:${'aa'.repeat(32)}` },
+        variant: { manifestDigest: `sha256:${'bb'.repeat(32)}` },
+      },
       // Exact VM batches: different asset filters must never share a page
       // sequence, and an exact batch must never join a full sync.
       { name: 'assetUals', base: { assetUals: [EXACT_UAL_7] }, variant: { assetUals: [EXACT_UAL_8] } },

--- a/packages/agent/test/sync-operation-telemetry.test.ts
+++ b/packages/agent/test/sync-operation-telemetry.test.ts
@@ -278,6 +278,44 @@ describe('W1 I4/I5 — the operation denominator and its rejections', () => {
     await blocking;
   });
 
+  it('releases an active lane after signal-aware work observes cancellation', async () => {
+    const agent = await createAgent({ syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 2 });
+    const controller = new AbortController();
+    let firstStarted = false;
+    let secondStarted = false;
+
+    const first = admit(
+      agent,
+      {
+        source: 'vm-recovery',
+        label: 'cancel-active',
+        operationSignal: controller.signal,
+      },
+      () => new Promise<void>((_resolve, reject) => {
+        firstStarted = true;
+        const rejectAbort = () => reject(controller.signal.reason);
+        if (controller.signal.aborted) rejectAbort();
+        else controller.signal.addEventListener('abort', rejectAbort, { once: true });
+      }),
+    );
+    await waitFor(() => firstStarted && getSyncBackpressureSnapshot().inflight === 1);
+
+    const second = admit(
+      agent,
+      { source: 'catchup-foreground', label: 'after-cancel' },
+      async () => { secondStarted = true; },
+    );
+    await waitFor(() => getSyncBackpressureSnapshot().queued === 1);
+    expect(secondStarted).toBe(false);
+
+    const reason = new Error('caller cancelled active recovery');
+    controller.abort(reason);
+    await expect(first).rejects.toBe(reason);
+    await expect(second).resolves.toBeUndefined();
+    expect(secondStarted).toBe(true);
+    expect(getSyncBackpressureSnapshot()).toMatchObject({ inflight: 0, queued: 0 });
+  });
+
   it('separates a failed operation from a cancelled one CAUSALLY, and clamps a non-requester lane', async () => {
     // `cancelled` means something cancelled the operation — not that the error
     // happened to be shaped like an abort.
@@ -571,7 +609,7 @@ describe('adaptive page-size production wiring', () => {
       );
 
     await expect(fetch(PEER_A, 'meta')).rejects.toThrow('relay stream reset');
-    expect(requested.map(({ limit }) => limit)).toEqual([8_192, 64, 64]);
+    expect(requested.map(({ limit }) => limit)).toEqual([512, 64, 64]);
 
     failTransport = false;
     await expect(fetch(PEER_A, 'meta')).resolves.toMatchObject({ completed: true });
@@ -589,7 +627,7 @@ describe('adaptive page-size production wiring', () => {
       contextGraphId: CG,
       includeSharedMemory: true,
       phase: 'data',
-      limit: 8_192,
+      limit: 512,
     });
 
     const peerB = '12D3KooWPageSizeProfileIsolationPeerBBBBBBBBBBBBBBBB';
@@ -599,7 +637,7 @@ describe('adaptive page-size production wiring', () => {
       contextGraphId: CG,
       includeSharedMemory: true,
       phase: 'meta',
-      limit: 8_192,
+      limit: 512,
     });
 
     const otherContextGraphId = `${CG}-other`;
@@ -611,7 +649,7 @@ describe('adaptive page-size production wiring', () => {
       contextGraphId: otherContextGraphId,
       includeSharedMemory: true,
       phase: 'meta',
-      limit: 8_192,
+      limit: 512,
     });
 
     await expect(fetch(PEER_A, 'meta', CG, false)).resolves.toMatchObject({
@@ -622,7 +660,7 @@ describe('adaptive page-size production wiring', () => {
       contextGraphId: CG,
       includeSharedMemory: false,
       phase: 'meta',
-      limit: 8_192,
+      limit: 512,
     });
   });
 });

--- a/packages/agent/test/sync-page-frame-budget.test.ts
+++ b/packages/agent/test/sync-page-frame-budget.test.ts
@@ -6,7 +6,9 @@ import {
 import {
   SYNC_BYTE_BUDGET_MAX_ROWS,
   SYNC_BYTE_BUDGET_RESPONSE_BYTES,
+  SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD,
   SYNC_PAGE_SIZE,
+  SYNC_REQUEST_INITIAL_PAGE_SIZE,
   SYNC_REQUEST_PAGE_SIZE,
   SYNC_REQUEST_SAFE_PAGE_SIZE,
   SYNC_RESPONSE_FRAME_HEADROOM_BYTES,
@@ -25,6 +27,8 @@ describe('sync requester transport frame budget', () => {
   it('keeps the adaptive retry floor below the protocol read cap', () => {
     expect(SYNC_REQUEST_PAGE_SIZE).toBe(8_192);
     expect(SYNC_REQUEST_PAGE_SIZE).toBe(SYNC_BYTE_BUDGET_MAX_ROWS);
+    expect(SYNC_REQUEST_INITIAL_PAGE_SIZE).toBe(512);
+    expect(SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD).toBe(8);
     expect(SYNC_REQUEST_SAFE_PAGE_SIZE).toBe(64);
     expect(SYNC_RESPONSE_FRAME_HEADROOM_BYTES).toBe(6 * 1024 * 1024);
     expect(SYNC_BYTE_BUDGET_RESPONSE_BYTES).toBe(4 * 1024 * 1024);

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -367,6 +367,10 @@ describe('sync requester progress accounting', () => {
       ctx,
       remotePeerId: 'peer-a',
       contextGraphIds: ['resumed-cg'],
+      // Full rootless snapshots now require a fresh, complete META manifest
+      // before DATA. Exercise phase-level progress accounting on the delta
+      // path, where independent resumed META/DATA cursors remain valid.
+      sinceBatchIdFor: () => 'progress-cursor',
       durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
       fetchSyncPages: async ({ contextGraphId, phase }) => (
         pageResult(contextGraphId, phase, { resumedFromOffset: 500, nextOffset: 500 })
@@ -514,6 +518,7 @@ describe('sync requester progress accounting', () => {
       ctx,
       remotePeerId: 'peer-a',
       contextGraphIds: ['meta-only-cg'],
+      sinceBatchIdFor: () => 'meta-only-cursor',
       durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
       fetchSyncPages,
       processDurableBatchInWorker: async () => ({
@@ -558,6 +563,7 @@ describe('sync requester progress accounting', () => {
       ctx,
       remotePeerId: 'peer-a',
       contextGraphIds: ['discarded-controls'],
+      sinceBatchIdFor: () => 'discarded-controls-cursor',
       durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
       fetchSyncPages,
       processDurableBatchInWorker: async () => ({
@@ -638,6 +644,7 @@ describe('sync requester progress accounting', () => {
       ctx,
       remotePeerId: 'peer-a',
       contextGraphIds: ['discarded-non-iri'],
+      sinceBatchIdFor: () => 'discarded-non-iri-cursor',
       durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
       fetchSyncPages,
       processDurableBatchInWorker: async () => ({
@@ -680,6 +687,7 @@ describe('sync requester progress accounting', () => {
       ctx,
       remotePeerId: 'peer-a',
       contextGraphIds: ['discarded-mixed'],
+      sinceBatchIdFor: () => 'discarded-mixed-cursor',
       durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
       fetchSyncPages,
       processDurableBatchInWorker: async () => ({

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -253,6 +253,40 @@ describe('sync responder pagination interleaving', () => {
     })).rejects.toThrow(/expected 2 rows, found 1/);
   });
 
+  it('uses a sentinel row to reject surplus data in page-only exact-graph mode', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'rootless-v2-surplus-page-only';
+    const manifest = graphScopedVmMeta({
+      cgId,
+      ual: 'did:dkg:base:8453/0x00000000000000000000000000000000000000ac/10',
+      publicTripleCount: 1,
+      status: 'confirmed',
+    });
+    await store.insert([
+      ...manifest.quads,
+      q(manifest.graph, 0),
+      q(manifest.graph, 1),
+    ]);
+    const cap = registerTestSyncHandler(store, {
+      syncPageSize: 10,
+      snapshotBudget: {
+        maxRows: 1_000,
+        maxBytesEstimate: 1_000_000,
+        maxSnapshotRows: 0,
+        maxSnapshotBytesEstimate: 1_000_000,
+      },
+    });
+
+    await expect(cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 10,
+      syncSessionId: 'rootless-v2-surplus-page-only',
+    })).rejects.toThrow(/expected 1 total rows but found a surplus row/);
+  });
+
   it('fails closed instead of treating an incomplete V2 descriptor as legacy data', async () => {
     const store = new OxigraphStore();
     const cgId = 'rootless-v2-incomplete-manifest';
@@ -408,7 +442,7 @@ describe('sync responder pagination interleaving', () => {
     boundedQuery.assertObserved();
   });
 
-  it('preserves durable cursors beyond one million rows instead of replaying the clamp boundary', async () => {
+  it('preserves durable cursors beyond one million rows and fails closed on a short exact graph', async () => {
     const store = new OxigraphStore();
     const cgId = 'rootless-cursor-over-one-million';
     const manifest = graphScopedVmMeta({
@@ -444,7 +478,8 @@ describe('sync responder pagination interleaving', () => {
     };
 
     expect(linesFromNquads(await cap.invoke({ ...base, offset: 0 }))).toHaveLength(1);
-    expect(linesFromNquads(await cap.invoke({ ...base, offset: requestedDeepOffset }))).toHaveLength(0);
+    await expect(cap.invoke({ ...base, offset: requestedDeepOffset }))
+      .rejects.toThrow(/expected 1 rows at offset 1000005, found 0/);
     boundedQuery.assertObserved();
   });
 


### PR DESCRIPTION
## Generation-bound durable continuation (stack-level fix)

This update closes the DATA-continuation/META-generation hole without changing the responder wire protocol or the bounded-prefix behavior already in this PR.

### Root cause

Durable META and DATA used independent checkpoints and responder sessions. A later round could therefore combine a complete META manifest from generation **Y** with a nonzero DATA offset/token created under generation **X**. The numeric graph-boundary check proved only that the number happened to be a boundary in Y; it did not prove that the prefix, graph order, counts, or roots before that number were the same generation.

That made equal-width replacement, insertion, deletion, append, count/root changes, and DATA-plan reordering unsafe even when the old offset was still numerically valid.

### New invariant

> No nonzero DATA checkpoint or responder session may be resumed unless it is bound to the exact completed canonical META manifest that defines the DATA plan.

The requester now:

1. fetches META completely from offset zero;
2. structurally validates and parses one canonical graph-scoped manifest plan;
3. computes `manifestDigest` from that plan;
4. resumes DATA only when the saved `(offset, responderSessionId, manifestDigest)` tuple matches;
5. retains the existing numeric graph-boundary check as a secondary invariant;
6. deletes the paired DATA checkpoint/session on mismatch, missing legacy digest, missing responder session, misaligned offset, or verification failure.

Incomplete/suffix META cannot authorize DATA progress or terminal completion. Legacy or mixed metadata that cannot produce a canonical plan is forced into a fresh offset-zero session and can complete only in one verified round.

### Canonical manifest identity

`createGraphScopedDurableManifestPlan` is now the single parsed model used by digesting, boundary checking, and bounded-prefix planning. This also addresses the review request to keep graph-boundary repair inside one planning abstraction instead of reparsing metadata in requester branches.

The SHA-256 input uses explicit domain/version separation plus 4-byte big-endian length prefixes for every scalar. Descriptors use exactly the same Unicode code-point ordering as the DATA plan. For each descriptor the encoding commits to:

- Context Graph identity and descriptor count;
- UAL, content-scope version, assertion version, Context Graph, optional subgraph name, and assertion graph;
- public triple count and public Merkle root;
- private triple count and optional private Merkle root.

Raw RDF META row order does not affect the digest. Any field or DATA-plan order change does.

### Checkpoint/session schema and rolling behavior

The requester checkpoint store now carries an optional `manifestDigest`. Generation-bound writes update offset, responder session/token, and digest in the same in-memory map entry; a token is preserved only while its digest matches. A generic unbound offset update cannot inherit a bound token or digest.

Rolling behavior is fail-safe:

- old checkpoint/session record without a digest -> delete only that DATA continuation and restart at zero;
- digest mismatch -> delete offset and paired token, then start a new responder session at zero;
- digest match but token missing/expired after a responder restart -> restart at zero;
- custom/older checkpoint store without generation-bound offset support -> discard the unprovable continuation instead of retaining it;
- no destructive migration and no unrelated checkpoint records are touched;
- no responder protocol change is required, so an upgraded requester remains compatible with an older responder.

### Completion and exact-cardinality safety

Terminal success still requires the complete plan to be verified and materialized under one bound digest. EOF, received counts, a final page, or a numeric boundary are not independently sufficient. Verification rejection clears the paired DATA continuation so a stale session cannot be renewed.

The page-only exact-graph responder path now requests one sentinel row when a page reaches the declared end of a graph. A surplus row therefore fails closed instead of allowing the first `N` rows to masquerade as an exact `N`-row graph. This addresses the open exact-cardinality review finding while preserving short-graph and no-borrow behavior.

### Unchanged generation

```mermaid
sequenceDiagram
    participant R as Requester
    participant M as META responder
    participant C as Checkpoint store
    participant D as DATA responder
    participant V as Verifier/materializer

    R->>M: Fetch complete META from offset 0
    M-->>R: Canonical manifest X
    R->>R: Validate, order, SHA-256 -> digest X
    R->>C: Load DATA tuple
    C-->>R: offset N, token T, digest X
    R->>R: digest X == digest X; boundary N is valid
    R->>D: Fetch DATA at offset N with token T
    D-->>R: Next bounded pages from generation X
    R->>V: Verify complete graph prefix against manifest X
    V-->>R: Verified safe boundary N+k
    R->>C: Atomically retain offset N+k, token T, digest X
    Note over R,V: Terminal only after the entire X plan verifies and materializes
```

### Generation mismatch/reset

```mermaid
sequenceDiagram
    participant R as Requester
    participant M as META responder
    participant C as Checkpoint store
    participant D as DATA responder
    participant V as Verifier/materializer

    R->>M: Fetch complete META from offset 0
    M-->>R: Canonical manifest Y
    R->>R: Validate, order, SHA-256 -> digest Y
    R->>C: Load DATA tuple
    C-->>R: offset N, token T, digest X
    R->>R: digest Y != digest X
    R->>C: Delete paired offset/token/digest tuple
    R->>D: Fetch DATA at offset 0 with new token T2
    D-->>R: Bounded pages from generation Y
    R->>V: Verify against manifest Y
    V-->>R: Verified safe boundary K
    R->>C: Retain offset K, token T2, digest Y
```

### Test matrix

The new two-round harness runs the real `runDurableSync` -> `fetchSyncPages` -> checkpoint/session-cache path with a fake wire responder:

| Round 2 condition | Expected result |
|---|---|
| same canonical manifest, raw META rows reordered | resume old offset and token; complete only after remaining generation verifies |
| equal-width replacement `[A,C,E] -> [A,B,E]` | reset offset/token; remain nonterminal |
| append / insertion / deletion | reset offset/token; remain nonterminal |
| assertion-graph / DATA-plan order change | reset offset/token; remain nonterminal |
| public count or Merkle/content change | reset offset/token; remain nonterminal |
| legacy checkpoint without digest | reset offset/token |
| responder restart with missing paired session | reset offset/token |
| incomplete META | issue no DATA request; remain nonterminal |
| page-only graph has a surplus row | responder rejects via sentinel probe |

Canonical helper tests also cover deterministic encoding, raw-RDF-order independence, every committed field, length-prefix collision resistance, DATA-plan order sensitivity, and domain/version separation.

### Validation for this update

- `pnpm exec vitest run test/durable-manifest-digest.test.ts test/durable-manifest-continuation.test.ts test/sync-checkpoint-key.test.ts test/rootless-durable-bounded-progress.test.ts test/sync-responder-concurrent-interleaving.test.ts test/sync-responder-oversized-fallback.test.ts`: **6 files / 82 tests passed**;
- `pnpm --filter @origintrail-official/dkg-agent exec tsc --noEmit --pretty false`: passed;
- `pnpm --filter @origintrail-official/dkg-agent build`: passed (`tsc`, type tests, package-root test);
- `pnpm --filter @origintrail-official/dkg-agent test`: exercised the broad package suite for about 20 minutes. It exposed one stale rootless-resume fixture, which was corrected and is green in the focused rerun. The broad run then encountered unrelated local chain-harness failures (`issue-865-public-cg-allowlist`) and was stopped rather than reported as green.

### Scale

For the observed Blackbox workload, 562 canonical descriptors encode to about 171,922 bytes (168 KiB) for a 32-byte digest while binding a 6,357,721-triple DATA plan. Recomputing the digest once per completed META round is negligible relative to transferring and verifying the payload.

---
## Summary

This is a stacked follow-up to #2248. It keeps the partitioned admission policy from that PR and fixes the next failure mode observed during a multi-million-triple Blackbox VM recovery: bounded fetch attempts were downloading useful, verifiable graph prefixes, but cursor drift, partition gaps, and an initially aggressive page size could prevent that work from becoming a reusable checkpoint.

The change makes partial recovery monotonic and makes the requester conservative until a specific peer/Context Graph/plane/phase proves that it can sustain larger pages.

## Problem

The live Blackbox recovery repeatedly encountered responder/store timeouts and transport resets while fetching a 6M+ triple graph. Three related behaviors amplified the cost:

1. A rootless durable response could contain complete graph partitions followed by an incomplete partition. The requester did not checkpoint the complete prefix before the gap.
2. A persisted cursor could become misaligned with the peer's current graph boundaries. Retrying from that cursor could repeatedly reproduce the same unusable tail.
3. An unknown transport profile started at the maximum 8,192-row request size. A failure then forced a large request directly down to the safe floor.

Count progress remains diagnostic only. Merkle/graph verification continues to decide which prefix is safe to retain and whether a snapshot is complete.

## Changes

### Durable prefix retention

- Checkpoint the last complete verified graph boundary before the first incomplete partition.
- Reject incomplete control metadata from the retained data prefix.
- Preserve a verified prefix when raw cursor/manifest totals drift between attempts.
- Detect checkpoints that no longer align with the responder's graph plan and restart that phase from a valid boundary.

### Adaptive request sizing

- Start an unknown peer/Context Graph/plane/phase profile at **512 rows**.
- Double the request size after **8 consecutive successful pages**.
- Cap growth at the existing **8,192-row** maximum.
- Drop to the existing **64-row** safe floor after a retryable failure.
- Reuse the learned profile only within the same scoped transport profile.

### Admission and cancellation invariants

- Confirm an active slow-lane operation releases capacity only after signal-aware work observes cancellation and settles.
- Confirm different-budget durable syncs for the same peer and Context Graph serialize outside scarce admission capacity.
- Preserve identical-operation coalescing.

## Sequence

```mermaid
sequenceDiagram
    participant R as Requester
    participant A as Partitioned admission
    participant P as Curator peer
    participant V as Graph verifier
    participant C as Durable checkpoint

    R->>A: acquire slow lane
    A-->>R: admitted
    R->>P: page(offset, 512)
    P-->>R: graph rows
    R->>V: validate ordered graph partitions
    V-->>R: complete verified prefix + optional partial tail
    R->>C: persist last complete graph boundary
    Note over R,P: after 8 clean pages, 512 -> 1024 -> 2048 -> 4096 -> 8192
    alt retryable timeout/reset
        P--xR: responder/store/transport failure
        R->>R: reduce learned page size to 64
        R->>P: retry from durable safe boundary
    else phase deadline
        R->>C: retain verified prefix
        R-->>A: settle operation and release lane
    end
```

## Test results

### Focused

- `sync-operation-telemetry.test.ts`
- `sync-fetch-coalescing.test.ts`
- **63 tests passed**

### Broad adversarial sync suite

- `rootless-durable-bounded-progress.test.ts`
- graph-scoped materialization and exact accumulation suites
- requester progress and fresh-per-attempt suites
- `sync-byte-budget-pages.test.ts`
- `sync-page-frame-budget.test.ts`
- sync telemetry, coalescing, durable coalescing, and backpressure suites
- **11 files / 297 tests passed**

### Build/package boundary

- `pnpm --filter @origintrail-official/dkg-agent build` — passed
- `pnpm --filter @origintrail-official/dkg build` — passed
- `scripts/test-catchup-worker-package-boundary.mjs` — passed against the packaged runtime
- Native `better-sqlite3` ABI verified against Node `v24.11.1`

## Live Blackbox evidence

Tested with packaged pre-rebase commit `2858bfa8c8ff4815b649af0384d5ff227009c647` (code-equivalent to rebased PR head `7d67e3d80`) and partitioned admission configured as:

- global: `3`
- fast: `1`
- slow: `2`
- slow foreground reserved: `1`
- background slow inflight: `1`

Observed results before opening this PR:

- The first failure occurred at offset **61,440**, which is the exact cumulative staircase produced by eight clean pages at each size: `512 -> 1,024 -> 2,048 -> 4,096`, followed by the first `8,192` request. This proves the deployed requester started at 512 rather than 8,192.
- A timeout reduced the learned profile from `8,192` to `64`.
- Two concurrent recovery attempts retained safe verified prefixes of **1,479,041** and **625,858** triples instead of discarding their completed graph partitions.
- Slow-lane operations subsequently settled and new operations were admitted, demonstrating that the capacity was released rather than leaked.

This evidence does **not** claim terminal snapshot success. The remaining live sync is still being observed; five-minute checkpoints and the terminal outcome will be added separately.

## Live five-minute checkpoints

The table is updated from the Blackbox-owned node while the explicit `blackbox sync --wait --timeout 3600 --require-rules` process is active. `current` is received work, `safe` is the verified reusable prefix, and neither is terminal success.

| Observed (UTC) | Runtime | Process | Public | Current | Safe | Expected | Progress | Peers | Sync-global | New evidence |
|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|
| 2026-08-11 20:43:44 | `2858bfa8c` | running | 525,322 | 634,944 | 625,858 | 6,357,721 | 10.0% | 7 | stalled | Initial post-restart baseline; no terminal snapshot result. |

| 2026-08-11 20:50:32 | `2858bfa8c` | running | 525,322 | 1,616,617 (+981,673) | 1,604,463 (+978,605) | 6,357,721 | 25.4% (+15.4 pp) | 6 | healthy | Active `vm-recovery`; two bounded phase timeouts, 8,192→64 fallback, verified prefix retained; no terminal result. |

| 2026-08-11 20:55:53 | `2858bfa8c` | running | 525,322 | 481,664 (−1,134,953 vs max) | 481,632 (−1,122,831 vs max) | 6,277,721 | 7.7% (new manifest) | 7 | stalled | Active `vm-recovery`; manifest changed, so prior maxima remain authoritative; bounded request-abort retries retained a 481,632 safe prefix; no terminal result. |

| 2026-08-11 21:01:24 | `2858bfa8c` | running | 525,322 | 1,741,745 (+125,128) | 1,741,153 (+136,690) | 6,357,721 | 27.4% (+2.0 pp) | 6 | saturated | Active `on-connect`; verified prefix advanced across two bounded phases; separate 10k session expired with safe offset 0 and was not promoted; no terminal result. |

| 2026-08-11 21:06:56 | `2858bfa8c` | running | 525,322 | 1,790,897 (+49,152) | 1,778,840 (+37,687) | 6,357,721 | 28.2% (+0.8 pp) | 6 | healthy | Active `on-connect` + `vm-recovery`; one phase timeout retained 323,815 new safe rows; remote-close/queue-wait retries fell to 64; no terminal result. |

| 2026-08-11 21:12:20 | `2858bfa8c` | running | 525,322 | 1,816,280 (+25,383) | 1,805,006 (+26,166) | 6,357,721 | 28.6% (+0.4 pp) | 7 | healthy | Active `vm-recovery`; timeout retained 2 complete graphs / 26,166 safe rows; one remote-close and responder queue-wait retry; no terminal result. |

| 2026-08-11 21:17:51 | `2858bfa8c` | running | 525,322 | 1,910,542 (+94,262) | 1,903,749 (+98,743) | 6,357,721 | 30.1% (+1.5 pp) | 7 | stalled | Active `vm-recovery` + `unspecified`; timeout retained 8 complete graphs / 98,743 safe rows; remote-close plus separate queue-wait/snapshot-expiry retries; no terminal result. |

| 2026-08-11 21:23:21 | `2858bfa8c` | running | 525,322 | 2,509,957 (+599,415) | 2,506,803 (+603,054) | 6,357,721 | 39.5% (+9.4 pp) | 7 | healthy | Active `unspecified`; timeout retained 49 complete graphs / 603,054 safe rows; one 10k repair completed while a separate 10k session expired unpromoted; no terminal snapshot result. |

| 2026-08-11 21:28:53 | `2858bfa8c` | running | 525,322 | 3,075,635 (+565,678) | 3,064,235 (+557,432) | 6,357,721 | 48.4% (+8.9 pp) | 7 | stalled | Active `on-connect`; timeout retained 44 complete graphs / 557,432 safe rows after an 8,192→64 remote-close fallback; separate 10k repair completed; no terminal snapshot result. |

| 2026-08-11 21:35:52 | `2858bfa8c` | running | 525,322 | 3,075,635 (+0) | 3,064,235 (+0) | 6,357,721 | 48.4% (+0.0 pp) | 7 | stalled | Active `durable:on-connect`; aggregate checkpoint unchanged, while one peer phase retained 208,928 safe rows and a separate 10k repair completed; queue-wait/snapshot-expiry and remote-close/reset sessions produced no safe prefix; no terminal snapshot result. |

| 2026-08-11 21:41:21 | `2858bfa8c` | exited / retryable failure | 525,322 | 3,435,898 (+360,263) | 3,430,285 (+366,050) | 6,357,721 | 54.0% (+5.6 pp) | 7 | stalled | Store healthy; `durable:on-connect` remains active. Latest phase timeout retained 48 complete graphs to safe 3,430,285; explicit CLI then exited at its wait deadline with retryable 503 `DURABLE_CATCHUP_ALL_PEERS_FAILED` (`incompleteWithoutProgress=1`); no terminal snapshot success. |

## Rollout decision

Keep `global=3 / slow=2 / fast=1` for this validation. The observed residual failures are responder/store queue waits and expiring snapshot sessions, not a queue of locally starved slow-lane work. Raising slow concurrency before those downstream operations settle would increase store contention rather than improve throughput.